### PR TITLE
fix: enforce TLS for non-localhost WebSocket connections

### DIFF
--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -157,4 +157,85 @@ describe("WebSocketManager", () => {
 
     manager.dispose();
   });
+
+  it("should upgrade ws:// to wss:// for non-localhost connections", () => {
+    const cache = {
+      deleteByPrefixAsync: async () => 0,
+      deleteByPrefixAndSuffixAsync: async () => 0,
+    } as unknown as FileCache;
+
+    const client = {
+      getProjectId: () => "project-1",
+      listAllFiles: async () => [],
+    } as unknown as VeryfrontApiClient;
+
+    const manager = new WebSocketManager({
+      apiBaseUrl: "http://api.example.com/api",
+      apiToken: "test-token",
+      projectSlug: "test-project",
+      cache,
+      client,
+      invalidationCallbacks: {},
+      getContentContext: () => ({
+        sourceType: "branch",
+        projectSlug: "test-project",
+        branch: "main",
+      }),
+      getContentSource: () => ({ type: "branch", branch: "main" }),
+      getProjectDir: () => undefined,
+      clearMemoryCaches: () => {},
+      clearFileListIndex: () => {},
+      setFileListCache: async () => {},
+    });
+
+    manager.connect("project-1");
+    const socket = MockWebSocket.instances.at(-1);
+    assertExists(socket);
+
+    // http:// should be upgraded to wss:// for non-localhost
+    assertEquals(socket.url.startsWith("wss://"), true);
+    assertEquals(socket.url.includes("token=test-token"), true);
+
+    manager.dispose();
+  });
+
+  it("should keep ws:// for localhost connections", () => {
+    const cache = {
+      deleteByPrefixAsync: async () => 0,
+      deleteByPrefixAndSuffixAsync: async () => 0,
+    } as unknown as FileCache;
+
+    const client = {
+      getProjectId: () => "project-1",
+      listAllFiles: async () => [],
+    } as unknown as VeryfrontApiClient;
+
+    const manager = new WebSocketManager({
+      apiBaseUrl: "http://localhost:8080/api",
+      apiToken: "test-token",
+      projectSlug: "test-project",
+      cache,
+      client,
+      invalidationCallbacks: {},
+      getContentContext: () => ({
+        sourceType: "branch",
+        projectSlug: "test-project",
+        branch: "main",
+      }),
+      getContentSource: () => ({ type: "branch", branch: "main" }),
+      getProjectDir: () => undefined,
+      clearMemoryCaches: () => {},
+      clearFileListIndex: () => {},
+      setFileListCache: async () => {},
+    });
+
+    manager.connect("project-1");
+    const socket = MockWebSocket.instances.at(-1);
+    assertExists(socket);
+
+    // localhost should stay as ws://
+    assertEquals(socket.url.startsWith("ws://"), true);
+
+    manager.dispose();
+  });
 });

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -238,4 +238,44 @@ describe("WebSocketManager", () => {
 
     manager.dispose();
   });
+
+  it("should keep ws:// for IPv6 loopback connections", () => {
+    const cache = {
+      deleteByPrefixAsync: async () => 0,
+      deleteByPrefixAndSuffixAsync: async () => 0,
+    } as unknown as FileCache;
+
+    const client = {
+      getProjectId: () => "project-1",
+      listAllFiles: async () => [],
+    } as unknown as VeryfrontApiClient;
+
+    const manager = new WebSocketManager({
+      apiBaseUrl: "http://[::1]:8080/api",
+      apiToken: "test-token",
+      projectSlug: "test-project",
+      cache,
+      client,
+      invalidationCallbacks: {},
+      getContentContext: () => ({
+        sourceType: "branch",
+        projectSlug: "test-project",
+        branch: "main",
+      }),
+      getContentSource: () => ({ type: "branch", branch: "main" }),
+      getProjectDir: () => undefined,
+      clearMemoryCaches: () => {},
+      clearFileListIndex: () => {},
+      setFileListCache: async () => {},
+    });
+
+    manager.connect("project-1");
+    const socket = MockWebSocket.instances.at(-1);
+    assertExists(socket);
+
+    // IPv6 loopback should stay as ws://
+    assertEquals(socket.url.startsWith("ws://"), true);
+
+    manager.dispose();
+  });
 });

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -95,7 +95,8 @@ export class WebSocketManager {
     if (wsUrl.startsWith("ws://")) {
       try {
         const host = new URL(wsUrl.replace(/^ws:/, "http:")).hostname;
-        const isLocal = host === "localhost" || host === "127.0.0.1" || host === "::1";
+        const isLocal = host === "localhost" || host === "127.0.0.1" ||
+          host === "::1" || host === "[::1]";
         if (!isLocal) {
           wsUrl = wsUrl.replace(/^ws:/, "wss:");
           logger.warn("Upgraded WebSocket connection to wss:// for non-localhost host", { host });

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -86,10 +86,26 @@ export class WebSocketManager {
       this.wsConsecutiveFailures = 0;
     }
 
-    const wsUrl = this.deps.apiBaseUrl
+    let wsUrl = this.deps.apiBaseUrl
       .replace(/^http:/, "ws:")
       .replace(/^https:/, "wss:")
       .replace(/\/api$/, "");
+
+    // Enforce TLS for non-localhost connections to protect the auth token
+    if (wsUrl.startsWith("ws://")) {
+      try {
+        const host = new URL(wsUrl.replace(/^ws:/, "http:")).hostname;
+        const isLocal = host === "localhost" || host === "127.0.0.1" || host === "::1";
+        if (!isLocal) {
+          wsUrl = wsUrl.replace(/^ws:/, "wss:");
+          logger.warn("Upgraded WebSocket connection to wss:// for non-localhost host", { host });
+        }
+      } catch {
+        // If URL parsing fails, upgrade to be safe
+        wsUrl = wsUrl.replace(/^ws:/, "wss:");
+      }
+    }
+
     const url = `${wsUrl}/ws/${projectId}/events?token=${this.deps.apiToken}`;
 
     logger.debug("Connecting to WebSocket", {


### PR DESCRIPTION
## Summary
- WebSocket connection carries auth token in URL query string, which was sent unencrypted when `apiBaseUrl` used `http://`
- Non-localhost `ws://` connections are now automatically upgraded to `wss://` to protect the token in transit
- Localhost exemption covers `localhost`, `127.0.0.1`, `::1`, and bracketed `[::1]` (as returned by `URL.hostname` for IPv6)

## Test plan
- [x] `ws://` upgraded to `wss://` for non-localhost hosts (e.g., `api.example.com`)
- [x] `ws://` preserved for localhost connections
- [x] `ws://` preserved for IPv6 loopback `[::1]` connections
- [x] Existing reconnect/backoff test passes unchanged
- [x] Full pre-push suite passes