### PR TITLE
Improve start guidance and empty-state discoverability

### DIFF
--- a/cli/commands/start/command-help.ts
+++ b/cli/commands/start/command-help.ts
@@ -17,7 +17,7 @@ export const startHelp: CommandHelp = {
     },
     {
       flag: "--project <path>",
-      description: "Path to a Veryfront project directory",
+      description: "Path to a Veryfront project directory (single-project mode)",
     },
     {
       flag: "--headless, --no-tui",
@@ -29,5 +29,24 @@ export const startHelp: CommandHelp = {
     "veryfront start --port 9000",
     "veryfront start --project ./my-app",
     "veryfront start --headless",
+  ],
+  notes: [
+    "Veryfront supports two modes:",
+    "",
+    "  Single project — run inside a project directory, or use --project <path>.",
+    "  A project is any folder with an app/, pages/, or components/ directory.",
+    "",
+    "  Workspace — run from a parent directory containing a projects/ folder.",
+    "  Each subfolder in projects/ that has app/, pages/, or components/ is",
+    "  auto-discovered and served. A project picker UI is shown at the root URL.",
+    "",
+    "  Workspace layout:",
+    "    my-workspace/",
+    "      projects/",
+    "        site-a/        # auto-discovered",
+    "          app/",
+    "        site-b/        # auto-discovered",
+    "          app/",
+    "      examples/         # also scanned",
   ],
 };

