### PR TITLE
style: fix formatting in bootstrap.ts

### DIFF
--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -181,7 +181,10 @@ export async function bootstrap(
   let dispose: (() => void) | undefined;
   if (isExtendedFSAdapter(enhancedAdapter.fs)) {
     const underlying = enhancedAdapter.fs.getUnderlyingAdapter();
-    if ("dispose" in underlying && typeof (underlying as { dispose?: () => void }).dispose === "function") {
+    if (
+      "dispose" in underlying &&
+      typeof (underlying as { dispose?: () => void }).dispose === "function"
+    ) {
       dispose = () => (underlying as { dispose: () => void }).dispose();
     }
   }


### PR DESCRIPTION
## Summary
- Fix `deno fmt` violation introduced in #467 — line-length exceeded on the dispose type-check conditional