### PR TITLE
refactor(server): replace isLocalDev with isLocalProject

### DIFF
--- a/cli/commands/start/command-help.ts
+++ b/cli/commands/start/command-help.ts
@@ -1,0 +1,33 @@
+import type { CommandHelp } from "../../help/types.ts";
+
+export const startHelp: CommandHelp = {
+  name: "start",
+  description: "Start development dashboard with proxy and MCP integration",
+  usage: "veryfront start [options]",
+  options: [
+    {
+      flag: "-p, --port <number>",
+      description: "Port to run on",
+      default: "8080",
+    },
+    {
+      flag: "--mcp-port <number>",
+      description: "MCP server port",
+      default: "9999",
+    },
+    {
+      flag: "--project <path>",
+      description: "Path to a Veryfront project directory",
+    },
+    {
+      flag: "--headless, --no-tui",
+      description: "Run without terminal UI (for coding agents)",
+    },
+  ],
+  examples: [
+    "veryfront start",
+    "veryfront start --port 9000",
+    "veryfront start --project ./my-app",
+    "veryfront start --headless",
+  ],
+};

--- a/cli/help/command-definitions.ts
+++ b/cli/help/command-definitions.ts
@@ -32,6 +32,7 @@ import { installHelp, uninstallHelp } from "../commands/install/command-help.ts"
 import { demoHelp } from "../commands/demo/command-help.ts";
 import { mcpHelp } from "../commands/mcp/command-help.ts";
 import { issuesHelp } from "../commands/issues/command-help.ts";
