### PR TITLE
fix: pin redis to 4.6.13 to fix dnt npm build

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -233,7 +233,7 @@
     "tailwindcss/plugin": "https://esm.sh/tailwindcss@4.1.8/plugin",
     "tailwindcss/defaultTheme": "https://esm.sh/tailwindcss@4.1.8/defaultTheme",
     "tailwindcss/colors": "https://esm.sh/tailwindcss@4.1.8/colors",
-    "redis": "npm:redis",
+    "redis": "npm:redis@4.6.13",
     "pg": "npm:pg",
     "@opentelemetry/api": "npm:@opentelemetry/api@1",
     "@opentelemetry/core": "npm:@opentelemetry/core@1",

--- a/src/proxy/cache/redis-cache.ts
+++ b/src/proxy/cache/redis-cache.ts
@@ -104,7 +104,7 @@ export class RedisCache implements TokenCache {
         const client = this.client!;
 
         const pattern = `${this.prefix}*`;
-        let cursor = "0";
+        let cursor = 0;
         let totalDeleted = 0;
 
         do {
@@ -113,12 +113,12 @@ export class RedisCache implements TokenCache {
             COUNT: DEFAULT_SCAN_COUNT,
           });
 
-          cursor = String(nextCursor);
+          cursor = nextCursor;
 
           if (keys.length > 0) {
             totalDeleted += await client.del(keys);
           }
-        } while (cursor !== "0");
+        } while (cursor !== 0);
 
         if (totalDeleted > 0) {
           console.log(`[RedisCache] Cleared ${totalDeleted} keys`);

--- a/src/workflow/claude-code/event-publisher.ts
+++ b/src/workflow/claude-code/event-publisher.ts
@@ -104,7 +104,7 @@ export class RedisEventPublisher implements ClaudeCodeEventPublisher, ClaudeCode
     if (this.initialized) return;
 
     // Dynamic import to avoid loading Redis if not used
-    const { createClient } = await import("npm:redis@4.6.13");
+    const { createClient } = await import("redis");
 
     this.publishClient = createClient({ url: this.config.url });
     this.subscribeClient = createClient({ url: this.config.url });


### PR DESCRIPTION
## Summary
- Pin `redis` to `4.6.13` in `deno.json` import map to match the version used in `event-publisher.ts`
- Use the mapped `"redis"` specifier in `event-publisher.ts` dynamic import instead of hardcoded `npm:redis@4.6.13`
- Fix `scan()` cursor type from `string` to `number` for redis@4.6.13 API compatibility

## Context
The main CI prerelease job fails with:
```
Specifier npm:redis with version * did not match specifier npm:redis@4.6.13 with version 4.6.13
```
This happens during `deno task build:npm` (dnt) because `deno.json` maps `redis` to `npm:redis` (unversioned) while `event-publisher.ts` uses `import("npm:redis@4.6.13")` (pinned).

Fixes #283

## Test plan
- [ ] CI type check passes
- [ ] CI prerelease `build:npm` step succeeds