### PR TITLE
docs: update examples and docs for new model provider API

### DIFF
--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -1,124 +1,90 @@
 ---
 title: "Providers"
-description: "Unified LLM interface for Anthropic, Google, and OpenAI."
+description: "AI SDK model provider registry with auto-initialization from environment variables."
 order: 12
 ---
 
 # Providers
 
-Unified LLM interface for Anthropic, Google, and OpenAI.
+AI SDK model provider registry. Maps "provider/model" strings to AI SDK LanguageModel instances.
 
-## Setup
+## Environment variables (recommended)
 
-Initialize providers with API keys, typically in your app's entry point or a shared module:
-
-```ts
-import { initializeProviders } from "veryfront/provider";
-import { getEnv } from "veryfront";
-
-initializeProviders({
-  openai: { apiKey: getEnv("OPENAI_API_KEY") },
-  anthropic: { apiKey: getEnv("ANTHROPIC_API_KEY") },
-  google: { apiKey: getEnv("GOOGLE_API_KEY") },
-});
-```
-
-Only configure the providers you use.
-
-## Model strings
-
-Agents reference models as `"provider/model"`:
-
-```ts
-import { agent } from "veryfront/agent";
-
-export default agent({
-  model: "openai/gpt-4o",       // OpenAI
-  // model: "anthropic/claude-sonnet-4-5-20250929", // Anthropic
-  // model: "google/gemini-pro",  // Google
-  system: "You are a helpful assistant.",
-});
-```
-
-The framework resolves the provider from the model string, routes the request to the right API, and normalizes the response.
-
-## Direct provider access
-
-For cases outside the agent system:
-
-```ts
-import { getProviderFromModel } from "veryfront/provider";
-
-const { provider, model } = getProviderFromModel("openai/gpt-4o");
-
-const response = await provider.complete({
-  model,
-  messages: [{ role: "user", content: "Hello" }],
-});
-```
-
-Or get a provider by name:
-
-```ts
-import { getProvider } from "veryfront/provider";
-
-const openai = getProvider("openai");
-const response = await openai.complete({
-  model: "gpt-4o",
-  messages: [{ role: "user", content: "Hello" }],
-});
-```
-
-## Custom base URLs
-
-Point a provider to a compatible API (Azure OpenAI, local models, proxies):
-
-```ts
-initializeProviders({
-  openai: {
-    apiKey: getEnv("AZURE_OPENAI_KEY"),
-    baseUrl: "https://my-deployment.openai.azure.com/v1",
-  },
-});
-```
-
-## Provider configuration
-
-### OpenAI
-
-```ts
-{
-  apiKey: string;
-  baseUrl?: string;  // Custom API endpoint
-}
-```
-
-### Anthropic
-
-```ts
-{
-  apiKey: string;
-  baseUrl?: string;
-}
-```
-
-### Google
-
-```ts
-{
-  apiKey: string;
-}
-```
-
-## Environment variables
-
-The framework auto-detects API keys from standard environment variables if you don't call `initializeProviders()`:
+Providers are auto-initialized from standard environment variables on first use:
 
 | Variable | Provider |
 |----------|----------|
 | `OPENAI_API_KEY` | OpenAI |
 | `ANTHROPIC_API_KEY` | Anthropic |
 | `GOOGLE_API_KEY` | Google |
+| `OPENAI_BASE_URL` | Custom OpenAI-compatible endpoint |
+
+No setup code is needed — just set env vars and use `agent()`:
+
+```ts
+import { agent } from "veryfront/agent";
+
+export default agent({
+  model: "openai/gpt-4o",       // OpenAI
+  // model: "anthropic/claude-sonnet-4-20250514", // Anthropic
+  // model: "google/gemini-2.0-flash",  // Google
+  system: "You are a helpful assistant.",
+});
+```
+
+## Model strings
+
+Agents reference models as `"provider/model"`. The framework splits on the first `/`, so nested model IDs work:
+
+```ts
+// Standard
+agent({ model: "openai/gpt-4o" })
+
+// Nested model ID (e.g. OpenRouter)
+agent({ model: "openai/meta-llama/llama-3.1-405b" })
+```
+
+## OpenAI-compatible services
+
+Override the base URL to route through OpenRouter, Azure OpenAI, Ollama, or any OpenAI-compatible API:
+
+```bash
+OPENAI_API_KEY=sk-or-v1-...
+OPENAI_BASE_URL=https://openrouter.ai/api/v1
+```
+
+Both `apiKey` and `baseURL` are resolved per-request, so each project in a multi-tenant setup can have its own configuration.
+
+## Custom provider registration
+
+For providers not covered by env vars, use `registerModelProvider()`:
+
+```ts
+import { registerModelProvider } from "veryfront/provider";
+import { createOpenAI } from "@ai-sdk/openai";
+
+registerModelProvider("ollama", (id) =>
+  createOpenAI({
+    apiKey: "ollama",
+    baseURL: "http://localhost:11434/v1",
+  })(id)
+);
+
+// Then use it
+agent({ model: "ollama/llama3.2" });
+```
+
+The factory receives the model ID and must return an AI SDK `LanguageModel` instance.
+
+## Direct model resolution
+
+For cases outside the agent system:
+
+```ts
+import { resolveModel } from "veryfront/provider";
+
+const model = resolveModel("openai/gpt-4o");
+```
 
 ## Next
 

