### PR TITLE
fix: exclude data/ from HMR file watcher to prevent chat state loss

### DIFF
--- a/src/server/dev-server/file-watch-setup.ts
+++ b/src/server/dev-server/file-watch-setup.ts
@@ -134,7 +134,9 @@ export class FileWatchSetup {
 
         try {
           // Filter out paths that shouldn't trigger HMR (cache, node_modules, runtime data, etc.)
-          const relevantPaths = paths.filter((p) => !shouldIgnorePath(p) && !this.isRuntimeDataPath(p));
+          const relevantPaths = paths.filter((p) =>
+            !shouldIgnorePath(p) && !this.isRuntimeDataPath(p)
+          );
           if (relevantPaths.length === 0) continue;
 
           if (this.optimizedWatcher) {

--- a/src/server/dev-server/file-watch-setup.ts
+++ b/src/server/dev-server/file-watch-setup.ts
@@ -30,9 +30,14 @@ const IGNORED_PATH_PATTERNS = [
   ".git\\",
   ".veryfront/",
   ".veryfront\\",
-  "data/",
-  "data\\",
 ];
+
+/**
+ * Project-root directory names that contain runtime data (not source code)
+ * and should be excluded from HMR. Matched by first path segment relative
+ * to projectDir to avoid false positives (e.g. "src/data/" is fine).
+ */
+const IGNORED_RUNTIME_DIRS = new Set(["data"]);
 
 /**
  * Check if a path should be ignored for HMR purposes.
@@ -128,8 +133,8 @@ export class FileWatchSetup {
         if (signal.aborted) break;
 
         try {
-          // Filter out paths that shouldn't trigger HMR (cache, node_modules, etc.)
-          const relevantPaths = paths.filter((p) => !shouldIgnorePath(p));
+          // Filter out paths that shouldn't trigger HMR (cache, node_modules, runtime data, etc.)
+          const relevantPaths = paths.filter((p) => !shouldIgnorePath(p) && !this.isRuntimeDataPath(p));
           if (relevantPaths.length === 0) continue;
 
           if (this.optimizedWatcher) {
@@ -175,6 +180,16 @@ export class FileWatchSetup {
     const rel = relative(this.projectDir, fullPath);
     const firstSegment = rel.split(sep)[0] ?? "";
     return this.aiDirs.has(firstSegment);
+  }
+
+  /**
+   * Check if a path is inside a runtime data directory (data/, etc.)
+   * that contains generated content (embedding indices) rather than source code.
+   */
+  private isRuntimeDataPath(fullPath: string): boolean {
+    const rel = relative(this.projectDir, fullPath);
+    const firstSegment = rel.split(sep)[0] ?? "";
+    return IGNORED_RUNTIME_DIRS.has(firstSegment);
   }
 
   /** FNV-1a hash for fast content comparison */

--- a/src/server/dev-server/file-watch-setup.ts
+++ b/src/server/dev-server/file-watch-setup.ts
@@ -30,6 +30,8 @@ const IGNORED_PATH_PATTERNS = [
   ".git\\",
   ".veryfront/",
   ".veryfront\\",
+  "data/",
+  "data\\",
 ];
 
 /**


### PR DESCRIPTION
## Summary

- Excludes the project-root `data/` directory from HMR file watching
- Uses segment-based path matching (like `isAIPath`) to avoid false positives on paths like `src/data/` or `metadata/`

## Problem

When using the RAG agent template, the first chat message about a document triggers `indexContentDir()`, which writes to `data/index.json`. The file watcher picks this up and triggers an HMR reload, resetting React state and causing chat messages to disappear.

## Fix

Adds `isRuntimeDataPath()` method that matches only the project-root `data/` directory using `relative()` + first segment check, consistent with the existing `isAIPath()` pattern. The `data/` directory contains runtime data (embedding indices, uploaded content), not source code.

## Test plan

- [x] Built binary and tested with legal-app
- [x] Verified `data/index.json` write no longer triggers HMR reload
- [x] Verified chat messages persist after RAG indexing
- [x] Existing file watcher tests pass
- [x] `src/data/` and other paths containing "data" are not affected