### PR TITLE
fix: use projectId for router detection cache to prevent cross-tenant poisoning

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/modules/import-map/preloader.ts
+++ b/src/modules/import-map/preloader.ts
@@ -7,24 +7,26 @@ const importMapCache = new Map<string, Promise<ImportMapConfig>>();
 export function preloadImportMap(
   projectDir: string,
   adapter: RuntimeAdapter,
+  projectId?: string,
 ): Promise<ImportMapConfig> {
-  const cached = importMapCache.get(projectDir);
+  const cacheKey = projectId ?? projectDir;
+  const cached = importMapCache.get(cacheKey);
   if (cached) return cached;
 
   const promise = loadImportMap(projectDir, adapter);
-  importMapCache.set(projectDir, promise);
+  importMapCache.set(cacheKey, promise);
 
   promise.catch(() => {
-    importMapCache.delete(projectDir);
+    importMapCache.delete(cacheKey);
   });
 
   return promise;
 }
 
 export async function getCachedImportMap(
-  projectDir: string,
+  cacheKey: string,
 ): Promise<ImportMapConfig | undefined> {
-  const cached = importMapCache.get(projectDir);
+  const cached = importMapCache.get(cacheKey);
   if (!cached) return undefined;
 
   try {
@@ -35,9 +37,9 @@ export async function getCachedImportMap(
   }
 }
 
-export function clearImportMapCache(projectDir?: string): void {
-  if (projectDir) {
-    importMapCache.delete(projectDir);
+export function clearImportMapCache(cacheKey?: string): void {
+  if (cacheKey) {
+    importMapCache.delete(cacheKey);
     return;
   }
 

--- a/src/platform/adapters/fs/veryfront/types.ts
+++ b/src/platform/adapters/fs/veryfront/types.ts
@@ -124,7 +124,7 @@ export interface InvalidationProjectContext {
 export interface InvalidationCallbacks {
   clearSSRModuleCache?: () => void;
   clearSSRModuleCacheForProject?: (projectId: string) => void;
-  clearRouterDetectionCacheForProject?: (projectDir: string) => void;
+  clearRouterDetectionCacheForProject?: (projectId: string) => void;
   clearModulePathCache?: () => void;
   invalidateModulePaths?: (changedPaths: string[]) => void;
   clearSnippetCacheForProject?: (projectSlug: string) => void;

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -641,7 +641,6 @@ export class WebSocketManager {
     this.deps.invalidationCallbacks.clearDomainCache?.();
 
     const projectId = this.deps.client.getProjectId();
-    const projectDir = this.deps.getProjectDir();
 
     if (this.deps.invalidationCallbacks.clearSSRModuleCacheForProject && projectId) {
       this.deps.invalidationCallbacks.clearSSRModuleCacheForProject(projectId);
@@ -649,8 +648,8 @@ export class WebSocketManager {
       this.deps.invalidationCallbacks.clearSSRModuleCache?.();
     }
 
-    if (this.deps.invalidationCallbacks.clearRouterDetectionCacheForProject && projectDir) {
-      this.deps.invalidationCallbacks.clearRouterDetectionCacheForProject(projectDir);
+    if (this.deps.invalidationCallbacks.clearRouterDetectionCacheForProject && projectId) {
+      this.deps.invalidationCallbacks.clearRouterDetectionCacheForProject(projectId);
     }
 
     this.deps.invalidationCallbacks.clearModulePathCache?.();

--- a/src/react/compat/version-detector/version-cache.ts
+++ b/src/react/compat/version-detector/version-cache.ts
@@ -9,17 +9,21 @@ export function getReactVersionInfo(): ReactVersionInfo {
   return defaultVersionInfo;
 }
 
-export async function getReactVersionInfoForProject(projectDir: string): Promise<ReactVersionInfo> {
-  const cached = projectVersionCache.get(projectDir);
+export async function getReactVersionInfoForProject(
+  projectDir: string,
+  projectId?: string,
+): Promise<ReactVersionInfo> {
+  const cacheKey = projectId ?? projectDir;
+  const cached = projectVersionCache.get(cacheKey);
   if (cached) return cached;
 
   const info = await detectReactVersionFromProject(projectDir);
-  projectVersionCache.set(projectDir, info);
+  projectVersionCache.set(cacheKey, info);
   return info;
 }
 
-export function clearProjectVersionCache(projectDir: string): void {
-  projectVersionCache.delete(projectDir);
+export function clearProjectVersionCache(projectId: string): void {
+  projectVersionCache.delete(projectId);
 }
 
 export function hasFeature(feature: keyof ReactFeatures): boolean {

--- a/src/rendering/factories/service-factories.ts
+++ b/src/rendering/factories/service-factories.ts
@@ -11,6 +11,7 @@ import { PageRenderer } from "../page-renderer.ts";
 export function createPageResolver(ctx: RenderContext): PageResolver {
   return new PageResolver({
     projectDir: ctx.projectDir,
+    projectId: ctx.projectId,
     config: ctx.config,
     adapter: ctx.adapter,
   });
@@ -22,6 +23,7 @@ export function createLayoutCollector(
 ): LayoutCollector {
   return new LayoutCollector({
     projectDir: ctx.projectDir,
+    projectId: ctx.projectId,
     adapter: ctx.adapter,
     config: ctx.config,
     compileMDX,

--- a/src/rendering/factories/service-factories.ts
+++ b/src/rendering/factories/service-factories.ts
@@ -41,7 +41,7 @@ export function createLayoutCompiler(
 }
 
 export function createSSRRenderer(ctx: RenderContext): SSRRenderer {
-  return new SSRRenderer(ctx.mode, ctx.adapter, ctx.projectDir);
+  return new SSRRenderer(ctx.mode, ctx.adapter, ctx.projectDir, ctx.projectId);
 }
 
 export function createComponentRegistry(

--- a/src/rendering/layouts/layout-applicator.ts
+++ b/src/rendering/layouts/layout-applicator.ts
@@ -89,7 +89,9 @@ export class LayoutApplicator {
           layoutDataMap,
         );
 
-        const useAppRouter = await detectAppRouter(this.projectDir, this.config, this.adapter);
+        const useAppRouter = await detectAppRouter(this.projectDir, this.config, this.adapter, {
+          projectId: this.projectId,
+        });
         const pageFilePath = pageInfo.entity.path;
 
         const isDotPath = pageFilePath

--- a/src/rendering/layouts/layout-collector.ts
+++ b/src/rendering/layouts/layout-collector.ts
@@ -78,6 +78,7 @@ export interface LayoutCollectionResult {
 
 export interface LayoutCollectorOptions {
   projectDir: string;
+  projectId?: string;
   adapter: RuntimeAdapter;
   config: VeryfrontConfig;
   compileMDX: (
@@ -89,6 +90,7 @@ export interface LayoutCollectorOptions {
 
 export class LayoutCollector {
   private projectDir: string;
+  private projectId?: string;
   private adapter: RuntimeAdapter;
   private config: VeryfrontConfig;
   private compileMDX: (
@@ -99,6 +101,7 @@ export class LayoutCollector {
 
   constructor(options: LayoutCollectorOptions) {
     this.projectDir = options.projectDir;
+    this.projectId = options.projectId;
     this.adapter = options.adapter;
     this.config = options.config;
     this.compileMDX = options.compileMDX;
@@ -303,7 +306,9 @@ export class LayoutCollector {
 
   private async collectNestedLayouts(pageInfo: EntityInfo): Promise<LayoutItem[]> {
     const pageFilePath = pageInfo.entity.path;
-    const useAppRouter = await detectAppRouter(this.projectDir, this.config, this.adapter);
+    const useAppRouter = await detectAppRouter(this.projectDir, this.config, this.adapter, {
+      projectId: this.projectId,
+    });
 
     // Unified path for ALL adapters - discoverNestedLayouts uses adapter.fs.stat()
     // which works for both filesystem and API adapters

--- a/src/rendering/layouts/utils/component-loader.ts
+++ b/src/rendering/layouts/utils/component-loader.ts
@@ -133,7 +133,7 @@ export function loadMDXLayout(
         hasPreloadedImportMap: !!preloadedImportMap,
       });
 
-      const map = preloadedImportMap ?? (await preloadImportMap(projectDir, adapter));
+      const map = preloadedImportMap ?? (await preloadImportMap(projectDir, adapter, projectId));
       if (preloadedImportMap) {
         loadMdxLayoutLog.debug("Using preloaded import map", { projectSlug });
       }

--- a/src/rendering/orchestrator/layout.ts
+++ b/src/rendering/orchestrator/layout.ts
@@ -74,7 +74,7 @@ export class LayoutOrchestrator {
       this.config.layoutCache.clear();
     }
     clearSSRModuleCacheForProject(this.config.projectId);
-    clearImportMapCache(this.config.projectDir);
+    clearImportMapCache(this.config.projectId);
     this._preloadedImportMap = null;
   }
 
@@ -130,6 +130,7 @@ export class LayoutOrchestrator {
                 const importMap = await preloadImportMap(
                   this.config.projectDir,
                   this.config.adapter,
+                  this.config.projectId,
                 );
                 this._preloadedImportMap = importMap;
                 return { type: "importMap" as const, success: true };

--- a/src/rendering/orchestrator/lifecycle.ts
+++ b/src/rendering/orchestrator/lifecycle.ts
@@ -159,7 +159,7 @@ export class RendererLifecycle {
       debugMode,
     });
 
-    const ssrRenderer = new SSRRenderer(mode, this.adapter, projectDir);
+    const ssrRenderer = new SSRRenderer(mode, this.adapter, projectDir, this.projectId);
 
     const pageRenderer = new PageRenderer({
       projectDir,

--- a/src/rendering/orchestrator/lifecycle.ts
+++ b/src/rendering/orchestrator/lifecycle.ts
@@ -143,6 +143,7 @@ export class RendererLifecycle {
 
     const layoutCollector = new LayoutCollector({
       projectDir,
+      projectId: this.projectId,
       adapter: this.adapter,
       config,
       compileMDX: compileMDXProxy,
@@ -172,6 +173,7 @@ export class RendererLifecycle {
 
     const pageResolver = new PageResolver({
       projectDir,
+      projectId: this.projectId,
       config,
       adapter: this.adapter,
     });

--- a/src/rendering/page-resolution/page-resolver.ts
+++ b/src/rendering/page-resolution/page-resolver.ts
@@ -39,17 +39,20 @@ function appDirToSlug(dirPath: string, appDirName: string): string {
 
 export interface PageResolverOptions {
   projectDir: string;
+  projectId?: string;
   config: VeryfrontConfig;
   adapter: RuntimeAdapter;
 }
 
 export class PageResolver {
   private projectDir: string;
+  private projectId?: string;
   private config: VeryfrontConfig;
   private adapter: RuntimeAdapter;
 
   constructor(options: PageResolverOptions) {
     this.projectDir = options.projectDir;
+    this.projectId = options.projectId;
     this.config = options.config;
     this.adapter = options.adapter;
   }
@@ -62,6 +65,7 @@ export class PageResolver {
           this.projectDir,
           this.config,
           this.adapter,
+          { projectId: this.projectId },
         );
 
         const appDirName = this.config.directories?.app ?? "app";
@@ -207,6 +211,7 @@ export class PageResolver {
       this.projectDir,
       this.config,
       this.adapter,
+      { projectId: this.projectId },
     );
     return useAppRouter ? "app" : "pages";
   }

--- a/src/rendering/router-detection.ts
+++ b/src/rendering/router-detection.ts
@@ -29,6 +29,8 @@ const routerDetectionCache = new LRUCache<string, boolean>({
   ttlMs: ROUTER_DETECTION_CACHE_TTL_MS,
 });
 
+let warnedMissingProjectId = false;
+
 /**
  * Clear the router detection cache. Call when filesystem changes.
  * @deprecated Use clearRouterDetectionCacheForProject for multi-tenant deployments
@@ -68,16 +70,16 @@ export async function detectAppRouter(
   if (config?.router === "pages") return false;
 
   const cacheKey = options?.projectId ?? projectDir;
+  const cached = routerDetectionCache.get(cacheKey);
+  if (cached !== undefined) return cached;
 
-  if (!options?.projectId && config?.fs?.type === "veryfront-api") {
+  if (!options?.projectId && config?.fs?.type === "veryfront-api" && !warnedMissingProjectId) {
+    warnedMissingProjectId = true;
     logger.warn(
       "detectAppRouter called without projectId in multi-tenant mode — cache key falls back to projectDir which may cause cross-tenant poisoning",
       { projectDir },
     );
   }
-
-  const cached = routerDetectionCache.get(cacheKey);
-  if (cached !== undefined) return cached;
 
   return await withSpan(
     SpanNames.ROUTER_DETECT_APP,

--- a/src/rendering/router-detection.ts
+++ b/src/rendering/router-detection.ts
@@ -9,11 +9,14 @@
 
 import { join } from "#veryfront/compat/path";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { rendererLogger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { SpanNames } from "#veryfront/observability/tracing/span-names.ts";
+
+const logger = rendererLogger.component("router-detection");
 
 // Re-export from app-route-resolver for backward compatibility
 export { getAppRouteEntity } from "./app-route-resolver.ts";
@@ -65,6 +68,14 @@ export async function detectAppRouter(
   if (config?.router === "pages") return false;
 
   const cacheKey = options?.projectId ?? projectDir;
+
+  if (!options?.projectId && config?.fs?.type === "veryfront-api") {
+    logger.warn(
+      "detectAppRouter called without projectId in multi-tenant mode — cache key falls back to projectDir which may cause cross-tenant poisoning",
+      { projectDir },
+    );
+  }
+
   const cached = routerDetectionCache.get(cacheKey);
   if (cached !== undefined) return cached;
 

--- a/src/rendering/router-detection.ts
+++ b/src/rendering/router-detection.ts
@@ -37,34 +37,47 @@ export function clearRouterDetectionCache(): void {
 /**
  * Clear the router detection cache for a specific project.
  * Use this in multi-tenant deployments to avoid clearing other projects' caches.
+ *
+ * @param projectId - The project ID used as cache key. Falls back to projectDir for local dev.
  */
-export function clearRouterDetectionCacheForProject(projectDir: string): void {
-  routerDetectionCache.delete(projectDir);
+export function clearRouterDetectionCacheForProject(projectId: string): void {
+  routerDetectionCache.delete(projectId);
+}
+
+export interface DetectAppRouterOptions {
+  /** Project ID for cache isolation in multi-tenant deployments */
+  projectId?: string;
 }
 
 /**
- * Detect if app router should be used based on config and directory structure
+ * Detect if app router should be used based on config and directory structure.
+ *
+ * In multi-tenant proxy mode, `projectDir` is the same for all projects ("/app"),
+ * so the cache key must use `projectId` to avoid cross-project cache poisoning.
  */
 export async function detectAppRouter(
   projectDir: string,
   config: VeryfrontConfig,
   adapter: RuntimeAdapter,
+  options?: DetectAppRouterOptions,
 ): Promise<boolean> {
   if (config?.router === "app") return true;
   if (config?.router === "pages") return false;
 
-  const cached = routerDetectionCache.get(projectDir);
+  const cacheKey = options?.projectId ?? projectDir;
+  const cached = routerDetectionCache.get(cacheKey);
   if (cached !== undefined) return cached;
 
   return await withSpan(
     SpanNames.ROUTER_DETECT_APP,
     async () => {
       const result = await detectAppRouterImpl(projectDir, config, adapter);
-      routerDetectionCache.set(projectDir, result);
+      routerDetectionCache.set(cacheKey, result);
       return result;
     },
     {
       "router.project_dir": projectDir,
+      "router.project_id": cacheKey,
       "router.config_router": config?.router ?? "auto",
     },
   );

--- a/src/rendering/router-detection.ts
+++ b/src/rendering/router-detection.ts
@@ -77,7 +77,7 @@ export async function detectAppRouter(
     },
     {
       "router.project_dir": projectDir,
-      "router.project_id": cacheKey,
+      "router.cache_key": cacheKey,
       "router.config_router": config?.router ?? "auto",
     },
   );

--- a/src/rendering/ssr-renderer.ts
+++ b/src/rendering/ssr-renderer.ts
@@ -76,12 +76,19 @@ export class SSRRenderer {
   private readonly mode: string;
   private readonly adapter?: RuntimeAdapter;
   private readonly projectDir?: string;
+  private readonly projectId?: string;
   private versionInfo: ReturnType<typeof getReactVersionInfo> | null = null;
 
-  constructor(mode: string, adapter?: RuntimeAdapter, projectDir?: string) {
+  constructor(
+    mode: string,
+    adapter?: RuntimeAdapter,
+    projectDir?: string,
+    projectId?: string,
+  ) {
     this.mode = mode;
     this.adapter = adapter;
     this.projectDir = projectDir;
+    this.projectId = projectId;
   }
 
   private async getVersionInfo(): Promise<ReturnType<typeof getReactVersionInfo>> {
@@ -93,7 +100,7 @@ export class SSRRenderer {
     }
 
     const { getReactVersionInfoForProject } = await import("#veryfront/react");
-    this.versionInfo = await getReactVersionInfoForProject(this.projectDir);
+    this.versionInfo = await getReactVersionInfoForProject(this.projectDir, this.projectId);
     return this.versionInfo;
   }
 

--- a/src/server/context/cache-invalidation.ts
+++ b/src/server/context/cache-invalidation.ts
@@ -10,7 +10,10 @@ import {
 } from "#veryfront/modules/react-loader/ssr-module-loader/index.ts";
 import { cacheRegistry } from "#veryfront/cache";
 import { clearRendererCacheForProject } from "#veryfront/rendering/renderer.ts";
-import { clearRouterDetectionCache } from "#veryfront/rendering/router-detection.ts";
+import {
+  clearRouterDetectionCache,
+  clearRouterDetectionCacheForProject,
+} from "#veryfront/rendering/router-detection.ts";
 import { clearSnippetCacheForProject } from "#veryfront/rendering/snippet-renderer.ts";
 import { resetApiHandlerForProject } from "#veryfront/server/handlers/request/api/pages-api-handler.ts";
 
@@ -72,8 +75,12 @@ export async function invalidateProjectCaches(
     clearSSRModuleCache();
   }
 
-  logger.debug("Clearing router detection cache", { projectSlug });
-  clearRouterDetectionCache();
+  logger.debug("Clearing router detection cache", { projectSlug, projectId });
+  if (projectId) {
+    clearRouterDetectionCacheForProject(projectId);
+  } else {
+    clearRouterDetectionCache();
+  }
 
   if (!hasRealProjectSlug) {
     logger.error(

--- a/src/server/handlers/request/rsc/index.ts
+++ b/src/server/handlers/request/rsc/index.ts
@@ -48,6 +48,7 @@ export class RSCHandler extends BaseHandler {
           req,
           pathname,
           projectDir: ctx.projectDir,
+          projectId: ctx.projectId,
           adapter: ctx.adapter,
           config: ctx.config,
         });

--- a/src/server/services/rsc/endpoints/endpoint-router.ts
+++ b/src/server/services/rsc/endpoints/endpoint-router.ts
@@ -24,7 +24,7 @@ const rscLog = serverLogger.component("rsc");
  * @returns Response or null if not an RSC endpoint
  */
 export async function handleRSCEndpoint(
-  { req, pathname, projectDir, adapter, config }: RSCEndpointParams,
+  { req, pathname, projectDir, projectId, adapter, config }: RSCEndpointParams,
 ): Promise<Response | null> {
   if (!pathname.startsWith("/_veryfront/rsc/")) {
     return null;
@@ -52,7 +52,7 @@ export async function handleRSCEndpoint(
   }
 
   const url = new URL(req.url);
-  const handler = getRSCHandler(projectDir);
+  const handler = getRSCHandler(projectDir, projectId);
 
   try {
     if (sub.startsWith("render/")) {

--- a/src/server/services/rsc/endpoints/handler-registry.ts
+++ b/src/server/services/rsc/endpoints/handler-registry.ts
@@ -53,13 +53,17 @@ function getHandlersCache(): HandlerCache<RSCDevServerHandler> {
   return rscHandlersByProject;
 }
 
-export function getRSCHandler(projectDir: string): RSCDevServerHandler {
+export function getRSCHandler(
+  projectDir: string,
+  projectId?: string,
+): RSCDevServerHandler {
+  const cacheKey = projectId ?? projectDir;
   const cache = getHandlersCache();
-  const existing = cache.get(projectDir);
+  const existing = cache.get(cacheKey);
   if (existing) return existing;
 
   const handler = new RSCDevServerHandler(projectDir);
-  cache.set(projectDir, handler);
+  cache.set(cacheKey, handler);
   return handler;
 }
 

--- a/src/server/services/rsc/endpoints/types.ts
+++ b/src/server/services/rsc/endpoints/types.ts
@@ -16,6 +16,7 @@ export interface RSCEndpointParams {
   req: Request;
   pathname: string;
   projectDir: string;
+  projectId?: string;
   adapter: RuntimeAdapter;
   config?: VeryfrontConfig;
 }


### PR DESCRIPTION
## Summary

- **Root cause**: In multi-tenant proxy mode, all renderer pods share `projectDir="/app"` (Docker WORKDIR). The `routerDetectionCache` was keyed by `projectDir`, so when a pod cached the router type for one project, it returned that same result for all other projects — causing 500 errors when the wrong router type was applied (e.g., looking for `app/layout.tsx` when the project only has `components/layout.tsx`).
- Keys the router detection cache by `projectId` (UUID) instead of `projectDir`, with fallback to `projectDir` for local dev where each project has a unique directory.
- Updates all callers (`PageResolver`, `LayoutCollector`, `LayoutApplicator`), service factories, lifecycle, cache invalidation, and WebSocket manager to pass `projectId` through.

## Test plan

- [x] `deno task build` passes
- [x] `deno task verify:quick` passes (fmt, lint, typecheck)
- [ ] Existing `router-detection.test.ts` passes (uses `projectDir` fallback — no `projectId` needed)
- [ ] Deploy to staging and verify new projects render without 500
- [ ] Verify local dev (`deno task start`) still works without `projectId`