### PR TITLE
feat(studio): add screenshot capture to studio bridge

### DIFF
--- a/src/server/handlers/request/css-handler.ts
+++ b/src/server/handlers/request/css-handler.ts
@@ -1,20 +1,9 @@
 /**
  * Hashed CSS Handler
  *
- * Serves Tailwind CSS by hash at /_vf/css/[hash].css
- *
- * In production, CSS is generated during SSR and cached by hash.
- * The browser requests the hashed URL and receives the cached CSS
- * with immutable caching headers for optimal performance.
- *
- * Flow:
- * 1. SSR generates HTML with <link href="/_vf/css/[hash].css">
- * 2. cacheCSSAsync() stores CSS in memory + distributed cache
- * 3. Browser requests /_vf/css/[hash].css
- * 4. This handler retrieves CSS by hash and serves it
- *
- * Note: The distributed cache (API) is project-scoped, so we must set up
- * the cache context from HandlerContext before looking up CSS.
+ * Serves Tailwind CSS by hash at /_vf/css/[hash].css with immutable caching.
+ * CSS is generated during SSR and cached (local + distributed). The distributed
+ * cache is project-scoped, so we set cache context from HandlerContext before lookup.
  */
 
 import { BaseHandler } from "../response/base.ts";
@@ -53,17 +42,11 @@ export class CSSHandler extends BaseHandler {
       return this.continue();
     }
 
-    // Extract cache context from handler context for distributed cache lookup.
-    // The distributed cache (API) is project-scoped, so we need context to find
-    // CSS that was stored during SSR (which may have been on a different pod).
+    // Set cache context for project-scoped distributed cache lookup
     const cacheCtx = extractCacheKeyContext(ctx);
-
-    // Retrieve CSS from cache by hash (checks local then distributed cache)
     const css = await runWithCacheKeyContext(cacheCtx, () => getCSSByHashAsync(cssHash));
 
     if (!css) {
-      // Cache miss - CSS was either never cached or evicted
-      // This can happen if server restarted between SSR and CSS request
       this.logDebug(`CSS hash not found: ${cssHash}`, {}, ctx);
 
       const builder = this.createResponseBuilder(ctx);
@@ -79,7 +62,6 @@ export class CSSHandler extends BaseHandler {
       );
     }
 
