### PR TITLE
chore: bump version to 0.1.7-rc.54

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.7-rc.53",
+  "version": "0.1.7-rc.54",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",


### PR DESCRIPTION
## Summary
- Bump version to 0.1.7-rc.54 to trigger clean build+deploy
- rc.53 npm publish succeeded but GitHub release failed (missing Windows artifact)