### PR TITLE
feat(ai): migrate Message type to v5 format with parts array

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'  # Trigger on version tags like v0.0.67, v1.0.0
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -55,9 +59,7 @@ jobs:
 
       - name: Publish to npm
         working-directory: npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",

--- a/docs/ai/getting-started.md
+++ b/docs/ai/getting-started.md
@@ -87,7 +87,7 @@ export default function MyChat() {
     <ChatContainer className="your-design-system">
       <MessageList>
         {chat.messages.map((msg) => (
-          <MessageItem key={msg.id}>{msg.content}</MessageItem>
+          <MessageItem key={msg.id} message={msg} />
         ))}
       </MessageList>
     </ChatContainer>
@@ -468,9 +468,7 @@ export default function MyChat() {
     <ChatContainer className="h-screen flex flex-col">
       <MessageList className="flex-1 overflow-y-auto p-4">
         {chat.messages.map((msg) => (
-          <MessageItem key={msg.id} className="my-custom-message">
-            {msg.content}
-          </MessageItem>
+          <MessageItem key={msg.id} message={msg} className="my-custom-message" />
         ))}
       </MessageList>
     </ChatContainer>

--- a/docs/ai/implementation-status.md
+++ b/docs/ai/implementation-status.md
@@ -359,9 +359,7 @@ import { useChat } from 'veryfront/ai/react';
 <ChatContainer className="your-styles">
   <MessageList>
     {messages.map((msg) => (
-      <MessageItem key={msg.id} className="your-message-styles">
-        {msg.content}
-      </MessageItem>
+      <MessageItem key={msg.id} message={msg} className="your-message-styles" />
     ))}
   </MessageList>
 </ChatContainer>
@@ -641,7 +639,7 @@ import { useChat } from 'veryfront/ai/react';
 <ChatContainer className="your-design-system">
   <MessageList>
     {messages.map((msg) => (
-      <MessageItem className="your-styles">{msg.content}</MessageItem>
+      <MessageItem key={msg.id} message={msg} className="your-styles" />
     ))}
   </MessageList>
 </ChatContainer>

--- a/docs/ai/specification.md
+++ b/docs/ai/specification.md
@@ -1234,7 +1234,7 @@ function Messages({ messages }) {
                 : 'bg-gray-200 text-gray-900'
             )}
           >
-            {msg.content}
+            {getTextFromParts(msg.parts)}
           </div>
         </MessageItem>
       ))}
