### PR TITLE
feat: request-scoped environment variables for API routes

### DIFF
--- a/src/platform/compat/process.ts
+++ b/src/platform/compat/process.ts
@@ -1,4 +1,5 @@
 import { isBun as IS_BUN, isDeno as IS_DENO } from "./runtime.ts";
+import { getRequestEnv } from "../../server/env-vars/request-env-store.ts";
 
 const nodeProcess = (globalThis as { process?: typeof import("node:process") }).process;
 const hasNodeProcess = !!nodeProcess?.versions?.node;
@@ -53,6 +54,10 @@ export function env(): Record<string, string> {
 }
 
 export function getEnv(key: string): string | undefined {
+  // Request-scoped env vars take precedence (project env vars from API)
+  const scoped = getRequestEnv(key);
+  if (scoped !== undefined) return scoped;
+
   if (IS_DENO) return Deno.env.get(key);
   if (hasNodeProcess) return nodeProcess!.env[key];
   return undefined;

--- a/src/server/env-vars/env-var-source.ts
+++ b/src/server/env-vars/env-var-source.ts
@@ -1,0 +1,92 @@
+/**
+ * Environment Variable Source Interface & API Implementation
+ *
+ * Defines the contract for fetching environment variables and provides
+ * an implementation that fetches from the Veryfront REST API.
+ *
+ * @module server/env-vars/env-var-source
+ */
+
+import { getBaseLogger } from "#veryfront/utils/logger/logger.ts";
+import { injectContext } from "#veryfront/observability/tracing/otlp-setup.ts";
+
+const logger = getBaseLogger("ENV-VARS");
+
+/**
+ * Interface for fetching environment variables by environment ID.
+ */
+export interface EnvVarSource {
+  fetchByEnvironmentId(environmentId: string): Promise<Record<string, string>>;
+}
+
+interface EnvironmentVariable {
+  id: string;
+  name: string;
+  value: string;
+}
+
+interface EnvironmentResponse {
+  id: string;
+  name: string;
+  environment_variables: EnvironmentVariable[];
+}
+
+/**
+ * Fetches environment variables from the Veryfront REST API.
+ *
+ * Uses the endpoint: GET /projects/{projectSlug}/environments/{environmentId}
+ */
+export class ApiEnvVarSource implements EnvVarSource {
+  private readonly timeoutMs: number;
+
+  constructor(
+    private readonly apiBaseUrl: string,
+    private readonly apiToken: string,
+    options?: { timeoutMs?: number },
+  ) {
+    this.timeoutMs = options?.timeoutMs ?? 10_000;
+  }
+
+  async fetchByEnvironmentId(environmentId: string): Promise<Record<string, string>> {
+    const url = `${this.apiBaseUrl}/environments/${encodeURIComponent(environmentId)}/variables`;
+
+    logger.debug("[EnvVarSource] Fetching env vars", { environmentId });
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const headers = new Headers({
+        Authorization: `Bearer ${this.apiToken}`,
+        Accept: "application/json",
+      });
+      injectContext(headers);
+
+      const response = await fetch(url, { headers, signal: controller.signal });
+
+      if (!response.ok) {
+        logger.error("[EnvVarSource] API error", {
+          environmentId,
+          status: response.status,
+        });
+        throw new Error(`Failed to fetch env vars: ${response.status} ${response.statusText}`);
+      }
+
+      const data = (await response.json()) as EnvironmentResponse;
+      const vars: Record<string, string> = {};
+
+      for (const envVar of data.environment_variables ?? []) {
+        vars[envVar.name] = envVar.value;
+      }
+
+      logger.debug("[EnvVarSource] Fetched env vars", {
+        environmentId,
+        count: Object.keys(vars).length,
+      });
+
+      return vars;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/src/server/env-vars/environment-variable-cache.test.ts
+++ b/src/server/env-vars/environment-variable-cache.test.ts
@@ -1,0 +1,154 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { EnvironmentVariableCache } from "./environment-variable-cache.ts";
+import type { EnvVarSource } from "./env-var-source.ts";
+
+function createMockSource(
+  data: Record<string, Record<string, string>> = {},
+  delay = 0,
+): { source: EnvVarSource; callCount: () => number } {
+  let calls = 0;
+  return {
+    source: {
+      async fetchByEnvironmentId(environmentId: string): Promise<Record<string, string>> {
+        calls++;
+        if (delay > 0) await new Promise((r) => setTimeout(r, delay));
+        const result = data[environmentId];
+        if (!result) throw new Error(`No data for ${environmentId}`);
+        return result;
+      },
+    },
+    callCount: () => calls,
+  };
+}
+
+describe("EnvironmentVariableCache", () => {
+  it("returns vars from source on cache miss", async () => {
+    const { source } = createMockSource({ "env-1": { KEY: "value" } });
+    const cache = new EnvironmentVariableCache(source);
+
+    const vars = await cache.get("env-1");
+    assertEquals(vars, { KEY: "value" });
+  });
+
+  it("returns cached vars on cache hit", async () => {
+    const { source, callCount } = createMockSource({ "env-1": { KEY: "value" } });
+    const cache = new EnvironmentVariableCache(source);
+
+    await cache.get("env-1");
+    await cache.get("env-1");
+
+    assertEquals(callCount(), 1);
+  });
+
+  it("refetches after TTL expires", async () => {
+    const { source, callCount } = createMockSource({ "env-1": { KEY: "v1" } });
+    const cache = new EnvironmentVariableCache(source, 10); // 10ms TTL
+
+    await cache.get("env-1");
+    assertEquals(callCount(), 1);
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    await cache.get("env-1");
+    assertEquals(callCount(), 2);
+  });
+
+  it("deduplicates concurrent fetches for the same environment", async () => {
+    const { source, callCount } = createMockSource({ "env-1": { KEY: "value" } }, 20);
+    const cache = new EnvironmentVariableCache(source);
+
+    const [r1, r2, r3] = await Promise.all([
+      cache.get("env-1"),
+      cache.get("env-1"),
+      cache.get("env-1"),
+    ]);
+
+    assertEquals(callCount(), 1);
+    assertEquals(r1, { KEY: "value" });
+    assertEquals(r2, { KEY: "value" });
+    assertEquals(r3, { KEY: "value" });
+  });
+
+  it("does not deduplicate fetches for different environments", async () => {
+    const { source, callCount } = createMockSource({
+      "env-1": { A: "1" },
+      "env-2": { B: "2" },
+    }, 10);
+    const cache = new EnvironmentVariableCache(source);
+
+    const [r1, r2] = await Promise.all([
+      cache.get("env-1"),
+      cache.get("env-2"),
+    ]);
+
+    assertEquals(callCount(), 2);
+    assertEquals(r1, { A: "1" });
+    assertEquals(r2, { B: "2" });
+  });
+
+  it("returns stale data on fetch failure when cache exists", async () => {
+    let shouldFail = false;
+    const source: EnvVarSource = {
+      async fetchByEnvironmentId(_id: string) {
+        if (shouldFail) throw new Error("network error");
+        return { KEY: "stale-value" };
+      },
+    };
+    const cache = new EnvironmentVariableCache(source, 10);
+
+    // Populate cache
+    await cache.get("env-1");
+
+    // Expire cache and make source fail
+    await new Promise((r) => setTimeout(r, 20));
+    shouldFail = true;
+
+    const vars = await cache.get("env-1");
+    assertEquals(vars, { KEY: "stale-value" });
+  });
+
+  it("throws on fetch failure when no cached data exists", async () => {
+    const source: EnvVarSource = {
+      fetchByEnvironmentId: () => Promise.reject(new Error("fail")),
+    };
+    const cache = new EnvironmentVariableCache(source);
+
+    await assertRejects(
+      () => cache.get("env-1"),
+      Error,
+      "fail",
+    );
+  });
+
+  it("invalidate() removes a specific environment", async () => {
+    const { source, callCount } = createMockSource({ "env-1": { KEY: "value" } });
+    const cache = new EnvironmentVariableCache(source);
+
+    await cache.get("env-1");
+    assertEquals(callCount(), 1);
+
+    cache.invalidate("env-1");
+
+    await cache.get("env-1");
+    assertEquals(callCount(), 2);
+  });
+
+  it("invalidate() without args clears all", async () => {
+    const { source, callCount } = createMockSource({
+      "env-1": { A: "1" },
+      "env-2": { B: "2" },
+    });
+    const cache = new EnvironmentVariableCache(source);
+
+    await cache.get("env-1");
+    await cache.get("env-2");
+    assertEquals(callCount(), 2);
+
+    cache.invalidate();
+
+    await cache.get("env-1");
+    await cache.get("env-2");
+    assertEquals(callCount(), 4);
+  });
+});

--- a/src/server/env-vars/environment-variable-cache.ts
+++ b/src/server/env-vars/environment-variable-cache.ts
@@ -1,0 +1,62 @@
+/**
+ * Environment Variable Cache
+ *
+ * Caches environment variables per environment ID with TTL,
+ * deduplicates concurrent fetches, and serves stale data on failure.
+ *
+ * @module server/env-vars/environment-variable-cache
+ */
+
+import type { EnvVarSource } from "./env-var-source.ts";
+
+interface CacheEntry {
+  vars: Record<string, string>;
+  expiresAt: number;
+}
+
+export class EnvironmentVariableCache {
+  private cache = new Map<string, CacheEntry>();
+  private inflight = new Map<string, Promise<Record<string, string>>>();
+
+  constructor(
+    private readonly source: EnvVarSource,
+    private readonly ttlMs: number = 60_000,
+  ) {}
+
+  async get(environmentId: string): Promise<Record<string, string>> {
+    const cached = this.cache.get(environmentId);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.vars;
+    }
+
+    let pending = this.inflight.get(environmentId);
+    if (!pending) {
+      pending = this.source.fetchByEnvironmentId(environmentId)
+        .then((vars) => {
+          this.cache.set(environmentId, {
+            vars,
+            expiresAt: Date.now() + this.ttlMs,
+          });
+          this.inflight.delete(environmentId);
+          return vars;
+        })
+        .catch((err) => {
+          this.inflight.delete(environmentId);
+          // Stale on failure: return expired cache entry if available
+          if (cached) return cached.vars;
+          throw err;
+        });
+      this.inflight.set(environmentId, pending);
+    }
+
+    return pending;
+  }
+
+  invalidate(environmentId?: string): void {
+    if (environmentId) {
+      this.cache.delete(environmentId);
+    } else {
+      this.cache.clear();
+    }
+  }
+}

--- a/src/server/env-vars/get-env-integration.test.ts
+++ b/src/server/env-vars/get-env-integration.test.ts
@@ -1,0 +1,78 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { getRequestEnv, runWithEnv } from "./request-env-store.ts";
+
+describe("getEnv() with request-scoped env vars", () => {
+  it("returns runtime env when not in request context", () => {
+    // getEnv should fall through to Deno.env / process.env when no request context
+    const result = getEnv("__UNLIKELY_KEY_12345__");
+    assertEquals(result, undefined);
+  });
+
+  it("returns request-scoped value when in context", () => {
+    const result = runWithEnv({ MY_SCOPED_VAR: "scoped-value" }, () => {
+      return getEnv("MY_SCOPED_VAR");
+    });
+    assertEquals(result, "scoped-value");
+  });
+
+  it("request-scoped takes precedence over runtime env", () => {
+    // PATH exists in runtime env on all systems
+    const runtimePath = getEnv("PATH");
+    assertEquals(typeof runtimePath, "string");
+
+    const result = runWithEnv({ PATH: "overridden" }, () => {
+      return getEnv("PATH");
+    });
+    assertEquals(result, "overridden");
+  });
+
+  it("falls through to runtime env for unscoped keys", () => {
+    const runtimePath = getEnv("PATH");
+
+    const result = runWithEnv({ OTHER: "val" }, () => {
+      return getEnv("PATH");
+    });
+    // Should get the runtime PATH since it's not in the scoped vars
+    assertEquals(result, runtimePath);
+  });
+
+  it("concurrent requests see their own vars", async () => {
+    const results: string[] = [];
+
+    await Promise.all([
+      runWithEnv({ STRIPE_KEY: "sk_project_a" }, async () => {
+        await new Promise((r) => setTimeout(r, 10));
+        results.push(`a:${getEnv("STRIPE_KEY")}`);
+      }),
+      runWithEnv({ STRIPE_KEY: "sk_project_b" }, async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        results.push(`b:${getEnv("STRIPE_KEY")}`);
+      }),
+    ]);
+
+    assertEquals(results, ["b:sk_project_b", "a:sk_project_a"]);
+  });
+
+  it("set() in one request context doesn't affect another", async () => {
+    const resultsA: (string | undefined)[] = [];
+    const resultsB: (string | undefined)[] = [];
+
+    await Promise.all([
+      runWithEnv({ SHARED: "a" }, async () => {
+        resultsA.push(getRequestEnv("SHARED"));
+        await new Promise((r) => setTimeout(r, 10));
+        resultsA.push(getRequestEnv("SHARED"));
+      }),
+      runWithEnv({ SHARED: "b" }, async () => {
+        resultsB.push(getRequestEnv("SHARED"));
+        await new Promise((r) => setTimeout(r, 5));
+        resultsB.push(getRequestEnv("SHARED"));
+      }),
+    ]);
+
+    assertEquals(resultsA, ["a", "a"]);
+    assertEquals(resultsB, ["b", "b"]);
+  });
+});

--- a/src/server/env-vars/request-env-store.test.ts
+++ b/src/server/env-vars/request-env-store.test.ts
@@ -1,0 +1,84 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { getRequestEnv, runWithEnv } from "./request-env-store.ts";
+
+describe("request-env-store", () => {
+  describe("getRequestEnv()", () => {
+    it("returns undefined outside of a request context", () => {
+      assertEquals(getRequestEnv("ANYTHING"), undefined);
+    });
+  });
+
+  describe("runWithEnv()", () => {
+    it("makes env vars available within the callback", () => {
+      const result = runWithEnv({ MY_KEY: "my-value" }, () => {
+        return getRequestEnv("MY_KEY");
+      });
+      assertEquals(result, "my-value");
+    });
+
+    it("returns undefined for keys not in the provided vars", () => {
+      const result = runWithEnv({ A: "1" }, () => {
+        return getRequestEnv("B");
+      });
+      assertEquals(result, undefined);
+    });
+
+    it("returns the callback's return value", () => {
+      const result = runWithEnv({}, () => 42);
+      assertEquals(result, 42);
+    });
+
+    it("supports async callbacks", async () => {
+      const result = await runWithEnv({ KEY: "async-value" }, async () => {
+        await new Promise((r) => setTimeout(r, 1));
+        return getRequestEnv("KEY");
+      });
+      assertEquals(result, "async-value");
+    });
+
+    it("isolates concurrent runs", async () => {
+      const results: string[] = [];
+
+      await Promise.all([
+        runWithEnv({ PROJECT: "alpha" }, async () => {
+          await new Promise((r) => setTimeout(r, 10));
+          results.push(`a:${getRequestEnv("PROJECT")}`);
+        }),
+        runWithEnv({ PROJECT: "beta" }, async () => {
+          await new Promise((r) => setTimeout(r, 5));
+          results.push(`b:${getRequestEnv("PROJECT")}`);
+        }),
+      ]);
+
+      // beta resolves first due to shorter delay
+      assertEquals(results, ["b:beta", "a:alpha"]);
+    });
+
+    it("supports nesting — inner context takes precedence", () => {
+      const result = runWithEnv({ KEY: "outer" }, () => {
+        return runWithEnv({ KEY: "inner" }, () => {
+          return getRequestEnv("KEY");
+        });
+      });
+      assertEquals(result, "inner");
+    });
+
+    it("restores outer context after inner run", () => {
+      const result = runWithEnv({ KEY: "outer" }, () => {
+        runWithEnv({ KEY: "inner" }, () => {
+          // inner context
+        });
+        return getRequestEnv("KEY");
+      });
+      assertEquals(result, "outer");
+    });
+
+    it("cleans up after callback completes", () => {
+      runWithEnv({ KEY: "value" }, () => {
+        // in context
+      });
+      assertEquals(getRequestEnv("KEY"), undefined);
+    });
+  });
+});

--- a/src/server/env-vars/request-env-store.ts
+++ b/src/server/env-vars/request-env-store.ts
@@ -1,0 +1,29 @@
+/**
+ * Request-Scoped Environment Variable Store
+ *
+ * Uses AsyncLocalStorage to provide per-request environment variable isolation.
+ * Each API route request runs within its own context, ensuring multi-tenant safety.
+ *
+ * @module server/env-vars/request-env-store
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const envStore = new AsyncLocalStorage<Record<string, string>>();
+
+/**
+ * Run a function with request-scoped environment variables.
+ * The provided vars are available via getRequestEnv() within the callback
+ * and any async operations it initiates.
+ */
+export function runWithEnv<T>(vars: Record<string, string>, fn: () => T): T {
+  return envStore.run(vars, fn);
+}
+
+/**
+ * Get a request-scoped environment variable.
+ * Returns undefined if not in a request context or if the key doesn't exist.
+ */
+export function getRequestEnv(key: string): string | undefined {
+  return envStore.getStore()?.[key];
+}

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -8,6 +8,8 @@ import type {
 import { getApiHandler } from "./pages-api-handler.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { runWithEnv } from "../../../env-vars/request-env-store.ts";
+import type { EnvironmentVariableCache } from "../../../env-vars/environment-variable-cache.ts";
 
 type FsWrapper = {
   isMultiProjectMode?: () => boolean;
@@ -24,6 +26,7 @@ export class ApiHandlerWrapper extends BaseHandler {
   private projectDir: string;
   private adapter: import("#veryfront/platform/adapters/base.ts").RuntimeAdapter;
   private initPromise: Promise<void> | null = null;
+  private envVarCache: EnvironmentVariableCache | null = null;
 
   metadata: HandlerMetadata = {
     name: "ApiHandlerWrapper",
@@ -33,10 +36,12 @@ export class ApiHandlerWrapper extends BaseHandler {
   constructor(
     projectDir: string,
     adapter: import("#veryfront/platform/adapters/base.ts").RuntimeAdapter,
+    envVarCache?: EnvironmentVariableCache,
   ) {
     super();
     this.projectDir = projectDir;
     this.adapter = adapter;
+    this.envVarCache = envVarCache ?? null;
   }
 
   async initialize(): Promise<void> {
@@ -104,8 +109,17 @@ export class ApiHandlerWrapper extends BaseHandler {
       "api.handleWithContext",
       async () => {
         try {
-          const api = await getApiHandler(ctx);
-          const apiRes = await api.handle(req);
+          // Resolve request-scoped environment variables
+          const envVars = await this.resolveEnvVars(ctx);
+
+          const executeHandler = async () => {
+            const api = await getApiHandler(ctx);
+            return api.handle(req);
+          };
+
+          const apiRes = envVars
+            ? await runWithEnv(envVars, executeHandler)
+            : await executeHandler();
 
           if (!apiRes) {
             this.logDebug(
@@ -150,5 +164,24 @@ export class ApiHandlerWrapper extends BaseHandler {
         "api.projectSlug": ctx.projectSlug ?? "unknown",
       },
     );
+  }
+
+  /**
+   * Resolve environment variables for this request from the cache.
+   * Returns null if no cache is configured or no environment ID is available.
+   */
+  private async resolveEnvVars(ctx: HandlerContext): Promise<Record<string, string> | null> {
+    if (!this.envVarCache || !ctx.environmentId) return null;
+
+    try {
+      return await this.envVarCache.get(ctx.environmentId);
+    } catch (error) {
+      this.logDebug(
+        "[API-Wrapper] Failed to resolve env vars, continuing without",
+        { error: this.getErrorMessage(error), environmentId: ctx.environmentId },
+        ctx,
+      );
+      return null;
+    }
   }
 }

--- a/src/server/runtime-handler/handler-context-builder.ts
+++ b/src/server/runtime-handler/handler-context-builder.ts
@@ -44,6 +44,8 @@ export interface HandlerContextOptions {
   proxyToken: string | undefined;
   /** Environment name */
   environmentName: string | undefined;
+  /** Environment ID from domain lookup */
+  environmentId: string | undefined;
   /** Resolved environment */
   resolvedEnvironment: "preview" | "production";
   /** Request context (from createRequestContext) */
@@ -102,6 +104,7 @@ export function buildHandlerContext(opts: HandlerContextOptions): HandlerContext
     releaseId: opts.releaseId,
     proxyToken: opts.isLocalProject ? undefined : opts.proxyToken,
     environmentName: opts.environmentName,
+    environmentId: opts.environmentId,
     resolvedEnvironment: opts.resolvedEnvironment,
     requestContext: { ...opts.requestContext, mode: opts.resolvedEnvironment },
     routeRegistry: opts.routeRegistry,

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -44,6 +44,8 @@ import { CSSHandler } from "../handlers/request/css.handler.ts";
 import { RSCHandler } from "../handlers/request/rsc/index.ts";
 import { ModuleHandler } from "../handlers/request/module/index.ts";
 import { ApiHandlerWrapper } from "../handlers/request/api/index.ts";
+import { EnvironmentVariableCache } from "../env-vars/environment-variable-cache.ts";
+import { ApiEnvVarSource } from "../env-vars/env-var-source.ts";
 import { SSRHandler } from "../handlers/request/ssr/index.ts";
 import { NotFoundHandler } from "../handlers/response/not-found.ts";
 import { HMRHandler } from "../handlers/preview/hmr.handler.ts";
@@ -160,7 +162,14 @@ export function createVeryfrontHandler(
     enableMetrics: true,
   });
 
-  const apiHandler = new ApiHandlerWrapper(projectDir, adapter);
+  // Initialize environment variable cache for request-scoped env vars
+  const apiBaseUrl = adapter.env.get("VERYFRONT_API_BASE_URL");
+  const apiToken = adapter.env.get("VERYFRONT_API_TOKEN");
+  const envVarCache = apiBaseUrl && apiToken
+    ? new EnvironmentVariableCache(new ApiEnvVarSource(apiBaseUrl, apiToken))
+    : undefined;
+
+  const apiHandler = new ApiHandlerWrapper(projectDir, adapter, envVarCache);
 
   registry.registerAll([
     new AuthHandler(),
@@ -382,6 +391,7 @@ export function createVeryfrontHandler(
             releaseId: envRes.releaseId,
             proxyToken: reqCtx.token,
             environmentName: projectRes.environmentName,
+            environmentId: projectRes.environmentId,
             resolvedEnvironment: envRes.resolvedEnvironment ?? "preview",
             requestContext: reqCtx,
             routeRegistry: registry,

--- a/src/server/runtime-handler/project-resolution.ts
+++ b/src/server/runtime-handler/project-resolution.ts
@@ -94,6 +94,8 @@ export interface ProjectResolutionResult {
   releaseId: string | undefined;
   /** Environment name (e.g., "staging") */
   environmentName: string | undefined;
+  /** Environment ID from domain lookup */
+  environmentId: string | undefined;
   /** Resolved proxy environment (preview/production) */
   proxyEnv: ProxyEnvironment | undefined;
   /** Parsed domain information */
@@ -149,6 +151,7 @@ export async function resolveProject(
   let projectId: string | undefined = headers.projectId ?? opts.defaultProjectId;
   let releaseId: string | undefined = headers.releaseId;
   let environmentName: string | undefined;
+  let environmentId: string | undefined;
   let proxyEnv = parseProxyEnvironment(headers.environment ?? null);
 
   const shouldSkipDomainLookup = isInternalHost(host);
@@ -184,6 +187,7 @@ export async function resolveProject(
         projectId = projectId ?? lookupResult.project_id;
         releaseId = releaseId ?? lookupResult.release_id ?? undefined;
         environmentName = lookupResult.environment?.name;
+        environmentId = lookupResult.environment?.id;
 
         if (!proxyEnv) proxyEnv = deps.getEnvironmentType(lookupResult);
 
@@ -230,6 +234,7 @@ export async function resolveProject(
         releaseId = lookupResult.release_id;
         projectId = lookupResult.project_id;
         environmentName = environmentName ?? lookupResult.environment?.name;
+        environmentId = environmentId ?? lookupResult.environment?.id;
         proxyEnv = "production";
 
         logger.debug("[project-resolution] Veryfront domain release lookup successful", {
@@ -246,6 +251,7 @@ export async function resolveProject(
     projectId,
     releaseId,
     environmentName,
+    environmentId,
     proxyEnv,
     parsedDomain,
   };

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -64,6 +64,8 @@ export interface HandlerContext {
   proxyToken?: string;
   /** Actual environment name from API (e.g., "Development", "Production") */
   environmentName?: string;
+  /** Environment ID from domain lookup (used for env var fetching) */
+  environmentId?: string;
   /**
    * Resolved environment from domain lookup or proxy headers.
    * This takes precedence over requestContext.mode for cache isolation.


### PR DESCRIPTION
## Summary

Implements RFC #291 — uses AsyncLocalStorage to make project environment variables available to API route handlers via the existing `getEnv()` function. No new APIs, no context changes — existing code just works.

## Changes

### New files
- **`src/server/env-vars/request-env-store.ts`** — AsyncLocalStorage wrapper with `runWithEnv()` and `getRequestEnv()`
- **`src/server/env-vars/environment-variable-cache.ts`** — Cache with 60s TTL, fetch deduplication, stale-on-failure
- **`src/server/env-vars/env-var-source.ts`** — `EnvVarSource` interface + API fetch implementation

### Modified files
- **`src/platform/compat/process.ts`** — Patched `getEnv()` to check request scope first via `getRequestEnv()`
- **`src/server/handlers/request/api/api-handler-wrapper.ts`** — Wraps handler execution with `runWithEnv()`
- **`src/server/runtime-handler/index.ts`** — Initializes `EnvironmentVariableCache` with API credentials
- **`src/server/runtime-handler/project-resolution.ts`** — Threads `environmentId` from domain lookup
- **`src/server/runtime-handler/handler-context-builder.ts`** — Passes `environmentId` to context
- **`src/types/server.ts`** — Added `environmentId` to `HandlerContext`

### Tests (26 test steps)
- `request-env-store.test.ts`: basic get/set, nesting, isolation, async, cleanup
- `environment-variable-cache.test.ts`: cache hit/miss, TTL, dedup, stale-on-failure, invalidate
- `get-env-integration.test.ts`: scoped precedence, runtime fallthrough, concurrent isolation

## Data Flow

```
Request → Domain Lookup → environmentId
                              ↓
                      Cache lookup (TTL 60s)
                              ↓
                      AsyncLocalStorage.run(envVars, handler)
                              ↓
                      User API Route
                      getEnv("STRIPE_KEY") → "sk_live_..."
```

## Security
- **Isolation**: AsyncLocalStorage is per-request — no cross-tenant leakage
- **Server-side only**: Never serialized to client bundles
- **Graceful degradation**: Stale cache on API failure, null on no environment ID

Closes #291