### PR TITLE
fix: surface missing module errors in dev overlay

### DIFF
--- a/src/transforms/mdx/esm-module-loader/utils/stub-module.ts
+++ b/src/transforms/mdx/esm-module-loader/utils/stub-module.ts
@@ -3,6 +3,7 @@ import { rendererLogger as logger } from "#veryfront/utils";
 import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 import { getLocalFs } from "../cache/index.ts";
 import { hashString } from "./hash.ts";
+import { getErrorCollector } from "#veryfront/cli/mcp/error-collector.ts";
 
 export function extractNamedImports(
   code: string,
@@ -27,7 +28,12 @@ function generateNamedExports(names: string[], modulePath: string): string {
   return names
     .map(
       (name) =>
-        `export const ${name} = () => { console.warn('[Veryfront] Missing export "${name}" from "${modulePath}"'); return null; };`,
+        `export const ${name} = () => {
+  const error = new Error('[Veryfront] Missing export "${name}" from "${modulePath}". This module or file does not exist in your project.');
+  error.name = 'MissingModuleError';
+  console.error(error.message);
+  throw error;
+};`,
     )
     .join("\n");
 }
@@ -46,10 +52,17 @@ const handler = {
     if (prop === 'default' || prop === '__esModule' || typeof prop === 'symbol') {
       return new Proxy({}, handler);
     }
-    console.warn('[Veryfront] Missing module: ${modulePath}. Component "' + prop + '" was not found.');
-    return () => null;
+    const error = new Error('[Veryfront] Missing module: ${modulePath}. Export "' + prop + '" was not found. This module or file does not exist in your project.');
+    error.name = 'MissingModuleError';
+    console.error(error.message);
+    throw error;
   },
-  apply() { return null; }
+  apply() {
+    const error = new Error('[Veryfront] Missing module: ${modulePath}. This module or file does not exist in your project.');
+    error.name = 'MissingModuleError';
+    console.error(error.message);
+    throw error;
+  }
 };
 export default new Proxy(function(){}, handler);
 ${namedExports}
@@ -69,8 +82,25 @@ export async function createStubModule(
 
   try {
     await getLocalFs().writeTextFile(stubPath, stubCode);
-    logger.warn(
-      `${LOG_PREFIX_MDX_LOADER} Created stub for missing module: ${modulePath}`,
+
+    // Report the missing module error to the error collector
+    const errorMessage = namedImports.length > 0
+      ? `Missing module: ${modulePath} (imports: ${namedImports.join(", ")})`
+      : `Missing module: ${modulePath}`;
+
+    try {
+      getErrorCollector().addModuleError(
+        errorMessage,
+        modulePath,
+        { namedImports, importStatement },
+      );
+    } catch {
+      // Error collector may not be initialized in all contexts
+    }
+
+    logger.error(
+      `${LOG_PREFIX_MDX_LOADER} Missing module: ${modulePath}`,
+      { namedImports },
     );
     return stubPath;
   } catch (error) {


### PR DESCRIPTION
## Summary

- Stub exports now **throw `MissingModuleError`** instead of silently returning `null`
- Errors are reported to **ErrorCollector** for MCP visibility
- **Error overlay** now shows missing module errors clearly

## Problem

Previously, when a module import failed (file doesn't exist), the renderer created a "stub" that silently returned `null`. This made debugging **extremely difficult** as components would just disappear with no error.

Example: A layout imports `BreakpointsProvider` from a file that doesn't exist → the entire header silently disappears → hours of debugging.

## Before

```
[Veryfront] Missing export "BreakpointsProvider" from "../../providers/BreakpointsProvider.js"
// ^ Just a console.warn, component returns null, page renders broken
```

## After

```
Runtime Error
MissingModuleError

[Veryfront] Missing export "BreakpointsProvider" from "../../providers/BreakpointsProvider.js". 
This module or file does not exist in your project.
```

## Test plan

- [ ] Start dev server with a project that has a missing import
- [ ] Verify error overlay appears with `MissingModuleError`
- [ ] Verify `vf_get_errors` MCP tool shows the module error

🤖 Generated with [Claude Code](https://claude.com/claude-code)