### PR TITLE
fix: support .dark class and data-theme for error page

### DIFF
--- a/src/server/handlers/request/ssr/ssr-handler.ts
+++ b/src/server/handlers/request/ssr/ssr-handler.ts
@@ -576,12 +576,18 @@ function generateStyledErrorHtml(
       --title: #374151;
       --message: #9ca3af;
     }
+    /* Dark mode: system preference, .dark class, or data-theme="dark" */
     @media (prefers-color-scheme: dark) {
-      :root {
+      :root:not(.light):not([data-theme="light"]) {
         --bg: #0d0e11;
         --title: #949A9F;
         --message: #6b7280;
       }
+    }
+    :root.dark, :root[data-theme="dark"] {
+      --bg: #0d0e11;
+      --title: #949A9F;
+      --message: #6b7280;
     }
     body {
       margin: 0;


### PR DESCRIPTION
## Summary

Adds support for `.dark` class and `data-theme="dark"` attribute to the error page, in addition to `prefers-color-scheme`.

Follow-up to #87 (commit was pushed but not included in merge).

## Test plan

1. Visit a non-deployed project
2. Add `class="dark"` or `data-theme="dark"` to `<html>` in devtools
3. Verify dark theme applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)