### PR TITLE
chore: bump version to 0.1.16

### DIFF
--- a/cli/commands/serve/command.ts
+++ b/cli/commands/serve/command.ts
@@ -45,6 +45,9 @@ async function runProxy(options: ServeOptions): Promise<void> {
   // DenoHttpServer.serve() blocks until the server stops,
   // so this import keeps the process alive.
   await import("veryfront/proxy/main");
+
+  // Keep the process alive (Deno.serve returns immediately in compiled binaries)
+  await new Promise(() => {});
 }
 
 async function runProductionServer(options: ServeOptions): Promise<void> {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "nodeModulesDir": "auto",
   "exclude": [
     "npm/",


### PR DESCRIPTION
Triggers new release with the DenoHttpServer.serve() fix from #395.

v0.1.15 was released before the fix merged, so the proxy is still crashing with the old binary.