### PR TITLE
feat(ai): add OpenAI o-series reasoning model support

### DIFF
--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -54,7 +54,7 @@ export class OpenAIProvider extends BaseProvider {
     // Base request body
     const body: Record<string, unknown> = {
       model,
-      messages: this.formatMessages(request.messages),
+      messages: this.formatMessages(request.messages, request.system),
       stream: request.stream || false,
     };
 
@@ -179,8 +179,11 @@ export class OpenAIProvider extends BaseProvider {
     };
   }
 
-  private formatMessages(messages: CompletionRequest["messages"]) {
-    return messages.map((msg) => {
+  private formatMessages(
+    messages: CompletionRequest["messages"],
+    system?: string,
+  ) {
+    const formattedMessages = messages.map((msg) => {
       // Handle tool results
       if (msg.tool_call_id) {
         return {
@@ -211,5 +214,15 @@ export class OpenAIProvider extends BaseProvider {
         content: msg.content,
       };
     });
+
+    // Prepend system message if provided
+    if (system) {
+      return [
+        { role: "system", content: system },
+        ...formattedMessages,
+      ];
+    }
+
+    return formattedMessages;
   }
 }

--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -9,7 +9,8 @@
  * - Support reasoning_effort parameter
  */
 
-import { z } from "zod";
+import { BaseProvider, mapFinishReason } from "./base.ts";
+import type { CompletionRequest, CompletionResponse, OpenAIConfig } from "../types/provider.ts";
 
 /**
  * Check if a model is an o-series reasoning model (o1, o3, etc.)
@@ -19,54 +20,32 @@ function isOSeriesModel(model: string): boolean {
   return model.startsWith("o1") || model.startsWith("o3");
 }
 
-import { BaseProvider } from "./base.ts";
-import { createError, toError } from "../../core/errors/veryfront-error.ts";
-import type { CompletionRequest, CompletionResponse, OpenAIConfig } from "../types/provider.ts";
-
-const OpenAIToolCallSchema = z.object({
-  id: z.string(),
-  function: z.object({
-    name: z.string(),
-    arguments: z.string(),
-  }),
-});
-
-const OpenAIResponseSchema = z.object({
-  choices: z.array(z.object({
-    message: z.object({
-      content: z.string().nullable().optional(),
-      tool_calls: z.array(OpenAIToolCallSchema).optional(),
-    }),
-    finish_reason: z.string(),
-  })).min(1),
-  usage: z.object({
-    prompt_tokens: z.number().optional(),
-    completion_tokens: z.number().optional(),
-    total_tokens: z.number().optional(),
-  }).optional(),
-});
-
 export class OpenAIProvider extends BaseProvider {
   name = "openai";
-  private apiKey: string;
-  private baseUrl: string;
-  private defaultModel: string;
-  private organization?: string;
 
   constructor(config: OpenAIConfig) {
-    super();
-    this.apiKey = config.apiKey;
-    this.baseUrl = config.baseUrl || "https://api.openai.com/v1";
-    this.defaultModel = config.defaultModel || "gpt-4o";
-    this.organization = config.organization;
+    super(config);
   }
 
-  /**
-   * Build the request body for OpenAI API
-   * Handles o-series models differently than standard models
-   */
-  private buildRequestBody(request: CompletionRequest): Record<string, unknown> {
-    const model = request.model || this.defaultModel;
+  protected getHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.config.apiKey}`,
+    };
+
+    if (this.config.organizationId) {
+      headers["OpenAI-Organization"] = this.config.organizationId;
+    }
+
+    return headers;
+  }
+
+  protected getEndpoint(path: string): string {
+    const baseURL = this.config.baseURL || "https://api.openai.com/v1";
+    return `${baseURL}${path}`;
+  }
+
+  protected transformRequest(request: CompletionRequest): Record<string, unknown> {
+    const model = request.model;
     const isReasoning = isOSeriesModel(model);
 
     // Base request body
@@ -90,9 +69,9 @@ export class OpenAIProvider extends BaseProvider {
       body.temperature = request.temperature;
     }
 
-    // Stop sequences
-    if (request.stopSequences?.length) {
-      body.stop = request.stopSequences;
+    // Top P
+    if (!isReasoning && request.topP !== undefined) {
+      body.top_p = request.topP;
     }
 
     // Tools - o-series doesn't support parallel_tool_calls
@@ -102,7 +81,7 @@ export class OpenAIProvider extends BaseProvider {
         function: {
           name: tool.name,
           description: tool.description,
-          parameters: tool.inputSchema,
+          parameters: tool.parameters,
         },
       }));
 
@@ -113,109 +92,83 @@ export class OpenAIProvider extends BaseProvider {
     }
 
     // Reasoning effort - only for o-series models
-    if (isReasoning && request.reasoningEffort) {
-      body.reasoning_effort = request.reasoningEffort;
+    if (isReasoning && request.reasoning?.effort) {
+      body.reasoning_effort = request.reasoning.effort;
     }
 
     return body;
   }
 
-  async complete(request: CompletionRequest): Promise<CompletionResponse> {
-    const body = this.buildRequestBody(request);
-
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      "Authorization": `Bearer ${this.apiKey}`,
+  protected transformResponse(response: unknown): CompletionResponse {
+    const data = response as {
+      choices: Array<{
+        message: {
+          role: string;
+          content: string | null;
+          tool_calls?: Array<{
+            id: string;
+            type: string;
+            function: {
+              name: string;
+              arguments: string;
+            };
+          }>;
+        };
+        finish_reason: string | null;
+      }>;
+      usage?: {
+        prompt_tokens: number;
+        completion_tokens: number;
+        total_tokens: number;
+      };
     };
 
-    if (this.organization) {
-      headers["OpenAI-Organization"] = this.organization;
+    const choice = data.choices[0];
+    if (!choice) {
+      throw new Error("OpenAI response missing choices");
     }
 
-    const response = await fetch(`${this.baseUrl}/chat/completions`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(body),
-    });
-
-    if (!response.ok) {
-      const errorBody = await response.text();
-      throw toError(
-        createError({
-          type: "provider",
-          message: `OpenAI API error: ${response.status} ${response.statusText}`,
-          context: { body: errorBody },
-        }),
-      );
-    }
-
-    const data = await response.json();
-    const parsed = OpenAIResponseSchema.parse(data);
-    const choice = parsed.choices[0];
-
-    // Extract tool calls if present, with error handling for JSON parsing
-    const toolCalls = choice.message.tool_calls?.map((tc) => {
-      try {
-        return {
-          id: tc.id,
-          name: tc.function.name,
-          arguments: JSON.parse(tc.function.arguments),
-        };
-      } catch (error) {
-        throw toError(createError({
-          type: "agent",
-          message: `OpenAI: Invalid tool call arguments JSON for ${tc.function.name}: ${error instanceof Error ? error.message : String(error)}`,
-        }));
-      }
-    });
+    // Extract tool calls if present
+    const toolCalls = choice.message.tool_calls?.map((tc) => ({
+      id: tc.id,
+      name: tc.function.name,
+      arguments: JSON.parse(tc.function.arguments) as Record<string, unknown>,
+    }));
 
     return {
-      content: choice.message.content || "",
+      text: choice.message.content || "",
       toolCalls,
-      usage: parsed.usage ? {
-        promptTokens: parsed.usage.prompt_tokens,
-        completionTokens: parsed.usage.completion_tokens,
-        totalTokens: parsed.usage.total_tokens,
-      } : undefined,
-      finishReason: this.mapFinishReason(choice.finish_reason),
+      usage: {
+        promptTokens: data.usage?.prompt_tokens ?? 0,
+        completionTokens: data.usage?.completion_tokens ?? 0,
+        totalTokens: data.usage?.total_tokens ?? 0,
+      },
+      finishReason: mapFinishReason(choice.finish_reason ?? "stop"),
     };
-  }
-
-  private mapFinishReason(reason: string): CompletionResponse["finishReason"] {
-    switch (reason) {
-      case "stop":
-        return "stop";
-      case "length":
-        return "length";
-      case "tool_calls":
-        return "tool_use";
-      case "content_filter":
-        return "content_filter";
-      default:
-        return "stop";
-    }
   }
 
   private formatMessages(messages: CompletionRequest["messages"]) {
     return messages.map((msg) => {
-      if (msg.role === "tool") {
+      // Handle tool results
+      if (msg.tool_call_id) {
         return {
           role: "tool",
-          tool_call_id: msg.toolCallId,
+          tool_call_id: msg.tool_call_id,
           content: typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content),
         };
       }
 
-      if (msg.role === "assistant" && msg.toolCalls) {
+      // Handle assistant messages with tool calls
+      if (msg.role === "assistant" && msg.tool_calls) {
         return {
           role: "assistant",
           content: msg.content || null,
-          tool_calls: msg.toolCalls.map((tc) => ({
+          tool_calls: msg.tool_calls.map((tc) => ({
             id: tc.id,
-            type: "function",
+            type: tc.type || "function",
             function: {
-              name: tc.name,
-              arguments: JSON.stringify(tc.arguments),
+              name: tc.function.name,
+              arguments: tc.function.arguments,
             },
           })),
         };
@@ -226,16 +179,5 @@ export class OpenAIProvider extends BaseProvider {
         content: msg.content,
       };
     });
-  }
-
-  async *stream(
-    _request: CompletionRequest,
-  ): AsyncGenerator<CompletionResponse, void, unknown> {
-    throw toError(
-      createError({
-        type: "provider",
-        message: "Streaming not yet implemented for OpenAI provider",
-      }),
-    );
   }
 }

--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -29,19 +29,21 @@ export class OpenAIProvider extends BaseProvider {
   }
 
   protected getHeaders(): Record<string, string> {
+    const config = this.config as OpenAIConfig;
     const headers: Record<string, string> = {
-      Authorization: `Bearer ${this.config.apiKey}`,
+      Authorization: `Bearer ${config.apiKey}`,
     };
 
-    if (this.config.organizationId) {
-      headers["OpenAI-Organization"] = this.config.organizationId;
+    if (config.organizationId) {
+      headers["OpenAI-Organization"] = config.organizationId;
     }
 
     return headers;
   }
 
   protected getEndpoint(path: string): string {
-    const baseURL = this.config.baseURL || "https://api.openai.com/v1";
+    const config = this.config as OpenAIConfig;
+    const baseURL = config.baseURL || "https://api.openai.com/v1";
     return `${baseURL}${path}`;
   }
 
@@ -101,9 +103,17 @@ export class OpenAIProvider extends BaseProvider {
   }
 
   protected transformResponse(response: unknown): CompletionResponse {
+    // Basic validation to prevent crashes on malformed responses
+    if (!response || typeof response !== "object") {
+      throw toError(createError({
+        type: "agent",
+        message: "OpenAI: Invalid response format - expected object",
+      }));
+    }
+
     const data = response as {
-      choices: Array<{
-        message: {
+      choices?: Array<{
+        message?: {
           role: string;
           content: string | null;
           tool_calls?: Array<{
@@ -124,9 +134,19 @@ export class OpenAIProvider extends BaseProvider {
       };
     };
 
+    if (!data.choices || !Array.isArray(data.choices) || data.choices.length === 0) {
+      throw toError(createError({
+        type: "agent",
+        message: "OpenAI: Response missing choices array",
+      }));
+    }
+
     const choice = data.choices[0];
-    if (!choice) {
-      throw new Error("OpenAI response missing choices");
+    if (!choice || !choice.message) {
+      throw toError(createError({
+        type: "agent",
+        message: "OpenAI: Invalid choice or missing message in response",
+      }));
     }
 
     // Extract tool calls if present, with error handling for JSON parsing

--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -1,7 +1,25 @@
-/** OpenAI provider implementation */
+/**
+ * OpenAI provider implementation
+ *
+ * Supports both standard models and o-series reasoning models (o1, o3).
+ * O-series models have different parameter requirements:
+ * - Use max_completion_tokens instead of max_tokens
+ * - Don't support temperature parameter
+ * - Don't support parallel_tool_calls
+ * - Support reasoning_effort parameter
+ */
 
 import { z } from "zod";
-import { BaseProvider, mapFinishReason } from "./base.ts";
+
+/**
+ * Check if a model is an o-series reasoning model (o1, o3, etc.)
+ * These models have different API parameter requirements.
+ */
+function isOSeriesModel(model: string): boolean {
+  return model.startsWith("o1") || model.startsWith("o3");
+}
+
+import { BaseProvider } from "./base.ts";
 import { createError, toError } from "../../core/errors/veryfront-error.ts";
 import type { CompletionRequest, CompletionResponse, OpenAIConfig } from "../types/provider.ts";
 
@@ -31,115 +49,184 @@ const OpenAIResponseSchema = z.object({
 export class OpenAIProvider extends BaseProvider {
   name = "openai";
   private apiKey: string;
-  private baseURL: string;
-  private organizationId?: string;
+  private baseUrl: string;
+  private defaultModel: string;
+  private organization?: string;
 
   constructor(config: OpenAIConfig) {
-    super(config);
+    super();
     this.apiKey = config.apiKey;
-    this.baseURL = config.baseURL || "https://api.openai.com/v1";
-    this.organizationId = config.organizationId;
+    this.baseUrl = config.baseUrl || "https://api.openai.com/v1";
+    this.defaultModel = config.defaultModel || "gpt-4o";
+    this.organization = config.organization;
   }
 
-  protected getHeaders(): Record<string, string> {
-    const headers: Record<string, string> = {
-      "Authorization": `Bearer ${this.apiKey}`,
-    };
+  /**
+   * Build the request body for OpenAI API
+   * Handles o-series models differently than standard models
+   */
+  private buildRequestBody(request: CompletionRequest): Record<string, unknown> {
+    const model = request.model || this.defaultModel;
+    const isReasoning = isOSeriesModel(model);
 
-    if (this.organizationId) {
-      headers["OpenAI-Organization"] = this.organizationId;
-    }
-
-    return headers;
-  }
-
-  protected getEndpoint(path: string): string {
-    return `${this.baseURL}${path}`;
-  }
-
-  protected transformRequest(
-    request: CompletionRequest,
-  ): Record<string, unknown> {
+    // Base request body
     const body: Record<string, unknown> = {
-      model: request.model,
-      messages: request.messages,
+      model,
+      messages: this.formatMessages(request.messages),
       stream: request.stream || false,
     };
 
-    if (request.system) {
-      // Add system message at the beginning
-      body.messages = [
-        { role: "system", content: request.system },
-        ...request.messages,
-      ];
-    }
-
+    // Handle max tokens - o-series uses max_completion_tokens
     if (request.maxTokens) {
-      body.max_tokens = request.maxTokens;
+      if (isReasoning) {
+        body.max_completion_tokens = request.maxTokens;
+      } else {
+        body.max_tokens = request.maxTokens;
+      }
     }
 
-    if (request.temperature !== undefined) {
+    // Temperature - not supported by o-series models
+    if (!isReasoning && request.temperature !== undefined) {
       body.temperature = request.temperature;
     }
 
-    if (request.topP !== undefined) {
-      body.top_p = request.topP;
+    // Stop sequences
+    if (request.stopSequences?.length) {
+      body.stop = request.stopSequences;
     }
 
-    if (request.tools && request.tools.length > 0) {
+    // Tools - o-series doesn't support parallel_tool_calls
+    if (request.tools?.length) {
       body.tools = request.tools.map((tool) => ({
         type: "function",
         function: {
           name: tool.name,
           description: tool.description,
-          parameters: tool.parameters,
+          parameters: tool.inputSchema,
         },
       }));
-      // Disable parallel tool calls to avoid streaming JSON corruption
-      // when multiple tool calls are made simultaneously
-      body.parallel_tool_calls = false;
+
+      // Only add parallel_tool_calls for non-reasoning models
+      if (!isReasoning) {
+        body.parallel_tool_calls = false;
+      }
+    }
+
+    // Reasoning effort - only for o-series models
+    if (isReasoning && request.reasoningEffort) {
+      body.reasoning_effort = request.reasoningEffort;
     }
 
     return body;
   }
 
-  protected transformResponse(response: unknown): CompletionResponse {
-    const parsed = OpenAIResponseSchema.safeParse(response);
+  async complete(request: CompletionRequest): Promise<CompletionResponse> {
+    const body = this.buildRequestBody(request);
 
-    if (!parsed.success) {
-      throw toError(createError({
-        type: "agent",
-        message: `OpenAI: Invalid response format: ${parsed.error.message}`,
-      }));
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${this.apiKey}`,
+    };
+
+    if (this.organization) {
+      headers["OpenAI-Organization"] = this.organization;
     }
 
-    const data = parsed.data;
-    const choice = data.choices[0];
+    const response = await fetch(`${this.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
 
-    if (!choice) {
-      throw toError(createError({
-        type: "agent",
-        message: "OpenAI: No choices in response (unexpected)",
-      }));
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw toError(
+        createError({
+          type: "provider",
+          message: `OpenAI API error: ${response.status} ${response.statusText}`,
+          context: { body: errorBody },
+        }),
+      );
     }
 
-    const message = choice.message;
+    const data = await response.json();
+    const parsed = OpenAIResponseSchema.parse(data);
+    const choice = parsed.choices[0];
 
-    const toolCalls = message.tool_calls?.map((tc) => ({
+    // Extract tool calls if present
+    const toolCalls = choice.message.tool_calls?.map((tc) => ({
       id: tc.id,
       name: tc.function.name,
       arguments: JSON.parse(tc.function.arguments),
     }));
 
     return {
-      text: message.content || "",
+      content: choice.message.content || "",
       toolCalls,
-      usage: {
-        promptTokens: data.usage?.prompt_tokens || 0,
-        completionTokens: data.usage?.completion_tokens || 0,
-        totalTokens: data.usage?.total_tokens || 0,
-      },
-      finishReason: mapFinishReason(choice.finish_reason),
+      usage: parsed.usage ? {
+        promptTokens: parsed.usage.prompt_tokens,
+        completionTokens: parsed.usage.completion_tokens,
+        totalTokens: parsed.usage.total_tokens,
+      } : undefined,
+      finishReason: this.mapFinishReason(choice.finish_reason),
     };
+  }
+
+  private mapFinishReason(reason: string): CompletionResponse["finishReason"] {
+    switch (reason) {
+      case "stop":
+        return "stop";
+      case "length":
+        return "length";
+      case "tool_calls":
+        return "tool_use";
+      case "content_filter":
+        return "content_filter";
+      default:
+        return "stop";
+    }
+  }
+
+  private formatMessages(messages: CompletionRequest["messages"]) {
+    return messages.map((msg) => {
+      if (msg.role === "tool") {
+        return {
+          role: "tool",
+          tool_call_id: msg.toolCallId,
+          content: typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content),
+        };
+      }
+
+      if (msg.role === "assistant" && msg.toolCalls) {
+        return {
+          role: "assistant",
+          content: msg.content || null,
+          tool_calls: msg.toolCalls.map((tc) => ({
+            id: tc.id,
+            type: "function",
+            function: {
+              name: tc.name,
+              arguments: JSON.stringify(tc.arguments),
+            },
+          })),
+        };
+      }
+
+      return {
+        role: msg.role,
+        content: msg.content,
+      };
+    });
+  }
+
+  async *stream(
+    _request: CompletionRequest,
+  ): AsyncGenerator<CompletionResponse, void, unknown> {
+    throw toError(
+      createError({
+        type: "provider",
+        message: "Streaming not yet implemented for OpenAI provider",
+      }),
+    );
   }
 }

--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -160,7 +160,9 @@ export class OpenAIProvider extends BaseProvider {
       } catch (error) {
         throw toError(createError({
           type: "agent",
-          message: `OpenAI: Invalid tool call arguments JSON for ${tc.function.name}: ${error instanceof Error ? error.message : String(error)}`,
+          message: `OpenAI: Invalid tool call arguments JSON for ${tc.function.name}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
         }));
       }
     });

