### PR TITLE
fix: reduce noisy production logs

### DIFF
--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -153,12 +153,15 @@ export class WebSocketManager {
       };
 
       this.ws.onerror = (event) => {
-        logger.warn("WebSocket error", {
-          type: event.type,
-          url: (event.target as WebSocket)?.url?.replace(/token=[^&]+/, "token=***"),
-          readyState: (event.target as WebSocket)?.readyState,
-          consecutiveFailures: this.wsConsecutiveFailures,
-        });
+        // Only log the first error per reconnect cycle to avoid flooding logs.
+        // The onclose handler already schedules reconnection with backoff.
+        if (this.wsConsecutiveFailures === 0) {
+          logger.warn("WebSocket error", {
+            type: event.type,
+            url: (event.target as WebSocket)?.url?.replace(/token=[^&]+/, "token=***"),
+            readyState: (event.target as WebSocket)?.readyState,
+          });
+        }
       };
     } catch (error) {
       this.wsConsecutiveFailures++;

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -53,6 +53,7 @@ export class WebSocketManager {
 
   private wsConnectionId: string | null = null;
   private wsConsecutiveFailures = 0;
+  private wsErrorLogged = false;
   private disposed = false;
   private pokeMetrics = {
     received: 0,
@@ -117,6 +118,7 @@ export class WebSocketManager {
     try {
       this.ws = new WebSocket(url);
       this.wsConnectionId = crypto.randomUUID().slice(0, 8);
+      this.wsErrorLogged = false;
 
       this.ws.onopen = () => {
         this.wsConsecutiveFailures = 0;
@@ -153,13 +155,14 @@ export class WebSocketManager {
       };
 
       this.ws.onerror = (event) => {
-        // Only log the first error per reconnect cycle to avoid flooding logs.
-        // The onclose handler already schedules reconnection with backoff.
-        if (this.wsConsecutiveFailures === 0) {
+        // Log once per connection attempt to avoid flooding logs.
+        if (!this.wsErrorLogged) {
+          this.wsErrorLogged = true;
           logger.warn("WebSocket error", {
             type: event.type,
             url: (event.target as WebSocket)?.url?.replace(/token=[^&]+/, "token=***"),
             readyState: (event.target as WebSocket)?.readyState,
+            consecutiveFailures: this.wsConsecutiveFailures,
           });
         }
       };

--- a/src/platform/adapters/veryfront-api-client/retry-handler.ts
+++ b/src/platform/adapters/veryfront-api-client/retry-handler.ts
@@ -67,7 +67,10 @@ export async function requestWithRetry(
           if (!response.ok) {
             const text = await response.text();
 
-            veryfrontApiClientLog.error("Request failed", {
+            // 4xx = client errors (expected, e.g. 404 for missing deno.json) → warn
+            // 5xx = server errors (unexpected) → error
+            const logLevel = response.status >= 500 ? "error" : "warn";
+            veryfrontApiClientLog[logLevel]("Request failed", {
               url: url.replace(/token=[^&]+/, "token=***"),
               status: response.status,
               statusText: response.statusText,

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -336,7 +336,7 @@ export function createVeryfrontHandler(
             : null;
 
           if (missingHeader) {
-            logger.error(missingHeader.detail, {
+            logger.warn(missingHeader.detail, {
               pathname: url.pathname,
               domain,
               projectSlug: headers.projectSlug,


### PR DESCRIPTION
## Summary
- **WebSocket error spam**: Only log the first `onerror` per reconnect cycle at `warn` level; suppress subsequent duplicates. This was 88% of all log volume (~1,200 lines/hour from a single stuck connection logging every 5 seconds with empty `error={}`).
- **API client 404s as error**: Downgrade 4xx responses from `error` to `warn`. 404s for optional files like `deno.json` are expected and shouldn't pollute error-level logs. 5xx responses remain at `error`.
- **Missing proxy header as error**: Downgrade from `error` to `warn`. These are external bad requests (bots probing `/.git/config`), not server errors.

## Test plan
- [x] `deno check` passes on all three changed files
- [x] `retry-handler.test.ts` — all 21 tests pass
- [ ] Verify in Loki after deploy that log volume drops significantly