### PR TITLE
fix: resolve framework module 404s for #veryfront/* browser imports

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -131,6 +131,22 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     assertEquals(response.status, 200);
   });
 
+  it("should resolve framework directory imports to index files", async () => {
+    const response = await serve(
+      new Request("http://localhost:3000/_vf_modules/_veryfront/utils"),
+    );
+
+    assertEquals(response.status, 200);
+  });
+
+  it("should serve remapped framework directories through their resolved platform paths", async () => {
+    const response = await serve(
+      new Request("http://localhost:3000/_vf_modules/_veryfront/platform/compat/console"),
+    );
+
+    assertEquals(response.status, 200);
+  });
+
   it("should serve dnt shims as JavaScript content type", async () => {
     const response = await serve(
       new Request("http://localhost:3000/_vf_modules/_veryfront/_dnt.shims.js"),

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -512,19 +512,23 @@ async function findSourceFile(
         ? basePathWithoutExt.slice(prefix.length)
         : basePathWithoutExt;
 
-      for (const ext of extensions) {
-        const frameworkPath = join(frameworkDir, pathWithinFramework + ext);
-        try {
-          const stat = await platformFs.stat(frameworkPath);
-          if (stat.isFile) {
-            logger.debug(`Found framework ${label} file`, {
-              basePath: basePathWithoutExt,
-              resolvedPath: frameworkPath,
-            });
-            return { path: frameworkPath, isFrameworkFile: true };
+      // Try direct file match first, then index file fallback
+      const candidates = [pathWithinFramework, `${pathWithinFramework}/index`];
+      for (const candidate of candidates) {
+        for (const ext of extensions) {
+          const frameworkPath = join(frameworkDir, candidate + ext);
+          try {
+            const stat = await platformFs.stat(frameworkPath);
+            if (stat.isFile) {
+              logger.debug(`Found framework ${label} file`, {
+                basePath: basePathWithoutExt,
+                resolvedPath: frameworkPath,
+              });
+              return { path: frameworkPath, isFrameworkFile: true };
+            }
+          } catch (_) {
+            /* expected: file may not exist at this extension */
           }
-        } catch (_) {
-          /* expected: file may not exist at this extension */
         }
       }
     }

--- a/src/transforms/import-rewriter/strategies/veryfront-strategy.test.ts
+++ b/src/transforms/import-rewriter/strategies/veryfront-strategy.test.ts
@@ -96,4 +96,28 @@ describe("VeryfrontStrategy", () => {
       );
     });
   });
+
+  describe("internal import-map resolution", () => {
+    it("should resolve exact internal aliases using deno.json mappings", () => {
+      const result = strategy.rewrite(
+        makeInfo("#veryfront/compat/console"),
+        makeCtx({ target: "browser" }),
+      );
+      assertEquals(
+        result.specifier,
+        "/_vf_modules/_veryfront/platform/compat/console/index.js",
+      );
+    });
+
+    it("should resolve prefix internal aliases using the longest matching mapping", () => {
+      const result = strategy.rewrite(
+        makeInfo("#veryfront/compat/path/index.ts"),
+        makeCtx({ target: "ssr" }),
+      );
+      assertEquals(
+        result.specifier,
+        "/_vf_modules/_veryfront/platform/compat/path/index.js?ssr=true",
+      );
+    });
+  });
 });

--- a/src/transforms/import-rewriter/strategies/veryfront-strategy.ts
+++ b/src/transforms/import-rewriter/strategies/veryfront-strategy.ts
@@ -12,7 +12,7 @@ import type {
   RewriteResult,
 } from "../types.ts";
 import { buildVeryfrontModuleUrl } from "../url-builder.ts";
-import { resolveVeryfrontModuleUrl } from "../../veryfront-module-urls.ts";
+import { resolveInternalModuleUrl, resolveVeryfrontModuleUrl } from "../../veryfront-module-urls.ts";
 
 /**
  * SSR-specific module overrides.
@@ -46,9 +46,16 @@ export class VeryfrontStrategy implements ImportRewriteStrategy {
       // Try resolving via deno.json mappings first (veryfront/head → react/components/Head.js)
       const mapped = resolveVeryfrontModuleUrl(`veryfront/${path}`);
       if (mapped) {
-        // For SSR, append ?ssr=true to signal server-side rendering
         if (ctx.target === "ssr") return { specifier: `${mapped}?ssr=true` };
         return { specifier: mapped };
+      }
+      // Try resolving via #veryfront/* import map (handles paths where the
+      // filesystem layout differs from the specifier, e.g. #veryfront/compat/console
+      // maps to src/platform/compat/console/index.ts, not src/compat/console.ts)
+      const internalMapped = resolveInternalModuleUrl(specifier);
+      if (internalMapped) {
+        if (ctx.target === "ssr") return { specifier: `${internalMapped}?ssr=true` };
+        return { specifier: internalMapped };
       }
       const builtUrl = buildVeryfrontModuleUrl(path);
       if (ctx.target === "ssr") return { specifier: `${builtUrl}?ssr=true` };

--- a/src/transforms/import-rewriter/strategies/veryfront-strategy.ts
+++ b/src/transforms/import-rewriter/strategies/veryfront-strategy.ts
@@ -12,7 +12,10 @@ import type {
   RewriteResult,
 } from "../types.ts";
 import { buildVeryfrontModuleUrl } from "../url-builder.ts";
-import { resolveInternalModuleUrl, resolveVeryfrontModuleUrl } from "../../veryfront-module-urls.ts";
+import {
+  resolveInternalModuleUrl,
+  resolveVeryfrontModuleUrl,
+} from "../../veryfront-module-urls.ts";
 
 /**
  * SSR-specific module overrides.

--- a/src/transforms/pipeline/stages/ssr-vf-modules.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules.test.ts
@@ -12,7 +12,11 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import { buildReactUrl, getReactImportMap } from "../../import-rewriter/url-builder.ts";
-import { resolveVeryfrontModuleUrl } from "../../veryfront-module-urls.ts";
+import {
+  resolveInternalModuleTarget,
+  resolveInternalModuleUrl,
+  resolveVeryfrontModuleUrl,
+} from "../../veryfront-module-urls.ts";
 import { ssrVfModulesPlugin } from "./ssr-vf-modules.ts";
 import {
   _testExports,
@@ -281,6 +285,15 @@ describe("ssr-vf-modules integration", { sanitizeOps: false, sanitizeResources: 
     assertStringIncludes(result!, "/src/utils");
   });
 
+  it("resolves prefix-mapped #veryfront/ specifiers to source paths", async () => {
+    const { resolveVeryfrontSourcePath } = _testExports;
+
+    const result = await resolveVeryfrontSourcePath("#veryfront/compat/path/index.ts");
+
+    assertEquals(result !== null, true, "Should resolve #veryfront/compat/path/index.ts");
+    assertStringIncludes(result!, "/src/platform/compat/path/index.ts");
+  });
+
   it("returns null for non-existent #veryfront/ imports", async () => {
     const { resolveVeryfrontSourcePath } = _testExports;
 
@@ -431,6 +444,16 @@ describe("ssr-vf-modules relative import resolution", {
       transformedModule.resolveVeryfrontModuleUrl("veryfront/chat"),
       resolveVeryfrontModuleUrl("veryfront/chat"),
       "Transformed module should preserve import/export mappings from deno.json",
+    );
+    assertEquals(
+      transformedModule.resolveInternalModuleUrl("#veryfront/compat/path/index.ts"),
+      resolveInternalModuleUrl("#veryfront/compat/path/index.ts"),
+      "Transformed module should preserve internal prefix mappings from deno.json",
+    );
+    assertEquals(
+      transformedModule.resolveInternalModuleTarget("#veryfront/compat/path/index.ts"),
+      resolveInternalModuleTarget("#veryfront/compat/path/index.ts"),
+      "Transformed module should preserve internal target resolution from deno.json",
     );
   });
 });

--- a/src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.ts
@@ -8,6 +8,7 @@
 import { createFileSystem, exists } from "#veryfront/platform/compat/fs.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { rendererLogger as logger } from "#veryfront/utils";
+import { resolveInternalModuleTarget } from "../../../veryfront-module-urls.ts";
 import {
   EMBEDDED_SRC_DIR,
   EXTENSIONS,
@@ -120,7 +121,10 @@ export async function resolveFrameworkFile(
 export async function resolveVeryfrontSourcePath(specifier: string): Promise<string | null> {
   if (!specifier.startsWith("#veryfront/")) return null;
 
-  const relativePath = specifier.slice("#veryfront/".length);
+  const mappedTarget = resolveInternalModuleTarget(specifier);
+  if (!mappedTarget?.startsWith("./src/")) return null;
+
+  const relativePath = mappedTarget.slice("./src/".length);
   const hasExtension = /\.(tsx?|jsx?|mjs)$/.test(relativePath);
 
   // Check embedded sources first (for compiled binaries), then regular src/

--- a/src/transforms/veryfront-module-urls.test.ts
+++ b/src/transforms/veryfront-module-urls.test.ts
@@ -1,0 +1,52 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  resolveInternalModuleTarget,
+  resolveInternalModuleUrl,
+  resolveVeryfrontModuleTarget,
+  resolveVeryfrontModuleUrl,
+} from "./veryfront-module-urls.ts";
+
+describe("veryfront-module-urls", () => {
+  it("resolves public exact mappings from deno.json", () => {
+    assertEquals(resolveVeryfrontModuleTarget("veryfront/head"), "./src/react/components/Head.tsx");
+    assertEquals(
+      resolveVeryfrontModuleUrl("veryfront/head"),
+      "/_vf_modules/_veryfront/react/components/Head.js",
+    );
+  });
+
+  it("resolves internal exact mappings from deno.json", () => {
+    assertEquals(resolveInternalModuleTarget("#veryfront/utils"), "./src/utils/index.ts");
+    assertEquals(
+      resolveInternalModuleUrl("#veryfront/utils"),
+      "/_vf_modules/_veryfront/utils/index.js",
+    );
+    assertEquals(
+      resolveInternalModuleUrl("#veryfront/compat/console"),
+      "/_vf_modules/_veryfront/platform/compat/console/index.js",
+    );
+  });
+
+  it("resolves internal prefix mappings using the longest matching alias", () => {
+    assertEquals(
+      resolveInternalModuleTarget("#veryfront/compat/path/index.ts"),
+      "./src/platform/compat/path/index.ts",
+    );
+    assertEquals(
+      resolveInternalModuleUrl("#veryfront/compat/path/index.ts"),
+      "/_vf_modules/_veryfront/platform/compat/path/index.js",
+    );
+  });
+
+  it("falls back to the root #veryfront/ prefix for unmapped internal files", () => {
+    assertEquals(
+      resolveInternalModuleTarget("#veryfront/react/head-collector.ts"),
+      "./src/react/head-collector.ts",
+    );
+    assertEquals(
+      resolveInternalModuleUrl("#veryfront/react/head-collector.ts"),
+      "/_vf_modules/_veryfront/react/head-collector.js",
+    );
+  });
+});

--- a/src/transforms/veryfront-module-urls.ts
+++ b/src/transforms/veryfront-module-urls.ts
@@ -8,41 +8,82 @@ type DenoConfig = {
 const MODULE_EXT_RE = /\.(mjs|cjs|js|jsx|ts|tsx)$/;
 const SRC_PREFIX = "./src/";
 
+type ModuleTargetIndex = {
+  exactTargets: Map<string, string>;
+  prefixTargets: Array<{ specifierPrefix: string; targetPrefix: string }>;
+};
+
+function createTargetIndex(): ModuleTargetIndex {
+  return {
+    exactTargets: new Map<string, string>(),
+    prefixTargets: [],
+  };
+}
+
+function normalizeModulePath(path: string): string {
+  if (!path) return path;
+  if (path.endsWith("/")) return path;
+  return path.replace(MODULE_EXT_RE, ".js");
+}
+
 function toModuleServerUrl(target: string): string | null {
   if (!target.startsWith(SRC_PREFIX)) return null;
 
   const relative = target.slice(SRC_PREFIX.length);
   if (!relative) return null;
 
-  const withoutExt = relative.replace(MODULE_EXT_RE, "");
-  return `/_vf_modules/_veryfront/${withoutExt}.js`;
+  return `/_vf_modules/_veryfront/${normalizeModulePath(relative)}`;
 }
 
 function addMapping(
-  map: Map<string, string>,
+  index: ModuleTargetIndex,
   specifier: string,
   target: string,
 ): void {
-  const url = toModuleServerUrl(target);
-  if (!url) return;
-  map.set(specifier, url);
+  if (!target.startsWith(SRC_PREFIX)) return;
+
+  if (specifier.endsWith("/")) {
+    index.prefixTargets.push({
+      specifierPrefix: specifier,
+      targetPrefix: target.endsWith("/") ? target : `${target}/`,
+    });
+    return;
+  }
+
+  index.exactTargets.set(specifier, target);
+}
+
+function finalizeIndex(index: ModuleTargetIndex): void {
+  index.prefixTargets.sort((a, b) => b.specifierPrefix.length - a.specifierPrefix.length);
+}
+
+function resolveTarget(index: ModuleTargetIndex, specifier: string): string | null {
+  const exact = index.exactTargets.get(specifier);
+  if (exact) return exact;
+
+  for (const { specifierPrefix, targetPrefix } of index.prefixTargets) {
+    if (!specifier.startsWith(specifierPrefix)) continue;
+    return `${targetPrefix}${specifier.slice(specifierPrefix.length)}`;
+  }
+
+  return null;
 }
 
 const config = denoConfig as DenoConfig;
-const veryfrontModuleUrlMap = new Map<string, string>();
-const internalModuleUrlMap = new Map<string, string>();
+const veryfrontTargetIndex = createTargetIndex();
+const internalTargetIndex = createTargetIndex();
 
 for (const [specifier, target] of Object.entries(config.imports ?? {})) {
   if (typeof target !== "string") continue;
 
-  if (specifier.startsWith("veryfront/")) {
-    addMapping(veryfrontModuleUrlMap, specifier, target);
+  if (specifier === "veryfront" || specifier.startsWith("veryfront/")) {
+    addMapping(veryfrontTargetIndex, specifier, target);
   }
 
-  // Also index #veryfront/* internal imports so the import rewriter can
+  // Also index #veryfront imports so the import rewriter can
   // generate correct /_vf_modules/ URLs that match the actual filesystem layout.
-  if (specifier.startsWith("#veryfront/")) {
-    addMapping(internalModuleUrlMap, specifier, target);
+  if (specifier === "#veryfront" || specifier.startsWith("#veryfront/")) {
+    addMapping(internalTargetIndex, specifier, target);
   }
 }
 
@@ -50,16 +91,28 @@ for (const [key, target] of Object.entries(config.exports ?? {})) {
   if (typeof target !== "string") continue;
 
   if (key === ".") {
-    addMapping(veryfrontModuleUrlMap, "veryfront", target);
+    addMapping(veryfrontTargetIndex, "veryfront", target);
     continue;
   }
 
   if (!key.startsWith("./")) continue;
-  addMapping(veryfrontModuleUrlMap, `veryfront/${key.slice(2)}`, target);
+  addMapping(veryfrontTargetIndex, `veryfront/${key.slice(2)}`, target);
+}
+
+finalizeIndex(veryfrontTargetIndex);
+finalizeIndex(internalTargetIndex);
+
+export function resolveVeryfrontModuleTarget(specifier: string): string | null {
+  return resolveTarget(veryfrontTargetIndex, specifier);
+}
+
+export function resolveInternalModuleTarget(specifier: string): string | null {
+  return resolveTarget(internalTargetIndex, specifier);
 }
 
 export function resolveVeryfrontModuleUrl(specifier: string): string | null {
-  return veryfrontModuleUrlMap.get(specifier) ?? null;
+  const target = resolveVeryfrontModuleTarget(specifier);
+  return target ? toModuleServerUrl(target) : null;
 }
 
 /**
@@ -69,5 +122,6 @@ export function resolveVeryfrontModuleUrl(specifier: string): string | null {
  * maps to src/platform/compat/console/index.ts, not src/compat/console.ts).
  */
 export function resolveInternalModuleUrl(specifier: string): string | null {
-  return internalModuleUrlMap.get(specifier) ?? null;
+  const target = resolveInternalModuleTarget(specifier);
+  return target ? toModuleServerUrl(target) : null;
 }

--- a/src/transforms/veryfront-module-urls.ts
+++ b/src/transforms/veryfront-module-urls.ts
@@ -30,11 +30,20 @@ function addMapping(
 
 const config = denoConfig as DenoConfig;
 const veryfrontModuleUrlMap = new Map<string, string>();
+const internalModuleUrlMap = new Map<string, string>();
 
 for (const [specifier, target] of Object.entries(config.imports ?? {})) {
-  if (!specifier.startsWith("veryfront/")) continue;
   if (typeof target !== "string") continue;
-  addMapping(veryfrontModuleUrlMap, specifier, target);
+
+  if (specifier.startsWith("veryfront/")) {
+    addMapping(veryfrontModuleUrlMap, specifier, target);
+  }
+
+  // Also index #veryfront/* internal imports so the import rewriter can
+  // generate correct /_vf_modules/ URLs that match the actual filesystem layout.
+  if (specifier.startsWith("#veryfront/")) {
+    addMapping(internalModuleUrlMap, specifier, target);
+  }
 }
 
 for (const [key, target] of Object.entries(config.exports ?? {})) {
@@ -51,4 +60,14 @@ for (const [key, target] of Object.entries(config.exports ?? {})) {
 
 export function resolveVeryfrontModuleUrl(specifier: string): string | null {
   return veryfrontModuleUrlMap.get(specifier) ?? null;
+}
+
+/**
+ * Resolve an internal #veryfront/* specifier to a /_vf_modules/ URL.
+ * Uses the deno.json import map to get the correct filesystem path,
+ * which may differ from the specifier path (e.g. #veryfront/compat/console
+ * maps to src/platform/compat/console/index.ts, not src/compat/console.ts).
+ */
+export function resolveInternalModuleUrl(specifier: string): string | null {
+  return internalModuleUrlMap.get(specifier) ?? null;
 }


### PR DESCRIPTION
## Summary
- Module server's `findSourceFile()` now tries index files for framework paths (e.g. `_veryfront/utils` → `src/utils/index.ts`)
- Import rewriter now uses deno.json import map to resolve `#veryfront/*` internal specifiers to correct `/_vf_modules/` URLs, instead of naively stripping the prefix
- Fixes 404s for `/_vf_modules/_veryfront/compat/console` and `/_vf_modules/_veryfront/utils` which caused client-side hydration failures

## Test plan
- [x] `deno check` passes on all modified files
- [x] All 78 transform tests pass
- [x] All 6 module server tests pass
- [x] Veryfront strategy tests pass
- [ ] Verify no 404s for framework modules in browser console after deploy