### PR TITLE
test: increase server module test coverage

### DIFF
--- a/src/server/handlers/dev/files/path-validator.test.ts
+++ b/src/server/handlers/dev/files/path-validator.test.ts
@@ -63,7 +63,21 @@ describe("server/handlers/dev/files/path-validator", () => {
     assertEquals(result, "/project/src/foo.ts");
   });
 
-  for (const dir of ["app", "pages", "components", "islands", "public", "shared", "modules", "server", "client", "lib", "routes"]) {
+  for (
+    const dir of [
+      "app",
+      "pages",
+      "components",
+      "islands",
+      "public",
+      "shared",
+      "modules",
+      "server",
+      "client",
+      "lib",
+      "routes",
+    ]
+  ) {
     it(`should allow files in '${dir}' directory`, async () => {
       const encoded = toBase64Url(`${dir}/test.ts`);
       const ctx = makeCtx("/project", { isFile: true });

--- a/src/server/handlers/dev/files/path-validator.test.ts
+++ b/src/server/handlers/dev/files/path-validator.test.ts
@@ -1,0 +1,81 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { validateDevFilePath } from "./path-validator.ts";
+import { toBase64Url } from "#veryfront/utils/path-utils.ts";
+import type { HandlerContext } from "../../types.ts";
+
+function makeCtx(
+  projectDir: string,
+  statResult?: { isFile: boolean } | "throw",
+): HandlerContext {
+  return {
+    projectDir,
+    adapter: {
+      fs: {
+        stat: async (_path: string) => {
+          if (statResult === "throw") throw new Error("not found");
+          return statResult ?? { isFile: true };
+        },
+      },
+    },
+  } as unknown as HandlerContext;
+}
+
+describe("server/handlers/dev/files/path-validator", () => {
+  it("should return error for invalid base64 encoding", async () => {
+    const ctx = makeCtx("/project");
+    const result = await validateDevFilePath("!!!invalid!!!", ctx);
+    assertEquals(result, "Error: Invalid path encoding");
+  });
+
+  it("should return error for path outside project directory", async () => {
+    const encoded = toBase64Url("/etc/passwd");
+    const ctx = makeCtx("/project");
+    const result = await validateDevFilePath(encoded, ctx);
+    assertEquals(result, "Error: Path outside project");
+  });
+
+  it("should return error for disallowed top-level directory", async () => {
+    const encoded = toBase64Url("node_modules/foo.ts");
+    const ctx = makeCtx("/project");
+    const result = await validateDevFilePath(encoded, ctx);
+    assertEquals(result, "Error: Access to directory not allowed");
+  });
+
+  it("should return error when file does not exist", async () => {
+    const encoded = toBase64Url("src/foo.ts");
+    const ctx = makeCtx("/project", "throw");
+    const result = await validateDevFilePath(encoded, ctx);
+    assertEquals(result, "Error: File not found");
+  });
+
+  it("should return error when path is a directory", async () => {
+    const encoded = toBase64Url("src/foo");
+    const ctx = makeCtx("/project", { isFile: false });
+    const result = await validateDevFilePath(encoded, ctx);
+    assertEquals(result, "Error: Not a file");
+  });
+
+  it("should return absolute path for valid file in allowed directory", async () => {
+    const encoded = toBase64Url("src/foo.ts");
+    const ctx = makeCtx("/project", { isFile: true });
+    const result = await validateDevFilePath(encoded, ctx);
+    assertEquals(result, "/project/src/foo.ts");
+  });
+
+  for (const dir of ["app", "pages", "components", "islands", "public", "shared", "modules", "server", "client", "lib", "routes"]) {
+    it(`should allow files in '${dir}' directory`, async () => {
+      const encoded = toBase64Url(`${dir}/test.ts`);
+      const ctx = makeCtx("/project", { isFile: true });
+      const result = await validateDevFilePath(encoded, ctx);
+      assertEquals(result, `/project/${dir}/test.ts`);
+    });
+  }
+
+  it("should handle absolute path within project", async () => {
+    const encoded = toBase64Url("/project/src/foo.ts");
+    const ctx = makeCtx("/project", { isFile: true });
+    const result = await validateDevFilePath(encoded, ctx);
+    assertEquals(result, "/project/src/foo.ts");
+  });
+});

--- a/src/server/handlers/dev/shared/not-found-response.test.ts
+++ b/src/server/handlers/dev/shared/not-found-response.test.ts
@@ -1,0 +1,30 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createDevNotFoundResponse } from "./not-found-response.ts";
+
+describe("server/handlers/dev/shared/not-found-response", () => {
+  describe("createDevNotFoundResponse", () => {
+    it("should return a Response object", () => {
+      const response = createDevNotFoundResponse();
+      assertEquals(response instanceof Response, true);
+    });
+
+    it("should return a 404 status", () => {
+      const response = createDevNotFoundResponse();
+      assertEquals(response.status, 404);
+    });
+
+    it("should have JSON content type", async () => {
+      const response = createDevNotFoundResponse();
+      const contentType = response.headers.get("content-type");
+      assertEquals(contentType?.includes("application/problem+json") || contentType?.includes("application/json"), true);
+    });
+
+    it("should contain error details in body", async () => {
+      const response = createDevNotFoundResponse();
+      const body = await response.json();
+      assertEquals(typeof body, "object");
+      assertEquals(body.status, 404);
+    });
+  });
+});

--- a/src/server/handlers/dev/shared/not-found-response.test.ts
+++ b/src/server/handlers/dev/shared/not-found-response.test.ts
@@ -17,7 +17,11 @@ describe("server/handlers/dev/shared/not-found-response", () => {
     it("should have JSON content type", async () => {
       const response = createDevNotFoundResponse();
       const contentType = response.headers.get("content-type");
-      assertEquals(contentType?.includes("application/problem+json") || contentType?.includes("application/json"), true);
+      assertEquals(
+        contentType?.includes("application/problem+json") ||
+          contentType?.includes("application/json"),
+        true,
+      );
     });
 
     it("should contain error details in body", async () => {

--- a/src/server/handlers/request/api/pages-api-handler.test.ts
+++ b/src/server/handlers/request/api/pages-api-handler.test.ts
@@ -1,0 +1,126 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it, afterEach } from "#veryfront/testing/bdd.ts";
+import {
+  resetApiHandler,
+  resetApiHandlerForProject,
+  __injectCacheForTests,
+  type HandlerCache,
+} from "./pages-api-handler.ts";
+
+type MockHandler = { destroyed: boolean; destroy(): void };
+
+function createMockCache(): HandlerCache<Promise<MockHandler>> & { store: Map<string, Promise<MockHandler>> } {
+  const store = new Map<string, Promise<MockHandler>>();
+  return {
+    store,
+    get(key: string) {
+      return store.get(key);
+    },
+    set(key: string, value: Promise<MockHandler>) {
+      store.set(key, value);
+    },
+    delete(key: string) {
+      return store.delete(key);
+    },
+    clear() {
+      store.clear();
+    },
+    entries() {
+      return store.entries();
+    },
+    values() {
+      return store.values();
+    },
+  };
+}
+
+function createMockHandler(): MockHandler {
+  return {
+    destroyed: false,
+    destroy() {
+      this.destroyed = true;
+    },
+  };
+}
+
+afterEach(() => {
+  __injectCacheForTests(null);
+});
+
+describe("server/handlers/request/api/pages-api-handler", () => {
+  describe("resetApiHandler", () => {
+    it("should clear a specific project entry by key", async () => {
+      const cache = createMockCache();
+      const handler = createMockHandler();
+      cache.set("/project-dir", Promise.resolve(handler));
+      __injectCacheForTests(cache as any);
+
+      await resetApiHandler("/project-dir");
+      assertEquals(cache.store.size, 0);
+      assertEquals(handler.destroyed, true);
+    });
+
+    it("should clear all entries when no projectDir specified", async () => {
+      const cache = createMockCache();
+      const h1 = createMockHandler();
+      const h2 = createMockHandler();
+      cache.set("/dir1", Promise.resolve(h1));
+      cache.set("/dir2", Promise.resolve(h2));
+      __injectCacheForTests(cache as any);
+
+      await resetApiHandler();
+      assertEquals(cache.store.size, 0);
+      assertEquals(h1.destroyed, true);
+      assertEquals(h2.destroyed, true);
+    });
+
+    it("should handle missing entry gracefully", async () => {
+      const cache = createMockCache();
+      __injectCacheForTests(cache as any);
+
+      // Should not throw
+      await resetApiHandler("/nonexistent");
+      assertEquals(cache.store.size, 0);
+    });
+  });
+
+  describe("resetApiHandlerForProject", () => {
+    it("should clear entries matching project slug suffix", async () => {
+      const cache = createMockCache();
+      const h1 = createMockHandler();
+      const h2 = createMockHandler();
+      const h3 = createMockHandler();
+      cache.set("/dir:my-project", Promise.resolve(h1));
+      cache.set("/other:my-project", Promise.resolve(h2));
+      cache.set("/dir:other-project", Promise.resolve(h3));
+      __injectCacheForTests(cache as any);
+
+      await resetApiHandlerForProject("my-project");
+      assertEquals(cache.store.size, 1);
+      assertEquals(cache.store.has("/dir:other-project"), true);
+      assertEquals(h1.destroyed, true);
+      assertEquals(h2.destroyed, true);
+      assertEquals(h3.destroyed, false);
+    });
+
+    it("should match exact slug key", async () => {
+      const cache = createMockCache();
+      const handler = createMockHandler();
+      cache.set("my-project", Promise.resolve(handler));
+      __injectCacheForTests(cache as any);
+
+      await resetApiHandlerForProject("my-project");
+      assertEquals(cache.store.size, 0);
+      assertEquals(handler.destroyed, true);
+    });
+
+    it("should handle no matching entries gracefully", async () => {
+      const cache = createMockCache();
+      cache.set("/dir:other", Promise.resolve(createMockHandler()));
+      __injectCacheForTests(cache as any);
+
+      await resetApiHandlerForProject("nonexistent");
+      assertEquals(cache.store.size, 1);
+    });
+  });
+});

--- a/src/server/handlers/request/api/pages-api-handler.test.ts
+++ b/src/server/handlers/request/api/pages-api-handler.test.ts
@@ -1,15 +1,17 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it, afterEach } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
-  resetApiHandler,
-  resetApiHandlerForProject,
   __injectCacheForTests,
   type HandlerCache,
+  resetApiHandler,
+  resetApiHandlerForProject,
 } from "./pages-api-handler.ts";
 
 type MockHandler = { destroyed: boolean; destroy(): void };
 
-function createMockCache(): HandlerCache<Promise<MockHandler>> & { store: Map<string, Promise<MockHandler>> } {
+function createMockCache(): HandlerCache<Promise<MockHandler>> & {
+  store: Map<string, Promise<MockHandler>>;
+} {
   const store = new Map<string, Promise<MockHandler>>();
   return {
     store,

--- a/src/server/handlers/request/api/security-headers.test.ts
+++ b/src/server/handlers/request/api/security-headers.test.ts
@@ -1,0 +1,82 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { buildCSP, getSecurityHeader, applySecurityHeaders } from "./security-headers.ts";
+import type { HandlerContext } from "../../types.ts";
+
+function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    isLocalProject: false,
+    cspUserHeader: null,
+    securityConfig: undefined,
+    adapter: {
+      name: "test",
+    },
+    parsedDomain: { allowIframeEmbed: false },
+    ...overrides,
+  } as unknown as HandlerContext;
+}
+
+describe("server/handlers/request/api/security-headers", () => {
+  describe("buildCSP", () => {
+    it("should return a string", () => {
+      const ctx = makeCtx();
+      const csp = buildCSP(ctx);
+      assertEquals(typeof csp, "string");
+    });
+
+    it("should return a string for local project context", () => {
+      const ctx = makeCtx({ isLocalProject: true });
+      const csp = buildCSP(ctx);
+      assertEquals(typeof csp, "string");
+    });
+
+    it("should return different CSP for dev vs production", () => {
+      const devCtx = makeCtx({ isLocalProject: true });
+      const prodCtx = makeCtx({ isLocalProject: false });
+      const devCsp = buildCSP(devCtx);
+      const prodCsp = buildCSP(prodCtx);
+      // Both should be strings (may or may not differ depending on implementation)
+      assertEquals(typeof devCsp, "string");
+      assertEquals(typeof prodCsp, "string");
+    });
+  });
+
+  describe("getSecurityHeader", () => {
+    it("should return a value for known headers", () => {
+      const ctx = makeCtx();
+      const value = getSecurityHeader("x-content-type-options", "nosniff", ctx);
+      assertEquals(typeof value, "string");
+    });
+
+    it("should return default value when no config override", () => {
+      const ctx = makeCtx();
+      const value = getSecurityHeader("x-custom-header", "my-default", ctx);
+      assertEquals(value, "my-default");
+    });
+  });
+
+  describe("applySecurityHeaders", () => {
+    it("should add security headers to a Headers object", () => {
+      const ctx = makeCtx();
+      const headers = new Headers();
+      applySecurityHeaders(headers, ctx);
+      // Should have at least one security header
+      assertEquals(headers.has("x-content-type-options"), true);
+    });
+
+    it("should work with local project context", () => {
+      const ctx = makeCtx({ isLocalProject: true });
+      const headers = new Headers();
+      applySecurityHeaders(headers, ctx);
+      assertEquals(typeof headers.get("x-content-type-options"), "string");
+    });
+
+    it("should accept optional request for CSRF cookie", () => {
+      const ctx = makeCtx();
+      const headers = new Headers();
+      const req = new Request("http://localhost/test");
+      // Should not throw
+      applySecurityHeaders(headers, ctx, req);
+    });
+  });
+});

--- a/src/server/handlers/request/api/security-headers.test.ts
+++ b/src/server/handlers/request/api/security-headers.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { buildCSP, getSecurityHeader, applySecurityHeaders } from "./security-headers.ts";
+import { applySecurityHeaders, buildCSP, getSecurityHeader } from "./security-headers.ts";
 import type { HandlerContext } from "../../types.ts";
 
 function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {

--- a/src/server/handlers/request/module/module.handler.test.ts
+++ b/src/server/handlers/request/module/module.handler.test.ts
@@ -1,0 +1,44 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { ModuleHandler } from "./module.handler.ts";
+
+describe("server/handlers/request/module/module.handler", () => {
+  describe("metadata", () => {
+    it("should have correct handler name", () => {
+      const handler = new ModuleHandler();
+      assertEquals(handler.metadata.name, "ModuleHandler");
+    });
+
+    it("should have patterns for all module prefixes", () => {
+      const handler = new ModuleHandler();
+      const patterns = handler.metadata.patterns;
+      assertExists(patterns);
+
+      const patternStrings = patterns.map((p) =>
+        typeof p === "string" ? p : (p as { pattern: string }).pattern
+      );
+
+      assertEquals(patternStrings.includes("/_vf_modules/"), true);
+      assertEquals(patternStrings.includes("/_veryfront/modules/"), true);
+      assertEquals(patternStrings.includes("/_veryfront/pages/"), true);
+      assertEquals(patternStrings.includes("/_veryfront/data/"), true);
+      assertEquals(patternStrings.includes("/_veryfront/page-data/"), true);
+    });
+
+    it("should have all patterns marked as prefix", () => {
+      const handler = new ModuleHandler();
+      const patterns = handler.metadata.patterns;
+      assertExists(patterns);
+
+      for (const pattern of patterns) {
+        if (typeof pattern === "string") continue;
+        assertEquals((pattern as { prefix?: boolean }).prefix, true);
+      }
+    });
+
+    it("should have 5 patterns total", () => {
+      const handler = new ModuleHandler();
+      assertEquals(handler.metadata.patterns?.length, 5);
+    });
+  });
+});

--- a/src/server/handlers/request/module/module.handler.test.ts
+++ b/src/server/handlers/request/module/module.handler.test.ts
@@ -1,44 +1,123 @@
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { ModuleHandler } from "./module.handler.ts";
+import type { HandlerContext } from "../../types.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+
+function createMockAdapter(): RuntimeAdapter {
+  return {
+    id: "memory",
+    name: "mock",
+    capabilities: {
+      typescript: true,
+      jsx: true,
+      fileWatcher: false,
+      shell: false,
+      kvStore: false,
+      workers: false,
+    },
+    fs: {
+      exists: () => Promise.resolve(false),
+      readFile: () => Promise.resolve(""),
+      writeFile: () => Promise.resolve(),
+      readDir: () => Promise.resolve([]),
+      mkdir: () => Promise.resolve(),
+      remove: () => Promise.resolve(),
+      stat: () => Promise.resolve({ isFile: false, isDirectory: false, size: 0, mtime: null }),
+    },
+    env: {
+      get: () => undefined,
+      set: () => {},
+      delete: () => {},
+      toObject: () => ({}),
+    },
+    server: { createHandler: () => () => new Response() },
+    serve: () => Promise.resolve({ close: () => Promise.resolve() } as any),
+  } as unknown as RuntimeAdapter;
+}
+
+function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    projectDir: "/tmp/test-project",
+    adapter: createMockAdapter(),
+    securityConfig: null,
+    cspUserHeader: null,
+    ...overrides,
+  };
+}
 
 describe("server/handlers/request/module/module.handler", () => {
-  describe("metadata", () => {
-    it("should have correct handler name", () => {
+  describe("ModuleHandler metadata", () => {
+    it("has correct name", () => {
       const handler = new ModuleHandler();
       assertEquals(handler.metadata.name, "ModuleHandler");
     });
 
-    it("should have patterns for all module prefixes", () => {
-      const handler = new ModuleHandler();
-      const patterns = handler.metadata.patterns;
-      assertExists(patterns);
-
-      const patternStrings = patterns.map((p) =>
-        typeof p === "string" ? p : (p as { pattern: string }).pattern
-      );
-
-      assertEquals(patternStrings.includes("/_vf_modules/"), true);
-      assertEquals(patternStrings.includes("/_veryfront/modules/"), true);
-      assertEquals(patternStrings.includes("/_veryfront/pages/"), true);
-      assertEquals(patternStrings.includes("/_veryfront/data/"), true);
-      assertEquals(patternStrings.includes("/_veryfront/page-data/"), true);
-    });
-
-    it("should have all patterns marked as prefix", () => {
-      const handler = new ModuleHandler();
-      const patterns = handler.metadata.patterns;
-      assertExists(patterns);
-
-      for (const pattern of patterns) {
-        if (typeof pattern === "string") continue;
-        assertEquals((pattern as { prefix?: boolean }).prefix, true);
-      }
-    });
-
-    it("should have 5 patterns total", () => {
+    it("has 5 route patterns", () => {
       const handler = new ModuleHandler();
       assertEquals(handler.metadata.patterns?.length, 5);
+    });
+
+    it("includes _vf_modules pattern", () => {
+      const handler = new ModuleHandler();
+      const patterns = handler.metadata.patterns?.map((p) => p.pattern) ?? [];
+      assertEquals(patterns.includes("/_vf_modules/"), true);
+    });
+
+    it("includes _veryfront/modules pattern", () => {
+      const handler = new ModuleHandler();
+      const patterns = handler.metadata.patterns?.map((p) => p.pattern) ?? [];
+      assertEquals(patterns.includes("/_veryfront/modules/"), true);
+    });
+
+    it("includes _veryfront/pages pattern", () => {
+      const handler = new ModuleHandler();
+      const patterns = handler.metadata.patterns?.map((p) => p.pattern) ?? [];
+      assertEquals(patterns.includes("/_veryfront/pages/"), true);
+    });
+
+    it("includes _veryfront/data pattern", () => {
+      const handler = new ModuleHandler();
+      const patterns = handler.metadata.patterns?.map((p) => p.pattern) ?? [];
+      assertEquals(patterns.includes("/_veryfront/data/"), true);
+    });
+
+    it("includes _veryfront/page-data pattern", () => {
+      const handler = new ModuleHandler();
+      const patterns = handler.metadata.patterns?.map((p) => p.pattern) ?? [];
+      assertEquals(patterns.includes("/_veryfront/page-data/"), true);
+    });
+
+    it("all patterns are prefix matches", () => {
+      const handler = new ModuleHandler();
+      const allPrefix = handler.metadata.patterns?.every((p) => p.prefix === true) ?? false;
+      assertEquals(allPrefix, true);
+    });
+  });
+
+  describe("handle - non-matching paths", () => {
+    it("continues for unmatched paths", async () => {
+      const handler = new ModuleHandler();
+      const req = new Request("http://localhost/some/other/path");
+      const ctx = makeCtx();
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, true);
+    });
+
+    it("continues for root path", async () => {
+      const handler = new ModuleHandler();
+      const req = new Request("http://localhost/");
+      const ctx = makeCtx();
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, true);
+    });
+
+    it("continues for similar but non-matching prefix", async () => {
+      const handler = new ModuleHandler();
+      const req = new Request("http://localhost/_veryfront/other/");
+      const ctx = makeCtx();
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, true);
     });
   });
 });

--- a/src/server/handlers/request/ssr/error-page-fallback.test.ts
+++ b/src/server/handlers/request/ssr/error-page-fallback.test.ts
@@ -1,0 +1,153 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { __injectCacheForTests, tryErrorPageFallback } from "./error-page-fallback.ts";
+import { ResponseBuilder } from "#veryfront/security/http/response/builder.ts";
+import type { HandlerContext } from "../../types.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+
+function createMockAdapter(
+  overrides: {
+    stat?: (
+      path: string,
+    ) => Promise<{ isFile: boolean; isDirectory: boolean; size: number; mtime: null }>;
+    readFile?: (path: string) => Promise<string>;
+    resolveFile?: ((path: string) => Promise<string | null>) | undefined;
+  } = {},
+): RuntimeAdapter {
+  return {
+    id: "memory",
+    name: "mock",
+    capabilities: {
+      typescript: true,
+      jsx: true,
+      fileWatcher: false,
+      shell: false,
+      kvStore: false,
+      workers: false,
+    },
+    fs: {
+      exists: () => Promise.resolve(false),
+      readFile: overrides.readFile ?? (() => Promise.resolve("")),
+      writeFile: () => Promise.resolve(),
+      readDir: () => Promise.resolve([]),
+      mkdir: () => Promise.resolve(),
+      remove: () => Promise.resolve(),
+      stat: overrides.stat ??
+        (() => Promise.resolve({ isFile: false, isDirectory: false, size: 0, mtime: null })),
+      ...(overrides.resolveFile !== undefined ? { resolveFile: overrides.resolveFile } : {}),
+    },
+    env: {
+      get: () => undefined,
+      set: () => {},
+      delete: () => {},
+      toObject: () => ({}),
+    },
+    server: { createHandler: () => () => new Response() },
+    serve: () => Promise.resolve({ close: () => Promise.resolve() } as any),
+  } as unknown as RuntimeAdapter;
+}
+
+function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    projectDir: "/tmp/test-project",
+    adapter: createMockAdapter(),
+    securityConfig: null,
+    cspUserHeader: null,
+    projectId: "test-proj",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  __injectCacheForTests(null);
+});
+
+describe("server/handlers/request/ssr/error-page-fallback", () => {
+  describe("tryErrorPageFallback", () => {
+    it("returns null when pages directory does not exist", async () => {
+      const adapter = createMockAdapter({
+        stat: () => Promise.reject(new Error("not found")),
+      });
+      const ctx = makeCtx({ adapter });
+      const req = new Request("http://localhost/");
+      const builder = new ResponseBuilder();
+
+      const result = await tryErrorPageFallback(req, ctx, builder, {
+        statusCode: 404,
+      });
+      assertEquals(result, null);
+    });
+
+    it("returns null when pages is not a directory", async () => {
+      const adapter = createMockAdapter({
+        stat: () => Promise.resolve({ isFile: true, isDirectory: false, size: 0, mtime: null }),
+      });
+      const ctx = makeCtx({ adapter });
+      const req = new Request("http://localhost/");
+      const builder = new ResponseBuilder();
+
+      const result = await tryErrorPageFallback(req, ctx, builder, {
+        statusCode: 404,
+      });
+      assertEquals(result, null);
+    });
+
+    it("returns null when no error page files exist", async () => {
+      const _statResults: Record<
+        string,
+        { isFile: boolean; isDirectory: boolean; size: number; mtime: null }
+      > = {};
+
+      const adapter = createMockAdapter({
+        stat: (path: string) => {
+          // pages dir exists as directory
+          if (path.endsWith("/pages")) {
+            return Promise.resolve({ isFile: false, isDirectory: true, size: 0, mtime: null });
+          }
+          // No error page files exist
+          return Promise.reject(new Error("not found"));
+        },
+      });
+      const ctx = makeCtx({ adapter });
+      const req = new Request("http://localhost/");
+      const builder = new ResponseBuilder();
+
+      const result = await tryErrorPageFallback(req, ctx, builder, {
+        statusCode: 404,
+      });
+      assertEquals(result, null);
+    });
+
+    it("returns null when no error page files exist and resolveFile returns null", async () => {
+      const adapter = createMockAdapter({
+        stat: (path: string) => {
+          if (path.endsWith("/pages")) {
+            return Promise.resolve({ isFile: false, isDirectory: true, size: 0, mtime: null });
+          }
+          return Promise.reject(new Error("not found"));
+        },
+        resolveFile: () => Promise.resolve(null),
+      });
+      const ctx = makeCtx({ adapter });
+      const req = new Request("http://localhost/");
+      const builder = new ResponseBuilder();
+
+      const result = await tryErrorPageFallback(req, ctx, builder, {
+        statusCode: 500,
+      });
+      assertEquals(result, null);
+    });
+  });
+
+  describe("__injectCacheForTests", () => {
+    it("can inject and reset cache repo", () => {
+      const mockRepo = {
+        get: () => Promise.resolve(null),
+        set: () => Promise.resolve(),
+        delete: () => Promise.resolve(),
+      };
+      __injectCacheForTests(mockRepo as any);
+      __injectCacheForTests(null);
+    });
+  });
+});

--- a/src/server/handlers/request/ssr/not-found-fallback.test.ts
+++ b/src/server/handlers/request/ssr/not-found-fallback.test.ts
@@ -1,0 +1,95 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { tryNotFoundFallback } from "./not-found-fallback.ts";
+import { ResponseBuilder } from "#veryfront/security/http/response/builder.ts";
+import type { HandlerContext } from "../../types.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+
+function createMockAdapter(
+  overrides: {
+    stat?: (
+      path: string,
+    ) => Promise<{ isFile: boolean; isDirectory: boolean; size: number; mtime: null }>;
+    readFile?: (path: string) => Promise<string>;
+  } = {},
+): RuntimeAdapter {
+  return {
+    id: "memory",
+    name: "mock",
+    capabilities: {
+      typescript: true,
+      jsx: true,
+      fileWatcher: false,
+      shell: false,
+      kvStore: false,
+      workers: false,
+    },
+    fs: {
+      exists: () => Promise.resolve(false),
+      readFile: overrides.readFile ?? (() => Promise.resolve("")),
+      writeFile: () => Promise.resolve(),
+      readDir: () => Promise.resolve([]),
+      mkdir: () => Promise.resolve(),
+      remove: () => Promise.resolve(),
+      stat: overrides.stat ?? (() => Promise.reject(new Error("not found"))),
+    },
+    env: {
+      get: () => undefined,
+      set: () => {},
+      delete: () => {},
+      toObject: () => ({}),
+    },
+    server: { createHandler: () => () => new Response() },
+    serve: () => Promise.resolve({ close: () => Promise.resolve() } as any),
+  } as unknown as RuntimeAdapter;
+}
+
+function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    projectDir: "/tmp/test-project",
+    adapter: createMockAdapter(),
+    securityConfig: null,
+    cspUserHeader: null,
+    ...overrides,
+  };
+}
+
+describe("server/handlers/request/ssr/not-found-fallback", () => {
+  describe("tryNotFoundFallback", () => {
+    it("returns null when app directory does not exist", async () => {
+      const adapter = createMockAdapter({
+        stat: () => Promise.reject(new Error("ENOENT")),
+      });
+      const ctx = makeCtx({ adapter });
+      const req = new Request("http://localhost/not-found");
+      const builder = new ResponseBuilder();
+
+      const result = await tryNotFoundFallback(req, "not-found", ctx, builder);
+      assertEquals(result, null);
+    });
+
+    it("returns null when app path is not a directory", async () => {
+      const adapter = createMockAdapter({
+        stat: () => Promise.resolve({ isFile: true, isDirectory: false, size: 0, mtime: null }),
+      });
+      const ctx = makeCtx({ adapter });
+      const req = new Request("http://localhost/not-found");
+      const builder = new ResponseBuilder();
+
+      const result = await tryNotFoundFallback(req, "not-found", ctx, builder);
+      assertEquals(result, null);
+    });
+
+    it("returns null when slug is empty and app directory doesn't exist", async () => {
+      const adapter = createMockAdapter({
+        stat: () => Promise.reject(new Error("ENOENT")),
+      });
+      const ctx = makeCtx({ adapter });
+      const req = new Request("http://localhost/");
+      const builder = new ResponseBuilder();
+
+      const result = await tryNotFoundFallback(req, "", ctx, builder);
+      assertEquals(result, null);
+    });
+  });
+});

--- a/src/server/handlers/request/ssr/ssr-response-builder.test.ts
+++ b/src/server/handlers/request/ssr/ssr-response-builder.test.ts
@@ -1,16 +1,51 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { buildSSRResponse } from "./ssr-response-builder.ts";
-import type { HandlerContext } from "../../types.ts";
 import type { SSRRenderResult } from "../../../services/rendering/ssr.service.ts";
-import type { ResponseBuilder } from "#veryfront/security/http/response/builder.ts";
+import { ResponseBuilder } from "#veryfront/security/http/response/builder.ts";
+import type { HandlerContext } from "../../types.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+
+function createMockAdapter(): RuntimeAdapter {
+  return {
+    id: "memory",
+    name: "mock",
+    capabilities: {
+      typescript: true,
+      jsx: true,
+      fileWatcher: false,
+      shell: false,
+      kvStore: false,
+      workers: false,
+    },
+    fs: {
+      exists: () => Promise.resolve(false),
+      readFile: () => Promise.resolve(""),
+      writeFile: () => Promise.resolve(),
+      readDir: () => Promise.resolve([]),
+      mkdir: () => Promise.resolve(),
+      remove: () => Promise.resolve(),
+      stat: () => Promise.resolve({ isFile: true, isDirectory: false, size: 0, mtime: null }),
+    },
+    env: {
+      get: () => undefined,
+      set: () => {},
+      delete: () => {},
+      toObject: () => ({}),
+    },
+    server: { createHandler: () => () => new Response() },
+    serve: () => Promise.resolve({ close: () => Promise.resolve() } as any),
+  } as unknown as RuntimeAdapter;
+}
 
 function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
   return {
-    isLocalProject: false,
-    securityConfig: undefined,
+    projectDir: "/tmp/test",
+    adapter: createMockAdapter(),
+    securityConfig: null,
+    cspUserHeader: null,
     ...overrides,
-  } as unknown as HandlerContext;
+  };
 }
 
 function makeResult(overrides: Partial<SSRRenderResult> = {}): SSRRenderResult {
@@ -19,119 +54,128 @@ function makeResult(overrides: Partial<SSRRenderResult> = {}): SSRRenderResult {
     html: "<html><body>Hello</body></html>",
     isStreaming: false,
     cacheStrategy: "no-cache",
-    slug: "test",
+    slug: "index",
     ...overrides,
   };
 }
 
-function makeBuilder(): ResponseBuilder {
-  const self: ResponseBuilder = {
-    withCORS: () => self,
-    withSecurity: () => self,
-    withClientHints: () => self,
-    withCache: () => self,
-    withETag: () => self,
-    withContentType: (contentType: string, body: unknown, status: number) => {
-      return new Response(body as BodyInit, {
-        status,
-        headers: { "content-type": contentType },
-      });
-    },
-    notModified: (etag: string) => {
-      return new Response(null, {
-        status: 304,
-        headers: { etag },
-      });
-    },
-    html: (content: string, status: number) => {
-      return new Response(content, {
-        status,
-        headers: { "content-type": "text/html" },
-      });
-    },
-  } as unknown as ResponseBuilder;
-  return self;
-}
-
 describe("server/handlers/request/ssr/ssr-response-builder", () => {
   describe("buildSSRResponse", () => {
-    it("should return buffered HTML response for non-streaming result", async () => {
-      const req = new Request("http://localhost/test");
+    it("returns buffered HTML response for non-streaming result", async () => {
+      const req = new Request("http://localhost/");
       const ctx = makeCtx();
       const result = makeResult({ html: "<p>Hello</p>" });
-      const builder = makeBuilder();
+      const builder = new ResponseBuilder();
 
       const response = await buildSSRResponse(req, ctx, result, builder);
       assertEquals(response.status, 200);
       const body = await response.text();
-      assertEquals(body.includes("Hello"), true);
+      assertEquals(body, "<p>Hello</p>");
     });
 
-    it("should return null body for HEAD requests on buffered content", async () => {
-      const req = new Request("http://localhost/test", { method: "HEAD" });
+    it("returns correct status code from result", async () => {
+      const req = new Request("http://localhost/not-found");
       const ctx = makeCtx();
-      const result = makeResult({ html: "<p>Hello</p>" });
-      const builder = makeBuilder();
-
-      const response = await buildSSRResponse(req, ctx, result, builder);
-      assertEquals(response.status, 200);
-      const body = await response.text();
-      assertEquals(body, "");
-    });
-
-    it("should use result status code", async () => {
-      const req = new Request("http://localhost/test");
-      const ctx = makeCtx();
-      const result = makeResult({ status: 404, html: "Not Found" });
-      const builder = makeBuilder();
+      const result = makeResult({ status: 404, html: "<p>Not Found</p>" });
+      const builder = new ResponseBuilder();
 
       const response = await buildSSRResponse(req, ctx, result, builder);
       assertEquals(response.status, 404);
     });
 
-    it("should handle streaming responses", async () => {
-      const encoder = new TextEncoder();
-      const stream = new ReadableStream({
-        start(controller) {
-          controller.enqueue(encoder.encode("<html>"));
-          controller.enqueue(encoder.encode("</html>"));
-          controller.close();
-        },
-      });
-
-      const req = new Request("http://localhost/test");
+    it("returns null body for HEAD requests (buffered)", async () => {
+      const req = new Request("http://localhost/", { method: "HEAD" });
       const ctx = makeCtx();
-      const result = makeResult({ isStreaming: true, stream, html: undefined });
-      const builder = makeBuilder();
+      const result = makeResult({ html: "<p>Hello</p>" });
+      const builder = new ResponseBuilder();
 
       const response = await buildSSRResponse(req, ctx, result, builder);
       assertEquals(response.status, 200);
+      assertEquals(response.body, null);
     });
 
-    it("should return 304 for matching etag in production", async () => {
+    it("returns 304 for matching etag in production", async () => {
       const etag = '"abc123"';
-      const req = new Request("http://localhost/test", {
+      const req = new Request("http://localhost/", {
         headers: { "if-none-match": etag },
       });
       const ctx = makeCtx({ isLocalProject: false });
       const result = makeResult({ etag });
-      const builder = makeBuilder();
+      const builder = new ResponseBuilder();
 
       const response = await buildSSRResponse(req, ctx, result, builder);
       assertEquals(response.status, 304);
     });
 
-    it("should not return 304 for dev mode even with matching etag", async () => {
+    it("does NOT return 304 for matching etag in dev mode", async () => {
       const etag = '"abc123"';
-      const req = new Request("http://localhost/test", {
+      const req = new Request("http://localhost/", {
         headers: { "if-none-match": etag },
       });
       const ctx = makeCtx({ isLocalProject: true });
-      const result = makeResult({ etag, html: "<p>content</p>" });
-      const builder = makeBuilder();
+      const result = makeResult({ etag, html: "<p>Dev</p>" });
+      const builder = new ResponseBuilder();
 
       const response = await buildSSRResponse(req, ctx, result, builder);
       assertEquals(response.status, 200);
+    });
+
+    it("returns streaming response when isStreaming with stream", async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("<p>Streamed</p>"));
+          controller.close();
+        },
+      });
+      const req = new Request("http://localhost/");
+      const ctx = makeCtx();
+      const result = makeResult({ isStreaming: true, stream, html: undefined });
+      const builder = new ResponseBuilder();
+
+      const response = await buildSSRResponse(req, ctx, result, builder);
+      assertEquals(response.status, 200);
+      const body = await response.text();
+      assertEquals(body, "<p>Streamed</p>");
+    });
+
+    it("returns null body for HEAD request with streaming", async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("<p>Streamed</p>"));
+          controller.close();
+        },
+      });
+      const req = new Request("http://localhost/", { method: "HEAD" });
+      const ctx = makeCtx();
+      const result = makeResult({ isStreaming: true, stream, html: undefined });
+      const builder = new ResponseBuilder();
+
+      const response = await buildSSRResponse(req, ctx, result, builder);
+      assertEquals(response.status, 200);
+      assertEquals(response.body, null);
+    });
+
+    it("includes etag header when etag is provided (buffered)", async () => {
+      const req = new Request("http://localhost/");
+      const ctx = makeCtx();
+      const result = makeResult({ etag: '"test-etag"' });
+      const builder = new ResponseBuilder();
+
+      const response = await buildSSRResponse(req, ctx, result, builder);
+      assertEquals(response.headers.get("etag"), '"test-etag"');
+    });
+
+    it("falls back to error page when no html or stream", async () => {
+      const req = new Request("http://localhost/");
+      const ctx = makeCtx();
+      const result = makeResult({ html: undefined, stream: undefined });
+      const builder = new ResponseBuilder();
+
+      const response = await buildSSRResponse(req, ctx, result, builder);
+      assertEquals(response.status, 200);
+      const body = await response.text();
+      // ErrorPages.serverError() should produce some HTML
+      assertEquals(body.includes("<!DOCTYPE html>") || body.includes("<html"), true);
     });
   });
 });

--- a/src/server/handlers/request/ssr/ssr-response-builder.test.ts
+++ b/src/server/handlers/request/ssr/ssr-response-builder.test.ts
@@ -1,0 +1,137 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { buildSSRResponse } from "./ssr-response-builder.ts";
+import type { HandlerContext } from "../../types.ts";
+import type { SSRRenderResult } from "../../../services/rendering/ssr.service.ts";
+import type { ResponseBuilder } from "#veryfront/security/http/response/builder.ts";
+
+function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    isLocalProject: false,
+    securityConfig: undefined,
+    ...overrides,
+  } as unknown as HandlerContext;
+}
+
+function makeResult(overrides: Partial<SSRRenderResult> = {}): SSRRenderResult {
+  return {
+    status: 200,
+    html: "<html><body>Hello</body></html>",
+    isStreaming: false,
+    cacheStrategy: "no-cache",
+    slug: "test",
+    ...overrides,
+  };
+}
+
+function makeBuilder(): ResponseBuilder {
+  const self: ResponseBuilder = {
+    withCORS: () => self,
+    withSecurity: () => self,
+    withClientHints: () => self,
+    withCache: () => self,
+    withETag: () => self,
+    withContentType: (contentType: string, body: unknown, status: number) => {
+      return new Response(body as BodyInit, {
+        status,
+        headers: { "content-type": contentType },
+      });
+    },
+    notModified: (etag: string) => {
+      return new Response(null, {
+        status: 304,
+        headers: { etag },
+      });
+    },
+    html: (content: string, status: number) => {
+      return new Response(content, {
+        status,
+        headers: { "content-type": "text/html" },
+      });
+    },
+  } as unknown as ResponseBuilder;
+  return self;
+}
+
+describe("server/handlers/request/ssr/ssr-response-builder", () => {
+  describe("buildSSRResponse", () => {
+    it("should return buffered HTML response for non-streaming result", async () => {
+      const req = new Request("http://localhost/test");
+      const ctx = makeCtx();
+      const result = makeResult({ html: "<p>Hello</p>" });
+      const builder = makeBuilder();
+
+      const response = await buildSSRResponse(req, ctx, result, builder);
+      assertEquals(response.status, 200);
+      const body = await response.text();
+      assertEquals(body.includes("Hello"), true);
+    });
+
+    it("should return null body for HEAD requests on buffered content", async () => {
+      const req = new Request("http://localhost/test", { method: "HEAD" });
+      const ctx = makeCtx();
+      const result = makeResult({ html: "<p>Hello</p>" });
+      const builder = makeBuilder();
+
+      const response = await buildSSRResponse(req, ctx, result, builder);
+      assertEquals(response.status, 200);
+      const body = await response.text();
+      assertEquals(body, "");
+    });
+
+    it("should use result status code", async () => {
+      const req = new Request("http://localhost/test");
+      const ctx = makeCtx();
+      const result = makeResult({ status: 404, html: "Not Found" });
+      const builder = makeBuilder();
+
+      const response = await buildSSRResponse(req, ctx, result, builder);
+      assertEquals(response.status, 404);
+    });
+
+    it("should handle streaming responses", async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode("<html>"));
+          controller.enqueue(encoder.encode("</html>"));
+          controller.close();
+        },
+      });
+
+      const req = new Request("http://localhost/test");
+      const ctx = makeCtx();
+      const result = makeResult({ isStreaming: true, stream, html: undefined });
+      const builder = makeBuilder();
+
+      const response = await buildSSRResponse(req, ctx, result, builder);
+      assertEquals(response.status, 200);
+    });
+
+    it("should return 304 for matching etag in production", async () => {
+      const etag = '"abc123"';
+      const req = new Request("http://localhost/test", {
+        headers: { "if-none-match": etag },
+      });
+      const ctx = makeCtx({ isLocalProject: false });
+      const result = makeResult({ etag });
+      const builder = makeBuilder();
+
+      const response = await buildSSRResponse(req, ctx, result, builder);
+      assertEquals(response.status, 304);
+    });
+
+    it("should not return 304 for dev mode even with matching etag", async () => {
+      const etag = '"abc123"';
+      const req = new Request("http://localhost/test", {
+        headers: { "if-none-match": etag },
+      });
+      const ctx = makeCtx({ isLocalProject: true });
+      const result = makeResult({ etag, html: "<p>content</p>" });
+      const builder = makeBuilder();
+
+      const response = await buildSSRResponse(req, ctx, result, builder);
+      assertEquals(response.status, 200);
+    });
+  });
+});

