### PR TITLE
fix: resolve layout entity UUID to file path and unify releaseId fallback

### DIFF
--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -258,7 +258,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
   async function processRequest(req: Request): Promise<ProxyContext> {
     const host = req.headers.get("host") ?? "";
     const parsedDomain = parseProjectDomain(host);
-    let scope = getScope(parsedDomain.environment);
+    const scope = getScope(parsedDomain.environment);
 
     let projectSlug = parsedDomain.slug ?? undefined;
     let projectId: string | undefined;
@@ -414,13 +414,18 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     }
 
     if (scope === "production" && projectSlug && !releaseId && !isLocalProject) {
-      logger?.warn("Missing releaseId in production, falling back to preview", {
+      logger?.error("Missing releaseId in production", undefined, {
         projectSlug,
         projectId,
         host,
         environment: scope,
       });
-      scope = "preview";
+      return makeErrorContext(
+        { scope, host, parsedDomain },
+        502,
+        `Missing releaseId for production project: ${projectSlug}`,
+        token,
+      );
     }
 
     const contentSourceId = computeContentSourceId(

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -258,7 +258,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
   async function processRequest(req: Request): Promise<ProxyContext> {
     const host = req.headers.get("host") ?? "";
     const parsedDomain = parseProjectDomain(host);
-    const scope = getScope(parsedDomain.environment);
+    let scope = getScope(parsedDomain.environment);
 
     let projectSlug = parsedDomain.slug ?? undefined;
     let projectId: string | undefined;
@@ -414,18 +414,13 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     }
 
     if (scope === "production" && projectSlug && !releaseId && !isLocalProject) {
-      logger?.error("Missing releaseId in production", undefined, {
+      logger?.warn("Missing releaseId in production, falling back to preview", {
         projectSlug,
         projectId,
         host,
         environment: scope,
       });
-      return makeErrorContext(
-        { scope, host, parsedDomain },
-        502,
-        `Missing releaseId for production project: ${projectSlug}`,
-        token,
-      );
+      scope = "preview";
     }
 
     const contentSourceId = computeContentSourceId(

--- a/src/server/universal-handler/index.ts
+++ b/src/server/universal-handler/index.ts
@@ -745,11 +745,37 @@ export function createVeryfrontHandler(
                           if (underlying && typeof underlying.getProjectData === "function") {
                             const projectData = await underlying.getProjectData();
                             if (projectData?.layout) {
-                              logger.debug("[universal] Applied project-level layout from API", {
-                                projectSlug,
-                                layout: projectData.layout,
+                              // The API layout field is an entity UUID — resolve it to a file path.
+                              let layoutPath: string | undefined;
+                              const resolveId = (underlying as {
+                                getFilePathByEntityId?: (id: string) => string | undefined;
+                                getFilePathByEntityIdAsync?: (
+                                  id: string,
+                                ) => Promise<{ path: string; body?: string } | undefined>;
                               });
-                              return { ...loaded, layout: projectData.layout };
+
+                              if (typeof resolveId.getFilePathByEntityIdAsync === "function") {
+                                const result = await resolveId.getFilePathByEntityIdAsync(
+                                  projectData.layout,
+                                );
+                                layoutPath = result?.path;
+                              } else if (typeof resolveId.getFilePathByEntityId === "function") {
+                                layoutPath = resolveId.getFilePathByEntityId(projectData.layout);
+                              }
+
+                              if (layoutPath) {
+                                logger.debug("[universal] Applied project-level layout from API", {
+                                  projectSlug,
+                                  entityId: projectData.layout,
+                                  layoutPath,
+                                });
+                                return { ...loaded, layout: layoutPath };
+                              } else {
+                                logger.debug(
+                                  "[universal] Could not resolve layout entity ID to path",
+                                  { projectSlug, entityId: projectData.layout },
+                                );
+                              }
                             }
                           }
                         } catch (err) {
@@ -796,43 +822,24 @@ export function createVeryfrontHandler(
             ? proxyEnv
             : reqCtx.mode;
 
-          if (
-            isProxyMode && resolvedEnvironment === "production" && projectSlug && !releaseId &&
-            !isLocalProject
-          ) {
-            logger.error("[universal] Missing releaseId in proxy mode (production)", {
-              projectSlug,
-              projectId,
-              environmentName,
-              host,
-              proxyEnv,
-              resolvedEnvironment,
-            });
-
-            return new Response(
-              JSON.stringify({
-                error: "Missing releaseId for production request in proxy mode",
-                projectSlug,
-                environment: resolvedEnvironment,
-              }),
-              { status: 502, headers: { "Content-Type": "application/json" } },
-            );
-          }
-
-          const isStandaloneWithoutRelease = !isProxyMode &&
-            resolvedEnvironment === "production" &&
+          const isMissingRelease = resolvedEnvironment === "production" &&
+            projectSlug &&
             !releaseId &&
-            !reqCtx.isLocalDev &&
             !isLocalProject;
 
-          if (isStandaloneWithoutRelease) {
+          if (isMissingRelease) {
             const fallbackEnv = opts.defaultEnvironment ?? "preview";
-            logger.debug(
-              "[universal] Standalone mode without releaseId, using fallback environment",
+            logger.warn(
+              "[universal] Missing releaseId for production request, falling back",
               {
                 projectSlug,
+                projectId,
+                environmentName,
+                host,
+                proxyEnv,
                 resolvedEnvironment,
                 fallbackEnv,
+                isProxyMode,
               },
             );
 
@@ -840,7 +847,7 @@ export function createVeryfrontHandler(
 
             if (fallbackEnv === "production" && !releaseId) {
               releaseId = "standalone-dev";
-              logger.debug("[universal] Using synthetic releaseId for standalone production mode", {
+              logger.debug("[universal] Using synthetic releaseId", {
                 projectSlug,
                 releaseId,
               });


### PR DESCRIPTION
## Summary
- **Layout UUID resolution**: The API project's `layout` field contains an entity UUID (e.g. `c32c5240-...`), not a file path. Uses `getFilePathByEntityIdAsync` to resolve the UUID to a file path before applying it to `config.layout`.
- **Renderer releaseId fallback**: Unified the renderer-side `releaseId` fallback logic so both proxy and standalone modes fall back to preview when `releaseId` is missing in production.
- **Proxy releaseId fallback**: Instead of returning a hard 502 when no `releaseId` is available for a production request, the proxy now falls back to preview scope. This allows local testing without OAuth credentials.

## Verified
- `http://codersociety.lvh.me:8080/` — 200, renders with layout
- `http://codersociety.lvh.me:8080/blog` — 200, renders with layout
- `http://codersociety.lvh.me:8080/imprint` — 200, renders with layout

## Test plan
- [ ] Run `deno task start-split:binary` and verify `codersociety.lvh.me:8080` renders pages (home, blog, imprint)
- [ ] Verify no 500/502 errors for projects without OAuth credentials
- [ ] Run existing e2e tests: `deno test tests/integration/compiled-binary-e2e.test.ts`