### PR TITLE
fix: skip COOP header in dev mode to avoid browser warnings

### DIFF
--- a/src/security/http/response/security-handler.ts
+++ b/src/security/http/response/security-handler.ts
@@ -131,12 +131,14 @@ export function applySecurityHeaders(
     headers.set("Strict-Transport-Security", hstsOverride ?? hstsValue);
   }
 
-  // Set COOP, CORP, COEP
-  const coop = getSecurityHeader("COOP", "same-origin", config, adapter);
+  // Set COOP, CORP, COEP (skip COOP in dev - browsers ignore it for non-trustworthy origins)
+  const coop = isDev ? "" : getSecurityHeader("COOP", "same-origin", config, adapter);
   const corp = getSecurityHeader("CORP", "same-origin", config, adapter);
   const coep = getSecurityHeader("COEP", "", config, adapter);
 
-  headers.set("Cross-Origin-Opener-Policy", coop);
+  if (coop) {
+    headers.set("Cross-Origin-Opener-Policy", coop);
+  }
   headers.set("Cross-Origin-Resource-Policy", corp);
   if (coep) {
     headers.set("Cross-Origin-Embedder-Policy", coep);


### PR DESCRIPTION
## Summary

Browsers ignore `Cross-Origin-Opener-Policy` headers for non-trustworthy origins (HTTP on non-localhost domains like `lvh.me`) and show console warnings. This PR skips setting the COOP header in development mode.

## Changes

1. **COOP header fix** - Skip setting `Cross-Origin-Opener-Policy` header when `isDev` is true
2. **Lint fixes** - Fixed pre-existing lint errors (unused imports/vars, unnecessary async)
3. **Projects overview fix** - Removed outdated `proxyMode` check from ProjectsHandler that was blocking the projects overview page at `http://lvh.me:8080/`

## Rationale

- Security headers are less critical in development mode
- HTTP on domains like `lvh.me` is not trustworthy per browser spec
- Other headers like `X-Frame-Options` and `HSTS` are already conditionally set based on `isDev`
- `proxyMode` is now the default, so the check was always failing

Fixes #84

## Test plan

- [x] All linting passes
- [x] All type checking passes  
- [x] Unit tests pass
- [ ] Integration tests (pre-existing failures on main - unrelated to this PR)
- [ ] Run `deno task start` and access `http://lvh.me:8080/`
- [ ] Verify no COOP warning in browser console
- [ ] Verify projects overview page shows

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)