### PR TITLE
chore: bump version to 0.1.7-rc.62

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.7-rc.61",
+  "version": "0.1.7-rc.62",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",
@@ -379,6 +379,9 @@
   },
   "allowScripts": {
     "allow": [],
-    "deny": ["npm:esbuild@0.20.2", "npm:protobufjs@7.5.4"]
+    "deny": [
+      "npm:esbuild@0.20.2",
+      "npm:protobufjs@7.5.4"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Bumps version from `0.1.7-rc.61` to `0.1.7-rc.62` in `deno.json`
- Fixes CI prerelease job failing with `npm error 403 Forbidden - You cannot publish over the previously published versions: 0.1.7-rc.61`

## Test plan
- [ ] CI passes (format, lint, typecheck, tests)
- [ ] Prerelease job successfully publishes `0.1.7-rc.62` to npm