### PR TITLE
refactor(renderer): add tests and improve config

### DIFF
--- a/src/server/handlers/request/ssr/is-production-mode.test.ts
+++ b/src/server/handlers/request/ssr/is-production-mode.test.ts
@@ -1,0 +1,66 @@
+import { assertEquals } from "https://deno.land/std@0.220.0/assert/mod.ts";
+import { isProductionMode } from "./ssr-handler.ts";
+import type { HandlerContext } from "../../types.ts";
+
+function createContext(overrides: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    projectDir: "/test",
+    adapter: {} as HandlerContext["adapter"],
+    mode: "production",
+    securityConfig: null,
+    cspUserHeader: null,
+    ...overrides,
+  };
+}
+
+const prodConfig = { fs: { veryfront: { apiBaseUrl: "http://test", productionMode: true } } };
+
+Deno.test("isProductionMode", async (t) => {
+  await t.step("returns true when config.productionMode is true", () => {
+    const ctx = createContext({ config: prodConfig });
+    assertEquals(isProductionMode(ctx), true);
+  });
+
+  await t.step("config.productionMode takes priority over domain", () => {
+    const ctx = createContext({
+      config: prodConfig,
+      parsedDomain: { isVeryfrontDomain: true, isDraft: true, slug: "test", branch: null, environment: "preview" },
+    });
+    assertEquals(isProductionMode(ctx), true);
+  });
+
+  await t.step("returns true for veryfront domain when isDraft is false", () => {
+    const ctx = createContext({
+      parsedDomain: { isVeryfrontDomain: true, isDraft: false, slug: "test", branch: null, environment: "production" },
+    });
+    assertEquals(isProductionMode(ctx), true);
+  });
+
+  await t.step("returns false for veryfront domain when isDraft is true", () => {
+    const ctx = createContext({
+      parsedDomain: { isVeryfrontDomain: true, isDraft: true, slug: "test", branch: null, environment: "preview" },
+    });
+    assertEquals(isProductionMode(ctx), false);
+  });
+
+  await t.step("returns true for custom domain with production proxy environment", () => {
+    const ctx = createContext({
+      parsedDomain: { isVeryfrontDomain: false, isDraft: false, slug: null, branch: null, environment: null },
+      proxyEnvironment: "production",
+    });
+    assertEquals(isProductionMode(ctx), true);
+  });
+
+  await t.step("returns false for custom domain with preview proxy environment", () => {
+    const ctx = createContext({
+      parsedDomain: { isVeryfrontDomain: false, isDraft: false, slug: null, branch: null, environment: null },
+      proxyEnvironment: "preview",
+    });
+    assertEquals(isProductionMode(ctx), false);
+  });
+
+  await t.step("returns false when no indicators present", () => {
+    const ctx = createContext({});
+    assertEquals(isProductionMode(ctx), false);
+  });
+});

--- a/src/server/handlers/request/ssr/ssr-handler.ts
+++ b/src/server/handlers/request/ssr/ssr-handler.ts
@@ -42,7 +42,7 @@ import { isMultiProjectAdapter } from "@veryfront/platform/adapters/multi-projec
  * Determine if request should serve production (released) content.
  * Priority: config > veryfront domain isDraft flag > proxy environment header
  */
