### PR TITLE
fix: show banner and relevant shortcuts in TUI empty state

### DIFF
--- a/cli/app/shell.ts
+++ b/cli/app/shell.ts
@@ -156,7 +156,7 @@ export function createApp(config: AppConfig): App {
       case "dashboard":
         content = state.projects.items.length > 0 || state.examples.items.length > 0
           ? renderDashboard(state)
-          : renderEmptyState();
+          : renderEmptyState(state);
         break;
       case "new-project":
         content = renderNewProjectView(state);

--- a/cli/app/views/dashboard.ts
+++ b/cli/app/views/dashboard.ts
@@ -160,7 +160,10 @@ function renderHelpBar(state: AppState): string {
   if (!state.showHelp) {
     const userInfo = state.remote.user ? `  ${dim("-")}  ${brand(state.remote.user.email)}` : "";
     if (!hasItems) {
-      return `  ${dim("n")} ${dim("new project")}  ${dim("a")} ${dim("login")}  ${dim("? more")}  ${
+      const authHint = state.remote.user
+        ? `${dim("x")} ${dim("logout")}`
+        : `${dim("a")} ${dim("login")}`;
+      return `  ${dim("n")} ${dim("new project")}  ${authHint}  ${dim("? more")}  ${
         dim("q quit")
       }${userInfo}`;
     }

--- a/cli/app/views/dashboard.ts
+++ b/cli/app/views/dashboard.ts
@@ -154,18 +154,32 @@ function renderSection(title: string, isActive = true): string {
  * Render the help bar at the bottom
  */
 function renderHelpBar(state: AppState): string {
+  const hasItems = state.projects.items.length > 0 || state.examples.items.length > 0 ||
+    (!!state.remote.user && state.remote.projects.length > 0);
+
   if (!state.showHelp) {
     const userInfo = state.remote.user ? `  ${dim("-")}  ${brand(state.remote.user.email)}` : "";
+    if (!hasItems) {
+      return `  ${dim("n")} ${dim("new project")}  ${dim("a")} ${dim("login")}  ${dim("? more")}  ${
+        dim("q quit")
+      }${userInfo}`;
+    }
     return `  ${dim("↑↓ select  enter open  ? more  q quit")}${userInfo}`;
   }
 
   const lines: string[] = [];
-  lines.push(`  ${dim("o")} open  ${dim("s")} studio  ${dim("i")} ide`);
+
+  if (hasItems) {
+    lines.push(`  ${dim("o")} open  ${dim("s")} studio  ${dim("i")} ide`);
+  }
 
   if (!state.remote.user) {
     lines.push(`  ${dim("n")} new  ${dim("a")} login`);
   } else {
-    lines.push(`  ${dim("n")} new  ${dim("p")} pull  ${dim("u")} push  ${dim("x")} logout`);
+    const parts = [`  ${dim("n")} new`];
+    if (hasItems) parts.push(`${dim("p")} pull  ${dim("u")} push`);
+    parts.push(`${dim("x")} logout`);
+    lines.push(parts.join("  "));
   }
 
   lines.push(`  ${dim("? hide  q quit")}`);
@@ -193,6 +207,12 @@ export function renderDashboardBoxed(state: AppState): string {
 /**
  * Render empty state when no projects found
  */
-export function renderEmptyState(): string {
-  return `\n  ${dim("No projects.")} ${brand("n")} ${dim("to create")}\n`;
+export function renderEmptyState(state: AppState): string {
+  const lines: string[] = [];
+
+  lines.push(renderBanner(state), "");
+  lines.push(`  ${dim("No projects.")} ${brand("n")} ${dim("to create")}`, "");
+  lines.push(renderHelpBar(state));
+
+  return lines.join("\n");
 }


### PR DESCRIPTION
## Summary
- Show the full header banner (logo, "Veryfront is now running", URL, MCP) in the TUI even when no projects exist
- Make help bar shortcuts context-aware: hide navigation/project actions (↑↓ select, enter open, o/s/i, p pull, u push) when no items exist, show relevant ones (n new project, a login)

## Test plan
- [ ] Run `veryfront` in an empty directory (no projects/) — verify banner with logo and URL appears
- [ ] Run `veryfront` with projects — verify dashboard looks unchanged
- [ ] Press `?` in empty state — verify only relevant shortcuts shown (no open/studio/ide/pull/push)
- [ ] Press `?` with projects — verify all shortcuts shown as before