### PR TITLE
fix: skip COOP header in dev mode to avoid browser warnings

### DIFF
--- a/src/security/http/response/security-handler.ts
+++ b/src/security/http/response/security-handler.ts
@@ -131,12 +131,14 @@ export function applySecurityHeaders(
     headers.set("Strict-Transport-Security", hstsOverride ?? hstsValue);
   }
 
-  // Set COOP, CORP, COEP
-  const coop = getSecurityHeader("COOP", "same-origin", config, adapter);
+  // Set COOP, CORP, COEP (skip COOP in dev - browsers ignore it for non-trustworthy origins)
+  const coop = isDev ? "" : getSecurityHeader("COOP", "same-origin", config, adapter);
   const corp = getSecurityHeader("CORP", "same-origin", config, adapter);
   const coep = getSecurityHeader("COEP", "", config, adapter);
 
-  headers.set("Cross-Origin-Opener-Policy", coop);
+  if (coop) {
+    headers.set("Cross-Origin-Opener-Policy", coop);
+  }
   headers.set("Cross-Origin-Resource-Policy", corp);
   if (coep) {
     headers.set("Cross-Origin-Embedder-Policy", coep);


### PR DESCRIPTION
## Summary

Browsers ignore `Cross-Origin-Opener-Policy` headers for non-trustworthy origins (HTTP on non-localhost domains like `lvh.me`) and show console warnings. This PR skips setting the COOP header in development mode.

## Changes

Skip setting `Cross-Origin-Opener-Policy` header when `isDev` is true, matching the existing pattern used for `X-Frame-Options` and `HSTS`.

## Rationale

- Security headers are less critical in development mode
- HTTP on domains like `lvh.me` is not trustworthy per browser spec
- Other headers like `X-Frame-Options` and `HSTS` are already conditionally set based on `isDev`

Fixes #84

## Test plan

- [ ] Run `deno task start` and access `http://lvh.me:8080/`
- [ ] Verify no COOP warning in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)