### PR TITLE
fix: remove system prompt from 503 no_ai_available response

### DIFF
--- a/src/agent/chat-handler.test.ts
+++ b/src/agent/chat-handler.test.ts
@@ -12,6 +12,7 @@ import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/te
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createChatHandler } from "./chat-handler.ts";
 import { registerAgent } from "./composition/index.ts";
+import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 
 describe("createChatHandler", () => {
   // The handler calls extractRequest first. If that fails, it throws
@@ -282,5 +283,102 @@ describe("createChatHandler", () => {
     assertEquals((streamMessages[0]?.parts[0] as { text?: string }).text, "replacement");
     assertEquals(streamMessages[1]?.role, "system");
     assertStringIncludes(streamMessages[1]?.id ?? "", "append_");
+  });
+
+  it("should not leak system prompt in 503 no_ai_available response", async () => {
+    const agentId = `no-ai-agent-${crypto.randomUUID()}`;
+    const secretSystemPrompt =
+      "TOP SECRET: You are a financial advisor with access to internal data.";
+
+    const fakeAgent = {
+      id: agentId,
+      config: { model: "local/smollm2-360m", system: secretSystemPrompt },
+      clearMemory: async () => {},
+      stream: async () => {
+        throw toError(
+          createError({
+            type: "no_ai_available",
+            message: "Local AI model unavailable.",
+          }),
+        );
+      },
+    };
+
+    // deno-lint-ignore no-explicit-any
+    registerAgent(agentId, fakeAgent as any);
+
+    const handler = createChatHandler(agentId);
+    const request = new Request("http://localhost/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: [
+          {
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ],
+      }),
+    });
+
+    const response = await handler(request);
+    assertEquals(response.status, 503);
+
+    const body = await response.json();
+    assertEquals(body.code, "NO_AI_AVAILABLE");
+    assertEquals(body.fallback, "browser");
+    assertEquals(body.systemPrompt, undefined, "Server system prompt must not be sent to client");
+    assertEquals(
+      JSON.stringify(body).includes(secretSystemPrompt),
+      false,
+      "Response body must not contain the system prompt anywhere",
+    );
+  });
+
+  it("should not leak async system prompt in 503 no_ai_available response", async () => {
+    const agentId = `no-ai-async-${crypto.randomUUID()}`;
+
+    const fakeAgent = {
+      id: agentId,
+      config: {
+        model: "local/smollm2-360m",
+        system: () => Promise.resolve("CONFIDENTIAL: Internal instructions for the agent."),
+      },
+      clearMemory: async () => {},
+      stream: async () => {
+        throw toError(
+          createError({
+            type: "no_ai_available",
+            message: "Local AI model unavailable.",
+          }),
+        );
+      },
+    };
+
+    // deno-lint-ignore no-explicit-any
+    registerAgent(agentId, fakeAgent as any);
+
+    const handler = createChatHandler(agentId);
+    const request = new Request("http://localhost/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: [
+          {
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ],
+      }),
+    });
+
+    const response = await handler(request);
+    assertEquals(response.status, 503);
+
+    const body = await response.json();
+    assertEquals(body.code, "NO_AI_AVAILABLE");
+    assertEquals(body.systemPrompt, undefined, "Async system prompt must not be sent to client");
   });
 });

--- a/src/agent/chat-handler.ts
+++ b/src/agent/chat-handler.ts
@@ -282,8 +282,6 @@ export function createChatHandler(
   // deno-lint-ignore no-explicit-any
   return async function POST(requestOrCtx: any): Promise<Response> {
     const request = extractRequest(requestOrCtx);
-    // Resolve agent outside try so it's available in the catch block for
-    // extracting the system prompt in the 503 fallback response.
     let agent: ReturnType<typeof getAgent> | undefined;
     try {
       agent = getAgent(agentId);
@@ -341,27 +339,17 @@ export function createChatHandler(
         );
       }
 
-      // Detect structured "no_ai_available" errors from local engine
+      // Detect structured "no_ai_available" errors from local engine.
+      // Never send the server-side system prompt to the client — it may
+      // contain business logic, personas, or internal instructions.
+      // The client (useChat) has its own systemPrompt option for browser fallback.
       const vfError = fromError(error);
       if (vfError?.type === "no_ai_available") {
-        let systemPrompt: string | undefined;
-        try {
-          systemPrompt = agent
-            ? typeof agent.config.system === "string"
-              ? agent.config.system
-              : typeof agent.config.system === "function"
-              ? await agent.config.system()
-              : undefined
-            : undefined;
-        } catch {
-          // If system prompt resolution fails, continue without it
-        }
         return Response.json(
           {
             code: "NO_AI_AVAILABLE",
             fallback: "browser",
             model: DEFAULT_LOCAL_MODEL,
-            ...(systemPrompt ? { systemPrompt } : {}),
           },
           { status: 503 },
         );

--- a/src/agent/react/use-chat/use-chat.ts
+++ b/src/agent/react/use-chat/use-chat.ts
@@ -252,9 +252,6 @@ export function useChat(options: UseChatOptions): UseChatResult {
           try {
             const body = await response.json();
             if (body.code === "NO_AI_AVAILABLE") {
-              if (body.systemPrompt) {
-                systemPromptRef.current = body.systemPrompt;
-              }
               setInferenceMode("browser");
               setBrowserStatus("idle");
               await doBrowserInference(allMessages);

--- a/tests/ai/chat-handler-fallback.test.ts
+++ b/tests/ai/chat-handler-fallback.test.ts
@@ -109,7 +109,8 @@ describe("chat-handler 503 fallback", () => {
       assertEquals(body.code, "NO_AI_AVAILABLE");
       assertEquals(body.fallback, "browser");
       assertEquals(body.model, "smollm2-135m");
-      assertEquals(body.systemPrompt, "You are a test bot.");
+      // System prompt must NOT be sent to the client (security: C2)
+      assertEquals(body.systemPrompt, undefined);
     } finally {
       if (originalLogLevel) setEnv("LOG_LEVEL", originalLogLevel);
       if (originalNodeEnv) setEnv("NODE_ENV", originalNodeEnv);


### PR DESCRIPTION
## Summary
- Remove server-side system prompt from the 503 `NO_AI_AVAILABLE` response body — it leaked business logic, personas, and internal instructions to the client
- Remove client-side code in `useChat` that consumed `body.systemPrompt` from the 503 response
- The client already has its own `systemPrompt` option for browser fallback inference via `useChat({ systemPrompt: "..." })`

**Security:** Addresses C2 in `plans/security_audit.md`

## Changes
- `src/agent/chat-handler.ts` — removed system prompt resolution and inclusion from 503 response
- `src/agent/react/use-chat/use-chat.ts` — removed dead code reading `body.systemPrompt`
- `src/agent/chat-handler.test.ts` — added 2 tests verifying the prompt is never leaked (string system prompt and async function system prompt)

## Test plan
- [x] Existing chat handler tests pass (11/11)
- [x] New test: 503 response with string system prompt does not contain the prompt
- [x] New test: 503 response with async system prompt does not contain the prompt
- [x] Manual: trigger browser fallback — verify chat still works with client-provided systemPrompt