### PR TITLE
fix: create PR for Homebrew tap update instead of direct push

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -481,16 +481,34 @@ jobs:
             BRANCH="update-veryfront-v${VERSION}"
             git checkout -b "${BRANCH}"
             git commit -m "Update veryfront to v${VERSION}"
-            git push -u origin "${BRANCH}"
+            git push -u origin "${BRANCH}" || git push -u origin "${BRANCH}" --force-with-lease
 
-            GH_TOKEN="${GITHUB_PAT}" gh pr create \
+            PR_NUMBER=$(GH_TOKEN="${GITHUB_PAT}" gh pr list \
               --repo veryfront/homebrew-tap \
               --base main \
               --head "${BRANCH}" \
-              --title "Update veryfront to v${VERSION}" \
-              --body "Automated update from CI — veryfront v${VERSION}" \
-              --fill
+              --state open \
+              --json number \
+              --jq '.[0].number')
 
-            GH_TOKEN="${GITHUB_PAT}" gh pr merge "${BRANCH}" \
+            if [ -z "${PR_NUMBER}" ] || [ "${PR_NUMBER}" = "null" ]; then
+              GH_TOKEN="${GITHUB_PAT}" gh pr create \
+                --repo veryfront/homebrew-tap \
+                --base main \
+                --head "${BRANCH}" \
+                --title "Update veryfront to v${VERSION}" \
+                --body "Automated update from CI — veryfront v${VERSION}" \
+                --fill
+
+              PR_NUMBER=$(GH_TOKEN="${GITHUB_PAT}" gh pr list \
+                --repo veryfront/homebrew-tap \
+                --base main \
+                --head "${BRANCH}" \
+                --state open \
+                --json number \
+                --jq '.[0].number')
+            fi
+
+            GH_TOKEN="${GITHUB_PAT}" gh pr merge "${PR_NUMBER}" \
               --repo veryfront/homebrew-tap \
               --merge --auto

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -467,7 +467,7 @@ jobs:
             FORMULA="${FORMULA//SHA256_LINUX_ARM64_PLACEHOLDER/${SHAS[veryfront-linux-arm64]}}"
             FORMULA="${FORMULA//SHA256_LINUX_X64_PLACEHOLDER/${SHAS[veryfront-linux-x64]}}"
 
-            # Push to tap repo (fresh clone each retry to avoid conflicts)
+            # Create PR against tap repo (branch protection requires PRs)
             rm -rf tap
             git clone "https://x-access-token:${GITHUB_PAT}@github.com/veryfront/homebrew-tap.git" tap
             mkdir -p tap/Formula
@@ -477,5 +477,20 @@ jobs:
             git config user.email "actions@github.com"
             git add Formula/veryfront.rb
             git diff --cached --quiet && echo "No changes to commit" && exit 0
+
+            BRANCH="update-veryfront-v${VERSION}"
+            git checkout -b "${BRANCH}"
             git commit -m "Update veryfront to v${VERSION}"
-            git push
+            git push -u origin "${BRANCH}"
+
+            GH_TOKEN="${GITHUB_PAT}" gh pr create \
+              --repo veryfront/homebrew-tap \
+              --base main \
+              --head "${BRANCH}" \
+              --title "Update veryfront to v${VERSION}" \
+              --body "Automated update from CI — veryfront v${VERSION}" \
+              --fill
+
+            GH_TOKEN="${GITHUB_PAT}" gh pr merge "${BRANCH}" \
+              --repo veryfront/homebrew-tap \
+              --merge --auto


### PR DESCRIPTION
## Summary
- The `homebrew-tap` repo has branch protection requiring changes through pull requests
- CI was trying to `git push` directly to `main`, which is rejected with `GH013: Repository rule violations`
- Changed to create a branch, open a PR via `gh pr create`, and auto-merge it with `gh pr merge --auto`

## Test plan
- [ ] CI passes on this PR
- [ ] On next stable release, Homebrew tap PR is created and auto-merged