### PR TITLE
fix: log unhandled chat handler errors

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/chat-handler.ts
+++ b/src/agent/chat-handler.ts
@@ -424,6 +424,11 @@ export function createChatHandler(
         );
       }
 
+      agentLogger.error("Chat handler error", {
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+
       return Response.json(
         { error: "Internal server error" },
         { status: 500 },


### PR DESCRIPTION
## Summary

- Add error logging to the catch-all 500 handler in `createChatHandler` so production errors are visible in server logs instead of silently returning "Internal server error"
- Bump version to 0.1.61

The earthy-sand chat endpoint now discovers the agent correctly (PR #619), but `agent.stream()` fails with a 500 and no error is logged. This makes it impossible to diagnose the root cause.

## Test plan

- [x] All 13 chat-handler tests pass
- [ ] Deploy and check logs for the actual error behind the 500