### PR TITLE
fix: invalidate API route handler cache on file changes

### DIFF
--- a/src/server/context/cache-invalidation.ts
+++ b/src/server/context/cache-invalidation.ts
@@ -104,7 +104,11 @@ export async function invalidateProjectCaches(
   clearSnippetCacheForProject(projectSlug);
 
   logger.debug("Clearing API route handler cache (per-project)", { projectSlug });
-  await resetApiHandlerForProject(projectSlug);
+  try {
+    await resetApiHandlerForProject(projectSlug);
+  } catch (error) {
+    logger.error("Failed to reset API route handler cache", { projectSlug, error });
+  }
 
   if (projectId) {
     if (environment) {

--- a/src/server/context/cache-invalidation.ts
+++ b/src/server/context/cache-invalidation.ts
@@ -12,6 +12,7 @@ import { cacheRegistry } from "#veryfront/cache";
 import { clearRendererCacheForProject } from "#veryfront/rendering/renderer.ts";
 import { clearRouterDetectionCache } from "#veryfront/rendering/router-detection.ts";
 import { clearSnippetCacheForProject } from "#veryfront/rendering/snippet-renderer.ts";
+import { resetApiHandlerForProject } from "#veryfront/server/handlers/request/api/pages-api-handler.ts";
 
 const logger = serverLogger.component("cache-invalidation");
 
@@ -101,6 +102,9 @@ export async function invalidateProjectCaches(
 
   logger.debug("Clearing snippet cache (per-project)", { projectSlug });
   clearSnippetCacheForProject(projectSlug);
+
+  logger.debug("Clearing API route handler cache (per-project)", { projectSlug });
+  await resetApiHandlerForProject(projectSlug);
 
   if (projectId) {
     if (environment) {

--- a/src/server/handlers/request/api/index.ts
+++ b/src/server/handlers/request/api/index.ts
@@ -7,6 +7,6 @@
 export { ApiHandlerWrapper } from "./api-handler-wrapper.ts";
 export { handleAppRouter } from "./app-router-handler.ts";
 export { resolveAppRouteFile } from "./app-router-resolver.ts";
-export { getApiHandler, resetApiHandler } from "./pages-api-handler.ts";
+export { getApiHandler, resetApiHandler, resetApiHandlerForProject } from "./pages-api-handler.ts";
 export { applySecurityHeaders, buildCSP, getSecurityHeader } from "./security-headers.ts";
 export type { AppRouteMatch, HandlerFn, RouteHandlerModule } from "./types.ts";

--- a/src/server/handlers/request/api/pages-api-handler.ts
+++ b/src/server/handlers/request/api/pages-api-handler.ts
@@ -18,6 +18,7 @@ export interface HandlerCache<T> {
   set(key: string, value: T): void;
   delete(key: string): boolean;
   clear(): void;
+  entries(): IterableIterator<[string, T]>;
   values(): IterableIterator<T>;
 }
 
@@ -83,4 +84,28 @@ export async function resetApiHandler(projectDir?: string): Promise<void> {
   const handlers = Array.from(cache.values());
   cache.clear();
   await Promise.all(handlers.map(destroyHandler));
+}
+
+/**
+ * Reset cached API handlers for a specific project slug.
+ *
+ * In proxy/production mode the cache key is `"${projectDir}:${projectSlug}"`,
+ * so we can't reuse `resetApiHandler(projectDir)`. Instead we iterate all
+ * entries and destroy those whose key ends with `:${projectSlug}`.
+ */
+export async function resetApiHandlerForProject(
+  projectSlug: string,
+): Promise<void> {
+  const cache = getCache();
+  const suffix = `:${projectSlug}`;
+  const toDestroy: Promise<APIRouteHandler>[] = [];
+
+  for (const [key, promise] of cache.entries()) {
+    if (key.endsWith(suffix) || key === projectSlug) {
+      cache.delete(key);
+      toDestroy.push(promise);
+    }
+  }
+
+  await Promise.all(toDestroy.map(destroyHandler));
 }

--- a/tests/server/handlers/request/api/pages-api-handler.test.ts
+++ b/tests/server/handlers/request/api/pages-api-handler.test.ts
@@ -1,0 +1,125 @@
+import { assertEquals } from "#std/assert";
+import { afterEach, beforeEach, describe, it } from "#std/testing/bdd";
+import type { APIRouteHandler } from "../../../../../src/routing/api/handler.ts";
+import {
+  type HandlerCache,
+  __injectCacheForTests,
+  resetApiHandler,
+  resetApiHandlerForProject,
+} from "../../../../../src/server/handlers/request/api/pages-api-handler.ts";
+
+function createMockHandler(destroyed = { value: false }): APIRouteHandler {
+  return { destroy: () => { destroyed.value = true; } } as unknown as APIRouteHandler;
+}
+
+function createTestCache(): HandlerCache<Promise<APIRouteHandler>> & { size: number } {
+  const map = new Map<string, Promise<APIRouteHandler>>();
+  return {
+    get: (k) => map.get(k),
+    set: (k, v) => { map.set(k, v); },
+    delete: (k) => map.delete(k),
+    clear: () => map.clear(),
+    entries: () => map.entries(),
+    values: () => map.values(),
+    get size() { return map.size; },
+  };
+}
+
+describe("pages-api-handler", () => {
+  let cache: ReturnType<typeof createTestCache>;
+
+  beforeEach(() => {
+    cache = createTestCache();
+    __injectCacheForTests(cache);
+  });
+
+  afterEach(() => {
+    __injectCacheForTests(null);
+  });
+
+  describe("resetApiHandlerForProject", () => {
+    it("removes entries matching the project slug suffix", async () => {
+      const d1 = { value: false };
+      const d2 = { value: false };
+      cache.set("/tmp/projects/abc:my-project", Promise.resolve(createMockHandler(d1)));
+      cache.set("/tmp/projects/xyz:other-project", Promise.resolve(createMockHandler(d2)));
+
+      await resetApiHandlerForProject("my-project");
+
+      assertEquals(cache.size, 1);
+      assertEquals(d1.value, true);
+      assertEquals(d2.value, false);
+    });
+
+    it("removes entries where key equals the slug exactly", async () => {
+      const d1 = { value: false };
+      cache.set("my-project", Promise.resolve(createMockHandler(d1)));
+
+      await resetApiHandlerForProject("my-project");
+
+      assertEquals(cache.size, 0);
+      assertEquals(d1.value, true);
+    });
+
+    it("removes multiple entries for the same slug", async () => {
+      const d1 = { value: false };
+      const d2 = { value: false };
+      cache.set("/dir-a:my-project", Promise.resolve(createMockHandler(d1)));
+      cache.set("/dir-b:my-project", Promise.resolve(createMockHandler(d2)));
+
+      await resetApiHandlerForProject("my-project");
+
+      assertEquals(cache.size, 0);
+      assertEquals(d1.value, true);
+      assertEquals(d2.value, true);
+    });
+
+    it("does nothing when no entries match", async () => {
+      const d1 = { value: false };
+      cache.set("/tmp:other-project", Promise.resolve(createMockHandler(d1)));
+
+      await resetApiHandlerForProject("my-project");
+
+      assertEquals(cache.size, 1);
+      assertEquals(d1.value, false);
+    });
+
+    it("does not match partial slug suffixes", async () => {
+      const d1 = { value: false };
+      cache.set("/tmp:not-my-project", Promise.resolve(createMockHandler(d1)));
+
+      await resetApiHandlerForProject("my-project");
+
+      assertEquals(cache.size, 1);
+      assertEquals(d1.value, false);
+    });
+  });
+
+  describe("resetApiHandler", () => {
+    it("removes a specific entry by projectDir key", async () => {
+      const d1 = { value: false };
+      const d2 = { value: false };
+      cache.set("/dir-a", Promise.resolve(createMockHandler(d1)));
+      cache.set("/dir-b", Promise.resolve(createMockHandler(d2)));
+
+      await resetApiHandler("/dir-a");
+
+      assertEquals(cache.size, 1);
+      assertEquals(d1.value, true);
+      assertEquals(d2.value, false);
+    });
+
+    it("clears all entries when no projectDir given", async () => {
+      const d1 = { value: false };
+      const d2 = { value: false };
+      cache.set("/dir-a", Promise.resolve(createMockHandler(d1)));
+      cache.set("/dir-b", Promise.resolve(createMockHandler(d2)));
+
+      await resetApiHandler();
+
+      assertEquals(cache.size, 0);
+      assertEquals(d1.value, true);
+      assertEquals(d2.value, true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix stale API routes** after file edits/deploys in proxy/production mode
- **Fix 404s for new API routes** that were only discovered during `initialize()` which never re-ran

## Root Cause

`invalidateProjectCaches()` clears SSR caches, module caches, renderer caches, and snippet caches — but never destroys the cached `APIRouteHandler` instance. In local dev mode this works because `invalidateRuntimeHandler()` calls `resetApiHandler()` directly, but in proxy/production mode the handler cache was never touched.

## Changes

- **`pages-api-handler.ts`**: Add `resetApiHandlerForProject(projectSlug)` — iterates the handler cache and destroys entries matching the project slug (handles both `${projectDir}:${projectSlug}` proxy keys and plain slug keys). Add `entries()` to `HandlerCache` interface.
- **`cache-invalidation.ts`**: Call `resetApiHandlerForProject(projectSlug)` inside `invalidateProjectCaches()` alongside existing cache clears.

## Test plan

- [x] Existing unit tests pass (`tests/server/context/cache-invalidation.test.ts`)
- [x] Existing integration tests pass (`tests/integration/core/api-handler.test.ts`, `tests/integration/adapters/cache-invalidation.test.ts`)
- [x] Full typecheck passes (pre-commit hook)
- [ ] Manual: edit an API route in Studio, verify preview immediately reflects the change
- [ ] Manual: create a new API route, verify it's accessible without pod restart
- [ ] Manual: Deploy, verify production reflects the change