### PR TITLE
Handle HEAD requests for dev endpoints

### DIFF
--- a/src/server/dev-server/request-handler.ts
+++ b/src/server/dev-server/request-handler.ts
@@ -79,7 +79,11 @@ export class RequestHandler {
       });
 
     if (normalized === DEV_SERVER_ENDPOINTS.HMR_RUNTIME && this.hmrServer) {
-      const runtime = isHeadRequest ? null : this.getHMRRuntime();
+      if (isHeadRequest) {
+        return builder.withContentType(HTTP_CONTENT_TYPES.JS, "", HTTP_OK);
+      }
+
+      const runtime = this.getHMRRuntime();
       if (runtime === null) {
         return null;
       }

--- a/tests/integration/server/dev-server-handlers.test.ts
+++ b/tests/integration/server/dev-server-handlers.test.ts
@@ -173,6 +173,55 @@ describe(
       });
     });
 
+    it("responds to HEAD requests for HMR runtime", async () => {
+      await withTestContext("dev-server-hmr-head", async (context) => {
+        const { server, port } = await createTestDevServer(context, {
+          enableHMR: true,
+          hmrPort: await context.allocatePort(),
+        });
+
+        const response = await fetch(`http://localhost:${port}/_veryfront/hmr-runtime.js`, {
+          method: "HEAD",
+        });
+
+        assertEquals(response.status, 200);
+        const contentType = response.headers.get("content-type");
+        assert(
+          contentType?.startsWith("application/javascript"),
+          `Expected content-type to start with "application/javascript" but got "${contentType}"`,
+        );
+
+        // HEAD requests should not fall through to application router
+        assertEquals(await response.text(), "");
+
+        await server.stop();
+        await drainEventLoop();
+      });
+    });
+
+    it("responds to HEAD requests for error overlay runtime", async () => {
+      await withTestContext("dev-server-error-overlay-head", async (context) => {
+        const { server, port } = await createTestDevServer(context);
+
+        const response = await fetch(`http://localhost:${port}/_veryfront/error-overlay.js`, {
+          method: "HEAD",
+        });
+
+        assertEquals(response.status, 200);
+        const contentType = response.headers.get("content-type");
+        assert(
+          contentType?.startsWith("application/javascript"),
+          `Expected content-type to start with "application/javascript" but got "${contentType}"`,
+        );
+
+        // HEAD requests should not fall through to application router
+        assertEquals(await response.text(), "");
+
+        await server.stop();
+        await drainEventLoop();
+      });
+    });
+
     it("handles virtual module requests", async () => {
       await withTestContext("dev-server-virtual-modules", async (context) => {
         const { server, port } = await createTestDevServer(context);


### PR DESCRIPTION
## Summary
- ensure dev server returns a response for HEAD requests to the HMR runtime endpoint instead of falling through
- add regression tests covering HEAD requests for HMR and error overlay runtime assets

## Testing
- deno test tests/integration/server/dev-server-handlers.test.ts *(fails: deno not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924cc5345b4832da47377f7a8f3442f)