### PR TITLE
fix: resolve packageRoot to absolute path for Windows esbuild

### DIFF
--- a/src/build/production-build/client-runtime.ts
+++ b/src/build/production-build/client-runtime.ts
@@ -54,7 +54,7 @@ async function readTextFile(path: string): Promise<string> {
 }
 
 const moduleDir = dirname(fromFileUrl(import.meta.url));
-const packageRoot = join(moduleDir, "..", "..", "..");
+const packageRoot = resolve(join(moduleDir, "..", "..", ".."));
 const vfSrcPrefix = "@vf-src/";
 const moduleExtensions = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".mts", ".cjs", ".cts"] as const;
 const externalSpecifier = /^(std\/|@std\/|node:|deno:|https?:)/;


### PR DESCRIPTION
## Summary

- `join(moduleDir, "..", "..", "..")` in `client-runtime.ts` can produce a relative path (`./../../..`) on Windows
- esbuild's `absWorkingDir` requires an absolute path, causing the Windows binary build to fail
- Wrapping with `resolve()` ensures the path is always absolute

Fixes the Windows `build-binaries` failure introduced when `build:prepare` was added to CI (which now runs `prebundle-client-scripts.ts` that triggers esbuild).

## Test plan

- [ ] Windows CI build-binaries job passes