### PR TITLE
fix: block getUnsafeAdapter() in production

### DIFF
--- a/src/security/secure-fs.test.ts
+++ b/src/security/secure-fs.test.ts
@@ -1,0 +1,57 @@
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createSecureFs } from "./secure-fs.ts";
+import { VeryfrontError } from "#veryfront/errors/types.ts";
+
+// Minimal adapter stub — only getUnsafeAdapter() is being tested
+function createMockAdapter() {
+  return { fs: {} } as any;
+}
+
+describe("SecureFs", () => {
+  describe("getUnsafeAdapter", () => {
+    it("throws in production", () => {
+      const originalEnv = Deno.env.get("NODE_ENV");
+      try {
+        Deno.env.set("NODE_ENV", "production");
+        const secureFs = createSecureFs({
+          baseDir: "/tmp",
+          adapter: createMockAdapter(),
+        });
+
+        assertThrows(
+          () => secureFs.getUnsafeAdapter(),
+          VeryfrontError,
+          "not allowed in production",
+        );
+      } finally {
+        if (originalEnv !== undefined) {
+          Deno.env.set("NODE_ENV", originalEnv);
+        } else {
+          Deno.env.delete("NODE_ENV");
+        }
+      }
+    });
+
+    it("returns adapter in development", () => {
+      const originalEnv = Deno.env.get("NODE_ENV");
+      try {
+        Deno.env.set("NODE_ENV", "development");
+        const adapter = createMockAdapter();
+        const secureFs = createSecureFs({
+          baseDir: "/tmp",
+          adapter,
+        });
+
+        const result = secureFs.getUnsafeAdapter();
+        assertEquals(result, adapter);
+      } finally {
+        if (originalEnv !== undefined) {
+          Deno.env.set("NODE_ENV", originalEnv);
+        } else {
+          Deno.env.delete("NODE_ENV");
+        }
+      }
+    });
+  });
+});

--- a/src/security/secure-fs.ts
+++ b/src/security/secure-fs.ts
@@ -15,6 +15,7 @@ import {
 } from "./path-validation.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { SECURITY_VIOLATION } from "#veryfront/errors/error-registry.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 const logger = baseLogger.component("secure-fs");
 
@@ -282,7 +283,7 @@ export class SecureFs {
   }
 
   getUnsafeAdapter(): RuntimeAdapter {
-    if (typeof Deno !== "undefined" && Deno.env.get("NODE_ENV") === "production") {
+    if (getHostEnv("NODE_ENV") === "production") {
       throw SECURITY_VIOLATION.create({
         detail: "getUnsafeAdapter() is not allowed in production",
       });

--- a/src/security/secure-fs.ts
+++ b/src/security/secure-fs.ts
@@ -282,6 +282,11 @@ export class SecureFs {
   }
 
   getUnsafeAdapter(): RuntimeAdapter {
+    if (typeof Deno !== "undefined" && Deno.env.get("NODE_ENV") === "production") {
+      throw SECURITY_VIOLATION.create({
+        detail: "getUnsafeAdapter() is not allowed in production",
+      });
+    }
     logger.warn("Using unsafe adapter - security checks bypassed!");
     return this.config.adapter;
   }


### PR DESCRIPTION
## Summary
- `getUnsafeAdapter()` bypasses all SecureFS path validation, which is dangerous if accidentally called in production
- Added production environment guard that throws `SECURITY_VIOLATION` when `NODE_ENV=production`
- Uses runtime-agnostic `getHostEnv()` from platform compat layer — works in Deno, Node, and Bun
- Method remains available in development/testing for legitimate use cases

## Test plan
- [x] Throws SECURITY_VIOLATION in production environment
- [x] Returns adapter normally in development environment
- [x] Full pre-push suite passes