### PR TITLE
fix: add Referrer-Policy header to security response headers

### DIFF
--- a/src/security/http/response/security-handler.test.ts
+++ b/src/security/http/response/security-handler.test.ts
@@ -230,5 +230,28 @@ describe("security/http/response/security-handler", () => {
       applySecurityHeaders(headers, false, "nonce", null, config);
       assertEquals(headers.get("X-Content-Type-Options"), "custom-value");
     });
+
+    it("should set Referrer-Policy to strict-origin-when-cross-origin by default", () => {
+      const headers = new Headers();
+      applySecurityHeaders(headers, false, "nonce", null);
+      assertEquals(headers.get("Referrer-Policy"), "strict-origin-when-cross-origin");
+    });
+
+    it("should set Referrer-Policy in dev mode", () => {
+      const headers = new Headers();
+      applySecurityHeaders(headers, true, "nonce", null);
+      assertEquals(headers.get("Referrer-Policy"), "strict-origin-when-cross-origin");
+    });
+
+    it("should allow overriding Referrer-Policy via config.headers", () => {
+      const headers = new Headers();
+      const config: SecurityConfig = {
+        headers: {
+          "Referrer-Policy": "no-referrer",
+        },
+      };
+      applySecurityHeaders(headers, false, "nonce", null, config);
+      assertEquals(headers.get("Referrer-Policy"), "no-referrer");
+    });
   });
 });

--- a/src/security/http/response/security-handler.ts
+++ b/src/security/http/response/security-handler.ts
@@ -104,6 +104,11 @@ export function applySecurityHeaders(
   headers.set("Cross-Origin-Resource-Policy", corp);
   if (coep) headers.set("Cross-Origin-Embedder-Policy", coep);
 
+  headers.set(
+    "Referrer-Policy",
+    getHeaderOverride("referrer-policy") ?? "strict-origin-when-cross-origin",
+  );
+
   const extraHeaders = config?.headers;
   if (extraHeaders) {
     for (const [key, value] of Object.entries(extraHeaders)) {


### PR DESCRIPTION
## Summary

- Add `Referrer-Policy: strict-origin-when-cross-origin` to the security headers set by `applySecurityHeaders()`
- Without this header, browsers use their default policy which may leak full URLs (including query params with tokens) to external sites via the Referer header
- The header is set in both dev and production modes, and is overridable via `config.headers`

## Test plan

- [x] Default value is `strict-origin-when-cross-origin` in production
- [x] Default value is `strict-origin-when-cross-origin` in dev mode
- [x] Overridable via `config.headers["Referrer-Policy"]`
- [x] All existing security header tests still pass (35 total)