-    // Serve CSS with immutable caching (hash-based URLs never change)
     const builder = this.createResponseBuilder(ctx);
     return this.respond(
       builder

--- a/src/server/handlers/request/css-handler.ts
+++ b/src/server/handlers/request/css-handler.ts
@@ -21,7 +21,10 @@ import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { getCSSByHashAsync } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
 import { HTTP_NOT_FOUND, HTTP_OK, PRIORITY_HIGH } from "#veryfront/utils/constants/index.ts";
-import { extractCacheKeyContext, runWithCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
+import {
+  extractCacheKeyContext,
+  runWithCacheKeyContext,
+} from "#veryfront/cache/cache-key-builder.ts";
 
 /** Pattern to match hashed CSS URLs: /_vf/css/[8-char-hash].css */
 const CSS_URL_PATTERN = /^\/_vf\/css\/([a-z0-9-]{1,16})\.css$/;

--- a/src/server/handlers/request/css-handler.ts
+++ b/src/server/handlers/request/css-handler.ts
@@ -12,12 +12,16 @@
  * 2. cacheCSSAsync() stores CSS in memory + distributed cache
  * 3. Browser requests /_vf/css/[hash].css
  * 4. This handler retrieves CSS by hash and serves it
+ *
+ * Note: The distributed cache (API) is project-scoped, so we must set up
+ * the cache context from HandlerContext before looking up CSS.
  */
 
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { getCSSByHashAsync } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
 import { HTTP_NOT_FOUND, HTTP_OK, PRIORITY_HIGH } from "#veryfront/utils/constants/index.ts";
+import { extractCacheKeyContext, runWithCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
 
 /** Pattern to match hashed CSS URLs: /_vf/css/[8-char-hash].css */
 const CSS_URL_PATTERN = /^\/_vf\/css\/([a-z0-9-]{1,16})\.css$/;
@@ -46,8 +50,13 @@ export class CSSHandler extends BaseHandler {
       return this.continue();
     }
 
+    // Extract cache context from handler context for distributed cache lookup.
+    // The distributed cache (API) is project-scoped, so we need context to find
+    // CSS that was stored during SSR (which may have been on a different pod).
+    const cacheCtx = extractCacheKeyContext(ctx);
+
     // Retrieve CSS from cache by hash (checks local then distributed cache)
-    const css = await getCSSByHashAsync(cssHash);
+    const css = await runWithCacheKeyContext(cacheCtx, () => getCSSByHashAsync(cssHash));
 
     if (!css) {
       // Cache miss - CSS was either never cached or evicted

--- a/src/studio/bridge-template.ts
+++ b/src/studio/bridge-template.ts
@@ -642,6 +642,9 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
   async function captureScreenshot(options) {
     const { scrollTo, fullPage, quality = 0.8 } = options || {};
 
+    // Save original scroll position to restore later
+    const originalScrollY = window.scrollY;
+
     try {
       await loadHtml2Canvas();
 
@@ -654,7 +657,8 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
       const target = document.body;
       const canvasOptions = {
         useCORS: true,
-        allowTaint: true,
+        // Don't use allowTaint - it causes SecurityError on cross-origin images
+        // With useCORS only, we get partial screenshots instead of hard failures
         logging: false,
         scale: window.devicePixelRatio || 1,
       };
@@ -670,6 +674,9 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
       const canvas = await window.html2canvas(target, canvasOptions);
       const dataUrl = canvas.toDataURL('image/png', quality);
 
+      // Restore original scroll position
+      window.scrollTo(0, originalScrollY);
+
       return {
         success: true,
         data: dataUrl,
@@ -681,6 +688,8 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
         url: window.location.href
       };
     } catch (error) {
+      // Restore scroll position even on error
+      window.scrollTo(0, originalScrollY);
       return {
         success: false,
         error: error.message || String(error)
@@ -689,21 +698,28 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
   }
 
   async function captureMultipleSections(sectionCount) {
+    // Save original scroll position to restore after all captures
+    const originalScrollY = window.scrollY;
     const results = [];
     const totalHeight = document.documentElement.scrollHeight;
     const viewportHeight = window.innerHeight;
     const sections = sectionCount || Math.ceil(totalHeight / viewportHeight);
 
-    for (let i = 0; i < sections; i++) {
-      const scrollY = Math.min(i * viewportHeight, totalHeight - viewportHeight);
-      const result = await captureScreenshot({ scrollTo: scrollY });
-      if (result.success) {
-        results.push({
-          ...result,
-          section: i + 1,
-          totalSections: sections
-        });
+    try {
+      for (let i = 0; i < sections; i++) {
+        const scrollY = Math.min(i * viewportHeight, totalHeight - viewportHeight);
+        const result = await captureScreenshot({ scrollTo: scrollY });
+        if (result.success) {
+          results.push({
+            ...result,
+            section: i + 1,
+            totalSections: sections
+          });
+        }
       }
+    } finally {
+      // Restore original scroll position
+      window.scrollTo(0, originalScrollY);
     }
 
     return results;

--- a/src/studio/bridge-template.ts
+++ b/src/studio/bridge-template.ts
@@ -616,6 +616,99 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
     document.documentElement.classList.add(mode);
   }
 
+  // ============ Screenshot Capture ============
+
+  let html2canvasLoaded = false;
+  let html2canvasPromise = null;
+
+  function loadHtml2Canvas() {
+    if (html2canvasLoaded) return Promise.resolve();
+    if (html2canvasPromise) return html2canvasPromise;
+
+    html2canvasPromise = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = 'https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js';
+      script.onload = () => {
+        html2canvasLoaded = true;
+        resolve();
+      };
+      script.onerror = reject;
+      document.head.appendChild(script);
+    });
+
+    return html2canvasPromise;
+  }
+
+  async function captureScreenshot(options) {
+    const { scrollTo, fullPage, quality = 0.8 } = options || {};
+
+    try {
+      await loadHtml2Canvas();
+
+      // Scroll if requested
+      if (typeof scrollTo === 'number') {
+        window.scrollTo(0, scrollTo);
+        await new Promise(r => setTimeout(r, 150)); // Wait for render
+      }
+
+      const target = document.body;
+      const canvasOptions = {
+        useCORS: true,
+        allowTaint: true,
+        logging: false,
+        scale: window.devicePixelRatio || 1,
+      };
+
+      if (fullPage) {
+        canvasOptions.height = document.documentElement.scrollHeight;
+        canvasOptions.windowHeight = document.documentElement.scrollHeight;
+        canvasOptions.y = 0;
+        window.scrollTo(0, 0);
+        await new Promise(r => setTimeout(r, 100));
+      }
+
+      const canvas = await window.html2canvas(target, canvasOptions);
+      const dataUrl = canvas.toDataURL('image/png', quality);
+
+      return {
+        success: true,
+        data: dataUrl,
+        width: canvas.width,
+        height: canvas.height,
+        scrollY: window.scrollY,
+        totalHeight: document.documentElement.scrollHeight,
+        viewportHeight: window.innerHeight,
+        url: window.location.href
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error.message || String(error)
+      };
+    }
+  }
+
+  async function captureMultipleSections(sectionCount) {
+    const results = [];
+    const totalHeight = document.documentElement.scrollHeight;
+    const viewportHeight = window.innerHeight;
+    const sections = sectionCount || Math.ceil(totalHeight / viewportHeight);
+
+    for (let i = 0; i < sections; i++) {
+      const scrollY = Math.min(i * viewportHeight, totalHeight - viewportHeight);
+      const result = await captureScreenshot({ scrollTo: scrollY });
+      if (result.success) {
+        results.push({
+          ...result,
+          section: i + 1,
+          totalSections: sections
+        });
+      }
+    }
+
+    return results;
+  }
+
   // ============ Studio Message Handler ============
 
   function handleStudioMessage(event) {
@@ -680,6 +773,29 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
 
       case 'toggleLayout':
         // Layout toggling handled by the renderer
+        break;
+
+      case 'screenshot':
+        (async function() {
+          let result;
+          if (message.multipleSections) {
+            result = await captureMultipleSections(message.sectionCount);
+            postToStudio({
+              action: 'screenshotResult',
+              requestId: message.requestId,
+              multiple: true,
+              results: result
+            });
+          } else {
+            result = await captureScreenshot(message.options);
+            postToStudio({
+              action: 'screenshotResult',
+              requestId: message.requestId,
+              multiple: false,
+              ...result
+            });
+          }
+        })();
         break;
 
       default:


### PR DESCRIPTION
## Summary
- Add screenshot capture functionality to the studio bridge (`bridge-template.ts`)
- Enable the veryfront agent to capture screenshots of the preview iframe

## Changes
- `loadHtml2Canvas()` - dynamically loads html2canvas from CDN
- `captureScreenshot()` - captures viewport or full page screenshots
- `captureMultipleSections()` - captures long pages in multiple sections
- Message handler for `screenshot` action from studio

## How it works
Studio sends a `screenshot` postMessage to the iframe, and the bridge captures the screenshot using html2canvas and returns the base64 PNG data via `screenshotResult` message.

## Test plan
- [ ] Deploy renderer with this change
- [ ] Test with studio capture_preview tool (see veryfront-studio PR)
- [ ] Verify viewport capture works
- [ ] Verify fullPage capture works
- [ ] Verify scrollTo option works