### PR TITLE
refactor: centralize 7 scattered error classes into VeryfrontError + slug registry

### DIFF
--- a/plans/centralize_scattered_errors.md
+++ b/plans/centralize_scattered_errors.md
@@ -1,0 +1,161 @@
+# Centralize Scattered Error Classes
+
+Migrate 7 error classes that extend plain `Error` into the centralized `VeryfrontError` + slug registry.
+
+**Prerequisite:** Complete [error codes refactoring](./refactor_error_codes.md) (slug registry must exist).
+
+---
+
+## Target State
+
+- 7 scattered error classes replaced with `VeryfrontError` + slug definitions in `error-registry.ts`
+- `instanceof` checks migrated to `error.slug ===` checks
+- 5 local control-flow errors documented as intentionally local
+
+---
+
+## New Slug Definitions
+
+| Slug | Category | Status | Replaces | Location |
+|------|----------|--------|----------|----------|
+| `api-client-error` | SERVER | per-response | `VeryfrontAPIError` | `src/platform/adapters/veryfront-api-client/types.ts` |
+| `config-validation-failed` | CONFIG | 400 | `ConfigValidationError` | `src/config/loader.ts` |
+| `security-violation` | GENERAL | 403 | `SecurityError` | `src/security/secure-fs.ts` |
+| `input-validation-failed` | GENERAL | 400 | `ValidationError` | `src/security/input-validation/errors.ts` |
+| `token-storage-error` | SERVER | per-response | `TokenStorageError` | `src/platform/adapters/token/veryfront/types.ts` |
+| `cache-invariant-violation` | SERVER | 500 | `CacheInvariantError` | `src/cache/paths.ts` + `src/transforms/esm/http-cache-invariants.ts` |
+| `fallback-exhausted` | SERVER | 500 | `FallbackExecutionError` | `src/platform/adapters/fallback-wrapper.ts` |
+
+---
+
+## Intentionally Local (not centralizing)
+
+These are internal control-flow errors — caught close to throw sites, never surface to users/logs.
+
+| Class | Location | Reason |
+|-------|----------|--------|
+| `SemaphoreTimeoutError` | `src/utils/semaphore.ts` | Concurrency primitive, triggers retry |
+| `TransformTreeTimeoutError` | `src/transforms/mdx/esm-module-loader/module-fetcher/index.ts` | Caught and converted at boundary |
+| `NotSupportedError` | `src/platform/adapters/fs/wrapper.ts` | Adapter feature detection |
+| `TimeoutError` | `src/rendering/utils/stream-utils.ts` | Generic primitive, wrapped before surfacing |
+| `StreamTimeoutError` | `src/rendering/utils/stream-utils.ts` | Generic primitive, wrapped before surfacing |
+
+---
+
+## Execution Plan
+
+### Phase 1: Add 7 slug definitions to registry
+
+- [ ] **1.1** Add 7 new error definitions to `src/errors/error-registry.ts` (see table above)
+- [ ] **1.2** Add tests for new slugs in `src/errors/error-registry.test.ts`
+
+### Phase 2: Migrate each error class
+
+> 2.1–2.7 are independent. Run as parallel subagents.
+
+- [ ] **2.1** `VeryfrontAPIError` → `api-client-error` slug
+  - File: `src/platform/adapters/veryfront-api-client/types.ts`
+  - Used in: `client.ts`, `operations.ts`, `retry-handler.ts`, `index.ts`, `ssr.service.ts`, `snippet.handler.ts` (14 files total)
+  - Preserve `status` and `details` as `VeryfrontError` fields
+  - Re-export from `src/platform/adapters/index.ts`
+
+- [ ] **2.2** `ConfigValidationError` → `config-validation-failed` slug
+  - File: `src/config/loader.ts` (private class, 1 file only)
+  - Replace with `throw CONFIG_VALIDATION_FAILED.create({ detail: message })`
+
+- [ ] **2.3** `SecurityError` → `security-violation` slug
+  - File: `src/security/secure-fs.ts`
+  - Used in: `secure-fs.ts`, `index.ts` (2 files)
+  - Preserve `code` and `path` fields via `detail` and error metadata
+
+- [ ] **2.4** `ValidationError` → `input-validation-failed` slug
+  - File: `src/security/input-validation/errors.ts`
+  - Used in: 19 files across `src/security/input-validation/` and `src/security/path-validation/`
+  - Preserve `details` field via `VeryfrontError.detail`
+
+- [ ] **2.5** `TokenStorageError` → `token-storage-error` slug
+  - File: `src/platform/adapters/token/veryfront/types.ts`
+  - Used in: `api-client.ts`, `index.ts`, `adapters/index.ts` (7 files)
+  - Preserve `statusCode` and `details` fields
+
+- [ ] **2.6** `CacheInvariantError` → `cache-invariant-violation` slug
+  - Files: `src/cache/paths.ts` + `src/transforms/esm/http-cache-invariants.ts`
+  - Used in: `tokenizing-gateway.ts`, `http-cache.ts`, `http-cache-wrapper.ts`, `cache/index.ts` (6 files)
+  - Two classes (base + subclass) — consolidate into single slug
+
+- [ ] **2.7** `FallbackExecutionError` → `fallback-exhausted` slug
+  - File: `src/platform/adapters/fallback-wrapper.ts`
+  - Used in: `adapters/index.ts` (4 files)
+  - Preserve `primaryError` and `fallbackError` via error chaining (`cause`)
+
+### Phase 3: Delete old error classes
+
+> 3.1–3.7 are independent. Run as parallel subagents.
+
+- [ ] **3.1** Delete `VeryfrontAPIError` class from `types.ts`
+- [ ] **3.2** Delete `ConfigValidationError` class from `loader.ts`
+- [ ] **3.3** Delete `SecurityError` class from `secure-fs.ts`
+- [ ] **3.4** Delete `ValidationError` class from `errors.ts`
+- [ ] **3.5** Delete `TokenStorageError` class from `types.ts`
+- [ ] **3.6** Delete both `CacheInvariantError` classes
+- [ ] **3.7** Delete `FallbackExecutionError` class from `fallback-wrapper.ts`
+
+### Phase 4: Verify
+
+- [ ] **4.1** `grep -r "extends Error" src/ --include="*.ts"` — only intentionally local errors remain (5 listed above)
+- [ ] **4.2** All tests pass
+
+---
+
+## File Changes
+
+| File | Phase | Change |
+|------|-------|--------|
+| `src/errors/error-registry.ts` | 1 | Add 7 definitions |
+| `src/errors/error-registry.test.ts` | 1 | Add 7 slug tests |
+| `src/platform/adapters/veryfront-api-client/types.ts` | 2–3 | Replace class → import slug |
+| `src/platform/adapters/veryfront-api-client/client.ts` | 2 | Update throws |
+| `src/platform/adapters/veryfront-api-client/operations.ts` | 2 | Update throws |
+| `src/platform/adapters/veryfront-api-client/retry-handler.ts` | 2 | Update instanceof → slug check |
+| `src/config/loader.ts` | 2–3 | Replace class → import slug |
+| `src/security/secure-fs.ts` | 2–3 | Replace class → import slug |
+| `src/security/input-validation/errors.ts` | 2–3 | Replace class → import slug |
+| `src/security/input-validation/*.ts` (18 files) | 2 | Update instanceof → slug check |
+| `src/platform/adapters/token/veryfront/types.ts` | 2–3 | Replace class → import slug |
+| `src/platform/adapters/token/veryfront/api-client.ts` | 2 | Update throws |
+| `src/cache/paths.ts` | 2–3 | Replace class → import slug |
+| `src/transforms/esm/http-cache-invariants.ts` | 2–3 | Replace class → import slug |
+| `src/platform/adapters/fallback-wrapper.ts` | 2–3 | Replace class → import slug |
+
+---
+
+## Migration Pattern
+
+Before:
+```typescript
+import { VeryfrontAPIError } from "./types.ts";
+throw new VeryfrontAPIError("Not found", 404, { id: "abc" });
+```
+
+After:
+```typescript
+import { API_CLIENT_ERROR } from "#veryfront/errors/error-registry.ts";
+throw API_CLIENT_ERROR.create({
+  detail: "Not found",
+  status: 404,
+});
+```
+
+Before (instanceof check):
+```typescript
+if (error instanceof VeryfrontAPIError) {
+  console.error(`API error: ${error.status}`);
+}
+```
+
+After:
+```typescript
+if (error instanceof VeryfrontError && error.slug === "api-client-error") {
+  console.error(`API error: ${error.status}`);
+}
+```

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -10,7 +10,7 @@ export * from "./tokenizing-gateway.ts";
 export {
   assertPortableCode,
   CACHE_DIR_TOKEN,
-  CacheInvariantError,
+  CACHE_INVARIANT_VIOLATION,
   detokenizeAllCachePaths,
   detokenizeCachePaths,
   hasHardcodedCachePaths,

--- a/src/cache/paths.ts
+++ b/src/cache/paths.ts
@@ -120,25 +120,20 @@ export function detokenizeAllCachePaths(code: string): string {
   return detokenizeCachePaths(code, getCacheBaseDir());
 }
 
-/**
- * Error thrown when a cache invariant is violated (e.g., absolute path leaked to Redis).
- */
-export class CacheInvariantError extends Error {
-  constructor(message: string) {
-    super(`[CACHE INVARIANT VIOLATION] ${message}`);
-    this.name = "CacheInvariantError";
-  }
-}
+import { CACHE_INVARIANT_VIOLATION } from "#veryfront/errors/error-registry.ts";
+
+export { CACHE_INVARIANT_VIOLATION };
 
 /**
  * Assert that code is safe to store in distributed cache (portable).
- * @throws CacheInvariantError if code contains hardcoded paths
+ * @throws VeryfrontError (cache-invariant-violation) if code contains hardcoded paths
  */
 export function assertPortableCode(code: string): void {
   if (hasHardcodedCachePaths(code)) {
     logger.error("[CACHE] Invariant violation: hardcoded paths in portable code");
-    throw new CacheInvariantError(
-      "Code contains hardcoded cache paths that should be tokenized before storage in distributed cache.",
-    );
+    throw CACHE_INVARIANT_VIOLATION.create({
+      detail:
+        "[CACHE INVARIANT VIOLATION] Code contains hardcoded cache paths that should be tokenized before storage in distributed cache.",
+    });
   }
 }

--- a/src/cache/paths.ts
+++ b/src/cache/paths.ts
@@ -10,6 +10,7 @@
  */
 
 import { getCacheBaseDir } from "#veryfront/utils/cache-dir.ts";
+import { CACHE_INVARIANT_VIOLATION } from "#veryfront/errors/error-registry.ts";
 import { logger } from "#veryfront/utils/logger/logger.ts";
 
 /** Portable cache directory token */
@@ -119,8 +120,6 @@ export function tokenizeAllCachePaths(code: string): string {
 export function detokenizeAllCachePaths(code: string): string {
   return detokenizeCachePaths(code, getCacheBaseDir());
 }
-
-import { CACHE_INVARIANT_VIOLATION } from "#veryfront/errors/error-registry.ts";
 
 export { CACHE_INVARIANT_VIOLATION };
 

--- a/src/cache/tokenizing-gateway.ts
+++ b/src/cache/tokenizing-gateway.ts
@@ -17,7 +17,7 @@ import { logger } from "#veryfront/utils";
 import type { CacheBackend } from "./types.ts";
 import {
   assertPortableCode,
-  CacheInvariantError,
+  CACHE_INVARIANT_VIOLATION,
   detokenizeAllCachePaths,
   tokenizeAllVeryFrontPaths,
 } from "./paths.ts";
@@ -48,7 +48,7 @@ export interface CodeCacheGateway {
   /**
    * Store code in cache with automatic tokenization.
    * ALWAYS tokenizes before storage.
-   * @throws CacheInvariantError if code contains paths that can't be tokenized
+   * @throws VeryfrontError (cache-invariant-violation) if code contains paths that can't be tokenized
    */
   setCode(key: string, code: string, ttlSeconds?: number): Promise<void>;
 
@@ -170,7 +170,7 @@ export class TokenizingCacheGateway implements CodeCacheGateway {
   /**
    * Store code in cache with automatic tokenization.
    * Validates that code is portable before storage.
-   * @throws CacheInvariantError if code contains paths that can't be properly tokenized
+   * @throws VeryfrontError (cache-invariant-violation) if code contains paths that can't be properly tokenized
    */
   async setCode(key: string, code: string, ttlSeconds?: number): Promise<void> {
     // For memory backend, no tokenization needed
@@ -282,5 +282,5 @@ export function createTokenizingGateway(
   return new TokenizingCacheGateway(backend, name);
 }
 
-// Re-export error type for consumers
-export { CacheInvariantError };
+// Re-export error definition for consumers
+export { CACHE_INVARIANT_VIOLATION };

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -11,6 +11,8 @@ import { buildConfigCacheKey } from "../cache/keys.ts";
 import { DEFAULT_PORT } from "./defaults.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { getErrorMessage } from "../errors/veryfront-error.ts";
+import { CONFIG_VALIDATION_FAILED } from "../errors/error-registry.ts";
+import { VeryfrontError } from "../errors/types.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { SpanNames } from "#veryfront/observability/tracing/span-names.ts";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
@@ -132,13 +134,6 @@ registerLRUCache("config-cache", configCacheByProject);
 
 let cacheRevision = 0;
 
-class ConfigValidationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ConfigValidationError";
-  }
-}
-
 function validateCorsConfig(userConfig: unknown): void {
   if (!userConfig || typeof userConfig !== "object") return;
 
@@ -150,9 +145,9 @@ function validateCorsConfig(userConfig: unknown): void {
 
   const origin = (cors as Record<string, unknown>).origin;
   if (origin !== undefined && typeof origin !== "string") {
-    throw new ConfigValidationError(
-      "security.cors.origin must be a string. Expected boolean or { origin?: string }",
-    );
+    throw CONFIG_VALIDATION_FAILED.create({
+      detail: "security.cors.origin must be a string. Expected boolean or { origin?: string }",
+    });
   }
 }
 
@@ -162,9 +157,9 @@ function validateConfigShape(userConfig: unknown): void {
 
   const unknown = findUnknownTopLevelKeys(userConfig as Record<string, unknown>);
   if (unknown.length > 0) {
-    throw new ConfigValidationError(
-      `Unknown config keys: ${unknown.join(", ")}. Check for typos in veryfront.config.`,
-    );
+    throw CONFIG_VALIDATION_FAILED.create({
+      detail: `Unknown config keys: ${unknown.join(", ")}. Check for typos in veryfront.config.`,
+    });
   }
 }
 
@@ -233,9 +228,9 @@ function mergeConfigs(userConfig: Partial<VeryfrontConfig>): VeryfrontConfig {
 
 function validateAndCacheConfig(userConfig: unknown, cacheKey: string): VeryfrontConfig {
   if (!userConfig || typeof userConfig !== "object" || Array.isArray(userConfig)) {
-    throw new ConfigValidationError(
-      `Expected object, received ${userConfig === null ? "null" : typeof userConfig}`,
-    );
+    throw CONFIG_VALIDATION_FAILED.create({
+      detail: `Expected object, received ${userConfig === null ? "null" : typeof userConfig}`,
+    });
   }
 
   validateCorsConfig(userConfig);
@@ -252,7 +247,7 @@ function validateAndCacheConfig(userConfig: unknown, cacheKey: string): Veryfron
 }
 
 function isConfigError(error: unknown): boolean {
-  if (error instanceof ConfigValidationError) return true;
+  if (error instanceof VeryfrontError && error.slug === "config-validation-failed") return true;
   return error instanceof Error && error.message.startsWith("Invalid veryfront.config");
 }
 

--- a/src/errors/error-registry.test.ts
+++ b/src/errors/error-registry.test.ts
@@ -1,12 +1,19 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  API_CLIENT_ERROR,
   BUILD_FAILED,
+  CACHE_INVARIANT_VIOLATION,
   CONFIG_NOT_FOUND,
+  CONFIG_VALIDATION_FAILED,
   ERROR_REGISTRY,
+  FALLBACK_EXHAUSTED,
   getAllSlugs,
   getErrorBySlug,
   getErrorsByCategory,
+  INPUT_VALIDATION_FAILED,
+  SECURITY_VIOLATION,
+  TOKEN_STORAGE_ERROR,
 } from "./error-registry.ts";
 import type { ErrorCategory } from "./types.ts";
 
@@ -18,9 +25,9 @@ describe("error-registry", () => {
       assertEquals(slugs.length, uniqueSlugs.size, "Duplicate slugs detected");
     });
 
-    it("should have 69 registered errors", () => {
+    it("should have 76 registered errors", () => {
       const slugs = getAllSlugs();
-      assertEquals(slugs.length, 69);
+      assertEquals(slugs.length, 76);
     });
   });
 
@@ -134,7 +141,7 @@ describe("error-registry", () => {
   describe("getErrorsByCategory", () => {
     it("should return CONFIG errors", () => {
       const errors = getErrorsByCategory("CONFIG");
-      assertEquals(errors.length, 7);
+      assertEquals(errors.length, 8);
       for (const error of errors) {
         assertEquals(error.category, "CONFIG");
       }
@@ -187,6 +194,25 @@ describe("error-registry", () => {
 
       assertEquals(error.context, context);
     });
+
+    it("should support status override via create options", () => {
+      const error = API_CLIENT_ERROR.create({
+        detail: "Not found",
+        status: 404,
+      });
+
+      assertEquals(error.status, 404);
+    });
+
+    it("should support Error object as cause", () => {
+      const cause = new Error("original failure");
+      const error = FALLBACK_EXHAUSTED.create({
+        detail: "Both operations failed",
+        cause,
+      });
+
+      assertEquals(error.cause, cause);
+    });
   });
 
   describe("RFC 9457 compliance", () => {
@@ -210,7 +236,7 @@ describe("error-registry", () => {
       assertExists(rfc9457.suggestion);
     });
 
-    it("should include cause in RFC 9457 response when provided", () => {
+    it("should include cause in RFC 9457 response when provided as string", () => {
       const error = BUILD_FAILED.create({
         detail: "Build failed due to TypeScript errors",
         cause: "typescript-error",
@@ -218,6 +244,16 @@ describe("error-registry", () => {
 
       const rfc9457 = error.toRFC9457();
       assertEquals(rfc9457.cause, "typescript-error");
+    });
+
+    it("should omit non-string cause from RFC 9457 response", () => {
+      const error = FALLBACK_EXHAUSTED.create({
+        detail: "Both operations failed",
+        cause: new Error("original"),
+      });
+
+      const rfc9457 = error.toRFC9457();
+      assertEquals(rfc9457.cause, undefined);
     });
 
     it("should have type URI that matches docs URL", () => {
@@ -251,17 +287,17 @@ describe("error-registry", () => {
 
   describe("error categories coverage", () => {
     const expectedCategoryCounts: Record<string, number> = {
-      CONFIG: 7,
+      CONFIG: 8,
       BUILD: 8,
       RUNTIME: 7,
       ROUTE: 6,
       MODULE: 6,
-      SERVER: 8,
+      SERVER: 12,
       BOUNDARY: 6,
       DEV: 5,
       DEPLOY: 4,
       AGENT: 5,
-      GENERAL: 7,
+      GENERAL: 9,
     };
 
     for (const [category, count] of Object.entries(expectedCategoryCounts)) {
@@ -274,5 +310,94 @@ describe("error-registry", () => {
         );
       });
     }
+  });
+
+  // =========================================================================
+  // Scattered error migration tests
+  // =========================================================================
+
+  describe("API_CLIENT_ERROR", () => {
+    it("should preserve status and context", () => {
+      const error = API_CLIENT_ERROR.create({
+        detail: "Not found",
+        status: 404,
+        context: { endpoint: "/api/users" },
+      });
+      assertEquals(error.slug, "api-client-error");
+      assertEquals(error.status, 404);
+      assertEquals((error.context as Record<string, unknown>).endpoint, "/api/users");
+    });
+
+    it("should use title as message when no detail", () => {
+      const error = API_CLIENT_ERROR.create();
+      assertEquals(error.message, "API client request failed");
+      assertEquals(error.detail, undefined);
+    });
+  });
+
+  describe("CONFIG_VALIDATION_FAILED", () => {
+    it("should default to status 400", () => {
+      const error = CONFIG_VALIDATION_FAILED.create({ detail: "Invalid port" });
+      assertEquals(error.slug, "config-validation-failed");
+      assertEquals(error.status, 400);
+    });
+  });
+
+  describe("SECURITY_VIOLATION", () => {
+    it("should default to status 403", () => {
+      const error = SECURITY_VIOLATION.create({
+        detail: "Path traversal detected",
+        context: { path: "../etc/passwd", code: "TRAVERSAL" },
+      });
+      assertEquals(error.slug, "security-violation");
+      assertEquals(error.status, 403);
+      assertEquals((error.context as Record<string, unknown>).path, "../etc/passwd");
+    });
+  });
+
+  describe("INPUT_VALIDATION_FAILED", () => {
+    it("should default to status 400", () => {
+      const error = INPUT_VALIDATION_FAILED.create({
+        detail: "URL too long",
+        context: { maxLength: 2048 },
+      });
+      assertEquals(error.slug, "input-validation-failed");
+      assertEquals(error.status, 400);
+    });
+  });
+
+  describe("TOKEN_STORAGE_ERROR", () => {
+    it("should preserve status from response", () => {
+      const error = TOKEN_STORAGE_ERROR.create({
+        detail: "Failed to get token",
+        status: 503,
+      });
+      assertEquals(error.slug, "token-storage-error");
+      assertEquals(error.status, 503);
+    });
+  });
+
+  describe("CACHE_INVARIANT_VIOLATION", () => {
+    it("should default to status 500", () => {
+      const error = CACHE_INVARIANT_VIOLATION.create({
+        detail: "Hardcoded paths in portable code",
+      });
+      assertEquals(error.slug, "cache-invariant-violation");
+      assertEquals(error.status, 500);
+    });
+  });
+
+  describe("FALLBACK_EXHAUSTED", () => {
+    it("should chain cause errors", () => {
+      const primary = new Error("primary failed");
+      const error = FALLBACK_EXHAUSTED.create({
+        detail: "Both primary and fallback failed",
+        cause: primary,
+        context: { operationName: "readFile" },
+      });
+      assertEquals(error.slug, "fallback-exhausted");
+      assertEquals(error.status, 500);
+      assertEquals(error.cause, primary);
+    });
   });
 });

--- a/src/errors/error-registry.ts
+++ b/src/errors/error-registry.ts
@@ -60,6 +60,15 @@ export const CORS_CONFIG_INVALID = defineError({
   suggestion: "Review CORS settings in your configuration",
 });
 
+/** Config file validation failures (replaces ConfigValidationError) */
+export const CONFIG_VALIDATION_FAILED = defineError({
+  slug: "config-validation-failed",
+  category: "CONFIG",
+  status: 400,
+  title: "Configuration validation failed",
+  suggestion: "Check configuration values against requirements",
+});
+
 // =============================================================================
 // BUILD - Build & compilation errors
 // =============================================================================
@@ -360,6 +369,42 @@ export const NETWORK_ERROR = defineError({
   suggestion: "Check network connectivity and retry",
 });
 
+/** API client request/response errors (replaces VeryfrontAPIError) */
+export const API_CLIENT_ERROR = defineError({
+  slug: "api-client-error",
+  category: "SERVER",
+  status: 500,
+  title: "API client request failed",
+  suggestion: "Check API connectivity and authentication",
+});
+
+/** Token storage adapter failures (replaces TokenStorageError) */
+export const TOKEN_STORAGE_ERROR = defineError({
+  slug: "token-storage-error",
+  category: "SERVER",
+  status: 500,
+  title: "Token storage operation failed",
+  suggestion: "Check token storage backend and credentials",
+});
+
+/** Cache path invariant violations (replaces CacheInvariantError) */
+export const CACHE_INVARIANT_VIOLATION = defineError({
+  slug: "cache-invariant-violation",
+  category: "SERVER",
+  status: 500,
+  title: "Cache path invariant violated",
+  suggestion: "Clear the cache and rebuild",
+});
+
+/** Both primary and fallback operations failed (replaces FallbackExecutionError) */
+export const FALLBACK_EXHAUSTED = defineError({
+  slug: "fallback-exhausted",
+  category: "SERVER",
+  status: 500,
+  title: "Primary and fallback operations both failed",
+  suggestion: "Check service availability and connectivity",
+});
+
 // =============================================================================
 // BOUNDARY - RSC/client boundary violations
 // =============================================================================
@@ -596,6 +641,24 @@ export const NOT_SUPPORTED = defineError({
   suggestion: "Check documentation for supported features",
 });
 
+/** Path traversal / secure-fs violations (replaces SecurityError) */
+export const SECURITY_VIOLATION = defineError({
+  slug: "security-violation",
+  category: "GENERAL",
+  status: 403,
+  title: "Security violation detected",
+  suggestion: "Check for path traversal or unauthorized access attempts",
+});
+
+/** HTTP request input validation failures (replaces ValidationError) */
+export const INPUT_VALIDATION_FAILED = defineError({
+  slug: "input-validation-failed",
+  category: "GENERAL",
+  status: 400,
+  title: "Input validation failed",
+  suggestion: "Check request input against validation rules",
+});
+
 // =============================================================================
 // Registry exports
 // =============================================================================
@@ -612,6 +675,7 @@ export const ERROR_REGISTRY = {
   "config-type-error": CONFIG_TYPE_ERROR,
   "import-map-invalid": IMPORT_MAP_INVALID,
   "cors-config-invalid": CORS_CONFIG_INVALID,
+  "config-validation-failed": CONFIG_VALIDATION_FAILED,
 
   // BUILD
   "build-failed": BUILD_FAILED,
@@ -657,6 +721,10 @@ export const ERROR_REGISTRY = {
   "service-overloaded": SERVICE_OVERLOADED,
   "cache-path-mismatch": CACHE_PATH_MISMATCH,
   "network-error": NETWORK_ERROR,
+  "api-client-error": API_CLIENT_ERROR,
+  "token-storage-error": TOKEN_STORAGE_ERROR,
+  "cache-invariant-violation": CACHE_INVARIANT_VIOLATION,
+  "fallback-exhausted": FALLBACK_EXHAUSTED,
 
   // BOUNDARY
   "client-boundary-violation": CLIENT_BOUNDARY_VIOLATION,
@@ -694,6 +762,8 @@ export const ERROR_REGISTRY = {
   "timeout-error": TIMEOUT_ERROR,
   "initialization-error": INITIALIZATION_ERROR,
   "not-supported": NOT_SUPPORTED,
+  "security-violation": SECURITY_VIOLATION,
+  "input-validation-failed": INPUT_VALIDATION_FAILED,
 } as const;
 
 export type ErrorSlug = keyof typeof ERROR_REGISTRY;

--- a/src/errors/error-registry.ts
+++ b/src/errors/error-registry.ts
@@ -28,6 +28,7 @@ export const CONFIG_PARSE_ERROR = defineError({
   suggestion: "Ensure your configuration file is valid TypeScript/JSON",
 });
 
+/** Schema-level config validation (e.g. Zod schema mismatch at runtime) */
 export const CONFIG_VALIDATION_ERROR = defineError({
   slug: "config-validation-error",
   category: "CONFIG",

--- a/src/errors/types.ts
+++ b/src/errors/types.ts
@@ -44,9 +44,11 @@ export interface ErrorDefinition {
  */
 export interface ErrorCreateOptions {
   detail?: string;
-  cause?: string;
+  cause?: unknown;
   instance?: string;
   context?: unknown;
+  /** Override the definition's default HTTP status (e.g., for per-request status codes) */
+  status?: number;
 }
 
 /**
@@ -63,10 +65,10 @@ export function defineError(definition: ErrorDefinition): RegisteredError {
   return {
     ...definition,
     create(options?: ErrorCreateOptions): VeryfrontError {
-      return new VeryfrontError(definition.title, {
+      return new VeryfrontError(options?.detail || definition.title, {
         slug: definition.slug,
         category: definition.category,
-        status: definition.status,
+        status: options?.status ?? definition.status,
         title: definition.title,
         suggestion: definition.suggestion,
         detail: options?.detail,
@@ -93,14 +95,13 @@ export interface VeryfrontErrorOptions extends ErrorCreateOptions {
  * Veryfront Error class with slug-based error identity
  */
 export class VeryfrontError extends Error {
-  // Slug-based properties
   public slug: string;
   public category: ErrorCategory;
   public status: number;
   public title: string;
   public suggestion?: string;
   public detail?: string;
-  public override cause?: string;
+  public override cause?: unknown;
   public instance?: string;
   public context?: unknown;
 
@@ -131,7 +132,7 @@ export class VeryfrontError extends Error {
       instance: this.instance,
       category: this.category,
       suggestion: this.suggestion,
-      cause: this.cause,
+      cause: typeof this.cause === "string" ? this.cause : undefined,
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,11 +31,12 @@ export type { APIContext, APIHandler, APIResponse, APIRoute } from "#veryfront/r
 export {
   CommonSchemas,
   createValidatedHandler,
+  createValidationError,
+  INPUT_VALIDATION_FAILED,
   parseFormData,
   parseJsonBody,
   parseQueryParams,
   sanitizeData,
-  ValidationError,
 } from "#veryfront/security";
 export type { ValidatedHandlerConfig, ValidatedHandlerFunction } from "#veryfront/security";
 

--- a/src/platform/adapters/fallback-wrapper.test.ts
+++ b/src/platform/adapters/fallback-wrapper.test.ts
@@ -4,10 +4,11 @@ import { delay } from "#std/async.ts";
 import {
   createAdapterFallback,
   createAdapterFallbackSync,
-  FallbackExecutionError,
+  FALLBACK_EXHAUSTED,
   withFallback,
   withFallbackSync,
 } from "./fallback-wrapper.ts";
+import { VeryfrontError } from "#veryfront/errors/types.ts";
 
 describe("fallback-wrapper", () => {
   describe("withFallback", () => {
@@ -34,7 +35,7 @@ describe("fallback-wrapper", () => {
       assertEquals(result, "fallback-success");
     });
 
-    it("should throw FallbackExecutionError when both fail", async () => {
+    it("should throw VeryfrontError with fallback-exhausted slug when both fail", async () => {
       const primaryError = new Error("primary-error");
       const fallbackError = new Error("fallback-error");
 
@@ -47,7 +48,7 @@ describe("fallback-wrapper", () => {
             operationName: "test-operation",
             logError: false,
           }),
-        FallbackExecutionError,
+        VeryfrontError,
         "Both primary and fallback operations failed for test-operation",
       );
     });
@@ -71,21 +72,12 @@ describe("fallback-wrapper", () => {
       );
     });
 
-    it("should preserve error context in FallbackExecutionError", async () => {
+    it("should preserve error context in fallback-exhausted error", async () => {
       const primaryError = new Error("primary-error");
       const fallbackError = new Error("fallback-error");
 
       const primary = () => Promise.reject(primaryError);
       const fallback = () => Promise.reject(fallbackError);
-
-      await assertRejects(
-        () =>
-          withFallback(primary, fallback, {
-            operationName: "test-operation",
-            logError: false,
-          }),
-        FallbackExecutionError,
-      );
 
       try {
         await withFallback(primary, fallback, {
@@ -94,9 +86,11 @@ describe("fallback-wrapper", () => {
         });
         throw new Error("Should have thrown");
       } catch (error) {
-        if (!(error instanceof FallbackExecutionError)) throw error;
-        assertEquals(error.primaryError, primaryError);
-        assertEquals(error.fallbackError, fallbackError);
+        if (!(error instanceof VeryfrontError && error.slug === "fallback-exhausted")) throw error;
+        const ctx = error.context as { primaryError: unknown; fallbackError: unknown };
+        assertEquals(ctx.primaryError, primaryError);
+        assertEquals(ctx.fallbackError, fallbackError);
+        assertEquals(error.cause, primaryError);
       }
     });
 
@@ -153,7 +147,7 @@ describe("fallback-wrapper", () => {
       assertEquals(result, "fallback-success");
     });
 
-    it("should throw FallbackExecutionError when both fail", () => {
+    it("should throw VeryfrontError with fallback-exhausted slug when both fail", () => {
       const primaryError = new Error("primary-error");
       const fallbackError = new Error("fallback-error");
 
@@ -171,7 +165,7 @@ describe("fallback-wrapper", () => {
         });
         throw new Error("Should have thrown");
       } catch (error) {
-        if (!(error instanceof FallbackExecutionError)) throw error;
+        if (!(error instanceof VeryfrontError && error.slug === "fallback-exhausted")) throw error;
         assertEquals(
           error.message,
           "Both primary and fallback operations failed for test-operation",
@@ -372,30 +366,28 @@ describe("fallback-wrapper", () => {
     });
   });
 
-  describe("FallbackExecutionError", () => {
-    it("should store both primary and fallback errors", () => {
+  describe("FALLBACK_EXHAUSTED", () => {
+    it("should create error with slug and context", () => {
       const primaryError = new Error("primary");
-      const fallbackError = new Error("fallback");
 
-      const error = new FallbackExecutionError(
-        "Both failed",
-        primaryError,
-        fallbackError,
-      );
+      const error = FALLBACK_EXHAUSTED.create({
+        detail: "Both failed",
+        cause: primaryError,
+        context: { primaryError, fallbackError: new Error("fallback") },
+      });
 
-      assertEquals(error.name, "FallbackExecutionError");
+      assertEquals(error.slug, "fallback-exhausted");
       assertEquals(error.message, "Both failed");
-      assertEquals(error.primaryError, primaryError);
-      assertEquals(error.fallbackError, fallbackError);
+      assertEquals(error.cause, primaryError);
+      const ctx = error.context as { primaryError: unknown; fallbackError: unknown };
+      assertEquals(ctx.primaryError, primaryError);
     });
 
-    it("should work without fallback error", () => {
-      const primaryError = new Error("primary");
+    it("should work without cause", () => {
+      const error = FALLBACK_EXHAUSTED.create({ detail: "Primary failed" });
 
-      const error = new FallbackExecutionError("Primary failed", primaryError);
-
-      assertEquals(error.primaryError, primaryError);
-      assertEquals(error.fallbackError, undefined);
+      assertEquals(error.slug, "fallback-exhausted");
+      assertEquals(error.cause, undefined);
     });
   });
 });

--- a/src/platform/adapters/fallback-wrapper.ts
+++ b/src/platform/adapters/fallback-wrapper.ts
@@ -1,20 +1,12 @@
 import { logger } from "#veryfront/utils";
+import { FALLBACK_EXHAUSTED } from "#veryfront/errors/error-registry.ts";
+
+export { FALLBACK_EXHAUSTED } from "#veryfront/errors/error-registry.ts";
 
 export interface FallbackOptions {
   operationName: string;
   logError?: boolean;
   rethrowOnFallbackFailure?: boolean;
-}
-
-export class FallbackExecutionError extends Error {
-  constructor(
-    message: string,
-    public readonly primaryError: unknown,
-    public readonly fallbackError?: unknown,
-  ) {
-    super(message);
-    this.name = "FallbackExecutionError";
-  }
 }
 
 function logPrimaryFailure(operationName: string, error: unknown): void {
@@ -43,11 +35,11 @@ function handleFallbackFailure(
   }
 
   if (rethrowOnFallbackFailure) {
-    throw new FallbackExecutionError(
-      `Both primary and fallback operations failed for ${operationName}`,
-      primaryError,
-      fallbackError,
-    );
+    throw FALLBACK_EXHAUSTED.create({
+      detail: `Both primary and fallback operations failed for ${operationName}`,
+      cause: primaryError,
+      context: { operationName, primaryError, fallbackError },
+    });
   }
 
   throw fallbackError;

--- a/src/platform/adapters/index.test.ts
+++ b/src/platform/adapters/index.test.ts
@@ -57,8 +57,12 @@ describe("adapters/index.ts exports", () => {
       await assertExport("VeryfrontAPIClient", "function");
     });
 
-    it("should export VeryfrontAPIError", async () => {
-      await assertExport("VeryfrontAPIError", "function");
+    it("should export API_CLIENT_ERROR", async () => {
+      await assertExport("API_CLIENT_ERROR", "object");
+    });
+
+    it("should export VeryfrontError", async () => {
+      await assertExport("VeryfrontError", "function");
     });
   });
 
@@ -75,8 +79,8 @@ describe("adapters/index.ts exports", () => {
       await assertExport("VeryfrontTokenAdapter", "function");
     });
 
-    it("should export TokenStorageError", async () => {
-      await assertExport("TokenStorageError", "function");
+    it("should export TOKEN_STORAGE_ERROR", async () => {
+      await assertExport("TOKEN_STORAGE_ERROR", "object");
     });
   });
 
@@ -89,8 +93,8 @@ describe("adapters/index.ts exports", () => {
       await assertExport("withFallback", "function");
     });
 
-    it("should export FallbackExecutionError", async () => {
-      await assertExport("FallbackExecutionError", "function");
+    it("should export FALLBACK_EXHAUSTED", async () => {
+      await assertExport("FALLBACK_EXHAUSTED", "object");
     });
   });
 

--- a/src/platform/adapters/index.ts
+++ b/src/platform/adapters/index.ts
@@ -33,6 +33,7 @@ export type {
 } from "./fs/index.ts";
 
 export {
+  API_CLIENT_ERROR,
   type FileContext,
   type FileDetail,
   type FileListResult,
@@ -42,7 +43,7 @@ export {
   type ProjectFile,
   VeryfrontAPIClient,
   type VeryfrontAPIConfig,
-  VeryfrontAPIError,
+  VeryfrontError,
 } from "./veryfront-api-client/index.ts";
 
 export {
@@ -52,10 +53,10 @@ export {
   isTokenStorageConfigured,
   MemoryTokenAdapter,
   resetTokenStorageAdapter,
+  TOKEN_STORAGE_ERROR,
   type TokenStorageAdapter,
   type TokenStorageAdapterConfig,
   TokenStorageAPIClient,
-  TokenStorageError,
   VeryfrontTokenAdapter,
   type VeryfrontTokenConfig,
 } from "./token/index.ts";
@@ -64,7 +65,7 @@ export {
   type AsyncAdapterFallback,
   createAdapterFallback,
   createAdapterFallbackSync,
-  FallbackExecutionError,
+  FALLBACK_EXHAUSTED,
   type FallbackOptions,
   type SyncAdapterFallback,
   withFallback,

--- a/src/platform/adapters/token/index.test.ts
+++ b/src/platform/adapters/token/index.test.ts
@@ -16,7 +16,12 @@ describe("token/index.ts exports", () => {
   it("should export MemoryTokenAdapter", () => assertExportedFunction("MemoryTokenAdapter"));
   it("should export VeryfrontTokenAdapter", () => assertExportedFunction("VeryfrontTokenAdapter"));
   it("should export TokenStorageAPIClient", () => assertExportedFunction("TokenStorageAPIClient"));
-  it("should export TokenStorageError", () => assertExportedFunction("TokenStorageError"));
+  it("should export TOKEN_STORAGE_ERROR", async () => {
+    const mod = await getModule();
+    const value = mod["TOKEN_STORAGE_ERROR" as keyof typeof mod];
+    assertExists(value);
+    assertEquals(typeof value, "object");
+  });
   it("should export createTokenStorageAdapter", () =>
     assertExportedFunction("createTokenStorageAdapter"));
 

--- a/src/platform/adapters/token/index.ts
+++ b/src/platform/adapters/token/index.ts
@@ -1,9 +1,9 @@
 export {
   MemoryTokenAdapter,
+  TOKEN_STORAGE_ERROR,
   type TokenStorageAdapter,
   type TokenStorageAdapterConfig,
   TokenStorageAPIClient,
-  TokenStorageError,
   VeryfrontTokenAdapter,
   type VeryfrontTokenConfig,
 } from "./veryfront/index.ts";

--- a/src/platform/adapters/token/veryfront/api-client.ts
+++ b/src/platform/adapters/token/veryfront/api-client.ts
@@ -1,6 +1,8 @@
 import { logger } from "#veryfront/utils";
 import { injectContext } from "#veryfront/observability/tracing/otlp-setup.ts";
-import { TokenStorageError, type VeryfrontTokenConfig } from "./types.ts";
+import { type VeryfrontTokenConfig } from "./types.ts";
+import { TOKEN_STORAGE_ERROR } from "#veryfront/errors/error-registry.ts";
+import { VeryfrontError } from "#veryfront/errors/types.ts";
 
 /** Default timeout for token storage API requests (30 seconds) */
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
@@ -26,10 +28,10 @@ export class TokenStorageAPIClient {
       }
 
       if (!response.ok) {
-        throw new TokenStorageError(
-          `Failed to get token: ${response.statusText}`,
-          response.status,
-        );
+        throw TOKEN_STORAGE_ERROR.create({
+          detail: `Failed to get token: ${response.statusText}`,
+          status: response.status,
+        });
       }
 
       const data: { value: string } = await response.json();
@@ -53,10 +55,10 @@ export class TokenStorageAPIClient {
       });
 
       if (!response.ok) {
-        throw new TokenStorageError(
-          `Failed to set token: ${response.statusText}`,
-          response.status,
-        );
+        throw TOKEN_STORAGE_ERROR.create({
+          detail: `Failed to set token: ${response.statusText}`,
+          status: response.status,
+        });
       }
     } catch (error) {
       throw this.wrapError(error, "Set", key, `Failed to set token`);
@@ -76,10 +78,10 @@ export class TokenStorageAPIClient {
         return;
       }
 
-      throw new TokenStorageError(
-        `Failed to delete token: ${response.statusText}`,
-        response.status,
-      );
+      throw TOKEN_STORAGE_ERROR.create({
+        detail: `Failed to delete token: ${response.statusText}`,
+        status: response.status,
+      });
     } catch (error) {
       throw this.wrapError(error, "Delete", key, `Failed to delete token`);
     }
@@ -102,16 +104,16 @@ export class TokenStorageAPIClient {
       });
 
       if (!response.ok) {
-        throw new TokenStorageError(
-          `Failed to list tokens: ${response.statusText}`,
-          response.status,
-        );
+        throw TOKEN_STORAGE_ERROR.create({
+          detail: `Failed to list tokens: ${response.statusText}`,
+          status: response.status,
+        });
       }
 
       const data: { keys?: string[] } = await response.json();
       return data.keys ?? [];
     } catch (error) {
-      if (error instanceof TokenStorageError) {
+      if (error instanceof VeryfrontError && error.slug === "token-storage-error") {
         throw error;
       }
 
@@ -122,7 +124,7 @@ export class TokenStorageAPIClient {
         error: message,
       });
 
-      throw new TokenStorageError(`Failed to list tokens: ${message}`);
+      throw TOKEN_STORAGE_ERROR.create({ detail: `Failed to list tokens: ${message}` });
     }
   }
 
@@ -155,8 +157,8 @@ export class TokenStorageAPIClient {
     action: "Get" | "Set" | "Delete",
     key: string,
     prefixMessage: string,
-  ): TokenStorageError {
-    if (error instanceof TokenStorageError) {
+  ): VeryfrontError {
+    if (error instanceof VeryfrontError && error.slug === "token-storage-error") {
       return error;
     }
 
@@ -164,7 +166,7 @@ export class TokenStorageAPIClient {
 
     logger.error(`[TokenStorageAPIClient] ${action} failed`, { key, error: message });
 
-    return new TokenStorageError(`${prefixMessage}: ${message}`);
+    return TOKEN_STORAGE_ERROR.create({ detail: `${prefixMessage}: ${message}` });
   }
 
   private async fetchWithRetry(url: string, init: RequestInit): Promise<Response> {
@@ -227,8 +229,8 @@ export class TokenStorageAPIClient {
       }
     }
 
-    throw new TokenStorageError(
-      `Request failed after ${maxRetries} retries: ${lastError?.message}`,
-    );
+    throw TOKEN_STORAGE_ERROR.create({
+      detail: `Request failed after ${maxRetries} retries: ${lastError?.message}`,
+    });
   }
 }

--- a/src/platform/adapters/token/veryfront/index.ts
+++ b/src/platform/adapters/token/veryfront/index.ts
@@ -3,8 +3,8 @@ export { VeryfrontTokenAdapter } from "./adapter.ts";
 export { MemoryTokenAdapter } from "./memory-adapter.ts";
 export {
   createTokenConfig,
+  TOKEN_STORAGE_ERROR,
   type TokenStorageAdapter,
   type TokenStorageAdapterConfig,
-  TokenStorageError,
   type VeryfrontTokenConfig,
 } from "./types.ts";

--- a/src/platform/adapters/token/veryfront/types.ts
+++ b/src/platform/adapters/token/veryfront/types.ts
@@ -128,17 +128,4 @@ export function createTokenConfig(config: TokenStorageAdapterConfig): VeryfrontT
   };
 }
 
-/**
- * Error thrown by token storage operations
- */
-export class TokenStorageError extends Error {
-  public readonly statusCode?: number;
-  public readonly details?: Record<string, unknown>;
-
-  constructor(message: string, statusCode?: number, details?: Record<string, unknown>) {
-    super(message);
-    this.name = "TokenStorageError";
-    this.statusCode = statusCode;
-    this.details = details;
-  }
-}
+export { TOKEN_STORAGE_ERROR } from "#veryfront/errors/error-registry.ts";

--- a/src/platform/adapters/veryfront-api-client.test.ts
+++ b/src/platform/adapters/veryfront-api-client.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
-import { VeryfrontAPIClient, VeryfrontAPIError } from "./veryfront-api-client/index.ts";
+import { VeryfrontAPIClient, VeryfrontError } from "./veryfront-api-client/index.ts";
 
 function withMockFetch<T>(
   mockFetch: typeof globalThis.fetch,
@@ -14,9 +14,9 @@ function withMockFetch<T>(
   });
 }
 
-function assertVeryfrontError(error: unknown): VeryfrontAPIError {
-  assertEquals(error instanceof VeryfrontAPIError, true);
-  return error as VeryfrontAPIError;
+function assertVeryfrontError(error: unknown): VeryfrontError {
+  assertEquals(error instanceof VeryfrontError, true);
+  return error as VeryfrontError;
 }
 
 describe("VeryfrontAPIClient", () => {

--- a/src/platform/adapters/veryfront-api-client/client.test.ts
+++ b/src/platform/adapters/veryfront-api-client/client.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { VeryfrontAPIClient } from "./client.ts";
-import { VeryfrontAPIError } from "./types.ts";
+import { VeryfrontError } from "#veryfront/errors/types.ts";
 
 const baseConfig = {
   apiBaseUrl: "http://test.api",
@@ -35,7 +35,7 @@ describe("VeryfrontAPIClient", () => {
 
     it("throws when no token available", () => {
       const client = createClient({ apiBaseUrl: "http://test.api" });
-      assertThrows(() => client.getToken(), VeryfrontAPIError, "No API token available");
+      assertThrows(() => client.getToken(), VeryfrontError, "No API token available");
     });
   });
 
@@ -114,7 +114,7 @@ describe("VeryfrontAPIClient", () => {
       const client = createClient({ apiBaseUrl: "http://test.api", apiToken: "token" });
       await assertRejects(
         () => client.initialize(),
-        VeryfrontAPIError,
+        VeryfrontError,
         "No project slug available",
       );
     });
@@ -140,7 +140,7 @@ describe("VeryfrontAPIClient", () => {
       const client = createClient();
       assertThrows(
         () => client.listPublishedFiles(undefined, undefined, undefined),
-        VeryfrontAPIError,
+        VeryfrontError,
         "Cannot list published files without releaseId or environmentName",
       );
     });
@@ -149,7 +149,7 @@ describe("VeryfrontAPIClient", () => {
       const client = createClient();
       await assertRejects(
         () => client.getPublishedFileContent("pages/index.mdx"),
-        VeryfrontAPIError,
+        VeryfrontError,
         "Cannot fetch published file without releaseId or environmentName",
       );
     });

--- a/src/platform/adapters/veryfront-api-client/client.ts
+++ b/src/platform/adapters/veryfront-api-client/client.ts
@@ -6,7 +6,7 @@ import {
   type TokenProvider,
   VeryfrontAPIOperations,
 } from "./operations.ts";
-import { type VeryfrontAPIConfig, VeryfrontAPIError } from "./types.ts";
+import { API_CLIENT_ERROR, type VeryfrontAPIConfig } from "./types.ts";
 
 /**
  * File context for API operations.
@@ -45,7 +45,7 @@ export class VeryfrontAPIClient {
     const tokenProvider: TokenProvider = () => {
       if (this.requestToken) return this.requestToken;
       if (this.config.apiToken) return this.config.apiToken;
-      throw new VeryfrontAPIError("No API token available", 401);
+      throw API_CLIENT_ERROR.create({ detail: "No API token available", status: 401 });
     };
 
     this.operations = new VeryfrontAPIOperations(
@@ -166,7 +166,10 @@ export class VeryfrontAPIClient {
     logger.debug("[VeryfrontAPIClient] doInitialize START", { slug });
 
     if (!slug) {
-      throw new VeryfrontAPIError("No project slug available for initialization", 400);
+      throw API_CLIENT_ERROR.create({
+        detail: "No project slug available for initialization",
+        status: 400,
+      });
     }
 
     if (this.config.projectId) {
@@ -445,10 +448,10 @@ export class VeryfrontAPIClient {
       return this.operations.listAllEnvironmentFiles(projectRef, environmentName);
     }
 
-    throw new VeryfrontAPIError(
-      "Cannot list published files without releaseId or environmentName",
-      400,
-    );
+    throw API_CLIENT_ERROR.create({
+      detail: "Cannot list published files without releaseId or environmentName",
+      status: 400,
+    });
   }
 
   async getPublishedFileContent(
@@ -468,9 +471,9 @@ export class VeryfrontAPIClient {
       return result.content;
     }
 
-    throw new VeryfrontAPIError(
-      "Cannot fetch published file without releaseId or environmentName",
-      400,
-    );
+    throw API_CLIENT_ERROR.create({
+      detail: "Cannot fetch published file without releaseId or environmentName",
+      status: 400,
+    });
   }
 }

--- a/src/platform/adapters/veryfront-api-client/index.test.ts
+++ b/src/platform/adapters/veryfront-api-client/index.test.ts
@@ -9,7 +9,8 @@ describe("veryfront-api-client/index.ts exports", () => {
       ["VeryfrontAPIClient", "function"],
       ["VeryfrontAPIOperations", "function"],
       ["requestWithRetry", "function"],
-      ["VeryfrontAPIError", "function"],
+      ["API_CLIENT_ERROR", "object"],
+      ["VeryfrontError", "function"],
       ["API_ENDPOINTS", "object"],
     ];
 

--- a/src/platform/adapters/veryfront-api-client/index.ts
+++ b/src/platform/adapters/veryfront-api-client/index.ts
@@ -7,13 +7,14 @@ export {
 } from "./operations.ts";
 export { type RequestOptions, requestWithRetry, type RetryConfig } from "./retry-handler.ts";
 export {
+  API_CLIENT_ERROR,
   type Environment,
   type LookupDomainResponse,
   type PageInfo,
   type Project,
   type ProjectFile,
   type VeryfrontAPIConfig,
-  VeryfrontAPIError,
+  VeryfrontError,
 } from "./types.ts";
 export {
   API_ENDPOINTS,

--- a/src/platform/adapters/veryfront-api-client/operations.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.ts
@@ -1,7 +1,7 @@
 import { logger } from "#veryfront/utils";
 import { z } from "zod";
 import { requestWithRetry, type RetryConfig } from "./retry-handler.ts";
-import { VeryfrontAPIError } from "./types.ts";
+import { API_CLIENT_ERROR } from "./types.ts";
 import {
   BranchFileDetailSchema,
   EnvironmentFileDetailSchema,
@@ -120,9 +120,9 @@ export class VeryfrontAPIOperations {
   getProjectId(): string {
     if (this.projectId) return this.projectId;
 
-    throw new VeryfrontAPIError(
-      "Veryfront API client not initialized. Call initialize() with a project ID first.",
-    );
+    throw API_CLIENT_ERROR.create({
+      detail: "Veryfront API client not initialized. Call initialize() with a project ID first.",
+    });
   }
 
   async listProjects(options?: {

--- a/src/platform/adapters/veryfront-api-client/retry-handler.test.ts
+++ b/src/platform/adapters/veryfront-api-client/retry-handler.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { requestWithRetry } from "./retry-handler.ts";
-import { VeryfrontAPIError } from "./types.ts";
+import { VeryfrontError } from "#veryfront/errors/types.ts";
 
 const originalFetch = globalThis.fetch;
 
@@ -13,11 +13,11 @@ function setFetch(
 
 async function captureVeryfrontError(
   fn: () => Promise<unknown>,
-): Promise<VeryfrontAPIError> {
+): Promise<VeryfrontError> {
   try {
     await fn();
   } catch (e) {
-    return e as VeryfrontAPIError;
+    return e as VeryfrontError;
   }
   throw new Error("Expected function to throw");
 }

--- a/src/platform/adapters/veryfront-api-client/retry-handler.ts
+++ b/src/platform/adapters/veryfront-api-client/retry-handler.ts
@@ -2,7 +2,7 @@ import { logger } from "#veryfront/utils";
 import { injectContext, withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { SpanNames } from "#veryfront/observability/tracing/span-names.ts";
 import { recordApiRequest, recordApiRetry } from "#veryfront/observability/simple-metrics/index.ts";
-import { VeryfrontAPIError } from "./types.ts";
+import { API_CLIENT_ERROR, VeryfrontError } from "./types.ts";
 
 export interface RetryConfig {
   maxRetries: number;
@@ -71,11 +71,11 @@ export async function requestWithRetry(
               responseText: text.slice(0, 500),
             });
 
-            throw new VeryfrontAPIError(
-              `API request failed: ${response.status} ${response.statusText}`,
-              response.status,
-              { url, responseText: text },
-            );
+            throw API_CLIENT_ERROR.create({
+              detail: `API request failed: ${response.status} ${response.statusText}`,
+              status: response.status,
+              context: { details: { url, responseText: text } },
+            });
           }
 
           const data = options.returnText ? await response.text() : await response.json();
@@ -104,7 +104,7 @@ export async function requestWithRetry(
         });
       }
 
-      if (error instanceof VeryfrontAPIError) {
+      if (error instanceof VeryfrontError && error.slug === "api-client-error") {
         const status = error.status;
         if (status && status >= 400 && status < 500 && status !== 429) {
           throw error;
@@ -133,9 +133,9 @@ export async function requestWithRetry(
     }
   }
 
-  throw new VeryfrontAPIError(
-    `API request failed after ${maxRetries} retries: ${lastError?.message}`,
-    undefined,
-    { originalError: lastError },
-  );
+  throw API_CLIENT_ERROR.create({
+    detail: `API request failed after ${maxRetries} retries: ${lastError?.message}`,
+    cause: lastError ?? undefined,
+    context: { details: { originalError: lastError } },
+  });
 }

--- a/src/platform/adapters/veryfront-api-client/types.ts
+++ b/src/platform/adapters/veryfront-api-client/types.ts
@@ -29,14 +29,5 @@ export interface VeryfrontAPIConfig {
   };
 }
 
-export class VeryfrontAPIError extends Error {
-  public status?: number;
-  public details?: unknown;
-
-  constructor(message: string, status?: number, details?: unknown) {
-    super(message);
-    this.name = "VeryfrontAPIError";
-    this.status = status;
-    this.details = details;
-  }
-}
+export { API_CLIENT_ERROR } from "#veryfront/errors/error-registry.ts";
+export { VeryfrontError } from "#veryfront/errors/types.ts";

--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -4,14 +4,15 @@ export type { HandlerHelpers } from "./http/base-handler.ts";
 export {
   CommonSchemas,
   createValidatedHandler,
+  createValidationError,
   DEFAULT_LIMITS,
+  INPUT_VALIDATION_FAILED,
   parseFormData,
   parseJsonBody,
   parseQueryParams,
   readBodyWithLimit,
   sanitizeData,
   validateRequestLimits,
-  ValidationError,
 } from "./input-validation/index.ts";
 export type {
   ParseFormOptions,
@@ -76,5 +77,10 @@ export {
 } from "./path-validation.ts";
 export type { ValidationLevel, ValidationOptions, ValidationResult } from "./path-validation.ts";
 
-export { createSecureFs, SecureFs, SecurityError, wrapAdapterWithSecurity } from "./secure-fs.ts";
+export {
+  createSecureFs,
+  SecureFs,
+  SECURITY_VIOLATION,
+  wrapAdapterWithSecurity,
+} from "./secure-fs.ts";
 export type { SecureFsConfig, SecurityContext, SecurityEvent } from "./secure-fs.ts";

--- a/src/security/input-validation/errors.test.ts
+++ b/src/security/input-validation/errors.test.ts
@@ -1,34 +1,34 @@
 import { assertEquals, assertInstanceOf } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { ValidationError } from "./errors.ts";
+import { createValidationError, VeryfrontError } from "./errors.ts";
 
 describe("security/input-validation/errors", () => {
-  describe("ValidationError", () => {
-    it("should extend Error", () => {
-      const error = new ValidationError("test");
+  describe("createValidationError", () => {
+    it("should create a VeryfrontError", () => {
+      const error = createValidationError("test");
       assertInstanceOf(error, Error);
-      assertInstanceOf(error, ValidationError);
+      assertInstanceOf(error, VeryfrontError);
     });
 
     it("should set message", () => {
-      const error = new ValidationError("Something went wrong");
+      const error = createValidationError("Something went wrong");
       assertEquals(error.message, "Something went wrong");
     });
 
-    it("should set name to ValidationError", () => {
-      const error = new ValidationError("test");
-      assertEquals(error.name, "ValidationError");
+    it("should set slug to input-validation-failed", () => {
+      const error = createValidationError("test");
+      assertEquals(error.slug, "input-validation-failed");
     });
 
-    it("should store details when provided", () => {
+    it("should store details in context when provided", () => {
       const details = { field: "email", code: "invalid" };
-      const error = new ValidationError("Validation failed", details);
-      assertEquals(error.details, details);
+      const error = createValidationError("Validation failed", details);
+      assertEquals((error.context as { details: unknown }).details, details);
     });
 
-    it("should have undefined details when not provided", () => {
-      const error = new ValidationError("test");
-      assertEquals(error.details, undefined);
+    it("should have undefined context when no details provided", () => {
+      const error = createValidationError("test");
+      assertEquals(error.context, undefined);
     });
 
     it("should store complex details objects", () => {
@@ -38,27 +38,22 @@ describe("security/input-validation/errors", () => {
           { path: "email", message: "Invalid format" },
         ],
       };
-      const error = new ValidationError("Multiple errors", details);
-      assertEquals(error.details, details);
+      const error = createValidationError("Multiple errors", details);
+      assertEquals((error.context as { details: unknown }).details, details);
     });
 
     it("should store primitive details", () => {
-      const error = new ValidationError("test", 42);
-      assertEquals(error.details, 42);
+      const error = createValidationError("test", 42);
+      assertEquals((error.context as { details: unknown }).details, 42);
     });
 
     it("should store string details", () => {
-      const error = new ValidationError("test", "extra info");
-      assertEquals(error.details, "extra info");
-    });
-
-    it("should store null details", () => {
-      const error = new ValidationError("test", null);
-      assertEquals(error.details, null);
+      const error = createValidationError("test", "extra info");
+      assertEquals((error.context as { details: unknown }).details, "extra info");
     });
 
     it("should have a stack trace", () => {
-      const error = new ValidationError("test");
+      const error = createValidationError("test");
       assertEquals(typeof error.stack, "string");
     });
   });

--- a/src/security/input-validation/errors.ts
+++ b/src/security/input-validation/errors.ts
@@ -1,9 +1,17 @@
-export class ValidationError extends Error {
-  public readonly details?: unknown;
+import { INPUT_VALIDATION_FAILED } from "#veryfront/errors/error-registry.ts";
+import { VeryfrontError } from "#veryfront/errors/types.ts";
 
-  constructor(message: string, details?: unknown) {
-    super(message);
-    this.name = "ValidationError";
-    this.details = details;
-  }
+export { INPUT_VALIDATION_FAILED, VeryfrontError };
+
+/**
+ * Create an input validation error.
+ * Convenience wrapper around INPUT_VALIDATION_FAILED.create().
+ *
+ * The `details` are stored in `error.context` for catch-site access.
+ */
+export function createValidationError(message: string, details?: unknown): VeryfrontError {
+  return INPUT_VALIDATION_FAILED.create({
+    detail: message,
+    context: details != null ? { details } : undefined,
+  });
 }

--- a/src/security/input-validation/handler.ts
+++ b/src/security/input-validation/handler.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ValidationError } from "./errors.ts";
+import { VeryfrontError } from "./errors.ts";
 import { parseJsonBody, parseQueryParams } from "./parsers.ts";
 import { type RequestLimits, type ValidatedData } from "./types.ts";
 
@@ -33,12 +33,13 @@ export function createValidatedHandler<TBody = unknown, TQuery = unknown>(
 
       return await handler(request, validated);
     } catch (error) {
-      if (!(error instanceof ValidationError)) {
+      if (!(error instanceof VeryfrontError && error.slug === "input-validation-failed")) {
         throw error;
       }
 
+      const details = (error.context as { details?: unknown } | undefined)?.details;
       return new Response(
-        JSON.stringify({ error: error.message, details: error.details }),
+        JSON.stringify({ error: error.message, details }),
         { status: 400, headers: { "Content-Type": "application/json" } },
       );
     }

--- a/src/security/input-validation/index.ts
+++ b/src/security/input-validation/index.ts
@@ -1,6 +1,6 @@
 export type { ParseFormOptions, ParseJsonOptions, RequestLimits, ValidatedData } from "./types.ts";
 export { DEFAULT_LIMITS } from "./types.ts";
-export { ValidationError } from "./errors.ts";
+export { createValidationError, INPUT_VALIDATION_FAILED } from "./errors.ts";
 export { readBodyWithLimit, validateRequestLimits } from "./limits.ts";
 export { parseFormData, parseJsonBody, parseQueryParams } from "./parsers.ts";
 export { sanitizeData } from "./sanitizers.ts";

--- a/src/security/input-validation/limits.test.ts
+++ b/src/security/input-validation/limits.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { ValidationError } from "./errors.ts";
+import { VeryfrontError } from "./errors.ts";
 import { readBodyWithLimit, validateRequestLimits } from "./limits.ts";
 
 describe("security/input-validation/limits", () => {
@@ -18,7 +18,7 @@ describe("security/input-validation/limits", () => {
 
       assertThrows(
         () => validateRequestLimits(req, { maxUrlLength: 100 }),
-        ValidationError,
+        VeryfrontError,
         "URL too long",
       );
     });
@@ -31,7 +31,7 @@ describe("security/input-validation/limits", () => {
 
       assertThrows(
         () => validateRequestLimits(req, { maxBodySize: 1000 }),
-        ValidationError,
+        VeryfrontError,
         "too large",
       );
     });
@@ -44,7 +44,7 @@ describe("security/input-validation/limits", () => {
 
       assertThrows(
         () => validateRequestLimits(req),
-        ValidationError,
+        VeryfrontError,
         "Invalid Content-Length",
       );
     });
@@ -60,7 +60,7 @@ describe("security/input-validation/limits", () => {
 
       assertThrows(
         () => validateRequestLimits(req, { maxHeaderSize: 1000 }),
-        ValidationError,
+        VeryfrontError,
         "Headers too large",
       );
     });
@@ -86,7 +86,7 @@ describe("security/input-validation/limits", () => {
 
       await assertRejects(
         () => readBodyWithLimit(req, 10),
-        ValidationError,
+        VeryfrontError,
         "exceeds size limit",
       );
     });
@@ -96,7 +96,7 @@ describe("security/input-validation/limits", () => {
 
       await assertRejects(
         () => readBodyWithLimit(req),
-        ValidationError,
+        VeryfrontError,
         "No request body",
       );
     });

--- a/src/security/input-validation/limits.ts
+++ b/src/security/input-validation/limits.ts
@@ -1,4 +1,4 @@
-import { ValidationError } from "./errors.ts";
+import { createValidationError } from "./errors.ts";
 import { DEFAULT_LIMITS, type RequestLimits } from "./types.ts";
 
 export function validateRequestLimits(
@@ -18,7 +18,7 @@ export function validateRequestLimits(
 function validateUrlLength(url: string, maxLength: number): void {
   if (url.length <= maxLength) return;
 
-  throw new ValidationError("URL too long", {
+  throw createValidationError("URL too long", {
     maxLength,
     actualLength: url.length,
   });
@@ -29,10 +29,10 @@ function validateContentLength(request: Request, maxSize: number): void {
   if (!contentLength) return;
 
   const size = Number.parseInt(contentLength, 10);
-  if (Number.isNaN(size)) throw new ValidationError("Invalid Content-Length header");
+  if (Number.isNaN(size)) throw createValidationError("Invalid Content-Length header");
   if (size <= maxSize) return;
 
-  throw new ValidationError("Request body too large", {
+  throw createValidationError("Request body too large", {
     maxSize,
     actualSize: size,
   });
@@ -47,7 +47,7 @@ function validateHeaderSize(request: Request, maxSize: number): void {
 
   if (headerSize <= maxSize) return;
 
-  throw new ValidationError("Headers too large", {
+  throw createValidationError("Headers too large", {
     maxSize,
     actualSize: headerSize,
   });
@@ -58,7 +58,7 @@ export async function readBodyWithLimit(
   maxSize: number = DEFAULT_LIMITS.maxBodySize,
 ): Promise<string> {
   const reader = request.body?.getReader();
-  if (!reader) throw new ValidationError("No request body");
+  if (!reader) throw createValidationError("No request body");
 
   const chunks: Uint8Array[] = [];
   let totalSize = 0;
@@ -70,7 +70,7 @@ export async function readBodyWithLimit(
 
       totalSize += value.length;
       if (totalSize > maxSize) {
-        throw new ValidationError("Request body exceeds size limit", {
+        throw createValidationError("Request body exceeds size limit", {
           maxSize,
           bytesRead: totalSize,
         });

--- a/src/security/input-validation/parsers.test.ts
+++ b/src/security/input-validation/parsers.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { z } from "zod";
-import { ValidationError } from "./errors.ts";
+import { VeryfrontError } from "./errors.ts";
 import { parseJsonBody, parseQueryParams } from "./parsers.ts";
 
 describe("parseJsonBody", () => {
@@ -30,7 +30,7 @@ describe("parseJsonBody", () => {
 
     await assertRejects(
       () => parseJsonBody(request, schema),
-      ValidationError,
+      VeryfrontError,
       "Invalid JSON",
     );
   });
@@ -42,7 +42,7 @@ describe("parseJsonBody", () => {
 
     await assertRejects(
       () => parseJsonBody(request, schema),
-      ValidationError,
+      VeryfrontError,
       "Validation failed",
     );
   });
@@ -52,7 +52,7 @@ describe("parseJsonBody", () => {
 
     await assertRejects(
       () => parseJsonBody(request, schema),
-      ValidationError,
+      VeryfrontError,
       "Validation failed",
     );
   });
@@ -75,7 +75,7 @@ describe("parseQueryParams", () => {
 
     assertThrows(
       () => parseQueryParams(request, schema),
-      ValidationError,
+      VeryfrontError,
       "Query parameter validation failed",
     );
   });

--- a/src/security/input-validation/parsers.ts
+++ b/src/security/input-validation/parsers.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ValidationError } from "./errors.ts";
+import { createValidationError, VeryfrontError } from "./errors.ts";
 import { readBodyWithLimit, validateRequestLimits } from "./limits.ts";
 import { sanitizeData } from "./sanitizers.ts";
 import { DEFAULT_LIMITS, type ParseFormOptions, type ParseJsonOptions } from "./types.ts";
@@ -16,9 +16,9 @@ export async function parseJsonBody<T>(
     const text = await readBodyWithLimit(request, options?.limits?.maxBodySize);
     data = JSON.parse(text);
   } catch (error) {
-    if (error instanceof ValidationError) throw error;
+    if (error instanceof VeryfrontError && error.slug === "input-validation-failed") throw error;
 
-    throw new ValidationError("Invalid JSON in request body", {
+    throw createValidationError("Invalid JSON in request body", {
       error: error instanceof Error ? error.message : "Parse error",
     });
   }
@@ -29,7 +29,7 @@ export async function parseJsonBody<T>(
   } catch (error) {
     if (!(error instanceof z.ZodError)) throw error;
 
-    throw new ValidationError("Validation failed", {
+    throw createValidationError("Validation failed", {
       errors: error.errors.map((e) => ({
         path: e.path.join("."),
         message: e.message,
@@ -53,7 +53,7 @@ export async function parseFormData<T>(
 
     for (const [key, value] of formData.entries()) {
       if (value instanceof File && value.size > maxFileSize) {
-        throw new ValidationError(`File ${key} too large`, {
+        throw createValidationError(`File ${key} too large`, {
           maxSize: maxFileSize,
           actualSize: value.size,
         });
@@ -65,7 +65,7 @@ export async function parseFormData<T>(
   } catch (error) {
     if (!(error instanceof z.ZodError)) throw error;
 
-    throw new ValidationError("Form validation failed", {
+    throw createValidationError("Form validation failed", {
       errors: error.errors,
     });
   }
@@ -96,7 +96,7 @@ export function parseQueryParams<T>(request: Request, schema: z.ZodSchema<T>): T
   } catch (error) {
     if (!(error instanceof z.ZodError)) throw error;
 
-    throw new ValidationError("Query parameter validation failed", {
+    throw createValidationError("Query parameter validation failed", {
       errors: error.errors,
     });
   }

--- a/src/security/secure-fs.ts
+++ b/src/security/secure-fs.ts
@@ -14,6 +14,7 @@ import {
   type ValidationResult,
 } from "./path-validation.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { SECURITY_VIOLATION } from "#veryfront/errors/error-registry.ts";
 
 export type SecurityContext =
   | "user-input"
@@ -140,11 +141,10 @@ export class SecureFs {
   ): void {
     if (result.valid || !this.config.throwOnError) return;
 
-    throw new SecurityError(
-      `Path validation failed for ${operation}: ${result.error}`,
-      result.code,
-      path,
-    );
+    throw SECURITY_VIOLATION.create({
+      detail: `Path validation failed for ${operation}: ${result.error}`,
+      context: { code: result.code, path },
+    });
   }
 
   private async validatePathForOperation(
@@ -172,7 +172,10 @@ export class SecureFs {
     path: string,
   ): string {
     if (validation.valid && validation.canonicalPath) return validation.canonicalPath;
-    throw new SecurityError("Invalid path", validation.code, path);
+    throw SECURITY_VIOLATION.create({
+      detail: "Invalid path",
+      context: { code: validation.code, path },
+    });
   }
 
   readFile(path: string): Promise<string> {
@@ -260,11 +263,10 @@ export class SecureFs {
 
     if (validatedPaths.length === 0) {
       if (this.config.throwOnError) {
-        throw new SecurityError(
-          "No valid paths to watch",
-          "NO_VALID_PATHS",
-          paths.toString(),
-        );
+        throw SECURITY_VIOLATION.create({
+          detail: "No valid paths to watch",
+          context: { code: "NO_VALID_PATHS", path: paths.toString() },
+        });
       }
 
       return this.config.adapter.fs.watch([], options);
@@ -292,16 +294,7 @@ export class SecureFs {
   }
 }
 
-export class SecurityError extends Error {
-  constructor(
-    message: string,
-    public code?: string,
-    public path?: string,
-  ) {
-    super(message);
-    this.name = "SecurityError";
-  }
-}
+export { SECURITY_VIOLATION } from "#veryfront/errors/error-registry.ts";
 
 export function createSecureFs(config: SecureFsConfig): SecureFs {
   return new SecureFs(config);

--- a/src/server/handlers/request/snippet.handler.ts
+++ b/src/server/handlers/request/snippet.handler.ts
@@ -3,7 +3,7 @@ import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } 
 import { serverLogger as logger } from "#veryfront/utils";
 import { renderSnippet } from "#veryfront/rendering/snippet-renderer.ts";
 import { getErrorMessage } from "#veryfront/errors/veryfront-error.ts";
-import { VeryfrontAPIError } from "#veryfront/platform/adapters/veryfront-api-client/types.ts";
+import { VeryfrontError } from "#veryfront/errors/types.ts";
 
 const PRIORITY_SNIPPET = 450;
 
@@ -76,7 +76,10 @@ export class SnippetHandler extends BaseHandler {
             .withContentType("text/html; charset=utf-8", result.html, 200),
         );
       } catch (error) {
-        if (error instanceof VeryfrontAPIError && error.status === 404) {
+        if (
+          error instanceof VeryfrontError && error.slug === "api-client-error" &&
+          error.status === 404
+        ) {
           logger.debug("[SnippetHandler] Snippet file not found", { filePath });
         } else {
           logger.error("[SnippetHandler] Error rendering snippet", {

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -13,7 +13,6 @@ import {
   endRenderSession,
   startRenderSession,
 } from "#veryfront/transforms/mdx/esm-module-loader/module-fetcher/index.ts";
-import { VeryfrontAPIError } from "#veryfront/platform/adapters/veryfront-api-client/types.ts";
 import { getErrorCollector } from "#veryfront/observability/error-collector.ts";
 import { ErrorOverlay } from "../../dev-server/error-overlay/index.ts";
 import { ErrorPages } from "../../utils/error-html.ts";
@@ -192,8 +191,12 @@ export class SSRService {
       };
     }
 
-    if (error instanceof VeryfrontAPIError && error.status === 404) {
-      const apiUrl = ((error.details as { url?: string } | undefined)?.url ?? "").toString();
+    if (
+      error instanceof VeryfrontError && error.slug === "api-client-error" && error.status === 404
+    ) {
+      const apiUrl =
+        (((error.context as { details?: { url?: string } } | undefined)?.details?.url) ?? "")
+          .toString();
 
       const isFileListRequest = apiUrl.includes("/files") &&
         !apiUrl.includes("/files/") &&

--- a/src/transforms/esm/http-cache-invariants.ts
+++ b/src/transforms/esm/http-cache-invariants.ts
@@ -11,9 +11,10 @@ import { rendererLogger as logger } from "#veryfront/utils";
 import type { BundleHash, LocalModuleCode, PortableModuleCode } from "./http-cache-types.ts";
 import {
   CACHE_DIR_TOKEN,
-  CacheInvariantError as BaseCacheInvariantError,
+  CACHE_INVARIANT_VIOLATION,
   hasHardcodedCachePaths as baseHasHardcodedCachePaths,
 } from "#veryfront/cache";
+import { VeryfrontError } from "#veryfront/errors/types.ts";
 
 /**
  * Portable cache directory token for cross-environment compatibility.
@@ -21,16 +22,7 @@ import {
  */
 export { CACHE_DIR_TOKEN };
 
-/**
- * Error thrown when a cache invariant is violated.
- * These errors indicate programming bugs, not user errors.
- */
-export class CacheInvariantError extends BaseCacheInvariantError {
-  constructor(message: string) {
-    super(message);
-    this.name = "CacheInvariantError";
-  }
-}
+export { CACHE_INVARIANT_VIOLATION, VeryfrontError };
 
 /**
  * Check if code contains hardcoded cache paths that should be tokenized.
@@ -56,7 +48,7 @@ export function hasPortableTokens(code: string): boolean {
  * Fails fast if code contains hardcoded paths that should have been tokenized.
  *
  * @param code - The code to validate
- * @throws CacheInvariantError if code contains hardcoded paths
+ * @throws VeryfrontError (cache-invariant-violation) if code contains hardcoded paths
  */
 export function assertPortable(code: PortableModuleCode): void {
   const codeStr = code as unknown as string;
@@ -66,10 +58,10 @@ export function assertPortable(code: PortableModuleCode): void {
       preview: codeStr.substring(0, 200),
     });
 
-    throw new CacheInvariantError(
-      `Code contains hardcoded cache paths that should be tokenized.\n` +
-        `This indicates tokenization was not applied correctly.`,
-    );
+    throw CACHE_INVARIANT_VIOLATION.create({
+      detail:
+        "[CACHE INVARIANT VIOLATION] Code contains hardcoded cache paths that should be tokenized.\nThis indicates tokenization was not applied correctly.",
+    });
   }
 }
 
@@ -78,7 +70,7 @@ export function assertPortable(code: PortableModuleCode): void {
  * Fails fast if code contains __VF_CACHE_DIR__ tokens that weren't detokenized.
  *
  * @param code - The code to validate
- * @throws CacheInvariantError if code contains portable tokens
+ * @throws VeryfrontError (cache-invariant-violation) if code contains portable tokens
  */
 export function assertLocal(code: LocalModuleCode): void {
   const codeStr = code as unknown as string;
@@ -89,10 +81,10 @@ export function assertLocal(code: LocalModuleCode): void {
       preview: codeStr.substring(0, 200),
     });
 
-    throw new CacheInvariantError(
-      `Code contains ${CACHE_DIR_TOKEN} tokens that should be detokenized.\n` +
-        `This indicates detokenization was not applied correctly.`,
-    );
+    throw CACHE_INVARIANT_VIOLATION.create({
+      detail:
+        `[CACHE INVARIANT VIOLATION] Code contains ${CACHE_DIR_TOKEN} tokens that should be detokenized.\nThis indicates detokenization was not applied correctly.`,
+    });
   }
 }
 
@@ -102,12 +94,15 @@ export function assertLocal(code: LocalModuleCode): void {
  *
  * @param hash - The hash string
  * @returns Branded BundleHash
- * @throws CacheInvariantError if hash format is invalid
+ * @throws VeryfrontError (cache-invariant-violation) if hash format is invalid
  */
 export function asBundleHash(hash: string): BundleHash {
   // Bundle hashes should be numeric (from simpleHash)
   if (!/^\d+$/.test(hash)) {
-    throw new CacheInvariantError(`Invalid bundle hash format: "${hash}" (expected numeric)`);
+    throw CACHE_INVARIANT_VIOLATION.create({
+      detail:
+        `[CACHE INVARIANT VIOLATION] Invalid bundle hash format: "${hash}" (expected numeric)`,
+    });
   }
   return hash as unknown as BundleHash;
 }
@@ -118,13 +113,14 @@ export function asBundleHash(hash: string): BundleHash {
  *
  * @param code - The code string
  * @returns Branded LocalModuleCode
- * @throws CacheInvariantError if code contains portable tokens
+ * @throws VeryfrontError (cache-invariant-violation) if code contains portable tokens
  */
 export function asLocalModuleCode(code: string): LocalModuleCode {
   if (hasPortableTokens(code)) {
-    throw new CacheInvariantError(
-      `Cannot treat code as LocalModuleCode: contains ${CACHE_DIR_TOKEN} tokens`,
-    );
+    throw CACHE_INVARIANT_VIOLATION.create({
+      detail:
+        `[CACHE INVARIANT VIOLATION] Cannot treat code as LocalModuleCode: contains ${CACHE_DIR_TOKEN} tokens`,
+    });
   }
   return code as unknown as LocalModuleCode;
 }
@@ -135,13 +131,14 @@ export function asLocalModuleCode(code: string): LocalModuleCode {
  *
  * @param code - The code string
  * @returns Branded PortableModuleCode
- * @throws CacheInvariantError if code contains hardcoded paths
+ * @throws VeryfrontError (cache-invariant-violation) if code contains hardcoded paths
  */
 export function asPortableModuleCode(code: string): PortableModuleCode {
   if (hasHardcodedCachePaths(code)) {
-    throw new CacheInvariantError(
-      `Cannot treat code as PortableModuleCode: contains hardcoded cache paths`,
-    );
+    throw CACHE_INVARIANT_VIOLATION.create({
+      detail:
+        "[CACHE INVARIANT VIOLATION] Cannot treat code as PortableModuleCode: contains hardcoded cache paths",
+    });
   }
   return code as unknown as PortableModuleCode;
 }

--- a/src/transforms/esm/http-cache-wrapper.ts
+++ b/src/transforms/esm/http-cache-wrapper.ts
@@ -29,7 +29,7 @@ import {
   assertLocal,
   assertPortable,
   CACHE_DIR_TOKEN,
-  CacheInvariantError,
+  VeryfrontError,
 } from "./http-cache-invariants.ts";
 
 /** Maximum number of keys per batch request to distributed cache API */
@@ -208,7 +208,9 @@ export class HttpBundleCache {
 
       return { code: localCode, wasGzipped: decoded.wasGzipped };
     } catch (error) {
-      if (error instanceof CacheInvariantError) throw error;
+      if (error instanceof VeryfrontError && error.slug === "cache-invariant-violation") {
+        throw error;
+      }
       logger.debug("[HTTP-CACHE-WRAPPER] Get code failed", { hash: hashStr, error });
       return { code: null, wasGzipped: false, failReason: "error" };
     }
@@ -250,7 +252,9 @@ export class HttpBundleCache {
 
       return { code: localCode, wasGzipped: decoded.wasGzipped };
     } catch (error) {
-      if (error instanceof CacheInvariantError) throw error;
+      if (error instanceof VeryfrontError && error.slug === "cache-invariant-violation") {
+        throw error;
+      }
       logger.debug("[HTTP-CACHE-WRAPPER] Get code by URL failed", { hash: hashStr, error });
       return { code: null, wasGzipped: false, failReason: "error" };
     }
@@ -294,7 +298,9 @@ export class HttpBundleCache {
 
       logger.debug("[HTTP-CACHE-WRAPPER] Stored code in distributed cache", { hash: hashStr });
     } catch (error) {
-      if (error instanceof CacheInvariantError) throw error;
+      if (error instanceof VeryfrontError && error.slug === "cache-invariant-violation") {
+        throw error;
+      }
       logger.debug("[HTTP-CACHE-WRAPPER] Set code failed", { hash: hashStr, error });
     }
   }

--- a/src/transforms/esm/http-cache.ts
+++ b/src/transforms/esm/http-cache.ts
@@ -38,7 +38,7 @@ import { HTTP_FETCH_TIMEOUT_MS } from "#veryfront/utils/constants/http.ts";
 
 // Type-safe cache wrapper (new architecture)
 import { httpBundleCache } from "./http-cache-wrapper.ts";
-import { asLocalModuleCode, CacheInvariantError } from "./http-cache-invariants.ts";
+import { asLocalModuleCode, VeryfrontError } from "./http-cache-invariants.ts";
 
 /** Maximum number of keys per batch request to distributed cache API */
 // Note: Now handled by httpBundleCache wrapper, kept for reference during migration
@@ -929,7 +929,7 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
         HTTP_MODULE_DISTRIBUTED_TTL_SEC,
       );
     } catch (error) {
-      if (error instanceof CacheInvariantError) {
+      if (error instanceof VeryfrontError && error.slug === "cache-invariant-violation") {
         // Invariant violations should propagate - they indicate bugs
         throw error;
       }
@@ -1341,7 +1341,7 @@ export async function recoverHttpBundleByHash(
     logger.debug("[HTTP-CACHE] No recovery data found for hash", { hash });
     return false;
   } catch (error) {
-    if (error instanceof CacheInvariantError) {
+    if (error instanceof VeryfrontError && error.slug === "cache-invariant-violation") {
       // Invariant violations should propagate - they indicate bugs
       logger.error("[HTTP-CACHE] Cache invariant violation during recovery", { hash, error });
       throw error;


### PR DESCRIPTION
Follow-up to #246. Migrates 7 error classes that bypass the centralized system into the `VeryfrontError` + slug registry pattern.

Full plan: [`plans/centralize_scattered_errors.md`](plans/centralize_scattered_errors.md)

---

## Errors Centralized (7)

| Slug | Replaces | Category | Default Status |
|------|----------|----------|----------------|
| `api-client-error` | `VeryfrontAPIError` | SERVER | 500 (overridable) |
| `config-validation-failed` | `ConfigValidationError` | CONFIG | 400 |
| `security-violation` | `SecurityError` | GENERAL | 403 |
| `input-validation-failed` | `ValidationError` | GENERAL | 400 |
| `token-storage-error` | `TokenStorageError` | SERVER | 500 (overridable) |
| `cache-invariant-violation` | `CacheInvariantError` (2 classes) | SERVER | 500 |
| `fallback-exhausted` | `FallbackExecutionError` | SERVER | 500 |

## API Changes to `types.ts`

- `ErrorCreateOptions.status?: number` — allows per-request status override (e.g., API client errors vary by response)
- `ErrorCreateOptions.cause?: unknown` — supports standard Error chaining (not just RFC 9457 string cause)
- `defineError().create()` uses `options.status ?? definition.status` for status resolution
- `toRFC9457()` only serializes string causes; Error objects are omitted from the RFC response

## Intentionally Local (5 — not migrating)

`SemaphoreTimeoutError`, `TransformTreeTimeoutError`, `NotSupportedError`, `TimeoutError`, `StreamTimeoutError` — internal control-flow errors caught close to throw sites.

---

## Tasks

### Phase 1: Add definitions to registry

- [x] **1.1** Add 7 slug definitions to `error-registry.ts`
- [x] **1.2** Add tests for new slugs

### Phase 2: Migrate each error class

- [x] **2.1** `VeryfrontAPIError` → `api-client-error` (14 files)
- [x] **2.2** `ConfigValidationError` → `config-validation-failed` (1 file)
- [x] **2.3** `SecurityError` → `security-violation` (2 files)
- [x] **2.4** `ValidationError` → `input-validation-failed` (19 files)
- [x] **2.5** `TokenStorageError` → `token-storage-error` (7 files)
- [x] **2.6** `CacheInvariantError` → `cache-invariant-violation` (6 files)
- [x] **2.7** `FallbackExecutionError` → `fallback-exhausted` (4 files)

### Phase 3: Delete old error classes

- [x] **3.1–3.7** Delete each original class definition (replaced with re-exports)

### Phase 4: Verify

- [x] **4.1** Only 5 intentionally local `extends Error` classes remain
- [x] **4.2** All 909 unit tests pass (0 failures)
- [x] **4.3** Rebased on main — integrated with new registry (69 → 76 definitions)