-function isProductionMode(ctx: HandlerContext): boolean {
+export function isProductionMode(ctx: HandlerContext): boolean {
   // Config override (PRODUCTION_MODE env var)
   if (ctx.config?.fs?.veryfront?.productionMode === true) {
     return true;

--- a/src/server/universal-handler/index.ts
+++ b/src/server/universal-handler/index.ts
@@ -81,7 +81,7 @@ const VALID_PROXY_ENVIRONMENTS = ["preview", "production"] as const;
 type ProxyEnvironment = (typeof VALID_PROXY_ENVIRONMENTS)[number];
 
 /** Validate and parse proxy environment header */
-function parseProxyEnvironment(value: string | null): ProxyEnvironment | undefined {
+export function parseProxyEnvironment(value: string | null): ProxyEnvironment | undefined {
   if (!value) return undefined;
   return VALID_PROXY_ENVIRONMENTS.includes(value as ProxyEnvironment)
     ? (value as ProxyEnvironment)

--- a/src/server/universal-handler/parse-proxy-environment.test.ts
+++ b/src/server/universal-handler/parse-proxy-environment.test.ts
@@ -1,0 +1,27 @@
+import { assertEquals } from "https://deno.land/std@0.220.0/assert/mod.ts";
+import { parseProxyEnvironment } from "./index.ts";
+
+Deno.test("parseProxyEnvironment", async (t) => {
+  await t.step("returns 'preview' for valid preview value", () => {
+    assertEquals(parseProxyEnvironment("preview"), "preview");
+  });
+
+  await t.step("returns 'production' for valid production value", () => {
+    assertEquals(parseProxyEnvironment("production"), "production");
+  });
+
+  await t.step("returns undefined for null", () => {
+    assertEquals(parseProxyEnvironment(null), undefined);
+  });
+
+  await t.step("returns undefined for empty string", () => {
+    assertEquals(parseProxyEnvironment(""), undefined);
+  });
+
+  await t.step("returns undefined for invalid value", () => {
+    assertEquals(parseProxyEnvironment("staging"), undefined);
+    assertEquals(parseProxyEnvironment("dev"), undefined);
+    assertEquals(parseProxyEnvironment("PREVIEW"), undefined);
+    assertEquals(parseProxyEnvironment("PRODUCTION"), undefined);
+  });
+});

--- a/veryfront.config.ts
+++ b/veryfront.config.ts
@@ -10,6 +10,18 @@
  *   Direct mode: Set VERYFRONT_API_TOKEN and VERYFRONT_PROJECT_SLUG in .env.local
  */
 
+// Default URLs
+const DEFAULT_API_URL_LOCAL = "http://api.lvh.me:4000/api";
+const DEFAULT_API_URL_PROD = "https://api.veryfront.com";
+const DEFAULT_CORS_ORIGIN_LOCAL = "http://api.lvh.me:4000";
+
+class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigError";
+  }
+}
+
 // Load .env.local manually since config is evaluated before bootstrap
 // In production, .env.local won't exist - that's fine, we use env vars
 let env: Record<string, string> = {};
@@ -31,7 +43,7 @@ const productionMode = Deno.env.get("PRODUCTION_MODE") === "1";
 function getApiBaseUrl(): string {
   return Deno.env.get("VERYFRONT_API_BASE_URL") ||
     env.VERYFRONT_API_BASE_URL ||
-    "http://api.lvh.me:4000/api";
+    DEFAULT_API_URL_LOCAL;
 }
 
 const apiBaseUrl = getApiBaseUrl();
@@ -45,8 +57,7 @@ const releaseId = Deno.env.get("VERYFRONT_RELEASE_ID") || env.VERYFRONT_RELEASE_
 // Skip check during tests or CI
 const isTestEnv = Deno.env.get("DENO_JOBS") !== undefined || Deno.env.get("CI") !== undefined;
 if (!isTestEnv && !proxyMode && (!apiToken || !projectSlug)) {
-  console.error(`
-❌ Missing required environment variables in .env.local:
+  throw new ConfigError(`Missing required environment variables in .env.local:
 
    VERYFRONT_API_TOKEN=${apiToken ? "✓" : "missing"}
    VERYFRONT_PROJECT_SLUG=${projectSlug ? "✓" : "missing"}
@@ -56,9 +67,7 @@ To get started:
   Option B (Direct mode):
     1. Get an API key from veryfront.com settings
     2. Copy the token to .env.local
-    3. Set your project slug in .env.local
-  `);
-  Deno.exit(1);
+    3. Set your project slug in .env.local`);
 }
 
 if (proxyMode) {
@@ -122,7 +131,7 @@ export default useGitHub ? {
   // Security - allow requests from local API (in proxy mode) or production
   security: {
     cors: {
-      origin: proxyMode ? "http://api.lvh.me:4000" : "https://api.veryfront.com",
+      origin: proxyMode ? DEFAULT_CORS_ORIGIN_LOCAL : DEFAULT_API_URL_PROD,
     },
   },
 };


### PR DESCRIPTION
## Summary
- Add unit tests for `isProductionMode()` and `parseProxyEnvironment()`
- Export functions to make them testable
- Extract config constants (DEFAULT_API_URL_LOCAL, DEFAULT_API_URL_PROD)
- Replace console.error + Deno.exit with proper ConfigError exception

## Changes
- `src/server/handlers/request/ssr/is-production-mode.test.ts` - new test file
- `src/server/universal-handler/parse-proxy-environment.test.ts` - new test file  
- `src/server/handlers/request/ssr/ssr-handler.ts` - export isProductionMode
- `src/server/universal-handler/index.ts` - export parseProxyEnvironment
- `veryfront.config.ts` - config improvements

## Test plan
- [x] All 595 unit tests pass
- [x] No merge conflicts with main