### PR TITLE
Remove unused MDX loader parameter and clean comments

### DIFF
--- a/src/rendering/app-route-resolver.ts
+++ b/src/rendering/app-route-resolver.ts
@@ -7,7 +7,6 @@
  * - Page file loading with frontmatter extraction
  */
 
-// join import removed as unused
 import type { RuntimeAdapter } from "@veryfront/platform/adapters/base.ts";
 import type { EntityInfo, Frontmatter } from "@veryfront/types";
 

--- a/src/rendering/ssr/mdx-module-loader.ts
+++ b/src/rendering/ssr/mdx-module-loader.ts
@@ -4,7 +4,6 @@
  * @module
  */
 
-import type * as React from "react";
 import { getCacheNamespace } from "@veryfront/utils/cache/keys/namespace.ts";
 import { CompilationError, wrapError } from "@veryfront/errors/index.ts";
 import { getAdapter } from "@veryfront/platform/adapters/index.ts";
@@ -28,7 +27,6 @@ export function clearMDXModuleCache(): void {
  * Loads an MDX module from the given path with caching support.
  *
  * @param modulePath - Absolute path to the MDX module
- * @param _components - Optional custom components (currently unused, reserved for future use)
  * @returns Promise resolving to the loaded MDX module
  * @throws {CompilationError} If the module has no default export
  * @throws {Error} If the module fails to load
@@ -41,7 +39,6 @@ export function clearMDXModuleCache(): void {
  */
 export async function loadMDXModule(
   modulePath: string,
-  _components: Record<string, React.ComponentType<unknown>> = {},
 ): Promise<MDXModule> {
   try {
     const ns = getCacheNamespace() || "default";


### PR DESCRIPTION
## Summary
- remove unused components parameter from the MDX module loader
- drop redundant React import that was only used by the unused parameter
- clean up stale comment in the app route resolver

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924cbdcc1a0832d958f55d200705a89)