### PR TITLE
fix: replace html2canvas with html2canvas-pro for oklch color support

### DIFF
--- a/src/studio/bridge-template.ts
+++ b/src/studio/bridge-template.ts
@@ -490,7 +490,7 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
 
     html2canvasPromise = new Promise((resolve, reject) => {
       const script = document.createElement('script');
-      script.src = 'https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js';
+      script.src = 'https://cdn.jsdelivr.net/npm/html2canvas-pro@2.0.0/dist/html2canvas-pro.min.js';
       script.onload = () => {
         html2canvasLoaded = true;
         resolve();
@@ -528,7 +528,8 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
         await new Promise(r => setTimeout(r, 100));
       }
 
-      const canvas = await window.html2canvas(document.body, canvasOptions);
+      const html2canvasFn = window.html2canvas.default || window.html2canvas;
+      const canvas = await html2canvasFn(document.body, canvasOptions);
       const dataUrl = canvas.toDataURL('image/png', quality);
 
       window.scrollTo(0, originalScrollY);


### PR DESCRIPTION
## Summary
- Replaces `html2canvas@1.4.1` with `html2canvas-pro@2.0.0` (drop-in fork) to fix screenshot capture failing on projects using Tailwind CSS v4+ which outputs oklch colors by default
- Adds fallback for the v2 named export pattern (`window.html2canvas.default || window.html2canvas`)

## Test plan
- [ ] Open a project using Tailwind v4+ with oklch colors
- [ ] Trigger `capturePreview` tool — screenshot should succeed without "unsupported color function" error
- [ ] Verify screenshots still work on projects using legacy RGB/HSL colors