### PR TITLE
fix: preserve ALS context in discovery transpiler & add fsAdapter plugin tests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.7-rc.57",
+  "version": "0.1.7-rc.58",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",

--- a/src/discovery/transpiler.test.ts
+++ b/src/discovery/transpiler.test.ts
@@ -1,0 +1,156 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { afterAll, afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
+import { clearTranspileCache, importModule } from "./transpiler.ts";
+import type { FileDiscoveryContext } from "./types.ts";
+import { stop as stopEsbuild } from "esbuild";
+
+/**
+ * Creates a mock FileSystemAdapter backed by an in-memory file map.
+ */
+function createMockAdapter(
+  files: Record<string, string>,
+): FileSystemAdapter {
+  return {
+    async readFile(path: string): Promise<string> {
+      const content = files[path];
+      if (content === undefined) throw new Error(`File not found: ${path}`);
+      return content;
+    },
+    async exists(path: string): Promise<boolean> {
+      return path in files;
+    },
+    async *readDir(path: string) {
+      const prefix = path.endsWith("/") ? path : `${path}/`;
+      const seen = new Set<string>();
+      for (const key of Object.keys(files)) {
+        if (!key.startsWith(prefix)) continue;
+        const rest = key.slice(prefix.length);
+        const name = rest.split("/")[0]!;
+        if (seen.has(name)) continue;
+        seen.add(name);
+        const isFile = !rest.includes("/");
+        yield { name, isFile, isDirectory: !isFile, isSymlink: false };
+      }
+    },
+    async stat(path: string) {
+      const isFile = path in files;
+      return {
+        size: isFile ? files[path]!.length : 0,
+        isFile,
+        isDirectory: !isFile,
+        isSymlink: false,
+        mtime: new Date(),
+      };
+    },
+    async writeFile() {},
+    async mkdir() {},
+    async remove() {},
+    async makeTempDir() {
+      return "/tmp/mock";
+    },
+    watch() {
+      return null as never;
+    },
+  } satisfies FileSystemAdapter;
+}
+
+describe("discovery/transpiler", () => {
+  afterEach(() => {
+    clearTranspileCache();
+  });
+
+  afterAll(async () => {
+    await stopEsbuild();
+  });
+
+  describe("importModule with fsAdapter", () => {
+    it("should transpile a simple module via fsAdapter", async () => {
+      const files: Record<string, string> = {
+        "/project/agents/assistant.ts": `export default { name: "test-agent" };`,
+      };
+
+      const adapter = createMockAdapter(files);
+      const context: FileDiscoveryContext = {
+        platform: "node",
+        fsAdapter: adapter,
+        baseDir: "/project",
+      };
+
+      const mod = await importModule(
+        "file:///project/agents/assistant.ts",
+        context,
+      ) as { default: { name: string } };
+
+      assertEquals(mod.default.name, "test-agent");
+    });
+
+    it("should resolve relative imports via fsAdapter plugin", async () => {
+      const files: Record<string, string> = {
+        "/project/agents/assistant.ts": [
+          `import { CONFIG } from "./config";`,
+          `export default { name: "assistant", model: CONFIG.model };`,
+        ].join("\n"),
+        "/project/agents/config.ts": [
+          `export const CONFIG = { model: "gpt-4" };`,
+        ].join("\n"),
+      };
+
+      const adapter = createMockAdapter(files);
+      const context: FileDiscoveryContext = {
+        platform: "node",
+        fsAdapter: adapter,
+        baseDir: "/project",
+      };
+
+      const mod = await importModule(
+        "file:///project/agents/assistant.ts",
+        context,
+      ) as { default: { name: string; model: string } };
+
+      assertEquals(mod.default.name, "assistant");
+      assertEquals(mod.default.model, "gpt-4");
+    });
+
+    it("should resolve deep relative imports across directories", async () => {
+      const files: Record<string, string> = {
+        "/project/agents/assistant.ts": [
+          `import { helper } from "./utils/helper";`,
+          `export default { value: helper() };`,
+        ].join("\n"),
+        "/project/agents/utils/helper.ts": [
+          `export function helper() { return 42; }`,
+        ].join("\n"),
+      };
+
+      const adapter = createMockAdapter(files);
+      const context: FileDiscoveryContext = {
+        platform: "node",
+        fsAdapter: adapter,
+        baseDir: "/project",
+      };
+
+      const mod = await importModule(
+        "file:///project/agents/assistant.ts",
+        context,
+      ) as { default: { value: number } };
+
+      assertEquals(mod.default.value, 42);
+    });
+
+    it("should throw when file is not found via fsAdapter", async () => {
+      const adapter = createMockAdapter({});
+      const context: FileDiscoveryContext = {
+        platform: "node",
+        fsAdapter: adapter,
+        baseDir: "/project",
+      };
+
+      await assertRejects(
+        () => importModule("file:///project/agents/missing.ts", context),
+        Error,
+        "Failed to read file",
+      );
+    });
+  });
+});

--- a/src/discovery/transpiler.ts
+++ b/src/discovery/transpiler.ts
@@ -13,6 +13,7 @@ import { getEsbuildLoader } from "#veryfront/utils/path-utils.ts";
 import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { FileDiscoveryContext } from "./types.ts";
 import { rewriteDiscoveryImports, rewriteForDeno } from "./import-rewriter.ts";
+import { wrapWithCurrentContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 
 const transpileCache = new Map<string, unknown>();
 
@@ -82,40 +83,50 @@ function createFsAdapterPlugin(fsAdapter: FileSystemAdapter): Plugin {
   return {
     name: "veryfront-fsadapter",
     setup(build: PluginBuild) {
-      build.onResolve({ filter: /^\.\.?\// }, async (args) => {
-        const importerDir = args.importer ? pathHelper.dirname(args.importer) : args.resolveDir;
-        const basePath = pathHelper.resolve(importerDir, args.path);
+      // Wrap callbacks with wrapWithCurrentContext to preserve the
+      // MultiProjectFSAdapter AsyncLocalStorage context across esbuild's
+      // child-process message boundary. Without this, fsAdapter.exists()
+      // and fsAdapter.readFile() cannot resolve the per-project adapter.
+      build.onResolve(
+        { filter: /^\.\.?\// },
+        wrapWithCurrentContext(async (args) => {
+          const importerDir = args.importer ? pathHelper.dirname(args.importer) : args.resolveDir;
+          const basePath = pathHelper.resolve(importerDir, args.path);
 
-        const resolvedPath = await resolveWithExtensions(basePath);
-        if (resolvedPath) return { path: resolvedPath, namespace: "fsadapter" };
+          const resolvedPath = await resolveWithExtensions(basePath);
+          if (resolvedPath) return { path: resolvedPath, namespace: "fsadapter" };
 
-        return {
-          errors: [
-            {
-              text: `Could not resolve "${args.path}" from "${importerDir}" via fsAdapter`,
-            },
-          ],
-        };
-      });
-
-      build.onLoad({ filter: /.*/, namespace: "fsadapter" }, async (args) => {
-        try {
-          const content = await fsAdapter.readFile(args.path);
-          return {
-            contents: content,
-            loader: getEsbuildLoader(args.path),
-            resolveDir: pathHelper.dirname(args.path),
-          };
-        } catch (error) {
           return {
             errors: [
               {
-                text: `Failed to load "${args.path}" from fsAdapter: ${error}`,
+                text: `Could not resolve "${args.path}" from "${importerDir}" via fsAdapter`,
               },
             ],
           };
-        }
-      });
+        }),
+      );
+
+      build.onLoad(
+        { filter: /.*/, namespace: "fsadapter" },
+        wrapWithCurrentContext(async (args) => {
+          try {
+            const content = await fsAdapter.readFile(args.path);
+            return {
+              contents: content,
+              loader: getEsbuildLoader(args.path),
+              resolveDir: pathHelper.dirname(args.path),
+            };
+          } catch (error) {
+            return {
+              errors: [
+                {
+                  text: `Failed to load "${args.path}" from fsAdapter: ${error}`,
+                },
+              ],
+            };
+          }
+        }),
+      );
     },
   };
 }

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -69,12 +69,23 @@ async function ensureProjectDiscovery(ctx: HandlerContext): Promise<void> {
       verbose: false,
     });
 
-    serverLogger.debug("[API-Wrapper] Lazy AI discovery completed", {
+    const logData = {
       projectSlug: ctx.projectSlug,
       releaseId: ctx.releaseId,
       agents: result.agents.size,
       tools: result.tools.size,
-    });
+      errors: result.errors.length,
+    };
+
+    if (result.agents.size === 0 && result.tools.size === 0) {
+      serverLogger.warn("[API-Wrapper] AI discovery found 0 agents and 0 tools", {
+        ...logData,
+        errorMessages: result.errors.map((e) => e.error.message).slice(0, 5),
+        baseDir: ctx.projectDir,
+      });
+    } else {
+      serverLogger.info("[API-Wrapper] AI discovery completed", logData);
+    }
   })();
 
   discoveredProjects.set(key, promise);
