### PR TITLE
Fix permissions for protected environments

### DIFF
--- a/proxy/handler.test.ts
+++ b/proxy/handler.test.ts
@@ -172,4 +172,330 @@ describe("Proxy Handler", () => {
       await handler.close();
     });
   });
+
+  describe("protected environments", () => {
+    it("redirects to sign-in for protected custom domain without auth token", async () => {
+      const adapter = await getLocalAdapter();
+      const port = await getFreePort();
+
+      const server = await adapter.serve(
+        (req: Request) => {
+          const url = new URL(req.url);
+
+          if (url.pathname === "/auth/token") {
+            return Response.json({
+              access_token: "test-token",
+              token_type: "Bearer",
+              expires_in: 3600,
+            });
+          }
+
+          if (url.pathname.startsWith("/projects/")) {
+            return Response.json({
+              id: "proj-123",
+              slug: "protected-project",
+              name: "Protected Project",
+              environments: [{
+                id: "env-1",
+                name: "production",
+                domains: ["protected.example.com"],
+                active_release_id: "rel-123",
+                protected: true,
+              }],
+            });
+          }
+
+          return new Response("Not found", { status: 404 });
+        },
+        { port, hostname: "127.0.0.1" },
+      );
+
+      try {
+        const handler = createProxyHandler({
+          config: {
+            apiBaseUrl: `http://127.0.0.1:${port}`,
+            clientId: "test-client",
+            clientSecret: "test-secret",
+            previewClientId: "test-client",
+            previewClientSecret: "test-secret",
+          },
+        });
+
+        const req = new Request("http://protected.example.com/page", {
+          headers: { host: "protected.example.com" },
+        });
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error?.status, 302);
+        assertEquals(ctx.error?.message, "Authentication required");
+        assertEquals(
+          ctx.error?.redirectUrl,
+          "https://veryfront.com/sign-in?from=http%3A%2F%2Fprotected.example.com%2Fpage",
+        );
+
+        await handler.close();
+      } finally {
+        await server.stop();
+      }
+    });
+
+    it("allows access to protected custom domain with auth token", async () => {
+      const adapter = await getLocalAdapter();
+      const port = await getFreePort();
+
+      const server = await adapter.serve(
+        (req: Request) => {
+          const url = new URL(req.url);
+
+          if (url.pathname === "/auth/token") {
+            return Response.json({
+              access_token: "test-token",
+              token_type: "Bearer",
+              expires_in: 3600,
+            });
+          }
+
+          if (url.pathname.startsWith("/projects/")) {
+            return Response.json({
+              id: "proj-123",
+              slug: "protected-project",
+              name: "Protected Project",
+              environments: [{
+                id: "env-1",
+                name: "production",
+                domains: ["protected.example.com"],
+                active_release_id: "rel-123",
+                protected: true,
+              }],
+            });
+          }
+
+          return new Response("Not found", { status: 404 });
+        },
+        { port, hostname: "127.0.0.1" },
+      );
+
+      try {
+        const handler = createProxyHandler({
+          config: {
+            apiBaseUrl: `http://127.0.0.1:${port}`,
+            clientId: "test-client",
+            clientSecret: "test-secret",
+            previewClientId: "test-client",
+            previewClientSecret: "test-secret",
+          },
+        });
+
+        const req = new Request("http://protected.example.com/page", {
+          headers: {
+            host: "protected.example.com",
+            cookie: "authToken=user-auth-token",
+          },
+        });
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error, undefined);
+        assertEquals(ctx.projectSlug, "protected-project");
+        assertEquals(ctx.releaseId, "rel-123");
+
+        await handler.close();
+      } finally {
+        await server.stop();
+      }
+    });
+
+    it("redirects to sign-in for protected veryfront domain without auth token", async () => {
+      const adapter = await getLocalAdapter();
+      const port = await getFreePort();
+
+      const server = await adapter.serve(
+        (req: Request) => {
+          const url = new URL(req.url);
+
+          if (url.pathname === "/auth/token") {
+            return Response.json({
+              access_token: "test-token",
+              token_type: "Bearer",
+              expires_in: 3600,
+            });
+          }
+
+          if (url.pathname.startsWith("/projects/")) {
+            return Response.json({
+              id: "proj-123",
+              slug: "protected-project",
+              name: "Protected Project",
+              environments: [{
+                id: "env-1",
+                name: "staging",
+                active_release_id: "rel-123",
+                protected: true,
+              }],
+            });
+          }
+
+          return new Response("Not found", { status: 404 });
+        },
+        { port, hostname: "127.0.0.1" },
+      );
+
+      try {
+        const handler = createProxyHandler({
+          config: {
+            apiBaseUrl: `http://127.0.0.1:${port}`,
+            clientId: "test-client",
+            clientSecret: "test-secret",
+            previewClientId: "test-client",
+            previewClientSecret: "test-secret",
+          },
+        });
+
+        const req = new Request("http://protected-project.staging.veryfront.com/page", {
+          headers: { host: "protected-project.staging.veryfront.com" },
+        });
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error?.status, 302);
+        assertEquals(ctx.error?.message, "Authentication required");
+        assertEquals(
+          ctx.error?.redirectUrl,
+          "https://veryfront.com/sign-in?from=http%3A%2F%2Fprotected-project.staging.veryfront.com%2Fpage",
+        );
+
+        await handler.close();
+      } finally {
+        await server.stop();
+      }
+    });
+
+    it("allows access to protected veryfront domain with auth token", async () => {
+      const adapter = await getLocalAdapter();
+      const port = await getFreePort();
+
+      const server = await adapter.serve(
+        (req: Request) => {
+          const url = new URL(req.url);
+
+          if (url.pathname === "/auth/token") {
+            return Response.json({
+              access_token: "test-token",
+              token_type: "Bearer",
+              expires_in: 3600,
+            });
+          }
+
+          if (url.pathname.startsWith("/projects/")) {
+            return Response.json({
+              id: "proj-123",
+              slug: "protected-project",
+              name: "Protected Project",
+              environments: [{
+                id: "env-1",
+                name: "staging",
+                active_release_id: "rel-123",
+                protected: true,
+              }],
+            });
+          }
+
+          return new Response("Not found", { status: 404 });
+        },
+        { port, hostname: "127.0.0.1" },
+      );
+
+      try {
+        const handler = createProxyHandler({
+          config: {
+            apiBaseUrl: `http://127.0.0.1:${port}`,
+            clientId: "test-client",
+            clientSecret: "test-secret",
+            previewClientId: "test-client",
+            previewClientSecret: "test-secret",
+          },
+        });
+
+        const req = new Request("http://protected-project.staging.veryfront.com/page", {
+          headers: {
+            host: "protected-project.staging.veryfront.com",
+            cookie: "authToken=user-auth-token",
+          },
+        });
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error, undefined);
+        assertEquals(ctx.projectSlug, "protected-project");
+        assertEquals(ctx.releaseId, "rel-123");
+
+        await handler.close();
+      } finally {
+        await server.stop();
+      }
+    });
+
+    it("allows access to non-protected environment without auth token", async () => {
+      const adapter = await getLocalAdapter();
+      const port = await getFreePort();
+
+      const server = await adapter.serve(
+        (req: Request) => {
+          const url = new URL(req.url);
+
+          if (url.pathname === "/auth/token") {
+            return Response.json({
+              access_token: "test-token",
+              token_type: "Bearer",
+              expires_in: 3600,
+            });
+          }
+
+          if (url.pathname.startsWith("/projects/")) {
+            return Response.json({
+              id: "proj-123",
+              slug: "public-project",
+              name: "Public Project",
+              environments: [{
+                id: "env-1",
+                name: "production",
+                domains: ["public.example.com"],
+                active_release_id: "rel-123",
+                protected: false,
+              }],
+            });
+          }
+
+          return new Response("Not found", { status: 404 });
+        },
+        { port, hostname: "127.0.0.1" },
+      );
+
+      try {
+        const handler = createProxyHandler({
+          config: {
+            apiBaseUrl: `http://127.0.0.1:${port}`,
+            clientId: "test-client",
+            clientSecret: "test-secret",
+            previewClientId: "test-client",
+            previewClientSecret: "test-secret",
+          },
+        });
+
+        const req = new Request("http://public.example.com/page", {
+          headers: { host: "public.example.com" },
+        });
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error, undefined);
+        assertEquals(ctx.projectSlug, "public-project");
+
+        await handler.close();
+      } finally {
+        await server.stop();
+      }
+    });
+  });
 });

