### PR TITLE
fix: preserve AsyncLocalStorage context in esbuild plugin callbacks

### DIFF
--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
@@ -270,6 +270,25 @@ export function getCurrentRequestContext(): RequestContext | null {
   return asyncLocalStorage.getStore() ?? null;
 }
 
+/**
+ * Wraps a callback to preserve the current AsyncLocalStorage context.
+ *
+ * esbuild communicates with its Go binary via a child process. When esbuild's
+ * plugin callbacks (onResolve, onLoad) fire, they run in the child process's
+ * message handler context, which does NOT inherit the AsyncLocalStorage store
+ * from the original caller. This utility captures the current store and
+ * re-enters it inside the callback, so that `getAdapter()` can resolve the
+ * correct per-project adapter.
+ */
+export function wrapWithCurrentContext<T extends (...args: never[]) => unknown>(fn: T): T {
+  const store = asyncLocalStorage.getStore();
+  if (!store) return fn;
+
+  return ((...args: Parameters<T>) => {
+    return asyncLocalStorage.run(store, () => fn(...args));
+  }) as unknown as T;
+}
+
 export function getRequestScopedFile(cacheKey: string): string | undefined {
   return asyncLocalStorage.getStore()?.fileCache?.get(cacheKey);
 }

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -14,6 +14,7 @@ import * as pathHelper from "#veryfront/compat/path";
 import { isDeno, isNode } from "#veryfront/platform/compat/runtime.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { isCompiledBinary } from "#veryfront/utils";
+import { wrapWithCurrentContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 
 const FILE_EXTENSIONS: string[] = ["", ".ts", ".tsx", ".js", ".jsx", ".mjs"];
 
@@ -164,25 +165,28 @@ function createImportMapPlugin(
         return { path: absolutePath, namespace: "import-map" };
       });
 
-      build.onLoad({ filter: /.*/, namespace: "import-map" }, async (args) => {
-        try {
-          const { filePath, contents } = await readFileWithExtensions(
-            adapter,
-            args.path,
-            FILE_EXTENSIONS,
-          );
+      build.onLoad(
+        { filter: /.*/, namespace: "import-map" },
+        wrapWithCurrentContext(async (args) => {
+          try {
+            const { filePath, contents } = await readFileWithExtensions(
+              adapter,
+              args.path,
+              FILE_EXTENSIONS,
+            );
 
-          return {
-            contents,
-            loader: getLoaderForFile(filePath),
-            resolveDir: pathHelper.dirname(filePath),
-          };
-        } catch (error) {
-          const msg = error instanceof Error ? error.message : String(error);
-          logger.error(`[API] Failed to load file via import map: ${args.path}`, error);
-          return { errors: [{ text: `Failed to load: ${msg}` }] };
-        }
-      });
+            return {
+              contents,
+              loader: getLoaderForFile(filePath),
+              resolveDir: pathHelper.dirname(filePath),
+            };
+          } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            logger.error(`[API] Failed to load file via import map: ${args.path}`, error);
+            return { errors: [{ text: `Failed to load: ${msg}` }] };
+          }
+        }),
+      );
     },
   };
 }
@@ -207,25 +211,33 @@ function createAdapterResolvePlugin(adapter: RuntimeAdapter): Plugin {
         return { path: absolutePath, namespace: "vf-adapter" };
       });
 
-      build.onLoad({ filter: /.*/, namespace: "vf-adapter" }, async (args) => {
-        try {
-          const { filePath, contents } = await readFileWithExtensions(
-            adapter,
-            args.path,
-            FILE_EXTENSIONS,
-          );
+      // Wrap the onLoad callback with wrapWithCurrentContext to preserve the
+      // AsyncLocalStorage context. esbuild runs in a child process and its plugin
+      // callbacks fire from the child process message handler, losing the
+      // AsyncLocalStorage store. Without this, MultiProjectFSAdapter.getAdapter()
+      // cannot resolve the per-project adapter and all file reads fail silently.
+      build.onLoad(
+        { filter: /.*/, namespace: "vf-adapter" },
+        wrapWithCurrentContext(async (args) => {
+          try {
+            const { filePath, contents } = await readFileWithExtensions(
+              adapter,
+              args.path,
+              FILE_EXTENSIONS,
+            );
 
-          return {
-            contents,
-            loader: getLoaderForFile(filePath),
-            resolveDir: pathHelper.dirname(filePath),
-          };
-        } catch (error) {
-          const msg = error instanceof Error ? error.message : String(error);
-          logger.error(`[API] Failed to load via adapter: ${args.path}`, error);
-          return { errors: [{ text: `Failed to load: ${msg}` }] };
-        }
-      });
+            return {
+              contents,
+              loader: getLoaderForFile(filePath),
+              resolveDir: pathHelper.dirname(filePath),
+            };
+          } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            logger.error(`[API] Failed to load via adapter: ${args.path}`, error);
+            return { errors: [{ text: `Failed to load: ${msg}` }] };
+          }
+        }),
+      );
     },
   };
 }


### PR DESCRIPTION
## Summary

- **Root cause**: esbuild communicates with its Go binary via a child process. When esbuild plugin callbacks (`onLoad`) fire, they execute in the child process's message handler context, which does **not** inherit the `AsyncLocalStorage` store from the original caller. This causes `MultiProjectFSAdapter.getAdapter()` to throw "No request context available", which `readFileWithExtensions()` silently catches — resulting in all 6 extension variants failing and "File not found" errors.
- **Fix**: Added `wrapWithCurrentContext()` utility that captures the current ALS store and re-enters it inside the callback. Wrapped both the `vf-adapter-resolve` and `import-map` plugin `onLoad` callbacks.
- **Impact**: Fixes `flow-ops.veryfront.com/api/flows` (and all other VFS-proxied API routes that import dependencies) returning 500 "Handler not found".

## Evidence

Production logs showed `networkMs: 0` with 6 "network fetches" (one per `FILE_EXTENSIONS` variant), confirming instant failures rather than actual HTTP errors. The file `lib/xml-parser.ts` exists in the release (14,123 bytes confirmed via DB query) but was unreachable due to context loss.

## Test plan

- [ ] Verify `deno check` passes (pre-commit hook confirms)
- [ ] Deploy and verify `curl https://flow-ops.veryfront.com/api/flows` returns 200
- [ ] Verify other VFS-proxied projects with API routes still work