### PR TITLE
Fix cross-context Response validation in API routes

### DIFF
--- a/src/routing/api/route-executor.test.ts
+++ b/src/routing/api/route-executor.test.ts
@@ -47,8 +47,14 @@ function makeAdapter(mode = "development"): RuntimeAdapter {
         [Symbol.asyncIterator]: async function* () {},
       }),
     },
-    server: { upgradeWebSocket: () => { throw new Error("not implemented"); } },
-    serve: () => { throw new Error("not implemented"); },
+    server: {
+      upgradeWebSocket: () => {
+        throw new Error("not implemented");
+      },
+    },
+    serve: () => {
+      throw new Error("not implemented");
+    },
   };
 }
 

--- a/src/routing/api/route-executor.test.ts
+++ b/src/routing/api/route-executor.test.ts
@@ -8,7 +8,24 @@ function makeAdapter(mode = "development"): RuntimeAdapter {
   const envMap = new Map<string, string>([["MODE", mode]]);
 
   return {
-    env: { get: (key: string) => envMap.get(key) },
+    id: "node",
+    name: "test-stub",
+    capabilities: {
+      typescript: true,
+      jsx: true,
+      http2: false,
+      websocket: false,
+      workers: false,
+      fileWatching: false,
+      shell: false,
+      kvStore: false,
+      writableFs: false,
+    },
+    env: {
+      get: (key: string) => envMap.get(key),
+      set: (key: string, value: string) => envMap.set(key, value),
+      toObject: () => Object.fromEntries(envMap),
+    },
     fs: {
       readFile: () => Promise.resolve(""),
       writeFile: () => Promise.resolve(),
@@ -30,6 +47,8 @@ function makeAdapter(mode = "development"): RuntimeAdapter {
         [Symbol.asyncIterator]: async function* () {},
       }),
     },
+    server: { upgradeWebSocket: () => { throw new Error("not implemented"); } },
+    serve: () => { throw new Error("not implemented"); },
   };
 }
 

--- a/src/routing/api/route-executor.test.ts
+++ b/src/routing/api/route-executor.test.ts
@@ -150,6 +150,76 @@ describe("routing/api/route-executor", () => {
       assertEquals(response.status, 500);
     });
 
+    it("should accept Response.json() return value", async () => {
+      const handler = {
+        GET: () => Response.json({ ok: true }),
+      };
+
+      const request = new Request("http://localhost/api/test", { method: "GET" });
+      const response = await executeAppRoute(
+        handler,
+        request,
+        makeMatch(),
+        "/api/test",
+        makeAdapter(),
+      );
+
+      assertEquals(response.status, 200);
+      assertEquals(await response.json(), { ok: true });
+    });
+
+    it("should accept cross-context Response-like objects (duck typing)", async () => {
+      const fakeResponse = {
+        status: 200,
+        statusText: "OK",
+        headers: new Headers({ "content-type": "application/json" }),
+        body: null,
+        ok: true,
+        redirected: false,
+        type: "basic" as ResponseType,
+        url: "",
+        text: () => Promise.resolve('{"cross":"context"}'),
+        json: () => Promise.resolve({ cross: "context" }),
+        clone: () => fakeResponse,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+        blob: () => Promise.resolve(new Blob()),
+        formData: () => Promise.resolve(new FormData()),
+        bodyUsed: false,
+      };
+
+      const handler = {
+        GET: () => fakeResponse as unknown as Response,
+      };
+
+      const request = new Request("http://localhost/api/test", { method: "GET" });
+      const response = await executeAppRoute(
+        handler,
+        request,
+        makeMatch(),
+        "/api/test",
+        makeAdapter(),
+      );
+
+      assertEquals(response.status, 200);
+    });
+
+    it("should reject objects missing Response interface", async () => {
+      const handler = {
+        GET: () => ({ data: "not a response" }) as unknown as Response,
+      };
+
+      const request = new Request("http://localhost/api/test", { method: "GET" });
+      const response = await executeAppRoute(
+        handler,
+        request,
+        makeMatch(),
+        "/api/test",
+        makeAdapter(),
+      );
+
+      assertEquals(response.status, 500);
+    });
+
     it("should pass route params to handler context", async () => {
       let capturedCtx: { params: Record<string, string> } | undefined;
 

--- a/src/routing/api/route-executor.ts
+++ b/src/routing/api/route-executor.ts
@@ -72,6 +72,20 @@ function createProjectScopedFs(fs: FileSystemAdapter, projectDir: string): FileS
 function validateResponse(response: unknown): asserts response is Response {
   if (response instanceof Response) return;
 
+  // Duck-type check for cross-context Response objects. When user route files
+  // are loaded via direct Deno import (loadTSModuleDirect), they return native
+  // Deno Response objects, while this code runs in the npm package context
+  // which may have a different Response constructor.
+  if (
+    response != null &&
+    typeof response === "object" &&
+    "status" in response &&
+    "headers" in response &&
+    typeof (response as Response).text === "function"
+  ) {
+    return;
+  }
+
   throw toError(
     createError({
       type: "api",

--- a/src/routing/api/route-executor.ts
+++ b/src/routing/api/route-executor.ts
@@ -69,23 +69,28 @@ function createProjectScopedFs(fs: FileSystemAdapter, projectDir: string): FileS
   };
 }
 
+/**
+ * Check if an object is a cross-context Response (e.g. Deno native Response
+ * when this code runs in the npm package context with a different constructor).
+ */
+function isCrossContextResponse(
+  value: unknown,
+): value is { status: number; statusText: string; headers: Headers; body: ReadableStream | null } {
+  if (value == null || typeof value !== "object") return false;
+  const r = value as Record<string, unknown>;
+  return (
+    typeof r.status === "number" &&
+    typeof r.headers === "object" &&
+    r.headers !== null &&
+    typeof (r.headers as Headers).get === "function" &&
+    typeof r.text === "function" &&
+    typeof r.arrayBuffer === "function"
+  );
+}
+
 function validateResponse(response: unknown): asserts response is Response {
   if (response instanceof Response) return;
-
-  // Duck-type check for cross-context Response objects. When user route files
-  // are loaded via direct Deno import (loadTSModuleDirect), they return native
-  // Deno Response objects, while this code runs in the npm package context
-  // which may have a different Response constructor.
-  if (
-    response != null &&
-    typeof response === "object" &&
-    "status" in response &&
-    "headers" in response &&
-    typeof (response as Response).text === "function"
-  ) {
-    return;
-  }
-
+  if (isCrossContextResponse(response)) return;
   throw toError(
     createError({
       type: "api",


### PR DESCRIPTION
## Summary
- `validateResponse` in route-executor fails with `instanceof Response` when user route files are loaded via `loadTSModuleDirect` (direct Deno import), because the native Deno Response constructor differs from the npm package context's Response
- Added a duck-type fallback that checks for `status`, `headers`, and `text()` method before rejecting
- Added 3 test cases covering `Response.json()`, cross-context Response-like objects, and rejection of non-Response objects