### PR TITLE
fix: add missing icon field to anthropic and aws integrations

### DIFF
--- a/cli/templates/integrations/anthropic/connector.json
+++ b/cli/templates/integrations/anthropic/connector.json
@@ -1,6 +1,7 @@
 {
   "name": "anthropic",
   "displayName": "Anthropic",
+  "icon": "anthropic.svg",
   "description": "Integrate with Anthropic Admin API to manage workspaces, monitor usage, and access organization data",
   "auth": {
     "type": "api-key",

--- a/cli/templates/integrations/aws/connector.json
+++ b/cli/templates/integrations/aws/connector.json
@@ -1,6 +1,7 @@
 {
   "name": "aws",
   "displayName": "Amazon Web Services",
+  "icon": "aws.svg",
   "description": "Integration with AWS services including S3, EC2, and Lambda",
   "version": "1.0.0",
   "auth": {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.7-rc.61",
+  "version": "0.1.7-rc.62",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",


### PR DESCRIPTION
## Summary
- Add missing `"icon"` field to `anthropic/connector.json` and `aws/connector.json`
- Both integrations had SVG files but were the only ones missing the `"icon"` field in their connector config
- Bump version to `0.1.7-rc.62`

## Test plan
- [x] Pre-commit verification passed (fmt, lint, typecheck)
- [ ] Verify anthropic and aws icons render correctly in Studio integration picker