### PR TITLE
fix: log async cache backfill errors instead of silencing them

### DIFF
--- a/src/cache/multi-tier.ts
+++ b/src/cache/multi-tier.ts
@@ -174,7 +174,11 @@ export class MultiTierCache<T = string> {
         );
 
         if (this.config.asyncBackfill) {
-          void Promise.all(setOps).catch(() => {});
+          void Promise.all(setOps).catch((err) => {
+            logger.warn(`[${this.config.name}] Cache backfill failed`, {
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
           return;
         }
 


### PR DESCRIPTION
## Summary
- Replaces `.catch(() => {})` with `.catch(err => logger.warn(...))` in `MultiTierCache.set()` for async backfill operations
- Previously, errors during async cache writes were completely swallowed, making debugging cache issues impossible

## Test plan
- [x] All 1120+ unit tests pass (no regressions)