### PR TITLE
fix: handle Windows backslash paths in Deno path compat layer

### DIFF
--- a/src/platform/compat/path/basic-operations.test.ts
+++ b/src/platform/compat/path/basic-operations.test.ts
@@ -37,6 +37,10 @@ describe("platform/compat/path/basic-operations", () => {
     it("should return . for files without directory", () => {
       assertEquals(dirname("file.ts"), ".");
     });
+
+    it("should handle Windows backslash paths", () => {
+      assertEquals(dirname("D:\\a\\project\\src\\file.ts"), "D:/a/project/src");
+    });
   });
 
   describe("basename", () => {

--- a/src/platform/compat/path/basic-operations.ts
+++ b/src/platform/compat/path/basic-operations.ts
@@ -4,10 +4,16 @@ function useNodePath(): boolean {
   return !isDeno && hasNodePath;
 }
 
+/** Normalize backslashes to forward slashes (for Deno on Windows). */
+function normSep(p: string): string {
+  return p.includes("\\") ? p.replace(/\\/g, "/") : p;
+}
+
 export function join(...paths: string[]): string {
   if (useNodePath()) return nodePath!.join(...paths);
 
   const joined = paths
+    .map(normSep)
     .filter((p) => p.length > 0)
     .join("/")
     .replace(/\/+/g, "/")
@@ -19,10 +25,11 @@ export function join(...paths: string[]): string {
 export function dirname(path: string): string {
   if (useNodePath()) return nodePath!.dirname(path);
 
-  const lastSlash = path.lastIndexOf("/");
+  const p = normSep(path);
+  const lastSlash = p.lastIndexOf("/");
   if (lastSlash === -1) return ".";
   if (lastSlash === 0) return "/";
-  return path.slice(0, lastSlash);
+  return p.slice(0, lastSlash);
 }
 
 export function basename(path: string, ext?: string): string {
@@ -31,7 +38,7 @@ export function basename(path: string, ext?: string): string {
     return ext === undefined ? nodePath!.basename(path) : nodePath!.basename(path, ext);
   }
 
-  let normalizedPath = path;
+  let normalizedPath = normSep(path);
   while (normalizedPath.length > 1 && normalizedPath.endsWith("/")) {
     normalizedPath = normalizedPath.slice(0, -1);
   }

--- a/src/platform/compat/path/resolution.test.ts
+++ b/src/platform/compat/path/resolution.test.ts
@@ -19,6 +19,24 @@ describe("platform/compat/path/resolution", () => {
     it("should use last absolute path", () => {
       assertEquals(resolve("/first", "/second"), "/second");
     });
+
+    it("should handle Windows drive-letter paths", () => {
+      assertEquals(
+        resolve("D:/a/project/src/build", "..", "..", ".."),
+        "D:/a",
+      );
+    });
+
+    it("should handle Windows backslash paths", () => {
+      assertEquals(
+        resolve("D:\\a\\project\\src\\build", "..", "..", ".."),
+        "D:/a",
+      );
+    });
+
+    it("should preserve drive letter when resolving to root", () => {
+      assertEquals(resolve("D:/a", ".."), "D:/");
+    });
   });
 
   describe("isAbsolute", () => {
@@ -32,6 +50,11 @@ describe("platform/compat/path/resolution", () => {
 
     it("should return false for dot-relative paths", () => {
       assertEquals(isAbsolute("./file"), false);
+    });
+
+    it("should return true for Windows drive-letter paths", () => {
+      assertEquals(isAbsolute("D:/a/project"), true);
+      assertEquals(isAbsolute("C:\\Users\\test"), true);
     });
   });
 
@@ -72,6 +95,14 @@ describe("platform/compat/path/resolution", () => {
 
     it("should handle relative parent traversal", () => {
       assertEquals(normalize("../foo"), "../foo");
+    });
+
+    it("should normalize Windows backslash paths", () => {
+      assertEquals(normalize("D:\\a\\project\\src\\..\\lib"), "D:/a/project/lib");
+    });
+
+    it("should preserve Windows drive letter", () => {
+      assertEquals(normalize("D:/"), "D:/");
     });
   });
 });

--- a/src/platform/compat/path/resolution.ts
+++ b/src/platform/compat/path/resolution.ts
@@ -4,14 +4,37 @@ function useNodePath(): boolean {
   return !isDeno && hasNodePath;
 }
 
+/** Normalize backslashes to forward slashes (for Deno on Windows). */
+function normSep(p: string): string {
+  return p.includes("\\") ? p.replace(/\\/g, "/") : p;
+}
+
+/** Match Windows drive letter prefix like "C:/" */
+const DRIVE_LETTER = /^[A-Za-z]:\//;
+
 export function resolve(...paths: string[]): string {
   if (useNodePath()) return nodePath!.resolve(...paths);
 
-  let resolvedPath = globalThis.Deno?.cwd() ?? "/";
+  let resolvedPath = normSep(globalThis.Deno?.cwd() ?? "/");
 
-  for (const path of paths) {
-    if (!path) continue;
-    resolvedPath = path.startsWith("/") ? path : `${resolvedPath}/${path}`;
+  for (const rawPath of paths) {
+    if (!rawPath) continue;
+    const path = normSep(rawPath);
+    if (path.startsWith("/") || DRIVE_LETTER.test(path)) {
+      resolvedPath = path;
+    } else {
+      resolvedPath = `${resolvedPath}/${path}`;
+    }
+  }
+
+  // Preserve drive letter prefix (e.g. "D:/") if present
+  let prefix = "/";
+  const driveMatch = resolvedPath.match(DRIVE_LETTER);
+  if (driveMatch) {
+    prefix = driveMatch[0]; // e.g. "D:/"
+    resolvedPath = resolvedPath.slice(prefix.length);
+  } else if (resolvedPath.startsWith("/")) {
+    resolvedPath = resolvedPath.slice(1);
   }
 
   const parts = resolvedPath.split("/").filter(Boolean);
@@ -25,22 +48,31 @@ export function resolve(...paths: string[]): string {
     if (part !== ".") resolved.push(part);
   }
 
-  return `/${resolved.join("/")}`;
+  return `${prefix}${resolved.join("/")}`;
 }
 
 export function isAbsolute(path: string): boolean {
   if (useNodePath()) return nodePath!.isAbsolute(path);
   // Deno fallback: Unix, Windows drive letters, and UNC paths
   if (path.startsWith("/")) return true;
-  if (/^[A-Za-z]:[\/\\]/.test(path)) return true;
+  if (/^[A-Za-z]:[/\\]/.test(path)) return true;
   return /^\\\\[^\\]+\\[^\\]+/.test(path);
 }
 
 export function relative(from: string, to: string): string {
   if (useNodePath()) return nodePath!.relative(from, to);
 
-  const fromParts = resolve(from).split("/").filter(Boolean);
-  const toParts = resolve(to).split("/").filter(Boolean);
+  const resolvedFrom = resolve(from);
+  const resolvedTo = resolve(to);
+
+  // Strip drive prefix for comparison (both will share the same drive after resolve)
+  const fromDrive = resolvedFrom.match(DRIVE_LETTER);
+  const fromBase = fromDrive ? resolvedFrom.slice(fromDrive[0].length) : resolvedFrom.slice(1);
+  const toDrive = resolvedTo.match(DRIVE_LETTER);
+  const toBase = toDrive ? resolvedTo.slice(toDrive[0].length) : resolvedTo.slice(1);
+
+  const fromParts = fromBase.split("/").filter(Boolean);
+  const toParts = toBase.split("/").filter(Boolean);
 
   let common = 0;
   const minLen = Math.min(fromParts.length, toParts.length);
@@ -60,8 +92,20 @@ export function normalize(path: string): string {
   if (useNodePath()) return nodePath!.normalize(path);
   if (path === "") return ".";
 
-  const abs = isAbsolute(path);
-  const parts = path.split("/").filter((p) => p && p !== ".");
+  const p = normSep(path);
+  const abs = isAbsolute(p);
+
+  // Preserve drive letter prefix
+  let prefix = "";
+  const driveMatch = p.match(DRIVE_LETTER);
+  if (driveMatch) {
+    prefix = driveMatch[0];
+  } else if (abs) {
+    prefix = "/";
+  }
+
+  const pathWithoutPrefix = driveMatch ? p.slice(prefix.length) : abs ? p.slice(1) : p;
+  const parts = pathWithoutPrefix.split("/").filter((s) => s && s !== ".");
 
   const normalized: string[] = [];
 
@@ -82,7 +126,7 @@ export function normalize(path: string): string {
 
   const result = normalized.join("/");
 
-  if (abs) return result ? `/${result}` : "/";
+  if (abs) return result ? `${prefix}${result}` : prefix || "/";
 
   return result || ".";
 }


### PR DESCRIPTION
## Summary

- Fixes the Windows binary build failure (`The working directory "/" is not an absolute path`)
- Root cause: the POSIX-only path fallback functions (`dirname`, `join`, `resolve`, `normalize`, `relative`) only split on `/`, but `fromFileUrl` on Windows Deno returns backslash-separated paths like `D:\a\project\src\...`
- Adds `normSep()` backslash→forward-slash normalization at function entry points
- Makes `resolve` and `normalize` aware of Windows drive-letter prefixes (`D:/`) so they're preserved through parent traversal
- Adds 7 new Windows path tests covering drive letters, backslashes, and normalization

This fixes the underlying compat layer bug that #523 worked around at the call site.

## Test plan

- [x] All 104 existing + new path test steps pass
- [x] Simulated the exact CI scenario: `resolve(join(dirname("D:\\a\\veryfront-code\\veryfront-code\\src\\build\\production-build\\client-runtime.ts"), "..", "..", ".."))` → `D:/a/veryfront-code/veryfront-code` ✓
- [ ] Windows CI binary build passes