### PR TITLE
fix: protect LRU cache size tracking from onEvict callback errors

### DIFF
--- a/src/utils/cache/eviction/eviction-manager.ts
+++ b/src/utils/cache/eviction/eviction-manager.ts
@@ -1,3 +1,7 @@
+import { serverLogger } from "../../logger/logger.ts";
+
+const logger = serverLogger.component("cache");
+
 export interface EvictableEntry {
   size: number;
   timestamp?: number;
@@ -94,8 +98,11 @@ export class EvictionManager<TEntry extends EvictableEntry> {
 
     try {
       this.onEvict?.(node.key, node.entry.value);
-    } catch {
-      // Prevent onEvict errors from corrupting cache size tracking
+    } catch (error) {
+      logger.warn("onEvict callback threw during eviction", {
+        key: node.key,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
 
     return currentSize - node.entry.size;

--- a/src/utils/cache/eviction/eviction-manager.ts
+++ b/src/utils/cache/eviction/eviction-manager.ts
@@ -92,7 +92,11 @@ export class EvictionManager<TEntry extends EvictableEntry> {
       this.cleanupTags(tags, node.key, tagIndex);
     }
 
-    this.onEvict?.(node.key, node.entry.value);
+    try {
+      this.onEvict?.(node.key, node.entry.value);
+    } catch {
+      // Prevent onEvict errors from corrupting cache size tracking
+    }
 
     return currentSize - node.entry.size;
   }

--- a/src/utils/cache/stores/memory/lru-cache-adapter.test.ts
+++ b/src/utils/cache/stores/memory/lru-cache-adapter.test.ts
@@ -286,4 +286,45 @@ describe("LRUCacheAdapter", () => {
       expect(cache.get("buffer")).toEqual(buffer);
     });
   });
+
+  describe("onEvict error resilience", () => {
+    it("should not corrupt size tracking when onEvict throws", () => {
+      const throwingCache = new LRUCacheAdapter({
+        maxEntries: 2,
+        onEvict: () => {
+          throw new Error("onEvict error");
+        },
+      });
+
+      throwingCache.set("a", "value-a");
+      throwingCache.set("b", "value-b");
+      // This triggers eviction of "a" (oldest), onEvict throws but should be caught
+      throwingCache.set("c", "value-c");
+
+      // Cache should still function correctly
+      expect(throwingCache.get("c")).toBe("value-c");
+      const stats = throwingCache.getStats();
+      expect(stats.entries).toBe(2);
+      expect(stats.sizeBytes).toBeGreaterThan(0);
+    });
+
+    it("should maintain consistent size after onEvict throws during delete", () => {
+      const throwingCache = new LRUCacheAdapter({
+        maxEntries: 10,
+        onEvict: () => {
+          throw new Error("onEvict error");
+        },
+      });
+
+      throwingCache.set("a", "value-a");
+      const sizeBefore = throwingCache.getStats().sizeBytes;
+
+      // delete calls onEvict which throws, but size should still be decremented
+      throwingCache.delete("a");
+
+      expect(throwingCache.getStats().entries).toBe(0);
+      expect(throwingCache.getStats().sizeBytes).toBe(0);
+      expect(sizeBefore).toBeGreaterThan(0);
+    });
+  });
 });

--- a/src/utils/cache/stores/memory/lru-cache-adapter.ts
+++ b/src/utils/cache/stores/memory/lru-cache-adapter.ts
@@ -1,8 +1,11 @@
+import { serverLogger } from "../../../logger/logger.ts";
 import type { CacheAdapter, LRUCacheOptions, LRUCacheStats, LRUEntry } from "./types.ts";
 import { LRUNode } from "./lru-node.ts";
 import { LRUListManager } from "./lru-list-manager.ts";
 import { EvictionManager } from "../../eviction/eviction-manager.ts";
 import { EntryManager } from "./entry-manager.ts";
+
+const logger = serverLogger.component("cache");
 
 const MAX_ESTIMATION_DEPTH = 10;
 
@@ -141,8 +144,11 @@ export class LRUCacheAdapter implements CacheAdapter {
 
     try {
       this.onEvict?.(key, node.entry.value);
-    } catch {
-      // Prevent onEvict errors from corrupting cache size tracking
+    } catch (error) {
+      logger.warn("onEvict callback threw during delete", {
+        key,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 

--- a/src/utils/cache/stores/memory/lru-cache-adapter.ts
+++ b/src/utils/cache/stores/memory/lru-cache-adapter.ts
@@ -139,7 +139,11 @@ export class LRUCacheAdapter implements CacheAdapter {
 
     if (node.entry.tags) this.entryManager.cleanupTags(node.entry.tags, key, this.tagIndex);
 
-    this.onEvict?.(key, node.entry.value);
+    try {
+      this.onEvict?.(key, node.entry.value);
+    } catch {
+      // Prevent onEvict errors from corrupting cache size tracking
+    }
   }
 
   invalidateTag(tag: string): number {


### PR DESCRIPTION
## Summary
- Wraps `onEvict` callbacks in try-catch in both `LRUCacheAdapter.delete()` and `EvictionManager.evictLRUFromList()` to prevent thrown errors from corrupting internal size tracking
- Without this fix, an onEvict error would skip the size decrement, causing the cache to believe it has more entries than it does
- Logs caught errors via `logger.warn` so they're visible for debugging

## Test plan
- [x] Added tests in `src/utils/cache/stores/memory/lru-cache-adapter.test.ts`
- [x] Test: throwing onEvict during eviction doesn't corrupt size
- [x] Test: throwing onEvict during delete maintains consistency
- [x] All 1120+ unit tests pass