### PR TITLE
Remove markdown editor toolbar

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/studio/bridge/bridge-editor-state.ts
+++ b/src/studio/bridge/bridge-editor-state.ts
@@ -64,12 +64,7 @@ export const editorState = {
   markdownSyncTimer: null as ReturnType<typeof setTimeout> | null,
   markdownSelectionSyncTimer: null as ReturnType<typeof setTimeout> | null,
 
-  // Persist
-  markdownPersistStatus: null as HTMLElement | null,
-
-  // Presence & selections
-  markdownPresenceRoot: null as HTMLElement | null,
-  markdownSelectionsRoot: null as HTMLElement | null,
+  // Selection overlay
   markdownSelectionOverlayRoot: null as HTMLElement | null,
   markdownOverlaySelections: [] as RemoteSelection[],
   markdownSelectionOverlayRenderFrame: null as number | null,
@@ -146,27 +141,3 @@ export const editorState = {
   markdownPendingSelection: null as { start: number; end: number } | null,
 };
 
-// ---------------------------------------------------------------------------
-// Persist status (lives here with editor state, not bridge-state)
-// ---------------------------------------------------------------------------
-
-export function setMarkdownPersistStatus(status: string): void {
-  if (!editorState.markdownPersistStatus) {
-    return;
-  }
-
-  const nextStatus = status === "saving" || status === "saved" || status === "error"
-    ? status
-    : "saved";
-
-  editorState.markdownPersistStatus.setAttribute("data-state", nextStatus);
-  if (nextStatus === "saving") {
-    editorState.markdownPersistStatus.textContent = "Saving...";
-    return;
-  }
-  if (nextStatus === "error") {
-    editorState.markdownPersistStatus.textContent = "Save failed";
-    return;
-  }
-  editorState.markdownPersistStatus.textContent = "Saved";
-}

--- a/src/studio/bridge/bridge-editor-state.ts
+++ b/src/studio/bridge/bridge-editor-state.ts
@@ -118,8 +118,6 @@ export const editorState = {
   markdownLatestPresenceUsers: [] as PresenceUser[],
   markdownLatestSelections: [] as RemoteSelection[],
   markdownHasUnsavedChanges: false,
-  markdownSaveInProgress: false,
-  markdownSaveRequestedContent: null as string | null,
 
   // Yjs (dynamically imported — typed structurally)
   markdownYDoc: null as {

--- a/src/studio/bridge/bridge-editor-state.ts
+++ b/src/studio/bridge/bridge-editor-state.ts
@@ -138,4 +138,3 @@ export const editorState = {
   markdownYjsY: null as YjsModule | null,
   markdownPendingSelection: null as { start: number; end: number } | null,
 };
-

--- a/src/studio/bridge/bridge-markdown-core.ts
+++ b/src/studio/bridge/bridge-markdown-core.ts
@@ -339,6 +339,7 @@ export function scheduleMarkdownSync(_content: string): void {
       getConfig().pagePath,
       state.markdownCurrentContent,
     );
+    state.markdownHasUnsavedChanges = false;
   }, 120);
 }
 

--- a/src/studio/bridge/bridge-markdown-core.ts
+++ b/src/studio/bridge/bridge-markdown-core.ts
@@ -607,4 +607,3 @@ export function handleMarkdownLocalChange(
   scheduleMarkdownSync(fullContent);
   scheduleMarkdownSelectionOverlayRender();
 }
-

--- a/src/studio/bridge/bridge-markdown-core.ts
+++ b/src/studio/bridge/bridge-markdown-core.ts
@@ -10,7 +10,7 @@
  * function bodies (never at module top-level).
  */
 
-import { editorState as state, setMarkdownPersistStatus } from "./bridge-editor-state.ts";
+import { editorState as state } from "./bridge-editor-state.ts";
 import type { MdxBlock, MdxImportEntry } from "./bridge-state.ts";
 import { getConfig, isMdxPage } from "./bridge-config.ts";
 import { getEditorCallbacks } from "./bridge-editor-callbacks.ts";
@@ -607,38 +607,3 @@ export function handleMarkdownLocalChange(
   scheduleMarkdownSelectionOverlayRender();
 }
 
