### PR TITLE
chore: fix formatting in markdown-preview handler

### DIFF
--- a/src/server/handlers/preview/markdown-preview.handler.ts
+++ b/src/server/handlers/preview/markdown-preview.handler.ts
@@ -158,7 +158,8 @@ export class MarkdownPreviewHandler extends BaseHandler {
         projectId: ctx.projectSlug || ctx.projectId || "markdown-preview",
         filePath,
         branchId: ctx.parsedDomain?.branch ?? null,
-        requestHost: req.headers.get("x-forwarded-host")?.split(",")[0]?.trim() || req.headers.get("host") || url.host,
+        requestHost: req.headers.get("x-forwarded-host")?.split(",")[0]?.trim() ||
+          req.headers.get("host") || url.host,
       });
 
       const responseBuilder = this.createResponseBuilder(ctx)


### PR DESCRIPTION
## Summary

- Fix `deno fmt` formatting issue from PR #485 (line too long)

## Test plan

- [x] `deno fmt --check` passes