### PR TITLE
fix: React context duplication between SSR and Orchestrator loaders

### DIFF
--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -6,13 +6,12 @@
  * @module module-system/react-loader/ssr-module-loader/loader
  */
 
-import { isAbsolute, join } from "#veryfront/platform/compat/path/index.ts";
-import { cwd } from "#veryfront/platform/compat/process.ts";
+import { join } from "#veryfront/platform/compat/path/index.ts";
 import type * as React from "react";
 import { transformToESM } from "#veryfront/transforms/esm/index.ts";
 import type { TransformOptions } from "#veryfront/transforms/esm/types.ts";
 import { TRANSFORM_CACHE_VERSION } from "#veryfront/transforms/esm/package-registry.ts";
-import { buildSSRModuleCacheKey, buildSSRModuleProjectKey } from "../../../cache/keys.ts";
+import { buildSSRModuleCacheKey } from "../../../cache/keys.ts";
 import {
   type CrossProjectImport,
   type MissingImport,
@@ -21,6 +20,7 @@ import {
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import { rendererLogger as logger } from "#veryfront/utils";
+import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import { getApiBaseUrlEnv } from "#veryfront/config/env.ts";
 import { injectContext, withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { SpanNames } from "#veryfront/observability/tracing/span-names.ts";
@@ -48,7 +48,8 @@ import {
   transformSemaphore,
 } from "./cache/index.ts";
 import type { ModuleCacheEntry, SSRModuleLoaderOptions } from "./types.ts";
-import { getCacheBaseDir } from "#veryfront/utils/cache-dir.ts";
+import { getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
+import { lookupMdxEsmCache } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
 
 /**
  * SSR Module Loader with Redis Support.
@@ -389,6 +390,29 @@ export class SSRModuleLoader {
         globalModuleCache.set(filePathCacheKey, entry);
 
         logger.debug("[SSR-MODULE-LOADER] Redis cache hit", { file: filePath.slice(-40) });
+
+        await this.ensureDependenciesExist(code, filePath, depth);
+        return;
+      }
+    }
+
+    // Check MDX-ESM cache to share modules with MDX loader and avoid duplicate React contexts
+    if (this.options.projectId && this.options.contentSourceId) {
+      const baseCacheDir = getMdxEsmCacheDir();
+      const projectKey = encodeURIComponent(this.options.projectId);
+      const sourceKey = encodeURIComponent(this.options.contentSourceId);
+      const mdxCacheDir = join(baseCacheDir, projectKey, sourceKey);
+
+      const mdxCachedPath = await lookupMdxEsmCache(filePath, mdxCacheDir, this.options.projectDir);
+      if (mdxCachedPath) {
+        const entry: ModuleCacheEntry = { tempPath: mdxCachedPath, contentHash };
+        globalModuleCache.set(contentCacheKey, entry);
+        globalModuleCache.set(filePathCacheKey, entry);
+
+        logger.debug("[SSR-MODULE-LOADER] Reusing MDX-ESM cache", {
+          file: filePath.slice(-40),
+          cachedPath: mdxCachedPath.slice(-60),
+        });
 
         await this.ensureDependenciesExist(code, filePath, depth);
         return;
@@ -783,25 +807,11 @@ export class SSRModuleLoader {
   }
 
   /**
-   * Fast sync hash for small strings (project IDs, etc.)
-   * Use hashContentAsync for large file content.
-   */
-  private hashCode(str: string): string {
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-      const char = str.charCodeAt(i);
-      hash = (hash << 5) - hash + char;
-      hash = hash & hash;
-    }
-    return Math.abs(hash).toString(16);
-  }
-
-  /**
    * Async hash for large content using Web Crypto API.
-   * Doesn't block event loop for large files.
+   * Falls back to sync hash for small files.
    */
   private async hashContentAsync(content: string): Promise<string> {
-    if (content.length < 10000) return this.hashCode(content);
+    if (content.length < 10000) return hashCodeHex(content);
 
     try {
       const data = new TextEncoder().encode(content);
@@ -812,7 +822,7 @@ export class SSRModuleLoader {
         .map((b) => b.toString(16).padStart(2, "0"))
         .join("");
     } catch {
-      return this.hashCode(content);
+      return hashCodeHex(content);
     }
   }
 
@@ -832,33 +842,28 @@ export class SSRModuleLoader {
   }
 
   private async ensureTmpDir(): Promise<string> {
-    let projectDir = this.options.projectDir;
     const { projectId, contentSourceId } = this.options;
 
     if (!projectId) {
-      throw new Error(`Missing projectId for SSR temp directory (projectDir: ${projectDir})`);
+      throw new Error(
+        `Missing projectId for SSR temp directory (projectDir: ${this.options.projectDir})`,
+      );
     }
     if (!contentSourceId) {
       throw new Error(`Missing contentSourceId for SSR temp directory (project: ${projectId})`);
     }
 
-    if (!projectDir.startsWith("/")) {
-      projectDir = join(cwd(), projectDir);
-    }
-
-    const cacheBaseDir = getCacheBaseDir();
-    const baseDir = isAbsolute(cacheBaseDir) ? cacheBaseDir : join(cwd(), cacheBaseDir);
-
-    const cacheKey = `${baseDir}|${
-      buildSSRModuleProjectKey(projectDir, projectId)
-    }|${contentSourceId}`;
+    // Use the same cache directory as MDX-ESM loader to share module instances.
+    // This prevents issues like React context being created twice in separate files.
+    const baseCacheDir = getMdxEsmCacheDir();
+    const projectKey = encodeURIComponent(projectId);
+    const sourceKey = encodeURIComponent(contentSourceId);
+    const cacheKey = `${baseCacheDir}|${projectKey}|${sourceKey}`;
 
     const existingDir = globalTmpDirs.get(cacheKey);
     if (existingDir) return existingDir;
 
-    const projectKey = this.hashCode(projectId);
-    const sourceKey = this.hashCode(contentSourceId);
-    const tmpDir = join(baseDir, "veryfront-ssr", projectKey, sourceKey);
+    const tmpDir = join(baseCacheDir, projectKey, sourceKey);
 
     await this.fs.mkdir(tmpDir, { recursive: true });
     globalTmpDirs.set(cacheKey, tmpDir);

--- a/src/rendering/orchestrator/module-loader/index.ts
+++ b/src/rendering/orchestrator/module-loader/index.ts
@@ -11,11 +11,18 @@ import { Singleflight } from "#veryfront/utils/singleflight.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { CacheBackend } from "#veryfront/cache/backend.ts";
 import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
-import { generateHash } from "./cache.ts";
-import { findLocalLibFile, findSourceFile } from "../file-resolver/index.ts";
+import { findSourceFile } from "../file-resolver/index.ts";
 import { transformToESM } from "#veryfront/transforms/esm-transform.ts";
 import { getProjectTmpDir } from "#veryfront/modules/react-loader/index.ts";
 import { TRANSFORM_CACHE_VERSION } from "#veryfront/transforms/esm/package-registry.ts";
+import { getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
+import { join } from "#veryfront/platform/compat/path/index.ts";
+import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
+import {
+  getModulePathCache,
+  lookupMdxEsmCache,
+  saveModulePathCache,
+} from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
 
 // Re-export utilities
 export { createEsmCache, createModuleCache, generateHash } from "./cache.ts";
@@ -72,19 +79,10 @@ function getTransformCacheKey(projectId: string, filePath: string, contentHash: 
   return `v${TRANSFORM_CACHE_VERSION}:${projectId}:${filePath}:${contentHash}`;
 }
 
-/** Simple string hash for cache keys */
-function hashString(str: string): string {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = ((hash << 5) - hash) + str.charCodeAt(i);
-    hash &= hash;
-  }
-  return Math.abs(hash).toString(36);
-}
-
 export interface ModuleLoaderConfig {
   projectDir: string;
   projectId?: string;
+  contentSourceId?: string;
   adapter: RuntimeAdapter;
   mode: "development" | "production";
   moduleCache: Map<string, string>;
@@ -125,19 +123,14 @@ async function resolveAliasImport(
   imp: AliasImport,
   projectDir: string,
   adapter: RuntimeAdapter,
-  localAdapter: RuntimeAdapter,
+  _localAdapter: RuntimeAdapter,
 ): Promise<ResolvedDep> {
   const relativePath = imp.path.substring(2); // Remove @/ prefix
 
-  if (relativePath.startsWith("lib/")) {
-    const depFilePath = await findLocalLibFile(relativePath, localAdapter);
-    return { ...imp, relativePath, depFilePath, isLocalLib: true };
-  }
-
-  let depFilePath = await findSourceFile(relativePath, projectDir, adapter);
-  if (!depFilePath) {
-    depFilePath = await findSourceFile(`components/${relativePath}`, projectDir, adapter);
-  }
+  // @/ alias always resolves to project directory
+  // Try exact path first, then components/ subdirectory
+  const depFilePath = await findSourceFile(relativePath, projectDir, adapter) ??
+    await findSourceFile(`components/${relativePath}`, projectDir, adapter);
 
   return { ...imp, relativePath, depFilePath, isLocalLib: false };
 }
@@ -159,11 +152,25 @@ export async function transformModuleWithDeps(
   config: ModuleLoaderConfig,
   useLocalAdapter = false,
 ): Promise<string> {
-  const { moduleCache, projectDir, projectId, adapter, mode } = config;
+  const { moduleCache, projectDir, projectId, contentSourceId, adapter, mode } = config;
   const cacheKey = getModuleCacheKey(filePath, projectId, projectDir);
 
   const cachedPath = moduleCache.get(cacheKey);
   if (cachedPath) return cachedPath;
+
+  // Check MDX-ESM cache to share modules with SSR loader (prevents duplicate React contexts)
+  if (projectId && contentSourceId) {
+    const baseCacheDir = getMdxEsmCacheDir();
+    const projectKey = encodeURIComponent(projectId);
+    const sourceKey = encodeURIComponent(contentSourceId);
+    const mdxCacheDir = join(baseCacheDir, projectKey, sourceKey);
+
+    const mdxCachedPath = await lookupMdxEsmCache(filePath, mdxCacheDir, projectDir);
+    if (mdxCachedPath) {
+      moduleCache.set(cacheKey, mdxCachedPath);
+      return mdxCachedPath;
+    }
+  }
 
   const readAdapter = useLocalAdapter ? localAdapter : adapter;
   let fileContent = decodeFileContent(await readAdapter.fs.readFile(filePath));
@@ -221,7 +228,7 @@ export async function transformModuleWithDeps(
     });
   }
 
-  const contentHash = hashString(fileContent);
+  const contentHash = hashCodeHex(fileContent);
   const effectiveProjectId = projectId ?? projectDir;
   const transformCacheKey = getTransformCacheKey(effectiveProjectId, filePath, contentHash);
 
@@ -259,10 +266,19 @@ export async function transformModuleWithDeps(
     }
   }
 
-  const hash = await generateHash(filePath);
-  const tempFilePath = `${tmpDir}/mod-${hash}.js`;
+  // Use TRANSFORMED hash for filename (matches SSR loader behavior)
+  const transformedHash = hashCodeHex(transformedCode).slice(0, 8);
 
-  await ensureDir(localAdapter, tmpDir);
+  const relativePath = filePath.startsWith(projectDir)
+    ? filePath.slice(projectDir.length).replace(/^\/+/, "")
+    : filePath.replace(/^\/+/, "");
+
+  const jsPath = relativePath.replace(/\.(tsx?|jsx|mdx)$/, `.${transformedHash}.js`);
+  const tempFilePath = join(tmpDir, jsPath);
+
+  // Ensure directory exists (might be nested like lib/ or components/)
+  const tempDir = tempFilePath.substring(0, tempFilePath.lastIndexOf("/"));
+  await ensureDir(localAdapter, tempDir);
 
   try {
     await localAdapter.fs.writeFile(tempFilePath, transformedCode);
@@ -275,8 +291,50 @@ export async function transformModuleWithDeps(
     throw error;
   }
 
+  // Register in MDX-ESM cache index so other loaders can find this module
+  if (contentSourceId) {
+    const normalizedPath = `_vf_modules/${relativePath.replace(/\.(tsx?|jsx|mdx)$/, ".js")}`;
+    const mdxCacheKey = `v${TRANSFORM_CACHE_VERSION}:${normalizedPath}`;
+    const cache = await getModulePathCache(tmpDir);
+    cache.set(mdxCacheKey, tempFilePath);
+    // Persist to disk so MDX loader can find it
+    saveModulePathCache(tmpDir).catch((err) => {
+      logger.debug("[ModuleLoader] Failed to save module cache", { error: String(err) });
+    });
+    logger.debug("[ModuleLoader] Registered module in MDX-ESM cache", {
+      file: filePath.slice(-40),
+      mdxCacheKey,
+      tempFilePath: tempFilePath.slice(-60),
+    });
+  }
+
   moduleCache.set(cacheKey, tempFilePath);
   return tempFilePath;
+}
+
+/**
+ * Get the cache directory for module transforms.
+ * Uses MDX-ESM cache when contentSourceId is available, otherwise falls back to project tmp dir.
+ * This ensures modules are shared between orchestrator and MDX loader to prevent duplicate contexts.
+ */
+async function getModuleCacheDir(config: ModuleLoaderConfig): Promise<string> {
+  const { projectId, contentSourceId, projectDir } = config;
+
+  if (projectId && contentSourceId) {
+    const baseCacheDir = getMdxEsmCacheDir();
+    const projectKey = encodeURIComponent(projectId);
+    const sourceKey = encodeURIComponent(contentSourceId);
+    const cacheDir = join(baseCacheDir, projectKey, sourceKey);
+
+    // Ensure directory exists
+    const { createFileSystem } = await import("#veryfront/platform/compat/fs.ts");
+    await createFileSystem().mkdir(cacheDir, { recursive: true });
+
+    return cacheDir;
+  }
+
+  // Fallback for cases without contentSourceId
+  return getProjectTmpDir(projectId ?? projectDir);
 }
 
 /**
@@ -287,7 +345,7 @@ export async function transformModuleWithDeps(
  * @returns The loaded module
  */
 export async function loadModule(filePath: string, config: ModuleLoaderConfig): Promise<any> {
-  const tmpDir = await getProjectTmpDir(config.projectId ?? config.projectDir);
+  const tmpDir = await getModuleCacheDir(config);
   const localAdapter = await getLocalAdapter();
 
   const tempFilePath = await transformModuleWithDeps(filePath, tmpDir, localAdapter, config);

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -253,6 +253,7 @@ export class RenderPipeline {
     setupSSRGlobals();
 
     this.moduleLoaderConfig.projectId = projectId;
+    this.moduleLoaderConfig.contentSourceId = options?.contentSourceId;
 
     if (this.config.mode === "development") {
       clearSSRModuleCacheForProject(projectId);
@@ -523,6 +524,7 @@ export class RenderPipeline {
 
     const projectId = options?.projectId ?? this.config.projectDir;
     this.moduleLoaderConfig.projectId = projectId;
+    this.moduleLoaderConfig.contentSourceId = options?.contentSourceId;
 
     if (this.config.mode === "development") {
       clearSSRModuleCacheForProject(projectId);

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -14,6 +14,7 @@ import {
   type FileSystem,
   isNotFoundError,
 } from "#veryfront/platform/compat/fs.ts";
+import { TRANSFORM_CACHE_VERSION } from "../../../esm/package-registry.ts";
 import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 
 // Local filesystem for cache operations (not project's FSAdapter which may be remote/read-only)
@@ -149,4 +150,69 @@ export async function clearESMDiskCache(): Promise<void> {
       logger.warn(`${LOG_PREFIX_MDX_LOADER} Failed to clear ESM disk cache`, error);
     }
   }
+}
+
+/**
+ * Convert a project-relative file path to MDX-ESM cache key format.
+ *
+ * @param filePath - Project-relative path like "lib/ChatContext.tsx" or absolute path
+ * @param projectDir - Project directory to strip from absolute paths
+ * @returns Cache key like "v10:_vf_modules/lib/ChatContext.js"
+ */
+function toMdxEsmCacheKey(filePath: string, projectDir?: string): string {
+  // Strip project directory prefix if present
+  let relativePath = filePath;
+  if (projectDir && filePath.startsWith(projectDir)) {
+    relativePath = filePath.slice(projectDir.length).replace(/^\/+/, "");
+  }
+  // Strip leading slashes
+  relativePath = relativePath.replace(/^\/+/, "");
+
+  // Convert extension to .js
+  const jsPath = relativePath.replace(/\.(tsx?|jsx|mdx)$/, ".js");
+
+  // Build the versioned key in MDX-ESM format
+  return `v${TRANSFORM_CACHE_VERSION}:_vf_modules/${jsPath}`;
+}
+
+/**
+ * Look up a module in the MDX-ESM cache.
+ *
+ * This allows other loaders (like SSR loader) to reuse modules that
+ * MDX-ESM has already transformed and cached, preventing duplicate
+ * module instances (which breaks React context, etc.).
+ *
+ * @param filePath - Project-relative file path like "lib/ChatContext.tsx"
+ * @param cacheDir - The MDX-ESM cache directory for this project/contentSource
+ * @param projectDir - Project directory to strip from absolute paths
+ * @returns The cached file path if found, null otherwise
+ */
+export async function lookupMdxEsmCache(
+  filePath: string,
+  cacheDir: string,
+  projectDir?: string,
+): Promise<string | null> {
+  const cache = await getModulePathCache(cacheDir);
+  const cacheKey = toMdxEsmCacheKey(filePath, projectDir);
+
+  const cachedPath = cache.get(cacheKey);
+  if (!cachedPath) {
+    return null;
+  }
+
+  // Verify the cached file still exists
+  try {
+    const stat = await getLocalFs().stat(cachedPath);
+    if (stat?.isFile) {
+      logger.debug(
+        `${LOG_PREFIX_MDX_LOADER} SSR reusing MDX-ESM cache: ${filePath} -> ${cachedPath}`,
+      );
+      return cachedPath;
+    }
+  } catch {
+    // File no longer exists, remove stale entry
+    cache.delete(cacheKey);
+  }
+
+  return null;
 }

--- a/src/utils/hash-utils.ts
+++ b/src/utils/hash-utils.ts
@@ -33,6 +33,11 @@ export function simpleHash(str: string): number {
   return Math.abs(hash);
 }
 
+/** Hash string to hex (base 16) - used for module filenames */
+export function hashCodeHex(str: string): string {
+  return simpleHash(str).toString(16);
+}
+
 export async function shortHash(content: string): Promise<string> {
   const fullHash = await computeHash(content);
   return fullHash.slice(0, 8);


### PR DESCRIPTION
## Summary

Fix "useCurrentChat must be used within a ChatProvider" error in projects like `ai-assistant-template` where shared `@/lib` modules are imported from both `app.tsx` and `layout.tsx`.

## The Bug

Projects with shared lib code (like `@/lib/ChatContext`) imported from both `app.tsx` and `layout.tsx` fail with React context errors:

```
Error: useCurrentChat must be used within a ChatProvider
```

**Dashboard works** (both imports use SSR loader):
```
┌────────────────────────────────────────────────────────────┐
│                     SSR Loader (same loader!)              │
│                                                            │
│   app.tsx ──imports──┐      page.tsx ──imports──┐         │
│                      ▼                          ▼         │
│              ┌─────────────────────────────────────┐      │
│              │    lib/auth.{hash}.js              │      │
│              │    (SAME FILE = SAME CONTEXT)      │      │
│              └─────────────────────────────────────┘      │
└────────────────────────────────────────────────────────────┘
✓ Both app.tsx and page.tsx are processed by SSR Loader
✓ Same loader = Same cache = Same file = Works!
```

**AI-Assistant-Template broken** (different loaders):
```
┌─────────────────────────┐    ┌──────────────────────────────┐
│      SSR Loader         │    │    Orchestrator Loader       │
│                         │    │                              │
│   app.tsx               │    │   layout.tsx                 │
│      │imports           │    │      │imports                │
│      ▼                  │    │      ▼                       │
│  ┌──────────────────┐   │    │  ┌────────────────────────┐  │
│  │ ChatContext.js   │   │    │  │ ChatContext.js         │  │
│  │ (context #1)     │   │    │  │ (context #2) DUPLICATE!│  │
│  └──────────────────┘   │    │  └────────────────────────┘  │
└─────────────────────────┘    └──────────────────────────────┘
✗ app.tsx → SSR Loader
✗ layout.tsx → Orchestrator Loader
✗ DIFFERENT loaders = DIFFERENT files = TWO CONTEXTS = BROKEN!
```

## Root Cause

SSR loader and Orchestrator used **different hash algorithms**:
- SSR loader: `Math.abs(hash).toString(16)` (base 16 / hex)
- Orchestrator: `Math.abs(hash).toString(36)` (base 36 / alphanumeric)

Same source content → different hashes → different filenames → two separate React context instances.

```
BEFORE:
  SSR:          ChatContext.tsx → ChatContext.7773c105.js
  Orchestrator: ChatContext.tsx → ChatContext.x569z9.js   ← Different!
```

## Solution

1. Extract shared `hashCodeHex()` function to `src/utils/hash-utils.ts`
2. Both loaders now use identical hash algorithm (base 16)
3. Add MDX-ESM cache sharing between loaders

```
AFTER:
  SSR:          ChatContext.tsx → ChatContext.7773c105.js
  Orchestrator: ChatContext.tsx → ChatContext.7773c105.js  ← Same!
```

## Changes

| File | Change |
|------|--------|
| `src/utils/hash-utils.ts` | Add shared `hashCodeHex()` |
| `src/modules/react-loader/ssr-module-loader/loader.ts` | Use shared hash function |
| `src/rendering/orchestrator/module-loader/index.ts` | Use shared hash function, add MDX-ESM cache lookup |
| `src/rendering/orchestrator/pipeline.ts` | Pass `contentSourceId` to module loader |
| `src/transforms/mdx/esm-module-loader/cache/index.ts` | Add `lookupMdxEsmCache()` for cache sharing |

## Test Plan

- [x] `ai-assistant-template` renders without context error
- [x] `dashboard` continues to work
- [x] Verify only ONE ChatContext file is created in cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)