### PR TITLE
fix: prevent markdown content drift and add contentChanged handler

### DIFF
--- a/src/studio/bridge/bridge-editor-state.ts
+++ b/src/studio/bridge/bridge-editor-state.ts
@@ -110,6 +110,8 @@ export const editorState = {
   markdownCurrentEditorContent: "",
   markdownLexicalRenderedContent: null as string | null,
   markdownApplyingRemoteUpdate: false,
+  markdownRemoteUpdateToken: 0,
+  markdownPendingLocalReconcile: false,
   markdownLastRemoteContent: null as string | null,
   markdownFrontmatter: "",
   markdownRawBlocks: [] as string[],
@@ -122,6 +124,7 @@ export const editorState = {
   markdownLatestSelections: [] as RemoteSelection[],
   markdownHasUnsavedChanges: false,
   markdownSaveInProgress: false,
+  markdownSaveRequestedContent: null as string | null,
 
   // Yjs (dynamically imported — typed structurally)
   markdownYDoc: null as {

--- a/src/studio/bridge/bridge-editor-state.ts
+++ b/src/studio/bridge/bridge-editor-state.ts
@@ -110,6 +110,7 @@ export const editorState = {
   markdownCurrentEditorContent: "",
   markdownLexicalRenderedContent: null as string | null,
   markdownApplyingRemoteUpdate: false,
+  markdownLastRemoteContent: null as string | null,
   markdownFrontmatter: "",
   markdownRawBlocks: [] as string[],
   markdownRawBlockTokenPrefix: "VF_RAW_BLOCK",

--- a/src/studio/bridge/bridge-markdown-core.ts
+++ b/src/studio/bridge/bridge-markdown-core.ts
@@ -595,10 +595,12 @@ export function handleMarkdownLocalChange(
   }
   state.markdownCurrentContent = fullContent;
   state.markdownHasUnsavedChanges = true;
-  // Only sync to Yjs for genuinely local edits. When markdownLastRemoteContent
-  // is set, Lexical is still processing a remote update (e.g. normalizing
-  // whitespace) and the output should NOT echo back to Yjs.
-  if (state.markdownYjsConnected && state.markdownLastRemoteContent === null) {
+  // Echo-back prevention is handled upstream: the Lexical update listener
+  // returns early when markdownApplyingRemoteUpdate is true, capturing edits
+  // via pendingLocalReconcile for replay after the remote apply settles.
+  // This function always syncs to Yjs when connected to avoid silently
+  // dropping user edits.
+  if (state.markdownYjsConnected) {
     syncLocalChangeToYText(fullContent);
   }
   scheduleMarkdownSync(fullContent);

--- a/src/studio/bridge/bridge-markdown-core.ts
+++ b/src/studio/bridge/bridge-markdown-core.ts
@@ -326,7 +326,7 @@ export function postMarkdownEditorReady(): void {
   getEditorCallbacks()?.onEditorReady(state.markdownFileId, getConfig().pagePath);
 }
 
-export function scheduleMarkdownSync(content: string): void {
+export function scheduleMarkdownSync(_content: string): void {
   if (!state.markdownFileId) {
     return;
   }
@@ -337,7 +337,7 @@ export function scheduleMarkdownSync(content: string): void {
     getEditorCallbacks()?.onContentChange(
       state.markdownFileId,
       getConfig().pagePath,
-      content,
+      state.markdownCurrentContent,
     );
   }, 120);
 }
@@ -609,11 +609,15 @@ export function saveMarkdownContent(): void {
   if (!state.markdownHasUnsavedChanges) {
     return;
   }
+  if (state.markdownSaveInProgress) {
+    return;
+  }
   const cb = getEditorCallbacks();
   if (!cb) {
     return;
   }
   state.markdownSaveInProgress = true;
+  state.markdownSaveRequestedContent = state.markdownCurrentContent;
   setMarkdownPersistStatus("saving");
   if (state.markdownSyncTimer) {
     clearTimeout(state.markdownSyncTimer);
@@ -628,6 +632,7 @@ export function saveMarkdownContent(): void {
     );
   } catch (err) {
     state.markdownSaveInProgress = false;
+    state.markdownSaveRequestedContent = null;
     setMarkdownPersistStatus("error");
     console.error("[StudioBridge] Save failed:", err);
   }

--- a/src/studio/bridge/bridge-markdown-core.ts
+++ b/src/studio/bridge/bridge-markdown-core.ts
@@ -595,7 +595,10 @@ export function handleMarkdownLocalChange(
   }
   state.markdownCurrentContent = fullContent;
   state.markdownHasUnsavedChanges = true;
-  if (state.markdownYjsConnected) {
+  // Only sync to Yjs for genuinely local edits. When markdownLastRemoteContent
+  // is set, Lexical is still processing a remote update (e.g. normalizing
+  // whitespace) and the output should NOT echo back to Yjs.
+  if (state.markdownYjsConnected && state.markdownLastRemoteContent === null) {
     syncLocalChangeToYText(fullContent);
   }
   scheduleMarkdownSync(fullContent);

--- a/src/studio/bridge/bridge-markdown-editor.ts
+++ b/src/studio/bridge/bridge-markdown-editor.ts
@@ -132,6 +132,9 @@ export function setupMarkdownLexicalEditor(): void {
         update: any,
       ) {
         if (state.markdownApplyingRemoteUpdate) {
+          // Reconcile once remote apply settles so local edits during this window
+          // are not silently dropped.
+          state.markdownPendingLocalReconcile = true;
           return;
         }
 
@@ -296,6 +299,12 @@ export function applyMarkdownContent(content: unknown): void {
   state.markdownCurrentContent = content;
   state.markdownCurrentEditorContent = editorContent;
 
+  // Cancel any pending debounced sync from pre-remote local edits.
+  if (state.markdownSyncTimer) {
+    clearTimeout(state.markdownSyncTimer);
+    state.markdownSyncTimer = null;
+  }
+
   if (state.markdownLexicalApi) {
     // Save current selection offset before rebuilding the tree
     let savedSelectionOffset = -1;
@@ -314,6 +323,9 @@ export function applyMarkdownContent(content: unknown): void {
     }
 
     state.markdownLastRemoteContent = content;
+    const remoteUpdateToken = state.markdownRemoteUpdateToken + 1;
+    state.markdownRemoteUpdateToken = remoteUpdateToken;
+    state.markdownPendingLocalReconcile = false;
     state.markdownApplyingRemoteUpdate = true;
     state.markdownLexicalRenderedContent = content;
     const api = state.markdownLexicalApi;
@@ -349,10 +361,45 @@ export function applyMarkdownContent(content: unknown): void {
     // setTimeout(0) is more reliable than queueMicrotask for catching
     // secondary updates from list normalization, etc.
     setTimeout(function () {
+      // Ignore stale reset callbacks from earlier remote applies.
+      if (state.markdownRemoteUpdateToken !== remoteUpdateToken) {
+        return;
+      }
       state.markdownApplyingRemoteUpdate = false;
       if (state.markdownLastRemoteContent === remoteContentSnapshot) {
         state.markdownLastRemoteContent = null;
       }
+
+      if (!state.markdownPendingLocalReconcile || !state.markdownLexicalApi) {
+        return;
+      }
+      state.markdownPendingLocalReconcile = false;
+
+      let nextContent = "";
+      let renderedText = "";
+      const reconcileApi = state.markdownLexicalApi;
+      reconcileApi.editor.getEditorState().read(function () {
+        nextContent = reconcileApi.markdownModule.$convertToMarkdownString(
+          reconcileApi.markdownModule.TRANSFORMERS,
+          undefined,
+          true,
+        );
+        renderedText = reconcileApi.lexicalModule.$getRoot().getTextContent();
+      });
+
+      const maps = buildEditorRenderedMaps(nextContent, renderedText);
+      state.markdownEditorToRenderedMap = maps.editorToRendered;
+      state.markdownRenderedToEditorMap = maps.renderedToEditor;
+
+      const restoredBody = restoreRawBlocksFromEditor(nextContent);
+      const fullContent = composeMarkdownContent(restoredBody);
+      if (fullContent === state.markdownLexicalRenderedContent) {
+        return;
+      }
+      state.markdownLexicalRenderedContent = fullContent;
+      handleMarkdownLocalChange(nextContent, fullContent);
+      scheduleMarkdownSlashMenuUpdate();
+      scheduleMarkdownInlineToolbarUpdate();
     }, 0);
 
     // Restore selection to the same offset (clamped to new content length)

--- a/src/studio/bridge/bridge-markdown-editor.ts
+++ b/src/studio/bridge/bridge-markdown-editor.ts
@@ -313,9 +313,11 @@ export function applyMarkdownContent(content: unknown): void {
       }
     }
 
+    state.markdownLastRemoteContent = content;
     state.markdownApplyingRemoteUpdate = true;
     state.markdownLexicalRenderedContent = content;
     const api = state.markdownLexicalApi;
+    const remoteContentSnapshot = content;
     api.editor.update(
       function () {
         const lexicalModule = api.lexicalModule;
@@ -343,12 +345,15 @@ export function applyMarkdownContent(content: unknown): void {
       state.markdownRenderedToEditorMap = maps.renderedToEditor;
     });
 
-    // Reset flag after all synchronous Lexical reconciliation completes
-    // (avoids race where secondary updates from list normalization etc.
-    // are mistakenly treated as local changes and echoed back to Yjs)
-    queueMicrotask(function () {
+    // Reset flags after all synchronous Lexical reconciliation completes.
+    // setTimeout(0) is more reliable than queueMicrotask for catching
+    // secondary updates from list normalization, etc.
+    setTimeout(function () {
       state.markdownApplyingRemoteUpdate = false;
-    });
+      if (state.markdownLastRemoteContent === remoteContentSnapshot) {
+        state.markdownLastRemoteContent = null;
+      }
+    }, 0);
 
     // Restore selection to the same offset (clamped to new content length)
     if (savedSelectionOffset >= 0 && state.markdownEditorSurface) {

--- a/src/studio/bridge/bridge-markdown-sync.test.ts
+++ b/src/studio/bridge/bridge-markdown-sync.test.ts
@@ -130,20 +130,15 @@ Deno.test("computeTextDiff: whitespace normalization (the real echo-back scenari
 });
 
 // ---------------------------------------------------------------------------
-// handleMarkdownLocalChange: echo-back guard
+// handleMarkdownLocalChange: state updates and Yjs sync
 // ---------------------------------------------------------------------------
 
-Deno.test("handleMarkdownLocalChange: syncs to Yjs when connected and no remote content pending", () => {
+Deno.test("handleMarkdownLocalChange: syncs to Yjs when connected", () => {
   resetState();
 
-  // Track whether syncLocalChangeToYText would be called by checking
-  // state changes that happen unconditionally
   editorState.markdownYjsConnected = true;
-  editorState.markdownLastRemoteContent = null;
   editorState.markdownCurrentContent = "old content";
 
-  // We can't easily mock syncLocalChangeToYText without Yjs being set up,
-  // but we CAN verify that the state is correctly updated
   handleMarkdownLocalChange("new body content", "new body content");
 
   assertEquals(editorState.markdownCurrentContent, "new body content");
@@ -152,23 +147,20 @@ Deno.test("handleMarkdownLocalChange: syncs to Yjs when connected and no remote 
   cleanupTimers();
 });
 
-Deno.test("handleMarkdownLocalChange: does NOT sync to Yjs when markdownLastRemoteContent is set", () => {
+Deno.test("handleMarkdownLocalChange: always syncs to Yjs even during remote update window", () => {
   resetState();
 
   editorState.markdownYjsConnected = true;
   editorState.markdownLastRemoteContent = "remote content being applied";
   editorState.markdownCurrentContent = "old content";
 
-  // When markdownLastRemoteContent is set, Lexical's normalization
-  // output should NOT be pushed back to Yjs. The state should still
-  // update locally, but the Yjs sync call should be skipped.
-  handleMarkdownLocalChange("normalized content", "normalized content");
+  // Echo-back prevention is handled UPSTREAM by the Lexical update listener
+  // (which returns early when markdownApplyingRemoteUpdate is true).
+  // handleMarkdownLocalChange always syncs to Yjs to avoid dropping edits.
+  handleMarkdownLocalChange("user edit during window", "user edit during window");
 
-  // State updates should still happen
-  assertEquals(editorState.markdownCurrentContent, "normalized content");
+  assertEquals(editorState.markdownCurrentContent, "user edit during window");
   assertEquals(editorState.markdownHasUnsavedChanges, true);
-  // markdownLastRemoteContent should NOT have been cleared by this function
-  assertEquals(editorState.markdownLastRemoteContent, "remote content being applied");
 
   cleanupTimers();
 });
@@ -177,7 +169,6 @@ Deno.test("handleMarkdownLocalChange: does NOT sync when Yjs is disconnected", (
   resetState();
 
   editorState.markdownYjsConnected = false;
-  editorState.markdownLastRemoteContent = null;
   editorState.markdownCurrentContent = "old content";
 
   handleMarkdownLocalChange("new content", "new content");

--- a/src/studio/bridge/bridge-markdown-sync.test.ts
+++ b/src/studio/bridge/bridge-markdown-sync.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for markdown content sync: computeTextDiff and echo-back guard.
+ *
+ * These tests prove that:
+ * 1. computeTextDiff produces correct minimal diffs
+ * 2. handleMarkdownLocalChange guards against Yjs echo-back when
+ *    markdownLastRemoteContent is set (i.e. during remote update processing)
+ * 3. handleMarkdownLocalChange DOES sync to Yjs for genuine local edits
+ */
+
+import { assertEquals } from "@std/assert";
+import { setConfigForTest } from "./bridge-config.ts";
+import { editorState } from "./bridge-editor-state.ts";
+import { computeTextDiff, handleMarkdownLocalChange } from "./bridge-markdown-core.ts";
+
+// ---------------------------------------------------------------------------
+// Browser API polyfills for Deno test environment
+// ---------------------------------------------------------------------------
+
+if (typeof globalThis.requestAnimationFrame === "undefined") {
+  (globalThis as any).requestAnimationFrame = (cb: () => void) => setTimeout(cb, 0);
+}
+if (typeof globalThis.cancelAnimationFrame === "undefined") {
+  (globalThis as any).cancelAnimationFrame = (id: number) => clearTimeout(id);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetState(): void {
+  // Clear any pending timers from previous tests
+  if (editorState.markdownSyncTimer) {
+    clearTimeout(editorState.markdownSyncTimer);
+  }
+  if (editorState.markdownSelectionOverlayRenderFrame) {
+    cancelAnimationFrame(editorState.markdownSelectionOverlayRenderFrame);
+  }
+  setConfigForTest({ pagePath: "test.md", pageId: "test-id", projectId: "proj-id" });
+  editorState.markdownCurrentContent = "";
+  editorState.markdownCurrentEditorContent = "";
+  editorState.markdownHasUnsavedChanges = false;
+  editorState.markdownYjsConnected = false;
+  editorState.markdownLastRemoteContent = null;
+  editorState.markdownApplyingRemoteUpdate = false;
+  editorState.markdownFrontmatter = "";
+  editorState.markdownRawBlocks = [];
+  editorState.markdownSyncTimer = null;
+  editorState.markdownSelectionOverlayRenderFrame = null;
+  editorState.markdownFileId = "test-file";
+}
+
+function cleanupTimers(): void {
+  if (editorState.markdownSyncTimer) {
+    clearTimeout(editorState.markdownSyncTimer);
+    editorState.markdownSyncTimer = null;
+  }
+  if (editorState.markdownSelectionOverlayRenderFrame) {
+    cancelAnimationFrame(editorState.markdownSelectionOverlayRenderFrame);
+    editorState.markdownSelectionOverlayRenderFrame = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// computeTextDiff
+// ---------------------------------------------------------------------------
+
+Deno.test("computeTextDiff: identical strings produce no-op diff", () => {
+  const diff = computeTextDiff("hello world", "hello world");
+  assertEquals(diff.index, 11);
+  assertEquals(diff.deleteCount, 0);
+  assertEquals(diff.insertText, "");
+});
+
+Deno.test("computeTextDiff: appending text", () => {
+  const diff = computeTextDiff("hello", "hello world");
+  assertEquals(diff.index, 5);
+  assertEquals(diff.deleteCount, 0);
+  assertEquals(diff.insertText, " world");
+});
+
+Deno.test("computeTextDiff: deleting text", () => {
+  const diff = computeTextDiff("hello world", "hello");
+  assertEquals(diff.index, 5);
+  assertEquals(diff.deleteCount, 6);
+  assertEquals(diff.insertText, "");
+});
+
+Deno.test("computeTextDiff: replacing text in the middle", () => {
+  const diff = computeTextDiff("hello world", "hello there");
+  assertEquals(diff.index, 6);
+  assertEquals(diff.deleteCount, 5);
+  assertEquals(diff.insertText, "there");
+});
+
+Deno.test("computeTextDiff: inserting in the middle", () => {
+  const diff = computeTextDiff("abcdef", "abcXYZdef");
+  assertEquals(diff.index, 3);
+  assertEquals(diff.deleteCount, 0);
+  assertEquals(diff.insertText, "XYZ");
+});
+
+Deno.test("computeTextDiff: empty to non-empty", () => {
+  const diff = computeTextDiff("", "hello");
+  assertEquals(diff.index, 0);
+  assertEquals(diff.deleteCount, 0);
+  assertEquals(diff.insertText, "hello");
+});
+
+Deno.test("computeTextDiff: non-empty to empty", () => {
+  const diff = computeTextDiff("hello", "");
+  assertEquals(diff.index, 0);
+  assertEquals(diff.deleteCount, 5);
+  assertEquals(diff.insertText, "");
+});
+
+Deno.test("computeTextDiff: whitespace normalization (the real echo-back scenario)", () => {
+  // Lexical might normalize "- item1\n- item2" to "- item1\n\n- item2"
+  const original = "# Title\n\n- item1\n- item2\n";
+  const normalized = "# Title\n\n- item1\n\n- item2\n";
+  const diff = computeTextDiff(original, normalized);
+  // Should detect the inserted newline
+  assertEquals(diff.insertText.includes("\n"), true);
+  assertEquals(diff.deleteCount >= 0, true);
+  // Applying this diff to original should produce normalized
+  const result = original.slice(0, diff.index) +
+    diff.insertText +
+    original.slice(diff.index + diff.deleteCount);
+  assertEquals(result, normalized);
+});
+
+// ---------------------------------------------------------------------------
+// handleMarkdownLocalChange: echo-back guard
+// ---------------------------------------------------------------------------
+
+Deno.test("handleMarkdownLocalChange: syncs to Yjs when connected and no remote content pending", () => {
+  resetState();
+
+  // Track whether syncLocalChangeToYText would be called by checking
+  // state changes that happen unconditionally
+  editorState.markdownYjsConnected = true;
+  editorState.markdownLastRemoteContent = null;
+  editorState.markdownCurrentContent = "old content";
+
+  // We can't easily mock syncLocalChangeToYText without Yjs being set up,
+  // but we CAN verify that the state is correctly updated
+  handleMarkdownLocalChange("new body content", "new body content");
+
+  assertEquals(editorState.markdownCurrentContent, "new body content");
+  assertEquals(editorState.markdownHasUnsavedChanges, true);
+
+  cleanupTimers();
+});
+
+Deno.test("handleMarkdownLocalChange: does NOT sync to Yjs when markdownLastRemoteContent is set", () => {
+  resetState();
+
+  editorState.markdownYjsConnected = true;
+  editorState.markdownLastRemoteContent = "remote content being applied";
+  editorState.markdownCurrentContent = "old content";
+
+  // When markdownLastRemoteContent is set, Lexical's normalization
+  // output should NOT be pushed back to Yjs. The state should still
+  // update locally, but the Yjs sync call should be skipped.
+  handleMarkdownLocalChange("normalized content", "normalized content");
+
+  // State updates should still happen
+  assertEquals(editorState.markdownCurrentContent, "normalized content");
+  assertEquals(editorState.markdownHasUnsavedChanges, true);
+  // markdownLastRemoteContent should NOT have been cleared by this function
+  assertEquals(editorState.markdownLastRemoteContent, "remote content being applied");
+
+  cleanupTimers();
+});
+
+Deno.test("handleMarkdownLocalChange: does NOT sync when Yjs is disconnected", () => {
+  resetState();
+
+  editorState.markdownYjsConnected = false;
+  editorState.markdownLastRemoteContent = null;
+  editorState.markdownCurrentContent = "old content";
+
+  handleMarkdownLocalChange("new content", "new content");
+
+  assertEquals(editorState.markdownCurrentContent, "new content");
+  assertEquals(editorState.markdownHasUnsavedChanges, true);
+
+  cleanupTimers();
+});
+
+Deno.test("handleMarkdownLocalChange: skips when content matches current", () => {
+  resetState();
+
+  editorState.markdownCurrentContent = "same content";
+
+  handleMarkdownLocalChange("body", "same content");
+
+  // Should not have changed unsaved changes flag
+  assertEquals(editorState.markdownHasUnsavedChanges, false);
+});
+
+Deno.test("handleMarkdownLocalChange: non-string content is ignored", () => {
+  resetState();
+
+  editorState.markdownCurrentContent = "original";
+
+  // @ts-expect-error: testing runtime guard
+  handleMarkdownLocalChange(null, null);
+
+  assertEquals(editorState.markdownCurrentContent, "original");
+  assertEquals(editorState.markdownHasUnsavedChanges, false);
+});

--- a/src/studio/bridge/bridge-markdown-yjs.test.ts
+++ b/src/studio/bridge/bridge-markdown-yjs.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for bridge-markdown-yjs: dispose cleanup and syncLocalChangeToYText.
+ *
+ * These tests prove that:
+ * 1. disposeMarkdownYjs resets ALL echo-back guard state
+ * 2. syncLocalChangeToYText is a no-op when Yjs is not connected
+ * 3. State is clean after dispose so re-entering edit mode works correctly
+ */
+
+import { assertEquals } from "@std/assert";
+import { setConfigForTest } from "./bridge-config.ts";
+import { editorState } from "./bridge-editor-state.ts";
+import { disposeMarkdownYjs, syncLocalChangeToYText } from "./bridge-markdown-yjs.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetState(): void {
+  setConfigForTest({ pagePath: "test.md", pageId: "test-id", projectId: "proj-id" });
+}
+
+// ---------------------------------------------------------------------------
+// disposeMarkdownYjs: state cleanup
+// ---------------------------------------------------------------------------
+
+Deno.test("disposeMarkdownYjs: resets echo-back guard state", () => {
+  resetState();
+
+  // Simulate state that would exist during active Yjs session
+  editorState.markdownLastRemoteContent = "some remote content";
+  editorState.markdownApplyingRemoteUpdate = true;
+  editorState.markdownYjsConnected = true;
+  editorState.markdownPendingSelection = { start: 0, end: 5 };
+
+  disposeMarkdownYjs();
+
+  // All echo-back guard state must be reset
+  assertEquals(editorState.markdownLastRemoteContent, null);
+  assertEquals(editorState.markdownApplyingRemoteUpdate, false);
+  assertEquals(editorState.markdownYjsConnected, false);
+  assertEquals(editorState.markdownPendingSelection, null);
+});
+
+Deno.test("disposeMarkdownYjs: resets Yjs connection state", () => {
+  resetState();
+
+  editorState.markdownYjsConnected = true;
+  editorState.markdownYjsY = {} as any;
+
+  disposeMarkdownYjs();
+
+  assertEquals(editorState.markdownYDoc, null);
+  assertEquals(editorState.markdownYProvider, null);
+  assertEquals(editorState.markdownYText, null);
+  assertEquals(editorState.markdownYjsConnected, false);
+  assertEquals(editorState.markdownYjsY, null);
+});
+
+Deno.test("disposeMarkdownYjs: increments setupId to invalidate stale callbacks", () => {
+  resetState();
+
+  const before = editorState.markdownYjsSetupId;
+  disposeMarkdownYjs();
+  const after = editorState.markdownYjsSetupId;
+
+  assertEquals(after, before + 1);
+});
+
+Deno.test("disposeMarkdownYjs: is safe to call when already disposed", () => {
+  resetState();
+
+  // All Yjs state is already null/false
+  editorState.markdownYDoc = null;
+  editorState.markdownYProvider = null;
+  editorState.markdownYText = null;
+  editorState.markdownYjsConnected = false;
+
+  // Should not throw
+  disposeMarkdownYjs();
+
+  assertEquals(editorState.markdownYDoc, null);
+  assertEquals(editorState.markdownYjsConnected, false);
+});
+
+// ---------------------------------------------------------------------------
+// syncLocalChangeToYText: guards
+// ---------------------------------------------------------------------------
+
+Deno.test("syncLocalChangeToYText: no-op when YText is null", () => {
+  resetState();
+
+  editorState.markdownYText = null;
+  editorState.markdownYDoc = null;
+
+  // Should not throw
+  syncLocalChangeToYText("some content");
+});
+
+Deno.test("syncLocalChangeToYText: no-op when YDoc is null", () => {
+  resetState();
+
+  editorState.markdownYText = {
+    length: 0,
+    insert: () => {},
+    delete: () => {},
+    toString: () => "",
+    observe: () => {},
+  };
+  editorState.markdownYDoc = null;
+
+  syncLocalChangeToYText("some content");
+
+  // Clean up
+  editorState.markdownYText = null;
+});
+
+Deno.test("syncLocalChangeToYText: no-op when content matches Y.Text", () => {
+  resetState();
+
+  const content = "matching content";
+  editorState.markdownYText = {
+    length: content.length,
+    insert: () => {
+      throw new Error("insert should not be called");
+    },
+    delete: () => {
+      throw new Error("delete should not be called");
+    },
+    toString: () => content,
+    observe: () => {},
+  };
+  editorState.markdownYDoc = {
+    getText: () => editorState.markdownYText!,
+    destroy: () => {},
+    transact: (fn: () => void) => fn(),
+  };
+
+  // Same content — should be a no-op
+  syncLocalChangeToYText(content);
+
+  // Clean up
+  editorState.markdownYText = null;
+  editorState.markdownYDoc = null;
+});
+
+Deno.test("syncLocalChangeToYText: applies diff when content differs", () => {
+  resetState();
+
+  const operations: Array<{ op: string; args: any[] }> = [];
+  const currentContent = "hello world";
+
+  editorState.markdownYText = {
+    length: currentContent.length,
+    insert: (index: number, text: string) => {
+      operations.push({ op: "insert", args: [index, text] });
+    },
+    delete: (index: number, len: number) => {
+      operations.push({ op: "delete", args: [index, len] });
+    },
+    toString: () => currentContent,
+    observe: () => {},
+  };
+  editorState.markdownYDoc = {
+    getText: () => editorState.markdownYText!,
+    destroy: () => {},
+    transact: (fn: () => void, _origin?: unknown) => fn(),
+  };
+
+  syncLocalChangeToYText("hello there");
+
+  // Should have produced delete + insert operations for "world" -> "there"
+  assertEquals(operations.length >= 1, true);
+
+  // Verify the operations would produce the correct result
+  const hasDelete = operations.some((op) => op.op === "delete");
+  const hasInsert = operations.some((op) => op.op === "insert" && op.args[1] === "there");
+  assertEquals(hasDelete, true);
+  assertEquals(hasInsert, true);
+
+  // Clean up
+  editorState.markdownYText = null;
+  editorState.markdownYDoc = null;
+});

--- a/src/studio/bridge/bridge-markdown-yjs.ts
+++ b/src/studio/bridge/bridge-markdown-yjs.ts
@@ -100,6 +100,12 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
       const WebsocketProvider = modules[1].WebsocketProvider;
       state.markdownYjsY = Y as unknown as import("./bridge-editor-state.ts").YjsModule;
 
+      console.debug("[StudioBridge] Yjs setup:", {
+        wsUrl: config.wsUrl,
+        guid: config.guid,
+        fileId: config.fileId,
+      });
+
       const doc = new Y.Doc({ guid: config.guid });
       // Cookie auth: authToken cookie on .veryfront.com is sent automatically
       // with the WebSocket upgrade request. No explicit token param needed.
@@ -115,12 +121,23 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
 
       // Filter non-binary messages to prevent y-websocket parse errors
       provider.on("status", (event: { status: string }) => {
-        console.debug("[StudioBridge] Yjs status:", event.status);
-        if (event.status === "connected" && provider.ws) {
+        console.debug("[StudioBridge] Yjs status:", event.status, {
+          hasWs: !!provider.ws,
+          wsReadyState: provider.ws?.readyState,
+        });
+        if (event.status !== "connected") {
+          state.markdownYjsConnected = false;
+          return;
+        }
+        if (provider.ws) {
           const ws = provider.ws;
           const origOnMessage = ws.onmessage;
           ws.onmessage = function (wsEvent: MessageEvent) {
             if (typeof wsEvent.data === "string") {
+              console.debug(
+                "[StudioBridge] Yjs filtered string message:",
+                (wsEvent.data as string).slice(0, 120),
+              );
               return;
             }
             if (origOnMessage) {
@@ -247,19 +264,27 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
       let ytextObserverRegistered = false;
 
       provider.on("sync", (synced: boolean) => {
-        if (synced && !state.markdownYjsConnected) {
+        console.debug("[StudioBridge] Yjs sync:", {
+          synced,
+          ytextLength: ytext.length,
+          contentPreview: ytext.toString().slice(0, 80),
+        });
+        if (!synced) {
+          state.markdownYjsConnected = false;
+          return;
+        }
+        if (!state.markdownYjsConnected) {
           state.markdownYjsConnected = true;
 
           const ytextContent = ytext.toString();
           if (
             state.markdownHasUnsavedChanges &&
-            state.markdownCurrentContent &&
             state.markdownCurrentContent !== ytextContent
           ) {
             // User made actual edits before sync completed - push to Y.Text
             syncLocalChangeToYText(state.markdownCurrentContent);
-          } else if (ytextContent) {
-            // No local edits or same content - seed editor from Y.Text
+          } else {
+            // No conflicting local edits - seed editor from Y.Text (including empty content)
             applyMarkdownContent(ytextContent);
           }
 
@@ -281,11 +306,18 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
           if (!ytextObserverRegistered) {
             ytextObserverRegistered = true;
             ytext.observe((event: any) => {
-              if (event.transaction.origin === LEXICAL_YJS_ORIGIN) {
+              const origin = event.transaction.origin;
+              if (origin === LEXICAL_YJS_ORIGIN) {
                 return;
               }
               const fullContent = ytext.toString();
-              if (fullContent === state.markdownCurrentContent) {
+              const contentMatch = fullContent === state.markdownCurrentContent;
+              console.debug("[StudioBridge] Yjs Y.Text observer:", {
+                origin: String(origin),
+                contentMatch,
+                ytextLength: fullContent.length,
+              });
+              if (contentMatch) {
                 return;
               }
               applyMarkdownContent(fullContent);
@@ -368,6 +400,7 @@ export function disposeMarkdownYjs(): void {
   state.markdownYjsSetupId++;
 
   if (state.markdownYProvider) {
+    state.markdownYProvider.awareness.setLocalStateField("selection", null);
     state.markdownYProvider.disconnect();
     state.markdownYProvider.destroy();
     state.markdownYProvider = null;
@@ -380,4 +413,7 @@ export function disposeMarkdownYjs(): void {
   state.markdownYText = null;
   state.markdownYjsConnected = false;
   state.markdownYjsY = null;
+  state.markdownPendingSelection = null;
+  setMarkdownPresence([]);
+  setMarkdownSelections([]);
 }

--- a/src/studio/bridge/bridge-markdown-yjs.ts
+++ b/src/studio/bridge/bridge-markdown-yjs.ts
@@ -118,9 +118,17 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
       state.markdownYDoc = doc;
       state.markdownYProvider = provider;
       state.markdownYText = ytext;
+      const isCurrentSetup = (): boolean =>
+        setupId === state.markdownYjsSetupId &&
+        state.markdownYProvider === provider &&
+        state.markdownYDoc === doc &&
+        state.markdownYText === ytext;
 
       // Filter non-binary messages to prevent y-websocket parse errors
       provider.on("status", (event: { status: string }) => {
+        if (!isCurrentSetup()) {
+          return;
+        }
         console.debug("[StudioBridge] Yjs status:", event.status, {
           hasWs: !!provider.ws,
           wsReadyState: provider.ws?.readyState,
@@ -196,6 +204,9 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
        * selections, and push both to the editor UI.
        */
       function syncAwareness(): void {
+        if (!isCurrentSetup()) {
+          return;
+        }
         const states = Array.from(
           provider.awareness.getStates().entries(),
         ) as [number, Record<string, unknown>][];
@@ -264,6 +275,9 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
       let ytextObserverRegistered = false;
 
       provider.on("sync", (synced: boolean) => {
+        if (!isCurrentSetup()) {
+          return;
+        }
         console.debug("[StudioBridge] Yjs sync:", {
           synced,
           ytextLength: ytext.length,
@@ -306,6 +320,9 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
           if (!ytextObserverRegistered) {
             ytextObserverRegistered = true;
             ytext.observe((event: any) => {
+              if (!isCurrentSetup()) {
+                return;
+              }
               const origin = event.transaction.origin;
               if (origin === LEXICAL_YJS_ORIGIN) {
                 return;
@@ -414,6 +431,8 @@ export function disposeMarkdownYjs(): void {
   state.markdownYjsConnected = false;
   state.markdownYjsY = null;
   state.markdownPendingSelection = null;
+  state.markdownLastRemoteContent = null;
+  state.markdownApplyingRemoteUpdate = false;
   setMarkdownPresence([]);
   setMarkdownSelections([]);
 }

--- a/src/studio/bridge/bridge-message-handler.test.ts
+++ b/src/studio/bridge/bridge-message-handler.test.ts
@@ -42,7 +42,9 @@ let reloadCallCount = 0;
 
 function resetState(pagePath = "test.md"): void {
   reloadCallCount = 0;
-  (globalThis as any).location.reload = () => { reloadCallCount++; };
+  (globalThis as any).location.reload = () => {
+    reloadCallCount++;
+  };
   setConfigForTest({ pagePath, pageId: "test-id", projectId: "proj-id" });
   editorState.markdownFileId = "file-123";
   editorState.markdownCurrentContent = "";

--- a/src/studio/bridge/bridge-message-handler.test.ts
+++ b/src/studio/bridge/bridge-message-handler.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for bridge-message-handler: contentChanged handler branching logic.
+ *
+ * These tests prove that:
+ * 1. contentChanged in non-edit mode triggers page reload
+ * 2. contentChanged in edit mode with Yjs connected does NOT apply content
+ *    (Yjs is the source of truth when connected)
+ * 3. contentChanged in edit mode with Yjs disconnected applies content as fallback
+ * 4. contentChanged with fileId mismatch is ignored
+ * 5. contentChanged on non-markdown pages is ignored
+ *
+ * We test the handler's branching logic by directly calling handleStudioMessage
+ * with a synthetic MessageEvent. The handler delegates to isFromStudio() which
+ * checks origin, so we construct events from a valid origin.
+ */
+
+import { assertEquals } from "@std/assert";
+import { setConfigForTest } from "./bridge-config.ts";
+import { editorState } from "./bridge-editor-state.ts";
+import { handleStudioMessage } from "./bridge-message-handler.ts";
+
+// ---------------------------------------------------------------------------
+// Browser API polyfills for Deno test environment
+// ---------------------------------------------------------------------------
+
+if (typeof globalThis.window === "undefined") {
+  (globalThis as any).window = globalThis;
+}
+if (typeof globalThis.location === "undefined") {
+  (globalThis as any).location = {
+    href: "https://test.veryfront.com/test",
+    hostname: "test.veryfront.com",
+    reload: () => {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let reloadCallCount = 0;
+
+function resetState(pagePath = "test.md"): void {
+  reloadCallCount = 0;
+  (globalThis as any).location.reload = () => { reloadCallCount++; };
+  setConfigForTest({ pagePath, pageId: "test-id", projectId: "proj-id" });
+  editorState.markdownFileId = "file-123";
+  editorState.markdownCurrentContent = "";
+  editorState.markdownCurrentEditorContent = "";
+  editorState.markdownApplyingRemoteUpdate = false;
+  editorState.markdownLastRemoteContent = null;
+  editorState.markdownYjsConnected = false;
+  editorState.markdownEditorRoot = null;
+  editorState.markdownLexicalApi = null;
+  editorState.markdownLexicalRenderedContent = null;
+}
+
+function makeEvent(data: Record<string, unknown>): MessageEvent {
+  return {
+    data,
+    origin: "https://veryfront.com",
+    source: null,
+    ports: [],
+  } as unknown as MessageEvent;
+}
+
+// ---------------------------------------------------------------------------
+// contentChanged: page type guard
+// ---------------------------------------------------------------------------
+
+Deno.test("contentChanged: ignored on non-markdown pages", () => {
+  resetState("page.tsx"); // Not a markdown page
+
+  const event = makeEvent({
+    action: "contentChanged",
+    fileId: "file-123",
+    content: "new content",
+  });
+
+  // Should not throw or have any side effects
+  handleStudioMessage(event);
+
+  // Content should not have been modified
+  assertEquals(editorState.markdownCurrentContent, "");
+});
+
+// ---------------------------------------------------------------------------
+// contentChanged: fileId mismatch
+// ---------------------------------------------------------------------------
+
+Deno.test("contentChanged: ignored when fileId does not match", () => {
+  resetState();
+
+  const event = makeEvent({
+    action: "contentChanged",
+    fileId: "different-file-id",
+    content: "new content",
+  });
+
+  handleStudioMessage(event);
+
+  // Content should not have been modified
+  assertEquals(editorState.markdownCurrentContent, "");
+});
+
+// ---------------------------------------------------------------------------
+// contentChanged: non-edit mode (no editor root displayed)
+// ---------------------------------------------------------------------------
+
+Deno.test("contentChanged: non-edit mode reloads (editorRoot not displayed)", () => {
+  resetState();
+
+  // Simulate non-edit mode: no editor root at all
+  editorState.markdownEditorRoot = null;
+
+  const event = makeEvent({
+    action: "contentChanged",
+    fileId: "file-123",
+    content: "updated markdown content",
+  });
+
+  handleStudioMessage(event);
+
+  // In non-edit mode, reload should have been called
+  assertEquals(reloadCallCount, 1);
+
+  // Content should NOT have been applied via applyMarkdownContent
+  assertEquals(editorState.markdownCurrentContent, "");
+});
+
+// ---------------------------------------------------------------------------
+// contentChanged: edit mode with Yjs connected
+// ---------------------------------------------------------------------------
+
+Deno.test("contentChanged: edit mode with Yjs connected does NOT apply content", () => {
+  resetState();
+
+  // Simulate edit mode: editor root exists and is displayed
+  const fakeRoot = { style: { display: "block" } } as unknown as HTMLElement;
+  editorState.markdownEditorRoot = fakeRoot;
+  editorState.markdownYjsConnected = true;
+  editorState.markdownCurrentContent = "original content";
+
+  const event = makeEvent({
+    action: "contentChanged",
+    fileId: "file-123",
+    content: "content from postMessage",
+  });
+
+  handleStudioMessage(event);
+
+  // When Yjs is connected, contentChanged should NOT apply content
+  // because Yjs is the authoritative source
+  assertEquals(editorState.markdownCurrentContent, "original content");
+});
+
+// ---------------------------------------------------------------------------
+// contentChanged: edit mode with Yjs disconnected
+// ---------------------------------------------------------------------------
+
+Deno.test("contentChanged: edit mode with Yjs disconnected applies content", () => {
+  resetState();
+
+  // Simulate edit mode: editor root exists and is displayed
+  const fakeRoot = { style: { display: "block" } } as unknown as HTMLElement;
+  editorState.markdownEditorRoot = fakeRoot;
+  editorState.markdownYjsConnected = false;
+  editorState.markdownCurrentContent = "original content";
+
+  const event = makeEvent({
+    action: "contentChanged",
+    fileId: "file-123",
+    content: "content from postMessage",
+  });
+
+  handleStudioMessage(event);
+
+  // When Yjs is disconnected, contentChanged SHOULD apply content
+  // via applyMarkdownContent. Since we don't have Lexical set up,
+  // it will take the textarea fallback path, but markdownCurrentContent
+  // should be updated.
+  assertEquals(editorState.markdownCurrentContent, "content from postMessage");
+});
+
+// ---------------------------------------------------------------------------
+// contentChanged: missing content
+// ---------------------------------------------------------------------------
+
+Deno.test("contentChanged: missing content field in non-edit mode still reloads", () => {
+  resetState();
+
+  // Non-edit mode (no editor root)
+  editorState.markdownEditorRoot = null;
+
+  const event = makeEvent({
+    action: "contentChanged",
+    fileId: "file-123",
+    // content is missing (undefined)
+  });
+
+  // Should not throw, and should reload since in non-edit mode
+  handleStudioMessage(event);
+
+  assertEquals(reloadCallCount, 1);
+  assertEquals(editorState.markdownCurrentContent, "");
+});
+
+Deno.test("contentChanged: missing content field in edit mode does not apply", () => {
+  resetState();
+
+  // Edit mode
+  const fakeRoot = { style: { display: "block" } } as unknown as HTMLElement;
+  editorState.markdownEditorRoot = fakeRoot;
+  editorState.markdownYjsConnected = false;
+  editorState.markdownCurrentContent = "original";
+
+  const event = makeEvent({
+    action: "contentChanged",
+    fileId: "file-123",
+    // content is missing
+  });
+
+  handleStudioMessage(event);
+
+  // Missing content should not apply anything
+  assertEquals(editorState.markdownCurrentContent, "original");
+  assertEquals(reloadCallCount, 0);
+});
+
+Deno.test("contentChanged: null content in edit mode does NOT apply", () => {
+  resetState();
+
+  const fakeRoot = { style: { display: "block" } } as unknown as HTMLElement;
+  editorState.markdownEditorRoot = fakeRoot;
+  editorState.markdownYjsConnected = false;
+  editorState.markdownCurrentContent = "original";
+
+  const event = makeEvent({
+    action: "contentChanged",
+    fileId: "file-123",
+    content: null,
+  });
+
+  handleStudioMessage(event);
+
+  // null content should NOT be applied even in edit mode with Yjs disconnected
+  assertEquals(editorState.markdownCurrentContent, "original");
+});

--- a/src/studio/bridge/bridge-message-handler.ts
+++ b/src/studio/bridge/bridge-message-handler.ts
@@ -17,6 +17,7 @@ import {
   showSelectionOverlay,
 } from "./bridge-inspector.ts";
 import { captureMultipleSections, captureScreenshot } from "./bridge-screenshot.ts";
+import { applyMarkdownContent } from "./bridge-markdown-editor.ts";
 import { replaceYTextContent, writeToYText } from "./bridge-markdown-yjs.ts";
 
 export function handleStudioMessage(event: MessageEvent): void {
@@ -112,6 +113,27 @@ export function handleStudioMessage(event: MessageEvent): void {
           position: typeof message.position === "number" ? message.position : 0,
           origin: "agent-write",
         });
+      }
+      return;
+    }
+
+    case "contentChanged": {
+      if (!isMarkdownPage()) return;
+      if (
+        message.fileId && editorState.markdownFileId &&
+        message.fileId !== editorState.markdownFileId
+      ) {
+        return;
+      }
+
+      const content = typeof message.content === "string" ? message.content : null;
+      const isEditMode = !!editorState.markdownEditorRoot &&
+        editorState.markdownEditorRoot.style.display === "block";
+
+      if (isEditMode && content !== null) {
+        applyMarkdownContent(content);
+      } else {
+        window.location.reload();
       }
       return;
     }

--- a/src/studio/bridge/bridge-message-handler.ts
+++ b/src/studio/bridge/bridge-message-handler.ts
@@ -90,13 +90,29 @@ export function handleStudioMessage(event: MessageEvent): void {
         return;
       }
       if (editorState.markdownSaveInProgress) {
-        setMarkdownPersistStatus(message.status || "saved");
-        if (message.status === "saved") {
+        const status = message.status || "saved";
+        if (status === "saved") {
+          const requestedContent = editorState.markdownSaveRequestedContent;
           editorState.markdownSaveInProgress = false;
-          editorState.markdownHasUnsavedChanges = false;
-        } else if (message.status === "error") {
+          editorState.markdownSaveRequestedContent = null;
+
+          // Only clear dirty state when current content still matches the request we saved.
+          if (
+            typeof requestedContent === "string" &&
+            editorState.markdownCurrentContent !== requestedContent
+          ) {
+            setMarkdownPersistStatus("saving");
+          } else {
+            editorState.markdownHasUnsavedChanges = false;
+            setMarkdownPersistStatus("saved");
+          }
+        } else if (status === "error") {
           editorState.markdownSaveInProgress = false;
+          editorState.markdownSaveRequestedContent = null;
+          setMarkdownPersistStatus("error");
           // Keep markdownHasUnsavedChanges = true so user can retry
+        } else {
+          setMarkdownPersistStatus(status);
         }
       }
       return;
@@ -130,8 +146,10 @@ export function handleStudioMessage(event: MessageEvent): void {
       const isEditMode = !!editorState.markdownEditorRoot &&
         editorState.markdownEditorRoot.style.display === "block";
 
-      if (isEditMode && content !== null) {
-        applyMarkdownContent(content);
+      if (isEditMode) {
+        if (content !== null && !editorState.markdownYjsConnected) {
+          applyMarkdownContent(content);
+        }
       } else {
         window.location.reload();
       }

--- a/src/studio/bridge/bridge-selection.ts
+++ b/src/studio/bridge/bridge-selection.ts
@@ -405,6 +405,10 @@ export function scheduleMarkdownSelectionSync(): void {
   state.markdownSelectionSyncTimer = setTimeout(function () {
     const selection = getMarkdownEditorSelection();
     if (!selection) {
+      state.markdownPendingSelection = null;
+      if (state.markdownYProvider) {
+        state.markdownYProvider.awareness.setLocalStateField("selection", null);
+      }
       return;
     }
 

--- a/src/studio/bridge/bridge-selection.ts
+++ b/src/studio/bridge/bridge-selection.ts
@@ -447,6 +447,12 @@ export function scheduleMarkdownSelectionSync(): void {
 }
 
 export function clearMarkdownSelectionSync(): void {
+  if (state.markdownSelectionSyncTimer) {
+    clearTimeout(state.markdownSelectionSyncTimer);
+    state.markdownSelectionSyncTimer = null;
+  }
+  state.markdownPendingSelection = null;
+
   if (state.markdownYProvider) {
     state.markdownYProvider.awareness.setLocalStateField("selection", null);
   }


### PR DESCRIPTION
## Summary
- Add `contentChanged` postMessage handler so Studio can push content updates directly to the preview (reload in non-edit mode, apply to Lexical in edit mode)
- Fix echo-back race condition where Lexical's markdown normalization (whitespace, list rebalancing) was syncing back to Yjs, overwriting the original formatting from Monaco
- Add Yjs diagnostic logging at connection, sync, observer, and message filter points for debugging sync issues
- Clean up selection state and awareness properly on Yjs disposal

## Test plan
- [ ] Open markdown file in Advanced Mode, edit in Monaco — preview should reload via `contentChanged`
- [ ] Enter edit mode, check console for `[StudioBridge] Yjs` logs showing connection lifecycle
- [ ] Edit in Lexical, verify Monaco content matches without whitespace drift
- [ ] Confirm no "echo-back" to Yjs during remote updates (only genuine local edits sync)
- [ ] `deno task typecheck` passes