### PR TITLE
feat: implement true HMR for preview mode with WebSocket proxy support

### DIFF
--- a/docs/guides/architecture/preview-hmr.md
+++ b/docs/guides/architecture/preview-hmr.md
@@ -1,0 +1,169 @@
+# Preview HMR (Hot Module Replacement)
+
+Live updates for cloud preview environments without full page reloads.
+
+## Overview
+
+Preview HMR enables real-time code updates in cloud preview environments (e.g., `myapp.preview.veryfront.com`). When a file is saved in Studio, the browser updates without a full page reload.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         API Server                               │
+│         (broadcasts "poke" with changedPaths to renderers)       │
+└──────────────────────────────┬──────────────────────────────────┘
+                               │ WebSocket (per-project events)
+          ┌────────────────────┼────────────────────┐
+          ▼                    ▼                    ▼
+   ┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+   │  Renderer 1  │     │  Renderer 2  │     │  Renderer 3  │
+   │ (subscribes) │     │ (subscribes) │     │ (subscribes) │
+   └──────┬───────┘     └──────┬───────┘     └──────────────┘
+          │                    │
+          ▼                    ▼
+   ┌──────────────┐     ┌──────────────┐
+   │  Browser A   │     │  Browser B   │
+   │   (HMR WS)   │     │   (HMR WS)   │
+   └──────────────┘     └──────────────┘
+```
+
+## Request Flow
+
+### HTTP Requests vs WebSocket Connections
+
+The proxy handles HTTP and WebSocket differently:
+
+**HTTP Requests:**
+```
+Browser → Proxy → Renderer → Response
+         (fetch)
+```
+- Standard request/response cycle
+- Load balanced across replicas
+- Each request can hit any replica
+
+**WebSocket Connections:**
+```
+Browser ←──────────────────→ Proxy ←──────────────────→ Renderer
+         (persistent WS)            (persistent WS)
+```
+- Persistent bidirectional connection
+- Stays connected to same replica for lifetime
+- Proxy bridges client and renderer WebSockets
+
+### HMR Update Flow
+
+1. **User saves file** in Studio
+2. **API persists** the file and broadcasts "poke" to all renderers
+3. **All renderer replicas** receive the poke (they all subscribe to project events)
+4. **Each replica** clears its cache and broadcasts HMR update to connected browsers
+5. **Browser** receives update and applies it without full reload
+
+## Components
+
+### Proxy WebSocket Handler (`proxy/main.ts`)
+
+Detects WebSocket upgrades and creates a bridge:
+
+```typescript
+if (req.headers.get("upgrade")?.toLowerCase() === "websocket") {
+  // 1. Upgrade client connection
+  const { socket: clientSocket, response } = Deno.upgradeWebSocket(req);
+
+  // 2. Connect to renderer
+  const rendererSocket = new WebSocket(rendererWsUrl);
+
+  // 3. Bridge messages bidirectionally
+  clientSocket.onmessage = (e) => rendererSocket.send(e.data);
+  rendererSocket.onmessage = (e) => clientSocket.send(e.data);
+}
+```
+
+### HMR Handler (`src/server/handlers/preview/hmr-handler.ts`)
+
+Server-side WebSocket handler for preview mode:
+
+- Listens on `/_ws` endpoint
+- Subscribes to `ReloadNotifier` for file change events
+- Broadcasts `update` messages with changed file paths
+- Only enabled when `proxyEnvironment === "preview"`
+
+### Preview HMR Client (`endpoints.ts` - `getPreviewHMRScript()`)
+
+Client-side script injected in preview mode:
+
+```javascript
+// On receiving update message:
+1. Load changed module with cache-busting URL
+2. Clear component cache: window.__veryfrontClearComponentCache()
+3. Re-render page: window.__veryfrontRenderPage(pathname)
+4. Fall back to full reload if HMR functions unavailable
+```
+
+### ReloadNotifier (`src/server/reload-notifier.ts`)
+
+Event bus for file change notifications:
+
+- `triggerReload(changedPaths?)` - Called by FSAdapter when files change
+- `subscribe(listener)` - HMRHandler subscribes to receive updates
+- Debounces rapid changes (300ms) to batch updates
+
+## Message Types
+
+| Type | Direction | Description |
+|------|-----------|-------------|
+| `update` | Server → Client | Smart update with file path |
+| `reload` | Server → Client | Full page reload (fallback) |
+| `connected` | Server → Client | Connection acknowledged |
+
+### Update Message Format
+
+```json
+{
+  "type": "update",
+  "path": "pages/index.mdx",
+  "timestamp": 1704672000000
+}
+```
+
+## Multi-Replica Support
+
+HMR works correctly with multiple proxy and renderer replicas because:
+
+1. **All renderers subscribe** to API's project event stream
+2. **WebSocket connections are persistent** - browser stays connected to one replica
+3. **Each replica independently broadcasts** to its connected browsers
+4. **No sticky sessions required** - persistent connections handle affinity naturally
+
+## CSS vs JS Updates
+
+| File Type | Update Method |
+|-----------|---------------|
+| `.css` | Hot reload via `<link>` href refresh |
+| `.tsx`, `.ts`, `.mdx`, `.jsx` | Clear component cache + re-render |
+
+## Enabling Preview HMR
+
+Preview HMR is automatically enabled when:
+- `proxyEnvironment === "preview"` (set by proxy via `x-environment` header)
+- The `/_veryfront/preview-hmr.js` script is injected into the HTML
+
+## Debugging
+
+Check browser console for HMR messages:
+```
+[Preview HMR] Connected to wss://myapp.preview.veryfront.com/_ws
+[Preview HMR] Update received for: pages/index.mdx
+[Preview HMR] Module loaded, applying update
+[Preview HMR] Component cache cleared
+[Preview HMR] Re-rendering page
+```
+
+## Related Files
+
+- `proxy/main.ts` - WebSocket proxy handler
+- `src/server/handlers/preview/hmr-handler.ts` - HMR WebSocket server
+- `src/server/handlers/dev/endpoints.ts` - Preview HMR client script
+- `src/server/reload-notifier.ts` - File change event bus
+- `src/platform/adapters/veryfront-fs-adapter/adapter.ts` - API poke handling

--- a/proxy/main.ts
+++ b/proxy/main.ts
@@ -71,10 +71,98 @@ function getScope(environment: string | null): TokenScope {
   return environment === "preview" ? "preview" : "production";
 }
 
+/**
+ * Handle WebSocket upgrade requests by proxying to renderer.
+ */
+function handleWebSocketUpgrade(req: Request): Response {
+  const url = new URL(req.url);
+  const host = req.headers.get("host") || "";
+  const parsed = parseProjectDomain(host);
+  const scope = getScope(parsed.environment);
+  const projectSlug = parsed.slug || undefined;
+
+  proxyLogger.info("WebSocket upgrade request", {
+    path: url.pathname,
+    projectSlug,
+    environment: scope,
+  });
+
+  // Upgrade the client connection
+  const { socket: clientSocket, response } = Deno.upgradeWebSocket(req);
+
+  // Build renderer WebSocket URL
+  const rendererWsUrl = RENDERER_URL.replace(/^http/, "ws");
+  const targetUrl = `${rendererWsUrl}${url.pathname}${url.search}`;
+
+  // Connect to renderer WebSocket with auth headers as query params
+  // (WebSocket doesn't support custom headers, so we pass token via query)
+  const targetUrlWithAuth = new URL(targetUrl);
+  // For preview HMR, we don't need token - it's internal renderer communication
+  targetUrlWithAuth.searchParams.set("x-project-slug", projectSlug || "");
+  targetUrlWithAuth.searchParams.set("x-environment", scope);
+
+  let rendererSocket: WebSocket | null = null;
+
+  clientSocket.onopen = () => {
+    proxyLogger.debug("Client WebSocket opened, connecting to renderer", {
+      targetUrl: targetUrlWithAuth.toString().replace(/token=[^&]+/, "token=***"),
+    });
+
+    rendererSocket = new WebSocket(targetUrlWithAuth.toString());
+
+    rendererSocket.onopen = () => {
+      proxyLogger.debug("Renderer WebSocket connected");
+    };
+
+    rendererSocket.onmessage = (event) => {
+      // Forward renderer messages to client
+      if (clientSocket.readyState === WebSocket.OPEN) {
+        clientSocket.send(event.data);
+      }
+    };
+
+    rendererSocket.onerror = (error) => {
+      proxyLogger.error("Renderer WebSocket error", { error });
+    };
+
+    rendererSocket.onclose = () => {
+      proxyLogger.debug("Renderer WebSocket closed");
+      if (clientSocket.readyState === WebSocket.OPEN) {
+        clientSocket.close();
+      }
+    };
+  };
+
+  clientSocket.onmessage = (event) => {
+    // Forward client messages to renderer
+    if (rendererSocket?.readyState === WebSocket.OPEN) {
+      rendererSocket.send(event.data);
+    }
+  };
+
+  clientSocket.onerror = (error) => {
+    proxyLogger.error("Client WebSocket error", { error });
+  };
+
+  clientSocket.onclose = () => {
+    proxyLogger.debug("Client WebSocket closed");
+    if (rendererSocket?.readyState === WebSocket.OPEN) {
+      rendererSocket.close();
+    }
+  };
+
+  return response;
+}
+
 async function handleRequest(req: Request): Promise<Response> {
   const startTime = performance.now();
   const host = req.headers.get("host") || "";
   const url = new URL(req.url);
+
+  // Handle WebSocket upgrade requests
+  if (req.headers.get("upgrade")?.toLowerCase() === "websocket") {
+    return handleWebSocketUpgrade(req);
+  }
 
   const parentContext = extractContext(req.headers);
   const spanInfo = startServerSpan(req.method, url.pathname, parentContext);

--- a/proxy/main.ts
+++ b/proxy/main.ts
@@ -116,6 +116,10 @@ function handleWebSocketUpgrade(req: Request): Response {
 
     rendererSocket.onmessage = (event) => {
       // Forward renderer messages to client
+      proxyLogger.debug("Renderer->Client message", {
+        data: typeof event.data === 'string' ? event.data.slice(0, 100) : 'binary',
+        clientState: clientSocket.readyState
+      });
       if (clientSocket.readyState === WebSocket.OPEN) {
         clientSocket.send(event.data);
       }

--- a/proxy/websocket-proxy.test.ts
+++ b/proxy/websocket-proxy.test.ts
@@ -116,7 +116,8 @@ describe("Proxy WebSocket Handler Tests", { sanitizeOps: false, sanitizeResource
       const parts = host.split(".");
 
       // For branch preview: slug--branch.preview.veryfront.com
-      const slugAndBranch = parts[0].split("--");
+      const firstPart = parts[0] ?? "";
+      const slugAndBranch = firstPart.split("--");
       const slug = slugAndBranch[0];
       const branch = slugAndBranch[1];
 

--- a/proxy/websocket-proxy.test.ts
+++ b/proxy/websocket-proxy.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Proxy WebSocket Handler Tests
+ *
+ * Tests for the WebSocket proxy functionality in the Veryfront proxy.
+ * Note: These are unit tests for the WebSocket upgrade detection logic.
+ * Full integration tests require running both proxy and renderer.
+ */
+
+import { assertEquals, assertExists } from "std/assert/mod.ts";
+import { describe, it } from "std/testing/bdd.ts";
+
+describe("Proxy WebSocket Handler Tests", { sanitizeOps: false, sanitizeResources: false }, () => {
+  describe("WebSocket Upgrade Detection", () => {
+    it("detects WebSocket upgrade request", () => {
+      const req = new Request("http://localhost:8080/_ws", {
+        headers: {
+          upgrade: "websocket",
+          connection: "upgrade",
+        },
+      });
+
+      const isWebSocket = req.headers.get("upgrade")?.toLowerCase() === "websocket";
+      assertEquals(isWebSocket, true);
+    });
+
+    it("ignores non-WebSocket requests", () => {
+      const req = new Request("http://localhost:8080/_ws");
+
+      const isWebSocket = req.headers.get("upgrade")?.toLowerCase() === "websocket";
+      assertEquals(isWebSocket, false);
+    });
+
+    it("handles case-insensitive upgrade header", () => {
+      const variants = ["websocket", "WebSocket", "WEBSOCKET", "WebSOCKET"];
+
+      for (const variant of variants) {
+        const req = new Request("http://localhost:8080/_ws", {
+          headers: { upgrade: variant },
+        });
+
+        const isWebSocket = req.headers.get("upgrade")?.toLowerCase() === "websocket";
+        assertEquals(isWebSocket, true, `Should detect '${variant}' as WebSocket upgrade`);
+      }
+    });
+  });
+
+  describe("WebSocket URL Construction", () => {
+    it("converts HTTP to WS URL", () => {
+      const rendererUrl = "http://localhost:3001";
+      const wsUrl = rendererUrl.replace(/^http/, "ws");
+
+      assertEquals(wsUrl, "ws://localhost:3001");
+    });
+
+    it("converts HTTPS to WSS URL", () => {
+      const rendererUrl = "https://renderer.example.com";
+      const wsUrl = rendererUrl.replace(/^http/, "ws");
+
+      assertEquals(wsUrl, "wss://renderer.example.com");
+    });
+
+    it("preserves path in WebSocket URL", () => {
+      const rendererUrl = "http://localhost:3001";
+      const path = "/_ws";
+      const query = "?foo=bar";
+      const targetUrl = `${rendererUrl.replace(/^http/, "ws")}${path}${query}`;
+
+      assertEquals(targetUrl, "ws://localhost:3001/_ws?foo=bar");
+    });
+  });
+
+  describe("WebSocket Query Parameters", () => {
+    it("adds project slug as query parameter", () => {
+      const baseUrl = new URL("ws://localhost:3001/_ws");
+      const projectSlug = "my-project";
+
+      baseUrl.searchParams.set("x-project-slug", projectSlug);
+
+      assertEquals(baseUrl.searchParams.get("x-project-slug"), "my-project");
+    });
+
+    it("adds environment as query parameter", () => {
+      const baseUrl = new URL("ws://localhost:3001/_ws");
+      const environment = "preview";
+
+      baseUrl.searchParams.set("x-environment", environment);
+
+      assertEquals(baseUrl.searchParams.get("x-environment"), "preview");
+    });
+
+    it("handles empty project slug", () => {
+      const baseUrl = new URL("ws://localhost:3001/_ws");
+
+      baseUrl.searchParams.set("x-project-slug", "");
+
+      assertEquals(baseUrl.searchParams.get("x-project-slug"), "");
+    });
+  });
+
+  describe("Domain Parsing for WebSocket", () => {
+    it("extracts project slug from preview domain", () => {
+      // This simulates what parseProjectDomain would return
+      const host = "myproject.preview.veryfront.com";
+      const parts = host.split(".");
+
+      // For preview domains: slug.preview.veryfront.com
+      const slug = parts[0];
+      const isPreview = parts[1] === "preview";
+
+      assertEquals(slug, "myproject");
+      assertEquals(isPreview, true);
+    });
+
+    it("extracts branch from preview domain with branch", () => {
+      const host = "myproject--feature-branch.preview.veryfront.com";
+      const parts = host.split(".");
+
+      // For branch preview: slug--branch.preview.veryfront.com
+      const slugAndBranch = parts[0].split("--");
+      const slug = slugAndBranch[0];
+      const branch = slugAndBranch[1];
+
+      assertEquals(slug, "myproject");
+      assertEquals(branch, "feature-branch");
+    });
+  });
+
+  describe("WebSocket State Management", () => {
+    it("WebSocket readyState constants are correct", () => {
+      assertEquals(WebSocket.CONNECTING, 0);
+      assertEquals(WebSocket.OPEN, 1);
+      assertEquals(WebSocket.CLOSING, 2);
+      assertEquals(WebSocket.CLOSED, 3);
+    });
+  });
+});

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -326,6 +326,12 @@ ${options.globalCSS || generateThemeVariables()}
     })
     : "";
 
+  // Preview HMR script for live updates in cloud preview mode
+  // Connects to /_ws WebSocket and reloads on file changes
+  const previewHMRScript = options.proxyEnvironment === "preview"
+    ? `<script src="/_veryfront/preview-hmr.js"${nonce ? ` nonce="${nonce}"` : ""}></script>`
+    : "";
+
   // Mermaid initialization script for diagram rendering
   const mermaidScript = `
   <!-- Mermaid diagram rendering -->
