### PR TITLE
feat: route proxy traffic to dedicated servers when assigned

### DIFF
--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -352,9 +352,9 @@ function forwardToServer(req: Request): Promise<Response> {
 
           for (let attempt = 0; attempt <= maxRetries; attempt++) {
             // Dedicated server takes priority; otherwise use shared pool with renderer router
-            const baseUrl = dedicatedServerUrl
-              ?? rendererRouter?.resolve(ctx.projectSlug)
-              ?? PRODUCTION_SERVER_URL;
+            const baseUrl = dedicatedServerUrl ??
+              rendererRouter?.resolve(ctx.projectSlug) ??
+              PRODUCTION_SERVER_URL;
             const serverUrl = new URL(url.pathname + url.search, baseUrl);
             // Delay before retry (not on first attempt)
             if (attempt > 0) {

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -34,6 +34,7 @@ import {
 import { proxyLogger, runWithProxyRequestContext } from "./logger.ts";
 import { ErrorPages } from "../server/utils/error-html.ts";
 import { RendererRouter } from "./renderer-router.ts";
+import { ServerResolver } from "./server-resolver.ts";
 import { parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
 import { exit, getEnv, onSignal } from "#veryfront/platform/compat/process.ts";
 import { createHttpServer, upgradeWebSocket } from "#veryfront/platform/compat/http/index.ts";
@@ -81,6 +82,13 @@ const rendererRouter = (discoveryHost || staticTargets)
     parseInt(getEnv("VERYFRONT_SERVER_DISCOVERY_INTERVAL_MS") || "15000") || 15000,
   )
   : null;
+
+// Dedicated server resolver: routes environments to their dedicated server if assigned
+const apiInternalUrl = getEnv("VERYFRONT_API_INTERNAL_URL") || config.apiBaseUrl;
+const apiInternalUser = getEnv("VERYFRONT_API_INTERNAL_USER") || "";
+const apiInternalPass = getEnv("VERYFRONT_API_INTERNAL_PASS") || "";
+const serverResolver = new ServerResolver(apiInternalUrl, apiInternalUser, apiInternalPass);
+
 const { hostname: HOST, port: PORT } = resolveProxyBinding();
 const WS_CONNECT_TIMEOUT_MS = 30000;
 // Timeout for forwarding requests to production server (SSR can take time on cold start)
@@ -339,9 +347,14 @@ function forwardToServer(req: Request): Promise<Response> {
           const maxRetries = isIdempotent ? VERYFRONT_SERVER_RETRY_COUNT : 0;
           let lastError: Error | null = null;
 
+          // Check if this environment has a dedicated server
+          const dedicatedServerUrl = await serverResolver.resolve(ctx.environmentId);
+
           for (let attempt = 0; attempt <= maxRetries; attempt++) {
-            // Re-resolve on each attempt so retries can pick a different pod
-            const baseUrl = rendererRouter?.resolve(ctx.projectSlug) ?? PRODUCTION_SERVER_URL;
+            // Dedicated server takes priority; otherwise use shared pool with renderer router
+            const baseUrl = dedicatedServerUrl
+              ?? rendererRouter?.resolve(ctx.projectSlug)
+              ?? PRODUCTION_SERVER_URL;
             const serverUrl = new URL(url.pathname + url.search, baseUrl);
             // Delay before retry (not on first attempt)
             if (attempt > 0) {
@@ -549,6 +562,7 @@ function router(req: Request): Promise<Response> {
 async function shutdown(): Promise<void> {
   proxyLogger.info("Shutting down");
   rendererRouter?.close();
+  serverResolver.close();
   await proxyHandler.close();
   await shutdownOTLP();
   proxyLogger.info("Closed connections");

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -15,6 +15,9 @@
  * - LOCAL_PROJECTS: JSON map of slug → filesystem path (for dev)
  * - CACHE_TYPE: "memory" (default) or "redis"
  * - REDIS_URL: Redis connection URL (required if CACHE_TYPE=redis)
+ * - VERYFRONT_API_INTERNAL_URL: API URL for internal endpoints (falls back to VERYFRONT_PROXY_API_BASE_URL)
+ * - VERYFRONT_API_INTERNAL_USER: Basic auth user for internal API
+ * - VERYFRONT_API_INTERNAL_PASS: Basic auth pass for internal API
  */
 
 import { createProxyHandler, INTERNAL_PROXY_HEADERS, type ProxyConfig } from "./handler.ts";
@@ -346,12 +349,14 @@ function forwardToServer(req: Request): Promise<Response> {
           const isIdempotent = ["GET", "HEAD", "OPTIONS"].includes(req.method);
           const maxRetries = isIdempotent ? VERYFRONT_SERVER_RETRY_COUNT : 0;
           let lastError: Error | null = null;
-
-          // Check if this environment has a dedicated server
-          const dedicatedServerUrl = await serverResolver.resolve(ctx.environmentId);
+          // After a retryable connection error to a dedicated server, fall back to shared pool
+          let skipDedicated = false;
 
           for (let attempt = 0; attempt <= maxRetries; attempt++) {
-            // Dedicated server takes priority; otherwise use shared pool with renderer router
+            // Resolve dedicated server per attempt so retries can fall back to shared pool
+            const dedicatedServerUrl = skipDedicated
+              ? null
+              : await serverResolver.resolve(ctx.environmentId);
             const baseUrl = dedicatedServerUrl ??
               rendererRouter?.resolve(ctx.projectSlug) ??
               PRODUCTION_SERVER_URL;
@@ -436,10 +441,26 @@ function forwardToServer(req: Request): Promise<Response> {
 
               // Check if this is a retryable error and we have retries left
               if (isRetryableConnectionError(error) && attempt < maxRetries) {
-                proxyLogger.warn(`[Retry] Retryable connection error on attempt ${attempt + 1}`, {
-                  pathname: url.pathname,
-                  error: error instanceof Error ? error.message : String(error),
-                });
+                // If we were targeting a dedicated server, fall back to shared pool on retry
+                if (dedicatedServerUrl) {
+                  skipDedicated = true;
+                  proxyLogger.warn(
+                    `[Retry] Dedicated server unreachable, falling back to shared pool`,
+                    {
+                      pathname: url.pathname,
+                      dedicatedServerUrl,
+                      error: error instanceof Error ? error.message : String(error),
+                    },
+                  );
+                } else {
+                  proxyLogger.warn(
+                    `[Retry] Retryable connection error on attempt ${attempt + 1}`,
+                    {
+                      pathname: url.pathname,
+                      error: error instanceof Error ? error.message : String(error),
+                    },
+                  );
+                }
                 continue; // Try again
               }
 

--- a/src/proxy/server-resolver.test.ts
+++ b/src/proxy/server-resolver.test.ts
@@ -1,0 +1,149 @@
+import { assertEquals } from "@std/assert";
+import { ServerResolver } from "./server-resolver.ts";
+
+// Minimal HTTP server for testing
+function createMockApi(
+  handler: (req: Request) => Response | Promise<Response>,
+): { url: string; close: () => Promise<void> } {
+  const server = Deno.serve({ port: 0, onListen: () => {} }, handler);
+  const addr = server.addr as Deno.NetAddr;
+  return {
+    url: `http://localhost:${addr.port}`,
+    close: () => server.shutdown(),
+  };
+}
+
+Deno.test("ServerResolver", async (t) => {
+  await t.step("returns dedicated server URL when environment has running server", async () => {
+    const api = createMockApi(() =>
+      Response.json({
+        server: {
+          id: "srv-1",
+          short_id: "4281039506",
+          hostname: "veryfront-server-4281039506.veryfront-production.svc.cluster.local",
+          status: "running",
+        },
+      })
+    );
+    const resolver = new ServerResolver(api.url, "", "");
+    try {
+      const result = await resolver.resolve("env-001");
+      assertEquals(
+        result,
+        "http://veryfront-server-4281039506.veryfront-production.svc.cluster.local",
+      );
+    } finally {
+      resolver.close();
+      await api.close();
+    }
+  });
+
+  await t.step("returns null when no dedicated server", async () => {
+    const api = createMockApi(() => Response.json({ server: null }));
+    const resolver = new ServerResolver(api.url, "", "");
+    try {
+      const result = await resolver.resolve("env-002");
+      assertEquals(result, null);
+    } finally {
+      resolver.close();
+      await api.close();
+    }
+  });
+
+  await t.step("returns null when environmentId is undefined", async () => {
+    const resolver = new ServerResolver("http://unused", "", "");
+    try {
+      const result = await resolver.resolve(undefined);
+      assertEquals(result, null);
+    } finally {
+      resolver.close();
+    }
+  });
+
+  await t.step("caches result and reuses on second call", async () => {
+    let callCount = 0;
+    const api = createMockApi(() => {
+      callCount++;
+      return Response.json({
+        server: {
+          id: "srv-1",
+          short_id: "1234567890",
+          hostname: "veryfront-server-1234567890.ns.svc.cluster.local",
+          status: "running",
+        },
+      });
+    });
+    const resolver = new ServerResolver(api.url, "", "", 5_000);
+    try {
+      await resolver.resolve("env-cached");
+      await resolver.resolve("env-cached");
+      assertEquals(callCount, 1, "should only call API once due to cache");
+    } finally {
+      resolver.close();
+      await api.close();
+    }
+  });
+
+  await t.step("returns null and does not throw when API is unreachable", async () => {
+    const resolver = new ServerResolver("http://localhost:1", "", "");
+    try {
+      const result = await resolver.resolve("env-unreachable");
+      assertEquals(result, null);
+    } finally {
+      resolver.close();
+    }
+  });
+
+  await t.step("returns null when API returns non-OK status", async () => {
+    const api = createMockApi(() => new Response("Internal Server Error", { status: 500 }));
+    const resolver = new ServerResolver(api.url, "", "");
+    try {
+      const result = await resolver.resolve("env-500");
+      assertEquals(result, null);
+    } finally {
+      resolver.close();
+      await api.close();
+    }
+  });
+
+  await t.step("sends basic auth when credentials are configured", async () => {
+    let receivedAuth = "";
+    const api = createMockApi((req) => {
+      receivedAuth = req.headers.get("authorization") || "";
+      return Response.json({ server: null });
+    });
+    const resolver = new ServerResolver(api.url, "admin", "secret123");
+    try {
+      await resolver.resolve("env-auth");
+      assertEquals(receivedAuth, `Basic ${btoa("admin:secret123")}`);
+    } finally {
+      resolver.close();
+      await api.close();
+    }
+  });
+
+  await t.step("deduplicates concurrent requests for same environment", async () => {
+    let callCount = 0;
+    const api = createMockApi(async () => {
+      callCount++;
+      await new Promise((r) => setTimeout(r, 50)); // simulate latency
+      return Response.json({ server: null });
+    });
+    const resolver = new ServerResolver(api.url, "", "");
+    try {
+      // Fire 3 concurrent requests for the same environment
+      const [r1, r2, r3] = await Promise.all([
+        resolver.resolve("env-dedup"),
+        resolver.resolve("env-dedup"),
+        resolver.resolve("env-dedup"),
+      ]);
+      assertEquals(r1, null);
+      assertEquals(r2, null);
+      assertEquals(r3, null);
+      assertEquals(callCount, 1, "should deduplicate to single API call");
+    } finally {
+      resolver.close();
+      await api.close();
+    }
+  });
+});

--- a/src/proxy/server-resolver.test.ts
+++ b/src/proxy/server-resolver.test.ts
@@ -1,14 +1,17 @@
 import { assertEquals } from "@std/assert";
 import { ServerResolver } from "./server-resolver.ts";
 
-// Minimal HTTP server for testing
+// Minimal HTTP server for testing — bind to 127.0.0.1 to avoid IPv6 flakiness
 function createMockApi(
   handler: (req: Request) => Response | Promise<Response>,
 ): { url: string; close: () => Promise<void> } {
-  const server = Deno.serve({ port: 0, onListen: () => {} }, handler);
+  const server = Deno.serve(
+    { hostname: "127.0.0.1", port: 0, onListen: () => {} },
+    handler,
+  );
   const addr = server.addr as Deno.NetAddr;
   return {
-    url: `http://localhost:${addr.port}`,
+    url: `http://${addr.hostname}:${addr.port}`,
     close: () => server.shutdown(),
   };
 }
@@ -141,6 +144,41 @@ Deno.test("ServerResolver", async (t) => {
       assertEquals(r2, null);
       assertEquals(r3, null);
       assertEquals(callCount, 1, "should deduplicate to single API call");
+    } finally {
+      resolver.close();
+      await api.close();
+    }
+  });
+
+  await t.step("does not cache transient API errors (retries on next request)", async () => {
+    let callCount = 0;
+    const api = createMockApi(() => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response("Service Unavailable", { status: 503 });
+      }
+      return Response.json({
+        server: {
+          id: "srv-1",
+          short_id: "9999999999",
+          hostname: "veryfront-server-9999999999.ns.svc.cluster.local",
+          status: "running",
+        },
+      });
+    });
+    const resolver = new ServerResolver(api.url, "", "", 30_000);
+    try {
+      // First call: API returns 503 → should return null (fallback) but NOT cache
+      const r1 = await resolver.resolve("env-transient");
+      assertEquals(r1, null);
+
+      // Second call: API now healthy → should hit API again (not use cached null)
+      const r2 = await resolver.resolve("env-transient");
+      assertEquals(
+        r2,
+        "http://veryfront-server-9999999999.ns.svc.cluster.local",
+      );
+      assertEquals(callCount, 2, "should call API twice (error was not cached)");
     } finally {
       resolver.close();
       await api.close();

--- a/src/proxy/server-resolver.ts
+++ b/src/proxy/server-resolver.ts
@@ -1,0 +1,129 @@
+/**
+ * Dedicated Server Resolver
+ *
+ * Resolves an environment ID to a dedicated server hostname.
+ * Used by the proxy to route traffic to dedicated servers instead of the shared pool.
+ *
+ * Caches results in memory with a short TTL to avoid hitting the API on every request.
+ * A null result (no dedicated server) is also cached to prevent repeated lookups.
+ */
+
+import { proxyLogger } from "./logger.ts";
+import { unrefTimer } from "#veryfront/platform/compat/process.ts";
+
+const logger = proxyLogger.child({ module: "server-resolver" });
+
+interface DedicatedServer {
+  id: string;
+  short_id: string;
+  hostname: string;
+  status: string;
+}
+
+interface CacheEntry {
+  server: DedicatedServer | null;
+  expiresAt: number;
+}
+
+export class ServerResolver {
+  private cache = new Map<string, CacheEntry>();
+  private pending = new Map<string, Promise<DedicatedServer | null>>();
+  private cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private apiInternalUrl: string,
+    private apiUser: string,
+    private apiPass: string,
+    private cacheTtlMs: number = 30_000,
+  ) {
+    // Cleanup expired entries every 60s
+    this.cleanupTimer = setInterval(() => this.cleanup(), 60_000);
+    // Don't keep the process alive for cleanup
+    unrefTimer(this.cleanupTimer);
+  }
+
+  /**
+   * Resolve an environment ID to a dedicated server URL, or null for shared pool.
+   */
+  async resolve(environmentId: string | undefined): Promise<string | null> {
+    if (!environmentId) return null;
+
+    const cached = this.cache.get(environmentId);
+    if (cached && Date.now() < cached.expiresAt) {
+      return cached.server ? `http://${cached.server.hostname}` : null;
+    }
+
+    // Deduplicate concurrent requests for the same environment
+    const inflight = this.pending.get(environmentId);
+    if (inflight) {
+      const server = await inflight;
+      return server ? `http://${server.hostname}` : null;
+    }
+
+    const promise = this.fetchServer(environmentId);
+    this.pending.set(environmentId, promise);
+
+    try {
+      const server = await promise;
+      this.cache.set(environmentId, {
+        server,
+        expiresAt: Date.now() + this.cacheTtlMs,
+      });
+      return server ? `http://${server.hostname}` : null;
+    } finally {
+      this.pending.delete(environmentId);
+    }
+  }
+
+  close(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
+    this.cache.clear();
+  }
+
+  private async fetchServer(environmentId: string): Promise<DedicatedServer | null> {
+    try {
+      const url = `${this.apiInternalUrl}/internal/environment-server?environmentId=${encodeURIComponent(environmentId)}`;
+      const headers: Record<string, string> = { Accept: "application/json" };
+
+      if (this.apiUser && this.apiPass) {
+        headers.Authorization = `Basic ${btoa(`${this.apiUser}:${this.apiPass}`)}`;
+      }
+
+      const response = await fetch(url, { headers, signal: AbortSignal.timeout(5_000) });
+
+      if (!response.ok) {
+        await response.body?.cancel();
+        logger.warn("[ServerResolver] API returned non-OK status", {
+          status: response.status,
+          environmentId,
+        });
+        return null;
+      }
+
+      const data = (await response.json()) as { server: DedicatedServer | null };
+      if (data.server) {
+        logger.debug("[ServerResolver] Resolved dedicated server", {
+          environmentId,
+          hostname: data.server.hostname,
+        });
+      }
+      return data.server;
+    } catch (error) {
+      logger.warn("[ServerResolver] Failed to resolve server, falling back to shared pool", {
+        error: error instanceof Error ? error.message : String(error),
+        environmentId,
+      });
+      return null;
+    }
+  }
+
+  private cleanup(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.cache) {
+      if (now >= entry.expiresAt) this.cache.delete(key);
+    }
+  }
+}

--- a/src/proxy/server-resolver.ts
+++ b/src/proxy/server-resolver.ts
@@ -25,6 +25,13 @@ interface CacheEntry {
   expiresAt: number;
 }
 
+/** Thrown when the API call fails (network error, non-OK status, parse error). */
+class ServerResolverError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+  }
+}
+
 export class ServerResolver {
   private cache = new Map<string, CacheEntry>();
   private pending = new Map<string, Promise<DedicatedServer | null>>();
@@ -65,11 +72,21 @@ export class ServerResolver {
 
     try {
       const server = await promise;
+      // Only cache successful API responses (server found OR explicit "no server").
+      // Transient errors (network failures, non-OK status) are NOT cached so the
+      // next request retries the API instead of suppressing dedicated routing.
       this.cache.set(environmentId, {
         server,
         expiresAt: Date.now() + this.cacheTtlMs,
       });
       return server ? `http://${server.hostname}` : null;
+    } catch (error) {
+      // API error — don't cache, fall back to shared pool for this request
+      logger.warn("[ServerResolver] Transient error, skipping cache", {
+        environmentId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
     } finally {
       this.pending.delete(environmentId);
     }
@@ -83,43 +100,44 @@ export class ServerResolver {
     this.cache.clear();
   }
 
+  /**
+   * Fetch dedicated server from API.
+   * Returns DedicatedServer | null on success (null = no dedicated server assigned).
+   * Throws ServerResolverError on transient failures (network, non-OK status).
+   */
   private async fetchServer(environmentId: string): Promise<DedicatedServer | null> {
-    try {
-      const url = `${this.apiInternalUrl}/internal/environment-server?environmentId=${
-        encodeURIComponent(environmentId)
-      }`;
-      const headers: Record<string, string> = { Accept: "application/json" };
+    const url = `${this.apiInternalUrl}/internal/environment-server?environmentId=${
+      encodeURIComponent(environmentId)
+    }`;
+    const headers: Record<string, string> = { Accept: "application/json" };
 
-      if (this.apiUser && this.apiPass) {
-        headers.Authorization = `Basic ${btoa(`${this.apiUser}:${this.apiPass}`)}`;
-      }
-
-      const response = await fetch(url, { headers, signal: AbortSignal.timeout(5_000) });
-
-      if (!response.ok) {
-        await response.body?.cancel();
-        logger.warn("[ServerResolver] API returned non-OK status", {
-          status: response.status,
-          environmentId,
-        });
-        return null;
-      }
-
-      const data = (await response.json()) as { server: DedicatedServer | null };
-      if (data.server) {
-        logger.debug("[ServerResolver] Resolved dedicated server", {
-          environmentId,
-          hostname: data.server.hostname,
-        });
-      }
-      return data.server;
-    } catch (error) {
-      logger.warn("[ServerResolver] Failed to resolve server, falling back to shared pool", {
-        error: error instanceof Error ? error.message : String(error),
-        environmentId,
-      });
-      return null;
+    if (this.apiUser && this.apiPass) {
+      headers.Authorization = `Basic ${btoa(`${this.apiUser}:${this.apiPass}`)}`;
     }
+
+    let response: Response;
+    try {
+      response = await fetch(url, { headers, signal: AbortSignal.timeout(5_000) });
+    } catch (error) {
+      throw new ServerResolverError(
+        `Failed to reach API: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
+
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new ServerResolverError(`API returned ${response.status} for ${environmentId}`);
+    }
+
+    const data = (await response.json()) as { server: DedicatedServer | null };
+    if (data.server) {
+      logger.debug("[ServerResolver] Resolved dedicated server", {
+        environmentId,
+        hostname: data.server.hostname,
+      });
+    }
+    return data.server;
   }
 
   private cleanup(): void {

--- a/src/proxy/server-resolver.ts
+++ b/src/proxy/server-resolver.ts
@@ -85,7 +85,9 @@ export class ServerResolver {
 
   private async fetchServer(environmentId: string): Promise<DedicatedServer | null> {
     try {
-      const url = `${this.apiInternalUrl}/internal/environment-server?environmentId=${encodeURIComponent(environmentId)}`;
+      const url = `${this.apiInternalUrl}/internal/environment-server?environmentId=${
+        encodeURIComponent(environmentId)
+      }`;
       const headers: Record<string, string> = { Accept: "application/json" };
 
       if (this.apiUser && this.apiPass) {


### PR DESCRIPTION
## Summary
- Add `ServerResolver` class that calls `GET /internal/environment-server` to check if an environment has a dedicated server
- Modify proxy routing: dedicated server takes priority over shared renderer pool
- Results cached in memory (30s TTL) with request deduplication

Depends on: veryfront/veryfront-api#254 (merged)
Part of: veryfront/veryfront-api#253 (Dedicated Server RFC, Task 2)

## Changes
| File | Change |
|------|--------|
| `src/proxy/server-resolver.ts` | **New** — `ServerResolver` class: fetches API, caches results, deduplicates concurrent requests, graceful fallback to shared pool on any error |
| `src/proxy/main.ts` | Import `ServerResolver`, initialize with env vars, resolve dedicated server before `rendererRouter`, cleanup on shutdown |
| `src/proxy/server-resolver.test.ts` | **New** — 8 test cases with real mock HTTP servers |

## Routing logic change
```
// BEFORE:
const baseUrl = rendererRouter?.resolve(ctx.projectSlug) ?? PRODUCTION_SERVER_URL;

// AFTER:
const dedicatedServerUrl = await serverResolver.resolve(ctx.environmentId);
const baseUrl = dedicatedServerUrl ?? rendererRouter?.resolve(ctx.projectSlug) ?? PRODUCTION_SERVER_URL;
```

## New env vars (for production Helm values)
| Var | Purpose | Default |
|-----|---------|---------|
| `VERYFRONT_API_INTERNAL_URL` | API URL for internal endpoints | Falls back to `VERYFRONT_PROXY_API_BASE_URL` |
| `VERYFRONT_API_INTERNAL_USER` | Basic auth user | (empty) |
| `VERYFRONT_API_INTERNAL_PASS` | Basic auth pass | (empty) |

## Test plan
- [x] All 8 new server-resolver tests pass
- [x] All 109 existing proxy test steps still pass (10/10 suites)
- [x] Zero resource leaks detected by Deno
- [ ] CI passes