### PR TITLE
Avoid remote deno.json probe when absent

### DIFF
--- a/src/platform/adapters/fs/veryfront/file-list-index.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-index.ts
@@ -22,6 +22,7 @@ const INDEX_STALENESS_LIMIT_MS = 5 * 60 * 1000; // 5 minutes
 
 export class FileListIndex {
   private index: Map<string, string> | null = null;
+  private knownPaths: Set<string> | null = null;
   private indexKey: string | null = null;
   private indexBuiltAt = 0;
   private readyPromise: Promise<void> | null = null;
@@ -35,13 +36,15 @@ export class FileListIndex {
   }
 
   clear(): void {
-    if (!this.index) return;
+    if (!this.index && !this.knownPaths) return;
 
-    const indexedWithContent = this.index.size;
+    const indexedWithContent = this.index?.size ?? 0;
+    const knownPathCount = this.knownPaths?.size ?? 0;
     this.index = null;
+    this.knownPaths = null;
     this.indexKey = null;
     this.indexBuiltAt = 0;
-    logger.debug("Cleared file list index", { indexedWithContent });
+    logger.debug("Cleared file list index", { indexedWithContent, knownPathCount });
   }
 
   private async ensureReady(): Promise<void> {
@@ -83,6 +86,26 @@ export class FileListIndex {
     return content;
   }
 
+  async hasPath(normalizedPath: string): Promise<boolean | undefined> {
+    await this.ensureReady();
+
+    const index = await this.getOrBuild();
+    if (!index) return undefined;
+
+    return this.knownPaths?.has(normalizedPath) ?? undefined;
+  }
+
+  async hasAnyPath(normalizedPaths: string[]): Promise<boolean | undefined> {
+    await this.ensureReady();
+
+    const index = await this.getOrBuild();
+    if (!index) return undefined;
+
+    const knownPaths = this.knownPaths;
+    if (!knownPaths) return undefined;
+
+    return normalizedPaths.some((path) => knownPaths.has(path));
+  }
   async findFirstWithContent(
     normalizedPaths: string[],
   ): Promise<{ path: string; content: string } | undefined> {
@@ -126,6 +149,7 @@ export class FileListIndex {
           staleLimitMs: INDEX_STALENESS_LIMIT_MS,
         });
         this.index = null;
+        this.knownPaths = null;
         this.indexKey = null;
       }
       logger.debug(
@@ -152,11 +176,14 @@ export class FileListIndex {
     }
 
     const index = new Map<string, string>();
+    const knownPaths = new Set<string>();
     for (const file of fileList) {
+      knownPaths.add(file.path);
       if (file.content) index.set(file.path, file.content);
     }
 
     this.index = index;
+    this.knownPaths = knownPaths;
     this.indexKey = indexKey;
     this.indexBuiltAt = Date.now();
 
@@ -165,6 +192,7 @@ export class FileListIndex {
     logger.debug("Built file list index", {
       fileListSize: fileList.length,
       indexedWithContent: index.size,
+      knownPathCount: knownPaths.size,
       sampleFilePath: sampleFile?.path,
       sampleContentLength: sampleContent?.length,
       sampleContentHash: sampleContent ? hashPreview(sampleContent) : undefined,

--- a/src/platform/adapters/fs/veryfront/read-operations.test.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
 import { FileCache } from "../cache/file-cache.ts";
@@ -370,7 +370,7 @@ describe("ReadOperations", () => {
       assertEquals(apiFetchCount, 0);
     });
 
-    it("should fall back to API for explicit dotted files missing from file list cache", async () => {
+    it("should short-circuit known-missing explicit files like deno.json from file list cache", async () => {
       let resolveCallCount = 0;
       let apiFetchCount = 0;
 
@@ -395,11 +395,13 @@ describe("ReadOperations", () => {
 
       readOps.setFileListReadyPromise(Promise.resolve());
 
-      const content = await readOps.readTextFile("deno.json");
-
-      assertEquals(content, "published API content");
-      assertEquals(resolveCallCount, 1);
-      assertEquals(apiFetchCount, 1);
+      await assertRejects(
+        () => readOps.readTextFile("deno.json"),
+        Error,
+        "404 Not Found",
+      );
+      assertEquals(resolveCallCount, 0);
+      assertEquals(apiFetchCount, 0);
     });
 
     it("should cache extension resolution to avoid repeated API calls", async () => {

--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -55,6 +55,11 @@ function previewText(content: string, max = 80): string {
   return content.length > max ? `${content.slice(0, max)}...` : content;
 }
 
+function hasExplicitExtension(path: string): boolean {
+  const lastSegment = path.split("/").pop() ?? path;
+  return lastSegment.includes(".") && lastSegment !== "." && lastSegment !== "..";
+}
+
 export class ReadOperations {
   private readonly inFlightRequests = new InFlightRequestDeduper<string>({
     timeoutMs: IN_FLIGHT_REQUEST_TIMEOUT_MS,
@@ -493,6 +498,20 @@ export class ReadOperations {
           isPreviewMode,
         );
         if (resolvedFromFileList) return resolvedFromFileList;
+
+        if (hasExplicitExtension(apiPath)) {
+          const exactPathKnown = await this.fileListIndex.hasPath(normalizedPath);
+          const hasExtensionCandidate = await this.fileListIndex.hasAnyPath(
+            EXTENSION_PRIORITY.map((ext) => `${normalizedPath}${ext}`),
+          );
+
+          if (exactPathKnown === false && hasExtensionCandidate === false) {
+            logger.debug("Known-missing explicit path in file list, skipping API fetch", {
+              path: normalizedPath,
+            });
+            throw new Error(`404 Not Found: ${normalizedPath}`);
+          }
+        }
       }
 
       const resolved = await this.tryResolveExtensionlessPath(


### PR DESCRIPTION
## Summary
- avoid remote deno.json file fetches when the release or environment file list already proves the file is absent
- teach the file list index to track known paths and resolve extensionless paths directly from cached file-list content
- add regression coverage for dotted extensionless paths and known-missing deno.json reads

## Testing
- deno test --allow-env src/platform/adapters/fs/veryfront/read-operations.test.ts