### PR TITLE
chore: bump version to 0.1.64

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [


### PR DESCRIPTION
## Summary
- Bump framework version to 0.1.64
- Includes channel invoke and assistants runtime handlers from #624 and #628