### PR TITLE
fix: Windows cross-compile path + dynamic binary collection in CI

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -246,6 +246,13 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           GH_TOKEN: ${{ secrets.GH_PAT_VERYFRONT }}
         run: |
+          # Collect available binaries dynamically (Windows build is optional)
+          BINARIES=""
+          for f in binaries/veryfront-*/veryfront-*; do
+            [ -f "$f" ] && BINARIES="$BINARIES $f"
+          done
+          echo "Available binaries: $BINARIES"
+
           # Public repo release
           gh release create "v${VERSION}" \
             --repo veryfront/veryfront \
@@ -253,11 +260,7 @@ jobs:
             --notes '```bash
           npx veryfront@'"${VERSION}"'
           ```' \
-            binaries/veryfront-macos-arm64/veryfront-macos-arm64 \
-            binaries/veryfront-macos-x64/veryfront-macos-x64 \
-            binaries/veryfront-linux-x64/veryfront-linux-x64 \
-            binaries/veryfront-linux-arm64/veryfront-linux-arm64 \
-            binaries/veryfront-windows-x64.exe/veryfront-windows-x64.exe \
+            $BINARIES \
             scripts/install.sh
 
       - name: Create source repo release
@@ -336,6 +339,13 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           GH_TOKEN: ${{ secrets.GH_PAT_VERYFRONT }}
         run: |
+          # Collect available binaries dynamically (Windows build is optional)
+          BINARIES=""
+          for f in binaries/veryfront-*/veryfront-*; do
+            [ -f "$f" ] && BINARIES="$BINARIES $f"
+          done
+          echo "Available binaries: $BINARIES"
+
           # Public repo release with binaries and install scripts
           gh release create "v${VERSION}" \
             --repo veryfront/veryfront \
@@ -349,11 +359,7 @@ jobs:
           # npm
           npm install -g veryfront
           ```' \
-            binaries/veryfront-macos-arm64/veryfront-macos-arm64 \
-            binaries/veryfront-macos-x64/veryfront-macos-x64 \
-            binaries/veryfront-linux-x64/veryfront-linux-x64 \
-            binaries/veryfront-linux-arm64/veryfront-linux-arm64 \
-            binaries/veryfront-windows-x64.exe/veryfront-windows-x64.exe \
+            $BINARIES \
             scripts/install.sh \
             scripts/install.ps1
 

--- a/scripts/build/prepare-framework-sources.ts
+++ b/scripts/build/prepare-framework-sources.ts
@@ -17,9 +17,9 @@
  */
 
 import { walk } from "@std/fs";
-import { dirname, join, relative } from "#std/path.ts";
+import { dirname, fromFileUrl, join, relative } from "#std/path.ts";
 
-const FRAMEWORK_ROOT = new URL("../..", import.meta.url).pathname.replace(/\/$/, "");
+const FRAMEWORK_ROOT = fromFileUrl(new URL("../..", import.meta.url));
 const SRC_ROOT = join(FRAMEWORK_ROOT, "src");
 const OUTPUT_DIR = join(FRAMEWORK_ROOT, "dist", "framework-src");
 const METADATA_FILE = join(OUTPUT_DIR, ".compile-metadata.json");


### PR DESCRIPTION
## Summary

- **Fix Windows path handling** in `prepare-framework-sources.ts`: Use `fromFileUrl()` instead of `URL.pathname` which returns `/D:/a/...` on Windows, breaking `Deno.mkdir()` and `Deno.writeTextFile()`
- **Dynamically collect available binaries** in both `prerelease` and `release` CI jobs so `gh release create` doesn't fail when the optional Windows build is missing

Fixes #282, fixes #283

## Test plan

- [ ] CI Windows cross-compile step passes (verify `prepare-framework-sources.ts` runs without path errors)
- [ ] Prerelease job completes even if Windows binary artifact is absent
- [ ] Release job completes even if Windows binary artifact is absent
- [ ] All non-Windows binaries are still included in the GitHub release