### PR TITLE
refactor: remove template alias, standardize on templateSlug

### DIFF
--- a/cli/mcp/remote-file-tools.ts
+++ b/cli/mcp/remote-file-tools.ts
@@ -615,7 +615,7 @@ const remoteCreateProjectInput = z.object({
   slug: z.string().describe(
     "Project slug (lowercase letters, numbers, hyphens only). A random suffix is appended if the slug is already taken.",
   ),
-  template: z.string().optional().describe("Template to use (e.g., 'chat', 'rag', 'minimal')"),
+  templateSlug: z.string().optional().describe("Template project slug to fork from (e.g., 'blank', 'chat', 'rag')"),
   is_public: z.boolean().optional().describe("Whether the project is public (default: false)"),
 });
 
@@ -633,7 +633,7 @@ export const vfRemoteCreateProject: MCPTool<RemoteCreateProjectInput, RemoteCrea
   inputSchema: remoteCreateProjectInput,
   execute: async (input) => {
     const result = await createProjectWithRetry(input.slug, {
-      template: input.template,
+      templateSlug: input.templateSlug,
       isPublic: input.is_public,
     });
 

--- a/cli/mcp/remote-file-tools.ts
+++ b/cli/mcp/remote-file-tools.ts
@@ -615,7 +615,9 @@ const remoteCreateProjectInput = z.object({
   slug: z.string().describe(
     "Project slug (lowercase letters, numbers, hyphens only). A random suffix is appended if the slug is already taken.",
   ),
-  templateSlug: z.string().optional().describe("Template project slug to fork from (e.g., 'blank', 'chat', 'rag')"),
+  templateSlug: z.string().optional().describe(
+    "Template project slug to fork from (e.g., 'blank', 'chat', 'rag')",
+  ),
   is_public: z.boolean().optional().describe("Whether the project is public (default: false)"),
 });
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [


### PR DESCRIPTION
Renames template → templateSlug in vf_remote_create_project MCP tool to match the veryfront-api breaking change. The local vf_create_project scaffolding template field is unchanged (different concept).