### PR TITLE
fix: add missing js-yaml dependency for npm package

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -161,6 +161,7 @@
     "picocolors": "^1.1.0",
     "mri": "^1.2.0",
     "yaml": "^2.3.0",
+    "js-yaml": "^4.1.0",
     "gray-matter": "^4.0.3",
     "ws": "^8.18.0",
     "lightningcss": "^1.22.0",


### PR DESCRIPTION
## Summary
Add `js-yaml` to npm package dependencies for Node.js frontmatter parsing.

## Problem
The npm package uses `import(\"js-yaml\")` for YAML frontmatter parsing in Node.js, but the dependency was missing from package.json, causing runtime errors.

## Changes
- `npm/package.json` - add `"js-yaml": "^4.1.0"` to dependencies

## Usage
Used in:
- `src/core/types/entities/getEntityInfo.ts:28`
- `src/rendering/app-route-resolver.ts:41`

## Note
The Deno runtime detection fix from the original branch was already merged to main. Only the js-yaml dependency addition remains.

## Test plan
- [x] Rebased on latest main
- [x] No conflicts