### PR TITLE
docs: remove outdated prompts directory from quickstart guide

### DIFF
--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -58,8 +58,6 @@ my-app/
     assistant.ts    # AI agent definition
   tools/
     calculator.ts   # Tool the agent can call
-  prompts/
-    assistant.ts    # System prompt
   app/
     layout.tsx
     page.tsx        # Chat UI


### PR DESCRIPTION
## Summary

- Remove `prompts/assistant.ts` from the quickstart guide directory tree — system prompts are now defined inline in agent definitions, not in a separate directory

## Test plan

- [x] Documentation-only change, no code affected