--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -11,6 +11,7 @@
 
 import { BaseProvider, mapFinishReason } from "./base.ts";
 import type { CompletionRequest, CompletionResponse, OpenAIConfig } from "../types/provider.ts";
+import { createError, toError } from "../../core/errors/veryfront-error.ts";
 
 /**
  * Check if a model is an o-series reasoning model (o1, o3, etc.)
@@ -128,12 +129,21 @@ export class OpenAIProvider extends BaseProvider {
       throw new Error("OpenAI response missing choices");
     }
 
-    // Extract tool calls if present
-    const toolCalls = choice.message.tool_calls?.map((tc) => ({
-      id: tc.id,
-      name: tc.function.name,
-      arguments: JSON.parse(tc.function.arguments) as Record<string, unknown>,
-    }));
+    // Extract tool calls if present, with error handling for JSON parsing
+    const toolCalls = choice.message.tool_calls?.map((tc) => {
+      try {
+        return {
+          id: tc.id,
+          name: tc.function.name,
+          arguments: JSON.parse(tc.function.arguments) as Record<string, unknown>,
+        };
+      } catch (error) {
+        throw toError(createError({
+          type: "agent",
+          message: `OpenAI: Invalid tool call arguments JSON for ${tc.function.name}: ${error instanceof Error ? error.message : String(error)}`,
+        }));
+      }
+    });
 
     return {
       text: choice.message.content || "",

--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -153,12 +153,21 @@ export class OpenAIProvider extends BaseProvider {
     const parsed = OpenAIResponseSchema.parse(data);
     const choice = parsed.choices[0];
 
-    // Extract tool calls if present
-    const toolCalls = choice.message.tool_calls?.map((tc) => ({
-      id: tc.id,
-      name: tc.function.name,
-      arguments: JSON.parse(tc.function.arguments),
-    }));
+    // Extract tool calls if present, with error handling for JSON parsing
+    const toolCalls = choice.message.tool_calls?.map((tc) => {
+      try {
+        return {
+          id: tc.id,
+          name: tc.function.name,
+          arguments: JSON.parse(tc.function.arguments),
+        };
+      } catch (error) {
+        throw toError(createError({
+          type: "agent",
+          message: `OpenAI: Invalid tool call arguments JSON for ${tc.function.name}: ${error instanceof Error ? error.message : String(error)}`,
+        }));
+      }
+    });
 
     return {
       content: choice.message.content || "",

--- a/src/ai/types/provider.ts
+++ b/src/ai/types/provider.ts
@@ -106,6 +106,19 @@ export interface CompletionRequest {
 
   /** Tools available */
   tools?: ToolDefinition[];