--- a/cli/commands/start/command.ts
+++ b/cli/commands/start/command.ts
@@ -151,6 +151,25 @@ export async function startCommand(options: StartOptions): Promise<void> {
   const { createApp, showStartup } = await import("../../app/index.ts");
   const discovered = await discoverProjects(projectPath);
 
+  // Log discovered projects for discoverability
+  const totalProjects = discovered.projects.size + discovered.examples.size;
+  if (discovered.defaultProject) {
+    logger.info(`Serving project "${discovered.defaultProject}"`);
+  } else if (totalProjects > 0) {
+    const dirs = [...new Set(
+      [...discovered.projects.values(), ...discovered.examples.values()]
+        .map((p) => {
+          const rel = p.replace(cwd() + "/", "");
+          return rel.split("/").slice(0, -1).join("/");
+        }),
+    )].join(", ");
+    logger.info(`Found ${totalProjects} project(s) in ${dirs}`);
+  } else {
+    logger.info(
+      "No projects found. Create one with `veryfront init my-app` or place projects in ./projects/",
+    );
+  }
+
   const app = createApp({
     port,
     mcpPort,

--- a/cli/commands/start/command.ts
+++ b/cli/commands/start/command.ts
@@ -156,13 +156,15 @@ export async function startCommand(options: StartOptions): Promise<void> {
   if (discovered.defaultProject) {
     logger.info(`Serving project "${discovered.defaultProject}"`);
   } else if (totalProjects > 0) {
-    const dirs = [...new Set(
-      [...discovered.projects.values(), ...discovered.examples.values()]
-        .map((p) => {
-          const rel = p.replace(cwd() + "/", "");
-          return rel.split("/").slice(0, -1).join("/");
-        }),
-    )].join(", ");
+    const dirs = [
+      ...new Set(
+        [...discovered.projects.values(), ...discovered.examples.values()]
+          .map((p) => {
+            const rel = p.replace(cwd() + "/", "");
+            return rel.split("/").slice(0, -1).join("/");
+          }),
+      ),
+    ].join(", ");
     logger.info(`Found ${totalProjects} project(s) in ${dirs}`);
   } else {
     logger.info(

--- a/cli/help/command-help.test.ts
+++ b/cli/help/command-help.test.ts
@@ -2,9 +2,25 @@
  * Tests for command help display
  */
 
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { showCommandHelp } from "./command-help.ts";
+
+function captureConsoleLog(run: () => void): string {
+  const output: string[] = [];
+  const originalLog = console.log;
+
+  try {
+    console.log = (msg?: unknown, ...rest: unknown[]) => {
+      output.push(String(msg), ...rest.map(String));
+    };
+    run();
+  } finally {
+    console.log = originalLog;
+  }
+
+  return output.join("\n");
+}
 
 describe("command-help", () => {
   describe("showCommandHelp", () => {
@@ -12,8 +28,11 @@ describe("command-help", () => {
       assertEquals(typeof showCommandHelp, "function");
     });
 
-    // Note: showCommandHelp calls console.log directly
-    // Full output testing would require mocking console.log
-    // The function behavior is verified through integration testing
+    it("renders notes when available", () => {
+      const output = captureConsoleLog(() => showCommandHelp("start"));
+      assertStringIncludes(output, "Notes:");
+      assertStringIncludes(output, "Single project");
+      assertStringIncludes(output, "Workspace");
+    });
   });
 });

--- a/cli/help/command-help.ts
+++ b/cli/help/command-help.ts
@@ -47,6 +47,19 @@ export function showCommandHelp(command: string): void {
     console.log();
   }
 
+  const notes = cmd.notes ?? [];
+  if (notes.length) {
+    console.log(`  ${formatSectionHeader("Notes")}`);
+    for (const note of notes) {
+      if (note.length === 0) {
+        console.log();
+        continue;
+      }
+      console.log(`    ${note}`);
+    }
+    console.log();
+  }
+
   const tips = getCommandTips(command);
   if (tips) {
     console.log(tips);

--- a/src/server/dev-ui/projects/App.tsx
+++ b/src/server/dev-ui/projects/App.tsx
@@ -124,7 +124,7 @@ export function App(): React.JSX.Element {
         ? "Try a different search term"
         : "Create a project to get started";
 
-      return <EmptyState title={title} description={description} />;
+      return <EmptyState title={title} description={description} showWorkspaceGuide={!search} />;
     }
 
     return (

--- a/src/server/dev-ui/projects/components/EmptyState.tsx
+++ b/src/server/dev-ui/projects/components/EmptyState.tsx
@@ -2,19 +2,49 @@ interface EmptyStateProps {
   title: string;
   description: string;
   variant?: "default" | "error";
+  showWorkspaceGuide?: boolean;
+}
+
+function WorkspaceGuide(): JSX.Element {
+  return (
+    <div className="mt-8 max-w-md mx-auto text-left">
+      <p className="text-sm font-medium text-gray-500 mb-3">Get started</p>
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <p className="text-sm text-gray-600 mb-3">
+          Create a project, or place projects in a <code className="text-xs bg-gray-100 px-1.5 py-0.5 rounded font-mono">projects/</code> folder:
+        </p>
+        <pre className="text-xs font-mono text-gray-500 leading-relaxed bg-gray-50 rounded p-3">{
+`my-workspace/
+  projects/
+    site-a/
+      app/        ← detected
+    site-b/
+      app/        ← detected`
+        }</pre>
+        <div className="mt-3 pt-3 border-t border-gray-100">
+          <p className="text-xs text-gray-400">
+            Or run <code className="bg-gray-100 px-1.5 py-0.5 rounded font-mono">veryfront init my-app</code> to scaffold a new project.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export function EmptyState({
   title,
   description,
   variant = "default",
+  showWorkspaceGuide = false,
 }: EmptyStateProps): JSX.Element {
   const titleClassName = variant === "error" ? "text-amber-600" : "text-gray-600";
+  const showGuide = variant === "default" && showWorkspaceGuide;
 
   return (
     <div className="text-center py-16 px-6">
       <p className={`text-lg mb-2 ${titleClassName}`}>{title}</p>
       <p className="text-sm text-gray-400">{description}</p>
+      {showGuide && <WorkspaceGuide />}
     </div>
   );
 }

--- a/src/server/dev-ui/projects/components/EmptyState.tsx
+++ b/src/server/dev-ui/projects/components/EmptyState.tsx
@@ -11,7 +11,10 @@ function WorkspaceGuide(): JSX.Element {
       <p className="text-sm font-medium text-gray-500 mb-3">Get started</p>
       <div className="bg-white rounded-lg border border-gray-200 p-4">
         <p className="text-sm text-gray-600 mb-3">
-          Create a project, or place projects in a <code className="text-xs bg-gray-100 px-1.5 py-0.5 rounded font-mono">projects/</code> folder:
+          Create a project, or place projects in a{" "}
+          <code className="text-xs bg-gray-100 px-1.5 py-0.5 rounded font-mono">projects/</code>
+          {" "}
+          folder:
         </p>
         <pre className="text-xs font-mono text-gray-500 leading-relaxed bg-gray-50 rounded p-3">{
 `my-workspace/
@@ -23,7 +26,11 @@ function WorkspaceGuide(): JSX.Element {
         }</pre>
         <div className="mt-3 pt-3 border-t border-gray-100">
           <p className="text-xs text-gray-400">
-            Or run <code className="bg-gray-100 px-1.5 py-0.5 rounded font-mono">veryfront init my-app</code> to scaffold a new project.
+            Or run{" "}
+            <code className="bg-gray-100 px-1.5 py-0.5 rounded font-mono">
+              veryfront init my-app
+            </code>{" "}
+            to scaffold a new project.
           </p>
         </div>
       </div>


### PR DESCRIPTION
- add start command notes for single-project vs workspace mode
- log discovered projects at startup to improve discoverability
- render command help notes section so start notes are visible
- keep empty-state guide deterministic with explicit prop instead of string matching
- add help test coverage for notes rendering

Validation:
- deno test --no-check --allow-all cli/help/command-help.test.ts
- deno check cli/help/command-help.ts src/server/dev-ui/projects/App.tsx src/server/dev-ui/projects/components/EmptyState.tsx