### PR TITLE
chore: bump version to 0.1.7-rc.49

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.7-rc.48",
+  "version": "0.1.7-rc.49",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",


### PR DESCRIPTION
## Summary
- Bump version to avoid npm publish collision with 0.1.7-rc.48

## Test plan
- [ ] CI passes