### PR TITLE
chore: bump version to 0.1.7-rc.67

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.7-rc.66",
+  "version": "0.1.7-rc.67",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.7-rc.64",
+  "version": "0.1.7-rc.67",
   "description": "The simplest way to build AI-powered apps",
   "keywords": [
     "react",


### PR DESCRIPTION
## Summary
- Sync deno.json and npm/package.json versions to 0.1.7-rc.67
- They were out of sync (deno was rc.66, npm was rc.64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)