### PR TITLE
style: fix deno fmt formatting in bridge-messaging

### DIFF
--- a/src/studio/bridge/bridge-messaging.ts
+++ b/src/studio/bridge/bridge-messaging.ts
@@ -22,8 +22,7 @@ export function isFromStudio(event: MessageEvent): boolean {
   try {
     const url = new URL(event.origin || "");
     const host = url.hostname;
-    const valid =
-      host === "localhost" ||
+    const valid = host === "localhost" ||
       host.endsWith(".veryfront.org") ||
       host === "veryfront.org" ||
       host.endsWith(".veryfront.com") ||


### PR DESCRIPTION
## Summary
- Fix `deno fmt` violation from PR #498 — `const valid =` assignment must start on the same line

## Test plan
- [x] `deno fmt --check` passes