### PR TITLE
chore: restructure README for open-source launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,36 @@
-# Veryfront Code
+# Veryfront
 
-AI-native full-stack framework for building agentic apps and agents with TypeScript and React. Works with Node.js, Deno, and Bun.
+[![npm version](https://badge.fury.io/js/veryfront.svg)](https://www.npmjs.com/package/veryfront)
+[![Socket Badge](https://socket.dev/api/badge/npm/package/veryfront)](https://socket.dev/npm/package/veryfront)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
 
-## Getting started
+Veryfront is a full-stack framework for building AI-powered applications and agents with TypeScript and React.
+
+It gives you agents, tools, workflows, and a complete React rendering stack in a single framework. Veryfront runs on Node.js, Deno, and Bun, and can be deployed anywhere or shipped through the Veryfront platform with built-in preview environments and production hosting.
+
+## Why Veryfront?
+
+Purpose-built for TypeScript and React, Veryfront gives you everything you need to build agentic full-stack applications out-of-the-box.
+
+- [**Agents**](https://veryfront.com/docs/code/guides/agents) — Build autonomous agents with model routing, system prompts, and tool calling. Agents reason about goals and iterate until they reach a final answer.
+
+- [**Tools**](https://veryfront.com/docs/code/guides/tools) — Define Zod-validated functions that agents can call. Tools are auto-discovered from the file system with no registration needed.
+
+- [**Workflows**](https://veryfront.com/docs/code/guides/workflows) — Orchestrate multi-step AI pipelines with branching, parallelism, and human-in-the-loop approval gates.
+
+- [**Multi-Agent**](https://veryfront.com/docs/code/guides/multi-agent) — Compose agents that delegate to each other as tools for complex, coordinated tasks.
+
+- [**Memory & Streaming**](https://veryfront.com/docs/code/guides/memory-and-streaming) — Give agents conversation history and streaming responses. Built-in chat UI components for React.
+
+- [**MCP Server**](https://veryfront.com/docs/code/guides/mcp-server) — Expose agents, tools, and resources via the Model Context Protocol. Connect your coding agent to live errors, logs, and HMR.
+
+- [**Pages & Routing**](https://veryfront.com/docs/code/guides/pages-and-routing) — File-based routing with React Server Components, layouts, and server-side rendering.
+
+- [**Data Fetching & API Routes**](https://veryfront.com/docs/code/guides/data-fetching) — Server-side data loading, API route handlers, and [middleware](https://veryfront.com/docs/code/guides/middleware) with built-in [OAuth](https://veryfront.com/docs/code/guides/oauth) support.
+
+## Get Started
+
+The **recommended** way to get started with Veryfront:
 
 ```bash
 npm create veryfront
@@ -28,346 +56,35 @@ brew install veryfront/tap/veryfront
 
 </details>
 
-## What You Get
-
-Agents, tools, and workflows are files. Auto-discovered, no registration needed.
-
-```
-my-app/
-  agents/
-    assistant.ts      # AI agent with model, system prompt, tools
-  tools/
-    search.ts         # Zod-validated tool the agent can call
-  prompts/
-    assistant.ts      # System prompt (versioned, swappable)
-  workflows/
-    pipeline.ts       # DAG workflow with branching + parallelism
-  app/
-    layout.tsx        # Root layout
-    page.tsx          # Chat UI
-    api/
-      chat/
-        route.ts      # Streaming chat endpoint
-```
-
-## Define Agent
-
-Agents have a model, system prompt, and optional tools and memory.
-
-```ts
-// agents/assistant.ts
-import { agent } from "veryfront/agent";
-
-export default agent({
-  id: "assistant",
-  model: "openai/gpt-4o",
-  system: "You are a helpful assistant.",
-  tools: true,       // auto-attach all discovered tools
-  maxSteps: 10,
-});
-```
-
-## Define Tool
-
-Tools are Zod-validated functions an agent can call.
-
-```ts
-// tools/search.ts
-import { tool } from "veryfront/tool";
-import { z } from "zod";
-
-export default tool({
-  id: "search",
-  description: "Search the knowledge base",
-  inputSchema: z.object({
-    query: z.string(),
-  }),
-  execute: async ({ query }) => {
-    // your logic here
-    return { results: [] };
-  },
-});
-```
-
-## Define Prompt
-
-Versioned system prompts with `{{variable}}` support.
-
-```ts
-// prompts/assistant.ts
-import { prompt } from "veryfront/prompt";
-
-export default prompt({
-  description: "General-purpose assistant",
-  content: "You are a helpful assistant for {{company}}.",
-});
-```
-
-## Expose Chat Endpoint
-
-One-line API route via `createChatHandler`, or use `getAgent` for full control.
-
-```ts
-// app/api/chat/route.ts
-import { createChatHandler } from "veryfront/agent";
-
-export const POST = createChatHandler("assistant");
-```
-
-<details>
-<summary>Manual handler with getAgent</summary>
-
-```ts
-// app/api/chat/route.ts
-import { getAgent } from "veryfront/agent";
-
-export async function POST(req: Request) {
-  const { messages } = await req.json();
-  const agent = getAgent("assistant");
-  const result = await agent.stream({ messages });
-  return result.toDataStreamResponse();
-}
-```
-
-</details>
-
-## Add Chat UI
-
-Pre-built `<Chat />` component with streaming and tool call rendering.
-
-```tsx
-// app/page.tsx
-"use client"
-import { Chat, useChat } from "veryfront/chat";
-
-export default function Page() {
-  const chat = useChat({ api: "/api/chat" });
-  return <Chat {...chat} />;
-}
-```
-
-## Define Workflow
-
-Multi-step DAG pipelines with branching, parallelism, and human-in-the-loop.
-
-```ts
-// workflows/content-pipeline.ts
-import { workflow, step, parallel, waitForApproval } from "veryfront/workflow";
-
-export default workflow({
-  id: "content-pipeline",
-  steps: () => [
-    step("research", { agent: "researcher" }),
-    parallel("generate", [
-      step("write", { agent: "writer" }),
-      step("images", { tool: "imageGenerator" }),
-    ]),
-    waitForApproval("review", { timeout: "24h" }),
-    step("publish", { agent: "publisher" }),
-  ],
-});
-```
-
-## Compose Agents
-
-For advanced setups, agents can delegate to other agents as tools.
-
-```ts
-import { agent, registerAgent, getAgentsAsTools } from "veryfront/agent";
-
-const researcher = agent({ model: "openai/gpt-4o", system: "Research topics thoroughly." });
-const writer = agent({ model: "openai/gpt-4o", system: "Write clear, concise prose." });
-
-registerAgent(researcher);
-registerAgent(writer);
-
-const orchestrator = agent({
-  model: "openai/gpt-4o",
-  system: "Coordinate research and writing.",
-  tools: getAgentsAsTools(["researcher", "writer"]),
-});
-```
-
-## Templates
-
-```bash
-npx veryfront init my-app
-```
-
-| Template | Description |
-|----------|-------------|
-| **chat** | Conversational chat agent with tools and streaming UI |
-| **rag** | RAG-powered app to chat with your docs |
-| **multi-agent** | Coordinated AI agents that delegate to each other as tools |
-| **workflow** | Multi-step AI pipeline with approvals and parallelism |
-| **coding-agent** | AI code assistant with file read/write/edit tools |
-| **saas** | AI SaaS with auth, per-user chat, memory |
-| **minimal** | Blank canvas |
-
-## Deploy
-
-Push, merge, and ship from the command line.
-
-```bash
-veryfront push                # Upload to a branch
-veryfront merge my-branch     # Merge into main
-veryfront deploy              # Release to production
-```
-
-Preview at `https://<slug>--<branch>.preview.veryfront.com`, production at `https://<slug>.production.veryfront.com`.
-
-## Terminal UI
-
-Browse projects, view logs, and open in browser or IDE.
-
-```bash
-veryfront
-```
-
-```
-╭──────────────────────────────────────────────────────────╮
-│                                                          │
-│  ○ ○ ○ ○ ○ ○ ○                                           │
-│  ○ ● ● ● ○ ○ ○   Veryfront is now running                │
-│  ○ ● ● ● ○ ○ ○                                           │
-│  ○ ● ● ○ ● ● ○   Url http://veryfront.me:8080            │
-│  ○ ○ ○ ● ● ● ○   Mcp http://veryfront.me:9999/mcp        │
-│  ○ ○ ○ ● ● ● ○                                           │
-│  ○ ○ ○ ○ ○ ○ ○                                           │
-│                                                          │
-╰──────────────────────────────────────────────────────────╯
-```
-
-<details>
-<summary>Keyboard shortcuts</summary>
-
-| Key | Action |
-|-----|--------|
-| `↑` `↓` | Navigate projects |
-| `enter` | Open selected project |
-| `o` | Open in browser |
-| `s` | Open in Studio |
-| `i` | Open in IDE |
-| `n` | Create new project |
-| `l` | Toggle logs |
-| `q` | Quit |
-
-</details>
-
-## Connect Your Coding Agent
-
-Give your coding agent access to live errors, logs, and HMR.
-
-<details>
-<summary>Claude Code</summary>
-
-```bash
-/plugin install veryfront@veryfront/claude-plugins
-```
-
-Or add to `.mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "veryfront": {
-      "command": "veryfront",
-      "args": ["mcp"]
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary>Cursor</summary>
-
-Add to `.cursor/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "veryfront": {
-      "command": "veryfront",
-      "args": ["mcp"]
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary>Codex CLI</summary>
-
-Add to `~/.codex/config.toml`:
-
-```toml
-[mcp_servers.veryfront]
-command = "veryfront"
-args = ["mcp"]
-```
-
-</details>
-
-<details>
-<summary>Gemini CLI</summary>
-
-Add to `~/.gemini/settings.json`:
-
-```json
-{
-  "mcpServers": {
-    "veryfront": {
-      "command": "veryfront",
-      "args": ["mcp"]
-    }
-  }
-}
-```
-
-</details>
-
-**Available MCP tools:**
-
-| Tool | Description |
-|------|-------------|
-| `vf_get_errors` | Live compile, runtime, and bundle errors |
-| `vf_get_logs` | Recent server logs with filtering |
-| `vf_get_status` | Dev server status and stats |
-| `vf_trigger_hmr` | Trigger hot module reload |
+Follow the [Quickstart guide](https://veryfront.com/docs/code/guides/quickstart) for step-by-step setup, or explore our [templates](https://veryfront.com/docs/code/guides/quickstart#templates) to start building with Veryfront today.
 
 ## Documentation
 
-**Getting Started**
-- [Quickstart](https://veryfront.com/docs/code/guides/quickstart)
+Visit our [official documentation](https://veryfront.com/docs/code).
 
-**Basics**
-- [Project Structure](https://veryfront.com/docs/code/guides/project-structure)
-- [Pages & Routing](https://veryfront.com/docs/code/guides/pages-and-routing)
-- [Data Fetching](https://veryfront.com/docs/code/guides/data-fetching)
-- [API Routes](https://veryfront.com/docs/code/guides/api-routes)
+**Getting Started** — [Quickstart](https://veryfront.com/docs/code/guides/quickstart) · [Project Structure](https://veryfront.com/docs/code/guides/project-structure)
 
-**AI**
-- [Agents](https://veryfront.com/docs/code/guides/agents)
-- [Tools](https://veryfront.com/docs/code/guides/tools)
-- [Memory & Streaming](https://veryfront.com/docs/code/guides/memory-and-streaming)
-- [Chat UI](https://veryfront.com/docs/code/guides/chat-ui)
-- [Workflows](https://veryfront.com/docs/code/guides/workflows)
-- [Multi-Agent](https://veryfront.com/docs/code/guides/multi-agent)
+**AI** — [Agents](https://veryfront.com/docs/code/guides/agents) · [Tools](https://veryfront.com/docs/code/guides/tools) · [Memory & Streaming](https://veryfront.com/docs/code/guides/memory-and-streaming) · [Chat UI](https://veryfront.com/docs/code/guides/chat-ui) · [Workflows](https://veryfront.com/docs/code/guides/workflows) · [Multi-Agent](https://veryfront.com/docs/code/guides/multi-agent)
 
-**Infrastructure**
-- [Providers](https://veryfront.com/docs/code/guides/providers)
-- [Middleware](https://veryfront.com/docs/code/guides/middleware)
-- [OAuth](https://veryfront.com/docs/code/guides/oauth)
-- [MCP Server](https://veryfront.com/docs/code/guides/mcp-server)
-- [Integrations](https://veryfront.com/docs/code/integrations)
+**Infrastructure** — [Providers](https://veryfront.com/docs/code/guides/providers) · [Pages & Routing](https://veryfront.com/docs/code/guides/pages-and-routing) · [Data Fetching](https://veryfront.com/docs/code/guides/data-fetching) · [API Routes](https://veryfront.com/docs/code/guides/api-routes) · [Middleware](https://veryfront.com/docs/code/guides/middleware) · [OAuth](https://veryfront.com/docs/code/guides/oauth) · [MCP Server](https://veryfront.com/docs/code/guides/mcp-server) · [Integrations](https://veryfront.com/docs/code/integrations)
 
-**Production**
-- [Configuration](https://veryfront.com/docs/code/guides/configuration)
-- [Building & Deploying](https://veryfront.com/docs/code/guides/deploying)
-- [Head & SEO](https://veryfront.com/docs/code/guides/head-and-seo)
+**Production** — [Configuration](https://veryfront.com/docs/code/guides/configuration) · [Building & Deploying](https://veryfront.com/docs/code/guides/deploying) · [Head & SEO](https://veryfront.com/docs/code/guides/head-and-seo)
+
+## Contributing
+
+Looking to contribute? All types of help are appreciated, from coding to testing and feature specification. Read [CONTRIBUTING.md](./CONTRIBUTING.md) for more details on how to get involved.
+
+If you are a developer and would like to contribute with code, please open an issue to discuss before opening a Pull Request.
+
+## Support
+
+We have an [open community Discord](https://discord.gg/veryfront). Come say hello and let us know if you have any questions or need help getting things running.
+
+It's also super helpful if you leave the project a star here at the [top of the page](https://github.com/veryfront/veryfront-code).
+
+## Security
+
+We are committed to maintaining the security of Veryfront. If you discover a security vulnerability, please responsibly disclose it to us at [security@veryfront.com](mailto:security@veryfront.com) and we will respond within 48 hours.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Restructure README to follow Mastra-style layout for open-source readiness
- Add badges: npm version, Socket, License (Apache 2.0)
- Replace inline code examples with "Why Veryfront?" feature highlights linking to docs
- Keep `npm create veryfront` install command with alternative package managers
- Add compact inline documentation links grouped by category
- Add Contributing, Support, and Security sections

## Rationale
Docs site is the single source of truth — README links to it instead of duplicating content. This keeps the README concise and maintainable.