### PR TITLE
fix: restrict debug/monitoring endpoints to local projects

### DIFF
--- a/src/server/handlers/monitoring/memory.handler.test.ts
+++ b/src/server/handlers/monitoring/memory.handler.test.ts
@@ -1,0 +1,102 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { MemoryDebugHandler } from "./memory.handler.ts";
+
+function createHandler(): MemoryDebugHandler {
+  return new MemoryDebugHandler();
+}
+
+const localCtx = { securityConfig: undefined, isLocalProject: true } as never;
+const remoteCtx = { securityConfig: undefined, isLocalProject: false } as never;
+
+describe("server/handlers/monitoring/memory-debug", () => {
+  describe("MemoryDebugHandler metadata", () => {
+    it("should have correct handler name", () => {
+      const handler = createHandler();
+      assertEquals(handler.metadata.name, "MemoryDebugHandler");
+    });
+
+    it("should match /_debug/memory prefix", () => {
+      const handler = createHandler();
+      assertExists(handler.metadata.patterns);
+      assertEquals(handler.metadata.patterns.length, 1);
+
+      const pattern = handler.metadata.patterns[0];
+      assertExists(pattern);
+      assertEquals(typeof pattern !== "string" && pattern.pattern, "/_debug/memory");
+      assertEquals(typeof pattern !== "string" && pattern.prefix, true);
+    });
+
+    it("should only be enabled for local projects", () => {
+      const handler = createHandler();
+      const enabledFn = handler.metadata.enabled;
+      assertEquals(typeof enabledFn, "function");
+
+      if (typeof enabledFn !== "function") return;
+
+      assertEquals(enabledFn({ isLocalProject: false } as never), false);
+      assertEquals(enabledFn({ isLocalProject: true } as never), true);
+      assertEquals(enabledFn({} as never), false);
+    });
+  });
+
+  describe("MemoryDebugHandler.handle", () => {
+    it("should return continue for remote projects", async () => {
+      const handler = createHandler();
+      const req = new Request("http://localhost/_debug/memory");
+      const result = await handler.handle(req, remoteCtx);
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
+    });
+
+    it("should return continue for non-matching pathname", async () => {
+      const handler = createHandler();
+      const req = new Request("http://localhost/other-path");
+      const result = await handler.handle(req, localCtx);
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
+    });
+
+    it("should return memory snapshot for local projects", async () => {
+      const handler = createHandler();
+      const req = new Request("http://localhost/_debug/memory");
+      const result = await handler.handle(req, localCtx);
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 200);
+    });
+
+    it("should return heap stats for /heap sub-path", async () => {
+      const handler = createHandler();
+      const req = new Request("http://localhost/_debug/memory/heap");
+      const result = await handler.handle(req, localCtx);
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 200);
+      const body = await result.response.json();
+      assertExists(body.heap);
+    });
+
+    it("should return cache stats for /caches sub-path", async () => {
+      const handler = createHandler();
+      const req = new Request("http://localhost/_debug/memory/caches");
+      const result = await handler.handle(req, localCtx);
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 200);
+      const body = await result.response.json();
+      assertExists(body.caches);
+    });
+
+    it("should return pressure check for /pressure sub-path", async () => {
+      const handler = createHandler();
+      const req = new Request("http://localhost/_debug/memory/pressure");
+      const result = await handler.handle(req, localCtx);
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 200);
+      const body = await result.response.json();
+      assertExists(body.recommendations);
+    });
+  });
+});

--- a/src/server/handlers/monitoring/memory.handler.test.ts
+++ b/src/server/handlers/monitoring/memory.handler.test.ts
@@ -1,13 +1,14 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "../types.ts";
 import { MemoryDebugHandler } from "./memory.handler.ts";
 
 function createHandler(): MemoryDebugHandler {
   return new MemoryDebugHandler();
 }
 
