### PR TITLE
refactor: early return for monitoring paths

### DIFF
--- a/src/server/universal-handler/index.ts
+++ b/src/server/universal-handler/index.ts
@@ -92,7 +92,7 @@ function isInternalHost(host: string): boolean {
 }
 
 /** Monitoring paths that should skip domain lookup */
-const MONITORING_PATHS = new Set(["/healthz", "/readyz", "/_health", "/metrics"]);
+const MONITORING_PATHS = new Set(["/healthz", "/readyz", "/_health", "/_metrics"]);
 
 /** Request timeout in milliseconds (configurable via REQUEST_TIMEOUT_MS env var) */
 const REQUEST_TIMEOUT_MS = getTimeoutFromEnv();
@@ -707,11 +707,11 @@ export function createVeryfrontHandler(
         const contentSourceId = isMonitoringPath(url.pathname)
           ? "monitoring"
           : (proxyContentSourceId ?? computeContentSourceId(
-              reqCtx.isLocalDev || isLocalProject,
-              resolvedEnvironment,
-              reqCtx.branch,
-              releaseId,
-            ));
+            reqCtx.isLocalDev || isLocalProject,
+            resolvedEnvironment,
+            reqCtx.branch,
+            releaseId,
+          ));
 
         const enrichedContext = effectiveConfig && projectSlug
           ? buildEnrichedContext({

--- a/src/server/universal-handler/index.ts
+++ b/src/server/universal-handler/index.ts
@@ -702,12 +702,16 @@ export function createVeryfrontHandler(
         }
 
         // Use proxy header if available, otherwise compute using shared utility
-        const contentSourceId = proxyContentSourceId ?? computeContentSourceId(
-          reqCtx.isLocalDev || isLocalProject,
-          resolvedEnvironment,
-          reqCtx.branch,
-          releaseId,
-        );
+        // Skip contentSourceId computation for monitoring paths - they don't need it
+        // and would fail for kubelet health checks that don't have proxy headers
+        const contentSourceId = isMonitoringPath(url.pathname)
+          ? "monitoring"
+          : (proxyContentSourceId ?? computeContentSourceId(
+              reqCtx.isLocalDev || isLocalProject,
+              resolvedEnvironment,
+              reqCtx.branch,
+              releaseId,
+            ));
 
         const enrichedContext = effectiveConfig && projectSlug
           ? buildEnrichedContext({

--- a/src/server/universal-handler/index.ts
+++ b/src/server/universal-handler/index.ts
@@ -298,8 +298,38 @@ export function createVeryfrontHandler(
     if (perfRequestId) startRequest(perfRequestId);
     const stopTotal = startTimer("total");
 
-    const trackingRequestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
     const url = new URL(req.url);
+
+    // Early return for monitoring paths - skip expensive context building
+    // (domain lookups, project resolution, enriched context, etc.)
+    // Health checks (/healthz, /readyz, /_health) and metrics (/_metrics) need minimal context
+    // but still need auth/security config loaded
+    if (isMonitoringPath(url.pathname)) {
+      try {
+        // Wait for ready and security config to load (needed for auth checks)
+        await readyPromise;
+        if (!isProxyMode) {
+          await securityLoader.ensureLoaded();
+        }
+
+        const minimalCtx: HandlerContext = {
+          projectDir,
+          adapter,
+          securityConfig: securityLoader.getSecurityConfig(),
+          cspUserHeader: securityLoader.getCspUserHeader(),
+          debug: opts.debug,
+          config,
+        };
+
+        const response = await registry.execute(req, minimalCtx);
+        return response ?? new Response("Not Found", { status: 404 });
+      } finally {
+        stopTotal();
+        if (perfRequestId) endRequest(perfRequestId);
+      }
+    }
+
+    const trackingRequestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
 
     const parentContext = extractContext(req.headers);
     const spanInfo = startServerSpan(req.method, url.pathname, parentContext);
@@ -317,17 +347,14 @@ export function createVeryfrontHandler(
     const earlyEnv = req.headers.get("x-environment") || undefined;
     const earlyReleaseId = req.headers.get("x-release-id") || undefined;
 
-    const shouldTrackRequest = !isMonitoringPath(url.pathname);
-    if (shouldTrackRequest) {
-      requestTracker.start(
-        trackingRequestId,
-        earlyProjectSlug,
-        url.pathname,
-        req.method,
-        earlyEnv || undefined,
-        earlyReleaseId || undefined,
-      );
-    }
+    requestTracker.start(
+      trackingRequestId,
+      earlyProjectSlug,
+      url.pathname,
+      req.method,
+      earlyEnv || undefined,
+      earlyReleaseId || undefined,
+    );
 
     // Skip concurrency limiting for lightweight paths (modules, static assets)
     // These requests are fast once initialized and shouldn't block each other
@@ -336,7 +363,7 @@ export function createVeryfrontHandler(
       ? projectIsolation.checkRequest(earlyProjectSlug)
       : { allowed: true };
     if (!isolationCheck.allowed) {
-      if (shouldTrackRequest) requestTracker.complete(trackingRequestId, 503, false);
+      requestTracker.complete(trackingRequestId, 503, false);
 
       const message = isolationCheck.reason === "circuit_open"
         ? `Service temporarily unavailable for project. Retry after ${
@@ -424,7 +451,8 @@ export function createVeryfrontHandler(
           proxyProjectId,
         });
 
-        const shouldSkipDomainLookup = isInternalHost(host) || isMonitoringPath(url.pathname);
+        // Monitoring paths have early return above, so only check for internal hosts
+        const shouldSkipDomainLookup = isInternalHost(host);
 
         if (
           !projectSlug &&
@@ -702,16 +730,13 @@ export function createVeryfrontHandler(
         }
 
         // Use proxy header if available, otherwise compute using shared utility
-        // Skip contentSourceId computation for monitoring paths - they don't need it
-        // and would fail for kubelet health checks that don't have proxy headers
-        const contentSourceId = isMonitoringPath(url.pathname)
-          ? "monitoring"
-          : (proxyContentSourceId ?? computeContentSourceId(
-            reqCtx.isLocalDev || isLocalProject,
-            resolvedEnvironment,
-            reqCtx.branch,
-            releaseId,
-          ));
+        // Note: Monitoring paths have early return above, so they never reach here
+        const contentSourceId = proxyContentSourceId ?? computeContentSourceId(
+          reqCtx.isLocalDev || isLocalProject,
+          resolvedEnvironment,
+          reqCtx.branch,
+          releaseId,
+        );
 
         const enrichedContext = effectiveConfig && projectSlug
           ? buildEnrichedContext({
@@ -771,8 +796,7 @@ export function createVeryfrontHandler(
         return new Response("Internal Server Error", { status: 500 });
       };
 
-      const shouldApplyTimeout = !isMonitoringPath(url.pathname);
-
+      // Note: Monitoring paths have early return above, so timeout always applies here
       let response: Response;
       let error: Error | undefined;
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -782,16 +806,12 @@ export function createVeryfrontHandler(
           ? () => withContext(spanInfo.context, executeHandler)
           : executeHandler;
 
-        if (!shouldApplyTimeout) {
-          response = await executeWithContext();
-        } else {
-          response = await Promise.race([
-            executeWithContext(),
-            new Promise<never>((_, reject) => {
-              timeoutId = setTimeout(() => reject(TIMEOUT_SENTINEL), REQUEST_TIMEOUT_MS);
-            }),
-          ]);
-        }
+        response = await Promise.race([
+          executeWithContext(),
+          new Promise<never>((_, reject) => {
+            timeoutId = setTimeout(() => reject(TIMEOUT_SENTINEL), REQUEST_TIMEOUT_MS);
+          }),
+        ]);
       } catch (e) {
         if (e === TIMEOUT_SENTINEL) {
           logger.warn("[universal] Request timed out", {
@@ -822,9 +842,7 @@ export function createVeryfrontHandler(
       endServerSpan(span, response.status, error);
 
       const isTimeout = response.status === HTTP_GATEWAY_TIMEOUT;
-      if (shouldTrackRequest) {
-        requestTracker.complete(trackingRequestId, response.status, isTimeout);
-      }
+      requestTracker.complete(trackingRequestId, response.status, isTimeout);
 
       // Only complete isolation tracking if we started it (heavyweight requests)
       if (shouldCheckIsolation) {

--- a/tests/integration/server/universal-handler/index.test.ts
+++ b/tests/integration/server/universal-handler/index.test.ts
@@ -748,7 +748,10 @@ describe(
           const tempDir = await makeTempDir({ prefix: "vf_proxy_header_" });
           try {
             await mkdir(`${tempDir}/app`, { recursive: true });
-            await writeTextFile(`${tempDir}/app/page.tsx`, `export default function Page() { return <div>Test</div>; }`);
+            await writeTextFile(
+              `${tempDir}/app/page.tsx`,
+              `export default function Page() { return <div>Test</div>; }`,
+            );
 
             const adapter = await createMockAdapter({});
             const handler = createVeryfrontHandler(tempDir, adapter, {
@@ -798,7 +801,10 @@ describe(
           const tempDir = await makeTempDir({ prefix: "vf_proxy_vf_domain_" });
           try {
             await mkdir(`${tempDir}/app`, { recursive: true });
-            await writeTextFile(`${tempDir}/app/page.tsx`, `export default function Page() { return <div>Test</div>; }`);
+            await writeTextFile(
+              `${tempDir}/app/page.tsx`,
+              `export default function Page() { return <div>Test</div>; }`,
+            );
 
             const adapter = await createMockAdapter({});
             const handler = createVeryfrontHandler(tempDir, adapter, {
@@ -815,7 +821,98 @@ describe(
               }),
             );
 
-            assertEquals(res.status, 200, "Should correctly parse Veryfront domain from x-forwarded-host");
+            assertEquals(
+              res.status,
+              200,
+              "Should correctly parse Veryfront domain from x-forwarded-host",
+            );
+          } finally {
+            await remove(tempDir, { recursive: true });
+          }
+        });
+      },
+    );
+
+    describe(
+      "Monitoring Paths - Kubelet Health Checks",
+      {},
+      () => {
+        it("handles /healthz without proxy headers (kubelet probe)", async () => {
+          const tempDir = await makeTempDir({ prefix: "vf_kubelet_healthz_" });
+          try {
+            // Simulate production environment without proxy headers
+            // This is how kubelet health probes hit the renderer
+            const adapter = await createMockAdapter({
+              PROXY_MODE: "1", // Production proxy mode
+            });
+            const handler = createVeryfrontHandler(tempDir, adapter);
+
+            // Kubelet probe: no x-release-id, no x-environment headers
+            const res = await handler(
+              new Request("http://localhost:8000/healthz"),
+            );
+
+            assertEquals(res.status, 200, "Should handle /healthz without proxy headers");
+          } finally {
+            await remove(tempDir, { recursive: true });
+          }
+        });
+
+        it("handles /_metrics without proxy headers", async () => {
+          const tempDir = await makeTempDir({ prefix: "vf_kubelet_metrics_" });
+          try {
+            const adapter = await createMockAdapter({
+              PROXY_MODE: "1",
+            });
+            const handler = createVeryfrontHandler(tempDir, adapter);
+
+            // Prometheus scrape: no proxy headers
+            const res = await handler(
+              new Request("http://localhost:8000/_metrics"),
+            );
+
+            assertEquals(res.status, 200, "Should handle /_metrics without proxy headers");
+          } finally {
+            await remove(tempDir, { recursive: true });
+          }
+        });
+
+        it("handles /readyz without proxy headers", async () => {
+          const tempDir = await makeTempDir({ prefix: "vf_kubelet_readyz_" });
+          try {
+            const adapter = await createMockAdapter({
+              PROXY_MODE: "1",
+            });
+            const handler = createVeryfrontHandler(tempDir, adapter);
+
+            const res = await handler(
+              new Request("http://localhost:8000/readyz"),
+            );
+
+            // /readyz returns 200 (ready) or 503 (not ready) - both are valid
+            // The key is it should NOT return 500 (error) when proxy headers are missing
+            assert(
+              res.status === 200 || res.status === 503,
+              `Should handle /readyz without throwing (got ${res.status})`,
+            );
+          } finally {
+            await remove(tempDir, { recursive: true });
+          }
+        });
+
+        it("handles /_health without proxy headers", async () => {
+          const tempDir = await makeTempDir({ prefix: "vf_kubelet_health_" });
+          try {
+            const adapter = await createMockAdapter({
+              PROXY_MODE: "1",
+            });
+            const handler = createVeryfrontHandler(tempDir, adapter);
+
+            const res = await handler(
+              new Request("http://localhost:8000/_health"),
+            );
+
+            assertEquals(res.status, 200, "Should handle /_health without proxy headers");
           } finally {
             await remove(tempDir, { recursive: true });
           }


### PR DESCRIPTION
## Summary
Add early return for monitoring paths (`/healthz`, `/readyz`, `/_health`, `/_metrics`) to skip expensive context building.

## Root Cause
Kubelet health probes hit the renderer directly without proxy headers. The handler built full context for ALL requests, causing `computeContentSourceId()` to throw when `releaseId` was missing.

## Solution
Single early return after URL parsing that:
- Creates minimal `HandlerContext`
- Executes handlers directly
- Skips domain lookups, config loading, enriched context, timeout wrapper

**Before:** 5 scattered `isMonitoringPath()` checks including a hack (`contentSourceId = "monitoring"`)
**After:** 1 early return, clean architecture

## Also Fixed
- Path mismatch: `/metrics` → `/_metrics` to match `MetricsHandler`

## Test Plan
- [x] All existing tests pass
- [x] New kubelet health check tests (no proxy headers)
- [ ] Deploy to staging

Fixes #137