### PR TITLE
fix: include embedding module in compiled binary

### DIFF
--- a/src/discovery/transpiler.test.ts
+++ b/src/discovery/transpiler.test.ts
@@ -4,6 +4,7 @@ import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
 import { clearTranspileCache, importModule } from "./transpiler.ts";
 import type { FileDiscoveryContext } from "./types.ts";
 import { stop as stopEsbuild } from "esbuild";
+import * as embeddingMod from "#veryfront/embedding/index.ts";
 
 /**
  * Creates a mock FileSystemAdapter backed by an in-memory file map.
@@ -54,6 +55,37 @@ function createMockAdapter(
     },
   } satisfies FileSystemAdapter;
 }
+
+describe("embedding module static import", () => {
+  // The embedding module must be statically imported so deno compile includes
+  // it in the binary. Unlike agent/tool/platform which are statically imported
+  // throughout the codebase, embedding is only referenced in transpiler.ts.
+  // If this import breaks, the compiled binary will fail to load upload handlers.
+
+  it("exports createUploadHandler", () => {
+    assertEquals(typeof embeddingMod.createUploadHandler, "function");
+  });
+
+  it("exports uploadStore", () => {
+    assertEquals(typeof embeddingMod.uploadStore, "function");
+  });
+
+  it("exports embedding", () => {
+    assertEquals(typeof embeddingMod.embedding, "function");
+  });
+
+  it("exports vectorStore", () => {
+    assertEquals(typeof embeddingMod.vectorStore, "function");
+  });
+
+  it("exports chunk", () => {
+    assertEquals(typeof embeddingMod.chunk, "function");
+  });
+
+  it("exports loadUpload", () => {
+    assertEquals(typeof embeddingMod.loadUpload, "function");
+  });
+});
 
 describe("discovery/transpiler", () => {
   afterEach(() => {

--- a/src/discovery/transpiler.ts
+++ b/src/discovery/transpiler.ts
@@ -14,6 +14,10 @@ import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { FileDiscoveryContext } from "./types.ts";
 import { rewriteDiscoveryImports, rewriteForDeno } from "./import-rewriter.ts";
 import { wrapWithCurrentContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
+// Static import ensures deno compile includes embedding in the binary.
+// Other modules (agent, tool, etc.) are statically imported elsewhere;
+// embedding is only referenced here.
+import * as embeddingMod from "#veryfront/embedding/index.ts";
 
 const transpileCache = new Map<string, unknown>();
 
@@ -26,13 +30,12 @@ let veryfrontGlobalsInitialized = false;
 async function ensureVeryfrontGlobals(): Promise<void> {
   if (veryfrontGlobalsInitialized || !isDenoCompiled) return;
 
-  const [agentMod, toolMod, platformMod, promptMod, resourceMod, embeddingMod] = await Promise.all([
+  const [agentMod, toolMod, platformMod, promptMod, resourceMod] = await Promise.all([
     import("#veryfront/agent"),
     import("#veryfront/tool"),
     import("#veryfront/platform"),
     import("#veryfront/prompt"),
     import("#veryfront/resource"),
-    import("#veryfront/embedding"),
   ]);
 
   (globalThis as Record<string, unknown>).__VERYFRONT_MODULES__ = {

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -246,6 +246,28 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
     assertEquals(typeof route?.GET, "function");
   });
 
+  it("loads handler that imports veryfront/embedding", async () => {
+    const tmpDir = await makeTempDir();
+    const modulePath = join(tmpDir, "handler.ts");
+
+    await fs.writeTextFile(
+      modulePath,
+      [
+        `import { createUploadHandler } from "veryfront/embedding";`,
+        `export const GET = () => new Response(typeof createUploadHandler);`,
+      ].join("\n"),
+    );
+
+    const route = await loadHandlerModule({
+      projectDir: tmpDir,
+      modulePath,
+      adapter,
+      config: undefined,
+    });
+
+    assertEquals(typeof route?.GET, "function");
+  });
+
   it("converts aliased named imports to valid CJS destructuring", () => {
     assertEquals(
       toCjsDestructureBindings("{ parse as parsePdf, version }"),

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -973,11 +973,26 @@ async function registerVfModules(subpaths: Set<string>): Promise<void> {
     Record<string, unknown>
   >;
 
+  // __VERYFRONT_MODULES__ is populated by the discovery transpiler via hash
+  // imports (#veryfront/...) which resolve correctly in compiled binaries.
+  // Check it first before attempting bare specifier dynamic imports.
+  const discoveryModules = (globalThis as Record<string, unknown>).__VERYFRONT_MODULES__ as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+
   for (const subpath of subpaths) {
     if (modules[subpath]) continue;
 
+    const specifier = `veryfront/${subpath}`;
+
+    const fromDiscovery = discoveryModules?.[specifier];
+    if (fromDiscovery) {
+      modules[subpath] = fromDiscovery;
+      logger.debug(`[API] Registered module ${specifier} from discovery globals`);
+      continue;
+    }
+
     try {
-      const specifier = `veryfront/${subpath}`;
       modules[subpath] = await import(specifier) as Record<string, unknown>;
       logger.debug(`[API] Registered module ${specifier} on globalThis`);
     } catch (e) {


### PR DESCRIPTION
## Summary

- The embedding module (`veryfront/embedding`) was only dynamically imported in the discovery transpiler, so `deno compile` excluded it from the binary. This caused upload handler routes to fail with `Module not found: file:///tmp/deno-compile-veryfront/src/embedding` at runtime.
- Add a static `import * as embeddingMod` in `transpiler.ts` so the compiler includes it. Other modules (agent, tool, platform, etc.) already work because they're statically imported elsewhere in the codebase.
- Also make `registerVfModules` in the API loader check `__VERYFRONT_MODULES__` (populated by the transpiler) before attempting bare specifier dynamic imports that fail in compiled binaries.

## Test plan

- [x] Added test verifying the embedding static import has expected exports (`createUploadHandler`, `uploadStore`, etc.)
- [x] Added test verifying `loadHandlerModule` succeeds with a handler that imports `veryfront/embedding`
- [x] Manually tested: built binary, ran `veryfront dev` on legal-app, uploaded PDF — returns 200 with `{"success":true}`