### PR TITLE
fix: add null check for directBlock in markdown block drag handler

### DIFF
--- a/src/studio/bridge/bridge-block-drag.ts
+++ b/src/studio/bridge/bridge-block-drag.ts
@@ -279,9 +279,11 @@ export function getMarkdownBlockHoverIndexFromPointer(
   }
 
   const directBlock = getMarkdownBlockElementFromNode(targetNode);
-  const directIndex = blocks.indexOf(directBlock!);
-  if (directIndex >= 0) {
-    return directIndex;
+  if (directBlock) {
+    const directIndex = blocks.indexOf(directBlock);
+    if (directIndex >= 0) {
+      return directIndex;
+    }
   }
 
   if (!state.markdownEditorSurface) {


### PR DESCRIPTION
## Summary
- Adds null guard for `directBlock` before calling `blocks.indexOf(directBlock!)` in `bridge-block-drag.ts`
- Previously, `getMarkdownBlockElementFromNode()` could return null, and the non-null assertion would cause `indexOf` to search for null, returning -1

## Test plan
- [x] Browser/studio code — no unit tests (DOM-dependent)
- [x] All 1120+ unit tests pass (no regressions)