### PR TITLE
feat: add task discovery and CLI command

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -308,6 +308,14 @@ jobs:
           event-type: veryfront-code-released
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
 
+      - name: Trigger job-runner deploy
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GH_PAT_VERYFRONT }}
+          repository: veryfront/veryfront-job-runner
+          event-type: veryfront-code-released
+          client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
+
   # ============================================
   # CD: Stable Release (clean semver only)
   # Runs when deno.json version is X.Y.Z (no suffix)
@@ -428,6 +436,14 @@ jobs:
         with:
           token: ${{ secrets.GH_PAT_VERYFRONT }}
           repository: veryfront/veryfront-server
+          event-type: veryfront-code-released
+          client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
+
+      - name: Trigger job-runner deploy
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GH_PAT_VERYFRONT }}
+          repository: veryfront/veryfront-job-runner
           event-type: veryfront-code-released
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
 

--- a/cli/commands/task/command-help.ts
+++ b/cli/commands/task/command-help.ts
@@ -1,0 +1,22 @@
+import type { CommandHelp } from "../../help/types.ts";
+
+export const taskHelp: CommandHelp = {
+  name: "task",
+  description: "Run a task from the tasks/ directory",
+  usage: "veryfront task <name> [options]",
+  options: [
+    {
+      flag: "--config <json>",
+      description: "JSON config to pass to the task's ctx.config",
+    },
+    {
+      flag: "--debug",
+      description: "Enable debug logging",
+    },
+  ],
+  examples: [
+    "veryfront task sync-data",
+    "veryfront task send-report --config '{\"to\": \"team@example.com\"}'",
+    "veryfront task cleanup --debug",
+  ],
+};

--- a/cli/commands/task/command-help.ts
+++ b/cli/commands/task/command-help.ts
@@ -16,7 +16,7 @@ export const taskHelp: CommandHelp = {
   ],
   examples: [
     "veryfront task sync-data",
-    "veryfront task send-report --config '{\"to\": \"team@example.com\"}'",
+    'veryfront task send-report --config \'{"to": "team@example.com"}\'',
     "veryfront task cleanup --debug",
   ],
 };

--- a/cli/commands/task/command.ts
+++ b/cli/commands/task/command.ts
@@ -1,0 +1,96 @@
+/**
+ * Task command - Discover and run a task from the tasks/ directory
+ *
+ * Finds the specified task file, imports it, and calls its run() function
+ * with a local execution context.
+ */
+
+import { cliLogger } from "#cli/utils";
+import { exitProcess } from "#cli/utils";
+import type { TaskArgs } from "./handler.ts";
+
+export interface TaskOptions extends TaskArgs {}
+
+export async function taskCommand(options: TaskOptions): Promise<void> {
+  const { getAdapter } = await import(
+    "../../../src/platform/adapters/detect.ts"
+  );
+  const { discoverTasks } = await import(
+    "../../../src/task/discovery.ts"
+  );
+  const { runTask } = await import(
+    "../../../src/task/runner.ts"
+  );
+
+  const taskName = options.name;
+  if (!taskName) {
+    cliLogger.error("Task name is required. Usage: veryfront task <name>");
+    exitProcess(1);
+    return;
+  }
+
+  const projectDir = Deno.cwd();
+  const adapter = await getAdapter();
+
+  cliLogger.info(`Discovering tasks in ${projectDir}/tasks/...`);
+
+  const { tasks, errors } = await discoverTasks({
+    projectDir,
+    adapter,
+    debug: options.debug,
+  });
+
+  if (errors.length > 0 && options.debug) {
+    for (const err of errors) {
+      cliLogger.warn(`  Warning: ${err.filePath}: ${err.error}`);
+    }
+  }
+
+  const task = tasks.find((t) => t.id === taskName);
+  if (!task) {
+    cliLogger.error(`Task "${taskName}" not found.`);
+    if (tasks.length > 0) {
+      cliLogger.info("Available tasks:");
+      for (const t of tasks) {
+        cliLogger.info(`  - ${t.id}${t.name !== t.id ? ` (${t.name})` : ""}`);
+      }
+    } else {
+      cliLogger.info("No tasks found. Create a task file in tasks/ directory:");
+      cliLogger.info("  tasks/my-task.ts");
+    }
+    exitProcess(1);
+    return;
+  }
+
+  // Parse config JSON if provided
+  let config: Record<string, unknown> = {};
+  if (options.config) {
+    try {
+      config = JSON.parse(options.config);
+    } catch {
+      cliLogger.error("Invalid --config JSON");
+      exitProcess(1);
+      return;
+    }
+  }
+
+  cliLogger.info(`Running task: ${task.name} (${task.id})`);
+  cliLogger.info("");
+
+  const result = await runTask({
+    task,
+    config,
+    debug: options.debug,
+  });
+
+  cliLogger.info("");
+  if (result.success) {
+    cliLogger.info(`Task completed in ${result.durationMs}ms`);
+    if (result.result !== undefined) {
+      cliLogger.info(`Result: ${JSON.stringify(result.result, null, 2)}`);
+    }
+  } else {
+    cliLogger.error(`Task failed after ${result.durationMs}ms: ${result.error}`);
+    exitProcess(1);
+  }
+}

