### PR TITLE
fix: markdown editor line breaks, styling, and initial content (v0.1.28)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/studio/bridge-template.ts
+++ b/src/studio/bridge-template.ts
@@ -76,6 +76,7 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
   let markdownLatestMdxImportMap = {};
   let markdownLatestPresenceUsers = [];
   let markdownLatestSelections = [];
+  let markdownHasUnsavedChanges = false;
 
   const MARKDOWN_SLASH_COMMANDS = [
     {
@@ -655,9 +656,6 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
         background: #111827;
       }
 
-      [data-theme='dark'] .vf-markdown-editor__surface {
-      }
-
       [data-theme='dark'] .vf-markdown-editor__textarea {
         color: #f9fafb;
       }
@@ -825,13 +823,18 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
   }
 
   function isFromStudio(event) {
-    const origin = event.origin || '';
-    return (
-      origin.includes('veryfront.org') ||
-      origin.includes('veryfront.com') ||
-      origin.includes('veryfront.dev') ||
-      origin.includes('localhost')
-    );
+    try {
+      const url = new URL(event.origin || '');
+      const host = url.hostname;
+      return (
+        host === 'localhost' ||
+        host.endsWith('.veryfront.org') || host === 'veryfront.org' ||
+        host.endsWith('.veryfront.com') || host === 'veryfront.com' ||
+        host.endsWith('.veryfront.dev') || host === 'veryfront.dev'
+      );
+    } catch (e) {
+      return false;
+    }
   }
 
   const originalConsole = {};
@@ -1726,7 +1729,7 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
 
     applyMarkdownContent(nextFullContent);
     if (hasChanged) {
-      setMarkdownPersistStatus('saving');
+      markdownHasUnsavedChanges = true;
       scheduleMarkdownSync(nextFullContent);
     }
 
@@ -2912,9 +2915,28 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
       return;
     }
     markdownCurrentContent = fullContent;
-    setMarkdownPersistStatus('saving');
+    markdownHasUnsavedChanges = true;
     scheduleMarkdownSync(fullContent);
     scheduleMarkdownSelectionOverlayRender();
+  }
+
+  function saveMarkdownContent() {
+    if (!markdownHasUnsavedChanges) {
+      return;
+    }
+    setMarkdownPersistStatus('saving');
+    if (markdownSyncTimer) {
+      clearTimeout(markdownSyncTimer);
+      markdownSyncTimer = null;
+    }
+    postToStudio({
+      action: 'markdownContentChange',
+      fileId: markdownFileId,
+      filePath: PAGE_PATH,
+      content: markdownCurrentContent,
+      save: true
+    });
+    markdownHasUnsavedChanges = false;
   }
 
   function setupMarkdownLexicalEditor() {
@@ -3079,18 +3101,21 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
 
     if (markdownLexicalApi) {
       markdownApplyingRemoteUpdate = true;
-      markdownLexicalRenderedContent = content;
-      markdownLexicalApi.editor.update(function() {
-        const lexicalModule = markdownLexicalApi.lexicalModule;
-        const markdownModule = markdownLexicalApi.markdownModule;
-        const root = lexicalModule.$getRoot();
-        root.clear();
-        markdownModule.$convertFromMarkdownString(editorContent, markdownModule.TRANSFORMERS, true);
-        if (root.getChildrenSize() === 0) {
-          root.append(lexicalModule.$createParagraphNode());
-        }
-      }, { discrete: true });
-      markdownApplyingRemoteUpdate = false;
+      try {
+        markdownLexicalRenderedContent = content;
+        markdownLexicalApi.editor.update(function() {
+          const lexicalModule = markdownLexicalApi.lexicalModule;
+          const markdownModule = markdownLexicalApi.markdownModule;
+          const root = lexicalModule.$getRoot();
+          root.clear();
+          markdownModule.$convertFromMarkdownString(editorContent, markdownModule.TRANSFORMERS, true);
+          if (root.getChildrenSize() === 0) {
+            root.append(lexicalModule.$createParagraphNode());
+          }
+        }, { discrete: true });
+      } finally {
+        markdownApplyingRemoteUpdate = false;
+      }
       scheduleMarkdownSelectionOverlayRender();
       scheduleMarkdownSlashMenuUpdate();
       scheduleMarkdownInlineToolbarUpdate();
@@ -3293,8 +3318,8 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
     const status = document.createElement('div');
     status.className = 'vf-markdown-editor__status';
     status.setAttribute(DATA_VF_IGNORE, 'true');
-    status.textContent = 'Saved';
-    status.setAttribute('data-state', 'saved');
+    status.textContent = '';
+    status.setAttribute('data-state', '');
 
     const presence = document.createElement('div');
     presence.className = 'vf-markdown-editor__presence';
@@ -3394,6 +3419,12 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
         if (moved) {
           event.preventDefault();
         }
+      }
+    });
+    surface.addEventListener('keydown', function(event) {
+      if ((event.metaKey || event.ctrlKey) && event.key === 's') {
+        event.preventDefault();
+        saveMarkdownContent();
       }
     });
     surface.addEventListener('scroll', scheduleMarkdownSelectionOverlayRender);
