### PR TITLE
fix: document API token query parameter security risk

### DIFF
--- a/cli/templates/integrations/pipedrive/files/lib/pipedrive-client.ts
+++ b/cli/templates/integrations/pipedrive/files/lib/pipedrive-client.ts
@@ -65,6 +65,11 @@ async function pipedriveFetch<T>(endpoint: string, options: RequestInit = {}): P
   }
 
   const url = new URL(`${PIPEDRIVE_BASE_URL}${endpoint}`);
+  // SECURITY: Pipedrive's v1 API requires the token as a query parameter.
+  // Tokens in query params may be recorded in browser history, server/proxy
+  // access logs, and leaked via the Referer header. The Referrer-Policy
+  // header (set by Veryfront's security middleware) mitigates the Referer leak.
+  // This is an API design limitation — there is no Authorization header alternative.
   url.searchParams.set("api_token", token);
 
   const response = await fetch(url.toString(), {

--- a/cli/templates/integrations/trello/files/lib/trello-client.ts
+++ b/cli/templates/integrations/trello/files/lib/trello-client.ts
@@ -61,6 +61,11 @@ async function trelloFetch<T>(endpoint: string, options: RequestInit = {}): Prom
   }
 
   const url = new URL(`${TRELLO_BASE_URL}${endpoint}`);
+  // SECURITY: Trello's REST API requires key and token as query parameters.
+  // Tokens in query params may be recorded in browser history, server/proxy
+  // access logs, and leaked via the Referer header. The Referrer-Policy
+  // header (set by Veryfront's security middleware) mitigates the Referer leak.
+  // This is an API design limitation — there is no Authorization header alternative.
   url.searchParams.set("key", clientId);
   url.searchParams.set("token", token);
 


### PR DESCRIPTION
## Summary
- **Security fix (M5):** Added `SECURITY:` comments to the Pipedrive and Trello integration template clients documenting the risk of passing API tokens as URL query parameters (browser history, server/proxy logs, Referer header leakage).
- Both APIs require query param authentication — there is no Authorization header alternative, so this is documentation-only.
- Notes that the `Referrer-Policy: strict-origin-when-cross-origin` header (shipped in #440) mitigates the Referer leak vector.

## Test plan
- [x] Documentation-only change — no behavior modifications, no tests needed