### PR TITLE
fix: isolate SSR module cache by environment (contentSourceId)

### DIFF
--- a/src/rendering/layouts/layout-applicator.ts
+++ b/src/rendering/layouts/layout-applicator.ts
@@ -26,6 +26,8 @@ export interface LayoutApplicationOptions {
   projectId?: string;
   /** Project slug for HTTP fallback in multi-project mode */
   projectSlug?: string;
+  /** Content source identifier for cache isolation (branch name or release ID) */
+  contentSourceId?: string;
   adapter: RuntimeAdapter;
   config: VeryfrontConfig;
   layoutCache: LayoutComponentCache;
@@ -53,11 +55,13 @@ export class LayoutApplicator {
   private headings?: Array<{ id: string; text: string; level: number }>;
   private projectId?: string;
   private projectSlug?: string;
+  private contentSourceId?: string;
 
   constructor(options: LayoutApplicationOptions) {
     this.projectDir = options.projectDir;
     this.projectId = options.projectId;
     this.projectSlug = options.projectSlug;
+    this.contentSourceId = options.contentSourceId;
     this.adapter = options.adapter;
     this.config = options.config;
     this.layoutCache = options.layoutCache;
@@ -178,6 +182,7 @@ export class LayoutApplicator {
         layoutDataMap,
         this.projectId,
         this.projectSlug,
+        this.contentSourceId,
       );
     }
 

--- a/src/rendering/layouts/utils/applicator.ts
+++ b/src/rendering/layouts/utils/applicator.ts
@@ -20,6 +20,7 @@ export async function applyLayoutsESM(
   layoutDataMap?: Map<string, Record<string, unknown>>,
   projectId?: string,
   projectSlug?: string,
+  contentSourceId?: string,
 ): Promise<BundledReact.ReactElement> {
   let element = pageElement;
 
@@ -37,6 +38,7 @@ export async function applyLayoutsESM(
             adapter,
             projectId,
             projectSlug,
+            contentSourceId,
           );
         } else if (item.kind === "tsx") {
           const props = item.componentPath ? layoutDataMap?.get(item.componentPath) : undefined;
@@ -67,6 +69,7 @@ export async function applyLayoutsESM(
       adapter,
       projectId,
       projectSlug,
+      contentSourceId,
     );
     logger.debug("[applyLayoutsESM] Named layoutBundle applied successfully");
   } else {

--- a/src/rendering/layouts/utils/component-loader.ts
+++ b/src/rendering/layouts/utils/component-loader.ts
@@ -103,6 +103,7 @@ export async function loadMDXLayout(
   adapter: RuntimeAdapter,
   projectId?: string,
   projectSlug?: string,
+  contentSourceId?: string,
 ): Promise<BundledReact.ComponentType<{ components?: MDXComponents }> | undefined> {
   const map = await loadImportMap(projectDir, adapter);
   const code = transformImportsWithMap(bundle.compiledCode, map);
@@ -113,6 +114,7 @@ export async function loadMDXLayout(
     projectId,
     projectDir,
     projectSlug,
+    contentSourceId,
   )) as MDXModule;
   logger.debug("[loadMDXLayout] Module loaded", { exports: Object.keys(mod) });
   return mod.MDXLayout || mod.MainLayout || mod.default;
@@ -152,9 +154,17 @@ export async function applyMDXLayout(
   adapter: RuntimeAdapter,
   projectId?: string,
   projectSlug?: string,
+  contentSourceId?: string,
 ): Promise<BundledReact.ReactElement> {
   const React = await getProjectReact();
-  const LayoutFn = await loadMDXLayout(bundle, projectDir, adapter, projectId, projectSlug);
+  const LayoutFn = await loadMDXLayout(
+    bundle,
+    projectDir,
+    adapter,
+    projectId,
+    projectSlug,
+    contentSourceId,
+  );
 
   if (!LayoutFn) {
     logger.debug("[applyMDXLayout] No layout function found");

--- a/src/rendering/orchestrator/layout.ts
+++ b/src/rendering/orchestrator/layout.ts
@@ -15,6 +15,8 @@ export interface LayoutOrchestratorConfig {
   projectId?: string;
   /** Project slug for HTTP fallback in multi-project mode */
   projectSlug?: string;
+  /** Content source identifier for cache isolation (branch name or release ID) */
+  contentSourceId?: string;
   adapter: RuntimeAdapter;
   config: VeryfrontConfig;
   mode: "development" | "production";
@@ -66,6 +68,7 @@ export class LayoutOrchestrator {
       projectDir: this.config.projectDir,
       projectId: this.config.projectId,
       projectSlug: projectSlug ?? this.config.projectSlug,
+      contentSourceId: this.config.contentSourceId,
       adapter: this.config.adapter,
       config: this.config.config,
       layoutCache: this.config.layoutCache,

--- a/src/rendering/orchestrator/types.ts
+++ b/src/rendering/orchestrator/types.ts
@@ -50,6 +50,8 @@ export interface RenderOptions {
   proxyEnvironment?: "preview" | "production";
   /** Project slug for HTTP fallback in multi-project mode */
   projectSlug?: string;
+  /** Content source identifier for cache isolation (branch name or release ID) */
+  contentSourceId?: string;
 }
 
 export interface RenderContext {

--- a/src/rendering/page-renderer.ts
+++ b/src/rendering/page-renderer.ts
@@ -30,6 +30,8 @@ export interface PageRenderOptions {
   studioEmbed?: boolean;
   /** Project slug for HTTP fallback in multi-project mode */
   projectSlug?: string;
+  /** Content source identifier for cache isolation (branch name or release ID) */
+  contentSourceId?: string;
 }
 
 export interface PageBundleResult {
@@ -220,6 +222,7 @@ export class PageRenderer {
             projectId: options?.projectId,
             studioEmbed: options?.studioEmbed,
             projectSlug: options?.projectSlug,
+            contentSourceId: options?.contentSourceId,
           },
         );
 

--- a/src/rendering/page-rendering.ts
+++ b/src/rendering/page-rendering.ts
@@ -34,6 +34,8 @@ export async function handleMDXPage(
     projectSlug?: string;
     /** Enable node position injection for Studio Navigator */
     studioEmbed?: boolean;
+    /** Content source identifier for cache isolation (branch name or release ID) */
+    contentSourceId?: string;
   },
 ): Promise<MDXPageResult> {
   const fmArg = pageInfo.entity.frontmatter && Object.keys(pageInfo.entity.frontmatter).length > 0
@@ -87,6 +89,7 @@ export async function handleMDXPage(
       options?.projectId,
       projectDir,
       options?.projectSlug,
+      options?.contentSourceId,
     )) as MDXModule;
     const MDXComp = mod.MDXContent || mod.default;
     if (!MDXComp) {

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -173,12 +173,18 @@ export class Renderer {
     // Pass colorScheme so the pipeline cache also respects theme
     const services = this.createServicesForContext(ctx, options?.colorScheme);
 
+    // Compute contentSourceId for cache isolation between preview/production
+    const contentSourceId = ctx.environment === "production" && ctx.releaseId
+      ? `release-${ctx.releaseId}`
+      : `${ctx.environment}-draft`;
+
     // Run the render pipeline
     const result = await services.pipeline.renderPage(slug, {
       ...options,
       projectId: ctx.projectId,
       projectSlug: ctx.projectSlug,
       proxyEnvironment: ctx.environment,
+      contentSourceId,
     });
 
     // Cache the result (context-aware, includes colorScheme in key)
@@ -317,10 +323,15 @@ export class Renderer {
     });
 
     // Create layout orchestrator
+    // Compute contentSourceId for cache isolation between preview/production
+    const contentSourceId = ctx.environment === "production" && ctx.releaseId
+      ? `release-${ctx.releaseId}`
+      : `${ctx.environment}-draft`;
     const layoutOrchestrator = new LayoutOrchestrator({
       projectDir: ctx.projectDir,
       projectId: ctx.projectId,
       projectSlug: ctx.projectSlug,
+      contentSourceId,
       adapter: ctx.adapter,
       config: ctx.config,
       mode: ctx.mode,

--- a/src/transforms/mdx/esm-module-loader/loader.ts
+++ b/src/transforms/mdx/esm-module-loader/loader.ts
@@ -47,6 +47,7 @@ function resolveProjectDir(context: ESMLoaderContext): string {
 
 /**
  * Initialize the ESM cache directory.
+ * Includes contentSourceId in the path to isolate preview vs production caches.
  */
 async function initializeCacheDir(context: ESMLoaderContext): Promise<string> {
   if (context.esmCacheDir) {
@@ -56,7 +57,11 @@ async function initializeCacheDir(context: ESMLoaderContext): Promise<string> {
   const localFs = getLocalFs();
   const baseCacheDir = getMdxEsmCacheDir();
   const projectKey = context.projectId ? encodeURIComponent(context.projectId) : "default";
-  const persistentCacheDir = join(baseCacheDir, projectKey);
+  // Include contentSourceId to separate caches by environment (branch/release)
+  const sourceKey = context.contentSourceId
+    ? encodeURIComponent(context.contentSourceId)
+    : "default";
+  const persistentCacheDir = join(baseCacheDir, projectKey, sourceKey);
 
   try {
     await localFs.mkdir(persistentCacheDir, { recursive: true });

--- a/src/transforms/mdx/esm-module-loader/types.ts
+++ b/src/transforms/mdx/esm-module-loader/types.ts
@@ -26,6 +26,8 @@ export interface ESMLoaderContext {
   projectDir?: string;
   /** Project slug for HTTP fallback URLs (multi-project mode) */
   projectSlug?: string;
+  /** Content source identifier for cache isolation (branch name or release ID) */
+  contentSourceId?: string;
 }
 
 /**

--- a/src/transforms/mdx/index.ts
+++ b/src/transforms/mdx/index.ts
@@ -45,6 +45,7 @@ export class MDXRenderer {
     projectId?: string,
     projectDir?: string,
     projectSlug?: string,
+    contentSourceId?: string,
   ): Promise<MDXModule> {
     // Don't pass esmCacheDir - let loadModuleESM get it fresh from getMdxEsmCacheDir()
     // which respects AsyncLocalStorage for proper test isolation
@@ -55,6 +56,7 @@ export class MDXRenderer {
       projectId,
       projectDir,
       projectSlug,
+      contentSourceId, // For cache isolation between preview/production
     };
     const result = await loadModuleESM(compiledProgramCode, context);
     // Don't cache context.esmCacheDir - it may be for a different AsyncLocalStorage context


### PR DESCRIPTION
## Summary

Adds `contentSourceId` parameter throughout the module loading chain to separate ESM caches between preview and production environments.

Previously, the SSR module cache was keyed only by `projectId`, causing preview and production to share the same cache directory. This led to hydration mismatches when switching environments - SSR would render with cached content from one environment while the client hydrated with different content.

## Root Cause

The ESM module cache path was:
```
.cache/veryfront-mdx-esm/{projectId}/
```

When a user visits preview first, modules get cached. Then visiting production reused those same cached modules (stale preview data). SSR rendered with preview content, client hydrated with production content → mismatch.

## Solution

The `contentSourceId` is computed as:
- Production with release: `release-{releaseId}`
- Preview/draft: `{environment}-draft`

New cache path:
```
.cache/veryfront-mdx-esm/{projectId}/{contentSourceId}/
```

## Files Changed

- `src/transforms/mdx/esm-module-loader/types.ts` - Added `contentSourceId` to `ESMLoaderContext`
- `src/transforms/mdx/esm-module-loader/loader.ts` - Include `contentSourceId` in cache path
- `src/transforms/mdx/index.ts` - Pass `contentSourceId` to module loader
- `src/rendering/page-rendering.ts` - Pass through render chain
- `src/rendering/layouts/utils/component-loader.ts` - Layout loading
- `src/rendering/layouts/utils/applicator.ts` - Layout application
- `src/rendering/layouts/layout-applicator.ts` - Layout applicator
- `src/rendering/orchestrator/layout.ts` - Layout orchestrator
- `src/rendering/orchestrator/types.ts` - RenderOptions type
- `src/rendering/page-renderer.ts` - PageRenderOptions type
- `src/rendering/renderer.ts` - Compute and pass `contentSourceId`

## Test plan

- [ ] Visit preview environment, note content
- [ ] Visit production environment, verify different content renders correctly
- [ ] Switch back and forth, verify no hydration mismatches
- [ ] Check cache directory structure shows separate folders per environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)