### PR TITLE
refactor: migrate doctor, routes, analyze-chunks, mcp, and demo handlers to Zod-based createArgParser

### DIFF
--- a/SHARED_TASK_NOTES.md
+++ b/SHARED_TASK_NOTES.md
@@ -1,0 +1,39 @@
+# CLI Refactoring: Zod createArgParser Migration
+
+## Goal
+Migrate all CLI command handlers from manual argument parsing to Zod-based `createArgParser` pattern.
+
+## Pattern Reference
+See `src/cli/commands/deploy/handler.ts` + `command.ts` for the canonical pattern:
+- Schema + parser defined in handler.ts (or command.ts for complex commands)
+- Use `CommonArgs` from `shared/args.ts` for reusable arg specs
+- Handler validates with `parseFooArgs(args)`, throws on failure, calls command with `result.data`
+
+## Migration Status
+
+### Migrated (10 handlers)
+- lock, clean, init, studio, generate (earlier iterations)
+- doctor, routes, analyze-chunks, mcp, demo (this iteration)
+
+### Still Need Migration (7 handlers)
+Priority order (simpler first):
+1. **install** - Manual `args.target`, `args.global`, `args.force` access. Also has 100+ lines of duplicated multiSelect UI code between install.ts and uninstall.ts
+2. **start** - Uses `args.__explicit?.port` for explicit flag detection, complex port handling
+3. **serve** - Manual parsing with multiple key variations (`args.mode`, `args.m`, `args.host`, `args.hostname`)
+4. **build** - Uses `parseArrayArg` from legacy `shared/arg-parser.ts` for include/exclude arrays. Has `exitProcess(0)` call
+5. **dev** - Complex project resolution logic, manual `args.project`, `args.port`, `args.hmr`
+6. **pull** - Has Zod schema but uses custom safeParse, not createArgParser
+7. **push** - Same as pull, has Zod schema but uses custom safeParse
+
+### Not Migrating
+- **new** - Has `exitProcess(0)` for user cancellation in interactive TUI, acceptable
+- **mcp** note: The CLI framework injects `DEFAULT_PORT=3000` as default for `--port`. MCP server needs its own default (8080). Handler has a filter for this.
+
+## Known Issues
+- `shared/arg-parser.ts` (legacy) coexists with `shared/args.ts` (new). Once all handlers migrate, the legacy module can be removed (except `parseArrayArg` used by build)
+- `CommonArgs.projectDir` uses `--project-dir`, `--dir`, `-d` — some old commands used `--project`. Migration standardizes this.
+
+## After All Handlers Are Migrated
+- Remove/reduce `shared/arg-parser.ts` (keep `parseArrayArg` if needed)
+- Consider extracting `parseArrayArg` into `shared/args.ts` as array support
+- Deduplicate install/uninstall multiSelect UI code