@@ -1242,6 +1242,8 @@ function Messages({ messages }) {
   );
 }
 ```
+
+> **Note**: Import `getTextFromParts` from `veryfront/ai` to extract text content from the v5 parts-based message format.
 
 #### InputBox
 
@@ -1309,7 +1311,7 @@ export function ChatMessage({ message }) {
   return (
     <Message role={message.role}>
       <MessageRole>{message.role}</MessageRole>
-      <MessageContent>{message.content}</MessageContent>
+      <MessageContent message={message} />
     </Message>
   );
 }
@@ -1626,9 +1628,7 @@ export default function MixedChat() {
       {/* Layer 2: Custom styled messages */}
       <MessageList>
         {chat.messages.map((msg) => (
-          <MessageItem key={msg.id} role={msg.role} className="my-custom-message">
-            {msg.content}
-          </MessageItem>
+          <MessageItem key={msg.id} message={msg} className="my-custom-message" />
         ))}
       </MessageList>
 
@@ -1680,9 +1680,7 @@ export default function AdvancedChat() {
     <div>
       <MessageList>
         {chat.messages.map((msg) => (
-          <MessageItem key={msg.id} className="custom-styling">
-            {msg.content}
-          </MessageItem>
+          <MessageItem key={msg.id} message={msg} className="custom-styling" />
         ))}
       </MessageList>
 
@@ -2246,9 +2244,7 @@ export default function ChatPage() {
     <ChatContainer className="your-design-system-container">
       <MessageList>
         {chat.messages.map((msg) => (
-          <MessageItem key={msg.id} className="your-design-system-message">
-            {msg.content}
-          </MessageItem>
+          <MessageItem key={msg.id} message={msg} className="your-design-system-message" />
         ))}
       </MessageList>
     </ChatContainer>

--- a/docs/ai/summary.md
+++ b/docs/ai/summary.md
@@ -111,9 +111,7 @@ function MyChat() {
     <ChatContainer className="your-design-system-container">
       <MessageList>
         {chat.messages.map((msg) => (
-          <MessageItem key={msg.id} className="your-message-styles">
-            {msg.content}
-          </MessageItem>
+          <MessageItem key={msg.id} message={msg} className="your-message-styles" />
         ))}
       </MessageList>
     </ChatContainer>

--- a/docs/reference/ai/hooks.md
+++ b/docs/reference/ai/hooks.md
@@ -59,6 +59,7 @@ const chat = useChat(options?: ChatOptions);
 "use client";
 
 import { useChat } from "veryfront/ai/react";
+import { getTextFromParts } from "veryfront/ai";
 
 export default function Chat() {
   const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat();
@@ -68,7 +69,7 @@ export default function Chat() {
       <div className="messages">
         {messages.map((m) => (
           <div key={m.id} className={m.role}>
-            {m.content}
+            {getTextFromParts(m.parts)}
           </div>
         ))}
       </div>
@@ -95,7 +96,7 @@ export default function Chat() {
 const { messages, handleSubmit } = useChat({
   api: "/api/assistant",
   onFinish: (message) => {
-    console.log("Response:", message.content);
+    console.log("Response:", getTextFromParts(message.parts));
   },
   onError: (error) => {
     console.error("Chat error:", error);
@@ -108,7 +109,7 @@ const { messages, handleSubmit } = useChat({
 ```tsx
 const { messages } = useChat({
   initialMessages: [
-    { id: "1", role: "assistant", content: "Hello! How can I help you?" },
+    { id: "1", role: "assistant", parts: [{ type: "text", text: "Hello! How can I help you?" }] },
   ],
 });
 ```
@@ -262,17 +263,33 @@ export default function TextGenerator() {
 }
 ```
 
-## Message Type
+## Message Type (AI SDK v5)
 
-The `Message` type used by `useChat`:
+The `Message` type uses a parts array for content (AI SDK v5 format):
 
 ```typescript
+type MessagePart =
+  | { type: "text"; text: string }
+  | { type: "tool-call"; toolCallId: string; toolName: string; args: Record<string, unknown> }
+  | { type: "tool-result"; toolCallId: string; toolName: string; result: unknown };
+
 interface Message {
   id: string;
-  role: "user" | "assistant" | "system";
-  content: string;
-  createdAt?: Date;
+  role: "user" | "assistant" | "system" | "tool";
+  parts: MessagePart[];
+  timestamp?: number;
+  metadata?: Record<string, unknown>;
 }
+```
+
+### Helper Function
+
+Use `getTextFromParts()` to extract text content:
+
+```typescript
+import { getTextFromParts } from "veryfront/ai";
+
+const text = getTextFromParts(message.parts);
 ```
 
 ## Backend Integration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.0.6",
