### PR TITLE
fix: guard embedding and search against empty query strings

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/embedding/embedding.ts
+++ b/src/embedding/embedding.ts
@@ -35,7 +35,11 @@ export function embedding(config: EmbeddingConfig): Embedding {
     model: modelId,
 
     async embed(text: string): Promise<number[]> {
-      const result = await embed({ model, value: queryPrefix + text });
+      const value = queryPrefix + text;
+      if (!value.trim()) {
+        throw new Error("Cannot embed an empty string");
+      }
+      const result = await embed({ model, value });
       return result.embedding;
     },
 

--- a/src/embedding/rag-store.ts
+++ b/src/embedding/rag-store.ts
@@ -320,6 +320,7 @@ function createLocalJsonRagStore(config: ResolvedRagStoreConfig): RagStore {
       query: string,
       options?: RagSearchOptions,
     ): Promise<RagSearchResult[]> {
+      if (!query.trim()) return [];
       return withLock(async () => {
         const data = await load();
         if (data.chunks.length === 0) return [];

--- a/src/embedding/vector-store.ts
+++ b/src/embedding/vector-store.ts
@@ -60,6 +60,7 @@ export function vectorStore(config: VectorStoreConfig): VectorStore {
     },
 
     async search(query: string, options?: SearchOptions): Promise<SearchResult[]> {
+      if (!query.trim()) return [];
       if (entries.length === 0) return [];
 
       const topK = options?.topK ?? 5;

--- a/src/embedding/veryfront-cloud/rag-store.ts
+++ b/src/embedding/veryfront-cloud/rag-store.ts
@@ -491,6 +491,7 @@ export function createVeryfrontCloudRagStore(config: ResolvedCloudRagStoreConfig
       query: string,
       options?: RagSearchOptions,
     ): Promise<RagSearchResult[]> {
+      if (!query.trim()) return [];
       const context = getCloudStoreContext(config);
       const queryEmbedder = createEmbedder(config);
       const vector = await queryEmbedder.embed(query);


### PR DESCRIPTION
## Summary
- The chat handler crashes with `AI_APICallError: Invalid 'input[0]': input cannot be an empty string` when an AI tool calls `store.search("")` with an empty query
- Root cause: OpenAI embedding API rejects empty input strings, and no validation existed in the search/embed chain
- Added early-return guards (`if (!query.trim()) return []`) in all search methods: `rag-store.ts`, `vector-store.ts`, and `veryfront-cloud/rag-store.ts`
- Added descriptive error in `embedding.ts:embed()` to catch empty strings with a clear message
- Bumps to 0.1.62

## Test plan
- [x] `deno test src/embedding/rag-store.test.ts -A` passes
- [ ] Deploy and verify chat on earthy-sand.preview.veryfront.com no longer returns 500