@@ -346,6 +352,7 @@ ${options.globalCSS || generateThemeVariables()}
   ${scriptTags}
   ${modeScripts}
   ${studioScripts}
+  ${previewHMRScript}
   ${mermaidScript}
 </body>
 </html>`;

--- a/src/html/types.ts
+++ b/src/html/types.ts
@@ -32,6 +32,8 @@ export interface HTMLGenerationOptions {
   sourceHash?: string;
   /** User's preferred color scheme from Sec-CH-Prefers-Color-Scheme header */
   colorScheme?: "light" | "dark";
+  /** Proxy environment for cloud deployments (preview or production) */
+  proxyEnvironment?: "preview" | "production";
 }
 
 export type { ImportMapConfig } from "../module-system/import-map/types.ts";

--- a/src/platform/adapters/veryfront-fs-adapter/adapter.ts
+++ b/src/platform/adapters/veryfront-fs-adapter/adapter.ts
@@ -330,8 +330,8 @@ export class VeryfrontFSAdapter implements FSAdapter {
       });
     }
 
-    // Notify browser to reload
-    ReloadNotifier.triggerReload();
+    // Notify browser to reload with changed paths for smart HMR
+    ReloadNotifier.triggerReload(changedPaths);
 
     const durationMs = Date.now() - startTime;
     logger.info("[VeryfrontFSAdapter] Selective invalidation complete", {

--- a/src/platform/adapters/veryfront-fs-adapter/adapter.ts
+++ b/src/platform/adapters/veryfront-fs-adapter/adapter.ts
@@ -181,12 +181,15 @@ export class VeryfrontFSAdapter implements FSAdapter {
         try {
           const data = JSON.parse(event.data as string);
           const changedPaths = data.data?.changedPaths as string[] | undefined;
-          // Only log poke messages at info level, ping/pong are debug
-          if (data.type === "poke") {
+          // Handle both legacy "poke" messages and new "entity_updated" messages from API
+          const isPoke = data.type === "poke" || data.type === "entity_updated";
+          if (isPoke) {
             logger.info("[VeryfrontFSAdapter] 🔄 POKE RECEIVED - triggering cache invalidation", {
+              type: data.type,
               source: data.data?.source,
               entityId: data.data?.entityId,
               entityType: data.data?.entityType,
+              action: data.data?.action,
               changedPathsCount: changedPaths?.length || 0,
               changedPaths: changedPaths || [],
             });

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -145,6 +145,7 @@ export class HTMLGenerator {
       pageId: context.options?.pageId,
       sourceHash,
       colorScheme: context.options?.colorScheme,
+      proxyEnvironment: context.options?.proxyEnvironment,
     };
 
     // Buffer the React stream to extract head elements
@@ -314,6 +315,7 @@ export class HTMLGenerator {
       pageId: context.options?.pageId,
       sourceHash,
       colorScheme: context.options?.colorScheme,
+      proxyEnvironment: context.options?.proxyEnvironment,
     };
 
     return await wrapInHTMLShell(

--- a/src/rendering/orchestrator/types.ts
+++ b/src/rendering/orchestrator/types.ts
@@ -48,6 +48,8 @@ export interface RenderOptions {
   pageId?: string;
   /** User's preferred color scheme from Sec-CH-Prefers-Color-Scheme client hint */
   colorScheme?: "light" | "dark";
+  /** Proxy environment for cloud deployments (preview or production) */
+  proxyEnvironment?: "preview" | "production";
 }
 
 export interface RenderContext {

--- a/src/server/dev-server/middleware.ts
+++ b/src/server/dev-server/middleware.ts
@@ -46,7 +46,10 @@ export function createRequestLoggerMiddleware() {
     }
 
     const duration = (performance.now() - start).toFixed(0);
-    if (response) response.headers.set("x-request-id", requestId);
+    // Don't modify headers for WebSocket upgrade responses (status 101) - they're immutable
+    if (response && response.status !== 101) {
+      response.headers.set("x-request-id", requestId);
+    }
 
     try {
       logger.info(

--- a/src/server/handlers/dev/endpoints.ts
+++ b/src/server/handlers/dev/endpoints.ts
@@ -17,8 +17,10 @@ export class DevEndpointsHandler extends BaseHandler {
       { pattern: "/_veryfront/dev-loader.js", exact: true },
       { pattern: "/_veryfront/hmr.js", exact: true },
       { pattern: "/_veryfront/hydrate.js", exact: true },
+      { pattern: "/_veryfront/preview-hmr.js", exact: true },
     ],
-    enabled: (ctx) => ctx.mode === "development", // Only in dev mode
+    // Enable in dev mode OR preview mode (for live updates)
+    enabled: (ctx) => ctx.mode === "development" || ctx.proxyEnvironment === "preview",
   };
 
   handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
@@ -72,6 +74,15 @@ export class DevEndpointsHandler extends BaseHandler {
     // Dev loader
     if (pathname === "/_veryfront/dev-loader.js") {
       const script = this.getDevLoader();
+      const response = builder
+        .withCache("no-cache")
+        .javascript(script, HTTP_OK);
+      return Promise.resolve(this.respond(response));
+    }
+
+    // Preview HMR script (for cloud preview mode - actually reloads)
+    if (pathname === "/_veryfront/preview-hmr.js") {
+      const script = this.getPreviewHMRScript();
       const response = builder
         .withCache("no-cache")
         .javascript(script, HTTP_OK);
@@ -313,6 +324,190 @@ if (window.__HMR_ENABLED__) {
 const errorScript = document.createElement('script');
 errorScript.src = '/_veryfront/error-overlay.js';
 document.head.appendChild(errorScript);
+    `.trim();
+  }
+
+  /**
+   * Preview HMR script for cloud preview mode.
+   * Implements true HMR with module cache clearing and re-rendering,
+   * matching the local dev server behavior. Falls back to full reload
+   * when HMR functions aren't available.
+   */
+  private getPreviewHMRScript(): string {
+    return `
+// Veryfront Preview HMR Client
+// Connects to /_ws WebSocket and handles true HMR updates
+
+(function() {
+  // Notify Studio that the app is ready (clears loading indicator)
+  if (window.parent !== window) {
+    try {
+      window.parent.postMessage({
+        action: 'appUpdated',
+        isInitialLoad: true,
+        url: window.location.href
+      }, '*');
+    } catch (e) { /* postMessage may fail in cross-origin iframes */ }
+  }
+
+  // Determine WebSocket URL (same host, use wss for https)
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const wsUrl = protocol + '//' + window.location.host + '/_ws';
+
+  let ws = null;
+  let reconnectAttempts = 0;
+  const maxReconnectAttempts = 10;
+  const reconnectDelay = 2000;
+
+  function connect() {
+    if (reconnectAttempts >= maxReconnectAttempts) {
+      console.log('[Preview HMR] Max reconnection attempts reached');
+      return;
+    }
+
+    ws = new WebSocket(wsUrl);
+
+    ws.onopen = () => {
+      console.log('[Preview HMR] Connected to', wsUrl);
+      reconnectAttempts = 0;
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+
+        switch (data.type) {
+          case 'update':
+            handleUpdate(data);
+            break;
+          case 'reload':
+            console.log('[Preview HMR] Full reload requested');
+            notifyStudioAndReload();
+            break;
+          case 'connected':
+            console.log('[Preview HMR] Server acknowledged connection');
+            break;
+          default:
+            console.log('[Preview HMR] Unknown message type:', data.type);
+        }
+      } catch (e) {
+        console.error('[Preview HMR] Failed to parse message', e);
+      }
+    };
+
+    ws.onerror = (error) => {
+      console.error('[Preview HMR] WebSocket error', error);
+    };
+
+    ws.onclose = () => {
+      console.log('[Preview HMR] Connection closed, reconnecting...');
+      reconnectAttempts++;
+      setTimeout(connect, reconnectDelay);
+    };
+  }
+
+  function handleUpdate(update) {
+    if (!update.path) {
+      console.warn('[Preview HMR] Update message missing path');
+      return;
+    }
+
+    console.log('[Preview HMR] Update received for:', update.path);
+
+    // Handle CSS updates without full reload
+    if (update.path.endsWith('.css')) {
+      updateCSS(update.path);
+      notifyStudio();
+      return;
+    }
+
+    // Handle JS/TSX/MDX updates
+    updateJS(update.path);
+  }
+
+  function updateCSS(path) {
+    console.log('[Preview HMR] Updating CSS:', path);
+    document.querySelectorAll('link[rel="stylesheet"]').forEach((link) => {
+      try {
+        const url = new URL(link.href);
+        if (url.pathname === path || url.pathname.includes(path)) {
+          const newUrl = new URL(link.href);
+          newUrl.searchParams.set('t', Date.now().toString());
+          link.href = newUrl.toString();
+          console.log('[Preview HMR] CSS updated:', path);
+        }
+      } catch (error) {
+        console.error('[Preview HMR] Failed to update CSS link:', error);
+      }
+    });
+  }
+
+  function updateJS(path) {
+    console.log('[Preview HMR] Updating JS module:', path);
+    try {
+      // Load the changed module with cache busting to get fresh code
+      const cacheBusted = path + (path.includes('?') ? '&' : '?') + 't=' + Date.now();
+      const script = document.createElement('script');
+      script.type = 'module';
+      script.crossOrigin = 'anonymous';
+
+      script.onload = () => {
+        console.log('[Preview HMR] Module loaded, applying update');
+        // Clear component cache to ensure fresh components are loaded
+        if (window.__veryfrontClearComponentCache) {
+          window.__veryfrontClearComponentCache();
+          console.log('[Preview HMR] Component cache cleared');
+        }
+
+        // Re-render the page with fresh components
+        if (window.__veryfrontRenderPage) {
+          console.log('[Preview HMR] Re-rendering page');
+          window.__veryfrontRenderPage(window.location.pathname);
+          notifyStudio();
+        } else {
+          // Fall back to full reload if re-render function not available
+          console.log('[Preview HMR] No __veryfrontRenderPage, falling back to reload');
+          notifyStudioAndReload();
+        }
+      };
+
+      script.onerror = () => {
+        console.log('[Preview HMR] Module load failed, falling back to reload');
+        notifyStudioAndReload();
+      };
+
+      script.src = cacheBusted;
+      document.head.appendChild(script);
+    } catch (error) {
+      console.error('[Preview HMR] Failed to update JS module:', error);
+      notifyStudioAndReload();
+    }
+  }
+
+  function notifyStudio() {
+    if (window.parent !== window) {
+      try {
+        window.parent.postMessage({
+          action: 'appUpdated',
+          isInitialLoad: false,
+          url: window.location.href
+        }, '*');
+      } catch (e) { /* ignore */ }
+    }
+  }
+
+  function notifyStudioAndReload() {
+    notifyStudio();
+    // Small delay to let Studio know, then reload
+    setTimeout(() => window.location.reload(), 100);
+  }
+
+  // Start connection
+  connect();
+
+  // Expose for debugging
+  window.__veryfrontPreviewHMR = { getSocket: () => ws };
+})();
     `.trim();
   }
 }

