### PR TITLE
fix: dark mode flash prevention + Head script support

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+echo "Running pre-push checks..."
+
+# Format check
+echo "Checking formatting..."
+deno fmt --check || {
+  echo "❌ Format check failed. Run 'deno fmt' to fix."
+  exit 1
+}
+
+# Lint
+echo "Running linter..."
+deno lint || {
+  echo "❌ Lint failed."
+  exit 1
+}
+
+# Type check
+echo "Running type check..."
+deno check src/index.ts || {
+  echo "❌ Type check failed."
+  exit 1
+}
+
+# Unit tests
+echo "Running unit tests..."
+deno task test:unit || {
+  echo "❌ Tests failed."
+  exit 1
+}
+
+echo "✅ All pre-push checks passed!"

--- a/src/html/html-shell-generator.test.ts
+++ b/src/html/html-shell-generator.test.ts
@@ -271,8 +271,8 @@ describe("html-generation/html-shell-generator", () => {
       );
 
       assertStringIncludes(result, 'lang="ja"');
-      assertStringIncludes(result, 'data-theme="light"');
-      assertStringIncludes(result, "color-scheme: light");
+      // data-theme/color-scheme only set when colorSchemeFromParam is true
+      assert(!result.includes('data-theme="light"'));
     });
 
     it("should use default language when not specified", async () => {
@@ -283,7 +283,19 @@ describe("html-generation/html-shell-generator", () => {
       );
 
       assertStringIncludes(result, 'lang="en"');
-      assertStringIncludes(result, 'data-theme="light"');
+      // data-theme only set when colorSchemeFromParam is true
+      assert(!result.includes('data-theme="light"'));
+    });
+
+    it("should set data-theme when colorSchemeFromParam is true", async () => {
+      const result = await wrapInHTMLShell(
+        "<div>Content</div>",
+        createMeta(),
+        createOptions({ colorScheme: "dark", colorSchemeFromParam: true }),
+      );
+
+      assertStringIncludes(result, 'data-theme="dark"');
+      assertStringIncludes(result, "color-scheme: dark");
     });
 
     it("should add body class if specified", async () => {

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -231,10 +231,14 @@ async function generateHTMLShellPartsImpl(
 </script>`;
 
   const colorScheme = options.colorScheme ?? "light";
+  // Only set data-theme/color-scheme when explicitly set via URL param (?color_mode=dark|light).
+  const hasExplicitTheme = options.colorSchemeFromParam;
+  const themeAttrs = hasExplicitTheme
+    ? [`data-theme="${colorScheme}"`, `style="color-scheme: ${colorScheme};"`]
+    : [];
   const htmlAttrs = [
     `lang="${escapeHTML(lang)}"`,
-    `data-theme="${colorScheme}"`,
-    `style="color-scheme: ${colorScheme};"`,
+    ...themeAttrs,
     "suppressHydrationWarning",
   ].join(" ");
 

--- a/src/html/schemas/html.schema.ts
+++ b/src/html/schemas/html.schema.ts
@@ -33,6 +33,7 @@ export const HTMLGenerationOptionsSchema = z.object({
   sourceHash: z.string().optional(),
   colorScheme: colorSchemeSchema.optional(),
   colorSchemeFromParam: z.boolean().optional(),
+  colorSchemeFromHeader: z.boolean().optional(),
   environment: environmentSchema.optional(),
   headings: z
     .array(

--- a/src/react/components/Head.tsx
+++ b/src/react/components/Head.tsx
@@ -86,6 +86,37 @@ export function Head({ children }: { children: React.ReactNode }): React.ReactEl
 
       const element = document.createElement(type);
 
+      // For scripts, check if already exists to avoid double execution after SSR
+      if (type === "script") {
+        const src = props.src as string | undefined;
+        const id = props.id as string | undefined;
+
+        // Check by id first (most reliable)
+        if (id && document.getElementById(id)) {
+          return;
+        }
+        // Check by src for external scripts
+        if (src && document.querySelector(`script[src="${src}"]`)) {
+          return;
+        }
+        // For inline scripts without id, generate hash from content
+        const content = typeof props.children === "string"
+          ? props.children
+          : (props.dangerouslySetInnerHTML as { __html?: string })?.__html;
+        if (content && !id) {
+          // Simple hash: sum of char codes, then convert to base36
+          let sum = 0;
+          for (let i = 0; i < Math.min(content.length, 200); i++) {
+            sum = ((sum << 5) - sum + content.charCodeAt(i)) | 0;
+          }
+          const hash = "vf" + Math.abs(sum).toString(36);
+          if (document.querySelector(`script[data-vf-hash="${hash}"]`)) {
+            return;
+          }
+          element.setAttribute("data-vf-hash", hash);
+        }
+      }
+
       for (const [key, value] of Object.entries(props)) {
         if (key === "children") continue;
 

--- a/src/react/components/Head.tsx
+++ b/src/react/components/Head.tsx
@@ -44,6 +44,23 @@ export function Head({ children }: { children: React.ReactNode }): React.ReactEl
 
       if (type === "style") {
         collectHead({ styles: [String(props.children ?? "")] });
+        return;
+      }
+
+      if (type === "script") {
+        const script: Record<string, string | undefined> = {};
+        for (const [key, value] of Object.entries(props)) {
+          if (key === "children" || key === "dangerouslySetInnerHTML") continue;
+          if (value != null) script[key] = String(value);
+        }
+        // Handle inline script content
+        if (props.dangerouslySetInnerHTML) {
+          const html = props.dangerouslySetInnerHTML as { __html?: string };
+          if (html.__html) script.content = html.__html;
+        } else if (typeof props.children === "string") {
+          script.content = props.children;
+        }
+        collectHead({ scripts: [script] });
       }
     });
   }

--- a/src/react/components/Head.tsx
+++ b/src/react/components/Head.tsx
@@ -86,35 +86,35 @@ export function Head({ children }: { children: React.ReactNode }): React.ReactEl
 
       const element = document.createElement(type);
 
-      // For scripts, check if already exists to avoid double execution after SSR
+      // For scripts, check if already SSR'd via <Head> to avoid double execution
       if (type === "script") {
         const src = props.src as string | undefined;
         const id = props.id as string | undefined;
 
-        // Check by id first (most reliable)
-        if (id && document.getElementById(id)) {
+        // Check by id (look for SSR'd script with data-vf-head marker)
+        if (id && document.querySelector(`script[data-vf-head][id="${id}"]`)) {
           return;
         }
         // Check by src for external scripts
-        if (src && document.querySelector(`script[src="${src}"]`)) {
+        if (src && document.querySelector(`script[data-vf-head][src="${src}"]`)) {
           return;
         }
-        // For inline scripts without id, generate hash from content
+        // For inline scripts without id, check by content hash
         const content = typeof props.children === "string"
           ? props.children
           : (props.dangerouslySetInnerHTML as { __html?: string })?.__html;
         if (content && !id) {
-          // Simple hash: sum of char codes, then convert to base36
           let sum = 0;
           for (let i = 0; i < Math.min(content.length, 200); i++) {
             sum = ((sum << 5) - sum + content.charCodeAt(i)) | 0;
           }
           const hash = "vf" + Math.abs(sum).toString(36);
-          if (document.querySelector(`script[data-vf-hash="${hash}"]`)) {
+          if (document.querySelector(`script[data-vf-head][data-vf-hash="${hash}"]`)) {
             return;
           }
           element.setAttribute("data-vf-hash", hash);
         }
+        element.setAttribute("data-vf-head", "true");
       }
 
       for (const [key, value] of Object.entries(props)) {

--- a/src/react/head-collector.ts
+++ b/src/react/head-collector.ts
@@ -23,16 +23,29 @@ export interface HeadLink {
   [key: string]: string | undefined;
 }
 
+export interface HeadScript {
+  /** Inline script content */
+  content?: string;
+  /** Script src URL */
+  src?: string;
+  /** Script type (default: text/javascript) */
+  type?: string;
+  /** Additional attributes */
+  [key: string]: string | undefined;
+}
+
 export interface CollectedHead {
   title?: string;
   description?: string;
   metas: HeadMeta[];
   links: HeadLink[];
   styles: string[];
+  /** Blocking scripts - injected at top of <head> before CSS */
+  scripts: HeadScript[];
 }
 
 function createEmpty(): CollectedHead {
-  return { metas: [], links: [], styles: [] };
+  return { metas: [], links: [], styles: [], scripts: [] };
 }
 
 const headStorage = new AsyncLocalStorage<CollectedHead>();
@@ -65,6 +78,7 @@ export function collectHead(data: Partial<CollectedHead>): void {
 
   if (data.links?.length) collected.links.push(...data.links);
   if (data.styles?.length) collected.styles.push(...data.styles);
+  if (data.scripts?.length) collected.scripts.push(...data.scripts);
 }
 
 export function hasCollectedHead(): boolean {
@@ -76,7 +90,8 @@ export function hasCollectedHead(): boolean {
       collected.description ||
       collected.metas.length ||
       collected.links.length ||
-      collected.styles.length,
+      collected.styles.length ||
+      collected.scripts.length,
   );
 }
 
@@ -86,6 +101,7 @@ function clearCollectedHead(store: CollectedHead): void {
   store.metas = [];
   store.links = [];
   store.styles = [];
+  store.scripts = [];
 }
 
 export function resetHeadCollector(): void {
@@ -103,6 +119,7 @@ export function flushHeadCollector(): CollectedHead {
     metas: [...store.metas],
     links: [...store.links],
     styles: [...store.styles],
+    scripts: [...store.scripts],
   };
 
   clearCollectedHead(store);

--- a/src/react/head-collector.ts
+++ b/src/react/head-collector.ts
@@ -78,7 +78,14 @@ export function collectHead(data: Partial<CollectedHead>): void {
 
   if (data.links?.length) collected.links.push(...data.links);
   if (data.styles?.length) collected.styles.push(...data.styles);
-  if (data.scripts?.length) collected.scripts.push(...data.scripts);
+  for (const script of data.scripts ?? []) {
+    // Dedupe by id or src
+    const isDupe = collected.scripts.some((s) =>
+      (script.id && s.id === script.id) ||
+      (script.src && s.src === script.src)
+    );
+    if (!isDupe) collected.scripts.push(script);
+  }
 }
 
 export function hasCollectedHead(): boolean {

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -187,19 +187,43 @@ export class HTMLGenerator {
       reactContent,
     );
 
-    const headElements = this.buildHeadElements(head);
-    if (!headElements) return { start, end };
+    const { scripts, other } = this.buildHeadElements(head);
+    if (!scripts && !other) return { start, end };
 
-    return {
-      start: start.replace("</head>", `  ${headElements}\n</head>`),
-      end,
-    };
+    let modifiedStart = start;
+
+    // Inject blocking scripts at TOP of <head> (after opening tag, before meta/CSS)
+    if (scripts) {
+      modifiedStart = modifiedStart.replace("<head>", `<head>\n  ${scripts}`);
+    }
+
+    // Inject other head elements at BOTTOM of <head> (before closing tag)
+    if (other) {
+      modifiedStart = modifiedStart.replace("</head>", `  ${other}\n</head>`);
+    }
+
+    return { start: modifiedStart, end };
   }
 
-  private buildHeadElements(head?: CollectedHead): string {
-    if (!head) return "";
+  private buildHeadElements(head?: CollectedHead): { scripts: string; other: string } {
+    if (!head) return { scripts: "", other: "" };
 
-    const parts: string[] = [];
+    const scriptParts: string[] = [];
+    const otherParts: string[] = [];
+
+    // Scripts go at TOP of head (before CSS) to prevent flash
+    for (const script of head.scripts ?? []) {
+      const { content, ...attrs } = script;
+      const attrStr = Object.entries(attrs)
+        .filter(([, v]) => v != null)
+        .map(([k, v]) => `${k}="${v}"`)
+        .join(" ");
+      if (content) {
+        scriptParts.push(`<script${attrStr ? ` ${attrStr}` : ""}>${content}</script>`);
+      } else if (attrs.src) {
+        scriptParts.push(`<script ${attrStr}></script>`);
+      }
+    }
 
     for (const meta of head.metas) {
       if (meta.name === "description") continue;
@@ -208,7 +232,7 @@ export class HTMLGenerator {
       if (meta.name) attrs.push(`name="${meta.name}"`);
       if (meta.property) attrs.push(`property="${meta.property}"`);
       if (meta.content) attrs.push(`content="${meta.content}"`);
-      if (attrs.length) parts.push(`<meta ${attrs.join(" ")}>`);
+      if (attrs.length) otherParts.push(`<meta ${attrs.join(" ")}>`);
     }
 
     for (const link of head.links) {
@@ -216,14 +240,17 @@ export class HTMLGenerator {
         .filter(([, v]) => v != null)
         .map(([k, v]) => `${k}="${v}"`)
         .join(" ");
-      if (attrs) parts.push(`<link ${attrs}>`);
+      if (attrs) otherParts.push(`<link ${attrs}>`);
     }
 
     for (const style of head.styles) {
-      parts.push(`<style>${style}</style>`);
+      otherParts.push(`<style>${style}</style>`);
     }
 
-    return parts.join("\n  ");
+    return {
+      scripts: scriptParts.join("\n  "),
+      other: otherParts.join("\n  "),
+    };
   }
 
   private mergeFrontmatter(context: HTMLGenerationContext): MDXFrontmatter {
@@ -312,6 +339,7 @@ export class HTMLGenerator {
       sourceHash,
       colorScheme: context.options?.colorScheme,
       colorSchemeFromParam: context.options?.colorSchemeFromParam,
+      colorSchemeFromHeader: context.options?.colorSchemeFromHeader,
       environment: context.options?.environment,
       headings: context.pageBundle.headings,
       projectClasses,

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -220,7 +220,11 @@ export class HTMLGenerator {
     // Scripts go at TOP of head (before CSS) to prevent flash
     for (const script of head.scripts ?? []) {
       const { content, ...attrs } = script;
-      const attrPairs = Object.entries(attrs).filter(([, v]) => v != null);
+      const attrPairs: [string, string][] = [["data-vf-head", "true"]];
+
+      for (const [k, v] of Object.entries(attrs)) {
+        if (v != null) attrPairs.push([k, v]);
+      }
 
       // For inline scripts without id, add hash for client-side deduplication
       if (content && !attrs.id) {
@@ -228,13 +232,12 @@ export class HTMLGenerator {
         for (let i = 0; i < Math.min(content.length, 200); i++) {
           sum = ((sum << 5) - sum + content.charCodeAt(i)) | 0;
         }
-        const hash = "vf" + Math.abs(sum).toString(36);
-        attrPairs.push(["data-vf-hash", hash]);
+        attrPairs.push(["data-vf-hash", "vf" + Math.abs(sum).toString(36)]);
       }
 
       const attrStr = attrPairs.map(([k, v]) => `${k}="${v}"`).join(" ");
       if (content) {
-        scriptParts.push(`<script${attrStr ? ` ${attrStr}` : ""}>${content}</script>`);
+        scriptParts.push(`<script ${attrStr}>${content}</script>`);
       } else if (attrs.src) {
         scriptParts.push(`<script ${attrStr}></script>`);
       }

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -198,8 +198,14 @@ export class HTMLGenerator {
     }
 
     // Inject other head elements at BOTTOM of <head> (before closing tag)
+    // Use lastIndexOf to avoid matching </head> inside inline script content
     if (other) {
-      modifiedStart = modifiedStart.replace("</head>", `  ${other}\n</head>`);
+      const headCloseIdx = modifiedStart.lastIndexOf("</head>");
+      if (headCloseIdx !== -1) {
+        modifiedStart = modifiedStart.slice(0, headCloseIdx) +
+          `  ${other}\n` +
+          modifiedStart.slice(headCloseIdx);
+      }
     }
 
     return { start: modifiedStart, end };
@@ -214,10 +220,19 @@ export class HTMLGenerator {
     // Scripts go at TOP of head (before CSS) to prevent flash
     for (const script of head.scripts ?? []) {
       const { content, ...attrs } = script;
-      const attrStr = Object.entries(attrs)
-        .filter(([, v]) => v != null)
-        .map(([k, v]) => `${k}="${v}"`)
-        .join(" ");
+      const attrPairs = Object.entries(attrs).filter(([, v]) => v != null);
+
+      // For inline scripts without id, add hash for client-side deduplication
+      if (content && !attrs.id) {
+        let sum = 0;
+        for (let i = 0; i < Math.min(content.length, 200); i++) {
+          sum = ((sum << 5) - sum + content.charCodeAt(i)) | 0;
+        }
+        const hash = "vf" + Math.abs(sum).toString(36);
+        attrPairs.push(["data-vf-hash", hash]);
+      }
+
+      const attrStr = attrPairs.map(([k, v]) => `${k}="${v}"`).join(" ");
       if (content) {
         scriptParts.push(`<script${attrStr ? ` ${attrStr}` : ""}>${content}</script>`);
       } else if (attrs.src) {

--- a/src/rendering/orchestrator/types.ts
+++ b/src/rendering/orchestrator/types.ts
@@ -40,6 +40,8 @@ export interface RenderOptions {
   colorScheme?: "light" | "dark";
   /** Whether colorScheme was set via color_mode URL param (needs localStorage persistence) */
   colorSchemeFromParam?: boolean;
+  /** Whether colorScheme was set via Sec-CH-Prefers-Color-Scheme header */
+  colorSchemeFromHeader?: boolean;
   /** Deployment environment (preview or production) */
   environment?: "preview" | "production";
   /** Project slug for HTTP fallback in multi-project mode */

--- a/src/security/http/client-hints.ts
+++ b/src/security/http/client-hints.ts
@@ -10,6 +10,7 @@ export type ColorScheme = "light" | "dark";
 export interface ColorSchemeResult {
   scheme: ColorScheme;
   fromParam: boolean;
+  fromHeader: boolean;
 }
 
 export function getColorSchemeFromRequest(
@@ -23,7 +24,7 @@ export function getColorSchemeFromRequest(
     .toLowerCase();
 
   if (colorModeParam === "dark" || colorModeParam === "light") {
-    return { scheme: colorModeParam, fromParam: true };
+    return { scheme: colorModeParam, fromParam: true, fromHeader: false };
   }
 
   const headerValue = request.headers
@@ -32,9 +33,9 @@ export function getColorSchemeFromRequest(
     .trim()
     .toLowerCase();
 
-  if (headerValue === "dark") {
-    return { scheme: "dark", fromParam: false };
+  if (headerValue === "dark" || headerValue === "light") {
+    return { scheme: headerValue, fromParam: false, fromHeader: true };
   }
 
-  return { scheme: "light", fromParam: false };
+  return { scheme: "light", fromParam: false, fromHeader: false };
 }

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -99,7 +99,11 @@ export class SSRService {
       startRenderSession(renderSessionId, ctx.projectSlug, slug);
 
       const renderer = await this.getRenderer(ctx);
-      const { scheme: colorScheme, fromParam: colorSchemeFromParam, fromHeader: colorSchemeFromHeader } = getColorSchemeFromRequest(
+      const {
+        scheme: colorScheme,
+        fromParam: colorSchemeFromParam,
+        fromHeader: colorSchemeFromHeader,
+      } = getColorSchemeFromRequest(
         request,
         url,
       );

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -99,7 +99,7 @@ export class SSRService {
       startRenderSession(renderSessionId, ctx.projectSlug, slug);
 
       const renderer = await this.getRenderer(ctx);
-      const { scheme: colorScheme, fromParam: colorSchemeFromParam } = getColorSchemeFromRequest(
+      const { scheme: colorScheme, fromParam: colorSchemeFromParam, fromHeader: colorSchemeFromHeader } = getColorSchemeFromRequest(
         request,
         url,
       );
@@ -122,6 +122,7 @@ export class SSRService {
           pageId,
           colorScheme,
           colorSchemeFromParam,
+          colorSchemeFromHeader,
           environment: ctx.requestContext?.mode,
           projectSlug: ctx.projectSlug,
           noHmr,


### PR DESCRIPTION
## Summary

### Dark mode fix
- Remove default `data-theme="light"` from SSR HTML
- Only set `data-theme` when explicitly requested via URL param
- Allows next-themes ThemeProvider to work without flash

### Head script support (new feature)
- Add `<script>` collection to `<Head>` component
- Scripts injected at top of `<head>` (before CSS) for blocking behavior
- `data-vf-head` marker on all SSR'd scripts
- Client-side deduplication by id, src, or content hash
- SSR-side deduplication when collecting

### Safety improvements
- Use `lastIndexOf("</head>")` to avoid matching inside inline script content

## Usage

```tsx
// Dark mode with next-themes
<ThemeProvider attribute="data-theme" defaultTheme="system" enableSystem>
  {children}
</ThemeProvider>

// Blocking scripts via Head
<Head>
  <script id="analytics" src="/analytics.js" />
  <script id="config">{`window.CONFIG = {...}`}</script>
</Head>
```

## Test plan
- [x] Unit tests passing
- [x] Format/lint/typecheck passing
- [ ] Verify no flash when loading in dark mode
- [ ] Verify Head scripts are SSR'd and not duplicated on hydration

🤖 Generated with [Claude Code](https://claude.com/claude-code)