### PR TITLE
chore: release v0.1.42

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [


### PR DESCRIPTION
## Summary
- Version bump to 0.1.42
- Includes fix for offset mapping trailing newline divergence (#502)

## Test plan
- [ ] Verify markdown editor offset mapping works without console warnings
- [ ] Deploy and monitor collaborative cursor positioning