--- a/src/server/handlers/preview/hmr-handler.ts
+++ b/src/server/handlers/preview/hmr-handler.ts
@@ -1,0 +1,185 @@
+/**
+ * HMR Handler for Preview Mode
+ *
+ * Provides Hot Module Replacement WebSocket support for cloud preview environments.
+ * Listens to ReloadNotifier events (triggered by API poke) and broadcasts to browsers.
+ *
+ * Only enabled when proxyEnvironment === "preview" (not production).
+ */
+
+import { serverLogger as logger } from "@veryfront/utils";
+import { BaseHandler } from "../response/base.ts";
+import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
+import { ReloadNotifier } from "../../reload-notifier.ts";
+import { setupWebSocketHandlers, RateLimiter } from "@veryfront/modules/server/index.ts";
+import { HMR_MAX_MESSAGE_SIZE_BYTES, HMR_MAX_MESSAGES_PER_MINUTE } from "@veryfront/utils";
+
+// Priority between auth (0) and cors (50)
+const PRIORITY_HMR = 25 as HandlerPriority;
+
+export class HMRHandler extends BaseHandler {
+  private static clients = new Set<WebSocket>();
+  private static rateLimiter = new RateLimiter(HMR_MAX_MESSAGES_PER_MINUTE);
+  private static reloadUnsubscribe: (() => void) | null = null;
+  private static initialized = false;
+
+  metadata: HandlerMetadata = {
+    name: "HMRHandler",
+    priority: PRIORITY_HMR,
+    patterns: [{ pattern: "/_ws", exact: true }],
+    // Only enable in preview mode (not production)
+    enabled: (ctx) => ctx.proxyEnvironment === "preview",
+  };
+
+  /**
+   * Initialize HMR subscriptions (called once)
+   */
+  private static initialize(): void {
+    if (HMRHandler.initialized) return;
+    HMRHandler.initialized = true;
+
+    // Subscribe to ReloadNotifier to broadcast HMR messages
+    // When changedPaths are provided, send update messages for smart HMR
+    // Otherwise, send reload message for full page refresh
+    HMRHandler.reloadUnsubscribe = ReloadNotifier.subscribe((changedPaths) => {
+      HMRHandler.broadcastUpdate(changedPaths);
+    });
+
+    logger.info("[HMRHandler] Initialized - listening for reload events");
+  }
+
+  /**
+   * Broadcast HMR update to all connected clients
+   * Sends individual update messages for each changed path when available
+   * Falls back to reload message if no paths provided
+   */
+  private static broadcastUpdate(changedPaths?: string[]): void {
+    const timestamp = Date.now();
+
+    // If we have specific changed paths, send update messages for smart HMR
+    // This allows the client to update only changed modules without full reload
+    if (changedPaths && changedPaths.length > 0) {
+      for (const path of changedPaths) {
+        const message = JSON.stringify({
+          type: "update",
+          path,
+          timestamp,
+        });
+        HMRHandler.broadcastMessage(message);
+      }
+      logger.info("[HMRHandler] Broadcast update", {
+        changedPaths: changedPaths.length,
+        totalClients: HMRHandler.clients.size,
+      });
+    } else {
+      // No specific paths - fall back to full reload
+      const message = JSON.stringify({
+        type: "reload",
+        timestamp,
+      });
+      HMRHandler.broadcastMessage(message);
+      logger.info("[HMRHandler] Broadcast reload (no paths)", {
+        totalClients: HMRHandler.clients.size,
+      });
+    }
+  }
+
+  /**
+   * Send a message to all connected WebSocket clients
+   */
+  private static broadcastMessage(message: string): void {
+    for (const client of HMRHandler.clients) {
+      if (client.readyState === WebSocket.OPEN) {
+        try {
+          client.send(message);
+        } catch (error) {
+          logger.debug("[HMRHandler] Failed to send to client", { error });
+        }
+      }
+    }
+  }
+
+  handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
+    const url = new URL(req.url);
+
+    if (!this.shouldHandle(req, ctx)) {
+      return Promise.resolve(this.continue());
+    }
+
+    // Initialize on first request
+    HMRHandler.initialize();
+
+    // Check for WebSocket upgrade
+    if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      // Not a WebSocket request to /_ws - return info
+      const response = new Response(
+        JSON.stringify({
+          status: "ok",
+          clients: HMRHandler.clients.size,
+          message: "HMR WebSocket endpoint - connect via WebSocket",
+        }),
+        {
+          headers: { "content-type": "application/json" },
+        },
+      );
+      return Promise.resolve(this.respond(response));
+    }
+
+    // Upgrade to WebSocket
+    if (!ctx.adapter?.server) {
+      const response = new Response("WebSocket not supported", { status: 501 });
+      return Promise.resolve(this.respond(response));
+    }
+
+    try {
+      const { socket, response } = ctx.adapter.server.upgradeWebSocket(req);
+
+      // Setup WebSocket handlers using shared module
+      setupWebSocketHandlers(socket, {
+        clients: HMRHandler.clients,
+        rateLimiter: HMRHandler.rateLimiter,
+        maxMessageSize: HMR_MAX_MESSAGE_SIZE_BYTES,
+        reactRefresh: false,
+      });
+
+      logger.info("[HMRHandler] WebSocket client connected", {
+        totalClients: HMRHandler.clients.size + 1,
+      });
+
+      return Promise.resolve(this.respond(response));
+    } catch (error) {
+      logger.error("[HMRHandler] WebSocket upgrade failed", { error });
+      const response = new Response("WebSocket upgrade failed", { status: 500 });
+      return Promise.resolve(this.respond(response));
+    }
+  }
+
+  /**
+   * Get the number of connected clients (for monitoring)
+   */
+  static getClientCount(): number {
+    return HMRHandler.clients.size;
+  }
+
+  /**
+   * Cleanup resources on shutdown
+   */
+  static shutdown(): void {
+    if (HMRHandler.reloadUnsubscribe) {
+      HMRHandler.reloadUnsubscribe();
+      HMRHandler.reloadUnsubscribe = null;
+    }
+
+    for (const client of HMRHandler.clients) {
+      try {
+        client.close();
+      } catch {
+        // Ignore close errors
+      }
+    }
+    HMRHandler.clients.clear();
+    HMRHandler.initialized = false;
+
+    logger.info("[HMRHandler] Shutdown complete");
+  }
+}

