### PR TITLE
feat: use Tailwind browser CDN in preview mode for instant HMR

### DIFF
--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -14,11 +14,14 @@ import {
   extractCandidates,
   formatCSSError,
   generateTailwindCSS,
-  generateThemeVariables,
   getDevStyles,
   getProductionStyles,
   getProjectCSS,
 } from "./styles-builder/index.ts";
+
+// Tailwind v4 browser CDN - handles JIT compilation in the browser
+// https://tailwindcss.com/docs/installation/play-cdn
+const TAILWIND_BROWSER_CDN = "https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4";
 import type { HTMLGenerationOptions } from "./types.ts";
 import {
   buildContentAttributes,
@@ -129,7 +132,10 @@ async function generateHTMLShellPartsImpl(
   const stylesheetContent = options.globalCSS;
 
   const localDev = options.isLocalDev ?? false;
+  const isPreview = options.environment === "preview";
   const useProductionCSS = !localDev && options.environment === "production";
+  // Use browser CDN for dev (local + preview) - handles HMR automatically
+  const useBrowserCDN = localDev || isPreview;
 
   // Use projectClasses (extracted from ALL source files) + current page as fallback
   const candidates = new Set<string>(options.projectClasses ?? []);
@@ -142,7 +148,12 @@ async function generateHTMLShellPartsImpl(
   let tailwindError: string | undefined;
   let cssHash = "";
 
-  if (useProductionCSS && projectSlug !== "default") {
+  // In dev mode (local + preview), use browser CDN for instant HMR
+  // In production, pre-compile CSS for performance
+  if (useBrowserCDN) {
+    // Browser CDN handles all Tailwind compilation - no server-side CSS needed
+    tailwindCSS = "";
+  } else if (useProductionCSS && projectSlug !== "default") {
     const projectCSS = await getProjectCSS(projectSlug, stylesheetContent, candidates, {
       minify: true,
     });
@@ -244,24 +255,31 @@ async function generateHTMLShellPartsImpl(
 </script>`
     : "";
 
-  let tailwindCSSBlock = "";
-  if (tailwindCSS) {
-    if (useProductionCSS) {
-      tailwindCSSBlock = `<link rel="stylesheet" href="/_vf/css/${cssHash}.css">`;
-    } else {
-      tailwindCSSBlock = `<style id="vf-tailwind-css"${
+  // Preview: Tailwind browser CDN + user's globals.css
+  // Production: Pre-compiled CSS linked stylesheet
+  let tailwindHeadBlock = "";
+  if (useBrowserCDN) {
+    const cdnScript = `<script src="${TAILWIND_BROWSER_CDN}"${
+      nonce ? ` nonce="${nonce}"` : ""
+    }></script>`;
+    const userStylesheet = stylesheetContent
+      ? `<style type="text/tailwindcss"${
+        nonce ? ` nonce="${nonce}"` : ""
+      }>\n${stylesheetContent}\n  </style>`
+      : "";
+    tailwindHeadBlock = `${cdnScript}\n  ${userStylesheet}`;
+  } else if (tailwindCSS) {
+    tailwindHeadBlock = useProductionCSS
+      ? `<link rel="stylesheet" href="/_vf/css/${cssHash}.css">`
+      : `<style id="vf-tailwind-css"${
         nonce ? ` nonce="${nonce}"` : ""
       }>\n${tailwindCSS}\n  </style>`;
-    }
   }
 
+  // Production only: server-side compilation error (never in preview with browser CDN)
   const tailwindErrorComment = tailwindError
-    ? `<!-- Tailwind CSS Error: ${tailwindError.replace(/-->/g, "- ->")} -->`
+    ? `<!-- Tailwind Error: ${tailwindError.replace(/-->/g, "- ->")} -->`
     : "";
-
-  const themeVariablesBlock = options.globalCSS ? "" : `<style${nonce ? ` nonce="${nonce}"` : ""}>
-${generateThemeVariables()}
-  </style>`;
 
   const start = `<!DOCTYPE html>
 <html ${htmlAttrs}>
@@ -279,12 +297,9 @@ ${generateThemeVariables()}
   <!-- Modulepreload hints for faster cold start -->
   ${modulePreloadHints}
 
-  <!-- Tailwind CSS: Server-side JIT compiled -->
-  ${tailwindCSSBlock}
+  <!-- Tailwind CSS -->
+  ${tailwindHeadBlock}
   ${tailwindErrorComment}
-
-  <!-- CSS Variables for Theming -->
-  ${themeVariablesBlock}
 
   <!-- Syntax highlighting for code blocks -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/${syntaxHighlightTheme}.min.css">

--- a/src/html/hydration-script-builder/templates/router.ts
+++ b/src/html/hydration-script-builder/templates/router.ts
@@ -455,22 +455,6 @@ export const getRouterScript = () => `
         metaDesc?.setAttribute('content', pageData.frontmatter.description);
       }
 
-      // Inject CSS for the new page (ensures styles work without Tailwind CDN)
-      if (pageData.css) {
-        const existingStyle = document.getElementById('veryfront-spa-css');
-        if (existingStyle) {
-          // Update existing style element content
-          existingStyle.textContent = pageData.css;
-        } else {
-          // Create new style element
-          const styleEl = document.createElement('style');
-          styleEl.id = 'veryfront-spa-css';
-          styleEl.textContent = pageData.css;
-          document.head.appendChild(styleEl);
-        }
-        log('Injected CSS for SPA navigation', { cssLength: pageData.css.length });
-      }
-
       // Build the component tree with layouts
       let tree = React.createElement(PageComponent, {
         ...pageData.props,

--- a/src/server/handlers/dev/endpoints.ts
+++ b/src/server/handlers/dev/endpoints.ts
@@ -215,6 +215,7 @@ async function handleUpdate(update) {
 
 async function updateCSS(path) {
   console.log('[HMR] Updating CSS:', path);
+  let updated = false;
 
   // Try to update linked stylesheets
   document.querySelectorAll('link[rel="stylesheet"]').forEach((link) => {
@@ -225,25 +226,43 @@ async function updateCSS(path) {
         newUrl.searchParams.set('t', Date.now().toString());
         link.href = newUrl.toString();
         console.log('[HMR] CSS link updated:', path);
+        updated = true;
       }
     } catch (error) {
       console.error('[HMR] Failed to update CSS link:', error);
     }
   });
 
-  // Try to update inline Tailwind CSS style tag
-  const tailwindStyle = document.getElementById('vf-tailwind-css');
-  if (tailwindStyle && (path.includes('globals.css') || path.endsWith('.css'))) {
+  // Try to update Tailwind browser CDN style tag (type="text/tailwindcss")
+  const tailwindCDNStyle = document.querySelector('style[type="text/tailwindcss"]');
+  if (tailwindCDNStyle && (path.includes('globals.css') || path.endsWith('.css'))) {
     try {
-      // Fetch fresh compiled CSS from globals endpoint
+      // Fetch raw globals.css content (browser CDN will recompile)
+      const response = await fetch('/_vf_raw/globals.css?t=' + Date.now());
+      if (response.ok) {
+        const newCSS = await response.text();
+        tailwindCDNStyle.textContent = newCSS;
+        console.log('[HMR] Tailwind CDN style updated');
+        updated = true;
+      }
+    } catch (error) {
+      console.error('[HMR] Failed to fetch raw CSS:', error);
+    }
+  }
+
+  // Fallback: legacy inline Tailwind CSS (vf-tailwind-css)
+  const tailwindStyle = document.getElementById('vf-tailwind-css');
+  if (tailwindStyle && !updated && (path.includes('globals.css') || path.endsWith('.css'))) {
+    try {
       const response = await fetch('/_vf_styles/globals.css?t=' + Date.now());
       if (response.ok) {
         const newCSS = await response.text();
         tailwindStyle.textContent = newCSS;
-        console.log('[HMR] Inline Tailwind CSS updated');
+        console.log('[HMR] Legacy inline Tailwind CSS updated');
+        updated = true;
       }
     } catch (error) {
-      console.error('[HMR] Failed to fetch fresh CSS:', error);
+      console.error('[HMR] Failed to fetch compiled CSS:', error);
     }
   }
 
@@ -639,25 +658,42 @@ document.head.appendChild(errorScript);
       }
     }
 
-    // Try to update inline Tailwind CSS style tag
-    const tailwindStyle = document.getElementById('vf-tailwind-css');
-    console.log('[Preview HMR] Tailwind style element found:', !!tailwindStyle);
-    if (tailwindStyle && (path.includes('globals.css') || path.endsWith('.css'))) {
+    // Try to update Tailwind browser CDN style tag (type="text/tailwindcss")
+    const tailwindCDNStyle = document.querySelector('style[type="text/tailwindcss"]');
+    if (tailwindCDNStyle && (path.includes('globals.css') || path.endsWith('.css'))) {
+      console.log('[Preview HMR] Tailwind CDN style element found, fetching raw globals.css');
       try {
-        // Fetch fresh compiled CSS from globals endpoint
-        const cssUrl = '/_vf_styles/globals.css?t=' + Date.now();
-        console.log('[Preview HMR] Fetching fresh CSS from:', cssUrl);
+        // Fetch raw globals.css content (browser CDN will recompile)
+        const cssUrl = '/_vf_raw/globals.css?t=' + Date.now();
+        console.log('[Preview HMR] Fetching raw CSS from:', cssUrl);
         const response = await fetch(cssUrl);
-        console.log('[Preview HMR] CSS fetch response:', response.status, response.statusText);
         if (response.ok) {
           const newCSS = await response.text();
-          console.log('[Preview HMR] CSS fetched, length:', newCSS.length);
-          tailwindStyle.textContent = newCSS;
-          console.log('[Preview HMR] Inline Tailwind CSS updated');
+          console.log('[Preview HMR] Raw CSS fetched, length:', newCSS.length);
+          tailwindCDNStyle.textContent = newCSS;
+          console.log('[Preview HMR] Tailwind CDN style updated - browser will recompile');
           updated = true;
         }
       } catch (error) {
-        console.error('[Preview HMR] Failed to fetch fresh CSS:', error);
+        console.error('[Preview HMR] Failed to fetch raw CSS:', error);
+      }
+    }
+
+    // Fallback: legacy inline Tailwind CSS (vf-tailwind-css)
+    const tailwindStyle = document.getElementById('vf-tailwind-css');
+    if (tailwindStyle && !updated && (path.includes('globals.css') || path.endsWith('.css'))) {
+      console.log('[Preview HMR] Legacy Tailwind style element found');
+      try {
+        const cssUrl = '/_vf_styles/globals.css?t=' + Date.now();
+        const response = await fetch(cssUrl);
+        if (response.ok) {
+          const newCSS = await response.text();
+          tailwindStyle.textContent = newCSS;
+          console.log('[Preview HMR] Legacy inline Tailwind CSS updated');
+          updated = true;
+        }
+      } catch (error) {
+        console.error('[Preview HMR] Failed to fetch compiled CSS:', error);
       }
     }
 

--- a/src/server/handlers/dev/globals-css-handler.ts
+++ b/src/server/handlers/dev/globals-css-handler.ts
@@ -1,8 +1,9 @@
 /**
  * Globals CSS Handler
  *
- * Serves globals.css compiled via Tailwind's API for proper directive support.
- * CSS served via <link> tags can be hot-reloaded by updating the href.
+ * Serves globals.css in two modes:
+ * - /_vf_styles/globals.css: Compiled via Tailwind's API (for production/legacy)
+ * - /_vf_raw/globals.css: Raw file content (for browser CDN HMR)
  */
 
 import { BaseHandler } from "../response/base.ts";
@@ -15,7 +16,10 @@ export class GlobalsCSSHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "GlobalsCSSHandler",
     priority: PRIORITY_HIGH_DEV as HandlerPriority,
-    patterns: [{ pattern: "/_vf_styles/globals.css", exact: true, method: "GET" }],
+    patterns: [
+      { pattern: "/_vf_styles/globals.css", exact: true, method: "GET" },
+      { pattern: "/_vf_raw/globals.css", exact: true, method: "GET" },
+    ],
     // Enable in all modes for consistent styling
     enabled: () => true,
   };
@@ -25,16 +29,22 @@ export class GlobalsCSSHandler extends BaseHandler {
       return this.continue();
     }
 
+    const url = new URL(req.url);
+    const isRawEndpoint = url.pathname === "/_vf_raw/globals.css";
+
     // Wrap in proxy context for multi-project mode file resolution
     return await this.withProxyContext(ctx, async () => {
       // Load stylesheet from project root (configurable via tailwind.stylesheet)
       const stylesheetPath = ctx.config?.tailwind?.stylesheet || "globals.css";
       const filePath = joinPath(ctx.projectDir, stylesheetPath);
-      const responseBuilder = this.createResponseBuilder(ctx).withCache("no-cache"); // No caching for HMR to work
+      const responseBuilder = this.createResponseBuilder(ctx).withCache("no-cache"); // No caching for HMR
 
       try {
         const rawCss = await ctx.adapter.fs.readFile(filePath);
-        const css = await compileGlobalsCSS(rawCss);
+
+        // Raw endpoint: return uncompiled CSS (for browser CDN to process)
+        // Compiled endpoint: run through Tailwind compiler
+        const css = isRawEndpoint ? rawCss : await compileGlobalsCSS(rawCss);
 
         return this.respond(
           responseBuilder.withContentType("text/css; charset=utf-8", css, HTTP_OK),


### PR DESCRIPTION
## Summary

- Preview mode now uses `@tailwindcss/browser@4` CDN instead of server-side Tailwind compilation
- Enables instant HMR for Tailwind classes - when you change `bg-red-100` to `bg-blue-100`, it works immediately
- User's `globals.css` (with `@theme` directives) is injected as `<style type="text/tailwindcss">` for browser processing
- Production mode unchanged (pre-compiled CSS linked stylesheet)

## Changes

| File | Change |
|------|--------|
| `html-shell-generator.ts` | Add browser CDN script, rename `tailwindCSSBlock` → `tailwindHeadBlock`, remove legacy `themeVariablesBlock` |
| `globals-css-handler.ts` | Add `/_vf_raw/globals.css` endpoint for raw CSS (HMR fetches this) |
| `endpoints.ts` | HMR `updateCSS()` now handles `<style type="text/tailwindcss">` |
| `router.ts` | Remove dead CSS injection code (`pageData.css` was never populated) |

## How it works

**Preview mode:**
```html
<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
<style type="text/tailwindcss">
  /* user's globals.css with @theme directives */
</style>
```

**Production mode:** (unchanged)
```html
<link rel="stylesheet" href="/_vf/css/{hash}.css">
```

## Test plan

- [ ] Open preview in Studio, change a Tailwind class (e.g. `bg-red-100` → `bg-blue-100`)
- [ ] Verify HMR updates the styling instantly without full page reload
- [ ] Verify `globals.css` changes (e.g. `@theme` colors) also update via HMR
- [ ] Verify production build still uses pre-compiled CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)