### PR TITLE
fix: upgrade lightningcss to 1.29.2 for oklch() color support

### DIFF
--- a/src/build/asset-pipeline/css-optimizer/ARCHITECTURE.md
+++ b/src/build/asset-pipeline/css-optimizer/ARCHITECTURE.md
@@ -428,7 +428,7 @@ tests/build/asset-pipeline/
 
 ### Optional (External)
 
-- `https://esm.sh/lightningcss@1.22.0` - Advanced CSS optimization
+- `https://esm.sh/lightningcss@1.29.2` - Advanced CSS optimization
 
 ### Internal
 

--- a/src/build/asset-pipeline/css-optimizer/strategies/lightning-strategy.ts
+++ b/src/build/asset-pipeline/css-optimizer/strategies/lightning-strategy.ts
@@ -20,7 +20,7 @@ export class LightningCSSStrategy implements CSSOptimizationStrategy {
     this.initialized = true;
 
     try {
-      this.lightningCSS = await import("https://esm.sh/lightningcss@1.22.0");
+      this.lightningCSS = await import("https://esm.sh/lightningcss@1.29.2");
       logger.info("Lightning CSS optimizer loaded successfully");
       return true;
     } catch (error) {

--- a/src/build/asset-pipeline/index.ts
+++ b/src/build/asset-pipeline/index.ts
@@ -198,7 +198,7 @@ export async function checkAssetPipelineDependencies(): Promise<{
   }
 
   try {
-    await import("https://esm.sh/lightningcss@1.22.0");
+    await import("https://esm.sh/lightningcss@1.29.2");
     dependencies.lightningCSS = true;
   } catch (error) {
     logger.debug("Lightning CSS not available:", error);


### PR DESCRIPTION
## Summary
- Upgrades lightningcss from 1.22.0 to 1.29.2 to add support for modern CSS Color Level 4 functions
- Fixes `Error: Attempting to parse an unsupported color function "oklch"` when rendering projects that use `oklch()` or `color-mix(in oklch, ...)` in their CSS

## Test plan
- [ ] Deploy to preview and verify a project using `oklch()` colors in CSS renders without errors
- [ ] Verify CSS minification still works correctly for standard color formats (hex, hsl, rgb)