### PR TITLE
feat: direct Yjs binding for Lexical markdown editor

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/studio/bridge-template.ts
+++ b/src/studio/bridge-template.ts
@@ -78,6 +78,11 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
   let markdownLatestSelections = [];
   let markdownHasUnsavedChanges = false;
   let markdownSaveInProgress = false;
+  let markdownYDoc = null;
+  let markdownYProvider = null;
+  let markdownYText = null;
+  let markdownYjsConnected = false;
+  const LEXICAL_YJS_ORIGIN = 'lexical-yjs-binding';
 
   const MARKDOWN_SLASH_COMMANDS = [
     {
@@ -1416,6 +1421,131 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
         content: content
       });
     }, 120);
+  }
+
+  function computeTextDiff(oldText, newText) {
+    var prefixLen = 0;
+    var minLen = Math.min(oldText.length, newText.length);
+    while (prefixLen < minLen && oldText.charCodeAt(prefixLen) === newText.charCodeAt(prefixLen)) {
+      prefixLen++;
+    }
+    var suffixLen = 0;
+    var maxSuffix = minLen - prefixLen;
+    while (suffixLen < maxSuffix &&
+           oldText.charCodeAt(oldText.length - 1 - suffixLen) === newText.charCodeAt(newText.length - 1 - suffixLen)) {
+      suffixLen++;
+    }
+    return {
+      index: prefixLen,
+      deleteCount: oldText.length - prefixLen - suffixLen,
+      insertText: newText.slice(prefixLen, suffixLen > 0 ? newText.length - suffixLen : undefined)
+    };
+  }
+
+  function syncLocalChangeToYText(fullContent) {
+    if (!markdownYText || !markdownYDoc) {
+      return;
+    }
+    var currentYContent = markdownYText.toString();
+    if (currentYContent === fullContent) {
+      return;
+    }
+    var diff = computeTextDiff(currentYContent, fullContent);
+    if (diff.deleteCount === 0 && diff.insertText === '') {
+      return;
+    }
+    markdownYDoc.transact(function() {
+      if (diff.deleteCount > 0) {
+        markdownYText.delete(diff.index, diff.deleteCount);
+      }
+      if (diff.insertText) {
+        markdownYText.insert(diff.index, diff.insertText);
+      }
+    }, LEXICAL_YJS_ORIGIN);
+  }
+
+  function setupMarkdownYjsConnection(config) {
+    if (markdownYDoc) {
+      return;
+    }
+
+    Promise.all([
+      import('https://esm.sh/yjs@13.6.28?target=es2022'),
+      import('https://esm.sh/y-websocket@2.1.0?target=es2022')
+    ]).then(function(modules) {
+      var Y = modules[0];
+      var WebsocketProvider = modules[1].WebsocketProvider;
+
+      var doc = new Y.Doc({ guid: config.guid });
+      var provider = new WebsocketProvider(config.wsUrl, config.guid, doc, {
+        resyncInterval: -1,
+        params: { token: config.authToken }
+      });
+
+      var ytext = doc.getText(config.fileId);
+
+      markdownYDoc = doc;
+      markdownYProvider = provider;
+      markdownYText = ytext;
+
+      // Filter non-binary messages to prevent y-websocket parse errors
+      provider.on('status', function(event) {
+        console.debug('[StudioBridge] Yjs status:', event.status);
+        if (event.status === 'connected' && provider.ws) {
+          var origOnMessage = provider.ws.onmessage;
+          provider.ws.onmessage = function(wsEvent) {
+            if (typeof wsEvent.data === 'string') {
+              return;
+            }
+            if (origOnMessage) {
+              origOnMessage.call(provider.ws, wsEvent);
+            }
+          };
+        }
+      });
+
+      provider.on('sync', function(synced) {
+        if (synced && !markdownYjsConnected) {
+          markdownYjsConnected = true;
+
+          // Seed editor with Y.Text content
+          var content = ytext.toString();
+          if (content) {
+            applyMarkdownContent(content);
+          }
+
+          // Observe Y.Text for remote changes (from other users / Monaco)
+          ytext.observe(function(event) {
+            if (event.transaction.origin === LEXICAL_YJS_ORIGIN) {
+              return;
+            }
+            var fullContent = ytext.toString();
+            if (fullContent === markdownCurrentContent) {
+              return;
+            }
+            applyMarkdownContent(fullContent);
+          });
+
+          console.debug('[StudioBridge] Yjs synced, bound to Y.Text for fileId:', config.fileId);
+        }
+      });
+    }).catch(function(error) {
+      console.error('[StudioBridge] Failed to setup Yjs connection:', error);
+    });
+  }
+
+  function disposeMarkdownYjs() {
+    if (markdownYProvider) {
+      markdownYProvider.disconnect();
+      markdownYProvider.destroy();
+      markdownYProvider = null;
+    }
+    if (markdownYDoc) {
+      markdownYDoc.destroy();
+      markdownYDoc = null;
+    }
+    markdownYText = null;
+    markdownYjsConnected = false;
   }
 
   function getTextOffsetWithinRoot(root, targetNode, targetOffset) {
@@ -2917,7 +3047,11 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
     }
     markdownCurrentContent = fullContent;
     markdownHasUnsavedChanges = true;
-    scheduleMarkdownSync(fullContent);
+    if (markdownYjsConnected) {
+      syncLocalChangeToYText(fullContent);
+    } else {
+      scheduleMarkdownSync(fullContent);
+    }
     scheduleMarkdownSelectionOverlayRender();
   }
 
