### PR TITLE
refactor(md): remove auto-injected styles, adopt standard rendering

### DIFF
--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -1146,7 +1146,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
   async getAllSourceFiles(): Promise<Array<{ path: string; content?: string }>> {
     if (!this.contentContext) {
-      logger.warn("[VeryfrontFSAdapter] getAllSourceFiles called without contentContext", {
+      logger.debug("[VeryfrontFSAdapter] getAllSourceFiles called without contentContext", {
         initialized: this.initialized,
         projectSlug: this.projectSlug,
       });
@@ -1157,7 +1157,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
     const files = await this.cache.getAsync<Array<{ path: string; content?: string }>>(cacheKey);
 
     if (!files?.length) {
-      logger.warn("[VeryfrontFSAdapter] getAllSourceFiles cache miss or empty", {
+      logger.debug("[VeryfrontFSAdapter] getAllSourceFiles cache miss or empty", {
         cacheKey,
         initialized: this.initialized,
         hasFiles: !!files,


### PR DESCRIPTION
## Summary

Adopt standard MD/MDX rendering without magic styling. We now use a standard remark/rehype pipeline - users opt-in to styling.

## Rendering Pipeline

| Plugin | Purpose |
|--------|---------|
| `remark-gfm` | GitHub Flavored Markdown (tables, strikethrough, task lists, autolinks) |
| `rehype-highlight` | Syntax highlighting via highlight.js classes |
| `rehype-slug` | Adds `id` attributes to headings for anchor links |

## What Changed

- **Deleted** `markdown-styles.ts` module
- **Removed** Tailwind safelist entries (`prose`, `dark:prose-invert`, `mx-auto`, `p-4`)
- **Removed** `shouldDisableProse` frontmatter option
- **Removed** tests for highlight.js/mermaid CDN scripts (opt-in features)
- **Removed** orphaned `mdx-compiler.test.ts`
- **Fixed** `getAllSourceFiles` warnings downgraded to debug (noisy on startup)
- MD component passes `className` through directly (no base classes)

## User Opt-In

To style markdown, users add classes in their layouts or CSS:

```tsx
<MDContent className="prose dark:prose-invert max-w-3xl mx-auto p-4" />
```

## Test Plan

- [x] All 549 tests pass
- [x] Server starts without warnings
- [x] MD files render without auto-injected classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)