### PR TITLE
Release v0.1.9

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -325,7 +325,16 @@ jobs:
           if [[ "$VERSION" == *"-rc"* ]] || [[ "$VERSION" == *"-alpha"* ]] || [[ "$VERSION" == *"-beta"* ]]; then
             cd npm && npm publish --access public --tag rc
           else
-            cd npm && npm publish --access public
+            cd npm && npm publish --access public || {
+              # If publish fails because version already exists (published by prerelease job),
+              # just promote the existing rc-tagged version to latest
+              if npm view "veryfront@${VERSION}" version 2>/dev/null; then
+                echo "Version ${VERSION} already published, promoting to latest..."
+                npm dist-tag add "veryfront@${VERSION}" latest
+              else
+                exit 1
+              fi
+            }
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",


### PR DESCRIPTION
## Summary
- Bump version to 0.1.9
- Fix release workflow: if npm publish fails because the version was already published by the prerelease job, promote it to `latest` via `dist-tag` instead of failing

## Test plan
- [ ] Merge to main, then push `v0.1.9` tag
- [ ] Verify `veryfront@0.1.9` appears as `latest` on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)