### PR TITLE
feat(proxy): add negative caching for invalid domain lookups

### DIFF
--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -103,7 +103,7 @@ describe("Proxy Handler", () => {
       }
     });
 
-    it("returns 502 error when no token available for custom domain", async () => {
+    it("returns 404 error when no token available for custom domain", async () => {
       const handler = createProxyHandler({
         config: {
           apiBaseUrl: "http://localhost:9999",
@@ -121,10 +121,10 @@ describe("Proxy Handler", () => {
       const ctx = await handler.processRequest(req);
 
       assertEquals(ctx.projectSlug, undefined);
-      assertEquals(ctx.error?.status, 502);
+      assertEquals(ctx.error?.status, 404);
       assertEquals(
         ctx.error?.message,
-        "Failed to authenticate for domain: custom-domain.com",
+        "No project configured for domain: custom-domain.com",
       );
 
       await handler.close();

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -1,4 +1,4 @@
-import { TokenManager, type TokenScope } from "./token-manager.ts";
+import { TokenManager, type TokenScope, ProjectNotFoundError } from "./token-manager.ts";
 import { type ParsedDomain, parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
 import type { TokenCache } from "./cache/types.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
@@ -333,7 +333,12 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
           try {
             token = await tokenManager.getToken(scope, projectSlug, customDomain);
           } catch (error) {
-            logger?.error("Token fetch failed", error as Error, { projectSlug, customDomain });
+            // Log ProjectNotFoundError at debug level since it's expected for invalid domains
+            if (error instanceof ProjectNotFoundError) {
+              logger?.debug("Token fetch failed: project not found", { customDomain: error.domain });
+            } else {
+              logger?.error("Token fetch failed", error as Error, { projectSlug, customDomain });
+            }
           }
         }
       }
@@ -347,8 +352,9 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
       if (isCustomDomain && !projectSlug) {
         if (!token) {
-          logger?.error("Cannot process custom domain without token", undefined, { domain: host });
-          return makeErrorContext(base, 502, `Failed to authenticate for domain: ${host}`, token);
+          // Log at debug level for expected "not found" scenarios to reduce noise
+          logger?.debug("Cannot process custom domain without token", { domain: host });
+          return makeErrorContext(base, 404, `No project configured for domain: ${host}`, token);
         }
 
         const lookupResult = await lookupProjectByDomain(host, config.apiBaseUrl, token, logger);

--- a/src/proxy/token-manager.ts
+++ b/src/proxy/token-manager.ts
@@ -16,12 +16,26 @@ export interface OAuthConfig {
 export interface TokenManagerOptions {
   cache?: TokenCache;
   refreshBuffer?: number; // ms before expiry to trigger refresh
+  negativeCacheTtl?: number; // ms to cache failed lookups (default: 5 minutes)
+}
+
+export class ProjectNotFoundError extends Error {
+  constructor(public readonly domain: string) {
+    super(`Project not found for domain: ${domain}`);
+    this.name = "ProjectNotFoundError";
+  }
+}
+
+interface NegativeCacheEntry {
+  expiresAt: number;
 }
 
 export class TokenManager {
   private cache: TokenCache;
   private pendingRequests = new Map<string, Promise<string>>();
+  private negativeCache = new Map<string, NegativeCacheEntry>();
   private refreshBuffer: number;
+  private negativeCacheTtl: number;
 
   constructor(
     private config: OAuthConfig,
@@ -29,6 +43,7 @@ export class TokenManager {
   ) {
     this.cache = options.cache ?? new MemoryCache();
     this.refreshBuffer = options.refreshBuffer ?? 2 * 60 * 1000; // 2 minutes before expiry
+    this.negativeCacheTtl = options.negativeCacheTtl ?? 5 * 60 * 1000; // 5 minutes for failed lookups
   }
 
   async getToken(
@@ -42,6 +57,19 @@ export class TokenManager {
     return withSpan(
       ProxySpanNames.PROXY_TOKEN_FETCH,
       async () => {
+        // Check negative cache first for custom domains
+        if (customDomain) {
+          const negativeCacheKey = this.getNegativeCacheKey(customDomain);
+          const negativeEntry = this.negativeCache.get(negativeCacheKey);
+          if (negativeEntry && Date.now() < negativeEntry.expiresAt) {
+            throw new ProjectNotFoundError(customDomain);
+          }
+          // Clean up expired negative cache entry
+          if (negativeEntry) {
+            this.negativeCache.delete(negativeCacheKey);
+          }
+        }
+
         const cached = await this.cache.get(cacheKey);
         if (cached && this.isTokenValid(cached)) return cached.token;
 
@@ -72,6 +100,11 @@ export class TokenManager {
 
   async clearCache(): Promise<void> {
     await this.cache.clear();
+    this.negativeCache.clear();
+  }
+
+  clearNegativeCache(): void {
+    this.negativeCache.clear();
   }
 
   async getStats(): Promise<{ hits: number; misses: number; size: number; type: string }> {
@@ -84,6 +117,17 @@ export class TokenManager {
 
   private getCacheKey(scope: TokenScope, projectSlug?: string): string {
     return `${scope}:${projectSlug || "global"}`;
+  }
+
+  private getNegativeCacheKey(domain: string): string {
+    return `negative:${domain.toLowerCase()}`;
+  }
+
+  private addToNegativeCache(domain: string): void {
+    const key = this.getNegativeCacheKey(domain);
+    this.negativeCache.set(key, {
+      expiresAt: Date.now() + this.negativeCacheTtl,
+    });
   }
 
   private isTokenValid(cached: TokenCacheEntry): boolean {
@@ -101,24 +145,37 @@ export class TokenManager {
       ? this.config.previewApiClientSecret
       : this.config.apiClientSecret;
 
-    const response = await fetchOAuthToken({
-      apiBaseUrl: this.config.apiBaseUrl,
-      apiClientId,
-      apiClientSecret,
-      projectSlug,
-      customDomain,
-    });
+    try {
+      const response = await fetchOAuthToken({
+        apiBaseUrl: this.config.apiBaseUrl,
+        apiClientId,
+        apiClientSecret,
+        projectSlug,
+        customDomain,
+      });
 
-    const projectKey = projectSlug || customDomain;
+      const projectKey = projectSlug || customDomain;
 
-    await this.cache.set(this.getCacheKey(scope, projectKey), {
-      token: response.access_token,
-      expiresAt: this.calculateExpiresAt(response),
-      scope,
-      projectSlug: projectKey,
-    });
+      await this.cache.set(this.getCacheKey(scope, projectKey), {
+        token: response.access_token,
+        expiresAt: this.calculateExpiresAt(response),
+        scope,
+        projectSlug: projectKey,
+      });
 
-    return response.access_token;
+      return response.access_token;
+    } catch (error) {
+      // Cache "Project not found" errors for custom domains to avoid repeated API calls
+      if (
+        customDomain &&
+        error instanceof Error &&
+        error.message.includes("Project not found")
+      ) {
+        this.addToNegativeCache(customDomain);
+        throw new ProjectNotFoundError(customDomain);
+      }
+      throw error;
+    }
   }
 
   private calculateExpiresAt(response: TokenResponse): number {

--- a/src/proxy/token-priority.test.ts
+++ b/src/proxy/token-priority.test.ts
@@ -165,7 +165,7 @@ describe("Token Priority Cascade", () => {
   });
 
   describe("no token available", () => {
-    it("returns 502 for custom domain when no token source exists", async () => {
+    it("returns 404 for custom domain when no token source exists", async () => {
       const handler = createProxyHandler({
         config: {
           apiBaseUrl: "http://localhost:9999",
@@ -183,10 +183,10 @@ describe("Token Priority Cascade", () => {
       const ctx = await handler.processRequest(req);
 
       assertEquals(ctx.token, undefined);
-      assertEquals(ctx.error?.status, 502);
+      assertEquals(ctx.error?.status, 404);
       assertEquals(
         ctx.error?.message,
-        "Failed to authenticate for domain: custom-domain.com",
+        "No project configured for domain: custom-domain.com",
       );
 
       await handler.close();


### PR DESCRIPTION
## Summary
- Adds negative caching for domain lookups that fail with "Project not found"
- Reduces error log noise and API load from repeated requests to non-existent domains
- Changes response from 502 to 404 for domains without configured projects

## Problem
The proxy service was logging thousands of errors per hour for requests to invalid/non-existent domains:
- `Token fetch failed: OAuth token request failed: 400 - {"error":"Project not found for domain"}`
- `Cannot process custom domain without token`

These requests were likely from:
1. Security scanners hitting random domains
2. Orphaned DNS records pointing to deleted projects
3. Malformed subdomain requests

Each invalid request triggered an API call, generating error logs and unnecessary load.

## Solution
1. **Negative caching**: When a domain lookup fails with "Project not found", cache that failure for 5 minutes. Subsequent requests for the same domain return immediately without hitting the API.

2. **New error type**: Added `ProjectNotFoundError` class for type-safe error handling, allowing callers to distinguish "not found" errors from other failures.

3. **Improved logging**: `ProjectNotFoundError` is now logged at `debug` level instead of `error` level, reducing log noise.

4. **Correct HTTP status**: Changed response from 502 (Bad Gateway) to 404 (Not Found) for domains without projects, which is semantically more accurate.

## Test plan
- [ ] Verify negative cache prevents repeated API calls for same invalid domain
- [ ] Verify negative cache expires after 5 minutes
- [ ] Verify valid domains still work correctly
- [ ] Verify error logs are reduced for invalid domain requests
- [ ] Run existing proxy tests

## Related Issues
Fixes veryfront/veryfront-api#274