### PR TITLE
docs: clarify individual and corporate CLA paths

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -99,7 +99,9 @@ jobs:
             ${example || "Your Name (@your-github-login)"}
             \`\`\`
 
-            By adding your name, you agree to the [CLA](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CLA.md). This is a one-time step.`;
+            By adding your name, you agree to the [CLA](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CLA.md). This is a one-time step.
+
+            If you are contributing on behalf of a company, please see our [Corporate CLA](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CLA-CORPORATE.md).`;
 
             // Create or update a single sticky CLA comment from this bot.
             const comments = await github.rest.issues.listComments({

--- a/CLA-CORPORATE.md
+++ b/CLA-CORPORATE.md
@@ -58,3 +58,5 @@ Provide the following information:
 - List of initial Authorized Contributors (GitHub usernames)
 
 The Corporate CLA must be signed by an authorized representative of the corporation.
+
+For individual (non-corporate) contributions, see the [Individual CLA](./CLA.md).

--- a/CLA.md
+++ b/CLA.md
@@ -44,4 +44,6 @@ You agree to notify Us of any facts or circumstances of which You become aware t
 
 By signing this CLA, You accept and agree to the terms and conditions of this Agreement for Your present and future Contributions submitted to the Project.
 
-**To sign:** When prompted by the CLA Assistant bot on your pull request, follow the link to sign this agreement. Your signature will be recorded and linked to your GitHub account.
+**Individual contributors:** Add your contributor entry in `CONTRIBUTORS.md` in your pull request. By adding your name, you agree to this Individual CLA.
+
+**Corporate contributors:** If you are contributing on behalf of your employer or another organization, your organization must also sign the [Corporate CLA](./CLA-CORPORATE.md). Please contact **cla@veryfront.com**.


### PR DESCRIPTION
## Summary
- update `CLA.md` signing section to clearly split individual and corporate paths
- add reciprocal pointer in `CLA-CORPORATE.md` back to the individual CLA
- add a Corporate CLA link in the PR reminder comment posted by the CLA workflow

## Why
Contributors should immediately see that corporate contribution requires a separate agreement and where to find it.
