### PR TITLE
fix: escape frontmatter in markdown preview HTML to prevent XSS

### DIFF
--- a/src/server/handlers/preview/markdown-html-generator.test.ts
+++ b/src/server/handlers/preview/markdown-html-generator.test.ts
@@ -1,0 +1,74 @@
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { generateMarkdownHtml } from "./markdown-html-generator.ts";
+
+function makeOptions(overrides: Partial<Parameters<typeof generateMarkdownHtml>[0]> = {}) {
+  return {
+    rawHtml: "<p>Hello</p>",
+    title: "Test Page",
+    description: "A test page",
+    request: new Request("http://localhost/test.md"),
+    url: new URL("http://localhost/test.md"),
+    projectId: "test-project",
+    filePath: "test.md",
+    ...overrides,
+  };
+}
+
+describe("generateMarkdownHtml", () => {
+  describe("XSS prevention", () => {
+    it("escapes HTML in title", () => {
+      const html = generateMarkdownHtml(
+        makeOptions({ title: '<script>alert("xss")</script>' }),
+      );
+      assert(!html.includes('<script>alert("xss")</script>'));
+      assert(html.includes("&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;"));
+    });
+
+    it("escapes HTML in description", () => {
+      const html = generateMarkdownHtml(
+        makeOptions({ description: '"><script>alert(1)</script>' }),
+      );
+      assert(!html.includes('"><script>alert(1)</script>'));
+      assert(html.includes("&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;"));
+    });
+
+    it("escapes single quotes in title", () => {
+      const html = generateMarkdownHtml(
+        makeOptions({ title: "It's a test" }),
+      );
+      assert(html.includes("It&#39;s a test"));
+    });
+  });
+
+  describe("theme detection", () => {
+    it("applies light theme from query param", () => {
+      const html = generateMarkdownHtml(
+        makeOptions({ url: new URL("http://localhost/test.md?color_mode=light") }),
+      );
+      assert(html.includes('data-theme="light"'));
+    });
+
+    it("applies dark theme from query param", () => {
+      const html = generateMarkdownHtml(
+        makeOptions({ url: new URL("http://localhost/test.md?color_mode=dark") }),
+      );
+      assert(html.includes('data-theme="dark"'));
+    });
+
+    it("omits theme attrs when no preference", () => {
+      const html = generateMarkdownHtml(makeOptions());
+      assert(html.includes('<html lang="en">'));
+    });
+  });
+
+  it("includes raw HTML content in article", () => {
+    const html = generateMarkdownHtml(makeOptions({ rawHtml: "<h1>Hello</h1>" }));
+    assert(html.includes("<h1>Hello</h1>"));
+  });
+
+  it("omits description meta tag when empty", () => {
+    const html = generateMarkdownHtml(makeOptions({ description: "" }));
+    assert(!html.includes('meta name="description"'));
+  });
+});

--- a/src/server/handlers/preview/markdown-html-generator.test.ts
+++ b/src/server/handlers/preview/markdown-html-generator.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { assert } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { generateMarkdownHtml } from "./markdown-html-generator.ts";
 

--- a/src/server/handlers/preview/markdown-html-generator.ts
+++ b/src/server/handlers/preview/markdown-html-generator.ts
@@ -9,6 +9,7 @@
  */
 
 import { generateStudioBridgeScript } from "#veryfront/studio/bridge-template.ts";
+import { escapeHtml } from "veryfront/utils/html-escape";
 
 /** Options for generating markdown preview HTML. */
 export interface MarkdownHtmlOptions {
@@ -86,8 +87,8 @@ export function generateMarkdownHtml(options: MarkdownHtmlOptions): string {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  ${description ? `<meta name="description" content="${description}">` : ""}
-  <title>${title}</title>
+  ${description ? `<meta name="description" content="${escapeHtml(description)}">` : ""}
+  <title>${escapeHtml(title)}</title>
 
   <!-- GitHub Markdown Preview Styles -->
   <link rel="stylesheet" href="https://cdn.veryfront.com/styles/github-markdown.min.css">

--- a/src/server/handlers/preview/markdown-preview.handler.ts
+++ b/src/server/handlers/preview/markdown-preview.handler.ts
@@ -140,8 +140,8 @@ export class MarkdownPreviewHandler extends BaseHandler {
 
       const html = generateMarkdownHtml({
         rawHtml: bundle.rawHtml || "",
-        title: (frontmatter.title as string) || filePath,
-        description: (frontmatter.description as string) || "",
+        title: frontmatter.title != null ? String(frontmatter.title) : filePath,
+        description: frontmatter.description != null ? String(frontmatter.description) : "",
         request: req,
         url,
         projectId: ctx.projectSlug || ctx.projectId || "markdown-preview",


### PR DESCRIPTION
## Summary
- HTML-escape `title` and `description` from markdown frontmatter before interpolating into the preview HTML document
- Uses the existing `escapeHtml()` utility from `src/utils/html-escape.ts`
- Previously, crafted frontmatter like `description: '"><script>alert(1)</script>'` could break out of the HTML attribute and execute arbitrary JavaScript

## Test plan
- [x] `<script>` tags in title are escaped
- [x] Attribute breakout (`">) in description is escaped
- [x] Single quotes in title are escaped
- [x] Light/dark theme detection still works
- [x] Empty description omits the meta tag
- [x] Raw HTML content renders in article body