### PR TITLE
chore: bump version to 0.1.47

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [


### PR DESCRIPTION
## Summary

- Bump version from 0.1.46 to 0.1.47

Includes bridge fixes from #516 and #517:
- Prevent studioOrigin poisoning from same-window messages
- Deselect node on DOM removal and route change

🤖 Generated with [Claude Code](https://claude.com/claude-code)