### PR TITLE
feat: add channel invoke runtime handler

### DIFF
--- a/src/agent/factory.ts
+++ b/src/agent/factory.ts
@@ -159,7 +159,7 @@ export function agent(config: AgentConfig): Agent {
     generate(input): Promise<AgentResponse> {
       return withSpan(
         "agent.factory.generate",
-        () => runtime.generate(input.input, input.context, input.model),
+        () => runtime.generate(input.input, input.context, input.model, input.maxOutputTokens),
         { "agent.id": id },
       );
     },
@@ -178,10 +178,16 @@ export function agent(config: AgentConfig): Agent {
             ]
             : (input.messages ?? []);
 
-          const stream = await runtime.stream(inputMessages, input.context, {
-            onToolCall: input.onToolCall,
-            onChunk: input.onChunk,
-          }, input.model);
+          const stream = await runtime.stream(
+            inputMessages,
+            input.context,
+            {
+              onToolCall: input.onToolCall,
+              onChunk: input.onChunk,
+            },
+            input.model,
+            input.maxOutputTokens,
+          );
 
           return createAgentStreamResult(stream);
         },
@@ -197,6 +203,7 @@ export function agent(config: AgentConfig): Agent {
             messages?: Message[];
             context?: Record<string, unknown>;
             model?: string;
+            maxOutputTokens?: number;
           } = await request.json();
 
           // Validate model override against allowlist when configured
@@ -215,7 +222,13 @@ export function agent(config: AgentConfig): Agent {
           }
 
           const messages = body.messages ?? [];
-          const stream = await runtime.stream(messages, body.context, undefined, modelOverride);
+          const stream = await runtime.stream(
+            messages,
+            body.context,
+            undefined,
+            modelOverride,
+            body.maxOutputTokens,
+          );
 
           return new Response(stream, { headers: STREAMING_HEADERS });
         },

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -194,6 +194,7 @@ export class AgentRuntime {
     input: string | Message[],
     context?: Record<string, unknown>,
     modelOverride?: string,
+    maxOutputTokensOverride?: number,
   ): Promise<AgentResponse> {
     const requestedModel = resolveConfiguredAgentModel(modelOverride || this.config.model);
     const resolvedModelString = maybeUpgradeLocalModel(requestedModel);
@@ -221,7 +222,13 @@ export class AgentRuntime {
       const chain = new MiddlewareChain(this.config.middleware);
       return chain.execute(
         agentContext,
-        () => this.executeAgentLoop(systemPrompt, messages, resolvedModelString),
+        () =>
+          this.executeAgentLoop(
+            systemPrompt,
+            messages,
+            resolvedModelString,
+            maxOutputTokensOverride,
+          ),
       );
     });
   }
@@ -238,6 +245,7 @@ export class AgentRuntime {
       onChunk?: (chunk: string) => void;
     },
     modelOverride?: string,
+    maxOutputTokensOverride?: number,
   ): Promise<ReadableStream<Uint8Array>> {
     const requestedModel = resolveConfiguredAgentModel(modelOverride || this.config.model);
     // Auto-upgrade local/* to a cloud provider when API keys are available.
@@ -300,6 +308,7 @@ export class AgentRuntime {
             toolContext,
             resolvedModelString,
             languageModel,
+            maxOutputTokensOverride,
           );
 
           sendSSE(controller, encoder, { type: "text-end", id: textPartId });
@@ -325,6 +334,7 @@ export class AgentRuntime {
     systemPrompt: string,
     messages: Message[],
     modelString?: string,
+    maxOutputTokensOverride?: number,
   ): Promise<AgentResponse> {
     return withSpan("agent.execution_loop", async (loopSpan) => {
       const { maxAgentSteps } = getPlatformCapabilities();
@@ -373,7 +383,7 @@ export class AgentRuntime {
             system: systemPrompt,
             messages: convertToModelMessages(currentMessages),
             tools: convertToolsToAISDK(tools),
-            maxOutputTokens: this.config.memory?.maxTokens ?? DEFAULT_MAX_TOKENS,
+            maxOutputTokens: this.resolveMaxOutputTokens(maxOutputTokensOverride),
             temperature: DEFAULT_TEMPERATURE,
           });
         });
@@ -556,6 +566,7 @@ export class AgentRuntime {
     toolContext?: Record<string, unknown>,
     modelString?: string,
     resolvedModel?: LanguageModel,
+    maxOutputTokensOverride?: number,
   ): Promise<AgentResponse> {
     const { maxAgentSteps } = getPlatformCapabilities();
     const maxSteps = this.computeMaxSteps(maxAgentSteps);
@@ -597,7 +608,7 @@ export class AgentRuntime {
         system: systemPrompt,
         messages: convertToModelMessages(currentMessages),
         tools: convertToolsToAISDK(tools),
-        maxOutputTokens: this.config.memory?.maxTokens ?? DEFAULT_MAX_TOKENS,
+        maxOutputTokens: this.resolveMaxOutputTokens(maxOutputTokensOverride),
         temperature: DEFAULT_TEMPERATURE,
       });
 
@@ -816,6 +827,18 @@ export class AgentRuntime {
   private computeMaxSteps(platformLimit: number): number {
     const edgeMaxSteps = this.config.edge?.enabled ? this.config.edge.maxSteps : undefined;
     return getMaxSteps(this.config.maxSteps, edgeMaxSteps, platformLimit);
+  }
+
+  private resolveMaxOutputTokens(maxOutputTokensOverride?: number): number {
+    if (
+      typeof maxOutputTokensOverride === "number" &&
+      Number.isFinite(maxOutputTokensOverride) &&
+      maxOutputTokensOverride > 0
+    ) {
+      return Math.floor(maxOutputTokensOverride);
+    }
+
+    return this.config.memory?.maxTokens ?? DEFAULT_MAX_TOKENS;
   }
 
   /**

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -132,6 +132,8 @@ export interface Agent {
     context?: Record<string, unknown>;
     /** Override the agent's default model for this request. Must be in `allowedModels` if configured. */
     model?: ModelString;
+    /** Override the maximum model output tokens for this request. */
+    maxOutputTokens?: number;
   }): Promise<AgentResponse>;
 
   stream(input: {
@@ -140,6 +142,8 @@ export interface Agent {
     context?: Record<string, unknown>;
     /** Override the agent's default model for this request. Must be in `allowedModels` if configured. */
     model?: ModelString;
+    /** Override the maximum model output tokens for this request. */
+    maxOutputTokens?: number;
     onToolCall?: (toolCall: ToolCall) => void;
     onChunk?: (chunk: string) => void;
   }): Promise<AgentStreamResult>;

--- a/src/channels/invoke.test.ts
+++ b/src/channels/invoke.test.ts
@@ -183,6 +183,44 @@ describe("channels/invoke", () => {
       );
     });
 
