### PR TITLE
fix: address P0/P1 issues from bridge editor code review

### DIFF
--- a/src/studio/bridge/bridge-markdown-core.ts
+++ b/src/studio/bridge/bridge-markdown-core.ts
@@ -495,12 +495,15 @@ export function extractRawBlocksForEditor(
     });
   };
 
-  const replaceWithToken = function (
-    match: string,
-    leadingNewline: string,
-    offset: number,
-    inputText: string,
-  ): string {
+  // Uses rest args because different patterns have different numbers of
+  // capture groups. In a .replace() callback, the last two args are
+  // always (offset, inputText), and the first capture group is always
+  // the leading newline.
+  const replaceWithToken = function (...args: any[]): string {
+    const match: string = args[0];
+    const leadingNewline: string = args[1];
+    const offset: number = args[args.length - 2];
+    const inputText: string = args[args.length - 1];
     const safeLeading = typeof leadingNewline === "string" ? leadingNewline : "";
     const tokenIndex = rawBlocks.length;
     const rawBlock = typeof match === "string" ? match.trimStart() : "";
@@ -522,8 +525,10 @@ export function extractRawBlocksForEditor(
     "(^|\\n)\\x60\\x60\\x60(?:tsx|jsx)[^\\n]*\\n[\\s\\S]*?\\n\\x60\\x60\\x60(?=\\n|$)",
     "g",
   );
+  // Match opening and closing tag names to handle nested elements correctly.
+  // Without backreference, <div><p>text</p></div> would stop at </p>.
   const htmlBlockPattern = new RegExp(
-    "(^|\\n)<[A-Za-z][\\w:-]*(?:\\s[^>\\n]*)?>[\\s\\S]*?<\\/[A-Za-z][\\w:-]*>(?=\\n|$)",
+    "(^|\\n)<([A-Za-z][\\w:-]*)(?:\\s[^>\\n]*)?>[\\s\\S]*?<\\/\\2>(?=\\n|$)",
     "g",
   );
   const htmlSelfClosingPattern = new RegExp(
@@ -574,14 +579,17 @@ export function restoreRawBlocksFromEditor(editorBody: string): string {
  * Syncs changes to Yjs when connected and schedules content sync
  * and selection overlay rendering.
  */
-export function handleMarkdownLocalChange(content: string): void {
+export function handleMarkdownLocalChange(
+  content: string,
+  precomputedFullContent?: string,
+): void {
   if (typeof content !== "string") {
     return;
   }
 
   state.markdownCurrentEditorContent = content;
-  const restoredBody = restoreRawBlocksFromEditor(content);
-  const fullContent = composeMarkdownContent(restoredBody);
+  const fullContent = precomputedFullContent ??
+    composeMarkdownContent(restoreRawBlocksFromEditor(content));
   if (fullContent === state.markdownCurrentContent) {
     return;
   }

--- a/src/studio/bridge/bridge-markdown-editor.ts
+++ b/src/studio/bridge/bridge-markdown-editor.ts
@@ -36,8 +36,10 @@ import {
   buildEditorRenderedMaps,
   clearMarkdownSelectionOverlay,
   clearMarkdownSelectionSync,
+  getTextOffsetWithinRoot,
   scheduleMarkdownSelectionOverlayRender,
   scheduleMarkdownSelectionSync,
+  setMarkdownEditorSelection,
   sourceSelectionToEditorRange,
 } from "./bridge-selection.ts";
 
@@ -157,7 +159,8 @@ export function setupMarkdownLexicalEditor(): void {
         }
         state.markdownLexicalRenderedContent = fullContent;
 
-        handleMarkdownLocalChange(nextContent);
+        // Pass pre-computed fullContent to avoid redundant restore+compose
+        handleMarkdownLocalChange(nextContent, fullContent);
         scheduleMarkdownSlashMenuUpdate();
         scheduleMarkdownInlineToolbarUpdate();
       });
@@ -294,39 +297,66 @@ export function applyMarkdownContent(content: unknown): void {
   state.markdownCurrentEditorContent = editorContent;
 
   if (state.markdownLexicalApi) {
-    state.markdownApplyingRemoteUpdate = true;
-    try {
-      state.markdownLexicalRenderedContent = content;
-      const api = state.markdownLexicalApi;
-      api.editor.update(
-        function () {
-          const lexicalModule = api.lexicalModule;
-          const markdownModule = api.markdownModule;
-          const root = lexicalModule.$getRoot();
-          root.clear();
-          markdownModule.$convertFromMarkdownString(
-            editorContent,
-            markdownModule.TRANSFORMERS,
-            undefined,
-            true,
+    // Save current selection offset before rebuilding the tree
+    let savedSelectionOffset = -1;
+    if (state.markdownEditorSurface) {
+      const sel = window.getSelection();
+      if (sel && sel.rangeCount > 0) {
+        const range = sel.getRangeAt(0);
+        if (state.markdownEditorSurface.contains(range.startContainer)) {
+          savedSelectionOffset = getTextOffsetWithinRoot(
+            state.markdownEditorSurface,
+            range.startContainer,
+            range.startOffset,
           );
-          if (root.getChildrenSize() === 0) {
-            root.append(lexicalModule.$createParagraphNode());
-          }
-        },
-        { discrete: true },
-      );
-
-      // Build editor↔rendered offset maps from committed state
-      api.editor.getEditorState().read(function () {
-        const renderedText = api.lexicalModule.$getRoot().getTextContent();
-        const maps = buildEditorRenderedMaps(editorContent, renderedText);
-        state.markdownEditorToRenderedMap = maps.editorToRendered;
-        state.markdownRenderedToEditorMap = maps.renderedToEditor;
-      });
-    } finally {
-      state.markdownApplyingRemoteUpdate = false;
+        }
+      }
     }
+
+    state.markdownApplyingRemoteUpdate = true;
+    state.markdownLexicalRenderedContent = content;
+    const api = state.markdownLexicalApi;
+    api.editor.update(
+      function () {
+        const lexicalModule = api.lexicalModule;
+        const markdownModule = api.markdownModule;
+        const root = lexicalModule.$getRoot();
+        root.clear();
+        markdownModule.$convertFromMarkdownString(
+          editorContent,
+          markdownModule.TRANSFORMERS,
+          undefined,
+          true,
+        );
+        if (root.getChildrenSize() === 0) {
+          root.append(lexicalModule.$createParagraphNode());
+        }
+      },
+      { discrete: true },
+    );
+
+    // Build editor↔rendered offset maps from committed state
+    api.editor.getEditorState().read(function () {
+      const renderedText = api.lexicalModule.$getRoot().getTextContent();
+      const maps = buildEditorRenderedMaps(editorContent, renderedText);
+      state.markdownEditorToRenderedMap = maps.editorToRendered;
+      state.markdownRenderedToEditorMap = maps.renderedToEditor;
+    });
+
+    // Reset flag after all synchronous Lexical reconciliation completes
+    // (avoids race where secondary updates from list normalization etc.
+    // are mistakenly treated as local changes and echoed back to Yjs)
+    queueMicrotask(function () {
+      state.markdownApplyingRemoteUpdate = false;
+    });
+
+    // Restore selection to the same offset (clamped to new content length)
+    if (savedSelectionOffset >= 0 && state.markdownEditorSurface) {
+      const maxOffset = editorContent.length;
+      const restoredOffset = Math.min(savedSelectionOffset, maxOffset);
+      setMarkdownEditorSelection(restoredOffset);
+    }
+
     scheduleMarkdownSelectionOverlayRender();
     scheduleMarkdownSlashMenuUpdate();
     scheduleMarkdownInlineToolbarUpdate();

--- a/src/studio/bridge/bridge-markdown-yjs.ts
+++ b/src/studio/bridge/bridge-markdown-yjs.ts
@@ -242,19 +242,24 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
 
       provider.awareness.on("change", syncAwareness);
 
+      // Register Y.Text observer once (outside sync handler to prevent
+      // duplicate registration on reconnect — sync can fire multiple times)
+      let ytextObserverRegistered = false;
+
       provider.on("sync", (synced: boolean) => {
         if (synced && !state.markdownYjsConnected) {
           state.markdownYjsConnected = true;
 
           const ytextContent = ytext.toString();
           if (
+            state.markdownHasUnsavedChanges &&
             state.markdownCurrentContent &&
             state.markdownCurrentContent !== ytextContent
           ) {
-            // User typed before sync completed - push local edits to Y.Text
+            // User made actual edits before sync completed - push to Y.Text
             syncLocalChangeToYText(state.markdownCurrentContent);
           } else if (ytextContent) {
-            // No local edits - seed editor from Y.Text
+            // No local edits or same content - seed editor from Y.Text
             applyMarkdownContent(ytextContent);
           }
 
@@ -273,16 +278,19 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
           }
 
           // Observe Y.Text for remote changes (from other users / Monaco)
-          ytext.observe((event: any) => {
-            if (event.transaction.origin === LEXICAL_YJS_ORIGIN) {
-              return;
-            }
-            const fullContent = ytext.toString();
-            if (fullContent === state.markdownCurrentContent) {
-              return;
-            }
-            applyMarkdownContent(fullContent);
-          });
+          if (!ytextObserverRegistered) {
+            ytextObserverRegistered = true;
+            ytext.observe((event: any) => {
+              if (event.transaction.origin === LEXICAL_YJS_ORIGIN) {
+                return;
+              }
+              const fullContent = ytext.toString();
+              if (fullContent === state.markdownCurrentContent) {
+                return;
+              }
+              applyMarkdownContent(fullContent);
+            });
+          }
 
           // Initial awareness sync after Yjs is connected
           syncAwareness();

--- a/src/studio/bridge/bridge-message-handler.ts
+++ b/src/studio/bridge/bridge-message-handler.ts
@@ -101,14 +101,15 @@ export function handleStudioMessage(event: MessageEvent): void {
       return;
 
     case "agentWriteMarkdown": {
-      const mode: string = message.mode || "replace";
+      const content = typeof message.content === "string" ? message.content : "";
+      const mode: string = typeof message.mode === "string" ? message.mode : "replace";
       if (mode === "replace") {
-        replaceYTextContent(message.content || "");
+        replaceYTextContent(content);
       } else if (mode === "append") {
-        writeToYText(message.content || "");
+        writeToYText(content);
       } else if (mode === "insert_at") {
-        writeToYText(message.content || "", {
-          position: message.position ?? 0,
+        writeToYText(content, {
+          position: typeof message.position === "number" ? message.position : 0,
           origin: "agent-write",
         });
       }

--- a/src/studio/bridge/bridge-messaging.ts
+++ b/src/studio/bridge/bridge-messaging.ts
@@ -2,12 +2,17 @@
  * Bridge Messaging
  *
  * Communication layer between the preview iframe and Studio.
+ * Captures the Studio origin from the first valid incoming message
+ * and uses it as the targetOrigin for outgoing postMessage calls
+ * to prevent information leakage to untrusted embedders.
  */
+
+let studioOrigin: string | null = null;
 
 export function postToStudio(message: Record<string, unknown>): void {
   if (!window.parent || window.parent === window) return;
   try {
-    window.parent.postMessage(message, "*");
+    window.parent.postMessage(message, studioOrigin || "*");
   } catch (e) {
     console.debug("[StudioBridge] postMessage failed:", e);
   }
@@ -17,15 +22,18 @@ export function isFromStudio(event: MessageEvent): boolean {
   try {
     const url = new URL(event.origin || "");
     const host = url.hostname;
-    return (
+    const valid =
       host === "localhost" ||
       host.endsWith(".veryfront.org") ||
       host === "veryfront.org" ||
       host.endsWith(".veryfront.com") ||
       host === "veryfront.com" ||
       host.endsWith(".veryfront.dev") ||
-      host === "veryfront.dev"
-    );
+      host === "veryfront.dev";
+    if (valid && !studioOrigin) {
+      studioOrigin = event.origin;
+    }
+    return valid;
   } catch {
     return false;
   }

--- a/src/studio/bridge/bridge-selection.ts
+++ b/src/studio/bridge/bridge-selection.ts
@@ -265,6 +265,17 @@ export function buildEditorRenderedMaps(
     }
   }
 
+  // Warn when alignment didn't consume all rendered text — indicates a
+  // mapping failure that will cause visible selection offset bugs.
+  if (ri < renderedText.length) {
+    console.warn(
+      "[StudioBridge] Offset mapping divergence: rendered text has",
+      renderedText.length - ri,
+      "unconsumed characters starting at index",
+      ri,
+    );
+  }
+
   // End-of-string sentinels
   e2r[editorContent.length] = Math.min(ri, renderedText.length);
   r2e[renderedText.length] = editorContent.length;


### PR DESCRIPTION
## Summary

Fixes 9 issues identified by a 3-way AI code review (Claude, Gemini, Codex) of the markdown editor bridge code.

### P0 Fixes
- **Duplicate Yjs observer**: `ytext.observe()` was registered inside the `sync` handler which fires on reconnect, accumulating duplicate observers causing redundant DOM rebuilds. Added `ytextObserverRegistered` guard.
- **Remote update flag timing**: `markdownApplyingRemoteUpdate` was reset in a `finally` block before Lexical's secondary updates (e.g. list normalization) complete, causing echo-back to Yjs. Now resets via `queueMicrotask()`.
- **Double change processing**: The Lexical update listener computed `restoreRawBlocksFromEditor` + `composeMarkdownContent`, then `handleMarkdownLocalChange` recomputed the same. Now passes pre-computed `fullContent` to avoid redundant work.

### P1 Fixes
- **agentWriteMarkdown validation**: Added `typeof` checks for `message.content`, `message.mode`, and `message.position` to prevent Yjs corruption from malformed messages.
- **Nested HTML regex**: `<div><p>text</p></div>` was incorrectly tokenized because the non-greedy `[\s\S]*?` stopped at the first `</p>`. Fixed with backreference `\2` to match opening/closing tag names.
- **Selection preservation**: `applyMarkdownContent` now saves the cursor offset before `root.clear()` and restores it after rebuilding the tree, preventing cursor loss on remote edits.
- **Offset mapping divergence warning**: `buildEditorRenderedMaps` now logs a warning when the greedy alignment doesn't consume all rendered text, making mapping failures visible.
- **Initial Yjs sync race**: Stale local content could overwrite remote changes on first sync. Now checks `markdownHasUnsavedChanges` to distinguish loaded content from actual user edits.
- **postMessage targetOrigin**: Replaced `"*"` with captured Studio origin from the first valid incoming message, preventing information leakage to untrusted embedders.

## Test plan
- [x] `deno check` passes on all bridge modules
- [x] All 3 existing bridge tests pass
- [ ] Open .md page → click Edit → editor loads, type text, verify Yjs sync
- [ ] Open in two tabs → verify collaborative edits don't lose cursor position
- [ ] Test with nested HTML in MDX (e.g. `<div><p>text</p></div>`) → verify correct tokenization
- [ ] Verify console shows no offset mapping divergence warnings on normal documents