### PR TITLE
fix: pin AI SDK versions to exact versions for stability

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.0.63",
+  "version": "0.0.66",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",
@@ -110,10 +110,10 @@
     "unist": "npm:@types/unist@3.0.2",
     "unified": "npm:unified@11.0.5",
     "ai": "https://esm.sh/ai@5.0.76?deps=react@18.3.1,react-dom@18.3.1",
-    "ai/react": "https://esm.sh/@ai-sdk/react@2.0.59?deps=react@18.3.1,react-dom@18.3.1",
-    "@ai-sdk/react": "https://esm.sh/@ai-sdk/react@2.0.59?deps=react@18.3.1,react-dom@18.3.1",
+    "ai/react": "https://esm.sh/@ai-sdk/react@2.0.1?deps=react@18.3.1,react-dom@18.3.1",
+    "@ai-sdk/react": "https://esm.sh/@ai-sdk/react@2.0.1?deps=react@18.3.1,react-dom@18.3.1",
     "@ai-sdk/openai": "https://esm.sh/@ai-sdk/openai@2.0.1",
-    "@ai-sdk/anthropic": "https://esm.sh/@ai-sdk/anthropic@2.0.4",
+    "@ai-sdk/anthropic": "https://esm.sh/@ai-sdk/anthropic@2.0.1",
     "unocss": "https://esm.sh/unocss@0.59.0",
     "@unocss/core": "https://esm.sh/@unocss/core@0.59.0",
     "@unocss/preset-wind": "https://esm.sh/@unocss/preset-wind@0.59.0",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.0.63",
+  "version": "0.0.66",
   "description": "Zero-config React meta-framework for building agentic AI applications",
   "type": "module",
   "main": "./dist/index.js",
@@ -116,7 +116,7 @@
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "zod": "^3.22.0",
-    "ai": "^5.0.0"
+    "ai": "5.0.76"
   },
   "peerDependenciesMeta": {
     "zod": {
@@ -127,9 +127,9 @@
     }
   },
   "dependencies": {
-    "@ai-sdk/openai": "^2.0.0",
-    "@ai-sdk/anthropic": "^2.0.0",
-    "@ai-sdk/react": "^2.0.0",
+    "@ai-sdk/openai": "2.0.1",
+    "@ai-sdk/anthropic": "2.0.1",
+    "@ai-sdk/react": "2.0.1",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.30.0",
     "esbuild": "^0.20.0",

--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -551,9 +551,11 @@ for (const [name, entryPath] of Object.entries(entryPoints)) {
 				"process",
 			],
 			define: {
-				"Deno.env.get": "process.env",
+				// Note: We inject deno-env.ts shim to handle Deno.env.get properly
+				// Simple replacement doesn't work because Deno.env.get(key) != process.env(key)
 				"Deno.cwd": "process.cwd",
 			},
+			inject: [pathHelper.resolve(PROJECT_ROOT, "src/_shims/deno-env.ts")],
 			jsx: "automatic",
 			jsxImportSource: "react",
 		});
@@ -1356,16 +1358,16 @@ const packageJson = {
 		react: "^17.0.0 || ^18.0.0 || ^19.0.0",
 		"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
 		zod: "^3.22.0",
-		ai: "^5.0.0",
+		ai: "5.0.76",
 	},
 	peerDependenciesMeta: {
 		zod: { optional: false },
 		ai: { optional: false },
 	},
 	dependencies: {
-		"@ai-sdk/openai": "^2.0.0",
-		"@ai-sdk/anthropic": "^2.0.0",
-		"@ai-sdk/react": "^2.0.0",
+		"@ai-sdk/openai": "2.0.1",
+		"@ai-sdk/anthropic": "2.0.1",
+		"@ai-sdk/react": "2.0.1",
 		"@opentelemetry/api": "^1.9.0",
 		"@opentelemetry/core": "^1.30.0",
 		esbuild: "^0.20.0",

--- a/src/_shims/deno-env.ts
+++ b/src/_shims/deno-env.ts
@@ -1,0 +1,25 @@
+/**
+ * Shim for Deno.env in Node.js environment
+ * This file is injected by esbuild to provide Deno.env compatibility
+ */
+
+// @ts-ignore - Global Deno shim for Node.js
+globalThis.Deno = globalThis.Deno || {
+  env: {
+    get(key: string): string | undefined {
+      return process.env[key];
+    },
+    set(key: string, value: string): void {
+      process.env[key] = value;
+    },
+    delete(key: string): void {
+      delete process.env[key];
+    },
+    has(key: string): boolean {
+      return key in process.env;
+    },
+    toObject(): Record<string, string> {
+      return { ...process.env } as Record<string, string>;
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- Pin AI SDK dependencies to exact versions for consistent behavior across installations
- `ai`: `5.0.76`
- `@ai-sdk/openai`: `2.0.1`
- `@ai-sdk/anthropic`: `2.0.1`
- `@ai-sdk/react`: `2.0.1`

## Test plan
- [x] Published veryfront@0.0.66 to npm with pinned versions
- [ ] Verify npm install installs exact versions