### PR TITLE
chore: migrate from 1Password to GitHub Secrets

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -212,30 +212,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Load secrets from 1Password
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 3
-          max_attempts: 5
-          retry_wait_seconds: 10
-          command: |
-            # Install 1Password CLI
-            curl -sS https://downloads.1password.com/linux/keys/1password.asc | gpg --dearmor --output /tmp/1password-archive-keyring.gpg
-            echo "deb [arch=amd64 signed-by=/tmp/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/amd64 stable main" | sudo tee /etc/apt/sources.list.d/1password.list
-            sudo apt-get update && sudo apt-get install -y 1password-cli
-
-            # Fetch secrets with retry
-            NPM_TOKEN=$(op read "op://VERYFRONT_CI/NPM_TOKEN_VERYFRONT/password")
-            GITHUB_PAT=$(op read "op://VERYFRONT_CI/GITHUB_VERYFRONT_PAT/credential")
-
-            # Export to GITHUB_ENV (masked)
-            echo "::add-mask::$NPM_TOKEN"
-            echo "::add-mask::$GITHUB_PAT"
-            echo "NPM_TOKEN=$NPM_TOKEN" >> $GITHUB_ENV
-            echo "GITHUB_PAT=$GITHUB_PAT" >> $GITHUB_ENV
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-
       - uses: denoland/setup-deno@v2
         with:
           deno-version: lts
@@ -252,7 +228,7 @@ jobs:
       - name: Build and publish
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           deno task build:npm
           cd npm && npm publish --access public --tag rc
@@ -264,7 +240,7 @@ jobs:
       - name: Create GitHub releases
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          GH_TOKEN: ${{ env.GITHUB_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_VERYFRONT_PAT }}
         run: |
           # Public repo release
           gh release create "v${VERSION}" \
@@ -291,7 +267,7 @@ jobs:
       - name: Trigger server deploy
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ env.GITHUB_PAT }}
+          token: ${{ secrets.GITHUB_VERYFRONT_PAT }}
           repository: veryfront/veryfront-server
           event-type: veryfront-code-released
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
@@ -310,30 +286,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-
-      - name: Load secrets from 1Password
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 3
-          max_attempts: 5
-          retry_wait_seconds: 10
-          command: |
-            # Install 1Password CLI
-            curl -sS https://downloads.1password.com/linux/keys/1password.asc | gpg --dearmor --output /tmp/1password-archive-keyring.gpg
-            echo "deb [arch=amd64 signed-by=/tmp/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/amd64 stable main" | sudo tee /etc/apt/sources.list.d/1password.list
-            sudo apt-get update && sudo apt-get install -y 1password-cli
-
-            # Fetch secrets with retry
-            NPM_TOKEN=$(op read "op://VERYFRONT_CI/NPM_TOKEN_VERYFRONT/password")
-            GITHUB_PAT=$(op read "op://VERYFRONT_CI/GITHUB_VERYFRONT_PAT/credential")
-
-            # Export to GITHUB_ENV (masked)
-            echo "::add-mask::$NPM_TOKEN"
-            echo "::add-mask::$GITHUB_PAT"
-            echo "NPM_TOKEN=$NPM_TOKEN" >> $GITHUB_ENV
-            echo "GITHUB_PAT=$GITHUB_PAT" >> $GITHUB_ENV
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Validate tag matches deno.json
         run: |
@@ -369,7 +321,7 @@ jobs:
             cd npm && npm publish --access public
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - uses: actions/download-artifact@v4
         with:
@@ -378,7 +330,7 @@ jobs:
       - name: Create GitHub releases
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          GH_TOKEN: ${{ env.GITHUB_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_VERYFRONT_PAT }}
         run: |
           # Public repo release with binaries and install scripts
           gh release create "v${VERSION}" \