--- a/src/cli/commands/analyze-chunks/handler.test.ts
+++ b/src/cli/commands/analyze-chunks/handler.test.ts
@@ -1,16 +1,6 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { handleAnalyzeChunksCommand } from "./handler.ts";
-import type { ParsedArgs } from "../../shared/types.ts";
-
-function extractAnalyzeChunksArgs(args: ParsedArgs, cwdVal: string) {
-  const projectDir = typeof args.project === "string" ? args.project : cwdVal;
-  const output = typeof args.output === "string" ? args.output : undefined;
-  return {
-    projectDir,
-    output,
-  };
-}
+import { handleAnalyzeChunksCommand, parseAnalyzeChunksArgs } from "./handler.ts";
 
 describe("commands/analyze-chunks/handler", () => {
   describe("handleAnalyzeChunksCommand", () => {
@@ -24,56 +14,62 @@ describe("commands/analyze-chunks/handler", () => {
     });
   });
 
-  describe("argument extraction", () => {
-    const CWD = "/home/user/project";
-
-    it("uses cwd when no --project flag provided", () => {
-      const result = extractAnalyzeChunksArgs({ _: ["analyze-chunks"] }, CWD);
-      assertEquals(result.projectDir, CWD);
+  describe("parseAnalyzeChunksArgs", () => {
+    it("defaults projectDir to empty string when not provided", () => {
+      const result = parseAnalyzeChunksArgs({ _: ["analyze-chunks"] });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.projectDir, "");
     });
 
-    it("uses --project string value when provided", () => {
-      const result = extractAnalyzeChunksArgs(
-        { _: ["analyze-chunks"], project: "/custom/path" },
-        CWD,
-      );
-      assertEquals(result.projectDir, "/custom/path");
+    it("uses --project-dir string value when provided", () => {
+      const result = parseAnalyzeChunksArgs({
+        _: ["analyze-chunks"],
+        "project-dir": "/custom/path",
+      });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.projectDir, "/custom/path");
     });
 
-    it("falls back to cwd when --project is non-string (boolean true)", () => {
-      const result = extractAnalyzeChunksArgs({ _: ["analyze-chunks"], project: true }, CWD);
-      assertEquals(result.projectDir, CWD);
+    it("uses -d alias for project dir", () => {
+      const result = parseAnalyzeChunksArgs({
+        _: ["analyze-chunks"],
+        d: "/custom/path",
+      });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.projectDir, "/custom/path");
     });
 
     it("parses --output as string value", () => {
-      const result = extractAnalyzeChunksArgs(
-        { _: ["analyze-chunks"], output: "report.json" },
-        CWD,
-      );
-      assertEquals(result.output, "report.json");
+      const result = parseAnalyzeChunksArgs({
+        _: ["analyze-chunks"],
+        output: "report.json",
+      });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.output, "report.json");
     });
 
     it("returns undefined for --output when not provided", () => {
-      const result = extractAnalyzeChunksArgs({ _: ["analyze-chunks"] }, CWD);
-      assertEquals(result.output, undefined);
+      const result = parseAnalyzeChunksArgs({ _: ["analyze-chunks"] });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.output, undefined);
     });
 
-    it("returns undefined for --output when value is boolean (flag without value)", () => {
-      const result = extractAnalyzeChunksArgs({ _: ["analyze-chunks"], output: true }, CWD);
-      assertEquals(result.output, undefined);
-    });
-
-    it("returns undefined for --output when value is a number", () => {
-      const result = extractAnalyzeChunksArgs({ _: ["analyze-chunks"], output: 42 }, CWD);
-      assertEquals(result.output, undefined);
+    it("uses -o alias for output", () => {
+      const result = parseAnalyzeChunksArgs({
+        _: ["analyze-chunks"],
+        o: "report.json",
+      });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.output, "report.json");
     });
 
     it("accepts output path with directory separators", () => {
-      const result = extractAnalyzeChunksArgs(
-        { _: ["analyze-chunks"], output: "./reports/chunks.json" },
-        CWD,
-      );
-      assertEquals(result.output, "./reports/chunks.json");
+      const result = parseAnalyzeChunksArgs({
+        _: ["analyze-chunks"],
+        output: "./reports/chunks.json",
+      });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.output, "./reports/chunks.json");
     });
   });
 });

--- a/src/cli/commands/analyze-chunks/handler.ts
+++ b/src/cli/commands/analyze-chunks/handler.ts
@@ -2,18 +2,31 @@
  * Analyze chunks command handler
  */
 
+import { z } from "zod";
 import { cwd } from "#veryfront/platform/compat/process.ts";
 import { analyzeChunksCommand } from "./command.ts";
 import { showLogo } from "../../utils/index.ts";
+import { CommonArgs, createArgParser } from "../../shared/args.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
+
+const AnalyzeChunksArgsSchema = z.object({
+  projectDir: z.string().default(""),
+  output: z.string().optional(),
+});
+
+export const parseAnalyzeChunksArgs = createArgParser(AnalyzeChunksArgsSchema, {
+  projectDir: CommonArgs.projectDir,
+  output: CommonArgs.output,
+});
 
 export async function handleAnalyzeChunksCommand(args: ParsedArgs): Promise<void> {
   showLogo();
-  const projectDir = typeof args.project === "string" ? args.project : cwd();
-  const output = typeof args.output === "string" ? args.output : undefined;
-
+  const result = parseAnalyzeChunksArgs(args);
+  if (!result.success) {
+    throw new Error(`Invalid analyze-chunks arguments: ${result.error.message}`);
+  }
   await analyzeChunksCommand({
-    projectDir,
-    output,
+    projectDir: result.data.projectDir || cwd(),
+    output: result.data.output,
   });
 }

--- a/src/cli/commands/clean/handler.ts
+++ b/src/cli/commands/clean/handler.ts
@@ -2,20 +2,37 @@
  * Clean command handler
  */
 
+import { z } from "zod";
 import { cwd } from "#veryfront/platform/compat/process.ts";
 import { cleanCommand } from "./command.ts";
 import { showLogo } from "../../utils/index.ts";
+import { CommonArgs, createArgParser } from "../../shared/args.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
+
+const CleanArgsSchema = z.object({
+  projectDir: z.string().default(""),
+  cache: z.boolean().default(false),
+  build: z.boolean().default(false),
+  all: z.boolean().default(false),
+  force: z.boolean().default(false),
+});
+
+const parseCleanArgs = createArgParser(CleanArgsSchema, {
+  projectDir: CommonArgs.projectDir,
+  cache: { keys: ["cache"], type: "boolean" },
+  build: { keys: ["build"], type: "boolean" },
+  all: { keys: ["all"], type: "boolean" },
+  force: { keys: ["force", "f", "y"], type: "boolean" },
+});
 
 export async function handleCleanCommand(args: ParsedArgs): Promise<void> {
   showLogo();
-  const projectDir = typeof args.project === "string" ? args.project : cwd();
-
+  const result = parseCleanArgs(args);
+  if (!result.success) {
+    throw new Error(`Invalid clean arguments: ${result.error.message}`);
+  }
   await cleanCommand({
-    projectDir,
-    cache: args.cache === true,
-    build: args.build === true,
-    all: args.all === true,
-    force: args.force === true || args.f === true || args.y === true,
+    ...result.data,
+    projectDir: result.data.projectDir || cwd(),
   });
 }

--- a/src/cli/commands/demo/handler.ts
+++ b/src/cli/commands/demo/handler.ts
@@ -2,15 +2,27 @@
  * Demo command handler
  */
 
+import { z } from "zod";
+import { createArgParser } from "../../shared/args.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
 
+const DemoArgsSchema = z.object({
+  projectName: z.string().optional(),
+  auto: z.boolean().default(false),
+  loginMethod: z.enum(["google", "github", "microsoft", "token"]).optional(),
+});
+
+export const parseDemoArgs = createArgParser(DemoArgsSchema, {
+  projectName: { keys: ["project-name"], type: "string", positional: 0 },
+  auto: { keys: ["auto"], type: "boolean" },
+  loginMethod: { keys: ["login"], type: "string" },
+});
+
 export async function handleDemoCommand(args: ParsedArgs): Promise<void> {
+  const result = parseDemoArgs(args);
+  if (!result.success) {
+    throw new Error(`Invalid demo arguments: ${result.error.message}`);
+  }
   const { demoCommand } = await import("./index.ts");
-  await demoCommand({
-    projectName: args._[1] ? String(args._[1]) : undefined,
-    auto: Boolean(args.auto),
-    loginMethod: args.login
-      ? (String(args.login) as "google" | "github" | "microsoft" | "token")
-      : undefined,
-  });
+  await demoCommand(result.data);
 }

--- a/src/cli/commands/doctor/handler.test.ts
+++ b/src/cli/commands/doctor/handler.test.ts
@@ -1,14 +1,7 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { handleDoctorCommand } from "./handler.ts";
+import { handleDoctorCommand, parseDoctorArgs } from "./handler.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
-
-// Uses Boolean() coercion (not strict === true) to match the handler behavior
-function extractDoctorArgs(args: Record<string, unknown>) {
-  return {
-    strict: Boolean(args.strict || args.s),
-  };
-}
 
 describe("commands/doctor/handler", () => {
   describe("handleDoctorCommand", () => {
@@ -22,53 +15,36 @@ describe("commands/doctor/handler", () => {
     });
   });
 
-  describe("argument extraction", () => {
+  describe("parseDoctorArgs", () => {
     it("strict defaults to false when not provided", () => {
-      assertEquals(extractDoctorArgs({ _: ["doctor"] }).strict, false);
+      const result = parseDoctorArgs({ _: ["doctor"] });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.strict, false);
     });
 
     it("parses --strict flag", () => {
-      assertEquals(extractDoctorArgs({ _: ["doctor"], strict: true }).strict, true);
+      const result = parseDoctorArgs({ _: ["doctor"], strict: true });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.strict, true);
     });
 
     it("parses -s as alias for --strict", () => {
-      assertEquals(extractDoctorArgs({ _: ["doctor"], s: true }).strict, true);
+      const result = parseDoctorArgs({ _: ["doctor"], s: true });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.strict, true);
     });
 
-    it("strict is true if either --strict or -s is set", () => {
-      assertEquals(
-        extractDoctorArgs({ _: ["doctor"], strict: false, s: true }).strict,
-        true,
-      );
-      assertEquals(
-        extractDoctorArgs({ _: ["doctor"], strict: true, s: false }).strict,
-        true,
-      );
-    });
-
-    it("strict is false when both --strict and -s are false", () => {
-      assertEquals(
-        extractDoctorArgs({ _: ["doctor"], strict: false, s: false }).strict,
-        false,
-      );
-    });
-
-    it("uses Boolean() coercion (truthy values enable strict)", () => {
-      assertEquals(extractDoctorArgs({ _: ["doctor"], strict: "yes" }).strict, true);
-      assertEquals(extractDoctorArgs({ _: ["doctor"], strict: 1 }).strict, true);
-    });
-
-    it("Boolean() coercion treats falsy values as false", () => {
-      assertEquals(extractDoctorArgs({ _: ["doctor"], strict: 0 }).strict, false);
-      assertEquals(extractDoctorArgs({ _: ["doctor"], strict: "" }).strict, false);
-      assertEquals(extractDoctorArgs({ _: ["doctor"], strict: null }).strict, false);
-      assertEquals(extractDoctorArgs({ _: ["doctor"], strict: undefined }).strict, false);
+    it("strict is false when flag is explicitly false", () => {
+      const result = parseDoctorArgs({ _: ["doctor"], strict: false });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.strict, false);
     });
 
     it("does not use --project flag (always uses cwd)", () => {
       const args: ParsedArgs = { _: ["doctor"], project: "/some/path" };
-      const result = extractDoctorArgs(args);
-      assertEquals("projectDir" in result, false);
+      const result = parseDoctorArgs(args);
+      assertEquals(result.success, true);
+      if (result.success) assertEquals("projectDir" in result.data, false);
     });
   });
 });

--- a/src/cli/commands/doctor/handler.ts
+++ b/src/cli/commands/doctor/handler.ts
@@ -2,12 +2,26 @@
  * Doctor command handler
  */
 
+import { z } from "zod";
 import { cwd } from "#veryfront/platform/compat/process.ts";
 import { doctorCommand } from "./index.ts";
 import { showLogo } from "../../utils/index.ts";
+import { createArgParser } from "../../shared/args.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
+
+const DoctorArgsSchema = z.object({
+  strict: z.boolean().default(false),
+});
+
+export const parseDoctorArgs = createArgParser(DoctorArgsSchema, {
+  strict: { keys: ["strict", "s"], type: "boolean" },
+});
 
 export async function handleDoctorCommand(args: ParsedArgs): Promise<void> {
   showLogo();
-  await doctorCommand(cwd(), { strict: Boolean(args.strict || args.s) });
+  const result = parseDoctorArgs(args);
+  if (!result.success) {
+    throw new Error(`Invalid doctor arguments: ${result.error.message}`);
+  }
+  await doctorCommand(cwd(), result.data);
 }

--- a/src/cli/commands/generate/handler.ts
+++ b/src/cli/commands/generate/handler.ts
@@ -3,8 +3,7 @@
  */
 
 import { generateCommand } from "./index.ts";
-import { showCommandHelp } from "../../help/index.ts";
-import { exitProcess, showLogo } from "../../utils/index.ts";
+import { showLogo } from "../../utils/index.ts";
 import type { GenerateCommandArgs } from "../../shared/types.ts";
 import { cwd } from "#veryfront/platform/compat/process.ts";
 
@@ -24,9 +23,11 @@ export async function handleGenerateCommand(args: GenerateCommandArgs): Promise<
   if (
     typeof type !== "string" || !VALID_TYPES.includes(type as typeof VALID_TYPES[number]) || !name
   ) {
-    showCommandHelp("generate");
-    exitProcess(2);
-    return;
+    throw new Error(
+      `Invalid arguments. Usage: veryfront generate <type> <name>\n\nValid types: ${
+        VALID_TYPES.join(", ")
+      }`,
+    );
   }
 
   await generateCommand(cwd(), type, String(name));

--- a/src/cli/commands/init/handler.ts
+++ b/src/cli/commands/init/handler.ts
@@ -6,7 +6,6 @@
 
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { cliLogger } from "#veryfront/utils";
-import { exitProcess } from "../../utils/index.ts";
 import { resolvePath } from "../../shared/path-utils.ts";
 import { initCommand } from "./init-command.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
@@ -51,12 +50,10 @@ export async function handleInitCommand(args: ParsedArgs): Promise<void> {
 
       cliLogger.debug(`Loaded config from ${resolvedPath}`);
     } catch (error) {
-      cliLogger.error(`Failed to read config file: ${resolvedPath}`);
-      if (error instanceof SyntaxError) {
-        cliLogger.error("Invalid JSON syntax in config file");
-      }
-      exitProcess(1);
-      return;
+      const detail = error instanceof SyntaxError
+        ? "Invalid JSON syntax in config file"
+        : "Could not read file";
+      throw new Error(`Failed to read config file: ${resolvedPath} (${detail})`);
     }
   }
 

--- a/src/cli/commands/lock/handler.ts
+++ b/src/cli/commands/lock/handler.ts
@@ -2,21 +2,39 @@
  * Lock command handler
  */
 
+import { z } from "zod";
 import { cwd } from "#veryfront/platform/compat/process.ts";
 import { lockCommand } from "./command.ts";
 import { showLogo } from "../../utils/index.ts";
+import { createArgParser } from "../../shared/args.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
+
+const LockArgsSchema = z.object({
+  projectDir: z.string().default(""),
+  update: z.boolean().default(false),
+  verify: z.boolean().default(false),
+  clear: z.boolean().default(false),
+  list: z.boolean().default(false),
+  force: z.boolean().default(false),
+});
+
+const parseLockArgs = createArgParser(LockArgsSchema, {
+  projectDir: { keys: ["project"], type: "string" },
+  update: { keys: ["update"], type: "boolean" },
+  verify: { keys: ["verify"], type: "boolean" },
+  clear: { keys: ["clear"], type: "boolean" },
+  list: { keys: ["list"], type: "boolean" },
+  force: { keys: ["force", "f", "y"], type: "boolean" },
+});
 
 export async function handleLockCommand(args: ParsedArgs): Promise<void> {
   showLogo();
-  const projectDir = typeof args.project === "string" ? args.project : cwd();
-
+  const result = parseLockArgs(args);
+  if (!result.success) {
+    throw new Error(`Invalid lock arguments: ${result.error.message}`);
+  }
   await lockCommand({
-    projectDir,
-    update: args.update === true,
-    verify: args.verify === true,
-    clear: args.clear === true,
-    list: args.list === true,
-    force: args.force === true || args.f === true || args.y === true,
+    ...result.data,
+    projectDir: result.data.projectDir || cwd(),
   });
 }

--- a/src/cli/commands/mcp/handler.ts
+++ b/src/cli/commands/mcp/handler.ts
@@ -2,11 +2,27 @@
  * MCP command handler
  */
 
+import { z } from "zod";
 import { DEFAULT_PORT } from "#veryfront/config/defaults.ts";
+import { createArgParser } from "../../shared/args.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
 
+const MCPArgsSchema = z.object({
+  port: z.number().optional(),
+});
+
+export const parseMCPArgs = createArgParser(MCPArgsSchema, {
+  port: { keys: ["port"], type: "number" },
+});
+
 export async function handleMCPCommand(args: ParsedArgs): Promise<void> {
-  const port = args.port !== DEFAULT_PORT ? Number(args.port) : undefined;
+  const result = parseMCPArgs(args);
+  if (!result.success) {
+    throw new Error(`Invalid MCP arguments: ${result.error.message}`);
+  }
+  // The CLI framework injects DEFAULT_PORT (3000) as a default for --port.
+  // Filter it out so the MCP server uses its own default (8080).
+  const port = result.data.port !== DEFAULT_PORT ? result.data.port : undefined;
   const { createStandaloneMCPServer } = await import("../../mcp/standalone.ts");
   const mcpServer = createStandaloneMCPServer({ port });
   await new Promise(() => {});

--- a/src/cli/commands/merge/command.ts
+++ b/src/cli/commands/merge/command.ts
@@ -10,7 +10,7 @@
 import { z } from "zod";
 import { cliLogger } from "#veryfront/utils";
 import { cwd } from "#veryfront/platform/compat/process.ts";
-import { type ApiClient, createApiClient, resolveConfig } from "../../shared/config.ts";
+import { type ApiClient, createApiClient, resolveConfigWithAuth } from "../../shared/config.ts";
 import { CommonArgs, createArgParser } from "../../shared/args.ts";
 import { confirmPrompt, logInfo, logSuccess } from "../../utils/index.ts";
 import { createSpinner } from "../../ui/progress.ts";
@@ -150,7 +150,7 @@ export async function mergeCommand(options: MergeOptions): Promise<void> {
 
   let spinner = createSpinner("Resolving configuration...");
 
-  const config = await resolveConfig(cwd());
+  const config = await resolveConfigWithAuth(cwd());
   const client = createApiClient(config);
 
   spinner.update(`Looking up branch "${branch}"...`);

--- a/src/cli/commands/pull/command.ts
+++ b/src/cli/commands/pull/command.ts
@@ -22,6 +22,7 @@ import { confirmPrompt, logInfo, logSuccess, logWarning } from "../../utils/inde
 import { createNoopSpinner, createSpinner } from "../../ui/progress.ts";
 import { getApiTokenEnv } from "#veryfront/config/env.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { getStringArg, resolveProjectDir } from "../../shared/args.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
 
 /**
@@ -52,28 +53,6 @@ function parseCsvArg(value: unknown): string[] | undefined {
     return value.map(String).filter(Boolean);
   }
   return undefined;
-}
-
-/**
- * Helper to get string arg with fallbacks
- */
-function getStringArg(args: ParsedArgs, ...keys: string[]): string | undefined {
-  for (const key of keys) {
-    const val = args[key];
-    if (typeof val === "string" && val) return val;
-  }
-  return undefined;
-}
-
-/**
- * Resolve project directory from args
- */
-function resolveProjectDir(args: ParsedArgs, keys: string[]): string {
-  for (const key of keys) {
-    const val = args[key];
-    if (typeof val === "string" && val) return val;
-  }
-  return cwd();
 }
 
 /**

--- a/src/cli/commands/push/command.ts
+++ b/src/cli/commands/push/command.ts
@@ -24,6 +24,7 @@ import { createNoopSpinner, createSpinner } from "../../ui/progress.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { createIgnoreChecker, type IgnoreChecker, loadIgnorePatterns } from "../../sync/ignore.ts";
 import { listAllFiles } from "../pull/index.ts";
+import { getStringArg, resolveProjectDir } from "../../shared/args.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
 
 /**
@@ -39,28 +40,6 @@ export const PushArgsSchema = z.object({
 });
 
 export type PushArgs = z.infer<typeof PushArgsSchema>;
-
-/**
- * Helper to get string arg with fallbacks
- */
-function getStringArg(args: ParsedArgs, ...keys: string[]): string | undefined {
-  for (const key of keys) {
-    const val = args[key];
-    if (typeof val === "string" && val) return val;
-  }
-  return undefined;
-}
-
-/**
- * Resolve project directory from args
- */
-function resolveProjectDir(args: ParsedArgs, keys: string[]): string {
-  for (const key of keys) {
-    const val = args[key];
-    if (typeof val === "string" && val) return val;
-  }
-  return cwd();
-}
 
 /**
  * Parse push command arguments from CLI args

--- a/src/cli/commands/routes/handler.test.ts
+++ b/src/cli/commands/routes/handler.test.ts
@@ -1,15 +1,6 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { handleRoutesCommand } from "./handler.ts";
-import type { ParsedArgs } from "../../shared/types.ts";
-
-function extractRoutesArgs(args: ParsedArgs, cwdVal: string) {
-  const projectDir = typeof args.project === "string" ? args.project : cwdVal;
-  return {
-    projectDir,
-    json: args.json === true,
-  };
-}
+import { handleRoutesCommand, parseRoutesArgs } from "./handler.ts";
 
 describe("commands/routes/handler", () => {
   describe("handleRoutesCommand", () => {
@@ -23,45 +14,47 @@ describe("commands/routes/handler", () => {
     });
   });
 
-  describe("argument extraction", () => {
-    const CWD = "/home/user/project";
-
-    it("uses cwd when no --project flag provided", () => {
-      const result = extractRoutesArgs({ _: ["routes"] }, CWD);
-      assertEquals(result.projectDir, CWD);
+  describe("parseRoutesArgs", () => {
+    it("defaults projectDir to empty string when not provided", () => {
+      const result = parseRoutesArgs({ _: ["routes"] });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.projectDir, "");
     });
 
-    it("uses --project string value when provided", () => {
-      const result = extractRoutesArgs({ _: ["routes"], project: "/custom/path" }, CWD);
-      assertEquals(result.projectDir, "/custom/path");
+    it("uses --project-dir string value when provided", () => {
+      const result = parseRoutesArgs({ _: ["routes"], "project-dir": "/custom/path" });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.projectDir, "/custom/path");
     });
 
-    it("falls back to cwd when --project is non-string (boolean true)", () => {
-      const result = extractRoutesArgs({ _: ["routes"], project: true }, CWD);
-      assertEquals(result.projectDir, CWD);
+    it("uses --dir alias", () => {
+      const result = parseRoutesArgs({ _: ["routes"], dir: "/custom/path" });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.projectDir, "/custom/path");
     });
 
-    it("falls back to cwd when --project is a number", () => {
-      const result = extractRoutesArgs({ _: ["routes"], project: 42 }, CWD);
-      assertEquals(result.projectDir, CWD);
+    it("uses -d alias", () => {
+      const result = parseRoutesArgs({ _: ["routes"], d: "/custom/path" });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.projectDir, "/custom/path");
     });
 
-    it("parses --json flag", () => {
-      assertEquals(extractRoutesArgs({ _: ["routes"], json: true }, CWD).json, true);
-      assertEquals(extractRoutesArgs({ _: ["routes"], json: false }, CWD).json, false);
-      assertEquals(extractRoutesArgs({ _: ["routes"] }, CWD).json, false);
+    it("parses --json flag as true", () => {
+      const result = parseRoutesArgs({ _: ["routes"], json: true });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.json, true);
     });
 
-    it("rejects non-boolean values for --json via strict equality", () => {
-      const strArgs = { _: ["routes"], json: "true" } as unknown as ParsedArgs;
-      const numArgs = { _: ["routes"], json: 1 } as unknown as ParsedArgs;
-      assertEquals(extractRoutesArgs(strArgs, CWD).json, false);
-      assertEquals(extractRoutesArgs(numArgs, CWD).json, false);
+    it("defaults --json to false", () => {
+      const result = parseRoutesArgs({ _: ["routes"] });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.json, false);
     });
 
-    it("defaults to human-readable output when --json is omitted", () => {
-      const result = extractRoutesArgs({ _: ["routes"] }, CWD);
-      assertEquals(result.json, false);
+    it("parses --json flag as false", () => {
+      const result = parseRoutesArgs({ _: ["routes"], json: false });
+      assertEquals(result.success, true);
+      if (result.success) assertEquals(result.data.json, false);
     });
   });
 });

--- a/src/cli/commands/routes/handler.ts
+++ b/src/cli/commands/routes/handler.ts
@@ -2,16 +2,29 @@
  * Routes command handler
  */
 
+import { z } from "zod";
 import { cwd } from "#veryfront/platform/compat/process.ts";
 import { routesCommand } from "./command.ts";
 import { showLogo } from "../../utils/index.ts";
+import { CommonArgs, createArgParser } from "../../shared/args.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
+
+const RoutesArgsSchema = z.object({
+  projectDir: z.string().default(""),
+  json: z.boolean().default(false),
+});
+
+export const parseRoutesArgs = createArgParser(RoutesArgsSchema, {
+  projectDir: CommonArgs.projectDir,
+  json: { keys: ["json"], type: "boolean" },
+});
 
 export async function handleRoutesCommand(args: ParsedArgs): Promise<void> {
   showLogo();
-  const projectDir = typeof args.project === "string" ? args.project : cwd();
-
-  await routesCommand(projectDir, {
-    json: args.json === true,
-  });
+  const result = parseRoutesArgs(args);
+  if (!result.success) {
+    throw new Error(`Invalid routes arguments: ${result.error.message}`);
+  }
+  const projectDir = result.data.projectDir || cwd();
+  await routesCommand(projectDir, { json: result.data.json });
 }

--- a/src/cli/commands/studio/handler.ts
+++ b/src/cli/commands/studio/handler.ts
@@ -4,19 +4,11 @@
 
 import type { ParsedArgs } from "../../shared/types.ts";
 import { studioCommand } from "./index.ts";
-import { cliLogger } from "#veryfront/utils";
-import { formatUserError } from "#veryfront/errors/user-friendly/index.ts";
-import { exitProcess } from "../../utils/index.ts";
 
 export async function handleStudioCommand(args: ParsedArgs): Promise<void> {
   const project = typeof args._[1] === "string" ? args._[1] : undefined;
   const branch = typeof args.branch === "string" ? args.branch : undefined;
   const file = typeof args.file === "string" ? args.file : undefined;
 
-  try {
-    await studioCommand({ project, branch, file });
-  } catch (error) {
-    cliLogger.error(error instanceof Error ? formatUserError(error) : String(error));
-    exitProcess(1);
-  }
+  await studioCommand({ project, branch, file });
 }

--- a/src/cli/commands/up/command.ts
+++ b/src/cli/commands/up/command.ts
@@ -9,7 +9,8 @@ import {
   type EnvironmentConfig,
   getEnvironmentConfig,
 } from "#veryfront/config/environment-config.ts";
-import { getColorEnabled, isTTY, promptUser } from "../../utils/index.ts";
+import { shouldUseColor } from "../../ui/colors.ts";
+import { isTTY, promptUser } from "../../utils/index.ts";
 import { createSpinner } from "../../ui/progress.ts";
 import { CommonArgs, createArgParser } from "../../shared/args.ts";
 import { readConfigFile, type VeryfrontConfig } from "../../shared/config.ts";
@@ -102,7 +103,7 @@ export async function upCommand(
 ): Promise<void> {
   const { force = false, dryRun = false } = options;
 
-  const useColor = getColorEnabled();
+  const useColor = shouldUseColor();
   const c = (fn: (s: string) => string, s: string): string => (useColor ? fn(s) : s);
 
   const projectDir = cwd();

--- a/src/cli/discovery/config-validator.ts
+++ b/src/cli/discovery/config-validator.ts
@@ -27,22 +27,6 @@ export function validateAIConfig(config: VeryfrontConfig): ValidationResult {
   return result;
 }
 
-function _printMessages(
-  title: string,
-  icon: string,
-  color: (text: string) => string,
-  messages: string[],
-): void {
-  if (messages.length === 0) return;
-
-  console.log("");
-  logger.warn(`${color(title)}:`);
-  for (const message of messages) {
-    console.log(`  ${color(icon)} ${message.replace(/\n/g, "\n    ")}`);
-  }
-  console.log("");
-}
-
 export function runAIConfigValidation(config: VeryfrontConfig): void {
   const result = validateAIConfig(config);
 

--- a/src/cli/mcp/server.ts
+++ b/src/cli/mcp/server.ts
@@ -156,7 +156,6 @@ export class MCPDevServer {
       const isAllowedOrigin = origin === "" ||
         origin.startsWith("http://localhost") ||
         origin.startsWith("http://127.0.0.1") ||
-        origin.startsWith("http://veryfront.me") ||
         origin.startsWith("http://veryfront.me");
 
       const headers: Record<string, string> = {

--- a/src/cli/router.ts
+++ b/src/cli/router.ts
@@ -31,7 +31,8 @@ import { handleUpCommand } from "./commands/up/index.ts";
 import { login, logout, whoami } from "./auth/index.ts";
 import { parseLoginMethod } from "./auth/utils.ts";
 import { showCommandHelp, showMainHelp } from "./help/index.ts";
-import { exitProcess, setColorMode, setQuietMode, setVerboseMode } from "./utils/index.ts";
+import { setColorOverride } from "./ui/colors.ts";
+import { exitProcess, setQuietMode, setVerboseMode } from "./utils/index.ts";
 import type { ParsedArgs } from "./shared/types.ts";
 
 /**
@@ -52,8 +53,8 @@ function showHelp(command?: string): void {
  */
 export async function routeCommand(args: ParsedArgs): Promise<void> {
   // Handle global flags
-  if (args["no-color"]) setColorMode(false);
-  else if (args.color) setColorMode(true);
+  if (args["no-color"]) setColorOverride(false);
+  else if (args.color) setColorOverride(true);
 
   if (args.verbose) setVerboseMode(true);
   else if (args.quiet || args.q) setQuietMode(true);

--- a/src/cli/shared/args.ts
+++ b/src/cli/shared/args.ts
@@ -7,6 +7,7 @@
  */
 
 import { z } from "zod";
+import { cwd } from "#veryfront/platform/compat/process.ts";
 import type { ParsedArgs } from "./types.ts";
 
 /**
@@ -112,6 +113,28 @@ export function createArgParser<T extends z.ZodRawShape>(
   ): z.SafeParseReturnType<unknown, z.infer<z.ZodObject<T>>> {
     return schema.safeParse(extractArgs(args, argMap));
   };
+}
+
+/**
+ * Get the first non-empty string value from parsed args for any of the given keys
+ */
+export function getStringArg(args: ParsedArgs, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const val = args[key];
+    if (typeof val === "string" && val) return val;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a project directory from parsed args, falling back to cwd()
+ */
+export function resolveProjectDir(args: ParsedArgs, keys: string[]): string {
+  for (const key of keys) {
+    const val = args[key];
+    if (typeof val === "string" && val) return val;
+  }
+  return cwd();
 }
 
 /**

--- a/src/cli/templates/index.ts
+++ b/src/cli/templates/index.ts
@@ -81,4 +81,3 @@ export function getTemplateConfig(name: TemplateName): TemplateConfig | null {
   return templateConfigs[name] ?? null;
 }
 
-export const templates: Record<string, TemplateFile[]> = {};

--- a/src/cli/templates/index.ts
+++ b/src/cli/templates/index.ts
@@ -80,4 +80,3 @@ export async function getTemplate(name: TemplateName): Promise<TemplateFile[] | 
 export function getTemplateConfig(name: TemplateName): TemplateConfig | null {
   return templateConfigs[name] ?? null;
 }
-

--- a/src/cli/ui/colors.ts
+++ b/src/cli/ui/colors.ts
@@ -50,6 +50,7 @@ export function shouldUseColor(): boolean {
 let cachedColorLevel: ColorLevel | null = null;
 let cachedColorEnvKey: string | null = null;
 let testOverrideColorLevel: ColorLevel | null = null;
+let cliColorOverride: boolean | undefined;
 
 function buildColorEnvKey(envObj: Record<string, string>, stdoutTty: boolean): string {
   return [
@@ -68,6 +69,10 @@ function getCachedColorLevel(): ColorLevel {
     return testOverrideColorLevel;
   }
 
+  // CLI --no-color / --color flag override
+  if (cliColorOverride === false) return "none";
+  if (cliColorOverride === true) return "truecolor";
+
   const envObj = getEnvObject();
   const stdoutTty = isStdoutTTY();
   const envKey = buildColorEnvKey(envObj, stdoutTty);
@@ -83,6 +88,15 @@ export function resetColorCache(): void {
   cachedColorLevel = null;
   cachedColorEnvKey = null;
   testOverrideColorLevel = null;
+  cliColorOverride = undefined;
+}
+
+/**
+ * Override color output from CLI flags (--color / --no-color).
+ * Pass `true` to force colors on, `false` to force off, `undefined` to clear.
+ */
+export function setColorOverride(enabled: boolean | undefined): void {
+  cliColorOverride = enabled;
 }
 
 /**

--- a/src/cli/utils/index.ts
+++ b/src/cli/utils/index.ts
@@ -1,9 +1,12 @@
 import { cliLogger, formatBytes, VERSION } from "#veryfront/utils";
-import { bold, cyan, dim } from "#veryfront/compat/console";
 import { exit, isStdoutTTY, onSignal, promptSync } from "#veryfront/platform/compat/process.ts";
-import { getForceColorEnv, getNoColorEnv } from "#veryfront/config/env.ts";
 import {
+  bold,
+  brand,
+  dim,
   error as errorColor,
+  muted,
+  shouldUseColor,
   success as successColor,
   warning as warningColor,
 } from "../ui/colors.ts";
@@ -12,51 +15,18 @@ export function isTTY(): boolean {
   return isStdoutTTY();
 }
 
-let _colorEnabled: boolean | undefined;
-
-export function shouldUseColor(forceColor?: boolean): boolean {
-  if (forceColor !== undefined) return forceColor;
-
-  if (getNoColorEnv()) return false;
-
-  const forceColorEnv = getForceColorEnv();
-  if (forceColorEnv && forceColorEnv !== "0") return true;
-
-  return isTTY();
-}
-
-export function setColorMode(enabled: boolean | undefined): void {
-  _colorEnabled = enabled;
-}
-
-export function getColorEnabled(): boolean {
-  return shouldUseColor(_colorEnabled);
-}
-
-export function stripColors(str: string): string {
-  // deno-lint-ignore no-control-regex
-  return str.replace(/\x1b\[[0-9;]*m/g, "");
-}
-
-export function conditionalColor<T extends (s: string) => string>(
-  colorFn: T,
-  text: string,
-): string {
-  return getColorEnabled() ? colorFn(text) : text;
-}
-
-function colorize(useColor: boolean, fn: (s: string) => string, s: string): string {
-  return useColor ? fn(s) : s;
-}
-
 export function showLogo(): void {
-  const useColor = getColorEnabled();
+  if (!shouldUseColor()) {
+    cliLogger.info(`
+⚡ Veryfront v${VERSION}
+──────────────────────
+`);
+    return;
+  }
 
   cliLogger.info(`
-${colorize(useColor, cyan, "⚡")} ${
-    colorize(useColor, bold, colorize(useColor, cyan, "Veryfront"))
-  } ${colorize(useColor, dim, `v${VERSION}`)}
-${colorize(useColor, dim, "──────────────────────")}
+${brand("⚡")} ${bold(brand("Veryfront"))} ${dim(`v${VERSION}`)}
+${muted("──────────────────────")}
 `);
 }
 


### PR DESCRIPTION
(typeof guards, Boolean coercion, strict equality checks) to the
Zod-based createArgParser pattern established in shared/args.ts.

Handlers migrated:
- doctor: replaces Boolean(args.strict || args.s) with Zod boolean schema
- routes: replaces typeof guards for --project and strict === true for
  --json with Zod schema using CommonArgs.projectDir
- analyze-chunks: replaces typeof guards for --project and --output with
  Zod schema using CommonArgs.projectDir and CommonArgs.output
- mcp: replaces raw args.port access with Zod number schema, preserves
  the DEFAULT_PORT filter so the MCP server uses its own 8080 default
- demo: replaces positional args._[1] extraction, Boolean(args.auto),
  and String(args.login) type assertion with Zod schema including
  z.enum() validation for login methods

Test suites for doctor, routes, and analyze-chunks are updated to test
the exported parse functions directly instead of duplicating extraction
logic in test helpers. Tests now verify the Zod result.success/data
pattern and cover CommonArgs aliases (--project-dir, --dir, -d, -o).

Adds SHARED_TASK_NOTES.md documenting the overall migration status:
10 of 17 handlers migrated, 7 remaining with notes on complexity.