### PR TITLE
fix: sanitize SSE error messages to prevent leaking internals (M5)

### DIFF
--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -307,9 +307,10 @@ export class AgentRuntime {
           controller.close();
         } catch (error) {
           this.status = "error";
+          logger.error("Agent stream error", { error });
           sendSSE(controller, encoder, {
             type: "error",
-            error: error instanceof Error ? error.message : String(error),
+            error: "An internal error occurred",
           });
           controller.close();
         }


### PR DESCRIPTION
## Summary
- Replace raw `error.message` in SSE error events with generic `"An internal error occurred"`
- Log the full error server-side with `logger.error` for debugging
- Prevents leaking file paths, connection strings, and stack traces to clients

## Test plan
- [x] Lint passes
- [x] Full CI suite