### PR TITLE
fix: handle dnt-generated imports and Response shim in SSR pipeline

### DIFF
--- a/src/platform/adapters/runtime/deno/adapter.ts
+++ b/src/platform/adapters/runtime/deno/adapter.ts
@@ -396,16 +396,34 @@ export class DenoAdapter implements RuntimeAdapter {
     // dnt rewrites both `Deno.*` and `globalThis.*` to use @deno/shim-deno which lacks .serve.
     // `self` is not shimmed by dnt and equals `globalThis` in Deno.
     const nativeDeno = (self as unknown as Record<string, typeof Deno>)["Deno"]!;
+
+    // Access native Response via `self` to bypass dnt shim transform.
+    // In npm packages, dnt replaces Response with undici's polyfill,
+    // but Deno.serve requires native Response instances.
+    const NativeResponse = (self as unknown as { Response: typeof Response })
+      .Response;
+
     const server = nativeDeno.serve({
       port,
       hostname,
       signal,
       handler: async (request) => {
         try {
-          return await wrappedHandler(request);
+          const response: Response = await wrappedHandler(request);
+          // If already native (compiled binary), return as-is
+          if (response instanceof NativeResponse) return response;
+          // Re-wrap polyfilled Response as native Response.
+          // dnt replaces Response with undici's polyfill which fails
+          // Deno.serve's native instanceof check.
+          const r = response as unknown as Response;
+          return new NativeResponse(r.body, {
+            status: r.status,
+            statusText: r.statusText,
+            headers: r.headers,
+          });
         } catch (error) {
           serverLogger.error("Request handler error:", error);
-          return new Response("Internal Server Error", { status: 500 });
+          return new NativeResponse("Internal Server Error", { status: 500 });
         }
       },
       onListen: (params) => {

--- a/src/platform/compat/http/deno-server.test.ts
+++ b/src/platform/compat/http/deno-server.test.ts
@@ -1,0 +1,84 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { DenoHttpServer } from "./deno-server.ts";
+
+/** Find a free port by temporarily binding to port 0. */
+function getFreePort(): number {
+  const tmp = Deno.listen({ port: 0 });
+  const port = (tmp.addr as Deno.NetAddr).port;
+  tmp.close();
+  return port;
+}
+
+describe("DenoHttpServer", () => {
+  describe("serve", () => {
+    it("returns native Response instances from handler", async () => {
+      const server = new DenoHttpServer();
+      const ac = new AbortController();
+      const port = getFreePort();
+
+      const responseBody = "hello";
+      const handler = () => new Response(responseBody, { status: 200 });
+
+      // Start serve (blocks until abort)
+      const servePromise = server.serve(handler, {
+        port,
+        signal: ac.signal,
+      });
+
+      // Wait for the server to be ready
+      await new Promise((r) => setTimeout(r, 100));
+
+      try {
+        const res = await fetch(`http://127.0.0.1:${port}`);
+        assertEquals(res.status, 200);
+        assertEquals(await res.text(), responseBody);
+      } finally {
+        ac.abort();
+      }
+
+      await servePromise;
+    });
+
+    it("re-wraps non-native Response-like objects as native Response", async () => {
+      const server = new DenoHttpServer();
+      const ac = new AbortController();
+      const port = getFreePort();
+
+      // Simulate what dnt does: create a Response-like object that is NOT
+      // an instanceof the native Response class.
+      const handler = () => {
+        const real = new Response("wrapped body", {
+          status: 201,
+          statusText: "Created",
+          headers: { "x-custom": "test" },
+        });
+        // Create a plain object that mimics Response but fails instanceof
+        return Object.create(null, {
+          body: { get: () => real.body },
+          status: { get: () => real.status },
+          statusText: { get: () => real.statusText },
+          headers: { get: () => real.headers },
+        }) as Response;
+      };
+
+      const servePromise = server.serve(handler, {
+        port,
+        signal: ac.signal,
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      try {
+        const res = await fetch(`http://127.0.0.1:${port}`);
+        assertEquals(res.status, 201);
+        assertEquals(res.headers.get("x-custom"), "test");
+        assertEquals(await res.text(), "wrapped body");
+      } finally {
+        ac.abort();
+      }
+
+      await servePromise;
+    });
+  });
+});

--- a/src/platform/compat/http/deno-server.ts
+++ b/src/platform/compat/http/deno-server.ts
@@ -14,7 +14,32 @@ export class DenoHttpServer implements HttpServer {
 
     // Access native Deno.serve via `self` to bypass dnt shim transform.
     const nativeDeno = (self as unknown as Record<string, typeof Deno>)["Deno"]!;
-    await nativeDeno.serve({ port, hostname, signal: serveSignal }, handler);
+
+    // Access native Response via `self` to bypass dnt shim transform.
+    // In npm packages, dnt replaces Response with undici's polyfill,
+    // but Deno.serve requires native Response instances.
+    const NativeResponse = (self as unknown as { Response: typeof Response })
+      .Response;
+
+    const wrappedHandler: Handler = async (req) => {
+      const response: Response = await handler(req);
+      // If already native (compiled binary or WebSocket upgrade), return as-is
+      if (response instanceof NativeResponse) return response;
+      // Re-wrap polyfilled Response as native Response.
+      // At runtime, `response` may be an undici Response (from dnt shim) that
+      // fails Deno's native instanceof check. Cast to access its properties.
+      const r = response as unknown as Response;
+      return new NativeResponse(r.body, {
+        status: r.status,
+        statusText: r.statusText,
+        headers: r.headers,
+      });
+    };
+
+    await nativeDeno.serve(
+      { port, hostname, signal: serveSignal },
+      wrappedHandler,
+    );
   }
 
   close(): Promise<void> {

--- a/src/transforms/pipeline/stages/ssr-vf-modules.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules.test.ts
@@ -16,7 +16,8 @@ import { ssrVfModulesPlugin } from "./ssr-vf-modules.ts";
 import { _testExports } from "./ssr-vf-modules/index.ts";
 import type { TransformContext } from "../types.ts";
 
-const { findVfModuleImports, FRAMEWORK_ROOT, EXTENSIONS } = _testExports;
+const { findVfModuleImports, findRelativeImports, FRAMEWORK_ROOT, EMBEDDED_SRC_DIR, EXTENSIONS } =
+  _testExports;
 
 describe("ssr-vf-modules", { sanitizeOps: false, sanitizeResources: false }, () => {
   describe("findVfModuleImports", () => {
@@ -73,6 +74,69 @@ describe("ssr-vf-modules", { sanitizeOps: false, sanitizeResources: false }, () 
       const code = `const path = "/_vf_modules/something";`;
       const imports = findVfModuleImports(code);
       assertEquals(imports, []);
+    });
+  });
+
+  describe("findRelativeImports", () => {
+    it("finds from-style relative imports", () => {
+      const code = `
+        import { foo } from "./foo.js";
+        import { bar } from "../bar.js";
+      `;
+      const imports = findRelativeImports(code);
+      assertEquals(imports.length, 2);
+      assertEquals(imports.includes("./foo.js"), true);
+      assertEquals(imports.includes("../bar.js"), true);
+    });
+
+    it("finds side-effect relative imports (no from keyword)", () => {
+      const code = `import "./polyfills.js";`;
+      const imports = findRelativeImports(code);
+      assertEquals(imports, ["./polyfills.js"]);
+    });
+
+    it("finds deeply nested side-effect imports like dnt polyfills", () => {
+      const code = `import "../../../_dnt.polyfills.js";`;
+      const imports = findRelativeImports(code);
+      assertEquals(imports, ["../../../_dnt.polyfills.js"]);
+    });
+
+    it("finds both from and side-effect imports in the same code", () => {
+      const code = `
+        import "../../../_dnt.polyfills.js";
+        import { shims } from "./_dnt.shims.js";
+        import "./setup.js";
+      `;
+      const imports = findRelativeImports(code);
+      assertEquals(imports.length, 3);
+      assertEquals(imports.includes("../../../_dnt.polyfills.js"), true);
+      assertEquals(imports.includes("./_dnt.shims.js"), true);
+      assertEquals(imports.includes("./setup.js"), true);
+    });
+
+    it("deduplicates across from and side-effect patterns", () => {
+      const code = `
+        import "./shared.js";
+        import { x } from "./shared.js";
+      `;
+      const imports = findRelativeImports(code);
+      assertEquals(imports.length, 1);
+      assertEquals(imports[0], "./shared.js");
+    });
+
+    it("ignores non-relative side-effect imports", () => {
+      const code = `
+        import "some-bare-module";
+        import "@scope/package";
+      `;
+      const imports = findRelativeImports(code);
+      assertEquals(imports, []);
+    });
+
+    it("handles single quotes in side-effect imports", () => {
+      const code = `import '../polyfills.js';`;
+      const imports = findRelativeImports(code);
+      assertEquals(imports, ["../polyfills.js"]);
     });
   });
 
@@ -341,5 +405,94 @@ describe("ssr-vf-modules relative import resolution", {
       true,
       "Cached module should have file:// imports for dependencies",
     );
+  });
+});
+
+describe("ssr-vf-modules non-framework source skipping", {
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, () => {
+  it("FRAMEWORK_ROOT/src/ is a valid framework source prefix", () => {
+    // The transform skips recursive processing for files outside framework source dirs.
+    // Verify the prefix paths are correctly formed.
+    const frameworkSrcDir = `${FRAMEWORK_ROOT}/src/`;
+    assertStringIncludes(frameworkSrcDir, "/src/");
+    // A file inside src/ should match the prefix
+    const insidePath = `${FRAMEWORK_ROOT}/src/react/components/Head.tsx`;
+    assertEquals(insidePath.startsWith(frameworkSrcDir), true);
+  });
+
+  it("EMBEDDED_SRC_DIR is a valid framework source prefix", () => {
+    const embeddedPrefix = `${EMBEDDED_SRC_DIR}/`;
+    assertStringIncludes(embeddedPrefix, "dist/framework-src/");
+    // A file inside embedded src should match
+    const insidePath = `${EMBEDDED_SRC_DIR}/react/components/Head.src`;
+    assertEquals(insidePath.startsWith(embeddedPrefix), true);
+  });
+
+  it("files at package root are outside framework source dirs", () => {
+    // dnt shim files live at FRAMEWORK_ROOT root, not in src/ or dist/framework-src/
+    const frameworkSrcDir = `${FRAMEWORK_ROOT}/src/`;
+    const embeddedPrefix = `${EMBEDDED_SRC_DIR}/`;
+
+    const dntShims = `${FRAMEWORK_ROOT}/_dnt.shims.js`;
+    const dntPolyfills = `${FRAMEWORK_ROOT}/_dnt.polyfills.js`;
+
+    assertEquals(
+      dntShims.startsWith(frameworkSrcDir),
+      false,
+      "_dnt.shims.js should NOT be inside framework src/",
+    );
+    assertEquals(
+      dntShims.startsWith(embeddedPrefix),
+      false,
+      "_dnt.shims.js should NOT be inside embedded src/",
+    );
+    assertEquals(
+      dntPolyfills.startsWith(frameworkSrcDir),
+      false,
+      "_dnt.polyfills.js should NOT be inside framework src/",
+    );
+    assertEquals(
+      dntPolyfills.startsWith(embeddedPrefix),
+      false,
+      "_dnt.polyfills.js should NOT be inside embedded src/",
+    );
+  });
+
+  it("resolveRelativeFrameworkImport resolves dnt shim paths at package root", async () => {
+    // When a framework source file imports ../_dnt.shims.js, the path resolves
+    // to FRAMEWORK_ROOT/_dnt.shims.js which is outside src/ and should be
+    // skipped by the transform (not recursively processed).
+    const { resolveRelativeFrameworkImport } = _testExports;
+    const fs = createFileSystem();
+
+    // Simulate a file in src/something/ importing ../../_dnt.shims.js
+    // which would resolve to FRAMEWORK_ROOT/_dnt.shims.js
+    const sourcePath = `${FRAMEWORK_ROOT}/src/some/module.ts`;
+
+    // Check if _dnt.shims.js exists at root (only in npm/dnt builds)
+    const shimPath = `${FRAMEWORK_ROOT}/_dnt.shims.js`;
+    const shimExists = await fs.exists(shimPath);
+
+    if (shimExists) {
+      const resolved = await resolveRelativeFrameworkImport(
+        "../../_dnt.shims.js",
+        sourcePath,
+        fs,
+      );
+      assertEquals(resolved !== null, true, "Should resolve _dnt.shims.js path");
+
+      // Verify it's outside framework source directories
+      const frameworkSrcDir = `${FRAMEWORK_ROOT}/src/`;
+      const embeddedPrefix = `${EMBEDDED_SRC_DIR}/`;
+      assertEquals(
+        resolved!.startsWith(frameworkSrcDir) || resolved!.startsWith(embeddedPrefix),
+        false,
+        "Resolved dnt shim path should be outside framework source dirs",
+      );
+    }
+    // If shims don't exist (source dev mode), the test passes - the guard
+    // only matters in npm/dnt package builds
   });
 });

--- a/src/transforms/pipeline/stages/ssr-vf-modules/import-finder.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/import-finder.ts
@@ -26,10 +26,17 @@ export function findVfModuleImports(code: string): string[] {
  */
 export function findRelativeImports(code: string): string[] {
   const imports: string[] = [];
-  const pattern = /from\s*["'](\.\.?\/[^"']+)["']/g;
+
+  // Match: from "./foo" or from "../bar"
+  const fromPattern = /from\s*["'](\.\.?\/[^"']+)["']/g;
+  // Match side-effect imports: import "./foo" or import "../bar" (no `from`)
+  const sideEffectPattern = /import\s*["'](\.\.?\/[^"']+)["']/g;
 
   let match: RegExpExecArray | null;
-  while ((match = pattern.exec(code)) !== null) {
+  while ((match = fromPattern.exec(code)) !== null) {
+    imports.push(match[1]!);
+  }
+  while ((match = sideEffectPattern.exec(code)) !== null) {
     imports.push(match[1]!);
   }
 

--- a/src/transforms/pipeline/stages/ssr-vf-modules/index.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/index.ts
@@ -85,6 +85,7 @@ export const _testExports = {
   resolveVeryfrontSourcePath,
   resolveAndTransformVeryfrontImport,
   FRAMEWORK_ROOT,
+  EMBEDDED_SRC_DIR,
   EXTENSIONS,
 };
 

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
@@ -18,6 +18,7 @@ import { buildReactUrl, getReactImportMap } from "../../../import-rewriter/url-b
 import { findRelativeImports } from "./import-finder.ts";
 import { resolveRelativeFrameworkImport, resolveVeryfrontSourcePath } from "./path-resolver.ts";
 import {
+  EMBEDDED_SRC_DIR,
   FRAMEWORK_ROOT,
   frameworkFileCache,
   frameworkWriteFlight,
@@ -193,6 +194,11 @@ export async function transformFrameworkCode(
     // cycles, and frameworkFileCache deduplicates already-transformed files.
     const relativeReplacements = new Map<string, string>();
 
+    // Prefixes for framework source directories - files outside these are
+    // already-compiled JS (e.g. dnt shims) that should not be recursively transformed.
+    const frameworkSrcDir = join(FRAMEWORK_ROOT, "src") + "/";
+    const embeddedSrcDirPrefix = EMBEDDED_SRC_DIR + "/";
+
     {
       const relativeImports = findRelativeImports(transformed);
 
@@ -212,6 +218,17 @@ export async function transformFrameworkCode(
           logger.warn(
             `${LOG_PREFIX} Could not resolve relative import "${specifier}" in ${sourcePath}`,
           );
+          continue;
+        }
+
+        // Files outside framework source directories (e.g. _dnt.shims.js,
+        // _dnt.polyfills.js) are already-compiled JS with bare npm imports
+        // that Deno resolves natively. Skip recursive transformation and
+        // just point to the file directly.
+        const isFrameworkSource = resolvedPath.startsWith(frameworkSrcDir) ||
+          resolvedPath.startsWith(embeddedSrcDirPrefix);
+        if (!isFrameworkSource) {
+          relativeReplacements.set(specifier, `file://${resolvedPath}`);
           continue;
         }
 


### PR DESCRIPTION
## Summary
- **SSR import finder**: Detect side-effect imports (`import "./path.js"`) alongside `from`-style imports, fixing dnt-generated polyfill imports that were missed during SSR transforms
- **Response re-wrapping**: In npm builds, dnt replaces `Response` with undici's polyfill which fails `Deno.serve`'s native `instanceof` check. Both the main Deno adapter (dev server) and `DenoHttpServer` (MCP server) now access native `Response` via `self` and re-wrap polyfilled responses
- **Tests**: Added tests for both the import finder (side-effect imports, dnt polyfill patterns) and the `DenoHttpServer` response wrapping

## Test plan
- [x] Unit tests pass for SSR vf-modules import finder
- [x] Unit tests pass for DenoHttpServer response wrapping
- [x] Verified `deno task dev` in `veryfront-examples/agent-code-assistant` with npm build serves pages successfully (HTTP 200, no TypeError)