### PR TITLE
fix: persist color_mode only when set via URL param

### DIFF
--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -297,10 +297,19 @@ ${tailwindConfig.customCSS}
     "suppressHydrationWarning",
   ].join(" ");
 
+  // Theme persistence script - only needed when color_mode was set via URL param
+  // This ensures next-themes picks up the SSR theme and doesn't flash/revert
+  const themePersistenceScript = options.colorSchemeFromParam
+    ? `<script${nonce ? ` nonce="${nonce}"` : ""}>
+(function(){try{localStorage.setItem('theme','${colorScheme}')}catch(e){}})();
+</script>`
+    : "";
+
   const start = `<!DOCTYPE html>
 <html ${htmlAttrs}>
 <head>
   ${hydrationErrorSuppression}
+  ${themePersistenceScript}
   ${metaTags}
   <title>${escapeHTML(effectiveTitle)}</title>
 

--- a/src/html/types.ts
+++ b/src/html/types.ts
@@ -30,8 +30,10 @@ export interface HTMLGenerationOptions {
   pageId?: string;
   /** Hash of source code for Navigator tree sync detection */
   sourceHash?: string;
-  /** User's preferred color scheme from Sec-CH-Prefers-Color-Scheme header */
+  /** User's preferred color scheme from Sec-CH-Prefers-Color-Scheme header or URL param */
   colorScheme?: "light" | "dark";
+  /** Whether colorScheme was set via color_mode URL param (needs localStorage persistence) */
+  colorSchemeFromParam?: boolean;
   /** Proxy environment for cloud deployments (preview or production) */
   proxyEnvironment?: "preview" | "production";
   /** Headings extracted from MDX for sidebar/TOC navigation */

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -260,6 +260,7 @@ export class HTMLGenerator {
       pageId: context.options?.pageId,
       sourceHash,
       colorScheme: context.options?.colorScheme,
+      colorSchemeFromParam: context.options?.colorSchemeFromParam,
       proxyEnvironment: context.options?.proxyEnvironment,
       headings: context.pageBundle.headings,
     };

--- a/src/rendering/orchestrator/types.ts
+++ b/src/rendering/orchestrator/types.ts
@@ -45,6 +45,8 @@ export interface RenderOptions {
   projectId?: string;
   pageId?: string;
   colorScheme?: "light" | "dark";
+  /** Whether colorScheme was set via color_mode URL param (needs localStorage persistence) */
+  colorSchemeFromParam?: boolean;
   proxyEnvironment?: "preview" | "production";
   /** Project slug for HTTP fallback in multi-project mode */
   projectSlug?: string;

--- a/src/security/http/client-hints.ts
+++ b/src/security/http/client-hints.ts
@@ -7,25 +7,47 @@
 
 export type ColorScheme = "light" | "dark";
 
+export interface ColorSchemeResult {
+  scheme: ColorScheme;
+  fromParam: boolean;
+}
+
 /**
- * Extract color scheme preference from Sec-CH-Prefers-Color-Scheme header
+ * Extract color scheme preference from multiple sources (priority order):
+ * 1. `color_mode` query parameter (explicit override)
+ * 2. `Sec-CH-Prefers-Color-Scheme` header (browser preference)
+ * 3. Default: "light"
  *
  * @param request - The incoming request
- * @returns The color scheme preference, defaults to "light"
+ * @param url - Optional URL to check for color_mode query param
+ * @returns Object with scheme and whether it came from a URL param
  */
-export function getColorSchemeFromRequest(request: Request): ColorScheme {
+export function getColorSchemeFromRequest(
+  request: Request,
+  url?: URL,
+): ColorSchemeResult {
+  // Priority 1: Check color_mode query parameter (explicit user override)
+  const requestUrl = url || new URL(request.url);
+  const colorModeParam = requestUrl.searchParams.get("color_mode");
+
+  if (colorModeParam) {
+    const normalizedParam = colorModeParam.trim().toLowerCase();
+    if (normalizedParam === "dark" || normalizedParam === "light") {
+      return { scheme: normalizedParam, fromParam: true };
+    }
+  }
+
+  // Priority 2: Check Sec-CH-Prefers-Color-Scheme header
   const header = request.headers.get("Sec-CH-Prefers-Color-Scheme");
 
-  if (!header) {
-    return "light";
+  if (header) {
+    // Header value is quoted: "dark" or "light"
+    const value = header.replace(/"/g, "").trim().toLowerCase();
+
+    if (value === "dark") {
+      return { scheme: "dark", fromParam: false };
+    }
   }
 
-  // Header value is quoted: "dark" or "light"
-  const value = header.replace(/"/g, "").trim().toLowerCase();
-
-  if (value === "dark") {
-    return "dark";
-  }
-
-  return "light";
+  return { scheme: "light", fromParam: false };
 }

--- a/src/server/handlers/request/ssr/ssr-handler.ts
+++ b/src/server/handlers/request/ssr/ssr-handler.ts
@@ -268,8 +268,11 @@ export class SSRHandler extends BaseHandler {
         undefined;
       const pageId = url.searchParams.get("page_id") || undefined;
 
-      // Extract color scheme from client hints (Sec-CH-Prefers-Color-Scheme header)
-      const colorScheme = getColorSchemeFromRequest(req);
+      // Extract color scheme from client hints or color_mode query parameter
+      const { scheme: colorScheme, fromParam: colorSchemeFromParam } = getColorSchemeFromRequest(
+        req,
+        url,
+      );
 
       // Memory profiling: log heap before render for debugging large projects
       const preRenderHeap = getHeapStats();
@@ -298,6 +301,7 @@ export class SSRHandler extends BaseHandler {
           projectId,
           pageId,
           colorScheme,
+          colorSchemeFromParam,
           proxyEnvironment: ctx.proxyEnvironment,
           projectSlug: ctx.projectSlug,
         }));


### PR DESCRIPTION
## Summary

- Track when colorScheme comes from URL param vs client hints header
- Only write theme to localStorage when explicitly set via `color_mode` param
- Prevents overwriting user's theme preference on every page load

## Problem

When visiting a page with `?color_mode=dark`, the theme was correctly applied during SSR, but after hydration the theme would revert. This happened because the client-side script always checked for `color_mode` in the URL and wrote to localStorage, but the hydration process would then read from localStorage before the script ran.

## Solution

1. Server now tracks whether colorScheme came from URL param (`colorSchemeFromParam`)
2. Theme persistence script only runs when `colorSchemeFromParam` is true
3. The script writes the server-determined theme value directly to localStorage (no URL parsing needed client-side)

## Test plan

- [ ] Visit `http://localhost:8080/?color_mode=dark` - should render dark and stay dark after hydration
- [ ] Visit `http://localhost:8080/` without color_mode param - should use browser preference/localStorage
- [ ] Toggle theme using next-themes/UI - preference should persist across refreshes

Fixes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)