### PR TITLE
chore: bump version to 0.1.7-rc.52

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.7-rc.51",
+  "version": "0.1.7-rc.52",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",


### PR DESCRIPTION
## Summary
- Bump version to 0.1.7-rc.52 to trigger npm publish and server deploy (rc.51 already published)