### PR TITLE
fix: add negative caching to proxy TokenManager

### DIFF
--- a/src/proxy/token-manager.ts
+++ b/src/proxy/token-manager.ts
@@ -5,6 +5,15 @@ import { ProxySpanNames, withSpan } from "./tracing.ts";
 
 export type TokenScope = "preview" | "production";
 
+interface NegativeCacheEntry {
+  status: number;
+  message: string;
+  cachedAt: number;
+}
+
+const NEGATIVE_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+const NEGATIVE_CACHE_MAX_SIZE = 1000;
+
 export interface OAuthConfig {
   apiBaseUrl: string;
   apiClientId: string;
@@ -21,6 +30,7 @@ export interface TokenManagerOptions {
 export class TokenManager {
   private cache: TokenCache;
   private pendingRequests = new Map<string, Promise<string>>();
+  private negativeCache = new Map<string, NegativeCacheEntry>();
   private refreshBuffer: number;
 
   constructor(
@@ -42,6 +52,14 @@ export class TokenManager {
     return withSpan(
       ProxySpanNames.PROXY_TOKEN_FETCH,
       async () => {
+        const negEntry = this.negativeCache.get(cacheKey);
+        if (negEntry) {
+          if (Date.now() - negEntry.cachedAt < NEGATIVE_CACHE_TTL) {
+            throw new Error(negEntry.message);
+          }
+          this.negativeCache.delete(cacheKey);
+        }
+
         const cached = await this.cache.get(cacheKey);
         if (cached && this.isTokenValid(cached)) return cached.token;
 
@@ -67,10 +85,13 @@ export class TokenManager {
   }
 
   async invalidateToken(scope: TokenScope, projectSlug?: string): Promise<void> {
-    await this.cache.delete(this.getCacheKey(scope, projectSlug));
+    const cacheKey = this.getCacheKey(scope, projectSlug);
+    this.negativeCache.delete(cacheKey);
+    await this.cache.delete(cacheKey);
   }
 
   async clearCache(): Promise<void> {
+    this.negativeCache.clear();
     await this.cache.clear();
   }
 
@@ -101,13 +122,32 @@ export class TokenManager {
       ? this.config.previewApiClientSecret
       : this.config.apiClientSecret;
 
-    const response = await fetchOAuthToken({
-      apiBaseUrl: this.config.apiBaseUrl,
-      apiClientId,
-      apiClientSecret,
-      projectSlug,
-      customDomain,
-    });
+    let response: TokenResponse;
+    try {
+      response = await fetchOAuthToken({
+        apiBaseUrl: this.config.apiBaseUrl,
+        apiClientId,
+        apiClientSecret,
+        projectSlug,
+        customDomain,
+      });
+    } catch (error) {
+      const status = this.parseStatusFromError(error);
+      if (status === 400 || status === 404) {
+        const projectKey = projectSlug || customDomain;
+        const cacheKey = this.getCacheKey(scope, projectKey);
+        if (this.negativeCache.size >= NEGATIVE_CACHE_MAX_SIZE) {
+          const oldest = this.negativeCache.keys().next().value;
+          if (oldest !== undefined) this.negativeCache.delete(oldest);
+        }
+        this.negativeCache.set(cacheKey, {
+          status,
+          message: error instanceof Error ? error.message : String(error),
+          cachedAt: Date.now(),
+        });
+      }
+      throw error;
+    }
 
     const projectKey = projectSlug || customDomain;
 
@@ -119,6 +159,12 @@ export class TokenManager {
     });
 
     return response.access_token;
+  }
+
+  private parseStatusFromError(error: unknown): number | null {
+    const message = error instanceof Error ? error.message : String(error);
+    const match = message.match(/failed: (\d+)/);
+    return match ? Number(match[1]) : null;
   }
 
   private calculateExpiresAt(response: TokenResponse): number {


### PR DESCRIPTION
## Summary
- Add in-memory negative cache to `TokenManager` that stores 400/404 token fetch failures for 5 minutes
- Subsequent requests for the same invalid project/domain fail fast without hitting the API
- Capped at 1000 entries with oldest-first eviction to prevent OOM from random slug flooding
- Server errors (5xx) and timeouts are not cached (transient)

## Context
Production logs show ~40 failed token requests/minute for non-existent projects like `cms.veryfront.com`. Each request triggered a fresh OAuth API call guaranteed to return 404, creating unnecessary load.

## Test plan
- [x] All existing proxy tests pass (10 tests, 114 steps)
- [x] `deno lint` clean
- [ ] Deploy to staging, verify repeated requests for invalid slugs only produce one API call per 5-minute window
- [ ] Verify `invalidateToken()` and `clearCache()` also clear negative cache entries