### PR TITLE
fix: use public API URL for browser-injected WebSocket scripts (v0.1.36)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/config/environment-config.test.ts
+++ b/src/config/environment-config.test.ts
@@ -216,6 +216,7 @@ describe("EnvironmentConfig", () => {
         "denoTesting",
         "perfEnabled",
         "apiBaseUrl",
+        "publicApiBaseUrl",
         "apiUrl",
         "apiToken",
         "projectSlug",

--- a/src/config/environment-config.ts
+++ b/src/config/environment-config.ts
@@ -115,7 +115,7 @@ function readEnvSnapshot(): EnvironmentConfig {
     apiBaseUrl: getEnv("VERYFRONT_API_BASE_URL") ||
       apiUrl?.replace("/graphql", "/api") ||
       DEFAULTS.apiBaseUrl,
-    publicApiBaseUrl: getEnv("VERYFRONT_PUBLIC_API_URL") ||
+    publicApiBaseUrl: getEnv("VERYFRONT_PUBLIC_API_BASE_URL") ||
       DEFAULTS.apiBaseUrl,
     apiUrl,
     apiToken: getEnv("VERYFRONT_API_TOKEN") || undefined,

--- a/src/config/environment-config.ts
+++ b/src/config/environment-config.ts
@@ -14,6 +14,8 @@ export interface EnvironmentConfig {
   perfEnabled: boolean;
 
   apiBaseUrl: string;
+  /** Public-facing API URL for browser-injected scripts (WebSocket URLs, etc.). */
+  publicApiBaseUrl: string;
   apiUrl: string | undefined;
   apiToken: string | undefined;
   projectSlug: string | undefined;
@@ -112,6 +114,8 @@ function readEnvSnapshot(): EnvironmentConfig {
 
     apiBaseUrl: getEnv("VERYFRONT_API_BASE_URL") ||
       apiUrl?.replace("/graphql", "/api") ||
+      DEFAULTS.apiBaseUrl,
+    publicApiBaseUrl: getEnv("VERYFRONT_PUBLIC_API_URL") ||
       DEFAULTS.apiBaseUrl,
     apiUrl,
     apiToken: getEnv("VERYFRONT_API_TOKEN") || undefined,

--- a/src/server/handlers/preview/markdown-preview.handler.ts
+++ b/src/server/handlers/preview/markdown-preview.handler.ts
@@ -159,7 +159,7 @@ export class MarkdownPreviewHandler extends BaseHandler {
         projectId: ctx.projectSlug || ctx.projectId || "markdown-preview",
         filePath,
         branchId: ctx.parsedDomain?.branch ?? null,
-        apiBaseUrl: getEnvironmentConfig().apiBaseUrl,
+        apiBaseUrl: getEnvironmentConfig().publicApiBaseUrl,
       });
 
       const responseBuilder = this.createResponseBuilder(ctx)


### PR DESCRIPTION
## Summary
- `getEnvironmentConfig().apiBaseUrl` returns internal K8s URL (`http://veryfront-api`) in production, causing Mixed Content errors when injected into browser scripts
- Add `publicApiBaseUrl` field to environment config that reads `VERYFRONT_PUBLIC_API_URL` env var, defaulting to `https://api.veryfront.com`
- Use `publicApiBaseUrl` instead of `apiBaseUrl` for browser-injected WebSocket URLs
- No K8s deployment changes needed — default is the correct public URL

## Test plan
- [ ] Open markdown file in Studio — WebSocket connects to `wss://api.veryfront.com/api/ws/{projectId}/yjs` (not internal K8s URL)
- [ ] No Mixed Content errors in console
- [ ] Yjs sync works correctly for collaborative editing