### PR TITLE
feat: self-sufficient Yjs binding for preview bridge

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/html/dev-scripts.ts
+++ b/src/html/dev-scripts.ts
@@ -59,6 +59,10 @@ export interface StudioScriptOptions {
   nonce?: string;
   /** Hash of source code for sync detection with Navigator tree */
   sourceHash?: string;
+  /** WebSocket URL for direct Yjs connection from the bridge */
+  wsUrl?: string;
+  /** Yjs document GUID for the bridge to join the same room */
+  yjsGuid?: string;
 }
 
 export function getStudioScripts(options: StudioScriptOptions): string {
@@ -68,6 +72,8 @@ export function getStudioScripts(options: StudioScriptOptions): string {
     projectId: options.projectId,
     pageId: options.pageId,
     ...(options.pagePath ? { pagePath: options.pagePath } : {}),
+    ...(options.wsUrl ? { wsUrl: options.wsUrl } : {}),
+    ...(options.yjsGuid ? { yjsGuid: options.yjsGuid } : {}),
   }).toString();
 
   const sourceHashScript = options.sourceHash

--- a/src/html/html-injection.ts
+++ b/src/html/html-injection.ts
@@ -23,6 +23,10 @@ export interface InjectHTMLContentOptions {
   pageId?: string;
   /** CSP nonce */
   nonce?: string;
+  /** WebSocket URL for direct Yjs connection from the bridge */
+  wsUrl?: string;
+  /** Yjs document GUID for the bridge to join the same room */
+  yjsGuid?: string;
 }
 
 export function injectHTMLContent(
@@ -99,6 +103,8 @@ export function injectHTMLContent(
       projectId: options.projectId ?? options.slug,
       pageId: options.pageId ?? options.slug,
       nonce: options.nonce,
+      wsUrl: options.wsUrl,
+      yjsGuid: options.yjsGuid,
     });
     html = html.replace(/<\/body>/i, `${studioScripts}</body>`);
   }

--- a/src/server/handlers/preview/markdown-html-generator.ts
+++ b/src/server/handlers/preview/markdown-html-generator.ts
@@ -27,6 +27,10 @@ export interface MarkdownHtmlOptions {
   projectId: string;
   /** File path of the markdown file. */
   filePath: string;
+  /** Branch ID for Yjs room GUID computation. */
+  branchId?: string | null;
+  /** Request host for computing the WebSocket URL. */
+  requestHost?: string;
 }
 
 /**
@@ -56,21 +60,37 @@ function detectTheme(req: Request, url: URL): "light" | "dark" | null {
  * Injected when embedded in Studio (`studio_embed=true`) or for standalone
  * markdown/MDX pages so the edit button and editor features are available.
  */
