### PR TITLE
fix: write CSS to hash-level cache on fresh generation to prevent 404s

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.7-rc.58",
+  "version": "0.1.7-rc.59",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",

--- a/src/html/styles-builder/project-css-cache.test.ts
+++ b/src/html/styles-builder/project-css-cache.test.ts
@@ -2,12 +2,55 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   clearCSSCache,
+  getCSSByHash,
   getProjectCSS,
   invalidateCompiler,
   invalidateProjectCSS,
 } from "./tailwind-compiler.ts";
 
 describe("styles-builder/project-css-cache", () => {
+  it("populates hash-level cache on fresh generation so other pods can serve CSS", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = ((input: URL | Request | string) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+
+      if (!url.includes("tailwindcss")) {
+        return Promise.reject(new Error(`Unexpected fetch URL during test: ${url}`));
+      }
+
+      return Promise.resolve(
+        new Response("@layer theme, base, components, utilities;", { status: 200 }),
+      );
+    }) as typeof fetch;
+
+    const projectSlug = `hash-cache-test-${crypto.randomUUID()}`;
+
+    try {
+      clearCSSCache();
+      invalidateCompiler();
+      invalidateProjectCSS(projectSlug);
+
+      const candidates = new Set(["text-green-500"]);
+      const result = await getProjectCSS(projectSlug, undefined, candidates, { minify: false });
+      assertEquals(result.fromCache, false);
+
+      // After fresh generation, the hash-level local cache must contain the CSS.
+      // This is what allows /_vf/css/{hash}.css to be served by any pod.
+      const cached = getCSSByHash(result.hash);
+      assertEquals(typeof cached, "string");
+      assertEquals(cached!.length > 0, true);
+    } finally {
+      globalThis.fetch = originalFetch;
+      clearCSSCache();
+      invalidateCompiler();
+      invalidateProjectCSS(projectSlug);
+    }
+  });
+
   it("invalidates project CSS cache when candidates change or explicit invalidation runs", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = ((input: URL | Request | string) => {

--- a/src/html/styles-builder/project-css-cache.ts
+++ b/src/html/styles-builder/project-css-cache.ts
@@ -231,11 +231,11 @@ export async function tryGetProjectCSSFromDistributedCache(
 // Store generated CSS
 // ============================================================================
 
-export function storeProjectCSS(
+export async function storeProjectCSS(
   context: ProjectCSSRequestContext,
   entry: ProjectCSSCacheEntry,
   candidates: Set<string>,
-): void {
+): Promise<void> {
   if (projectCSSBackend) {
     projectCSSBackend.set(context.cacheKey, JSON.stringify(entry), PROJECT_CSS_CACHE_TTL_SECONDS)
       .catch((error) => {
@@ -247,7 +247,11 @@ export function storeProjectCSS(
   }
 
   setProjectCSSLocalFallback(context.cacheKey, entry);
-  cacheProjectCSSEntryByHash(entry, candidates, context.stylesheet).catch(() => {});
+
+  // Await the hash-level cache write so other pods can serve
+  // /_vf/css/{hash}.css immediately. Without awaiting, the browser's
+  // CSS request may hit a different pod before the write completes.
+  await cacheProjectCSSEntryByHash(entry, candidates, context.stylesheet);
 }
 
 /**

--- a/src/html/styles-builder/tailwind-compiler.ts
+++ b/src/html/styles-builder/tailwind-compiler.ts
@@ -6,7 +6,6 @@ import { extractCandidates, hashCSS } from "./candidate-extractor.ts";
 import { formatCSSErrorMessage } from "./tailwind-compiler-utils.ts";
 import { getCompiler } from "./tailwind-compiler-cache.ts";
 import {
-  cacheCSSAsync,
   type CSSCacheEntry,
   DEFAULT_STYLESHEET,
   persistRegeneratedCSSEntry,
@@ -96,16 +95,11 @@ export async function getProjectCSS(
   }
 
   const hash = hashCSS(result.css);
-  storeProjectCSS(
+  await storeProjectCSS(
     context,
     { css: result.css, hash, candidatesHash: context.candidatesHash },
     candidates,
   );
-
-  // Store in hash-level cache so other pods can serve /_vf/css/{hash}.css
-  // immediately. Without this, the browser's CSS request may hit a different
-  // pod before the project-level cache propagates, causing a 404.
-  await cacheCSSAsync(result.css, hash, { candidates, stylesheet: context.stylesheet });
 
   logger.debug("[tailwind] Project CSS generated", {
     projectSlug: context.projectSlug,

--- a/src/html/styles-builder/tailwind-compiler.ts
+++ b/src/html/styles-builder/tailwind-compiler.ts
@@ -6,6 +6,7 @@ import { extractCandidates, hashCSS } from "./candidate-extractor.ts";
 import { formatCSSErrorMessage } from "./tailwind-compiler-utils.ts";
 import { getCompiler } from "./tailwind-compiler-cache.ts";
 import {
+  cacheCSSAsync,
   type CSSCacheEntry,
   DEFAULT_STYLESHEET,
   persistRegeneratedCSSEntry,
@@ -100,6 +101,11 @@ export async function getProjectCSS(
     { css: result.css, hash, candidatesHash: context.candidatesHash },
     candidates,
   );
+
+  // Store in hash-level cache so other pods can serve /_vf/css/{hash}.css
+  // immediately. Without this, the browser's CSS request may hit a different
+  // pod before the project-level cache propagates, causing a 404.
+  await cacheCSSAsync(result.css, hash, { candidates, stylesheet: context.stylesheet });
 
   logger.debug("[tailwind] Project CSS generated", {
     projectSlug: context.projectSlug,


### PR DESCRIPTION
## Summary

- Fix CSS 404 race condition on multi-pod renderer: `/_vf/css/{hash}.css` returned "not found" when the browser's CSS request hit a different pod than the one that generated the CSS
- Root cause: `getProjectCSS()` never wrote to the hash-level distributed cache (Redis) on fresh generation — only the project-level cache (fire-and-forget) was populated
- Add `await cacheCSSAsync()` after `storeProjectCSS()` so any pod can serve the CSS immediately

## Test plan

- [ ] Deploy to staging with multiple renderer pods
- [ ] Load a page and verify `/_vf/css/{hash}.css` returns valid CSS (not the "not found" comment)
- [ ] Repeat with cache cleared to trigger fresh generation path
- [ ] Monitor Redis for hash-level cache entries being written

Closes veryfront/veryfront-server#11