+  "version": "0.0.70",
   "description": "React meta-framework with AI-native capabilities",
   "keywords": [
     "deno",

--- a/src/ai/agent/factory.ts
+++ b/src/ai/agent/factory.ts
@@ -127,8 +127,12 @@ export function agent(config: AgentConfig): Agent {
       onToolCall?: (toolCall: ToolCall) => void;
       onChunk?: (chunk: string) => void;
     }): Promise<AgentStreamResult> {
-      const inputMessages = input.input
-        ? [{ role: "user" as const, content: input.input }]
+      const inputMessages: Message[] = input.input
+        ? [{
+          id: `msg_${Date.now()}`,
+          role: "user" as const,
+          parts: [{ type: "text", text: input.input }],
+        }]
         : input.messages || [];
 
       const stream = await runtime.stream(inputMessages, input.context, {

--- a/src/ai/agent/memory.ts
+++ b/src/ai/agent/memory.ts
@@ -7,7 +7,7 @@
  * - Summary: Summarize old messages to save tokens
  */
 
-import type { MemoryConfig, Message } from "../types/agent.ts";
+import { getTextFromParts, type MemoryConfig, type Message } from "../types/agent.ts";
 
 /**
  * Memory interface
@@ -112,7 +112,7 @@ export class ConversationMemory implements Memory {
   private estimateTokens(messages: Message[]): number {
     // Rough estimation: ~4 characters per token
     const totalChars = messages.reduce(
-      (sum, msg) => sum + msg.content.length,
+      (sum, msg) => sum + getTextFromParts(msg.parts).length,
       0,
     );
     return Math.ceil(totalChars / 4);
@@ -161,7 +161,7 @@ export class BufferMemory implements Memory {
 
   private estimateTokens(messages: Message[]): number {
     const totalChars = messages.reduce(
-      (sum, msg) => sum + msg.content.length,
+      (sum, msg) => sum + getTextFromParts(msg.parts).length,
       0,
     );
     return Math.ceil(totalChars / 4);
@@ -199,7 +199,7 @@ export class SummaryMemory implements Memory {
         {
           id: "summary",
           role: "system",
-          content: `Previous conversation summary:\n${this.summary}`,
+          parts: [{ type: "text", text: `Previous conversation summary:\n${this.summary}` }],
           timestamp: Date.now(),
         },
         ...this.messages,
@@ -232,7 +232,7 @@ export class SummaryMemory implements Memory {
     // Simple summarization (in production, use LLM)
     const topics = toSummarize
       .filter((m) => m.role === "user")
-      .map((m) => m.content.substring(0, 50))
+      .map((m) => getTextFromParts(m.parts).substring(0, 50))
       .join("; ");
 
     this.summary = `Discussed: ${topics}`;
@@ -241,7 +241,7 @@ export class SummaryMemory implements Memory {
   }
 
   private estimateTokens(messages: Message[]): number {
-    const totalChars = messages.reduce((sum, msg) => sum + msg.content.length, 0) +
+    const totalChars = messages.reduce((sum, msg) => sum + getTextFromParts(msg.parts).length, 0) +
       this.summary.length;
     return Math.ceil(totalChars / 4);
   }

--- a/src/ai/agent/runtime.ts
+++ b/src/ai/agent/runtime.ts
@@ -88,7 +88,9 @@ interface ProviderMessage {
 }
 
 /**
- * Convert v5 Message to provider format
+ * Convert v5 Message to provider format.
+ * Empty parts array results in empty content string, which is valid for
+ * providers (e.g., assistant message with only tool calls, no text).
  */
 function convertMessageToProvider(msg: Message): ProviderMessage {
   const content = getTextFromParts(msg.parts);

--- a/src/ai/agent/runtime.ts
+++ b/src/ai/agent/runtime.ts
@@ -9,14 +9,15 @@
  * - Middleware execution
  */
 
-import type {
-  AgentConfig,
-  AgentContext,
-  AgentResponse,
-  AgentStatus,
-  Message,
-  StreamToolCall,
-  ToolCall,
+import {
+  type AgentConfig,
+  type AgentContext,
+  type AgentResponse,
+  type AgentStatus,
+  getTextFromParts,
+  type Message,
+  type MessagePart,
+  type ToolCall,
 } from "../types/agent.ts";
 import type { ToolDefinition } from "../types/tool.ts";
 import type { Provider } from "../types/provider.ts";
@@ -71,6 +72,58 @@ type AgentStreamEvent = z.infer<typeof AgentStreamEventSchema>;
 
 const DEFAULT_MAX_TOKENS = 4096;
 const DEFAULT_TEMPERATURE = 0.7;
+
+/**
+ * Provider message format
+ */
+interface ProviderMessage {
+  role: string;
+  content: string;
+  tool_calls?: Array<{
+    id: string;
+    type: string;
+    function: { name: string; arguments: string };
+  }>;
+  tool_call_id?: string;
+}
+
+/**
+ * Convert v5 Message to provider format
+ */
+function convertMessageToProvider(msg: Message): ProviderMessage {
+  const content = getTextFromParts(msg.parts);
+
+  const providerMsg: ProviderMessage = {
+    role: msg.role,
+    content,
+  };
+
+  // Extract tool calls from parts
+  const toolCallParts = msg.parts.filter(
+    (p): p is MessagePart & { type: "tool-call" } => p.type === "tool-call",
+  );
+  if (toolCallParts.length > 0) {
+    providerMsg.tool_calls = toolCallParts.map((tc) => ({
+      id: tc.toolCallId,
+      type: "function",
+      function: {
+        name: tc.toolName,
+        arguments: JSON.stringify(tc.args),
+      },
+    }));
+  }
+
+  // Extract tool result info from parts
+  const toolResultPart = msg.parts.find(
+    (p): p is MessagePart & { type: "tool-result" } => p.type === "tool-result",
+  );
+  if (toolResultPart && msg.role === "tool") {
+    providerMsg.tool_call_id = toolResultPart.toolCallId;
+    providerMsg.content = JSON.stringify(toolResultPart.result);
+  }
+
+  return providerMsg;
+}
 
 export class AgentRuntime {
   private id: string;
@@ -258,43 +311,7 @@ export class AgentRuntime {
           return await provider.complete({
             model,
             system: systemPrompt,
-            messages: currentMessages.map((m) => {
-              const msg: {
-                role: string;
-                content: string;
-                tool_calls?: Array<{
-                  id: string;
-                  type?: string;
-                  function: {
-                    name: string;
-                    arguments: string;
-                  };
-                }>;
-                tool_call_id?: string;
-              } = {
-                role: m.role,
-                content: m.content,
-              };
-
-              // Include tool_calls for assistant messages
-              if (m.role === "assistant" && m.toolCalls) {
-                msg.tool_calls = m.toolCalls.map((tc) => ({
-                  id: tc.id,
-                  type: "function",
-                  function: {
-                    name: tc.name,
-                    arguments: JSON.stringify(tc.arguments),
-                  },
-                }));
-              }
-
-              // Include tool_call_id for tool result messages
-              if (m.role === "tool" && m.toolCallId) {
-                msg.tool_call_id = m.toolCallId;
-              }
-
-              return msg;
-            }),
+            messages: currentMessages.map((m) => convertMessageToProvider(m)),
             tools: tools.length > 0 ? tools : undefined,
             maxTokens: this.config.memory?.maxTokens || DEFAULT_MAX_TOKENS,
             temperature: DEFAULT_TEMPERATURE,
@@ -305,11 +322,26 @@ export class AgentRuntime {
         totalUsage.completionTokens += response.usage.completionTokens;
         totalUsage.totalTokens += response.usage.totalTokens;
 
+        // Build parts array for v5 Message
+        const assistantParts: MessagePart[] = [];
+        if (response.text) {
+          assistantParts.push({ type: "text", text: response.text });
+        }
+        if (response.toolCalls) {
+          for (const tc of response.toolCalls) {
+            assistantParts.push({
+              type: "tool-call",
+              toolCallId: tc.id,
+              toolName: tc.name,
+              args: tc.arguments,
+            });
+          }
+        }
+
         const assistantMessage: Message = {
           id: `msg_${Date.now()}_${step}`,
           role: "assistant",
-          content: response.text,
-          toolCalls: response.toolCalls,
+          parts: assistantParts,
           timestamp: Date.now(),
         };
         currentMessages.push(assistantMessage);
@@ -350,9 +382,12 @@ export class AgentRuntime {
                 const toolResultMessage: Message = {
                   id: `tool_${tc.id}`,
                   role: "tool",
-                  content: JSON.stringify(result),
-                  toolCallId: tc.id,
-                  toolCall,
+                  parts: [{
+                    type: "tool-result",
+                    toolCallId: tc.id,
+                    toolName: tc.name,
+                    result,
+                  }],
                   timestamp: Date.now(),
                 };
                 currentMessages.push(toolResultMessage);
@@ -365,9 +400,12 @@ export class AgentRuntime {
                 const errorMessage: Message = {
                   id: `tool_error_${tc.id}`,
                   role: "tool",
-                  content: `Error: ${toolCall.error}`,
-                  toolCallId: tc.id,
-                  toolCall,
+                  parts: [{
+                    type: "tool-result",
+                    toolCallId: tc.id,
+                    toolName: tc.name,
+                    result: { error: toolCall.error },
+                  }],
                   timestamp: Date.now(),
                 };
                 currentMessages.push(errorMessage);
@@ -396,8 +434,9 @@ export class AgentRuntime {
       this.status = "completed";
       addSpanEvent(loopSpan, "max_steps_reached", { maxSteps });
 
+      const lastMsg = currentMessages[currentMessages.length - 1];
       return {
-        text: currentMessages[currentMessages.length - 1]?.content || "",
+        text: lastMsg ? getTextFromParts(lastMsg.parts) : "",
         messages: currentMessages,
         toolCalls,
         status: this.status,
@@ -444,19 +483,7 @@ export class AgentRuntime {
       const stream = await provider.stream({
         model,
         system: systemPrompt,
-        messages: currentMessages.map((m) => ({
-          role: m.role,
-          content: m.content,
-          tool_calls: m.toolCalls?.map((tc) => ({
-            id: tc.id,
-            type: "function",
-            function: {
-              name: tc.name,
-              arguments: JSON.stringify(tc.arguments),
-            },
-          })),
-          tool_call_id: m.toolCallId,
-        })),
+        messages: currentMessages.map((m) => convertMessageToProvider(m)),
         tools: tools.length > 0 ? tools : undefined,
         maxTokens: this.config.memory?.maxTokens || DEFAULT_MAX_TOKENS,
         temperature: DEFAULT_TEMPERATURE,
@@ -504,9 +531,12 @@ export class AgentRuntime {
         const errorMessage: Message = {
           id: `tool_error_${toolCall.id}`,
           role: "tool",
-          content: `Error: ${errorStr}`,
-          toolCallId: toolCall.id,
-          toolCall,
+          parts: [{
+            type: "tool-result",
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            result: { error: errorStr },
+          }],
           timestamp: Date.now(),
         };
         currentMessages.push(errorMessage);
@@ -641,31 +671,35 @@ export class AgentRuntime {
         }
       }
 
+      // Build v5 parts array
+      const streamParts: MessagePart[] = [];
+      if (accumulatedText) {
+        streamParts.push({ type: "text", text: accumulatedText });
+      }
+      if (streamToolCalls.size > 0) {
+        for (const tc of streamToolCalls.values()) {
+          const { args, error } = parseStreamToolArgs(tc.arguments);
+          if (error) {
+            logger.warn("[AGENT] Failed to parse streamed tool arguments", {
+              toolCallId: tc.id,
+              error,
+            });
+          }
+          streamParts.push({
+            type: "tool-call",
+            toolCallId: tc.id,
+            toolName: tc.name,
+            args,
+          });
+        }
+      }
+
       const assistantMessage: Message = {
         id: `msg_${Date.now()}_${step}`,
         role: "assistant",
-        content: accumulatedText,
+        parts: streamParts,
         timestamp: Date.now(),
       };
-
-      if (streamToolCalls.size > 0) {
-        assistantMessage.toolCalls = Array.from(streamToolCalls.values()).map(
-          (tc): StreamToolCall => {
-            const { args, error } = parseStreamToolArgs(tc.arguments);
-            if (error) {
-              logger.warn("[AGENT] Failed to parse streamed tool arguments", {
-                toolCallId: tc.id,
-                error,
-              });
-            }
-            return {
-              id: tc.id,
-              name: tc.name,
-              arguments: args,
-            };
-          },
-        );
-      }
 
       currentMessages.push(assistantMessage);
       await this.memory.add(assistantMessage);
@@ -729,9 +763,12 @@ export class AgentRuntime {
             const toolResultMessage: Message = {
               id: `tool_${tc.id}`,
               role: "tool",
-              content: JSON.stringify(result),
-              toolCallId: tc.id,
-              toolCall,
+              parts: [{
+                type: "tool-result",
+                toolCallId: tc.id,
+                toolName: tc.name,
+                result,
+              }],
               timestamp: Date.now(),
             };
             currentMessages.push(toolResultMessage);
@@ -749,8 +786,9 @@ export class AgentRuntime {
       break;
     }
 
+    const lastMessage = currentMessages[currentMessages.length - 1];
     return {
-      text: currentMessages[currentMessages.length - 1]?.content || "",
+      text: lastMessage ? getTextFromParts(lastMessage.parts) : "",
       messages: currentMessages,
       toolCalls,
       status: "completed",
@@ -847,7 +885,7 @@ export class AgentRuntime {
   }
 
   /**
-   * Normalize input to messages array
+   * Normalize input to messages array (v5 format with parts)
    */
   private normalizeInput(input: string | Message[]): Message[] {
     if (typeof input === "string") {
@@ -855,7 +893,7 @@ export class AgentRuntime {
         {
           id: `msg_${Date.now()}`,
           role: "user",
-          content: input,
+          parts: [{ type: "text", text: input }],
           timestamp: Date.now(),
         },
       ];

--- a/src/ai/types/agent.ts
+++ b/src/ai/types/agent.ts
@@ -129,35 +129,41 @@ export interface AgentContext {
 }
 
 /**
- * Message in a conversation
+ * Message part types (AI SDK v5 format)
+ */
+export type MessagePart =
+  | { type: "text"; text: string }
+  | { type: "tool-call"; toolCallId: string; toolName: string; args: Record<string, unknown> }
+  | { type: "tool-result"; toolCallId: string; toolName: string; result: unknown };
+
+/**
+ * Message in a conversation (AI SDK v5 format)
  */
 export interface Message {
   /** Message ID */
-  id?: string;
+  id: string;
 
   /** Message role */
   role: "user" | "assistant" | "system" | "tool";
 
-  /** Message content */
-  content: string;
-
-  /** Tool calls made by assistant (for assistant messages) */
-  toolCalls?: StreamToolCall[];
-
-  /** Tool call ID (for tool result messages) */
-  toolCallId?: string;
-
-  /** Tool call information (for tool messages) */
-  toolCall?: ToolCall;
-
-  /** Tool result (for tool response messages) */
-  toolResult?: unknown;
+  /** Message parts (v5 format) */
+  parts: MessagePart[];
 
   /** Timestamp */
   timestamp?: number;
 
   /** Additional metadata */
   metadata?: Record<string, unknown>;
+}
+
+/**
+ * Helper to extract text content from message parts
+ */
+export function getTextFromParts(parts: MessagePart[]): string {
+  return parts
+    .filter((p): p is MessagePart & { type: "text" } => p.type === "text")
+    .map((p) => p.text)
+    .join("");
 }
 
 /**

--- a/src/ai/workflow/runtime/agent-registry.ts
+++ b/src/ai/workflow/runtime/agent-registry.ts
@@ -192,8 +192,16 @@ export function createMockAgent(
       return {
         text,
         messages: [
-          { role: "user" as const, content: inputStr },
-          { role: "assistant" as const, content: text },
+          {
+            id: `msg_${Date.now()}_0`,
+            role: "user" as const,
+            parts: [{ type: "text" as const, text: inputStr }],
+          },
+          {
+            id: `msg_${Date.now()}_1`,
+            role: "assistant" as const,
+            parts: [{ type: "text" as const, text }],
+          },
         ],
         toolCalls: options.toolCalls?.map((tc) => ({
           ...tc,

--- a/tests/ai/agent-runtime-streaming.test.ts
+++ b/tests/ai/agent-runtime-streaming.test.ts
@@ -1,7 +1,6 @@
 import { describe, it } from "std/testing/bdd.ts";
 import {
   type AgentConfig,
-  getTextFromParts,
   type Message,
   type MessagePart,
 } from "../../src/ai/types/agent.ts";

--- a/tests/ai/agent-runtime-streaming.test.ts
+++ b/tests/ai/agent-runtime-streaming.test.ts
@@ -1,5 +1,10 @@
 import { describe, it } from "std/testing/bdd.ts";
-import type { AgentConfig, Message, StreamToolCall } from "../../src/ai/types/agent.ts";
+import {
+  type AgentConfig,
+  getTextFromParts,
+  type Message,
+  type MessagePart,
+} from "../../src/ai/types/agent.ts";
 
 type Provider = {
   name: string;
@@ -22,7 +27,9 @@ function assertEquals<T>(actual: T, expected: T, message?: string): void {
     ? JSON.stringify(actual) === JSON.stringify(expected)
     : actual === expected;
   if (!pass) {
-    throw new Error(message || `Assertion failed: ${JSON.stringify(actual)} !== ${JSON.stringify(expected)}`);
+    throw new Error(
+      message || `Assertion failed: ${JSON.stringify(actual)} !== ${JSON.stringify(expected)}`,
+    );
   }
 }
 
@@ -95,7 +102,7 @@ describe("AgentRuntime streaming JSON buffering", () => {
     ]);
 
     const runtime = new AgentRuntime("test", baseConfig);
-    const messages: Message[] = [{ id: "m1", role: "user", content: "hi" }];
+    const messages: Message[] = [{ id: "m1", role: "user", parts: [{ type: "text", text: "hi" }] }];
     const controller = {
       enqueue: (_chunk: Uint8Array) => {},
       close: () => {},
@@ -112,12 +119,15 @@ describe("AgentRuntime streaming JSON buffering", () => {
     );
 
     assert(response.text.includes("Hello"), "should include streamed content");
-    // No tool execution because finishReason=stop, but assistant message should carry parsed toolCalls
+    // No tool execution because finishReason=stop, but assistant message should carry parsed tool-call parts
     const assistant = response.messages.find((m) => m.role === "assistant");
-    assert(assistant?.toolCalls && assistant.toolCalls.length === 1, "assistant toolCalls captured");
-    const tc = assistant!.toolCalls![0]! as StreamToolCall;
-    assertEquals(tc.name, "testTool");
-    assertEquals(tc.arguments, { x: 1 });
+    const toolCallParts = assistant?.parts.filter((p): p is MessagePart & { type: "tool-call" } =>
+      p.type === "tool-call"
+    );
+    assert(toolCallParts && toolCallParts.length === 1, "assistant tool-call parts captured");
+    const tc = toolCallParts![0]!;
+    assertEquals(tc.toolName, "testTool");
+    assertEquals(tc.args, { x: 1 });
     // Restore env if we modified it
     if (restoreEnv) {
       restoreEnv();


### PR DESCRIPTION
## Summary
- Update Message interface to use `parts: MessagePart[]` instead of `content: string`
- Add MessagePart type for text, tool-call, and tool-result parts
- Add `getTextFromParts()` helper function
- Update AgentRuntime to create v5 messages and convert to provider format
- Update memory system to work with parts array

## Breaking Change
`Message` type now requires `parts` array instead of `content` string:

```typescript
// Before (v4)
const msg: Message = { 
  id: "1", 
  role: "user", 
  content: "Hello" 
};

// After (v5)
const msg: Message = { 
  id: "1", 
  role: "user", 
  parts: [{ type: "text", text: "Hello" }] 
};
```

## Test plan
- [x] All AI tests pass (4 passed, 15 steps)
- [x] Type checking passes
- [x] Lint passes