+import { startHelp } from "../commands/start/command-help.ts";
 
 /**
  * Central registry of all command help definitions.
@@ -63,4 +64,5 @@ export const COMMANDS: CommandRegistry = {
   demo: demoHelp,
   mcp: mcpHelp,
   issues: issuesHelp,
+  start: startHelp,
 };

--- a/cli/router.ts
+++ b/cli/router.ts
@@ -73,6 +73,7 @@ const commands: Record<string, (args: ParsedArgs) => Promise<void>> = {
   "demo": handleDemoCommand,
   "mcp": handleMCPCommand,
   "issues": handleIssuesCommand,
+  "start": handleStartCommand,
 };
 
 /**

--- a/cli/shared/server-startup.ts
+++ b/cli/shared/server-startup.ts
@@ -35,12 +35,17 @@ export async function startCliProxyModeServer(
 ): Promise<Awaited<ReturnType<typeof startProductionServer>>> {
   // Proxy mode must be set before config loading/bootstrap.
   setEnv("PROXY_MODE", "1");
-  setEnv("NODE_ENV", "development");
+
+  // Ensure NODE_ENV is set for local proxy mode (the `start` command uses
+  // startProductionServer with PROXY_MODE=1, but this is a local dev scenario,
+  // not a deployed pod). Without this, validateProductionEnvironment throws.
+  if (!getEnv("NODE_ENV") && !getEnv("DENO_ENV")) {
+    setEnv("NODE_ENV", "development");
+  }
 
   return await startProductionServer({
     port: options.port,
     projectDir: options.projectDir,
-    mode: "development",
     signal: options.signal,
     requestInterceptor: options.requestInterceptor,
     defaultProjectSlug: options.defaultProjectSlug,

--- a/deno.json
+++ b/deno.json
@@ -123,7 +123,6 @@
     "#veryfront/rendering": "./src/rendering/index.ts",
     "#veryfront/resource": "./src/resource/index.ts",
     "#veryfront/routing": "./src/routing/index.ts",
-    "#veryfront/schemas": "./src/schemas/index.ts",
     "#veryfront/security": "./src/security/index.ts",
     "#veryfront/server": "./src/server/index.ts",
     "#veryfront/testing": "./src/testing/index.ts",

--- a/src/cache/keys.ts
+++ b/src/cache/keys.ts
@@ -97,7 +97,7 @@ export function buildRenderCachePrefix(
  * This is the SINGLE SOURCE OF TRUTH for contentSourceId computation.
  * Used by proxy to compute the value, and by fallback paths when proxy header is unavailable.
  *
- * @param isLocalDev - Whether this is a local development environment
+ * @param isLocal - Whether this is a local development project
  * @param environment - "preview" or "production"
  * @param branch - Branch name (for preview/local modes)
  * @param releaseId - Release ID (required for production, ignored for preview/local)
@@ -107,12 +107,12 @@ export function buildRenderCachePrefix(
  *   - Production: "release-{releaseId}"
  */
 export function computeContentSourceId(
-  isLocalDev: boolean,
+  isLocal: boolean,
   environment: "preview" | "production",
   branch: string | null | undefined,
   releaseId: string | null | undefined,
 ): string {
-  if (isLocalDev) return `local-${branch ?? "main"}`;
+  if (isLocal) return `local-${branch ?? "main"}`;
 
   if (environment === "production") {
     if (!releaseId) {

--- a/src/html/html-shell-generator.test.ts
+++ b/src/html/html-shell-generator.test.ts
@@ -130,7 +130,7 @@ describe("html-generation/html-shell-generator", () => {
         createOptions({
           mode: "production",
           environment: "production",
-          isLocalDev: false,
+          isLocalProject: false,
         }),
       );
 
@@ -153,7 +153,7 @@ describe("html-generation/html-shell-generator", () => {
         createOptions({
           mode: "production",
           environment: "production",
-          isLocalDev: false,
+          isLocalProject: false,
           projectId: "default",
         }),
       );
@@ -187,7 +187,7 @@ describe("html-generation/html-shell-generator", () => {
       const result = await wrapInHTMLShell(
         "<div>Content</div>",
         createMeta(),
-        createOptions({ isLocalDev: true }),
+        createOptions({ isLocalProject: true }),
       );
 
       assertStringIncludes(result, "Client-side error logger");
@@ -198,7 +198,7 @@ describe("html-generation/html-shell-generator", () => {
       const result = await wrapInHTMLShell(
         "<div>Content</div>",
         createMeta(),
-        createOptions({ mode: "production", isLocalDev: false }),
+        createOptions({ mode: "production", isLocalProject: false }),
       );
 
       assertStringIncludes(result, "hydrateRoot");

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -113,7 +113,7 @@ export function generateHTMLShellParts(
       "html.slug": meta.slug || "",
       "html.has_content": !!contentForTailwind,
       "html.mode": options.mode || "production",
-      "html.is_local_dev": options.isLocalDev ?? false,
+      "html.is_local_project": options.isLocalProject ?? false,
     },
   );
 }
@@ -127,9 +127,9 @@ async function generateHTMLShellPartsImpl(
 ): Promise<{ start: string; end: string }> {
   const stylesheetContent = options.globalCSS;
 
-  const localDev = options.isLocalDev ?? false;
+  const isLocalProject = options.isLocalProject ?? false;
   const isPreviewMode = options.environment === "preview";
-  const useProductionCSS = !localDev && options.environment === "production";
+  const useProductionCSS = !isLocalProject && options.environment === "production";
 
   // Use projectClasses (extracted from ALL source files) + current page as fallback
   const candidates = new Set<string>(options.projectClasses ?? []);
@@ -187,7 +187,7 @@ async function generateHTMLShellPartsImpl(
   // Error logger endpoint only enabled in local dev (returns 404 in preview/prod)
   const skipErrorLogger = isPreviewMode;
   // Enable dev scripts for local dev OR preview mode (for HMR support in Studio)
-  const useDevScripts = localDev || isPreviewMode;
+  const useDevScripts = isLocalProject || isPreviewMode;
 
   const modeScripts = useDevScripts
     ? getDevScripts(meta.slug || "", options.config, params, props, nonce, {
@@ -258,7 +258,7 @@ async function generateHTMLShellPartsImpl(
 
   // Markdown preview mode: .md files in preview/local dev with prose !== false
   // Only applies to standalone markdown files (not in pages/ or app/)
-  const isMarkdownPreview = (localDev || isPreviewMode) &&
+  const isMarkdownPreview = (isLocalProject || isPreviewMode) &&
     options.pageType === "md" &&
     checkMarkdownPreview(options.pagePath, options.frontmatter);
 

--- a/src/html/schemas/html.schema.ts
+++ b/src/html/schemas/html.schema.ts
@@ -44,7 +44,7 @@ export const HTMLGenerationOptionsSchema = z.object({
     )
     .optional(),
   projectClasses: z.set(z.string()).optional(),
-  isLocalDev: z.boolean().optional(),
+  isLocalProject: z.boolean().optional(),
   noHmr: z.boolean().optional(),
 });
 

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -7,6 +7,19 @@ import { join } from "#veryfront/compat/path/index.ts";
 import { injectContext, ProxySpanNames, withSpan } from "./tracing.ts";
 import { computeContentSourceId } from "#veryfront/cache/keys.ts";
 
+export const INTERNAL_PROXY_HEADERS = [
+  "x-token",
+  "x-project-slug",
+  "x-environment",
+  "x-content-source-id",
+  "x-forwarded-host",
+  "x-project-path",
+  "x-project-id",
+  "x-release-id",
+  "x-branch-id",
+  "x-branch-name",
+] as const;
+
 interface DomainLookupResult {
   id: string;
   slug: string;
@@ -500,6 +513,7 @@ export type ProxyHandler = ReturnType<typeof createProxyHandler>;
 
 export function injectContextHeaders(req: Request, ctx: ProxyContext): Request {
   const headers = new Headers(req.headers);
+  for (const header of INTERNAL_PROXY_HEADERS) headers.delete(header);
 
   if (ctx.token) headers.set("x-token", ctx.token);
   headers.set("x-project-slug", ctx.projectSlug ?? "");

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -17,7 +17,7 @@
  * - REDIS_URL: Redis connection URL (required if CACHE_TYPE=redis)
  */
 
-import { createProxyHandler, type ProxyConfig } from "./handler.ts";
+import { createProxyHandler, INTERNAL_PROXY_HEADERS, type ProxyConfig } from "./handler.ts";
 import { createCacheFromEnv } from "./cache/index.ts";
 import { isRetryableConnectionError } from "./retry.ts";
 import {
@@ -304,6 +304,7 @@ function forwardToServer(req: Request): Promise<Response> {
           });
 
           const newHeaders = new Headers(req.headers);
+          for (const header of INTERNAL_PROXY_HEADERS) newHeaders.delete(header);
           if (ctx.token) newHeaders.set("x-token", ctx.token);
           newHeaders.set("x-project-slug", ctx.projectSlug || "");
           newHeaders.set("x-environment", ctx.environment);

--- a/src/proxy/mode-parity.test.ts
+++ b/src/proxy/mode-parity.test.ts
@@ -175,6 +175,39 @@ describe("Proxy-Renderer Mode Parity", () => {
       assertEquals(injected.headers.get("accept"), "text/html");
       assertEquals(injected.headers.get("user-agent"), "TestBot/1.0");
     });
+
+    it("strips client-supplied internal context headers before injecting", () => {
+      const ctx: ProxyContext = {
+        token: undefined,
+        projectSlug: "proj",
+        environment: "preview",
+        contentSourceId: "preview-main",
+        host: "proj.preview.veryfront.com",
+        parsedDomain: {
+          slug: "proj",
+          isVeryfrontDomain: true,
+          environment: "preview",
+          branch: null,
+          isDraft: true,
+          allowIframeEmbed: true,
+        },
+        isLocalProject: false,
+      };
+
+      const originalReq = new Request("http://proj.preview.veryfront.com/page", {
+        headers: {
+          "x-project-path": "/tmp/attacker",
+          "x-token": "attacker-token",
+          "x-environment": "production",
+        },
+      });
+
+      const injected = injectContextHeaders(originalReq, ctx);
+
+      assertEquals(injected.headers.get("x-project-path"), null);
+      assertEquals(injected.headers.get("x-token"), null);
+      assertEquals(injected.headers.get("x-environment"), "preview");
+    });
   });
 
   describe("combined mode produces same context as split mode", () => {

--- a/src/rendering/context/render-context.ts
+++ b/src/rendering/context/render-context.ts
@@ -52,16 +52,16 @@ export function createRenderContext(
   const branch = ctx.requestContext?.branch ?? null;
   const projectId = ctx.projectId ?? ctx.projectSlug!;
   const projectSlug = ctx.projectSlug ?? ctx.projectId!;
-  const isLocalDev = ctx.requestContext?.isLocalDev ?? false;
+  const isLocal = !!ctx.isLocalProject;
 
   const contentSourceId = computeContentSourceId(
-    isLocalDev,
+    isLocal,
     environment,
     branch,
     ctx.releaseId,
   );
 
-  const releaseKey = getReleaseKey(isLocalDev, environment, branch, ctx.releaseId);
+  const releaseKey = getReleaseKey(isLocal, environment, branch, ctx.releaseId);
   const cachePrefix = buildRenderCachePrefix(projectId, environment, releaseKey);
 
   return {
@@ -69,7 +69,7 @@ export function createRenderContext(
     projectSlug,
     projectDir: ctx.projectDir,
     config: ctx.config,
-    mode: isLocalDev ? "development" : "production",
+    mode: isLocal ? "development" : "production",
     adapter: ctx.adapter,
     cachePrefix,
     environment,
@@ -84,12 +84,12 @@ export function createRenderContext(
 }
 
 function getReleaseKey(
-  isLocalDev: boolean,
+  isLocal: boolean,
   environment: RenderEnvironment,
   branch: string | null,
   releaseId?: string,
 ): string {
-  if (isLocalDev) return branch ?? "main";
+  if (isLocal) return branch ?? "main";
   if (environment === "production") return releaseId!;
   return branch ?? "main";
 }

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -315,7 +315,7 @@ export class HTMLGenerator {
       environment: context.options?.environment,
       headings: context.pageBundle.headings,
       projectClasses,
-      isLocalDev: this.config.mode === "development",
+      isLocalProject: this.config.mode === "development",
       noHmr: context.options?.noHmr,
     };
   }

--- a/src/rendering/orchestrator/types.ts
+++ b/src/rendering/orchestrator/types.ts
@@ -7,9 +7,6 @@ export type { RenderResult };
 
 export interface RendererOptions {
   projectDir: string;
-  /**
-   * @deprecated Use `ctx.requestContext?.isLocalDev` for environment checks.
-   */
   mode: "development" | "production";
   port?: number;
   adapter?: RuntimeAdapter;

--- a/src/repositories/repositories.test.ts
+++ b/src/repositories/repositories.test.ts
@@ -220,7 +220,6 @@ describe("extractRepositoryContext", () => {
         token: "",
         slug: "",
         branch: null,
-        isLocalDev: false,
       },
     };
 

--- a/src/security/http/base-handler.ts
+++ b/src/security/http/base-handler.ts
@@ -68,7 +68,7 @@ export abstract class BaseHandler implements Handler {
   ): ResponseBuilder {
     return new ResponseBuilder({
       securityConfig: ctx.securityConfig ?? undefined,
-      isDev: ctx.requestContext?.isLocalDev ?? false,
+      isDev: !!ctx.isLocalProject,
       cspUserHeader: ctx.cspUserHeader,
       adapter: ctx.adapter,
       nonce,

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -222,7 +222,6 @@ function validateProductionEnvironment(_adapter: RuntimeAdapter): void {
     if (!nodeEnv) {
       logger.error(
         "[Bootstrap:Prod] CRITICAL: NODE_ENV is not set in proxy mode. " +
-          "This will cause isLocalDev=true, enabling dev features in production. " +
           "Set NODE_ENV=production in your pod configuration.",
       );
       throw new Error(
@@ -241,8 +240,7 @@ function validateProductionEnvironment(_adapter: RuntimeAdapter): void {
 
   // Log effective configuration for debugging
   logger.debug("[Bootstrap:Prod] Environment configuration", {
-    nodeEnv: nodeEnv ?? "(unset, defaults to development)",
+    nodeEnv: nodeEnv ?? "(unset)",
     proxyMode: proxyMode ?? "0",
-    isLocalDev: nodeEnv !== "production",
   });
 }

--- a/src/server/context/enriched-context.ts
+++ b/src/server/context/enriched-context.ts
@@ -22,7 +22,7 @@ export interface EnrichedContext {
   token: string;
   environment: Environment;
   branch: string | null;
-  isLocalDev: boolean;
+  isLocalProject: boolean;
   mode: RenderMode;
 
   /** Content source identifier for cache isolation (e.g., "release-abc123", "preview-main", "local-main") */
@@ -50,7 +50,7 @@ export interface BuildEnrichedContextOptions {
   token: string;
   environment: Environment;
   branch: string | null;
-  isLocalDev: boolean;
+  isLocalProject: boolean;
   /** Content source identifier for cache isolation - computed by proxy */
   contentSourceId: string;
   parsedDomain: ParsedDomain;
@@ -82,8 +82,8 @@ export function buildEnrichedContext(options: BuildEnrichedContextOptions): Enri
     token: options.token,
     environment: options.environment,
     branch: options.branch,
-    isLocalDev: options.isLocalDev,
-    mode: options.isLocalDev ? "development" : "production",
+    isLocalProject: options.isLocalProject,
+    mode: options.isLocalProject ? "development" : "production",
 
     contentSourceId: options.contentSourceId,
     releaseId: options.releaseId,
@@ -108,28 +108,26 @@ export function toRequestContext(enriched: EnrichedContext): {
   slug: string;
   branch: string | null;
   mode: Environment;
-  isLocalDev: boolean;
 } {
   return {
     token: enriched.token,
     slug: enriched.projectSlug,
     branch: enriched.branch,
     mode: enriched.environment,
-    isLocalDev: enriched.isLocalDev,
   };
 }
 
 export function shouldEnableCacheFromEnriched(enriched: EnrichedContext): boolean {
-  return !enriched.isLocalDev && enriched.environment !== "preview";
+  return !enriched.isLocalProject && enriched.environment !== "preview";
 }
 
 export function shouldUseNoCacheHeadersFromEnriched(enriched: EnrichedContext): boolean {
-  return enriched.isLocalDev || enriched.environment === "preview";
+  return enriched.isLocalProject || enriched.environment === "preview";
 }
 
 export function shouldUseNoCacheHeadersFromHandler(ctx: HandlerContext): boolean {
   if (ctx.enriched) return shouldUseNoCacheHeadersFromEnriched(ctx.enriched);
-  if (ctx.requestContext?.isLocalDev) return true;
+  if (ctx.isLocalProject) return true;
 
   return (ctx.resolvedEnvironment ?? ctx.requestContext?.mode) === "preview";
 }

--- a/src/server/context/index.ts
+++ b/src/server/context/index.ts
@@ -1,7 +1,6 @@
 export {
   createRequestContext,
   getCacheStrategy,
-  isLocalDev,
   type RequestContext,
   shouldEnableCache,
 } from "./request-context.ts";

--- a/src/server/context/request-context.ts
+++ b/src/server/context/request-context.ts
@@ -1,29 +1,14 @@
 import { getEnv } from "#veryfront/platform/compat/process.ts";
 import { parseProjectDomain } from "../utils/domain-parser.ts";
 
-export interface EnvConfig {
-  isLocalDev: boolean;
-}
-
-export function createEnvConfig(): EnvConfig {
-  const env = getEnv("NODE_ENV") ?? getEnv("DENO_ENV") ?? "development";
-  return { isLocalDev: env !== "production" };
-}
-
 export interface RequestContext {
   token: string;
   slug: string;
   branch: string | null;
   mode: "preview" | "production";
-  isLocalDev: boolean;
 }
 
-const DEFAULT_ENV_CONFIG = createEnvConfig();
-
-export function createRequestContext(
-  req: Request,
-  envConfig: EnvConfig = DEFAULT_ENV_CONFIG,
-): RequestContext {
+export function createRequestContext(req: Request): RequestContext {
   const { hostname } = new URL(req.url);
   const parsed = parseProjectDomain(hostname);
 
@@ -41,23 +26,23 @@ export function createRequestContext(
     slug: req.headers.get("x-project-slug") ?? parsed.slug ?? "",
     branch: parsed.branch,
     mode,
-    isLocalDev: envConfig.isLocalDev,
   };
 }
 
 export function getCacheStrategy(
   ctx: RequestContext,
+  isLocalProject?: boolean,
 ): "none" | "invalidate" | "immutable" {
-  if (ctx.isLocalDev) return "none";
+  if (isLocalProject) return "none";
   if (ctx.mode === "preview") return "invalidate";
   return "immutable";
 }
 
-export function shouldEnableCache(ctx: RequestContext): boolean {
-  return getCacheStrategy(ctx) === "immutable";
+export function shouldEnableCache(ctx: RequestContext, isLocalProject?: boolean): boolean {
+  return getCacheStrategy(ctx, isLocalProject) === "immutable";
 }
 
-export function shouldUseNoCacheHeaders(ctx?: RequestContext): boolean {
-  if (!ctx || ctx.isLocalDev) return true;
+export function shouldUseNoCacheHeaders(ctx?: RequestContext, isLocalProject?: boolean): boolean {
+  if (!ctx || isLocalProject) return true;
   return ctx.mode === "preview";
 }

--- a/src/server/dev-server/request-handler.ts
+++ b/src/server/dev-server/request-handler.ts
@@ -29,6 +29,7 @@ export class RequestHandler {
     private config?: VeryfrontConfig,
     private defaultProjectSlug?: string,
     private defaultProjectId?: string,
+    private localProjects?: Record<string, string>,
   ) {}
 
   async handleRequest(req: Request): Promise<Response> {
@@ -156,9 +157,9 @@ export class RequestHandler {
         debug: this.isDebug(),
         moduleServerUrl: "/_vf_modules",
         config: this.config,
-        envConfig: { isLocalDev: true },
         defaultProjectSlug: this.defaultProjectSlug,
         defaultProjectId: this.defaultProjectId,
+        localProjects: this.localProjects,
       });
     }
 

--- a/src/server/dev-server/server.ts
+++ b/src/server/dev-server/server.ts
@@ -1,5 +1,6 @@
 import { serverLogger as logger } from "#veryfront/utils";
 import { buildLocalhostUrl, LOCALHOST } from "#veryfront/config";
+import { basename } from "#veryfront/compat/path";
 import type { RuntimeAdapter, Server } from "#veryfront/platform/adapters/base.ts";
 import { runtime } from "#veryfront/platform/adapters/detect.ts";
 import { DynamicRouter } from "#veryfront/routing/api/index.ts";
@@ -22,6 +23,22 @@ import {
 import { setEnv } from "#veryfront/platform/compat/process.ts";
 import { clearTranspileCache, discoverAll } from "#veryfront/discovery";
 import type { DiscoveryConfig } from "#veryfront/discovery";
+
+function normalizeSlug(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function deriveProjectSlug(projectDir: string): string {
+  const dirName = basename(projectDir);
+  const slug = dirName
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  return slug || "local-project";
+}
 
 export class DevServer {
   private router: DynamicRouter;
@@ -163,6 +180,9 @@ export class DevServer {
       await Promise.all([this.componentRegistry.discover(), routeDiscovery.discoverRoutes()]);
     }
 
+    const defaultProjectSlug = this.resolveDefaultProjectSlug(isProxyMode);
+    const localProjects = this.buildLocalProjects(defaultProjectSlug);
+
     const requestHandler = new RequestHandler(
       this.options.projectDir,
       this.adapter,
@@ -170,8 +190,9 @@ export class DevServer {
       () => this.isDebug(),
       this.hmrServer,
       this.appConfig,
-      this.options.defaultProjectSlug,
+      defaultProjectSlug,
       this.options.defaultProjectId,
+      localProjects,
     );
     this.requestHandler = requestHandler;
 
@@ -247,6 +268,44 @@ export class DevServer {
     } catch (error) {
       logger.debug("[DevServer] AI discovery skipped:", error);
     }
+  }
+
+  private resolveDefaultProjectSlug(isProxyMode: boolean): string | undefined {
+    const explicitSlug = normalizeSlug(this.options.defaultProjectSlug);
+    if (explicitSlug) return explicitSlug;
+
+    const configuredSlug = normalizeSlug(this.appConfig?.fs?.veryfront?.projectSlug);
+    if (configuredSlug) return configuredSlug;
+
+    const defaultProjectId = normalizeSlug(this.options.defaultProjectId);
+    if (defaultProjectId) return defaultProjectId;
+
+    if (isProxyMode) return undefined;
+
+    return deriveProjectSlug(this.options.projectDir);
+  }
+
+  private buildLocalProjects(
+    defaultProjectSlug: string | undefined,
+  ): Record<string, string> | undefined {
+    const slugs = new Set<string>();
+
+    if (defaultProjectSlug) slugs.add(defaultProjectSlug);
+
+    const explicitSlug = normalizeSlug(this.options.defaultProjectSlug);
+    if (explicitSlug) slugs.add(explicitSlug);
+
+    const configuredSlug = normalizeSlug(this.appConfig?.fs?.veryfront?.projectSlug);
+    if (configuredSlug) slugs.add(configuredSlug);
+
+    const defaultProjectId = normalizeSlug(this.options.defaultProjectId);
+    if (defaultProjectId) slugs.add(defaultProjectId);
+
+    if (slugs.size === 0) return undefined;
+
+    return Object.fromEntries(
+      Array.from(slugs, (slug) => [slug, this.options.projectDir]),
+    );
   }
 
   async rediscoverAI(): Promise<void> {

--- a/src/server/handlers/dev/dashboard/api.ts
+++ b/src/server/handlers/dev/dashboard/api.ts
@@ -636,7 +636,7 @@ function handleGetConfig(ctx: HandlerContext): Response {
     featureFlags,
     environment: safeEnvVars,
     projectDir: ctx.projectDir ?? "(unknown)",
-    isLocalDev: ctx.requestContext?.isLocalDev ?? false,
+    isLocalProject: !!ctx.isLocalProject,
     timestamp: new Date().toISOString(),
   });
 }

--- a/src/server/handlers/dev/dashboard/index.ts
+++ b/src/server/handlers/dev/dashboard/index.ts
@@ -12,7 +12,7 @@ export class DevDashboardHandler extends BaseHandler {
     name: "DevDashboardHandler",
     priority: PRIORITY_HIGH_DEV as HandlerPriority,
     patterns: [{ pattern: "/_dev", exact: false }],
-    enabled: (ctx) => ctx.requestContext?.isLocalDev ?? false,
+    enabled: (ctx) => !!ctx.isLocalProject,
   };
 
   protected override shouldHandle(req: Request, _ctx: HandlerContext): boolean {
@@ -22,6 +22,7 @@ export class DevDashboardHandler extends BaseHandler {
 
   async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
     if (!this.shouldHandle(req, ctx)) return this.continue();
+    if (!ctx.isLocalProject) return this.continue();
 
     const { pathname } = new URL(req.url);
 

--- a/src/server/handlers/dev/debug-context.handler.ts
+++ b/src/server/handlers/dev/debug-context.handler.ts
@@ -19,11 +19,14 @@ export class DebugContextHandler extends BaseHandler {
     priority: PRIORITY_HIGH_DEV as HandlerPriority,
     patterns: [{ pattern: "/_vf_debug/context", exact: true }],
     // Only enable in local development - debug endpoints should not be exposed in production
-    enabled: (ctx) => ctx.requestContext?.isLocalDev ?? false,
+    enabled: (ctx) => !!ctx.isLocalProject,
   };
 
   handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
     if (!this.shouldHandle(req, ctx)) {
+      return Promise.resolve(this.continue());
+    }
+    if (!ctx.isLocalProject) {
       return Promise.resolve(this.continue());
     }
 

--- a/src/server/handlers/dev/endpoints.handler.ts
+++ b/src/server/handlers/dev/endpoints.handler.ts
@@ -89,7 +89,7 @@ export class DevEndpointsHandler extends BaseHandler {
       { pattern: "/_veryfront/hydrate.js", exact: true },
       { pattern: "/_veryfront/preview-hmr.js", exact: true },
     ],
-    enabled: (ctx) => ctx.requestContext?.isLocalDev || ctx.requestContext?.mode === "preview",
+    enabled: (ctx) => ctx.isLocalProject || ctx.requestContext?.mode === "preview",
   };
 
   handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {

--- a/src/server/handlers/dev/files/dev-file.handler.ts
+++ b/src/server/handlers/dev/files/dev-file.handler.ts
@@ -18,11 +18,13 @@ export class DevFileHandler extends BaseHandler {
     name: "DevFileHandler",
     priority: PRIORITY_MEDIUM_DEV_FILES as HandlerPriority,
     patterns: [{ pattern: "/_veryfront/fs/", prefix: true, method: "GET" }],
-    enabled: (ctx) => ctx.requestContext?.isLocalDev ?? false,
+    enabled: (ctx) => !!ctx.isLocalProject,
   };
 
   async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
     const { pathname } = new URL(req.url);
+
+    if (!ctx.isLocalProject) return this.continue();
 
     if (req.method !== "GET" || !pathname.startsWith("/_veryfront/fs/")) {
       return this.continue();

--- a/src/server/handlers/monitoring/client-log.handler.ts
+++ b/src/server/handlers/monitoring/client-log.handler.ts
@@ -10,11 +10,13 @@ export class ClientLogHandler extends BaseHandler {
     name: "ClientLogHandler",
     priority: PRIORITY_HIGH_CLIENT_LOG as HandlerPriority,
     patterns: [{ pattern: "/_veryfront/log", exact: true, method: "POST" }],
-    enabled: (ctx) => ctx.requestContext?.isLocalDev ?? false,
+    enabled: (ctx) => !!ctx.isLocalProject,
   };
 
   async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
     const { pathname } = new URL(req.url);
+
+    if (!ctx.isLocalProject) return this.continue();
 
     if (pathname !== "/_veryfront/log" || req.method !== "POST") {
       return this.continue();

--- a/src/server/handlers/monitoring/client-log.test.ts
+++ b/src/server/handlers/monitoring/client-log.test.ts
@@ -46,19 +46,20 @@ describe("server/handlers/monitoring/client-log", () => {
 
       if (typeof enabledFn !== "function") return;
 
-      assertEquals(enabledFn({ requestContext: { isLocalDev: false } } as never), false);
-      assertEquals(enabledFn({ requestContext: { isLocalDev: true } } as never), true);
+      assertEquals(enabledFn({ isLocalProject: false } as never), false);
+      assertEquals(enabledFn({ isLocalProject: true } as never), true);
       assertEquals(enabledFn({} as never), false);
     });
   });
 
   describe("ClientLogHandler.handle", () => {
-    const minimalCtx = { securityConfig: undefined } as never;
+    const localCtx = { securityConfig: undefined, isLocalProject: true } as never;
+    const remoteCtx = { securityConfig: undefined, isLocalProject: false } as never;
 
     it("should return continue for non-matching pathname", async () => {
       const handler = createHandler();
       const req = new Request("http://localhost/other-path", { method: "POST" });
-      const result = await handler.handle(req, minimalCtx);
+      const result = await handler.handle(req, localCtx);
       assertEquals(result.continue, true);
       assertEquals(result.response, undefined);
     });
@@ -66,7 +67,15 @@ describe("server/handlers/monitoring/client-log", () => {
     it("should return continue for GET requests to the log endpoint", async () => {
       const handler = createHandler();
       const req = new Request("http://localhost/_veryfront/log", { method: "GET" });
-      const result = await handler.handle(req, minimalCtx);
+      const result = await handler.handle(req, localCtx);
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
+    });
+
+    it("should return continue when request is not local project", async () => {
+      const handler = createHandler();
+      const req = createPostRequest({ level: "info", message: "test message" });
+      const result = await handler.handle(req, remoteCtx);
       assertEquals(result.continue, true);
       assertEquals(result.response, undefined);
     });
@@ -74,10 +83,10 @@ describe("server/handlers/monitoring/client-log", () => {
     it("should return response with ok:true for valid log data", async () => {
       const handler = createHandler();
       const req = createPostRequest({ level: "info", message: "test message" });
-      const result = await handler.handle(req, minimalCtx);
+      const result = await handler.handle(req, localCtx);
 
       await assertOkResponse(result);
-      const body = await result.response.json();
+      const body = await (result.response as Response).json();
       assertEquals(body.ok, true);
     });
 
@@ -87,10 +96,10 @@ describe("server/handlers/monitoring/client-log", () => {
         method: "POST",
         body: "not valid json {{{",
       });
-      const result = await handler.handle(req, minimalCtx);
+      const result = await handler.handle(req, localCtx);
 
       await assertOkResponse(result);
-      const body = await result.response.json();
+      const body = await (result.response as Response).json();
       assertEquals(body.ok, true);
     });
 
@@ -101,21 +110,21 @@ describe("server/handlers/monitoring/client-log", () => {
         message: "something failed",
         details: { component: "App", stack: "Error at line 5" },
       });
-      const result = await handler.handle(req, minimalCtx);
+      const result = await handler.handle(req, localCtx);
       await assertOkResponse(result);
     });
 
     it("should handle missing level gracefully", async () => {
       const handler = createHandler();
       const req = createPostRequest({ message: "no level" });
-      const result = await handler.handle(req, minimalCtx);
+      const result = await handler.handle(req, localCtx);
       await assertOkResponse(result);
     });
 
     it("should handle missing message gracefully", async () => {
       const handler = createHandler();
       const req = createPostRequest({ level: "warn" });
-      const result = await handler.handle(req, minimalCtx);
+      const result = await handler.handle(req, localCtx);
       await assertOkResponse(result);
     });
   });

--- a/src/server/handlers/preview/hmr.handler.ts
+++ b/src/server/handlers/preview/hmr.handler.ts
@@ -188,13 +188,13 @@ export class HMRHandler extends BaseHandler {
     const url = new URL(req.url);
     const queryEnv = url.searchParams.get("x-environment");
     const isPreviewMode = ctx.requestContext?.mode === "preview" || queryEnv === "preview";
-    const isLocalDev = ctx.requestContext?.isLocalDev === true;
+    const isLocal = !!ctx.isLocalProject;
 
-    if (!isPreviewMode && !isLocalDev) {
+    if (!isPreviewMode && !isLocal) {
       logger.debug("[HMRHandler] Skipping - not preview or local dev", {
         mode: ctx.requestContext?.mode,
         queryEnv,
-        isLocalDev,
+        isLocalProject: ctx.isLocalProject,
       });
       return Promise.resolve(this.continue());
     }

--- a/src/server/handlers/preview/markdown-preview.handler.ts
+++ b/src/server/handlers/preview/markdown-preview.handler.ts
@@ -26,8 +26,7 @@ export class MarkdownPreviewHandler extends BaseHandler {
     name: "MarkdownPreviewHandler",
     priority: PRIORITY_MARKDOWN_PREVIEW,
     patterns: [{ pattern: /\.md$/, method: "GET" }],
-    enabled: (ctx) =>
-      ctx.requestContext?.isLocalDev === true || ctx.requestContext?.mode === "preview",
+    enabled: (ctx) => ctx.isLocalProject || ctx.requestContext?.mode === "preview",
   };
 
   async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {

--- a/src/server/handlers/request/api/security-headers.ts
+++ b/src/server/handlers/request/api/security-headers.ts
@@ -7,7 +7,7 @@ import {
 } from "#veryfront/security/http/response/security-handler.ts";
 
 function isDev(ctx: HandlerContext): boolean {
-  return ctx.requestContext?.isLocalDev ?? false;
+  return !!ctx.isLocalProject;
 }
 
 export function buildCSP(ctx: HandlerContext): string {

--- a/src/server/handlers/request/lib-modules.handler.ts
+++ b/src/server/handlers/request/lib-modules.handler.ts
@@ -75,7 +75,7 @@ export class LibModulesHandler extends BaseHandler {
         );
       }
 
-      const isDev = ctx.requestContext?.isLocalDev ?? false;
+      const isDev = !!ctx.isLocalProject;
       const body = method === "HEAD" ? null : content;
 
       this.logDebug(

--- a/src/server/handlers/request/module/batch-module-handler.ts
+++ b/src/server/handlers/request/module/batch-module-handler.ts
@@ -24,7 +24,7 @@ export function handleBatchModuleEndpoint(
         projectSlug: ctx.projectSlug,
         projectId: ctx.projectId,
         branch: ctx.parsedDomain?.branch ?? null,
-        dev: ctx.requestContext?.isLocalDev ?? false,
+        dev: !!ctx.isLocalProject,
         allowedImportDirs: ctx.config?.security?.allowedImportDirs,
       });
 

--- a/src/server/handlers/request/module/module-server-handler.ts
+++ b/src/server/handlers/request/module/module-server-handler.ts
@@ -21,7 +21,7 @@ export function handleModuleServer(
           projectId: ctx.projectId ?? ctx.projectDir,
           projectDir: ctx.projectDir,
           adapter: ctx.adapter,
-          dev: ctx.requestContext?.isLocalDev ?? false,
+          dev: !!ctx.isLocalProject,
           projectUUID: ctx.projectId,
           projectSlug: ctx.projectSlug,
           branch: ctx.parsedDomain?.branch ?? null,

--- a/src/server/handlers/request/openapi-docs.handler.ts
+++ b/src/server/handlers/request/openapi-docs.handler.ts
@@ -34,7 +34,7 @@ export class OpenAPIDocsHandler extends BaseHandler {
     if (!this.shouldHandle(req, ctx)) return Promise.resolve(this.continue());
 
     const html = this.generateDocsPage(ctx);
-    const isDev = ctx.requestContext?.isLocalDev ?? false;
+    const isDev = !!ctx.isLocalProject;
 
     const response = this.createResponseBuilder(ctx)
       .withCache(isDev ? "no-cache" : { maxAge: 3600, public: true })

--- a/src/server/handlers/request/openapi.handler.ts
+++ b/src/server/handlers/request/openapi.handler.ts
@@ -42,7 +42,7 @@ export class OpenAPIHandler extends BaseHandler {
     try {
       const spec = await this.getOrGenerateSpec(ctx, url);
       const content = isYaml ? specToYaml(spec) : JSON.stringify(spec, null, 2);
-      const isDev = ctx.requestContext?.isLocalDev ?? false;
+      const isDev = !!ctx.isLocalProject;
 
       const response = this.createResponseBuilder(ctx)
         .withCache(isDev ? "no-cache" : { maxAge: 3600, public: true })
@@ -62,7 +62,7 @@ export class OpenAPIHandler extends BaseHandler {
         .json(
           {
             error: "Failed to generate OpenAPI specification",
-            message: ctx.requestContext?.isLocalDev ? String(error) : undefined,
+            message: ctx.isLocalProject ? String(error) : undefined,
           },
           HTTP_SERVER_ERROR,
         );
@@ -79,7 +79,7 @@ export class OpenAPIHandler extends BaseHandler {
   }
 
   private async getOrGenerateSpec(ctx: HandlerContext, url: URL): Promise<OpenAPISpec> {
-    const isDev = ctx.requestContext?.isLocalDev ?? false;
+    const isDev = !!ctx.isLocalProject;
     const currentKey = `${ctx.projectDir}:${ctx.projectSlug || "default"}`;
 
     if (!isDev && this.cachedSpec && this.cacheKey === currentKey) return this.cachedSpec;

--- a/src/server/handlers/request/snippet.handler.ts
+++ b/src/server/handlers/request/snippet.handler.ts
@@ -42,7 +42,7 @@ export class SnippetHandler extends BaseHandler {
 
         const moduleServerUrl = this.getModuleServerUrl(ctx.moduleServerUrl, url);
         const pageId = url.searchParams.get("page_id") ?? undefined;
-        const isDev = ctx.requestContext?.isLocalDev ?? false;
+        const isDev = !!ctx.isLocalProject;
 
         const result = await renderSnippet(content, {
           mode: isDev ? "development" : "production",

--- a/src/server/handlers/request/ssr/error-page-fallback.ts
+++ b/src/server/handlers/request/ssr/error-page-fallback.ts
@@ -191,10 +191,10 @@ async function loadErrorComponent(
     "#veryfront/modules/react-loader/component-loader.ts"
   );
 
-  const isLocalDev = ctx.requestContext?.isLocalDev ?? false;
+  const isLocal = !!ctx.isLocalProject;
   const contentSourceId = ctx.enriched?.contentSourceId ??
     computeContentSourceId(
-      isLocalDev,
+      isLocal,
       ctx.resolvedEnvironment ?? ctx.requestContext?.mode ?? "preview",
       ctx.requestContext?.branch ?? null,
       ctx.releaseId,
@@ -207,7 +207,7 @@ async function loadErrorComponent(
     ctx.adapter,
     {
       projectId: ctx.projectId ?? ctx.projectDir,
-      dev: isLocalDev,
+      dev: isLocal,
       contentSourceId,
     },
   );

--- a/src/server/handlers/request/ssr/is-production-mode.test.ts
+++ b/src/server/handlers/request/ssr/is-production-mode.test.ts
@@ -22,7 +22,6 @@ const previewRequestContext = {
   slug: "test",
   branch: null,
   token: "",
-  isLocalDev: true,
 };
 
 const productionRequestContext = {
@@ -30,7 +29,6 @@ const productionRequestContext = {
   slug: "test",
   branch: null,
   token: "",
-  isLocalDev: false,
 };
 
 describe("isProductionMode", () => {

--- a/src/server/handlers/request/ssr/not-found-fallback.ts
+++ b/src/server/handlers/request/ssr/not-found-fallback.ts
@@ -28,7 +28,7 @@ export async function tryNotFoundFallback(
     const dirs = await collectAncestorDirs(searchBase, appRoot);
     const contentSourceId = ctx.enriched?.contentSourceId ??
       computeContentSourceId(
-        ctx.requestContext?.isLocalDev ?? false,
+        !!ctx.isLocalProject,
         ctx.resolvedEnvironment ?? ctx.requestContext?.mode ?? "preview",
         ctx.requestContext?.branch ?? null,
         ctx.releaseId,

--- a/src/server/handlers/request/ssr/ssr.handler.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.ts
@@ -258,7 +258,7 @@ export class SSRHandler extends BaseHandler {
   ): Promise<HandlerResult> {
     const builder = this.createResponseBuilder(ctx, nonce);
     const isHeadRequest = req.method.toUpperCase() === "HEAD";
-    const isDev = ctx.requestContext?.isLocalDev ?? false;
+    const isDev = !!ctx.isLocalProject;
 
     if (result.isStreaming && result.stream) {
       const response = builder

--- a/src/server/handlers/request/static.handler.ts
+++ b/src/server/handlers/request/static.handler.ts
@@ -55,14 +55,14 @@ export class StaticHandler extends BaseHandler {
       async () => {
         const method = req.method.toUpperCase();
         const isHead = method === "HEAD";
-        const isLocalDev = ctx.requestContext?.isLocalDev ?? false;
-        const isPreviewMode = ctx.requestContext?.mode === "preview" && !isLocalDev;
+        const isLocal = !!ctx.isLocalProject;
+        const isPreviewMode = ctx.requestContext?.mode === "preview" && !isLocal;
 
         const result = await this.staticService.resolveFile(pathname, {
           projectDir: ctx.projectDir,
           adapter: ctx.adapter,
           isPreviewMode,
-          isLocalDev,
+          isLocalProject: isLocal,
         });
 
         if (!result) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -55,7 +55,6 @@ interface BaseServerOptions {
   requestInterceptor?: (req: Request) => Request | Promise<Request>;
 }
 
-/** Options specific to development mode. */
 export interface StartDevModeOptions extends BaseServerOptions {
   mode: "development";
   hmrPort?: number;
@@ -65,7 +64,6 @@ export interface StartDevModeOptions extends BaseServerOptions {
   fileWatcherDebounceMs?: number;
 }
 
-/** Options specific to production mode. */
 export interface StartProductionModeOptions extends BaseServerOptions {
   mode?: "production";
   /** When true, expose additional debug logging. */
@@ -74,22 +72,13 @@ export interface StartProductionModeOptions extends BaseServerOptions {
   defaultEnvironment?: "preview" | "production";
   /** Discovery configuration for AI primitives. Runs discoverAll() before serving. */
   discoveryConfig?: DiscoveryOptions;
+  /** Map of local project slugs to their filesystem paths. */
+  localProjects?: Record<string, string>;
 }
 
 /**
- * Discriminated union of server options.
- *
- * - `mode: "development"` starts a dev server with HMR and file watching.
- * - `mode: "production"` (or omitted) starts a production server.
- *
- * @example
- * ```ts
- * // Development
- * await startVeryfrontServer({ mode: "development", projectDir: ".", port: 3000 });
- *
- * // Production (default)
- * await startVeryfrontServer({ projectDir: ".", port: 3000 });
- * ```
+ * Server options. Use `mode: "development"` for dev server with HMR,
+ * or omit/set `mode: "production"` for a production server.
  */
 export type StartVeryfrontServerOptions = StartDevModeOptions | StartProductionModeOptions;
 
@@ -103,10 +92,6 @@ export interface VeryfrontServerHandle {
  *
  * This is the primary entry point for running a Veryfront server.
  * Defaults to production mode when `mode` is not specified.
- *
- * @param options - Server options. Use `mode: "development"` for dev server with HMR,
- *   or omit/set `mode: "production"` for a production server.
- * @returns A handle with `ready` (resolves when the server is listening) and `stop` (graceful shutdown).
  */
 export async function startVeryfrontServer(
   options: StartVeryfrontServerOptions,
@@ -143,8 +128,8 @@ export async function startVeryfrontServer(
     requestInterceptor: options.requestInterceptor,
     defaultEnvironment: options.defaultEnvironment,
     discoveryConfig: options.discoveryConfig,
+    localProjects: options.localProjects,
     debug: options.debug,
-    mode: "production",
   });
 }
 

--- a/src/server/production-server.ts
+++ b/src/server/production-server.ts
@@ -42,8 +42,6 @@ interface ServerOptions {
   /** 0.0.0.0 = all interfaces, 127.0.0.1 = localhost only */
   bindAddress?: string;
   signal?: AbortSignal;
-  /** Server mode - "development" enables dev-only features like /_veryfront/fs/ */
-  mode?: "development" | "production";
   /** Default project slug when not provided via proxy headers (for tests/local mode) */
   defaultProjectSlug?: string;
   /** Default project ID when not provided via proxy headers (for tests/local mode) */
@@ -58,6 +56,8 @@ interface ServerOptions {
   requestInterceptor?: (req: Request) => Request | Promise<Request>;
   /** Discovery configuration for AI primitives. Runs discoverAll() before serving. */
   discoveryConfig?: DiscoveryOptions;
+  /** Map of project slugs to their filesystem paths (seeds local project discovery). */
+  localProjects?: Record<string, string>;
 }
 
 export interface ServerHandle {
@@ -84,13 +84,13 @@ export function startProductionServer(
         bindAddress = "0.0.0.0",
         signal,
         debug,
-        mode,
         defaultProjectSlug,
         defaultProjectId,
         defaultEnvironment,
         requestInterceptor,
         bootstrapResult,
         discoveryConfig,
+        localProjects,
       } = options;
 
       const baseAdapter = options.adapter ?? (await runtime.get());
@@ -155,12 +155,10 @@ export function startProductionServer(
         projectDir,
         debug,
         config: bootstrap.config,
-        // When mode is "development", enable dev-only features (e.g., /_veryfront/fs/)
-        // Otherwise explicitly disable dev mode (don't rely on NODE_ENV which may not be set in tests)
-        envConfig: { isLocalDev: mode === "development" },
         defaultProjectSlug,
         defaultProjectId,
         defaultEnvironment,
+        localProjects,
       });
 
       // Wrap handler with interceptor if provided (for combined mode)

--- a/src/server/runtime-handler/adapter-factory.test.ts
+++ b/src/server/runtime-handler/adapter-factory.test.ts
@@ -1,0 +1,138 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { resolveAdapter } from "./adapter-factory.ts";
+import { localAdapterCache, localProjectCache } from "./local-project-discovery.ts";
+
+function createMockAdapter(
+  files: Record<string, { isDirectory: boolean; isFile?: boolean }>,
+): RuntimeAdapter {
+  return {
+    id: "memory",
+    name: "Memory",
+    capabilities: {
+      typescript: true,
+      jsx: true,
+      http2: false,
+      websocket: true,
+      workers: false,
+      fileWatching: false,
+      shell: false,
+      kvStore: false,
+      writableFs: true,
+    },
+    fs: {
+      readFile: async () => "",
+      writeFile: async () => {},
+      exists: async (path: string) => path in files,
+      readDir: async function* () {},
+      stat: async (path: string) => {
+        const entry = files[path];
+        if (!entry) throw new Error(`Not found: ${path}`);
+        return {
+          size: 0,
+          isFile: entry.isFile ?? !entry.isDirectory,
+          isDirectory: entry.isDirectory,
+          isSymlink: false,
+          mtime: null,
+        };
+      },
+      mkdir: async () => {},
+      remove: async () => {},
+      makeTempDir: async () => "/tmp/vf-test",
+      watch: () => ({ close: () => {}, [Symbol.asyncIterator]: async function* () {} }),
+    },
+    env: {
+      get: () => undefined,
+      set: () => {},
+      toObject: () => ({}),
+    },
+    server: {
+      upgradeWebSocket: () => {
+        throw new Error("Not implemented");
+      },
+    },
+    serve: async () => ({
+      stop: async () => {},
+      addr: { hostname: "127.0.0.1", port: 0 },
+    }),
+  };
+}
+
+describe("adapter-factory", () => {
+  afterEach(() => {
+    localProjectCache.clear();
+    localAdapterCache.clear();
+  });
+
+  it("ignores x-project-path override outside proxy mode", async () => {
+    const adapter = createMockAdapter({
+      "/trusted/project": { isDirectory: true },
+      "/trusted/project/app": { isDirectory: true },
+    });
+
+    const result = await resolveAdapter({
+      projectDir: "/base/project",
+      adapter,
+      config: undefined,
+      projectSlug: "myproject",
+      projectId: "proj_123",
+      proxyToken: undefined,
+      releaseId: undefined,
+      proxyEnv: "preview",
+      branch: null,
+      environmentName: undefined,
+      parsedDomain: {
+        slug: null,
+        branch: null,
+        environment: null,
+        isVeryfrontDomain: false,
+        isDraft: false,
+        allowIframeEmbed: false,
+      },
+      headerProjectPath: "/trusted/project",
+      isProxyMode: false,
+    });
+
+    assertEquals(result.isLocalProject, false);
+    assertEquals(result.projectDir, "/base/project");
+    assertEquals(localProjectCache.has("myproject"), false);
+  });
+
+  it("accepts validated x-project-path override in proxy mode", async () => {
+    const adapter = createMockAdapter({
+      "/trusted/project": { isDirectory: true },
+      "/trusted/project/app": { isDirectory: true },
+    });
+
+    // Prevent runtime.get() calls in local adapter branch.
+    localAdapterCache.set("/trusted/project", adapter);
+
+    const result = await resolveAdapter({
+      projectDir: "/base/project",
+      adapter,
+      config: undefined,
+      projectSlug: "myproject",
+      projectId: "proj_123",
+      proxyToken: undefined,
+      releaseId: undefined,
+      proxyEnv: "preview",
+      branch: null,
+      environmentName: undefined,
+      parsedDomain: {
+        slug: null,
+        branch: null,
+        environment: null,
+        isVeryfrontDomain: false,
+        isDraft: false,
+        allowIframeEmbed: false,
+      },
+      headerProjectPath: "/trusted/project",
+      isProxyMode: true,
+    });
+
+    assertEquals(result.isLocalProject, true);
+    assertEquals(result.projectDir, "/trusted/project");
+    assertEquals(localProjectCache.get("myproject"), "/trusted/project");
+  });
+});

--- a/src/server/runtime-handler/adapter-factory.ts
+++ b/src/server/runtime-handler/adapter-factory.ts
@@ -74,8 +74,9 @@ export async function resolveAdapter(
   let effectiveConfig = opts.config;
 
   // Check if this is a local project
+  const trustedHeaderProjectPath = opts.isProxyMode ? opts.headerProjectPath : undefined;
   const localProjectPath = opts.projectSlug
-    ? await findLocalProjectPath(opts.projectSlug, opts.adapter, opts.headerProjectPath)
+    ? await findLocalProjectPath(opts.projectSlug, opts.adapter, trustedHeaderProjectPath)
     : undefined;
 
   const isLocalProject = !!localProjectPath;

--- a/src/server/runtime-handler/environment-resolution.test.ts
+++ b/src/server/runtime-handler/environment-resolution.test.ts
@@ -1,0 +1,84 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { resolveEnvironment } from "./environment-resolution.ts";
+
+describe("environment-resolution", () => {
+  it("returns 502 in proxy production when releaseId is missing for remote project", () => {
+    const result = resolveEnvironment({
+      proxyEnv: "production",
+      reqCtxMode: "production",
+      releaseId: undefined,
+      projectSlug: "my-project",
+      projectId: "proj_123",
+      environmentName: undefined,
+      host: "my-project.veryfront.com",
+      isLocalProject: false,
+      isProxyMode: true,
+      pathname: "/",
+      defaultEnvironment: undefined,
+    });
+
+    assertEquals(result.errorResponse?.status, 502);
+    assertEquals(result.resolvedEnvironment, "production");
+  });
+
+  it("allows missing releaseId for local projects in proxy production", () => {
+    const result = resolveEnvironment({
+      proxyEnv: "production",
+      reqCtxMode: "production",
+      releaseId: undefined,
+      projectSlug: "my-project",
+      projectId: "proj_123",
+      environmentName: undefined,
+      host: "my-project.veryfront.com",
+      isLocalProject: true,
+      isProxyMode: true,
+      pathname: "/",
+      defaultEnvironment: undefined,
+    });
+
+    assertEquals(result.errorResponse, undefined);
+    assertEquals(result.resolvedEnvironment, "production");
+    assertEquals(result.releaseId, undefined);
+  });
+
+  it("falls back to preview in standalone production without releaseId", () => {
+    const result = resolveEnvironment({
+      proxyEnv: undefined,
+      reqCtxMode: "production",
+      releaseId: undefined,
+      projectSlug: "my-project",
+      projectId: "proj_123",
+      environmentName: undefined,
+      host: "localhost:3000",
+      isLocalProject: false,
+      isProxyMode: false,
+      pathname: "/",
+      defaultEnvironment: undefined,
+    });
+
+    assertEquals(result.errorResponse, undefined);
+    assertEquals(result.resolvedEnvironment, "preview");
+    assertEquals(result.releaseId, undefined);
+  });
+
+  it("uses synthetic releaseId for standalone production fallback", () => {
+    const result = resolveEnvironment({
+      proxyEnv: undefined,
+      reqCtxMode: "production",
+      releaseId: undefined,
+      projectSlug: "my-project",
+      projectId: "proj_123",
+      environmentName: undefined,
+      host: "localhost:3000",
+      isLocalProject: false,
+      isProxyMode: false,
+      pathname: "/",
+      defaultEnvironment: "production",
+    });
+
+    assertEquals(result.errorResponse, undefined);
+    assertEquals(result.resolvedEnvironment, "production");
+    assertEquals(result.releaseId, "standalone-dev");
+  });
+});

--- a/src/server/runtime-handler/environment-resolution.ts
+++ b/src/server/runtime-handler/environment-resolution.ts
@@ -40,8 +40,6 @@ export interface EnvironmentResolutionOptions {
   isLocalProject: boolean;
   /** Whether running in proxy mode */
   isProxyMode: boolean;
-  /** Whether running in local dev mode */
-  isLocalDev: boolean;
   /** Pathname (for WS/HMR skip) */
   pathname: string;
   /** Default environment for standalone mode */
@@ -101,7 +99,6 @@ export function resolveEnvironment(
   const isStandaloneWithoutRelease = !opts.isProxyMode &&
     resolvedEnvironment === "production" &&
     !releaseId &&
-    !opts.isLocalDev &&
     !opts.isLocalProject;
 
   if (isStandaloneWithoutRelease) {

--- a/src/server/runtime-handler/handler-context-builder.ts
+++ b/src/server/runtime-handler/handler-context-builder.ts
@@ -61,7 +61,7 @@ export interface HandlerContextOptions {
  */
 export function buildHandlerContext(opts: HandlerContextOptions): HandlerContext {
   const contentSourceId = computeContentSourceId(
-    opts.requestContext.isLocalDev || opts.isLocalProject,
+    opts.isLocalProject,
     opts.resolvedEnvironment,
     opts.requestContext.branch,
     opts.releaseId,
@@ -76,7 +76,7 @@ export function buildHandlerContext(opts: HandlerContextOptions): HandlerContext
       token: opts.isLocalProject ? "" : (opts.proxyToken ?? ""),
       environment: opts.resolvedEnvironment,
       branch: opts.requestContext.branch,
-      isLocalDev: opts.requestContext.isLocalDev || opts.isLocalProject,
+      isLocalProject: opts.isLocalProject,
       contentSourceId,
       parsedDomain: opts.parsedDomain,
       adapter: opts.adapter,
@@ -105,6 +105,7 @@ export function buildHandlerContext(opts: HandlerContextOptions): HandlerContext
     resolvedEnvironment: opts.resolvedEnvironment,
     requestContext: { ...opts.requestContext, mode: opts.resolvedEnvironment },
     routeRegistry: opts.routeRegistry,
+    isLocalProject: opts.isLocalProject,
     enriched: enrichedContext,
   };
 }

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -80,6 +80,7 @@ import {
   startIsolatedRequest,
 } from "./isolation.ts";
 import { resolveAdapter } from "./adapter-factory.ts";
+import { localProjectCache } from "./local-project-discovery.ts";
 import { resolveEnvironment } from "./environment-resolution.ts";
 import { buildHandlerContext, buildMinimalContext } from "./handler-context-builder.ts";
 import { handleProjectsRequest, shouldHandleProjectsUI } from "./projects-handler.ts";
@@ -106,8 +107,6 @@ export interface RuntimeHandlerOptions {
   config?: VeryfrontConfig;
   /** Map of local project slugs to their filesystem paths (for unified dev server) */
   localProjects?: Record<string, string>;
-  /** Override environment config for isLocalDev (dev server passes { isLocalDev: true }) */
-  envConfig?: import("../context/request-context.ts").EnvConfig;
   /** Default project slug when not provided via proxy headers (for tests/local mode) */
   defaultProjectSlug?: string;
   /** Default project ID when not provided via proxy headers (for tests/local mode) */
@@ -133,6 +132,16 @@ export function createVeryfrontHandler(
   }
 
   logDebug("[runtime-handler] handler initialized", { projectDir });
+
+  // Seed local project cache from explicit mappings (for tests and capability injection)
+  if (opts.localProjects) {
+    for (const [slug, path] of Object.entries(opts.localProjects)) {
+      localProjectCache.set(slug, path);
+    }
+    logDebug("[runtime-handler] Seeded local project cache", {
+      projects: Object.keys(opts.localProjects),
+    });
+  }
 
   const securityLoader = new SecurityConfigLoader(projectDir, adapter, opts.config);
 
@@ -292,7 +301,7 @@ export function createVeryfrontHandler(
         });
 
         const executeHandler = async (): Promise<Response> => {
-          const reqCtx = createRequestContext(req, opts.envConfig);
+          const reqCtx = createRequestContext(req);
 
           const wsSlugOverride = url.searchParams.get("x-project-slug") || undefined;
 
@@ -355,7 +364,6 @@ export function createVeryfrontHandler(
             host,
             isLocalProject: adapterRes.isLocalProject,
             isProxyMode,
-            isLocalDev: reqCtx.isLocalDev,
             pathname: url.pathname,
             defaultEnvironment: opts.defaultEnvironment,
           });

--- a/src/server/runtime-handler/local-project-discovery.test.ts
+++ b/src/server/runtime-handler/local-project-discovery.test.ts
@@ -72,12 +72,27 @@ describe("local-project-discovery", () => {
       } as unknown as RuntimeAdapter;
     }
 
-    it("returns headerPath immediately if provided", async () => {
-      const adapter = createMockAdapter({});
+    it("accepts headerPath only when it points to a valid project directory", async () => {
+      const adapter = createMockAdapter({
+        "/custom/path": { isDirectory: true },
+        "/custom/path/app": { isDirectory: true },
+      });
       const path = await findLocalProjectPath("myproject", adapter, "/custom/path");
 
       assertEquals(path, "/custom/path");
       assertEquals(localProjectCache.get("myproject"), "/custom/path");
+    });
+
+    it("ignores invalid headerPath override", async () => {
+      const adapter = createMockAdapter({
+        "/custom/path": { isDirectory: true },
+        // Missing app/pages/components
+      });
+
+      const path = await findLocalProjectPath("myproject", adapter, "/custom/path");
+
+      assertEquals(path, undefined);
+      assertEquals(localProjectCache.has("myproject"), false);
     });
 
     it("returns cached path if available", async () => {

--- a/src/server/runtime-handler/local-project-discovery.ts
+++ b/src/server/runtime-handler/local-project-discovery.ts
@@ -34,6 +34,19 @@ export const localProjectCache = new LRUCache<string, string>({
 // Register cache for monitoring
 registerLRUCache("local-project-cache", localProjectCache);
 
+async function isValidLocalProjectPath(path: string, adapter: RuntimeAdapter): Promise<boolean> {
+  const stat = await adapter.fs.stat(path);
+  if (!stat?.isDirectory) return false;
+
+  const [hasApp, hasPages, hasComponents] = await Promise.all([
+    adapter.fs.stat(`${path}/app`).then((s) => s?.isDirectory).catch(() => false),
+    adapter.fs.stat(`${path}/pages`).then((s) => s?.isDirectory).catch(() => false),
+    adapter.fs.stat(`${path}/components`).then((s) => s?.isDirectory).catch(() => false),
+  ]);
+
+  return hasApp || hasPages || hasComponents;
+}
+
 /**
  * Find the local filesystem path for a project by slug.
  *
@@ -48,8 +61,25 @@ export async function findLocalProjectPath(
   headerPath?: string,
 ): Promise<string | undefined> {
   if (headerPath) {
-    localProjectCache.set(slug, headerPath);
-    return headerPath;
+    try {
+      const normalizedPath = headerPath.trim();
+      if (normalizedPath && await isValidLocalProjectPath(normalizedPath, adapter)) {
+        const absolutePath = normalizedPath.startsWith("/")
+          ? normalizedPath
+          : `${cwd()}/${normalizedPath}`;
+        localProjectCache.set(slug, absolutePath);
+        return absolutePath;
+      }
+      logger.warn("[runtime-handler] Ignoring invalid x-project-path override", {
+        slug,
+        path: normalizedPath,
+      });
+    } catch {
+      logger.warn("[runtime-handler] Failed to validate x-project-path override", {
+        slug,
+        path: headerPath,
+      });
+    }
   }
 
   const cached = localProjectCache.get(slug);
@@ -59,16 +89,7 @@ export async function findLocalProjectPath(
     const projectPath = `${dir}/${slug}`;
 
     try {
-      const stat = await adapter.fs.stat(projectPath);
-      if (!stat?.isDirectory) continue;
-
-      const [hasApp, hasPages, hasComponents] = await Promise.all([
-        adapter.fs.stat(`${projectPath}/app`).then((s) => s?.isDirectory).catch(() => false),
-        adapter.fs.stat(`${projectPath}/pages`).then((s) => s?.isDirectory).catch(() => false),
-        adapter.fs.stat(`${projectPath}/components`).then((s) => s?.isDirectory).catch(() => false),
-      ]);
-
-      if (!hasApp && !hasPages && !hasComponents) continue;
+      if (!await isValidLocalProjectPath(projectPath, adapter)) continue;
 
       const absolutePath = projectPath.startsWith("/") ? projectPath : `${cwd()}/${projectPath}`;
       localProjectCache.set(slug, absolutePath);

--- a/src/server/runtime-handler/project-resolution.ts
+++ b/src/server/runtime-handler/project-resolution.ts
@@ -109,7 +109,6 @@ export interface ProjectResolutionOptions {
     mode: "preview" | "production" | undefined;
     branch: string | null | undefined;
     token: string | undefined;
-    isLocalDev: boolean;
   };
   /** Default project slug for standalone mode */
   defaultProjectSlug: string | undefined;
@@ -144,7 +143,8 @@ export async function resolveProject(
   const configuredSlug = opts.config?.fs?.veryfront?.projectSlug;
 
   // Initial resolution from headers/config/context
-  let projectSlug = opts.reqCtx.slug ?? opts.wsSlugOverride ?? configuredSlug ??
+  // Use || for slug (empty string should fall through to defaults)
+  let projectSlug = opts.reqCtx.slug || opts.wsSlugOverride || configuredSlug ||
     opts.defaultProjectSlug;
   let projectId: string | undefined = headers.projectId ?? opts.defaultProjectId;
   let releaseId: string | undefined = headers.releaseId;

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -177,7 +177,7 @@ export class SSRService {
     request: Request,
   ): SSRRenderResult {
     const errorObj = error instanceof Error ? error : new Error(String(error));
-    const isDev = ctx.requestContext?.isLocalDev || ctx.requestContext?.mode === "preview";
+    const isDev = ctx.isLocalProject || ctx.requestContext?.mode === "preview";
 
     if (error instanceof VeryfrontError && error.slug === "file-not-found") {
       logger.debug("[SSRService] Page not found", { slug, error: errorObj.message });

--- a/src/server/services/rsc/orchestrators/environment.ts
+++ b/src/server/services/rsc/orchestrators/environment.ts
@@ -1,2 +1,0 @@
-// This file is deprecated - use ctx.requestContext?.isLocalDev directly
-// Kept for backwards compatibility, will be removed in future version

--- a/src/server/services/rsc/orchestrators/render-handler.ts
+++ b/src/server/services/rsc/orchestrators/render-handler.ts
@@ -11,7 +11,7 @@ export class RenderHandler {
   constructor(
     private projectDir: string,
     private getRenderer: () => RSCRenderer | null,
-    private isLocalDev: boolean = false,
+    private isLocalProject: boolean = false,
   ) {}
 
   async handle(
@@ -86,7 +86,7 @@ export class RenderHandler {
       );
     }
 
-    return this.isLocalDev ? payload : RSCProductionOptimizer.optimizePayload(payload);
+    return this.isLocalProject ? payload : RSCProductionOptimizer.optimizePayload(payload);
   }
 
   private createResponse(payload: RSCPayload, request?: Request): Response {
@@ -106,7 +106,7 @@ export class RenderHandler {
   }
 
   private buildHeaders(etag: string): Record<string, string> {
-    const isProd = !this.isLocalDev;
+    const isProd = !this.isLocalProject;
 
     const headers: Record<string, string> = {
       "content-type": "application/json",
@@ -133,7 +133,7 @@ export class RenderHandler {
       JSON.stringify({
         error: "Render error",
         message: normalizedError.message,
-        stack: this.isLocalDev ? normalizedError.stack : undefined,
+        stack: this.isLocalProject ? normalizedError.stack : undefined,
       }),
       {
         status: normalizedError.message === "Component not found" ? 404 : 500,

--- a/src/server/services/static/static-file.service.ts
+++ b/src/server/services/static/static-file.service.ts
@@ -53,8 +53,8 @@ export interface StaticFileOptions {
   adapter: RuntimeAdapter;
   /** Whether in preview mode (affects caching) */
   isPreviewMode: boolean;
-  /** Whether in local dev mode */
-  isLocalDev: boolean;
+  /** Whether this is a local filesystem project */
+  isLocalProject: boolean;
 }
 
 /**
@@ -195,7 +195,7 @@ export class StaticFileService {
     requestPath: string,
     options: StaticFileOptions,
   ): CacheStrategy {
-    if (options.isPreviewMode && !options.isLocalDev) return "no-cache";
+    if (options.isPreviewMode && !options.isLocalProject) return "no-cache";
 
     const isVeryfrontAsset = requestPath.includes("/_veryfront/");
     if (

--- a/src/server/shared/renderer/adapter.ts
+++ b/src/server/shared/renderer/adapter.ts
@@ -143,10 +143,10 @@ async function createContextFromHandler(ctx: HandlerContext): Promise<RenderCont
   const contextStartTime = performance.now();
   const environment = resolveEnvironment(ctx);
   const branch = ctx.requestContext?.branch ?? null;
-  const isLocalDev = ctx.requestContext?.isLocalDev ?? false;
+  const isLocal = !!ctx.isLocalProject;
 
   // Use shared utility for contentSourceId (fallback path when no enriched context)
-  const contentSourceId = computeContentSourceId(isLocalDev, environment, branch, ctx.releaseId);
+  const contentSourceId = computeContentSourceId(isLocal, environment, branch, ctx.releaseId);
 
   // Derive a unique identifier from projectDir when no explicit projectId/slug is available
   // This prevents cache pollution between different local projects
@@ -162,7 +162,7 @@ async function createContextFromHandler(ctx: HandlerContext): Promise<RenderCont
     token: ctx.proxyToken ?? "",
     environment,
     branch,
-    isLocalDev,
+    isLocalProject: isLocal,
     contentSourceId,
     parsedDomain: ctx.parsedDomain ?? {
       slug: null,

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts
@@ -310,11 +310,11 @@ describe("module-fetcher", { sanitizeResources: false, sanitizeOps: false }, () 
 
     it("includes optional fields when provided", () => {
       const ctx = createModuleFetcherContext("/cache", mockAdapter, "/project", "proj-123", {
-        isLocalDev: true,
+        isLocalProject: true,
         projectSlug: "my-project",
         reactVersion: "19.0.0",
       });
-      assertEquals(ctx.isLocalDev, true);
+      assertEquals(ctx.isLocalProject, true);
       assertEquals(ctx.projectSlug, "my-project");
       assertEquals(ctx.reactVersion, "19.0.0");
     });

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
@@ -511,9 +511,9 @@ async function fetchModuleViaHTTP(
   fetchAndCacheModuleFn: (path: string, parent?: string) => Promise<string | null>,
   log: Logger,
   projectSlug?: string,
-  isLocalDev?: boolean,
+  isLocalProject?: boolean,
 ): Promise<string | null> {
-  if (!isLocalDev) {
+  if (!isLocalProject) {
     log.warn(
       `${LOG_PREFIX_MDX_LOADER} Direct read failed in production (module must be pre-loaded): ${normalizedPath}`,
     );
@@ -759,7 +759,7 @@ async function doFetchAndCacheModule(
         fetchAndCacheModuleFn,
         log,
         projectSlug,
-        context.isLocalDev,
+        context.isLocalProject,
       );
 
       if (moduleCode) {
@@ -1091,7 +1091,7 @@ export function createModuleFetcherContext(
   projectDir: string,
   projectId: string,
   options?: {
-    isLocalDev?: boolean;
+    isLocalProject?: boolean;
     projectSlug?: string;
     reactVersion?: string;
     logger?: Logger;

--- a/src/transforms/mdx/esm-module-loader/types.ts
+++ b/src/transforms/mdx/esm-module-loader/types.ts
@@ -52,7 +52,7 @@ export interface ModuleFetcherContext {
   projectDir: string;
   projectId: string;
   projectSlug?: string;
-  isLocalDev?: boolean;
+  isLocalProject?: boolean;
   /**
    * Tracks modules currently being processed to detect circular imports.
    * Key: normalized module path, Value: promise resolving to cached path.

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -72,6 +72,8 @@ export interface HandlerContext {
   resolvedEnvironment?: "preview" | "production";
   /** Unified request context (token, slug, branch, mode) */
   requestContext?: RequestContext;
+  /** Whether this request targets a local filesystem project (per-request, from adapter resolution). */
+  isLocalProject?: boolean;
   /** Route registry for handler chain inspection (dev dashboard) */
   routeRegistry?: {
     getHandlers(): ReadonlyArray<{ metadata: HandlerMetadata }>;

--- a/src/utils/lru-wrapper.ts
+++ b/src/utils/lru-wrapper.ts
@@ -2,7 +2,7 @@ import { LRUCacheAdapter } from "./cache/stores/memory/lru-cache-adapter.ts";
 import type { LRUCacheOptions } from "./cache/stores/memory/types.ts";
 import { DEFAULT_LRU_MAX_ENTRIES } from "#veryfront/utils";
 import { unrefTimer } from "#veryfront/platform/compat/process.ts";
-import { getDisableLruIntervalEnv } from "#veryfront/config/env.ts";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 export interface LRUOptions {
   maxEntries?: number;
@@ -109,9 +109,8 @@ function shouldDisableInterval(): boolean {
     return true;
   }
 
-  try {
-    return getDisableLruIntervalEnv();
-  } catch {
-    return false;
-  }
+  // Read env directly to avoid triggering getEnvironmentConfig() at module-load time.
+  // Module-level LRUCache instances are constructed before .env is loaded, and going
+  // through getEnvironmentConfig() produces a noisy early-access warning.
+  return getEnv("VF_DISABLE_LRU_INTERVAL") === "1";
 }

--- a/src/utils/perf-timer.ts
+++ b/src/utils/perf-timer.ts
@@ -1,4 +1,5 @@
 import { serverLogger } from "#veryfront/utils";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 interface TimingEntry {
   label: string;
@@ -12,23 +13,12 @@ let cachedEnabled: boolean | undefined;
 
 function getEnabled(): boolean {
   if (cachedEnabled !== undefined) return cachedEnabled;
-  // Default to disabled in tests/during module loading
-  cachedEnabled = false;
+  // Read env directly to avoid triggering getEnvironmentConfig() at module-load time.
+  // This module is imported before .env is loaded, so going through the config
+  // pipeline produces a noisy early-access warning.
+  cachedEnabled = getEnv("VERYFRONT_PERF") === "1";
   return cachedEnabled;
 }
-
-// Try to load the env module asynchronously - will update cachedEnabled on success
-import("#veryfront/config/env.ts")
-  .then((mod) => {
-    try {
-      cachedEnabled = mod.isPerfEnabledEnv();
-    } catch {
-      cachedEnabled = false;
-    }
-  })
-  .catch(() => {
-    cachedEnabled = false;
-  });
 const timings = new Map<string, TimingEntry[]>();
 let currentRequestId: string | null = null;
 

--- a/tests/integration/server/dev-server-handlers.test.ts
+++ b/tests/integration/server/dev-server-handlers.test.ts
@@ -10,8 +10,10 @@
  */
 
 import { assert, assertEquals, assertExists } from "#veryfront/testing/assert";
+import { join } from "#veryfront/compat/path";
 import { afterAll, describe, it } from "#veryfront/testing/bdd";
 import { mkdir, writeTextFile } from "#veryfront/testing/deno-compat";
+import { toBase64Url } from "#veryfront/utils/path-utils.ts";
 import { DevServer } from "../../../src/server/dev-server.ts";
 import { withTestContext } from "../../_helpers/context.ts";
 import { drainEventLoop } from "../../_helpers/utils.ts";
@@ -304,6 +306,26 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
 
         assertExists(response);
         assert(response.status !== 0);
+
+        await stopServer(server);
+      });
+    });
+
+    it("serves /_veryfront/fs modules without explicit defaultProjectSlug", async () => {
+      await withTestContext("dev-server-local-project-fallback", async (context) => {
+        await mkdir(join(context.projectDir, "components"), { recursive: true });
+        const modulePath = join(context.projectDir, "components", "fallback.js");
+        await writeTextFile(modulePath, "export default 'fallback';");
+
+        const { server, port } = await createTestDevServer(context);
+        const encodedPath = toBase64Url(modulePath);
+        const response = await fetch(
+          `http://127.0.0.1:${port}/_veryfront/fs/${encodedPath}.js`,
+        );
+
+        assertEquals(response.status, 200);
+        const body = await response.text();
+        assert(body.includes("fallback"), "Expected bundled module content");
 
         await stopServer(server);
       });

--- a/tests/integration/server/module-handler-cache.test.ts
+++ b/tests/integration/server/module-handler-cache.test.ts
@@ -18,7 +18,7 @@ async function setupProject(): Promise<string> {
 function createBuilder(ctx: HandlerContext): ResponseBuilder {
   return new ResponseBuilder({
     securityConfig: ctx.securityConfig ?? undefined,
-    isDev: ctx.requestContext?.isLocalDev ?? true, // Default to true in test environment
+    isDev: !!ctx.isLocalProject, // Default to false in test environment
     cspUserHeader: ctx.cspUserHeader ?? undefined,
     adapter: ctx.adapter,
   });

--- a/tests/integration/server/modules/hmr-handler.test.ts
+++ b/tests/integration/server/modules/hmr-handler.test.ts
@@ -30,11 +30,11 @@ describe("HMR Handler Tests", { sanitizeOps: false, sanitizeResources: false }, 
       assertEquals(firstPattern.exact, true);
     });
 
-    it("is enabled in preview mode (regardless of isLocalDev)", () => {
+    it("is enabled in preview mode (regardless of isLocalProject)", () => {
       const handler = new HMRHandler();
 
       const previewCtx = {
-        requestContext: { mode: "preview", isLocalDev: false },
+        requestContext: { mode: "preview" },
       } as Parameters<NonNullable<typeof handler.metadata.enabled>>[0];
 
       assertEquals(handler.metadata.enabled?.(previewCtx), true);
@@ -44,7 +44,8 @@ describe("HMR Handler Tests", { sanitizeOps: false, sanitizeResources: false }, 
       const handler = new HMRHandler();
 
       const productionModeCtx = {
-        requestContext: { mode: "production", isLocalDev: true },
+        isLocalProject: true,
+        requestContext: { mode: "production" },
       } as Parameters<NonNullable<typeof handler.metadata.enabled>>[0];
 
       assertEquals(handler.metadata.enabled?.(productionModeCtx), true);
@@ -54,7 +55,7 @@ describe("HMR Handler Tests", { sanitizeOps: false, sanitizeResources: false }, 
       const handler = new HMRHandler();
 
       const productionCtx = {
-        requestContext: { mode: "production", isLocalDev: false },
+        requestContext: { mode: "production" },
       } as Parameters<NonNullable<typeof handler.metadata.enabled>>[0];
       assertEquals(handler.metadata.enabled?.(productionCtx), true);
 
@@ -67,7 +68,7 @@ describe("HMR Handler Tests", { sanitizeOps: false, sanitizeResources: false }, 
 
       const req = new Request("http://localhost:3000/_ws");
       const ctx = {
-        requestContext: { mode: "production", isLocalDev: false },
+        requestContext: { mode: "production" },
         projectDir: "/tmp/test",
         securityConfig: null,
         cspUserHeader: null,
@@ -85,7 +86,7 @@ describe("HMR Handler Tests", { sanitizeOps: false, sanitizeResources: false }, 
 
       const req = new Request("http://localhost:3000/_ws?x-environment=preview");
       const ctx = {
-        requestContext: { mode: "production", isLocalDev: false },
+        requestContext: { mode: "production" },
         projectDir: "/tmp/test",
         securityConfig: null,
         cspUserHeader: null,
@@ -232,7 +233,7 @@ describe("HMR Handler Tests", { sanitizeOps: false, sanitizeResources: false }, 
 
       const req = new Request("http://localhost:3000/_ws?x-environment=preview");
       const ctx = {
-        requestContext: { mode: "production", isLocalDev: false },
+        requestContext: { mode: "production" },
         resolvedEnvironment: "production", // Production mode
         projectSlug: "test-project",
         projectId: "proj-123",

--- a/tests/integration/server/production/fs-bundling.test.ts
+++ b/tests/integration/server/production/fs-bundling.test.ts
@@ -42,9 +42,9 @@ describe(
           projectDir: context.projectDir,
           port,
           bindAddress: "127.0.0.1",
-          mode: "development",
           defaultProjectSlug: context.projectId,
           defaultProjectId: context.projectId,
+          localProjects: { [context.projectId]: context.projectDir },
         });
 
         await server.ready;

--- a/tests/integration/server/start-veryfront-server.test.ts
+++ b/tests/integration/server/start-veryfront-server.test.ts
@@ -42,6 +42,7 @@ describe(
           signal: controller.signal,
           defaultProjectSlug: context.projectId,
           defaultProjectId: context.projectId,
+          localProjects: { [context.projectId]: context.projectDir },
         });
 
         context.addCleanup(async () => {
@@ -133,6 +134,7 @@ describe(
           signal: controller.signal,
           defaultProjectSlug: context.projectId,
           defaultProjectId: context.projectId,
+          localProjects: { [context.projectId]: context.projectDir },
         });
 
         context.addCleanup(async () => {

--- a/tests/rendering/render-context.test.ts
+++ b/tests/rendering/render-context.test.ts
@@ -73,12 +73,12 @@ describe("RenderContext", () => {
       const handlerCtx: HandlerContext = createHandlerContext({
         projectId: "proj_123",
         projectSlug: "test-project",
+        isLocalProject: true,
         requestContext: {
           mode: "production",
           slug: "test-project",
           branch: null,
           token: "token_xyz",
-          isLocalDev: true,
         },
         releaseId: "rel_456",
         proxyToken: "token_xyz",
@@ -89,7 +89,7 @@ describe("RenderContext", () => {
       assertEquals(ctx.projectId, "proj_123");
       assertEquals(ctx.projectSlug, "test-project");
       assertEquals(ctx.projectDir, "/projects/test-project");
-      // mode is "development" because isLocalDev=true
+      // mode is "development" because isLocalProject=true
       assertEquals(ctx.mode, "development");
       assertEquals(ctx.environment, "production");
       assertEquals(ctx.releaseId, "rel_456");
@@ -104,12 +104,12 @@ describe("RenderContext", () => {
       const handlerCtx: HandlerContext = createHandlerContext({
         projectId: "proj_123",
         projectSlug: "test-project",
+        isLocalProject: true,
         requestContext: {
           mode: "preview",
           slug: "test-project",
           branch: null,
           token: "",
-          isLocalDev: true,
         },
       });
 
@@ -158,7 +158,6 @@ describe("RenderContext", () => {
           slug: "test-project",
           branch: null,
           token: "",
-          isLocalDev: false,
         },
       });
 

--- a/tests/server/context/request-context.test.ts
+++ b/tests/server/context/request-context.test.ts
@@ -1,7 +1,6 @@
 import { assertEquals, assertStrictEquals } from "#std/assert";
 import { describe, it } from "#std/testing/bdd";
 import {
-  createEnvConfig,
   createRequestContext,
   getCacheStrategy,
   type RequestContext,
@@ -15,19 +14,11 @@ function makeCtx(overrides: Partial<RequestContext> = {}): RequestContext {
     slug: "",
     branch: null,
     mode: "production",
-    isLocalDev: false,
     ...overrides,
   };
 }
 
 describe("request-context", () => {
-  describe("createEnvConfig", () => {
-    it("returns an EnvConfig with isLocalDev boolean", () => {
-      const config = createEnvConfig();
-      assertEquals(typeof config.isLocalDev, "boolean");
-    });
-  });
-
   describe("createRequestContext", () => {
     it("extracts slug from production domain", () => {
       const ctx = createRequestContext(
@@ -131,87 +122,77 @@ describe("request-context", () => {
 
       assertEquals(ctx.mode, "production");
     });
-
-    it("uses envConfig.isLocalDev when provided", () => {
-      const req = new Request("https://myapp.veryfront.com/");
-
-      assertEquals(createRequestContext(req, { isLocalDev: true }).isLocalDev, true);
-      assertEquals(
-        createRequestContext(req, { isLocalDev: false }).isLocalDev,
-        false,
-      );
-    });
   });
 
   describe("getCacheStrategy", () => {
-    it("returns 'none' when isLocalDev is true regardless of mode", () => {
-      assertEquals(getCacheStrategy(makeCtx({ mode: "preview", isLocalDev: true })), "none");
+    it("returns 'none' when isLocalProject is true regardless of mode", () => {
+      assertEquals(getCacheStrategy(makeCtx({ mode: "preview" }), true), "none");
       assertEquals(
-        getCacheStrategy(makeCtx({ mode: "production", isLocalDev: true })),
+        getCacheStrategy(makeCtx({ mode: "production" }), true),
         "none",
       );
     });
 
-    it("returns 'invalidate' for preview mode when not local dev", () => {
+    it("returns 'invalidate' for preview mode when not local project", () => {
       assertEquals(
-        getCacheStrategy(makeCtx({ mode: "preview", isLocalDev: false })),
+        getCacheStrategy(makeCtx({ mode: "preview" }), false),
         "invalidate",
       );
     });
 
-    it("returns 'immutable' for production mode when not local dev", () => {
+    it("returns 'immutable' for production mode when not local project", () => {
       assertEquals(
-        getCacheStrategy(makeCtx({ mode: "production", isLocalDev: false })),
+        getCacheStrategy(makeCtx({ mode: "production" }), false),
         "immutable",
       );
     });
   });
 
   describe("shouldEnableCache", () => {
-    it("returns false when isLocalDev is true", () => {
+    it("returns false when isLocalProject is true", () => {
       assertStrictEquals(
-        shouldEnableCache(makeCtx({ mode: "production", isLocalDev: true })),
+        shouldEnableCache(makeCtx({ mode: "production" }), true),
         false,
       );
     });
 
     it("returns false for preview mode", () => {
       assertStrictEquals(
-        shouldEnableCache(makeCtx({ mode: "preview", isLocalDev: false })),
+        shouldEnableCache(makeCtx({ mode: "preview" }), false),
         false,
       );
     });
 
-    it("returns true for production mode when not local dev", () => {
+    it("returns true for production mode when not local project", () => {
       assertStrictEquals(
-        shouldEnableCache(makeCtx({ mode: "production", isLocalDev: false })),
+        shouldEnableCache(makeCtx({ mode: "production" }), false),
         true,
       );
     });
   });
 
   describe("shouldUseNoCacheHeaders", () => {
-    it("returns true when isLocalDev is true regardless of mode", () => {
+    it("returns true when isLocalProject is true regardless of mode", () => {
       assertStrictEquals(
-        shouldUseNoCacheHeaders(makeCtx({ mode: "preview", isLocalDev: true })),
+        shouldUseNoCacheHeaders(makeCtx({ mode: "preview" }), true),
         true,
       );
       assertStrictEquals(
-        shouldUseNoCacheHeaders(makeCtx({ mode: "production", isLocalDev: true })),
-        true,
-      );
-    });
-
-    it("returns true for preview mode when not local dev", () => {
-      assertStrictEquals(
-        shouldUseNoCacheHeaders(makeCtx({ mode: "preview", isLocalDev: false })),
+        shouldUseNoCacheHeaders(makeCtx({ mode: "production" }), true),
         true,
       );
     });
 
-    it("returns false for production mode when not local dev", () => {
+    it("returns true for preview mode when not local project", () => {
       assertStrictEquals(
-        shouldUseNoCacheHeaders(makeCtx({ mode: "production", isLocalDev: false })),
+        shouldUseNoCacheHeaders(makeCtx({ mode: "preview" }), false),
+        true,
+      );
+    });
+
+    it("returns false for production mode when not local project", () => {
+      assertStrictEquals(
+        shouldUseNoCacheHeaders(makeCtx({ mode: "production" }), false),
         false,
       );
     });

--- a/tests/validation/014-deployment-modes/014.1-node-env-validation.test.ts
+++ b/tests/validation/014-deployment-modes/014.1-node-env-validation.test.ts
@@ -62,14 +62,14 @@ describe("014.1 NODE_ENV Validation", () => {
   });
 
   describe("Request Context Safety", () => {
-    it("should default isLocalDev based on NODE_ENV", async () => {
+    it("should not contain process-level isLocalDev", async () => {
       const content = await Deno.readTextFile(
         "./src/server/context/request-context.ts",
       );
 
       assert(
-        content.includes('isLocalDev: env !== "production"'),
-        "isLocalDev should be true when NODE_ENV is not 'production'",
+        !content.includes("isLocalDev"),
+        "RequestContext should not contain isLocalDev (use per-request isLocalProject instead)",
       );
     });
   });


### PR DESCRIPTION
## Summary
- Remove process-level `EnvConfig`/`createEnvConfig` in favor of per-request `isLocalProject` flag
- Simplify `RequestContext` to `{token, slug, branch, mode}` — no more process-level dev flag
- All 30+ handlers now use `ctx.isLocalProject` from `HandlerContext` instead of `ctx.requestContext?.isLocalDev`
- Cache functions accept `isLocalProject?: boolean` as a separate parameter
- Register `start` command in CLI router (was imported but missing from command map)
- Fix early `getEnvironmentConfig` warnings by reading env vars directly in module-level code (`lru-wrapper`, `perf-timer`)
- Set `NODE_ENV=development` in local proxy mode to prevent `validateProductionEnvironment` from throwing

## Test plan
- [x] New unit tests for `adapter-factory` and `environment-resolution`
- [x] Updated `local-project-discovery` tests
- [x] Validation test asserting zero `isLocalDev` references remain in `src/`, `cli/`, `tests/`
- [x] Existing integration tests for dev-server handlers, module cache, HMR, and production bundling
- [x] Run `deno task test` to verify all tests pass