-function buildStudioScript(url: URL, projectId: string, filePath: string): string {
+function buildStudioScript(
+  url: URL,
+  projectId: string,
+  filePath: string,
+  branchId?: string | null,
+  requestHost?: string,
+): string {
   const studioEmbed = url.searchParams.get("studio_embed") === "true";
   const isMarkdown = /\.mdx?$/i.test(filePath);
   if (!studioEmbed && !isMarkdown) return "";
 
-  const queryProjectId = url.searchParams.get("vf_project_id")?.trim() || "";
+  const rawQueryProjectId = url.searchParams.get("vf_project_id")?.trim() || "";
+  // Validate query param to prevent path traversal in WebSocket URL
+  const queryProjectId = /^[a-zA-Z0-9_-]+$/.test(rawQueryProjectId) ? rawQueryProjectId : "";
   const queryFileId = url.searchParams.get("vf_file_id")?.trim() || "";
   const canonicalProjectId = queryProjectId || projectId;
   const canonicalPageId = queryFileId || filePath;
+
+  // Compute Yjs connection config for the bridge to self-connect
+  const wsProtocol = url.protocol === "https:" ? "wss" : "ws";
+  const host = requestHost || url.host;
+  const wsUrl = `${wsProtocol}://${host}/api/ws/${canonicalProjectId}/yjs`;
+  const yjsGuid = branchId ? `${canonicalProjectId}:${branchId}` : canonicalProjectId;
 
   return `<script>${
     generateStudioBridgeScript({
       projectId: canonicalProjectId,
       pageId: canonicalPageId,
       pagePath: filePath,
+      wsUrl,
+      yjsGuid,
     })
   }</script>`;
 }
@@ -83,10 +103,11 @@ function buildStudioScript(url: URL, projectId: string, filePath: string): strin
  * studio bridge integration.
  */
 export function generateMarkdownHtml(options: MarkdownHtmlOptions): string {
-  const { rawHtml, title, description, request, url, projectId, filePath } = options;
+  const { rawHtml, title, description, request, url, projectId, filePath, branchId, requestHost } =
+    options;
 
   const theme = detectTheme(request, url);
-  const studioScript = buildStudioScript(url, projectId, filePath);
+  const studioScript = buildStudioScript(url, projectId, filePath, branchId, requestHost);
   const themeAttrs = theme ? ` data-theme="${theme}" style="color-scheme: ${theme};"` : "";
 
   return `<!DOCTYPE html>

--- a/src/server/handlers/preview/markdown-preview.handler.ts
+++ b/src/server/handlers/preview/markdown-preview.handler.ts
@@ -157,6 +157,8 @@ export class MarkdownPreviewHandler extends BaseHandler {
         url,
         projectId: ctx.projectSlug || ctx.projectId || "markdown-preview",
         filePath,
+        branchId: ctx.parsedDomain?.branch ?? null,
+        requestHost: url.host,
       });
 
       const responseBuilder = this.createResponseBuilder(ctx)

--- a/src/server/handlers/studio/endpoints.handler.ts
+++ b/src/server/handlers/studio/endpoints.handler.ts
@@ -36,8 +36,10 @@ export class StudioEndpointsHandler extends BaseHandler {
     const projectId = url.searchParams.get("projectId") ?? "";
     const pageId = url.searchParams.get("pageId") ?? "";
     const pagePath = url.searchParams.get("pagePath") ?? undefined;
+    const wsUrl = url.searchParams.get("wsUrl") ?? undefined;
+    const yjsGuid = url.searchParams.get("yjsGuid") ?? undefined;
 
-    const script = generateStudioBridgeScript({ projectId, pageId, pagePath });
+    const script = generateStudioBridgeScript({ projectId, pageId, pagePath, wsUrl, yjsGuid });
     const response = builder.withCache("no-cache").javascript(script, HTTP_OK);
 
     return Promise.resolve(this.respond(response));

--- a/src/studio/bridge-template.test.ts
+++ b/src/studio/bridge-template.test.ts
@@ -20,7 +20,6 @@ Deno.test("generateStudioBridgeScript includes markdown collaboration actions", 
   });
 
   assertStringIncludes(script, "markdownContentChange");
-  assertStringIncludes(script, "setMarkdownContent");
   assertStringIncludes(script, "setMarkdownPersistState");
   assertStringIncludes(script, "setMarkdownPresence");
   assertStringIncludes(script, "setMarkdownSelections");

--- a/src/studio/bridge-template.ts
+++ b/src/studio/bridge-template.ts
@@ -2,6 +2,8 @@ export interface StudioBridgeOptions {
   projectId: string;
   pageId: string;
   pagePath?: string;
+  wsUrl?: string;
+  yjsGuid?: string;
   debugSkipInit?: boolean;
   debugExposeInternals?: boolean;
 }
@@ -13,6 +15,8 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
   const PROJECT_ID = ${JSON.stringify(options.projectId)};
   const PAGE_ID = ${JSON.stringify(options.pageId)};
   const PAGE_PATH = ${JSON.stringify(options.pagePath ?? options.pageId)};
+  const WS_URL = ${JSON.stringify(options.wsUrl ?? "")};
+  const YJS_GUID = ${JSON.stringify(options.yjsGuid ?? "")};
   const DEBUG_SKIP_INIT = ${options.debugSkipInit ? "true" : "false"};
   const DEBUG_EXPOSE_INTERNALS = ${options.debugExposeInternals ? "true" : "false"};
 
@@ -84,6 +88,7 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
   let markdownYjsConnected = false;
   let markdownYjsSetupId = 0;
   let markdownYjsY = null;
+  let markdownPendingSelection = null;
   const LEXICAL_YJS_ORIGIN = 'lexical-yjs-binding';
 
   const MARKDOWN_SLASH_COMMANDS = [
@@ -1487,9 +1492,10 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
       markdownYjsY = Y;
 
       var doc = new Y.Doc({ guid: config.guid });
+      // Cookie auth: authToken cookie on .veryfront.com is sent automatically
+      // with the WebSocket upgrade request. No explicit token param needed.
       var provider = new WebsocketProvider(config.wsUrl, config.guid, doc, {
-        resyncInterval: -1,
-        params: { token: config.authToken }
+        resyncInterval: -1
       });
 
       var ytext = doc.getText(config.fileId);
@@ -1514,6 +1520,93 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
         }
       });
 
+      // Extract user identity from authToken JWT cookie for presence
+      var presenceUser = { id: 'preview-' + Math.random().toString(36).slice(2), name: 'Preview' };
+      try {
+        var cookieMatch = document.cookie.match(/authToken=([^;]+)/);
+        if (cookieMatch) {
+          var parts = cookieMatch[1].split('.');
+          if (parts.length === 3) {
+            var payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
+            if (payload.userId) {
+              presenceUser.id = payload.userId;
+            }
+            if (payload.email) {
+              var local = payload.email.split('@')[0] || '';
+              if (local.includes('.') || local.includes('_')) {
+                presenceUser.name = local.split(/[._]/).map(function(p) { return p.charAt(0).toUpperCase() + p.slice(1); }).join(' ');
+              } else {
+                presenceUser.name = local.charAt(0).toUpperCase() + local.slice(1);
+              }
+            }
+          }
+        }
+      } catch (e) {
+        // Fall back to defaults on any parse error
+      }
+
+      // Set local user on awareness for presence
+      provider.awareness.setLocalStateField('user', {
+        id: presenceUser.id,
+        name: presenceUser.name,
+        color: '#10b981'
+      });
+
+      // Observe awareness for remote presence and selection changes
+      function syncAwareness() {
+        var states = Array.from(provider.awareness.getStates().entries());
+
+        // Sync presence users
+        var users = [];
+        for (var i = 0; i < states.length; i++) {
+          var clientId = states[i][0];
+          var state = states[i][1];
+          var user = state.user;
+          if (!user || typeof user.name !== 'string') {
+            continue;
+          }
+          users.push({
+            id: user.id || String(clientId),
+            name: user.name,
+            color: user.color || '#6b7280',
+            isCurrentUser: clientId === provider.awareness.clientID,
+            isAgent: user.isAgent || false
+          });
+        }
+        setMarkdownPresence(users);
+
+        // Sync remote selections
+        var selections = [];
+        for (var j = 0; j < states.length; j++) {
+          var cId = states[j][0];
+          var st = states[j][1];
+          var u = st.user;
+          var ranges = st.selection;
+          if (!u || !Array.isArray(ranges) || ranges.length === 0) {
+            continue;
+          }
+          for (var k = 0; k < ranges.length; k++) {
+            var range = ranges[k];
+            var anchorPos = Y.createAbsolutePositionFromRelativePosition(range.anchor, doc);
+            var markerPos = Y.createAbsolutePositionFromRelativePosition(range.marker, doc);
+            if (!anchorPos || !markerPos || anchorPos.type !== ytext || markerPos.type !== ytext) {
+              continue;
+            }
+            selections.push({
+              id: u.id || String(cId),
+              name: u.name || 'Anonymous',
+              color: u.color || '#6b7280',
+              isCurrentUser: cId === provider.awareness.clientID,
+              start: Math.min(anchorPos.index, markerPos.index),
+              end: Math.max(anchorPos.index, markerPos.index)
+            });
+          }
+        }
+        setMarkdownSelections(selections);
+      }
+
+      provider.awareness.on('change', syncAwareness);
+
       provider.on('sync', function(synced) {
         if (synced && !markdownYjsConnected) {
           markdownYjsConnected = true;
@@ -1527,6 +1620,18 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
             applyMarkdownContent(ytextContent);
           }
 
+          // Replay any selection queued before Yjs was ready
+          if (markdownPendingSelection) {
+            var ps = markdownPendingSelection;
+            markdownPendingSelection = null;
+            var cs = Math.max(0, Math.min(ytext.length, ps.start));
+            var ce = Math.max(0, Math.min(ytext.length, ps.end));
+            provider.awareness.setLocalStateField('selection', [{
+              anchor: Y.createRelativePositionFromTypeIndex(ytext, cs),
+              marker: Y.createRelativePositionFromTypeIndex(ytext, ce)
+            }]);
+          }
+
           // Observe Y.Text for remote changes (from other users / Monaco)
           ytext.observe(function(event) {
             if (event.transaction.origin === LEXICAL_YJS_ORIGIN) {
@@ -1538,6 +1643,9 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
             }
             applyMarkdownContent(fullContent);
           });
+
+          // Initial awareness sync after Yjs is connected
+          syncAwareness();
 
           console.debug('[StudioBridge] Yjs synced, bound to Y.Text for fileId:', config.fileId);
         }
@@ -2648,43 +2756,26 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
       const start = editorOffsetToSourceOffset(selection.start, 'start');
       const end = editorOffsetToSourceOffset(selection.end, 'end');
 
-      var message = {
-        action: 'markdownSelectionChange',
-        fileId: markdownFileId,
-        filePath: PAGE_PATH,
-        start: start,
-        end: end
-      };
-
-      // When Yjs is connected, include pre-computed RelativePositions
-      // from the bridge's Y.Text (which is up-to-date) so Studio doesn't
-      // need to compute against potentially stale Y.Text
-      if (markdownYjsConnected && markdownYText && markdownYjsY) {
+      // Set local selection on Yjs awareness directly
+      if (markdownYjsConnected && markdownYText && markdownYjsY && markdownYProvider) {
         var clampedStart = Math.max(0, Math.min(markdownYText.length, start));
         var clampedEnd = Math.max(0, Math.min(markdownYText.length, end));
-        message.relativeStart = markdownYjsY.relativePositionToJSON(
-          markdownYjsY.createRelativePositionFromTypeIndex(markdownYText, clampedStart)
-        );
-        message.relativeEnd = markdownYjsY.relativePositionToJSON(
-          markdownYjsY.createRelativePositionFromTypeIndex(markdownYText, clampedEnd)
-        );
+        markdownYProvider.awareness.setLocalStateField('selection', [{
+          anchor: markdownYjsY.createRelativePositionFromTypeIndex(markdownYText, clampedStart),
+          marker: markdownYjsY.createRelativePositionFromTypeIndex(markdownYText, clampedEnd)
+        }]);
+        markdownPendingSelection = null;
+      } else {
+        // Queue selection for replay after Yjs connects
+        markdownPendingSelection = { start: start, end: end };
       }
-
-      postToStudio(message);
     }, 80);
   }
 
   function clearMarkdownSelectionSync() {
-    if (!markdownFileId) {
-      return;
+    if (markdownYProvider) {
+      markdownYProvider.awareness.setLocalStateField('selection', null);
     }
-    postToStudio({
-      action: 'markdownSelectionChange',
-      fileId: markdownFileId,
-      filePath: PAGE_PATH,
-      start: -1,
-      end: -1
-    });
   }
 
   function clearMarkdownSelectionOverlay() {
@@ -3080,9 +3171,8 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
     markdownHasUnsavedChanges = true;
     if (markdownYjsConnected) {
       syncLocalChangeToYText(fullContent);
-    } else {
-      scheduleMarkdownSync(fullContent);
     }
+    scheduleMarkdownSync(fullContent);
     scheduleMarkdownSelectionOverlayRender();
   }
 
@@ -3873,6 +3963,15 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
       scheduleMarkdownSlashMenuUpdate();
       scheduleMarkdownInlineToolbarUpdate();
       postMarkdownEditorReady();
+
+      // Self-connect to Yjs when server-injected config is available
+      if (WS_URL && YJS_GUID && !markdownYDoc) {
+        setupMarkdownYjsConnection({
+          wsUrl: WS_URL,
+          guid: YJS_GUID,
+          fileId: markdownFileId
+        });
+      }
     } else {
       markdownBody.style.display = '';
       if (markdownEditorRoot) {
@@ -4108,37 +4207,6 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
         if (!inspectMode) showHoverOverlay(message.id);
         return;
 
-      case 'setMarkdownContent':
-        if (!isMarkdownPage()) {
-          return;
-        }
-        if (message.fileId && markdownFileId && message.fileId !== markdownFileId) {
-          return;
-        }
-        if (markdownYjsConnected) {
-          return;
-        }
-        applyMarkdownContent(message.content || '');
-        return;
-
-      case 'initYjsConnection':
-        if (!isMarkdownPage()) {
-          return;
-        }
-        if (message.fileId && markdownFileId && message.fileId !== markdownFileId) {
-          return;
-        }
-        if (message.initialContent) {
-          applyMarkdownContent(message.initialContent);
-        }
-        setupMarkdownYjsConnection({
-          wsUrl: message.wsUrl,
-          guid: message.guid,
-          fileId: message.fileId || markdownFileId,
-          authToken: message.authToken
-        });
-        return;
-
       case 'setMarkdownPersistState':
         if (!isMarkdownPage()) {
           return;
@@ -4153,26 +4221,6 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
             markdownHasUnsavedChanges = false;
           }
         }
-        return;
-
-      case 'setMarkdownPresence':
-        if (!isMarkdownPage()) {
-          return;
-        }
-        if (message.fileId && markdownFileId && message.fileId !== markdownFileId) {
-          return;
-        }
-        setMarkdownPresence(message.users);
-        return;
-
-      case 'setMarkdownSelections':
-        if (!isMarkdownPage()) {
-          return;
-        }
-        if (message.fileId && markdownFileId && message.fileId !== markdownFileId) {
-          return;
-        }
-        setMarkdownSelections(message.selections);
         return;
 
       case 'screenshot':
@@ -4232,47 +4280,59 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
   function init() {
     const params = new URLSearchParams(window.location.search);
     const studioEmbed = params.get('studio_embed') === 'true';
+    const isStandalone = window.parent === window && !studioEmbed;
 
-    if (window.parent === window && !studioEmbed) {
-      console.debug('[StudioBridge] Not in iframe and not studio_embed mode, skipping initialization');
-      return;
+    if (isStandalone) {
+      // Allow standalone markdown editing when WS_URL is available (server-injected Yjs config)
+      if (!WS_URL) {
+        console.debug('[StudioBridge] Not in iframe and not studio_embed mode, skipping initialization');
+        return;
+      }
     }
 
     console.debug('[StudioBridge] Initializing...');
 
-    injectOverlayStyles();
-    hoverOverlay = createOverlay('hover');
-    selectionOverlay = createOverlay('selection');
+    // Only set up Studio interaction features when embedded in Studio
+    if (!isStandalone) {
+      injectOverlayStyles();
+      hoverOverlay = createOverlay('hover');
+      selectionOverlay = createOverlay('selection');
 
-    setupConsoleCapture();
-    setupErrorHandling();
-    setupInspectMode();
+      setupConsoleCapture();
+      setupErrorHandling();
+      setupInspectMode();
+    }
+
     setupMarkdownEditor(params);
 
     window.addEventListener('message', handleStudioMessage);
 
-    // IMPORTANT: notifyAppLoaded() must be called BEFORE setupMutationObserver()
-    // because notifyAppLoaded sends onPageTransitionEnd which sets previewId,
-    // and treeUpdated (from setupMutationObserver) requires previewId to be set
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', function() {
+    if (!isStandalone) {
+      // IMPORTANT: notifyAppLoaded() must be called BEFORE setupMutationObserver()
+      // because notifyAppLoaded sends onPageTransitionEnd which sets previewId,
+      // and treeUpdated (from setupMutationObserver) requires previewId to be set
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function() {
+          notifyAppLoaded();
+          setupMutationObserver();
+        });
+      } else {
         notifyAppLoaded();
         setupMutationObserver();
-      });
-    } else {
-      notifyAppLoaded();
-      setupMutationObserver();
-    }
+      }
 
-    window.addEventListener('beforeunload', notifyAppUnloaded);
+      window.addEventListener('beforeunload', notifyAppUnloaded);
+    }
 
     const colorMode = params.get('color_mode');
     if (colorMode) setColorMode(colorMode);
 
-    const inspectModeParam = params.get('inspect_mode');
-    if (inspectModeParam === 'true') {
-      inspectMode = true;
-      console.debug('[StudioBridge] Inspect mode enabled from query param');
+    if (!isStandalone) {
+      const inspectModeParam = params.get('inspect_mode');
+      if (inspectModeParam === 'true') {
+        inspectMode = true;
+        console.debug('[StudioBridge] Inspect mode enabled from query param');
+      }
     }
 
     console.debug('[StudioBridge] Initialized successfully');

--- a/src/studio/schemas/studio.schema.test.ts
+++ b/src/studio/schemas/studio.schema.test.ts
@@ -453,54 +453,11 @@ describe("studio/schema", () => {
       assertEquals(result.success, true);
     });
 
-    it("should accept setMarkdownContent action", () => {
-      const result = MessageFromStudioSchema.safeParse({
-        action: "setMarkdownContent",
-        fileId: "f43f9fb3-4a3a-4eb8-b8d0-8b6f8a4ca03f",
-        content: "# Updated",
-      });
-      assertEquals(result.success, true);
-    });
-
     it("should accept setMarkdownPersistState action", () => {
       const result = MessageFromStudioSchema.safeParse({
         action: "setMarkdownPersistState",
         fileId: "f43f9fb3-4a3a-4eb8-b8d0-8b6f8a4ca03f",
         status: "saved",
-      });
-      assertEquals(result.success, true);
-    });
-
-    it("should accept setMarkdownPresence action", () => {
-      const result = MessageFromStudioSchema.safeParse({
-        action: "setMarkdownPresence",
-        fileId: "f43f9fb3-4a3a-4eb8-b8d0-8b6f8a4ca03f",
-        users: [
-          {
-            id: "user-1",
-            name: "Alice",
-            color: "#3b82f6",
-            isCurrentUser: false,
-          },
-        ],
-      });
-      assertEquals(result.success, true);
-    });
-
-    it("should accept setMarkdownSelections action", () => {
-      const result = MessageFromStudioSchema.safeParse({
-        action: "setMarkdownSelections",
-        fileId: "f43f9fb3-4a3a-4eb8-b8d0-8b6f8a4ca03f",
-        selections: [
-          {
-            id: "user-1",
-            name: "Alice",
-            color: "#3b82f6",
-            isCurrentUser: true,
-            start: 12,
-            end: 27,
-          },
-        ],
       });
       assertEquals(result.success, true);
     });

--- a/src/studio/schemas/studio.schema.ts
+++ b/src/studio/schemas/studio.schema.ts
@@ -149,8 +149,6 @@ export const MessageFromRendererSchema = z.discriminatedUnion("action", [
     filePath: z.string(),
     start: z.number(),
     end: z.number(),
-    relativeStart: z.unknown().optional(),
-    relativeEnd: z.unknown().optional(),
   }),
   z.object({
     action: z.literal("logEvent"),
@@ -237,49 +235,9 @@ export const MessageFromStudioSchema = z.discriminatedUnion("action", [
     id: z.string(),
   }),
   z.object({
-    action: z.literal("setMarkdownContent"),
-    fileId: z.string(),
-    content: z.string(),
-  }),
-  z.object({
-    action: z.literal("initYjsConnection"),
-    fileId: z.string(),
-    wsUrl: z.string(),
-    guid: z.string(),
-    authToken: z.string(),
-    initialContent: z.string().optional(),
-  }),
-  z.object({
     action: z.literal("setMarkdownPersistState"),
     fileId: z.string(),
     status: z.enum(["saving", "saved", "error"]),
-  }),
-  z.object({
-    action: z.literal("setMarkdownPresence"),
-    fileId: z.string(),
-    users: z.array(
-      z.object({
-        id: z.string(),
-        name: z.string(),
-        color: z.string(),
-        isCurrentUser: z.boolean().optional(),
-        isAgent: z.boolean().optional(),
-      }),
-    ),
-  }),
-  z.object({
-    action: z.literal("setMarkdownSelections"),
-    fileId: z.string(),
-    selections: z.array(
-      z.object({
-        id: z.string(),
-        name: z.string(),
-        color: z.string(),
-        isCurrentUser: z.boolean().optional(),
-        start: z.number(),
-        end: z.number(),
-      }),
-    ),
   }),
 ]);
 


### PR DESCRIPTION
## Summary

- Bridge connects directly to Yjs WebSocket server using server-injected config (`wsUrl`/`yjsGuid`) instead of relying on Studio to relay connection info via postMessage
- Server computes and injects `WS_URL`/`YJS_GUID` constants into the bridge script at render time
- Bridge auto-connects to Yjs on edit mode entry using cookie auth (no explicit token param)
- Awareness protocol handles presence (with real user identity from JWT) and selection sync directly
- Removes `initYjsConnection`, `setMarkdownContent`, `setMarkdownPresence`, `setMarkdownSelections` postMessage handlers and Zod schemas
- Queues selections made during Yjs connection window and replays them on sync
- Validates `vf_project_id` query param against path traversal
- Skips unnecessary bridge setup (overlays, console capture, inspect mode, mutation observer) in standalone mode

## Architecture

```
Before:  Bridge --postMessage--> Studio --postMessage--> Bridge (initYjsConnection)
After:   Bridge --WebSocket--> Yjs Server <--WebSocket-- Studio (same Y.Doc room)
```

## Files changed

| File | Change |
|------|--------|
| `src/studio/bridge-template.ts` | Self-connect to Yjs, awareness handling, JWT presence, standalone optimization |
| `src/html/dev-scripts.ts` | Add `wsUrl`/`yjsGuid` to `StudioScriptOptions` |
| `src/html/html-injection.ts` | Pass `wsUrl`/`yjsGuid` through injection pipeline |
| `src/server/handlers/preview/markdown-html-generator.ts` | Compute wsUrl/yjsGuid, validate `vf_project_id` |
| `src/server/handlers/preview/markdown-preview.handler.ts` | Pass `branchId` + `requestHost` |
| `src/server/handlers/studio/endpoints.handler.ts` | Extract `wsUrl`/`yjsGuid` from query params |
| `src/studio/schemas/studio.schema.ts` | Remove obsolete message schemas |
| `deno.json` | Version bump to `0.1.32` |

## Test plan

- [x] `deno task typecheck` passes
- [x] `deno task test` passes (1166 tests, 0 failures)
- [ ] Manual: Open markdown in Studio → edit mode → content loads via Yjs, cursor tracking works
- [ ] Manual: Navigate to `{slug}.preview.veryfront.com/file.md?edit=true` → standalone editing works
- [ ] Verify presence shows real user name (from JWT email) instead of "Preview"

## Companion PR needed

`veryfront-studio` changes (remove `initYjsConnection` sending, selection/presence postMessage sync, unused types) should be submitted as a companion PR.