### PR TITLE
fix: skip npm publish when version already exists

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -261,10 +261,14 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          deno task build:npm
-          cd npm
-          jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
-          npm publish --access public --tag rc
+          if npm view veryfront@"${VERSION}" version 2>/dev/null; then
+            echo "::notice::v${VERSION} already published to npm — skipping publish"
+          else
+            deno task build:npm
+            cd npm
+            jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
+            npm publish --access public --tag rc
+          fi
 
       - uses: actions/download-artifact@v4
         with:
@@ -339,11 +343,16 @@ jobs:
       - run: npm install -g npm@latest
 
       - name: Build and publish
-        run: |
-          deno task build:npm
-          cd npm && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if npm view veryfront@"${VERSION}" version 2>/dev/null; then
+            echo "::notice::v${VERSION} already published to npm — skipping publish"
+          else
+            deno task build:npm
+            cd npm && npm publish --access public
+          fi
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- Check npm registry before publishing to avoid `You cannot publish over the previously published versions` errors
- Applies to both stable release and RC prerelease jobs
- Emits a GitHub Actions notice when skipping

## Test plan
- [ ] CI passes on this PR
- [ ] Merge to main — release job should skip publish for 0.1.13 (already on npm) and succeed