### PR TITLE
fix: enforce project membership on protected environments

### DIFF
--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -16,8 +16,10 @@ function createNotFoundResponse(): Response {
 }
 
 function createFakeJwt(userId: string): string {
-  const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }));
-  const payload = btoa(JSON.stringify({ userId }));
+  const base64UrlEncode = (input: string): string =>
+    btoa(input).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+  const header = base64UrlEncode(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = base64UrlEncode(JSON.stringify({ userId }));
   return `${header}.${payload}.fake-signature`;
 }
 

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -15,6 +15,12 @@ function createNotFoundResponse(): Response {
   return new Response("Not found", { status: 404 });
 }
 
+function createFakeJwt(userId: string): string {
+  const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = btoa(JSON.stringify({ userId }));
+  return `${header}.${payload}.fake-signature`;
+}
+
 function createHandler(port: number) {
   return createProxyHandler({
     config: {
@@ -255,7 +261,8 @@ describe("Proxy Handler", () => {
       }
     });
 
-    it("allows access to protected custom domain with auth token", async () => {
+    it("allows access to protected custom domain with auth token for project member", async () => {
+      const memberToken = createFakeJwt("user-123");
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);
 
@@ -266,6 +273,7 @@ describe("Proxy Handler", () => {
             id: "proj-123",
             slug: "protected-project",
             name: "Protected Project",
+            users: [{ id: "user-123" }],
             environments: [{
               id: "env-1",
               name: "production",
@@ -285,7 +293,7 @@ describe("Proxy Handler", () => {
         const req = new Request("http://protected.example.com/page", {
           headers: {
             host: "protected.example.com",
-            cookie: "authToken=user-auth-token",
+            cookie: `authToken=${memberToken}`,
           },
         });
 
@@ -294,6 +302,53 @@ describe("Proxy Handler", () => {
         assertEquals(ctx.error, undefined);
         assertEquals(ctx.projectSlug, "protected-project");
         assertEquals(ctx.releaseId, "rel-123");
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
+    it("returns 403 for protected custom domain when authenticated user is not a member", async () => {
+      const nonMemberToken = createFakeJwt("other-user");
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") return createTokenResponse();
+
+        if (pathname.startsWith("/projects/")) {
+          return Response.json({
+            id: "proj-123",
+            slug: "protected-project",
+            name: "Protected Project",
+            users: [{ id: "user-123" }],
+            environments: [{
+              id: "env-1",
+              name: "production",
+              domains: ["protected.example.com"],
+              active_release_id: "rel-123",
+              protected: true,
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+
+        const req = new Request("http://protected.example.com/page", {
+          headers: {
+            host: "protected.example.com",
+            cookie: `authToken=${nonMemberToken}`,
+          },
+        });
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error?.status, 403);
+        assertEquals(ctx.error?.message, "Access denied");
 
         await handler.close();
       } finally {
@@ -349,7 +404,8 @@ describe("Proxy Handler", () => {
       }
     });
 
-    it("allows access to protected veryfront domain with auth token", async () => {
+    it("allows access to protected veryfront domain with auth token for project member", async () => {
+      const memberToken = createFakeJwt("user-123");
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);
 
@@ -360,6 +416,7 @@ describe("Proxy Handler", () => {
             id: "proj-123",
             slug: "protected-project",
             name: "Protected Project",
+            users: [{ id: "user-123" }],
             environments: [{
               id: "env-1",
               name: "staging",
@@ -380,7 +437,7 @@ describe("Proxy Handler", () => {
           {
             headers: {
               host: "protected-project.staging.veryfront.com",
-              cookie: "authToken=user-auth-token",
+              cookie: `authToken=${memberToken}`,
             },
           },
         );
@@ -390,6 +447,55 @@ describe("Proxy Handler", () => {
         assertEquals(ctx.error, undefined);
         assertEquals(ctx.projectSlug, "protected-project");
         assertEquals(ctx.releaseId, "rel-123");
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
+    it("returns 403 for protected veryfront domain when authenticated user is not a member", async () => {
+      const nonMemberToken = createFakeJwt("other-user");
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") return createTokenResponse();
+
+        if (pathname.startsWith("/projects/")) {
+          return Response.json({
+            id: "proj-123",
+            slug: "protected-project",
+            name: "Protected Project",
+            users: [{ id: "user-123" }],
+            environments: [{
+              id: "env-1",
+              name: "staging",
+              active_release_id: "rel-123",
+              protected: true,
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+
+        const req = new Request(
+          "http://protected-project.staging.veryfront.com/page",
+          {
+            headers: {
+              host: "protected-project.staging.veryfront.com",
+              cookie: `authToken=${nonMemberToken}`,
+            },
+          },
+        );
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error?.status, 403);
+        assertEquals(ctx.error?.message, "Access denied");
 
         await handler.close();
       } finally {
@@ -583,7 +689,8 @@ describe("Proxy Handler", () => {
       }
     });
 
-    it("allows access to protected preview domain with auth token", async () => {
+    it("allows access to protected preview domain with auth token for project member", async () => {
+      const memberToken = createFakeJwt("user-123");
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);
 
@@ -594,6 +701,7 @@ describe("Proxy Handler", () => {
             id: "proj-123",
             slug: "protected-project",
             name: "Protected Project",
+            users: [{ id: "user-123" }],
             environments: [{
               id: "env-1",
               name: "preview",
@@ -614,7 +722,7 @@ describe("Proxy Handler", () => {
           {
             headers: {
               host: "protected-project.preview.veryfront.com",
-              cookie: "authToken=user-auth-token",
+              cookie: `authToken=${memberToken}`,
             },
           },
         );
@@ -624,6 +732,55 @@ describe("Proxy Handler", () => {
         assertEquals(ctx.error, undefined);
         assertEquals(ctx.projectSlug, "protected-project");
         assertEquals(ctx.environmentId, "env-1");
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
+    it("returns 403 for protected preview domain when authenticated user is not a member", async () => {
+      const nonMemberToken = createFakeJwt("other-user");
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") return createTokenResponse();
+
+        if (pathname.startsWith("/projects/")) {
+          return Response.json({
+            id: "proj-123",
+            slug: "protected-project",
+            name: "Protected Project",
+            users: [{ id: "user-123" }],
+            environments: [{
+              id: "env-1",
+              name: "preview",
+              active_release_id: "rel-123",
+              protected: true,
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+
+        const req = new Request(
+          "http://protected-project.preview.veryfront.com/page",
+          {
+            headers: {
+              host: "protected-project.preview.veryfront.com",
+              cookie: `authToken=${nonMemberToken}`,
+            },
+          },
+        );
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error?.status, 403);
+        assertEquals(ctx.error?.message, "Access denied");
 
         await handler.close();
       } finally {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -25,6 +25,7 @@ interface DomainLookupResult {
   id: string;
   slug: string;
   name: string;
+  users?: Array<{ id: string }>;
   environments?: Array<{
     id: string;
     name: string;
@@ -149,6 +150,25 @@ function extractUserToken(cookieHeader: string): string | undefined {
   return match?.[1] ? decodeURIComponent(match[1]) : undefined;
 }
 
+function extractUserIdFromToken(token: string): string | undefined {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return undefined;
+    const decoded = JSON.parse(atob(payload));
+    return decoded?.userId;
+  } catch {
+    return undefined;
+  }
+}
+
+function isProjectMember(
+  users: Array<{ id: string }> | undefined,
+  userId: string | undefined,
+): boolean {
+  if (!users || !userId) return false;
+  return users.some((u) => u.id === userId);
+}
+
 export function createProxyHandler(options: ProxyHandlerOptions) {
   const { config, cache, logger } = options;
   const localProjects = config.localProjects ?? {};
@@ -248,6 +268,38 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     return `https://veryfront.com/sign-in?from=${encodeURIComponent(returnPath)}`;
   }
 
+  function checkProtectedAccess(
+    req: Request,
+    matchingEnv: NonNullable<DomainLookupResult["environments"]>[number] | undefined,
+    userToken: string | undefined,
+    users: DomainLookupResult["users"],
+    logContext: Record<string, unknown>,
+  ): { status: number; message: string; redirectUrl?: string } | null {
+    if (!matchingEnv?.protected) return null;
+
+    if (!userToken) {
+      const redirectUrl = makeAuthRedirectUrl(req);
+      logger?.info("Protected environment requires authentication", {
+        ...logContext,
+        environmentName: matchingEnv.name,
+        redirectUrl,
+      });
+      return { status: 302, message: "Authentication required", redirectUrl };
+    }
+
+    const userId = extractUserIdFromToken(userToken);
+    if (!isProjectMember(users, userId)) {
+      logger?.info("User is not a member of the project", {
+        ...logContext,
+        environmentName: matchingEnv.name,
+        userId,
+      });
+      return { status: 403, message: "Access denied" };
+    }
+
+    return null;
+  }
+
   async function resolveReleaseAndProtection(
     req: Request,
     token: string,
@@ -264,15 +316,14 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
     const matchingEnv = lookupResult.environments?.find(envMatcher);
 
-    if (matchingEnv?.protected && !userToken) {
-      const redirectUrl = makeAuthRedirectUrl(req);
-      logger?.info("Protected environment requires authentication", {
-        ...logContext,
-        environmentName: matchingEnv.name,
-        redirectUrl,
-      });
-      return { error: { status: 302, message: "Authentication required", redirectUrl } };
-    }
+    const protectionError = checkProtectedAccess(
+      req,
+      matchingEnv,
+      userToken,
+      lookupResult.users,
+      logContext,
+    );
+    if (protectionError) return { error: protectionError };
 
     return {
       projectId: lookupResult.id,
@@ -373,14 +424,21 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
         releaseId = matchingEnv?.active_release_id ?? undefined;
         environmentId = matchingEnv?.id;
 
-        if (matchingEnv?.protected && !userToken) {
-          const redirectUrl = makeAuthRedirectUrl(req);
-          logger?.info("Protected environment requires authentication", {
-            domain: host,
-            environmentName: matchingEnv.name,
-            redirectUrl,
-          });
-          return makeErrorContext(base, 302, "Authentication required", token, redirectUrl);
+        const protectionError = checkProtectedAccess(
+          req,
+          matchingEnv,
+          userToken,
+          lookupResult.users,
+          { domain: host },
+        );
+        if (protectionError) {
+          return makeErrorContext(
+            base,
+            protectionError.status,
+            protectionError.message,
+            token,
+            protectionError.redirectUrl,
+          );
         }
 
         logger?.info("Resolved custom domain to project", {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -154,7 +154,12 @@ function extractUserIdFromToken(token: string): string | undefined {
   try {
     const payload = token.split(".")[1];
     if (!payload) return undefined;
-    const decoded = JSON.parse(atob(payload));
+    // JWT payloads are base64url-encoded: normalize to standard base64 before decoding
+    let base64 = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const remainder = base64.length % 4;
+    if (remainder === 2) base64 += "==";
+    else if (remainder === 3) base64 += "=";
+    const decoded = JSON.parse(atob(base64));
     return decoded?.userId;
   } catch {
     return undefined;
@@ -288,6 +293,16 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     }
 
     const userId = extractUserIdFromToken(userToken);
+    if (!userId) {
+      // Malformed token — treat as unauthenticated so user can re-sign-in
+      const redirectUrl = makeAuthRedirectUrl(req);
+      logger?.info("Could not extract userId from token", {
+        ...logContext,
+        environmentName: matchingEnv.name,
+        redirectUrl,
+      });
+      return { status: 302, message: "Authentication required", redirectUrl };
+    }
     if (!isProjectMember(users, userId)) {
       logger?.info("User is not a member of the project", {
         ...logContext,


### PR DESCRIPTION
## Summary

- Protected environments only checked "is user logged in?" but never verified "is user a member of this project?" — any authenticated user could access any protected environment
- Now decodes the JWT to extract `userId` and checks membership against the `users` array already returned by the API
- Extracts shared `checkProtectedAccess()` function to eliminate duplication between `resolveReleaseAndProtection` and the custom domain handler

## Changes

**`src/proxy/handler.ts`**
- Extended `DomainLookupResult` to include `users?: Array<{ id: string }>`
- Added `extractUserIdFromToken()` — base64 decodes JWT payload to get `userId`
- Added `isProjectMember()` — checks if userId is in the users array
- Added `checkProtectedAccess()` — shared function used by both veryfront domain and custom domain paths
- No API changes needed — the API already returns the `users` array

**`src/proxy/handler.test.ts`**
- Updated existing "allows access" tests to use proper JWTs with matching user IDs
- Added 3 new tests: authenticated non-member gets 403 for custom domain, veryfront domain, and preview domain
- All 23 tests pass

## Test plan

- [ ] `deno test src/proxy/handler.test.ts` — all 23 tests pass
- [ ] Protected env + no auth → 302 redirect to sign-in
- [ ] Protected env + authenticated member → 200 (allowed)
- [ ] Protected env + authenticated non-member → 403 (denied)
- [ ] Non-protected env + no auth → 200 (allowed)