### PR TITLE
fix: reduce log level for 404 responses from error to debug

### DIFF
--- a/src/platform/adapters/veryfront-api-client/retry-handler.ts
+++ b/src/platform/adapters/veryfront-api-client/retry-handler.ts
@@ -64,7 +64,10 @@ export async function requestWithRetry(
           if (!response.ok) {
             const text = await response.text();
 
-            logger.error("[VeryfrontAPIClient] Request failed", {
+            // Use debug level for 404s (expected for optional files like deno.json, globals.css)
+            // Use error level for other failures (5xx, 4xx except 404)
+            const logLevel = response.status === 404 ? "debug" : "error";
+            logger[logLevel]("[VeryfrontAPIClient] Request failed", {
               url: url.replace(/token=[^&]+/, "token=***"),
               status: response.status,
               statusText: response.statusText,


### PR DESCRIPTION
## Summary
- Reduces log level for 404 responses from `error` to `debug` in the API client retry handler
- 404 responses are expected for optional files like `deno.json` and `globals.css`

## Problem
The current implementation logs ALL non-OK responses at error level, including 404s for optional files. This causes excessive error logging in production:

```json
{
  "level": "error",
  "message": "[VeryfrontAPIClient] Request failed",
  "context": {
    "url": ".../files/deno.json",
    "status": 404
  }
}
```

~62 such errors were observed in just 30 minutes in production, making it harder to identify real issues.

## Solution
Use dynamic log level based on status code:
- **404**: `debug` level (expected for optional files)
- **Other 4xx/5xx**: `error` level (indicates real problems)

## Test plan
- [ ] Verify 404 responses are logged at debug level
- [ ] Verify other error responses (500, 403, etc.) are still logged at error level
- [ ] Deploy and confirm reduced error log volume in production

## Related Issues
- veryfront/veryfront-api#218