### PR TITLE
fix: preserve .css extension in alias import rewriting

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,14 @@
+# Contributors
+
+By adding your name to this file, you agree to the
+[Contributor License Agreement](./CLA.md).
+
+This is a one-time step. Add yourself in your first PR.
+
+## Format
+
+Name (GitHub @username)
+
+## Contributors
+
+Koji Wakayama (@kojiwakayama)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,3 +12,4 @@ Name (GitHub @username)
 ## Contributors
 
 Koji Wakayama (@kojiwakayama)
+Aris Kemper (@ariskemper)

--- a/src/transforms/import-rewriter/strategies/alias-strategy.test.ts
+++ b/src/transforms/import-rewriter/strategies/alias-strategy.test.ts
@@ -131,6 +131,41 @@ describe("AliasStrategy", () => {
       });
     });
 
+    describe("CSS file imports (issue #453)", () => {
+      it("should NOT append .js to .css imports for SSR", () => {
+        // Bug: @/globals.css becomes /_vf_modules/globals.css.js
+        // because .css is not in the known extension list
+        const result = aliasStrategy.rewrite(
+          makeInfo("@/globals.css"),
+          makeCtx({ target: "ssr", filePath: "/project/app/layout.tsx" }),
+        );
+        // Expected: /_vf_modules/globals.css (preserve .css extension)
+        // Actual (bug): /_vf_modules/globals.css.js
+        assertEquals(result.specifier, "/_vf_modules/globals.css");
+      });
+
+      it("should NOT append .js to .css imports with moduleServerUrl", () => {
+        const result = aliasStrategy.rewrite(
+          makeInfo("@/globals.css"),
+          makeCtx({
+            filePath: "/project/app/layout.tsx",
+            moduleServerUrl: "/_vf_modules",
+          }),
+        );
+        assertEquals(result.specifier, "/_vf_modules/globals.css");
+      });
+
+      it("should NOT append .js to .css imports in browser fallback", () => {
+        const result = aliasStrategy.rewrite(
+          makeInfo("@/globals.css"),
+          makeCtx({ filePath: "/project/app/layout.tsx" }),
+        );
+        // Should preserve .css, not become globals.css.js
+        assertEquals(result.specifier?.endsWith(".css"), true);
+        assertEquals(result.specifier?.endsWith(".css.js"), false);
+      });
+    });
+
     describe("relative path fallback (no moduleServerUrl)", () => {
       it("should handle file at components/elements depth correctly", () => {
         // File is at components/elements/Textarea.tsx

--- a/src/transforms/import-rewriter/strategies/alias-strategy.ts
+++ b/src/transforms/import-rewriter/strategies/alias-strategy.ts
@@ -21,7 +21,7 @@ export class AliasStrategy implements ImportRewriteStrategy {
     if (ctx.target === "ssr") {
       let normalizedPath = normalizeExtension(path);
       // Add .js if no extension present
-      if (!/\.(tsx?|jsx?|mjs|cjs|mdx|js)$/.test(normalizedPath)) {
+      if (!/\.(tsx?|jsx?|mjs|cjs|mdx|css|js)$/.test(normalizedPath)) {
         normalizedPath = `${normalizedPath}.js`;
       }
       return { specifier: `/_vf_modules/${normalizedPath}` };
@@ -33,7 +33,7 @@ export class AliasStrategy implements ImportRewriteStrategy {
     // but module path is "_vf_modules/components/elements/Textarea.js").
     if (ctx.moduleServerUrl) {
       let normalizedPath = normalizeExtension(path);
-      if (!/\.(tsx?|jsx?|mjs|cjs|mdx|js)$/.test(normalizedPath)) {
+      if (!/\.(tsx?|jsx?|mjs|cjs|mdx|css|js)$/.test(normalizedPath)) {
         normalizedPath = `${normalizedPath}.js`;
       }
       return { specifier: `${ctx.moduleServerUrl}/${normalizedPath}` };
@@ -47,7 +47,7 @@ export class AliasStrategy implements ImportRewriteStrategy {
 
     let relativePath = depth === 0 ? `./${path}` : `${"../".repeat(depth)}${path}`;
 
-    if (!/\.(tsx?|jsx?|mjs|cjs|mdx)$/.test(relativePath)) {
+    if (!/\.(tsx?|jsx?|mjs|cjs|mdx|css)$/.test(relativePath)) {
       relativePath = `${relativePath}.js`;
     }
 


### PR DESCRIPTION
## Summary

- Fixes #453 — scaffolded projects importing CSS via `@/globals.css` were completely broken
- Added `css` to the known-extension regex in all 3 code paths of `AliasStrategy.rewrite()` (SSR, moduleServerUrl, browser fallback)
- `@/globals.css` now correctly resolves to `/_vf_modules/globals.css` instead of the broken `/_vf_modules/globals.css.js`

## Root Cause

The `AliasStrategy` appends `.js` to any import whose extension isn't in a known-extension regex. `.css` was missing from that list, so `@/globals.css` → `/_vf_modules/globals.css.js`, causing three cascading errors:

1. **Module not found** — `globals.css.js` doesn't exist
2. **Component blocked** — circuit breaker trips after repeated failures
3. **Preview 404** — layout can't render, page falls through to 404

## Test plan

- [x] Added 3 new unit tests covering CSS imports across all code paths (SSR, moduleServerUrl, browser fallback)
- [ ] Verify scaffolded project with `@/globals.css` import loads correctly in preview