### PR TITLE
docs: add all provider functions to API_DOCS allowlist

### DIFF
--- a/scripts/docs/generate-api-reference.ts
+++ b/scripts/docs/generate-api-reference.ts
@@ -1020,7 +1020,13 @@ const API_DOCS: Record<string, APIDocs> = {
     expandTypes: ["CorsOptions", "RateLimitOptions", "LoggerOptions", "TimeoutOptions"],
   },
   "veryfront/provider": {
-    functions: { registerModelProvider: {} },
+    functions: {
+      registerModelProvider: {},
+      resolveModel: {},
+      hasModelProvider: {},
+      getRegisteredModelProviders: {},
+      clearModelProviders: {},
+    },
   },
   "veryfront/mcp": {
     functions: { createMCPServer: { configType: "MCPServerConfig" } },


### PR DESCRIPTION
## Summary

- Add `resolveModel`, `hasModelProvider`, `getRegisteredModelProviders`, and `clearModelProviders` to the `API_DOCS` allowlist in the API reference generator
- Without this, only `registerModelProvider` gets a detailed `### fn()` heading in the generated docs; the other four functions would only appear in the exports table

Follow-up to #340 addressing [Codex review comment](https://github.com/veryfront/veryfront-code/pull/340#discussion_r2802913011).

## Test plan

- [ ] `deno task docs` generates `### resolveModel(modelString)`, `### hasModelProvider(name)`, etc. in the provider reference