### PR TITLE
refactor: extract hardcoded values into named constants

### DIFF
--- a/src/agent/ai-defaults.ts
+++ b/src/agent/ai-defaults.ts
@@ -1,47 +1,47 @@
 export const AGENT_DEFAULTS = {
-  maxTokens: 4096,
+  maxTokens: 4_096,
   temperature: 0.7,
   maxSteps: 20,
   memoryType: "conversation",
-  memoryMaxTokens: 4000,
+  memoryMaxTokens: 4_000,
 } as const;
 
 export const STREAMING_DEFAULTS = {
-  maxBufferSize: 1024 * 1024,
-  chunkSize: 16384,
+  maxBufferSize: 1_024 * 1_024, // 1 MB
+  chunkSize: 16_384,
 } as const;
 
 export const MEMORY_DEFAULTS = {
   bufferSize: 10,
   summaryThreshold: 20,
-  redisTtl: 86400,
+  redisTtl: 86_400, // 24 hours
   redisKeyPrefix: "veryfront:agent:memory:",
 } as const;
 
 export const RATE_LIMIT_DEFAULTS = {
   requestsPerMinute: 60,
-  tokensPerMinute: 100000,
-  windowMs: 60000,
+  tokensPerMinute: 100_000,
+  windowMs: 60_000,
 } as const;
 
 export const COST_TRACKING_DEFAULTS = {
   dailyBudget: 100,
-  monthlyBudget: 1000,
+  monthlyBudget: 1_000,
   warningThreshold: 0.8,
 } as const;
 
 export const RETRY_DEFAULTS = {
   maxAttempts: 3,
-  initialDelayMs: 1000,
-  maxDelayMs: 30000,
+  initialDelayMs: 1_000,
+  maxDelayMs: 30_000,
   backoffMultiplier: 2,
 } as const;
 
 export const WORKFLOW_DEFAULTS = {
-  timeoutMs: 300000,
+  timeoutMs: 300_000, // 5 minutes
   maxParallel: 10,
-  checkpointIntervalMs: 5000,
-  approvalTimeoutMs: 86400000,
+  checkpointIntervalMs: 5_000,
+  approvalTimeoutMs: 86_400_000, // 24 hours
 } as const;
 
 export const PROVIDER_DEFAULTS = {
@@ -50,12 +50,12 @@ export const PROVIDER_DEFAULTS = {
     anthropic: "claude-sonnet-4-20250514",
     google: "gemini-1.5-pro",
   },
-  requestTimeoutMs: 120000,
+  requestTimeoutMs: 120_000, // 2 minutes
 } as const;
 
 export const SECURITY_DEFAULTS = {
-  maxInputLength: 100000,
-  maxOutputLength: 100000,
+  maxInputLength: 100_000,
+  maxOutputLength: 100_000,
   redactPii: false,
 } as const;
 

--- a/src/agent/chat-handler.ts
+++ b/src/agent/chat-handler.ts
@@ -4,13 +4,18 @@ import type { Message } from "./types.ts";
 import { fromError } from "#veryfront/errors/veryfront-error.ts";
 import { DEFAULT_LOCAL_MODEL } from "../provider/local/model-catalog.ts";
 
+/** Maximum character length for a single text part */
+const MAX_TEXT_PART_LENGTH = 10_000;
+/** Maximum number of messages in a single chat request */
+const MAX_MESSAGES_PER_REQUEST = 100;
+
 // ---------------------------------------------------------------------------
 // Zod schemas for validating AI SDK v5 chat UI messages
 // ---------------------------------------------------------------------------
 
 const textPartSchema = z.object({
   type: z.literal("text"),
-  text: z.string().max(10000),
+  text: z.string().max(MAX_TEXT_PART_LENGTH),
   state: z.string().optional(),
 });
 
@@ -65,7 +70,7 @@ const messageSchema = z.object({
 });
 
 const chatRequestSchema = z.object({
-  messages: z.array(messageSchema).min(1).max(100),
+  messages: z.array(messageSchema).min(1).max(MAX_MESSAGES_PER_REQUEST),
   model: z.string().optional(),
 });
 

--- a/src/agent/memory/redis.ts
+++ b/src/agent/memory/redis.ts
@@ -37,7 +37,7 @@ export interface RedisMemoryConfig extends MemoryConfigBase {
   ttl?: number;
 }
 
-const DEFAULT_TTL = 86400; // 24 hours
+const DEFAULT_TTL = 86_400; // 24 hours
 const DEFAULT_KEY_PREFIX = "veryfront:agent:memory:";
 
 export class RedisMemory<M extends MinimalMessage = MinimalMessage> implements Memory<M> {

--- a/src/agent/middleware/cache/cache.ts
+++ b/src/agent/middleware/cache/cache.ts
@@ -1,6 +1,10 @@
 import type { AgentResponse } from "../../types.ts";
 import { setActiveSpanAttributes, withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 
+const DEFAULT_LRU_MAX_SIZE = 100;
+const DEFAULT_TTL_MS = 300_000; // 5 minutes
+const TTL_CLEANUP_INTERVAL_MS = 60_000;
+
 export interface CacheConfig {
   strategy: "memory" | "lru" | "ttl";
   maxSize?: number;
@@ -61,7 +65,7 @@ class MemoryCache {
 class LRUCache {
   private cache = new Map<string, CacheEntry>();
 
-  constructor(private maxSize: number = 100) {}
+  constructor(private maxSize: number = DEFAULT_LRU_MAX_SIZE) {}
 
   set(key: string, response: AgentResponse): void {
     if (this.cache.has(key)) this.cache.delete(key);
@@ -175,7 +179,7 @@ class TTLCache {
           this.cache.delete(key);
         }
       }
-    }, 60000);
+    }, TTL_CLEANUP_INTERVAL_MS);
   }
 }
 
