### PR TITLE
feat: CSS import support for SSR and browser pipelines

### DIFF
--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -141,6 +141,8 @@ async function generateHTMLShellPartsImpl(
   if (useProductionCSS && projectSlug !== "default") {
     const projectCSS = await getProjectCSS(projectSlug, stylesheetContent, candidates, {
       minify: true,
+      environment: options.environment,
+      buildMode: options.mode,
     });
     cssHash = projectCSS.hash;
   }

--- a/src/html/styles-builder/project-css-cache.ts
+++ b/src/html/styles-builder/project-css-cache.ts
@@ -18,6 +18,7 @@ import {
   resolveStylesheet,
 } from "./tailwind-compiler-utils.ts";
 import { cacheCSSAsync, DEFAULT_STYLESHEET } from "./css-hash-cache.ts";
+import { TAILWIND_VERSION } from "#veryfront/utils/constants/cdn.ts";
 
 const projectCssCacheLog = logger.component("project-css-cache");
 const tailwindLog = logger.component("tailwind");
@@ -40,7 +41,15 @@ export interface ProjectCSSRequestContext {
   projectSlug: string;
   stylesheet: string;
   candidatesHash: string;
+  profileHash: string;
+  environment: string;
   cacheKey: string;
+}
+
+export interface ProjectCSSProfile {
+  minify?: boolean;
+  environment?: string;
+  buildMode?: "development" | "production";
 }
 
 // ============================================================================
@@ -116,15 +125,29 @@ export function createProjectCSSRequestContext(
   projectSlug: string,
   stylesheet: string | undefined,
   candidates: Set<string>,
+  profile?: ProjectCSSProfile,
 ): ProjectCSSRequestContext {
   const resolvedStylesheet = resolveStylesheet(stylesheet, DEFAULT_STYLESHEET);
   const stylesheetHash = hashString(resolvedStylesheet);
   const candidatesHash = hashCandidates(candidates);
+  const environment = profile?.environment ?? "preview";
+  const profileHash = hashString(
+    JSON.stringify({
+      cacheSchema: "v2",
+      tailwindVersion: TAILWIND_VERSION,
+      minify: profile?.minify ?? false,
+      buildMode: profile?.buildMode ?? "production",
+      environment,
+    }),
+  );
+
   return {
     projectSlug,
     stylesheet: resolvedStylesheet,
     candidatesHash,
-    cacheKey: `${projectSlug}:${stylesheetHash}`,
+    profileHash,
+    environment,
+    cacheKey: `${projectSlug}:${environment}:${stylesheetHash}:${candidatesHash}:${profileHash}`,
   };
 }
 

--- a/src/html/styles-builder/tailwind-compiler.ts
+++ b/src/html/styles-builder/tailwind-compiler.ts
@@ -43,6 +43,11 @@ export {
 } from "./project-css-cache.ts";
 
 const logger = serverLogger.component("tailwind");
+const inFlightProjectCSS = new Map<
+  string,
+  Promise<{ css: string; hash: string; fromCache: boolean }>
+>();
+const inFlightRegeneration = new Map<string, Promise<string | undefined>>();
 
 export interface TailwindResult {
   css: string;
@@ -51,6 +56,8 @@ export interface TailwindResult {
 
 export interface GenerateOptions {
   minify?: boolean;
+  environment?: string;
+  buildMode?: "development" | "production";
 }
 
 export interface CSSErrorInfo {
@@ -69,7 +76,11 @@ export async function getProjectCSS(
   candidates: Set<string>,
   options?: GenerateOptions,
 ): Promise<{ css: string; hash: string; fromCache: boolean }> {
-  const context = createProjectCSSRequestContext(projectSlug, stylesheet, candidates);
+  const context = createProjectCSSRequestContext(projectSlug, stylesheet, candidates, {
+    minify: options?.minify,
+    environment: options?.environment,
+    buildMode: options?.buildMode,
+  });
 
   const localHit = await tryGetProjectCSSFromLocalFallback(context, candidates);
   if (localHit) return localHit;
@@ -81,36 +92,55 @@ export async function getProjectCSS(
   const distributedHit = await tryGetProjectCSSFromDistributedCache(context, candidates);
   if (distributedHit) return distributedHit;
 
-  // Generate fresh CSS
-  const result = await generateTailwindCSS(context.stylesheet, candidates, options);
-
-  if (result.error) {
-    const formatted = formatCSSError(result.error);
-    logger.error("Project CSS generation failed", {
+  const inFlight = inFlightProjectCSS.get(context.cacheKey);
+  if (inFlight) {
+    logger.debug("Project CSS compile single-flight hit", {
       projectSlug: context.projectSlug,
-      error: formatted.message,
-      suggestion: formatted.suggestion,
+      cacheKeySuffix: context.cacheKey.slice(-24),
     });
-    throw new Error(
-      `[tailwind] ${formatted.title}: ${formatted.message} Suggestion: ${formatted.suggestion}`,
-    );
+    return inFlight;
   }
 
-  const hash = hashCSS(result.css);
-  await storeProjectCSS(
-    context,
-    { css: result.css, hash, candidatesHash: context.candidatesHash },
-    candidates,
-  );
+  const generationPromise = (async () => {
+    // Generate fresh CSS
+    const result = await generateTailwindCSS(context.stylesheet, candidates, options);
 
-  logger.debug("Project CSS generated", {
-    projectSlug: context.projectSlug,
-    hash,
-    cssLength: result.css.length,
-    candidateCount: candidates.size,
-  });
+    if (result.error) {
+      const formatted = formatCSSError(result.error);
+      logger.error("Project CSS generation failed", {
+        projectSlug: context.projectSlug,
+        error: formatted.message,
+        suggestion: formatted.suggestion,
+      });
+      throw new Error(
+        `[tailwind] ${formatted.title}: ${formatted.message} Suggestion: ${formatted.suggestion}`,
+      );
+    }
 
-  return { css: result.css, hash, fromCache: false };
+    const hash = hashCSS(result.css);
+    await storeProjectCSS(
+      context,
+      { css: result.css, hash, candidatesHash: context.candidatesHash },
+      candidates,
+    );
+
+    logger.debug("Project CSS generated", {
+      projectSlug: context.projectSlug,
+      hash,
+      cssLength: result.css.length,
+      candidateCount: candidates.size,
+    });
+
+    return { css: result.css, hash, fromCache: false };
+  })();
+
+  inFlightProjectCSS.set(context.cacheKey, generationPromise);
+
+  try {
+    return await generationPromise;
+  } finally {
+    inFlightProjectCSS.delete(context.cacheKey);
+  }
 }
 
 // ============================================================================
@@ -128,7 +158,10 @@ export async function getProjectCSS(
  * @returns The regenerated CSS if inputs are cached and hash matches, undefined otherwise
  */
 export async function regenerateCSSByHash(expectedHash: string): Promise<string | undefined> {
-  return await withSpan(
+  const inFlight = inFlightRegeneration.get(expectedHash);
+  if (inFlight) return await inFlight;
+
+  const regenerationPromise = withSpan(
     SpanNames.HTML_REGENERATE_CSS_BY_HASH,
     async () => {
       const inputs = await resolveRegenerationInputs(expectedHash);
@@ -175,6 +208,14 @@ export async function regenerateCSSByHash(expectedHash: string): Promise<string 
     },
     { "css.hash": expectedHash },
   );
+
+  inFlightRegeneration.set(expectedHash, regenerationPromise);
+
+  try {
+    return await regenerationPromise;
+  } finally {
+    inFlightRegeneration.delete(expectedHash);
+  }
 }
 
 // ============================================================================

--- a/src/modules/react-loader/css-import-collector.ts
+++ b/src/modules/react-loader/css-import-collector.ts
@@ -1,0 +1,50 @@
+/**
+ * CSS Import Collector - Request-scoped CSS import tracking for SSR
+ *
+ * Collects CSS import paths discovered during module loading using
+ * AsyncLocalStorage for proper isolation between concurrent requests.
+ *
+ * Usage:
+ *   const { result, cssImports } = await runWithCSSCollector(() => loadModules(...));
+ *   // cssImports contains absolute paths to CSS files discovered during loading
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+interface CSSCollectorStore {
+  imports: Set<string>;
+}
+
+const cssStorage = new AsyncLocalStorage<CSSCollectorStore>();
+
+/**
+ * Run a function with CSS import collection enabled.
+ * Returns the function result and all collected CSS import paths.
+ */
+export async function runWithCSSCollector<T>(
+  fn: () => T | Promise<T>,
+): Promise<{ result: T; cssImports: string[] }> {
+  const store: CSSCollectorStore = { imports: new Set() };
+  const result = await cssStorage.run(store, fn);
+  return { result, cssImports: [...store.imports] };
+}
+
+/**
+ * Register a CSS import path discovered during module loading.
+ * No-op if called outside of a runWithCSSCollector context.
+ */
+export function registerCSSImport(absolutePath: string): void {
+  const store = cssStorage.getStore();
+  if (!store) return;
+  store.imports.add(absolutePath);
+}
+
+/**
+ * Get all CSS imports collected so far in the current context.
+ * Returns empty array if called outside of a runWithCSSCollector context.
+ */
+export function getCSSImports(): string[] {
+  const store = cssStorage.getStore();
+  if (!store) return [];
+  return [...store.imports];
+}

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -52,6 +52,7 @@ import { SSRCircuitBreaker } from "./ssr-circuit-breaker.ts";
 import { SSRDependencyValidator } from "./ssr-dependency-validator.ts";
 import { preflightLocalImports } from "./preflight-imports.ts";
 import { resolveVfModuleImports } from "./vf-module-resolver.ts";
+import { registerCSSImport } from "../css-import-collector.ts";
 
 const logger = rendererLogger.component("ssr-module-loader");
 
@@ -479,6 +480,12 @@ export class SSRModuleLoader {
         this.options.projectDir,
         this.options.adapter,
       );
+
+      // Register CSS imports for later inclusion in HTML output.
+      // CSS files are not JS modules — skip them in the dependency graph.
+      for (const cssImport of parseResult.cssImports) {
+        registerCSSImport(cssImport.absolutePath);
+      }
 
       if (parseResult.missing.length > 0) {
         this.depValidator.missingDependencies.push(...parseResult.missing);

--- a/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
@@ -9,6 +9,7 @@
 
 import type { CrossProjectImport, MissingImport } from "#veryfront/transforms/esm/import-parser.ts";
 import { parseLocalImports } from "#veryfront/transforms/esm/import-parser.ts";
+import { registerCSSImport } from "../css-import-collector.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import { rendererLogger } from "#veryfront/utils";
@@ -91,6 +92,11 @@ export class SSRDependencyValidator {
       this.projectDir,
       this.adapter,
     );
+
+    // Register CSS imports from cached modules for HTML inclusion
+    for (const cssImport of parseResult.cssImports) {
+      registerCSSImport(cssImport.absolutePath);
+    }
 
     if (parseResult.missing.length > 0) {
       this.missingDependencies.push(...parseResult.missing);

--- a/src/platform/adapters/fs/factory.ts
+++ b/src/platform/adapters/fs/factory.ts
@@ -19,6 +19,7 @@ import {
 } from "#veryfront/rendering/snippet-renderer.ts";
 import { clearRendererCacheForProject } from "#veryfront/rendering/renderer.ts";
 import { invalidateProjectCSS } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
+import { invalidateProjectCandidateManifests } from "#veryfront/rendering/orchestrator/css-candidate-manifest.ts";
 
 export function createFSAdapter(config: FSAdapterConfig): Promise<FSAdapter> {
   const type = config.type ?? "local";
@@ -51,7 +52,10 @@ export function createFSAdapter(config: FSAdapterConfig): Promise<FSAdapter> {
             clearRouterDetectionCacheForProject,
             clearSnippetCacheForProject,
             clearRendererCacheForProject,
-            clearProjectCSSCache: invalidateProjectCSS,
+            clearProjectCSSCache: (projectSlug: string) => {
+              invalidateProjectCSS(projectSlug);
+              invalidateProjectCandidateManifests(projectSlug);
+            },
             ...config.invalidationCallbacks,
           },
         };

--- a/src/rendering/orchestrator/css-candidate-manifest.ts
+++ b/src/rendering/orchestrator/css-candidate-manifest.ts
@@ -1,0 +1,176 @@
+import { extractCandidates } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
+import { getRouteModulePaths } from "#veryfront/modules/manifest/route-module-manifest.ts";
+import { rendererLogger } from "#veryfront/utils";
+
+interface SourceFileLike {
+  path: string;
+  content?: string;
+}
+
+interface CandidateManifest {
+  fileCandidates: Map<string, Set<string>>;
+  allCandidates: Set<string>;
+  builtAt: number;
+}
+
+interface RouteCandidateOptions {
+  projectScope: string;
+  projectVersion: string;
+  projectDir: string;
+  routeKey: string;
+  routeFilePaths: string[];
+  files: SourceFileLike[];
+  developmentMode: boolean;
+}
+
+const logger = rendererLogger.component("css-candidate-manifest");
+const SOURCE_EXTENSIONS = [".tsx", ".jsx", ".mdx", ".ts", ".js"];
+const DEV_MANIFEST_TTL_MS = 2000;
+
+const manifestCache = new Map<string, CandidateManifest>();
+const routeCandidateCache = new Map<string, Set<string>>();
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/{2,}/g, "/");
+}
+
+function toRelativeProjectPath(path: string, projectDir: string): string {
+  const normalized = normalizePath(path);
+  const normalizedProjectDir = normalizePath(projectDir).replace(/\/+$/, "");
+  if (normalized.startsWith(normalizedProjectDir)) {
+    return normalized.slice(normalizedProjectDir.length).replace(/^\/+/, "");
+  }
+  return normalized.replace(/^\/+/, "");
+}
+
+function buildManifestCacheKey(projectScope: string, projectVersion: string): string {
+  return `${projectScope}:${projectVersion}`;
+}
+
+function shouldRebuildManifest(
+  existing: CandidateManifest | undefined,
+  developmentMode: boolean,
+): boolean {
+  if (!existing) return true;
+  if (!developmentMode) return false;
+  return (Date.now() - existing.builtAt) > DEV_MANIFEST_TTL_MS;
+}
+
+function buildSourceCandidatePaths(modulePath: string): string[] {
+  const normalized = normalizePath(modulePath).replace(/^\/+/, "").replace(/^_vf_modules\//, "");
+  if (!normalized.endsWith(".js")) return [normalized];
+  const withoutJs = normalized.slice(0, -3);
+  return [
+    `${withoutJs}.tsx`,
+    `${withoutJs}.ts`,
+    `${withoutJs}.jsx`,
+    `${withoutJs}.mdx`,
+    `${withoutJs}.js`,
+  ];
+}
+
+function buildCandidateManifest(files: SourceFileLike[], projectDir: string): CandidateManifest {
+  const fileCandidates = new Map<string, Set<string>>();
+  const allCandidates = new Set<string>();
+
+  for (const file of files) {
+    if (!file.content) continue;
+    if (!SOURCE_EXTENSIONS.some((ext) => file.path.endsWith(ext))) continue;
+
+    const candidates = new Set(extractCandidates(file.content));
+    const relativePath = toRelativeProjectPath(file.path, projectDir);
+    const absolutePath = normalizePath(file.path);
+
+    fileCandidates.set(relativePath, candidates);
+    fileCandidates.set(absolutePath, candidates);
+
+    for (const cls of candidates) allCandidates.add(cls);
+  }
+
+  return { fileCandidates, allCandidates, builtAt: Date.now() };
+}
+
+function addCandidatesForPath(
+  target: Set<string>,
+  manifest: CandidateManifest,
+  path: string,
+  projectDir: string,
+): void {
+  const absolutePath = normalizePath(path);
+  const relativePath = toRelativeProjectPath(path, projectDir);
+  const candidates = manifest.fileCandidates.get(absolutePath) ??
+    manifest.fileCandidates.get(relativePath);
+  if (!candidates) return;
+  for (const cls of candidates) target.add(cls);
+}
+
+/**
+ * Resolve route-scoped Tailwind candidates from a precomputed per-project manifest.
+ */
+export function getRouteCandidates(options: RouteCandidateOptions): Set<string> {
+  const manifestKey = buildManifestCacheKey(options.projectScope, options.projectVersion);
+  const existingManifest = manifestCache.get(manifestKey);
+  const manifest = shouldRebuildManifest(existingManifest, options.developmentMode)
+    ? buildCandidateManifest(options.files, options.projectDir)
+    : existingManifest!;
+
+  if (manifest !== existingManifest) {
+    manifestCache.set(manifestKey, manifest);
+
+    // Clear route subsets when project-level file manifest is rebuilt.
+    for (const key of routeCandidateCache.keys()) {
+      if (key.startsWith(`${manifestKey}:`)) routeCandidateCache.delete(key);
+    }
+  }
+
+  const routeCacheKey = `${manifestKey}:${options.routeKey}`;
+  const cachedRoute = routeCandidateCache.get(routeCacheKey);
+  if (cachedRoute) return new Set(cachedRoute);
+
+  const routeCandidates = new Set<string>();
+
+  for (const path of options.routeFilePaths) {
+    addCandidatesForPath(routeCandidates, manifest, path, options.projectDir);
+  }
+
+  for (const modulePath of getRouteModulePaths(options.projectScope, options.routeKey)) {
+    for (const sourcePath of buildSourceCandidatePaths(modulePath)) {
+      addCandidatesForPath(routeCandidates, manifest, sourcePath, options.projectDir);
+    }
+  }
+
+  // Fallback to full-project candidates for correctness if route manifest is incomplete.
+  if (routeCandidates.size === 0) {
+    for (const cls of manifest.allCandidates) routeCandidates.add(cls);
+  }
+
+  routeCandidateCache.set(routeCacheKey, routeCandidates);
+
+  logger.debug("Resolved route candidates", {
+    projectScope: options.projectScope,
+    projectVersion: options.projectVersion,
+    route: options.routeKey,
+    count: routeCandidates.size,
+  });
+
+  return new Set(routeCandidates);
+}
+
+/**
+ * Invalidate cached candidate manifests for one project scope (or all scopes).
+ */
+export function invalidateProjectCandidateManifests(projectScope?: string): void {
+  if (!projectScope) {
+    manifestCache.clear();
+    routeCandidateCache.clear();
+    return;
+  }
+
+  for (const key of manifestCache.keys()) {
+    if (key.startsWith(`${projectScope}:`)) manifestCache.delete(key);
+  }
+
+  for (const key of routeCandidateCache.keys()) {
+    if (key.startsWith(`${projectScope}:`)) routeCandidateCache.delete(key);
+  }
+}

--- a/src/rendering/orchestrator/html.test.ts
+++ b/src/rendering/orchestrator/html.test.ts
@@ -219,4 +219,92 @@ describe("HTMLGenerator helpers", () => {
       assertExists(generator);
     });
   });
+
+  describe("mergeImportedCSS", () => {
+    it("deduplicates only exact configured stylesheet path", async () => {
+      const readPaths: string[] = [];
+      const mockAdapter = {
+        fs: {
+          readFile: async (path: string) => {
+            readPaths.push(path);
+            if (path === "/project/styles/globals.css") return ".feature { color: red; }";
+            if (path === "/project/globals.css") return ".duplicate { color: blue; }";
+            return "";
+          },
+          exists: async () => false,
+          stat: async () => ({
+            isFile: false,
+            isDirectory: false,
+            isSymlink: false,
+            size: 0,
+            mtime: null,
+          }),
+          readDir: async function* () {},
+          mkdir: async () => {},
+          writeFile: async () => {},
+        },
+      };
+
+      const generator = new HTMLGenerator({
+        projectDir: "/project",
+        adapter: mockAdapter as any,
+        config: {} as any,
+        mode: "development",
+      });
+
+      const merged = await (generator as any).mergeImportedCSS(
+        "/* global */",
+        ["/project/styles/globals.css", "/project/globals.css"],
+        "globals.css",
+      );
+
+      assertEquals(readPaths, ["/project/styles/globals.css"]);
+      assertEquals(merged?.includes("/* global */"), true);
+      assertEquals(merged?.includes(".feature { color: red; }"), true);
+      assertEquals(merged?.includes(".duplicate { color: blue; }"), false);
+    });
+
+    it("orders imported css deterministically and rewrites module selectors", async () => {
+      const mockAdapter = {
+        fs: {
+          readFile: async (path: string) => {
+            if (path === "/project/b.css") return ".b { color: blue; }";
+            if (path === "/project/a.module.css") return ".root { color: red; }";
+            return "";
+          },
+          exists: async () => false,
+          stat: async () => ({
+            isFile: false,
+            isDirectory: false,
+            isSymlink: false,
+            size: 0,
+            mtime: null,
+          }),
+          readDir: async function* () {},
+          mkdir: async () => {},
+          writeFile: async () => {},
+        },
+      };
+
+      const generator = new HTMLGenerator({
+        projectDir: "/project",
+        adapter: mockAdapter as any,
+        config: {} as any,
+        mode: "development",
+      });
+
+      const merged = await (generator as any).mergeImportedCSS(
+        "/* global */",
+        ["/project/a.module.css", "/project/b.css"],
+        "globals.css",
+      );
+
+      assertEquals(
+        merged?.indexOf(".b { color: blue; }")! > merged?.indexOf("/* global */")!,
+        true,
+      );
+      assertEquals(merged?.includes(".a_root__"), true);
+      assertEquals(merged?.indexOf(".a_root__")! > merged?.indexOf(".b { color: blue; }")!, true);
+    });
+  });
 });

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -8,7 +8,6 @@ import {
   injectHTMLContent,
   isFullHTMLDocument,
 } from "#veryfront/html";
-import { extractCandidates } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
 import type { CollectedHead } from "#veryfront/react/head-collector.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type {
@@ -25,6 +24,11 @@ import { computeSourceHash } from "#veryfront/studio/hash-utils.ts";
 import { extractRelativePath } from "#veryfront/utils/route-path-utils.ts";
 import { resolveAppComponentPath } from "../layouts/utils/app-resolver.ts";
 import { StreamTimeoutError, streamToString } from "../utils/stream-utils.ts";
+import {
+  normalizeCssModuleKey,
+  rewriteCssModuleContent,
+} from "#veryfront/transforms/css-modules/naming.ts";
+import { getRouteCandidates } from "./css-candidate-manifest.ts";
 
 const logger = rendererLogger.component("html-generator");
 
@@ -46,6 +50,8 @@ export interface HTMLGenerationContext {
   ssrHash: string;
   options?: RenderOptions;
   collectedHead?: CollectedHead;
+  /** Absolute paths to CSS files imported by components (collected during module loading) */
+  cssImports?: string[];
 }
 
 export class HTMLGenerator {
@@ -306,11 +312,15 @@ export class HTMLGenerator {
     mergedFrontmatter: MDXFrontmatter,
   ): Promise<HTMLGenerationOptions> {
     const stylesheetPath = this.config.config?.tailwind?.stylesheet || "globals.css";
-    const [appComponentPath, globalCSS, projectClasses] = await Promise.all([
+    const [appComponentPath, globalCSS] = await Promise.all([
       this.resolveAppPath().then((p) => p ?? undefined),
       this.loadProjectFile(stylesheetPath),
-      this.extractProjectClasses(),
     ]);
+    const projectClasses = await this.extractProjectClassesForRoute(context, appComponentPath);
+
+    // Load CSS imported by components and merge with globalCSS.
+    // Deduplicate against the configured stylesheet to avoid double-loading.
+    const combinedCSS = await this.mergeImportedCSS(globalCSS, context.cssImports, stylesheetPath);
 
     logger.debug("App component resolution", {
       appComponentPath,
@@ -351,7 +361,7 @@ export class HTMLGenerator {
       pagePath,
       pageType,
       nonce: context.options?.nonce,
-      globalCSS,
+      globalCSS: combinedCSS,
       frontmatter: mergedFrontmatter,
       studioEmbed: context.options?.studioEmbed,
       projectId: context.options?.projectId,
@@ -368,8 +378,94 @@ export class HTMLGenerator {
     };
   }
 
-  private async extractProjectClasses(): Promise<Set<string>> {
-    const SOURCE_EXTENSIONS = [".tsx", ".jsx", ".mdx", ".ts", ".js"];
+  /**
+   * Load CSS files imported by components and merge with the global stylesheet.
+   * Deduplicates against the configured Tailwind stylesheet path to avoid
+   * double-loading globals.css when it's both auto-discovered and explicitly imported.
+   */
+  private async mergeImportedCSS(
+    globalCSS: string | undefined,
+    cssImports: string[] | undefined,
+    stylesheetPath: string,
+  ): Promise<string | undefined> {
+    if (!cssImports || cssImports.length === 0) return globalCSS;
+
+    const normalizedStylesheetPath = stylesheetPath.replace(/^\/+/, "");
+    const configuredStylesheetAbsolute = normalizeCssModuleKey(
+      join(this.config.projectDir, normalizedStylesheetPath),
+    );
+    const uniqueImports = new Map<string, string>();
+    for (const cssPath of cssImports) {
+      const normalized = normalizeCssModuleKey(cssPath);
+      if (!uniqueImports.has(normalized)) {
+        uniqueImports.set(normalized, cssPath);
+      }
+    }
+
+    const sortedImports = [...uniqueImports.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+    const regularCssSegments: string[] = [];
+    const moduleCssSegments: string[] = [];
+
+    for (const [normalizedCssPath, cssPath] of sortedImports) {
+      // Deduplicate only exact path matches to avoid skipping unrelated files
+      // like /styles/globals.css when the configured stylesheet is /globals.css.
+      if (normalizedCssPath === configuredStylesheetAbsolute) {
+        continue;
+      }
+
+      try {
+        const content = await this.config.adapter.fs.readFile(cssPath);
+        if (!content) continue;
+
+        if (normalizedCssPath.endsWith(".module.css")) {
+          moduleCssSegments.push(rewriteCssModuleContent(content, normalizedCssPath));
+        } else {
+          regularCssSegments.push(content);
+        }
+      } catch {
+        logger.debug("Could not load imported CSS file", { cssPath });
+      }
+    }
+
+    if (regularCssSegments.length === 0 && moduleCssSegments.length === 0) return globalCSS;
+
+    const combined = [globalCSS, ...regularCssSegments, ...moduleCssSegments]
+      .filter(Boolean)
+      .join("\n");
+    logger.debug("Merged imported CSS with global stylesheet", {
+      importedCount: regularCssSegments.length + moduleCssSegments.length,
+      regularCount: regularCssSegments.length,
+      moduleCount: moduleCssSegments.length,
+      totalLength: combined.length,
+    });
+    return combined;
+  }
+
+  private getProjectContentVersion(): string | undefined {
+    const wrappedFs = this.config.adapter.fs as unknown as {
+      getUnderlyingAdapter?: () => unknown;
+    };
+
+    if (typeof wrappedFs.getUnderlyingAdapter !== "function") return undefined;
+
+    const fsAdapter = wrappedFs.getUnderlyingAdapter() as {
+      getProjectData?: () => { updated_at?: string } | undefined;
+    };
+
+    return fsAdapter.getProjectData?.()?.updated_at;
+  }
+
+  private buildRouteManifestKey(pagePath: string): string {
+    const relativePagePath = extractRelativePath(pagePath, this.config.projectDir);
+    return relativePagePath
+      .replace(/\.(tsx|ts|jsx|mdx|md|js)$/, "")
+      .replace(/^pages\//, "");
+  }
+
+  private async extractProjectClassesForRoute(
+    context: HTMLGenerationContext,
+    appComponentPath?: string,
+  ): Promise<Set<string>> {
     const classes = new Set<string>();
 
     const wrappedFs = this.config.adapter.fs as unknown as {
@@ -387,20 +483,36 @@ export class HTMLGenerator {
     if (typeof fsAdapter.getAllSourceFiles !== "function") return classes;
 
     const files = await fsAdapter.getAllSourceFiles();
+    const projectScope = context.options?.projectSlug || context.options?.projectId ||
+      this.config.projectDir;
+    const projectVersion = this.getProjectContentVersion() ??
+      (this.config.mode === "development" ? "dev" : "unknown");
+    const routeKey = this.buildRouteManifestKey(context.pageInfo.entity.path);
+    const routeLayoutPaths = context.nestedLayouts
+      .map((layout) => layout.componentPath || layout.path)
+      .filter((path): path is string => Boolean(path));
+    const routeFilePaths = [
+      context.pageInfo.entity.path,
+      ...routeLayoutPaths,
+      ...(appComponentPath ? [appComponentPath] : []),
+    ];
 
-    let filesProcessed = 0;
-    for (const file of files) {
-      if (!file.content) continue;
-      if (!SOURCE_EXTENSIONS.some((ext) => file.path.endsWith(ext))) continue;
+    const routeCandidates = getRouteCandidates({
+      projectScope,
+      projectVersion,
+      projectDir: this.config.projectDir,
+      routeKey,
+      routeFilePaths,
+      files,
+      developmentMode: this.config.mode === "development",
+    });
 
-      filesProcessed++;
-      for (const cls of extractCandidates(file.content)) {
-        classes.add(cls);
-      }
-    }
+    for (const cls of routeCandidates) classes.add(cls);
 
     logger.debug("extractProjectClasses", {
-      filesProcessed,
+      filesProcessed: files.length,
+      routeKey,
+      routeFileCount: routeFilePaths.length,
       totalClasses: classes.size,
     });
 

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -46,6 +46,10 @@ import { withTimeout, withTimeoutThrow } from "../utils/stream-utils.ts";
 import { generateTailwind4CSS } from "#veryfront/html/styles-builder/index.ts";
 import { createEsmCache, createModuleCache, loadModule } from "./module-loader/index.ts";
 import type { ModuleLoaderConfig } from "./module-loader/index.ts";
+import {
+  getCSSImports,
+  runWithCSSCollector,
+} from "#veryfront/modules/react-loader/css-import-collector.ts";
 
 // Extracted modules
 import { EMPTY_LAYOUT_RESULT, isDotPath } from "./path-helpers.ts";
@@ -339,186 +343,200 @@ export class RenderPipeline {
 
     return withSpan(
       "render.page",
-      async () => {
-        const pageResolveStart = performance.now();
-        const pageInfo = await withSpan(
-          "render.resolve_page",
-          () => this.config.pageResolver.resolvePage(slug),
-          { "render.slug": slug },
-        );
-        timing.pageResolve = Math.round(performance.now() - pageResolveStart);
-
-        const skipLayouts = isDotPath(slug, pageInfo.entity.path);
-
-        const layoutCollectStart = performance.now();
-        const layoutResult = skipLayouts ? EMPTY_LAYOUT_RESULT : await withSpan(
-          "render.collect_layouts",
-          () => this.config.layoutOrchestrator.collectLayouts(pageInfo),
-          { "render.slug": slug },
-        );
-        timing.layoutCollect = Math.round(performance.now() - layoutCollectStart);
-
-        const layoutPreloadPromise = !skipLayouts && layoutResult.nestedLayouts.length > 0
-          ? this.config.layoutOrchestrator.preloadLayoutModules(layoutResult.nestedLayouts)
-          : Promise.resolve();
-
-        let dataFetchingProps: Record<string, unknown> | undefined;
-        let resolvedParams: Record<string, string | string[]> = options?.params
-          ? { ...options.params }
-          : {};
-        let layoutDataMap = new Map<string, Record<string, unknown>>();
-
-        const dataFetchStart = performance.now();
-        if (options?.request && options?.url) {
-          await withSpan(
-            "render.data_fetching",
-            async () => {
-              try {
-                const dataResolution = await this.resolveDataFetching(
-                  slug,
-                  pageInfo.entity.path,
-                  layoutResult.nestedLayouts,
-                  options,
-                );
-                resolvedParams = dataResolution.params;
-                dataFetchingProps = Object.keys(dataResolution.pageProps).length > 0
-                  ? dataResolution.pageProps
-                  : undefined;
-                layoutDataMap = dataResolution.layoutProps;
-              } catch (error) {
-                if (error instanceof VeryfrontError) throw error;
-
-                renderPageLog.error("Data fetching error", {
-                  slug,
-                  error: error instanceof Error ? error.message : String(error),
-                });
-                throw error;
-              }
-            },
+      () =>
+        runWithCSSCollector(async () => {
+          const pageResolveStart = performance.now();
+          const pageInfo = await withSpan(
+            "render.resolve_page",
+            () => this.config.pageResolver.resolvePage(slug),
             { "render.slug": slug },
           );
-        }
-        timing.dataFetch = Math.round(performance.now() - dataFetchStart);
+          timing.pageResolve = Math.round(performance.now() - pageResolveStart);
 
-        const hasResolvedParams = Object.keys(resolvedParams).length > 0;
-        const mergedOptions = (dataFetchingProps || hasResolvedParams)
-          ? {
-            ...options,
-            ...(hasResolvedParams ? { params: resolvedParams } : {}),
-            ...(dataFetchingProps ? { props: { ...options?.props, ...dataFetchingProps } } : {}),
+          const skipLayouts = isDotPath(slug, pageInfo.entity.path);
+
+          const layoutCollectStart = performance.now();
+          const layoutResult = skipLayouts ? EMPTY_LAYOUT_RESULT : await withSpan(
+            "render.collect_layouts",
+            () => this.config.layoutOrchestrator.collectLayouts(pageInfo),
+            { "render.slug": slug },
+          );
+          timing.layoutCollect = Math.round(performance.now() - layoutCollectStart);
+
+          const layoutPreloadPromise = !skipLayouts && layoutResult.nestedLayouts.length > 0
+            ? this.config.layoutOrchestrator.preloadLayoutModules(layoutResult.nestedLayouts)
+            : Promise.resolve();
+
+          let dataFetchingProps: Record<string, unknown> | undefined;
+          let resolvedParams: Record<string, string | string[]> = options?.params
+            ? { ...options.params }
+            : {};
+          let layoutDataMap = new Map<string, Record<string, unknown>>();
+
+          const dataFetchStart = performance.now();
+          if (options?.request && options?.url) {
+            await withSpan(
+              "render.data_fetching",
+              async () => {
+                try {
+                  const dataResolution = await this.resolveDataFetching(
+                    slug,
+                    pageInfo.entity.path,
+                    layoutResult.nestedLayouts,
+                    options,
+                  );
+                  resolvedParams = dataResolution.params;
+                  dataFetchingProps = Object.keys(dataResolution.pageProps).length > 0
+                    ? dataResolution.pageProps
+                    : undefined;
+                  layoutDataMap = dataResolution.layoutProps;
+                } catch (error) {
+                  if (error instanceof VeryfrontError) throw error;
+
+                  renderPageLog.error("Data fetching error", {
+                    slug,
+                    error: error instanceof Error ? error.message : String(error),
+                  });
+                  throw error;
+                }
+              },
+              { "render.slug": slug },
+            );
           }
-          : options;
+          timing.dataFetch = Math.round(performance.now() - dataFetchStart);
 
-        const bundlePrepStart = performance.now();
-        const pageBundleResult = await withSpan(
-          "render.prepare_bundles",
-          () =>
-            this.config.pageRenderer.preparePageBundles(
-              pageInfo,
-              slug,
-              cacheResult?.cachedModule,
-              mergedOptions,
-            ),
-          { "render.slug": slug },
-        );
-        timing.bundlePrep = Math.round(performance.now() - bundlePrepStart);
+          const hasResolvedParams = Object.keys(resolvedParams).length > 0;
+          const mergedOptions = (dataFetchingProps || hasResolvedParams)
+            ? {
+              ...options,
+              ...(hasResolvedParams ? { params: resolvedParams } : {}),
+              ...(dataFetchingProps ? { props: { ...options?.props, ...dataFetchingProps } } : {}),
+            }
+            : options;
 
-        if (pageBundleResult.scriptResult) return pageBundleResult.scriptResult;
-
-        if (!pageBundleResult.pageElement || !pageBundleResult.pageBundle) {
-          throw RENDER_ERROR.create({
-            detail: "Failed to prepare page bundle",
-            context: { slug },
-          });
-        }
-
-        const { pageElement, pageBundle } = pageBundleResult;
-
-        const mergedFrontmatter = {
-          ...pageInfo.entity.frontmatter,
-          ...(pageBundle as MdxBundle).frontmatter,
-        };
-
-        const headings = (pageBundle as PageBundle).headings || [];
-
-        await layoutPreloadPromise;
-
-        const layoutApplyStart = performance.now();
-        const wrappedElement = await withSpan(
-          "render.apply_layouts",
-          () =>
-            this.config.layoutOrchestrator.applyLayoutsAndWrappers(
-              pageElement,
-              pageInfo,
-              layoutResult.layoutBundle,
-              layoutResult.nestedLayouts,
-              layoutDataMap,
-              options?.url,
-              mergedFrontmatter,
-              headings,
-              options?.projectSlug,
-            ),
-          { "render.slug": slug, "render.layout_count": layoutResult.nestedLayouts.length },
-        );
-        timing.layoutApply = Math.round(performance.now() - layoutApplyStart);
-
-        const ssrStart = performance.now();
-        const ssrResult = await withSpan(
-          "render.ssr",
-          () =>
-            withTimeoutThrow(
-              this.config.ssrOrchestrator.performSSRRendering(
-                wrappedElement,
-                {
-                  pageInfo,
-                  pageBundle,
-                  layoutBundle: layoutResult.layoutBundle,
-                  nestedLayouts: layoutResult.nestedLayouts,
-                  collectedMetadata: pageBundleResult.collectedMetadata,
-                  slug,
-                },
+          const bundlePrepStart = performance.now();
+          const pageBundleResult = await withSpan(
+            "render.prepare_bundles",
+            () =>
+              this.config.pageRenderer.preparePageBundles(
+                pageInfo,
+                slug,
+                cacheResult?.cachedModule,
                 mergedOptions,
               ),
-              SSR_RENDER_TIMEOUT_MS,
-              `SSR rendering for ${slug}`,
-            ),
-          { "render.slug": slug, "render.delivery": mergedOptions?.delivery || "full" },
-        );
-        timing.ssr = Math.round(performance.now() - ssrStart);
+            { "render.slug": slug },
+          );
+          timing.bundlePrep = Math.round(performance.now() - bundlePrepStart);
 
-        const pageModule = pageBundleResult.clientModuleCode && pageBundleResult.pageModuleType
-          ? {
-            slug,
-            code: pageBundleResult.clientModuleCode,
-            type: pageBundleResult.pageModuleType,
-          }
-          : undefined;
+          if (pageBundleResult.scriptResult) return pageBundleResult.scriptResult;
 
-        const result: RenderResult = {
-          html: ssrResult.fullHtml,
-          frontmatter: (pageBundleResult.pageBundle as MdxBundle).frontmatter || {},
-          headings: pageBundleResult.pageBundle.headings || [],
-          nodeMap: pageBundleResult.pageBundle.nodeMap,
-          stream: ssrResult.finalStream,
-          ssrHash: ssrResult.ssrHash,
-          ...(pageModule ? { pageModule } : {}),
-        };
-
-        if (shouldCache && !options?.skipCachePersist) {
-          this.config.cacheCoordinator.persistResult(result, slug, cacheKey).catch((error) => {
-            renderPipelineLog.error("Cache persist failed", {
-              slug,
-              error: error instanceof Error ? error.message : String(error),
-              stack: error instanceof Error ? error.stack : undefined,
+          if (!pageBundleResult.pageElement || !pageBundleResult.pageBundle) {
+            throw RENDER_ERROR.create({
+              detail: "Failed to prepare page bundle",
+              context: { slug },
             });
-          });
-        }
+          }
 
-        timing.total = Math.round(performance.now() - pipelineStartTime);
-        renderPipelineLog.debug("Complete", { slug, timing });
+          const { pageElement, pageBundle } = pageBundleResult;
 
-        return result;
-      },
+          const mergedFrontmatter = {
+            ...pageInfo.entity.frontmatter,
+            ...(pageBundle as MdxBundle).frontmatter,
+          };
+
+          const headings = (pageBundle as PageBundle).headings || [];
+
+          await layoutPreloadPromise;
+
+          const layoutApplyStart = performance.now();
+          const wrappedElement = await withSpan(
+            "render.apply_layouts",
+            () =>
+              this.config.layoutOrchestrator.applyLayoutsAndWrappers(
+                pageElement,
+                pageInfo,
+                layoutResult.layoutBundle,
+                layoutResult.nestedLayouts,
+                layoutDataMap,
+                options?.url,
+                mergedFrontmatter,
+                headings,
+                options?.projectSlug,
+              ),
+            { "render.slug": slug, "render.layout_count": layoutResult.nestedLayouts.length },
+          );
+          timing.layoutApply = Math.round(performance.now() - layoutApplyStart);
+
+          // Snapshot CSS imports collected during module loading (before SSR rendering).
+          // These are passed to the HTML generator to be included in the output.
+          const collectedCSSImports = getCSSImports();
+
+          const ssrStart = performance.now();
+          const ssrResult = await withSpan(
+            "render.ssr",
+            () =>
+              withTimeoutThrow(
+                this.config.ssrOrchestrator.performSSRRendering(
+                  wrappedElement,
+                  {
+                    pageInfo,
+                    pageBundle,
+                    layoutBundle: layoutResult.layoutBundle,
+                    nestedLayouts: layoutResult.nestedLayouts,
+                    collectedMetadata: pageBundleResult.collectedMetadata,
+                    slug,
+                    cssImports: collectedCSSImports,
+                  },
+                  mergedOptions,
+                ),
+                SSR_RENDER_TIMEOUT_MS,
+                `SSR rendering for ${slug}`,
+              ),
+            { "render.slug": slug, "render.delivery": mergedOptions?.delivery || "full" },
+          );
+          timing.ssr = Math.round(performance.now() - ssrStart);
+
+          if (collectedCSSImports.length > 0) {
+            renderPipelineLog.debug("CSS imports collected for HTML generation", {
+              slug,
+              count: collectedCSSImports.length,
+              paths: collectedCSSImports.map((p) => p.split("/").pop()),
+            });
+          }
+
+          const pageModule = pageBundleResult.clientModuleCode && pageBundleResult.pageModuleType
+            ? {
+              slug,
+              code: pageBundleResult.clientModuleCode,
+              type: pageBundleResult.pageModuleType,
+            }
+            : undefined;
+
+          const result: RenderResult = {
+            html: ssrResult.fullHtml,
+            frontmatter: (pageBundleResult.pageBundle as MdxBundle).frontmatter || {},
+            headings: pageBundleResult.pageBundle.headings || [],
+            nodeMap: pageBundleResult.pageBundle.nodeMap,
+            stream: ssrResult.finalStream,
+            ssrHash: ssrResult.ssrHash,
+            ...(pageModule ? { pageModule } : {}),
+          };
+
+          if (shouldCache && !options?.skipCachePersist) {
+            this.config.cacheCoordinator.persistResult(result, slug, cacheKey).catch((error) => {
+              renderPipelineLog.error("Cache persist failed", {
+                slug,
+                error: error instanceof Error ? error.message : String(error),
+                stack: error instanceof Error ? error.stack : undefined,
+              });
+            });
+          }
+
+          timing.total = Math.round(performance.now() - pipelineStartTime);
+          renderPipelineLog.debug("Complete", { slug, timing });
+
+          return result;
+        }).then(({ result }) => result),
       {
         "render.slug": slug,
         "render.project_id": options?.projectId || this.config.projectDir,

--- a/src/task/index.ts
+++ b/src/task/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Task system public exports.
+ * @module
+ */
 export type { TaskContext, TaskDefinition } from "./types.ts";
 export { isTaskDefinition } from "./types.ts";
 export { deriveTaskId, discoverTasks, findTaskById } from "./discovery.ts";

--- a/src/transforms/css-modules/naming.test.ts
+++ b/src/transforms/css-modules/naming.test.ts
@@ -1,0 +1,63 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  normalizeCssModuleKey,
+  resolveCssModuleKey,
+  rewriteCssModuleContent,
+  toScopedCssModuleClass,
+} from "./naming.ts";
+
+describe("css-modules/naming", () => {
+  it("resolves relative and alias module keys deterministically", () => {
+    const relative = resolveCssModuleKey(
+      "./Button.module.css",
+      "/project/pages/home/index.tsx",
+      "/project",
+    );
+    const alias = resolveCssModuleKey(
+      "@/styles/Button.module.css",
+      "/project/pages/index.tsx",
+      "/project",
+    );
+
+    assertEquals(relative, "/project/pages/home/Button.module.css");
+    assertEquals(alias, "/project/styles/Button.module.css");
+  });
+
+  it("generates stable scoped class names", () => {
+    const key = "/project/components/Button.module.css";
+    const first = toScopedCssModuleClass(key, "container");
+    const second = toScopedCssModuleClass(key, "container");
+    const different = toScopedCssModuleClass(key, "header");
+
+    assertEquals(first, second);
+    assertEquals(first === different, false);
+    assertEquals(first.startsWith("Button_container__"), true);
+  });
+
+  it("rewrites module selectors and preserves :global()", () => {
+    const key = normalizeCssModuleKey("/project/components/Button.module.css");
+    const css = `
+.container { color: red; }
+:global(.prose) .container { margin: 0; }
+`;
+
+    const rewritten = rewriteCssModuleContent(css, key);
+
+    assertEquals(rewritten.includes(".Button_container__"), true);
+    assertEquals(rewritten.includes(":global(.prose)"), true);
+  });
+
+  it("rewrites compound selectors like .a.b", () => {
+    const key = normalizeCssModuleKey("/project/components/Card.module.css");
+    const css = `.container.active { color: red; }`;
+
+    const rewritten = rewriteCssModuleContent(css, key);
+
+    assertEquals(rewritten.includes(".Card_container__"), true);
+    assertEquals(rewritten.includes(".Card_active__"), true);
+    // Original unsoped class names should not remain
+    assertEquals(rewritten.includes(".container"), false);
+    assertEquals(rewritten.includes(".active {"), false);
+  });
+});

--- a/src/transforms/css-modules/naming.ts
+++ b/src/transforms/css-modules/naming.ts
@@ -1,0 +1,152 @@
+/**
+ * CSS Module naming and selector rewriting helpers.
+ *
+ * Provides deterministic class-name scoping that is stable across
+ * transform/runtime boundaries and HTML CSS aggregation.
+ */
+
+const CSS_MODULE_EXTENSION = ".module.css";
+
+/**
+ * Normalize a module key to a stable slash-based format.
+ * Removes query/hash suffixes and normalizes duplicate separators.
+ */
+export function normalizeCssModuleKey(path: string): string {
+  const withoutFilePrefix = path.startsWith("file://") ? path.slice("file://".length) : path;
+  const withoutQuery = withoutFilePrefix.replace(/[?#].*$/, "");
+  const slashed = withoutQuery.replace(/\\/g, "/");
+  const collapsed = slashed.replace(/\/{2,}/g, "/");
+  if (collapsed.startsWith("/")) return collapsed;
+  if (collapsed.startsWith("http://") || collapsed.startsWith("https://")) return collapsed;
+  return `/${collapsed.replace(/^\/+/, "")}`;
+}
+
+function dirname(path: string): string {
+  const normalized = normalizeCssModuleKey(path);
+  const lastSlash = normalized.lastIndexOf("/");
+  return lastSlash <= 0 ? "/" : normalized.slice(0, lastSlash);
+}
+
+function normalizePathSegments(path: string): string {
+  const normalized = normalizeCssModuleKey(path);
+  if (normalized.startsWith("http://") || normalized.startsWith("https://")) return normalized;
+
+  const parts = normalized.split("/").filter(Boolean);
+  const resolved: string[] = [];
+
+  for (const part of parts) {
+    if (part === ".") continue;
+    if (part === "..") {
+      resolved.pop();
+      continue;
+    }
+    resolved.push(part);
+  }
+
+  return `/${resolved.join("/")}`;
+}
+
+/**
+ * Resolve a CSS import specifier to a deterministic module key.
+ * Supports relative imports, @/ aliases, absolute paths, and URLs.
+ */
+export function resolveCssModuleKey(
+  specifier: string,
+  importerFilePath: string,
+  projectDir: string,
+): string {
+  if (specifier.startsWith("http://") || specifier.startsWith("https://")) {
+    return normalizeCssModuleKey(specifier);
+  }
+
+  if (specifier.startsWith("@/")) {
+    const aliasPath = specifier.slice(2).replace(/^\/+/, "");
+    return normalizePathSegments(`${normalizeCssModuleKey(projectDir)}/${aliasPath}`);
+  }
+
+  if (specifier.startsWith("/")) {
+    return normalizePathSegments(specifier);
+  }
+
+  if (specifier.startsWith("./") || specifier.startsWith("../")) {
+    const importerDir = dirname(importerFilePath);
+    return normalizePathSegments(`${importerDir}/${specifier}`);
+  }
+
+  // Bare specifiers are uncommon for CSS in this system, but keep deterministic behavior.
+  return normalizeCssModuleKey(specifier);
+}
+
+function hashString(input: string): string {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) + hash) ^ input.charCodeAt(i);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function sanitizeToken(token: string): string {
+  return token.replace(/[^\w-]/g, "_");
+}
+
+/**
+ * Build deterministic module scope info.
+ */
+export function getCssModuleScope(moduleKey: string): { base: string; hash: string } {
+  const normalized = normalizeCssModuleKey(moduleKey);
+  const filename = normalized.split("/").pop() || "module";
+  const base = sanitizeToken(
+    filename.endsWith(CSS_MODULE_EXTENSION)
+      ? filename.slice(0, -CSS_MODULE_EXTENSION.length)
+      : filename.replace(/\.css$/, ""),
+  ) || "module";
+  const hash = hashString(normalized).slice(0, 6);
+  return { base, hash };
+}
+
+/**
+ * Convert a local class name to its scoped CSS Module class.
+ */
+export function toScopedCssModuleClass(moduleKey: string, localName: string): string {
+  const { base, hash } = getCssModuleScope(moduleKey);
+  const normalizedLocal = sanitizeToken(localName);
+  return `${base}_${normalizedLocal}__${hash}`;
+}
+
+function maskGlobalSelectors(css: string): { masked: string; restore: (input: string) => string } {
+  const segments: string[] = [];
+  const masked = css.replace(/:global\(([^()]*)\)/g, (match) => {
+    const token = `__VF_CSS_GLOBAL_${segments.length}__`;
+    segments.push(match);
+    return token;
+  });
+
+  return {
+    masked,
+    restore: (input: string) => {
+      let result = input;
+      for (const [i, segment] of segments.entries()) {
+        result = result.replaceAll(`__VF_CSS_GLOBAL_${i}__`, segment);
+      }
+      return result;
+    },
+  };
+}
+
+/**
+ * Rewrite `.module.css` selectors to deterministic scoped class names.
+ * Keeps `:global(...)` segments untouched.
+ */
+export function rewriteCssModuleContent(content: string, moduleKey: string): string {
+  const { masked, restore } = maskGlobalSelectors(content);
+  // After :global() masking, every `.identifier` in the CSS is a local class
+  // selector. No lookbehind needed — numeric decimals like `0.5em` won't
+  // match because digits aren't in [_a-zA-Z].
+  const rewritten = masked.replace(
+    /\.([_a-zA-Z][_a-zA-Z0-9-]*)/g,
+    (_match, className: string) => {
+      return `.${toScopedCssModuleClass(moduleKey, className)}`;
+    },
+  );
+  return restore(rewritten);
+}

--- a/src/transforms/esm/import-parser.ts
+++ b/src/transforms/esm/import-parser.ts
@@ -26,12 +26,13 @@ export interface MissingImport {
 
 export interface ParseLocalImportsResult {
   imports: LocalImport[];
+  cssImports: LocalImport[];
   crossProjectImports: CrossProjectImport[];
   missing: MissingImport[];
 }
 
 const EXTENSIONS = [".tsx", ".ts", ".jsx", ".js", ".mdx"];
-const HAS_EXTENSION_RE = /\.(tsx?|jsx?|mjs|cjs|mdx)$/;
+const HAS_EXTENSION_RE = /\.(tsx?|jsx?|mjs|cjs|mdx|css)$/;
 
 export async function parseLocalImports(
   code: string,
@@ -40,7 +41,7 @@ export async function parseLocalImports(
   adapter?: RuntimeAdapter,
 ): Promise<ParseLocalImportsResult> {
   if (filePath.endsWith(".css") || filePath.endsWith(".json")) {
-    return { imports: [], crossProjectImports: [], missing: [] };
+    return { imports: [], cssImports: [], crossProjectImports: [], missing: [] };
   }
 
   const esbuild = await getEsbuild();
@@ -58,6 +59,7 @@ export async function parseLocalImports(
 
   const imports = await parseImports(result.code);
   const localImports: LocalImport[] = [];
+  const cssImports: LocalImport[] = [];
   const crossProjectImports: CrossProjectImport[] = [];
   const missingImports: MissingImport[] = [];
 
@@ -68,7 +70,11 @@ export async function parseLocalImports(
     if (specifier.startsWith("./") || specifier.startsWith("../")) {
       const resolved = await resolveLocalImportPath(filePath, specifier, adapter);
       if (resolved) {
-        localImports.push({ specifier, absolutePath: resolved });
+        if (resolved.endsWith(".css")) {
+          cssImports.push({ specifier, absolutePath: resolved });
+        } else {
+          localImports.push({ specifier, absolutePath: resolved });
+        }
         continue;
       }
 
@@ -84,7 +90,11 @@ export async function parseLocalImports(
       const aliasPath = specifier.slice(2);
       const resolved = await resolveAliasImportPath(aliasPath, projectDir, adapter);
       if (resolved) {
-        localImports.push({ specifier, absolutePath: resolved });
+        if (resolved.endsWith(".css")) {
+          cssImports.push({ specifier, absolutePath: resolved });
+        } else {
+          localImports.push({ specifier, absolutePath: resolved });
+        }
         continue;
       }
 
@@ -109,7 +119,7 @@ export async function parseLocalImports(
     });
   }
 
-  return { imports: localImports, crossProjectImports, missing: missingImports };
+  return { imports: localImports, cssImports, crossProjectImports, missing: missingImports };
 }
 
 async function checkFileExists(path: string, adapter?: RuntimeAdapter): Promise<boolean> {

--- a/src/transforms/pipeline/index.ts
+++ b/src/transforms/pipeline/index.ts
@@ -22,6 +22,7 @@ import type {
 } from "./types.ts";
 import {
   compilePlugin,
+  cssStripPlugin,
   finalizePlugin,
   parsePlugin,
   resolveImportsPlugin,
@@ -39,6 +40,7 @@ import { extractFrameworkBundlePaths } from "../shared/framework-bundle-paths.ts
 const SSR_PIPELINE: TransformPlugin[] = [
   parsePlugin,
   compilePlugin,
+  cssStripPlugin, // Strip CSS imports before they hit import resolution
   resolveImportsPlugin, // Unified import resolution
   ssrVfModulesPlugin, // Resolve /_vf_modules/ to framework files with React transforms
   ssrHttpStubPlugin,
@@ -49,6 +51,7 @@ const SSR_PIPELINE: TransformPlugin[] = [
 const BROWSER_PIPELINE: TransformPlugin[] = [
   parsePlugin,
   compilePlugin,
+  cssStripPlugin, // Strip CSS imports before they hit import resolution
   resolveImportsPlugin, // Unified import resolution
   finalizePlugin,
 ];

--- a/src/transforms/pipeline/stages/index.ts
+++ b/src/transforms/pipeline/stages/index.ts
@@ -6,6 +6,7 @@
 
 export { parsePlugin } from "./parse.ts";
 export { compilePlugin } from "./compile.ts";
+export { cssStripPlugin } from "./ssr-css-strip.ts";
 export { resolveImportsPlugin } from "./resolve-imports.ts";
 export { ssrVfModulesPlugin } from "./ssr-vf-modules.ts";
 export { ssrHttpStubPlugin } from "./ssr-http-stub.ts";

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -1,0 +1,65 @@
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { TransformContext } from "../types.ts";
+import { cssStripPlugin } from "./ssr-css-strip.ts";
+
+function createContext(code: string): TransformContext {
+  return {
+    code,
+    originalSource: code,
+    filePath: "/project/pages/index.tsx",
+    projectDir: "/project",
+    projectId: "project",
+    target: "ssr",
+    dev: true,
+    contentHash: "hash",
+    jsxImportSource: "react",
+    timing: new Map(),
+    debug: false,
+    metadata: new Map(),
+    reactVersion: "19.1.1",
+  } as TransformContext;
+}
+
+describe("css-strip plugin", () => {
+  it("rewrites dynamic css imports to a valid expression stub", async () => {
+    const ctx = createContext(
+      `async function load(){ const styles = await import("./Button.module.css"); return styles.default.container; }`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+
+    assertEquals(result.includes(`import("./Button.module.css")`), false);
+    assertEquals(result.includes("await /* css import"), false);
+    assertStringIncludes(
+      result,
+      'await Promise.resolve({ default: new Proxy({}, { get: (_, p) => typeof p === "string" ? "Button_"',
+    );
+    assertStringIncludes(result, "__");
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("rewrites static css module imports to scoped class names", async () => {
+    const ctx = createContext(
+      `import styles, { container as root } from "./Button.module.css"; export const c = styles.container + " " + root;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+
+    assertEquals(result.includes(`import styles`), false);
+    assertStringIncludes(result, "const styles = new Proxy({},");
+    assertStringIncludes(result, "const styles = new Proxy({},");
+    assertStringIncludes(result, 'root = "Button_container__');
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("keeps dynamic non-css imports untouched", async () => {
+    const code = `async function load(){ return await import("./feature.js"); }`;
+    const ctx = createContext(code);
+
+    const result = await cssStripPlugin.transform(ctx);
+
+    assertEquals(result, code);
+    assertEquals(ctx.metadata.has("cssImports"), false);
+  });
+});

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -1,0 +1,201 @@
+/**
+ * CSS Strip Stage - removes CSS import statements from compiled code.
+ *
+ * CSS files are not valid JS modules and will crash both the SSR module
+ * loader and browser module system if left in compiled code. This plugin
+ * strips them and records the CSS specifiers in pipeline metadata for
+ * downstream collection (used by the SSR rendering pipeline to include
+ * the CSS content in the HTML output).
+ *
+ * For CSS Module imports (`import styles from "./X.module.css"`), the
+ * import is replaced with a Proxy stub that returns the property name
+ * as the class name. This matches the Next.js convention where
+ * `styles.container` → `"container"` (identity mapping), which works
+ * correctly with Tailwind CSS class-based styling.
+ */
+
+import type { TransformPlugin } from "../types.ts";
+import { TransformStage } from "../types.ts";
+import { parseImports, rewriteImports } from "../../esm/lexer.ts";
+import {
+  getCssModuleScope,
+  resolveCssModuleKey,
+  toScopedCssModuleClass,
+} from "#veryfront/transforms/css-modules/naming.ts";
+
+function isCSSImport(specifier: string | undefined): boolean {
+  return specifier?.endsWith(".css") || false;
+}
+
+function isCssModuleImport(specifier: string | undefined): boolean {
+  return specifier?.endsWith(".module.css") || false;
+}
+
+function cssModuleProxyExpression(): string {
+  return "new Proxy({}, { get: (_, p) => String(p) })";
+}
+
+function scopedCssModuleProxyExpression(moduleKey: string): string {
+  const scope = getCssModuleScope(moduleKey);
+  return `new Proxy({}, { get: (_, p) => typeof p === "string" ? "${scope.base}_" + String(p).replace(/[^\\w-]/g, "_") + "__${scope.hash}" : "" })`;
+}
+
+type NamedImportBinding = { imported: string; local: string };
+
+function parseNamedImportBindings(namedClause: string): NamedImportBinding[] {
+  const bindings: NamedImportBinding[] = [];
+
+  for (const rawPart of namedClause.split(",")) {
+    const part = rawPart.trim();
+    if (!part) continue;
+
+    const aliasMatch = part.match(/^([_$a-zA-Z][\w$-]*)\s+as\s+([_$a-zA-Z][\w$]*)$/);
+    if (aliasMatch) {
+      const imported = aliasMatch[1];
+      const local = aliasMatch[2];
+      if (!imported || !local) continue;
+      bindings.push({ imported, local });
+      continue;
+    }
+
+    if (/^[_$a-zA-Z][\w$]*$/.test(part)) {
+      bindings.push({ imported: part, local: part });
+    }
+  }
+
+  return bindings;
+}
+
+/**
+ * Generate a replacement for a static CSS import statement.
+ *
+ * - Side-effect import: `import "./globals.css"` → comment
+ * - Default import: `import styles from "./X.module.css"` → Proxy stub
+ * - Named imports: `import { a } from "./X.css"` → null stubs
+ */
+function generateCSSStub(statement: string, specifier: string): string {
+  const trimmed = statement.trim();
+
+  // Re-export from CSS: export { default as styles } from './module.css'
+  // → strip entirely, the CSS is collected separately
+  if (/^export\s/.test(trimmed)) {
+    return `/* css re-export stripped: ${specifier} */`;
+  }
+
+  // Side-effect import: import "./globals.css"
+  if (/^import\s+['"`]/.test(trimmed)) {
+    return `/* css import: ${specifier} */`;
+  }
+
+  const fromIndex = trimmed.lastIndexOf(" from ");
+  if (fromIndex === -1) {
+    return `/* css import: ${specifier} */`;
+  }
+
+  const cssModuleKey = isCssModuleImport(specifier) ? specifier : undefined;
+  const importClause = trimmed.slice(6, fromIndex).trim(); // Skip "import "
+
+  // Default import: import styles from "./Button.module.css"
+  // → const styles = new Proxy({}, { get: (_, p) => String(p) })
+  // This makes styles.container return "container" (identity mapping)
+  if (/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(importClause)) {
+    const expr = cssModuleKey
+      ? scopedCssModuleProxyExpression(cssModuleKey)
+      : cssModuleProxyExpression();
+    return `const ${importClause} = ${expr}; /* css module: ${specifier} */`;
+  }
+
+  // Namespace import: import * as styles from "./X.module.css"
+  const nsMatch = importClause.match(/^\*\s+as\s+([a-zA-Z_$][a-zA-Z0-9_$]*)$/);
+  if (nsMatch) {
+    const expr = cssModuleKey
+      ? scopedCssModuleProxyExpression(cssModuleKey)
+      : cssModuleProxyExpression();
+    return `const ${nsMatch[1]} = ${expr}; /* css module: ${specifier} */`;
+  }
+
+  // Named imports: import { container, header } from "./X.module.css"
+  const namedMatch = importClause.match(/^\{([^}]+)\}$/);
+  if (namedMatch?.[1]) {
+    const bindings = parseNamedImportBindings(namedMatch[1]);
+    if (bindings.length > 0) {
+      const stubs = bindings
+        .map((binding) => {
+          const value = cssModuleKey
+            ? toScopedCssModuleClass(cssModuleKey, binding.imported)
+            : binding.imported;
+          return `${binding.local} = "${value}"`;
+        })
+        .join(", ");
+      return `const ${stubs}; /* css module: ${specifier} */`;
+    }
+  }
+
+  // Mixed: import styles, { container } from "./X.module.css"
+  const mixedMatch = importClause.match(/^([a-zA-Z_$][a-zA-Z0-9_$]*)\s*,\s*\{([^}]+)\}$/);
+  if (mixedMatch?.[1] && mixedMatch[2]) {
+    const defaultName = mixedMatch[1];
+    const bindings = parseNamedImportBindings(mixedMatch[2]);
+    const namedStubs = bindings
+      .map((binding) => {
+        const value = cssModuleKey
+          ? toScopedCssModuleClass(cssModuleKey, binding.imported)
+          : binding.imported;
+        return `${binding.local} = "${value}"`;
+      })
+      .join(", ");
+    const defaultExpr = cssModuleKey
+      ? scopedCssModuleProxyExpression(cssModuleKey)
+      : cssModuleProxyExpression();
+    return namedStubs.length > 0
+      ? `const ${defaultName} = ${defaultExpr}, ${namedStubs}; /* css module: ${specifier} */`
+      : `const ${defaultName} = ${defaultExpr}; /* css module: ${specifier} */`;
+  }
+
+  return `/* css import: ${specifier} */`;
+}
+
+/**
+ * Generate a replacement for dynamic CSS imports.
+ * Keeps syntax valid in expression position (e.g. await import("./x.css")).
+ */
+function generateDynamicCSSStub(specifier: string): string {
+  if (isCssModuleImport(specifier)) {
+    return `Promise.resolve({ default: ${
+      scopedCssModuleProxyExpression(specifier)
+    } }) /* css import: ${specifier} */`;
+  }
+
+  return `Promise.resolve({}) /* css import: ${specifier} */`;
+}
+
+export const cssStripPlugin: TransformPlugin = {
+  name: "css-strip",
+  stage: TransformStage.COMPILE + 0.5, // Run after esbuild compile, before import resolution
+
+  async transform(ctx) {
+    const imports = await parseImports(ctx.code);
+
+    const hasCssImports = imports.some((imp) => isCSSImport(imp.n));
+    if (!hasCssImports) return ctx.code;
+
+    const cssSpecifiers: string[] = [];
+
+    const result = await rewriteImports(ctx.code, (imp, statement) => {
+      if (!isCSSImport(imp.n)) return null;
+      cssSpecifiers.push(imp.n!);
+      const moduleKey = isCssModuleImport(imp.n)
+        ? resolveCssModuleKey(imp.n!, ctx.filePath, ctx.projectDir)
+        : undefined;
+      const specifierForStub = moduleKey ?? imp.n!;
+      if (imp.d > -1) return generateDynamicCSSStub(specifierForStub);
+      return generateCSSStub(statement, specifierForStub);
+    });
+
+    if (cssSpecifiers.length > 0) {
+      ctx.metadata.set("cssImports", cssSpecifiers);
+    }
+
+    return result;
+  },
+};


### PR DESCRIPTION
## Summary

- Adds Next.js-compatible CSS import handling across SSR and browser transform pipelines
- Implements CSS Module scoped class names with deterministic hashing for SSR/HTML consistency
- Introduces route-scoped Tailwind candidate resolution (manifest cache) for more targeted CSS generation
- Adds single-flight deduplication for CSS generation and environment-aware cache keys
- Fixes compound CSS selector rewriting (`.a.b`) in CSS Module content

## Key changes

| Area | Files | What |
|------|-------|------|
| CSS collection | `css-import-collector.ts` | AsyncLocalStorage-based request-scoped CSS import tracking |
| Transform pipeline | `ssr-css-strip.ts`, `pipeline/index.ts` | Strip CSS imports in both SSR and browser pipelines, replace with Proxy stubs |
| CSS Modules | `css-modules/naming.ts` | Deterministic scoped class names, selector rewriting |
| HTML generation | `html.ts`, `css-candidate-manifest.ts` | Merge imported CSS into output, route-scoped Tailwind candidates |
| Caching | `project-css-cache.ts`, `tailwind-compiler.ts` | Environment-aware cache keys, single-flight dedup |
| Import parsing | `import-parser.ts` | Separate CSS imports from JS imports in dependency graph |

## Test plan

- [x] `naming.test.ts` — module key resolution, scoped class names, compound selectors, `:global()` preservation
- [x] `ssr-css-strip.test.ts` — static/dynamic CSS imports, module proxy stubs, non-CSS passthrough
- [x] `html.test.ts` — CSS deduplication against configured stylesheet, deterministic ordering, module rewriting