### PR TITLE
fix(proxy): downgrade expected WebSocket disconnection logs for both client and renderer

### DIFF
--- a/proxy/main.ts
+++ b/proxy/main.ts
@@ -168,11 +168,17 @@ function handleWebSocketUpgrade(req: Request): Response {
 
     rendererSocket.onerror = (event) => {
       clearConnectTimeout();
-      proxyLogger.error("[WebSocket] Renderer connection error", {
+      const errorMessage = event instanceof ErrorEvent ? event.message : "Unknown error";
+      // Renderer disconnections (EOF, connection reset) are expected during pod scaling
+      const isExpectedDisconnect = errorMessage.includes("EOF") ||
+        errorMessage.includes("connection reset") ||
+        errorMessage.includes("ECONNRESET");
+      const logFn = isExpectedDisconnect ? proxyLogger.debug : proxyLogger.error;
+      logFn("[WebSocket] Renderer connection error", {
         projectSlug,
         environment: scope,
         targetUrl: targetUrl.toString(),
-        error: event instanceof ErrorEvent ? event.message : "Unknown error",
+        error: errorMessage,
       });
     };
 
@@ -197,8 +203,16 @@ function handleWebSocketUpgrade(req: Request): Response {
 
   clientSocket.onerror = (event) => {
     clearConnectTimeout();
-    proxyLogger.error("[WebSocket] Client connection error", {
-      error: event instanceof ErrorEvent ? event.message : "Unknown error",
+    const errorMessage = event instanceof ErrorEvent ? event.message : "Unknown error";
+    // Client disconnections (EOF, connection reset) are expected operational events
+    const isExpectedDisconnect = errorMessage.includes("EOF") ||
+      errorMessage.includes("connection reset") ||
+      errorMessage.includes("ECONNRESET");
+    const logFn = isExpectedDisconnect ? proxyLogger.debug : proxyLogger.error;
+    logFn("[WebSocket] Client connection error", {
+      error: errorMessage,
+      projectSlug,
+      environment: scope,
     });
   };
 


### PR DESCRIPTION
## Summary
- Apply consistent log level handling for expected disconnection patterns (EOF, connection reset, ECONNRESET) to **both** client and renderer WebSocket error handlers
- Renderer connection errors now log at debug level for expected disconnections (addresses production noise during pod scaling)
- Client connection errors now include projectSlug and environment context for better observability
- Both handlers use the same pattern detection logic for consistency

## Context
PR #159 addressed client-side WebSocket disconnection logging but missed the renderer-side handler. Production logs showed "Unexpected EOF" errors from renderer connections during pod scaling events, causing unnecessary noise.

## Test plan
- [ ] Verify renderer WebSocket disconnection logs appear at debug level for expected patterns
- [ ] Verify client WebSocket disconnection logs appear at debug level for expected patterns  
- [ ] Verify unexpected WebSocket errors still log at error level for both handlers
- [ ] Check monitoring dashboards for reduced noise during pod scaling

Closes #161
Supersedes #159 (includes both client and renderer fixes)