### PR TITLE
fix: warn on empty remoteHosts, clean up SECURITY.md (M17, M19)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ currently being supported with security updates.
 
 We take the security of Veryfront seriously. If you have found a security vulnerability, please do not report it in the public issue tracker.
 
-Instead, please email **security@veryfront.com** (replace with actual email) with details. We will review the issue and respond within 48 hours.
+Instead, please email **security@veryfront.com** with details. We will review the issue and respond within 48 hours.
 
 ### What to include:
 

--- a/src/routing/api/module-loader/security-config.ts
+++ b/src/routing/api/module-loader/security-config.ts
@@ -12,6 +12,12 @@ export async function loadSecurityConfig(
     const remote = cfg.security?.remoteHosts;
 
     if (Array.isArray(remote)) {
+      if (remote.length === 0) {
+        logger.warn(
+          "security.remoteHosts is set to an empty array — all remote requests will be blocked. " +
+            "If this is intentional, you can ignore this warning.",
+        );
+      }
       return remote;
     }
   } catch (e) {


### PR DESCRIPTION
## Summary
- Add `logger.warn` when `remoteHosts` is explicitly set to empty array (blocks all remote requests)
- Remove "(replace with actual email)" placeholder from SECURITY.md, keeping `security@veryfront.com`

## Test plan
- [x] Lint passes
- [x] Full CI suite