### PR TITLE
refactor: unify env access to getEnv() wrapper

### DIFF
--- a/src/platform/compat/process.test.ts
+++ b/src/platform/compat/process.test.ts
@@ -6,6 +6,7 @@
 
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { runWithProjectEnv } from "../../server/project-env/storage.ts";
 import {
   chdir,
   cwd,
@@ -18,6 +19,7 @@ import {
   getEnvNumber,
   getEnvOverlayStorage,
   getEnvString,
+  getHostEnv,
   getOsType,
   getRuntimeVersion,
   getStdout,
@@ -90,6 +92,27 @@ describe("Process Compat", () => {
       const specialValue = "hello=world&foo=bar;baz";
       setEnv(testKey, specialValue);
       assertEquals(getEnv(testKey), specialValue);
+    });
+  });
+
+  describe("getHostEnv", () => {
+    const testKey = "__TEST_HOST_ENV__";
+
+    afterEach(() => {
+      try {
+        deleteEnv(testKey);
+      } catch {
+        // Ignore if not supported
+      }
+    });
+
+    it("should bypass project env overlays", () => {
+      setEnv(testKey, "host-value");
+
+      runWithProjectEnv({ [testKey]: "project-value" }, () => {
+        assertEquals(getEnv(testKey), "project-value");
+        assertEquals(getHostEnv(testKey), "host-value");
+      });
     });
   });
 

--- a/src/platform/compat/process.ts
+++ b/src/platform/compat/process.ts
@@ -62,6 +62,16 @@ export function env(): Record<string, string> {
   return {};
 }
 
+/**
+ * Read a host-level environment variable without consulting any project env overlay.
+ * Use this for framework-owned runtime configuration that should not be shadowed by tenant env.
+ */
+export function getHostEnv(key: string): string | undefined {
+  if (IS_DENO) return Deno.env.get(key);
+  if (runtimeProcess) return runtimeProcess.env[key];
+  return undefined;
+}
+
 // Lazy-loaded references to project-env/storage.ts functions.
 // Uses globalThis to avoid circular imports (process.ts is low-level, project-env is high-level).
 // IMPORTANT: Only cache when the real getter is found. If storage.ts hasn't loaded yet,
@@ -107,9 +117,7 @@ export function getEnv(key: string): string | undefined {
   // reading host-level secrets like AWS_SECRET_ACCESS_KEY, DATABASE_URL, etc.
   if (isProjectEnvActiveSafe()) return undefined;
 
-  if (IS_DENO) return Deno.env.get(key);
-  if (runtimeProcess) return runtimeProcess.env[key];
-  return undefined;
+  return getHostEnv(key);
 }
 
 const DEFAULT_ENV_TRUE_VALUES = ["1", "true", "yes"] as const;

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd";
 import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert";
