### PR TITLE
fix: preserve quotes when replacing dynamic import specifiers

### DIFF
--- a/src/transforms/esm/lexer.ts
+++ b/src/transforms/esm/lexer.ts
@@ -123,7 +123,20 @@ export async function replaceSpecifiers(
 
     if (!replacement || replacement === originalSpecifier) continue;
 
-    result = result.substring(0, imp.s) + replacement + result.substring(imp.e);
+    // For dynamic imports with string literals, es-module-lexer's s/e include the quotes.
+    // We need to preserve the quote style when replacing.
+    const isDynamic = imp.d > -1;
+    if (isDynamic) {
+      const quote = result[imp.s];
+      if (quote === '"' || quote === "'" || quote === "`") {
+        result = result.substring(0, imp.s) + quote + replacement + quote + result.substring(imp.e);
+      } else {
+        // Dynamic import with expression, not string literal - shouldn't happen if n is defined
+        result = result.substring(0, imp.s) + replacement + result.substring(imp.e);
+      }
+    } else {
+      result = result.substring(0, imp.s) + replacement + result.substring(imp.e);
+    }
   }
 
   return unmaskHttpUrls(result, urlMap);


### PR DESCRIPTION
## Summary

Fixes a syntax error when caching HTTP modules that use dynamic imports.

For dynamic imports like `import("/foo")`, es-module-lexer's `s/e` positions include the quotes. When replacing the specifier, we were losing the quotes, resulting in invalid syntax:

```javascript
// Before (broken)
return import(<local-path>)

// After (fixed)  
return import("<local-path>")
```

This was causing `react-syntax-highlighter` and other packages with lazy-loaded modules to fail with:
```
The module's source code could not be parsed: Expected ',', got ':'
```

## Changes

- Detect when replacing a dynamic import with a string literal
- Preserve the original quote style (single, double, or backtick)

## Test plan

- [x] Clear `.cache/veryfront-http-bundle/` and restart server
- [x] Load `ai-assistant-template.preview.lvh.me:8080/` - no more syntax error

🤖 Generated with [Claude Code](https://claude.com/claude-code)