### PR TITLE
fix: support .jsx, .ts, .js extensions in named layout resolution

### DIFF
--- a/src/types/entities/getEntityInfo.ts
+++ b/src/types/entities/getEntityInfo.ts
@@ -377,24 +377,54 @@ export async function getLayoutEntity(
         return null;
       }
 
-      const possiblePaths = [
+      // Files in layouts/ are treated as layouts by convention (any extension)
+      const layoutsDirPaths = [
         pathHelper.join(projectDir, "layouts", `${resolvedLayoutName}.mdx`),
         pathHelper.join(projectDir, "layouts", `${resolvedLayoutName}.md`),
         pathHelper.join(projectDir, "layouts", `${resolvedLayoutName}.tsx`),
+        pathHelper.join(projectDir, "layouts", `${resolvedLayoutName}.jsx`),
+        pathHelper.join(projectDir, "layouts", `${resolvedLayoutName}.ts`),
+        pathHelper.join(projectDir, "layouts", `${resolvedLayoutName}.js`),
+      ];
+
+      // Files in components/ must be detected as layouts by name/frontmatter
+      const componentsPaths = [
         pathHelper.join(projectDir, "components", `${resolvedLayoutName}Layout.mdx`),
         pathHelper.join(projectDir, "components", `${resolvedLayoutName}Layout.md`),
         pathHelper.join(projectDir, "components", `${resolvedLayoutName}Layout.tsx`),
+        pathHelper.join(projectDir, "components", `${resolvedLayoutName}Layout.jsx`),
+        pathHelper.join(projectDir, "components", `${resolvedLayoutName}Layout.ts`),
+        pathHelper.join(projectDir, "components", `${resolvedLayoutName}Layout.js`),
         pathHelper.join(projectDir, "components", "Layout.mdx"),
         pathHelper.join(projectDir, "components", "Layout.md"),
         pathHelper.join(projectDir, "components", "Layout.tsx"),
+        pathHelper.join(projectDir, "components", "Layout.jsx"),
+        pathHelper.join(projectDir, "components", "Layout.ts"),
+        pathHelper.join(projectDir, "components", "Layout.js"),
       ];
 
-      const pathResults = await parallelMap(possiblePaths, async (p) => {
+      const allPaths = [...layoutsDirPaths, ...componentsPaths];
+      const pathResults = await parallelMap(allPaths, async (p) => {
         return await getEntityInfo(p, adapter);
       });
 
-      for (const info of pathResults) {
-        if (info?.entity.isLayout) return info;
+      const layoutsDirCount = layoutsDirPaths.length;
+      for (let i = 0; i < pathResults.length; i++) {
+        const info = pathResults[i];
+        if (!info) continue;
+        // layouts/ dir: any valid entity is a layout
+        // components/ dir: must be detected as layout by name/frontmatter
+        if (i < layoutsDirCount || info.entity.isLayout) {
+          return {
+            entity: {
+              ...info.entity,
+              type: "layout",
+              isLayout: true,
+              isComponent: false,
+              isPage: false,
+            },
+          };
+        }
       }
 
       return null;

--- a/tests/integration/core/getEntityInfo.test.ts
+++ b/tests/integration/core/getEntityInfo.test.ts
@@ -234,6 +234,21 @@ describe("getEntityBySlug", () => {
     });
   });
 
+  it("does not misclassify pages/layouts/ files as layouts", async () => {
+    await withTestContext("entity-pages-layouts-dir", async (context) => {
+      const layoutsPageDir = join(context.projectDir, "pages", "layouts");
+      await createTestFile(
+        join(layoutsPageDir, "index.tsx"),
+        `export default function LayoutsIndex() { return <div>Layouts page</div>; }`,
+      );
+
+      const info = await getEntityInfo(join(layoutsPageDir, "index.tsx"));
+      assertExists(info);
+      assertEquals(info.entity.isPage, true);
+      assertEquals(info.entity.isLayout, false);
+    });
+  });
+
   it("skips non-page entities", async () => {
     await withTestContext("entity-slug-skip", async (context) => {
       const pagesDir = join(context.projectDir, "pages");
@@ -304,6 +319,86 @@ Generic layout`,
       const genericLayout = await getLayoutEntity(context.projectDir, "any");
       assertExists(genericLayout);
       assertEquals(genericLayout.entity.content.includes("Generic layout"), true);
+    });
+  });
+
+  it("finds layout in layouts/ with .jsx extension", async () => {
+    await withTestContext("entity-layout-jsx", async (context) => {
+      const layoutsDir = join(context.projectDir, "layouts");
+      await createTestFile(
+        join(layoutsDir, "sidebar.jsx"),
+        `export default function SidebarLayout({ children }) {
+    return children;
+  }`,
+      );
+
+      const layout = await getLayoutEntity(context.projectDir, "sidebar");
+      assertExists(layout);
+      assertEquals(layout.entity.isLayout, true);
+    });
+  });
+
+  it("finds layout in layouts/ with .ts extension", async () => {
+    await withTestContext("entity-layout-ts", async (context) => {
+      const layoutsDir = join(context.projectDir, "layouts");
+      await createTestFile(
+        join(layoutsDir, "minimal.ts"),
+        `export default function MinimalLayout({ children }: { children: any }) {
+    return children;
+  }`,
+      );
+
+      const layout = await getLayoutEntity(context.projectDir, "minimal");
+      assertExists(layout);
+      assertEquals(layout.entity.isLayout, true);
+    });
+  });
+
+  it("finds layout in layouts/ with .js extension", async () => {
+    await withTestContext("entity-layout-js", async (context) => {
+      const layoutsDir = join(context.projectDir, "layouts");
+      await createTestFile(
+        join(layoutsDir, "simple.js"),
+        `export default function SimpleLayout({ children }) {
+    return children;
+  }`,
+      );
+
+      const layout = await getLayoutEntity(context.projectDir, "simple");
+      assertExists(layout);
+      assertEquals(layout.entity.isLayout, true);
+    });
+  });
+
+  it("finds ComponentLayout in components/ with .jsx extension", async () => {
+    await withTestContext("entity-layout-component-jsx", async (context) => {
+      const componentsDir = join(context.projectDir, "components");
+      await createTestFile(
+        join(componentsDir, "BlogLayout.jsx"),
+        `export default function BlogLayout({ children }) {
+    return children;
+  }`,
+      );
+
+      const layout = await getLayoutEntity(context.projectDir, "Blog");
+      assertExists(layout);
+      assertEquals(layout.entity.isLayout, true);
+    });
+  });
+
+  it("finds Layout fallback in components/ with .jsx extension", async () => {
+    await withTestContext("entity-layout-fallback-jsx", async (context) => {
+      const componentsDir = join(context.projectDir, "components");
+      await createTestFile(
+        join(componentsDir, "Layout.jsx"),
+        `export default function Layout({ children }) {
+    return children;
+  }`,
+      );
+
+      const layout = await getLayoutEntity(context.projectDir, "anything");
+      assertExists(layout);
+      assertEquals(layout.entity.isLayout, true);
     });
   });
 


### PR DESCRIPTION
## Summary
- `getLayoutEntity` only checked `.mdx`, `.md`, `.tsx` when resolving named layouts — missing `.jsx`, `.ts`, `.js`
- Files in the top-level `layouts/` directory (e.g. `layouts/main.jsx`) weren't found because `detectEntityType` only classifies by filename/frontmatter, not directory context

## Changes
- Added `.jsx`, `.ts`, `.js` to all three lookup groups in `getLayoutEntity` (layouts/, components/XLayout, components/Layout)
- `getLayoutEntity` now promotes any valid entity from the `layouts/` directory to a layout, while still requiring name/frontmatter-based detection for `components/` paths
- `detectEntityType` is left unchanged — no `parentDir` heuristic that could misclassify route pages under `pages/layouts/`

## Test plan
- [x] All existing `getEntityInfo` tests pass
- [x] 5 new tests for `.jsx`/`.ts`/`.js` layouts in `layouts/` and `components/` directories
- [x] New test confirming `pages/layouts/index.tsx` is correctly classified as a page (not a layout)
- [x] Manually verified with `basic-mdx` example using `layouts/main.jsx`