### PR TITLE
feat: split preview mode and embed params, handle branch 404s

### DIFF
--- a/proxy/main.ts
+++ b/proxy/main.ts
@@ -76,9 +76,9 @@ function handleWebSocketUpgrade(req: Request): Response {
   const url = new URL(req.url);
   const host = req.headers.get("host") || "";
   const parsed = parseProjectDomain(host);
-  // Use preview mode when studio_embed=true (Studio preview iframe)
-  const isStudioEmbed = url.searchParams.get("studio_embed") === "true";
-  const scope = isStudioEmbed ? "preview" : getScope(parsed.environment);
+  // Use preview mode when preview_mode=true
+  const isPreviewMode = url.searchParams.get("preview_mode") === "true";
+  const scope = isPreviewMode ? "preview" : getScope(parsed.environment);
   const projectSlug = parsed.slug || undefined;
 
   proxyLogger.info("WebSocket upgrade request", {
@@ -185,16 +185,16 @@ function handleRequest(req: Request): Promise<Response> {
   const execute = async (): Promise<Response> => {
     try {
       const parsed = parseProjectDomain(host);
-      // Use preview mode when studio_embed=true (Studio preview iframe)
-      // This ensures custom domains use draft content in Studio preview
-      const isStudioEmbed = url.searchParams.get("studio_embed") === "true";
-      const scope = isStudioEmbed ? "preview" : getScope(parsed.environment);
+      // Use preview mode when preview_mode=true
+      // This ensures custom domains use draft content when requested
+      const isPreviewMode = url.searchParams.get("preview_mode") === "true";
+      const scope = isPreviewMode ? "preview" : getScope(parsed.environment);
       const projectSlug = parsed.slug || undefined;
 
       const reqLogger = proxyLogger.child({
         project: projectSlug,
         env: scope,
-        ...(isStudioEmbed && { studio: true }),
+        ...(isPreviewMode && { preview: true }),
       });
 
       reqLogger.debug("Request received", {

--- a/src/security/http/response/security-handler.ts
+++ b/src/security/http/response/security-handler.ts
@@ -95,9 +95,9 @@ export function applySecurityHeaders(
   const contentTypeOptions = getHeaderOverride("x-content-type-options") ?? "nosniff";
   headers.set("X-Content-Type-Options", contentTypeOptions);
 
-  // Skip X-Frame-Options in development mode or when embedded in Studio
-  // This allows Studio iframe embedding for preview functionality
-  // In production (non-studio), default to DENY for security
+  // X-Frame-Options: Block iframe embedding by default for security
+  // Skip when studio_embed=true to allow embedding (e.g., in Veryfront Studio)
+  // Projects can customize via config.headers["x-frame-options"]
   if (!isDev && !studioEmbed) {
     const frameOptions = getHeaderOverride("x-frame-options") ?? "DENY";
     headers.set("X-Frame-Options", frameOptions);

--- a/src/server/handlers/request/ssr/is-production-mode.test.ts
+++ b/src/server/handlers/request/ssr/is-production-mode.test.ts
@@ -94,7 +94,7 @@ Deno.test("isProductionMode", async (t) => {
     assertEquals(isProductionMode(ctx), false);
   });
 
-  await t.step("returns false when studio_embed=true regardless of other settings", () => {
+  await t.step("returns false when preview_mode=true regardless of other settings", () => {
     const ctx = createContext({
       config: prodConfig, // Would normally make it production
       parsedDomain: {
@@ -106,13 +106,13 @@ Deno.test("isProductionMode", async (t) => {
       },
       proxyEnvironment: "production", // Would normally make it production
     });
-    const url = new URL("https://example.com/?studio_embed=true");
+    const url = new URL("https://example.com/?preview_mode=true");
     assertEquals(isProductionMode(ctx, url), false);
   });
 
-  await t.step("studio_embed=true overrides config.productionMode", () => {
+  await t.step("preview_mode=true overrides config.productionMode", () => {
     const ctx = createContext({ config: prodConfig });
-    const url = new URL("https://example.com/?studio_embed=true");
+    const url = new URL("https://example.com/?preview_mode=true");
     assertEquals(isProductionMode(ctx, url), false);
   });
 

--- a/src/server/handlers/request/ssr/ssr-handler.ts
+++ b/src/server/handlers/request/ssr/ssr-handler.ts
@@ -45,11 +45,11 @@ import { VeryfrontAPIError } from "@veryfront/platform/adapters/veryfront-api-cl
 
 /**
  * Determine if request should serve production (released) content.
- * Priority: studio_embed override > config > veryfront domain isDraft flag > proxy environment header
+ * Priority: preview_mode param > config > veryfront domain isDraft flag > proxy environment header
  */
 export function isProductionMode(ctx: HandlerContext, url?: URL): boolean {
-  // Studio embed always uses preview/draft mode for Studio preview iframe
-  if (url?.searchParams.get("studio_embed") === "true") {
+  // preview_mode=true forces preview/draft mode
+  if (url?.searchParams.get("preview_mode") === "true") {
     return false;
   }
 
@@ -213,7 +213,11 @@ export class SSRHandler extends BaseHandler {
           .withCache("no-cache")
           .withContentType(
             getContentType(".html"),
-            '<!DOCTYPE html><html><head><meta charset="utf-8"><title>Service Temporarily Unavailable</title></head><body><h1>503 Service Temporarily Unavailable</h1><p>The server is under heavy load. Please try again.</p></body></html>',
+            generateStyledErrorHtml(
+              503,
+              "Service Unavailable",
+              "The server is under heavy load. Please try again.",
+            ),
             503,
           ),
       );
@@ -433,11 +437,11 @@ export class SSRHandler extends BaseHandler {
         }
 
         const isHeadRequest = req.method.toUpperCase() === "HEAD";
-        const body = isHeadRequest
-          ? null
-          : `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>404 Not Found</title></head><body><h1>404 Not Found</h1><p>The requested path ${
-            slug || "/"
-          } could not be located.</p></body></html>`;
+        const body = isHeadRequest ? null : generateStyledErrorHtml(
+          404,
+          "Not Found",
+          `The requested path "${slug || "/"}" could not be found`,
+        );
 
         const response = builder
           .withCORS(req, ctx.securityConfig?.cors)
@@ -448,24 +452,24 @@ export class SSRHandler extends BaseHandler {
         return this.respond(response);
       }
 
-      // Check for API 404 errors from environment LIST endpoint - means no release exists
-      // Important: Only match the list endpoint (/environments/{name}/files or /files?...)
-      // NOT individual file fetches (/environments/{name}/files/{path}) which are normal 404s
+      // Check for API 404 errors from file LIST endpoints - means no content exists
+      // This handles both:
+      // - /environments/{name}/files (production mode, no release)
+      // - /branches/{name}/files (preview mode with preview_mode=true, no draft content)
+      // Important: Only match list endpoints, NOT individual file fetches (/files/{path})
       if (error instanceof VeryfrontAPIError && error.status === 404) {
-        const isProductionRequest = isProductionMode(ctx, url);
         const errorDetails = error.details as { url?: string; responseText?: string } | undefined;
         const apiUrl = errorDetails?.url || "";
 
-        // Check if this is an environment list request (not a specific file fetch)
-        // List endpoint: /environments/{name}/files or /environments/{name}/files?...
-        // File endpoint: /environments/{name}/files/{path} - has path after /files/
-        const isEnvironmentListRequest = apiUrl.includes("/environments/") &&
-          apiUrl.includes("/files") &&
-          !apiUrl.includes("/files/"); // No path segment after /files/
+        // Check if this is a file list request (not a specific file fetch)
+        // List endpoints end with /files or /files?... (no path after /files/)
+        const isFileListRequest = apiUrl.includes("/files") &&
+          !apiUrl.includes("/files/") &&
+          (apiUrl.includes("/environments/") || apiUrl.includes("/branches/"));
 
-        // If this is a production request hitting the environment LIST endpoint, it means no release
-        if (isProductionRequest && isEnvironmentListRequest) {
-          this.logDebug("No release found for production environment", {
+        // Show friendly page when listing files fails (no release or no draft content)
+        if (isFileListRequest) {
+          this.logDebug("No content found for project", {
             projectSlug: ctx.projectSlug,
             apiUrl,
             error: this.getErrorMessage(error),
@@ -475,9 +479,11 @@ export class SSRHandler extends BaseHandler {
           const builder = this.createResponseBuilder(ctx, notDeployedNonce, builderOptions);
           const isHeadRequest = req.method.toUpperCase() === "HEAD";
 
-          const body = isHeadRequest
-            ? null
-            : generateNotDeployedHtml(ctx.projectSlug || "this project");
+          const body = isHeadRequest ? null : generateStyledErrorHtml(
+            404,
+            "Not Deployed",
+            "This project hasn't been deployed yet",
+          );
 
           const response = builder
             .withCORS(req, ctx.securityConfig?.cors)
@@ -536,9 +542,11 @@ export class SSRHandler extends BaseHandler {
       }
 
       // Generic error fallback
-      const body = isHead
-        ? null
-        : `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Internal Server Error</title></head><body><h1>500 Internal Server Error</h1><p>Unexpected error rendering this page.</p></body></html>`;
+      const body = isHead ? null : generateStyledErrorHtml(
+        500,
+        "Server Error",
+        "An unexpected error occurred while rendering this page",
+      );
 
       const response = builder
         .withCORS(req, ctx.securityConfig?.cors)
@@ -552,24 +560,28 @@ export class SSRHandler extends BaseHandler {
 }
 
 /**
- * Generate a 404 page for projects that haven't been deployed yet.
+ * Generate a styled error page for any status code.
  * Styled to match the Veryfront design system.
  */
-function generateNotDeployedHtml(_projectSlug: string): string {
+function generateStyledErrorHtml(
+  statusCode: number,
+  title: string,
+  message: string,
+): string {
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <link rel="icon" type="image/png" href="https://cdn.veryfront.com/images/veryfront-favicon.png">
-  <title>Not Deployed — Veryfront</title>
+  <title>${statusCode} ${title} — Veryfront</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body>
   <div class="fixed z-[2147483647] inset-0 min-h-screen min-w-full flex flex-col items-center justify-center leading-[1.25] bg-[#0d0e11] text-white">
     <div class="font-sans antialiased text-center flex flex-col items-center px-8 gap-4 tracking-wide">
-      <p class="m-0 font-semibold text-5xl md:text-6xl text-[#949A9F]">Not Deployed</p>
-      <p class="text-white text-xl">This project hasn't been deployed yet</p>
+      <p class="m-0 font-semibold text-5xl md:text-6xl text-[#949A9F]">${title}</p>
+      <p class="text-white text-xl">${message}</p>
     </div>
   </div>
 </body>

--- a/src/server/handlers/request/ssr/ssr-handler.ts
+++ b/src/server/handlers/request/ssr/ssr-handler.ts
@@ -544,8 +544,8 @@ export class SSRHandler extends BaseHandler {
       // Generic error fallback
       const body = isHead ? null : generateStyledErrorHtml(
         500,
-        "Server Error",
-        "An unexpected error occurred while rendering this page",
+        "Internal Server Error",
+        "Something went wrong while rendering this page",
       );
 
       const response = builder


### PR DESCRIPTION
## Summary

- Separate `studio_embed` (embedding/Studio features) from `preview_mode` (draft content)
- `preview_mode=true` forces preview/draft content fetching
- `studio_embed=true` enables Studio features and allows iframe embedding
- Handle "Not Deployed" page for both `/environments/` (production) AND `/branches/` (preview) 404s

## Changes

- **proxy/main.ts**: Check for `preview_mode=true` instead of `studio_embed=true` for preview scope
- **security-handler.ts**: X-Frame-Options: DENY by default, skipped when `studio_embed=true`
- **ssr-handler.ts**: 
  - Check `preview_mode` param for preview mode
  - Handle branch list 404s same as environment list 404s
- **tests**: Updated to use `preview_mode` param

## Test plan

- [ ] `https://myproject.veryfront.com/` - Production content, iframe blocked
- [ ] `https://myproject.veryfront.com/?studio_embed=true` - Production content, iframe allowed
- [ ] `https://myproject.veryfront.com/?preview_mode=true` - Preview/draft content
- [ ] `https://myproject.veryfront.com/?studio_embed=true&preview_mode=true` - Preview content with Studio features

🤖 Generated with [Claude Code](https://claude.com/claude-code)