### PR TITLE
chore: bump version to 0.1.7-rc.50

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.7-rc.49",
+  "version": "0.1.7-rc.50",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",


### PR DESCRIPTION
## Summary
- Bumps version to 0.1.7-rc.50 so the prerelease step can publish to npm
- rc.49 was already published before the API surface refactor and dnt fix

## Test plan
- [x] Pre-commit verification passes