### PR TITLE
fix: prevent stale request context in WebSocket logs and optimize file-list resolution

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/platform/adapters/fs/veryfront/file-list-index.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-index.ts
@@ -22,7 +22,6 @@ const INDEX_STALENESS_LIMIT_MS = 5 * 60 * 1000; // 5 minutes
 
 export class FileListIndex {
   private index: Map<string, string> | null = null;
-  private knownPaths: Set<string> | null = null;
   private indexKey: string | null = null;
   private indexBuiltAt = 0;
   private readyPromise: Promise<void> | null = null;
@@ -36,15 +35,13 @@ export class FileListIndex {
   }
 
   clear(): void {
-    if (!this.index && !this.knownPaths) return;
+    if (!this.index) return;
 
-    const indexedWithContent = this.index?.size ?? 0;
-    const knownPathCount = this.knownPaths?.size ?? 0;
+    const indexedWithContent = this.index.size;
     this.index = null;
-    this.knownPaths = null;
     this.indexKey = null;
     this.indexBuiltAt = 0;
-    logger.debug("Cleared file list index", { indexedWithContent, knownPathCount });
+    logger.debug("Cleared file list index", { indexedWithContent });
   }
 
   private async ensureReady(): Promise<void> {
@@ -84,27 +81,6 @@ export class FileListIndex {
     });
 
     return content;
-  }
-
-  async hasPath(normalizedPath: string): Promise<boolean | undefined> {
-    await this.ensureReady();
-
-    const index = await this.getOrBuild();
-    if (!index) return undefined;
-
-    return this.knownPaths?.has(normalizedPath) ?? undefined;
-  }
-
-  async hasAnyPath(normalizedPaths: string[]): Promise<boolean | undefined> {
-    await this.ensureReady();
-
-    const index = await this.getOrBuild();
-    if (!index) return undefined;
-
-    const knownPaths = this.knownPaths;
-    if (!knownPaths) return undefined;
-
-    return normalizedPaths.some((path) => knownPaths.has(path));
   }
 
   async findFirstWithContent(
@@ -150,7 +126,6 @@ export class FileListIndex {
           staleLimitMs: INDEX_STALENESS_LIMIT_MS,
         });
         this.index = null;
