### PR TITLE
ci: auto-sync API reference docs to veryfront-docs

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -17,6 +17,6 @@ jobs:
       - uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GH_PAT_VERYFRONT }}
-          repository: veryfront/docs
+          repository: veryfront/veryfront-docs
           event-type: docs-update
           client-payload: '{"sha": "${{ github.sha }}"}'

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,0 +1,22 @@
+name: Sync Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/**/index.ts"
+      - "src/**/types.ts"
+      - "scripts/docs/**"
+      - "deno.json"
+  workflow_dispatch:
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GH_PAT_VERYFRONT }}
+          repository: veryfront/docs
+          event-type: docs-update
+          client-payload: '{"sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## Summary
- Adds `sync-docs.yml` workflow that sends a `repository_dispatch` event to `veryfront/veryfront-docs` when relevant source files change on main
- Triggers on changes to `src/**/index.ts`, `src/**/types.ts`, `scripts/docs/**`, or `deno.json`
- Uses the existing `GH_PAT_VERYFRONT` secret (same as server/job-runner dispatches)

## Test plan
- [ ] Merge this PR + the companion PR in veryfront-docs
- [ ] Push a JSDoc change to a barrel file → verify dispatch fires
- [ ] Verify docs repo workflow runs and commits updated reference