### PR TITLE
fix: wrap OpenAPI discovery in runWithContext for proxy mode

### DIFF
--- a/src/server/handlers/request/openapi.handler.test.ts
+++ b/src/server/handlers/request/openapi.handler.test.ts
@@ -3,7 +3,9 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { OpenAPIHandler } from "./openapi.handler.ts";
 import type { HandlerContext } from "../types.ts";
 
-function createMockFs(opts: { existsReturn?: boolean; needsContext?: boolean } = {}) {
+function createMockFs(
+  opts: { existsReturn?: boolean; needsContext?: boolean; multiProject?: boolean } = {},
+) {
   const calls: string[] = [];
   const fs: Record<string, unknown> = {
     exists: async (_path: string) => {
@@ -25,7 +27,7 @@ function createMockFs(opts: { existsReturn?: boolean; needsContext?: boolean } =
     // Simulate extended FS adapter that requires context
     fs.isVeryfrontAdapter = () => true;
     fs.getUnderlyingAdapter = () => ({});
-    fs.isMultiProjectMode = () => true;
+    fs.isMultiProjectMode = () => opts.multiProject !== false;
     fs.isContextualMode = () => true;
     fs.getAdapterType = () => "VeryfrontFSAdapter";
     fs.runWithContext = async (
@@ -110,10 +112,66 @@ describe("server/handlers/request/openapi.handler", () => {
       assertEquals(result.response?.status, 200);
       assertEquals(calls.includes("runWithContext"), false);
     });
+
+    it("should NOT call runWithContext when extended FS lacks multi-project mode", async () => {
+      const { fs, calls } = createMockFs({ needsContext: true, multiProject: false });
+      const handler = new OpenAPIHandler();
+      const ctx = createCtx({
+        adapter: { fs } as never,
+        isLocalProject: false,
+        projectSlug: "test-project",
+        proxyToken: "test-token",
+        projectId: "proj-123",
+        resolvedEnvironment: "production",
+        parsedDomain: { branch: null } as never,
+      });
+
+      const req = new Request("https://example.com/_openapi.json");
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.response?.status, 200);
+      assertEquals(calls.includes("runWithContext"), false);
+    });
   });
 
-  describe("spec generation with populated paths in proxy mode", () => {
-    it("should discover routes when exists returns true within context", async () => {
+  describe("spec caching", () => {
+    it("should use different cache keys for different branches", async () => {
+      const { fs } = createMockFs({ needsContext: true });
+      const handler = new OpenAPIHandler();
+
+      // First request on branch "main"
+      const ctx1 = createCtx({
+        adapter: { fs } as never,
+        isLocalProject: false,
+        projectSlug: "test-project",
+        proxyToken: "test-token",
+        parsedDomain: { branch: "main" } as never,
+        releaseId: "rel-1",
+      });
+      const req1 = new Request("https://example.com/_openapi.json");
+      const result1 = await handler.handle(req1, ctx1);
+      assertEquals(result1.response?.status, 200);
+
+      // Second request on branch "feature" — should NOT serve stale spec
+      const ctx2 = createCtx({
+        adapter: { fs } as never,
+        isLocalProject: false,
+        projectSlug: "test-project",
+        proxyToken: "test-token",
+        parsedDomain: { branch: "feature" } as never,
+        releaseId: "rel-2",
+      });
+      const req2 = new Request("https://example.com/_openapi.json");
+      const result2 = await handler.handle(req2, ctx2);
+      assertEquals(result2.response?.status, 200);
+
+      // Both should succeed without serving stale cached spec from first branch
+      // (The handler's internal cacheKey should differ for different branches/releases)
+    });
+  });
+
+  describe("spec generation with route discovery in proxy mode", () => {
+    it("should attempt directory existence checks within runWithContext", async () => {
       const { fs, calls } = createMockFs({ needsContext: true, existsReturn: true });
       const handler = new OpenAPIHandler();
       const ctx = createCtx({
@@ -129,7 +187,7 @@ describe("server/handlers/request/openapi.handler", () => {
       const req = new Request("https://example.com/_openapi.json");
       await handler.handle(req, ctx);
 
-      // Verify exists was called (discovery attempted) within runWithContext
+      // Verify runWithContext was used and discovery directories were checked
       assertEquals(calls.includes("runWithContext"), true);
       const existsCalls = calls.filter((c) => c.startsWith("exists:"));
       assertEquals(existsCalls.length > 0, true);

--- a/src/server/handlers/request/openapi.handler.test.ts
+++ b/src/server/handlers/request/openapi.handler.test.ts
@@ -1,0 +1,138 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { OpenAPIHandler } from "./openapi.handler.ts";
+import type { HandlerContext } from "../types.ts";
+
+function createMockFs(opts: { existsReturn?: boolean; needsContext?: boolean } = {}) {
+  const calls: string[] = [];
+  const fs: Record<string, unknown> = {
+    exists: async (_path: string) => {
+      calls.push(`exists:${_path}`);
+      return opts.existsReturn ?? false;
+    },
+    readDir: async function* () {/* empty */},
+    readFile: async () => "",
+    stat: async () => ({
+      size: 0,
+      isFile: true,
+      isDirectory: false,
+      isSymlink: false,
+      mtime: null,
+    }),
+  };
+
+  if (opts.needsContext) {
+    // Simulate extended FS adapter that requires context
+    fs.isVeryfrontAdapter = () => true;
+    fs.getUnderlyingAdapter = () => ({});
+    fs.isMultiProjectMode = () => true;
+    fs.isContextualMode = () => true;
+    fs.getAdapterType = () => "VeryfrontFSAdapter";
+    fs.runWithContext = async (
+      _slug: string,
+      _token: string,
+      fn: () => Promise<unknown>,
+      _projectId?: string,
+      _options?: Record<string, unknown>,
+    ) => {
+      calls.push("runWithContext");
+      return await fn();
+    };
+  }
+
+  return { fs, calls };
+}
+
+function createCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter: { fs: createMockFs().fs } as never,
+    config: { openapi: { enabled: true } },
+    isLocalProject: false,
+    ...overrides,
+  } as unknown as HandlerContext;
+}
+
+describe("server/handlers/request/openapi.handler", () => {
+  describe("proxy mode uses runWithContext", () => {
+    it("should call runWithContext when in proxy mode with extended FS", async () => {
+      const { fs, calls } = createMockFs({ needsContext: true });
+      const handler = new OpenAPIHandler();
+      const ctx = createCtx({
+        adapter: { fs } as never,
+        isLocalProject: false,
+        projectSlug: "test-project",
+        proxyToken: "test-token",
+        projectId: "proj-123",
+        resolvedEnvironment: "production",
+        parsedDomain: { branch: null } as never,
+      });
+
+      const req = new Request("https://example.com/_openapi.json");
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.response?.status, 200);
+      const body = JSON.parse(await result.response!.text());
+      assertEquals(typeof body.paths, "object");
+      assertEquals(calls.includes("runWithContext"), true);
+    });
+
+    it("should NOT call runWithContext for local projects", async () => {
+      const { fs, calls } = createMockFs({ needsContext: true });
+      const handler = new OpenAPIHandler();
+      const ctx = createCtx({
+        adapter: { fs } as never,
+        isLocalProject: true,
+        projectSlug: "test-project",
+        proxyToken: "test-token",
+      });
+
+      const req = new Request("https://example.com/_openapi.json");
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.response?.status, 200);
+      assertEquals(calls.includes("runWithContext"), false);
+    });
+
+    it("should NOT call runWithContext when no proxyToken", async () => {
+      const { fs, calls } = createMockFs({ needsContext: true });
+      const handler = new OpenAPIHandler();
+      const ctx = createCtx({
+        adapter: { fs } as never,
+        isLocalProject: false,
+        projectSlug: "test-project",
+        proxyToken: undefined,
+      });
+
+      const req = new Request("https://example.com/_openapi.json");
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.response?.status, 200);
+      assertEquals(calls.includes("runWithContext"), false);
+    });
+  });
+
+  describe("spec generation with populated paths in proxy mode", () => {
+    it("should discover routes when exists returns true within context", async () => {
+      const { fs, calls } = createMockFs({ needsContext: true, existsReturn: true });
+      const handler = new OpenAPIHandler();
+      const ctx = createCtx({
+        adapter: { fs } as never,
+        isLocalProject: false,
+        projectSlug: "test-project",
+        proxyToken: "test-token",
+        projectId: "proj-123",
+        resolvedEnvironment: "production",
+        parsedDomain: { branch: null } as never,
+      });
+
+      const req = new Request("https://example.com/_openapi.json");
+      await handler.handle(req, ctx);
+
+      // Verify exists was called (discovery attempted) within runWithContext
+      assertEquals(calls.includes("runWithContext"), true);
+      const existsCalls = calls.filter((c) => c.startsWith("exists:"));
+      assertEquals(existsCalls.length > 0, true);
+    });
+  });
+});

--- a/src/server/handlers/request/openapi.handler.ts
+++ b/src/server/handlers/request/openapi.handler.ts
@@ -84,7 +84,8 @@ export class OpenAPIHandler extends BaseHandler {
 
   private async getOrGenerateSpec(ctx: HandlerContext, url: URL): Promise<OpenAPISpec> {
     const isDev = !!ctx.isLocalProject;
-    const currentKey = `${ctx.projectDir}:${ctx.projectSlug || "default"}`;
+    const branch = ctx.parsedDomain?.branch ?? "";
+    const currentKey = `${ctx.projectDir}:${ctx.projectSlug || "default"}:${branch}:${ctx.releaseId ?? ""}`;
 
     if (!isDev && this.cachedSpec && this.cacheKey === currentKey) return this.cachedSpec;
 
@@ -117,10 +118,11 @@ export class OpenAPIHandler extends BaseHandler {
       });
     };
 
-    // In proxy mode, wrap discovery in runWithContext so VFS can resolve files
+    // In proxy mode, wrap discovery in runWithContext so VFS can resolve files.
+    // Requires both extended FS adapter AND multi-project mode support.
     const extFs = isExtendedFSAdapter(ctx.adapter.fs) ? ctx.adapter.fs : null;
     const needsContext = !isDev && ctx.projectSlug && ctx.proxyToken &&
-      extFs?.runWithContext;
+      extFs?.isMultiProjectMode();
 
     const spec = needsContext
       ? await (extFs as ExtendedFileSystemAdapter).runWithContext(

--- a/src/server/handlers/request/openapi.handler.ts
+++ b/src/server/handlers/request/openapi.handler.ts
@@ -7,6 +7,10 @@ import { generateOpenAPISpec, specToYaml } from "#veryfront/routing/api/openapi/
 import type { OpenAPISpec } from "#veryfront/routing/api/openapi/types.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { logger } from "#veryfront/utils";
+import {
+  type ExtendedFileSystemAdapter,
+  isExtendedFSAdapter,
+} from "#veryfront/platform/adapters/fs/wrapper.ts";
 
 const DEFAULT_JSON_PATH = "/_openapi.json";
 const DEFAULT_YAML_PATH = "/_openapi.yaml";
@@ -84,32 +88,54 @@ export class OpenAPIHandler extends BaseHandler {
 
     if (!isDev && this.cachedSpec && this.cacheKey === currentKey) return this.cachedSpec;
 
-    const router = new DynamicRouter();
-    const pagesDir = ctx.config?.directories?.pages ?? "pages";
-    const appDirName = ctx.config?.directories?.app ?? "app";
+    const discover = async (): Promise<OpenAPISpec> => {
+      const router = new DynamicRouter();
+      const pagesDir = ctx.config?.directories?.pages ?? "pages";
+      const appDirName = ctx.config?.directories?.app ?? "app";
 
-    await this.tryDiscover(async () => {
-      const apiDir = join(ctx.projectDir, pagesDir, "api");
-      if (!(await ctx.adapter.fs.exists(apiDir))) return;
-      await discoverPagesRoutes(router, apiDir, "/api", ctx.adapter);
-    });
+      await this.tryDiscover(async () => {
+        const apiDir = join(ctx.projectDir, pagesDir, "api");
+        if (!(await ctx.adapter.fs.exists(apiDir))) return;
+        await discoverPagesRoutes(router, apiDir, "/api", ctx.adapter);
+      });
 
-    await this.tryDiscover(async () => {
-      const appApiDir = join(ctx.projectDir, appDirName, "api");
-      if (!(await ctx.adapter.fs.exists(appApiDir))) return;
-      await discoverAppRoutes(router, appApiDir, "/api", ctx.adapter);
-    });
+      await this.tryDiscover(async () => {
+        const appApiDir = join(ctx.projectDir, appDirName, "api");
+        if (!(await ctx.adapter.fs.exists(appApiDir))) return;
+        await discoverAppRoutes(router, appApiDir, "/api", ctx.adapter);
+      });
 
-    await this.tryDiscover(async () => {
-      const appDir = join(ctx.projectDir, appDirName);
-      if (!(await ctx.adapter.fs.exists(appDir))) return;
-      await discoverAppRoutes(router, appDir, "", ctx.adapter);
-    });
+      await this.tryDiscover(async () => {
+        const appDir = join(ctx.projectDir, appDirName);
+        if (!(await ctx.adapter.fs.exists(appDir))) return;
+        await discoverAppRoutes(router, appDir, "", ctx.adapter);
+      });
 
-    const serverUrl = `${url.protocol}//${url.host}`;
-    const spec = await generateOpenAPISpec(router, ctx.projectDir, ctx.adapter, ctx.config, {
-      servers: [{ url: serverUrl, description: "Current server" }],
-    });
+      const serverUrl = `${url.protocol}//${url.host}`;
+      return await generateOpenAPISpec(router, ctx.projectDir, ctx.adapter, ctx.config, {
+        servers: [{ url: serverUrl, description: "Current server" }],
+      });
+    };
+
+    // In proxy mode, wrap discovery in runWithContext so VFS can resolve files
+    const extFs = isExtendedFSAdapter(ctx.adapter.fs) ? ctx.adapter.fs : null;
+    const needsContext = !isDev && ctx.projectSlug && ctx.proxyToken &&
+      extFs?.runWithContext;
+
+    const spec = needsContext
+      ? await (extFs as ExtendedFileSystemAdapter).runWithContext(
+        ctx.projectSlug!,
+        ctx.proxyToken!,
+        discover,
+        ctx.projectId,
+        {
+          productionMode: ctx.resolvedEnvironment === "production",
+          releaseId: ctx.releaseId,
+          branch: ctx.parsedDomain?.branch ?? null,
+          environmentName: ctx.environmentName,
+        },
+      )
+      : await discover();
 
     if (!isDev) {
       this.cachedSpec = spec;


### PR DESCRIPTION
## Problem

`/_openapi.json` returns `{"paths": {}}` in production (remote/proxy mode) but works locally.

`OpenAPIHandler.getOrGenerateSpec()` calls `adapter.fs.exists()` and route discovery functions without project context. In proxy mode, VFS needs slug + token to resolve files — without it, all FS calls return empty → empty paths.

## Fix

Wrap all discovery logic in `runWithContext()` when in proxy mode (non-local project with extended FS adapter), matching the pattern already used in `adapter-factory.ts` for config loading.

## Tests

- ✅ `runWithContext` called in proxy mode with extended FS
- ✅ Not called for local projects  
- ✅ Not called without proxyToken
- ✅ Discovery happens within context

Fixes #293