### PR TITLE
fix: connect Yjs WebSocket to API host, not preview host (v0.1.35)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/server/handlers/preview/markdown-html-generator.ts
+++ b/src/server/handlers/preview/markdown-html-generator.ts
@@ -29,8 +29,8 @@ export interface MarkdownHtmlOptions {
   filePath: string;
   /** Branch ID for Yjs room GUID computation. */
   branchId?: string | null;
-  /** Request host for computing the WebSocket URL. */
-  requestHost?: string;
+  /** API base URL for computing the WebSocket URL (e.g. "https://api.veryfront.com"). */
+  apiBaseUrl?: string;
 }
 
 /**
@@ -61,12 +61,11 @@ function detectTheme(req: Request, url: URL): "light" | "dark" | null {
  * markdown/MDX pages so the edit button and editor features are available.
  */
 function buildStudioScript(
-  req: Request,
   url: URL,
   projectId: string,
   filePath: string,
   branchId?: string | null,
-  requestHost?: string,
+  apiBaseUrl?: string,
 ): string {
   const studioEmbed = url.searchParams.get("studio_embed") === "true";
   const isMarkdown = /\.mdx?$/i.test(filePath);
@@ -79,13 +78,17 @@ function buildStudioScript(
   const canonicalProjectId = queryProjectId || projectId;
   const canonicalPageId = queryFileId || filePath;
 
-  // Compute Yjs connection config for the bridge to self-connect
-  // Use x-forwarded-proto to detect the public-facing protocol (internal K8s URL is always http)
-  const forwardedProto = req.headers.get("x-forwarded-proto")?.split(",")[0]?.trim();
-  const isSecure = forwardedProto === "https" || url.protocol === "https:";
-  const wsProtocol = isSecure ? "wss" : "ws";
-  const host = requestHost || url.host;
-  const wsUrl = `${wsProtocol}://${host}/api/ws/${canonicalProjectId}/yjs`;
+  // Compute Yjs WebSocket URL from the API base URL (Yjs endpoint lives on the API server)
+  let wsUrl = "";
+  if (apiBaseUrl) {
+    try {
+      const apiUrl = new URL(apiBaseUrl);
+      const wsProtocol = apiUrl.protocol === "https:" ? "wss:" : "ws:";
+      wsUrl = `${wsProtocol}//${apiUrl.host}/api/ws/${canonicalProjectId}/yjs`;
+    } catch {
+      // Invalid API URL — wsUrl stays empty, bridge won't self-connect
+    }
+  }
   const yjsGuid = branchId ? `${canonicalProjectId}:${branchId}` : canonicalProjectId;
 
   return `<script>${
@@ -107,11 +110,11 @@ function buildStudioScript(
  * studio bridge integration.
  */
 export function generateMarkdownHtml(options: MarkdownHtmlOptions): string {
-  const { rawHtml, title, description, request, url, projectId, filePath, branchId, requestHost } =
+  const { rawHtml, title, description, request, url, projectId, filePath, branchId, apiBaseUrl } =
     options;
 
   const theme = detectTheme(request, url);
-  const studioScript = buildStudioScript(request, url, projectId, filePath, branchId, requestHost);
+  const studioScript = buildStudioScript(url, projectId, filePath, branchId, apiBaseUrl);
   const themeAttrs = theme ? ` data-theme="${theme}" style="color-scheme: ${theme};"` : "";
 
   return `<!DOCTYPE html>

--- a/src/server/handlers/preview/markdown-preview.handler.ts
+++ b/src/server/handlers/preview/markdown-preview.handler.ts
@@ -17,6 +17,7 @@ import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts"
 import { getEnv } from "#veryfront/platform/compat/process.ts";
 import { tryNotFoundFallback } from "../request/ssr/not-found-fallback.ts";
 import { generateMarkdownHtml } from "./markdown-html-generator.ts";
+import { getEnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import { validatePathSync } from "#veryfront/security";
 
 const logger = serverLogger.component("markdown-preview-handler");
@@ -158,8 +159,7 @@ export class MarkdownPreviewHandler extends BaseHandler {
         projectId: ctx.projectSlug || ctx.projectId || "markdown-preview",
         filePath,
         branchId: ctx.parsedDomain?.branch ?? null,
-        requestHost: req.headers.get("x-forwarded-host")?.split(",")[0]?.trim() ||
-          req.headers.get("host") || url.host,
+        apiBaseUrl: getEnvironmentConfig().apiBaseUrl,
       });
 
       const responseBuilder = this.createResponseBuilder(ctx)

--- a/src/studio/bridge-template.ts
+++ b/src/studio/bridge-template.ts
@@ -3969,7 +3969,7 @@ export function generateStudioBridgeScript(options: StudioBridgeOptions): string
         setupMarkdownYjsConnection({
           wsUrl: WS_URL,
           guid: YJS_GUID,
-          fileId: markdownFileId
+          fileId: markdownFileId,
         });
       }
     } else {


### PR DESCRIPTION
## Summary

The Yjs WebSocket endpoint lives on the **API server** (`api.veryfront.com`), not on the preview server (`*.preview.veryfront.com`). The bridge was generating the WebSocket URL from the preview host, which doesn't serve `/api/ws/.../yjs`, causing immediate connection close and retry loops.

- Derive `wsUrl` from `apiBaseUrl` (`VERYFRONT_API_BASE_URL` env, defaults to `https://api.veryfront.com`) instead of the request host
- Replace `requestHost` with `apiBaseUrl` in `MarkdownHtmlOptions`
- Bridge self-connects to Yjs in both standalone and embedded modes (decoupled from Studio)

## Before → After

```
Before: wss://grand-pond.preview.veryfront.com/api/ws/{id}/yjs → connection refused
After:  wss://api.veryfront.com/api/ws/{id}/yjs → connects to Yjs server
```

## Test plan

- [x] `deno task typecheck` passes
- [x] Tests pass (9/9)
- [ ] Verify markdown edit mode connects to `wss://api.veryfront.com/api/ws/...`
- [ ] Verify standalone mode works at `{slug}.preview.veryfront.com/file.md`