### PR TITLE
fix: normalize cross-context Response objects to prevent downstream issues

### DIFF
--- a/src/routing/api/route-executor.test.ts
+++ b/src/routing/api/route-executor.test.ts
@@ -194,11 +194,17 @@ describe("routing/api/route-executor", () => {
     });
 
     it("should accept cross-context Response-like objects (duck typing)", async () => {
+      const bodyStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"cross":"context"}'));
+          controller.close();
+        },
+      });
       const fakeResponse = {
         status: 200,
         statusText: "OK",
         headers: new Headers({ "content-type": "application/json" }),
-        body: null,
+        body: bodyStream,
         ok: true,
         redirected: false,
         type: "basic" as ResponseType,
@@ -227,6 +233,97 @@ describe("routing/api/route-executor", () => {
 
       assert(response instanceof Response, "should be normalized to a real Response instance");
       assertEquals(response.status, 200);
+      assertEquals(response.headers.get("content-type"), "application/json");
+      assertEquals(await response.text(), '{"cross":"context"}');
+    });
+
+    it("should normalize cross-context Response for HEAD requests", async () => {
+      const fakeResponse = {
+        status: 201,
+        statusText: "Created",
+        headers: new Headers({ "x-custom": "value" }),
+        body: new ReadableStream(),
+        ok: true,
+        redirected: false,
+        type: "basic" as ResponseType,
+        url: "",
+        text: () => Promise.resolve(""),
+        json: () => Promise.resolve({}),
+        clone: () => fakeResponse,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+        blob: () => Promise.resolve(new Blob()),
+        formData: () => Promise.resolve(new FormData()),
+        bodyUsed: false,
+      };
+
+      const handler = {
+        GET: () => fakeResponse as unknown as Response,
+      };
+
+      const request = new Request("http://localhost/api/test", { method: "HEAD" });
+      const response = await executeAppRoute(
+        handler,
+        request,
+        makeMatch(),
+        "/api/test",
+        makeAdapter(),
+      );
+
+      assert(response instanceof Response, "should be a real Response instance");
+      assertEquals(response.status, 201);
+      assertEquals(response.headers.get("x-custom"), "value");
+      assertEquals(await response.text(), "");
+    });
+
+    it("should return error response when handler returns null", async () => {
+      const handler = {
+        GET: () => null as unknown as Response,
+      };
+
+      const request = new Request("http://localhost/api/test", { method: "GET" });
+      const response = await executeAppRoute(
+        handler,
+        request,
+        makeMatch(),
+        "/api/test",
+        makeAdapter(),
+      );
+
+      assertEquals(response.status, 500);
+    });
+
+    it("should return error response when handler returns undefined", async () => {
+      const handler = {
+        GET: () => undefined as unknown as Response,
+      };
+
+      const request = new Request("http://localhost/api/test", { method: "GET" });
+      const response = await executeAppRoute(
+        handler,
+        request,
+        makeMatch(),
+        "/api/test",
+        makeAdapter(),
+      );
+
+      assertEquals(response.status, 500);
+    });
+
+    it("should return error response when async handler rejects", async () => {
+      const handler = {
+        GET: () => Promise.reject(new Error("async failure")),
+      };
+
+      const request = new Request("http://localhost/api/test", { method: "GET" });
+      const response = await executeAppRoute(
+        handler,
+        request,
+        makeMatch(),
+        "/api/test",
+        makeAdapter(),
+      );
+
+      assertEquals(response.status, 500);
     });
 
     it("should reject objects missing Response interface", async () => {

--- a/src/routing/api/route-executor.test.ts
+++ b/src/routing/api/route-executor.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { executeAppRoute, executePagesRoute } from "./route-executor.ts";
 import type { RouteMatch } from "./api-route-matcher.ts";
@@ -225,6 +225,7 @@ describe("routing/api/route-executor", () => {
         makeAdapter(),
       );
 
+      assert(response instanceof Response, "should be normalized to a real Response instance");
       assertEquals(response.status, 200);
     });
 

--- a/src/routing/api/route-executor.ts
+++ b/src/routing/api/route-executor.ts
@@ -88,9 +88,20 @@ function isCrossContextResponse(
   );
 }
 
-function validateResponse(response: unknown): asserts response is Response {
-  if (response instanceof Response) return;
-  if (isCrossContextResponse(response)) return;
+function validateResponse(response: unknown): Response {
+  if (response instanceof Response) return response;
+
+  // Normalize cross-context Response objects into a real Response so downstream
+  // code (toHeadResponse, applyCORSHeaders, withHeaders) always receives a
+  // genuine instance with correct body, headers, and status.
+  if (isCrossContextResponse(response)) {
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  }
+
   throw toError(
     createError({
       type: "api",
@@ -129,8 +140,7 @@ export function executeAppRoute(
 
       try {
         const appContext: AppRouteContext = { params: normalizeParams(match.params) };
-        const response = await resolvedFn(request, appContext);
-        validateResponse(response);
+        const response = validateResponse(await resolvedFn(request, appContext));
         return method === "HEAD" ? toHeadResponse(response) : response;
       } catch (error) {
         return handleAPIError(error, pathname, adapter);
@@ -162,9 +172,7 @@ export function executePagesRoute(
       try {
         const fs = projectDir ? createProjectScopedFs(adapter.fs, projectDir) : adapter.fs;
         const ctx = createContext(request, match, fs);
-        const response = await (methodHandler as PagesRouteHandler)(ctx);
-        validateResponse(response);
-        return response;
+        return validateResponse(await (methodHandler as PagesRouteHandler)(ctx));
       } catch (error) {
         return handleAPIError(error, pathname, adapter);
       }


### PR DESCRIPTION
## Summary

- **Normalizes** duck-typed cross-context Response objects into real `Response` instances at the `validateResponse` boundary, instead of passing them through as-is
- **Prevents silent header loss** in `withHeaders` where cross-context `Headers` fails `instanceof Headers` and `Object.entries()` returns empty
- **Prevents missing properties** (`body`, `statusText`) when downstream code like `applyCORSHeaders` consumes the response
- Changes `validateResponse` from `asserts response is Response` to returning `Response`, with call sites updated accordingly

Follows up on #410 which introduced the duck-type fallback.

## Test plan

- [x] Existing duck-type test now also asserts `response instanceof Response` to verify normalization
- [x] All 18 route-executor tests pass