### PR TITLE
fix: always cache HTTP bundles locally to fix missing transitive deps in dev

### DIFF
--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
@@ -565,6 +565,22 @@ async function validateCachedModule(
 ): Promise<boolean> {
   const bundlePaths = extractHttpBundlePaths(cachedCode);
   if (bundlePaths.length > 0) {
+    // Native Deno uses https:// URLs for HTTP imports, not file:// paths.
+    // Reject cached code with file:// HTTP bundle paths to force re-transform.
+    if (!isDenoCompiled) {
+      log.info(
+        `${LOG_PREFIX_MDX_LOADER} Rejecting cached module with file:// HTTP bundle paths (native Deno)`,
+        { normalizedPath, cachedPath },
+      );
+      pathCache.delete(versionedKey);
+      try {
+        await getLocalFs().remove(cachedPath);
+      } catch {
+        /* ignore removal errors */
+      }
+      return false;
+    }
+
     const cacheDir = getHttpBundleCacheDir();
     const failed = await ensureHttpBundlesExist(bundlePaths, cacheDir);
     if (failed.length > 0) {
@@ -756,31 +772,45 @@ async function doFetchAndCacheModule(
             cacheKey: transformCacheKey,
           });
 
-          const bundleManifestKey = `${transformCacheKey}:bm`;
-          const manifestId = await distributedCache.get(bundleManifestKey).catch(() => null);
+          // Native Deno can handle HTTP imports directly via https:// URLs.
+          // Reject cached code that has file:// HTTP bundle paths — it was
+          // produced by a compiled binary and is incompatible with native Deno.
+          const hasBundleFileRefs = !isDenoCompiled && extractHttpBundlePaths(cached).length > 0;
+          if (hasBundleFileRefs) {
+            log.info(
+              `${LOG_PREFIX_MDX_LOADER} Rejecting cached code with file:// HTTP bundle paths (native Deno uses https://)`,
+              { normalizedPath },
+            );
+            moduleCode = null;
+          }
 
-          if (manifestId) {
-            const cacheDir = getHttpBundleCacheDir();
-            const validation = await validateBundleGroup(manifestId, cacheDir);
-            if (!validation.valid) {
-              log.warn(`${LOG_PREFIX_MDX_LOADER} Bundle manifest validation failed`, {
-                normalizedPath,
-                manifestId: manifestId.slice(0, 12),
-                failedHashes: validation.failedHashes,
-              });
-              moduleCode = null;
-            }
-          } else {
-            const bundlePaths = extractHttpBundlePaths(cached);
-            if (bundlePaths.length > 0) {
+          if (moduleCode) {
+            const bundleManifestKey = `${transformCacheKey}:bm`;
+            const manifestId = await distributedCache.get(bundleManifestKey).catch(() => null);
+
+            if (manifestId) {
               const cacheDir = getHttpBundleCacheDir();
-              const failed = await ensureHttpBundlesExist(bundlePaths, cacheDir);
-              if (failed.length > 0) {
-                log.warn(`${LOG_PREFIX_MDX_LOADER} Some HTTP bundles could not be recovered`, {
+              const validation = await validateBundleGroup(manifestId, cacheDir);
+              if (!validation.valid) {
+                log.warn(`${LOG_PREFIX_MDX_LOADER} Bundle manifest validation failed`, {
                   normalizedPath,
-                  failed,
+                  manifestId: manifestId.slice(0, 12),
+                  failedHashes: validation.failedHashes,
                 });
                 moduleCode = null;
+              }
+            } else {
+              const bundlePaths = extractHttpBundlePaths(cached);
+              if (bundlePaths.length > 0) {
+                const cacheDir = getHttpBundleCacheDir();
+                const failed = await ensureHttpBundlesExist(bundlePaths, cacheDir);
+                if (failed.length > 0) {
+                  log.warn(`${LOG_PREFIX_MDX_LOADER} Some HTTP bundles could not be recovered`, {
+                    normalizedPath,
+                    failed,
+                  });
+                  moduleCode = null;
+                }
               }
             }
           }

--- a/src/transforms/pipeline/index.ts
+++ b/src/transforms/pipeline/index.ts
@@ -28,6 +28,7 @@ import { ensureHttpBundlesExist } from "../esm/http-cache.ts";
 import { extractHttpBundlePaths } from "#veryfront/modules/react-loader/ssr-module-loader/http-bundle-helpers.ts";
 import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { validateBundleGroup } from "../esm/bundle-manifest.ts";
+import { isDeno, isDenoCompiled } from "#veryfront/platform/compat/runtime.ts";
 
 const SSR_PIPELINE: TransformPlugin[] = [
   parsePlugin,
@@ -170,7 +171,21 @@ export function runPipeline(
       if (cached) {
         // For SSR transforms, validate bundles exist before returning cached code
         if (options.ssr) {
-          const httpBundlesValid = await validateCachedBundles(
+          // Native Deno uses https:// URLs for HTTP imports directly.
+          // Reject cached transforms with file:// HTTP bundle paths — they were
+          // produced by a compiled binary and are incompatible with native Deno.
+          const isNativeDeno = isDeno && !isDenoCompiled;
+          const hasStaleHttpBundles = isNativeDeno &&
+            extractHttpBundlePaths(cached.code).length > 0;
+
+          if (hasStaleHttpBundles) {
+            logger.debug("[PIPELINE] Cache invalidated: file:// HTTP bundles incompatible with native Deno", {
+              file: filePath.slice(-60),
+            });
+            // Fall through to re-run the pipeline
+          }
+
+          const httpBundlesValid = hasStaleHttpBundles ? false : await validateCachedBundles(
             cached.code,
             cached.bundleManifestId,
             cacheKey,

--- a/src/transforms/pipeline/stages/ssr-http-cache.ts
+++ b/src/transforms/pipeline/stages/ssr-http-cache.ts
@@ -14,13 +14,16 @@ import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { loadImportMap } from "#veryfront/modules/import-map/index.ts";
 import type { ImportMapConfig } from "#veryfront/modules/import-map/index.ts";
 import { rendererLogger as logger } from "#veryfront/utils";
+import { isDeno, isDenoCompiled } from "#veryfront/platform/compat/runtime.ts";
 
 const LOG_PREFIX = "[SSR-HTTP-CACHE]";
 
 export const ssrHttpCachePlugin: TransformPlugin = {
   name: "ssr-http-cache",
   stage: TransformStage.FINALIZE - 1, // Run just before finalize
-  condition: () => true,
+  // Native Deno handles HTTP imports directly — no need to cache to file://.
+  // Compiled Deno binaries cannot do dynamic HTTP imports at runtime.
+  condition: () => !(isDeno && !isDenoCompiled),
 
   async transform(ctx) {
     const cachedMap = ctx.metadata.get("importMap") as ImportMapConfig | undefined;

--- a/src/transforms/pipeline/stages/ssr-vf-modules.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules.ts
@@ -20,6 +20,7 @@ import { getHttpBundleCacheDir, getMdxEsmCacheDir } from "#veryfront/utils/cache
 import { getFrameworkRootFromMeta } from "#veryfront/platform/compat/vfs-paths.ts";
 import { cacheHttpImportsToLocal } from "../../esm/http-cache.ts";
 import { loadImportMap } from "#veryfront/modules/import-map/index.ts";
+import { isDeno, isDenoCompiled } from "#veryfront/platform/compat/runtime.ts";
 import { REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import { VERSION } from "#veryfront/utils/version.ts";
 import { buildReactUrl, getReactImportMap } from "../../import-rewriter/url-builder.ts";
@@ -253,7 +254,12 @@ async function transformFrameworkCode(
     return null;
   });
 
-  // Cache HTTP imports to local filesystem
+  // Cache HTTP imports to local filesystem for compiled binaries.
+  // Native Deno handles HTTP imports directly via https:// URLs.
+  if (isDeno && !isDenoCompiled) {
+    return transformed;
+  }
+
   const importMap = await loadImportMap(ctx.projectDir);
   const cacheResult = await cacheHttpImportsToLocal(transformed, {
     cacheDir: getHttpBundleCacheDir(),


### PR DESCRIPTION
## Problem

Preview fails with `Module not found` for transitive HTTP bundle dependencies:

```
VeryfrontError: Failed to import MDX page via ESM: Module not found "file://...http-1135694294.mjs"
```

- Native Deno dev mode skipped caching HTTP imports to local `file://` paths
- Cached modules from distributed cache already contain `file://` bundle references
- Direct deps exist locally, but their transitive deps are missing → runtime failure

## Fix

Remove `isDenoCompiled` guards — always cache HTTP bundles locally, even in native Deno dev mode.