### PR TITLE
fix: add path traversal validation to snippet and markdown preview handlers

### DIFF
--- a/src/server/handlers/preview/markdown-preview.handler.ts
+++ b/src/server/handlers/preview/markdown-preview.handler.ts
@@ -17,6 +17,7 @@ import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts"
 import { getEnv } from "#veryfront/platform/compat/process.ts";
 import { tryNotFoundFallback } from "../request/ssr/not-found-fallback.ts";
 import { generateMarkdownHtml } from "./markdown-html-generator.ts";
+import { validatePathSync } from "#veryfront/security";
 
 const logger = serverLogger.component("markdown-preview-handler");
 
@@ -45,6 +46,16 @@ export class MarkdownPreviewHandler extends BaseHandler {
     }
 
     const filePath = pathname.replace(/^\//, "");
+
+    const pathResult = validatePathSync(filePath, {
+      baseDir: ctx.projectDir,
+    });
+
+    if (!pathResult.valid) {
+      logger.warn("Path traversal blocked in markdown preview", { pathname, filePath });
+      return this.continue();
+    }
+
     const fsAdapter = ctx.adapter.fs;
 
     logger.debug("Attempting to serve", {

--- a/src/server/handlers/request/snippet.handler.test.ts
+++ b/src/server/handlers/request/snippet.handler.test.ts
@@ -1,0 +1,59 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { validatePathSync } from "#veryfront/security";
+
+/**
+ * Tests that validatePathSync correctly blocks path traversal for paths
+ * produced by SnippetHandler.resolveFilePath(). The handler validates
+ * resolved paths before passing them to fs.readFile().
+ *
+ * Note: The URL constructor normalizes basic `..` traversals (e.g.,
+ * `/@/../../etc/passwd` → `/etc/passwd`) before the handler sees them.
+ * These tests verify the validatePathSync safety net catches traversals
+ * that survive URL normalization or arrive via non-browser HTTP clients.
+ */
+describe("snippet handler path validation", () => {
+  const baseDir = "/project";
+
+  describe("blocks traversal in resolved paths", () => {
+    it("rejects ../../etc/passwd (from /@/ prefix)", () => {
+      // resolveFilePath("/@/../../etc/passwd") → "../../etc/passwd"
+      const result = validatePathSync("../../etc/passwd", { baseDir });
+      assertEquals(result.valid, false);
+    });
+
+    it("rejects components/../../../etc/passwd (from /@components/ prefix)", () => {
+      // resolveFilePath("/@components/../../../etc/passwd") → "components/../../../etc/passwd"
+      const result = validatePathSync("components/../../../etc/passwd", { baseDir });
+      assertEquals(result.valid, false);
+    });
+
+    it("rejects paths with null bytes", () => {
+      const result = validatePathSync("components/foo\0bar", { baseDir });
+      assertEquals(result.valid, false);
+    });
+
+    it("rejects deeply nested traversal", () => {
+      const result = validatePathSync("a/b/c/../../../../etc/passwd", { baseDir });
+      assertEquals(result.valid, false);
+    });
+  });
+
+  describe("allows valid paths", () => {
+    it("allows components/button.snippet.mdx", () => {
+      const result = validatePathSync("components/button.snippet.mdx", { baseDir });
+      assertEquals(result.valid, true);
+    });
+
+    it("allows nested component paths", () => {
+      const result = validatePathSync("components/ui/card.snippet.mdx", { baseDir });
+      assertEquals(result.valid, true);
+    });
+
+    it("allows paths from /@/ prefix", () => {
+      // resolveFilePath("/@/components/button.mdx") → "components/button.mdx"
+      const result = validatePathSync("components/button.mdx", { baseDir });
+      assertEquals(result.valid, true);
+    });
+  });
+});

--- a/src/server/handlers/request/snippet.handler.ts
+++ b/src/server/handlers/request/snippet.handler.ts
@@ -4,8 +4,9 @@ import { serverLogger } from "#veryfront/utils";
 import { renderSnippet } from "#veryfront/rendering/snippet-renderer.ts";
 import { getErrorMessage } from "#veryfront/errors/veryfront-error.ts";
 import { VeryfrontError } from "#veryfront/errors/types.ts";
-import { FILE_NOT_FOUND } from "#veryfront/errors/error-registry.ts";
+import { FILE_NOT_FOUND, SECURITY_VIOLATION } from "#veryfront/errors/error-registry.ts";
 import { createErrorResponse } from "#veryfront/errors/http-error.ts";
+import { validatePathSync } from "#veryfront/security";
 
 const logger = serverLogger.component("snippet-handler");
 
@@ -32,6 +33,18 @@ export class SnippetHandler extends BaseHandler {
     });
 
     const filePath = this.resolveFilePath(pathname);
+
+    const pathResult = validatePathSync(filePath, {
+      baseDir: ctx.projectDir,
+    });
+
+    if (!pathResult.valid) {
+      logger.warn("Path traversal blocked in snippet request", { pathname, filePath });
+      const error = SECURITY_VIOLATION.create({
+        detail: "Invalid snippet path",
+      });
+      return Promise.resolve({ response: createErrorResponse(error) });
+    }
 
     logger.debug("Resolved file path", { filePath });
 


### PR DESCRIPTION
## Summary
- Added `validatePathSync()` from the security module to both `SnippetHandler` and `MarkdownPreviewHandler`
- Previously, user-controlled URL paths were passed directly to `fs.readFile()` without checking for `..` traversal
- Snippet handler now returns 403 for invalid paths; markdown preview handler skips to the next handler
- Uses the existing `resolvePathSegments()` + `isWithinDirectory()` chain for robust traversal detection

## Changes
- `src/server/handlers/request/snippet.handler.ts` — validate path before `readFile()`
- `src/server/handlers/preview/markdown-preview.handler.ts` — validate path before `readFile()`
- `src/server/handlers/request/snippet.handler.test.ts` — new tests

## Test plan
- [x] Rejects `../../etc/passwd` traversal
- [x] Rejects `components/../../../etc/passwd` traversal
- [x] Rejects null bytes in paths
- [x] Rejects deeply nested traversal
- [x] Allows valid component paths
- [x] Allows nested component paths
- [x] Typechecks and lints clean