@@ -413,7 +365,7 @@ jobs:
       - name: Trigger server deploy
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ env.GITHUB_PAT }}
+          token: ${{ secrets.GITHUB_VERYFRONT_PAT }}
           repository: veryfront/veryfront-server
           event-type: veryfront-code-released
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
@@ -429,29 +381,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Load secrets from 1Password
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 3
-          max_attempts: 5
-          retry_wait_seconds: 10
-          command: |
-            # Install 1Password CLI
-            curl -sS https://downloads.1password.com/linux/keys/1password.asc | gpg --dearmor --output /tmp/1password-archive-keyring.gpg
-            echo "deb [arch=amd64 signed-by=/tmp/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/amd64 stable main" | sudo tee /etc/apt/sources.list.d/1password.list
-            sudo apt-get update && sudo apt-get install -y 1password-cli
-
-            # Fetch secrets with retry
-            GITHUB_PAT=$(op read "op://VERYFRONT_CI/GITHUB_VERYFRONT_PAT/credential")
-
-            # Export to GITHUB_ENV (masked)
-            echo "::add-mask::$GITHUB_PAT"
-            echo "GITHUB_PAT=$GITHUB_PAT" >> $GITHUB_ENV
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-
       - name: Update Homebrew tap
         uses: nick-fields/retry@v3
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_VERYFRONT_PAT }}
         with:
           timeout_minutes: 5
           max_attempts: 3

--- a/.serena/memories/task_completion.md
+++ b/.serena/memories/task_completion.md
@@ -1,6 +1,6 @@
 # Task Completion Checklist
 
-When completing a coding task in veryfront-renderer, run these checks:
+When completing a coding task in veryfront-server, run these checks:
 
 ## Before Committing
 

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,5 +1,5 @@
 # the name by which the project can be referenced within Serena
-project_name: "veryfront-renderer"
+project_name: "veryfront-server"
 
 
 # list of languages for which language servers are started; choose from:

--- a/scripts/batch-simplify/batch-simplify.ts
+++ b/scripts/batch-simplify/batch-simplify.ts
@@ -235,7 +235,7 @@ async function submit(): Promise<void> {
       endpoint: "/v1/chat/completions",
       completion_window: "24h",
       metadata: {
-        project: "veryfront-renderer",
+        project: "veryfront-server",
         task: "code-simplification",
       },
     }),

--- a/src/errors/catalog/module-errors.ts
+++ b/src/errors/catalog/module-errors.ts
@@ -16,7 +16,7 @@ curl -X DELETE "https://api.veryfront.com/internal/cache/project/{projectId}/tra
   -H "Authorization: Bearer $ADMIN_TOKEN"
 
 # Or restart pods:
-kubectl rollout restart deployment/veryfront-renderer -n veryfront-production
+kubectl rollout restart deployment/veryfront-server -n veryfront-production
 
 # To reproduce locally with production cache:
 VERYFRONT_PROXY_API_BASE_URL=https://api.veryfront.com PROXY_MODE=1 deno task start`,

