### PR TITLE
fix: enforce Content-Type validation in body parsers and MCP server

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -7,6 +7,8 @@ import type { MCPServerConfig } from "./types.ts";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { VERSION } from "#veryfront/utils/version.ts";
+import { validateContentType } from "#veryfront/security/input-validation/limits.ts";
+import { VeryfrontError } from "#veryfront/security/input-validation/errors.ts";
 
 type JSONRPCParams = Record<string, unknown> | unknown[];
 
@@ -272,12 +274,15 @@ export class MCPServer {
         if (!authorized) return new Response("Unauthorized", { status: 401 });
       }
 
-      const ct = request.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase();
-      if (ct !== "application/json") {
+      try {
+        validateContentType(request, "application/json");
+      } catch (error) {
+        const message = error instanceof VeryfrontError ? error.message : "Invalid Content-Type";
         return new Response(
           JSON.stringify({
             jsonrpc: "2.0",
-            error: { code: -32700, message: "Invalid Content-Type" },
+            id: null,
+            error: { code: -32700, message },
           }),
           { status: 400, headers: { "Content-Type": "application/json" } },
         );
@@ -290,6 +295,7 @@ export class MCPServer {
         return new Response(
           JSON.stringify({
             jsonrpc: "2.0",
+            id: null,
             error: { code: -32700, message: "Parse error" },
           }),
           {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -272,6 +272,17 @@ export class MCPServer {
         if (!authorized) return new Response("Unauthorized", { status: 401 });
       }
 
+      const ct = request.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase();
+      if (ct !== "application/json") {
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            error: { code: -32700, message: "Invalid Content-Type" },
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
       let rpcRequest: JSONRPCRequest;
       try {
         rpcRequest = await request.json();

--- a/src/security/input-validation/index.ts
+++ b/src/security/input-validation/index.ts
@@ -7,7 +7,7 @@
 export type { ParseFormOptions, ParseJsonOptions, RequestLimits, ValidatedData } from "./types.ts";
 export { DEFAULT_LIMITS } from "./types.ts";
 export { createValidationError, INPUT_VALIDATION_FAILED } from "./errors.ts";
-export { readBodyWithLimit, validateRequestLimits } from "./limits.ts";
+export { readBodyWithLimit, validateContentType, validateRequestLimits } from "./limits.ts";
 export { parseFormData, parseJsonBody, parseQueryParams } from "./parsers.ts";
 export { sanitizeData } from "./sanitizers.ts";
 export { CommonSchemas } from "#veryfront/schemas/index.ts";

--- a/src/security/input-validation/limits.test.ts
+++ b/src/security/input-validation/limits.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { VeryfrontError } from "./errors.ts";
-import { readBodyWithLimit, validateRequestLimits } from "./limits.ts";
+import { readBodyWithLimit, validateContentType, validateRequestLimits } from "./limits.ts";
 
 describe("security/input-validation/limits", () => {
   describe("validateRequestLimits", () => {
@@ -62,6 +62,64 @@ describe("security/input-validation/limits", () => {
         () => validateRequestLimits(req, { maxHeaderSize: 1000 }),
         VeryfrontError,
         "Headers too large",
+      );
+    });
+  });
+
+  describe("validateContentType", () => {
+    it("should pass for matching Content-Type", () => {
+      const req = new Request("http://localhost/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      validateContentType(req, "application/json");
+    });
+
+    it("should pass with extra parameters", () => {
+      const req = new Request("http://localhost/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+      });
+
+      validateContentType(req, "application/json");
+    });
+
+    it("should reject prefix-sharing Content-Type", () => {
+      const req = new Request("http://localhost/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json-seq" },
+      });
+
+      assertThrows(
+        () => validateContentType(req, "application/json"),
+        VeryfrontError,
+        "Invalid Content-Type",
+      );
+    });
+
+    it("should reject mismatched Content-Type", () => {
+      const req = new Request("http://localhost/", {
+        method: "POST",
+        headers: { "Content-Type": "text/plain" },
+      });
+
+      assertThrows(
+        () => validateContentType(req, "application/json"),
+        VeryfrontError,
+        "Invalid Content-Type",
+      );
+    });
+
+    it("should reject missing Content-Type", () => {
+      const req = new Request("http://localhost/", {
+        method: "POST",
+      });
+
+      assertThrows(
+        () => validateContentType(req, "application/json"),
+        VeryfrontError,
+        "Missing Content-Type",
       );
     });
   });

--- a/src/security/input-validation/limits.ts
+++ b/src/security/input-validation/limits.ts
@@ -53,15 +53,17 @@ function validateHeaderSize(request: Request, maxSize: number): void {
   });
 }
 
-export function validateContentType(request: Request, expected: string): void {
+export function validateContentType(request: Request, expected: string | string[]): void {
+  const allowed = Array.isArray(expected) ? expected : [expected];
+  const label = allowed.join(" or ");
   const contentType = request.headers.get("content-type");
   if (!contentType) {
-    throw createValidationError(`Missing Content-Type header, expected ${expected}`);
+    throw createValidationError(`Missing Content-Type header, expected ${label}`);
   }
   const mediaType = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
-  if (mediaType !== expected) {
-    throw createValidationError(`Invalid Content-Type: expected ${expected}`, {
-      expected,
+  if (!allowed.includes(mediaType)) {
+    throw createValidationError(`Invalid Content-Type: expected ${label}`, {
+      expected: allowed,
       actual: contentType,
     });
   }

--- a/src/security/input-validation/limits.ts
+++ b/src/security/input-validation/limits.ts
@@ -53,6 +53,20 @@ function validateHeaderSize(request: Request, maxSize: number): void {
   });
 }
 
+export function validateContentType(request: Request, expected: string): void {
+  const contentType = request.headers.get("content-type");
+  if (!contentType) {
+    throw createValidationError(`Missing Content-Type header, expected ${expected}`);
+  }
+  const mediaType = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+  if (mediaType !== expected) {
+    throw createValidationError(`Invalid Content-Type: expected ${expected}`, {
+      expected,
+      actual: contentType,
+    });
+  }
+}
+
 export async function readBodyWithLimit(
   request: Request,
   maxSize: number = DEFAULT_LIMITS.maxBodySize,

--- a/src/security/input-validation/parsers.test.ts
+++ b/src/security/input-validation/parsers.test.ts
@@ -25,6 +25,47 @@ describe("parseJsonBody", () => {
     assertEquals(result, { name: "Alice", age: 30 });
   });
 
+  it("should reject request with wrong Content-Type", async () => {
+    const request = new Request("http://localhost/test", {
+      method: "POST",
+      body: JSON.stringify({ name: "Alice", age: 30 }),
+      headers: { "content-type": "text/plain" },
+    });
+
+    await assertRejects(
+      () => parseJsonBody(request, schema),
+      VeryfrontError,
+      "Invalid Content-Type",
+    );
+  });
+
+  it("should reject request with missing Content-Type", async () => {
+    const request = new Request("http://localhost/test", {
+      method: "POST",
+      body: JSON.stringify({ name: "Alice", age: 30 }),
+    });
+    // Deno auto-sets Content-Type to text/plain for string bodies,
+    // so delete it to simulate a truly missing header
+    request.headers.delete("content-type");
+
+    await assertRejects(
+      () => parseJsonBody(request, schema),
+      VeryfrontError,
+      "Missing Content-Type",
+    );
+  });
+
+  it("should accept application/json with charset", async () => {
+    const request = new Request("http://localhost/test", {
+      method: "POST",
+      body: JSON.stringify({ name: "Alice", age: 30 }),
+      headers: { "content-type": "application/json; charset=utf-8" },
+    });
+
+    const result = await parseJsonBody(request, schema);
+    assertEquals(result, { name: "Alice", age: 30 });
+  });
+
   it("should throw ValidationError for invalid JSON", async () => {
     const request = createJsonRequest("not json");
 

--- a/src/security/input-validation/parsers.ts
+++ b/src/security/input-validation/parsers.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { createValidationError, VeryfrontError } from "./errors.ts";
-import { readBodyWithLimit, validateRequestLimits } from "./limits.ts";
+import { readBodyWithLimit, validateContentType, validateRequestLimits } from "./limits.ts";
 import { sanitizeData } from "./sanitizers.ts";
 import { DEFAULT_LIMITS, type ParseFormOptions, type ParseJsonOptions } from "./types.ts";
 
@@ -10,6 +10,7 @@ export async function parseJsonBody<T>(
   options?: ParseJsonOptions,
 ): Promise<T> {
   validateRequestLimits(request, options?.limits);
+  validateContentType(request, "application/json");
 
   let data: unknown;
   try {
@@ -45,6 +46,14 @@ export async function parseFormData<T>(
   options?: ParseFormOptions,
 ): Promise<T> {
   validateRequestLimits(request, options?.limits);
+
+  const ct = request.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase() ?? "";
+  if (ct !== "multipart/form-data" && ct !== "application/x-www-form-urlencoded") {
+    throw createValidationError(
+      "Invalid Content-Type: expected multipart/form-data or application/x-www-form-urlencoded",
+      { actual: request.headers.get("content-type") },
+    );
+  }
 
   try {
     const formData = await request.formData();

--- a/src/security/input-validation/parsers.ts
+++ b/src/security/input-validation/parsers.ts
@@ -47,13 +47,7 @@ export async function parseFormData<T>(
 ): Promise<T> {
   validateRequestLimits(request, options?.limits);
 
-  const ct = request.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase() ?? "";
-  if (ct !== "multipart/form-data" && ct !== "application/x-www-form-urlencoded") {
-    throw createValidationError(
-      "Invalid Content-Type: expected multipart/form-data or application/x-www-form-urlencoded",
-      { actual: request.headers.get("content-type") },
-    );
-  }
+  validateContentType(request, ["multipart/form-data", "application/x-www-form-urlencoded"]);
 
   try {
     const formData = await request.formData();


### PR DESCRIPTION
## Summary

- Add `validateContentType()` utility to `src/security/input-validation/limits.ts` that validates the `Content-Type` header against an expected MIME type, throwing `INPUT_VALIDATION_FAILED` (400) on mismatch or missing header
- `parseJsonBody()` now rejects requests without `application/json` Content-Type
- `parseFormData()` now rejects requests without `multipart/form-data` or `application/x-www-form-urlencoded` Content-Type
- MCP server HTTP handler returns JSON-RPC `-32700` error for non-`application/json` requests before attempting to parse the body
- Export `validateContentType` from `src/security/input-validation/index.ts`

## Test plan

- [x] `validateContentType` unit tests: matching type, charset params, mismatch, missing header
- [x] `parseJsonBody` tests: wrong Content-Type, missing Content-Type, `application/json; charset=utf-8`
- [x] `deno test src/security/input-validation/` — all pass
- [x] `deno task typecheck` — no errors
- [x] `deno task test` — 1118 passed, 1 pre-existing failure (unrelated subprocess leak)