### PR TITLE
fix: correct circuit breaker error type to fix typecheck

### DIFF
--- a/src/modules/react-loader/ssr-module-loader/ssr-circuit-breaker.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-circuit-breaker.ts
@@ -37,15 +37,14 @@ export class SSRCircuitBreaker {
     ) {
       throw toError(
         createError({
-          type: "runtime",
+          type: "render",
           message:
             `Component ${filePath} is temporarily blocked due to repeated failures. Will retry in ${
               Math.ceil((CIRCUIT_BREAKER_RESET_MS - timeSinceFailure) / 1000)
             }s.`,
           context: {
-            file: filePath,
-            phase: "circuit-breaker",
-            failures: failureRecord.count,
+            component: filePath,
+            phase: "server",
           },
         }),
       );


### PR DESCRIPTION
## Summary
- Circuit breaker in `ssr-circuit-breaker.ts` used `type: "runtime"` which doesn't exist in the `VeryfrontErrorData` union, causing typecheck failure on main
- Also used `file` property which doesn't exist on any error context type
- Changed to `type: "render"` with proper `RenderContext` (`component`, `phase: "server"`)

## Test plan
- [x] `deno check` passes on the fixed file
- [ ] CI typecheck passes