### PR TITLE
fix: add components/layout.* fallback for local filesystem adapter

### DIFF
--- a/src/rendering/layouts/layout-collector.ts
+++ b/src/rendering/layouts/layout-collector.ts
@@ -1,6 +1,5 @@
 import { join } from "#veryfront/platform/compat/path-helper.ts";
 import { rendererLogger as logger } from "#veryfront/utils";
-import { parallelFind } from "#veryfront/utils/parallel.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
 import type { EntityInfo, LayoutItem, MdxBundle } from "#veryfront/types";
@@ -8,7 +7,7 @@ import type { VeryfrontConfig } from "#veryfront/config";
 import { getLayoutEntity } from "#veryfront/types/entities/getEntityInfo.ts";
 import { discoverNestedLayouts } from "./utils/discovery.ts";
 import { detectAppRouter } from "../router-detection.ts";
-import { LAYOUT_EXTENSIONS } from "./types.ts";
+import { LAYOUT_EXTENSIONS, type LayoutExtension } from "./types.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { SpanNames } from "#veryfront/observability/tracing/span-names.ts";
 
@@ -18,6 +17,62 @@ function getLayoutKind(path: string): "mdx" | "tsx" {
 
 function isValidLayoutPath(layout: string): boolean {
   return /\.(tsx|jsx|ts|js|mdx|md)$/.test(layout);
+}
+
+/**
+ * Creates a LayoutItem from a path. For tsx/jsx/ts/js files, creates a tsx kind item.
+ * For mdx/md files, creates an mdx kind item with optional bundle.
+ */
+function createLayoutItem(
+  layoutPath: string,
+  bundle?: MdxBundle,
+): LayoutItem {
+  const kind = getLayoutKind(layoutPath);
+  if (kind === "mdx") {
+    return { kind: "mdx", bundle, path: layoutPath };
+  }
+  return {
+    kind: "tsx",
+    component: undefined,
+    componentPath: layoutPath,
+    path: layoutPath,
+  };
+}
+
+/**
+ * FileExistenceChecker is a pure interface for checking file existence.
+ * This allows unit testing without mocking the full adapter.
+ */
+export interface FileExistenceChecker {
+  exists(path: string): Promise<boolean>;
+}
+
+/**
+ * Discovers a components/layout.* file in the given project directory.
+ * Returns the full path if found, or null if no layout file exists.
+ *
+ * This is a pure function that can be unit tested without mocking the full adapter.
+ */
+export async function discoverComponentsLayoutPath(
+  projectDir: string,
+  checker: FileExistenceChecker,
+): Promise<string | null> {
+  for (const ext of LAYOUT_EXTENSIONS) {
+    const layoutPath = join(projectDir, "components", `layout.${ext}`);
+    const exists = await checker.exists(layoutPath);
+    if (exists) {
+      return layoutPath;
+    }
+  }
+  return null;
+}
+
+/**
+ * Result from discovering a components layout file.
+ */
+export interface ComponentsLayoutDiscoveryResult {
+  layoutPath: string;
+  extension: LayoutExtension;
 }
 
 export interface LayoutCollectionResult {
@@ -115,20 +170,12 @@ export class LayoutCollector {
     layoutName: string | undefined,
   ): Promise<LayoutCollectionResult> {
     if (hasExplicitFrontmatterLayout && layoutPath) {
-      const kind = getLayoutKind(layoutPath);
-      const nestedLayouts: LayoutItem[] = [
-        {
-          kind,
-          bundle: kind === "mdx" ? layoutBundle : undefined,
-          componentPath: kind === "tsx" ? layoutPath : undefined,
-          path: layoutPath,
-        },
-      ];
+      const nestedLayouts: LayoutItem[] = [createLayoutItem(layoutPath, layoutBundle)];
 
       logger.debug("[LayoutCollector] Using frontmatter layout as nestedLayout", {
         layoutPath,
         layoutName,
-        kind,
+        kind: getLayoutKind(layoutPath),
       });
 
       return { layoutBundle: undefined, nestedLayouts };
@@ -150,15 +197,7 @@ export class LayoutCollector {
       }
 
       const kind = getLayoutKind(layoutPath);
-      nestedLayouts = [
-        {
-          kind,
-          bundle: kind === "mdx" ? layoutBundle : undefined,
-          componentPath: kind === "tsx" ? layoutPath : undefined,
-          path: layoutPath,
-        },
-        ...nestedLayouts,
-      ];
+      nestedLayouts = [createLayoutItem(layoutPath, layoutBundle), ...nestedLayouts];
 
       logger.debug("[LayoutCollector] Added config.layout to nestedLayouts for client hydration", {
         layoutPath,
@@ -269,22 +308,27 @@ export class LayoutCollector {
   }
 
   private async collectAPILayoutConfiguration(wrappedAdapter: unknown): Promise<LayoutItem[]> {
-    const nestedLayouts: LayoutItem[] = [];
     const configLayout = this.config?.layout;
 
     if (configLayout === false) {
       logger.debug("[LayoutCollector] Layout disabled via config.layout: false");
-      return nestedLayouts;
+      return [];
     }
 
-    const existsFn = (wrappedAdapter as { exists: (path: string) => Promise<boolean> }).exists;
+    const checker: FileExistenceChecker = {
+      exists: (path: string) =>
+        (wrappedAdapter as { exists: (path: string) => Promise<boolean> }).exists.call(
+          wrappedAdapter,
+          path,
+        ),
+    };
 
     if (configLayout && isValidLayoutPath(configLayout)) {
       const layoutPath = configLayout.startsWith("/") || configLayout.startsWith(this.projectDir)
         ? configLayout
         : join(this.projectDir, configLayout);
 
-      const layoutExists = await existsFn.call(wrappedAdapter, layoutPath);
+      const layoutExists = await checker.exists(layoutPath);
 
       logger.debug("[LayoutCollector] Checking config layout", {
         configLayout,
@@ -299,47 +343,18 @@ export class LayoutCollector {
         );
       }
 
-      const kind = getLayoutKind(configLayout);
-      if (kind === "mdx") {
-        const content = await this.adapter.fs.readFile(layoutPath);
-        const bundle = await this.compileMDX(content, { isLayout: true }, layoutPath);
-        nestedLayouts.push({ kind: "mdx", bundle, path: layoutPath });
-      } else {
-        nestedLayouts.push({
-          kind: "tsx",
-          component: undefined,
-          componentPath: layoutPath,
-          path: layoutPath,
-        });
-      }
-
-      logger.debug("[LayoutCollector] Added config layout to nestedLayouts", { layoutPath, kind });
-      return nestedLayouts;
+      return [await this.createLayoutItemWithBundle(layoutPath)];
     }
 
     if (!configLayout) {
-      const foundExt = await parallelFind([...LAYOUT_EXTENSIONS], async (ext) => {
-        const layoutPath = join(this.projectDir, "components", `layout.${ext}`);
-        return await existsFn.call(wrappedAdapter, layoutPath);
-      });
-
-      if (foundExt) {
-        const defaultLayoutPath = join(this.projectDir, "components", `layout.${foundExt}`);
-        const kind = getLayoutKind(defaultLayoutPath);
-        nestedLayouts.push({
-          kind,
-          component: undefined,
-          componentPath: defaultLayoutPath,
-          path: defaultLayoutPath,
-        });
-
-        logger.debug(`[LayoutCollector] Added default components/layout.${foundExt}`, {
-          layoutPath: defaultLayoutPath,
-        });
+      const layoutPath = await discoverComponentsLayoutPath(this.projectDir, checker);
+      if (layoutPath) {
+        logger.debug("[LayoutCollector] Added default components layout", { layoutPath });
+        return [createLayoutItem(layoutPath)];
       }
     }
 
-    return nestedLayouts;
+    return [];
   }
 
   private async collectFilesystemLayouts(
@@ -347,6 +362,57 @@ export class LayoutCollector {
     useAppRouter: boolean,
   ): Promise<LayoutItem[]> {
     const rootDir = useAppRouter ? join(this.projectDir, "app") : join(this.projectDir, "pages");
-    return await discoverNestedLayouts(pageFilePath, rootDir, this.projectDir, this.adapter);
+    const nestedLayouts = await discoverNestedLayouts(
+      pageFilePath,
+      rootDir,
+      this.projectDir,
+      this.adapter,
+    );
+
+    // If nested layouts found, use them
+    if (nestedLayouts.length > 0) {
+      return nestedLayouts;
+    }
+
+    // Fallback: check components/layout.* (consistent with API adapter behavior)
+    return await this.checkComponentsLayoutFallback();
+  }
+
+  /**
+   * Check for components/layout.* as a fallback when no nested layouts are found.
+   * This provides consistent behavior between filesystem and API adapters.
+   */
+  private async checkComponentsLayoutFallback(): Promise<LayoutItem[]> {
+    const checker: FileExistenceChecker = {
+      exists: async (path: string) => {
+        try {
+          const stat = await this.adapter.fs.stat(path);
+          return stat.isFile;
+        } catch {
+          return false;
+        }
+      },
+    };
+
+    const layoutPath = await discoverComponentsLayoutPath(this.projectDir, checker);
+    if (!layoutPath) {
+      return [];
+    }
+
+    logger.debug("[LayoutCollector] Added fallback components layout", { layoutPath });
+    return [await this.createLayoutItemWithBundle(layoutPath)];
+  }
+
+  /**
+   * Creates a LayoutItem, compiling MDX content if needed.
+   */
+  private async createLayoutItemWithBundle(layoutPath: string): Promise<LayoutItem> {
+    const kind = getLayoutKind(layoutPath);
+    if (kind === "mdx") {
+      const content = await this.adapter.fs.readFile(layoutPath);
+      const bundle = await this.compileMDX(content, { isLayout: true }, layoutPath);
+      return createLayoutItem(layoutPath, bundle);
+    }
+    return createLayoutItem(layoutPath);
   }
 }

--- a/tests/unit/rendering/layouts/components-layout-discovery.test.ts
+++ b/tests/unit/rendering/layouts/components-layout-discovery.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Unit tests for components/layout.* discovery functionality.
+ *
+ * These tests verify the pure function `discoverComponentsLayoutPath`
+ * which can be tested without mocking the full adapter.
+ */
+
+import { assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import {
+  discoverComponentsLayoutPath,
+  type FileExistenceChecker,
+} from "../../../../src/rendering/layouts/layout-collector.ts";
+import { LAYOUT_EXTENSIONS } from "../../../../src/rendering/layouts/types.ts";
+
+/**
+ * Creates a mock FileExistenceChecker for testing.
+ */
+function createMockChecker(existingPaths: Set<string>): FileExistenceChecker {
+  return {
+    exists: (path: string) => Promise.resolve(existingPaths.has(path)),
+  };
+}
+
+describe("discoverComponentsLayoutPath", () => {
+  const projectDir = "/project";
+
+  it("should return null when no layout file exists", async () => {
+    const checker = createMockChecker(new Set());
+
+    const result = await discoverComponentsLayoutPath(projectDir, checker);
+
+    assertEquals(result, null, "Should return null when no layout exists");
+  });
+
+  it("should find layout.tsx file", async () => {
+    const checker = createMockChecker(
+      new Set(["/project/components/layout.tsx"]),
+    );
+
+    const result = await discoverComponentsLayoutPath(projectDir, checker);
+
+    assertEquals(
+      result,
+      "/project/components/layout.tsx",
+      "Should find layout.tsx",
+    );
+  });
+
+  it("should find layout.mdx file", async () => {
+    const checker = createMockChecker(
+      new Set(["/project/components/layout.mdx"]),
+    );
+
+    const result = await discoverComponentsLayoutPath(projectDir, checker);
+
+    assertEquals(
+      result,
+      "/project/components/layout.mdx",
+      "Should find layout.mdx",
+    );
+  });
+
+  it("should find layout.jsx file", async () => {
+    const checker = createMockChecker(
+      new Set(["/project/components/layout.jsx"]),
+    );
+
+    const result = await discoverComponentsLayoutPath(projectDir, checker);
+
+    assertEquals(
+      result,
+      "/project/components/layout.jsx",
+      "Should find layout.jsx",
+    );
+  });
+
+  it("should find layout.md file", async () => {
+    const checker = createMockChecker(
+      new Set(["/project/components/layout.md"]),
+    );
+
+    const result = await discoverComponentsLayoutPath(projectDir, checker);
+
+    assertEquals(
+      result,
+      "/project/components/layout.md",
+      "Should find layout.md",
+    );
+  });
+
+  it("should find layout.ts file", async () => {
+    const checker = createMockChecker(
+      new Set(["/project/components/layout.ts"]),
+    );
+
+    const result = await discoverComponentsLayoutPath(projectDir, checker);
+
+    assertEquals(
+      result,
+      "/project/components/layout.ts",
+      "Should find layout.ts",
+    );
+  });
+
+  it("should find layout.js file", async () => {
+    const checker = createMockChecker(
+      new Set(["/project/components/layout.js"]),
+    );
+
+    const result = await discoverComponentsLayoutPath(projectDir, checker);
+
+    assertEquals(
+      result,
+      "/project/components/layout.js",
+      "Should find layout.js",
+    );
+  });
+
+  it("should prefer mdx over tsx when both exist (due to extension order)", async () => {
+    // LAYOUT_EXTENSIONS = ["mdx", "md", "tsx", "jsx", "ts", "js"]
+    const checker = createMockChecker(
+      new Set([
+        "/project/components/layout.tsx",
+        "/project/components/layout.mdx",
+      ]),
+    );
+
+    const result = await discoverComponentsLayoutPath(projectDir, checker);
+
+    assertEquals(
+      result,
+      "/project/components/layout.mdx",
+      "Should prefer mdx (first in extension order)",
+    );
+  });
+
+  it("should prefer md over tsx when both exist", async () => {
+    const checker = createMockChecker(
+      new Set([
+        "/project/components/layout.tsx",
+        "/project/components/layout.md",
+      ]),
+    );
+
+    const result = await discoverComponentsLayoutPath(projectDir, checker);
+
+    assertEquals(
+      result,
+      "/project/components/layout.md",
+      "Should prefer md over tsx",
+    );
+  });
+
+  it("should prefer tsx over jsx when both exist", async () => {
+    const checker = createMockChecker(
+      new Set([
+        "/project/components/layout.tsx",
+        "/project/components/layout.jsx",
+      ]),
+    );
+
+    const result = await discoverComponentsLayoutPath(projectDir, checker);
+
+    assertEquals(
+      result,
+      "/project/components/layout.tsx",
+      "Should prefer tsx over jsx",
+    );
+  });
+
+  it("should work with different project directories", async () => {
+    const customProjectDir = "/custom/path/to/project";
+    const checker = createMockChecker(
+      new Set([`${customProjectDir}/components/layout.tsx`]),
+    );
+
+    const result = await discoverComponentsLayoutPath(customProjectDir, checker);
+
+    assertEquals(
+      result,
+      `${customProjectDir}/components/layout.tsx`,
+      "Should work with custom project directory",
+    );
+  });
+
+  it("should not find files in wrong locations", async () => {
+    const checker = createMockChecker(
+      new Set([
+        "/project/layout.tsx", // Wrong location (root, not components)
+        "/project/src/components/layout.tsx", // Wrong path (src/components)
+        "/project/components/layouts/layout.tsx", // Wrong path (layouts subdirectory)
+      ]),
+    );
+
+    const result = await discoverComponentsLayoutPath(projectDir, checker);
+
+    assertEquals(
+      result,
+      null,
+      "Should not find layout files in incorrect locations",
+    );
+  });
+
+  it("should handle checker that always returns false", async () => {
+    const checker: FileExistenceChecker = {
+      exists: () => Promise.resolve(false),
+    };
+
+    const result = await discoverComponentsLayoutPath(projectDir, checker);
+
+    assertEquals(result, null, "Should return null when checker always returns false");
+  });
+
+  it("should respect the defined extension order", async () => {
+    // Verify the extension order matches LAYOUT_EXTENSIONS
+    const expectedOrder = ["mdx", "md", "tsx", "jsx", "ts", "js"];
+    assertEquals(
+      [...LAYOUT_EXTENSIONS],
+      expectedOrder,
+      "LAYOUT_EXTENSIONS should have the expected order",
+    );
+  });
+});
+
+describe("FileExistenceChecker interface", () => {
+  it("should allow async exists implementation", async () => {
+    const asyncChecker: FileExistenceChecker = {
+      exists: async (path: string) => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return path === "/project/components/layout.tsx";
+      },
+    };
+
+    const result = await discoverComponentsLayoutPath("/project", asyncChecker);
+
+    assertEquals(
+      result,
+      "/project/components/layout.tsx",
+      "Should work with async checker",
+    );
+  });
+
+  it("should allow tracking of checked paths", async () => {
+    const checkedPaths: string[] = [];
+    const trackingChecker: FileExistenceChecker = {
+      exists: async (path: string) => {
+        checkedPaths.push(path);
+        return false;
+      },
+    };
+
+    await discoverComponentsLayoutPath("/project", trackingChecker);
+
+    assertEquals(
+      checkedPaths.length,
+      LAYOUT_EXTENSIONS.length,
+      "Should check all extensions when none exist",
+    );
+
+    for (const ext of LAYOUT_EXTENSIONS) {
+      const expectedPath = `/project/components/layout.${ext}`;
+      assertEquals(
+        checkedPaths.includes(expectedPath),
+        true,
+        `Should have checked ${expectedPath}`,
+      );
+    }
+  });
+
+  it("should stop checking after finding first match", async () => {
+    const checkedPaths: string[] = [];
+    const trackingChecker: FileExistenceChecker = {
+      exists: async (path: string) => {
+        checkedPaths.push(path);
+        return path === "/project/components/layout.mdx";
+      },
+    };
+
+    const result = await discoverComponentsLayoutPath("/project", trackingChecker);
+
+    assertEquals(result, "/project/components/layout.mdx");
+    assertEquals(
+      checkedPaths.length,
+      1,
+      "Should stop after finding first match (mdx is first)",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- The local filesystem adapter was missing the `components/layout.*` fallback that the API adapter had
- This caused layouts to not be discovered when placed in the conventional `components/` directory
- Now both adapters have consistent behavior

## Changes

- Add `checkComponentsLayoutFallback()` to `collectFilesystemLayouts()`
- Extract `discoverComponentsLayoutPath()` pure function for testability
- Consolidate duplicate layout discovery logic between adapters
- Add unit tests for components layout discovery (17 test cases)

## Test plan

- [x] Tested with local filesystem adapter (tomcode project in projects/)
- [x] Tested with remote API adapter (tomcode.preview.lvh.me)
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)