### PR TITLE
fix: pass contentSourceId in resolvePageData for SPA navigation

### DIFF
--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -218,12 +218,18 @@ export class Renderer {
       throw new Error("Renderer not initialized. Call initialize() first.");
     }
 
+    // Compute contentSourceId for cache isolation between preview/production
+    const contentSourceId = ctx.environment === "production" && ctx.releaseId
+      ? `release-${ctx.releaseId}`
+      : `${ctx.environment}-draft`;
+
     const services = this.createServicesForContext(ctx);
     return services.pipeline.resolvePageData(slug, {
       ...options,
       projectId: ctx.projectId,
       projectSlug: ctx.projectSlug,
       proxyEnvironment: ctx.environment,
+      contentSourceId,
     });
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #124 - the `resolvePageData` method was missing `contentSourceId`, causing SPA page-data requests to use the shared "default" cache directory.

This meant preview/production could still return stale MDX modules during client-side navigation, even after the initial fix.

## Changes

Added `contentSourceId` computation to `Renderer.resolvePageData()` to match `renderPage()`.

## Test plan

- [ ] Navigate between pages in SPA mode on preview
- [ ] Switch to production, do SPA navigation  
- [ ] Verify no stale frontmatter/headings/CSS from wrong environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)