### PR TITLE
fix(inspect): inject source locations in dev/preview mode without studio_embed param

### DIFF
--- a/src/modules/react-loader/component-loader.ts
+++ b/src/modules/react-loader/component-loader.ts
@@ -35,6 +35,7 @@ export function loadComponentFromSource(
           dev,
           contentSourceId: options?.contentSourceId,
           reactVersion: options?.reactVersion,
+          mode: options?.mode,
         });
 
         return loader.loadModule(filePath, source);

--- a/src/modules/react-loader/ssr-module-loader/loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.test.ts
@@ -10,6 +10,15 @@ import { VERSION } from "#veryfront/utils/version.ts";
 import { computeConfigHashSync } from "../../../cache/config-hash.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import { makeTempDir, mkdir, remove, writeTextFile } from "#veryfront/testing/deno-compat.ts";
+import { injectNodePositions } from "#veryfront/transforms/plugins/babel-node-positions.ts";
+
+/** Hash source as the loader sees it (after node position injection for .tsx in dev/preview) */
+function hashAsLoader(source: string, filePath: string, projectDir: string): string {
+  const rel = filePath.startsWith(projectDir)
+    ? filePath.slice(projectDir.length).replace(/^\/+/, "")
+    : filePath;
+  return hashCodeHex(injectNodePositions(source, { filePath: rel }));
+}
 
 describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, () => {
   it("isolates cache by projectId", async () => {
@@ -66,7 +75,7 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       await mkdir(componentsDir, { recursive: true });
 
       const source = "export default function CacheInvalTest() { return null; }";
-      const contentHash = hashCodeHex(source);
+      const contentHash = hashAsLoader(source, filePath, projectDir);
       const configHash = computeConfigHashSync({ dev: true });
       const reactVersion = "default";
 
@@ -138,7 +147,7 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       await mkdir(componentsDir, { recursive: true });
 
       const source = "export default function CacheRetainOnRuntimeError() { return null; }";
-      const contentHash = hashCodeHex(source);
+      const contentHash = hashAsLoader(source, filePath, projectDir);
       const configHash = computeConfigHashSync({ dev: true });
       const reactVersion = "default";
 
@@ -284,7 +293,7 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       await mkdir(componentsDir, { recursive: true });
 
       const source = "export default function RebuildAfterStaleCache() { return null; }";
-      const contentHash = hashCodeHex(source);
+      const contentHash = hashAsLoader(source, filePath, projectDir);
       const configHash = computeConfigHashSync({ dev: true });
       const reactVersion = "default";
 
@@ -355,7 +364,7 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       const source = "export default function RetryAfterInProgressError() { return null; }";
       await writeTextFile(filePath, source);
 
-      const contentHash = hashCodeHex(source);
+      const contentHash = hashAsLoader(source, filePath, projectDir);
       const configHash = computeConfigHashSync({ dev: true });
       const reactVersion = "default";
       const contentCacheKey = buildSSRModuleCacheKey(

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -53,6 +53,7 @@ import { SSRDependencyValidator } from "./ssr-dependency-validator.ts";
 import { preflightLocalImports } from "./preflight-imports.ts";
 import { resolveVfModuleImports } from "./vf-module-resolver.ts";
 import { registerCSSImport } from "../css-import-collector.ts";
+import { injectNodePositions } from "#veryfront/transforms/plugins/babel-node-positions.ts";
 
 const logger = rendererLogger.component("ssr-module-loader");
 
@@ -344,7 +345,16 @@ export class SSRModuleLoader {
       );
     }
 
-    const code = source ?? (await this.options.adapter.fs.readFile(filePath));
+    let code = source ?? (await this.options.adapter.fs.readFile(filePath));
+
+    // Inject node positions for JSX files in dev mode
+    if (this.options.dev && /\.(tsx|jsx)$/i.test(filePath)) {
+      const relativeFilePath = filePath.startsWith(this.options.projectDir)
+        ? filePath.slice(this.options.projectDir.length).replace(/^\/+/, "")
+        : filePath;
+      code = injectNodePositions(code, { filePath: relativeFilePath });
+    }
+
     const contentHash = await this.cache.hashContentAsync(code);
     const contentCacheKey = this.cache.getCacheKey(`${filePath}:${contentHash}`);
     const filePathCacheKey = this.cache.getCacheKey(filePath);

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -347,8 +347,9 @@ export class SSRModuleLoader {
 
     let code = source ?? (await this.options.adapter.fs.readFile(filePath));
 
-    // Inject node positions for JSX files in dev mode
-    if (this.options.dev && /\.(tsx|jsx)$/i.test(filePath)) {
+    // Inject node positions for JSX files in dev or preview mode
+    const shouldInjectPositions = this.options.dev || this.options.mode === "preview";
+    if (shouldInjectPositions && /\.(tsx|jsx)$/i.test(filePath)) {
       const relativeFilePath = filePath.startsWith(this.options.projectDir)
         ? filePath.slice(this.options.projectDir.length).replace(/^\/+/, "")
         : filePath;

--- a/src/modules/react-loader/ssr-module-loader/types.ts
+++ b/src/modules/react-loader/ssr-module-loader/types.ts
@@ -20,6 +20,8 @@ export interface SSRModuleLoaderOptions {
   contentSourceId?: string;
   /** React version for transforms (defaults to DEFAULT_REACT_VERSION) */
   reactVersion?: string;
+  /** Request mode ("preview" | "production") for studio features */
+  mode?: string;
 }
 
 export interface ModuleCacheEntry {

--- a/src/modules/react-loader/types.ts
+++ b/src/modules/react-loader/types.ts
@@ -13,6 +13,8 @@ export interface LoadComponentOptions {
   contentSourceId?: string;
   /** React version for transforms (from project config) */
   reactVersion?: string;
+  /** Request mode ("preview" | "production") for studio features */
+  mode?: string;
 }
 
 export interface ComponentSource {

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -144,6 +144,8 @@ export interface ModuleServerOptions {
   allowedImportDirs?: string[];
   /** React version for transforms (from project config) */
   reactVersion?: string;
+  /** Request mode ("preview" | "production") for studio features like node positions */
+  mode?: string;
 }
 
 /** Serve transformed module at /_vf_modules/* path */
@@ -397,8 +399,9 @@ export function serveModule(req: Request, options: ModuleServerOptions): Promise
           const isSSR = url.searchParams.get("ssr") === "true" || userAgent.startsWith("Deno/");
 
           const studioEmbed = url.searchParams.get("studio_embed") === "true";
+          const shouldInjectPositions = dev || options.mode === "preview";
           const isJsxFile = /\.(tsx|jsx)$/i.test(sourceFile);
-          if (studioEmbed && !isFrameworkFile && isJsxFile) {
+          if (shouldInjectPositions && !isFrameworkFile && isJsxFile) {
             const relativeFilePath = sourceFile.startsWith(projectDir)
               ? sourceFile.slice(projectDir.length).replace(/^\/+/, "")
               : sourceFile;

--- a/src/rendering/component-handling.ts
+++ b/src/rendering/component-handling.ts
@@ -61,8 +61,8 @@ export async function handleComponentPage(
     logger.debug(`Loading TSX/JSX file: ${pageInfo.entity.path}`);
 
     // Node positions are injected by the SSR module loader (for all files
-    // including this entry point) when dev mode is enabled — no need to
-    // inject here to avoid double-injection which shifts positions.
+    // including this entry point) when dev || mode === "preview" — no need
+    // to inject here to avoid double-injection which shifts positions.
     const fileContent = await adapter.fs.readFile(pageInfo.entity.path);
 
     const clientModuleCode = options?.cachedClientModule ??
@@ -77,6 +77,7 @@ export async function handleComponentPage(
       ));
 
     const { loadComponentFromSource } = await import("#veryfront/modules/react-loader/index.ts");
+    const dev = options?.mode === "development";
     const PageComponent = await loadComponentFromSource(
       fileContent,
       pageInfo.entity.path,
@@ -84,7 +85,7 @@ export async function handleComponentPage(
       adapter,
       {
         projectId: options?.projectId ?? projectDir,
-        dev: true,
+        dev,
         moduleServerUrl: options?.moduleServerUrl,
         ssr: true,
         contentSourceId: options?.contentSourceId,

--- a/src/rendering/component-handling.ts
+++ b/src/rendering/component-handling.ts
@@ -9,7 +9,6 @@ import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { EntityInfo, PageBundle } from "#veryfront/types";
 import { createError, getErrorMessage, toError } from "#veryfront/errors/veryfront-error.ts";
 import { getProjectReact } from "#veryfront/react";
-import { injectNodePositions } from "#veryfront/transforms/plugins/babel-node-positions.ts";
 import { buildComponentCacheKey } from "#veryfront/cache/keys.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { registerLRUCache } from "#veryfront/cache";
@@ -50,6 +49,8 @@ export async function handleComponentPage(
     projectId?: string;
     /** Enable node position injection for Studio Navigator */
     studioEmbed?: boolean;
+    /** Request mode ("preview" | "production") for studio features */
+    mode?: string;
     /** Content source ID for cache isolation (branch name or release ID) */
     contentSourceId?: string;
     /** React version for transforms (from project config) */
@@ -59,13 +60,10 @@ export async function handleComponentPage(
   try {
     logger.debug(`Loading TSX/JSX file: ${pageInfo.entity.path}`);
 
-    const rawFileContent = await adapter.fs.readFile(pageInfo.entity.path);
-    const normalizedPath = pageInfo.entity.path.startsWith(projectDir)
-      ? pageInfo.entity.path.slice(projectDir.length).replace(/^\/+/, "")
-      : pageInfo.entity.path;
-    const fileContent = options?.studioEmbed
-      ? injectNodePositions(rawFileContent, { filePath: normalizedPath })
-      : rawFileContent;
+    // Node positions are injected by the SSR module loader (for all files
+    // including this entry point) when dev mode is enabled — no need to
+    // inject here to avoid double-injection which shifts positions.
+    const fileContent = await adapter.fs.readFile(pageInfo.entity.path);
 
     const clientModuleCode = options?.cachedClientModule ??
       (await bundleComponentForClient(

--- a/src/rendering/component-handling.ts
+++ b/src/rendering/component-handling.ts
@@ -89,6 +89,7 @@ export async function handleComponentPage(
         ssr: true,
         contentSourceId: options?.contentSourceId,
         reactVersion: options?.reactVersion,
+        mode: options?.mode,
       },
     );
 

--- a/src/rendering/page-renderer.ts
+++ b/src/rendering/page-renderer.ts
@@ -162,6 +162,7 @@ export class PageRenderer {
                   moduleServerUrl: this.moduleServerUrl,
                   projectId: options?.projectId,
                   studioEmbed: options?.studioEmbed,
+                  mode: this.mode,
                   contentSourceId: options?.contentSourceId,
                 },
               ),

--- a/src/server/handlers/request/module/module-server-handler.ts
+++ b/src/server/handlers/request/module/module-server-handler.ts
@@ -34,6 +34,7 @@ export function handleModuleServer(
           releaseId: ctx.releaseId ?? null,
           allowedImportDirs: ctx.config?.security?.allowedImportDirs,
           reactVersion,
+          mode: ctx.requestContext?.mode,
         });
 
         const response = createResponseBuilder(ctx)

--- a/src/studio/bridge/bridge-constants.ts
+++ b/src/studio/bridge/bridge-constants.ts
@@ -16,3 +16,4 @@ export const DATA_NODE_LINE = "data-node-line";
 export const DATA_NODE_COLUMN = "data-node-column";
 export const DATA_NODE_END_LINE = "data-node-end-line";
 export const DATA_NODE_END_COLUMN = "data-node-end-column";
+export const DATA_NODE_SOURCE = "data-node-source";

--- a/src/studio/bridge/bridge-inspector.ts
+++ b/src/studio/bridge/bridge-inspector.ts
@@ -12,6 +12,7 @@ import {
   DATA_NODE_ID,
   DATA_NODE_LINE,
   DATA_NODE_NAME,
+  DATA_NODE_SOURCE,
   DATA_VF_ID,
   DATA_VF_IGNORE,
   DATA_VF_SELECTOR,
@@ -97,18 +98,10 @@ function isValidElement(el: Element): boolean {
 }
 
 function getNodeType(el: Element): string {
-  const tagName = el.tagName.toLowerCase();
-
   const vfId = el.getAttribute(DATA_VF_ID) || "";
   if (vfId && /^[A-Z]/.test(vfId)) return "component";
   if (el.hasAttribute(DATA_VF_TEXT)) return "text";
-
-  if (
-    ["h1", "h2", "h3", "h4", "h5", "h6", "p", "blockquote", "ul", "ol", "li", "pre", "code"]
-      .includes(tagName)
-  ) {
-    return "markdown";
-  }
+  if (el.getAttribute(DATA_NODE_SOURCE) === "md") return "markdown";
 
   return "element";
 }

--- a/src/transforms/plugins/rehype-node-positions.test.ts
+++ b/src/transforms/plugins/rehype-node-positions.test.ts
@@ -46,6 +46,7 @@ describe("rehype-node-positions", () => {
       assertEquals(el.properties["data-node-name"], "h1");
       assertEquals(el.properties["data-node-line"], "3");
       assertEquals(el.properties["data-node-column"], "0"); // column - 1
+      assertEquals(el.properties["data-node-source"], "md");
     });
 
     it("converts column to 0-based", () => {
@@ -245,8 +246,11 @@ describe("rehype-node-positions", () => {
       runPlugin(tree, { filePath: "docs/page.mdx" });
 
       assertEquals(el.properties["data-node-name"], "h1");
+      assertEquals(el.properties["data-node-source"], "md");
       const nameAttr = mdx.attributes.find((a: Any) => a.name === "data-node-name");
       assertEquals(nameAttr?.value, "Alert");
+      const sourceAttr = mdx.attributes.find((a: Any) => a.name === "data-node-source");
+      assertEquals(sourceAttr, undefined);
     });
 
     it("ignores unrelated node types", () => {

--- a/src/transforms/plugins/rehype-node-positions.ts
+++ b/src/transforms/plugins/rehype-node-positions.ts
@@ -42,6 +42,7 @@ export function rehypeNodePositions(
         props["data-node-name"] = el.tagName;
         props["data-node-line"] = String(start.line);
         props["data-node-column"] = String(start.column - 1);
+        props["data-node-source"] = "md";
         return;
       }
 


### PR DESCRIPTION
## Summary

Fixes #519 — child component elements reported `line: 0, column: 0` in inspect mode because source location injection didn't propagate through ESM imports.

- **SSR module loader**: Inject node positions for all JSX/TSX files (including child components) when in dev mode
- **Module server**: Decouple position injection from `?studio_embed` param — inject when `dev || mode === "preview"`
- **Bridge inspector**: Replace tag-name heuristic in `getNodeType()` with `data-node-source="md"` attribute check
- **Rehype plugin**: Stamp `data-node-source="md"` on markdown-originated elements (not explicit HTML/JSX in MDX)
- **Component handling**: Remove duplicate injection (SSR loader handles all files) to prevent position offset bugs

## Test plan
- [x] Existing babel-node-positions tests pass
- [x] Existing rehype-node-positions tests pass (new assertions for `data-node-source`)
- [x] Module server tests pass
- [ ] Manual: verify inspect mode highlights correct elements for child components
- [ ] Manual: verify markdown vs HTML elements classified correctly in bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)