### PR TITLE
test: add coverage for untested public modules

### DIFF
--- a/src/prompt/factory.test.ts
+++ b/src/prompt/factory.test.ts
@@ -1,0 +1,136 @@
+import { describe, it } from "#veryfront/testing/bdd";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert";
+import { prompt } from "./factory.ts";
+
+describe("prompt factory", () => {
+  describe("prompt()", () => {
+    it("should create a prompt with explicit id", () => {
+      const p = prompt({ id: "my-prompt", description: "A test prompt", content: "Hello" });
+      assertEquals(p.id, "my-prompt");
+      assertEquals(p.description, "A test prompt");
+    });
+
+    it("should auto-generate id when not provided", () => {
+      const p = prompt({ description: "auto-id", content: "Hello" });
+      assertStringIncludes(p.id, "prompt_");
+    });
+
+    it("should preserve suggestion field", () => {
+      const p = prompt({
+        id: "suggest",
+        description: "desc",
+        content: "Hello",
+        suggestion: "Try asking me about...",
+      });
+      assertEquals(p.suggestion, "Try asking me about...");
+    });
+  });
+
+  describe("getContent() with static content", () => {
+    it("should return static content without variables", async () => {
+      const p = prompt({ id: "static", description: "desc", content: "Hello world" });
+      assertEquals(await p.getContent(), "Hello world");
+    });
+
+    it("should interpolate variables in template", async () => {
+      const p = prompt({
+        id: "template",
+        description: "desc",
+        content: "Hello {name}, welcome to {place}!",
+      });
+      const result = await p.getContent({ name: "Alice", place: "Wonderland" });
+      assertEquals(result, "Hello Alice, welcome to Wonderland!");
+    });
+
+    it("should leave unmatched placeholders unchanged", async () => {
+      const p = prompt({
+        id: "partial",
+        description: "desc",
+        content: "Hello {name}, your id is {id}",
+      });
+      const result = await p.getContent({ name: "Bob" });
+      assertEquals(result, "Hello Bob, your id is {id}");
+    });
+
+    it("should convert non-string variable values to strings", async () => {
+      const p = prompt({
+        id: "convert",
+        description: "desc",
+        content: "Count: {count}, active: {active}",
+      });
+      const result = await p.getContent({ count: 42, active: true });
+      assertEquals(result, "Count: 42, active: true");
+    });
+
+    it("should not replace when variable value is null", async () => {
+      const p = prompt({
+        id: "null-var",
+        description: "desc",
+        content: "Value: {val}",
+      });
+      const result = await p.getContent({ val: null });
+      assertEquals(result, "Value: {val}");
+    });
+
+    it("should not replace when variable value is undefined", async () => {
+      const p = prompt({
+        id: "undef-var",
+        description: "desc",
+        content: "Value: {val}",
+      });
+      const result = await p.getContent({ val: undefined });
+      assertEquals(result, "Value: {val}");
+    });
+  });
+
+  describe("getContent() with generate function", () => {
+    it("should call generate function with variables", async () => {
+      const p = prompt({
+        id: "gen",
+        description: "desc",
+        generate: (vars) => `Generated: ${vars.input}`,
+      });
+      const result = await p.getContent({ input: "test" });
+      assertEquals(result, "Generated: test");
+    });
+
+    it("should support async generate function", async () => {
+      const p = prompt({
+        id: "async-gen",
+        description: "desc",
+        generate: async (vars) => `Async: ${vars.value}`,
+      });
+      const result = await p.getContent({ value: "hello" });
+      assertEquals(result, "Async: hello");
+    });
+
+    it("should pass empty object when no variables provided", async () => {
+      let receivedVars: Record<string, unknown> | undefined;
+      const p = prompt({
+        id: "no-vars",
+        description: "desc",
+        generate: (vars) => {
+          receivedVars = vars;
+          return "ok";
+        },
+      });
+      await p.getContent();
+      assertEquals(receivedVars, {});
+    });
+  });
+
+  describe("getContent() error handling", () => {
+    it("should throw when prompt has neither content nor generate", async () => {
+      const p = prompt({ id: "empty", description: "desc" });
+      await assertRejects(
+        () => p.getContent(),
+        Error,
+        'Prompt "empty" has no content or generator',
+      );
+    });
+  });
+});

--- a/src/prompt/factory.test.ts
+++ b/src/prompt/factory.test.ts
@@ -1,9 +1,5 @@
 import { describe, it } from "#veryfront/testing/bdd";
