### PR TITLE
fix: unify veryfront config

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -156,6 +156,14 @@ function mergeConfigs(userConfig: Partial<VeryfrontConfig>): VeryfrontConfig {
   const merged = {
     ...defaults,
     ...userConfig,
+    fs: {
+      ...defaults.fs,
+      ...userConfig.fs,
+      veryfront: {
+        ...defaults.fs?.veryfront,
+        ...userConfig.fs?.veryfront,
+      },
+    },
     dev: {
       ...defaults.dev,
       ...userConfig.dev,

--- a/src/platform/adapters/fs/index.ts
+++ b/src/platform/adapters/fs/index.ts
@@ -16,7 +16,6 @@ export type {
   DirectoryEntry,
   FSAdapter,
   FSAdapterConfig,
-  VeryfrontConfig,
   VeryfrontFSState,
 } from "./veryfront/types.ts";
 export {

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -308,4 +308,3 @@ describe("VeryfrontFSAdapter", () => {
     });
   });
 });
-

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -1,7 +1,6 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { VeryfrontFSAdapter } from "./adapter.ts";
-import { createVeryfrontConfig } from "./types.ts";
 import type { FSAdapterConfig, ResolvedContentContext } from "./types.ts";
 
 function createAdapter(
@@ -9,7 +8,7 @@ function createAdapter(
 ): VeryfrontFSAdapter {
   return new VeryfrontFSAdapter({
     veryfront: {
-      baseUrl: "https://api.example.com",
+      apiBaseUrl: "https://api.example.com",
       apiToken: "test-token",
       projectSlug: "test-project",
       cache: { enabled: false },
@@ -35,7 +34,7 @@ describe("VeryfrontFSAdapter", () => {
       assertExists(
         createAdapter({
           veryfront: {
-            baseUrl: "https://api.example.com",
+            apiBaseUrl: "https://api.example.com",
             apiToken: "test-token",
             projectSlug: "test-project",
             proxyMode: true,
@@ -53,7 +52,7 @@ describe("VeryfrontFSAdapter", () => {
       assertExists(
         createAdapter({
           veryfront: {
-            baseUrl: "https://api.example.com",
+            apiBaseUrl: "https://api.example.com",
             apiToken: "test-token",
             projectSlug: "test-project",
             contentSource: { type: "environment", name: "production" },
@@ -68,7 +67,7 @@ describe("VeryfrontFSAdapter", () => {
 
       const adapter = new VeryfrontFSAdapter({
         veryfront: {
-          baseUrl: "https://api.example.com",
+          apiBaseUrl: "https://api.example.com",
           apiToken: "test-token",
           projectSlug: "test-project",
           cache: { enabled: false },
@@ -310,139 +309,3 @@ describe("VeryfrontFSAdapter", () => {
   });
 });
 
-describe("createVeryfrontConfig", () => {
-  it("should throw when veryfront config is missing", () => {
-    try {
-      createVeryfrontConfig({});
-      assertEquals(true, false, "Should have thrown");
-    } catch (e) {
-      assertExists(e);
-    }
-  });
-
-  it("should use default cache settings", () => {
-    const config = createVeryfrontConfig({
-      veryfront: {
-        baseUrl: "https://api.example.com",
-        apiToken: "test-token",
-        projectSlug: "test",
-      },
-    });
-
-    assertEquals(config.cache.enabled, true);
-    assertEquals(config.cache.ttl, 60_000);
-    assertEquals(config.cache.maxSize, 1000);
-  });
-
-  it("should override cache settings", () => {
-    const config = createVeryfrontConfig({
-      veryfront: {
-        baseUrl: "https://api.example.com",
-        apiToken: "test-token",
-        projectSlug: "test",
-        cache: { enabled: false, ttl: 5000 },
-      },
-    });
-
-    assertEquals(config.cache.enabled, false);
-    assertEquals(config.cache.ttl, 5000);
-  });
-
-  it("should use default retry settings", () => {
-    const config = createVeryfrontConfig({
-      veryfront: {
-        baseUrl: "https://api.example.com",
-        apiToken: "test-token",
-        projectSlug: "test",
-      },
-    });
-
-    assertEquals(config.retry.maxRetries, 3);
-    assertEquals(config.retry.initialDelay, 1000);
-    assertEquals(config.retry.maxDelay, 10000);
-  });
-
-  it("should default to branch content source", () => {
-    const config = createVeryfrontConfig({
-      veryfront: {
-        baseUrl: "https://api.example.com",
-        apiToken: "test-token",
-        projectSlug: "test",
-      },
-    });
-
-    assertEquals(config.contentSource.type, "branch");
-  });
-
-  it("should use provided content source", () => {
-    const config = createVeryfrontConfig({
-      veryfront: {
-        baseUrl: "https://api.example.com",
-        apiToken: "test-token",
-        projectSlug: "test",
-        contentSource: { type: "environment", name: "production" },
-      },
-    });
-
-    assertEquals(config.contentSource.type, "environment");
-  });
-
-  it("should use apiKey as fallback for apiToken", () => {
-    const config = createVeryfrontConfig({
-      veryfront: {
-        baseUrl: "https://api.example.com",
-        apiKey: "key-123",
-        projectSlug: "test",
-      },
-    });
-
-    assertEquals(config.apiToken, "key-123");
-  });
-
-  it("should prefer apiToken over apiKey", () => {
-    const config = createVeryfrontConfig({
-      veryfront: {
-        baseUrl: "https://api.example.com",
-        apiToken: "token-123",
-        apiKey: "key-123",
-        projectSlug: "test",
-      },
-    });
-
-    assertEquals(config.apiToken, "token-123");
-  });
-
-  it("should default empty strings when optional fields missing", () => {
-    const config = createVeryfrontConfig({ veryfront: {} });
-
-    assertEquals(config.apiBaseUrl, "");
-    assertEquals(config.apiToken, "");
-    assertEquals(config.projectSlug, "");
-  });
-
-  it("should pass through proxyMode", () => {
-    const config = createVeryfrontConfig({
-      veryfront: {
-        baseUrl: "https://api.example.com",
-        apiToken: "test-token",
-        projectSlug: "test",
-        proxyMode: true,
-      },
-    });
-
-    assertEquals(config.proxyMode, true);
-  });
-
-  it("should pass through projectId", () => {
-    const config = createVeryfrontConfig({
-      veryfront: {
-        baseUrl: "https://api.example.com",
-        apiToken: "test-token",
-        projectSlug: "test",
-        projectId: "proj-abc",
-      },
-    });
-
-    assertEquals(config.projectId, "proj-abc");
-  });
-});

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -1,4 +1,5 @@
 import { logger } from "#veryfront/utils";
+import { createError, toError } from "#veryfront/errors";
 import type {
   CacheStats,
   ContentSource,
@@ -8,7 +9,6 @@ import type {
   InvalidationCallbacks,
   ResolvedContentContext,
 } from "./types.ts";
-import { createVeryfrontConfig } from "./types.ts";
 import type { FileInfo } from "../../base.ts";
 import { VeryfrontAPIClient } from "../../veryfront-api-client/index.ts";
 import type { Project } from "../../veryfront-api-client/index.ts";
@@ -65,24 +65,47 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
   constructor(config: FSAdapterConfig) {
     this.invalidationCallbacks = config.invalidationCallbacks ?? {};
-    const veryfrontConfig = createVeryfrontConfig(config);
+    const vf = config.veryfront;
+    if (!vf) {
+      throw toError(
+        createError({
+          type: "config",
+          message: "Veryfront adapter requires veryfront configuration",
+        }),
+      );
+    }
 
-    this.apiBaseUrl = veryfrontConfig.apiBaseUrl;
-    this.apiToken = veryfrontConfig.apiToken;
-    this.projectSlug = veryfrontConfig.projectSlug;
-    this.contentSource = veryfrontConfig.contentSource;
-    this.proxyMode = veryfrontConfig.proxyMode ?? false;
+    this.apiBaseUrl = vf.apiBaseUrl ?? "";
+    this.apiToken = vf.apiToken ?? "";
+    this.projectSlug = vf.projectSlug ?? "";
+    this.contentSource = vf.contentSource ?? { type: "branch", branch: "main" };
+    this.proxyMode = vf.proxyMode ?? false;
+
+    const retryConfig = {
+      maxRetries: 3,
+      initialDelay: 1000,
+      maxDelay: 10000,
+      ...vf.retry,
+    };
 
     this.client = new VeryfrontAPIClient({
-      apiBaseUrl: veryfrontConfig.apiBaseUrl,
-      apiToken: veryfrontConfig.apiToken,
-      projectSlug: veryfrontConfig.projectSlug,
-      projectId: veryfrontConfig.projectId,
-      proxyMode: veryfrontConfig.proxyMode,
-      retry: veryfrontConfig.retry,
+      apiBaseUrl: this.apiBaseUrl,
+      apiToken: this.apiToken,
+      projectSlug: this.projectSlug,
+      projectId: vf.projectId,
+      proxyMode: vf.proxyMode,
+      retry: retryConfig,
     });
 
-    this.cache = new FileCache(veryfrontConfig.cache as FileCacheOptions);
+    const cacheConfig: FileCacheOptions = {
+      enabled: true,
+      ttl: 60_000,
+      maxSize: 1000,
+      maxMemory: 100 * 1024 * 1024,
+      ...vf.cache,
+    };
+
+    this.cache = new FileCache(cacheConfig);
     this.normalizer = new PathNormalizer(config.projectDir);
 
     const contentContextGetter = {
@@ -188,11 +211,11 @@ export class VeryfrontFSAdapter implements FSAdapter {
     });
 
     logger.debug("[VeryfrontFSAdapter] Created", {
-      apiBaseUrl: veryfrontConfig.apiBaseUrl,
-      projectSlug: veryfrontConfig.projectSlug,
+      apiBaseUrl: this.apiBaseUrl,
+      projectSlug: this.projectSlug,
       projectDir: config.projectDir,
       contentSource: this.contentSource,
-      cacheEnabled: veryfrontConfig.cache.enabled,
+      cacheEnabled: cacheConfig.enabled,
     });
   }
 

--- a/src/platform/adapters/fs/veryfront/index.ts
+++ b/src/platform/adapters/fs/veryfront/index.ts
@@ -1,2 +1,2 @@
 export { VeryfrontFSAdapter } from "./adapter.ts";
-export type { CacheStats, VeryfrontConfig, VeryfrontFSState } from "./types.ts";
+export type { CacheStats, VeryfrontFSState } from "./types.ts";

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
@@ -5,7 +5,7 @@ import { isMultiProjectAdapter, MultiProjectFSAdapter } from "./multi-project-ad
 function createAdapter(): MultiProjectFSAdapter {
   return new MultiProjectFSAdapter({
     veryfront: {
-      baseUrl: "https://api.example.com",
+      apiBaseUrl: "https://api.example.com",
       apiToken: "test-token",
       projectSlug: "test-project",
       cache: { enabled: false },

--- a/src/platform/adapters/fs/veryfront/proxy-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/proxy-manager.test.ts
@@ -4,7 +4,7 @@ import { ProxyFSAdapterManager } from "./proxy-manager.ts";
 
 const baseConfig = {
   veryfront: {
-    baseUrl: "https://api.example.com",
+    apiBaseUrl: "https://api.example.com",
     apiToken: "test-token",
     projectSlug: "test-project",
     cache: { enabled: false },

--- a/src/platform/adapters/fs/veryfront/types.ts
+++ b/src/platform/adapters/fs/veryfront/types.ts
@@ -1,5 +1,4 @@
 import type { Project } from "../../veryfront-api-client/index.ts";
-import { createError, toError } from "#veryfront/errors";
 import type { GitHubConfig } from "../github/types.ts";
 import type { DirectoryEntry } from "../shared-types.ts";
 
@@ -72,11 +71,10 @@ export interface FSAdapterConfig {
   type?: "local" | "veryfront-api" | "memory" | "github";
   projectDir?: string;
   veryfront?: {
-    apiKey?: string;
     apiToken?: string;
     projectSlug?: string;
     projectId?: string;
-    baseUrl?: string;
+    apiBaseUrl?: string;
     proxyMode?: boolean;
     contentSource?: ContentSource;
     cache?: {
@@ -90,26 +88,6 @@ export interface FSAdapterConfig {
   };
   github?: GitHubConfig;
   invalidationCallbacks?: InvalidationCallbacks;
-}
-
-export interface VeryfrontConfig {
-  apiBaseUrl: string;
-  apiToken: string;
-  projectSlug: string;
-  projectId?: string;
-  proxyMode?: boolean;
-  contentSource: ContentSource;
-  cache: {
-    enabled: boolean;
-    ttl: number;
-    maxSize: number;
-    maxMemory: number;
-  };
-  retry: {
-    maxRetries: number;
-    initialDelay: number;
-    maxDelay: number;
-  };
 }
 
 export interface VeryfrontFSState {
@@ -161,40 +139,3 @@ export interface InvalidationCallbacks {
   clearDomainCache?: () => void;
 }
 
-function resolveContentSource(veryfront: NonNullable<FSAdapterConfig["veryfront"]>): ContentSource {
-  return veryfront.contentSource ?? { type: "branch", branch: "main" };
-}
-
-export function createVeryfrontConfig(config: FSAdapterConfig): VeryfrontConfig {
-  const veryfront = config.veryfront;
-  if (!veryfront) {
-    throw toError(
-      createError({
-        type: "config",
-        message: "Veryfront adapter requires veryfront configuration",
-      }),
-    );
-  }
-
-  return {
-    apiBaseUrl: veryfront.baseUrl ?? "",
-    apiToken: veryfront.apiToken ?? veryfront.apiKey ?? "",
-    projectSlug: veryfront.projectSlug ?? "",
-    projectId: veryfront.projectId,
-    proxyMode: veryfront.proxyMode,
-    contentSource: resolveContentSource(veryfront),
-    cache: {
-      enabled: true,
-      ttl: 60_000,
-      maxSize: 1000,
-      maxMemory: 100 * 1024 * 1024,
-      ...veryfront.cache,
-    },
-    retry: {
-      maxRetries: 3,
-      initialDelay: 1000,
-      maxDelay: 10000,
-      ...veryfront.retry,
-    },
-  };
-}

--- a/src/platform/adapters/fs/veryfront/types.ts
+++ b/src/platform/adapters/fs/veryfront/types.ts
@@ -138,4 +138,3 @@ export interface InvalidationCallbacks {
   /** Clear domain lookup cache to refresh release IDs after publishing */
   clearDomainCache?: () => void;
 }
-

--- a/src/platform/adapters/token/integration.ts
+++ b/src/platform/adapters/token/integration.ts
@@ -35,7 +35,7 @@ export function resetTokenStorageAdapter(): void {
 function buildAdapterConfigFromEnv(): TokenStorageAdapterConfig {
   const apiToken = getEnvVar("VERYFRONT_API_TOKEN");
   const projectSlug = getEnvVar("VERYFRONT_PROJECT_SLUG");
-  const baseUrl = getEnvVar("VERYFRONT_API_URL");
+  const apiBaseUrl = getEnvVar("VERYFRONT_API_URL");
 
   if (!apiToken || !projectSlug) {
     logger.debug("[TokenAdapterIntegration] Using in-memory storage (development)");
@@ -46,7 +46,7 @@ function buildAdapterConfigFromEnv(): TokenStorageAdapterConfig {
 
   return {
     type: "veryfront-api",
-    veryfront: { apiToken, projectSlug, baseUrl },
+    veryfront: { apiToken, projectSlug, apiBaseUrl },
   };
 }
 

--- a/src/platform/adapters/token/veryfront/types.ts
+++ b/src/platform/adapters/token/veryfront/types.ts
@@ -48,7 +48,7 @@ export interface TokenStorageAdapterConfig {
     /** Project slug */
     projectSlug?: string;
     /** API base URL (defaults to production) */
-    baseUrl?: string;
+    apiBaseUrl?: string;
     /** Retry configuration */
     retry?: {
       maxRetries?: number;
@@ -117,7 +117,7 @@ export function createTokenConfig(config: TokenStorageAdapterConfig): VeryfrontT
   const retry = veryfront.retry;
 
   return {
-    apiBaseUrl: veryfront.baseUrl ?? "https://api.veryfront.com",
+    apiBaseUrl: veryfront.apiBaseUrl ?? "https://api.veryfront.com",
     apiToken,
     projectSlug,
     retry: {

--- a/src/server/universal-handler/index.ts
+++ b/src/server/universal-handler/index.ts
@@ -469,10 +469,7 @@ export function createVeryfrontHandler(
             !shouldSkipDomainLookup
           ) {
             const effectiveToken = proxyToken || config.fs.veryfront.apiToken || "";
-            const baseUrl =
-              (config.fs.veryfront as { baseUrl?: string; apiBaseUrl?: string }).baseUrl ||
-              config.fs.veryfront.apiBaseUrl ||
-              "https://api.veryfront.com";
+            const baseUrl = config.fs.veryfront.apiBaseUrl || "https://api.veryfront.com";
 
             const lookupHost = forwardedHost || host;
 
@@ -533,10 +530,7 @@ export function createVeryfrontHandler(
             !shouldSkipDomainLookup
           ) {
             const effectiveToken = proxyToken || config.fs.veryfront.apiToken || "";
-            const baseUrl =
-              (config.fs.veryfront as { baseUrl?: string; apiBaseUrl?: string }).baseUrl ||
-              config.fs.veryfront.apiBaseUrl ||
-              "https://api.veryfront.com";
+            const baseUrl = config.fs.veryfront.apiBaseUrl || "https://api.veryfront.com";
 
             if (effectiveToken) {
               const lookupResult = await withSpan(


### PR DESCRIPTION
## Problem

`FSAdapterConfig.veryfront.baseUrl` vs `VeryfrontConfig.fs.veryfront.apiBaseUrl` — name mismatch caused `""` values in proxy mode.

## What changed

### 1. Single source of truth
Deleted redundant `VeryfrontConfig` interface and `createVeryfrontConfig` factory. Adapter reads config directly.

### 2. Request-scoped config
`mergeConfigs` now deep-merges `fs.veryfront` so proxy-mode defaults survive user config overrides.

### 3. Config layering: env → platform → user
- **env**: `VERYFRONT_API_BASE_URL` → `fs.veryfront.apiBaseUrl`
- **platform**: adapter applies cache/retry defaults
- **user**: `veryfront.config.ts` overrides fields without wiping the layer below