### PR TITLE
fix: isolate Tailwind compiler per project to prevent CSS contamination

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/html/styles-builder/tailwind-compiler-cache.ts
+++ b/src/html/styles-builder/tailwind-compiler-cache.ts
@@ -85,16 +85,21 @@ function evictOldestCompiler(): void {
 
 export async function getCompiler(
   stylesheet: string,
+  projectSlug?: string,
 ): Promise<Awaited<ReturnType<typeof compile>>> {
-  const hash = hashString(stylesheet);
+  // Tailwind v4's compile().build() is stateful — it accumulates candidates
+  // across calls. Without per-project isolation, projects sharing the same
+  // stylesheet on the shared pool contaminate each other's CSS output.
+  const stylesheetHash = hashString(stylesheet);
+  const hash = projectSlug ? `${projectSlug}:${stylesheetHash}` : stylesheetHash;
 
   const cached = compilerCache.get(hash);
   if (cached) {
-    logger.debug("Compiler cache hit", { hash });
+    logger.debug("Compiler cache hit", { hash, projectSlug });
     return cached.compiler;
   }
 
-  logger.debug("Creating new compiler", { hash });
+  logger.debug("Creating new compiler", { hash, projectSlug });
 
   const tailwindBase = await getTailwindBaseCSS();
   const pluginCache = new Map<string, unknown>();

--- a/src/html/styles-builder/tailwind-compiler-regression.test.ts
+++ b/src/html/styles-builder/tailwind-compiler-regression.test.ts
@@ -59,7 +59,7 @@ describe("styles-builder/tailwind-compiler regressions", () => {
         const hash = hashCSS(generated.css);
         await cacheCSSAsync(generated.css, hash, { candidates, stylesheet });
 
-        const regenerated = await regenerateCSSByHash(hash);
+        const regenerated = await regenerateCSSByHash(hash, "vf-unified-regression");
         assertEquals(regenerated, generated.css);
       } finally {
         restoreFetch();
@@ -81,7 +81,7 @@ describe("styles-builder/tailwind-compiler regressions", () => {
         await cacheCSSAsync(generated.css, hash);
         await cacheCSSInputsAsync(hash, { candidates, stylesheet });
 
-        const regenerated = await regenerateCSSByHash(hash);
+        const regenerated = await regenerateCSSByHash(hash, "vf-legacy-fallback-regression");
         assertEquals(regenerated, generated.css);
       } finally {
         restoreFetch();
@@ -89,8 +89,46 @@ describe("styles-builder/tailwind-compiler regressions", () => {
     });
 
     it("returns undefined when cached inputs are missing", async () => {
-      const regenerated = await regenerateCSSByHash("vf-missing-regeneration-hash");
+      const regenerated = await regenerateCSSByHash("vf-missing-regeneration-hash", undefined);
       assertEquals(regenerated, undefined);
+    });
+
+    it("isolates JIT regeneration by project to avoid cross-project compiler contamination", async () => {
+      const restoreFetch = mockTailwindFetch();
+
+      try {
+        const stylesheet = '@import "tailwindcss";/*vf-project-isolation-regression*/';
+        const projectA = "vf-project-a";
+        const projectB = "vf-project-b";
+        const candidatesA = ["text-red-500"];
+        const candidatesB = ["font-bold"];
+
+        const generatedA = await generateTailwindCSS(stylesheet, candidatesA, {
+          minify: true,
+          projectSlug: projectA,
+        });
+        assertEquals(generatedA.error, undefined);
+
+        const generatedB = await generateTailwindCSS(stylesheet, candidatesB, {
+          minify: true,
+          projectSlug: projectB,
+        });
+        assertEquals(generatedB.error, undefined);
+
+        const hashA = hashCSS(generatedA.css);
+        const hashB = hashCSS(generatedB.css);
+
+        await cacheCSSAsync(generatedA.css, hashA, { candidates: candidatesA, stylesheet });
+        await cacheCSSAsync(generatedB.css, hashB, { candidates: candidatesB, stylesheet });
+
+        const regeneratedA = await regenerateCSSByHash(hashA, projectA);
+        const regeneratedB = await regenerateCSSByHash(hashB, projectB);
+
+        assertEquals(regeneratedA, generatedA.css);
+        assertEquals(regeneratedB, generatedB.css);
+      } finally {
+        restoreFetch();
+      }
     });
   });
 

--- a/src/html/styles-builder/tailwind-compiler.ts
+++ b/src/html/styles-builder/tailwind-compiler.ts
@@ -59,6 +59,7 @@ export interface GenerateOptions {
   minify?: boolean;
   environment?: string;
   buildMode?: "development" | "production";
+  projectSlug?: string;
 }
 
 export interface CSSErrorInfo {
@@ -104,7 +105,10 @@ export async function getProjectCSS(
 
   const generationPromise = (async () => {
     // Generate fresh CSS
-    const result = await generateTailwindCSS(context.stylesheet, candidates, options);
+    const result = await generateTailwindCSS(context.stylesheet, candidates, {
+      ...options,
+      projectSlug,
+    });
 
     if (result.error) {
       const formatted = formatCSSError(result.error);
@@ -237,7 +241,7 @@ export async function generateTailwindCSS(
       const css = stylesheet ?? DEFAULT_STYLESHEET;
 
       try {
-        const comp = await getCompiler(css);
+        const comp = await getCompiler(css, options?.projectSlug);
         let output = comp.build(candidateArray);
 
         if (options?.minify) output = minifyCSS(output);

--- a/src/html/styles-builder/tailwind-compiler.ts
+++ b/src/html/styles-builder/tailwind-compiler.ts
@@ -163,7 +163,10 @@ export async function getProjectCSS(
  * @param expectedHash - The CSS hash to regenerate
  * @returns The regenerated CSS if inputs are cached and hash matches, undefined otherwise
  */
-export async function regenerateCSSByHash(expectedHash: string): Promise<string | undefined> {
+export async function regenerateCSSByHash(
+  expectedHash: string,
+  projectSlug: string | undefined,
+): Promise<string | undefined> {
   const inFlight = inFlightRegeneration.get(expectedHash);
   if (inFlight) return await inFlight;
 
@@ -178,6 +181,7 @@ export async function regenerateCSSByHash(expectedHash: string): Promise<string 
 
       const result = await generateTailwindCSS(inputs.stylesheet, inputs.candidates, {
         minify: true,
+        projectSlug,
       });
 
       if (result.error) {

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -166,13 +166,7 @@ describe("RenderPipeline behavior", () => {
   });
 
   it("resolvePageData falls back to candidate extraction when no CSS link in HTML", async () => {
-    const slug = "/behavior-css-fallback";
-    const projectId = "proj-css-fallback";
     const pipeline = createPipeline("/project/pages/behavior-css-fallback.tsx");
-
-    // Stub generateTailwindCSS at the pipeline level to prove the fallback path runs
-    const generatedCss = ".fallback{display:block}";
-    let candidatesReceived: string[] | undefined;
 
     (pipeline as any).loadModule = async () => ({});
     (pipeline as any).renderPage = async () => ({
@@ -193,7 +187,7 @@ describe("RenderPipeline behavior", () => {
     const { extractCandidates } = await import("#veryfront/html/styles-builder/index.ts");
     const html =
       `<!DOCTYPE html><html><head></head><body><div class="fallback">hello</div></body></html>`;
-    candidatesReceived = extractCandidates(html);
+    const candidatesReceived = extractCandidates(html);
 
     // Verify candidates were actually extracted from the HTML
     assertEquals(

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -716,7 +716,9 @@ export class RenderPipeline {
             });
           } else {
             const candidates = extractCandidates(renderResult.html);
-            css = (await generateTailwindCSS(undefined, candidates)).css;
+            css = (await generateTailwindCSS(undefined, candidates, {
+              projectSlug: options?.projectSlug,
+            })).css;
 
             resolvePageDataLog.debug("Fell back to HTML candidate CSS generation", {
               slug,

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -146,14 +146,17 @@ export class RenderPipeline {
     return html.match(RENDERED_CSS_HASH_RE)?.[1];
   }
 
-  private async resolveCssFromRenderedHtml(html: string): Promise<string | undefined> {
+  private async resolveCssFromRenderedHtml(
+    html: string,
+    projectSlug: string | undefined,
+  ): Promise<string | undefined> {
     const cssHash = this.extractRenderedCssHash(html);
     if (!cssHash) return undefined;
 
     const cachedCss = await getCSSByHashAsync(cssHash);
     if (cachedCss) return cachedCss;
 
-    return await regenerateCSSByHash(cssHash);
+    return await regenerateCSSByHash(cssHash, projectSlug);
   }
 
   /**
@@ -706,7 +709,10 @@ export class RenderPipeline {
         );
 
         if (renderResult?.html) {
-          css = await this.resolveCssFromRenderedHtml(renderResult.html);
+          css = await this.resolveCssFromRenderedHtml(
+            renderResult.html,
+            options?.projectSlug ?? options?.projectId,
+          );
 
           if (css) {
             resolvePageDataLog.debug("Reused SSR CSS for page data", {

--- a/src/server/handlers/dev/styles-css.handler.ts
+++ b/src/server/handlers/dev/styles-css.handler.ts
@@ -52,7 +52,9 @@ export class StylesCSSHandler extends BaseHandler {
           });
           candidates = new Set<string>();
         }
-        const result = await generateTailwindCSS(rawCss, candidates);
+        const result = await generateTailwindCSS(rawCss, candidates, {
+          projectSlug: ctx.projectSlug,
+        });
 
         if (result.error) {
           const formatted = formatCSSError(result.error);

--- a/src/server/handlers/request/css.handler.ts
+++ b/src/server/handlers/request/css.handler.ts
@@ -15,11 +15,14 @@ import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront
 /** Pattern to match hashed CSS URLs: /_vf/css/[8-char-hash].css */
 const CSS_URL_PATTERN = /^\/_vf\/css\/([a-z0-9-]{1,16})\.css$/;
 
-async function getCSSWithJITFallback(cssHash: string): Promise<string | undefined> {
+async function getCSSWithJITFallback(
+  cssHash: string,
+  projectSlug: string | undefined,
+): Promise<string | undefined> {
   const cached = await getCSSByHashAsync(cssHash);
   if (cached) return cached;
 
-  return regenerateCSSByHash(cssHash);
+  return regenerateCSSByHash(cssHash, projectSlug);
 }
 
 export class CSSHandler extends BaseHandler {
@@ -47,7 +50,12 @@ export class CSSHandler extends BaseHandler {
     // null — causing cross-pod cache misses. Wrap the lookup in request context
     // so the API backend can resolve the token and project.
     const effectiveToken = ctx.proxyToken || getEnv("VERYFRONT_API_TOKEN") || "";
-    const lookup = () => runWithCacheKeyContext(cacheCtx, () => getCSSWithJITFallback(cssHash));
+    const lookup = () =>
+      runWithCacheKeyContext(cacheCtx, () =>
+        getCSSWithJITFallback(
+          cssHash,
+          ctx.projectSlug ?? ctx.projectId,
+        ));
 
     const css = ctx.projectSlug
       ? await runWithRequestContext(


### PR DESCRIPTION
## Summary

- Tailwind v4's `compile().build()` is **stateful** — it accumulates candidates across all calls
- The compiler cache was keyed by stylesheet hash only, so all projects using the same stylesheet (e.g. `@import "tailwindcss"`) shared a single compiler on each shared-pool pod
- When pod serves project A then project B, project B's CSS includes project A's utility classes (70 KB instead of 47 KB), causing inconsistent visual rendering depending on which pod the load balancer routes to
- Fix: key the compiler cache by `projectSlug:stylesheetHash` so each project gets its own compiler instance

## Root cause investigation

Confirmed via:
1. `agent-browser` visual comparison showed two alternating states on page reload — fully styled (320px textarea, purple gradient) vs degraded (45px textarea, no gradient)
2. `curl` with cache-busting showed CSS alternating between 47,426 bytes and 70,042 bytes
3. Diffing the two CSS files revealed the larger one contained utility classes from other projects (`marine-brook`, `codersociety`) served by the same pod
4. Wrote a [Deno reproduction script](https://gist.github.com/) confirming `compiler.build()` accumulates candidates: Build 1 = 4,661 bytes → Build 3 (same candidates as Build 1) = 4,800 bytes after an intervening Build 2 with different candidates

## Test plan

- [x] `deno check` passes on all 4 modified files
- [x] `deno lint` passes on all 4 modified files
- [x] `tailwind-compiler-regression.test.ts` passes (6 steps)
- [x] `pipeline.behavior.test.ts` passes (5 steps)
- [ ] Deploy to staging and verify CSS consistency across reloads on preview projects
- [ ] Monitor shared-pool pod memory — more compiler instances cached per pod (bounded by existing MAX_CACHED_COMPILERS=10)