### PR TITLE
fix: prevent WebSocket reconnect loop during shutdown and improve error logging

### DIFF
--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -130,8 +130,13 @@ export class WebSocketManager {
         this.wsReconnectTimer = setTimeout(() => this.connect(projectId), delay);
       };
 
-      this.ws.onerror = (error) => {
-        logger.warn("WebSocket error", { error });
+      this.ws.onerror = (event) => {
+        logger.warn("WebSocket error", {
+          type: event.type,
+          url: (event.target as WebSocket)?.url?.replace(/token=[^&]+/, "token=***"),
+          readyState: (event.target as WebSocket)?.readyState,
+          consecutiveFailures: this.wsConsecutiveFailures,
+        });
       };
     } catch (error) {
       this.wsConsecutiveFailures++;


### PR DESCRIPTION
## Summary
- **Reconnect race in dispose()**: `ws.close()` triggers `onclose` asynchronously, which scheduled new reconnect timers after dispose had already cleaned up — causing zombie reconnect loops during pod termination
- **No disposed guard**: Added `disposed` flag checked in `connect()` and `onclose` to prevent all reconnection after dispose
- **Detach handlers before close**: Null out `onclose`/`onerror`/`onmessage` before calling `ws.close()` as a belt-and-suspenders defense
- **Graceful shutdown wiring**: `production-server.ts` now calls `bootstrap.dispose()` on SIGTERM, propagating through MultiProjectAdapter → ProxyManager → each VeryfrontFsAdapter → WebSocketManager
- **Empty error logging**: WebSocket `onerror` receives an `Event` (not `Error`), which serialized to `{}`. Now extracts `url`, `readyState`, and `consecutiveFailures`

## Test plan
- [ ] `deno test --allow-env --allow-read --allow-net src/platform/adapters/fs/veryfront/websocket-manager.test.ts` passes
- [ ] `deno check` passes on all modified files
- [ ] Deploy and verify: no more error bursts during pod termination
- [ ] WebSocket error logs now show actual diagnostic fields instead of `error={}`