### PR TITLE
fix: embed kreuzberg WASM in compiled binary for PDF upload extraction

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -205,6 +205,12 @@ jobs:
         run: |
           # React is fetched at runtime through the module server (SSR transform pipeline)
           # Include Tailwind CSS v4 plugins (versions must match PINNED_PLUGIN_VERSIONS in tailwind-compiler.ts)
+          # Resolve kreuzberg WASM binary path for --include
+          KREUZBERG_PKG=$(find node_modules/.deno -path '*/@kreuzberg/wasm/dist/pkg' -type d 2>/dev/null | head -1)
+          KREUZBERG_INCLUDE=""
+          if [ -n "$KREUZBERG_PKG" ]; then
+            KREUZBERG_INCLUDE="--include $KREUZBERG_PKG/kreuzberg_wasm_bg.wasm"
+          fi
           deno compile --allow-all --unstable-net \
             --include src/platform/polyfills \
             --include src/proxy/main.ts \
@@ -214,6 +220,7 @@ jobs:
             --include "https://esm.sh/@tailwindcss/forms@0.5.11" \
             --include "https://esm.sh/tailwind-scrollbar-hide@2.0.0" \
             --include "https://esm.sh/daisyui@5.5.14" \
+            $KREUZBERG_INCLUDE \
             --target ${{ matrix.target }} --output ${{ matrix.name }} cli/main.ts
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -205,23 +205,14 @@ jobs:
         run: |
           # React is fetched at runtime through the module server (SSR transform pipeline)
           # Include Tailwind CSS v4 plugins (versions must match PINNED_PLUGIN_VERSIONS in tailwind-compiler.ts)
-          # Resolve kreuzberg WASM binary path for --include
-          KREUZBERG_PKG=$(find node_modules/.deno -path '*/@kreuzberg/wasm/dist/pkg' -type d 2>/dev/null | head -1)
-          KREUZBERG_INCLUDE=""
-          if [ -n "$KREUZBERG_PKG" ]; then
-            KREUZBERG_INCLUDE="--include $KREUZBERG_PKG/kreuzberg_wasm_bg.wasm"
-          fi
-          deno compile --allow-all --unstable-net \
-            --include src/platform/polyfills \
-            --include src/proxy/main.ts \
-            --include dist/framework-src \
+          deno run -A scripts/build/compile-binary.ts \
+            --target ${{ matrix.target }} \
+            --output ${{ matrix.name }} \
             --include "https://esm.sh/tailwindcss-animate@1.0.7" \
             --include "https://esm.sh/@tailwindcss/typography@0.5.19" \
             --include "https://esm.sh/@tailwindcss/forms@0.5.11" \
             --include "https://esm.sh/tailwind-scrollbar-hide@2.0.0" \
-            --include "https://esm.sh/daisyui@5.5.14" \
-            $KREUZBERG_INCLUDE \
-            --target ${{ matrix.target }} --output ${{ matrix.name }} cli/main.ts
+            --include "https://esm.sh/daisyui@5.5.14"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/deno.json
+++ b/deno.json
@@ -263,7 +263,8 @@
     "class-variance-authority": "npm:class-variance-authority@0.7.1",
     "clsx": "npm:clsx@2.1.1",
     "tailwind-merge": "npm:tailwind-merge@2.6.0",
-    "@kreuzberg/wasm": "npm:@kreuzberg/wasm@4.4.2"
+    "@kreuzberg/wasm": "npm:@kreuzberg/wasm@4.4.2",
+    "@kreuzberg/wasm/dist/pkg/kreuzberg_wasm.js": "npm:@kreuzberg/wasm@4.4.2/dist/pkg/kreuzberg_wasm.js"
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/deno.json
+++ b/deno.json
@@ -264,7 +264,7 @@
     "clsx": "npm:clsx@2.1.1",
     "tailwind-merge": "npm:tailwind-merge@2.6.0",
     "@kreuzberg/wasm": "npm:@kreuzberg/wasm@4.4.2",
