### PR TITLE
fix: correct Lexical markdown API signatures (v0.1.29)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/studio/bridge-template.ts
+++ b/src/studio/bridge-template.ts
@@ -2988,7 +2988,7 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
 
         let nextContent = '';
         update.editorState.read(function() {
-          nextContent = markdownModule.$convertToMarkdownString(markdownModule.TRANSFORMERS, true);
+          nextContent = markdownModule.$convertToMarkdownString(markdownModule.TRANSFORMERS, undefined, true);
         });
         const restoredBody = restoreRawBlocksFromEditor(nextContent);
         const fullContent = composeMarkdownContent(restoredBody);
@@ -3108,7 +3108,7 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
           const markdownModule = markdownLexicalApi.markdownModule;
           const root = lexicalModule.$getRoot();
           root.clear();
-          markdownModule.$convertFromMarkdownString(editorContent, markdownModule.TRANSFORMERS, true);
+          markdownModule.$convertFromMarkdownString(editorContent, markdownModule.TRANSFORMERS, undefined, true);
           if (root.getChildrenSize() === 0) {
             root.append(lexicalModule.$createParagraphNode());
           }


### PR DESCRIPTION
## Summary
- Fix `$convertToMarkdownString(transformers, true)` → `$convertToMarkdownString(transformers, undefined, true)` — second param is `node`, not `shouldPreserveNewLines`
- Fix `$convertFromMarkdownString(content, transformers, true)` → `$convertFromMarkdownString(content, transformers, undefined, true)` — third param is `node`, not `shouldPreserveNewLines`
- Passing `true` as the node caused `.getChildren is not a function` TypeError, crashing Lexical and falling back to textarea

## Test plan
- [ ] Open a markdown page in preview with `?edit=true`
- [ ] Verify Lexical editor loads without errors (no textarea fallback)
- [ ] Verify blank lines are preserved when typing