### PR TITLE
fix: standardize cursor offset counting on Range.toString() space

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/studio/bridge/bridge-markdown-editor.ts
+++ b/src/studio/bridge/bridge-markdown-editor.ts
@@ -36,6 +36,7 @@ import {
   buildEditorRenderedMaps,
   clearMarkdownSelectionOverlay,
   clearMarkdownSelectionSync,
+  getDomRenderedText,
   getTextOffsetWithinRoot,
   scheduleMarkdownSelectionOverlayRender,
   scheduleMarkdownSelectionSync,
@@ -139,15 +140,17 @@ export function setupMarkdownLexicalEditor(): void {
         }
 
         let nextContent = "";
-        let renderedText = "";
         update.editorState.read(function () {
           nextContent = markdownModule.$convertToMarkdownString(
             markdownModule.TRANSFORMERS,
             undefined,
             true,
           );
-          renderedText = lexicalModule.$getRoot().getTextContent();
         });
+
+        // Use Range.toString() for rendered text — consistent with
+        // getTextOffsetWithinRoot (1 \n per block boundary).
+        const renderedText = getDomRenderedText(state.markdownEditorSurface);
 
         // Rebuild editor↔rendered offset maps after every edit
         const maps = buildEditorRenderedMaps(nextContent, renderedText);
@@ -349,13 +352,14 @@ export function applyMarkdownContent(content: unknown): void {
       { discrete: true },
     );
 
-    // Build editor↔rendered offset maps from committed state
-    api.editor.getEditorState().read(function () {
-      const renderedText = api.lexicalModule.$getRoot().getTextContent();
+    // Build editor↔rendered offset maps from committed DOM state.
+    // Use Range.toString() — consistent with getTextOffsetWithinRoot.
+    {
+      const renderedText = getDomRenderedText(state.markdownEditorSurface);
       const maps = buildEditorRenderedMaps(editorContent, renderedText);
       state.markdownEditorToRenderedMap = maps.editorToRendered;
       state.markdownRenderedToEditorMap = maps.renderedToEditor;
-    });
+    }
 
     // Reset flags after all synchronous Lexical reconciliation completes.
     // setTimeout(0) is more reliable than queueMicrotask for catching
@@ -376,7 +380,6 @@ export function applyMarkdownContent(content: unknown): void {
       state.markdownPendingLocalReconcile = false;
 
       let nextContent = "";
-      let renderedText = "";
       const reconcileApi = state.markdownLexicalApi;
       reconcileApi.editor.getEditorState().read(function () {
         nextContent = reconcileApi.markdownModule.$convertToMarkdownString(
@@ -384,9 +387,10 @@ export function applyMarkdownContent(content: unknown): void {
           undefined,
           true,
         );
-        renderedText = reconcileApi.lexicalModule.$getRoot().getTextContent();
       });
 
+      // Use Range.toString() — consistent with getTextOffsetWithinRoot.
+      const renderedText = getDomRenderedText(state.markdownEditorSurface);
       const maps = buildEditorRenderedMaps(nextContent, renderedText);
       state.markdownEditorToRenderedMap = maps.editorToRendered;
       state.markdownRenderedToEditorMap = maps.renderedToEditor;

--- a/src/studio/bridge/bridge-selection.ts
+++ b/src/studio/bridge/bridge-selection.ts
@@ -541,7 +541,7 @@ export function resolveMarkdownTextPoint(
       // Target falls within this node
       const nodeStart = cumulative - textLength;
       const localOffset = offset - nodeStart;
-      return { node: node, offset: Math.min(localOffset, textLength) };
+      return { node: node, offset: Math.max(0, Math.min(localOffset, textLength)) };
     }
 
     node = walker.nextNode();

--- a/src/studio/bridge/bridge-selection.ts
+++ b/src/studio/bridge/bridge-selection.ts
@@ -13,6 +13,22 @@ import { DATA_VF_IGNORE } from "./bridge-constants.ts";
 // Offset helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Return the plain-text content of `root` as seen by `Range.toString()`.
+ * This produces 1 `\n` per block boundary, consistent with
+ * `getTextOffsetWithinRoot` which also uses `Range.toString().length`.
+ */
+export function getDomRenderedText(root: Node | null): string {
+  if (!root) return "";
+  try {
+    const range = document.createRange();
+    range.selectNodeContents(root);
+    return range.toString();
+  } catch {
+    return "";
+  }
+}
+
 export function getTextOffsetWithinRoot(
   root: Node | null,
   targetNode: Node | null,
@@ -496,18 +512,38 @@ export function resolveMarkdownTextPoint(
   rawOffset: number,
 ): { node: Node; offset: number } {
   const offset = Math.max(0, Math.trunc(rawOffset || 0));
+  if (offset === 0) {
+    // Fast path: find the first text node and return offset 0
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    const first = walker.nextNode();
+    return first
+      ? { node: first, offset: 0 }
+      : { node: root, offset: 0 };
+  }
+
+  // Walk text nodes and use Range.toString().length to measure cumulative
+  // offset in the same coordinate space as getTextOffsetWithinRoot.
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
-  let remaining = offset;
+  const measureRange = document.createRange();
+  measureRange.setStart(root, 0);
   let lastTextNode: Node | null = null;
   let node = walker.nextNode();
 
   while (node) {
     lastTextNode = node;
     const textLength = node.textContent ? node.textContent.length : 0;
-    if (remaining <= textLength) {
-      return { node: node, offset: remaining };
+
+    // Measure cumulative Range.toString() offset through end of this node
+    measureRange.setEnd(node, textLength);
+    const cumulative = measureRange.toString().length;
+
+    if (cumulative >= offset) {
+      // Target falls within this node
+      const nodeStart = cumulative - textLength;
+      const localOffset = offset - nodeStart;
+      return { node: node, offset: Math.min(localOffset, textLength) };
     }
-    remaining -= textLength;
+
     node = walker.nextNode();
   }
 


### PR DESCRIPTION
## Summary

- Collaborative cursors (green overlays) appeared at wrong positions in the Lexical preview editor because three offset-counting functions used inconsistent methods (`Range.toString()` vs `$getRoot().getTextContent()` vs `TreeWalker`)
- Added `getDomRenderedText(root)` using `Range.toString()` for consistent rendered text (1 `\n` per block boundary)
- Rewrote `resolveMarkdownTextPoint` to use `Range`-based cumulative offsets instead of `TreeWalker` text-node counting
- Replaced `$getRoot().getTextContent()` with `getDomRenderedText` at 3 call sites in `bridge-markdown-editor.ts`

## Test plan

- [x] `deno task typecheck` — passes
- [x] `deno task test` — all 1193 tests pass
- [ ] Manual: open Studio with two users editing same markdown file, verify cursors align between Monaco and preview
- [ ] Check browser console: `[StudioBridge] Offset mapping divergence` warnings should disappear or be greatly reduced