### PR TITLE
chore: bump version to 0.1.15

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.11",
+  "version": "0.1.15",
   "description": "The simplest way to build AI-powered apps",
   "keywords": [
     "react",
@@ -19,7 +19,7 @@
     "type": "git",
     "url": "git+https://github.com/veryfront/veryfront.git"
   },
-  "license": "Apache-2.0",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/veryfront/veryfront/issues"
   },
@@ -94,6 +94,9 @@
     "./integrations": {
       "import": "./esm/src/integrations/index.js"
     },
+    "./sandbox": {
+      "import": "./esm/src/sandbox/index.js"
+    },
     "./cli": {
       "import": "./esm/cli/main.js"
     },
@@ -104,6 +107,9 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "optionalDependencies": {
+    "@huggingface/transformers": "^3.4.2"
   },
   "peerDependenciesMeta": {
     "better-sqlite3": {
@@ -119,6 +125,7 @@
     "@babel/parser": "7.26.3",
     "@babel/traverse": "7.26.3",
     "@babel/types": "7.26.3",
+    "@huggingface/transformers": "3.4.2",
     "@mdx-js/mdx": "3.0.0",
     "@opentelemetry/api": "1",
     "@opentelemetry/context-async-hooks": "1",


### PR DESCRIPTION
## Summary
- Bump version from 0.1.14 to 0.1.15 in `deno.json` and `npm/package.json`

## Changelog
- feat: add Sandbox SDK module (#390)
- fix: sort sandbox exports alphabetically for deno fmt (#391)
- fix: remove incorrect /api prefix from sandbox session URLs (#392)
- fix: handle dnt-generated imports and Response shim in SSR pipeline (#393)