### PR TITLE
fix: correct selection offset mapping between Monaco and markdown editor

### DIFF
--- a/src/studio/bridge/bridge-editor-state.ts
+++ b/src/studio/bridge/bridge-editor-state.ts
@@ -113,6 +113,8 @@ export const editorState = {
   markdownFrontmatter: "",
   markdownRawBlocks: [] as string[],
   markdownRawBlockTokenPrefix: "VF_RAW_BLOCK",
+  markdownEditorToRenderedMap: [] as number[],
+  markdownRenderedToEditorMap: [] as number[],
   markdownLatestMdxBlocks: [] as MdxBlock[],
   markdownLatestMdxImportMap: {} as Record<string, MdxImportEntry>,
   markdownLatestPresenceUsers: [] as PresenceUser[],

--- a/src/studio/bridge/bridge-markdown-editor.ts
+++ b/src/studio/bridge/bridge-markdown-editor.ts
@@ -33,6 +33,7 @@ import {
 } from "./bridge-markdown-yjs.ts";
 
 import {
+  buildEditorRenderedMaps,
   clearMarkdownSelectionOverlay,
   clearMarkdownSelectionSync,
   scheduleMarkdownSelectionOverlayRender,
@@ -133,13 +134,21 @@ export function setupMarkdownLexicalEditor(): void {
         }
 
         let nextContent = "";
+        let renderedText = "";
         update.editorState.read(function () {
           nextContent = markdownModule.$convertToMarkdownString(
             markdownModule.TRANSFORMERS,
             undefined,
             true,
           );
+          renderedText = lexicalModule.$getRoot().getTextContent();
         });
+
+        // Rebuild editor↔rendered offset maps after every edit
+        const maps = buildEditorRenderedMaps(nextContent, renderedText);
+        state.markdownEditorToRenderedMap = maps.editorToRendered;
+        state.markdownRenderedToEditorMap = maps.renderedToEditor;
+
         const restoredBody = restoreRawBlocksFromEditor(nextContent);
         const fullContent = composeMarkdownContent(restoredBody);
 
@@ -304,6 +313,12 @@ export function applyMarkdownContent(content: unknown): void {
           if (root.getChildrenSize() === 0) {
             root.append(lexicalModule.$createParagraphNode());
           }
+
+          // Build editor↔rendered offset maps after conversion
+          const renderedText = root.getTextContent();
+          const maps = buildEditorRenderedMaps(editorContent, renderedText);
+          state.markdownEditorToRenderedMap = maps.editorToRendered;
+          state.markdownRenderedToEditorMap = maps.renderedToEditor;
         },
         { discrete: true },
       );

--- a/src/studio/bridge/bridge-markdown-editor.ts
+++ b/src/studio/bridge/bridge-markdown-editor.ts
@@ -313,15 +313,17 @@ export function applyMarkdownContent(content: unknown): void {
           if (root.getChildrenSize() === 0) {
             root.append(lexicalModule.$createParagraphNode());
           }
-
-          // Build editor↔rendered offset maps after conversion
-          const renderedText = root.getTextContent();
-          const maps = buildEditorRenderedMaps(editorContent, renderedText);
-          state.markdownEditorToRenderedMap = maps.editorToRendered;
-          state.markdownRenderedToEditorMap = maps.renderedToEditor;
         },
         { discrete: true },
       );
+
+      // Build editor↔rendered offset maps from committed state
+      api.editor.getEditorState().read(function () {
+        const renderedText = api.lexicalModule.$getRoot().getTextContent();
+        const maps = buildEditorRenderedMaps(editorContent, renderedText);
+        state.markdownEditorToRenderedMap = maps.editorToRendered;
+        state.markdownRenderedToEditorMap = maps.renderedToEditor;
+      });
     } finally {
       state.markdownApplyingRemoteUpdate = false;
     }