--- a/docs/reference/provider.md
+++ b/docs/reference/provider.md
@@ -1,62 +1,82 @@
 ---
 title: "veryfront/provider"
-description: "Unified LLM interface for Anthropic, Google, and OpenAI."
+description: "AI SDK model provider registry with auto-initialization from environment variables."
 order: 17
 ---
 
 # veryfront/provider
 
-Unified LLM interface for Anthropic, Google, and OpenAI.
+AI SDK model provider registry. Maps "provider/model" strings to AI SDK LanguageModel instances.
 
 ## Import
 
 ```ts
 import {
-  initializeProviders,
-  getProvider,
-  getProviderFromModel,
-  OpenAIProvider,
-  AnthropicProvider,
-  BaseProvider,
+  registerModelProvider,
+  resolveModel,
+  hasModelProvider,
+  getRegisteredModelProviders,
 } from "veryfront/provider";
 ```
 
 ## Examples
 
-### Initialize providers
+### Auto-initialized (zero config)
 
 ```ts
-import { initializeProviders } from "veryfront/provider";
+// Set OPENAI_API_KEY in .env — no code needed
+import { agent } from "veryfront/agent";
 
-initializeProviders({
-  openai: { apiKey: getEnv("OPENAI_API_KEY") },
+export default agent({
+  model: "openai/gpt-4o",
+  system: "You are helpful.",
 });
 ```
 
-### Route to model
+### Register a custom provider
 
 ```ts
-import { initializeProviders, getProviderFromModel } from "veryfront/provider";
+import { registerModelProvider } from "veryfront/provider";
+import { createOpenAI } from "@ai-sdk/openai";
 
-initializeProviders({
-  openai: { apiKey: getEnv("OPENAI_API_KEY") },
-  anthropic: { apiKey: getEnv("ANTHROPIC_API_KEY") },
-});
+registerModelProvider("ollama", (id) =>
+  createOpenAI({ apiKey: "ollama", baseURL: "http://localhost:11434/v1" })(id)
+);
+```
 
-const { provider, model } = getProviderFromModel("openai/gpt-4o");
-const response = await provider.complete({
-  model,
-  messages: [{ role: "user", content: "Hello" }],
-});
+### Resolve a model directly
+
+```ts
+import { resolveModel } from "veryfront/provider";
+
+const model = resolveModel("openai/gpt-4o");
 ```
 
 ## API
 
-### `initializeProviders(config)`
+### `registerModelProvider(name, factory)`
 
-Set up providers with API keys
+Register a model provider factory for the current project.
 
 **Returns:** `void`
+
+### `resolveModel(modelString)`
+
+Resolve a "provider/model" string to an AI SDK LanguageModel instance.
+
+**Returns:** `LanguageModel`
+
+### `hasModelProvider(name)`
+
+Check if a model provider is registered (project-scoped or shared).
+
+**Returns:** `boolean`
+
+### `getRegisteredModelProviders()`
+
+Get list of registered model provider names.
+
+**Returns:** `string[]`
 
 ## Exports
 
@@ -64,31 +84,17 @@ Set up providers with API keys
 
 | Name | Description |
 |------|-------------|
-| `getProvider` | Get provider by name |
-| `getProviderFromModel` | Resolve `provider/model` string |
-| `initializeProviders` | Set up providers with API keys |
-
-### Classes
-
-| Name | Description |
-|------|-------------|
-| `AnthropicProvider` | Anthropic implementation |
-| `BaseProvider` | Abstract provider base class |
-| `GoogleProvider` | Google AI implementation |
-| `OpenAIProvider` | OpenAI implementation |
+| `registerModelProvider` | Register a model provider factory |
+| `resolveModel` | Resolve "provider/model" to LanguageModel |
+| `hasModelProvider` | Check if provider is registered |
+| `getRegisteredModelProviders` | List registered provider names |
+| `clearModelProviders` | Clear all providers (for testing) |
 
 ### Types
 
 | Name | Description |
 |------|-------------|
-| `AnthropicConfig` | Anthropic config |
-| `CompletionRequest` | Normalized completion request |
-| `CompletionResponse` | Normalized completion response |
-| `GoogleConfig` | Google AI config |
-| `OpenAIConfig` | OpenAI config |
-| `Provider` | Provider interface |
-| `ProviderConfig` | Single provider config |
-| `ProvidersConfig` | All providers config map |
+| `ModelProviderFactory` | `(modelId: string) => LanguageModel` |
 
 ## Related
 

--- a/examples/agent-basic/example.ts
+++ b/examples/agent-basic/example.ts
@@ -12,9 +12,6 @@
 // Platform
 import { detectPlatform, getPlatformCapabilities, getPlatformWarnings } from 'veryfront';
 
-// Providers
-import { initializeProviders } from 'veryfront/provider';
-
 // Agent & Tool factories
 import { agent } from 'veryfront/agent';
 import { tool, registerTool } from 'veryfront/tool';
@@ -78,24 +75,7 @@ if (warnings.length > 0) {
 }
 
 // ============================================================================
