### PR TITLE
refactor: convert .then() promise chains to async/await

### DIFF
--- a/src/client/spa/ClientApp.tsx
+++ b/src/client/spa/ClientApp.tsx
@@ -116,10 +116,11 @@ export function ClientApp({ initialData }: ClientAppProps): JSX.Element {
   useEffect(() => {
     if (state.PageComponent || !initialData.pagePath) return;
 
-    loadComponent(initialData.pagePath).then((Component) => {
+    (async () => {
+      const Component = await loadComponent(initialData.pagePath);
       if (!Component) return;
       setState((prev) => ({ ...prev, PageComponent: Component }));
-    });
+    })();
   }, [initialData.pagePath, state.PageComponent]);
 
   useEffect(() => {

--- a/src/observability/simple-metrics/metrics-recorder.ts
+++ b/src/observability/simple-metrics/metrics-recorder.ts
@@ -11,11 +11,14 @@ import type { RSCRequestKind } from "./types.ts";
 function recordObservability(
   fn: (obs: Awaited<ReturnType<typeof getObservabilityMetrics>>) => void,
 ): void {
-  void getObservabilityMetrics()
-    .then(fn)
-    .catch(() => {
+  void (async () => {
+    try {
+      const obs = await getObservabilityMetrics();
+      fn(obs);
+    } catch {
       /* metrics recording failure - non-critical */
-    });
+    }
+  })();
 }
 
 /**

--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -578,13 +578,14 @@ export class ReadOperations {
     const candidates = EXTENSION_PRIORITY.filter((ext) => ext !== originalExt);
     const startTime = performance.now();
 
-    const promises = candidates.map((ext) =>
-      this.client.getPublishedFileContent(
+    const promises = candidates.map(async (ext) => {
+      const content = await this.client.getPublishedFileContent(
         basePath + ext,
         releaseId ?? undefined,
         environmentName ?? undefined,
-      ).then((content) => ({ ext, content }))
-    );
+      );
+      return { ext, content };
+    });
 
     // Mark all promises as handled to prevent unhandled rejection errors
     // when we return early after a high-priority success (skipping lower-priority promises).

--- a/src/platform/adapters/runtime/node/websocket-adapter.ts
+++ b/src/platform/adapters/runtime/node/websocket-adapter.ts
@@ -20,12 +20,15 @@ export class NodeServerAdapter implements ServerAdapter {
     const protocol = request.headers.get("sec-websocket-protocol");
     const socket = new NodeWebSocket();
 
-    void registerWebSocketUpgrade(key)
-      .then((ws) => socket._attachRealSocket(ws))
-      .catch((error) => {
+    void (async () => {
+      try {
+        const ws = await registerWebSocketUpgrade(key);
+        socket._attachRealSocket(ws);
+      } catch (error) {
         serverLogger.error("WebSocket upgrade failed:", error);
-        socket._emitError(error);
-      });
+        socket._emitError(error instanceof Error ? error : new Error(String(error)));
+      }
+    })();
 
     const headers: Record<string, string> = {
       Upgrade: "websocket",

--- a/src/platform/adapters/runtime/shared/shared-watcher.ts
+++ b/src/platform/adapters/runtime/shared/shared-watcher.ts
@@ -21,10 +21,13 @@ export async function setupNodeFsWatcher(
     const fs = await import("node:fs");
     const fsPromises = await import("node:fs/promises");
 
-    const exists = await fsPromises
-      .access(path)
-      .then(() => true)
-      .catch(() => false);
+    let exists: boolean;
+    try {
+      await fsPromises.access(path);
+      exists = true;
+    } catch {
+      exists = false;
+    }
 
     if (!exists) return;
 

--- a/src/platform/compat/stdin.ts
+++ b/src/platform/compat/stdin.ts
@@ -114,23 +114,20 @@ export function getStdinReader(): StdinReader {
  * Works in both Deno and Node.js.
  */
 export function waitForKeypress(): Promise<void> {
-  return new Promise((resolve) => {
-    if (isDeno) {
+  if (isDeno) {
+    return (async () => {
       Deno.stdin.setRaw(true);
       const reader = Deno.stdin.readable.getReader();
-
-      void reader.read().then(() => {
+      try {
+        await reader.read();
+      } finally {
         Deno.stdin.setRaw(false);
         reader.releaseLock();
-        resolve();
-      }).catch(() => {
-        Deno.stdin.setRaw(false);
-        reader.releaseLock();
-        resolve();
-      });
-      return;
-    }
+      }
+    })();
+  }
 
+  return new Promise((resolve) => {
     const stdin = process?.stdin;
     if (!stdin) {
       resolve();

--- a/src/provider/local/local-engine.ts
+++ b/src/provider/local/local-engine.ts
@@ -241,40 +241,38 @@ export async function* generateStream(
   let resolveWaiting: (() => void) | null = null;
   let done = false;
 
+  function flushWaiting(): void {
+    if (resolveWaiting) {
+      resolveWaiting();
+      resolveWaiting = null;
+    }
+  }
+
   const streamer = new transformers.TextStreamer(pipe.tokenizer, {
     skip_prompt: true,
     skip_special_tokens: true,
     callback_function: (text: string) => {
       tokenQueue.push(text);
-      if (resolveWaiting) {
-        resolveWaiting();
-        resolveWaiting = null;
-      }
+      flushWaiting();
     },
   });
 
   // Start generation in the background
-  const generatePromise = pipe(messages, {
-    max_new_tokens: maxNewTokens,
-    temperature,
-    top_p: topP,
-    top_k: topK,
-    do_sample: temperature > 0,
-    streamer,
-  }).then(() => {
-    done = true;
-    if (resolveWaiting) {
-      resolveWaiting();
-      resolveWaiting = null;
+  const generatePromise = (async () => {
+    try {
+      await pipe(messages, {
+        max_new_tokens: maxNewTokens,
+        temperature,
+        top_p: topP,
+        top_k: topK,
+        do_sample: temperature > 0,
+        streamer,
+      });
+    } finally {
+      done = true;
+      flushWaiting();
     }
-  }).catch((error: Error) => {
-    done = true;
-    if (resolveWaiting) {
-      resolveWaiting();
-      resolveWaiting = null;
-    }
-    throw error;
-  });
+  })();
 
   // Yield tokens as they arrive
   while (true) {

--- a/src/server/dev-server/request-handler.ts
+++ b/src/server/dev-server/request-handler.ts
@@ -88,10 +88,13 @@ export class RequestHandler {
     });
   }
 
-  private incrementRequestMetrics(): void {
-    void import("#veryfront/observability/simple-metrics/index.ts")
-      .then(({ metrics }) => metrics.incRequest())
-      .catch((error: unknown) => logger.debug("[dev] metrics.incRequest failed", error));
+  private async incrementRequestMetrics(): Promise<void> {
+    try {
+      const { metrics } = await import("#veryfront/observability/simple-metrics/index.ts");
+      metrics.incRequest();
+    } catch (error) {
+      logger.debug("[dev] metrics.incRequest failed", error);
+    }
   }
 
   private handleDevEndpoint(req: Request, pathname: string): Response | null {

--- a/src/server/dev-ui/dashboard/components/AITab.tsx
+++ b/src/server/dev-ui/dashboard/components/AITab.tsx
@@ -58,23 +58,34 @@ export function AITab({ tools, resources, prompts, agents }: AITabProps): React.
   const [workflowsError, setWorkflowsError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch("/_dev/api/infrastructure")
-      .then((res) => res.json())
-      .then((d) => {
+    async function loadProviders(): Promise<void> {
+      try {
+        const res = await fetch("/_dev/api/infrastructure");
+        const d = await res.json();
         setProviders(d.providers ?? []);
         setProvidersError(null);
-      })
-      .catch((e: unknown) => setProvidersError(e instanceof Error ? e.message : String(e)))
-      .finally(() => setProvidersLoading(false));
+      } catch (e: unknown) {
+        setProvidersError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setProvidersLoading(false);
+      }
+    }
 
-    fetch("/_dev/api/workflows")
-      .then((res) => res.json())
-      .then((d) => {
+    async function loadWorkflows(): Promise<void> {
+      try {
+        const res = await fetch("/_dev/api/workflows");
+        const d = await res.json();
         setWorkflows(d.workflows ?? []);
         setWorkflowsError(null);
-      })
-      .catch((e: unknown) => setWorkflowsError(e instanceof Error ? e.message : String(e)))
-      .finally(() => setWorkflowsLoading(false));
+      } catch (e: unknown) {
+        setWorkflowsError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setWorkflowsLoading(false);
+      }
+    }
+
+    loadProviders();
+    loadWorkflows();
   }, []);
 
   function navigateToMCP(mcpSubTab: "tools" | "resources" | "prompts", itemId: string): void {

--- a/src/server/dev-ui/dashboard/components/ConfigTab.tsx
+++ b/src/server/dev-ui/dashboard/components/ConfigTab.tsx
@@ -26,32 +26,34 @@ export function ConfigTab(): React.JSX.Element {
   const [debugContent, setDebugContent] = useState<string>("");
   const [debugLoading, setDebugLoading] = useState<boolean>(true);
 
-  function loadConfig(): void {
+  async function loadConfig(): Promise<void> {
     setLoading(true);
 
-    fetch("/_dev/api/config")
-      .then((res) => res.json())
-      .then((d) => {
-        setData(d);
-        setError(null);
-      })
-      .catch((e: unknown) => {
-        setError(e instanceof Error ? e.message : String(e));
-      })
-      .finally(() => setLoading(false));
+    try {
+      const res = await fetch("/_dev/api/config");
+      const d = await res.json();
+      setData(d);
+      setError(null);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
   }
 
-  function loadDebug(): void {
+  async function loadDebug(): Promise<void> {
     setDebugLoading(true);
 
-    fetch("/_vf_debug/context")
-      .then((res) => res.json())
-      .then((d) => setDebugContent(JSON.stringify(d, null, 2)))
-      .catch((e: unknown) => {
-        const message = e instanceof Error ? e.message : String(e);
-        setDebugContent(`Error: ${message}`);
-      })
-      .finally(() => setDebugLoading(false));
+    try {
+      const res = await fetch("/_vf_debug/context");
+      const d = await res.json();
+      setDebugContent(JSON.stringify(d, null, 2));
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      setDebugContent(`Error: ${message}`);
+    } finally {
+      setDebugLoading(false);
+    }
   }
 
   function refresh(): void {

--- a/src/server/dev-ui/dashboard/components/ErrorsTab.tsx
+++ b/src/server/dev-ui/dashboard/components/ErrorsTab.tsx
@@ -43,19 +43,19 @@ export function ErrorsTab(): React.JSX.Element {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [selectedError, setSelectedError] = useState<ErrorEntry | null>(null);
 
-  function loadData(): void {
+  async function loadData(): Promise<void> {
     setLoading(true);
 
-    fetch("/_dev/api/errors")
-      .then((res) => res.json())
-      .then((d: ErrorsData) => {
-        setData(d);
-        setError(null);
-      })
-      .catch((e: unknown) => {
-        setError(e instanceof Error ? e.message : String(e));
-      })
-      .finally(() => setLoading(false));
+    try {
+      const res = await fetch("/_dev/api/errors");
+      const d: ErrorsData = await res.json();
+      setData(d);
+      setError(null);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
   }
 
   useEffect(() => {

--- a/src/server/dev-ui/dashboard/components/FilesTab.tsx
+++ b/src/server/dev-ui/dashboard/components/FilesTab.tsx
@@ -109,16 +109,20 @@ function FileDetail({ path }: { path: string }): React.ReactElement {
   const ext = useMemo((): string => path.split(".").pop()?.toLowerCase() ?? "", [path]);
 
   useEffect(() => {
-    setLoading(true);
-
-    fetch(`/_dev/api/file-content?path=${encodeURIComponent(path)}`)
-      .then((res) => res.json())
-      .then(setContent)
-      .catch((e: unknown) => {
+    async function loadContent(): Promise<void> {
+      setLoading(true);
+      try {
+        const res = await fetch(`/_dev/api/file-content?path=${encodeURIComponent(path)}`);
+        const data = await res.json();
+        setContent(data);
+      } catch (e: unknown) {
         const message = e instanceof Error ? e.message : String(e);
         setContent({ error: message });
-      })
-      .finally(() => setLoading(false));
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadContent();
   }, [path]);
 
   const title = !loading && content?.content !== undefined ? "Contents" : undefined;

--- a/src/server/dev-ui/dashboard/components/RuntimeTab.tsx
+++ b/src/server/dev-ui/dashboard/components/RuntimeTab.tsx
@@ -40,20 +40,30 @@ export function RuntimeTab(): React.JSX.Element {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  function loadData(): void {
+  async function loadData(): Promise<void> {
     setLoading(true);
 
-    Promise.all([
-      fetch("/_dev/api/metrics").then((r) => r.json()),
-      fetch("/_dev/api/memory").then((r) => r.json()),
-    ])
-      .then(([m, mem]) => {
-        setMetrics(m.counters || {});
-        setMemory(mem);
-        setError(null);
-      })
-      .catch((e) => setError((e as Error).message))
-      .finally(() => setLoading(false));
+    try {
+      const fetchMetrics = async (): Promise<{ counters?: Record<string, number | unknown> }> => {
+        const r = await fetch("/_dev/api/metrics");
+        return await r.json();
+      };
+      const fetchMemory = async (): Promise<MemoryData> => {
+        const r = await fetch("/_dev/api/memory");
+        return await r.json();
+      };
+      const [m, mem] = await Promise.all([
+        fetchMetrics(),
+        fetchMemory(),
+      ]);
+      setMetrics(m.counters || {});
+      setMemory(mem);
+      setError(null);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
   }
 
   useEffect(() => {

--- a/src/server/dev-ui/dashboard/components/ServerTab.tsx
+++ b/src/server/dev-ui/dashboard/components/ServerTab.tsx
@@ -42,9 +42,17 @@ export function ServerTab(): React.ReactElement {
       setLoading(true);
 
       try {
+        const fetchHandlers = async (): Promise<{ handlers?: Handler[] }> => {
+          const r = await fetch("/_dev/api/handlers");
+          return await r.json();
+        };
+        const fetchBuild = async (): Promise<BuildInfo> => {
+          const r = await fetch("/_dev/api/build");
+          return await r.json();
+        };
         const [handlersRes, buildRes] = await Promise.all([
-          fetch("/_dev/api/handlers").then((r) => r.json()),
-          fetch("/_dev/api/build").then((r) => r.json()),
+          fetchHandlers(),
+          fetchBuild(),
         ]);
 
         if (cancelled) return;

--- a/src/server/dev-ui/projects/App.tsx
+++ b/src/server/dev-ui/projects/App.tsx
@@ -30,10 +30,16 @@ export function App(): React.JSX.Element {
   const abortControllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
-    fetch("/_projects/api/config")
-      .then((r) => r.json())
-      .then(setConfig)
-      .catch((e) => console.error("Failed to load config:", e));
+    async function loadConfig(): Promise<void> {
+      try {
+        const r = await fetch("/_projects/api/config");
+        const data = await r.json();
+        setConfig(data);
+      } catch (e) {
+        console.error("Failed to load config:", e);
+      }
+    }
+    loadConfig();
   }, []);
 
   const fetchProjects = useCallback(async (searchQuery: string): Promise<void> => {

--- a/src/server/runtime-handler/local-project-discovery.ts
+++ b/src/server/runtime-handler/local-project-discovery.ts
@@ -54,10 +54,19 @@ async function isValidLocalProjectPath(path: string, adapter: RuntimeAdapter): P
     throw error; // Unexpected errors (permissions, I/O) propagate to caller
   }
 
+  const checkDir = async (subPath: string): Promise<boolean> => {
+    try {
+      const s = await adapter.fs.stat(subPath);
+      return s?.isDirectory ?? false;
+    } catch {
+      return false;
+    }
+  };
+
   const [hasApp, hasPages, hasComponents] = await Promise.all([
-    adapter.fs.stat(`${path}/app`).then((s) => s?.isDirectory).catch(() => false),
-    adapter.fs.stat(`${path}/pages`).then((s) => s?.isDirectory).catch(() => false),
-    adapter.fs.stat(`${path}/components`).then((s) => s?.isDirectory).catch(() => false),
+    checkDir(`${path}/app`),
+    checkDir(`${path}/pages`),
+    checkDir(`${path}/components`),
   ]);
 
   return hasApp || hasPages || hasComponents;

--- a/src/studio/bridge/bridge-markdown-editor.ts
+++ b/src/studio/bridge/bridge-markdown-editor.ts
@@ -86,7 +86,7 @@ function setupMarkdownLexicalEditor(): void {
   }
 
   // deno-lint-ignore no-explicit-any -- dynamic ESM CDN imports have no static types
-  state.markdownLexicalSetupPromise = (async function (): Promise<void> {
+  state.markdownLexicalSetupPromise = (async () => {
     try {
       const modules: any[] = await Promise.all([
         import("https://esm.sh/lexical@0.21.0?target=es2022"),

--- a/src/transforms/esm/in-flight-manager.ts
+++ b/src/transforms/esm/in-flight-manager.ts
@@ -127,14 +127,17 @@ export function trackBundleAccumulator(
 ): void {
   const accumulator = bundleAccumulatorStorage.getStore();
   if (accumulator) {
-    void createFileSystem().stat(cachePath).then((stat) => {
-      accumulator.push({
-        hash: String(hash),
-        url: normalizedUrl,
-        sizeBytes: stat?.size ?? 0,
-      });
-    }).catch(() => {
-      // Ignore stat errors
-    });
+    void (async () => {
+      try {
+        const stat = await createFileSystem().stat(cachePath);
+        accumulator.push({
+          hash: String(hash),
+          url: normalizedUrl,
+          sizeBytes: stat?.size ?? 0,
+        });
+      } catch {
+        // Ignore stat errors
+      }
+    })();
   }
 }

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts
@@ -210,19 +210,22 @@ export function writeDistributedCache(
   const bundlePaths = extractHttpBundlePaths(moduleCode);
   if (bundlePaths.length > 0) {
     const entries = bundlePaths.map((b) => ({ hash: b.hash, url: "", sizeBytes: 0 }));
-    void createBundleManifest(entries).then(async (manifest) => {
-      await storeBundleManifest(manifest);
-      const bundleManifestKey = `${transformCacheKey}:bm`;
-      await distributedCache.set(
-        bundleManifestKey,
-        manifest.manifestId,
-        TRANSFORM_CACHE_TTL_SECONDS,
-      );
-    }).catch((error) => {
-      log.debug(`${LOG_PREFIX_MDX_LOADER} Bundle manifest creation failed`, {
-        normalizedPath,
-        error,
-      });
-    });
+    void (async () => {
+      try {
+        const manifest = await createBundleManifest(entries);
+        await storeBundleManifest(manifest);
+        const bundleManifestKey = `${transformCacheKey}:bm`;
+        await distributedCache.set(
+          bundleManifestKey,
+          manifest.manifestId,
+          TRANSFORM_CACHE_TTL_SECONDS,
+        );
+      } catch (error) {
+        log.debug(`${LOG_PREFIX_MDX_LOADER} Bundle manifest creation failed`, {
+          normalizedPath,
+          error,
+        });
+      }
+    })();
   }
 }

--- a/src/workflow/worker/executors/process.ts
+++ b/src/workflow/worker/executors/process.ts
@@ -225,37 +225,40 @@ export class ProcessJobExecutor implements JobExecutor {
     }, timeout);
 
     // Wait for process to complete (fire-and-forget with error handling)
-    void job.process.status.then((status) => {
-      clearTimeout(timeoutId);
+    void (async () => {
+      try {
+        const status = await job.process.status;
+        clearTimeout(timeoutId);
 
-      job.completedAt = new Date();
+        job.completedAt = new Date();
 
-      if (job.status === "failed") {
-        // Already marked as failed (e.g. timeout) — don't overwrite
-        return;
-      }
-
-      if (status.success) {
-        job.status = "succeeded";
-
-        if (this.config.debug) {
-          logger.info(`Job ${job.jobId} succeeded`);
+        if (job.status === "failed") {
+          // Already marked as failed (e.g. timeout) — don't overwrite
+          return;
         }
-      } else {
+
+        if (status.success) {
+          job.status = "succeeded";
+
+          if (this.config.debug) {
+            logger.info(`Job ${job.jobId} succeeded`);
+          }
+        } else {
+          job.status = "failed";
+          job.error = `Process exited with code ${status.code}`;
+
+          logger.error(`Job ${job.jobId} failed with code ${status.code}`);
+        }
+      } catch (error) {
+        clearTimeout(timeoutId);
+
         job.status = "failed";
-        job.error = `Process exited with code ${status.code}`;
+        job.error = error instanceof Error ? error.message : String(error);
+        job.completedAt = new Date();
 
-        logger.error(`Job ${job.jobId} failed with code ${status.code}`);
+        logger.error(`Job ${job.jobId} error:`, error);
       }
-    }).catch((error) => {
-      clearTimeout(timeoutId);
-
-      job.status = "failed";
-      job.error = error instanceof Error ? error.message : String(error);
-      job.completedAt = new Date();
-
-      logger.error(`Job ${job.jobId} error:`, error);
-    });
+    })();
 
     // Log stdout/stderr in debug mode
     if (this.config.debug) {


### PR DESCRIPTION
## Summary

- Convert ~48 `.then()` promise chains across 34 files to `async/await` with proper `try/catch` error handling
- Improves stack traces, readability, and error handling consistency
- Intentionally preserves `.then()` in template strings (service worker, import rewriter), mutex/queue patterns (upload-store, module cache), microtask scheduling (bdd.ts), and promise deduplication (memoize.ts)

## Test plan

- [x] `deno fmt` — no formatting issues
- [x] `deno task verify:quick` — lint + typecheck green
- [x] `deno test` — 964 tests passed, 0 failed