### PR TITLE
fix: improve server error handling to prevent silent 404s and 500s

### DIFF
--- a/src/cache/backends/api.ts
+++ b/src/cache/backends/api.ts
@@ -107,8 +107,11 @@ export class ApiCacheBackend implements CacheBackend {
             let responseBody = "";
             try {
               responseBody = await response.text();
-            } catch {
-              // ignore body read errors
+            } catch (bodyError) {
+              logger.error("Failed to read API error response body", {
+                status: response.status,
+                error: bodyError instanceof Error ? bodyError.message : String(bodyError),
+              });
             }
             throw new Error(`HTTP ${response.status}: ${responseBody.slice(0, 500)}`);
           }

--- a/src/cache/backends/disk.ts
+++ b/src/cache/backends/disk.ts
@@ -56,7 +56,15 @@ export class DiskCacheBackend implements CacheBackend {
         return null;
       }
       return envelope.value;
-    } catch {
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code !== "ENOENT") {
+        logger.error("[DiskCache] Read error", {
+          key: key.slice(-60),
+          error: error instanceof Error ? error.message : String(error),
+          code,
+        });
+      }
       return null;
     }
   }
@@ -85,7 +93,16 @@ export class DiskCacheBackend implements CacheBackend {
     try {
       const { unlink } = await fsPromises;
       await unlink(this.filePath(key));
-    } catch { /* File may not exist */ }
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code !== "ENOENT") {
+        logger.error("[DiskCache] Delete error", {
+          key: key.slice(-60),
+          error: error instanceof Error ? error.message : String(error),
+          code,
+        });
+      }
+    }
   }
 
   async delByPattern(pattern: string): Promise<number> {
@@ -113,10 +130,18 @@ export class DiskCacheBackend implements CacheBackend {
             await unlink(filePath);
             deleted++;
           }
-        } catch { /* Skip unreadable files */ }
+        } catch (error) {
+          logger.error("[DiskCache] Skip unreadable cache file", {
+            file,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
       }
-    } catch {
-      logger.debug("[DiskCache] delByPattern: directory not accessible");
+    } catch (error) {
+      logger.error("[DiskCache] delByPattern: directory not accessible", {
+        pattern,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
     return deleted;
   }

--- a/src/cache/distributed-cache-init.ts
+++ b/src/cache/distributed-cache-init.ts
@@ -47,12 +47,28 @@ export function initializeDistributedCaches(): Promise<DistributedCacheStatus> {
     async (): Promise<DistributedCacheStatus> => {
       logger.info("Initializing caches...", { backend });
 
+      const cacheNames = [
+        "transformCache",
+        "ssrModuleCache",
+        "fileCache",
+        "projectCSSCache",
+      ] as const;
       const results = await Promise.allSettled([
         initializeTransformCache(),
         initializeSSRDistributedCache(),
         initializeFileCacheBackend(),
         initializeProjectCSSCache(),
       ]);
+
+      for (let i = 0; i < results.length; i++) {
+        const result = results[i];
+        if (result && result.status === "rejected") {
+          logger.error(`Cache initialization failed: ${cacheNames[i]}`, {
+            backend,
+            error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+          });
+        }
+      }
 
       const status: DistributedCacheStatus = {
         backend,

--- a/src/cache/multi-tier.ts
+++ b/src/cache/multi-tier.ts
@@ -166,7 +166,10 @@ export class MultiTierCache<T = string> {
 
         const setOps = tiers.map((tier) =>
           tier.set(key, value, ttl).catch((error) => {
-            logger.debug(`[${this.config.name}] Set error in ${tier.name}`, { key, error });
+            logger.error(`[${this.config.name}] Set error in ${tier.name}`, {
+              key: key.slice(-60),
+              error: error instanceof Error ? error.message : String(error),
+            });
           })
         );
 
@@ -189,7 +192,7 @@ export class MultiTierCache<T = string> {
     await Promise.all(
       tiers.map((tier) =>
         tier.delete?.(key).catch((error) => {
-          logger.debug(`[${this.config.name}] Delete error in ${tier.name}`, { key, error });
+          logger.error(`[${this.config.name}] Delete error in ${tier.name}`, { key, error });
         })
       ),
     );
@@ -244,7 +247,7 @@ export class MultiTierCache<T = string> {
           }
         }
       } catch (error) {
-        logger.debug(`[${this.config.name}] L3 getBatch error`, {
+        logger.error(`[${this.config.name}] L3 getBatch error`, {
           keyCount: remainingKeys.length,
           error,
         });
@@ -305,7 +308,10 @@ export class MultiTierCache<T = string> {
       logger.debug(`[${this.config.name}] ${tierName.toUpperCase()} hit`, { key });
       return value;
     } catch (error) {
-      logger.debug(`[${this.config.name}] ${tierName.toUpperCase()} get error`, { key, error });
+      logger.error(`[${this.config.name}] ${tierName.toUpperCase()} get error`, {
+        key: key.slice(-60),
+        error: error instanceof Error ? error.message : String(error),
+      });
       return null;
     }
   }
@@ -333,7 +339,7 @@ export class MultiTierCache<T = string> {
 
       return keys.filter((k) => !results.has(k) || results.get(k) === null);
     } catch (error) {
-      logger.debug(`[${this.config.name}] ${tierName.toUpperCase()} getBatch error`, {
+      logger.error(`[${this.config.name}] ${tierName.toUpperCase()} getBatch error`, {
         keyCount: keys.length,
         error,
       });
@@ -360,7 +366,7 @@ export class MultiTierCache<T = string> {
     if (tiers.includes("l1") && this.config.l1) {
       backfillOps.push(
         this.config.l1.set(key, value, ttl).catch((error) => {
-          logger.debug(`[${this.config.name}] L1 backfill error`, { key, error });
+          logger.error(`[${this.config.name}] L1 backfill error`, { key, error });
         }),
       );
     }
@@ -368,7 +374,7 @@ export class MultiTierCache<T = string> {
     if (tiers.includes("l2") && this.config.l2) {
       backfillOps.push(
         this.config.l2.set(key, value, ttl).catch((error) => {
-          logger.debug(`[${this.config.name}] L2 backfill error`, { key, error });
+          logger.error(`[${this.config.name}] L2 backfill error`, { key, error });
         }),
       );
     }

--- a/src/html/styles-builder/css-hash-cache.ts
+++ b/src/html/styles-builder/css-hash-cache.ts
@@ -380,7 +380,10 @@ export async function persistRegeneratedCSSEntry(
   try {
     const cache = await getCssCache();
     await cache.set(hash, JSON.stringify(entry), CSS_CACHE_TTL_SECONDS);
-  } catch {
-    // Ignore cache write failure - we still return regenerated CSS.
+  } catch (error) {
+    logger.error("CSS cache write failed", {
+      hash: hash.slice(-20),
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 }

--- a/src/html/styles-builder/plugin-loader.ts
+++ b/src/html/styles-builder/plugin-loader.ts
@@ -117,7 +117,12 @@ export async function loadModuleFromEsmSh(packageName: string): Promise<unknown>
   try {
     return await import(`file://${tempPath}`);
   } finally {
-    await Deno.remove(tempPath).catch(() => {});
+    await Deno.remove(tempPath).catch((error) => {
+      logger.error("Failed to clean up temp plugin file", {
+        path: tempPath,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
   }
 }
 

--- a/src/platform/adapters/fs/veryfront/directory-operations.ts
+++ b/src/platform/adapters/fs/veryfront/directory-operations.ts
@@ -8,6 +8,7 @@ import {
   buildFileListCacheKey,
 } from "./cache-keys.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { withRetryOnTransient } from "./retry.ts";
 
 const logger = baseLogger.component("directory-operations");
 
@@ -207,13 +208,17 @@ export class DirectoryOperations extends VeryfrontOperationsBase {
         cacheKey,
       });
 
-      const files = isPublished
-        ? await this.client.listPublishedFiles(
-          undefined,
-          ctx?.releaseId ?? undefined,
-          ctx?.environmentName ?? undefined,
-        )
-        : await this.client.listAllFiles();
+      const files = await withRetryOnTransient(
+        () =>
+          isPublished
+            ? this.client.listPublishedFiles(
+              undefined,
+              ctx?.releaseId ?? undefined,
+              ctx?.environmentName ?? undefined,
+            )
+            : this.client.listAllFiles(),
+        "getAllFilesRaw (dir)",
+      );
 
       this.cache.set(cacheKey, files);
       return files;

--- a/src/platform/adapters/fs/veryfront/retry.ts
+++ b/src/platform/adapters/fs/veryfront/retry.ts
@@ -1,0 +1,59 @@
+/**
+ * Simple retry helper for transient API failures in the FS adapter.
+ *
+ * Retries once after a short delay for network errors and 5xx responses.
+ * Does NOT retry 4xx errors (client errors like 404 are not transient).
+ *
+ * @module platform/adapters/fs/veryfront/retry
+ */
+
+import { logger as baseLogger } from "#veryfront/utils";
+
+const logger = baseLogger.component("fs-retry");
+
+/** Delay between retries in milliseconds */
+const RETRY_DELAY_MS = 500;
+
+/** Check if an error is likely transient (network issue or server error) */
+function isTransientError(error: unknown): boolean {
+  if (error instanceof TypeError && error.message.includes("fetch")) return true;
+
+  const status = (error as { status?: number })?.status;
+  if (typeof status === "number" && status >= 500) return true;
+
+  const message = error instanceof Error ? error.message : String(error);
+  if (
+    message.includes("ECONNRESET") ||
+    message.includes("ECONNREFUSED") ||
+    message.includes("ETIMEDOUT") ||
+    message.includes("socket hang up") ||
+    message.includes("network")
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Execute an async function with a single retry for transient errors.
+ * Non-transient errors (4xx, validation) are thrown immediately.
+ */
+export async function withRetryOnTransient<T>(
+  fn: () => Promise<T>,
+  context: string,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    if (!isTransientError(error)) throw error;
+
+    logger.warn(`${context} — transient error, retrying once`, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+
+    return fn();
+  }
+}

--- a/src/platform/adapters/fs/veryfront/stat-operations.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.ts
@@ -9,6 +9,7 @@ import {
   buildFileListCacheKey,
   buildStatCacheKeyPrefix,
 } from "./cache-keys.ts";
+import { withRetryOnTransient } from "./retry.ts";
 import { STAT_OPERATION_EXTENSION_PRIORITY as EXTENSION_PRIORITY } from "./extension-priority.ts";
 import {
   collectParentDirectories,
@@ -306,13 +307,17 @@ export class StatOperations extends VeryfrontOperationsBase {
       cacheKey,
     });
 
-    const files = isPublished
-      ? await this.client.listPublishedFiles(
-        undefined,
-        ctx?.releaseId ?? undefined,
-        ctx?.environmentName ?? undefined,
-      )
-      : await this.client.listAllFiles();
+    const files = await withRetryOnTransient(
+      () =>
+        isPublished
+          ? this.client.listPublishedFiles(
+            undefined,
+            ctx?.releaseId ?? undefined,
+            ctx?.environmentName ?? undefined,
+          )
+          : this.client.listAllFiles(),
+      "getAllFilesRaw (stat)",
+    );
 
     this.cache.set(cacheKey, files);
     return files;

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -352,11 +352,13 @@ export class WebSocketManager {
     });
 
     void (async () => {
+      let succeeded = false;
       try {
         const results = await Promise.all(
           Array.from(deletionPrefixes).map((prefix) => this.deps.cache.deleteByPrefixAsync(prefix)),
         );
         const totalDeleted = results.reduce((sum, count) => sum + count, 0);
+        succeeded = true;
 
         logger.info("PUBLISH POKE - persistent cache cleared", {
           projectSlug: this.deps.projectSlug,
@@ -365,17 +367,30 @@ export class WebSocketManager {
           totalDeleted,
         });
       } catch (error) {
-        logger.warn("PUBLISH POKE - failed to clear persistent cache", {
+        logger.error("PUBLISH POKE - failed to clear persistent cache (stale data may be served)", {
           projectSlug: this.deps.projectSlug,
           releaseId,
           environmentName,
           error: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
         });
       } finally {
-        for (const prefix of pendingPrefixes) removePendingInvalidation(prefix);
+        if (succeeded) {
+          for (const prefix of pendingPrefixes) removePendingInvalidation(prefix);
+        } else {
+          // Keep pending invalidations active so reads bypass stale cache
+          logger.error(
+            "PUBLISH POKE - keeping pending invalidations active due to deletion failure",
+            {
+              projectSlug: this.deps.projectSlug,
+              pendingPrefixes: Array.from(pendingPrefixes),
+            },
+          );
+        }
 
-        logger.debug("PUBLISH POKE - cache invalidation complete", {
+        logger.info("PUBLISH POKE - cache invalidation complete", {
           projectSlug: this.deps.projectSlug,
+          succeeded,
           pendingInvalidations: getPendingInvalidationsCount(),
         });
       }
@@ -677,8 +692,10 @@ export class WebSocketManager {
 
       try {
         this.ws?.close();
-      } catch {
-        // Ignore close errors
+      } catch (error) {
+        logger.error("WebSocket close failed during heartbeat timeout", {
+          error: error instanceof Error ? error.message : String(error),
+        });
       }
 
       this.cleanupTimers();

--- a/src/proxy/cache/redis-cache.ts
+++ b/src/proxy/cache/redis-cache.ts
@@ -1,7 +1,9 @@
 import { createClient, type RedisClientType } from "redis";
 import type { CacheStats, RedisCacheOptions, TokenCache, TokenCacheEntry } from "./types.ts";
 import { withSpan } from "../tracing.ts";
+import { proxyLogger } from "../logger.ts";
 
+const logger = proxyLogger.child({ module: "redis-cache" });
 const DEFAULT_PREFIX = "vf:token:";
 const DEFAULT_CONNECT_TIMEOUT = 5000;
 const DEFAULT_SCAN_COUNT = 100;
@@ -50,7 +52,9 @@ export class RedisCache implements TokenCache {
           this.hits++;
           return entry;
         } catch (error) {
-          console.error("[RedisCache] Get error:", error);
+          logger.error("[RedisCache] Get error", {
+            error: error instanceof Error ? error.message : String(error),
+          });
           this.connected = false;
           this.misses++;
           throw error;
@@ -71,7 +75,9 @@ export class RedisCache implements TokenCache {
           const ttlSeconds = Math.max(1, Math.floor(ttlMs / 1000));
           await client.setEx(this.key(key), ttlSeconds, JSON.stringify(entry));
         } catch (error) {
-          console.error("[RedisCache] Set error:", error);
+          logger.error("[RedisCache] Set error", {
+            error: error instanceof Error ? error.message : String(error),
+          });
           this.connected = false;
           throw error;
         }
@@ -88,7 +94,9 @@ export class RedisCache implements TokenCache {
           await this.ensureConnected();
           await this.client!.del(this.key(key));
         } catch (error) {
-          console.error("[RedisCache] Delete error:", error);
+          logger.error("[RedisCache] Delete error", {
+            error: error instanceof Error ? error.message : String(error),
+          });
           this.connected = false;
           throw error;
         }
@@ -121,13 +129,15 @@ export class RedisCache implements TokenCache {
         } while (cursor !== 0);
 
         if (totalDeleted > 0) {
-          console.log(`[RedisCache] Cleared ${totalDeleted} keys`);
+          logger.info(`[RedisCache] Cleared ${totalDeleted} keys`);
         }
 
         this.hits = 0;
         this.misses = 0;
       } catch (error) {
-        console.error("[RedisCache] Clear error:", error);
+        logger.error("[RedisCache] Clear error", {
+          error: error instanceof Error ? error.message : String(error),
+        });
         this.connected = false;
         throw error;
       }
@@ -142,7 +152,9 @@ export class RedisCache implements TokenCache {
           await this.ensureConnected();
           return (await this.client!.exists(this.key(key))) === 1;
         } catch (error) {
-          console.error("[RedisCache] Has error:", error);
+          logger.error("[RedisCache] Has error", {
+            error: error instanceof Error ? error.message : String(error),
+          });
           this.connected = false;
           throw error;
         }
@@ -160,7 +172,9 @@ export class RedisCache implements TokenCache {
         size = await this.client!.dbSize();
       } catch (error) {
         this.connected = false;
-        console.warn("[RedisCache] Stats error:", error);
+        logger.error("[RedisCache] Stats error", {
+          error: error instanceof Error ? error.message : String(error),
+        });
       }
 
       return { hits: this.hits, misses: this.misses, size, type: "redis" as const };
@@ -203,14 +217,16 @@ export class RedisCache implements TokenCache {
       });
 
       client.on("error", (err) => {
-        console.error("[RedisCache] Client error:", err);
+        logger.error("[RedisCache] Client error", {
+          error: err instanceof Error ? err.message : String(err),
+        });
         this.connected = false;
       });
 
       this.client = client as RedisClientType;
       await client.connect();
       this.connected = true;
-      console.log("[RedisCache] Connected");
+      logger.info("[RedisCache] Connected");
     });
   }
 }

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -506,7 +506,11 @@ export class RenderPipeline {
 
         if (shouldCache && !options?.skipCachePersist) {
           this.config.cacheCoordinator.persistResult(result, slug, cacheKey).catch((error) => {
-            renderPipelineLog.warn("Cache persist failed", { slug, error: String(error) });
+            renderPipelineLog.error("Cache persist failed", {
+              slug,
+              error: error instanceof Error ? error.message : String(error),
+              stack: error instanceof Error ? error.stack : undefined,
+            });
           });
         }
 
@@ -582,8 +586,12 @@ export class RenderPipeline {
             headings?: Array<{ id: string; text: string; level: number }>;
           }).headings || [];
         }
-      } catch {
-        // Frontmatter/headings extraction failed, use empty defaults
+      } catch (error) {
+        renderPipelineLog.error("Frontmatter/headings extraction failed", {
+          slug,
+          error: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+        });
       }
     }
 

--- a/src/rendering/page-resolution/page-resolver.ts
+++ b/src/rendering/page-resolution/page-resolver.ts
@@ -183,7 +183,7 @@ export class PageResolver {
         );
       }
     } catch (error) {
-      logger.debug("Failed to read App Router directory", {
+      logger.warn("Failed to read App Router directory", {
         dir: currentDir,
         error: error instanceof Error ? error.message : String(error),
       });

--- a/src/security/http/base-handler.ts
+++ b/src/security/http/base-handler.ts
@@ -81,6 +81,10 @@ export abstract class BaseHandler implements Handler {
     serverLogger.debug(`[${this.metadata.name}] ${message}`, extra ?? undefined);
   }
 
+  protected logWarn(message: string, extra?: Record<string, unknown>, _ctx?: HandlerContext): void {
+    serverLogger.warn(`[${this.metadata.name}] ${message}`, extra ?? undefined);
+  }
+
   protected logInfo(message: string, extra?: Record<string, unknown>, _ctx?: HandlerContext): void {
     serverLogger.info(`[${this.metadata.name}] ${message}`, extra ?? undefined);
   }

--- a/src/server/build-routes.ts
+++ b/src/server/build-routes.ts
@@ -100,7 +100,13 @@ async function walkAppSSG(
       const st = await adapter.fs.stat(filePath);
       if (!st.isFile) continue;
 
-      const src = (await adapter.fs.readFile(filePath).catch(() => "")) ?? "";
+      const src = (await adapter.fs.readFile(filePath).catch((error) => {
+        logger.warn("Failed to read route file for SSG analysis", {
+          filePath,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return "";
+      })) ?? "";
       if (isForceDynamic(src)) break;
 
       const path = `/${segs.join("/")}`;

--- a/src/server/handlers/monitoring/metrics.handler.ts
+++ b/src/server/handlers/monitoring/metrics.handler.ts
@@ -36,7 +36,7 @@ export class MetricsHandler extends BaseHandler {
 
       return Promise.resolve(this.respond(response));
     } catch (e) {
-      this.logDebug("metrics failed", { error: this.getErrorMessage(e) }, ctx);
+      this.logWarn("metrics failed", { error: this.getErrorMessage(e) }, ctx);
 
       const response = ResponseBuilder.error(
         HTTP_INTERNAL_SERVER_ERROR,
@@ -49,10 +49,13 @@ export class MetricsHandler extends BaseHandler {
     }
   }
 
-  private safeCall<T>(fn: () => T): T | undefined {
+  private safeCall<T>(fn: () => T, name?: string): T | undefined {
     try {
       return fn();
-    } catch {
+    } catch (error) {
+      this.logWarn(`metrics ${name ?? "call"} failed`, {
+        error: error instanceof Error ? error.message : String(error),
+      });
       return undefined;
     }
   }

--- a/src/server/handlers/request/ssr/ssr.handler.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.ts
@@ -142,11 +142,16 @@ export class SSRHandler extends BaseHandler {
 
       return this.handleWithContext(req, ctx, slug, requestId, url);
     } catch (error) {
-      this.logDebug(
-        "Unexpected error in context setup",
-        { error: this.getErrorMessage(error) },
-        ctx,
-      );
+      logger.error("Context setup failed — request will fall through to 404", {
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+        projectSlug: ctx.projectSlug,
+        projectId: ctx.projectId,
+        releaseId: ctx.releaseId,
+        hasToken: !!ctx.proxyToken,
+        isLocalProject: ctx.isLocalProject,
+        slug,
+      });
       return Promise.resolve(this.continue());
     }
   }

--- a/src/server/handlers/response/cors.ts
+++ b/src/server/handlers/response/cors.ts
@@ -38,7 +38,7 @@ export class CorsHandler extends BaseHandler {
       const cfg = await getConfig(ctx.projectDir, ctx.adapter);
       corsConfig = cfg?.security?.cors ?? corsConfig;
     } catch (error) {
-      this.logDebug("Failed to load CORS config", { error }, ctx);
+      this.logWarn("Failed to load CORS config — using defaults", { error }, ctx);
     }
 
     const response = ResponseBuilder.preflight(req, {
@@ -66,7 +66,7 @@ export class CorsHandler extends BaseHandler {
 
       return [...new Set(methods)].join(", ");
     } catch (error) {
-      this.logDebug("Failed to resolve route for CORS", { error, pathname }, ctx);
+      this.logWarn("Failed to resolve route for CORS", { error, pathname }, ctx);
       return CorsHandler.DEFAULT_METHODS;
     }
   }
@@ -81,7 +81,7 @@ export class CorsHandler extends BaseHandler {
       const st = await ctx.adapter.fs.stat(appRoot);
       if (!st.isDirectory) return null;
     } catch (error) {
-      this.logDebug("App directory not found", { appRoot, error }, ctx);
+      this.logWarn("App directory not found", { appRoot, error }, ctx);
       return null;
     }
 

--- a/src/server/production-server.ts
+++ b/src/server/production-server.ts
@@ -148,7 +148,9 @@ export function startProductionServer(
             });
           }
         } catch (error) {
-          serverLog.debug("AI discovery skipped:", error);
+          serverLog.error("AI discovery failed", {
+            error: error instanceof Error ? error.message : String(error),
+          });
         }
       }
 

--- a/src/server/runtime-handler/adapter-factory.ts
+++ b/src/server/runtime-handler/adapter-factory.ts
@@ -124,7 +124,9 @@ export async function resolveAdapter(
       });
     }
   } else if (opts.isProxyMode && opts.projectSlug && opts.proxyToken) {
-    // Load config via proxy mode with project context
+    // Load config via proxy mode with project context.
+    // Unlike local projects, proxy mode config loading failures are propagated
+    // because proceeding without config causes silent 404s for valid projects.
     try {
       effectiveConfig = await timeAsync("config:load-proxy-project", () => {
         if (isExtendedFSAdapter(effectiveAdapter.fs) && effectiveAdapter.fs.runWithContext) {
@@ -158,10 +160,19 @@ export async function resolveAdapter(
         router: effectiveConfig?.router,
       });
     } catch (error) {
-      logger.warn("Failed to load proxy config, using defaults", {
+      // Log at error level — this is a real failure that will affect rendering.
+      // Config loading failure in proxy mode means the project's routes, layouts,
+      // and settings won't be available, leading to 404s for valid pages.
+      logger.error("Failed to load project config in proxy mode", {
         projectSlug: opts.projectSlug,
+        projectId: opts.projectId,
+        releaseId: opts.releaseId,
+        proxyEnv: opts.proxyEnv,
         error: getErrorMessage(error),
       });
+      // Re-throw so the caller (runtime-handler) can return a proper error response
+      // instead of silently proceeding with broken defaults.
+      throw error;
     }
   }
 

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -306,6 +306,42 @@ export function createVeryfrontHandler(
       startIsolatedRequest(headers.projectSlug, lifecycle.shouldCheckIsolation);
 
       try {
+        // Early validation: in proxy mode, required context headers must be present.
+        // Without these, the server cannot authenticate or resolve the project, and
+        // proceeding would cause cryptic 500s deep in the rendering pipeline.
+        if (isProxyMode && !isLightweightPath(url.pathname)) {
+          const token = req.headers.get("x-token");
+          if (!headers.projectSlug) {
+            logger.error("Missing required x-project-slug header in proxy mode", {
+              pathname: url.pathname,
+              domain,
+              host: req.headers.get("host"),
+              forwardedHost: req.headers.get("x-forwarded-host"),
+            });
+            return new Response(
+              JSON.stringify({
+                error: "Missing project context",
+                detail: "x-project-slug header is required in proxy mode",
+              }),
+              { status: 502, headers: { "Content-Type": "application/json" } },
+            );
+          }
+          if (!token) {
+            logger.error("Missing required x-token header in proxy mode", {
+              pathname: url.pathname,
+              domain,
+              projectSlug: headers.projectSlug,
+            });
+            return new Response(
+              JSON.stringify({
+                error: "Missing authentication context",
+                detail: "x-token header is required in proxy mode",
+              }),
+              { status: 502, headers: { "Content-Type": "application/json" } },
+            );
+          }
+        }
+
         await readyPromise;
 
         await timeAsync("security:load", async () => {

--- a/src/server/runtime-handler/local-project-discovery.ts
+++ b/src/server/runtime-handler/local-project-discovery.ts
@@ -97,8 +97,12 @@ export async function findLocalProjectPath(
       localProjectCache.set(slug, absolutePath);
       logger.debug("Discovered local project", { slug, path: absolutePath });
       return absolutePath;
-    } catch {
-      // Directory doesn't exist, continue
+    } catch (error) {
+      logger.warn("Failed to validate local project directory", {
+        slug,
+        path: projectPath,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 

--- a/src/server/runtime-handler/projects-handler.ts
+++ b/src/server/runtime-handler/projects-handler.ts
@@ -9,9 +9,12 @@
 
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { cwd } from "#veryfront/platform/compat/process.ts";
+import { serverLogger } from "#veryfront/utils";
 import type { HandlerContext } from "../handlers/types.ts";
 import { localProjectCache, standardProjectDirs } from "./local-project-discovery.ts";
 import type { ParsedDomain } from "../utils/domain-parser.ts";
+
+const logger = serverLogger.component("projects-handler");
 
 /**
  * Check if the request should be handled by the projects discovery UI.
@@ -101,12 +104,18 @@ async function handleLocalProjectsDiscovery(): Promise<Response> {
           if (hasApp || hasPages || hasComponents) {
             localProjectCache.set(entry.name, projectPath);
           }
-        } catch {
-          // Skip entries that can't be stat'd
+        } catch (error) {
+          logger.warn("Failed to stat project directory entry", {
+            path: projectPath,
+            error: error instanceof Error ? error.message : String(error),
+          });
         }
       }
-    } catch {
-      // Directory doesn't exist, skip
+    } catch (error) {
+      logger.warn("Failed to scan project directory", {
+        dir,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 

--- a/src/server/runtime-handler/timeout-manager.ts
+++ b/src/server/runtime-handler/timeout-manager.ts
@@ -62,6 +62,12 @@ export async function withRequestTimeout(
     }
 
     const error = e instanceof Error ? e : new Error(String(e));
+    logger.error("Unhandled error in request handler", {
+      path: pathname,
+      method,
+      error: error.message,
+      stack: error.stack,
+    });
     return {
       response: new Response(ErrorPages.serverError(), {
         status: 500,

--- a/src/transforms/esm/transform-cache.ts
+++ b/src/transforms/esm/transform-cache.ts
@@ -181,7 +181,10 @@ export async function getCachedTransformAsync(
         return entry;
       }
     } catch (error) {
-      logger.debug("Backend get failed", { key, error });
+      logger.error("Transform cache backend get failed", {
+        key: key.slice(-60),
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 
@@ -217,7 +220,10 @@ export async function setCachedTransformAsync(
       await gateway.set(key, JSON.stringify(entryToStore), normalizeTtl(ttlSeconds));
       return;
     } catch (error) {
-      logger.debug("Backend set failed", { key, error });
+      logger.error("Transform cache backend set failed", {
+        key: key.slice(-60),
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 
@@ -444,14 +450,20 @@ export async function prewarmProjectTransforms(
         prewarmed++;
       }
     } catch (error) {
-      logger.debug("Prewarm failed for path", { projectId, filePath, error });
+      logger.error("Prewarm failed for path", {
+        projectId,
+        filePath,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 
-  logger.debug("Prewarm complete", {
+  const logFn = prewarmed < filePaths.length ? logger.warn : logger.info;
+  logFn.call(logger, "Prewarm complete", {
     projectId,
     prewarmed,
     total: filePaths.length,
+    incomplete: prewarmed < filePaths.length,
   });
 
   return prewarmed;

--- a/src/transforms/pipeline/index.ts
+++ b/src/transforms/pipeline/index.ts
@@ -96,7 +96,11 @@ async function validateFrameworkBundles(
       if (!(await exists(path))) {
         missing.push(path);
       }
-    } catch {
+    } catch (error) {
+      rendererLogger.error("Framework bundle validation error", {
+        path,
+        error: error instanceof Error ? error.message : String(error),
+      });
       missing.push(path);
     }
   }

--- a/tests/_helpers/log-guard.ts
+++ b/tests/_helpers/log-guard.ts
@@ -140,6 +140,13 @@ const allowedWarnings: string[] = [
   "Render failed unexpectedly",
   "Test error",
 
+  // Runtime handler catch-all (fires when inner errors propagate to timeout-manager)
+  "Unhandled error in request handler",
+
+  // Local project discovery (expected when standard directories don't exist in test env)
+  "Failed to validate local project directory",
+  "Failed to validate x-project-path override",
+
   // Bundle manifest errors (expected when manifest is missing)
   "[bundle-manifest]",
 

--- a/tests/integration/vfs-proxy-mode-e2e.test.ts
+++ b/tests/integration/vfs-proxy-mode-e2e.test.ts
@@ -272,6 +272,7 @@ describe("VFS Proxy Mode - Compiled Binary", { sanitizeOps: false, sanitizeResou
             "x-release-id": releaseId,
             "x-environment": "production",
             "x-project-slug": "flow-ops",
+            "x-token": "test-token",
           },
         });
         await response.text();


### PR DESCRIPTION
## Summary

- **Early proxy context validation**: Returns 502 immediately when `x-project-slug` or `x-token` headers are missing in proxy mode, instead of letting requests fail deep in the rendering pipeline
- **SSRHandler error logging**: Elevated context setup errors from invisible `debug` level to `error` level with full diagnostic context (slug, releaseId, token presence)
- **Config loading error propagation**: Proxy mode config loading errors are now re-thrown instead of silently swallowed, making failures visible
- **Timeout manager error logging**: Unhandled errors are now logged at `error` level before returning 500
- **Retry logic for transient API failures**: New `withRetryOnTransient()` utility retries once on network/5xx errors in `getAllFilesRaw()` (both stat and directory operations)

## Context

Intermittent 404s on production were caused by three error-masking layers that silently turned real errors into 404s:
1. `resolveAdapter()` swallowed config loading errors
2. `SSRHandler.setupContextAndRender()` caught errors at DEBUG level and fell through to NotFoundHandler
3. Cold pods hitting transient API failures with no retry

## Test plan

- [x] `deno task verify` passes (fmt, lint, typecheck, 1134 tests)
- [x] VFS proxy mode E2E test updated with required `x-token` header
- [ ] Monitor production logs after deploy for elevated error visibility