### PR TITLE
fix: resolve #deno-config import in SSR VF Modules transform

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/transforms/pipeline/stages/ssr-vf-modules.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules.test.ts
@@ -12,8 +12,13 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import { buildReactUrl, getReactImportMap } from "../../import-rewriter/url-builder.ts";
+import { resolveVeryfrontModuleUrl } from "../../veryfront-module-urls.ts";
 import { ssrVfModulesPlugin } from "./ssr-vf-modules.ts";
-import { _testExports } from "./ssr-vf-modules/index.ts";
+import {
+  _testExports,
+  cacheTransformedCode,
+  transformFrameworkSource,
+} from "./ssr-vf-modules/index.ts";
 import type { TransformContext } from "../types.ts";
 
 const { findVfModuleImports, findRelativeImports, FRAMEWORK_ROOT, EMBEDDED_SRC_DIR, EXTENSIONS } =
@@ -404,6 +409,28 @@ describe("ssr-vf-modules relative import resolution", {
       fileImportCount > 0,
       true,
       "Cached module should have file:// imports for dependencies",
+    );
+  });
+
+  it("preserves deno.json imports and exports when rewriting #deno-config", async () => {
+    const fs = createFileSystem();
+    const sourcePath = `${FRAMEWORK_ROOT}/src/transforms/veryfront-module-urls.ts`;
+    const content = await fs.readTextFile(sourcePath);
+
+    const transformed = await transformFrameworkSource(
+      content,
+      sourcePath,
+      REACT_DEFAULT_VERSION,
+      "/tmp/test-project",
+      fs,
+    );
+    const cachePath = await cacheTransformedCode(transformed, sourcePath, fs);
+    const transformedModule = await import(`file://${cachePath}`);
+
+    assertEquals(
+      transformedModule.resolveVeryfrontModuleUrl("veryfront/chat"),
+      resolveVeryfrontModuleUrl("veryfront/chat"),
+      "Transformed module should preserve import/export mappings from deno.json",
     );
   });
 });

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
@@ -291,7 +291,22 @@ export async function transformFrameworkCode(
     // Rewrite imports to resolved paths
     const reactImportMap = getReactImportMap(ctx.reactVersion);
 
+    // Handle Deno import-map aliases (e.g. #deno-config) that only exist in
+    // the Deno runtime and cannot be resolved by esm.sh or the HTTP cache.
+    // We create a cached JS stub module so the transformed code can import it.
+    let denoConfigStubUrl: string | null = null;
+    if (transformed.includes('"#deno-config"') || transformed.includes("'#deno-config'")) {
+      const stubCode = `export default ${JSON.stringify({ version: VERSION })};`;
+      const stubPath = await cacheTransformedCode(stubCode, "#deno-config-stub", ctx.fs);
+      denoConfigStubUrl = `file://${stubPath}`;
+    }
+
     transformed = await replaceSpecifiers(transformed, (specifier) => {
+      // Handle Deno import-map aliases
+      if (specifier === "#deno-config") {
+        return denoConfigStubUrl;
+      }
+
       // Handle #veryfront/ imports
       if (specifier.startsWith("#veryfront/")) {
         return veryfrontReplacements.get(specifier) ?? null;

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
@@ -7,6 +7,7 @@
 
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { join } from "#veryfront/compat/path/index.ts";
+import denoConfig from "#deno-config" with { type: "json" };
 import { rendererLogger as logger } from "#veryfront/utils";
 import { IMPORT_RESOLUTION_ERROR } from "#veryfront/errors";
 import { replaceSpecifiers } from "../../../esm/lexer.ts";
@@ -29,6 +30,8 @@ import {
   transformingFiles,
   veryfrontTransformCache,
 } from "./constants.ts";
+
+const DENO_CONFIG_STUB_CODE = `export default ${JSON.stringify(denoConfig)};`;
 
 /**
  * Check if a transformed code string is a cycle placeholder.
@@ -293,11 +296,15 @@ export async function transformFrameworkCode(
 
     // Handle Deno import-map aliases (e.g. #deno-config) that only exist in
     // the Deno runtime and cannot be resolved by esm.sh or the HTTP cache.
-    // We create a cached JS stub module so the transformed code can import it.
+    // We create a cached JS stub module so the transformed code can import it
+    // without losing access to imports/exports metadata from deno.json.
     let denoConfigStubUrl: string | null = null;
     if (transformed.includes('"#deno-config"') || transformed.includes("'#deno-config'")) {
-      const stubCode = `export default ${JSON.stringify({ version: VERSION })};`;
-      const stubPath = await cacheTransformedCode(stubCode, "#deno-config-stub", ctx.fs);
+      const stubPath = await cacheTransformedCode(
+        DENO_CONFIG_STUB_CODE,
+        "#deno-config-stub",
+        ctx.fs,
+      );
       denoConfigStubUrl = `file://${stubPath}`;
     }
 


### PR DESCRIPTION
## Summary
- The `#deno-config` Deno import-map alias (`→ ./deno.json`) was unhandled in the SSR VF Modules transform's `replaceSpecifiers` callback, causing it to fall through to `cacheHttpImportsToLocal` which tried esm.sh and failed
- This broke any framework module that transitively imports `version.ts` (e.g. `veryfront/chat` → `#veryfront/utils` → `version.ts` → `#deno-config`)
- Fix creates a cached JS stub module (`export default { version: "..." }`) and rewrites the `#deno-config` import to point to it during transformation
- Bumps version to 0.1.57 to trigger release

## Test plan
- [x] `deno check` passes on modified file
- [x] SSR VF Modules test suite passes (4 passed, 46 steps)
- [x] `version.test.ts` passes
- [ ] Verify docs-agent template with `veryfront/chat` import works in preview after deploy