-// 2. Initialize Providers
-// ============================================================================
-
-console.log('\n=== Provider Initialization ===');
-
-initializeProviders({
-  openai: {
-    apiKey: getEnv('OPENAI_API_KEY') || 'sk-test',
-  },
-  anthropic: {
-    apiKey: getEnv('ANTHROPIC_API_KEY') || 'sk-ant-test',
-  },
-});
-
-console.log('Providers initialized');
-
-// ============================================================================
-// 3. Create Tools
+// 2. Create Tools
 // ============================================================================
 
 console.log('\n=== Tool Creation ===');

--- a/examples/agent-code-assistant/app/api/chat/route.ts
+++ b/examples/agent-code-assistant/app/api/chat/route.ts
@@ -7,7 +7,6 @@
 
 import { agent } from 'veryfront/agent';
 import { discoverAll } from 'veryfront/mcp';
-import { initializeProviders } from 'veryfront/provider';
 import type { Agent } from 'veryfront/agent';
 
 // System prompt for the code assistant
@@ -73,14 +72,6 @@ You: "Let me search for that in the codebase..."
 - Provide context and explanations, not just raw data
 - Ask follow-up questions when needed
 - **CRITICAL**: Always end with a complete thought, never just tool output`;
-
-// Initialize providers - works in both Node.js and Deno
-initializeProviders({
-  openai: {
-    apiKey: (typeof process !== 'undefined' ? process.env.OPENAI_API_KEY : '') ||
-            (typeof Deno !== 'undefined' ? Deno.env.get('OPENAI_API_KEY') : '') || '',
-  },
-});
 
 // Auto-discover tools and resources on module load
 // Use cwd() to get the actual project directory (not the temp bundle directory)

--- a/examples/agent-dev-tools/example.ts
+++ b/examples/agent-dev-tools/example.ts
@@ -10,8 +10,6 @@
 
 import { agent } from 'veryfront/agent';
 import { tool, registerTool } from 'veryfront/tool';
-import { initializeProviders } from 'veryfront/provider';
-
 import {
   testAgent,
   printTestResults,
@@ -40,13 +38,6 @@ function getEnv(key: string): string | undefined {
 }
 
 console.log('=== Phase 7: Developer Tools ===\n');
-
-// Initialize providers
-initializeProviders({
-  openai: {
-    apiKey: getEnv('OPENAI_API_KEY') || 'sk-test',
-  },
-});
 
 // ============================================================================
 // 1. Create and Test a Tool

--- a/examples/async-worker-redis/src/agent_factory.ts
+++ b/examples/async-worker-redis/src/agent_factory.ts
@@ -14,22 +14,11 @@ function getEnv(key: string): string | undefined {
 }
 
 import { agent } from "veryfront/agent";
-import { initializeProviders } from "veryfront/provider";
 import { tool } from "veryfront/tool";
 import { z } from "zod";
 
-// Try to initialize real providers
-const OPENAI_KEY = getEnv("OPENAI_API_KEY");
-const ANTHROPIC_KEY = getEnv("ANTHROPIC_API_KEY");
-
-let hasProviders = false;
-if (OPENAI_KEY || ANTHROPIC_KEY) {
-  initializeProviders({
-    openai: OPENAI_KEY ? { apiKey: OPENAI_KEY } : undefined,
-    anthropic: ANTHROPIC_KEY ? { apiKey: ANTHROPIC_KEY } : undefined,
-  });
-  hasProviders = true;
-}
+// Check if providers are available via env vars
+const hasProviders = !!(getEnv("OPENAI_API_KEY") || getEnv("ANTHROPIC_API_KEY"));
 
 /**
  * Safe math expression evaluator.

--- a/examples/full-demo/demo.ts
+++ b/examples/full-demo/demo.ts
@@ -6,7 +6,6 @@
 
 // Core
 import { agent, createWorkflow, agentAsTool } from 'veryfront/agent';
-import { initializeProviders } from 'veryfront/provider';
 import { detectPlatform, getPlatformCapabilities } from 'veryfront/platform';
 
 // Discovery & MCP
@@ -61,15 +60,6 @@ console.log(`Platform: ${capabilities.displayName}`);
 console.log(`MCP Server Support: ${capabilities.canRunMCPServer}`);
 console.log(`Max Agent Steps: ${capabilities.maxAgentSteps}`);
 console.log('');
-
-// Initialize providers
-initializeProviders({
-  openai: {
-    apiKey: getEnv('OPENAI_API_KEY') || 'sk-test',
-  },
-});
-
-console.log('Providers initialized ✓\n');
 
 // ============================================================================
 // Phase 2: MCP Integration - Auto-Discovery

--- a/examples/ingestion-pipeline/run.ts
+++ b/examples/ingestion-pipeline/run.ts
@@ -32,21 +32,10 @@ import { S3BlobStorage } from "veryfront/workflow/blob";
 import ingestionWorkflow from "./ai/workflows/ingestion.ts";
 import processorAgent from "./ai/agents/processor.ts";
 import indexerAgent from "./ai/agents/indexer.ts";
-import { initializeProviders } from "veryfront/provider";
-
 async function main() {
   console.log("🚀 Starting Ingestion Pipeline Example...");
 
-  // 1. Setup AI Providers
-  // In a real app, this would be auto-configured from env vars.
-  // Here we explicitly initialize it to ensure it uses the provided key.
-  initializeProviders({
-    openai: {
-      apiKey: getEnv("OPENAI_API_KEY") || "sk-no-key-provided",
-    },
-  });
-
-  // 2. Setup MinIO Blob Storage
+  // 1. Setup MinIO Blob Storage
   const blobStorage = new S3BlobStorage({
     region: "us-east-1",
     bucket: "ingest-bucket",

--- a/examples/knowledge-base/app/api/chat/route.ts
+++ b/examples/knowledge-base/app/api/chat/route.ts
@@ -24,17 +24,10 @@ if (typeof Deno === 'undefined') {
 }
 
 import { agent } from "veryfront/agent";
-import { initializeProviders } from "veryfront/provider";
 import { tool } from "veryfront/tool";
 import { z } from "zod";
 
-// Initialize providers
 const OPENAI_API_KEY = getEnv("OPENAI_API_KEY");
-if (OPENAI_API_KEY) {
-  initializeProviders({
-    openai: { apiKey: OPENAI_API_KEY },
-  });
-}
 
 // Load Knowledge Base (in-memory for demo)
 // In production, use a real Vector DB (Pinecone, Weaviate, pgvector, etc.)

--- a/examples/knowledge-base/docs/ai.md
+++ b/examples/knowledge-base/docs/ai.md
@@ -30,5 +30,16 @@ const myTool = tool({
 
 ## Providers
 
-We support OpenAI and Anthropic out of the box.
-Providers handle the API communication and streaming.
+OpenAI, Anthropic, and Google are auto-initialized from environment variables
+(`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`).
+
+For custom providers, use `registerModelProvider()`:
+
+```typescript
+import { registerModelProvider } from "veryfront/provider";
+import { createOpenAI } from "@ai-sdk/openai";
+
+registerModelProvider("ollama", (id) =>
+  createOpenAI({ apiKey: "ollama", baseURL: "http://localhost:11434/v1" })(id)
+);
+```

--- a/examples/provider-sdk-integration/README.md
+++ b/examples/provider-sdk-integration/README.md
@@ -1,15 +1,14 @@
-# Veryfront AI - AI SDK Integration Example
+# Veryfront AI - Provider Integration Example
 
-This example demonstrates the flexibility of Veryfront's AI system:
+This example demonstrates how to configure AI model providers:
 
-- Using Vercel AI SDK providers (30+ providers available)
-- Using Veryfront custom providers (full control)
-- Hybrid approach (both in same application)
-- Veryfront enhancements work with both approaches
+- Auto-initialized providers from environment variables
+- Custom provider registration with `registerModelProvider()`
+- OpenAI-compatible services (OpenRouter, Ollama) via base URL override
 
 ## Setup
 
-1. Set your API key:
+1. Set your API key (choose one method):
 
 **Option A: Environment variable**
 ```bash