-import {
-  assertEquals,
-  assertRejects,
-  assertStringIncludes,
-} from "#veryfront/testing/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert";
 import { prompt } from "./factory.ts";
 
 describe("prompt factory", () => {

--- a/src/resource/factory.test.ts
+++ b/src/resource/factory.test.ts
@@ -52,10 +52,10 @@ describe("resource factory", () => {
         description: "Data",
         paramsSchema: z.object({}),
         load: async () => ({}),
-        mcp: { enabled: true, requiresAuth: true },
+        mcp: { enabled: true, cachePolicy: "cache-first" },
       });
       assertEquals(r.mcp?.enabled, true);
-      assertEquals(r.mcp?.requiresAuth, true);
+      assertEquals(r.mcp?.cachePolicy, "cache-first");
     });
 
     it("should preserve subscribe function", () => {

--- a/src/resource/factory.test.ts
+++ b/src/resource/factory.test.ts
@@ -1,0 +1,145 @@
+import { describe, it } from "#veryfront/testing/bdd";
+import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert";
+import { z } from "zod";
+import { resource } from "./factory.ts";
+
+describe("resource factory", () => {
+  describe("resource()", () => {
+    it("should create a resource with explicit pattern", () => {
+      const r = resource({
+        pattern: "/users/:userId",
+        description: "Get user",
+        paramsSchema: z.object({ userId: z.string() }),
+        load: async ({ userId }) => ({ id: userId }),
+      });
+      assertEquals(r.pattern, "/users/:userId");
+      assertEquals(r.description, "Get user");
+    });
+
+    it("should derive id from pattern", () => {
+      const r = resource({
+        pattern: "/users/:userId/profile",
+        description: "User profile",
+        paramsSchema: z.object({ userId: z.string() }),
+        load: async () => ({}),
+      });
+      assertEquals(r.id, "users_userId_profile");
+    });
+
+    it("should auto-generate pattern when not provided", () => {
+      const r = resource({
+        description: "Auto pattern",
+        paramsSchema: z.object({}),
+        load: async () => ({}),
+      });
+      assertStringIncludes(r.pattern, "/resource_");
+    });
+
+    it("should preserve paramsSchema", () => {
+      const schema = z.object({ section: z.string() });
+      const r = resource({
+        pattern: "/docs/:section",
+        description: "Docs",
+        paramsSchema: schema,
+        load: async () => ({}),
+      });
+      assertEquals(r.paramsSchema, schema);
+    });
+
+    it("should preserve mcp config", () => {
+      const r = resource({
+        pattern: "/data",
+        description: "Data",
+        paramsSchema: z.object({}),
+        load: async () => ({}),
+        mcp: { enabled: true, requiresAuth: true },
+      });
+      assertEquals(r.mcp?.enabled, true);
+      assertEquals(r.mcp?.requiresAuth, true);
+    });
+
+    it("should preserve subscribe function", () => {
+      const subscribeFn = async function* () {
+        yield { data: "test" };
+      };
+      const r = resource({
+        pattern: "/stream",
+        description: "Stream",
+        paramsSchema: z.object({}),
+        load: async () => ({}),
+        subscribe: subscribeFn,
+      });
+      assertEquals(r.subscribe, subscribeFn);
+    });
+  });
+
+  describe("load()", () => {
+    it("should validate params and call load function", async () => {
+      const r = resource({
+        pattern: "/items/:id",
+        description: "Item",
+        paramsSchema: z.object({ id: z.string() }),
+        load: async ({ id }) => ({ name: `Item ${id}` }),
+      });
+      const result = await r.load({ id: "123" });
+      assertEquals(result, { name: "Item 123" });
+    });
+
+    it("should throw on invalid params", async () => {
+      const r = resource({
+        pattern: "/items/:id",
+        description: "Item",
+        paramsSchema: z.object({ id: z.string() }),
+        load: async () => ({}),
+      });
+      await assertRejects(
+        () => r.load({ id: 42 } as unknown as { id: string }),
+        Error,
+        "params validation failed",
+      );
+    });
+
+    it("should support sync load functions", async () => {
+      const r = resource({
+        pattern: "/sync",
+        description: "Sync",
+        paramsSchema: z.object({ key: z.string() }),
+        load: ({ key }) => ({ value: key }),
+      });
+      const result = await r.load({ key: "test" });
+      assertEquals(result, { value: "test" });
+    });
+  });
+
+  describe("pattern to id conversion", () => {
+    it("should strip leading slash", () => {
+      const r = resource({
+        pattern: "/simple",
+        description: "Simple",
+        paramsSchema: z.object({}),
+        load: async () => ({}),
+      });
+      assertEquals(r.id, "simple");
+    });
+
+    it("should replace slashes with underscores", () => {
+      const r = resource({
+        pattern: "/a/b/c",
+        description: "Nested",
+        paramsSchema: z.object({}),
+        load: async () => ({}),
+      });
+      assertEquals(r.id, "a_b_c");
+    });
+
+    it("should remove colons from params", () => {
+      const r = resource({
+        pattern: "/users/:userId/posts/:postId",
+        description: "User posts",
+        paramsSchema: z.object({ userId: z.string(), postId: z.string() }),
+        load: async () => ({}),
+      });
+      assertEquals(r.id, "users_userId_posts_postId");
+    });
+  });
+});

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -1,14 +1,15 @@
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd";
 import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert";
+import type { ExecStreamEvent } from "./sandbox.ts";
 import { Sandbox } from "./sandbox.ts";
 
 // Mock fetch for testing
 const originalFetch = globalThis.fetch;
 let fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
-let fetchResponses: Array<Response> = [];
+let fetchResponses: Array<Response | (() => Response)> = [];
 
 function mockFetch(responses: Array<Response | (() => Response)>) {
-  fetchResponses = responses.map((r) => (typeof r === "function" ? r() : r));
+  fetchResponses = [...responses];
   fetchCalls = [];
   globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
     const url = typeof input === "string"
@@ -17,10 +18,23 @@ function mockFetch(responses: Array<Response | (() => Response)>) {
       ? input.toString()
       : input.url;
     fetchCalls.push({ url, init });
-    const response = fetchResponses.shift();
-    if (!response) throw new Error(`No mock response for: ${url}`);
-    return response;
+    const entry = fetchResponses.shift();
+    if (!entry) throw new Error(`No mock response for: ${url}`);
+    return typeof entry === "function" ? entry() : entry;
   }) as typeof fetch;
+}
+
+// Zero-delay setTimeout mock to avoid real polling delays (cross-runtime)
+const originalSetTimeout = globalThis.setTimeout;
+function mockTimers() {
+  // deno-lint-ignore no-explicit-any
+  (globalThis as any).setTimeout = (fn: () => void, _ms?: number) => {
+    return originalSetTimeout(fn, 0);
+  };
+}
+function restoreTimers() {
+  // deno-lint-ignore no-explicit-any
+  (globalThis as any).setTimeout = originalSetTimeout;
 }
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -55,6 +69,7 @@ describe("Sandbox", () => {
   });
 
   afterEach(() => {
+    restoreTimers();
     globalThis.fetch = originalFetch;
   });
 
@@ -77,6 +92,7 @@ describe("Sandbox", () => {
     });
 
     it("should poll until ready when not running", async () => {
+      mockTimers();
       mockFetch([
         jsonResponse({
           id: "session-2",
@@ -111,6 +127,7 @@ describe("Sandbox", () => {
     });
 
     it("should throw when sandbox fails to start", async () => {
+      mockTimers();
       mockFetch([
         jsonResponse({
           id: "session-3",
@@ -190,6 +207,81 @@ describe("Sandbox", () => {
       assertEquals(result.stdout, "");
       assertEquals(result.stderr, "error occurred\n");
       assertEquals(result.exitCode, 1);
+    });
+  });
+
+  describe("executeStream()", () => {
+    it("should stream events directly", async () => {
+      mockFetch([
+        jsonResponse({ id: "stream-1", endpoint: "https://sb.test", status: "running" }),
+        ndjsonResponse([
+          { type: "stdout", data: "line1\n" },
+          { type: "stderr", data: "warn\n" },
+          { type: "exit", exitCode: 0 },
+        ]),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      const events: ExecStreamEvent[] = [];
+      for await (const event of sandbox.executeStream("cmd")) {
+        events.push(event);
+      }
+
+      assertEquals(events.length, 3);
+      assertEquals(events[0]!.type, "stdout");
+      assertEquals(events[0]!.data, "line1\n");
+      assertEquals(events[1]!.type, "stderr");
+      assertEquals(events[2]!.type, "exit");
+      assertEquals(events[2]!.exitCode, 0);
+    });
+
+    it("should throw on non-OK response", async () => {
+      mockFetch([
+        jsonResponse({ id: "stream-2", endpoint: "https://sb.test", status: "running" }),
+        textResponse("Internal Server Error", 500),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      await assertRejects(
+        async () => {
+          for await (const _event of sandbox.executeStream("bad-cmd")) {
+            // consume
+          }
+        },
+        Error,
+        "Exec failed",
+      );
+    });
+
+    it("should handle chunked NDJSON delivery", async () => {
+      // Simulate a response where JSON lines are split across chunks
+      const chunk1 = '{"type":"stdout","data":"part1\\n"}\n{"type":"stde';
+      const chunk2 = 'rr","data":"err\\n"}\n{"type":"exit","exitCode":0}\n';
+      const encoder = new TextEncoder();
+
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(chunk1));
+          controller.enqueue(encoder.encode(chunk2));
+          controller.close();
+        },
+      });
+
+      mockFetch([
+        jsonResponse({ id: "stream-3", endpoint: "https://sb.test", status: "running" }),
+        new Response(stream, { status: 200 }),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      const events: ExecStreamEvent[] = [];
+      for await (const event of sandbox.executeStream("cmd")) {
+        events.push(event);
+      }
+
+      assertEquals(events.length, 3);
+      assertEquals(events[0]!.type, "stdout");
+      assertEquals(events[1]!.type, "stderr");
+      assertEquals(events[2]!.type, "exit");
     });
   });
 

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, afterEach } from "#veryfront/testing/bdd";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd";
 import {
   assert,
   assertEquals,
@@ -16,7 +16,11 @@ function mockFetch(responses: Array<Response | (() => Response)>) {
   fetchResponses = responses.map((r) => (typeof r === "function" ? r() : r));
   fetchCalls = [];
   globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.toString()
+      : input.url;
     fetchCalls.push({ url, init });
     const response = fetchResponses.shift();
     if (!response) throw new Error(`No mock response for: ${url}`);
@@ -56,7 +60,11 @@ describe("Sandbox", () => {
   describe("create()", () => {
     it("should create a sandbox and return instance", async () => {
       mockFetch([
-        jsonResponse({ id: "session-1", endpoint: "https://sandbox.example.com", status: "running" }),
+        jsonResponse({
+          id: "session-1",
+          endpoint: "https://sandbox.example.com",
+          status: "running",
+        }),
       ]);
 
       const sandbox = await Sandbox.create({ authToken: "test-token" });
@@ -70,11 +78,22 @@ describe("Sandbox", () => {
 
     it("should poll until ready when not running", async () => {
       mockFetch([
-        jsonResponse({ id: "session-2", endpoint: "https://sandbox.example.com", status: "starting" }),
-        jsonResponse({ id: "session-2", endpoint: "https://sandbox.example.com", status: "running" }),
+        jsonResponse({
+          id: "session-2",
+          endpoint: "https://sandbox.example.com",
+          status: "starting",
+        }),
+        jsonResponse({
+          id: "session-2",
+          endpoint: "https://sandbox.example.com",
+          status: "running",
+        }),
       ]);
 
-      const sandbox = await Sandbox.create({ authToken: "test-token", apiUrl: "https://api.test.com" });
+      const sandbox = await Sandbox.create({
+        authToken: "test-token",
+        apiUrl: "https://api.test.com",
+      });
       assertEquals(sandbox.id, "session-2");
       assertEquals(fetchCalls.length, 2);
     });
@@ -93,7 +112,11 @@ describe("Sandbox", () => {
 
     it("should throw when sandbox fails to start", async () => {
       mockFetch([
-        jsonResponse({ id: "session-3", endpoint: "https://sandbox.example.com", status: "pending" }),
+        jsonResponse({
+          id: "session-3",
+          endpoint: "https://sandbox.example.com",
+          status: "pending",
+        }),
         jsonResponse({ id: "session-3", status: "error" }),
       ]);
 
@@ -126,7 +149,8 @@ describe("Sandbox", () => {
       ]);
 
       await assertRejects(
-        () => Sandbox.get("nonexistent", { authToken: "test-token", apiUrl: "https://api.test.com" }),
+        () =>
+          Sandbox.get("nonexistent", { authToken: "test-token", apiUrl: "https://api.test.com" }),
         Error,
         "Failed to get sandbox",
       );

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -1,10 +1,5 @@
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd";
-import {
-  assert,
-  assertEquals,
-  assertRejects,
-  assertStringIncludes,
-} from "#veryfront/testing/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert";
 import { Sandbox } from "./sandbox.ts";
 
 // Mock fetch for testing

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -62,6 +62,18 @@ function call(index: number): { url: string; init?: RequestInit } {
   return entry;
 }
 
+function headerValue(index: number, name: string): string | null {
+  return new Headers(call(index).init?.headers).get(name);
+}
+
+function jsonBody(index: number): unknown {
+  const body = call(index).init?.body;
+  if (typeof body !== "string") {
+    throw new Error(`Expected string body for fetch call ${index}`);
+  }
+  return JSON.parse(body);
+}
+
 describe("Sandbox", () => {
   beforeEach(() => {
     fetchCalls = [];
@@ -89,6 +101,8 @@ describe("Sandbox", () => {
 
       assertStringIncludes(call(0).url, "/sandbox-sessions");
       assertEquals(call(0).init?.method, "POST");
+      assertEquals(headerValue(0, "Authorization"), "Bearer test-token");
+      assertEquals(headerValue(0, "Content-Type"), "application/json");
     });
 
     it("should poll until ready when not running", async () => {
@@ -112,6 +126,8 @@ describe("Sandbox", () => {
       });
       assertEquals(sandbox.id, "session-2");
       assertEquals(fetchCalls.length, 2);
+      assertStringIncludes(call(1).url, "/sandbox-sessions/session-2");
+      assertEquals(headerValue(1, "Authorization"), "Bearer test-token");
     });
 
     it("should throw on creation failure", async () => {
@@ -158,6 +174,7 @@ describe("Sandbox", () => {
       assertEquals(sandbox.id, "session-existing");
       assertEquals(sandbox.url, "https://sandbox.example.com");
       assertStringIncludes(call(0).url, "/sandbox-sessions/session-existing");
+      assertEquals(headerValue(0, "Authorization"), "Bearer test-token");
     });
 
     it("should throw when sandbox not found", async () => {
@@ -190,6 +207,10 @@ describe("Sandbox", () => {
       assertEquals(result.stdout, "hello\n");
       assertEquals(result.stderr, "");
       assertEquals(result.exitCode, 0);
+      assertEquals(call(1).init?.method, "POST");
+      assertEquals(headerValue(1, "Authorization"), "Bearer token");
+      assertEquals(headerValue(1, "Content-Type"), "application/json");
+      assertEquals(jsonBody(1), { command: "echo hello" });
     });
 
     it("should collect stderr output", async () => {
@@ -207,6 +228,7 @@ describe("Sandbox", () => {
       assertEquals(result.stdout, "");
       assertEquals(result.stderr, "error occurred\n");
       assertEquals(result.exitCode, 1);
+      assertEquals(jsonBody(1), { command: "failing-cmd" });
     });
   });
 
@@ -233,6 +255,10 @@ describe("Sandbox", () => {
       assertEquals(events[1]!.type, "stderr");
       assertEquals(events[2]!.type, "exit");
       assertEquals(events[2]!.exitCode, 0);
+      assertEquals(call(1).init?.method, "POST");
+      assertEquals(headerValue(1, "Authorization"), "Bearer token");
+      assertEquals(headerValue(1, "Content-Type"), "application/json");
+      assertEquals(jsonBody(1), { command: "cmd" });
     });
 
     it("should throw on non-OK response", async () => {
@@ -251,6 +277,7 @@ describe("Sandbox", () => {
         Error,
         "Exec failed",
       );
+      assertEquals(jsonBody(1), { command: "bad-cmd" });
     });
 
     it("should handle chunked NDJSON delivery", async () => {
@@ -282,6 +309,7 @@ describe("Sandbox", () => {
       assertEquals(events[0]!.type, "stdout");
       assertEquals(events[1]!.type, "stderr");
       assertEquals(events[2]!.type, "exit");
+      assertEquals(jsonBody(1), { command: "cmd" });
     });
   });
 
@@ -297,6 +325,7 @@ describe("Sandbox", () => {
 
       assertEquals(content, "file content here");
       assertStringIncludes(call(1).url, "/file?path=");
+      assertEquals(headerValue(1, "Authorization"), "Bearer token");
     });
 
     it("should throw on read failure", async () => {
@@ -329,6 +358,14 @@ describe("Sandbox", () => {
 
       assertEquals(call(1).init?.method, "POST");
       assertStringIncludes(call(1).url, "/files");
+      assertEquals(headerValue(1, "Authorization"), "Bearer token");
+      assertEquals(headerValue(1, "Content-Type"), "application/json");
+      assertEquals(jsonBody(1), {
+        files: [
+          { path: "/workspace/a.txt", content: "aaa" },
+          { path: "/workspace/b.txt", content: "bbb" },
+        ],
+      });
     });
   });
 
@@ -344,6 +381,7 @@ describe("Sandbox", () => {
 
       assertStringIncludes(call(1).url, "/sandbox-sessions/s6/heartbeat");
       assertEquals(call(1).init?.method, "POST");
+      assertEquals(headerValue(1, "Authorization"), "Bearer token");
     });
   });
 
@@ -359,6 +397,7 @@ describe("Sandbox", () => {
 
       assertStringIncludes(call(1).url, "/sandbox-sessions/s7");
       assertEquals(call(1).init?.method, "DELETE");
+      assertEquals(headerValue(1, "Authorization"), "Bearer token");
     });
   });
 

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -42,6 +42,12 @@ function ndjsonResponse(events: Array<Record<string, unknown>>): Response {
   });
 }
 
+function call(index: number): { url: string; init?: RequestInit } {
+  const entry = fetchCalls[index];
+  if (!entry) throw new Error(`No fetch call at index ${index}`);
+  return entry;
+}
+
 describe("Sandbox", () => {
   beforeEach(() => {
     fetchCalls = [];
@@ -66,9 +72,8 @@ describe("Sandbox", () => {
       assertEquals(sandbox.id, "session-1");
       assertEquals(sandbox.url, "https://sandbox.example.com");
 
-      assertStringIncludes(fetchCalls[0].url, "/sandbox-sessions");
-      assertEquals(fetchCalls[0].init?.method, "POST");
-      assertStringIncludes(fetchCalls[0].init?.headers?.toString() ?? "", "");
+      assertStringIncludes(call(0).url, "/sandbox-sessions");
+      assertEquals(call(0).init?.method, "POST");
     });
 
     it("should poll until ready when not running", async () => {
@@ -135,7 +140,7 @@ describe("Sandbox", () => {
       });
       assertEquals(sandbox.id, "session-existing");
       assertEquals(sandbox.url, "https://sandbox.example.com");
-      assertStringIncludes(fetchCalls[0].url, "/sandbox-sessions/session-existing");
+      assertStringIncludes(call(0).url, "/sandbox-sessions/session-existing");
     });
 
     it("should throw when sandbox not found", async () => {
@@ -154,7 +159,6 @@ describe("Sandbox", () => {
 
   describe("executeCommand()", () => {
     it("should execute command and collect output", async () => {
-      // Create sandbox first
       mockFetch([
         jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
         ndjsonResponse([
@@ -200,7 +204,7 @@ describe("Sandbox", () => {
       const content = await sandbox.readFile("/workspace/test.txt");
 
       assertEquals(content, "file content here");
-      assertStringIncludes(fetchCalls[1].url, "/file?path=");
+      assertStringIncludes(call(1).url, "/file?path=");
     });
 
     it("should throw on read failure", async () => {
@@ -231,8 +235,8 @@ describe("Sandbox", () => {
         { path: "/workspace/b.txt", content: "bbb" },
       ]);
 
-      assertEquals(fetchCalls[1].init?.method, "POST");
-      assertStringIncludes(fetchCalls[1].url, "/files");
+      assertEquals(call(1).init?.method, "POST");
+      assertStringIncludes(call(1).url, "/files");
     });
   });
 
@@ -246,8 +250,8 @@ describe("Sandbox", () => {
       const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
       await sandbox.heartbeat();
 
-      assertStringIncludes(fetchCalls[1].url, "/sandbox-sessions/s6/heartbeat");
-      assertEquals(fetchCalls[1].init?.method, "POST");
+      assertStringIncludes(call(1).url, "/sandbox-sessions/s6/heartbeat");
+      assertEquals(call(1).init?.method, "POST");
     });
   });
 
@@ -261,15 +265,19 @@ describe("Sandbox", () => {
       const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
       await sandbox.close();
 
-      assertStringIncludes(fetchCalls[1].url, "/sandbox-sessions/s7");
-      assertEquals(fetchCalls[1].init?.method, "DELETE");
+      assertStringIncludes(call(1).url, "/sandbox-sessions/s7");
+      assertEquals(call(1).init?.method, "DELETE");
     });
   });
 
   describe("properties", () => {
     it("should expose id and url", async () => {
       mockFetch([
-        jsonResponse({ id: "props-test", endpoint: "https://sb.example.com", status: "running" }),
+        jsonResponse({
+          id: "props-test",
+          endpoint: "https://sb.example.com",
+          status: "running",
+        }),
       ]);
 
       const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, beforeEach, afterEach } from "#veryfront/testing/bdd";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert";
+import { Sandbox } from "./sandbox.ts";
+
+// Mock fetch for testing
+const originalFetch = globalThis.fetch;
+let fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+let fetchResponses: Array<Response> = [];
+
+function mockFetch(responses: Array<Response | (() => Response)>) {
+  fetchResponses = responses.map((r) => (typeof r === "function" ? r() : r));
+  fetchCalls = [];
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    fetchCalls.push({ url, init });
+    const response = fetchResponses.shift();
+    if (!response) throw new Error(`No mock response for: ${url}`);
+    return response;
+  }) as typeof fetch;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function textResponse(body: string, status = 200): Response {
+  return new Response(body, { status });
+}
+
+function ndjsonResponse(events: Array<Record<string, unknown>>): Response {
+  const body = events.map((e) => JSON.stringify(e)).join("\n");
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "application/x-ndjson" },
+  });
+}
+
+describe("Sandbox", () => {
+  beforeEach(() => {
+    fetchCalls = [];
+    fetchResponses = [];
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe("create()", () => {
+    it("should create a sandbox and return instance", async () => {
+      mockFetch([
+        jsonResponse({ id: "session-1", endpoint: "https://sandbox.example.com", status: "running" }),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "test-token" });
+      assertEquals(sandbox.id, "session-1");
+      assertEquals(sandbox.url, "https://sandbox.example.com");
+
+      assertStringIncludes(fetchCalls[0].url, "/sandbox-sessions");
+      assertEquals(fetchCalls[0].init?.method, "POST");
+      assertStringIncludes(fetchCalls[0].init?.headers?.toString() ?? "", "");
+    });
+
+    it("should poll until ready when not running", async () => {
+      mockFetch([
+        jsonResponse({ id: "session-2", endpoint: "https://sandbox.example.com", status: "starting" }),
+        jsonResponse({ id: "session-2", endpoint: "https://sandbox.example.com", status: "running" }),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "test-token", apiUrl: "https://api.test.com" });
+      assertEquals(sandbox.id, "session-2");
+      assertEquals(fetchCalls.length, 2);
+    });
+
+    it("should throw on creation failure", async () => {
+      mockFetch([
+        textResponse("Forbidden", 403),
+      ]);
+
+      await assertRejects(
+        () => Sandbox.create({ authToken: "bad-token", apiUrl: "https://api.test.com" }),
+        Error,
+        "Failed to create sandbox",
+      );
+    });
+
+    it("should throw when sandbox fails to start", async () => {
+      mockFetch([
+        jsonResponse({ id: "session-3", endpoint: "https://sandbox.example.com", status: "pending" }),
+        jsonResponse({ id: "session-3", status: "error" }),
+      ]);
+
+      await assertRejects(
+        () => Sandbox.create({ authToken: "test-token", apiUrl: "https://api.test.com" }),
+        Error,
+        "Sandbox failed to start",
+      );
+    });
+  });
+
+  describe("get()", () => {
+    it("should reconnect to existing sandbox", async () => {
+      mockFetch([
+        jsonResponse({ endpoint: "https://sandbox.example.com" }),
+      ]);
+
+      const sandbox = await Sandbox.get("session-existing", {
+        authToken: "test-token",
+        apiUrl: "https://api.test.com",
+      });
+      assertEquals(sandbox.id, "session-existing");
+      assertEquals(sandbox.url, "https://sandbox.example.com");
+      assertStringIncludes(fetchCalls[0].url, "/sandbox-sessions/session-existing");
+    });
+
+    it("should throw when sandbox not found", async () => {
+      mockFetch([
+        textResponse("Not found", 404),
+      ]);
+
+      await assertRejects(
+        () => Sandbox.get("nonexistent", { authToken: "test-token", apiUrl: "https://api.test.com" }),
+        Error,
+        "Failed to get sandbox",
+      );
+    });
+  });
+
+  describe("executeCommand()", () => {
+    it("should execute command and collect output", async () => {
+      // Create sandbox first
+      mockFetch([
+        jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
+        ndjsonResponse([
+          { type: "stdout", data: "hello\n" },
+          { type: "exit", exitCode: 0 },
+        ]),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      const result = await sandbox.executeCommand("echo hello");
+
+      assertEquals(result.stdout, "hello\n");
+      assertEquals(result.stderr, "");
+      assertEquals(result.exitCode, 0);
+    });
+
+    it("should collect stderr output", async () => {
+      mockFetch([
+        jsonResponse({ id: "s2", endpoint: "https://sb.test", status: "running" }),
+        ndjsonResponse([
+          { type: "stderr", data: "error occurred\n" },
+          { type: "exit", exitCode: 1 },
+        ]),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      const result = await sandbox.executeCommand("failing-cmd");
+
+      assertEquals(result.stdout, "");
+      assertEquals(result.stderr, "error occurred\n");
+      assertEquals(result.exitCode, 1);
+    });
+  });
+
+  describe("readFile()", () => {
+    it("should read a file from sandbox", async () => {
+      mockFetch([
+        jsonResponse({ id: "s3", endpoint: "https://sb.test", status: "running" }),
+        textResponse("file content here"),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      const content = await sandbox.readFile("/workspace/test.txt");
+
+      assertEquals(content, "file content here");
+      assertStringIncludes(fetchCalls[1].url, "/file?path=");
+    });
+
+    it("should throw on read failure", async () => {
+      mockFetch([
+        jsonResponse({ id: "s4", endpoint: "https://sb.test", status: "running" }),
+        textResponse("Not found", 404),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      await assertRejects(
+        () => sandbox.readFile("/nonexistent"),
+        Error,
+        "Read file failed",
+      );
+    });
+  });
+
+  describe("writeFiles()", () => {
+    it("should write files to sandbox", async () => {
+      mockFetch([
+        jsonResponse({ id: "s5", endpoint: "https://sb.test", status: "running" }),
+        jsonResponse({ ok: true }),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      await sandbox.writeFiles([
+        { path: "/workspace/a.txt", content: "aaa" },
+        { path: "/workspace/b.txt", content: "bbb" },
+      ]);
+
+      assertEquals(fetchCalls[1].init?.method, "POST");
+      assertStringIncludes(fetchCalls[1].url, "/files");
+    });
+  });
+
+  describe("heartbeat()", () => {
+    it("should send heartbeat request", async () => {
+      mockFetch([
+        jsonResponse({ id: "s6", endpoint: "https://sb.test", status: "running" }),
+        jsonResponse({ ok: true }),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      await sandbox.heartbeat();
+
+      assertStringIncludes(fetchCalls[1].url, "/sandbox-sessions/s6/heartbeat");
+      assertEquals(fetchCalls[1].init?.method, "POST");
+    });
+  });
+
+  describe("close()", () => {
+    it("should send delete request", async () => {
+      mockFetch([
+        jsonResponse({ id: "s7", endpoint: "https://sb.test", status: "running" }),
+        jsonResponse({ ok: true }),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      await sandbox.close();
+
+      assertStringIncludes(fetchCalls[1].url, "/sandbox-sessions/s7");
+      assertEquals(fetchCalls[1].init?.method, "DELETE");
+    });
+  });
+
+  describe("properties", () => {
+    it("should expose id and url", async () => {
+      mockFetch([
+        jsonResponse({ id: "props-test", endpoint: "https://sb.example.com", status: "running" }),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      assertEquals(sandbox.id, "props-test");
+      assertEquals(sandbox.url, "https://sb.example.com");
+    });
+  });
+});

--- a/src/tool/executor.test.ts
+++ b/src/tool/executor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, it } from "#veryfront/testing/bdd";
-import { assertEquals, assertThrows } from "#veryfront/testing/assert";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert";
 import { z } from "zod";
 import { tool } from "./factory.ts";
 import { toolRegistry } from "./registry.ts";
@@ -40,9 +40,9 @@ describe("executeTool", () => {
     assertEquals((receivedContext as Record<string, unknown>).agentId, "test-agent");
   });
 
-  it("should throw when tool not found", () => {
-    assertThrows(
-      () => executeTool("nonexistent", {}),
+  it("should throw when tool not found", async () => {
+    await assertRejects(
+      async () => await executeTool("nonexistent", {}),
       Error,
       'Tool "nonexistent" not found',
     );

--- a/src/tool/executor.test.ts
+++ b/src/tool/executor.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, afterEach } from "#veryfront/testing/bdd";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert";
+import { z } from "zod";
+import { tool } from "./factory.ts";
+import { toolRegistry } from "./registry.ts";
+import { executeTool } from "./executor.ts";
+
+describe("executeTool", () => {
+  afterEach(() => {
+    toolRegistry.clearAll();
+  });
+
+  it("should execute a registered tool", async () => {
+    const t = tool({
+      id: "greet",
+      description: "Greet someone",
+      inputSchema: z.object({ name: z.string() }),
+      execute: async ({ name }) => `Hello, ${name}!`,
+    });
+    toolRegistry.register("greet", t);
+
+    const result = await executeTool("greet", { name: "World" });
+    assertEquals(result, "Hello, World!");
+  });
+
+  it("should pass context to tool execution", async () => {
+    let receivedContext: unknown;
+    const t = tool({
+      id: "ctx-tool",
+      description: "Context tool",
+      inputSchema: z.object({}),
+      execute: async (_input, ctx) => {
+        receivedContext = ctx;
+        return null;
+      },
+    });
+    toolRegistry.register("ctx-tool", t);
+
+    await executeTool("ctx-tool", {}, { agentId: "test-agent" });
+    assertEquals((receivedContext as Record<string, unknown>).agentId, "test-agent");
+  });
+
+  it("should throw when tool not found", () => {
+    assertThrows(
+      () => executeTool("nonexistent", {}),
+      Error,
+      'Tool "nonexistent" not found',
+    );
+  });
+});

--- a/src/tool/executor.test.ts
+++ b/src/tool/executor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, afterEach } from "#veryfront/testing/bdd";
+import { afterEach, describe, it } from "#veryfront/testing/bdd";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert";
 import { z } from "zod";
 import { tool } from "./factory.ts";

--- a/src/tool/factory.test.ts
+++ b/src/tool/factory.test.ts
@@ -1,9 +1,5 @@
 import { describe, it } from "#veryfront/testing/bdd";
-import {
-  assertEquals,
-  assertRejects,
-  assertStringIncludes,
-} from "#veryfront/testing/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert";
 import { z } from "zod";
 import { dynamicTool, tool } from "./factory.ts";
 

--- a/src/tool/factory.test.ts
+++ b/src/tool/factory.test.ts
@@ -43,6 +43,18 @@ describe("tool factory", () => {
       assertEquals(t.inputSchemaJson?.required?.includes("age"), true);
     });
 
+    it("should fall back to permissive schema with allowUnknownSchema", () => {
+      const t = tool({
+        id: "permissive-tool",
+        description: "desc",
+        inputSchema: {} as z.ZodSchema<unknown>,
+        execute: async () => null,
+        allowUnknownSchema: true,
+      });
+      assertEquals(t.inputSchemaJson?.type, "object");
+      assertEquals(t.inputSchemaJson?.additionalProperties, true);
+    });
+
     it("should preserve mcp config", () => {
       const t = tool({
         id: "mcp-tool",
@@ -123,7 +135,7 @@ describe("tool factory", () => {
       assertEquals(t.inputSchemaJson?.additionalProperties, true);
     });
 
-    it("should apply toModelOutput transform", async () => {
+    it("should apply toModelOutput transform in execute return value", async () => {
       const t = dynamicTool({
         id: "transform",
         description: "desc",

--- a/src/tool/factory.test.ts
+++ b/src/tool/factory.test.ts
@@ -1,0 +1,162 @@
+import { describe, it } from "#veryfront/testing/bdd";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert";
+import { z } from "zod";
+import { dynamicTool, tool } from "./factory.ts";
+
+describe("tool factory", () => {
+  describe("tool()", () => {
+    it("should create a tool with explicit id", () => {
+      const t = tool({
+        id: "my-tool",
+        description: "A test tool",
+        inputSchema: z.object({ query: z.string() }),
+        execute: async () => "result",
+      });
+      assertEquals(t.id, "my-tool");
+      assertEquals(t.type, "function");
+      assertEquals(t.description, "A test tool");
+    });
+
+    it("should auto-generate id when not provided", () => {
+      const t = tool({
+        description: "auto-id",
+        inputSchema: z.object({}),
+        execute: async () => null,
+      });
+      assertStringIncludes(t.id, "tool_");
+    });
+
+    it("should convert zod schema to JSON schema", () => {
+      const t = tool({
+        id: "schema-test",
+        description: "desc",
+        inputSchema: z.object({
+          name: z.string(),
+          age: z.number(),
+        }),
+        execute: async () => null,
+      });
+      assertEquals(t.inputSchemaJson?.type, "object");
+      assertEquals(t.inputSchemaJson?.properties?.name, { type: "string" });
+      assertEquals(t.inputSchemaJson?.properties?.age, { type: "number" });
+      assertEquals(t.inputSchemaJson?.required?.includes("name"), true);
+      assertEquals(t.inputSchemaJson?.required?.includes("age"), true);
+    });
+
+    it("should preserve mcp config", () => {
+      const t = tool({
+        id: "mcp-tool",
+        description: "desc",
+        inputSchema: z.object({}),
+        execute: async () => null,
+        mcp: { enabled: true, requiresAuth: false, cachePolicy: "cache" },
+      });
+      assertEquals(t.mcp?.enabled, true);
+      assertEquals(t.mcp?.cachePolicy, "cache");
+    });
+  });
+
+  describe("tool execute()", () => {
+    it("should validate input and execute", async () => {
+      const t = tool({
+        id: "exec-test",
+        description: "desc",
+        inputSchema: z.object({ value: z.string() }),
+        execute: async ({ value }) => `Got: ${value}`,
+      });
+      const result = await t.execute({ value: "hello" });
+      assertEquals(result, "Got: hello");
+    });
+
+    it("should throw on invalid input", async () => {
+      const t = tool({
+        id: "validate-test",
+        description: "desc",
+        inputSchema: z.object({ value: z.string() }),
+        execute: async () => "ok",
+      });
+      await assertRejects(
+        () => t.execute({ value: 123 } as unknown as { value: string }),
+        Error,
+        "input validation failed",
+      );
+    });
+
+    it("should pass execution context to handler", async () => {
+      let receivedCtx: unknown;
+      const t = tool({
+        id: "ctx-test",
+        description: "desc",
+        inputSchema: z.object({}),
+        execute: async (_input, ctx) => {
+          receivedCtx = ctx;
+          return null;
+        },
+      });
+      const ctx = { agentId: "agent-1", projectId: "proj-1" };
+      await t.execute({}, ctx);
+      assertEquals((receivedCtx as Record<string, unknown>).agentId, "agent-1");
+    });
+
+    it("should support sync execute functions", async () => {
+      const t = tool({
+        id: "sync-exec",
+        description: "desc",
+        inputSchema: z.object({ x: z.number() }),
+        execute: ({ x }) => x * 2,
+      });
+      const result = await t.execute({ x: 5 });
+      assertEquals(result, 10);
+    });
+  });
+
+  describe("dynamicTool()", () => {
+    it("should create a dynamic tool with permissive schema", () => {
+      const t = dynamicTool({
+        id: "dynamic",
+        description: "A dynamic tool",
+        inputSchema: {},
+        execute: async () => "done",
+      });
+      assertEquals(t.id, "dynamic");
+      assertEquals(t.type, "dynamic");
+      assertEquals(t.inputSchemaJson?.additionalProperties, true);
+    });
+
+    it("should apply toModelOutput transform", async () => {
+      const t = dynamicTool({
+        id: "transform",
+        description: "desc",
+        inputSchema: {},
+        execute: async () => ({ raw: "data" }),
+        toModelOutput: (output) => `transformed: ${JSON.stringify(output)}`,
+      });
+      const result = await t.execute({});
+      assertEquals(result, 'transformed: {"raw":"data"}');
+    });
+
+    it("should pass through output when no toModelOutput", async () => {
+      const t = dynamicTool({
+        id: "passthrough",
+        description: "desc",
+        inputSchema: {},
+        execute: async () => ({ value: 42 }),
+      });
+      const result = await t.execute({});
+      assertEquals(result, { value: 42 });
+    });
+
+    it("should auto-generate id when not provided", () => {
+      const t = dynamicTool({
+        description: "auto-id",
+        inputSchema: {},
+        execute: async () => null,
+      });
+      assertStringIncludes(t.id, "tool_");
+    });
+  });
+});

--- a/src/tool/schema/zod-json-schema.test.ts
+++ b/src/tool/schema/zod-json-schema.test.ts
@@ -115,6 +115,18 @@ describe("zodToJsonSchema", () => {
       const result = zodToJsonSchema(z.union([z.string(), z.number()]));
       assertEquals(result, { anyOf: [{ type: "string" }, { type: "number" }] });
     });
+
+    it("should convert z.discriminatedUnion()", () => {
+      const result = zodToJsonSchema(
+        z.discriminatedUnion("type", [
+          z.object({ type: z.literal("a"), value: z.string() }),
+          z.object({ type: z.literal("b"), count: z.number() }),
+        ]),
+      );
+      assertEquals(result.anyOf?.length, 2);
+      assertEquals(result.anyOf?.[0]?.type, "object");
+      assertEquals(result.anyOf?.[1]?.type, "object");
+    });
   });
 
   describe("record types", () => {
@@ -131,6 +143,25 @@ describe("zodToJsonSchema", () => {
     it("should include default in schema", () => {
       const result = zodToJsonSchema(z.string().default("hello"));
       assertEquals(result, { type: "string", default: "hello" });
+    });
+  });
+
+  describe("lazy types", () => {
+    it("should convert z.lazy()", () => {
+      const result = zodToJsonSchema(z.lazy(() => z.string()));
+      assertEquals(result, { type: "string" });
+    });
+  });
+
+  describe("effects types", () => {
+    it("should convert z.string().refine() (ZodEffects)", () => {
+      const result = zodToJsonSchema(z.string().refine((s) => s.length > 0));
+      assertEquals(result, { type: "string" });
+    });
+
+    it("should convert z.string().transform() (ZodEffects)", () => {
+      const result = zodToJsonSchema(z.string().transform((s) => s.toUpperCase()));
+      assertEquals(result, { type: "string" });
     });
   });
 

--- a/src/tool/schema/zod-json-schema.test.ts
+++ b/src/tool/schema/zod-json-schema.test.ts
@@ -1,0 +1,168 @@
+import { describe, it } from "#veryfront/testing/bdd";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert";
+import { z } from "zod";
+import { isOptionalSchema, zodToJsonSchema } from "./zod-json-schema.ts";
+
+describe("zodToJsonSchema", () => {
+  describe("primitive types", () => {
+    it("should convert z.string()", () => {
+      assertEquals(zodToJsonSchema(z.string()), { type: "string" });
+    });
+
+    it("should convert z.number()", () => {
+      assertEquals(zodToJsonSchema(z.number()), { type: "number" });
+    });
+
+    it("should convert z.boolean()", () => {
+      assertEquals(zodToJsonSchema(z.boolean()), { type: "boolean" });
+    });
+
+    it("should convert z.bigint()", () => {
+      assertEquals(zodToJsonSchema(z.bigint()), { type: "integer" });
+    });
+  });
+
+  describe("literal types", () => {
+    it("should convert string literal", () => {
+      const result = zodToJsonSchema(z.literal("hello"));
+      assertEquals(result, { const: "hello", type: "string" });
+    });
+
+    it("should convert number literal", () => {
+      const result = zodToJsonSchema(z.literal(42));
+      assertEquals(result, { const: 42, type: "number" });
+    });
+
+    it("should convert boolean literal", () => {
+      const result = zodToJsonSchema(z.literal(true));
+      assertEquals(result, { const: true, type: "boolean" });
+    });
+  });
+
+  describe("enum types", () => {
+    it("should convert z.enum()", () => {
+      const result = zodToJsonSchema(z.enum(["a", "b", "c"]));
+      assertEquals(result, { type: "string", enum: ["a", "b", "c"] });
+    });
+
+    it("should convert z.nativeEnum()", () => {
+      enum Status {
+        Active = "active",
+        Inactive = "inactive",
+      }
+      const result = zodToJsonSchema(z.nativeEnum(Status));
+      assertEquals(result.enum?.includes("active"), true);
+      assertEquals(result.enum?.includes("inactive"), true);
+    });
+  });
+
+  describe("object types", () => {
+    it("should convert simple object", () => {
+      const result = zodToJsonSchema(z.object({ name: z.string(), age: z.number() }));
+      assertEquals(result.type, "object");
+      assertEquals(result.properties?.name, { type: "string" });
+      assertEquals(result.properties?.age, { type: "number" });
+      assertEquals(result.required?.includes("name"), true);
+      assertEquals(result.required?.includes("age"), true);
+    });
+
+    it("should mark optional fields as not required", () => {
+      const result = zodToJsonSchema(
+        z.object({ required: z.string(), optional: z.string().optional() }),
+      );
+      assertEquals(result.required, ["required"]);
+    });
+
+    it("should handle empty object", () => {
+      const result = zodToJsonSchema(z.object({}));
+      assertEquals(result.type, "object");
+      assertEquals(result.properties, {});
+    });
+
+    it("should handle nested objects", () => {
+      const result = zodToJsonSchema(
+        z.object({ nested: z.object({ value: z.number() }) }),
+      );
+      assertEquals(result.properties?.nested?.type, "object");
+      assertEquals(result.properties?.nested?.properties?.value, { type: "number" });
+    });
+  });
+
+  describe("array types", () => {
+    it("should convert z.array()", () => {
+      const result = zodToJsonSchema(z.array(z.string()));
+      assertEquals(result, { type: "array", items: { type: "string" } });
+    });
+
+    it("should convert z.tuple()", () => {
+      const result = zodToJsonSchema(z.tuple([z.string(), z.number()]));
+      assertEquals(result.type, "array");
+      assertEquals(result.prefixItems, [{ type: "string" }, { type: "number" }]);
+      assertEquals(result.minItems, 2);
+      assertEquals(result.maxItems, 2);
+    });
+  });
+
+  describe("nullable types", () => {
+    it("should wrap nullable types with anyOf", () => {
+      const result = zodToJsonSchema(z.string().nullable());
+      assertEquals(result, { anyOf: [{ type: "string" }, { type: "null" }] });
+    });
+  });
+
+  describe("union types", () => {
+    it("should convert z.union()", () => {
+      const result = zodToJsonSchema(z.union([z.string(), z.number()]));
+      assertEquals(result, { anyOf: [{ type: "string" }, { type: "number" }] });
+    });
+  });
+
+  describe("record types", () => {
+    it("should convert z.record()", () => {
+      const result = zodToJsonSchema(z.record(z.string(), z.number()));
+      assertEquals(result, {
+        type: "object",
+        additionalProperties: { type: "number" },
+      });
+    });
+  });
+
+  describe("default values", () => {
+    it("should include default in schema", () => {
+      const result = zodToJsonSchema(z.string().default("hello"));
+      assertEquals(result, { type: "string", default: "hello" });
+    });
+  });
+
+  describe("error handling", () => {
+    it("should throw for invalid schemas", () => {
+      assertThrows(
+        () => zodToJsonSchema(null as unknown as z.ZodTypeAny),
+        Error,
+        "Invalid Zod schema",
+      );
+    });
+
+    it("should throw for schema without _def", () => {
+      assertThrows(
+        () => zodToJsonSchema({} as unknown as z.ZodTypeAny),
+        Error,
+        "Invalid Zod schema",
+      );
+    });
+  });
+});
+
+describe("isOptionalSchema", () => {
+  it("should return false for required schemas", () => {
+    assertEquals(isOptionalSchema(z.string()), false);
+  });
+
+  it("should return true for optional schemas", () => {
+    assertEquals(isOptionalSchema(z.string().optional()), true);
+  });
+
+  it("should return true for nested optional (nullable + optional)", () => {
+    assertEquals(isOptionalSchema(z.string().nullable().optional()), true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add unit tests for 4 public modules that previously had zero test coverage: **prompt**, **resource**, **tool**, and **sandbox**
- 6 test files, 106 test steps covering factory functions, schema conversion, executor dispatch, param validation, and sandbox client operations
- Tests use the project's standard `Deno.test` + `src/testing/assert.ts` framework

## Test plan

- [x] All 6 new test files pass (`deno test --allow-env --allow-net`)
- [x] Full test suite passes (955 tests, 0 failures in pre-push hook)
- [x] Type checking passes on all new files (`deno check`)
- [x] Formatting and lint checks pass