--- a/cli/commands/task/handler.ts
+++ b/cli/commands/task/handler.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { createArgParser, parseArgsOrThrow } from "#cli/shared/args";
+import type { ParsedArgs } from "#cli/shared/types";
+
+const TaskArgsSchema = z.object({
+  name: z.string(),
+  config: z.string().optional(),
+  debug: z.boolean().default(false),
+});
+
+export type TaskArgs = z.infer<typeof TaskArgsSchema>;
+
+export const parseTaskArgs = createArgParser(TaskArgsSchema, {
+  name: { keys: ["name"], type: "string", positional: 0 },
+  config: { keys: ["config"], type: "string" },
+  debug: { keys: ["debug"], type: "boolean" },
+});
+
+export async function handleTaskCommand(args: ParsedArgs): Promise<void> {
+  const opts = parseArgsOrThrow(parseTaskArgs, "task", args);
+  const { taskCommand } = await import("./command.ts");
+  await taskCommand(opts);
+}

--- a/cli/commands/task/index.ts
+++ b/cli/commands/task/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Task command - Run tasks from the tasks/ directory
+ */
+
+export { taskCommand } from "./command.ts";
+export type { TaskOptions } from "./command.ts";
+export { handleTaskCommand } from "./handler.ts";
+export { taskHelp } from "./command-help.ts";

--- a/cli/help/command-definitions.ts
+++ b/cli/help/command-definitions.ts
@@ -32,6 +32,7 @@ import { demoHelp } from "../commands/demo/command-help.ts";
 import { mcpHelp } from "../commands/mcp/command-help.ts";
 import { issuesHelp } from "../commands/issues/command-help.ts";
 import { startHelp } from "../commands/start/command-help.ts";
+import { taskHelp } from "../commands/task/command-help.ts";
 
 /**
  * Central registry of all command help definitions.
@@ -63,4 +64,5 @@ export const COMMANDS: CommandRegistry = {
   mcp: mcpHelp,
   issues: issuesHelp,
   start: startHelp,
+  task: taskHelp,
 };

--- a/cli/router.ts
+++ b/cli/router.ts
@@ -27,6 +27,7 @@ import { handleServeCommand } from "./commands/serve/handler.ts";
 import { handleStartCommand } from "./commands/start/handler.ts";
 import { handleStudioCommand } from "./commands/studio/handler.ts";
 import { handleUpCommand } from "./commands/up/index.ts";
+import { handleTaskCommand } from "./commands/task/handler.ts";
 import { handleWorkerCommand } from "./commands/worker/handler.ts";
 import { login, logout, whoami } from "./auth/index.ts";
 import { parseLoginMethod } from "./auth/utils.ts";
@@ -73,6 +74,7 @@ const commands: Record<string, (args: ParsedArgs) => Promise<void>> = {
   "mcp": handleMCPCommand,
   "issues": handleIssuesCommand,
   "start": handleStartCommand,
+  "task": handleTaskCommand,
   "worker": handleWorkerCommand,
 };
 

--- a/src/discovery/discovery-engine.ts
+++ b/src/discovery/discovery-engine.ts
@@ -20,6 +20,7 @@ import {
   agentHandler,
   promptHandler,
   resourceHandler,
+  taskHandler,
   toolHandler,
   workflowHandler,
 } from "./handlers/index.ts";
@@ -89,6 +90,7 @@ export async function discoverAll(config: DiscoveryConfig): Promise<DiscoveryRes
     resources: new Map(),
     prompts: new Map(),
     workflows: new Map(),
+    tasks: new Map(),
     errors: [],
   };
 
@@ -115,6 +117,11 @@ export async function discoverAll(config: DiscoveryConfig): Promise<DiscoveryRes
   // Discover workflows
   for (const dir of config.workflowDirs ?? ["workflows"]) {
     await discoverItems(`${baseDir}/${dir}`, result, context, workflowHandler, config.verbose);
+  }
+
+  // Discover tasks
+  for (const dir of config.taskDirs ?? ["tasks"]) {
+    await discoverItems(`${baseDir}/${dir}`, result, context, taskHandler, config.verbose);
   }
 
   return result;

--- a/src/discovery/handlers/index.ts
+++ b/src/discovery/handlers/index.ts
@@ -9,3 +9,4 @@ export { agentHandler } from "./agent-handler.ts";
 export { resourceHandler } from "./resource-handler.ts";
 export { promptHandler } from "./prompt-handler.ts";
 export { workflowHandler } from "./workflow-handler.ts";
+export { taskHandler } from "./task-handler.ts";

--- a/src/discovery/handlers/task-handler.ts
+++ b/src/discovery/handlers/task-handler.ts
@@ -3,15 +3,12 @@
  */
 
 import type { TaskDefinition } from "#veryfront/task/types.ts";
