### PR TITLE
Release v0.1.10

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "description": "The simplest way to build AI-powered apps",
   "keywords": [
     "react",


### PR DESCRIPTION
## Summary
- Bump version to 0.1.10

Includes the pnpm postinstall fix from #348. After merge, tag `v0.1.10` to trigger the release pipeline.