### PR TITLE
fix(bridge): deselect node on DOM removal and route change

### DIFF
--- a/src/studio/bridge/bridge-inspector.ts
+++ b/src/studio/bridge/bridge-inspector.ts
@@ -217,7 +217,16 @@ export function setupMutationObserver(): void {
     const hasRelevantChanges = mutations.some(
       (m) => m.type === "childList" || m.type === "characterData",
     );
-    if (hasRelevantChanges) debouncedTreeUpdate();
+    if (!hasRelevantChanges) return;
+
+    // Deselect if the selected element was removed from the DOM
+    if (state.selectedNodeId && !findElementById(state.selectedNodeId)) {
+      state.selectedNodeId = null;
+      hideOverlay(state.selectionOverlay);
+      postToStudio({ action: "setSelectedNode", id: null });
+    }
+
+    debouncedTreeUpdate();
   });
 
   mutationObserver.observe(root, { childList: true, characterData: true, subtree: true });

--- a/src/studio/bridge/bridge-message-handler.ts
+++ b/src/studio/bridge/bridge-message-handler.ts
@@ -31,6 +31,11 @@ export function handleStudioMessage(event: MessageEvent): void {
   switch (message.action) {
     case "routeChange":
       if (message.url) {
+        if (state.selectedNodeId) {
+          state.selectedNodeId = null;
+          hideOverlay(state.selectionOverlay);
+          postToStudio({ action: "setSelectedNode", id: null });
+        }
         postToStudio({
           action: "onPageTransitionStart",
           url: message.url,


### PR DESCRIPTION
## Summary

- Emit `setSelectedNode: null` to the studio when the selected element is removed from the DOM
- Emit `setSelectedNode: null` to the studio before navigating on route change

Previously, if the selected element was removed (e.g. conditional render, list update) or the page navigated, the studio kept stale selection state with no way to know the element was gone.

## Test plan

- [ ] Select an element in inspect mode, then trigger a re-render that removes it — studio should receive deselection
- [ ] Select an element, then navigate to a different route — studio should receive deselection before the transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)