### PR TITLE
fix: rename veryfront.baseUrl to apiBaseUrl to match env var

### DIFF
--- a/scripts/split-mode/veryfront.config.mjs
+++ b/scripts/split-mode/veryfront.config.mjs
@@ -17,7 +17,7 @@ export default {
   fs: {
     type: "veryfront-api",
     veryfront: {
-      baseUrl: getEnv("VERYFRONT_API_BASE_URL", "https://api.veryfront.com"),
+      apiBaseUrl: getEnv("VERYFRONT_API_BASE_URL", "https://api.veryfront.com"),
       proxyMode: true,
       cache: { enabled: true, ttl: 60000 },
       retry: { maxRetries: 3, initialDelay: 500, maxDelay: 5000 },

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -9,7 +9,7 @@ function createAdapter(
 ): VeryfrontFSAdapter {
   return new VeryfrontFSAdapter({
     veryfront: {
-      baseUrl: "https://api.example.com",
+      apiBaseUrl: "https://api.example.com",
       apiToken: "test-token",
       projectSlug: "test-project",
       cache: { enabled: false },
@@ -35,7 +35,7 @@ describe("VeryfrontFSAdapter", () => {
       assertExists(
         createAdapter({
           veryfront: {
-            baseUrl: "https://api.example.com",
+            apiBaseUrl: "https://api.example.com",
             apiToken: "test-token",
             projectSlug: "test-project",
             proxyMode: true,
@@ -53,7 +53,7 @@ describe("VeryfrontFSAdapter", () => {
       assertExists(
         createAdapter({
           veryfront: {
-            baseUrl: "https://api.example.com",
+            apiBaseUrl: "https://api.example.com",
             apiToken: "test-token",
             projectSlug: "test-project",
             contentSource: { type: "environment", name: "production" },
@@ -68,7 +68,7 @@ describe("VeryfrontFSAdapter", () => {
 
       const adapter = new VeryfrontFSAdapter({
         veryfront: {
-          baseUrl: "https://api.example.com",
+          apiBaseUrl: "https://api.example.com",
           apiToken: "test-token",
           projectSlug: "test-project",
           cache: { enabled: false },
@@ -323,7 +323,7 @@ describe("createVeryfrontConfig", () => {
   it("should use default cache settings", () => {
     const config = createVeryfrontConfig({
       veryfront: {
-        baseUrl: "https://api.example.com",
+        apiBaseUrl: "https://api.example.com",
         apiToken: "test-token",
         projectSlug: "test",
       },
@@ -337,7 +337,7 @@ describe("createVeryfrontConfig", () => {
   it("should override cache settings", () => {
     const config = createVeryfrontConfig({
       veryfront: {
-        baseUrl: "https://api.example.com",
+        apiBaseUrl: "https://api.example.com",
         apiToken: "test-token",
         projectSlug: "test",
         cache: { enabled: false, ttl: 5000 },
@@ -351,7 +351,7 @@ describe("createVeryfrontConfig", () => {
   it("should use default retry settings", () => {
     const config = createVeryfrontConfig({
       veryfront: {
-        baseUrl: "https://api.example.com",
+        apiBaseUrl: "https://api.example.com",
         apiToken: "test-token",
         projectSlug: "test",
       },
@@ -365,7 +365,7 @@ describe("createVeryfrontConfig", () => {
   it("should default to branch content source", () => {
     const config = createVeryfrontConfig({
       veryfront: {
-        baseUrl: "https://api.example.com",
+        apiBaseUrl: "https://api.example.com",
         apiToken: "test-token",
         projectSlug: "test",
       },
@@ -377,7 +377,7 @@ describe("createVeryfrontConfig", () => {
   it("should use provided content source", () => {
     const config = createVeryfrontConfig({
       veryfront: {
-        baseUrl: "https://api.example.com",
+        apiBaseUrl: "https://api.example.com",
         apiToken: "test-token",
         projectSlug: "test",
         contentSource: { type: "environment", name: "production" },
@@ -390,7 +390,7 @@ describe("createVeryfrontConfig", () => {
   it("should use apiKey as fallback for apiToken", () => {
     const config = createVeryfrontConfig({
       veryfront: {
-        baseUrl: "https://api.example.com",
+        apiBaseUrl: "https://api.example.com",
         apiKey: "key-123",
         projectSlug: "test",
       },
@@ -402,7 +402,7 @@ describe("createVeryfrontConfig", () => {
   it("should prefer apiToken over apiKey", () => {
     const config = createVeryfrontConfig({
       veryfront: {
-        baseUrl: "https://api.example.com",
+        apiBaseUrl: "https://api.example.com",
         apiToken: "token-123",
         apiKey: "key-123",
         projectSlug: "test",
@@ -423,7 +423,7 @@ describe("createVeryfrontConfig", () => {
   it("should pass through proxyMode", () => {
     const config = createVeryfrontConfig({
       veryfront: {
-        baseUrl: "https://api.example.com",
+        apiBaseUrl: "https://api.example.com",
         apiToken: "test-token",
         projectSlug: "test",
         proxyMode: true,
@@ -436,7 +436,7 @@ describe("createVeryfrontConfig", () => {
   it("should pass through projectId", () => {
     const config = createVeryfrontConfig({
       veryfront: {
-        baseUrl: "https://api.example.com",
+        apiBaseUrl: "https://api.example.com",
         apiToken: "test-token",
         projectSlug: "test",
         projectId: "proj-abc",

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
@@ -5,7 +5,7 @@ import { isMultiProjectAdapter, MultiProjectFSAdapter } from "./multi-project-ad
 function createAdapter(): MultiProjectFSAdapter {
   return new MultiProjectFSAdapter({
     veryfront: {
-      baseUrl: "https://api.example.com",
+      apiBaseUrl: "https://api.example.com",
       apiToken: "test-token",
       projectSlug: "test-project",
       cache: { enabled: false },

--- a/src/platform/adapters/fs/veryfront/proxy-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/proxy-manager.test.ts
@@ -4,7 +4,7 @@ import { ProxyFSAdapterManager } from "./proxy-manager.ts";
 
 const baseConfig = {
   veryfront: {
-    baseUrl: "https://api.example.com",
+    apiBaseUrl: "https://api.example.com",
     apiToken: "test-token",
     projectSlug: "test-project",
     cache: { enabled: false },

--- a/src/platform/adapters/fs/veryfront/types.ts
+++ b/src/platform/adapters/fs/veryfront/types.ts
@@ -76,7 +76,7 @@ export interface FSAdapterConfig {
     apiToken?: string;
     projectSlug?: string;
     projectId?: string;
-    baseUrl?: string;
+    apiBaseUrl?: string;
     proxyMode?: boolean;
     contentSource?: ContentSource;
     cache?: {
@@ -177,7 +177,7 @@ export function createVeryfrontConfig(config: FSAdapterConfig): VeryfrontConfig 
   }
 
   return {
-    apiBaseUrl: veryfront.baseUrl ?? "",
+    apiBaseUrl: veryfront.apiBaseUrl ?? "",
     apiToken: veryfront.apiToken ?? veryfront.apiKey ?? "",
     projectSlug: veryfront.projectSlug ?? "",
     projectId: veryfront.projectId,

--- a/src/platform/adapters/token/veryfront/types.ts
+++ b/src/platform/adapters/token/veryfront/types.ts
@@ -48,7 +48,7 @@ export interface TokenStorageAdapterConfig {
     /** Project slug */
     projectSlug?: string;
     /** API base URL (defaults to production) */
-    baseUrl?: string;
+    apiBaseUrl?: string;
     /** Retry configuration */
     retry?: {
       maxRetries?: number;
@@ -117,7 +117,7 @@ export function createTokenConfig(config: TokenStorageAdapterConfig): VeryfrontT
   const retry = veryfront.retry;
 
   return {
-    apiBaseUrl: veryfront.baseUrl ?? "https://api.veryfront.com",
+    apiBaseUrl: veryfront.apiBaseUrl ?? "https://api.veryfront.com",
     apiToken,
     projectSlug,
     retry: {


### PR DESCRIPTION
Without `apiBaseUrl`, API requests are made to relative paths like `/projects/<id>` instead of `https://api.veryfront.com/projects/<id>`, resulting in:

```
TypeError: Invalid URL: '/projects/6ba0cf13-d07b-494c-9d9d-71175e9be870'
    at getSerialization (ext:deno_web/00_url.js:98:11)
    at new URL (ext:deno_web/00_url.js:405:27)
    at requestWithRetry (src/platform/adapters/veryfront/...)
    at VeryfrontAPIOperations.request
    at VeryfrontAPIOperations.getProject
    at VeryfrontFSAdapter.initialize
```

Even though `.env` contained `VERYFRONT_API_BASE_URL=https://api.veryfront.com`.
The createVeryfrontConfig() returned empty baseUrl.
