### PR TITLE
fix: resolve #deno-config import in browser modules

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -189,6 +189,7 @@ async function updateTemplates(newVersion: string) {
 	const filesToUpdate = [
 		"cli/commands/init/config-generator.ts",
 		"src/core/utils/constants/cdn.ts",
+		"src/utils/version.ts",
 	];
 
 	for (const filePath of filesToUpdate) {

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -158,6 +158,23 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     assertEquals(text.includes("0.1.59"), true);
   });
 
+  it("should serve #deno-config as embedded JSON for browser imports", async () => {
+    const response = await serve(
+      new Request("http://localhost:3000/_vf_modules/_deno-config.json"),
+    );
+
+    assertEquals(response.status, 200);
+    assertEquals(response.headers.get("content-type"), "application/json; charset=utf-8");
+
+    const text = await response.text();
+    const config = JSON.parse(text) as {
+      version?: string;
+      imports?: Record<string, string>;
+    };
+    assertEquals(config.version, "0.1.59");
+    assertEquals(config.imports?.["#deno-config"], "./deno.json");
+  });
+
   it("should serve dnt shims as JavaScript content type", async () => {
     const response = await serve(
       new Request("http://localhost:3000/_vf_modules/_veryfront/_dnt.shims.js"),

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -147,6 +147,17 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     assertEquals(response.status, 200);
   });
 
+  it("should serve browser-safe framework version modules without #deno-config", async () => {
+    const response = await serve(
+      new Request("http://localhost:3000/_vf_modules/_veryfront/utils/version.js"),
+    );
+
+    assertEquals(response.status, 200);
+    const text = await response.text();
+    assertEquals(text.includes("#deno-config"), false);
+    assertEquals(text.includes("0.1.59"), true);
+  });
+
   it("should serve dnt shims as JavaScript content type", async () => {
     const response = await serve(
       new Request("http://localhost:3000/_vf_modules/_veryfront/_dnt.shims.js"),

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -10,6 +10,8 @@
 
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
+import { VERSION } from "#veryfront/utils/version.ts";
 import { isModuleRequest } from "./module-server.ts";
 
 describe("isModuleRequest", () => {
@@ -56,12 +58,12 @@ describe("isModuleRequest", () => {
 // pipeline which spawns a long-lived child process. This is a pre-existing
 // resource that cannot be torn down inside a unit test.
 describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, () => {
-  async function serve(req: Request): Promise<Response> {
+  async function serve(req: Request, projectDir = "/tmp/test"): Promise<Response> {
     const { serveModule } = await import("./module-server.ts");
     return await serveModule(req, {
       projectId: "test",
-      projectDir: "/tmp/test",
-      adapter: {} as any,
+      projectDir,
+      adapter: denoAdapter,
     });
   }
 
@@ -155,24 +157,22 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     assertEquals(response.status, 200);
     const text = await response.text();
     assertEquals(text.includes("#deno-config"), false);
-    assertEquals(text.includes("0.1.59"), true);
+    assertEquals(text.includes(VERSION), true);
   });
 
-  it("should serve #deno-config as embedded JSON for browser imports", async () => {
+  it("should serve #deno-config as embedded JS module for browser imports", async () => {
     const response = await serve(
-      new Request("http://localhost:3000/_vf_modules/_deno-config.json"),
+      new Request("http://localhost:3000/_vf_modules/_veryfront/_deno-config.js"),
     );
 
     assertEquals(response.status, 200);
-    assertEquals(response.headers.get("content-type"), "application/json; charset=utf-8");
+    const contentType = response.headers.get("content-type") ?? "";
+    assertEquals(contentType.includes("javascript"), true);
 
     const text = await response.text();
-    const config = JSON.parse(text) as {
-      version?: string;
-      imports?: Record<string, string>;
-    };
-    assertEquals(config.version, "0.1.59");
-    assertEquals(config.imports?.["#deno-config"], "./deno.json");
+    // esbuild may transform `export default {...}` into other export forms
+    assertEquals(text.includes(VERSION), true);
+    assertEquals(text.includes("version"), true);
   });
 
   it("should serve dnt shims as JavaScript content type", async () => {

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -4,7 +4,7 @@ import { join } from "#veryfront/compat/path/index.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { type TransformOptions, transformToESM } from "#veryfront/transforms/esm-transform.ts";
-import { serverLogger } from "#veryfront/utils";
+import { serverLogger, VERSION } from "#veryfront/utils";
 import { HTTP_NOT_FOUND, HTTP_OK, HTTP_SERVER_ERROR } from "#veryfront/utils";
 import { getContentTypeForPath } from "#veryfront/server/handlers/utils/content-types.ts";
 import { createSecureFs } from "#veryfront/security";
@@ -79,6 +79,9 @@ export default {};
     `export default {};`,
   ].join("\n") + "\n",
   "_dnt.polyfills": `export default {};\n`,
+  // Deno import-map alias stub for browser — version.ts imports #deno-config
+  // which only exists in the Deno runtime. Serve a JS module with version info.
+  "_deno-config": `export default ${JSON.stringify({ version: VERSION })};\n`,
 };
 
 const DEV_MODULE_PREFIX = /^\/(?:_vf_modules|_veryfront\/modules)\//;

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -4,7 +4,8 @@ import { join } from "#veryfront/compat/path/index.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { type TransformOptions, transformToESM } from "#veryfront/transforms/esm-transform.ts";
-import { serverLogger, VERSION } from "#veryfront/utils";
+import denoConfig from "#deno-config" with { type: "json" };
+import { serverLogger } from "#veryfront/utils";
 import { HTTP_NOT_FOUND, HTTP_OK, HTTP_SERVER_ERROR } from "#veryfront/utils";
 import { getContentTypeForPath } from "#veryfront/server/handlers/utils/content-types.ts";
 import { createSecureFs } from "#veryfront/security";
@@ -79,9 +80,9 @@ export default {};
     `export default {};`,
   ].join("\n") + "\n",
   "_dnt.polyfills": `export default {};\n`,
-  // Deno import-map alias stub for browser — version.ts imports #deno-config
-  // which only exists in the Deno runtime. Serve a JS module with version info.
-  "_deno-config": `export default ${JSON.stringify({ version: VERSION })};\n`,
+  // Deno import-map alias stub for browser/HTTP-served modules.
+  // Keep the real deno.json shape so import-map readers continue to work.
+  "_deno-config": JSON.stringify(denoConfig),
 };
 
 const DEV_MODULE_PREFIX = /^\/(?:_vf_modules|_veryfront\/modules)\//;
@@ -450,6 +451,7 @@ async function findSourceFile(
 ): Promise<FindSourceFileResult | null> {
   // Extensions including .src for compiled binary embedded sources
   const extensions = [
+    ".json",
     ".tsx.src",
     ".ts.src",
     ".jsx.src",
@@ -468,7 +470,7 @@ async function findSourceFile(
 
   const hasKnownExt = extensions.some((ext) => basePath.endsWith(ext));
   const rawBasePathWithoutExt = hasKnownExt
-    ? basePath.replace(/\.(tsx|ts|jsx|js|mdx|md)(\.src)?$/, "")
+    ? basePath.replace(/\.(json|tsx|ts|jsx|js|mdx|md)(\.src)?$/, "")
     : basePath;
   let basePathWithoutExt = rawBasePathWithoutExt.replace(/^\/+/, "");
   if (basePathWithoutExt.startsWith("_vf_modules/")) {
@@ -497,7 +499,7 @@ async function findSourceFile(
       basePath: basePathWithoutExt,
     });
     return {
-      path: `embedded:${basePathWithoutExt}`,
+      path: `embedded:${basePath}`,
       isFrameworkFile: true,
       embeddedContent,
     };

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -4,8 +4,7 @@ import { join } from "#veryfront/compat/path/index.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { type TransformOptions, transformToESM } from "#veryfront/transforms/esm-transform.ts";
-import denoConfig from "#deno-config" with { type: "json" };
-import { serverLogger } from "#veryfront/utils";
+import { serverLogger, VERSION } from "#veryfront/utils";
 import { HTTP_NOT_FOUND, HTTP_OK, HTTP_SERVER_ERROR } from "#veryfront/utils";
 import { getContentTypeForPath } from "#veryfront/server/handlers/utils/content-types.ts";
 import { createSecureFs } from "#veryfront/security";
@@ -80,9 +79,10 @@ export default {};
     `export default {};`,
   ].join("\n") + "\n",
   "_dnt.polyfills": `export default {};\n`,
-  // Deno import-map alias stub for browser/HTTP-served modules.
-  // Keep the real deno.json shape so import-map readers continue to work.
-  "_deno-config": JSON.stringify(denoConfig),
+  // Deno import-map alias stub for browser/HTTP-served framework modules.
+  // Must be a JS module (not JSON) because esbuild strips `with { type: "json" }`
+  // at es2020 target, and browsers reject JSON MIME type without the assertion.
+  "_veryfront/_deno-config": `export default ${JSON.stringify({ version: VERSION })};\n`,
 };
 
 const DEV_MODULE_PREFIX = /^\/(?:_vf_modules|_veryfront\/modules)\//;

--- a/src/transforms/import-rewriter/strategies/veryfront-strategy.test.ts
+++ b/src/transforms/import-rewriter/strategies/veryfront-strategy.test.ts
@@ -102,12 +102,12 @@ describe("VeryfrontStrategy", () => {
   });
 
   describe("internal import-map resolution", () => {
-    it("should rewrite #deno-config to the browser JSON stub", () => {
+    it("should rewrite #deno-config to the framework-scoped browser stub", () => {
       const result = strategy.rewrite(
         makeInfo("#deno-config"),
         makeCtx({ target: "browser" }),
       );
-      assertEquals(result.specifier, "/_vf_modules/_deno-config.json");
+      assertEquals(result.specifier, "/_vf_modules/_veryfront/_deno-config.js");
     });
 
     it("should resolve exact internal aliases using deno.json mappings", () => {

--- a/src/transforms/import-rewriter/strategies/veryfront-strategy.test.ts
+++ b/src/transforms/import-rewriter/strategies/veryfront-strategy.test.ts
@@ -44,6 +44,10 @@ describe("VeryfrontStrategy", () => {
       assertEquals(strategy.matches("veryfront", makeCtx()), true);
     });
 
+    it("should match #deno-config", () => {
+      assertEquals(strategy.matches("#deno-config", makeCtx()), true);
+    });
+
     it("should not match other specifiers", () => {
       assertEquals(strategy.matches("react", makeCtx()), false);
       assertEquals(strategy.matches("lodash", makeCtx()), false);
@@ -98,6 +102,14 @@ describe("VeryfrontStrategy", () => {
   });
 
   describe("internal import-map resolution", () => {
+    it("should rewrite #deno-config to the browser JSON stub", () => {
+      const result = strategy.rewrite(
+        makeInfo("#deno-config"),
+        makeCtx({ target: "browser" }),
+      );
+      assertEquals(result.specifier, "/_vf_modules/_deno-config.json");
+    });
+
     it("should resolve exact internal aliases using deno.json mappings", () => {
       const result = strategy.rewrite(
         makeInfo("#veryfront/compat/console"),

--- a/src/transforms/import-rewriter/strategies/veryfront-strategy.ts
+++ b/src/transforms/import-rewriter/strategies/veryfront-strategy.ts
@@ -45,9 +45,10 @@ export class VeryfrontStrategy implements ImportRewriteStrategy {
     const specifier = info.specifier;
 
     // Handle #deno-config — Deno import-map alias that doesn't exist in browsers.
-    // Rewrite to an embedded polyfill served by the module server.
+    // Rewrite to embedded JSON served by the module server so
+    // `with { type: "json" }` imports remain valid in browsers.
     if (specifier === "#deno-config") {
-      return { specifier: "/_vf_modules/_deno-config.js" };
+      return { specifier: "/_vf_modules/_deno-config.json" };
     }
 
     // Handle #veryfront/* (internal framework imports)

--- a/src/transforms/import-rewriter/strategies/veryfront-strategy.ts
+++ b/src/transforms/import-rewriter/strategies/veryfront-strategy.ts
@@ -45,10 +45,10 @@ export class VeryfrontStrategy implements ImportRewriteStrategy {
     const specifier = info.specifier;
 
     // Handle #deno-config — Deno import-map alias that doesn't exist in browsers.
-    // Rewrite to embedded JSON served by the module server so
-    // `with { type: "json" }` imports remain valid in browsers.
+    // Rewrite to a JS module (not JSON) because esbuild strips `with { type: "json" }`
+    // at es2020 target and browsers reject JSON MIME without the assertion.
     if (specifier === "#deno-config") {
-      return { specifier: "/_vf_modules/_deno-config.json" };
+      return { specifier: "/_vf_modules/_veryfront/_deno-config.js" };
     }
 
     // Handle #veryfront/* (internal framework imports)

--- a/src/transforms/import-rewriter/strategies/veryfront-strategy.ts
+++ b/src/transforms/import-rewriter/strategies/veryfront-strategy.ts
@@ -36,12 +36,19 @@ export class VeryfrontStrategy implements ImportRewriteStrategy {
     return (
       specifier.startsWith("#veryfront/") ||
       specifier.startsWith("veryfront/") ||
-      specifier === "veryfront"
+      specifier === "veryfront" ||
+      specifier === "#deno-config"
     );
   }
 
   rewrite(info: ImportSpecifierInfo, ctx: RewriteContext): RewriteResult {
     const specifier = info.specifier;
+
+    // Handle #deno-config — Deno import-map alias that doesn't exist in browsers.
+    // Rewrite to an embedded polyfill served by the module server.
+    if (specifier === "#deno-config") {
+      return { specifier: "/_vf_modules/_deno-config.js" };
+    }
 
     // Handle #veryfront/* (internal framework imports)
     if (specifier.startsWith("#veryfront/")) {

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,11 +1,6 @@
-import denoConfig from "#deno-config" with { type: "json" };
-
-function getVersionFromDeno(): string {
-  return typeof denoConfig.version === "string" ? denoConfig.version : "0.0.0";
-}
-
-// Use deno.json version directly to avoid env access at module load
-export const VERSION: string = getVersionFromDeno();
+// Keep in sync with deno.json version.
+// scripts/release.ts updates this constant during releases.
+export const VERSION = "0.1.59";
 
 export const SERVER_START_TIME: number = Date.now();
 


### PR DESCRIPTION
## Summary

- Browsers fail with `TypeError: Failed to resolve module specifier "#deno-config"` because the browser transform pipeline had no handler for this Deno import-map alias
- The import rewriter now rewrites `#deno-config` → `/_vf_modules/_deno-config.js`, served by an embedded polyfill stub with framework version info
- `version.ts` refactored to a hardcoded constant (updated by `scripts/release.ts`) so it no longer imports `#deno-config` at all

## Changes

| File | Change |
|------|--------|
| `veryfront-strategy.ts` | Match and rewrite `#deno-config` to embedded polyfill URL |
| `module-server.ts` | Add `_deno-config` embedded polyfill with version info |
| `version.ts` | Replace `#deno-config` import with hardcoded constant |
| `release.ts` | Add `version.ts` to release script's file update list |
| `module-server.test.ts` | Add test verifying version module served without `#deno-config` |
| `deno.json` | Bump version to 0.1.59 |

## Test plan

- [x] Module server tests pass (including new `#deno-config` test)
- [x] Import rewriter tests pass
- [ ] Verify browser console no longer shows `#deno-config` resolution errors on earthy-sand.preview.veryfront.com