### PR TITLE
fix(ssr): head reconciliation to prevent duplicate titles

### DIFF
--- a/src/html/html-shell-generator.test.ts
+++ b/src/html/html-shell-generator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "std/testing/bdd.ts";
-import { assert, assertStringIncludes } from "std/assert/mod.ts";
-import { wrapInHTMLShell } from "./html-shell-generator.ts";
+import { assert, assertEquals, assertStringIncludes } from "std/assert/mod.ts";
+import { extractHeadElements, wrapInHTMLShell } from "./html-shell-generator.ts";
 import type { RenderMetadata } from "@veryfront/types";
 import type { HTMLGenerationOptions } from "./types.ts";
 
@@ -10,6 +10,92 @@ describe("html-generation/html-shell-generator", () => {
       components: [],
     },
   };
+
+  describe("extractHeadElements", () => {
+    it("should extract title from Head wrapper", () => {
+      const content = `
+        <div data-veryfront-head="1" style="display:none">
+          <title>My Page Title</title>
+        </div>
+        <main>Content</main>
+      `;
+
+      const { metadata, cleanedContent } = extractHeadElements(content);
+
+      assertEquals(metadata.title, "My Page Title");
+      assertStringIncludes(
+        cleanedContent,
+        '<div data-veryfront-head="1" style="display:none"></div>',
+      );
+    });
+
+    it("should extract description from Head wrapper", () => {
+      const content = `
+        <div data-veryfront-head="1" style="display:none">
+          <meta name="description" content="Page description"/>
+        </div>
+        <main>Content</main>
+      `;
+
+      const { metadata } = extractHeadElements(content);
+
+      assertEquals(metadata.description, "Page description");
+    });
+
+    it("should collect all meta tags", () => {
+      const content = `
+        <div data-veryfront-head="1" style="display:none">
+          <meta property="og:title" content="OG Title"/>
+          <meta name="twitter:card" content="summary_large_image"/>
+        </div>
+        <main>Content</main>
+      `;
+
+      const { metadata } = extractHeadElements(content);
+
+      assertEquals(metadata.metas.length, 2);
+      assertEquals(metadata.metas[0]?.property, "og:title");
+      assertEquals(metadata.metas[0]?.content, "OG Title");
+      assertEquals(metadata.metas[1]?.name, "twitter:card");
+      assertEquals(metadata.metas[1]?.content, "summary_large_image");
+    });
+
+    it("should keep og: and twitter: meta in headElements", () => {
+      const content = `
+        <div data-veryfront-head="1" style="display:none">
+          <title>Title</title>
+          <meta property="og:image" content="/image.png"/>
+        </div>
+        <main>Content</main>
+      `;
+
+      const { headElements } = extractHeadElements(content);
+
+      // og: meta should remain in headElements (injected before </head>)
+      assertStringIncludes(headElements, 'property="og:image"');
+      // title should NOT be in headElements (handled by shell)
+      assert(!headElements.includes("<title>"));
+    });
+
+    it("should handle multiple Head wrappers", () => {
+      const content = `
+        <div data-veryfront-head="1" style="display:none">
+          <title>First Title</title>
+        </div>
+        <div data-veryfront-head="1" style="display:none">
+          <title>Second Title</title>
+          <meta name="description" content="Second description"/>
+        </div>
+        <main>Content</main>
+      `;
+
+      const { metadata } = extractHeadElements(content);
+
+      // Last title wins
+      assertEquals(metadata.title, "Second Title");
+      assertEquals(metadata.description, "Second description");
+    });
+  });
 
   describe("wrapInHTMLShell", () => {
     it("should generate complete HTML document", async () => {
@@ -444,6 +530,129 @@ describe("html-generation/html-shell-generator", () => {
 
       assert(!result.includes("<script>alert('xss')</script>"));
       assertStringIncludes(result, "&lt;script&gt;");
+    });
+
+    it("should use title from Head component over frontmatter default", async () => {
+      const meta: RenderMetadata = {
+        title: "Veryfront App", // Default title
+        slug: "test",
+        frontmatter: {},
+      };
+
+      const options: HTMLGenerationOptions = {
+        mode: "production",
+        config: mockConfig,
+      };
+
+      // Simulate SSR output with Head component containing a title
+      const contentWithHead = `
+        <div data-veryfront-head="1" style="display:none">
+          <title>My Custom Page Title</title>
+        </div>
+        <main>Content</main>
+      `;
+
+      const result = await wrapInHTMLShell(contentWithHead, meta, options);
+
+      // Should have exactly ONE title tag with the Head component's value
+      const titleMatches = result.match(/<title>/g);
+      assert(
+        titleMatches?.length === 1,
+        `Expected exactly 1 title tag, found ${titleMatches?.length}`,
+      );
+      assertStringIncludes(result, "<title>My Custom Page Title</title>");
+      assert(!result.includes("<title>Veryfront App</title>"), "Should not include default title");
+    });
+
+    it("should use description from Head component over default", async () => {
+      const meta: RenderMetadata = {
+        title: "Test",
+        slug: "test",
+        frontmatter: {
+          description: "Default description",
+        },
+      };
+
+      const options: HTMLGenerationOptions = {
+        mode: "production",
+        config: mockConfig,
+      };
+
+      const contentWithHead = `
+        <div data-veryfront-head="1" style="display:none">
+          <meta name="description" content="Custom description from Head"/>
+        </div>
+        <main>Content</main>
+      `;
+
+      const result = await wrapInHTMLShell(contentWithHead, meta, options);
+
+      // Should have the Head component's description
+      assertStringIncludes(result, 'content="Custom description from Head"');
+      assert(
+        !result.includes('content="Default description"'),
+        "Should not include default description",
+      );
+    });
+
+    it("should keep og: and twitter: meta tags from Head component", async () => {
+      const meta: RenderMetadata = {
+        title: "Test",
+        slug: "test",
+        frontmatter: {},
+      };
+
+      const options: HTMLGenerationOptions = {
+        mode: "production",
+        config: mockConfig,
+      };
+
+      const contentWithHead = `
+        <div data-veryfront-head="1" style="display:none">
+          <title>Page Title</title>
+          <meta property="og:title" content="OG Title"/>
+          <meta name="twitter:card" content="summary"/>
+        </div>
+        <main>Content</main>
+      `;
+
+      const result = await wrapInHTMLShell(contentWithHead, meta, options);
+
+      // Title should be extracted and used in shell
+      assertStringIncludes(result, "<title>Page Title</title>");
+
+      // og: and twitter: meta should be injected
+      assertStringIncludes(result, 'property="og:title"');
+      assertStringIncludes(result, 'name="twitter:card"');
+    });
+
+    it("should leave empty wrapper after extraction", async () => {
+      const meta: RenderMetadata = {
+        title: "Test",
+        slug: "test",
+        frontmatter: {},
+      };
+
+      const options: HTMLGenerationOptions = {
+        mode: "production",
+        config: mockConfig,
+      };
+
+      const contentWithHead = `
+        <div data-veryfront-head="1" style="display:none">
+          <title>Page Title</title>
+        </div>
+        <main>Content</main>
+      `;
+
+      const result = await wrapInHTMLShell(contentWithHead, meta, options);
+
+      // Wrapper should be empty (for hydration match)
+      assertStringIncludes(result, '<div data-veryfront-head="1" style="display:none"></div>');
+
+      // Title should be in <head>, not in body
+      const bodyContent = result.split("<body")[1];
+      assert(!bodyContent?.includes("<title>Page Title</title>"), "Title should not be in body");
     });
   });
 });

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -30,6 +30,16 @@ import {
 } from "../module-system/manifest/route-module-manifest.ts";
 
 /**
+ * Metadata extracted from Head component for reconciliation with shell defaults.
+ * These values override frontmatter/default metadata when present.
+ */
+export interface ExtractedHeadMetadata {
+  title?: string;
+  description?: string;
+  metas: Array<{ name?: string; property?: string; content: string }>;
+}
+
+/**
  * Extract head elements from React SSR content and return them separately.
  *
  * React's Head component renders a hidden div with data-veryfront-head attribute.
@@ -37,24 +47,73 @@ import {
  * causing hydration mismatch. This function extracts those elements to inject
  * into the actual <head>, and removes them from the body content.
  *
+ * HEAD RECONCILIATION: This function also parses the extracted content to identify
+ * title, description, and other meta tags. These are returned separately so the
+ * shell generator can use them to REPLACE defaults (not duplicate them).
+ *
  * @param content - The React SSR rendered HTML content
- * @returns Object with extracted head elements HTML and cleaned content
+ * @returns Object with extracted head elements, cleaned content, and parsed metadata
  */
 export function extractHeadElements(
   content: string,
-): { headElements: string; cleanedContent: string } {
+): { headElements: string; cleanedContent: string; metadata: ExtractedHeadMetadata } {
   // Match data-veryfront-head wrappers and extract their inner content
   // Pattern: <div data-veryfront-head="1" style="display:none">...</div>
   // Also handles <template data-veryfront-head="1">...</template>
   const headPattern = /<(div|template)(\s+data-veryfront-head="1"[^>]*)>([\s\S]*?)<\/\1>/gi;
 
   const headElements: string[] = [];
+  const metadata: ExtractedHeadMetadata = { metas: [] };
+
   const cleanedContent = content.replace(headPattern, (_match, tagName, attrs, innerContent) => {
     // Extract valid head elements from the inner content
     // Filter out <body> elements which are invalid in head
     const validHeadContent = innerContent.replace(/<body[^>]*>.*?<\/body>/gi, "");
+
     if (validHeadContent.trim()) {
-      headElements.push(validHeadContent.trim());
+      // Parse title - extract and remove from head elements (shell will render it)
+      const titleMatch = validHeadContent.match(/<title[^>]*>([^<]*)<\/title>/i);
+      if (titleMatch) {
+        metadata.title = titleMatch[1].trim();
+      }
+
+      // Parse meta tags for deduplication
+      const metaPattern = /<meta\s+([^>]*)>/gi;
+      let metaMatch;
+      while ((metaMatch = metaPattern.exec(validHeadContent)) !== null) {
+        const attrsStr = metaMatch[1] ?? "";
+        const nameMatch = attrsStr.match(/name=["']([^"']+)["']/i);
+        const propertyMatch = attrsStr.match(/property=["']([^"']+)["']/i);
+        const contentMatch = attrsStr.match(/content=["']([^"']+)["']/i);
+
+        if (contentMatch?.[1]) {
+          const name = nameMatch?.[1];
+          const property = propertyMatch?.[1];
+          const content = contentMatch[1];
+
+          // Extract description for shell generator
+          if (name === "description") {
+            metadata.description = content;
+          }
+
+          metadata.metas.push({
+            name,
+            property,
+            content,
+          });
+        }
+      }
+
+      // Remove title and description meta from head elements (shell handles these)
+      // Keep other elements (og:*, twitter:*, link, script, style, etc.)
+      const filteredContent = validHeadContent
+        .replace(/<title[^>]*>[^<]*<\/title>/gi, "")
+        .replace(/<meta\s+[^>]*name=["']description["'][^>]*>/gi, "")
+        .trim();
+
+      if (filteredContent) {
+        headElements.push(filteredContent);
+      }
     }
     // Return EMPTY wrapper (not removed) so hydration matches client initial render
     return `<${tagName}${attrs}></${tagName}>`;
@@ -63,6 +122,7 @@ export function extractHeadElements(
   return {
     headElements: headElements.join("\n  "),
     cleanedContent,
+    metadata,
   };
 }
 
@@ -401,13 +461,29 @@ export async function wrapInHTMLShell(
 ): Promise<string> {
   // Extract head elements from React content to inject into actual <head>
   // This fixes hydration mismatch caused by browser hoisting <link>/<meta> out of <div>
-  const { headElements, cleanedContent: rawCleanedContent } = extractHeadElements(content);
+  const { headElements, cleanedContent: rawCleanedContent, metadata } = extractHeadElements(
+    content,
+  );
   // Trim leading/trailing whitespace to prevent hydration mismatch
   // React's virtual DOM doesn't include whitespace at container boundaries
   const cleanedContent = rawCleanedContent.trim();
 
+  // HEAD RECONCILIATION: Use extracted metadata to override frontmatter defaults
+  // This ensures <Head> component values take precedence and avoids duplicate titles
+  const enrichedMeta: RenderMetadata = {
+    ...meta,
+    // If Head component provided a title, use it (overrides frontmatter default)
+    title: metadata.title || meta.title,
+    frontmatter: {
+      ...meta.frontmatter,
+      // Override frontmatter title/description with Head component values
+      ...(metadata.title && { title: metadata.title }),
+      ...(metadata.description && { description: metadata.description }),
+    },
+  };
+
   const { start, end } = await generateHTMLShellParts(
-    meta,
+    enrichedMeta,
     options,
     params,
     props,
@@ -415,6 +491,7 @@ export async function wrapInHTMLShell(
   );
 
   // Inject extracted head elements into the <head> section (before </head>)
+  // Note: title and description are already handled by shell via enrichedMeta
   const startWithHeadElements = headElements
     ? start.replace("</head>", `  ${headElements}\n</head>`)
     : start;

--- a/src/html/index.ts
+++ b/src/html/index.ts
@@ -9,6 +9,7 @@ export {
   generateHTMLShellParts,
   wrapInHTMLShell,
 } from "./html-shell-generator.ts";
+export type { ExtractedHeadMetadata } from "./html-shell-generator.ts";
 export {
   generateHydrationData,
   getDevScripts,

--- a/src/react/components/Head.tsx
+++ b/src/react/components/Head.tsx
@@ -6,21 +6,28 @@ const isServer = typeof window === "undefined";
 /**
  * Head component for declaring head elements (title, meta, link, etc.)
  *
- * HYDRATION FIX: This component uses environment-aware rendering:
+ * Works with React 19's native document metadata support.
  *
- * SSR Phase:
- * 1. Renders hidden div with children: <div data-veryfront-head><link>...</div>
- * 2. extractHeadElements() moves children to actual <head>
- * 3. Leaves empty wrapper: <div data-veryfront-head></div>
+ * SSR PHASE:
+ * 1. Renders hidden div with children: <div data-veryfront-head><title>...</title></div>
+ * 2. extractHeadElements() parses title/description and passes to shell generator
+ * 3. Shell generator uses extracted title (overrides frontmatter default)
+ * 4. Remaining elements injected before </head>
+ * 5. Wrapper left empty: <div data-veryfront-head></div>
  *
- * Client Phase:
+ * HEAD RECONCILIATION:
+ * - Title from <Head> overrides frontmatter title (no duplicates)
+ * - Description from <Head> overrides frontmatter description
+ * - Other meta tags (og:*, twitter:*) are injected alongside frontmatter meta
+ *
+ * CLIENT PHASE:
  * 1. Initial render: empty wrapper (matches SSR cleaned output) - no hydration mismatch
  * 2. After mount: useEffect adds elements directly to document.head
+ * 3. React 19 handles subsequent updates to title/meta natively
  *
- * This ensures:
- * - Head elements are in <head> during SSR (SEO, preloading)
- * - Hydration succeeds (empty wrapper matches both sides)
- * - Client-side navigation works via applyHeadDirectives() in dom-utils.ts
+ * CSR NAVIGATION:
+ * - Server-rendered HTML includes children in wrapper
+ * - applyHeadDirectives() (dom-utils.ts) extracts and applies to document.head
  */
 export function Head({ children }: { children: React.ReactNode }) {
   const mountedRef = useRef(false);

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -94,17 +94,29 @@ export class HTMLGenerator {
     const reactContent = await response.text();
 
     // Extract head elements from React content (moves <link>, <meta>, etc. from body to head)
-    const { headElements, cleanedContent: rawCleanedContent } = extractHeadElements(reactContent);
+    const { headElements, cleanedContent: rawCleanedContent, metadata } = extractHeadElements(
+      reactContent,
+    );
     // Trim leading/trailing whitespace to prevent hydration mismatch
     // React's virtual DOM doesn't include whitespace at container boundaries
     const cleanedContent = rawCleanedContent.trim();
 
+    // HEAD RECONCILIATION: Use extracted metadata to override frontmatter defaults
+    // This ensures <Head> component values take precedence and avoids duplicate titles
+    const effectiveTitle = metadata.title || mergedFrontmatter.title || "Veryfront App";
+    const effectiveDescription = metadata.description || mergedFrontmatter.description || "";
+    const enrichedFrontmatter = {
+      ...mergedFrontmatter,
+      ...(metadata.title && { title: metadata.title }),
+      ...(metadata.description && { description: metadata.description }),
+    };
+
     const { start, end } = await generateHTMLShellParts(
       {
-        title: mergedFrontmatter.title || "Veryfront App",
-        description: mergedFrontmatter.description || "",
+        title: effectiveTitle,
+        description: effectiveDescription,
         slug: context.slug,
-        frontmatter: mergedFrontmatter,
+        frontmatter: enrichedFrontmatter,
         layoutFrontmatter: context.layoutBundle?.frontmatter,
         ssrHash: context.ssrHash,
       },


### PR DESCRIPTION
## Summary

Fixes the title flash issue where the page title would flash from "Veryfront App" to the actual title during hydration.

**Root cause:** The `<Head>` component's title was being appended to the HTML shell *after* it already generated a default title, resulting in two `<title>` tags. The browser uses the first one, then React hydration updates to the correct title → visible flash.

**Solution:** Parse the extracted head elements to identify title/description, then use those values to *override* the shell defaults instead of appending.

## Changes

- `extractHeadElements()` now returns parsed metadata (title, description, metas)
- `wrapInHTMLShell()` uses extracted metadata to override shell defaults
- `generateHTMLStream()` updated with same reconciliation logic
- Updated `Head.tsx` documentation to explain the reconciliation flow
- Added 9 tests proving correct SSR output and hydration matching

## How it works

```
BEFORE (duplicate titles):
1. Shell: <title>Veryfront App</title>
2. Inject: <title>Real Title</title>
→ Two titles, browser uses first → FLASH

AFTER (single title via reconciliation):
1. Extract: parses title from Head wrapper
2. Enrich: passes to shell generator as override
3. Shell: <title>Real Title</title>
→ Single correct title → NO FLASH
```

## Test plan

- [x] All existing tests pass
- [x] New tests verify:
  - Title from Head component overrides default
  - Description from Head component overrides default
  - og:/twitter: meta tags preserved
  - Empty wrapper for hydration match
- [x] Proven via script that SSR output has single correct title
- [x] Proven hydration matches (empty wrapper on both server and client)

Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)