### PR TITLE
fix: improve Deno runtime detection to handle env shim

### DIFF
--- a/src/platform/adapters/detect.ts
+++ b/src/platform/adapters/detect.ts
@@ -25,7 +25,9 @@ interface CloudflareGlobal {
 }
 
 function isDeno(global: typeof globalThis): global is typeof globalThis & DenoGlobal {
-  return "Deno" in global && typeof (global as DenoGlobal).Deno === "object";
+  return "Deno" in global &&
+    typeof (global as DenoGlobal).Deno === "object" &&
+    typeof (global as DenoGlobal).Deno.version === "object";
 }
 
 function isBun(global: typeof globalThis): global is typeof globalThis & BunGlobal {

--- a/src/platform/compat/runtime.ts
+++ b/src/platform/compat/runtime.ts
@@ -1,4 +1,4 @@
-export const isDeno = typeof Deno !== "undefined";
+export const isDeno = typeof Deno !== "undefined" && typeof Deno.version === "object";
 export const isNode =
   typeof (globalThis as { process?: { versions?: { node?: string } } }).process !== "undefined" &&
   (globalThis as { process?: { versions?: { node?: string } } }).process?.versions?.node !==
@@ -15,6 +15,8 @@ export const isCloudflare = typeof globalThis !== "undefined" && "caches" in glo
 export function isNodeRuntime(): boolean {
   // deno-lint-ignore no-explicit-any
   const _global = globalThis as any;
-  return typeof Deno === "undefined" && typeof _global.process !== "undefined" &&
+  // Check Deno.version to distinguish real Deno from the npm build shim
+  const isRealDeno = typeof Deno !== "undefined" && typeof Deno.version === "object";
+  return !isRealDeno && typeof _global.process !== "undefined" &&
     !!_global.process?.versions?.node;
 }


### PR DESCRIPTION
## Summary
- Fix `Deno.serve is not a function` error when running npm package in Node.js
- Add `Deno.version` check to runtime detection in both `detect.ts` and `runtime.ts`
- Add missing `js-yaml` dependency to npm package

## Problem
The `deno-env.ts` shim creates a partial `globalThis.Deno` object (with only `env` methods) for npm builds. This caused runtime detection to incorrectly return `"deno"` because it only checked if `Deno` existed.

## Changes
- `src/platform/adapters/detect.ts:isDeno()` - add `Deno.version` check
- `src/platform/compat/runtime.ts:isDeno` - add `Deno.version` check  
- `src/platform/compat/runtime.ts:isNodeRuntime()` - use consistent detection
- `npm/package.json` - add `js-yaml` dependency for frontmatter parsing

## Test plan
- [x] Build npm package with fix
- [x] Install globally and test CLI
- [x] Verified: `veryfront dev` now starts successfully in Node.js

**Before:**
```
Error: Deno.serve is not a function
```

**After:**
```
[SERVER] Dev server running at http://localhost:3000
[CLI] ✓ Server started successfully!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)