### PR TITLE
fix: embed framework sources in cross-compiled binaries

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -177,6 +177,7 @@ jobs:
           deno-version: lts
 
       - run: deno run -A scripts/build/generate-templates-manifest.ts
+      - run: deno run -A scripts/build/prepare-framework-sources.ts
 
       - name: Compile binary
         shell: bash
@@ -184,6 +185,9 @@ jobs:
           # React is fetched at runtime through the module server (SSR transform pipeline)
           # Include Tailwind CSS v4 plugins (versions must match PINNED_PLUGIN_VERSIONS in tailwind-compiler.ts)
           deno compile --allow-all --unstable-net \
+            --include src/platform/polyfills \
+            --include src/proxy/main.ts \
+            --include dist/framework-src \
             --include "https://esm.sh/tailwindcss-animate@1.0.7" \
             --include "https://esm.sh/@tailwindcss/typography@0.5.19" \
             --include "https://esm.sh/@tailwindcss/forms@0.5.11" \


### PR DESCRIPTION
## Summary
- Cross-compile build step (Linux/Windows) was missing `prepare-framework-sources.ts` and `--include dist/framework-src`
- This caused `agent/` and `workflow/` framework modules to 404 in production (#275)
- The macOS build (`deno task build`) already included these correctly

## Changes
- Added `prepare-framework-sources.ts` step before cross-compile
- Added `--include src/platform/polyfills --include src/proxy/main.ts --include dist/framework-src` to cross-compile command

## Test plan
- [ ] CI build-binaries passes
- [ ] After merge + deploy, verify `curl https://flow-ops.veryfront.com/_vf_modules/_veryfront/agent/react/index.js` returns 200