### PR TITLE
feat: agent markdown writing, bridge styling, and type safety

### DIFF
--- a/src/studio/bridge/bridge-block-drag.ts
+++ b/src/studio/bridge/bridge-block-drag.ts
@@ -509,8 +509,9 @@ export function moveMarkdownLexicalBlock(sourceIndex: number, targetSlotIndex: n
   }
 
   let didMove = false;
-  state.markdownLexicalApi.editor.update(function () {
-    const root = state.markdownLexicalApi.lexicalModule.$getRoot();
+  const lexApi = state.markdownLexicalApi;
+  lexApi.editor.update(function () {
+    const root = lexApi.lexicalModule.$getRoot();
     const children = root.getChildren();
     const maxSlot = children.length;
     if (source < 0 || source >= maxSlot || targetSlot < 0 || targetSlot > maxSlot) {

--- a/src/studio/bridge/bridge-config.ts
+++ b/src/studio/bridge/bridge-config.ts
@@ -5,12 +5,15 @@
  * and provides typed access to bridge options.
  */
 
+export type StudioMode = "simple" | "advanced";
+
 export interface BridgeConfig {
   projectId: string;
   pageId: string;
   pagePath: string;
   wsUrl: string;
   yjsGuid: string;
+  studioMode: StudioMode;
   debugSkipInit: boolean;
   debugExposeInternals: boolean;
 }
@@ -19,6 +22,14 @@ let config: BridgeConfig | null = null;
 
 export function initConfig(): void {
   const raw = (window as any).__VF_BRIDGE_CONFIG__;
+
+  // studioMode can come from the injected config or from a query parameter
+  // (Studio sets vf_studio_mode on the iframe URL).
+  const params = new URLSearchParams(window.location.search);
+  const qsMode = params.get("vf_studio_mode");
+  const resolveMode = (value: unknown): StudioMode =>
+    value === "simple" || qsMode === "simple" ? "simple" : "advanced";
+
   if (!raw || typeof raw !== "object") {
     console.warn("[StudioBridge] No bridge config found on window.__VF_BRIDGE_CONFIG__");
     config = {
@@ -27,6 +38,7 @@ export function initConfig(): void {
       pagePath: "",
       wsUrl: "",
       yjsGuid: "",
+      studioMode: resolveMode(undefined),
       debugSkipInit: false,
       debugExposeInternals: false,
     };
@@ -38,6 +50,7 @@ export function initConfig(): void {
     pagePath: raw.pagePath ?? raw.pageId ?? "",
     wsUrl: raw.wsUrl ?? "",
     yjsGuid: raw.yjsGuid ?? "",
+    studioMode: resolveMode(raw.studioMode),
     debugSkipInit: !!raw.debugSkipInit,
     debugExposeInternals: !!raw.debugExposeInternals,
   };
@@ -72,6 +85,7 @@ export function setConfigForTest(override: Partial<BridgeConfig>): void {
     pagePath: "",
     wsUrl: "",
     yjsGuid: "",
+    studioMode: "advanced",
     debugSkipInit: false,
     debugExposeInternals: false,
     ...override,

--- a/src/studio/bridge/bridge-coordinator.ts
+++ b/src/studio/bridge/bridge-coordinator.ts
@@ -9,6 +9,7 @@
 import { getConfig, initConfig } from "./bridge-config.ts";
 import { extractRawBlocksForEditor, parseMdxImportMap } from "./bridge-markdown-core.ts";
 import { getMdxBlockOpenUiState } from "./bridge-block-drag.ts";
+import { writeToYText, replaceYTextContent } from "./bridge-markdown-yjs.ts";
 import { init } from "./bridge-init.ts";
 
 // Initialize config from the global injected by the server
@@ -22,6 +23,8 @@ if (config.debugExposeInternals && typeof window !== "undefined") {
     parseMdxImportMap: parseMdxImportMap,
     extractRawBlocksForEditor: extractRawBlocksForEditor,
     getMdxBlockOpenUiState: getMdxBlockOpenUiState,
+    writeToYText: writeToYText,
+    replaceYTextContent: replaceYTextContent,
   };
 }
 

--- a/src/studio/bridge/bridge-coordinator.ts
+++ b/src/studio/bridge/bridge-coordinator.ts
@@ -9,7 +9,7 @@
 import { getConfig, initConfig } from "./bridge-config.ts";
 import { extractRawBlocksForEditor, parseMdxImportMap } from "./bridge-markdown-core.ts";
 import { getMdxBlockOpenUiState } from "./bridge-block-drag.ts";
-import { writeToYText, replaceYTextContent } from "./bridge-markdown-yjs.ts";
+import { replaceYTextContent, writeToYText } from "./bridge-markdown-yjs.ts";
 import { init } from "./bridge-init.ts";
 
 // Initialize config from the global injected by the server

--- a/src/studio/bridge/bridge-editor-state.ts
+++ b/src/studio/bridge/bridge-editor-state.ts
@@ -20,6 +20,38 @@ import type {
   SlashMenuContext,
 } from "./bridge-state.ts";
 
+// ---------------------------------------------------------------------------
+// Yjs structural types (dynamically imported from ESM CDN)
+// ---------------------------------------------------------------------------
+
+export interface YText {
+  length: number;
+  insert(index: number, text: string): void;
+  delete(index: number, length: number): void;
+  toString(): string;
+  observe(fn: (event: unknown) => void): void;
+}
+
+export interface YjsAwareness {
+  clientID: number;
+  setLocalStateField(field: string, value: unknown): void;
+  getStates(): Map<number, Record<string, unknown>>;
+  on(event: string, fn: (...args: unknown[]) => void): void;
+}
+
+export interface YjsModule {
+  Doc: new (opts?: { guid?: string }) => {
+    getText(name: string): YText;
+    destroy(): void;
+    transact(fn: () => void, origin?: unknown): void;
+  };
+  createRelativePositionFromTypeIndex(type: YText, index: number): unknown;
+  createAbsolutePositionFromRelativePosition(
+    pos: unknown,
+    doc: unknown,
+  ): { index: number; type: unknown } | null;
+}
+
 export const editorState = {
   // Editor DOM
   markdownEditorRoot: null as HTMLElement | null,
@@ -89,17 +121,22 @@ export const editorState = {
   markdownSaveInProgress: false,
 
   // Yjs (dynamically imported — typed structurally)
-  markdownYDoc: null as { getText(name: string): unknown; destroy(): void } | null,
+  markdownYDoc: null as {
+    getText(name: string): YText;
+    destroy(): void;
+    transact(fn: () => void, origin?: unknown): void;
+  } | null,
   markdownYProvider: null as {
     on(event: string, cb: (...args: unknown[]) => void): void;
     disconnect(): void;
     destroy(): void;
-    awareness: unknown;
+    ws: WebSocket | null;
+    awareness: YjsAwareness;
   } | null,
-  markdownYText: null as { length: number } | null,
+  markdownYText: null as YText | null,
   markdownYjsConnected: false,
   markdownYjsSetupId: 0,
-  markdownYjsY: null as unknown,
+  markdownYjsY: null as YjsModule | null,
   markdownPendingSelection: null as { start: number; end: number } | null,
 };
 

--- a/src/studio/bridge/bridge-inline-toolbar.ts
+++ b/src/studio/bridge/bridge-inline-toolbar.ts
@@ -60,11 +60,12 @@ export function insertMarkdownLink(): void {
   ) {
     return;
   }
-  state.markdownLexicalApi.editor.update(function () {
-    const selection = state.markdownLexicalApi.lexicalModule.$getSelection();
+  const api = state.markdownLexicalApi;
+  api.editor.update(function () {
+    const selection = api.lexicalModule.$getSelection();
     if (
       !selection ||
-      !state.markdownLexicalApi.lexicalModule.$isRangeSelection(selection)
+      !api.lexicalModule.$isRangeSelection(selection)
     ) {
       return;
     }
@@ -246,8 +247,7 @@ export function updateMarkdownInlineToolbar(): void {
   const buttons = state.markdownInlineToolbarRoot.querySelectorAll<HTMLElement>(
     ".vf-markdown-editor__inline-button[data-format]",
   );
-  for (let i = 0; i < buttons.length; i++) {
-    const btn = buttons[i];
+  for (const btn of buttons) {
     const fmt = btn.getAttribute("data-format");
     if (fmt && toolbarState[fmt]) {
       btn.classList.add("active");
@@ -279,8 +279,7 @@ export function updateMarkdownInlineToolbar(): void {
     const options = blockDropdown.querySelectorAll<HTMLElement>(
       ".vf-markdown-editor__block-option",
     );
-    for (let j = 0; j < options.length; j++) {
-      const opt = options[j];
+    for (const opt of options) {
       if (opt.getAttribute("data-block-type") === toolbarState.blockType) {
         opt.classList.add("active");
       } else {

--- a/src/studio/bridge/bridge-markdown-core.ts
+++ b/src/studio/bridge/bridge-markdown-core.ts
@@ -238,8 +238,8 @@ export function parseMdxImportMap(content: string): Record<string, MdxImportEntr
       const aliasMatch = normalizedPart.match(
         /^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/,
       );
-      const sourceName = aliasMatch ? aliasMatch[1] : normalizedPart;
-      const localName = aliasMatch ? aliasMatch[2] : normalizedPart;
+      const sourceName = aliasMatch ? aliasMatch[1]! : normalizedPart;
+      const localName = aliasMatch ? aliasMatch[2]! : normalizedPart;
       if (localName) {
         const isDefaultAlias = sourceName === "default";
         setImportEntry(
@@ -491,7 +491,7 @@ export function extractRawBlocksForEditor(
       label: label,
       lineNumber: getLineNumberForOffset(inputText, offset),
       filePath: componentPath,
-      symbolName: componentSymbol,
+      symbolName: componentSymbol || "",
     });
   };
 

--- a/src/studio/bridge/bridge-markdown-editor.ts
+++ b/src/studio/bridge/bridge-markdown-editor.ts
@@ -26,7 +26,11 @@ import {
   saveMarkdownContent,
 } from "./bridge-markdown-core.ts";
 
-import { disposeMarkdownYjs, setupMarkdownYjsConnection, writeToYText } from "./bridge-markdown-yjs.ts";
+import {
+  disposeMarkdownYjs,
+  setupMarkdownYjsConnection,
+  writeToYText,
+} from "./bridge-markdown-yjs.ts";
 
 import {
   clearMarkdownSelectionOverlay,
@@ -508,9 +512,14 @@ export function ensureMarkdownEditor(): HTMLElement | undefined {
 
   const presence = el("div", "vf-markdown-editor__presence");
   const selections = el("div", "vf-markdown-editor__selections");
+  // In Simple Mode the editor IS the experience — hide Done button.
+  // In Advanced Mode, show Done to return to preview.
   const exitButton = btn("vf-markdown-editor__exit", "Done", function () {
     setMarkdownEditMode(false);
   });
+  if (getConfig().studioMode === "simple") {
+    exitButton.style.display = "none";
+  }
 
   actions.appendChild(status);
   actions.appendChild(presence);

--- a/src/studio/bridge/bridge-markdown-editor.ts
+++ b/src/studio/bridge/bridge-markdown-editor.ts
@@ -26,7 +26,7 @@ import {
   saveMarkdownContent,
 } from "./bridge-markdown-core.ts";
 
-import { disposeMarkdownYjs, setupMarkdownYjsConnection } from "./bridge-markdown-yjs.ts";
+import { disposeMarkdownYjs, setupMarkdownYjsConnection, writeToYText } from "./bridge-markdown-yjs.ts";
 
 import {
   clearMarkdownSelectionOverlay,
@@ -284,10 +284,11 @@ export function applyMarkdownContent(content: unknown): void {
     state.markdownApplyingRemoteUpdate = true;
     try {
       state.markdownLexicalRenderedContent = content;
-      state.markdownLexicalApi.editor.update(
+      const api = state.markdownLexicalApi;
+      api.editor.update(
         function () {
-          const lexicalModule = state.markdownLexicalApi.lexicalModule;
-          const markdownModule = state.markdownLexicalApi.markdownModule;
+          const lexicalModule = api.lexicalModule;
+          const markdownModule = api.markdownModule;
           const root = lexicalModule.$getRoot();
           root.clear();
           markdownModule.$convertFromMarkdownString(
@@ -465,8 +466,10 @@ export function setMarkdownSelections(selections: any[]): void {
     }
 
     state.markdownOverlaySelections.push({
+      id: selection.id || "",
       name: displayName,
       color: color,
+      isCurrentUser: selection.isCurrentUser || false,
       start: editorRange.start,
       end: editorRange.end,
     });
@@ -512,6 +515,18 @@ export function ensureMarkdownEditor(): HTMLElement | undefined {
   actions.appendChild(status);
   actions.appendChild(presence);
   actions.appendChild(selections);
+
+  // Debug button: write test content via Yjs (only visible when debugExposeInternals is on)
+  if (getConfig().debugExposeInternals) {
+    const debugBtn = btn("vf-markdown-editor__exit", "Yjs Write", function () {
+      const ok = writeToYText("\n\nHello from Yjs debug write!\n");
+      console.debug("[StudioBridge] Debug Yjs write:", ok ? "success" : "failed (not connected)");
+    });
+    debugBtn.style.fontSize = "10px";
+    debugBtn.style.opacity = "0.6";
+    actions.appendChild(debugBtn);
+  }
+
   actions.appendChild(exitButton);
 
   toolbar.appendChild(title);
@@ -534,7 +549,7 @@ export function ensureMarkdownEditor(): HTMLElement | undefined {
   });
   surface.addEventListener("keyup", scheduleMarkdownSlashMenuUpdate);
   surface.addEventListener("mouseup", scheduleMarkdownSlashMenuUpdate);
-  surface.addEventListener("keydown", handleMarkdownSlashMenuKeydown as EventListener);
+  surface.addEventListener("keydown", handleMarkdownSlashMenuKeydown as unknown as EventListener);
   surface.addEventListener("keydown", function (event: KeyboardEvent) {
     if (!event.shiftKey || !event.altKey) {
       return;
@@ -980,7 +995,7 @@ export function setMarkdownEditMode(enabled: boolean): void {
       setupMarkdownYjsConnection({
         wsUrl: getConfig().wsUrl,
         guid: getConfig().yjsGuid,
-        fileId: state.markdownFileId,
+        fileId: state.markdownFileId || "",
       });
     }
   } else {
@@ -1037,9 +1052,17 @@ export function setupMarkdownEditor(params: URLSearchParams): void {
   }
 
   state.markdownFileId = params.get("vf_file_id") || getConfig().pageId || null;
-  ensureMarkdownEditButton();
 
-  if (params.get("edit") === "true") {
+  // In Simple Mode, auto-activate the editor for markdown pages
+  // (no Edit button needed — the editor IS the experience).
+  // In Advanced Mode, show the Edit button and wait for user click.
+  if (getConfig().studioMode === "simple") {
     setMarkdownEditMode(true);
+  } else {
+    ensureMarkdownEditButton();
+
+    if (params.get("edit") === "true") {
+      setMarkdownEditMode(true);
+    }
   }
 }

--- a/src/studio/bridge/bridge-markdown-yjs.ts
+++ b/src/studio/bridge/bridge-markdown-yjs.ts
@@ -312,8 +312,8 @@ export function writeToYText(
   text: string,
   options?: { position?: number; origin?: string },
 ): boolean {
-  if (!state.markdownYText || !state.markdownYDoc) {
-    console.warn("[StudioBridge] writeToYText: Yjs not connected");
+  if (!state.markdownYText || !state.markdownYDoc || !state.markdownYjsConnected) {
+    console.warn("[StudioBridge] writeToYText: Yjs not connected or not synced");
     return false;
   }
 
@@ -334,8 +334,8 @@ export function writeToYText(
  * Returns true if the write succeeded.
  */
 export function replaceYTextContent(content: string): boolean {
-  if (!state.markdownYText || !state.markdownYDoc) {
-    console.warn("[StudioBridge] replaceYTextContent: Yjs not connected");
+  if (!state.markdownYText || !state.markdownYDoc || !state.markdownYjsConnected) {
+    console.warn("[StudioBridge] replaceYTextContent: Yjs not connected or not synced");
     return false;
   }
 

--- a/src/studio/bridge/bridge-markdown-yjs.ts
+++ b/src/studio/bridge/bridge-markdown-yjs.ts
@@ -55,12 +55,13 @@ export function syncLocalChangeToYText(fullContent: string): void {
     return;
   }
 
+  const ytext = state.markdownYText;
   state.markdownYDoc.transact(() => {
     if (diff.deleteCount > 0) {
-      state.markdownYText.delete(diff.index, diff.deleteCount);
+      ytext.delete(diff.index, diff.deleteCount);
     }
     if (diff.insertText) {
-      state.markdownYText.insert(diff.index, diff.insertText);
+      ytext.insert(diff.index, diff.insertText);
     }
   }, LEXICAL_YJS_ORIGIN);
 }
@@ -97,7 +98,7 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
 
       const Y = modules[0];
       const WebsocketProvider = modules[1].WebsocketProvider;
-      state.markdownYjsY = Y;
+      state.markdownYjsY = Y as unknown as import("./bridge-editor-state.ts").YjsModule;
 
       const doc = new Y.Doc({ guid: config.guid });
       // Cookie auth: authToken cookie on .veryfront.com is sent automatically
@@ -116,13 +117,14 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
       provider.on("status", (event: { status: string }) => {
         console.debug("[StudioBridge] Yjs status:", event.status);
         if (event.status === "connected" && provider.ws) {
-          const origOnMessage = provider.ws.onmessage;
-          provider.ws.onmessage = function (wsEvent: MessageEvent) {
+          const ws = provider.ws;
+          const origOnMessage = ws.onmessage;
+          ws.onmessage = function (wsEvent: MessageEvent) {
             if (typeof wsEvent.data === "string") {
               return;
             }
             if (origOnMessage) {
-              origOnMessage.call(provider.ws, wsEvent);
+              origOnMessage.call(ws, wsEvent);
             }
           };
         }
@@ -136,10 +138,10 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
       try {
         const cookieMatch = document.cookie.match(/authToken=([^;]+)/);
         if (cookieMatch) {
-          const parts = cookieMatch[1].split(".");
+          const parts = cookieMatch[1]!.split(".");
           if (parts.length === 3) {
             const payload = JSON.parse(
-              atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")),
+              atob(parts[1]!.replace(/-/g, "+").replace(/_/g, "/")),
             );
             if (payload.userId) {
               presenceUser.id = payload.userId;
@@ -177,41 +179,36 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
        * selections, and push both to the editor UI.
        */
       function syncAwareness(): void {
-        const states: [number, Record<string, any>][] = Array.from(
+        const states = Array.from(
           provider.awareness.getStates().entries(),
-        );
+        ) as [number, Record<string, unknown>][];
 
         // Sync presence users
         const users: PresenceUser[] = [];
-        for (let i = 0; i < states.length; i++) {
-          const clientId = states[i][0];
-          const st = states[i][1];
-          const user = st.user;
+        for (const [clientId, st] of states) {
+          const user = st.user as Record<string, unknown> | undefined;
           if (!user || typeof user.name !== "string") {
             continue;
           }
           users.push({
-            id: user.id || String(clientId),
+            id: (user.id as string) || String(clientId),
             name: user.name,
-            color: user.color || "#6b7280",
+            color: (user.color as string) || "#6b7280",
             isCurrentUser: clientId === provider.awareness.clientID,
-            isAgent: user.isAgent || false,
+            isAgent: (user.isAgent as boolean) || false,
           });
         }
         setMarkdownPresence(users);
 
         // Sync remote selections
         const selections: RemoteSelection[] = [];
-        for (let j = 0; j < states.length; j++) {
-          const cId = states[j][0];
-          const st = states[j][1];
-          const u = st.user;
+        for (const [cId, st] of states) {
+          const u = st.user as Record<string, unknown> | undefined;
           const ranges = st.selection;
           if (!u || !Array.isArray(ranges) || ranges.length === 0) {
             continue;
           }
-          for (let k = 0; k < ranges.length; k++) {
-            const range = ranges[k];
+          for (const range of ranges) {
             const anchorPos = Y.createAbsolutePositionFromRelativePosition(
               range.anchor,
               doc,
@@ -229,9 +226,9 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
               continue;
             }
             selections.push({
-              id: u.id || String(cId),
-              name: u.name || "Anonymous",
-              color: u.color || "#6b7280",
+              id: (u.id as string) || String(cId),
+              name: (u.name as string) || "Anonymous",
+              color: (u.color as string) || "#6b7280",
               isCurrentUser: cId === provider.awareness.clientID,
               start: Math.min(anchorPos.index, markerPos.index),
               end: Math.max(anchorPos.index, markerPos.index),
@@ -300,6 +297,55 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
     .catch((error) => {
       console.error("[StudioBridge] Failed to setup Yjs connection:", error);
     });
+}
+
+// ---------------------------------------------------------------------------
+// writeToYText (programmatic write, e.g. from agent or debug)
+// ---------------------------------------------------------------------------
+
+/**
+ * Write content into Y.Text at a given position or at the end.
+ * The write appears as coming from a distinct "agent" presence.
+ * Returns true if the write succeeded (Yjs is connected and Y.Text exists).
+ */
+export function writeToYText(
+  text: string,
+  options?: { position?: number; origin?: string },
+): boolean {
+  if (!state.markdownYText || !state.markdownYDoc) {
+    console.warn("[StudioBridge] writeToYText: Yjs not connected");
+    return false;
+  }
+
+  const origin = options?.origin ?? "agent-write";
+  const pos = options?.position ?? state.markdownYText.length;
+  const safePos = Math.max(0, Math.min(pos, state.markdownYText.length));
+
+  const yt = state.markdownYText;
+  state.markdownYDoc.transact(() => {
+    yt.insert(safePos, text);
+  }, origin);
+
+  return true;
+}
+
+/**
+ * Replace all Y.Text content with new content.
+ * Returns true if the write succeeded.
+ */
+export function replaceYTextContent(content: string): boolean {
+  if (!state.markdownYText || !state.markdownYDoc) {
+    console.warn("[StudioBridge] replaceYTextContent: Yjs not connected");
+    return false;
+  }
+
+  const yt2 = state.markdownYText;
+  state.markdownYDoc.transact(() => {
+    yt2.delete(0, yt2.length);
+    yt2.insert(0, content);
+  }, "agent-write");
+
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/studio/bridge/bridge-message-handler.ts
+++ b/src/studio/bridge/bridge-message-handler.ts
@@ -17,6 +17,7 @@ import {
   showSelectionOverlay,
 } from "./bridge-inspector.ts";
 import { captureMultipleSections, captureScreenshot } from "./bridge-screenshot.ts";
+import { replaceYTextContent, writeToYText } from "./bridge-markdown-yjs.ts";
 
 export function handleStudioMessage(event: MessageEvent): void {
   if (!isFromStudio(event)) return;
@@ -98,6 +99,21 @@ export function handleStudioMessage(event: MessageEvent): void {
         }
       }
       return;
+
+    case "agentWriteMarkdown": {
+      const mode: string = message.mode || "replace";
+      if (mode === "replace") {
+        replaceYTextContent(message.content || "");
+      } else if (mode === "append") {
+        writeToYText(message.content || "");
+      } else if (mode === "insert_at") {
+        writeToYText(message.content || "", {
+          position: message.position ?? 0,
+          origin: "agent-write",
+        });
+      }
+      return;
+    }
 
     case "screenshot":
       (async function () {

--- a/src/studio/bridge/bridge-selection.ts
+++ b/src/studio/bridge/bridge-selection.ts
@@ -96,7 +96,7 @@ export function escapeRegexText(value: unknown): string {
   const text = String(value || "");
   let escaped = "";
   for (let i = 0; i < text.length; i += 1) {
-    const char = text[i];
+    const char = text[i]!;
     if ("\\^$.*+?()[]{}|".indexOf(char) >= 0) {
       escaped += "\\" + char;
     } else {

--- a/src/studio/bridge/bridge-state.ts
+++ b/src/studio/bridge/bridge-state.ts
@@ -107,7 +107,11 @@ export interface LexicalListModule {
 
 export interface LexicalMarkdownModule {
   TRANSFORMERS: unknown[];
-  $convertToMarkdownString(transformers: unknown[], node?: unknown, shouldPreserve?: boolean): string;
+  $convertToMarkdownString(
+    transformers: unknown[],
+    node?: unknown,
+    shouldPreserve?: boolean,
+  ): string;
   $convertFromMarkdownString(
     markdown: string,
     transformers: unknown[],

--- a/src/studio/bridge/bridge-state.ts
+++ b/src/studio/bridge/bridge-state.ts
@@ -58,14 +58,81 @@ export interface MdxBlock {
   symbolName: string;
 }
 
+// ---------------------------------------------------------------------------
+// Lexical structural types (dynamically imported from ESM CDN)
+// ---------------------------------------------------------------------------
+
+// deno-lint-ignore no-explicit-any
+type LexicalCommand = any;
+// deno-lint-ignore no-explicit-any
+type LexicalEditorState = any;
+// deno-lint-ignore no-explicit-any
+type LexicalNode = any;
+// deno-lint-ignore no-explicit-any
+type LexicalSelection = any;
+
+export interface LexicalEditor {
+  focus(): void;
+  update(fn: () => void, options?: { discrete?: boolean }): void;
+  dispatchCommand(command: LexicalCommand, payload: unknown): void;
+  getEditorState(): { read(fn: () => void): void };
+  registerUpdateListener(fn: (payload: { editorState: LexicalEditorState }) => void): () => void;
+  setRootElement(element: HTMLElement | null): void;
+}
+
+export interface LexicalModule {
+  createEditor(config: Record<string, unknown>): LexicalEditor;
+  $getRoot(): LexicalNode;
+  $getSelection(): LexicalSelection | null;
+  $isRangeSelection(selection: unknown): boolean;
+  $createParagraphNode(): LexicalNode;
+  FORMAT_TEXT_COMMAND: LexicalCommand;
+}
+
+export interface LexicalRichTextModule {
+  HeadingNode: unknown;
+  QuoteNode: unknown;
+  registerRichText(editor: LexicalEditor): () => void;
+  $createHeadingNode(tag: string): LexicalNode;
+  $createQuoteNode(): LexicalNode;
+}
+
+export interface LexicalListModule {
+  ListNode: unknown;
+  ListItemNode: unknown;
+  registerList(editor: LexicalEditor): () => void;
+  INSERT_UNORDERED_LIST_COMMAND: LexicalCommand;
+  INSERT_ORDERED_LIST_COMMAND: LexicalCommand;
+}
+
+export interface LexicalMarkdownModule {
+  TRANSFORMERS: unknown[];
+  $convertToMarkdownString(transformers: unknown[], node?: unknown, shouldPreserve?: boolean): string;
+  $convertFromMarkdownString(
+    markdown: string,
+    transformers: unknown[],
+    node?: unknown,
+    shouldPreserve?: boolean,
+  ): void;
+}
+
+export interface LexicalSelectionModule {
+  $setBlocksType(selection: LexicalSelection, factory: () => LexicalNode): void;
+}
+
+export interface LexicalHistoryModule {
+  registerHistory(editor: LexicalEditor, state: unknown, delay: number): () => void;
+  createEmptyHistoryState(): unknown;
+}
+
 /** Lexical editor API surface exposed after dynamic import */
 export interface LexicalApi {
-  editor: unknown;
-  lexicalModule: unknown;
-  richTextModule: unknown;
-  listModule: unknown;
-  markdownModule: unknown;
-  selectionModule: unknown;
+  editor: LexicalEditor;
+  lexicalModule: LexicalModule;
+  richTextModule: LexicalRichTextModule;
+  listModule: LexicalListModule;
+  markdownModule: LexicalMarkdownModule;
+  selectionModule: LexicalSelectionModule;
   unregisterRichText: () => void;
   unregisterList: () => void;
   unregisterHistory: () => void;

--- a/src/studio/bridge/bridge-styles.ts
+++ b/src/studio/bridge/bridge-styles.ts
@@ -1,9 +1,17 @@
 /**
  * Bridge Styles
  * CSS injection for overlay, editor, and inspector styles.
+ *
+ * Design tokens are hardcoded to match Studio's visual language (oklch color
+ * space, radii, shadows, spacing). Uses system font stack since Studio's
+ * Gellix font is proprietary and unavailable in the preview iframe.
  */
 
 const OVERLAY_CSS = `
+      /* ------------------------------------------------------------------ */
+      /* Overlays (hover / selection inspector)                              */
+      /* ------------------------------------------------------------------ */
+
       .vf-overlay {
         position: fixed;
         pointer-events: none;
@@ -12,21 +20,21 @@ const OVERLAY_CSS = `
         transition: all 0.05s ease-out;
       }
       .vf-overlay-hover {
-        border: 2px solid #0081F8;
-        background: rgba(0, 129, 248, 0.05);
+        border: 2px solid oklch(0.6852 0.162 241.8);
+        background: oklch(0.6852 0.162 241.8 / 0.06);
       }
       .vf-overlay-selection {
-        border: 2px solid #0081F8;
-        background: rgba(0, 129, 248, 0.1);
+        border: 2px solid oklch(0.6852 0.162 241.8);
+        background: oklch(0.6852 0.162 241.8 / 0.1);
       }
       .vf-overlay-label {
         position: absolute;
         top: -22px;
         left: -2px;
-        background: #0081F8;
+        background: oklch(0.6852 0.162 241.8);
         color: white;
         font-size: 11px;
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
         padding: 2px 6px;
         border-radius: 3px 3px 0 0;
         white-space: nowrap;
@@ -38,29 +46,51 @@ const OVERLAY_CSS = `
         border-radius: 0 0 3px 3px;
       }
 
+      /* ------------------------------------------------------------------ */
+      /* Edit button (floating CTA)                                          */
+      /* ------------------------------------------------------------------ */
+
       .vf-markdown-edit-button {
         position: fixed;
         right: 16px;
         bottom: 16px;
         z-index: 100001;
-        border: 1px solid rgba(0, 0, 0, 0.2);
-        border-radius: 8px;
-        background: #111827;
-        color: #ffffff;
+        border: 1px solid oklch(0.84 0.0055 95.11);
+        border-radius: 9999px;
+        background: oklch(0.2768 0 0);
+        color: oklch(0.9512 0.008 98.88);
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
         font-size: 13px;
+        font-weight: 500;
         line-height: 1;
-        padding: 10px 12px;
+        padding: 10px 16px;
         cursor: pointer;
-        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+        box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1);
+        transition: transform 100ms ease, box-shadow 100ms ease;
       }
+      .vf-markdown-edit-button:hover {
+        box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1);
+      }
+      .vf-markdown-edit-button:active {
+        transform: scale(0.98);
+      }
+
+      /* ------------------------------------------------------------------ */
+      /* Editor root                                                         */
+      /* ------------------------------------------------------------------ */
 
       .vf-markdown-editor {
         position: fixed;
         inset: 0;
         z-index: 100000;
-        background: var(--vf-markdown-editor-bg, #ffffff);
+        background: oklch(1 0 0);
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
         display: none;
       }
+
+      /* ------------------------------------------------------------------ */
+      /* Toolbar                                                             */
+      /* ------------------------------------------------------------------ */
 
       .vf-markdown-editor__toolbar {
         display: flex;
@@ -68,15 +98,16 @@ const OVERLAY_CSS = `
         align-items: center;
         gap: 8px;
         padding: 8px 16px;
-        border-bottom: 1px solid rgba(0, 0, 0, 0.06);
-        background: rgba(255, 255, 255, 0.94);
+        border-bottom: 1px solid oklch(0.9 0 0);
+        background: oklch(0.97 0 0 / 0.96);
+        backdrop-filter: blur(8px);
         position: sticky;
         top: 0;
       }
 
       .vf-markdown-editor__title {
         font-size: 12px;
-        color: #6b7280;
+        color: oklch(0.55 0.005 95.11);
         font-weight: 500;
         display: inline-flex;
         align-items: center;
@@ -91,20 +122,25 @@ const OVERLAY_CSS = `
 
       .vf-markdown-editor__status {
         font-size: 12px;
-        color: #6b7280;
+        color: oklch(0.55 0.005 95.11);
+        transition: color 150ms ease;
       }
 
       .vf-markdown-editor__status[data-state='saving'] {
-        color: #b45309;
+        color: oklch(0.65 0.15 75);
       }
 
       .vf-markdown-editor__status[data-state='saved'] {
-        color: #15803d;
+        color: oklch(0.52 0.15 145);
       }
 
       .vf-markdown-editor__status[data-state='error'] {
-        color: #b91c1c;
+        color: oklch(0.55 0.22 27);
       }
+
+      /* ------------------------------------------------------------------ */
+      /* Presence pills                                                      */
+      /* ------------------------------------------------------------------ */
 
       .vf-markdown-editor__presence {
         display: none;
@@ -113,13 +149,15 @@ const OVERLAY_CSS = `
       }
 
       .vf-markdown-editor__presence-pill {
-        border: 1px solid rgba(0, 0, 0, 0.16);
+        border: 1px solid oklch(0.84 0.0055 95.11);
         border-left-width: 4px;
-        border-radius: 999px;
+        border-radius: 9999px;
         padding: 2px 8px;
         font-size: 11px;
-        color: #111827;
-        background: #ffffff;
+        font-weight: 500;
+        color: oklch(0.2768 0 0);
+        background: oklch(1 0 0);
+        transition: border-color 75ms ease;
       }
 
       .vf-markdown-editor__presence-pill[data-current='true'] {
@@ -128,7 +166,13 @@ const OVERLAY_CSS = `
 
       .vf-markdown-editor__presence-pill[data-agent='true'] {
         font-style: italic;
+        background: oklch(0.96 0.02 280);
+        border-color: oklch(0.6852 0.162 241.8 / 0.3);
       }
+
+      /* ------------------------------------------------------------------ */
+      /* Selection pills                                                     */
+      /* ------------------------------------------------------------------ */
 
       .vf-markdown-editor__selections {
         display: none;
@@ -137,37 +181,60 @@ const OVERLAY_CSS = `
       }
 
       .vf-markdown-editor__selection-pill {
-        border: 1px solid rgba(0, 0, 0, 0.16);
+        border: 1px solid oklch(0.84 0.0055 95.11);
         border-left-width: 4px;
-        border-radius: 999px;
+        border-radius: 9999px;
         padding: 2px 8px;
         font-size: 11px;
-        color: #111827;
-        background: #ffffff;
+        font-weight: 500;
+        color: oklch(0.2768 0 0);
+        background: oklch(1 0 0);
       }
 
+      /* ------------------------------------------------------------------ */
+      /* Toolbar buttons                                                     */
+      /* ------------------------------------------------------------------ */
+
       .vf-markdown-editor__exit {
-        border: 1px solid rgba(0, 0, 0, 0.16);
+        border: 1px solid oklch(0.84 0.0055 95.11);
         border-radius: 6px;
-        background: #ffffff;
-        color: #111827;
+        background: oklch(1 0 0);
+        color: oklch(0.2768 0 0);
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
         font-size: 12px;
+        font-weight: 500;
         padding: 6px 10px;
         cursor: pointer;
+        transition: background 75ms ease;
+      }
+      .vf-markdown-editor__exit:hover {
+        background: oklch(0.93 0 0);
+      }
+      .vf-markdown-editor__exit:active {
+        transform: scale(0.98);
       }
 
       .vf-markdown-editor__history {
-        border: 1px solid rgba(0, 0, 0, 0.16);
+        border: 1px solid oklch(0.84 0.0055 95.11);
         border-radius: 6px;
-        background: #ffffff;
-        color: #111827;
+        background: oklch(1 0 0);
+        color: oklch(0.2768 0 0);
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
         font-size: 13px;
         line-height: 1;
         min-width: 28px;
         height: 28px;
         padding: 0 8px;
         cursor: pointer;
+        transition: background 75ms ease;
       }
+      .vf-markdown-editor__history:hover {
+        background: oklch(0.93 0 0);
+      }
+
+      /* ------------------------------------------------------------------ */
+      /* Surface (editor area)                                               */
+      /* ------------------------------------------------------------------ */
 
       .vf-markdown-editor__surface-wrap {
         position: relative;
@@ -187,6 +254,10 @@ const OVERLAY_CSS = `
         padding: 32px 40px;
         box-sizing: border-box;
       }
+
+      /* ------------------------------------------------------------------ */
+      /* Selection overlay                                                   */
+      /* ------------------------------------------------------------------ */
 
       .vf-markdown-editor__selection-overlay {
         position: absolute;
@@ -212,24 +283,28 @@ const OVERLAY_CSS = `
         position: absolute;
         transform: translateY(-100%);
         margin-top: -4px;
-        border-radius: 999px;
+        border-radius: 9999px;
         padding: 1px 7px;
         font-size: 10px;
         line-height: 1.4;
         white-space: nowrap;
-        color: #ffffff;
+        color: oklch(1 0 0);
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.16);
       }
+
+      /* ------------------------------------------------------------------ */
+      /* Slash menu                                                          */
+      /* ------------------------------------------------------------------ */
 
       .vf-markdown-editor__slash-menu {
         position: fixed;
         z-index: 100005;
         min-width: 240px;
         max-width: 300px;
-        border: 1px solid rgba(17, 24, 39, 0.12);
-        border-radius: 10px;
-        background: #ffffff;
-        box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12), 0 0 1px rgba(0, 0, 0, 0.1);
+        border: 1px solid oklch(0.84 0.0055 95.11);
+        border-radius: 8px;
+        background: oklch(1 0 0);
+        box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1);
         padding: 4px;
         display: none;
       }
@@ -238,7 +313,7 @@ const OVERLAY_CSS = `
         padding: 8px 10px 4px;
         font-size: 11px;
         font-weight: 600;
-        color: #9ca3af;
+        color: oklch(0.55 0.005 95.11);
         text-transform: none;
         letter-spacing: 0;
       }
@@ -251,14 +326,16 @@ const OVERLAY_CSS = `
         border: 0;
         border-radius: 6px;
         background: transparent;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
         text-align: left;
         padding: 6px 10px;
         cursor: pointer;
+        transition: background 75ms ease;
       }
 
       .vf-markdown-editor__slash-item:hover,
       .vf-markdown-editor__slash-item[data-active='true'] {
-        background: rgba(0, 0, 0, 0.04);
+        background: oklch(0.93 0 0);
       }
 
       .vf-markdown-editor__slash-icon {
@@ -267,12 +344,12 @@ const OVERLAY_CSS = `
         justify-content: center;
         width: 24px;
         height: 24px;
-        border: 1px solid rgba(0, 0, 0, 0.1);
+        border: 1px solid oklch(0.84 0.0055 95.11);
         border-radius: 4px;
-        background: #ffffff;
+        background: oklch(1 0 0);
         font-size: 13px;
         font-weight: 600;
-        color: #374151;
+        color: oklch(0.2768 0 0);
         flex-shrink: 0;
       }
 
@@ -280,7 +357,7 @@ const OVERLAY_CSS = `
         display: block;
         font-size: 13px;
         font-weight: 500;
-        color: #111827;
+        color: oklch(0.2768 0 0);
         line-height: 1.35;
         flex: 1;
       }
@@ -291,7 +368,7 @@ const OVERLAY_CSS = `
 
       .vf-markdown-editor__slash-shortcut {
         font-size: 11px;
-        color: #9ca3af;
+        color: oklch(0.55 0.005 95.11);
         font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
         flex-shrink: 0;
       }
@@ -302,19 +379,23 @@ const OVERLAY_CSS = `
         justify-content: space-between;
         padding: 6px 10px;
         margin-top: 2px;
-        border-top: 1px solid rgba(0, 0, 0, 0.06);
+        border-top: 1px solid oklch(0.9 0 0);
         font-size: 11px;
-        color: #9ca3af;
+        color: oklch(0.55 0.005 95.11);
       }
 
       .vf-markdown-editor__slash-footer-key {
         font-size: 10px;
-        color: #9ca3af;
-        border: 1px solid rgba(0, 0, 0, 0.1);
+        color: oklch(0.55 0.005 95.11);
+        border: 1px solid oklch(0.84 0.0055 95.11);
         border-radius: 3px;
         padding: 1px 4px;
         font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
       }
+
+      /* ------------------------------------------------------------------ */
+      /* Inline toolbar                                                      */
+      /* ------------------------------------------------------------------ */
 
       .vf-markdown-editor__inline-toolbar {
         position: fixed;
@@ -322,10 +403,10 @@ const OVERLAY_CSS = `
         display: none;
         flex-direction: column;
         min-width: 200px;
-        border: 1px solid rgba(17, 24, 39, 0.12);
-        border-radius: 10px;
-        background: #ffffff;
-        box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12), 0 0 1px rgba(0, 0, 0, 0.1);
+        border: 1px solid oklch(0.84 0.0055 95.11);
+        border-radius: 8px;
+        background: oklch(1 0 0);
+        box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1);
         padding: 4px;
       }
 
@@ -339,7 +420,7 @@ const OVERLAY_CSS = `
       .vf-markdown-editor__inline-separator {
         width: 1px;
         height: 20px;
-        background: rgba(0, 0, 0, 0.1);
+        background: oklch(0.9 0 0);
         margin: 0 2px;
         flex-shrink: 0;
       }
@@ -348,7 +429,8 @@ const OVERLAY_CSS = `
         border: 0;
         border-radius: 6px;
         background: transparent;
-        color: #111827;
+        color: oklch(0.2768 0 0);
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
         font-size: 12px;
         font-weight: 600;
         line-height: 1;
@@ -356,15 +438,16 @@ const OVERLAY_CSS = `
         height: 26px;
         padding: 0 7px;
         cursor: pointer;
+        transition: background 75ms ease;
       }
 
       .vf-markdown-editor__inline-button:hover {
-        background: rgba(0, 0, 0, 0.05);
+        background: oklch(0.93 0 0);
       }
 
       .vf-markdown-editor__inline-button.active {
-        background: rgba(0, 129, 248, 0.14);
-        color: #0081f8;
+        background: oklch(0.6852 0.162 241.8 / 0.14);
+        color: oklch(0.6852 0.162 241.8);
       }
 
       .vf-markdown-editor__inline-button[data-format='bold'] {
@@ -383,11 +466,16 @@ const OVERLAY_CSS = `
         text-decoration: underline;
       }
 
+      /* ------------------------------------------------------------------ */
+      /* Block type trigger                                                  */
+      /* ------------------------------------------------------------------ */
+
       .vf-markdown-editor__block-trigger {
         border: 0;
         border-radius: 6px;
         background: transparent;
-        color: #111827;
+        color: oklch(0.2768 0 0);
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
         font-size: 12px;
         font-weight: 600;
         line-height: 1;
@@ -398,17 +486,22 @@ const OVERLAY_CSS = `
         align-items: center;
         gap: 2px;
         white-space: nowrap;
+        transition: background 75ms ease;
       }
 
       .vf-markdown-editor__block-trigger:hover {
-        background: rgba(0, 0, 0, 0.05);
+        background: oklch(0.93 0 0);
       }
 
       .vf-markdown-editor__block-trigger::after {
         content: '\\25BE';
         font-size: 10px;
-        color: #9ca3af;
+        color: oklch(0.55 0.005 95.11);
       }
+
+      /* ------------------------------------------------------------------ */
+      /* Block dropdown                                                      */
+      /* ------------------------------------------------------------------ */
 
       .vf-markdown-editor__block-dropdown {
         position: absolute;
@@ -416,10 +509,10 @@ const OVERLAY_CSS = `
         left: 4px;
         z-index: 100007;
         min-width: 160px;
-        border: 1px solid rgba(17, 24, 39, 0.12);
-        border-radius: 8px;
-        background: #ffffff;
-        box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
+        border: 1px solid oklch(0.84 0.0055 95.11);
+        border-radius: 6px;
+        background: oklch(1 0 0);
+        box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1);
         padding: 4px;
         margin-top: 4px;
         display: none;
@@ -431,31 +524,37 @@ const OVERLAY_CSS = `
         border: 0;
         border-radius: 6px;
         background: transparent;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
         text-align: left;
         padding: 6px 10px;
         font-size: 13px;
         font-weight: 500;
-        color: #111827;
+        color: oklch(0.2768 0 0);
         cursor: pointer;
+        transition: background 75ms ease;
       }
 
       .vf-markdown-editor__block-option:hover {
-        background: rgba(0, 0, 0, 0.04);
+        background: oklch(0.93 0 0);
       }
 
       .vf-markdown-editor__block-option.active {
-        background: rgba(0, 129, 248, 0.1);
-        color: #0081f8;
+        background: oklch(0.6852 0.162 241.8 / 0.1);
+        color: oklch(0.6852 0.162 241.8);
       }
+
+      /* ------------------------------------------------------------------ */
+      /* Block drag handle                                                   */
+      /* ------------------------------------------------------------------ */
 
       .vf-markdown-editor__block-handle {
         position: fixed;
         z-index: 100007;
         display: none;
-        border: 1px solid rgba(17, 24, 39, 0.18);
+        border: 1px solid oklch(0.84 0.0055 95.11);
         border-radius: 6px;
-        background: #ffffff;
-        color: #374151;
+        background: oklch(1 0 0);
+        color: oklch(0.2768 0 0);
         font-size: 12px;
         font-weight: 700;
         line-height: 1;
@@ -463,51 +562,60 @@ const OVERLAY_CSS = `
         height: 28px;
         padding: 0;
         cursor: grab;
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.14);
+        box-shadow: 0 1px 3px rgba(0,0,0,0.1), 0 1px 2px -1px rgba(0,0,0,0.1);
+        transition: background 75ms ease, box-shadow 75ms ease;
       }
 
       .vf-markdown-editor__block-handle:hover {
-        background: rgba(0, 129, 248, 0.12);
+        background: oklch(0.6852 0.162 241.8 / 0.1);
       }
 
       .vf-markdown-editor__block-handle[data-dragging='true'] {
         cursor: grabbing;
       }
 
+      /* ------------------------------------------------------------------ */
+      /* Block drop indicator                                                */
+      /* ------------------------------------------------------------------ */
+
       .vf-markdown-editor__block-drop-indicator {
         position: fixed;
         z-index: 100006;
         display: none;
         height: 2px;
-        border-radius: 999px;
-        background: #0081f8;
-        box-shadow: 0 1px 6px rgba(0, 129, 248, 0.5);
+        border-radius: 9999px;
+        background: oklch(0.6852 0.162 241.8);
+        box-shadow: 0 1px 6px oklch(0.6852 0.162 241.8 / 0.5);
       }
 
       .vf-markdown-editor__block-drop-label {
         position: fixed;
         z-index: 100007;
         display: none;
-        border-radius: 999px;
-        border: 1px solid rgba(0, 129, 248, 0.24);
-        background: rgba(255, 255, 255, 0.96);
-        color: #0f172a;
+        border-radius: 9999px;
+        border: 1px solid oklch(0.6852 0.162 241.8 / 0.24);
+        background: oklch(1 0 0 / 0.96);
+        color: oklch(0.2768 0 0);
         font-size: 11px;
         font-weight: 600;
         line-height: 1.2;
         padding: 3px 8px;
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.14);
+        box-shadow: 0 1px 3px rgba(0,0,0,0.1), 0 1px 2px -1px rgba(0,0,0,0.1);
       }
+
+      /* ------------------------------------------------------------------ */
+      /* Block drag ghost                                                    */
+      /* ------------------------------------------------------------------ */
 
       .vf-markdown-editor__block-drag-ghost {
         position: fixed;
         top: -9999px;
         left: -9999px;
         width: 260px;
-        border: 1px solid rgba(17, 24, 39, 0.22);
-        border-radius: 10px;
-        background: #ffffff;
-        box-shadow: 0 10px 24px rgba(0, 0, 0, 0.2);
+        border: 1px solid oklch(0.84 0.0055 95.11);
+        border-radius: 8px;
+        background: oklch(1 0 0);
+        box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1);
         padding: 8px 10px;
       }
 
@@ -515,23 +623,27 @@ const OVERLAY_CSS = `
         display: block;
         font-size: 11px;
         font-weight: 700;
-        color: #1e293b;
+        color: oklch(0.2768 0 0);
       }
 
       .vf-markdown-editor__block-drag-ghost-text {
         display: block;
         margin-top: 4px;
         font-size: 11px;
-        color: #475569;
+        color: oklch(0.55 0.005 95.11);
         line-height: 1.35;
       }
+
+      /* ------------------------------------------------------------------ */
+      /* MDX blocks bar                                                      */
+      /* ------------------------------------------------------------------ */
 
       .vf-markdown-editor__mdx-blocks {
         display: none;
         gap: 8px;
         padding: 8px 16px;
-        border-bottom: 1px solid rgba(0, 0, 0, 0.08);
-        background: rgba(245, 247, 250, 0.95);
+        border-bottom: 1px solid oklch(0.9 0 0);
+        background: oklch(0.97 0 0 / 0.95);
         overflow-x: auto;
       }
 
@@ -539,35 +651,44 @@ const OVERLAY_CSS = `
         display: inline-flex;
         align-items: center;
         gap: 8px;
-        border: 1px solid rgba(0, 0, 0, 0.16);
-        border-radius: 8px;
-        background: #ffffff;
+        border: 1px solid oklch(0.84 0.0055 95.11);
+        border-radius: 6px;
+        background: oklch(1 0 0);
         padding: 6px 8px;
       }
 
       .vf-markdown-editor__mdx-block-label {
         font-size: 11px;
-        color: #334155;
+        color: oklch(0.2768 0 0);
         white-space: nowrap;
       }
 
       .vf-markdown-editor__mdx-note {
         font-size: 10px;
-        color: #6b7280;
+        color: oklch(0.55 0.005 95.11);
         white-space: nowrap;
       }
 
       .vf-markdown-editor__mdx-open {
-        border: 1px solid rgba(0, 0, 0, 0.16);
+        border: 1px solid oklch(0.84 0.0055 95.11);
         border-radius: 6px;
-        background: #ffffff;
-        color: #0f172a;
+        background: oklch(1 0 0);
+        color: oklch(0.2768 0 0);
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
         font-size: 11px;
         line-height: 1;
         padding: 5px 7px;
         cursor: pointer;
         white-space: nowrap;
+        transition: background 75ms ease;
       }
+      .vf-markdown-editor__mdx-open:hover {
+        background: oklch(0.93 0 0);
+      }
+
+      /* ------------------------------------------------------------------ */
+      /* Lexical surface overrides                                           */
+      /* ------------------------------------------------------------------ */
 
       .vf-markdown-editor__surface [data-lexical-editor] {
         outline: none;
@@ -575,38 +696,42 @@ const OVERLAY_CSS = `
 
       .vf-markdown-editor__surface p:empty::before {
         content: "Type '/' for commands";
-        color: rgba(0, 0, 0, 0.3);
+        color: oklch(0.55 0.005 95.11 / 0.6);
         pointer-events: none;
         font-style: normal;
       }
 
       .vf-markdown-editor__surface h1:empty::before {
         content: 'Heading 1';
-        color: rgba(0, 0, 0, 0.3);
+        color: oklch(0.55 0.005 95.11 / 0.6);
         pointer-events: none;
       }
 
       .vf-markdown-editor__surface h2:empty::before {
         content: 'Heading 2';
-        color: rgba(0, 0, 0, 0.3);
+        color: oklch(0.55 0.005 95.11 / 0.6);
         pointer-events: none;
       }
 
       .vf-markdown-editor__surface h3:empty::before {
         content: 'Heading 3';
-        color: rgba(0, 0, 0, 0.3);
+        color: oklch(0.55 0.005 95.11 / 0.6);
         pointer-events: none;
       }
 
       .vf-markdown-editor__surface blockquote:empty::before {
         content: 'Quote';
-        color: rgba(0, 0, 0, 0.3);
+        color: oklch(0.55 0.005 95.11 / 0.6);
         pointer-events: none;
       }
 
       .vf-markdown-editor__surface p {
         min-height: 1.5em;
       }
+
+      /* ------------------------------------------------------------------ */
+      /* Textarea fallback                                                   */
+      /* ------------------------------------------------------------------ */
 
       .vf-markdown-editor__textarea {
         width: 100%;
@@ -618,218 +743,258 @@ const OVERLAY_CSS = `
         font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
         font-size: 14px;
         line-height: 1.6;
-        color: #111827;
+        color: oklch(0.2768 0 0);
         background: transparent;
         padding: 16px;
         box-sizing: border-box;
       }
 
+      /* ================================================================== */
+      /* DARK MODE                                                           */
+      /* ================================================================== */
+
       [data-theme='dark'] .vf-markdown-editor {
-        --vf-markdown-editor-bg: #0b1220;
+        background: oklch(0.2768 0 0);
       }
 
       [data-theme='dark'] .vf-markdown-editor__toolbar {
-        border-bottom-color: rgba(255, 255, 255, 0.08);
-        background: rgba(17, 24, 39, 0.92);
+        border-bottom-color: oklch(0.3 0.01 220);
+        background: oklch(0.18 0.01 220 / 0.96);
       }
 
       [data-theme='dark'] .vf-markdown-editor__title {
-        color: #9ca3af;
+        color: oklch(0.5338 0.0046 106.55);
       }
 
       [data-theme='dark'] .vf-markdown-editor__exit {
-        background: #111827;
-        border-color: rgba(255, 255, 255, 0.2);
-        color: #f9fafb;
+        background: oklch(0.3211 0 0);
+        border-color: oklch(0.42 0.0017 106.48);
+        color: oklch(0.9512 0.008 98.88);
+      }
+      [data-theme='dark'] .vf-markdown-editor__exit:hover {
+        background: oklch(0.25 0.01 220);
       }
 
       [data-theme='dark'] .vf-markdown-editor__history {
-        background: #111827;
-        border-color: rgba(255, 255, 255, 0.2);
-        color: #f9fafb;
+        background: oklch(0.3211 0 0);
+        border-color: oklch(0.42 0.0017 106.48);
+        color: oklch(0.9512 0.008 98.88);
+      }
+      [data-theme='dark'] .vf-markdown-editor__history:hover {
+        background: oklch(0.25 0.01 220);
       }
 
       [data-theme='dark'] .vf-markdown-editor__status {
-        color: #9ca3af;
+        color: oklch(0.5338 0.0046 106.55);
       }
 
       [data-theme='dark'] .vf-markdown-editor__status[data-state='saving'] {
-        color: #fbbf24;
+        color: oklch(0.75 0.15 75);
       }
 
       [data-theme='dark'] .vf-markdown-editor__status[data-state='saved'] {
-        color: #4ade80;
+        color: oklch(0.62 0.15 145);
       }
 
       [data-theme='dark'] .vf-markdown-editor__status[data-state='error'] {
-        color: #f87171;
+        color: oklch(0.65 0.2 25);
       }
 
       [data-theme='dark'] .vf-markdown-editor__presence-pill {
-        border-color: rgba(255, 255, 255, 0.2);
-        color: #f9fafb;
-        background: #111827;
+        border-color: oklch(0.42 0.0017 106.48);
+        color: oklch(0.9512 0.008 98.88);
+        background: oklch(0.3211 0 0);
+      }
+
+      [data-theme='dark'] .vf-markdown-editor__presence-pill[data-agent='true'] {
+        background: oklch(0.25 0.03 280);
+        border-color: oklch(0.6852 0.162 241.8 / 0.3);
       }
 
       [data-theme='dark'] .vf-markdown-editor__selection-pill {
-        border-color: rgba(255, 255, 255, 0.2);
-        color: #f9fafb;
-        background: #111827;
+        border-color: oklch(0.42 0.0017 106.48);
+        color: oklch(0.9512 0.008 98.88);
+        background: oklch(0.3211 0 0);
       }
 
       [data-theme='dark'] .vf-markdown-editor__textarea {
-        color: #f9fafb;
+        color: oklch(0.9512 0.008 98.88);
       }
 
+      /* Slash menu – dark */
+
       [data-theme='dark'] .vf-markdown-editor__slash-menu {
-        border-color: rgba(255, 255, 255, 0.15);
-        background: #1e293b;
+        border-color: oklch(0.42 0.0017 106.48);
+        background: oklch(0.21 0.01 220);
       }
 
       [data-theme='dark'] .vf-markdown-editor__slash-section {
-        color: #6b7280;
+        color: oklch(0.5338 0.0046 106.55);
       }
 
       [data-theme='dark'] .vf-markdown-editor__slash-item:hover,
       [data-theme='dark'] .vf-markdown-editor__slash-item[data-active='true'] {
-        background: rgba(255, 255, 255, 0.08);
+        background: oklch(0.25 0.01 220);
       }
 
       [data-theme='dark'] .vf-markdown-editor__slash-icon {
-        border-color: rgba(255, 255, 255, 0.15);
-        background: #1e293b;
-        color: #d1d5db;
+        border-color: oklch(0.42 0.0017 106.48);
+        background: oklch(0.3211 0 0);
+        color: oklch(0.9512 0.008 98.88);
       }
 
       [data-theme='dark'] .vf-markdown-editor__slash-item-title {
-        color: #f9fafb;
+        color: oklch(0.9512 0.008 98.88);
       }
 
       [data-theme='dark'] .vf-markdown-editor__slash-shortcut {
-        color: #6b7280;
+        color: oklch(0.5338 0.0046 106.55);
       }
 
       [data-theme='dark'] .vf-markdown-editor__slash-footer {
-        border-top-color: rgba(255, 255, 255, 0.08);
-        color: #6b7280;
+        border-top-color: oklch(0.3 0.01 220);
+        color: oklch(0.5338 0.0046 106.55);
       }
 
       [data-theme='dark'] .vf-markdown-editor__slash-footer-key {
-        border-color: rgba(255, 255, 255, 0.15);
-        color: #6b7280;
+        border-color: oklch(0.42 0.0017 106.48);
+        color: oklch(0.5338 0.0046 106.55);
       }
 
+      /* Inline toolbar – dark */
+
       [data-theme='dark'] .vf-markdown-editor__inline-toolbar {
-        border-color: rgba(255, 255, 255, 0.15);
-        background: #1e293b;
+        border-color: oklch(0.42 0.0017 106.48);
+        background: oklch(0.21 0.01 220);
       }
 
       [data-theme='dark'] .vf-markdown-editor__inline-separator {
-        background: rgba(255, 255, 255, 0.12);
+        background: oklch(0.3 0.01 220);
       }
 
       [data-theme='dark'] .vf-markdown-editor__inline-button {
-        color: #f9fafb;
+        color: oklch(0.9512 0.008 98.88);
       }
 
       [data-theme='dark'] .vf-markdown-editor__inline-button:hover {
-        background: rgba(255, 255, 255, 0.08);
+        background: oklch(0.25 0.01 220);
       }
 
       [data-theme='dark'] .vf-markdown-editor__inline-button.active {
-        background: rgba(59, 130, 246, 0.24);
-        color: #60a5fa;
+        background: oklch(0.6852 0.162 241.8 / 0.2);
+        color: oklch(0.75 0.14 241.8);
       }
 
+      /* Block trigger – dark */
+
       [data-theme='dark'] .vf-markdown-editor__block-trigger {
-        color: #f9fafb;
+        color: oklch(0.9512 0.008 98.88);
       }
 
       [data-theme='dark'] .vf-markdown-editor__block-trigger:hover {
-        background: rgba(255, 255, 255, 0.08);
+        background: oklch(0.25 0.01 220);
       }
 
       [data-theme='dark'] .vf-markdown-editor__block-trigger::after {
-        color: #6b7280;
+        color: oklch(0.5338 0.0046 106.55);
       }
 
+      /* Block dropdown – dark */
+
       [data-theme='dark'] .vf-markdown-editor__block-dropdown {
-        border-color: rgba(255, 255, 255, 0.15);
-        background: #1e293b;
+        border-color: oklch(0.42 0.0017 106.48);
+        background: oklch(0.21 0.01 220);
       }
 
       [data-theme='dark'] .vf-markdown-editor__block-option {
-        color: #f9fafb;
+        color: oklch(0.9512 0.008 98.88);
       }
 
       [data-theme='dark'] .vf-markdown-editor__block-option:hover {
-        background: rgba(255, 255, 255, 0.08);
+        background: oklch(0.25 0.01 220);
       }
 
       [data-theme='dark'] .vf-markdown-editor__block-option.active {
-        background: rgba(59, 130, 246, 0.2);
-        color: #60a5fa;
+        background: oklch(0.6852 0.162 241.8 / 0.2);
+        color: oklch(0.75 0.14 241.8);
       }
+
+      /* Placeholder text – dark */
 
       [data-theme='dark'] .vf-markdown-editor__surface p:empty::before,
       [data-theme='dark'] .vf-markdown-editor__surface h1:empty::before,
       [data-theme='dark'] .vf-markdown-editor__surface h2:empty::before,
       [data-theme='dark'] .vf-markdown-editor__surface h3:empty::before,
       [data-theme='dark'] .vf-markdown-editor__surface blockquote:empty::before {
-        color: rgba(255, 255, 255, 0.2);
+        color: oklch(0.5338 0.0046 106.55 / 0.5);
       }
 
+      /* Block drag – dark */
+
       [data-theme='dark'] .vf-markdown-editor__block-handle {
-        border-color: rgba(255, 255, 255, 0.22);
-        background: #111827;
-        color: #d1d5db;
+        border-color: oklch(0.42 0.0017 106.48);
+        background: oklch(0.3211 0 0);
+        color: oklch(0.9512 0.008 98.88);
       }
 
       [data-theme='dark'] .vf-markdown-editor__block-handle:hover {
-        background: rgba(59, 130, 246, 0.24);
+        background: oklch(0.6852 0.162 241.8 / 0.2);
       }
 
       [data-theme='dark'] .vf-markdown-editor__block-drop-label {
-        border-color: rgba(59, 130, 246, 0.35);
-        background: rgba(17, 24, 39, 0.94);
-        color: #e5e7eb;
+        border-color: oklch(0.6852 0.162 241.8 / 0.35);
+        background: oklch(0.18 0.01 220 / 0.96);
+        color: oklch(0.9512 0.008 98.88);
       }
 
       [data-theme='dark'] .vf-markdown-editor__block-drag-ghost {
-        border-color: rgba(255, 255, 255, 0.24);
-        background: #111827;
+        border-color: oklch(0.42 0.0017 106.48);
+        background: oklch(0.3211 0 0);
       }
 
       [data-theme='dark'] .vf-markdown-editor__block-drag-ghost-title {
-        color: #e5e7eb;
+        color: oklch(0.9512 0.008 98.88);
       }
 
       [data-theme='dark'] .vf-markdown-editor__block-drag-ghost-text {
-        color: #94a3b8;
+        color: oklch(0.5338 0.0046 106.55);
       }
 
+      /* MDX blocks – dark */
+
       [data-theme='dark'] .vf-markdown-editor__mdx-blocks {
-        border-bottom-color: rgba(255, 255, 255, 0.12);
-        background: rgba(2, 6, 23, 0.7);
+        border-bottom-color: oklch(0.3 0.01 220);
+        background: oklch(0.18 0.01 220 / 0.8);
       }
 
       [data-theme='dark'] .vf-markdown-editor__mdx-block {
-        border-color: rgba(255, 255, 255, 0.22);
-        background: #111827;
+        border-color: oklch(0.42 0.0017 106.48);
+        background: oklch(0.3211 0 0);
       }
 
       [data-theme='dark'] .vf-markdown-editor__mdx-block-label {
-        color: #cbd5e1;
+        color: oklch(0.9512 0.008 98.88);
       }
 
       [data-theme='dark'] .vf-markdown-editor__mdx-note {
-        color: #94a3b8;
+        color: oklch(0.5338 0.0046 106.55);
       }
 
       [data-theme='dark'] .vf-markdown-editor__mdx-open {
-        border-color: rgba(255, 255, 255, 0.22);
-        background: #0b1220;
-        color: #e5e7eb;
+        border-color: oklch(0.42 0.0017 106.48);
+        background: oklch(0.2768 0 0);
+        color: oklch(0.9512 0.008 98.88);
+      }
+      [data-theme='dark'] .vf-markdown-editor__mdx-open:hover {
+        background: oklch(0.25 0.01 220);
+      }
+
+      /* Edit button – dark */
+
+      [data-theme='dark'] .vf-markdown-edit-button {
+        background: oklch(0.9512 0.008 98.88);
+        color: oklch(0.2768 0 0);
+        border-color: oklch(0.42 0.0017 106.48);
       }
 `;
 


### PR DESCRIPTION
## Summary

- Add `agentWriteMarkdown` message handler so the AI agent can write content directly into the markdown editor via Yjs (replace, append, insert_at modes)
- Restyle bridge editor with hardcoded Studio design tokens (oklch colors, radii, fonts, spacing) for visual consistency in both iframe and standalone contexts
- Add `studioMode` config for Simple Mode auto-activation of the .md editor
- Fix 77 pre-existing TypeScript errors by expanding structural types for dynamically imported Lexical and Yjs modules, fixing null-narrowing lost in closures, and correcting array/string indexing

## Changes

| File | What |
|------|------|
| `bridge-state.ts` | Expand `LexicalApi`, `LexicalEditor`, `LexicalModule` and related interfaces |
| `bridge-editor-state.ts` | Add `YText`, `YjsAwareness`, `YjsModule` structural types |
| `bridge-styles.ts` | Restyle with Studio design tokens (oklch colors, spacing, radii, fonts) |
| `bridge-config.ts` | Add `studioMode` to bridge config |
| `bridge-coordinator.ts` | Read `studioMode` from URL params |
| `bridge-markdown-editor.ts` | Auto-activate for .md in Simple Mode, fix null-narrowing |
| `bridge-markdown-yjs.ts` | Fix null-narrowing in transact closures, cast Y module |
| `bridge-markdown-core.ts` | Fix aliasMatch indexing, componentSymbol fallback |
| `bridge-inline-toolbar.ts` | Replace bounded loops with for-of, fix null-narrowing |
| `bridge-block-drag.ts` | Fix null-narrowing in Lexical update callback |
| `bridge-selection.ts` | Fix string character indexing |
| `bridge-message-handler.ts` | Add `agentWriteMarkdown` case |

## Companion PR

- veryfront/veryfront-studio — `feat/agent-write-markdown-tool` (server tool + client component)

## Test plan

- [ ] Open .md page → click Edit → editor visually matches Studio styling
- [ ] Toggle dark mode → consistent appearance
- [ ] Open in new tab → same styling
- [ ] Simple Mode + .md page → editor auto-activates
- [ ] Advanced Mode → Edit button still required
- [ ] `deno check` passes with zero errors on all bridge files