--- a/src/server/handlers/preview/hmr-handler.ts
+++ b/src/server/handlers/preview/hmr-handler.ts
@@ -11,7 +11,7 @@ import { serverLogger as logger } from "@veryfront/utils";
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { ReloadNotifier } from "../../reload-notifier.ts";
-import { setupWebSocketHandlers, RateLimiter } from "@veryfront/modules/server/index.ts";
+import { RateLimiter, setupWebSocketHandlers } from "@veryfront/modules/server/index.ts";
 import { HMR_MAX_MESSAGE_SIZE_BYTES, HMR_MAX_MESSAGES_PER_MINUTE } from "@veryfront/utils";
 
 // Priority between auth (0) and cors (50)
@@ -100,8 +100,6 @@ export class HMRHandler extends BaseHandler {
   }
 
   handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
-    const url = new URL(req.url);
-
     if (!this.shouldHandle(req, ctx)) {
       return Promise.resolve(this.continue());
     }

--- a/src/server/handlers/request/ssr/ssr-handler.ts
+++ b/src/server/handlers/request/ssr/ssr-handler.ts
@@ -291,6 +291,7 @@ export class SSRHandler extends BaseHandler {
           projectId,
           pageId,
           colorScheme,
+          proxyEnvironment: ctx.proxyEnvironment,
         }));
       this.logDebug("SSR successful", { slug, params }, ctx);
       endRequest(requestId);

