### PR TITLE
chore: bump version to 0.1.7-rc.55

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.7-rc.54",
+  "version": "0.1.7-rc.55",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",


### PR DESCRIPTION
## Summary
- Bump RC version from 0.1.7-rc.54 to 0.1.7-rc.55 to unblock prerelease CD pipeline (rc.54 was already published to npm)