### PR TITLE
fix: log fallback content source failures instead of silencing them

### DIFF
--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -589,7 +589,13 @@ export class ReadOperations {
 
     // Mark all promises as handled to prevent unhandled rejection errors
     // when we return early after a high-priority success (skipping lower-priority promises).
-    for (const p of promises) p.catch(() => {});
+    for (const p of promises) {
+      p.catch((err) => {
+        logger.debug("Fallback attempt failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
 
     // Await in priority order: return as soon as highest-priority succeeds
     for (const promise of promises) {


### PR DESCRIPTION
## Summary
- Replaces `.catch(() => {})` with `.catch(err => logger.debug(...))` for fallback content source promises in read-operations
- Previously, when a fallback source failed, the error was completely swallowed, making it impossible to diagnose content loading issues

## Test plan
- [x] All 1120+ unit tests pass (no regressions)