### PR TITLE
fix: exit cleanly after one-shot CLI commands

### DIFF
--- a/cli/commands/dev/handler.ts
+++ b/cli/commands/dev/handler.ts
@@ -60,9 +60,11 @@ export async function handleDevCommand(args: ParsedArgs): Promise<void> {
   // Clear stale ESM caches to prevent module resolution issues from previous runs
   await clearAllLocalCaches();
 
-  await devCommand({
+  const { done } = await devCommand({
     port: opts.port,
     projectDir,
     hmr: opts.hmr,
   });
+
+  await done;
 }

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -46,3 +46,8 @@ const args = getArgs();
 const { parseCliArgs } = await import("./shared/args.ts");
 const { routeCommand } = await import("./router.ts");
 await routeCommand(parseCliArgs(args));
+
+// Exit cleanly after one-shot commands. Long-running commands (dev, start, mcp)
+// never return from routeCommand, so this only runs for commands like deploy, push, init, build.
+const { exitProcess } = await import("./utils/index.ts");
+exitProcess(0);

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",


### PR DESCRIPTION
## Summary

- Adds `exitProcess(0)` after `routeCommand` completes
- Long-running commands (dev, start, mcp) never return from `routeCommand`, so this only runs for one-shot commands like deploy, push, init, build
- Prevents process from hanging on open handles after command completes

## Test plan

- [x] One-shot commands (e.g. `veryfront build`) exit cleanly
- [x] Long-running commands unaffected (they never reach the exit call)