@@ -28,78 +27,73 @@ cp ../../.env.example .env
 deno run --allow-net --allow-env --allow-read example.ts
 ```
 
-## What It Does
+## Provider Configuration
 
-1. **AI SDK Providers**: Uses Vercel AI SDK providers
-2. **Custom Providers**: Demonstrates custom provider implementation
-3. **Hybrid Usage**: Shows using both approaches in same app
-4. **Veryfront Enhancements**: Tools, agents, MCP work with both
+### Auto-Initialized (Recommended)
+
+Set environment variables and providers are auto-detected on first use:
+
+```bash
+OPENAI_API_KEY=sk-...        # → "openai" provider
+ANTHROPIC_API_KEY=sk-ant-... # → "anthropic" provider
+GOOGLE_API_KEY=...           # → "google" provider
+```
+
+```typescript
+import { agent } from 'veryfront/agent';
+
+// No provider setup needed — just use agent()
+const myAgent = agent({
+  model: 'openai/gpt-4o',
+  system: 'You are helpful.',
+});
+```
+
+### OpenAI-Compatible Services
+
+Override the base URL to use services like OpenRouter, Azure OpenAI, or Ollama:
+
+```bash
+OPENAI_API_KEY=sk-or-v1-...
+OPENAI_BASE_URL=https://openrouter.ai/api/v1
+```
+
+```typescript
+// Now "openai" provider routes through OpenRouter
+const myAgent = agent({
+  model: 'openai/meta-llama/llama-3.1-405b',
+  system: 'You are helpful.',
+});
+```
+
+### Custom Registration (Advanced)
+
+Use `registerModelProvider()` for full control over provider creation:
+
+```typescript
+import { registerModelProvider } from 'veryfront/provider';
+import { createOpenAI } from '@ai-sdk/openai';
+
+// Register Ollama as a custom provider
+registerModelProvider('ollama', (modelId) =>
+  createOpenAI({
+    apiKey: 'ollama',
+    baseURL: 'http://localhost:11434/v1',
+  })(modelId)
+);
+
+// Then use it
+const myAgent = agent({
+  model: 'ollama/llama3.2',
+  system: 'You are helpful.',
+});
+```
 
 ## Files
 
-- `example.ts` - Main example demonstrating integration options
+- `example.ts` - Main example demonstrating all provider options
 
-## Three Integration Options
-
-### Option 1: AI SDK Providers (Recommended)
-```typescript
-import { openai } from 'veryfront/provider';
-import { generateText } from 'veryfront/agent';
-
-const model = openai('gpt-4o', { apiKey });
-const result = await generateText({
-  model,
-  prompt: 'Hello',
-});
-```
-
-**Benefits:**
-- 30+ providers (OpenAI, Anthropic, Google, Mistral, etc.)
-- Battle-tested in production
-- Actively maintained by Vercel
-- Industry standard
-
-### Option 2: Custom Providers (Advanced)
-```typescript
-import { BaseProvider, initializeProviders } from 'veryfront/provider';
-
-class OllamaProvider extends BaseProvider {
-  name = 'ollama';
-  // Custom implementation...
-}
-
-initializeProviders({
-  ollama: new OllamaProvider({ /* config */ }),
-});
-```
-
-**Benefits:**
-- Full control over requests/responses
-- Custom authentication
-- Internal APIs
-- Special requirements
-
-### Option 3: Hybrid (Best of Both Worlds)
-```typescript
-import { openai } from 'veryfront/provider';
-import { initializeProviders } from 'veryfront/provider';
-
-// Use AI SDK for standard providers
-const model = openai('gpt-4o');
-
-// Use custom for special cases
-initializeProviders({
-  internal: new InternalProvider(),
-});
-```
-
-**Benefits:**
-- AI SDK for standard providers
-- Custom for special cases
-- Both in same application
-- No lock-in
-
-## Veryfront Enhancements (Work with All Options)
+## Veryfront Enhancements (Work with All Providers)
 
 All Veryfront features work regardless of provider choice:
 
@@ -108,23 +102,4 @@ All Veryfront features work regardless of provider choice:
 - **Multi-agent workflows**: `createWorkflow()`
 - **Agent composition**: `agentAsTool()`
 - **Memory strategies**: conversation, buffer, summary
-- **Three-layer UI**: hooks, primitives, styled components
 - **Production middleware**: rate limit, cache, cost, security
-
-## When to Use Each Option
-
-**Use AI SDK Providers when:**
-- You need a standard LLM provider
-- You want a maintained, standard integration
-- You prefer industry-standard approach
-
-**Use Custom Providers when:**
-- You have internal APIs
-- You need custom authentication
-- You require full request/response control
-- You're integrating non-standard models
-
-**Use Hybrid when:**
-- You want best of both worlds
-- Different parts of app have different needs
-- You're migrating from custom to standard

--- a/examples/provider-sdk-integration/example.ts
+++ b/examples/provider-sdk-integration/example.ts
@@ -1,22 +1,17 @@
 /**
- * AI SDK Integration Example
+ * AI SDK Provider Integration Example
  *
- * Demonstrates flexibility:
- * - Use AI SDK providers (30+ options)
- * - Use custom providers (full control, special cases)
- * - Use both in the same app (no lock-in)
- * - Veryfront enhancements work with both
+ * Demonstrates:
+ * - Auto-initialized providers from environment variables
+ * - Custom provider registration with registerModelProvider()
+ * - OpenAI-compatible services (OpenRouter, Ollama) via base URL override
+ * - Using agents with different providers
  */
 
-// AI SDK re-exports
-import { openai, anthropic, streamText, generateText } from 'veryfront/provider';
-
-// Veryfront custom providers (for special cases)
-import { BaseProvider, OpenAIProvider, AnthropicProvider } from 'veryfront/provider';
-
-// Veryfront enhancements
-import { initializeProviders } from 'veryfront/provider';
+import { agent } from 'veryfront/agent';
+import { registerModelProvider } from 'veryfront/provider';
 import { tool, registerTool } from 'veryfront/tool';
+import { createOpenAI } from '@ai-sdk/openai';
 
 import { z } from 'zod';
 
@@ -35,111 +30,68 @@ function getEnv(key: string): string | undefined {
   return undefined;
 }
 
-console.log('=== AI SDK Integration Example ===\n');
-console.log('Demonstrating flexibility: AI SDK + Custom Providers\n');
+console.log('=== AI SDK Provider Integration Example ===\n');
 
 // ============================================================================
-// 1. Use AI SDK Providers (Recommended)
+// 1. Auto-Initialized Providers (Zero Config)
 // ============================================================================
 
-console.log('=== 1. Using AI SDK Providers ===\n');
+console.log('=== 1. Auto-Initialized Providers ===\n');
 
-const apiKey = getEnv('OPENAI_API_KEY') || 'sk-test';
+console.log('Veryfront auto-detects providers from environment variables:');
+console.log('  OPENAI_API_KEY      → "openai" provider');
+console.log('  ANTHROPIC_API_KEY   → "anthropic" provider');
+console.log('  GOOGLE_API_KEY      → "google" provider');
+console.log('');
+console.log('No setup code needed — just set env vars and use agent():\n');
+console.log('  agent({ model: "openai/gpt-4o" })');
+console.log('  agent({ model: "anthropic/claude-sonnet-4-20250514" })');
+console.log('  agent({ model: "google/gemini-2.0-flash" })\n');
 
-if (apiKey && apiKey !== 'sk-test') {
-  console.log('Testing AI SDK provider (OpenAI)...\n');
+// ============================================================================
+// 2. OpenAI Base URL Override (OpenRouter, Azure, etc.)
+// ============================================================================
 
-  try {
-    // Use AI SDK's openai provider directly
-    const model = openai('gpt-4o', {
-      apiKey,
-    });
+console.log('=== 2. OpenAI-Compatible Services ===\n');
 
-    const result = await generateText({
-      model,
-      prompt: 'Say hello in 5 words',
-    });
+console.log('Use OPENAI_BASE_URL to point the "openai" provider elsewhere:');
+console.log('');
+console.log('  # OpenRouter');
+console.log('  OPENAI_API_KEY=sk-or-v1-...');
+console.log('  OPENAI_BASE_URL=https://openrouter.ai/api/v1');
+console.log('');
+console.log('  # Then use any OpenRouter model:');
+console.log('  agent({ model: "openai/meta-llama/llama-3.1-405b" })\n');
 
-    console.log('AI SDK OpenAI Result:');
-    console.log(`  Text: ${result.text}`);
-    console.log(`  Tokens: ${result.usage.totalTokens}`);
-    console.log('  ✅ AI SDK provider working!\n');
-  } catch (error) {
-    console.error('AI SDK error:', error);
-  }
-} else {
-  console.log('Skipping AI SDK test (set OPENAI_API_KEY)\n');
+// ============================================================================
+// 3. Custom Provider Registration (Advanced)
+// ============================================================================
+
+console.log('=== 3. Custom Provider Registration ===\n');
+
+// Register a custom provider for Ollama (local models)
+const ollamaKey = getEnv('OLLAMA_API_KEY');
+if (ollamaKey || true) {
+  // registerModelProvider() accepts a factory: (modelId) => LanguageModel
+  registerModelProvider('ollama', (modelId) => {
+    return createOpenAI({
+      apiKey: 'ollama', // Ollama doesn't need a real key
+      baseURL: 'http://localhost:11434/v1',
+    })(modelId);
+  });
+
+  console.log('Registered "ollama" provider');
+  console.log('  Uses @ai-sdk/openai with custom baseURL');
+  console.log('  Usage: agent({ model: "ollama/llama3.2" })\n');
 }
 
 // ============================================================================
-// 2. Use Custom Provider (Full Control)
+// 4. Create Agent with Auto-Detected Provider
 // ============================================================================
 
-console.log('=== 2. Using Custom Provider ===\n');
+console.log('=== 4. Using Agents ===\n');
 
-// Initialize with custom provider
-initializeProviders({
-  openai: {
-    apiKey: apiKey,
-  },
-});
-
-console.log('Custom OpenAIProvider initialized');
-console.log('  Implementation: src/ai/providers/openai.ts');
-console.log('  Full control over: headers, endpoints, transformations');
-console.log('  Use case: Internal APIs, custom auth, special requirements\n');
-
-// ============================================================================
-// 3. Implement Custom Provider (Example: Ollama)
-// ============================================================================
-
-console.log('=== 3. Custom Provider Example (Ollama) ===\n');
-
-class OllamaProvider extends BaseProvider {
-  name = 'ollama';
-
-  protected getHeaders(): Record<string, string> {
-    return {
-      'Content-Type': 'application/json',
-    };
-  }
-
-  protected getEndpoint(path: string): string {
-    return `http://localhost:11434/v1${path}`;
-  }
-
-  protected transformRequest(request: any): Record<string, unknown> {
-    return {
-      model: request.model,
-      messages: request.messages,
-      stream: request.stream || false,
-    };
-  }
-
-  protected transformResponse(response: any): any {
-    return {
-      text: response.message?.content || '',
-      usage: {
-        promptTokens: 0,
-        completionTokens: 0,
-        totalTokens: 0,
-      },
-      finishReason: 'stop' as const,
-    };
-  }
-}
-
-console.log('Created OllamaProvider (OpenAI-compatible local model)');
-console.log('  Endpoint: http://localhost:11434');
-console.log('  Use case: Local models, privacy, offline\n');
-
-// ============================================================================
-// 4. Veryfront Enhancements Work with Both
-// ============================================================================
-
-console.log('=== 4. Veryfront Enhancements (Work with Both) ===\n');
-
-// Create tool (works with AI SDK or custom providers)
+// Create tool (works with any provider)
 const weatherTool = tool({
   id: 'getWeather',
   description: 'Get current weather',
@@ -147,56 +99,60 @@ const weatherTool = tool({
     city: z.string(),
   }),
   execute: async ({ city }) => {
-    // Mock implementation
-    return {
-      city,
-      temperature: 72,
-      condition: 'Sunny',
-    };
+    return { city, temperature: 72, condition: 'Sunny' };
   },
 });
 
 registerTool('getWeather', weatherTool);
 
