### PR TITLE
fix: remove projectData.layout API fallback

### DIFF
--- a/src/server/universal-handler/index.ts
+++ b/src/server/universal-handler/index.ts
@@ -722,45 +722,9 @@ export function createVeryfrontHandler(
                     projectSlug,
                     proxyToken,
                     async () => {
-                      const loaded = await getConfig(effectiveProjectDir, effectiveAdapter, {
+                      return await getConfig(effectiveProjectDir, effectiveAdapter, {
                         cacheKey: projectId || projectSlug,
                       });
-
-                      // Apply project-level layout from API if config doesn't specify one.
-                      // The API project data may have a layout field (set via dashboard) that
-                      // should be used when veryfront.config.ts doesn't define a layout.
-                      // This must run inside runWithContext so the adapter has project context.
-                      if (loaded.layout === undefined) {
-                        try {
-                          const adapterFs = effectiveAdapter.fs;
-                          const underlying = isExtendedFSAdapter(adapterFs)
-                            ? adapterFs.getUnderlyingAdapter() as {
-                              getProjectData?: () =>
-                                | { layout?: string | null }
-                                | Promise<{ layout?: string | null }>
-                                | undefined;
-                            }
-                            : undefined;
-
-                          if (underlying && typeof underlying.getProjectData === "function") {
-                            const projectData = await underlying.getProjectData();
-                            if (projectData?.layout) {
-                              logger.debug("[universal] Applied project-level layout from API", {
-                                projectSlug,
-                                layout: projectData.layout,
-                              });
-                              return { ...loaded, layout: projectData.layout };
-                            }
-                          }
-                        } catch (err) {
-                          logger.debug("[universal] Failed to get project layout from adapter", {
-                            projectSlug,
-                            error: getErrorMessage(err),
-                          });
-                        }
-                      }
-
-                      return loaded;
                     },
                     projectId,
                     {


### PR DESCRIPTION
## Problem

`0a313ff` added a fallback: when `veryfront.config.ts` doesn't define `layout`, inject `projectData.layout` from the API. But the API returns an **entity UUID** (e.g. `c32c5240-...`), not a file path. The layout collector then tries to find `layouts/c32c5240-....mdx` — which doesn't exist — and throws `Layout "..." not found`.

## Fix

Remove the `projectData.layout` fallback entirely. When no `layout` is defined in `veryfront.config.ts`, the framework discovers layouts by convention:

1. **Frontmatter** — page defines `layout: MyLayout` in frontmatter
2. **Nested layouts** — `layout.mdx`/`layout.tsx` files in parent directories (app router convention)
3. **Convention paths** — `layouts/{name}.mdx`, `components/{name}Layout.tsx`, `components/Layout.mdx`

The API's `projectData.layout` field is an entity UUID meant for the dashboard, not for the renderer.

## Tested locally (`start-split:binary`)

- `codersociety.lvh.me:8080` — 200 OK
- `codersociety.preview.lvh.me:8080` — 200 OK