### PR TITLE
fix: embed agent and workflow framework sources in compiled binary

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.7-rc.50",
+  "version": "0.1.7-rc.51",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",

--- a/scripts/build/prepare-framework-sources.ts
+++ b/scripts/build/prepare-framework-sources.ts
@@ -28,6 +28,8 @@ const METADATA_FILE = join(OUTPUT_DIR, ".compile-metadata.json");
 const FRAMEWORK_DIRS = [
   "react",
   "lib",
+  "agent",
+  "workflow",
 ];
 
 // Extensions to process

--- a/tests/integration/vfs-proxy-mode-e2e.test.ts
+++ b/tests/integration/vfs-proxy-mode-e2e.test.ts
@@ -173,6 +173,54 @@ describe("VFS Proxy Mode - Compiled Binary", { sanitizeOps: false, sanitizeResou
     }
   });
 
+  it("should serve embedded framework modules from compiled binary", async () => {
+    const projectDir = await createMinimalVFSProject();
+    // Use standalone mode (no proxy) so framework modules can be served without
+    // needing a releaseId from the API. Framework files are resolved from
+    // dist/framework-src/ embedded in the compiled binary.
+    const server = await startVFSServer(projectDir, { PROXY_MODE: "0" });
+    try {
+      // Wait for server to be ready
+      const deadline = Date.now() + 30_000;
+      while (Date.now() < deadline) {
+        try {
+          const r = await fetch(`http://127.0.0.1:${server.port}/`);
+          await r.text();
+          break;
+        } catch { await new Promise((r) => setTimeout(r, 500)); }
+      }
+
+      // Framework modules under _veryfront/ should be served from embedded sources
+      // These are resolved from dist/framework-src/ in compiled binaries
+      const modulePaths = [
+        "_veryfront/react/components/Head.js",
+        "_veryfront/react/context/index.js",
+        "_veryfront/agent/react/index.js",
+        "_veryfront/workflow/react/index.js",
+      ];
+
+      for (const modulePath of modulePaths) {
+        const response = await fetch(
+          `http://127.0.0.1:${server.port}/_vf_modules/${modulePath}`,
+        );
+        const body = await response.text();
+
+        assertEquals(
+          response.status,
+          200,
+          `Expected 200 for ${modulePath}, got ${response.status}: ${body.slice(0, 200)}`,
+        );
+        assert(
+          body.includes("export") || body.includes("import"),
+          `Expected JS module for ${modulePath}, got: ${body.slice(0, 200)}`,
+        );
+      }
+    } finally {
+      await server.kill();
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
   // Only run live API tests when token is available (local dev, not CI)
   if (VERYFRONT_API_TOKEN) {
     it("should serve API routes from VFS project via domain", async () => {


### PR DESCRIPTION
## Summary

- Add `agent/` and `workflow/` to `FRAMEWORK_DIRS` in `prepare-framework-sources.ts`
- Add e2e test verifying framework modules are served from compiled binary

## Problem

`FRAMEWORK_DIRS` only included `["react", "lib"]`, so client-side modules like `veryfront/agent/react` (`useChat`, `useAgent`) and `veryfront/workflow/react` (`useWorkflow`, `useApproval`) returned 404 "Module not found" in production compiled binaries.

The embedded sources in `dist/framework-src/` only contained `react/` files. When the module server tried to resolve `_veryfront/agent/react/index.js`, it couldn't find it.

Fixes #275

## Test plan

- [x] Local compiled binary: `agent/react/index.js` returns 200 (was 404)
- [x] Local compiled binary: `workflow/react/index.js` returns 200 (was 404)
- [x] Local compiled binary: `react/components/Head.js` still returns 200
- [ ] E2e test: `should serve embedded framework modules from compiled binary`
- [ ] CI green