### PR TITLE
fix: harden dashboard API against path traversal

### DIFF
--- a/src/server/handlers/dev/dashboard/api.test.ts
+++ b/src/server/handlers/dev/dashboard/api.test.ts
@@ -1,0 +1,76 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { handleDashboardAPI } from "./api.ts";
+import type { HandlerContext } from "../../types.ts";
+
+// Minimal mock adapter with fs that tracks readDir/readFile calls
+function createMockCtx(): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter: {
+      fs: {
+        readDir: async function* () {},
+        readFile: async () => new Uint8Array(),
+      },
+    },
+    securityConfig: null,
+    cspUserHeader: null,
+  } as unknown as HandlerContext;
+}
+
+describe("Dashboard API path validation", () => {
+  it("rejects path traversal with '..' in list files", async () => {
+    const req = new Request("http://localhost/_dev/api/files?path=../../etc/passwd");
+    const res = await handleDashboardAPI(req, createMockCtx());
+    assertEquals(res?.status, 400);
+    const body = await res!.json();
+    assertEquals(body.error.includes("Invalid path"), true);
+  });
+
+  it("rejects encoded path traversal in list files", async () => {
+    const req = new Request("http://localhost/_dev/api/files?path=%2e%2e%2f%2e%2e%2fetc%2fpasswd");
+    const res = await handleDashboardAPI(req, createMockCtx());
+    assertEquals(res?.status, 400);
+  });
+
+  it("rejects null bytes in list files", async () => {
+    const req = new Request("http://localhost/_dev/api/files?path=src%00.ts");
+    const res = await handleDashboardAPI(req, createMockCtx());
+    assertEquals(res?.status, 400);
+  });
+
+  it("allows valid relative paths in list files", async () => {
+    const req = new Request("http://localhost/_dev/api/files?path=src/components");
+    const res = await handleDashboardAPI(req, createMockCtx());
+    // Should succeed (200) since mock adapter returns empty readDir
+    assertEquals(res?.status, 200);
+  });
+
+  it("rejects path traversal in file-content", async () => {
+    const req = new Request("http://localhost/_dev/api/file-content?path=../../etc/passwd");
+    const res = await handleDashboardAPI(req, createMockCtx());
+    assertEquals(res?.status, 400);
+  });
+
+  it("rejects encoded path traversal in file-content", async () => {
+    const req = new Request(
+      "http://localhost/_dev/api/file-content?path=%2e%2e%2f%2e%2e%2fetc%2fpasswd",
+    );
+    const res = await handleDashboardAPI(req, createMockCtx());
+    assertEquals(res?.status, 400);
+  });
+
+  it("rejects null bytes in file-content", async () => {
+    const req = new Request("http://localhost/_dev/api/file-content?path=src%00.ts");
+    const res = await handleDashboardAPI(req, createMockCtx());
+    assertEquals(res?.status, 400);
+  });
+
+  it("requires path parameter for file-content", async () => {
+    const req = new Request("http://localhost/_dev/api/file-content");
+    const res = await handleDashboardAPI(req, createMockCtx());
+    assertEquals(res?.status, 400);
+    const body = await res!.json();
+    assertEquals(body.error, "path parameter is required");
+  });
+});

--- a/src/server/handlers/dev/dashboard/api.test.ts
+++ b/src/server/handlers/dev/dashboard/api.test.ts
@@ -66,6 +66,13 @@ describe("Dashboard API path validation", () => {
     assertEquals(res?.status, 400);
   });
 
