### PR TITLE
fix: remove sensitive data from token store console output

### DIFF
--- a/cli/templates/integrations/_base/files/lib/token-store.ts
+++ b/cli/templates/integrations/_base/files/lib/token-store.ts
@@ -97,8 +97,8 @@ export async function decryptToken(encrypted: string): Promise<OAuthToken | null
     const decrypted = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, cryptoKey, ciphertext);
 
     return JSON.parse(new TextDecoder().decode(decrypted)) as OAuthToken;
-  } catch (error) {
-    console.error("[Token Store] Decryption failed:", error);
+  } catch {
+    console.error("[Token Store] Decryption failed");
     return null;
   }
 }
@@ -135,7 +135,6 @@ function getEncryptionKey(): Uint8Array | null {
 
   if (!globalStore[AUTO_KEY_STORAGE]) {
     globalStore[AUTO_KEY_STORAGE] = generateEncryptionKey();
-    console.log("[Token Store] Auto-generated encryption key for this session");
   }
 
   return hexToKeyBytes(globalStore[AUTO_KEY_STORAGE] as string);

--- a/cli/token-store-template.test.ts
+++ b/cli/token-store-template.test.ts
@@ -1,11 +1,14 @@
 import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
-import { describe, it, afterEach } from "#veryfront/testing/bdd.ts";
+import { describe, it, beforeEach, afterEach } from "#veryfront/testing/bdd.ts";
 import {
   encryptToken,
   decryptToken,
   generateEncryptionKey,
   type OAuthToken,
 } from "./templates/integrations/_base/files/lib/token-store.ts";
+
+const AUTO_KEY_STORAGE = "__veryfront_auto_encryption_key__";
+const globalStore = globalThis as Record<string, unknown>;
 
 /**
  * Tests that the token store does not leak sensitive data via console output.
@@ -21,12 +24,12 @@ describe("token store console output", () => {
   let logCalls: unknown[][] = [];
   let errorCalls: unknown[][] = [];
 
-  function spyConsole() {
+  beforeEach(() => {
     logCalls = [];
     errorCalls = [];
     console.log = (...args: unknown[]) => logCalls.push(args);
     console.error = (...args: unknown[]) => errorCalls.push(args);
-  }
+  });
 
   afterEach(() => {
     console.log = originalLog;
@@ -34,7 +37,8 @@ describe("token store console output", () => {
   });
 
   it("does not log auto-generated encryption key to console", async () => {
-    spyConsole();
+    // Clear cached key to force regeneration code path
+    delete globalStore[AUTO_KEY_STORAGE];
 
     // Trigger encryption which causes auto-key generation
     const token: OAuthToken = { accessToken: "test-access-token" };
@@ -52,8 +56,6 @@ describe("token store console output", () => {
   });
 
   it("does not include error object in decryption failure log", async () => {
-    spyConsole();
-
     // Pass corrupted encrypted data to trigger decryption failure
     const result = await decryptToken("encrypted:aW52YWxpZC1kYXRh");
 

--- a/cli/token-store-template.test.ts
+++ b/cli/token-store-template.test.ts
@@ -1,8 +1,8 @@
 import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
-import { describe, it, beforeEach, afterEach } from "#veryfront/testing/bdd.ts";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
-  encryptToken,
   decryptToken,
+  encryptToken,
   generateEncryptionKey,
   type OAuthToken,
 } from "./templates/integrations/_base/files/lib/token-store.ts";

--- a/cli/token-store-template.test.ts
+++ b/cli/token-store-template.test.ts
@@ -1,0 +1,111 @@
+import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
+import { describe, it, afterEach } from "#veryfront/testing/bdd.ts";
+import {
+  encryptToken,
+  decryptToken,
+  generateEncryptionKey,
+  type OAuthToken,
+} from "./templates/integrations/_base/files/lib/token-store.ts";
+
+/**
+ * Tests that the token store does not leak sensitive data via console output.
+ *
+ * Verifies:
+ * - Auto-generated encryption keys are not logged
+ * - Decryption failures do not include raw error objects or token data
+ * - Encrypt/decrypt roundtrip still works correctly
+ */
+describe("token store console output", () => {
+  const originalLog = console.log;
+  const originalError = console.error;
+  let logCalls: unknown[][] = [];
+  let errorCalls: unknown[][] = [];
+
+  function spyConsole() {
+    logCalls = [];
+    errorCalls = [];
+    console.log = (...args: unknown[]) => logCalls.push(args);
+    console.error = (...args: unknown[]) => errorCalls.push(args);
+  }
+
+  afterEach(() => {
+    console.log = originalLog;
+    console.error = originalError;
+  });
+
+  it("does not log auto-generated encryption key to console", async () => {
+    spyConsole();
+
+    // Trigger encryption which causes auto-key generation
+    const token: OAuthToken = { accessToken: "test-access-token" };
+    await encryptToken(token);
+
+    // No console.log calls should mention key generation
+    const logMessages = logCalls.map((args) => args.join(" "));
+    for (const msg of logMessages) {
+      assertEquals(
+        msg.includes("encryption key"),
+        false,
+        `console.log should not mention encryption key, got: "${msg}"`,
+      );
+    }
+  });
+
+  it("does not include error object in decryption failure log", async () => {
+    spyConsole();
+
+    // Pass corrupted encrypted data to trigger decryption failure
+    const result = await decryptToken("encrypted:aW52YWxpZC1kYXRh");
+
+    assertEquals(result, null);
+
+    // Find the "Decryption failed" error call
+    const failureCalls = errorCalls.filter(
+      (args) => typeof args[0] === "string" && args[0].includes("Decryption failed"),
+    );
+
+    // Should have logged the failure
+    assertNotEquals(failureCalls.length, 0, "Should log decryption failure");
+
+    // Should only contain the message string, no error object
+    for (const call of failureCalls) {
+      assertEquals(
+        call.length,
+        1,
+        `Decryption failure log should only contain message string, got ${call.length} args`,
+      );
+    }
+  });
+});
+
+describe("token store encrypt/decrypt roundtrip", () => {
+  it("encrypts and decrypts a token correctly", async () => {
+    const token: OAuthToken = {
+      accessToken: "access-123",
+      refreshToken: "refresh-456",
+      expiresAt: Date.now() + 3600_000,
+      tokenType: "Bearer",
+      scope: "read write",
+    };
+
+    const encrypted = await encryptToken(token);
+    assertEquals(encrypted.startsWith("encrypted:"), true);
+
+    const decrypted = await decryptToken(encrypted);
+    assertEquals(decrypted?.accessToken, token.accessToken);
+    assertEquals(decrypted?.refreshToken, token.refreshToken);
+    assertEquals(decrypted?.tokenType, token.tokenType);
+    assertEquals(decrypted?.scope, token.scope);
+  });
+
+  it("returns null for invalid JSON in unencrypted data", async () => {
+    const result = await decryptToken("not-valid-json{{{");
+    assertEquals(result, null);
+  });
+
+  it("generates 64-character hex encryption keys", () => {
+    const key = generateEncryptionKey();
+    assertEquals(key.length, 64);
+    assertEquals(/^[0-9a-f]{64}$/.test(key), true);
+  });
+});


### PR DESCRIPTION
## Summary

- Remove `console.log` that announced auto-generated encryption key creation, which could leak security-relevant operational details
- Strip raw error object from decryption failure `console.error` to prevent token data or internal stack traces from being exposed in logs

## Test plan

- [x] Verify `getEncryptionKey()` no longer logs when auto-generating a key
- [x] Verify `decryptToken()` still logs a failure message on decryption error but without the raw error object
- [x] Confirm existing token store functionality is unchanged