### PR TITLE
refactor: migrate remaining console calls to structured loggers

### DIFF
--- a/src/platform/compat/esbuild-init.ts
+++ b/src/platform/compat/esbuild-init.ts
@@ -4,6 +4,7 @@
  */
 
 import process from "node:process";
+import { serverLogger } from "#veryfront/utils/logger/logger.ts";
 import { isDenoCompiled } from "./runtime.ts";
 import { ESBUILD_VERSION, getEsbuildBinaryName, getVFSBasePath } from "./esbuild-shared.ts";
 
@@ -55,7 +56,7 @@ async function extractEsbuildBinary(): Promise<string | null> {
   await Deno.mkdir(cacheDir, { recursive: true });
   await Deno.writeFile(targetPath, await Deno.readFile(vfsPath), { mode: 0o755 });
 
-  console.log(`[esbuild] Extracted binary from VFS to ${targetPath}`);
+  serverLogger.info("[esbuild] Extracted binary from VFS", { targetPath });
   return targetPath;
 }
 
@@ -69,6 +70,6 @@ if (!Deno.env.get("ESBUILD_BINARY_PATH") && isDenoCompiled) {
       process.env.ESBUILD_BINARY_PATH = binaryPath;
     }
   } catch (error) {
-    console.warn(`[esbuild] Binary extraction failed:`, error);
+    serverLogger.warn("[esbuild] Binary extraction failed", error);
   }
 }

--- a/src/platform/compat/esbuild.ts
+++ b/src/platform/compat/esbuild.ts
@@ -7,6 +7,7 @@
 export type { BuildOptions, BuildResult, TransformOptions, TransformResult } from "esbuild";
 
 import nodeProcess from "node:process";
+import { serverLogger } from "#veryfront/utils/logger/logger.ts";
 import { getEnv, setEnv } from "./process.ts";
 import { isDenoCompiled } from "./runtime.ts";
 import { ESBUILD_VERSION, getEsbuildBinaryName, getVFSBasePath } from "./esbuild-shared.ts";
@@ -113,7 +114,7 @@ async function ensureEsbuildBinary(): Promise<void> {
       setEnv("ESBUILD_BINARY_PATH", binaryPath);
       nodeProcess.env.ESBUILD_BINARY_PATH = binaryPath;
     } catch (error) {
-      console.warn(`[esbuild] Binary extraction failed:`, error);
+      serverLogger.warn("[esbuild] Binary extraction failed", error);
     } finally {
       setupComplete = true;
     }


### PR DESCRIPTION
## Summary

- Replaced `console.log`/`console.warn` in esbuild compatibility modules (`esbuild-init.ts`, `esbuild.ts`) with `serverLogger` for structured logging support in Grafana/Loki
- Remaining ~100 `console.*` calls are intentionally preserved: client-side code, template literals generating browser JS, logger infrastructure, last-resort error handlers, and user-facing CLI/test output

## Test plan

- [x] `deno task verify:quick` passes (lint, typecheck)
- [x] `deno test --no-check --allow-all src/platform/` — 117 tests pass
- [x] Pre-push hooks pass (format, lint, typecheck, unit tests)