### PR TITLE
fix: unify React esm.sh URLs to prevent multiple instances

### DIFF
--- a/src/build/production-build/static-generation.ts
+++ b/src/build/production-build/static-generation.ts
@@ -45,6 +45,8 @@ export interface SSGOptions {
   baseUrl?: string;
   dryRun?: boolean;
   traceStep?: <T>(name: string, fn: () => Promise<T>) => Promise<T>;
+  /** React version for import map generation */
+  reactVersion?: string;
 }
 
 function getOutputPath(outputDir: string, slug: string): string {
@@ -176,6 +178,7 @@ export async function buildAppRoutes(
     contentSourceId = "build-static",
     dryRun = false,
     traceStep = defaultTraceStep,
+    reactVersion,
   } = options;
 
   const stats: SSGStats = { pages: 0, totalSize: 0, ssgPaths: [] };
@@ -192,6 +195,7 @@ export async function buildAppRoutes(
           routePath: route.path,
           pageFile: route.pageFile,
           contentSourceId,
+          reactVersion,
         }));
 
       const outputPath = getAppRouteOutputPath(outputDir, route.path);

--- a/src/cli/npm-cli.ts
+++ b/src/cli/npm-cli.ts
@@ -2,6 +2,7 @@ import { join } from "#veryfront/platform/compat/path/index.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { cwd, exit, getArgs } from "#veryfront/platform/compat/process.ts";
 import { getVeryfrontVersion } from "#veryfront/config/env.ts";
+import { DEFAULT_REACT_VERSION, getReactUrls } from "#veryfront/transforms/esm/package-registry.ts";
 
 const VERSION = getVeryfrontVersion() ?? "0.0.0-dev";
 