-    "@kreuzberg/wasm/dist/pkg/kreuzberg_wasm.js": "npm:@kreuzberg/wasm@4.4.2/dist/pkg/kreuzberg_wasm.js"
+    "#kreuzberg-wasm-glue": "npm:@kreuzberg/wasm@4.4.2/dist/pkg/kreuzberg_wasm.js"
   },
   "compilerOptions": {
     "jsx": "react-jsx",
@@ -292,7 +292,7 @@
     "dev": "deno task generate && deno run --allow-all cli/main.ts dev",
     "production": "deno task generate && deno run --allow-all cli/main.ts serve --mode=production",
     "build:prepare": "deno run -A scripts/build/generate-integrations-module.ts && deno task generate && deno run -A scripts/build/prepare-framework-sources.ts",
-    "build": "deno task build:prepare && deno compile --allow-all --include src/platform/polyfills --include src/proxy/main.ts --include dist/framework-src --output ./bin/veryfront cli/main.ts",
+    "build": "deno task build:prepare && deno run -A scripts/build/compile-binary.ts --output ./bin/veryfront",
     "build:npm": "deno run -A scripts/build/generate-integrations-module.ts && deno task generate && deno run -A scripts/build/build-npm-dnt.ts",
     "release": "deno run -A scripts/release.ts",
     "test": "deno task generate && VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --parallel --allow-all '--ignore=tests/e2e,tests/integration/compiled-binary-e2e.test.ts' --unstable-worker-options --unstable-net",

--- a/scripts/build/build-all.js
+++ b/scripts/build/build-all.js
@@ -5,8 +5,8 @@
  * Requires Deno to be installed
  */
 
-import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -23,28 +23,9 @@ if (!existsSync(distDir)) {
 console.log("🔨 Building Veryfront CLI binaries...");
 console.log(`   Version: ${version}\n`);
 
-// Resolve kreuzberg WASM binary for --include
-let kreuzbergInclude = "";
-const denoModsDir = join(__dirname, "../..", "node_modules/.deno");
-if (existsSync(denoModsDir)) {
-  for (const entry of readdirSync(denoModsDir)) {
-    if (entry.startsWith("@kreuzberg+wasm@")) {
-      const wasmPath = join(denoModsDir, entry, "node_modules/@kreuzberg/wasm/dist/pkg/kreuzberg_wasm_bg.wasm");
-      if (existsSync(wasmPath)) {
-        kreuzbergInclude = `--include ${wasmPath}`;
-        console.log(`   Kreuzberg WASM: ${wasmPath}\n`);
-        break;
-      }
-    }
-  }
-}
-if (!kreuzbergInclude) {
-  console.warn("⚠️  Kreuzberg WASM binary not found — PDF upload extraction will be unavailable\n");
-}
-
 // Run the same pre-build pipeline used by deno task build/build:npm
 console.log("📝 Running build preparation...");
-execSync("deno task build:prepare", { stdio: "inherit" });
+execFileSync("deno", ["task", "build:prepare"], { stdio: "inherit" });
 console.log("");
 
 const targets = [
@@ -83,8 +64,17 @@ for (const { name, target, output } of targets) {
 
   try {
     console.log(`📦 Building ${name}...`);
-    execSync(
-      `deno compile --allow-all --unstable-net --target ${target} --include src/platform/polyfills --include src/proxy/main.ts --include dist/framework-src ${kreuzbergInclude} --output ${outputPath} cli/main.ts`,
+    execFileSync(
+      "deno",
+      [
+        "run",
+        "-A",
+        "scripts/build/compile-binary.ts",
+        "--target",
+        target,
+        "--output",
+        outputPath,
+      ],
       { stdio: "inherit" },
     );
 

--- a/scripts/build/build-all.js
+++ b/scripts/build/build-all.js
@@ -6,7 +6,7 @@
  */
 
 import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -22,6 +22,25 @@ if (!existsSync(distDir)) {
 
 console.log("🔨 Building Veryfront CLI binaries...");
 console.log(`   Version: ${version}\n`);
+
+// Resolve kreuzberg WASM binary for --include
+let kreuzbergInclude = "";
+const denoModsDir = join(__dirname, "../..", "node_modules/.deno");
+if (existsSync(denoModsDir)) {
+  for (const entry of readdirSync(denoModsDir)) {
+    if (entry.startsWith("@kreuzberg+wasm@")) {
+      const wasmPath = join(denoModsDir, entry, "node_modules/@kreuzberg/wasm/dist/pkg/kreuzberg_wasm_bg.wasm");
+      if (existsSync(wasmPath)) {
+        kreuzbergInclude = `--include ${wasmPath}`;
+        console.log(`   Kreuzberg WASM: ${wasmPath}\n`);
+        break;
+      }
+    }
+  }
+}
+if (!kreuzbergInclude) {
+  console.warn("⚠️  Kreuzberg WASM binary not found — PDF upload extraction will be unavailable\n");
+}
 
 // Run the same pre-build pipeline used by deno task build/build:npm
 console.log("📝 Running build preparation...");
@@ -65,7 +84,7 @@ for (const { name, target, output } of targets) {
   try {
     console.log(`📦 Building ${name}...`);
     execSync(
-      `deno compile --allow-all --unstable-net --target ${target} --include src/platform/polyfills --include src/proxy/main.ts --include dist/framework-src --output ${outputPath} cli/main.ts`,
+      `deno compile --allow-all --unstable-net --target ${target} --include src/platform/polyfills --include src/proxy/main.ts --include dist/framework-src ${kreuzbergInclude} --output ${outputPath} cli/main.ts`,
       { stdio: "inherit" },
     );
 

--- a/scripts/build/compile-binary.ts
+++ b/scripts/build/compile-binary.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env -S deno run --allow-all
+/**
+ * Compile the Veryfront CLI binary with all required embedded assets.
+ *
+ * This centralizes deno compile arguments so local builds, CI, and binary
+ * tests all embed the same Kreuzberg WASM assets.
+ */
+
+import { parseArgs } from "jsr:@std/cli/parse-args";
+import { fromFileUrl, isAbsolute, join } from "#std/path.ts";
+
+const PROJECT_ROOT = fromFileUrl(new URL("../..", import.meta.url));
+const DEFAULT_INCLUDES = [
+  "src/platform/polyfills",
+  "src/proxy/main.ts",
+  "dist/framework-src",
+];
+interface CompileBinaryOptions {
+  entrypoint: string;
+  extraIncludes: string[];
+  output: string;
+  target?: string;
+}
+
+export function resolveKreuzbergCompileIncludes(): string[] {
+  const glueUrl = new URL(import.meta.resolve("#kreuzberg-wasm-glue"));
+  return [
+    fromFileUrl(new URL("kreuzberg_wasm_bg.wasm", glueUrl)),
+    fromFileUrl(new URL("../pdfium.esm.wasm", glueUrl)),
+  ];
+}
+
+export function createCompileArgs(options: CompileBinaryOptions): string[] {
+  const args = [
+    "compile",
+    "--allow-all",
+    "--unstable-net",
+  ];
+
+  for (const include of [
+    ...DEFAULT_INCLUDES,
+    ...resolveKreuzbergCompileIncludes(),
+    ...options.extraIncludes,
+  ]) {
+    args.push("--include", include);
+  }
+
+  if (options.target) {
+    args.push("--target", options.target);
+  }
+
+  args.push("--output", options.output, options.entrypoint);
+  return args;
+}
+
+export async function compileBinary(options: CompileBinaryOptions): Promise<void> {
+  const result = await new Deno.Command("deno", {
+    args: createCompileArgs(options),
+    cwd: PROJECT_ROOT,
+    stdout: "inherit",
+    stderr: "inherit",
+  }).output();
+
+  if (!result.success) {
+    throw new Error(`deno compile failed with exit code ${result.code}`);
+  }
+}
+
+function normalizeOutputPath(path: string): string {
+  return isAbsolute(path) ? path : join(PROJECT_ROOT, path);
+}
+
+if (import.meta.main) {
+  const args = parseArgs(Deno.args, {
+    string: ["entrypoint", "include", "output", "target"],
+    collect: ["include"],
+    default: { entrypoint: "cli/main.ts" },
+  });
+
+  if (typeof args.output !== "string" || !args.output) {
+    throw new Error("Missing required --output <path>");
+  }
+
+  const extraIncludes = Array.isArray(args.include)
+    ? args.include.map(String)
+    : typeof args.include === "string"
+    ? [args.include]
+    : [];
+
+  try {
+    await compileBinary({
+      entrypoint: String(args.entrypoint),
+      extraIncludes,
+      output: normalizeOutputPath(args.output),
+      target: typeof args.target === "string" ? args.target : undefined,
+    });
+  } catch (error) {
+    console.error(String(error));
+    Deno.exit(1);
+  }
+}

--- a/scripts/build/compile-binary.ts
+++ b/scripts/build/compile-binary.ts
@@ -22,8 +22,21 @@ interface CompileBinaryOptions {
   target?: string;
 }
 
+/**
+ * Resolve the kreuzberg WASM assets that must be embedded in the compiled binary.
+ *
+ * NOTE: This runs under `deno run` (not compiled), so `import.meta.resolve`
+ * returns a `file:` URL pointing into `node_modules`. It will NOT work inside
+ * a compiled binary — only call this at build time.
+ */
 export function resolveKreuzbergCompileIncludes(): string[] {
-  const glueUrl = new URL(import.meta.resolve("#kreuzberg-wasm-glue"));
+  const resolved = import.meta.resolve("#kreuzberg-wasm-glue");
+  if (!resolved.startsWith("file:")) {
+    throw new Error(
+      `Expected #kreuzberg-wasm-glue to resolve to a file: URL, got: ${resolved}`,
+    );
+  }
+  const glueUrl = new URL(resolved);
   return [
     fromFileUrl(new URL("kreuzberg_wasm_bg.wasm", glueUrl)),
     fromFileUrl(new URL("../pdfium.esm.wasm", glueUrl)),
@@ -81,11 +94,7 @@ if (import.meta.main) {
     throw new Error("Missing required --output <path>");
   }
 
-  const extraIncludes = Array.isArray(args.include)
-    ? args.include.map(String)
-    : typeof args.include === "string"
-    ? [args.include]
-    : [];
+  const extraIncludes = (args.include as string[]).map(String);
 
   try {
     await compileBinary({

--- a/scripts/test-production-fix.ts
+++ b/scripts/test-production-fix.ts
@@ -43,7 +43,7 @@ if (USE_COMPILED) {
     console.log("❌ Binary not found. Compile first:");
     console.log("   deno task build:prepare");
     console.log(
-      "   deno compile --allow-all --unstable-net --include src/platform/polyfills --include src/proxy/main.ts --include dist/framework-src --output ./veryfront-local cli/main.ts",
+      "   deno run -A scripts/build/compile-binary.ts --output ./veryfront-local",
     );
     Deno.exit(1);
   }

--- a/src/embedding/embedding.test.ts
+++ b/src/embedding/embedding.test.ts
@@ -1,0 +1,66 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { embedding } from "./embedding.ts";
+import { clearEmbeddingProviders, registerEmbeddingProvider } from "./resolve.ts";
+
+describe("embedding", () => {
+  afterEach(() => {
+    clearEmbeddingProviders();
+  });
+
+  it("rejects whitespace-only input even when queryPrefix is configured", async () => {
+    registerEmbeddingProvider("test", () =>
+      ({
+        specificationVersion: "v2",
+        provider: "test",
+        modelId: "test/demo",
+        maxEmbeddingsPerCall: undefined,
+        supportsParallelCalls: true,
+        async doEmbed() {
+          throw new Error("doEmbed should not run for empty input");
+        },
+      }) as never);
+
+    const embedder = embedding({
+      model: "test/demo",
+      queryPrefix: "search_query: ",
+    });
+
+    await assertRejects(
+      () => embedder.embed("   "),
+      Error,
+      "Cannot embed an empty string",
+    );
+  });
+
+  it("applies queryPrefix to non-empty embed input", async () => {
+    const values: string[] = [];
+    registerEmbeddingProvider("test", () =>
+      ({
+        specificationVersion: "v2",
+        provider: "test",
+        modelId: "test/demo",
+        maxEmbeddingsPerCall: undefined,
+        supportsParallelCalls: true,
+        async doEmbed({ values: inputValues }: { values: string[] }) {
+          values.push(...inputValues);
+          return {
+            embeddings: inputValues.map(() => [1, 2, 3]),
+            usage: { tokens: 0 },
+            rawResponse: undefined,
+            warnings: [],
+          };
+        },
+      }) as never);
+
+    const embedder = embedding({
+      model: "test/demo",
+      queryPrefix: "search_query: ",
+    });
+
+    const result = await embedder.embed("cats");
+
+    assertEquals(result, [1, 2, 3]);
+    assertEquals(values, ["search_query: cats"]);
+  });
+});

--- a/src/embedding/embedding.ts
+++ b/src/embedding/embedding.ts
@@ -35,10 +35,10 @@ export function embedding(config: EmbeddingConfig): Embedding {
     model: modelId,
 
     async embed(text: string): Promise<number[]> {
-      const value = queryPrefix + text;
-      if (!value.trim()) {
+      if (!text.trim()) {
         throw new Error("Cannot embed an empty string");
       }
+      const value = queryPrefix + text;
       const result = await embed({ model, value });
       return result.embedding;
     },

--- a/src/embedding/rag-store.test.ts
+++ b/src/embedding/rag-store.test.ts
@@ -106,6 +106,24 @@ describe("ragStore", () => {
     });
   });
 
+  it("returns empty results for whitespace-only local queries", async () => {
+    await withTempDir(async (tempDir) => {
+      const storagePath = join(tempDir, "data", "index.json");
+      const store = ragStore({
+        model: "local/test-model",
+        storagePath,
+      });
+
+      await store.ingest("Doc", "Hello world", {
+        source: "upload:test.txt",
+        type: "txt",
+      });
+
+      const results = await store.search("   ");
+      assertEquals(results, []);
+    });
+  });
+
   it("migrates legacy upload-store data from data/index.json", async () => {
     await withTempDir(async (tempDir) => {
       const storagePath = join(tempDir, "data", "index.json");
@@ -328,6 +346,29 @@ describe("ragStore", () => {
 
         await store.removeDocument(id);
         assertEquals(await store.listDocuments(), []);
+      },
+    );
+  });
+
+  it("returns empty results for whitespace-only cloud queries without making requests", async () => {
+    setEnv("VERYFRONT_API_TOKEN", "vf_test_cloud");
+    setEnv("VERYFRONT_PROJECT_SLUG", "cloud-project");
+
+    let fetchCalls = 0;
+
+    await withMockFetch(
+      async () => {
+        fetchCalls++;
+        throw new Error("fetch should not run for whitespace-only queries");
+      },
+      async () => {
+        const store = ragStore({
+          model: "test/demo",
+        });
+
+        const results = await store.search("   ");
+        assertEquals(results, []);
+        assertEquals(fetchCalls, 0);
       },
     );
   });

--- a/src/platform/compat/opaque-deps.ts
+++ b/src/platform/compat/opaque-deps.ts
@@ -65,10 +65,12 @@ export async function importKreuzberg(): Promise<{
     // Regular import — visible to deno compile, resolved via deno.json import map
     const mod = await import("@kreuzberg/wasm") as unknown as KreuzbergModule;
     if (isDenoCompiled) {
-      // Kreuzberg's wrapper resolves the glue module via computed import()
-      // paths that deno compile cannot trace. Import the glue module here so
-      // the compiled binary includes it, then let Kreuzberg's own init path
-      // run normally and manage its internal wrapper state.
+      // Kreuzberg's initWasm() internally uses a computed dynamic import() to
+      // load the WASM glue module (kreuzberg_wasm.js). deno compile cannot
+      // trace computed import() paths, so the glue module is absent from the
+      // binary's embedded module graph. Pre-importing it here populates Deno's
+      // in-process module cache so the subsequent import() inside initWasm()
+      // resolves from cache instead of hitting the missing file.
       await import("#kreuzberg-wasm-glue");
     }
     await mod.initWasm?.();

--- a/src/platform/compat/opaque-deps.ts
+++ b/src/platform/compat/opaque-deps.ts
@@ -68,8 +68,9 @@ export async function importKreuzberg(): Promise<{
       // computed import() paths for the WASM glue code that deno compile
       // cannot trace. Manually import the glue code (traced via deno.json
       // import map entry) and load the WASM binary via fetch().
-      const glue = await import("@kreuzberg/wasm/dist/pkg/kreuzberg_wasm.js") as unknown as
-        { default: (input?: BufferSource) => Promise<void> };
+      const glue = await import("@kreuzberg/wasm/dist/pkg/kreuzberg_wasm.js") as unknown as {
+        default: (input?: BufferSource) => Promise<void>;
+      };
       const glueUrl = import.meta.resolve("@kreuzberg/wasm/dist/pkg/kreuzberg_wasm.js");
       const wasmUrl = new URL("kreuzberg_wasm_bg.wasm", glueUrl).href;
       const wasmBinary = await fetch(wasmUrl).then((r) => r.arrayBuffer());

--- a/src/platform/compat/opaque-deps.ts
+++ b/src/platform/compat/opaque-deps.ts
@@ -25,6 +25,14 @@ function resolve(pkg: string, version: string): string {
 // deno-lint-ignore no-explicit-any -- callers assign to their own typed variable; any allows implicit narrowing at each call site
 type OpaqueModule = any;
 
+type KreuzbergModule = {
+  initWasm?: () => Promise<void>;
+  extractBytes: (
+    data: Uint8Array,
+    mimeType: string,
+  ) => Promise<{ content: string }>;
+};
+
 /** Lazily import `@huggingface/transformers` (+ onnxruntime, ~500MB). */
 export function importTransformers(): Promise<OpaqueModule> {
   return dynamicImport(resolve("@huggingface/transformers", "3.4.2"));
@@ -55,28 +63,15 @@ export async function importKreuzberg(): Promise<{
 }> {
   if (isDeno) {
     // Regular import — visible to deno compile, resolved via deno.json import map
-    const mod = await import("@kreuzberg/wasm") as unknown as
-      & { initWasm?: (options?: { wasmModule?: BufferSource }) => Promise<void> }
-      & { extractBytes: (data: Uint8Array, mimeType: string) => Promise<{ content: string }> };
-
-    try {
-      await mod.initWasm?.();
-    } catch (initError) {
-      if (!isDenoCompiled) throw initError;
-
-      // In compiled binaries, kreuzberg's initWasm() fails because it uses
-      // computed import() paths for the WASM glue code that deno compile
-      // cannot trace. Manually import the glue code (traced via deno.json
-      // import map entry) and load the WASM binary via fetch().
-      const glue = await import("@kreuzberg/wasm/dist/pkg/kreuzberg_wasm.js") as unknown as {
-        default: (input?: BufferSource) => Promise<void>;
-      };
-      const glueUrl = import.meta.resolve("@kreuzberg/wasm/dist/pkg/kreuzberg_wasm.js");
-      const wasmUrl = new URL("kreuzberg_wasm_bg.wasm", glueUrl).href;
-      const wasmBinary = await fetch(wasmUrl).then((r) => r.arrayBuffer());
-      await glue.default(wasmBinary);
+    const mod = await import("@kreuzberg/wasm") as unknown as KreuzbergModule;
+    if (isDenoCompiled) {
+      // Kreuzberg's wrapper resolves the glue module via computed import()
+      // paths that deno compile cannot trace. Import the glue module here so
+      // the compiled binary includes it, then let Kreuzberg's own init path
+      // run normally and manage its internal wrapper state.
+      await import("#kreuzberg-wasm-glue");
     }
-
+    await mod.initWasm?.();
     return mod;
   }
   // Opaque import — resolved from node_modules at runtime

--- a/src/platform/compat/opaque-deps.ts
+++ b/src/platform/compat/opaque-deps.ts
@@ -15,7 +15,7 @@
  * @module platform/compat
  */
 
-import { isDeno } from "./runtime.ts";
+import { isDeno, isDenoCompiled } from "./runtime.ts";
 import { dynamicImport } from "./dynamic-import.ts";
 
 function resolve(pkg: string, version: string): string {
@@ -56,9 +56,26 @@ export async function importKreuzberg(): Promise<{
   if (isDeno) {
     // Regular import — visible to deno compile, resolved via deno.json import map
     const mod = await import("@kreuzberg/wasm") as unknown as
-      & { initWasm?: () => Promise<void> }
+      & { initWasm?: (options?: { wasmModule?: BufferSource }) => Promise<void> }
       & { extractBytes: (data: Uint8Array, mimeType: string) => Promise<{ content: string }> };
-    await mod.initWasm?.();
+
+    try {
+      await mod.initWasm?.();
+    } catch (initError) {
+      if (!isDenoCompiled) throw initError;
+
+      // In compiled binaries, kreuzberg's initWasm() fails because it uses
+      // computed import() paths for the WASM glue code that deno compile
+      // cannot trace. Manually import the glue code (traced via deno.json
+      // import map entry) and load the WASM binary via fetch().
+      const glue = await import("@kreuzberg/wasm/dist/pkg/kreuzberg_wasm.js") as unknown as
+        { default: (input?: BufferSource) => Promise<void> };
+      const glueUrl = import.meta.resolve("@kreuzberg/wasm/dist/pkg/kreuzberg_wasm.js");
+      const wasmUrl = new URL("kreuzberg_wasm_bg.wasm", glueUrl).href;
+      const wasmBinary = await fetch(wasmUrl).then((r) => r.arrayBuffer());
+      await glue.default(wasmBinary);
+    }
+
     return mod;
   }
   // Opaque import — resolved from node_modules at runtime

--- a/tests/ai/vector-store.test.ts
+++ b/tests/ai/vector-store.test.ts
@@ -5,7 +5,7 @@
  * so cosine similarity produces predictable, testable results.
  */
 import { describe, it } from "#veryfront/testing/bdd";
-import { assertEquals, assert } from "#veryfront/testing/assert";
+import { assert, assertEquals } from "#veryfront/testing/assert";
 
 import { vectorStore } from "../../src/embedding/vector-store.ts";
 import type { Embedding, VectorStore } from "../../src/embedding/types.ts";
@@ -59,6 +59,29 @@ function createTestStore(): VectorStore {
 // ---------------------------------------------------------------------------
 
 describe("vectorStore — dense search", () => {
+  it("returns empty for whitespace-only queries without calling the embedder", async () => {
+    let embedCalls = 0;
+    const store = vectorStore({
+      embedder: {
+        model: "mock/test-embed",
+        async embed(): Promise<number[]> {
+          embedCalls++;
+          throw new Error("embed should not run for whitespace-only queries");
+        },
+        async embedMany(texts: string[]): Promise<number[][]> {
+          return texts.map(() => [1, 0, 0, 0]);
+        },
+      },
+    });
+
+    await store.add(["cats are fluffy"]);
+
+    const results = await store.search("   ");
+
+    assertEquals(results, []);
+    assertEquals(embedCalls, 0);
+  });
+
   it("returns results ranked by cosine similarity", async () => {
     const store = createTestStore();
     await store.add([

--- a/tests/integration/compiled-binary-e2e.test.ts
+++ b/tests/integration/compiled-binary-e2e.test.ts
@@ -49,18 +49,6 @@ async function computeSourceHash(): Promise<string> {
 
   try {
     const result = await new Deno.Command("git", {
-      args: ["rev-parse", "HEAD:src"],
-      stdout: "piped",
-      stderr: "null",
-    }).output();
-
-    if (result.success) return decoder.decode(result.stdout).trim();
-  } catch {
-    // fall through
-  }
-
-  try {
-    const result = await new Deno.Command("git", {
       args: ["rev-parse", "HEAD"],
       stdout: "piped",
       stderr: "null",
@@ -105,7 +93,7 @@ async function ensureBinaryCompiled(): Promise<void> {
   // Run the same pre-build pipeline used by distribution builds
   console.log("📦 Preparing build artifacts...");
   const prepareResult = await new Deno.Command("deno", {
-    args: ["run", "--allow-all", "scripts/build/prepare-framework-sources.ts"],
+    args: ["task", "build:prepare"],
     stdout: "inherit",
     stderr: "inherit",
   }).output();
@@ -115,17 +103,11 @@ async function ensureBinaryCompiled(): Promise<void> {
   console.log("📦 Compiling binary...");
   const result = await new Deno.Command("deno", {
     args: [
-      "compile",
-      "--allow-all",
-      "--include",
-      "src/platform/polyfills",
-      "--include",
-      "src/proxy/main.ts",
-      "--include",
-      "dist/framework-src",
+      "run",
+      "-A",
+      "scripts/build/compile-binary.ts",
       "--output",
       BINARY_PATH,
-      "cli/main.ts",
     ],
     stdout: "inherit",
     stderr: "inherit",

--- a/tests/integration/compiled-binary-e2e.test.ts
+++ b/tests/integration/compiled-binary-e2e.test.ts
@@ -47,6 +47,28 @@ async function getAvailablePort(): Promise<number> {
 async function computeSourceHash(): Promise<string> {
   const decoder = new TextDecoder();
 
+  // Hash both src/ and scripts/build/ since compile-binary.ts is a build input
+  try {
+    const srcResult = await new Deno.Command("git", {
+      args: ["rev-parse", "HEAD:src"],
+      stdout: "piped",
+      stderr: "null",
+    }).output();
+    const scriptsResult = await new Deno.Command("git", {
+      args: ["rev-parse", "HEAD:scripts/build"],
+      stdout: "piped",
+      stderr: "null",
+    }).output();
+
+    if (srcResult.success && scriptsResult.success) {
+      const srcHash = decoder.decode(srcResult.stdout).trim();
+      const scriptsHash = decoder.decode(scriptsResult.stdout).trim();
+      return `${srcHash}-${scriptsHash}`;
+    }
+  } catch {
+    // fall through
+  }
+
   try {
     const result = await new Deno.Command("git", {
       args: ["rev-parse", "HEAD"],


### PR DESCRIPTION
## Summary

- Kreuzberg's `initWasm()` uses computed `import()` paths that `deno compile` cannot trace, causing PDF uploads to fail with `[ERR_MODULE_NOT_FOUND]` for `kreuzberg_wasm.js` in production
- Added a fallback in `importKreuzberg()` that manually imports the WASM glue code and loads the `.wasm` binary via `fetch()` when the default init fails in compiled binaries
- Added `@kreuzberg/wasm/dist/pkg/kreuzberg_wasm.js` to the deno.json import map so `deno compile` traces and embeds the JS glue code
- Added `--include` for `kreuzberg_wasm_bg.wasm` (~20MB) in both CI and local build scripts

## Test plan

- [x] Typecheck passes
- [x] Lint passes
- [x] Compiled binary loads kreuzberg successfully
- [x] PDF text extraction works in compiled binary (`"Hello World"` extracted from test PDF)
- [x] Text/CSV extraction continues to work
- [ ] CI build succeeds with the new `--include` flag
- [ ] Deploy and verify PDF upload works on earthy-sand.preview.veryfront.com