### PR TITLE
fix(proxy): downgrade expected WebSocket disconnection logs to debug level

### DIFF
--- a/proxy/main.ts
+++ b/proxy/main.ts
@@ -197,8 +197,16 @@ function handleWebSocketUpgrade(req: Request): Response {
 
   clientSocket.onerror = (event) => {
     clearConnectTimeout();
-    proxyLogger.error("[WebSocket] Client connection error", {
-      error: event instanceof ErrorEvent ? event.message : "Unknown error",
+    const errorMessage = event instanceof ErrorEvent ? event.message : "Unknown error";
+    // Client disconnections (EOF, connection reset) are expected operational events
+    const isExpectedDisconnect = errorMessage.includes("EOF") ||
+      errorMessage.includes("connection reset") ||
+      errorMessage.includes("ECONNRESET");
+    const logFn = isExpectedDisconnect ? proxyLogger.debug : proxyLogger.error;
+    logFn("[WebSocket] Client connection error", {
+      error: errorMessage,
+      projectSlug,
+      environment: scope,
     });
   };
 


### PR DESCRIPTION
## Summary
- Detects common disconnection patterns (EOF, connection reset, ECONNRESET)
- Logs expected disconnections at debug level instead of error
- Adds projectSlug and environment context to all WebSocket error logs

## Test plan
- [ ] Verify WebSocket disconnection logs appear at debug level for expected patterns
- [ ] Verify unexpected WebSocket errors still log at error level
- [ ] Check monitoring dashboards for reduced noise

Closes #158