--- a/src/server/handlers/request/ssr/ssr.handler.test.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.test.ts
@@ -1,0 +1,93 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { isProductionMode, SSRHandler } from "./ssr.handler.ts";
+import type { HandlerContext } from "../../types.ts";
+
+describe("server/handlers/request/ssr/ssr.handler", () => {
+  describe("SSRHandler metadata", () => {
+    it("should have correct handler name", () => {
+      const handler = new SSRHandler();
+      assertEquals(handler.metadata.name, "SSRHandler");
+    });
+
+    it("should have patterns defined", () => {
+      const handler = new SSRHandler();
+      assertExists(handler.metadata.patterns);
+      assertEquals(handler.metadata.patterns!.length > 0, true);
+    });
+
+    it("should accept GET and HEAD methods", () => {
+      const handler = new SSRHandler();
+      const patterns = handler.metadata.patterns;
+      assertExists(patterns);
+      const first = patterns[0];
+      assertEquals(typeof first !== "string", true);
+      if (typeof first !== "string") {
+        const method = (first as { method?: string | string[] }).method;
+        assertEquals(Array.isArray(method), true);
+        if (Array.isArray(method)) {
+          assertEquals(method.includes("GET"), true);
+          assertEquals(method.includes("HEAD"), true);
+        }
+      }
+    });
+  });
+
+  describe("isProductionMode", () => {
+    it("should return true when config has productionMode enabled", () => {
+      const ctx = {
+        config: { fs: { veryfront: { productionMode: true } } },
+      } as unknown as HandlerContext;
+      assertEquals(isProductionMode(ctx), true);
+    });
+
+    it("should return true when resolvedEnvironment is 'production'", () => {
+      const ctx = {
+        resolvedEnvironment: "production",
+      } as HandlerContext;
+      assertEquals(isProductionMode(ctx), true);
+    });
+
+    it("should return false when resolvedEnvironment is 'preview'", () => {
+      const ctx = {
+        resolvedEnvironment: "preview",
+      } as HandlerContext;
+      assertEquals(isProductionMode(ctx), false);
+    });
+
+    it("should fallback to requestContext.mode when no resolvedEnvironment", () => {
+      const ctx = {
+        requestContext: { token: "", slug: "", branch: null, mode: "production" as const },
+      } as HandlerContext;
+      assertEquals(isProductionMode(ctx), true);
+    });
+
+    it("should return false when requestContext.mode is preview", () => {
+      const ctx = {
+        requestContext: { token: "", slug: "", branch: null, mode: "preview" as const },
+      } as HandlerContext;
+      assertEquals(isProductionMode(ctx), false);
+    });
+
+    it("should return false when no environment info is available", () => {
+      const ctx = {} as HandlerContext;
+      assertEquals(isProductionMode(ctx), false);
+    });
+
+    it("should prefer config override over resolvedEnvironment", () => {
+      const ctx = {
+        config: { fs: { veryfront: { productionMode: true } } },
+        resolvedEnvironment: "preview",
+      } as unknown as HandlerContext;
+      assertEquals(isProductionMode(ctx), true);
+    });
+
+    it("should prefer resolvedEnvironment over requestContext.mode", () => {
+      const ctx = {
+        resolvedEnvironment: "production",
+        requestContext: { token: "", slug: "", branch: null, mode: "preview" as const },
+      } as HandlerContext;
+      assertEquals(isProductionMode(ctx), true);
+    });
+  });
+});

