### PR TITLE
chore: bump version to 0.1.7-rc.60

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.7-rc.59",
+  "version": "0.1.7-rc.60",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",


### PR DESCRIPTION
## Summary
- Bumps version from `0.1.7-rc.59` to `0.1.7-rc.60` to fix prerelease CI failure (npm 403: cannot publish over previously published version)

## Test plan
- [x] Pre-commit verification passed locally