-console.log('✅ Tool created and registered');
-console.log('  Tool: getWeather');
-console.log('  Works with: AI SDK providers AND custom providers');
-console.log('  Auto-discovery: YES (if in ai/tools/)');
-console.log('  MCP exposed: YES (via veryfront dev --mcp)\n');
+const apiKey = getEnv('OPENAI_API_KEY');
+
+if (apiKey) {
+  console.log('Testing with OpenAI provider...\n');
+
+  const myAgent = agent({
+    model: 'openai/gpt-4o',
+    system: 'You are a helpful assistant.',
+    tools: { getWeather: true },
+  });
+
+  try {
+    const result = await myAgent.generate({
+      input: 'What is the weather in Tokyo?',
+    });
+    console.log(`Response: ${result.text}`);
+    console.log(`Tool Calls: ${result.toolCalls.length}\n`);
+  } catch (error) {
+    console.error('Error:', error);
+  }
+} else {
+  console.log('Skipping live test (set OPENAI_API_KEY)\n');
+}
 
 // ============================================================================
 // Summary
 // ============================================================================
 
 console.log('=== Summary ===\n');
-console.log('Veryfront provides THREE options:\n');
 
-console.log('Option 1: AI SDK Providers (Recommended)');
-console.log('  ✅ 30+ providers (OpenAI, Anthropic, Google, Mistral, etc.)');
-console.log('  ✅ Battle-tested in production');
-console.log('  ✅ Actively maintained by Vercel');
-console.log('  ✅ Use: import { openai } from "veryfront/provider"\n');
+console.log('Provider Setup Options:\n');
 