+
+  /**
+   * Reasoning configuration for o-series models (o1, o3)
+   */
+  reasoning?: {
+    /**
+     * Reasoning effort level.
+     * - "low": Faster responses, less reasoning
+     * - "medium": Balanced (default)
+     * - "high": More thorough reasoning, slower
+     */
+    effort?: "low" | "medium" | "high";
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
Add support for OpenAI o-series reasoning models (o1, o3) which have different API parameter requirements than standard models.

## Problem
The current OpenAI provider fails with o-series models because:
- It uses `max_tokens` instead of `max_completion_tokens`
- It sets `temperature` which o-series doesn't support
- It sets `parallel_tool_calls` which o-series doesn't support

## Solution
Detect o-series models and adjust API parameters accordingly:

| Parameter | Standard Models | O-Series Models |
|-----------|-----------------|-----------------|
| Max tokens | `max_tokens` | `max_completion_tokens` |
| Temperature | Supported | Skipped |
| Top P | Supported | Skipped |
| Parallel tool calls | `false` | Skipped |
| Reasoning effort | N/A | `low` / `medium` / `high` |

## Changes
- `src/ai/providers/openai.ts` - add o-series detection and parameter handling
- `src/ai/types/provider.ts` - add `reasoning.effort` option to CompletionRequest

## Test plan
- [x] All 595 unit tests pass
- [x] Lint passes
- [x] Clean rewrite from stale `feature/reasoning-support` branch

## Notes
This is a clean rewrite of the stale `origin/feature/reasoning-support` branch which had:
- 10 commits with complex conflicts
- `tmp/test-reasoning-ui/` directory (3,943 lines of cruft)
- 4 weeks of drift from main

The old branch can now be deleted.