### PR TITLE
fix: replace GCS JWT placeholder signature with real RS256 signing

### DIFF
--- a/src/workflow/blob/gcs-storage.test.ts
+++ b/src/workflow/blob/gcs-storage.test.ts
@@ -18,8 +18,9 @@ async function generateTestServiceAccountKey(): Promise<string> {
   const privateKeyBase64 = btoa(
     String.fromCharCode(...new Uint8Array(privateKeyDer)),
   );
-  const pem =
-    `-----BEGIN PRIVATE KEY-----\n${privateKeyBase64.match(/.{1,64}/g)!.join("\n")}\n-----END PRIVATE KEY-----`;
+  const pem = `-----BEGIN PRIVATE KEY-----\n${
+    privateKeyBase64.match(/.{1,64}/g)!.join("\n")
+  }\n-----END PRIVATE KEY-----`;
 
   return JSON.stringify({
     type: "service_account",
@@ -94,8 +95,9 @@ Deno.test("GCSBlobStorage signs JWT with RS256 using Web Crypto", async () => {
 
   const privateKeyDer = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
   const privateKeyBase64 = btoa(String.fromCharCode(...new Uint8Array(privateKeyDer)));
-  const pem =
-    `-----BEGIN PRIVATE KEY-----\n${privateKeyBase64.match(/.{1,64}/g)!.join("\n")}\n-----END PRIVATE KEY-----`;
+  const pem = `-----BEGIN PRIVATE KEY-----\n${
+    privateKeyBase64.match(/.{1,64}/g)!.join("\n")
+  }\n-----END PRIVATE KEY-----`;
 
   const saKey = JSON.stringify({
     type: "service_account",
@@ -131,11 +133,7 @@ Deno.test("GCSBlobStorage signs JWT with RS256 using Web Crypto", async () => {
     // Trigger getAccessToken by calling put (which calls getAccessToken internally)
     // Use a mock that returns after token fetch
     globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-      const url = typeof input === "string"
-        ? input
-        : input instanceof URL
-        ? input.href
-        : input.url;
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
       if (url === "https://oauth2.googleapis.com/token") {
         const body = new URLSearchParams(init?.body as string);
         capturedJwt = body.get("assertion") ?? "";

--- a/src/workflow/blob/gcs-storage.test.ts
+++ b/src/workflow/blob/gcs-storage.test.ts
@@ -116,22 +116,7 @@ Deno.test("GCSBlobStorage signs JWT with RS256 using Web Crypto", async () => {
   const originalFetch = globalThis.fetch;
   let capturedJwt = "";
 
-  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-    if (url === "https://oauth2.googleapis.com/token" && init?.body) {
-      const body = new URLSearchParams(init.body as string);
-      capturedJwt = body.get("assertion") ?? "";
-      return new Response(
-        JSON.stringify({ access_token: "test-token", expires_in: 3600 }),
-        { status: 200 },
-      );
-    }
-    return originalFetch(input, init);
-  }) as typeof fetch;
-
   try {
-    // Trigger getAccessToken by calling put (which calls getAccessToken internally)
-    // Use a mock that returns after token fetch
     globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
       if (url === "https://oauth2.googleapis.com/token") {

--- a/src/workflow/blob/gcs-storage.test.ts
+++ b/src/workflow/blob/gcs-storage.test.ts
@@ -1,0 +1,197 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { GCSBlobStorage } from "./gcs-storage.ts";
+
+// Generate a test RSA key pair using Web Crypto API
+async function generateTestServiceAccountKey(): Promise<string> {
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  );
+
+  const privateKeyDer = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+  const privateKeyBase64 = btoa(
+    String.fromCharCode(...new Uint8Array(privateKeyDer)),
+  );
+  const pem =
+    `-----BEGIN PRIVATE KEY-----\n${privateKeyBase64.match(/.{1,64}/g)!.join("\n")}\n-----END PRIVATE KEY-----`;
+
+  return JSON.stringify({
+    type: "service_account",
+    project_id: "test-project",
+    private_key: pem,
+    client_email: "test@test-project.iam.gserviceaccount.com",
+  });
+}
+
+Deno.test("GCSBlobStorage constructor validates serviceAccountKey JSON", () => {
+  assertThrows(
+    () =>
+      new GCSBlobStorage({
+        projectId: "test",
+        bucket: "test-bucket",
+        serviceAccountKey: "not-json",
+      }),
+    Error,
+    "valid JSON string",
+  );
+});
+
+Deno.test("GCSBlobStorage constructor rejects missing private_key", () => {
+  assertThrows(
+    () =>
+      new GCSBlobStorage({
+        projectId: "test",
+        bucket: "test-bucket",
+        serviceAccountKey: JSON.stringify({ client_email: "a@b.com" }),
+      }),
+    Error,
+    "private_key",
+  );
+});
+
+Deno.test("GCSBlobStorage constructor rejects missing client_email", () => {
+  assertThrows(
+    () =>
+      new GCSBlobStorage({
+        projectId: "test",
+        bucket: "test-bucket",
+        serviceAccountKey: JSON.stringify({
+          private_key: "-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----",
+        }),
+      }),
+    Error,
+    "client_email",
+  );
+});
+
+Deno.test("GCSBlobStorage constructor accepts valid service account key", async () => {
+  const key = await generateTestServiceAccountKey();
+  const storage = new GCSBlobStorage({
+    projectId: "test",
+    bucket: "test-bucket",
+    serviceAccountKey: key,
+  });
+  assertEquals(typeof storage, "object");
+});
+
+Deno.test("GCSBlobStorage signs JWT with RS256 using Web Crypto", async () => {
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  );
+
+  const privateKeyDer = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+  const privateKeyBase64 = btoa(String.fromCharCode(...new Uint8Array(privateKeyDer)));
+  const pem =
+    `-----BEGIN PRIVATE KEY-----\n${privateKeyBase64.match(/.{1,64}/g)!.join("\n")}\n-----END PRIVATE KEY-----`;
+
+  const saKey = JSON.stringify({
+    type: "service_account",
+    project_id: "test-project",
+    private_key: pem,
+    client_email: "test@test-project.iam.gserviceaccount.com",
+  });
+
+  const storage = new GCSBlobStorage({
+    projectId: "test-project",
+    bucket: "test-bucket",
+    serviceAccountKey: saKey,
+  });
+
+  // Intercept fetch to capture the JWT assertion and verify its signature
+  const originalFetch = globalThis.fetch;
+  let capturedJwt = "";
+
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url === "https://oauth2.googleapis.com/token" && init?.body) {
+      const body = new URLSearchParams(init.body as string);
+      capturedJwt = body.get("assertion") ?? "";
+      return new Response(
+        JSON.stringify({ access_token: "test-token", expires_in: 3600 }),
+        { status: 200 },
+      );
+    }
+    return originalFetch(input, init);
+  }) as typeof fetch;
+
+  try {
+    // Trigger getAccessToken by calling put (which calls getAccessToken internally)
+    // Use a mock that returns after token fetch
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.href
+        : input.url;
+      if (url === "https://oauth2.googleapis.com/token") {
+        const body = new URLSearchParams(init?.body as string);
+        capturedJwt = body.get("assertion") ?? "";
+        return new Response(
+          JSON.stringify({ access_token: "test-token", expires_in: 3600 }),
+          { status: 200 },
+        );
+      }
+      // Upload endpoint
+      return new Response(
+        JSON.stringify({
+          size: "5",
+          contentType: "text/plain",
+          timeCreated: new Date().toISOString(),
+          mediaLink: "https://storage.googleapis.com/test",
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    await storage.put("hello", { mimeType: "text/plain" });
+
+    // Verify the JWT structure
+    const parts = capturedJwt.split(".");
+    assertEquals(parts.length, 3, "JWT must have 3 parts");
+
+    // Decode header
+    const headerJson = JSON.parse(atob(parts[0].replace(/-/g, "+").replace(/_/g, "/")));
+    assertEquals(headerJson.alg, "RS256");
+    assertEquals(headerJson.typ, "JWT");
+
+    // Decode claims
+    const claimsJson = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
+    assertEquals(claimsJson.iss, "test@test-project.iam.gserviceaccount.com");
+    assertEquals(claimsJson.aud, "https://oauth2.googleapis.com/token");
+    assertEquals(typeof claimsJson.iat, "number");
+    assertEquals(typeof claimsJson.exp, "number");
+
+    // Verify signature is NOT "PLACEHOLDER_SIGNATURE"
+    assertEquals(parts[2] !== "PLACEHOLDER_SIGNATURE", true, "Signature must not be a placeholder");
+    assertEquals(parts[2].length > 20, true, "Signature must be a real RS256 signature");
+
+    // Verify the signature with the public key
+    const signatureBytes = Uint8Array.from(
+      atob(parts[2].replace(/-/g, "+").replace(/_/g, "/")),
+      (c) => c.charCodeAt(0),
+    );
+    const signingInput = new TextEncoder().encode(`${parts[0]}.${parts[1]}`);
+    const valid = await crypto.subtle.verify(
+      "RSASSA-PKCS1-v1_5",
+      keyPair.publicKey,
+      signatureBytes,
+      signingInput,
+    );
+    assertEquals(valid, true, "JWT signature must be verifiable with the corresponding public key");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/src/workflow/blob/gcs-storage.ts
+++ b/src/workflow/blob/gcs-storage.ts
@@ -45,6 +45,7 @@ export interface GCSBlobStorageConfig {
 
 export class GCSBlobStorage implements BlobStorage {
   private config: GCSBlobStorageConfig;
+  private serviceAccount: { private_key: string; client_email: string };
   private tokenCache: { accessToken: string; expiresAt: Date } | null = null;
 
   constructor(config: GCSBlobStorageConfig) {
@@ -66,6 +67,8 @@ export class GCSBlobStorage implements BlobStorage {
     if (typeof sa.client_email !== "string" || !sa.client_email) {
       throw new Error("GCSBlobStorage: serviceAccountKey must contain a valid client_email field.");
     }
+
+    this.serviceAccount = { private_key: sa.private_key, client_email: sa.client_email };
   }
 
   private getKey(id: string): string {
@@ -77,7 +80,7 @@ export class GCSBlobStorage implements BlobStorage {
       return this.tokenCache.accessToken;
     }
 
-    const sa = JSON.parse(this.config.serviceAccountKey);
+    const sa = this.serviceAccount;
     const tokenEndpoint = "https://oauth2.googleapis.com/token";
     const scope = "https://www.googleapis.com/auth/devstorage.full_control";
 

--- a/src/workflow/blob/gcs-storage.ts
+++ b/src/workflow/blob/gcs-storage.ts
@@ -3,6 +3,31 @@ import type { BlobRef, BlobStorage, StoreBlobOptions } from "./types.ts";
 
 const logger = baseLogger.component("gcs-blob-storage");
 
+function base64url(str: string): string {
+  return btoa(str).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64urlFromBytes(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function importPKCS8Key(pem: string): Promise<CryptoKey> {
+  const pemBody = pem
+    .replace(/-----BEGIN PRIVATE KEY-----/, "")
+    .replace(/-----END PRIVATE KEY-----/, "")
+    .replace(/\s/g, "");
+  const binaryDer = Uint8Array.from(atob(pemBody), (c) => c.charCodeAt(0));
+  return crypto.subtle.importKey(
+    "pkcs8",
+    binaryDer,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+}
+
 export interface GCSBlobStorageConfig {
   /** Google Cloud Project ID */
   projectId: string;
@@ -25,10 +50,21 @@ export class GCSBlobStorage implements BlobStorage {
   constructor(config: GCSBlobStorageConfig) {
     this.config = config;
 
+    let sa: Record<string, unknown>;
     try {
-      JSON.parse(this.config.serviceAccountKey);
+      sa = JSON.parse(this.config.serviceAccountKey);
     } catch {
       throw new Error("GCSBlobStorage: serviceAccountKey must be a valid JSON string.");
+    }
+
+    if (typeof sa.private_key !== "string" || !sa.private_key.includes("BEGIN PRIVATE KEY")) {
+      throw new Error(
+        "GCSBlobStorage: serviceAccountKey must contain a valid private_key field (PKCS8 PEM).",
+      );
+    }
+
+    if (typeof sa.client_email !== "string" || !sa.client_email) {
+      throw new Error("GCSBlobStorage: serviceAccountKey must contain a valid client_email field.");
     }
   }
 
@@ -49,8 +85,8 @@ export class GCSBlobStorage implements BlobStorage {
     const iat = Math.floor(now / 1000);
     const exp = iat + 3600;
 
-    const jwtHeader = btoa(JSON.stringify({ alg: "RS256", typ: "JWT" }));
-    const jwtClaimSet = btoa(
+    const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+    const claims = base64url(
       JSON.stringify({
         iss: sa.client_email,
         scope,
@@ -60,12 +96,15 @@ export class GCSBlobStorage implements BlobStorage {
       }),
     );
 
-    logger.warn(
-      "[GCSBlobStorage] JWT signing requires djwt library - using placeholder (not for production)",
+    const signingInput = `${header}.${claims}`;
+    const privateKey = await importPKCS8Key(sa.private_key);
+    const signatureBytes = await crypto.subtle.sign(
+      "RSASSA-PKCS1-v1_5",
+      privateKey,
+      new TextEncoder().encode(signingInput),
     );
-
-    const signature = "PLACEHOLDER_SIGNATURE";
-    const jwt = `${jwtHeader}.${jwtClaimSet}.${signature}`;
+    const signature = base64urlFromBytes(new Uint8Array(signatureBytes));
+    const jwt = `${signingInput}.${signature}`;
 
     const response = await fetch(tokenEndpoint, {
       method: "POST",


### PR DESCRIPTION
## Summary
- Replaced hardcoded `PLACEHOLDER_SIGNATURE` in GCS blob storage JWT assertions with real RS256 signing via Web Crypto API
- Added constructor validation for `private_key` (PKCS8 PEM) and `client_email` fields in service account key
- Added helper functions: `base64url()`, `base64urlFromBytes()`, `importPKCS8Key()` for JWT-compliant encoding and key import

## Test plan
- [x] Unit tests added (`gcs-storage.test.ts`) — 5 tests covering:
  - Constructor rejects invalid JSON
  - Constructor rejects missing `private_key`
  - Constructor rejects missing `client_email`
  - Constructor accepts valid service account key
  - JWT is signed with RS256 and signature verifies against public key
- [ ] Manual test with real GCS service account credentials