### PR TITLE
Release v0.1.11

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "The simplest way to build AI-powered apps",
   "keywords": [
     "react",
@@ -93,6 +93,9 @@
     },
     "./integrations": {
       "import": "./esm/src/integrations/index.js"
+    },
+    "./cli": {
+      "import": "./esm/cli/main.js"
     },
     "./tsconfig.json": "./tsconfig.json"
   },


### PR DESCRIPTION
## Summary
- Bump version to 0.1.11
- Includes fixes from #347 (CLI entry point) and #352 (bin permissions)

## After merge
Tag and push: `git tag v0.1.11 origin/main && git push origin v0.1.11`