-console.log('Option 2: Custom Providers (Advanced)');
-console.log('  ✅ Full control (internal APIs, custom auth)');
-console.log('  ✅ BaseProvider class provided');
-console.log('  ✅ Examples: OpenAI, Anthropic implementations');
-console.log('  ✅ Use: extend BaseProvider\n');
+console.log('1. Auto-Initialized (Recommended)');
+console.log('   Set OPENAI_API_KEY, ANTHROPIC_API_KEY, or GOOGLE_API_KEY');
+console.log('   Providers are auto-detected on first use\n');
 
-console.log('Option 3: Hybrid (Best of Both Worlds)');
-console.log('  ✅ AI SDK for standard providers');
-console.log('  ✅ Custom for special cases');
-console.log('  ✅ Both in same app');
-console.log('  ✅ No lock-in\n');
+console.log('2. Base URL Override');
+console.log('   Set OPENAI_BASE_URL for OpenAI-compatible services');
+console.log('   Works with OpenRouter, Azure OpenAI, Ollama, etc.\n');
 
-console.log('Veryfront Enhancements (Work with All):');
-console.log('  ✅ Auto-discovery (ai/tools/ → auto-register)');
-console.log('  ✅ MCP server (veryfront dev --mcp)');
-console.log('  ✅ Multi-agent workflows (createWorkflow)');
-console.log('  ✅ Agent composition (agentAsTool)');
-console.log('  ✅ Memory strategies (conversation, buffer, summary)');
-console.log('  ✅ Three-layer UI (hooks, primitives, styled)');
-console.log('  ✅ Production middleware (rate limit, cache, cost, security)\n');
+console.log('3. Custom Registration');
+console.log('   Use registerModelProvider() for full control');
+console.log('   Accepts any AI SDK LanguageModel factory\n');
 
