### PR TITLE
feat: GitHub-style markdown preview for standalone .md files

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -218,6 +218,7 @@
     "remark-frontmatter": "npm:remark-frontmatter@5.0.0",
     "remark-rehype": "npm:remark-rehype@11.1.1",
     "rehype-highlight": "npm:rehype-highlight@7.0.2",
+    "rehype-starry-night": "npm:rehype-starry-night@2.2.0",
     "rehype-slug": "npm:rehype-slug@6.0.0",
     "rehype-stringify": "npm:rehype-stringify@10.0.1",
     "esbuild": "npm:esbuild@0.20.2",

--- a/deno.json
+++ b/deno.json
@@ -270,6 +270,7 @@
   "tasks": {
     "setup": "deno run --allow-all scripts/setup.ts",
     "start": "deno run --allow-all scripts/server.ts",
+    "start:clean": "rm -rf .cache/ && deno run --allow-all scripts/server.ts",
     "start:headless": "deno run --allow-all scripts/server.ts --headless",
     "proxy": "deno run --allow-net --allow-env --allow-read proxy/main.ts",
     "renderer": "deno run --allow-all --unstable-net --unstable-worker-options src/cli/main.ts dev",
@@ -286,6 +287,7 @@
     "test:coverage:integration": "rm -rf coverage && VF_DISABLE_LRU_INTERVAL=1 NODE_ENV=production LOG_FORMAT=text deno test --no-check --parallel --fail-fast --allow-all --coverage=coverage tests --unstable-worker-options --unstable-net || exit 1",
     "coverage:report": "deno coverage coverage --include=src/ --exclude=tests --exclude=src/**/*_test.ts --exclude=src/**/*_test.tsx --exclude=src/**/*.test.ts --exclude=src/**/*.test.tsx --lcov > coverage/lcov.info && deno run --allow-read scripts/check-coverage.ts 80",
     "coverage:html": "deno coverage coverage --include=src/ --exclude=tests --exclude=src/**/*_test.ts --exclude=src/**/*_test.tsx --exclude=src/**/*.test.ts --exclude=src/**/*.test.tsx --html",
+    "clean": "rm -rf .cache/",
     "lint": "DENO_NO_PACKAGE_JSON=1 deno lint src/",
     "fmt": "deno fmt src/",
     "fmt:check": "deno fmt --check src/",

--- a/scripts/server.ts
+++ b/scripts/server.ts
@@ -149,9 +149,14 @@ async function findLocalProjects(baseDirs: string[]): Promise<Map<string, string
   return projects;
 }
 
