### PR TITLE
refactor: clean up deprecated APIs and migrate callers

### DIFF
--- a/cli/commands/dev/command.ts
+++ b/cli/commands/dev/command.ts
@@ -107,7 +107,6 @@ export function devCommand(options: DevOptions): Promise<DevCommandResult> {
         devServer = await startDevServer({
           port: finalPort,
           projectDir,
-          hmrPort: finalPort + 1,
           enableHMR,
           enableFastRefresh: true,
           signal: shutdownController.signal,

--- a/cli/commands/start/command.ts
+++ b/cli/commands/start/command.ts
@@ -217,7 +217,6 @@ export async function startCommand(options: StartOptions): Promise<void> {
     server = await startCliDevServer({
       port,
       projectDir,
-      hmrPort: port + 1,
       enableHMR: true,
       enableFastRefresh: true,
       signal: shutdownController.signal,

--- a/cli/shared/server-startup.ts
+++ b/cli/shared/server-startup.ts
@@ -58,7 +58,6 @@ export interface StartCliDevServerOptions {
   port: number;
   projectDir: string;
   signal: AbortSignal;
-  hmrPort?: number;
   enableHMR?: boolean;
   enableFastRefresh?: boolean;
 }
@@ -69,7 +68,6 @@ export async function startCliDevServer(
   const devOptions: DevServerOptions = {
     port: options.port,
     projectDir: options.projectDir,
-    hmrPort: options.hmrPort,
     enableHMR: options.enableHMR,
     enableFastRefresh: options.enableFastRefresh,
     signal: options.signal,

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -94,7 +94,6 @@ export type {
   AgentStreamResult,
   EdgeConfig,
   MemoryConfig,
-  Message,
   Message as AgentMessage,
   MessagePart,
   ModelProvider,

--- a/src/platform/README.md
+++ b/src/platform/README.md
@@ -138,10 +138,11 @@ interface RuntimeAdapter {
 ### Platform Detection
 
 ```typescript
-import { detectRuntime } from "#veryfront/platform/compat/runtime";
+import { runtime } from "#veryfront/platform/adapters/registry.ts";
 
-const runtime = detectRuntime();
+const adapter = await runtime.get();
 // Uses feature detection, not user agent
+// adapter.id is "deno" | "node" | "bun" | "cloudflare"
 ```
 
 ### Virtual Filesystems

--- a/src/platform/adapters/detect.test.ts
+++ b/src/platform/adapters/detect.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { isBun, isDeno, isNode } from "#veryfront/platform/compat/runtime.ts";
-import { detectRuntime, getAdapter } from "./detect.ts";
+import { getAdapter } from "./detect.ts";
 import type { RuntimeId } from "./base.ts";
 
 function getExpectedRuntime(): RuntimeId {
@@ -12,30 +12,8 @@ function getExpectedRuntime(): RuntimeId {
 }
 
 const expectedRuntime = getExpectedRuntime();
-const validRuntimes: Array<RuntimeId | "unknown"> = [
-  "deno",
-  "node",
-  "bun",
-  "cloudflare",
-  "unknown",
-];
 
 describe("detect.ts", () => {
-  describe("detectRuntime", () => {
-    it("should return a valid runtime identifier", () => {
-      const runtime = detectRuntime();
-      assertEquals(validRuntimes.includes(runtime), true);
-    });
-
-    it("should detect current runtime in this test environment", () => {
-      assertEquals(detectRuntime(), expectedRuntime);
-    });
-
-    it("should return string type", () => {
-      assertEquals(typeof detectRuntime(), "string");
-    });
-  });
-
   describe("getAdapter", () => {
     it("should return a valid RuntimeAdapter", async () => {
       const adapter = await getAdapter();

--- a/src/platform/adapters/detect.ts
+++ b/src/platform/adapters/detect.ts
@@ -4,9 +4,6 @@ import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import { detectRuntime } from "./runtime-detection.ts";
 import type { RuntimeAdapter } from "./base.ts";
 
-// Re-export from standalone module to avoid circular dependency
-export { detectRuntime } from "./runtime-detection.ts";
-
 // Re-export the registry for convenient access
 export { runtime } from "./registry.ts";
 

--- a/src/platform/adapters/fs/factory.ts
+++ b/src/platform/adapters/fs/factory.ts
@@ -5,18 +5,12 @@ import {
   clearSSRModuleCache,
   clearSSRModuleCacheForProject,
 } from "#veryfront/modules/react-loader/ssr-module-loader/cache/index.ts";
-import {
-  clearRouterDetectionCache,
-  clearRouterDetectionCacheForProject,
-} from "#veryfront/rendering/router-detection.ts";
+import { clearRouterDetectionCacheForProject } from "#veryfront/rendering/router-detection.ts";
 import {
   clearModulePathCache,
   invalidateModulePaths,
 } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
-import {
-  clearSnippetCache,
-  clearSnippetCacheForProject,
-} from "#veryfront/rendering/snippet-renderer.ts";
+import { clearSnippetCacheForProject } from "#veryfront/rendering/snippet-renderer.ts";
 import { clearRendererCacheForProject } from "#veryfront/rendering/renderer.ts";
 import { invalidateProjectCSS } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
 import { invalidateProjectCandidateManifests } from "#veryfront/rendering/orchestrator/css-candidate-manifest.ts";
@@ -44,10 +38,8 @@ export function createFSAdapter(config: FSAdapterConfig): Promise<FSAdapter> {
           ...config,
           invalidationCallbacks: {
             clearSSRModuleCache,
-            clearRouterDetectionCache,
             clearModulePathCache,
             invalidateModulePaths,
-            clearSnippetCache,
             clearSSRModuleCacheForProject,
             clearRouterDetectionCacheForProject,
             clearSnippetCacheForProject,

--- a/src/platform/adapters/fs/veryfront/proxy-manager.ts
+++ b/src/platform/adapters/fs/veryfront/proxy-manager.ts
@@ -7,18 +7,12 @@ import {
   clearSSRModuleCache,
   clearSSRModuleCacheForProject,
 } from "#veryfront/modules/react-loader/ssr-module-loader/cache/index.ts";
-import {
-  clearRouterDetectionCache,
-  clearRouterDetectionCacheForProject,
-} from "#veryfront/rendering/router-detection.ts";
+import { clearRouterDetectionCacheForProject } from "#veryfront/rendering/router-detection.ts";
 import {
   clearModulePathCache,
   invalidateModulePaths,
 } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
-import {
-  clearSnippetCache,
-  clearSnippetCacheForProject,
-} from "#veryfront/rendering/snippet-renderer.ts";
+import { clearSnippetCacheForProject } from "#veryfront/rendering/snippet-renderer.ts";
 import { clearRendererCacheForProject } from "#veryfront/rendering/renderer.ts";
 import { GetAdapterParamsSchema } from "./schemas/index.ts";
 
@@ -313,10 +307,8 @@ export class ProxyFSAdapterManager {
       },
       invalidationCallbacks: {
         clearSSRModuleCache,
-        clearRouterDetectionCache,
         clearModulePathCache,
         invalidateModulePaths,
-        clearSnippetCache,
         clearSSRModuleCacheForProject,
         clearRouterDetectionCacheForProject,
         clearSnippetCacheForProject,

--- a/src/platform/adapters/fs/veryfront/types.ts
+++ b/src/platform/adapters/fs/veryfront/types.ts
@@ -124,14 +124,11 @@ export interface InvalidationProjectContext {
 export interface InvalidationCallbacks {
   clearSSRModuleCache?: () => void;
   clearSSRModuleCacheForProject?: (projectId: string) => void;
-  clearRouterDetectionCache?: () => void;
   clearRouterDetectionCacheForProject?: (projectDir: string) => void;
   clearModulePathCache?: () => void;
   invalidateModulePaths?: (changedPaths: string[]) => void;
-  clearSnippetCache?: () => void;
   clearSnippetCacheForProject?: (projectSlug: string) => void;
   triggerReload?: (changedPaths?: string[], project?: InvalidationProjectContext) => void;
-  clearRendererCache?: () => void | Promise<void>;
   clearRendererCacheForProject?: (projectId: string) => void | Promise<void>;
   /** Invalidate project-level CSS cache when source files change */
   clearProjectCSSCache?: (projectSlug: string) => void;

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -651,16 +651,12 @@ export class WebSocketManager {
 
     if (this.deps.invalidationCallbacks.clearRouterDetectionCacheForProject && projectDir) {
       this.deps.invalidationCallbacks.clearRouterDetectionCacheForProject(projectDir);
-    } else {
-      this.deps.invalidationCallbacks.clearRouterDetectionCache?.();
     }
 
     this.deps.invalidationCallbacks.clearModulePathCache?.();
 
     if (this.deps.invalidationCallbacks.clearSnippetCacheForProject && this.deps.projectSlug) {
       this.deps.invalidationCallbacks.clearSnippetCacheForProject(this.deps.projectSlug);
-    } else {
-      this.deps.invalidationCallbacks.clearSnippetCache?.();
     }
 
     if (this.deps.invalidationCallbacks.clearRendererCacheForProject && projectId) {

--- a/src/platform/adapters/index.ts
+++ b/src/platform/adapters/index.ts
@@ -27,7 +27,6 @@ export type {
 } from "./base.ts";
 
 // Detection & registry
-export { detectRuntime } from "./detect.ts";
 export { getAdapter } from "./detect.ts";
 export { getLocalAdapter, resetLocalAdapter, runtime } from "./registry.ts";
 

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -425,16 +425,6 @@ export class Renderer {
     await this.cache.clearForContext(ctx);
   }
 
-  /**
-   * Clear all cached render results (across all contexts).
-   * Called by poke/invalidation handlers to ensure fresh renders.
-   * @deprecated Use clearCacheForProject for multi-tenant deployments
-   */
-  async clearAllCaches(): Promise<void> {
-    logger.debug("Clearing ALL render caches (global)");
-    await this.cache.clearAll();
-  }
-
   async clearCacheForProject(projectId: string): Promise<void> {
     logger.debug("Clearing render cache for project", { projectId });
     await this.cache.clearForProject(projectId);
@@ -573,21 +563,6 @@ export async function destroyRenderer(): Promise<void> {
 
   await renderer.destroy();
   renderer = null;
-}
-
-/**
- * Clear all cached render results from the singleton renderer.
- * Safe to call even if renderer is not initialized (no-op).
- * @deprecated Use clearRendererCacheForProject for multi-tenant deployments
- */
-export async function clearRendererCaches(): Promise<void> {
-  logger.debug("clearRendererCaches called (global)", { hasRenderer: !!renderer });
-  if (!renderer) {
-    logger.debug("No renderer instance, skipping cache clear");
-    return;
-  }
-
-  await renderer.clearAllCaches();
 }
 
 export async function clearRendererCacheForProject(projectId: string): Promise<void> {

--- a/src/routing/README.md
+++ b/src/routing/README.md
@@ -28,7 +28,7 @@ The routing module provides pattern-based URL matching, dynamic route handling, 
 ```
 routing/
 ├── matchers/              # Route pattern matching
-│   ├── router.ts         # DynamicRouter implementation
+│   ├── router.ts         # PageRouteMatcher implementation
 │   ├── matcher.ts        # Pattern matching logic
 │   └── types.ts          # Route types
 ├── slug-mapper/          # Path/slug conversion
@@ -54,7 +54,7 @@ routing/
 
 ### Route Matching
 
-- `DynamicRouter` - Main router class
+- `PageRouteMatcher` - Main router class
 - `matchRoute(pattern, path)` - Match URL to pattern
 - `parseRoute(pattern)` - Parse route pattern
 - `getSpecificityScore(pattern)` - Calculate route priority
@@ -108,10 +108,10 @@ None (zero external dependencies)
 ### Route Matching
 
 ```typescript
-import { DynamicRouter, normalizePath } from "#veryfront/routing";
+import { normalizePath, PageRouteMatcher } from "#veryfront/routing";
 
 // Create router
-const router = new DynamicRouter();
+const router = new PageRouteMatcher();
 
 // Add routes
 router.addRoute({

--- a/src/routing/api/README.md
+++ b/src/routing/api/README.md
@@ -17,7 +17,7 @@ import { APIRouteHandler, json, notFound } from "./api/index.ts";
 The API module exports:
 
 - **`APIRouteHandler`** - Main class for API route discovery and execution
-- **`DynamicRouter`** - File-based dynamic route matching with parameters
+- **`ApiRouteMatcher`** - File-based dynamic route matching with parameters
 - **Response helpers** - `json()`, `redirect()`, `notFound()`, `badRequest()`, etc.
 - **CORS utilities** - CORS preflight and header handling
 - **Context utilities** - Request context creation and parsing
@@ -29,7 +29,7 @@ api/
 ├── index.ts                    # Public API (barrel file) ← USE THIS
 ├── README.md                   # This file
 ├── handler.ts                  # APIRouteHandler implementation
-├── api-route-matcher.ts        # DynamicRouter implementation
+├── api-route-matcher.ts        # ApiRouteMatcher implementation
 ├── responses.ts                # Response helper functions
 ├── cors-handler.ts             # CORS utilities
 ├── context-builder.ts          # Context creation utilities

--- a/src/routing/api/api-route-matcher.test.ts
+++ b/src/routing/api/api-route-matcher.test.ts
@@ -1,11 +1,11 @@
 import { assertEquals, assertExists, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
-import { DynamicRouter } from "./api-route-matcher.ts";
+import { ApiRouteMatcher } from "./api-route-matcher.ts";
 
-const routers: DynamicRouter[] = [];
+const routers: ApiRouteMatcher[] = [];
 
-function createRouter(): DynamicRouter {
-  const router = new DynamicRouter();
+function createRouter(): ApiRouteMatcher {
+  const router = new ApiRouteMatcher();
   routers.push(router);
   return router;
 }
@@ -14,7 +14,7 @@ afterEach((): void => {
   while (routers.length) routers.pop()?.destroy();
 });
 
-describe("DynamicRouter", () => {
+describe("ApiRouteMatcher", () => {
   describe("Static routes", () => {
     it("matches exact static routes", () => {
       const router = createRouter();

--- a/src/routing/api/api-route-matcher.ts
+++ b/src/routing/api/api-route-matcher.ts
@@ -183,9 +183,6 @@ export class ApiRouteMatcher {
   }
 }
 
-/** @deprecated Use ApiRouteMatcher instead - kept for backwards compatibility */
-export { ApiRouteMatcher as DynamicRouter };
-
 function shouldDisableLruInterval(): boolean {
   if ((globalThis as Record<string, unknown>).__vfDisableLruInterval === true) return true;
 

--- a/src/routing/api/dynamic-router.test.ts
+++ b/src/routing/api/dynamic-router.test.ts
@@ -1,11 +1,11 @@
 import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
-import { DynamicRouter } from "./api-route-matcher.ts";
+import { ApiRouteMatcher } from "./api-route-matcher.ts";
 
-const routers: DynamicRouter[] = [];
+const routers: ApiRouteMatcher[] = [];
 
-function createRouter(): DynamicRouter {
-  const router = new DynamicRouter();
+function createRouter(): ApiRouteMatcher {
+  const router = new ApiRouteMatcher();
   routers.push(router);
   return router;
 }
@@ -14,7 +14,7 @@ afterEach((): void => {
   for (const router of routers.splice(0)) router.destroy();
 });
 
-describe("DynamicRouter - Basic Route Matching", () => {
+describe("ApiRouteMatcher - Basic Route Matching", () => {
   describe("addRoute() and match()", () => {
     it("should match exact static routes", () => {
       const router = createRouter();
@@ -72,7 +72,7 @@ describe("DynamicRouter - Basic Route Matching", () => {
   });
 });
 
-describe("DynamicRouter - Dynamic Parameters", () => {
+describe("ApiRouteMatcher - Dynamic Parameters", () => {
   describe("Single parameter routes [param]", () => {
     it("should match and extract single parameter", () => {
       const router = createRouter();
@@ -205,7 +205,7 @@ describe("DynamicRouter - Dynamic Parameters", () => {
   });
 });
 
-describe("DynamicRouter - Route Priority", () => {
+describe("ApiRouteMatcher - Route Priority", () => {
   describe("Static routes have priority over dynamic", () => {
     it("should match static route before dynamic", () => {
       const router = createRouter();
@@ -265,7 +265,7 @@ describe("DynamicRouter - Route Priority", () => {
   });
 });
 
-describe("DynamicRouter - Cache Management", () => {
+describe("ApiRouteMatcher - Cache Management", () => {
   describe("Route caching", () => {
     it("should cache successful matches", () => {
       const router = createRouter();
@@ -309,7 +309,7 @@ describe("DynamicRouter - Cache Management", () => {
   });
 });
 
-describe("DynamicRouter - Utility Methods", () => {
+describe("ApiRouteMatcher - Utility Methods", () => {
   describe("listRoutes()", () => {
     it("should list all registered routes", () => {
       const router = createRouter();

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -8,7 +8,7 @@ import { badGateway, internalServerError, notFound } from "#veryfront/http/respo
 import type { CORSConfig } from "#veryfront/security";
 import { applyCORSHeaders, handleCORSPreflight } from "#veryfront/security";
 import { type APIContext } from "./context-builder.ts";
-import { DynamicRouter, type RouteMatch } from "./api-route-matcher.ts";
+import { ApiRouteMatcher, type RouteMatch } from "./api-route-matcher.ts";
 import type { APIRoute } from "./module-loader/types.ts";
 import { loadHandlerModule } from "./module-loader/loader.ts";
 import { discoverAppRoutes, discoverPagesRoutes } from "./route-discovery.ts";
@@ -57,7 +57,7 @@ export interface APIResponse {
 export type APIHandler = (ctx: APIContext) => Promise<Response> | Response;
 
 export class APIRouteHandler {
-  private router = new DynamicRouter();
+  private router = new ApiRouteMatcher();
   private routeCache = new LRUCache<string, APIRoute>({ maxEntries: HANDLER_CACHE_MAX_ENTRIES });
   private lastErrorMessage: string | null = null;
 

--- a/src/routing/api/index.ts
+++ b/src/routing/api/index.ts
@@ -7,7 +7,7 @@
 export { APIRouteHandler } from "./handler.ts";
 export type { APIContext, APIHandler, APIResponse, APIRoute } from "./handler.ts";
 
-export { ApiRouteMatcher, DynamicRouter } from "./api-route-matcher.ts";
+export { ApiRouteMatcher } from "./api-route-matcher.ts";
 export type { Route, RouteMatch } from "./api-route-matcher.ts";
 
 export {

--- a/src/routing/api/openapi/spec-generator.ts
+++ b/src/routing/api/openapi/spec-generator.ts
@@ -8,7 +8,7 @@
 
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
-import type { DynamicRouter, RouteEntry } from "../api-route-matcher.ts";
+import type { ApiRouteMatcher, RouteEntry } from "../api-route-matcher.ts";
 import { loadHandlerModule } from "../module-loader/loader.ts";
 import {
   getDefaultStatusDescription,
@@ -41,7 +41,7 @@ interface GenerateSpecOptions {
 }
 
 export async function generateOpenAPISpec(
-  router: DynamicRouter,
+  router: ApiRouteMatcher,
   projectDir: string,
   adapter: RuntimeAdapter,
   config?: VeryfrontConfig,
@@ -213,7 +213,7 @@ function buildOperation(
 }
 
 export async function generateOpenAPIJson(
-  router: DynamicRouter,
+  router: ApiRouteMatcher,
   projectDir: string,
   adapter: RuntimeAdapter,
   config?: VeryfrontConfig,

--- a/src/routing/api/route-discovery-app.test.ts
+++ b/src/routing/api/route-discovery-app.test.ts
@@ -1,13 +1,13 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
-import { DynamicRouter } from "./api-route-matcher.ts";
+import { ApiRouteMatcher } from "./api-route-matcher.ts";
 import { discoverAppRoutes } from "./route-discovery.ts";
 
-const routers: DynamicRouter[] = [];
+const routers: ApiRouteMatcher[] = [];
 
-function createRouter(): DynamicRouter {
-  const router = new DynamicRouter();
+function createRouter(): ApiRouteMatcher {
+  const router = new ApiRouteMatcher();
   routers.push(router);
   return router;
 }
@@ -362,8 +362,8 @@ describe("route-discovery.ts - App Router Discovery", () => {
     });
   });
 
-  describe("discoverAppRoutes() - Integration with DynamicRouter", () => {
-    it("should add routes that can be matched by DynamicRouter", async () => {
+  describe("discoverAppRoutes() - Integration with ApiRouteMatcher", () => {
+    it("should add routes that can be matched by ApiRouteMatcher", async () => {
       const adapter = createMockAdapter();
       const router = createRouter();
 

--- a/src/routing/api/route-discovery-pages.test.ts
+++ b/src/routing/api/route-discovery-pages.test.ts
@@ -1,13 +1,13 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
-import { DynamicRouter } from "./api-route-matcher.ts";
+import { ApiRouteMatcher } from "./api-route-matcher.ts";
 import { discoverPagesRoutes } from "./route-discovery.ts";
 
-const routers: DynamicRouter[] = [];
+const routers: ApiRouteMatcher[] = [];
 
-function createRouter(): DynamicRouter {
-  const router = new DynamicRouter();
+function createRouter(): ApiRouteMatcher {
+  const router = new ApiRouteMatcher();
   routers.push(router);
   return router;
 }
@@ -420,8 +420,8 @@ describe("route-discovery.ts - Pages Router Discovery", () => {
     });
   });
 
-  describe("discoverPagesRoutes() - Integration with DynamicRouter", () => {
-    it("should add routes that can be matched by DynamicRouter", async () => {
+  describe("discoverPagesRoutes() - Integration with ApiRouteMatcher", () => {
+    it("should add routes that can be matched by ApiRouteMatcher", async () => {
       const adapter = createMockAdapter();
       const router = createRouter();
 

--- a/src/routing/api/route-discovery.ts
+++ b/src/routing/api/route-discovery.ts
@@ -1,6 +1,6 @@
 import { relative } from "#veryfront/compat/path/index.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
-import type { DynamicRouter } from "./api-route-matcher.ts";
+import type { ApiRouteMatcher } from "./api-route-matcher.ts";
 import { discoverFiles } from "#veryfront/utils/file-discovery.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 
@@ -9,7 +9,7 @@ const ROUTE_FILE_RE = /^route\.(ts|js|tsx|jsx)$/;
 const PAGE_EXT_RE = /\.(ts|js|tsx|jsx)$/;
 
 export function discoverPagesRoutes(
-  router: DynamicRouter,
+  router: ApiRouteMatcher,
   dir: string,
   prefix: string,
   adapter: RuntimeAdapter,
@@ -30,7 +30,7 @@ export function discoverPagesRoutes(
 }
 
 export function discoverAppRoutes(
-  router: DynamicRouter,
+  router: ApiRouteMatcher,
   dir: string,
   prefix: string,
   adapter: RuntimeAdapter,

--- a/src/routing/index.ts
+++ b/src/routing/index.ts
@@ -7,10 +7,10 @@
 
 export type { Route, RouteMatch } from "./matchers/index.ts";
 export {
-  DynamicRouter,
   getSpecificityScore,
   matchRoute,
   normalizePath,
+  PageRouteMatcher,
   parseRoute,
 } from "./matchers/index.ts";
 

--- a/src/routing/matchers/index.ts
+++ b/src/routing/matchers/index.ts
@@ -5,7 +5,7 @@
  */
 
 export type { Route, RouteMatch } from "./types.ts";
-export { DynamicRouter, PageRouteMatcher } from "./pattern-route-matcher.ts";
+export { PageRouteMatcher } from "./pattern-route-matcher.ts";
 export { getSpecificityScore, parseRoute } from "./route-parser.ts";
 export { matchRoute } from "./route-matcher.ts";
 export { normalizePath } from "#veryfront/utils";

--- a/src/routing/matchers/pattern-route-matcher.test.ts
+++ b/src/routing/matchers/pattern-route-matcher.test.ts
@@ -1,11 +1,11 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { DynamicRouter } from "./pattern-route-matcher.ts";
+import { PageRouteMatcher } from "./pattern-route-matcher.ts";
 
 describe("pattern-route-matcher", () => {
-  describe("DynamicRouter", () => {
+  describe("PageRouteMatcher", () => {
     it("should add and match static routes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "about.tsx");
 
       const match = router.match("/about");
@@ -13,7 +13,7 @@ describe("pattern-route-matcher", () => {
     });
 
     it("should match dynamic routes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/users/[id]", "user.tsx");
 
       const match = router.match("/users/123");
@@ -21,7 +21,7 @@ describe("pattern-route-matcher", () => {
     });
 
     it("should prioritize static over dynamic routes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/users/[id]", "user-dynamic.tsx");
       router.addRoute("/users/profile", "profile.tsx");
 
@@ -30,7 +30,7 @@ describe("pattern-route-matcher", () => {
     });
 
     it("should prioritize dynamic over catch-all routes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/docs/[...slug]", "docs-catch.tsx");
       router.addRoute("/docs/[id]", "docs-single.tsx");
 
@@ -39,7 +39,7 @@ describe("pattern-route-matcher", () => {
     });
 
     it("should cache route matches", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "about.tsx");
 
       const match1 = router.match("/about");
@@ -49,7 +49,7 @@ describe("pattern-route-matcher", () => {
     });
 
     it("should clear cache", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/test", "test.tsx");
 
       router.match("/test");
@@ -60,7 +60,7 @@ describe("pattern-route-matcher", () => {
     });
 
     it("should return null for unmatched routes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "about.tsx");
 
       const match = router.match("/unknown");
@@ -68,7 +68,7 @@ describe("pattern-route-matcher", () => {
     });
 
     it("should handle multiple dynamic params", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/blog/[year]/[month]", "archive.tsx");
 
       const match = router.match("/blog/2024/03");
@@ -77,7 +77,7 @@ describe("pattern-route-matcher", () => {
     });
 
     it("should get all routes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/a", "a.tsx");
       router.addRoute("/b", "b.tsx");
 
@@ -86,7 +86,7 @@ describe("pattern-route-matcher", () => {
     });
 
     it("should normalize trailing slashes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "about.tsx");
 
       const match = router.match("/about/");

--- a/src/routing/matchers/pattern-route-matcher.ts
+++ b/src/routing/matchers/pattern-route-matcher.ts
@@ -44,6 +44,3 @@ export class PageRouteMatcher {
     return [...this.routes];
   }
 }
-
-/** @deprecated Use PageRouteMatcher instead - kept for backwards compatibility */
-export { PageRouteMatcher as DynamicRouter };

--- a/src/routing/router.test.ts
+++ b/src/routing/router.test.ts
@@ -1,11 +1,11 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { DynamicRouter } from "./matchers/index.ts";
+import { PageRouteMatcher } from "./matchers/index.ts";
 
-describe("DynamicRouter", () => {
+describe("PageRouteMatcher", () => {
   describe("Static routes", () => {
     it("matches exact static routes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "pages/about.tsx");
       router.addRoute("/contact", "pages/contact.tsx");
 
@@ -16,14 +16,14 @@ describe("DynamicRouter", () => {
     });
 
     it("returns null for non-matching routes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "pages/about.tsx");
 
       assertEquals(router.match("/not-found"), null);
     });
 
     it("normalizes trailing slashes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "pages/about.tsx");
 
       const match1 = router.match("/about");
@@ -35,7 +35,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles root route correctly", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/", "pages/index.tsx");
 
       const match = router.match("/");
@@ -46,7 +46,7 @@ describe("DynamicRouter", () => {
 
   describe("Dynamic segments - single parameter", () => {
     it("matches single dynamic segment", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/blog/[slug]", "pages/blog/[slug].tsx");
 
       const match = router.match("/blog/hello-world");
@@ -56,7 +56,7 @@ describe("DynamicRouter", () => {
     });
 
     it("extracts parameter as string not array", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/user/[id]", "pages/user/[id].tsx");
 
       const match = router.match("/user/12345");
@@ -66,7 +66,7 @@ describe("DynamicRouter", () => {
     });
 
     it("decodes URL encoded parameters", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/user/[name]", "pages/user/[name].tsx");
 
       const match = router.match("/user/John%20Doe");
@@ -75,7 +75,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles special characters in dynamic segments", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/tag/[name]", "pages/tag/[name].tsx");
 
       const match = router.match("/tag/c%2B%2B");
@@ -86,7 +86,7 @@ describe("DynamicRouter", () => {
 
   describe("Dynamic segments - multiple parameters", () => {
     it("matches two dynamic segments", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute(
         "/shop/[category]/[product]",
         "pages/shop/[category]/[product].tsx",
@@ -101,7 +101,7 @@ describe("DynamicRouter", () => {
     });
 
     it("matches three dynamic segments in sequence", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/posts/[year]/[month]/[day]", "pages/posts/archive.tsx");
 
       const match = router.match("/posts/2024/03/15");
@@ -114,7 +114,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles mix of static and dynamic segments", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute(
         "/api/v1/users/[userId]/posts/[postId]",
         "api/user-posts.tsx",
@@ -129,7 +129,7 @@ describe("DynamicRouter", () => {
     });
 
     it("preserves parameter order correctly", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/[a]/[b]/[c]", "pages/abc.tsx");
 
       const match = router.match("/first/second/third");
@@ -142,7 +142,7 @@ describe("DynamicRouter", () => {
     });
 
     it("fails when segment count does not match", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/posts/[category]/[id]", "pages/posts.tsx");
 
       assertEquals(router.match("/posts/tech"), null);
@@ -151,7 +151,7 @@ describe("DynamicRouter", () => {
 
   describe("Catch-all routes", () => {
     it("matches catch-all routes with multiple segments", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/docs/[...path]", "pages/docs/[...path].tsx");
 
       const match = router.match("/docs/api/auth/login");
@@ -162,7 +162,7 @@ describe("DynamicRouter", () => {
     });
 
     it("matches catch-all with single segment", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/files/[...path]", "pages/files/[...path].tsx");
 
       const match = router.match("/files/readme.txt");
@@ -173,7 +173,7 @@ describe("DynamicRouter", () => {
     });
 
     it("does not match empty catch-all path", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/docs/[...path]", "pages/docs/[...path].tsx");
 
       assertEquals(router.match("/docs"), null);
@@ -181,7 +181,7 @@ describe("DynamicRouter", () => {
     });
 
     it("extracts catch-all parameter as array", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/docs/[...path]", "pages/docs.tsx");
 
       const match = router.match("/docs/introduction");
@@ -191,7 +191,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles very deep paths with catch-all", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/files/[...path]", "pages/files.tsx");
 
       const match = router.match("/files/a/b/c/d/e/f/file.txt");
@@ -204,7 +204,7 @@ describe("DynamicRouter", () => {
 
   describe("Optional catch-all routes", () => {
     it("matches optional catch-all with segments", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/app/[[...segments]]", "pages/app/[[...segments]].tsx");
 
       const match = router.match("/app/dashboard/settings");
@@ -215,7 +215,7 @@ describe("DynamicRouter", () => {
     });
 
     it("matches optional catch-all without segments", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/app/[[...segments]]", "pages/app/[[...segments]].tsx");
 
       const match = router.match("/app");
@@ -226,7 +226,7 @@ describe("DynamicRouter", () => {
     });
 
     it("matches optional catch-all with trailing slash", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/app/[[...segments]]", "pages/app/[[...segments]].tsx");
 
       const match = router.match("/app/");
@@ -237,7 +237,7 @@ describe("DynamicRouter", () => {
     });
 
     it("matches root path with optional catch-all", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/[[...path]]", "pages/home.tsx");
 
       const match = router.match("/");
@@ -248,7 +248,7 @@ describe("DynamicRouter", () => {
 
   describe("Route specificity and priority", () => {
     it("prefers static routes over dynamic", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/blog/[slug]", "pages/blog/[slug].tsx");
       router.addRoute("/blog/about", "pages/blog/about.tsx");
 
@@ -258,7 +258,7 @@ describe("DynamicRouter", () => {
     });
 
     it("prefers dynamic routes over catch-all", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/files/[...path]", "pages/files/[...path].tsx");
       router.addRoute("/files/[type]/[name]", "pages/files/[type]/[name].tsx");
 
@@ -272,7 +272,7 @@ describe("DynamicRouter", () => {
     });
 
     it("prefers catch-all over optional catch-all", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/api/[[...path]]", "pages/api/optional.tsx");
       router.addRoute("/api/[...path]", "pages/api/required.tsx");
 
@@ -282,7 +282,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles complex route priority correctly", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/products/[[...path]]", "optional-catch-all.tsx");
       router.addRoute("/products/new", "static.tsx");
       router.addRoute("/products/[id]", "dynamic.tsx");
@@ -306,7 +306,7 @@ describe("DynamicRouter", () => {
     });
 
     it("prioritizes longer static paths", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/api/[version]", "pages/api-version.tsx");
       router.addRoute("/api/v1/users", "pages/users.tsx");
 
@@ -316,7 +316,7 @@ describe("DynamicRouter", () => {
 
   describe("Cache behavior", () => {
     it("caches successful matches", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/blog/[slug]", "pages/blog/[slug].tsx");
 
       const match1 = router.match("/blog/test");
@@ -326,7 +326,7 @@ describe("DynamicRouter", () => {
     });
 
     it("caches null results", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "pages/about.tsx");
 
       assertEquals(router.match("/not-found"), null);
@@ -334,7 +334,7 @@ describe("DynamicRouter", () => {
     });
 
     it("clears cache correctly", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/blog/[slug]", "pages/blog/[slug].tsx");
 
       const match1 = router.match("/blog/test");
@@ -348,7 +348,7 @@ describe("DynamicRouter", () => {
     });
 
     it("maintains separate cache entries for different paths", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/blog/[slug]", "pages/blog.tsx");
 
       const match1 = router.match("/blog/post1");
@@ -366,7 +366,7 @@ describe("DynamicRouter", () => {
 
   describe("Edge cases - trailing slashes", () => {
     it("normalizes trailing slashes for non-root paths", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "pages/about.tsx");
 
       const match1 = router.match("/about");
@@ -378,7 +378,7 @@ describe("DynamicRouter", () => {
     });
 
     it("preserves root path without removing slash", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/", "pages/index.tsx");
 
       const match = router.match("/");
@@ -387,7 +387,7 @@ describe("DynamicRouter", () => {
     });
 
     it("normalizes trailing slash in dynamic routes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/blog/[slug]", "pages/blog.tsx");
 
       const match1 = router.match("/blog/hello");
@@ -401,7 +401,7 @@ describe("DynamicRouter", () => {
 
   describe("Edge cases - URL decoding", () => {
     it("decodes spaces in parameters", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/article/[title]", "pages/article.tsx");
 
       const match = router.match("/article/How%20to%20Code");
@@ -410,7 +410,7 @@ describe("DynamicRouter", () => {
     });
 
     it("decodes special characters", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/tag/[name]", "pages/tag.tsx");
 
       const match1 = router.match("/tag/C%23");
@@ -423,7 +423,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles parameters with dots", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/files/[filename]", "pages/files/[filename].tsx");
 
       const match = router.match("/files/document.v2.final.pdf");
@@ -434,7 +434,7 @@ describe("DynamicRouter", () => {
 
   describe("Edge cases - empty parameters", () => {
     it("handles empty parameter in optional catch-all", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/[[...path]]", "pages/[[...path]].tsx");
 
       const match = router.match("/");
@@ -443,14 +443,14 @@ describe("DynamicRouter", () => {
     });
 
     it("returns null for empty path on non-optional routes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "pages/about.tsx");
 
       assertEquals(router.match(""), null);
     });
 
     it("handles empty segments correctly in optional catch-all", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/app/[[...segments]]", "pages/app.tsx");
 
       const match = router.match("/app");
@@ -461,7 +461,7 @@ describe("DynamicRouter", () => {
 
   describe("getRoutes() method", () => {
     it("returns all routes in sorted order", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/products/[...path]", "catch-all.tsx");
       router.addRoute("/products/new", "static.tsx");
       router.addRoute("/products/[id]", "dynamic.tsx");
@@ -474,7 +474,7 @@ describe("DynamicRouter", () => {
     });
 
     it("returns a copy of routes array", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "about.tsx");
 
       const routes1 = router.getRoutes();
@@ -486,7 +486,7 @@ describe("DynamicRouter", () => {
     });
 
     it("returns empty array for router with no routes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       assertEquals(router.getRoutes().length, 0);
     });
   });

--- a/src/routing/router_deno.test.ts
+++ b/src/routing/router_deno.test.ts
@@ -1,11 +1,11 @@
 import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { DynamicRouter } from "./matchers/index.ts";
+import { PageRouteMatcher } from "./matchers/index.ts";
 
-describe("DynamicRouter", () => {
+describe("PageRouteMatcher", () => {
   describe("Static routes", () => {
     it("matches exact static routes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "pages/about.tsx");
       router.addRoute("/contact", "pages/contact.tsx");
 
@@ -16,14 +16,14 @@ describe("DynamicRouter", () => {
     });
 
     it("returns null for non-matching routes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "pages/about.tsx");
 
       assertEquals(router.match("/not-found"), null);
     });
 
     it("normalizes trailing slashes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "pages/about.tsx");
 
       const match1 = router.match("/about");
@@ -35,7 +35,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles root route", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/", "pages/index.tsx");
 
       const match = router.match("/");
@@ -46,7 +46,7 @@ describe("DynamicRouter", () => {
 
   describe("Dynamic segments", () => {
     it("matches single dynamic segment", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/blog/[slug]", "pages/blog/[slug].tsx");
 
       const match = router.match("/blog/hello-world");
@@ -55,7 +55,7 @@ describe("DynamicRouter", () => {
     });
 
     it("matches multiple dynamic segments", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/shop/[category]/[product]", "pages/shop/[category]/[product].tsx");
 
       const match = router.match("/shop/electronics/laptop");
@@ -67,7 +67,7 @@ describe("DynamicRouter", () => {
     });
 
     it("decodes URL encoded parameters", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/user/[name]", "pages/user/[name].tsx");
 
       const match = router.match("/user/John%20Doe");
@@ -76,7 +76,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles special characters in dynamic segments", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/tag/[name]", "pages/tag/[name].tsx");
 
       const match = router.match("/tag/c%2B%2B");
@@ -87,7 +87,7 @@ describe("DynamicRouter", () => {
 
   describe("Catch-all routes", () => {
     it("matches catch-all routes with multiple segments", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/docs/[...path]", "pages/docs/[...path].tsx");
 
       const match = router.match("/docs/api/auth/login");
@@ -98,7 +98,7 @@ describe("DynamicRouter", () => {
     });
 
     it("matches catch-all with single segment", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/files/[...path]", "pages/files/[...path].tsx");
 
       const match = router.match("/files/readme.txt");
@@ -109,7 +109,7 @@ describe("DynamicRouter", () => {
     });
 
     it("does not match empty catch-all", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/docs/[...path]", "pages/docs/[...path].tsx");
 
       assertEquals(router.match("/docs"), null);
@@ -119,7 +119,7 @@ describe("DynamicRouter", () => {
 
   describe("Optional catch-all routes", () => {
     it("matches optional catch-all with segments", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/app/[[...segments]]", "pages/app/[[...segments]].tsx");
 
       const match = router.match("/app/dashboard/settings");
@@ -130,7 +130,7 @@ describe("DynamicRouter", () => {
     });
 
     it("matches optional catch-all without segments", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/app/[[...segments]]", "pages/app/[[...segments]].tsx");
 
       const match = router.match("/app");
@@ -141,7 +141,7 @@ describe("DynamicRouter", () => {
     });
 
     it("matches optional catch-all with trailing slash", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/app/[[...segments]]", "pages/app/[[...segments]].tsx");
 
       const match = router.match("/app/");
@@ -154,7 +154,7 @@ describe("DynamicRouter", () => {
 
   describe("Route priority and sorting", () => {
     it("prefers static routes over dynamic", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/blog/[slug]", "pages/blog/[slug].tsx");
       router.addRoute("/blog/about", "pages/blog/about.tsx");
 
@@ -164,7 +164,7 @@ describe("DynamicRouter", () => {
     });
 
     it("prefers dynamic routes over catch-all", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/files/[...path]", "pages/files/[...path].tsx");
       router.addRoute("/files/[type]/[name]", "pages/files/[type]/[name].tsx");
 
@@ -178,7 +178,7 @@ describe("DynamicRouter", () => {
     });
 
     it("prefers catch-all over optional catch-all", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/api/[[...path]]", "pages/api/optional.tsx");
       router.addRoute("/api/[...path]", "pages/api/required.tsx");
 
@@ -188,7 +188,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles complex route priority correctly", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/products/[[...path]]", "optional-catch-all.tsx");
       router.addRoute("/products/new", "static.tsx");
       router.addRoute("/products/[id]", "dynamic.tsx");
@@ -205,7 +205,7 @@ describe("DynamicRouter", () => {
 
   describe("Caching", () => {
     it("caches successful matches", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/blog/[slug]", "pages/blog/[slug].tsx");
 
       const match1 = router.match("/blog/test");
@@ -215,7 +215,7 @@ describe("DynamicRouter", () => {
     });
 
     it("caches null results", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "pages/about.tsx");
 
       assertEquals(router.match("/not-found"), null);
@@ -223,7 +223,7 @@ describe("DynamicRouter", () => {
     });
 
     it("clears cache correctly", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/blog/[slug]", "pages/blog/[slug].tsx");
 
       const match1 = router.match("/blog/test");
@@ -239,7 +239,7 @@ describe("DynamicRouter", () => {
 
   describe("Edge cases", () => {
     it("handles routes with special regex characters", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/api/v1.0/users", "pages/api/v1.0/users.tsx");
       router.addRoute("/files/(test)/data", "pages/files/test/data.tsx");
 
@@ -253,7 +253,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles empty parameter in optional catch-all", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/[[...path]]", "pages/[[...path]].tsx");
 
       const match = router.match("/");
@@ -262,7 +262,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles complex nested patterns", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/api/[version]/users/[userId]/posts/[postId]", "complex.tsx");
 
       const match = router.match("/api/v2/users/123/posts/456");
@@ -273,7 +273,7 @@ describe("DynamicRouter", () => {
         postId: "456",
       });
 
-      const router2 = new DynamicRouter();
+      const router2 = new PageRouteMatcher();
       router2.addRoute("/docs/[...path]", "docs.tsx");
 
       const match2 = router2.match("/docs/api/v1/users");
@@ -284,7 +284,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles parameters with dots", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/files/[filename]", "pages/files/[filename].tsx");
 
       const match = router.match("/files/document.v2.final.pdf");
@@ -293,7 +293,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles parameters with underscores in names", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/items/[item_id]", "pages/items/[item_id].tsx");
 
       const match = router.match("/items/abc-123_xyz");
@@ -304,7 +304,7 @@ describe("DynamicRouter", () => {
 
   describe("getRoutes", () => {
     it("returns all routes in sorted order", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/products/[...path]", "catch-all.tsx");
       router.addRoute("/products/new", "static.tsx");
       router.addRoute("/products/[id]", "dynamic.tsx");
@@ -317,7 +317,7 @@ describe("DynamicRouter", () => {
     });
 
     it("returns a copy of routes array", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "about.tsx");
 
       const routes1 = router.getRoutes();
@@ -331,7 +331,7 @@ describe("DynamicRouter", () => {
 
   describe("Route pattern validation", () => {
     it("handles patterns with only word characters in parameters", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/user/[userId123]", "pages/user.tsx");
 
       const match = router.match("/user/abc456");
@@ -340,7 +340,7 @@ describe("DynamicRouter", () => {
     });
 
     it("correctly identifies catch-all vs regular parameters", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/a/[...path]", "pages/a.tsx");
       router.addRoute("/c/[path]/d", "pages/c.tsx");
 
@@ -356,7 +356,7 @@ describe("DynamicRouter", () => {
 
   describe("Multiple Dynamic Segments - Extended", () => {
     it("matches three dynamic segments in a row", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/posts/[year]/[month]/[day]", "pages/posts/archive.tsx");
 
       const match = router.match("/posts/2024/03/15");
@@ -369,7 +369,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles mix of static and dynamic segments", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/api/v1/users/[userId]/posts/[postId]", "api/user-posts.tsx");
 
       const match = router.match("/api/v1/users/123/posts/456");
@@ -381,7 +381,7 @@ describe("DynamicRouter", () => {
     });
 
     it("preserves order of multiple dynamic segments", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/[a]/[b]/[c]", "pages/abc.tsx");
 
       const match = router.match("/first/second/third");
@@ -394,14 +394,14 @@ describe("DynamicRouter", () => {
     });
 
     it("fails to match when segment count does not match", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/posts/[category]/[id]", "pages/posts.tsx");
 
       assertEquals(router.match("/posts/tech"), null);
     });
 
     it("matches four dynamic segments in a row", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/posts/[year]/[month]/[day]/[slug]", "pages/posts/detail.tsx");
 
       const match = router.match("/posts/2024/03/15/hello-world");
@@ -415,7 +415,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles dynamic segments with numeric values", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/users/[userId]/orders/[orderId]", "pages/order.tsx");
 
       const match = router.match("/users/12345/orders/67890");
@@ -429,7 +429,7 @@ describe("DynamicRouter", () => {
 
   describe("Catch-All Routes - Extended", () => {
     it("matches very deep path with catch-all", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/files/[...path]", "pages/files.tsx");
 
       const match = router.match("/files/a/b/c/d/e/f/g/file.txt");
@@ -440,7 +440,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles catch-all with static prefix", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/docs/guide/[...sections]", "pages/docs.tsx");
 
       const match = router.match("/docs/guide/getting-started/installation");
@@ -451,7 +451,7 @@ describe("DynamicRouter", () => {
     });
 
     it("does not match catch-all with missing required prefix", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/docs/guide/[...sections]", "pages/docs.tsx");
 
       assertEquals(router.match("/docs"), null);
@@ -459,7 +459,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles catch-all with URL-encoded segments", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/files/[...path]", "pages/files.tsx");
 
       const match = router.match("/files/My%20Documents/report%202024.pdf");
@@ -470,7 +470,7 @@ describe("DynamicRouter", () => {
     });
 
     it("normalizes catch-all parameter for single segment", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/docs/[...path]", "pages/docs.tsx");
 
       const match = router.match("/docs/introduction");
@@ -480,7 +480,7 @@ describe("DynamicRouter", () => {
     });
 
     it("combines static prefix with dynamic and catch-all", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/api/[version]/endpoints/[...path]", "pages/api.tsx");
 
       const match = router.match("/api/v2/endpoints/users/list");
@@ -494,7 +494,7 @@ describe("DynamicRouter", () => {
 
   describe("Optional Catch-All - Extended", () => {
     it("matches root path with optional catch-all", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/[[...path]]", "pages/home.tsx");
 
       const match = router.match("/");
@@ -503,7 +503,7 @@ describe("DynamicRouter", () => {
     });
 
     it("matches single segment with optional catch-all", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/app/[[...sections]]", "pages/app.tsx");
 
       const match = router.match("/app/dashboard");
@@ -514,7 +514,7 @@ describe("DynamicRouter", () => {
     });
 
     it("matches multiple segments with optional catch-all", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/app/[[...sections]]", "pages/app.tsx");
 
       const match = router.match("/app/dashboard/settings/profile");
@@ -525,7 +525,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles optional catch-all with static prefix", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/blog/posts/[[...slug]]", "pages/blog.tsx");
 
       const match1 = router.match("/blog/posts");
@@ -538,7 +538,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles multiple optional catch-all scenarios", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/shop/[[...category]]", "pages/shop.tsx");
 
       const match1 = router.match("/shop");
@@ -557,7 +557,7 @@ describe("DynamicRouter", () => {
 
   describe("Route Priority/Specificity - Extended", () => {
     it("prioritizes more specific static segments", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/blog/[slug]", "pages/dynamic.tsx");
       router.addRoute("/blog/featured", "pages/featured.tsx");
       router.addRoute("/blog/archive", "pages/archive.tsx");
@@ -568,7 +568,7 @@ describe("DynamicRouter", () => {
     });
 
     it("prioritizes longer static paths over shorter", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/api/[version]", "pages/api-version.tsx");
       router.addRoute("/api/v1/users", "pages/users.tsx");
 
@@ -576,7 +576,7 @@ describe("DynamicRouter", () => {
     });
 
     it("prioritizes dynamic with more static parts", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/[...all]", "pages/catch-all.tsx");
       router.addRoute("/api/[endpoint]", "pages/api.tsx");
       router.addRoute("/api/users/[id]", "pages/user.tsx");
@@ -586,7 +586,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles specificity with multiple routes at same level", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/shop/[category]/featured", "pages/featured.tsx");
       router.addRoute("/shop/[category]/[product]", "pages/product.tsx");
 
@@ -595,7 +595,7 @@ describe("DynamicRouter", () => {
     });
 
     it("scores routes correctly by specificity", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/a/b/c", "static-3.tsx");
       router.addRoute("/a/b/[c]", "dynamic-1.tsx");
       router.addRoute("/a/[b]/[c]", "dynamic-2.tsx");
@@ -611,7 +611,7 @@ describe("DynamicRouter", () => {
     });
 
     it("prefers exact match over prefix when both exist", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/api/[...path]", "pages/api-catch-all.tsx");
       router.addRoute("/api", "pages/api-root.tsx");
 
@@ -622,7 +622,7 @@ describe("DynamicRouter", () => {
 
   describe("Cache Behavior - Extended", () => {
     it("maintains separate cache entries for different paths", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/blog/[slug]", "pages/blog.tsx");
 
       const match1 = router.match("/blog/post1");
@@ -638,7 +638,7 @@ describe("DynamicRouter", () => {
     });
 
     it("invalidates cache after adding new routes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/blog/[slug]", "pages/dynamic.tsx");
 
       const match1 = router.match("/blog/featured");
@@ -654,7 +654,7 @@ describe("DynamicRouter", () => {
     });
 
     it("caches complex route matches", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/[org]/[repo]/[...path]", "pages/github.tsx");
 
       const match1 = router.match("/myorg/myrepo/src/index.ts");
@@ -664,7 +664,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles cache for trailing slash normalized paths", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "pages/about.tsx");
 
       const match1 = router.match("/about");
@@ -678,7 +678,7 @@ describe("DynamicRouter", () => {
 
   describe("Edge Cases - Extended", () => {
     it("handles empty pathname correctly", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/", "pages/home.tsx");
       router.addRoute("/about", "pages/about.tsx");
 
@@ -686,7 +686,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles special characters in static paths", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/api/v2.5/users", "pages/api.tsx");
       router.addRoute("/files/(archived)", "pages/files.tsx");
 
@@ -695,7 +695,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles URL-encoded special characters", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/search/[query]", "pages/search.tsx");
 
       const match = router.match("/search/hello%20world%21");
@@ -704,14 +704,14 @@ describe("DynamicRouter", () => {
     });
 
     it("normalizes leading slashes correctly", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "pages/about.tsx");
 
       assertExists(router.match("/about"));
     });
 
     it("handles case-sensitive routes", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/About", "pages/about.tsx");
 
       assertExists(router.match("/About"));
@@ -719,7 +719,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles very long paths efficiently", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/[...path]", "pages/catch-all.tsx");
 
       const longPath = "/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z";
@@ -732,7 +732,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles parameters with special characters needing decoding", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/tag/[name]", "pages/tag.tsx");
 
       const match1 = router.match("/tag/C%23");
@@ -745,7 +745,7 @@ describe("DynamicRouter", () => {
     });
 
     it("returns null for no route match (404 scenario)", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/about", "pages/about.tsx");
       router.addRoute("/blog/[slug]", "pages/blog.tsx");
 
@@ -753,14 +753,14 @@ describe("DynamicRouter", () => {
     });
 
     it("handles paths with consecutive slashes after normalization", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/api/users", "pages/users.tsx");
 
       assertExists(router.match("/api/users"));
     });
 
     it("handles dynamic segments with dashes and underscores in values", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/posts/[postId]", "pages/post.tsx");
 
       const match = router.match("/posts/my-awesome-post_123");
@@ -769,7 +769,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles parameter decoding with spaces", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/article/[title]", "pages/article.tsx");
 
       const match = router.match("/article/How%20to%20Code");
@@ -778,7 +778,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles empty segments in catch-all correctly", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/docs/[...path]", "pages/docs.tsx");
 
       const match = router.match("/docs/guide");
@@ -787,7 +787,7 @@ describe("DynamicRouter", () => {
     });
 
     it("handles routes ending with dynamic segment", () => {
-      const router = new DynamicRouter();
+      const router = new PageRouteMatcher();
       router.addRoute("/users/[id]", "pages/user.tsx");
 
       const match = router.match("/users/123");

--- a/src/server/dev-server/request-handler.ts
+++ b/src/server/dev-server/request-handler.ts
@@ -13,7 +13,7 @@ import { ErrorOverlay } from "./error-overlay/index.ts";
 import { createResponseBuilder } from "#veryfront/security/index.ts";
 import { resetApiHandler } from "../handlers/request/api/pages-api-handler.ts";
 import { clearLayoutDiscoveryCache } from "#veryfront/rendering/layouts/index.ts";
-import { clearRendererCaches } from "#veryfront/rendering/renderer.ts";
+import { clearRendererCacheForProject } from "#veryfront/rendering/renderer.ts";
 import { getErrorCollector } from "#veryfront/observability/error-collector.ts";
 import { getLogBuffer } from "#veryfront/observability/log-buffer.ts";
 
@@ -156,8 +156,9 @@ export class RequestHandler {
 
     clearConfigCache();
     clearLayoutDiscoveryCache();
-    clearRendererCaches().catch((error) => {
-      logger.debug("clearRendererCaches failed", error);
+    const rendererProjectKey = this.defaultProjectId ?? this.defaultProjectSlug ?? "local";
+    clearRendererCacheForProject(rendererProjectKey).catch((error) => {
+      logger.debug("clearRendererCacheForProject failed", error);
     });
   }
 

--- a/src/server/dev-server/route-discovery.ts
+++ b/src/server/dev-server/route-discovery.ts
@@ -1,7 +1,7 @@
 import { serverLogger } from "#veryfront/utils";
 import { join } from "#veryfront/compat/path/index.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
-import type { DynamicRouter } from "#veryfront/routing/api/index.ts";
+import type { ApiRouteMatcher } from "#veryfront/routing/api/index.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import type { RouteDirectory } from "./types.ts";
 import { withFallback } from "#veryfront/platform/adapters/fallback-wrapper.ts";
@@ -36,7 +36,7 @@ export class RouteDiscovery {
   constructor(
     private projectDir: string,
     private adapter: RuntimeAdapter,
-    private router: DynamicRouter,
+    private router: ApiRouteMatcher,
     private config?: VeryfrontConfig,
   ) {
     const fsType = config?.fs?.type;

--- a/src/server/dev-server/server.ts
+++ b/src/server/dev-server/server.ts
@@ -4,7 +4,7 @@ import { buildLocalhostUrl, LOCALHOST } from "#veryfront/config";
 import { basename } from "#veryfront/compat/path";
 import type { RuntimeAdapter, Server } from "#veryfront/platform/adapters/base.ts";
 import { runtime } from "#veryfront/platform/adapters/detect.ts";
-import { DynamicRouter } from "#veryfront/routing/api/index.ts";
+import { ApiRouteMatcher } from "#veryfront/routing/api/index.ts";
 import { ComponentRegistry } from "#veryfront/modules/component-registry/index.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { MiddlewarePipeline } from "#veryfront/middleware/core/pipeline/index.ts";
@@ -51,7 +51,7 @@ function deriveProjectSlug(projectDir: string): string {
 }
 
 export class DevServer {
-  private router: DynamicRouter;
+  private router: ApiRouteMatcher;
   private componentRegistry!: ComponentRegistry;
   private fileWatchSetup?: FileWatchSetup;
   private pipeline: MiddlewarePipeline;
@@ -71,7 +71,7 @@ export class DevServer {
     this.ready = new Promise<void>((resolve) => {
       this._resolveReady = resolve;
     });
-    this.router = new DynamicRouter();
+    this.router = new ApiRouteMatcher();
     this.pipeline = new MiddlewarePipeline();
   }
 
@@ -120,13 +120,6 @@ export class DevServer {
       hmr: this.options.enableHMR,
       fastRefresh: this.options.enableFastRefresh,
     });
-
-    if (this.options.hmrPort !== undefined) {
-      devServerLog.warn(
-        "`hmrPort` is deprecated and ignored. HMR now uses /_ws on the main dev server port.",
-        { hmrPort: this.options.hmrPort, serverPort: this.options.port },
-      );
-    }
 
     // Set VERYFRONT_DEV_PORT for ESM module loader HTTP fallback
     // This ensures the correct port is used when fetching modules via localhost

--- a/src/server/dev-server/types.ts
+++ b/src/server/dev-server/types.ts
@@ -5,8 +5,6 @@ export interface DevServerOptions {
   handlerOnly?: boolean;
   /** 0.0.0.0 = all interfaces, 127.0.0.1 = localhost only */
   bindAddress?: string;
-  /** @deprecated Ignored: HMR now uses /_ws on the main dev server port. */
-  hmrPort?: number;
   moduleServerPort?: number;
   enableHMR?: boolean;
   enableFastRefresh?: boolean;

--- a/src/server/handlers/request/openapi.handler.ts
+++ b/src/server/handlers/request/openapi.handler.ts
@@ -1,7 +1,7 @@
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { HTTP_OK, HTTP_SERVER_ERROR, PRIORITY_HIGH_DEV } from "#veryfront/utils/constants/index.ts";
-import { DynamicRouter } from "#veryfront/routing/api/api-route-matcher.ts";
+import { ApiRouteMatcher } from "#veryfront/routing/api/api-route-matcher.ts";
 import { discoverAppRoutes, discoverPagesRoutes } from "#veryfront/routing/api/route-discovery.ts";
 import { generateOpenAPISpec, specToYaml } from "#veryfront/routing/api/openapi/spec-generator.ts";
 import type { OpenAPISpec } from "#veryfront/routing/api/openapi/types.ts";
@@ -97,7 +97,7 @@ export class OpenAPIHandler extends BaseHandler {
     if (!isDev && this.cachedSpec && this.cacheKey === currentKey) return this.cachedSpec;
 
     const discover = async (): Promise<OpenAPISpec> => {
-      const router = new DynamicRouter();
+      const router = new ApiRouteMatcher();
       const pagesDir = ctx.config?.directories?.pages ?? "pages";
       const appDirName = ctx.config?.directories?.app ?? "app";
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -33,6 +33,7 @@ import {
   HMR_CLOSE_RATE_LIMIT,
   HMR_MAX_MESSAGE_SIZE_BYTES,
   HMR_MAX_MESSAGES_PER_MINUTE,
+  serverLogger,
 } from "#veryfront/utils";
 
 /** Default server port when no port is specified */

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -33,7 +33,6 @@ import {
   HMR_CLOSE_RATE_LIMIT,
   HMR_MAX_MESSAGE_SIZE_BYTES,
   HMR_MAX_MESSAGES_PER_MINUTE,
-  serverLogger,
 } from "#veryfront/utils";
 
 /** Default server port when no port is specified */
@@ -51,8 +50,6 @@ export type {
 import { ReloadNotifier } from "./reload-notifier.ts";
 export { ReloadNotifier };
 export type { BuildOptions, BuildStats } from "./build-types.ts";
-
-const serverApiLog = serverLogger.component("server-api");
 
 /** Shared options for both development and production server modes. */
 interface BaseServerOptions {
@@ -75,8 +72,6 @@ interface BaseServerOptions {
 
 export interface StartDevModeOptions extends BaseServerOptions {
   mode?: "development";
-  /** @deprecated Ignored: HMR now uses /_ws on the main server port. */
-  hmrPort?: number;
   moduleServerPort?: number;
   enableHMR?: boolean;
   enableFastRefresh?: boolean;
@@ -400,13 +395,6 @@ export async function startServer(
   }
 
   // Development mode (default)
-  if ("hmrPort" in options && options.hmrPort !== undefined) {
-    serverApiLog.warn(
-      "`hmrPort` is deprecated and ignored. HMR now uses /_ws on the main server port.",
-      { hmrPort: options.hmrPort, serverPort: port },
-    );
-  }
-
   const devServer = await startDevServer({
     port,
     projectDir,
@@ -432,5 +420,5 @@ export async function startServer(
 }
 
 // Note: Wildcard re-exports removed to prevent circular dependency risks.
-// Import from "#veryfront/routing" for Route, RouteMatch, DynamicRouter, etc.
+// Import from "#veryfront/routing" for Route, RouteMatch, PageRouteMatcher, etc.
 // Import from "#veryfront/observability" for tracing and metrics utilities.

--- a/src/utils/logger/logger.ts
+++ b/src/utils/logger/logger.ts
@@ -40,13 +40,13 @@ export interface LogEntry {
   // Error details if applicable
   error?: SerializedError;
   // Request context (when available)
-  /** @deprecated Use `request_id` instead. Kept for Grafana dashboard transition. */
+  /** @deprecated Use `request_id` instead. Kept for Grafana dashboard transition. Planned removal after Grafana dashboard migration is complete. */
   requestId?: string;
-  /** @deprecated Use `trace_id` instead. Kept for Grafana dashboard transition. */
+  /** @deprecated Use `trace_id` instead. Kept for Grafana dashboard transition. Planned removal after Grafana dashboard migration is complete. */
   traceId?: string;
-  /** @deprecated Use `span_id` instead. Kept for Grafana dashboard transition. */
+  /** @deprecated Use `span_id` instead. Kept for Grafana dashboard transition. Planned removal after Grafana dashboard migration is complete. */
   spanId?: string;
-  /** @deprecated Use `project_slug` instead. Kept for Grafana dashboard transition. */
+  /** @deprecated Use `project_slug` instead. Kept for Grafana dashboard transition. Planned removal after Grafana dashboard migration is complete. */
   projectSlug?: string;
   // Standard fields for Loki filtering (snake_case)
   request_id?: string;
@@ -60,7 +60,7 @@ export interface LogEntry {
   branch_id?: string;
   branch_name?: string;
   // Duration for timed operations
-  /** @deprecated Use `duration_ms` instead. Kept for Grafana dashboard transition. */
+  /** @deprecated Use `duration_ms` instead. Kept for Grafana dashboard transition. Planned removal after Grafana dashboard migration is complete. */
   durationMs?: number;
   duration_ms?: number;
 }

--- a/tests/integration/adapters/runtime-detection.test.ts
+++ b/tests/integration/adapters/runtime-detection.test.ts
@@ -3,10 +3,10 @@ import { describe, it } from "#veryfront/testing/bdd";
 import {
   bunAdapter,
   denoAdapter,
-  detectRuntime,
   getAdapter,
   nodeAdapter,
 } from "#veryfront/platform/adapters/detect.ts";
+import { detectRuntime } from "#veryfront/platform/adapters/runtime-detection.ts";
 import { isBun, isDeno, isNode } from "../../../src/platform/compat/runtime.ts";
 
 function assertRuntime(runtime: string): void {
@@ -184,7 +184,6 @@ describe("Runtime detection", () => {
       it("should import detect module successfully", async () => {
         const mod = await import("#veryfront/platform/adapters/detect.ts");
 
-        assertExists(mod.detectRuntime);
         assertExists(mod.getAdapter);
         assertExists(mod.denoAdapter);
         assertExists(mod.bunAdapter);


### PR DESCRIPTION
## Summary

- Remove `DynamicRouter` aliases from routing, migrate all callers to `PageRouteMatcher` / `ApiRouteMatcher`
- Remove `detectRuntime` re-export from platform barrel (internal function preserved for `runtime.get()`)
- Remove `hmrPort` option from server types and CLI commands (was already ignored)
- Remove `clearRendererCaches()` / `clearAllCaches()` from renderer, migrate callers to per-project variants
- Remove deprecated global cache clear fallbacks from websocket manager
- Remove bare `Message` re-export from agent barrel (use `AgentMessage`)
- Add migration timeline to 5 logger deprecated fields (Grafana dashboard transition)

**Deprecated markers: 18 → 8** (10 removed, 8 intentionally kept)

Remaining `@deprecated` markers are intentionally preserved:
- 5 logger fields — kept for Grafana dashboard transition (timeline documented)
- 2 global cache functions — callers lack per-project context for migration
- 1 `getAdapter()` — still has internal callers

## Test plan

- [x] `deno task verify:quick` passes (format, lint, typecheck)
- [x] All 971 unit tests pass
- [x] No remaining references to removed exports (`DynamicRouter`, `detectRuntime` barrel, `hmrPort`, `clearRendererCaches`, bare `Message`)