-const localCtx = { securityConfig: undefined, isLocalProject: true } as never;
-const remoteCtx = { securityConfig: undefined, isLocalProject: false } as never;
+const localCtx = { securityConfig: undefined, isLocalProject: true } as unknown as HandlerContext;
+const remoteCtx = { securityConfig: undefined, isLocalProject: false } as unknown as HandlerContext;
 
 describe("server/handlers/monitoring/memory-debug", () => {
   describe("MemoryDebugHandler metadata", () => {
@@ -34,9 +35,9 @@ describe("server/handlers/monitoring/memory-debug", () => {
 
       if (typeof enabledFn !== "function") return;
 
-      assertEquals(enabledFn({ isLocalProject: false } as never), false);
-      assertEquals(enabledFn({ isLocalProject: true } as never), true);
-      assertEquals(enabledFn({} as never), false);
+      assertEquals(enabledFn({ isLocalProject: false } as unknown as HandlerContext), false);
+      assertEquals(enabledFn({ isLocalProject: true } as unknown as HandlerContext), true);
+      assertEquals(enabledFn({} as unknown as HandlerContext), false);
     });
   });
 

--- a/src/server/handlers/monitoring/memory.handler.test.ts
+++ b/src/server/handlers/monitoring/memory.handler.test.ts
@@ -88,6 +88,19 @@ describe("server/handlers/monitoring/memory-debug", () => {
       assertExists(body.caches);
     });
 
+    it("should handle GC trigger for /gc sub-path", async () => {
+      const handler = createHandler();
+      const req = new Request("http://localhost/_debug/memory/gc");
+      const result = await handler.handle(req, localCtx);
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 200);
+      const body = await result.response.json();
+      assertEquals(typeof body.gcTriggered, "boolean");
+      assertExists(body.before);
+      assertExists(body.after);
+    });
+
     it("should return pressure check for /pressure sub-path", async () => {
       const handler = createHandler();
       const req = new Request("http://localhost/_debug/memory/pressure");

--- a/src/server/handlers/monitoring/memory.handler.ts
+++ b/src/server/handlers/monitoring/memory.handler.ts
@@ -22,10 +22,15 @@ export class MemoryDebugHandler extends BaseHandler {
     name: "MemoryDebugHandler",
     priority: PRIORITY_HIGH as HandlerPriority,
     patterns: [{ pattern: "/_debug/memory", prefix: true }],
+    enabled: (ctx) => !!ctx.isLocalProject,
   };
 
   async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
     const pathname = new URL(req.url).pathname;
+
+    if (!ctx.isLocalProject) {
+      return this.continue();
+    }
 
     if (!pathname.startsWith("/_debug/memory")) {
       return this.continue();

--- a/src/server/handlers/monitoring/metrics.handler.test.ts
+++ b/src/server/handlers/monitoring/metrics.handler.test.ts
@@ -1,0 +1,71 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { MetricsHandler } from "./metrics.handler.ts";
+
+function createHandler(): MetricsHandler {
+  return new MetricsHandler();
+}
+
+const localCtx = { securityConfig: undefined, isLocalProject: true } as never;
+const remoteCtx = { securityConfig: undefined, isLocalProject: false } as never;
+
+describe("server/handlers/monitoring/metrics", () => {
+  describe("MetricsHandler metadata", () => {
+    it("should have correct handler name", () => {
+      const handler = createHandler();
+      assertEquals(handler.metadata.name, "MetricsHandler");
+    });
+
+    it("should match /_metrics exactly", () => {
+      const handler = createHandler();
+      assertExists(handler.metadata.patterns);
+      assertEquals(handler.metadata.patterns.length, 1);
+
+      const pattern = handler.metadata.patterns[0];
+      assertExists(pattern);
+      assertEquals(typeof pattern !== "string" && pattern.pattern, "/_metrics");
+      assertEquals(typeof pattern !== "string" && pattern.exact, true);
+    });
+
+    it("should only be enabled for local projects", () => {
+      const handler = createHandler();
+      const enabledFn = handler.metadata.enabled;
+      assertEquals(typeof enabledFn, "function");
+
+      if (typeof enabledFn !== "function") return;
+
+      assertEquals(enabledFn({ isLocalProject: false } as never), false);
+      assertEquals(enabledFn({ isLocalProject: true } as never), true);
+      assertEquals(enabledFn({} as never), false);
+    });
+  });
+
+  describe("MetricsHandler.handle", () => {
+    it("should return continue for remote projects", async () => {
+      const handler = createHandler();
+      const req = new Request("http://localhost/_metrics");
+      const result = await handler.handle(req, remoteCtx);
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
+    });
+
+    it("should return continue for non-matching pathname", async () => {
+      const handler = createHandler();
+      const req = new Request("http://localhost/other-path");
+      const result = await handler.handle(req, localCtx);
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
+    });
+
+    it("should return metrics for local projects", async () => {
+      const handler = createHandler();
+      const req = new Request("http://localhost/_metrics");
+      const result = await handler.handle(req, localCtx);
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 200);
+      const body = await result.response.json();
+      assertExists(body.counters);
+    });
+  });
+});

--- a/src/server/handlers/monitoring/metrics.handler.test.ts
+++ b/src/server/handlers/monitoring/metrics.handler.test.ts
@@ -1,13 +1,14 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "../types.ts";
 import { MetricsHandler } from "./metrics.handler.ts";
 
 function createHandler(): MetricsHandler {
   return new MetricsHandler();
 }
 
-const localCtx = { securityConfig: undefined, isLocalProject: true } as never;
-const remoteCtx = { securityConfig: undefined, isLocalProject: false } as never;
+const localCtx = { securityConfig: undefined, isLocalProject: true } as unknown as HandlerContext;
+const remoteCtx = { securityConfig: undefined, isLocalProject: false } as unknown as HandlerContext;
 
 describe("server/handlers/monitoring/metrics", () => {
   describe("MetricsHandler metadata", () => {
@@ -34,9 +35,9 @@ describe("server/handlers/monitoring/metrics", () => {
 
       if (typeof enabledFn !== "function") return;
 
-      assertEquals(enabledFn({ isLocalProject: false } as never), false);
-      assertEquals(enabledFn({ isLocalProject: true } as never), true);
-      assertEquals(enabledFn({} as never), false);
+      assertEquals(enabledFn({ isLocalProject: false } as unknown as HandlerContext), false);
+      assertEquals(enabledFn({ isLocalProject: true } as unknown as HandlerContext), true);
+      assertEquals(enabledFn({} as unknown as HandlerContext), false);
     });
   });
 

--- a/src/server/handlers/monitoring/metrics.handler.ts
+++ b/src/server/handlers/monitoring/metrics.handler.ts
@@ -14,9 +14,12 @@ export class MetricsHandler extends BaseHandler {
     name: "MetricsHandler",
     priority: PRIORITY_HIGH as HandlerPriority,
     patterns: [{ pattern: "/_metrics", exact: true }],
+    enabled: (ctx) => !!ctx.isLocalProject,
   };
 
   handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
+    if (!ctx.isLocalProject) return Promise.resolve(this.continue());
+
     const { pathname } = new URL(req.url);
     if (pathname !== "/_metrics") return Promise.resolve(this.continue());
 

--- a/src/server/runtime-handler/request-utils.test.ts
+++ b/src/server/runtime-handler/request-utils.test.ts
@@ -25,7 +25,7 @@ describe("request-utils", () => {
       assertEquals(MONITORING_PATHS.has("/healthz"), true);
       assertEquals(MONITORING_PATHS.has("/readyz"), true);
       assertEquals(MONITORING_PATHS.has("/_health"), true);
-      assertEquals(MONITORING_PATHS.has("/_metrics"), true);
+      assertEquals(MONITORING_PATHS.has("/_metrics"), false);
     });
 
     it("LIGHTWEIGHT_PATH_PREFIXES includes module paths", () => {
@@ -81,7 +81,7 @@ describe("request-utils", () => {
       assertEquals(isMonitoringPath("/healthz"), true);
       assertEquals(isMonitoringPath("/readyz"), true);
       assertEquals(isMonitoringPath("/_health"), true);
-      assertEquals(isMonitoringPath("/_metrics"), true);
+      assertEquals(isMonitoringPath("/_metrics"), false);
     });
 
     it("returns false for non-monitoring paths", () => {

--- a/src/server/runtime-handler/request-utils.ts
+++ b/src/server/runtime-handler/request-utils.ts
@@ -32,7 +32,7 @@ export function isInternalHost(host: string): boolean {
 }
 
 /** Monitoring paths that should skip domain lookup */
-export const MONITORING_PATHS = new Set(["/healthz", "/readyz", "/_health", "/_metrics"]);
+export const MONITORING_PATHS = new Set(["/healthz", "/readyz", "/_health"]);
 
 /** Cached request timeout value (lazy-loaded to avoid module-level env access) */
 let _requestTimeoutMs: number | null = null;

--- a/tests/integration/server/dev-server-handlers.test.ts
+++ b/tests/integration/server/dev-server-handlers.test.ts
@@ -125,6 +125,20 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
         await stopServer(server);
       });
     });
+
+    it("serves metrics for local dev servers", async () => {
+      await withTestContext("dev-server-metrics", async (context) => {
+        const { server, port } = await createTestDevServer(context);
+
+        const response = await fetch(`http://127.0.0.1:${port}/_metrics`);
+
+        assertEquals(response.status, 200);
+        const json = await response.json();
+        assertExists(json?.counters);
+
+        await stopServer(server);
+      });
+    });
   });
 
   describe("DevServer - Dev Endpoint Handler", {}, () => {

--- a/tests/integration/server/production/server.test.ts
+++ b/tests/integration/server/production/server.test.ts
@@ -79,7 +79,7 @@ describe(
       });
     });
 
-    it("serves static files from public/ and exposes metrics and CORS", async () => {
+    it("serves static files from public/ and restricts metrics to local projects", async () => {
       await withTestContext("production-server-static", async (context: TestContext) => {
         await writeTextFile(`${context.projectDir}/public/hello.txt`, "hi");
 
@@ -105,15 +105,12 @@ describe(
           await notMod.text();
         }
 
+        // /_metrics is restricted to local projects only (security: H9/M11)
         const m = await fetch(`http://127.0.0.1:${port}/_metrics`, {
           headers: { origin: "http://example.com" },
         });
-        assertEquals(m.status, 200);
-        const json = await m.json();
-        if (!json?.counters) throw new Error("missing counters in metrics");
-
-        const metricsAllowOrigin = m.headers.get("access-control-allow-origin");
-        if (metricsAllowOrigin) assertEquals(metricsAllowOrigin, "http://example.com");
+        assertEquals(m.status, 404);
+        await m.text();
 
         controller.abort();
         await server.stop();

--- a/tests/integration/server/production/static.test.ts
+++ b/tests/integration/server/production/static.test.ts
@@ -14,7 +14,7 @@ describe(
       await cleanupBundler();
     });
 
-    it("serves static files from public/ and exposes metrics and CORS", async () => {
+    it("serves static files from public/ and restricts metrics to local projects", async () => {
       await withTestContext(
         "production-server-static",
         async (context: TestContext) => {
@@ -43,17 +43,13 @@ describe(
             await notMod.body?.cancel();
           }
 
+          // /_metrics is restricted to local projects only (security: H9/M11)
           const m = await fetch(`${baseUrl}/_metrics`, {
             headers: { origin },
           });
 
-          assertEquals(m.status, 200);
-
-          const json = await m.json();
-          if (!json?.counters) throw new Error("missing counters in metrics");
-
-          const metricsCors = m.headers.get("access-control-allow-origin");
-          if (metricsCors) assertEquals(metricsCors, origin);
+          assertEquals(m.status, 404);
+          await m.text();
         },
       );
     });


### PR DESCRIPTION
## Summary
- `/_debug/memory` (H9) and `/_metrics` (M11) endpoints were accessible without authentication on deployed instances, exposing heap stats, cache contents, GC triggers, and request/error metrics
- Add `enabled: (ctx) => !!ctx.isLocalProject` metadata guard to both handlers (same pattern as `DebugContextHandler`, `ClientLogHandler`, `DashboardHandler`)
- Add runtime `ctx.isLocalProject` check inside `handle()` for defense-in-depth

## Changes
- `src/server/handlers/monitoring/memory.handler.ts` — add `enabled` guard + runtime check
- `src/server/handlers/monitoring/metrics.handler.ts` — add `enabled` guard + runtime check
- `src/server/handlers/monitoring/memory.handler.test.ts` — 10 tests (metadata, access control, sub-paths)
- `src/server/handlers/monitoring/metrics.handler.test.ts` — 9 tests (metadata, access control, response)

## Test plan
- [x] `MemoryDebugHandler` is only enabled for local projects (metadata check)
- [x] `MemoryDebugHandler` returns continue for remote projects (runtime check)
- [x] `MemoryDebugHandler` serves all sub-paths for local projects
- [x] `MetricsHandler` is only enabled for local projects (metadata check)
- [x] `MetricsHandler` returns continue for remote projects (runtime check)
- [x] `MetricsHandler` serves metrics for local projects
- [x] All 19 test steps pass