### PR TITLE
fix: log transform rejections instead of silencing them in SSR loader

### DIFF
--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -479,9 +479,14 @@ export class SSRModuleLoader {
       resolveTransform = resolve;
       rejectTransform = reject;
     });
-    // Attach no-op catch to prevent unhandled rejection when waiters timeout
+    // Attach catch to prevent unhandled rejection when waiters timeout
     // and stop listening. The actual error is thrown to the caller directly.
-    transformPromise.catch(() => {});
+    transformPromise.catch((err) => {
+      logger.debug("Transform rejected (waiters may have timed out)", {
+        key: inProgressKey,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
     globalInProgress.set(inProgressKey, transformPromise);
 
     try {


### PR DESCRIPTION
## Summary
- Replaces `.catch(() => {})` with `.catch(err => logger.debug(...))` for transform promise rejections in the SSR module loader
- Previously, when a transform was rejected (e.g., due to waiters timing out), the error was completely swallowed

## Test plan
- [x] All 1120+ unit tests pass (no regressions)