### PR TITLE
refactor(renderer): simplify proxy mode handling

### DIFF
--- a/src/platform/adapters/multi-project-fs-adapter.ts
+++ b/src/platform/adapters/multi-project-fs-adapter.ts
@@ -86,10 +86,8 @@ export class MultiProjectFSAdapter implements FSAdapter {
     const context = asyncLocalStorage.getStore();
 
     if (!context) {
-      // Log at info level to debug production issues
-      logger.info("[MultiProjectFSAdapter] No context available", {
+      logger.debug("[MultiProjectFSAdapter] No context available", {
         hasDefaultAdapter: !!this.defaultAdapter,
-        stack: new Error().stack?.split("\n").slice(0, 10).join("\n"),
       });
 
       if (this.defaultAdapter) {
@@ -107,11 +105,9 @@ export class MultiProjectFSAdapter implements FSAdapter {
     const productionMode = context.productionMode ?? false;
     const releaseId = context.releaseId ?? null;
 
-    // Log at info level to debug context propagation issues
-    logger.info("[MultiProjectFSAdapter] getAdapter with context", {
+    logger.debug("[MultiProjectFSAdapter] getAdapter with context", {
       projectSlug: context.projectSlug,
       productionMode,
-      hasProjectId: !!context.projectId,
     });
 
     return this.manager.getAdapter(

--- a/src/platform/adapters/proxy-fs-adapter-manager.ts
+++ b/src/platform/adapters/proxy-fs-adapter-manager.ts
@@ -75,11 +75,8 @@ export class ProxyFSAdapterManager {
       existing.lastAccessed = Date.now();
       existing.adapter.setRequestToken(effectiveToken);
 
-      logger.info("[ProxyFSAdapterManager] Reusing cached adapter", {
-        projectSlug,
+      logger.debug("[ProxyFSAdapterManager] Reusing cached adapter", {
         cacheKey,
-        productionMode: effectiveProductionMode,
-        releaseId: effectiveReleaseId ?? "null",
       });
 
       if (existing.initializing) {
@@ -121,12 +118,9 @@ export class ProxyFSAdapterManager {
   ): Promise<VeryfrontFSAdapter> {
     const effectiveToken = token || this.baseConfig.veryfront?.apiToken;
 
-    logger.info("[ProxyFSAdapterManager] Creating adapter", {
+    logger.debug("[ProxyFSAdapterManager] Creating adapter", {
       cacheKey,
       projectSlug,
-      projectId: projectId || "(none)",
-      productionMode,
-      releaseId: releaseId ?? "null",
     });
 
     const config: FSAdapterConfig = {
@@ -156,7 +150,7 @@ export class ProxyFSAdapterManager {
       projectAdapter.initializing = adapter.initialize();
       try {
         await projectAdapter.initializing;
-        logger.info("[ProxyFSAdapterManager] Adapter initialized", { cacheKey, projectSlug });
+        logger.debug("[ProxyFSAdapterManager] Adapter initialized", { cacheKey });
         this.adapters.set(cacheKey, projectAdapter);
       } catch (error) {
         throw error;

--- a/src/server/handlers/request/ssr/ssr-handler.ts
+++ b/src/server/handlers/request/ssr/ssr-handler.ts
@@ -36,6 +36,24 @@ import {
 } from "@veryfront/core/constants/index.ts";
 import { generateNonce } from "@veryfront/security/http/response/security-handler.ts";
 import { getColorSchemeFromRequest } from "@veryfront/security/http/client-hints.ts";
+import { isMultiProjectAdapter } from "@veryfront/platform/adapters/multi-project-fs-adapter.ts";
+
+/**
+ * Determine if request should serve production (released) content.
+ * Priority: config > veryfront domain isDraft flag > proxy environment header
+ */
+function isProductionMode(ctx: HandlerContext): boolean {
+  // Config override (PRODUCTION_MODE env var)
+  if (ctx.config?.fs?.veryfront?.productionMode === true) {
+    return true;
+  }
+  // Veryfront domain: production if not draft
+  if (ctx.parsedDomain?.isVeryfrontDomain) {
+    return ctx.parsedDomain.isDraft === false;
+  }
+  // Custom domain: use proxy environment header
+  return ctx.proxyEnvironment === "production";
+}
 
 /**
  * SSR Handler Class
@@ -85,95 +103,47 @@ export class SSRHandler extends BaseHandler {
     this.logDebug("SSR attempt", { pathname, slug }, ctx);
 
     try {
-      // Inject proxy token into FSAdapter before rendering
-      // This ensures API calls use the per-request OAuth token from the proxy
-      const fsWrapper = ctx.adapter.fs as {
-        setRequestToken?: (t: string) => void;
-        setRequestBranch?: (b: string | null) => void;
-        runWithContext?: <T>(
-          slug: string,
-          token: string,
-          fn: () => Promise<T>,
-          projectId?: string,
-          options?: { productionMode?: boolean; releaseId?: string | null },
-        ) => Promise<T>;
-      };
+      const fsAdapter = ctx.adapter.fs;
 
       // For multi-project mode, use runWithContext (required for MultiProjectFSAdapter)
-      // The token can be empty - ProxyFSAdapterManager will fall back to config token
-      if (ctx.projectSlug && typeof fsWrapper.runWithContext === "function") {
-        // Determine production mode based on domain type
-        let isProduction = false;
-        if (ctx.parsedDomain?.isVeryfrontDomain) {
-          isProduction = ctx.parsedDomain.isDraft === false;
-        } else {
-          isProduction = ctx.proxyEnvironment === "production";
-        }
+      if (ctx.projectSlug && isMultiProjectAdapter(fsAdapter)) {
+        const prodMode = isProductionMode(ctx);
 
         this.logDebug("Using multi-project context", {
           projectSlug: ctx.projectSlug,
-          projectId: ctx.projectId,
-          hasProxyToken: !!ctx.proxyToken,
-          productionMode: isProduction,
+          productionMode: prodMode,
         }, ctx);
 
-        return fsWrapper.runWithContext(
+        return fsAdapter.runWithContext(
           ctx.projectSlug,
           ctx.proxyToken || "",
           () => this.handleWithContext(req, ctx, slug, requestId, url),
           ctx.projectId,
-          { productionMode: isProduction, releaseId: ctx.releaseId },
+          { productionMode: prodMode, releaseId: ctx.releaseId },
         );
       }
 
-      // Log why multi-project context wasn't used
-      _logger.info("[SSR] NOT using multi-project context", {
-        hasProjectSlug: !!ctx.projectSlug,
-        hasRunWithContext: typeof fsWrapper.runWithContext === "function",
-        projectSlug: ctx.projectSlug || "(none)",
-      });
-
-      // For single-project mode with proxy token, use setRequestToken
-      if (ctx.proxyToken && typeof fsWrapper.setRequestToken === "function") {
-        fsWrapper.setRequestToken(ctx.proxyToken);
-        this.logDebug("Injected proxy token into FSAdapter", {}, ctx);
-      }
-
-      // Always set branch from URL - either the parsed branch or null for main
-      // This ensures each request uses the correct branch and clears any previously set branch
-      if (typeof fsWrapper.setRequestBranch === "function") {
-        const branch = ctx.parsedDomain?.branch ?? null;
-        fsWrapper.setRequestBranch(branch);
-        this.logDebug("Set FSAdapter branch", { branch: branch ?? "main" }, ctx);
-      }
-
-      // Set production mode for non-draft environments (staging, production)
-      // When production mode is enabled, content is served from releases (JIT rendering)
-      const setProductionMode = fsWrapper as {
+      // Single-project mode: duck-type for optional methods
+      const fsWrapper = fsAdapter as {
+        setRequestToken?: (t: string) => void;
+        setRequestBranch?: (b: string | null) => void;
         setProductionMode?: (enabled: boolean, releaseId?: string | null) => void;
       };
-      if (typeof setProductionMode.setProductionMode === "function") {
-        // Determine production mode based on:
-        // 1. Config's productionMode setting (from PRODUCTION_MODE env var)
-        // 2. Veryfront domain isDraft flag
-        // 3. Proxy environment header
-        let isProduction = ctx.config?.fs?.veryfront?.productionMode === true;
-        if (!isProduction && ctx.parsedDomain?.isVeryfrontDomain) {
-          isProduction = ctx.parsedDomain.isDraft === false;
-        } else if (!isProduction) {
-          // Custom domain - proxy tells us the environment
-          isProduction = ctx.proxyEnvironment === "production";
-        }
 
-        setProductionMode.setProductionMode(isProduction, ctx.releaseId);
-        if (isProduction) {
-          this.logDebug("Production mode enabled - serving from releases", {
-            environment: ctx.parsedDomain?.environment ?? ctx.proxyEnvironment,
-            isCustomDomain: !ctx.parsedDomain?.isVeryfrontDomain,
-            fromConfig: ctx.config?.fs?.veryfront?.productionMode === true,
-            releaseId: ctx.releaseId ?? "latest",
-          }, ctx);
-        }
+      // Single-project mode: set per-request token if available
+      if (ctx.proxyToken && typeof fsWrapper.setRequestToken === "function") {
+        fsWrapper.setRequestToken(ctx.proxyToken);
+      }
+
+      // Set branch from URL
+      if (typeof fsWrapper.setRequestBranch === "function") {
+        fsWrapper.setRequestBranch(ctx.parsedDomain?.branch ?? null);
+      }
+
+      // Set production mode for non-draft environments
+      if (typeof fsWrapper.setProductionMode === "function") {
+        const prodMode = isProductionMode(ctx);
+        fsWrapper.setProductionMode(prodMode, ctx.releaseId);
       }
 
       return this.handleWithContext(req, ctx, slug, requestId, url);

--- a/src/server/universal-handler/index.ts
+++ b/src/server/universal-handler/index.ts
@@ -50,6 +50,7 @@ function isMonitoringPath(pathname: string): boolean {
     pathname === "/_health" ||
     pathname === "/metrics";
 }
+
 import { RouteRegistry } from "@veryfront/routing/registry/index.ts";
 import { SecurityConfigLoader } from "@veryfront/security/http/config.ts";
 import { getConfig } from "@veryfront/config/loader.ts";
@@ -74,6 +75,18 @@ import { ApiHandlerWrapper } from "../handlers/request/api/index.ts";
 import { SSRHandler } from "../handlers/request/ssr/index.ts";
 import { NotFoundHandler } from "../handlers/response/not-found.ts";
 import { HMRHandler } from "../handlers/preview/hmr-handler.ts";
+
+/** Valid proxy environment values */
+const VALID_PROXY_ENVIRONMENTS = ["preview", "production"] as const;
+type ProxyEnvironment = (typeof VALID_PROXY_ENVIRONMENTS)[number];
+
+/** Validate and parse proxy environment header */
+function parseProxyEnvironment(value: string | null): ProxyEnvironment | undefined {
+  if (!value) return undefined;
+  return VALID_PROXY_ENVIRONMENTS.includes(value as ProxyEnvironment)
+    ? (value as ProxyEnvironment)
+    : undefined;
+}
 
 export interface UniversalHandlerOptions {
   projectDir: string;
@@ -225,8 +238,9 @@ export function createVeryfrontHandler(
       const proxyToken = req.headers.get("x-token") || undefined;
       const proxySlug = req.headers.get("x-project-slug") ||
         _url.searchParams.get("x-project-slug") || undefined;
-      let proxyEnv = (req.headers.get("x-environment") ||
-        _url.searchParams.get("x-environment")) as "preview" | "production" | undefined;
+      let proxyEnv = parseProxyEnvironment(
+        req.headers.get("x-environment") || _url.searchParams.get("x-environment"),
+      );
       const forwardedHost = req.headers.get("x-forwarded-host") || undefined;
 
       // Get project slug: proxy header > URL parsing > config


### PR DESCRIPTION
## Summary
- Simplify SSR handler by extracting `isProductionMode()` helper
- Reduce logging verbosity (info → debug) for routine operations
- Use proper type guard `isMultiProjectAdapter()` instead of duck-typing
- Add `parseProxyEnvironment()` for input validation

## Changes
- `src/server/handlers/request/ssr/ssr-handler.ts` - major cleanup (-57 lines)
- `src/server/universal-handler/index.ts` - add parseProxyEnvironment
- `src/platform/adapters/multi-project-fs-adapter.ts` - reduce log verbosity
- `src/platform/adapters/proxy-fs-adapter-manager.ts` - reduce log verbosity

## Test plan
- [x] All 595 unit tests pass
- [x] No merge conflicts with main
- [x] Net reduction of 26 lines