### PR TITLE
fix: remove /api prefix from WebSocket URL path

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/server/handlers/preview/markdown-html-generator.ts
+++ b/src/server/handlers/preview/markdown-html-generator.ts
@@ -84,7 +84,7 @@ function buildStudioScript(
     try {
       const apiUrl = new URL(apiBaseUrl);
       const wsProtocol = apiUrl.protocol === "https:" ? "wss:" : "ws:";
-      wsUrl = `${wsProtocol}//${apiUrl.host}/api/ws/${canonicalProjectId}/yjs`;
+      wsUrl = `${wsProtocol}//${apiUrl.host}/ws/${canonicalProjectId}/yjs`;
     } catch {
       // Invalid API URL — wsUrl stays empty, bridge won't self-connect
     }


### PR DESCRIPTION
## Summary

- Remove `/api` prefix from WebSocket URL injected into bridge scripts
- API's WebSocket server expects `/ws/{projectId}/yjs`, not `/api/ws/{projectId}/yjs`
- Studio's Express proxy strips `/api` before forwarding, but the bridge connects directly to the API host so the path must not include the prefix
- Bumps to v0.1.37

## Context

Follow-up to PR #488. The WebSocket connection was failing with `wss://api.veryfront.com/api/ws/...` because the API's `parseWebSocketPath()` expects the first path segment to be `ws`, not `api`.

## Test plan

- [ ] `deno task typecheck` passes
- [ ] `deno task test` passes
- [ ] Manual: Open markdown in Studio → edit mode → WebSocket connects to `wss://api.veryfront.com/ws/{id}/yjs`