### PR TITLE
fix: remove unused react-dom/client mapping from dnt build

### DIFF
--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -94,11 +94,6 @@ await build({
 			version: "19.1.1",
 			subPath: "server",
 		},
-		"https://esm.sh/react-dom@19.1.1/client?external=react&target=es2022&deps=csstype@3.2.3": {
-			name: "react-dom",
-			version: "19.1.1",
-			subPath: "client",
-		},
 		"https://esm.sh/react@19.1.1/jsx-runtime?external=react&target=es2022&deps=csstype@3.2.3": {
 			name: "react",
 			version: "19.1.1",


### PR DESCRIPTION
## Summary
- Removes the `react-dom/client` esm.sh mapping from the dnt build script
- The API surface refactor (#264) reduced exports to 18 flat paths, none of which transitively import `react-dom/client`
- dnt fails when a mapping is specified but no entry point source file references the mapped URL

## Test plan
- [x] `deno run -A scripts/build/build-npm-dnt.ts` completes successfully
- [x] Pre-commit verification passes (fmt, lint, typecheck)