### PR TITLE
fix: normalize x-forwarded-host to first hop (v0.1.34)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/server/handlers/preview/markdown-preview.handler.ts
+++ b/src/server/handlers/preview/markdown-preview.handler.ts
@@ -158,7 +158,7 @@ export class MarkdownPreviewHandler extends BaseHandler {
         projectId: ctx.projectSlug || ctx.projectId || "markdown-preview",
         filePath,
         branchId: ctx.parsedDomain?.branch ?? null,
-        requestHost: req.headers.get("x-forwarded-host") || req.headers.get("host") || url.host,
+        requestHost: req.headers.get("x-forwarded-host")?.split(",")[0]?.trim() || req.headers.get("host") || url.host,
       });
 
       const responseBuilder = this.createResponseBuilder(ctx)


### PR DESCRIPTION
## Summary

- Normalize `x-forwarded-host` by splitting on `,` and taking the first trimmed value
- Prevents invalid WebSocket URL when header carries multiple proxy hops (e.g. `public.example.com, ingress.internal`)
- Matches the existing `x-forwarded-proto` normalization pattern
- Version bump to v0.1.34

## Test plan

- [x] `deno task typecheck` passes
- [x] Tests pass
- [ ] Verify markdown edit mode connects with correct public hostname