### PR TITLE
chore: add base tsconfig and React types for user projects

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -93,7 +93,8 @@
     },
     "./integrations": {
       "import": "./esm/src/integrations/index.js"
-    }
+    },
+    "./tsconfig.json": "./tsconfig.json"
   },
   "scripts": {
     "postinstall": "node scripts/postinstall.js"
@@ -144,12 +145,14 @@
     "unified": "11.0.5",
     "unist-util-visit": "5.0.0",
     "vfile": "6.0.1",
-    "ws": "^8.18.0",
     "zod": "3.25.76",
     "@deno/shim-deno": "~0.18.0",
     "@deno/shim-crypto": "~0.3.1",
     "@deno/shim-timers": "~0.1.0",
-    "undici": "^6.0.0"
+    "undici": "^6.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "ws": "^8.18.0"
   },
   "peerDependencies": {
     "better-sqlite3": ">=9.0.0"
@@ -171,6 +174,7 @@
     "src",
     "bin",
     "scripts",
+    "tsconfig.json",
     "LICENSE",
     "README.md"
   ]

--- a/npm/tsconfig.json
+++ b/npm/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "noEmit": true
+  }
+}

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -125,6 +125,8 @@ await build({
 		// ws is dynamically imported for Node.js WebSocket upgrade (HMR dev server)
 		// dnt can't detect dynamic imports, so we add it explicitly
 		dependencies: {
+			"@types/react": "^19.0.0",
+			"@types/react-dom": "^19.0.0",
 			"ws": "^8.18.0",
 		},
 		keywords: [
@@ -233,13 +235,28 @@ if (existsSync(nativeBinary)) {
 		// Copy README (optional)
 		await copyFileIfExists("./README.md", "./npm/README.md");
 
+		// Copy base tsconfig for user projects to extend
+		await Deno.writeTextFile("./npm/tsconfig.json", JSON.stringify({
+			compilerOptions: {
+				target: "ES2022",
+				module: "ESNext",
+				moduleResolution: "Bundler",
+				jsx: "react-jsx",
+				strict: true,
+				skipLibCheck: true,
+				esModuleInterop: true,
+				noEmit: true,
+			},
+		}, null, 2));
+
 		// Update package.json with bin entry, postinstall, and type
 		const pkgPath = "./npm/package.json";
 		const pkg = JSON.parse(await Deno.readTextFile(pkgPath));
 		pkg.type = "module"; // Required for ESM imports without warnings
 		pkg.bin = { veryfront: "bin/veryfront.js" };
-		pkg.files = ["esm", "script", "src", "bin", "scripts", "LICENSE", "README.md"];
+		pkg.files = ["esm", "script", "src", "bin", "scripts", "tsconfig.json", "LICENSE", "README.md"];
 		pkg.scripts = { postinstall: "node scripts/postinstall.js" };
+		pkg.exports["./tsconfig.json"] = "./tsconfig.json";
 		await Deno.writeTextFile(pkgPath, JSON.stringify(pkg, null, 2));
 	},
 });


### PR DESCRIPTION
## Summary
- Add `tsconfig.json` with React/JSX defaults that users can extend
- Include `@types/react` and `@types/react-dom` as dependencies
- Export tsconfig.json in package.json exports

Users can now use a minimal tsconfig:
```json
{
  "extends": "veryfront/tsconfig.json"
}
```

## Test plan
- [x] Verified TypeScript works with minimal tsconfig in test project
- [x] Verified React types are available without extra installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)