### PR TITLE
fix: enforce body size limit on client log endpoint

### DIFF
--- a/src/server/handlers/monitoring/client-log.handler.ts
+++ b/src/server/handlers/monitoring/client-log.handler.ts
@@ -1,11 +1,15 @@
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
-import { ResponseBuilder } from "#veryfront/security/index.ts";
+import { readBodyWithLimit, ResponseBuilder } from "#veryfront/security/index.ts";
 import { serverLogger } from "#veryfront/utils";
 import { HTTP_OK, PRIORITY_HIGH_CLIENT_LOG } from "#veryfront/utils/constants/index.ts";
 import { getErrorMessage } from "#veryfront/errors/veryfront-error.ts";
+import { VeryfrontError } from "#veryfront/errors/types.ts";
 
 const logger = serverLogger.component("client-log-handler");
+
+/** Max body size for client log payloads (64 KB) */
+const CLIENT_LOG_MAX_BODY_BYTES = 64 * 1024;
 
 export class ClientLogHandler extends BaseHandler {
   metadata: HandlerMetadata = {
@@ -27,7 +31,7 @@ export class ClientLogHandler extends BaseHandler {
     let body = "";
 
     try {
-      body = await req.text();
+      body = await readBodyWithLimit(req, CLIENT_LOG_MAX_BODY_BYTES);
       const logData = JSON.parse(body);
 
       const level = typeof logData?.level === "string" ? logData.level : "info";
@@ -47,6 +51,19 @@ export class ClientLogHandler extends BaseHandler {
         serverLogger.debug(`${prefix} ${message}`, details);
       }
     } catch (e) {
+      if (
+        e instanceof VeryfrontError &&
+        e.slug === "input-validation-failed" &&
+        e.detail === "Request body exceeds size limit"
+      ) {
+        logger.warn("Client log body too large, rejected");
+        return this.respond(
+          ResponseBuilder.json({ error: "Payload too large" }, req, {
+            corsConfig: ctx.securityConfig?.cors,
+            status: 413,
+          }),
+        );
+      }
       this.handleParseError(e, body);
     }
 

--- a/src/server/handlers/monitoring/client-log.test.ts
+++ b/src/server/handlers/monitoring/client-log.test.ts
@@ -127,5 +127,21 @@ describe("server/handlers/monitoring/client-log", () => {
       const result = await handler.handle(req, localCtx);
       await assertOkResponse(result);
     });
+
+    it("should reject oversized body with 413", async () => {
+      const handler = createHandler();
+      // 64 KB limit — send a body that exceeds it
+      const oversizedBody = "x".repeat(65 * 1024);
+      const req = new Request("http://localhost/_veryfront/log", {
+        method: "POST",
+        body: oversizedBody,
+      });
+      const result = await handler.handle(req, localCtx);
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 413);
+      const body = await result.response.json();
+      assertEquals(body.error, "Payload too large");
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Replace unbounded `req.text()` with `readBodyWithLimit()` (64 KB cap) in `ClientLogHandler`
- Oversized payloads now return 413 (Payload Too Large) instead of being fully buffered into memory
- Catches the `input-validation-failed` error from `readBodyWithLimit` and returns a proper error response

## Test plan
- [x] Existing tests pass (valid log data, invalid JSON, missing fields, non-matching routes)
- [x] New test: oversized body (65 KB) returns 413 with `{ error: "Payload too large" }`