### PR TITLE
Migrate API response fields from camelCase to snake_case

### DIFF
--- a/src/cli/commands/pull.ts
+++ b/src/cli/commands/pull.ts
@@ -46,9 +46,9 @@ interface ProjectFile {
   path: string;
   size: number;
   type: string;
-  mimeType?: string;
-  createdAt: string;
-  updatedAt: string;
+  mime_type?: string;
+  created_at: string;
+  updated_at: string;
 }
 
 /**
@@ -58,7 +58,7 @@ interface ListFilesResponse {
   data: ProjectFile[];
   pagination?: {
     cursor?: string;
-    hasMore: boolean;
+    has_more: boolean;
   };
 }
 
@@ -84,8 +84,8 @@ async function listAllFiles(
   do {
     const params: Record<string, string> = {
       limit: "10000",
-      sortBy: "updatedAt",
-      sortOrder: "desc",
+      sort_by: "updatedAt",
+      sort_order: "desc",
     };
     if (cursor) params.cursor = cursor;
     if (branch) params.branch = branch;
@@ -96,7 +96,7 @@ async function listAllFiles(
     );
 
     allFiles.push(...response.data);
-    cursor = response.pagination?.hasMore ? response.pagination.cursor : undefined;
+    cursor = response.pagination?.has_more ? response.pagination.cursor : undefined;
   } while (cursor);
 
   return allFiles;

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -199,7 +199,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
           sourceType: "environment",
           projectSlug: this.projectSlug,
           environmentName: this.contentSource.name,
-          releaseId: envResult.releaseId,
+          releaseId: envResult.release_id,
         };
       }
 
@@ -211,9 +211,9 @@ export class VeryfrontFSAdapter implements FSAdapter {
         }
         return {
           sourceType: "environment",
-          projectSlug: lookup.projectSlug,
+          projectSlug: lookup.project_slug,
           environmentName: lookup.environment?.name ?? "production",
-          releaseId: lookup.releaseId ?? undefined,
+          releaseId: lookup.release_id ?? undefined,
         };
       }
 

--- a/src/platform/adapters/fs/veryfront/stat-operations.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.ts
@@ -54,7 +54,7 @@ export class StatOperations {
       logger.debug("[StatOperations] stat found file", { normalizedPath });
       const info: FileInfo = {
         size: file.size,
-        mtime: new Date(file.updatedAt),
+        mtime: new Date(file.updated_at),
         isDirectory: false,
         isFile: true,
         isSymlink: false,

--- a/src/platform/adapters/veryfront-api-client.test.ts
+++ b/src/platform/adapters/veryfront-api-client.test.ts
@@ -147,8 +147,8 @@ describe("VeryfrontAPIClient", () => {
                   id: "00000000-0000-0000-0000-000000000001",
                   name: "Test",
                   slug: "test-project",
-                  createdAt: "2024-01-01",
-                  updatedAt: "2024-01-01",
+                  created_at: "2024-01-01",
+                  updated_at: "2024-01-01",
                 }],
               }),
               { status: 200, headers: { "Content-Type": "application/json" } },
@@ -164,14 +164,14 @@ describe("VeryfrontAPIClient", () => {
               new Response(
                 JSON.stringify({
                   data: [
-                    { path: "file1.ts", size: 100, type: "file", updatedAt: "2024-01-01" },
-                    { path: "file2.ts", size: 200, type: "file", updatedAt: "2024-01-01" },
+                    { path: "file1.ts", size: 100, type: "file", updated_at: "2024-01-01" },
+                    { path: "file2.ts", size: 200, type: "file", updated_at: "2024-01-01" },
                   ],
-                  pageInfo: {
-                    hasNextPage: true,
-                    endCursor: "page2",
-                    hasPreviousPage: false,
-                    startCursor: null,
+                  page_info: {
+                    has_next_page: true,
+                    end_cursor: "page2",
+                    has_previous_page: false,
+                    start_cursor: null,
                   },
                 }),
                 { status: 200, headers: { "Content-Type": "application/json" } },
@@ -182,13 +182,13 @@ describe("VeryfrontAPIClient", () => {
               new Response(
                 JSON.stringify({
                   data: [
-                    { path: "file3.ts", size: 300, type: "file", updatedAt: "2024-01-01" },
+                    { path: "file3.ts", size: 300, type: "file", updated_at: "2024-01-01" },
                   ],
-                  pageInfo: {
-                    hasNextPage: false,
-                    endCursor: null,
-                    hasPreviousPage: true,
-                    startCursor: "page1",
+                  page_info: {
+                    has_next_page: false,
+                    end_cursor: null,
+                    has_previous_page: true,
+                    start_cursor: "page1",
                   },
                 }),
                 { status: 200, headers: { "Content-Type": "application/json" } },
@@ -203,8 +203,8 @@ describe("VeryfrontAPIClient", () => {
               id: "00000000-0000-0000-0000-000000000001",
               name: "Test",
               slug: "test-project",
-              createdAt: "2024-01-01",
-              updatedAt: "2024-01-01",
+              created_at: "2024-01-01",
+              updated_at: "2024-01-01",
             }),
             { status: 200, headers: { "Content-Type": "application/json" } },
           ),
@@ -238,8 +238,8 @@ describe("VeryfrontAPIClient", () => {
                   id: "00000000-0000-0000-0000-000000000001",
                   name: "Test",
                   slug: "test-project",
-                  createdAt: "2024-01-01",
-                  updatedAt: "2024-01-01",
+                  created_at: "2024-01-01",
+                  updated_at: "2024-01-01",
                 }],
               }),
               { status: 200, headers: { "Content-Type": "application/json" } },
@@ -256,7 +256,7 @@ describe("VeryfrontAPIClient", () => {
                 content: 'console.log("Hello")',
                 size: 21,
                 type: "file",
-                updatedAt: "2024-01-01",
+                updated_at: "2024-01-01",
               }),
               { status: 200, headers: { "Content-Type": "application/json" } },
             ),
@@ -269,11 +269,11 @@ describe("VeryfrontAPIClient", () => {
             new Response(
               JSON.stringify({
                 data: [],
-                pageInfo: {
-                  hasNextPage: false,
-                  endCursor: null,
-                  hasPreviousPage: false,
-                  startCursor: null,
+                page_info: {
+                  has_next_page: false,
+                  end_cursor: null,
+                  has_previous_page: false,
+                  start_cursor: null,
                 },
               }),
               { status: 200, headers: { "Content-Type": "application/json" } },
@@ -287,8 +287,8 @@ describe("VeryfrontAPIClient", () => {
               id: "00000000-0000-0000-0000-000000000001",
               name: "Test",
               slug: "test-project",
-              createdAt: "2024-01-01",
-              updatedAt: "2024-01-01",
+              created_at: "2024-01-01",
+              updated_at: "2024-01-01",
             }),
             { status: 200, headers: { "Content-Type": "application/json" } },
           ),

--- a/src/platform/adapters/veryfront-api-client/operations.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.ts
@@ -69,7 +69,11 @@ export interface FileDetail {
 
 function buildListParams(options: ListFilesOptions): URLSearchParams {
   const { cursor, limit = 100, pattern, sortBy = "updatedAt", sortOrder = "desc" } = options;
-  const params = new URLSearchParams({ limit: String(limit), sort_by: sortBy, sort_order: sortOrder });
+  const params = new URLSearchParams({
+    limit: String(limit),
+    sort_by: sortBy,
+    sort_order: sortOrder,
+  });
   if (cursor) params.set("cursor", cursor);
   if (pattern) params.set("pattern", pattern);
   return params;
@@ -178,7 +182,9 @@ export class VeryfrontAPIOperations {
         limit: 10000,
       });
       allFiles.push(...result.files);
-      cursor = result.page_info.has_next_page ? (result.page_info.end_cursor ?? undefined) : undefined;
+      cursor = result.page_info.has_next_page
+        ? (result.page_info.end_cursor ?? undefined)
+        : undefined;
     } while (cursor);
 
     return allFiles;
@@ -271,7 +277,9 @@ export class VeryfrontAPIOperations {
         limit: 10000,
       });
       allFiles.push(...result.files);
-      cursor = result.page_info.has_next_page ? (result.page_info.end_cursor ?? undefined) : undefined;
+      cursor = result.page_info.has_next_page
+        ? (result.page_info.end_cursor ?? undefined)
+        : undefined;
     } while (cursor);
 
     logger.debug("[API] listAllEnvironmentFiles", {
@@ -365,7 +373,9 @@ export class VeryfrontAPIOperations {
         limit: 10000,
       });
       allFiles.push(...result.files);
-      cursor = result.page_info.has_next_page ? (result.page_info.end_cursor ?? undefined) : undefined;
+      cursor = result.page_info.has_next_page
+        ? (result.page_info.end_cursor ?? undefined)
+        : undefined;
     } while (cursor);
 
     return allFiles;

--- a/src/platform/adapters/veryfront-api-client/operations.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.ts
@@ -37,16 +37,16 @@ export interface ListFilesOptions {
  */
 export interface FileListResult {
   files: ProjectFile[];
-  pageInfo: {
-    hasNextPage: boolean;
-    endCursor: string | null;
-    hasPreviousPage?: boolean;
-    startCursor?: string | null;
+  page_info: {
+    has_next_page: boolean;
+    end_cursor: string | null;
+    has_previous_page?: boolean;
+    start_cursor?: string | null;
   };
-  releaseId?: string;
-  releaseVersion?: string | null;
-  environmentId?: string;
-  environmentName?: string;
+  release_id?: string;
+  release_version?: string | null;
+  environment_id?: string;
+  environment_name?: string;
 }
 
 /**
@@ -56,11 +56,11 @@ export interface FileDetail {
   path: string;
   content: string;
   id?: string;
-  versionId?: string;
+  version_id?: string;
   type?: string;
   size?: number;
-  releaseId?: string;
-  releaseVersion?: string | null;
+  release_id?: string;
+  release_version?: string | null;
 }
 
 // =============================================================================
@@ -69,7 +69,7 @@ export interface FileDetail {
 
 function buildListParams(options: ListFilesOptions): URLSearchParams {
   const { cursor, limit = 100, pattern, sortBy = "updatedAt", sortOrder = "desc" } = options;
-  const params = new URLSearchParams({ limit: String(limit), sortBy, sortOrder });
+  const params = new URLSearchParams({ limit: String(limit), sort_by: sortBy, sort_order: sortOrder });
   if (cursor) params.set("cursor", cursor);
   if (pattern) params.set("pattern", pattern);
   return params;
@@ -154,9 +154,9 @@ export class VeryfrontAPIOperations {
         content: f.content,
         type: f.type,
         size: f.size,
-        updatedAt: f.updatedAt,
+        updated_at: f.updated_at,
       })),
-      pageInfo: response.pageInfo,
+      page_info: response.page_info,
     };
   }
 
@@ -178,7 +178,7 @@ export class VeryfrontAPIOperations {
         limit: 10000,
       });
       allFiles.push(...result.files);
-      cursor = result.pageInfo.hasNextPage ? (result.pageInfo.endCursor ?? undefined) : undefined;
+      cursor = result.page_info.has_next_page ? (result.page_info.end_cursor ?? undefined) : undefined;
     } while (cursor);
 
     return allFiles;
@@ -238,18 +238,18 @@ export class VeryfrontAPIOperations {
     return {
       files: response.data.map((f) => ({
         id: f.id,
-        versionId: f.versionId,
+        version_id: f.version_id,
         path: f.path,
         content: f.content,
         type: f.type,
         size: f.size,
-        updatedAt: f.updatedAt,
+        updated_at: f.updated_at,
       })),
-      pageInfo: response.pageInfo,
-      releaseId: response.releaseId,
-      releaseVersion: response.releaseVersion,
-      environmentId: response.environmentId,
-      environmentName: response.environmentName,
+      page_info: response.page_info,
+      release_id: response.release_id,
+      release_version: response.release_version,
+      environment_id: response.environment_id,
+      environment_name: response.environment_name,
     };
   }
 
@@ -271,7 +271,7 @@ export class VeryfrontAPIOperations {
         limit: 10000,
       });
       allFiles.push(...result.files);
-      cursor = result.pageInfo.hasNextPage ? (result.pageInfo.endCursor ?? undefined) : undefined;
+      cursor = result.page_info.has_next_page ? (result.page_info.end_cursor ?? undefined) : undefined;
     } while (cursor);
 
     logger.debug("[API] listAllEnvironmentFiles", {
@@ -303,9 +303,9 @@ export class VeryfrontAPIOperations {
       path: response.path,
       content: response.content,
       id: response.id,
-      versionId: response.versionId,
-      releaseId: response.releaseId,
-      releaseVersion: response.releaseVersion,
+      version_id: response.version_id,
+      release_id: response.release_id,
+      release_version: response.release_version,
     };
   }
 
@@ -334,16 +334,16 @@ export class VeryfrontAPIOperations {
     return {
       files: response.data.map((f) => ({
         id: f.id,
-        versionId: f.versionId,
+        version_id: f.version_id,
         path: f.path,
         content: f.content,
         type: f.type,
         size: f.size,
-        updatedAt: f.updatedAt,
+        updated_at: f.updated_at,
       })),
-      pageInfo: response.pageInfo,
-      releaseId: response.releaseId,
-      releaseVersion: response.releaseVersion,
+      page_info: response.page_info,
+      release_id: response.release_id,
+      release_version: response.release_version,
     };
   }
 
@@ -365,7 +365,7 @@ export class VeryfrontAPIOperations {
         limit: 10000,
       });
       allFiles.push(...result.files);
-      cursor = result.pageInfo.hasNextPage ? (result.pageInfo.endCursor ?? undefined) : undefined;
+      cursor = result.page_info.has_next_page ? (result.page_info.end_cursor ?? undefined) : undefined;
     } while (cursor);
 
     return allFiles;
@@ -391,9 +391,9 @@ export class VeryfrontAPIOperations {
       path: response.path,
       content: response.content,
       id: response.id,
-      versionId: response.versionId,
-      releaseId: response.releaseId,
-      releaseVersion: response.releaseVersion,
+      version_id: response.version_id,
+      release_id: response.release_id,
+      release_version: response.release_version,
     };
   }
 
@@ -415,7 +415,7 @@ export class VeryfrontAPIOperations {
 
       logger.debug("[API] Domain lookup result", {
         domain,
-        projectSlug: response.projectSlug,
+        projectSlug: response.project_slug,
         environment: response.environment?.name,
       });
 

--- a/src/platform/adapters/veryfront-api-client/schemas.ts
+++ b/src/platform/adapters/veryfront-api-client/schemas.ts
@@ -40,7 +40,7 @@ const BaseFileFields = {
   path: z.string(),
   type: FileTypeEnum,
   size: z.number(),
-  updatedAt: z.string(),
+  updated_at: z.string(),
   _links: LinksSchema.optional(),
 };
 
@@ -53,8 +53,8 @@ export const ProjectSchema = z.object({
   name: z.string(),
   slug: z.string(),
   description: z.string().optional(),
-  createdAt: z.string().optional(),
-  updatedAt: z.string().optional(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
   provider: z.string().optional(),
   provider_id: z.string().optional(),
   layout: z.string().optional(),
@@ -64,19 +64,19 @@ export const ProjectSchema = z.object({
 
 export const ProjectFileSchema = z.object({
   id: z.string().optional(),
-  versionId: z.string().optional(),
+  version_id: z.string().optional(),
   path: z.string(),
   content: z.string().optional(),
   size: z.number(),
   type: FileTypeEnum,
-  updatedAt: z.string(),
+  updated_at: z.string(),
 });
 
 export const PageInfoSchema = z.object({
-  hasNextPage: z.boolean(),
-  endCursor: z.string().nullable(),
-  hasPreviousPage: z.boolean().optional(),
-  startCursor: z.string().nullable().optional(),
+  has_next_page: z.boolean(),
+  end_cursor: z.string().nullable(),
+  has_previous_page: z.boolean().optional(),
+  start_cursor: z.string().nullable().optional(),
 });
 
 export const EnvironmentSchema = z.object({
@@ -97,7 +97,7 @@ export const BranchFileListItemSchema = z.object({
 
 export const ListBranchFilesResponseSchema = z.object({
   data: z.array(BranchFileListItemSchema),
-  pageInfo: PageInfoSchema,
+  page_info: PageInfoSchema,
   _links: LinksSchema.optional(),
 });
 
@@ -115,17 +115,17 @@ export const BranchFileDetailSchema = z.object({
 // Shared fields for environment/release responses
 const VersionedFileFields = {
   id: z.string(),
-  versionId: z.string(),
+  version_id: z.string(),
 };
 
 const ReleaseMetaFields = {
-  releaseId: z.string(),
-  releaseVersion: z.string().nullable(),
+  release_id: z.string(),
+  release_version: z.string().nullable(),
 };
 
 const EnvironmentMetaFields = {
-  environmentId: z.string(),
-  environmentName: z.string(),
+  environment_id: z.string(),
+  environment_name: z.string(),
   ...ReleaseMetaFields,
 };
 
@@ -137,7 +137,7 @@ export const EnvironmentFileListItemSchema = z.object({
 
 export const ListEnvironmentFilesResponseSchema = z.object({
   data: z.array(EnvironmentFileListItemSchema),
-  pageInfo: PageInfoSchema,
+  page_info: PageInfoSchema,
   ...EnvironmentMetaFields,
   _links: LinksSchema.optional(),
 });
@@ -162,7 +162,7 @@ export const ReleaseFileListItemSchema = z.object({
 
 export const ListReleaseFilesResponseSchema = z.object({
   data: z.array(ReleaseFileListItemSchema),
-  pageInfo: PageInfoSchema,
+  page_info: PageInfoSchema,
   ...ReleaseMetaFields,
   _links: LinksSchema.optional(),
 });
@@ -188,11 +188,11 @@ export const ListProjectsResponseSchema = z.object({
 // =============================================================================
 
 export const LookupDomainResponseSchema = z.object({
-  projectId: z.string().uuid(),
-  projectSlug: z.string(),
-  projectName: z.string(),
+  project_id: z.string().uuid(),
+  project_slug: z.string(),
+  project_name: z.string(),
   environment: EnvironmentSchema.nullable(),
-  releaseId: z.string().uuid().nullable(),
+  release_id: z.string().uuid().nullable(),
 });
 
 // =============================================================================

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -750,9 +750,9 @@ export class RenderPipeline {
     const fs = this.config.adapter?.fs;
     if (fs && isExtendedFSAdapter(fs) && fs.isVeryfrontAdapter()) {
       const wrappedAdapter = fs.getUnderlyingAdapter() as {
-        getProjectData?: () => { updatedAt?: string } | undefined;
+        getProjectData?: () => { updated_at?: string } | undefined;
       };
-      projectUpdatedAt = wrappedAdapter.getProjectData?.()?.updatedAt;
+      projectUpdatedAt = wrappedAdapter.getProjectData?.()?.updated_at;
     }
 
     // 11. Resolve app component path (contains QueryClientProvider, etc.)

--- a/src/server/universal-handler/index.ts
+++ b/src/server/universal-handler/index.ts
@@ -294,16 +294,16 @@ export function createVeryfrontHandler(
           const lookupResult = await lookupProjectByDomain(lookupHost, apiConfig);
 
           if (lookupResult) {
-            projectSlug = lookupResult.projectSlug;
-            projectId = lookupResult.projectId;
-            releaseId = lookupResult.releaseId ?? undefined;
+            projectSlug = lookupResult.project_slug;
+            projectId = lookupResult.project_id;
+            releaseId = lookupResult.release_id ?? undefined;
             proxyEnv = getEnvironmentType(lookupResult);
             logger.info("[universal] Domain lookup successful", {
               domain: host,
-              projectSlug: lookupResult.projectSlug,
-              projectId: lookupResult.projectId,
+              projectSlug: lookupResult.project_slug,
+              projectId: lookupResult.project_id,
               environment: proxyEnv,
-              releaseId: lookupResult.releaseId,
+              releaseId: lookupResult.release_id,
             });
           } else {
             logger.warn("[universal] No project found for domain", { host: lookupHost });
@@ -341,9 +341,9 @@ export function createVeryfrontHandler(
             apiToken: effectiveToken,
           });
 
-          if (lookupResult?.releaseId) {
-            releaseId = lookupResult.releaseId;
-            projectId = projectId || lookupResult.projectId;
+          if (lookupResult?.release_id) {
+            releaseId = lookupResult.release_id;
+            projectId = projectId || lookupResult.project_id;
             proxyEnv = "production";
             logger.info("[universal] Veryfront domain release lookup successful", {
               projectSlug,

--- a/src/server/utils/domain-lookup.ts
+++ b/src/server/utils/domain-lookup.ts
@@ -8,11 +8,11 @@
 import { logger } from "@veryfront/utils";
 
 export interface DomainLookupResult {
-  projectId: string;
-  projectSlug: string;
-  projectName: string;
+  project_id: string;
+  project_slug: string;
+  project_name: string;
   environment: { id: string; name: string } | null;
-  releaseId: string | null;
+  release_id: string | null;
 }
 
 export interface DomainLookupConfig {
@@ -61,7 +61,7 @@ export async function lookupProjectByDomain(
 
     logger.debug("[DomainLookup] Domain lookup result", {
       domain,
-      projectSlug: result.projectSlug,
+      projectSlug: result.project_slug,
       environment: result.environment?.name,
     });
 


### PR DESCRIPTION
## Description

Update the renderer to align with the API's snake_case naming conventions for all response properties. This includes file metadata (updated_at, version_id), pagination info (page_info, has_next_page), project details (project_id, project_slug), and domain lookup responses.

## Type of Change

- [x] Refactoring (no feature or behavior change)

## Changes Made

- Updated Zod schemas in `schemas.ts` to use snake_case property names
- Updated API response parsing in `operations.ts` to read and map snake_case fields
- Updated domain lookup interface and property access in `domain-lookup.ts`
- Updated universal handler to use snake_case when accessing lookup results
- Updated file stat operations to use snake_case timestamps
- Updated test mocks to use snake_case API response format

## Testing

- [x] All tests pass locally: 695 passed (3844 steps)
- [x] Type checking passes: deno task typecheck
- [x] Linting passes: deno task lint

## Code Quality

- [x] No type errors detected
- [x] All unit tests passing
- [x] Lint checks passing

**Test Results:**
```
ok | 695 passed (3844 steps) | 0 failed (4s)
```