### PR TITLE
fix: prevent length leakage in constant-time string comparison

### DIFF
--- a/src/security/utils/constant-time.test.ts
+++ b/src/security/utils/constant-time.test.ts
@@ -31,4 +31,44 @@ describe("constantTimeEqual", () => {
     expect(constantTimeEqual(`Basic ${encoded}`, `Basic ${encoded}`)).toBe(true);
     expect(constantTimeEqual(`Basic ${encoded}`, "Basic wrong")).toBe(false);
   });
+
+  it("should reject when only lengths differ but content prefix matches", () => {
+    expect(constantTimeEqual("abc", "abcdef")).toBe(false);
+    expect(constantTimeEqual("abcdef", "abc")).toBe(false);
+  });
+
+  it("should not have timing difference between length mismatch and content mismatch", () => {
+    const secret = "a".repeat(1000);
+    const sameLenWrong = "b".repeat(1000);
+    const diffLenWrong = "b".repeat(500);
+
+    const iterations = 5000;
+
+    // Warm up JIT
+    for (let i = 0; i < 1000; i++) {
+      constantTimeEqual(secret, sameLenWrong);
+      constantTimeEqual(secret, diffLenWrong);
+    }
+
+    // Measure same-length comparison
+    const t1 = performance.now();
+    for (let i = 0; i < iterations; i++) {
+      constantTimeEqual(secret, sameLenWrong);
+    }
+    const sameLenTime = performance.now() - t1;
+
+    // Measure different-length comparison
+    const t2 = performance.now();
+    for (let i = 0; i < iterations; i++) {
+      constantTimeEqual(secret, diffLenWrong);
+    }
+    const diffLenTime = performance.now() - t2;
+
+    // The different-length comparison should take at least as long as same-length
+    // (it iterates over max length). Allow generous margin for JIT variance.
+    // The key assertion: diffLenTime should NOT be significantly faster than sameLenTime,
+    // which would indicate an early-return on length mismatch.
+    const ratio = diffLenTime / sameLenTime;
+    expect(ratio).toBeGreaterThan(0.5);
+  });
 });

--- a/src/security/utils/constant-time.ts
+++ b/src/security/utils/constant-time.ts
@@ -4,17 +4,12 @@ export function constantTimeEqual(a: string, b: string): boolean {
   const aBuf = encoder.encode(a);
   const bBuf = encoder.encode(b);
 
-  if (aBuf.length !== bBuf.length) {
-    let xor = 1;
-    for (let i = 0; i < aBuf.length; i++) {
-      xor |= aBuf[i]! ^ aBuf[i]!;
-    }
-    return xor === 0;
+  const len = Math.max(aBuf.length, bBuf.length);
+  let xor = aBuf.length ^ bBuf.length;
+
+  for (let i = 0; i < len; i++) {
+    xor |= (aBuf[i] ?? 0) ^ (bBuf[i] ?? 0);
   }
 
-  let xor = 0;
-  for (let i = 0; i < aBuf.length; i++) {
-    xor |= aBuf[i]! ^ bBuf[i]!;
-  }
   return xor === 0;
 }


### PR DESCRIPTION
## Summary

- Fix timing side-channel in `constantTimeEqual()` that leaked string length information
- The previous implementation had two issues:
  1. Early-return branch for mismatched lengths executed in different time than the equal-length path, leaking length info via timing
  2. The dummy loop XOR'd `aBuf[i] ^ aBuf[i]` (self-comparison, always 0) — a no-op that didn't provide meaningful constant-time behavior
- Replace with a single code path that always iterates over `Math.max(a.length, b.length)`, seeds the XOR accumulator with the length difference, and uses `?? 0` for out-of-bounds bytes


## Test plan

- [x] All existing `constantTimeEqual` tests pass (equal strings, different strings, different lengths, unicode, base64 credentials)
- [x] New test: prefix-matching strings with different lengths are correctly rejected
- [x] New test: timing verification that different-length comparisons do not return significantly faster than same-length comparisons