### PR TITLE
refactor: migrate console calls to structured loggers

### DIFF
--- a/src/agent/testing/agent-tester.ts
+++ b/src/agent/testing/agent-tester.ts
@@ -7,7 +7,6 @@
  **************************/
 
 import type { Agent, AgentResponse, Message } from "../types.ts";
-import { agentLogger } from "#veryfront/utils/logger/logger.ts";
 
 export interface TestCase {
   /** Test name */
@@ -163,24 +162,24 @@ async function validateTestCase(
 }
 
 export function printTestResults(suite: TestSuite): void {
-  agentLogger.info(`\n=== Test Suite: ${suite.name} ===\n`);
+  console.log(`\n=== Test Suite: ${suite.name} ===\n`);
 
   const passed = suite.results.filter((r) => r.passed).length;
   const total = suite.results.length;
 
   for (const [index, result] of suite.results.entries()) {
     const icon = result.passed ? "✅" : "❌";
-    agentLogger.info(`${icon} ${index + 1}. ${result.name}`);
+    console.log(`${icon} ${index + 1}. ${result.name}`);
 
-    if (!result.passed && result.error) agentLogger.info(`   Error: ${result.error}`);
-    if (result.toolCalls.length) agentLogger.info(`   Tools used: ${result.toolCalls.join(", ")}`);
+    if (!result.passed && result.error) console.log(`   Error: ${result.error}`);
+    if (result.toolCalls.length) console.log(`   Tools used: ${result.toolCalls.join(", ")}`);
 
-    agentLogger.info(`   Time: ${result.executionTime}ms\n`);
+    console.log(`   Time: ${result.executionTime}ms\n`);
   }
 
-  agentLogger.info(`Results: ${passed}/${total} passed`);
-  agentLogger.info(`Total time: ${suite.totalTime}ms`);
-  agentLogger.info(`Status: ${suite.passed ? "✅ PASSED" : "❌ FAILED"}\n`);
+  console.log(`Results: ${passed}/${total} passed`);
+  console.log(`Total time: ${suite.totalTime}ms`);
+  console.log(`Status: ${suite.passed ? "✅ PASSED" : "❌ FAILED"}\n`);
 }
 
 export function assertContains(response: AgentResponse, text: string): boolean {

--- a/src/agent/testing/agent-tester.ts
+++ b/src/agent/testing/agent-tester.ts
@@ -7,6 +7,7 @@
  **************************/
 
 import type { Agent, AgentResponse, Message } from "../types.ts";
+import { agentLogger } from "#veryfront/utils/logger/logger.ts";
 
 export interface TestCase {
   /** Test name */
@@ -162,24 +163,24 @@ async function validateTestCase(
 }
 
 export function printTestResults(suite: TestSuite): void {
-  console.log(`\n=== Test Suite: ${suite.name} ===\n`);
+  agentLogger.info(`\n=== Test Suite: ${suite.name} ===\n`);
 
   const passed = suite.results.filter((r) => r.passed).length;
   const total = suite.results.length;
 
   for (const [index, result] of suite.results.entries()) {
     const icon = result.passed ? "✅" : "❌";
-    console.log(`${icon} ${index + 1}. ${result.name}`);
+    agentLogger.info(`${icon} ${index + 1}. ${result.name}`);
 
-    if (!result.passed && result.error) console.log(`   Error: ${result.error}`);
-    if (result.toolCalls.length) console.log(`   Tools used: ${result.toolCalls.join(", ")}`);
+    if (!result.passed && result.error) agentLogger.info(`   Error: ${result.error}`);
+    if (result.toolCalls.length) agentLogger.info(`   Tools used: ${result.toolCalls.join(", ")}`);
 
-    console.log(`   Time: ${result.executionTime}ms\n`);
+    agentLogger.info(`   Time: ${result.executionTime}ms\n`);
   }
 
-  console.log(`Results: ${passed}/${total} passed`);
-  console.log(`Total time: ${suite.totalTime}ms`);
-  console.log(`Status: ${suite.passed ? "✅ PASSED" : "❌ FAILED"}\n`);
+  agentLogger.info(`Results: ${passed}/${total} passed`);
+  agentLogger.info(`Total time: ${suite.totalTime}ms`);
+  agentLogger.info(`Status: ${suite.passed ? "✅ PASSED" : "❌ FAILED"}\n`);
 }
 
 export function assertContains(response: AgentResponse, text: string): boolean {

--- a/src/embedding/upload-handler.ts
+++ b/src/embedding/upload-handler.ts
@@ -1,3 +1,4 @@
+import { serverLogger } from "#veryfront/utils";
 import type { UploadStore } from "./types.ts";
 import { loadUpload } from "./upload-loader.ts";
 
@@ -153,7 +154,7 @@ export function createUploadHandler(
       const uploads = await store.listUploads();
       return Response.json({ uploads });
     } catch (error) {
-      console.error("Upload list failed:", error);
+      serverLogger.error("Upload list failed:", error);
       return Response.json({ error: "Failed to list uploads" }, { status: 500 });
     }
   }
@@ -170,7 +171,7 @@ export function createUploadHandler(
       await store.removeUpload(id);
       return Response.json({ success: true });
     } catch (error) {
-      console.error("Upload delete failed:", error);
+      serverLogger.error("Upload delete failed:", error);
       return Response.json({ error: "Delete failed" }, { status: 500 });
     }
   }

--- a/src/embedding/upload-store.ts
+++ b/src/embedding/upload-store.ts
@@ -7,6 +7,7 @@ import {
   writeTextFile,
 } from "#veryfront/platform/compat/fs.ts";
 import { dirname, extname, join } from "#veryfront/platform/compat/path/basic-operations.ts";
+import { serverLogger } from "#veryfront/utils";
 import { embedding } from "./embedding.ts";
 import { chunk } from "./chunk.ts";
 import type {
@@ -58,7 +59,7 @@ export function uploadStore(config: UploadStoreConfig): UploadStore {
     mutex = result.then(
       () => {},
       (err) => {
-        console.error("[upload-store] Lock operation failed:", err);
+        serverLogger.error("[upload-store] Lock operation failed:", err);
       },
     );
     return result;
@@ -76,7 +77,7 @@ export function uploadStore(config: UploadStoreConfig): UploadStore {
       const data = await readTextFile(storagePath);
       const parsed = JSON.parse(data);
       if (!parsed || !Array.isArray(parsed.uploads) || !Array.isArray(parsed.chunks)) {
-        console.warn("[upload-store] Corrupted store file, resetting:", storagePath);
+        serverLogger.warn("[upload-store] Corrupted store file, resetting", { storagePath });
         return { uploads: [], chunks: [] };
       }
       return parsed as UploadStoreData;
@@ -85,7 +86,7 @@ export function uploadStore(config: UploadStoreConfig): UploadStore {
       if (isNotFoundError(err)) {
         return { uploads: [], chunks: [] };
       }
-      console.warn("[upload-store] Failed to load store, resetting:", err);
+      serverLogger.warn("[upload-store] Failed to load store, resetting:", err);
       return { uploads: [], chunks: [] };
     }
   }
@@ -255,7 +256,7 @@ export function uploadStore(config: UploadStoreConfig): UploadStore {
           const content = await readTextFile(file);
           if (!content?.trim()) continue;
           if (content.length > MAX_TEXT_LENGTH) {
-            console.warn(
+            serverLogger.warn(
               `[upload-store] Skipping ${file}: exceeds ${
                 MAX_TEXT_LENGTH / 1024 / 1024
               } MB text limit`,

--- a/src/embedding/upload-store.ts
+++ b/src/embedding/upload-store.ts
@@ -86,7 +86,7 @@ export function uploadStore(config: UploadStoreConfig): UploadStore {
       if (isNotFoundError(err)) {
         return { uploads: [], chunks: [] };
       }
-      serverLogger.warn("[upload-store] Failed to load store, resetting:", err);
+      serverLogger.warn("[upload-store] Failed to load store, resetting", err);
       return { uploads: [], chunks: [] };
     }
   }

--- a/src/errors/logging.ts
+++ b/src/errors/logging.ts
@@ -6,6 +6,7 @@
  */
 
 import { isProduction } from "#veryfront/build/config/environment.ts";
+import { serverLogger } from "#veryfront/utils/logger/logger.ts";
 import { VeryfrontError } from "./types.ts";
 
 export interface ErrorLogEntry {
@@ -50,23 +51,24 @@ export function logError(
   };
 
   if (isProduction()) {
-    // Structured JSON for log aggregation systems
+    // Direct JSON output — this module owns its own structured format
+    // (slug, category, status, docs) which differs from the logger envelope.
     console.error(JSON.stringify(entry));
   } else {
     // Human-readable format for development
-    console.error(`[ERROR] ${error.slug} (${error.category}) — ${error.title}`);
+    serverLogger.error(`[ERROR] ${error.slug} (${error.category}) — ${error.title}`);
     if (error.detail) {
-      console.error(`  Detail: ${error.detail}`);
+      serverLogger.error(`  Detail: ${error.detail}`);
     }
     if (error.suggestion) {
-      console.error(`  💡 Suggestion: ${error.suggestion}`);
+      serverLogger.error(`  💡 Suggestion: ${error.suggestion}`);
     }
-    console.error(`  📚 Docs: ${entry.docs}`);
+    serverLogger.error(`  📚 Docs: ${entry.docs}`);
     const mergedContext = context
       ? { ...(error.context as Record<string, unknown> ?? {}), ...context }
       : error.context;
     if (mergedContext) {
-      console.error(`  Context: ${JSON.stringify(mergedContext, null, 2)}`);
+      serverLogger.error(`  Context: ${JSON.stringify(mergedContext, null, 2)}`);
     }
   }
 }

--- a/src/proxy/cache/memory-cache.ts
+++ b/src/proxy/cache/memory-cache.ts
@@ -3,6 +3,7 @@
  */
 
 import type { CacheStats, MemoryCacheOptions, TokenCache, TokenCacheEntry } from "./types.ts";
+import { proxyLogger } from "../logger.ts";
 import { withSpan } from "../tracing.ts";
 
 const DEFAULT_MAX_SIZE = 1000;
@@ -127,7 +128,7 @@ export class MemoryCache implements TokenCache {
     }
 
     if (cleaned > 0) {
-      console.log(`[MemoryCache] Cleaned ${cleaned} expired entries`);
+      proxyLogger.debug("[MemoryCache] Cleaned expired entries", { cleaned });
     }
   }
 }

--- a/src/proxy/tracing.ts
+++ b/src/proxy/tracing.ts
@@ -6,6 +6,7 @@
 import type { Context, Span, Tracer } from "@opentelemetry/api";
 import denoConfig from "#deno-config" with { type: "json" };
 import { getEnv } from "./env.ts";
+import { proxyLogger } from "./logger.ts";
 
 // Get version from environment variable or root deno.json
 const VERYFRONT_VERSION: string = getEnv("VERYFRONT_VERSION") ??
@@ -78,7 +79,7 @@ export async function initializeOTLPWithApis(): Promise<void> {
   }
 
   if (!config.endpoint) {
-    console.warn("[otel] No endpoint configured");
+    proxyLogger.warn("[otel] No endpoint configured");
     initialized = true;
     return;
   }
@@ -116,12 +117,12 @@ export async function initializeOTLPWithApis(): Promise<void> {
 
     await loadApis();
 
-    console.log("[otel] Initialized", {
+    proxyLogger.info("[otel] Initialized", {
       serviceName: config.serviceName,
       endpoint: config.endpoint,
     });
   } catch (error) {
-    console.error("[otel] Init failed", { error });
+    proxyLogger.error("[otel] Init failed", error);
     initialized = true;
   }
 }
@@ -131,9 +132,9 @@ export async function shutdownOTLP(): Promise<void> {
 
   try {
     await tracerProvider.shutdown();
-    console.log("[otel] Shutdown complete");
+    proxyLogger.info("[otel] Shutdown complete");
   } catch (error) {
-    console.warn("[otel] Shutdown error", { error });
+    proxyLogger.error("[otel] Shutdown error", error);
   }
 }
 

--- a/src/server/handlers/studio/bridge-modules.handler.ts
+++ b/src/server/handlers/studio/bridge-modules.handler.ts
@@ -18,6 +18,9 @@ import type {
 } from "../../handlers/types.ts";
 import { HTTP_OK, PRIORITY_HIGH_DEV } from "#veryfront/utils/constants/index.ts";
 import { STUDIO_BRIDGE_BUNDLE } from "#veryfront/studio/bridge/bridge-bundle.generated.ts";
+import { serverLogger } from "#veryfront/utils";
+
+const logger = serverLogger.component("studio-bridge-handler");
 
 /** Cached bundle output. */
 let bundleCache: { js: string; etag: string } | null = null;
@@ -114,7 +117,7 @@ export class StudioBridgeModulesHandler extends BaseHandler {
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      console.error("[StudioBridgeHandler] Bundle error:", message);
+      logger.error("Bundle error", { message });
       return this.respond(
         new Response(`// Bundle error: ${message}`, {
           status: 500,

--- a/src/studio/bridge/bridge-config.ts
+++ b/src/studio/bridge/bridge-config.ts
@@ -34,7 +34,7 @@ export function initConfig(): void {
     value === "simple" || qsMode === "simple" ? "simple" : "advanced";
 
   if (!raw || typeof raw !== "object") {
-    logger.warn("[StudioBridge] No bridge config found on window.__VF_BRIDGE_CONFIG__");
+    logger.warn("No bridge config found on window.__VF_BRIDGE_CONFIG__");
     config = {
       projectId: "",
       pageId: "",

--- a/src/studio/bridge/bridge-config.ts
+++ b/src/studio/bridge/bridge-config.ts
@@ -5,6 +5,8 @@
  * and provides typed access to bridge options.
  */
 
+import { logger } from "./bridge-logger.ts";
+
 export type StudioMode = "simple" | "advanced";
 
 export interface BridgeConfig {
@@ -32,7 +34,7 @@ export function initConfig(): void {
     value === "simple" || qsMode === "simple" ? "simple" : "advanced";
 
   if (!raw || typeof raw !== "object") {
-    console.warn("[StudioBridge] No bridge config found on window.__VF_BRIDGE_CONFIG__");
+    logger.warn("[StudioBridge] No bridge config found on window.__VF_BRIDGE_CONFIG__");
     config = {
       projectId: "",
       pageId: "",

--- a/src/studio/bridge/bridge-editor-callbacks.ts
+++ b/src/studio/bridge/bridge-editor-callbacks.ts
@@ -28,7 +28,7 @@ let callbacks: EditorCallbacks | null = null;
 
 export function registerEditorCallbacks(cb: EditorCallbacks): void {
   if (callbacks) {
-    logger.warn("[StudioBridge] EditorCallbacks already registered, overwriting");
+    logger.warn("EditorCallbacks already registered, overwriting");
   }
   callbacks = cb;
 }

--- a/src/studio/bridge/bridge-editor-callbacks.ts
+++ b/src/studio/bridge/bridge-editor-callbacks.ts
@@ -6,6 +6,8 @@
  * time; editor modules call them without knowing about postToStudio.
  */
 
+import { logger } from "./bridge-logger.ts";
+
 export interface EditorCallbacks {
   onContentChange(
     fileId: string | null,
@@ -26,7 +28,7 @@ let callbacks: EditorCallbacks | null = null;
 
 export function registerEditorCallbacks(cb: EditorCallbacks): void {
   if (callbacks) {
-    console.warn("[StudioBridge] EditorCallbacks already registered, overwriting");
+    logger.warn("[StudioBridge] EditorCallbacks already registered, overwriting");
   }
   callbacks = cb;
 }

--- a/src/studio/bridge/bridge-init.ts
+++ b/src/studio/bridge/bridge-init.ts
@@ -5,6 +5,7 @@
  * inspect mode, markdown editor, mutation observer, and message listener.
  */
 
+import { logger } from "./bridge-logger.ts";
 import { state } from "./bridge-state.ts";
 import { getConfig } from "./bridge-config.ts";
 import { postToStudio } from "./bridge-messaging.ts";
@@ -56,14 +57,14 @@ export function init(): void {
   if (isStandalone) {
     // Allow standalone markdown editing when WS_URL is available (server-injected Yjs config)
     if (!config.wsUrl) {
-      console.debug(
+      logger.debug(
         "[StudioBridge] Not in iframe and not studio_embed mode, skipping initialization",
       );
       return;
     }
   }
 
-  console.debug("[StudioBridge] Initializing...");
+  logger.debug("[StudioBridge] Initializing...");
 
   // Only set up Studio interaction features when embedded in Studio
   if (!isStandalone) {
@@ -131,9 +132,9 @@ export function init(): void {
     const inspectModeParam = params.get("inspect_mode");
     if (inspectModeParam === "true") {
       state.inspectMode = true;
-      console.debug("[StudioBridge] Inspect mode enabled from query param");
+      logger.debug("[StudioBridge] Inspect mode enabled from query param");
     }
   }
 
-  console.debug("[StudioBridge] Initialized successfully");
+  logger.debug("[StudioBridge] Initialized successfully");
 }

--- a/src/studio/bridge/bridge-init.ts
+++ b/src/studio/bridge/bridge-init.ts
@@ -64,7 +64,7 @@ export function init(): void {
     }
   }
 
-  logger.debug("[StudioBridge] Initializing...");
+  logger.debug("Initializing...");
 
   // Only set up Studio interaction features when embedded in Studio
   if (!isStandalone) {
@@ -132,9 +132,9 @@ export function init(): void {
     const inspectModeParam = params.get("inspect_mode");
     if (inspectModeParam === "true") {
       state.inspectMode = true;
-      logger.debug("[StudioBridge] Inspect mode enabled from query param");
+      logger.debug("Inspect mode enabled from query param");
     }
   }
 
-  logger.debug("[StudioBridge] Initialized successfully");
+  logger.debug("Initialized successfully");
 }

--- a/src/studio/bridge/bridge-logger.ts
+++ b/src/studio/bridge/bridge-logger.ts
@@ -9,31 +9,42 @@
  * can intercept and forward it to Studio.
  */
 
+type LogContext = Record<string, unknown> | Error;
+
 interface BridgeLogger {
-  debug(message: string, context?: Record<string, unknown>): void;
-  info(message: string, context?: Record<string, unknown>): void;
-  warn(message: string, context?: Record<string, unknown>): void;
-  error(message: string, context?: Record<string, unknown>): void;
+  debug(message: string, context?: LogContext): void;
+  info(message: string, context?: LogContext): void;
+  warn(message: string, context?: LogContext): void;
+  error(message: string, context?: LogContext): void;
 }
 
-function formatArgs(message: string, context?: Record<string, unknown>): unknown[] {
-  if (!context || Object.keys(context).length === 0) {
+function normalizeContext(context?: LogContext): Record<string, unknown> | undefined {
+  if (!context) return undefined;
+  if (context instanceof Error) {
+    return { error: context.message, ...(context.stack ? { stack: context.stack } : {}) };
+  }
+  return context;
+}
+
+function formatArgs(message: string, context?: LogContext): unknown[] {
+  const normalized = normalizeContext(context);
+  if (!normalized || Object.keys(normalized).length === 0) {
     return [message];
   }
-  return [message, context];
+  return [message, normalized];
 }
 
 export const logger: BridgeLogger = {
-  debug(message: string, context?: Record<string, unknown>): void {
+  debug(message: string, context?: LogContext): void {
     console.debug(...formatArgs(message, context));
   },
-  info(message: string, context?: Record<string, unknown>): void {
+  info(message: string, context?: LogContext): void {
     console.log(...formatArgs(message, context));
   },
-  warn(message: string, context?: Record<string, unknown>): void {
+  warn(message: string, context?: LogContext): void {
     console.warn(...formatArgs(message, context));
   },
-  error(message: string, context?: Record<string, unknown>): void {
+  error(message: string, context?: LogContext): void {
     console.error(...formatArgs(message, context));
   },
 };

--- a/src/studio/bridge/bridge-logger.ts
+++ b/src/studio/bridge/bridge-logger.ts
@@ -1,0 +1,39 @@
+/**
+ * Bridge Logger
+ *
+ * Lightweight structured logger for browser-side bridge modules.
+ * Wraps console methods with a consistent API matching the server-side
+ * Logger interface (debug/info/warn/error with optional context).
+ *
+ * All output still goes through console.* so that bridge-console.ts
+ * can intercept and forward it to Studio.
+ */
+
+interface BridgeLogger {
+  debug(message: string, context?: Record<string, unknown>): void;
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown>): void;
+}
+
+function formatArgs(message: string, context?: Record<string, unknown>): unknown[] {
+  if (!context || Object.keys(context).length === 0) {
+    return [message];
+  }
+  return [message, context];
+}
+
+export const logger: BridgeLogger = {
+  debug(message: string, context?: Record<string, unknown>): void {
+    console.debug(...formatArgs(message, context));
+  },
+  info(message: string, context?: Record<string, unknown>): void {
+    console.log(...formatArgs(message, context));
+  },
+  warn(message: string, context?: Record<string, unknown>): void {
+    console.warn(...formatArgs(message, context));
+  },
+  error(message: string, context?: Record<string, unknown>): void {
+    console.error(...formatArgs(message, context));
+  },
+};

--- a/src/studio/bridge/bridge-markdown-editor.ts
+++ b/src/studio/bridge/bridge-markdown-editor.ts
@@ -115,9 +115,10 @@ export function setupMarkdownLexicalEditor(): void {
           listModule.ListItemNode,
         ],
         onError: function (error: unknown) {
-          logger.error("[StudioBridge] Markdown Lexical error", {
-            error: error instanceof Error ? error.message : String(error),
-          });
+          logger.error(
+            "Markdown Lexical error",
+            error instanceof Error ? error : { error: String(error) },
+          );
         },
       });
 
@@ -200,8 +201,8 @@ export function setupMarkdownLexicalEditor(): void {
     })
     .catch(function (error: unknown) {
       logger.warn(
-        "[StudioBridge] Failed to load Lexical markdown editor; falling back to textarea",
-        { error: error instanceof Error ? error.message : String(error) },
+        "Failed to load Lexical markdown editor; falling back to textarea",
+        error instanceof Error ? error : { error: String(error) },
       );
       if (state.markdownEditorSurface) {
         state.markdownEditorSurface.style.display = "none";
@@ -268,7 +269,7 @@ export function applyMarkdownContent(content: unknown): void {
     state.markdownLexicalRenderedContent === content
   ) {
     logger.debug(
-      "[StudioBridge] applyMarkdownContent: skipped (content unchanged)",
+      "applyMarkdownContent: skipped (content unchanged)",
     );
     state.markdownCurrentContent = content;
     scheduleMarkdownSelectionOverlayRender();
@@ -279,7 +280,7 @@ export function applyMarkdownContent(content: unknown): void {
   }
 
   logger.debug(
-    "[StudioBridge] applyMarkdownContent: rebuilding Lexical DOM",
+    "applyMarkdownContent: rebuilding Lexical DOM",
     {
       contentLength: content.length,
       renderedMatch: state.markdownLexicalRenderedContent === content,

--- a/src/studio/bridge/bridge-markdown-editor.ts
+++ b/src/studio/bridge/bridge-markdown-editor.ts
@@ -10,6 +10,7 @@
  * All cross-module calls must remain in function bodies (never at module top-level).
  */
 
+import { logger } from "./bridge-logger.ts";
 import { editorState as state } from "./bridge-editor-state.ts";
 import type { RemoteSelection } from "./bridge-state.ts";
 import { getConfig, isMarkdownPage } from "./bridge-config.ts";
@@ -114,7 +115,9 @@ export function setupMarkdownLexicalEditor(): void {
           listModule.ListItemNode,
         ],
         onError: function (error: unknown) {
-          console.error("[StudioBridge] Markdown Lexical error", error);
+          logger.error("[StudioBridge] Markdown Lexical error", {
+            error: error instanceof Error ? error.message : String(error),
+          });
         },
       });
 
@@ -196,9 +199,9 @@ export function setupMarkdownLexicalEditor(): void {
       hideMarkdownBlockDropIndicator();
     })
     .catch(function (error: unknown) {
-      console.warn(
+      logger.warn(
         "[StudioBridge] Failed to load Lexical markdown editor; falling back to textarea",
-        error,
+        { error: error instanceof Error ? error.message : String(error) },
       );
       if (state.markdownEditorSurface) {
         state.markdownEditorSurface.style.display = "none";
@@ -264,7 +267,7 @@ export function applyMarkdownContent(content: unknown): void {
     state.markdownLexicalApi &&
     state.markdownLexicalRenderedContent === content
   ) {
-    console.debug(
+    logger.debug(
       "[StudioBridge] applyMarkdownContent: skipped (content unchanged)",
     );
     state.markdownCurrentContent = content;
@@ -275,13 +278,13 @@ export function applyMarkdownContent(content: unknown): void {
     return;
   }
 
-  console.debug(
-    "[StudioBridge] applyMarkdownContent: rebuilding Lexical DOM, content length:",
-    content.length,
-    "rendered match:",
-    state.markdownLexicalRenderedContent === content,
-    "current match:",
-    state.markdownCurrentContent === content,
+  logger.debug(
+    "[StudioBridge] applyMarkdownContent: rebuilding Lexical DOM",
+    {
+      contentLength: content.length,
+      renderedMatch: state.markdownLexicalRenderedContent === content,
+      currentMatch: state.markdownCurrentContent === content,
+    },
   );
 
   const mdxImportMap = parseMdxImportMap(content);

--- a/src/studio/bridge/bridge-markdown-yjs.ts
+++ b/src/studio/bridge/bridge-markdown-yjs.ts
@@ -101,7 +101,7 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
       const WebsocketProvider = modules[1].WebsocketProvider;
       state.markdownYjsY = Y as unknown as import("./bridge-editor-state.ts").YjsModule;
 
-      logger.debug("[StudioBridge] Yjs setup", {
+      logger.debug("Yjs setup", {
         wsUrl: config.wsUrl,
         guid: config.guid,
         fileId: config.fileId,
@@ -130,7 +130,7 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
         if (!isCurrentSetup()) {
           return;
         }
-        logger.debug("[StudioBridge] Yjs status", {
+        logger.debug("Yjs status", {
           status: event.status,
           hasWs: !!provider.ws,
           wsReadyState: provider.ws?.readyState,
@@ -144,7 +144,7 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
           const origOnMessage = ws.onmessage;
           ws.onmessage = function (wsEvent: MessageEvent) {
             if (typeof wsEvent.data === "string") {
-              logger.debug("[StudioBridge] Yjs filtered string message", {
+              logger.debug("Yjs filtered string message", {
                 preview: (wsEvent.data as string).slice(0, 120),
               });
               return;
@@ -279,7 +279,7 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
         if (!isCurrentSetup()) {
           return;
         }
-        logger.debug("[StudioBridge] Yjs sync", {
+        logger.debug("Yjs sync", {
           synced,
           ytextLength: ytext.length,
           contentPreview: ytext.toString().slice(0, 80),
@@ -330,7 +330,7 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
               }
               const fullContent = ytext.toString();
               const contentMatch = fullContent === state.markdownCurrentContent;
-              logger.debug("[StudioBridge] Yjs Y.Text observer", {
+              logger.debug("Yjs Y.Text observer", {
                 origin: String(origin),
                 contentMatch,
                 ytextLength: fullContent.length,
@@ -345,16 +345,17 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
           // Initial awareness sync after Yjs is connected
           syncAwareness();
 
-          logger.debug("[StudioBridge] Yjs synced, bound to Y.Text for fileId", {
+          logger.debug("Yjs synced, bound to Y.Text for fileId", {
             fileId: config.fileId,
           });
         }
       });
     })
     .catch((error) => {
-      logger.error("[StudioBridge] Failed to setup Yjs connection", {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.error(
+        "Failed to setup Yjs connection",
+        error instanceof Error ? error : { error: String(error) },
+      );
     });
 }
 
@@ -372,7 +373,7 @@ export function writeToYText(
   options?: { position?: number; origin?: string },
 ): boolean {
   if (!state.markdownYText || !state.markdownYDoc || !state.markdownYjsConnected) {
-    logger.warn("[StudioBridge] writeToYText: Yjs not connected or not synced");
+    logger.warn("writeToYText: Yjs not connected or not synced");
     return false;
   }
 
@@ -394,7 +395,7 @@ export function writeToYText(
  */
 export function replaceYTextContent(content: string): boolean {
   if (!state.markdownYText || !state.markdownYDoc || !state.markdownYjsConnected) {
-    logger.warn("[StudioBridge] replaceYTextContent: Yjs not connected or not synced");
+    logger.warn("replaceYTextContent: Yjs not connected or not synced");
     return false;
   }
 

--- a/src/studio/bridge/bridge-markdown-yjs.ts
+++ b/src/studio/bridge/bridge-markdown-yjs.ts
@@ -10,6 +10,7 @@
  * All cross-module calls must remain in function bodies (never at module top-level).
  */
 
+import { logger } from "./bridge-logger.ts";
 import { editorState as state } from "./bridge-editor-state.ts";
 import { LEXICAL_YJS_ORIGIN, type PresenceUser, type RemoteSelection } from "./bridge-state.ts";
 import { computeTextDiff } from "./bridge-markdown-core.ts";
@@ -100,7 +101,7 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
       const WebsocketProvider = modules[1].WebsocketProvider;
       state.markdownYjsY = Y as unknown as import("./bridge-editor-state.ts").YjsModule;
 
-      console.debug("[StudioBridge] Yjs setup:", {
+      logger.debug("[StudioBridge] Yjs setup", {
         wsUrl: config.wsUrl,
         guid: config.guid,
         fileId: config.fileId,
@@ -129,7 +130,8 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
         if (!isCurrentSetup()) {
           return;
         }
-        console.debug("[StudioBridge] Yjs status:", event.status, {
+        logger.debug("[StudioBridge] Yjs status", {
+          status: event.status,
           hasWs: !!provider.ws,
           wsReadyState: provider.ws?.readyState,
         });
@@ -142,10 +144,9 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
           const origOnMessage = ws.onmessage;
           ws.onmessage = function (wsEvent: MessageEvent) {
             if (typeof wsEvent.data === "string") {
-              console.debug(
-                "[StudioBridge] Yjs filtered string message:",
-                (wsEvent.data as string).slice(0, 120),
-              );
+              logger.debug("[StudioBridge] Yjs filtered string message", {
+                preview: (wsEvent.data as string).slice(0, 120),
+              });
               return;
             }
             if (origOnMessage) {
@@ -278,7 +279,7 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
         if (!isCurrentSetup()) {
           return;
         }
-        console.debug("[StudioBridge] Yjs sync:", {
+        logger.debug("[StudioBridge] Yjs sync", {
           synced,
           ytextLength: ytext.length,
           contentPreview: ytext.toString().slice(0, 80),
@@ -329,7 +330,7 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
               }
               const fullContent = ytext.toString();
               const contentMatch = fullContent === state.markdownCurrentContent;
-              console.debug("[StudioBridge] Yjs Y.Text observer:", {
+              logger.debug("[StudioBridge] Yjs Y.Text observer", {
                 origin: String(origin),
                 contentMatch,
                 ytextLength: fullContent.length,
@@ -344,15 +345,16 @@ export function setupMarkdownYjsConnection(config: MarkdownYjsConnectionOptions)
           // Initial awareness sync after Yjs is connected
           syncAwareness();
 
-          console.debug(
-            "[StudioBridge] Yjs synced, bound to Y.Text for fileId:",
-            config.fileId,
-          );
+          logger.debug("[StudioBridge] Yjs synced, bound to Y.Text for fileId", {
+            fileId: config.fileId,
+          });
         }
       });
     })
     .catch((error) => {
-      console.error("[StudioBridge] Failed to setup Yjs connection:", error);
+      logger.error("[StudioBridge] Failed to setup Yjs connection", {
+        error: error instanceof Error ? error.message : String(error),
+      });
     });
 }
 
@@ -370,7 +372,7 @@ export function writeToYText(
   options?: { position?: number; origin?: string },
 ): boolean {
   if (!state.markdownYText || !state.markdownYDoc || !state.markdownYjsConnected) {
-    console.warn("[StudioBridge] writeToYText: Yjs not connected or not synced");
+    logger.warn("[StudioBridge] writeToYText: Yjs not connected or not synced");
     return false;
   }
 
@@ -392,7 +394,7 @@ export function writeToYText(
  */
 export function replaceYTextContent(content: string): boolean {
   if (!state.markdownYText || !state.markdownYDoc || !state.markdownYjsConnected) {
-    console.warn("[StudioBridge] replaceYTextContent: Yjs not connected or not synced");
+    logger.warn("[StudioBridge] replaceYTextContent: Yjs not connected or not synced");
     return false;
   }
 

--- a/src/studio/bridge/bridge-message-handler.ts
+++ b/src/studio/bridge/bridge-message-handler.ts
@@ -151,7 +151,7 @@ export function handleStudioMessage(event: MessageEvent): void {
       return;
 
     default:
-      logger.debug("[StudioBridge] Unknown action", { action: message.action });
+      logger.debug("Unknown action", { action: message.action });
       return;
   }
 }

--- a/src/studio/bridge/bridge-message-handler.ts
+++ b/src/studio/bridge/bridge-message-handler.ts
@@ -4,6 +4,7 @@
  * Dispatches incoming Studio messages to the appropriate bridge functions.
  */
 
+import { logger } from "./bridge-logger.ts";
 import { editorState } from "./bridge-editor-state.ts";
 import { state } from "./bridge-state.ts";
 import { getConfig } from "./bridge-config.ts";
@@ -150,7 +151,7 @@ export function handleStudioMessage(event: MessageEvent): void {
       return;
 
     default:
-      console.debug("[StudioBridge] Unknown action:", message.action);
+      logger.debug("[StudioBridge] Unknown action", { action: message.action });
       return;
   }
 }

--- a/src/studio/bridge/bridge-messaging.ts
+++ b/src/studio/bridge/bridge-messaging.ts
@@ -7,6 +7,8 @@
  * to prevent information leakage to untrusted embedders.
  */
 
+import { logger } from "./bridge-logger.ts";
+
 let studioOrigin: string | null = null;
 
 export function postToStudio(message: Record<string, unknown>): void {
@@ -14,7 +16,9 @@ export function postToStudio(message: Record<string, unknown>): void {
   try {
     window.parent.postMessage(message, studioOrigin || "*");
   } catch (e) {
-    console.debug("[StudioBridge] postMessage failed:", e);
+    logger.debug("[StudioBridge] postMessage failed", {
+      error: e instanceof Error ? e.message : String(e),
+    });
   }
 }
 

--- a/src/studio/bridge/bridge-messaging.ts
+++ b/src/studio/bridge/bridge-messaging.ts
@@ -16,9 +16,7 @@ export function postToStudio(message: Record<string, unknown>): void {
   try {
     window.parent.postMessage(message, studioOrigin || "*");
   } catch (e) {
-    logger.debug("[StudioBridge] postMessage failed", {
-      error: e instanceof Error ? e.message : String(e),
-    });
+    logger.debug("postMessage failed", e instanceof Error ? e : { error: String(e) });
   }
 }
 

--- a/src/studio/bridge/bridge-screenshot.ts
+++ b/src/studio/bridge/bridge-screenshot.ts
@@ -4,6 +4,7 @@
  * html2canvas loading, single and multi-section screenshot capture.
  */
 
+import { logger } from "./bridge-logger.ts";
 import { state } from "./bridge-state.ts";
 
 declare const window: Window & {
@@ -38,18 +39,18 @@ function loadHtml2Canvas(): Promise<void> {
       resolve();
     };
     script.onerror = (event) => {
-      console.warn(
+      logger.warn(
         "[StudioBridge] Failed to load html2canvas script. This may be caused by CSP script-src restrictions.",
-        event,
+        { event: String(event) },
       );
       reject(new Error("Failed to load html2canvas script"));
     };
     try {
       document.head.appendChild(script);
     } catch (error) {
-      console.warn(
+      logger.warn(
         "[StudioBridge] Failed to append html2canvas script element. This may be caused by CSP script-src restrictions.",
-        error,
+        { error: error instanceof Error ? error.message : String(error) },
       );
       reject(
         error instanceof Error ? error : new Error("Failed to append html2canvas script element"),
@@ -94,12 +95,10 @@ export async function captureScreenshot(options?: {
     const canvas = await html2canvasFn(document.body, canvasOptions);
 
     if (!canvas || canvas.width === 0 || canvas.height === 0) {
-      console.error(
-        "[bridge] html2canvas produced empty canvas:",
-        canvas?.width,
-        "x",
-        canvas?.height,
-      );
+      logger.error("[StudioBridge] html2canvas produced empty canvas", {
+        width: canvas?.width,
+        height: canvas?.height,
+      });
       window.scrollTo(0, originalScrollY);
       return {
         success: false,
@@ -110,10 +109,9 @@ export async function captureScreenshot(options?: {
     const dataUrl = canvas.toDataURL("image/png", quality);
 
     if (!dataUrl || !dataUrl.startsWith("data:image/") || dataUrl.length < 100) {
-      console.error(
-        "[bridge] html2canvas produced invalid data URL:",
-        dataUrl?.substring(0, 50),
-      );
+      logger.error("[StudioBridge] html2canvas produced invalid data URL", {
+        dataUrlPreview: dataUrl?.substring(0, 50),
+      });
       window.scrollTo(0, originalScrollY);
       return {
         success: false,
@@ -134,7 +132,9 @@ export async function captureScreenshot(options?: {
       url: window.location.href,
     };
   } catch (error: unknown) {
-    console.error("[bridge] html2canvas error:", error);
+    logger.error("[StudioBridge] html2canvas error", {
+      error: error instanceof Error ? error.message : String(error),
+    });
     window.scrollTo(0, originalScrollY);
     return {
       success: false,

--- a/src/studio/bridge/bridge-screenshot.ts
+++ b/src/studio/bridge/bridge-screenshot.ts
@@ -40,7 +40,7 @@ function loadHtml2Canvas(): Promise<void> {
     };
     script.onerror = (event) => {
       logger.warn(
-        "[StudioBridge] Failed to load html2canvas script. This may be caused by CSP script-src restrictions.",
+        "Failed to load html2canvas script. This may be caused by CSP script-src restrictions.",
         { event: String(event) },
       );
       reject(new Error("Failed to load html2canvas script"));
@@ -49,8 +49,8 @@ function loadHtml2Canvas(): Promise<void> {
       document.head.appendChild(script);
     } catch (error) {
       logger.warn(
-        "[StudioBridge] Failed to append html2canvas script element. This may be caused by CSP script-src restrictions.",
-        { error: error instanceof Error ? error.message : String(error) },
+        "Failed to append html2canvas script element. This may be caused by CSP script-src restrictions.",
+        error instanceof Error ? error : { error: String(error) },
       );
       reject(
         error instanceof Error ? error : new Error("Failed to append html2canvas script element"),
@@ -95,7 +95,7 @@ export async function captureScreenshot(options?: {
     const canvas = await html2canvasFn(document.body, canvasOptions);
 
     if (!canvas || canvas.width === 0 || canvas.height === 0) {
-      logger.error("[StudioBridge] html2canvas produced empty canvas", {
+      logger.error("html2canvas produced empty canvas", {
         width: canvas?.width,
         height: canvas?.height,
       });
@@ -109,7 +109,7 @@ export async function captureScreenshot(options?: {
     const dataUrl = canvas.toDataURL("image/png", quality);
 
     if (!dataUrl || !dataUrl.startsWith("data:image/") || dataUrl.length < 100) {
-      logger.error("[StudioBridge] html2canvas produced invalid data URL", {
+      logger.error("html2canvas produced invalid data URL", {
         dataUrlPreview: dataUrl?.substring(0, 50),
       });
       window.scrollTo(0, originalScrollY);
@@ -132,9 +132,7 @@ export async function captureScreenshot(options?: {
       url: window.location.href,
     };
   } catch (error: unknown) {
-    logger.error("[StudioBridge] html2canvas error", {
-      error: error instanceof Error ? error.message : String(error),
-    });
+    logger.error("html2canvas error", error instanceof Error ? error : { error: String(error) });
     window.scrollTo(0, originalScrollY);
     return {
       success: false,

--- a/src/studio/bridge/bridge-selection.ts
+++ b/src/studio/bridge/bridge-selection.ts
@@ -6,6 +6,7 @@
  * Y.js awareness; and selection overlay rendering for remote cursors.
  */
 
+import { logger } from "./bridge-logger.ts";
 import { editorState as state } from "./bridge-editor-state.ts";
 import { DATA_VF_IGNORE } from "./bridge-constants.ts";
 
@@ -301,11 +302,9 @@ export function buildEditorRenderedMaps(
   // Warn when alignment didn't consume all rendered text — indicates a
   // mapping failure that will cause visible selection offset bugs.
   if (ri < trimmed.length) {
-    console.warn(
-      "[StudioBridge] Offset mapping divergence: rendered text has",
-      trimmed.length - ri,
-      "unconsumed characters starting at index",
-      ri,
+    logger.warn(
+      "[StudioBridge] Offset mapping divergence: rendered text has unconsumed characters",
+      { unconsumedCount: trimmed.length - ri, startIndex: ri },
     );
   }
 

--- a/src/studio/bridge/bridge-selection.ts
+++ b/src/studio/bridge/bridge-selection.ts
@@ -303,7 +303,7 @@ export function buildEditorRenderedMaps(
   // mapping failure that will cause visible selection offset bugs.
   if (ri < trimmed.length) {
     logger.warn(
-      "[StudioBridge] Offset mapping divergence: rendered text has unconsumed characters",
+      "Offset mapping divergence: rendered text has unconsumed characters",
       { unconsumedCount: trimmed.length - ri, startIndex: ri },
     );
   }

--- a/src/studio/bridge/bridge-styles.ts
+++ b/src/studio/bridge/bridge-styles.ts
@@ -7,6 +7,8 @@
  * Gellix font is proprietary and unavailable in the preview iframe.
  */
 
+import { logger } from "./bridge-logger.ts";
+
 const OVERLAY_CSS = `
       /* ------------------------------------------------------------------ */
       /* Overlays (hover / selection inspector)                              */
@@ -831,12 +833,14 @@ export function injectOverlayStyles(): void {
   try {
     document.head.appendChild(style);
     if (!style.sheet) {
-      console.warn("[StudioBridge] Inline style injection may be blocked by CSP (style-src).");
+      logger.warn("[StudioBridge] Inline style injection may be blocked by CSP (style-src)");
     }
   } catch (error) {
-    console.warn(
+    logger.warn(
       "[StudioBridge] Failed to inject bridge styles. This may be caused by CSP style-src restrictions.",
-      error,
+      {
+        error: error instanceof Error ? error.message : String(error),
+      },
     );
   }
 }

--- a/src/studio/bridge/bridge-styles.ts
+++ b/src/studio/bridge/bridge-styles.ts
@@ -833,13 +833,13 @@ export function injectOverlayStyles(): void {
   try {
     document.head.appendChild(style);
     if (!style.sheet) {
-      logger.warn("[StudioBridge] Inline style injection may be blocked by CSP (style-src)");
+      logger.warn("Inline style injection may be blocked by CSP (style-src)");
     }
   } catch (error) {
     logger.warn(
-      "[StudioBridge] Failed to inject bridge styles. This may be caused by CSP style-src restrictions.",
-      {
-        error: error instanceof Error ? error.message : String(error),
+      "Failed to inject bridge styles. This may be caused by CSP style-src restrictions.",
+      error instanceof Error ? error : {
+        error: String(error),
       },
     );
   }

--- a/src/workflow/claude-code/event-publisher.ts
+++ b/src/workflow/claude-code/event-publisher.ts
@@ -156,7 +156,7 @@ export class RedisEventPublisher implements ClaudeCodeEventPublisher, ClaudeCode
     await this.getPublishClient().publish(channel, message);
 
     if (this.config.debug) {
-      logger.debug("Published event", { channel, eventType: event.type });
+      logger.info("Published event", { channel, eventType: event.type });
     }
   }
 
@@ -178,7 +178,7 @@ export class RedisEventPublisher implements ClaudeCodeEventPublisher, ClaudeCode
     await subscribeClient.subscribe(channel, listener);
 
     if (this.config.debug) {
-      logger.debug("Subscribed to channel", { channel });
+      logger.info("Subscribed to channel", { channel });
     }
 
     return async () => {

--- a/src/workflow/claude-code/event-publisher.ts
+++ b/src/workflow/claude-code/event-publisher.ts
@@ -4,12 +4,15 @@
  * Provides different ways to publish Claude Code events for streaming.
  */
 
+import { logger as baseLogger } from "#veryfront/utils";
 import type {
   ClaudeCodeEvent,
   ClaudeCodeEventHandler,
   ClaudeCodeEventPublisher,
   ClaudeCodeEventSubscriber,
 } from "./types.ts";
+
+const logger = baseLogger.component("redis-event-publisher");
 
 // =============================================================================
 // In-Memory Publisher (for testing/single-process)
@@ -153,7 +156,7 @@ export class RedisEventPublisher implements ClaudeCodeEventPublisher, ClaudeCode
     await this.getPublishClient().publish(channel, message);
 
     if (this.config.debug) {
-      console.log(`[RedisEventPublisher] Published to ${channel}:`, event.type);
+      logger.debug("Published event", { channel, eventType: event.type });
     }
   }
 
@@ -168,14 +171,14 @@ export class RedisEventPublisher implements ClaudeCodeEventPublisher, ClaudeCode
         const event = JSON.parse(message) as ClaudeCodeEvent;
         handler(event);
       } catch (error) {
-        console.error("[RedisEventPublisher] Failed to parse event:", error);
+        logger.error("Failed to parse event", error);
       }
     };
 
     await subscribeClient.subscribe(channel, listener);
 
     if (this.config.debug) {
-      console.log(`[RedisEventPublisher] Subscribed to ${channel}`);
+      logger.debug("Subscribed to channel", { channel });
     }
 
     return async () => {

--- a/src/workflow/claude-code/websocket-publisher.ts
+++ b/src/workflow/claude-code/websocket-publisher.ts
@@ -79,9 +79,9 @@ export class WebSocketPublisher implements BidirectionalPublisher {
       this.stopPingInterval();
     };
 
-    socket.onerror = (error) => {
+    socket.onerror = (event) => {
       if (this.config.debug) {
-        logger.error("Socket error", error);
+        logger.error("Socket error", { event: String(event) });
       }
       // Stop ping interval on error to prevent resource leak
       // The socket may or may not close after an error, but we should

--- a/src/workflow/claude-code/websocket-publisher.ts
+++ b/src/workflow/claude-code/websocket-publisher.ts
@@ -92,7 +92,7 @@ export class WebSocketPublisher implements BidirectionalPublisher {
 
   private handleCommand(command: ClientCommand): void {
     if (this.config.debug) {
-      logger.debug("Received command", { commandType: command.type });
+      logger.info("Received command", { commandType: command.type });
     }
 
     // Handle ping internally
@@ -176,7 +176,7 @@ export class WebSocketPublisher implements BidirectionalPublisher {
     socket.send(JSON.stringify(event));
 
     if (this.config.debug) {
-      logger.debug("Sent event", { eventType: event.type });
+      logger.info("Sent event", { eventType: event.type });
     }
   }
 

--- a/src/workflow/claude-code/websocket-publisher.ts
+++ b/src/workflow/claude-code/websocket-publisher.ts
@@ -4,6 +4,7 @@
  * Provides bidirectional communication between client and agent.
  */
 
+import { logger as baseLogger } from "#veryfront/utils";
 import type {
   BidirectionalPublisher,
   CancelledEvent,
@@ -13,6 +14,8 @@ import type {
   ClientCommandHandler,
   PongEvent,
 } from "./types.ts";
+
+const logger = baseLogger.component("websocket-publisher");
 
 /**
  * WebSocket publisher configuration
@@ -66,7 +69,7 @@ export class WebSocketPublisher implements BidirectionalPublisher {
         this.handleCommand(command);
       } catch (error) {
         if (this.config.debug) {
-          console.error("[WebSocketPublisher] Failed to parse command:", error);
+          logger.error("Failed to parse command", error);
         }
       }
     };
@@ -78,7 +81,7 @@ export class WebSocketPublisher implements BidirectionalPublisher {
 
     socket.onerror = (error) => {
       if (this.config.debug) {
-        console.error("[WebSocketPublisher] Socket error:", error);
+        logger.error("Socket error", error);
       }
       // Stop ping interval on error to prevent resource leak
       // The socket may or may not close after an error, but we should
@@ -89,7 +92,7 @@ export class WebSocketPublisher implements BidirectionalPublisher {
 
   private handleCommand(command: ClientCommand): void {
     if (this.config.debug) {
-      console.log("[WebSocketPublisher] Received command:", command.type);
+      logger.debug("Received command", { commandType: command.type });
     }
 
     // Handle ping internally
@@ -104,7 +107,7 @@ export class WebSocketPublisher implements BidirectionalPublisher {
         handler(command);
       } catch (error) {
         if (this.config.debug) {
-          console.error("[WebSocketPublisher] Handler error:", error);
+          logger.error("Handler error", error);
         }
       }
     }
@@ -165,7 +168,7 @@ export class WebSocketPublisher implements BidirectionalPublisher {
     const { socket } = this.config;
     if (socket.readyState !== WebSocket.OPEN) {
       if (this.config.debug) {
-        console.warn("[WebSocketPublisher] Socket not open, dropping event");
+        logger.warn("Socket not open, dropping event");
       }
       return;
     }
@@ -173,7 +176,7 @@ export class WebSocketPublisher implements BidirectionalPublisher {
     socket.send(JSON.stringify(event));
 
     if (this.config.debug) {
-      console.log("[WebSocketPublisher] Sent event:", event.type);
+      logger.debug("Sent event", { eventType: event.type });
     }
   }
 

--- a/src/workflow/claude-code/workspace-sync.ts
+++ b/src/workflow/claude-code/workspace-sync.ts
@@ -10,9 +10,12 @@
  * 3. After execution: Upload changed files back to Veryfront API
  */
 
+import { logger as baseLogger } from "#veryfront/utils";
 import { api } from "../api.ts";
 import type { CapturedTenantContext } from "../types.ts";
 import { join, relative, resolve } from "@std/path";
+
+const logger = baseLogger.component("workspace-sync");
 
 /**
  * Workspace configuration
@@ -172,7 +175,7 @@ export class WorkspaceSync {
     let bytesDownloaded = 0;
 
     if (this.config.debug) {
-      console.log(`[WorkspaceSync] Initializing workspace: ${this.workspaceDir}`);
+      logger.debug("Initializing workspace", { workspaceDir: this.workspaceDir });
     }
 
     // Create workspace directory
@@ -182,7 +185,7 @@ export class WorkspaceSync {
     const files = await api.files.listAll();
 
     if (this.config.debug) {
-      console.log(`[WorkspaceSync] Found ${files.length} files in project`);
+      logger.debug("Found files in project", { count: files.length });
     }
 
     // Download each file
@@ -211,7 +214,7 @@ export class WorkspaceSync {
         if (content.length > this.config.maxFileSize) {
           skippedFiles.push(path);
           if (this.config.debug) {
-            console.log(`[WorkspaceSync] Skipping large file: ${path} (${content.length} bytes)`);
+            logger.debug("Skipping large file", { path, size: content.length });
           }
           continue;
         }
@@ -230,11 +233,11 @@ export class WorkspaceSync {
         bytesDownloaded += content.length;
 
         if (this.config.debug) {
-          console.log(`[WorkspaceSync] Downloaded: ${path}`);
+          logger.debug("Downloaded file", { path });
         }
       } catch (error) {
         if (this.config.debug) {
-          console.error(`[WorkspaceSync] Failed to download ${path}:`, error);
+          logger.error("Failed to download file", { path }, error);
         }
         skippedFiles.push(path);
       }
@@ -251,7 +254,8 @@ export class WorkspaceSync {
     };
 
     if (this.config.debug) {
-      console.log(`[WorkspaceSync] Initialized in ${result.duration}ms`, {
+      logger.debug("Workspace initialized", {
+        duration: result.duration,
         filesDownloaded,
         bytesDownloaded,
         skipped: skippedFiles.length,
@@ -296,7 +300,7 @@ export class WorkspaceSync {
     }
 
     if (this.config.debug) {
-      console.log(`[WorkspaceSync] Detected ${changes.length} changes`);
+      logger.debug("Detected changes", { count: changes.length });
     }
 
     return changes;
@@ -387,7 +391,7 @@ export class WorkspaceSync {
         } else {
           // No upload handler - just log the change
           if (this.config.debug) {
-            console.log(`[WorkspaceSync] Would upload: ${change.path} (${change.type})`);
+            logger.debug("Would upload file", { path: change.path, type: change.type });
           }
           // Mark as uploaded for tracking, even though we didn't actually upload
           uploaded.push(change);
@@ -473,14 +477,14 @@ export class WorkspaceSync {
    */
   async cleanup(): Promise<void> {
     if (this.config.debug) {
-      console.log(`[WorkspaceSync] Cleaning up workspace: ${this.workspaceDir}`);
+      logger.debug("Cleaning up workspace", { workspaceDir: this.workspaceDir });
     }
 
     try {
       await Deno.remove(this.workspaceDir, { recursive: true });
     } catch (error) {
       if (this.config.debug) {
-        console.error(`[WorkspaceSync] Cleanup failed:`, error);
+        logger.error("Cleanup failed", error);
       }
     }
 

--- a/src/workflow/claude-code/workspace-sync.ts
+++ b/src/workflow/claude-code/workspace-sync.ts
@@ -175,7 +175,7 @@ export class WorkspaceSync {
     let bytesDownloaded = 0;
 
     if (this.config.debug) {
-      logger.debug("Initializing workspace", { workspaceDir: this.workspaceDir });
+      logger.info("Initializing workspace", { workspaceDir: this.workspaceDir });
     }
 
     // Create workspace directory
@@ -185,7 +185,7 @@ export class WorkspaceSync {
     const files = await api.files.listAll();
 
     if (this.config.debug) {
-      logger.debug("Found files in project", { count: files.length });
+      logger.info("Found files in project", { count: files.length });
     }
 
     // Download each file
@@ -214,7 +214,7 @@ export class WorkspaceSync {
         if (content.length > this.config.maxFileSize) {
           skippedFiles.push(path);
           if (this.config.debug) {
-            logger.debug("Skipping large file", { path, size: content.length });
+            logger.info("Skipping large file", { path, size: content.length });
           }
           continue;
         }
@@ -233,7 +233,7 @@ export class WorkspaceSync {
         bytesDownloaded += content.length;
 
         if (this.config.debug) {
-          logger.debug("Downloaded file", { path });
+          logger.info("Downloaded file", { path });
         }
       } catch (error) {
         if (this.config.debug) {
@@ -254,7 +254,7 @@ export class WorkspaceSync {
     };
 
     if (this.config.debug) {
-      logger.debug("Workspace initialized", {
+      logger.info("Workspace initialized", {
         duration: result.duration,
         filesDownloaded,
         bytesDownloaded,
@@ -300,7 +300,7 @@ export class WorkspaceSync {
     }
 
     if (this.config.debug) {
-      logger.debug("Detected changes", { count: changes.length });
+      logger.info("Detected changes", { count: changes.length });
     }
 
     return changes;
@@ -391,7 +391,7 @@ export class WorkspaceSync {
         } else {
           // No upload handler - just log the change
           if (this.config.debug) {
-            logger.debug("Would upload file", { path: change.path, type: change.type });
+            logger.info("Would upload file", { path: change.path, type: change.type });
           }
           // Mark as uploaded for tracking, even though we didn't actually upload
           uploaded.push(change);
@@ -477,7 +477,7 @@ export class WorkspaceSync {
    */
   async cleanup(): Promise<void> {
     if (this.config.debug) {
-      logger.debug("Cleaning up workspace", { workspaceDir: this.workspaceDir });
+      logger.info("Cleaning up workspace", { workspaceDir: this.workspaceDir });
     }
 
     try {


### PR DESCRIPTION
## Summary
- Migrate ~75 ad-hoc `console.log/warn/error` calls to structured loggers across 21 files
- Server modules use `serverLogger`, proxy uses `proxyLogger`, workflow uses `baseLogger.component()`
- New `bridge-logger.ts` for browser-side bridge modules (wraps console.* for Studio interception)
- Client-side modules (`react/`, `security/client/`) intentionally kept on `console.*`
- Error objects passed directly to loggers (not wrapped in `{ error }`) for proper serialization

## Test plan
- [x] `deno task verify:quick` — lint + typecheck pass
- [x] All 948 unit tests pass