### PR TITLE
fix: harden unhandled error and SIGTERM shutdown paths

### DIFF
--- a/cli/commands/serve/command.ts
+++ b/cli/commands/serve/command.ts
@@ -37,11 +37,6 @@ async function runProxy(options: ServeOptions): Promise<void> {
   setEnv("PORT", String(options.port));
   setEnv("HOST", options.bindAddress);
 
-  registerTerminationSignals((signal) => {
-    cliLogger.info(`Received ${signal}, shutting down proxy server...`);
-    exitProcess(0);
-  });
-
   // DenoHttpServer.serve() blocks until the server stops,
   // so this import keeps the process alive.
   await import("veryfront/proxy/main");

--- a/cli/commands/start/command.ts
+++ b/cli/commands/start/command.ts
@@ -232,22 +232,27 @@ export async function startCommand(options: StartOptions): Promise<void> {
   app.setServerReady();
 
   let shuttingDown = false;
-  async function shutdown(): Promise<void> {
+  async function shutdown(signal: "SIGINT" | "SIGTERM"): Promise<void> {
     if (shuttingDown) return;
     shuttingDown = true;
 
     restoreConsole();
-    cliLogger.info("Shutting down...");
+    cliLogger.info(`Received ${signal}, shutting down...`);
 
-    app.stop();
-    await mcpServer.stop();
-    shutdownController.abort();
-    await server.stop();
-    await proxy.close();
-    exitProcess(0);
+    try {
+      app.stop();
+      await mcpServer.stop();
+      shutdownController.abort();
+      await server.stop();
+      await proxy.close();
+    } catch (error) {
+      cliLogger.warn("Error while shutting down start command:", error);
+    } finally {
+      exitProcess(0);
+    }
   }
 
-  registerTerminationSignals(() => void shutdown());
+  registerTerminationSignals((signal) => shutdown(signal));
   app.start();
 
   await new Promise(() => {});

--- a/cli/utils/index.ts
+++ b/cli/utils/index.ts
@@ -115,7 +115,18 @@ export function registerTerminationSignals(
 
   for (const signal of signals) {
     onSignal(signal, () => {
-      void handler(signal);
+      try {
+        const result = handler(signal);
+        if (result && typeof (result as PromiseLike<void>).then === "function") {
+          void Promise.resolve(result).catch((error) => {
+            cliLogger.error(`Unhandled error while handling ${signal}:`, error);
+            exitProcess(1);
+          });
+        }
+      } catch (error) {
+        cliLogger.error(`Unhandled error while handling ${signal}:`, error);
+        exitProcess(1);
+      }
     });
   }
 }

--- a/src/platform/compat/process.ts
+++ b/src/platform/compat/process.ts
@@ -360,7 +360,10 @@ export function getOsType(): string {
 /**
  * Register a signal handler (SIGINT, SIGTERM) for graceful shutdown
  */
-export function onSignal(signal: "SIGINT" | "SIGTERM", handler: () => void): void {
+export function onSignal(
+  signal: "SIGINT" | "SIGTERM",
+  handler: () => void,
+): void {
   if (IS_DENO) {
     Deno.addSignalListener(signal, handler);
     return;
@@ -396,14 +399,35 @@ export function onGlobalError(
 
   if (!hasNodeProcess) return;
 
+  const handleNodeGlobalError = (
+    error: Error,
+    type: "uncaughtException" | "unhandledRejection",
+  ): void => {
+    let shouldPreventExit = false;
+    try {
+      shouldPreventExit = onError(error, type) === true;
+    } catch (handlerError) {
+      const handlerException = handlerError instanceof Error
+        ? handlerError
+        : new Error(String(handlerError));
+      console.error("Global error handler threw while processing", type, handlerException);
+    }
+
+    if (shouldPreventExit) return;
+
+    // Node/Bun suppress default fatal behavior when a listener is registered.
+    // If the callback did not explicitly handle the error, exit to preserve
+    // expected fatal semantics for uncaught exceptions and unhandled rejections.
+    nodeProcess!.exit(1);
+  };
+
   nodeProcess!.on("uncaughtException", (error: Error) => {
-    onError(error, "uncaughtException");
-    // Note: In Node.js, uncaughtException doesn't exit by default if handler is registered
+    handleNodeGlobalError(error, "uncaughtException");
   });
 
   nodeProcess!.on("unhandledRejection", (reason: unknown) => {
     const error = reason instanceof Error ? reason : new Error(String(reason));
-    onError(error, "unhandledRejection");
+    handleNodeGlobalError(error, "unhandledRejection");
   });
 }
 

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -579,19 +579,40 @@ function router(req: Request): Promise<Response> {
   return forwardToServer(req);
 }
 
+// Create server before signal registration so early SIGTERM/SIGINT can close it safely.
+const server = createHttpServer();
+
 // Graceful shutdown
-async function shutdown(): Promise<void> {
-  proxyLogger.info("Shutting down");
-  rendererRouter?.close();
-  serverResolver.close();
-  await proxyHandler.close();
-  await shutdownOTLP();
-  proxyLogger.info("Closed connections");
-  exit(0);
+let shuttingDown = false;
+async function shutdown(signal: "SIGINT" | "SIGTERM"): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+
+  proxyLogger.info(`Received ${signal}, shutting down`);
+
+  try {
+    await server.close();
+    rendererRouter?.close();
+    serverResolver.close();
+    await proxyHandler.close();
+    await shutdownOTLP();
+    proxyLogger.info("Closed connections");
+  } catch (error) {
+    proxyLogger.error("Error while shutting down proxy", error);
+  } finally {
+    exit(0);
+  }
 }
 
-onSignal("SIGINT", shutdown);
-onSignal("SIGTERM", shutdown);
+const handleSignal = (signal: "SIGINT" | "SIGTERM"): void => {
+  void shutdown(signal).catch((error) => {
+    proxyLogger.error("Unhandled shutdown error", { signal }, error);
+    exit(1);
+  });
+};
+
+onSignal("SIGINT", () => handleSignal("SIGINT"));
+onSignal("SIGTERM", () => handleSignal("SIGTERM"));
 
 // Wait for sticky-session router to resolve initial target list
 await rendererRouter?.ready();
@@ -605,6 +626,5 @@ proxyLogger.debug("Starting proxy server (split mode)", {
   apiBaseUrl: config.apiBaseUrl,
 });
 
-// Create and start the HTTP server
-const server = createHttpServer();
+// Start the HTTP server
 await server.serve(router, { port: PORT, hostname: HOST });

--- a/src/server/production-server.ts
+++ b/src/server/production-server.ts
@@ -351,8 +351,14 @@ if (import.meta.main) {
       }
     };
 
-    onSignal("SIGINT", () => void shutdown("SIGINT"));
-    onSignal("SIGTERM", () => void shutdown("SIGTERM"));
+    const handleSignal = (signal: "SIGINT" | "SIGTERM"): void => {
+      void shutdown(signal).catch((error) => {
+        logger.warn("Unhandled error while shutting down production server", { signal, error });
+      });
+    };
+
+    onSignal("SIGINT", () => handleSignal("SIGINT"));
+    onSignal("SIGTERM", () => handleSignal("SIGTERM"));
   } catch (e) {
     logger.error("Failed to start production server:", e);
   }


### PR DESCRIPTION
## Summary
- enforce Node/Bun global-error return semantics so unhandled fatal errors exit when not explicitly handled
- harden CLI termination signal handling to catch async shutdown rejections and sync throws
- make start shutdown always finalize with try/catch/finally and explicit exit
- remove proxy-mode early-exit signal hook in serve so proxy runtime graceful shutdown can run
- make proxy runtime shutdown idempotent, close HTTP server explicitly, and catch signal-triggered async shutdown failures
- add defensive signal wrapper in production server main entrypoint

## Validation
- deno check cli/utils/index.ts src/platform/compat/process.ts cli/commands/start/command.ts cli/commands/serve/command.ts src/proxy/main.ts src/server/production-server.ts
- deno test --allow-all src/platform/compat/process.test.ts
- deno test --allow-all cli/commands/start/command.test.ts
- deno test --allow-all cli/commands/serve/command.test.ts
- deno test --allow-all src/proxy/mode-parity.test.ts