### PR TITLE
fix: replace Math.random with crypto.randomUUID for secure temp names (M20)

### DIFF
--- a/src/cache/backends/disk.ts
+++ b/src/cache/backends/disk.ts
@@ -78,7 +78,7 @@ export class DiskCacheBackend implements CacheBackend {
       expiresAt: ttlSeconds != null ? Date.now() + ttlSeconds * 1000 : undefined,
     };
     const filePath = this.filePath(key);
-    const tmpPath = `${filePath}.tmp.${Date.now()}.${Math.random().toString(36).slice(2, 8)}`;
+    const tmpPath = `${filePath}.tmp.${Date.now()}.${crypto.randomUUID().slice(0, 8)}`;
     const content = JSON.stringify(envelope);
     const { writeFile, rename, unlink } = await fsPromises;
     try {

--- a/src/modules/react-loader/unified-loader.ts
+++ b/src/modules/react-loader/unified-loader.ts
@@ -74,7 +74,7 @@ async function transformAllComponents(
 
 async function createTempDir(projectId: string, adapter: RuntimeAdapter): Promise<string> {
   const baseTmp = await getProjectTmpDir(projectId);
-  const uniqueTmp = `unified-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const uniqueTmp = `unified-${Date.now()}-${crypto.randomUUID().slice(0, 12)}`;
   const tmpDir = join(baseTmp, uniqueTmp);
 
   await adapter.fs.mkdir(tmpDir, { recursive: true });

--- a/src/platform/compat/fs.ts
+++ b/src/platform/compat/fs.ts
@@ -161,7 +161,7 @@ class NodeFileSystem implements FileSystem {
     await this.ensureInitialized();
     const tempDir = this.getPath().join(
       this.getOs().tmpdir(),
-      `${options?.prefix ?? "tmp-"}${Math.random().toString(36).substring(2, 8)}`,
+      `${options?.prefix ?? "tmp-"}${crypto.randomUUID().slice(0, 8)}`,
     );
     await this.getFs().mkdir(tempDir, { recursive: true });
     return tempDir;

--- a/src/skill/executor.ts
+++ b/src/skill/executor.ts
@@ -76,7 +76,7 @@ function formatEnvAssignments(env?: Record<string, string>): string[] {
 
 function createSandboxScriptPath(scriptPath: string): string {
   const ext = extname(scriptPath) || ".sh";
-  const suffix = Math.random().toString(36).slice(2, 10);
+  const suffix = crypto.randomUUID().slice(0, 8);
   return `/tmp/veryfront-skill-script-${Date.now()}-${suffix}${ext}`;
 }
 


### PR DESCRIPTION
## Summary
- Replace `Math.random()` with `crypto.randomUUID()` in 4 files that generate temporary file/directory names
- Affected: `src/platform/compat/fs.ts`, `src/cache/backends/disk.ts`, `src/modules/react-loader/unified-loader.ts`, `src/skill/executor.ts`
- `crypto.randomUUID()` provides cryptographically secure random values, preventing predictable path collisions

## Test plan
- [x] All 80 related unit tests pass
- [x] Lint passes on all 4 modified files
- [x] Full CI suite