### PR TITLE
fix: use centralized React version for transforms

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -264,8 +264,7 @@
   },
   "tasks": {
     "setup": "deno run --allow-all scripts/setup.ts",
-    "start": "deno run --allow-all scripts/server.ts",
-    "start:clean": "rm -rf .cache/ && deno run --allow-all scripts/server.ts",
+    "start": "rm -rf .cache/ && deno run --allow-all scripts/server.ts",
     "start:headless": "deno run --allow-all scripts/server.ts --headless",
     "proxy": "deno run --allow-net --allow-env --allow-read proxy/main.ts",
     "renderer": "deno run --allow-all --unstable-net --unstable-worker-options src/cli/main.ts dev",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "preview": "veryfront preview"
   },
   "dependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1",
     "veryfront": "^0.0.63",
     "zod": "^3.24.0"
   }

--- a/src/modules/react-loader/ssr-module-loader/cache/redis.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/redis.ts
@@ -4,10 +4,7 @@ import { rendererLogger as logger } from "#veryfront/utils";
 import { type RedisClient } from "#veryfront/utils/redis-client.ts";
 import { buildRedisSSRModuleKey } from "#veryfront/cache";
 import { getSSRModuleRedisTTL } from "../constants.ts";
-import {
-  CacheBackends,
-  createDistributedCacheAccessor,
-} from "#veryfront/cache/backend.ts";
+import { CacheBackends, createDistributedCacheAccessor } from "#veryfront/cache/backend.ts";
 
 /** Lazy-loaded distributed cache backend for cross-pod sharing */
 const getDistributedCache = createDistributedCacheAccessor(

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -662,7 +662,10 @@ export class SSRModuleLoader {
           setInRedis(contentCacheKey, transformed, {
             isProduction: this.isProductionContentSource(),
           }).catch((error) => {
-            logger.debug("[SSR-MODULE-LOADER] Distributed cache set failed", { key: contentCacheKey, error });
+            logger.debug("[SSR-MODULE-LOADER] Distributed cache set failed", {
+              key: contentCacheKey,
+              error,
+            });
           });
         }
 

--- a/src/server/handlers/dev/projects/ui-handler.ts
+++ b/src/server/handlers/dev/projects/ui-handler.ts
@@ -83,7 +83,10 @@ export function handleProjectsUI(req: Request): Promise<Response | null> {
     async () => {
       const relativePath = pathname.replace("/_projects/ui/", "").replace(/\.js$/, "");
       if (relativePath.includes("..")) {
-        return new Response("Invalid path", { status: 400, headers: { "Content-Type": "text/plain" } });
+        return new Response("Invalid path", {
+          status: 400,
+          headers: { "Content-Type": "text/plain" },
+        });
       }
       const uiDir = getUiDirectory();
 

--- a/src/transforms/pipeline/context.ts
+++ b/src/transforms/pipeline/context.ts
@@ -1,5 +1,5 @@
 import { computeShortContentHash } from "../esm/transform-utils.ts";
-import { REACT_VERSION } from "../esm/package-registry.ts";
+import { getReactVersion } from "../esm/package-registry.ts";
 import type {
   TransformContext,
   TransformOptions,
@@ -7,21 +7,13 @@ import type {
   TransformTarget,
 } from "./types.ts";
 
-async function detectProjectReactVersion(projectDir: string): Promise<string> {
-  try {
-    const content = await Deno.readTextFile(`${projectDir}/package.json`);
-    const pkg = JSON.parse(content) as {
-      dependencies?: Record<string, string>;
-      devDependencies?: Record<string, string>;
-    };
-
-    const reactVersion = { ...pkg.dependencies, ...pkg.devDependencies }?.react;
-    if (reactVersion) return reactVersion.replace(/^[\^~]/, "");
-  } catch {
-    // Project doesn't have package.json or no React dependency
-  }
-
-  return REACT_VERSION;
+/**
+ * Get React version for transforms.
+ * Uses the centralized version from package-registry (set by project config).
+ * This ensures all transforms use the same React version as deno.json import map.
+ */
+function getProjectReactVersion(): string {
+  return getReactVersion();
 }
 
 function buildContext(
@@ -63,9 +55,7 @@ export async function createTransformContext(
 ): Promise<TransformContext> {
   const [contentHash, reactVersion] = await Promise.all([
     computeShortContentHash(source),
-    options.reactVersion
-      ? Promise.resolve(options.reactVersion)
-      : detectProjectReactVersion(projectDir),
+    Promise.resolve(options.reactVersion ?? getProjectReactVersion()),
   ]);
 
   return buildContext(source, filePath, projectDir, contentHash, options, reactVersion);
@@ -84,7 +74,7 @@ export function createTransformContextSync(
     projectDir,
     contentHash,
     options,
-    options.reactVersion ?? REACT_VERSION,
+    options.reactVersion ?? getReactVersion(),
   );
 }
 


### PR DESCRIPTION
## Summary

- Fix React version mismatch causing "Cannot read properties of null (reading 'useContext')" error
- Use centralized `getReactVersion()` instead of reading from local `package.json`
- Update `package.json` React versions from `^19.0.0` to `^19.1.1` to match `deno.json`
- Clear `.cache/` on `deno task start` for local development

## Problem

The transform pipeline was reading React version from `package.json` via `detectProjectReactVersion()`, which returned `19.0.0`. However, `deno.json` specifies `npm:react@19.1.1`. This caused:

1. HTTP bundles cached with `npm:react@19.0.0` imports
2. Deno loading `npm:react@19.1.1` at runtime
3. Two React instances → broken context → "useContext" errors

## Solution

Use `getReactVersion()` from `package-registry.ts` which is set from project config via `setReactVersion()`. This ensures transforms use the same React version as the runtime.

## Test plan

- [x] `http://blank.preview.lvh.me:8080/` loads without errors
- [ ] Verify other projects still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)