### PR TITLE
fix: support named exports and object-based createChatHandler for agent discovery

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/chat-handler.test.ts
+++ b/src/agent/chat-handler.test.ts
@@ -336,6 +336,46 @@ describe("createChatHandler", () => {
     );
   });
 
+  it("should accept agent instance via object-based config", async () => {
+    const agentId = `obj-api-agent-${crypto.randomUUID()}`;
+    let streamCalled = false;
+
+    const fakeAgent = {
+      id: agentId,
+      config: { model: "openai/gpt-4o", system: "Object API test" },
+      generate: () => {},
+      clearMemory: async () => {},
+      stream: async () => {
+        streamCalled = true;
+        return {
+          toDataStreamResponse: () => new Response("ok", { status: 200 }),
+        };
+      },
+    };
+
+    // Use the object-based API: createChatHandler({ agent, beforeStream })
+    // deno-lint-ignore no-explicit-any
+    const handler = createChatHandler({ agent: fakeAgent as any });
+
+    const request = new Request("http://localhost/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: [
+          {
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ],
+      }),
+    });
+
+    const response = await handler(request);
+    assertEquals(response.status, 200);
+    assertEquals(streamCalled, true);
+  });
+
   it("should not leak async system prompt in 503 no_ai_available response", async () => {
     const agentId = `no-ai-async-${crypto.randomUUID()}`;
 

--- a/src/agent/chat-handler.test.ts
+++ b/src/agent/chat-handler.test.ts
@@ -376,6 +376,56 @@ describe("createChatHandler", () => {
     assertEquals(streamCalled, true);
   });
 
+  it("should honor second-argument options with object-based config", async () => {
+    const agentId = `obj-api-opts-${crypto.randomUUID()}`;
+    let beforeStreamCalled = false;
+    let streamContext: Record<string, unknown> | undefined;
+
+    const fakeAgent = {
+      id: agentId,
+      config: { model: "openai/gpt-4o", system: "Object API options test" },
+      generate: () => {},
+      clearMemory: async () => {},
+      stream: async (input: { context?: Record<string, unknown> }) => {
+        streamContext = input.context;
+        return {
+          toDataStreamResponse: () => new Response("ok", { status: 200 }),
+        };
+      },
+    };
+
+    const handler = createChatHandler(
+      // deno-lint-ignore no-explicit-any
+      { agent: fakeAgent as any },
+      {
+        context: { tenant: "acme" },
+        beforeStream: ({ context }) => {
+          beforeStreamCalled = true;
+          assertEquals(context.tenant, "acme");
+        },
+      },
+    );
+
+    const request = new Request("http://localhost/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: [
+          {
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ],
+      }),
+    });
+
+    const response = await handler(request);
+    assertEquals(response.status, 200);
+    assertEquals(beforeStreamCalled, true);
+    assertEquals(streamContext?.tenant, "acme");
+  });
+
   it("should not leak async system prompt in 503 no_ai_available response", async () => {
     const agentId = `no-ai-async-${crypto.randomUUID()}`;
 

--- a/src/agent/chat-handler.ts
+++ b/src/agent/chat-handler.ts
@@ -244,6 +244,12 @@ export interface ChatHandlerOptions {
   beforeStream?: ChatHandlerBeforeStream;
 }
 
+/** Options when passing an agent instance directly. */
+export interface ChatHandlerConfigWithAgent extends ChatHandlerOptions {
+  /** The agent instance to use (bypasses registry lookup). */
+  agent: import("./types.ts").Agent;
+}
+
 /**
  * Extract the raw Request from either a raw Request or a Pages Router APIContext.
  * Pages Router handlers receive `(ctx)` where `ctx.request` is the Request.
@@ -297,25 +303,46 @@ function extractRequest(requestOrCtx: unknown): Request {
  * - App Router: `app/api/chat/route.ts` — handler receives `(request, context)`
  * - Pages Router: `pages/api/chat.ts` — handler receives `(ctx)`
  *
+ * Accepts either:
+ * - `createChatHandler("agentId", options?)` — looks up agent by ID from the registry
+ * - `createChatHandler({ agent, ...options })` — uses the provided agent instance directly
+ *
  * @example
  * ```ts
- * import { createChatHandler } from "veryfront/agent";
+ * // By agent ID (requires auto-discovery registration)
  * export const POST = createChatHandler("assistant");
+ *
+ * // By agent instance (no registry needed)
+ * import { myAgent } from "../../agents/my-agent";
+ * export const POST = createChatHandler({ agent: myAgent, beforeStream: ... });
  * ```
  */
 export function createChatHandler(
-  agentId: string,
+  agentIdOrConfig: string | ChatHandlerConfigWithAgent,
   options?: ChatHandlerOptions,
 ) {
   return async function POST(requestOrCtx: unknown): Promise<Response> {
     const request = extractRequest(requestOrCtx);
+
     let agent: ReturnType<typeof getAgent> | undefined;
-    try {
-      agent = getAgent(agentId);
-    } catch (error) {
-      agentLogger.debug("getAgent lookup failed", { error });
-      return Response.json({ error: "Agent not found" }, { status: 404 });
+
+    if (
+      typeof agentIdOrConfig === "object" && agentIdOrConfig !== null && "agent" in agentIdOrConfig
+    ) {
+      // Object-based API: createChatHandler({ agent, beforeStream, ... })
+      agent = agentIdOrConfig.agent;
+      options = agentIdOrConfig;
+    } else {
+      // String-based API: createChatHandler("agentId", options?)
+      const agentId = agentIdOrConfig as string;
+      try {
+        agent = getAgent(agentId);
+      } catch (error) {
+        agentLogger.debug("getAgent lookup failed", { error });
+        return Response.json({ error: "Agent not found" }, { status: 404 });
+      }
     }
+
     if (!agent) {
       return Response.json({ error: "Agent not found" }, { status: 404 });
     }

--- a/src/agent/chat-handler.ts
+++ b/src/agent/chat-handler.ts
@@ -250,6 +250,14 @@ export interface ChatHandlerConfigWithAgent extends ChatHandlerOptions {
   agent: import("./types.ts").Agent;
 }
 
+function mergeChatHandlerConfig(
+  config: ChatHandlerConfigWithAgent,
+  options?: ChatHandlerOptions,
+): ChatHandlerConfigWithAgent {
+  if (!options) return config;
+  return { ...options, ...config };
+}
+
 /**
  * Extract the raw Request from either a raw Request or a Pages Router APIContext.
  * Pages Router handlers receive `(ctx)` where `ctx.request` is the Request.
@@ -318,6 +326,14 @@ function extractRequest(requestOrCtx: unknown): Request {
  * ```
  */
 export function createChatHandler(
+  agentId: string,
+  options?: ChatHandlerOptions,
+): (requestOrCtx: unknown) => Promise<Response>;
+export function createChatHandler(
+  config: ChatHandlerConfigWithAgent,
+  options?: ChatHandlerOptions,
+): (requestOrCtx: unknown) => Promise<Response>;
+export function createChatHandler(
   agentIdOrConfig: string | ChatHandlerConfigWithAgent,
   options?: ChatHandlerOptions,
 ) {
@@ -330,8 +346,9 @@ export function createChatHandler(
       typeof agentIdOrConfig === "object" && agentIdOrConfig !== null && "agent" in agentIdOrConfig
     ) {
       // Object-based API: createChatHandler({ agent, beforeStream, ... })
-      agent = agentIdOrConfig.agent;
-      options = agentIdOrConfig;
+      const config = mergeChatHandlerConfig(agentIdOrConfig, options);
+      agent = config.agent;
+      options = config;
     } else {
       // String-based API: createChatHandler("agentId", options?)
       const agentId = agentIdOrConfig as string;

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -135,6 +135,7 @@ export {
   type ChatHandlerBeforeStream,
   type ChatHandlerBeforeStreamContext,
   type ChatHandlerBeforeStreamResult,
+  type ChatHandlerConfigWithAgent,
   type ChatHandlerMessageInput,
   type ChatHandlerOptions,
   createChatHandler,

--- a/src/discovery/auto-discovery.integration.test.ts
+++ b/src/discovery/auto-discovery.integration.test.ts
@@ -72,5 +72,63 @@ describe(
       assertExists(result);
       assertExists(result.errors);
     });
+
+    it("should discover all valid named exports from a single tool file", async () => {
+      const tempDir = await Deno.makeTempDir({ prefix: "vf-discovery-multi-export-" });
+
+      try {
+        await Deno.mkdir(`${tempDir}/tools`, { recursive: true });
+        await Deno.writeTextFile(
+          `${tempDir}/tools/many.ts`,
+          [
+            'export const alpha = { execute: async () => "alpha" };',
+            'export const beta = { execute: async () => "beta" };',
+          ].join("\n"),
+        );
+
+        const result = await discoverAll({
+          baseDir: tempDir,
+          verbose: false,
+        });
+
+        assertEquals(Array.from(result.tools.keys()).sort(), ["alpha", "beta"]);
+        assertEquals(toolRegistry.getAllIds().sort(), ["alpha", "beta"]);
+      } finally {
+        await Deno.remove(tempDir, { recursive: true });
+      }
+    });
+
+    it("should keep concrete tool files over index barrel re-exports", async () => {
+      const tempDir = await Deno.makeTempDir({ prefix: "vf-discovery-barrel-" });
+
+      try {
+        await Deno.mkdir(`${tempDir}/tools`, { recursive: true });
+        await Deno.writeTextFile(
+          `${tempDir}/tools/foo.ts`,
+          'export const foo = { execute: async () => "foo" };\n',
+        );
+        await Deno.writeTextFile(
+          `${tempDir}/tools/bar.ts`,
+          'export const bar = { execute: async () => "bar" };\n',
+        );
+        await Deno.writeTextFile(
+          `${tempDir}/tools/index.ts`,
+          [
+            'export { foo } from "./foo.ts";',
+            'export { bar } from "./bar.ts";',
+          ].join("\n"),
+        );
+
+        const result = await discoverAll({
+          baseDir: tempDir,
+          verbose: false,
+        });
+
+        assertEquals(Array.from(result.tools.keys()).sort(), ["bar", "foo"]);
+        assertEquals(toolRegistry.getAllIds().sort(), ["bar", "foo"]);
+      } finally {
+        await Deno.remove(tempDir, { recursive: true });
+      }
+    });
   },
 );

--- a/src/discovery/discovery-engine.ts
+++ b/src/discovery/discovery-engine.ts
@@ -26,9 +26,61 @@ import {
   toolHandler,
   workflowHandler,
 } from "./handlers/index.ts";
+import { filenameToId } from "./discovery-utils.ts";
 import { join } from "#veryfront/compat/path";
 
 const logger = agentLogger.component("discovery");
+
+type DiscoveryCandidate<T> = {
+  exportName: string;
+  item: T;
+};
+
+function isIndexModule(file: string): boolean {
+  const normalized = file.replace("file://", "");
+  return /(?:^|\/)index\.(?:ts|tsx|js|jsx)$/.test(normalized);
+}
+
+function compareDiscoveryFiles(a: string, b: string): number {
+  const aIsIndex = isIndexModule(a);
+  const bIsIndex = isIndexModule(b);
+  if (aIsIndex !== bIsIndex) return aIsIndex ? 1 : -1;
+  return a.localeCompare(b);
+}
+
+function collectDiscoveryCandidates<T>(
+  module: unknown,
+  handler: DiscoveryHandler<T>,
+): DiscoveryCandidate<T>[] {
+  const defaultItem = (module as { default?: T }).default;
+  if (handler.validate(defaultItem)) {
+    return [{ exportName: "default", item: defaultItem }];
+  }
+
+  const candidates: DiscoveryCandidate<T>[] = [];
+  for (const [exportName, value] of Object.entries(module as Record<string, unknown>)) {
+    if (exportName === "default") continue;
+    if (!handler.validate(value)) continue;
+    candidates.push({ exportName, item: value });
+  }
+
+  return candidates;
+}
+
+function getCandidateId<T>(
+  candidate: DiscoveryCandidate<T>,
+  file: string,
+  dir: string,
+  handler: DiscoveryHandler<T>,
+  useExportNameFallback: boolean,
+): string {
+  const derivedId = handler.getId(candidate.item, file, dir);
+  if (!useExportNameFallback) return derivedId;
+
+  const fileId = filenameToId(file);
+  if (derivedId !== fileId) return derivedId;
+  return candidate.exportName;
+}
 
 /**
  * Discover items of a specific type in a directory
@@ -40,7 +92,8 @@ async function discoverItems<T>(
   handler: DiscoveryHandler<T>,
   verbose?: boolean,
 ): Promise<void> {
-  const files = await findTypeScriptFiles(dir, context);
+  const files = (await findTypeScriptFiles(dir, context)).sort(compareDiscoveryFiles);
+  const resultMap = handler.getResultMap(result);
 
   if (verbose) {
     logger.info(`Found ${files.length} ${handler.typeName} files in ${dir}`);
@@ -49,35 +102,40 @@ async function discoverItems<T>(
   for (const file of files) {
     try {
       const module = await importModule(file, context);
-
-      // Check default export first, then fall back to named exports
-      let item = (module as { default?: T }).default;
-
-      if (!handler.validate(item)) {
-        // Search named exports for a valid item (e.g. `export const myAgent = agent(...)`)
-        for (const key of Object.keys(module as Record<string, unknown>)) {
-          if (key === "default") continue;
-          const candidate = (module as Record<string, unknown>)[key] as T;
-          if (handler.validate(candidate)) {
-            item = candidate;
-            break;
-          }
-        }
-      }
-
-      if (!handler.validate(item)) {
+      const candidates = collectDiscoveryCandidates(module, handler);
+      if (candidates.length === 0) {
         if (verbose) {
           logger.warn(`${file} does not export a valid ${handler.typeName}`);
         }
         continue;
       }
 
-      const id = handler.getId(item, file, dir);
-      const registered = handler.register(id, item, file, dir);
-      handler.getResultMap(result).set(id, registered);
+      const useExportNameFallback = candidates.length > 1 || isIndexModule(file);
+      for (const candidate of candidates) {
+        const id = getCandidateId(
+          candidate,
+          file,
+          dir,
+          handler,
+          useExportNameFallback,
+        );
 
-      if (verbose) {
-        logger.info(`Registered ${handler.typeName}: ${id}`);
+        if (resultMap.has(id)) {
+          if (verbose) {
+            logger.warn(`Duplicate ${handler.typeName} "${id}" in ${file}; keeping first`);
+          }
+          continue;
+        }
+
+        const registered = handler.register(id, candidate.item, file, dir);
+        resultMap.set(id, registered);
+
+        if (verbose) {
+          const exportSuffix = candidate.exportName === "default"
+            ? ""
+            : ` (export: ${candidate.exportName})`;
+          logger.info(`Registered ${handler.typeName}: ${id}${exportSuffix}`);
+        }
       }
     } catch (error) {
       result.errors.push({ file, error: ensureError(error) });

--- a/src/discovery/discovery-engine.ts
+++ b/src/discovery/discovery-engine.ts
@@ -49,7 +49,21 @@ async function discoverItems<T>(
   for (const file of files) {
     try {
       const module = await importModule(file, context);
-      const item = (module as { default?: T }).default;
+
+      // Check default export first, then fall back to named exports
+      let item = (module as { default?: T }).default;
+
+      if (!handler.validate(item)) {
+        // Search named exports for a valid item (e.g. `export const myAgent = agent(...)`)
+        for (const key of Object.keys(module as Record<string, unknown>)) {
+          if (key === "default") continue;
+          const candidate = (module as Record<string, unknown>)[key] as T;
+          if (handler.validate(candidate)) {
+            item = candidate;
+            break;
+          }
+        }
+      }
 
       if (!handler.validate(item)) {
         if (verbose) {


### PR DESCRIPTION
## Summary

Fixes agent auto-registration failing in production (earthy-sand.preview.veryfront.com returning 404 on `/api/chat`).

- **Discovery named export fallback**: `discoverItems()` only checked `module.default`, silently skipping user code that uses named exports like `export const ragAgent = agent(...)`. Now falls back to scanning named exports when the default fails validation.
- **Object-based `createChatHandler` API**: User code calling `createChatHandler({ agent: myAgent, beforeStream: ... })` was hitting the string-ID path and failing with "Agent not found". Now accepts both `createChatHandler("id", opts)` and `createChatHandler({ agent, ...opts })`.

## Test plan

- [x] All 12 chat-handler tests pass, including new test for object-based API
- [x] Lint, fmt, and typecheck clean
- [ ] Deploy and verify earthy-sand.preview.veryfront.com chat returns 200 instead of 404