### PR TITLE
fix: use hashCodeHex for SSR cache paths to fix module resolution

### DIFF
--- a/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
@@ -15,6 +15,7 @@ import {
 import { verifiedHttpBundlePaths } from "../http-bundle-helpers.ts";
 import { getTransformPerProjectLimit } from "../constants.ts";
 import { getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
+import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 
 describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
   function resetState(): void {
@@ -214,8 +215,8 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
       resetState();
 
       const baseCacheDir = getMdxEsmCacheDir();
-      const key1 = `${baseCacheDir}|${encodeURIComponent("project-1")}|preview-main`;
-      const key2 = `${baseCacheDir}|${encodeURIComponent("project-2")}|preview-main`;
+      const key1 = `${baseCacheDir}|${hashCodeHex("project-1")}|preview-main`;
+      const key2 = `${baseCacheDir}|${hashCodeHex("project-2")}|preview-main`;
 
       globalTmpDirs.set(key1, "/tmp/proj1");
       globalTmpDirs.set(key2, "/tmp/proj2");

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.ts
@@ -15,6 +15,7 @@
 
 import { registerCache } from "#veryfront/utils/memory/index.ts";
 import { isKeyForProject, registerMapCache } from "#veryfront/cache/keys.ts";
+import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import { rendererLogger } from "#veryfront/utils";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import {
@@ -223,7 +224,7 @@ export function clearSSRModuleCache(): void {
 
 export function clearSSRModuleCacheForProject(projectId: string): void {
   let cleared = 0;
-  const encodedProjectId = encodeURIComponent(projectId);
+  const encodedProjectId = hashCodeHex(projectId);
 
   for (const key of globalModuleCache.keys()) {
     if (!isKeyForProject(key, projectId)) continue;

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -17,6 +17,7 @@ import {
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { verifyCacheFileExists, writeCacheFile } from "#veryfront/utils/cache-file-ops.ts";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
+import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import { rendererLogger } from "#veryfront/utils";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { SpanNames } from "#veryfront/observability/tracing/span-names.ts";
@@ -404,7 +405,7 @@ export class SSRModuleLoader {
 
     if (this.options.projectId && this.options.contentSourceId) {
       const baseCacheDir = getMdxEsmCacheDir();
-      const projectKey = encodeURIComponent(this.options.projectId);
+      const projectKey = hashCodeHex(this.options.projectId);
       const sourceKey = this.options.contentSourceId;
       const mdxCacheDir = join(baseCacheDir, projectKey, sourceKey);
 

--- a/src/modules/react-loader/ssr-module-loader/tmp-paths.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/tmp-paths.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { buildTempModulePath, buildTmpDirPath, getTmpDirCacheKey } from "./tmp-paths.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
@@ -40,5 +40,17 @@ describe("modules/react-loader/ssr-module-loader/tmp-paths", () => {
     );
 
     assertEquals(tempPath, `/cache/mdx/${projectHash}/release-1/tmp/external.v0-1-7-rc-49.js`);
+  });
+
+  it("should not produce URL-encoded characters in cache paths", () => {
+    // Regression: encodeURIComponent created dirs with literal %2F chars
+    // which broke Deno's file:// URL module resolution.
+    const deepPath = "/home/user/Documents/Projects/org/my-app";
+    const path = buildTmpDirPath("/cache/mdx", deepPath, "build-static");
+    const key = getTmpDirCacheKey("/cache/mdx", deepPath, "build-static");
+
+    assert(!path.includes("%"), `cache path must not contain percent-encoded chars: ${path}`);
+    assert(!key.includes("%"), `cache key must not contain percent-encoded chars: ${key}`);
+    assert(/^[a-f0-9]+$/.test(hashCodeHex(deepPath)), "project key should be hex-only");
   });
 });

--- a/src/modules/react-loader/ssr-module-loader/tmp-paths.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/tmp-paths.test.ts
@@ -1,21 +1,23 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { buildTempModulePath, buildTmpDirPath, getTmpDirCacheKey } from "./tmp-paths.ts";
+import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 
 describe("modules/react-loader/ssr-module-loader/tmp-paths", () => {
-  it("builds a stable tmp dir cache key with encoded project id", () => {
+  it("builds a stable tmp dir cache key with hashed project id", () => {
     const key = getTmpDirCacheKey("/cache/mdx", "my/project", "release-1");
-    assertEquals(key, "/cache/mdx|my%2Fproject|release-1");
+    assertEquals(key, `/cache/mdx|${hashCodeHex("my/project")}|release-1`);
   });
 
-  it("builds tmp dir path with encoded project id", () => {
+  it("builds tmp dir path with hashed project id", () => {
     const path = buildTmpDirPath("/cache/mdx", "my/project", "branch-main");
-    assertEquals(path, "/cache/mdx/my%2Fproject/branch-main");
+    assertEquals(path, `/cache/mdx/${hashCodeHex("my/project")}/branch-main`);
   });
 
   it("builds hashed temp module path for files under project dir", () => {
+    const projectHash = hashCodeHex("my/project");
     const tempPath = buildTempModulePath(
-      "/cache/mdx/my%2Fproject/release-1",
+      `/cache/mdx/${projectHash}/release-1`,
       "/repo/project/src/page.tsx",
       "/repo/project",
       "0.1.7-rc.49",
@@ -24,18 +26,19 @@ describe("modules/react-loader/ssr-module-loader/tmp-paths", () => {
 
     assertEquals(
       tempPath,
-      "/cache/mdx/my%2Fproject/release-1/src/page.v0-1-7-rc-49.deadbeef.js",
+      `/cache/mdx/${projectHash}/release-1/src/page.v0-1-7-rc-49.deadbeef.js`,
     );
   });
 
   it("keeps absolute path structure when file is outside project dir", () => {
+    const projectHash = hashCodeHex("my/project");
     const tempPath = buildTempModulePath(
-      "/cache/mdx/my%2Fproject/release-1",
+      `/cache/mdx/${projectHash}/release-1`,
       "/tmp/external.tsx",
       "/repo/project",
       "0.1.7-rc.49",
     );
 
-    assertEquals(tempPath, "/cache/mdx/my%2Fproject/release-1/tmp/external.v0-1-7-rc-49.js");
+    assertEquals(tempPath, `/cache/mdx/${projectHash}/release-1/tmp/external.v0-1-7-rc-49.js`);
   });
 });

--- a/src/modules/react-loader/ssr-module-loader/tmp-paths.ts
+++ b/src/modules/react-loader/ssr-module-loader/tmp-paths.ts
@@ -3,13 +3,14 @@
  */
 
 import { join } from "#veryfront/compat/path/index.ts";
+import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 
 export function getTmpDirCacheKey(
   baseCacheDir: string,
   projectId: string,
   contentSourceId: string,
 ): string {
-  const projectKey = encodeURIComponent(projectId);
+  const projectKey = hashCodeHex(projectId);
   return `${baseCacheDir}|${projectKey}|${contentSourceId}`;
 }
 
@@ -18,7 +19,7 @@ export function buildTmpDirPath(
   projectId: string,
   contentSourceId: string,
 ): string {
-  const projectKey = encodeURIComponent(projectId);
+  const projectKey = hashCodeHex(projectId);
   return join(baseCacheDir, projectKey, contentSourceId);
 }
 

--- a/src/modules/react-loader/ssr-module-loader/vf-module-resolver.ts
+++ b/src/modules/react-loader/ssr-module-loader/vf-module-resolver.ts
@@ -5,6 +5,7 @@
  */
 
 import { join } from "#veryfront/compat/path/index.ts";
+import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { rendererLogger } from "#veryfront/utils";
 import { getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
@@ -68,7 +69,7 @@ export async function resolveVfModuleImports(
   });
 
   const baseCacheDir = getMdxEsmCacheDir();
-  const projectKey = encodeURIComponent(options.projectId);
+  const projectKey = hashCodeHex(options.projectId);
   const esmCacheDir = join(baseCacheDir, projectKey, options.contentSourceId);
 
   const fetcherContext = createModuleFetcherContext(


### PR DESCRIPTION
## Summary

- `encodeURIComponent()` on full filesystem project paths (e.g. `<local-path>`) created cache directories with literal `%2F` characters
- When Deno dynamically imports cached modules via `file://` URLs, these `%2F` characters in directory names break module resolution, causing all app route builds to fail with "Module not found"
- Replaced `encodeURIComponent()` with `hashCodeHex()` (produces safe hex names like `178529b6`) in all 4 affected locations:
  - `tmp-paths.ts` — `getTmpDirCacheKey` and `buildTmpDirPath`
  - `loader.ts` — MDX-ESM cache dir construction
  - `vf-module-resolver.ts` — ESM cache dir construction
  - `cache/memory.ts` — cache key matching in `clearSSRModuleCacheForProject`
- This completes the partial fix from 52a60ba3 which only updated one call site

## Test plan

- [x] `tmp-paths.test.ts` — updated assertions, all pass
- [x] `cache/memory.test.ts` — updated assertions, all pass
- [x] Full unit suite — 955 tests pass, 0 failures
- [x] `veryfront-examples/auth-app` build — 4/4 pages built successfully (was 0/4 before fix)