### PR TITLE
feat: add channel assistant runtime discovery

### DIFF
--- a/src/channels/invoke.test.ts
+++ b/src/channels/invoke.test.ts
@@ -6,9 +6,12 @@ import type { HandlerContext } from "#veryfront/types";
 import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
 import {
   buildChannelResponseParts,
+  ChannelAssistantsRequestSchema,
+  ChannelAssistantsResponseSchema,
   type ChannelInvokeDeps,
   type ChannelInvokeRequest,
   executeChannelInvoke,
+  listChannelAssistants,
   normalizeConversationHistoryForRuntime,
   resolveChannelInvokeAgent,
   verifyDispatchJws,
@@ -76,7 +79,7 @@ function createPayload(
     dispatchId: "dispatch-1",
     conversationId: "conversation-1",
     projectId: "proj-1",
-    agentConfigId: "agent-1",
+    assistantId: "agent-1",
     platform: "slack",
     inboundMessage: {
       text: "Hello from Slack",
@@ -284,6 +287,71 @@ describe("channels/invoke", () => {
     });
   });
 
+  describe("listChannelAssistants", () => {
+    it("returns discovered runtime assistants sorted by name", async () => {
+      let discoveryCalls = 0;
+      const response = await listChannelAssistants(createHandlerContext(), {
+        ensureProjectDiscovery: async () => {
+          discoveryCalls += 1;
+        },
+        getAgent: (id) => {
+          if (id === "assistant-b") {
+            return {
+              ...createAgent({ id }),
+              config: {
+                system: "You are Beta.",
+                model: "anthropic/claude-sonnet-4-6",
+                name: "Beta",
+              } as unknown as Agent["config"],
+            };
+          }
+          if (id === "assistant-a") {
+            return {
+              ...createAgent({ id }),
+              config: {
+                system: "You are Alpha.",
+                model: "openai/gpt-5",
+                name: "Alpha",
+                description: "Primary assistant",
+              } as unknown as Agent["config"],
+            };
+          }
+          return undefined;
+        },
+        getAllAgentIds: () => ["assistant-b", "assistant-a"],
+      });
+
+      assertEquals(discoveryCalls, 1);
+      assertEquals(response, ChannelAssistantsResponseSchema.parse({
+        assistants: [
+          {
+            id: "assistant-a",
+            name: "Alpha",
+            description: "Primary assistant",
+            model: "openai/gpt-5",
+          },
+          {
+            id: "assistant-b",
+            name: "Beta",
+            description: null,
+            model: "anthropic/claude-sonnet-4-6",
+          },
+        ],
+      }));
+    });
+
+    it("validates assistants request payload shape", () => {
+      const parsed = ChannelAssistantsRequestSchema.parse({
+        requestId: "request-1",
+        projectId: "proj-1",
+        platform: "slack",
+      });
+
+      assertEquals(parsed.platform, "slack");
+      assertEquals(parsed.requestId, "request-1");
+    });
+  });
+
   describe("resolveChannelInvokeAgent", () => {
     it("returns an exact registry match when available", () => {
       const agent = createAgent({ id: "agent-1" });
@@ -295,20 +363,10 @@ describe("channels/invoke", () => {
       assertEquals(resolved, agent);
     });
 
-    it("falls back only when exactly one runtime agent exists", () => {
-      const agent = createAgent({ id: "agent-runtime" });
-      const resolved = resolveChannelInvokeAgent("api-agent-config", {
-        getAgent: (id) => id === "agent-runtime" ? agent : undefined,
-        getAllAgentIds: () => ["agent-runtime"],
-      });
-
-      assertEquals(resolved, agent);
-    });
-
-    it("fails closed when multiple runtime agents make the mapping ambiguous", () => {
+    it("fails closed when the requested assistant is not registered", () => {
       const resolved = resolveChannelInvokeAgent("api-agent-config", {
         getAgent: () => undefined,
-        getAllAgentIds: () => ["agent-a", "agent-b"],
+        getAllAgentIds: () => ["agent-runtime"],
       });
 
       assertEquals(resolved, undefined);
@@ -411,6 +469,23 @@ describe("channels/invoke", () => {
       assertEquals(response, {
         ignored: false,
         error: { code: "provider_error", retryable: false },
+      });
+    });
+
+    it("fails closed when the requested assistant is not registered on the runtime", async () => {
+      const response = await executeChannelInvoke(
+        createPayload({ assistantId: "assistant-missing" }),
+        createHandlerContext(),
+        {
+          ensureProjectDiscovery: async () => {},
+          getAgent: () => undefined,
+          getAllAgentIds: () => ["agent-1"],
+        },
+      );
+
+      assertEquals(response, {
+        ignored: false,
+        error: { code: "internal_error", retryable: false },
       });
     });
   });

--- a/src/channels/invoke.test.ts
+++ b/src/channels/invoke.test.ts
@@ -322,22 +322,25 @@ describe("channels/invoke", () => {
       });
 
       assertEquals(discoveryCalls, 1);
-      assertEquals(response, ChannelAssistantsResponseSchema.parse({
-        assistants: [
-          {
-            id: "assistant-a",
-            name: "Alpha",
-            description: "Primary assistant",
-            model: "openai/gpt-5",
-          },
-          {
-            id: "assistant-b",
-            name: "Beta",
-            description: null,
-            model: "anthropic/claude-sonnet-4-6",
-          },
-        ],
-      }));
+      assertEquals(
+        response,
+        ChannelAssistantsResponseSchema.parse({
+          assistants: [
+            {
+              id: "assistant-a",
+              name: "Alpha",
+              description: "Primary assistant",
+              model: "openai/gpt-5",
+            },
+            {
+              id: "assistant-b",
+              name: "Beta",
+              description: null,
+              model: "anthropic/claude-sonnet-4-6",
+            },
+          ],
+        }),
+      );
     });
 
     it("validates assistants request payload shape", () => {

--- a/src/channels/invoke.ts
+++ b/src/channels/invoke.ts
@@ -33,11 +33,11 @@ const channelInvokeHistoryMessageSchema = z.object({
   createdAt: z.string().optional(),
 });
 
-export const ChannelInvokeRequestSchema = z.object({
+const channelInvokeRequestWireSchema = z.object({
   dispatchId: z.string().min(1),
   conversationId: z.string().min(1),
   projectId: z.string().min(1),
-  agentConfigId: z.string().min(1),
+  assistantId: z.string().min(1),
   platform: z.literal("slack"),
   inboundMessage: z.object({
     text: z.string(),
@@ -50,6 +50,25 @@ export const ChannelInvokeRequestSchema = z.object({
   generation: z.object({
     maxResponseTokens: z.number().int().positive().max(16384).optional(),
   }).optional(),
+});
+
+export const ChannelInvokeRequestSchema = channelInvokeRequestWireSchema;
+
+export const ChannelAssistantsRequestSchema = z.object({
+  requestId: z.string().min(1),
+  projectId: z.string().min(1),
+  platform: z.literal("slack"),
+});
+
+export const ChannelAssistantSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().nullable().optional(),
+  model: z.string().nullable().optional(),
+});
+
+export const ChannelAssistantsResponseSchema = z.object({
+  assistants: z.array(ChannelAssistantSchema),
 });
 
 const channelTextPartSchema = z.object({
@@ -124,9 +143,12 @@ const dispatchClaimsSchema = z.object({
 
 export type ChannelInvokeRequest = z.infer<typeof ChannelInvokeRequestSchema>;
 export type ChannelInvokeResponse = z.infer<typeof ChannelInvokeResponseSchema>;
+export type ChannelAssistantsRequest = z.infer<typeof ChannelAssistantsRequestSchema>;
+export type ChannelAssistantsResponse = z.infer<typeof ChannelAssistantsResponseSchema>;
 
 type ChannelResponsePart = z.infer<typeof ChannelResponsePartSchema>;
 type DispatchClaims = z.infer<typeof dispatchClaimsSchema>;
+type ChannelAssistant = z.infer<typeof ChannelAssistantSchema>;
 
 export interface ChannelInvokeDeps {
   ensureProjectDiscovery: (ctx: HandlerContext) => Promise<void>;
@@ -139,6 +161,34 @@ export const defaultChannelInvokeDeps: ChannelInvokeDeps = {
   getAgent: getRegisteredAgent,
   getAllAgentIds: getRegisteredAgentIds,
 };
+
+function getAssistantMetadata(agent: Agent): ChannelAssistant {
+  const rawConfig = agent.config as unknown as Record<string, unknown>;
+
+  return ChannelAssistantSchema.parse({
+    id: agent.id,
+    name: typeof rawConfig.name === "string" && rawConfig.name.trim().length > 0
+      ? rawConfig.name
+      : agent.id,
+    description: typeof rawConfig.description === "string" ? rawConfig.description : null,
+    model: agent.config.model ?? null,
+  });
+}
+
+export async function listChannelAssistants(
+  ctx: HandlerContext,
+  deps: ChannelInvokeDeps,
+): Promise<ChannelAssistantsResponse> {
+  await deps.ensureProjectDiscovery(ctx);
+
+  const assistants = deps.getAllAgentIds()
+    .map((id) => deps.getAgent(id))
+    .filter((agent): agent is Agent => Boolean(agent))
+    .map(getAssistantMetadata)
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  return ChannelAssistantsResponseSchema.parse({ assistants });
+}
 
 function base64urlDecodeToBytes(input: string): ArrayBuffer {
   const normalized = input
@@ -299,35 +349,10 @@ export function normalizeConversationHistoryForRuntime(
 }
 
 export function resolveChannelInvokeAgent(
-  agentConfigId: string,
+  assistantId: string,
   deps: Pick<ChannelInvokeDeps, "getAgent" | "getAllAgentIds">,
 ): Agent | undefined {
-  const exactAgent = deps.getAgent(agentConfigId);
-  if (exactAgent) {
-    return exactAgent;
-  }
-
-  const agentIds = deps.getAllAgentIds();
-  if (agentIds.length !== 1) {
-    return undefined;
-  }
-
-  const onlyAgentId = agentIds[0];
-  if (!onlyAgentId) {
-    return undefined;
-  }
-  const onlyAgent = deps.getAgent(onlyAgentId);
-  if (onlyAgent) {
-    logger.warn(
-      "Channel invoke fell back to the only discovered runtime agent because agentConfigId did not match a registry id",
-      {
-        requestedAgentConfigId: agentConfigId,
-        resolvedAgentId: onlyAgentId,
-      },
-    );
-  }
-
-  return onlyAgent;
+  return deps.getAgent(assistantId);
 }
 
 function normalizeToolCallState(status: string): "pending" | "completed" | "error" {
@@ -454,10 +479,10 @@ export async function executeChannelInvoke(
 ): Promise<ChannelInvokeResponse> {
   await deps.ensureProjectDiscovery(ctx);
 
-  const agent = resolveChannelInvokeAgent(payload.agentConfigId, deps);
+  const agent = resolveChannelInvokeAgent(payload.assistantId, deps);
   if (!agent) {
     logger.error("Channel invoke could not resolve a runtime agent for the request", {
-      requestedAgentConfigId: payload.agentConfigId,
+      requestedAssistantId: payload.assistantId,
       discoveredAgentIds: deps.getAllAgentIds(),
       projectSlug: ctx.projectSlug,
       projectId: ctx.projectId,
@@ -482,7 +507,7 @@ export async function executeChannelInvoke(
         dispatchId: payload.dispatchId,
         conversationId: payload.conversationId,
         projectId: payload.projectId,
-        agentConfigId: payload.agentConfigId,
+        assistantId: payload.assistantId,
         channel: payload.inboundMessage,
       },
       ...(payload.generation?.maxResponseTokens

--- a/src/server/handlers/request/channel-assistants.handler.test.ts
+++ b/src/server/handlers/request/channel-assistants.handler.test.ts
@@ -93,7 +93,11 @@ describe("server/handlers/request/channel-assistants.handler", () => {
             stream: async () => ({ toDataStreamResponse: () => new Response() } as never),
             respond: async () => new Response(),
             getMemory: () => ({} as never),
-            getMemoryStats: async () => ({ totalMessages: 0, estimatedTokens: 0, type: "conversation" }),
+            getMemoryStats: async () => ({
+              totalMessages: 0,
+              estimatedTokens: 0,
+              type: "conversation",
+            }),
             clearMemory: async () => {},
           };
         }

--- a/src/server/handlers/request/channel-assistants.handler.test.ts
+++ b/src/server/handlers/request/channel-assistants.handler.test.ts
@@ -1,0 +1,164 @@
+import type { Agent } from "#veryfront/agent";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+import { ChannelAssistantsHandler } from "./channel-assistants.handler.ts";
+
+const encoder = new TextEncoder();
+
+function encodePem(label: string, der: ArrayBuffer): string {
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = base64.match(/.{1,64}/g) ?? [base64];
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
+}
+
+async function sha256Base64url(body: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(body));
+  return base64urlEncodeBytes(new Uint8Array(digest));
+}
+
+async function createDispatchSignature(
+  body: string,
+  overrides: Partial<{
+    audience: string;
+    projectId: string;
+  }> = {},
+): Promise<{ jws: string; publicKeyPem: string }> {
+  const keyPair = await crypto.subtle.generateKey(
+    "Ed25519",
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+  const publicKeyDer = await crypto.subtle.exportKey("spki", keyPair.publicKey);
+  const publicKeyPem = encodePem("PUBLIC KEY", publicKeyDer);
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = base64urlEncode(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
+  const payload = base64urlEncode(JSON.stringify({
+    iss: "veryfront-api",
+    aud: overrides.audience ?? "demo-project",
+    sub: "assistants-1",
+    project_id: overrides.projectId ?? "proj-1",
+    platform: "slack",
+    body_sha256: await sha256Base64url(body),
+    iat: now,
+    exp: now + 60,
+  }));
+
+  const signingInput = encoder.encode(`${header}.${payload}`);
+  const signature = await crypto.subtle.sign("Ed25519", keyPair.privateKey, signingInput);
+
+  return {
+    publicKeyPem,
+    jws: `${header}.${payload}.${base64urlEncodeBytes(new Uint8Array(signature))}`,
+  };
+}
+
+function createCtx(publicKeyPem?: string): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter: {
+      env: {
+        get: (key: string) =>
+          key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? publicKeyPem : undefined,
+      },
+      fs: {},
+    },
+    securityConfig: null,
+    cspUserHeader: null,
+    projectSlug: "demo-project",
+    projectId: "proj-1",
+    isLocalProject: false,
+  } as unknown as HandlerContext;
+}
+
+describe("server/handlers/request/channel-assistants.handler", () => {
+  it("returns discovered assistants for a valid signed request", async () => {
+    let discoveryCalls = 0;
+    const handler = new ChannelAssistantsHandler({
+      ensureProjectDiscovery: async () => {
+        discoveryCalls += 1;
+      },
+      getAgent: (id) => {
+        if (id === "assistant-1") {
+          return {
+            id,
+            config: {
+              system: "You are Support.",
+              model: "anthropic/claude-sonnet-4-6",
+              name: "Support",
+            } as unknown as Agent["config"],
+            generate: async () => ({}) as never,
+            stream: async () => ({ toDataStreamResponse: () => new Response() } as never),
+            respond: async () => new Response(),
+            getMemory: () => ({} as never),
+            getMemoryStats: async () => ({ totalMessages: 0, estimatedTokens: 0, type: "conversation" }),
+            clearMemory: async () => {},
+          };
+        }
+
+        return undefined;
+      },
+      getAllAgentIds: () => ["assistant-1"],
+    });
+
+    const body = JSON.stringify({
+      requestId: "assistants-1",
+      projectId: "proj-1",
+      platform: "slack",
+    });
+    const { jws, publicKeyPem } = await createDispatchSignature(body);
+
+    const result = await handler.handle(
+      new Request("https://example.com/channels/assistants", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-dispatch-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(discoveryCalls, 1);
+    assertEquals(await result.response.json(), {
+      assistants: [
+        {
+          id: "assistant-1",
+          name: "Support",
+          description: null,
+          model: "anthropic/claude-sonnet-4-6",
+        },
+      ],
+    });
+  });
+
+  it("returns 401 when the dispatch signature is missing", async () => {
+    const handler = new ChannelAssistantsHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: () => undefined,
+      getAllAgentIds: () => [],
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/channels/assistants", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          requestId: "assistants-1",
+          projectId: "proj-1",
+          platform: "slack",
+        }),
+      }),
+      createCtx("-----BEGIN PUBLIC KEY-----\nZmFrZQ==\n-----END PUBLIC KEY-----"),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 401);
+    assertEquals(await result.response.json(), { error: "Missing dispatch signature" });
+  });
+});

--- a/src/server/handlers/request/channel-assistants.handler.ts
+++ b/src/server/handlers/request/channel-assistants.handler.ts
@@ -1,0 +1,93 @@
+import { BaseHandler } from "../response/base.ts";
+import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
+import {
+  ChannelAssistantsRequestSchema,
+  defaultChannelInvokeDeps,
+  listChannelAssistants,
+  type ChannelInvokeDeps,
+  verifyDispatchJws,
+} from "../../../channels/invoke.ts";
+import {
+  HTTP_INTERNAL_SERVER_ERROR,
+  PRIORITY_MEDIUM_API,
+} from "#veryfront/utils/constants/index.ts";
+
+const DISPATCH_JWS_HEADER = "x-veryfront-dispatch-jws";
+const MAX_DISPATCH_SIGNATURE_AGE_SECONDS = 60;
+
+export class ChannelAssistantsHandler extends BaseHandler {
+  metadata: HandlerMetadata = {
+    name: "ChannelAssistantsHandler",
+    priority: PRIORITY_MEDIUM_API as HandlerPriority,
+    patterns: [{ pattern: "/channels/assistants", exact: true, method: "POST" }],
+  };
+
+  constructor(private readonly deps: ChannelInvokeDeps = defaultChannelInvokeDeps) {
+    super();
+  }
+
+  async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
+    if (!this.shouldHandle(req, ctx)) {
+      return this.continue();
+    }
+
+    return this.withProxyContext(ctx, async () => {
+      const builder = this.createResponseBuilder(ctx)
+        .withCORS(req, ctx.securityConfig?.cors)
+        .withSecurity(ctx.securityConfig ?? undefined, req);
+
+      const publicKeyPem = ctx.adapter.env.get("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
+      if (!publicKeyPem) {
+        this.logWarn("Missing CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY for channel assistants endpoint");
+        return this.respond(
+          builder.json(
+            { error: "Channel dispatch verification is not configured" },
+            HTTP_INTERNAL_SERVER_ERROR,
+          ),
+        );
+      }
+
+      const projectSlug = ctx.projectSlug;
+      if (!projectSlug) {
+        this.logWarn("Channel assistants request arrived without resolved project slug");
+        return this.respond(builder.json({ error: "Project context is unavailable" }, 400));
+      }
+
+      const dispatchJws = req.headers.get(DISPATCH_JWS_HEADER);
+      if (!dispatchJws) {
+        return this.respond(builder.json({ error: "Missing dispatch signature" }, 401));
+      }
+
+      const rawBody = await req.text();
+      try {
+        await verifyDispatchJws(dispatchJws, rawBody, {
+          audience: projectSlug,
+          expectedProjectId: ctx.projectId,
+          publicKeyPem,
+          maxAgeSeconds: MAX_DISPATCH_SIGNATURE_AGE_SECONDS,
+        });
+      } catch (error) {
+        this.logWarn("Channel assistants signature verification failed", {
+          error: error instanceof Error ? error.message : String(error),
+          projectSlug,
+          projectId: ctx.projectId,
+        });
+        return this.respond(builder.json({ error: "Invalid dispatch signature" }, 401));
+      }
+
+      try {
+        ChannelAssistantsRequestSchema.parse(JSON.parse(rawBody));
+      } catch (error) {
+        this.logWarn("Channel assistants request validation failed", {
+          error: error instanceof Error ? error.message : String(error),
+          projectSlug,
+          projectId: ctx.projectId,
+        });
+        return this.respond(builder.json({ error: "Invalid channel assistants request" }, 400));
+      }
+
+      const response = await listChannelAssistants(ctx, this.deps);
+      return this.respond(builder.json(response, 200));
+    });
+  }
+}

--- a/src/server/handlers/request/channel-assistants.handler.ts
+++ b/src/server/handlers/request/channel-assistants.handler.ts
@@ -2,9 +2,9 @@ import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import {
   ChannelAssistantsRequestSchema,
+  type ChannelInvokeDeps,
   defaultChannelInvokeDeps,
   listChannelAssistants,
-  type ChannelInvokeDeps,
   verifyDispatchJws,
 } from "../../../channels/invoke.ts";
 import {

--- a/src/server/handlers/request/channel-invoke.handler.test.ts
+++ b/src/server/handlers/request/channel-invoke.handler.test.ts
@@ -61,7 +61,7 @@ function createPayload(): ChannelInvokeRequest {
     dispatchId: "dispatch-1",
     conversationId: "conversation-1",
     projectId: "proj-1",
-    agentConfigId: "agent-1",
+    assistantId: "agent-1",
     platform: "slack",
     inboundMessage: {
       text: "Hello from Slack",
@@ -200,7 +200,7 @@ describe("server/handlers/request/channel-invoke.handler", () => {
     const invalidBody = JSON.stringify({
       dispatchId: "dispatch-1",
       projectId: "proj-1",
-      agentConfigId: "agent-1",
+      assistantId: "agent-1",
       platform: "slack",
       inboundMessage: {
         text: "Hello from Slack",

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -51,6 +51,7 @@ import { HMRHandler } from "../handlers/preview/hmr.handler.ts";
 import { MarkdownPreviewHandler } from "../handlers/preview/markdown-preview.handler.ts";
 import { OpenAPIHandler } from "../handlers/request/openapi.handler.ts";
 import { OpenAPIDocsHandler } from "../handlers/request/openapi-docs.handler.ts";
+import { ChannelAssistantsHandler } from "../handlers/request/channel-assistants.handler.ts";
 import { ChannelInvokeHandler } from "../handlers/request/channel-invoke.handler.ts";
 import { DevDashboardHandler } from "../handlers/dev/dashboard/index.ts";
 import { ProjectsHandler } from "../handlers/dev/projects/index.ts";
@@ -203,6 +204,7 @@ export function createVeryfrontHandler(
     new DebugContextHandler(),
     new OpenAPIHandler(),
     new OpenAPIDocsHandler(),
+    new ChannelAssistantsHandler(),
     new ChannelInvokeHandler(),
     new DevDashboardHandler(),
     new ProjectsHandler(),


### PR DESCRIPTION
## Summary
- add signed `/channels/assistants` runtime discovery
- switch channel invoke payloads from `agentConfigId` to `assistantId`
- resolve channel invokes strictly by runtime assistant id

## Verification
- deno check src/channels/invoke.ts src/server/handlers/request/channel-assistants.handler.ts src/server/handlers/request/channel-invoke.handler.ts src/server/runtime-handler/index.ts
- deno test --allow-env src/channels/invoke.test.ts src/server/handlers/request/channel-invoke.handler.test.ts src/server/handlers/request/channel-assistants.handler.test.ts