--- a/proxy/handler.ts
+++ b/proxy/handler.ts
@@ -34,6 +34,7 @@ interface DomainLookupResult {
     name: string;
     domains?: string[];
     active_release_id?: string | null;
+    protected?: boolean;
   }>;
 }
 
@@ -127,7 +128,7 @@ export interface ProxyContext {
   parsedDomain: ParsedDomain;
   isLocalProject: boolean;
   /** Error if request cannot be processed (e.g., custom domain not found) */
-  error?: { status: number; message: string };
+  error?: { status: number; message: string; redirectUrl?: string };
 }
 
 export interface ProxyLogger {
@@ -258,7 +259,12 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
       isCustomDomain,
     });
 
-    const makeErrorContext = (status: number, message: string, token?: string): ProxyContext => ({
+    const makeErrorContext = (
+      status: number,
+      message: string,
+      token?: string,
+      redirectUrl?: string,
+    ): ProxyContext => ({
       token,
       projectSlug: undefined,
       projectId: undefined,
@@ -268,20 +274,20 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
       host,
       parsedDomain,
       isLocalProject: false,
-      error: { status, message },
+      error: { status, message, redirectUrl },
     });
 
     let token: string | undefined;
+    // Extract user auth token from cookies (used for preview scope and protected env check)
+    const cookieHeader = req.headers.get("cookie") || "";
+    const userToken = extractUserToken(cookieHeader);
 
     if (isLocalProject) {
       logger?.debug("Local project, skipping token fetch", { localPath });
     } else {
-      if (scope === "preview") {
-        const cookieHeader = req.headers.get("cookie") || "";
-        token = extractUserToken(cookieHeader);
-        if (token) {
-          logger?.debug("Using user auth token for preview");
-        }
+      if (scope === "preview" && userToken) {
+        token = userToken;
+        logger?.debug("Using user auth token for preview");
       }
 
       if (!token && config.clientId && config.clientSecret) {
@@ -321,6 +327,18 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
             releaseId = matchingEnv.active_release_id;
           }
 
+          // Check if environment is protected and user is not authenticated
+          if (matchingEnv?.protected && !userToken) {
+            const originalUrl = req.url;
+            const redirectUrl = `https://veryfront.com/sign-in?from=${encodeURIComponent(originalUrl)}`;
+            logger?.info("Protected environment requires authentication", {
+              domain: host,
+              environmentName: matchingEnv.name,
+              redirectUrl,
+            });
+            return makeErrorContext(302, "Authentication required", token, redirectUrl);
+          }
+
           logger?.info("Resolved custom domain to project", {
             domain: host,
             projectSlug,
@@ -346,6 +364,18 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
           if (matchingEnv?.active_release_id) {
             releaseId = matchingEnv.active_release_id;
+          }
+
+          // Check if environment is protected and user is not authenticated
+          if (matchingEnv?.protected && !userToken) {
+            const originalUrl = req.url;
+            const redirectUrl = `https://veryfront.com/sign-in?from=${encodeURIComponent(originalUrl)}`;
+            logger?.info("Protected environment requires authentication", {
+              projectSlug,
+              environmentName: matchingEnv.name,
+              redirectUrl,
+            });
+            return makeErrorContext(302, "Authentication required", token, redirectUrl);
           }
 
           logger?.info("Resolved veryfront domain to project", {

--- a/proxy/main.ts
+++ b/proxy/main.ts
@@ -241,6 +241,15 @@ function forwardToRenderer(req: Request): Promise<Response> {
         const ms = Math.round(performance.now() - startTime);
         proxyLogger.error(`${ctx.error.status} ${req.method} ${url.pathname}`, { ms, domain: ctx.host });
         endSpan(spanInfo?.span, ctx.error.status);
+
+        // Handle redirect for protected environments
+        if (ctx.error.redirectUrl) {
+          return new Response(null, {
+            status: 302,
+            headers: { Location: ctx.error.redirectUrl },
+          });
+        }
+
         return jsonErrorResponse(ctx.error.status, { error: ctx.error.message, status: ctx.error.status });
       }
 


### PR DESCRIPTION
## Summary
- Protected environments now redirect unauthenticated users to sign-in
- Redirect URL format: `https://veryfront.com/sign-in?from=<encoded_original_url>`

## Test plan
- [x] Tests added for protected environment scenarios
- [ ] Set `protected: true` on an environment
- [ ] Visit preview URL without auth → redirects to sign-in
- [ ] Log in → redirects back, page loads

Fixes https://github.com/veryfront/veryfront-api/issues/179