### PR TITLE
fix: rewrite npm:react@* specifiers to configured version

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -240,10 +240,10 @@
     "@opentelemetry/exporter-trace-otlp-http": "npm:@opentelemetry/exporter-trace-otlp-http@0.57",
     "@opentelemetry/resources": "npm:@opentelemetry/resources@1",
     "@opentelemetry/semantic-conventions": "npm:@opentelemetry/semantic-conventions@1",
-    "@babel/parser": "npm:@babel/parser@7.26.3",
-    "@babel/traverse": "npm:@babel/traverse@7.26.3",
-    "@babel/generator": "npm:@babel/generator@7.26.3",
-    "@babel/types": "npm:@babel/types@7.26.3"
+    "@babel/parser": "npm:@babel/parser@7.28.6",
+    "@babel/traverse": "npm:@babel/traverse@7.28.6",
+    "@babel/generator": "npm:@babel/generator@7.28.6",
+    "@babel/types": "npm:@babel/types@7.28.6"
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/src/transforms/esm/http-cache.ts
+++ b/src/transforms/esm/http-cache.ts
@@ -327,14 +327,15 @@ async function resolveSpecifier(
     if (isDeno) {
       // Rewrite npm:react@* and npm:react-dom@* to use the configured version
       // This ensures consistency when esm.sh returns bundles with hardcoded React versions
+      // Regex matches version (including prereleases like 19.1.0-canary-672f8cf68) up to first /
       const reactVersion = options.reactVersion ?? REACT_VERSION;
-      const npmReactMatch = specifier.match(/^npm:react@[\d.]+(-[a-z0-9.]+)?(.*)$/);
+      const npmReactMatch = specifier.match(/^npm:react@[^/]+(\/.*)?$/);
       if (npmReactMatch) {
-        return `npm:react@${reactVersion}${npmReactMatch[2] ?? ""}`;
+        return `npm:react@${reactVersion}${npmReactMatch[1] ?? ""}`;
       }
-      const npmReactDomMatch = specifier.match(/^npm:react-dom@[\d.]+(-[a-z0-9.]+)?(.*)$/);
+      const npmReactDomMatch = specifier.match(/^npm:react-dom@[^/]+(\/.*)?$/);
       if (npmReactDomMatch) {
-        return `npm:react-dom@${reactVersion}${npmReactDomMatch[2] ?? ""}`;
+        return `npm:react-dom@${reactVersion}${npmReactDomMatch[1] ?? ""}`;
       }
       return specifier; // Let Deno's native npm resolution handle it
     }

--- a/src/transforms/esm/http-cache.ts
+++ b/src/transforms/esm/http-cache.ts
@@ -321,10 +321,21 @@ async function resolveSpecifier(
 ): Promise<string | null> {
   if (isExternalScheme(specifier) || isInternalBare(specifier)) return null;
 
-  // For Deno: Keep npm: specifiers as-is (Deno resolves them natively with auto-dedup)
+  // For Deno: Keep npm: specifiers but ensure React uses the correct version.
   // For other runtimes: Convert to esm.sh and cache locally
   if (specifier.startsWith("npm:")) {
     if (isDeno) {
+      // Rewrite npm:react@* and npm:react-dom@* to use the configured version
+      // This ensures consistency when esm.sh returns bundles with hardcoded React versions
+      const reactVersion = options.reactVersion ?? REACT_VERSION;
+      const npmReactMatch = specifier.match(/^npm:react@[\d.]+(-[a-z0-9.]+)?(.*)$/);
+      if (npmReactMatch) {
+        return `npm:react@${reactVersion}${npmReactMatch[2] ?? ""}`;
+      }
+      const npmReactDomMatch = specifier.match(/^npm:react-dom@[\d.]+(-[a-z0-9.]+)?(.*)$/);
+      if (npmReactDomMatch) {
+        return `npm:react-dom@${reactVersion}${npmReactDomMatch[2] ?? ""}`;
+      }
       return specifier; // Let Deno's native npm resolution handle it
     }
     const cached = await cacheHttpModule(toEsmShUrlFromNpm(specifier), options);

--- a/src/transforms/esm/package-registry.ts
+++ b/src/transforms/esm/package-registry.ts
@@ -47,8 +47,9 @@ export const REACT_VERSION = DEFAULT_REACT_VERSION;
  * v10: Fix import regex to match minified code (from"..." without whitespace)
  * v11: Add HTTP bundle hash→URL mapping for cross-pod recovery
  * v12: Store HTTP bundle code by hash for direct recovery (code:{hash})
+ * v13: Rewrite npm:react@* specifiers to configured version (fixes version mismatch)
  */
-export const TRANSFORM_CACHE_VERSION = 12;
+export const TRANSFORM_CACHE_VERSION = 13;
 
 function esmSh(pkg: string, version: string, path = "", query = "target=es2022"): string {
   return `https://esm.sh/${pkg}@${version}${path}?${query}`;


### PR DESCRIPTION
## Summary

- Fixes React version mismatch error where esm.sh bundles hardcode `npm:react@19.0.0` while our configured version is `19.1.1`
- Rewrites `npm:react@*` and `npm:react-dom@*` specifiers to use the configured React version before passing to Deno's npm resolution
- Bumps `TRANSFORM_CACHE_VERSION` to 13 to invalidate stale cached bundles

## Root Cause

esm.sh returns bundles with `external=react` that embed `npm:react@19.0.0` specifiers (esm.sh's own version resolution). When passed through to Deno unchanged, this installs React 19.0.0 alongside our configured 19.1.1, causing:

```
Incompatible React versions: The "react" and "react-dom" packages must have the exact same version.
  - react:      19.0.0
  - react-dom:  19.1.1
```

## Test plan

- [x] `http://codersociety.preview.lvh.me:8080/` renders without errors
- [x] `http://veryfront.preview.lvh.me:8080/` renders without errors  
- [x] `http://dashboard.preview.lvh.me:8080/dashboard` renders without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)