### PR TITLE
feat: disk cache backend + sticky session routing

### DIFF
--- a/cli/commands/serve/split-mode.ts
+++ b/cli/commands/serve/split-mode.ts
@@ -7,7 +7,7 @@
 
 import { cliLogger } from "#cli/utils";
 import { exitProcess } from "#cli/utils";
-import { SERVER_PERMISSIONS } from "#veryfront/security/deno-permissions.ts";
+import { SERVER_PERMISSIONS } from "veryfront/security";
 
 interface SplitModeOptions {
   productionServerPort: number;

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",

--- a/deno.json
+++ b/deno.json
@@ -89,6 +89,7 @@
     "veryfront/build": "./src/build/index.ts",
     "veryfront/rendering": "./src/rendering/index.ts",
     "veryfront/cache": "./src/cache/index.ts",
+    "veryfront/security": "./src/security/index.ts",
     "veryfront/errors": "./src/errors/index.ts",
     "veryfront/issues": "./src/issues/index.ts",
     "veryfront/discovery": "./src/discovery/index.ts",

--- a/src/cache/backend.ts
+++ b/src/cache/backend.ts
@@ -21,6 +21,7 @@ export {
   createDistributedCodeCacheAccessor,
   createTokenizingGateway,
   isApiCacheAvailable,
+  isDiskCacheConfigured,
   isDistributedBackend,
   MemoryCacheBackend,
   RedisCacheBackend,

--- a/src/cache/backends/disk.test.ts
+++ b/src/cache/backends/disk.test.ts
@@ -1,12 +1,38 @@
 import { assertEquals } from "@std/assert";
 import { join } from "#veryfront/compat/path/index.ts";
 import { DiskCacheBackend } from "./disk.ts";
+import {
+  runCacheInvariantTests,
+  testConcurrentAccess,
+  testKeyCollisionResistance,
+} from "../testing/invariants.ts";
 
 const TEST_DIR = join(Deno.makeTempDirSync(), "disk-cache-test");
 
 function makeBackend(): DiskCacheBackend {
   return new DiskCacheBackend(TEST_DIR);
 }
+
+/** Adapter: wraps DiskCacheBackend for the MinimalCache invariant test interface */
+function makeMinimalCache() {
+  const backend = makeBackend();
+  return {
+    get: (key: string) => backend.get(key),
+    set: (key: string, value: string, ttl?: number) => backend.set(key, value, ttl),
+    delete: (key: string) => backend.del(key),
+  };
+}
+
+Deno.test("DiskCacheBackend invariants", async (t) => {
+  const opts = {
+    createCache: makeMinimalCache,
+    createValue: () => `value-${Date.now()}-${Math.random()}`,
+    name: "disk",
+  };
+  await runCacheInvariantTests(t, opts);
+  await testKeyCollisionResistance(t, opts);
+  await testConcurrentAccess(t, opts);
+});
 
 Deno.test("DiskCacheBackend", async (t) => {
   await t.step("get returns null for missing key", async () => {
@@ -75,7 +101,8 @@ Deno.test("DiskCacheBackend", async (t) => {
   });
 
   await t.step("delByPattern removes matching keys", async () => {
-    const backend = makeBackend();
+    const isolatedDir = join(Deno.makeTempDirSync(), "delbypattern-test");
+    const backend = new DiskCacheBackend(isolatedDir);
     await backend.set("user:1:name", "alice");
     await backend.set("user:2:name", "bob");
     await backend.set("other:key", "value");
@@ -92,6 +119,16 @@ Deno.test("DiskCacheBackend", async (t) => {
     assertEquals(await backend.get("overwrite"), "v1");
     await backend.set("overwrite", "v2");
     assertEquals(await backend.get("overwrite"), "v2");
+  });
+
+  await t.step("concurrent writes to same key are safe", async () => {
+    const backend = makeBackend();
+    await Promise.all([
+      backend.set("race", "value-a"),
+      backend.set("race", "value-b"),
+    ]);
+    const result = await backend.get("race");
+    assertEquals(result === "value-a" || result === "value-b", true);
   });
 
   await t.step("concurrent writes to different keys", async () => {
@@ -111,6 +148,21 @@ Deno.test("DiskCacheBackend", async (t) => {
     const largeValue = "x".repeat(100_000);
     await backend.set("large", largeValue);
     assertEquals(await backend.get("large"), largeValue);
+  });
+
+  await t.step("delByPattern with no matching keys returns 0", async () => {
+    const backend = makeBackend();
+    await backend.set("keep:this", "value");
+    const deleted = await backend.delByPattern("nomatch:*");
+    assertEquals(deleted, 0);
+    assertEquals(await backend.get("keep:this"), "value");
+  });
+
+  await t.step("delByPattern on empty directory returns 0", async () => {
+    const emptyDir = join(Deno.makeTempDirSync(), "empty-cache");
+    const backend = new DiskCacheBackend(emptyDir);
+    const deleted = await backend.delByPattern("*");
+    assertEquals(deleted, 0);
   });
 
   await t.step("type property is 'disk'", () => {

--- a/src/cache/backends/disk.test.ts
+++ b/src/cache/backends/disk.test.ts
@@ -1,0 +1,120 @@
+import { assertEquals } from "@std/assert";
+import { join } from "#veryfront/compat/path/index.ts";
+import { DiskCacheBackend } from "./disk.ts";
+
+const TEST_DIR = join(Deno.makeTempDirSync(), "disk-cache-test");
+
+function makeBackend(): DiskCacheBackend {
+  return new DiskCacheBackend(TEST_DIR);
+}
+
+Deno.test("DiskCacheBackend", async (t) => {
+  await t.step("get returns null for missing key", async () => {
+    const backend = makeBackend();
+    assertEquals(await backend.get("nonexistent"), null);
+  });
+
+  await t.step("set and get round-trip", async () => {
+    const backend = makeBackend();
+    await backend.set("hello", "world");
+    assertEquals(await backend.get("hello"), "world");
+  });
+
+  await t.step("del removes a key", async () => {
+    const backend = makeBackend();
+    await backend.set("to-delete", "value");
+    assertEquals(await backend.get("to-delete"), "value");
+    await backend.del("to-delete");
+    assertEquals(await backend.get("to-delete"), null);
+  });
+
+  await t.step("del on nonexistent key does not throw", async () => {
+    const backend = makeBackend();
+    await backend.del("never-existed");
+  });
+
+  await t.step("TTL=0 expires very quickly", async () => {
+    const backend = makeBackend();
+    await backend.set("ttl-zero", "val", 0);
+    // TTL=0 means expiresAt = Date.now() + 0; wait 1ms to ensure it's expired
+    await new Promise((r) => setTimeout(r, 5));
+    assertEquals(await backend.get("ttl-zero"), null);
+  });
+
+  await t.step("TTL non-expired returns value", async () => {
+    const backend = makeBackend();
+    await backend.set("ttl-long", "val", 3600);
+    assertEquals(await backend.get("ttl-long"), "val");
+  });
+
+  await t.step("short TTL expires after delay", async () => {
+    const backend = makeBackend();
+    await backend.set("ttl-short", "val", 1);
+    assertEquals(await backend.get("ttl-short"), "val");
+    await new Promise((r) => setTimeout(r, 1100));
+    assertEquals(await backend.get("ttl-short"), null);
+  });
+
+  await t.step("no TTL means never expire", async () => {
+    const backend = makeBackend();
+    await backend.set("no-ttl", "forever");
+    assertEquals(await backend.get("no-ttl"), "forever");
+  });
+
+  await t.step("keys with path separators", async () => {
+    const backend = makeBackend();
+    await backend.set("a/b/c", "nested");
+    assertEquals(await backend.get("a/b/c"), "nested");
+  });
+
+  await t.step("keys with special characters", async () => {
+    const backend = makeBackend();
+    const key = "special:chars!@#$%^&*()=+[]{}|;',.<>?";
+    await backend.set(key, "special-value");
+    assertEquals(await backend.get(key), "special-value");
+  });
+
+  await t.step("delByPattern removes matching keys", async () => {
+    const backend = makeBackend();
+    await backend.set("user:1:name", "alice");
+    await backend.set("user:2:name", "bob");
+    await backend.set("other:key", "value");
+    const deleted = await backend.delByPattern("user:*");
+    assertEquals(deleted, 2);
+    assertEquals(await backend.get("user:1:name"), null);
+    assertEquals(await backend.get("user:2:name"), null);
+    assertEquals(await backend.get("other:key"), "value");
+  });
+
+  await t.step("overwrite existing key", async () => {
+    const backend = makeBackend();
+    await backend.set("overwrite", "v1");
+    assertEquals(await backend.get("overwrite"), "v1");
+    await backend.set("overwrite", "v2");
+    assertEquals(await backend.get("overwrite"), "v2");
+  });
+
+  await t.step("concurrent writes to different keys", async () => {
+    const backend = makeBackend();
+    const writes = Array.from(
+      { length: 10 },
+      (_, i) => backend.set(`concurrent-${i}`, `value-${i}`),
+    );
+    await Promise.all(writes);
+    for (let i = 0; i < 10; i++) {
+      assertEquals(await backend.get(`concurrent-${i}`), `value-${i}`);
+    }
+  });
+
+  await t.step("large value", async () => {
+    const backend = makeBackend();
+    const largeValue = "x".repeat(100_000);
+    await backend.set("large", largeValue);
+    assertEquals(await backend.get("large"), largeValue);
+  });
+
+  await t.step("type property is 'disk'", () => {
+    const backend = makeBackend();
+    assertEquals(backend.type, "disk");
+  });
+});

--- a/src/cache/backends/disk.ts
+++ b/src/cache/backends/disk.ts
@@ -31,8 +31,9 @@ export class DiskCacheBackend implements CacheBackend {
   private dir: string;
   private regexCache = new Map<string, RegExp>();
 
-  constructor(baseDir?: string) {
-    this.dir = join(baseDir ?? getCacheBaseDir(), CACHE_SUBDIR);
+  constructor(baseDir?: string, keyPrefix?: string) {
+    const base = join(baseDir ?? getCacheBaseDir(), CACHE_SUBDIR);
+    this.dir = keyPrefix ? join(base, keyPrefix) : base;
   }
 
   private filePath(key: string): string {

--- a/src/cache/backends/disk.ts
+++ b/src/cache/backends/disk.ts
@@ -70,15 +70,12 @@ export class DiskCacheBackend implements CacheBackend {
     const filePath = this.filePath(key);
     const tmpPath = `${filePath}.tmp.${Date.now()}.${Math.random().toString(36).slice(2, 8)}`;
     const content = JSON.stringify(envelope);
-    const { writeFile, rename } = await fsPromises;
+    const { writeFile, rename, unlink } = await fsPromises;
     try {
       await writeFile(tmpPath, content, "utf-8");
       await rename(tmpPath, filePath);
     } catch (error) {
-      try {
-        const { unlink } = await fsPromises;
-        await unlink(tmpPath);
-      } catch { /* ignore cleanup failure */ }
+      await unlink(tmpPath).catch(() => {});
       throw error;
     }
   }

--- a/src/cache/backends/disk.ts
+++ b/src/cache/backends/disk.ts
@@ -91,7 +91,8 @@ export class DiskCacheBackend implements CacheBackend {
   async delByPattern(pattern: string): Promise<number> {
     let regex = this.regexCache.get(pattern);
     if (!regex) {
-      regex = new RegExp(`^${pattern.replace(/\*/g, ".*").replace(/\?/g, ".")}$`);
+      const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+      regex = new RegExp(`^${escaped.replace(/\*/g, ".*").replace(/\?/g, ".")}$`);
       if (this.regexCache.size >= 100) {
         const firstKey = this.regexCache.keys().next().value as string | undefined;
         if (firstKey) this.regexCache.delete(firstKey);

--- a/src/cache/backends/disk.ts
+++ b/src/cache/backends/disk.ts
@@ -1,0 +1,122 @@
+import { join } from "#veryfront/compat/path/index.ts";
+import { getCacheBaseDir } from "#veryfront/utils/cache-dir.ts";
+import { logger } from "#veryfront/utils";
+import type { CacheBackend } from "../types.ts";
+
+const CACHE_SUBDIR = "veryfront-files";
+
+interface DiskCacheEnvelope {
+  key: string;
+  value: string;
+  expiresAt?: number;
+}
+
+function hashKey(input: string): string {
+  const seeds = [0x811c9dc5, 0x6c62272e, 0x2e726c6f, 0x636f6465];
+  return seeds
+    .map((seed) => {
+      let h = seed;
+      for (let i = 0; i < input.length; i++) {
+        h ^= input.charCodeAt(i);
+        h = Math.imul(h, 0x01000193);
+      }
+      return (h >>> 0).toString(16).padStart(8, "0");
+    })
+    .join("");
+}
+
+export class DiskCacheBackend implements CacheBackend {
+  readonly type = "disk" as const;
+  private dir: string;
+  private regexCache = new Map<string, RegExp>();
+
+  constructor(baseDir?: string) {
+    this.dir = join(baseDir ?? getCacheBaseDir(), CACHE_SUBDIR);
+  }
+
+  private filePath(key: string): string {
+    return join(this.dir, `${hashKey(key)}.json`);
+  }
+
+  private async ensureDir(): Promise<void> {
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(this.dir, { recursive: true });
+  }
+
+  async get(key: string): Promise<string | null> {
+    try {
+      const { readFile } = await import("node:fs/promises");
+      const raw = await readFile(this.filePath(key), "utf-8");
+      const envelope: DiskCacheEnvelope = JSON.parse(raw);
+      if (envelope.expiresAt != null && Date.now() > envelope.expiresAt) {
+        this.del(key).catch(() => {});
+        return null;
+      }
+      return envelope.value;
+    } catch {
+      return null;
+    }
+  }
+
+  async set(key: string, value: string, ttlSeconds?: number): Promise<void> {
+    await this.ensureDir();
+    const envelope: DiskCacheEnvelope = {
+      key,
+      value,
+      expiresAt: ttlSeconds != null ? Date.now() + ttlSeconds * 1000 : undefined,
+    };
+    const filePath = this.filePath(key);
+    const tmpPath = `${filePath}.tmp.${Date.now()}.${Math.random().toString(36).slice(2, 8)}`;
+    const content = JSON.stringify(envelope);
+    const { writeFile, rename } = await import("node:fs/promises");
+    try {
+      await writeFile(tmpPath, content, "utf-8");
+      await rename(tmpPath, filePath);
+    } catch (error) {
+      try {
+        const { unlink } = await import("node:fs/promises");
+        await unlink(tmpPath);
+      } catch { /* ignore cleanup failure */ }
+      throw error;
+    }
+  }
+
+  async del(key: string): Promise<void> {
+    try {
+      const { unlink } = await import("node:fs/promises");
+      await unlink(this.filePath(key));
+    } catch { /* File may not exist */ }
+  }
+
+  async delByPattern(pattern: string): Promise<number> {
+    let regex = this.regexCache.get(pattern);
+    if (!regex) {
+      regex = new RegExp(`^${pattern.replace(/\*/g, ".*").replace(/\?/g, ".")}$`);
+      if (this.regexCache.size >= 100) {
+        const firstKey = this.regexCache.keys().next().value as string | undefined;
+        if (firstKey) this.regexCache.delete(firstKey);
+      }
+      this.regexCache.set(pattern, regex);
+    }
+    let deleted = 0;
+    try {
+      const { readdir, readFile, unlink } = await import("node:fs/promises");
+      const files = await readdir(this.dir);
+      for (const file of files) {
+        if (!file.endsWith(".json")) continue;
+        try {
+          const filePath = join(this.dir, file);
+          const raw = await readFile(filePath, "utf-8");
+          const envelope: DiskCacheEnvelope = JSON.parse(raw);
+          if (regex.test(envelope.key)) {
+            await unlink(filePath);
+            deleted++;
+          }
+        } catch { /* Skip unreadable files */ }
+      }
+    } catch {
+      logger.debug("[DiskCache] delByPattern: directory not accessible");
+    }
+    return deleted;
+  }
+}

--- a/src/cache/backends/disk.ts
+++ b/src/cache/backends/disk.ts
@@ -4,6 +4,7 @@ import { logger } from "#veryfront/utils";
 import type { CacheBackend } from "../types.ts";
 
 const CACHE_SUBDIR = "veryfront-files";
+const fsPromises = import("node:fs/promises");
 
 interface DiskCacheEnvelope {
   key: string;
@@ -39,15 +40,16 @@ export class DiskCacheBackend implements CacheBackend {
   }
 
   private async ensureDir(): Promise<void> {
-    const { mkdir } = await import("node:fs/promises");
+    const { mkdir } = await fsPromises;
     await mkdir(this.dir, { recursive: true });
   }
 
   async get(key: string): Promise<string | null> {
     try {
-      const { readFile } = await import("node:fs/promises");
+      const { readFile } = await fsPromises;
       const raw = await readFile(this.filePath(key), "utf-8");
       const envelope: DiskCacheEnvelope = JSON.parse(raw);
+      if (envelope.key !== key) return null;
       if (envelope.expiresAt != null && Date.now() > envelope.expiresAt) {
         this.del(key).catch(() => {});
         return null;
@@ -68,13 +70,13 @@ export class DiskCacheBackend implements CacheBackend {
     const filePath = this.filePath(key);
     const tmpPath = `${filePath}.tmp.${Date.now()}.${Math.random().toString(36).slice(2, 8)}`;
     const content = JSON.stringify(envelope);
-    const { writeFile, rename } = await import("node:fs/promises");
+    const { writeFile, rename } = await fsPromises;
     try {
       await writeFile(tmpPath, content, "utf-8");
       await rename(tmpPath, filePath);
     } catch (error) {
       try {
-        const { unlink } = await import("node:fs/promises");
+        const { unlink } = await fsPromises;
         await unlink(tmpPath);
       } catch { /* ignore cleanup failure */ }
       throw error;
@@ -83,7 +85,7 @@ export class DiskCacheBackend implements CacheBackend {
 
   async del(key: string): Promise<void> {
     try {
-      const { unlink } = await import("node:fs/promises");
+      const { unlink } = await fsPromises;
       await unlink(this.filePath(key));
     } catch { /* File may not exist */ }
   }
@@ -100,7 +102,7 @@ export class DiskCacheBackend implements CacheBackend {
     }
     let deleted = 0;
     try {
-      const { readdir, readFile, unlink } = await import("node:fs/promises");
+      const { readdir, readFile, unlink } = await fsPromises;
       const files = await readdir(this.dir);
       for (const file of files) {
         if (!file.endsWith(".json")) continue;

--- a/src/cache/backends/factory.test.ts
+++ b/src/cache/backends/factory.test.ts
@@ -1,5 +1,7 @@
 import { assertEquals } from "@std/assert";
-import { createCacheBackend, isDiskCacheConfigured } from "./factory.ts";
+import { createCacheBackend, isDiskCacheConfigured, isDistributedBackend } from "./factory.ts";
+import { DiskCacheBackend } from "./disk.ts";
+import { MemoryCacheBackend } from "./memory.ts";
 
 Deno.test("factory: isDiskCacheConfigured", async (t) => {
   await t.step("returns false when no env vars set", () => {
@@ -17,4 +19,34 @@ Deno.test("factory: createCacheBackend with preferredBackend=disk", async () => 
 Deno.test("factory: createCacheBackend with preferredBackend=memory", async () => {
   const backend = await createCacheBackend({ preferredBackend: "memory" });
   assertEquals(backend.type, "memory");
+});
+
+Deno.test("factory: isDistributedBackend", async (t) => {
+  await t.step("returns true for disk backend", () => {
+    assertEquals(isDistributedBackend(new DiskCacheBackend()), true);
+  });
+
+  await t.step("returns false for memory backend", () => {
+    assertEquals(isDistributedBackend(new MemoryCacheBackend()), false);
+  });
+});
+
+Deno.test("factory: isDiskCacheConfigured responds to env vars", async (t) => {
+  await t.step("returns true when VF_CACHE_BACKEND=disk", () => {
+    Deno.env.set("VF_CACHE_BACKEND", "disk");
+    try {
+      assertEquals(isDiskCacheConfigured(), true);
+    } finally {
+      Deno.env.delete("VF_CACHE_BACKEND");
+    }
+  });
+
+  await t.step("returns true when VF_DISK_CACHE_DIR is set", () => {
+    Deno.env.set("VF_DISK_CACHE_DIR", "/tmp/test");
+    try {
+      assertEquals(isDiskCacheConfigured(), true);
+    } finally {
+      Deno.env.delete("VF_DISK_CACHE_DIR");
+    }
+  });
 });

--- a/src/cache/backends/factory.test.ts
+++ b/src/cache/backends/factory.test.ts
@@ -1,0 +1,20 @@
+import { assertEquals } from "@std/assert";
+import { createCacheBackend, isDiskCacheConfigured } from "./factory.ts";
+
+Deno.test("factory: isDiskCacheConfigured", async (t) => {
+  await t.step("returns false when no env vars set", () => {
+    // Default state: no VF_CACHE_BACKEND or VF_DISK_CACHE_DIR
+    const result = isDiskCacheConfigured();
+    assertEquals(typeof result, "boolean");
+  });
+});
+
+Deno.test("factory: createCacheBackend with preferredBackend=disk", async () => {
+  const backend = await createCacheBackend({ preferredBackend: "disk" });
+  assertEquals(backend.type, "disk");
+});
+
+Deno.test("factory: createCacheBackend with preferredBackend=memory", async () => {
+  const backend = await createCacheBackend({ preferredBackend: "memory" });
+  assertEquals(backend.type, "memory");
+});

--- a/src/cache/backends/factory.ts
+++ b/src/cache/backends/factory.ts
@@ -96,7 +96,7 @@ export function createCacheBackend(config: CacheBackendConfig = {}): Promise<Cac
 }
 
 export function isDistributedBackend(backend: CacheBackend): boolean {
-  return backend.type !== "memory" && backend.type !== "disk";
+  return backend.type !== "memory";
 }
 
 const DISTRIBUTED_CACHE_RETRY_MS = 30_000;

--- a/src/cache/backends/factory.ts
+++ b/src/cache/backends/factory.ts
@@ -12,6 +12,7 @@ import {
 import { MemoryCacheBackend } from "./memory.ts";
 import { isRedisConfigured, RedisCacheBackend } from "./redis.ts";
 import { ApiCacheBackend } from "./api.ts";
+import { DiskCacheBackend } from "./disk.ts";
 import { getEnvValue } from "./helpers.ts";
 
 const logger = baseLogger.component("cache-backend");
@@ -22,7 +23,7 @@ export type { CodeCacheGateway, TokenizingCacheGateway };
 export interface CacheBackendConfig {
   keyPrefix?: string;
   memoryMaxEntries?: number;
-  preferredBackend?: "api" | "redis" | "memory";
+  preferredBackend?: "api" | "redis" | "disk" | "memory";
   apiBaseUrl?: string;
   circuitBreakerName?: string;
 }
@@ -37,6 +38,10 @@ export function isApiCacheAvailable(): boolean {
     !!(apiUrl && !apiUrl.includes("localhost") && !apiUrl.includes("lvh.me"));
 
   return isProduction && !!apiUrl;
+}
+
+export function isDiskCacheConfigured(): boolean {
+  return getEnv("VF_CACHE_BACKEND") === "disk" || !!getEnv("VF_DISK_CACHE_DIR");
 }
 
 export function createCacheBackend(config: CacheBackendConfig = {}): Promise<CacheBackend> {
@@ -70,6 +75,15 @@ export function createCacheBackend(config: CacheBackendConfig = {}): Promise<Cac
         }
       }
 
+      const shouldUseDisk = preferredBackend === "disk" ||
+        (!preferredBackend && isDiskCacheConfigured());
+      if (shouldUseDisk) {
+        const diskDir = getEnv("VF_DISK_CACHE_DIR") || undefined;
+        logger.debug("Using disk backend");
+        span?.setAttribute("cache.backend.type", "disk");
+        return new DiskCacheBackend(diskDir);
+      }
+
       logger.debug("Using memory backend");
       span?.setAttribute("cache.backend.type", "memory");
       return new MemoryCacheBackend(memoryMaxEntries);
@@ -82,7 +96,7 @@ export function createCacheBackend(config: CacheBackendConfig = {}): Promise<Cac
 }
 
 export function isDistributedBackend(backend: CacheBackend): boolean {
-  return backend.type !== "memory";
+  return backend.type !== "memory" && backend.type !== "disk";
 }
 
 const DISTRIBUTED_CACHE_RETRY_MS = 30_000;

--- a/src/cache/backends/factory.ts
+++ b/src/cache/backends/factory.ts
@@ -81,7 +81,7 @@ export function createCacheBackend(config: CacheBackendConfig = {}): Promise<Cac
         const diskDir = getEnv("VF_DISK_CACHE_DIR") || undefined;
         logger.debug("Using disk backend");
         span?.setAttribute("cache.backend.type", "disk");
-        return new DiskCacheBackend(diskDir);
+        return new DiskCacheBackend(diskDir, keyPrefix || undefined);
       }
 
       logger.debug("Using memory backend");

--- a/src/cache/backends/factory.ts
+++ b/src/cache/backends/factory.ts
@@ -108,18 +108,7 @@ export function createDistributedCacheAccessor(
   let backend: CacheBackend | null | undefined;
   let lastFailureTime = 0;
 
-  const singleflight = new (class {
-    private promise: Promise<CacheBackend | null> | null = null;
-
-    do(fn: () => Promise<CacheBackend | null>): Promise<CacheBackend | null> {
-      if (!this.promise) {
-        this.promise = fn().finally(() => {
-          this.promise = null;
-        });
-      }
-      return this.promise;
-    }
-  })();
+  let inflight: Promise<CacheBackend | null> | null = null;
 
   return () => {
     if (backend !== undefined) {
@@ -134,27 +123,33 @@ export function createDistributedCacheAccessor(
       if (backend !== undefined) return Promise.resolve(backend);
     }
 
-    return singleflight.do(async () => {
-      try {
-        const b = await factory();
-        if (!isDistributedBackend(b)) {
-          backend = null;
+    if (!inflight) {
+      inflight = (async () => {
+        try {
+          const b = await factory();
+          if (!isDistributedBackend(b)) {
+            backend = null;
+            lastFailureTime = 0;
+            logger.debug(`[${name}] No distributed cache available (memory only)`);
+            return null;
+          }
+
+          backend = b;
           lastFailureTime = 0;
-          logger.debug(`[${name}] No distributed cache available (memory only)`);
+          logger.debug(`[${name}] Distributed cache initialized`, { type: b.type });
+          return b;
+        } catch (error) {
+          logger.debug(`[${name}] Failed to initialize distributed cache`, { error });
+          backend = null;
+          lastFailureTime = Date.now();
           return null;
         }
+      })().finally(() => {
+        inflight = null;
+      });
+    }
 
-        backend = b;
-        lastFailureTime = 0;
-        logger.debug(`[${name}] Distributed cache initialized`, { type: b.type });
-        return b;
-      } catch (error) {
-        logger.debug(`[${name}] Failed to initialize distributed cache`, { error });
-        backend = null;
-        lastFailureTime = Date.now();
-        return null;
-      }
-    });
+    return inflight;
   };
 }
 

--- a/src/cache/backends/index.ts
+++ b/src/cache/backends/index.ts
@@ -11,6 +11,7 @@ export type { CacheBackend } from "../types.ts";
 export { MemoryCacheBackend } from "./memory.ts";
 export { RedisCacheBackend } from "./redis.ts";
 export { ApiCacheBackend } from "./api.ts";
+export { DiskCacheBackend } from "./disk.ts";
 
 // Factory functions and config
 export {

--- a/src/cache/backends/index.ts
+++ b/src/cache/backends/index.ts
@@ -21,6 +21,7 @@ export {
   createDistributedCacheAccessor,
   createDistributedCodeCacheAccessor,
   isApiCacheAvailable,
+  isDiskCacheConfigured,
   isDistributedBackend,
 } from "./factory.ts";
 

--- a/src/cache/backends/memory.ts
+++ b/src/cache/backends/memory.ts
@@ -82,7 +82,8 @@ export class MemoryCacheBackend implements CacheBackend {
   delByPattern(pattern: string): Promise<number> {
     let regex = this.regexCache.get(pattern);
     if (!regex) {
-      regex = new RegExp(`^${pattern.replace(/\*/g, ".*").replace(/\?/g, ".")}$`);
+      const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+      regex = new RegExp(`^${escaped.replace(/\*/g, ".*").replace(/\?/g, ".")}$`);
 
       if (this.regexCache.size >= 100) {
         const firstKey = this.regexCache.keys().next().value as string | undefined;

--- a/src/cache/distributed-cache-init.ts
+++ b/src/cache/distributed-cache-init.ts
@@ -6,12 +6,12 @@ import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { initializeProjectCSSCache } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
 import { logger as baseLogger } from "#veryfront/utils/logger/logger.ts";
 import { isRedisConfigured } from "#veryfront/utils/redis-client.ts";
-import { isApiCacheAvailable } from "./backend.ts";
+import { isApiCacheAvailable, isDiskCacheConfigured } from "./backend.ts";
 
 const logger = baseLogger.component("distributed-cache");
 
 export interface DistributedCacheStatus {
-  backend: "api" | "redis" | "memory";
+  backend: "api" | "redis" | "disk" | "memory";
   transformCache: boolean;
   ssrModuleCache: boolean;
   fileCache: boolean;
@@ -21,6 +21,7 @@ export interface DistributedCacheStatus {
 function determineBackend(): DistributedCacheStatus["backend"] {
   if (isApiCacheAvailable()) return "api";
   if (isRedisConfigured()) return "redis";
+  if (isDiskCacheConfigured()) return "disk";
   return "memory";
 }
 

--- a/src/cache/distributed-cache-init.ts
+++ b/src/cache/distributed-cache-init.ts
@@ -62,10 +62,12 @@ export function initializeDistributedCaches(): Promise<DistributedCacheStatus> {
         projectCSSCache: wasSuccessful(results[3]),
       };
 
-      const enabled = Number(status.transformCache) +
-        Number(status.ssrModuleCache) +
-        Number(status.fileCache) +
-        Number(status.projectCSSCache);
+      const enabled = [
+        status.transformCache,
+        status.ssrModuleCache,
+        status.fileCache,
+        status.projectCSSCache,
+      ].filter(Boolean).length;
 
       if (enabled === 0) {
         logger.warn("No caches enabled despite backend being available", {

--- a/src/cache/schemas/cache-backend.schema.ts
+++ b/src/cache/schemas/cache-backend.schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const CacheBackendTypeSchema = z.enum(["memory", "redis", "api"]);
+export const CacheBackendTypeSchema = z.enum(["memory", "redis", "api", "disk"]);
 
 export const CacheSetBatchEntrySchema = z.object({
   key: z.string(),

--- a/src/cache/testing/mock-backend.ts
+++ b/src/cache/testing/mock-backend.ts
@@ -289,7 +289,8 @@ export class MockCacheBackend implements CacheBackend {
       timestamp: Date.now(),
     };
 
-    const regex = new RegExp(`^${pattern.replace(/\*/g, ".*").replace(/\?/g, ".")}$`);
+    const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+    const regex = new RegExp(`^${escaped.replace(/\*/g, ".*").replace(/\?/g, ".")}$`);
     let deleted = 0;
 
     for (const key of this.store.keys()) {

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -73,9 +73,10 @@ function resolveProxyBinding(): { hostname: string; port: number } {
 const PRODUCTION_SERVER_URL = getEnv("VERYFRONT_SERVER_URL") || "http://localhost:3001";
 
 const headlessService = getEnv("VERYFRONT_SERVER_HEADLESS_SERVICE");
-const rendererRouter = headlessService
+const staticPodIps = getEnv("VERYFRONT_SERVER_POD_IPS");
+const rendererRouter = (headlessService || staticPodIps)
   ? new RendererRouter(
-    headlessService,
+    headlessService || "static-pods",
     PRODUCTION_SERVER_URL,
     parseInt(getEnv("VERYFRONT_SERVER_POD_REFRESH_MS") || "15000"),
   )

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -33,6 +33,7 @@ import {
 } from "./tracing.ts";
 import { proxyLogger, runWithProxyRequestContext } from "./logger.ts";
 import { ErrorPages } from "../server/utils/error-html.ts";
+import { RendererRouter } from "./renderer-router.ts";
 import { parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
 import { exit, getEnv, onSignal } from "#veryfront/platform/compat/process.ts";
 import { createHttpServer, upgradeWebSocket } from "#veryfront/platform/compat/http/index.ts";
@@ -70,6 +71,15 @@ function resolveProxyBinding(): { hostname: string; port: number } {
 }
 
 const PRODUCTION_SERVER_URL = getEnv("VERYFRONT_SERVER_URL") || "http://localhost:3001";
+
+const headlessService = getEnv("VERYFRONT_SERVER_HEADLESS_SERVICE");
+const rendererRouter = headlessService
+  ? new RendererRouter(
+    headlessService,
+    PRODUCTION_SERVER_URL,
+    parseInt(getEnv("VERYFRONT_SERVER_POD_REFRESH_MS") || "15000"),
+  )
+  : null;
 const { hostname: HOST, port: PORT } = resolveProxyBinding();
 const WS_CONNECT_TIMEOUT_MS = 30000;
 // Timeout for forwarding requests to production server (SSR can take time on cold start)
@@ -323,7 +333,8 @@ function forwardToServer(req: Request): Promise<Response> {
 
           injectContext(newHeaders);
 
-          const serverUrl = new URL(url.pathname + url.search, PRODUCTION_SERVER_URL);
+          const baseUrl = rendererRouter?.resolve(ctx.projectSlug) ?? PRODUCTION_SERVER_URL;
+          const serverUrl = new URL(url.pathname + url.search, baseUrl);
 
           // Only retry idempotent methods (GET, HEAD, OPTIONS)
           const isIdempotent = ["GET", "HEAD", "OPTIONS"].includes(req.method);
@@ -536,6 +547,7 @@ function router(req: Request): Promise<Response> {
 // Graceful shutdown
 async function shutdown(): Promise<void> {
   proxyLogger.info("Shutting down");
+  rendererRouter?.close();
   await proxyHandler.close();
   await shutdownOTLP();
   proxyLogger.info("Closed connections");

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -78,7 +78,7 @@ const rendererRouter = (headlessService || staticPodIps)
   ? new RendererRouter(
     headlessService || "static-pods",
     PRODUCTION_SERVER_URL,
-    parseInt(getEnv("VERYFRONT_SERVER_POD_REFRESH_MS") || "15000"),
+    parseInt(getEnv("VERYFRONT_SERVER_POD_REFRESH_MS") || "15000") || 15000,
   )
   : null;
 const { hostname: HOST, port: PORT } = resolveProxyBinding();
@@ -334,15 +334,15 @@ function forwardToServer(req: Request): Promise<Response> {
 
           injectContext(newHeaders);
 
-          const baseUrl = rendererRouter?.resolve(ctx.projectSlug) ?? PRODUCTION_SERVER_URL;
-          const serverUrl = new URL(url.pathname + url.search, baseUrl);
-
           // Only retry idempotent methods (GET, HEAD, OPTIONS)
           const isIdempotent = ["GET", "HEAD", "OPTIONS"].includes(req.method);
           const maxRetries = isIdempotent ? VERYFRONT_SERVER_RETRY_COUNT : 0;
           let lastError: Error | null = null;
 
           for (let attempt = 0; attempt <= maxRetries; attempt++) {
+            // Re-resolve on each attempt so retries can pick a different pod
+            const baseUrl = rendererRouter?.resolve(ctx.projectSlug) ?? PRODUCTION_SERVER_URL;
+            const serverUrl = new URL(url.pathname + url.search, baseUrl);
             // Delay before retry (not on first attempt)
             if (attempt > 0) {
               proxyLogger.info(

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -557,6 +557,9 @@ async function shutdown(): Promise<void> {
 onSignal("SIGINT", shutdown);
 onSignal("SIGTERM", shutdown);
 
+// Wait for sticky-session router to resolve initial pod list
+await rendererRouter?.ready();
+
 // Initialize tracing and start server
 await initializeOTLPWithApis();
 

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -72,13 +72,13 @@ function resolveProxyBinding(): { hostname: string; port: number } {
 
 const PRODUCTION_SERVER_URL = getEnv("VERYFRONT_SERVER_URL") || "http://localhost:3001";
 
-const headlessService = getEnv("VERYFRONT_SERVER_HEADLESS_SERVICE");
-const staticPodIps = getEnv("VERYFRONT_SERVER_POD_IPS");
-const rendererRouter = (headlessService || staticPodIps)
+const discoveryHost = getEnv("VERYFRONT_SERVER_DISCOVERY_HOST");
+const staticTargets = getEnv("VERYFRONT_SERVER_TARGETS");
+const rendererRouter = (discoveryHost || staticTargets)
   ? new RendererRouter(
-    headlessService || "static-pods",
+    discoveryHost || "static-targets",
     PRODUCTION_SERVER_URL,
-    parseInt(getEnv("VERYFRONT_SERVER_POD_REFRESH_MS") || "15000") || 15000,
+    parseInt(getEnv("VERYFRONT_SERVER_DISCOVERY_INTERVAL_MS") || "15000") || 15000,
   )
   : null;
 const { hostname: HOST, port: PORT } = resolveProxyBinding();
@@ -558,7 +558,7 @@ async function shutdown(): Promise<void> {
 onSignal("SIGINT", shutdown);
 onSignal("SIGTERM", shutdown);
 
-// Wait for sticky-session router to resolve initial pod list
+// Wait for sticky-session router to resolve initial target list
 await rendererRouter?.ready();
 
 // Initialize tracing and start server

--- a/src/proxy/renderer-router.test.ts
+++ b/src/proxy/renderer-router.test.ts
@@ -130,4 +130,29 @@ Deno.test({ name: "RendererRouter", sanitizeOps: false, sanitizeResources: false
     const url = router.resolve("some-project");
     assertEquals(url.startsWith("http://10.0.0.1:"), true);
   });
+
+  await t.step("ready() resolves (first refresh completes)", async () => {
+    const router = new RendererRouter("dummy-service", fallback, 999999);
+    // ready() should resolve without throwing even if DNS fails
+    await router.ready();
+    router.close();
+  });
+
+  await t.step("falls back when pod list is stale", () => {
+    const router = new RendererRouter("dummy-service", fallback, 999999);
+    router._setPods(["10.0.0.1", "10.0.0.2"]);
+    // Set last refresh to 6 minutes ago (exceeds 5-minute staleness threshold)
+    router._setLastRefresh(Date.now() - 6 * 60 * 1000);
+    assertEquals(router.resolve("my-project"), fallback);
+    router.close();
+  });
+
+  await t.step("routes normally when pod list is fresh", () => {
+    const router = new RendererRouter("dummy-service", fallback, 999999);
+    router._setPods(["10.0.0.1", "10.0.0.2"]);
+    // _setPods sets lastSuccessfulRefresh to now, so it should be fresh
+    const url = router.resolve("my-project");
+    assertNotEquals(url, fallback);
+    router.close();
+  });
 });

--- a/src/proxy/renderer-router.test.ts
+++ b/src/proxy/renderer-router.test.ts
@@ -155,4 +155,20 @@ Deno.test({ name: "RendererRouter", sanitizeOps: false, sanitizeResources: false
     assertNotEquals(url, fallback);
     router.close();
   });
+
+  await t.step("uses static pod IPs from env var", async () => {
+    Deno.env.set("VERYFRONT_SERVER_POD_IPS", "10.0.1.1,10.0.1.2,10.0.1.3");
+    try {
+      const router = new RendererRouter("unused-service", fallback, 999999);
+      assertEquals(router.podCount, 3);
+      const url = router.resolve("my-project");
+      assertNotEquals(url, fallback);
+      assertEquals(url.startsWith("http://10.0.1."), true);
+      // Should be immediately ready (no DNS)
+      await router.ready();
+      router.close();
+    } finally {
+      Deno.env.delete("VERYFRONT_SERVER_POD_IPS");
+    }
+  });
 });

--- a/src/proxy/renderer-router.test.ts
+++ b/src/proxy/renderer-router.test.ts
@@ -1,0 +1,133 @@
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { jumpHash, RendererRouter } from "./renderer-router.ts";
+
+Deno.test("jumpHash", async (t) => {
+  await t.step("returns value in range [0, numBuckets)", () => {
+    for (let n = 1; n <= 20; n++) {
+      for (let i = 0; i < 50; i++) {
+        const result = jumpHash(`key-${i}`, n);
+        assertEquals(result >= 0, true, `expected >= 0, got ${result}`);
+        assertEquals(result < n, true, `expected < ${n}, got ${result}`);
+      }
+    }
+  });
+
+  await t.step("is deterministic", () => {
+    assertEquals(jumpHash("test", 10), jumpHash("test", 10));
+    assertEquals(jumpHash("project-abc", 5), jumpHash("project-abc", 5));
+  });
+
+  await t.step("distributes keys across buckets", () => {
+    const buckets = new Map<number, number>();
+    const numBuckets = 10;
+    const numKeys = 10_000;
+    for (let i = 0; i < numKeys; i++) {
+      const b = jumpHash(`key-${i}`, numBuckets);
+      buckets.set(b, (buckets.get(b) || 0) + 1);
+    }
+    // Every bucket should be hit
+    assertEquals(buckets.size, numBuckets);
+    // Each bucket should get roughly 1/numBuckets of keys (within 50% tolerance)
+    const expected = numKeys / numBuckets;
+    for (const [bucket, count] of buckets) {
+      assertEquals(
+        count > expected * 0.5 && count < expected * 1.5,
+        true,
+        `bucket ${bucket} got ${count} keys, expected ~${expected}`,
+      );
+    }
+  });
+
+  await t.step("single bucket always returns 0", () => {
+    for (let i = 0; i < 100; i++) {
+      assertEquals(jumpHash(`key-${i}`, 1), 0);
+    }
+  });
+
+  await t.step("minimal remapping when adding a bucket", () => {
+    const numKeys = 1000;
+    let changed = 0;
+    for (let i = 0; i < numKeys; i++) {
+      const key = `key-${i}`;
+      if (jumpHash(key, 10) !== jumpHash(key, 11)) changed++;
+    }
+    // At most ~1/11 of keys should remap
+    assertEquals(changed < numKeys * 0.2, true, `too many remapped: ${changed}/${numKeys}`);
+  });
+
+  await t.step("minimal remapping when removing a bucket", () => {
+    const numKeys = 1000;
+    let changed = 0;
+    for (let i = 0; i < numKeys; i++) {
+      const key = `key-${i}`;
+      if (jumpHash(key, 10) !== jumpHash(key, 9)) changed++;
+    }
+    // At most ~1/10 of keys should remap
+    assertEquals(changed < numKeys * 0.2, true, `too many remapped: ${changed}/${numKeys}`);
+  });
+});
+
+Deno.test({ name: "RendererRouter", sanitizeOps: false, sanitizeResources: false }, async (t) => {
+  const fallback = "http://fallback:3001";
+
+  await t.step("returns fallback when no slug", () => {
+    const router = new RendererRouter("dummy-service", fallback, 999999);
+    router._setPods(["10.0.0.1", "10.0.0.2"]);
+    assertEquals(router.resolve(undefined), fallback);
+    router.close();
+  });
+
+  await t.step("returns fallback when no pods", () => {
+    const router = new RendererRouter("dummy-service", fallback, 999999);
+    assertEquals(router.resolve("my-project"), fallback);
+    router.close();
+  });
+
+  await t.step("routes to a pod when slug and pods available", () => {
+    const router = new RendererRouter("dummy-service", fallback, 999999);
+    router._setPods(["10.0.0.1", "10.0.0.2", "10.0.0.3"]);
+    const url = router.resolve("my-project");
+    assertNotEquals(url, fallback);
+    assertEquals(url.startsWith("http://10.0.0."), true);
+    router.close();
+  });
+
+  await t.step("is deterministic for same slug", () => {
+    const router = new RendererRouter("dummy-service", fallback, 999999);
+    router._setPods(["10.0.0.1", "10.0.0.2", "10.0.0.3"]);
+    const url1 = router.resolve("my-project");
+    const url2 = router.resolve("my-project");
+    assertEquals(url1, url2);
+    router.close();
+  });
+
+  await t.step("distributes across pods", () => {
+    const router = new RendererRouter("dummy-service", fallback, 999999);
+    const pods = ["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5"];
+    router._setPods(pods);
+    const seen = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      seen.add(router.resolve(`project-${i}`)!);
+    }
+    // Should hit at least 3 out of 5 pods
+    assertEquals(seen.size >= 3, true, `only hit ${seen.size} pods`);
+    router.close();
+  });
+
+  await t.step("podCount reflects injected pods", () => {
+    const router = new RendererRouter("dummy-service", fallback, 999999);
+    assertEquals(router.podCount, 0);
+    router._setPods(["10.0.0.1", "10.0.0.2"]);
+    assertEquals(router.podCount, 2);
+    router.close();
+  });
+
+  await t.step("resolve still works after close", () => {
+    const router = new RendererRouter("dummy-service", fallback, 999999);
+    router._setPods(["10.0.0.1"]);
+    router.close();
+    // Should still resolve with cached pods
+    const url = router.resolve("some-project");
+    assertEquals(url.startsWith("http://10.0.0.1:"), true);
+  });
+});

--- a/src/proxy/renderer-router.test.ts
+++ b/src/proxy/renderer-router.test.ts
@@ -71,21 +71,21 @@ Deno.test({ name: "RendererRouter", sanitizeOps: false, sanitizeResources: false
   const fallback = "http://fallback:3001";
 
   await t.step("returns fallback when no slug", () => {
-    const router = new RendererRouter("dummy-service", fallback, 999999);
-    router._setPods(["10.0.0.1", "10.0.0.2"]);
+    const router = new RendererRouter("dummy-host", fallback, 999999);
+    router._setTargets(["10.0.0.1", "10.0.0.2"]);
     assertEquals(router.resolve(undefined), fallback);
     router.close();
   });
 
-  await t.step("returns fallback when no pods", () => {
-    const router = new RendererRouter("dummy-service", fallback, 999999);
+  await t.step("returns fallback when no targets", () => {
+    const router = new RendererRouter("dummy-host", fallback, 999999);
     assertEquals(router.resolve("my-project"), fallback);
     router.close();
   });
 
-  await t.step("routes to a pod when slug and pods available", () => {
-    const router = new RendererRouter("dummy-service", fallback, 999999);
-    router._setPods(["10.0.0.1", "10.0.0.2", "10.0.0.3"]);
+  await t.step("routes to a target when slug and targets available", () => {
+    const router = new RendererRouter("dummy-host", fallback, 999999);
+    router._setTargets(["10.0.0.1", "10.0.0.2", "10.0.0.3"]);
     const url = router.resolve("my-project");
     assertNotEquals(url, fallback);
     assertEquals(url.startsWith("http://10.0.0."), true);
@@ -93,74 +93,74 @@ Deno.test({ name: "RendererRouter", sanitizeOps: false, sanitizeResources: false
   });
 
   await t.step("is deterministic for same slug", () => {
-    const router = new RendererRouter("dummy-service", fallback, 999999);
-    router._setPods(["10.0.0.1", "10.0.0.2", "10.0.0.3"]);
+    const router = new RendererRouter("dummy-host", fallback, 999999);
+    router._setTargets(["10.0.0.1", "10.0.0.2", "10.0.0.3"]);
     const url1 = router.resolve("my-project");
     const url2 = router.resolve("my-project");
     assertEquals(url1, url2);
     router.close();
   });
 
-  await t.step("distributes across pods", () => {
-    const router = new RendererRouter("dummy-service", fallback, 999999);
-    const pods = ["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5"];
-    router._setPods(pods);
+  await t.step("distributes across targets", () => {
+    const router = new RendererRouter("dummy-host", fallback, 999999);
+    const targets = ["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5"];
+    router._setTargets(targets);
     const seen = new Set<string>();
     for (let i = 0; i < 100; i++) {
       seen.add(router.resolve(`project-${i}`)!);
     }
-    // Should hit at least 3 out of 5 pods
-    assertEquals(seen.size >= 3, true, `only hit ${seen.size} pods`);
+    // Should hit at least 3 out of 5 targets
+    assertEquals(seen.size >= 3, true, `only hit ${seen.size} targets`);
     router.close();
   });
 
-  await t.step("podCount reflects injected pods", () => {
-    const router = new RendererRouter("dummy-service", fallback, 999999);
-    assertEquals(router.podCount, 0);
-    router._setPods(["10.0.0.1", "10.0.0.2"]);
-    assertEquals(router.podCount, 2);
+  await t.step("targetCount reflects injected targets", () => {
+    const router = new RendererRouter("dummy-host", fallback, 999999);
+    assertEquals(router.targetCount, 0);
+    router._setTargets(["10.0.0.1", "10.0.0.2"]);
+    assertEquals(router.targetCount, 2);
     router.close();
   });
 
   await t.step("resolve still works after close", () => {
-    const router = new RendererRouter("dummy-service", fallback, 999999);
-    router._setPods(["10.0.0.1"]);
+    const router = new RendererRouter("dummy-host", fallback, 999999);
+    router._setTargets(["10.0.0.1"]);
     router.close();
-    // Should still resolve with cached pods
+    // Should still resolve with cached targets
     const url = router.resolve("some-project");
     assertEquals(url.startsWith("http://10.0.0.1:"), true);
   });
 
   await t.step("ready() resolves (first refresh completes)", async () => {
-    const router = new RendererRouter("dummy-service", fallback, 999999);
+    const router = new RendererRouter("dummy-host", fallback, 999999);
     // ready() should resolve without throwing even if DNS fails
     await router.ready();
     router.close();
   });
 
-  await t.step("falls back when pod list is stale", () => {
-    const router = new RendererRouter("dummy-service", fallback, 999999);
-    router._setPods(["10.0.0.1", "10.0.0.2"]);
+  await t.step("falls back when target list is stale", () => {
+    const router = new RendererRouter("dummy-host", fallback, 999999);
+    router._setTargets(["10.0.0.1", "10.0.0.2"]);
     // Set last refresh to 6 minutes ago (exceeds 5-minute staleness threshold)
     router._setLastRefresh(Date.now() - 6 * 60 * 1000);
     assertEquals(router.resolve("my-project"), fallback);
     router.close();
   });
 
-  await t.step("routes normally when pod list is fresh", () => {
-    const router = new RendererRouter("dummy-service", fallback, 999999);
-    router._setPods(["10.0.0.1", "10.0.0.2"]);
-    // _setPods sets lastSuccessfulRefresh to now, so it should be fresh
+  await t.step("routes normally when target list is fresh", () => {
+    const router = new RendererRouter("dummy-host", fallback, 999999);
+    router._setTargets(["10.0.0.1", "10.0.0.2"]);
+    // _setTargets sets lastSuccessfulRefresh to now, so it should be fresh
     const url = router.resolve("my-project");
     assertNotEquals(url, fallback);
     router.close();
   });
 
-  await t.step("uses static pod IPs from env var", async () => {
-    Deno.env.set("VERYFRONT_SERVER_POD_IPS", "10.0.1.1,10.0.1.2,10.0.1.3");
+  await t.step("uses static targets from env var", async () => {
+    Deno.env.set("VERYFRONT_SERVER_TARGETS", "10.0.1.1,10.0.1.2,10.0.1.3");
     try {
-      const router = new RendererRouter("unused-service", fallback, 999999);
-      assertEquals(router.podCount, 3);
+      const router = new RendererRouter("unused-host", fallback, 999999);
+      assertEquals(router.targetCount, 3);
       const url = router.resolve("my-project");
       assertNotEquals(url, fallback);
       assertEquals(url.startsWith("http://10.0.1."), true);
@@ -168,7 +168,7 @@ Deno.test({ name: "RendererRouter", sanitizeOps: false, sanitizeResources: false
       await router.ready();
       router.close();
     } finally {
-      Deno.env.delete("VERYFRONT_SERVER_POD_IPS");
+      Deno.env.delete("VERYFRONT_SERVER_TARGETS");
     }
   });
 });

--- a/src/proxy/renderer-router.ts
+++ b/src/proxy/renderer-router.ts
@@ -37,14 +37,14 @@ export class RendererRouter {
   private serverPort: number;
   private lastSuccessfulRefresh = 0;
   private _ready: Promise<void>;
-  private useStaticPods: boolean;
 
   constructor(
     private headlessService: string,
     private fallbackUrl: string,
     refreshMs?: number,
   ) {
-    const parsed = parseInt(getEnv("VERYFRONT_SERVER_PORT") || String(DEFAULT_SERVER_PORT));
+    const portEnv = getEnv("VERYFRONT_SERVER_PORT");
+    const parsed = portEnv ? parseInt(portEnv) : NaN;
     this.serverPort = Number.isNaN(parsed) ? DEFAULT_SERVER_PORT : parsed;
 
     // Support static pod IPs via env var for local testing (bypasses DNS)
@@ -52,13 +52,11 @@ export class RendererRouter {
     if (staticPodIps) {
       this.pods = staticPodIps.split(",").map((ip) => ip.trim()).filter(Boolean).sort();
       this.lastSuccessfulRefresh = Date.now();
-      this.useStaticPods = true;
       this._ready = Promise.resolve();
       proxyLogger.debug("[RendererRouter] Using static pod IPs", { pods: this.pods.length });
       return;
     }
 
-    this.useStaticPods = false;
     this._ready = this.refreshPods();
     const interval = refreshMs ?? DEFAULT_REFRESH_MS;
     this.refreshTimer = setInterval(() => this.refreshPods(), interval);

--- a/src/proxy/renderer-router.ts
+++ b/src/proxy/renderer-router.ts
@@ -37,6 +37,7 @@ export class RendererRouter {
   private serverPort: number;
   private lastSuccessfulRefresh = 0;
   private _ready: Promise<void>;
+  private useStaticPods: boolean;
 
   constructor(
     private headlessService: string,
@@ -45,6 +46,19 @@ export class RendererRouter {
   ) {
     const parsed = parseInt(getEnv("VERYFRONT_SERVER_PORT") || String(DEFAULT_SERVER_PORT));
     this.serverPort = Number.isNaN(parsed) ? DEFAULT_SERVER_PORT : parsed;
+
+    // Support static pod IPs via env var for local testing (bypasses DNS)
+    const staticPodIps = getEnv("VERYFRONT_SERVER_POD_IPS");
+    if (staticPodIps) {
+      this.pods = staticPodIps.split(",").map((ip) => ip.trim()).filter(Boolean).sort();
+      this.lastSuccessfulRefresh = Date.now();
+      this.useStaticPods = true;
+      this._ready = Promise.resolve();
+      proxyLogger.debug("[RendererRouter] Using static pod IPs", { pods: this.pods.length });
+      return;
+    }
+
+    this.useStaticPods = false;
     this._ready = this.refreshPods();
     const interval = refreshMs ?? DEFAULT_REFRESH_MS;
     this.refreshTimer = setInterval(() => this.refreshPods(), interval);

--- a/src/proxy/renderer-router.ts
+++ b/src/proxy/renderer-router.ts
@@ -1,0 +1,91 @@
+import { resolve4 } from "node:dns/promises";
+import { proxyLogger } from "./logger.ts";
+import { getEnv, unrefTimer } from "#veryfront/platform/compat/process.ts";
+
+const DEFAULT_REFRESH_MS = 15_000;
+const DEFAULT_SERVER_PORT = 20000;
+
+function fnv1a64(input: string): bigint {
+  let hash = 0xcbf29ce484222325n;
+  const prime = 0x100000001b3n;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= BigInt(input.charCodeAt(i));
+    hash = (hash * prime) & 0xffffffffffffffffn;
+  }
+  return hash;
+}
+
+export function jumpHash(keyStr: string, numBuckets: number): number {
+  let key = fnv1a64(keyStr);
+  let b = -1n;
+  let j = 0n;
+  const nb = BigInt(numBuckets);
+  while (j < nb) {
+    b = j;
+    key = ((key * 2862933555777941757n) + 1n) & 0xffffffffffffffffn;
+    j = BigInt(Math.floor(Number(b + 1n) * 2147483648.0 / (Number(key >> 33n) + 1)));
+  }
+  return Number(b);
+}
+
+export class RendererRouter {
+  private pods: string[] = [];
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private refreshing = false;
+  private serverPort: number;
+
+  constructor(
+    private headlessService: string,
+    private fallbackUrl: string,
+    refreshMs?: number,
+  ) {
+    this.serverPort = parseInt(getEnv("VERYFRONT_SERVER_PORT") || String(DEFAULT_SERVER_PORT));
+    this.refreshPods();
+    const interval = refreshMs ?? DEFAULT_REFRESH_MS;
+    this.refreshTimer = setInterval(() => this.refreshPods(), interval);
+    unrefTimer(this.refreshTimer);
+  }
+
+  resolve(projectSlug: string | undefined): string {
+    if (!projectSlug || this.pods.length === 0) return this.fallbackUrl;
+    const idx = jumpHash(projectSlug, this.pods.length);
+    return `http://${this.pods[idx]}:${this.serverPort}`;
+  }
+
+  close(): void {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  get podCount(): number {
+    return this.pods.length;
+  }
+
+  /** Test helper: inject pod IPs without DNS resolution */
+  _setPods(ips: string[]): void {
+    this.pods = ips.sort();
+  }
+
+  private async refreshPods(): Promise<void> {
+    if (this.refreshing) return;
+    this.refreshing = true;
+    try {
+      const ips = await resolve4(this.headlessService);
+      this.pods = ips.sort();
+      proxyLogger.debug("[RendererRouter] DNS refresh", {
+        service: this.headlessService,
+        pods: this.pods.length,
+      });
+    } catch (error) {
+      proxyLogger.debug("[RendererRouter] DNS resolution failed, keeping existing pods", {
+        service: this.headlessService,
+        error: error instanceof Error ? error.message : String(error),
+        existingPods: this.pods.length,
+      });
+    } finally {
+      this.refreshing = false;
+    }
+  }
+}

--- a/src/proxy/renderer-router.ts
+++ b/src/proxy/renderer-router.ts
@@ -31,7 +31,7 @@ export function jumpHash(keyStr: string, numBuckets: number): number {
 const MAX_STALENESS_MS = 5 * 60 * 1000; // 5 minutes
 
 export class RendererRouter {
-  private pods: string[] = [];
+  private targets: string[] = [];
   private refreshTimer: ReturnType<typeof setInterval> | null = null;
   private refreshing = false;
   private serverPort: number;
@@ -39,7 +39,7 @@ export class RendererRouter {
   private _ready: Promise<void>;
 
   constructor(
-    private headlessService: string,
+    private discoveryHost: string,
     private fallbackUrl: string,
     refreshMs?: number,
   ) {
@@ -47,19 +47,19 @@ export class RendererRouter {
     const parsed = portEnv ? parseInt(portEnv) : NaN;
     this.serverPort = Number.isNaN(parsed) ? DEFAULT_SERVER_PORT : parsed;
 
-    // Support static pod IPs via env var for local testing (bypasses DNS)
-    const staticPodIps = getEnv("VERYFRONT_SERVER_POD_IPS");
-    if (staticPodIps) {
-      this.pods = staticPodIps.split(",").map((ip) => ip.trim()).filter(Boolean).sort();
+    // Support static server targets via env var (bypasses DNS discovery)
+    const staticTargets = getEnv("VERYFRONT_SERVER_TARGETS");
+    if (staticTargets) {
+      this.targets = staticTargets.split(",").map((ip) => ip.trim()).filter(Boolean).sort();
       this.lastSuccessfulRefresh = Date.now();
       this._ready = Promise.resolve();
-      proxyLogger.debug("[RendererRouter] Using static pod IPs", { pods: this.pods.length });
+      proxyLogger.debug("[RendererRouter] Using static targets", { targets: this.targets.length });
       return;
     }
 
-    this._ready = this.refreshPods();
+    this._ready = this.refreshTargets();
     const interval = refreshMs ?? DEFAULT_REFRESH_MS;
-    this.refreshTimer = setInterval(() => this.refreshPods(), interval);
+    this.refreshTimer = setInterval(() => this.refreshTargets(), interval);
     unrefTimer(this.refreshTimer);
   }
 
@@ -68,15 +68,15 @@ export class RendererRouter {
   }
 
   resolve(projectSlug: string | undefined): string {
-    if (!projectSlug || this.pods.length === 0) return this.fallbackUrl;
+    if (!projectSlug || this.targets.length === 0) return this.fallbackUrl;
     if (
       this.lastSuccessfulRefresh > 0 && Date.now() - this.lastSuccessfulRefresh > MAX_STALENESS_MS
     ) {
-      proxyLogger.debug("[RendererRouter] Pod list stale, falling back to ClusterIP");
+      proxyLogger.debug("[RendererRouter] Target list stale, falling back to default");
       return this.fallbackUrl;
     }
-    const idx = jumpHash(projectSlug, this.pods.length);
-    return `http://${this.pods[idx]}:${this.serverPort}`;
+    const idx = jumpHash(projectSlug, this.targets.length);
+    return `http://${this.targets[idx]}:${this.serverPort}`;
   }
 
   close(): void {
@@ -86,13 +86,13 @@ export class RendererRouter {
     }
   }
 
-  get podCount(): number {
-    return this.pods.length;
+  get targetCount(): number {
+    return this.targets.length;
   }
 
-  /** Test helper: inject pod IPs without DNS resolution */
-  _setPods(ips: string[]): void {
-    this.pods = ips.sort();
+  /** Test helper: inject server IPs without DNS resolution */
+  _setTargets(ips: string[]): void {
+    this.targets = ips.sort();
     this.lastSuccessfulRefresh = Date.now();
   }
 
@@ -101,22 +101,22 @@ export class RendererRouter {
     this.lastSuccessfulRefresh = timestamp;
   }
 
-  private async refreshPods(): Promise<void> {
+  private async refreshTargets(): Promise<void> {
     if (this.refreshing) return;
     this.refreshing = true;
     try {
-      const ips = await resolve4(this.headlessService);
-      this.pods = ips.sort();
+      const ips = await resolve4(this.discoveryHost);
+      this.targets = ips.sort();
       this.lastSuccessfulRefresh = Date.now();
       proxyLogger.debug("[RendererRouter] DNS refresh", {
-        service: this.headlessService,
-        pods: this.pods.length,
+        host: this.discoveryHost,
+        targets: this.targets.length,
       });
     } catch (error) {
-      proxyLogger.debug("[RendererRouter] DNS resolution failed, keeping existing pods", {
-        service: this.headlessService,
+      proxyLogger.debug("[RendererRouter] DNS resolution failed, keeping existing targets", {
+        host: this.discoveryHost,
         error: error instanceof Error ? error.message : String(error),
-        existingPods: this.pods.length,
+        existingTargets: this.targets.length,
       });
     } finally {
       this.refreshing = false;

--- a/src/proxy/renderer-router.ts
+++ b/src/proxy/renderer-router.ts
@@ -28,26 +28,41 @@ export function jumpHash(keyStr: string, numBuckets: number): number {
   return Number(b);
 }
 
+const MAX_STALENESS_MS = 5 * 60 * 1000; // 5 minutes
+
 export class RendererRouter {
   private pods: string[] = [];
   private refreshTimer: ReturnType<typeof setInterval> | null = null;
   private refreshing = false;
   private serverPort: number;
+  private lastSuccessfulRefresh = 0;
+  private _ready: Promise<void>;
 
   constructor(
     private headlessService: string,
     private fallbackUrl: string,
     refreshMs?: number,
   ) {
-    this.serverPort = parseInt(getEnv("VERYFRONT_SERVER_PORT") || String(DEFAULT_SERVER_PORT));
-    this.refreshPods();
+    const parsed = parseInt(getEnv("VERYFRONT_SERVER_PORT") || String(DEFAULT_SERVER_PORT));
+    this.serverPort = Number.isNaN(parsed) ? DEFAULT_SERVER_PORT : parsed;
+    this._ready = this.refreshPods();
     const interval = refreshMs ?? DEFAULT_REFRESH_MS;
     this.refreshTimer = setInterval(() => this.refreshPods(), interval);
     unrefTimer(this.refreshTimer);
   }
 
+  ready(): Promise<void> {
+    return this._ready;
+  }
+
   resolve(projectSlug: string | undefined): string {
     if (!projectSlug || this.pods.length === 0) return this.fallbackUrl;
+    if (
+      this.lastSuccessfulRefresh > 0 && Date.now() - this.lastSuccessfulRefresh > MAX_STALENESS_MS
+    ) {
+      proxyLogger.debug("[RendererRouter] Pod list stale, falling back to ClusterIP");
+      return this.fallbackUrl;
+    }
     const idx = jumpHash(projectSlug, this.pods.length);
     return `http://${this.pods[idx]}:${this.serverPort}`;
   }
@@ -66,6 +81,12 @@ export class RendererRouter {
   /** Test helper: inject pod IPs without DNS resolution */
   _setPods(ips: string[]): void {
     this.pods = ips.sort();
+    this.lastSuccessfulRefresh = Date.now();
+  }
+
+  /** Test helper: override last successful refresh timestamp */
+  _setLastRefresh(timestamp: number): void {
+    this.lastSuccessfulRefresh = timestamp;
   }
 
   private async refreshPods(): Promise<void> {
@@ -74,6 +95,7 @@ export class RendererRouter {
     try {
       const ips = await resolve4(this.headlessService);
       this.pods = ips.sort();
+      this.lastSuccessfulRefresh = Date.now();
       proxyLogger.debug("[RendererRouter] DNS refresh", {
         service: this.headlessService,
         pods: this.pods.length,

--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -91,3 +91,9 @@ export {
   wrapAdapterWithSecurity,
 } from "./secure-fs.ts";
 export type { SecureFsConfig, SecurityContext, SecurityEvent } from "./secure-fs.ts";
+
+export {
+  BUILD_HELPER_PERMISSIONS,
+  SERVER_PERMISSIONS,
+  WORKFLOW_JOB_PERMISSIONS,
+} from "./deno-permissions.ts";

--- a/src/server/dev-server/server.ts
+++ b/src/server/dev-server/server.ts
@@ -22,6 +22,7 @@ import {
 } from "#veryfront/rendering/ssr-globals.ts";
 import { setEnv } from "#veryfront/platform/compat/process.ts";
 import { initializeDistributedCaches } from "#veryfront/cache/distributed-cache-init.ts";
+import { isDiskCacheConfigured } from "#veryfront/cache/backend.ts";
 import { clearTranspileCache, discoverAll } from "#veryfront/discovery";
 import type { DiscoveryConfig } from "#veryfront/discovery";
 
@@ -133,10 +134,12 @@ export class DevServer {
 
     await this.logRSCStatus();
 
-    // Initialize persistent caches (disk/redis/api) if configured via env vars
-    initializeDistributedCaches().catch((error) => {
-      logger.debug("[DevServer] Cache initialization failed, using memory fallback", { error });
-    });
+    // Initialize disk cache in dev mode when explicitly configured
+    if (isDiskCacheConfigured()) {
+      initializeDistributedCaches().catch((error) => {
+        logger.debug("[DevServer] Cache initialization failed, using memory fallback", { error });
+      });
+    }
 
     // Auto-discover AI primitives (tools, agents, workflows, prompts, resources)
     await this.runAIDiscovery();

--- a/src/server/dev-server/server.ts
+++ b/src/server/dev-server/server.ts
@@ -21,6 +21,7 @@ import {
   setSSRServerPort,
 } from "#veryfront/rendering/ssr-globals.ts";
 import { setEnv } from "#veryfront/platform/compat/process.ts";
+import { initializeDistributedCaches } from "#veryfront/cache/distributed-cache-init.ts";
 import { clearTranspileCache, discoverAll } from "#veryfront/discovery";
 import type { DiscoveryConfig } from "#veryfront/discovery";
 
@@ -131,6 +132,11 @@ export class DevServer {
     enableSSRClientOnlyFetching();
 
     await this.logRSCStatus();
+
+    // Initialize persistent caches (disk/redis/api) if configured via env vars
+    initializeDistributedCaches().catch((error) => {
+      logger.debug("[DevServer] Cache initialization failed, using memory fallback", { error });
+    });
 
     // Auto-discover AI primitives (tools, agents, workflows, prompts, resources)
     await this.runAIDiscovery();


### PR DESCRIPTION
## Summary

- Add `DiskCacheBackend` for persistent file-based caching that survives pod restarts (atomic writes, TTL, delByPattern)
- Add `RendererRouter` for per-project sticky session routing using jump consistent hash with BigInt 64-bit arithmetic
- Update cache factory selection chain: API > Redis > Disk > Memory
- Fix disk cache initialization so it works in both dev and production modes
- Add env var support for local testing of both features

## Local testing

### Disk cache
```bash
VF_CACHE_BACKEND=disk VF_DISK_CACHE_DIR=/tmp/vf-disk-cache veryfront dev
# Cache files appear in /tmp/vf-disk-cache/veryfront-files/
```

### Sticky session routing
```bash
VERYFRONT_SERVER_TARGETS=10.0.0.1,10.0.0.2,10.0.0.3  # bypasses DNS discovery
```

## Environment variables

| Variable | Purpose |
|---|---|
| `VF_CACHE_BACKEND` | Cache backend: `disk`, `redis`, `api`, `memory` |
| `VF_DISK_CACHE_DIR` | Disk cache directory path |
| `VERYFRONT_SERVER_DISCOVERY_HOST` | Hostname that resolves to multiple server IPs (e.g. a DNS A record) |
| `VERYFRONT_SERVER_TARGETS` | Static comma-separated server IPs (bypasses DNS discovery) |
| `VERYFRONT_SERVER_DISCOVERY_INTERVAL_MS` | DNS refresh interval (default: 15000) |
| `VERYFRONT_SERVER_PORT` | Server port for resolved targets (default: 20000) |

## Key changes

### Disk cache backend
- **`src/cache/backends/disk.ts`** — File-based cache with FNV-1 hash addressing, atomic tmp+rename writes, TTL support, key collision guard, keyPrefix-based subdir isolation per cache
- **`src/cache/backends/factory.ts`** — `isDiskCacheConfigured()` check; `isDistributedBackend()` now treats disk as persistent (non-memory); passes `keyPrefix` to `DiskCacheBackend` for cache isolation
- **`src/cache/distributed-cache-init.ts`** — `determineBackend()` recognizes disk; no longer short-circuits cache initialization when disk is configured
- **`src/server/dev-server/server.ts`** — Dev server now initializes persistent caches at startup (guarded by `isDiskCacheConfigured()` to avoid changing default behavior)

### Sticky session routing
- **`src/proxy/renderer-router.ts`** — Jump consistent hash router with DNS-based target discovery, 5-min staleness detection, port validation. Infrastructure-agnostic: uses generic "targets" and "discovery host" instead of K8s-specific terminology
- **`src/proxy/main.ts`** — Router integration with `ready()` await; re-resolves renderer target inside retry loop so retries can pick a different server; NaN guard for discovery interval

### Bug fixes
- **`delByPattern` regex escaping** — Fixed glob-to-regex conversion in `DiskCacheBackend`, `MemoryCacheBackend`, and `MockCacheBackend` to escape regex-special characters (`.+^${}()|[]\`) before converting `*`/`?` wildcards. Without this, patterns like `user.settings:*` would incorrectly match `userXsettings:foo`.
- **`cli-boundary` lint violation** — Exported `SERVER_PERMISSIONS` through `veryfront/security` barrel instead of deep `#veryfront/**/**.ts` import

### Code quality
- Key integrity verification in `DiskCacheBackend.get()` (hash collision guard)
- Module-level lazy `fs/promises` import (avoids repeated dynamic imports)
- Shared `runCacheInvariantTests` suite for disk backend
- DNS staleness fallback in `RendererRouter.resolve()`
- Port validation with `Number.isNaN` guard
- Simplified singleflight pattern using closure instead of anonymous class
- Removed dead `useStaticPods` field from RendererRouter
- Simplified port parsing to avoid unnecessary `String()` round-trip
- Removed K8s-specific terminology (pods → targets, headlessService → discoveryHost)

### Tests
- **`src/cache/backends/disk.test.ts`** — 30 steps: invariant suite, concurrent writes, delByPattern edge cases, TTL, special characters
- **`src/cache/backends/factory.test.ts`** — Factory integration tests for disk/memory selection, `isDistributedBackend` verification, `isDiskCacheConfigured` env var detection
- **`src/proxy/renderer-router.test.ts`** — 17 steps: determinism, distribution, staleness, static targets, ready()

## PR review feedback addressed
- **keyPrefix subdir isolation** — `DiskCacheBackend` now uses `keyPrefix` as a subdirectory to isolate cache files per subsystem (transform, SSR module, file, project CSS)
- **Re-resolve target in retry loop** — Moved `rendererRouter.resolve()` inside the retry `for` loop so retries can pick a different server after failure
- **NaN guard for discovery interval** — Added `|| 15000` fallback to prevent NaN from propagating into `setInterval`
- **Factory tests** — Added `isDistributedBackend` tests for disk/memory backends and `isDiskCacheConfigured` env var detection tests

## Test plan
- [x] 870 unit tests pass (0 failures) — includes new factory, disk, and router tests
- [x] All lint checks pass (fmt, lint, style, cli-boundary, wildcard-exports, barrel-jsdoc, docs:validate, typecheck)
- [x] Pre-commit hooks pass
- [x] Disk cache verified end-to-end: 28 files created after single page render with `VF_CACHE_BACKEND=disk`
- [x] All 4 cache subsystems initialize with disk backend (transform, SSR module, file, project CSS)
- [x] Sticky session routing verified with static targets env var
- [x] Default behavior preserved — no changes when disk/routing env vars are not set