### PR TITLE
fix: content versioning bugs and preview auth forwarding

### DIFF
--- a/proxy/main.ts
+++ b/proxy/main.ts
@@ -95,7 +95,20 @@ async function handleRequest(req: Request): Promise<Response> {
       reqLogger.info("Request received");
 
       let token = "";
-      if (config.clientId && config.clientSecret) {
+
+      // For preview requests, try to use user's auth token from cookie first.
+      // This allows previewing user-owned projects that aren't accessible via OAuth client credentials.
+      if (scope === "preview") {
+        const cookieHeader = req.headers.get("cookie") || "";
+        const authTokenMatch = cookieHeader.match(/(?:^|;\s*)authToken=([^;]+)/);
+        if (authTokenMatch?.[1]) {
+          token = decodeURIComponent(authTokenMatch[1]);
+          reqLogger.info("Using user auth token for preview");
+        }
+      }
+
+      // Fall back to OAuth client credentials if no user token or for production requests
+      if (!token && config.clientId && config.clientSecret) {
         try {
           // Don't pass projectSlug as projectId - the API expects a UUID, not a slug.
           // The token works globally for all projects under the OAuth client credentials.

--- a/src/platform/adapters/multi-project-fs-adapter.ts
+++ b/src/platform/adapters/multi-project-fs-adapter.ts
@@ -26,8 +26,6 @@ const asyncLocalStorage = new AsyncLocalStorage<RequestContext>();
 export class MultiProjectFSAdapter implements FSAdapter {
   private manager: ProxyFSAdapterManager;
   private defaultAdapter?: VeryfrontFSAdapter;
-  private productionMode = false;
-  private releaseId: string | null = null;
 
   constructor(config: FSAdapterConfig) {
     this.manager = new ProxyFSAdapterManager({
@@ -78,14 +76,10 @@ export class MultiProjectFSAdapter implements FSAdapter {
     }
   }
 
-  setProductionMode(enabled: boolean, releaseId?: string | null): void {
-    this.productionMode = enabled;
-    this.releaseId = releaseId ?? null;
-
-    logger.info("[MultiProjectFSAdapter] Production mode set", {
-      enabled,
-      releaseId: releaseId ?? "(none)",
-    });
+  setProductionMode(_enabled: boolean, _releaseId?: string | null): void {
+    // No-op: In proxy mode, productionMode/releaseId are passed via runWithContext().
+    // This method exists for interface compatibility but is never called in practice
+    // because ssr-handler returns early after runWithContext().
   }
 
   private getAdapter(): Promise<VeryfrontFSAdapter> {
@@ -109,10 +103,9 @@ export class MultiProjectFSAdapter implements FSAdapter {
       );
     }
 
-    // Use production mode from context (set by runWithContext)
-    // Fall back to class-level setting for backward compatibility
-    const productionMode = context.productionMode ?? this.productionMode;
-    const releaseId = context.releaseId ?? this.releaseId;
+    // Production mode is set by runWithContext() - always present in context
+    const productionMode = context.productionMode ?? false;
+    const releaseId = context.releaseId ?? null;
 
     // Log at info level to debug context propagation issues
     logger.info("[MultiProjectFSAdapter] getAdapter with context", {

--- a/src/platform/adapters/veryfront-fs-adapter/adapter.ts
+++ b/src/platform/adapters/veryfront-fs-adapter/adapter.ts
@@ -609,7 +609,8 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
     if (modeChanged || releaseChanged) {
       this.statOps.clearIndex();
-      logger.info("[VeryfrontFSAdapter] Cleared index due to mode change", {
+      this.dirOps.clearTree();
+      logger.info("[VeryfrontFSAdapter] Cleared index and dirTree due to mode change", {
         oldProductionMode,
         newProductionMode: enabled,
         oldReleaseId: oldReleaseId ?? "null",

--- a/src/platform/adapters/veryfront-fs-adapter/directory-operations.ts
+++ b/src/platform/adapters/veryfront-fs-adapter/directory-operations.ts
@@ -25,7 +25,11 @@ export class DirectoryOperations {
   async readdir(path: string): Promise<DirectoryEntry[]> {
     const normalizedPath = this.normalizer.normalize(path);
     const branch = this.client.getRequestBranch() || "main";
-    const cacheKey = `dir:entries:${branch}:${normalizedPath}`;
+    const isProduction = this.productionContext?.isProductionMode() ?? false;
+    const releaseId = this.productionContext?.getReleaseId() ?? null;
+    // Include production context in cache key to prevent mixing preview/production entries
+    const mode = isProduction ? `production:${releaseId ?? "latest"}` : `preview:${branch}`;
+    const cacheKey = `dir:entries:${mode}:${normalizedPath}`;
 
     const cached = this.cache.get<DirectoryEntry[]>(cacheKey);
     if (cached) {

--- a/src/server/handlers/request/ssr/ssr-handler.ts
+++ b/src/server/handlers/request/ssr/ssr-handler.ts
@@ -165,12 +165,13 @@ export class SSRHandler extends BaseHandler {
           isProduction = ctx.proxyEnvironment === "production";
         }
 
-        setProductionMode.setProductionMode(isProduction);
+        setProductionMode.setProductionMode(isProduction, ctx.releaseId);
         if (isProduction) {
           this.logDebug("Production mode enabled - serving from releases", {
             environment: ctx.parsedDomain?.environment ?? ctx.proxyEnvironment,
             isCustomDomain: !ctx.parsedDomain?.isVeryfrontDomain,
             fromConfig: ctx.config?.fs?.veryfront?.productionMode === true,
+            releaseId: ctx.releaseId ?? "latest",
           }, ctx);
         }
       }


### PR DESCRIPTION
## Summary

This PR fixes two related issues that affect multi-project proxy mode:

### Issue #31 - Content Versioning Bugs
- **Bug 1**: Pass `releaseId` to `setProductionMode` in ssr-handler.ts
- **Bug 2**: Remove shared mutable state in `MultiProjectFSAdapter` - now uses AsyncLocalStorage context exclusively to prevent race conditions between concurrent requests
- **Bug 3**: Add `dirTree` invalidation when production mode or releaseId changes in `VeryfrontFSAdapter`
- **Bug 4**: Include production context in `readdir` cache key to prevent mixing preview/production directory entries

### Issue #32 - Preview Proxy Cannot Access User-owned Projects
- Forward user's `authToken` cookie for preview requests instead of using OAuth client credentials
- OAuth client credentials don't have access to user-owned projects, so preview URLs for private projects would fail with "Project not found"
- The user's auth token from their browser session has the correct permissions

## Changes

| File | Change |
|------|--------|
| `proxy/main.ts` | Extract and forward user's authToken cookie for preview requests |
| `src/server/handlers/request/ssr/ssr-handler.ts` | Pass `ctx.releaseId` to `setProductionMode` |
| `src/platform/adapters/multi-project-fs-adapter.ts` | Remove class-level state, update context instead |
| `src/platform/adapters/veryfront-fs-adapter/adapter.ts` | Clear `dirTree` on mode change |
| `src/platform/adapters/veryfront-fs-adapter/directory-operations.ts` | Include production context in cache key |

## Test plan

- [ ] Verify preview URLs for user-owned projects now work (previously returned 500)
- [ ] Verify production and preview content don't mix when accessed concurrently
- [ ] Verify cache invalidation works when switching between production/preview modes

Fixes #31, Fixes #32