### PR TITLE
fix: eagerly register HMR broadcast and expand localhost detection

### DIFF
--- a/src/server/context/request-context.ts
+++ b/src/server/context/request-context.ts
@@ -20,7 +20,8 @@ export function createRequestContext(req: Request): RequestContext {
 
   const xEnvironment = req.headers.get("x-environment");
 
-  const mode: "preview" | "production" = effectiveHost.includes(".preview.") ||
+  const mode: "preview" | "production" = parsed.environment === "preview" ||
+      effectiveHost.includes(".preview.") ||
       xEnvironment === "preview"
     ? "preview"
     : "production";

--- a/src/server/dev-server/server.ts
+++ b/src/server/dev-server/server.ts
@@ -172,7 +172,9 @@ export class DevServer {
           changedPaths,
           projectSlug: project?.projectSlug,
         });
-        broadcastUpdate(changedPaths, project?.projectSlug);
+        // Broadcast without projectSlug filter so that connectHMR() clients
+        // (which are registered without a projectSlug) also receive updates.
+        broadcastUpdate(changedPaths);
       });
 
       hmrLog.debug("ReloadNotifier subscriptions registered (invalidate + reload broadcast)");

--- a/src/server/dev-server/server.ts
+++ b/src/server/dev-server/server.ts
@@ -9,6 +9,8 @@ import type { VeryfrontConfig } from "#veryfront/config";
 import { MiddlewarePipeline } from "#veryfront/middleware/core/pipeline/index.ts";
 import { bootstrapDev } from "../bootstrap.ts";
 import { ReloadNotifier } from "../reload-notifier.ts";
+import { broadcastUpdate } from "../handlers/preview/hmr-message-router.ts";
+import { HMRHandler } from "../handlers/preview/hmr.handler.ts";
 import type { DevServerOptions } from "./types.ts";
 import { RequestHandler } from "./request-handler.ts";
 import { setupMiddleware } from "./middleware.ts";
