### PR TITLE
fix: use POSIX-compatible spinner in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -165,12 +165,12 @@ main() {
   printf "${ORANGE}Installing Veryfront v%s...${NC}" "$VERSION"
   download "$DOWNLOAD_URL" "$BINARY_PATH" &
   PID=$!
-  SPINNER="⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+  SPINNER='|/-\'
   i=0
   while kill -0 $PID 2>/dev/null; do
-    i=$(( (i + 1) % 10 ))
-    printf "\r${ORANGE}Installing Veryfront v%s...${NC} %s" "$VERSION" "$(echo "$SPINNER" | cut -c$((i+1)))"
-    sleep 0.1
+    i=$(( (i + 1) % 4 ))
+    printf "\r${ORANGE}Installing Veryfront v%s...${NC} %s" "$VERSION" "$(echo "$SPINNER" | cut -c$((i + 1)))"
+    sleep 1
   done
 
   wait $PID


### PR DESCRIPTION
## Summary
- Replace Unicode braille spinner (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) with ASCII `|/-\` for reliable `cut -c` behavior in plain `sh`
- Replace `sleep 0.1` (non-POSIX) with `sleep 1` for POSIX compliance

## Context
The install script uses `#!/bin/sh` for maximum portability, but had two non-POSIX features: multi-byte Unicode characters parsed with `cut -c`, and fractional sleep. This aligns the implementation with the POSIX shebang.

## Test plan
- [ ] Run `curl -fsSL https://veryfront.com/install.sh | sh` on macOS
- [ ] Run on Alpine/minimal Linux container to verify POSIX compat