+    it("rejects an expired dispatch signature", async () => {
+      const payload = createPayload();
+      const body = JSON.stringify(payload);
+      const now = Math.floor(Date.now() / 1000);
+      const { jws, publicKeyPem } = await createDispatchSignature(body, {
+        iat: now - 120,
+        exp: now - 60,
+      });
+
+      await assertRejects(() =>
+        verifyDispatchJws(jws, body, {
+          audience: "demo-project",
+          publicKeyPem,
+          maxAgeSeconds: 60,
+          expectedProjectId: "proj-1",
+        })
+      );
+    });
+
+    it("rejects a dispatch signature issued in the future", async () => {
+      const payload = createPayload();
+      const body = JSON.stringify(payload);
+      const now = Math.floor(Date.now() / 1000);
+      const { jws, publicKeyPem } = await createDispatchSignature(body, {
+        iat: now + 30,
+        exp: now + 90,
+      });
+
+      await assertRejects(() =>
+        verifyDispatchJws(jws, body, {
+          audience: "demo-project",
+          publicKeyPem,
+          maxAgeSeconds: 60,
+          expectedProjectId: "proj-1",
+        })
+      );
+    });
+
     it("rejects a dispatch when the body hash does not match", async () => {
       const payload = createPayload();
       const body = JSON.stringify(payload);

--- a/src/channels/invoke.test.ts
+++ b/src/channels/invoke.test.ts
@@ -1,0 +1,379 @@
+import type { Agent, AgentMessage as Message, AgentResponse } from "#veryfront/agent";
+import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+import {
+  buildChannelResponseParts,
+  type ChannelInvokeDeps,
+  type ChannelInvokeRequest,
+  executeChannelInvoke,
+  normalizeConversationHistoryForRuntime,
+  resolveChannelInvokeAgent,
+  verifyDispatchJws,
+} from "./invoke.ts";
+
+const encoder = new TextEncoder();
+
+async function sha256Base64url(body: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(body));
+  return base64urlEncodeBytes(new Uint8Array(digest));
+}
+
+function encodePem(label: string, der: ArrayBuffer): string {
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = base64.match(/.{1,64}/g) ?? [base64];
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
+}
+
+async function createDispatchSignature(
+  body: string,
+  overrides: Partial<{
+    audience: string;
+    projectId: string;
+    iat: number;
+    exp: number;
+    bodySha256: string;
+  }> = {},
+): Promise<{ jws: string; publicKeyPem: string }> {
+  const keyPair = await crypto.subtle.generateKey(
+    "Ed25519",
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+  const publicKeyDer = await crypto.subtle.exportKey("spki", keyPair.publicKey);
+  const publicKeyPem = encodePem("PUBLIC KEY", publicKeyDer);
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "EdDSA", typ: "JWT" };
+  const claims = {
+    iss: "veryfront-api",
+    aud: overrides.audience ?? "demo-project",
+    sub: "dispatch-1",
+    project_id: overrides.projectId ?? "proj-1",
+    platform: "slack",
+    body_sha256: overrides.bodySha256 ?? await sha256Base64url(body),
+    iat: overrides.iat ?? now,
+    exp: overrides.exp ?? now + 60,
+  };
+
+  const encodedHeader = base64urlEncode(JSON.stringify(header));
+  const encodedPayload = base64urlEncode(JSON.stringify(claims));
+  const signingInput = encoder.encode(`${encodedHeader}.${encodedPayload}`);
+  const signature = await crypto.subtle.sign("Ed25519", keyPair.privateKey, signingInput);
+
+  return {
+    publicKeyPem,
+    jws: `${encodedHeader}.${encodedPayload}.${base64urlEncodeBytes(new Uint8Array(signature))}`,
+  };
+}
+
+function createPayload(
+  overrides: Partial<ChannelInvokeRequest> = {},
+): ChannelInvokeRequest {
+  return {
+    dispatchId: "dispatch-1",
+    conversationId: "conversation-1",
+    projectId: "proj-1",
+    agentConfigId: "agent-1",
+    platform: "slack",
+    inboundMessage: {
+      text: "Hello from Slack",
+      userId: "U123",
+      userName: "Alice",
+      isDirectMessage: false,
+    },
+    conversationHistory: [
+      {
+        id: "msg-user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Hello from Slack" }],
+        createdAt: "2026-03-13T10:00:00.000Z",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function createHandlerContext(): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter: {
+      env: { get: () => undefined },
+      fs: {},
+    },
+    securityConfig: null,
+    cspUserHeader: null,
+    projectSlug: "demo-project",
+    projectId: "proj-1",
+    isLocalProject: false,
+  } as unknown as HandlerContext;
+}
+
+function createAgentResponse(
+  text = "Hello from runtime",
+  overrides: Partial<AgentResponse> = {},
+): AgentResponse {
+  const assistantMessage: Message = {
+    id: "assistant-1",
+    role: "assistant",
+    parts: [{ type: "text", text }],
+    timestamp: Date.now(),
+  };
+
+  return {
+    text,
+    messages: [assistantMessage],
+    toolCalls: [],
+    status: "completed",
+    usage: { promptTokens: 12, completionTokens: 8, totalTokens: 20 },
+    ...overrides,
+  };
+}
+
+function createAgent(overrides: {
+  id?: string;
+  generate?: Agent["generate"];
+  clearMemory?: Agent["clearMemory"];
+} = {}): Agent {
+  return {
+    id: overrides.id ?? "agent-1",
+    config: {} as Agent["config"],
+    generate: overrides.generate ?? (() => Promise.resolve(createAgentResponse())),
+    stream: async () => ({ toDataStreamResponse: () => new Response() } as never),
+    respond: async () => new Response(),
+    getMemory: () => ({} as never),
+    getMemoryStats: async () => ({ totalMessages: 0, estimatedTokens: 0, type: "conversation" }),
+    clearMemory: overrides.clearMemory ?? (() => Promise.resolve()),
+  };
+}
+
+describe("channels/invoke", () => {
+  describe("verifyDispatchJws", () => {
+    it("accepts a valid Ed25519 dispatch signature", async () => {
+      const payload = createPayload();
+      const body = JSON.stringify(payload);
+      const { jws, publicKeyPem } = await createDispatchSignature(body);
+
+      const claims = await verifyDispatchJws(jws, body, {
+        audience: "demo-project",
+        publicKeyPem,
+        maxAgeSeconds: 60,
+        expectedProjectId: "proj-1",
+      });
+
+      assertEquals(claims.aud, "demo-project");
+      assertEquals(claims.project_id, "proj-1");
+      assertEquals(claims.body_sha256, await sha256Base64url(body));
+    });
+
+    it("rejects a dispatch with the wrong audience", async () => {
+      const payload = createPayload();
+      const body = JSON.stringify(payload);
+      const { jws, publicKeyPem } = await createDispatchSignature(body);
+
+      await assertRejects(() =>
+        verifyDispatchJws(jws, body, {
+          audience: "other-project",
+          publicKeyPem,
+          maxAgeSeconds: 60,
+          expectedProjectId: "proj-1",
+        })
+      );
+    });
+
+    it("rejects a dispatch when the body hash does not match", async () => {
+      const payload = createPayload();
+      const body = JSON.stringify(payload);
+      const { jws, publicKeyPem } = await createDispatchSignature(body);
+
+      await assertRejects(() =>
+        verifyDispatchJws(jws, `${body} `, {
+          audience: "demo-project",
+          publicKeyPem,
+          maxAgeSeconds: 60,
+          expectedProjectId: "proj-1",
+        })
+      );
+    });
+  });
+
+  describe("normalizeConversationHistoryForRuntime", () => {
+    it("maps supported message parts and drops unsupported ones", () => {
+      const normalized = normalizeConversationHistoryForRuntime([
+        {
+          id: "msg-1",
+          role: "assistant",
+          parts: [
+            { type: "text", text: "Done" },
+            { type: "reasoning", text: "internal reasoning" },
+            { type: "tool_call", id: "tool-1", name: "search", input: { query: "docs" } },
+            {
+              type: "tool_result",
+              tool_call_id: "tool-1",
+              tool_name: "search",
+              output: { answer: 42 },
+            },
+            { type: "file", url: "https://example.com/file.png" },
+          ],
+          metadata: { source: "channel" },
+          createdAt: "2026-03-13T10:00:00.000Z",
+        },
+      ]);
+
+      assertEquals(normalized, [{
+        id: "msg-1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "Done" },
+          {
+            type: "tool-search",
+            toolCallId: "tool-1",
+            toolName: "search",
+            args: { query: "docs" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tool-1",
+            toolName: "search",
+            result: { answer: 42 },
+          },
+        ],
+        metadata: { source: "channel" },
+        timestamp: Date.parse("2026-03-13T10:00:00.000Z"),
+      }]);
+    });
+  });
+
+  describe("resolveChannelInvokeAgent", () => {
+    it("returns an exact registry match when available", () => {
+      const agent = createAgent({ id: "agent-1" });
+      const resolved = resolveChannelInvokeAgent("agent-1", {
+        getAgent: (id) => id === "agent-1" ? agent : undefined,
+        getAllAgentIds: () => ["agent-1", "agent-2"],
+      });
+
+      assertEquals(resolved, agent);
+    });
+
+    it("falls back only when exactly one runtime agent exists", () => {
+      const agent = createAgent({ id: "agent-runtime" });
+      const resolved = resolveChannelInvokeAgent("api-agent-config", {
+        getAgent: (id) => id === "agent-runtime" ? agent : undefined,
+        getAllAgentIds: () => ["agent-runtime"],
+      });
+
+      assertEquals(resolved, agent);
+    });
+
+    it("fails closed when multiple runtime agents make the mapping ambiguous", () => {
+      const resolved = resolveChannelInvokeAgent("api-agent-config", {
+        getAgent: () => undefined,
+        getAllAgentIds: () => ["agent-a", "agent-b"],
+      });
+
+      assertEquals(resolved, undefined);
+    });
+  });
+
+  describe("buildChannelResponseParts", () => {
+    it("includes reasoning, tool calls, tool results, and final text", () => {
+      const response = createAgentResponse("Final answer", {
+        thinking: "Need to check a tool first",
+        toolCalls: [{
+          id: "tool-1",
+          name: "search",
+          args: { query: "docs" },
+          status: "completed",
+          result: { hits: 2 },
+        }],
+      });
+
+      const parts = buildChannelResponseParts(response);
+
+      assertEquals(parts, [
+        { type: "reasoning", text: "Need to check a tool first" },
+        {
+          type: "tool_call",
+          id: "tool-1",
+          name: "search",
+          input: { query: "docs" },
+          state: "completed",
+        },
+        {
+          type: "tool_result",
+          tool_call_id: "tool-1",
+          output: { hits: 2 },
+        },
+        { type: "text", text: "Final answer" },
+      ]);
+    });
+  });
+
+  describe("executeChannelInvoke", () => {
+    it("forwards maxResponseTokens to the runtime agent and returns normalized parts", async () => {
+      let discoveryCalls = 0;
+      let clearMemoryCalls = 0;
+      let capturedGenerateInput: Parameters<Agent["generate"]>[0] | undefined;
+      const agent = createAgent({
+        clearMemory: async () => {
+          clearMemoryCalls += 1;
+        },
+        generate: async (input) => {
+          capturedGenerateInput = input;
+          return createAgentResponse("Runtime answer");
+        },
+      });
+
+      const deps: ChannelInvokeDeps = {
+        ensureProjectDiscovery: async () => {
+          discoveryCalls += 1;
+        },
+        getAgent: (id) => id === "agent-1" ? agent : undefined,
+        getAllAgentIds: () => ["agent-1"],
+      };
+
+      const response = await executeChannelInvoke(
+        createPayload({ generation: { maxResponseTokens: 321 } }),
+        createHandlerContext(),
+        deps,
+      );
+
+      assertEquals(discoveryCalls, 1);
+      assertEquals(clearMemoryCalls, 1);
+      assertExists(capturedGenerateInput);
+      assertEquals(capturedGenerateInput.maxOutputTokens, 321);
+      assertEquals(response, {
+        ignored: false,
+        responseParts: [{ type: "text", text: "Runtime answer" }],
+        tokenUsage: { inputTokens: 12, outputTokens: 8, totalTokens: 20 },
+      });
+    });
+
+    it("returns a structured provider error when no AI runtime is available", async () => {
+      const agent = createAgent({
+        generate: async () => {
+          throw toError(
+            createError({ type: "no_ai_available", message: "Local model unavailable" }),
+          );
+        },
+      });
+
+      const response = await executeChannelInvoke(
+        createPayload(),
+        createHandlerContext(),
+        {
+          ensureProjectDiscovery: async () => {},
+          getAgent: () => agent,
+          getAllAgentIds: () => ["agent-1"],
+        },
+      );
+
+      assertEquals(response, {
+        ignored: false,
+        error: { code: "provider_error", retryable: false },
+      });
+    });
+  });
+});

--- a/src/channels/invoke.ts
+++ b/src/channels/invoke.ts
@@ -48,7 +48,7 @@ export const ChannelInvokeRequestSchema = z.object({
   }),
   conversationHistory: z.array(channelInvokeHistoryMessageSchema),
   generation: z.object({
-    maxResponseTokens: z.number().int().positive().optional(),
+    maxResponseTokens: z.number().int().positive().max(16384).optional(),
   }).optional(),
 });
 