-export function saveMarkdownContent(): void {
-  if (!state.markdownHasUnsavedChanges) {
-    return;
-  }
-  if (state.markdownSaveInProgress) {
-    return;
-  }
-  const cb = getEditorCallbacks();
-  if (!cb) {
-    return;
-  }
-  state.markdownSaveInProgress = true;
-  state.markdownSaveRequestedContent = state.markdownCurrentContent;
-  setMarkdownPersistStatus("saving");
-  if (state.markdownSyncTimer) {
-    clearTimeout(state.markdownSyncTimer);
-    state.markdownSyncTimer = null;
-  }
-  try {
-    cb.onContentChange(
-      state.markdownFileId,
-      getConfig().pagePath,
-      state.markdownCurrentContent,
-      true,
-    );
-  } catch (err) {
-    state.markdownSaveInProgress = false;
-    state.markdownSaveRequestedContent = null;
-    setMarkdownPersistStatus("error");
-    console.error("[StudioBridge] Save failed:", err);
-  }
-  // markdownHasUnsavedChanges is cleared by setMarkdownPersistState response
-  // from Studio, not here — avoids race where edits between save request
-  // and response would be incorrectly marked as saved.
-}

--- a/src/studio/bridge/bridge-markdown-editor.ts
+++ b/src/studio/bridge/bridge-markdown-editor.ts
@@ -615,14 +615,6 @@ export function ensureMarkdownEditor(): HTMLElement | undefined {
 
   const presence = el("div", "vf-markdown-editor__presence");
   const selections = el("div", "vf-markdown-editor__selections");
-  // In Simple Mode the editor IS the experience — hide Done button.
-  // In Advanced Mode, show Done to return to preview.
-  const exitButton = btn("vf-markdown-editor__exit", "Done", function () {
-    setMarkdownEditMode(false);
-  });
-  if (getConfig().studioMode === "simple") {
-    exitButton.style.display = "none";
-  }
 
   actions.appendChild(status);
   actions.appendChild(presence);
@@ -638,8 +630,6 @@ export function ensureMarkdownEditor(): HTMLElement | undefined {
     debugBtn.style.opacity = "0.6";
     actions.appendChild(debugBtn);
   }
-
-  actions.appendChild(exitButton);
 
   toolbar.appendChild(title);
   toolbar.appendChild(actions);
@@ -1130,6 +1120,11 @@ export function setMarkdownEditMode(enabled: boolean): void {
     state.markdownGlobalListenerCleanups = [];
   }
 
+  // Update floating edit button label to reflect current mode
+  if (state.markdownEditButton) {
+    state.markdownEditButton.textContent = enabled ? "Done" : "Edit";
+  }
+
   const nextUrl = new URL(window.location.href);
   if (enabled) {
     nextUrl.searchParams.set("edit", "true");
@@ -1149,7 +1144,9 @@ export function ensureMarkdownEditButton(): void {
   }
 
   const button = btn("vf-markdown-edit-button", "Edit", function () {
-    setMarkdownEditMode(true);
+    const isEditing = state.markdownEditorRoot &&
+      state.markdownEditorRoot.style.display === "block";
+    setMarkdownEditMode(!isEditing);
   });
 
   document.body.appendChild(button);

--- a/src/studio/bridge/bridge-markdown-editor.ts
+++ b/src/studio/bridge/bridge-markdown-editor.ts
@@ -663,15 +663,15 @@ export function ensureMarkdownEditor(): HTMLElement | undefined {
       toggleMarkdownInlineFormat("underline");
     }),
   );
+  row.appendChild(
+    createInlineButton("S", "strikethrough", function () {
+      toggleMarkdownInlineFormat("strikethrough");
+    }),
+  );
   row.appendChild(createSeparator());
   row.appendChild(
     createInlineButton(String.fromCodePoint(128279), null, function () {
       insertMarkdownLink();
-    }),
-  );
-  row.appendChild(
-    createInlineButton("S", "strikethrough", function () {
-      toggleMarkdownInlineFormat("strikethrough");
     }),
   );
   row.appendChild(

--- a/src/studio/bridge/bridge-markdown-editor.ts
+++ b/src/studio/bridge/bridge-markdown-editor.ts
@@ -643,46 +643,44 @@ export function ensureMarkdownEditor(): HTMLElement | undefined {
     event.preventDefault();
   });
 
-  // -- Inline toolbar rows ---------------------------------------------------
+  // -- Inline toolbar row ----------------------------------------------------
 
