### PR TITLE
ci: run CLA check from file-based CONTRIBUTORS flow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,50 +1,89 @@
-name: CLA Assistant
-
-# SECURITY: This workflow uses pull_request_target intentionally so that the CLA
-# bot can write comments and commit signatures. Do NOT add checkout steps that
-# reference the PR head — that would allow untrusted code execution.
+name: CLA Check
 
 on:
-  issue_comment:
-    types: [created]
   pull_request_target:
     types: [opened, synchronize]
 
 permissions:
-  contents: write
   pull-requests: write
-  statuses: write
 
 jobs:
   cla:
     runs-on: ubuntu-latest
-    if: |
-      (github.event_name == 'pull_request_target') ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
-       startsWith(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA'))
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.user.login != 'github-actions[bot]' &&
+      github.event.pull_request.user.login != 'renovate[bot]'
     steps:
-      - name: CLA Assistant
-        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_TOKEN }}
+      - name: Checkout base branch
+        uses: actions/checkout@v4
         with:
-          path-to-signatures: "signatures/cla.json"
-          path-to-document: "https://github.com/${{ github.repository }}/blob/main/CLA.md"
-          branch: "main"
-          allowlist: dependabot[bot],github-actions[bot],renovate[bot]
-          custom-notsigned-prcomment: |
-            Thank you for your contribution! Before we can merge this pull request, we need you to sign our [Contributor License Agreement (CLA)](https://github.com/${{ github.repository }}/blob/main/CLA.md).
+          ref: ${{ github.event.pull_request.base.ref }}
 
-            **Why?** The CLA ensures that the project can be sustainably maintained and that contributors' rights are protected.
+      - name: Check CONTRIBUTORS file
+        id: check
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          if grep -qi "@${PR_AUTHOR})" CONTRIBUTORS.md; then
+            echo "signed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+          fi
 
-            **How to sign:**
-            To sign, please comment on this PR with the following text:
+      - name: Check if PR adds contributor
+        if: steps.check.outputs.signed == 'false'
+        id: pr_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if the PR itself modifies CONTRIBUTORS
+          FILES=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files --jq '.[].filename')
+          if echo "$FILES" | grep -q "^CONTRIBUTORS.md$"; then
+            echo "adding=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "adding=false" >> "$GITHUB_OUTPUT"
+          fi
 
-            > I have read the CLA Document and I hereby sign the CLA
+      - name: Post CLA reminder
+        if: steps.check.outputs.signed == 'false' && steps.pr_check.outputs.adding == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const author = context.payload.pull_request.user.login;
+            const body = `Thanks for your contribution, @${author}!
 
-            If you are contributing on behalf of a company, please see our [Corporate CLA](https://github.com/${{ github.repository }}/blob/main/CLA-CORPORATE.md).
+            Before we can merge this PR, we need you to accept our [Contributor License Agreement (CLA)](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CLA.md).
 
-          custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"
-          custom-allsigned-prcomment: "All contributors have signed the CLA. Thank you!"
-          lock-pullrequest-aftermerge: false
+            **How to sign:** Add yourself to the \`CONTRIBUTORS.md\` file in this PR:
+
+            \`\`\`
+            Your Name (@${author})
+            \`\`\`
+
+            By adding your name, you agree to the [CLA](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CLA.md). This is a one-time step.`;
+
+            // Check if we already posted a CLA comment
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const existing = comments.data.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Contributor License Agreement')
+            );
+
+            if (!existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            }
+
+      - name: Fail if CLA not signed
+        if: steps.check.outputs.signed == 'false' && steps.pr_check.outputs.adding == 'false'
+        run: |
+          echo "::error::CLA not signed. Please add yourself to CONTRIBUTORS.md."
+          exit 1


### PR DESCRIPTION
## Summary\n- replace CLA Assistant bot workflow with a file-based CLA check workflow\n- run on pull_request_target from base branch so checks use the merged workflow definition\n- post actionable PR comment when contributor is missing from CONTRIBUTORS.md\n\n## Why\npull_request_target executes workflow files from the base branch. Shipping this in an isolated PR lets us merge the fix immediately so CLA checks for other PRs use the new workflow.