### PR TITLE
fix(bridge): prevent studioOrigin poisoning from same-window messages

### DIFF
--- a/src/studio/bridge/bridge-message-handler.test.ts
+++ b/src/studio/bridge/bridge-message-handler.test.ts
@@ -57,11 +57,14 @@ function resetState(pagePath = "test.md"): void {
   editorState.markdownLexicalRenderedContent = null;
 }
 
+// Fake parent window reference so isFromStudio accepts the event
+const fakeParentWindow = {} as Window;
+
 function makeEvent(data: Record<string, unknown>): MessageEvent {
   return {
     data,
     origin: "https://veryfront.com",
-    source: null,
+    source: fakeParentWindow,
     ports: [],
   } as unknown as MessageEvent;
 }

--- a/src/studio/bridge/bridge-messaging.ts
+++ b/src/studio/bridge/bridge-messaging.ts
@@ -20,6 +20,10 @@ export function postToStudio(message: Record<string, unknown>): void {
 
 export function isFromStudio(event: MessageEvent): boolean {
   try {
+    // Ignore messages from the current window (e.g. React DevTools, browser extensions).
+    // Only accept messages from a different window (the parent Studio frame).
+    if (!event.source || event.source === window) return false;
+
     const url = new URL(event.origin || "");
     const host = url.hostname;
     const valid = host === "localhost" ||


### PR DESCRIPTION
## Summary

- Add `event.source` guard in `isFromStudio()` to reject same-window `postMessage` calls
- Fixes iframe→studio messages (like `setSelectedNode` from inspect mode) being silently dropped

## Problem

`isFromStudio()` validates message origins by checking if the hostname ends with `.veryfront.com`. Both the studio (e.g. `veryfront.com`) and the preview iframe (e.g. `hello.preview.veryfront.com`) pass this check.

When a same-window `postMessage` fires inside the iframe — typically from React DevTools or browser extensions — `isFromStudio()` accepts it and locks `studioOrigin` to the iframe's own origin. All subsequent `postToStudio()` calls then use this wrong origin as `targetOrigin`, which doesn't match the actual parent studio window, so the browser silently drops every message.

## Fix

Check `event.source` before processing: if the message came from the current window (`event.source === window` or `null`), reject it immediately. This ensures `studioOrigin` is only captured from actual cross-window studio messages.

## Test plan

- [ ] Open a project in Studio with React DevTools installed
- [ ] Activate inspect mode and click an element in the preview
- [ ] Verify `setSelectedNode` message arrives in the parent Studio
- [ ] Verify other bridge messages (`appLoaded`, `treeUpdated`, console capture) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)