### PR TITLE
fix: add input validation and size limit to sandbox runInWorker

### DIFF
--- a/src/errors/types.ts
+++ b/src/errors/types.ts
@@ -43,6 +43,8 @@ export interface ErrorDefinition {
  * Options for creating an error instance
  */
 export interface ErrorCreateOptions {
+  /** Override the error message (defaults to detail or definition title) */
+  message?: string;
   detail?: string;
   cause?: unknown;
   instance?: string;
@@ -65,7 +67,7 @@ export function defineError(definition: ErrorDefinition): RegisteredError {
   return {
     ...definition,
     create(options?: ErrorCreateOptions): VeryfrontError {
-      return new VeryfrontError(options?.detail || definition.title, {
+      return new VeryfrontError(options?.message || options?.detail || definition.title, {
         slug: definition.slug,
         category: definition.category,
         status: options?.status ?? definition.status,

--- a/src/security/sandbox/constants.ts
+++ b/src/security/sandbox/constants.ts
@@ -1,1 +1,2 @@
 export const DEFAULT_SANDBOX_TIMEOUT_MS = 5000;
+export const MAX_SANDBOX_CODE_SIZE = 1_000_000; // 1 MB

--- a/src/security/sandbox/deno-sandbox.test.ts
+++ b/src/security/sandbox/deno-sandbox.test.ts
@@ -1,7 +1,35 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { isDeno } from "#veryfront/platform/compat/runtime.ts";
 import { runInWorker } from "./deno-sandbox.ts";
+import { MAX_SANDBOX_CODE_SIZE } from "./constants.ts";
+
+// Input validation tests work in all runtimes (no Worker needed)
+describe("deno-sandbox input validation", () => {
+  it("rejects empty code", () => {
+    assertThrows(
+      () => runInWorker(""),
+      Error,
+      "empty",
+    );
+  });
+
+  it("rejects non-string code", () => {
+    assertThrows(
+      () => runInWorker(123 as unknown as string),
+      Error,
+      "string",
+    );
+  });
+
+  it("rejects oversized code", () => {
+    assertThrows(
+      () => runInWorker("x".repeat(MAX_SANDBOX_CODE_SIZE + 1)),
+      Error,
+      "maximum size",
+    );
+  });
+});
 
 const testSuite = isDeno ? describe : describe.skip;
 

--- a/src/security/sandbox/deno-sandbox.test.ts
+++ b/src/security/sandbox/deno-sandbox.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { isDeno } from "#veryfront/platform/compat/runtime.ts";
 import { runInWorker } from "./deno-sandbox.ts";
@@ -6,25 +6,38 @@ import { MAX_SANDBOX_CODE_SIZE } from "./constants.ts";
 
 // Input validation tests work in all runtimes (no Worker needed)
 describe("deno-sandbox input validation", () => {
-  it("rejects empty code", () => {
-    assertThrows(
+  it("rejects empty code", async () => {
+    await assertRejects(
       () => runInWorker(""),
       Error,
       "empty",
     );
   });
 
-  it("rejects non-string code", () => {
-    assertThrows(
+  it("rejects non-string code", async () => {
+    await assertRejects(
       () => runInWorker(123 as unknown as string),
       Error,
       "string",
     );
   });
 
-  it("rejects oversized code", () => {
-    assertThrows(
+  it("rejects oversized code", async () => {
+    await assertRejects(
       () => runInWorker("x".repeat(MAX_SANDBOX_CODE_SIZE + 1)),
+      Error,
+      "maximum size",
+    );
+  });
+
+  it("enforces byte length not character count", async () => {
+    // 4-byte emoji repeated to exceed limit by byte count but not char count
+    const fourByteChar = "\u{1F600}"; // 😀 = 4 bytes in UTF-8
+    const count = Math.floor(MAX_SANDBOX_CODE_SIZE / 4) + 1;
+    const code = fourByteChar.repeat(count);
+    // code.length (UTF-16 units) = count * 2, but byte length > MAX_SANDBOX_CODE_SIZE
+    await assertRejects(
+      () => runInWorker(code),
       Error,
       "maximum size",
     );

--- a/src/security/sandbox/deno-sandbox.ts
+++ b/src/security/sandbox/deno-sandbox.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_SANDBOX_TIMEOUT_MS } from "./constants.ts";
+import { DEFAULT_SANDBOX_TIMEOUT_MS, MAX_SANDBOX_CODE_SIZE } from "./constants.ts";
 import { isCompiledBinary, serverLogger } from "#veryfront/utils";
 import { isDeno, isNode } from "#veryfront/platform/compat/runtime.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
@@ -20,6 +20,18 @@ type ExtendedWorkerOptions = WorkerOptions & {
 };
 
 export function runInWorker<T = unknown>(code: string, options: SandboxOptions = {}): Promise<T> {
+  if (typeof code !== "string") {
+    throw INVALID_ARGUMENT.create({ message: "Sandbox code must be a string" });
+  }
+  if (code.length === 0) {
+    throw INVALID_ARGUMENT.create({ message: "Sandbox code cannot be empty" });
+  }
+  if (code.length > MAX_SANDBOX_CODE_SIZE) {
+    throw INVALID_ARGUMENT.create({
+      message: `Sandbox code exceeds maximum size (${MAX_SANDBOX_CODE_SIZE} bytes)`,
+    });
+  }
+
   const timeoutMs = options.timeoutMs ?? DEFAULT_SANDBOX_TIMEOUT_MS;
 
   return withSpan(

--- a/src/security/sandbox/deno-sandbox.ts
+++ b/src/security/sandbox/deno-sandbox.ts
@@ -21,15 +21,16 @@ type ExtendedWorkerOptions = WorkerOptions & {
 
 export function runInWorker<T = unknown>(code: string, options: SandboxOptions = {}): Promise<T> {
   if (typeof code !== "string") {
-    throw INVALID_ARGUMENT.create({ message: "Sandbox code must be a string" });
+    return Promise.reject(INVALID_ARGUMENT.create({ message: "Sandbox code must be a string" }));
   }
   if (code.length === 0) {
-    throw INVALID_ARGUMENT.create({ message: "Sandbox code cannot be empty" });
+    return Promise.reject(INVALID_ARGUMENT.create({ message: "Sandbox code cannot be empty" }));
   }
-  if (code.length > MAX_SANDBOX_CODE_SIZE) {
-    throw INVALID_ARGUMENT.create({
+  const codeByteLength = new TextEncoder().encode(code).byteLength;
+  if (codeByteLength > MAX_SANDBOX_CODE_SIZE) {
+    return Promise.reject(INVALID_ARGUMENT.create({
       message: `Sandbox code exceeds maximum size (${MAX_SANDBOX_CODE_SIZE} bytes)`,
-    });
+    }));
   }
 
   const timeoutMs = options.timeoutMs ?? DEFAULT_SANDBOX_TIMEOUT_MS;


### PR DESCRIPTION
## Summary
- Adds input validation to `runInWorker` — rejects non-string, empty, and oversized (>1MB) code inputs before spawning a Worker
- Introduces `MAX_SANDBOX_CODE_SIZE` constant in `constants.ts` for consistent enforcement
- Adds `message` field to `ErrorCreateOptions` for explicit error messages (separate from RFC 9457 `detail`)
- Returns `Promise.reject` instead of sync throw so callers using `.catch()` handle validation errors consistently
- Uses `TextEncoder` to measure actual **byte length** instead of UTF-16 code units for the size limit

## Test plan
- [x] Rejects empty code (via `assertRejects`)
- [x] Rejects non-string code (via `assertRejects`)
- [x] Rejects oversized code (via `assertRejects`)
- [x] Enforces byte length — multibyte characters measured correctly
- [x] Existing sandbox Worker tests (execute, error, timeout) still pass
- [x] All error system tests pass with new `message` field
- [x] Full pre-push suite passes