@@ -83,9 +84,7 @@ async function initCommand(name: string, template: string = "minimal"): Promise<
     imports: {
       veryfront: `npm:veryfront@^${VERSION}`,
       "veryfront/": `npm:veryfront@^${VERSION}/`,
-      react: "https://esm.sh/react@18.3.1",
-      "react-dom": "https://esm.sh/react-dom@18.3.1",
-      "react/jsx-runtime": "https://esm.sh/react@18.3.1/jsx-runtime",
+      ...getReactUrls(DEFAULT_REACT_VERSION),
     },
     compilerOptions: {
       jsx: "react-jsx",

--- a/src/html/utils.ts
+++ b/src/html/utils.ts
@@ -1,6 +1,7 @@
 import { escapeHTML } from "./html-escape.ts";
 import type { VeryfrontConfig } from "#veryfront/config/types.ts";
 import { REACT_DEFAULT_VERSION, VERYFRONT_VERSION } from "#veryfront/utils/constants/cdn.ts";
+import { esmShReact } from "#veryfront/transforms/esm/package-registry.ts";
 
 function joinAttributes(attrs: Array<string | false | undefined | null | "">): string {
   return attrs.filter(Boolean).join(" ");
@@ -96,11 +97,13 @@ interface CdnUrlTemplates {
 
 const CDN_URL_TEMPLATES: Record<CdnProvider, CdnUrlTemplates> = {
   "esm.sh": {
-    react: (v) => `https://esm.sh/react@${v}?target=es2022`,
-    reactDom: (v) => `https://esm.sh/react-dom@${v}?external=react&target=es2022`,
-    reactDomClient: (v) => `https://esm.sh/react-dom@${v}/client?external=react&target=es2022`,
-    jsxRuntime: (v) => `https://esm.sh/react@${v}/jsx-runtime?target=es2022`,
-    jsxDevRuntime: (v) => `https://esm.sh/react@${v}/jsx-dev-runtime?target=es2022`,
+    // Use centralized esmShReact() helper from package-registry.ts to ensure URL consistency
+    // Any URL mismatch causes esm.sh to serve different modules -> multiple React instances -> hooks fail
+    react: (v) => esmShReact("react", v),
+    reactDom: (v) => esmShReact("react-dom", v, "", true),
+    reactDomClient: (v) => esmShReact("react-dom", v, "/client", true),
+    jsxRuntime: (v) => esmShReact("react", v, "/jsx-runtime", true),
+    jsxDevRuntime: (v) => esmShReact("react", v, "/jsx-dev-runtime", true),
     veryfrontAgentReact: (v) =>
       `https://esm.sh/veryfront@${v}/agent/react?external=react,react-dom&target=es2022`,
     veryfrontComponentsAi: (v) =>

--- a/src/modules/react-loader/unified-loader.ts
+++ b/src/modules/react-loader/unified-loader.ts
@@ -6,7 +6,10 @@ import { rendererLogger as logger } from "#veryfront/utils";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { getProjectTmpDir } from "./temp-directory.ts";
 import type { ComponentMap, ComponentSource, LoadComponentOptions } from "./types.ts";
-import { DEFAULT_REACT_VERSION } from "#veryfront/transforms/esm/package-registry.ts";
+import {
+  DEFAULT_REACT_VERSION,
+  getReactImportMap,
+} from "#veryfront/transforms/esm/package-registry.ts";
 
 type TransformedComponent = { name: string; code: string };
 
@@ -78,6 +81,8 @@ async function writeComponentFiles(
 
 function generateEntryPoint(components: TransformedComponent[], reactVersion?: string): string {
   const version = reactVersion ?? DEFAULT_REACT_VERSION;
+  // Use centralized React URL from package-registry to ensure consistency
+  const reactUrl = getReactImportMap(version).react;
   const imports = components
     .map((comp) => `import { default as ${comp.name} } from './${comp.name}.js'`)
     .join("\n");
@@ -85,7 +90,7 @@ function generateEntryPoint(components: TransformedComponent[], reactVersion?: s
   const exports = components.map((comp) => comp.name).join(", ");
 
   return `
-    import * as React from 'https://esm.sh/react@${version}?target=es2022'
+    import * as React from '${reactUrl}'
     ${imports}
 
     export { ${exports} }

--- a/src/react/compat/config-generator.ts
+++ b/src/react/compat/config-generator.ts
@@ -2,6 +2,12 @@ import { rendererLogger as logger } from "#veryfront/utils";
 import { join } from "#veryfront/platform/compat/path/index.ts";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { getReactUrls } from "#veryfront/transforms/esm/package-registry.ts";
+import {
+  REACT_VERSION_17,
+  REACT_VERSION_18_2,
+  REACT_VERSION_19_RC,
+} from "#veryfront/utils/constants/cdn.ts";
 
 export type ReactVersion = "17" | "18" | "19";
 
@@ -20,38 +26,18 @@ export interface ReactVersionSwitcher {
 export const REACT_CONFIGS: Record<ReactVersion, ReactVersionConfig> = {
   "17": {
     version: "17",
-    exact: "17.0.2",
-    imports: {
-      react: "https://esm.sh/react@17.0.2",
-      "react-dom": "https://esm.sh/react-dom@17.0.2",
-      "react-dom/server": "https://esm.sh/react-dom@17.0.2/server",
-      "react/jsx-runtime": "https://esm.sh/react@17.0.2/jsx-runtime",
-      "react/jsx-dev-runtime": "https://esm.sh/react@17.0.2/jsx-dev-runtime",
-    },
+    exact: REACT_VERSION_17,
+    imports: getReactUrls(REACT_VERSION_17),
   },
   "18": {
     version: "18",
-    exact: "18.2.0",
-    imports: {
-      react: "https://esm.sh/react@18.2.0",
-      "react-dom": "https://esm.sh/react-dom@18.2.0",
-      "react-dom/server": "https://esm.sh/react-dom@18.2.0/server",
-      "react-dom/client": "https://esm.sh/react-dom@18.2.0/client",
-      "react/jsx-runtime": "https://esm.sh/react@18.2.0/jsx-runtime",
-      "react/jsx-dev-runtime": "https://esm.sh/react@18.2.0/jsx-dev-runtime",
-    },
+    exact: REACT_VERSION_18_2,
+    imports: getReactUrls(REACT_VERSION_18_2),
   },
   "19": {
     version: "19",
-    exact: "19.0.0-rc.0",
-    imports: {
-      react: "https://esm.sh/react@19.0.0-rc.0",
-      "react-dom": "https://esm.sh/react-dom@19.0.0-rc.0",
-      "react-dom/server": "https://esm.sh/react-dom@19.0.0-rc.0/server",
-      "react-dom/client": "https://esm.sh/react-dom@19.0.0-rc.0/client",
-      "react/jsx-runtime": "https://esm.sh/react@19.0.0-rc.0/jsx-runtime",
-      "react/jsx-dev-runtime": "https://esm.sh/react@19.0.0-rc.0/jsx-dev-runtime",
-    },
+    exact: REACT_VERSION_19_RC,
+    imports: getReactUrls(REACT_VERSION_19_RC),
   },
 };
 

--- a/src/server/build-app-route-renderer.ts
+++ b/src/server/build-app-route-renderer.ts
@@ -8,8 +8,7 @@ import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { getProjectReact, renderToStringAdapter } from "#veryfront/react";
 import { loadComponentFromSource } from "#veryfront/modules/react-loader/index.ts";
 import { CompilationError } from "#veryfront/errors/index.ts";
-import { getReactUrls } from "#veryfront/transforms/esm/package-registry.ts";
-import { REACT_VERSION_18_3 } from "#veryfront/utils/constants/cdn.ts";
+import { DEFAULT_REACT_VERSION, getReactUrls } from "#veryfront/transforms/esm/package-registry.ts";
 
 type ReactComponentLike = import("react").ComponentType<{ children?: import("react").ReactNode }>;
 
@@ -46,8 +45,9 @@ export async function renderAppRouteToHTML(args: {
   routePath: string;
   pageFile: string;
   contentSourceId: string;
+  reactVersion?: string;
 }): Promise<string> {
-  const { adapter, projectDir, routePath, pageFile, contentSourceId } = args;
+  const { adapter, projectDir, routePath, pageFile, contentSourceId, reactVersion } = args;
 
   const appRoot = join(projectDir, "app");
   const layouts: string[] = [];
@@ -103,7 +103,7 @@ export async function renderAppRouteToHTML(args: {
 
   <!-- Import map for React dependencies -->
   <script type="importmap">
-  ${JSON.stringify({ imports: getReactUrls(REACT_VERSION_18_3) }, null, 4)}
+  ${JSON.stringify({ imports: getReactUrls(reactVersion ?? DEFAULT_REACT_VERSION) }, null, 4)}
   </script>
 
   <!-- Basic styles -->

--- a/src/server/build-app-route-renderer.ts
+++ b/src/server/build-app-route-renderer.ts
@@ -8,6 +8,8 @@ import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { getProjectReact, renderToStringAdapter } from "#veryfront/react";
 import { loadComponentFromSource } from "#veryfront/modules/react-loader/index.ts";
 import { CompilationError } from "#veryfront/errors/index.ts";
+import { getReactUrls } from "#veryfront/transforms/esm/package-registry.ts";
+import { REACT_VERSION_18_3 } from "#veryfront/utils/constants/cdn.ts";
 
 type ReactComponentLike = import("react").ComponentType<{ children?: import("react").ReactNode }>;
 
@@ -101,15 +103,7 @@ export async function renderAppRouteToHTML(args: {
 
   <!-- Import map for React dependencies -->
   <script type="importmap">
-  {
-    "imports": {
-      "react": "https://esm.sh/react@18.3.1",
-      "react-dom": "https://esm.sh/react-dom@18.3.1",
-      "react-dom/client": "https://esm.sh/react-dom@18.3.1/client",
-      "react/jsx-runtime": "https://esm.sh/react@18.3.1/jsx-runtime",
-      "react/jsx-dev-runtime": "https://esm.sh/react@18.3.1/jsx-dev-runtime"
-    }
-  }
+  ${JSON.stringify({ imports: getReactUrls(REACT_VERSION_18_3) }, null, 4)}
   </script>
 
   <!-- Basic styles -->

--- a/src/transforms/esm/import-rewriter.ts
+++ b/src/transforms/esm/import-rewriter.ts
@@ -50,10 +50,6 @@ function normalizeVersionedSpecifier(specifier: string): string {
   return specifier.replace(/@[\d^~x][\d.x^~-]*(?=\/|$)/, "");
 }
 
-// Use centralized React import map from package-registry.ts to ensure URL consistency
-// Any URL mismatch between SSR and browser causes multiple React instances -> hooks fail
-const REACT_IMPORT_MAP: Record<string, string> = getReactImportMap(REACT_DEFAULT_VERSION);
-
 function shouldSkipRewrite(specifier: string): boolean {
   return (
     specifier.startsWith("http://") ||
@@ -67,12 +63,19 @@ function shouldSkipRewrite(specifier: string): boolean {
   );
 }
 
-export function rewriteBareImports(code: string, _moduleServerUrl?: string): Promise<string> {
+export function rewriteBareImports(
+  code: string,
+  _moduleServerUrl?: string,
+  reactVersion?: string,
+): Promise<string> {
+  // Get React import map for the specified version (uses centralized URL builder)
+  const reactImportMap = getReactImportMap(reactVersion ?? REACT_DEFAULT_VERSION);
+
   return withSpan(
     "transforms.esm.rewriteBareImports",
     () =>
       replaceSpecifiers(code, (specifier) => {
-        const mapped = REACT_IMPORT_MAP[specifier];
+        const mapped = reactImportMap[specifier];
         if (mapped) return mapped;
 
         if (shouldSkipRewrite(specifier)) return null;

--- a/src/transforms/esm/import-rewriter.ts
+++ b/src/transforms/esm/import-rewriter.ts
@@ -2,6 +2,7 @@ import { parseImports, replaceSpecifiers, rewriteImports } from "./lexer.ts";
 import { REACT_DEFAULT_VERSION, TAILWIND_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import { rendererLogger as logger } from "#veryfront/utils";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { getReactImportMap } from "./package-registry.ts";
 
 export function addHMRTimestamps(code: string, timestamp: string | number): Promise<string> {
   return withSpan(
@@ -49,17 +50,9 @@ function normalizeVersionedSpecifier(specifier: string): string {
   return specifier.replace(/@[\d^~x][\d.x^~-]*(?=\/|$)/, "");
 }
 
-const REACT_IMPORT_MAP: Record<string, string> = {
-  react: `https://esm.sh/react@${REACT_DEFAULT_VERSION}?target=es2022`,
-  "react-dom": `https://esm.sh/react-dom@${REACT_DEFAULT_VERSION}?external=react&target=es2022`,
-  "react-dom/client":
-    `https://esm.sh/react-dom@${REACT_DEFAULT_VERSION}/client?external=react&target=es2022`,
-  "react-dom/server":
-    `https://esm.sh/react-dom@${REACT_DEFAULT_VERSION}/server?external=react&target=es2022`,
-  "react/jsx-runtime": `https://esm.sh/react@${REACT_DEFAULT_VERSION}/jsx-runtime?target=es2022`,
-  "react/jsx-dev-runtime":
-    `https://esm.sh/react@${REACT_DEFAULT_VERSION}/jsx-dev-runtime?target=es2022`,
-};
+// Use centralized React import map from package-registry.ts to ensure URL consistency
+// Any URL mismatch between SSR and browser causes multiple React instances -> hooks fail
+const REACT_IMPORT_MAP: Record<string, string> = getReactImportMap(REACT_DEFAULT_VERSION);
 
 function shouldSkipRewrite(specifier: string): boolean {
   return (

--- a/src/transforms/esm/package-registry.ts
+++ b/src/transforms/esm/package-registry.ts
@@ -63,10 +63,14 @@ export const REACT_VERSION = DEFAULT_REACT_VERSION;
 export const TRANSFORM_CACHE_VERSION = 12;
 
 /** csstype version - must match deno.json for type consistency */
-const CSSTYPE_VERSION = "3.2.3";
+export const CSSTYPE_VERSION = "3.2.3";
 
-/** Build esm.sh URL with deps=csstype for React packages (ensures type consistency) */
-function esmShReact(pkg: string, version: string, path = "", external = false): string {
+/**
+ * Build esm.sh URL with deps=csstype for React packages (ensures type consistency).
+ * CRITICAL: This is the single source of truth for React URLs. All other files
+ * (html/utils.ts, import-rewriter.ts, etc.) must use this or getReactImportMap().
+ */
+export function esmShReact(pkg: string, version: string, path = "", external = false): string {
   const params = external
     ? [`external=react`, `target=es2022`, `deps=csstype@${CSSTYPE_VERSION}`]
     : [`target=es2022`, `deps=csstype@${CSSTYPE_VERSION}`];

--- a/src/transforms/pipeline/stages/resolve-bare.ts
+++ b/src/transforms/pipeline/stages/resolve-bare.ts
@@ -24,7 +24,7 @@ export const resolveBarePlugin: TransformPlugin = {
       return rewriteVendorImports(ctx.code, ctx.moduleServerUrl, ctx.vendorBundleHash);
     }
 
-    return rewriteBareImports(ctx.code, ctx.moduleServerUrl);
+    return rewriteBareImports(ctx.code, ctx.moduleServerUrl, ctx.reactVersion);
   },
 };
 

--- a/src/utils/constants/cdn.ts
+++ b/src/utils/constants/cdn.ts
@@ -10,57 +10,33 @@ export const REACT_VERSION_19 = "19.1.1";
 
 export const REACT_DEFAULT_VERSION = REACT_VERSION_19;
 
-/**
- * esm.sh URL builder with consistent query params.
- *
- * For React packages (react-dom, jsx-runtime), we only need external=react:
- * - react-dom depends on react → external=react makes it import "react" as bare specifier
- * - react-dom doesn't need external=react-dom because it IS react-dom
- * - jsx-runtime depends on react core → external=react
- *
- * Third-party packages (e.g., @tanstack/react-query) need external=react,react-dom
- * because they may depend on BOTH. That's handled by bundleHttpImports() separately.
- */
-function esmSh(pkg: string, version: string, path = "", external = false): string {
-  const params = ["target=es2022"];
-  if (external) params.push("external=react");
-  return `${ESM_CDN_BASE}/${pkg}@${version}${path}?${params.join("&")}`;
-}
+// Re-export from package-registry.ts - the SINGLE SOURCE OF TRUTH for React URLs.
+// This ensures all React URLs include deps=csstype and match exactly.
+// DO NOT add duplicate URL builders here - use package-registry.ts instead.
+import * as ReactRegistry from "#veryfront/transforms/esm/package-registry.ts";
 
-export function getReactCDNUrl(version: string = REACT_DEFAULT_VERSION): string {
-  return esmSh("react", version);
-}
+export const esmShReact = ReactRegistry.esmShReact;
+export const getReactImportMap = ReactRegistry.getReactImportMap;
+export const getReactUrls = ReactRegistry.getReactUrls;
 
-export function getReactDOMCDNUrl(version: string = REACT_DEFAULT_VERSION): string {
-  return esmSh("react-dom", version, "", true);
-}
+// Named getters for convenience - delegate to ReactRegistry
+export const getReactCDNUrl = (version = REACT_DEFAULT_VERSION) =>
+  ReactRegistry.getReactUrls(version).react!;
 
-export function getReactDOMClientCDNUrl(version: string = REACT_DEFAULT_VERSION): string {
-  return esmSh("react-dom", version, "/client", true);
-}
+export const getReactDOMCDNUrl = (version = REACT_DEFAULT_VERSION) =>
+  ReactRegistry.getReactUrls(version)["react-dom"]!;
 
-export function getReactDOMServerCDNUrl(version: string = REACT_DEFAULT_VERSION): string {
-  return esmSh("react-dom", version, "/server", true);
-}
+export const getReactDOMClientCDNUrl = (version = REACT_DEFAULT_VERSION) =>
+  ReactRegistry.getReactUrls(version)["react-dom/client"]!;
 
-export function getReactJSXRuntimeCDNUrl(version: string = REACT_DEFAULT_VERSION): string {
-  return esmSh("react", version, "/jsx-runtime", true);
-}
+export const getReactDOMServerCDNUrl = (version = REACT_DEFAULT_VERSION) =>
+  ReactRegistry.getReactUrls(version)["react-dom/server"]!;
 
-export function getReactJSXDevRuntimeCDNUrl(version: string = REACT_DEFAULT_VERSION): string {
-  return esmSh("react", version, "/jsx-dev-runtime", true);
-}
+export const getReactJSXRuntimeCDNUrl = (version = REACT_DEFAULT_VERSION) =>
+  ReactRegistry.getReactUrls(version)["react/jsx-runtime"]!;
 
-export function getReactImportMap(version: string = REACT_DEFAULT_VERSION): Record<string, string> {
-  return {
-    react: getReactCDNUrl(version),
-    "react-dom": getReactDOMCDNUrl(version),
-    "react-dom/client": getReactDOMClientCDNUrl(version),
-    "react-dom/server": getReactDOMServerCDNUrl(version),
-    "react/jsx-runtime": getReactJSXRuntimeCDNUrl(version),
-    "react/jsx-dev-runtime": getReactJSXDevRuntimeCDNUrl(version),
-  };
-}
+export const getReactJSXDevRuntimeCDNUrl = (version = REACT_DEFAULT_VERSION) =>
+  ReactRegistry.getReactUrls(version)["react/jsx-dev-runtime"]!;
 
 export const DEFAULT_ALLOWED_CDN_HOSTS = [ESM_CDN_BASE, DENO_STD_BASE];
 


### PR DESCRIPTION
## Summary

- Fixed URL mismatch between client import map and transform pipeline
- Client was using `react@19.1.1?target=es2022` 
- Transforms produced `react@19.1.1?target=es2022&deps=csstype@3.2.3`
- esm.sh treats different URLs as different modules → two React instances → hooks fail

## Root Cause

`Cannot read properties of null (reading 'useState')` error in coding-agent example was caused by multiple React instances loading due to URL parameter mismatch.

## Changes

- Export `esmShReact()` from `package-registry.ts` as single source of truth
- Update `html/utils.ts` to use `esmShReact()` for client import map
- Update `import-rewriter.ts` to use `getReactImportMap()` instead of duplicating URLs
- Update `unified-loader.ts` to use `getReactImportMap()` for React URL

## Test plan

- [ ] Run `deno task start`
- [ ] Open http://coding-agent.veryfront.me:8080/
- [ ] Verify no `useState` errors in console
- [ ] Verify page renders and hooks work

🤖 Generated with [Claude Code](https://claude.com/claude-code)