### PR TITLE
fix: replace check-then-set lock with atomic Mutex in renderer concurrency

### DIFF
--- a/src/rendering/renderer-concurrency.test.ts
+++ b/src/rendering/renderer-concurrency.test.ts
@@ -1,0 +1,115 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { Mutex } from "./renderer-concurrency.ts";
+
+describe("Mutex", () => {
+  it("acquires immediately when unlocked", async () => {
+    const mutex = new Mutex();
+    const release = await mutex.acquire();
+    assertEquals(typeof release, "function");
+    release();
+  });
+
+  it("serializes concurrent access", async () => {
+    const mutex = new Mutex();
+    const order: number[] = [];
+
+    const release1 = await mutex.acquire();
+    assertEquals(mutex.waiting, 0);
+
+    // Second acquire should queue
+    const p2 = mutex.acquire().then((release) => {
+      order.push(2);
+      release();
+    });
+
+    // Third acquire should also queue
+    const p3 = mutex.acquire().then((release) => {
+      order.push(3);
+      release();
+    });
+
+    assertEquals(mutex.waiting, 2);
+
+    // Release first lock — should wake waiters in order
+    order.push(1);
+    release1();
+
+    await p2;
+    await p3;
+
+    assertEquals(order, [1, 2, 3]);
+  });
+
+  it("allows re-acquisition after release", async () => {
+    const mutex = new Mutex();
+
+    const release1 = await mutex.acquire();
+    release1();
+
+    const release2 = await mutex.acquire();
+    release2();
+
+    // Should not deadlock or throw
+    assertEquals(mutex.waiting, 0);
+  });
+
+  it("times out when lock is held too long", async () => {
+    const mutex = new Mutex();
+
+    // Hold the lock indefinitely
+    const _release = await mutex.acquire();
+
+    await assertRejects(
+      () => mutex.acquire(10),
+      Error,
+      "Lock acquisition timeout",
+    );
+
+    assertEquals(mutex.waiting, 0);
+
+    _release();
+  });
+
+  it("does not resolve timed-out waiter when lock is released", async () => {
+    const mutex = new Mutex();
+    const events: string[] = [];
+
+    const release1 = await mutex.acquire();
+
+    // This will timeout
+    const timedOut = mutex.acquire(10).then(
+      (release) => {
+        events.push("should-not-happen");
+        release();
+      },
+      () => {
+        events.push("timeout");
+      },
+    );
+
+    await timedOut;
+    assertEquals(events, ["timeout"]);
+
+    // Release original lock — the timed-out waiter should NOT be notified
+    release1();
+
+    // Give microtasks a chance to run
+    await new Promise((r) => setTimeout(r, 5));
+    assertEquals(events, ["timeout"]);
+  });
+
+  it("handles concurrent acquire and release without deadlock", async () => {
+    const mutex = new Mutex();
+    let counter = 0;
+
+    const tasks = Array.from({ length: 20 }, async () => {
+      const release = await mutex.acquire();
+      counter++;
+      release();
+    });
+
+    await Promise.all(tasks);
+    assertEquals(counter, 20);
+  });
+});

--- a/src/rendering/renderer-concurrency.ts
+++ b/src/rendering/renderer-concurrency.ts
@@ -4,7 +4,7 @@
  * Manages concurrency control for the shared multi-tenant renderer:
  * - Global render semaphore (limits total concurrent renders per pod)
  * - Per-project slot management (noisy-neighbor protection)
- * - Lock primitives for race-free slot acquisition
+ * - Mutex-based locking for race-free slot acquisition
  *
  * @module rendering/renderer-concurrency
  */
@@ -38,8 +38,66 @@ export const RENDER_PER_PROJECT_LIMIT = getEnvNumber("RENDER_PER_PROJECT_LIMIT")
  */
 export const RENDER_ACQUIRE_TIMEOUT_MS = 5000;
 
-/** Maximum time to wait for a lock before giving up (10 seconds) */
+/** Maximum time to wait for a project lock before giving up (10 seconds) */
 export const LOCK_TIMEOUT_MS = 10_000;