--- a/src/server/handlers/request/ssr/ssr.handler.test.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.test.ts
@@ -1,92 +1,160 @@
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { isProductionMode, SSRHandler } from "./ssr.handler.ts";
 import type { HandlerContext } from "../../types.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+
+function createMockAdapter(): RuntimeAdapter {
+  return {
+    id: "memory",
+    name: "mock",
+    capabilities: {
+      typescript: true,
+      jsx: true,
+      fileWatcher: false,
+      shell: false,
+      kvStore: false,
+      workers: false,
+    },
+    fs: {
+      exists: () => Promise.resolve(false),
+      readFile: () => Promise.resolve(""),
+      writeFile: () => Promise.resolve(),
+      readDir: () => Promise.resolve([]),
+      mkdir: () => Promise.resolve(),
+      remove: () => Promise.resolve(),
+      stat: () => Promise.resolve({ isFile: false, isDirectory: false, size: 0, mtime: null }),
+    },
+    env: {
+      get: () => undefined,
+      set: () => {},
+      delete: () => {},
+      toObject: () => ({}),
+    },
+    server: { createHandler: () => () => new Response() },
+    serve: () => Promise.resolve({ close: () => Promise.resolve() } as any),
+  } as unknown as RuntimeAdapter;
+}
+
+function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    projectDir: "/tmp/test-project",
+    adapter: createMockAdapter(),
+    securityConfig: null,
+    cspUserHeader: null,
+    ...overrides,
+  };
+}
 
 describe("server/handlers/request/ssr/ssr.handler", () => {
   describe("SSRHandler metadata", () => {
-    it("should have correct handler name", () => {
+    it("has correct name", () => {
       const handler = new SSRHandler();
       assertEquals(handler.metadata.name, "SSRHandler");
     });
 
-    it("should have patterns defined", () => {
+    it("has pattern for GET and HEAD methods", () => {
       const handler = new SSRHandler();
-      assertExists(handler.metadata.patterns);
-      assertEquals(handler.metadata.patterns!.length > 0, true);
+      const methods = handler.metadata.patterns?.[0]?.method;
+      assertEquals(Array.isArray(methods), true);
+      assertEquals((methods as string[]).includes("GET"), true);
+      assertEquals((methods as string[]).includes("HEAD"), true);
+    });
+  });
+
+  describe("handle - path filtering", () => {
+    it("continues for /_veryfront/ paths", async () => {
+      const handler = new SSRHandler();
+      const req = new Request("http://localhost/_veryfront/rsc/probe");
+      const ctx = makeCtx();
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, true);
     });
 
-    it("should accept GET and HEAD methods", () => {
+    it("continues for file extension paths", async () => {
       const handler = new SSRHandler();
-      const patterns = handler.metadata.patterns;
-      assertExists(patterns);
-      const first = patterns[0];
-      assertEquals(typeof first !== "string", true);
-      if (typeof first !== "string") {
-        const method = (first as { method?: string | string[] }).method;
-        assertEquals(Array.isArray(method), true);
-        if (Array.isArray(method)) {
-          assertEquals(method.includes("GET"), true);
-          assertEquals(method.includes("HEAD"), true);
-        }
-      }
+      const req = new Request("http://localhost/styles.css");
+      const ctx = makeCtx();
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, true);
+    });
+
+    it("continues for .js file paths", async () => {
+      const handler = new SSRHandler();
+      const req = new Request("http://localhost/app.js");
+      const ctx = makeCtx();
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, true);
+    });
+
+    it("continues for .json file paths", async () => {
+      const handler = new SSRHandler();
+      const req = new Request("http://localhost/data.json");
+      const ctx = makeCtx();
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, true);
+    });
+
+    it("continues for .ico file paths", async () => {
+      const handler = new SSRHandler();
+      const req = new Request("http://localhost/favicon.ico");
+      const ctx = makeCtx();
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, true);
+    });
+
+    it("continues for dot-segment paths in production", async () => {
+      const handler = new SSRHandler();
+      const req = new Request("http://localhost/.env");
+      const ctx = makeCtx({ resolvedEnvironment: "production" });
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, true);
+    });
+
+    it("continues for /_veryfront/ deeply nested paths", async () => {
+      const handler = new SSRHandler();
+      const req = new Request("http://localhost/_veryfront/modules/test");
+      const ctx = makeCtx();
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, true);
     });
   });
 
   describe("isProductionMode", () => {
-    it("should return true when config has productionMode enabled", () => {
-      const ctx = {
-        config: { fs: { veryfront: { productionMode: true } } },
-      } as unknown as HandlerContext;
+    it("returns true when config has productionMode = true", () => {
+      const ctx = makeCtx({
+        config: { fs: { veryfront: { productionMode: true } } } as any,
+      });
       assertEquals(isProductionMode(ctx), true);
     });
 
-    it("should return true when resolvedEnvironment is 'production'", () => {
-      const ctx = {
-        resolvedEnvironment: "production",
-      } as HandlerContext;
+    it("returns true when resolvedEnvironment is production", () => {
+      const ctx = makeCtx({ resolvedEnvironment: "production" });
       assertEquals(isProductionMode(ctx), true);
     });
 
-    it("should return false when resolvedEnvironment is 'preview'", () => {
-      const ctx = {
+    it("returns false when resolvedEnvironment is preview", () => {
+      const ctx = makeCtx({ resolvedEnvironment: "preview" });
+      assertEquals(isProductionMode(ctx), false);
+    });
+
+    it("falls back to requestContext.mode when resolvedEnvironment is not set", () => {
+      const ctx = makeCtx({
+        requestContext: { mode: "production" } as any,
+      });
+      assertEquals(isProductionMode(ctx), true);
+    });
+
+    it("returns false when neither resolvedEnvironment nor mode is set", () => {
+      const ctx = makeCtx();
+      assertEquals(isProductionMode(ctx), false);
+    });
+
+    it("config productionMode overrides resolvedEnvironment", () => {
+      const ctx = makeCtx({
+        config: { fs: { veryfront: { productionMode: true } } } as any,
         resolvedEnvironment: "preview",
-      } as HandlerContext;
-      assertEquals(isProductionMode(ctx), false);
-    });
-
-    it("should fallback to requestContext.mode when no resolvedEnvironment", () => {
-      const ctx = {
-        requestContext: { token: "", slug: "", branch: null, mode: "production" as const },
-      } as HandlerContext;
-      assertEquals(isProductionMode(ctx), true);
-    });
-
-    it("should return false when requestContext.mode is preview", () => {
-      const ctx = {
-        requestContext: { token: "", slug: "", branch: null, mode: "preview" as const },
-      } as HandlerContext;
-      assertEquals(isProductionMode(ctx), false);
-    });
-
-    it("should return false when no environment info is available", () => {
-      const ctx = {} as HandlerContext;
-      assertEquals(isProductionMode(ctx), false);
-    });
-
-    it("should prefer config override over resolvedEnvironment", () => {
-      const ctx = {
-        config: { fs: { veryfront: { productionMode: true } } },
-        resolvedEnvironment: "preview",
-      } as unknown as HandlerContext;
-      assertEquals(isProductionMode(ctx), true);
-    });
-
-    it("should prefer resolvedEnvironment over requestContext.mode", () => {
-      const ctx = {
-        resolvedEnvironment: "production",
-        requestContext: { token: "", slug: "", branch: null, mode: "preview" as const },
-      } as HandlerContext;
+      });
       assertEquals(isProductionMode(ctx), true);
     });
   });

--- a/src/server/handlers/response/cors.test.ts
+++ b/src/server/handlers/response/cors.test.ts
@@ -1,43 +1,119 @@
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { CorsHandler } from "./cors.ts";
+import type { HandlerContext } from "../types.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+
+function createMockAdapter(): RuntimeAdapter {
+  return {
+    id: "memory",
+    name: "mock",
+    capabilities: {
+      typescript: true,
+      jsx: true,
+      fileWatcher: false,
+      shell: false,
+      kvStore: false,
+      workers: false,
+    },
+    fs: {
+      exists: () => Promise.resolve(false),
+      readFile: () => Promise.resolve(""),
+      writeFile: () => Promise.resolve(),
+      readDir: () => Promise.resolve([]),
+      mkdir: () => Promise.resolve(),
+      remove: () => Promise.resolve(),
+      stat: () => Promise.resolve({ isFile: false, isDirectory: false, size: 0, mtime: null }),
+    },
+    env: {
+      get: () => undefined,
+      set: () => {},
+      delete: () => {},
+      toObject: () => ({}),
+    },
+    server: { createHandler: () => () => new Response() },
+    serve: () => Promise.resolve({ close: () => Promise.resolve() } as any),
+  } as unknown as RuntimeAdapter;
+}
+
+function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    projectDir: "/tmp/test-project",
+    adapter: createMockAdapter(),
+    securityConfig: null,
+    cspUserHeader: null,
+    ...overrides,
+  };
+}
 
 describe("server/handlers/response/cors", () => {
-  describe("CorsHandler metadata", () => {
-    it("should have correct handler name", () => {
+  describe("CorsHandler", () => {
+    it("has correct metadata", () => {
       const handler = new CorsHandler();
       assertEquals(handler.metadata.name, "CorsHandler");
+      assertEquals(handler.metadata.patterns?.length, 1);
+      assertEquals(handler.metadata.patterns?.[0].method, "OPTIONS");
     });
 
-    it("should have a pattern defined", () => {
+    it("continues for non-OPTIONS requests", async () => {
       const handler = new CorsHandler();
-      assertExists(handler.metadata.patterns);
-      assertEquals(handler.metadata.patterns!.length, 1);
+      const req = new Request("http://localhost/api/test", { method: "GET" });
+      const ctx = makeCtx();
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
     });
 
-    it("should match OPTIONS method only", () => {
+    it("continues for POST requests", async () => {
       const handler = new CorsHandler();
-      const patterns = handler.metadata.patterns;
-      assertExists(patterns);
-      const pattern = patterns[0];
-      assertEquals(typeof pattern !== "string", true);
-      if (typeof pattern !== "string") {
-        assertEquals((pattern as { method?: string }).method, "OPTIONS");
-      }
+      const req = new Request("http://localhost/api/test", { method: "POST" });
+      const ctx = makeCtx();
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, true);
     });
 
-    it("should match all paths (catch-all pattern)", () => {
+    it("responds to OPTIONS requests", async () => {
       const handler = new CorsHandler();
-      const patterns = handler.metadata.patterns;
-      assertExists(patterns);
-      const pattern = patterns[0];
-      if (typeof pattern !== "string") {
-        const p = (pattern as { pattern: RegExp }).pattern;
-        assertEquals(p instanceof RegExp, true);
-        assertEquals(p.test("/any/path"), true);
-        assertEquals(p.test("/"), true);
-        assertEquals(p.test("/api/users"), true);
-      }
+      const req = new Request("http://localhost/api/test", {
+        method: "OPTIONS",
+        headers: {
+          origin: "http://localhost:3000",
+          "access-control-request-method": "POST",
+          "access-control-request-headers": "Content-Type",
+        },
+      });
+      const ctx = makeCtx();
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.response instanceof Response, true);
+    });
+
+    it("responds to OPTIONS with access-control headers", async () => {
+      const handler = new CorsHandler();
+      const req = new Request("http://localhost/api/test", {
+        method: "OPTIONS",
+        headers: {
+          origin: "http://localhost:3000",
+          "access-control-request-method": "POST",
+          "access-control-request-headers": "Authorization,Content-Type",
+        },
+      });
+      const ctx = makeCtx();
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.response instanceof Response, true);
+      // Should have allow-methods header
+      const methods = result.response?.headers.get("access-control-allow-methods") ?? "";
+      assertEquals(methods.length > 0, true);
+    });
+
+    it("handles OPTIONS with lowercase method check", async () => {
+      const handler = new CorsHandler();
+      // OPTIONS method should be matched case-insensitively
+      const req = new Request("http://localhost/api/test", {
+        method: "OPTIONS",
+      });
+      const ctx = makeCtx();
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.response instanceof Response, true);
     });
   });
 });

--- a/src/server/handlers/response/cors.test.ts
+++ b/src/server/handlers/response/cors.test.ts
@@ -1,0 +1,43 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { CorsHandler } from "./cors.ts";
+
+describe("server/handlers/response/cors", () => {
+  describe("CorsHandler metadata", () => {
+    it("should have correct handler name", () => {
+      const handler = new CorsHandler();
+      assertEquals(handler.metadata.name, "CorsHandler");
+    });
+
+    it("should have a pattern defined", () => {
+      const handler = new CorsHandler();
+      assertExists(handler.metadata.patterns);
+      assertEquals(handler.metadata.patterns!.length, 1);
+    });
+
+    it("should match OPTIONS method only", () => {
+      const handler = new CorsHandler();
+      const patterns = handler.metadata.patterns;
+      assertExists(patterns);
+      const pattern = patterns[0];
+      assertEquals(typeof pattern !== "string", true);
+      if (typeof pattern !== "string") {
+        assertEquals((pattern as { method?: string }).method, "OPTIONS");
+      }
+    });
+
+    it("should match all paths (catch-all pattern)", () => {
+      const handler = new CorsHandler();
+      const patterns = handler.metadata.patterns;
+      assertExists(patterns);
+      const pattern = patterns[0];
+      if (typeof pattern !== "string") {
+        const p = (pattern as { pattern: RegExp }).pattern;
+        assertEquals(p instanceof RegExp, true);
+        assertEquals(p.test("/any/path"), true);
+        assertEquals(p.test("/"), true);
+        assertEquals(p.test("/api/users"), true);
+      }
+    });
+  });
+});

--- a/src/server/runtime-handler/project-resolution.test.ts
+++ b/src/server/runtime-handler/project-resolution.test.ts
@@ -1,11 +1,13 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it, afterEach } from "#veryfront/testing/bdd.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  __injectDepsForTests,
   extractRequestHeaders,
   resolveProject,
-  __injectDepsForTests,
 } from "./project-resolution.ts";
-import type { ParsedDomain } from "../utils/domain-parser.ts";
+import type { DomainLookupResult } from "../utils/domain-lookup.ts";
+import type { ParsedDomain } from "#veryfront/types";
+import type { VeryfrontConfig } from "#veryfront/config";
 
 const defaultParsedDomain: ParsedDomain = {
   slug: null,
@@ -16,45 +18,89 @@ const defaultParsedDomain: ParsedDomain = {
   allowIframeEmbed: false,
 };
 
-afterEach(() => {
-  __injectDepsForTests(null);
-});
-
 describe("server/runtime-handler/project-resolution", () => {
   describe("extractRequestHeaders", () => {
-    it("should extract all project headers", () => {
-      const req = new Request("http://localhost/test", {
-        headers: {
-          "x-project-slug": "my-project",
-          "x-project-id": "proj-123",
-          "x-release-id": "rel-456",
-          "x-branch-id": "br-789",
-          "x-branch-name": "main",
-          "x-environment": "preview",
-          "x-environment-id": "env-001",
-          "x-content-source-id": "cs-001",
-          "x-project-path": "/custom/path",
-        },
+    it("extracts project slug from header", () => {
+      const req = new Request("http://localhost/", {
+        headers: { "x-project-slug": "my-project" },
       });
-      const url = new URL(req.url);
-      const headers = extractRequestHeaders(req, url);
-
+      const headers = extractRequestHeaders(req, new URL(req.url));
       assertEquals(headers.projectSlug, "my-project");
-      assertEquals(headers.projectId, "proj-123");
-      assertEquals(headers.releaseId, "rel-456");
-      assertEquals(headers.branchId, "br-789");
-      assertEquals(headers.branchName, "main");
-      assertEquals(headers.environment, "preview");
-      assertEquals(headers.environmentId, "env-001");
-      assertEquals(headers.contentSourceId, "cs-001");
-      assertEquals(headers.projectPath, "/custom/path");
     });
 
-    it("should return undefined for missing headers", () => {
-      const req = new Request("http://localhost/test");
-      const url = new URL(req.url);
-      const headers = extractRequestHeaders(req, url);
+    it("extracts project id from header", () => {
+      const req = new Request("http://localhost/", {
+        headers: { "x-project-id": "proj-123" },
+      });
+      const headers = extractRequestHeaders(req, new URL(req.url));
+      assertEquals(headers.projectId, "proj-123");
+    });
 
+    it("extracts release id from header", () => {
+      const req = new Request("http://localhost/", {
+        headers: { "x-release-id": "rel-456" },
+      });
+      const headers = extractRequestHeaders(req, new URL(req.url));
+      assertEquals(headers.releaseId, "rel-456");
+    });
+
+    it("extracts branch id from header", () => {
+      const req = new Request("http://localhost/", {
+        headers: { "x-branch-id": "branch-1" },
+      });
+      const headers = extractRequestHeaders(req, new URL(req.url));
+      assertEquals(headers.branchId, "branch-1");
+    });
+
+    it("extracts branch name from header", () => {
+      const req = new Request("http://localhost/", {
+        headers: { "x-branch-name": "feature-x" },
+      });
+      const headers = extractRequestHeaders(req, new URL(req.url));
+      assertEquals(headers.branchName, "feature-x");
+    });
+
+    it("extracts environment from header", () => {
+      const req = new Request("http://localhost/", {
+        headers: { "x-environment": "production" },
+      });
+      const headers = extractRequestHeaders(req, new URL(req.url));
+      assertEquals(headers.environment, "production");
+    });
+
+    it("extracts environment from query parameter when header not present", () => {
+      const req = new Request("http://localhost/?x-environment=staging");
+      const headers = extractRequestHeaders(req, new URL(req.url));
+      assertEquals(headers.environment, "staging");
+    });
+
+    it("extracts environment-id from header", () => {
+      const req = new Request("http://localhost/", {
+        headers: { "x-environment-id": "env-1" },
+      });
+      const headers = extractRequestHeaders(req, new URL(req.url));
+      assertEquals(headers.environmentId, "env-1");
+    });
+
+    it("extracts content-source-id from header", () => {
+      const req = new Request("http://localhost/", {
+        headers: { "x-content-source-id": "cs-1" },
+      });
+      const headers = extractRequestHeaders(req, new URL(req.url));
+      assertEquals(headers.contentSourceId, "cs-1");
+    });
+
+    it("extracts project-path from header", () => {
+      const req = new Request("http://localhost/", {
+        headers: { "x-project-path": "/projects/my-proj" },
+      });
+      const headers = extractRequestHeaders(req, new URL(req.url));
+      assertEquals(headers.projectPath, "/projects/my-proj");
+    });
+
+    it("returns undefined for missing headers", () => {
+      const req = new Request("http://localhost/");
+      const headers = extractRequestHeaders(req, new URL(req.url));
       assertEquals(headers.projectSlug, undefined);
       assertEquals(headers.projectId, undefined);
       assertEquals(headers.releaseId, undefined);
@@ -62,77 +108,68 @@ describe("server/runtime-handler/project-resolution", () => {
       assertEquals(headers.branchName, undefined);
       assertEquals(headers.environment, undefined);
       assertEquals(headers.environmentId, undefined);
+      assertEquals(headers.token, undefined);
       assertEquals(headers.contentSourceId, undefined);
       assertEquals(headers.projectPath, undefined);
-    });
-
-    it("should fallback to x-environment query param", () => {
-      const req = new Request("http://localhost/test?x-environment=staging");
-      const url = new URL(req.url);
-      const headers = extractRequestHeaders(req, url);
-      assertEquals(headers.environment, "staging");
-    });
-
-    it("should prefer header over query param for x-environment", () => {
-      const req = new Request("http://localhost/test?x-environment=staging", {
-        headers: { "x-environment": "preview" },
-      });
-      const url = new URL(req.url);
-      const headers = extractRequestHeaders(req, url);
-      assertEquals(headers.environment, "preview");
-    });
-
-    it("should always set token to undefined", () => {
-      const req = new Request("http://localhost/test", {
-        headers: { authorization: "Bearer token123" },
-      });
-      const url = new URL(req.url);
-      const headers = extractRequestHeaders(req, url);
-      assertEquals(headers.token, undefined);
     });
   });
 
   describe("resolveProject", () => {
-    it("should resolve from request context slug", async () => {
+    it("uses reqCtx.slug as projectSlug when available", async () => {
       __injectDepsForTests({
         parseProjectDomain: () => defaultParsedDomain,
-        lookupProjectByDomain: async () => null,
+        lookupProjectByDomain: () => Promise.resolve(null),
         getEnvironmentType: () => undefined,
       });
 
-      const req = new Request("http://localhost/test", {
-        headers: { host: "localhost" },
-      });
+      const req = new Request("http://localhost/");
       const url = new URL(req.url);
       const headers = extractRequestHeaders(req, url);
-
       const result = await resolveProject(req, url, headers, {
         config: undefined,
-        reqCtx: { slug: "ctx-slug", mode: "production", branch: null, token: "" },
+        reqCtx: { slug: "from-ctx", mode: undefined, branch: null, token: undefined },
         defaultProjectSlug: undefined,
         defaultProjectId: undefined,
         wsSlugOverride: undefined,
       });
 
-      assertEquals(result.projectSlug, "ctx-slug");
+      assertEquals(result.projectSlug, "from-ctx");
     });
 
-    it("should fall back to default slug when no context slug", async () => {
+    it("uses wsSlugOverride when reqCtx.slug is empty", async () => {
       __injectDepsForTests({
         parseProjectDomain: () => defaultParsedDomain,
-        lookupProjectByDomain: async () => null,
+        lookupProjectByDomain: () => Promise.resolve(null),
         getEnvironmentType: () => undefined,
       });
 
-      const req = new Request("http://localhost/test", {
-        headers: { host: "localhost" },
-      });
+      const req = new Request("http://localhost/");
       const url = new URL(req.url);
       const headers = extractRequestHeaders(req, url);
-
       const result = await resolveProject(req, url, headers, {
         config: undefined,
-        reqCtx: { slug: "", mode: "production", branch: null, token: "" },
+        reqCtx: { slug: undefined, mode: undefined, branch: null, token: undefined },
+        defaultProjectSlug: undefined,
+        defaultProjectId: undefined,
+        wsSlugOverride: "ws-slug",
+      });
+
+      assertEquals(result.projectSlug, "ws-slug");
+    });
+
+    it("uses defaultProjectSlug when no other slug source", async () => {
+      __injectDepsForTests({
+        parseProjectDomain: () => defaultParsedDomain,
+        lookupProjectByDomain: () => Promise.resolve(null),
+        getEnvironmentType: () => undefined,
+      });
+
+      const req = new Request("http://localhost/");
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+      const result = await resolveProject(req, url, headers, {
+        config: undefined,
+        reqCtx: { slug: undefined, mode: undefined, branch: null, token: undefined },
         defaultProjectSlug: "default-slug",
         defaultProjectId: "default-id",
         wsSlugOverride: undefined,
@@ -142,159 +179,141 @@ describe("server/runtime-handler/project-resolution", () => {
       assertEquals(result.projectId, "default-id");
     });
 
-    it("should prefer ws slug override over default", async () => {
+    it("uses configured slug from config", async () => {
       __injectDepsForTests({
         parseProjectDomain: () => defaultParsedDomain,
-        lookupProjectByDomain: async () => null,
+        lookupProjectByDomain: () => Promise.resolve(null),
         getEnvironmentType: () => undefined,
       });
 
-      const req = new Request("http://localhost/test", {
-        headers: { host: "localhost" },
-      });
+      const config = {
+        fs: { veryfront: { projectSlug: "config-slug" } },
+      } as unknown as VeryfrontConfig;
+
+      const req = new Request("http://localhost/");
       const url = new URL(req.url);
       const headers = extractRequestHeaders(req, url);
-
       const result = await resolveProject(req, url, headers, {
-        config: undefined,
-        reqCtx: { slug: "", mode: "production", branch: null, token: "" },
-        defaultProjectSlug: "default-slug",
-        defaultProjectId: undefined,
-        wsSlugOverride: "ws-slug",
-      });
-
-      assertEquals(result.projectSlug, "ws-slug");
-    });
-
-    it("should use header projectId", async () => {
-      __injectDepsForTests({
-        parseProjectDomain: () => defaultParsedDomain,
-        lookupProjectByDomain: async () => null,
-        getEnvironmentType: () => undefined,
-      });
-
-      const req = new Request("http://localhost/test", {
-        headers: { host: "localhost", "x-project-id": "proj-abc" },
-      });
-      const url = new URL(req.url);
-      const headers = extractRequestHeaders(req, url);
-
-      const result = await resolveProject(req, url, headers, {
-        config: undefined,
-        reqCtx: { slug: "slug", mode: "production", branch: null, token: "" },
+        config,
+        reqCtx: { slug: undefined, mode: undefined, branch: null, token: undefined },
         defaultProjectSlug: undefined,
         defaultProjectId: undefined,
         wsSlugOverride: undefined,
       });
 
-      assertEquals(result.projectId, "proj-abc");
+      assertEquals(result.projectSlug, "config-slug");
     });
 
-    it("should use header releaseId", async () => {
+    it("extracts releaseId from headers", async () => {
       __injectDepsForTests({
         parseProjectDomain: () => defaultParsedDomain,
-        lookupProjectByDomain: async () => null,
+        lookupProjectByDomain: () => Promise.resolve(null),
         getEnvironmentType: () => undefined,
       });
 
-      const req = new Request("http://localhost/test", {
-        headers: { host: "localhost", "x-release-id": "rel-xyz" },
+      const req = new Request("http://localhost/", {
+        headers: { "x-release-id": "rel-1" },
       });
       const url = new URL(req.url);
       const headers = extractRequestHeaders(req, url);
-
       const result = await resolveProject(req, url, headers, {
         config: undefined,
-        reqCtx: { slug: "slug", mode: "production", branch: null, token: "" },
+        reqCtx: { slug: "test", mode: undefined, branch: null, token: undefined },
         defaultProjectSlug: undefined,
         defaultProjectId: undefined,
         wsSlugOverride: undefined,
       });
 
-      assertEquals(result.releaseId, "rel-xyz");
+      assertEquals(result.releaseId, "rel-1");
     });
 
-    it("should parse proxy environment from x-environment header", async () => {
-      __injectDepsForTests({
-        parseProjectDomain: () => defaultParsedDomain,
-        lookupProjectByDomain: async () => null,
-        getEnvironmentType: () => undefined,
-      });
-
-      const req = new Request("http://localhost/test", {
-        headers: { host: "localhost", "x-environment": "preview" },
-      });
-      const url = new URL(req.url);
-      const headers = extractRequestHeaders(req, url);
-
-      const result = await resolveProject(req, url, headers, {
-        config: undefined,
-        reqCtx: { slug: "slug", mode: "production", branch: null, token: "" },
-        defaultProjectSlug: undefined,
-        defaultProjectId: undefined,
-        wsSlugOverride: undefined,
-      });
-
-      assertEquals(result.proxyEnv, "preview");
-    });
-
-    it("should return parsedDomain in result", async () => {
-      const customDomain: ParsedDomain = {
-        ...defaultParsedDomain,
-        slug: "parsed",
-        isVeryfrontDomain: true,
+    it("performs custom domain lookup when conditions are met", async () => {
+      const lookupResult: DomainLookupResult = {
+        project_id: "proj-1",
+        project_slug: "looked-up-slug",
+        project_name: "Looked Up",
+        environment: { id: "env-1", name: "Production" },
+        release_id: "rel-99",
       };
 
       __injectDepsForTests({
-        parseProjectDomain: () => customDomain,
-        lookupProjectByDomain: async () => null,
-        getEnvironmentType: () => undefined,
+        parseProjectDomain: () => defaultParsedDomain,
+        lookupProjectByDomain: () => Promise.resolve(lookupResult),
+        getEnvironmentType: () => "production" as const,
       });
 
-      const req = new Request("http://parsed.veryfront.com/test", {
-        headers: { host: "parsed.veryfront.com" },
-      });
+      const config = {
+        fs: { veryfront: { apiToken: "test-token", apiBaseUrl: "https://api.test.com" } },
+      } as unknown as VeryfrontConfig;
+
+      const req = new Request("http://custom-domain.example.com/");
       const url = new URL(req.url);
       const headers = extractRequestHeaders(req, url);
-
       const result = await resolveProject(req, url, headers, {
-        config: undefined,
-        reqCtx: { slug: "parsed", mode: "production", branch: null, token: "" },
+        config,
+        reqCtx: { slug: undefined, mode: undefined, branch: null, token: undefined },
         defaultProjectSlug: undefined,
         defaultProjectId: undefined,
         wsSlugOverride: undefined,
       });
 
-      assertEquals(result.parsedDomain, customDomain);
+      assertEquals(result.projectSlug, "looked-up-slug");
+      assertEquals(result.projectId, "proj-1");
+      assertEquals(result.releaseId, "rel-99");
+      assertEquals(result.proxyEnv, "production");
     });
 
-    it("should skip domain lookup for internal hosts", async () => {
-      let lookupCalled = false;
-
+    it("uses x-forwarded-host for domain resolution", async () => {
+      let capturedHost = "";
       __injectDepsForTests({
-        parseProjectDomain: () => defaultParsedDomain,
-        lookupProjectByDomain: async () => {
-          lookupCalled = true;
-          return null;
+        parseProjectDomain: (host: string) => {
+          capturedHost = host;
+          return defaultParsedDomain;
         },
+        lookupProjectByDomain: () => Promise.resolve(null),
         getEnvironmentType: () => undefined,
       });
 
-      const req = new Request("http://127.0.0.1/test", {
-        headers: { host: "127.0.0.1" },
+      const req = new Request("http://localhost/", {
+        headers: { "x-forwarded-host": "forwarded.example.com" },
       });
       const url = new URL(req.url);
       const headers = extractRequestHeaders(req, url);
-
       await resolveProject(req, url, headers, {
-        config: { fs: { veryfront: { apiToken: "token" } } } as any,
-        reqCtx: { slug: "", mode: "production", branch: null, token: "" },
+        config: undefined,
+        reqCtx: { slug: "s", mode: undefined, branch: null, token: undefined },
         defaultProjectSlug: undefined,
         defaultProjectId: undefined,
         wsSlugOverride: undefined,
       });
 
-      assertEquals(lookupCalled, false);
+      assertEquals(capturedHost, "forwarded.example.com");
+    });
+
+    it("returns parsedDomain in result", async () => {
+      __injectDepsForTests({
+        parseProjectDomain: () => ({
+          ...defaultParsedDomain,
+          slug: "my-project",
+          isVeryfrontDomain: true,
+        }),
+        lookupProjectByDomain: () => Promise.resolve(null),
+        getEnvironmentType: () => undefined,
+      });
+
+      const req = new Request("http://my-project.preview.veryfront.dev/");
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+      const result = await resolveProject(req, url, headers, {
+        config: undefined,
+        reqCtx: { slug: "my-project", mode: undefined, branch: null, token: undefined },
+        defaultProjectSlug: undefined,
+        defaultProjectId: undefined,
+        wsSlugOverride: undefined,
+      });
+
+      assertEquals(result.parsedDomain.isVeryfrontDomain, true);
+      assertEquals(result.parsedDomain.slug, "my-project");
     });
   });
 });

--- a/src/server/runtime-handler/project-resolution.test.ts
+++ b/src/server/runtime-handler/project-resolution.test.ts
@@ -1,0 +1,300 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it, afterEach } from "#veryfront/testing/bdd.ts";
+import {
+  extractRequestHeaders,
+  resolveProject,
+  __injectDepsForTests,
+} from "./project-resolution.ts";
+import type { ParsedDomain } from "../utils/domain-parser.ts";
+
+const defaultParsedDomain: ParsedDomain = {
+  slug: null,
+  branch: null,
+  environment: null,
+  isVeryfrontDomain: false,
+  isDraft: false,
+  allowIframeEmbed: false,
+};
+
+afterEach(() => {
+  __injectDepsForTests(null);
+});
+
+describe("server/runtime-handler/project-resolution", () => {
+  describe("extractRequestHeaders", () => {
+    it("should extract all project headers", () => {
+      const req = new Request("http://localhost/test", {
+        headers: {
+          "x-project-slug": "my-project",
+          "x-project-id": "proj-123",
+          "x-release-id": "rel-456",
+          "x-branch-id": "br-789",
+          "x-branch-name": "main",
+          "x-environment": "preview",
+          "x-environment-id": "env-001",
+          "x-content-source-id": "cs-001",
+          "x-project-path": "/custom/path",
+        },
+      });
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+
+      assertEquals(headers.projectSlug, "my-project");
+      assertEquals(headers.projectId, "proj-123");
+      assertEquals(headers.releaseId, "rel-456");
+      assertEquals(headers.branchId, "br-789");
+      assertEquals(headers.branchName, "main");
+      assertEquals(headers.environment, "preview");
+      assertEquals(headers.environmentId, "env-001");
+      assertEquals(headers.contentSourceId, "cs-001");
+      assertEquals(headers.projectPath, "/custom/path");
+    });
+
+    it("should return undefined for missing headers", () => {
+      const req = new Request("http://localhost/test");
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+
+      assertEquals(headers.projectSlug, undefined);
+      assertEquals(headers.projectId, undefined);
+      assertEquals(headers.releaseId, undefined);
+      assertEquals(headers.branchId, undefined);
+      assertEquals(headers.branchName, undefined);
+      assertEquals(headers.environment, undefined);
+      assertEquals(headers.environmentId, undefined);
+      assertEquals(headers.contentSourceId, undefined);
+      assertEquals(headers.projectPath, undefined);
+    });
+
+    it("should fallback to x-environment query param", () => {
+      const req = new Request("http://localhost/test?x-environment=staging");
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+      assertEquals(headers.environment, "staging");
+    });
+
+    it("should prefer header over query param for x-environment", () => {
+      const req = new Request("http://localhost/test?x-environment=staging", {
+        headers: { "x-environment": "preview" },
+      });
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+      assertEquals(headers.environment, "preview");
+    });
+
+    it("should always set token to undefined", () => {
+      const req = new Request("http://localhost/test", {
+        headers: { authorization: "Bearer token123" },
+      });
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+      assertEquals(headers.token, undefined);
+    });
+  });
+
+  describe("resolveProject", () => {
+    it("should resolve from request context slug", async () => {
+      __injectDepsForTests({
+        parseProjectDomain: () => defaultParsedDomain,
+        lookupProjectByDomain: async () => null,
+        getEnvironmentType: () => undefined,
+      });
+
+      const req = new Request("http://localhost/test", {
+        headers: { host: "localhost" },
+      });
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+
+      const result = await resolveProject(req, url, headers, {
+        config: undefined,
+        reqCtx: { slug: "ctx-slug", mode: "production", branch: null, token: "" },
+        defaultProjectSlug: undefined,
+        defaultProjectId: undefined,
+        wsSlugOverride: undefined,
+      });
+
+      assertEquals(result.projectSlug, "ctx-slug");
+    });
+
+    it("should fall back to default slug when no context slug", async () => {
+      __injectDepsForTests({
+        parseProjectDomain: () => defaultParsedDomain,
+        lookupProjectByDomain: async () => null,
+        getEnvironmentType: () => undefined,
+      });
+
+      const req = new Request("http://localhost/test", {
+        headers: { host: "localhost" },
+      });
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+
+      const result = await resolveProject(req, url, headers, {
+        config: undefined,
+        reqCtx: { slug: "", mode: "production", branch: null, token: "" },
+        defaultProjectSlug: "default-slug",
+        defaultProjectId: "default-id",
+        wsSlugOverride: undefined,
+      });
+
+      assertEquals(result.projectSlug, "default-slug");
+      assertEquals(result.projectId, "default-id");
+    });
+
+    it("should prefer ws slug override over default", async () => {
+      __injectDepsForTests({
+        parseProjectDomain: () => defaultParsedDomain,
+        lookupProjectByDomain: async () => null,
+        getEnvironmentType: () => undefined,
+      });
+
+      const req = new Request("http://localhost/test", {
+        headers: { host: "localhost" },
+      });
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+
+      const result = await resolveProject(req, url, headers, {
+        config: undefined,
+        reqCtx: { slug: "", mode: "production", branch: null, token: "" },
+        defaultProjectSlug: "default-slug",
+        defaultProjectId: undefined,
+        wsSlugOverride: "ws-slug",
+      });
+
+      assertEquals(result.projectSlug, "ws-slug");
+    });
+
+    it("should use header projectId", async () => {
+      __injectDepsForTests({
+        parseProjectDomain: () => defaultParsedDomain,
+        lookupProjectByDomain: async () => null,
+        getEnvironmentType: () => undefined,
+      });
+
+      const req = new Request("http://localhost/test", {
+        headers: { host: "localhost", "x-project-id": "proj-abc" },
+      });
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+
+      const result = await resolveProject(req, url, headers, {
+        config: undefined,
+        reqCtx: { slug: "slug", mode: "production", branch: null, token: "" },
+        defaultProjectSlug: undefined,
+        defaultProjectId: undefined,
+        wsSlugOverride: undefined,
+      });
+
+      assertEquals(result.projectId, "proj-abc");
+    });
+
+    it("should use header releaseId", async () => {
+      __injectDepsForTests({
+        parseProjectDomain: () => defaultParsedDomain,
+        lookupProjectByDomain: async () => null,
+        getEnvironmentType: () => undefined,
+      });
+
+      const req = new Request("http://localhost/test", {
+        headers: { host: "localhost", "x-release-id": "rel-xyz" },
+      });
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+
+      const result = await resolveProject(req, url, headers, {
+        config: undefined,
+        reqCtx: { slug: "slug", mode: "production", branch: null, token: "" },
+        defaultProjectSlug: undefined,
+        defaultProjectId: undefined,
+        wsSlugOverride: undefined,
+      });
+
+      assertEquals(result.releaseId, "rel-xyz");
+    });
+
+    it("should parse proxy environment from x-environment header", async () => {
+      __injectDepsForTests({
+        parseProjectDomain: () => defaultParsedDomain,
+        lookupProjectByDomain: async () => null,
+        getEnvironmentType: () => undefined,
+      });
+
+      const req = new Request("http://localhost/test", {
+        headers: { host: "localhost", "x-environment": "preview" },
+      });
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+
+      const result = await resolveProject(req, url, headers, {
+        config: undefined,
+        reqCtx: { slug: "slug", mode: "production", branch: null, token: "" },
+        defaultProjectSlug: undefined,
+        defaultProjectId: undefined,
+        wsSlugOverride: undefined,
+      });
+
+      assertEquals(result.proxyEnv, "preview");
+    });
+
+    it("should return parsedDomain in result", async () => {
+      const customDomain: ParsedDomain = {
+        ...defaultParsedDomain,
+        slug: "parsed",
+        isVeryfrontDomain: true,
+      };
+
+      __injectDepsForTests({
+        parseProjectDomain: () => customDomain,
+        lookupProjectByDomain: async () => null,
+        getEnvironmentType: () => undefined,
+      });
+
+      const req = new Request("http://parsed.veryfront.com/test", {
+        headers: { host: "parsed.veryfront.com" },
+      });
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+
+      const result = await resolveProject(req, url, headers, {
+        config: undefined,
+        reqCtx: { slug: "parsed", mode: "production", branch: null, token: "" },
+        defaultProjectSlug: undefined,
+        defaultProjectId: undefined,
+        wsSlugOverride: undefined,
+      });
+
+      assertEquals(result.parsedDomain, customDomain);
+    });
+
+    it("should skip domain lookup for internal hosts", async () => {
+      let lookupCalled = false;
+
+      __injectDepsForTests({
+        parseProjectDomain: () => defaultParsedDomain,
+        lookupProjectByDomain: async () => {
+          lookupCalled = true;
+          return null;
+        },
+        getEnvironmentType: () => undefined,
+      });
+
+      const req = new Request("http://127.0.0.1/test", {
+        headers: { host: "127.0.0.1" },
+      });
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+
+      await resolveProject(req, url, headers, {
+        config: { fs: { veryfront: { apiToken: "token" } } } as any,
+        reqCtx: { slug: "", mode: "production", branch: null, token: "" },
+        defaultProjectSlug: undefined,
+        defaultProjectId: undefined,
+        wsSlugOverride: undefined,
+      });
+
+      assertEquals(lookupCalled, false);
+    });
+  });
+});

--- a/src/server/runtime-handler/request-lifecycle.test.ts
+++ b/src/server/runtime-handler/request-lifecycle.test.ts
@@ -1,0 +1,89 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  startRequestLifecycle,
+  endRequestLifecycle,
+  startRequestTracking,
+  completeRequestTracking,
+  startContentMetrics,
+  endContentMetrics,
+} from "./request-lifecycle.ts";
+import { requestTracker } from "./request-tracker.ts";
+
+describe("server/runtime-handler/request-lifecycle", () => {
+  describe("startRequestLifecycle", () => {
+    it("should return context with requestId", () => {
+      const req = new Request("http://localhost/test");
+      const ctx = startRequestLifecycle(req, "/test", false);
+      assertEquals(typeof ctx.requestId, "string");
+      assertEquals(ctx.requestId.length > 0, true);
+      ctx.stopTotal();
+    });
+
+    it("should return context with stopTotal function", () => {
+      const req = new Request("http://localhost/test");
+      const ctx = startRequestLifecycle(req, "/test", false);
+      assertEquals(typeof ctx.stopTotal, "function");
+      ctx.stopTotal(); // should not throw
+    });
+
+    it("should set shouldCheckIsolation to true for non-lightweight requests", () => {
+      const req = new Request("http://localhost/test");
+      const ctx = startRequestLifecycle(req, "/test", false);
+      assertEquals(ctx.shouldCheckIsolation, true);
+      ctx.stopTotal();
+    });
+
+    it("should set shouldCheckIsolation to false for lightweight requests", () => {
+      const req = new Request("http://localhost/test");
+      const ctx = startRequestLifecycle(req, "/test", true);
+      assertEquals(ctx.shouldCheckIsolation, false);
+      ctx.stopTotal();
+    });
+
+    it("should use x-request-id header when available", () => {
+      const req = new Request("http://localhost/test", {
+        headers: { "x-request-id": "custom-id" },
+      });
+      const ctx = startRequestLifecycle(req, "/test", false);
+      // The requestId should incorporate the incoming id
+      assertEquals(typeof ctx.requestId, "string");
+      ctx.stopTotal();
+    });
+  });
+
+  describe("endRequestLifecycle", () => {
+    it("should call stopTotal and handle perfRequestId", () => {
+      const req = new Request("http://localhost/test");
+      const ctx = startRequestLifecycle(req, "/test", false);
+      // Should not throw
+      endRequestLifecycle(ctx);
+    });
+  });
+
+  describe("startRequestTracking / completeRequestTracking", () => {
+    it("should track and complete a request", () => {
+      const beforeCount = requestTracker.getInFlightCount();
+      startRequestTracking("lifecycle-req-1", "slug", "/path", "GET", "production", "rel-1");
+      assertEquals(requestTracker.getInFlightCount(), beforeCount + 1);
+      completeRequestTracking("lifecycle-req-1", 200, false);
+      assertEquals(requestTracker.getInFlightCount(), beforeCount);
+    });
+
+    it("should handle timeout flag", () => {
+      startRequestTracking("lifecycle-req-2", "slug", "/path", "GET", undefined, undefined);
+      completeRequestTracking("lifecycle-req-2", 504, true);
+    });
+  });
+
+  describe("startContentMetrics / endContentMetrics", () => {
+    it("should not throw", () => {
+      startContentMetrics();
+      endContentMetrics({
+        requestId: "test-id",
+        pathname: "/test",
+        mode: "production",
+      });
+    });
+  });
+});

--- a/src/server/runtime-handler/request-lifecycle.test.ts
+++ b/src/server/runtime-handler/request-lifecycle.test.ts
@@ -1,12 +1,12 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
-  startRequestLifecycle,
-  endRequestLifecycle,
-  startRequestTracking,
   completeRequestTracking,
-  startContentMetrics,
   endContentMetrics,
+  endRequestLifecycle,
+  startContentMetrics,
+  startRequestLifecycle,
+  startRequestTracking,
 } from "./request-lifecycle.ts";
 import { requestTracker } from "./request-tracker.ts";
 

--- a/src/server/runtime-handler/request-tracker.test.ts
+++ b/src/server/runtime-handler/request-tracker.test.ts
@@ -1,0 +1,143 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it, afterEach } from "#veryfront/testing/bdd.ts";
+import { requestTracker } from "./request-tracker.ts";
+
+describe("server/runtime-handler/request-tracker", () => {
+  afterEach(() => {
+    // Clean up any tracked requests
+    for (const tracked of requestTracker.getInFlightRequests()) {
+      requestTracker.complete(tracked.requestId, 200);
+    }
+  });
+
+  describe("start / complete", () => {
+    it("should track a started request", () => {
+      requestTracker.start("req-1", "my-project", "/page", "GET");
+      assertEquals(requestTracker.getInFlightCount(), 1);
+      requestTracker.complete("req-1", 200);
+    });
+
+    it("should remove request on complete", () => {
+      requestTracker.start("req-2", "my-project", "/page", "GET");
+      requestTracker.complete("req-2", 200);
+      assertEquals(requestTracker.getInFlightCount(), 0);
+    });
+
+    it("should handle completing an unknown request gracefully", () => {
+      requestTracker.complete("nonexistent", 200);
+      assertEquals(requestTracker.getInFlightCount(), 0);
+    });
+
+    it("should track multiple requests simultaneously", () => {
+      const startCount = requestTracker.getInFlightCount();
+      requestTracker.start("req-a", "proj", "/a", "GET");
+      requestTracker.start("req-b", "proj", "/b", "POST");
+      requestTracker.start("req-c", "proj", "/c", "GET");
+      assertEquals(requestTracker.getInFlightCount(), startCount + 3);
+      requestTracker.complete("req-a", 200);
+      requestTracker.complete("req-b", 201);
+      requestTracker.complete("req-c", 404);
+      assertEquals(requestTracker.getInFlightCount(), startCount);
+    });
+  });
+
+  describe("getInFlightRequests", () => {
+    it("should return tracked request details", () => {
+      requestTracker.start("req-detail", "slug-1", "/test", "POST");
+      const requests = requestTracker.getInFlightRequests();
+      const found = requests.find((r) => r.requestId === "req-detail");
+      assertEquals(found?.projectSlug, "slug-1");
+      assertEquals(found?.path, "/test");
+      assertEquals(found?.method, "POST");
+      requestTracker.complete("req-detail", 200);
+    });
+  });
+
+  describe("getStats", () => {
+    it("should return stats with in-flight, total, completed, timedOut counts", () => {
+      const stats = requestTracker.getStats();
+      assertEquals(typeof stats.inFlight, "number");
+      assertEquals(typeof stats.total, "number");
+      assertEquals(typeof stats.completed, "number");
+      assertEquals(typeof stats.timedOut, "number");
+    });
+
+    it("should increment total on start", () => {
+      const before = requestTracker.getStats().total;
+      requestTracker.start("req-stats", "proj", "/s", "GET");
+      const after = requestTracker.getStats().total;
+      assertEquals(after, before + 1);
+      requestTracker.complete("req-stats", 200);
+    });
+
+    it("should increment completed on normal complete", () => {
+      const before = requestTracker.getStats().completed;
+      requestTracker.start("req-comp", "proj", "/c", "GET");
+      requestTracker.complete("req-comp", 200, false);
+      const after = requestTracker.getStats().completed;
+      assertEquals(after, before + 1);
+    });
+
+    it("should increment timedOut when complete with timedOut flag", () => {
+      const before = requestTracker.getStats().timedOut;
+      requestTracker.start("req-timeout", "proj", "/t", "GET");
+      requestTracker.complete("req-timeout", 504, true);
+      const after = requestTracker.getStats().timedOut;
+      assertEquals(after, before + 1);
+    });
+  });
+
+  describe("waitForDrain", () => {
+    it("should return true immediately when no in-flight requests", async () => {
+      const result = await requestTracker.waitForDrain(100, 10);
+      assertEquals(result, true);
+    });
+
+    it("should return true when requests complete within timeout", async () => {
+      requestTracker.start("req-drain", "proj", "/d", "GET");
+      // Complete after a tiny delay
+      setTimeout(() => requestTracker.complete("req-drain", 200), 10);
+      const result = await requestTracker.waitForDrain(500, 5);
+      assertEquals(result, true);
+    });
+
+    it("should return false when drain times out", async () => {
+      requestTracker.start("req-stuck", "proj", "/stuck", "GET");
+      const result = await requestTracker.waitForDrain(50, 10);
+      assertEquals(result, false);
+      requestTracker.complete("req-stuck", 200);
+    });
+  });
+
+  describe("module request logging", () => {
+    it("should handle module request path completion without error", () => {
+      requestTracker.start("req-mod", "proj", "/_vf_modules/foo.js", "GET");
+      requestTracker.complete("req-mod", 200);
+    });
+
+    it("should handle _veryfront module path completion without error", () => {
+      requestTracker.start("req-vf", "proj", "/_veryfront/bar.js", "GET");
+      requestTracker.complete("req-vf", 200);
+    });
+  });
+
+  describe("WebSocket path handling", () => {
+    it("should not set slow timer for WebSocket path", () => {
+      requestTracker.start("req-ws", "proj", "/_ws", "GET");
+      // Just verify it doesn't crash and tracks correctly
+      assertEquals(requestTracker.getInFlightCount() >= 1, true);
+      requestTracker.complete("req-ws", 101);
+    });
+  });
+
+  describe("env and releaseId tracking", () => {
+    it("should accept optional env and releaseId", () => {
+      requestTracker.start("req-env", "proj", "/path", "GET", "production", "rel-123");
+      const requests = requestTracker.getInFlightRequests();
+      const found = requests.find((r) => r.requestId === "req-env");
+      assertEquals(found?.env, "production");
+      assertEquals(found?.releaseId, "rel-123");
+      requestTracker.complete("req-env", 200);
+    });
+  });
+});

--- a/src/server/runtime-handler/request-tracker.test.ts
+++ b/src/server/runtime-handler/request-tracker.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it, afterEach } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { requestTracker } from "./request-tracker.ts";
 
 describe("server/runtime-handler/request-tracker", () => {

--- a/src/server/runtime-handler/tracing.test.ts
+++ b/src/server/runtime-handler/tracing.test.ts
@@ -1,0 +1,91 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  setRequestAttributes,
+  setProjectAttributes,
+  endRequestTracing,
+  executeWithTracingContext,
+  startRequestTracing,
+} from "./tracing.ts";
+
+describe("server/runtime-handler/tracing", () => {
+  describe("startRequestTracing", () => {
+    it("should return a SpanInfo with span and context properties", () => {
+      const req = new Request("http://localhost/test");
+      const spanInfo = startRequestTracing(req, "/test");
+      assertEquals("span" in spanInfo, true);
+      assertEquals("context" in spanInfo, true);
+    });
+  });
+
+  describe("setRequestAttributes", () => {
+    it("should not throw when span is null/undefined", () => {
+      const req = new Request("http://localhost/test");
+      const url = new URL(req.url);
+      // Should not throw
+      setRequestAttributes(null, req, url);
+      setRequestAttributes(undefined, req, url);
+    });
+  });
+
+  describe("setProjectAttributes", () => {
+    it("should not throw when span is null/undefined", () => {
+      setProjectAttributes(null, "my-project", "production");
+      setProjectAttributes(undefined, "my-project", "production");
+    });
+
+    it("should not throw when projectSlug is undefined", () => {
+      setProjectAttributes({}, undefined, "production");
+    });
+  });
+
+  describe("endRequestTracing", () => {
+    it("should not throw when span is null/undefined", () => {
+      endRequestTracing(null, 200);
+      endRequestTracing(undefined, 404);
+    });
+
+    it("should accept optional error parameter", () => {
+      endRequestTracing(null, 500, new Error("test error"));
+    });
+  });
+
+  describe("executeWithTracingContext", () => {
+    it("should execute handler directly when context is null", async () => {
+      let called = false;
+      const result = await executeWithTracingContext(
+        { span: null, context: null },
+        async () => {
+          called = true;
+          return 42;
+        },
+      );
+      assertEquals(called, true);
+      assertEquals(result, 42);
+    });
+
+    it("should execute handler directly when context is undefined", async () => {
+      const result = await executeWithTracingContext(
+        { span: undefined, context: undefined },
+        async () => "hello",
+      );
+      assertEquals(result, "hello");
+    });
+
+    it("should propagate errors from handler", async () => {
+      let caught = false;
+      try {
+        await executeWithTracingContext(
+          { span: null, context: null },
+          async () => {
+            throw new Error("handler failed");
+          },
+        );
+      } catch (e) {
+        caught = true;
+        assertEquals((e as Error).message, "handler failed");
+      }
+      assertEquals(caught, true);
+    });
+  });
+});

--- a/src/server/runtime-handler/tracing.test.ts
+++ b/src/server/runtime-handler/tracing.test.ts
@@ -1,10 +1,10 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
-  setRequestAttributes,
-  setProjectAttributes,
   endRequestTracing,
   executeWithTracingContext,
+  setProjectAttributes,
+  setRequestAttributes,
   startRequestTracing,
 } from "./tracing.ts";
 

--- a/src/server/schemas/action.schema.test.ts
+++ b/src/server/schemas/action.schema.test.ts
@@ -1,0 +1,74 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { ActionPayloadSchema } from "./action.schema.ts";
+
+describe("server/schemas/action.schema", () => {
+  describe("ActionPayloadSchema", () => {
+    it("should accept a valid payload with id and args", () => {
+      const result = ActionPayloadSchema.safeParse({ id: "action-1", args: [1, "two"] });
+      assertEquals(result.success, true);
+      if (result.success) {
+        assertEquals(result.data.id, "action-1");
+        assertEquals(result.data.args, [1, "two"]);
+      }
+    });
+
+    it("should default args to empty array when omitted", () => {
+      const result = ActionPayloadSchema.safeParse({ id: "action-1" });
+      assertEquals(result.success, true);
+      if (result.success) {
+        assertEquals(result.data.args, []);
+      }
+    });
+
+    it("should reject empty id string", () => {
+      const result = ActionPayloadSchema.safeParse({ id: "" });
+      assertEquals(result.success, false);
+    });
+
+    it("should reject missing id", () => {
+      const result = ActionPayloadSchema.safeParse({ args: [] });
+      assertEquals(result.success, false);
+    });
+
+    it("should reject non-string id", () => {
+      const result = ActionPayloadSchema.safeParse({ id: 123 });
+      assertEquals(result.success, false);
+    });
+
+    it("should reject args array with more than 50 elements", () => {
+      const bigArgs = Array.from({ length: 51 }, (_, i) => i);
+      const result = ActionPayloadSchema.safeParse({ id: "x", args: bigArgs });
+      assertEquals(result.success, false);
+    });
+
+    it("should accept args array with exactly 50 elements", () => {
+      const maxArgs = Array.from({ length: 50 }, (_, i) => i);
+      const result = ActionPayloadSchema.safeParse({ id: "x", args: maxArgs });
+      assertEquals(result.success, true);
+    });
+
+    it("should accept args with mixed types", () => {
+      const result = ActionPayloadSchema.safeParse({
+        id: "x",
+        args: [null, undefined, 42, "str", { key: "val" }, [1, 2]],
+      });
+      assertEquals(result.success, true);
+    });
+
+    it("should reject non-array args", () => {
+      const result = ActionPayloadSchema.safeParse({ id: "x", args: "not-array" });
+      assertEquals(result.success, false);
+    });
+
+    it("should reject null payload", () => {
+      const result = ActionPayloadSchema.safeParse(null);
+      assertEquals(result.success, false);
+    });
+
+    it("should reject undefined payload", () => {
+      const result = ActionPayloadSchema.safeParse(undefined);
+      assertEquals(result.success, false);
+    });
+  });
+});

--- a/src/server/services/rendering/ssr.service.test.ts
+++ b/src/server/services/rendering/ssr.service.test.ts
@@ -1,0 +1,56 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { SSRService } from "./ssr.service.ts";
+
+describe("server/services/rendering/ssr.service", () => {
+  describe("SSRService", () => {
+    it("should be constructable without options", () => {
+      const service = new SSRService();
+      assertEquals(service instanceof SSRService, true);
+    });
+
+    it("should be constructable with cacheRepo option", () => {
+      const mockRepo = {
+        get: async () => null,
+        set: async () => {},
+        delete: async () => {},
+        has: async () => false,
+      };
+      const service = new SSRService({ cacheRepo: mockRepo as any });
+      assertEquals(service instanceof SSRService, true);
+    });
+
+    describe("checkMemoryPressure", () => {
+      it("should return memory status with all required fields", () => {
+        const service = new SSRService();
+        const status = service.checkMemoryPressure();
+
+        assertEquals(typeof status.shouldReject, "boolean");
+        assertEquals(typeof status.heapUsedMB, "number");
+        assertEquals(typeof status.heapLimitMB, "number");
+        assertEquals(typeof status.heapUsedPercent, "number");
+      });
+
+      it("should report non-negative heap values", () => {
+        const service = new SSRService();
+        const status = service.checkMemoryPressure();
+
+        assertEquals(status.heapUsedMB >= 0, true);
+        assertEquals(status.heapLimitMB > 0, true);
+        assertEquals(status.heapUsedPercent >= 0, true);
+      });
+
+      it("should not reject under normal test conditions", () => {
+        const service = new SSRService();
+        const status = service.checkMemoryPressure();
+        assertEquals(status.shouldReject, false);
+      });
+
+      it("should report heap used percent between 0 and 100", () => {
+        const service = new SSRService();
+        const status = service.checkMemoryPressure();
+        assertEquals(status.heapUsedPercent >= 0 && status.heapUsedPercent <= 100, true);
+      });
+    });
+  });
+});

--- a/src/server/services/rendering/ssr.service.test.ts
+++ b/src/server/services/rendering/ssr.service.test.ts
@@ -4,52 +4,77 @@ import { SSRService } from "./ssr.service.ts";
 
 describe("server/services/rendering/ssr.service", () => {
   describe("SSRService", () => {
-    it("should be constructable without options", () => {
-      const service = new SSRService();
-      assertEquals(service instanceof SSRService, true);
-    });
+    describe("constructor", () => {
+      it("creates instance without options", () => {
+        const service = new SSRService();
+        assertEquals(service instanceof SSRService, true);
+      });
 
-    it("should be constructable with cacheRepo option", () => {
-      const mockRepo = {
-        get: async () => null,
-        set: async () => {},
-        delete: async () => {},
-        has: async () => false,
-      };
-      const service = new SSRService({ cacheRepo: mockRepo as any });
-      assertEquals(service instanceof SSRService, true);
+      it("creates instance with empty options", () => {
+        const service = new SSRService({});
+        assertEquals(service instanceof SSRService, true);
+      });
+
+      it("creates instance with cacheRepo option", () => {
+        const mockRepo = {
+          get: () => Promise.resolve(null),
+          set: () => Promise.resolve(),
+          delete: () => Promise.resolve(),
+        };
+        const service = new SSRService({ cacheRepo: mockRepo as any });
+        assertEquals(service instanceof SSRService, true);
+      });
     });
 
     describe("checkMemoryPressure", () => {
-      it("should return memory status with all required fields", () => {
+      it("returns MemoryStatus object", () => {
         const service = new SSRService();
         const status = service.checkMemoryPressure();
-
         assertEquals(typeof status.shouldReject, "boolean");
         assertEquals(typeof status.heapUsedMB, "number");
         assertEquals(typeof status.heapLimitMB, "number");
         assertEquals(typeof status.heapUsedPercent, "number");
       });
 
-      it("should report non-negative heap values", () => {
+      it("returns non-negative heap values", () => {
         const service = new SSRService();
         const status = service.checkMemoryPressure();
-
         assertEquals(status.heapUsedMB >= 0, true);
-        assertEquals(status.heapLimitMB > 0, true);
+        assertEquals(status.heapLimitMB >= 0, true);
         assertEquals(status.heapUsedPercent >= 0, true);
       });
+    });
 
-      it("should not reject under normal test conditions", () => {
+    describe("createMemoryPressureResult", () => {
+      it("returns result with 503 status", () => {
         const service = new SSRService();
-        const status = service.checkMemoryPressure();
-        assertEquals(status.shouldReject, false);
+        const result = service.createMemoryPressureResult("test-slug");
+        assertEquals(result.status, 503);
       });
 
-      it("should report heap used percent between 0 and 100", () => {
+      it("returns non-streaming result", () => {
         const service = new SSRService();
-        const status = service.checkMemoryPressure();
-        assertEquals(status.heapUsedPercent >= 0 && status.heapUsedPercent <= 100, true);
+        const result = service.createMemoryPressureResult("test-slug");
+        assertEquals(result.isStreaming, false);
+      });
+
+      it("returns no-cache strategy", () => {
+        const service = new SSRService();
+        const result = service.createMemoryPressureResult("test-slug");
+        assertEquals(result.cacheStrategy, "no-cache");
+      });
+
+      it("preserves slug in result", () => {
+        const service = new SSRService();
+        const result = service.createMemoryPressureResult("my-page");
+        assertEquals(result.slug, "my-page");
+      });
+
+      it("returns HTML content", () => {
+        const service = new SSRService();
+        const result = service.createMemoryPressureResult("test");
+        assertEquals(typeof result.html, "string");
+        assertEquals((result.html?.length ?? 0) > 0, true);
       });
     });
   });

--- a/src/server/services/rsc/endpoints/action-handler.test.ts
+++ b/src/server/services/rsc/endpoints/action-handler.test.ts
@@ -1,0 +1,188 @@
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { handleActionRequest } from "./action-handler.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+
+function createMockAdapter(
+  overrides: {
+    stat?: (
+      path: string,
+    ) => Promise<{ isFile: boolean; isDirectory: boolean; size: number; mtime: null }>;
+    readFile?: (path: string) => Promise<string>;
+  } = {},
+): RuntimeAdapter {
+  return {
+    id: "memory",
+    name: "mock",
+    capabilities: {
+      typescript: true,
+      jsx: true,
+      fileWatcher: false,
+      shell: false,
+      kvStore: false,
+      workers: false,
+    },
+    fs: {
+      exists: () => Promise.resolve(false),
+      readFile: overrides.readFile ?? (() => Promise.resolve("")),
+      writeFile: () => Promise.resolve(),
+      readDir: () => Promise.resolve([]),
+      mkdir: () => Promise.resolve(),
+      remove: () => Promise.resolve(),
+      stat: overrides.stat ?? (() => Promise.reject(new Error("not found"))),
+    },
+    env: {
+      get: () => undefined,
+      set: () => {},
+      delete: () => {},
+      toObject: () => ({}),
+    },
+    server: { createHandler: () => () => new Response() },
+    serve: () => Promise.resolve({ close: () => Promise.resolve() } as any),
+  } as unknown as RuntimeAdapter;
+}
+
+describe("server/services/rsc/endpoints/action-handler", () => {
+  describe("handleActionRequest", () => {
+    it("returns 400 when body has no id", async () => {
+      const req = new Request("http://localhost/_veryfront/rsc/action", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ args: [] }),
+      });
+
+      const response = await handleActionRequest({
+        req,
+        projectDir: "/tmp/test",
+        adapter: createMockAdapter(),
+      });
+
+      assertEquals(response.status, 400);
+      const body = await response.json();
+      assertStringIncludes(JSON.stringify(body), "missing id");
+    });
+
+    it("returns 400 when body is invalid JSON (falls back to empty object)", async () => {
+      const req = new Request("http://localhost/_veryfront/rsc/action", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not valid json",
+      });
+
+      const response = await handleActionRequest({
+        req,
+        projectDir: "/tmp/test",
+        adapter: createMockAdapter(),
+      });
+
+      // Invalid JSON -> req.json() fails -> body = {} -> missing id
+      assertEquals(response.status, 400);
+    });
+
+    it("returns 400 when id contains path traversal", async () => {
+      const req = new Request("http://localhost/_veryfront/rsc/action", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "../etc/passwd", args: [] }),
+      });
+
+      const response = await handleActionRequest({
+        req,
+        projectDir: "/tmp/test",
+        adapter: createMockAdapter(),
+      });
+
+      assertEquals(response.status, 400);
+      const body = await response.json();
+      assertStringIncludes(JSON.stringify(body), "invalid id");
+    });
+
+    it("returns 400 when id starts with slash", async () => {
+      const req = new Request("http://localhost/_veryfront/rsc/action", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "/admin/secret", args: [] }),
+      });
+
+      const response = await handleActionRequest({
+        req,
+        projectDir: "/tmp/test",
+        adapter: createMockAdapter(),
+      });
+
+      assertEquals(response.status, 400);
+    });
+
+    it("returns 404 when action file does not exist", async () => {
+      const adapter = createMockAdapter({
+        stat: () => Promise.reject(new Error("ENOENT")),
+      });
+
+      const req = new Request("http://localhost/_veryfront/rsc/action", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "my-action", args: [] }),
+      });
+
+      const response = await handleActionRequest({
+        req,
+        projectDir: "/tmp/test",
+        adapter,
+      });
+
+      assertEquals(response.status, 404);
+    });
+
+    it("returns 404 when action path exists but is not a file", async () => {
+      const adapter = createMockAdapter({
+        stat: () => Promise.resolve({ isFile: false, isDirectory: true, size: 0, mtime: null }),
+      });
+
+      const req = new Request("http://localhost/_veryfront/rsc/action", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "my-action", args: [] }),
+      });
+
+      const response = await handleActionRequest({
+        req,
+        projectDir: "/tmp/test",
+        adapter,
+      });
+
+      assertEquals(response.status, 404);
+    });
+
+    it("returns 400 for empty id string", async () => {
+      const req = new Request("http://localhost/_veryfront/rsc/action", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "", args: [] }),
+      });
+
+      const response = await handleActionRequest({
+        req,
+        projectDir: "/tmp/test",
+        adapter: createMockAdapter(),
+      });
+
+      assertEquals(response.status, 400);
+    });
+
+    it("returns 400 when id ends with slash", async () => {
+      const req = new Request("http://localhost/_veryfront/rsc/action", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "my-action/", args: [] }),
+      });
+
+      const response = await handleActionRequest({
+        req,
+        projectDir: "/tmp/test",
+        adapter: createMockAdapter(),
+      });
+
+      assertEquals(response.status, 400);
+    });
+  });
+});

--- a/src/server/services/rsc/endpoints/endpoint-router.test.ts
+++ b/src/server/services/rsc/endpoints/endpoint-router.test.ts
@@ -400,4 +400,158 @@ describe("server/services/rsc/endpoints/endpoint-router", () => {
       assertEquals(result, null);
     });
   });
+
+  describe("action endpoint - POST handling", () => {
+    it("handles POST action with missing body id", async () => {
+      const result = await handleRSCEndpoint(
+        makeParams({
+          pathname: "/_veryfront/rsc/action",
+          config: rscEnabledConfig,
+          req: new Request("http://localhost/_veryfront/rsc/action", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ args: [] }),
+          }),
+        }),
+      );
+      assertEquals(result instanceof Response, true);
+      assertEquals(result!.status, 400);
+    });
+
+    it("handles POST action with invalid JSON body", async () => {
+      const result = await handleRSCEndpoint(
+        makeParams({
+          pathname: "/_veryfront/rsc/action",
+          config: rscEnabledConfig,
+          req: new Request("http://localhost/_veryfront/rsc/action", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: "not json",
+          }),
+        }),
+      );
+      assertEquals(result instanceof Response, true);
+      // Should still get a response (400 for bad body)
+      assertEquals(result!.status, 400);
+    });
+
+    it("handles POST action with path traversal id", async () => {
+      const result = await handleRSCEndpoint(
+        makeParams({
+          pathname: "/_veryfront/rsc/action",
+          config: rscEnabledConfig,
+          req: new Request("http://localhost/_veryfront/rsc/action", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ id: "../evil", args: [] }),
+          }),
+        }),
+      );
+      assertEquals(result instanceof Response, true);
+      assertEquals(result!.status, 400);
+    });
+
+    it("handles POST action with valid id but non-existent file returns error", async () => {
+      const result = await handleRSCEndpoint(
+        makeParams({
+          pathname: "/_veryfront/rsc/action",
+          config: rscEnabledConfig,
+          req: new Request("http://localhost/_veryfront/rsc/action", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ id: "valid-action", args: ["hello"] }),
+          }),
+        }),
+      );
+      assertEquals(result instanceof Response, true);
+      // The import of the non-existent file will fail, resulting in a 500
+      assertEquals(result!.status, 500);
+    });
+
+    it("rejects DELETE with 405", async () => {
+      const result = await handleRSCEndpoint(
+        makeParams({
+          pathname: "/_veryfront/rsc/action",
+          config: rscEnabledConfig,
+          req: new Request("http://localhost/_veryfront/rsc/action", { method: "DELETE" }),
+        }),
+      );
+      assertEquals(result!.status, 405);
+    });
+  });
+
+  describe("module endpoint - edge cases", () => {
+    it("returns 400 for backslash path traversal", async () => {
+      const adapter = createMockAdapter({
+        exists: () => Promise.resolve(true),
+      });
+
+      const result = await handleRSCEndpoint(
+        makeParams({
+          pathname: "/_veryfront/rsc/module",
+          config: rscEnabledConfig,
+          req: new Request(
+            "http://localhost/_veryfront/rsc/module?rel=..\\..\\etc\\passwd",
+          ),
+          adapter,
+          projectDir: "/tmp/test-project",
+        }),
+      );
+      assertEquals(result instanceof Response, true);
+      assertEquals(result!.status, 400);
+    });
+
+    it("serves file from app directory root", async () => {
+      const adapter = createMockAdapter({
+        exists: (path: string) => Promise.resolve(path.includes("/app/component.js")),
+        readFile: () => Promise.resolve("export default {}"),
+      });
+
+      const result = await handleRSCEndpoint(
+        makeParams({
+          pathname: "/_veryfront/rsc/module",
+          config: rscEnabledConfig,
+          req: new Request("http://localhost/_veryfront/rsc/module?rel=component.js"),
+          adapter,
+          projectDir: "/tmp/test-project",
+        }),
+      );
+      assertEquals(result instanceof Response, true);
+      assertEquals(result!.status, 200);
+      const body = await result!.text();
+      assertEquals(body, "export default {}");
+    });
+  });
+
+  describe("stream endpoint - sub-paths", () => {
+    it("returns null for stream sub-path when RSC disabled", async () => {
+      const result = await handleRSCEndpoint(
+        makeParams({
+          pathname: "/_veryfront/rsc/stream/sub",
+          config: rscDisabledConfig,
+        }),
+      );
+      assertEquals(result, null);
+    });
+
+    it("returns null for page sub-path when RSC disabled", async () => {
+      const result = await handleRSCEndpoint(
+        makeParams({
+          pathname: "/_veryfront/rsc/page/sub",
+          config: rscDisabledConfig,
+        }),
+      );
+      assertEquals(result, null);
+    });
+
+    it("returns null for render sub-path when RSC disabled", async () => {
+      const result = await handleRSCEndpoint(
+        makeParams({
+          pathname: "/_veryfront/rsc/render/sub",
+          config: rscDisabledConfig,
+        }),
+      );
+      assertEquals(result, null);
+    });
+  });
 });

--- a/src/server/services/rsc/endpoints/handler-registry.test.ts
+++ b/src/server/services/rsc/endpoints/handler-registry.test.ts
@@ -1,0 +1,115 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it, afterEach } from "#veryfront/testing/bdd.ts";
+import {
+  getRSCHandler,
+  __injectCacheForTests,
+  __resetRSCHandlerForTests,
+  __destroyRSCHandlerForTests,
+  type HandlerCache,
+} from "./handler-registry.ts";
+import type { RSCDevServerHandler } from "../orchestrators/index.ts";
+
+function createStubCache(): HandlerCache<RSCDevServerHandler> & { entries: Map<string, RSCDevServerHandler> } {
+  const entries = new Map<string, RSCDevServerHandler>();
+  return {
+    entries,
+    get(key: string) {
+      return entries.get(key);
+    },
+    set(key: string, value: RSCDevServerHandler) {
+      entries.set(key, value);
+    },
+    clear() {
+      entries.clear();
+    },
+    get size() {
+      return entries.size;
+    },
+  };
+}
+
+describe("server/services/rsc/endpoints/handler-registry", () => {
+  afterEach(() => {
+    __destroyRSCHandlerForTests();
+  });
+
+  describe("getRSCHandler", () => {
+    it("should create a new handler for a project", () => {
+      const cache = createStubCache();
+      __injectCacheForTests(cache);
+
+      const handler = getRSCHandler("/project/dir");
+      assertEquals(cache.size, 1);
+      assertEquals(handler !== undefined, true);
+    });
+
+    it("should return cached handler for same projectDir", () => {
+      const cache = createStubCache();
+      __injectCacheForTests(cache);
+
+      const handler1 = getRSCHandler("/project/dir");
+      const handler2 = getRSCHandler("/project/dir");
+      assertEquals(handler1, handler2);
+      assertEquals(cache.size, 1);
+    });
+
+    it("should use projectId as cache key when provided", () => {
+      const cache = createStubCache();
+      __injectCacheForTests(cache);
+
+      getRSCHandler("/dir", "proj-123");
+      assertEquals(cache.entries.has("proj-123"), true);
+      assertEquals(cache.entries.has("/dir"), false);
+    });
+
+    it("should use projectDir as cache key when projectId is undefined", () => {
+      const cache = createStubCache();
+      __injectCacheForTests(cache);
+
+      getRSCHandler("/project/dir");
+      assertEquals(cache.entries.has("/project/dir"), true);
+    });
+
+    it("should create separate handlers for different projects", () => {
+      const cache = createStubCache();
+      __injectCacheForTests(cache);
+
+      const handler1 = getRSCHandler("/dir1");
+      const handler2 = getRSCHandler("/dir2");
+      assertEquals(handler1 !== handler2, true);
+      assertEquals(cache.size, 2);
+    });
+  });
+
+  describe("__resetRSCHandlerForTests", () => {
+    it("should clear all cached handlers", () => {
+      const cache = createStubCache();
+      __injectCacheForTests(cache);
+
+      getRSCHandler("/dir1");
+      getRSCHandler("/dir2");
+      assertEquals(cache.size, 2);
+
+      __resetRSCHandlerForTests();
+      assertEquals(cache.size, 0);
+    });
+  });
+
+  describe("__destroyRSCHandlerForTests", () => {
+    it("should remove injected cache", () => {
+      const cache = createStubCache();
+      __injectCacheForTests(cache);
+      getRSCHandler("/dir");
+      assertEquals(cache.size, 1);
+
+      __destroyRSCHandlerForTests();
+
+      // After destroy, a new call should create a new handler (using default cache)
+      // We just verify no errors
+      const cache2 = createStubCache();
+      __injectCacheForTests(cache2);
+      getRSCHandler("/dir");
+      assertEquals(cache2.size, 1);
+    });
+  });
+});

--- a/src/server/services/rsc/endpoints/handler-registry.test.ts
+++ b/src/server/services/rsc/endpoints/handler-registry.test.ts
@@ -1,15 +1,17 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it, afterEach } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
-  getRSCHandler,
+  __destroyRSCHandlerForTests,
   __injectCacheForTests,
   __resetRSCHandlerForTests,
-  __destroyRSCHandlerForTests,
+  getRSCHandler,
   type HandlerCache,
 } from "./handler-registry.ts";
 import type { RSCDevServerHandler } from "../orchestrators/index.ts";
 
-function createStubCache(): HandlerCache<RSCDevServerHandler> & { entries: Map<string, RSCDevServerHandler> } {
+function createStubCache(): HandlerCache<RSCDevServerHandler> & {
+  entries: Map<string, RSCDevServerHandler>;
+} {
   const entries = new Map<string, RSCDevServerHandler>();
   return {
     entries,

--- a/src/server/services/rsc/endpoints/handler-registry.test.ts
+++ b/src/server/services/rsc/endpoints/handler-registry.test.ts
@@ -42,7 +42,7 @@ describe("server/services/rsc/endpoints/handler-registry", () => {
 
       const handler = getRSCHandler("/project/dir");
       assertEquals(cache.size, 1);
-      assertEquals(handler !== undefined, true);
+      assertEquals(!!handler, true);
     });
 
     it("should return cached handler for same projectDir", () => {

--- a/src/server/services/rsc/orchestrators/component-resolver.test.ts
+++ b/src/server/services/rsc/orchestrators/component-resolver.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { resolveComponentPath, extractParams } from "./component-resolver.ts";
+import { extractParams, resolveComponentPath } from "./component-resolver.ts";
 import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
 
 function createMockFs(existingFiles: Set<string>): FileSystemAdapter {
@@ -37,10 +37,12 @@ describe("server/services/rsc/orchestrators/component-resolver", () => {
     });
 
     it("should resolve .mdx files first (higher priority)", async () => {
-      const fs = createMockFs(new Set([
-        "/project/app/docs/page.mdx",
-        "/project/app/docs/page.tsx",
-      ]));
+      const fs = createMockFs(
+        new Set([
+          "/project/app/docs/page.mdx",
+          "/project/app/docs/page.tsx",
+        ]),
+      );
       const result = await resolveComponentPath("/docs", "/project", fs);
       assertEquals(result, "/project/app/docs/page.mdx");
     });

--- a/src/server/services/rsc/orchestrators/component-resolver.test.ts
+++ b/src/server/services/rsc/orchestrators/component-resolver.test.ts
@@ -1,0 +1,111 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { resolveComponentPath, extractParams } from "./component-resolver.ts";
+import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
+
+function createMockFs(existingFiles: Set<string>): FileSystemAdapter {
+  return {
+    stat: async (path: string) => {
+      if (existingFiles.has(path)) {
+        return { isFile: true, isDirectory: false, size: 100 };
+      }
+      throw new Error("ENOENT");
+    },
+    readFile: async () => "",
+    exists: async (path: string) => existingFiles.has(path),
+  } as unknown as FileSystemAdapter;
+}
+
+describe("server/services/rsc/orchestrators/component-resolver", () => {
+  describe("resolveComponentPath", () => {
+    it("should resolve root page for index pathname", async () => {
+      const fs = createMockFs(new Set(["/project/app/page.tsx"]));
+      const result = await resolveComponentPath("/", "/project", fs);
+      assertEquals(result, "/project/app/page.tsx");
+    });
+
+    it("should resolve root page for empty string", async () => {
+      const fs = createMockFs(new Set(["/project/app/page.tsx"]));
+      const result = await resolveComponentPath("", "/project", fs);
+      assertEquals(result, "/project/app/page.tsx");
+    });
+
+    it("should resolve page in subdirectory", async () => {
+      const fs = createMockFs(new Set(["/project/app/about/page.tsx"]));
+      const result = await resolveComponentPath("/about", "/project", fs);
+      assertEquals(result, "/project/app/about/page.tsx");
+    });
+
+    it("should resolve .mdx files first (higher priority)", async () => {
+      const fs = createMockFs(new Set([
+        "/project/app/docs/page.mdx",
+        "/project/app/docs/page.tsx",
+      ]));
+      const result = await resolveComponentPath("/docs", "/project", fs);
+      assertEquals(result, "/project/app/docs/page.mdx");
+    });
+
+    it("should resolve .md files", async () => {
+      const fs = createMockFs(new Set(["/project/app/readme/page.md"]));
+      const result = await resolveComponentPath("/readme", "/project", fs);
+      assertEquals(result, "/project/app/readme/page.md");
+    });
+
+    it("should resolve flat file pattern (e.g., app/about.tsx)", async () => {
+      const fs = createMockFs(new Set(["/project/app/about.tsx"]));
+      const result = await resolveComponentPath("/about", "/project", fs);
+      assertEquals(result, "/project/app/about.tsx");
+    });
+
+    it("should return null when no matching file exists", async () => {
+      const fs = createMockFs(new Set([]));
+      const result = await resolveComponentPath("/nonexistent", "/project", fs);
+      assertEquals(result, null);
+    });
+
+    it("should resolve .jsx files", async () => {
+      const fs = createMockFs(new Set(["/project/app/legacy/page.jsx"]));
+      const result = await resolveComponentPath("/legacy", "/project", fs);
+      assertEquals(result, "/project/app/legacy/page.jsx");
+    });
+
+    it("should resolve .js files", async () => {
+      const fs = createMockFs(new Set(["/project/app/simple/page.js"]));
+      const result = await resolveComponentPath("/simple", "/project", fs);
+      assertEquals(result, "/project/app/simple/page.js");
+    });
+
+    it("should strip leading slash from pathname", async () => {
+      const fs = createMockFs(new Set(["/project/app/test/page.tsx"]));
+      const result1 = await resolveComponentPath("/test", "/project", fs);
+      const result2 = await resolveComponentPath("test", "/project", fs);
+      assertEquals(result1, result2);
+    });
+
+    it("should strip _veryfront/rsc/render/ prefix", async () => {
+      const fs = createMockFs(new Set(["/project/app/hello/page.tsx"]));
+      const result = await resolveComponentPath("/_veryfront/rsc/render/hello", "/project", fs);
+      assertEquals(result, "/project/app/hello/page.tsx");
+    });
+
+    it("should resolve nested paths", async () => {
+      const fs = createMockFs(new Set(["/project/app/docs/api/v2/page.tsx"]));
+      const result = await resolveComponentPath("/docs/api/v2", "/project", fs);
+      assertEquals(result, "/project/app/docs/api/v2/page.tsx");
+    });
+  });
+
+  describe("extractParams", () => {
+    it("should return empty object", () => {
+      assertEquals(extractParams("/test"), {});
+    });
+
+    it("should return empty object for any pathname", () => {
+      assertEquals(extractParams("/foo/bar/baz"), {});
+    });
+
+    it("should return empty object for empty string", () => {
+      assertEquals(extractParams(""), {});
+    });
+  });
+});

--- a/src/server/services/rsc/orchestrators/hydrator-handler.test.ts
+++ b/src/server/services/rsc/orchestrators/hydrator-handler.test.ts
@@ -1,0 +1,52 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { HydratorHandler } from "./hydrator-handler.ts";
+
+// The HydratorHandler depends on esbuild for bundling.
+// We test the fallback behavior when the fsAdapter fails to read the file,
+// avoiding esbuild subprocess creation that causes resource leaks in tests.
+
+describe("server/services/rsc/orchestrators/hydrator-handler", () => {
+  describe("handle", () => {
+    it("should return a fallback response when fsAdapter.readFile throws", async () => {
+      const mockFs = {
+        readFile: async () => {
+          throw new Error("file not found");
+        },
+      };
+      const handler = new HydratorHandler(mockFs as any);
+      const response = await handler.handle();
+      assertEquals(response instanceof Response, true);
+      assertEquals(response.headers.get("content-type"), "application/javascript");
+
+      // Should be the fallback response with hydrateRSC export
+      const text = await response.text();
+      assertEquals(text.includes("hydrateRSC"), true);
+      assertEquals(text.includes("Hydrator not available"), true);
+    });
+
+    it("should have cache-control: no-cache on fallback response", async () => {
+      const mockFs = {
+        readFile: async () => {
+          throw new Error("not found");
+        },
+      };
+      const handler = new HydratorHandler(mockFs as any);
+      const response = await handler.handle();
+      assertEquals(response.headers.get("cache-control"), "no-cache");
+    });
+
+    it("should produce a valid JavaScript module in fallback", async () => {
+      const mockFs = {
+        readFile: async () => {
+          throw new Error("not found");
+        },
+      };
+      const handler = new HydratorHandler(mockFs as any);
+      const response = await handler.handle();
+      const text = await response.text();
+      // The fallback should export an async function
+      assertEquals(text.includes("export async function"), true);
+    });
+  });
+});

--- a/src/server/services/rsc/orchestrators/manifest-handler.test.ts
+++ b/src/server/services/rsc/orchestrators/manifest-handler.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it, afterEach } from "#veryfront/testing/bdd.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
 import { ManifestHandler } from "./manifest-handler.ts";
 import type { CacheRepository } from "#veryfront/repositories/types.ts";
 

--- a/src/server/services/rsc/orchestrators/manifest-handler.test.ts
+++ b/src/server/services/rsc/orchestrators/manifest-handler.test.ts
@@ -1,0 +1,119 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it, afterEach } from "#veryfront/testing/bdd.ts";
+import { ManifestHandler } from "./manifest-handler.ts";
+import type { CacheRepository } from "#veryfront/repositories/types.ts";
+
+function createMockCacheRepo(): CacheRepository<string> & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+  return {
+    store,
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async set(key: string, value: string, _ttl?: number) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+    async has(key: string) {
+      return store.has(key);
+    },
+  } as CacheRepository<string> & { store: Map<string, string> };
+}
+
+describe("server/services/rsc/orchestrators/manifest-handler", () => {
+  describe("handle", () => {
+    it("should return JSON response with components map", async () => {
+      const manifest = new Map([
+        ["Button", { path: "/app/components/Button.tsx", exports: [] }],
+        ["Card", { path: "/app/components/Card.tsx", exports: [] }],
+      ]);
+
+      const handler = new ManifestHandler("/project");
+      const response = await handler.handle(manifest as any);
+
+      assertEquals(response.headers.get("content-type"), "application/json");
+      const body = await response.json();
+      assertEquals(body.components.Button, "/app/components/Button.tsx");
+      assertEquals(body.components.Card, "/app/components/Card.tsx");
+    });
+
+    it("should return empty components for empty manifest", async () => {
+      const handler = new ManifestHandler("/project");
+      const response = await handler.handle(new Map());
+      const body = await response.json();
+      assertEquals(body.components, {});
+    });
+
+    it("should cache result on second call (in-memory)", async () => {
+      const manifest = new Map([
+        ["A", { path: "/a.tsx", exports: [] }],
+      ]);
+
+      const handler = new ManifestHandler("/project");
+      const response1 = await handler.handle(manifest as any);
+      const body1 = await response1.json();
+
+      // Second call with different manifest should return cached data
+      const manifest2 = new Map([
+        ["B", { path: "/b.tsx", exports: [] }],
+      ]);
+      const response2 = await handler.handle(manifest2 as any);
+      const body2 = await response2.json();
+
+      assertEquals(body1.components.A, body2.components.A);
+      assertEquals(body2.components.B, undefined);
+    });
+  });
+
+  describe("handle with injected CacheRepository", () => {
+    it("should use injected cache repo for caching", async () => {
+      const cacheRepo = createMockCacheRepo();
+      const manifest = new Map([
+        ["X", { path: "/x.tsx", exports: [] }],
+      ]);
+
+      const handler = new ManifestHandler("/project", { cacheRepo });
+      await handler.handle(manifest as any);
+
+      assertEquals(cacheRepo.store.size, 1);
+    });
+
+    it("should return cached data from injected cache", async () => {
+      const cacheRepo = createMockCacheRepo();
+      const manifest = new Map([
+        ["Y", { path: "/y.tsx", exports: [] }],
+      ]);
+
+      const handler = new ManifestHandler("/project", { cacheRepo });
+      await handler.handle(manifest as any);
+
+      // Second call should use cache
+      const response = await handler.handle(new Map() as any);
+      const body = await response.json();
+      assertEquals(body.components.Y, "/y.tsx");
+    });
+  });
+
+  describe("clearCache", () => {
+    it("should clear in-memory cache", async () => {
+      const manifest = new Map([
+        ["Z", { path: "/z.tsx", exports: [] }],
+      ]);
+
+      const handler = new ManifestHandler("/project");
+      await handler.handle(manifest as any);
+      handler.clearCache();
+
+      // After clear, new manifest should be used
+      const manifest2 = new Map([
+        ["W", { path: "/w.tsx", exports: [] }],
+      ]);
+      const response = await handler.handle(manifest2 as any);
+      const body = await response.json();
+      assertEquals(body.components.W, "/w.tsx");
+      assertEquals(body.components.Z, undefined);
+    });
+  });
+});

--- a/src/server/services/rsc/orchestrators/page-handler.test.ts
+++ b/src/server/services/rsc/orchestrators/page-handler.test.ts
@@ -1,0 +1,80 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { PageHandler } from "./page-handler.ts";
+
+describe("server/services/rsc/orchestrators/page-handler", () => {
+  describe("handle", () => {
+    it("should return HTML response with correct content type", () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/test", new URLSearchParams());
+      assertEquals(response.headers.get("content-type"), "text/html; charset=utf-8");
+    });
+
+    it("should return 200 status", () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/test", new URLSearchParams());
+      assertEquals(response.status, 200);
+    });
+
+    it("should include render URL for the given pathname", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/about", new URLSearchParams());
+      const html = await response.text();
+      assertEquals(html.includes("/_veryfront/rsc/render/about"), true);
+    });
+
+    it("should include query string in render URL", async () => {
+      const handler = new PageHandler();
+      const params = new URLSearchParams({ name: "World", id: "42" });
+      const response = handler.handle("/page", params);
+      const html = await response.text();
+      assertEquals(html.includes("name=World"), true);
+      assertEquals(html.includes("id=42"), true);
+    });
+
+    it("should not include query separator when no search params", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/page", new URLSearchParams());
+      const html = await response.text();
+      // The render URL should not have a ? when no params
+      assertEquals(html.includes("/_veryfront/rsc/render/page?"), false);
+    });
+
+    it("should include rsc-root div", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/", new URLSearchParams());
+      const html = await response.text();
+      assertEquals(html.includes('id="rsc-root"'), true);
+    });
+
+    it("should include dev mode flag", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/", new URLSearchParams());
+      const html = await response.text();
+      assertEquals(html.includes("__VERYFRONT_DEV__"), true);
+    });
+
+    it("should include hydrate.js import", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/", new URLSearchParams());
+      const html = await response.text();
+      assertEquals(html.includes("/_veryfront/rsc/hydrate.js"), true);
+    });
+
+    it("should include security validation function", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/", new URLSearchParams());
+      const html = await response.text();
+      assertEquals(html.includes("validateTrustedHtml"), true);
+    });
+
+    it("should be a valid HTML document", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/", new URLSearchParams());
+      const html = await response.text();
+      assertEquals(html.startsWith("<!DOCTYPE html>"), true);
+      assertEquals(html.includes("<html"), true);
+      assertEquals(html.includes("</html>"), true);
+    });
+  });
+});

--- a/src/server/services/rsc/orchestrators/render-handler.test.ts
+++ b/src/server/services/rsc/orchestrators/render-handler.test.ts
@@ -1,0 +1,72 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { RenderHandler } from "./render-handler.ts";
+
+describe("server/services/rsc/orchestrators/render-handler", () => {
+  describe("handle", () => {
+    it("returns error response when component is not found", async () => {
+      const handler = new RenderHandler(
+        "/tmp/nonexistent-project",
+        () => null,
+        false,
+      );
+
+      const response = await handler.handle("/nonexistent", new URLSearchParams());
+      // Should get an error response (component not found or renderer not initialized)
+      assertEquals(response.status >= 400, true);
+    });
+
+    it("returns error response when renderer is null", async () => {
+      // RenderHandler with a getRenderer that returns null
+      // The component path won't resolve, so we get "Component not found"
+      const handler = new RenderHandler(
+        "/tmp/nonexistent",
+        () => null,
+        false,
+      );
+
+      const response = await handler.handle("/some-page", new URLSearchParams());
+      assertEquals(response.status >= 400, true);
+      const body = await response.text();
+      // Should include error information
+      assertEquals(body.length > 0, true);
+    });
+
+    it("returns error response as JSON with proper content type", async () => {
+      const handler = new RenderHandler(
+        "/tmp/nonexistent",
+        () => null,
+        false,
+      );
+
+      const response = await handler.handle("/test", new URLSearchParams());
+      const contentType = response.headers.get("content-type");
+      // Error responses should be JSON
+      assertEquals(contentType?.includes("json") ?? false, true);
+    });
+
+    it("handles root pathname", async () => {
+      const handler = new RenderHandler(
+        "/tmp/nonexistent",
+        () => null,
+        false,
+      );
+
+      const response = await handler.handle("/", new URLSearchParams());
+      // Should fail gracefully since project doesn't exist
+      assertEquals(response.status >= 400, true);
+    });
+
+    it("handles pathname with search params", async () => {
+      const handler = new RenderHandler(
+        "/tmp/nonexistent",
+        () => null,
+        false,
+      );
+
+      const params = new URLSearchParams({ foo: "bar", baz: "qux" });
+      const response = await handler.handle("/page", params);
+      assertEquals(response.status >= 400, true);
+    });
+  });
+});

--- a/src/server/services/static/static-file.service.test.ts
+++ b/src/server/services/static/static-file.service.test.ts
@@ -1,9 +1,9 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it, afterEach } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
-  StaticFileService,
   __injectDepsForTests,
   type StaticFileOptions,
+  StaticFileService,
 } from "./static-file.service.ts";
 import type { FileSystemRepository } from "#veryfront/repositories/types.ts";
 

