### PR TITLE
chore: add Contributor License Agreement and CLA bot

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,50 @@
+name: CLA Assistant
+
+# SECURITY: This workflow uses pull_request_target intentionally so that the CLA
+# bot can write comments and commit signatures. Do NOT add checkout steps that
+# reference the PR head — that would allow untrusted code execution.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'pull_request_target') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA'))
+    steps:
+      - name: CLA Assistant
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_TOKEN }}
+        with:
+          path-to-signatures: "signatures/cla.json"
+          path-to-document: "https://github.com/${{ github.repository }}/blob/main/CLA.md"
+          branch: "main"
+          allowlist: dependabot[bot],github-actions[bot],renovate[bot]
+          custom-notsigned-prcomment: |
+            Thank you for your contribution! Before we can merge this pull request, we need you to sign our [Contributor License Agreement (CLA)](https://github.com/${{ github.repository }}/blob/main/CLA.md).
+
+            **Why?** The CLA ensures that the project can be sustainably maintained and that contributors' rights are protected.
+
+            **How to sign:**
+            To sign, please comment on this PR with the following text:
+
+            > I have read the CLA Document and I hereby sign the CLA
+
+            If you are contributing on behalf of a company, please see our [Corporate CLA](https://github.com/${{ github.repository }}/blob/main/CLA-CORPORATE.md).
+
+          custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"
+          custom-allsigned-prcomment: "All contributors have signed the CLA. Thank you!"
+          lock-pullrequest-aftermerge: false

--- a/CLA-CORPORATE.md
+++ b/CLA-CORPORATE.md
@@ -1,0 +1,60 @@
+# Veryfront Corporate Contributor License Agreement
+
+Thank you for your organization's interest in contributing to Veryfront (the "Project"), owned and managed by Veryfront GmbH ("We" or "Us").
+
+This Corporate Contributor License Agreement ("Agreement") documents the rights granted by corporate contributors to Us. This Agreement is for Your protection as a contributor as well as the protection of Us; it does not change Your rights to use Your own Contributions for any other purpose.
+
+## 1. Definitions
+
+"You" (or "Your") shall mean the corporation, limited liability company, or other legal entity exercising permissions granted by this Agreement. For legal entities, the entity making a Contribution and all other entities that control, are controlled by, or under common control with that entity are considered to be a single contributor.
+
+"Contribution" shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to the Project for inclusion in, or documentation of, the Project.
+
+"Authorized Contributor" shall mean an employee or agent of Your organization who is authorized by You to submit Contributions on Your behalf.
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us and to recipients of software distributed by Us a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Contributions made by Your Authorized Contributors and such derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us and to recipients of software distributed by Us a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Contribution, where such license applies only to those patent claims licensable by You that are necessarily infringed by the Contribution(s) alone or by combination of the Contribution(s) with the Project to which such Contribution(s) was submitted.
+
+## 4. Right to Grant Licenses
+
+You represent that You are legally entitled to grant the above licenses. You represent that each Authorized Contributor designated by You is authorized to submit Contributions on behalf of Your organization.
+
+## 5. Original Work
+
+You represent that each Contribution is an original creation of Your Authorized Contributors. You represent that Contribution submissions include complete details of any third-party license or other restriction of which You are aware and which are associated with any part of the Contributions.
+
+## 6. Support and Warranty Disclaimer
+
+Unless required by applicable law or agreed to in writing, You provide Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7. Relicensing
+
+You acknowledge and agree that We may license the Contribution under any license, including (without limitation) a copyleft, permissive, commercial, or proprietary license. This right to relicense is a key purpose of this Agreement and is necessary for the long-term sustainability of the Project.
+
+## 8. Authorized Contributors
+
+You are responsible for maintaining a list of Authorized Contributors and providing it to Us upon request. It is Your responsibility to notify Us when a person is no longer authorized to contribute on Your behalf.
+
+## 9. Notification
+
+You agree to notify Us of any facts or circumstances of which You become aware that would make the representations in this Agreement inaccurate in any respect.
+
+---
+
+## Signing
+
+To sign this Corporate CLA, please contact the project maintainers at: **cla@veryfront.com**
+
+Provide the following information:
+
+- Corporation name
+- Corporation address
+- Point of contact (name, email, phone)
+- List of initial Authorized Contributors (GitHub usernames)
+
+The Corporate CLA must be signed by an authorized representative of the corporation.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,47 @@
+# Veryfront Individual Contributor License Agreement
+
+Thank you for your interest in contributing to Veryfront (the "Project"), owned and managed by Veryfront GmbH ("We" or "Us").
+
+This Contributor License Agreement ("Agreement") documents the rights granted by contributors to Us. This is a legally binding document, so please read it carefully before agreeing to it.
+
+## 1. Definitions
+
+"You" (or "Your") shall mean the copyright owner or legal entity authorized by the copyright owner that is making this Agreement with Us.
+
+"Contribution" shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to the Project for inclusion in, or documentation of, the Project. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Project maintainers or their representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Project for the purpose of discussing and improving the Project, but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us and to recipients of software distributed by Us a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us and to recipients of software distributed by Us a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Contribution, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Project to which such Contribution(s) was submitted.
+
+## 4. Right to Grant Licenses
+
+You represent that You are legally entitled to grant the above licenses. If Your employer(s) has rights to intellectual property that You create that includes Your Contributions, You represent that You have received permission to make Contributions on behalf of that employer, that Your employer has waived such rights for Your Contributions to the Project, or that Your employer has executed a separate Corporate Contributor License Agreement with Us.
+
+## 5. Original Work
+
+You represent that each of Your Contributions is Your original creation. You represent that Your Contribution submissions include complete details of any third-party license or other restriction (including, but not limited to, related patents and trademarks) of which You are personally aware and which are associated with any part of Your Contributions.
+
+## 6. Support and Warranty Disclaimer
+
+You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. You may provide support for free, for a fee, or not at all. Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7. Relicensing
+
+You acknowledge and agree that We may license the Contribution under any license, including (without limitation) a copyleft, permissive, commercial, or proprietary license. This right to relicense is a key purpose of this Agreement and is necessary for the long-term sustainability of the Project.
+
+## 8. Notification
+
+You agree to notify Us of any facts or circumstances of which You become aware that would make the representations in this Agreement inaccurate in any respect.
+
+---
+
+## Signing
+
+By signing this CLA, You accept and agree to the terms and conditions of this Agreement for Your present and future Contributions submitted to the Project.
+
+**To sign:** When prompted by the CLA Assistant bot on your pull request, follow the link to sign this agreement. Your signature will be recorded and linked to your GitHub account.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Thank you for your interest in contributing to Veryfront! This document provides
 
 ## Table of Contents
 
+- [Contributor License Agreement](#contributor-license-agreement)
 - [Code Organization](#code-organization)
 - [Development Setup](#development-setup)
 - [Code Style](#code-style)
@@ -11,6 +12,15 @@ Thank you for your interest in contributing to Veryfront! This document provides
 - [Pull Request Process](#pull-request-process)
 - [Release Process](#release-process)
 - [Module Guidelines](#module-guidelines)
+
+## Contributor License Agreement
+
+Before we can accept your contributions, you must sign our Contributor License Agreement (CLA). This is a one-time requirement that protects both you and the project.
+
+- **Individual contributors**: When you open your first pull request, the CLA Assistant bot will prompt you to sign the [Individual CLA](./CLA.md) by posting a comment on the PR.
+- **Corporate contributors**: If you are contributing on behalf of your employer, your organization must sign the [Corporate CLA](./CLA-CORPORATE.md). Please contact cla@veryfront.com to arrange this.
+
+The CLA grants Veryfront GmbH the ability to distribute your contributions under the project's Apache 2.0 license as well as other licenses if needed for the long-term sustainability of the project. You retain full ownership of your contributions.
 
 ## Code Organization
 


### PR DESCRIPTION
## Summary

- Add individual CLA (`CLA.md`) and corporate CLA (`CLA-CORPORATE.md`) for Veryfront GmbH
- Add GitHub Actions workflow (`.github/workflows/cla.yml`) using [cla-assistant](https://github.com/contributor-assistant/github-action) to automate CLA signing on PRs
- Update `CONTRIBUTING.md` with CLA requirements section

## Security hardening

- Action pinned to full commit SHA (`ca4a40a7...`) instead of mutable tag to prevent supply-chain attacks
- Removed unnecessary `actions: write` permission (least-privilege)
- Added security comment warning about `pull_request_target` risks
- Removed unused `closed` trigger type

## Prerequisites

- [x] Create `CLA_TOKEN` repo secret (fine-grained PAT with `Contents: Read and write` scope, ideally on a bot account)
- [x] Ensure `cla@veryfront.com` mailbox exists for corporate CLA inquiries

## Test plan

- [ ] Verify workflow triggers on a test PR from an external contributor
- [ ] Verify CLA bot posts the signing prompt comment
- [ ] Verify signing via comment records the signature in `signatures/cla.json`
- [ ] Verify allowlisted bots are not prompted