+
+// ---------------------------------------------------------------------------
+// Mutex
+// ---------------------------------------------------------------------------
+
+/**
+ * Promise-based mutex with atomic lock state transitions.
+ * No TOCTOU race: `acquire()` synchronously marks the lock as held when
+ * uncontested, and `release()` atomically hands the lock to the next waiter.
+ */
+export class Mutex {
+  private queue: Array<(release: () => void) => void> = [];
+  private locked = false;
+
+  acquire(timeoutMs?: number): Promise<() => void> {
+    if (!this.locked) {
+      this.locked = true;
+      return Promise.resolve(() => this.release());
+    }
+
+    return new Promise<() => void>((resolve, reject) => {
+      let settled = false;
+
+      const onAcquire = (release: () => void) => {
+        if (settled) return;
+        settled = true;
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
+        resolve(release);
+      };
+
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      if (timeoutMs !== undefined && timeoutMs > 0) {
+        timeoutId = setTimeout(() => {
+          if (settled) return;
+          settled = true;
+          const idx = this.queue.indexOf(onAcquire);
+          if (idx !== -1) this.queue.splice(idx, 1);
+          reject(new Error(`Lock acquisition timeout after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }
+
+      this.queue.push(onAcquire);
+    });
+  }
+
+  private release(): void {
+    const next = this.queue.shift();
+    if (next) {
+      next(() => this.release());
+    } else {
+      this.locked = false;
+    }
+  }
+
+  get waiting(): number {
+    return this.queue.length;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Global State
@@ -63,62 +121,40 @@ export const renderSemaphore = new Semaphore(RENDER_MAX_CONCURRENT, {
 export const projectRenderCounts = new Map<string, number>();
 
 /**
- * Lock map to prevent race conditions in acquireProjectSlot/releaseProjectSlot.
- * Each project has its own lock to allow concurrent access across different projects
- * while serializing access within the same project.
- *
- * The race condition: Without locking, concurrent requests can read the same count,
- * both pass the limit check, and both increment - allowing 2*limit concurrent renders.
+ * Per-project mutexes for serializing slot acquire/release within the same project.
+ * Each project gets its own mutex so different projects don't block each other.
  */
-export const projectSlotLocks = new Map<string, Promise<void>>();
+const projectMutexes = new Map<string, Mutex>();
+
+function getProjectMutex(projectId: string): Mutex {
+  let mutex = projectMutexes.get(projectId);
+  if (!mutex) {
+    mutex = new Mutex();
+    projectMutexes.set(projectId, mutex);
+  }
+  return mutex;
+}
 
 // ---------------------------------------------------------------------------
-// Lock Functions
+// Slot Functions
 // ---------------------------------------------------------------------------
 
 /**
  * Acquire a lock for a specific project. Returns a release function.
- * Uses a retry loop to ensure atomicity - avoids TOCTOU race conditions.
  */
-export async function acquireProjectLock(projectId: string): Promise<() => void> {
-  const startTime = Date.now();
-
-  while (true) {
-    if (Date.now() - startTime > LOCK_TIMEOUT_MS) {
-      throw new Error(`Lock acquisition timeout for project: ${projectId}`);
-    }
-
-    const existingLock = projectSlotLocks.get(projectId);
-    if (existingLock) {
-      await existingLock;
-      continue;
-    }
-
-    let releaseLock!: () => void;
-    const lockPromise = new Promise<void>((resolve) => {
-      releaseLock = resolve;
-    });
-
-    if (projectSlotLocks.has(projectId)) {
-      continue;
-    }
-
-    projectSlotLocks.set(projectId, lockPromise);
-
-    return () => {
-      releaseLock();
-      if (projectSlotLocks.get(projectId) === lockPromise) {
-        projectSlotLocks.delete(projectId);
-      }
-    };
-  }
+export function acquireProjectLock(
+  projectId: string,
+): Promise<() => void> {
+  return getProjectMutex(projectId).acquire(LOCK_TIMEOUT_MS);
 }
 
 /**
  * Attempt to acquire a project render slot with proper locking.
  * Returns true if acquired, false if limit reached.
  */
-export async function acquireProjectSlot(projectId: string): Promise<boolean> {
+export async function acquireProjectSlot(
+  projectId: string,
+): Promise<boolean> {
   if (RENDER_PER_PROJECT_LIMIT <= 0) return true;
 
   const release = await acquireProjectLock(projectId);
@@ -136,7 +172,9 @@ export async function acquireProjectSlot(projectId: string): Promise<boolean> {
 /**
  * Release a project render slot with proper locking.
  */
-export async function releaseProjectSlot(projectId: string): Promise<void> {
+export async function releaseProjectSlot(
+  projectId: string,
+): Promise<void> {
   if (RENDER_PER_PROJECT_LIMIT <= 0) return;
 
   const release = await acquireProjectLock(projectId);
@@ -144,6 +182,7 @@ export async function releaseProjectSlot(projectId: string): Promise<void> {
     const current = projectRenderCounts.get(projectId) ?? 0;
     if (current <= 1) {
       projectRenderCounts.delete(projectId);
+      projectMutexes.delete(projectId);
       return;
     }
     projectRenderCounts.set(projectId, current - 1);


### PR DESCRIPTION
## Summary
- **Security fix (M8):** The `acquireProjectLock` function used a fragile check-then-set pattern with `Map<string, Promise<void>>` that was susceptible to TOCTOU races. Replaced with a proper `Mutex` class.
- The `Mutex` has atomic lock state transitions: `acquire()` synchronously marks the lock as held when uncontested, and `release()` atomically hands the lock to the next queued waiter — no gap between check and set.
- Includes timeout support (uses existing `LOCK_TIMEOUT_MS = 10s`) for deadlock prevention.
- Removed the exported `projectSlotLocks` map (was only used internally). The public API (`acquireProjectLock`, `acquireProjectSlot`, `releaseProjectSlot`) is unchanged.

## Test plan
- [x] Added test: acquires immediately when unlocked
- [x] Added test: serializes concurrent access (verifies FIFO ordering)
- [x] Added test: allows re-acquisition after release
- [x] Added test: times out when lock is held too long
- [x] Added test: timed-out waiter is not resolved when lock is later released
- [x] Added test: 20 concurrent acquire/release cycles without deadlock
- [x] All 6 Mutex tests pass