--- a/src/observability/tracing/otlp-setup.ts
+++ b/src/observability/tracing/otlp-setup.ts
@@ -67,7 +67,7 @@ async function ensureApis(): Promise<void> {
 
 function getServiceName(): string {
   const tracingConfig = getOtelTracingConfig();
-  return tracingConfig.serviceName || "veryfront-renderer";
+  return tracingConfig.serviceName || "veryfront-server";
 }
 
 function setSpanErrorStatus(span: import("@opentelemetry/api").Span, error: unknown): void {

--- a/src/observability/tracing/otlp-setup.ts
+++ b/src/observability/tracing/otlp-setup.ts
@@ -67,7 +67,7 @@ async function ensureApis(): Promise<void> {
 
 function getServiceName(): string {
   const tracingConfig = getOtelTracingConfig();
-  return tracingConfig.serviceName || "veryfront-server";
+  return tracingConfig.serviceName || "veryfront";
 }
 
 function setSpanErrorStatus(span: import("@opentelemetry/api").Span, error: unknown): void {

--- a/src/platform/adapters/fs/github/github-api-client.ts
+++ b/src/platform/adapters/fs/github/github-api-client.ts
@@ -88,7 +88,7 @@ export class GitHubAPIClient {
           headers: {
             Authorization: `Bearer ${this.config.token}`,
             Accept: "application/vnd.github.v3+json",
-            "User-Agent": "veryfront-renderer",
+            "User-Agent": "veryfront-server",
             "X-GitHub-Api-Version": "2022-11-28",
           },
         });

--- a/src/platform/compat/vfs-paths.test.ts
+++ b/src/platform/compat/vfs-paths.test.ts
@@ -6,13 +6,13 @@ describe("getFrameworkRoot", () => {
   const cases: Array<{ name: string; input: string; expected: string }> = [
     {
       name: "should resolve Unix dev path correctly",
-      input: "/Users/dev/code/veryfront-renderer/src/modules/server/module-server.ts",
-      expected: "/Users/dev/code/veryfront-renderer",
+      input: "/Users/dev/code/veryfront-server/src/modules/server/module-server.ts",
+      expected: "/Users/dev/code/veryfront-server",
     },
     {
       name: "should resolve Linux dev path correctly",
-      input: "/home/developer/projects/veryfront-renderer/src/platform/compat/vfs-paths.ts",
-      expected: "/home/developer/projects/veryfront-renderer",
+      input: "/home/developer/projects/veryfront-server/src/platform/compat/vfs-paths.ts",
+      expected: "/home/developer/projects/veryfront-server",
     },
     {
       name: "should resolve deno-compile VFS path",
@@ -31,8 +31,8 @@ describe("getFrameworkRoot", () => {
     },
     {
       name: "should resolve Windows dev path with backslashes",
-      input: "C:\\Users\\dev\\code\\veryfront-renderer\\src\\modules\\server\\module-server.ts",
-      expected: "C:/Users/dev/code/veryfront-renderer",
+      input: "C:\\Users\\dev\\code\\veryfront-server\\src\\modules\\server\\module-server.ts",
+      expected: "C:/Users/dev/code/veryfront-server",
     },
     {
       name: "should resolve Windows deno-compile VFS path",
@@ -41,8 +41,8 @@ describe("getFrameworkRoot", () => {
     },
     {
       name: "should handle mixed slashes",
-      input: "C:\\Users\\dev/code/veryfront-renderer/src\\modules/server.ts",
-      expected: "C:/Users/dev/code/veryfront-renderer",
+      input: "C:\\Users\\dev/code/veryfront-server/src\\modules/server.ts",
+      expected: "C:/Users/dev/code/veryfront-server",
     },
     {
       name: "should return empty string for path without src/",
@@ -51,8 +51,8 @@ describe("getFrameworkRoot", () => {
     },
     {
       name: "should use last src/ when multiple exist",
-      input: "/home/src-user/projects/veryfront-renderer/src/modules/server.ts",
-      expected: "/home/src-user/projects/veryfront-renderer",
+      input: "/home/src-user/projects/veryfront-server/src/modules/server.ts",
+      expected: "/home/src-user/projects/veryfront-server",
     },
     {
       name: "should handle empty string",
@@ -72,8 +72,8 @@ describe("getFrameworkRootFromMeta", () => {
   const cases: Array<{ name: string; input: string; expected: string }> = [
     {
       name: "should resolve from file:// URL",
-      input: "file:///Users/dev/code/veryfront-renderer/src/platform/compat/vfs-paths.ts",
-      expected: "/Users/dev/code/veryfront-renderer",
+      input: "file:///Users/dev/code/veryfront-server/src/platform/compat/vfs-paths.ts",
+      expected: "/Users/dev/code/veryfront-server",
     },
     {
       name: "should resolve VFS URL from compiled binary",

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -42,13 +42,8 @@ function getLocalProjects(): Record<string, string> {
 }
 
 // Configuration from environment variables
-// Support both new and legacy env var names for backward compatibility
-const apiClientId = getEnv("VERYFRONT_PROXY_API_CLIENT_ID") ||
-  getEnv("API_CLIENT_ID_VERYFRONT_RENDERER_PROXY") ||
-  "";
-const apiClientSecret = getEnv("VERYFRONT_PROXY_API_CLIENT_SECRET") ||
-  getEnv("API_CLIENT_SECRET_VERYFRONT_RENDERER_PROXY") ||
-  "";
+const apiClientId = getEnv("VERYFRONT_PROXY_API_CLIENT_ID") || "";
+const apiClientSecret = getEnv("VERYFRONT_PROXY_API_CLIENT_SECRET") || "";
 
 const config: ProxyConfig = {
   apiBaseUrl: getEnv("VERYFRONT_PROXY_API_BASE_URL") || "https://api.veryfront.com",

--- a/src/proxy/retry.test.ts
+++ b/src/proxy/retry.test.ts
@@ -58,7 +58,7 @@ describe("isRetryableConnectionError", () => {
     assertEquals(
       isRetryableConnectionError(
         new TypeError(
-          "error sending request from 10.192.0.35:60358 for http://veryfront-renderer/ (10.193.189.155:80): client error (SendRequest): connection error: Connection reset by peer (os error 104)",
+          "error sending request from 10.192.0.35:60358 for http://veryfront-server/ (10.193.189.155:80): client error (SendRequest): connection error: Connection reset by peer (os error 104)",
         ),
       ),
       true,
@@ -67,7 +67,7 @@ describe("isRetryableConnectionError", () => {
     assertEquals(
       isRetryableConnectionError(
         new TypeError(
-          "error sending request from 10.192.0.35:46166 for http://veryfront-renderer/ (10.193.189.155:80): client error (SendRequest): connection closed before message completed",
+          "error sending request from 10.192.0.35:46166 for http://veryfront-server/ (10.193.189.155:80): client error (SendRequest): connection closed before message completed",
         ),
       ),
       true,
@@ -76,7 +76,7 @@ describe("isRetryableConnectionError", () => {
     assertEquals(
       isRetryableConnectionError(
         new TypeError(
-          "error sending request for url (http://veryfront-renderer/_vf_modules/components/Welcome.js): client error (Connect): tcp connect error: Connection refused (os error 111)",
+          "error sending request for url (http://veryfront-server/_vf_modules/components/Welcome.js): client error (Connect): tcp connect error: Connection refused (os error 111)",
         ),
       ),
       true,

--- a/src/utils/path-utils.ts
+++ b/src/utils/path-utils.ts
@@ -127,7 +127,7 @@ const FRAMEWORK_SOURCE_PATH_RE = new RegExp(
  * Framework paths can appear in two forms:
  * 1. "_veryfront/..." - original framework module path prefix
  * 2. "src/react/...", "src/platform/...", etc. - framework source paths
- *    (after FSAdapter normalizes absolute paths like /Users/.../veryfront-renderer/src/...)
+ *    (after FSAdapter normalizes absolute paths like /Users/.../veryfront-server/src/...)
  */
 export function isFrameworkSourcePath(normalizedPath: string): boolean {
   // Check for _veryfront/ prefix (with or without embedded: prefix)

--- a/tests/integration/server/parallel-requests.test.ts
+++ b/tests/integration/server/parallel-requests.test.ts
@@ -4,8 +4,6 @@
  * Verifies that concurrent requests to the same page don't cause:
  * 1. "body already consumed" errors (from shared Response streams)
  * 2. Singleflight deadlocks (from recursive dependency resolution)
- *
- * @see https://github.com/veryfront/veryfront-server/issues/XXX
  */
 
 import { assertEquals, assertNotEquals, assertStringIncludes } from "#veryfront/testing/assert";

--- a/tests/integration/server/parallel-requests.test.ts
+++ b/tests/integration/server/parallel-requests.test.ts
@@ -5,7 +5,7 @@
  * 1. "body already consumed" errors (from shared Response streams)
  * 2. Singleflight deadlocks (from recursive dependency resolution)
  *
- * @see https://github.com/veryfront/veryfront-renderer/issues/XXX
+ * @see https://github.com/veryfront/veryfront-server/issues/XXX
  */
 
 import { assertEquals, assertNotEquals, assertStringIncludes } from "#veryfront/testing/assert";


### PR DESCRIPTION
## Summary
- Remove `op read` from CI/CD workflow
- Use `secrets.NPM_TOKEN` and `secrets.GITHUB_VERYFRONT_PAT` directly
- Remove legacy env var fallbacks in proxy (`API_CLIENT_ID_VERYFRONT_RENDERER_PROXY`)
- Rename `veryfront-renderer` → `veryfront-server` throughout codebase

## Changes
- `.github/workflows/cicd.yml` — removed 1Password, uses org secrets
- `src/proxy/main.ts` — removed legacy env var fallbacks
- `src/platform/adapters/fs/github/github-api-client.ts` — User-Agent updated
- `src/observability/tracing/otlp-setup.ts` — service name fallback updated
- `src/errors/catalog/module-errors.ts` — kubectl command updated
- Test files — updated URLs and references
- `.serena/` config — project name updated

## Coordination
This PR is part of a cross-repo migration. Related PRs:
- veryfront-server (cloud-renderer)
- veryfront-api
- veryfront-studio
- veryfront-infrastructure

## Test plan
- [ ] CI passes (fmt, lint, typecheck, tests)
- [ ] `deno task release` dry-run works