### PR TITLE
fix: use public host and protocol for WebSocket URL in bridge

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/server/handlers/preview/markdown-html-generator.ts
+++ b/src/server/handlers/preview/markdown-html-generator.ts
@@ -61,6 +61,7 @@ function detectTheme(req: Request, url: URL): "light" | "dark" | null {
  * markdown/MDX pages so the edit button and editor features are available.
  */
 function buildStudioScript(
+  req: Request,
   url: URL,
   projectId: string,
   filePath: string,
@@ -79,7 +80,10 @@ function buildStudioScript(
   const canonicalPageId = queryFileId || filePath;
 
   // Compute Yjs connection config for the bridge to self-connect
-  const wsProtocol = url.protocol === "https:" ? "wss" : "ws";
+  // Use x-forwarded-proto to detect the public-facing protocol (internal K8s URL is always http)
+  const forwardedProto = req.headers.get("x-forwarded-proto")?.split(",")[0]?.trim();
+  const isSecure = forwardedProto === "https" || url.protocol === "https:";
+  const wsProtocol = isSecure ? "wss" : "ws";
   const host = requestHost || url.host;
   const wsUrl = `${wsProtocol}://${host}/api/ws/${canonicalProjectId}/yjs`;
   const yjsGuid = branchId ? `${canonicalProjectId}:${branchId}` : canonicalProjectId;
@@ -107,7 +111,7 @@ export function generateMarkdownHtml(options: MarkdownHtmlOptions): string {
     options;
 
   const theme = detectTheme(request, url);
-  const studioScript = buildStudioScript(url, projectId, filePath, branchId, requestHost);
+  const studioScript = buildStudioScript(request, url, projectId, filePath, branchId, requestHost);
   const themeAttrs = theme ? ` data-theme="${theme}" style="color-scheme: ${theme};"` : "";
 
   return `<!DOCTYPE html>

--- a/src/server/handlers/preview/markdown-preview.handler.ts
+++ b/src/server/handlers/preview/markdown-preview.handler.ts
@@ -158,7 +158,7 @@ export class MarkdownPreviewHandler extends BaseHandler {
         projectId: ctx.projectSlug || ctx.projectId || "markdown-preview",
         filePath,
         branchId: ctx.parsedDomain?.branch ?? null,
-        requestHost: url.host,
+        requestHost: req.headers.get("x-forwarded-host") || req.headers.get("host") || url.host,
       });
 
       const responseBuilder = this.createResponseBuilder(ctx)


### PR DESCRIPTION
## Summary

- Use `x-forwarded-host`/`host` header instead of `url.host` for the WebSocket hostname (internal K8s service name `veryfront-server` was being used instead of the public domain)
- Use `x-forwarded-proto` header to detect HTTPS for `wss://` protocol (internal URL is always `http:`, causing mixed content block)

## Root cause

Behind Traefik ingress in K8s, the request URL seen by the handler has internal values:
- `url.host` = `veryfront-server` (K8s service name)
- `url.protocol` = `http:`

The browser blocked `ws://veryfront-server/...` as mixed content on the HTTPS page.

## Test plan

- [x] `deno task typecheck` passes
- [x] Tests pass (9/9)
- [ ] Verify markdown edit mode connects via `wss://{public-domain}/api/ws/...`