@@ -3665,7 +3696,7 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
       setupMarkdownLexicalEditor();
       markdownBody.style.display = 'none';
       markdownEditorRoot.style.display = 'block';
-      setMarkdownPersistStatus('saved');
+      markdownHasUnsavedChanges = false;
       focusMarkdownEditor();
       scheduleMarkdownSelectionSync();
       scheduleMarkdownSelectionOverlayRender();
@@ -3906,9 +3937,6 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
         if (!inspectMode) showHoverOverlay(message.id);
         return;
 
-      case 'toggleLayout':
-        return;
-
       case 'setMarkdownContent':
         if (!isMarkdownPage()) {
           return;
@@ -3927,6 +3955,9 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
           return;
         }
         setMarkdownPersistStatus(message.status || 'saved');
+        if (message.status === 'saved') {
+          markdownHasUnsavedChanges = false;
+        }
         return;
 
       case 'setMarkdownPresence':

--- a/src/studio/bridge-template.ts
+++ b/src/studio/bridge-template.ts
@@ -327,17 +327,15 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
 
       .vf-markdown-editor__surface {
         width: 100%;
+        max-width: 980px;
+        margin: 0 auto;
         height: 100%;
         overflow: auto;
         outline: none;
         position: relative;
         z-index: 1;
-        font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
-        font-size: 16px;
-        line-height: 1.6;
-        color: #111827;
         background: transparent;
-        padding: 16px;
+        padding: 32px 40px;
         box-sizing: border-box;
       }
 
@@ -571,28 +569,8 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
         white-space: nowrap;
       }
 
-      .vf-markdown-editor__surface p {
-        margin: 0 0 12px;
-      }
-
-      .vf-markdown-editor__surface h1,
-      .vf-markdown-editor__surface h2,
-      .vf-markdown-editor__surface h3,
-      .vf-markdown-editor__surface h4,
-      .vf-markdown-editor__surface h5,
-      .vf-markdown-editor__surface h6 {
-        margin: 20px 0 12px;
-        line-height: 1.35;
-      }
-
-      .vf-markdown-editor__surface ul,
-      .vf-markdown-editor__surface ol {
-        margin: 0 0 12px 24px;
-        padding: 0;
-      }
-
-      .vf-markdown-editor__surface code {
-        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+      .vf-markdown-editor__surface [data-lexical-editor] {
+        outline: none;
       }
 
       .vf-markdown-editor__textarea {
@@ -669,7 +647,6 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
       }
 
       [data-theme='dark'] .vf-markdown-editor__surface {
-        color: #f9fafb;
       }
 
       [data-theme='dark'] .vf-markdown-editor__textarea {
@@ -2980,7 +2957,7 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
 
         let nextContent = '';
         update.editorState.read(function() {
-          nextContent = markdownModule.$convertToMarkdownString(markdownModule.TRANSFORMERS);
+          nextContent = markdownModule.$convertToMarkdownString(markdownModule.TRANSFORMERS, true);
         });
         const restoredBody = restoreRawBlocksFromEditor(nextContent);
         markdownLexicalRenderedContent = composeMarkdownContent(restoredBody);
@@ -3095,7 +3072,7 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
         const markdownModule = markdownLexicalApi.markdownModule;
         const root = lexicalModule.$getRoot();
         root.clear();
-        markdownModule.$convertFromMarkdownString(editorContent, markdownModule.TRANSFORMERS);
+        markdownModule.$convertFromMarkdownString(editorContent, markdownModule.TRANSFORMERS, true);
         if (root.getChildrenSize() === 0) {
           root.append(lexicalModule.$createParagraphNode());
         }
@@ -3377,7 +3354,7 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
     mdxBlocks.setAttribute(DATA_VF_IGNORE, 'true');
 
     const surface = document.createElement('div');
-    surface.className = 'vf-markdown-editor__surface';
+    surface.className = 'vf-markdown-editor__surface markdown-body';
     surface.setAttribute(DATA_VF_IGNORE, 'true');
     surface.setAttribute('contenteditable', 'true');
     surface.setAttribute('aria-label', 'Markdown editor');
@@ -3673,6 +3650,9 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
     }
 
     if (enabled) {
+      if (!markdownCurrentContent && markdownBody.innerText) {
+        markdownCurrentContent = markdownBody.innerText.trim();
+      }
       ensureMarkdownEditor();
       setupMarkdownLexicalEditor();
       markdownBody.style.display = 'none';

--- a/src/studio/bridge-template.ts
+++ b/src/studio/bridge-template.ts
@@ -573,6 +573,15 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
         outline: none;
       }
 
+      .vf-markdown-editor__surface p:empty::before {
+        content: '';
+        display: inline-block;
+      }
+
+      .vf-markdown-editor__surface p {
+        min-height: 1.5em;
+      }
+
       .vf-markdown-editor__textarea {
         width: 100%;
         height: calc(100vh - 52px);
@@ -2960,7 +2969,12 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
           nextContent = markdownModule.$convertToMarkdownString(markdownModule.TRANSFORMERS, true);
         });
         const restoredBody = restoreRawBlocksFromEditor(nextContent);
