### PR TITLE
fix: restore CLI entry point in npm package

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -1,3 +1,14 @@
+/**
+ * Veryfront CLI entry point.
+ *
+ * @module cli
+ *
+ * @example
+ * ```sh
+ * npx veryfront dev
+ * ```
+ */
+
 // CRITICAL: Extract esbuild binary and set env var BEFORE any imports
 // This must happen synchronously at the very start to ensure esbuild sees the correct path
 await import("veryfront/platform/esbuild-init");

--- a/deno.json
+++ b/deno.json
@@ -36,7 +36,8 @@
     "./oauth": "./src/oauth/index.ts",
     "./provider": "./src/provider/index.ts",
     "./fs": "./src/fs/index.ts",
-    "./integrations": "./src/integrations/index.ts"
+    "./integrations": "./src/integrations/index.ts",
+    "./cli": "./cli/main.ts"
   },
   "imports": {
     "veryfront/head": "./src/react/components/Head.tsx",

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -216,8 +216,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const nativeBinary = join(__dirname, process.platform === 'win32' ? 'veryfront.exe' : 'veryfront');
 
 async function runJsFallback() {
-  const { main } = await import('../esm/cli/main.js');
-  await main();
+  await import('../esm/cli/main.js');
 }
 
 if (existsSync(nativeBinary)) {


### PR DESCRIPTION
## Summary

- **Restores `./cli` to `deno.json` exports** so dnt transpiles `cli/main.ts` into the npm package
- **Fixes bin wrapper** — `cli/main.ts` is a side-effect script (top-level await), not a module exporting `main()`
- **Bumps version to 0.1.10**

## Problem

After the API surface tightening (b3cb6eaf9), `./cli` was moved from `exports` to `imports`. Since dnt only transpiles entry points listed in `exports`, `esm/cli/main.js` stopped being included in the npm package.

When the native binary isn't available (v0.1.9 has no release assets), the bin wrapper falls back to `import('../esm/cli/main.js')` which doesn't exist:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../veryfront/esm/cli/main.js'
```

This breaks all CLI commands (`veryfront dev`, `veryfront init`, etc.) for users installing via npm/pnpm.

## Test plan

- [ ] Run `deno task build:npm` and verify `npm/esm/cli/main.js` exists
- [ ] In a fresh directory: `pnpm create veryfront` → project scaffolds successfully
- [ ] In scaffolded project: `pnpm dev` → dev server starts