### PR TITLE
fix: guard bypassPermissions behind explicit server-side opt-in

### DIFF
--- a/src/platform/compat/opaque-deps.ts
+++ b/src/platform/compat/opaque-deps.ts
@@ -32,6 +32,9 @@ export function importTransformers(): Promise<OpaqueModule> {
 
 /** Lazily import `@anthropic-ai/claude-agent-sdk` (~69MB). */
 export function importClaudeAgentSDK(): Promise<OpaqueModule> {
+  // Allow tests to inject a mock SDK without loading the real 69 MB package.
+  const mock = (globalThis as Record<string, unknown>).__vfMockClaudeSDK;
+  if (mock) return Promise.resolve(mock);
   return dynamicImport(resolve("@anthropic-ai/claude-agent-sdk", "0.2.37"));
 }
 

--- a/src/platform/compat/opaque-deps.ts
+++ b/src/platform/compat/opaque-deps.ts
@@ -34,7 +34,7 @@ export function importTransformers(): Promise<OpaqueModule> {
 export function importClaudeAgentSDK(): Promise<OpaqueModule> {
   // Allow tests to inject a mock SDK without loading the real 69 MB package.
   const mock = (globalThis as Record<string, unknown>).__vfMockClaudeSDK;
-  if (mock) return Promise.resolve(mock);
+  if (mock && typeof mock === "object" && "query" in mock) return Promise.resolve(mock);
   return dynamicImport(resolve("@anthropic-ai/claude-agent-sdk", "0.2.37"));
 }
 

--- a/src/security/utils/constant-time.test.ts
+++ b/src/security/utils/constant-time.test.ts
@@ -42,7 +42,8 @@ describe("constantTimeEqual", () => {
     const sameLenWrong = "b".repeat(1000);
     const diffLenWrong = "b".repeat(500);
 
-    const iterations = 5000;
+    const iterations = 2000;
+    const rounds = 7;
 
     // Warm up JIT
     for (let i = 0; i < 1000; i++) {
@@ -50,25 +51,35 @@ describe("constantTimeEqual", () => {
       constantTimeEqual(secret, diffLenWrong);
     }
 
-    // Measure same-length comparison
-    const t1 = performance.now();
-    for (let i = 0; i < iterations; i++) {
-      constantTimeEqual(secret, sameLenWrong);
-    }
-    const sameLenTime = performance.now() - t1;
+    const measure = (candidate: string): number => {
+      const start = performance.now();
+      for (let i = 0; i < iterations; i++) {
+        constantTimeEqual(secret, candidate);
+      }
+      return performance.now() - start;
+    };
 
-    // Measure different-length comparison
-    const t2 = performance.now();
-    for (let i = 0; i < iterations; i++) {
-      constantTimeEqual(secret, diffLenWrong);
+    const ratios: number[] = [];
+    for (let round = 0; round < rounds; round++) {
+      const sameFirst = round % 2 === 0;
+      const firstCandidate = sameFirst ? sameLenWrong : diffLenWrong;
+      const secondCandidate = sameFirst ? diffLenWrong : sameLenWrong;
+      const firstTime = measure(firstCandidate);
+      const secondTime = measure(secondCandidate);
+      const sameLenTime = sameFirst ? firstTime : secondTime;
+      const diffLenTime = sameFirst ? secondTime : firstTime;
+
+      ratios.push(diffLenTime / sameLenTime);
     }
-    const diffLenTime = performance.now() - t2;
+
+    const sortedRatios = [...ratios].sort((a, b) => a - b);
+    const medianRatio = sortedRatios[Math.floor(sortedRatios.length / 2)];
 
     // The different-length comparison should take at least as long as same-length
-    // (it iterates over max length). Allow generous margin for JIT variance.
-    // The key assertion: diffLenTime should NOT be significantly faster than sameLenTime,
-    // which would indicate an early-return on length mismatch.
-    const ratio = diffLenTime / sameLenTime;
-    expect(ratio).toBeGreaterThan(0.5);
+    // (it iterates over max length). Use the median across alternating rounds
+    // so scheduler noise in one direction doesn't make this test flaky.
+    // The key assertion: length mismatch should NOT be dramatically faster
+    // than same-length mismatch, which would indicate an early return.
+    expect(medianRatio).toBeGreaterThan(0.5);
   });
 });

--- a/src/workflow/claude-code/README.md
+++ b/src/workflow/claude-code/README.md
@@ -38,12 +38,14 @@ This module provides a harness for running Claude Code SDK agents within Veryfro
 
 ### 1. Built-in Tool Modes
 
-| Mode       | Tools Enabled        | Use Case                    |
-| ---------- | -------------------- | --------------------------- |
-| `code`     | bash, file editor    | Code modifications, scripts |
-| `analysis` | file reader only     | Code review, analysis       |
-| `full`     | bash, file, computer | Full automation             |
-| `custom`   | User-specified       | Fine-grained control        |
+| Mode       | Tools Enabled     | Use Case                    |
+| ---------- | ----------------- | --------------------------- |
+| `code`     | bash, file editor | Code modifications, scripts |
+| `analysis` | file reader only  | Code review, analysis       |
+| `custom`   | User-specified    | Fine-grained control        |
+
+`bypassPermissions` remains available only as an explicit server-side
+`AgentConfig` opt-in. It is not a user-facing tool mode.
 
 ### 2. Tenant-Aware File Operations
 
@@ -171,7 +173,7 @@ interface ClaudeCodeAgentConfig {
   /** Model to use (default: claude-sonnet-4-20250514) */
   model?: string;
 
-  /** Tool mode: 'code' | 'analysis' | 'full' | 'custom' */
+  /** Tool mode: 'code' | 'analysis' | 'custom' */
   mode?: ClaudeCodeMode;
 
   /** Sandbox mode: 'strict' | 'permissive' | 'none' */

--- a/src/workflow/claude-code/agent.test.ts
+++ b/src/workflow/claude-code/agent.test.ts
@@ -13,13 +13,14 @@ function createMockSDK(): {
   uninstall: () => void;
 } {
   let capturedOptions: Record<string, unknown> | null = null;
-  const original = (globalThis as Record<string, unknown>).__vfMockClaudeSDK;
+  let original: unknown;
 
   return {
     get capturedOptions() {
       return capturedOptions;
     },
     install() {
+      original = (globalThis as Record<string, unknown>).__vfMockClaudeSDK;
       (globalThis as Record<string, unknown>).__vfMockClaudeSDK = {
         query(args: { prompt: string; options: Record<string, unknown> }) {
           capturedOptions = args.options;
@@ -66,32 +67,29 @@ async function capturePermissionMode(
   }
 }
 
-// Check if the SDK mock mechanism is wired up in opaque-deps.
-// If not, fall back to testing the schema only. The mock requires
-// opaque-deps.ts to check globalThis.__vfMockClaudeSDK first.
+// Verify the SDK mock mechanism is wired up in opaque-deps.
+// Hard-fail if the mock doesn't work — silent skips hide regressions.
 const sdkMockAvailable = await (async () => {
+  const mock = createMockSDK();
+  mock.install();
   try {
-    const mock = createMockSDK();
-    mock.install();
     const { executeAgent } = await import("./agent.ts");
     await executeAgent("probe", { cwd: "/tmp" });
-    const ok = mock.capturedOptions !== null;
-    mock.uninstall();
-    return ok;
+    return mock.capturedOptions !== null;
   } catch {
     return false;
+  } finally {
+    mock.uninstall();
   }
 })();
 
+if (!sdkMockAvailable) {
+  throw new Error(
+    "SDK mock not available — ensure opaque-deps.ts checks globalThis.__vfMockClaudeSDK and tests run with --allow-env",
+  );
+}
+
 describe("resolvePermissionMode (via executeAgent)", () => {
-  if (!sdkMockAvailable) {
-    it("requires SDK mock to be wired up", () => {
-      throw new Error(
-        "SDK mock not available — ensure opaque-deps.ts checks globalThis.__vfMockClaudeSDK and tests run with --allow-env",
-      );
-    });
-    return;
-  }
 
   it("maps 'code' mode to acceptEdits", async () => {
     assertEquals(await capturePermissionMode({ mode: "code" }), "acceptEdits");

--- a/src/workflow/claude-code/agent.test.ts
+++ b/src/workflow/claude-code/agent.test.ts
@@ -90,7 +90,6 @@ if (!sdkMockAvailable) {
 }
 
 describe("resolvePermissionMode (via executeAgent)", () => {
-
   it("maps 'code' mode to acceptEdits", async () => {
     assertEquals(await capturePermissionMode({ mode: "code" }), "acceptEdits");
   });

--- a/src/workflow/claude-code/agent.test.ts
+++ b/src/workflow/claude-code/agent.test.ts
@@ -85,7 +85,11 @@ const sdkMockAvailable = await (async () => {
 
 describe("resolvePermissionMode (via executeAgent)", () => {
   if (!sdkMockAvailable) {
-    it("skipped — SDK mock not wired up", () => {});
+    it("requires SDK mock to be wired up", () => {
+      throw new Error(
+        "SDK mock not available — ensure opaque-deps.ts checks globalThis.__vfMockClaudeSDK and tests run with --allow-env",
+      );
+    });
     return;
   }
 

--- a/src/workflow/claude-code/agent.test.ts
+++ b/src/workflow/claude-code/agent.test.ts
@@ -2,96 +2,135 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ClaudeCodeMode } from "./types.ts";
 
-// Import the module to access resolvePermissionMode indirectly via executeAgent/createAgent.
-// Since resolvePermissionMode is not exported, we test it through the public API
-// by verifying the config passed to the SDK query() call.
+/**
+ * Mock the Claude Agent SDK import to capture the permissionMode
+ * passed to query() — this lets us test the real resolvePermissionMode
+ * logic inside executeAgent without requiring the actual SDK.
+ */
+function createMockSDK(): {
+  capturedOptions: Record<string, unknown> | null;
+  install: () => void;
+  uninstall: () => void;
+} {
+  let capturedOptions: Record<string, unknown> | null = null;
+  const original = (globalThis as Record<string, unknown>).__vfMockClaudeSDK;
 
-describe("resolvePermissionMode", () => {
-  // We re-implement the logic inline to unit-test the mapping without
-  // requiring the Claude Agent SDK to be installed.
-  function resolvePermissionMode(config: {
-    mode?: ClaudeCodeMode;
-    bypassPermissions?: boolean;
-  }): "default" | "acceptEdits" | "bypassPermissions" | "plan" {
-    if (config.bypassPermissions) return "bypassPermissions";
-    switch (config.mode) {
-      case "analysis":
-        return "plan";
-      case "code":
-        return "acceptEdits";
-      case "custom":
-        return "default";
-      default:
-        return "acceptEdits";
-    }
+  return {
+    get capturedOptions() {
+      return capturedOptions;
+    },
+    install() {
+      (globalThis as Record<string, unknown>).__vfMockClaudeSDK = {
+        query(args: { prompt: string; options: Record<string, unknown> }) {
+          capturedOptions = args.options;
+          // Return an async iterable that immediately yields a result
+          return (async function* () {
+            yield {
+              type: "result",
+              subtype: "success",
+              result: "mocked",
+              num_turns: 0,
+              total_cost_usd: 0,
+              duration_ms: 0,
+            };
+          })();
+        },
+      };
+    },
+    uninstall() {
+      if (original === undefined) {
+        delete (globalThis as Record<string, unknown>).__vfMockClaudeSDK;
+      } else {
+        (globalThis as Record<string, unknown>).__vfMockClaudeSDK = original;
+      }
+      capturedOptions = null;
+    },
+  };
+}
+
+/**
+ * Helper to execute the agent with a given config and return the
+ * permissionMode that was passed to the SDK query() call.
+ */
+async function capturePermissionMode(
+  config: { mode?: ClaudeCodeMode; bypassPermissions?: boolean },
+): Promise<string> {
+  const mock = createMockSDK();
+  mock.install();
+  try {
+    const { executeAgent } = await import("./agent.ts");
+    await executeAgent("test task", { ...config, cwd: "/tmp" });
+    return mock.capturedOptions?.permissionMode as string;
+  } finally {
+    mock.uninstall();
+  }
+}
+
+// Check if the SDK mock mechanism is wired up in opaque-deps.
+// If not, fall back to testing the schema only. The mock requires
+// opaque-deps.ts to check globalThis.__vfMockClaudeSDK first.
+const sdkMockAvailable = await (async () => {
+  try {
+    const mock = createMockSDK();
+    mock.install();
+    const { executeAgent } = await import("./agent.ts");
+    await executeAgent("probe", { cwd: "/tmp" });
+    const ok = mock.capturedOptions !== null;
+    mock.uninstall();
+    return ok;
+  } catch {
+    return false;
+  }
+})();
+
+describe("resolvePermissionMode (via executeAgent)", () => {
+  if (!sdkMockAvailable) {
+    it("skipped — SDK mock not wired up", () => {});
+    return;
   }
 
-  it("maps 'code' mode to acceptEdits", () => {
-    assertEquals(resolvePermissionMode({ mode: "code" }), "acceptEdits");
+  it("maps 'code' mode to acceptEdits", async () => {
+    assertEquals(await capturePermissionMode({ mode: "code" }), "acceptEdits");
   });
 
-  it("maps 'analysis' mode to plan", () => {
-    assertEquals(resolvePermissionMode({ mode: "analysis" }), "plan");
+  it("maps 'analysis' mode to plan", async () => {
+    assertEquals(await capturePermissionMode({ mode: "analysis" }), "plan");
   });
 
-  it("maps 'custom' mode to default", () => {
-    assertEquals(resolvePermissionMode({ mode: "custom" }), "default");
+  it("maps 'custom' mode to default", async () => {
+    assertEquals(await capturePermissionMode({ mode: "custom" }), "default");
   });
 
-  it("defaults to acceptEdits when no mode specified", () => {
-    assertEquals(resolvePermissionMode({}), "acceptEdits");
+  it("defaults to acceptEdits when no mode specified", async () => {
+    assertEquals(await capturePermissionMode({}), "acceptEdits");
   });
 
-  it("returns bypassPermissions only when explicitly opted in", () => {
+  it("returns bypassPermissions only when explicitly opted in", async () => {
     assertEquals(
-      resolvePermissionMode({ bypassPermissions: true }),
+      await capturePermissionMode({ bypassPermissions: true }),
       "bypassPermissions",
     );
   });
 
-  it("bypassPermissions flag overrides mode", () => {
+  it("bypassPermissions flag overrides mode", async () => {
     assertEquals(
-      resolvePermissionMode({ mode: "analysis", bypassPermissions: true }),
+      await capturePermissionMode({ mode: "analysis", bypassPermissions: true }),
       "bypassPermissions",
     );
   });
 
-  it("bypassPermissions=false does not grant bypass", () => {
+  it("bypassPermissions=false does not grant bypass", async () => {
     assertEquals(
-      resolvePermissionMode({ mode: "code", bypassPermissions: false }),
+      await capturePermissionMode({ mode: "code", bypassPermissions: false }),
       "acceptEdits",
     );
   });
-});
 
-describe("ClaudeCodeMode type safety", () => {
-  it("does not include 'full' as a valid mode", () => {
-    // Verify that "full" is not in the set of valid modes.
-    // This is a compile-time check enforced by TypeScript, but we also
-    // verify at runtime that the resolver treats unknown modes as acceptEdits.
-    const unknownMode = "full" as ClaudeCodeMode;
-    // TypeScript would flag this assignment — at runtime we just verify
-    // the fallback behavior for any unrecognized value.
-    function resolvePermissionMode(config: {
-      mode?: ClaudeCodeMode;
-      bypassPermissions?: boolean;
-    }): string {
-      if (config.bypassPermissions) return "bypassPermissions";
-      switch (config.mode) {
-        case "analysis":
-          return "plan";
-        case "code":
-          return "acceptEdits";
-        case "custom":
-          return "default";
-        default:
-          return "acceptEdits";
-      }
-    }
-
-    // Even if someone passes "full" (e.g. from unvalidated input), it
-    // falls through to the safe default (acceptEdits), NOT bypassPermissions.
-    assertEquals(resolvePermissionMode({ mode: unknownMode }), "acceptEdits");
+  it("'full' mode falls through to safe default (acceptEdits)", async () => {
+    // Even if unvalidated input somehow passes "full", it must NOT
+    // resolve to bypassPermissions.
+    const mode = "full" as ClaudeCodeMode;
+    assertEquals(await capturePermissionMode({ mode }), "acceptEdits");
   });
 });
 

--- a/src/workflow/claude-code/agent.test.ts
+++ b/src/workflow/claude-code/agent.test.ts
@@ -130,11 +130,37 @@ describe("resolvePermissionMode (via executeAgent)", () => {
     );
   });
 
+  it("truthy non-boolean bypassPermissions does not grant bypass", async () => {
+    assertEquals(
+      await capturePermissionMode({
+        mode: "analysis",
+        bypassPermissions: "false" as unknown as boolean,
+      }),
+      "plan",
+    );
+  });
+
   it("'full' mode falls through to safe default (acceptEdits)", async () => {
     // Even if unvalidated input somehow passes "full", it must NOT
     // resolve to bypassPermissions.
     const mode = "full" as ClaudeCodeMode;
     assertEquals(await capturePermissionMode({ mode }), "acceptEdits");
+  });
+
+  it("createAgent strips bypassPermissions from overrides", async () => {
+    const mock = createMockSDK();
+    mock.install();
+    try {
+      const { createAgent } = await import("./agent.ts");
+      const reviewer = createAgent({ mode: "analysis" });
+      await reviewer("test task", {
+        mode: "analysis",
+        bypassPermissions: true,
+      });
+      assertEquals(mock.capturedOptions?.permissionMode, "plan");
+    } finally {
+      mock.uninstall();
+    }
   });
 });
 

--- a/src/workflow/claude-code/agent.test.ts
+++ b/src/workflow/claude-code/agent.test.ts
@@ -1,0 +1,120 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ClaudeCodeMode } from "./types.ts";
+
+// Import the module to access resolvePermissionMode indirectly via executeAgent/createAgent.
+// Since resolvePermissionMode is not exported, we test it through the public API
+// by verifying the config passed to the SDK query() call.
+
+describe("resolvePermissionMode", () => {
+  // We re-implement the logic inline to unit-test the mapping without
+  // requiring the Claude Agent SDK to be installed.
+  function resolvePermissionMode(config: {
+    mode?: ClaudeCodeMode;
+    bypassPermissions?: boolean;
+  }): "default" | "acceptEdits" | "bypassPermissions" | "plan" {
+    if (config.bypassPermissions) return "bypassPermissions";
+    switch (config.mode) {
+      case "analysis":
+        return "plan";
+      case "code":
+        return "acceptEdits";
+      case "custom":
+        return "default";
+      default:
+        return "acceptEdits";
+    }
+  }
+
+  it("maps 'code' mode to acceptEdits", () => {
+    assertEquals(resolvePermissionMode({ mode: "code" }), "acceptEdits");
+  });
+
+  it("maps 'analysis' mode to plan", () => {
+    assertEquals(resolvePermissionMode({ mode: "analysis" }), "plan");
+  });
+
+  it("maps 'custom' mode to default", () => {
+    assertEquals(resolvePermissionMode({ mode: "custom" }), "default");
+  });
+
+  it("defaults to acceptEdits when no mode specified", () => {
+    assertEquals(resolvePermissionMode({}), "acceptEdits");
+  });
+
+  it("returns bypassPermissions only when explicitly opted in", () => {
+    assertEquals(
+      resolvePermissionMode({ bypassPermissions: true }),
+      "bypassPermissions",
+    );
+  });
+
+  it("bypassPermissions flag overrides mode", () => {
+    assertEquals(
+      resolvePermissionMode({ mode: "analysis", bypassPermissions: true }),
+      "bypassPermissions",
+    );
+  });
+
+  it("bypassPermissions=false does not grant bypass", () => {
+    assertEquals(
+      resolvePermissionMode({ mode: "code", bypassPermissions: false }),
+      "acceptEdits",
+    );
+  });
+});
+
+describe("ClaudeCodeMode type safety", () => {
+  it("does not include 'full' as a valid mode", () => {
+    // Verify that "full" is not in the set of valid modes.
+    // This is a compile-time check enforced by TypeScript, but we also
+    // verify at runtime that the resolver treats unknown modes as acceptEdits.
+    const unknownMode = "full" as ClaudeCodeMode;
+    // TypeScript would flag this assignment — at runtime we just verify
+    // the fallback behavior for any unrecognized value.
+    function resolvePermissionMode(config: {
+      mode?: ClaudeCodeMode;
+      bypassPermissions?: boolean;
+    }): string {
+      if (config.bypassPermissions) return "bypassPermissions";
+      switch (config.mode) {
+        case "analysis":
+          return "plan";
+        case "code":
+          return "acceptEdits";
+        case "custom":
+          return "default";
+        default:
+          return "acceptEdits";
+      }
+    }
+
+    // Even if someone passes "full" (e.g. from unvalidated input), it
+    // falls through to the safe default (acceptEdits), NOT bypassPermissions.
+    assertEquals(resolvePermissionMode({ mode: unknownMode }), "acceptEdits");
+  });
+});
+
+describe("tool input schema", () => {
+  it("does not accept 'full' as a valid mode value", async () => {
+    const { claudeCodeTool } = await import("./tool.ts");
+    const schema = claudeCodeTool.inputSchema;
+
+    const result = schema.safeParse({
+      task: "test task",
+      mode: "full",
+    });
+
+    assertEquals(result.success, false, "'full' mode must be rejected by the input schema");
+  });
+
+  it("accepts valid mode values", async () => {
+    const { claudeCodeTool } = await import("./tool.ts");
+    const schema = claudeCodeTool.inputSchema;
+
+    for (const mode of ["code", "analysis", "custom"]) {
+      const result = schema.safeParse({ task: "test", mode });
+      assertEquals(result.success, true, `'${mode}' should be accepted`);
+    }
+  });
+});

--- a/src/workflow/claude-code/agent.ts
+++ b/src/workflow/claude-code/agent.ts
@@ -73,7 +73,7 @@ const DEFAULT_MODEL = "claude-sonnet-4-5-20250929";
 function resolvePermissionMode(
   config: AgentConfig,
 ): "default" | "acceptEdits" | "bypassPermissions" | "plan" {
-  if (config.bypassPermissions) {
+  if (config.bypassPermissions === true) {
     logger.warn(
       "Agent running with bypassPermissions — unrestricted filesystem and shell access",
     );
@@ -240,8 +240,9 @@ export async function executeAgent(
 /**
  * Create a reusable agent function with preset configuration.
  *
- * **Security note:** Do not expose the `overrides` parameter to untrusted
- * input — it can set `bypassPermissions: true`.
+ * **Security note:** `overrides` cannot set `bypassPermissions` — it is
+ * stripped before execution. Only `defaults` can enable bypass mode, so keep
+ * `defaults` server-controlled and never derived from untrusted input.
  *
  * @example
  * ```typescript

--- a/src/workflow/claude-code/agent.ts
+++ b/src/workflow/claude-code/agent.ts
@@ -24,6 +24,18 @@ export interface AgentConfig {
   /** Tool mode — maps to SDK permission modes */
   mode?: ClaudeCodeMode;
 
+  /**
+   * Explicitly opt in to `bypassPermissions` mode (unrestricted filesystem
+   * and shell access with no interactive prompts).
+   *
+   * When `true`, the agent runs with `permissionMode: "bypassPermissions"`
+   * regardless of `mode`. This is a server-side-only flag — it cannot be
+   * set from tool input schemas.
+   *
+   * @default false
+   */
+  bypassPermissions?: boolean;
+
   /** Maximum conversation turns before stopping */
   maxTurns?: number;
 
@@ -52,18 +64,27 @@ export interface AgentConfig {
 const DEFAULT_MODEL = "claude-sonnet-4-5-20250929";
 
 /**
- * Map tool mode to SDK permission mode
+ * Map tool mode to SDK permission mode.
+ *
+ * `bypassPermissions` is only available when explicitly opted in via
+ * `config.bypassPermissions = true` — it cannot be selected from
+ * user-facing tool input schemas.
  */
 function resolvePermissionMode(
-  mode?: ClaudeCodeMode,
+  config: AgentConfig,
 ): "default" | "acceptEdits" | "bypassPermissions" | "plan" {
-  switch (mode) {
+  if (config.bypassPermissions) {
+    logger.warn(
+      "Agent running with bypassPermissions — unrestricted filesystem and shell access",
+    );
+    return "bypassPermissions";
+  }
+
+  switch (config.mode) {
     case "analysis":
       return "plan"; // read-only
     case "code":
       return "acceptEdits"; // can write files + run commands
-    case "full":
-      return "bypassPermissions"; // all tools, no prompts
     case "custom":
       return "default"; // user controls via allowedTools
     default:
@@ -113,7 +134,7 @@ export async function executeAgent(
         cwd: config.cwd || cwd(),
         maxTurns: config.maxTurns,
         maxBudgetUsd: config.maxBudgetUsd,
-        permissionMode: resolvePermissionMode(config.mode),
+        permissionMode: resolvePermissionMode(config),
         allowedTools: config.allowedTools,
         additionalDirectories: config.additionalDirectories,
         systemPrompt: config.systemPrompt

--- a/src/workflow/claude-code/agent.ts
+++ b/src/workflow/claude-code/agent.ts
@@ -240,6 +240,9 @@ export async function executeAgent(
 /**
  * Create a reusable agent function with preset configuration.
  *
+ * **Security note:** Do not expose the `overrides` parameter to untrusted
+ * input — it can set `bypassPermissions: true`.
+ *
  * @example
  * ```typescript
  * const reviewer = createAgent({

--- a/src/workflow/claude-code/agent.ts
+++ b/src/workflow/claude-code/agent.ts
@@ -256,6 +256,8 @@ export async function executeAgent(
 export function createAgent(
   defaults: AgentConfig = {},
 ): (task: string, overrides?: AgentConfig) => Promise<ClaudeCodeResult> {
-  return (task: string, overrides: AgentConfig = {}) =>
-    executeAgent(task, { ...defaults, ...overrides });
+  return (task: string, overrides: AgentConfig = {}) => {
+    const { bypassPermissions: _, ...safeOverrides } = overrides;
+    return executeAgent(task, { ...defaults, ...safeOverrides });
+  };
 }

--- a/src/workflow/claude-code/event-publisher.ts
+++ b/src/workflow/claude-code/event-publisher.ts
@@ -127,6 +127,20 @@ export class RedisEventPublisher implements ClaudeCodeEventPublisher, ClaudeCode
     return `${this.config.channelPrefix}:events:${runId}`;
   }
 
+  private getPublishClient(): RedisClient {
+    if (!this.publishClient) {
+      throw new Error("Redis publish client not initialized");
+    }
+    return this.publishClient;
+  }
+
+  private getSubscribeClient(): RedisClient {
+    if (!this.subscribeClient) {
+      throw new Error("Redis subscribe client not initialized");
+    }
+    return this.subscribeClient;
+  }
+
   async publish(event: ClaudeCodeEvent): Promise<void> {
     await this.ensureInitialized();
 
@@ -136,7 +150,7 @@ export class RedisEventPublisher implements ClaudeCodeEventPublisher, ClaudeCode
 
     const message = JSON.stringify(event);
 
-    await this.publishClient.publish(channel, message);
+    await this.getPublishClient().publish(channel, message);
 
     if (this.config.debug) {
       console.log(`[RedisEventPublisher] Published to ${channel}:`, event.type);
@@ -147,6 +161,7 @@ export class RedisEventPublisher implements ClaudeCodeEventPublisher, ClaudeCode
     await this.ensureInitialized();
 
     const channel = this.getChannel(runId);
+    const subscribeClient = this.getSubscribeClient();
 
     const listener = (message: string) => {
       try {
@@ -157,14 +172,14 @@ export class RedisEventPublisher implements ClaudeCodeEventPublisher, ClaudeCode
       }
     };
 
-    await this.subscribeClient.subscribe(channel, listener);
+    await subscribeClient.subscribe(channel, listener);
 
     if (this.config.debug) {
       console.log(`[RedisEventPublisher] Subscribed to ${channel}`);
     }
 
     return async () => {
-      await this.subscribeClient.unsubscribe(channel);
+      await subscribeClient.unsubscribe(channel);
     };
   }
 
@@ -176,6 +191,8 @@ export class RedisEventPublisher implements ClaudeCodeEventPublisher, ClaudeCode
       this.subscribeClient?.quit(),
     ]);
 
+    this.publishClient = null;
+    this.subscribeClient = null;
     this.initialized = false;
   }
 }

--- a/src/workflow/claude-code/tool.ts
+++ b/src/workflow/claude-code/tool.ts
@@ -18,10 +18,10 @@ const claudeCodeInputSchema = z.object({
 
   /** Tool mode */
   mode: z
-    .enum(["code", "analysis", "full", "custom"])
+    .enum(["code", "analysis", "custom"])
     .optional()
     .default("code")
-    .describe("Tool mode: code (read-write), analysis (read-only), full (all tools)"),
+    .describe("Tool mode: code (read-write), analysis (read-only), custom (user-specified)"),
 
   /** Maximum turns */
   maxTurns: z
@@ -102,7 +102,7 @@ export const claudeCodeTool: Tool<ClaudeCodeInput, ClaudeCodeResult> = {
       task: { type: "string", description: "The task for the agent" },
       mode: {
         type: "string",
-        enum: ["code", "analysis", "full", "custom"],
+        enum: ["code", "analysis", "custom"],
         default: "code",
       },
       maxTurns: { type: "number", default: 20 },

--- a/src/workflow/claude-code/types.ts
+++ b/src/workflow/claude-code/types.ts
@@ -10,7 +10,6 @@
 export type ClaudeCodeMode =
   | "code" // read-write (maps to SDK acceptEdits)
   | "analysis" // read-only (maps to SDK plan)
-  | "full" // all tools (maps to SDK bypassPermissions)
   | "custom"; // user-specified (maps to SDK default)
 
 /**


### PR DESCRIPTION
## Summary
- Remove `"full"` from `ClaudeCodeMode` type and the Zod tool input schema — it previously allowed any agent or workflow to get unrestricted filesystem and shell access by specifying `mode: "full"`
- Add `bypassPermissions` boolean flag to `AgentConfig` as an explicit server-side opt-in for `bypassPermissions` mode
- `resolvePermissionMode` now only returns `bypassPermissions` when the flag is explicitly set; unknown/removed mode values fall through to the safe default (`acceptEdits`)
- Add mock SDK hook in `importClaudeAgentSDK` to test real `executeAgent` code path without loading the 69 MB SDK package
- Add security JSDoc warning to `createAgent` about untrusted `overrides` parameter

## Changes
- `src/workflow/claude-code/types.ts` — removed `"full"` from `ClaudeCodeMode` union
- `src/workflow/claude-code/tool.ts` — removed `"full"` from Zod enum and JSON schema
- `src/workflow/claude-code/agent.ts` — added `bypassPermissions` config flag, updated `resolvePermissionMode` to accept config object, added JSDoc security warning to `createAgent`
- `src/workflow/claude-code/agent.test.ts` — 10 tests covering permission mode resolution and schema validation via mock SDK
- `src/platform/compat/opaque-deps.ts` — added `globalThis.__vfMockClaudeSDK` test hook for SDK mocking

## Test plan
- [x] `resolvePermissionMode` maps all modes correctly (7 tests via real `executeAgent` + mock SDK)
- [x] `"full"` falls through to safe default `acceptEdits` if somehow passed (1 test)
- [x] Tool input schema rejects `"full"` as invalid (1 test)
- [x] Tool input schema accepts valid modes: `code`, `analysis`, `custom` (1 test)