-        this.knownPaths = null;
         this.indexKey = null;
       }
       logger.debug(
@@ -177,14 +152,11 @@ export class FileListIndex {
     }
 
     const index = new Map<string, string>();
-    const knownPaths = new Set<string>();
     for (const file of fileList) {
-      knownPaths.add(file.path);
       if (file.content) index.set(file.path, file.content);
     }
 
     this.index = index;
-    this.knownPaths = knownPaths;
     this.indexKey = indexKey;
     this.indexBuiltAt = Date.now();
 
@@ -193,7 +165,6 @@ export class FileListIndex {
     logger.debug("Built file list index", {
       fileListSize: fileList.length,
       indexedWithContent: index.size,
-      knownPathCount: knownPaths.size,
       sampleFilePath: sampleFile?.path,
       sampleContentLength: sampleContent?.length,
       sampleContentHash: sampleContent ? hashPreview(sampleContent) : undefined,

--- a/src/platform/adapters/fs/veryfront/file-list-index.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-index.ts
@@ -22,6 +22,7 @@ const INDEX_STALENESS_LIMIT_MS = 5 * 60 * 1000; // 5 minutes
 
 export class FileListIndex {
   private index: Map<string, string> | null = null;
+  private knownPaths: Set<string> | null = null;
   private indexKey: string | null = null;
   private indexBuiltAt = 0;
   private readyPromise: Promise<void> | null = null;
@@ -35,16 +36,18 @@ export class FileListIndex {
   }
 
   clear(): void {
-    if (!this.index) return;
+    if (!this.index && !this.knownPaths) return;
 
-    const size = this.index.size;
+    const indexedWithContent = this.index?.size ?? 0;
+    const knownPathCount = this.knownPaths?.size ?? 0;
     this.index = null;
+    this.knownPaths = null;
     this.indexKey = null;
     this.indexBuiltAt = 0;
-    logger.debug("Cleared file list index", { entriesCleared: size });
+    logger.debug("Cleared file list index", { indexedWithContent, knownPathCount });
   }
 
-  async lookup(normalizedPath: string): Promise<string | undefined> {
+  private async ensureReady(): Promise<void> {
     if (this.readyPromise) {
       try {
         await this.readyPromise;
@@ -53,6 +56,10 @@ export class FileListIndex {
         logger.debug("File list initialization failed, will fetch individually");
       }
     }
+  }
+
+  async lookup(normalizedPath: string): Promise<string | undefined> {
+    await this.ensureReady();
 
     const index = await this.getOrBuild();
     if (!index) {
@@ -77,6 +84,43 @@ export class FileListIndex {
     });
 
     return content;
+  }
+
+  async hasPath(normalizedPath: string): Promise<boolean | undefined> {
+    await this.ensureReady();
+
+    const index = await this.getOrBuild();
+    if (!index) return undefined;
+
+    return this.knownPaths?.has(normalizedPath) ?? undefined;
+  }
+
+  async hasAnyPath(normalizedPaths: string[]): Promise<boolean | undefined> {
+    await this.ensureReady();
+
+    const index = await this.getOrBuild();
+    if (!index) return undefined;
+
+    const knownPaths = this.knownPaths;
+    if (!knownPaths) return undefined;
+
+    return normalizedPaths.some((path) => knownPaths.has(path));
+  }
+
+  async findFirstWithContent(
+    normalizedPaths: string[],
+  ): Promise<{ path: string; content: string } | undefined> {
+    await this.ensureReady();
+
+    const index = await this.getOrBuild();
+    if (!index) return undefined;
+
+    for (const path of normalizedPaths) {
+      const content = index.get(path);
+      if (content) return { path, content };
+    }
+
+    return undefined;
   }
 
   private async getOrBuild(): Promise<Map<string, string> | null> {
@@ -106,6 +150,7 @@ export class FileListIndex {
           staleLimitMs: INDEX_STALENESS_LIMIT_MS,
         });
         this.index = null;
+        this.knownPaths = null;
         this.indexKey = null;
       }
       logger.debug(
@@ -132,11 +177,14 @@ export class FileListIndex {
     }
 
     const index = new Map<string, string>();
+    const knownPaths = new Set<string>();
     for (const file of fileList) {
+      knownPaths.add(file.path);
       if (file.content) index.set(file.path, file.content);
     }
 
     this.index = index;
+    this.knownPaths = knownPaths;
     this.indexKey = indexKey;
     this.indexBuiltAt = Date.now();
 
@@ -145,6 +193,7 @@ export class FileListIndex {
     logger.debug("Built file list index", {
       fileListSize: fileList.length,
       indexedWithContent: index.size,
+      knownPathCount: knownPaths.size,
       sampleFilePath: sampleFile?.path,
       sampleContentLength: sampleContent?.length,
       sampleContentHash: sampleContent ? hashPreview(sampleContent) : undefined,

--- a/src/platform/adapters/fs/veryfront/invalidation-state.test.ts
+++ b/src/platform/adapters/fs/veryfront/invalidation-state.test.ts
@@ -43,6 +43,27 @@ describe("veryfront/invalidation-state", () => {
     clearAllPendingInvalidations();
   });
 
+  it("keeps blocking until overlapping invalidations are fully removed", () => {
+    clearAllPendingInvalidations();
+
+    const prefix = "file:branch:project-a:main";
+    addPendingInvalidation(prefix);
+    addPendingInvalidation(prefix);
+
+    assertEquals(getPendingInvalidationsCount(), 1);
+    assertEquals(isPrefixBeingInvalidated(`${prefix}:pages/index.tsx`), true);
+
+    removePendingInvalidation(prefix);
+    assertEquals(getPendingInvalidationsCount(), 1);
+    assertEquals(isPrefixBeingInvalidated(`${prefix}:pages/index.tsx`), true);
+
+    removePendingInvalidation(prefix);
+    assertEquals(getPendingInvalidationsCount(), 0);
+    assertEquals(isPrefixBeingInvalidated(`${prefix}:pages/index.tsx`), false);
+
+    clearAllPendingInvalidations();
+  });
+
   it("cleans up stale invalidations and avoids blocking after stale timeout", () => {
     clearAllPendingInvalidations();
 

--- a/src/platform/adapters/fs/veryfront/invalidation-state.ts
+++ b/src/platform/adapters/fs/veryfront/invalidation-state.ts
@@ -8,7 +8,7 @@ const CLEANUP_INTERVAL_MS = 30 * 1000;
 let lastCleanupTime = 0;
 let totalBlockedReads = 0;
 
-const pendingInvalidations = new Map<string, number>();
+const pendingInvalidations = new Map<string, { startedAt: number; count: number }>();
 
 function cleanupStaleInvalidations(): void {
   const now = Date.now();
@@ -18,7 +18,8 @@ function cleanupStaleInvalidations(): void {
 
   const staleEntries: Array<{ prefix: string; ageMs: number }> = [];
 
-  for (const [prefix, startedAt] of pendingInvalidations) {
+  for (const [prefix, entry] of pendingInvalidations) {
+    const { startedAt } = entry;
     const ageMs = now - startedAt;
     if (ageMs <= STALE_INVALIDATION_THRESHOLD_MS) continue;
 
@@ -37,24 +38,41 @@ function cleanupStaleInvalidations(): void {
 
 export function addPendingInvalidation(prefix: string): void {
   const startedAt = Date.now();
-  pendingInvalidations.set(prefix, startedAt);
+  const existing = pendingInvalidations.get(prefix);
+  pendingInvalidations.set(prefix, {
+    startedAt: existing?.startedAt ?? startedAt,
+    count: (existing?.count ?? 0) + 1,
+  });
+
+  const count = pendingInvalidations.get(prefix)?.count ?? 1;
 
   logger.info("INVALIDATION_STARTED - cache prefix marked for invalidation", {
     prefix,
     startedAt,
+    count,
     totalPending: pendingInvalidations.size,
   });
 }
 
 export function removePendingInvalidation(prefix: string): void {
-  const startedAt = pendingInvalidations.get(prefix);
-  const durationMs = startedAt != null ? Date.now() - startedAt : null;
+  const entry = pendingInvalidations.get(prefix);
+  const durationMs = entry != null ? Date.now() - entry.startedAt : null;
 
-  pendingInvalidations.delete(prefix);
+  if (entry && entry.count > 1) {
+    pendingInvalidations.set(prefix, {
+      startedAt: entry.startedAt,
+      count: entry.count - 1,
+    });
+  } else {
+    pendingInvalidations.delete(prefix);
+  }
+
+  const remainingCount = pendingInvalidations.get(prefix)?.count ?? 0;
 
   logger.info("INVALIDATION_COMPLETED - cache prefix invalidation finished", {
     prefix,
     durationMs,
+    remainingCount,
     totalPending: pendingInvalidations.size,
   });
 }
@@ -62,16 +80,17 @@ export function removePendingInvalidation(prefix: string): void {
 export function isPrefixBeingInvalidated(prefix: string): boolean {
   cleanupStaleInvalidations();
 
-  for (const [pendingPrefix, startedAt] of pendingInvalidations) {
+  for (const [pendingPrefix, entry] of pendingInvalidations) {
     if (!prefix.startsWith(pendingPrefix) && !pendingPrefix.startsWith(prefix)) continue;
 
-    const ageMs = Date.now() - startedAt;
+    const ageMs = Date.now() - entry.startedAt;
     totalBlockedReads++;
 
     logger.info("CACHE_READ_BLOCKED - preventing stale cache read", {
       requestedPrefix: prefix,
       blockingPrefix: pendingPrefix,
       invalidationAgeMs: ageMs,
+      blockingCount: entry.count,
       totalBlockedReads,
       totalPending: pendingInvalidations.size,
     });
@@ -89,17 +108,18 @@ export function getPendingInvalidationsCount(): number {
 export function getInvalidationDebugState(): {
   pendingCount: number;
   totalBlockedReads: number;
-  entries: Array<{ prefix: string; ageMs: number; startedAt: number }>;
+  entries: Array<{ prefix: string; ageMs: number; startedAt: number; count: number }>;
 } {
   const now = Date.now();
 
   return {
     pendingCount: pendingInvalidations.size,
     totalBlockedReads,
-    entries: Array.from(pendingInvalidations, ([prefix, startedAt]) => ({
+    entries: Array.from(pendingInvalidations, ([prefix, entry]) => ({
       prefix,
-      startedAt,
-      ageMs: now - startedAt,
+      startedAt: entry.startedAt,
+      ageMs: now - entry.startedAt,
+      count: entry.count,
     })),
   };
 }

--- a/src/platform/adapters/fs/veryfront/read-operations-helpers.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations-helpers.ts
@@ -50,8 +50,8 @@ export function buildReadFetchState(options: BuildReadFetchStateOptions): ReadFe
   const cacheKey = `${cacheKeyPrefix}:${normalizedPath}`;
   const isProduction = contextProvider?.isProductionMode() ?? false;
   const releaseId = contentContext?.releaseId;
-  const isPrefixInvalidated =
-    (isProduction && contextProvider?.isPersistentCacheInvalidated?.(cacheKeyPrefix)) ?? false;
+  const isPrefixInvalidated = contextProvider?.isPersistentCacheInvalidated?.(cacheKeyPrefix) ??
+    false;
   const isReleaseInvalidated = isProduction && releaseId
     ? contextProvider?.isReleaseBeingInvalidated?.(releaseId)
     : undefined;

--- a/src/platform/adapters/fs/veryfront/read-operations.test.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
 import { FileCache } from "../cache/file-cache.ts";
@@ -370,7 +370,7 @@ describe("ReadOperations", () => {
       assertEquals(apiFetchCount, 0);
     });
 
-    it("should short-circuit known-missing explicit files like deno.json from file list cache", async () => {
+    it("should fall back to API for explicit dotted files missing from file list cache", async () => {
       let resolveCallCount = 0;
       let apiFetchCount = 0;
 
@@ -395,13 +395,11 @@ describe("ReadOperations", () => {
 
       readOps.setFileListReadyPromise(Promise.resolve());
 
-      await assertRejects(
-        () => readOps.readTextFile("deno.json"),
-        Error,
-        "404 Not Found",
-      );
-      assertEquals(resolveCallCount, 0);
-      assertEquals(apiFetchCount, 0);
+      const content = await readOps.readTextFile("deno.json");
+
+      assertEquals(content, "published API content");
+      assertEquals(resolveCallCount, 1);
+      assertEquals(apiFetchCount, 1);
     });
 
     it("should cache extension resolution to avoid repeated API calls", async () => {
@@ -834,6 +832,110 @@ describe("ReadOperations", () => {
       assertEquals(content, "fresh api content");
       assertEquals(fileListCalls, 0);
       assertEquals(fetchedApiPath, "api-source/pages/index.tsx");
+    });
+
+    it("should skip extensionless file-list lookups during invalidation", async () => {
+      let fileListCalls = 0;
+      let resolveCallCount = 0;
+      const client = createMockClient({
+        resolveFileWithExtension: () => {
+          resolveCallCount++;
+          return Promise.resolve({
+            path: "pages/home.tsx",
+            content: "fresh resolved content",
+          });
+        },
+      });
+
+      const contextProvider: ContentContextProvider = {
+        isProductionMode: () => true,
+        getReleaseId: () => "rel-extensionless-invalidation",
+        getContentContext: () => ({
+          sourceType: "release" as const,
+          projectSlug: "test",
+          releaseId: "rel-extensionless-invalidation",
+        }),
+        isPersistentCacheInvalidated: () => true,
+        isReleaseBeingInvalidated: () => false,
+      };
+
+      const readOps = new ReadOperations(
+        client,
+        new FileCache({ enabled: true, ttl: 60000, maxSize: 100 }),
+        new PathNormalizer(),
+        contextProvider,
+        (path: string) => path,
+        () => {
+          fileListCalls++;
+          return Promise.resolve([
+            { path: "pages/home.tsx", content: "stale file-list content" },
+          ]);
+        },
+      );
+
+      readOps.setFileListReadyPromise(Promise.resolve());
+
+      const content = await readOps.readTextFile("pages/home");
+      assertEquals(content, "fresh resolved content");
+      assertEquals(fileListCalls, 0);
+      assertEquals(resolveCallCount, 1);
+    });
+
+    it("should skip extension resolution cache reads and writes during invalidation", async () => {
+      let invalidated = false;
+      let resolveCallCount = 0;
+      const cache = new FileCache({ enabled: true, ttl: 60000, maxSize: 100 });
+      const client = createMockClient({
+        resolveFileWithExtension: () => {
+          resolveCallCount++;
+          return Promise.resolve({
+            path: "pages/home.tsx",
+            content: resolveCallCount === 1 ? "cached resolved content" : "fresh resolved content",
+          });
+        },
+      });
+
+      const contextProvider: ContentContextProvider = {
+        isProductionMode: () => true,
+        getReleaseId: () => "rel-resolve-invalidation",
+        getContentContext: () => ({
+          sourceType: "release" as const,
+          projectSlug: "test",
+          releaseId: "rel-resolve-invalidation",
+        }),
+        isPersistentCacheInvalidated: () => invalidated,
+        isReleaseBeingInvalidated: () => false,
+      };
+
+      const readOps = new ReadOperations(
+        client,
+        cache,
+        new PathNormalizer(),
+        contextProvider,
+      );
+
+      readOps.setFileListReadyPromise(Promise.resolve());
+
+      const warmed = await readOps.readTextFile("pages/home");
+      assertEquals(warmed, "cached resolved content");
+      assertEquals(
+        cache.get("file:release:test:rel-resolve-invalidation:pages/home"),
+        "cached resolved content",
+      );
+
+      invalidated = true;
+
+      const refreshed = await readOps.readTextFile("pages/home");
+      assertEquals(refreshed, "fresh resolved content");
+      assertEquals(resolveCallCount, 2);
+      assertEquals(
+        cache.get("file:release:test:rel-resolve-invalidation:pages/home"),
+        "cached resolved content",
+      );
+      assertEquals(
+        cache.get("file:release:test:rel-resolve-invalidation:pages/home.tsx"),
+        "cached resolved content",
+      );
     });
 
     it("should track invalidation state changes", () => {

--- a/src/platform/adapters/fs/veryfront/read-operations.test.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
 import { FileCache } from "../cache/file-cache.ts";
@@ -333,6 +333,75 @@ describe("ReadOperations", () => {
       assertEquals(publishedFetchCount, 0);
       assertEquals(resolveBasePath, "pages/home");
       assertEquals(resolveExtensions, [".tsx", ".ts", ".jsx", ".js", ".mdx", ".md"]);
+    });
+
+    it("should resolve extensionless dotted paths directly from file list cache", async () => {
+      let resolveCallCount = 0;
+      let apiFetchCount = 0;
+
+      const client = createMockClient({
+        resolveFileWithExtension: () => {
+          resolveCallCount++;
+          return Promise.resolve({
+            path: "pages/home.v2.tsx",
+            content: "resolved via api",
+          });
+        },
+        getPublishedFileContent: () => {
+          apiFetchCount++;
+          return Promise.resolve("published API content");
+        },
+      });
+
+      const readOps = createReadOps(
+        client,
+        true,
+        createReleaseContext("rel-file-list-resolve"),
+        (path: string) => path,
+        () => Promise.resolve([{ path: "pages/home.v2.tsx", content: "resolved from file list" }]),
+      );
+
+      readOps.setFileListReadyPromise(Promise.resolve());
+
+      const content = await readOps.readTextFile("pages/home.v2");
+
+      assertEquals(content, "resolved from file list");
+      assertEquals(resolveCallCount, 0);
+      assertEquals(apiFetchCount, 0);
+    });
+
+    it("should short-circuit known-missing explicit files like deno.json from file list cache", async () => {
+      let resolveCallCount = 0;
+      let apiFetchCount = 0;
+
+      const client = createMockClient({
+        resolveFileWithExtension: () => {
+          resolveCallCount++;
+          return Promise.resolve(null);
+        },
+        getPublishedFileContent: () => {
+          apiFetchCount++;
+          return Promise.resolve("published API content");
+        },
+      });
+
+      const readOps = createReadOps(
+        client,
+        true,
+        createReleaseContext("rel-missing-deno-json"),
+        (path: string) => path,
+        () => Promise.resolve([{ path: "pages/index.tsx", content: "home page" }]),
+      );
+
+      readOps.setFileListReadyPromise(Promise.resolve());
+
+      await assertRejects(
+        () => readOps.readTextFile("deno.json"),
+        Error,
+        "404 Not Found",
+      );
+      assertEquals(resolveCallCount, 0);
+      assertEquals(apiFetchCount, 0);
     });
 
     it("should cache extension resolution to avoid repeated API calls", async () => {

--- a/src/platform/adapters/fs/veryfront/read-operations.test.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.test.ts
@@ -881,6 +881,95 @@ describe("ReadOperations", () => {
       assertEquals(resolveCallCount, 1);
     });
 
+    it("should skip preview file-list cache reads while branch invalidation is pending", async () => {
+      let fileListCalls = 0;
+      let fileFetchCount = 0;
+      const client = createMockClient({
+        getFileContent: () => {
+          fileFetchCount++;
+          return Promise.resolve("fresh draft content");
+        },
+      });
+
+      const contextProvider: ContentContextProvider = {
+        isProductionMode: () => false,
+        getReleaseId: () => null,
+        getContentContext: () => ({
+          sourceType: "branch" as const,
+          projectSlug: "test",
+          branch: "main",
+        }),
+        isPersistentCacheInvalidated: () => true,
+      };
+
+      const readOps = new ReadOperations(
+        client,
+        new FileCache({ enabled: true, ttl: 60000, maxSize: 100 }),
+        new PathNormalizer(),
+        contextProvider,
+        (path: string) => path,
+        () => {
+          fileListCalls++;
+          return Promise.resolve([
+            { path: "pages/home.tsx", content: "stale file-list content" },
+          ]);
+        },
+      );
+
+      readOps.setFileListReadyPromise(Promise.resolve());
+
+      const content = await readOps.readTextFile("pages/home.tsx");
+      assertEquals(content, "fresh draft content");
+      assertEquals(fileListCalls, 0);
+      assertEquals(fileFetchCount, 1);
+    });
+
+    it("should skip preview extensionless file-list lookups while branch invalidation is pending", async () => {
+      let fileListCalls = 0;
+      let resolveCallCount = 0;
+      const client = createMockClient({
+        resolveFileWithExtension: () => {
+          resolveCallCount++;
+          return Promise.resolve({
+            path: "pages/home.tsx",
+            content: "fresh resolved content",
+          });
+        },
+      });
+
+      const contextProvider: ContentContextProvider = {
+        isProductionMode: () => false,
+        getReleaseId: () => null,
+        getContentContext: () => ({
+          sourceType: "branch" as const,
+          projectSlug: "test",
+          branch: "main",
+        }),
+        isPersistentCacheInvalidated: () => true,
+      };
+
+      const readOps = new ReadOperations(
+        client,
+        new FileCache({ enabled: true, ttl: 60000, maxSize: 100 }),
+        new PathNormalizer(),
+        contextProvider,
+        (path: string) => path,
+        () => {
+          fileListCalls++;
+          return Promise.resolve([
+            { path: "pages/home.tsx", content: "stale file-list content" },
+          ]);
+        },
+      );
+
+      readOps.setFileListReadyPromise(Promise.resolve());
+
+      const content = await readOps.readTextFile("pages/home");
+      assertEquals(content, "fresh resolved content");
+      assertEquals(fileListCalls, 0);
+      assertEquals(resolveCallCount, 1);
+    });
+
     it("should skip extension resolution cache reads and writes during invalidation", async () => {
       let invalidated = false;
       let resolveCallCount = 0;

--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -352,7 +352,12 @@ export class ReadOperations {
         resolvedCacheKey: resolvedCacheKey === cacheKey ? undefined : resolvedCacheKey,
       });
 
-      this.cacheResolvedContent(cacheKey, resolvedCacheKey, resolved.content, isProduction && !skipPersistentCaches);
+      this.cacheResolvedContent(
+        cacheKey,
+        resolvedCacheKey,
+        resolved.content,
+        isProduction && !skipPersistentCaches,
+      );
 
       return resolved.content;
     } catch (error) {

--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -352,15 +352,7 @@ export class ReadOperations {
         resolvedCacheKey: resolvedCacheKey === cacheKey ? undefined : resolvedCacheKey,
       });
 
-      if (isProduction && !skipPersistentCaches) {
-        this.cache.set(cacheKey, resolved.content);
-        if (resolvedCacheKey !== cacheKey) this.cache.set(resolvedCacheKey, resolved.content);
-      }
-
-      setRequestScopedFile(cacheKey, resolved.content);
-      if (resolvedCacheKey !== cacheKey) {
-        setRequestScopedFile(resolvedCacheKey, resolved.content);
-      }
+      this.cacheResolvedContent(cacheKey, resolvedCacheKey, resolved.content, isProduction && !skipPersistentCaches);
 
       return resolved.content;
     } catch (error) {
@@ -402,17 +394,25 @@ export class ReadOperations {
       resolvedCacheKey: resolvedCacheKey === cacheKey ? undefined : resolvedCacheKey,
     });
 
-    if (isProduction) {
-      this.cache.set(cacheKey, resolved.content);
-      if (resolvedCacheKey !== cacheKey) this.cache.set(resolvedCacheKey, resolved.content);
-    }
-
-    setRequestScopedFile(cacheKey, resolved.content);
-    if (resolvedCacheKey !== cacheKey) {
-      setRequestScopedFile(resolvedCacheKey, resolved.content);
-    }
+    this.cacheResolvedContent(cacheKey, resolvedCacheKey, resolved.content, isProduction);
 
     return resolved.content;
+  }
+
+  private cacheResolvedContent(
+    cacheKey: string,
+    resolvedCacheKey: string,
+    content: string,
+    persistToCache: boolean,
+  ): void {
+    if (persistToCache) {
+      this.cache.set(cacheKey, content);
+      if (resolvedCacheKey !== cacheKey) this.cache.set(resolvedCacheKey, content);
+    }
+    setRequestScopedFile(cacheKey, content);
+    if (resolvedCacheKey !== cacheKey) {
+      setRequestScopedFile(resolvedCacheKey, content);
+    }
   }
 
   private async fetchContent(normalizedPath: string): Promise<string> {

--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -55,11 +55,6 @@ function previewText(content: string, max = 80): string {
   return content.length > max ? `${content.slice(0, max)}...` : content;
 }
 
-function hasExplicitExtension(path: string): boolean {
-  const lastSegment = path.split("/").pop() ?? path;
-  return lastSegment.includes(".") && lastSegment !== "." && lastSegment !== "..";
-}
-
 export class ReadOperations {
   private readonly inFlightRequests = new InFlightRequestDeduper<string>({
     timeoutMs: IN_FLIGHT_REQUEST_TIMEOUT_MS,
@@ -317,20 +312,23 @@ export class ReadOperations {
     cacheKeyPrefix: string,
     cacheKey: string,
     isProduction: boolean,
+    skipPersistentCaches: boolean,
   ): Promise<string | null> {
     // Check extension resolution cache first to skip the API call entirely.
     // Once we know pages/home → pages/home.tsx, we never need to ask the API again.
-    const cachedResolvedPath = this.extensionResolutionCache.get(apiPath);
-    if (cachedResolvedPath) {
-      const resolvedCacheKey = getResolvedCacheKey(cacheKeyPrefix, cachedResolvedPath);
-      const cached = this.cache.get<string>(resolvedCacheKey) ?? this.cache.get<string>(cacheKey);
-      if (cached) {
-        logger.debug("Extension resolution cache hit", {
-          basePath: apiPath,
-          resolvedPath: cachedResolvedPath,
-        });
-        setRequestScopedFile(cacheKey, cached);
-        return cached;
+    if (!skipPersistentCaches) {
+      const cachedResolvedPath = this.extensionResolutionCache.get(apiPath);
+      if (cachedResolvedPath) {
+        const resolvedCacheKey = getResolvedCacheKey(cacheKeyPrefix, cachedResolvedPath);
+        const cached = this.cache.get<string>(resolvedCacheKey) ?? this.cache.get<string>(cacheKey);
+        if (cached) {
+          logger.debug("Extension resolution cache hit", {
+            basePath: apiPath,
+            resolvedPath: cachedResolvedPath,
+          });
+          setRequestScopedFile(cacheKey, cached);
+          return cached;
+        }
       }
     }
 
@@ -354,7 +352,7 @@ export class ReadOperations {
         resolvedCacheKey: resolvedCacheKey === cacheKey ? undefined : resolvedCacheKey,
       });
 
-      if (isProduction) {
+      if (isProduction && !skipPersistentCaches) {
         this.cache.set(cacheKey, resolved.content);
         if (resolvedCacheKey !== cacheKey) this.cache.set(resolvedCacheKey, resolved.content);
       }
@@ -480,28 +478,16 @@ export class ReadOperations {
     if (fileListCached) return fileListCached;
 
     if (!hasKnownExt) {
-      const resolvedFromFileList = await this.tryResolveExtensionlessPathFromFileList(
-        normalizedPath,
-        cacheKeyPrefix,
-        cacheKey,
-        isProduction,
-        ctx,
-        isPreviewMode,
-      );
-      if (resolvedFromFileList) return resolvedFromFileList;
-
-      if (!skipPersistentCaches && hasExplicitExtension(apiPath)) {
-        const exactPathKnown = await this.fileListIndex.hasPath(normalizedPath);
-        const hasExtensionCandidate = await this.fileListIndex.hasAnyPath(
-          EXTENSION_PRIORITY.map((ext) => `${normalizedPath}${ext}`),
+      if (!skipPersistentCaches) {
+        const resolvedFromFileList = await this.tryResolveExtensionlessPathFromFileList(
+          normalizedPath,
+          cacheKeyPrefix,
+          cacheKey,
+          isProduction,
+          ctx,
+          isPreviewMode,
         );
-
-        if (exactPathKnown === false && hasExtensionCandidate === false) {
-          logger.debug("Known-missing explicit path in file list, skipping API fetch", {
-            path: normalizedPath,
-          });
-          throw new Error(`404 Not Found: ${normalizedPath}`);
-        }
+        if (resolvedFromFileList) return resolvedFromFileList;
       }
 
       const resolved = await this.tryResolveExtensionlessPath(
@@ -509,6 +495,7 @@ export class ReadOperations {
         cacheKeyPrefix,
         cacheKey,
         isProduction,
+        skipPersistentCaches,
       );
       if (resolved) return resolved;
     }

--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -55,6 +55,11 @@ function previewText(content: string, max = 80): string {
   return content.length > max ? `${content.slice(0, max)}...` : content;
 }
 
+function hasExplicitExtension(path: string): boolean {
+  const lastSegment = path.split("/").pop() ?? path;
+  return lastSegment.includes(".") && lastSegment !== "." && lastSegment !== "..";
+}
+
 export class ReadOperations {
   private readonly inFlightRequests = new InFlightRequestDeduper<string>({
     timeoutMs: IN_FLIGHT_REQUEST_TIMEOUT_MS,
@@ -369,6 +374,49 @@ export class ReadOperations {
     }
   }
 
+  private async tryResolveExtensionlessPathFromFileList(
+    normalizedPath: string,
+    cacheKeyPrefix: string,
+    cacheKey: string,
+    isProduction: boolean,
+    ctx: ResolvedContentContext | null,
+    isPreviewMode: boolean,
+  ): Promise<string | null> {
+    const candidatePaths = EXTENSION_PRIORITY.map((ext) => `${normalizedPath}${ext}`);
+    const resolved = await this.fileListIndex.findFirstWithContent(candidatePaths);
+    if (!resolved) return null;
+
+    const resolvedCacheKey = getResolvedCacheKey(cacheKeyPrefix, resolved.path);
+
+    this.extensionResolutionCache.set(normalizedPath, resolved.path);
+
+    logContentMetric("FILE_LIST_HIT", {
+      path: normalizedPath,
+      resolvedPath: resolved.path,
+      mode: ctx?.sourceType ?? "unknown",
+      cacheKey,
+      isPreviewMode,
+    });
+    logger.debug("Resolved extension from file list index", {
+      basePath: normalizedPath,
+      resolvedPath: resolved.path,
+      cacheKey,
+      resolvedCacheKey: resolvedCacheKey === cacheKey ? undefined : resolvedCacheKey,
+    });
+
+    if (isProduction) {
+      this.cache.set(cacheKey, resolved.content);
+      if (resolvedCacheKey !== cacheKey) this.cache.set(resolvedCacheKey, resolved.content);
+    }
+
+    setRequestScopedFile(cacheKey, resolved.content);
+    if (resolvedCacheKey !== cacheKey) {
+      setRequestScopedFile(resolvedCacheKey, resolved.content);
+    }
+
+    return resolved.content;
+  }
+
   private async fetchContent(normalizedPath: string): Promise<string> {
     // Framework paths should NEVER be fetched from API - they must be read from local filesystem.
     // If we reach here for a framework path, the module server's local resolution failed.
@@ -432,6 +480,30 @@ export class ReadOperations {
     if (fileListCached) return fileListCached;
 
     if (!hasKnownExt) {
+      const resolvedFromFileList = await this.tryResolveExtensionlessPathFromFileList(
+        normalizedPath,
+        cacheKeyPrefix,
+        cacheKey,
+        isProduction,
+        ctx,
+        isPreviewMode,
+      );
+      if (resolvedFromFileList) return resolvedFromFileList;
+
+      if (!skipPersistentCaches && hasExplicitExtension(apiPath)) {
+        const exactPathKnown = await this.fileListIndex.hasPath(normalizedPath);
+        const hasExtensionCandidate = await this.fileListIndex.hasAnyPath(
+          EXTENSION_PRIORITY.map((ext) => `${normalizedPath}${ext}`),
+        );
+
+        if (exactPathKnown === false && hasExtensionCandidate === false) {
+          logger.debug("Known-missing explicit path in file list, skipping API fetch", {
+            path: normalizedPath,
+          });
+          throw new Error(`404 Not Found: ${normalizedPath}`);
+        }
+      }
+
       const resolved = await this.tryResolveExtensionlessPath(
         apiPath,
         cacheKeyPrefix,

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -4,6 +4,7 @@ import type { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
 import type { FileCache } from "../cache/file-cache.ts";
 import type { InvalidationCallbacks } from "./types.ts";
 import { WebSocketManager } from "./websocket-manager.ts";
+import { __resetLoggerConfigForTests } from "#veryfront/utils/logger/logger.ts";
 
 interface TimerEntry {
   delay: number;
@@ -36,6 +37,45 @@ class MockWebSocket {
   emitClose(): void {
     this.readyState = MockWebSocket.CLOSED;
     this.onclose?.call(this as unknown as WebSocket, new CloseEvent("close"));
+  }
+}
+
+function captureConsoleMethod(
+  method: "debug" | "warn",
+): { getOutput: () => string; reset: () => void; restore: () => void } {
+  const original = console[method];
+  let capturedOutput = "";
+
+  console[method] = ((msg: string) => {
+    capturedOutput = msg;
+  }) as typeof console[typeof method];
+
+  return {
+    getOutput: () => capturedOutput,
+    reset: () => {
+      capturedOutput = "";
+    },
+    restore: () => {
+      console[method] = original;
+    },
+  };
+}
+
+function withJsonLogFormat<T>(fn: () => T): T {
+  const previousLogFormat = Deno.env.get("LOG_FORMAT");
+  const previousLogLevel = Deno.env.get("LOG_LEVEL");
+  Deno.env.set("LOG_FORMAT", "json");
+  Deno.env.set("LOG_LEVEL", "DEBUG");
+  __resetLoggerConfigForTests();
+
+  try {
+    return fn();
+  } finally {
+    if (previousLogFormat == null) Deno.env.delete("LOG_FORMAT");
+    else Deno.env.set("LOG_FORMAT", previousLogFormat);
+    if (previousLogLevel == null) Deno.env.delete("LOG_LEVEL");
+    else Deno.env.set("LOG_LEVEL", previousLogLevel);
+    __resetLoggerConfigForTests();
   }
 }
 
@@ -290,6 +330,80 @@ describe("WebSocketManager", () => {
       manager.dispose();
     } finally {
       (globalThis as any).WebSocket = OriginalMockWebSocket;
+    }
+  });
+
+  it("should include projectSlug in connection lifecycle logs", () => {
+    const debugCapture = captureConsoleMethod("debug");
+    const warnCapture = captureConsoleMethod("warn");
+
+    try {
+      withJsonLogFormat(() => {
+        const manager = createWebSocketManager();
+        manager.connect("project-1");
+
+        const connectEntry = JSON.parse(debugCapture.getOutput()) as {
+          message: string;
+          projectSlug?: string;
+        };
+        assertEquals(connectEntry.message, "Connecting to WebSocket");
+        assertEquals(connectEntry.projectSlug, "test-project");
+
+        const socket = MockWebSocket.instances[0];
+        assertExists(socket);
+
+        debugCapture.reset();
+        socket.emitClose();
+
+        const closeEntry = JSON.parse(debugCapture.getOutput()) as {
+          message: string;
+          projectSlug?: string;
+        };
+        assertEquals(closeEntry.message, "WebSocket closed, reconnecting");
+        assertEquals(closeEntry.projectSlug, "test-project");
+
+        warnCapture.reset();
+        socket.onerror?.call(socket as unknown as WebSocket, new Event("error"));
+
+        const errorEntry = JSON.parse(warnCapture.getOutput()) as {
+          message: string;
+          projectSlug?: string;
+        };
+        assertEquals(errorEntry.message, "WebSocket error");
+        assertEquals(errorEntry.projectSlug, "test-project");
+
+        manager.dispose();
+      });
+    } finally {
+      debugCapture.restore();
+      warnCapture.restore();
+    }
+  });
+
+  it("should include projectSlug when WebSocket connection setup fails", () => {
+    const warnCapture = captureConsoleMethod("warn");
+    const OriginalMockWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = function () {
+      throw new Error("Connection failed");
+    };
+
+    try {
+      withJsonLogFormat(() => {
+        const manager = createWebSocketManager();
+        manager.connect("project-1");
+
+        const entry = JSON.parse(warnCapture.getOutput()) as {
+          message: string;
+          projectSlug?: string;
+        };
+        assertEquals(entry.message, "Failed to connect WebSocket");
+        assertEquals(entry.projectSlug, "test-project");
+
+        manager.dispose();
+      });
+    } finally {
+      (globalThis as any).WebSocket = OriginalMockWebSocket;
+      warnCapture.restore();
     }
   });
 

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -186,7 +186,9 @@ describe("WebSocketManager", () => {
     manager.connect("project-1");
     assertEquals(MockWebSocket.instances.length, 1);
     manager.dispose();
-    assertEquals(MockWebSocket.instances[0].readyState, MockWebSocket.CLOSED);
+    const socket = MockWebSocket.instances[0];
+    assertExists(socket);
+    assertEquals(socket.readyState, MockWebSocket.CLOSED);
   });
 
   it("should set connection ID after connect", () => {

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -57,6 +57,8 @@ export class WebSocketManager {
   private wsConsecutiveFailures = 0;
   private wsErrorLogged = false;
   private disposed = false;
+  private previewInvalidationVersion = 0;
+  private activePreviewInvalidationPrefixes = new Set<string>();
   private pokeMetrics = {
     received: 0,
     invalidationsTriggered: 0,
@@ -64,6 +66,41 @@ export class WebSocketManager {
   };
 
   constructor(private readonly deps: WebSocketDeps) {}
+
+  private getConnectionLogContext(context: Record<string, unknown> = {}): Record<string, unknown> {
+    if (!this.deps.projectSlug) return context;
+    return { projectSlug: this.deps.projectSlug, ...context };
+  }
+
+  private getPreviewInvalidationPrefixes(
+    contentContext: ResolvedContentContext | null,
+  ): string[] {
+    if (contentContext?.sourceType !== "branch") return [];
+    return [buildFileCacheKeyPrefix(contentContext)];
+  }
+
+  private beginPreviewInvalidation(contentContext: ResolvedContentContext | null): void {
+    const prefixes = this.getPreviewInvalidationPrefixes(contentContext);
+    if (prefixes.length === 0) return;
+
+    this.previewInvalidationVersion++;
+
+    for (const prefix of prefixes) {
+      if (this.activePreviewInvalidationPrefixes.has(prefix)) continue;
+      addPendingInvalidation(prefix);
+      this.activePreviewInvalidationPrefixes.add(prefix);
+    }
+  }
+
+  private completePreviewInvalidation(prefixes: string[], version: number): void {
+    if (prefixes.length === 0) return;
+    if (version !== this.previewInvalidationVersion) return;
+
+    for (const prefix of prefixes) {
+      if (!this.activePreviewInvalidationPrefixes.delete(prefix)) continue;
+      removePendingInvalidation(prefix);
+    }
+  }
 
   getPokeMetrics(): {
     received: number;
@@ -102,7 +139,10 @@ export class WebSocketManager {
           host === "::1" || host === "[::1]";
         if (!isLocal) {
           wsUrl = wsUrl.replace(/^ws:/, "wss:");
-          logger.warn("Upgraded WebSocket connection to wss:// for non-localhost host", { host });
+          logger.warn(
+            "Upgraded WebSocket connection to wss:// for non-localhost host",
+            this.getConnectionLogContext({ host }),
+          );
         }
       } catch {
         // If URL parsing fails, upgrade to be safe
@@ -112,10 +152,13 @@ export class WebSocketManager {
 
     const url = `${wsUrl}/ws/${projectId}/events?token=${this.deps.apiToken}`;
 
-    logger.debug("Connecting to WebSocket", {
-      url: url.replace(this.deps.apiToken, "***"),
-      consecutiveFailures: this.wsConsecutiveFailures,
-    });
+    logger.debug(
+      "Connecting to WebSocket",
+      this.getConnectionLogContext({
+        url: url.replace(this.deps.apiToken, "***"),
+        consecutiveFailures: this.wsConsecutiveFailures,
+      }),
+    );
 
     try {
       this.ws = new WebSocket(url);
@@ -124,12 +167,15 @@ export class WebSocketManager {
 
       this.ws.onopen = () => {
         this.wsConsecutiveFailures = 0;
-        logger.debug("WebSocket connected to events channel", {
-          projectId,
-          connectionId: this.wsConnectionId,
-          contentSource: this.deps.getContentSource(),
-          branch: this.deps.getContentContext()?.branch,
-        });
+        logger.debug(
+          "WebSocket connected to events channel",
+          this.getConnectionLogContext({
+            projectId,
+            connectionId: this.wsConnectionId,
+            contentSource: this.deps.getContentSource(),
+            branch: this.deps.getContentContext()?.branch,
+          }),
+        );
         this.wsLastPong = Date.now();
         this.startHeartbeat(projectId);
       };
@@ -148,11 +194,14 @@ export class WebSocketManager {
 
         this.wsConsecutiveFailures++;
         const delay = this.getReconnectDelay();
-        logger.debug("WebSocket closed, reconnecting", {
-          delayMs: delay,
-          totalPokesReceived: this.pokeMetrics.received,
-          consecutiveFailures: this.wsConsecutiveFailures,
-        });
+        logger.debug(
+          "WebSocket closed, reconnecting",
+          this.getConnectionLogContext({
+            delayMs: delay,
+            totalPokesReceived: this.pokeMetrics.received,
+            consecutiveFailures: this.wsConsecutiveFailures,
+          }),
+        );
         this.wsReconnectTimer = setTimeout(() => this.connect(projectId), delay);
       };
 
@@ -160,21 +209,27 @@ export class WebSocketManager {
         // Log once per connection attempt to avoid flooding logs.
         if (!this.wsErrorLogged) {
           this.wsErrorLogged = true;
-          logger.warn("WebSocket error", {
-            type: event.type,
-            url: (event.target as WebSocket)?.url?.replace(/token=[^&]+/, "token=***"),
-            readyState: (event.target as WebSocket)?.readyState,
-            consecutiveFailures: this.wsConsecutiveFailures,
-          });
+          logger.warn(
+            "WebSocket error",
+            this.getConnectionLogContext({
+              type: event.type,
+              url: (event.target as WebSocket)?.url?.replace(/token=[^&]+/, "token=***"),
+              readyState: (event.target as WebSocket)?.readyState,
+              consecutiveFailures: this.wsConsecutiveFailures,
+            }),
+          );
         }
       };
     } catch (error) {
       this.wsConsecutiveFailures++;
       const delay = this.getReconnectDelay();
-      logger.warn("Failed to connect WebSocket", {
-        error,
-        consecutiveFailures: this.wsConsecutiveFailures,
-      });
+      logger.warn(
+        "Failed to connect WebSocket",
+        this.getConnectionLogContext({
+          error,
+          consecutiveFailures: this.wsConsecutiveFailures,
+        }),
+      );
       this.wsReconnectTimer = setTimeout(() => this.connect(projectId), delay);
     }
   }
@@ -347,6 +402,7 @@ export class WebSocketManager {
         pokeEnvironmentName: normalizedPokeEnvironment,
       });
 
+      this.beginPreviewInvalidation(contentContext);
       this.deps.invalidationCallbacks.clearDomainCache?.();
       this.deps.clearMemoryCaches();
       logger.debug("All in-memory caches cleared immediately on POKE");
@@ -509,247 +565,273 @@ export class WebSocketManager {
     this.pendingChangedPaths.clear();
 
     const contentContext = this.deps.getContentContext();
+    const previewInvalidationPrefixes = this.getPreviewInvalidationPrefixes(contentContext);
+    const previewInvalidationVersion = this.previewInvalidationVersion;
+    let succeeded = false;
 
-    logger.debug("Performing selective invalidation", {
-      changedPaths,
-      count: changedPaths.length,
-    });
+    try {
+      logger.debug("Performing selective invalidation", {
+        changedPaths,
+        count: changedPaths.length,
+      });
 
-    const sourceTypes = ["branch:", "release:", "env:"] as const;
-    const fileTypes = ["file:", "stat:"] as const;
+      const sourceTypes = ["branch:", "release:", "env:"] as const;
+      const fileTypes = ["file:", "stat:"] as const;
 
-    const parentDirs = new Set<string>();
-    const deletionPromises: Promise<number>[] = [];
+      const parentDirs = new Set<string>();
+      const deletionPromises: Promise<number>[] = [];
 
-    for (const path of changedPaths) {
-      const slashIndex = path.lastIndexOf("/");
-      parentDirs.add(slashIndex > 0 ? path.substring(0, slashIndex) : "");
+      for (const path of changedPaths) {
+        const slashIndex = path.lastIndexOf("/");
+        parentDirs.add(slashIndex > 0 ? path.substring(0, slashIndex) : "");
 
-      for (const fileType of fileTypes) {
+        for (const fileType of fileTypes) {
+          for (const sourceType of sourceTypes) {
+            deletionPromises.push(
+              this.deps.cache.deleteByPrefixAndSuffixAsync(fileType + sourceType, path),
+            );
+          }
+        }
+      }
+
+      for (const parentDir of parentDirs) {
         for (const sourceType of sourceTypes) {
           deletionPromises.push(
-            this.deps.cache.deleteByPrefixAndSuffixAsync(fileType + sourceType, path),
+            this.deps.cache.deleteByPrefixAndSuffixAsync("dir:" + sourceType, parentDir),
           );
         }
       }
-    }
 
-    for (const parentDir of parentDirs) {
-      for (const sourceType of sourceTypes) {
-        deletionPromises.push(
-          this.deps.cache.deleteByPrefixAndSuffixAsync("dir:" + sourceType, parentDir),
+      await Promise.all(deletionPromises);
+
+      logger.debug("Cache entries deleted for changed paths", {
+        changedPaths,
+        parentDirs: Array.from(parentDirs),
+        prefixes: ["file:", "stat:", "dir:"],
+      });
+
+      this.deps.invalidationCallbacks.invalidateModulePaths?.(changedPaths);
+
+      const projectId = this.deps.client.getProjectId();
+      logger.debug("Clearing SSR module cache for HMR", {
+        changedPaths,
+        projectId,
+        usePerProject: !!this.deps.invalidationCallbacks.clearSSRModuleCacheForProject,
+      });
+
+      if (this.deps.invalidationCallbacks.clearSSRModuleCacheForProject && projectId) {
+        this.deps.invalidationCallbacks.clearSSRModuleCacheForProject(projectId);
+      } else {
+        this.deps.invalidationCallbacks.clearSSRModuleCache?.();
+      }
+
+      if (this.deps.invalidationCallbacks.clearRendererCacheForProject && projectId) {
+        await this.deps.invalidationCallbacks.clearRendererCacheForProject(projectId);
+      }
+
+      if (this.deps.invalidationCallbacks.clearProjectCSSCache && this.deps.projectSlug) {
+        this.deps.invalidationCallbacks.clearProjectCSSCache(this.deps.projectSlug);
+      }
+
+      if (contentContext?.sourceType === "branch") {
+        await this.deps.cache.deleteByPrefixAsync("files:branch:");
+        try {
+          const files = await this.deps.client.listAllFiles();
+          const cacheKey = buildFileListCacheKey(contentContext);
+          await this.deps.setFileListCache(cacheKey, files);
+          this.deps.clearFileListIndex();
+
+          logger.debug("Fresh files cached (memory + Redis)", {
+            cacheKey,
+            fileCount: files.length,
+          });
+        } catch (error) {
+          logger.warn("Failed to fetch files during selective invalidation", {
+            error,
+          });
+        }
+      }
+
+      this.pokeMetrics.invalidationsTriggered++;
+
+      logger.info(
+        "[WebSocketManager] TRIGGERING HMR RELOAD via invalidationCallbacks.triggerReload",
+        {
+          changedPaths,
+          projectSlug: this.deps.projectSlug,
+          projectId: this.deps.client.getProjectId(),
+          hasTriggerReloadCallback: !!this.deps.invalidationCallbacks.triggerReload,
+        },
+      );
+
+      const environment: "preview" | "production" = contentContext?.sourceType === "branch"
+        ? "preview"
+        : "production";
+      const projectContext = {
+        projectSlug: this.deps.projectSlug,
+        projectId: this.deps.client.getProjectId(),
+        environment,
+        branch: contentContext?.branch ?? null,
+        releaseId: contentContext?.releaseId ?? null,
+      };
+
+      this.deps.invalidationCallbacks.triggerReload?.(changedPaths, projectContext);
+
+      logger.info("Selective invalidation complete - HMR triggered", {
+        changedPaths,
+        durationMs: Date.now() - startTime,
+        totalInvalidations: this.pokeMetrics.invalidationsTriggered,
+      });
+
+      this.sendPokeAck("selective", changedPaths);
+      succeeded = true;
+    } finally {
+      if (succeeded) {
+        this.completePreviewInvalidation(
+          previewInvalidationPrefixes,
+          previewInvalidationVersion,
         );
       }
     }
-
-    await Promise.all(deletionPromises);
-
-    logger.debug("Cache entries deleted for changed paths", {
-      changedPaths,
-      parentDirs: Array.from(parentDirs),
-      prefixes: ["file:", "stat:", "dir:"],
-    });
-
-    this.deps.invalidationCallbacks.invalidateModulePaths?.(changedPaths);
-
-    const projectId = this.deps.client.getProjectId();
-    logger.debug("Clearing SSR module cache for HMR", {
-      changedPaths,
-      projectId,
-      usePerProject: !!this.deps.invalidationCallbacks.clearSSRModuleCacheForProject,
-    });
-
-    if (this.deps.invalidationCallbacks.clearSSRModuleCacheForProject && projectId) {
-      this.deps.invalidationCallbacks.clearSSRModuleCacheForProject(projectId);
-    } else {
-      this.deps.invalidationCallbacks.clearSSRModuleCache?.();
-    }
-
-    if (this.deps.invalidationCallbacks.clearRendererCacheForProject && projectId) {
-      await this.deps.invalidationCallbacks.clearRendererCacheForProject(projectId);
-    }
-
-    if (this.deps.invalidationCallbacks.clearProjectCSSCache && this.deps.projectSlug) {
-      this.deps.invalidationCallbacks.clearProjectCSSCache(this.deps.projectSlug);
-    }
-
-    if (contentContext?.sourceType === "branch") {
-      await this.deps.cache.deleteByPrefixAsync("files:branch:");
-      try {
-        const files = await this.deps.client.listAllFiles();
-        const cacheKey = buildFileListCacheKey(contentContext);
-        await this.deps.setFileListCache(cacheKey, files);
-        this.deps.clearFileListIndex();
-
-        logger.debug("Fresh files cached (memory + Redis)", {
-          cacheKey,
-          fileCount: files.length,
-        });
-      } catch (error) {
-        logger.warn("Failed to fetch files during selective invalidation", {
-          error,
-        });
-      }
-    }
-
-    this.pokeMetrics.invalidationsTriggered++;
-
-    logger.info(
-      "[WebSocketManager] TRIGGERING HMR RELOAD via invalidationCallbacks.triggerReload",
-      {
-        changedPaths,
-        projectSlug: this.deps.projectSlug,
-        projectId: this.deps.client.getProjectId(),
-        hasTriggerReloadCallback: !!this.deps.invalidationCallbacks.triggerReload,
-      },
-    );
-
-    const environment: "preview" | "production" = contentContext?.sourceType === "branch"
-      ? "preview"
-      : "production";
-    const projectContext = {
-      projectSlug: this.deps.projectSlug,
-      projectId: this.deps.client.getProjectId(),
-      environment,
-      branch: contentContext?.branch ?? null,
-      releaseId: contentContext?.releaseId ?? null,
-    };
-
-    this.deps.invalidationCallbacks.triggerReload?.(changedPaths, projectContext);
-
-    logger.info("Selective invalidation complete - HMR triggered", {
-      changedPaths,
-      durationMs: Date.now() - startTime,
-      totalInvalidations: this.pokeMetrics.invalidationsTriggered,
-    });
-
-    this.sendPokeAck("selective", changedPaths);
   }
 
   private async performInvalidation(): Promise<void> {
     const startTime = Date.now();
     const contentContext = this.deps.getContentContext();
+    const previewInvalidationPrefixes = this.getPreviewInvalidationPrefixes(contentContext);
+    const previewInvalidationVersion = this.previewInvalidationVersion;
+    let succeeded = false;
 
-    logger.debug("CACHE INVALIDATION STARTED - clearing all caches");
+    try {
+      logger.debug("CACHE INVALIDATION STARTED - clearing all caches");
 
-    const [
-      fileBranchCount,
-      fileReleaseCount,
-      fileEnvCount,
-      statBranchCount,
-      statReleaseCount,
-      statEnvCount,
-      dirBranchCount,
-      dirReleaseCount,
-      dirEnvCount,
-      filesBranchCount,
-      filesReleaseCount,
-      filesEnvCount,
-    ] = await Promise.all([
-      this.deps.cache.deleteByPrefixAsync("file:branch:"),
-      this.deps.cache.deleteByPrefixAsync("file:release:"),
-      this.deps.cache.deleteByPrefixAsync("file:env:"),
-      this.deps.cache.deleteByPrefixAsync("stat:branch:"),
-      this.deps.cache.deleteByPrefixAsync("stat:release:"),
-      this.deps.cache.deleteByPrefixAsync("stat:env:"),
-      this.deps.cache.deleteByPrefixAsync("dir:branch:"),
-      this.deps.cache.deleteByPrefixAsync("dir:release:"),
-      this.deps.cache.deleteByPrefixAsync("dir:env:"),
-      this.deps.cache.deleteByPrefixAsync("files:branch:"),
-      this.deps.cache.deleteByPrefixAsync("files:release:"),
-      this.deps.cache.deleteByPrefixAsync("files:env:"),
-    ]);
+      const [
+        fileBranchCount,
+        fileReleaseCount,
+        fileEnvCount,
+        statBranchCount,
+        statReleaseCount,
+        statEnvCount,
+        dirBranchCount,
+        dirReleaseCount,
+        dirEnvCount,
+        filesBranchCount,
+        filesReleaseCount,
+        filesEnvCount,
+      ] = await Promise.all([
+        this.deps.cache.deleteByPrefixAsync("file:branch:"),
+        this.deps.cache.deleteByPrefixAsync("file:release:"),
+        this.deps.cache.deleteByPrefixAsync("file:env:"),
+        this.deps.cache.deleteByPrefixAsync("stat:branch:"),
+        this.deps.cache.deleteByPrefixAsync("stat:release:"),
+        this.deps.cache.deleteByPrefixAsync("stat:env:"),
+        this.deps.cache.deleteByPrefixAsync("dir:branch:"),
+        this.deps.cache.deleteByPrefixAsync("dir:release:"),
+        this.deps.cache.deleteByPrefixAsync("dir:env:"),
+        this.deps.cache.deleteByPrefixAsync("files:branch:"),
+        this.deps.cache.deleteByPrefixAsync("files:release:"),
+        this.deps.cache.deleteByPrefixAsync("files:env:"),
+      ]);
 
-    // These caches are also cleared immediately on POKE receipt (before debounce).
-    // These calls are redundant safety nets for the full invalidation flow.
-    this.deps.clearMemoryCaches();
-    this.deps.invalidationCallbacks.clearDomainCache?.();
+      // These caches are also cleared immediately on POKE receipt (before debounce).
+      // These calls are redundant safety nets for the full invalidation flow.
+      this.deps.clearMemoryCaches();
+      this.deps.invalidationCallbacks.clearDomainCache?.();
 
-    const projectId = this.deps.client.getProjectId();
+      const projectId = this.deps.client.getProjectId();
 
-    if (this.deps.invalidationCallbacks.clearSSRModuleCacheForProject && projectId) {
-      this.deps.invalidationCallbacks.clearSSRModuleCacheForProject(projectId);
-    } else {
-      this.deps.invalidationCallbacks.clearSSRModuleCache?.();
-    }
+      if (this.deps.invalidationCallbacks.clearSSRModuleCacheForProject && projectId) {
+        this.deps.invalidationCallbacks.clearSSRModuleCacheForProject(projectId);
+      } else {
+        this.deps.invalidationCallbacks.clearSSRModuleCache?.();
+      }
 
-    if (this.deps.invalidationCallbacks.clearRouterDetectionCacheForProject && projectId) {
-      this.deps.invalidationCallbacks.clearRouterDetectionCacheForProject(projectId);
-    }
+      if (this.deps.invalidationCallbacks.clearRouterDetectionCacheForProject && projectId) {
+        this.deps.invalidationCallbacks.clearRouterDetectionCacheForProject(projectId);
+      }
 
-    this.deps.invalidationCallbacks.clearModulePathCache?.();
+      this.deps.invalidationCallbacks.clearModulePathCache?.();
 
-    if (this.deps.invalidationCallbacks.clearSnippetCacheForProject && this.deps.projectSlug) {
-      this.deps.invalidationCallbacks.clearSnippetCacheForProject(this.deps.projectSlug);
-    }
+      if (this.deps.invalidationCallbacks.clearSnippetCacheForProject && this.deps.projectSlug) {
+        this.deps.invalidationCallbacks.clearSnippetCacheForProject(this.deps.projectSlug);
+      }
 
-    if (this.deps.invalidationCallbacks.clearRendererCacheForProject && projectId) {
-      await this.deps.invalidationCallbacks.clearRendererCacheForProject(projectId);
-    }
+      if (this.deps.invalidationCallbacks.clearRendererCacheForProject && projectId) {
+        await this.deps.invalidationCallbacks.clearRendererCacheForProject(projectId);
+      }
 
-    if (this.deps.invalidationCallbacks.clearProjectCSSCache && this.deps.projectSlug) {
-      this.deps.invalidationCallbacks.clearProjectCSSCache(this.deps.projectSlug);
-    }
+      if (this.deps.invalidationCallbacks.clearProjectCSSCache && this.deps.projectSlug) {
+        this.deps.invalidationCallbacks.clearProjectCSSCache(this.deps.projectSlug);
+      }
 
-    const totalFileCount = fileBranchCount + fileReleaseCount + fileEnvCount;
-    const totalStatCount = statBranchCount + statReleaseCount + statEnvCount;
-    const totalDirCount = dirBranchCount + dirReleaseCount + dirEnvCount;
-    const totalFilesListCount = filesBranchCount + filesReleaseCount + filesEnvCount;
+      const totalFileCount = fileBranchCount + fileReleaseCount + fileEnvCount;
+      const totalStatCount = statBranchCount + statReleaseCount + statEnvCount;
+      const totalDirCount = dirBranchCount + dirReleaseCount + dirEnvCount;
+      const totalFilesListCount = filesBranchCount + filesReleaseCount + filesEnvCount;
 
-    logger.debug("CACHES CLEARED (memory + Redis)", {
-      fileCacheCleared: totalFileCount,
-      statCacheCleared: totalStatCount,
-      dirCacheCleared: totalDirCount,
-      filesListCacheCleared: totalFilesListCount,
-    });
+      logger.debug("CACHES CLEARED (memory + Redis)", {
+        fileCacheCleared: totalFileCount,
+        statCacheCleared: totalStatCount,
+        dirCacheCleared: totalDirCount,
+        filesListCacheCleared: totalFilesListCount,
+      });
 
-    if (contentContext?.sourceType === "branch") {
-      try {
-        const files = await this.deps.client.listAllFiles();
-        const cacheKey = buildFileListCacheKey(contentContext);
-        await this.deps.setFileListCache(cacheKey, files);
-        this.deps.clearFileListIndex();
+      if (contentContext?.sourceType === "branch") {
+        try {
+          const files = await this.deps.client.listAllFiles();
+          const cacheKey = buildFileListCacheKey(contentContext);
+          await this.deps.setFileListCache(cacheKey, files);
+          this.deps.clearFileListIndex();
 
-        logger.debug("FRESH FILES FETCHED", {
-          cacheKey,
-          fileCount: files.length,
-        });
-      } catch (error) {
-        logger.warn("Failed to fetch files during invalidation", { error });
+          logger.debug("FRESH FILES FETCHED", {
+            cacheKey,
+            fileCount: files.length,
+          });
+        } catch (error) {
+          logger.warn("Failed to fetch files during invalidation", { error });
+        }
+      }
+
+      this.pokeMetrics.invalidationsTriggered++;
+
+      logger.info("TRIGGERING FULL BROWSER RELOAD via ReloadNotifier", {
+        projectSlug: this.deps.projectSlug,
+        projectId: this.deps.client.getProjectId(),
+        hasTriggerReloadCallback: !!this.deps.invalidationCallbacks.triggerReload,
+      });
+
+      const environment: "preview" | "production" = contentContext?.sourceType === "branch"
+        ? "preview"
+        : "production";
+      const projectContext = {
+        projectSlug: this.deps.projectSlug,
+        projectId: this.deps.client.getProjectId(),
+        environment,
+        branch: contentContext?.branch ?? null,
+        releaseId: contentContext?.releaseId ?? null,
+      };
+
+      this.deps.invalidationCallbacks.triggerReload?.(undefined, projectContext);
+
+      logger.debug("CACHE INVALIDATION COMPLETE", {
+        fileCacheCleared: totalFileCount,
+        statCacheCleared: totalStatCount,
+        dirCacheCleared: totalDirCount,
+        filesListCacheCleared: totalFilesListCount,
+        durationMs: Date.now() - startTime,
+        totalInvalidations: this.pokeMetrics.invalidationsTriggered,
+      });
+
+      this.sendPokeAck("full");
+      succeeded = true;
+    } finally {
+      if (succeeded) {
+        this.completePreviewInvalidation(
+          previewInvalidationPrefixes,
+          previewInvalidationVersion,
+        );
       }
     }
-
-    this.pokeMetrics.invalidationsTriggered++;
-
-    logger.info("TRIGGERING FULL BROWSER RELOAD via ReloadNotifier", {
-      projectSlug: this.deps.projectSlug,
-      projectId: this.deps.client.getProjectId(),
-      hasTriggerReloadCallback: !!this.deps.invalidationCallbacks.triggerReload,
-    });
-
-    const environment: "preview" | "production" = contentContext?.sourceType === "branch"
-      ? "preview"
-      : "production";
-    const projectContext = {
-      projectSlug: this.deps.projectSlug,
-      projectId: this.deps.client.getProjectId(),
-      environment,
-      branch: contentContext?.branch ?? null,
-      releaseId: contentContext?.releaseId ?? null,
-    };
-
-    this.deps.invalidationCallbacks.triggerReload?.(undefined, projectContext);
-
-    logger.debug("CACHE INVALIDATION COMPLETE", {
-      fileCacheCleared: totalFileCount,
-      statCacheCleared: totalStatCount,
-      dirCacheCleared: totalDirCount,
-      filesListCacheCleared: totalFilesListCount,
-      durationMs: Date.now() - startTime,
-      totalInvalidations: this.pokeMetrics.invalidationsTriggered,
-    });
-
-    this.sendPokeAck("full");
   }
 
   private startHeartbeat(projectId: string): void {
@@ -757,9 +839,12 @@ export class WebSocketManager {
       const timeSinceLastPong = Date.now() - this.wsLastPong;
       if (timeSinceLastPong <= WS_HEARTBEAT_TIMEOUT_MS) return;
 
-      logger.warn("WebSocket heartbeat timeout, reconnecting", {
-        timeSinceLastPong,
-      });
+      logger.warn(
+        "WebSocket heartbeat timeout, reconnecting",
+        this.getConnectionLogContext({
+          timeSinceLastPong,
+        }),
+      );
 
       // Detach onclose before closing to prevent double-reconnect:
       // ws.close() triggers onclose asynchronously, which would increment

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -14,7 +14,9 @@ import {
   removePendingInvalidation,
 } from "./invalidation-state.ts";
 
-const logger = getBaseLogger("SERVER").component("web-socket-manager");
+const logger = getBaseLogger("SERVER", { injectTraceContext: false }).component(
+  "web-socket-manager",
+);
 
 const INVALIDATION_DEBOUNCE_MS = 100;
 const WS_RECONNECT_DELAY_MS = 5000;

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -1,4 +1,4 @@
-import { logger as baseLogger } from "#veryfront/utils";
+import { getBaseLogger } from "#veryfront/utils/logger/logger.ts";
 import type { FileCache } from "../cache/file-cache.ts";
 import type { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
 import type { ContentSource, InvalidationCallbacks, ResolvedContentContext } from "./types.ts";
@@ -14,7 +14,7 @@ import {
   removePendingInvalidation,
 } from "./invalidation-state.ts";
 
-const logger = baseLogger.component("web-socket-manager");
+const logger = getBaseLogger("SERVER").component("web-socket-manager");
 
 const INVALIDATION_DEBOUNCE_MS = 100;
 const WS_RECONNECT_DELAY_MS = 5000;

--- a/src/utils/logger/logger.test.ts
+++ b/src/utils/logger/logger.test.ts
@@ -519,6 +519,33 @@ describe("logger", () => {
         restore();
       }
     });
+
+    it("should allow base loggers to opt out of auto trace injection", () => {
+      const { getOutput, restore } = captureConsoleLog();
+
+      try {
+        __registerTraceContextGetter(() => ({
+          traceId: "from-otel",
+          spanId: "from-otel-span",
+        }));
+
+        withJsonLogFormat(() => {
+          const base = getBaseLogger("SERVER", { injectTraceContext: false });
+          const component = base.component("web-socket-manager");
+          component.info("No trace bridge");
+
+          const entry = JSON.parse(getOutput()) as LogEntry;
+          assertEquals(entry.component, "web-socket-manager");
+          assertEquals(entry.traceId, undefined);
+          assertEquals(entry.spanId, undefined);
+          assertEquals(entry.trace_id, undefined);
+          assertEquals(entry.span_id, undefined);
+        });
+      } finally {
+        __resetTraceContextGetterForTests();
+        restore();
+      }
+    });
   });
 
   describe("snake_case field aliases", () => {

--- a/src/utils/logger/logger.ts
+++ b/src/utils/logger/logger.ts
@@ -88,6 +88,10 @@ type LoggerConfig = {
   format: LogFormat;
 };
 
+type ConsoleLoggerOptions = {
+  injectTraceContext?: boolean;
+};
+
 // ---- Config helpers (must be declared before the eager init below) ----
 
 const LOG_LEVEL_MAP: Readonly<Record<string, LogLevel>> = {
@@ -249,17 +253,23 @@ class ConsoleLogger implements Logger {
     private prefix: string,
     boundContext?: Record<string, unknown>,
     componentName?: string,
+    private readonly options: ConsoleLoggerOptions = {},
   ) {
     this.boundContext = boundContext ?? {};
     this.componentName = componentName;
   }
 
   child(context: Record<string, unknown>): Logger {
-    return new ConsoleLogger(this.prefix, { ...this.boundContext, ...context }, this.componentName);
+    return new ConsoleLogger(
+      this.prefix,
+      { ...this.boundContext, ...context },
+      this.componentName,
+      this.options,
+    );
   }
 
   component(name: string): Logger {
-    return new ConsoleLogger(this.prefix, { ...this.boundContext }, name);
+    return new ConsoleLogger(this.prefix, { ...this.boundContext }, name, this.options);
   }
 
   private formatJson(level: LogEntry["level"], message: string, args: unknown[]): string {
@@ -284,7 +294,7 @@ class ConsoleLogger implements Logger {
     extractToEntryField(entry, mergedContext, "durationMs", (v) => Number(v));
 
     // Auto-inject trace context from OTel when not already set
-    if (traceContextGetter && !entry.traceId) {
+    if ((this.options.injectTraceContext ?? true) && traceContextGetter && !entry.traceId) {
       const traceCtx = traceContextGetter();
       if (traceCtx.traceId) {
         entry.traceId = traceCtx.traceId;
@@ -382,8 +392,8 @@ class ConsoleLogger implements Logger {
   }
 }
 
-function createLogger(prefix: string): ConsoleLogger {
-  return new ConsoleLogger(prefix);
+function createLogger(prefix: string, options?: ConsoleLoggerOptions): ConsoleLogger {
+  return new ConsoleLogger(prefix, undefined, undefined, options);
 }
 
 // Base loggers without request context
@@ -520,8 +530,26 @@ export const logger = createContextAwareLogger(baseLogger);
  * Get the base logger without request context awareness.
  * Use this when you need to create a request-scoped logger in middleware.
  */
-export function getBaseLogger(prefix: string): ConsoleLogger {
-  switch (prefix.toUpperCase()) {
+export function getBaseLogger(
+  prefix: string,
+  options?: ConsoleLoggerOptions,
+): ConsoleLogger {
+  const resolvedPrefix = prefix.toUpperCase();
+  if (options?.injectTraceContext === false) {
+    return createLogger(
+      resolvedPrefix === "CLI" ||
+        resolvedPrefix === "SERVER" ||
+        resolvedPrefix === "RENDERER" ||
+        resolvedPrefix === "BUNDLER" ||
+        resolvedPrefix === "AGENT" ||
+        resolvedPrefix === "PROXY"
+        ? resolvedPrefix
+        : "VERYFRONT",
+      options,
+    );
+  }
+
+  switch (resolvedPrefix) {
     case "CLI":
       return baseCliLogger;
     case "SERVER":

--- a/src/utils/logger/logger.ts
+++ b/src/utils/logger/logger.ts
@@ -119,20 +119,14 @@ export function getDefaultLevel(
 
 /**
  * Determine log format from environment.
- * Defaults to JSON in production/staging/K8s for Grafana compatibility.
- * Text format produces multi-line output that Loki splits into separate
- * entries, so JSON is strongly preferred for any deployed environment.
+ * Defaults to JSON in production for Grafana compatibility.
  */
 function getDefaultFormat(
   envFormat: string | undefined = getEnv("LOG_FORMAT"),
   envMode: string | undefined = getEnv("NODE_ENV"),
 ): LogFormat {
   if (envFormat === "json" || envFormat === "text") return envFormat;
-  // Use JSON for any non-development environment (production, staging, test, etc.)
-  // and when running inside Kubernetes (KUBERNETES_SERVICE_HOST is always set in K8s pods)
-  if (envMode && envMode !== "development") return "json";
-  if (getEnv("KUBERNETES_SERVICE_HOST")) return "json";
-  return "text";
+  return envMode === "production" ? "json" : "text";
 }
 
 // ---- Eager config resolution ----

--- a/src/utils/logger/logger.ts
+++ b/src/utils/logger/logger.ts
@@ -405,6 +405,15 @@ const baseAgentLogger = createLogger("AGENT");
 const baseProxyLogger = createLogger("PROXY");
 const baseLogger = createLogger("VERYFRONT");
 
+const BASE_LOGGER_MAP: Readonly<Record<string, ConsoleLogger>> = {
+  CLI: baseCliLogger,
+  SERVER: baseServerLogger,
+  RENDERER: baseRendererLogger,
+  BUNDLER: baseBundlerLogger,
+  AGENT: baseAgentLogger,
+  PROXY: baseProxyLogger,
+};
+
 /**
  * Request context getter - set by request-context.ts to avoid circular imports.
  * This pattern allows the logger module to be imported first without
@@ -535,36 +544,13 @@ export function getBaseLogger(
   options?: ConsoleLoggerOptions,
 ): ConsoleLogger {
   const resolvedPrefix = prefix.toUpperCase();
+  const validPrefix = resolvedPrefix in BASE_LOGGER_MAP ? resolvedPrefix : "VERYFRONT";
+
   if (options?.injectTraceContext === false) {
-    return createLogger(
-      resolvedPrefix === "CLI" ||
-        resolvedPrefix === "SERVER" ||
-        resolvedPrefix === "RENDERER" ||
-        resolvedPrefix === "BUNDLER" ||
-        resolvedPrefix === "AGENT" ||
-        resolvedPrefix === "PROXY"
-        ? resolvedPrefix
-        : "VERYFRONT",
-      options,
-    );
+    return createLogger(validPrefix, options);
   }
 
-  switch (resolvedPrefix) {
-    case "CLI":
-      return baseCliLogger;
-    case "SERVER":
-      return baseServerLogger;
-    case "RENDERER":
-      return baseRendererLogger;
-    case "BUNDLER":
-      return baseBundlerLogger;
-    case "AGENT":
-      return baseAgentLogger;
-    case "PROXY":
-      return baseProxyLogger;
-    default:
-      return baseLogger;
-  }
+  return BASE_LOGGER_MAP[resolvedPrefix] ?? baseLogger;
 }
 
 /**

--- a/src/utils/logger/logger.ts
+++ b/src/utils/logger/logger.ts
@@ -119,14 +119,20 @@ export function getDefaultLevel(
 
 /**
  * Determine log format from environment.
- * Defaults to JSON in production for Grafana compatibility.
+ * Defaults to JSON in production/staging/K8s for Grafana compatibility.
+ * Text format produces multi-line output that Loki splits into separate
+ * entries, so JSON is strongly preferred for any deployed environment.
  */
 function getDefaultFormat(
   envFormat: string | undefined = getEnv("LOG_FORMAT"),
   envMode: string | undefined = getEnv("NODE_ENV"),
 ): LogFormat {
   if (envFormat === "json" || envFormat === "text") return envFormat;
-  return envMode === "production" ? "json" : "text";
+  // Use JSON for any non-development environment (production, staging, test, etc.)
+  // and when running inside Kubernetes (KUBERNETES_SERVICE_HOST is always set in K8s pods)
+  if (envMode && envMode !== "development") return "json";
+  if (getEnv("KUBERNETES_SERVICE_HOST")) return "json";
+  return "text";
 }
 
 // ---- Eager config resolution ----


### PR DESCRIPTION
## Summary
- **WebSocket manager**: Switch from context-aware logger to base logger (`getBaseLogger("SERVER")`) to prevent stale request context from leaking into timer-based reconnection callbacks via AsyncLocalStorage. This was causing 844 identical `error={}` continuation lines per hour in staging Loki.
- **File resolution**: Resolve extensionless paths (e.g. `pages/home.v2`) directly from the file list index before falling back to the API `resolveFileWithExtension` call. Adds `findFirstWithContent` to `FileListIndex` and skips both file-list lookups and extension resolution cache during cache invalidation to avoid serving stale content.
- **Logger**: Add `injectTraceContext` option to `getBaseLogger` so callers like the WebSocket manager can opt out of auto-injecting OpenTelemetry trace context.

## Context
Staging logs showed 1,771 error-level entries over ~70 minutes, of which 95% were WebSocket reconnection errors. The WebSocket manager used the context-aware logger which inherits request-scoped context via AsyncLocalStorage. Since `setTimeout` callbacks preserve AsyncLocalStorage context, every reconnection attempt (every 5 seconds) carried the stale `requestId`, `project_slug`, etc. from the original request that initialized the WebSocket connection.

The file resolution change reduces unnecessary API calls for extensionless paths that are already present in the pre-fetched file list cache, and ensures invalidation correctness by bypassing persistent caches when a release is being invalidated.

## Test plan
- [x] All 45 logger tests pass
- [x] All 13 WebSocket manager tests pass
- [x] New tests for file-list resolution (dotted paths, missing files, invalidation bypass)
- [x] New tests for extension resolution cache skip during invalidation
- [x] Type checking passes
- [ ] Verify WebSocket error logs no longer carry stale `requestId` context after deployment