-// Clear module caches on startup
+// Clear all local caches on startup to prevent stale cache issues
 async function clearModuleCaches(): Promise<void> {
-  const cacheDirs = [".cache/veryfront-mdx-esm", ".cache/veryfront-modules"];
+  const cacheDirs = [
+    ".cache/veryfront-mdx-esm",
+    ".cache/veryfront-modules",
+    ".cache/veryfront-ssr",
+    ".cache/veryfront-http-bundle",
+  ];
   for (const dir of cacheDirs) {
     try {
       await Deno.remove(dir, { recursive: true });

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -23,6 +23,7 @@ import {
   buildRootAttributes,
   shouldDisableLayout,
 } from "./utils.ts";
+import { isMarkdownPreview as checkMarkdownPreview } from "../transforms/md/utils.ts";
 import {
   generateModulePreloadHintsFromManifest,
   getRouteManifest,
@@ -249,11 +250,9 @@ async function generateHTMLShellPartsImpl(
 
   // Markdown preview mode: .md files in preview/local dev with prose !== false
   // Only applies to standalone markdown files (not in pages/ or app/)
-  const isInPagesDir = options.pagePath?.includes("/pages/") || options.pagePath?.includes("/app/");
   const isMarkdownPreview = (localDev || isPreviewMode) &&
     options.pageType === "md" &&
-    !isInPagesDir &&
-    options.frontmatter?.prose !== false;
+    checkMarkdownPreview(options.pagePath, options.frontmatter);
 
   const markdownPreviewStyles = isMarkdownPreview
     ? `<!-- GitHub Markdown Preview Styles -->

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -307,7 +307,18 @@ async function generateHTMLShellPartsImpl(
   const mermaidScript = isMarkdownPreview
     ? `<script type="module"${nonce ? ` nonce="${nonce}"` : ""}>
 import mermaid from 'https://esm.sh/mermaid@11';
-mermaid.initialize({ startOnLoad: true, theme: document.documentElement.dataset.theme === 'dark' ? 'dark' : 'default' });
+mermaid.initialize({ startOnLoad: false, theme: document.documentElement.dataset.theme === 'dark' ? 'dark' : 'default' });
+// Convert code.language-mermaid blocks to mermaid-compatible format
+document.querySelectorAll('code.language-mermaid').forEach((code, i) => {
+  const pre = code.parentElement;
+  if (pre?.tagName === 'PRE') {
+    const div = document.createElement('pre');
+    div.className = 'mermaid';
+    div.textContent = code.textContent;
+    pre.replaceWith(div);
+  }
+});
+mermaid.run();
 </script>`
     : "";
 

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -247,6 +247,21 @@ async function generateHTMLShellPartsImpl(
       `<link id="vf-tailwind-css" rel="stylesheet" href="/_vf_styles/styles.css?t=${Date.now()}">`;
   }
 
+  // Markdown preview mode: .md files in preview/local dev with prose !== false
+  // Only applies to standalone markdown files (not in pages/ or app/)
+  const isInPagesDir = options.pagePath?.includes("/pages/") || options.pagePath?.includes("/app/");
+  const isMarkdownPreview = (localDev || isPreviewMode) &&
+    options.pageType === "md" &&
+    !isInPagesDir &&
+    options.frontmatter?.prose !== false;
+
+  const markdownPreviewStyles = isMarkdownPreview
+    ? `<!-- GitHub Markdown Preview Styles -->
+  <link rel="stylesheet" href="https://cdn.veryfront.com/styles/github-markdown.min.css">
+  <link rel="stylesheet" href="https://cdn.veryfront.com/styles/github-syntax-highlighting.min.css">
+  <link rel="stylesheet" href="https://cdn.veryfront.com/styles/mermaid.min.css">`
+    : "";
+
   const start = `<!DOCTYPE html>
 <html ${htmlAttrs}>
 <head>
@@ -265,6 +280,7 @@ async function generateHTMLShellPartsImpl(
 
   <!-- Tailwind CSS: Server-side JIT compiled -->
   ${tailwindCSSBlock}
+  ${markdownPreviewStyles}
 
   ${linkTags}
   ${styleTags}
@@ -289,6 +305,13 @@ async function generateHTMLShellPartsImpl(
     ? `<script src="/_veryfront/preview-hmr.js"${nonce ? ` nonce="${nonce}"` : ""}></script>`
     : "";
 
+  const mermaidScript = isMarkdownPreview
+    ? `<script type="module"${nonce ? ` nonce="${nonce}"` : ""}>
+import mermaid from 'https://esm.sh/mermaid@11';
+mermaid.initialize({ startOnLoad: true, theme: document.documentElement.dataset.theme === 'dark' ? 'dark' : 'default' });
+</script>`
+    : "";
+
   const end = `</div>
   </div>
   <div id="veryfront-portals"></div>
@@ -302,6 +325,7 @@ async function generateHTMLShellPartsImpl(
   ${modeScripts}
   ${studioScripts}
   ${previewHMRScript}
+  ${mermaidScript}
 </body>
 </html>`;
 

--- a/src/html/hydration-script-builder/types.ts
+++ b/src/html/hydration-script-builder/types.ts
@@ -10,7 +10,7 @@ export interface HydrationDataStructure {
   layouts: HydrationLayout[];
   appPath?: string;
   pagePath?: string;
-  pageType?: "mdx" | "tsx" | "jsx" | "ts" | "js";
+  pageType?: "mdx" | "md" | "tsx" | "jsx" | "ts" | "js";
   frontmatter?: Record<string, unknown>;
   layoutProps?: Record<string, Record<string, unknown>>;
   /**

--- a/src/html/types.ts
+++ b/src/html/types.ts
@@ -13,7 +13,7 @@ export interface HTMLGenerationOptions {
   nestedLayouts?: Array<{ kind: string; path?: string; componentPath?: string }>;
   appPath?: string;
   pagePath?: string;
-  pageType?: "mdx" | "tsx" | "jsx" | "ts" | "js";
+  pageType?: "mdx" | "md" | "tsx" | "jsx" | "ts" | "js";
   nonce?: string;
   /** Project directory for resolving package versions */
   projectDir?: string;

--- a/src/lib/spa/ClientApp.tsx
+++ b/src/lib/spa/ClientApp.tsx
@@ -7,7 +7,7 @@ import { getCachedComponent, loadComponent, preloadComponent } from "./component
 export interface PageDataResponse {
   slug: string;
   pagePath: string;
-  pageType: "mdx" | "tsx" | "jsx" | "ts" | "js";
+  pageType: "mdx" | "md" | "tsx" | "jsx" | "ts" | "js";
   layouts: LayoutInfo[];
   providers: string[];
   frontmatter: Record<string, unknown>;

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -276,6 +276,10 @@ export class HTMLGenerator {
       this.config.projectDir,
     );
 
+    // Determine pageType from file extension
+    const fileExtension = context.pageInfo.entity.path.split(".").pop()?.toLowerCase();
+    const pageType = fileExtension as "mdx" | "md" | "tsx" | "jsx" | "ts" | "js" | undefined;
+
     const sourceHash = context.options?.studioEmbed && context.pageInfo.entity.content
       ? computeSourceHash(context.pageInfo.entity.content)
       : undefined;
@@ -291,6 +295,7 @@ export class HTMLGenerator {
       })),
       appPath: appComponentPath,
       pagePath,
+      pageType,
       nonce: context.options?.nonce,
       globalCSS,
       frontmatter: mergedFrontmatter,
@@ -303,6 +308,7 @@ export class HTMLGenerator {
       environment: context.options?.environment,
       headings: context.pageBundle.headings,
       projectClasses,
+      isLocalDev: this.config.mode === "development",
     };
   }
 

--- a/src/rendering/orchestrator/types.ts
+++ b/src/rendering/orchestrator/types.ts
@@ -73,7 +73,7 @@ export interface RenderContext {
 export interface PageDataResponse {
   slug: string;
   pagePath: string;
-  pageType: "mdx" | "tsx" | "jsx" | "ts" | "js";
+  pageType: "mdx" | "md" | "tsx" | "jsx" | "ts" | "js";
   layouts: Array<{ kind: "mdx" | "tsx"; path: string }>;
   providers: string[];
   frontmatter: Record<string, unknown>;

--- a/src/routing/client/types.ts
+++ b/src/routing/client/types.ts
@@ -29,7 +29,7 @@ export interface LayoutInfo {
 export interface SpaPageData {
   slug: string;
   pagePath: string;
-  pageType: "mdx" | "tsx" | "jsx" | "ts" | "js";
+  pageType: "mdx" | "md" | "tsx" | "jsx" | "ts" | "js";
   layouts: LayoutInfo[];
   providers: string[];
   frontmatter: Record<string, unknown>;

--- a/src/server/handlers/dev/styles-css-handler.ts
+++ b/src/server/handlers/dev/styles-css-handler.ts
@@ -39,6 +39,40 @@ export class StylesCSSHandler extends BaseHandler {
 
       if (result.error) {
         logger.error("[StylesCSSHandler] Tailwind error", { error: result.error });
+        // Surface error in CSS so developers can see it
+        const errorCSS = `/*
+  ╔══════════════════════════════════════════════════════════════╗
+  ║  TAILWIND CSS COMPILATION ERROR                               ║
+  ╠══════════════════════════════════════════════════════════════╣
+  ║  ${result.error.replace(/\n/g, "\n  ║  ")}
+  ╚══════════════════════════════════════════════════════════════╝
+*/
+
+body::before {
+  content: "CSS Error: ${result.error.replace(/"/g, '\\"').replace(/\n/g, " ")}";
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  padding: 16px;
+  background: #dc2626;
+  color: white;
+  font-family: monospace;
+  font-size: 14px;
+  z-index: 99999;
+  white-space: pre-wrap;
+}
+`;
+        return this.respond(
+          responseBuilder.withContentType("text/css; charset=utf-8", errorCSS, HTTP_OK),
+        );
+      }
+
+      // Warn if CSS is unexpectedly empty (no error but no output)
+      if (!result.css && candidates.size > 0) {
+        logger.warn("[StylesCSSHandler] CSS is empty despite having candidates", {
+          candidates: candidates.size,
+        });
       }
 
       logger.debug("[StylesCSSHandler] CSS generated", {

--- a/src/server/handlers/preview/markdown-preview-handler.ts
+++ b/src/server/handlers/preview/markdown-preview-handler.ts
@@ -12,8 +12,6 @@ import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } 
 import { serverLogger as logger } from "#veryfront/utils";
 import { HTTP_OK } from "#veryfront/utils/constants/index.ts";
 import { compileMarkdownRuntime } from "#veryfront/transforms/md/compiler/md-compiler.ts";
-import { generateHTMLShellParts } from "#veryfront/html";
-import type { MDXFrontmatter } from "#veryfront/types";
 import { extract } from "#std/front-matter/yaml.ts";
 import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
@@ -159,39 +157,48 @@ export class MarkdownPreviewHandler extends BaseHandler {
         "server",
       );
 
-      // Wrap in div to match client-side MDContent (class added by MDContent)
-      const bodyContent = `<div class="markdown-body">${bundle.rawHtml || ""}</div>`;
-
-      // Get color scheme
+      // Get color scheme from URL param
       const colorScheme = url.searchParams.get("color_mode") as "light" | "dark" | null;
+      const theme = colorScheme || "light";
+      const title = (frontmatter.title as string) || filePath;
+      const description = (frontmatter.description as string) || "";
 
-      // Generate HTML shell
-      const { start, end } = await generateHTMLShellParts(
-        {
-          title: frontmatter.title as string || filePath,
-          description: frontmatter.description as string || "",
-          slug: filePath,
-          frontmatter: bundle.frontmatter as MDXFrontmatter,
-          ssrHash: "",
-        },
-        {
-          mode: "development",
-          config: ctx.config ?? {},
-          projectDir: ctx.projectDir,
-          pagePath: filePath,
-          pageType: "md",
-          frontmatter: bundle.frontmatter as MDXFrontmatter,
-          environment: ctx.requestContext?.mode === "preview" ? "preview" : undefined,
-          isLocalDev: ctx.requestContext?.isLocalDev ?? false,
-          colorScheme: colorScheme || "light",
-          colorSchemeFromParam: !!colorScheme,
-        },
-        {},
-        {},
-        bodyContent,
-      );
+      // Generate simple static HTML (no React hydration, no layouts, no app)
+      const html = `<!DOCTYPE html>
+<html lang="en" data-theme="${theme}" style="color-scheme: ${theme};">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  ${description ? `<meta name="description" content="${description}">` : ""}
+  <title>${title}</title>
 
-      const html = `${start}${bodyContent}${end}`;
+  <!-- GitHub Markdown Preview Styles -->
+  <link rel="stylesheet" href="https://cdn.veryfront.com/styles/github-markdown.min.css">
+  <link rel="stylesheet" href="https://cdn.veryfront.com/styles/github-syntax-highlighting.min.css">
+  <link rel="stylesheet" href="https://cdn.veryfront.com/styles/mermaid.min.css">
+</head>
+<body>
+  <article class="markdown-body" id="markdown-body">
+    ${bundle.rawHtml || ""}
+  </article>
+
+  <script type="module">
+    import mermaid from 'https://esm.sh/mermaid@11';
+    mermaid.initialize({ startOnLoad: false, theme: document.documentElement.dataset.theme === 'dark' ? 'dark' : 'default' });
+    // Convert code.language-mermaid blocks to mermaid-compatible format
+    document.querySelectorAll('code.language-mermaid').forEach((code) => {
+      const pre = code.parentElement;
+      if (pre?.tagName === 'PRE') {
+        const div = document.createElement('pre');
+        div.className = 'mermaid';
+        div.textContent = code.textContent;
+        pre.replaceWith(div);
+      }
+    });
+    mermaid.run();
+  </script>
+</body>
+</html>`;
 
       const responseBuilder = this.createResponseBuilder(ctx)
         .withCache("no-cache")

--- a/src/server/handlers/preview/markdown-preview-handler.ts
+++ b/src/server/handlers/preview/markdown-preview-handler.ts
@@ -1,0 +1,214 @@
+/**
+ * Markdown Preview Handler
+ *
+ * Serves standalone markdown files (*.md) with GitHub-style preview rendering.
+ * Only active in preview/local dev mode. Files in pages/ or app/ are excluded.
+ *
+ * @module server/handlers/preview/markdown-preview-handler
+ */
+
+import { BaseHandler } from "../response/base.ts";
+import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
+import { serverLogger as logger } from "#veryfront/utils";
+import { HTTP_OK } from "#veryfront/utils/constants/index.ts";
+import { compileMarkdownRuntime } from "#veryfront/transforms/md/compiler/md-compiler.ts";
+import { generateHTMLShellParts } from "#veryfront/html";
+import type { MDXFrontmatter } from "#veryfront/types";
+import { extract } from "#std/front-matter/yaml.ts";
+import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { tryNotFoundFallback } from "../request/ssr/not-found-fallback.ts";
+
+// Priority 900: between MEDIUM (600) and LOW/SSR (1000)
+const PRIORITY_MARKDOWN_PREVIEW = 900 as HandlerPriority;
+
+export class MarkdownPreviewHandler extends BaseHandler {
+  metadata: HandlerMetadata = {
+    name: "MarkdownPreviewHandler",
+    priority: PRIORITY_MARKDOWN_PREVIEW,
+    patterns: [{ pattern: /\.md$/, method: "GET" }],
+    enabled: (ctx) => {
+      return ctx.requestContext?.isLocalDev === true || ctx.requestContext?.mode === "preview";
+    },
+  };
+
+  async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
+    const url = new URL(req.url);
+    const pathname = url.pathname;
+
+    // Only handle .md files (not .mdx which are page components)
+    if (!pathname.endsWith(".md")) {
+      logger.debug("[MarkdownPreviewHandler] Skipping - no .md extension", { pathname });
+      return this.continue();
+    }
+
+    // Skip files in pages/ or app/ directories - those are routed normally
+    if (pathname.includes("/pages/") || pathname.includes("/app/")) {
+      return this.continue();
+    }
+
+    // Skip internal paths
+    if (pathname.startsWith("/_")) {
+      return this.continue();
+    }
+
+    const filePath = pathname.replace(/^\//, ""); // Remove leading slash
+    const fsAdapter = ctx.adapter.fs;
+
+    logger.debug("[MarkdownPreviewHandler] Attempting to serve", {
+      pathname,
+      filePath,
+      projectDir: ctx.projectDir,
+      projectSlug: ctx.projectSlug,
+    });
+
+    // Handle multi-project mode (preview)
+    const hasMultiProjectSupport = isExtendedFSAdapter(fsAdapter) &&
+      fsAdapter.isMultiProjectMode();
+
+    if (ctx.projectSlug && hasMultiProjectSupport) {
+      const effectiveToken = ctx.proxyToken || getEnv("VERYFRONT_API_TOKEN") || "";
+      const branch = ctx.parsedDomain?.branch ?? null;
+
+      return await fsAdapter.runWithContext(
+        ctx.projectSlug,
+        effectiveToken,
+        () => this.renderMarkdown(req, ctx, filePath, url),
+        ctx.projectId,
+        {
+          productionMode: false, // Preview mode
+          branch,
+          environmentName: ctx.environmentName,
+        },
+      );
+    }
+
+    // Handle contextual mode (single project)
+    if (isExtendedFSAdapter(fsAdapter) && fsAdapter.isContextualMode()) {
+      try {
+        if (ctx.proxyToken) {
+          fsAdapter.setRequestToken(ctx.proxyToken);
+        }
+        fsAdapter.setRequestBranch(ctx.parsedDomain?.branch ?? null);
+        fsAdapter.setProductionMode(false);
+      } catch {
+        // Some operations may not be supported
+      }
+    }
+
+    return await this.renderMarkdown(req, ctx, filePath, url);
+  }
+
+  private async renderMarkdown(
+    req: Request,
+    ctx: HandlerContext,
+    filePath: string,
+    url: URL,
+  ): Promise<HandlerResult> {
+    try {
+      // Try to resolve the file path (handles extension lookup)
+      const resolveFile = ctx.adapter.fs.resolveFile;
+      let resolvedPath: string | null = null;
+
+      if (resolveFile) {
+        // Try the exact path first
+        resolvedPath = await resolveFile.call(ctx.adapter.fs, filePath);
+        logger.debug("[MarkdownPreviewHandler] resolveFile result", { filePath, resolvedPath });
+      }
+
+      // Read file content
+      let content: string;
+      try {
+        const pathToRead = resolvedPath || filePath;
+        content = await ctx.adapter.fs.readFile(pathToRead);
+      } catch {
+        logger.debug("[MarkdownPreviewHandler] File not found", { filePath, resolvedPath });
+        // Return project's styled 404 page
+        const builder = this.createResponseBuilder(ctx);
+        const notFoundResponse = await tryNotFoundFallback(req, filePath, ctx, builder);
+        if (notFoundResponse) {
+          return this.respond(notFoundResponse);
+        }
+        return this.continue();
+      }
+
+      // Extract frontmatter
+      let frontmatter: Record<string, unknown> = {};
+      let body = content;
+      try {
+        const extracted = extract(content);
+        frontmatter = extracted.attrs as Record<string, unknown>;
+        body = extracted.body;
+      } catch {
+        // No frontmatter or malformed YAML
+      }
+
+      // Check for prose: false opt-out
+      if (frontmatter.prose === false) {
+        logger.debug("[MarkdownPreviewHandler] Skipping - prose: false", { filePath });
+        return this.continue();
+      }
+
+      // Compile markdown
+      const bundle = await compileMarkdownRuntime(
+        "development",
+        ctx.projectDir,
+        body,
+        frontmatter,
+        filePath,
+        "server",
+      );
+
+      // Wrap in div to match client-side MDContent (class added by MDContent)
+      const bodyContent = `<div class="markdown-body">${bundle.rawHtml || ""}</div>`;
+
+      // Get color scheme
+      const colorScheme = url.searchParams.get("color_mode") as "light" | "dark" | null;
+
+      // Generate HTML shell
+      const { start, end } = await generateHTMLShellParts(
+        {
+          title: frontmatter.title as string || filePath,
+          description: frontmatter.description as string || "",
+          slug: filePath,
+          frontmatter: bundle.frontmatter as MDXFrontmatter,
+          ssrHash: "",
+        },
+        {
+          mode: "development",
+          config: ctx.config ?? {},
+          projectDir: ctx.projectDir,
+          pagePath: filePath,
+          pageType: "md",
+          frontmatter: bundle.frontmatter as MDXFrontmatter,
+          environment: ctx.requestContext?.mode === "preview" ? "preview" : undefined,
+          isLocalDev: ctx.requestContext?.isLocalDev ?? false,
+          colorScheme: colorScheme || "light",
+          colorSchemeFromParam: !!colorScheme,
+        },
+        {},
+        {},
+        bodyContent,
+      );
+
+      const html = `${start}${bodyContent}${end}`;
+
+      const responseBuilder = this.createResponseBuilder(ctx)
+        .withCache("no-cache")
+        .withContentType("text/html; charset=utf-8", html, HTTP_OK);
+
+      logger.debug("[MarkdownPreviewHandler] Serving markdown preview", {
+        filePath,
+        htmlLength: html.length,
+      });
+
+      return this.respond(responseBuilder);
+    } catch (error) {
+      logger.error("[MarkdownPreviewHandler] Error rendering markdown", {
+        filePath,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return this.continue();
+    }
+  }
+}

--- a/src/server/handlers/preview/markdown-preview-handler.ts
+++ b/src/server/handlers/preview/markdown-preview-handler.ts
@@ -16,6 +16,7 @@ import { extract } from "#std/front-matter/yaml.ts";
 import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
 import { tryNotFoundFallback } from "../request/ssr/not-found-fallback.ts";
+import { generateStudioBridgeScript } from "#veryfront/studio/bridge-template.ts";
 
 // Priority 900: between MEDIUM (600) and LOW/SSR (1000)
 const PRIORITY_MARKDOWN_PREVIEW = 900 as HandlerPriority;
@@ -163,6 +164,18 @@ export class MarkdownPreviewHandler extends BaseHandler {
       const title = (frontmatter.title as string) || filePath;
       const description = (frontmatter.description as string) || "";
 
+      // Check for studio embed mode
+      const studioEmbed = url.searchParams.get("studio_embed") === "true";
+      const studioScript = studioEmbed
+        ? `<script>${
+          generateStudioBridgeScript({
+            projectId: ctx.projectSlug || ctx.projectId || "markdown-preview",
+            pageId: filePath,
+            pagePath: filePath,
+          })
+        }</script>`
+        : "";
+
       // Generate simple static HTML (no React hydration, no layouts, no app)
       const html = `<!DOCTYPE html>
 <html lang="en" data-theme="${theme}" style="color-scheme: ${theme};">
@@ -182,20 +195,48 @@ export class MarkdownPreviewHandler extends BaseHandler {
     ${bundle.rawHtml || ""}
   </article>
 
+  ${studioScript}
+
   <script type="module">
     import mermaid from 'https://esm.sh/mermaid@11';
-    mermaid.initialize({ startOnLoad: false, theme: document.documentElement.dataset.theme === 'dark' ? 'dark' : 'default' });
-    // Convert code.language-mermaid blocks to mermaid-compatible format
-    document.querySelectorAll('code.language-mermaid').forEach((code) => {
-      const pre = code.parentElement;
-      if (pre?.tagName === 'PRE') {
-        const div = document.createElement('pre');
-        div.className = 'mermaid';
-        div.textContent = code.textContent;
-        pre.replaceWith(div);
+
+    function getMermaidTheme() {
+      return document.documentElement.dataset.theme === 'dark' ? 'dark' : 'default';
+    }
+
+    function initMermaid() {
+      mermaid.initialize({ startOnLoad: false, theme: getMermaidTheme() });
+      // Convert code.language-mermaid blocks to mermaid-compatible format
+      document.querySelectorAll('code.language-mermaid').forEach((code) => {
+        const pre = code.parentElement;
+        if (pre?.tagName === 'PRE') {
+          const div = document.createElement('pre');
+          div.className = 'mermaid';
+          div.textContent = code.textContent;
+          pre.replaceWith(div);
+        }
+      });
+      mermaid.run();
+    }
+
+    // Initial render
+    initMermaid();
+
+    // Re-render mermaid when color mode changes (via Studio bridge)
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (mutation.attributeName === 'data-theme') {
+          // Re-initialize mermaid with new theme
+          mermaid.initialize({ startOnLoad: false, theme: getMermaidTheme() });
+          // Re-render all mermaid diagrams
+          document.querySelectorAll('.mermaid').forEach((el) => {
+            el.removeAttribute('data-processed');
+          });
+          mermaid.run();
+        }
       }
     });
-    mermaid.run();
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
   </script>
 </body>
 </html>`;

--- a/src/server/handlers/request/static.ts
+++ b/src/server/handlers/request/static.ts
@@ -327,6 +327,10 @@ export class StaticHandler extends BaseHandler {
     if (pathname.includes("/.veryfront/") || pathname.startsWith("/.veryfront")) {
       return false;
     }
+    // Don't treat .md files as asset requests - they should go through to MarkdownPreviewHandler
+    if (pathname.endsWith(".md")) {
+      return false;
+    }
     return pathname.includes(".") || pathname.startsWith("/_veryfront/");
   }
 }

--- a/src/server/universal-handler/index.ts
+++ b/src/server/universal-handler/index.ts
@@ -63,6 +63,7 @@ import { ApiHandlerWrapper } from "../handlers/request/api/index.ts";
 import { SSRHandler } from "../handlers/request/ssr/index.ts";
 import { NotFoundHandler } from "../handlers/response/not-found.ts";
 import { HMRHandler } from "../handlers/preview/hmr-handler.ts";
+import { MarkdownPreviewHandler } from "../handlers/preview/markdown-preview-handler.ts";
 import { OpenAPIHandler } from "../handlers/request/openapi-handler.ts";
 import { OpenAPIDocsHandler } from "../handlers/request/openapi-docs-handler.ts";
 import { DevDashboardHandler } from "../handlers/dev/dashboard/index.ts";
@@ -237,6 +238,7 @@ export function createVeryfrontHandler(
     new RSCHandler(), // Priority: 600 (MEDIUM, runs before static to expose RSC endpoints)
     new ModuleHandler(), // Priority: 600 (MEDIUM)
     apiHandler, // Priority: 700 (MEDIUM)
+    new MarkdownPreviewHandler(), // Priority: 900 (preview/dev only - serves .md files with GitHub styling)
     new SSRHandler(), // Priority: 1000 (LOW)
     new NotFoundHandler(), // Priority: 10000 (FALLBACK)
   ]);

--- a/src/transforms/md/compiler/md-compiler.ts
+++ b/src/transforms/md/compiler/md-compiler.ts
@@ -17,6 +17,7 @@ import type {
   CompilationTarget,
   MdxRuntimeBundle,
 } from "../../mdx/compiler/types.ts";
+import { isMarkdownPreview as checkMarkdownPreview } from "../utils.ts";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import Slugger from "github-slugger";
@@ -89,11 +90,10 @@ export function compileMarkdownRuntime(
 
         // Use GitHub-style wrapper for standalone markdown files (not in pages/ or app/)
         // unless prose: false in frontmatter
-        const isInPagesDir = filePath?.includes("/pages/") || filePath?.includes("/app/");
-        const isMarkdownPreview = !isInPagesDir && extractedFrontmatter?.prose !== false;
+        const isPreview = checkMarkdownPreview(filePath, extractedFrontmatter);
 
         // Note: destructure params/components to prevent them from spreading to DOM
-        const compiledCode = isMarkdownPreview
+        const compiledCode = isPreview
           ? `import { jsx as _jsx } from "react/jsx-runtime";
 export default function MDContent({ components, params, ...props }) {
   return _jsx("div", {

--- a/src/transforms/md/compiler/md-compiler.ts
+++ b/src/transforms/md/compiler/md-compiler.ts
@@ -3,7 +3,7 @@ import remarkParse from "remark-parse";
 import remarkGfm from "remark-gfm";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkRehype from "remark-rehype";
-import rehypeHighlight from "rehype-highlight";
+import rehypeStarryNight from "rehype-starry-night";
 import rehypeSlug from "rehype-slug";
 import rehypeStringify from "rehype-stringify";
 import { visit } from "unist-util-visit";
@@ -72,7 +72,7 @@ export function compileMarkdownRuntime(
           .use(remarkFrontmatter)
           .use(remarkExtractHeadings, headings)
           .use(remarkRehype, { allowDangerousHtml: true })
-          .use(rehypeHighlight, { detect: true, ignoreMissing: true })
+          .use(rehypeStarryNight)
           .use(rehypeSlug)
           .use(rehypeStringify, { allowDangerousHtml: true });
 
@@ -87,10 +87,24 @@ export function compileMarkdownRuntime(
 
         const escapedHtml = escapeForJsString(html);
 
-        const compiledCode = `import { jsx as _jsx } from "react/jsx-runtime";
-export default function MDContent({ components, className, ...props }) {
+        // Use GitHub-style wrapper for standalone markdown files (not in pages/ or app/)
+        // unless prose: false in frontmatter
+        const isInPagesDir = filePath?.includes("/pages/") || filePath?.includes("/app/");
+        const isMarkdownPreview = !isInPagesDir && extractedFrontmatter?.prose !== false;
+
+        // Note: destructure params/components to prevent them from spreading to DOM
+        const compiledCode = isMarkdownPreview
+          ? `import { jsx as _jsx } from "react/jsx-runtime";
+export default function MDContent({ components, params, ...props }) {
   return _jsx("div", {
-    ...props,
+    className: "markdown-body",
+    dangerouslySetInnerHTML: { __html: \`${escapedHtml}\` }
+  });
+}
+`
+          : `import { jsx as _jsx } from "react/jsx-runtime";
+export default function MDContent({ components, params, className, ...props }) {
+  return _jsx("div", {
     className,
     dangerouslySetInnerHTML: { __html: \`${escapedHtml}\` }
   });
@@ -103,6 +117,7 @@ export default function MDContent({ components, className, ...props }) {
           globals: {},
           headings,
           nodeMap: new Map(),
+          rawHtml: html,
         };
       } catch (error) {
         logger.error("[MD Compiler] Compilation failed:", {

--- a/src/transforms/md/utils.ts
+++ b/src/transforms/md/utils.ts
@@ -1,0 +1,35 @@
+/**
+ * Markdown Preview Utilities
+ *
+ * Helpers for determining markdown preview mode and related checks.
+ *
+ * @module transforms/md/utils
+ */
+
+/**
+ * Check if a file path is inside pages/ or app/ directories.
+ * Files in these directories are routed normally, not as standalone markdown.
+ */
+export function isInRoutableDir(filePath: string | undefined): boolean {
+  if (!filePath) return false;
+  return filePath.startsWith("pages/") || filePath.startsWith("app/") ||
+    filePath.includes("/pages/") || filePath.includes("/app/");
+}
+
+/**
+ * Check if a markdown file should be rendered with GitHub preview styles.
+ * Returns true for standalone .md files not in pages/app directories,
+ * unless opted out via `prose: false` frontmatter.
+ */
+export function isMarkdownPreview(
+  filePath: string | undefined,
+  frontmatter?: Record<string, unknown>,
+): boolean {
+  // Files in pages/ or app/ are routed normally
+  if (isInRoutableDir(filePath)) return false;
+
+  // prose: false opts out of preview styling
+  if (frontmatter?.prose === false) return false;
+
+  return true;
+}

--- a/src/transforms/mdx/compiler/types.ts
+++ b/src/transforms/mdx/compiler/types.ts
@@ -4,6 +4,8 @@ export interface MdxRuntimeBundle {
   globals: Record<string, unknown>;
   headings?: { id: string; text: string; level: number }[];
   nodeMap?: Map<number, unknown>;
+  /** Raw HTML output (for standalone markdown preview) */
+  rawHtml?: string;
 }
 
 export type CompilationMode = "development" | "production";

--- a/src/types/entities/getEntityInfo.ts
+++ b/src/types/entities/getEntityInfo.ts
@@ -10,6 +10,7 @@ import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { withFallback } from "#veryfront/platform/adapters/fallback-wrapper.ts";
 import { parallelMap } from "#veryfront/utils/parallel.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { logger } from "#veryfront/utils";
 
 const entityInfoScope = createErrorScope("getEntityInfo");
 const fs = createFileSystem();
@@ -149,31 +150,49 @@ export async function getEntityBySlug(
       const isVeryfrontRoute = slug.startsWith(".veryfront/") || slug === ".veryfront";
       const resolveFile = adapter?.fs.resolveFile;
 
-      if (resolveFile) {
-        const basePaths = [
-          pathHelper.join(projectDir, "pages", slug),
-          pathHelper.join(projectDir, slug),
-        ];
+      logger.debug("[getEntityBySlug] START", {
+        slug,
+        projectDir,
+        isVeryfrontRoute,
+        hasResolveFile: !!resolveFile,
+      });
 
+      if (resolveFile) {
+        // Only check pages/ directory for routes (root files are not routable)
+        const basePaths = [pathHelper.join(projectDir, "pages", slug)];
+
+        // .veryfront routes can be at root level
         if (isVeryfrontRoute) {
           basePaths.unshift(pathHelper.join(projectDir, slug));
         }
 
         if (slug === "index" || slug === "") {
-          basePaths.unshift(
-            pathHelper.join(projectDir, "pages", "index"),
-            pathHelper.join(projectDir, "index"),
-          );
+          basePaths.unshift(pathHelper.join(projectDir, "pages", "index"));
         }
+
+        logger.debug("[getEntityBySlug] Checking paths (resolveFile branch)", {
+          slug,
+          basePaths,
+        });
 
         const pathResults = await parallelMap(basePaths, async (basePath) => {
           const resolvedPath = await resolveFile.call(adapter.fs, basePath);
+          logger.debug("[getEntityBySlug] resolveFile result", {
+            basePath,
+            resolvedPath,
+          });
           if (!resolvedPath) return null;
           return await getEntityInfo(resolvedPath, adapter);
         });
 
         for (const info of pathResults) {
-          if (info?.entity.isPage) return info;
+          if (info?.entity.isPage) {
+            logger.debug("[getEntityBySlug] Found page via resolveFile", {
+              slug,
+              path: info.entity.path,
+            });
+            return info;
+          }
         }
 
         const slugParts = slug.split("/");
@@ -220,9 +239,11 @@ export async function getEntityBySlug(
           }
         }
 
+        logger.debug("[getEntityBySlug] No page found via resolveFile branch", { slug });
         return null;
       }
 
+      // Only check pages/ directory for routes (root files are not routable)
       const possiblePaths = [
         pathHelper.join(projectDir, "pages", `${slug}.mdx`),
         pathHelper.join(projectDir, "pages", `${slug}.md`),
@@ -234,12 +255,9 @@ export async function getEntityBySlug(
         pathHelper.join(projectDir, "pages", `${slug}/index.tsx`),
         pathHelper.join(projectDir, "pages", `${slug}/index.jsx`),
         pathHelper.join(projectDir, "pages", `${slug}/index.ts`),
-        pathHelper.join(projectDir, `${slug}.mdx`),
-        pathHelper.join(projectDir, `${slug}.md`),
-        pathHelper.join(projectDir, `${slug}.tsx`),
-        pathHelper.join(projectDir, `${slug}.ts`),
       ];
 
+      // .veryfront routes can be at root level
       if (isVeryfrontRoute) {
         possiblePaths.unshift(
           pathHelper.join(projectDir, `${slug}.mdx`),
@@ -255,10 +273,6 @@ export async function getEntityBySlug(
           pathHelper.join(projectDir, "pages", "index.md"),
           pathHelper.join(projectDir, "pages", "index.tsx"),
           pathHelper.join(projectDir, "pages", "index.ts"),
-          pathHelper.join(projectDir, "index.mdx"),
-          pathHelper.join(projectDir, "index.md"),
-          pathHelper.join(projectDir, "index.tsx"),
-          pathHelper.join(projectDir, "index.ts"),
         );
       }
 

--- a/tests/integration/server/production-server.test.ts
+++ b/tests/integration/server/production-server.test.ts
@@ -323,7 +323,8 @@ describe(
           const server = await context.createProductionServer();
 
           // Act
-          const response = await fetch(`http://127.0.0.1:${server.port}/pages/test`);
+          // URL /test maps to pages/test.mdx (pages/ is the routing root, not part of URL)
+          const response = await fetch(`http://127.0.0.1:${server.port}/test`);
           const html = await response.text();
 
           // Assert


### PR DESCRIPTION
## Summary

Adds a new `MarkdownPreviewHandler` to serve standalone `.md` files with GitHub-style markdown rendering. This feature is only active in preview/local dev mode.

## Key Changes

- **New Handler**: `MarkdownPreviewHandler` at priority 900 (between StaticHandler and SSRHandler)
- **Routing**: Standalone `.md` files render at their explicit path (e.g., `/readme.md`)
- **Exclusions**: Files in `pages/` or `app/` directories are excluded (routed normally via SSR)
- **Opt-out**: Frontmatter `prose: false` disables preview styling
- **Styling**: Content wrapped in `<div class="markdown-body">` for GitHub CSS compatibility

## Behavior

| File Location | URL | Handler |
|--------------|-----|---------|
| `/readme.md` | `/readme.md` | MarkdownPreviewHandler |
| `/docs/guide.md` | `/docs/guide.md` | MarkdownPreviewHandler |
| `/pages/about.md` | `/about` | SSRHandler (slug routing) |

## Files Modified

- `src/server/handlers/preview/markdown-preview-handler.ts` - New handler
- `src/server/handlers/request/static.ts` - Pass `.md` files through
- `src/transforms/md/compiler/md-compiler.ts` - Add `markdown-body` class for preview mode
- `src/transforms/mdx/compiler/types.ts` - Add `rawHtml` field to bundle
- Various type files - Add `"md"` to `pageType` union

## Test plan

- [ ] Access `/markdown.md` in preview mode - renders with GitHub styling
- [ ] Access `/markdown` - returns 404 (not slug-routable for root files)
- [ ] Access `pages/test.md` at `/test` - renders via SSR (not preview handler)
- [ ] Add `prose: false` frontmatter - skips GitHub styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)