### PR TITLE
fix: add transform cache versioning to prevent stale module issues

### DIFF
--- a/scripts/dev-proxy.ts
+++ b/scripts/dev-proxy.ts
@@ -36,6 +36,19 @@ function c(color: string, text: string): string {
   return shouldUseColor() ? `${color}${text}${ANSI.reset}` : text;
 }
 
+// Clear module caches on startup to prevent stale transform issues
+// See: https://github.com/veryfront/veryfront-renderer/issues/79
+async function clearModuleCaches(): Promise<void> {
+  const cacheDirs = [".cache/veryfront-mdx-esm", ".cache/veryfront-modules"];
+  for (const dir of cacheDirs) {
+    try {
+      await Deno.remove(dir, { recursive: true });
+    } catch {
+      // Directory doesn't exist, ignore
+    }
+  }
+}
+
 // Check for --single flag
 const args = Deno.args.filter(arg => arg !== "--single");
 const isSingleMode = Deno.args.includes("--single");
@@ -63,6 +76,9 @@ try {
   console.error(c(ANSI.dim, "error:"), "Missing .env - copy from .env.example");
   Deno.exit(1);
 }
+
+// Clear stale module caches on startup
+await clearModuleCaches();
 
 // Start proxy (info level to show request logs)
 const proxyEnv = {

--- a/src/build/transforms/esm/package-registry.ts
+++ b/src/build/transforms/esm/package-registry.ts
@@ -9,6 +9,13 @@ export const REACT_VERSION = "18.3.1";
 export const TAILWIND_VERSION = "4.1.8";
 
 /**
+ * Transform cache version - bump when transform logic changes.
+ * This invalidates all cached modules (local + Redis) to prevent stale transform issues.
+ * See: https://github.com/veryfront/veryfront-renderer/issues/79
+ */
+export const TRANSFORM_CACHE_VERSION = 1;
+
+/**
  * Generate esm.sh URL for browser.
  * Uses ?external= so browser import map provides React (ensures single instance).
  * Uses ?target=es2022 for consistent builds.

--- a/src/build/transforms/mdx/esm-module-loader/module-fetcher/index.ts
+++ b/src/build/transforms/mdx/esm-module-loader/module-fetcher/index.ts
@@ -11,6 +11,7 @@ import { join, posix } from "https://deno.land/std@0.220.0/path/mod.ts";
 import { rendererLogger as logger } from "@veryfront/utils";
 import type { RuntimeAdapter } from "@veryfront/platform/adapters/base.ts";
 import { transformToESM } from "../../../esm-transform.ts";
+import { TRANSFORM_CACHE_VERSION } from "../../../esm/package-registry.ts";
 import {
   LOG_PREFIX_MDX_LOADER,
   RELATIVE_IMPORT_PATTERN,
@@ -228,8 +229,9 @@ async function cacheModule(
   }
 
   // Use content-based cache key so unchanged files stay cached
+  // Include transform version to invalidate on transform logic changes
   const contentHash = hashString(normalizedPath + moduleCode);
-  const cachePath = join(esmCacheDir, `vfmod-${contentHash}.mjs`);
+  const cachePath = join(esmCacheDir, `vfmod-v${TRANSFORM_CACHE_VERSION}-${contentHash}.mjs`);
 
   // Check if this exact content is already cached
   const localFs = getLocalFs();

--- a/src/build/transforms/mdx/esm-module-loader/module-fetcher/index.ts
+++ b/src/build/transforms/mdx/esm-module-loader/module-fetcher/index.ts
@@ -34,6 +34,10 @@ function getPathCacheKey(projectId: string, normalizedPath: string): string {
   return `${encodeURIComponent(projectId)}:${normalizedPath}`;
 }
 
+function getVersionedPathCacheKey(normalizedPath: string): string {
+  return `v${TRANSFORM_CACHE_VERSION}:${normalizedPath}`;
+}
+
 /**
  * Track modules loaded during current render for manifest recording.
  * Key: renderSessionId, Value: Set of normalized module paths
@@ -238,7 +242,7 @@ async function cacheModule(
   try {
     const stat = await localFs.stat(cachePath);
     if (stat?.isFile) {
-      pathCache.set(normalizedPath, cachePath);
+      pathCache.set(getVersionedPathCacheKey(normalizedPath), cachePath);
       logger.debug(`${LOG_PREFIX_MDX_LOADER} Content cache hit: ${normalizedPath}`);
       return cachePath;
     }
@@ -249,7 +253,7 @@ async function cacheModule(
   // Ensure cache directory exists before writing
   await localFs.mkdir(esmCacheDir, { recursive: true });
   await localFs.writeTextFile(cachePath, moduleCode);
-  pathCache.set(normalizedPath, cachePath);
+  pathCache.set(getVersionedPathCacheKey(normalizedPath), cachePath);
   await saveModulePathCache(esmCacheDir);
   logger.debug(`${LOG_PREFIX_MDX_LOADER} Cached vf_module: ${normalizedPath} -> ${cachePath}`);
 
@@ -364,7 +368,8 @@ export async function fetchAndCacheModule(
 
     // Check persistent module path cache first
     const pathCache = await getModulePathCache(esmCacheDir);
-    const cachedPath = pathCache.get(normalizedPath);
+    const versionedKey = getVersionedPathCacheKey(normalizedPath);
+    const cachedPath = pathCache.get(versionedKey);
     if (cachedPath) {
       // Verify the file still exists
       try {
@@ -384,7 +389,7 @@ export async function fetchAndCacheModule(
         }
       } catch {
         // Cache entry is stale, remove it
-        pathCache.delete(normalizedPath);
+        pathCache.delete(versionedKey);
       }
     }
 

--- a/src/module-system/react-loader/ssr-module-loader/loader.ts
+++ b/src/module-system/react-loader/ssr-module-loader/loader.ts
@@ -10,6 +10,7 @@ import { join } from "@veryfront/platform/compat/path/index.ts";
 import type * as React from "react";
 import { transformToESM } from "@veryfront/transforms/esm/index.ts";
 import type { TransformOptions } from "@veryfront/transforms/esm/types.ts";
+import { TRANSFORM_CACHE_VERSION } from "@veryfront/transforms/esm/package-registry.ts";
 import {
   type CrossProjectImport,
   type MissingImport,
@@ -142,7 +143,7 @@ export class SSRModuleLoader {
   }
 
   private getCacheKey(filePath: string): string {
-    return `${this.options.projectId}:${filePath}`;
+    return `v${TRANSFORM_CACHE_VERSION}:${this.options.projectId}:${filePath}`;
   }
 
   private getRegistryBaseUrl(): string {


### PR DESCRIPTION
## Summary

- Add `TRANSFORM_CACHE_VERSION` constant to invalidate caches when transform logic changes
- Include version in SSR module loader Redis cache keys (production)
- Include version in MDX module local cache filenames (dev)
- Clear module caches on dev startup to prevent stale transforms

## Related Issue

Fixes #79 - Multi-project mode fails with "No QueryClient set" due to stale cached modules

## Root Cause

Stale cached modules with old `external=react,react-dom` config instead of current `external=react` caused two React instances, breaking context and resulting in "No QueryClient set" errors.

## Test plan

- [x] Run `deno task dev` and verify `http://codersociety.lvh.me:8080/` loads without QueryClient error
- [x] Verify cache files use new `vfmod-v1-{hash}.mjs` naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)