### PR TITLE
fix: improve WebSocket error logging with useful context

### DIFF
--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -110,8 +110,17 @@ export class WebSocketManager {
         this.wsReconnectTimer = setTimeout(() => this.connect(projectId), WS_RECONNECT_DELAY_MS);
       };
 
-      this.ws.onerror = (error) => {
-        logger.warn("[WebSocketManager] WebSocket error", { error });
+      this.ws.onerror = (event) => {
+        // WebSocket error events don't serialize well to JSON (results in empty {})
+        // Extract useful information from the event for logging
+        const errorInfo = {
+          type: event.type,
+          message: event instanceof ErrorEvent ? event.message : "WebSocket connection error",
+          url: this.ws?.url,
+          readyState: this.ws?.readyState,
+          connectionId: this.wsConnectionId,
+        };
+        logger.warn("[WebSocketManager] WebSocket error", errorInfo);
       };
     } catch (error) {
       logger.warn("[WebSocketManager] Failed to connect WebSocket", { error });


### PR DESCRIPTION
## Summary
- Fixes WebSocket error events logging as empty `{}` objects
- Extracts useful diagnostic information from error events

## Changes
- Modified `websocket-manager.ts` to extract meaningful error details
- Now logs: event type, error message, WebSocket URL, readyState, and connectionId

## Test plan
- [ ] Verify WebSocket error logs now include diagnostic information
- [ ] Confirm no sensitive data is exposed in logs
- [ ] Test reconnection behavior is unchanged

## Related
Fixes #227