### PR TITLE
fix(ai): Update agent stream to v5 UI message stream protocol

### DIFF
--- a/src/ai/agent/runtime.ts
+++ b/src/ai/agent/runtime.ts
@@ -158,7 +158,8 @@ export class AgentRuntime {
     const { provider, model } = getProviderFromModel(this.config.model);
 
     const encoder = new TextEncoder();
-    const messageId = `msg_${crypto.randomUUID()}`;
+    // Use prefix + 12 chars from UUID (matches AI SDK generateId pattern)
+    const messageId = `msg_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
 
     // Build tool execution context - merge user context with agent context
     const toolContext = {
@@ -167,7 +168,7 @@ export class AgentRuntime {
     };
 
     // Generate a unique text part ID for UI message stream
-    const textPartId = `text_${crypto.randomUUID()}`;
+    const textPartId = `text_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
 
     return new ReadableStream({
       start: async (controller) => {

--- a/src/ai/agent/runtime.ts
+++ b/src/ai/agent/runtime.ts
@@ -21,7 +21,7 @@ import type {
 import type { ToolDefinition } from "../types/tool.ts";
 import type { Provider } from "../types/provider.ts";
 import { getProviderFromModel } from "../providers/factory.ts";
-import { executeTool, toolRegistry, toolToProviderDefinition } from "../utils/tool.ts";
+import { executeTool, toolRegistry, toolToProviderDefinition, generateId } from "../utils/index.ts";
 import { detectPlatform, getPlatformCapabilities } from "../runtime/platform.ts";
 import { createMemory, type Memory } from "./memory.ts";
 import { serverLogger as logger } from "@veryfront/utils";
@@ -158,8 +158,7 @@ export class AgentRuntime {
     const { provider, model } = getProviderFromModel(this.config.model);
 
     const encoder = new TextEncoder();
-    // Use prefix + 12 chars from UUID (matches AI SDK generateId pattern)
-    const messageId = `msg_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const messageId = generateId("msg");
 
     // Build tool execution context - merge user context with agent context
     const toolContext = {
@@ -168,7 +167,7 @@ export class AgentRuntime {
     };
 
     // Generate a unique text part ID for UI message stream
-    const textPartId = `text_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const textPartId = generateId("text");
 
     return new ReadableStream({
       start: async (controller) => {

--- a/src/ai/agent/runtime.ts
+++ b/src/ai/agent/runtime.ts
@@ -425,7 +425,7 @@ export class AgentRuntime {
       onToolCall?: (toolCall: ToolCall) => void;
       onChunk?: (chunk: string) => void;
     },
-    _messageId?: string,
+    textPartId?: string,
     toolContext?: Record<string, unknown>,
   ): Promise<AgentResponse> {
     const capabilities = getPlatformCapabilities();
@@ -523,7 +523,7 @@ export class AgentRuntime {
             // Use Vercel AI SDK UI Message Stream Protocol v5 format
             const textDeltaEvent = JSON.stringify({
               type: "text-delta",
-              id: _messageId,
+              id: textPartId,
               delta: event.content,
             });
             controller.enqueue(encoder.encode(`data: ${textDeltaEvent}\n\n`));

--- a/src/ai/agent/runtime.ts
+++ b/src/ai/agent/runtime.ts
@@ -158,7 +158,6 @@ export class AgentRuntime {
     const { provider, model } = getProviderFromModel(this.config.model);
 
     const encoder = new TextEncoder();
-    const messageId = generateId("msg");
 
     // Build tool execution context - merge user context with agent context
     const toolContext = {
@@ -185,7 +184,7 @@ export class AgentRuntime {
           });
           controller.enqueue(encoder.encode(`data: ${textStartEvent}\n\n`));
 
-          const response = await this.executeAgentLoopStreaming(
+          await this.executeAgentLoopStreaming(
             provider,
             model,
             systemPrompt,

--- a/src/ai/agent/runtime.ts
+++ b/src/ai/agent/runtime.ts
@@ -158,7 +158,7 @@ export class AgentRuntime {
     const { provider, model } = getProviderFromModel(this.config.model);
 
     const encoder = new TextEncoder();
-    const messageId = `msg_${Date.now()}`;
+    const messageId = `msg_${crypto.randomUUID()}`;
 
     // Build tool execution context - merge user context with agent context
     const toolContext = {
@@ -166,17 +166,24 @@ export class AgentRuntime {
       ...context,
     };
 
+    // Generate a unique text part ID for UI message stream
+    const textPartId = `text_${crypto.randomUUID()}`;
+
     return new ReadableStream({
       start: async (controller) => {
         try {
           this.status = "streaming";
 
-          // Send start event (Vercel AI SDK Data Stream Protocol)
-          const startEvent = JSON.stringify({
-            type: "start",
-            messageId,
-          });
+          // Send start event (UI Message Stream Protocol v5)
+          const startEvent = JSON.stringify({ type: "start" });
           controller.enqueue(encoder.encode(`data: ${startEvent}\n\n`));
+
+          // Send text-start event with ID
+          const textStartEvent = JSON.stringify({
+            type: "text-start",
+            id: textPartId,
+          });
+          controller.enqueue(encoder.encode(`data: ${textStartEvent}\n\n`));
 
           const response = await this.executeAgentLoopStreaming(
             provider,
@@ -186,19 +193,20 @@ export class AgentRuntime {
             controller,
             encoder,
             callbacks,
-            messageId,
+            textPartId,
             toolContext,
           );
 
-          // Send finish event
-          const finishEvent = JSON.stringify({
-            type: "finish",
-            usage: response.usage,
+          // Send text-end event (UI Message Stream Protocol v5)
+          const textEndEvent = JSON.stringify({
+            type: "text-end",
+            id: textPartId,
           });
-          controller.enqueue(encoder.encode(`data: ${finishEvent}\n\n`));
+          controller.enqueue(encoder.encode(`data: ${textEndEvent}\n\n`));
 
-          // Send [DONE] to signal end of stream
-          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          // Send finish event (UI Message Stream Protocol v5)
+          const finishEvent = JSON.stringify({ type: "finish" });
+          controller.enqueue(encoder.encode(`data: ${finishEvent}\n\n`));
 
           controller.close();
         } catch (error) {
@@ -404,7 +412,7 @@ export class AgentRuntime {
 
   /**
    * Execute agent loop with streaming
-   * Uses Vercel AI SDK Data Stream Protocol format
+   * Uses Vercel AI SDK UI Message Stream Protocol v5 format
    */
   private async executeAgentLoopStreaming(
     provider: Provider,
@@ -512,10 +520,11 @@ export class AgentRuntime {
           case "content": {
             accumulatedText += event.content;
 
-            // Use Vercel AI SDK text-delta format
+            // Use Vercel AI SDK UI Message Stream Protocol v5 format
             const textDeltaEvent = JSON.stringify({
               type: "text-delta",
-              textDelta: event.content,
+              id: _messageId,
+              delta: event.content,
             });
             controller.enqueue(encoder.encode(`data: ${textDeltaEvent}\n\n`));
 

--- a/src/ai/agent/runtime.ts
+++ b/src/ai/agent/runtime.ts
@@ -21,7 +21,7 @@ import type {
 import type { ToolDefinition } from "../types/tool.ts";
 import type { Provider } from "../types/provider.ts";
 import { getProviderFromModel } from "../providers/factory.ts";
-import { executeTool, toolRegistry, toolToProviderDefinition, generateId } from "../utils/index.ts";
+import { executeTool, generateId, toolRegistry, toolToProviderDefinition } from "../utils/index.ts";
 import { detectPlatform, getPlatformCapabilities } from "../runtime/platform.ts";
 import { createMemory, type Memory } from "./memory.ts";
 import { serverLogger as logger } from "@veryfront/utils";

--- a/src/ai/react/README.md
+++ b/src/ai/react/README.md
@@ -8,30 +8,84 @@
 
 This module provides **headless React hooks** for AI interactions with zero UI opinions. These hooks give you complete control over state, behavior, and rendering.
 
+**Uses AI SDK v5 UI Message format** with parts-based content structure.
+
 ## Available Hooks
 
 ### useChat
 
-Complete chat state management:
+Complete chat state management with v5 UI Message format:
 
 ```typescript
 import { useChat } from "veryfront/ai/react";
+import type { UIMessage } from "veryfront/ai/react";
+
+// Helper to extract text from v5 parts array
+function getTextContent(message: UIMessage): string {
+  return message.parts
+    .filter((p) => p.type === "text")
+    .map((p) => p.text)
+    .join("");
+}
 
 function MyChat() {
   const {
-    messages, // Message history
-    input, // Current input
-    isLoading, // Loading state
-    setInput, // Update input
-    append, // Add message
-    reload, // Retry last
-    stop, // Stop generation
+    messages,        // UIMessage[] with parts array
+    input,           // Current input
+    isLoading,       // Loading state
+    setInput,        // Update input
+    sendMessage,     // Send message: sendMessage({ text: "..." })
+    handleSubmit,    // Form submit handler
+    reload,          // Retry last
+    stop,            // Stop generation
   } = useChat({
     api: "/api/chat",
   });
 
-  return <YourCustomUI {...{ messages, input, setInput, append }} />;
+  return (
+    <div>
+      {messages.map((msg) => (
+        <div key={msg.id}>
+          <strong>{msg.role}:</strong> {getTextContent(msg)}
+        </div>
+      ))}
+      <form onSubmit={handleSubmit}>
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <button type="submit" disabled={isLoading}>
+          Send
+        </button>
+      </form>
+    </div>
+  );
 }
+```
+
+### UIMessage Format (AI SDK v5)
+
+Messages use the v5 parts-based structure:
+
+```typescript
+interface UIMessage {
+  id: string;
+  role: "system" | "user" | "assistant";
+  parts: UIMessagePart[];  // Content as parts array
+}
+
+type UIMessagePart =
+  | { type: "text"; text: string; state?: "streaming" | "done" }
+  | { type: "reasoning"; text: string; state?: "streaming" | "done" }
+  | { type: "tool-call"; toolCallId: string; toolName: string; state: ToolState; input?: unknown }
+  | { type: "tool-result"; toolCallId: string; toolName: string; result: unknown };
+
+type ToolState =
+  | "input-streaming"
+  | "input-available"
+  | "output-streaming"
+  | "output-available"
+  | "output-error";
 ```
 
 ### useAgent
@@ -45,10 +99,10 @@ function MyAgent() {
   const {
     messages,
     toolCalls, // Active tool invocations
-    status, // Agent status
-    thinking, // Reasoning text
-    invoke, // Start agent
-    stop, // Stop agent
+    status,    // Agent status
+    thinking,  // Reasoning text
+    invoke,    // Start agent
+    stop,      // Stop agent
   } = useAgent({
     agent: "support",
     onToolCall: (tool) => console.log("Tool:", tool.name),
@@ -69,8 +123,8 @@ function MyCompletion() {
   const {
     completion, // Generated text
     isLoading,
-    complete, // Trigger completion
-    stop, // Stop generation
+    complete,   // Trigger completion
+    stop,       // Stop generation
   } = useCompletion({
     api: "/api/complete",
   });
@@ -88,10 +142,10 @@ import { useStreaming } from "veryfront/ai/react";
 
 function MyStreaming() {
   const {
-    data, // Streaming data
+    data,        // Streaming data
     isStreaming,
-    start, // Start stream
-    stop, // Stop stream
+    start,       // Start stream
+    stop,        // Stop stream
   } = useStreaming({
     url: "/api/stream",
     onChunk: (chunk) => console.log("Chunk:", chunk),
@@ -105,8 +159,8 @@ function MyStreaming() {
 
 - **Zero UI opinions** - Build any interface
 - **Complete control** - Full access to state and behavior
-- **TypeScript first** - Full type safety
-- **Streaming support** - Real-time responses
+- **TypeScript first** - Full type safety with v5 types
+- **Streaming support** - Real-time responses with v5 events
 - **Error handling** - Built-in error states
 - **Abort support** - Cancel requests anytime
 - **Flexible** - Customize everything
@@ -120,7 +174,8 @@ npm install veryfront
 ```
 
 ```typescript
-import { useAgent, useChat } from "veryfront/ai/react";
+import { useChat, useAgent } from "veryfront/ai/react";
+import type { UIMessage, UIMessagePart, ToolState } from "veryfront/ai/react";
 ```
 
 ## Next: Layer 2 & 3
@@ -140,12 +195,12 @@ See `examples/ai-react-hooks/` for full examples (coming soon).
 
 **Phase 4: Headless Hooks** **COMPLETE**
 
-- useChat - Complete chat state management
+- useChat - Complete chat state management (v5 format)
 - useAgent - Agent orchestration
 - useCompletion - Single completions
 - useStreaming - Low-level streaming
-- Full TypeScript support
-- Streaming support
+- Full TypeScript support with v5 types
+- Streaming support with v5 events
 - Error handling
 - Abort controllers
 

--- a/src/ai/react/components/README.md
+++ b/src/ai/react/components/README.md
@@ -8,6 +8,8 @@
 
 Production-ready, fully styled components built on Layer 2 primitives. Get started in seconds with sensible defaults.
 
+**Uses AI SDK v5 UI Message format** with parts-based content structure.
+
 ## Philosophy
 
 - **Production-ready** - Fully styled with Tailwind CSS
@@ -39,6 +41,8 @@ export default function ChatPage() {
 }
 ```
 
+The `Chat` component handles v5 UIMessage format internally, extracting text from the `parts` array automatically.
+
 **Customization via theme:**
 
 ```tsx
@@ -59,13 +63,24 @@ export default function ChatPage() {
 **Customization via render props:**
 
 ```tsx
+import type { UIMessage } from "veryfront/ai/react";
+
+// Helper to extract text from v5 parts array
+function getTextContent(message: UIMessage): string {
+  return message.parts
+    .filter((p) => p.type === "text")
+    .map((p) => p.text)
+    .join("");
+}
+
 <Chat
   {...chat}
   renderMessage={(msg) => (
     <CustomMessage
-      {...msg}
-      avatar={getUserAvatar(msg.role)}
-      timestamp={formatTime(msg.timestamp)}
+      id={msg.id}
+      role={msg.role}
+      content={getTextContent(msg)}
+      parts={msg.parts}
     />
   )}
 />;
@@ -122,13 +137,13 @@ export default function AgentInterface() {
 
 ### Message
 
-Standalone message component.
+Standalone message component for v5 UIMessage format.
 
 ```tsx
 import { Message } from "veryfront/ai/components";
 
 <Message
-  message={msg}
+  message={msg}  // UIMessage with parts array
   showRole={true}
   showTimestamp={true}
   theme={{
@@ -301,13 +316,52 @@ export default function AgentChat() {
 }
 ```
 
+### Working with v5 Message Parts
+
+```tsx
+import { Chat } from "veryfront/ai/components";
+import { useChat } from "veryfront/ai/react";
+import type { UIMessage, UIMessagePart } from "veryfront/ai/react";
+
+// Custom renderer that handles all part types
+function CustomMessage({ message }: { message: UIMessage }) {
+  return (
+    <div>
+      {message.parts.map((part, i) => {
+        switch (part.type) {
+          case "text":
+            return <p key={i}>{part.text}</p>;
+          case "reasoning":
+            return <blockquote key={i}>{part.text}</blockquote>;
+          case "tool-call":
+            return <div key={i}>Tool: {part.toolName} ({part.state})</div>;
+          case "tool-result":
+            return <div key={i}>Result: {JSON.stringify(part.result)}</div>;
+        }
+      })}
+    </div>
+  );
+}
+
+export default function AdvancedChat() {
+  const chat = useChat({ api: "/api/chat" });
+
+  return (
+    <Chat
+      {...chat}
+      renderMessage={(msg) => <CustomMessage message={msg} />}
+    />
+  );
+}
+```
+
 ## Status
 
 **Phase 6: Styled Components** **COMPLETE**
 
 **Created:**
 
-- Chat component with theme system
+- Chat component with theme system (v5 UIMessage support)
 - AgentCard component
 - Message component
 - StreamingMessage component
@@ -322,6 +376,32 @@ export default function AgentChat() {
 
 ## Migration Path
 
+### From v4 to v5 Message Format
+
+```tsx
+// Before (v4 - deprecated)
+{messages.map((msg) => (
+  <div key={msg.id}>{msg.content}</div>
+))}
+
+// After (v5)
+import type { UIMessage } from "veryfront/ai/react";
+
+function getTextContent(message: UIMessage): string {
+  return message.parts
+    .filter((p) => p.type === "text")
+    .map((p) => p.text)
+    .join("");
+}
+
+{messages.map((msg) => (
+  <div key={msg.id}>{getTextContent(msg)}</div>
+))}
+
+// Or just use the Chat component which handles this automatically
+<Chat {...chat} />
+```
+
 ### From Custom UI → Styled Components
 
 ```tsx
@@ -329,7 +409,7 @@ export default function AgentChat() {
 <div className="chat-container">
   {messages.map((msg) => (
     <div key={msg.id} className="message">
-      {msg.content}
+      {getTextContent(msg)}
     </div>
   ))}
 </div>
@@ -349,7 +429,7 @@ export default function AgentChat() {
   <MessageList>
     {messages.map((msg) => (
       <MessageItem key={msg.id} className="your-styles">
-        {msg.content}
+        {getTextContent(msg)}
       </MessageItem>
     ))}
   </MessageList>
@@ -364,8 +444,8 @@ export default function AgentChat() {
   <MessageList />
 </ChatContainer>;
 
-// Hooks only
-const { messages, input, append } = useChat({ api: "/api/chat" });
+// Hooks only (v5 API)
+const { messages, input, sendMessage, handleSubmit } = useChat({ api: "/api/chat" });
 return <YourCompletelyCustomUI />;
 ```
 

--- a/src/ai/react/components/chat.tsx
+++ b/src/ai/react/components/chat.tsx
@@ -14,13 +14,24 @@ import {
   SubmitButton,
 } from "../primitives/index.ts";
 import { useVoiceInput } from "../hooks/use-voice-input.ts";
-import type { Message, ToolCall } from "../../types/agent.ts";
+import type { ToolCall } from "../../types/agent.ts";
+import type { UIMessage, UIMessagePart } from "../hooks/use-chat.ts";
 import { type ChatTheme, cn, defaultChatTheme, mergeThemes } from "./theme.ts";
 import { Markdown } from "./markdown.tsx";
 
+/**
+ * Get text content from UIMessage parts
+ */
+function getTextContent(message: UIMessage): string {
+  return message.parts
+    .filter((p): p is UIMessagePart & { type: "text" } => p.type === "text")
+    .map((p) => p.text)
+    .join("");
+}
+
 export interface ChatProps {
-  /** Messages to display */
-  messages: Message[];
+  /** Messages to display (AI SDK v5 format) */
+  messages: UIMessage[];
 
   /** Current input value */
   input: string;
@@ -68,7 +79,7 @@ export interface ChatProps {
   theme?: Partial<ChatTheme>;
 
   /** Custom message renderer */
-  renderMessage?: (message: Message) => React.ReactNode;
+  renderMessage?: (message: UIMessage) => React.ReactNode;
 
   /** Custom tool renderer */
   renderTool?: (toolCall: ToolCall) => React.ReactNode;
@@ -157,8 +168,9 @@ export const Chat = React.forwardRef<HTMLDivElement, ChatProps>(
         {/* Message List - scrollable content area */}
         <MessageList className="flex-1 min-h-0 overflow-y-auto">
           <div className="max-w-2xl mx-auto px-4 py-4 space-y-2">
-            {messages.map((msg) =>
-              renderMessage
+            {messages.map((msg) => {
+              const content = getTextContent(msg);
+              return renderMessage
                 ? <React.Fragment key={msg.id}>{renderMessage(msg)}</React.Fragment>
                 : (
                   <MessageItem
@@ -173,18 +185,18 @@ export const Chat = React.forwardRef<HTMLDivElement, ChatProps>(
                       {msg.role === "user"
                         ? (
                           <p className="whitespace-pre-wrap text-[15px] leading-relaxed">
-                            {msg.content}
+                            {content}
                           </p>
                         )
                         : (
                           <Markdown className="text-[15px] leading-relaxed">
-                            {msg.content}
+                            {content}
                           </Markdown>
                         )}
                     </div>
                   </MessageItem>
-                )
-            )}
+                );
+            })}
 
             {/* Loading indicator */}
             {isLoading && (

--- a/src/ai/react/hooks/index.ts
+++ b/src/ai/react/hooks/index.ts
@@ -8,18 +8,18 @@
 
 export { useChat } from "./use-chat.ts";
 export type {
-  UseChatOptions,
-  UseChatResult,
+  OnToolCallArg,
+  ReasoningUIPart,
+  TextUIPart,
+  ToolOutput,
+  ToolResultUIPart,
+  ToolState,
+  ToolUIPart,
   // AI SDK v5 compatible types
   UIMessage,
   UIMessagePart,
-  TextUIPart,
-  ReasoningUIPart,
-  ToolUIPart,
-  ToolResultUIPart,
-  ToolState,
-  ToolOutput,
-  OnToolCallArg,
+  UseChatOptions,
+  UseChatResult,
 } from "./use-chat.ts";
 
 export { useAgent } from "./use-agent.ts";

--- a/src/ai/react/hooks/index.ts
+++ b/src/ai/react/hooks/index.ts
@@ -10,9 +10,16 @@ export { useChat } from "./use-chat.ts";
 export type {
   UseChatOptions,
   UseChatResult,
-  ToolCallUI,
-  ReasoningUI,
-  MessageWithParts,
+  // AI SDK v5 compatible types
+  UIMessage,
+  UIMessagePart,
+  TextUIPart,
+  ReasoningUIPart,
+  ToolUIPart,
+  ToolResultUIPart,
+  ToolState,
+  ToolOutput,
+  OnToolCallArg,
 } from "./use-chat.ts";
 
 export { useAgent } from "./use-agent.ts";

--- a/src/ai/react/hooks/index.ts
+++ b/src/ai/react/hooks/index.ts
@@ -7,7 +7,13 @@
  */
 
 export { useChat } from "./use-chat.ts";
-export type { UseChatOptions, UseChatResult } from "./use-chat.ts";
+export type {
+  UseChatOptions,
+  UseChatResult,
+  ToolCallUI,
+  ReasoningUI,
+  MessageWithParts,
+} from "./use-chat.ts";
 
 export { useAgent } from "./use-agent.ts";
 export type { UseAgentOptions, UseAgentResult } from "./use-agent.ts";

--- a/src/ai/react/hooks/use-chat.ts
+++ b/src/ai/react/hooks/use-chat.ts
@@ -295,7 +295,14 @@ export function useChat(options: UseChatOptions): UseChatResult {
 
 /**
  * Handle streaming response from server
- * Uses Vercel AI SDK data stream format
+ * Supports AI SDK v5 UI Message Stream Protocol
+ *
+ * v5 Event Types:
+ * - start: Stream beginning
+ * - start-step / finish-step: Step boundaries (for multi-step/tools)
+ * - text-start / text-delta / text-end: Text block lifecycle
+ * - finish: Stream end
+ * - data: Custom data
  */
 async function handleStreamingResponse(
   body: ReadableStream,
@@ -305,8 +312,11 @@ async function handleStreamingResponse(
 ): Promise<void> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
-  let accumulatedText = "";
-  let messageId = `msg_${Date.now()}`;
+
+  // Track text blocks by ID (v5 uses IDs to group text-start/delta/end)
+  const textBlocks = new Map<string, string>();
+  let currentTextId = "";
+  let messageId = "";
 
   while (true) {
     const { done, value } = await reader.read();
@@ -322,16 +332,11 @@ async function handleStreamingResponse(
       if (line.startsWith("data: ")) {
         const data = line.slice(6);
 
+        // Legacy [DONE] marker (v4 compatibility)
         if (data === "[DONE]") {
-          // Stream finished - create the assistant message
+          const accumulatedText = getAccumulatedText(textBlocks);
           if (accumulatedText) {
-            const assistantMessage: Message = {
-              id: messageId,
-              role: "assistant",
-              content: accumulatedText,
-              timestamp: Date.now(),
-            };
-            onMessage(assistantMessage);
+            onMessage(createAssistantMessage(messageId, accumulatedText));
           }
           continue;
         }
@@ -339,30 +344,78 @@ async function handleStreamingResponse(
         try {
           const parsed = JSON.parse(data);
 
-          if (parsed.type === "data") {
-            onData(parsed.data);
-          } else if (parsed.type === "start") {
-            // New message starting
-            messageId = parsed.messageId || `msg_${Date.now()}`;
-            accumulatedText = "";
-          } else if (parsed.type === "text-delta") {
-            // Text chunk - accumulate and update UI (v5 uses `delta`, fallback to `textDelta` for v4)
-            accumulatedText += parsed.delta || parsed.textDelta || "";
-            // Call onUpdate to show text progressively
-            if (onUpdate) {
-              onUpdate(accumulatedText, messageId);
+          switch (parsed.type) {
+            // v5: Stream start
+            case "start":
+              messageId = parsed.messageId || generateClientId("msg");
+              textBlocks.clear();
+              break;
+
+            // v5: Step boundaries (for multi-step tool calls)
+            case "start-step":
+            case "finish-step":
+              // Currently no-op, but could track step state
+              break;
+
+            // v5: Text block start
+            case "text-start":
+              currentTextId = parsed.id || generateClientId("text");
+              textBlocks.set(currentTextId, "");
+              break;
+
+            // v5: Text delta (also handles v4 format)
+            case "text-delta": {
+              const textId = parsed.id || currentTextId || "default";
+              const delta = parsed.delta || parsed.textDelta || "";
+
+              // Initialize text block if needed
+              if (!textBlocks.has(textId)) {
+                textBlocks.set(textId, "");
+                currentTextId = textId;
+              }
+
+              // Append delta to text block
+              textBlocks.set(textId, (textBlocks.get(textId) || "") + delta);
+
+              // Update UI with accumulated text
+              if (onUpdate) {
+                onUpdate(getAccumulatedText(textBlocks), messageId);
+              }
+              break;
             }
-          } else if (parsed.type === "finish") {
-            // Stream completed
-            if (accumulatedText) {
-              const assistantMessage: Message = {
-                id: messageId,
-                role: "assistant",
-                content: accumulatedText,
-                timestamp: Date.now(),
-              };
-              onMessage(assistantMessage);
+
+            // v5: Text block end
+            case "text-end":
+              // Text block complete, no action needed
+              break;
+
+            // v5: Stream finish
+            case "finish": {
+              const accumulatedText = getAccumulatedText(textBlocks);
+              if (accumulatedText) {
+                onMessage(createAssistantMessage(messageId, accumulatedText));
+              }
+              break;
             }
+
+            // Custom data events
+            case "data":
+              onData(parsed.data || parsed.value);
+              break;
+
+            // Tool events (future support)
+            case "tool-input-start":
+            case "tool-input-delta":
+            case "tool-result":
+              // TODO: Implement tool call UI updates
+              break;
+
+            // Reasoning events (future support)
+            case "reasoning-start":
+            case "reasoning-delta":
+            case "reasoning-end":
+              // TODO: Implement reasoning UI updates
+              break;
           }
         } catch {
           // Skip invalid JSON
@@ -370,4 +423,30 @@ async function handleStreamingResponse(
       }
     }
   }
+}
+
+/**
+ * Get accumulated text from all text blocks
+ */
+function getAccumulatedText(textBlocks: Map<string, string>): string {
+  return Array.from(textBlocks.values()).join("");
+}
+
+/**
+ * Create assistant message
+ */
+function createAssistantMessage(messageId: string, content: string): Message {
+  return {
+    id: messageId || generateClientId("msg"),
+    role: "assistant",
+    content,
+    timestamp: Date.now(),
+  };
+}
+
+/**
+ * Generate client-side ID (fallback when server doesn't provide one)
+ */
+function generateClientId(prefix: string): string {
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }

--- a/src/ai/react/hooks/use-chat.ts
+++ b/src/ai/react/hooks/use-chat.ts
@@ -13,46 +13,98 @@ import type { Message } from "../../types/agent.ts";
 import { createError, toError } from "../../../core/errors/veryfront-error.ts";
 
 /**
- * Tool call information for UI
+ * Text part - AI SDK v5 compatible
  */
-export interface ToolCallUI {
-  /** Tool call ID */
-  id: string;
-  /** Tool name */
-  toolName: string;
-  /** Tool input (parsed JSON) */
-  input?: unknown;
-  /** Tool input as raw text (for streaming) */
-  inputText?: string;
-  /** Tool output/result */
-  output?: unknown;
-  /** Tool call status */
-  status: "pending" | "streaming" | "executing" | "completed" | "error";
-}
-
-/**
- * Reasoning block for UI
- */
-export interface ReasoningUI {
-  /** Reasoning block ID */
-  id: string;
-  /** Accumulated reasoning text */
+export interface TextUIPart {
+  type: "text";
   text: string;
-  /** Whether reasoning is complete */
-  isComplete: boolean;
+  state?: "streaming" | "done";
 }
 
 /**
- * Extended message with parts (v5 compatible)
+ * Reasoning part - AI SDK v5 compatible
  */
-export interface MessageWithParts extends Message {
-  /** Message parts for rich content */
-  parts?: Array<
-    | { type: "text"; text: string }
-    | { type: "tool-call"; toolCallId: string; toolName: string; args: unknown }
-    | { type: "tool-result"; toolCallId: string; result: unknown }
-    | { type: "reasoning"; id: string; text: string }
-  >;
+export interface ReasoningUIPart {
+  type: "reasoning";
+  text: string;
+  state?: "streaming" | "done";
+}
+
+/**
+ * Tool call state - AI SDK v5 compatible
+ */
+export type ToolState =
+  | "input-streaming"
+  | "input-available"
+  | "output-streaming"
+  | "output-available"
+  | "output-error";
+
+/**
+ * Tool UI part - AI SDK v5 compatible
+ * Generic type allows typed tool inputs/outputs
+ */
+export interface ToolUIPart<INPUT = unknown, OUTPUT = unknown> {
+  type: "tool-call";
+  toolCallId: string;
+  toolName: string;
+  state: ToolState;
+  input?: INPUT;
+  output?: OUTPUT;
+  errorText?: string;
+}
+
+/**
+ * Tool result part - AI SDK v5 compatible
+ */
+export interface ToolResultUIPart<RESULT = unknown> {
+  type: "tool-result";
+  toolCallId: string;
+  toolName: string;
+  result: RESULT;
+  isError?: boolean;
+}
+
+/**
+ * All possible UI message parts - AI SDK v5 compatible
+ */
+export type UIMessagePart =
+  | TextUIPart
+  | ReasoningUIPart
+  | ToolUIPart
+  | ToolResultUIPart;
+
+/**
+ * UI Message - AI SDK v5 compatible
+ * Uses parts array as primary content structure
+ */
+export interface UIMessage {
+  id: string;
+  role: "system" | "user" | "assistant";
+  parts: UIMessagePart[];
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Tool output for addToolOutput - AI SDK v5 compatible
+ */
+export interface ToolOutput {
+  tool: string;
+  toolCallId: string;
+  output?: unknown;
+  state?: "output-available" | "output-error";
+  errorText?: string;
+}
+
+/**
+ * Tool call argument for onToolCall callback - AI SDK v5 compatible
+ */
+export interface OnToolCallArg {
+  toolCall: {
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+  };
 }
 
 export interface UseChatOptions {
@@ -60,7 +112,7 @@ export interface UseChatOptions {
   api: string;
 
   /** Initial messages */
-  initialMessages?: Message[];
+  initialMessages?: UIMessage[];
 
   /** Additional data to send */
   body?: Record<string, unknown>;
@@ -75,21 +127,21 @@ export interface UseChatOptions {
   onResponse?: (response: Response) => void;
 
   /** Callback when message finished */
-  onFinish?: (message: MessageWithParts) => void;
+  onFinish?: (message: UIMessage) => void;
 
   /** Callback when error occurs */
   onError?: (error: Error) => void;
 
-  /** Callback when tool call starts */
-  onToolCall?: (toolCall: ToolCallUI) => void;
-
-  /** Callback when tool result received */
-  onToolResult?: (toolCall: ToolCallUI) => void;
+  /**
+   * Callback when tool call is available - AI SDK v5 compatible
+   * Use addToolOutput to provide results (don't await inside callback)
+   */
+  onToolCall?: (arg: OnToolCallArg) => void | Promise<void>;
 }
 
 export interface UseChatResult {
-  /** Message history */
-  messages: Message[];
+  /** Message history - AI SDK v5 UIMessage format */
+  messages: UIMessage[];
 
   /** Current input value */
   input: string;
@@ -103,8 +155,8 @@ export interface UseChatResult {
   /** Set input value */
   setInput: (input: string) => void;
 
-  /** Add a message and get response */
-  append: (message: Omit<Message, "id" | "timestamp">) => Promise<void>;
+  /** Send a message - AI SDK v5 compatible */
+  sendMessage: (message: { text: string }) => Promise<void>;
 
   /** Retry last message */
   reload: () => Promise<void>;
@@ -113,7 +165,13 @@ export interface UseChatResult {
   stop: () => void;
 
   /** Manually set messages */
-  setMessages: (messages: Message[]) => void;
+  setMessages: (messages: UIMessage[]) => void;
+
+  /**
+   * Add tool output - AI SDK v5 compatible
+   * Call this from onToolCall to provide tool results
+   */
+  addToolOutput: (output: ToolOutput) => void;
 
   /** Additional data from server */
   data?: unknown;
@@ -123,13 +181,16 @@ export interface UseChatResult {
 
   /** Handle form submit */
   handleSubmit: (e: React.FormEvent) => Promise<void>;
+
+  /** @deprecated Use sendMessage instead */
+  append: (message: Omit<Message, "id" | "timestamp">) => Promise<void>;
 }
 
 /**
- * useChat hook for managing chat state
+ * useChat hook for managing chat state - AI SDK v5 compatible
  */
 export function useChat(options: UseChatOptions): UseChatResult {
-  const [messages, setMessages] = useState<Message[]>(
+  const [messages, setMessages] = useState<UIMessage[]>(
     options.initialMessages || [],
   );
   const [input, setInput] = useState("");
@@ -138,28 +199,54 @@ export function useChat(options: UseChatOptions): UseChatResult {
   const [data, setData] = useState<unknown>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
+  // Track pending tool outputs for addToolOutput
+  const pendingToolOutputsRef = useRef<Map<string, ToolOutput>>(new Map());
+
   /**
-   * Append a message and get AI response
+   * Add tool output - AI SDK v5 compatible
+   * Call from onToolCall to provide results (don't await)
    */
-  const append = useCallback(
-    async (message: Omit<Message, "id" | "timestamp">) => {
-      const userMessage: Message = {
-        ...message,
-        id: `msg_${Date.now()}`,
-        timestamp: Date.now(),
+  const addToolOutput = useCallback((output: ToolOutput) => {
+    pendingToolOutputsRef.current.set(output.toolCallId, output);
+
+    // Update the tool part state in messages
+    setMessages((prev) =>
+      prev.map((msg) => ({
+        ...msg,
+        parts: msg.parts.map((part) => {
+          if (part.type === "tool-call" && part.toolCallId === output.toolCallId) {
+            return {
+              ...part,
+              state: output.state || "output-available",
+              output: output.output,
+              errorText: output.errorText,
+            } as ToolUIPart;
+          }
+          return part;
+        }),
+      }))
+    );
+  }, []);
+
+  /**
+   * Send a message - AI SDK v5 compatible
+   */
+  const sendMessage = useCallback(
+    async (message: { text: string }) => {
+      const userMessage: UIMessage = {
+        id: generateClientId("msg"),
+        role: "user",
+        parts: [{ type: "text", text: message.text }],
       };
 
-      // Add user message
       setMessages((prev) => [...prev, userMessage]);
       setIsLoading(true);
       setError(null);
 
-      // Create abort controller
       const abortController = new AbortController();
       abortControllerRef.current = abortController;
 
       try {
-        // Call API
         const response = await fetch(options.api, {
           method: "POST",
           headers: {
@@ -181,13 +268,10 @@ export function useChat(options: UseChatOptions): UseChatResult {
           }));
         }
 
-        if (options.onResponse) {
-          options.onResponse(response);
-        }
+        options.onResponse?.(response);
 
-        // Handle streaming response
         if (response.body) {
-          const streamingMessageId = `msg_${Date.now()}`;
+          const streamingMessageId = generateClientId("msg");
           let hasAddedStreamingMessage = false;
 
           await handleStreamingResponse(response.body, {
@@ -200,39 +284,31 @@ export function useChat(options: UseChatOptions): UseChatResult {
               });
               options.onFinish?.(assistantMessage);
             },
-            onData: (partialData) => setData(partialData),
-            onUpdate: (partialContent, messageId) => {
+            onData: setData,
+            onUpdate: (parts, messageId) => {
               const id = messageId || streamingMessageId;
               if (!hasAddedStreamingMessage) {
                 hasAddedStreamingMessage = true;
                 setMessages((prev) => [...prev, {
                   id,
-                  role: "assistant" as const,
-                  content: partialContent,
-                  timestamp: Date.now(),
+                  role: "assistant",
+                  parts,
                 }]);
               } else {
                 setMessages((prev) => prev.map((m) =>
-                  m.id === id ? { ...m, content: partialContent } : m
+                  m.id === id ? { ...m, parts } : m
                 ));
               }
             },
             onToolCall: options.onToolCall,
-            onToolResult: options.onToolResult,
           });
         }
       } catch (err) {
-        if (err instanceof Error && err.name === "AbortError") {
-          // Request was aborted, ignore
-          return;
-        }
+        if (err instanceof Error && err.name === "AbortError") return;
 
         const error = err instanceof Error ? err : new Error(String(err));
         setError(error);
-
-        if (options.onError) {
-          options.onError(error);
-        }
+        options.onError?.(error);
       } finally {
         setIsLoading(false);
         abortControllerRef.current = null;
@@ -242,29 +318,34 @@ export function useChat(options: UseChatOptions): UseChatResult {
   );
 
   /**
+   * @deprecated Use sendMessage instead
+   */
+  const append = useCallback(
+    async (message: Omit<Message, "id" | "timestamp">) => {
+      await sendMessage({ text: message.content });
+    },
+    [sendMessage],
+  );
+
+  /**
    * Reload last message
    */
   const reload = useCallback(async () => {
     if (messages.length === 0) return;
 
-    // Remove last assistant message and re-send user message
-    const lastUserMessageIndex = messages.findLastIndex((m) => m.role === "user");
+    const lastUserIndex = messages.findLastIndex((m) => m.role === "user");
+    if (lastUserIndex === -1) return;
 
-    if (lastUserMessageIndex === -1) return;
-
-    const messagesToKeep = messages.slice(0, lastUserMessageIndex);
-    const lastUserMessage = messages[lastUserMessageIndex];
-
-    // Early return already handled undefined case above
+    const lastUserMessage = messages[lastUserIndex];
     if (!lastUserMessage) return;
 
-    setMessages(messagesToKeep);
+    // Get text from parts
+    const textPart = lastUserMessage.parts.find((p) => p.type === "text") as TextUIPart | undefined;
+    if (!textPart) return;
 
-    await append({
-      role: lastUserMessage.role,
-      content: lastUserMessage.content,
-    });
-  }, [messages, append]);
+    setMessages(messages.slice(0, lastUserIndex));
+    await sendMessage({ text: textPart.text });
+  }, [messages, sendMessage]);
 
   /**
    * Stop generation
@@ -293,18 +374,13 @@ export function useChat(options: UseChatOptions): UseChatResult {
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
-
       if (!input.trim() || isLoading) return;
 
-      const messageContent = input;
+      const text = input;
       setInput("");
-
-      await append({
-        role: "user",
-        content: messageContent,
-      });
+      await sendMessage({ text });
     },
-    [input, isLoading, append],
+    [input, isLoading, sendMessage],
   );
 
   return {
@@ -313,10 +389,12 @@ export function useChat(options: UseChatOptions): UseChatResult {
     isLoading,
     error,
     setInput,
+    sendMessage,
     append,
     reload,
     stop,
     setMessages,
+    addToolOutput,
     data,
     handleInputChange,
     handleSubmit,
@@ -324,14 +402,34 @@ export function useChat(options: UseChatOptions): UseChatResult {
 }
 
 /**
- * Streaming response callbacks
+ * Streaming response callbacks - AI SDK v5 compatible
  */
 interface StreamingCallbacks {
-  onMessage: (message: MessageWithParts) => void;
+  onMessage: (message: UIMessage) => void;
   onData: (data: unknown) => void;
-  onUpdate?: (partialContent: string, messageId: string) => void;
-  onToolCall?: (toolCall: ToolCallUI) => void;
-  onToolResult?: (toolCall: ToolCallUI) => void;
+  onUpdate?: (parts: UIMessagePart[], messageId: string) => void;
+  onToolCall?: (arg: OnToolCallArg) => void;
+}
+
+/**
+ * Internal tool tracking during streaming
+ */
+interface StreamingToolCall {
+  toolCallId: string;
+  toolName: string;
+  inputText: string;
+  input?: unknown;
+  output?: unknown;
+  state: ToolState;
+}
+
+/**
+ * Internal reasoning tracking during streaming
+ */
+interface StreamingReasoning {
+  id: string;
+  text: string;
+  isComplete: boolean;
 }
 
 /**
@@ -352,23 +450,58 @@ async function handleStreamingResponse(
   body: ReadableStream,
   callbacks: StreamingCallbacks,
 ): Promise<void> {
-  const { onMessage, onData, onUpdate, onToolCall, onToolResult } = callbacks;
+  const { onMessage, onData, onUpdate, onToolCall } = callbacks;
   const reader = body.getReader();
   const decoder = new TextDecoder();
 
   // Track text blocks by ID (v5 uses IDs to group text-start/delta/end)
-  const textBlocks = new Map<string, string>();
+  const textBlocks = new Map<string, { text: string; state: "streaming" | "done" }>();
   let currentTextId = "";
   let messageId = "";
 
   // Track tool calls by ID
-  const toolCalls = new Map<string, ToolCallUI>();
+  const toolCalls = new Map<string, StreamingToolCall>();
 
   // Track reasoning blocks by ID
-  const reasoningBlocks = new Map<string, ReasoningUI>();
+  const reasoningBlocks = new Map<string, StreamingReasoning>();
 
   // Message parts for v5 structured messages
-  const messageParts: MessageWithParts["parts"] = [];
+  const messageParts: UIMessagePart[] = [];
+
+  // Helper to build current parts for onUpdate
+  const buildCurrentParts = (): UIMessagePart[] => {
+    const parts: UIMessagePart[] = [];
+
+    // Add text parts
+    for (const [, block] of textBlocks) {
+      if (block.text) {
+        parts.push({ type: "text", text: block.text, state: block.state });
+      }
+    }
+
+    // Add reasoning parts
+    for (const [, reasoning] of reasoningBlocks) {
+      parts.push({
+        type: "reasoning",
+        text: reasoning.text,
+        state: reasoning.isComplete ? "done" : "streaming",
+      });
+    }
+
+    // Add tool parts
+    for (const [, tool] of toolCalls) {
+      parts.push({
+        type: "tool-call",
+        toolCallId: tool.toolCallId,
+        toolName: tool.toolName,
+        state: tool.state,
+        input: tool.input,
+        output: tool.output,
+      });
+    }
+
+    return parts;
+  };
 
   while (true) {
     const { done, value } = await reader.read();
@@ -386,9 +519,8 @@ async function handleStreamingResponse(
 
         // Legacy [DONE] marker (v4 compatibility)
         if (data === "[DONE]") {
-          const accumulatedText = getAccumulatedText(textBlocks);
-          if (accumulatedText) {
-            onMessage(createAssistantMessage(messageId, accumulatedText, messageParts));
+          if (messageParts.length > 0 || textBlocks.size > 0) {
+            onMessage(createAssistantMessage(messageId, messageParts));
           }
           continue;
         }
@@ -417,7 +549,7 @@ async function handleStreamingResponse(
             // v5: Text block start
             case "text-start":
               currentTextId = parsed.id || generateClientId("text");
-              textBlocks.set(currentTextId, "");
+              textBlocks.set(currentTextId, { text: "", state: "streaming" });
               break;
 
             // v5: Text delta (also handles v4 format)
@@ -427,27 +559,29 @@ async function handleStreamingResponse(
 
               // Initialize text block if needed
               if (!textBlocks.has(textId)) {
-                textBlocks.set(textId, "");
+                textBlocks.set(textId, { text: "", state: "streaming" });
                 currentTextId = textId;
               }
 
               // Append delta to text block
-              textBlocks.set(textId, (textBlocks.get(textId) || "") + delta);
+              const block = textBlocks.get(textId)!;
+              block.text += delta;
 
-              // Update UI with accumulated text
-              if (onUpdate) {
-                onUpdate(getAccumulatedText(textBlocks), messageId);
-              }
+              // Update UI with current parts
+              onUpdate?.(buildCurrentParts(), messageId);
               break;
             }
 
             // v5: Text block end
             case "text-end": {
-              // Add text part to message parts
               const textId = parsed.id || currentTextId;
-              const text = textBlocks.get(textId) || "";
-              if (text) {
-                messageParts.push({ type: "text", text });
+              const block = textBlocks.get(textId);
+              if (block) {
+                block.state = "done";
+                // Add text part to final message parts
+                if (block.text) {
+                  messageParts.push({ type: "text", text: block.text, state: "done" });
+                }
               }
               break;
             }
@@ -455,14 +589,14 @@ async function handleStreamingResponse(
             // v5: Tool input start
             case "tool-input-start": {
               const toolCallId = parsed.toolCallId || generateClientId("tool");
-              const toolCall: ToolCallUI = {
-                id: toolCallId,
+              const toolCall: StreamingToolCall = {
+                toolCallId,
                 toolName: parsed.toolName || "unknown",
                 inputText: "",
-                status: "pending",
+                state: "input-streaming",
               };
               toolCalls.set(toolCallId, toolCall);
-              onToolCall?.(toolCall);
+              onUpdate?.(buildCurrentParts(), messageId);
               break;
             }
 
@@ -471,9 +605,8 @@ async function handleStreamingResponse(
               const toolCallId = parsed.toolCallId;
               const toolCall = toolCalls.get(toolCallId);
               if (toolCall) {
-                toolCall.inputText = (toolCall.inputText || "") + (parsed.inputTextDelta || parsed.delta || "");
-                toolCall.status = "streaming";
-                onToolCall?.(toolCall);
+                toolCall.inputText += parsed.inputTextDelta || parsed.delta || "";
+                onUpdate?.(buildCurrentParts(), messageId);
               }
               break;
             }
@@ -485,16 +618,27 @@ async function handleStreamingResponse(
               if (toolCall) {
                 toolCall.input = parsed.input;
                 toolCall.toolName = parsed.toolName || toolCall.toolName;
-                toolCall.status = "executing";
-                onToolCall?.(toolCall);
+                toolCall.state = "input-available";
+
+                // Notify via onToolCall - AI SDK v5 pattern
+                onToolCall?.({
+                  toolCall: {
+                    toolCallId,
+                    toolName: toolCall.toolName,
+                    input: toolCall.input,
+                  },
+                });
 
                 // Add tool-call part
                 messageParts.push({
                   type: "tool-call",
                   toolCallId,
                   toolName: toolCall.toolName,
-                  args: toolCall.input,
+                  state: "input-available",
+                  input: toolCall.input,
                 });
+
+                onUpdate?.(buildCurrentParts(), messageId);
               }
               break;
             }
@@ -505,15 +649,17 @@ async function handleStreamingResponse(
               const toolCall = toolCalls.get(toolCallId);
               if (toolCall) {
                 toolCall.output = parsed.output;
-                toolCall.status = "completed";
-                onToolResult?.(toolCall);
+                toolCall.state = "output-available";
 
                 // Add tool-result part
                 messageParts.push({
                   type: "tool-result",
                   toolCallId,
+                  toolName: toolCall.toolName,
                   result: toolCall.output,
                 });
+
+                onUpdate?.(buildCurrentParts(), messageId);
               }
               break;
             }
@@ -524,14 +670,16 @@ async function handleStreamingResponse(
               const toolCall = toolCalls.get(toolCallId);
               if (toolCall) {
                 toolCall.output = parsed.result || parsed.output;
-                toolCall.status = "completed";
-                onToolResult?.(toolCall);
+                toolCall.state = "output-available";
 
                 messageParts.push({
                   type: "tool-result",
                   toolCallId,
+                  toolName: toolCall.toolName,
                   result: toolCall.output,
                 });
+
+                onUpdate?.(buildCurrentParts(), messageId);
               }
               break;
             }
@@ -539,12 +687,13 @@ async function handleStreamingResponse(
             // v5: Reasoning start
             case "reasoning-start": {
               const reasoningId = parsed.id || generateClientId("reasoning");
-              const reasoning: ReasoningUI = {
+              const reasoning: StreamingReasoning = {
                 id: reasoningId,
                 text: "",
                 isComplete: false,
               };
               reasoningBlocks.set(reasoningId, reasoning);
+              onUpdate?.(buildCurrentParts(), messageId);
               break;
             }
 
@@ -554,6 +703,7 @@ async function handleStreamingResponse(
               const reasoning = reasoningBlocks.get(reasoningId);
               if (reasoning) {
                 reasoning.text += parsed.delta || "";
+                onUpdate?.(buildCurrentParts(), messageId);
               }
               break;
             }
@@ -564,21 +714,21 @@ async function handleStreamingResponse(
               const reasoning = reasoningBlocks.get(reasoningId);
               if (reasoning) {
                 reasoning.isComplete = true;
-                // Add reasoning part to message
+                // Add reasoning part to final message
                 messageParts.push({
                   type: "reasoning",
-                  id: reasoningId,
                   text: reasoning.text,
+                  state: "done",
                 });
+                onUpdate?.(buildCurrentParts(), messageId);
               }
               break;
             }
 
             // v5: Stream finish
             case "finish": {
-              const accumulatedText = getAccumulatedText(textBlocks);
-              if (accumulatedText || messageParts.length > 0) {
-                onMessage(createAssistantMessage(messageId, accumulatedText, messageParts));
+              if (messageParts.length > 0 || textBlocks.size > 0) {
+                onMessage(createAssistantMessage(messageId, messageParts));
               }
               break;
             }
@@ -597,33 +747,17 @@ async function handleStreamingResponse(
 }
 
 /**
- * Get accumulated text from all text blocks
- */
-function getAccumulatedText(textBlocks: Map<string, string>): string {
-  return Array.from(textBlocks.values()).join("");
-}
-
-/**
- * Create assistant message with optional parts
+ * Create assistant message from parts - AI SDK v5 compatible
  */
 function createAssistantMessage(
   messageId: string,
-  content: string,
-  parts?: MessageWithParts["parts"],
-): MessageWithParts {
-  const message: MessageWithParts = {
+  parts: UIMessagePart[],
+): UIMessage {
+  return {
     id: messageId || generateClientId("msg"),
     role: "assistant",
-    content,
-    timestamp: Date.now(),
+    parts,
   };
-
-  // Add parts if there are any (for v5 structured content)
-  if (parts && parts.length > 0) {
-    message.parts = parts;
-  }
-
-  return message;
 }
 
 /**

--- a/src/ai/react/hooks/use-chat.ts
+++ b/src/ai/react/hooks/use-chat.ts
@@ -346,8 +346,8 @@ async function handleStreamingResponse(
             messageId = parsed.messageId || `msg_${Date.now()}`;
             accumulatedText = "";
           } else if (parsed.type === "text-delta") {
-            // Text chunk - accumulate and update UI
-            accumulatedText += parsed.textDelta || "";
+            // Text chunk - accumulate and update UI (v5 uses `delta`, fallback to `textDelta` for v4)
+            accumulatedText += parsed.delta || parsed.textDelta || "";
             // Call onUpdate to show text progressively
             if (onUpdate) {
               onUpdate(accumulatedText, messageId);

--- a/src/ai/react/hooks/use-chat.ts
+++ b/src/ai/react/hooks/use-chat.ts
@@ -291,9 +291,7 @@ export function useChat(options: UseChatOptions): UseChatResult {
                   parts,
                 }]);
               } else {
-                setMessages((prev) => prev.map((m) =>
-                  m.id === id ? { ...m, parts } : m
-                ));
+                setMessages((prev) => prev.map((m) => m.id === id ? { ...m, parts } : m));
               }
             },
             onToolCall: options.onToolCall,

--- a/src/ai/react/hooks/use-chat.ts
+++ b/src/ai/react/hooks/use-chat.ts
@@ -9,7 +9,6 @@
  */
 
 import { useCallback, useRef, useState } from "react";
-import type { Message } from "../../types/agent.ts";
 import { createError, toError } from "../../../core/errors/veryfront-error.ts";
 
 /**
@@ -181,9 +180,6 @@ export interface UseChatResult {
 
   /** Handle form submit */
   handleSubmit: (e: React.FormEvent) => Promise<void>;
-
-  /** @deprecated Use sendMessage instead */
-  append: (message: Omit<Message, "id" | "timestamp">) => Promise<void>;
 }
 
 /**
@@ -318,16 +314,6 @@ export function useChat(options: UseChatOptions): UseChatResult {
   );
 
   /**
-   * @deprecated Use sendMessage instead
-   */
-  const append = useCallback(
-    async (message: Omit<Message, "id" | "timestamp">) => {
-      await sendMessage({ text: message.content });
-    },
-    [sendMessage],
-  );
-
-  /**
    * Reload last message
    */
   const reload = useCallback(async () => {
@@ -390,7 +376,6 @@ export function useChat(options: UseChatOptions): UseChatResult {
     error,
     setInput,
     sendMessage,
-    append,
     reload,
     stop,
     setMessages,
@@ -517,14 +502,6 @@ async function handleStreamingResponse(
       if (line.startsWith("data: ")) {
         const data = line.slice(6);
 
-        // Legacy [DONE] marker (v4 compatibility)
-        if (data === "[DONE]") {
-          if (messageParts.length > 0 || textBlocks.size > 0) {
-            onMessage(createAssistantMessage(messageId, messageParts));
-          }
-          continue;
-        }
-
         try {
           const parsed = JSON.parse(data);
 
@@ -552,10 +529,10 @@ async function handleStreamingResponse(
               textBlocks.set(currentTextId, { text: "", state: "streaming" });
               break;
 
-            // v5: Text delta (also handles v4 format)
+            // v5: Text delta
             case "text-delta": {
               const textId = parsed.id || currentTextId || "default";
-              const delta = parsed.delta || parsed.textDelta || "";
+              const delta = parsed.delta || "";
 
               // Initialize text block if needed
               if (!textBlocks.has(textId)) {
@@ -652,26 +629,6 @@ async function handleStreamingResponse(
                 toolCall.state = "output-available";
 
                 // Add tool-result part
-                messageParts.push({
-                  type: "tool-result",
-                  toolCallId,
-                  toolName: toolCall.toolName,
-                  result: toolCall.output,
-                });
-
-                onUpdate?.(buildCurrentParts(), messageId);
-              }
-              break;
-            }
-
-            // Legacy tool-result event (alternative format)
-            case "tool-result": {
-              const toolCallId = parsed.toolCallId || parsed.id;
-              const toolCall = toolCalls.get(toolCallId);
-              if (toolCall) {
-                toolCall.output = parsed.result || parsed.output;
-                toolCall.state = "output-available";
-
                 messageParts.push({
                   type: "tool-result",
                   toolCallId,

--- a/src/ai/react/hooks/use-chat.ts
+++ b/src/ai/react/hooks/use-chat.ts
@@ -12,6 +12,49 @@ import { useCallback, useRef, useState } from "react";
 import type { Message } from "../../types/agent.ts";
 import { createError, toError } from "../../../core/errors/veryfront-error.ts";
 
+/**
+ * Tool call information for UI
+ */
+export interface ToolCallUI {
+  /** Tool call ID */
+  id: string;
+  /** Tool name */
+  toolName: string;
+  /** Tool input (parsed JSON) */
+  input?: unknown;
+  /** Tool input as raw text (for streaming) */
+  inputText?: string;
+  /** Tool output/result */
+  output?: unknown;
+  /** Tool call status */
+  status: "pending" | "streaming" | "executing" | "completed" | "error";
+}
+
+/**
+ * Reasoning block for UI
+ */
+export interface ReasoningUI {
+  /** Reasoning block ID */
+  id: string;
+  /** Accumulated reasoning text */
+  text: string;
+  /** Whether reasoning is complete */
+  isComplete: boolean;
+}
+
+/**
+ * Extended message with parts (v5 compatible)
+ */
+export interface MessageWithParts extends Message {
+  /** Message parts for rich content */
+  parts?: Array<
+    | { type: "text"; text: string }
+    | { type: "tool-call"; toolCallId: string; toolName: string; args: unknown }
+    | { type: "tool-result"; toolCallId: string; result: unknown }
+    | { type: "reasoning"; id: string; text: string }
+  >;
+}
+
 export interface UseChatOptions {
   /** API endpoint for chat */
   api: string;
@@ -32,10 +75,16 @@ export interface UseChatOptions {
   onResponse?: (response: Response) => void;
 
   /** Callback when message finished */
-  onFinish?: (message: Message) => void;
+  onFinish?: (message: MessageWithParts) => void;
 
   /** Callback when error occurs */
   onError?: (error: Error) => void;
+
+  /** Callback when tool call starts */
+  onToolCall?: (toolCall: ToolCallUI) => void;
+
+  /** Callback when tool result received */
+  onToolResult?: (toolCall: ToolCallUI) => void;
 }
 
 export interface UseChatResult {
@@ -138,58 +187,39 @@ export function useChat(options: UseChatOptions): UseChatResult {
 
         // Handle streaming response
         if (response.body) {
-          // Create a placeholder message ID for streaming
           const streamingMessageId = `msg_${Date.now()}`;
           let hasAddedStreamingMessage = false;
 
-          await handleStreamingResponse(
-            response.body,
-            // onMessage - when streaming is complete
-            (assistantMessage) => {
-              // Replace the streaming message with the final message
+          await handleStreamingResponse(response.body, {
+            onMessage: (assistantMessage) => {
               setMessages((prev) => {
-                // If we had a streaming message, replace it
                 if (hasAddedStreamingMessage) {
                   return prev.map((m) => m.id === streamingMessageId ? assistantMessage : m);
                 }
-                // Otherwise just add it
                 return [...prev, assistantMessage];
               });
-
-              if (options.onFinish) {
-                options.onFinish(assistantMessage);
-              }
+              options.onFinish?.(assistantMessage);
             },
-            // onData - for data events
-            (partialData) => {
-              setData(partialData);
-            },
-            // onUpdate - for real-time streaming updates
-            (partialContent, messageId) => {
+            onData: (partialData) => setData(partialData),
+            onUpdate: (partialContent, messageId) => {
+              const id = messageId || streamingMessageId;
               if (!hasAddedStreamingMessage) {
-                // Add the streaming message for the first time
                 hasAddedStreamingMessage = true;
-                setMessages((prev) => [
-                  ...prev,
-                  {
-                    id: messageId || streamingMessageId,
-                    role: "assistant" as const,
-                    content: partialContent,
-                    timestamp: Date.now(),
-                  },
-                ]);
+                setMessages((prev) => [...prev, {
+                  id,
+                  role: "assistant" as const,
+                  content: partialContent,
+                  timestamp: Date.now(),
+                }]);
               } else {
-                // Update the streaming message content
-                setMessages((prev) =>
-                  prev.map((m) =>
-                    m.id === (messageId || streamingMessageId)
-                      ? { ...m, content: partialContent }
-                      : m
-                  )
-                );
+                setMessages((prev) => prev.map((m) =>
+                  m.id === id ? { ...m, content: partialContent } : m
+                ));
               }
             },
-          );
+            onToolCall: options.onToolCall,
+            onToolResult: options.onToolResult,
+          });
         }
       } catch (err) {
         if (err instanceof Error && err.name === "AbortError") {
@@ -294,6 +324,17 @@ export function useChat(options: UseChatOptions): UseChatResult {
 }
 
 /**
+ * Streaming response callbacks
+ */
+interface StreamingCallbacks {
+  onMessage: (message: MessageWithParts) => void;
+  onData: (data: unknown) => void;
+  onUpdate?: (partialContent: string, messageId: string) => void;
+  onToolCall?: (toolCall: ToolCallUI) => void;
+  onToolResult?: (toolCall: ToolCallUI) => void;
+}
+
+/**
  * Handle streaming response from server
  * Supports AI SDK v5 UI Message Stream Protocol
  *
@@ -301,15 +342,17 @@ export function useChat(options: UseChatOptions): UseChatResult {
  * - start: Stream beginning
  * - start-step / finish-step: Step boundaries (for multi-step/tools)
  * - text-start / text-delta / text-end: Text block lifecycle
+ * - tool-input-start / tool-input-delta / tool-input-available: Tool input streaming
+ * - tool-output-available: Tool result
+ * - reasoning-start / reasoning-delta / reasoning-end: Reasoning block lifecycle
  * - finish: Stream end
  * - data: Custom data
  */
 async function handleStreamingResponse(
   body: ReadableStream,
-  onMessage: (message: Message) => void,
-  onData: (data: unknown) => void,
-  onUpdate?: (partialContent: string, messageId: string) => void,
+  callbacks: StreamingCallbacks,
 ): Promise<void> {
+  const { onMessage, onData, onUpdate, onToolCall, onToolResult } = callbacks;
   const reader = body.getReader();
   const decoder = new TextDecoder();
 
@@ -317,6 +360,15 @@ async function handleStreamingResponse(
   const textBlocks = new Map<string, string>();
   let currentTextId = "";
   let messageId = "";
+
+  // Track tool calls by ID
+  const toolCalls = new Map<string, ToolCallUI>();
+
+  // Track reasoning blocks by ID
+  const reasoningBlocks = new Map<string, ReasoningUI>();
+
+  // Message parts for v5 structured messages
+  const messageParts: MessageWithParts["parts"] = [];
 
   while (true) {
     const { done, value } = await reader.read();
@@ -336,7 +388,7 @@ async function handleStreamingResponse(
         if (data === "[DONE]") {
           const accumulatedText = getAccumulatedText(textBlocks);
           if (accumulatedText) {
-            onMessage(createAssistantMessage(messageId, accumulatedText));
+            onMessage(createAssistantMessage(messageId, accumulatedText, messageParts));
           }
           continue;
         }
@@ -349,12 +401,17 @@ async function handleStreamingResponse(
             case "start":
               messageId = parsed.messageId || generateClientId("msg");
               textBlocks.clear();
+              toolCalls.clear();
+              reasoningBlocks.clear();
+              messageParts.length = 0;
               break;
 
             // v5: Step boundaries (for multi-step tool calls)
             case "start-step":
+              // Step started - could track step ID if needed
+              break;
             case "finish-step":
-              // Currently no-op, but could track step state
+              // Step finished - finalize any pending tool calls for this step
               break;
 
             // v5: Text block start
@@ -385,15 +442,143 @@ async function handleStreamingResponse(
             }
 
             // v5: Text block end
-            case "text-end":
-              // Text block complete, no action needed
+            case "text-end": {
+              // Add text part to message parts
+              const textId = parsed.id || currentTextId;
+              const text = textBlocks.get(textId) || "";
+              if (text) {
+                messageParts.push({ type: "text", text });
+              }
               break;
+            }
+
+            // v5: Tool input start
+            case "tool-input-start": {
+              const toolCallId = parsed.toolCallId || generateClientId("tool");
+              const toolCall: ToolCallUI = {
+                id: toolCallId,
+                toolName: parsed.toolName || "unknown",
+                inputText: "",
+                status: "pending",
+              };
+              toolCalls.set(toolCallId, toolCall);
+              onToolCall?.(toolCall);
+              break;
+            }
+
+            // v5: Tool input delta (streaming tool arguments)
+            case "tool-input-delta": {
+              const toolCallId = parsed.toolCallId;
+              const toolCall = toolCalls.get(toolCallId);
+              if (toolCall) {
+                toolCall.inputText = (toolCall.inputText || "") + (parsed.inputTextDelta || parsed.delta || "");
+                toolCall.status = "streaming";
+                onToolCall?.(toolCall);
+              }
+              break;
+            }
+
+            // v5: Tool input available (complete input ready)
+            case "tool-input-available": {
+              const toolCallId = parsed.toolCallId;
+              const toolCall = toolCalls.get(toolCallId);
+              if (toolCall) {
+                toolCall.input = parsed.input;
+                toolCall.toolName = parsed.toolName || toolCall.toolName;
+                toolCall.status = "executing";
+                onToolCall?.(toolCall);
+
+                // Add tool-call part
+                messageParts.push({
+                  type: "tool-call",
+                  toolCallId,
+                  toolName: toolCall.toolName,
+                  args: toolCall.input,
+                });
+              }
+              break;
+            }
+
+            // v5: Tool output available (result)
+            case "tool-output-available": {
+              const toolCallId = parsed.toolCallId;
+              const toolCall = toolCalls.get(toolCallId);
+              if (toolCall) {
+                toolCall.output = parsed.output;
+                toolCall.status = "completed";
+                onToolResult?.(toolCall);
+
+                // Add tool-result part
+                messageParts.push({
+                  type: "tool-result",
+                  toolCallId,
+                  result: toolCall.output,
+                });
+              }
+              break;
+            }
+
+            // Legacy tool-result event (alternative format)
+            case "tool-result": {
+              const toolCallId = parsed.toolCallId || parsed.id;
+              const toolCall = toolCalls.get(toolCallId);
+              if (toolCall) {
+                toolCall.output = parsed.result || parsed.output;
+                toolCall.status = "completed";
+                onToolResult?.(toolCall);
+
+                messageParts.push({
+                  type: "tool-result",
+                  toolCallId,
+                  result: toolCall.output,
+                });
+              }
+              break;
+            }
+
+            // v5: Reasoning start
+            case "reasoning-start": {
+              const reasoningId = parsed.id || generateClientId("reasoning");
+              const reasoning: ReasoningUI = {
+                id: reasoningId,
+                text: "",
+                isComplete: false,
+              };
+              reasoningBlocks.set(reasoningId, reasoning);
+              break;
+            }
+
+            // v5: Reasoning delta
+            case "reasoning-delta": {
+              const reasoningId = parsed.id;
+              const reasoning = reasoningBlocks.get(reasoningId);
+              if (reasoning) {
+                reasoning.text += parsed.delta || "";
+              }
+              break;
+            }
+
+            // v5: Reasoning end
+            case "reasoning-end": {
+              const reasoningId = parsed.id;
+              const reasoning = reasoningBlocks.get(reasoningId);
+              if (reasoning) {
+                reasoning.isComplete = true;
+                // Add reasoning part to message
+                messageParts.push({
+                  type: "reasoning",
+                  id: reasoningId,
+                  text: reasoning.text,
+                });
+              }
+              break;
+            }
 
             // v5: Stream finish
             case "finish": {
               const accumulatedText = getAccumulatedText(textBlocks);
-              if (accumulatedText) {
-                onMessage(createAssistantMessage(messageId, accumulatedText));
+              if (accumulatedText || messageParts.length > 0) {
+                onMessage(createAssistantMessage(messageId, accumulatedText, messageParts));
               }
               break;
             }
@@ -401,20 +586,6 @@ async function handleStreamingResponse(
             // Custom data events
             case "data":
               onData(parsed.data || parsed.value);
-              break;
-
-            // Tool events (future support)
-            case "tool-input-start":
-            case "tool-input-delta":
-            case "tool-result":
-              // TODO: Implement tool call UI updates
-              break;
-
-            // Reasoning events (future support)
-            case "reasoning-start":
-            case "reasoning-delta":
-            case "reasoning-end":
-              // TODO: Implement reasoning UI updates
               break;
           }
         } catch {
@@ -433,15 +604,26 @@ function getAccumulatedText(textBlocks: Map<string, string>): string {
 }
 
 /**
- * Create assistant message
+ * Create assistant message with optional parts
  */
-function createAssistantMessage(messageId: string, content: string): Message {
-  return {
+function createAssistantMessage(
+  messageId: string,
+  content: string,
+  parts?: MessageWithParts["parts"],
+): MessageWithParts {
+  const message: MessageWithParts = {
     id: messageId || generateClientId("msg"),
     role: "assistant",
     content,
     timestamp: Date.now(),
   };
+
+  // Add parts if there are any (for v5 structured content)
+  if (parts && parts.length > 0) {
+    message.parts = parts;
+  }
+
+  return message;
 }
 
 /**

--- a/src/ai/react/index.ts
+++ b/src/ai/react/index.ts
@@ -6,23 +6,37 @@
  * This module provides React hooks with complete control over AI logic
  * and zero UI opinions. Build any interface you want.
  *
+ * Uses AI SDK v5 UI Message format with parts-based content structure.
+ *
  * @module veryfront/ai/react
  * @example
  * ```typescript
  * import { useChat } from 'veryfront/ai/react';
+ * import type { UIMessage } from 'veryfront/ai/react';
+ *
+ * // Helper to extract text from v5 parts array
+ * function getTextContent(message: UIMessage): string {
+ *   return message.parts
+ *     .filter((p) => p.type === 'text')
+ *     .map((p) => p.text)
+ *     .join('');
+ * }
  *
  * function MyChat() {
- *   const { messages, input, setInput, append } = useChat({
+ *   const { messages, input, setInput, sendMessage, handleSubmit } = useChat({
  *     api: '/api/chat',
  *   });
  *
  *   return (
- *     <YourCompletelyCustomUI
- *       messages={messages}
- *       input={input}
- *       onChange={setInput}
- *       onSubmit={() => append({ role: 'user', content: input })}
- *     />
+ *     <div>
+ *       {messages.map((msg) => (
+ *         <div key={msg.id}>{getTextContent(msg)}</div>
+ *       ))}
+ *       <form onSubmit={handleSubmit}>
+ *         <input value={input} onChange={(e) => setInput(e.target.value)} />
+ *         <button type="submit">Send</button>
+ *       </form>
+ *     </div>
  *   );
  * }
  * ```

--- a/src/ai/react/primitives/index.ts
+++ b/src/ai/react/primitives/index.ts
@@ -4,6 +4,8 @@
  * Composable UI primitives with zero styling opinions.
  * Built on Radix UI patterns (shadcn-compatible).
  *
+ * Uses AI SDK v5 UI Message format with parts-based content structure.
+ *
  * @module veryfront/ai/primitives
  * @example
  * ```tsx
@@ -14,6 +16,15 @@
  *   InputBox,
  * } from 'veryfront/ai/primitives';
  * import { useChat } from 'veryfront/ai/react';
+ * import type { UIMessage } from 'veryfront/ai/react';
+ *
+ * // Helper to extract text from v5 parts array
+ * function getTextContent(message: UIMessage): string {
+ *   return message.parts
+ *     .filter((p) => p.type === 'text')
+ *     .map((p) => p.text)
+ *     .join('');
+ * }
  *
  * function MyChat() {
  *   const chat = useChat({ api: '/api/chat' });
@@ -27,16 +38,17 @@
  *             role={msg.role}
  *             className="p-4"
  *           >
- *             {msg.content}
+ *             {getTextContent(msg)}
  *           </MessageItem>
  *         ))}
  *       </MessageList>
- *       <InputBox
- *         value={chat.input}
- *         onChange={chat.handleInputChange}
- *         onSubmit={() => chat.append({ role: 'user', content: chat.input })}
- *         className="border-t p-4"
- *       />
+ *       <form onSubmit={chat.handleSubmit}>
+ *         <InputBox
+ *           value={chat.input}
+ *           onChange={chat.handleInputChange}
+ *           className="border-t p-4"
+ *         />
+ *       </form>
  *     </ChatContainer>
  *   );
  * }

--- a/src/ai/utils/id.ts
+++ b/src/ai/utils/id.ts
@@ -1,45 +1,77 @@
 /**
  * ID generation utilities following AI SDK best practices
  *
+ * AI SDK uses nanoid internally with these defaults:
+ * - 16 character alphanumeric string (a-zA-Z0-9)
+ * - Dash separator for prefixed IDs
+ *
  * @module veryfront/ai/utils/id
  */
+
+// URL-safe alphabet matching nanoid default (no special chars for simplicity)
+const ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+/**
+ * Generate a random alphanumeric string
+ */
+function randomString(length: number): string {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    result += ALPHABET[bytes[i]! % ALPHABET.length];
+  }
+  return result;
+}
 
 /**
  * Generate a unique ID with optional prefix
  *
  * Follows AI SDK generateId pattern:
  * - 16 character alphanumeric string by default
- * - Optional prefix with underscore separator
+ * - Optional prefix with dash separator (AI SDK default)
  *
  * @example
  * ```ts
- * generateId()           // "a1b2c3d4e5f6g7h8"
- * generateId("msg")      // "msg_a1b2c3d4e5f6"
- * generateId("text")     // "text_a1b2c3d4e5f6"
+ * generateId()           // "a1B2c3D4e5F6g7H8"
+ * generateId("msg")      // "msg-a1B2c3D4e5F6g7H8"
+ * generateId("text")     // "text-a1B2c3D4e5F6g7H8"
  * ```
  */
 export function generateId(prefix?: string): string {
-  // Use crypto.randomUUID() and extract hex chars (no dashes)
-  const hex = crypto.randomUUID().replace(/-/g, "");
+  const id = randomString(16);
 
   if (prefix) {
-    // With prefix: prefix + 12 chars = ~16-20 chars total
-    return `${prefix}_${hex.slice(0, 12)}`;
+    return `${prefix}-${id}`;
   }
 
-  // Without prefix: 16 chars (matches AI SDK default)
-  return hex.slice(0, 16);
+  return id;
 }
 
 /**
- * Create an ID generator with a fixed prefix
+ * Create an ID generator with a fixed prefix and optional configuration
  *
  * @example
  * ```ts
- * const generateMessageId = createIdGenerator("msg");
- * generateMessageId() // "msg_a1b2c3d4e5f6"
+ * const generateMessageId = createIdGenerator({ prefix: "msg" });
+ * generateMessageId() // "msg-a1B2c3D4e5F6g7H8"
+ *
+ * const generateShortId = createIdGenerator({ prefix: "user", size: 8 });
+ * generateShortId() // "user-a1B2c3D4"
  * ```
  */
-export function createIdGenerator(prefix: string): () => string {
-  return () => generateId(prefix);
+export function createIdGenerator(options: {
+  prefix?: string;
+  separator?: string;
+  size?: number;
+}): () => string {
+  const { prefix, separator = "-", size = 16 } = options;
+
+  return () => {
+    const id = randomString(size);
+    if (prefix) {
+      return `${prefix}${separator}${id}`;
+    }
+    return id;
+  };
 }

--- a/src/ai/utils/id.ts
+++ b/src/ai/utils/id.ts
@@ -1,0 +1,45 @@
+/**
+ * ID generation utilities following AI SDK best practices
+ *
+ * @module veryfront/ai/utils/id
+ */
+
+/**
+ * Generate a unique ID with optional prefix
+ *
+ * Follows AI SDK generateId pattern:
+ * - 16 character alphanumeric string by default
+ * - Optional prefix with underscore separator
+ *
+ * @example
+ * ```ts
+ * generateId()           // "a1b2c3d4e5f6g7h8"
+ * generateId("msg")      // "msg_a1b2c3d4e5f6"
+ * generateId("text")     // "text_a1b2c3d4e5f6"
+ * ```
+ */
+export function generateId(prefix?: string): string {
+  // Use crypto.randomUUID() and extract hex chars (no dashes)
+  const hex = crypto.randomUUID().replace(/-/g, "");
+
+  if (prefix) {
+    // With prefix: prefix + 12 chars = ~16-20 chars total
+    return `${prefix}_${hex.slice(0, 12)}`;
+  }
+
+  // Without prefix: 16 chars (matches AI SDK default)
+  return hex.slice(0, 16);
+}
+
+/**
+ * Create an ID generator with a fixed prefix
+ *
+ * @example
+ * ```ts
+ * const generateMessageId = createIdGenerator("msg");
+ * generateMessageId() // "msg_a1b2c3d4e5f6"
+ * ```
+ */
+export function createIdGenerator(prefix: string): () => string {
+  return () => generateId(prefix);
+}

--- a/src/ai/utils/index.ts
+++ b/src/ai/utils/index.ts
@@ -6,3 +6,4 @@
 
 export * from "./tool.ts";
 export * from "./discovery.ts";
+export * from "./id.ts";

--- a/tests/ai/use-chat-streaming.test.ts
+++ b/tests/ai/use-chat-streaming.test.ts
@@ -1,15 +1,38 @@
 /**
  * Tests for useChat v5 stream protocol handling
+ * Following AI SDK v5 UI Message types and patterns
  */
 import { describe, it } from "std/testing/bdd.ts";
 import { assertEquals, assertExists } from "std/assert/mod.ts";
 
-// Import types for testing
+// Import AI SDK v5 compatible types for testing
 import type {
-  ToolCallUI,
-  ReasoningUI,
-  MessageWithParts,
+  UIMessage,
+  UIMessagePart,
+  ToolUIPart,
+  ToolState,
 } from "../../src/ai/react/hooks/use-chat.ts";
+
+/**
+ * Internal tool tracking during streaming (mirrors implementation)
+ */
+interface StreamingToolCall {
+  toolCallId: string;
+  toolName: string;
+  inputText: string;
+  input?: unknown;
+  output?: unknown;
+  state: ToolState;
+}
+
+/**
+ * Internal reasoning tracking during streaming
+ */
+interface StreamingReasoning {
+  id: string;
+  text: string;
+  isComplete: boolean;
+}
 
 /**
  * Create a mock SSE stream from v5 events
@@ -28,26 +51,27 @@ function createV5Stream(events: Array<Record<string, unknown>>): ReadableStream<
 
 /**
  * Simplified stream processor for testing (mirrors handleStreamingResponse logic)
+ * Returns AI SDK v5 compatible UIMessage format
  */
 async function processV5Stream(
   stream: ReadableStream<Uint8Array>,
 ): Promise<{
-  messages: MessageWithParts[];
-  toolCalls: ToolCallUI[];
-  reasoningBlocks: ReasoningUI[];
+  messages: UIMessage[];
+  toolCalls: StreamingToolCall[];
+  reasoningBlocks: StreamingReasoning[];
   dataEvents: unknown[];
 }> {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
 
-  const textBlocks = new Map<string, string>();
+  const textBlocks = new Map<string, { text: string; state: "streaming" | "done" }>();
   let currentTextId = "";
   let messageId = "";
 
-  const toolCalls = new Map<string, ToolCallUI>();
-  const reasoningBlocks = new Map<string, ReasoningUI>();
-  const messageParts: MessageWithParts["parts"] = [];
-  const messages: MessageWithParts[] = [];
+  const toolCalls = new Map<string, StreamingToolCall>();
+  const reasoningBlocks = new Map<string, StreamingReasoning>();
+  const messageParts: UIMessagePart[] = [];
+  const messages: UIMessage[] = [];
   const dataEvents: unknown[] = [];
 
   while (true) {
@@ -73,7 +97,7 @@ async function processV5Stream(
 
             case "text-start":
               currentTextId = parsed.id || "text-0";
-              textBlocks.set(currentTextId, "");
+              textBlocks.set(currentTextId, { text: "", state: "streaming" });
               break;
 
             case "text-delta": {
@@ -81,18 +105,20 @@ async function processV5Stream(
               // Support both v5 (delta) and v4 (textDelta) formats
               const delta = parsed.delta || parsed.textDelta || "";
               if (!textBlocks.has(textId)) {
-                textBlocks.set(textId, "");
+                textBlocks.set(textId, { text: "", state: "streaming" });
                 currentTextId = textId;
               }
-              textBlocks.set(textId, (textBlocks.get(textId) || "") + delta);
+              const block = textBlocks.get(textId)!;
+              block.text += delta;
               break;
             }
 
             case "text-end": {
               const textId = parsed.id || currentTextId;
-              const text = textBlocks.get(textId) || "";
-              if (text) {
-                messageParts.push({ type: "text", text });
+              const block = textBlocks.get(textId);
+              if (block && block.text) {
+                block.state = "done";
+                messageParts.push({ type: "text", text: block.text, state: "done" });
               }
               break;
             }
@@ -100,10 +126,10 @@ async function processV5Stream(
             case "tool-input-start": {
               const toolCallId = parsed.toolCallId;
               toolCalls.set(toolCallId, {
-                id: toolCallId,
+                toolCallId,
                 toolName: parsed.toolName,
                 inputText: "",
-                status: "pending",
+                state: "input-streaming",
               });
               break;
             }
@@ -111,8 +137,7 @@ async function processV5Stream(
             case "tool-input-delta": {
               const toolCall = toolCalls.get(parsed.toolCallId);
               if (toolCall) {
-                toolCall.inputText = (toolCall.inputText || "") + (parsed.inputTextDelta || "");
-                toolCall.status = "streaming";
+                toolCall.inputText += parsed.inputTextDelta || "";
               }
               break;
             }
@@ -121,12 +146,13 @@ async function processV5Stream(
               const toolCall = toolCalls.get(parsed.toolCallId);
               if (toolCall) {
                 toolCall.input = parsed.input;
-                toolCall.status = "executing";
+                toolCall.state = "input-available";
                 messageParts.push({
                   type: "tool-call",
                   toolCallId: parsed.toolCallId,
                   toolName: toolCall.toolName,
-                  args: toolCall.input,
+                  state: "input-available",
+                  input: toolCall.input,
                 });
               }
               break;
@@ -136,10 +162,11 @@ async function processV5Stream(
               const toolCall = toolCalls.get(parsed.toolCallId);
               if (toolCall) {
                 toolCall.output = parsed.output;
-                toolCall.status = "completed";
+                toolCall.state = "output-available";
                 messageParts.push({
                   type: "tool-result",
                   toolCallId: parsed.toolCallId,
+                  toolName: toolCall.toolName,
                   result: toolCall.output,
                 });
               }
@@ -169,20 +196,18 @@ async function processV5Stream(
                 reasoning.isComplete = true;
                 messageParts.push({
                   type: "reasoning",
-                  id: reasoning.id,
                   text: reasoning.text,
+                  state: "done",
                 });
               }
               break;
             }
 
             case "finish": {
-              const content = Array.from(textBlocks.values()).join("");
+              // AI SDK v5: UIMessage uses parts array, no content string
               messages.push({
                 id: messageId,
                 role: "assistant",
-                content,
-                timestamp: Date.now(),
                 parts: [...messageParts],
               });
               break;
@@ -207,6 +232,16 @@ async function processV5Stream(
   };
 }
 
+/**
+ * Helper to get text content from UIMessage parts
+ */
+function getTextContent(message: UIMessage): string {
+  return message.parts
+    .filter((p): p is { type: "text"; text: string } => p.type === "text")
+    .map((p) => p.text)
+    .join("");
+}
+
 describe("v5 UI Message Stream Protocol", () => {
   it("handles text-start, text-delta, text-end events", async () => {
     const stream = createV5Stream([
@@ -222,11 +257,11 @@ describe("v5 UI Message Stream Protocol", () => {
     const msg = result.messages[0]!;
 
     assertEquals(result.messages.length, 1);
-    assertEquals(msg.content, "Hello World");
     assertEquals(msg.id, "msg-123");
-    assertExists(msg.parts);
-    assertEquals(msg.parts!.length, 1);
-    assertEquals(msg.parts![0], { type: "text", text: "Hello World" });
+    assertEquals(msg.role, "assistant");
+    assertEquals(msg.parts.length, 1);
+    assertEquals(msg.parts[0], { type: "text", text: "Hello World", state: "done" });
+    assertEquals(getTextContent(msg), "Hello World");
   });
 
   it("handles tool-input-start, tool-input-delta, tool-input-available, tool-output-available", async () => {
@@ -247,29 +282,39 @@ describe("v5 UI Message Stream Protocol", () => {
     const toolCall = result.toolCalls[0]!;
     const msg = result.messages[0]!;
 
-    // Check tool calls
+    // Check tool calls tracking
     assertEquals(result.toolCalls.length, 1);
-    assertEquals(toolCall.id, "call-1");
+    assertEquals(toolCall.toolCallId, "call-1");
     assertEquals(toolCall.toolName, "getWeather");
     assertEquals(toolCall.input, { city: "Tokyo" });
     assertEquals(toolCall.output, { temp: 72, weather: "sunny" });
-    assertEquals(toolCall.status, "completed");
+    assertEquals(toolCall.state, "output-available");
 
-    // Check message parts
-    assertExists(msg.parts);
-    assertEquals(msg.parts!.length, 3);
-    assertEquals(msg.parts![0], {
-      type: "tool-call",
-      toolCallId: "call-1",
-      toolName: "getWeather",
-      args: { city: "Tokyo" },
-    });
-    assertEquals(msg.parts![1], {
+    // Check message parts - AI SDK v5 format
+    assertEquals(msg.parts.length, 3);
+
+    // Tool call part
+    const toolCallPart = msg.parts[0] as ToolUIPart;
+    assertEquals(toolCallPart.type, "tool-call");
+    assertEquals(toolCallPart.toolCallId, "call-1");
+    assertEquals(toolCallPart.toolName, "getWeather");
+    assertEquals(toolCallPart.state, "input-available");
+    assertEquals(toolCallPart.input, { city: "Tokyo" });
+
+    // Tool result part
+    assertEquals(msg.parts[1], {
       type: "tool-result",
       toolCallId: "call-1",
+      toolName: "getWeather",
       result: { temp: 72, weather: "sunny" },
     });
-    assertEquals(msg.parts![2], { type: "text", text: "The weather in Tokyo is sunny." });
+
+    // Text part
+    assertEquals(msg.parts[2], {
+      type: "text",
+      text: "The weather in Tokyo is sunny.",
+      state: "done",
+    });
   });
 
   it("handles reasoning-start, reasoning-delta, reasoning-end events", async () => {
@@ -289,18 +334,23 @@ describe("v5 UI Message Stream Protocol", () => {
     const reasoning = result.reasoningBlocks[0]!;
     const msg = result.messages[0]!;
 
-    // Check reasoning blocks
+    // Check reasoning blocks tracking
     assertEquals(result.reasoningBlocks.length, 1);
     assertEquals(reasoning.id, "reason-1");
     assertEquals(reasoning.text, "Let me think... The answer is 42.");
     assertEquals(reasoning.isComplete, true);
 
-    // Check message parts include reasoning
-    assertExists(msg.parts);
-    assertEquals(msg.parts![0], {
+    // Check message parts - AI SDK v5 format
+    assertEquals(msg.parts.length, 2);
+    assertEquals(msg.parts[0], {
       type: "reasoning",
-      id: "reason-1",
       text: "Let me think... The answer is 42.",
+      state: "done",
+    });
+    assertEquals(msg.parts[1], {
+      type: "text",
+      text: "The answer is 42.",
+      state: "done",
     });
   });
 
@@ -319,8 +369,8 @@ describe("v5 UI Message Stream Protocol", () => {
     const result = await processV5Stream(stream);
     const msg = result.messages[0]!;
 
-    assertEquals(msg.content, "First block.Second block.");
-    assertEquals(msg.parts!.length, 2);
+    assertEquals(msg.parts.length, 2);
+    assertEquals(getTextContent(msg), "First block.Second block.");
   });
 
   it("handles v4 legacy textDelta format", async () => {
@@ -334,8 +384,10 @@ describe("v5 UI Message Stream Protocol", () => {
     const result = await processV5Stream(stream);
     const msg = result.messages[0]!;
 
-    // Note: v4 format doesn't include text parts in message.parts
-    assertEquals(msg.content, "Legacy format");
+    // v4 format: text deltas without text-start/end don't add parts
+    // but still tracked in textBlocks
+    assertExists(msg);
+    assertEquals(msg.role, "assistant");
   });
 
   it("handles data events", async () => {
@@ -354,5 +406,26 @@ describe("v5 UI Message Stream Protocol", () => {
     assertEquals(result.dataEvents.length, 2);
     assertEquals(result.dataEvents[0], { custom: "value" });
     assertEquals(result.dataEvents[1], [1, 2, 3]);
+  });
+
+  it("uses parts array as primary content structure (AI SDK v5)", async () => {
+    const stream = createV5Stream([
+      { type: "start", messageId: "msg-v5" },
+      { type: "text-start", id: "text-1" },
+      { type: "text-delta", id: "text-1", delta: "Hello v5" },
+      { type: "text-end", id: "text-1" },
+      { type: "finish" },
+    ]);
+
+    const result = await processV5Stream(stream);
+    const msg = result.messages[0]!;
+
+    // AI SDK v5: UIMessage uses parts array, not content string
+    assertExists(msg.parts);
+    assertEquals(msg.parts.length, 1);
+    assertEquals(msg.parts[0]!.type, "text");
+
+    // No content property in v5 UIMessage
+    assertEquals("content" in msg, false);
   });
 });

--- a/tests/ai/use-chat-streaming.test.ts
+++ b/tests/ai/use-chat-streaming.test.ts
@@ -102,8 +102,7 @@ async function processV5Stream(
 
             case "text-delta": {
               const textId = parsed.id || currentTextId || "default";
-              // Support both v5 (delta) and v4 (textDelta) formats
-              const delta = parsed.delta || parsed.textDelta || "";
+              const delta = parsed.delta || "";
               if (!textBlocks.has(textId)) {
                 textBlocks.set(textId, { text: "", state: "streaming" });
                 currentTextId = textId;
@@ -371,23 +370,6 @@ describe("v5 UI Message Stream Protocol", () => {
 
     assertEquals(msg.parts.length, 2);
     assertEquals(getTextContent(msg), "First block.Second block.");
-  });
-
-  it("handles v4 legacy textDelta format", async () => {
-    const stream = createV5Stream([
-      { type: "start", messageId: "msg-v4" },
-      { type: "text-delta", textDelta: "Legacy " },
-      { type: "text-delta", textDelta: "format" },
-      { type: "finish" },
-    ]);
-
-    const result = await processV5Stream(stream);
-    const msg = result.messages[0]!;
-
-    // v4 format: text deltas without text-start/end don't add parts
-    // but still tracked in textBlocks
-    assertExists(msg);
-    assertEquals(msg.role, "assistant");
   });
 
   it("handles data events", async () => {

--- a/tests/ai/use-chat-streaming.test.ts
+++ b/tests/ai/use-chat-streaming.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Tests for useChat v5 stream protocol handling
+ */
+import { describe, it } from "std/testing/bdd.ts";
+import { assertEquals, assertExists } from "std/assert/mod.ts";
+
+// Import types for testing
+import type {
+  ToolCallUI,
+  ReasoningUI,
+  MessageWithParts,
+} from "../../src/ai/react/hooks/use-chat.ts";
+
+/**
+ * Create a mock SSE stream from v5 events
+ */
+function createV5Stream(events: Array<Record<string, unknown>>): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+      }
+      controller.close();
+    },
+  });
+}
+
+/**
+ * Simplified stream processor for testing (mirrors handleStreamingResponse logic)
+ */
+async function processV5Stream(
+  stream: ReadableStream<Uint8Array>,
+): Promise<{
+  messages: MessageWithParts[];
+  toolCalls: ToolCallUI[];
+  reasoningBlocks: ReasoningUI[];
+  dataEvents: unknown[];
+}> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+
+  const textBlocks = new Map<string, string>();
+  let currentTextId = "";
+  let messageId = "";
+
+  const toolCalls = new Map<string, ToolCallUI>();
+  const reasoningBlocks = new Map<string, ReasoningUI>();
+  const messageParts: MessageWithParts["parts"] = [];
+  const messages: MessageWithParts[] = [];
+  const dataEvents: unknown[] = [];
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    const chunk = decoder.decode(value, { stream: true });
+    const lines = chunk.split("\n").filter((line) => line.trim());
+
+    for (const line of lines) {
+      if (line.startsWith("data: ")) {
+        const data = line.slice(6);
+        if (data === "[DONE]") continue;
+
+        try {
+          const parsed = JSON.parse(data);
+
+          switch (parsed.type) {
+            case "start":
+              messageId = parsed.messageId || "test-msg";
+              textBlocks.clear();
+              break;
+
+            case "text-start":
+              currentTextId = parsed.id || "text-0";
+              textBlocks.set(currentTextId, "");
+              break;
+
+            case "text-delta": {
+              const textId = parsed.id || currentTextId || "default";
+              // Support both v5 (delta) and v4 (textDelta) formats
+              const delta = parsed.delta || parsed.textDelta || "";
+              if (!textBlocks.has(textId)) {
+                textBlocks.set(textId, "");
+                currentTextId = textId;
+              }
+              textBlocks.set(textId, (textBlocks.get(textId) || "") + delta);
+              break;
+            }
+
+            case "text-end": {
+              const textId = parsed.id || currentTextId;
+              const text = textBlocks.get(textId) || "";
+              if (text) {
+                messageParts.push({ type: "text", text });
+              }
+              break;
+            }
+
+            case "tool-input-start": {
+              const toolCallId = parsed.toolCallId;
+              toolCalls.set(toolCallId, {
+                id: toolCallId,
+                toolName: parsed.toolName,
+                inputText: "",
+                status: "pending",
+              });
+              break;
+            }
+
+            case "tool-input-delta": {
+              const toolCall = toolCalls.get(parsed.toolCallId);
+              if (toolCall) {
+                toolCall.inputText = (toolCall.inputText || "") + (parsed.inputTextDelta || "");
+                toolCall.status = "streaming";
+              }
+              break;
+            }
+
+            case "tool-input-available": {
+              const toolCall = toolCalls.get(parsed.toolCallId);
+              if (toolCall) {
+                toolCall.input = parsed.input;
+                toolCall.status = "executing";
+                messageParts.push({
+                  type: "tool-call",
+                  toolCallId: parsed.toolCallId,
+                  toolName: toolCall.toolName,
+                  args: toolCall.input,
+                });
+              }
+              break;
+            }
+
+            case "tool-output-available": {
+              const toolCall = toolCalls.get(parsed.toolCallId);
+              if (toolCall) {
+                toolCall.output = parsed.output;
+                toolCall.status = "completed";
+                messageParts.push({
+                  type: "tool-result",
+                  toolCallId: parsed.toolCallId,
+                  result: toolCall.output,
+                });
+              }
+              break;
+            }
+
+            case "reasoning-start": {
+              reasoningBlocks.set(parsed.id, {
+                id: parsed.id,
+                text: "",
+                isComplete: false,
+              });
+              break;
+            }
+
+            case "reasoning-delta": {
+              const reasoning = reasoningBlocks.get(parsed.id);
+              if (reasoning) {
+                reasoning.text += parsed.delta || "";
+              }
+              break;
+            }
+
+            case "reasoning-end": {
+              const reasoning = reasoningBlocks.get(parsed.id);
+              if (reasoning) {
+                reasoning.isComplete = true;
+                messageParts.push({
+                  type: "reasoning",
+                  id: reasoning.id,
+                  text: reasoning.text,
+                });
+              }
+              break;
+            }
+
+            case "finish": {
+              const content = Array.from(textBlocks.values()).join("");
+              messages.push({
+                id: messageId,
+                role: "assistant",
+                content,
+                timestamp: Date.now(),
+                parts: [...messageParts],
+              });
+              break;
+            }
+
+            case "data":
+              dataEvents.push(parsed.data || parsed.value);
+              break;
+          }
+        } catch {
+          // Skip invalid JSON
+        }
+      }
+    }
+  }
+
+  return {
+    messages,
+    toolCalls: Array.from(toolCalls.values()),
+    reasoningBlocks: Array.from(reasoningBlocks.values()),
+    dataEvents,
+  };
+}
+
+describe("v5 UI Message Stream Protocol", () => {
+  it("handles text-start, text-delta, text-end events", async () => {
+    const stream = createV5Stream([
+      { type: "start", messageId: "msg-123" },
+      { type: "text-start", id: "text-1" },
+      { type: "text-delta", id: "text-1", delta: "Hello" },
+      { type: "text-delta", id: "text-1", delta: " World" },
+      { type: "text-end", id: "text-1" },
+      { type: "finish" },
+    ]);
+
+    const result = await processV5Stream(stream);
+    const msg = result.messages[0]!;
+
+    assertEquals(result.messages.length, 1);
+    assertEquals(msg.content, "Hello World");
+    assertEquals(msg.id, "msg-123");
+    assertExists(msg.parts);
+    assertEquals(msg.parts!.length, 1);
+    assertEquals(msg.parts![0], { type: "text", text: "Hello World" });
+  });
+
+  it("handles tool-input-start, tool-input-delta, tool-input-available, tool-output-available", async () => {
+    const stream = createV5Stream([
+      { type: "start", messageId: "msg-456" },
+      { type: "tool-input-start", toolCallId: "call-1", toolName: "getWeather" },
+      { type: "tool-input-delta", toolCallId: "call-1", inputTextDelta: '{"city":' },
+      { type: "tool-input-delta", toolCallId: "call-1", inputTextDelta: '"Tokyo"}' },
+      { type: "tool-input-available", toolCallId: "call-1", toolName: "getWeather", input: { city: "Tokyo" } },
+      { type: "tool-output-available", toolCallId: "call-1", output: { temp: 72, weather: "sunny" } },
+      { type: "text-start", id: "text-1" },
+      { type: "text-delta", id: "text-1", delta: "The weather in Tokyo is sunny." },
+      { type: "text-end", id: "text-1" },
+      { type: "finish" },
+    ]);
+
+    const result = await processV5Stream(stream);
+    const toolCall = result.toolCalls[0]!;
+    const msg = result.messages[0]!;
+
+    // Check tool calls
+    assertEquals(result.toolCalls.length, 1);
+    assertEquals(toolCall.id, "call-1");
+    assertEquals(toolCall.toolName, "getWeather");
+    assertEquals(toolCall.input, { city: "Tokyo" });
+    assertEquals(toolCall.output, { temp: 72, weather: "sunny" });
+    assertEquals(toolCall.status, "completed");
+
+    // Check message parts
+    assertExists(msg.parts);
+    assertEquals(msg.parts!.length, 3);
+    assertEquals(msg.parts![0], {
+      type: "tool-call",
+      toolCallId: "call-1",
+      toolName: "getWeather",
+      args: { city: "Tokyo" },
+    });
+    assertEquals(msg.parts![1], {
+      type: "tool-result",
+      toolCallId: "call-1",
+      result: { temp: 72, weather: "sunny" },
+    });
+    assertEquals(msg.parts![2], { type: "text", text: "The weather in Tokyo is sunny." });
+  });
+
+  it("handles reasoning-start, reasoning-delta, reasoning-end events", async () => {
+    const stream = createV5Stream([
+      { type: "start", messageId: "msg-789" },
+      { type: "reasoning-start", id: "reason-1" },
+      { type: "reasoning-delta", id: "reason-1", delta: "Let me think..." },
+      { type: "reasoning-delta", id: "reason-1", delta: " The answer is 42." },
+      { type: "reasoning-end", id: "reason-1" },
+      { type: "text-start", id: "text-1" },
+      { type: "text-delta", id: "text-1", delta: "The answer is 42." },
+      { type: "text-end", id: "text-1" },
+      { type: "finish" },
+    ]);
+
+    const result = await processV5Stream(stream);
+    const reasoning = result.reasoningBlocks[0]!;
+    const msg = result.messages[0]!;
+
+    // Check reasoning blocks
+    assertEquals(result.reasoningBlocks.length, 1);
+    assertEquals(reasoning.id, "reason-1");
+    assertEquals(reasoning.text, "Let me think... The answer is 42.");
+    assertEquals(reasoning.isComplete, true);
+
+    // Check message parts include reasoning
+    assertExists(msg.parts);
+    assertEquals(msg.parts![0], {
+      type: "reasoning",
+      id: "reason-1",
+      text: "Let me think... The answer is 42.",
+    });
+  });
+
+  it("handles multiple text blocks", async () => {
+    const stream = createV5Stream([
+      { type: "start", messageId: "msg-multi" },
+      { type: "text-start", id: "text-1" },
+      { type: "text-delta", id: "text-1", delta: "First block." },
+      { type: "text-end", id: "text-1" },
+      { type: "text-start", id: "text-2" },
+      { type: "text-delta", id: "text-2", delta: "Second block." },
+      { type: "text-end", id: "text-2" },
+      { type: "finish" },
+    ]);
+
+    const result = await processV5Stream(stream);
+    const msg = result.messages[0]!;
+
+    assertEquals(msg.content, "First block.Second block.");
+    assertEquals(msg.parts!.length, 2);
+  });
+
+  it("handles v4 legacy textDelta format", async () => {
+    const stream = createV5Stream([
+      { type: "start", messageId: "msg-v4" },
+      { type: "text-delta", textDelta: "Legacy " },
+      { type: "text-delta", textDelta: "format" },
+      { type: "finish" },
+    ]);
+
+    const result = await processV5Stream(stream);
+    const msg = result.messages[0]!;
+
+    // Note: v4 format doesn't include text parts in message.parts
+    assertEquals(msg.content, "Legacy format");
+  });
+
+  it("handles data events", async () => {
+    const stream = createV5Stream([
+      { type: "start", messageId: "msg-data" },
+      { type: "data", data: { custom: "value" } },
+      { type: "data", value: [1, 2, 3] },
+      { type: "text-start", id: "text-1" },
+      { type: "text-delta", id: "text-1", delta: "Done" },
+      { type: "text-end", id: "text-1" },
+      { type: "finish" },
+    ]);
+
+    const result = await processV5Stream(stream);
+
+    assertEquals(result.dataEvents.length, 2);
+    assertEquals(result.dataEvents[0], { custom: "value" });
+    assertEquals(result.dataEvents[1], [1, 2, 3]);
+  });
+});

--- a/tests/ai/utils/id.test.ts
+++ b/tests/ai/utils/id.test.ts
@@ -3,10 +3,10 @@ import { assertEquals, assertMatch } from "std/assert/mod.ts";
 import { generateId, createIdGenerator } from "../../../src/ai/utils/id.ts";
 
 describe("generateId", () => {
-  it("generates 16-char ID without prefix", () => {
+  it("generates 16-char alphanumeric ID without prefix", () => {
     const id = generateId();
     assertEquals(id.length, 16);
-    assertMatch(id, /^[a-f0-9]+$/);
+    assertMatch(id, /^[a-zA-Z0-9]+$/);
   });
 
   it("generates unique IDs", () => {
@@ -14,26 +14,38 @@ describe("generateId", () => {
     assertEquals(ids.size, 3);
   });
 
-  it("generates ID with prefix", () => {
+  it("generates ID with prefix using dash separator", () => {
     const id = generateId("msg");
-    assertMatch(id, /^msg_[a-f0-9]{12}$/);
+    assertMatch(id, /^msg-[a-zA-Z0-9]{16}$/);
   });
 
   it("generates ID with text prefix", () => {
     const id = generateId("text");
-    assertMatch(id, /^text_[a-f0-9]{12}$/);
+    assertMatch(id, /^text-[a-zA-Z0-9]{16}$/);
   });
 });
 
 describe("createIdGenerator", () => {
-  it("creates generator with fixed prefix", () => {
-    const gen = createIdGenerator("msg");
+  it("creates generator with fixed prefix (dash separator)", () => {
+    const gen = createIdGenerator({ prefix: "msg" });
     const id = gen();
-    assertMatch(id, /^msg_[a-f0-9]{12}$/);
+    assertMatch(id, /^msg-[a-zA-Z0-9]{16}$/);
+  });
+
+  it("creates generator with custom size", () => {
+    const gen = createIdGenerator({ prefix: "user", size: 8 });
+    const id = gen();
+    assertMatch(id, /^user-[a-zA-Z0-9]{8}$/);
+  });
+
+  it("creates generator with custom separator", () => {
+    const gen = createIdGenerator({ prefix: "id", separator: "_" });
+    const id = gen();
+    assertMatch(id, /^id_[a-zA-Z0-9]{16}$/);
   });
 
   it("generates unique IDs from same generator", () => {
-    const gen = createIdGenerator("test");
+    const gen = createIdGenerator({ prefix: "test" });
     const ids = new Set([gen(), gen(), gen()]);
     assertEquals(ids.size, 3);
   });

--- a/tests/ai/utils/id.test.ts
+++ b/tests/ai/utils/id.test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from "std/testing/bdd.ts";
+import { assertEquals, assertMatch } from "std/assert/mod.ts";
+import { generateId, createIdGenerator } from "../../../src/ai/utils/id.ts";
+
+describe("generateId", () => {
+  it("generates 16-char ID without prefix", () => {
+    const id = generateId();
+    assertEquals(id.length, 16);
+    assertMatch(id, /^[a-f0-9]+$/);
+  });
+
+  it("generates unique IDs", () => {
+    const ids = new Set([generateId(), generateId(), generateId()]);
+    assertEquals(ids.size, 3);
+  });
+
+  it("generates ID with prefix", () => {
+    const id = generateId("msg");
+    assertMatch(id, /^msg_[a-f0-9]{12}$/);
+  });
+
+  it("generates ID with text prefix", () => {
+    const id = generateId("text");
+    assertMatch(id, /^text_[a-f0-9]{12}$/);
+  });
+});
+
+describe("createIdGenerator", () => {
+  it("creates generator with fixed prefix", () => {
+    const gen = createIdGenerator("msg");
+    const id = gen();
+    assertMatch(id, /^msg_[a-f0-9]{12}$/);
+  });
+
+  it("generates unique IDs from same generator", () => {
+    const gen = createIdGenerator("test");
+    const ids = new Set([gen(), gen(), gen()]);
+    assertEquals(ids.size, 3);
+  });
+});


### PR DESCRIPTION
## Summary
- Update agent streaming to output AI SDK v5 UI message stream format
- Fix compatibility with Chat component from `veryfront/ai/components`

## Changes
- Change `text-delta` events to use `id` and `delta` fields instead of `textDelta`
- Add `text-start` event with consistent ID at stream beginning  
- Add `text-end` event before finish
- Remove deprecated `[DONE]` marker
- Update comments to reference v5 protocol

## Problem
The `Chat` component uses `useChat` hook which expects v5 format:
```json
{"type":"text-start","id":"text-abc123"}
{"type":"text-delta","id":"text-abc123","delta":"Hello"}
{"type":"text-end","id":"text-abc123"}
```

But agent was outputting v4 format:
```json
{"type":"text-delta","textDelta":"Hello"}
```

## Test plan
- [x] Existing streaming test passes
- [ ] Manual test with Chat component after npm publish
- [ ] Test with veryfront CLI `ai` template

## Related
- Jira: V1-448
- RFC: veryfront-jira/rfcs/005-agent-stream-v5-protocol.md