@@ -3719,6 +3853,7 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
       markdownOverlaySelections = [];
       clearMarkdownSelectionOverlay();
       clearMarkdownSelectionSync();
+      disposeMarkdownYjs();
     }
 
     const nextUrl = new URL(window.location.href);
@@ -3949,7 +4084,28 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
         if (message.fileId && markdownFileId && message.fileId !== markdownFileId) {
           return;
         }
+        if (markdownYjsConnected) {
+          return;
+        }
         applyMarkdownContent(message.content || '');
+        return;
+
+      case 'initYjsConnection':
+        if (!isMarkdownPage()) {
+          return;
+        }
+        if (message.fileId && markdownFileId && message.fileId !== markdownFileId) {
+          return;
+        }
+        if (message.initialContent) {
+          applyMarkdownContent(message.initialContent);
+        }
+        setupMarkdownYjsConnection({
+          wsUrl: message.wsUrl,
+          guid: message.guid,
+          fileId: message.fileId || markdownFileId,
+          authToken: message.authToken
+        });
         return;
 
       case 'setMarkdownPersistState':

--- a/src/studio/bridge-template.ts
+++ b/src/studio/bridge-template.ts
@@ -82,6 +82,7 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
   let markdownYProvider = null;
   let markdownYText = null;
   let markdownYjsConnected = false;
+  let markdownYjsSetupId = 0;
   const LEXICAL_YJS_ORIGIN = 'lexical-yjs-binding';
 
   const MARKDOWN_SLASH_COMMANDS = [
@@ -1469,10 +1470,17 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
       return;
     }
 
+    var setupId = ++markdownYjsSetupId;
+
     Promise.all([
       import('https://esm.sh/yjs@13.6.28?target=es2022'),
       import('https://esm.sh/y-websocket@2.1.0?target=es2022')
     ]).then(function(modules) {
+      // Abort if edit mode was closed while imports were loading
+      if (setupId !== markdownYjsSetupId) {
+        return;
+      }
+
       var Y = modules[0];
       var WebsocketProvider = modules[1].WebsocketProvider;
 
@@ -1508,10 +1516,13 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
         if (synced && !markdownYjsConnected) {
           markdownYjsConnected = true;
 
-          // Seed editor with Y.Text content
-          var content = ytext.toString();
-          if (content) {
-            applyMarkdownContent(content);
+          var ytextContent = ytext.toString();
+          if (markdownCurrentContent && markdownCurrentContent !== ytextContent) {
+            // User typed before sync completed — push local edits to Y.Text
+            syncLocalChangeToYText(markdownCurrentContent);
+          } else if (ytextContent) {
+            // No local edits — seed editor from Y.Text
+            applyMarkdownContent(ytextContent);
           }
 
           // Observe Y.Text for remote changes (from other users / Monaco)
@@ -1535,6 +1546,7 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
   }
 
   function disposeMarkdownYjs() {
+    markdownYjsSetupId++;
     if (markdownYProvider) {
       markdownYProvider.disconnect();
       markdownYProvider.destroy();

--- a/src/studio/schemas/studio.schema.ts
+++ b/src/studio/schemas/studio.schema.ts
@@ -240,6 +240,14 @@ export const MessageFromStudioSchema = z.discriminatedUnion("action", [
     content: z.string(),
   }),
   z.object({
+    action: z.literal("initYjsConnection"),
+    fileId: z.string(),
+    wsUrl: z.string(),
+    guid: z.string(),
+    authToken: z.string(),
+    initialContent: z.string().optional(),
+  }),
+  z.object({
     action: z.literal("setMarkdownPersistState"),
     fileId: z.string(),
     status: z.enum(["saving", "saved", "error"]),


### PR DESCRIPTION
## Summary
- Replace postMessage round-trip content sync with direct Yjs Y.Text binding in the preview iframe
- Bridge connects to the same Yjs room as Studio, using `?token=` auth for cross-origin WebSocket
- Uses transaction origins (like MonacoBinding) to prevent echo loops — local changes tagged with `LEXICAL_YJS_ORIGIN`, observer skips matching origins
- Computes incremental text diffs (common prefix/suffix) for minimal Y.Text operations instead of full content replacement
- Eliminates the cursor jumping and text garbling caused by the 150ms debounced content echo loop

## Changes
**bridge-template.ts:**
- `computeTextDiff()` — finds minimal insert/delete ops between old and new text
- `syncLocalChangeToYText()` — applies diff to Y.Text within a tagged transaction
- `setupMarkdownYjsConnection()` — creates Y.Doc, WebsocketProvider with token auth, Y.Text observer for remote changes
- `disposeMarkdownYjs()` — cleanup on edit mode exit
- `handleMarkdownLocalChange` routes to Y.Text sync when connected, falls back to postMessage
- `initYjsConnection` message handler seeds editor and starts Yjs connection
- `setMarkdownContent` handler skips when Yjs is active

**studio.schema.ts:**
- Added `initYjsConnection` action to MessageFromStudio schema

## Companion PR
Requires veryfront/veryfront-studio PR (same branch name) for Studio-side changes.

## Test plan
- [ ] Open markdown file in Studio, enter edit mode
- [ ] Verify typing is smooth with no cursor jumping
- [ ] Verify fast typing doesn't garble text
- [ ] Verify Cmd+S saves correctly with status indicator
- [ ] Verify remote changes from Monaco appear in Lexical editor
- [ ] Verify exiting edit mode cleans up Yjs connection