### PR TITLE
chore: bump version to 0.1.13

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",


### PR DESCRIPTION
## Summary
- Bump version from 0.1.12 to 0.1.13 to unblock CI release pipeline
- v0.1.12 was already published to npm, causing `npm publish` to fail on every push to main

## Test plan
- [ ] CI release job publishes successfully after merge