### PR TITLE
feat: enable more E2E test projects and document issues

### DIFF
--- a/docs/E2E_PROJECT_ISSUES.md
+++ b/docs/E2E_PROJECT_ISSUES.md
@@ -1,0 +1,31 @@
+# E2E Test Project Issues
+
+Projects that fail E2E tests.
+
+| Project | Issue | Fix Location |
+|---------|-------|--------------|
+| `real-estate-template` | TypeScript `interface` in MDX | Project content |
+| `dashboard` | Invalid JSX expression in MDX | Project content |
+| `tomcode` | SVG component missing `export default` | **RENDERER BUG** |
+
+## real-estate-template
+
+**Error:** `Could not parse import/exports with acorn`
+
+**Cause:** `pages/index.mdx` contains TypeScript syntax (`interface SearchFilters { ... }`). MDX uses acorn which only parses JavaScript, not TypeScript.
+
+**Fix:** Rename to `.tsx` or move interfaces to a separate `.ts` file.
+
+## dashboard
+
+**Error:** `Could not parse expression with acorn`
+
+**Cause:** `pages/dashboard/index.mdx` contains an invalid JSX expression that acorn cannot parse.
+
+**Fix:** Fix the expression or convert to `.tsx`.
+
+## tomcode
+
+**Error:** `The requested module does not provide an export named 'default'`
+
+**Cause:** SVG components are compiled to JSX but missing `export default`. This is a **renderer bug** in `src/transforms/esm/`.

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -8,62 +8,30 @@
  * Zero tolerance: ANY failure blocks push
  */
 
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import {
-  setupErrorCollection,
-  assertColorMode,
-  assertStudioEmbed,
-  assertPreviewMode,
+  setupErrorCollection
 } from "./helpers/assertions.js";
 
 /**
- * All available projects for testing.
+ * Projects to test.
  *
- * These are local projects that the dev server discovers automatically.
- * Each project tests different aspects of the renderer.
- *
- * Filter by project: E2E_PROJECT=codersociety deno task test:e2e
+ * Comment/uncomment to enable/disable projects.
+ * Filter by project: E2E_PROJECT=codersociety npx playwright test
  */
-const ALL_PROJECTS = [
-  {
-    subdomain: "blank",
-    name: "Blank",
-    description: "Minimal baseline project",
-  },
-  {
-    subdomain: "codersociety",
-    name: "CoderSociety",
-    description: "Full-featured project with complex layouts",
-  },
-  {
-    subdomain: "veryfront",
-    name: "Veryfront",
-    description: "Marketing site with MDX content",
-  },
-];
-
-/**
- * Filter projects based on E2E_PROJECT environment variable.
- *
- * Usage:
- *   E2E_PROJECT=blank deno task test:e2e       # Test only blank project
- *   E2E_PROJECT=codersociety deno task test:e2e # Test only codersociety
- *   deno task test:e2e                          # Test default projects
- *
- * All projects are enabled by default.
- */
-const DEFAULT_PROJECTS = [
+const ENABLED_PROJECTS = [
   "blank",
   "codersociety",
   "veryfront",
-  // Static templates:
-  // "marketing-template",
-  // "restaurant-template",
-  // "real-estate-template",
-  // "lease-calculator",
-  // "impartial-chandrasekhar-qsohb",
-  // "dashboard",
-  // "immo-price-finder",
+  "restaurant-template",
+  "lease-calculator",
+  "impartial-chandrasekhar-qsohb",
+  "immo-price-finder",
+  // "marketing-template", // missing remote deps (veryfront-ui 404s)
+  // "tomcode", // RENDERER BUG: SVG components missing `export default` (see docs/E2E_PROJECT_ISSUES.md)
+  // "real-estate-template", // DATA ISSUE: TypeScript `interface` in MDX (see docs/E2E_PROJECT_ISSUES.md)
+  // "dashboard", // DATA ISSUE: Invalid JSX expression in MDX (see docs/E2E_PROJECT_ISSUES.md)
+  //
   // AI templates:
   // "ai-assistant-template",
   // "task-manager-template",
@@ -75,24 +43,16 @@ const DEFAULT_PROJECTS = [
   // "ai-agent-kitchen-sink",
   // "invest-pro-template",
 ];
+
 const targetProject = process.env.E2E_PROJECT;
-
-const PROJECTS = targetProject
-  ? ALL_PROJECTS.filter((p) => p.subdomain === targetProject)
-  : ALL_PROJECTS.filter((p) => DEFAULT_PROJECTS.includes(p.subdomain));
-
-if (targetProject && PROJECTS.length === 0) {
-  console.error(`Unknown project: ${targetProject}`);
-  console.error(`Available: ${ALL_PROJECTS.map((p) => p.subdomain).join(", ")}`);
-  process.exit(1);
-}
+const PROJECTS = targetProject ? [targetProject] : ENABLED_PROJECTS;
 
 /**
  * Test each project
  */
-for (const project of PROJECTS) {
-  test.describe(`${project.name} (${project.subdomain})`, () => {
-    const baseUrl = `http://${project.subdomain}.lvh.me:8080`;
+for (const subdomain of PROJECTS) {
+  test.describe(subdomain, () => {
+    const baseUrl = `http://${subdomain}.lvh.me:8080`;
 
     /**
      * Basic smoke test: page loads without errors
@@ -250,8 +210,8 @@ for (const project of PROJECTS) {
  */
 test("smoke test summary", async () => {
   console.log(`\nSmoke tests completed for ${PROJECTS.length} projects:`);
-  for (const project of PROJECTS) {
-    console.log(`  - ${project.name}: ${project.description}`);
+  for (const subdomain of PROJECTS) {
+    console.log(`  - ${subdomain}`);
   }
   console.log("\nAll assertions passed!");
 });


### PR DESCRIPTION
## Summary

- Enable 4 additional E2E test projects: `restaurant-template`, `lease-calculator`, `impartial-chandrasekhar-qsohb`, `immo-price-finder`
- Document 3 failing projects in `docs/E2E_PROJECT_ISSUES.md`

## Failing Projects (documented)

| Project | Issue | Type |
|---------|-------|------|
| `real-estate-template` | TypeScript `interface` in MDX | Data issue |
| `dashboard` | Invalid JSX expression in MDX | Data issue |
| `tomcode` | SVG missing `export default` | Renderer bug |

## Test plan

- [x] All 43 E2E tests pass (7 projects × 6 tests + 1 summary)
- [x] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)