### PR TITLE
feat(ai/react): update components and primitives for AI SDK v5

### DIFF
--- a/src/ai/react/components/chat.tsx
+++ b/src/ai/react/components/chat.tsx
@@ -14,8 +14,7 @@ import {
   SubmitButton,
 } from "../primitives/index.ts";
 import { useVoiceInput } from "../hooks/use-voice-input.ts";
-import type { ToolCall } from "../../types/agent.ts";
-import type { UIMessage, UIMessagePart } from "../hooks/use-chat.ts";
+import type { UIMessage, UIMessagePart, ToolUIPart, DynamicToolUIPart } from "../hooks/use-chat.ts";
 import { type ChatTheme, cn, defaultChatTheme, mergeThemes } from "./theme.ts";
 import { Markdown } from "./markdown.tsx";
 
@@ -27,6 +26,16 @@ function getTextContent(message: UIMessage): string {
     .filter((p): p is UIMessagePart & { type: "text" } => p.type === "text")
     .map((p) => p.text)
     .join("");
+}
+
+/**
+ * Get tool parts from UIMessage
+ */
+function getToolParts(message: UIMessage): (ToolUIPart | DynamicToolUIPart)[] {
+  return message.parts.filter(
+    (p): p is ToolUIPart | DynamicToolUIPart =>
+      p.type === "tool-call" || p.type === "dynamic-tool"
+  );
 }
 
 export interface ChatProps {
@@ -81,8 +90,8 @@ export interface ChatProps {
   /** Custom message renderer */
   renderMessage?: (message: UIMessage) => React.ReactNode;
 
-  /** Custom tool renderer */
-  renderTool?: (toolCall: ToolCall) => React.ReactNode;
+  /** Custom tool renderer (v5 format) */
+  renderTool?: (tool: ToolUIPart | DynamicToolUIPart) => React.ReactNode;
 
   /** Enable multiline input */
   multiline?: boolean;
@@ -124,7 +133,7 @@ export const Chat = React.forwardRef<HTMLDivElement, ChatProps>(
       className,
       theme: userTheme,
       renderMessage,
-      renderTool: _renderTool,
+      renderTool,
       multiline = false,
     },
     ref,
@@ -170,6 +179,7 @@ export const Chat = React.forwardRef<HTMLDivElement, ChatProps>(
           <div className="max-w-2xl mx-auto px-4 py-4 space-y-2">
             {messages.map((msg) => {
               const content = getTextContent(msg);
+              const toolParts = getToolParts(msg);
               return renderMessage
                 ? <React.Fragment key={msg.id}>{renderMessage(msg)}</React.Fragment>
                 : (
@@ -193,6 +203,36 @@ export const Chat = React.forwardRef<HTMLDivElement, ChatProps>(
                             {content}
                           </Markdown>
                         )}
+                      {/* Render tool parts (v5) */}
+                      {toolParts.length > 0 && (
+                        <div className="mt-2 space-y-1">
+                          {toolParts.map((tool) =>
+                            renderTool ? (
+                              <React.Fragment key={tool.toolCallId}>
+                                {renderTool(tool)}
+                              </React.Fragment>
+                            ) : (
+                              <div
+                                key={tool.toolCallId}
+                                className={cn(
+                                  "text-xs rounded px-2 py-1",
+                                  tool.type === "dynamic-tool"
+                                    ? "bg-blue-50 dark:bg-blue-900/20"
+                                    : "bg-neutral-100 dark:bg-neutral-800"
+                                )}
+                              >
+                                <span className="font-mono">{tool.toolName}</span>
+                                <span className="ml-2 opacity-70">[{tool.state}]</span>
+                                {tool.errorText && (
+                                  <div className="text-red-600 dark:text-red-400 mt-1">
+                                    {tool.errorText}
+                                  </div>
+                                )}
+                              </div>
+                            )
+                          )}
+                        </div>
+                      )}
                     </div>
                   </MessageItem>
                 );

--- a/src/ai/react/components/chat.tsx
+++ b/src/ai/react/components/chat.tsx
@@ -14,7 +14,7 @@ import {
   SubmitButton,
 } from "../primitives/index.ts";
 import { useVoiceInput } from "../hooks/use-voice-input.ts";
-import type { UIMessage, UIMessagePart, ToolUIPart, DynamicToolUIPart } from "../hooks/use-chat.ts";
+import type { DynamicToolUIPart, ToolUIPart, UIMessage, UIMessagePart } from "../hooks/use-chat.ts";
 import { type ChatTheme, cn, defaultChatTheme, mergeThemes } from "./theme.ts";
 import { Markdown } from "./markdown.tsx";
 
@@ -33,8 +33,7 @@ function getTextContent(message: UIMessage): string {
  */
 function getToolParts(message: UIMessage): (ToolUIPart | DynamicToolUIPart)[] {
   return message.parts.filter(
-    (p): p is ToolUIPart | DynamicToolUIPart =>
-      p.type === "tool-call" || p.type === "dynamic-tool"
+    (p): p is ToolUIPart | DynamicToolUIPart => p.type === "tool-call" || p.type === "dynamic-tool",
   );
 }
 
@@ -207,29 +206,31 @@ export const Chat = React.forwardRef<HTMLDivElement, ChatProps>(
                       {toolParts.length > 0 && (
                         <div className="mt-2 space-y-1">
                           {toolParts.map((tool) =>
-                            renderTool ? (
-                              <React.Fragment key={tool.toolCallId}>
-                                {renderTool(tool)}
-                              </React.Fragment>
-                            ) : (
-                              <div
-                                key={tool.toolCallId}
-                                className={cn(
-                                  "text-xs rounded px-2 py-1",
-                                  tool.type === "dynamic-tool"
-                                    ? "bg-blue-50 dark:bg-blue-900/20"
-                                    : "bg-neutral-100 dark:bg-neutral-800"
-                                )}
-                              >
-                                <span className="font-mono">{tool.toolName}</span>
-                                <span className="ml-2 opacity-70">[{tool.state}]</span>
-                                {tool.errorText && (
-                                  <div className="text-red-600 dark:text-red-400 mt-1">
-                                    {tool.errorText}
-                                  </div>
-                                )}
-                              </div>
-                            )
+                            renderTool
+                              ? (
+                                <React.Fragment key={tool.toolCallId}>
+                                  {renderTool(tool)}
+                                </React.Fragment>
+                              )
+                              : (
+                                <div
+                                  key={tool.toolCallId}
+                                  className={cn(
+                                    "text-xs rounded px-2 py-1",
+                                    tool.type === "dynamic-tool"
+                                      ? "bg-blue-50 dark:bg-blue-900/20"
+                                      : "bg-neutral-100 dark:bg-neutral-800",
+                                  )}
+                                >
+                                  <span className="font-mono">{tool.toolName}</span>
+                                  <span className="ml-2 opacity-70">[{tool.state}]</span>
+                                  {tool.errorText && (
+                                    <div className="text-red-600 dark:text-red-400 mt-1">
+                                      {tool.errorText}
+                                    </div>
+                                  )}
+                                </div>
+                              )
                           )}
                         </div>
                       )}

--- a/src/ai/react/components/message.tsx
+++ b/src/ai/react/components/message.tsx
@@ -149,9 +149,9 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
             }
           })}
 
-          {showTimestamp && (
+          {showTimestamp && message.createdAt && (
             <div className="text-xs opacity-60 mt-1">
-              {new Date().toLocaleTimeString()}
+              {new Date(message.createdAt).toLocaleTimeString()}
             </div>
           )}
         </div>

--- a/src/ai/react/components/message.tsx
+++ b/src/ai/react/components/message.tsx
@@ -124,9 +124,7 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
                   <div key={key} className="text-xs bg-gray-100 rounded p-2 my-2">
                     <span className="font-mono">{part.toolName}</span>
                     <span className="ml-2 text-gray-500">[{part.state}]</span>
-                    {part.errorText && (
-                      <div className="text-red-600 mt-1">{part.errorText}</div>
-                    )}
+                    {part.errorText && <div className="text-red-600 mt-1">{part.errorText}</div>}
                   </div>
                 );
 
@@ -138,9 +136,7 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
                   <div key={key} className="text-xs bg-blue-50 rounded p-2 my-2">
                     <span className="font-mono">{part.toolName}</span>
                     <span className="ml-2 text-blue-500">[dynamic: {part.state}]</span>
-                    {part.errorText && (
-                      <div className="text-red-600 mt-1">{part.errorText}</div>
-                    )}
+                    {part.errorText && <div className="text-red-600 mt-1">{part.errorText}</div>}
                   </div>
                 );
 

--- a/src/ai/react/components/message.tsx
+++ b/src/ai/react/components/message.tsx
@@ -112,7 +112,7 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
                 }
                 return (
                   <div key={key} className="text-sm italic opacity-70 my-2 pl-2 border-l-2">
-                    {part.reasoning}
+                    {part.text}
                   </div>
                 );
 

--- a/src/ai/react/components/message.tsx
+++ b/src/ai/react/components/message.tsx
@@ -1,17 +1,17 @@
 /**
  * Message Component - Layer 3 (Styled)
  *
- * Production-ready message display.
+ * Production-ready message display with AI SDK v5 parts support.
  */
 
 import * as React from "react";
 import { MessageContent, MessageItem, MessageRole } from "../primitives/index.ts";
-import type { Message as MessageType } from "../../types/agent.ts";
+import type { UIMessage, UIMessagePart } from "../hooks/index.ts";
 import { type ChatTheme, cn, defaultChatTheme, mergeThemes } from "./theme.ts";
 
 export interface MessageProps {
-  /** Message to display */
-  message: MessageType;
+  /** Message to display (v5 UIMessage format) */
+  message: UIMessage;
 
   /** Additional class name */
   className?: string;
@@ -24,21 +24,55 @@ export interface MessageProps {
 
   /** Show timestamp */
   showTimestamp?: boolean;
+
+  /** Custom renderer for tool calls */
+  renderToolCall?: (part: Extract<UIMessagePart, { type: "tool-call" }>) => React.ReactNode;
+
+  /** Custom renderer for dynamic tools */
+  renderDynamicTool?: (
+    part: Extract<UIMessagePart, { type: "dynamic-tool" }>,
+  ) => React.ReactNode;
+
+  /** Custom renderer for reasoning */
+  renderReasoning?: (part: Extract<UIMessagePart, { type: "reasoning" }>) => React.ReactNode;
 }
 
 /**
- * Message - Styled message component
+ * Helper to extract text content from v5 parts array
+ */
+function getTextFromParts(parts: UIMessagePart[]): string {
+  return parts
+    .filter((p): p is Extract<UIMessagePart, { type: "text" }> => p.type === "text")
+    .map((p) => p.text)
+    .join("");
+}
+
+/**
+ * Message - Styled message component with v5 parts support
  *
  * @example
  * ```tsx
  * import { Message } from 'veryfront/ai/components';
  *
- * <Message message={msg} showRole={true} />
+ * <Message
+ *   message={msg}
+ *   showRole={true}
+ *   renderToolCall={(part) => <MyToolUI part={part} />}
+ * />
  * ```
  */
 export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
   (
-    { message, className, theme: userTheme, showRole = false, showTimestamp = false },
+    {
+      message,
+      className,
+      theme: userTheme,
+      showRole = false,
+      showTimestamp = false,
+      renderToolCall,
+      renderDynamicTool,
+      renderReasoning,
+    },
     ref,
   ) => {
     const theme = mergeThemes(defaultChatTheme, userTheme);
@@ -60,11 +94,64 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
             </MessageRole>
           )}
 
-          <MessageContent>{message.content}</MessageContent>
+          {/* Render parts array (v5 format) */}
+          {message.parts.map((part, index) => {
+            const key = `${message.id}-part-${index}`;
 
-          {showTimestamp && message.timestamp && (
+            switch (part.type) {
+              case "text":
+                return (
+                  <MessageContent key={key}>
+                    {part.text}
+                  </MessageContent>
+                );
+
+              case "reasoning":
+                if (renderReasoning) {
+                  return <React.Fragment key={key}>{renderReasoning(part)}</React.Fragment>;
+                }
+                return (
+                  <div key={key} className="text-sm italic opacity-70 my-2 pl-2 border-l-2">
+                    {part.reasoning}
+                  </div>
+                );
+
+              case "tool-call":
+                if (renderToolCall) {
+                  return <React.Fragment key={key}>{renderToolCall(part)}</React.Fragment>;
+                }
+                return (
+                  <div key={key} className="text-xs bg-gray-100 rounded p-2 my-2">
+                    <span className="font-mono">{part.toolName}</span>
+                    <span className="ml-2 text-gray-500">[{part.state}]</span>
+                    {part.errorText && (
+                      <div className="text-red-600 mt-1">{part.errorText}</div>
+                    )}
+                  </div>
+                );
+
+              case "dynamic-tool":
+                if (renderDynamicTool) {
+                  return <React.Fragment key={key}>{renderDynamicTool(part)}</React.Fragment>;
+                }
+                return (
+                  <div key={key} className="text-xs bg-blue-50 rounded p-2 my-2">
+                    <span className="font-mono">{part.toolName}</span>
+                    <span className="ml-2 text-blue-500">[dynamic: {part.state}]</span>
+                    {part.errorText && (
+                      <div className="text-red-600 mt-1">{part.errorText}</div>
+                    )}
+                  </div>
+                );
+
+              default:
+                return null;
+            }
+          })}
+
+          {showTimestamp && (
             <div className="text-xs opacity-60 mt-1">
-              {new Date(message.timestamp).toLocaleTimeString()}
+              {new Date().toLocaleTimeString()}
             </div>
           )}
         </div>
@@ -76,8 +163,8 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
 Message.displayName = "Message";
 
 export interface StreamingMessageProps {
-  /** Streaming content */
-  content: string;
+  /** Streaming parts (v5 format) */
+  parts: UIMessagePart[];
 
   /** Show typing cursor */
   showCursor?: boolean;
@@ -90,22 +177,23 @@ export interface StreamingMessageProps {
 }
 
 /**
- * StreamingMessage - Display streaming text
+ * StreamingMessage - Display streaming message with v5 parts
  *
  * @example
  * ```tsx
  * import { StreamingMessage } from 'veryfront/ai/components';
  *
- * {streamingText && (
- *   <StreamingMessage content={streamingText} showCursor={true} />
+ * {isStreaming && (
+ *   <StreamingMessage parts={streamingParts} showCursor={true} />
  * )}
  * ```
  */
 export const StreamingMessage = React.forwardRef<
   HTMLDivElement,
   StreamingMessageProps
->(({ content, showCursor = true, className, theme: userTheme }, ref) => {
+>(({ parts, showCursor = true, className, theme: userTheme }, ref) => {
   const theme = mergeThemes(defaultChatTheme, userTheme);
+  const textContent = getTextFromParts(parts);
 
   return (
     <MessageItem
@@ -115,7 +203,7 @@ export const StreamingMessage = React.forwardRef<
     >
       <div className={theme.message?.assistant}>
         <MessageContent>
-          {content}
+          {textContent}
           {showCursor && <span className="inline-block w-1 h-4 bg-current ml-1 animate-pulse" />}
         </MessageContent>
       </div>

--- a/src/ai/react/hooks/index.ts
+++ b/src/ai/react/hooks/index.ts
@@ -8,6 +8,7 @@
 
 export { useChat } from "./use-chat.ts";
 export type {
+  DynamicToolUIPart,
   OnToolCallArg,
   ReasoningUIPart,
   TextUIPart,

--- a/src/ai/react/hooks/use-chat.ts
+++ b/src/ai/react/hooks/use-chat.ts
@@ -98,6 +98,8 @@ export interface UIMessage {
   role: "system" | "user" | "assistant";
   parts: UIMessagePart[];
   metadata?: Record<string, unknown>;
+  /** Message creation timestamp (optional) */
+  createdAt?: Date | string;
 }
 
 /**

--- a/src/ai/react/primitives/message-list.tsx
+++ b/src/ai/react/primitives/message-list.tsx
@@ -6,7 +6,7 @@
  */
 
 import * as React from "react";
-import type { Message } from "../../types/agent.ts";
+import type { UIMessage } from "../hooks/index.ts";
 
 export interface MessageListProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
@@ -47,9 +47,9 @@ MessageList.displayName = "MessageList";
 
 export interface MessageItemProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Message role */
-  role: Message["role"];
+  role: UIMessage["role"];
 
-  /** Message content (can be children or prop) */
+  /** Message content (can be children or prop) - deprecated, use children with parts */
   content?: string;
 
   children?: React.ReactNode;

--- a/src/ai/react/primitives/tool-primitives.tsx
+++ b/src/ai/react/primitives/tool-primitives.tsx
@@ -50,7 +50,7 @@ export interface ToolInvocationProps extends React.HTMLAttributes<HTMLDivElement
 export const ToolInvocation = React.forwardRef<
   HTMLDivElement,
   ToolInvocationProps
->(({ className, name, input, output, state, errorText, dynamic, children, ...props }, ref) => {
+>(({ className, name, input, output: _output, state, errorText, dynamic, children, ...props }, ref) => {
   return (
     <div
       ref={ref}

--- a/src/ai/react/primitives/tool-primitives.tsx
+++ b/src/ai/react/primitives/tool-primitives.tsx
@@ -2,61 +2,80 @@
  * Tool Primitives - Layer 2 (Unstyled)
  *
  * Primitives for displaying tool invocations and results.
+ * Supports both regular tools and dynamic tools (MCP, user-defined).
  * Built on Radix UI patterns (shadcn-compatible).
  */
 
 import * as React from "react";
-import type { ToolCall } from "../../types/agent.ts";
+import type { ToolState, ToolUIPart, DynamicToolUIPart } from "../hooks/index.ts";
 
 export interface ToolInvocationProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Tool name */
   name: string;
 
-  /** Tool arguments */
-  args?: Record<string, unknown>;
+  /** Tool input */
+  input?: unknown;
 
-  /** Tool status */
-  status?: ToolCall["status"];
+  /** Tool output */
+  output?: unknown;
+
+  /** Tool state (v5 format) */
+  state?: ToolState;
+
+  /** Error text if tool failed */
+  errorText?: string;
+
+  /** Whether this is a dynamic tool (MCP, user-defined) */
+  dynamic?: boolean;
 
   children?: React.ReactNode;
 }
 
 /**
- * ToolInvocation - Tool call display
+ * ToolInvocation - Tool call display (v5 compatible)
  *
  * @example
  * ```tsx
  * <ToolInvocation
- *   name={tool.name}
- *   args={tool.args}
- *   status={tool.status}
+ *   name={part.toolName}
+ *   input={part.input}
+ *   state={part.state}
+ *   dynamic={part.type === 'dynamic-tool'}
  *   className="border-l-4 border-blue-500 pl-4"
  * >
- *   <ToolResult result={tool.result} />
+ *   <ToolResult output={part.output} />
  * </ToolInvocation>
  * ```
  */
 export const ToolInvocation = React.forwardRef<
   HTMLDivElement,
   ToolInvocationProps
->(({ className, name, args, status, children, ...props }, ref) => {
+>(({ className, name, input, output, state, errorText, dynamic, children, ...props }, ref) => {
   return (
     <div
       ref={ref}
       className={className}
       data-tool-invocation=""
       data-tool-name={name}
-      data-status={status}
+      data-state={state}
+      data-dynamic={dynamic || undefined}
       {...props}
     >
       <div data-tool-header="">
         <span data-tool-name="">{name}</span>
-        {status && <span data-tool-status="">({status})</span>}
+        {state && <span data-tool-state="">({state})</span>}
+        {dynamic && <span data-tool-dynamic="">[dynamic]</span>}
       </div>
 
-      {args && (
-        <div data-tool-args="">
-          <pre>{JSON.stringify(args, null, 2)}</pre>
+      {input && (
+        <div data-tool-input="">
+          <pre>{JSON.stringify(input, null, 2)}</pre>
+        </div>
+      )}
+
+      {errorText && (
+        <div data-tool-error="">
+          {errorText}
         </div>
       )}
 
@@ -68,27 +87,27 @@ export const ToolInvocation = React.forwardRef<
 ToolInvocation.displayName = "ToolInvocation";
 
 export interface ToolResultProps extends React.HTMLAttributes<HTMLDivElement> {
-  /** Tool result data */
-  result: unknown;
+  /** Tool output data */
+  output: unknown;
 
   /** Custom renderer */
-  renderResult?: (result: unknown) => React.ReactNode;
+  renderOutput?: (output: unknown) => React.ReactNode;
 }
 
 /**
- * ToolResult - Tool result display
+ * ToolResult - Tool result display (v5 compatible)
  *
  * @example
  * ```tsx
  * <ToolResult
- *   result={tool.result}
+ *   output={part.output}
  *   className="mt-2 p-2 bg-gray-100 rounded"
  * />
  * ```
  */
 export const ToolResult = React.forwardRef<HTMLDivElement, ToolResultProps>(
-  ({ className, result, renderResult, ...props }, ref) => {
-    const content = renderResult ? renderResult(result) : JSON.stringify(result, null, 2);
+  ({ className, output, renderOutput, ...props }, ref) => {
+    const content = renderOutput ? renderOutput(output) : JSON.stringify(output, null, 2);
 
     return (
       <div
@@ -105,32 +124,43 @@ export const ToolResult = React.forwardRef<HTMLDivElement, ToolResultProps>(
 
 ToolResult.displayName = "ToolResult";
 
+/** Union type for both tool types from v5 parts */
+type ToolPart = ToolUIPart | DynamicToolUIPart;
+
 export interface ToolListProps extends React.HTMLAttributes<HTMLDivElement> {
-  /** Tool calls to display */
-  toolCalls: ToolCall[];
+  /** Tool parts to display (v5 format) */
+  tools: ToolPart[];
 
   /** Render each tool */
-  renderTool?: (toolCall: ToolCall) => React.ReactNode;
+  renderTool?: (tool: ToolPart) => React.ReactNode;
 }
 
 /**
- * ToolList - Display list of tool calls
+ * ToolList - Display list of tool calls (v5 compatible)
  *
  * @example
  * ```tsx
+ * const toolParts = message.parts.filter(
+ *   p => p.type === 'tool-call' || p.type === 'dynamic-tool'
+ * );
+ *
  * <ToolList
- *   toolCalls={agent.toolCalls}
+ *   tools={toolParts}
  *   className="space-y-2"
  *   renderTool={(tool) => (
- *     <ToolInvocation {...tool}>
- *       <ToolResult result={tool.result} />
+ *     <ToolInvocation
+ *       name={tool.toolName}
+ *       state={tool.state}
+ *       dynamic={tool.type === 'dynamic-tool'}
+ *     >
+ *       {tool.output && <ToolResult output={tool.output} />}
  *     </ToolInvocation>
  *   )}
  * />
  * ```
  */
 export const ToolList = React.forwardRef<HTMLDivElement, ToolListProps>(
-  ({ className, toolCalls, renderTool, ...props }, ref) => {
+  ({ className, tools, renderTool, ...props }, ref) => {
     return (
       <div
         ref={ref}
@@ -138,17 +168,19 @@ export const ToolList = React.forwardRef<HTMLDivElement, ToolListProps>(
         data-tool-list=""
         {...props}
       >
-        {toolCalls.map((tool) =>
+        {tools.map((tool) =>
           renderTool
-            ? <React.Fragment key={tool.id}>{renderTool(tool)}</React.Fragment>
+            ? <React.Fragment key={tool.toolCallId}>{renderTool(tool)}</React.Fragment>
             : (
               <ToolInvocation
-                key={tool.id}
-                name={tool.name}
-                args={tool.args}
-                status={tool.status}
+                key={tool.toolCallId}
+                name={tool.toolName}
+                input={tool.input}
+                state={tool.state}
+                errorText={tool.errorText}
+                dynamic={tool.type === "dynamic-tool"}
               >
-                {tool.result !== undefined && <ToolResult result={tool.result} />}
+                {tool.output !== undefined && <ToolResult output={tool.output} />}
               </ToolInvocation>
             )
         )}

--- a/src/ai/react/primitives/tool-primitives.tsx
+++ b/src/ai/react/primitives/tool-primitives.tsx
@@ -50,7 +50,10 @@ export interface ToolInvocationProps extends React.HTMLAttributes<HTMLDivElement
 export const ToolInvocation = React.forwardRef<
   HTMLDivElement,
   ToolInvocationProps
->(({ className, name, input, output: _output, state, errorText, dynamic, children, ...props }, ref) => {
+>((
+  { className, name, input, output: _output, state, errorText, dynamic, children, ...props },
+  ref,
+) => {
   return (
     <div
       ref={ref}

--- a/src/ai/react/primitives/tool-primitives.tsx
+++ b/src/ai/react/primitives/tool-primitives.tsx
@@ -7,7 +7,7 @@
  */
 
 import * as React from "react";
-import type { ToolState, ToolUIPart, DynamicToolUIPart } from "../hooks/index.ts";
+import type { DynamicToolUIPart, ToolState, ToolUIPart } from "../hooks/index.ts";
 
 export interface ToolInvocationProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Tool name */


### PR DESCRIPTION
## Summary
- Update React components and primitives for AI SDK v5 UI Message format
- Add support for `parts` array rendering (text, reasoning, tool-call, dynamic-tool)
- Add custom render props for extensibility
- Preserve all existing features (voice input, theming, etc.)

### Changes
- **hooks/index.ts**: Export `DynamicToolUIPart` type
- **message.tsx**: Render v5 parts array with custom render props
- **message-list.tsx**: Use `UIMessage` type
- **tool-primitives.tsx**: Full v5 compatibility with ToolState and errorText
- **chat.tsx**: Add tool parts rendering with visual distinction

Closes #17

## Test plan
- [ ] Verify components render with v5 UIMessage format
- [ ] Test custom render props work correctly
- [ ] Verify voice input still works
- [ ] Verify theme customization still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)