### PR TITLE
chore: bump version to 0.1.7-rc.53

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.7-rc.52",
+  "version": "0.1.7-rc.53",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",


### PR DESCRIPTION
Trigger npm publish + server deploy with framework sources embedded in cross-compiled binaries.