@@ -184,9 +188,9 @@ type CacheInstance = Pick<MemoryCache, "set" | "get" | "has" | "delete" | "clear
 function createCacheByStrategy(config: CacheConfig): CacheInstance {
   switch (config.strategy) {
     case "lru":
-      return new LRUCache(config.maxSize ?? 100);
+      return new LRUCache(config.maxSize ?? DEFAULT_LRU_MAX_SIZE);
     case "ttl":
-      return new TTLCache(config.ttl ?? 300000);
+      return new TTLCache(config.ttl ?? DEFAULT_TTL_MS);
     default:
       return new MemoryCache();
   }

--- a/src/agent/middleware/cost-tracking/tracker.ts
+++ b/src/agent/middleware/cost-tracking/tracker.ts
@@ -1,6 +1,10 @@
 import type { AgentContext, AgentResponse } from "../../types.ts";
 import { agentLogger } from "#veryfront/utils/logger/logger.ts";
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1_000;
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1_000;
+const RESET_CHECK_INTERVAL_MS = 60_000;
+
 export interface CostConfig {
   /** Provider pricing (cost per 1M tokens) */
   pricing: {
@@ -155,12 +159,12 @@ class CostTracker {
 
   getDailySummary(): UsageSummary {
     const now = Date.now();
-    return this.getSummary(now - 24 * 60 * 60 * 1000, now);
+    return this.getSummary(now - ONE_DAY_MS, now);
   }
 
   getMonthlySummary(): UsageSummary {
     const now = Date.now();
-    return this.getSummary(now - 30 * 24 * 60 * 60 * 1000, now);
+    return this.getSummary(now - THIRTY_DAYS_MS, now);
   }
 
   private checkLimits(): void {
@@ -179,16 +183,16 @@ class CostTracker {
     this.resetInterval = setInterval(() => {
       const now = Date.now();
 
-      if (now - this.lastDayReset >= 24 * 60 * 60 * 1000) {
+      if (now - this.lastDayReset >= ONE_DAY_MS) {
         this.dailyTotal = 0;
         this.lastDayReset = now;
       }
 
-      if (now - this.lastMonthReset >= 30 * 24 * 60 * 60 * 1000) {
+      if (now - this.lastMonthReset >= THIRTY_DAYS_MS) {
         this.monthlyTotal = 0;
         this.lastMonthReset = now;
       }
-    }, 60_000);
+    }, RESET_CHECK_INTERVAL_MS);
   }
 
   destroy(): void {

--- a/src/agent/react/use-chat/browser-inference/browser-engine.ts
+++ b/src/agent/react/use-chat/browser-inference/browser-engine.ts
@@ -10,6 +10,11 @@ import type { UIMessage, UIMessagePart } from "../types.ts";
 import { generateClientId } from "../utils.ts";
 import { BrowserInferenceClient } from "./worker-client.ts";
 
+/** Default max tokens for browser-side inference */
+const DEFAULT_BROWSER_MAX_TOKENS = 512;
+/** Default temperature for browser-side inference */
+const DEFAULT_BROWSER_TEMPERATURE = 0.7;
+
 export interface BrowserInferenceCallbacks {
   onUpdate: (parts: UIMessagePart[], messageId: string) => void;
   onMessage: (message: UIMessage) => void;
@@ -45,7 +50,11 @@ export function runBrowserInference(
   client.generate(
     messageId,
     simpleMessages,
-    { systemPrompt, maxNewTokens: 512, temperature: 0.7 },
+    {
+      systemPrompt,
+      maxNewTokens: DEFAULT_BROWSER_MAX_TOKENS,
+      temperature: DEFAULT_BROWSER_TEMPERATURE,
+    },
     {
       onStatus: (status) => callbacks.onStatusChange(status),
       onDownloadProgress: (progress) => callbacks.onDownloadProgress?.(progress),

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -37,6 +37,7 @@ import { convertToolsToAISDK } from "./model-tool-converter.ts";
 import { createStreamState, processStream } from "./ai-stream-handler.ts";
 import { MiddlewareChain } from "../middleware/chain.ts";
 import { generateText, type LanguageModel, streamText } from "ai";
+import { AGENT_DEFAULTS } from "../ai-defaults.ts";
 
 // Re-export from submodules
 export { generateMessageId, sendSSE } from "./sse-utils.ts";
@@ -179,7 +180,8 @@ export class AgentRuntime {
     this.id = id;
     this.config = config;
 
-    const memoryConfig = config.memory || { type: "conversation", maxTokens: 4000 };
+    const memoryConfig = config.memory ||
+      { type: "conversation", maxTokens: AGENT_DEFAULTS.memoryMaxTokens };
     this.memory = createMemory<Message>(memoryConfig);
   }
 

--- a/src/build/asset-pipeline/image-optimizer/variant-generator.ts
+++ b/src/build/asset-pipeline/image-optimizer/variant-generator.ts
@@ -12,6 +12,9 @@ import type {
   SharpMetadata,
 } from "./types.ts";
 
+/** Default assumed image width when metadata has no width */
+const DEFAULT_IMAGE_WIDTH = 1_920;
+
 export function generateVariant(
   sharp: SharpConstructor,
   image: SharpInstance,
@@ -80,7 +83,7 @@ export function generateImageVariants(
     "build.asset.generateImageVariants",
     async (): Promise<ImageVariant[]> => {
       const variants: ImageVariant[] = [];
-      const originalWidth = metadata.width ?? 1920;
+      const originalWidth = metadata.width ?? DEFAULT_IMAGE_WIDTH;
       const metaWidth = metadata.width;
 
       const validSizes = metaWidth ? sizes.filter((size) => metaWidth >= size) : sizes;

--- a/src/build/config/environment.ts
+++ b/src/build/config/environment.ts
@@ -1,5 +1,12 @@
 import { getEnvironmentFromEnv } from "#veryfront/config/env.ts";
 
+/** Max cache entries for development builds */
+const DEV_CACHE_MAX_ENTRIES = 10;
+/** Max cache entries for production builds */
+const PROD_CACHE_MAX_ENTRIES = 100;
+/** Cache TTL for production builds (1 hour) */
+const PROD_CACHE_TTL_MS = 3_600_000;
+
 export type Environment = "development" | "production" | "test";
 
 function isEnvironment(value: unknown): value is Environment {
@@ -47,8 +54,8 @@ export function getBuildConfig(): BuildEnvironmentConfig {
     isDevelopment,
     isProduction,
     isTest,
-    cacheMaxEntries: isDevelopment ? 10 : 100,
-    cacheTTLMs: isDevelopment ? 0 : 3600000,
+    cacheMaxEntries: isDevelopment ? DEV_CACHE_MAX_ENTRIES : PROD_CACHE_MAX_ENTRIES,
+    cacheTTLMs: isDevelopment ? 0 : PROD_CACHE_TTL_MS,
     minify: isProduction,
     sourcemaps: isDevelopment ? "inline" : false,
     treeShaking: isProduction,

--- a/src/cache/backends/api.ts
+++ b/src/cache/backends/api.ts
@@ -8,6 +8,12 @@ import { getEnvValue } from "./helpers.ts";
 
 const logger = baseLogger.component("api-cache-backend");
 
+const DEFAULT_TIMEOUT_MS = 10_000;
+const CIRCUIT_BREAKER_RESET_TIMEOUT_MS = 15_000;
+const CIRCUIT_BREAKER_FAILURE_THRESHOLD = 10;
+const CIRCUIT_BREAKER_SUCCESS_THRESHOLD = 2;
+const ERROR_BODY_MAX_LENGTH = 500;
+
 type CacheRequestContext = {
   token?: string;
   projectId?: string;
@@ -40,13 +46,13 @@ export class ApiCacheBackend implements CacheBackend {
       getEnvValue("VERYFRONT_API_BASE_URL") ??
       "https://api.veryfront.com";
     this.keyPrefix = options.keyPrefix ?? "";
-    this.timeoutMs = options.timeoutMs ?? 10000;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
     const breakerName = options.circuitBreakerName ?? "api-cache";
     this.circuitBreaker = getCircuitBreaker(breakerName, {
-      failureThreshold: 10,
-      resetTimeoutMs: 15000,
-      successThreshold: 2,
+      failureThreshold: CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+      resetTimeoutMs: CIRCUIT_BREAKER_RESET_TIMEOUT_MS,
+      successThreshold: CIRCUIT_BREAKER_SUCCESS_THRESHOLD,
     });
   }
 
@@ -113,7 +119,9 @@ export class ApiCacheBackend implements CacheBackend {
                 error: bodyError instanceof Error ? bodyError.message : String(bodyError),
               });
             }
-            throw new Error(`HTTP ${response.status}: ${responseBody.slice(0, 500)}`);
+            throw new Error(
+              `HTTP ${response.status}: ${responseBody.slice(0, ERROR_BODY_MAX_LENGTH)}`,
+            );
           }
 
           return (await response.json()) as T;

--- a/src/cache/backends/disk.ts
+++ b/src/cache/backends/disk.ts
@@ -4,6 +4,7 @@ import { logger } from "#veryfront/utils";
 import type { CacheBackend } from "../types.ts";
 
 const CACHE_SUBDIR = "veryfront-files";
+const MAX_REGEX_CACHE_SIZE = 100;
 const fsPromises = import("node:fs/promises");
 
 interface DiskCacheEnvelope {
@@ -110,7 +111,7 @@ export class DiskCacheBackend implements CacheBackend {
     if (!regex) {
       const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
       regex = new RegExp(`^${escaped.replace(/\*/g, ".*").replace(/\?/g, ".")}$`);
-      if (this.regexCache.size >= 100) {
+      if (this.regexCache.size >= MAX_REGEX_CACHE_SIZE) {
         const firstKey = this.regexCache.keys().next().value as string | undefined;
         if (firstKey) this.regexCache.delete(firstKey);
       }

--- a/src/cache/backends/factory.ts
+++ b/src/cache/backends/factory.ts
@@ -17,6 +17,8 @@ import { getEnvValue } from "./helpers.ts";
 
 const logger = baseLogger.component("cache-backend");
 
+const DEFAULT_MEMORY_MAX_ENTRIES = 500;
+
 // Re-export gateway types for backward compatibility
 export type { CodeCacheGateway, TokenizingCacheGateway };
 
@@ -47,7 +49,7 @@ export function isDiskCacheConfigured(): boolean {
 export function createCacheBackend(config: CacheBackendConfig = {}): Promise<CacheBackend> {
   const {
     keyPrefix = "",
-    memoryMaxEntries = 500,
+    memoryMaxEntries = DEFAULT_MEMORY_MAX_ENTRIES,
     preferredBackend,
     apiBaseUrl,
     circuitBreakerName,

--- a/src/cache/backends/memory.ts
+++ b/src/cache/backends/memory.ts
@@ -4,6 +4,9 @@ import {
 } from "#veryfront/utils/constants/cache.ts";
 import type { CacheBackend } from "../types.ts";
 
+const DEFAULT_TTL_SECONDS = 300;
+const MAX_REGEX_CACHE_SIZE = 100;
+
 export class MemoryCacheBackend implements CacheBackend {
   readonly type = "memory" as const;
   private store = new Map<string, { value: string; expiresAt: number; sizeBytes: number }>();
@@ -66,7 +69,7 @@ export class MemoryCacheBackend implements CacheBackend {
     return Promise.resolve(results);
   }
 
-  set(key: string, value: string, ttlSeconds = 300): Promise<void> {
+  set(key: string, value: string, ttlSeconds = DEFAULT_TTL_SECONDS): Promise<void> {
     const entrySize = this.estimateSize(key, value);
 
     // Reject single entries that exceed the byte limit on their own
@@ -120,7 +123,7 @@ export class MemoryCacheBackend implements CacheBackend {
       this.currentSizeBytes += entrySize;
       this.store.set(key, {
         value,
-        expiresAt: now + (ttl ?? 300) * 1000,
+        expiresAt: now + (ttl ?? DEFAULT_TTL_SECONDS) * 1000,
         sizeBytes: entrySize,
       });
     }
@@ -141,7 +144,7 @@ export class MemoryCacheBackend implements CacheBackend {
       const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
       regex = new RegExp(`^${escaped.replace(/\*/g, ".*").replace(/\?/g, ".")}$`);
 
-      if (this.regexCache.size >= 100) {
+      if (this.regexCache.size >= MAX_REGEX_CACHE_SIZE) {
         const firstKey = this.regexCache.keys().next().value as string | undefined;
         if (firstKey) this.regexCache.delete(firstKey);
       }

--- a/src/cache/metrics.ts
+++ b/src/cache/metrics.ts
@@ -12,6 +12,8 @@ import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { ensureError } from "#veryfront/errors/veryfront-error.ts";
 import type { Span } from "@opentelemetry/api";
 
+const MAX_KEY_DISPLAY_LENGTH = 100;
+
 /**
  * Cache operation types for metrics tracking.
  */
@@ -360,7 +362,9 @@ export function withCacheSpan<T>(
     {
       "cache.domain": domain,
       "cache.operation": operation,
-      "cache.key": key.length > 100 ? key.slice(0, 100) + "..." : key,
+      "cache.key": key.length > MAX_KEY_DISPLAY_LENGTH
+        ? key.slice(0, MAX_KEY_DISPLAY_LENGTH) + "..."
+        : key,
     },
   );
 }

--- a/src/cache/registry.ts
+++ b/src/cache/registry.ts
@@ -6,6 +6,9 @@ import type { Span } from "@opentelemetry/api";
 
 const logger = rendererLogger.component("cache-registry");
 
+const DEFAULT_REDIS_SCAN_LIMIT = 1_000;
+const REDIS_SCAN_BATCH_COUNT = 100;
+
 export interface CacheStore {
   readonly name: string;
   get(key: string): unknown;
@@ -207,7 +210,7 @@ class CacheRegistry {
     this.stores.clear();
   }
 
-  scanRedisKeys(pattern: string, limit = 1000): Promise<string[]> {
+  scanRedisKeys(pattern: string, limit = DEFAULT_REDIS_SCAN_LIMIT): Promise<string[]> {
     if (!isRedisConfigured()) return Promise.resolve([]);
 
     return withSpan(
@@ -219,7 +222,10 @@ class CacheRegistry {
           let cursor = 0;
 
           do {
-            const result = await client.scan(cursor, { MATCH: pattern, COUNT: 100 });
+            const result = await client.scan(cursor, {
+              MATCH: pattern,
+              COUNT: REDIS_SCAN_BATCH_COUNT,
+            });
             cursor = typeof result.cursor === "string"
               ? parseInt(result.cursor, 10)
               : result.cursor;

--- a/src/config/environment-config.ts
+++ b/src/config/environment-config.ts
@@ -75,6 +75,11 @@ export interface EnvironmentConfig {
   veryfrontVersion: string | undefined;
 }
 
+/** Default timeout for incoming HTTP requests (used when REQUEST_TIMEOUT_MS is set but unparseable) */
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+/** Default timeout for outgoing HTTP fetch calls (used when VF_HTTP_FETCH_TIMEOUT is set but unparseable) */
+const DEFAULT_HTTP_FETCH_TIMEOUT_MS = 30_000;
+
 const DEFAULTS = {
   apiBaseUrl: "https://api.veryfront.com",
   port: 3001,
@@ -142,8 +147,12 @@ function readEnvSnapshot(): EnvironmentConfig {
     appUrl: getEnv("APP_URL") || getEnv("NEXT_PUBLIC_APP_URL") || undefined,
 
     port: parseNumber(getEnv("PORT"), DEFAULTS.port),
-    requestTimeoutMs: requestTimeoutRaw ? parseNumber(requestTimeoutRaw, 30000) : undefined,
-    httpFetchTimeoutMs: httpFetchTimeoutRaw ? parseNumber(httpFetchTimeoutRaw, 30000) : undefined,
+    requestTimeoutMs: requestTimeoutRaw
+      ? parseNumber(requestTimeoutRaw, DEFAULT_REQUEST_TIMEOUT_MS)
+      : undefined,
+    httpFetchTimeoutMs: httpFetchTimeoutRaw
+      ? parseNumber(httpFetchTimeoutRaw, DEFAULT_HTTP_FETCH_TIMEOUT_MS)
+      : undefined,
     ssrMaxConcurrentTransforms: parseNumber(
       getEnv("SSR_MAX_CONCURRENT_TRANSFORMS"),
       DEFAULTS.ssrMaxConcurrentTransforms,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -21,6 +21,19 @@ import { registerLRUCache } from "#veryfront/cache/registry.ts";
 
 const logger = serverLogger.component("config");
 
+/** Cache TTL for veryfront-api filesystem in proxy mode */
+const DEFAULT_FS_CACHE_TTL_MS = 60_000;
+/** Maximum retry attempts for veryfront-api filesystem requests */
+const DEFAULT_FS_MAX_RETRIES = 3;
+/** Initial backoff delay between retries */
+const DEFAULT_FS_INITIAL_DELAY_MS = 500;
+/** Maximum backoff delay between retries */
+const DEFAULT_FS_MAX_DELAY_MS = 5_000;
+/** Maximum entries in the render cache */
+const DEFAULT_RENDER_CACHE_MAX_ENTRIES = 500;
+/** Maximum entries in the per-project config cache */
+const DEFAULT_CONFIG_CACHE_MAX_ENTRIES = 100;
+
 export type { VeryfrontConfig } from "./schemas/index.ts";
 
 /**
@@ -57,8 +70,12 @@ function getDefaultFsConfig(): VeryfrontConfig["fs"] {
       veryfront: {
         apiBaseUrl,
         proxyMode: true,
-        cache: { enabled: true, ttl: 60000 },
-        retry: { maxRetries: 3, initialDelay: 500, maxDelay: 5000 },
+        cache: { enabled: true, ttl: DEFAULT_FS_CACHE_TTL_MS },
+        retry: {
+          maxRetries: DEFAULT_FS_MAX_RETRIES,
+          initialDelay: DEFAULT_FS_INITIAL_DELAY_MS,
+          maxDelay: DEFAULT_FS_MAX_DELAY_MS,
+        },
       },
     };
   }
@@ -103,7 +120,7 @@ function createFreshDefaults(): Partial<VeryfrontConfig> {
       render: {
         type: "memory",
         ttl: undefined,
-        maxEntries: 500,
+        maxEntries: DEFAULT_RENDER_CACHE_MAX_ENTRIES,
         kvPath: undefined,
         redisUrl: undefined,
         redisKeyPrefix: undefined,
@@ -129,7 +146,7 @@ function createFreshDefaults(): Partial<VeryfrontConfig> {
 }
 
 const configCacheByProject = new LRUCache<string, { revision: number; config: VeryfrontConfig }>({
-  maxEntries: 100,
+  maxEntries: DEFAULT_CONFIG_CACHE_MAX_ENTRIES,
 });
 
 // Register cache for monitoring

--- a/src/config/runtime-config.ts
+++ b/src/config/runtime-config.ts
@@ -11,6 +11,9 @@ import type { VeryfrontConfig } from "./schemas/index.ts";
 import type { EnvironmentConfig } from "./environment-config.ts";
 import { createTestEnvironmentConfig, getEnvironmentConfig } from "./environment-config.ts";
 
+/** Maximum entries in the default render cache */
+const DEFAULT_RENDER_CACHE_MAX_ENTRIES = 500;
+
 /**
  * Runtime-specific configuration derived from environment.
  */
@@ -70,7 +73,7 @@ export const DEFAULT_CONFIG: Partial<VeryfrontConfig> = {
     dir: ".veryfront",
     render: {
       type: "memory",
-      maxEntries: 500,
+      maxEntries: DEFAULT_RENDER_CACHE_MAX_ENTRIES,
     },
   },
   dev: {

--- a/src/embedding/chunk.ts
+++ b/src/embedding/chunk.ts
@@ -1,5 +1,11 @@
 import type { ChunkOptions } from "./types.ts";
 
+/** Default maximum characters per chunk (~512 tokens). */
+const DEFAULT_CHUNK_MAX_CHARS = 2_000;
+
+/** Default character overlap between consecutive chunks. */
+const DEFAULT_CHUNK_OVERLAP = 200;
+
 /**
  * Splits text into overlapping chunks for embedding.
  *
@@ -16,8 +22,8 @@ import type { ChunkOptions } from "./types.ts";
  * ```
  */
 export async function chunk(text: string, options?: ChunkOptions): Promise<string[]> {
-  const maxChars = options?.maxChars ?? 2000;
-  const overlap = options?.overlap ?? 200;
+  const maxChars = options?.maxChars ?? DEFAULT_CHUNK_MAX_CHARS;
+  const overlap = options?.overlap ?? DEFAULT_CHUNK_OVERLAP;
   const separators = options?.separators ?? ["\n\n", "\n", " ", ""];
 
   return splitRecursive(text, separators, maxChars, overlap);

--- a/src/embedding/upload-handler.ts
+++ b/src/embedding/upload-handler.ts
@@ -3,6 +3,7 @@ import type { UploadStore } from "./types.ts";
 import { loadUpload } from "./upload-loader.ts";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+const MAX_FILE_NAME_LENGTH = 200;
 
 const MIME_TO_TYPE: Record<string, string> = {
   "text/plain": "txt",
@@ -132,7 +133,7 @@ export function createUploadHandler(
       }
 
       // Sanitize file name: strip path components, limit length
-      const safeName = file.name.replace(/[/\\]/g, "_").slice(0, 200);
+      const safeName = file.name.replace(/[/\\]/g, "_").slice(0, MAX_FILE_NAME_LENGTH);
 
       const id = await store.ingest(safeName, text, {
         source: `upload:${safeName}`,

--- a/src/embedding/upload-store.ts
+++ b/src/embedding/upload-store.ts
@@ -20,6 +20,9 @@ import type {
   UploadStoreData,
 } from "./types.ts";
 
+/** Default number of top results returned by similarity search. */
+const DEFAULT_TOP_K = 5;
+
 /**
  * Creates a persistent upload store with lazy embedding and similarity search.
  *
@@ -198,7 +201,7 @@ export function uploadStore(config: UploadStoreConfig): UploadStore {
         if (updated) await save(data);
 
         const queryEmbedding = await embedder.embed(query);
-        const topK = options?.topK ?? 5;
+        const topK = options?.topK ?? DEFAULT_TOP_K;
         const threshold = options?.threshold;
 
         const docMap = new Map(data.uploads.map((d) => [d.id, d]));

--- a/src/middleware/builtin/timeout.ts
+++ b/src/middleware/builtin/timeout.ts
@@ -9,7 +9,7 @@ import { HTTP_GATEWAY_TIMEOUT } from "#veryfront/utils/constants/http.ts";
 
 const logger = serverLogger.component("timeout");
 
-const DEFAULT_TIMEOUT_MS = 60000;
+const DEFAULT_TIMEOUT_MS = 60_000;
 const TIMEOUT_SENTINEL = Symbol("timeout");
 
 export interface TimeoutOptions {

--- a/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.ts
+++ b/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.ts
@@ -1,3 +1,6 @@
+/** Default timeout for acquiring a semaphore permit (ms) */
+const DEFAULT_ACQUIRE_TIMEOUT_MS = 100;
+
 export class Semaphore {
   private permits: number;
   private readonly maxQueueSize: number;
@@ -8,7 +11,7 @@ export class Semaphore {
     this.maxQueueSize = options?.maxQueueSize ?? Infinity;
   }
 
-  tryAcquire(timeoutMs = 100): Promise<boolean> {
+  tryAcquire(timeoutMs = DEFAULT_ACQUIRE_TIMEOUT_MS): Promise<boolean> {
     if (this.permits > 0) {
       this.permits--;
       return Promise.resolve(true);

--- a/src/modules/react-loader/ssr-module-loader/http-bundle-helpers.ts
+++ b/src/modules/react-loader/ssr-module-loader/http-bundle-helpers.ts
@@ -10,6 +10,9 @@
 import { createFileSystem, exists } from "#veryfront/platform/compat/fs.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 
+/** Max entries in the verified HTTP bundle paths LRU cache */
+const VERIFIED_BUNDLE_CACHE_MAX_ENTRIES = 2_000;
+
 /**
  * Extract VF module paths (veryfront-mdx-esm/*.mjs) from code.
  * These are user project modules that may import HTTP bundles.
@@ -154,4 +157,6 @@ export function extractAllFilePaths(code: string): string[] {
  * Bounded LRU to prevent unbounded memory growth in long-running pods.
  * Keying by contentHash ensures verification is re-done when content changes at the same path.
  */
-export const verifiedHttpBundlePaths = new LRUCache<string, true>({ maxEntries: 2000 });
+export const verifiedHttpBundlePaths = new LRUCache<string, true>({
+  maxEntries: VERIFIED_BUNDLE_CACHE_MAX_ENTRIES,
+});

--- a/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.ts
@@ -26,6 +26,9 @@ import type { ModuleCacheEntry, SSRModuleLoaderOptions } from "./types.ts";
 
 const logger = rendererLogger.component("ssr-module-loader");
 
+/** Content length threshold: below this, use fast sync hash; above, use async SHA-256 */
+const SYNC_HASH_THRESHOLD = 10_000;
+
 const UNRESOLVED_VF_MODULE_IMPORT_PATTERN =
   /from\s*["']((?:file:\/\/)?\/?\/?_vf_modules\/[^"']+)["']/;
 
@@ -72,7 +75,7 @@ export class SSRCacheManager {
   }
 
   async hashContentAsync(content: string): Promise<string> {
-    if (content.length < 10000) return hashCodeHex(content);
+    if (content.length < SYNC_HASH_THRESHOLD) return hashCodeHex(content);
 
     try {
       const data = new TextEncoder().encode(content);

--- a/src/modules/server/module-batch-handler.ts
+++ b/src/modules/server/module-batch-handler.ts
@@ -43,9 +43,15 @@ const SLOW_REQUEST_THRESHOLD_MS = 500;
 /** Slow module transform threshold in milliseconds */
 const SLOW_TRANSFORM_THRESHOLD_MS = 100;
 
+/** Max entries in the per-project transform LRU cache */
+const TRANSFORM_CACHE_MAX_ENTRIES = 1_000;
+
+/** Immutable cache max-age in seconds (1 year) */
+const IMMUTABLE_CACHE_MAX_AGE_SECONDS = 31_536_000;
+
 /** Cache for transformed modules (path -> code) */
 const transformCache = new LRUCache<string, string>({
-  maxEntries: 1000,
+  maxEntries: TRANSFORM_CACHE_MAX_ENTRIES,
 });
 
 // Register cache for monitoring
@@ -248,7 +254,7 @@ export function handleModuleBatch(req: Request, options: BatchHandlerOptions): P
         status: HTTP_OK,
         headers: {
           "Content-Type": "application/javascript; charset=utf-8",
-          "Cache-Control": "public, max-age=31536000, immutable",
+          "Cache-Control": `public, max-age=${IMMUTABLE_CACHE_MAX_AGE_SECONDS}, immutable`,
           "X-Batch-Modules": String(successes.length),
           "X-Batch-Duration": String(Math.round(duration)),
           "X-Batch-Slow": isSlow ? "true" : "false",

--- a/src/oauth/providers/base.ts
+++ b/src/oauth/providers/base.ts
@@ -10,6 +10,12 @@ import type {
 } from "../types.ts";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
 
+/** Buffer before token expiry to trigger proactive refresh (5 minutes). */
+const TOKEN_REFRESH_BUFFER_MS = 300_000;
+
+/** Multiplier to convert `expires_in` (seconds) to milliseconds. */
+const SECONDS_TO_MS = 1_000;
+
 export type EnvReader = (key: string) => string | undefined;
 
 function generateRandomString(length: number): string {
@@ -145,7 +151,7 @@ export class OAuthProvider {
       : typeof rawExpiresIn === "string"
       ? Number(rawExpiresIn) || undefined
       : undefined;
-    if (expiresIn) tokens.expiresAt = Date.now() + expiresIn * 1000;
+    if (expiresIn) tokens.expiresAt = Date.now() + expiresIn * SECONDS_TO_MS;
 
     return tokens;
   }
@@ -308,7 +314,7 @@ export class OAuthService extends OAuthProvider {
     const tokens = await this.tokenStore?.getTokens(this.serviceId);
     if (!tokens) return null;
 
-    const isExpired = tokens.expiresAt && Date.now() > tokens.expiresAt - 300000;
+    const isExpired = tokens.expiresAt && Date.now() > tokens.expiresAt - TOKEN_REFRESH_BUFFER_MS;
     if (!isExpired) return tokens.accessToken;
 
     if (!tokens.refreshToken) return null;

--- a/src/oauth/token-store/memory.ts
+++ b/src/oauth/token-store/memory.ts
@@ -1,11 +1,11 @@
 import type { OAuthState, OAuthTokens, TokenStore } from "../types.ts";
 
+/** How long an OAuth state nonce remains valid (10 minutes). */
+const STATE_EXPIRATION_MS = 10 * 60 * 1_000;
+
 export class MemoryTokenStore implements TokenStore {
   private tokens = new Map<string, OAuthTokens>();
   private states = new Map<string, OAuthState>();
-
-  /** State expiration time in ms (10 minutes) */
-  private stateExpirationMs = 10 * 60 * 1000;
 
   async getTokens(serviceId: string): Promise<OAuthTokens | null> {
     return this.tokens.get(serviceId) ?? null;
@@ -23,7 +23,7 @@ export class MemoryTokenStore implements TokenStore {
     const oauthState = this.states.get(state);
     if (!oauthState) return null;
 
-    if (Date.now() - oauthState.createdAt > this.stateExpirationMs) {
+    if (Date.now() - oauthState.createdAt > STATE_EXPIRATION_MS) {
       this.states.delete(state);
       return null;
     }
@@ -43,7 +43,7 @@ export class MemoryTokenStore implements TokenStore {
   private cleanupExpiredStates(): void {
     const now = Date.now();
     for (const [state, oauthState] of this.states) {
-      if (now - oauthState.createdAt > this.stateExpirationMs) {
+      if (now - oauthState.createdAt > STATE_EXPIRATION_MS) {
         this.states.delete(state);
       }
     }

--- a/src/platform/adapters/fs/github/github-api-client.ts
+++ b/src/platform/adapters/fs/github/github-api-client.ts
@@ -12,6 +12,9 @@ import {
 
 const LOG_PREFIX = "[GitHubApiClient]";
 
+const RATE_LIMIT_WARNING_THRESHOLD = 100;
+const RETRY_JITTER_MAX_MS = 1_000;
+
 interface RateLimitInfo {
   limit: number;
   remaining: number;
@@ -138,7 +141,7 @@ export class GitHubApiClient {
       used: used ? parseInt(used, 10) : 0,
     };
 
-    if (this.rateLimitInfo.remaining < 100) {
+    if (this.rateLimitInfo.remaining < RATE_LIMIT_WARNING_THRESHOLD) {
       logger.warn(`${LOG_PREFIX} Approaching rate limit`, {
         remaining: this.rateLimitInfo.remaining,
         reset: this.rateLimitInfo.reset.toISOString(),
@@ -216,7 +219,7 @@ export class GitHubApiClient {
       this.config.retry.maxDelay,
     );
 
-    return delay + Math.random() * 1000;
+    return delay + Math.random() * RETRY_JITTER_MAX_MS;
   }
 
   private sleep(ms: number): Promise<void> {

--- a/src/platform/adapters/fs/github/types.ts
+++ b/src/platform/adapters/fs/github/types.ts
@@ -61,6 +61,13 @@ export interface FileIndexEntry {
   type: "blob" | "tree";
 }
 
+const DEFAULT_CACHE_TTL_MS = 60_000;
+const DEFAULT_CACHE_MAX_ENTRIES = 1_000;
+const DEFAULT_CACHE_MAX_MEMORY_BYTES = 100 * 1024 * 1024;
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_INITIAL_RETRY_DELAY_MS = 1_000;
+const DEFAULT_MAX_RETRY_DELAY_MS = 10_000;
+
 export function createGitHubConfig(config: GitHubConfig): ResolvedGitHubConfig {
   if (!config.token) {
     throw toError(
@@ -89,14 +96,14 @@ export function createGitHubConfig(config: GitHubConfig): ResolvedGitHubConfig {
     ref: config.ref ?? "main",
     cache: {
       enabled: config.cache?.enabled ?? true,
-      ttl: config.cache?.ttl ?? 60_000,
-      maxSize: config.cache?.maxSize ?? 1000,
-      maxMemory: config.cache?.maxMemory ?? 100 * 1024 * 1024,
+      ttl: config.cache?.ttl ?? DEFAULT_CACHE_TTL_MS,
+      maxSize: config.cache?.maxSize ?? DEFAULT_CACHE_MAX_ENTRIES,
+      maxMemory: config.cache?.maxMemory ?? DEFAULT_CACHE_MAX_MEMORY_BYTES,
     },
     retry: {
-      maxRetries: config.retry?.maxRetries ?? 3,
-      initialDelay: config.retry?.initialDelay ?? 1000,
-      maxDelay: config.retry?.maxDelay ?? 10_000,
+      maxRetries: config.retry?.maxRetries ?? DEFAULT_MAX_RETRIES,
+      initialDelay: config.retry?.initialDelay ?? DEFAULT_INITIAL_RETRY_DELAY_MS,
+      maxDelay: config.retry?.maxDelay ?? DEFAULT_MAX_RETRY_DELAY_MS,
     },
   };
 }

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -31,6 +31,13 @@ import {
 
 const logger = baseLogger.component("veryfront-fs-adapter");
 
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_INITIAL_RETRY_DELAY_MS = 1_000;
+const DEFAULT_MAX_RETRY_DELAY_MS = 10_000;
+const DEFAULT_CACHE_TTL_MS = 60_000;
+const DEFAULT_CACHE_MAX_ENTRIES = 1_000;
+const DEFAULT_CACHE_MAX_MEMORY_BYTES = 100 * 1024 * 1024;
+
 export class VeryfrontFSAdapter implements FSAdapter {
   private client: VeryfrontApiClient;
   private cache: FileCache;
@@ -79,9 +86,9 @@ export class VeryfrontFSAdapter implements FSAdapter {
     this.proxyMode = vf.proxyMode ?? false;
 
     const retryConfig = {
-      maxRetries: 3,
-      initialDelay: 1000,
-      maxDelay: 10000,
+      maxRetries: DEFAULT_MAX_RETRIES,
+      initialDelay: DEFAULT_INITIAL_RETRY_DELAY_MS,
+      maxDelay: DEFAULT_MAX_RETRY_DELAY_MS,
       ...vf.retry,
     };
 
@@ -96,9 +103,9 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
     const cacheConfig: FileCacheOptions = {
       enabled: true,
-      ttl: 60_000,
-      maxSize: 1000,
-      maxMemory: 100 * 1024 * 1024,
+      ttl: DEFAULT_CACHE_TTL_MS,
+      maxSize: DEFAULT_CACHE_MAX_ENTRIES,
+      maxMemory: DEFAULT_CACHE_MAX_MEMORY_BYTES,
       ...vf.cache,
     };
 

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
@@ -8,6 +8,10 @@ import { runWithCacheBatching } from "#veryfront/cache/request-cache-batcher.ts"
 
 const logger = baseLogger.component("multi-project-fs-adapter");
 
+const DEFAULT_MAX_ADAPTERS = 100;
+const DEFAULT_CLEANUP_INTERVAL_MS = 5 * 60 * 1_000;
+const DEFAULT_MAX_IDLE_MS = 30 * 60 * 1_000;
+
 interface RequestContext {
   projectSlug: string;
   projectId?: string;
@@ -36,9 +40,9 @@ export class MultiProjectFSAdapter implements FSAdapter {
   constructor(config: FSAdapterConfig) {
     this.manager = new ProxyFSAdapterManager({
       baseConfig: config,
-      maxAdapters: 100,
-      cleanupIntervalMs: 5 * 60 * 1000,
-      maxIdleMs: 30 * 60 * 1000,
+      maxAdapters: DEFAULT_MAX_ADAPTERS,
+      cleanupIntervalMs: DEFAULT_CLEANUP_INTERVAL_MS,
+      maxIdleMs: DEFAULT_MAX_IDLE_MS,
     });
 
     logger.debug("Created", {

--- a/src/platform/adapters/fs/veryfront/proxy-manager.ts
+++ b/src/platform/adapters/fs/veryfront/proxy-manager.ts
@@ -23,6 +23,9 @@ import { GetAdapterParamsSchema } from "./schemas/index.ts";
 
 const logger = baseLogger.component("proxy-fs-adapter-manager");
 
+const DEFAULT_MAX_ADAPTERS = 100;
+const DEFAULT_MAX_IDLE_MS = 30 * 60 * 1_000;
+
 interface ProjectAdapter {
   adapter: VeryfrontFSAdapter;
   lastAccessed: number;
@@ -46,8 +49,8 @@ export class ProxyFSAdapterManager {
 
   constructor(config: ProxyFSAdapterManagerConfig) {
     this.baseConfig = config.baseConfig;
-    this.maxAdapters = config.maxAdapters ?? 100;
-    this.maxIdleMs = config.maxIdleMs ?? 30 * 60 * 1000;
+    this.maxAdapters = config.maxAdapters ?? DEFAULT_MAX_ADAPTERS;
+    this.maxIdleMs = config.maxIdleMs ?? DEFAULT_MAX_IDLE_MS;
 
     if (config.cleanupIntervalMs) {
       this.cleanupTimer = setInterval(

--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -49,6 +49,7 @@ export interface ContentContextProvider {
 
 const IN_FLIGHT_REQUEST_TIMEOUT_MS = 15_000;
 const MAX_IN_FLIGHT_REQUESTS = 100;
+const IN_FLIGHT_CLEANUP_INTERVAL_MS = 1_000;
 
 function previewText(content: string, max = 80): string {
   return content.length > max ? `${content.slice(0, max)}...` : content;
@@ -58,7 +59,7 @@ export class ReadOperations {
   private readonly inFlightRequests = new InFlightRequestDeduper<string>({
     timeoutMs: IN_FLIGHT_REQUEST_TIMEOUT_MS,
     maxEntries: MAX_IN_FLIGHT_REQUESTS,
-    cleanupIntervalMs: 1000,
+    cleanupIntervalMs: IN_FLIGHT_CLEANUP_INTERVAL_MS,
   });
   private readonly fileListIndex: FileListIndex;
   /** Caches extensionless base paths → resolved full paths to avoid repeated API resolution calls */

--- a/src/platform/adapters/fs/veryfront/stat-operations.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.ts
@@ -26,6 +26,9 @@ const logger = baseLogger.component("stat-operations");
 
 const NOT_FOUND_SENTINEL = "__NOT_FOUND__";
 
+const API_SEARCH_CIRCUIT_BREAKER_THRESHOLD = 5;
+const API_SEARCH_CIRCUIT_BREAKER_COOLDOWN_MS = 30_000;
+
 export class StatOperations extends VeryfrontOperationsBase {
   private fileIndex: Map<string, ProjectFile> | null = null;
   private directoryIndex: Set<string> | null = null;
@@ -37,8 +40,8 @@ export class StatOperations extends VeryfrontOperationsBase {
   private pathMapping: Map<string, string> = new Map();
 
   private readonly apiSearchCircuitBreaker = new ApiSearchCircuitBreaker({
-    threshold: 5,
-    cooldownMs: 30000,
+    threshold: API_SEARCH_CIRCUIT_BREAKER_THRESHOLD,
+    cooldownMs: API_SEARCH_CIRCUIT_BREAKER_COOLDOWN_MS,
   });
 
   stat(path: string): Promise<FileInfo> {

--- a/src/platform/adapters/token/veryfront/types.ts
+++ b/src/platform/adapters/token/veryfront/types.ts
@@ -91,6 +91,10 @@ function requireVeryfrontConfig(
 /**
  * Create verified config from adapter config
  */
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_INITIAL_RETRY_DELAY_MS = 1_000;
+const DEFAULT_MAX_RETRY_DELAY_MS = 10_000;
+
 export function createTokenConfig(config: TokenStorageAdapterConfig): VeryfrontTokenConfig {
   const veryfront = requireVeryfrontConfig(config);
 
@@ -121,9 +125,9 @@ export function createTokenConfig(config: TokenStorageAdapterConfig): VeryfrontT
     apiToken,
     projectSlug,
     retry: {
-      maxRetries: retry?.maxRetries ?? 3,
-      initialDelay: retry?.initialDelay ?? 1000,
-      maxDelay: retry?.maxDelay ?? 10000,
+      maxRetries: retry?.maxRetries ?? DEFAULT_MAX_RETRIES,
+      initialDelay: retry?.initialDelay ?? DEFAULT_INITIAL_RETRY_DELAY_MS,
+      maxDelay: retry?.maxDelay ?? DEFAULT_MAX_RETRY_DELAY_MS,
     },
   };
 }

--- a/src/platform/adapters/veryfront-api-client/client.ts
+++ b/src/platform/adapters/veryfront-api-client/client.ts
@@ -10,6 +10,11 @@ import { API_CLIENT_ERROR, type VeryfrontAPIConfig } from "./types.ts";
 
 const logger = baseLogger.component("veryfront-api-client");
 
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_INITIAL_RETRY_DELAY_MS = 1_000;
+const DEFAULT_MAX_RETRY_DELAY_MS = 10_000;
+const DEFAULT_SEARCH_LIMIT = 100;
+
 /**
  * File context for API operations.
  * - branch: Draft/working copy from a specific branch
@@ -37,9 +42,9 @@ export class VeryfrontApiClient {
 
   constructor(config: VeryfrontAPIConfig) {
     const retryConfig = {
-      maxRetries: config.retry?.maxRetries ?? 3,
-      initialDelay: config.retry?.initialDelay ?? 1000,
-      maxDelay: config.retry?.maxDelay ?? 10000,
+      maxRetries: config.retry?.maxRetries ?? DEFAULT_MAX_RETRIES,
+      initialDelay: config.retry?.initialDelay ?? DEFAULT_INITIAL_RETRY_DELAY_MS,
+      maxDelay: config.retry?.maxDelay ?? DEFAULT_MAX_RETRY_DELAY_MS,
     };
 
     this.config = { ...config, retry: retryConfig };
@@ -350,7 +355,7 @@ export class VeryfrontApiClient {
   }
 
   async searchFiles(pattern: string): Promise<{ id?: string; path: string }[]> {
-    const result = await this.listFiles({ pattern, limit: 100 });
+    const result = await this.listFiles({ pattern, limit: DEFAULT_SEARCH_LIMIT });
     return result.files.map((f) => ({ id: f.id, path: f.path }));
   }
 
@@ -367,7 +372,7 @@ export class VeryfrontApiClient {
   async searchFilesWithContent(
     pattern: string,
   ): Promise<Array<{ path: string; content: string }>> {
-    const result = await this.listFiles({ pattern, limit: 100 });
+    const result = await this.listFiles({ pattern, limit: DEFAULT_SEARCH_LIMIT });
 
     const filesWithContent: Array<{ path: string; content: string }> = [];
     const filesNeedingContent: string[] = [];

--- a/src/platform/adapters/veryfront-api-client/operations.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.ts
@@ -21,6 +21,8 @@ import { SpanNames } from "#veryfront/observability/tracing/span-names.ts";
 
 const logger = baseLogger.component("api");
 
+const DEFAULT_PAGE_LIMIT = 100;
+
 export type TokenProvider = () => string;
 
 export interface ListFilesOptions {
@@ -52,7 +54,8 @@ export interface FileDetail {
 }
 
 function buildListParams(options: ListFilesOptions): URLSearchParams {
-  const { cursor, limit = 100, pattern, sortBy = "updated_at", sortOrder = "desc" } = options;
+  const { cursor, limit = DEFAULT_PAGE_LIMIT, pattern, sortBy = "updated_at", sortOrder = "desc" } =
+    options;
 
   const params = new URLSearchParams({
     limit: String(limit),
@@ -175,7 +178,11 @@ export class VeryfrontAPIOperations {
     options: Omit<ListFilesOptions, "cursor"> = {},
   ): Promise<ProjectFile[]> {
     const allFiles = await listAllFiles((cursor) =>
-      this.listBranchFiles(projectRef, branchName, { ...options, cursor, limit: 100 })
+      this.listBranchFiles(projectRef, branchName, {
+        ...options,
+        cursor,
+        limit: DEFAULT_PAGE_LIMIT,
+      })
     );
 
     logger.debug("listAllBranchFiles DONE", {
@@ -250,7 +257,11 @@ export class VeryfrontAPIOperations {
     options: Omit<ListFilesOptions, "cursor"> = {},
   ): Promise<ProjectFile[]> {
     const allFiles = await listAllFiles((cursor) =>
-      this.listEnvironmentFiles(projectRef, environmentName, { ...options, cursor, limit: 100 })
+      this.listEnvironmentFiles(projectRef, environmentName, {
+        ...options,
+        cursor,
+        limit: DEFAULT_PAGE_LIMIT,
+      })
     );
 
     logger.debug("listAllEnvironmentFiles", {
@@ -324,7 +335,7 @@ export class VeryfrontAPIOperations {
     options: Omit<ListFilesOptions, "cursor"> = {},
   ): Promise<ProjectFile[]> {
     return listAllFiles((cursor) =>
-      this.listReleaseFiles(projectRef, version, { ...options, cursor, limit: 100 })
+      this.listReleaseFiles(projectRef, version, { ...options, cursor, limit: DEFAULT_PAGE_LIMIT })
     );
   }
 

--- a/src/platform/core-platform.ts
+++ b/src/platform/core-platform.ts
@@ -50,6 +50,9 @@ const UNKNOWN_PLATFORM_MAX_AGENT_STEPS = 5;
 /** Minimum agent steps threshold for generating a warning */
 const MIN_AGENT_STEPS_WARNING_THRESHOLD = 10;
 
+/** CPU time limit below which a platform warning is emitted (60 seconds) */
+const CPU_TIME_WARNING_THRESHOLD_MS = 60_000;
+
 const PLATFORM_CAPABILITIES: Record<Platform, PlatformCapabilities> = {
   deno: {
     canRunMCPServer: true,
@@ -134,7 +137,7 @@ export function getPlatformWarnings(): string[] {
 
   if (
     capabilities.cpuTimeLimit !== null &&
-    capabilities.cpuTimeLimit < UNKNOWN_PLATFORM_CPU_TIME_LIMIT_MS
+    capabilities.cpuTimeLimit < CPU_TIME_WARNING_THRESHOLD_MS
   ) {
     warnings.push(
       `${capabilities.displayName} has CPU time limit of ${capabilities.cpuTimeLimit}ms. Enable streaming for better UX.`,

--- a/src/platform/core-platform.ts
+++ b/src/platform/core-platform.ts
@@ -33,6 +33,23 @@ export function detectPlatform(): Platform {
   return "unknown";
 }
 
+/** CPU time limit for Cloudflare Workers (30 seconds) */
+const CF_WORKERS_CPU_TIME_LIMIT_MS = 30_000;
+/** Memory limit for Cloudflare Workers (128 MB) */
+const CF_WORKERS_MEMORY_LIMIT_MB = 128;
+/** Max agent steps for Cloudflare Workers */
+const CF_WORKERS_MAX_AGENT_STEPS = 3;
+
+/** CPU time limit for unknown platforms (60 seconds) */
+const UNKNOWN_PLATFORM_CPU_TIME_LIMIT_MS = 60_000;
+/** Memory limit for unknown platforms (512 MB) */
+const UNKNOWN_PLATFORM_MEMORY_LIMIT_MB = 512;
+/** Max agent steps for unknown platforms */
+const UNKNOWN_PLATFORM_MAX_AGENT_STEPS = 5;
+
+/** Minimum agent steps threshold for generating a warning */
+const MIN_AGENT_STEPS_WARNING_THRESHOLD = 10;
+
 const PLATFORM_CAPABILITIES: Record<Platform, PlatformCapabilities> = {
   deno: {
     canRunMCPServer: true,
@@ -66,9 +83,9 @@ const PLATFORM_CAPABILITIES: Record<Platform, PlatformCapabilities> = {
   },
   "cloudflare-workers": {
     canRunMCPServer: false,
-    maxAgentSteps: 3,
-    cpuTimeLimit: 30000,
-    memoryLimit: 128,
+    maxAgentSteps: CF_WORKERS_MAX_AGENT_STEPS,
+    cpuTimeLimit: CF_WORKERS_CPU_TIME_LIMIT_MS,
+    memoryLimit: CF_WORKERS_MEMORY_LIMIT_MB,
     hasFileSystem: false,
     supportsLongRunning: false,
     streamingRecommended: true,
@@ -76,9 +93,9 @@ const PLATFORM_CAPABILITIES: Record<Platform, PlatformCapabilities> = {
   },
   unknown: {
     canRunMCPServer: false,
-    maxAgentSteps: 5,
-    cpuTimeLimit: 60000,
-    memoryLimit: 512,
+    maxAgentSteps: UNKNOWN_PLATFORM_MAX_AGENT_STEPS,
+    cpuTimeLimit: UNKNOWN_PLATFORM_CPU_TIME_LIMIT_MS,
+    memoryLimit: UNKNOWN_PLATFORM_MEMORY_LIMIT_MB,
     hasFileSystem: false,
     supportsLongRunning: false,
     streamingRecommended: true,
@@ -109,13 +126,16 @@ export function getPlatformWarnings(): string[] {
     );
   }
 
-  if (capabilities.maxAgentSteps < 10) {
+  if (capabilities.maxAgentSteps < MIN_AGENT_STEPS_WARNING_THRESHOLD) {
     warnings.push(
       `${capabilities.displayName} has limited agent steps (${capabilities.maxAgentSteps}). Use simple agents only.`,
     );
   }
 
-  if (capabilities.cpuTimeLimit !== null && capabilities.cpuTimeLimit < 60000) {
+  if (
+    capabilities.cpuTimeLimit !== null &&
+    capabilities.cpuTimeLimit < UNKNOWN_PLATFORM_CPU_TIME_LIMIT_MS
+  ) {
     warnings.push(
       `${capabilities.displayName} has CPU time limit of ${capabilities.cpuTimeLimit}ms. Enable streaming for better UX.`,
     );

--- a/src/provider/local/ai-sdk-adapter.ts
+++ b/src/provider/local/ai-sdk-adapter.ts
@@ -18,6 +18,9 @@ import { isLocalAIDisabled } from "./env.ts";
 
 const logger = serverLogger.component("local-llm");
 
+/** Default maximum new tokens for local model generation */
+const DEFAULT_MAX_NEW_TOKENS = 512;
+
 /** Shape of a single message in the AI SDK LanguageModelV2 prompt array. */
 interface PromptMessage {
   role: string;
@@ -75,7 +78,7 @@ interface LocalModelOptions {
 /** Map AI SDK generation options to local engine GenerateOptions. */
 function toGenerateOptions(options: LocalModelOptions): GenerateOptions {
   return {
-    maxNewTokens: options.maxOutputTokens ?? 512,
+    maxNewTokens: options.maxOutputTokens ?? DEFAULT_MAX_NEW_TOKENS,
     temperature: options.temperature ?? 0.7,
     topP: options.topP,
     topK: options.topK,

--- a/src/provider/local/local-engine.ts
+++ b/src/provider/local/local-engine.ts
@@ -19,6 +19,9 @@ import { isLocalAIDisabled } from "./env.ts";
 
 const logger = serverLogger.component("local-llm");
 
+/** Default maximum new tokens for local model generation */
+const DEFAULT_MAX_NEW_TOKENS = 512;
+
 /** Chat message format expected by Transformers.js */
 export interface ChatMessage {
   role: "system" | "user" | "assistant";
@@ -226,7 +229,7 @@ export async function* generateStream(
   const transformers = await getTransformers();
 
   const {
-    maxNewTokens = 512,
+    maxNewTokens = DEFAULT_MAX_NEW_TOKENS,
     temperature = 0.7,
     topP,
     topK,

--- a/src/proxy/cache/memory-cache.ts
+++ b/src/proxy/cache/memory-cache.ts
@@ -6,7 +6,7 @@ import type { CacheStats, MemoryCacheOptions, TokenCache, TokenCacheEntry } from
 import { proxyLogger } from "../logger.ts";
 import { withSpan } from "../tracing.ts";
 
-const DEFAULT_MAX_SIZE = 1000;
+const DEFAULT_MAX_SIZE = 1_000;
 const DEFAULT_CLEANUP_INTERVAL = 60_000;
 
 export class MemoryCache implements TokenCache {

--- a/src/proxy/cache/redis-cache.ts
+++ b/src/proxy/cache/redis-cache.ts
@@ -5,8 +5,11 @@ import { proxyLogger } from "../logger.ts";
 
 const logger = proxyLogger.child({ module: "redis-cache" });
 const DEFAULT_PREFIX = "vf:token:";
-const DEFAULT_CONNECT_TIMEOUT = 5000;
+const DEFAULT_CONNECT_TIMEOUT_MS = 5_000;
 const DEFAULT_SCAN_COUNT = 100;
+const MAX_RECONNECT_RETRIES = 3;
+const RECONNECT_BACKOFF_BASE_MS = 100;
+const RECONNECT_BACKOFF_MAX_MS = 3_000;
 
 export class RedisCache implements TokenCache {
   private client: RedisClientType | null = null;
@@ -20,7 +23,7 @@ export class RedisCache implements TokenCache {
   constructor(options: RedisCacheOptions) {
     this.url = options.url;
     this.prefix = options.prefix ?? DEFAULT_PREFIX;
-    this.connectTimeout = options.connectTimeout ?? DEFAULT_CONNECT_TIMEOUT;
+    this.connectTimeout = options.connectTimeout ?? DEFAULT_CONNECT_TIMEOUT_MS;
   }
 
   private key(k: string): string {
@@ -214,9 +217,10 @@ export class RedisCache implements TokenCache {
         socket: {
           connectTimeout: this.connectTimeout,
           reconnectStrategy: (retries) => {
-            // Exponential backoff with max 3 retries
-            if (retries > 3) return new Error("Max reconnection attempts reached");
-            return Math.min(retries * 100, 3000);
+            if (retries > MAX_RECONNECT_RETRIES) {
+              return new Error("Max reconnection attempts reached");
+            }
+            return Math.min(retries * RECONNECT_BACKOFF_BASE_MS, RECONNECT_BACKOFF_MAX_MS);
           },
         },
       });

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -82,7 +82,7 @@ const rendererRouter = (discoveryHost || staticTargets)
   ? new RendererRouter(
     discoveryHost || "static-targets",
     PRODUCTION_SERVER_URL,
-    parseInt(getEnv("VERYFRONT_SERVER_DISCOVERY_INTERVAL_MS") || "15000") || 15000,
+    parseInt(getEnv("VERYFRONT_SERVER_DISCOVERY_INTERVAL_MS") || "15000") || 15_000,
   )
   : null;
 
@@ -93,15 +93,20 @@ const apiInternalPass = getEnv("VERYFRONT_API_INTERNAL_PASS") || "";
 const serverResolver = new ServerResolver(apiInternalUrl, apiInternalUser, apiInternalPass);
 
 const { hostname: HOST, port: PORT } = resolveProxyBinding();
-const WS_CONNECT_TIMEOUT_MS = 30000;
+const WS_CONNECT_TIMEOUT_MS = 30_000;
 // Timeout for forwarding requests to production server (SSR can take time on cold start)
+const DEFAULT_SERVER_REQUEST_TIMEOUT_MS = 90_000;
 const VERYFRONT_SERVER_REQUEST_TIMEOUT_MS = parseInt(
-  getEnv("VERYFRONT_SERVER_REQUEST_TIMEOUT_MS") || "90000",
+  getEnv("VERYFRONT_SERVER_REQUEST_TIMEOUT_MS") || String(DEFAULT_SERVER_REQUEST_TIMEOUT_MS),
 );
 // Retry configuration for transient connection errors
-const VERYFRONT_SERVER_RETRY_COUNT = parseInt(getEnv("VERYFRONT_SERVER_RETRY_COUNT") || "1");
+const DEFAULT_SERVER_RETRY_COUNT = 1;
+const DEFAULT_SERVER_RETRY_DELAY_MS = 100;
+const VERYFRONT_SERVER_RETRY_COUNT = parseInt(
+  getEnv("VERYFRONT_SERVER_RETRY_COUNT") || String(DEFAULT_SERVER_RETRY_COUNT),
+);
 const VERYFRONT_SERVER_RETRY_DELAY_MS = parseInt(
-  getEnv("VERYFRONT_SERVER_RETRY_DELAY_MS") || "100",
+  getEnv("VERYFRONT_SERVER_RETRY_DELAY_MS") || String(DEFAULT_SERVER_RETRY_DELAY_MS),
 );
 
 // Initialize cache and proxy handler

--- a/src/proxy/oauth-client.ts
+++ b/src/proxy/oauth-client.ts
@@ -4,7 +4,7 @@
 
 import { injectContext, ProxySpanNames, withSpan } from "./tracing.ts";
 
-const DEFAULT_TIMEOUT_MS = 10000;
+const DEFAULT_TIMEOUT_MS = 10_000;
 
 export interface TokenResponse {
   access_token: string;

--- a/src/proxy/renderer-router.ts
+++ b/src/proxy/renderer-router.ts
@@ -28,7 +28,7 @@ export function jumpHash(keyStr: string, numBuckets: number): number {
   return Number(b);
 }
 
-const MAX_STALENESS_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_STALENESS_MS = 5 * 60 * 1_000; // 5 minutes
 
 export class RendererRouter {
   private targets: string[] = [];

--- a/src/proxy/token-manager.ts
+++ b/src/proxy/token-manager.ts
@@ -11,8 +11,10 @@ interface NegativeCacheEntry {
   cachedAt: number;
 }
 
-const NEGATIVE_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
-const NEGATIVE_CACHE_MAX_SIZE = 1000;
+const NEGATIVE_CACHE_TTL_MS = 5 * 60 * 1_000; // 5 minutes
+const NEGATIVE_CACHE_MAX_SIZE = 1_000;
+const DEFAULT_REFRESH_BUFFER_MS = 2 * 60 * 1_000; // 2 minutes before expiry
+const DEFAULT_TOKEN_TTL_MS = 3_600 * 1_000; // 1 hour
 
 export interface OAuthConfig {
   apiBaseUrl: string;
@@ -38,7 +40,7 @@ export class TokenManager {
     options: TokenManagerOptions = {},
   ) {
     this.cache = options.cache ?? new MemoryCache();
-    this.refreshBuffer = options.refreshBuffer ?? 2 * 60 * 1000; // 2 minutes before expiry
+    this.refreshBuffer = options.refreshBuffer ?? DEFAULT_REFRESH_BUFFER_MS;
   }
 
   async getToken(
@@ -54,7 +56,7 @@ export class TokenManager {
       async () => {
         const negEntry = this.negativeCache.get(cacheKey);
         if (negEntry) {
-          if (Date.now() - negEntry.cachedAt < NEGATIVE_CACHE_TTL) {
+          if (Date.now() - negEntry.cachedAt < NEGATIVE_CACHE_TTL_MS) {
             throw new Error(negEntry.message);
           }
           this.negativeCache.delete(cacheKey);
@@ -172,7 +174,7 @@ export class TokenManager {
 
     try {
       const payload = response.access_token.split(".")[1];
-      if (!payload) return Date.now() + 3600 * 1000;
+      if (!payload) return Date.now() + DEFAULT_TOKEN_TTL_MS;
 
       const decoded = JSON.parse(atob(payload));
       if (decoded?.exp) return decoded.exp * 1000;
@@ -180,6 +182,6 @@ export class TokenManager {
       // Fall through to default
     }
 
-    return Date.now() + 3600 * 1000;
+    return Date.now() + DEFAULT_TOKEN_TTL_MS;
   }
 }

--- a/src/rendering/cache/cache-coordinator.ts
+++ b/src/rendering/cache/cache-coordinator.ts
@@ -4,6 +4,9 @@ import type { CachePayload, CacheStore } from "./types.ts";
 import { MemoryCacheStore, type MemoryCacheStoreOptions } from "./stores/index.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 
+/** Default TTL for cache entries (5 minutes) */
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1_000;
+
 export interface CacheCoordinatorOptions {
   store?: CacheStore;
   memory?: MemoryCacheStoreOptions;
@@ -37,7 +40,7 @@ export interface CacheLookupResult {
 export class CacheCoordinator {
   private store: CacheStore;
   private ttlMs: number | undefined;
-  private readonly defaultTtlMs = 5 * 60 * 1000; // 5 minutes
+  private readonly defaultTtlMs = DEFAULT_CACHE_TTL_MS;
   private readonly projectId: string | undefined;
   private readonly contentSourceId: string | undefined;
   private readonly cachePrefix: string;

--- a/src/rendering/cache/stores/api-store.ts
+++ b/src/rendering/cache/stores/api-store.ts
@@ -5,6 +5,11 @@ import { type CacheBackend, createCacheBackend } from "#veryfront/cache/backend.
 
 const logger = rendererLogger.component("api-cache-store");
 
+/** Default TTL for distributed cache entries (1 hour) */
+const DEFAULT_TTL_SECONDS = 3_600;
+/** Default max entries for the local memory cache (fast reads) */
+const DEFAULT_LOCAL_MAX_ENTRIES = 200;
+
 export interface APICacheStoreOptions {
   /** Key prefix for cache entries */
   keyPrefix?: string;
@@ -47,12 +52,12 @@ export class APICacheStore implements CacheStore {
 
   constructor(options: APICacheStoreOptions = {}) {
     this.keyPrefix = options.keyPrefix ?? "render";
-    this.ttlSeconds = options.ttlSeconds ?? 3600; // 1 hour default
+    this.ttlSeconds = options.ttlSeconds ?? DEFAULT_TTL_SECONDS;
 
     const enableLocalCache = options.enableLocalCache ?? true;
     this.localCache = enableLocalCache
       ? new MemoryCacheStore({
-        maxEntries: options.localMaxEntries ?? 200,
+        maxEntries: options.localMaxEntries ?? DEFAULT_LOCAL_MAX_ENTRIES,
         ttlMs: this.ttlSeconds * 1000,
       })
       : null;

--- a/src/rendering/cache/stores/redis-store.ts
+++ b/src/rendering/cache/stores/redis-store.ts
@@ -16,7 +16,13 @@ interface RedisClient {
 }
 
 /** Default TTL for Redis cache entries (1 hour) */
-const DEFAULT_TTL_SECONDS = 3600;
+const DEFAULT_TTL_SECONDS = 3_600;
+/** Max entries for the in-memory fallback cache when Redis is unavailable */
+const FALLBACK_MAX_ENTRIES = 100;
+/** Number of keys to scan per Redis SCAN iteration */
+const REDIS_SCAN_COUNT = 100;
+/** Smaller scan batch size for clear operations (deletes each key inline) */
+const REDIS_CLEAR_SCAN_COUNT = 50;
 
 export interface RedisCacheStoreOptions {
   url?: string;
@@ -46,9 +52,9 @@ export class RedisCacheStore implements CacheStore {
   private getFallbackStore(): MemoryCacheStore {
     if (this.fallbackStore) return this.fallbackStore;
 
-    // Small fallback cache (100 entries) for when Redis is unavailable
+    // Small fallback cache for when Redis is unavailable
     this.fallbackStore = new MemoryCacheStore({
-      maxEntries: 100,
+      maxEntries: FALLBACK_MAX_ENTRIES,
       ttlMs: this.ttlSeconds * 1000,
     });
     logger.warn("Redis unavailable, using memory cache fallback");
@@ -189,7 +195,7 @@ export class RedisCacheStore implements CacheStore {
       do {
         const [nextCursor, keys] = await client.scan(cursor, {
           MATCH: `${this.keyPrefix}${prefix}*`,
-          COUNT: 100,
+          COUNT: REDIS_SCAN_COUNT,
         });
         cursor = nextCursor;
         if (keys.length) keysToDelete.push(...keys);
@@ -225,7 +231,7 @@ export class RedisCacheStore implements CacheStore {
       do {
         const [nextCursor, keys] = await client.scan(cursor, {
           MATCH: `${this.keyPrefix}*`,
-          COUNT: 50,
+          COUNT: REDIS_CLEAR_SCAN_COUNT,
         });
         cursor = nextCursor;
 

--- a/src/rendering/component-handling.ts
+++ b/src/rendering/component-handling.ts
@@ -24,7 +24,7 @@ export interface ComponentPageResult {
  * Safe for multi-tenant use (project-scoped + content-hashed).
  * Evicted when exceeding MAX_COMPONENT_CACHE_SIZE to prevent unbounded memory growth.
  */
-const MAX_COMPONENT_CACHE_SIZE = 5000;
+const MAX_COMPONENT_CACHE_SIZE = 5_000;
 const componentHydrationCache = new LRUCache<string, string>({
   maxEntries: MAX_COMPONENT_CACHE_SIZE,
 });

--- a/src/rendering/orchestrator/css-cache.ts
+++ b/src/rendering/orchestrator/css-cache.ts
@@ -10,7 +10,7 @@
 import type { CacheRepository } from "#veryfront/repositories/types.ts";
 
 /** Timeout for CSS generation SSR (shorter than full SSR since it's optional) */
-export const CSS_SSR_TIMEOUT_MS = 5000;
+export const CSS_SSR_TIMEOUT_MS = 5_000;
 
 /**
  * Per-page CSS cache to avoid redundant SSR for CSS generation.

--- a/src/rendering/orchestrator/css-candidate-manifest.ts
+++ b/src/rendering/orchestrator/css-candidate-manifest.ts
@@ -25,7 +25,7 @@ interface RouteCandidateOptions {
 
 const logger = rendererLogger.component("css-candidate-manifest");
 const SOURCE_EXTENSIONS = [".tsx", ".jsx", ".mdx", ".ts", ".js"];
-const DEV_MANIFEST_TTL_MS = 2000;
+const DEV_MANIFEST_TTL_MS = 2_000;
 
 const manifestCache = new Map<string, CandidateManifest>();
 const routeCandidateCache = new Map<string, Set<string>>();

--- a/src/rendering/orchestrator/lifecycle.ts
+++ b/src/rendering/orchestrator/lifecycle.ts
@@ -25,6 +25,11 @@ import { CompilerService } from "./compiler-service.ts";
 
 const logger = rendererLogger.component("lifecycle");
 
+/** Default max cache entries for debug mode */
+const DEBUG_MODE_MAX_ENTRIES = 50;
+/** Default max cache entries for production mode */
+const PRODUCTION_MAX_ENTRIES = 500;
+
 export interface LifecycleOptions {
   configManager: ConfigurationManager;
   port: number;
@@ -117,7 +122,8 @@ export class RendererLifecycle {
       case "memory":
       default:
         cacheStore = new MemoryCacheStore({
-          maxEntries: renderCacheConfig.maxEntries ?? (debugMode ? 50 : 500),
+          maxEntries: renderCacheConfig.maxEntries ??
+            (debugMode ? DEBUG_MODE_MAX_ENTRIES : PRODUCTION_MAX_ENTRIES),
           ttlMs: renderCacheConfig.ttl,
         });
         break;

--- a/src/rendering/orchestrator/module-collection.ts
+++ b/src/rendering/orchestrator/module-collection.ts
@@ -8,7 +8,7 @@
  */
 
 /** Timeout for module loading in resolvePageData (prevents hanging on slow transforms) */
-export const MODULE_LOAD_TIMEOUT_MS = 10000;
+export const MODULE_LOAD_TIMEOUT_MS = 10_000;
 
 /** Timeout for data fetching (getStaticData, getServerData) */
 export const DATA_FETCH_TIMEOUT_MS = 15_000;

--- a/src/rendering/orchestrator/module-loader/index.ts
+++ b/src/rendering/orchestrator/module-loader/index.ts
@@ -41,7 +41,7 @@ export { createEsmCache, createModuleCache, generateHash } from "./cache.ts";
 export { fetchEsmModule, rewriteEsmPaths } from "./esm-rewriter.ts";
 
 /** Maximum number of directories to track to prevent memory leaks */
-const MAX_CREATED_DIRS = 5000;
+const MAX_CREATED_DIRS = 5_000;
 
 /** Cache for created directories to avoid repeated mkdir calls (LRU-style) */
 const createdDirs = new Set<string>();

--- a/src/rendering/renderer-concurrency.ts
+++ b/src/rendering/renderer-concurrency.ts
@@ -36,7 +36,7 @@ export const RENDER_PER_PROJECT_LIMIT = getEnvNumber("RENDER_PER_PROJECT_LIMIT")
  * Timeout for acquiring render permit (ms).
  * If semaphore cannot be acquired within this time, request fails fast with 503.
  */
-export const RENDER_ACQUIRE_TIMEOUT_MS = 5000;
+export const RENDER_ACQUIRE_TIMEOUT_MS = 5_000;
 
 /** Maximum time to wait for a project lock before giving up (10 seconds) */
 export const LOCK_TIMEOUT_MS = 10_000;

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -88,7 +88,9 @@ const logger = rendererLogger.component("renderer");
  * Configurable via RENDER_TIMEOUT_MS env var for cold-start scenarios.
  * Default increased to 60s to handle cold-start module transforms.
  */
-const RENDER_PIPELINE_TIMEOUT_MS = getEnvNumber("RENDER_TIMEOUT_MS") ?? 60000;
+const DEFAULT_RENDER_PIPELINE_TIMEOUT_MS = 60_000;
+const RENDER_PIPELINE_TIMEOUT_MS = getEnvNumber("RENDER_TIMEOUT_MS") ??
+  DEFAULT_RENDER_PIPELINE_TIMEOUT_MS;
 
 /**
  * Options for initializing the Renderer

--- a/src/rendering/router-detection.ts
+++ b/src/rendering/router-detection.ts
@@ -18,9 +18,12 @@ import { SpanNames } from "#veryfront/observability/tracing/span-names.ts";
 // Re-export from app-route-resolver for backward compatibility
 export { getAppRouteEntity } from "./app-route-resolver.ts";
 
+const ROUTER_DETECTION_CACHE_MAX_ENTRIES = 200;
+const ROUTER_DETECTION_CACHE_TTL_MS = 60_000;
+
 const routerDetectionCache = new LRUCache<string, boolean>({
-  maxEntries: 200,
-  ttlMs: 60_000,
+  maxEntries: ROUTER_DETECTION_CACHE_MAX_ENTRIES,
+  ttlMs: ROUTER_DETECTION_CACHE_TTL_MS,
 });
 
 /**

--- a/src/rendering/rsc/constants.ts
+++ b/src/rendering/rsc/constants.ts
@@ -1,6 +1,6 @@
 import { INTERNAL_PATH_PREFIXES } from "#veryfront/utils/constants/server.ts";
 
-export const RSC_FILE_READ_BUFFER_SIZE = 2048;
+export const RSC_FILE_READ_BUFFER_SIZE = 2_048;
 export const RSC_PATH_PREFIX = INTERNAL_PATH_PREFIXES.RSC;
 export const FS_PATH_PREFIX = INTERNAL_PATH_PREFIXES.FS;
 export const HYDRATION_DATA_ID = "veryfront-hydration-data";

--- a/src/rendering/shared/context-aware-cache.ts
+++ b/src/rendering/shared/context-aware-cache.ts
@@ -9,6 +9,11 @@ import { createCacheKey } from "../context/render-context.ts";
 
 const logger = rendererLogger.component("context-aware-cache");
 
+/** Default TTL for context-aware cache entries (5 minutes) */
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1_000;
+/** Default max entries for the in-memory cache store */
+const DEFAULT_MAX_ENTRIES = 500;
+
 export interface ContextAwareCacheOptions {
   store?: CacheStore;
   memory?: MemoryCacheStoreOptions;
@@ -32,13 +37,13 @@ export interface ContextAwareCacheLookupResult {
 export class ContextAwareCacheCoordinator {
   private store: CacheStore;
   private ttlMs: number | undefined;
-  private readonly defaultTtlMs = 5 * 60 * 1000; // 5 minutes
+  private readonly defaultTtlMs = DEFAULT_CACHE_TTL_MS;
 
   constructor(options: ContextAwareCacheOptions = {}) {
     this.ttlMs = options.ttlMs ?? this.defaultTtlMs;
     this.store = options.store ??
       new MemoryCacheStore({
-        maxEntries: options.memory?.maxEntries ?? 500,
+        maxEntries: options.memory?.maxEntries ?? DEFAULT_MAX_ENTRIES,
         ttlMs: options.memory?.ttlMs ?? this.ttlMs,
       });
   }

--- a/src/rendering/snippet-renderer.ts
+++ b/src/rendering/snippet-renderer.ts
@@ -15,8 +15,9 @@ import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 const logger = rendererLogger.component("snippet-renderer");
 
 const SNIPPET_CACHE_MAX_ENTRIES = 500;
-const SNIPPET_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const SNIPPET_CACHE_TTL_MS = 10 * 60 * 1_000; // 10 minutes
 const SNIPPET_DISTRIBUTED_CACHE_TTL_SECONDS = 600; // 10 minutes for distributed cache
+const SNIPPET_CACHE_CLEANUP_INTERVAL_MS = 60_000;
 
 export interface SnippetRenderOptions {
   mode: "development" | "production";
@@ -47,7 +48,7 @@ interface SnippetCacheEntry {
 const snippetCache = new LRUCache<string, SnippetCacheEntry>({
   maxEntries: SNIPPET_CACHE_MAX_ENTRIES,
   ttlMs: SNIPPET_CACHE_TTL_MS,
-  cleanupIntervalMs: 60000,
+  cleanupIntervalMs: SNIPPET_CACHE_CLEANUP_INTERVAL_MS,
 });
 
 registerCache("snippet-cache", () => ({

--- a/src/rendering/ssr-globals/dom-stubs.ts
+++ b/src/rendering/ssr-globals/dom-stubs.ts
@@ -5,6 +5,11 @@ const noopNull = (): null => null;
 const noopEmptyArray = (): [] => [];
 const emptyString = "";
 
+/** Default SSR viewport width for window stub */
+const SSR_VIEWPORT_WIDTH = 1_024;
+/** Default SSR viewport height for window stub */
+const SSR_VIEWPORT_HEIGHT = 768;
+
 function createClassListStub(): {
   add: () => void;
   remove: () => void;
@@ -342,10 +347,10 @@ export function createWindowStub(): {
       forward: noop,
     },
 
-    innerWidth: 1024,
-    innerHeight: 768,
-    outerWidth: 1024,
-    outerHeight: 768,
+    innerWidth: SSR_VIEWPORT_WIDTH,
+    innerHeight: SSR_VIEWPORT_HEIGHT,
+    outerWidth: SSR_VIEWPORT_WIDTH,
+    outerHeight: SSR_VIEWPORT_HEIGHT,
     screenX: 0,
     screenY: 0,
     pageXOffset: 0,

--- a/src/rendering/ssr/mdx-module-loader.ts
+++ b/src/rendering/ssr/mdx-module-loader.ts
@@ -11,10 +11,12 @@ import type { MDXModule } from "./types.ts";
 
 const logger = rendererLogger.component("mdx");
 
+const MDX_CACHE_CLEANUP_INTERVAL_MS = 60_000;
+
 const mdxModuleCache = new LRUCache<string, MDXModule>({
   maxEntries: MDX_RENDERER_MAX_ENTRIES,
   ttlMs: MDX_RENDERER_TTL_MS,
-  cleanupIntervalMs: 60000,
+  cleanupIntervalMs: MDX_CACHE_CLEANUP_INTERVAL_MS,
 });
 
 registerCache("mdx-module-cache", () => ({

--- a/src/routing/api/api-route-matcher.ts
+++ b/src/routing/api/api-route-matcher.ts
@@ -2,6 +2,12 @@ import type { Route, RouteMatch } from "#veryfront/routing/matchers/types.ts";
 import { getDisableLruIntervalEnv } from "#veryfront/config/env.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 
+/** Max entries in the route-match LRU cache */
+const ROUTE_CACHE_MAX_ENTRIES = 500;
+
+/** Time-to-live for cached route matches (5 minutes) */
+const ROUTE_CACHE_TTL_MS = 5 * 60 * 1_000;
+
 export type { Route, RouteMatch };
 
 /** Route entry with compiled regex and metadata */
@@ -25,8 +31,8 @@ export class ApiRouteMatcher {
   constructor() {
     const disableIntervals = shouldDisableLruInterval();
     this.routeCache = new LRUCache<string, RouteMatch | null>({
-      maxEntries: 500,
-      ttlMs: disableIntervals ? undefined : 5 * 60 * 1000,
+      maxEntries: ROUTE_CACHE_MAX_ENTRIES,
+      ttlMs: disableIntervals ? undefined : ROUTE_CACHE_TTL_MS,
     });
   }
 

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -15,6 +15,9 @@ import { discoverAppRoutes, discoverPagesRoutes } from "./route-discovery.ts";
 import { executeAppRoute, executePagesRoute } from "./route-executor.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 
+/** Max entries in the loaded-handler LRU cache */
+const HANDLER_CACHE_MAX_ENTRIES = 256;
+
 export type { APIContext, APIRoute };
 
 /**
@@ -55,7 +58,7 @@ export type APIHandler = (ctx: APIContext) => Promise<Response> | Response;
 
 export class APIRouteHandler {
   private router = new DynamicRouter();
-  private routeCache = new LRUCache<string, APIRoute>({ maxEntries: 256 });
+  private routeCache = new LRUCache<string, APIRoute>({ maxEntries: HANDLER_CACHE_MAX_ENTRIES });
   private lastErrorMessage: string | null = null;
 
   private adapter: RuntimeAdapter | null;

--- a/src/security/http/response/security-handler.ts
+++ b/src/security/http/response/security-handler.ts
@@ -2,8 +2,14 @@ import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { recordSecurityHeaders } from "#veryfront/observability";
 import type { SecurityConfig } from "./types.ts";
 
+/** HSTS max-age default: 1 year in seconds */
+const HSTS_MAX_AGE_SECONDS = 31_536_000;
+
+/** Number of random bytes used to generate CSP nonces */
+const NONCE_BYTE_LENGTH = 16;
+
 export function generateNonce(): string {
-  const array = new Uint8Array(16);
+  const array = new Uint8Array(NONCE_BYTE_LENGTH);
   crypto.getRandomValues(array);
   return btoa(String.fromCharCode(...array));
 }
@@ -82,7 +88,7 @@ export function applySecurityHeaders(
   if (csp) headers.set("Content-Security-Policy", csp);
 
   if (!isDev) {
-    const hstsMaxAge = config?.hsts?.maxAge ?? 31536000;
+    const hstsMaxAge = config?.hsts?.maxAge ?? HSTS_MAX_AGE_SECONDS;
     const hstsIncludeSubDomains = config?.hsts?.includeSubDomains ?? true;
     const hstsPreload = config?.hsts?.preload ?? false;
 

--- a/src/security/rate-limit/memory-store.ts
+++ b/src/security/rate-limit/memory-store.ts
@@ -1,7 +1,7 @@
 import type { RateLimitState, RateLimitStore } from "./types.ts";
 
-const MAX_TIMESTAMPS_PER_KEY = 1000;
-const WINDOW_MS = 60000;
+const MAX_TIMESTAMPS_PER_KEY = 1_000;
+const WINDOW_MS = 60_000;
 
 export class MemoryRateLimitStore implements RateLimitStore {
   private store = new Map<string, RateLimitState>();

--- a/src/security/rate-limit/middleware.ts
+++ b/src/security/rate-limit/middleware.ts
@@ -3,6 +3,21 @@ import type { RateLimitConfig, RateLimitStore } from "./types.ts";
 import { MemoryRateLimitStore } from "./memory-store.ts";
 import { fixedWindowStrategy, slidingWindowStrategy, tokenBucketStrategy } from "./strategies.ts";
 
+/** Rate limit preset: window durations */
+const STRICT_WINDOW_MS = 60_000; // 1 minute
+const MODERATE_WINDOW_MS = 60_000; // 1 minute
+const LENIENT_WINDOW_MS = 3_600_000; // 1 hour
+const AUTH_WINDOW_MS = 900_000; // 15 minutes
+
+/** Rate limit preset: max requests per window */
+const STRICT_MAX_REQUESTS = 10;
+const MODERATE_MAX_REQUESTS = 100;
+const LENIENT_MAX_REQUESTS = 1_000;
+const AUTH_MAX_REQUESTS = 5;
+
+/** Default Retry-After header value in seconds */
+const DEFAULT_RETRY_AFTER_SECONDS = "60";
+
 function defaultKeyGenerator(request: Request): string {
   const forwardedFor = request.headers.get("x-forwarded-for");
   if (forwardedFor) {
@@ -22,7 +37,7 @@ function defaultRateLimitExceeded(_request: Request, _key: string, message: stri
       status: 429,
       headers: {
         "Content-Type": "application/json",
-        "Retry-After": "60",
+        "Retry-After": DEFAULT_RETRY_AFTER_SECONDS,
       },
     },
   );
@@ -111,32 +126,32 @@ export function createRateLimiter(
 export const RateLimitPresets = {
   strict: (store?: RateLimitStore) =>
     createRateLimiter({
-      maxRequests: 10,
-      windowMs: 60000,
+      maxRequests: STRICT_MAX_REQUESTS,
+      windowMs: STRICT_WINDOW_MS,
       strategy: "sliding-window",
       store,
     }),
 
   moderate: (store?: RateLimitStore) =>
     createRateLimiter({
-      maxRequests: 100,
-      windowMs: 60000,
+      maxRequests: MODERATE_MAX_REQUESTS,
+      windowMs: MODERATE_WINDOW_MS,
       strategy: "fixed-window",
       store,
     }),
 
   lenient: (store?: RateLimitStore) =>
     createRateLimiter({
-      maxRequests: 1000,
-      windowMs: 3600000,
+      maxRequests: LENIENT_MAX_REQUESTS,
+      windowMs: LENIENT_WINDOW_MS,
       strategy: "fixed-window",
       store,
     }),
 
   auth: (store?: RateLimitStore) =>
     createRateLimiter({
-      maxRequests: 5,
-      windowMs: 900000,
+      maxRequests: AUTH_MAX_REQUESTS,
+      windowMs: AUTH_WINDOW_MS,
       strategy: "sliding-window",
       message: "Too many authentication attempts. Please try again later.",
       store,

--- a/src/server/dev-server/error-overlay/html-template.ts
+++ b/src/server/dev-server/error-overlay/html-template.ts
@@ -1,6 +1,15 @@
 import { type ErrorInfo, formatErrorType } from "./error-formatter.ts";
 import { escapeHtml } from "#veryfront/html/html-escape.ts";
 
+/** Base delay multiplied by attempt count for WebSocket reconnection */
+const WS_RECONNECT_BASE_DELAY_MS = 1_000;
+
+/** Maximum delay between WebSocket reconnection attempts */
+const WS_RECONNECT_MAX_DELAY_MS = 5_000;
+
+/** Maximum number of WebSocket reconnection attempts before giving up */
+const WS_MAX_RECONNECT_ATTEMPTS = 10;
+
 export function generateRuntimeScript(): string {
   return `
     // Veryfront Error Overlay Runtime
@@ -279,7 +288,7 @@ export function generateErrorHTML(errorInfo: ErrorInfo, suggestion?: string): st
       const wsUrl = protocol + '//' + window.location.host + '/_ws';
       let ws = null;
       let reconnectAttempts = 0;
-      const maxReconnectAttempts = 10;
+      const maxReconnectAttempts = ${WS_MAX_RECONNECT_ATTEMPTS};
 
       function connect() {
         if (reconnectAttempts >= maxReconnectAttempts) return;
@@ -295,7 +304,7 @@ export function generateErrorHTML(errorInfo: ErrorInfo, suggestion?: string): st
         };
         ws.onclose = () => {
           reconnectAttempts++;
-          setTimeout(connect, Math.min(1000 * reconnectAttempts, 5000));
+          setTimeout(connect, Math.min(${WS_RECONNECT_BASE_DELAY_MS} * reconnectAttempts, ${WS_RECONNECT_MAX_DELAY_MS}));
         };
       }
       connect();

--- a/src/server/dev-ui/dashboard/components/RuntimeTab.tsx
+++ b/src/server/dev-ui/dashboard/components/RuntimeTab.tsx
@@ -2,6 +2,9 @@ import { useEffect, useState } from "react";
 import { Card } from "./Card.tsx";
 import { ErrorState, LoadingState, PageLayout } from "./shared.tsx";
 
+/** How often the dashboard auto-refreshes runtime metrics and memory data */
+const AUTO_REFRESH_INTERVAL_MS = 15_000;
+
 type SubTab = "metrics" | "memory";
 
 interface HeapStats {
@@ -55,7 +58,7 @@ export function RuntimeTab(): React.JSX.Element {
 
   useEffect(() => {
     loadData();
-    const interval = setInterval(loadData, 15000);
+    const interval = setInterval(loadData, AUTO_REFRESH_INTERVAL_MS);
     return () => clearInterval(interval);
   }, []);
 

--- a/src/server/dev-ui/projects/App.tsx
+++ b/src/server/dev-ui/projects/App.tsx
@@ -4,6 +4,9 @@ import { Header } from "./components/Header.tsx";
 import { ProjectCard } from "./components/ProjectCard.tsx";
 import { SearchInput } from "./components/SearchInput.tsx";
 
+/** Maximum projects to fetch per request */
+const PROJECTS_FETCH_LIMIT = 100;
+
 interface Project {
   id: string;
   name: string;
@@ -45,7 +48,7 @@ export function App(): React.JSX.Element {
       const params = new URLSearchParams({
         sort_by: "updated_at",
         sort_order: "desc",
-        limit: "100",
+        limit: String(PROJECTS_FETCH_LIMIT),
       });
 
       if (searchQuery) params.set("search", searchQuery);

--- a/src/server/handlers/dev/dashboard/api.ts
+++ b/src/server/handlers/dev/dashboard/api.ts
@@ -25,6 +25,8 @@ import { getLogBuffer } from "#veryfront/observability/log-buffer.ts";
 import { ReloadNotifier } from "../../../reload-notifier.ts";
 import type { HandlerContext } from "../../types.ts";
 
+const WORKFLOW_EXECUTION_TIMEOUT_MS = 30_000;
+
 const JSON_HEADERS = {
   "Content-Type": "application/json",
   "Cache-Control": "no-cache",
@@ -307,11 +309,13 @@ async function handleStartWorkflow(req: Request): Promise<Response> {
     const startTime = Date.now();
     const handle = await client.start(workflowId, (input as Record<string, unknown>) ?? {});
 
-    const timeoutMs = 30000;
     const result = await Promise.race([
       handle.result(),
       new Promise((_, reject) =>
-        setTimeout(() => reject(new Error("Workflow execution timed out (30s)")), timeoutMs)
+        setTimeout(
+          () => reject(new Error("Workflow execution timed out (30s)")),
+          WORKFLOW_EXECUTION_TIMEOUT_MS,
+        )
       ),
     ]);
 

--- a/src/server/handlers/dev/dashboard/ui-handler.ts
+++ b/src/server/handlers/dev/dashboard/ui-handler.ts
@@ -7,7 +7,7 @@ import devUiManifest from "#veryfront/server/dev-ui/manifest.json" with { type: 
 const logger = baseLogger.component("dev-dashboard");
 
 const moduleCache = new Map<string, { code: string; timestamp: number }>();
-const CACHE_TTL = 5000;
+const CACHE_TTL_MS = 5_000;
 
 const JS_HEADERS = {
   "Content-Type": "application/javascript",
@@ -82,7 +82,7 @@ export function handleDashboardUI(req: Request): Promise<Response | null> {
 
       const now = Date.now();
       const cached = moduleCache.get(filePath);
-      if (cached && now - cached.timestamp < CACHE_TTL) {
+      if (cached && now - cached.timestamp < CACHE_TTL_MS) {
         return new Response(cached.code, { headers: JS_HEADERS });
       }
 

--- a/src/server/handlers/dev/endpoints.handler.ts
+++ b/src/server/handlers/dev/endpoints.handler.ts
@@ -10,6 +10,8 @@ import { getHMRScript, getPreviewHMRScript } from "./scripts/hmr-scripts.ts";
 import { getErrorOverlay } from "./scripts/error-overlay.ts";
 import { getHydrateScript } from "./scripts/dev-loader.ts";
 
+const DEFAULT_HMR_PORT = "3000";
+
 export class DevEndpointsHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "DevEndpointsHandler",
@@ -44,7 +46,7 @@ export class DevEndpointsHandler extends BaseHandler {
   private getScriptForPath(pathname: string, url: URL): string | null {
     switch (pathname) {
       case "/_veryfront/hmr.js": {
-        const port = url.searchParams.get("port") ?? "3000";
+        const port = url.searchParams.get("port") ?? DEFAULT_HMR_PORT;
         return getHMRScript(parseInt(port, 10));
       }
       case "/_veryfront/hydrate.js": {

--- a/src/server/handlers/dev/projects/ui-handler.ts
+++ b/src/server/handlers/dev/projects/ui-handler.ts
@@ -7,7 +7,7 @@ import devUiManifest from "#veryfront/server/dev-ui/manifest.json" with { type: 
 const logger = baseLogger.component("projects");
 
 const moduleCache = new Map<string, { code: string; timestamp: number }>();
-const CACHE_TTL = 5000;
+const CACHE_TTL_MS = 5_000;
 
 const JS_HEADERS = {
   "Content-Type": "application/javascript",
@@ -105,7 +105,7 @@ export function handleProjectsUI(req: Request): Promise<Response | null> {
 
       const cached = moduleCache.get(filePath);
       const now = Date.now();
-      if (cached && now - cached.timestamp < CACHE_TTL) {
+      if (cached && now - cached.timestamp < CACHE_TTL_MS) {
         return new Response(cached.code, { headers: JS_HEADERS });
       }
 

--- a/src/server/handlers/dev/scripts/hmr-scripts.ts
+++ b/src/server/handlers/dev/scripts/hmr-scripts.ts
@@ -147,10 +147,10 @@ function generateHMRClient(opts: HMRScriptOptions): string {
   let lastReloadAt = 0;
 
   const RECONNECT_BASE_DELAY_MS = 500;
-  const RECONNECT_MAX_DELAY_MS = 5000;
-  const RELOAD_THROTTLE_MS = 2000;
-  const PING_INTERVAL_MS = 30000;
-  const PONG_TIMEOUT_MS = 90000;
+  const RECONNECT_MAX_DELAY_MS = 5_000;
+  const RELOAD_THROTTLE_MS = 2_000;
+  const PING_INTERVAL_MS = 30_000;
+  const PONG_TIMEOUT_MS = 90_000;
 
   let pingIntervalId = null;
   let lastPongAt = Date.now();

--- a/src/server/handlers/monitoring/client-log.handler.ts
+++ b/src/server/handlers/monitoring/client-log.handler.ts
@@ -11,6 +11,12 @@ const logger = serverLogger.component("client-log-handler");
 /** Max body size for client log payloads (64 KB) */
 const CLIENT_LOG_MAX_BODY_BYTES = 64 * 1024;
 
+/** Max length of the log message field */
+const CLIENT_LOG_MESSAGE_MAX_LENGTH = 5_000;
+
+/** Max chars of raw body shown in parse-error diagnostics */
+const CLIENT_LOG_BODY_PREVIEW_LENGTH = 500;
+
 export class ClientLogHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "ClientLogHandler",
@@ -36,7 +42,7 @@ export class ClientLogHandler extends BaseHandler {
 
       const level = typeof logData?.level === "string" ? logData.level : "info";
       const message = typeof logData?.message === "string"
-        ? logData.message.slice(0, 5000)
+        ? logData.message.slice(0, CLIENT_LOG_MESSAGE_MAX_LENGTH)
         : "[invalid message]";
       const details = logData?.details && typeof logData.details === "object"
         ? logData.details
@@ -91,8 +97,8 @@ export class ClientLogHandler extends BaseHandler {
       getErrorMessage(e),
     );
     serverLogger.error(
-      "[ClientLogHandler] Raw body received (first 500 chars):",
-      body.slice(0, 500),
+      `[ClientLogHandler] Raw body received (first ${CLIENT_LOG_BODY_PREVIEW_LENGTH} chars):`,
+      body.slice(0, CLIENT_LOG_BODY_PREVIEW_LENGTH),
     );
     logger.error("Body length:", body.length);
 

--- a/src/server/handlers/monitoring/memory.handler.ts
+++ b/src/server/handlers/monitoring/memory.handler.ts
@@ -17,6 +17,9 @@ import { rendererLogger } from "#veryfront/utils";
 
 const logger = rendererLogger.component("memory-debug-handler");
 
+/** Delay after forcing GC before re-measuring heap, so the runtime can settle */
+const GC_SETTLE_DELAY_MS = 200;
+
 export class MemoryDebugHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "MemoryDebugHandler",
@@ -119,7 +122,7 @@ export class MemoryDebugHandler extends BaseHandler {
     const beforeHeap = getHeapStats();
     const gcTriggered = await forceGC();
 
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    await new Promise((resolve) => setTimeout(resolve, GC_SETTLE_DELAY_MS));
 
     const afterHeap = getHeapStats();
     const freedMB = Math.round((beforeHeap.usedHeapSizeMB - afterHeap.usedHeapSizeMB) * 100) / 100;

--- a/src/server/handlers/preview/hmr-ping-keepalive.ts
+++ b/src/server/handlers/preview/hmr-ping-keepalive.ts
@@ -3,7 +3,7 @@ import { getOpenSockets } from "./hmr-client-manager.ts";
 
 const logger = serverLogger.component("hmr-handler");
 
-const PING_INTERVAL_MS = 45000;
+const PING_INTERVAL_MS = 45_000;
 
 let pingInterval: ReturnType<typeof setInterval> | null = null;
 

--- a/src/server/handlers/request/module/page-data-endpoint-handler.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.ts
@@ -6,7 +6,7 @@ import { TimeoutError, withTimeoutThrow } from "#veryfront/rendering/utils/strea
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { HTTP_GATEWAY_TIMEOUT } from "#veryfront/utils/constants/http.ts";
 
-const PAGE_DATA_TIMEOUT_MS = 25000;
+const PAGE_DATA_TIMEOUT_MS = 25_000;
 
 export function handlePageDataEndpoint(
   req: Request,

--- a/src/server/handlers/request/openapi-docs.handler.ts
+++ b/src/server/handlers/request/openapi-docs.handler.ts
@@ -16,6 +16,9 @@ import { escapeHtml } from "#veryfront/html/html-escape.ts";
 const DEFAULT_DOCS_PATH = "/_docs";
 const DEFAULT_JSON_PATH = "/_openapi.json";
 
+/** Cache duration for production docs pages (1 hour) */
+const DOCS_CACHE_MAX_AGE_SECONDS = 3_600;
+
 export class OpenAPIDocsHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "OpenAPIDocsHandler",
@@ -37,7 +40,7 @@ export class OpenAPIDocsHandler extends BaseHandler {
     const isDev = !!ctx.isLocalProject;
 
     const response = this.createResponseBuilder(ctx)
-      .withCache(isDev ? "no-cache" : { maxAge: 3600, public: true })
+      .withCache(isDev ? "no-cache" : { maxAge: DOCS_CACHE_MAX_AGE_SECONDS, public: true })
       .withContentType("text/html; charset=utf-8", html, HTTP_OK);
 
     return Promise.resolve(this.respond(response));

--- a/src/server/handlers/request/openapi.handler.ts
+++ b/src/server/handlers/request/openapi.handler.ts
@@ -17,6 +17,9 @@ const logger = baseLogger.component("open-api");
 const DEFAULT_JSON_PATH = "/_openapi.json";
 const DEFAULT_YAML_PATH = "/_openapi.yaml";
 
+/** Cache duration for production OpenAPI spec (1 hour) */
+const SPEC_CACHE_MAX_AGE_SECONDS = 3_600;
+
 export class OpenAPIHandler extends BaseHandler {
   private cachedSpec: OpenAPISpec | null = null;
   private cacheKey: string | null = null;
@@ -51,7 +54,7 @@ export class OpenAPIHandler extends BaseHandler {
       const isDev = !!ctx.isLocalProject;
 
       const response = this.createResponseBuilder(ctx)
-        .withCache(isDev ? "no-cache" : { maxAge: 3600, public: true })
+        .withCache(isDev ? "no-cache" : { maxAge: SPEC_CACHE_MAX_AGE_SECONDS, public: true })
         .withCORS(req, { origin: "*" })
         .withContentType(
           isYaml ? "text/yaml; charset=utf-8" : "application/json; charset=utf-8",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -36,6 +36,9 @@ import {
   serverLogger,
 } from "#veryfront/utils";
 
+/** Default server port when no port is specified */
+const DEFAULT_SERVER_PORT = 3_000;
+
 export { DevServer, startDevServer, startProductionServer };
 export type {
   DevServerOptions,
@@ -185,7 +188,7 @@ export async function createHandler(
   }
 
   // Development mode (default) — includes file watching, HMR, cache invalidation
-  const port = options.port ?? 3000;
+  const port = options.port ?? DEFAULT_SERVER_PORT;
   const devServer = new DevServer({
     port,
     projectDir,
@@ -370,7 +373,7 @@ export async function startServer(
   options: StartServerOptions = {},
 ): Promise<VeryfrontServer> {
   const projectDir = options.projectDir ?? process.cwd();
-  const port = options.port ?? 3000;
+  const port = options.port ?? DEFAULT_SERVER_PORT;
   const bindAddress = options.bindAddress ?? "localhost";
 
   if (options?.mode === "production") {

--- a/src/server/production-server.ts
+++ b/src/server/production-server.ts
@@ -28,6 +28,16 @@ import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
 const serverLog = logger.component("server");
 const globalLog = logger.component("global");
 
+/** Default interval for periodic memory usage snapshots */
+const DEFAULT_MEMORY_MONITORING_INTERVAL_MS = 30_000;
+
+/** Default time to wait for in-flight requests to drain during shutdown.
+ *  K8s default terminationGracePeriodSeconds is 30s, so 25s leaves headroom. */
+const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS = 25_000;
+
+/** Default port when PORT / VERYFRONT_PORT env vars are not set */
+const DEFAULT_SERVER_PORT = 3000;
+
 /** Configuration for AI primitives discovery during server startup */
 export interface DiscoveryOptions {
   baseDir: string;
@@ -268,7 +278,8 @@ if (import.meta.main) {
     // Start memory monitoring if enabled
     const enableMemoryMonitoring = adapter.env.get("ENABLE_MEMORY_MONITORING") === "true";
     const monitoringIntervalMs = parseInt(
-      adapter.env.get("MEMORY_MONITORING_INTERVAL_MS") ?? "30000",
+      adapter.env.get("MEMORY_MONITORING_INTERVAL_MS") ??
+        String(DEFAULT_MEMORY_MONITORING_INTERVAL_MS),
       10,
     );
 
@@ -287,7 +298,9 @@ if (import.meta.main) {
 
     const shutdownController = new AbortController();
     const projectDir = cwd();
-    const port = Number(adapter.env.get("PORT") ?? adapter.env.get("VERYFRONT_PORT") ?? 3000);
+    const port = Number(
+      adapter.env.get("PORT") ?? adapter.env.get("VERYFRONT_PORT") ?? DEFAULT_SERVER_PORT,
+    );
     // BIND_ADDRESS: 0.0.0.0 = all interfaces, 127.0.0.1 = localhost only
     // Note: Don't use HOSTNAME - K8s sets it to pod name which resolves to pod IP
     const bindAddress = adapter.env.get("BIND_ADDRESS") ?? "0.0.0.0";
@@ -312,7 +325,10 @@ if (import.meta.main) {
 
     // Graceful shutdown for direct CLI execution (e.g., deno run)
     // Default drain timeout: 25 seconds (K8s default terminationGracePeriodSeconds is 30)
-    const drainTimeoutMs = parseInt(adapter.env.get("SHUTDOWN_DRAIN_TIMEOUT_MS") ?? "25000", 10);
+    const drainTimeoutMs = parseInt(
+      adapter.env.get("SHUTDOWN_DRAIN_TIMEOUT_MS") ?? String(DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS),
+      10,
+    );
 
     let shuttingDown = false;
     const shutdown = async (signal: "SIGINT" | "SIGTERM"): Promise<void> => {

--- a/src/server/production-server.ts
+++ b/src/server/production-server.ts
@@ -36,7 +36,7 @@ const DEFAULT_MEMORY_MONITORING_INTERVAL_MS = 30_000;
 const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS = 25_000;
 
 /** Default port when PORT / VERYFRONT_PORT env vars are not set */
-const DEFAULT_SERVER_PORT = 3000;
+const DEFAULT_SERVER_PORT = 3_000;
 
 /** Configuration for AI primitives discovery during server startup */
 export interface DiscoveryOptions {

--- a/src/server/runtime-handler/request-tracker.ts
+++ b/src/server/runtime-handler/request-tracker.ts
@@ -31,6 +31,12 @@ const VERY_SLOW_REQUEST_THRESHOLD_MS = 25_000; // 25 seconds
 /** How often to log the current state of in-flight requests */
 const STATUS_LOG_INTERVAL_MS = 30_000; // 30 seconds
 
+/** How often to log drain progress during graceful shutdown */
+const DRAIN_PROGRESS_LOG_INTERVAL_MS = 5_000; // 5 seconds
+
+/** Only log module requests that exceed this duration (to reduce noise) */
+const MODULE_REQUEST_LOG_THRESHOLD_MS = 100;
+
 class RequestTracker {
   private inFlight = new Map<string, TrackedRequest>();
   private statusInterval: ReturnType<typeof setInterval> | undefined;
@@ -148,7 +154,7 @@ class RequestTracker {
       tracked.path.startsWith("/_veryfront/");
 
     if (isModuleRequest) {
-      if (durationMs > 100) {
+      if (durationMs > MODULE_REQUEST_LOG_THRESHOLD_MS) {
         logger.debug(`${tracked.method} ${tracked.path} ${statusCode} ${durationMs}ms`);
       }
       return;
@@ -219,7 +225,7 @@ class RequestTracker {
         return false;
       }
 
-      if (elapsedMs > 0 && elapsedMs % 5000 < pollIntervalMs) {
+      if (elapsedMs > 0 && elapsedMs % DRAIN_PROGRESS_LOG_INTERVAL_MS < pollIntervalMs) {
         logger.info("Drain progress", {
           inFlightCount: this.inFlight.size,
           elapsedMs,

--- a/src/server/services/rsc/endpoints/handler-registry.ts
+++ b/src/server/services/rsc/endpoints/handler-registry.ts
@@ -12,6 +12,7 @@ import { registerCache } from "#veryfront/utils/memory/index.ts";
 
 const RSC_HANDLERS_MAX_ENTRIES = 50;
 const RSC_HANDLERS_TTL_MS = 60 * 60 * 1000; // 1 hour
+const RSC_HANDLERS_CLEANUP_INTERVAL_MS = 300_000; // 5 minutes
 
 /**
  * Handler cache interface for dependency injection.
@@ -37,7 +38,7 @@ function getHandlersCache(): HandlerCache<RSCDevServerHandler> {
   rscHandlersByProject = new LRUCache<string, RSCDevServerHandler>({
     maxEntries: RSC_HANDLERS_MAX_ENTRIES,
     ttlMs: RSC_HANDLERS_TTL_MS,
-    cleanupIntervalMs: 300000, // 5 minutes
+    cleanupIntervalMs: RSC_HANDLERS_CLEANUP_INTERVAL_MS,
   });
 
   if (!cacheRegistered) {

--- a/src/server/shared/renderer/adapter.ts
+++ b/src/server/shared/renderer/adapter.ts
@@ -34,6 +34,12 @@ import { computeContentSourceId } from "#veryfront/cache/keys.ts";
 
 const logger = rendererLogger.component("renderer-adapter");
 
+/** TTL for the API-backed distributed render cache (1 hour) */
+const RENDER_CACHE_TTL_SECONDS = 3_600;
+
+/** Maximum entries for the local render cache layer */
+const RENDER_CACHE_LOCAL_MAX_ENTRIES = 200;
+
 export interface RendererAdapter {
   renderPage(slug: string, options?: RenderOptions): Promise<RenderResult>;
   resolvePageData(slug: string, options?: RenderOptions): Promise<PageDataResponse>;
@@ -72,16 +78,15 @@ async function getOrInitRenderer(): Promise<Renderer> {
 
   // Only use API-backed cache when both PROXY_MODE=1 and API URL is configured
   if (isProxyMode && apiBaseUrl) {
-    const renderCacheTtlSeconds = 3600;
     logger.debug("Using API-backed distributed render cache");
     options.cache = {
       store: new APICacheStore({
         keyPrefix: "render",
-        ttlSeconds: renderCacheTtlSeconds,
-        localMaxEntries: 200,
+        ttlSeconds: RENDER_CACHE_TTL_SECONDS,
+        localMaxEntries: RENDER_CACHE_LOCAL_MAX_ENTRIES,
         enableLocalCache: false,
       }),
-      ttlMs: renderCacheTtlSeconds * 1000,
+      ttlMs: RENDER_CACHE_TTL_SECONDS * 1000,
     };
   }
 

--- a/src/skill/tools.ts
+++ b/src/skill/tools.ts
@@ -27,6 +27,9 @@ import {
   SKILL_SCRIPTS_DIR,
 } from "./types.ts";
 
+/** Maximum allowed script execution timeout in milliseconds (5 minutes) */
+const MAX_SCRIPT_TIMEOUT_MS = 300_000;
+
 /**
  * Read a file from a skill directory.
  * Uses skill.fsAdapter if available (VFS/cloud), otherwise falls back to compat readTextFile.
@@ -159,9 +162,9 @@ export function createExecuteSkillScriptTool(): Tool {
         .number()
         .int()
         .positive()
-        .max(300_000)
+        .max(MAX_SCRIPT_TIMEOUT_MS)
         .optional()
-        .describe("Optional execution timeout in milliseconds (max 300000)"),
+        .describe(`Optional execution timeout in milliseconds (max ${MAX_SCRIPT_TIMEOUT_MS})`),
     }),
     execute: async (input) => {
       const skill = skillRegistry.get(input.skillId);

--- a/src/transforms/esm/http-cache.ts
+++ b/src/transforms/esm/http-cache.ts
@@ -63,6 +63,9 @@ import {
   recoverHttpBundleByHash as recoverHttpBundleByHashImpl,
 } from "./bundle-recovery.ts";
 
+/** Threshold in ms above which an HTTP module fetch is considered slow */
+const SLOW_HTTP_FETCH_THRESHOLD_MS = 500;
+
 const httpCacheLog = logger.component("http-cache");
 const contentMetricsLog = logger.component("content-metrics");
 
@@ -248,7 +251,7 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
       host: urlObj.host,
       duration_ms: httpFetchDuration,
       status: response.status,
-      slow: httpFetchDuration > 500,
+      slow: httpFetchDuration > SLOW_HTTP_FETCH_THRESHOLD_MS,
     });
 
     if (!response.ok) {

--- a/src/transforms/esm/transform-cache.ts
+++ b/src/transforms/esm/transform-cache.ts
@@ -14,6 +14,7 @@ const logger = baseLogger.component("transform-cache");
 
 const DEFAULT_TTL_SECONDS = 300; // 5 minutes
 const FALLBACK_MAX_ENTRIES = 500;
+const WARMUP_TTL_SECONDS = 3_600; // 1 hour
 
 /**
  * Pattern to match unresolved /_vf_modules/_veryfront/ imports.
@@ -354,7 +355,7 @@ export interface WarmupResult {
 
 export async function warmupTransformCache(
   entries: WarmupEntry[],
-  ttlSeconds: number = 3600,
+  ttlSeconds: number = WARMUP_TTL_SECONDS,
 ): Promise<WarmupResult> {
   const start = performance.now();
   let success = 0;

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -27,7 +27,11 @@ export type CacheLookupResult =
   | { status: "miss" }
   | { status: "corrupted"; reason: string; filePath: string };
 
-export const verifiedModuleDeps = new LRUCache<string, true>({ maxEntries: 2000 });
+const MAX_VERIFIED_MODULE_DEPS = 2_000;
+
+export const verifiedModuleDeps = new LRUCache<string, true>({
+  maxEntries: MAX_VERIFIED_MODULE_DEPS,
+});
 
 const FILE_PATH_PATTERN = /file:\/\/([^"'\s]+)/gi;
 

--- a/src/utils/circuit-breaker.ts
+++ b/src/utils/circuit-breaker.ts
@@ -26,11 +26,11 @@ const MAX_HALF_OPEN_ATTEMPTS = 3;
 export type CircuitState = "CLOSED" | "OPEN" | "HALF_OPEN";
 
 export interface CircuitBreakerOptions {
-  /** Failures before opening (default: DEFAULT_FAILURE_THRESHOLD) */
+  /** Failures before opening (default: 5) */
   failureThreshold?: number;
-  /** Ms to wait before retry (default: DEFAULT_RESET_TIMEOUT_MS) */
+  /** Ms to wait before retry (default: 30000) */
   resetTimeoutMs?: number;
-  /** Successes to close (default: DEFAULT_SUCCESS_THRESHOLD) */
+  /** Successes to close (default: 3) */
   successThreshold?: number;
   /** Optional name for logging */
   name?: string;

--- a/src/utils/circuit-breaker.ts
+++ b/src/utils/circuit-breaker.ts
@@ -11,14 +11,26 @@ import { logger as baseLogger } from "#veryfront/utils";
 
 const logger = baseLogger.component("circuit-breaker");
 
+/** Default number of consecutive failures before the circuit opens */
+const DEFAULT_FAILURE_THRESHOLD = 5;
+
+/** Default time to wait in OPEN state before attempting recovery (30 seconds) */
+const DEFAULT_RESET_TIMEOUT_MS = 30_000;
+
+/** Default number of successes in HALF_OPEN required to close the circuit */
+const DEFAULT_SUCCESS_THRESHOLD = 3;
+
+/** Maximum concurrent attempts allowed while the circuit is HALF_OPEN */
+const MAX_HALF_OPEN_ATTEMPTS = 3;
+
 export type CircuitState = "CLOSED" | "OPEN" | "HALF_OPEN";
 
 export interface CircuitBreakerOptions {
-  /** Failures before opening (default: 5) */
+  /** Failures before opening (default: DEFAULT_FAILURE_THRESHOLD) */
   failureThreshold?: number;
-  /** Ms to wait before retry (default: 30000) */
+  /** Ms to wait before retry (default: DEFAULT_RESET_TIMEOUT_MS) */
   resetTimeoutMs?: number;
-  /** Successes to close (default: 3) */
+  /** Successes to close (default: DEFAULT_SUCCESS_THRESHOLD) */
   successThreshold?: number;
   /** Optional name for logging */
   name?: string;
@@ -52,9 +64,9 @@ export class CircuitBreaker {
   private readonly breakerName: string;
 
   constructor(options: CircuitBreakerOptions = {}) {
-    this.failureThreshold = options.failureThreshold ?? 5;
-    this.resetTimeoutMs = options.resetTimeoutMs ?? 30000;
-    this.successThreshold = options.successThreshold ?? 3;
+    this.failureThreshold = options.failureThreshold ?? DEFAULT_FAILURE_THRESHOLD;
+    this.resetTimeoutMs = options.resetTimeoutMs ?? DEFAULT_RESET_TIMEOUT_MS;
+    this.successThreshold = options.successThreshold ?? DEFAULT_SUCCESS_THRESHOLD;
     this.breakerName = options.name ?? "default";
   }
 
@@ -67,7 +79,7 @@ export class CircuitBreaker {
     }
 
     if (this.state === "HALF_OPEN") {
-      if (this.halfOpenAttempts >= 3) {
+      if (this.halfOpenAttempts >= MAX_HALF_OPEN_ATTEMPTS) {
         this.transitionTo("OPEN");
         this.lastFailureTime = Date.now();
         throw new CircuitBreakerOpen(this.breakerName, this.resetTimeoutMs);
@@ -145,7 +157,7 @@ export class CircuitBreaker {
 }
 
 /** Maximum number of circuit breakers to keep in registry */
-const MAX_BREAKERS = 1000;
+const MAX_BREAKERS = 1_000;
 
 /** Minimum age (ms) before a breaker can be evicted (1 hour) */
 const MIN_EVICTION_AGE_MS = 60 * 60 * 1000;

--- a/src/utils/hash-utils.ts
+++ b/src/utils/hash-utils.ts
@@ -1,4 +1,8 @@
+import { FNV1A_PRIME_32 } from "./constants/crypto.ts";
 import { HASH_SEED_FNV1A } from "./constants/hash.ts";
+
+/** Number of hex characters kept by shortHash (8 hex chars = 32 bits) */
+const SHORT_HASH_LENGTH = 8;
 
 export async function computeHash(content: string): Promise<string> {
   const data = new TextEncoder().encode(content);
@@ -35,7 +39,7 @@ export function hashCodeHex(str: string): string {
 
 export async function shortHash(content: string): Promise<string> {
   const fullHash = await computeHash(content);
-  return fullHash.slice(0, 8);
+  return fullHash.slice(0, SHORT_HASH_LENGTH);
 }
 
 /** FNV-1a hash for strings - returns hex string */
@@ -44,7 +48,7 @@ export function fnv1aHash(input: string): string {
 
   for (const char of input) {
     hash ^= char.charCodeAt(0);
-    hash = Math.imul(hash, 16777619);
+    hash = Math.imul(hash, FNV1A_PRIME_32);
   }
 
   return (hash >>> 0).toString(16);

--- a/src/utils/lru-wrapper.ts
+++ b/src/utils/lru-wrapper.ts
@@ -4,6 +4,9 @@ import { DEFAULT_LRU_MAX_ENTRIES } from "#veryfront/utils";
 import { unrefTimer } from "#veryfront/platform/compat/process.ts";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
 
+/** Default interval between expired-entry cleanup sweeps (1 minute) */
+const DEFAULT_CLEANUP_INTERVAL_MS = 60_000;
+
 export interface LRUOptions {
   maxEntries?: number;
   ttlMs?: number;
@@ -24,7 +27,7 @@ export class LRUCache<K, V> {
 
     this.adapter = new LRUCacheAdapter(adapterOptions);
     this.ttlMs = options.ttlMs;
-    this.cleanupIntervalMs = options.cleanupIntervalMs ?? 60000;
+    this.cleanupIntervalMs = options.cleanupIntervalMs ?? DEFAULT_CLEANUP_INTERVAL_MS;
 
     if (this.ttlMs && this.ttlMs > 0) {
       this.startPeriodicCleanup();

--- a/src/utils/memoize.ts
+++ b/src/utils/memoize.ts
@@ -1,6 +1,5 @@
+import { FNV1A_PRIME_32 } from "./constants/crypto.ts";
 import { HASH_SEED_FNV1A } from "./constants/hash.ts";
-
-const FNV_PRIME = 16777619;
 
 export class MemoCache<V> {
   private cache = new Map<string, V>();
@@ -93,7 +92,7 @@ export function simpleHash(...values: unknown[]): string {
 
     for (let i = 0; i < str.length; i++) {
       hash ^= str.charCodeAt(i);
-      hash = Math.imul(hash, FNV_PRIME);
+      hash = Math.imul(hash, FNV1A_PRIME_32);
     }
   }
 

--- a/src/utils/memory/profiler.ts
+++ b/src/utils/memory/profiler.ts
@@ -10,6 +10,15 @@ import { getArgs, getEnv, memoryUsage } from "#veryfront/platform/compat/process
 
 const logger = rendererLogger.component("memory-profiler");
 
+/** Fallback V8 heap limit when no --max-old-space-size flag is set (5 GB) */
+const DEFAULT_HEAP_LIMIT_MB = 5_120;
+
+/** Default interval for periodic memory snapshots (30 seconds) */
+const DEFAULT_MEMORY_MONITORING_INTERVAL_MS = 30_000;
+
+/** Heap growth (MB) per interval that triggers a rapid-growth warning */
+const HEAP_RAPID_GROWTH_THRESHOLD_MB = 100;
+
 const cacheRegistry = new Map<string, () => CacheStats>();
 
 export interface CacheStats {
@@ -89,7 +98,7 @@ function getConfiguredHeapLimit(): number {
   const v8MaxOldSpaceSize = parseInt(getEnv("V8_MAX_OLD_SPACE_SIZE") ?? "", 10);
   if (!Number.isNaN(v8MaxOldSpaceSize) && v8MaxOldSpaceSize > 0) return v8MaxOldSpaceSize;
 
-  return 5120;
+  return DEFAULT_HEAP_LIMIT_MB;
 }
 
 export function getCacheStats(): CacheStats[] {
@@ -131,7 +140,7 @@ export async function forceGC(): Promise<boolean> {
   }
 }
 
-export function startMemoryMonitoring(intervalMs = 30000): void {
+export function startMemoryMonitoring(intervalMs = DEFAULT_MEMORY_MONITORING_INTERVAL_MS): void {
   if (memoryCheckInterval) clearInterval(memoryCheckInterval);
 
   logger.info(`Starting memory monitoring (interval: ${intervalMs}ms)`);
@@ -159,7 +168,7 @@ export function startMemoryMonitoring(intervalMs = 30000): void {
     }
 
     const heapGrowthMB = heap.usedHeapSizeMB - lastHeapUsed;
-    if (heapGrowthMB > 100) {
+    if (heapGrowthMB > HEAP_RAPID_GROWTH_THRESHOLD_MB) {
       logger.warn("Rapid heap growth detected", {
         growthMB: heapGrowthMB,
         intervalMs,

--- a/src/workflow/backends/memory.ts
+++ b/src/workflow/backends/memory.ts
@@ -28,7 +28,7 @@ export interface MemoryBackendConfig extends BackendConfig {
 }
 
 /** Default max queue size */
-const DEFAULT_MAX_QUEUE_SIZE = 10000;
+const DEFAULT_MAX_QUEUE_SIZE = 10_000;
 
 export class MemoryBackend implements WorkflowBackend {
   private runs = new Map<string, WorkflowRun>();

--- a/src/workflow/claude-code/react/use-claude-code-stream.ts
+++ b/src/workflow/claude-code/react/use-claude-code-stream.ts
@@ -7,6 +7,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ClaudeCodeEvent, ClaudeCodeResult } from "../types.ts";
 
+/** Default delay before reconnecting after disconnect */
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
+
+/** Default maximum number of events to retain in history */
+const DEFAULT_MAX_EVENT_HISTORY = 100;
+
 /**
  * State for Claude Code streaming
  */
@@ -145,9 +151,9 @@ export function useClaudeCodeStream(
     autoConnect = true,
     autoReconnect = true,
     maxReconnectAttempts = 5,
-    reconnectDelay = 1000,
+    reconnectDelay = DEFAULT_RECONNECT_DELAY_MS,
     keepEventHistory = false,
-    maxEventHistory = 100,
+    maxEventHistory = DEFAULT_MAX_EVENT_HISTORY,
     onEvent,
     onConnect,
     onDisconnect,

--- a/src/workflow/claude-code/react/use-claude-code-websocket.ts
+++ b/src/workflow/claude-code/react/use-claude-code-websocket.ts
@@ -13,6 +13,12 @@ import type {
   InputRequestEvent,
 } from "../types.ts";
 
+/** Default delay before reconnecting after disconnect */
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
+
+/** Default interval for WebSocket ping messages */
+const DEFAULT_PING_INTERVAL_MS = 30_000;
+
 /**
  * Pending approval state
  */
@@ -192,8 +198,8 @@ export function useClaudeCodeWebSocket(
     autoConnect = true,
     autoReconnect = true,
     maxReconnectAttempts = 5,
-    reconnectDelay = 1000,
-    pingInterval = 30000,
+    reconnectDelay = DEFAULT_RECONNECT_DELAY_MS,
+    pingInterval = DEFAULT_PING_INTERVAL_MS,
     onEvent,
     onConnect,
     onDisconnect,

--- a/src/workflow/claude-code/websocket-publisher.ts
+++ b/src/workflow/claude-code/websocket-publisher.ts
@@ -17,6 +17,15 @@ import type {
 
 const logger = baseLogger.component("websocket-publisher");
 
+/** Default interval for WebSocket ping/keepalive messages */
+const DEFAULT_PING_INTERVAL_MS = 30_000;
+
+/** Default timeout for tool call approval requests */
+const DEFAULT_APPROVAL_TIMEOUT_MS = 60_000;
+
+/** Default timeout for user input requests (5 minutes) */
+const DEFAULT_INPUT_TIMEOUT_MS = 300_000;
+
 /**
  * WebSocket publisher configuration
  */
@@ -52,7 +61,7 @@ export class WebSocketPublisher implements BidirectionalPublisher {
   constructor(config: WebSocketPublisherConfig) {
     this.config = {
       debug: false,
-      pingInterval: 30000,
+      pingInterval: DEFAULT_PING_INTERVAL_MS,
       ...config,
     };
 
@@ -403,7 +412,7 @@ export class AgentController {
       return Promise.reject(new Error("Agent cancelled"));
     }
 
-    const timeout = this.config.approvalTimeout || 60000;
+    const timeout = this.config.approvalTimeout || DEFAULT_APPROVAL_TIMEOUT_MS;
 
     // Send approval request to client
     this.publisher.send({
@@ -439,7 +448,7 @@ export class AgentController {
       return Promise.reject(new Error("Agent cancelled"));
     }
 
-    const timeout = this.config.inputTimeout || 300000; // 5 minutes
+    const timeout = this.config.inputTimeout || DEFAULT_INPUT_TIMEOUT_MS;
 
     // Send input request to client
     this.publisher.send({

--- a/src/workflow/claude-code/workspace-sync.ts
+++ b/src/workflow/claude-code/workspace-sync.ts
@@ -17,6 +17,9 @@ import { join, relative, resolve } from "@std/path";
 
 const logger = baseLogger.component("workspace-sync");
 
+/** Maximum file size for workspace sync (10 MB) */
+const MAX_WORKSPACE_FILE_SIZE = 10 * 1024 * 1024;
+
 /**
  * Workspace configuration
  */
@@ -152,7 +155,7 @@ export class WorkspaceSync {
 
     this.config = {
       baseDir: "/tmp/veryfront-workspaces",
-      maxFileSize: 10 * 1024 * 1024, // 10MB
+      maxFileSize: MAX_WORKSPACE_FILE_SIZE,
       debug: false,
       ...config,
     };

--- a/src/workflow/dsl/loop.ts
+++ b/src/workflow/dsl/loop.ts
@@ -1,6 +1,12 @@
 import type { BaseNodeConfig, RetryConfig, WorkflowContext, WorkflowNode } from "../types.ts";
 import { validateNodeId } from "./validation.ts";
 
+/** Default maximum number of loop iterations */
+const DEFAULT_MAX_ITERATIONS = 10;
+
+/** Absolute upper bound on loop iterations to prevent runaway loops */
+const MAX_ITERATIONS_LIMIT = 100;
+
 export interface LoopContext {
   iteration: number;
   totalIterations: number;
@@ -55,15 +61,15 @@ export function loop(id: string, options: LoopOptions): WorkflowNode {
     throw new Error(`Loop "${id}" must have 'steps' configured`);
   }
 
-  const maxIterations = options.maxIterations ?? 10;
+  const maxIterations = options.maxIterations ?? DEFAULT_MAX_ITERATIONS;
 
   if (maxIterations < 1) {
     throw new Error(`Loop "${id}" maxIterations must be at least 1`);
   }
 
-  if (maxIterations > 100) {
+  if (maxIterations > MAX_ITERATIONS_LIMIT) {
     throw new Error(
-      `Loop "${id}" maxIterations cannot exceed 100 (got ${maxIterations}). ` +
+      `Loop "${id}" maxIterations cannot exceed ${MAX_ITERATIONS_LIMIT} (got ${maxIterations}). ` +
         `For higher limits, consider restructuring your workflow.`,
     );
   }

--- a/src/workflow/executor/step-executor.ts
+++ b/src/workflow/executor/step-executor.ts
@@ -43,14 +43,20 @@ export function runWithWorkflowTenant<T>(
   return workflowTenantStorage.run(tenant, fn);
 }
 
+/** Default initial delay before first retry attempt */
+const DEFAULT_RETRY_INITIAL_DELAY_MS = 1_000;
+
+/** Default maximum delay between retry attempts */
+const DEFAULT_RETRY_MAX_DELAY_MS = 30_000;
+
 const DEFAULT_RETRY: RetryConfig = {
   maxAttempts: 1,
   backoff: "exponential",
-  initialDelay: 1000,
-  maxDelay: 30000,
+  initialDelay: DEFAULT_RETRY_INITIAL_DELAY_MS,
+  maxDelay: DEFAULT_RETRY_MAX_DELAY_MS,
 };
 
-const DEFAULT_STEP_TIMEOUT_MS = 5 * 60 * 1000;
+const DEFAULT_STEP_TIMEOUT_MS = 5 * 60 * 1_000;
 
 export interface AgentRegistry {
   get(id: string): Agent | undefined;
@@ -170,8 +176,8 @@ export class StepExecutor {
   }
 
   private calculateRetryDelay(attempt: number, config: RetryConfig): number {
-    const initialDelay = config.initialDelay ?? 1000;
-    const maxDelay = config.maxDelay ?? 30000;
+    const initialDelay = config.initialDelay ?? DEFAULT_RETRY_INITIAL_DELAY_MS;
+    const maxDelay = config.maxDelay ?? DEFAULT_RETRY_MAX_DELAY_MS;
 
     let baseDelay = initialDelay;
     if (config.backoff === "exponential") baseDelay = initialDelay * Math.pow(2, attempt - 1);

--- a/src/workflow/executor/workflow-executor.ts
+++ b/src/workflow/executor/workflow-executor.ts
@@ -26,6 +26,9 @@ import type { BlobStorage } from "../blob/types.ts";
 
 const logger = baseLogger.component("workflow-executor");
 
+/** Default polling interval for waiting on workflow result */
+const DEFAULT_RESULT_POLL_INTERVAL_MS = 1_000;
+
 /**
  * Workflow executor configuration
  */
@@ -87,9 +90,9 @@ export class WorkflowExecutor {
   private blobResolver?: BlobResolver;
 
   /** Default lock duration: 30 seconds */
-  private static readonly DEFAULT_LOCK_DURATION = 30000;
+  private static readonly DEFAULT_LOCK_DURATION = 30_000;
   /** Heartbeat interval for long-running workflow liveness tracking */
-  private static readonly HEARTBEAT_INTERVAL_MS = 10000;
+  private static readonly HEARTBEAT_INTERVAL_MS = 10_000;
 
   constructor(config: WorkflowExecutorConfig) {
     this.config = {
@@ -532,7 +535,10 @@ export class WorkflowExecutor {
   /**
    * Wait for workflow result
    */
-  private async waitForResult<TOutput>(runId: string, pollInterval = 1000): Promise<TOutput> {
+  private async waitForResult<TOutput>(
+    runId: string,
+    pollInterval = DEFAULT_RESULT_POLL_INTERVAL_MS,
+  ): Promise<TOutput> {
     while (true) {
       const run = await this.config.backend.getRun(runId);
       if (!run) throw new Error(`Run not found: ${runId}`);

--- a/src/workflow/react/use-workflow-list.ts
+++ b/src/workflow/react/use-workflow-list.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import type { RunFilter, WorkflowRun, WorkflowStatus } from "#veryfront/workflow/types.ts";
 
+/** Default interval for auto-refreshing the workflow list */
+const DEFAULT_REFRESH_INTERVAL_MS = 5_000;
+
 export interface UseWorkflowListOptions {
   workflowId?: string;
   status?: WorkflowStatus | WorkflowStatus[];
@@ -36,7 +39,7 @@ export function useWorkflowList(options: UseWorkflowListOptions = {}): UseWorkfl
     pageSize = 20,
     apiBase = "/api/workflows",
     autoRefresh = false,
-    refreshInterval = 5000,
+    refreshInterval = DEFAULT_REFRESH_INTERVAL_MS,
   } = options;
 
   const [runs, setRuns] = useState<WorkflowRun[]>([]);

--- a/src/workflow/react/use-workflow.ts
+++ b/src/workflow/react/use-workflow.ts
@@ -6,6 +6,9 @@ import type {
   WorkflowStatus,
 } from "#veryfront/workflow/types.ts";
 
+/** Default polling interval for workflow status updates */
+const DEFAULT_POLL_INTERVAL_MS = 2_000;
+
 export interface UseWorkflowOptions {
   runId: string;
   apiBase?: string;
@@ -35,7 +38,7 @@ export function useWorkflow(options: UseWorkflowOptions): UseWorkflowResult {
   const {
     runId,
     apiBase = "/api/workflows",
-    pollInterval = 2000,
+    pollInterval = DEFAULT_POLL_INTERVAL_MS,
     autoRefresh = true,
     onStatusChange,
     onComplete,

--- a/src/workflow/runtime/approval-manager.ts
+++ b/src/workflow/runtime/approval-manager.ts
@@ -12,6 +12,9 @@ import type { WorkflowExecutor } from "../executor/workflow-executor.ts";
 
 const logger = baseLogger.component("approval-manager");
 
+/** Default interval for checking expired approvals */
+const DEFAULT_EXPIRATION_CHECK_INTERVAL_MS = 60_000;
+
 export type ApprovalNotifier = (
   approval: PendingApproval,
   run: WorkflowRun,
@@ -53,7 +56,7 @@ export class ApprovalManager {
 
   constructor(config: ApprovalManagerConfig) {
     this.config = {
-      expirationCheckInterval: 60000,
+      expirationCheckInterval: DEFAULT_EXPIRATION_CHECK_INTERVAL_MS,
       debug: false,
       ...config,
     };

--- a/src/workflow/worker/executors/k8s.ts
+++ b/src/workflow/worker/executors/k8s.ts
@@ -10,6 +10,9 @@ import type { JobConfig, JobExecutor, JobInfo, JobStatus } from "./types.ts";
 
 const logger = baseLogger.component("k8s-job-executor");
 
+/** Default TTL for completed K8s Jobs before automatic cleanup (seconds) */
+const DEFAULT_TTL_AFTER_FINISHED_SECONDS = 300;
+
 /**
  * K8s Job Executor configuration
  */
@@ -139,7 +142,7 @@ export class K8sJobExecutor implements JobExecutor {
     this.config = {
       namespace: "default",
       imagePullPolicy: "IfNotPresent",
-      ttlAfterFinished: 300,
+      ttlAfterFinished: DEFAULT_TTL_AFTER_FINISHED_SECONDS,
       debug: false,
       ...config,
     };

--- a/src/workflow/worker/job-manager.ts
+++ b/src/workflow/worker/job-manager.ts
@@ -23,6 +23,15 @@ import type { JobConfig, JobExecutor, JobStatus } from "./executors/types.ts";
 
 const logger = baseLogger.component("workflow-job-manager");
 
+/** Default interval between poll cycles */
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+
+/** Default timeout for a single job (30 minutes) */
+const DEFAULT_JOB_TIMEOUT_MS = 30 * 60 * 1_000;
+
+/** Default threshold after which a run is considered stalled */
+const DEFAULT_STALLED_THRESHOLD_MS = 60_000;
+
 // Re-export types for convenience
 export type { JobExecutor, JobInfo, JobStatus } from "./executors/types.ts";
 
@@ -139,10 +148,10 @@ export class WorkflowJobManager {
     this.managerId = generateId("mgr");
 
     this.config = {
-      pollInterval: 5000,
+      pollInterval: DEFAULT_POLL_INTERVAL_MS,
       maxConcurrentJobs: 10,
-      jobTimeout: 30 * 60 * 1000, // 30 minutes
-      stalledThreshold: 60000, // 60 seconds
+      jobTimeout: DEFAULT_JOB_TIMEOUT_MS,
+      stalledThreshold: DEFAULT_STALLED_THRESHOLD_MS,
       debug: false,
       ...config,
     };

--- a/src/workflow/worker/workflow-worker.ts
+++ b/src/workflow/worker/workflow-worker.ts
@@ -13,6 +13,12 @@ import { generateId } from "../types.ts";
 
 const logger = baseLogger.component("workflow-worker");
 
+/** Default interval between poll cycles */
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+
+/** Default threshold after which a run is considered stalled */
+const DEFAULT_STALLED_THRESHOLD_MS = 60_000;
+
 /**
  * Configuration for the workflow worker
  */
@@ -107,8 +113,8 @@ export class WorkflowWorker {
     }
 
     this.config = {
-      pollInterval: 5000, // 5 seconds
-      stalledThreshold: 60000, // 60 seconds
+      pollInterval: DEFAULT_POLL_INTERVAL_MS,
+      stalledThreshold: DEFAULT_STALLED_THRESHOLD_MS,
       concurrency: 3,
       workerId: generateId("worker"),
       debug: false,


### PR DESCRIPTION
## Summary

- Extract ~120+ hardcoded magic numbers into descriptive named constants across 111 files
- Apply numeric separator formatting (`30000` → `30_000`) for readability
- Cover timeouts, size limits, cache config, rate limiting, retry params, and durations
- No behavioral changes — naming and formatting only

## Test plan

- [x] `deno fmt` — passes
- [x] `deno lint` — passes
- [x] `deno task typecheck` — passes
- [x] `deno task test` — 1219 passed, 0 failed
- [x] Pre-push hooks — all green