-console.log('🎉 Flexibility achieved! Use AI SDK, custom, or both.');
-console.log('   No lock-in. Best of both worlds.\n');
+console.log('Veryfront Features (Work with All Providers):');
+console.log('  Auto-discovery: ai/tools/ → auto-register');
+console.log('  MCP server: veryfront dev --mcp');
+console.log('  Multi-agent workflows: createWorkflow()');
+console.log('  Agent composition: agentAsTool()');
+console.log('  Memory strategies: conversation, buffer, summary');
+console.log('  Production middleware: rate limit, cache, cost, security\n');

--- a/examples/workflow-memory/example.ts
+++ b/examples/workflow-memory/example.ts
@@ -11,7 +11,6 @@
 
 import { agent, agentAsTool, createWorkflow, registerAgent } from 'veryfront/agent';
 import { tool } from 'veryfront/tool';
-import { initializeProviders } from 'veryfront/provider';
 import { z } from 'zod';
 
 // Helpers for Cross-Platform Compatibility (Deno/Node)
@@ -30,13 +29,6 @@ function getEnv(key: string): string | undefined {
 }
 
 console.log('=== Phase 3: Agent Enhancements ===\n');
-
-// Initialize providers
-initializeProviders({
-  openai: {
-    apiKey: getEnv('OPENAI_API_KEY') || 'sk-test',
-  },
-});
 
 // ============================================================================
 // 1. Memory Strategies

--- a/scripts/docs/generate-api-reference.ts
+++ b/scripts/docs/generate-api-reference.ts
@@ -193,7 +193,7 @@ const IMPORT_PRIORITY: Record<string, string[]> = {
     "createOAuthInitHandler", "createOAuthCallbackHandler", "githubConfig", "MemoryTokenStore",
   ],
   "veryfront/provider": [
-    "initializeProviders", "getProvider", "getProviderFromModel", "OpenAIProvider",
+    "registerModelProvider", "resolveModel", "hasModelProvider", "getRegisteredModelProviders",
   ],
   "veryfront/fs": ["readTextFile", "writeTextFile", "join", "resolve", "exists", "mkdir"],
 };