@@ -1031,6 +1033,8 @@ export function setMarkdownEditMode(enabled: boolean): void {
     hideMarkdownInlineToolbar();
     hideMarkdownBlockDragUi();
     state.markdownOverlaySelections = [];
+    state.markdownEditorToRenderedMap = [];
+    state.markdownRenderedToEditorMap = [];
     clearMarkdownSelectionOverlay();
     clearMarkdownSelectionSync();
     disposeMarkdownYjs();

--- a/src/studio/bridge/bridge-selection.ts
+++ b/src/studio/bridge/bridge-selection.ts
@@ -238,6 +238,28 @@ export function buildEditorRenderedMaps(
       r2e[ri] = si;
       ri++;
     } else {
+      // Try advancing rendered pointer past extra block separators
+      // (Lexical's getTextContent() inserts \n\n between block elements,
+      // but the markdown source may only have \n between e.g. list items)
+      if (ri < renderedText.length && renderedText[ri] === "\n") {
+        let tempRi = ri;
+        while (tempRi < renderedText.length && renderedText[tempRi] === "\n") {
+          tempRi++;
+        }
+        if (
+          tempRi < renderedText.length &&
+          editorContent[si] === renderedText[tempRi]
+        ) {
+          for (let k = ri; k < tempRi; k++) {
+            if (r2e[k] === undefined) r2e[k] = si;
+          }
+          ri = tempRi;
+          e2r[si] = ri;
+          r2e[ri] = si;
+          ri++;
+          continue;
+        }
+      }
       // Syntax character — maps to the current rendered position
       e2r[si] = ri;
     }

--- a/src/studio/bridge/bridge-selection.ts
+++ b/src/studio/bridge/bridge-selection.ts
@@ -199,14 +199,90 @@ export function bodyOffsetToEditorOffset(
 }
 
 export function editorOffsetToSourceOffset(
-  editorOffset: number,
+  renderedOffset: number,
   bias?: "start" | "end",
 ): number {
   const frontmatterLength = typeof state.markdownFrontmatter === "string"
     ? state.markdownFrontmatter.length
     : 0;
+  // Convert rendered offset → editor offset first
+  const editorOffset = renderedOffsetToEditorOffset(renderedOffset);
   const bodyOffset = editorOffsetToBodyOffset(editorOffset, bias);
   return Math.max(0, frontmatterLength + bodyOffset);
+}
+
+// ---------------------------------------------------------------------------
+// Editor ↔ Rendered offset mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Build bidirectional offset maps between the markdown editor content
+ * (source text fed to Lexical) and the rendered plain text (what Lexical
+ * displays in the DOM).
+ *
+ * Uses greedy alignment: every character in renderedText is expected to
+ * appear in editorContent in the same order. Extra characters in
+ * editorContent are markdown syntax (e.g. `# `, `**`, `~~`, `[`, `](url)`).
+ */
+export function buildEditorRenderedMaps(
+  editorContent: string,
+  renderedText: string,
+): { editorToRendered: number[]; renderedToEditor: number[] } {
+  const e2r: number[] = new Array(editorContent.length + 1);
+  const r2e: number[] = new Array(renderedText.length + 1);
+
+  let ri = 0;
+  for (let si = 0; si < editorContent.length; si++) {
+    if (ri < renderedText.length && editorContent[si] === renderedText[ri]) {
+      e2r[si] = ri;
+      r2e[ri] = si;
+      ri++;
+    } else {
+      // Syntax character — maps to the current rendered position
+      e2r[si] = ri;
+    }
+  }
+
+  // End-of-string sentinels
+  e2r[editorContent.length] = Math.min(ri, renderedText.length);
+  r2e[renderedText.length] = editorContent.length;
+
+  // Fill any remaining unmatched rendered positions
+  for (let r = ri; r < renderedText.length; r++) {
+    if (r2e[r] === undefined) {
+      r2e[r] = editorContent.length;
+    }
+  }
+
+  // Fill gaps in r2e (shouldn't happen normally, but defensive)
+  let lastSrc = 0;
+  for (let r = 0; r <= renderedText.length; r++) {
+    if (r2e[r] !== undefined) {
+      lastSrc = r2e[r]!;
+    } else {
+      r2e[r] = lastSrc;
+    }
+  }
+
+  return { editorToRendered: e2r, renderedToEditor: r2e };
+}
+
+function editorOffsetToRenderedOffset(editorOffset: number): number {
+  const map = state.markdownEditorToRenderedMap;
+  if (!map || map.length === 0) {
+    return editorOffset;
+  }
+  const idx = Math.max(0, Math.min(map.length - 1, Math.trunc(editorOffset || 0)));
+  return map[idx] ?? editorOffset;
+}
+
+function renderedOffsetToEditorOffset(renderedOffset: number): number {
+  const map = state.markdownRenderedToEditorMap;
+  if (!map || map.length === 0) {
+    return renderedOffset;
+  }
+  const idx = Math.max(0, Math.min(map.length - 1, Math.trunc(renderedOffset || 0)));
+  return map[idx] ?? renderedOffset;
 }
 
 export function sourceSelectionToEditorRange(
@@ -230,9 +306,13 @@ export function sourceSelectionToEditorRange(
   const editorStart = bodyOffsetToEditorOffset(bodyStart, "start");
   const editorEnd = bodyOffsetToEditorOffset(bodyEnd, "end");
 
+  // Convert editor (markdown) offsets → rendered (DOM text) offsets
+  const renderedStart = editorOffsetToRenderedOffset(editorStart);
+  const renderedEnd = editorOffsetToRenderedOffset(editorEnd);
+
   return {
-    start: Math.max(0, Math.min(editorStart, editorEnd)),
-    end: Math.max(0, Math.max(editorStart, editorEnd)),
+    start: Math.max(0, Math.min(renderedStart, renderedEnd)),
+    end: Math.max(0, Math.max(renderedStart, renderedEnd)),
   };
 }
 

--- a/src/studio/bridge/bridge-styles.ts
+++ b/src/studio/bridge/bridge-styles.ts
@@ -462,10 +462,6 @@ const OVERLAY_CSS = `
         text-decoration: line-through;
       }
 
-      .vf-markdown-editor__inline-button[data-format='underline'] {
-        text-decoration: underline;
-      }
-
       /* ------------------------------------------------------------------ */
       /* Block type trigger                                                  */
       /* ------------------------------------------------------------------ */

--- a/src/studio/bridge/bridge-styles.ts
+++ b/src/studio/bridge/bridge-styles.ts
@@ -694,6 +694,12 @@ const OVERLAY_CSS = `
         outline: none;
       }
 
+      .vf-markdown-editor__surface s,
+      .vf-markdown-editor__surface del,
+      .vf-markdown-editor__surface [style*='line-through'] {
+        text-decoration: line-through;
+      }
+
       .vf-markdown-editor__surface p:empty::before {
         content: "Type '/' for commands";
         color: oklch(0.55 0.005 95.11 / 0.6);


### PR DESCRIPTION
## Summary

- Fixes cursor/selection position mismatch between Monaco editor and the markdown rich-text editor
- The bridge converts between 4 offset spaces (source → body → editor → rendered), but was skipping the editor→rendered step, causing markdown syntax characters (`# `, `**`, `~~`, `[](url)`) to shift cursor positions
- Adds a greedy alignment algorithm (`buildEditorRenderedMaps`) that builds bidirectional offset maps between the markdown text fed to Lexical and the rendered plain text
- Maps are rebuilt after every `$convertFromMarkdownString` (remote content) and after every local edit (Lexical update listener)
- Handles list items where Lexical's `getTextContent()` inserts extra `\n` between block elements
- Maps built from committed editor state (not draft), and invalidated on editor teardown
- Adds surface-level strikethrough CSS; removes orphaned underline button CSS

## Test plan

- [ ] Open a `.md` page in the editor, place cursor in Monaco on a heading line → verify the cursor label in the markdown editor appears at the correct position (not shifted by `# ` prefix)
- [ ] Select bold text in Monaco → verify the highlight in the markdown editor covers the actual bold text, not shifted by `**` markers
- [ ] Select text in the markdown editor → verify Monaco highlights the matching source text
- [ ] Test with a list — cursor in Monaco on second list item should map correctly in editor
- [ ] Apply strikethrough formatting via toolbar → verify the text renders with line-through in the editor surface
- [ ] Close and reopen the editor → verify no stale selection artifacts