### PR TITLE
fix: inject bridge on standalone markdown pages (v0.1.27)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/server/handlers/preview/markdown-html-generator.test.ts
+++ b/src/server/handlers/preview/markdown-html-generator.test.ts
@@ -86,6 +86,36 @@ describe("generateMarkdownHtml", () => {
     );
   });
 
+  it("injects bridge script for standalone markdown pages without studio_embed", () => {
+    const html = generateMarkdownHtml(
+      makeOptions({
+        url: new URL("http://localhost/test.md"),
+        filePath: "docs/README.md",
+      }),
+    );
+    assert(html.includes("PAGE_PATH"));
+  });
+
+  it("injects bridge script for standalone mdx pages without studio_embed", () => {
+    const html = generateMarkdownHtml(
+      makeOptions({
+        url: new URL("http://localhost/test.mdx"),
+        filePath: "docs/page.mdx",
+      }),
+    );
+    assert(html.includes("PAGE_PATH"));
+  });
+
+  it("omits bridge script for non-markdown pages without studio_embed", () => {
+    const html = generateMarkdownHtml(
+      makeOptions({
+        url: new URL("http://localhost/index.html"),
+        filePath: "index.html",
+      }),
+    );
+    assert(!html.includes("PAGE_PATH"));
+  });
+
   it("prefers vf_project_id for bridge project id when present", () => {
     const html = generateMarkdownHtml(
       makeOptions({

--- a/src/server/handlers/preview/markdown-html-generator.ts
+++ b/src/server/handlers/preview/markdown-html-generator.ts
@@ -52,12 +52,14 @@ function detectTheme(req: Request, url: URL): "light" | "dark" | null {
 }
 
 /**
- * Generate the studio bridge `<script>` tag when embedded in Studio.
- * Returns an empty string when not in studio embed mode.
+ * Generate the studio bridge `<script>` tag.
+ * Injected when embedded in Studio (`studio_embed=true`) or for standalone
+ * markdown/MDX pages so the edit button and editor features are available.
  */
 function buildStudioScript(url: URL, projectId: string, filePath: string): string {
   const studioEmbed = url.searchParams.get("studio_embed") === "true";
-  if (!studioEmbed) return "";
+  const isMarkdown = /\.mdx?$/i.test(filePath);
+  if (!studioEmbed && !isMarkdown) return "";
 
   const queryProjectId = url.searchParams.get("vf_project_id")?.trim() || "";
   const queryFileId = url.searchParams.get("vf_file_id")?.trim() || "";


### PR DESCRIPTION
## Summary
- Inject bridge script on standalone markdown/MDX preview pages (not just when `studio_embed=true`)
- Enables `.vf-markdown-edit-button` to appear on direct markdown URLs like `grand-pond.preview.veryfront.com/AGENTS.md`
- Bump version to 0.1.27 to trigger release and deploy

## Test plan
- [ ] Visit `{project}.preview.veryfront.com/{file}.md` — edit button should appear
- [ ] `document.querySelector('.vf-markdown-edit-button')` returns the button element
- [ ] Studio embed mode continues to work as before