### PR TITLE
fix: validate mermaid SVG before dangerouslySetInnerHTML injection

### DIFF
--- a/src/react/components/ai/markdown.tsx
+++ b/src/react/components/ai/markdown.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { cn } from "./theme.ts";
 import { isBrowserEnvironment } from "#veryfront/platform/compat/runtime.ts";
+import { validateTrustedHtml } from "#veryfront/security/client/html-sanitizer.ts";
 
 export interface MarkdownProps {
   /** Markdown content to render */
@@ -72,7 +73,7 @@ function MermaidDiagram({ code }: { code: string }): React.ReactElement {
         const { svg: renderedSvg } = await mermaid.default.render(id, code);
 
         if (cancelled) return;
-        setSvg(renderedSvg);
+        setSvg(validateTrustedHtml(renderedSvg, { strict: true }));
         setError("");
       } catch (error) {
         if (cancelled) return;

--- a/src/security/client/html-sanitizer.test.ts
+++ b/src/security/client/html-sanitizer.test.ts
@@ -1,0 +1,88 @@
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { validateTrustedHtml } from "./html-sanitizer.ts";
+
+describe("validateTrustedHtml", () => {
+  describe("allows safe HTML", () => {
+    it("passes clean SVG through", () => {
+      const svg = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="100" height="100"/></svg>';
+      assertEquals(validateTrustedHtml(svg, { strict: true }), svg);
+    });
+
+    it("passes normal HTML elements", () => {
+      const html = "<div><p>Hello <strong>world</strong></p></div>";
+      assertEquals(validateTrustedHtml(html, { strict: true }), html);
+    });
+  });
+
+  describe("blocks inline scripts", () => {
+    it("throws on script tags in SVG", () => {
+      const svg = '<svg><script>alert("xss")</script></svg>';
+      assertThrows(
+        () => validateTrustedHtml(svg, { strict: true }),
+        Error,
+        "inline script",
+      );
+    });
+
+    it("throws on script tags with attributes", () => {
+      const svg = '<svg><script type="text/javascript">alert(1)</script></svg>';
+      assertThrows(
+        () => validateTrustedHtml(svg, { strict: true }),
+        Error,
+        "inline script",
+      );
+    });
+  });
+
+  describe("blocks javascript: URLs", () => {
+    it("throws on javascript: in href", () => {
+      const svg = '<svg><a href="javascript:alert(1)"><text>click</text></a></svg>';
+      assertThrows(
+        () => validateTrustedHtml(svg, { strict: true }),
+        Error,
+        "javascript: URL",
+      );
+    });
+  });
+
+  describe("blocks event handlers", () => {
+    it("throws on onload attribute", () => {
+      const svg = '<svg onload="alert(1)"><rect/></svg>';
+      assertThrows(
+        () => validateTrustedHtml(svg, { strict: true }),
+        Error,
+        "event handler",
+      );
+    });
+
+    it("throws on onerror attribute", () => {
+      const html = '<img onerror="alert(1)" src="x">';
+      assertThrows(
+        () => validateTrustedHtml(html, { strict: true }),
+        Error,
+        "event handler",
+      );
+    });
+
+    it("throws on onclick attribute", () => {
+      const svg = '<svg><rect onclick="alert(1)"/></svg>';
+      assertThrows(
+        () => validateTrustedHtml(svg, { strict: true }),
+        Error,
+        "event handler",
+      );
+    });
+  });
+
+  describe("blocks data: HTML URLs", () => {
+    it("throws on data:text/html", () => {
+      const html = '<iframe src="data: text/html,<h1>injected</h1>">';
+      assertThrows(
+        () => validateTrustedHtml(html, { strict: true }),
+        Error,
+        "data: HTML URL",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `validateTrustedHtml(renderedSvg, { strict: true })` before injecting Mermaid SVG output via `dangerouslySetInnerHTML` in the `MermaidDiagram` component
- Uses the existing HTML sanitizer which detects inline `<script>` tags, `javascript:` URLs, event handler attributes, and `data:` HTML URLs
- If suspicious patterns are detected, the validation throws and the existing error handler displays the error message instead of rendering unsafe HTML

## Context
Mermaid initializes with `securityLevel: "strict"` which provides primary protection. This change adds defense-in-depth in case Mermaid's filtering is ever bypassed.

## Test plan
- [x] Typechecks clean
- [x] Lints clean
- [x] Normal mermaid diagrams render as before (validateTrustedHtml passes clean SVG through)
- [x] SVG containing `<script>`, `javascript:`, or event handlers would be caught and shown as error