### PR TITLE
fix: resolve fileListReadyPromise on init failure to prevent crash

### DIFF
--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -307,4 +307,52 @@ describe("VeryfrontFSAdapter", () => {
       assertExists(createAdapter().getClient());
     });
   });
+
+  describe("initialize", () => {
+    it("should throw without causing unhandled rejection when file list fetch fails", async () => {
+      // Regression: initialize() used to call fileListReadyReject() in its catch block.
+      // Since no lookup() was pending, the rejected promise had no handler, causing
+      // "Uncaught (in promise)" that crashed the Deno process.
+      const adapter = createAdapter();
+
+      // Stub client methods so initialize() reaches fetchFileListForContext (the inner try/catch)
+      const client = (adapter as any).client;
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+      // This is what fetchFileListForContext calls — simulate 404
+      client.listAllFiles = () => Promise.reject(new Error("API request failed: 404 Not Found"));
+
+      adapter.setContentContext({
+        sourceType: "branch",
+        projectSlug: "test-project",
+        branch: "main",
+      });
+
+      let unhandledRejection: PromiseRejectionEvent | null = null;
+      const handler = (e: PromiseRejectionEvent) => {
+        unhandledRejection = e;
+        e.preventDefault();
+      };
+      globalThis.addEventListener("unhandledrejection", handler);
+
+      let threw = false;
+      try {
+        try {
+          await adapter.initialize();
+        } catch {
+          threw = true;
+        }
+
+        // Let microtasks flush so any unhandled rejection would fire
+        await new Promise((r) => setTimeout(r, 50));
+
+        assertEquals(threw, true, "initialize() should throw");
+        assertEquals(unhandledRejection, null, "should not cause unhandled rejection");
+      } finally {
+        globalThis.removeEventListener("unhandledrejection", handler);
+      }
+    });
+  });
 });

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -42,8 +42,6 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
   /** Resolves when file list initialization is complete (for coordinating reads) */
   private fileListReadyResolve: (() => void) | null = null;
-  /** Rejects when file list initialization fails */
-  private fileListReadyReject: ((error: Error) => void) | null = null;
 
   private projectData?: Project;
   private apiBaseUrl: string;
@@ -233,9 +231,8 @@ export class VeryfrontFSAdapter implements FSAdapter {
       return;
     }
 
-    const fileListReadyPromise = new Promise<void>((resolve, reject) => {
+    const fileListReadyPromise = new Promise<void>((resolve) => {
       this.fileListReadyResolve = resolve;
-      this.fileListReadyReject = reject;
     });
     this.readOps.setFileListReadyPromise(fileListReadyPromise);
 
@@ -303,7 +300,6 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
       this.fileListReadyResolve?.();
       this.fileListReadyResolve = null;
-      this.fileListReadyReject = null;
 
       logger.debug("Fetched files during initialization", {
         cacheKey,
@@ -357,9 +353,9 @@ export class VeryfrontFSAdapter implements FSAdapter {
         this.wsManager.connect(projectId);
       }
     } catch (error) {
-      this.fileListReadyReject?.(error instanceof Error ? error : new Error(String(error)));
+      // Resolve (not reject) to avoid an unhandled-rejection crash in Deno when no lookup() is awaiting.
+      this.fileListReadyResolve?.();
       this.fileListReadyResolve = null;
-      this.fileListReadyReject = null;
       throw error;
     }
   }


### PR DESCRIPTION
## Summary

When `initialize()` failed (e.g. 404 for a deleted project), the catch block rejected `fileListReadyPromise`. If no `lookup()` was awaiting it, Deno treated the rejection as unhandled and crashed the process.

**Fix:** resolve (not reject) the promise so it settles safely. The error still propagates via `throw`.

Closes #426

## Test plan

- Regression test stubs `client.listAllFiles` to reject with 404, verifies `initialize()` throws **and** no `unhandledrejection` event fires