-        markdownLexicalRenderedContent = composeMarkdownContent(restoredBody);
+        const fullContent = composeMarkdownContent(restoredBody);
+
+        if (fullContent === markdownLexicalRenderedContent) {
+          return;
+        }
+        markdownLexicalRenderedContent = fullContent;
 
         handleMarkdownLocalChange(nextContent);
         scheduleMarkdownSlashMenuUpdate();
@@ -3040,6 +3054,15 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
       return;
     }
 
+    if (markdownLexicalApi && markdownLexicalRenderedContent === content) {
+      markdownCurrentContent = content;
+      scheduleMarkdownSelectionOverlayRender();
+      scheduleMarkdownSlashMenuUpdate();
+      scheduleMarkdownInlineToolbarUpdate();
+      hideMarkdownBlockDropIndicator();
+      return;
+    }
+
     const mdxImportMap = parseMdxImportMap(content);
     const parts = extractMarkdownParts(content);
     const extracted = extractRawBlocksForEditor(parts.body, mdxImportMap);
@@ -3050,16 +3073,6 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
     markdownRawBlockTokenPrefix = extracted.tokenPrefix;
     markdownLatestMdxImportMap = mdxImportMap;
     setMarkdownMdxBlocks(mdxBlocks);
-
-    if (markdownLexicalApi && markdownLexicalRenderedContent === content) {
-      markdownCurrentContent = content;
-      markdownCurrentEditorContent = editorContent;
-      scheduleMarkdownSelectionOverlayRender();
-      scheduleMarkdownSlashMenuUpdate();
-      scheduleMarkdownInlineToolbarUpdate();
-      hideMarkdownBlockDropIndicator();
-      return;
-    }
 
     markdownCurrentContent = content;
     markdownCurrentEditorContent = editorContent;
@@ -3076,10 +3089,8 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
         if (root.getChildrenSize() === 0) {
           root.append(lexicalModule.$createParagraphNode());
         }
-      });
-      setTimeout(function() {
-        markdownApplyingRemoteUpdate = false;
-      }, 0);
+      }, { discrete: true });
+      markdownApplyingRemoteUpdate = false;
       scheduleMarkdownSelectionOverlayRender();
       scheduleMarkdownSlashMenuUpdate();
       scheduleMarkdownInlineToolbarUpdate();
@@ -3650,9 +3661,6 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
     }
 
     if (enabled) {
-      if (!markdownCurrentContent && markdownBody.innerText) {
-        markdownCurrentContent = markdownBody.innerText.trim();
-      }
       ensureMarkdownEditor();
       setupMarkdownLexicalEditor();
       markdownBody.style.display = 'none';


### PR DESCRIPTION
## Summary
- Fix line breaks being removed when pressing Enter — pass `shouldPreserveNewLines=true` to Lexical markdown import/export
- Fix editor styling — add `markdown-body` class to surface for GitHub-flavored markdown CSS
- Fix empty initial state — seed editor from rendered page text when Studio hasn't sent content yet
- Remove redundant custom typography overrides (now handled by `github-markdown.min.css`)
- Center editor with `max-width: 980px` and better padding
- Bump to v0.1.28

## Test plan
- [ ] Press Enter multiple times in editor — blank lines should be preserved
- [ ] Headings, bold, code blocks render with proper GitHub markdown styling
- [ ] Editor shows content immediately on open (no empty flash)