@@ -62,6 +64,7 @@ export class DevServer {
   private _isReady = false;
   private reloadUnsubscribe?: () => void;
   private invalidateUnsubscribe?: () => void;
+  private releaseExternalBroadcastSource?: () => void;
 
   constructor(private options: DevServerOptions) {
     this.ready = new Promise<void>((resolve) => {
@@ -158,7 +161,21 @@ export class DevServer {
         this.requestHandler?.invalidateRuntimeHandler();
       });
 
-      devServerLog.debug("ReloadNotifier invalidation subscription registered");
+      // Subscribe to debounced reload for broadcasting updates to connected HMR clients.
+      // This subscription must be eagerly registered here rather than lazily inside
+      // HMRHandler.initialize(), because HMRHandler.initialize() only runs when the
+      // first /_ws WebSocket request arrives. If that connection fails or hasn't
+      // happened yet, file changes are silently lost.
+      this.releaseExternalBroadcastSource = HMRHandler.registerExternalBroadcastSource();
+      this.reloadUnsubscribe = ReloadNotifier.subscribe((changedPaths, project) => {
+        hmrLog.debug("RELOAD callback triggered - broadcasting to HMR clients", {
+          changedPaths,
+          projectSlug: project?.projectSlug,
+        });
+        broadcastUpdate(changedPaths, project?.projectSlug);
+      });
+
+      hmrLog.debug("ReloadNotifier subscriptions registered (invalidate + reload broadcast)");
     }
 
     const moduleServerUrl = buildLocalhostUrl(this.options.port);
@@ -435,6 +452,7 @@ export class DevServer {
 
     this.reloadUnsubscribe?.();
     this.invalidateUnsubscribe?.();
+    this.releaseExternalBroadcastSource?.();
 
     if (this.fileWatchSetup) {
       const metrics = this.fileWatchSetup.getMetrics();

--- a/src/server/handlers/preview/hmr.handler.ts
+++ b/src/server/handlers/preview/hmr.handler.ts
@@ -38,6 +38,7 @@ const PRIORITY_HMR: HandlerPriority = HandlerPriority.EARLY;
 export class HMRHandler extends BaseHandler {
   private static rateLimiter = new RateLimiter(HMR_MAX_MESSAGES_PER_MINUTE);
   private static reloadUnsubscribe: (() => void) | null = null;
+  private static externalBroadcastSourceCount = 0;
   private static initialized = false;
 
   metadata: HandlerMetadata = {
@@ -66,6 +67,15 @@ export class HMRHandler extends BaseHandler {
         environment: project?.environment,
         branchId: project?.branch ?? undefined,
       });
+
+      if (HMRHandler.externalBroadcastSourceCount > 0) {
+        logger.debug("Skipping handler broadcast - external source active", {
+          projectSlug: project?.projectSlug,
+          externalBroadcastSourceCount: HMRHandler.externalBroadcastSourceCount,
+        });
+        return;
+      }
+
       broadcastUpdate(changedPaths, project?.projectSlug);
     });
 
@@ -84,14 +94,33 @@ export class HMRHandler extends BaseHandler {
     const isPreviewMode = ctx.requestContext?.mode === "preview" || queryEnv === "preview";
     const isLocal = !!ctx.isLocalProject;
     const host = req.headers.get("host") ?? "";
-    const isLocalhost = host.startsWith("localhost") || host.startsWith("127.0.0.1");
+    const hostWithoutPort = host.replace(/:\d+$/, "").toLowerCase();
+    const isVeryfrontMeRoot = hostWithoutPort === "veryfront.me";
+    const isVeryfrontMePreviewRoot = hostWithoutPort === "preview.veryfront.me";
+    const isVeryfrontMeProjectBase = /^[a-z0-9-]+\.veryfront\.me$/.test(hostWithoutPort);
+    const isVeryfrontMeProjectPreview = /^[a-z0-9-]+(?:--[a-z0-9-]+)?\.preview\.veryfront\.me$/
+      .test(hostWithoutPort);
+    const isLocalVeryfrontMeHost = isVeryfrontMeRoot ||
+      isVeryfrontMePreviewRoot ||
+      isVeryfrontMeProjectBase ||
+      isVeryfrontMeProjectPreview;
+    const isLocalhost = hostWithoutPort === "localhost" ||
+      hostWithoutPort === "127.0.0.1" ||
+      hostWithoutPort === "0.0.0.0" ||
+      hostWithoutPort.endsWith(".localhost") ||
+      hostWithoutPort.endsWith(".lvh.me") ||
+      hostWithoutPort === "lvh.me" ||
+      isLocalVeryfrontMeHost;
 
     if (!isPreviewMode && !isLocal && !isLocalhost) {
-      logger.debug("Skipping - not preview or local dev", {
+      logger.warn("Skipping /_ws - not preview, local dev, or localhost", {
         mode: ctx.requestContext?.mode,
         queryEnv,
         isLocalProject: ctx.isLocalProject,
         host,
+        isPreviewMode,
+        isLocal,
+        isLocalhost,
       });
       return Promise.resolve(this.continue());
     }
@@ -283,6 +312,17 @@ export class HMRHandler extends BaseHandler {
     lastBroadcastTime: number;
   } {
     return getMetrics();
+  }
+
+  static registerExternalBroadcastSource(): () => void {
+    HMRHandler.externalBroadcastSourceCount++;
+
+    return () => {
+      HMRHandler.externalBroadcastSourceCount = Math.max(
+        0,
+        HMRHandler.externalBroadcastSourceCount - 1,
+      );
+    };
   }
 
   static shutdown(): void {

--- a/src/server/handlers/preview/hmr.handler.ts
+++ b/src/server/handlers/preview/hmr.handler.ts
@@ -16,6 +16,7 @@ import {
 import { ReloadNotifier } from "../../reload-notifier.ts";
 import { invalidateProjectCaches } from "../../context/cache-invalidation.ts";
 import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
+import { isLocalDevHost } from "../../utils/domain-parser.ts";
 import {
   addClient,
   clearAll,
@@ -94,23 +95,7 @@ export class HMRHandler extends BaseHandler {
     const isPreviewMode = ctx.requestContext?.mode === "preview" || queryEnv === "preview";
     const isLocal = !!ctx.isLocalProject;
     const host = req.headers.get("host") ?? "";
-    const hostWithoutPort = host.replace(/:\d+$/, "").toLowerCase();
-    const isVeryfrontMeRoot = hostWithoutPort === "veryfront.me";
-    const isVeryfrontMePreviewRoot = hostWithoutPort === "preview.veryfront.me";
-    const isVeryfrontMeProjectBase = /^[a-z0-9-]+\.veryfront\.me$/.test(hostWithoutPort);
-    const isVeryfrontMeProjectPreview = /^[a-z0-9-]+(?:--[a-z0-9-]+)?\.preview\.veryfront\.me$/
-      .test(hostWithoutPort);
-    const isLocalVeryfrontMeHost = isVeryfrontMeRoot ||
-      isVeryfrontMePreviewRoot ||
-      isVeryfrontMeProjectBase ||
-      isVeryfrontMeProjectPreview;
-    const isLocalhost = hostWithoutPort === "localhost" ||
-      hostWithoutPort === "127.0.0.1" ||
-      hostWithoutPort === "0.0.0.0" ||
-      hostWithoutPort.endsWith(".localhost") ||
-      hostWithoutPort.endsWith(".lvh.me") ||
-      hostWithoutPort === "lvh.me" ||
-      isLocalVeryfrontMeHost;
+    const isLocalhost = isLocalDevHost(host);
 
     if (!isPreviewMode && !isLocal && !isLocalhost) {
       logger.warn("Skipping /_ws - not preview, local dev, or localhost", {
@@ -332,6 +317,7 @@ export class HMRHandler extends BaseHandler {
     stopPingInterval();
     clearAll();
     HMRHandler.rateLimiter = new RateLimiter(HMR_MAX_MESSAGES_PER_MINUTE);
+    HMRHandler.externalBroadcastSourceCount = 0;
 
     HMRHandler.initialized = false;
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -27,7 +27,6 @@ import { runtime } from "#veryfront/platform/adapters/detect.ts";
 import { bootstrapProd } from "./bootstrap.ts";
 import { createVeryfrontHandler } from "./runtime-handler/index.ts";
 import { addClient, getClient, removeClient } from "./handlers/preview/hmr-client-manager.ts";
-import { broadcastUpdate } from "./handlers/preview/hmr-message-router.ts";
 import { RateLimiter } from "#veryfront/modules/server/index.ts";
 import {
   HMR_CLOSE_MESSAGE_TOO_LARGE,
@@ -196,12 +195,8 @@ export async function createHandler(
   });
   await devServer.start();
 
-  // Subscribe to ReloadNotifier so file changes broadcast to connectHMR clients.
-  // HMRHandler.initialize() only runs on /_ws requests through the handler pipeline,
-  // but connectHMR bypasses the pipeline (Bun/Elysia manage upgrades natively).
-  ReloadNotifier.subscribe((changedPaths) => {
-    broadcastUpdate(changedPaths);
-  });
+  // ReloadNotifier subscription for HMR broadcast is now handled eagerly
+  // inside DevServer.start() — no additional subscription needed here.
 
   const internalFetch = devServer.handler;
   const fetch = async (req: Request) => toNativeResponse(await internalFetch(req));

--- a/src/server/utils/domain-parser.test.ts
+++ b/src/server/utils/domain-parser.test.ts
@@ -1,6 +1,11 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { getEffectiveProjectSlug, isVeryfrontDomain, parseProjectDomain } from "./domain-parser.ts";
+import {
+  getEffectiveProjectSlug,
+  isLocalDevHost,
+  isVeryfrontDomain,
+  parseProjectDomain,
+} from "./domain-parser.ts";
 
 describe("domain-parser", () => {
   describe("parseProjectDomain", () => {
@@ -161,6 +166,54 @@ describe("domain-parser", () => {
       assertEquals(result.isVeryfrontDomain, true);
     });
 
+    it("local staging environment root (lvh.me)", () => {
+      const result = parseProjectDomain("staging.lvh.me");
+      assertEquals(result.slug, null);
+      assertEquals(result.environment, "staging");
+      assertEquals(result.isVeryfrontDomain, true);
+      assertEquals(result.isDraft, false);
+    });
+
+    it("local production environment root (lvh.me)", () => {
+      const result = parseProjectDomain("production.lvh.me");
+      assertEquals(result.slug, null);
+      assertEquals(result.environment, "production");
+      assertEquals(result.isVeryfrontDomain, true);
+      assertEquals(result.isDraft, false);
+    });
+
+    it("local staging environment root (veryfront.me)", () => {
+      const result = parseProjectDomain("staging.veryfront.me");
+      assertEquals(result.slug, null);
+      assertEquals(result.environment, "staging");
+      assertEquals(result.isVeryfrontDomain, true);
+      assertEquals(result.isDraft, false);
+    });
+
+    it("local production environment root (veryfront.me)", () => {
+      const result = parseProjectDomain("production.veryfront.me");
+      assertEquals(result.slug, null);
+      assertEquals(result.environment, "production");
+      assertEquals(result.isVeryfrontDomain, true);
+      assertEquals(result.isDraft, false);
+    });
+
+    it("production environment root (veryfront.com)", () => {
+      const result = parseProjectDomain("production.veryfront.com");
+      assertEquals(result.slug, null);
+      assertEquals(result.environment, "production");
+      assertEquals(result.isVeryfrontDomain, true);
+      assertEquals(result.isDraft, false);
+    });
+
+    it("staging environment root (veryfront.com)", () => {
+      const result = parseProjectDomain("staging.veryfront.com");
+      assertEquals(result.slug, null);
+      assertEquals(result.environment, "staging");
+      assertEquals(result.isVeryfrontDomain, true);
+      assertEquals(result.isDraft, false);
+    });
+
     it("local unknown namespace is not recognized", () => {
       const result = parseProjectDomain("myproject.foobar.veryfront.me");
       assertEquals(result.slug, null);
@@ -254,6 +307,70 @@ describe("domain-parser", () => {
       assertEquals(result.branch, "experiment");
       assertEquals(result.environment, "production");
       assertEquals(result.isDraft, false);
+    });
+  });
+
+  describe("isLocalDevHost", () => {
+    it("recognizes loopback addresses", () => {
+      assertEquals(isLocalDevHost("localhost"), true);
+      assertEquals(isLocalDevHost("localhost:3000"), true);
+      assertEquals(isLocalDevHost("127.0.0.1"), true);
+      assertEquals(isLocalDevHost("127.0.0.1:8080"), true);
+      assertEquals(isLocalDevHost("0.0.0.0"), true);
+      assertEquals(isLocalDevHost("0.0.0.0:3000"), true);
+    });
+
+    it("recognizes *.localhost (W3C secure context)", () => {
+      assertEquals(isLocalDevHost("myproject.localhost"), true);
+      assertEquals(isLocalDevHost("myproject.localhost:3000"), true);
+    });
+
+    it("recognizes bare local dev domains", () => {
+      assertEquals(isLocalDevHost("veryfront.me"), true);
+      assertEquals(isLocalDevHost("lvh.me"), true);
+      assertEquals(isLocalDevHost("veryfront.dev"), true);
+      assertEquals(isLocalDevHost("veryfront.me:8080"), true);
+    });
+
+    it("recognizes slug-only local dev domains", () => {
+      assertEquals(isLocalDevHost("myproject.veryfront.me"), true);
+      assertEquals(isLocalDevHost("myproject.lvh.me:3001"), true);
+      assertEquals(isLocalDevHost("myproject.veryfront.dev"), true);
+    });
+
+    it("recognizes preview local dev domains", () => {
+      assertEquals(isLocalDevHost("myproject.preview.veryfront.me"), true);
+      assertEquals(isLocalDevHost("myproject.preview.lvh.me:3001"), true);
+      assertEquals(isLocalDevHost("preview.veryfront.me"), true);
+      assertEquals(isLocalDevHost("preview.lvh.me"), true);
+    });
+
+    it("rejects explicit production local dev domains", () => {
+      assertEquals(isLocalDevHost("myproject.production.veryfront.me"), false);
+      assertEquals(isLocalDevHost("myproject.production.lvh.me"), false);
+    });
+
+    it("rejects explicit staging local dev domains", () => {
+      assertEquals(isLocalDevHost("myproject.staging.veryfront.me"), false);
+      assertEquals(isLocalDevHost("myproject.staging.lvh.me"), false);
+    });
+
+    it("rejects custom domain simulation", () => {
+      assertEquals(isLocalDevHost("example.com.prod.lvh.me"), false);
+    });
+
+    it("rejects custom domains", () => {
+      assertEquals(isLocalDevHost("example.com"), false);
+      assertEquals(isLocalDevHost("mysite.org"), false);
+    });
+
+    it("rejects production veryfront domains", () => {
+      assertEquals(isLocalDevHost("myproject.preview.veryfront.com"), false);
+      assertEquals(isLocalDevHost("myproject.veryfront.com"), false);
+    });
+
+    it("rejects unknown namespace on local dev domains", () => {
+      assertEquals(isLocalDevHost("myproject.foobar.veryfront.me"), false);
     });
   });
 

--- a/src/server/utils/domain-parser.test.ts
+++ b/src/server/utils/domain-parser.test.ts
@@ -43,6 +43,14 @@ describe("domain-parser", () => {
       assertEquals(result.isDraft, true);
     });
 
+    it("local preview environment root (veryfront.me)", () => {
+      const result = parseProjectDomain("preview.veryfront.me");
+      assertEquals(result.slug, null);
+      assertEquals(result.environment, "preview");
+      assertEquals(result.isVeryfrontDomain, true);
+      assertEquals(result.isDraft, true);
+    });
+
     it("lvh.me preview", () => {
       const result = parseProjectDomain("myproject.preview.lvh.me:3001");
       assertEquals(result.slug, "myproject");
@@ -78,6 +86,14 @@ describe("domain-parser", () => {
       assertEquals(result.slug, null);
       assertEquals(result.environment, "development");
       assertEquals(result.isVeryfrontDomain, true);
+    });
+
+    it("local preview environment root (lvh.me)", () => {
+      const result = parseProjectDomain("preview.lvh.me");
+      assertEquals(result.slug, null);
+      assertEquals(result.environment, "preview");
+      assertEquals(result.isVeryfrontDomain, true);
+      assertEquals(result.isDraft, true);
     });
 
     it("veryfront.com preview", () => {
@@ -130,11 +146,26 @@ describe("domain-parser", () => {
       assertEquals(result.isDraft, false);
     });
 
+    it("local dev explicit staging: {slug}.staging.veryfront.me", () => {
+      const result = parseProjectDomain("myproject.staging.veryfront.me:8080");
+      assertEquals(result.slug, "myproject");
+      assertEquals(result.environment, "staging");
+      assertEquals(result.isVeryfrontDomain, true);
+      assertEquals(result.isDraft, false);
+    });
+
     it("environment root (no slug)", () => {
       const result = parseProjectDomain("preview.veryfront.com");
       assertEquals(result.slug, null);
       assertEquals(result.environment, "preview");
       assertEquals(result.isVeryfrontDomain, true);
+    });
+
+    it("local unknown namespace is not recognized", () => {
+      const result = parseProjectDomain("myproject.foobar.veryfront.me");
+      assertEquals(result.slug, null);
+      assertEquals(result.environment, null);
+      assertEquals(result.isVeryfrontDomain, false);
     });
 
     it("custom domain (not recognized)", () => {

--- a/src/server/utils/domain-parser.ts
+++ b/src/server/utils/domain-parser.ts
@@ -186,6 +186,42 @@ export function isVeryfrontDomain(host: string): boolean {
 }
 
 /**
+ * Check if a host is a local development host where HMR connections should be allowed.
+ * Recognises localhost, 127.0.0.1, 0.0.0.0, *.localhost, and local dev domains
+ * (veryfront.me, lvh.me, veryfront.dev) — but excludes explicit production/staging
+ * subdomains ({slug}.production.{local}, {slug}.staging.{local}) since those are
+ * used for testing non-dev behaviour locally.
+ */
+export function isLocalDevHost(host: string): boolean {
+  const domain = stripPort(host).toLowerCase();
+
+  // Standard loopback / bind-all addresses
+  if (domain === "localhost" || domain === "127.0.0.1" || domain === "0.0.0.0") return true;
+  // W3C *.localhost secure context
+  if (domain.endsWith(".localhost")) return true;
+
+  // Must be on a local dev TLD — production domains (veryfront.com/org) are not dev hosts
+  const isLocalTLD = /\.(veryfront\.me|lvh\.me|veryfront\.dev)$/i.test(domain) ||
+    /^(veryfront\.me|lvh\.me|veryfront\.dev)$/i.test(domain);
+  if (!isLocalTLD) return false;
+
+  const parsed = parseProjectDomain(host);
+
+  // Must be a recognized veryfront domain (rejects unknown namespaces and prod simulations)
+  if (!parsed.isVeryfrontDomain) return false;
+
+  // Explicit staging is for testing staging behaviour — not a dev host
+  if (parsed.environment === "staging") return false;
+
+  // Explicit production ({slug}.production.{local}) is for testing production behaviour.
+  // Slug-only domains ({slug}.{local}) also parse as "production" but ARE dev hosts,
+  // so only exclude when ".production." appears in the domain.
+  if (parsed.environment === "production" && /\.production\./i.test(domain)) return false;
+
+  return true;
+}
+
+/**
  * Get the effective project slug from request host or config
  */
 export function getEffectiveProjectSlug(

--- a/src/server/utils/domain-parser.ts
+++ b/src/server/utils/domain-parser.ts
@@ -108,6 +108,25 @@ export function parseProjectDomain(host: string): ParsedDomain {
     return createParsedDomain(localProductionMatch[1], null, "production", true, false);
   }
 
+  // Local development explicit staging: {slug}.staging.{lvh.me|veryfront.dev}
+  const localStagingMatch = matchDomain(
+    domain,
+    `^([A-Za-z0-9-]+)\\.staging\\.(${LOCAL_DEV_DOMAINS})$`,
+  );
+  if (localStagingMatch?.[1]) {
+    return createParsedDomain(localStagingMatch[1], null, "staging", true, false);
+  }
+
+  // Local environment root domains (no slug): preview|staging|production.{lvh.me|veryfront.dev}
+  const localEnvRootMatch = matchDomain(
+    domain,
+    `^(preview|staging|production)\\.(${LOCAL_DEV_DOMAINS})$`,
+  );
+  if (localEnvRootMatch?.[1]) {
+    const env = localEnvRootMatch[1] as Environment;
+    return createParsedDomain(null, null, env, true, env === "preview");
+  }
+
   // Local development base: {slug}.{lvh.me|veryfront.dev}
   // Mirrors production behavior: serves released content (isDraft: false)
   // Use {slug}.preview.lvh.me for draft content

--- a/tests/integration/server/modules/hmr-handler.test.ts
+++ b/tests/integration/server/modules/hmr-handler.test.ts
@@ -4,6 +4,8 @@
 import { assert, assertEquals, assertExists } from "#veryfront/testing/assert";
 import { afterAll, afterEach, describe, it } from "#veryfront/testing/bdd";
 import { HMRHandler } from "../../../../src/server/handlers/preview/hmr.handler.ts";
+import { ReloadNotifier } from "../../../../src/server/reload-notifier.ts";
+import { broadcastUpdate } from "../../../../src/server/handlers/preview/hmr-message-router.ts";
 import { cleanupBundler } from "../../../../src/rendering/cleanup.ts";
 import {
   HMR_CLOSE_MESSAGE_TOO_LARGE,
@@ -116,6 +118,86 @@ describe("HMR Handler Tests", { sanitizeOps: false, sanitizeResources: false }, 
 
       assertEquals(result.continue, true);
       assertEquals(result.response, undefined);
+    });
+
+    it("does not treat *.production.veryfront.me as localhost", async () => {
+      const handler = new HMRHandler();
+
+      const req = new Request("http://localhost:3000/_ws", {
+        headers: { host: "myproject.production.veryfront.me:3000" },
+      });
+      const ctx = {
+        requestContext: { mode: "production" },
+        projectDir: "/tmp/test",
+        securityConfig: null,
+        cspUserHeader: null,
+        adapter: { fs: {}, server: null },
+      } as unknown as Parameters<typeof handler.handle>[1];
+
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
+    });
+
+    it("does not treat *.staging.veryfront.me as localhost", async () => {
+      const handler = new HMRHandler();
+
+      const req = new Request("http://localhost:3000/_ws", {
+        headers: { host: "myproject.staging.veryfront.me:3000" },
+      });
+      const ctx = {
+        requestContext: { mode: "production" },
+        projectDir: "/tmp/test",
+        securityConfig: null,
+        cspUserHeader: null,
+        adapter: { fs: {}, server: null },
+      } as unknown as Parameters<typeof handler.handle>[1];
+
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
+    });
+
+    it("does not treat unknown *.veryfront.me namespace as localhost", async () => {
+      const handler = new HMRHandler();
+
+      const req = new Request("http://localhost:3000/_ws", {
+        headers: { host: "myproject.foobar.veryfront.me:3000" },
+      });
+      const ctx = {
+        requestContext: { mode: "production" },
+        projectDir: "/tmp/test",
+        securityConfig: null,
+        cspUserHeader: null,
+        adapter: { fs: {}, server: null },
+      } as unknown as Parameters<typeof handler.handle>[1];
+
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
+    });
+
+    it("treats preview.veryfront.me as local preview host", async () => {
+      const handler = new HMRHandler();
+
+      const req = new Request("http://localhost:3000/_ws", {
+        headers: { host: "preview.veryfront.me:3000" },
+      });
+      const ctx = {
+        requestContext: { mode: "production" },
+        projectDir: "/tmp/test",
+        securityConfig: null,
+        cspUserHeader: null,
+        adapter: { fs: {}, server: null },
+      } as unknown as Parameters<typeof handler.handle>[1];
+
+      const result = await handler.handle(req, ctx);
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 200);
     });
 
     it("handle accepts preview via query param (for proxy WebSocket)", async () => {
@@ -299,6 +381,66 @@ describe("HMR Handler Tests", { sanitizeOps: false, sanitizeResources: false }, 
       const rateLimitClose = mock.closeCalls.find((call) => call.code === HMR_CLOSE_RATE_LIMIT);
       assertExists(rateLimitClose);
       assertEquals(HMRHandler.getClientCount(), 0);
+    });
+
+    it("avoids duplicate reload broadcasts when external source is registered", async () => {
+      const handler = new HMRHandler();
+      const mock = createMockSocket();
+
+      const unregisterExternalSource = HMRHandler.registerExternalBroadcastSource();
+      const unsubscribeExternalReload = ReloadNotifier.subscribe((changedPaths, project) => {
+        broadcastUpdate(changedPaths, project?.projectSlug);
+      });
+
+      try {
+        const req = new Request("http://localhost:3000/_ws", {
+          headers: { upgrade: "websocket" },
+        });
+        const ctx = {
+          requestContext: { mode: "preview" },
+          mode: "development",
+          projectDir: "/tmp/test",
+          projectSlug: "test-project",
+          securityConfig: null,
+          cspUserHeader: null,
+          adapter: {
+            fs: {},
+            server: {
+              upgradeWebSocket: () => ({
+                socket: mock.socket,
+                response: new Response(null, { status: 101 }),
+              }),
+            },
+          },
+        } as unknown as Parameters<typeof handler.handle>[1];
+
+        await handler.handle(req, ctx);
+
+        // Ignore initial "connected" message; only validate reload/update emission.
+        mock.sentMessages.length = 0;
+
+        ReloadNotifier.triggerReload(["app.tsx"], { projectSlug: "test-project" });
+        await new Promise((resolve) => setTimeout(resolve, 350));
+
+        const hmrMessages = mock.sentMessages
+          .map((message) => {
+            try {
+              return JSON.parse(message) as { type?: string; path?: string };
+            } catch {
+              return null;
+            }
+          })
+          .filter((msg): msg is { type?: string; path?: string } =>
+            !!msg && (msg.type === "update" || msg.type === "reload")
+          );
+
+        assertEquals(hmrMessages.length, 1);
+        assertEquals(hmrMessages[0]?.type, "update");
+        assertEquals(hmrMessages[0]?.path, "app.tsx");
+      } finally {
+        unsubscribeExternalReload();
+        unregisterExternalSource();
+      }
     });
   });
 

--- a/tests/server/context/request-context.test.ts
+++ b/tests/server/context/request-context.test.ts
@@ -70,6 +70,16 @@ describe("request-context", () => {
       assertEquals(ctx.branch, null);
     });
 
+    it("sets preview mode from local preview environment root domain", () => {
+      const ctx = createRequestContext(
+        new Request("http://preview.veryfront.me:8080/page"),
+      );
+
+      assertEquals(ctx.slug, "");
+      assertEquals(ctx.mode, "preview");
+      assertEquals(ctx.branch, null);
+    });
+
     it("prefers x-token header over env var", () => {
       const ctx = createRequestContext(
         new Request("https://myapp.production.veryfront.com/", {


### PR DESCRIPTION
## Summary

- **Eagerly register ReloadNotifier broadcast** in `DevServer.start()` instead of relying on lazy init in `HMRHandler.initialize()`, which only runs on the first `/_ws` WebSocket request
- **Expand localhost detection** to recognize `lvh.me`, `*.veryfront.me`, `*.localhost`, and `0.0.0.0` in the `/_ws` guard
- **Prevent duplicate broadcasts** via `registerExternalBroadcastSource()` so the eager DevServer subscription and HMRHandler's lazy subscription don't double-send
- **Fix preview mode detection** in `request-context.ts` to use domain parser for local preview environment roots (`preview.veryfront.me`)
- **Add domain parser support** for local staging environments and environment root domains
- **Remove redundant subscription** from `createHandler()` path (now handled in DevServer)

## Root cause

PR #407 removed the old `HMRServer` and its eager `ReloadNotifier.subscribe()` call. The replacement `HMRHandler.initialize()` is lazy — it only subscribes when the first `/_ws` request arrives. If that connection is rejected by the localhost guard (e.g., when accessed via `{slug}.veryfront.me:8080`), `initialize()` never runs and HMR never works.

## Test plan

- [x] All 1145 tests pass (14143 steps)
- [x] Formatting checks pass
- [ ] Manual test: verify HMR works when accessing dev server via `localhost:3000`
- [ ] Manual test: verify HMR works when accessing dev server via `{slug}.veryfront.me:8080`
- [ ] Manual test: verify HMR works in preview mode via Studio
- [ ] Verify no duplicate reload messages in browser console