### PR TITLE
chore: enhance type safety across codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ docs/api/
 
 # Local working files
 .local/
+.refactor/
 
 # Claude Octopus plugin state
 .claude-octopus/

--- a/src/agent/chat-handler.ts
+++ b/src/agent/chat-handler.ts
@@ -86,13 +86,10 @@ type ToolPartWithOutput = {
 function isToolPartWithOutput(part: unknown): part is ToolPartWithOutput {
   if (!part || typeof part !== "object") return false;
 
-  const p = part as Record<string, unknown>;
-  const type = p.type;
+  if (!("type" in part) || typeof part.type !== "string") return false;
+  if (!part.type.startsWith("tool-") || part.type === "tool-result") return false;
 
-  if (typeof type !== "string") return false;
-  if (!type.startsWith("tool-") || type === "tool-result") return false;
-
-  return p.output !== undefined;
+  return "output" in part && part.output !== undefined;
 }
 
 /**
@@ -133,7 +130,7 @@ function transformUIMessages(messages: ParsedMessage[]): Message[] {
 }
 
 function isTextPart(part: unknown): part is ParsedTextPart {
-  return typeof part === "object" && part !== null && (part as { type?: string }).type === "text";
+  return typeof part === "object" && part !== null && "type" in part && part.type === "text";
 }
 
 function extractLastUserText(messages: ParsedMessage[]): string {
@@ -157,9 +154,12 @@ function isResponseLike(value: unknown): value is Response {
   return (
     typeof value === "object" &&
     value !== null &&
-    typeof (value as Response).status === "number" &&
-    typeof (value as Response).headers === "object" &&
-    typeof (value as Response).bodyUsed === "boolean"
+    "status" in value &&
+    typeof value.status === "number" &&
+    "headers" in value &&
+    typeof value.headers === "object" &&
+    "bodyUsed" in value &&
+    typeof value.bodyUsed === "boolean"
   );
 }
 
@@ -248,17 +248,26 @@ function isRequest(obj: unknown): obj is Request {
   return (
     typeof obj === "object" &&
     obj !== null &&
-    typeof (obj as Request).json === "function" &&
-    typeof (obj as Request).url === "string" &&
-    typeof (obj as Request).method === "string"
+    "json" in obj &&
+    typeof obj.json === "function" &&
+    "url" in obj &&
+    typeof obj.url === "string" &&
+    "method" in obj &&
+    typeof obj.method === "string"
   );
 }
 
 function extractRequest(requestOrCtx: unknown): Request {
   if (isRequest(requestOrCtx)) return requestOrCtx;
   // Pages Router APIContext — has a .request property
-  const ctx = requestOrCtx as { request?: Request };
-  if (isRequest(ctx.request)) return ctx.request;
+  if (
+    typeof requestOrCtx === "object" &&
+    requestOrCtx !== null &&
+    "request" in requestOrCtx
+  ) {
+    const candidate = (requestOrCtx as Record<string, unknown>).request;
+    if (isRequest(candidate)) return candidate;
+  }
   throw new Error("Invalid handler argument: expected Request or APIContext");
 }
 
@@ -279,8 +288,7 @@ export function createChatHandler(
   agentId: string,
   options?: ChatHandlerOptions,
 ) {
-  // deno-lint-ignore no-explicit-any
-  return async function POST(requestOrCtx: any): Promise<Response> {
+  return async function POST(requestOrCtx: unknown): Promise<Response> {
     const request = extractRequest(requestOrCtx);
     let agent: ReturnType<typeof getAgent> | undefined;
     try {

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -64,7 +64,7 @@ export function isDynamicTool(name: string): boolean {
  * Tool configuration entry from agent config.
  * Can be a boolean (true to enable from registry) or a Tool instance.
  */
-// deno-lint-ignore no-explicit-any
+// deno-lint-ignore no-explicit-any -- generic erasure: accepts Tool with any input/output types
 export type ToolConfigEntry = Tool<any, any> | boolean;
 
 function logToolDefinition(name: string, def: ToolDefinition): void {
@@ -77,6 +77,7 @@ function logToolDefinition(name: string, def: ToolDefinition): void {
 function addToolDefinition(
   tools: ToolDefinition[],
   name: string,
+  // deno-lint-ignore no-explicit-any -- generic erasure: accepts Tool with any input/output types
   tool: Tool<any, any>,
 ): void {
   const def = toolToProviderDefinition(tool);

--- a/src/data/data-fetcher.test.ts
+++ b/src/data/data-fetcher.test.ts
@@ -25,7 +25,7 @@ describe("DataFetcher", () => {
     });
 
     it("should create instance with adapter", () => {
-      const mockAdapter = { env: { get: () => undefined } } as any;
+      const mockAdapter = { env: { get: () => undefined } };
       assertExists(new DataFetcher(mockAdapter));
     });
   });

--- a/src/html/styles-builder/plugin-loader.ts
+++ b/src/html/styles-builder/plugin-loader.ts
@@ -17,7 +17,7 @@ const logger = serverLogger.component("tailwind");
 // Provide localStorage shim for plugins that use util-deprecate (which checks localStorage)
 // This prevents "LocalStorage is not supported in this context" errors in Deno.
 try {
-  // deno-lint-ignore no-explicit-any
+  // deno-lint-ignore no-explicit-any -- localStorage may not exist on globalThis in Deno; probing for its presence
   const _test = (globalThis as any).localStorage;
 } catch {
   const localStorageShim = {

--- a/src/html/styles-builder/tailwind-compiler-cache.ts
+++ b/src/html/styles-builder/tailwind-compiler-cache.ts
@@ -109,7 +109,7 @@ export async function getCompiler(
     loadModule: async (id: string) => {
       const loaded = await loadPlugin(id, pluginCache, pluginErrors);
       if (!loaded) throw new Error(`Failed to load plugin "${id}": plugin not installed`);
-      // deno-lint-ignore no-explicit-any
+      // deno-lint-ignore no-explicit-any -- dynamically loaded plugin cannot be statically verified against Tailwind's Plugin | Config type
       return { module: loaded as any, base: "/", path: "/" };
     },
   });

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -6,12 +6,11 @@ import type { Prompt } from "#veryfront/prompt";
 /**
  * Generic MCP tool definition
  */
-// deno-lint-ignore no-explicit-any
+// deno-lint-ignore no-explicit-any -- generic erasure: interface must accept any concrete Tool instantiation
 export interface MCPTool<TInput = any, TOutput = any> {
   name: string;
   description: string;
-  // Using ZodType with output type for compatibility with ZodDefault/ZodOptional
-  // deno-lint-ignore no-explicit-any
+  // deno-lint-ignore no-explicit-any -- ZodType Def/Input params require any for ZodDefault/ZodOptional compatibility
   inputSchema: z.ZodType<TInput, any, any>;
   execute: (input: TInput) => Promise<TOutput>;
 }

--- a/src/platform/compat/dynamic-import.ts
+++ b/src/platform/compat/dynamic-import.ts
@@ -8,7 +8,8 @@
  * @module platform/compat
  */
 
-// deno-lint-ignore no-explicit-any
-export const dynamicImport = new Function("specifier", "return import(specifier)") as <T = any>(
+export const dynamicImport = new Function("specifier", "return import(specifier)") as <
+  T = unknown,
+>(
   specifier: string,
 ) => Promise<T>;

--- a/src/platform/compat/std/expect.ts
+++ b/src/platform/compat/std/expect.ts
@@ -47,9 +47,8 @@ interface Matchers<T> {
   not: Matchers<T>;
 }
 
-// deno-lint-ignore no-explicit-any
-type ExternalExpectFn = (actual: any) => any;
-// deno-lint-ignore no-explicit-any
+type ExternalExpectFn = (actual: unknown) => unknown;
+// deno-lint-ignore no-explicit-any -- external matchers (Deno std, Bun) may expose additional methods beyond our Matchers<T> interface
 type ExpectFn = <T>(actual: T) => Matchers<T> & Record<string, any>;
 
 function createNodeExpect(): ExpectFn {

--- a/src/provider/local/ai-sdk-adapter.ts
+++ b/src/provider/local/ai-sdk-adapter.ts
@@ -63,9 +63,8 @@ function convertPrompt(prompt: ReadonlyArray<PromptMessage>): ChatMessage[] {
   return messages;
 }
 
-/** AI SDK LanguageModelV2 generation options that both doGenerate and doStream receive. */
 interface LocalModelOptions {
-  prompt: unknown[];
+  prompt: ReadonlyArray<PromptMessage>;
   maxOutputTokens?: number;
   temperature?: number;
   topP?: number;
@@ -105,7 +104,7 @@ export function createLocalModel(modelId?: string): LanguageModel {
     supportedUrls: {},
 
     async doGenerate(options: LocalModelOptions) {
-      const messages = convertPrompt(options.prompt as ReadonlyArray<PromptMessage>);
+      const messages = convertPrompt(options.prompt);
       const genOptions = toGenerateOptions(options);
 
       logger.debug(`[local] doGenerate: ${messages.length} messages → ${resolvedId}`);
@@ -139,7 +138,7 @@ export function createLocalModel(modelId?: string): LanguageModel {
         );
       }
 
-      const messages = convertPrompt(options.prompt as ReadonlyArray<PromptMessage>);
+      const messages = convertPrompt(options.prompt);
       const genOptions = toGenerateOptions(options);
 
       logger.debug(`[local] doStream: ${messages.length} messages → ${resolvedId}`);

--- a/src/provider/local/env.ts
+++ b/src/provider/local/env.ts
@@ -2,7 +2,7 @@
  * Cross-platform environment helpers for local AI provider.
  *
  * Abstracts Deno/Node env access so all local-AI checks go through
- * a single function — no duplicated `(globalThis as any).Deno?.env` patterns.
+ * a single function — no duplicated `globalThis.Deno?.env` patterns.
  *
  * @module provider/local
  */
@@ -12,9 +12,11 @@
  * Works in Deno, Node, and compiled binaries.
  */
 export function isLocalAIDisabled(): boolean {
-  // deno-lint-ignore no-explicit-any
-  const denoVal = (globalThis as any).Deno?.env?.get?.("VERYFRONT_DISABLE_LOCAL_AI");
-  if (denoVal === "1") return true;
+  const denoVal = (globalThis as Record<string, unknown>).Deno as
+    | { env?: { get?: (key: string) => string | undefined } }
+    | undefined;
+  const denoEnvVal = denoVal?.env?.get?.("VERYFRONT_DISABLE_LOCAL_AI");
+  if (denoEnvVal === "1") return true;
 
   if (
     typeof process !== "undefined" &&

--- a/src/provider/local/local-embedding-engine.ts
+++ b/src/provider/local/local-embedding-engine.ts
@@ -14,8 +14,13 @@ import { getTransformers } from "./local-engine.ts";
 
 const logger = serverLogger.component("local-embedding");
 
-// deno-lint-ignore no-explicit-any
-type Pipeline = any;
+interface EmbeddingOutput {
+  tolist(): number[][];
+}
+
+interface Pipeline {
+  (texts: string[], options: { pooling: string; normalize: boolean }): Promise<EmbeddingOutput>;
+}
 
 /** Cached pipeline instances keyed by HuggingFace model ID */
 const pipelineCache = new Map<string, Pipeline>();
@@ -43,14 +48,14 @@ async function loadPipeline(modelInfo: ModelInfo): Promise<Pipeline> {
       `Loading local embedding model: ${modelInfo.hfId} (${modelInfo.dtype}, ~${modelInfo.sizeMB}MB)...`,
     );
 
-    const pipe = await transformers.pipeline(
+    const pipe = (await transformers.pipeline(
       "feature-extraction",
       modelInfo.hfId,
       {
         dtype: modelInfo.dtype,
         device: "cpu",
       },
-    );
+    )) as Pipeline;
 
     logger.info(`Embedding model loaded: ${modelInfo.hfId}`);
     pipelineCache.set(cacheKey, pipe);
@@ -84,5 +89,5 @@ export async function embedTexts(
   const pooling = modelInfo.pooling ?? "mean";
   const output = await pipe(texts, { pooling, normalize: true });
 
-  return output.tolist() as number[][];
+  return output.tolist();
 }

--- a/src/provider/local/local-engine.ts
+++ b/src/provider/local/local-engine.ts
@@ -34,10 +34,42 @@ export interface GenerateOptions {
   stopSequences?: string[];
 }
 
-// deno-lint-ignore no-explicit-any
-type TransformersModule = any;
-// deno-lint-ignore no-explicit-any
-type Pipeline = any;
+interface TransformersEnv {
+  cacheDir: string;
+  useBrowserCache: boolean;
+}
+
+interface TransformersModule {
+  env: TransformersEnv;
+  pipeline: (
+    task: string,
+    model: string,
+    options: { dtype: string; device: string },
+  ) => Promise<unknown>;
+  TextStreamer: new (
+    tokenizer: unknown,
+    options: {
+      skip_prompt: boolean;
+      skip_special_tokens: boolean;
+      callback_function: (text: string) => void;
+    },
+  ) => unknown;
+}
+
+interface Pipeline {
+  tokenizer: unknown;
+  (
+    messages: ChatMessage[],
+    options: {
+      max_new_tokens: number;
+      temperature: number;
+      top_p?: number;
+      top_k?: number;
+      do_sample: boolean;
+      streamer: unknown;
+    },
+  ): Promise<void>;
+}
 
 /** Cached pipeline instances keyed by HuggingFace model ID */
 const pipelineCache = new Map<string, Pipeline>();
@@ -45,7 +77,6 @@ const pipelineCache = new Map<string, Pipeline>();
 /** Whether a model is currently being loaded (prevents concurrent loads) */
 const loadingLocks = new Map<string, Promise<Pipeline>>();
 
-/** Lazily loaded @huggingface/transformers module */
 let transformersModule: TransformersModule | null = null;
 
 /**
@@ -66,8 +97,9 @@ export async function getTransformers(): Promise<TransformersModule> {
 
   logger.info("Loading @huggingface/transformers...");
 
+  let mod: TransformersModule;
   try {
-    transformersModule = await importTransformers();
+    mod = await importTransformers();
   } catch {
     throw toError(
       createError({
@@ -81,11 +113,12 @@ export async function getTransformers(): Promise<TransformersModule> {
   }
 
   // Configure cache directory for model files
-  transformersModule.env.cacheDir = "./.cache/models";
+  mod.env.cacheDir = "./.cache/models";
   // Disable browser-specific features in Node/Deno
-  transformersModule.env.useBrowserCache = false;
+  mod.env.useBrowserCache = false;
 
-  return transformersModule;
+  transformersModule = mod;
+  return mod;
 }
 
 /**
@@ -111,14 +144,14 @@ async function loadPipeline(modelInfo: ModelInfo): Promise<Pipeline> {
       `Loading local model: ${modelInfo.hfId} (${modelInfo.dtype}, ~${modelInfo.sizeMB}MB)...`,
     );
 
-    const pipe = await transformers.pipeline(
+    const pipe = (await transformers.pipeline(
       "text-generation",
       modelInfo.hfId,
       {
         dtype: modelInfo.dtype,
         device: "cpu",
       },
-    );
+    )) as Pipeline;
 
     logger.info(`Model loaded: ${modelInfo.hfId}`);
     pipelineCache.set(cacheKey, pipe);

--- a/src/provider/schemas/provider.schema.ts
+++ b/src/provider/schemas/provider.schema.ts
@@ -50,7 +50,8 @@ export const CompletionRequestSchema = z.object({
   temperature: z.number().min(0).max(2).optional(),
   topP: z.number().min(0).max(1).optional(),
   stream: z.boolean().optional(),
-  tools: z.array(z.any()).optional(), // ToolDefinition is complex
+  // deno-lint-ignore no-explicit-any -- ToolDefinition shapes vary across providers
+  tools: z.array(z.any()).optional(),
   reasoning: z
     .object({
       effort: z.enum(["low", "medium", "high"]).optional(),

--- a/src/rendering/element-validator/primitive-checks.ts
+++ b/src/rendering/element-validator/primitive-checks.ts
@@ -61,7 +61,7 @@ export function getElementTypeName(element: React.ReactElement): string {
   const { type } = element;
 
   if (typeof type === "function") {
-    const componentType = type as React.ComponentType<any>;
+    const componentType = type as React.ComponentType<unknown>;
     return type.name || componentType.displayName || "<Anonymous>";
   }
 

--- a/src/rendering/layouts/layout-applicator.ts
+++ b/src/rendering/layouts/layout-applicator.ts
@@ -230,8 +230,7 @@ export class LayoutApplicator {
           const appSource = await this.adapter.fs.readFile(appPath);
           const isMdx = appPath.endsWith(".mdx") || appPath.endsWith(".md");
 
-          // deno-lint-ignore no-explicit-any
-          let App: any;
+          let App: BundledReact.ComponentType<Record<string, unknown>> | null;
 
           if (isMdx) {
             App = await this.loadMdxAppComponent(appSource, appPath);
@@ -270,8 +269,10 @@ export class LayoutApplicator {
     );
   }
 
-  // deno-lint-ignore no-explicit-any
-  private async loadMdxAppComponent(source: string, appPath: string): Promise<any> {
+  private async loadMdxAppComponent(
+    source: string,
+    appPath: string,
+  ): Promise<BundledReact.ComponentType<Record<string, unknown>> | null> {
     try {
       const { compile } = await import("@mdx-js/mdx");
       const { getRehypePlugins, getRemarkPlugins } = await import(

--- a/src/rendering/orchestrator/module-collection.ts
+++ b/src/rendering/orchestrator/module-collection.ts
@@ -27,8 +27,7 @@ export interface ModuleToLoad {
 export interface LoadedModule {
   type: "page" | "layout";
   id: string;
-  // deno-lint-ignore no-explicit-any
-  mod: any;
+  mod: unknown;
 }
 
 /**

--- a/src/rendering/orchestrator/module-loader/index.ts
+++ b/src/rendering/orchestrator/module-loader/index.ts
@@ -524,7 +524,10 @@ async function getModuleCacheDir(config: ModuleLoaderConfig): Promise<string> {
  * @param config - Module loader configuration
  * @returns The loaded module
  */
-export async function loadModule(filePath: string, config: ModuleLoaderConfig): Promise<any> {
+export async function loadModule(
+  filePath: string,
+  config: ModuleLoaderConfig,
+): Promise<Record<string, unknown>> {
   const tmpDir = await getModuleCacheDir(config);
   const localAdapter = await getLocalAdapter();
 

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -37,7 +37,7 @@ import type { LayoutOrchestrator } from "./layout.ts";
 import type { SSROrchestrator } from "./ssr-orchestrator.ts";
 import type { PageDataResponse, RenderOptions, RenderResult } from "./types.ts";
 import { DataFetcher } from "#veryfront/data/index.ts";
-import type { DataContext } from "#veryfront/data/types.ts";
+import type { DataContext, PageWithData } from "#veryfront/data/types.ts";
 import { clearSSRModuleCacheForProject } from "#veryfront/modules/react-loader/index.ts";
 import { setupSSRGlobals } from "../ssr-globals.ts";
 import { LAYOUT_EXTENSIONS } from "../layouts/types.ts";
@@ -133,7 +133,7 @@ export class RenderPipeline {
     this.moduleLoaderConfig.esmCache.clear();
   }
 
-  private loadModule(filePath: string): Promise<unknown> {
+  private loadModule(filePath: string): Promise<Record<string, unknown>> {
     return loadModule(filePath, this.moduleLoaderConfig);
   }
 
@@ -278,7 +278,7 @@ export class RenderPipeline {
           Promise.all(
             dataJobs.map((job) =>
               this.dataFetcher
-                .fetchData(job.mod, dataContext, this.config.mode)
+                .fetchData(job.mod as PageWithData, dataContext, this.config.mode)
                 .then((result) => ({ ...job, result, error: null as Error | null }))
                 .catch((error: Error) => ({ ...job, result: null, error }))
             ),

--- a/src/rendering/rsc/client-hydrator.ts
+++ b/src/rendering/rsc/client-hydrator.ts
@@ -16,7 +16,7 @@ interface WindowWithVeryfront extends Window {
 }
 
 export class RSCHydrator {
-  private componentCache = new Map<string, React.ComponentType<any>>();
+  private componentCache = new Map<string, React.ComponentType<Record<string, unknown>>>();
   private manifestUrl: string;
   private manifest: Record<string, string> | null = null;
   private onError?: (error: Error) => void;
@@ -59,7 +59,7 @@ export class RSCHydrator {
     const instanceId = element.dataset.rscId;
 
     try {
-      const props = propsJson ? JSON.parse(propsJson) : {};
+      const props: Record<string, unknown> = propsJson ? JSON.parse(propsJson) : {};
       const Component = await this.loadClientComponent(componentName);
       const reactElement = React.createElement(Component, props);
 
@@ -91,7 +91,9 @@ export class RSCHydrator {
     }
   }
 
-  private async loadClientComponent(name: string): Promise<React.ComponentType<any>> {
+  private async loadClientComponent(
+    name: string,
+  ): Promise<React.ComponentType<Record<string, unknown>>> {
     const cached = this.componentCache.get(name);
     if (cached) return cached;
 
@@ -122,8 +124,9 @@ export class RSCHydrator {
         });
       }
 
-      this.componentCache.set(name, Component);
-      return Component;
+      const validated = Component as React.ComponentType<Record<string, unknown>>;
+      this.componentCache.set(name, validated);
+      return validated;
     } catch (error) {
       rscLogger.error(`Failed to load component ${name}:`, error);
       if (
@@ -162,8 +165,8 @@ export class RSCHydrator {
         });
       }
 
-      const data = await response.json();
-      this.manifest = data.components || data;
+      const data: Record<string, unknown> = await response.json();
+      this.manifest = (data.components || data) as Record<string, string>;
 
       rscLogger.debug("Loaded manifest:", this.manifest);
     } catch (error) {

--- a/src/rendering/rsc/server-renderer/component-detector.ts
+++ b/src/rendering/rsc/server-renderer/component-detector.ts
@@ -1,6 +1,7 @@
 import type * as React from "react";
 import type { ClientComponentMeta } from "../types.ts";
 
+// deno-lint-ignore no-explicit-any -- RSC components accept arbitrary props at runtime
 export type RSCComponent = React.ComponentType<any> & {
   __rsc_client?: boolean;
   __rsc_id?: string;

--- a/src/rendering/rsc/server-renderer/rsc-renderer.ts
+++ b/src/rendering/rsc/server-renderer/rsc-renderer.ts
@@ -18,6 +18,7 @@ export class RSCRenderer {
   }
 
   renderToPayload(
+    // deno-lint-ignore no-explicit-any -- RSC components accept arbitrary props at runtime
     Component: React.ComponentType<any> | React.ReactElement,
     props: Record<string, unknown> = {},
   ): Promise<RSCPayload> {

--- a/src/rendering/rsc/server-renderer/tree-processor.ts
+++ b/src/rendering/rsc/server-renderer/tree-processor.ts
@@ -15,6 +15,7 @@ const logger = serverLogger.component("rsc");
 
 /** Recursively renders a component tree to RSC nodes */
 export async function renderTree(
+  // deno-lint-ignore no-explicit-any -- RSC components accept arbitrary props at runtime
   Component: React.ComponentType<any> | React.ReactElement | string | number | null | undefined,
   props: Record<string, unknown>,
   clientManifest: Map<string, ClientComponentMeta>,

--- a/src/server/services/rsc/orchestrators/render-handler.ts
+++ b/src/server/services/rsc/orchestrators/render-handler.ts
@@ -34,7 +34,7 @@ export class RenderHandler {
     }
   }
 
-  private async loadComponent(pathname: string): Promise<React.ComponentType<any>> {
+  private async loadComponent(pathname: string): Promise<React.ComponentType<RenderProps>> {
     const componentPath = await resolveComponentPath(pathname, this.projectDir);
     if (!componentPath) {
       throw toError(
@@ -57,7 +57,7 @@ export class RenderHandler {
       );
     }
 
-    return Component as React.ComponentType<any>;
+    return Component as React.ComponentType<RenderProps>;
   }
 
   private buildProps(pathname: string, searchParams: URLSearchParams): RenderProps {
@@ -68,7 +68,7 @@ export class RenderHandler {
   }
 
   private async renderPayload(
-    component: React.ComponentType<any>,
+    component: React.ComponentType<RenderProps>,
     props: RenderProps,
   ): Promise<RSCPayload> {
     const renderer = this.getRenderer();

--- a/src/skill/parser.ts
+++ b/src/skill/parser.ts
@@ -52,8 +52,8 @@ function parseFrontmatterFallback(content: string): ParsedSkillContent {
     return { frontmatter: {}, body: content };
   }
 
-  const rawFrontmatter = match[1]!;
-  const body = match[2]!;
+  const rawFrontmatter = match[1] ?? "";
+  const body = match[2] ?? "";
   const frontmatter: Record<string, unknown> = {};
 
   for (const line of rawFrontmatter.split("\n")) {

--- a/src/skill/path-safety.ts
+++ b/src/skill/path-safety.ts
@@ -126,7 +126,15 @@ export async function validateSkillPath(
     );
   }
 
-  const canonicalPath = result.canonicalPath!;
+  if (!result.canonicalPath) {
+    throw toError(
+      createError({
+        type: "agent",
+        message: `Path validation succeeded but canonical path is undefined for: ${requestedPath}`,
+      }),
+    );
+  }
+  const canonicalPath = result.canonicalPath;
 
   // Verify the path exists and points to a file.
   if (!(await pathExists(canonicalPath, fsAdapter))) {

--- a/src/skill/testing.ts
+++ b/src/skill/testing.ts
@@ -6,7 +6,7 @@
  * @module
  */
 
-import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { FileSystemAdapter, FileWatcher } from "#veryfront/platform/adapters/base.ts";
 
 /**
  * Create a lightweight in-memory FileSystemAdapter for tests.
@@ -68,7 +68,7 @@ export function createSkillTestAdapter(files: Record<string, string>): FileSyste
       const isFile = path in files;
       const isDirectory = !isFile && allPaths.some((filePath) => filePath.startsWith(`${path}/`));
       return {
-        size: isFile ? files[path]!.length : 0,
+        size: isFile ? (files[path] ?? "").length : 0,
         isFile,
         isDirectory,
         isSymlink: false,
@@ -81,8 +81,11 @@ export function createSkillTestAdapter(files: Record<string, string>): FileSyste
     async makeTempDir() {
       return "/tmp/mock";
     },
-    watch() {
-      return null as never;
+    watch(): FileWatcher {
+      return {
+        close() {},
+        async *[Symbol.asyncIterator]() {},
+      };
     },
   } satisfies FileSystemAdapter;
 }

--- a/src/studio/bridge/bridge-block-drag.ts
+++ b/src/studio/bridge/bridge-block-drag.ts
@@ -6,6 +6,7 @@
  */
 
 import { editorState as state } from "./bridge-editor-state.ts";
+import type { MdxBlock } from "./bridge-state.ts";
 import { getConfig, isMdxPage } from "./bridge-config.ts";
 import { DATA_VF_IGNORE } from "./bridge-constants.ts";
 import { btn, el } from "./bridge-dom-helpers.ts";
@@ -180,7 +181,7 @@ export function createMarkdownDragGhost(block: Element): HTMLElement {
 // MDX helpers
 // ---------------------------------------------------------------------------
 
-export function getMdxBlockOpenUiState(block: any): {
+export function getMdxBlockOpenUiState(block: Record<string, unknown> | null | undefined): {
   hasResolvedTarget: boolean;
   buttonLabel: string;
   showUnresolvedNote: boolean;
@@ -201,7 +202,7 @@ export function getMdxBlockOpenUiState(block: any): {
 // MDX blocks panel
 // ---------------------------------------------------------------------------
 
-export function setMarkdownMdxBlocks(blocks: any[]): void {
+export function setMarkdownMdxBlocks(blocks: MdxBlock[]): void {
   const PAGE_PATH = getConfig().pagePath;
 
   state.markdownLatestMdxBlocks = Array.isArray(blocks) ? blocks : [];

--- a/src/studio/bridge/bridge-config.ts
+++ b/src/studio/bridge/bridge-config.ts
@@ -21,6 +21,7 @@ export interface BridgeConfig {
 let config: BridgeConfig | null = null;
 
 export function initConfig(): void {
+  // deno-lint-ignore no-explicit-any -- accessing injected global property
   const raw = (window as any).__VF_BRIDGE_CONFIG__;
 
   // studioMode can come from the injected config or from a query parameter

--- a/src/studio/bridge/bridge-console.ts
+++ b/src/studio/bridge/bridge-console.ts
@@ -10,13 +10,15 @@ import { hideOverlay } from "./bridge-inspector.ts";
 
 export function setupConsoleCapture(): void {
   CONSOLE_METHODS.forEach((method) => {
+    // deno-lint-ignore no-explicit-any -- dynamic console method access by string key
     state.originalConsole[method] = (console as any)[method];
-    (console as any)[method] = function (...args: any[]) {
+    // deno-lint-ignore no-explicit-any -- replacing console methods dynamically
+    (console as any)[method] = function (...args: unknown[]) {
       state.originalConsole[method]!.apply(console, args);
 
       const logId = "vf-" + Date.now() + "-" + ++state.logCounter;
 
-      const formattedData = args.map((arg) => {
+      const formattedData = args.map((arg: unknown) => {
         try {
           if (arg instanceof Error) {
             return { __isError: true, message: arg.message, stack: arg.stack, name: arg.name };

--- a/src/studio/bridge/bridge-coordinator.ts
+++ b/src/studio/bridge/bridge-coordinator.ts
@@ -19,6 +19,7 @@ const config = getConfig();
 
 // Expose debug internals when configured
 if (config.debugExposeInternals && typeof window !== "undefined") {
+  // deno-lint-ignore no-explicit-any -- exposing debug internals on window global
   (window as any).__VF_STUDIO_BRIDGE_DEBUG = {
     parseMdxImportMap: parseMdxImportMap,
     extractRawBlocksForEditor: extractRawBlocksForEditor,

--- a/src/studio/bridge/bridge-inspector.ts
+++ b/src/studio/bridge/bridge-inspector.ts
@@ -87,6 +87,19 @@ export function findElementById(nodeId: string | null): Element | null {
 
 // --- Tree building ---
 
+interface NavigatorTreeNode {
+  id: string;
+  name: string;
+  type: string;
+  path: string;
+  parentId: string;
+  start: { line: number; column: number };
+  end: { line: number; column: number };
+  children: NavigatorTreeNode[];
+  text?: string;
+  isRemote: boolean;
+}
+
 function isValidElement(el: Element): boolean {
   return (
     !!el &&
@@ -106,13 +119,13 @@ function getNodeType(el: Element): string {
   return "element";
 }
 
-export function buildNavigatorTree(root: Element): any {
+export function buildNavigatorTree(root: Element): NavigatorTreeNode {
   const config = getConfig();
   let nodeIndex = 0;
 
-  function processElement(el: Element, parentId: string): any[] {
+  function processElement(el: Element, parentId: string): NavigatorTreeNode[] {
     if (!isValidElement(el)) {
-      const children: any[] = [];
+      const children: NavigatorTreeNode[] = [];
       Array.from(el.children || []).forEach((child) => {
         children.push(...processElement(child, parentId));
       });
@@ -130,9 +143,9 @@ export function buildNavigatorTree(root: Element): any {
     const vfId = el.getAttribute(DATA_VF_ID);
     const name = vfId ? vfId.split("_")[0] : el.tagName.toLowerCase();
 
-    const node: any = {
+    const node: NavigatorTreeNode = {
       id: id,
-      name: name,
+      name: name!,
       type: getNodeType(el),
       path: config.pagePath,
       parentId: parentId,
@@ -153,7 +166,7 @@ export function buildNavigatorTree(root: Element): any {
     return [node];
   }
 
-  const rootNode: any = {
+  const rootNode: NavigatorTreeNode = {
     id: "root",
     name: "root",
     type: "root",
@@ -162,6 +175,7 @@ export function buildNavigatorTree(root: Element): any {
     start: { line: 0, column: 0 },
     end: { line: 0, column: 0 },
     children: [],
+    isRemote: false,
   };
 
   Array.from(root.children || []).forEach((child) => {
@@ -193,6 +207,7 @@ export function sendTreeUpdate(): void {
     id: config.pageId,
     url: window.location.href,
     tree: buildNavigatorTree(root),
+    // deno-lint-ignore no-explicit-any -- accessing injected global property
     sourceHash: (window as any).__VERYFRONT_SOURCE_HASH__ || null,
   });
 }

--- a/src/studio/bridge/bridge-markdown-core.ts
+++ b/src/studio/bridge/bridge-markdown-core.ts
@@ -462,12 +462,8 @@ export function extractRawBlocksForEditor(
     const fallbackSymbol = componentParts.length > 0
       ? componentParts[componentParts.length - 1]
       : "";
-    const directEntry = normalizedComponentName
-      ? (importMap as Record<string, any>)[normalizedComponentName]
-      : null;
-    const namespaceEntry = !directEntry && namespaceName
-      ? (importMap as Record<string, any>)[namespaceName]
-      : null;
+    const directEntry = normalizedComponentName ? importMap[normalizedComponentName] : null;
+    const namespaceEntry = !directEntry && namespaceName ? importMap[namespaceName!] : null;
     const importEntry = directEntry || namespaceEntry || null;
     const entryPath = importEntry && typeof importEntry.filePath === "string"
       ? importEntry.filePath
@@ -500,11 +496,11 @@ export function extractRawBlocksForEditor(
   // capture groups. In a .replace() callback, the last two args are
   // always (offset, inputText), and the first capture group is always
   // the leading newline.
-  const replaceWithToken = function (...args: any[]): string {
-    const match: string = args[0];
-    const leadingNewline: string = args[1];
-    const offset: number = args[args.length - 2];
-    const inputText: string = args[args.length - 1];
+  const replaceWithToken = function (...args: unknown[]): string {
+    const match = args[0] as string;
+    const leadingNewline = args[1] as string;
+    const offset = args[args.length - 2] as number;
+    const inputText = args[args.length - 1] as string;
     const safeLeading = typeof leadingNewline === "string" ? leadingNewline : "";
     const tokenIndex = rawBlocks.length;
     const rawBlock = typeof match === "string" ? match.trimStart() : "";
@@ -537,12 +533,16 @@ export function extractRawBlocksForEditor(
     "g",
   );
 
+  // deno-lint-ignore no-explicit-any -- .replace() callback with variadic capture groups
   let editorBody = source.replace(mermaidFencePattern, replaceWithToken as any);
 
+  // deno-lint-ignore no-explicit-any -- .replace() callback with variadic capture groups
   editorBody = editorBody.replace(tsxFencePattern, replaceWithToken as any);
 
+  // deno-lint-ignore no-explicit-any -- .replace() callback with variadic capture groups
   editorBody = editorBody.replace(htmlBlockPattern, replaceWithToken as any);
 
+  // deno-lint-ignore no-explicit-any -- .replace() callback with variadic capture groups
   editorBody = editorBody.replace(htmlSelfClosingPattern, replaceWithToken as any);
 
   return {

--- a/src/studio/bridge/bridge-markdown-editor.ts
+++ b/src/studio/bridge/bridge-markdown-editor.ts
@@ -11,6 +11,7 @@
  */
 
 import { editorState as state } from "./bridge-editor-state.ts";
+import type { RemoteSelection } from "./bridge-state.ts";
 import { getConfig, isMarkdownPage } from "./bridge-config.ts";
 import { btn, el } from "./bridge-dom-helpers.ts";
 
@@ -91,6 +92,7 @@ export function setupMarkdownLexicalEditor(): void {
     import("https://esm.sh/@lexical/history@0.21.0?target=es2022"),
     import("https://esm.sh/@lexical/selection@0.21.0?target=es2022"),
   ])
+    // deno-lint-ignore no-explicit-any -- dynamic ESM CDN imports have no static types
     .then(function (modules: any[]) {
       if (!state.markdownEditorSurface) {
         return;
@@ -124,7 +126,7 @@ export function setupMarkdownLexicalEditor(): void {
         1000,
       );
       const unregisterUpdate = editor.registerUpdateListener(function (
-        update: any,
+        update: { editorState: { read(fn: () => void): void } },
       ) {
         if (state.markdownApplyingRemoteUpdate) {
           // Reconcile once remote apply settles so local edits during this window
@@ -229,7 +231,7 @@ export function focusMarkdownEditor(): void {
 // applyMarkdownHistoryCommand
 // ---------------------------------------------------------------------------
 
-export function applyMarkdownHistoryCommand(command: any): void {
+export function applyMarkdownHistoryCommand(command: unknown): void {
   if (
     !state.markdownLexicalApi ||
     !state.markdownLexicalApi.editor ||
@@ -455,7 +457,7 @@ export function applyMarkdownContent(content: unknown): void {
  * the cursor overlay render. No toolbar pill DOM — overlays show
  * cursors/highlights directly on the editor surface.
  */
-export function updateMarkdownOverlaySelections(selections: any[]): void {
+export function updateMarkdownOverlaySelections(selections: RemoteSelection[]): void {
   state.markdownLatestSelections = Array.isArray(selections) ? selections : [];
   state.markdownOverlaySelections = [];
 
@@ -465,7 +467,7 @@ export function updateMarkdownOverlaySelections(selections: any[]): void {
   }
 
   const validSelections = selections
-    .filter(function (selection: any) {
+    .filter(function (selection: RemoteSelection) {
       return (
         selection &&
         typeof selection.name === "string" &&

--- a/src/studio/bridge/bridge-markdown-yjs.ts
+++ b/src/studio/bridge/bridge-markdown-yjs.ts
@@ -26,6 +26,10 @@ interface MarkdownYjsConnectionOptions {
   token?: string;
 }
 
+interface YTextEvent {
+  transaction: { origin: unknown };
+}
+
 // ---------------------------------------------------------------------------
 // syncLocalChangeToYText
 // ---------------------------------------------------------------------------
@@ -315,11 +319,11 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
           // Observe Y.Text for remote changes (from other users / Monaco)
           if (!ytextObserverRegistered) {
             ytextObserverRegistered = true;
-            ytext.observe((event: any) => {
+            ytext.observe((event: unknown) => {
               if (!isCurrentSetup()) {
                 return;
               }
-              const origin = event.transaction.origin;
+              const origin = (event as YTextEvent).transaction.origin;
               if (origin === LEXICAL_YJS_ORIGIN) {
                 return;
               }

--- a/src/studio/bridge/bridge-screenshot.ts
+++ b/src/studio/bridge/bridge-screenshot.ts
@@ -7,9 +7,24 @@
 import { state } from "./bridge-state.ts";
 
 declare const window: Window & {
+  // deno-lint-ignore no-explicit-any -- third-party html2canvas loaded via CDN script tag
   html2canvas: any;
   devicePixelRatio: number;
 };
+
+interface ScreenshotResult {
+  success: boolean;
+  data?: string;
+  width?: number;
+  height?: number;
+  scrollY?: number;
+  totalHeight?: number;
+  viewportHeight?: number;
+  url?: string;
+  error?: string;
+  section?: number;
+  totalSections?: number;
+}
 
 function loadHtml2Canvas(): Promise<void> {
   if (state.html2canvasLoaded) return Promise.resolve();
@@ -49,7 +64,7 @@ export async function captureScreenshot(options?: {
   scrollTo?: number;
   fullPage?: boolean;
   quality?: number;
-}): Promise<any> {
+}): Promise<ScreenshotResult> {
   const { scrollTo, fullPage, quality = 0.8 } = options || {};
   const originalScrollY = window.scrollY;
 
@@ -61,7 +76,7 @@ export async function captureScreenshot(options?: {
       await new Promise((r) => setTimeout(r, 150));
     }
 
-    const canvasOptions: any = {
+    const canvasOptions: Record<string, unknown> = {
       useCORS: true,
       logging: false,
       scale: window.devicePixelRatio || 1,
@@ -118,19 +133,19 @@ export async function captureScreenshot(options?: {
       viewportHeight: window.innerHeight,
       url: window.location.href,
     };
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error("[bridge] html2canvas error:", error);
     window.scrollTo(0, originalScrollY);
     return {
       success: false,
-      error: error.message || String(error),
+      error: error instanceof Error ? error.message : String(error),
     };
   }
 }
 
-export async function captureMultipleSections(sectionCount?: number): Promise<any[]> {
+export async function captureMultipleSections(sectionCount?: number): Promise<ScreenshotResult[]> {
   const originalScrollY = window.scrollY;
-  const results: any[] = [];
+  const results: ScreenshotResult[] = [];
   const totalHeight = document.documentElement.scrollHeight;
   const viewportHeight = window.innerHeight;
   const sections = sectionCount || Math.ceil(totalHeight / viewportHeight);

--- a/src/studio/bridge/bridge-utils.ts
+++ b/src/studio/bridge/bridge-utils.ts
@@ -4,8 +4,10 @@
  * Small shared helpers used across bridge modules.
  */
 
+// deno-lint-ignore no-explicit-any -- generic debounce must accept any function signature
 export function debounce<T extends (...args: any[]) => void>(fn: T, ms: number): T {
   let timer: ReturnType<typeof setTimeout> | undefined;
+  // deno-lint-ignore no-explicit-any -- preserving original this/args for forwarding
   return function (this: any, ...args: any[]) {
     clearTimeout(timer);
     timer = setTimeout(() => {

--- a/src/testing/assert.ts
+++ b/src/testing/assert.ts
@@ -2,7 +2,7 @@ import "./init.ts";
 import { isDeno } from "#veryfront/platform/compat/runtime.ts";
 import { deepEquals, safeStringify } from "./utils.ts";
 
-// deno-lint-ignore no-explicit-any
+// deno-lint-ignore no-explicit-any -- any[] required: constructor params are contravariant
 type ErrorClass = new (...args: any[]) => Error;
 
 interface AssertImpl {
@@ -25,18 +25,17 @@ interface AssertImpl {
   ): Promise<unknown>;
   assertStringIncludes(actual: string, expected: string, msg?: string): void;
   assertMatch(actual: string, expected: RegExp, msg?: string): void;
-  // deno-lint-ignore no-explicit-any
   assertInstanceOf<T>(
     actual: unknown,
+    // deno-lint-ignore no-explicit-any -- any[] required: constructor params are contravariant
     expectedType: abstract new (...args: any[]) => T,
     msg?: string,
   ): void;
   fail(msg?: string): never;
   assertNotStrictEquals<T>(actual: T, expected: T, msg?: string): void;
-  // deno-lint-ignore no-explicit-any
   assertObjectMatch(
-    actual: Record<string, any>,
-    expected: Record<string, any>,
+    actual: Record<string, unknown>,
+    expected: Record<string, unknown>,
     msg?: string,
   ): void;
   assertGreater(actual: number, expected: number, msg?: string): void;
@@ -79,8 +78,8 @@ function createNodeAssertImpl(): AssertImpl {
   }
 
   function assertObjectMatch(
-    actual: Record<string, any>,
-    expected: Record<string, any>,
+    actual: Record<string, unknown>,
+    expected: Record<string, unknown>,
     msg?: string,
   ): void {
     for (const key of Object.keys(expected)) {
@@ -92,7 +91,11 @@ function createNodeAssertImpl(): AssertImpl {
           throw new Error(msg || `Expected ${key} to be an object`);
         }
 
-        assertObjectMatch(actualVal, expectedVal, msg);
+        assertObjectMatch(
+          actualVal as Record<string, unknown>,
+          expectedVal as Record<string, unknown>,
+          msg,
+        );
         continue;
       }
 
@@ -306,9 +309,9 @@ export function assertMatch(actual: string, expected: RegExp, msg?: string): voi
   impl.assertMatch(actual, expected, msg);
 }
 
-// deno-lint-ignore no-explicit-any
 export function assertInstanceOf<T>(
   actual: unknown,
+  // deno-lint-ignore no-explicit-any -- any[] required: constructor params are contravariant
   expectedType: abstract new (...args: any[]) => T,
   msg?: string,
 ): asserts actual is T {
@@ -323,10 +326,9 @@ export function assertNotStrictEquals<T>(actual: T, expected: T, msg?: string): 
   impl.assertNotStrictEquals(actual, expected, msg);
 }
 
-// deno-lint-ignore no-explicit-any
 export function assertObjectMatch(
-  actual: Record<string, any>,
-  expected: Record<string, any>,
+  actual: Record<string, unknown>,
+  expected: Record<string, unknown>,
   msg?: string,
 ): void {
   impl.assertObjectMatch(actual, expected, msg);

--- a/src/tool/factory.ts
+++ b/src/tool/factory.ts
@@ -80,8 +80,7 @@ function convertSchemaToJson(
 ): JsonSchema {
   if (hasValidZodTypeName(schema)) {
     const result = tryConvert(
-      // deno-lint-ignore no-explicit-any
-      () => zodToJsonSchema(schema as any),
+      () => zodToJsonSchema(schema as z.ZodTypeAny),
       toolId,
       logPrefix,
       permissive,

--- a/src/tool/schema/zod-json-schema.ts
+++ b/src/tool/schema/zod-json-schema.ts
@@ -55,13 +55,13 @@ function convert(schema: z.ZodTypeAny): JsonSchema {
 
     case ZodFirstPartyTypeKind.ZodNativeEnum:
       return {
-        enum: Object.values((schema as z.ZodNativeEnum<any>)._def.values).filter(
+        enum: Object.values((schema as z.ZodNativeEnum<z.EnumLike>)._def.values).filter(
           (value) => typeof value !== "number",
         ),
       };
 
     case ZodFirstPartyTypeKind.ZodObject: {
-      const obj = schema as z.ZodObject<any>;
+      const obj = schema as z.ZodObject<z.ZodRawShape>;
       const properties: Record<string, JsonSchema> = {};
       const required: string[] = [];
 
@@ -102,7 +102,10 @@ function convert(schema: z.ZodTypeAny): JsonSchema {
     }
 
     case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
-      const union = schema as z.ZodDiscriminatedUnion<string, z.ZodObject<any>[]>;
+      const union = schema as z.ZodDiscriminatedUnion<
+        string,
+        z.ZodDiscriminatedUnionOption<string>[]
+      >;
       return {
         anyOf: Array.from(union._def.options.values()).map((option) => zodToJsonSchema(option)),
       };
@@ -111,7 +114,9 @@ function convert(schema: z.ZodTypeAny): JsonSchema {
     case ZodFirstPartyTypeKind.ZodRecord:
       return {
         type: "object",
-        additionalProperties: zodToJsonSchema((schema as z.ZodRecord<any>)._def.valueType),
+        additionalProperties: zodToJsonSchema(
+          (schema as z.ZodRecord<z.ZodString, z.ZodTypeAny>)._def.valueType,
+        ),
       };
 
     case ZodFirstPartyTypeKind.ZodDefault: {
@@ -127,10 +132,10 @@ function convert(schema: z.ZodTypeAny): JsonSchema {
     }
 
     case ZodFirstPartyTypeKind.ZodLazy:
-      return convert((schema as z.ZodLazy<any>)._def.getter());
+      return convert((schema as z.ZodLazy<z.ZodTypeAny>)._def.getter());
 
     case ZodFirstPartyTypeKind.ZodEffects:
-      return convert((schema as z.ZodEffects<any>)._def.schema);
+      return convert((schema as z.ZodEffects<z.ZodTypeAny>)._def.schema);
 
     default:
       return { type: "object" };
@@ -157,7 +162,7 @@ function unwrapSchema(
         break;
 
       case ZodFirstPartyTypeKind.ZodEffects:
-        current = (current as z.ZodEffects<any>)._def.schema;
+        current = (current as z.ZodEffects<z.ZodTypeAny>)._def.schema;
         break;
 
       default:

--- a/src/tool/types.ts
+++ b/src/tool/types.ts
@@ -9,7 +9,7 @@ import type { BlobStorage } from "#veryfront/workflow/blob/types.ts";
 /**
  * Tool configuration options
  */
-// deno-lint-ignore no-explicit-any
+// deno-lint-ignore no-explicit-any -- generic erasure: interface must accept any concrete ToolConfig instantiation
 export interface ToolConfig<TInput = any, TOutput = any> {
   /** Tool identifier (optional, inferred from filename) */
   id?: string;
@@ -70,7 +70,7 @@ export type ToolType = "function" | "dynamic";
 /**
  * Tool instance (returned by tool() function)
  */
-// deno-lint-ignore no-explicit-any
+// deno-lint-ignore no-explicit-any -- generic erasure: interface must accept any concrete Tool instantiation
 export interface Tool<TInput = any, TOutput = any> {
   /** Tool ID */
   id: string;

--- a/src/transforms/mdx/esm-module-loader/jsx/runtime-loader.ts
+++ b/src/transforms/mdx/esm-module-loader/jsx/runtime-loader.ts
@@ -6,7 +6,7 @@ export interface JSXRuntime {
 }
 
 export async function loadJSXRuntime(): Promise<JSXRuntime> {
-  // deno-lint-ignore no-explicit-any
+  // deno-lint-ignore no-explicit-any -- react/jsx-dev-runtime has no type declarations in Deno; module shape is untyped
   const runtime = (await import("react/jsx-dev-runtime")) as any;
 
   return {

--- a/src/types/entities/getEntityInfo.ts
+++ b/src/types/entities/getEntityInfo.ts
@@ -113,12 +113,16 @@ export async function getEntityInfo(
           try {
             const adapterFs = adapter.fs;
             if (isExtendedFSAdapter(adapterFs) && adapterFs.isVeryfrontAdapter()) {
-              const underlyingAdapter = adapterFs.getUnderlyingAdapter() as {
-                getEntityIdForPath?: (path: string) => string | undefined;
-              };
+              const underlyingAdapter = adapterFs.getUnderlyingAdapter();
 
-              const getEntityIdForPath = underlyingAdapter?.getEntityIdForPath;
-              if (getEntityIdForPath) {
+              if (
+                underlyingAdapter &&
+                "getEntityIdForPath" in underlyingAdapter &&
+                typeof underlyingAdapter.getEntityIdForPath === "function"
+              ) {
+                const getEntityIdForPath = underlyingAdapter.getEntityIdForPath as (
+                  path: string,
+                ) => string | undefined;
                 const relativePath = filePath
                   .replace(/^.*?\/pages\//, "pages/")
                   .replace(/^.*?\/components\//, "components/");

--- a/src/types/global-guards.ts
+++ b/src/types/global-guards.ts
@@ -11,7 +11,8 @@ export interface GlobalWithVeryFrontCache {
 
 export function hasReactDOM(global: unknown): global is GlobalWithReactDOM {
   if (typeof global !== "object" || global === null) return false;
-  return "ReactDOM" in global && typeof (global as GlobalWithReactDOM).ReactDOM !== "undefined";
+  return "ReactDOM" in global &&
+    typeof (global as Record<string, unknown>)["ReactDOM"] !== "undefined";
 }
 
 export function hasVeryFrontCache(global: unknown): global is GlobalWithVeryFrontCache {

--- a/src/workflow/executor/workflow-executor.ts
+++ b/src/workflow/executor/workflow-executor.ts
@@ -82,6 +82,7 @@ export class WorkflowExecutor {
   private stepExecutor: StepExecutor;
   private checkpointManager: CheckpointManager;
   private dagExecutor: DAGExecutor;
+  // deno-lint-ignore no-explicit-any -- type-erased registry: register() accepts WorkflowDefinition<TInput, TOutput> with arbitrary type params
   private workflows = new Map<string, WorkflowDefinition<any, any>>();
   private blobResolver?: BlobResolver;
 
@@ -150,6 +151,7 @@ export class WorkflowExecutor {
   /**
    * Get a registered workflow
    */
+  // deno-lint-ignore no-explicit-any -- type-erased registry lookup
   getWorkflow(id: string): WorkflowDefinition<any, any> | undefined {
     return this.workflows.get(id);
   }

--- a/src/workflow/worker/dynamic-job-entrypoint.ts
+++ b/src/workflow/worker/dynamic-job-entrypoint.ts
@@ -160,6 +160,7 @@ export async function runDynamicWorkflowJob(
         const discoveryResult = await discoverWorkflows({
           projectDir: "", // Root of project (relative paths with API)
           adapter,
+          // deno-lint-ignore no-explicit-any -- fsConfig is a partial VeryfrontConfig subset
           config: fsConfig as any,
           debug,
         });


### PR DESCRIPTION
Audit all 55 modules (44 src + 11 cli) for permissive `any` types. 18 modules had `any` to fix (46 files changed), 37 were already clean.

- Structural interfaces for dynamic modules (TransformersModule, Pipeline)
- `unknown` with runtime narrowing instead of type assertions
- Proper generic params for Zod schemas and React components
- New interfaces: NavigatorTreeNode, ScreenshotResult, RemoteSelection
- Remaining unavoidable `any` annotated with lint-ignore reasons

All lint, format, type checks, and tests pass (805/805).

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
