### PR TITLE
fix: use projectId consistently for cache directory keys

### DIFF
--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -537,8 +537,8 @@ export class SSRModuleLoader {
     // Check MDX-ESM cache to share modules with MDX loader and avoid duplicate React contexts
     if (this.options.projectId && this.options.contentSourceId) {
       const baseCacheDir = getMdxEsmCacheDir();
-      // Use projectSlug when available to match MDX loader's directory structure
-      const projectKey = this.options.projectSlug || hashCodeHex(this.options.projectId);
+      // Use projectId consistently for stable cache keys (matches MDX loader)
+      const projectKey = encodeURIComponent(this.options.projectId);
       const sourceKey = this.options.contentSourceId;
       const mdxCacheDir = join(baseCacheDir, projectKey, sourceKey);
 
@@ -1022,8 +1022,8 @@ export class SSRModuleLoader {
     // Use the same cache directory as MDX-ESM loader to share module instances.
     // This prevents issues like React context being created twice in separate files.
     const baseCacheDir = getMdxEsmCacheDir();
-    // Use projectSlug when available to match MDX loader's directory structure
-    const projectKey = this.options.projectSlug || hashCodeHex(projectId);
+    // Use projectId consistently for stable cache keys (matches MDX loader)
+    const projectKey = encodeURIComponent(projectId);
     const sourceKey = contentSourceId;
     const cacheKey = `${baseCacheDir}|${projectKey}|${sourceKey}`;
 

--- a/src/transforms/mdx/esm-module-loader/loader.ts
+++ b/src/transforms/mdx/esm-module-loader/loader.ts
@@ -74,9 +74,8 @@ async function initializeCacheDir(context: ESMLoaderContext): Promise<string> {
 
   const localFs = getLocalFs();
   const baseCacheDir = getMdxEsmCacheDir();
-  // Use projectSlug when available to match SSRModuleLoader's directory structure
-  // This ensures all modules for a project share the same cache directory
-  const projectKey = encodeURIComponent(context.projectSlug || context.projectId);
+  // Use projectId consistently for stable cache keys (won't change if slug is renamed)
+  const projectKey = encodeURIComponent(context.projectId);
   const sourceKey = encodeURIComponent(context.contentSourceId);
   const persistentCacheDir = join(baseCacheDir, projectKey, sourceKey);
 


### PR DESCRIPTION
## Summary

- Both MDX-ESM and SSR loaders now use `encodeURIComponent(projectId)` for cache directories
- Ensures stable cache keys that won't change if project slugs are renamed
- Fixes potential mismatch where one loader had `projectSlug` and the other didn't

## Changes

| File | Change |
|------|--------|
| `src/transforms/mdx/esm-module-loader/loader.ts` | `projectSlug \|\| projectId` → `projectId` |
| `src/modules/react-loader/ssr-module-loader/loader.ts` | `projectSlug \|\| hashCodeHex(projectId)` → `encodeURIComponent(projectId)` |

## Test plan

- [x] `deno task verify:quick` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)