### PR TITLE
fix: isolate user identity in agent chat and Redis memory (M1, M2)

### DIFF
--- a/src/agent/chat-handler.ts
+++ b/src/agent/chat-handler.ts
@@ -264,6 +264,16 @@ function isRequest(obj: unknown): obj is Request {
   );
 }
 
+function extractUserId(request: Request): string {
+  const userId = request.headers.get("x-user-id");
+  if (userId) return userId;
+  agentLogger.warn(
+    "No user identity found in request. Using anonymous fallback. " +
+      "Set x-user-id header or provide a context function for proper user isolation.",
+  );
+  return "anonymous";
+}
+
 function extractRequest(requestOrCtx: unknown): Request {
   if (isRequest(requestOrCtx)) return requestOrCtx;
   // Pages Router APIContext — has a .request property
@@ -316,7 +326,7 @@ export function createChatHandler(
 
       const context = typeof options?.context === "function"
         ? await options.context(request)
-        : options?.context ?? { userId: "current-user" };
+        : options?.context ?? { userId: extractUserId(request) };
 
       const baseMessages = transformUIMessages(rawMessages);
       const beforeStreamResult = await options?.beforeStream?.({

--- a/src/agent/memory/redis.ts
+++ b/src/agent/memory/redis.ts
@@ -33,6 +33,8 @@ export interface RedisMemoryConfig extends MemoryConfigBase {
   client: RedisClient;
   /** Key prefix for namespacing */
   keyPrefix?: string;
+  /** User ID for per-user memory isolation */
+  userId?: string;
   /** TTL in seconds (default: 24 hours) */
   ttl?: number;
 }
@@ -43,6 +45,7 @@ const DEFAULT_KEY_PREFIX = "veryfront:agent:memory:";
 export class RedisMemory<M extends MinimalMessage = MinimalMessage> implements Memory<M> {
   private client: RedisClient;
   private agentId: string;
+  private userId: string;
   private keyPrefix: string;
   private ttl: number;
   private config: RedisMemoryConfig;
@@ -50,13 +53,14 @@ export class RedisMemory<M extends MinimalMessage = MinimalMessage> implements M
   constructor(agentId: string, config: RedisMemoryConfig) {
     this.client = config.client;
     this.agentId = agentId;
+    this.userId = config.userId ?? "anonymous";
     this.keyPrefix = config.keyPrefix ?? DEFAULT_KEY_PREFIX;
     this.ttl = config.ttl ?? DEFAULT_TTL;
     this.config = config;
   }
 
   private getKey(): string {
-    return `${this.keyPrefix}${this.agentId}`;
+    return `${this.keyPrefix}${this.agentId}:${this.userId}`;
   }
 
   private parseMessages(data: string | null): M[] {


### PR DESCRIPTION
## Summary
- Replace hardcoded `"current-user"` default in chat handler with `extractUserId()` that reads `x-user-id` header
- Log warning when no user identity is found (falls back to `"anonymous"`)
- Add `userId` to Redis memory key format: `prefix:agentId:userId` for per-user isolation
- Add optional `userId` field to `RedisMemoryConfig`

## Test plan
- [x] Lint passes
- [x] Full CI suite