### PR TITLE
fix: fix dnt build and bump version to 0.1.23

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -186,16 +186,6 @@ await build({
 			"dnt polyfill process.argv[1] fix",
 		);
 
-		// Bake version into embedded deno.js so VERSION constant works without env var.
-		// The npm package reads version from this embedded config, and without this fix
-		// it would use the stale version from the original deno.json at build time.
-		patchFile(
-			"./npm/esm/deno.js",
-			/"version":\s*"[^"]*"/,
-			`"version": "${version}"`,
-			"embedded deno.js version",
-		);
-
 		// Copy postinstall script
 		await Deno.mkdir("./npm/scripts", { recursive: true });
 		await Deno.copyFile("./scripts/postinstall.js", "./npm/scripts/postinstall.js");
@@ -259,14 +249,25 @@ function patchFile(
 	console.log(`📝 Patched ${description} in ${path}`);
 }
 
-/** Parse esm.sh URLs from deno.json imports into dnt mappings. */
+/**
+ * Parse esm.sh URLs from deno.json imports into dnt mappings.
+ * Only includes imports that dnt actually encounters in the build graph.
+ * Type-only packages (@types/*, csstype) and client-only imports (react-dom,
+ * react-dom/client) are excluded — dnt errors on unused mappings.
+ */
 function buildEsmShMappings(
 	imports: Record<string, string>,
 ): Record<string, { name: string; version: string; subPath?: string }> {
 	const mappings: Record<string, { name: string; version: string; subPath?: string }> = {};
 
-	for (const url of Object.values(imports)) {
+	for (const [key, url] of Object.entries(imports)) {
 		if (!url.startsWith("https://esm.sh/")) continue;
+
+		// Skip packages not reached from npm entry points. dnt errors on unused mappings.
+		// - @types/* and csstype: type-only, never in JS output
+		// - react-dom (base) and react-dom/client: client-side only, not in server build graph
+		if (key.startsWith("@types/") || key === "csstype") continue;
+		if (key === "react-dom" || key === "react-dom/client") continue;
 
 		// Strip prefix and query params: "react@19.1.1/jsx-runtime"
 		const pathPart = url.replace("https://esm.sh/", "").split("?")[0]!;


### PR DESCRIPTION
## Summary
- Filter esm.sh mappings in `buildEsmShMappings()` to exclude packages not in the dnt build graph (`@types/*`, `csstype`, `react-dom` base, `react-dom/client`). dnt errors on unused mappings since PR #422 switched from hand-curated mappings to auto-generation.
- Remove stale `deno.js` version patch — dnt already outputs the correct version from `deno.json`, so the patch was a no-op that threw.
- Bump version from 0.1.22 to 0.1.23.

## Test plan
- [x] `deno run -A scripts/build/build-npm-dnt.ts` completes successfully locally
- [ ] CI pipeline passes (format, lint, typecheck, tests)
- [ ] Release job succeeds on merge (builds npm package + binaries)