### PR TITLE
refactor: update domain lookup to use GET /projects/{domain}

### DIFF
--- a/proxy/handler.test.ts
+++ b/proxy/handler.test.ts
@@ -15,7 +15,7 @@ describe("Proxy Handler", () => {
         (req: Request) => {
           const url = new URL(req.url);
 
-          if (url.pathname === "/oauth/token") {
+          if (url.pathname === "/auth/token") {
             return Response.json({
               access_token: "test-token",
               token_type: "Bearer",
@@ -23,13 +23,12 @@ describe("Proxy Handler", () => {
             });
           }
 
-          if (url.pathname.startsWith("/lookup/domain/")) {
+          if (url.pathname.startsWith("/projects/")) {
             return Response.json({
-              project_id: "proj-123",
-              project_slug: "my-project",
-              project_name: "My Project",
-              environment: { id: "env-1", name: "production" },
-              release_id: "rel-1",
+              id: "proj-123",
+              slug: "my-project",
+              name: "My Project",
+              environments: [{ id: "env-1", name: "production" }],
             });
           }
 
@@ -73,7 +72,7 @@ describe("Proxy Handler", () => {
         (req: Request) => {
           const url = new URL(req.url);
 
-          if (url.pathname === "/oauth/token") {
+          if (url.pathname === "/auth/token") {
             return Response.json({
               access_token: "test-token",
               token_type: "Bearer",
@@ -81,7 +80,7 @@ describe("Proxy Handler", () => {
             });
           }
 
-          if (url.pathname.startsWith("/lookup/domain/")) {
+          if (url.pathname.startsWith("/projects/")) {
             return new Response("Not found", { status: 404 });
           }
 

--- a/proxy/handler.ts
+++ b/proxy/handler.ts
@@ -22,18 +22,18 @@ import { injectContext } from "./tracing.ts";
 
 /**
  * Domain lookup result from API.
+ * Uses GET /projects/{domain} which returns full project data.
  */
 interface DomainLookupResult {
-  project_id: string;
-  project_slug: string;
-  project_name: string;
-  environment: { id: string; name: string } | null;
-  release_id: string | null;
+  id: string;
+  slug: string;
+  name: string;
+  environments?: Array<{ id: string; name: string }>;
 }
 
 /**
  * Look up project info by custom domain.
- * Used to resolve project slug when request comes via custom domain.
+ * Uses GET /projects/{domain} to resolve project slug when request comes via custom domain.
  */
 async function lookupProjectByDomain(
   domain: string,
@@ -42,7 +42,7 @@ async function lookupProjectByDomain(
   logger?: ProxyLogger,
 ): Promise<DomainLookupResult | null> {
   const domainWithoutPort = domain.replace(/:\d+$/, "");
-  const url = `${apiBaseUrl}/lookup/domain/${encodeURIComponent(domainWithoutPort)}`;
+  const url = `${apiBaseUrl}/projects/${encodeURIComponent(domainWithoutPort)}`;
 
   logger?.debug("Looking up project by domain", { domain, url });
 
@@ -71,8 +71,8 @@ async function lookupProjectByDomain(
     const result = await response.json() as DomainLookupResult;
     logger?.debug("Domain lookup successful", {
       domain,
-      projectSlug: result.project_slug,
-      environment: result.environment?.name,
+      projectSlug: result.slug,
+      environments: result.environments?.map((e) => e.name),
     });
     return result;
   } catch (error) {
@@ -262,12 +262,11 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
         const lookupResult = await lookupProjectByDomain(host, config.apiBaseUrl, token, logger);
         if (lookupResult) {
-          projectSlug = lookupResult.project_slug;
+          projectSlug = lookupResult.slug;
           logger?.info("Resolved custom domain to project", {
             domain: host,
             projectSlug,
-            projectId: lookupResult.project_id,
-            environment: lookupResult.environment?.name,
+            projectId: lookupResult.id,
           });
         } else {
           logger?.error("Custom domain not found", undefined, { domain: host });

--- a/proxy/oauth-client.ts
+++ b/proxy/oauth-client.ts
@@ -24,7 +24,7 @@ export interface OAuthTokenConfig {
 export async function fetchOAuthToken(
   config: OAuthTokenConfig,
 ): Promise<TokenResponse> {
-  const url = `${config.apiBaseUrl}/oauth/token`;
+  const url = `${config.apiBaseUrl}/auth/token`;
   const controller = new AbortController();
   const timeoutId = setTimeout(
     () => controller.abort(),

--- a/src/platform/adapters/veryfront-api-client/operations.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.ts
@@ -1,4 +1,5 @@
 import { logger } from "#veryfront/utils";
+import { z } from "zod";
 import { requestWithRetry, type RetryConfig } from "./retry-handler.ts";
 import { VeryfrontAPIError } from "./types.ts";
 import {
@@ -9,7 +10,6 @@ import {
   ListProjectsResponseSchema,
   ListReleaseFilesResponseSchema,
   type LookupDomainResponse,
-  LookupDomainResponseSchema,
   type PageInfo,
   type Project,
   type ProjectFile,
@@ -452,18 +452,40 @@ export class VeryfrontAPIOperations {
 
   /**
    * Look up project info by custom domain.
+   * Uses GET /projects/{domain} which resolves domains automatically.
    * Returns project details and environment info for routing.
    */
   async lookupProjectByDomain(domain: string): Promise<LookupDomainResponse | null> {
     return await withSpan(
       SpanNames.API_DOMAIN_LOOKUP,
       async () => {
-        const url = `/lookup/domain/${encodeURIComponent(domain)}`;
+        const domainWithoutPort = domain.replace(/:\d+$/, "");
+        const url = `/projects/${encodeURIComponent(domainWithoutPort)}`;
         logger.debug("[API] lookupProjectByDomain", { domain });
 
         try {
           const raw = await this.request(url);
-          const response = LookupDomainResponseSchema.parse(raw);
+          const project = ProjectSchema.extend({
+            environments: z.array(z.object({
+              id: z.string().uuid(),
+              name: z.string(),
+              domains: z.array(z.string()).optional(),
+              active_release_id: z.string().uuid().nullable().optional(),
+            })).optional(),
+          }).parse(raw);
+
+          // Find the environment that has this domain
+          const matchingEnv = project.environments?.find(
+            (env) => env.domains?.some((d) => d.toLowerCase() === domainWithoutPort.toLowerCase()),
+          );
+
+          const response: LookupDomainResponse = {
+            project_id: project.id,
+            project_slug: project.slug,
+            project_name: project.name,
+            environment: matchingEnv ? { id: matchingEnv.id, name: matchingEnv.name } : null,
+            release_id: matchingEnv?.active_release_id ?? null,
+          };
 
           logger.debug("[API] Domain lookup result", {
             domain,

--- a/src/platform/adapters/veryfront-api-client/schemas.ts
+++ b/src/platform/adapters/veryfront-api-client/schemas.ts
@@ -190,8 +190,8 @@ export const ListProjectsResponseSchema = z.object({
 });
 
 // =============================================================================
-// Domain Lookup
-// GET /lookup/domain/{domain}
+// Domain Lookup Response
+// Transformed from GET /projects/{domain} response
 // =============================================================================
 
 export const LookupDomainResponseSchema = z.object({
@@ -272,7 +272,7 @@ export const API_ENDPOINTS = {
   },
   lookupDomain: {
     method: "GET" as const,
-    path: "/lookup/domain/{domain}",
-    description: "Look up project by custom domain",
+    path: "/projects/{domain}",
+    description: "Look up project by custom domain (resolved via project_reference)",
   },
 } as const;

--- a/src/server/utils/domain-lookup.ts
+++ b/src/server/utils/domain-lookup.ts
@@ -141,7 +141,28 @@ export async function lookupProjectByDomain(
 }
 
 /**
- * Internal function to fetch domain lookup from API.
+ * Project API response environment type.
+ */
+interface ProjectEnvironment {
+  id: string;
+  name: string;
+  domains?: string[];
+  active_release_id?: string | null;
+}
+
+/**
+ * Project API response type.
+ */
+interface ProjectResponse {
+  id: string;
+  name: string;
+  slug: string;
+  environments?: ProjectEnvironment[];
+}
+
+/**
+ * Internal function to fetch project by domain from API.
+ * Uses GET /projects/{domain} which resolves domains automatically.
  */
 async function fetchDomainLookup(
   domain: string,
@@ -149,7 +170,7 @@ async function fetchDomainLookup(
 ): Promise<DomainLookupResult | null> {
   const domainWithoutPort = domain.replace(/:\d+$/, "");
   const encodedDomain = encodeURIComponent(domainWithoutPort);
-  const url = `${config.apiBaseUrl}/lookup/domain/${encodedDomain}`;
+  const url = `${config.apiBaseUrl}/projects/${encodedDomain}`;
 
   logger.debug("[DomainLookup] Fetching from API", { domain, url });
 
@@ -176,7 +197,20 @@ async function fetchDomainLookup(
       return null;
     }
 
-    const result = await response.json() as DomainLookupResult;
+    const project = await response.json() as ProjectResponse;
+
+    // Find the environment that has this domain
+    const matchingEnv = project.environments?.find(
+      (env) => env.domains?.some((d) => d.toLowerCase() === domainWithoutPort.toLowerCase()),
+    );
+
+    const result: DomainLookupResult = {
+      project_id: project.id,
+      project_slug: project.slug,
+      project_name: project.name,
+      environment: matchingEnv ? { id: matchingEnv.id, name: matchingEnv.name } : null,
+      release_id: matchingEnv?.active_release_id ?? null,
+    };
 
     logger.debug("[DomainLookup] Domain lookup result", {
       domain,


### PR DESCRIPTION
## Summary

Updates Renderer to use the consolidated domain lookup endpoint.

### Changes

Domain lookup now uses `GET /projects/{domain}` instead of the deprecated `/lookup` endpoint.

### Files Changed

- `src/server/utils/domain-lookup.ts` - Updated endpoint path
- `src/platform/adapters/veryfront-api-client/operations.ts` - Updated API client
- `src/platform/adapters/veryfront-api-client/schemas.ts` - Updated schemas
- `proxy/oauth-client.ts` - Minor update

## Test Plan
- [x] Local integration verified with API
- [x] Domain resolution works correctly
- [x] Lint and typecheck pass

## Deployment
Deploy **after** API PR #159 is deployed.

**Order: API → Studio → Renderer**