### PR TITLE
chore: bump version to 0.1.63

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [


### PR DESCRIPTION
## Summary
- Patch version bump from 0.1.62 → 0.1.63

## Test plan
- [ ] CI passes
- [ ] Version number is correct in deno.json