+  it("allows filenames with percent signs (no double-decoding)", async () => {
+    const req = new Request("http://localhost/_dev/api/files?path=reports%2F100%25done");
+    const res = await handleDashboardAPI(req, createMockCtx());
+    // searchParams.get decodes to "reports/100%done" — should not fail
+    assertEquals(res?.status, 200);
+  });
+
   it("requires path parameter for file-content", async () => {
     const req = new Request("http://localhost/_dev/api/file-content");
     const res = await handleDashboardAPI(req, createMockCtx());

--- a/src/server/handlers/dev/dashboard/api.ts
+++ b/src/server/handlers/dev/dashboard/api.ts
@@ -28,6 +28,20 @@ import type { HandlerContext } from "../../types.ts";
 
 const WORKFLOW_EXECUTION_TIMEOUT_MS = 30_000;
 
+/** Validate a relative path for directory traversal, null bytes, and encoding tricks */
+function isValidRelativePath(path: string): boolean {
+  if (path.includes("\0")) return false;
+  // Decode to catch %2e%2e and similar encoding bypasses, then check for traversal
+  try {
+    const decoded = decodeURIComponent(path);
+    if (decoded.includes("..")) return false;
+    if (decoded.includes("\0")) return false;
+  } catch {
+    return false; // Malformed encoding
+  }
+  return true;
+}
+
 const JSON_HEADERS = {
   "Content-Type": "application/json",
   "Cache-Control": "no-cache",
@@ -386,7 +400,7 @@ async function handleListFiles(req: Request, ctx: HandlerContext): Promise<Respo
   if (!projectDir) return errorResponse("No project directory configured", 500);
 
   const relativePath = new URL(req.url).searchParams.get("path") ?? "";
-  if (relativePath.includes("..")) return errorResponse("Invalid path", 400);
+  if (!isValidRelativePath(relativePath)) return errorResponse("Invalid path", 400);
 
   const fullPath = relativePath ? `${projectDir}/${relativePath}` : projectDir;
 
@@ -422,7 +436,7 @@ async function handleReadFileContent(req: Request, ctx: HandlerContext): Promise
 
   const relativePath = new URL(req.url).searchParams.get("path") ?? "";
   if (!relativePath) return errorResponse("path parameter is required", 400);
-  if (relativePath.includes("..")) return errorResponse("Invalid path", 400);
+  if (!isValidRelativePath(relativePath)) return errorResponse("Invalid path", 400);
 
   try {
     const content = await adapter.fs.readFile(`${projectDir}/${relativePath}`);

--- a/src/server/handlers/dev/dashboard/api.ts
+++ b/src/server/handlers/dev/dashboard/api.ts
@@ -28,17 +28,11 @@ import type { HandlerContext } from "../../types.ts";
 
 const WORKFLOW_EXECUTION_TIMEOUT_MS = 30_000;
 
-/** Validate a relative path for directory traversal, null bytes, and encoding tricks */
+/** Validate a relative path for directory traversal and null bytes.
+ *  Note: searchParams.get() already percent-decodes, so no extra decoding needed. */
 function isValidRelativePath(path: string): boolean {
   if (path.includes("\0")) return false;
-  // Decode to catch %2e%2e and similar encoding bypasses, then check for traversal
-  try {
-    const decoded = decodeURIComponent(path);
-    if (decoded.includes("..")) return false;
-    if (decoded.includes("\0")) return false;
-  } catch {
-    return false; // Malformed encoding
-  }
+  if (path.includes("..")) return false;
   return true;
 }
 


### PR DESCRIPTION
## Summary
- Dashboard file listing and content endpoints only checked for literal `..` but could be bypassed with null bytes
- Added `isValidRelativePath()` that checks for `..` traversal and null bytes on the already-decoded path
- No double `decodeURIComponent` — `searchParams.get()` already percent-decodes, so filenames with `%` work correctly

## Test plan
- [x] Rejects `../../etc/passwd` in list files endpoint
- [x] Rejects `%2e%2e` encoded traversal in list files endpoint (decoded by searchParams)
- [x] Rejects null bytes in list files endpoint
- [x] Allows valid relative paths in list files endpoint
- [x] Allows filenames with percent signs (no double-decoding regression)
- [x] Rejects traversal and encoding attacks in file-content endpoint
- [x] Validates path parameter required for file-content
- [x] Full pre-push suite passes