### PR TITLE
fix: sanitize Basic auth realm to prevent header injection

### DIFF
--- a/src/security/http/auth.test.ts
+++ b/src/security/http/auth.test.ts
@@ -11,8 +11,8 @@ describe("AuthHandler realm sanitization", () => {
     return new AuthHandler();
   }
 
-  function createCtx(realm?: string) {
-    const basic: Record<string, string> = { username: "admin", password: "secret" };
+  function createCtx(realm?: unknown) {
+    const basic: Record<string, unknown> = { username: "admin", password: "secret" };
     if (realm !== undefined) basic.realm = realm;
     return {
       securityConfig: { auth: { basic } },
@@ -21,7 +21,7 @@ describe("AuthHandler realm sanitization", () => {
     };
   }
 
-  async function getWwwAuthenticate(handler: AuthHandler, realm?: string): Promise<string> {
+  async function getWwwAuthenticate(handler: AuthHandler, realm?: unknown): Promise<string> {
     const ctx = createCtx(realm);
     const req = new Request("http://localhost/test");
     const result = await handler.handle(req, ctx as any);
@@ -66,5 +66,11 @@ describe("AuthHandler realm sanitization", () => {
     const handler = createHandler();
     const header = await getWwwAuthenticate(handler);
     expect(header).toBe('Basic realm="Secure Area"');
+  });
+
+  it("coerces non-string realm values to string", async () => {
+    const handler = createHandler();
+    const header = await getWwwAuthenticate(handler, 12345);
+    expect(header).toBe('Basic realm="12345"');
   });
 });

--- a/src/security/http/auth.test.ts
+++ b/src/security/http/auth.test.ts
@@ -1,0 +1,89 @@
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { expect } from "#std/expect.ts";
+import { AuthHandler } from "./auth.ts";
+
+/**
+ * Tests that the AuthHandler sanitizes the Basic auth realm value
+ * to prevent CRLF/header injection via user-configured realm strings.
+ */
+describe("AuthHandler realm sanitization", () => {
+  function createHandler(): AuthHandler {
+    return new AuthHandler();
+  }
+
+  function createCtx(realm: string) {
+    return {
+      securityConfig: {
+        auth: {
+          basic: {
+            username: "admin",
+            password: "secret",
+            realm,
+          },
+        },
+      },
+      adapter: { env: { get: () => "" } },
+      isLocalProject: false,
+    };
+  }
+
+  async function getWwwAuthenticate(handler: AuthHandler, realm: string): Promise<string> {
+    const ctx = createCtx(realm);
+    // Send request with no auth header to trigger 401 with WWW-Authenticate
+    const req = new Request("http://localhost/test");
+    const result = await handler.handle(req, ctx as any);
+    const response = (result as any).response as Response;
+    return response.headers.get("WWW-Authenticate") ?? "";
+  }
+
+  it("passes clean realm values through", async () => {
+    const handler = createHandler();
+    const header = await getWwwAuthenticate(handler, "My App");
+    expect(header).toBe('Basic realm="My App"');
+  });
+
+  it("strips double quotes from realm", async () => {
+    const handler = createHandler();
+    const header = await getWwwAuthenticate(handler, 'break"out');
+    expect(header).toBe('Basic realm="breakout"');
+    expect(header).not.toContain('""');
+  });
+
+  it("strips backslashes from realm", async () => {
+    const handler = createHandler();
+    const header = await getWwwAuthenticate(handler, "back\\slash");
+    expect(header).toBe('Basic realm="backslash"');
+  });
+
+  it("strips CRLF characters from realm", async () => {
+    const handler = createHandler();
+    const header = await getWwwAuthenticate(handler, "line\r\nX-Injected: true");
+    expect(header).toBe('Basic realm="lineX-Injected: true"');
+    expect(header).not.toContain("\r");
+    expect(header).not.toContain("\n");
+  });
+
+  it("strips null bytes and other control characters from realm", async () => {
+    const handler = createHandler();
+    const header = await getWwwAuthenticate(handler, "null\x00byte\x01ctrl");
+    expect(header).toBe('Basic realm="nullbytectrl"');
+  });
+
+  it("uses default realm when none is configured", async () => {
+    const handler = createHandler();
+    const ctx = {
+      securityConfig: {
+        auth: {
+          basic: { username: "admin", password: "secret" },
+        },
+      },
+      adapter: { env: { get: () => "" } },
+      isLocalProject: false,
+    };
+    const req = new Request("http://localhost/test");
+    const result = await handler.handle(req, ctx as any);
+    const response = (result as any).response as Response;
+    const header = response.headers.get("WWW-Authenticate") ?? "";
+    expect(header).toBe('Basic realm="Secure Area"');
+  });
+});

--- a/src/security/http/auth.test.ts
+++ b/src/security/http/auth.test.ts
@@ -11,25 +11,18 @@ describe("AuthHandler realm sanitization", () => {
     return new AuthHandler();
   }
 
-  function createCtx(realm: string) {
+  function createCtx(realm?: string) {
+    const basic: Record<string, string> = { username: "admin", password: "secret" };
+    if (realm !== undefined) basic.realm = realm;
     return {
-      securityConfig: {
-        auth: {
-          basic: {
-            username: "admin",
-            password: "secret",
-            realm,
-          },
-        },
-      },
+      securityConfig: { auth: { basic } },
       adapter: { env: { get: () => "" } },
       isLocalProject: false,
     };
   }
 
-  async function getWwwAuthenticate(handler: AuthHandler, realm: string): Promise<string> {
+  async function getWwwAuthenticate(handler: AuthHandler, realm?: string): Promise<string> {
     const ctx = createCtx(realm);
-    // Send request with no auth header to trigger 401 with WWW-Authenticate
     const req = new Request("http://localhost/test");
     const result = await handler.handle(req, ctx as any);
     const response = (result as any).response as Response;
@@ -71,19 +64,7 @@ describe("AuthHandler realm sanitization", () => {
 
   it("uses default realm when none is configured", async () => {
     const handler = createHandler();
-    const ctx = {
-      securityConfig: {
-        auth: {
-          basic: { username: "admin", password: "secret" },
-        },
-      },
-      adapter: { env: { get: () => "" } },
-      isLocalProject: false,
-    };
-    const req = new Request("http://localhost/test");
-    const result = await handler.handle(req, ctx as any);
-    const response = (result as any).response as Response;
-    const header = response.headers.get("WWW-Authenticate") ?? "";
+    const header = await getWwwAuthenticate(handler);
     expect(header).toBe('Basic realm="Secure Area"');
   });
 });

--- a/src/security/http/auth.ts
+++ b/src/security/http/auth.ts
@@ -35,9 +35,9 @@ function encodeBase64(value: string): string {
   );
 }
 
-function sanitizeRealm(realm: string): string {
+function sanitizeRealm(realm: unknown): string {
   // deno-lint-ignore no-control-regex
-  return realm.replace(/[\x00-\x1f\x7f"\\]/g, "");
+  return String(realm).replace(/[\x00-\x1f\x7f"\\]/g, "");
 }
 
 export class AuthHandler extends BaseHandler {

--- a/src/security/http/auth.ts
+++ b/src/security/http/auth.ts
@@ -36,6 +36,7 @@ function encodeBase64(value: string): string {
 }
 
 function sanitizeRealm(realm: string): string {
+  // deno-lint-ignore no-control-regex
   return realm.replace(/[\x00-\x1f\x7f"\\]/g, "");
 }
 

--- a/src/security/http/auth.ts
+++ b/src/security/http/auth.ts
@@ -35,6 +35,10 @@ function encodeBase64(value: string): string {
   );
 }
 
+function sanitizeRealm(realm: string): string {
+  return realm.replace(/[\x00-\x1f\x7f"\\]/g, "");
+}
+
 export class AuthHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "AuthHandler",
@@ -73,7 +77,7 @@ export class AuthHandler extends BaseHandler {
     if (authConfig?.basic) {
       this.basicUser = authConfig.basic.username;
       this.basicPass = authConfig.basic.password;
-      this.basicRealm = authConfig.basic.realm || "Secure Area";
+      this.basicRealm = sanitizeRealm(authConfig.basic.realm || "Secure Area");
       return;
     }
 


### PR DESCRIPTION
## Summary

- Sanitize the Basic auth `realm` value before interpolating it into the `WWW-Authenticate` header
- A user-configured realm containing `"`, `\`, or CRLF characters could break out of the quoted-string or inject arbitrary HTTP headers
- Add `sanitizeRealm()` that strips control characters (0x00-0x1F, 0x7F), double quotes, and backslashes


## Test plan

- [x] Clean realm values pass through unchanged
- [x] Double quotes are stripped from realm
- [x] Backslashes are stripped from realm
- [x] CRLF characters are stripped (prevents header injection)
- [x] Null bytes and other control characters are stripped
- [x] Default realm "Secure Area" is used when none configured