--- a/src/server/reload-notifier.ts
+++ b/src/server/reload-notifier.ts
@@ -7,9 +7,11 @@
  * Two event types:
  * - invalidate: Triggered immediately when files change (for clearing caches)
  * - reload: Debounced for browser refresh (to batch rapid changes)
+ *
+ * When changedPaths are provided, HMR can do smart updates instead of full reload.
  */
 
-type ReloadListener = () => void;
+type ReloadListener = (changedPaths?: string[]) => void;
 type InvalidateListener = () => void;
 
 const DEBOUNCE_MS = 300;
@@ -18,9 +20,11 @@ class ReloadNotifierImpl {
   private listeners = new Set<ReloadListener>();
   private invalidateListeners = new Set<InvalidateListener>();
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingChangedPaths: Set<string> = new Set();
 
   /**
    * Subscribe to reload notifications (debounced, for browser refresh)
+   * Listener receives changedPaths if available for smart HMR updates
    */
   subscribe(listener: ReloadListener): () => void {
     this.listeners.add(listener);
@@ -37,12 +41,21 @@ class ReloadNotifierImpl {
 
   /**
    * Trigger a reload notification to all subscribers (debounced)
+   * @param changedPaths - Optional array of changed file paths for smart HMR
    */
-  triggerReload(): void {
+  triggerReload(changedPaths?: string[]): void {
     console.log("[ReloadNotifier] ✅ triggerReload called", {
       invalidateListeners: this.invalidateListeners.size,
       reloadListeners: this.listeners.size,
+      changedPaths: changedPaths?.length ?? 0,
     });
+
+    // Accumulate changed paths for batching
+    if (changedPaths) {
+      for (const path of changedPaths) {
+        this.pendingChangedPaths.add(path);
+      }
+    }
 
     // First, trigger immediate invalidation for cache clearing
     this.notifyInvalidateListeners();
@@ -53,10 +66,15 @@ class ReloadNotifierImpl {
     }
     this.debounceTimer = setTimeout(() => {
       this.debounceTimer = null;
+      const paths = this.pendingChangedPaths.size > 0
+        ? Array.from(this.pendingChangedPaths)
+        : undefined;
+      this.pendingChangedPaths.clear();
       console.log("[ReloadNotifier] ✅ Debounce complete, notifying reload listeners", {
         listenerCount: this.listeners.size,
+        changedPaths: paths?.length ?? 0,
       });
-      this.notifyListeners();
+      this.notifyListeners(paths);
     }, DEBOUNCE_MS);
   }
 
@@ -74,13 +92,14 @@ class ReloadNotifierImpl {
     console.log("[ReloadNotifier] ✅ Invalidate listeners notified");
   }
 
-  private notifyListeners(): void {
+  private notifyListeners(changedPaths?: string[]): void {
     console.log("[ReloadNotifier] ✅ Notifying reload listeners", {
       count: this.listeners.size,
+      changedPaths: changedPaths?.length ?? 0,
     });
     for (const listener of this.listeners) {
       try {
-        listener();
+        listener(changedPaths);
       } catch (error) {
         console.error("[ReloadNotifier] Listener error:", error);
       }

--- a/src/server/universal-handler/index.ts
+++ b/src/server/universal-handler/index.ts
@@ -221,9 +221,12 @@ export function createVeryfrontHandler(
       const parsedDomain = parseProjectDomain(host);
 
       // Check for proxy-provided headers (from Deno proxy)
+      // For WebSocket requests, also check query params since custom headers aren't supported
       const proxyToken = req.headers.get("x-token") || undefined;
-      const proxySlug = req.headers.get("x-project-slug") || undefined;
-      let proxyEnv = req.headers.get("x-environment") as "preview" | "production" | undefined;
+      const proxySlug = req.headers.get("x-project-slug") ||
+        _url.searchParams.get("x-project-slug") || undefined;
+      let proxyEnv = (req.headers.get("x-environment") ||
+        _url.searchParams.get("x-environment")) as "preview" | "production" | undefined;
       const forwardedHost = req.headers.get("x-forwarded-host") || undefined;
 
       // Get project slug: proxy header > URL parsing > config

--- a/src/server/universal-handler/index.ts
+++ b/src/server/universal-handler/index.ts
@@ -73,6 +73,7 @@ import { ModuleHandler } from "../handlers/request/module/index.ts";
 import { ApiHandlerWrapper } from "../handlers/request/api/index.ts";
 import { SSRHandler } from "../handlers/request/ssr/index.ts";
 import { NotFoundHandler } from "../handlers/response/not-found.ts";
+import { HMRHandler } from "../handlers/preview/hmr-handler.ts";
 
 export interface UniversalHandlerOptions {
   projectDir: string;
@@ -148,6 +149,7 @@ export function createVeryfrontHandler(
   // Register handlers in priority order
   registry.registerAll([
     new AuthHandler(), // Priority: 0 (CRITICAL)
+    new HMRHandler(), // Priority: 25 (preview mode HMR WebSocket)
     new CorsHandler(), // Priority: 50
     new HealthHandler(), // Priority: 100 (HIGH)
     new MetricsHandler(), // Priority: 100 (HIGH)

--- a/tests/integration/server/modules/hmr-handler.test.ts
+++ b/tests/integration/server/modules/hmr-handler.test.ts
@@ -32,8 +32,10 @@ describe("HMR Handler Tests", { sanitizeOps: false, sanitizeResources: false }, 
       assertEquals(handler.metadata.priority, 25);
       assertExists(handler.metadata.patterns);
       assertEquals(handler.metadata.patterns.length, 1);
-      assertEquals(handler.metadata.patterns[0].pattern, "/_ws");
-      assertEquals(handler.metadata.patterns[0].exact, true);
+      const firstPattern = handler.metadata.patterns[0];
+      assertExists(firstPattern);
+      assertEquals(firstPattern.pattern, "/_ws");
+      assertEquals(firstPattern.exact, true);
     });
 
     it("is enabled only in preview mode", () => {

--- a/tests/integration/server/modules/hmr-handler.test.ts
+++ b/tests/integration/server/modules/hmr-handler.test.ts
@@ -1,0 +1,126 @@
+// Disable LRU intervals during testing to prevent resource leaks
+(globalThis as Record<string, unknown>).__vfDisableLruInterval = true;
+
+/**
+ * HMR Handler Tests
+ *
+ * Tests for the Preview HMR WebSocket handler:
+ * - Message broadcasting
+ * - Update types (update vs reload)
+ * - Client management
+ */
+
+import { assert, assertEquals, assertExists } from "std/assert/mod.ts";
+import { afterAll, afterEach, beforeEach, describe, it } from "std/testing/bdd.ts";
+import { HMRHandler } from "../../../../src/server/handlers/preview/hmr-handler.ts";
+import { cleanupBundler } from "../../../../src/rendering/cleanup.ts";
+
+describe("HMR Handler Tests", { sanitizeOps: false, sanitizeResources: false }, () => {
+  afterAll(async () => {
+    await cleanupBundler();
+  });
+
+  afterEach(() => {
+    HMRHandler.shutdown();
+  });
+
+  describe("HMR Handler - Metadata", () => {
+    it("has correct metadata", () => {
+      const handler = new HMRHandler();
+
+      assertEquals(handler.metadata.name, "HMRHandler");
+      assertEquals(handler.metadata.priority, 25);
+      assertExists(handler.metadata.patterns);
+      assertEquals(handler.metadata.patterns.length, 1);
+      assertEquals(handler.metadata.patterns[0].pattern, "/_ws");
+      assertEquals(handler.metadata.patterns[0].exact, true);
+    });
+
+    it("is enabled only in preview mode", () => {
+      const handler = new HMRHandler();
+
+      // Should be enabled in preview mode
+      const previewCtx = { proxyEnvironment: "preview" } as Parameters<
+        NonNullable<typeof handler.metadata.enabled>
+      >[0];
+      assertEquals(handler.metadata.enabled?.(previewCtx), true);
+
+      // Should be disabled in production mode
+      const productionCtx = { proxyEnvironment: "production" } as Parameters<
+        NonNullable<typeof handler.metadata.enabled>
+      >[0];
+      assertEquals(handler.metadata.enabled?.(productionCtx), false);
+
+      // Should be disabled when no proxyEnvironment
+      const noEnvCtx = {} as Parameters<
+        NonNullable<typeof handler.metadata.enabled>
+      >[0];
+      assertEquals(handler.metadata.enabled?.(noEnvCtx), false);
+    });
+  });
+
+  describe("HMR Handler - Client Management", () => {
+    it("starts with zero clients", () => {
+      assertEquals(HMRHandler.getClientCount(), 0);
+    });
+
+    it("shutdown clears all state", () => {
+      HMRHandler.shutdown();
+      assertEquals(HMRHandler.getClientCount(), 0);
+    });
+  });
+
+  describe("HMR Handler - Non-WebSocket Requests", () => {
+    it("returns info response for non-WebSocket requests", async () => {
+      const handler = new HMRHandler();
+
+      const req = new Request("http://localhost:3000/_ws");
+      const ctx = {
+        proxyEnvironment: "preview",
+        mode: "development",
+        projectDir: "/tmp/test",
+        securityConfig: null,
+        cspUserHeader: null,
+        adapter: {
+          fs: {},
+          server: null, // No server adapter - simulates no WebSocket support
+        },
+      } as unknown as Parameters<typeof handler.handle>[1];
+
+      const result = await handler.handle(req, ctx);
+
+      // Should respond (not continue) - check for response property
+      assertExists(result.response);
+      assertEquals(result.response.status, 200);
+
+      const body = await result.response.json();
+      assertEquals(body.status, "ok");
+      assertEquals(body.clients, 0);
+      assert(body.message.includes("WebSocket"));
+    });
+
+    it("returns 501 for WebSocket upgrade without adapter server", async () => {
+      const handler = new HMRHandler();
+
+      const req = new Request("http://localhost:3000/_ws", {
+        headers: { upgrade: "websocket" },
+      });
+      const ctx = {
+        proxyEnvironment: "preview",
+        mode: "development",
+        projectDir: "/tmp/test",
+        securityConfig: null,
+        cspUserHeader: null,
+        adapter: {
+          fs: {},
+          server: null, // No server adapter - simulates no WebSocket support
+        },
+      } as unknown as Parameters<typeof handler.handle>[1];
+
+      const result = await handler.handle(req, ctx);
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 501);
+    });
+  });
+});

--- a/tests/integration/server/modules/reload-notifier.test.ts
+++ b/tests/integration/server/modules/reload-notifier.test.ts
@@ -1,0 +1,221 @@
+// Disable LRU intervals during testing to prevent resource leaks
+(globalThis as Record<string, unknown>).__vfDisableLruInterval = true;
+
+/**
+ * ReloadNotifier Tests
+ *
+ * Tests for the reload notification system:
+ * - Subscription management
+ * - Event triggering
+ * - Debouncing behavior
+ * - ChangedPaths support for smart HMR
+ */
+
+import { assert, assertEquals } from "std/assert/mod.ts";
+import { afterAll, afterEach, beforeEach, describe, it } from "std/testing/bdd.ts";
+import { ReloadNotifier } from "../../../../src/server/reload-notifier.ts";
+import { cleanupBundler } from "../../../../src/rendering/cleanup.ts";
+
+describe("ReloadNotifier Tests", { sanitizeOps: false, sanitizeResources: false }, () => {
+  afterAll(async () => {
+    await cleanupBundler();
+  });
+
+  describe("ReloadNotifier - Subscription Management", () => {
+    it("starts with zero listeners", () => {
+      assertEquals(ReloadNotifier.getListenerCount(), 0);
+      assertEquals(ReloadNotifier.getInvalidateListenerCount(), 0);
+    });
+
+    it("can subscribe and unsubscribe reload listeners", () => {
+      const listener = () => {};
+
+      assertEquals(ReloadNotifier.getListenerCount(), 0);
+
+      const unsubscribe = ReloadNotifier.subscribe(listener);
+      assertEquals(ReloadNotifier.getListenerCount(), 1);
+
+      unsubscribe();
+      assertEquals(ReloadNotifier.getListenerCount(), 0);
+    });
+
+    it("can subscribe and unsubscribe invalidate listeners", () => {
+      const listener = () => {};
+
+      assertEquals(ReloadNotifier.getInvalidateListenerCount(), 0);
+
+      const unsubscribe = ReloadNotifier.subscribeInvalidate(listener);
+      assertEquals(ReloadNotifier.getInvalidateListenerCount(), 1);
+
+      unsubscribe();
+      assertEquals(ReloadNotifier.getInvalidateListenerCount(), 0);
+    });
+
+    it("supports multiple listeners", () => {
+      const listeners = [() => {}, () => {}, () => {}];
+      const unsubscribers: (() => void)[] = [];
+
+      for (const listener of listeners) {
+        unsubscribers.push(ReloadNotifier.subscribe(listener));
+      }
+
+      assertEquals(ReloadNotifier.getListenerCount(), 3);
+
+      // Unsubscribe in reverse order
+      for (const unsub of unsubscribers.reverse()) {
+        unsub();
+      }
+
+      assertEquals(ReloadNotifier.getListenerCount(), 0);
+    });
+  });
+
+  describe("ReloadNotifier - Invalidate Events", () => {
+    it("triggers invalidate listeners immediately", async () => {
+      let invalidateCalled = false;
+
+      const unsubscribe = ReloadNotifier.subscribeInvalidate(() => {
+        invalidateCalled = true;
+      });
+
+      ReloadNotifier.triggerReload();
+
+      // Invalidate should be called immediately (not debounced)
+      assertEquals(invalidateCalled, true);
+
+      unsubscribe();
+    });
+  });
+
+  describe("ReloadNotifier - ChangedPaths Support", () => {
+    it("passes changedPaths to reload listeners after debounce", async () => {
+      let receivedPaths: string[] | undefined;
+
+      const unsubscribe = ReloadNotifier.subscribe((paths) => {
+        receivedPaths = paths;
+      });
+
+      ReloadNotifier.triggerReload(["pages/index.mdx", "components/Button.tsx"]);
+
+      // Wait for debounce (300ms + buffer)
+      await new Promise((resolve) => setTimeout(resolve, 400));
+
+      assertEquals(receivedPaths?.length, 2);
+      assert(receivedPaths?.includes("pages/index.mdx"));
+      assert(receivedPaths?.includes("components/Button.tsx"));
+
+      unsubscribe();
+    });
+
+    it("accumulates changedPaths during debounce window", async () => {
+      let receivedPaths: string[] | undefined;
+
+      const unsubscribe = ReloadNotifier.subscribe((paths) => {
+        receivedPaths = paths;
+      });
+
+      // Trigger multiple times within debounce window
+      ReloadNotifier.triggerReload(["pages/index.mdx"]);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      ReloadNotifier.triggerReload(["components/Button.tsx"]);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      ReloadNotifier.triggerReload(["lib/utils.ts"]);
+
+      // Wait for debounce to complete
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Should have all accumulated paths
+      assertEquals(receivedPaths?.length, 3);
+      assert(receivedPaths?.includes("pages/index.mdx"));
+      assert(receivedPaths?.includes("components/Button.tsx"));
+      assert(receivedPaths?.includes("lib/utils.ts"));
+
+      unsubscribe();
+    });
+
+    it("deduplicates changedPaths", async () => {
+      let receivedPaths: string[] | undefined;
+
+      const unsubscribe = ReloadNotifier.subscribe((paths) => {
+        receivedPaths = paths;
+      });
+
+      // Trigger same path multiple times
+      ReloadNotifier.triggerReload(["pages/index.mdx"]);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      ReloadNotifier.triggerReload(["pages/index.mdx"]);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      ReloadNotifier.triggerReload(["pages/index.mdx"]);
+
+      // Wait for debounce
+      await new Promise((resolve) => setTimeout(resolve, 400));
+
+      // Should only have one entry (deduplicated via Set)
+      assertEquals(receivedPaths?.length, 1);
+      assertEquals(receivedPaths?.[0], "pages/index.mdx");
+
+      unsubscribe();
+    });
+
+    it("handles empty changedPaths array", async () => {
+      let receivedPaths: string[] | undefined;
+
+      const unsubscribe = ReloadNotifier.subscribe((paths) => {
+        receivedPaths = paths;
+      });
+
+      ReloadNotifier.triggerReload([]);
+
+      // Wait for debounce
+      await new Promise((resolve) => setTimeout(resolve, 400));
+
+      // Should be undefined when no paths provided
+      assertEquals(receivedPaths, undefined);
+
+      unsubscribe();
+    });
+
+    it("handles undefined changedPaths", async () => {
+      let receivedPaths: string[] | undefined;
+
+      const unsubscribe = ReloadNotifier.subscribe((paths) => {
+        receivedPaths = paths;
+      });
+
+      ReloadNotifier.triggerReload();
+
+      // Wait for debounce
+      await new Promise((resolve) => setTimeout(resolve, 400));
+
+      // Should be undefined when no paths provided
+      assertEquals(receivedPaths, undefined);
+
+      unsubscribe();
+    });
+  });
+
+  describe("ReloadNotifier - Error Handling", () => {
+    it("continues notifying other listeners if one throws", async () => {
+      let secondListenerCalled = false;
+
+      const unsubscribe1 = ReloadNotifier.subscribe(() => {
+        throw new Error("Listener error");
+      });
+
+      const unsubscribe2 = ReloadNotifier.subscribe(() => {
+        secondListenerCalled = true;
+      });
+
+      ReloadNotifier.triggerReload();
+
+      // Wait for debounce
+      await new Promise((resolve) => setTimeout(resolve, 400));
+
+      // Second listener should still be called
+      assertEquals(secondListenerCalled, true);
+
+      unsubscribe1();
+      unsubscribe2();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Enables hot module replacement in cloud preview environments without full page reloads. Changes are reflected instantly when files are saved in Studio.

**Key changes:**
- Add WebSocket proxy support to handle HMR connections through the proxy
- Add HMRHandler on renderer for preview mode WebSocket endpoint (`/_ws`)
- Update ReloadNotifier to pass changed file paths for smart module updates
- Implement true HMR client that clears component cache and re-renders

## Architecture

```
┌─────────────────────────────────────────────────────────────────┐
│                         API Server                               │
│         (broadcasts "poke" with changedPaths to renderers)       │
└──────────────────────────────┬──────────────────────────────────┘
                               │ WebSocket (per-project events)
          ┌────────────────────┼────────────────────┐
          ▼                    ▼                    ▼
   ┌──────────────┐     ┌──────────────┐     ┌──────────────┐
   │  Renderer 1  │     │  Renderer 2  │     │  Renderer 3  │
   │ (subscribes) │     │ (subscribes) │     │ (subscribes) │
   └──────┬───────┘     └──────┬───────┘     └──────────────┘
          │                    │
          ▼                    ▼
   ┌──────────────┐     ┌──────────────┐
   │  Browser A   │     │  Browser B   │
   │   (HMR WS)   │     │   (HMR WS)   │
   └──────────────┘     └──────────────┘
```

**Works with multiple replicas** because:
- All renderers subscribe to API project events
- WebSocket connections are persistent to same replica
- Each replica broadcasts to its connected browsers

## Test plan

- [ ] Test HMR in local preview mode (lvh.me)
- [ ] Deploy to staging and test HMR via Studio
- [ ] Verify component updates don't cause full page reload
- [ ] Test CSS hot reload without page refresh
- [ ] Verify multi-replica behavior

## Documentation

Added `docs/guides/architecture/preview-hmr.md` explaining the system.