### PR TITLE
chore: bump version to 0.1.14

### DIFF
--- a/cli/auth/callback-server.ts
+++ b/cli/auth/callback-server.ts
@@ -185,8 +185,9 @@ function tryStartDenoServer(port: number): CallbackServer {
     resolveCallback = resolve;
   });
 
-  // @ts-ignore - Deno global
-  const server = Deno.serve(
+  // Access native Deno.serve via `self` to bypass dnt shim transform.
+  const nativeDeno = (self as unknown as Record<string, typeof Deno>)["Deno"]!;
+  const server = nativeDeno.serve(
     { port, hostname: "127.0.0.1", onListen: () => {} },
     (request: Request) => {
       const url = new URL(request.url);

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",

--- a/src/platform/adapters/runtime/deno/adapter.ts
+++ b/src/platform/adapters/runtime/deno/adapter.ts
@@ -392,7 +392,11 @@ export class DenoAdapter implements RuntimeAdapter {
       }
       : handler;
 
-    const server = Deno.serve({
+    // Access native Deno.serve via `self` to bypass dnt shim transform.
+    // dnt rewrites both `Deno.*` and `globalThis.*` to use @deno/shim-deno which lacks .serve.
+    // `self` is not shimmed by dnt and equals `globalThis` in Deno.
+    const nativeDeno = (self as unknown as Record<string, typeof Deno>)["Deno"]!;
+    const server = nativeDeno.serve({
       port,
       hostname,
       signal,

--- a/src/platform/compat/http/deno-server.ts
+++ b/src/platform/compat/http/deno-server.ts
@@ -12,7 +12,9 @@ export class DenoHttpServer implements HttpServer {
 
     onListen?.({ hostname, port });
 
-    await Deno.serve({ port, hostname, signal: serveSignal }, handler);
+    // Access native Deno.serve via `self` to bypass dnt shim transform.
+    const nativeDeno = (self as unknown as Record<string, typeof Deno>)["Deno"]!;
+    await nativeDeno.serve({ port, hostname, signal: serveSignal }, handler);
   }
 
   close(): Promise<void> {


### PR DESCRIPTION
## Summary

- Bumps version from 0.1.13 to 0.1.14

## Changes since 0.1.13

- fix: prebundle client scripts for compiled binary builds (#387)
- fix: align project creation with slug retry and humanized names (#383)
- fix: zero-config local AI runtime verification and browser fallback (#385)
- docs: update quickstart template list to match current CLI catalog (#382)