### PR TITLE
fix: prevent WebSocket reconnect loop during shutdown

### DIFF
--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -53,6 +53,7 @@ export class WebSocketManager {
 
   private wsConnectionId: string | null = null;
   private wsConsecutiveFailures = 0;
+  private disposed = false;
   private pokeMetrics = {
     received: 0,
     invalidationsTriggered: 0,
@@ -71,6 +72,8 @@ export class WebSocketManager {
   }
 
   connect(projectId: string): void {
+    if (this.disposed) return;
+
     this.cleanupTimers();
 
     if (this.wsConsecutiveFailures >= WS_RECONNECT_MAX_FAILURES) {
@@ -117,16 +120,18 @@ export class WebSocketManager {
       };
 
       this.ws.onclose = () => {
+        this.wsConnectionId = null;
+        this.cleanupTimers();
+
+        if (this.disposed) return;
+
         this.wsConsecutiveFailures++;
         const delay = this.getReconnectDelay();
         logger.debug("WebSocket closed, reconnecting", {
           delayMs: delay,
-          connectionId: this.wsConnectionId,
           totalPokesReceived: this.pokeMetrics.received,
           consecutiveFailures: this.wsConsecutiveFailures,
         });
-        this.wsConnectionId = null;
-        this.cleanupTimers();
         this.wsReconnectTimer = setTimeout(() => this.connect(projectId), delay);
       };
 
@@ -156,6 +161,7 @@ export class WebSocketManager {
   }
 
   dispose(): void {
+    this.disposed = true;
     this.cleanupTimers();
 
     if (this.invalidationTimer) {
@@ -169,6 +175,11 @@ export class WebSocketManager {
     }
 
     if (!this.ws) return;
+
+    // Detach handlers before closing to prevent onclose from scheduling a reconnect
+    this.ws.onclose = null;
+    this.ws.onerror = null;
+    this.ws.onmessage = null;
 
     try {
       this.ws.close();

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -8,6 +8,7 @@ import {
 } from "#veryfront/config/environment-config.ts";
 import { getErrorMessage } from "#veryfront/errors/veryfront-error.ts";
 import { enhanceAdapterWithFS } from "#veryfront/platform/adapters/fs/integration.ts";
+import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
 import { initializeEsbuild } from "#veryfront/platform/compat/esbuild.ts";
 import { logger } from "#veryfront/utils";
@@ -38,6 +39,9 @@ export interface BootstrapResult {
 
   /** FSAdapter type (if used) */
   fsAdapterType?: string;
+
+  /** Dispose FSAdapter resources (WebSocket connections, caches) */
+  dispose?: () => void;
 }
 
 let envLogged = false;
@@ -174,11 +178,20 @@ export async function bootstrap(
     fsAdapter: fsType,
   });
 
+  let dispose: (() => void) | undefined;
+  if (isExtendedFSAdapter(enhancedAdapter.fs)) {
+    const underlying = enhancedAdapter.fs.getUnderlyingAdapter();
+    if ("dispose" in underlying && typeof (underlying as { dispose?: () => void }).dispose === "function") {
+      dispose = () => (underlying as { dispose: () => void }).dispose();
+    }
+  }
+
   return {
     adapter: enhancedAdapter,
     config,
     usingFSAdapter: true,
     fsAdapterType: fsType,
+    dispose,
   };
 }
 

--- a/src/server/production-server.ts
+++ b/src/server/production-server.ts
@@ -292,12 +292,15 @@ if (import.meta.main) {
     // Note: Don't use HOSTNAME - K8s sets it to pod name which resolves to pod IP
     const bindAddress = adapter.env.get("BIND_ADDRESS") ?? "0.0.0.0";
 
+    const bootstrap = await bootstrapProd(projectDir, adapter);
+
     const server = await startProductionServer({
       projectDir,
       port,
       bindAddress,
       debug: isDebugEnabled(adapter.env),
       adapter, // Pass adapter to avoid re-detection
+      bootstrapResult: bootstrap,
       signal: shutdownController.signal,
     });
 
@@ -337,6 +340,7 @@ if (import.meta.main) {
         // Phase 3: Stop accepting new connections and clean up
         stopMemoryMonitoring();
         requestTracker.shutdown();
+        bootstrap.dispose?.();
         shutdownController.abort();
         await server.stop();
         await shutdownOTLP();


### PR DESCRIPTION
## Summary
Follow-up to #466 (error logging fix). Prevents the WebSocket error bursts seen during pod termination.

- **`disposed` flag**: Guards `connect()` and `onclose` from scheduling reconnects after dispose is called
- **Detach handlers before `ws.close()`**: Prevents the `onclose` → reconnect race since `ws.close()` triggers `onclose` asynchronously
- **Graceful shutdown wiring**: `production-server.ts` now calls `bootstrap.dispose()` on SIGTERM, propagating through MultiProjectAdapter → ProxyManager → each VeryfrontFsAdapter → WebSocketManager

## Test plan
- [ ] `deno check` passes on all modified files
- [ ] `deno test --allow-env --allow-read --allow-net src/platform/adapters/fs/veryfront/websocket-manager.test.ts` passes
- [ ] Deploy and verify no more WebSocket error bursts during pod termination