### PR TITLE
fix: support negative Tailwind classes and improve CSS minification

### DIFF
--- a/src/html/styles-builder/tailwind-compiler.ts
+++ b/src/html/styles-builder/tailwind-compiler.ts
@@ -10,6 +10,7 @@ import {
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { SpanNames } from "#veryfront/observability/tracing/span-names.ts";
 import { registerCache } from "#veryfront/utils/memory/index.ts";
+import { minifyCSS } from "#veryfront/build/asset-pipeline/tailwind-processor/css-utils.ts";
 
 export interface TailwindResult {
   css: string;
@@ -363,7 +364,8 @@ export function clearCSSCache(): void {
 }
 
 export function extractCandidates(content: string): string[] {
-  const pattern = /[a-zA-Z0-9][a-zA-Z0-9_\-:\/\.\[\]%#,()!'=<>$@{}|*+?;^]+/g;
+  // Match Tailwind classes including those starting with - (negative values like -translate-x-1/2)
+  const pattern = /-?[a-zA-Z0-9][a-zA-Z0-9_\-:\/\.\[\]%#,()!'=<>$@{}|*+?;^]*/g;
   const matches = content.match(pattern) ?? [];
   return [...new Set(matches)];
 }
@@ -487,7 +489,7 @@ export async function generateTailwindCSS(
         let output = comp.build(candidateArray);
 
         if (options?.minify) {
-          output = output.replace(/\n\s*\n/g, "\n");
+          output = minifyCSS(output);
         }
 
         logger.debug("[tailwind] Generated CSS", {


### PR DESCRIPTION
## Problem

### 1. Negative Tailwind Classes Not Detected

The candidate extraction regex didn't match classes starting with `-`:

```typescript
// BEFORE - didn't match negative values
const pattern = /[a-zA-Z0-9][a-zA-Z0-9_\-:\/\.\[\]%#,()!'=<>$@{}|*+?;^]+/g;
```

Classes like `-translate-x-1/2`, `-mt-4`, `-rotate-45` were being missed, causing:
- Missing negative margin/padding utilities
- Missing negative transform utilities
- Incomplete CSS output

### 2. Naive CSS Minification

The minification was just removing empty lines:

```typescript
// BEFORE - too simple
output = output.replace(/\n\s*\n/g, "\n");
```

This missed opportunities to remove:
- Comments
- Unnecessary whitespace
- Redundant semicolons

---

## Solution

### 1. Updated Regex to Match Negative Classes

```typescript
// AFTER - matches classes starting with -
const pattern = /-?[a-zA-Z0-9][a-zA-Z0-9_\-:\/\.\[\]%#,()!'=<>$@{}|*+?;^]*/g;
```

The `-?` at the start makes the leading dash optional, matching:
- `translate-x-1/2` (positive)
- `-translate-x-1/2` (negative)
- `mt-4` (positive margin)
- `-mt-4` (negative margin)

### 2. Proper CSS Minification

Now uses the existing `minifyCSS()` utility:

```typescript
import { minifyCSS } from "#veryfront/build/asset-pipeline/tailwind-processor/css-utils.ts";

if (options?.minify) {
  output = minifyCSS(output);
}
```

---

## Test Plan

- [ ] Verify negative Tailwind classes are included in output
- [ ] Verify CSS output is properly minified

🤖 Generated with [Claude Code](https://claude.com/claude-code)