### PR TITLE
fix: enforce protected check on preview environment URLs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -535,6 +535,102 @@ describe("Proxy Handler", () => {
       }
     });
 
+    it("redirects to sign-in for protected preview domain without auth token", async () => {
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") return createTokenResponse();
+
+        if (pathname.startsWith("/projects/")) {
+          return Response.json({
+            id: "proj-123",
+            slug: "protected-project",
+            name: "Protected Project",
+            environments: [{
+              id: "env-1",
+              name: "preview",
+              active_release_id: "rel-123",
+              protected: true,
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+
+        const req = new Request(
+          "http://protected-project.preview.veryfront.com/page",
+          {
+            headers: { host: "protected-project.preview.veryfront.com" },
+          },
+        );
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error?.status, 302);
+        assertEquals(ctx.error?.message, "Authentication required");
+        assertEquals(
+          ctx.error?.redirectUrl,
+          "https://veryfront.com/sign-in?from=%2Fpage",
+        );
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
+    it("allows access to protected preview domain with auth token", async () => {
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") return createTokenResponse();
+
+        if (pathname.startsWith("/projects/")) {
+          return Response.json({
+            id: "proj-123",
+            slug: "protected-project",
+            name: "Protected Project",
+            environments: [{
+              id: "env-1",
+              name: "preview",
+              active_release_id: "rel-123",
+              protected: true,
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+
+        const req = new Request(
+          "http://protected-project.preview.veryfront.com/page",
+          {
+            headers: {
+              host: "protected-project.preview.veryfront.com",
+              cookie: "authToken=user-auth-token",
+            },
+          },
+        );
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error, undefined);
+        assertEquals(ctx.projectSlug, "protected-project");
+        assertEquals(ctx.environmentId, "env-1");
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
     it("allows access to non-protected environment without auth token", async () => {
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -424,29 +424,35 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
           targetEnvName: parsedDomain.environment,
         });
       } else if (projectSlug && scope === "preview" && token) {
-        // For preview mode, we need projectId to fetch project metadata (e.g., layout config)
-        // but we don't need releaseId since preview uses branch-based content
-        const lookupResult = await lookupProjectByDomain(
-          projectSlug,
-          config.apiBaseUrl,
+        // Preview uses branch-based content (no releaseId needed), but must
+        // still enforce the environment's `protected` flag like other scopes.
+        const resolved = await resolveReleaseAndProtection(
+          req,
           token,
-          logger,
+          userToken,
+          projectSlug,
+          (env) => env.name.toLowerCase() === "preview",
+          { projectSlug },
         );
 
-        if (lookupResult) {
-          projectId = lookupResult.id;
-
-          // Find preview environment for env var resolution
-          const previewEnv = lookupResult.environments?.find(
-            (env) => env.name.toLowerCase() === "preview",
+        if ("error" in resolved) {
+          return makeErrorContext(
+            base,
+            resolved.error.status,
+            resolved.error.message,
+            token,
+            resolved.error.redirectUrl,
           );
-          environmentId = previewEnv?.id;
-
-          logger?.info("Resolved preview project", {
-            projectSlug,
-            projectId,
-          });
         }
+
+        projectId = resolved.projectId;
+        environmentId = resolved.environmentId;
+
+        logger?.info("Resolved preview project", {
+          projectSlug,
+          projectId,
+          environmentId,
+        });
       }
     }
 

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -448,11 +448,13 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
         projectId = resolved.projectId;
         environmentId = resolved.environmentId;
 
-        logger?.info("Resolved preview project", {
-          projectSlug,
-          projectId,
-          environmentId,
-        });
+        if (projectId) {
+          logger?.info("Resolved preview project", {
+            projectSlug,
+            projectId,
+            environmentId,
+          });
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- **Security fix**: Preview URLs (`*.preview.veryfront.com`) bypassed the environment `protected` flag, allowing unauthenticated public access to projects that require membership
- Reuses the existing `resolveReleaseAndProtection()` helper already used by custom domain and production handlers
- No new code paths — just routes preview through the same protection check

## Root Cause

The preview handler in `src/proxy/handler.ts` called `lookupProjectByDomain()` directly and extracted `projectId`/`environmentId` without checking `previewEnv?.protected`. Both custom domain (line 376) and production (line 396) handlers already enforce this check, but preview was missed.

**Before (vulnerable):**
```typescript
} else if (projectSlug && scope === "preview" && token) {
  const lookupResult = await lookupProjectByDomain(...);
  if (lookupResult) {
    projectId = lookupResult.id;
    const previewEnv = lookupResult.environments?.find(...);
    environmentId = previewEnv?.id;
    // ⚠️ No protected check — renders content for anyone
  }
}
```

**After (fixed):**
```typescript
} else if (projectSlug && scope === "preview" && token) {
  const resolved = await resolveReleaseAndProtection(
    req, token, userToken, projectSlug,
    (env) => env.name.toLowerCase() === "preview",
    { projectSlug },
  );
  if ("error" in resolved) {
    return makeErrorContext(...); // 302 → sign-in
  }
  projectId = resolved.projectId;
  environmentId = resolved.environmentId;
}
```

## Test plan

- [ ] Visit `https://snowy-inlet.preview.veryfront.com` while logged out → should redirect to sign-in
- [ ] Visit while logged in as project member → should render normally
- [ ] Visit while logged in as non-member → should be denied
- [ ] Production and custom domain environments still work as before