### PR TITLE
fix: show correct provider avatar after local-to-cloud auto-upgrade

### DIFF
--- a/src/agent/react/use-chat/types.ts
+++ b/src/agent/react/use-chat/types.ts
@@ -129,6 +129,8 @@ export interface UseChatResult {
   error: Error | null;
   /** Current model override (undefined = use agent default) */
   model: string | undefined;
+  /** The actual model being used after auto-upgrade (e.g. "anthropic/claude-sonnet-4-20250514") */
+  activeModel: string | undefined;
   /** Where inference is currently happening */
   inferenceMode: InferenceMode;
   /** Browser-side model loading/inference status (null when not using browser fallback) */

--- a/src/agent/react/use-chat/use-chat.ts
+++ b/src/agent/react/use-chat/use-chat.ts
@@ -75,6 +75,7 @@ export function useChat(options: UseChatOptions): UseChatResult {
   const [data, setData] = useState<unknown>(null);
   const [model, setModel] = useState<string | undefined>(options.model);
   const [inferenceMode, setInferenceMode] = useState<InferenceMode>("cloud");
+  const [activeModel, setActiveModel] = useState<string | undefined>(undefined);
   const [browserStatus, setBrowserStatus] = useState<BrowserInferenceStatus | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const requestIdRef = useRef(0);
@@ -300,15 +301,18 @@ export function useChat(options: UseChatOptions): UseChatResult {
           },
           onData: (eventData) => {
             setData(eventData);
-            // Detect inference mode from server metadata
+            // Detect inference mode and resolved model from server metadata
             if (
               eventData &&
               typeof eventData === "object" &&
               "inferenceMode" in eventData
             ) {
-              const mode = (eventData as { inferenceMode: string }).inferenceMode;
-              if (mode === "server-local" || mode === "cloud") {
-                setInferenceMode(mode);
+              const d = eventData as { inferenceMode: string; model?: string };
+              if (d.inferenceMode === "server-local" || d.inferenceMode === "cloud") {
+                setInferenceMode(d.inferenceMode);
+              }
+              if (d.model) {
+                setActiveModel(d.model);
               }
             }
           },
@@ -547,6 +551,7 @@ export function useChat(options: UseChatOptions): UseChatResult {
     isLoading,
     error,
     model,
+    activeModel,
     inferenceMode,
     browserStatus,
     setInput,

--- a/src/agent/react/use-chat/use-chat.ts
+++ b/src/agent/react/use-chat/use-chat.ts
@@ -283,6 +283,7 @@ export function useChat(options: UseChatOptions): UseChatResult {
         const currentMessageIdRef = { current: streamingMessageId };
         // Mutable local — updated by onData before onMessage/onUpdate use it.
         let serverModel: string | undefined = model;
+        setActiveModel(undefined);
 
         await handleStreamingResponse(response.body, {
           onMessage: (assistantMessage) => {

--- a/src/agent/react/use-chat/use-chat.ts
+++ b/src/agent/react/use-chat/use-chat.ts
@@ -281,12 +281,14 @@ export function useChat(options: UseChatOptions): UseChatResult {
         const streamingMessageId = generateClientId("msg");
         let hasAddedStreamingMessage = false;
         const currentMessageIdRef = { current: streamingMessageId };
+        // Mutable local — updated by onData before onMessage/onUpdate use it.
+        let serverModel: string | undefined = model;
 
         await handleStreamingResponse(response.body, {
           onMessage: (assistantMessage) => {
             const withMeta = {
               ...assistantMessage,
-              metadata: { ...assistantMessage.metadata, model },
+              metadata: { ...assistantMessage.metadata, model: serverModel },
             };
             setMessages((prev) => {
               if (!hasAddedStreamingMessage) return [...prev, withMeta];
@@ -312,6 +314,7 @@ export function useChat(options: UseChatOptions): UseChatResult {
                 setInferenceMode(d.inferenceMode);
               }
               if (d.model) {
+                serverModel = d.model;
                 setActiveModel(d.model);
               }
             }
@@ -333,7 +336,7 @@ export function useChat(options: UseChatOptions): UseChatResult {
               hasAddedStreamingMessage = true;
               setMessages((
                 prev,
-              ) => [...prev, { id, role: "assistant", parts, metadata: { model } }]);
+              ) => [...prev, { id, role: "assistant", parts, metadata: { model: serverModel } }]);
               return;
             }
 

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -192,11 +192,17 @@ export class AgentRuntime {
 
           const messageId = generateMessageId();
           sendSSE(controller, encoder, { type: "message-start", messageId });
+          // Report the effective model — when resolveModel falls back from
+          // cloud to local (e.g. missing API key), use the resolved object's
+          // modelId so the client avatar matches the actual provider.
+          const effectiveModel = isLocal && !resolvedModelString.startsWith("local/")
+            ? `local/${(languageModel as Record<string, unknown>).modelId ?? "unknown"}`
+            : resolvedModelString;
           sendSSE(controller, encoder, {
             type: "data",
             data: {
               inferenceMode: isLocal ? "server-local" : "cloud",
-              model: resolvedModelString,
+              model: effectiveModel,
             },
           });
           sendSSE(controller, encoder, { type: "text-start", id: textPartId });

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -196,6 +196,7 @@ export class AgentRuntime {
             type: "data",
             data: {
               inferenceMode: isLocal ? "server-local" : "cloud",
+              model: resolvedModelString,
             },
           });
           sendSSE(controller, encoder, { type: "text-start", id: textPartId });

--- a/src/react/components/ai/chat-with-sidebar.tsx
+++ b/src/react/components/ai/chat-with-sidebar.tsx
@@ -24,6 +24,7 @@ export interface ChatWithSidebarChatController {
   isLoading?: ChatProps["isLoading"];
   error?: ChatProps["error"];
   model?: ChatProps["model"];
+  activeModel?: ChatProps["activeModel"];
   onModelChange?: ChatProps["onModelChange"];
   inferenceMode?: ChatProps["inferenceMode"];
   browserStatus?: ChatProps["browserStatus"];

--- a/src/react/components/ai/chat-with-sidebar.tsx
+++ b/src/react/components/ai/chat-with-sidebar.tsx
@@ -170,6 +170,7 @@ export const ChatWithSidebar = React.forwardRef<HTMLDivElement, ChatWithSidebarP
       showScrollButton: features?.scrollButton,
       showMessageActions: features?.messageActions,
       models: models?.options,
+      activeModel: chat.activeModel,
       inferenceMode: chat.inferenceMode,
       browserStatus: chat.browserStatus,
       showSources: features?.sources,

--- a/src/react/components/ai/chat/index.tsx
+++ b/src/react/components/ai/chat/index.tsx
@@ -218,6 +218,8 @@ export interface ChatProps {
   showMessageActions?: boolean;
   models?: ModelOption[];
   model?: string;
+  /** The actual resolved model after auto-upgrade (used for avatar display) */
+  activeModel?: string;
   onModelChange?: (model: string) => void;
   inferenceMode?: InferenceMode;
   browserStatus?: BrowserInferenceStatus | null;
@@ -282,6 +284,7 @@ export const Chat = React.forwardRef<HTMLDivElement, ChatProps>(function Chat(
     showMessageActions = true,
     models,
     model,
+    activeModel,
     onModelChange,
     inferenceMode,
     browserStatus,
@@ -445,7 +448,7 @@ export const Chat = React.forwardRef<HTMLDivElement, ChatProps>(function Chat(
             theme={theme}
             renderMessage={renderMessage}
             renderTool={renderTool}
-            model={model}
+            model={activeModel || model}
             showMessageActions={showMessageActions}
             showSources={showSources}
             showSteps={showSteps}

--- a/tests/ai/chat-handler-fallback.test.ts
+++ b/tests/ai/chat-handler-fallback.test.ts
@@ -265,10 +265,9 @@ describe("runtime inference mode metadata", () => {
         (e) => e.type === "data" && typeof e.data === "object",
       );
       assertEquals(dataEvent !== undefined, true, "Should have a data event");
-      assertEquals(
-        (dataEvent?.data as { inferenceMode: string })?.inferenceMode,
-        "cloud",
-      );
+      const dataPayload = dataEvent?.data as { inferenceMode: string; model: string };
+      assertEquals(dataPayload.inferenceMode, "cloud");
+      assertEquals(dataPayload.model, "mock/test-model", "model field should match requested cloud model");
     } finally {
       if (originalLogLevel) setEnv("LOG_LEVEL", originalLogLevel);
       if (originalNodeEnv) setEnv("NODE_ENV", originalNodeEnv);
@@ -302,7 +301,7 @@ describe("runtime inference mode metadata", () => {
 
       const mockLocal = new MockLanguageModelV3({
         provider: "local",
-        modelId: "local/smollm2-135m",
+        modelId: "smollm2-135m",
         doStream: async () => ({
           stream: simulateReadableStream({
             chunks: [
@@ -370,9 +369,13 @@ describe("runtime inference mode metadata", () => {
         (e) => e.type === "data" && typeof e.data === "object",
       );
       assertEquals(dataEvent !== undefined, true, "Should have a data event");
+      const dataPayload = dataEvent?.data as { inferenceMode: string; model: string };
+      assertEquals(dataPayload.inferenceMode, "server-local");
+      // effectiveModel: requested "openai/gpt-4o" fell back to local — model should reflect the local modelId
       assertEquals(
-        (dataEvent?.data as { inferenceMode: string })?.inferenceMode,
-        "server-local",
+        dataPayload.model,
+        "local/smollm2-135m",
+        "model field should reflect the resolved local model, not the originally requested cloud model",
       );
     } finally {
       if (originalLogLevel) setEnv("LOG_LEVEL", originalLogLevel);
@@ -455,9 +458,13 @@ describe("runtime inference mode metadata", () => {
         (e) => e.type === "data" && typeof e.data === "object",
       );
       assertEquals(dataEvent !== undefined, true, "Should have a data event");
+      const dataPayload = dataEvent?.data as { inferenceMode: string; model: string };
+      assertEquals(dataPayload.inferenceMode, "cloud");
+      // Auto-upgraded from local to anthropic — model should be the cloud model string
       assertEquals(
-        (dataEvent?.data as { inferenceMode: string })?.inferenceMode,
-        "cloud",
+        dataPayload.model,
+        "anthropic/claude-sonnet-4-20250514",
+        "model field should reflect the upgraded cloud model",
       );
     } finally {
       if (originalLogLevel) setEnv("LOG_LEVEL", originalLogLevel);

--- a/tests/ai/use-chat-streaming.test.ts
+++ b/tests/ai/use-chat-streaming.test.ts
@@ -212,6 +212,24 @@ describe("useChat streaming handler (veryfront protocol)", () => {
     assertEquals(getTextContent(result.messages[0]!), "Local response");
   });
 
+  it("handles model field in data event from server", async () => {
+    const result = await processStream([
+      { type: "message-start", messageId: "msg-model" },
+      { type: "data", data: { inferenceMode: "cloud", model: "anthropic/claude-sonnet-4-20250514" } },
+      { type: "text-start", id: "text-1" },
+      { type: "text-delta", id: "text-1", delta: "Cloud response" },
+      { type: "text-end", id: "text-1" },
+      { type: "message-finish" },
+    ]);
+
+    assertEquals(result.dataEvents.length, 1);
+    assertEquals(
+      (result.dataEvents[0] as { model: string }).model,
+      "anthropic/claude-sonnet-4-20250514",
+    );
+    assertEquals(getTextContent(result.messages[0]!), "Cloud response");
+  });
+
   it("uses parts array as primary content structure", async () => {
     const result = await processStream([
       { type: "message-start", messageId: "msg-parts" },


### PR DESCRIPTION
## Summary
- Server now sends the resolved model string (e.g. `anthropic/claude-sonnet-4-20250514`) in the SSE `data` event alongside `inferenceMode`
- Uses `effectiveModel` logic to report the actual local model ID when cloud→local fallback occurs (e.g. missing API key)
- Client `useChat` hook stores it as `activeModel` and exposes it in `UseChatResult`
- `ChatMessageList` uses `activeModel` (falling back to `model`) for the `ModelAvatar`, so the correct provider logo (Anthropic, OpenAI, Google) is displayed even after local-to-cloud auto-upgrade
- Resets `activeModel` between conversations to prevent stale avatar

## Test plan
- [x] Existing chat tests pass (fallback, streaming, state)
- [x] SSE `model` field assertions for cloud, cloud→local fallback, and auto-upgrade scenarios
- [x] Streaming parser test for model field in data event
- [x] E2E: legal-app shows `"model":"anthropic/claude-sonnet-4-20250514"` in SSE data event
- [x] E2E: avatar resolves to Anthropic logo instead of generic sparkles icon