-  const row1 = el("div", "vf-markdown-editor__inline-row");
-  row1.appendChild(blockTrigger);
-  row1.appendChild(createSeparator());
-  row1.appendChild(
+  const row = el("div", "vf-markdown-editor__inline-row");
+  row.appendChild(blockTrigger);
+  row.appendChild(createSeparator());
+  row.appendChild(
     createInlineButton("B", "bold", function () {
       toggleMarkdownInlineFormat("bold");
     }),
   );
-  row1.appendChild(
+  row.appendChild(
     createInlineButton("I", "italic", function () {
       toggleMarkdownInlineFormat("italic");
     }),
   );
-  row1.appendChild(
+  row.appendChild(
     createInlineButton("U", "underline", function () {
       toggleMarkdownInlineFormat("underline");
     }),
   );
-
-  const row2 = el("div", "vf-markdown-editor__inline-row");
-  row2.appendChild(
+  row.appendChild(createSeparator());
+  row.appendChild(
     createInlineButton(String.fromCodePoint(128279), null, function () {
       insertMarkdownLink();
     }),
   );
-  row2.appendChild(
+  row.appendChild(
     createInlineButton("S", "strikethrough", function () {
       toggleMarkdownInlineFormat("strikethrough");
     }),
   );
-  row2.appendChild(
+  row.appendChild(
     createInlineButton("</>", "code", function () {
       toggleMarkdownInlineFormat("code");
     }),
   );
 
-  inlineToolbar.appendChild(row1);
-  inlineToolbar.appendChild(row2);
+  inlineToolbar.appendChild(row);
   inlineToolbar.appendChild(blockDropdown);
 
   // -- Global listeners for block dropdown -----------------------------------

--- a/src/studio/bridge/bridge-markdown-editor.ts
+++ b/src/studio/bridge/bridge-markdown-editor.ts
@@ -2,8 +2,8 @@
  * Bridge Markdown Editor
  *
  * Markdown editor lifecycle: Lexical rich-text setup, DOM scaffolding
- * (toolbar, surface, inline toolbar, block drag, textarea fallback),
- * content application, presence/selection pills, and edit-mode toggling.
+ * (surface, inline toolbar, block drag, textarea fallback),
+ * content application, overlay selections, and edit-mode toggling.
  *
  * NOTE: This module participates in a circular import cycle with
  * bridge-markdown-core.ts and bridge-markdown-yjs.ts.
@@ -12,7 +12,6 @@
 
 import { editorState as state } from "./bridge-editor-state.ts";
 import { getConfig, isMarkdownPage } from "./bridge-config.ts";
-import { DATA_VF_IGNORE } from "./bridge-constants.ts";
 import { btn, el } from "./bridge-dom-helpers.ts";
 
 import {
@@ -23,13 +22,11 @@ import {
   parseMdxImportMap,
   postMarkdownEditorReady,
   restoreRawBlocksFromEditor,
-  saveMarkdownContent,
 } from "./bridge-markdown-core.ts";
 
 import {
   disposeMarkdownYjs,
   setupMarkdownYjsConnection,
-  writeToYText,
 } from "./bridge-markdown-yjs.ts";
 
 import {
@@ -452,87 +449,25 @@ export function applyMarkdownContent(content: unknown): void {
 }
 
 // ---------------------------------------------------------------------------
-// setMarkdownPresence
+// updateMarkdownOverlaySelections
 // ---------------------------------------------------------------------------
 
-export function setMarkdownPresence(users: any[]): void {
-  state.markdownLatestPresenceUsers = Array.isArray(users) ? users : [];
-  if (!state.markdownPresenceRoot) {
-    return;
-  }
-
-  state.markdownPresenceRoot.textContent = "";
-  if (!Array.isArray(users) || users.length === 0) {
-    state.markdownPresenceRoot.style.display = "none";
-    return;
-  }
-
-  const seenIds: Record<string, boolean> = {};
-  const uniqueUsers = users.filter(function (user: any) {
-    if (!user || typeof user.name !== "string") {
-      return false;
-    }
-    const uniqueKey = user.id || user.name;
-    if (seenIds[uniqueKey]) {
-      return false;
-    }
-    seenIds[uniqueKey] = true;
-    return true;
-  });
-  const visibleUsers = uniqueUsers.slice(0, 4);
-
-  if (visibleUsers.length === 0) {
-    state.markdownPresenceRoot.style.display = "none";
-    return;
-  }
-
-  state.markdownPresenceRoot.style.display = "inline-flex";
-
-  for (const user of visibleUsers) {
-    const pill = document.createElement("div");
-    pill.className = "vf-markdown-editor__presence-pill";
-    pill.setAttribute(DATA_VF_IGNORE, "true");
-    pill.setAttribute(
-      "data-current",
-      user.isCurrentUser ? "true" : "false",
-    );
-    pill.setAttribute("data-agent", user.isAgent ? "true" : "false");
-    pill.textContent = user.isCurrentUser ? "You" : user.name;
-
-    const color = typeof user.color === "string" && user.color ? user.color : "#6b7280";
-    pill.style.borderLeftColor = color;
-
-    state.markdownPresenceRoot.appendChild(pill);
-  }
-
-  if (uniqueUsers.length > visibleUsers.length) {
-    const extra = document.createElement("div");
-    extra.className = "vf-markdown-editor__presence-pill";
-    extra.setAttribute(DATA_VF_IGNORE, "true");
-    extra.textContent = "+" + String(uniqueUsers.length - visibleUsers.length);
-    state.markdownPresenceRoot.appendChild(extra);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// setMarkdownSelections
-// ---------------------------------------------------------------------------
-
-export function setMarkdownSelections(selections: any[]): void {
+/**
+ * Rebuild overlay selections from the latest remote selections.
+ * Converts source offsets to editor (rendered) offsets and schedules
+ * the cursor overlay render. No toolbar pill DOM — overlays show
+ * cursors/highlights directly on the editor surface.
+ */
+export function updateMarkdownOverlaySelections(selections: any[]): void {
   state.markdownLatestSelections = Array.isArray(selections) ? selections : [];
-  if (!state.markdownSelectionsRoot) {
-    return;
-  }
-
-  state.markdownSelectionsRoot.textContent = "";
   state.markdownOverlaySelections = [];
+
   if (!Array.isArray(selections) || selections.length === 0) {
-    state.markdownSelectionsRoot.style.display = "none";
     clearMarkdownSelectionOverlay();
     return;
   }
 
-  const visibleSelections = selections
+  const validSelections = selections
     .filter(function (selection: any) {
       return (
         selection &&
@@ -540,32 +475,21 @@ export function setMarkdownSelections(selections: any[]): void {
         typeof selection.start === "number" &&
         typeof selection.end === "number"
       );
-    })
-    .slice(0, 4);
+    });
 
-  if (visibleSelections.length === 0) {
-    state.markdownSelectionsRoot.style.display = "none";
+  if (validSelections.length === 0) {
     clearMarkdownSelectionOverlay();
     return;
   }
 
-  state.markdownSelectionsRoot.style.display = "inline-flex";
-
-  for (const selection of visibleSelections) {
-    const pill = document.createElement("div");
-    pill.className = "vf-markdown-editor__selection-pill";
-    pill.setAttribute(DATA_VF_IGNORE, "true");
+  for (const selection of validSelections) {
     const color = typeof selection.color === "string" && selection.color
       ? selection.color
       : "#6b7280";
     const displayName = selection.isCurrentUser ? "You" : selection.name;
-    pill.style.borderLeftColor = color;
 
     const start = Math.max(0, Math.trunc(selection.start));
     const end = Math.max(0, Math.trunc(selection.end));
-    const rangeLabel = start === end ? "@" + String(start) : String(start) + "-" + String(end);
-    pill.textContent = displayName + " " + rangeLabel;
-    state.markdownSelectionsRoot.appendChild(pill);
 
     const editorRange = sourceSelectionToEditorRange(start, end);
     if (!editorRange) {
@@ -582,14 +506,6 @@ export function setMarkdownSelections(selections: any[]): void {
     });
   }
 
-  if (selections.length > visibleSelections.length) {
-    const extra = document.createElement("div");
-    extra.className = "vf-markdown-editor__selection-pill";
-    extra.setAttribute(DATA_VF_IGNORE, "true");
-    extra.textContent = "+" + String(selections.length - visibleSelections.length);
-    state.markdownSelectionsRoot.appendChild(extra);
-  }
-
   scheduleMarkdownSelectionOverlayRender();
 }
 
@@ -603,36 +519,6 @@ export function ensureMarkdownEditor(): HTMLElement | undefined {
   }
 
   const editorRoot = el("div", "vf-markdown-editor");
-
-  // -- Toolbar ---------------------------------------------------------------
-
-  const toolbar = el("div", "vf-markdown-editor__toolbar");
-  const title = el("div", "vf-markdown-editor__title", getConfig().pagePath || "Untitled");
-  const actions = el("div", "vf-markdown-editor__actions");
-
-  const status = el("div", "vf-markdown-editor__status");
-  status.setAttribute("data-state", "");
-
-  const presence = el("div", "vf-markdown-editor__presence");
-  const selections = el("div", "vf-markdown-editor__selections");
-
-  actions.appendChild(status);
-  actions.appendChild(presence);
-  actions.appendChild(selections);
-
-  // Debug button: write test content via Yjs (only visible when debugExposeInternals is on)
-  if (getConfig().debugExposeInternals) {
-    const debugBtn = btn("vf-markdown-editor__exit", "Yjs Write", function () {
-      const ok = writeToYText("\n\nHello from Yjs debug write!\n");
-      console.debug("[StudioBridge] Debug Yjs write:", ok ? "success" : "failed (not connected)");
-    });
-    debugBtn.style.fontSize = "10px";
-    debugBtn.style.opacity = "0.6";
-    actions.appendChild(debugBtn);
-  }
-
-  toolbar.appendChild(title);
-  toolbar.appendChild(actions);
 
   // -- MDX blocks bar --------------------------------------------------------
 
@@ -668,12 +554,6 @@ export function ensureMarkdownEditor(): HTMLElement | undefined {
       if (moved) {
         event.preventDefault();
       }
-    }
-  });
-  surface.addEventListener("keydown", function (event: KeyboardEvent) {
-    if ((event.metaKey || event.ctrlKey) && event.key === "s") {
-      event.preventDefault();
-      saveMarkdownContent();
     }
   });
   surface.addEventListener("scroll", scheduleMarkdownSelectionOverlayRender);
@@ -993,7 +873,6 @@ export function ensureMarkdownEditor(): HTMLElement | undefined {
 
   // -- Assemble editor root --------------------------------------------------
 
-  editorRoot.appendChild(toolbar);
   editorRoot.appendChild(mdxBlocks);
   editorRoot.appendChild(surfaceWrap);
   editorRoot.appendChild(textarea);
@@ -1009,9 +888,6 @@ export function ensureMarkdownEditor(): HTMLElement | undefined {
   state.markdownEditorRoot = editorRoot;
   state.markdownEditorSurface = surface;
   state.markdownEditorTextarea = textarea;
-  state.markdownPersistStatus = status;
-  state.markdownPresenceRoot = presence;
-  state.markdownSelectionsRoot = selections;
   state.markdownMdxBlocksRoot = mdxBlocks;
   state.markdownSelectionOverlayRoot = selectionOverlay;
   state.markdownSlashMenuRoot = slashMenu;
@@ -1020,8 +896,7 @@ export function ensureMarkdownEditor(): HTMLElement | undefined {
   state.markdownBlockDropIndicator = blockDropIndicator;
   state.markdownBlockDropLabel = blockDropLabel;
   setMarkdownMdxBlocks(state.markdownLatestMdxBlocks);
-  setMarkdownPresence(state.markdownLatestPresenceUsers);
-  setMarkdownSelections(state.markdownLatestSelections);
+  updateMarkdownOverlaySelections(state.markdownLatestSelections);
   setupMarkdownLexicalEditor();
   applyMarkdownContent(state.markdownCurrentContent);
 

--- a/src/studio/bridge/bridge-markdown-editor.ts
+++ b/src/studio/bridge/bridge-markdown-editor.ts
@@ -24,10 +24,7 @@ import {
   restoreRawBlocksFromEditor,
 } from "./bridge-markdown-core.ts";
 
-import {
-  disposeMarkdownYjs,
-  setupMarkdownYjsConnection,
-} from "./bridge-markdown-yjs.ts";
+import { disposeMarkdownYjs, setupMarkdownYjsConnection } from "./bridge-markdown-yjs.ts";
 
 import {
   buildEditorRenderedMaps,

--- a/src/studio/bridge/bridge-markdown-yjs.ts
+++ b/src/studio/bridge/bridge-markdown-yjs.ts
@@ -13,10 +13,7 @@
 import { editorState as state } from "./bridge-editor-state.ts";
 import { LEXICAL_YJS_ORIGIN, type PresenceUser, type RemoteSelection } from "./bridge-state.ts";
 import { computeTextDiff } from "./bridge-markdown-core.ts";
-import {
-  applyMarkdownContent,
-  updateMarkdownOverlaySelections,
-} from "./bridge-markdown-editor.ts";
+import { applyMarkdownContent, updateMarkdownOverlaySelections } from "./bridge-markdown-editor.ts";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/studio/bridge/bridge-markdown-yjs.ts
+++ b/src/studio/bridge/bridge-markdown-yjs.ts
@@ -15,8 +15,7 @@ import { LEXICAL_YJS_ORIGIN, type PresenceUser, type RemoteSelection } from "./b
 import { computeTextDiff } from "./bridge-markdown-core.ts";
 import {
   applyMarkdownContent,
-  setMarkdownPresence,
-  setMarkdownSelections,
+  updateMarkdownOverlaySelections,
 } from "./bridge-markdown-editor.ts";
 
 // ---------------------------------------------------------------------------
@@ -211,7 +210,7 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
           provider.awareness.getStates().entries(),
         ) as [number, Record<string, unknown>][];
 
-        // Sync presence users
+        // Sync presence users (stored for overlay name labels)
         const users: PresenceUser[] = [];
         for (const [clientId, st] of states) {
           const user = st.user as Record<string, unknown> | undefined;
@@ -226,9 +225,9 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
             isAgent: (user.isAgent as boolean) || false,
           });
         }
-        setMarkdownPresence(users);
+        state.markdownLatestPresenceUsers = users;
 
-        // Sync remote selections
+        // Sync remote selections → overlay cursors
         const selections: RemoteSelection[] = [];
         for (const [cId, st] of states) {
           const u = st.user as Record<string, unknown> | undefined;
@@ -263,7 +262,7 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
             });
           }
         }
-        setMarkdownSelections(selections);
+        updateMarkdownOverlaySelections(selections);
       }
 
       // ------------------------------------------------------------------
@@ -433,6 +432,6 @@ export function disposeMarkdownYjs(): void {
   state.markdownPendingSelection = null;
   state.markdownLastRemoteContent = null;
   state.markdownApplyingRemoteUpdate = false;
-  setMarkdownPresence([]);
-  setMarkdownSelections([]);
+  state.markdownLatestPresenceUsers = [];
+  updateMarkdownOverlaySelections([]);
 }

--- a/src/studio/bridge/bridge-message-handler.ts
+++ b/src/studio/bridge/bridge-message-handler.ts
@@ -80,32 +80,6 @@ export function handleStudioMessage(event: MessageEvent): void {
       return;
 
     case "setMarkdownPersistState":
-      if (!isMarkdownPage()) {
-        return;
-      }
-      if (
-        message.fileId && editorState.markdownFileId &&
-        message.fileId !== editorState.markdownFileId
-      ) {
-        return;
-      }
-      if (editorState.markdownSaveInProgress) {
-        const status = message.status || "saved";
-        if (status === "saved") {
-          const requestedContent = editorState.markdownSaveRequestedContent;
-          editorState.markdownSaveInProgress = false;
-          editorState.markdownSaveRequestedContent = null;
-          if (
-            !(typeof requestedContent === "string" &&
-              editorState.markdownCurrentContent !== requestedContent)
-          ) {
-            editorState.markdownHasUnsavedChanges = false;
-          }
-        } else if (status === "error") {
-          editorState.markdownSaveInProgress = false;
-          editorState.markdownSaveRequestedContent = null;
-        }
-      }
       return;
 
     case "agentWriteMarkdown": {

--- a/src/studio/bridge/bridge-message-handler.ts
+++ b/src/studio/bridge/bridge-message-handler.ts
@@ -4,7 +4,7 @@
  * Dispatches incoming Studio messages to the appropriate bridge functions.
  */
 
-import { editorState, setMarkdownPersistStatus } from "./bridge-editor-state.ts";
+import { editorState } from "./bridge-editor-state.ts";
 import { state } from "./bridge-state.ts";
 import { getConfig } from "./bridge-config.ts";
 import { isFromStudio, postToStudio } from "./bridge-messaging.ts";
@@ -95,24 +95,15 @@ export function handleStudioMessage(event: MessageEvent): void {
           const requestedContent = editorState.markdownSaveRequestedContent;
           editorState.markdownSaveInProgress = false;
           editorState.markdownSaveRequestedContent = null;
-
-          // Only clear dirty state when current content still matches the request we saved.
           if (
-            typeof requestedContent === "string" &&
-            editorState.markdownCurrentContent !== requestedContent
+            !(typeof requestedContent === "string" &&
+              editorState.markdownCurrentContent !== requestedContent)
           ) {
-            setMarkdownPersistStatus("saving");
-          } else {
             editorState.markdownHasUnsavedChanges = false;
-            setMarkdownPersistStatus("saved");
           }
         } else if (status === "error") {
           editorState.markdownSaveInProgress = false;
           editorState.markdownSaveRequestedContent = null;
-          setMarkdownPersistStatus("error");
-          // Keep markdownHasUnsavedChanges = true so user can retry
-        } else {
-          setMarkdownPersistStatus(status);
         }
       }
       return;

--- a/src/studio/bridge/bridge-selection.ts
+++ b/src/studio/bridge/bridge-selection.ts
@@ -516,9 +516,7 @@ export function resolveMarkdownTextPoint(
     // Fast path: find the first text node and return offset 0
     const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
     const first = walker.nextNode();
-    return first
-      ? { node: first, offset: 0 }
-      : { node: root, offset: 0 };
+    return first ? { node: first, offset: 0 } : { node: root, offset: 0 };
   }
 
   // Walk text nodes and use Range.toString().length to measure cumulative

--- a/src/studio/bridge/bridge-state.ts
+++ b/src/studio/bridge/bridge-state.ts
@@ -171,7 +171,7 @@ export const state = {
 // Re-exports from editor state (for modules that import from bridge-state)
 // ---------------------------------------------------------------------------
 
-export { editorState, setMarkdownPersistStatus } from "./bridge-editor-state.ts";
+export { editorState } from "./bridge-editor-state.ts";
 
 export const LEXICAL_YJS_ORIGIN = "lexical-yjs-binding";
 

--- a/src/studio/bridge/bridge-styles.ts
+++ b/src/studio/bridge/bridge-styles.ts
@@ -465,6 +465,7 @@ const OVERLAY_CSS = `
         border: 1px solid oklch(0.6852 0.162 241.8 / 0.24);
         background: oklch(1 0 0 / 0.96);
         color: oklch(0.2768 0 0);
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
         font-size: 11px;
         font-weight: 600;
         line-height: 1.2;

--- a/src/studio/bridge/bridge-styles.ts
+++ b/src/studio/bridge/bridge-styles.ts
@@ -88,132 +88,6 @@ const OVERLAY_CSS = `
         display: none;
       }
 
-      /* ------------------------------------------------------------------ */
-      /* Toolbar                                                             */
-      /* ------------------------------------------------------------------ */
-
-      .vf-markdown-editor__toolbar {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        gap: 8px;
-        padding: 8px 16px;
-        border-bottom: 1px solid oklch(0.9 0 0);
-        background: oklch(0.97 0 0 / 0.96);
-        backdrop-filter: blur(8px);
-        position: sticky;
-        top: 0;
-      }
-
-      .vf-markdown-editor__title {
-        font-size: 12px;
-        color: oklch(0.55 0.005 95.11);
-        font-weight: 500;
-        display: inline-flex;
-        align-items: center;
-        gap: 4px;
-      }
-
-      .vf-markdown-editor__actions {
-        display: inline-flex;
-        align-items: center;
-        gap: 8px;
-      }
-
-      .vf-markdown-editor__status {
-        font-size: 12px;
-        color: oklch(0.55 0.005 95.11);
-        transition: color 150ms ease;
-      }
-
-      .vf-markdown-editor__status[data-state='saving'] {
-        color: oklch(0.65 0.15 75);
-      }
-
-      .vf-markdown-editor__status[data-state='saved'] {
-        color: oklch(0.52 0.15 145);
-      }
-
-      .vf-markdown-editor__status[data-state='error'] {
-        color: oklch(0.55 0.22 27);
-      }
-
-      /* ------------------------------------------------------------------ */
-      /* Presence pills                                                      */
-      /* ------------------------------------------------------------------ */
-
-      .vf-markdown-editor__presence {
-        display: none;
-        align-items: center;
-        gap: 6px;
-      }
-
-      .vf-markdown-editor__presence-pill {
-        border: 1px solid oklch(0.84 0.0055 95.11);
-        border-left-width: 4px;
-        border-radius: 9999px;
-        padding: 2px 8px;
-        font-size: 11px;
-        font-weight: 500;
-        color: oklch(0.2768 0 0);
-        background: oklch(1 0 0);
-        transition: border-color 75ms ease;
-      }
-
-      .vf-markdown-editor__presence-pill[data-current='true'] {
-        font-weight: 600;
-      }
-
-      .vf-markdown-editor__presence-pill[data-agent='true'] {
-        font-style: italic;
-        background: oklch(0.96 0.02 280);
-        border-color: oklch(0.6852 0.162 241.8 / 0.3);
-      }
-
-      /* ------------------------------------------------------------------ */
-      /* Selection pills                                                     */
-      /* ------------------------------------------------------------------ */
-
-      .vf-markdown-editor__selections {
-        display: none;
-        align-items: center;
-        gap: 6px;
-      }
-
-      .vf-markdown-editor__selection-pill {
-        border: 1px solid oklch(0.84 0.0055 95.11);
-        border-left-width: 4px;
-        border-radius: 9999px;
-        padding: 2px 8px;
-        font-size: 11px;
-        font-weight: 500;
-        color: oklch(0.2768 0 0);
-        background: oklch(1 0 0);
-      }
-
-      /* ------------------------------------------------------------------ */
-      /* Toolbar buttons                                                     */
-      /* ------------------------------------------------------------------ */
-
-      .vf-markdown-editor__exit {
-        border: 1px solid oklch(0.84 0.0055 95.11);
-        border-radius: 6px;
-        background: oklch(1 0 0);
-        color: oklch(0.2768 0 0);
-        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-        font-size: 12px;
-        font-weight: 500;
-        padding: 6px 10px;
-        cursor: pointer;
-        transition: background 75ms ease;
-      }
-      .vf-markdown-editor__exit:hover {
-        background: oklch(0.93 0 0);
-      }
-      .vf-markdown-editor__exit:active {
-        transform: scale(0.98);
-      }
-
       .vf-markdown-editor__history {
         border: 1px solid oklch(0.84 0.0055 95.11);
         border-radius: 6px;
@@ -238,7 +112,7 @@ const OVERLAY_CSS = `
 
       .vf-markdown-editor__surface-wrap {
         position: relative;
-        height: calc(100vh - 52px);
+        height: 100vh;
       }
 
       .vf-markdown-editor__surface {
@@ -737,7 +611,7 @@ const OVERLAY_CSS = `
 
       .vf-markdown-editor__textarea {
         width: 100%;
-        height: calc(100vh - 52px);
+        height: 100vh;
         border: 0;
         outline: none;
         resize: none;
@@ -759,24 +633,6 @@ const OVERLAY_CSS = `
         background: oklch(0.2768 0 0);
       }
 
-      [data-theme='dark'] .vf-markdown-editor__toolbar {
-        border-bottom-color: oklch(0.3 0.01 220);
-        background: oklch(0.18 0.01 220 / 0.96);
-      }
-
-      [data-theme='dark'] .vf-markdown-editor__title {
-        color: oklch(0.5338 0.0046 106.55);
-      }
-
-      [data-theme='dark'] .vf-markdown-editor__exit {
-        background: oklch(0.3211 0 0);
-        border-color: oklch(0.42 0.0017 106.48);
-        color: oklch(0.9512 0.008 98.88);
-      }
-      [data-theme='dark'] .vf-markdown-editor__exit:hover {
-        background: oklch(0.25 0.01 220);
-      }
-
       [data-theme='dark'] .vf-markdown-editor__history {
         background: oklch(0.3211 0 0);
         border-color: oklch(0.42 0.0017 106.48);
@@ -784,39 +640,6 @@ const OVERLAY_CSS = `
       }
       [data-theme='dark'] .vf-markdown-editor__history:hover {
         background: oklch(0.25 0.01 220);
-      }
-
-      [data-theme='dark'] .vf-markdown-editor__status {
-        color: oklch(0.5338 0.0046 106.55);
-      }
-
-      [data-theme='dark'] .vf-markdown-editor__status[data-state='saving'] {
-        color: oklch(0.75 0.15 75);
-      }
-
-      [data-theme='dark'] .vf-markdown-editor__status[data-state='saved'] {
-        color: oklch(0.62 0.15 145);
-      }
-
-      [data-theme='dark'] .vf-markdown-editor__status[data-state='error'] {
-        color: oklch(0.65 0.2 25);
-      }
-
-      [data-theme='dark'] .vf-markdown-editor__presence-pill {
-        border-color: oklch(0.42 0.0017 106.48);
-        color: oklch(0.9512 0.008 98.88);
-        background: oklch(0.3211 0 0);
-      }
-
-      [data-theme='dark'] .vf-markdown-editor__presence-pill[data-agent='true'] {
-        background: oklch(0.25 0.03 280);
-        border-color: oklch(0.6852 0.162 241.8 / 0.3);
-      }
-
-      [data-theme='dark'] .vf-markdown-editor__selection-pill {
-        border-color: oklch(0.42 0.0017 106.48);
-        color: oklch(0.9512 0.008 98.88);
-        background: oklch(0.3211 0 0);
       }
 
       [data-theme='dark'] .vf-markdown-editor__textarea {

--- a/src/studio/bridge/bridge-styles.ts
+++ b/src/studio/bridge/bridge-styles.ts
@@ -276,7 +276,6 @@ const OVERLAY_CSS = `
         z-index: 100006;
         display: none;
         flex-direction: column;
-        min-width: 200px;
         border: 1px solid oklch(0.84 0.0055 95.11);
         border-radius: 8px;
         background: oklch(1 0 0);


### PR DESCRIPTION
## Summary

- Remove the redundant markdown editor toolbar (title, save status, presence pills, selection pills, debug button)
- Extract overlay-building logic from `setMarkdownSelections` into `updateMarkdownOverlaySelections` — collaborative cursor overlays still render correctly
- Delete `saveMarkdownContent`, `setMarkdownPersistStatus`, and Cmd+S handler — no explicit save concept with Yjs real-time sync
- Update surface-wrap/textarea height from `calc(100vh - 52px)` to `100vh` for full-height editing
- Clean up ~400 lines of toolbar CSS including dark mode variants
- Bump version to 0.1.44

## Test plan

- [ ] `deno task typecheck` passes (verified)
- [ ] `deno task test` — all 1193 tests pass (verified)
- [ ] Editor opens full-height with no toolbar, floating button toggles Edit/Done
- [ ] Collaborative cursors still render correctly as colored overlays with name labels
- [ ] Cmd+S no longer triggers save status (browser default or no-op)