### PR TITLE
fix: update Figma OAuth scope docs to file_content:read

### DIFF
--- a/cli/templates/integrations/figma/INTEGRATION_SUMMARY.md
+++ b/cli/templates/integrations/figma/INTEGRATION_SUMMARY.md
@@ -171,7 +171,7 @@ getFileSummary(file) → FileSummary
 ```
 Auth URL: https://www.figma.com/oauth
 Token URL: https://www.figma.com/api/oauth/token
-Scopes: file_read
+Scopes: file_content:read
 Callback: https://yourdomain.com/api/auth/figma/callback
 ```
 

--- a/cli/templates/integrations/figma/README.md
+++ b/cli/templates/integrations/figma/README.md
@@ -56,7 +56,7 @@ This integration enables AI assistants to:
 3. Configure your app:
    - **Name**: Your app name
    - **Callback URL**: `https://yourdomain.com/api/auth/figma/callback`
-   - **Scopes**: `file_read` (required)
+   - **Scopes**: `file_content:read` (required)
 
 ### 2. Configure Environment Variables
 
@@ -238,7 +238,7 @@ export async function getAccessToken(userId: string) {
 ```
 
 ### Scope Requirements
-- `file_read` - Required for all read operations
+- `file_content:read` - Required for all read operations (replaces deprecated `file_read`)
 - Additional scopes can be added in `connector.json`
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

- Updates Figma integration template docs to reference `file_content:read` (v2 granular scope) instead of the deprecated `file_read`
- The `connector.json` already uses the correct scope; only docs were stale

## Test plan

- [x] Verified `connector.json` already has `file_content:read`
- [x] No code changes, docs only