### PR TITLE
fix: prevent cursor jump from content echo loop (v0.1.31)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/studio/bridge-template.ts
+++ b/src/studio/bridge-template.ts
@@ -78,6 +78,7 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
   let markdownLatestSelections = [];
   let markdownHasUnsavedChanges = false;
   let markdownSaveInProgress = false;
+  const markdownPendingEchoContents = new Set();
 
   const MARKDOWN_SLASH_COMMANDS = [
     {
@@ -1409,6 +1410,8 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
       clearTimeout(markdownSyncTimer);
     }
     markdownSyncTimer = setTimeout(function() {
+      markdownPendingEchoContents.add(content);
+      setTimeout(function() { markdownPendingEchoContents.delete(content); }, 3000);
       postToStudio({
         action: 'markdownContentChange',
         fileId: markdownFileId,
@@ -2931,6 +2934,8 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
       clearTimeout(markdownSyncTimer);
       markdownSyncTimer = null;
     }
+    markdownPendingEchoContents.add(markdownCurrentContent);
+    setTimeout(function() { markdownPendingEchoContents.delete(markdownCurrentContent); }, 3000);
     postToStudio({
       action: 'markdownContentChange',
       fileId: markdownFileId,
@@ -3078,8 +3083,11 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
       return;
     }
 
-    if (markdownLexicalApi && (markdownLexicalRenderedContent === content || markdownCurrentContent === content)) {
-      console.debug('[StudioBridge] applyMarkdownContent: skipped (content unchanged)');
+    if (markdownLexicalApi && (markdownLexicalRenderedContent === content || markdownCurrentContent === content || markdownPendingEchoContents.has(content))) {
+      console.debug('[StudioBridge] applyMarkdownContent: skipped echo');
+      if (markdownPendingEchoContents.has(content)) {
+        markdownPendingEchoContents.delete(content);
+      }
       markdownCurrentContent = content;
       scheduleMarkdownSelectionOverlayRender();
       scheduleMarkdownSlashMenuUpdate();
@@ -3088,7 +3096,7 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
       return;
     }
 
-    console.debug('[StudioBridge] applyMarkdownContent: rebuilding Lexical DOM, content length:', content.length, 'rendered match:', markdownLexicalRenderedContent === content, 'current match:', markdownCurrentContent === content);
+    console.debug('[StudioBridge] applyMarkdownContent: rebuilding Lexical DOM (external change)');
 
     const mdxImportMap = parseMdxImportMap(content);
     const parts = extractMarkdownParts(content);


### PR DESCRIPTION
## Summary
- Track content sent to Studio in a pending echo set
- Skip Lexical DOM rebuild when echoed content comes back from Y.Text observer
- Only rebuild for genuine external changes (another collaborator)
- Entries auto-expire after 3s to prevent stale entries

## Root cause
Studio's Y.Text observer (`useIFrameMessageEvents.ts:540-565`) sends `setMarkdownContent` back to the preview on every Y.Text change, including changes the bridge itself sent. This echo triggers `root.clear()` + `$convertFromMarkdownString`, destroying the cursor position.

## Test plan
- [ ] Type in Lexical editor — cursor should stay in place
- [ ] Press Enter for new lines — no cursor jump
- [ ] Edit in Monaco (Studio) — changes should still sync to preview