### PR TITLE
fix: resolve relative imports in API routes served remotely

### DIFF
--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -109,7 +109,8 @@ describe("loadHandlerModule", () => {
       ].join("\n"),
     );
 
-    const virtualBase = `/tmp/vf-nonexistent-${Date.now()}`;
+    const tempRoot = await makeTempDir();
+    const virtualBase = join(tempRoot, `vf-nonexistent-${Date.now()}`);
     const toReal = (path: string): string => path.replace(virtualBase, realDir);
 
     const virtualAdapter: RuntimeAdapter = {

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertMatch } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path";
 import { loadHandlerModule } from "./loader.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
@@ -70,6 +70,11 @@ const adapter: RuntimeAdapter = {
 };
 
 describe("loadHandlerModule", () => {
+  afterAll(async () => {
+    const { stop } = await import("esbuild");
+    await stop();
+  });
+
   it("loads .ts file with explicit extension", async () => {
     const tmpDir = await makeTempDir();
     const modulePath = join(tmpDir, "handler.ts");
@@ -80,6 +85,46 @@ describe("loadHandlerModule", () => {
       projectDir: tmpDir,
       modulePath,
       adapter,
+      config: undefined,
+    });
+
+    assertEquals(typeof route?.GET, "function");
+  });
+
+  it("resolves relative imports through adapter when file is not local", async () => {
+    const realDir = await makeTempDir();
+    await fs.mkdir(join(realDir, "lib"), { recursive: true });
+    await fs.mkdir(join(realDir, "pages", "api"), { recursive: true });
+
+    await fs.writeTextFile(
+      join(realDir, "lib", "helper.ts"),
+      `export function greet(): string { return "hello"; }`,
+    );
+
+    await fs.writeTextFile(
+      join(realDir, "pages", "api", "test.ts"),
+      [
+        `import { greet } from "../../lib/helper.ts";`,
+        `export function GET() { return new Response(greet()); }`,
+      ].join("\n"),
+    );
+
+    const virtualBase = `/tmp/vf-nonexistent-${Date.now()}`;
+    const toReal = (path: string): string => path.replace(virtualBase, realDir);
+
+    const virtualAdapter: RuntimeAdapter = {
+      ...adapter,
+      fs: {
+        ...adapter.fs,
+        readFile: (path: string) => fs.readTextFile(toReal(path)),
+        exists: (path: string) => fs.exists(toReal(path)),
+      },
+    };
+
+    const route = await loadHandlerModule({
+      projectDir: virtualBase,
+      modulePath: join(virtualBase, "pages", "api", "test.ts"),
+      adapter: virtualAdapter,
       config: undefined,
     });
 

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -15,6 +15,8 @@ import { isDeno, isNode } from "#veryfront/platform/compat/runtime.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { isCompiledBinary } from "#veryfront/utils";
 
+const FILE_EXTENSIONS: string[] = ["", ".ts", ".tsx", ".js", ".jsx", ".mjs"];
+
 export function loadHandlerModule(options: LoadModuleOptions): Promise<APIRoute | null> {
   return withSpan(
     "api.loadHandlerModule",
@@ -152,14 +154,11 @@ function createImportMapPlugin(
 
       build.onLoad({ filter: /.*/, namespace: "import-map" }, async (args) => {
         try {
-          const { filePath, contents } = await readFileWithExtensions(adapter, args.path, [
-            "",
-            ".ts",
-            ".tsx",
-            ".js",
-            ".jsx",
-            ".mjs",
-          ]);
+          const { filePath, contents } = await readFileWithExtensions(
+            adapter,
+            args.path,
+            FILE_EXTENSIONS,
+          );
 
           const ext = filePath.split(".").pop() ?? "";
           const loaderMap: Record<string, "tsx" | "jsx" | "ts" | "js" | "json"> = {
@@ -184,6 +183,49 @@ function createImportMapPlugin(
   };
 }
 
+/** Resolves relative imports through the adapter's virtual FS for remote projects. */
+function createAdapterResolvePlugin(adapter: RuntimeAdapter): Plugin {
+  return {
+    name: "vf-adapter-resolve",
+    setup(build) {
+      build.onResolve({ filter: /^\.\.?\// }, (args) => {
+        if (args.namespace === "http-url" || args.namespace === "import-map") return undefined;
+
+        const baseDir = args.importer ? pathHelper.dirname(args.importer) : args.resolveDir;
+        if (!baseDir) return undefined;
+
+        const absolutePath = pathHelper.resolve(baseDir, args.path);
+        logger.debug(
+          `[API] Adapter resolve: ${args.path} (from ${
+            args.importer || "stdin"
+          }) -> ${absolutePath}`,
+        );
+        return { path: absolutePath, namespace: "vf-adapter" };
+      });
+
+      build.onLoad({ filter: /.*/, namespace: "vf-adapter" }, async (args) => {
+        try {
+          const { filePath, contents } = await readFileWithExtensions(
+            adapter,
+            args.path,
+            FILE_EXTENSIONS,
+          );
+
+          return {
+            contents,
+            loader: getEsbuildLoader(filePath),
+            resolveDir: pathHelper.dirname(filePath),
+          };
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          logger.error(`[API] Failed to load via adapter: ${args.path}`, error);
+          return { errors: [{ text: `Failed to load: ${msg}` }] };
+        }
+      });
+    },
+  };
+}
+
 function loadAndTranspileModule(
   modulePath: string,
   projectDir: string,
@@ -197,7 +239,7 @@ function loadAndTranspileModule(
       const { filePath: resolvedPath, contents: source } = await readFileWithExtensions(
         adapter,
         modulePath,
-        ["", ".ts", ".tsx", ".js", ".jsx", ".mjs"],
+        FILE_EXTENSIONS,
       );
 
       if (!source) {
@@ -245,6 +287,7 @@ function loadAndTranspileModule(
         },
         plugins: [
           createImportMapPlugin(projectDir, adapter, config),
+          createAdapterResolvePlugin(adapter),
           createHTTPPlugin(allowedHosts),
         ],
       });

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -17,6 +17,18 @@ import { isCompiledBinary } from "#veryfront/utils";
 
 const FILE_EXTENSIONS: string[] = ["", ".ts", ".tsx", ".js", ".jsx", ".mjs"];
 
+const EXT_TO_LOADER: Record<string, "tsx" | "jsx" | "ts" | "js" | "json"> = {
+  tsx: "tsx",
+  jsx: "jsx",
+  ts: "ts",
+  json: "json",
+};
+
+function getLoaderForFile(filePath: string): "tsx" | "jsx" | "ts" | "js" | "json" {
+  const ext = filePath.split(".").pop() ?? "";
+  return EXT_TO_LOADER[ext] ?? "js";
+}
+
 export function loadHandlerModule(options: LoadModuleOptions): Promise<APIRoute | null> {
   return withSpan(
     "api.loadHandlerModule",
@@ -160,17 +172,9 @@ function createImportMapPlugin(
             FILE_EXTENSIONS,
           );
 
-          const ext = filePath.split(".").pop() ?? "";
-          const loaderMap: Record<string, "tsx" | "jsx" | "ts" | "js" | "json"> = {
-            tsx: "tsx",
-            jsx: "jsx",
-            ts: "ts",
-            json: "json",
-          };
-
           return {
             contents,
-            loader: loaderMap[ext] ?? "js",
+            loader: getLoaderForFile(filePath),
             resolveDir: pathHelper.dirname(filePath),
           };
         } catch (error) {
@@ -213,7 +217,7 @@ function createAdapterResolvePlugin(adapter: RuntimeAdapter): Plugin {
 
           return {
             contents,
-            loader: getEsbuildLoader(filePath),
+            loader: getLoaderForFile(filePath),
             resolveDir: pathHelper.dirname(filePath),
           };
         } catch (error) {


### PR DESCRIPTION
## Summary

- Adds `createAdapterResolvePlugin` esbuild plugin that intercepts relative imports (`./`, `../`) and reads them through the runtime adapter's virtual FS instead of the local disk
- Extracts shared `FILE_EXTENSIONS` constant to deduplicate across 3 call sites
- Adds test that verifies relative imports resolve through a virtual adapter when files don't exist locally

## Problem

API routes with relative imports to project-local files (e.g., `import { parseFlowXml } from "../../lib/xml-parser.ts"`) fail with HTTP 500 "Handler not found" when served remotely (split mode, proxy mode, production). esbuild's `resolveDir` pointed to the local framework directory, which doesn't contain the project's files.

## Verified

- Unit test: `deno test --allow-all --no-check src/routing/api/module-loader/loader.test.ts` — 3/3 pass
- Split mode: `curl -H "Host: flow-ops.preview.veryfront.me" localhost:8080/api/flows` — **200 OK, 138 flows** (was 500)

Closes #256