### PR TITLE
chore: downgrade missing config log from warn to debug

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -471,7 +471,7 @@ export function getConfig(
         }
       }
 
-      logger.warn("No config file found, using defaults", {
+      logger.debug("No config file found, using defaults", {
         effectiveCacheKey,
         projectDir,
         isVirtualFS,


### PR DESCRIPTION
## Summary

- "No config file found, using defaults" was logged at `warn` level
- Most projects don't have a `veryfront.config.ts` — this is the normal path, not an issue
- Downgraded to `debug` to reduce production log noise

## Test plan

- [x] One-line change, log level only