### PR TITLE
chore: bump version to 0.1.25

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [


### PR DESCRIPTION
## Summary

- Bumps version from 0.1.24 to 0.1.25 in `deno.json`