### PR TITLE
feat: add contract-review-agent template

### DIFF
--- a/cli/app/shell.ts
+++ b/cli/app/shell.ts
@@ -97,6 +97,7 @@ export function createApp(config: AppConfig): App {
 
   state = setTemplates([
     { id: "ai-agent", name: "AI Chatbot", description: "Agent + chat UI + streaming" },
+    { id: "contract-review-agent", name: "Contract Review", description: "Upload contracts for clause-by-clause analysis + redlines" },
     { id: "docs-agent", name: "Docs Agent", description: "Document Q&A with source citations" },
     {
       id: "multi-agent-system",

--- a/cli/commands/init/catalog.test.ts
+++ b/cli/commands/init/catalog.test.ts
@@ -17,11 +17,12 @@ import {
 describe("catalog", () => {
   describe("TEMPLATES", () => {
     it("contains expected templates", () => {
-      assertEquals(TEMPLATES.length, 7);
+      assertEquals(TEMPLATES.length, 8);
       const ids = TEMPLATES.map((t) => t.id);
       assertEquals(ids, [
         "minimal",
         "ai-agent",
+        "contract-review-agent",
         "docs-agent",
         "agentic-workflow",
         "multi-agent-system",

--- a/cli/commands/init/catalog.ts
+++ b/cli/commands/init/catalog.ts
@@ -21,6 +21,11 @@ export const TEMPLATES: readonly TemplateOption[] = [
   { id: "minimal", label: "Minimal", description: "Blank canvas, no extras" },
   { id: "ai-agent", label: "AI Agent", description: "Agent + chat UI + streaming" },
   {
+    id: "contract-review-agent",
+    label: "Contract Review",
+    description: "Upload contracts for clause-by-clause analysis + redlines",
+  },
+  {
     id: "docs-agent",
     label: "Docs Agent",
     description: "Document Q&A with source citations",

--- a/cli/commands/init/command-help.ts
+++ b/cli/commands/init/command-help.ts
@@ -8,7 +8,7 @@ export const initHelp: CommandHelp = {
     {
       flag: "-t, --template <name>",
       description:
-        "Project template (minimal | ai-agent | docs-agent | agentic-workflow | multi-agent-system | coding-agent | saas-starter)",
+        "Project template (minimal | ai-agent | contract-review-agent | docs-agent | agentic-workflow | multi-agent-system | coding-agent | saas-starter)",
     },
     {
       flag: "--integrations <list>",

--- a/cli/commands/init/init-command.test.ts
+++ b/cli/commands/init/init-command.test.ts
@@ -12,6 +12,7 @@ describe("InitCommand Types", () => {
   describe("InitTemplate", () => {
     const templates: InitTemplate[] = [
       "ai-agent",
+      "contract-review-agent",
       "docs-agent",
       "multi-agent-system",
       "agentic-workflow",

--- a/cli/commands/init/types.ts
+++ b/cli/commands/init/types.ts
@@ -2,6 +2,7 @@ import type { FeatureName, IntegrationName } from "../../templates/types.ts";
 
 export type InitTemplate =
   | "ai-agent"
+  | "contract-review-agent"
   | "docs-agent"
   | "multi-agent-system"
   | "agentic-workflow"

--- a/cli/templates/files/contract-review-agent/README.md
+++ b/cli/templates/files/contract-review-agent/README.md
@@ -1,0 +1,71 @@
+# Contract Review Agent
+
+An AI-powered contract review assistant that analyzes contracts clause-by-clause, flags deviations by severity, and generates redline suggestions.
+
+## What's included
+
+- Contract review agent powered by the [contract-review skill](https://github.com/anthropics/knowledge-work-plugins/blob/main/legal/skills/contract-review/SKILL.md) from Anthropic's knowledge-work-plugins
+- Document upload supporting PDF, DOCX, TXT, MD, RTF, and HTML contracts
+- Embedding-based retrieval for clause-level analysis
+- Deviation classification: GREEN (acceptable), YELLOW (negotiate), RED (escalate)
+- Prioritized redline generation with fallback positions
+- Sample negotiation playbook in `content/`
+
+## Getting started
+
+1. Set your API keys:
+
+   ```bash
+   export ANTHROPIC_API_KEY=sk-ant-...
+   export OPENAI_API_KEY=sk-...        # for embeddings
+   ```
+
+2. Start the dev server:
+
+   ```bash
+   npx veryfront dev
+   ```
+
+3. Upload a contract (PDF, DOCX, etc.) and ask for a review.
+
+## Quick actions
+
+| Action | What it does |
+|--------|-------------|
+| **Full Review** | Clause-by-clause analysis with GREEN/YELLOW/RED classification |
+| **Liability Analysis** | Deep dive into liability caps, indemnification, and carveouts |
+| **IP & Data Review** | Intellectual property and data protection assessment |
+| **Term & Termination** | Exit options, renewal terms, and notice periods |
+| **Generate Redlines** | Prioritized redline suggestions for all flagged issues |
+
+## Customizing the playbook
+
+Edit `content/sample-playbook.md` with your organization's standard positions, acceptable ranges, and escalation triggers. The agent uses this as its baseline for reviews.
+
+## Structure
+
+```
+store.ts                                  Upload store config (embedding model, storage)
+agents/reviewer.ts                        Contract review agent with skill binding
+skills/contract-review/SKILL.md           Contract review skill instructions
+content/
+  sample-playbook.md                      Sample negotiation playbook
+app/
+  api/chat/route.ts                       Chat API with contract retrieval
+  api/uploads/route.ts                    Upload (POST) and list (GET)
+  api/uploads/[id]/route.ts              Delete upload
+  page.tsx                                Chat UI with contract upload
+  layout.tsx                              Root layout
+```
+
+## How it works
+
+1. **Upload** a contract via the attachment panel
+2. The contract is chunked, embedded, and stored in the local vector index
+3. When you ask a question, relevant contract sections are retrieved and prepended to the prompt
+4. The agent uses the **contract-review skill** to analyze clauses against playbook positions
+5. Issues are classified by severity and redline suggestions are generated
+
+## Important disclaimer
+
+This tool assists with legal workflows but does **not** provide legal advice. All analysis should be reviewed by qualified legal professionals before being relied upon.

--- a/cli/templates/files/contract-review-agent/agents/reviewer.ts
+++ b/cli/templates/files/contract-review-agent/agents/reviewer.ts
@@ -1,0 +1,18 @@
+import { agent } from "veryfront/agent";
+
+export default agent({
+  id: "contract-reviewer",
+  model: "anthropic/claude-sonnet-4-20250514",
+  system:
+    `You are a contract review assistant for an in-house legal team. ` +
+    `You analyze uploaded contracts clause-by-clause, flag deviations from standard positions, ` +
+    `classify issues by severity (GREEN/YELLOW/RED), and generate actionable redline suggestions. ` +
+    `Always cite the specific clause or section number when referencing contract language. ` +
+    `You assist with legal workflows but do NOT provide legal advice — ` +
+    `all analysis should be reviewed by qualified legal professionals.`,
+  skills: ["contract-review"],
+  tools: {
+    "load-skill": true,
+    "load-skill-reference": true,
+  },
+});

--- a/cli/templates/files/contract-review-agent/app/api/chat/route.ts
+++ b/cli/templates/files/contract-review-agent/app/api/chat/route.ts
@@ -1,0 +1,41 @@
+import { createChatHandler } from "veryfront/agent";
+import { store } from "../../../store.ts";
+
+export const POST = createChatHandler("contract-reviewer", {
+  beforeStream: async ({ lastUserText }) => {
+    const query = lastUserText.trim();
+    if (!query) return;
+
+    try {
+      await store.indexContentDir();
+      const results = await store.search(query, { topK: 8 });
+      if (results.length === 0) return;
+
+      const contextBlock = results
+        .map(
+          (result) =>
+            `[${result.title}] (score: ${result.score.toFixed(2)})\n${result.text}`,
+        )
+        .join("\n\n---\n\n");
+
+      return {
+        prepend: [
+          {
+            role: "system",
+            parts: [
+              {
+                type: "text",
+                text:
+                  `Here are relevant sections from the uploaded contract(s):\n\n${contextBlock}\n\n` +
+                  "Use these sections to perform your review. Reference specific clauses and section numbers.",
+              },
+            ],
+          },
+        ],
+      };
+    } catch (e) {
+      console.error("[Contract Review] Retrieval failed:", e);
+      return;
+    }
+  },
+});

--- a/cli/templates/files/contract-review-agent/app/api/uploads/[id]/route.ts
+++ b/cli/templates/files/contract-review-agent/app/api/uploads/[id]/route.ts
@@ -1,0 +1,4 @@
+import { createUploadHandler } from "veryfront/embedding";
+import { store } from "../../../../store.ts";
+
+export const { DELETE } = createUploadHandler(store);

--- a/cli/templates/files/contract-review-agent/app/api/uploads/route.ts
+++ b/cli/templates/files/contract-review-agent/app/api/uploads/route.ts
@@ -1,0 +1,4 @@
+import { createUploadHandler } from "veryfront/embedding";
+import { store } from "../../../store.ts";
+
+export const { POST, GET } = createUploadHandler(store);

--- a/cli/templates/files/contract-review-agent/app/layout.tsx
+++ b/cli/templates/files/contract-review-agent/app/layout.tsx
@@ -1,0 +1,12 @@
+import { Head } from "veryfront/head";
+
+export default function RootLayout({ children }: { children: React.ReactNode }): React.ReactNode {
+  return (
+    <>
+      <Head><title>Contract Review</title></Head>
+      <div className="flex flex-col h-screen">
+        {children}
+      </div>
+    </>
+  );
+}

--- a/cli/templates/files/contract-review-agent/app/page.tsx
+++ b/cli/templates/files/contract-review-agent/app/page.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { ChatWithSidebar, useChat, type QuickAction } from 'veryfront/chat'
+
+const UPLOAD_API = '/api/uploads'
+const ACCEPT = '.pdf,.doc,.docx,.txt,.md,.rtf,.html'
+
+const QUICK_ACTIONS: QuickAction[] = [
+  { id: 'full-review', label: 'Full Review', prompt: 'Review this contract clause by clause. Flag deviations as GREEN/YELLOW/RED and provide redline suggestions for any issues.' },
+  { id: 'liability-check', label: 'Liability Analysis', prompt: 'Analyze the limitation of liability and indemnification clauses. Are the caps adequate? Are there asymmetric carveouts?' },
+  { id: 'ip-review', label: 'IP & Data Review', prompt: 'Review the intellectual property and data protection clauses. Are there any IP assignment risks or missing DPA requirements?' },
+  { id: 'termination', label: 'Term & Termination', prompt: 'Analyze the term, renewal, and termination provisions. What are the exit options and notice requirements?' },
+  { id: 'redlines', label: 'Generate Redlines', prompt: 'Generate prioritized redline suggestions for all YELLOW and RED issues found in this contract.' },
+]
+
+interface Upload { id: string; title: string; source: string }
+
+function useUploads(api: string) {
+  const [uploads, setUploads] = useState<Upload[]>([])
+  const [uploading, setUploading] = useState(false)
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch(api)
+      if (!res.ok) return
+      const data = await res.json()
+      const all: Upload[] = Array.isArray(data) ? data : data.uploads ?? []
+      setUploads(all.filter((d) => d.source.startsWith('upload:')))
+    } catch { /* ignore */ }
+  }, [api])
+
+  useEffect(() => { refresh() }, [refresh])
+
+  const upload = useCallback(async (file: File) => {
+    setUploading(true)
+    try {
+      const form = new FormData()
+      form.append('file', file)
+      const res = await fetch(api, { method: 'POST', body: form })
+      if (!res.ok) throw new Error(await res.text())
+      await refresh()
+    } finally {
+      setUploading(false)
+    }
+  }, [api, refresh])
+
+  const remove = useCallback(async (id: string) => {
+    await fetch(`${api}/${id}`, { method: 'DELETE' })
+    await refresh()
+  }, [api, refresh])
+
+  return { uploads, uploading, upload, remove }
+}
+
+export default function ContractReview() {
+  const chat = useChat({ api: '/api/chat' })
+  const { uploads, uploading, upload, remove } = useUploads(UPLOAD_API)
+
+  const handleAttach = useCallback((files: FileList) => {
+    for (const file of Array.from(files)) upload(file)
+  }, [upload])
+
+  const handleQuickAction = useCallback((action: QuickAction) => {
+    if (action.prompt) chat.setInput(action.prompt)
+  }, [chat.setInput])
+
+  return (
+    <ChatWithSidebar
+      chat={chat}
+      sidebar={{ storageKey: 'contract-review-threads' }}
+      features={{ steps: true, tabs: true, sources: true, export: true }}
+      models={{
+        options: [
+          { value: 'anthropic/claude-sonnet-4-20250514', label: 'Claude Sonnet 4', provider: 'Anthropic' },
+          { value: 'openai/gpt-4o', label: 'GPT-4o', provider: 'OpenAI' },
+        ],
+      }}
+      attachments={{
+        uploads: uploads.map((d) => ({ id: d.id, name: d.title })),
+        onRemoveUpload: remove,
+        onAttach: handleAttach,
+        accept: ACCEPT,
+        items: uploads.map((d) => ({ id: d.id, name: d.title, status: 'ready' as const }))
+          .concat(uploading ? [{ id: '__uploading', name: 'Uploading...', status: 'uploading' as const }] : []),
+        onRemoveItem: remove,
+      }}
+      quickActions={{ actions: QUICK_ACTIONS, onAction: handleQuickAction }}
+      className="flex-1 min-h-0"
+      placeholder="Upload a contract and ask for a review..."
+      emptyState={{ title: 'Contract Review', description: 'Upload contracts for clause-by-clause analysis with redline suggestions' }}
+    />
+  )
+}

--- a/cli/templates/files/contract-review-agent/content/sample-playbook.md
+++ b/cli/templates/files/contract-review-agent/content/sample-playbook.md
@@ -1,0 +1,41 @@
+# Sample Negotiation Playbook
+
+This is a sample playbook to demonstrate the contract review workflow. Replace it with your organization's actual negotiation playbook.
+
+## Limitation of Liability
+
+- **Standard position**: Mutual cap at 12 months of fees paid
+- **Acceptable range**: 6-24 months of fees
+- **Escalation trigger**: Cap below 6 months or uncapped liability
+- **Consequential damages**: Mutual exclusion required; carveouts only for IP infringement and confidentiality breach
+
+## Indemnification
+
+- **Standard position**: Mutual indemnification for IP infringement and data breach
+- **Acceptable range**: Unilateral IP indemnification acceptable for pure SaaS vendors
+- **Escalation trigger**: Broad "any breach" indemnification or uncapped indemnification
+- **Procedure**: 30-day notice, right to control defense, no settlement without consent
+
+## Intellectual Property
+
+- **Standard position**: Each party retains pre-existing IP; customer owns deliverables
+- **Acceptable range**: Vendor retains general know-how and pre-existing tools
+- **Escalation trigger**: Any assignment of customer's pre-existing IP; broad feedback clauses
+
+## Data Protection
+
+- **Standard position**: DPA required when processing personal data; 72-hour breach notification
+- **Acceptable range**: Reasonable sub-processor notification process
+- **Escalation trigger**: No DPA offered; breach notification > 72 hours; no cross-border transfer protections
+
+## Term and Termination
+
+- **Standard position**: Annual term with 90-day renewal notice; termination for convenience with 30-day notice
+- **Acceptable range**: 60-day renewal notice; 60-day termination notice
+- **Escalation trigger**: No termination for convenience; auto-renewal with < 30-day notice window
+
+## Governing Law
+
+- **Preferred**: Delaware or New York law
+- **Acceptable**: Any major US commercial jurisdiction; England and Wales; Singapore
+- **Escalation trigger**: Mandatory arbitration in unfavorable jurisdiction; unfamiliar legal system

--- a/cli/templates/files/contract-review-agent/skills/contract-review/SKILL.md
+++ b/cli/templates/files/contract-review-agent/skills/contract-review/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: contract-review
+description: Review contracts against your organization's negotiation playbook, flagging deviations and generating redline suggestions. Use when reviewing vendor contracts, customer agreements, or any commercial agreement where you need clause-by-clause analysis against standard positions.
+---
+
+# Contract Review Skill
+
+You are a contract review assistant for an in-house legal team. You analyze contracts against the organization's negotiation playbook, identify deviations, classify their severity, and generate actionable redline suggestions.
+
+**Important**: You assist with legal workflows but do not provide legal advice. All analysis should be reviewed by qualified legal professionals before being relied upon.
+
+## Playbook-Based Review Methodology
+
+### Loading the Playbook
+
+Before reviewing any contract, check for a configured playbook in the user's local settings. The playbook defines the organization's standard positions, acceptable ranges, and escalation triggers for each major clause type.
+
+If no playbook is available:
+- Inform the user and offer to help create one
+- If proceeding without a playbook, use widely-accepted commercial standards as a baseline
+- Clearly label the review as "based on general commercial standards" rather than organizational positions
+
+### Review Process
+
+1. **Identify the contract type**: SaaS agreement, professional services, license, partnership, procurement, etc. The contract type affects which clauses are most material.
+2. **Determine the user's side**: Vendor, customer, licensor, licensee, partner. This fundamentally changes the analysis (e.g., limitation of liability protections favor different parties).
+3. **Read the entire contract** before flagging issues. Clauses interact with each other (e.g., an uncapped indemnity may be partially mitigated by a broad limitation of liability).
+4. **Analyze each material clause** against the playbook position.
+5. **Consider the contract holistically**: Are the overall risk allocation and commercial terms balanced?
+
+## Common Clause Analysis
+
+### Limitation of Liability
+
+**Key elements to review:**
+- Cap amount (fixed dollar amount, multiple of fees, or uncapped)
+- Whether the cap is mutual or applies differently to each party
+- Carveouts from the cap (what liabilities are uncapped)
+- Whether consequential, indirect, special, or punitive damages are excluded
+- Whether the exclusion is mutual
+- Carveouts from the consequential damages exclusion
+- Whether the cap applies per-claim, per-year, or aggregate
+
+**Common issues:**
+- Cap set at a fraction of fees paid (e.g., "fees paid in the prior 3 months" on a low-value contract)
+- Asymmetric carveouts favoring the drafter
+- Broad carveouts that effectively eliminate the cap (e.g., "any breach of Section X" where Section X covers most obligations)
+- No consequential damages exclusion for one party's breaches
+
+### Indemnification
+
+**Key elements to review:**
+- Whether indemnification is mutual or unilateral
+- Scope: what triggers the indemnification obligation (IP infringement, data breach, bodily injury, breach of reps and warranties)
+- Whether indemnification is capped (often subject to the overall liability cap, or sometimes uncapped)
+- Procedure: notice requirements, right to control defense, right to settle
+- Whether the indemnitee must mitigate
+- Relationship between indemnification and the limitation of liability clause
+
+**Common issues:**
+- Unilateral indemnification for IP infringement when both parties contribute IP
+- Indemnification for "any breach" (too broad; essentially converts the liability cap to uncapped liability)
+- No right to control defense of claims
+- Indemnification obligations that survive termination indefinitely
+
+### Intellectual Property
+
+**Key elements to review:**
+- Ownership of pre-existing IP (each party should retain their own)
+- Ownership of IP developed during the engagement
+- Work-for-hire provisions and their scope
+- License grants: scope, exclusivity, territory, sublicensing rights
+- Open source considerations
+- Feedback clauses (grants on suggestions or improvements)
+
+**Common issues:**
+- Broad IP assignment that could capture the customer's pre-existing IP
+- Work-for-hire provisions extending beyond the deliverables
+- Unrestricted feedback clauses granting perpetual, irrevocable licenses
+- License scope broader than needed for the business relationship
+
+### Data Protection
+
+**Key elements to review:**
+- Whether a Data Processing Agreement/Addendum (DPA) is required
+- Data controller vs. data processor classification
+- Sub-processor rights and notification obligations
+- Data breach notification timeline (72 hours for GDPR)
+- Cross-border data transfer mechanisms (SCCs, adequacy decisions, binding corporate rules)
+- Data deletion or return obligations on termination
+- Data security requirements and audit rights
+- Purpose limitation for data processing
+
+**Common issues:**
+- No DPA when personal data is being processed
+- Blanket authorization for sub-processors without notification
+- Breach notification timeline longer than regulatory requirements
+- No cross-border transfer protections when data moves internationally
+- Inadequate data deletion provisions
+
+### Term and Termination
+
+**Key elements to review:**
+- Initial term and renewal terms
+- Auto-renewal provisions and notice periods
+- Termination for convenience: available? notice period? early termination fees?
+- Termination for cause: cure period? what constitutes cause?
+- Effects of termination: data return, transition assistance, survival clauses
+- Wind-down period and obligations
+
+**Common issues:**
+- Long initial terms with no termination for convenience
+- Auto-renewal with short notice windows (e.g., 30-day notice for annual renewal)
+- No cure period for termination for cause
+- Inadequate transition assistance provisions
+- Survival clauses that effectively extend the agreement indefinitely
+
+### Governing Law and Dispute Resolution
+
+**Key elements to review:**
+- Choice of law (governing jurisdiction)
+- Dispute resolution mechanism (litigation, arbitration, mediation first)
+- Venue and jurisdiction for litigation
+- Arbitration rules and seat (if arbitration)
+- Jury waiver
+- Class action waiver
+- Prevailing party attorney's fees
+
+**Common issues:**
+- Unfavorable jurisdiction (unusual or remote venue)
+- Mandatory arbitration with rules favorable to the drafter
+- Waiver of jury trial without corresponding protections
+- No escalation process before formal dispute resolution
+
+## Deviation Severity Classification
+
+### GREEN -- Acceptable
+
+The clause aligns with or is better than the organization's standard position. Minor variations that are commercially reasonable and do not increase risk materially.
+
+**Examples:**
+- Liability cap at 18 months of fees when standard is 12 months (better for the customer)
+- Mutual NDA term of 2 years when standard is 3 years (shorter but reasonable)
+- Governing law in a well-established commercial jurisdiction close to the preferred one
+
+**Action**: Note for awareness. No negotiation needed.
+
+### YELLOW -- Negotiate
+
+The clause falls outside the standard position but within a negotiable range. The term is common in the market but not the organization's preference. Requires attention and likely negotiation, but not escalation.
+
+**Examples:**
+- Liability cap at 6 months of fees when standard is 12 months (below standard but negotiable)
+- Unilateral indemnification for IP infringement when standard is mutual (common market position but not preferred)
+- Auto-renewal with 60-day notice when standard is 90 days
+- Governing law in an acceptable but not preferred jurisdiction
+
+**Action**: Generate specific redline language. Provide fallback position. Estimate business impact of accepting vs. negotiating.
+
+### RED -- Escalate
+
+The clause falls outside acceptable range, triggers a defined escalation criterion, or poses material risk. Requires senior counsel review, outside counsel involvement, or business decision-maker sign-off.
+
+**Examples:**
+- Uncapped liability or no limitation of liability clause
+- Unilateral broad indemnification with no cap
+- IP assignment of pre-existing IP
+- No DPA offered when personal data is processed
+- Unreasonable non-compete or exclusivity provisions
+- Governing law in a problematic jurisdiction with mandatory arbitration
+
+**Action**: Explain the specific risk. Provide market-standard alternative language. Estimate exposure. Recommend escalation path.
+
+## Redline Generation Best Practices
+
+When generating redline suggestions:
+
+1. **Be specific**: Provide exact language, not vague guidance. The redline should be ready to insert.
+2. **Be balanced**: Propose language that is firm on critical points but commercially reasonable. Overly aggressive redlines slow negotiations.
+3. **Explain the rationale**: Include a brief, professional rationale suitable for sharing with the counterparty's counsel.
+4. **Provide fallback positions**: For YELLOW items, include a fallback position if the primary ask is rejected.
+5. **Prioritize**: Not all redlines are equal. Indicate which are must-haves and which are nice-to-haves.
+6. **Consider the relationship**: Adjust tone and approach based on whether this is a new vendor, strategic partner, or commodity supplier.
+
+### Redline Format
+
+For each redline:
+```
+**Clause**: [Section reference and clause name]
+**Current language**: "[exact quote from the contract]"
+**Proposed redline**: "[specific alternative language with additions in bold and deletions struck through conceptually]"
+**Rationale**: [1-2 sentences explaining why, suitable for external sharing]
+**Priority**: [Must-have / Should-have / Nice-to-have]
+**Fallback**: [Alternative position if primary redline is rejected]
+```
+
+## Negotiation Priority Framework
+
+When presenting redlines, organize by negotiation priority:
+
+### Tier 1 -- Must-Haves (Deal Breakers)
+Issues where the organization cannot proceed without resolution:
+- Uncapped or materially insufficient liability protections
+- Missing data protection requirements for regulated data
+- IP provisions that could jeopardize core assets
+- Terms that conflict with regulatory obligations
+
+### Tier 2 -- Should-Haves (Strong Preferences)
+Issues that materially affect risk but have negotiation room:
+- Liability cap adjustments within range
+- Indemnification scope and mutuality
+- Termination flexibility
+- Audit and compliance rights
+
+### Tier 3 -- Nice-to-Haves (Concession Candidates)
+Issues that improve the position but can be conceded strategically:
+- Preferred governing law (if alternative is acceptable)
+- Notice period preferences
+- Minor definitional improvements
+- Insurance certificate requirements
+
+**Negotiation strategy**: Lead with Tier 1 items. Trade Tier 3 concessions to secure Tier 2 wins. Never concede on Tier 1 without escalation.

--- a/cli/templates/files/contract-review-agent/store.ts
+++ b/cli/templates/files/contract-review-agent/store.ts
@@ -1,0 +1,7 @@
+import { uploadStore } from "veryfront/embedding";
+
+export const store = uploadStore({
+  model: "openai/text-embedding-3-small",
+  storagePath: "data/index.json",
+  contentDir: "content",
+});

--- a/cli/templates/files/contract-review-agent/tsconfig.json
+++ b/cli/templates/files/contract-review-agent/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/cli/templates/index.ts
+++ b/cli/templates/index.ts
@@ -48,8 +48,18 @@ const OPENAI_KEY_CONFIG = {
   docsUrl: "https://platform.openai.com/api-keys",
 } as const;
 
+const ANTHROPIC_KEY_CONFIG = {
+  name: "ANTHROPIC_API_KEY",
+  description: "Your Anthropic API key",
+  required: true,
+  sensitive: true,
+  placeholder: "sk-ant-...",
+  docsUrl: "https://console.anthropic.com/settings/keys",
+} as const;
+
 export const templateConfigs: Partial<Record<TemplateName, TemplateConfig>> = {
   "ai-agent": { envVars: [OPENAI_KEY_CONFIG] },
+  "contract-review-agent": { envVars: [ANTHROPIC_KEY_CONFIG, OPENAI_KEY_CONFIG] },
   "docs-agent": { envVars: [OPENAI_KEY_CONFIG] },
   "multi-agent-system": { envVars: [OPENAI_KEY_CONFIG] },
   "agentic-workflow": { envVars: [OPENAI_KEY_CONFIG] },
@@ -59,6 +69,7 @@ export const templateConfigs: Partial<Record<TemplateName, TemplateConfig>> = {
 
 const DIRECTORY_BASED_TEMPLATES: TemplateName[] = [
   "ai-agent",
+  "contract-review-agent",
   "docs-agent",
   "multi-agent-system",
   "agentic-workflow",

--- a/cli/templates/types.ts
+++ b/cli/templates/types.ts
@@ -25,6 +25,7 @@ export interface TemplateConfig {
 
 export type TemplateName =
   | "ai-agent"
+  | "contract-review-agent"
   | "docs-agent"
   | "multi-agent-system"
   | "agentic-workflow"


### PR DESCRIPTION
## Summary

- Adds a new `contract-review-agent` project template for `veryfront init`
- Includes AI-powered contract review with skill-based tool management, file upload handling, and playbook-driven analysis
- Registers the template across the CLI catalog, types, help text, and tests

## Test plan

- [ ] Run `deno task verify` to confirm all tests pass with the new template registration
- [ ] Run `veryfront init` and verify `contract-review-agent` appears in the template list
- [ ] Initialize a new project with the template and verify all files are scaffolded correctly