### PR TITLE
fix: remove forced ws→wss upgrade that broke K8s WebSocket connections

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -612,5 +612,4 @@ describe("WebSocketManager", () => {
 
     manager.dispose();
   });
-
 });

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -410,7 +410,7 @@ describe("WebSocketManager", () => {
     }
   });
 
-  it("should upgrade ws:// to wss:// for non-localhost connections", () => {
+  it("should derive ws:// from http:// base URL", () => {
     const cache = {
       deleteByPrefixAsync: async () => 0,
       deleteByPrefixAndSuffixAsync: async () => 0,
@@ -444,11 +444,91 @@ describe("WebSocketManager", () => {
     const socket = MockWebSocket.instances.at(-1);
     assertExists(socket);
 
-    // http:// should be upgraded to wss:// for non-localhost
-    assertEquals(socket.url.startsWith("wss://"), true);
+    // http:// base URL should produce ws:// WebSocket URL
+    assertEquals(socket.url.startsWith("ws://"), true);
     // Token is sent via subprotocol, not query string
     assertEquals(socket.url.includes("token="), false);
     assertEquals(socket.protocols, ["bearer-test-token"]);
+
+    manager.dispose();
+  });
+
+  it("should derive wss:// from https:// base URL", () => {
+    const cache = {
+      deleteByPrefixAsync: async () => 0,
+      deleteByPrefixAndSuffixAsync: async () => 0,
+    } as unknown as FileCache;
+
+    const client = {
+      getProjectId: () => "project-1",
+      listAllFiles: async () => [],
+    } as unknown as VeryfrontApiClient;
+
+    const manager = new WebSocketManager({
+      apiBaseUrl: "https://api.example.com/api",
+      apiToken: "test-token",
+      projectSlug: "test-project",
+      cache,
+      client,
+      invalidationCallbacks: {},
+      getContentContext: () => ({
+        sourceType: "branch",
+        projectSlug: "test-project",
+        branch: "main",
+      }),
+      getContentSource: () => ({ type: "branch", branch: "main" }),
+      getProjectDir: () => undefined,
+      clearMemoryCaches: () => {},
+      clearFileListIndex: () => {},
+      setFileListCache: async () => {},
+    });
+
+    manager.connect("project-1");
+    const socket = MockWebSocket.instances.at(-1);
+    assertExists(socket);
+
+    // https:// base URL should produce wss:// WebSocket URL
+    assertEquals(socket.url.startsWith("wss://"), true);
+
+    manager.dispose();
+  });
+
+  it("should keep ws:// for K8s internal service hostnames", () => {
+    const cache = {
+      deleteByPrefixAsync: async () => 0,
+      deleteByPrefixAndSuffixAsync: async () => 0,
+    } as unknown as FileCache;
+
+    const client = {
+      getProjectId: () => "project-1",
+      listAllFiles: async () => [],
+    } as unknown as VeryfrontApiClient;
+
+    const manager = new WebSocketManager({
+      apiBaseUrl: "http://veryfront-api:80",
+      apiToken: "test-token",
+      projectSlug: "test-project",
+      cache,
+      client,
+      invalidationCallbacks: {},
+      getContentContext: () => ({
+        sourceType: "branch",
+        projectSlug: "test-project",
+        branch: "main",
+      }),
+      getContentSource: () => ({ type: "branch", branch: "main" }),
+      getProjectDir: () => undefined,
+      clearMemoryCaches: () => {},
+      clearFileListIndex: () => {},
+      setFileListCache: async () => {},
+    });
+
+    manager.connect("project-1");
+    const socket = MockWebSocket.instances.at(-1);
+    assertExists(socket);
+
+    // K8s internal service (http://) should stay as ws://
+    assertEquals(socket.url.startsWith("ws://"), true);
 
     manager.dispose();
   });
@@ -532,4 +612,5 @@ describe("WebSocketManager", () => {
 
     manager.dispose();
   });
+
 });

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -126,7 +126,7 @@ export class WebSocketManager {
       this.wsConsecutiveFailures = 0;
     }
 
-    let wsUrl = this.deps.apiBaseUrl
+    const wsUrl = this.deps.apiBaseUrl
       .replace(/^http:/, "ws:")
       .replace(/^https:/, "wss:")
       .replace(/\/api$/, "");

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -131,24 +131,9 @@ export class WebSocketManager {
       .replace(/^https:/, "wss:")
       .replace(/\/api$/, "");
 
-    // Enforce TLS for non-localhost connections to protect the auth token
-    if (wsUrl.startsWith("ws://")) {
-      try {
-        const host = new URL(wsUrl.replace(/^ws:/, "http:")).hostname;
-        const isLocal = host === "localhost" || host === "127.0.0.1" ||
-          host === "::1" || host === "[::1]";
-        if (!isLocal) {
-          wsUrl = wsUrl.replace(/^ws:/, "wss:");
-          logger.warn(
-            "Upgraded WebSocket connection to wss:// for non-localhost host",
-            this.getConnectionLogContext({ host }),
-          );
-        }
-      } catch {
-        // If URL parsing fails, upgrade to be safe
-        wsUrl = wsUrl.replace(/^ws:/, "wss:");
-      }
-    }
+    // The WebSocket protocol (ws vs wss) is derived from the configured
+    // apiBaseUrl (http→ws, https→wss). No forced upgrade is needed because
+    // the auth token is sent via a subprotocol header, not in the URL.
 
     const url = `${wsUrl}/ws/${projectId}/events`;
 


### PR DESCRIPTION
## Summary

- Removes the forced `ws://` → `wss://` upgrade for non-localhost WebSocket connections (introduced in #569)
- #583 moved the auth token from the URL query string to a subprotocol header, making the forced upgrade unnecessary
- WebSocket protocol now mirrors the configured `apiBaseUrl`: `http://` → `ws://`, `https://` → `wss://`

## Problem

The forced TLS upgrade broke WebSocket connections for internal service URLs (`http://`), preventing poke notifications from being received. This caused file cache to never invalidate, so the preview never updated after saves.

## Test plan

- [x] Existing WebSocket tests pass (17/17)
- [x] New test: `http://` → `ws://`, `https://` → `wss://`, K8s internal hostname stays `ws://`
- [ ] After deploy: verify server logs show successful WebSocket connection
- [ ] After deploy: edit file, Cmd+S → preview updates