+import { isTaskDefinition } from "#veryfront/task/types.ts";
 import type { DiscoveryHandler, DiscoveryResult } from "../types.ts";
 
 export const taskHandler: DiscoveryHandler<TaskDefinition> = {
   typeName: "task",
-  validate: (item): item is TaskDefinition =>
-    item !== null &&
-    typeof item === "object" &&
-    "run" in item &&
-    typeof (item as TaskDefinition).run === "function",
+  validate: (item): item is TaskDefinition => isTaskDefinition(item),
   getId: (_task, file, dir) => {
     // Derive ID from file path relative to tasks dir
     let relative = file;

--- a/src/discovery/handlers/task-handler.ts
+++ b/src/discovery/handlers/task-handler.ts
@@ -1,0 +1,26 @@
+/**
+ * Task Discovery Handler
+ */
+
+import type { TaskDefinition } from "#veryfront/task/types.ts";
+import type { DiscoveryHandler, DiscoveryResult } from "../types.ts";
+
+export const taskHandler: DiscoveryHandler<TaskDefinition> = {
+  typeName: "task",
+  validate: (item): item is TaskDefinition =>
+    item !== null &&
+    typeof item === "object" &&
+    "run" in item &&
+    typeof (item as TaskDefinition).run === "function",
+  getId: (_task, file, dir) => {
+    // Derive ID from file path relative to tasks dir
+    let relative = file;
+    const prefix = dir.endsWith("/") ? dir : `${dir}/`;
+    if (relative.startsWith(prefix)) {
+      relative = relative.slice(prefix.length);
+    }
+    return relative.replace(/\.(ts|tsx|js|jsx)$/, "");
+  },
+  register: (_id, task) => task,
+  getResultMap: (result: DiscoveryResult) => result.tasks,
+};

--- a/src/discovery/index.test.ts
+++ b/src/discovery/index.test.ts
@@ -59,6 +59,7 @@ describe("src/discovery/index", () => {
         resources: new Map(),
         prompts: new Map(),
         workflows: new Map(),
+        tasks: new Map(),
         errors: [],
       };
 
@@ -67,6 +68,7 @@ describe("src/discovery/index", () => {
       assertEquals(result.resources.size, 0);
       assertEquals(result.prompts.size, 0);
       assertEquals(result.workflows.size, 0);
+      assertEquals(result.tasks.size, 0);
       assertEquals(result.errors.length, 0);
     });
   });

--- a/src/discovery/types.ts
+++ b/src/discovery/types.ts
@@ -9,6 +9,7 @@ import type { Agent } from "#veryfront/agent";
 import type { Resource } from "#veryfront/resource";
 import type { Prompt } from "#veryfront/prompt";
 import type { Workflow } from "#veryfront/workflow";
+import type { TaskDefinition } from "#veryfront/task/types.ts";
 import type { Platform } from "#veryfront/platform/core-platform.ts";
 import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
 
@@ -35,6 +36,7 @@ export interface DiscoveryConfig {
   resourceDirs?: string[];
   promptDirs?: string[];
   workflowDirs?: string[];
+  taskDirs?: string[];
   verbose?: boolean;
   fsAdapter?: FileSystemAdapter;
 }
@@ -48,6 +50,7 @@ export interface DiscoveryResult {
   resources: Map<string, Resource>;
   prompts: Map<string, Prompt>;
   workflows: Map<string, Workflow>;
+  tasks: Map<string, TaskDefinition>;
   errors: Array<{ file: string; error: Error }>;
 }
 

--- a/src/task/discovery.test.ts
+++ b/src/task/discovery.test.ts
@@ -1,0 +1,93 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { deriveTaskId } from "./discovery.ts";
+import { isTaskDefinition } from "./types.ts";
+
+describe("src/task/discovery", () => {
+  describe("deriveTaskId", () => {
+    it("should strip tasksDir prefix and extension", () => {
+      assertEquals(deriveTaskId("tasks/sync-data.ts", "tasks"), "sync-data");
+    });
+
+    it("should handle trailing slash in tasksDir", () => {
+      assertEquals(deriveTaskId("tasks/sync-data.ts", "tasks/"), "sync-data");
+    });
+
+    it("should handle nested file paths", () => {
+      assertEquals(
+        deriveTaskId("tasks/reports/daily.ts", "tasks"),
+        "reports/daily",
+      );
+    });
+
+    it("should handle .tsx extension", () => {
+      assertEquals(deriveTaskId("tasks/render.tsx", "tasks"), "render");
+    });
+
+    it("should handle .js extension", () => {
+      assertEquals(deriveTaskId("tasks/legacy.js", "tasks"), "legacy");
+    });
+
+    it("should handle .jsx extension", () => {
+      assertEquals(deriveTaskId("tasks/component.jsx", "tasks"), "component");
+    });
+
+    it("should handle absolute paths", () => {
+      assertEquals(
+        deriveTaskId("/project/tasks/cleanup.ts", "/project/tasks"),
+        "cleanup",
+      );
+    });
+
+    it("should return path as-is when prefix does not match", () => {
+      assertEquals(
+        deriveTaskId("other/cleanup.ts", "tasks"),
+        "other/cleanup",
+      );
+    });
+  });
+
+  describe("isTaskDefinition", () => {
+    it("should return true for an object with a run function", () => {
+      assertEquals(
+        isTaskDefinition({ run: () => {} }),
+        true,
+      );
+    });
+
+    it("should return true for a full task definition", () => {
+      assertEquals(
+        isTaskDefinition({
+          name: "My Task",
+          description: "Does things",
+          run: async () => ({ ok: true }),
+        }),
+        true,
+      );
+    });
+
+    it("should return false for null", () => {
+      assertEquals(isTaskDefinition(null), false);
+    });
+
+    it("should return false for undefined", () => {
+      assertEquals(isTaskDefinition(undefined), false);
+    });
+
+    it("should return false for a string", () => {
+      assertEquals(isTaskDefinition("not a task"), false);
+    });
+
+    it("should return false for a number", () => {
+      assertEquals(isTaskDefinition(42), false);
+    });
+
+    it("should return false for an object without run", () => {
+      assertEquals(isTaskDefinition({ name: "no run" }), false);
+    });
+
+    it("should return false when run is not a function", () => {
+      assertEquals(isTaskDefinition({ run: "not a function" }), false);
+    });
+  });
+});

--- a/src/task/discovery.ts
+++ b/src/task/discovery.ts
@@ -1,0 +1,214 @@
+/**
+ * Task Discovery
+ *
+ * Discovers task definitions from user's project `tasks/` directory.
+ * Follows the same patterns as workflow-discovery.ts.
+ *
+ * Scans:
+ * - tasks/*.ts - task definition files
+ * - tasks/**\/*.ts - nested task files
+ *
+ * Task files should export a task definition:
+ * ```typescript
+ * export default {
+ *   name: "Sync external data",
+ *   run: async (ctx) => {
+ *     console.log("Syncing data...")
+ *     return { synced: 42 }
+ *   }
+ * }
+ * ```
+ */
+
+import { join } from "@std/path";
+import { logger as baseLogger } from "#veryfront/utils";
+import type { RuntimeAdapter } from "#veryfront/platform";
+import type { VeryfrontConfig } from "#veryfront/config";
+import { collectFiles } from "#veryfront/utils/file-discovery.ts";
+import { loadHandlerModule } from "#veryfront/routing/api/module-loader/loader.ts";
+import type { TaskDefinition } from "./types.ts";
+
+const logger = baseLogger.component("task-discovery");
+
+/**
+ * Discovered task info
+ */
+export interface DiscoveredTask {
+  /** Task ID derived from file path (e.g., "sync-data" from tasks/sync-data.ts) */
+  id: string;
+
+  /** Human-readable name from task definition */
+  name: string;
+
+  /** File path where the task is defined */
+  filePath: string;
+
+  /** Export name (e.g., "default" or named export) */
+  exportName: string;
+
+  /** The task definition */
+  definition: TaskDefinition;
+}
+
+/**
+ * Options for task discovery
+ */
+export interface TaskDiscoveryOptions {
+  /** Project directory */
+  projectDir: string;
+
+  /** Runtime adapter for filesystem operations */
+  adapter: RuntimeAdapter;
+
+  /** Veryfront config (for import maps, etc.) */
+  config?: VeryfrontConfig;
+
+  /** Base directory for tasks (default: "tasks") */
+  tasksDir?: string;
+
+  /** Enable debug logging */
+  debug?: boolean;
+}
+
+/**
+ * Result of task discovery
+ */
+export interface TaskDiscoveryResult {
+  /** All discovered tasks */
+  tasks: DiscoveredTask[];
+
+  /** Errors encountered during discovery */
+  errors: Array<{ filePath: string; error: string }>;
+}
+
+/**
+ * Check if a value looks like a task definition
+ */
+function isTaskDefinition(value: unknown): value is TaskDefinition {
+  if (!value || typeof value !== "object") return false;
+  const obj = value as Record<string, unknown>;
+  return typeof obj.run === "function";
+}
+
+/**
+ * Derive task ID from file path (e.g., "tasks/sync-data.ts" → "sync-data")
+ */
+function deriveTaskId(filePath: string, tasksDir: string): string {
+  // Remove the tasks dir prefix and extension
+  let relative = filePath;
+  const dirPrefix = tasksDir.endsWith("/") ? tasksDir : `${tasksDir}/`;
+  if (relative.startsWith(dirPrefix)) {
+    relative = relative.slice(dirPrefix.length);
+  }
+  // Remove extension
+  return relative.replace(/\.(ts|tsx|js|jsx)$/, "");
+}
+
+/**
+ * Discover all tasks in a project
+ */
+export async function discoverTasks(
+  options: TaskDiscoveryOptions,
+): Promise<TaskDiscoveryResult> {
+  const {
+    projectDir,
+    adapter,
+    config,
+    tasksDir = "tasks",
+    debug = false,
+  } = options;
+
+  const tasks: DiscoveredTask[] = [];
+  const errors: Array<{ filePath: string; error: string }> = [];
+
+  const fsType = config?.fs?.type ?? "local";
+  const useRelativePaths = fsType === "github" || fsType === "veryfront-api";
+  const baseDir = useRelativePaths ? tasksDir : join(projectDir, tasksDir);
+
+  if (debug) {
+    logger.info(`Scanning ${baseDir} for tasks`);
+  }
+
+  try {
+    const dirExists = await adapter.fs.exists(baseDir);
+    if (!dirExists) {
+      if (debug) {
+        logger.info(`No tasks directory found at ${baseDir}`);
+      }
+      return { tasks, errors };
+    }
+
+    const files = await collectFiles({
+      baseDir,
+      extensions: [".ts", ".tsx", ".js", ".jsx"],
+      recursive: true,
+      ignorePatterns: ["node_modules", ".git", "__tests__", "*.test.*", "*.spec.*"],
+      adapter,
+    });
+
+    if (debug) {
+      logger.info(`Found ${files.length} potential task files`);
+    }
+
+    for (const file of files) {
+      try {
+        const module = await loadHandlerModule({
+          projectDir,
+          modulePath: file.path,
+          adapter,
+          config,
+        });
+
+        if (!module) continue;
+
+        // Check all exports for task definitions
+        for (const [exportName, value] of Object.entries(module)) {
+          if (isTaskDefinition(value)) {
+            const id = deriveTaskId(file.path, baseDir);
+            tasks.push({
+              id,
+              name: value.name || id,
+              filePath: file.path,
+              exportName,
+              definition: value,
+            });
+
+            if (debug) {
+              logger.info(`Found task "${id}" in ${file.path} (export: ${exportName})`);
+            }
+            break; // Only take the first valid export per file
+          }
+        }
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        errors.push({ filePath: file.path, error: errorMsg });
+
+        if (debug) {
+          logger.warn(`Failed to load ${file.path}: ${errorMsg}`);
+        }
+      }
+    }
+
+    if (debug) {
+      logger.info(`Discovered ${tasks.length} tasks`);
+    }
+
+    return { tasks, errors };
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    logger.error(`Task discovery failed: ${errorMsg}`);
+    errors.push({ filePath: baseDir, error: errorMsg });
+    return { tasks, errors };
+  }
+}
+
+/**
+ * Find a specific task by ID
+ */
+export async function findTaskById(
+  taskId: string,
+  options: TaskDiscoveryOptions,
+): Promise<DiscoveredTask | null> {
+  const { tasks } = await discoverTasks(options);
+  return tasks.find((t) => t.id === taskId) ?? null;
+}

--- a/src/task/discovery.ts
+++ b/src/task/discovery.ts
@@ -27,6 +27,7 @@ import type { VeryfrontConfig } from "#veryfront/config";
 import { collectFiles } from "#veryfront/utils/file-discovery.ts";
 import { loadHandlerModule } from "#veryfront/routing/api/module-loader/loader.ts";
 import type { TaskDefinition } from "./types.ts";
+import { isTaskDefinition } from "./types.ts";
 
 const logger = baseLogger.component("task-discovery");
 
@@ -82,18 +83,9 @@ export interface TaskDiscoveryResult {
 }
 
 /**
- * Check if a value looks like a task definition
- */
-function isTaskDefinition(value: unknown): value is TaskDefinition {
-  if (!value || typeof value !== "object") return false;
-  const obj = value as Record<string, unknown>;
-  return typeof obj.run === "function";
-}
-
-/**
  * Derive task ID from file path (e.g., "tasks/sync-data.ts" → "sync-data")
  */
-function deriveTaskId(filePath: string, tasksDir: string): string {
+export function deriveTaskId(filePath: string, tasksDir: string): string {
   // Remove the tasks dir prefix and extension
   let relative = filePath;
   const dirPrefix = tasksDir.endsWith("/") ? tasksDir : `${tasksDir}/`;
@@ -161,22 +153,40 @@ export async function discoverTasks(
 
         if (!module) continue;
 
-        // Check all exports for task definitions
-        for (const [exportName, value] of Object.entries(module)) {
-          if (isTaskDefinition(value)) {
-            const id = deriveTaskId(file.path, baseDir);
-            tasks.push({
-              id,
-              name: value.name || id,
-              filePath: file.path,
-              exportName,
-              definition: value,
-            });
+        // Prefer default export (aligned with discovery-engine behaviour)
+        const defaultExport = (module as Record<string, unknown>).default;
+        if (isTaskDefinition(defaultExport)) {
+          const id = deriveTaskId(file.path, baseDir);
+          tasks.push({
+            id,
+            name: defaultExport.name || id,
+            filePath: file.path,
+            exportName: "default",
+            definition: defaultExport,
+          });
 
-            if (debug) {
-              logger.info(`Found task "${id}" in ${file.path} (export: ${exportName})`);
+          if (debug) {
+            logger.info(`Found task "${id}" in ${file.path} (export: default)`);
+          }
+        } else {
+          // Fallback: check named exports
+          for (const [exportName, value] of Object.entries(module)) {
+            if (exportName === "default") continue;
+            if (isTaskDefinition(value)) {
+              const id = deriveTaskId(file.path, baseDir);
+              tasks.push({
+                id,
+                name: value.name || id,
+                filePath: file.path,
+                exportName,
+                definition: value,
+              });
+
+              if (debug) {
+                logger.info(`Found task "${id}" in ${file.path} (export: ${exportName})`);
+              }
+              break; // Only take the first valid named export per file
             }
-            break; // Only take the first valid export per file
           }
         }
       } catch (error) {
@@ -204,6 +214,10 @@ export async function discoverTasks(
 
 /**
  * Find a specific task by ID
+ *
+ * TODO: Optimise by short-circuiting discovery once the target task is found
+ * instead of discovering all tasks first. This is consistent with the workflow
+ * pattern but could be improved for large projects with many task files.
  */
 export async function findTaskById(
   taskId: string,

--- a/src/task/index.ts
+++ b/src/task/index.ts
@@ -1,0 +1,10 @@
+export type { TaskContext, TaskDefinition } from "./types.ts";
+export { isTaskDefinition } from "./types.ts";
+export { discoverTasks, findTaskById, deriveTaskId } from "./discovery.ts";
+export type {
+  DiscoveredTask,
+  TaskDiscoveryOptions,
+  TaskDiscoveryResult,
+} from "./discovery.ts";
+export { runTask } from "./runner.ts";
+export type { RunTaskOptions, TaskRunResult } from "./runner.ts";

--- a/src/task/index.ts
+++ b/src/task/index.ts
@@ -1,10 +1,6 @@
 export type { TaskContext, TaskDefinition } from "./types.ts";
 export { isTaskDefinition } from "./types.ts";
-export { discoverTasks, findTaskById, deriveTaskId } from "./discovery.ts";
-export type {
-  DiscoveredTask,
-  TaskDiscoveryOptions,
-  TaskDiscoveryResult,
-} from "./discovery.ts";
+export { deriveTaskId, discoverTasks, findTaskById } from "./discovery.ts";
+export type { DiscoveredTask, TaskDiscoveryOptions, TaskDiscoveryResult } from "./discovery.ts";
 export { runTask } from "./runner.ts";
 export type { RunTaskOptions, TaskRunResult } from "./runner.ts";

--- a/src/task/runner.test.ts
+++ b/src/task/runner.test.ts
@@ -1,0 +1,105 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { runTask } from "./runner.ts";
+import type { DiscoveredTask } from "./discovery.ts";
+import type { TaskDefinition } from "./types.ts";
+
+function makeTask(definition: TaskDefinition, id = "test-task"): DiscoveredTask {
+  return {
+    id,
+    name: definition.name || id,
+    filePath: `tasks/${id}.ts`,
+    exportName: "default",
+    definition,
+  };
+}
+
+describe("src/task/runner", () => {
+  describe("runTask", () => {
+    it("should return success with the task result", async () => {
+      const task = makeTask({
+        name: "simple",
+        run: () => ({ count: 42 }),
+      });
+
+      const result = await runTask({ task });
+
+      assertEquals(result.success, true);
+      assertEquals(result.result, { count: 42 });
+      assertEquals(typeof result.durationMs, "number");
+      assertEquals(result.error, undefined);
+    });
+
+    it("should handle async tasks", async () => {
+      const task = makeTask({
+        name: "async-task",
+        run: async () => {
+          return "done";
+        },
+      });
+
+      const result = await runTask({ task });
+
+      assertEquals(result.success, true);
+      assertEquals(result.result, "done");
+    });
+
+    it("should return failure when task throws", async () => {
+      const task = makeTask({
+        name: "failing-task",
+        run: () => {
+          throw new Error("something went wrong");
+        },
+      });
+
+      const result = await runTask({ task });
+
+      assertEquals(result.success, false);
+      assertEquals(result.error, "something went wrong");
+      assertEquals(result.result, undefined);
+      assertEquals(typeof result.durationMs, "number");
+    });
+
+    it("should return failure when async task rejects", async () => {
+      const task = makeTask({
+        name: "rejecting-task",
+        run: async () => {
+          throw new Error("async failure");
+        },
+      });
+
+      const result = await runTask({ task });
+
+      assertEquals(result.success, false);
+      assertEquals(result.error, "async failure");
+    });
+
+    it("should pass config to task context", async () => {
+      let receivedConfig: Record<string, unknown> = {};
+      const task = makeTask({
+        run: (ctx) => {
+          receivedConfig = ctx.config;
+          return null;
+        },
+      });
+
+      await runTask({ task, config: { key: "value" } });
+
+      assertEquals(receivedConfig, { key: "value" });
+    });
+
+    it("should pass projectId to task context", async () => {
+      let receivedProjectId: string | undefined;
+      const task = makeTask({
+        run: (ctx) => {
+          receivedProjectId = ctx.projectId;
+          return null;
+        },
+      });
+
+      await runTask({ task, projectId: "proj-123" });
+
+      assertEquals(receivedProjectId, "proj-123");
+    });
+  });
+});

--- a/src/task/runner.ts
+++ b/src/task/runner.ts
@@ -56,6 +56,9 @@ export async function runTask(options: RunTaskOptions): Promise<TaskRunResult> {
     logger.info(`Running task "${task.id}" (${task.name})`);
   }
 
+  // TODO: For cloud execution (Jobs/CronJobs), filter env vars to prevent
+  // leaking infrastructure secrets to user code. Accept an allowlist of
+  // env var names in RunTaskOptions and only pass those through.
   const ctx: TaskContext = {
     env: { ...Deno.env.toObject() },
     config,

--- a/src/task/runner.ts
+++ b/src/task/runner.ts
@@ -1,0 +1,82 @@
+/**
+ * Task Runner
+ *
+ * Executes a discovered task by calling its run() function
+ * with the appropriate context.
+ */
+
+import { logger as baseLogger } from "#veryfront/utils";
+import type { DiscoveredTask } from "./discovery.ts";
+import type { TaskContext } from "./types.ts";
+
+const logger = baseLogger.component("task-runner");
+
+/**
+ * Options for running a task
+ */
+export interface RunTaskOptions {
+  /** The discovered task to run */
+  task: DiscoveredTask;
+
+  /** Additional config to pass to the task */
+  config?: Record<string, unknown>;
+
+  /** Project ID (for cloud context) */
+  projectId?: string;
+
+  /** Enable debug logging */
+  debug?: boolean;
+}
+
+/**
+ * Result of running a task
+ */
+export interface TaskRunResult {
+  /** Whether the task completed successfully */
+  success: boolean;
+
+  /** Return value from the task's run() */
+  result?: unknown;
+
+  /** Error if the task failed */
+  error?: string;
+
+  /** Execution duration in milliseconds */
+  durationMs: number;
+}
+
+/**
+ * Run a task with the given options
+ */
+export async function runTask(options: RunTaskOptions): Promise<TaskRunResult> {
+  const { task, config = {}, projectId, debug = false } = options;
+  const start = Date.now();
+
+  if (debug) {
+    logger.info(`Running task "${task.id}" (${task.name})`);
+  }
+
+  const ctx: TaskContext = {
+    env: { ...Deno.env.toObject() },
+    config,
+    projectId,
+  };
+
+  try {
+    const result = await task.definition.run(ctx);
+    const durationMs = Date.now() - start;
+
+    if (debug) {
+      logger.info(`Task "${task.id}" completed in ${durationMs}ms`);
+    }
+
+    return { success: true, result, durationMs };
+  } catch (error) {
+    const durationMs = Date.now() - start;
+    const errorMsg = error instanceof Error ? error.message : String(error);
+
+    logger.error(`Task "${task.id}" failed: ${errorMsg}`);
+
+    return { success: false, error: errorMsg, durationMs };
+  }
+}

--- a/src/task/runner.ts
+++ b/src/task/runner.ts
@@ -59,12 +59,12 @@ export async function runTask(options: RunTaskOptions): Promise<TaskRunResult> {
     logger.info(`Running task "${task.id}" (${task.name})`);
   }
 
-  const allEnv = Deno.env.toObject();
-  const env = envAllowlist
-    ? Object.fromEntries(
-      envAllowlist.filter((k) => k in allEnv).map((k) => [k, allEnv[k]]),
-    )
-    : { ...allEnv };
+  const env: Record<string, string> = { ...Deno.env.toObject() };
+  if (envAllowlist) {
+    for (const k of Object.keys(env)) {
+      if (!envAllowlist.includes(k)) delete env[k];
+    }
+  }
 
   const ctx: TaskContext = {
     env,

--- a/src/task/runner.ts
+++ b/src/task/runner.ts
@@ -56,9 +56,9 @@ export async function runTask(options: RunTaskOptions): Promise<TaskRunResult> {
     logger.info(`Running task "${task.id}" (${task.name})`);
   }
 
-  // TODO: For cloud execution (Jobs/CronJobs), filter env vars to prevent
-  // leaking infrastructure secrets to user code. Accept an allowlist of
-  // env var names in RunTaskOptions and only pass those through.
+  // TODO(@kojiwakayama): For cloud execution (Jobs/CronJobs), filter env vars
+  // to prevent leaking infrastructure secrets to user code. Accept an allowlist
+  // of env var names in RunTaskOptions and only pass those through.
   const ctx: TaskContext = {
     env: { ...Deno.env.toObject() },
     config,

--- a/src/task/runner.ts
+++ b/src/task/runner.ts
@@ -24,6 +24,9 @@ export interface RunTaskOptions {
   /** Project ID (for cloud context) */
   projectId?: string;
 
+  /** If set, only these env var names are passed to the task. */
+  envAllowlist?: string[];
+
   /** Enable debug logging */
   debug?: boolean;
 }
@@ -49,18 +52,22 @@ export interface TaskRunResult {
  * Run a task with the given options
  */
 export async function runTask(options: RunTaskOptions): Promise<TaskRunResult> {
-  const { task, config = {}, projectId, debug = false } = options;
+  const { task, config = {}, projectId, envAllowlist, debug = false } = options;
   const start = Date.now();
 
   if (debug) {
     logger.info(`Running task "${task.id}" (${task.name})`);
   }
 
-  // TODO(@kojiwakayama): For cloud execution (Jobs/CronJobs), filter env vars
-  // to prevent leaking infrastructure secrets to user code. Accept an allowlist
-  // of env var names in RunTaskOptions and only pass those through.
+  const allEnv = Deno.env.toObject();
+  const env = envAllowlist
+    ? Object.fromEntries(
+      envAllowlist.filter((k) => k in allEnv).map((k) => [k, allEnv[k]]),
+    )
+    : { ...allEnv };
+
   const ctx: TaskContext = {
-    env: { ...Deno.env.toObject() },
+    env,
     config,
     projectId,
   };

--- a/src/task/types.ts
+++ b/src/task/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Task Types
+ *
+ * Type definitions for the task execution system.
+ * Tasks are user-defined functions in `tasks/` that can run
+ * locally via `veryfront task <name>` or in the cloud as Jobs/CronJobs.
+ */
+
+/**
+ * Context passed to task run() function
+ */
+export interface TaskContext {
+  /** Environment variables */
+  env: Record<string, string>;
+  /** Job config (when run as a cloud job) */
+  config: Record<string, unknown>;
+  /** Project ID (when run as a cloud job) */
+  projectId?: string;
+}
+
+/**
+ * Task definition exported from a tasks/ file
+ */
+export interface TaskDefinition {
+  /** Human-readable name */
+  name?: string;
+  /** Task description */
+  description?: string;
+  /** The function to execute */
+  run: (ctx: TaskContext) => Promise<unknown> | unknown;
+}

--- a/src/task/types.ts
+++ b/src/task/types.ts
@@ -29,3 +29,12 @@ export interface TaskDefinition {
   /** The function to execute */
   run: (ctx: TaskContext) => Promise<unknown> | unknown;
 }
+
+/**
+ * Type guard: checks if a value looks like a TaskDefinition
+ */
+export function isTaskDefinition(value: unknown): value is TaskDefinition {
+  if (!value || typeof value !== "object") return false;
+  const obj = value as Record<string, unknown>;
+  return typeof obj.run === "function";
+}


### PR DESCRIPTION
## Summary
- Introduces `tasks/` directory convention for user-defined task files
- Adds task discovery handler to the discovery engine
- Implements `veryfront task <name>` CLI command for local task execution

## New files
- `src/task/types.ts` — TaskContext and TaskDefinition interfaces
- `src/task/discovery.ts` — task file scanning and module loading
- `src/task/runner.ts` — task execution with context injection
- `src/discovery/handlers/task-handler.ts` — discovery engine handler
- `cli/commands/task/` — CLI command (handler, command, help, index)

## Modified files
- `cli/router.ts` — register task command
- `src/discovery/types.ts` — add taskDirs config and tasks result
- `src/discovery/discovery-engine.ts` — integrate task handler
- `src/discovery/handlers/index.ts` — export task handler

## Test plan
- [ ] `deno check` passes
- [ ] `deno task test` passes
- [ ] Create `tasks/hello.ts` with `run()` export, run `veryfront task hello`
- [ ] Run `veryfront task` without args to list available tasks