### PR TITLE
fix: .env loading and revert API defaults to lvh.me

### DIFF
--- a/proxy/logger.ts
+++ b/proxy/logger.ts
@@ -1,4 +1,7 @@
-import { getEnv } from "../src/platform/compat/process.ts";
+// Inline getEnv to avoid dependency on src/platform/compat (not copied in Docker)
+function getEnv(key: string): string | undefined {
+  return Deno.env.get(key);
+}
 import { getTraceContext } from "./tracing.ts";
 
 export type LogLevel = "debug" | "info" | "warn" | "error";

--- a/proxy/main.ts
+++ b/proxy/main.ts
@@ -33,7 +33,7 @@ import { proxyLogger } from "./logger.ts";
 // Configuration from environment variables
 const config = {
   apiBaseUrl: Deno.env.get("VERYFRONT_API_BASE_URL") ||
-    "http://api.veryfront.dev:4000",
+    "http://api.lvh.me:4000",
   clientId: Deno.env.get("OAUTH_CLIENT_ID") || "",
   clientSecret: Deno.env.get("OAUTH_CLIENT_SECRET") || "",
   previewClientId: Deno.env.get("OAUTH_PREVIEW_CLIENT_ID") || "",

--- a/src/core/config/env.ts
+++ b/src/core/config/env.ts
@@ -13,7 +13,7 @@ export function getDisableLruIntervalEnv(): boolean {
 export function getApiBaseUrlEnv(): string {
   return getEnv("VERYFRONT_API_BASE_URL") ||
     getEnv("VERYFRONT_API_URL")?.replace("/graphql", "/api") ||
-    "http://api.veryfront.dev:4000";
+    "http://api.lvh.me:4000";
 }
 
 export function getSsrMaxConcurrentTransformsEnv(defaultValue = 3): number {

--- a/veryfront.config.ts
+++ b/veryfront.config.ts
@@ -11,9 +11,9 @@
  */
 
 // Default URLs
-const DEFAULT_API_URL_LOCAL = "http://api.veryfront.dev:4000";
+const DEFAULT_API_URL_LOCAL = "http://api.lvh.me:4000";
 const DEFAULT_API_URL_PROD = "https://api.veryfront.com";
-const DEFAULT_CORS_ORIGIN_LOCAL = "http://api.veryfront.dev:4000";
+const DEFAULT_CORS_ORIGIN_LOCAL = "http://api.lvh.me:4000";
 
 class ConfigError extends Error {
   constructor(message: string) {
@@ -29,7 +29,8 @@ class ConfigError extends Error {
 let env: Record<string, string> = {};
 try {
   const { load } = await import("https://deno.land/std@0.220.0/dotenv/mod.ts");
-  env = await load({ envPath: ".env" });
+  // examplePath: null skips validation against .env.example (which requires all vars)
+  env = await load({ envPath: ".env", examplePath: null });
 } catch {
   // .env doesn't exist (production) - use environment variables only
 }
@@ -155,7 +156,7 @@ export default useGitHub ? {
   // Dev server config (ignored in production)
   dev: {
     port: 3001,
-    host: "veryfront.dev",
+    host: "lvh.me",
     hmr: contentSource.type === "branch", // Only enable HMR for branch mode
   },
 


### PR DESCRIPTION
## Summary

- Fix .env loading by adding `examplePath: null` to skip validation against `.env.example` (which was causing silent failures)
- Revert API URL defaults from `api.veryfront.dev` to `api.lvh.me` (broken in 76673dc7)
- Revert dev server host from `veryfront.dev` to `lvh.me`
- Inline `getEnv` in `proxy/logger.ts` to fix Docker build (was importing from `src/platform/compat` which isn't copied)

## Root Causes

1. **`.env` not loading**: The dotenv `load()` function validates against `.env.example` by default. When vars like `VERYFRONT_API_TOKEN` are commented out in `.env`, it throws an error which was silently caught, leaving `env = {}`.

2. **Wrong API defaults**: Commit 76673dc7 changed `DEFAULT_API_URL_LOCAL` from `api.lvh.me:4000` to `api.veryfront.dev:4000`. PR #62 fixed the dev server URLs but missed the API defaults.

3. **Docker build failure**: `proxy/logger.ts` imported from `../src/platform/compat/process.ts` which isn't copied in `Dockerfile.proxy`.

## Test plan

- [ ] Run `deno task dev:multi` and verify it connects to `https://api.veryfront.com`
- [ ] Verify Docker proxy build passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)