@@ -84,9 +95,10 @@ async function ensureProjectDiscovery(ctx: HandlerContext): Promise<void> {
   } catch (error) {
     // Allow retry on next request
     discoveredProjects.delete(key);
-    serverLogger.debug("[API-Wrapper] AI discovery failed (will retry)", {
+    serverLogger.warn("[API-Wrapper] AI discovery failed (will retry)", {
       projectSlug: ctx.projectSlug,
       error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
     });
   }
 }

--- a/tests/_helpers/log-guard.ts
+++ b/tests/_helpers/log-guard.ts
@@ -208,6 +208,10 @@ const allowedWarnings: string[] = [
   "loading.tsx",
   "error.tsx",
 
+  // AI discovery warnings (expected when test projects have no agents/tools)
+  "[API-Wrapper] AI discovery found 0 agents and 0 tools",
+  "[API-Wrapper] AI discovery failed",
+
   // ReloadNotifier errors (expected in tests that verify error handling)
   "[ReloadNotifier] Listener error",
   "Listener error",


### PR DESCRIPTION
## Summary
- Wrap discovery transpiler esbuild plugin callbacks with `wrapWithCurrentContext()` to preserve `MultiProjectFSAdapter` AsyncLocalStorage context across esbuild's child-process boundary
- Upgrade discovery logging from DEBUG to WARN/INFO so failures are visible in production
- Add unit tests for the esbuild fsAdapter plugin (relative imports, deep directories, error handling)

## Problem
In proxy mode (K8s), `ensureProjectDiscovery` runs agent/tool discovery inside `MultiProjectFSAdapter.runWithContext()`. esbuild's plugin callbacks (`onResolve`, `onLoad`) lose the AsyncLocalStorage context because esbuild communicates via a child process. This causes `fsAdapter.exists()`/`readFile()` to fail silently when agent files have relative imports, resulting in 0 agents discovered and the "Agent not found" error on `flow-ops.veryfront.com/api/chat`.

The same fix pattern is already applied in `module-loader/loader.ts` but was missing from the discovery transpiler.

Additionally, all discovery errors were logged at DEBUG level (invisible in production), making it impossible to diagnose.

## Changes
- **`src/discovery/transpiler.ts`** — Wrap `onResolve`/`onLoad` callbacks with `wrapWithCurrentContext()` so the multi-project adapter's ALS store is preserved across esbuild's child-process message boundary
- **`src/server/handlers/request/api/api-handler-wrapper.ts`** — Log WARN when discovery finds 0 agents/tools (with error messages and baseDir for diagnostics); log INFO on success; log WARN on failure with stack trace
- **`src/discovery/transpiler.test.ts`** *(new)* — Unit tests for fsAdapter esbuild plugin: simple module, relative imports, deep directory imports, missing file error

## Test plan
- [x] `deno task test` — new transpiler tests pass (4/4)
- [x] Pre-commit verification (fmt, lint, typecheck) passes
- [ ] Deploy and verify `flow-ops.veryfront.com/api/chat` returns agent response instead of "Agent not found"