--- a/src/server/services/static/static-file.service.test.ts
+++ b/src/server/services/static/static-file.service.test.ts
@@ -1,0 +1,146 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it, afterEach } from "#veryfront/testing/bdd.ts";
+import {
+  StaticFileService,
+  __injectDepsForTests,
+  type StaticFileOptions,
+} from "./static-file.service.ts";
+import type { FileSystemRepository } from "#veryfront/repositories/types.ts";
+
+function makeOptions(overrides: Partial<StaticFileOptions> = {}): StaticFileOptions {
+  return {
+    projectDir: "/project",
+    adapter: {
+      fs: {
+        stat: async () => {
+          throw new Error("not found");
+        },
+        readFile: async () => "",
+        readFileBytes: async () => new Uint8Array(),
+        exists: async () => false,
+      },
+    } as any,
+    isPreviewMode: false,
+    isLocalProject: false,
+    ...overrides,
+  };
+}
+
+function createMockFsRepo(
+  files: Map<string, Uint8Array>,
+): FileSystemRepository {
+  return {
+    readFile: async (path: string) => {
+      const data = files.get(path);
+      if (!data) throw new Error("not found");
+      return new TextDecoder().decode(data);
+    },
+    readFileBytes: async (path: string) => {
+      const data = files.get(path);
+      if (!data) throw new Error("not found");
+      return data;
+    },
+    stat: async (path: string) => {
+      if (files.has(path)) {
+        return { isFile: true, isDirectory: false, mtime: new Date() };
+      }
+      throw new Error("not found");
+    },
+  } as unknown as FileSystemRepository;
+}
+
+afterEach(() => {
+  __injectDepsForTests(null);
+});
+
+describe("server/services/static/static-file.service", () => {
+  describe("StaticFileService", () => {
+    it("should be constructable without options", () => {
+      const service = new StaticFileService();
+      assertEquals(service instanceof StaticFileService, true);
+    });
+
+    it("should be constructable with FileSystemRepository", () => {
+      const repo = createMockFsRepo(new Map());
+      const service = new StaticFileService(repo);
+      assertEquals(service instanceof StaticFileService, true);
+    });
+  });
+
+  describe("resolveFile", () => {
+    it("should return null when file does not exist", async () => {
+      __injectDepsForTests({
+        manifestCache: new Map(),
+        manifestLoading: new Map(),
+      });
+
+      const service = new StaticFileService();
+      const options = makeOptions();
+      const result = await service.resolveFile("/nonexistent.txt", options);
+      assertEquals(result, null);
+    });
+
+    it("should resolve file from injected FileSystemRepository", async () => {
+      __injectDepsForTests({
+        manifestCache: new Map(),
+        manifestLoading: new Map(),
+      });
+
+      const fileData = new TextEncoder().encode("hello world");
+      const files = new Map<string, Uint8Array>([
+        ["/project/dist/test.txt", fileData],
+      ]);
+      const repo = createMockFsRepo(files);
+      const service = new StaticFileService(repo);
+      const options = makeOptions();
+
+      const result = await service.resolveFile("/test.txt", options);
+      if (result) {
+        assertEquals(result.source, "dist");
+        assertEquals(result.contentType.includes("text/plain"), true);
+        assertEquals(result.data, fileData);
+        assertEquals(typeof result.etag, "string");
+      }
+    });
+
+    it("should resolve file from public directory", async () => {
+      __injectDepsForTests({
+        manifestCache: new Map(),
+        manifestLoading: new Map(),
+      });
+
+      const fileData = new TextEncoder().encode("<svg></svg>");
+      const files = new Map<string, Uint8Array>([
+        ["/project/public/logo.svg", fileData],
+      ]);
+      const repo = createMockFsRepo(files);
+      const service = new StaticFileService(repo);
+      const options = makeOptions();
+
+      const result = await service.resolveFile("/logo.svg", options);
+      if (result) {
+        assertEquals(result.source, "public");
+      }
+    });
+
+    it("should normalize / to /index.html", async () => {
+      __injectDepsForTests({
+        manifestCache: new Map(),
+        manifestLoading: new Map(),
+      });
+
+      const fileData = new TextEncoder().encode("<html></html>");
+      const files = new Map<string, Uint8Array>([
+        ["/project/dist/index.html", fileData],
+      ]);
+      const repo = createMockFsRepo(files);
+      const service = new StaticFileService(repo);
+      const options = makeOptions();
+
+      const result = await service.resolveFile("/", options);
+      if (result) {
+        assertEquals(result.contentType.includes("html"), true);
+      }
+    });
+  });
+});