+import { deleteEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import { runWithProjectEnv } from "../server/project-env/storage.ts";
 import type { ExecStreamEvent } from "./sandbox.ts";
 import { Sandbox } from "./sandbox.ts";
 
@@ -158,6 +160,28 @@ describe("Sandbox", () => {
         Error,
         "Sandbox failed to start",
       );
+    });
+
+    it("should use host VERYFRONT_API_URL even when project env overlay is active", async () => {
+      setEnv("VERYFRONT_API_URL", "https://internal.api.test");
+      try {
+        mockFetch([
+          jsonResponse({
+            id: "session-host-env",
+            endpoint: "https://sandbox.example.com",
+            status: "running",
+          }),
+        ]);
+
+        await runWithProjectEnv({}, async () => {
+          const sandbox = await Sandbox.create({ authToken: "test-token" });
+          assertEquals(sandbox.id, "session-host-env");
+        });
+
+        assertStringIncludes(call(0).url, "https://internal.api.test/sandbox-sessions");
+      } finally {
+        deleteEnv("VERYFRONT_API_URL");
+      }
     });
   });
 

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -8,6 +8,7 @@
  */
 
 import { INITIALIZATION_ERROR, REQUEST_ERROR, TIMEOUT_ERROR } from "#veryfront/errors";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 /** Options for creating a sandbox session. */
 export interface SandboxOptions {
@@ -42,9 +43,7 @@ export class Sandbox {
 
   private static resolveApiUrl(options: SandboxOptions): string {
     return options.apiUrl ||
-      (typeof Deno !== "undefined"
-        ? Deno.env.get("VERYFRONT_API_URL")
-        : process.env.VERYFRONT_API_URL) ||
+      getEnv("VERYFRONT_API_URL") ||
       "https://api.veryfront.com";
   }
 

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -8,7 +8,7 @@
  */
 
 import { INITIALIZATION_ERROR, REQUEST_ERROR, TIMEOUT_ERROR } from "#veryfront/errors";
-import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 /** Options for creating a sandbox session. */
 export interface SandboxOptions {
@@ -43,7 +43,7 @@ export class Sandbox {
 
   private static resolveApiUrl(options: SandboxOptions): string {
     return options.apiUrl ||
-      getEnv("VERYFRONT_API_URL") ||
+      getHostEnv("VERYFRONT_API_URL") ||
       "https://api.veryfront.com";
   }
 

--- a/src/server/project-env/getenv-integration.test.ts
+++ b/src/server/project-env/getenv-integration.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
-import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { getEnv, getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 // Import storage to ensure globalThis.__vfProjectEnvGetter and __vfProjectEnvActiveChecker are registered
 import { runWithProjectEnv } from "./storage.ts";
@@ -45,5 +45,13 @@ describe("getEnv with project env overlay", () => {
     });
     // Outside overlay, host env is accessible again
     assertEquals(typeof getEnv("PATH"), "string");
+  });
+
+  it("getHostEnv still reads host env when overlay is active", () => {
+    runWithProjectEnv({}, () => {
+      assertEquals(getEnv("PATH"), undefined);
+      assertEquals(typeof getHostEnv("PATH"), "string");
+      assertEquals((getHostEnv("PATH")?.length ?? 0) > 0, true);
+    });
   });
 });

--- a/src/utils/memory/profiler.ts
+++ b/src/utils/memory/profiler.ts
@@ -206,7 +206,7 @@ export function clearAllCaches(): void {
  */
 function getMemoryThreshold(envVar: string, fallback: number): number {
   try {
-    const value = typeof Deno !== "undefined" ? Deno.env.get(envVar) : undefined;
+    const value = getEnv(envVar);
     if (!value) return fallback;
 
     const parsed = parseInt(value, 10);

--- a/src/workflow/api.ts
+++ b/src/workflow/api.ts
@@ -23,7 +23,7 @@ import { getWorkflowTenant } from "./executor/step-executor.ts";
 import { getCurrentRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 import { VeryfrontApiClient } from "#veryfront/platform/adapters/veryfront-api-client/client.ts";
 import { INITIALIZATION_ERROR, INPUT_VALIDATION_FAILED } from "#veryfront/errors";
-import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 /**
  * Validate that a project slug is safe and well-formed.
@@ -86,7 +86,7 @@ function getClient(): VeryfrontApiClient {
   const tenant = getTenant();
 
   const client = new VeryfrontApiClient({
-    apiBaseUrl: getEnv("VERYFRONT_API_URL") || "https://api.veryfront.com",
+    apiBaseUrl: getHostEnv("VERYFRONT_API_URL") || "https://api.veryfront.com",
     proxyMode: true,
     projectId: tenant.projectId,
     projectSlug: tenant.projectSlug,

--- a/src/workflow/api.ts
+++ b/src/workflow/api.ts
@@ -23,6 +23,7 @@ import { getWorkflowTenant } from "./executor/step-executor.ts";
 import { getCurrentRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 import { VeryfrontApiClient } from "#veryfront/platform/adapters/veryfront-api-client/client.ts";
 import { INITIALIZATION_ERROR, INPUT_VALIDATION_FAILED } from "#veryfront/errors";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 /**
  * Validate that a project slug is safe and well-formed.
@@ -85,7 +86,7 @@ function getClient(): VeryfrontApiClient {
   const tenant = getTenant();
 
   const client = new VeryfrontApiClient({
-    apiBaseUrl: Deno.env.get("VERYFRONT_API_URL") || "https://api.veryfront.com",
+    apiBaseUrl: getEnv("VERYFRONT_API_URL") || "https://api.veryfront.com",
     proxyMode: true,
     projectId: tenant.projectId,
     projectSlug: tenant.projectSlug,

--- a/src/workflow/worker/dynamic-job-entrypoint.ts
+++ b/src/workflow/worker/dynamic-job-entrypoint.ts
@@ -26,6 +26,7 @@
  */
 
 import { logger as baseLogger } from "#veryfront/utils";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 import { enhanceAdapterWithFS } from "#veryfront/platform/adapters/fs/integration.ts";
 import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
@@ -63,8 +64,8 @@ export interface DynamicJobEntrypointConfig {
  * Get tenant context from environment variables
  */
 function getTenantFromEnv(): CapturedTenantContext | undefined {
-  const projectSlug = Deno.env.get("TENANT_PROJECT_SLUG");
-  const token = Deno.env.get("TENANT_TOKEN");
+  const projectSlug = getEnv("TENANT_PROJECT_SLUG");
+  const token = getEnv("TENANT_TOKEN");
 
   if (!projectSlug || !token) {
     return undefined;
@@ -73,9 +74,9 @@ function getTenantFromEnv(): CapturedTenantContext | undefined {
   return {
     projectSlug,
     token,
-    projectId: Deno.env.get("TENANT_PROJECT_ID"),
-    productionMode: Deno.env.get("TENANT_PRODUCTION_MODE") === "1",
-    releaseId: Deno.env.get("TENANT_RELEASE_ID") || undefined,
+    projectId: getEnv("TENANT_PROJECT_ID"),
+    productionMode: getEnv("TENANT_PRODUCTION_MODE") === "1",
+    releaseId: getEnv("TENANT_RELEASE_ID") || undefined,
   };
 }
 
@@ -96,7 +97,7 @@ export async function runDynamicWorkflowJob(
   const { backend, debug = false } = config;
 
   // Get workflow run ID from environment
-  const runId = Deno.env.get("WORKFLOW_RUN_ID");
+  const runId = getEnv("WORKFLOW_RUN_ID");
   if (!runId) {
     logger.error("Missing WORKFLOW_RUN_ID environment variable");
     return DYNAMIC_EXIT_CODES.CONFIG_ERROR;
@@ -138,7 +139,7 @@ export async function runDynamicWorkflowJob(
       },
       async () => {
         // Set up FS adapter with Veryfront API backend
-        const apiUrl = Deno.env.get("VERYFRONT_API_URL") || "https://api.veryfront.com";
+        const apiUrl = getEnv("VERYFRONT_API_URL") || "https://api.veryfront.com";
 
         const fsConfig = {
           fs: {

--- a/src/workflow/worker/job-entrypoint.ts
+++ b/src/workflow/worker/job-entrypoint.ts
@@ -21,6 +21,7 @@
  */
 
 import { logger as baseLogger } from "#veryfront/utils";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 import type { WorkflowBackend } from "../backends/types.ts";
 import type { WorkflowExecutor } from "../executor/workflow-executor.ts";
@@ -56,8 +57,8 @@ export const EXIT_CODES = {
  * Get tenant context from environment variables
  */
 function getTenantFromEnv(): CapturedTenantContext | undefined {
-  const projectSlug = Deno.env.get("TENANT_PROJECT_SLUG");
-  const token = Deno.env.get("TENANT_TOKEN");
+  const projectSlug = getEnv("TENANT_PROJECT_SLUG");
+  const token = getEnv("TENANT_TOKEN");
 
   if (!projectSlug || !token) {
     return undefined;
@@ -66,9 +67,9 @@ function getTenantFromEnv(): CapturedTenantContext | undefined {
   return {
     projectSlug,
     token,
-    projectId: Deno.env.get("TENANT_PROJECT_ID") || undefined,
-    productionMode: Deno.env.get("TENANT_PRODUCTION_MODE") === "1",
-    releaseId: Deno.env.get("TENANT_RELEASE_ID") || undefined,
+    projectId: getEnv("TENANT_PROJECT_ID") || undefined,
+    productionMode: getEnv("TENANT_PRODUCTION_MODE") === "1",
+    releaseId: getEnv("TENANT_RELEASE_ID") || undefined,
   };
 }
 
@@ -103,7 +104,7 @@ export async function runWorkflowJob(config: JobEntrypointConfig): Promise<numbe
   const { backend, executor, debug = false } = config;
 
   // Get workflow run ID from environment
-  const runId = Deno.env.get("WORKFLOW_RUN_ID");
+  const runId = getEnv("WORKFLOW_RUN_ID");
   if (!runId) {
     logger.error("Missing WORKFLOW_RUN_ID environment variable");
     return EXIT_CODES.CONFIG_ERROR;


### PR DESCRIPTION
## Summary
- Replace direct `Deno.env.get()` and `process.env` calls with the centralized `getEnv()` from the platform compat layer
- Ensures consistent env access for secrets auditing, cross-runtime compatibility, and project env overlay support
- 5 files changed across sandbox, workflow, and utils modules

## Test plan
- [x] `deno task verify:quick` passes (lint, format, typecheck)
- [x] Unit tests pass (pre-push hook)