### PR TITLE
fix: restore CLI entry point and set executable permission on npm bin wrapper

### DIFF
--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -228,6 +228,7 @@ if (existsSync(nativeBinary)) {
   runJsFallback().catch(err => { console.error(err); process.exit(1); });
 }
 `);
+		await Deno.chmod("./npm/bin/veryfront.js", 0o755);
 
 		// Copy LICENSE (generate default if missing)
 		await copyFileOrGenerate("./LICENSE", "./npm/LICENSE", generateMitLicense);


### PR DESCRIPTION
## Summary
- Set executable permission on `bin/veryfront.js` — `Deno.writeTextFile()` doesn't set the +x bit, causing "Permission denied" on global npm installs
- Restore `./cli` in `deno.json` exports so dnt transpiles `cli/main.ts` into the npm package (subsumes #347)
- Fix bin wrapper: `cli/main.ts` is a side-effect script with top-level await, not a module exporting `main()`

## Test plan
- [ ] Run `deno task build:npm` and verify `npm/bin/veryfront.js` is executable
- [ ] Run `deno task build:npm` and verify `npm/esm/cli/main.js` exists
- [ ] `npm install -g ./npm && veryfront --version` works without errors