### PR TITLE
fix: improve SSRF URL validation — fix IPv6 regex, add tests

### DIFF
--- a/src/integrations/endpoint-executor.test.ts
+++ b/src/integrations/endpoint-executor.test.ts
@@ -1,6 +1,171 @@
-import { assertEquals, assertRejects } from "@std/assert";
-import { executeEndpoint } from "./endpoint-executor.ts";
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import { executeEndpoint, validateEndpointUrl } from "./endpoint-executor.ts";
 import type { IntegrationEndpoint } from "./types.ts";
+import { VeryfrontError } from "#veryfront/errors/types.ts";
+
+Deno.test("validateEndpointUrl", async (t) => {
+  // Valid URLs
+  await t.step("accepts valid HTTPS URL", () => {
+    validateEndpointUrl("https://api.example.com/v1/data");
+  });
+
+  await t.step("accepts HTTPS URL with port", () => {
+    validateEndpointUrl("https://api.example.com:8443/v1/data");
+  });
+
+  await t.step("accepts HTTPS URL with query params", () => {
+    validateEndpointUrl("https://api.example.com/v1?key=value");
+  });
+
+  // Invalid schemes
+  await t.step("rejects HTTP URLs", () => {
+    assertThrows(
+      () => validateEndpointUrl("http://api.example.com/v1"),
+      VeryfrontError,
+      "must use HTTPS",
+    );
+  });
+
+  await t.step("rejects FTP URLs", () => {
+    assertThrows(
+      () => validateEndpointUrl("ftp://files.example.com/data"),
+      VeryfrontError,
+      "must use HTTPS",
+    );
+  });
+
+  await t.step("rejects invalid URLs", () => {
+    assertThrows(
+      () => validateEndpointUrl("not-a-url"),
+      VeryfrontError,
+      "Invalid endpoint URL",
+    );
+  });
+
+  // Localhost
+  await t.step("rejects localhost", () => {
+    assertThrows(
+      () => validateEndpointUrl("https://localhost/api"),
+      VeryfrontError,
+      "must not target localhost",
+    );
+  });
+
+  await t.step("rejects localhost with port", () => {
+    assertThrows(
+      () => validateEndpointUrl("https://localhost:3000/api"),
+      VeryfrontError,
+      "must not target localhost",
+    );
+  });
+
+  // Private IPv4 ranges
+  await t.step("rejects 127.0.0.1 (loopback)", () => {
+    assertThrows(
+      () => validateEndpointUrl("https://127.0.0.1/api"),
+      VeryfrontError,
+      "private/internal",
+    );
+  });
+
+  await t.step("rejects 10.x.x.x (class A private)", () => {
+    assertThrows(
+      () => validateEndpointUrl("https://10.0.0.1/api"),
+      VeryfrontError,
+      "private/internal",
+    );
+  });
+
+  await t.step("rejects 172.16.x.x (class B private)", () => {
+    assertThrows(
+      () => validateEndpointUrl("https://172.16.0.1/api"),
+      VeryfrontError,
+      "private/internal",
+    );
+  });
+
+  await t.step("rejects 172.31.x.x (class B upper bound)", () => {
+    assertThrows(
+      () => validateEndpointUrl("https://172.31.255.255/api"),
+      VeryfrontError,
+      "private/internal",
+    );
+  });
+
+  await t.step("allows 172.32.x.x (outside private range)", () => {
+    validateEndpointUrl("https://172.32.0.1/api");
+  });
+
+  await t.step("rejects 192.168.x.x (class C private)", () => {
+    assertThrows(
+      () => validateEndpointUrl("https://192.168.1.1/api"),
+      VeryfrontError,
+      "private/internal",
+    );
+  });
+
+  await t.step("rejects 169.254.x.x (link-local)", () => {
+    assertThrows(
+      () => validateEndpointUrl("https://169.254.169.254/api"),
+      VeryfrontError,
+      "private/internal",
+    );
+  });
+
+  await t.step("rejects 0.x.x.x", () => {
+    assertThrows(
+      () => validateEndpointUrl("https://0.0.0.0/api"),
+      VeryfrontError,
+      "private/internal",
+    );
+  });
+
+  // IPv6
+  await t.step("rejects ::1 (IPv6 loopback)", () => {
+    assertThrows(
+      () => validateEndpointUrl("https://[::1]/api"),
+      VeryfrontError,
+      "private/internal",
+    );
+  });
+
+  await t.step("rejects fc00:: (IPv6 unique local)", () => {
+    assertThrows(
+      () => validateEndpointUrl("https://[fc00::1]/api"),
+      VeryfrontError,
+      "private/internal",
+    );
+  });
+
+  await t.step("rejects fd12:: (IPv6 unique local)", () => {
+    assertThrows(
+      () => validateEndpointUrl("https://[fd12::1]/api"),
+      VeryfrontError,
+      "private/internal",
+    );
+  });
+
+  await t.step("rejects fe80:: (IPv6 link-local)", () => {
+    assertThrows(
+      () => validateEndpointUrl("https://[fe80::1]/api"),
+      VeryfrontError,
+      "private/internal",
+    );
+  });
+
+  // False positive avoidance
+  await t.step("allows fdic.gov (legitimate domain starting with fd)", () => {
+    validateEndpointUrl("https://fdic.gov/api");
+  });
+
+  await t.step("allows fdroid.org (legitimate domain starting with fd)", () => {
+    validateEndpointUrl("https://fdroid.org/api");
+  });
+
+  await t.step("allows fc-example.com (legitimate domain starting with fc)", () => {
+    validateEndpointUrl("https://fc-example.com/api");
+  });
+});
 
 Deno.test("endpoint-executor", async (t) => {
   await t.step("REST: builds URL with path params", async () => {

--- a/src/integrations/endpoint-executor.ts
+++ b/src/integrations/endpoint-executor.ts
@@ -18,12 +18,11 @@ const PRIVATE_IP_RANGES = [
   /^169\.254\./, // 169.254.0.0/16
   /^0\./, // 0.0.0.0/8
   /^::1$/, // IPv6 loopback
-  /^fc00:/i, // IPv6 unique local (fc00::/7)
-  /^fd/i, // IPv6 unique local (fd00::/8)
+  /^f[cd][0-9a-f]{2}:/i, // IPv6 unique local (fc00::/7)
   /^fe80:/i, // IPv6 link-local (fe80::/10)
 ];
 
-function validateEndpointUrl(url: string): void {
+export function validateEndpointUrl(url: string): void {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -38,14 +37,19 @@ function validateEndpointUrl(url: string): void {
   }
 
   const hostname = parsed.hostname.toLowerCase();
-  if (hostname === "localhost" || hostname === "[::1]") {
+  if (hostname === "localhost") {
     throw INVALID_ARGUMENT.create({
       detail: "Endpoint URL must not target localhost",
     });
   }
 
+  // Strip IPv6 brackets for regex matching
+  const bare = hostname.startsWith("[") && hostname.endsWith("]")
+    ? hostname.slice(1, -1)
+    : hostname;
+
   for (const range of PRIVATE_IP_RANGES) {
-    if (range.test(hostname)) {
+    if (range.test(bare)) {
       throw INVALID_ARGUMENT.create({
         detail: "Endpoint URL must not target private/internal networks",
       });


### PR DESCRIPTION
## Summary
- Fix `fd`/`fc` regex false positives that incorrectly blocked legitimate domains (e.g., `fdic.gov`, `fdroid.org`)
- Merge separate `fc00:` and `fd` patterns into single `fc00::/7` regex (`/^f[cd][0-9a-f]{2}:/i`)
- Strip IPv6 brackets before regex matching (Deno's `URL.hostname` preserves them)
- Remove dead `[::1]` hostname check (handled by regex)
- Export `validateEndpointUrl` for direct testing
- Add 23 unit tests covering: valid HTTPS, invalid schemes, localhost, all private IPv4 ranges, IPv6 ranges, and false-positive avoidance

## Test plan
- [x] Valid HTTPS URLs pass validation
- [x] HTTP/FTP/invalid URLs rejected
- [x] localhost (with and without port) rejected
- [x] All private IPv4 ranges rejected (127.x, 10.x, 172.16-31.x, 192.168.x, 169.254.x, 0.x)
- [x] IPv6 loopback, unique local, and link-local rejected
- [x] Legitimate domains starting with `fd`/`fc` not blocked (fdic.gov, fdroid.org)