@@ -645,21 +645,12 @@ const DESCRIPTIONS: Record<string, Record<string, string>> = {
   },
 
   "veryfront/provider": {
-    initializeProviders: "Set up providers with API keys",
-    getProvider: "Get provider by name",
-    getProviderFromModel: "Resolve `provider/model` string",
-    BaseProvider: "Abstract provider base class",
-    OpenAIProvider: "OpenAI implementation",
-    AnthropicProvider: "Anthropic implementation",
-    GoogleProvider: "Google AI implementation",
-    Provider: "Provider interface",
-    ProviderConfig: "Single provider config",
-    ProvidersConfig: "All providers config map",
-    CompletionRequest: "Normalized completion request",
-    CompletionResponse: "Normalized completion response",
-    OpenAIConfig: "OpenAI config",
-    AnthropicConfig: "Anthropic config",
-    GoogleConfig: "Google AI config",
+    registerModelProvider: "Register a model provider factory",
+    resolveModel: "Resolve \"provider/model\" to LanguageModel",
+    hasModelProvider: "Check if provider is registered",
+    getRegisteredModelProviders: "List registered provider names",
+    clearModelProviders: "Clear all providers (for testing)",
+    ModelProviderFactory: "(modelId: string) => LanguageModel",
   },
 
   "veryfront/fs": {
@@ -1029,8 +1020,7 @@ const API_DOCS: Record<string, APIDocs> = {
     expandTypes: ["CorsOptions", "RateLimitOptions", "LoggerOptions", "TimeoutOptions"],
   },
   "veryfront/provider": {
-    functions: { initializeProviders: { configType: "ProvidersConfig" } },
-    expandTypes: ["ProviderConfig", "CompletionRequest", "CompletionResponse"],
+    functions: { registerModelProvider: {} },
   },
   "veryfront/mcp": {
     functions: { createMCPServer: { configType: "MCPServerConfig" } },
@@ -1269,30 +1259,6 @@ const PROPERTY_DESCRIPTIONS: Record<string, Record<string, string>> = {
   TimeoutOptions: {
     timeout: "Request timeout (ms)",
     message: "Timeout error message",
-  },
-  ProvidersConfig: {
-    openai: "OpenAI provider config",
-    anthropic: "Anthropic provider config",
-    google: "Google AI provider config",
-  },
-  ProviderConfig: {
-    apiKey: "API key for the provider",
-    baseUrl: "Custom API base URL",
-    defaultModel: "Default model to use",
-  },
-  CompletionRequest: {
-    model: "Model identifier",
-    messages: "Input messages",
-    tools: "Available tools",
-    maxTokens: "Max tokens to generate",
-    temperature: "Sampling temperature",
-    stream: "Enable streaming",
-  },
-  CompletionResponse: {
-    text: "Generated text",
-    toolCalls: "Tool calls made by the model",
-    usage: "Token usage statistics",
-    finishReason: "Why generation stopped",
   },
   MCPServerConfig: {
     name: "Server name",

--- a/scripts/docs/verify-npm-exports.mjs
+++ b/scripts/docs/verify-npm-exports.mjs
@@ -46,7 +46,7 @@ const REQUIRED_EXPORTS = {
   "./mcp": ["createMCPServer", "registerTool", "registerPrompt", "registerResource"],
   "./middleware": ["cors", "rateLimit", "logger", "timeout", "MiddlewarePipeline"],
   "./oauth": ["createOAuthInitHandler", "createOAuthCallbackHandler", "githubConfig", "slackConfig", "MemoryTokenStore"],
-  "./provider": ["initializeProviders", "getProvider", "getProviderFromModel", "OpenAIProvider", "AnthropicProvider"],
+  "./provider": ["registerModelProvider", "resolveModel", "hasModelProvider", "getRegisteredModelProviders"],
   "./fs": ["readTextFile", "writeTextFile", "join", "resolve", "exists", "mkdir"],
 };
 

--- a/scripts/docs/verify-npm-node.mjs
+++ b/scripts/docs/verify-npm-node.mjs
@@ -173,11 +173,11 @@ try {
 console.log("veryfront/provider:");
 try {
   const prov = await imp("./provider");
-  assertType(prov.initializeProviders, "function", "initializeProviders is function");
-  assertType(prov.getProvider, "function", "getProvider is function");
-  assertType(prov.getProviderFromModel, "function", "getProviderFromModel is function");
-  assert(prov.OpenAIProvider !== undefined, "OpenAIProvider exists");
-  assert(prov.AnthropicProvider !== undefined, "AnthropicProvider exists");
+  assertType(prov.registerModelProvider, "function", "registerModelProvider is function");
+  assertType(prov.resolveModel, "function", "resolveModel is function");
+  assertType(prov.hasModelProvider, "function", "hasModelProvider is function");
+  assertType(prov.getRegisteredModelProviders, "function", "getRegisteredModelProviders is function");
+  assertType(prov.clearModelProviders, "function", "clearModelProviders is function");
   console.log("  OK    provider — 5 checks");
 } catch (err) {
   failed++;


### PR DESCRIPTION
## Summary

- Remove all references to deleted `initializeProviders()` and old provider classes (`OpenAIProvider`, `AnthropicProvider`, `GoogleProvider`)
- Update 8 examples to rely on auto-initialized providers from env vars (no setup code needed)
- Rewrite provider guide and API reference for the new registry API (`registerModelProvider`, `resolveModel`, etc.)
- Update doc tooling scripts (API reference generator, npm export/node verification) to match new exports

## Test plan

- [ ] `deno task typecheck` passes
- [ ] `node scripts/docs/verify-npm-exports.mjs` passes after `deno task build:npm`
- [ ] `node scripts/docs/verify-npm-node.mjs` passes after `deno task build:npm`
- [ ] Review provider guide renders correctly
- [ ] Review provider API reference renders correctly