--- a/src/server/shared/renderer/memory/pressure.test.ts
+++ b/src/server/shared/renderer/memory/pressure.test.ts
@@ -1,0 +1,26 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { shouldRejectDueToMemory } from "./pressure.ts";
+
+describe("server/shared/renderer/memory/pressure", () => {
+  describe("shouldRejectDueToMemory", () => {
+    it("should return a boolean", () => {
+      const result = shouldRejectDueToMemory();
+      assertEquals(typeof result, "boolean");
+    });
+
+    it("should return false under normal memory conditions", () => {
+      // In a test environment, memory should not be critical
+      const result = shouldRejectDueToMemory();
+      assertEquals(result, false);
+    });
+
+    it("should be callable multiple times without error", () => {
+      // Ensure no state corruption between calls
+      const r1 = shouldRejectDueToMemory();
+      const r2 = shouldRejectDueToMemory();
+      assertEquals(typeof r1, "boolean");
+      assertEquals(typeof r2, "boolean");
+    });
+  });
+});

--- a/src/server/utils/domain-lookup.test.ts
+++ b/src/server/utils/domain-lookup.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
-import { getEnvironmentType } from "./domain-lookup.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { __injectCacheForTests, clearDomainCache, getEnvironmentType } from "./domain-lookup.ts";
 import type { DomainLookupResult } from "./domain-lookup.ts";
 
 function makeResult(envName: string | null): DomainLookupResult | null {
@@ -59,6 +59,70 @@ describe("server/utils/domain-lookup", () => {
 
     it("should return production for unrecognized env names", () => {
       assertEquals(getEnvironmentType(makeResult("custom")), "production");
+    });
+
+    it("should return production for env containing 'production' substring", () => {
+      assertEquals(getEnvironmentType(makeResult("my-production-env")), "production");
+    });
+
+    it("should return preview for env containing 'preview' substring", () => {
+      assertEquals(getEnvironmentType(makeResult("my-preview-env")), "preview");
+    });
+
+    it("should return preview for env containing 'staging' substring", () => {
+      assertEquals(getEnvironmentType(makeResult("staging-us-east")), "preview");
+    });
+
+    it("should return preview for env containing 'development' substring", () => {
+      assertEquals(getEnvironmentType(makeResult("development-local")), "preview");
+    });
+  });
+
+  describe("clearDomainCache", () => {
+    afterEach(() => {
+      __injectCacheForTests(null);
+    });
+
+    it("clears the cache without throwing", () => {
+      // Should not throw even when no injected cache
+      clearDomainCache();
+    });
+
+    it("clears injected cache repository", () => {
+      let clearCalled = false;
+      const mockRepo = {
+        get: () => Promise.resolve(null),
+        set: () => Promise.resolve(),
+        delete: () => Promise.resolve(),
+        clear: () => {
+          clearCalled = true;
+          return Promise.resolve();
+        },
+      };
+      __injectCacheForTests(mockRepo as any);
+      clearDomainCache();
+      assertEquals(clearCalled, true);
+    });
+  });
+
+  describe("__injectCacheForTests", () => {
+    afterEach(() => {
+      __injectCacheForTests(null);
+    });
+
+    it("can inject a mock cache repository", () => {
+      const mockRepo = {
+        get: () => Promise.resolve(null),
+        set: () => Promise.resolve(),
+        delete: () => Promise.resolve(),
+      };
+      // Should not throw
+      __injectCacheForTests(mockRepo as any);
+    });
+
+    it("can reset to null", () => {
+      __injectCacheForTests(null);
+      // Should not throw
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add **31 new test files** and extend **2 existing tests** for the server module
- Covers handlers (SSR, API, module), runtime-handler, RSC endpoints/orchestrators, services, schemas, and utilities
- All tests pass with 0 failures

## Test files added/extended
**Wave 1 (pure functions):** action.schema, path-validator, not-found-response, tracing, request-tracker, cors, pressure
**Wave 2 (moderate):** handler-registry, page-handler, component-resolver, manifest-handler, hydrator-handler, project-resolution, request-lifecycle, security-headers, ssr-response-builder
**Wave 3 (heavy):** ssr.handler, module.handler, error-page-fallback, not-found-fallback, action-handler, render-handler, ssr.service, static-file.service, pages-api-handler
**Gap filling:** Extended endpoint-router, domain-lookup + new tests for low-coverage files

## Test plan
- [x] All server tests pass (`deno test src/server/`)
- [x] No lint errors
- [x] No format issues