### PR TITLE
fix: add js-yaml dependency for frontmatter parsing

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -145,6 +145,7 @@
     "picocolors": "^1.1.0",
     "mri": "^1.2.0",
     "yaml": "^2.3.0",
+    "js-yaml": "^4.1.0",
     "gray-matter": "^4.0.3",
     "ws": "^8.18.0",
     "lightningcss": "^1.22.0",


### PR DESCRIPTION
## Summary
Add missing `js-yaml` dependency to npm package.

## Problem
The CLI dynamically imports `js-yaml` for Node.js frontmatter parsing, but it was missing from npm dependencies, causing runtime warnings:
```
Could not import js-yaml for Node.js frontmatter parsing. Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'js-yaml'
```

## Fix
Add `js-yaml: ^4.1.0` to npm/package.json dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)