### PR TITLE
fix: update add-to-project action to v1.0.2

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -18,7 +18,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           PROJECT_TOKEN: op://VERYFRONT_CI/GITHUB_VERYFRONT_PAT/credential
 
-      - uses: actions/add-to-project@v1
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/veryfront/projects/3
           github-token: ${{ env.PROJECT_TOKEN }}


### PR DESCRIPTION
The `actions/add-to-project@v1` tag no longer exists. Updated to `v1.0.2`.