--- a/src/channels/invoke.ts
+++ b/src/channels/invoke.ts
@@ -1,0 +1,520 @@
+import type { Agent, AgentMessage as Message, AgentResponse } from "#veryfront/agent";
+import { fromError } from "#veryfront/errors/veryfront-error.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { serverLogger } from "#veryfront/utils";
+import { base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+import { z } from "zod";
+import {
+  getAgent as getRegisteredAgent,
+  getAllAgentIds as getRegisteredAgentIds,
+} from "../agent/composition/composition.ts";
+import { ensureProjectDiscovery as ensureProjectDiscoveryForProject } from "../server/handlers/request/api/project-discovery.ts";
+
+const logger = serverLogger.component("channels-invoke");
+const SIGNATURE_SKEW_SECONDS = 5;
+
+const rawHistoryPartSchema = z.object({
+  type: z.string(),
+}).passthrough();
+
+const channelAttachmentSchema = z.object({
+  id: z.string(),
+  kind: z.enum(["image", "file"]),
+  filename: z.string().optional(),
+  mediaType: z.string().optional(),
+  privateUrl: z.string().optional(),
+});
+
+const channelInvokeHistoryMessageSchema = z.object({
+  id: z.string(),
+  role: z.enum(["user", "assistant", "system", "tool"]),
+  parts: z.array(rawHistoryPartSchema),
+  metadata: z.record(z.unknown()).optional(),
+  createdAt: z.string().optional(),
+});
+
+export const ChannelInvokeRequestSchema = z.object({
+  dispatchId: z.string().min(1),
+  conversationId: z.string().min(1),
+  projectId: z.string().min(1),
+  agentConfigId: z.string().min(1),
+  platform: z.literal("slack"),
+  inboundMessage: z.object({
+    text: z.string(),
+    userId: z.string(),
+    userName: z.string(),
+    isDirectMessage: z.boolean(),
+    attachments: z.array(channelAttachmentSchema).optional(),
+  }),
+  conversationHistory: z.array(channelInvokeHistoryMessageSchema),
+  generation: z.object({
+    maxResponseTokens: z.number().int().positive().optional(),
+  }).optional(),
+});
+
+const channelTextPartSchema = z.object({
+  type: z.literal("text"),
+  text: z.string(),
+});
+
+const channelToolCallPartSchema = z.object({
+  type: z.literal("tool_call"),
+  id: z.string(),
+  name: z.string(),
+  input: z.record(z.unknown()),
+  state: z.enum(["streaming", "pending", "completed", "error"]),
+});
+
+const channelToolResultPartSchema = z.object({
+  type: z.literal("tool_result"),
+  tool_call_id: z.string(),
+  output: z.unknown(),
+  is_error: z.boolean().optional(),
+});
+
+const channelReasoningPartSchema = z.object({
+  type: z.literal("reasoning"),
+  text: z.string(),
+});
+
+const channelErrorPartSchema = z.object({
+  type: z.literal("error"),
+  code: z.string(),
+  message: z.string(),
+});
+
+export const ChannelResponsePartSchema = z.discriminatedUnion("type", [
+  channelTextPartSchema,
+  channelToolCallPartSchema,
+  channelToolResultPartSchema,
+  channelReasoningPartSchema,
+  channelErrorPartSchema,
+]);
+
+export const ChannelInvokeResponseSchema = z.object({
+  ignored: z.boolean(),
+  responseParts: z.array(ChannelResponsePartSchema).optional(),
+  tokenUsage: z.object({
+    inputTokens: z.number().int().nonnegative().optional(),
+    outputTokens: z.number().int().nonnegative().optional(),
+    totalTokens: z.number().int().nonnegative().optional(),
+  }).optional(),
+  error: z.object({
+    code: z.enum(["provider_error", "internal_error"]),
+    retryable: z.boolean(),
+  }).optional(),
+});
+
+const dispatchHeaderSchema = z.object({
+  alg: z.literal("EdDSA"),
+  typ: z.string().optional(),
+  kid: z.string().optional(),
+});
+
+const dispatchClaimsSchema = z.object({
+  iss: z.string(),
+  aud: z.string(),
+  sub: z.string(),
+  project_id: z.string(),
+  platform: z.string(),
+  body_sha256: z.string(),
+  iat: z.number().int(),
+  exp: z.number().int(),
+});
+
+export type ChannelInvokeRequest = z.infer<typeof ChannelInvokeRequestSchema>;
+export type ChannelInvokeResponse = z.infer<typeof ChannelInvokeResponseSchema>;
+
+type ChannelResponsePart = z.infer<typeof ChannelResponsePartSchema>;
+type DispatchClaims = z.infer<typeof dispatchClaimsSchema>;
+
+export interface ChannelInvokeDeps {
+  ensureProjectDiscovery: (ctx: HandlerContext) => Promise<void>;
+  getAgent: (id: string) => Agent | undefined;
+  getAllAgentIds: () => string[];
+}
+
+export const defaultChannelInvokeDeps: ChannelInvokeDeps = {
+  ensureProjectDiscovery: ensureProjectDiscoveryForProject,
+  getAgent: getRegisteredAgent,
+  getAllAgentIds: getRegisteredAgentIds,
+};
+
+function base64urlDecodeToBytes(input: string): ArrayBuffer {
+  const normalized = input
+    .replaceAll("-", "+")
+    .replaceAll("_", "/")
+    .padEnd(Math.ceil(input.length / 4) * 4, "=");
+
+  return toArrayBuffer(Uint8Array.from(atob(normalized), (char) => char.charCodeAt(0)));
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  return buffer;
+}
+
+function pemToDer(pem: string, label: string): ArrayBuffer {
+  const body = pem
+    .replace(`-----BEGIN ${label}-----`, "")
+    .replace(`-----END ${label}-----`, "")
+    .replace(/\s/g, "");
+
+  return toArrayBuffer(Uint8Array.from(atob(body), (char) => char.charCodeAt(0)));
+}
+
+async function importEd25519PublicKey(pem: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "spki",
+    pemToDer(pem, "PUBLIC KEY"),
+    "Ed25519",
+    false,
+    ["verify"],
+  );
+}
+
+async function sha256Base64url(body: string): Promise<string> {
+  const hash = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(body));
+  return base64urlEncodeBytes(new Uint8Array(hash));
+}
+
+export async function verifyDispatchJws(
+  jws: string,
+  body: string,
+  options: {
+    audience: string;
+    publicKeyPem: string;
+    maxAgeSeconds: number;
+    expectedProjectId?: string;
+  },
+): Promise<DispatchClaims> {
+  const parts = jws.split(".");
+  if (parts.length !== 3) {
+    throw new Error("Channel dispatch signature must be a compact JWS");
+  }
+
+  const encodedHeader = parts[0];
+  const encodedPayload = parts[1];
+  const encodedSignature = parts[2];
+  if (!encodedHeader || !encodedPayload || !encodedSignature) {
+    throw new Error("Channel dispatch signature must include header, payload, and signature");
+  }
+  const header = dispatchHeaderSchema.parse(
+    JSON.parse(new TextDecoder().decode(base64urlDecodeToBytes(encodedHeader))),
+  );
+  const claims = dispatchClaimsSchema.parse(
+    JSON.parse(new TextDecoder().decode(base64urlDecodeToBytes(encodedPayload))),
+  );
+
+  if (header.alg !== "EdDSA") {
+    throw new Error("Unsupported channel dispatch JWS algorithm");
+  }
+
+  const signingInput = new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`);
+  const signature = base64urlDecodeToBytes(encodedSignature);
+  const publicKey = await importEd25519PublicKey(options.publicKeyPem);
+  const verified = await crypto.subtle.verify("Ed25519", publicKey, signature, signingInput);
+
+  if (!verified) {
+    throw new Error("Channel dispatch signature verification failed");
+  }
+
+  if (claims.aud !== options.audience) {
+    throw new Error("Channel dispatch audience mismatch");
+  }
+
+  if (options.expectedProjectId && claims.project_id !== options.expectedProjectId) {
+    throw new Error("Channel dispatch project mismatch");
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (claims.exp <= now) {
+    throw new Error("Channel dispatch signature expired");
+  }
+
+  if (claims.iat > now + SIGNATURE_SKEW_SECONDS) {
+    throw new Error("Channel dispatch signature issued in the future");
+  }
+
+  if (now - claims.iat > options.maxAgeSeconds) {
+    throw new Error("Channel dispatch signature is too old");
+  }
+
+  const bodySha256 = await sha256Base64url(body);
+  if (claims.body_sha256 !== bodySha256) {
+    throw new Error("Channel dispatch body hash mismatch");
+  }
+
+  return claims;
+}
+
+function normalizeConversationPart(
+  part: z.infer<typeof rawHistoryPartSchema>,
+): Message["parts"][number] | null {
+  if (part.type === "text" && typeof part.text === "string") {
+    return { type: "text", text: part.text };
+  }
+
+  if (
+    part.type === "tool_call" &&
+    typeof part.id === "string" &&
+    typeof part.name === "string" &&
+    part.input &&
+    typeof part.input === "object" &&
+    !Array.isArray(part.input)
+  ) {
+    return {
+      type: `tool-${part.name}`,
+      toolCallId: part.id,
+      toolName: part.name,
+      args: part.input as Record<string, unknown>,
+    };
+  }
+
+  if (part.type === "tool_result" && typeof part.tool_call_id === "string") {
+    return {
+      type: "tool-result",
+      toolCallId: part.tool_call_id,
+      toolName: typeof part.tool_name === "string" ? part.tool_name : "unknown",
+      result: "output" in part ? part.output : undefined,
+    };
+  }
+
+  return null;
+}
+
+export function normalizeConversationHistoryForRuntime(
+  messages: ChannelInvokeRequest["conversationHistory"],
+): Message[] {
+  return messages.map((message) => ({
+    id: message.id,
+    role: message.role,
+    parts: message.parts
+      .map((part) => normalizeConversationPart(part))
+      .filter((part): part is NonNullable<typeof part> => part !== null),
+    ...(message.createdAt ? { timestamp: Date.parse(message.createdAt) || undefined } : {}),
+    ...(message.metadata ? { metadata: message.metadata } : {}),
+  }));
+}
+
+export function resolveChannelInvokeAgent(
+  agentConfigId: string,
+  deps: Pick<ChannelInvokeDeps, "getAgent" | "getAllAgentIds">,
+): Agent | undefined {
+  const exactAgent = deps.getAgent(agentConfigId);
+  if (exactAgent) {
+    return exactAgent;
+  }
+
+  const agentIds = deps.getAllAgentIds();
+  if (agentIds.length !== 1) {
+    return undefined;
+  }
+
+  const onlyAgentId = agentIds[0];
+  if (!onlyAgentId) {
+    return undefined;
+  }
+  const onlyAgent = deps.getAgent(onlyAgentId);
+  if (onlyAgent) {
+    logger.warn(
+      "Channel invoke fell back to the only discovered runtime agent because agentConfigId did not match a registry id",
+      {
+        requestedAgentConfigId: agentConfigId,
+        resolvedAgentId: onlyAgentId,
+      },
+    );
+  }
+
+  return onlyAgent;
+}
+
+function normalizeToolCallState(status: string): "pending" | "completed" | "error" {
+  switch (status) {
+    case "completed":
+      return "completed";
+    case "error":
+      return "error";
+    default:
+      return "pending";
+  }
+}
+
+function convertAssistantPartToChannelResponsePart(
+  part: Message["parts"][number],
+  knownToolCallIds: Set<string>,
+): ChannelResponsePart | null {
+  if (part.type === "text" && "text" in part) {
+    return channelTextPartSchema.parse({
+      type: "text",
+      text: part.text,
+    });
+  }
+
+  const isToolCallPart = part.type === "tool-call" ||
+    (part.type.startsWith("tool-") && part.type !== "tool-result");
+  if (
+    isToolCallPart &&
+    "toolCallId" in part &&
+    "toolName" in part &&
+    !knownToolCallIds.has(part.toolCallId)
+  ) {
+    return channelToolCallPartSchema.parse({
+      type: "tool_call",
+      id: part.toolCallId,
+      name: part.toolName,
+      input: "args" in part ? part.args : ("input" in part ? part.input : {}),
+      state: "pending",
+    });
+  }
+
+  return null;
+}
+
+function findLastAssistantMessage(messages: Message[]): Message | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.role === "assistant") {
+      return messages[index];
+    }
+  }
+
+  return undefined;
+}
+
+export function buildChannelResponseParts(response: AgentResponse): ChannelResponsePart[] {
+  const responseParts: ChannelResponsePart[] = [];
+  const knownToolCallIds = new Set<string>();
+
+  if (response.thinking?.trim()) {
+    responseParts.push(channelReasoningPartSchema.parse({
+      type: "reasoning",
+      text: response.thinking,
+    }));
+  }
+
+  for (const toolCall of response.toolCalls) {
+    knownToolCallIds.add(toolCall.id);
+    responseParts.push(channelToolCallPartSchema.parse({
+      type: "tool_call",
+      id: toolCall.id,
+      name: toolCall.name,
+      input: toolCall.args,
+      state: normalizeToolCallState(toolCall.status),
+    }));
+
+    if (toolCall.status === "completed" || toolCall.status === "error") {
+      responseParts.push(channelToolResultPartSchema.parse({
+        type: "tool_result",
+        tool_call_id: toolCall.id,
+        output: toolCall.status === "error"
+          ? { error: toolCall.error ?? "Tool execution failed" }
+          : toolCall.result,
+        ...(toolCall.status === "error" ? { is_error: true } : {}),
+      }));
+    }
+  }
+
+  const lastAssistantMessage = findLastAssistantMessage(response.messages);
+  if (lastAssistantMessage) {
+    for (const part of lastAssistantMessage.parts) {
+      const converted = convertAssistantPartToChannelResponsePart(part, knownToolCallIds);
+      if (converted) {
+        responseParts.push(converted);
+      }
+    }
+  } else if (response.text.trim()) {
+    responseParts.push(channelTextPartSchema.parse({
+      type: "text",
+      text: response.text,
+    }));
+  }
+
+  return responseParts;
+}
+
+function classifyRuntimeError(error: unknown): ChannelInvokeResponse["error"] {
+  const veryfrontError = fromError(error);
+
+  if (veryfrontError?.type === "no_ai_available") {
+    return { code: "provider_error", retryable: false };
+  }
+
+  if (veryfrontError?.type === "api" || veryfrontError?.type === "network") {
+    return { code: "provider_error", retryable: true };
+  }
+
+  return { code: "internal_error", retryable: true };
+}
+
+export async function executeChannelInvoke(
+  payload: ChannelInvokeRequest,
+  ctx: HandlerContext,
+  deps: ChannelInvokeDeps,
+): Promise<ChannelInvokeResponse> {
+  await deps.ensureProjectDiscovery(ctx);
+
+  const agent = resolveChannelInvokeAgent(payload.agentConfigId, deps);
+  if (!agent) {
+    logger.error("Channel invoke could not resolve a runtime agent for the request", {
+      requestedAgentConfigId: payload.agentConfigId,
+      discoveredAgentIds: deps.getAllAgentIds(),
+      projectSlug: ctx.projectSlug,
+      projectId: ctx.projectId,
+    });
+    return {
+      ignored: false,
+      error: {
+        code: "internal_error",
+        retryable: false,
+      },
+    };
+  }
+
+  const messages = normalizeConversationHistoryForRuntime(payload.conversationHistory);
+  await agent.clearMemory();
+
+  try {
+    const result = await agent.generate({
+      input: messages,
+      context: {
+        requestId: payload.dispatchId,
+        dispatchId: payload.dispatchId,
+        conversationId: payload.conversationId,
+        projectId: payload.projectId,
+        agentConfigId: payload.agentConfigId,
+        channel: payload.inboundMessage,
+      },
+      ...(payload.generation?.maxResponseTokens
+        ? {
+          maxOutputTokens: payload.generation.maxResponseTokens,
+        }
+        : {}),
+    });
+
+    return ChannelInvokeResponseSchema.parse({
+      ignored: false,
+      responseParts: buildChannelResponseParts(result),
+      tokenUsage: result.usage
+        ? {
+          inputTokens: result.usage.promptTokens,
+          outputTokens: result.usage.completionTokens,
+          totalTokens: result.usage.totalTokens,
+        }
+        : undefined,
+    });
+  } catch (error) {
+    logger.error("Channel invoke runtime execution failed", {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+      projectSlug: ctx.projectSlug,
+      projectId: ctx.projectId,
+      dispatchId: payload.dispatchId,
+    });
+
+    return {
+      ignored: false,
+      error: classifyRuntimeError(error),
+    };
+  }
+}

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -8,9 +8,7 @@ import type {
 import { getApiHandler } from "./pages-api-handler.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
-import { serverLogger } from "#veryfront/utils";
-
-const logger = serverLogger.component("api-wrapper");
+import { ensureProjectDiscovery } from "./project-discovery.ts";
 
 type FsWrapper = {
   isMultiProjectMode?: () => boolean;
@@ -22,88 +20,6 @@ type FsWrapper = {
     options?: { productionMode?: boolean; releaseId?: string | null },
   ) => Promise<T>;
 };
-
-/**
- * Tracks in-flight and completed AI discovery per project+release.
- *
- * Key: `{projectSlug}:{releaseId}` for production, `{projectSlug}:preview` for preview.
- * This ensures a new deployment triggers re-discovery of agents/tools.
- *
- * Using a Map<string, Promise> deduplicates concurrent requests and
- * allows retry on failure (the key is deleted if discovery rejects).
- */
-const discoveredProjects = new Map<string, Promise<void>>();
-
-/** Build a discovery cache key that incorporates the release/version. */
-function discoveryKey(ctx: HandlerContext): string {
-  const slug = ctx.projectSlug ?? ctx.projectDir;
-  const version = ctx.releaseId ?? "preview";
-  return `${slug}:${version}`;
-}
-
-/**
- * Run AI discovery (agents, tools) for a project if not already done.
- * Must be called within a runWithContext scope so the VFS can resolve
- * the correct remote project files and the agent registry uses the
- * correct project scope.
- */
-async function ensureProjectDiscovery(ctx: HandlerContext): Promise<void> {
-  const key = discoveryKey(ctx);
-
-  const existing = discoveredProjects.get(key);
-  if (existing) return existing;
-
-  const promise = (async () => {
-    const { discoverAll } = await import("#veryfront/discovery");
-    const { agentRegistry } = await import(
-      "#veryfront/agent/composition/composition.ts"
-    );
-    const { toolRegistry } = await import("#veryfront/tool/registry.ts");
-
-    // Clear stale entries for this project scope before re-discovery.
-    // This prevents agents/tools removed in a new release from lingering.
-    agentRegistry.clear();
-    toolRegistry.clear();
-
-    const result = await discoverAll({
-      baseDir: ctx.projectDir,
-      fsAdapter: ctx.adapter.fs,
-      verbose: false,
-    });
-
-    const logData = {
-      projectSlug: ctx.projectSlug,
-      releaseId: ctx.releaseId,
-      agents: result.agents.size,
-      tools: result.tools.size,
-      errors: result.errors.length,
-    };
-
-    if (result.agents.size === 0 && result.tools.size === 0) {
-      logger.warn("AI discovery found 0 agents and 0 tools", {
-        ...logData,
-        errorMessages: result.errors.map((e) => e.error.message).slice(0, 5),
-        baseDir: ctx.projectDir,
-      });
-    } else {
-      logger.info("AI discovery completed", logData);
-    }
-  })();
-
-  discoveredProjects.set(key, promise);
-
-  try {
-    await promise;
-  } catch (error) {
-    // Allow retry on next request
-    discoveredProjects.delete(key);
-    logger.warn("AI discovery failed (will retry)", {
-      projectSlug: ctx.projectSlug,
-      error: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-    });
-  }
-}
 
 export class ApiHandlerWrapper extends BaseHandler {
   private projectDir: string;

--- a/src/server/handlers/request/api/project-discovery.ts
+++ b/src/server/handlers/request/api/project-discovery.ts
@@ -1,0 +1,86 @@
+import { serverLogger } from "#veryfront/utils";
+import type { HandlerContext } from "../../types.ts";
+
+const logger = serverLogger.component("api-wrapper");
+
+/**
+ * Tracks in-flight and completed AI discovery per project+release.
+ *
+ * Key: `{projectSlug}:{releaseId}` for production, `{projectSlug}:preview` for preview.
+ * This ensures a new deployment triggers re-discovery of agents/tools.
+ *
+ * Using a Map<string, Promise> deduplicates concurrent requests and
+ * allows retry on failure (the key is deleted if discovery rejects).
+ */
+const discoveredProjects = new Map<string, Promise<void>>();
+
+/** Build a discovery cache key that incorporates the release/version. */
+function discoveryKey(ctx: HandlerContext): string {
+  const slug = ctx.projectSlug ?? ctx.projectDir;
+  const version = ctx.releaseId ?? "preview";
+  return `${slug}:${version}`;
+}
+
+/**
+ * Run AI discovery (agents, tools) for a project if not already done.
+ * Must be called within a runWithContext scope so the VFS can resolve
+ * the correct remote project files and the agent registry uses the
+ * correct project scope.
+ */
+export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<void> {
+  const key = discoveryKey(ctx);
+
+  const existing = discoveredProjects.get(key);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    const { discoverAll } = await import("#veryfront/discovery");
+    const { agentRegistry } = await import(
+      "#veryfront/agent/composition/composition.ts"
+    );
+    const { toolRegistry } = await import("#veryfront/tool/registry.ts");
+
+    // Clear stale entries for this project scope before re-discovery.
+    // This prevents agents/tools removed in a new release from lingering.
+    agentRegistry.clear();
+    toolRegistry.clear();
+
+    const result = await discoverAll({
+      baseDir: ctx.projectDir,
+      fsAdapter: ctx.adapter.fs,
+      verbose: false,
+    });
+
+    const logData = {
+      projectSlug: ctx.projectSlug,
+      releaseId: ctx.releaseId,
+      agents: result.agents.size,
+      tools: result.tools.size,
+      errors: result.errors.length,
+    };
+
+    if (result.agents.size === 0 && result.tools.size === 0) {
+      logger.warn("AI discovery found 0 agents and 0 tools", {
+        ...logData,
+        errorMessages: result.errors.map((e) => e.error.message).slice(0, 5),
+        baseDir: ctx.projectDir,
+      });
+    } else {
+      logger.info("AI discovery completed", logData);
+    }
+  })();
+
+  discoveredProjects.set(key, promise);
+
+  try {
+    await promise;
+  } catch (error) {
+    // Allow retry on next request
+    discoveredProjects.delete(key);
+    logger.warn("AI discovery failed (will retry)", {
+      projectSlug: ctx.projectSlug,
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+  }
+}

--- a/src/server/handlers/request/channel-invoke.handler.test.ts
+++ b/src/server/handlers/request/channel-invoke.handler.test.ts
@@ -1,0 +1,231 @@
+import type { Agent, AgentMessage as Message, AgentResponse } from "#veryfront/agent";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+import type { ChannelInvokeRequest } from "../../../channels/invoke.ts";
+import { ChannelInvokeHandler } from "./channel-invoke.handler.ts";
+
+const encoder = new TextEncoder();
+
+function encodePem(label: string, der: ArrayBuffer): string {
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = base64.match(/.{1,64}/g) ?? [base64];
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
+}
+
+async function sha256Base64url(body: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(body));
+  return base64urlEncodeBytes(new Uint8Array(digest));
+}
+
+async function createDispatchSignature(
+  body: string,
+  overrides: Partial<{
+    audience: string;
+    projectId: string;
+  }> = {},
+): Promise<{ jws: string; publicKeyPem: string }> {
+  const keyPair = await crypto.subtle.generateKey(
+    "Ed25519",
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+  const publicKeyDer = await crypto.subtle.exportKey("spki", keyPair.publicKey);
+  const publicKeyPem = encodePem("PUBLIC KEY", publicKeyDer);
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = base64urlEncode(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
+  const payload = base64urlEncode(JSON.stringify({
+    iss: "veryfront-api",
+    aud: overrides.audience ?? "demo-project",
+    sub: "dispatch-1",
+    project_id: overrides.projectId ?? "proj-1",
+    platform: "slack",
+    body_sha256: await sha256Base64url(body),
+    iat: now,
+    exp: now + 60,
+  }));
+
+  const signingInput = encoder.encode(`${header}.${payload}`);
+  const signature = await crypto.subtle.sign("Ed25519", keyPair.privateKey, signingInput);
+
+  return {
+    publicKeyPem,
+    jws: `${header}.${payload}.${base64urlEncodeBytes(new Uint8Array(signature))}`,
+  };
+}
+
+function createPayload(): ChannelInvokeRequest {
+  return {
+    dispatchId: "dispatch-1",
+    conversationId: "conversation-1",
+    projectId: "proj-1",
+    agentConfigId: "agent-1",
+    platform: "slack",
+    inboundMessage: {
+      text: "Hello from Slack",
+      userId: "U123",
+      userName: "Alice",
+      isDirectMessage: false,
+    },
+    conversationHistory: [
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Hello from Slack" }],
+      },
+    ],
+  };
+}
+
+function createAgentResponse(text = "Hello from handler"): AgentResponse {
+  const assistantMessage: Message = {
+    id: "assistant-1",
+    role: "assistant",
+    parts: [{ type: "text", text }],
+  };
+
+  return {
+    text,
+    messages: [assistantMessage],
+    toolCalls: [],
+    status: "completed",
+    usage: {
+      promptTokens: 5,
+      completionTokens: 7,
+      totalTokens: 12,
+    },
+  };
+}
+
+function createAgent(generate: Agent["generate"]): Agent {
+  return {
+    id: "agent-1",
+    config: {} as Agent["config"],
+    generate,
+    stream: async () => ({ toDataStreamResponse: () => new Response() } as never),
+    respond: async () => new Response(),
+    getMemory: () => ({} as never),
+    getMemoryStats: async () => ({ totalMessages: 0, estimatedTokens: 0, type: "conversation" }),
+    clearMemory: async () => {},
+  };
+}
+
+function createCtx(publicKeyPem?: string): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter: {
+      env: {
+        get: (key: string) =>
+          key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? publicKeyPem : undefined,
+      },
+      fs: {},
+    },
+    securityConfig: null,
+    cspUserHeader: null,
+    projectSlug: "demo-project",
+    projectId: "proj-1",
+    isLocalProject: false,
+  } as unknown as HandlerContext;
+}
+
+describe("server/handlers/request/channel-invoke.handler", () => {
+  it("returns 200 for a valid signed invoke request", async () => {
+    let discoveryCalls = 0;
+    const handler = new ChannelInvokeHandler({
+      ensureProjectDiscovery: async () => {
+        discoveryCalls += 1;
+      },
+      getAgent: () => createAgent(async () => createAgentResponse()),
+      getAllAgentIds: () => ["agent-1"],
+    });
+
+    const payload = createPayload();
+    const body = JSON.stringify(payload);
+    const { jws, publicKeyPem } = await createDispatchSignature(body);
+
+    const result = await handler.handle(
+      new Request("https://example.com/channels/invoke", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-dispatch-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(discoveryCalls, 1);
+
+    const responseBody = await result.response.json();
+    assertEquals(responseBody, {
+      ignored: false,
+      responseParts: [{ type: "text", text: "Hello from handler" }],
+      tokenUsage: { inputTokens: 5, outputTokens: 7, totalTokens: 12 },
+    });
+  });
+
+  it("returns 401 when the dispatch signature header is missing", async () => {
+    const handler = new ChannelInvokeHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: () => undefined,
+      getAllAgentIds: () => [],
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/channels/invoke", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(createPayload()),
+      }),
+      createCtx("-----BEGIN PUBLIC KEY-----\nZmFrZQ==\n-----END PUBLIC KEY-----"),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 401);
+    assertEquals(await result.response.json(), { error: "Missing dispatch signature" });
+  });
+
+  it("returns 400 when the signed body does not match the invoke schema", async () => {
+    const handler = new ChannelInvokeHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: () => undefined,
+      getAllAgentIds: () => [],
+    });
+
+    const invalidBody = JSON.stringify({
+      dispatchId: "dispatch-1",
+      projectId: "proj-1",
+      agentConfigId: "agent-1",
+      platform: "slack",
+      inboundMessage: {
+        text: "Hello from Slack",
+        userId: "U123",
+        userName: "Alice",
+        isDirectMessage: false,
+      },
+      conversationHistory: [],
+    });
+    const { jws, publicKeyPem } = await createDispatchSignature(invalidBody);
+
+    const result = await handler.handle(
+      new Request("https://example.com/channels/invoke", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-dispatch-jws": jws,
+        },
+        body: invalidBody,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 400);
+    assertEquals(await result.response.json(), { error: "Invalid channel invoke request" });
+  });
+});

--- a/src/server/handlers/request/channel-invoke.handler.ts
+++ b/src/server/handlers/request/channel-invoke.handler.ts
@@ -1,0 +1,92 @@
+import { BaseHandler } from "../response/base.ts";
+import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
+import {
+  type ChannelInvokeDeps,
+  ChannelInvokeRequestSchema,
+  defaultChannelInvokeDeps,
+  executeChannelInvoke,
+  verifyDispatchJws,
+} from "../../../channels/invoke.ts";
+import {
+  HTTP_INTERNAL_SERVER_ERROR,
+  PRIORITY_MEDIUM_API,
+} from "#veryfront/utils/constants/index.ts";
+
+const DISPATCH_JWS_HEADER = "x-veryfront-dispatch-jws";
+const MAX_DISPATCH_SIGNATURE_AGE_SECONDS = 60;
+
+export class ChannelInvokeHandler extends BaseHandler {
+  metadata: HandlerMetadata = {
+    name: "ChannelInvokeHandler",
+    priority: PRIORITY_MEDIUM_API as HandlerPriority,
+    patterns: [{ pattern: "/channels/invoke", exact: true, method: "POST" }],
+  };
+
+  constructor(private readonly deps: ChannelInvokeDeps = defaultChannelInvokeDeps) {
+    super();
+  }
+
+  async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
+    if (!this.shouldHandle(req, ctx)) {
+      return this.continue();
+    }
+
+    return this.withProxyContext(ctx, async () => {
+      const builder = this.createResponseBuilder(ctx)
+        .withCORS(req, ctx.securityConfig?.cors)
+        .withSecurity(ctx.securityConfig ?? undefined, req);
+
+      const publicKeyPem = ctx.adapter.env.get("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
+      if (!publicKeyPem) {
+        this.logWarn("Missing CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY for channel invoke endpoint");
+        return this.respond(
+          builder.json(
+            { error: "Channel dispatch verification is not configured" },
+            HTTP_INTERNAL_SERVER_ERROR,
+          ),
+        );
+      }
+
+      const projectSlug = ctx.projectSlug;
+      if (!projectSlug) {
+        this.logWarn("Channel invoke request arrived without resolved project slug");
+        return this.respond(builder.json({ error: "Project context is unavailable" }, 400));
+      }
+
+      const dispatchJws = req.headers.get(DISPATCH_JWS_HEADER);
+      if (!dispatchJws) {
+        return this.respond(builder.json({ error: "Missing dispatch signature" }, 401));
+      }
+
+      const rawBody = await req.text();
+      try {
+        await verifyDispatchJws(dispatchJws, rawBody, {
+          audience: projectSlug,
+          expectedProjectId: ctx.projectId,
+          publicKeyPem,
+          maxAgeSeconds: MAX_DISPATCH_SIGNATURE_AGE_SECONDS,
+        });
+      } catch (error) {
+        this.logWarn("Channel invoke signature verification failed", {
+          error: error instanceof Error ? error.message : String(error),
+          projectSlug,
+          projectId: ctx.projectId,
+        });
+        return this.respond(builder.json({ error: "Invalid dispatch signature" }, 401));
+      }
+
+      try {
+        const payload = ChannelInvokeRequestSchema.parse(JSON.parse(rawBody));
+        const response = await executeChannelInvoke(payload, ctx, this.deps);
+        return this.respond(builder.json(response, 200));
+      } catch (error) {
+        this.logWarn("Channel invoke request validation failed", {
+          error: error instanceof Error ? error.message : String(error),
+          projectSlug,
+          projectId: ctx.projectId,
+        });
+        return this.respond(builder.json({ error: "Invalid channel invoke request" }, 400));
+      }
+    });
+  }
+}

--- a/src/server/handlers/request/channel-invoke.handler.ts
+++ b/src/server/handlers/request/channel-invoke.handler.ts
@@ -75,10 +75,9 @@ export class ChannelInvokeHandler extends BaseHandler {
         return this.respond(builder.json({ error: "Invalid dispatch signature" }, 401));
       }
 
+      let payload;
       try {
-        const payload = ChannelInvokeRequestSchema.parse(JSON.parse(rawBody));
-        const response = await executeChannelInvoke(payload, ctx, this.deps);
-        return this.respond(builder.json(response, 200));
+        payload = ChannelInvokeRequestSchema.parse(JSON.parse(rawBody));
       } catch (error) {
         this.logWarn("Channel invoke request validation failed", {
           error: error instanceof Error ? error.message : String(error),
@@ -87,6 +86,9 @@ export class ChannelInvokeHandler extends BaseHandler {
         });
         return this.respond(builder.json({ error: "Invalid channel invoke request" }, 400));
       }
+
+      const response = await executeChannelInvoke(payload, ctx, this.deps);
+      return this.respond(builder.json(response, 200));
     });
   }
 }

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -51,6 +51,7 @@ import { HMRHandler } from "../handlers/preview/hmr.handler.ts";
 import { MarkdownPreviewHandler } from "../handlers/preview/markdown-preview.handler.ts";
 import { OpenAPIHandler } from "../handlers/request/openapi.handler.ts";
 import { OpenAPIDocsHandler } from "../handlers/request/openapi-docs.handler.ts";
+import { ChannelInvokeHandler } from "../handlers/request/channel-invoke.handler.ts";
 import { DevDashboardHandler } from "../handlers/dev/dashboard/index.ts";
 import { ProjectsHandler } from "../handlers/dev/projects/index.ts";
 
@@ -202,6 +203,7 @@ export function createVeryfrontHandler(
     new DebugContextHandler(),
     new OpenAPIHandler(),
     new OpenAPIDocsHandler(),
+    new ChannelInvokeHandler(),
     new DevDashboardHandler(),
     new ProjectsHandler(),
     new StudioBridgeModulesHandler(),


### PR DESCRIPTION
## Summary
- add a built-in POST /channels/invoke runtime handler with Ed25519 dispatch verification
- normalize API conversation history into runtime messages and return structured channel response parts
- extract shared project AI discovery and plumb max output token overrides through agent generate/stream paths

## Testing
- deno check src/channels/invoke.ts src/channels/invoke.test.ts src/server/handlers/request/channel-invoke.handler.ts src/server/handlers/request/channel-invoke.handler.test.ts src/server/runtime-handler/index.ts src/agent/runtime/index.ts src/agent/factory.ts src/agent/types.ts
- deno test --no-check --allow-all src/channels/invoke.test.ts src/server/handlers/request/channel-invoke.handler.test.ts
- deno test --no-check --allow-all src/agent/chat-handler.test.ts
- deno test --no-check --allow-all src/server/runtime-handler/request-lifecycle.test.ts