### PR TITLE
feat(runtime): add internal project-agent discovery and run endpoints

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -243,6 +243,7 @@ export class AgentRuntime {
     callbacks?: {
       onToolCall?: (toolCall: ToolCall) => void;
       onChunk?: (chunk: string) => void;
+      onFinish?: (response: AgentResponse) => void;
     },
     modelOverride?: string,
     maxOutputTokensOverride?: number,
@@ -298,7 +299,7 @@ export class AgentRuntime {
           });
           sendSSE(controller, encoder, { type: "text-start", id: textPartId });
 
-          await this.executeAgentLoopStreaming(
+          const response = await this.executeAgentLoopStreaming(
             systemPrompt,
             memoryMessages,
             controller,
@@ -310,6 +311,7 @@ export class AgentRuntime {
             languageModel,
             maxOutputTokensOverride,
           );
+          callbacks?.onFinish?.(response);
 
           sendSSE(controller, encoder, { type: "text-end", id: textPartId });
           sendSSE(controller, encoder, { type: "message-finish" });
@@ -479,7 +481,10 @@ export class AgentRuntime {
               toolCall.status = "executing";
               const startTime = Date.now();
 
-              const result = await executeTool(tc.toolName, toolCall.args, { agentId: this.id });
+              const result = await executeTool(tc.toolName, toolCall.args, {
+                agentId: this.id,
+                toolCallId: tc.toolCallId,
+              });
 
               toolCall.status = "completed";
               toolCall.result = result;
@@ -561,6 +566,7 @@ export class AgentRuntime {
     callbacks?: {
       onToolCall?: (toolCall: ToolCall) => void;
       onChunk?: (chunk: string) => void;
+      onFinish?: (response: AgentResponse) => void;
     },
     textPartId?: string,
     toolContext?: Record<string, unknown>,
@@ -590,6 +596,7 @@ export class AgentRuntime {
 
     // Request-scoped skill policy (not class-level mutable state)
     let activeSkillPolicy: string[] | undefined;
+    let finalFinishReason: string | undefined;
 
     for (let step = 0; step < maxSteps; step++) {
       sendSSE(controller, encoder, { type: "step-start" });
@@ -617,6 +624,7 @@ export class AgentRuntime {
         onChunk: callbacks?.onChunk,
         onUsage: (usage) => accumulateUsage(totalUsage, usage),
       });
+      finalFinishReason = state.finishReason ?? finalFinishReason;
 
       const streamParts: MessagePart[] = [];
       if (state.accumulatedText) streamParts.push({ type: "text", text: state.accumulatedText });
@@ -707,6 +715,7 @@ export class AgentRuntime {
 
           const result = await executeTool(tc.name, toolCall.args, {
             agentId: this.id,
+            toolCallId: tc.id,
             ...toolContext,
           });
 
@@ -768,6 +777,7 @@ export class AgentRuntime {
       toolCalls,
       status: "completed",
       usage: totalUsage,
+      metadata: finalFinishReason ? { finishReason: finalFinishReason } : undefined,
     };
   }
 

--- a/src/channels/control-plane.test.ts
+++ b/src/channels/control-plane.test.ts
@@ -1,0 +1,214 @@
+import type { Agent } from "#veryfront/agent";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+import {
+  listRuntimeAgents,
+  RuntimeAgentListResponseSchema,
+  verifyControlPlaneJws,
+} from "./control-plane.ts";
+
+const encoder = new TextEncoder();
+
+function encodePem(label: string, der: ArrayBuffer): string {
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = base64.match(/.{1,64}/g) ?? [base64];
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
+}
+
+async function sha256Base64url(body: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(body));
+  return base64urlEncodeBytes(new Uint8Array(digest));
+}
+
+async function createControlPlaneSignature(
+  body: string,
+  overrides: Partial<{
+    audience: string;
+    projectId: string;
+    requestId: string;
+    surface: "studio" | "channels" | "a2a" | "mcp";
+    requestHash: string;
+    iat: number;
+    exp: number;
+  }> = {},
+): Promise<{ jws: string; publicKeyPem: string }> {
+  const keyPair = await crypto.subtle.generateKey(
+    "Ed25519",
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+  const publicKeyDer = await crypto.subtle.exportKey("spki", keyPair.publicKey);
+  const publicKeyPem = encodePem("PUBLIC KEY", publicKeyDer);
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = base64urlEncode(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
+  const payload = base64urlEncode(JSON.stringify({
+    iss: "veryfront-api",
+    aud: overrides.audience ?? "demo-project",
+    sub: overrides.requestId ?? "agents-1",
+    surface: overrides.surface ?? "studio",
+    project_id: overrides.projectId ?? "proj-1",
+    request_hash: overrides.requestHash ?? await sha256Base64url(body),
+    iat: overrides.iat ?? now,
+    exp: overrides.exp ?? now + 60,
+  }));
+
+  const signingInput = encoder.encode(`${header}.${payload}`);
+  const signature = await crypto.subtle.sign("Ed25519", keyPair.privateKey, signingInput);
+
+  return {
+    publicKeyPem,
+    jws: `${header}.${payload}.${base64urlEncodeBytes(new Uint8Array(signature))}`,
+  };
+}
+
+function createHandlerContext(): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter: {
+      env: { get: () => undefined },
+      fs: {},
+    },
+    securityConfig: null,
+    cspUserHeader: null,
+    projectSlug: "demo-project",
+    projectId: "proj-1",
+    isLocalProject: false,
+  } as unknown as HandlerContext;
+}
+
+function createAgent(overrides: {
+  id?: string;
+  name?: string;
+  description?: string;
+  model?: string;
+  version?: string;
+} = {}): Agent {
+  return {
+    id: overrides.id ?? "agent-1",
+    config: {
+      system: "You are helpful.",
+      model: overrides.model ?? "anthropic/claude-sonnet-4-6",
+      name: overrides.name ?? "Support",
+      description: overrides.description ?? "Helps with support questions",
+      version: overrides.version ?? "2.0.0",
+    } as unknown as Agent["config"],
+    generate: async () => ({}) as never,
+    stream: async () => ({ toDataStreamResponse: () => new Response() } as never),
+    respond: async () => new Response(),
+    getMemory: () => ({} as never),
+    getMemoryStats: async () => ({
+      totalMessages: 0,
+      estimatedTokens: 0,
+      type: "conversation",
+    }),
+    clearMemory: async () => {},
+  };
+}
+
+describe("channels/control-plane", () => {
+  describe("verifyControlPlaneJws", () => {
+    it("accepts a valid control-plane signature", async () => {
+      const body = JSON.stringify({
+        requestId: "agents-1",
+        projectId: "proj-1",
+        surface: "studio",
+      });
+      const { jws, publicKeyPem } = await createControlPlaneSignature(body);
+
+      const claims = await verifyControlPlaneJws(jws, body, {
+        audience: "demo-project",
+        expectedProjectId: "proj-1",
+        expectedSubject: "agents-1",
+        expectedSurface: "studio",
+        publicKeyPem,
+        maxAgeSeconds: 60,
+      });
+
+      assertEquals(claims.surface, "studio");
+      assertEquals(claims.project_id, "proj-1");
+      assertEquals(claims.request_hash, await sha256Base64url(body));
+    });
+
+    it("rejects a control-plane signature when the body hash does not match", async () => {
+      const body = JSON.stringify({
+        requestId: "agents-1",
+        projectId: "proj-1",
+        surface: "studio",
+      });
+      const { jws, publicKeyPem } = await createControlPlaneSignature(body);
+
+      await assertRejects(() =>
+        verifyControlPlaneJws(jws, `${body} `, {
+          audience: "demo-project",
+          expectedProjectId: "proj-1",
+          publicKeyPem,
+          maxAgeSeconds: 60,
+        })
+      );
+    });
+  });
+
+  describe("listRuntimeAgents", () => {
+    it("returns canonical runtime agents sorted by name", async () => {
+      let discoveryCalls = 0;
+
+      const response = await listRuntimeAgents(createHandlerContext(), {
+        ensureProjectDiscovery: async () => {
+          discoveryCalls += 1;
+        },
+        getAgent: (id) => {
+          if (id === "assistant-b") {
+            return createAgent({
+              id,
+              name: "Beta",
+              description: "Second assistant",
+              model: "openai/gpt-5",
+              version: "1.1.0",
+            });
+          }
+
+          if (id === "assistant-a") {
+            return createAgent({
+              id,
+              name: "Alpha",
+              description: "Primary assistant",
+              model: "anthropic/claude-sonnet-4-6",
+              version: "2.0.0",
+            });
+          }
+
+          return undefined;
+        },
+        getAllAgentIds: () => ["assistant-b", "assistant-a"],
+      });
+
+      assertEquals(discoveryCalls, 1);
+      assertEquals(
+        response,
+        RuntimeAgentListResponseSchema.parse({
+          agents: [
+            {
+              id: "assistant-a",
+              name: "Alpha",
+              description: "Primary assistant",
+              model: "anthropic/claude-sonnet-4-6",
+              version: "2.0.0",
+              skills: [],
+            },
+            {
+              id: "assistant-b",
+              name: "Beta",
+              description: "Second assistant",
+              model: "openai/gpt-5",
+              version: "1.1.0",
+              skills: [],
+            },
+          ],
+        }),
+      );
+    });
+  });
+});

--- a/src/channels/control-plane.ts
+++ b/src/channels/control-plane.ts
@@ -174,6 +174,10 @@ async function verifySignedRequestJws<TClaims extends SignedRequestClaims>(
     throw new Error("Control-plane signature verification failed");
   }
 
+  if (claims.iss !== "veryfront-api") {
+    throw new Error("Control-plane issuer mismatch");
+  }
+
   if (claims.aud !== options.audience) {
     throw new Error("Control-plane audience mismatch");
   }

--- a/src/channels/control-plane.ts
+++ b/src/channels/control-plane.ts
@@ -1,0 +1,327 @@
+import type { Agent } from "#veryfront/agent";
+import type { HandlerContext } from "#veryfront/types";
+import { skillRegistry } from "#veryfront/skill/registry.ts";
+import { base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+import { z } from "zod";
+
+const SIGNATURE_SKEW_SECONDS = 5;
+
+const compactJwsHeaderSchema = z.object({
+  alg: z.literal("EdDSA"),
+  typ: z.string().optional(),
+  kid: z.string().optional(),
+});
+
+export const ControlPlaneSurfaceSchema = z.enum(["studio", "channels", "a2a", "mcp"]);
+
+export const ControlPlaneAgentsListRequestSchema = z.object({
+  requestId: z.string().min(1),
+  projectId: z.string().min(1),
+  surface: ControlPlaneSurfaceSchema,
+});
+
+export const RuntimeAgentSkillSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  examples: z.array(z.string()).optional(),
+});
+
+export const RuntimeAgentSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().nullable().optional(),
+  model: z.string().nullable().optional(),
+  version: z.string().nullable().optional(),
+  skills: z.array(RuntimeAgentSkillSchema).optional(),
+});
+
+export const RuntimeAgentListResponseSchema = z.object({
+  agents: z.array(RuntimeAgentSchema),
+});
+
+const dispatchClaimsSchema = z.object({
+  iss: z.string(),
+  aud: z.string(),
+  sub: z.string(),
+  project_id: z.string(),
+  platform: z.string(),
+  body_sha256: z.string(),
+  iat: z.number().int(),
+  exp: z.number().int(),
+});
+
+const controlPlaneClaimsSchema = z.object({
+  iss: z.string(),
+  aud: z.string(),
+  sub: z.string(),
+  surface: ControlPlaneSurfaceSchema,
+  project_id: z.string(),
+  request_hash: z.string(),
+  iat: z.number().int(),
+  exp: z.number().int(),
+});
+
+export type ControlPlaneSurface = z.infer<typeof ControlPlaneSurfaceSchema>;
+export type ControlPlaneAgentsListRequest = z.infer<typeof ControlPlaneAgentsListRequestSchema>;
+export type RuntimeAgentSkill = z.infer<typeof RuntimeAgentSkillSchema>;
+export type RuntimeAgent = z.infer<typeof RuntimeAgentSchema>;
+export type RuntimeAgentListResponse = z.infer<typeof RuntimeAgentListResponseSchema>;
+export type DispatchClaims = z.infer<typeof dispatchClaimsSchema>;
+export type ControlPlaneClaims = z.infer<typeof controlPlaneClaimsSchema>;
+
+export interface RuntimeAgentDiscoveryDeps {
+  ensureProjectDiscovery: (ctx: HandlerContext) => Promise<void>;
+  getAgent: (id: string) => Agent | undefined;
+  getAllAgentIds: () => string[];
+}
+
+type SignedRequestClaims = {
+  aud: string;
+  exp: number;
+  iat: number;
+  project_id: string;
+  sub: string;
+} & Record<string, unknown>;
+
+function base64urlDecodeToBytes(input: string): ArrayBuffer {
+  const normalized = input
+    .replaceAll("-", "+")
+    .replaceAll("_", "/")
+    .padEnd(Math.ceil(input.length / 4) * 4, "=");
+
+  return toArrayBuffer(Uint8Array.from(atob(normalized), (char) => char.charCodeAt(0)));
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  return buffer;
+}
+
+function pemToDer(pem: string, label: string): ArrayBuffer {
+  const body = pem
+    .replace(`-----BEGIN ${label}-----`, "")
+    .replace(`-----END ${label}-----`, "")
+    .replace(/\s/g, "");
+
+  return toArrayBuffer(Uint8Array.from(atob(body), (char) => char.charCodeAt(0)));
+}
+
+async function importEd25519PublicKey(pem: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "spki",
+    pemToDer(pem, "PUBLIC KEY"),
+    "Ed25519",
+    false,
+    ["verify"],
+  );
+}
+
+async function sha256Base64url(body: string): Promise<string> {
+  const hash = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(body));
+  return base64urlEncodeBytes(new Uint8Array(hash));
+}
+
+async function verifySignedRequestJws<TClaims extends SignedRequestClaims>(
+  jws: string,
+  body: string,
+  options: {
+    audience: string;
+    claimsSchema: z.ZodType<TClaims>;
+    expectedProjectId?: string;
+    expectedSubject?: string;
+    hashClaimKey: keyof TClaims & string;
+    maxAgeSeconds: number;
+    publicKeyPem: string;
+    scopedClaim?: {
+      key: keyof TClaims & string;
+      label: string;
+      value: string;
+    };
+  },
+): Promise<TClaims> {
+  const parts = jws.split(".");
+  if (parts.length !== 3) {
+    throw new Error("Control-plane signature must be a compact JWS");
+  }
+
+  const encodedHeader = parts[0];
+  const encodedPayload = parts[1];
+  const encodedSignature = parts[2];
+  if (!encodedHeader || !encodedPayload || !encodedSignature) {
+    throw new Error("Control-plane signature must include header, payload, and signature");
+  }
+
+  const header = compactJwsHeaderSchema.parse(
+    JSON.parse(new TextDecoder().decode(base64urlDecodeToBytes(encodedHeader))),
+  );
+  const claims = options.claimsSchema.parse(
+    JSON.parse(new TextDecoder().decode(base64urlDecodeToBytes(encodedPayload))),
+  );
+
+  if (header.alg !== "EdDSA") {
+    throw new Error("Unsupported control-plane JWS algorithm");
+  }
+
+  const signingInput = new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`);
+  const signature = base64urlDecodeToBytes(encodedSignature);
+  const publicKey = await importEd25519PublicKey(options.publicKeyPem);
+  const verified = await crypto.subtle.verify("Ed25519", publicKey, signature, signingInput);
+
+  if (!verified) {
+    throw new Error("Control-plane signature verification failed");
+  }
+
+  if (claims.aud !== options.audience) {
+    throw new Error("Control-plane audience mismatch");
+  }
+
+  if (options.expectedProjectId && claims.project_id !== options.expectedProjectId) {
+    throw new Error("Control-plane project mismatch");
+  }
+
+  if (options.expectedSubject && claims.sub !== options.expectedSubject) {
+    throw new Error("Control-plane subject mismatch");
+  }
+
+  if (options.scopedClaim && claims[options.scopedClaim.key] !== options.scopedClaim.value) {
+    throw new Error(`Control-plane ${options.scopedClaim.label} mismatch`);
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (claims.exp <= now) {
+    throw new Error("Control-plane signature expired");
+  }
+
+  if (claims.iat > now + SIGNATURE_SKEW_SECONDS) {
+    throw new Error("Control-plane signature issued in the future");
+  }
+
+  if (now - claims.iat > options.maxAgeSeconds) {
+    throw new Error("Control-plane signature is too old");
+  }
+
+  const requestHash = claims[options.hashClaimKey];
+  if (typeof requestHash !== "string") {
+    throw new Error("Control-plane request hash is missing");
+  }
+
+  const bodyHash = await sha256Base64url(body);
+  if (requestHash !== bodyHash) {
+    throw new Error("Control-plane body hash mismatch");
+  }
+
+  return claims;
+}
+
+function resolveAgentSkills(agent: Agent): RuntimeAgentSkill[] {
+  if (!agent.config.skills) {
+    return [];
+  }
+
+  return Array.from(skillRegistry.resolveForAgent(agent.config.skills).values())
+    .map((skill) =>
+      RuntimeAgentSkillSchema.parse({
+        id: skill.id,
+        name: skill.metadata.name || skill.id,
+        ...(skill.metadata.description ? { description: skill.metadata.description } : {}),
+      })
+    )
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function getRuntimeAgentMetadata(agent: Agent): RuntimeAgent {
+  const rawConfig = agent.config as unknown as Record<string, unknown>;
+
+  return RuntimeAgentSchema.parse({
+    id: agent.id,
+    name: typeof rawConfig.name === "string" && rawConfig.name.trim().length > 0
+      ? rawConfig.name
+      : agent.id,
+    description: typeof rawConfig.description === "string" ? rawConfig.description : null,
+    model: agent.config.model ?? null,
+    version: typeof rawConfig.version === "string" ? rawConfig.version : null,
+    skills: resolveAgentSkills(agent),
+  });
+}
+
+export async function listRuntimeAgents(
+  ctx: HandlerContext,
+  deps: RuntimeAgentDiscoveryDeps,
+): Promise<RuntimeAgentListResponse> {
+  await deps.ensureProjectDiscovery(ctx);
+
+  const agents = deps.getAllAgentIds()
+    .map((id) => deps.getAgent(id))
+    .filter((agent): agent is Agent => Boolean(agent))
+    .map(getRuntimeAgentMetadata)
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  return RuntimeAgentListResponseSchema.parse({ agents });
+}
+
+export async function verifyDispatchJws(
+  jws: string,
+  body: string,
+  options: {
+    audience: string;
+    expectedPlatform?: string;
+    expectedProjectId?: string;
+    expectedSubject?: string;
+    maxAgeSeconds: number;
+    publicKeyPem: string;
+  },
+): Promise<DispatchClaims> {
+  return verifySignedRequestJws(jws, body, {
+    audience: options.audience,
+    claimsSchema: dispatchClaimsSchema,
+    expectedProjectId: options.expectedProjectId,
+    ...(options.expectedSubject ? { expectedSubject: options.expectedSubject } : {}),
+    hashClaimKey: "body_sha256",
+    maxAgeSeconds: options.maxAgeSeconds,
+    publicKeyPem: options.publicKeyPem,
+    ...(options.expectedPlatform
+      ? {
+        scopedClaim: {
+          key: "platform" as const,
+          label: "platform",
+          value: options.expectedPlatform,
+        },
+      }
+      : {}),
+  });
+}
+
+export async function verifyControlPlaneJws(
+  jws: string,
+  body: string,
+  options: {
+    audience: string;
+    expectedProjectId?: string;
+    expectedSubject?: string;
+    expectedSurface?: ControlPlaneSurface;
+    maxAgeSeconds: number;
+    publicKeyPem: string;
+  },
+): Promise<ControlPlaneClaims> {
+  return verifySignedRequestJws(jws, body, {
+    audience: options.audience,
+    claimsSchema: controlPlaneClaimsSchema,
+    expectedProjectId: options.expectedProjectId,
+    ...(options.expectedSubject ? { expectedSubject: options.expectedSubject } : {}),
+    hashClaimKey: "request_hash",
+    maxAgeSeconds: options.maxAgeSeconds,
+    publicKeyPem: options.publicKeyPem,
+    ...(options.expectedSurface
+      ? {
+        scopedClaim: {
+          key: "surface" as const,
+          label: "surface",
+          value: options.expectedSurface,
+        },
+      }
+      : {}),
+  });
+}

--- a/src/channels/invoke.ts
+++ b/src/channels/invoke.ts
@@ -2,16 +2,15 @@ import type { Agent, AgentMessage as Message, AgentResponse } from "#veryfront/a
 import { fromError } from "#veryfront/errors/veryfront-error.ts";
 import type { HandlerContext } from "#veryfront/types";
 import { serverLogger } from "#veryfront/utils";
-import { base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
 import { z } from "zod";
 import {
   getAgent as getRegisteredAgent,
   getAllAgentIds as getRegisteredAgentIds,
 } from "../agent/composition/composition.ts";
+import { listRuntimeAgents, type RuntimeAgentDiscoveryDeps } from "./control-plane.ts";
 import { ensureProjectDiscovery as ensureProjectDiscoveryForProject } from "../server/handlers/request/api/project-discovery.ts";
 
 const logger = serverLogger.component("channels-invoke");
-const SIGNATURE_SKEW_SECONDS = 5;
 
 const rawHistoryPartSchema = z.object({
   type: z.string(),
@@ -124,37 +123,13 @@ export const ChannelInvokeResponseSchema = z.object({
   }).optional(),
 });
 
-const dispatchHeaderSchema = z.object({
-  alg: z.literal("EdDSA"),
-  typ: z.string().optional(),
-  kid: z.string().optional(),
-});
-
-const dispatchClaimsSchema = z.object({
-  iss: z.string(),
-  aud: z.string(),
-  sub: z.string(),
-  project_id: z.string(),
-  platform: z.string(),
-  body_sha256: z.string(),
-  iat: z.number().int(),
-  exp: z.number().int(),
-});
-
 export type ChannelInvokeRequest = z.infer<typeof ChannelInvokeRequestSchema>;
 export type ChannelInvokeResponse = z.infer<typeof ChannelInvokeResponseSchema>;
 export type ChannelAssistantsRequest = z.infer<typeof ChannelAssistantsRequestSchema>;
 export type ChannelAssistantsResponse = z.infer<typeof ChannelAssistantsResponseSchema>;
 
 type ChannelResponsePart = z.infer<typeof ChannelResponsePartSchema>;
-type DispatchClaims = z.infer<typeof dispatchClaimsSchema>;
-type ChannelAssistant = z.infer<typeof ChannelAssistantSchema>;
-
-export interface ChannelInvokeDeps {
-  ensureProjectDiscovery: (ctx: HandlerContext) => Promise<void>;
-  getAgent: (id: string) => Agent | undefined;
-  getAllAgentIds: () => string[];
-}
+export interface ChannelInvokeDeps extends RuntimeAgentDiscoveryDeps {}
 
 export const defaultChannelInvokeDeps: ChannelInvokeDeps = {
   ensureProjectDiscovery: ensureProjectDiscoveryForProject,
@@ -162,142 +137,23 @@ export const defaultChannelInvokeDeps: ChannelInvokeDeps = {
   getAllAgentIds: getRegisteredAgentIds,
 };
 
-function getAssistantMetadata(agent: Agent): ChannelAssistant {
-  const rawConfig = agent.config as unknown as Record<string, unknown>;
-
-  return ChannelAssistantSchema.parse({
-    id: agent.id,
-    name: typeof rawConfig.name === "string" && rawConfig.name.trim().length > 0
-      ? rawConfig.name
-      : agent.id,
-    description: typeof rawConfig.description === "string" ? rawConfig.description : null,
-    model: agent.config.model ?? null,
-  });
-}
-
 export async function listChannelAssistants(
   ctx: HandlerContext,
   deps: ChannelInvokeDeps,
 ): Promise<ChannelAssistantsResponse> {
-  await deps.ensureProjectDiscovery(ctx);
-
-  const assistants = deps.getAllAgentIds()
-    .map((id) => deps.getAgent(id))
-    .filter((agent): agent is Agent => Boolean(agent))
-    .map(getAssistantMetadata)
-    .sort((left, right) => left.name.localeCompare(right.name));
+  const response = await listRuntimeAgents(ctx, deps);
+  const assistants = response.agents.map((agent) =>
+    ChannelAssistantSchema.parse({
+      id: agent.id,
+      name: agent.name,
+      description: agent.description ?? null,
+      model: agent.model ?? null,
+    })
+  );
 
   return ChannelAssistantsResponseSchema.parse({ assistants });
 }
-
-function base64urlDecodeToBytes(input: string): ArrayBuffer {
-  const normalized = input
-    .replaceAll("-", "+")
-    .replaceAll("_", "/")
-    .padEnd(Math.ceil(input.length / 4) * 4, "=");
-
-  return toArrayBuffer(Uint8Array.from(atob(normalized), (char) => char.charCodeAt(0)));
-}
-
-function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
-  const buffer = new ArrayBuffer(bytes.byteLength);
-  new Uint8Array(buffer).set(bytes);
-  return buffer;
-}
-
-function pemToDer(pem: string, label: string): ArrayBuffer {
-  const body = pem
-    .replace(`-----BEGIN ${label}-----`, "")
-    .replace(`-----END ${label}-----`, "")
-    .replace(/\s/g, "");
-
-  return toArrayBuffer(Uint8Array.from(atob(body), (char) => char.charCodeAt(0)));
-}
-
-async function importEd25519PublicKey(pem: string): Promise<CryptoKey> {
-  return crypto.subtle.importKey(
-    "spki",
-    pemToDer(pem, "PUBLIC KEY"),
-    "Ed25519",
-    false,
-    ["verify"],
-  );
-}
-
-async function sha256Base64url(body: string): Promise<string> {
-  const hash = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(body));
-  return base64urlEncodeBytes(new Uint8Array(hash));
-}
-
-export async function verifyDispatchJws(
-  jws: string,
-  body: string,
-  options: {
-    audience: string;
-    publicKeyPem: string;
-    maxAgeSeconds: number;
-    expectedProjectId?: string;
-  },
-): Promise<DispatchClaims> {
-  const parts = jws.split(".");
-  if (parts.length !== 3) {
-    throw new Error("Channel dispatch signature must be a compact JWS");
-  }
-
-  const encodedHeader = parts[0];
-  const encodedPayload = parts[1];
-  const encodedSignature = parts[2];
-  if (!encodedHeader || !encodedPayload || !encodedSignature) {
-    throw new Error("Channel dispatch signature must include header, payload, and signature");
-  }
-  const header = dispatchHeaderSchema.parse(
-    JSON.parse(new TextDecoder().decode(base64urlDecodeToBytes(encodedHeader))),
-  );
-  const claims = dispatchClaimsSchema.parse(
-    JSON.parse(new TextDecoder().decode(base64urlDecodeToBytes(encodedPayload))),
-  );
-
-  if (header.alg !== "EdDSA") {
-    throw new Error("Unsupported channel dispatch JWS algorithm");
-  }
-
-  const signingInput = new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`);
-  const signature = base64urlDecodeToBytes(encodedSignature);
-  const publicKey = await importEd25519PublicKey(options.publicKeyPem);
-  const verified = await crypto.subtle.verify("Ed25519", publicKey, signature, signingInput);
-
-  if (!verified) {
-    throw new Error("Channel dispatch signature verification failed");
-  }
-
-  if (claims.aud !== options.audience) {
-    throw new Error("Channel dispatch audience mismatch");
-  }
-
-  if (options.expectedProjectId && claims.project_id !== options.expectedProjectId) {
-    throw new Error("Channel dispatch project mismatch");
-  }
-
-  const now = Math.floor(Date.now() / 1000);
-  if (claims.exp <= now) {
-    throw new Error("Channel dispatch signature expired");
-  }
-
-  if (claims.iat > now + SIGNATURE_SKEW_SECONDS) {
-    throw new Error("Channel dispatch signature issued in the future");
-  }
-
-  if (now - claims.iat > options.maxAgeSeconds) {
-    throw new Error("Channel dispatch signature is too old");
-  }
-
-  const bodySha256 = await sha256Base64url(body);
-  if (claims.body_sha256 !== bodySha256) {
-    throw new Error("Channel dispatch body hash mismatch");
-  }
-
-  return claims;
-}
+export { verifyDispatchJws } from "./control-plane.ts";
 
 function normalizeConversationPart(
   part: z.infer<typeof rawHistoryPartSchema>,

--- a/src/embedding/rag-store.test.ts
+++ b/src/embedding/rag-store.test.ts
@@ -1,6 +1,7 @@
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { exists, readTextFile, withTempDir } from "#veryfront/testing/deno-compat.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { deleteEnv, setEnv } from "#veryfront/compat/process.ts";
 import { join } from "#veryfront/compat/path";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
@@ -22,18 +23,6 @@ function clearCloudEnv(): void {
       // expected: env may already be unset
     }
   }
-}
-
-function withMockFetch<T>(
-  mockFetch: typeof globalThis.fetch,
-  fn: () => Promise<T>,
-): Promise<T> {
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = mockFetch;
-
-  return fn().finally(() => {
-    globalThis.fetch = originalFetch;
-  });
 }
 
 function registerTestEmbeddingProvider(): void {

--- a/src/embedding/upload-handler.test.ts
+++ b/src/embedding/upload-handler.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { deleteEnv, setEnv } from "#veryfront/compat/process.ts";
 import { createUploadHandler } from "./upload-handler.ts";
 import type { RagSearchOptions, RagSearchResult, RagStore } from "./types.ts";
@@ -19,18 +20,6 @@ function clearCloudEnv(): void {
       // expected: env may already be unset
     }
   }
-}
-
-function withMockFetch<T>(
-  mockFetch: typeof globalThis.fetch,
-  fn: () => Promise<T>,
-): Promise<T> {
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = mockFetch;
-
-  return fn().finally(() => {
-    globalThis.fetch = originalFetch;
-  });
 }
 
 function createStubStore(overrides: Partial<RagStore> = {}): RagStore {

--- a/src/internal-agents/ag-ui-sse.test.ts
+++ b/src/internal-agents/ag-ui-sse.test.ts
@@ -181,11 +181,12 @@ describe("internal-agents/ag-ui-sse", () => {
     const payload = formatAgUiEvent("RunStarted", {
       runId: "run_1",
       threadId: "thread-1",
+      agentId: "assistant-1",
     });
 
     assertEquals(
       new TextDecoder().decode(payload),
-      'event: RunStarted\ndata: {"runId":"run_1","threadId":"thread-1"}\n\n',
+      'event: RunStarted\ndata: {"runId":"run_1","threadId":"thread-1","agentId":"assistant-1"}\n\n',
     );
   });
 });

--- a/src/internal-agents/ag-ui-sse.test.ts
+++ b/src/internal-agents/ag-ui-sse.test.ts
@@ -23,6 +23,20 @@ describe("internal-agents/ag-ui-sse", () => {
     assertEquals(parsed.remainder, 'data: {"type":"message-start"');
   });
 
+  it("skips malformed SSE payloads and continues parsing", () => {
+    const parsed = parseSseJsonEvents(
+      'data: {"type":"text-delta","id":"text-1","delta":"hello"}\n\n' +
+        'data: {"type":"broken"\n\n' +
+        'data: {"type":"step-end"}\n\n',
+    );
+
+    assertEquals(parsed.events, [
+      { type: "text-delta", id: "text-1", delta: "hello" },
+      { type: "step-end" },
+    ]);
+    assertEquals(parsed.remainder, "");
+  });
+
   it("maps runtime tool and text events to AG-UI wire events", () => {
     const state = createStreamTransformState();
 

--- a/src/internal-agents/ag-ui-sse.test.ts
+++ b/src/internal-agents/ag-ui-sse.test.ts
@@ -1,0 +1,191 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  createStreamTransformState,
+  finalizeRunEvents,
+  formatAgUiEvent,
+  mapRuntimeEventToAgUi,
+  parseSseJsonEvents,
+} from "./ag-ui-sse.ts";
+
+describe("internal-agents/ag-ui-sse", () => {
+  it("parses complete SSE data frames and preserves incomplete remainder", () => {
+    const parsed = parseSseJsonEvents(
+      'data: {"type":"text-delta","id":"text-1","delta":"hello"}\n\n' +
+        'data: {"type":"step-end"}\n\n' +
+        'data: {"type":"message-start"',
+    );
+
+    assertEquals(parsed.events, [
+      { type: "text-delta", id: "text-1", delta: "hello" },
+      { type: "step-end" },
+    ]);
+    assertEquals(parsed.remainder, 'data: {"type":"message-start"');
+  });
+
+  it("maps runtime tool and text events to AG-UI wire events", () => {
+    const state = createStreamTransformState();
+
+    assertEquals(
+      mapRuntimeEventToAgUi(state, { type: "message-start", messageId: "assistant-1" }),
+      [],
+    );
+    assertEquals(
+      mapRuntimeEventToAgUi(state, { type: "text-start", id: "text-1" }),
+      [{ event: "TextMessageStart", payload: { messageId: "assistant-1", role: "assistant" } }],
+    );
+    assertEquals(
+      mapRuntimeEventToAgUi(state, { type: "text-delta", id: "text-1", delta: "hello" }),
+      [{ event: "TextMessageContent", payload: { messageId: "assistant-1", delta: "hello" } }],
+    );
+    assertEquals(
+      mapRuntimeEventToAgUi(state, {
+        type: "tool-input-start",
+        toolCallId: "tool-1",
+        toolName: "studio_focus_component",
+      }),
+      [{
+        event: "ToolCallStart",
+        payload: { toolCallId: "tool-1", toolCallName: "studio_focus_component" },
+      }],
+    );
+    assertEquals(
+      mapRuntimeEventToAgUi(state, {
+        type: "tool-output-error",
+        toolCallId: "tool-1",
+        errorText: "boom",
+      }),
+      [{
+        event: "ToolCallResult",
+        payload: { toolCallId: "tool-1", result: { error: "boom" }, isError: true },
+      }],
+    );
+    assertEquals(
+      mapRuntimeEventToAgUi(state, { type: "error", error: "Runtime failed" }),
+      [{ event: "RunError", payload: { message: "Runtime failed" } }],
+    );
+  });
+
+  it("covers implicit text start, tool transitions, steps, metadata, and terminal errors", () => {
+    const state = createStreamTransformState();
+
+    assertEquals(
+      mapRuntimeEventToAgUi(state, { type: "message-start", id: "assistant-2" }),
+      [],
+    );
+    assertEquals(
+      mapRuntimeEventToAgUi(state, { type: "text-delta", delta: "hello" }),
+      [
+        { event: "TextMessageStart", payload: { messageId: "assistant-2", role: "assistant" } },
+        { event: "TextMessageContent", payload: { messageId: "assistant-2", delta: "hello" } },
+      ],
+    );
+    assertEquals(
+      mapRuntimeEventToAgUi(state, { type: "text-end" }),
+      [{ event: "TextMessageEnd", payload: { messageId: "assistant-2" } }],
+    );
+    assertEquals(
+      mapRuntimeEventToAgUi(state, {
+        type: "tool-input-delta",
+        toolCallId: "tool-2",
+        inputTextDelta: '{"path":"app/page.tsx"}',
+      }),
+      [{
+        event: "ToolCallArgs",
+        payload: { toolCallId: "tool-2", delta: '{"path":"app/page.tsx"}' },
+      }],
+    );
+    assertEquals(
+      mapRuntimeEventToAgUi(state, { type: "tool-input-available", toolCallId: "tool-2" }),
+      [{ event: "ToolCallEnd", payload: { toolCallId: "tool-2" } }],
+    );
+    assertEquals(
+      mapRuntimeEventToAgUi(state, {
+        type: "tool-output-available",
+        toolCallId: "tool-2",
+        output: { ok: true },
+      }),
+      [{
+        event: "ToolCallResult",
+        payload: { toolCallId: "tool-2", result: { ok: true } },
+      }],
+    );
+    assertEquals(
+      mapRuntimeEventToAgUi(state, { type: "step-start" }),
+      [{ event: "StepStarted", payload: { stepIndex: 1 } }],
+    );
+    assertEquals(
+      mapRuntimeEventToAgUi(state, { type: "step-end" }),
+      [{ event: "StepFinished", payload: { stepIndex: 1 } }],
+    );
+    assertEquals(
+      mapRuntimeEventToAgUi(state, {
+        type: "data",
+        data: { model: "anthropic/claude-sonnet-4-6" },
+      }),
+      [],
+    );
+    assertEquals(state.metadata, {
+      model: "anthropic/claude-sonnet-4-6",
+      provider: "anthropic",
+    });
+    assertEquals(mapRuntimeEventToAgUi(state, { type: "unknown-event" }), []);
+    assertEquals(
+      mapRuntimeEventToAgUi(state, { type: "error", error: 123 }),
+      [{ event: "RunError", payload: { message: "Agent run failed" } }],
+    );
+    assertEquals(finalizeRunEvents(state, null), []);
+  });
+
+  it("finalizes open assistant text with usage metadata", () => {
+    const state = createStreamTransformState();
+    mapRuntimeEventToAgUi(state, { type: "message-start", messageId: "assistant-1" });
+    mapRuntimeEventToAgUi(state, { type: "text-start", id: "text-1" });
+
+    assertEquals(
+      finalizeRunEvents(state, {
+        text: "Done.",
+        messages: [],
+        toolCalls: [],
+        status: "completed",
+        usage: {
+          promptTokens: 3,
+          completionTokens: 5,
+          totalTokens: 8,
+        },
+        metadata: {
+          finishReason: "stop",
+        },
+      }),
+      [
+        {
+          event: "TextMessageEnd",
+          payload: { messageId: "assistant-1" },
+        },
+        {
+          event: "RunFinished",
+          payload: {
+            metadata: {
+              inputTokens: 3,
+              outputTokens: 5,
+              totalTokens: 8,
+              finishReason: "stop",
+            },
+          },
+        },
+      ],
+    );
+  });
+
+  it("formats AG-UI events as SSE frames", () => {
+    const payload = formatAgUiEvent("RunStarted", {
+      runId: "run_1",
+      threadId: "thread-1",
+    });
+
+    assertEquals(
+      new TextDecoder().decode(payload),
+      'event: RunStarted\ndata: {"runId":"run_1","threadId":"thread-1"}\n\n',
+    );
+  });
+});

--- a/src/internal-agents/ag-ui-sse.ts
+++ b/src/internal-agents/ag-ui-sse.ts
@@ -1,0 +1,256 @@
+import type { AgentResponse } from "#veryfront/agent";
+
+const encoder = new TextEncoder();
+
+type RuntimeDataEvent = Record<string, unknown> & { type: string };
+
+export interface RunFinishedMetadata {
+  provider?: string;
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  finishReason?: string;
+}
+
+export interface StreamTransformState {
+  messageId: string | null;
+  textOpen: boolean;
+  stepIndex: number;
+  sawTerminalError: boolean;
+  metadata: RunFinishedMetadata;
+}
+
+export function createStreamTransformState(): StreamTransformState {
+  return {
+    messageId: null,
+    textOpen: false,
+    stepIndex: 0,
+    sawTerminalError: false,
+    metadata: {},
+  };
+}
+
+export function formatAgUiEvent(event: string, payload: Record<string, unknown>): Uint8Array {
+  return encoder.encode(`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`);
+}
+
+export function parseSseJsonEvents(chunk: string): {
+  events: RuntimeDataEvent[];
+  remainder: string;
+} {
+  const blocks = chunk.split("\n\n");
+  const remainder = blocks.pop() ?? "";
+  const events = blocks.flatMap((block) => {
+    const dataLines = block.split("\n")
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trimStart());
+
+    if (!dataLines.length) {
+      return [];
+    }
+
+    const payload = JSON.parse(dataLines.join("\n")) as RuntimeDataEvent;
+    return [payload];
+  });
+
+  return { events, remainder };
+}
+
+function getMessageId(state: StreamTransformState, event: RuntimeDataEvent): string {
+  if (typeof event.messageId === "string") {
+    state.messageId = event.messageId;
+    return event.messageId;
+  }
+
+  if (!state.messageId && typeof event.id === "string") {
+    state.messageId = event.id;
+  }
+
+  if (!state.messageId) {
+    state.messageId = crypto.randomUUID();
+  }
+
+  return state.messageId;
+}
+
+function applyDataMetadata(state: StreamTransformState, event: RuntimeDataEvent): void {
+  const data = event.data && typeof event.data === "object" && !Array.isArray(event.data)
+    ? event.data as Record<string, unknown>
+    : event;
+
+  if (typeof data.model === "string") {
+    state.metadata.model = data.model;
+    const provider = data.model.split("/")[0];
+    if (provider) {
+      state.metadata.provider = provider;
+    }
+  }
+}
+
+function applyResponseMetadata(state: StreamTransformState, response: AgentResponse | null): void {
+  if (!response) return;
+
+  if (response.usage) {
+    state.metadata.inputTokens = response.usage.promptTokens;
+    state.metadata.outputTokens = response.usage.completionTokens;
+    state.metadata.totalTokens = response.usage.totalTokens;
+  }
+
+  const finishReason = response.metadata && typeof response.metadata === "object"
+    ? response.metadata.finishReason
+    : undefined;
+  if (typeof finishReason === "string") {
+    state.metadata.finishReason = finishReason;
+  }
+}
+
+export function mapRuntimeEventToAgUi(
+  state: StreamTransformState,
+  event: RuntimeDataEvent,
+): Array<{ event: string; payload: Record<string, unknown> }> {
+  switch (event.type) {
+    case "message-start":
+      getMessageId(state, event);
+      return [];
+
+    case "text-start": {
+      if (state.textOpen) return [];
+      const messageId = getMessageId(state, event);
+      state.textOpen = true;
+      return [{
+        event: "TextMessageStart",
+        payload: { messageId, role: "assistant" },
+      }];
+    }
+
+    case "text-delta": {
+      const messageId = getMessageId(state, event);
+      if (!state.textOpen) {
+        state.textOpen = true;
+        return [
+          { event: "TextMessageStart", payload: { messageId, role: "assistant" } },
+          {
+            event: "TextMessageContent",
+            payload: { messageId, delta: typeof event.delta === "string" ? event.delta : "" },
+          },
+        ];
+      }
+
+      return [{
+        event: "TextMessageContent",
+        payload: { messageId, delta: typeof event.delta === "string" ? event.delta : "" },
+      }];
+    }
+
+    case "text-end": {
+      if (!state.textOpen) return [];
+      state.textOpen = false;
+      return [{
+        event: "TextMessageEnd",
+        payload: { messageId: getMessageId(state, event) },
+      }];
+    }
+
+    case "tool-input-start":
+      return [{
+        event: "ToolCallStart",
+        payload: {
+          toolCallId: event.toolCallId,
+          toolCallName: event.toolName,
+        },
+      }];
+
+    case "tool-input-delta":
+      return [{
+        event: "ToolCallArgs",
+        payload: {
+          toolCallId: event.toolCallId,
+          delta: typeof event.inputTextDelta === "string" ? event.inputTextDelta : "",
+        },
+      }];
+
+    case "tool-input-available":
+      return [{
+        event: "ToolCallEnd",
+        payload: { toolCallId: event.toolCallId },
+      }];
+
+    case "tool-output-available":
+      return [{
+        event: "ToolCallResult",
+        payload: {
+          toolCallId: event.toolCallId,
+          result: event.output,
+        },
+      }];
+
+    case "tool-output-error":
+      return [{
+        event: "ToolCallResult",
+        payload: {
+          toolCallId: event.toolCallId,
+          result: { error: event.errorText },
+          isError: true,
+        },
+      }];
+
+    case "step-start":
+      state.stepIndex += 1;
+      return [{
+        event: "StepStarted",
+        payload: { stepIndex: state.stepIndex },
+      }];
+
+    case "step-end":
+      return [{
+        event: "StepFinished",
+        payload: { stepIndex: state.stepIndex },
+      }];
+
+    case "data":
+      applyDataMetadata(state, event);
+      return [];
+
+    case "error":
+      state.sawTerminalError = true;
+      return [{
+        event: "RunError",
+        payload: {
+          message: typeof event.error === "string" ? event.error : "Agent run failed",
+        },
+      }];
+
+    default:
+      return [];
+  }
+}
+
+export function finalizeRunEvents(
+  state: StreamTransformState,
+  response: AgentResponse | null,
+): Array<{ event: string; payload: Record<string, unknown> }> {
+  applyResponseMetadata(state, response);
+
+  if (state.sawTerminalError) {
+    return [];
+  }
+
+  const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
+  if (state.textOpen) {
+    state.textOpen = false;
+    events.push({
+      event: "TextMessageEnd",
+      payload: { messageId: getMessageId(state, { type: "text-end" }) },
+    });
+  }
+
+  events.push({
+    event: "RunFinished",
+    payload: {
+      metadata: state.metadata,
+    },
+  });
+
+  return events;
+}

--- a/src/internal-agents/ag-ui-sse.ts
+++ b/src/internal-agents/ag-ui-sse.ts
@@ -1,4 +1,5 @@
 import type { AgentResponse } from "#veryfront/agent";
+import { z } from "zod";
 
 const encoder = new TextEncoder();
 
@@ -31,8 +32,67 @@ export function createStreamTransformState(): StreamTransformState {
   };
 }
 
+const agUiEventPayloadSchemas = {
+  RunStarted: z.object({
+    runId: z.string().min(1),
+    threadId: z.string().min(1),
+    agentId: z.string().min(1),
+  }),
+  TextMessageStart: z.object({
+    messageId: z.string().min(1),
+    role: z.literal("assistant"),
+  }),
+  TextMessageContent: z.object({
+    messageId: z.string().min(1),
+    delta: z.string(),
+  }),
+  TextMessageEnd: z.object({
+    messageId: z.string().min(1),
+  }),
+  ToolCallStart: z.object({
+    toolCallId: z.string().min(1),
+    toolCallName: z.string().min(1),
+  }),
+  ToolCallArgs: z.object({
+    toolCallId: z.string().min(1),
+    delta: z.string(),
+  }),
+  ToolCallEnd: z.object({
+    toolCallId: z.string().min(1),
+  }),
+  ToolCallResult: z.object({
+    toolCallId: z.string().min(1),
+    result: z.unknown(),
+    isError: z.boolean().optional(),
+  }),
+  StepStarted: z.object({
+    stepIndex: z.number().int().positive(),
+  }),
+  StepFinished: z.object({
+    stepIndex: z.number().int().positive(),
+  }),
+  RunError: z.object({
+    code: z.string().min(1).optional(),
+    message: z.string().min(1),
+  }),
+  RunFinished: z.object({
+    metadata: z.object({
+      provider: z.string().optional(),
+      model: z.string().optional(),
+      inputTokens: z.number().int().nonnegative().optional(),
+      outputTokens: z.number().int().nonnegative().optional(),
+      totalTokens: z.number().int().nonnegative().optional(),
+      finishReason: z.string().optional(),
+    }),
+  }),
+} as const satisfies Record<string, z.ZodType<Record<string, unknown>>>;
+
+type AgUiEventName = keyof typeof agUiEventPayloadSchemas;
+
 export function formatAgUiEvent(event: string, payload: Record<string, unknown>): Uint8Array {
-  return encoder.encode(`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`);
+  const schema = agUiEventPayloadSchemas[event as AgUiEventName];
+  const validatedPayload = schema ? schema.parse(payload) : payload;
+  return encoder.encode(`event: ${event}\ndata: ${JSON.stringify(validatedPayload)}\n\n`);
 }
 
 export function parseSseJsonEvents(chunk: string): {

--- a/src/internal-agents/ag-ui-sse.ts
+++ b/src/internal-agents/ag-ui-sse.ts
@@ -1,7 +1,9 @@
 import type { AgentResponse } from "#veryfront/agent";
+import { serverLogger } from "#veryfront/utils";
 import { z } from "zod";
 
 const encoder = new TextEncoder();
+const logger = serverLogger.component("internal-agents-ag-ui-sse");
 
 type RuntimeDataEvent = Record<string, unknown> & { type: string };
 
@@ -110,8 +112,16 @@ export function parseSseJsonEvents(chunk: string): {
       return [];
     }
 
-    const payload = JSON.parse(dataLines.join("\n")) as RuntimeDataEvent;
-    return [payload];
+    try {
+      const payload = JSON.parse(dataLines.join("\n")) as RuntimeDataEvent;
+      return [payload];
+    } catch (error) {
+      logger.warn("Skipping malformed runtime SSE event payload", {
+        error,
+        dataLength: dataLines.join("\n").length,
+      });
+      return [];
+    }
   });
 
   return { events, remainder };

--- a/src/internal-agents/control-plane-auth.ts
+++ b/src/internal-agents/control-plane-auth.ts
@@ -1,0 +1,57 @@
+import { verifyControlPlaneJws } from "#veryfront/channels/control-plane.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { HTTP_INTERNAL_SERVER_ERROR } from "#veryfront/utils/constants/index.ts";
+
+const CONTROL_PLANE_JWS_HEADER = "x-veryfront-control-plane-jws";
+const MAX_CONTROL_PLANE_SIGNATURE_AGE_SECONDS = 60;
+
+export class ControlPlaneRequestError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+    this.name = "ControlPlaneRequestError";
+  }
+}
+
+export async function verifyControlPlaneRequest(
+  req: Request,
+  ctx: HandlerContext,
+  rawBody: string,
+  options: {
+    expectedSubject?: string;
+    expectedSurface?: "studio" | "channels" | "a2a" | "mcp";
+  } = {},
+) {
+  const publicKeyPem = ctx.adapter.env.get("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
+  if (!publicKeyPem) {
+    throw new ControlPlaneRequestError(
+      HTTP_INTERNAL_SERVER_ERROR,
+      "Control-plane verification is not configured",
+    );
+  }
+
+  const projectSlug = ctx.projectSlug;
+  if (!projectSlug) {
+    throw new ControlPlaneRequestError(400, "Project context is unavailable");
+  }
+
+  const controlPlaneJws = req.headers.get(CONTROL_PLANE_JWS_HEADER);
+  if (!controlPlaneJws) {
+    throw new ControlPlaneRequestError(401, "Missing control-plane signature");
+  }
+
+  try {
+    return await verifyControlPlaneJws(controlPlaneJws, rawBody, {
+      audience: projectSlug,
+      expectedProjectId: ctx.projectId,
+      expectedSubject: options.expectedSubject,
+      expectedSurface: options.expectedSurface,
+      publicKeyPem,
+      maxAgeSeconds: MAX_CONTROL_PLANE_SIGNATURE_AGE_SECONDS,
+    });
+  } catch {
+    throw new ControlPlaneRequestError(401, "Invalid control-plane signature");
+  }
+}

--- a/src/internal-agents/control-plane-auth.ts
+++ b/src/internal-agents/control-plane-auth.ts
@@ -1,9 +1,11 @@
 import { verifyControlPlaneJws } from "#veryfront/channels/control-plane.ts";
 import type { HandlerContext } from "#veryfront/types";
+import { serverLogger } from "#veryfront/utils";
 import { HTTP_INTERNAL_SERVER_ERROR } from "#veryfront/utils/constants/index.ts";
 
 const CONTROL_PLANE_JWS_HEADER = "x-veryfront-control-plane-jws";
 const MAX_CONTROL_PLANE_SIGNATURE_AGE_SECONDS = 60;
+const logger = serverLogger.component("internal-agents-auth");
 
 export class ControlPlaneRequestError extends Error {
   readonly status: number;
@@ -51,7 +53,13 @@ export async function verifyControlPlaneRequest(
       publicKeyPem,
       maxAgeSeconds: MAX_CONTROL_PLANE_SIGNATURE_AGE_SECONDS,
     });
-  } catch {
+  } catch (error) {
+    logger.warn("Invalid control-plane signature", {
+      error,
+      projectSlug,
+      expectedSubject: options.expectedSubject,
+      expectedSurface: options.expectedSurface,
+    });
     throw new ControlPlaneRequestError(401, "Invalid control-plane signature");
   }
 }

--- a/src/internal-agents/control-plane-auth.ts
+++ b/src/internal-agents/control-plane-auth.ts
@@ -54,12 +54,28 @@ export async function verifyControlPlaneRequest(
       maxAgeSeconds: MAX_CONTROL_PLANE_SIGNATURE_AGE_SECONDS,
     });
   } catch (error) {
-    logger.warn("Invalid control-plane signature", {
+    const isAuthError = error instanceof Error && (
+      error.message.includes("Control-plane") ||
+      error.message.includes("Unsupported")
+    );
+
+    if (isAuthError) {
+      logger.warn("Invalid control-plane signature", {
+        error,
+        projectSlug,
+        expectedSubject: options.expectedSubject,
+        expectedSurface: options.expectedSurface,
+      });
+      throw new ControlPlaneRequestError(401, "Invalid control-plane signature");
+    }
+
+    logger.error("Unexpected error during control-plane verification", {
       error,
       projectSlug,
-      expectedSubject: options.expectedSubject,
-      expectedSurface: options.expectedSurface,
     });
-    throw new ControlPlaneRequestError(401, "Invalid control-plane signature");
+    throw new ControlPlaneRequestError(
+      HTTP_INTERNAL_SERVER_ERROR,
+      "Internal error during request verification",
+    );
   }
 }

--- a/src/internal-agents/request-body.ts
+++ b/src/internal-agents/request-body.ts
@@ -1,0 +1,41 @@
+import { VeryfrontError } from "#veryfront/errors/types.ts";
+import { readBodyWithLimit } from "#veryfront/security/index.ts";
+import {
+  DEFAULT_MAX_BODY_SIZE_BYTES,
+  HTTP_PAYLOAD_TOO_LARGE,
+} from "#veryfront/utils/constants/index.ts";
+
+export const INTERNAL_AGENT_STREAM_MAX_BODY_BYTES = DEFAULT_MAX_BODY_SIZE_BYTES;
+export const INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES = 128 * 1024;
+
+export class InternalAgentRequestBodyTooLargeError extends Error {
+  readonly status = HTTP_PAYLOAD_TOO_LARGE;
+
+  constructor(message = "Payload too large") {
+    super(message);
+    this.name = "InternalAgentRequestBodyTooLargeError";
+  }
+}
+
+export async function readInternalAgentRequestBody(
+  request: Request,
+  maxBodyBytes = INTERNAL_AGENT_STREAM_MAX_BODY_BYTES,
+): Promise<string> {
+  if (!request.body) {
+    return "";
+  }
+
+  try {
+    return await readBodyWithLimit(request, maxBodyBytes);
+  } catch (error) {
+    if (
+      error instanceof VeryfrontError &&
+      error.slug === "input-validation-failed" &&
+      error.detail === "Request body exceeds size limit"
+    ) {
+      throw new InternalAgentRequestBodyTooLargeError();
+    }
+
+    throw error;
+  }
+}

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -218,6 +218,7 @@ export async function createRuntimeAgentStreamResponse(
   let completedResponse: AgentResponse | null = null;
   const runtimeMessages = normalizeRuntimeMessages(input.messages);
   let runtimeStream: ReadableStream<Uint8Array>;
+  let clientAttached = true;
   try {
     runtimeStream = await runtime.stream(
       runtimeMessages,
@@ -246,6 +247,19 @@ export async function createRuntimeAgentStreamResponse(
       let remainder = "";
       let aborted = false;
 
+      const enqueueIfAttached = (event: string, payload: Record<string, unknown>) => {
+        const encodedEvent = formatAgUiEvent(event, payload);
+        if (!clientAttached) {
+          return;
+        }
+
+        try {
+          controller.enqueue(encodedEvent);
+        } catch {
+          clientAttached = false;
+        }
+      };
+
       const throwIfAborted = () => {
         if (aborted || abortSignal.aborted) {
           throw new AgentRunCancelledError();
@@ -258,13 +272,11 @@ export async function createRuntimeAgentStreamResponse(
       };
 
       abortSignal.addEventListener("abort", abortHandler, { once: true });
-      controller.enqueue(
-        formatAgUiEvent("RunStarted", {
-          runId: input.runId,
-          threadId: input.threadId,
-          agentId: input.agentId,
-        }),
-      );
+      enqueueIfAttached("RunStarted", {
+        runId: input.runId,
+        threadId: input.threadId,
+        agentId: input.agentId,
+      });
 
       try {
         while (true) {
@@ -283,7 +295,7 @@ export async function createRuntimeAgentStreamResponse(
 
           for (const event of parsed.events) {
             for (const mappedEvent of mapRuntimeEventToAgUi(state, event)) {
-              controller.enqueue(formatAgUiEvent(mappedEvent.event, mappedEvent.payload));
+              enqueueIfAttached(mappedEvent.event, mappedEvent.payload);
             }
           }
         }
@@ -293,37 +305,40 @@ export async function createRuntimeAgentStreamResponse(
         const trailingEvents = parseSseJsonEvents(`${remainder}\n\n`);
         for (const event of trailingEvents.events) {
           for (const mappedEvent of mapRuntimeEventToAgUi(state, event)) {
-            controller.enqueue(formatAgUiEvent(mappedEvent.event, mappedEvent.payload));
+            enqueueIfAttached(mappedEvent.event, mappedEvent.payload);
           }
         }
 
         throwIfAborted();
 
         for (const mappedEvent of finalizeRunEvents(state, completedResponse)) {
-          controller.enqueue(formatAgUiEvent(mappedEvent.event, mappedEvent.payload));
+          enqueueIfAttached(mappedEvent.event, mappedEvent.payload);
         }
         deps.sessionManager.completeRun(input.runId);
       } catch (error) {
         if (error instanceof AgentRunCancelledError) {
           deps.sessionManager.cancelRun(input.runId);
-          controller.enqueue(formatAgUiEvent("RunError", {
+          enqueueIfAttached("RunError", {
             code: "CANCELLED",
             message: error.message,
-          }));
+          });
         } else {
           deps.sessionManager.failRun(input.runId);
-          controller.enqueue(formatAgUiEvent("RunError", {
+          enqueueIfAttached("RunError", {
             code: "RUNTIME_ERROR",
             message: error instanceof Error ? error.message : String(error),
-          }));
+          });
         }
       } finally {
         abortSignal.removeEventListener("abort", abortHandler);
-        controller.close();
+        if (clientAttached) {
+          controller.close();
+        }
       }
     },
     cancel() {
-      deps.sessionManager.cancelRun(input.runId);
+      clientAttached = false;
+      return Promise.resolve();
     },
   });
 

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -1,0 +1,328 @@
+import {
+  type Agent,
+  type AgentMessage as Message,
+  type AgentResponse,
+  AgentRuntime,
+} from "#veryfront/agent";
+import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
+import { type Tool, toolRegistry } from "#veryfront/tool";
+import { z } from "zod";
+import {
+  createStreamTransformState,
+  finalizeRunEvents,
+  formatAgUiEvent,
+  mapRuntimeEventToAgUi,
+  parseSseJsonEvents,
+} from "./ag-ui-sse.ts";
+import { AgentRunCancelledError, type AgentRunSessionManager } from "./session-manager.ts";
+import type { RuntimeRunAgentInput } from "./schema.ts";
+
+const anyObjectSchema = z.record(z.unknown());
+
+export interface RuntimeAgentStreamExecutionDeps {
+  sessionManager: AgentRunSessionManager;
+  createRuntime?: (
+    agent: Agent,
+    mergedTools: Agent["config"]["tools"],
+  ) => {
+    stream: (
+      messages: Message[],
+      context?: Record<string, unknown>,
+      callbacks?: {
+        onFinish?: (response: AgentResponse) => void;
+      },
+    ) => Promise<ReadableStream<Uint8Array>>;
+  };
+}
+
+function createInjectedStudioTool(
+  runId: string,
+  toolName: string,
+  description: string | undefined,
+  parameters: Record<string, unknown> | undefined,
+  sessionManager: AgentRunSessionManager,
+): Tool {
+  return {
+    id: toolName,
+    type: "function",
+    description: description ?? toolName,
+    inputSchema: anyObjectSchema,
+    inputSchemaJson: (parameters ??
+      { type: "object", properties: {}, additionalProperties: true }) as Tool["inputSchemaJson"],
+    execute: async (_input, context) => {
+      const toolCallId = typeof context?.toolCallId === "string" ? context.toolCallId : null;
+      if (!toolCallId) {
+        throw new Error(`Missing toolCallId for injected tool "${toolName}"`);
+      }
+
+      const waitResult = await sessionManager.waitForToolResult(runId, toolCallId);
+      if (waitResult.isError) {
+        throw new Error(
+          typeof waitResult.result === "string"
+            ? waitResult.result
+            : JSON.stringify(waitResult.result),
+        );
+      }
+      return waitResult.result;
+    },
+  };
+}
+
+function buildMergedTools(
+  agent: Agent,
+  input: RuntimeRunAgentInput,
+  sessionManager: AgentRunSessionManager,
+) {
+  const injectedTools = Object.fromEntries(
+    input.tools.map((tool) => [
+      tool.name,
+      createInjectedStudioTool(
+        input.runId,
+        tool.name,
+        tool.description,
+        tool.parameters,
+        sessionManager,
+      ),
+    ]),
+  );
+
+  if (!agent.config.tools) {
+    return Object.keys(injectedTools).length ? injectedTools : undefined;
+  }
+
+  if (agent.config.tools === true) {
+    const merged: Record<string, Tool | boolean> = {};
+    for (const [toolId] of toolRegistry.getAll()) {
+      if (!agent.config.skills && SKILL_TOOL_IDS.has(toolId)) {
+        continue;
+      }
+      merged[toolId] = true;
+    }
+    return { ...merged, ...injectedTools };
+  }
+
+  return { ...agent.config.tools, ...injectedTools };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeToolArgs(part: Record<string, unknown>): Record<string, unknown> {
+  if (isRecord(part.args)) {
+    return part.args;
+  }
+
+  if (isRecord(part.input)) {
+    return part.input;
+  }
+
+  return {};
+}
+
+function normalizeMessagePart(part: Record<string, unknown>): Message["parts"][number] | null {
+  if (part.type === "text" && typeof part.text === "string") {
+    return { type: "text", text: part.text };
+  }
+
+  if (
+    part.type === "tool_call" &&
+    typeof part.id === "string" &&
+    typeof part.name === "string"
+  ) {
+    return {
+      type: `tool-${part.name}`,
+      toolCallId: part.id,
+      toolName: part.name,
+      args: normalizeToolArgs(part),
+    };
+  }
+
+  if (
+    part.type === "tool-call" &&
+    typeof part.toolCallId === "string" &&
+    typeof part.toolName === "string"
+  ) {
+    return {
+      type: "tool-call",
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      args: normalizeToolArgs(part),
+    };
+  }
+
+  if (
+    typeof part.type === "string" &&
+    part.type.startsWith("tool-") &&
+    part.type !== "tool-result" &&
+    typeof part.toolCallId === "string" &&
+    typeof part.toolName === "string"
+  ) {
+    return {
+      type: part.type,
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      args: normalizeToolArgs(part),
+    };
+  }
+
+  if (part.type === "tool_result" && typeof part.tool_call_id === "string") {
+    return {
+      type: "tool-result",
+      toolCallId: part.tool_call_id,
+      toolName: typeof part.tool_name === "string" ? part.tool_name : "unknown",
+      result: "output" in part ? part.output : undefined,
+    };
+  }
+
+  if (part.type === "tool-result" && typeof part.toolCallId === "string") {
+    return {
+      type: "tool-result",
+      toolCallId: part.toolCallId,
+      toolName: typeof part.toolName === "string" ? part.toolName : "unknown",
+      result: "result" in part ? part.result : undefined,
+    };
+  }
+
+  return null;
+}
+
+function normalizeRuntimeMessages(messages: RuntimeRunAgentInput["messages"]): Message[] {
+  return messages.map((message) => ({
+    id: message.id,
+    role: message.role,
+    parts: message.parts
+      .map((part) => isRecord(part) ? normalizeMessagePart(part) : null)
+      .filter((part): part is Message["parts"][number] => part !== null),
+    ...(message.createdAt ? { timestamp: Date.parse(message.createdAt) || undefined } : {}),
+    ...(message.metadata ? { metadata: message.metadata } : {}),
+  }));
+}
+
+export async function createRuntimeAgentStreamResponse(
+  input: RuntimeRunAgentInput,
+  agent: Agent,
+  deps: RuntimeAgentStreamExecutionDeps,
+): Promise<Response> {
+  const abortSignal = deps.sessionManager.startRun({
+    runId: input.runId,
+    threadId: input.threadId,
+  });
+
+  const mergedTools = buildMergedTools(agent, input, deps.sessionManager);
+  const runtime = deps.createRuntime?.(agent, mergedTools) ?? new AgentRuntime(agent.id, {
+    ...agent.config,
+    tools: mergedTools,
+  });
+
+  let completedResponse: AgentResponse | null = null;
+  const runtimeMessages = normalizeRuntimeMessages(input.messages);
+  let runtimeStream: ReadableStream<Uint8Array>;
+  try {
+    runtimeStream = await runtime.stream(
+      runtimeMessages,
+      {
+        threadId: input.threadId,
+        runId: input.runId,
+        context: input.context,
+        forwardedProps: input.forwardedProps,
+      },
+      {
+        onFinish: (response) => {
+          completedResponse = response;
+        },
+      },
+    );
+  } catch (error) {
+    deps.sessionManager.failRun(input.runId);
+    throw error;
+  }
+
+  const response = new ReadableStream<Uint8Array>({
+    start: async (controller) => {
+      const state = createStreamTransformState();
+      const reader = runtimeStream.getReader();
+      const decoder = new TextDecoder();
+      let remainder = "";
+      let aborted = false;
+
+      const abortHandler = () => {
+        aborted = true;
+        reader.cancel(new AgentRunCancelledError()).catch(() => {});
+      };
+
+      abortSignal.addEventListener("abort", abortHandler, { once: true });
+      controller.enqueue(
+        formatAgUiEvent("RunStarted", {
+          runId: input.runId,
+          threadId: input.threadId,
+          agentId: input.agentId,
+        }),
+      );
+
+      try {
+        while (true) {
+          if (aborted) {
+            throw new AgentRunCancelledError();
+          }
+
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+
+          remainder += decoder.decode(value, { stream: true });
+          const parsed = parseSseJsonEvents(remainder);
+          remainder = parsed.remainder;
+
+          for (const event of parsed.events) {
+            for (const mappedEvent of mapRuntimeEventToAgUi(state, event)) {
+              controller.enqueue(formatAgUiEvent(mappedEvent.event, mappedEvent.payload));
+            }
+          }
+        }
+
+        const trailingEvents = parseSseJsonEvents(`${remainder}\n\n`);
+        for (const event of trailingEvents.events) {
+          for (const mappedEvent of mapRuntimeEventToAgUi(state, event)) {
+            controller.enqueue(formatAgUiEvent(mappedEvent.event, mappedEvent.payload));
+          }
+        }
+
+        for (const mappedEvent of finalizeRunEvents(state, completedResponse)) {
+          controller.enqueue(formatAgUiEvent(mappedEvent.event, mappedEvent.payload));
+        }
+        deps.sessionManager.completeRun(input.runId);
+      } catch (error) {
+        if (error instanceof AgentRunCancelledError) {
+          deps.sessionManager.cancelRun(input.runId);
+          controller.enqueue(formatAgUiEvent("RunError", {
+            code: "CANCELLED",
+            message: error.message,
+          }));
+        } else {
+          deps.sessionManager.failRun(input.runId);
+          controller.enqueue(formatAgUiEvent("RunError", {
+            code: "RUNTIME_ERROR",
+            message: error instanceof Error ? error.message : String(error),
+          }));
+        }
+      } finally {
+        abortSignal.removeEventListener("abort", abortHandler);
+        controller.close();
+      }
+    },
+    cancel() {
+      deps.sessionManager.cancelRun(input.runId);
+    },
+  });
+
+  return new Response(response, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -246,6 +246,12 @@ export async function createRuntimeAgentStreamResponse(
       let remainder = "";
       let aborted = false;
 
+      const throwIfAborted = () => {
+        if (aborted || abortSignal.aborted) {
+          throw new AgentRunCancelledError();
+        }
+      };
+
       const abortHandler = () => {
         aborted = true;
         reader.cancel(new AgentRunCancelledError()).catch(() => {});
@@ -262,11 +268,11 @@ export async function createRuntimeAgentStreamResponse(
 
       try {
         while (true) {
-          if (aborted) {
-            throw new AgentRunCancelledError();
-          }
+          throwIfAborted();
 
           const { done, value } = await reader.read();
+          throwIfAborted();
+
           if (done) {
             break;
           }
@@ -282,12 +288,16 @@ export async function createRuntimeAgentStreamResponse(
           }
         }
 
+        throwIfAborted();
+
         const trailingEvents = parseSseJsonEvents(`${remainder}\n\n`);
         for (const event of trailingEvents.events) {
           for (const mappedEvent of mapRuntimeEventToAgUi(state, event)) {
             controller.enqueue(formatAgUiEvent(mappedEvent.event, mappedEvent.payload));
           }
         }
+
+        throwIfAborted();
 
         for (const mappedEvent of finalizeRunEvents(state, completedResponse)) {
           controller.enqueue(formatAgUiEvent(mappedEvent.event, mappedEvent.payload));

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -131,7 +131,7 @@ function normalizeMessagePart(part: Record<string, unknown>): Message["parts"][n
     typeof part.name === "string"
   ) {
     return {
-      type: `tool-${part.name}`,
+      type: "tool-call",
       toolCallId: part.id,
       toolName: part.name,
       args: normalizeToolArgs(part),

--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -6,6 +6,7 @@ const MAX_CONTEXT_ITEM_BYTES = 16_384;
 const MAX_CONTEXT_TOTAL_BYTES = 65_536;
 const MAX_FORWARDED_PROPS_BYTES = 65_536;
 const MAX_TOOL_RESULT_BYTES = 65_536;
+const MAX_RUNTIME_MESSAGES = 100;
 
 const encoder = new TextEncoder();
 
@@ -71,7 +72,7 @@ export const RuntimeRunAgentInputSchema = z.object({
       metadata: z.record(z.unknown()).optional(),
       createdAt: z.string().optional(),
     }),
-  ),
+  ).max(MAX_RUNTIME_MESSAGES),
   tools: z.array(RuntimeInjectedToolSchema).max(50).default([]),
   context: z.array(RuntimeContextItemSchema).max(10).default([]).refine(
     (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_TOTAL_BYTES),

--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+
+const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const MAX_TOOL_PARAMETERS_BYTES = 16_384;
+const MAX_CONTEXT_ITEM_BYTES = 16_384;
+const MAX_CONTEXT_TOTAL_BYTES = 65_536;
+const MAX_FORWARDED_PROPS_BYTES = 65_536;
+const MAX_TOOL_RESULT_BYTES = 65_536;
+
+const encoder = new TextEncoder();
+
+function isWithinJsonSizeLimit(value: unknown, maxBytes: number): boolean {
+  try {
+    return encoder.encode(JSON.stringify(value)).byteLength <= maxBytes;
+  } catch {
+    return false;
+  }
+}
+
+export const RunIdSchema = z.string().min(1).max(128).regex(AGENT_ID_PATTERN);
+
+export const AgentIdSchema = z.string().min(1).max(128).regex(AGENT_ID_PATTERN);
+
+export const StudioToolNameSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^studio_[a-zA-Z0-9_]+$/, "Tool names must use the studio_ prefix");
+
+export const RuntimeInjectedToolSchema = z.object({
+  name: StudioToolNameSchema,
+  description: z.string().max(1024).optional(),
+  parameters: z.record(z.unknown()).optional().refine(
+    (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_TOOL_PARAMETERS_BYTES),
+    { message: "Tool parameters must be less than 16 KB" },
+  ),
+});
+
+export const RuntimeContextItemSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("text"),
+    title: z.string().max(256).optional(),
+    text: z.string().max(MAX_CONTEXT_ITEM_BYTES),
+  }),
+  z.object({
+    type: z.literal("json"),
+    title: z.string().max(256).optional(),
+    data: z.record(z.unknown()).refine(
+      (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_ITEM_BYTES),
+      { message: "JSON context item must be less than 16 KB" },
+    ),
+  }),
+  z.object({
+    type: z.literal("resource"),
+    title: z.string().max(256).optional(),
+    uri: z.string().max(2048),
+    mimeType: z.string().max(256).optional(),
+    text: z.string().max(MAX_CONTEXT_ITEM_BYTES).optional(),
+  }),
+]);
+
+export const RuntimeRunAgentInputSchema = z.object({
+  agentId: AgentIdSchema,
+  threadId: z.string().uuid(),
+  runId: RunIdSchema,
+  messages: z.array(
+    z.object({
+      id: z.string().min(1),
+      role: z.enum(["user", "assistant", "system", "tool"]),
+      parts: z.array(z.object({ type: z.string().min(1) }).passthrough()).default([]),
+      metadata: z.record(z.unknown()).optional(),
+      createdAt: z.string().optional(),
+    }),
+  ),
+  tools: z.array(RuntimeInjectedToolSchema).max(50).default([]),
+  context: z.array(RuntimeContextItemSchema).max(10).default([]).refine(
+    (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_TOTAL_BYTES),
+    { message: "context must be less than 64 KB total" },
+  ),
+  forwardedProps: z.record(z.unknown()).optional().refine(
+    (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_FORWARDED_PROPS_BYTES),
+    { message: "forwardedProps must be less than 64 KB" },
+  ),
+});
+
+export const ResumeSignalSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("tool_result"),
+    toolCallId: z.string().min(1).max(128),
+    result: z.unknown().refine(
+      (value) => isWithinJsonSizeLimit(value, MAX_TOOL_RESULT_BYTES),
+      { message: "Tool result must be less than 64 KB" },
+    ),
+    isError: z.boolean().optional().default(false),
+  }),
+]);
+
+export type RuntimeInjectedTool = z.infer<typeof RuntimeInjectedToolSchema>;
+export type RuntimeContextItem = z.infer<typeof RuntimeContextItemSchema>;
+export type RuntimeRunAgentInput = z.infer<typeof RuntimeRunAgentInputSchema>;
+export type ResumeSignal = z.infer<typeof ResumeSignalSchema>;

--- a/src/internal-agents/session-manager.test.ts
+++ b/src/internal-agents/session-manager.test.ts
@@ -94,4 +94,23 @@ describe("internal-agents/session-manager", () => {
     );
     assertEquals(sessionManager.getRunStatus("run_1"), null);
   });
+
+  it("evicts stale running sessions after the configured session TTL", () => {
+    const timerCallbacks: Array<() => void> = [];
+    const sessionManager = new AgentRunSessionManager({
+      sessionTtlMs: 1,
+      setTimeoutFn: ((callback: () => void) => {
+        timerCallbacks.push(callback);
+        return timerCallbacks.length as unknown as number;
+      }) as typeof setTimeout,
+      clearTimeoutFn: (() => {}) as typeof clearTimeout,
+    });
+
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    assertEquals(sessionManager.getRunStatus("run_1"), "running");
+
+    timerCallbacks[0]?.();
+
+    assertEquals(sessionManager.getRunStatus("run_1"), null);
+  });
 });

--- a/src/internal-agents/session-manager.test.ts
+++ b/src/internal-agents/session-manager.test.ts
@@ -1,0 +1,71 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  AgentRunCancelledError,
+  AgentRunSessionManager,
+  ToolResultConflictError,
+  ToolResultNotWaitingError,
+} from "./session-manager.ts";
+
+describe("internal-agents/session-manager", () => {
+  it("accepts duplicate tool results and rejects conflicting ones", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    const pending = sessionManager.waitForToolResult("run_1", "tool_1");
+
+    const first = sessionManager.submitToolResult("run_1", {
+      toolCallId: "tool_1",
+      result: { ok: true },
+    });
+    assertEquals(first, { accepted: true });
+    assertEquals(await pending, { result: { ok: true }, isError: false });
+
+    const duplicate = sessionManager.submitToolResult("run_1", {
+      toolCallId: "tool_1",
+      result: { ok: true },
+    });
+    assertEquals(duplicate, { accepted: true, duplicate: true });
+
+    await assertRejects(
+      async () => {
+        sessionManager.submitToolResult("run_1", {
+          toolCallId: "tool_1",
+          result: { ok: false },
+        });
+      },
+      ToolResultConflictError,
+    );
+  });
+
+  it("rejects submissions for tool calls that are not currently waiting", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    await assertRejects(
+      async () => {
+        sessionManager.submitToolResult("run_1", {
+          toolCallId: "tool_1",
+          result: { ok: true },
+        });
+      },
+      ToolResultNotWaitingError,
+    );
+  });
+
+  it("cancels waiting runs and rejects the parked tool promise", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    const pending = sessionManager.waitForToolResult("run_1", "tool_1");
+    assertEquals(sessionManager.cancelRun("run_1"), true);
+
+    await assertRejects(
+      async () => {
+        await pending;
+      },
+      AgentRunCancelledError,
+    );
+    assertEquals(sessionManager.getRunStatus("run_1"), null);
+  });
+});

--- a/src/internal-agents/session-manager.test.ts
+++ b/src/internal-agents/session-manager.test.ts
@@ -68,4 +68,30 @@ describe("internal-agents/session-manager", () => {
     );
     assertEquals(sessionManager.getRunStatus("run_1"), null);
   });
+
+  it("expires waiting runs after the configured TTL", async () => {
+    const timerCallbacks: Array<() => void> = [];
+    const sessionManager = new AgentRunSessionManager({
+      waitingForToolTtlMs: 1,
+      setTimeoutFn: ((callback: () => void) => {
+        timerCallbacks.push(callback);
+        return timerCallbacks.length as unknown as number;
+      }) as typeof setTimeout,
+      clearTimeoutFn: (() => {}) as typeof clearTimeout,
+    });
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    const pending = sessionManager.waitForToolResult("run_1", "tool_1");
+    assertEquals(sessionManager.getRunStatus("run_1"), "waiting");
+
+    timerCallbacks[0]?.();
+
+    await assertRejects(
+      async () => {
+        await pending;
+      },
+      AgentRunCancelledError,
+    );
+    assertEquals(sessionManager.getRunStatus("run_1"), null);
+  });
 });

--- a/src/internal-agents/session-manager.ts
+++ b/src/internal-agents/session-manager.ts
@@ -54,6 +54,7 @@ export class ToolResultConflictError extends Error {
 }
 
 const DEFAULT_WAITING_FOR_TOOL_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_SESSION_TTL_MS = 15 * 60 * 1000;
 
 type SessionStatus = "running" | "waiting" | "completed" | "cancelled" | "failed";
 
@@ -78,6 +79,7 @@ interface AgentRunSession {
   waitingTool: WaitingToolState | null;
   submittedResults: Map<string, SubmittedToolResult>;
   waitingTimeoutId: number | null;
+  sessionTimeoutId: number | null;
 }
 
 export interface SubmitToolResultOutcome {
@@ -91,6 +93,7 @@ export class AgentRunSessionManager {
   constructor(
     private readonly options: {
       waitingForToolTtlMs?: number;
+      sessionTtlMs?: number | null;
       setTimeoutFn?: typeof setTimeout;
       clearTimeoutFn?: typeof clearTimeout;
     } = {},
@@ -98,6 +101,10 @@ export class AgentRunSessionManager {
 
   private get waitingForToolTtlMs(): number {
     return this.options.waitingForToolTtlMs ?? DEFAULT_WAITING_FOR_TOOL_TTL_MS;
+  }
+
+  private get sessionTtlMs(): number | null {
+    return this.options.sessionTtlMs ?? null;
   }
 
   private get setTimeoutFn(): typeof setTimeout {
@@ -117,11 +124,39 @@ export class AgentRunSessionManager {
     session.waitingTimeoutId = null;
   }
 
+  private clearSessionTimeout(session: AgentRunSession): void {
+    if (session.sessionTimeoutId === null) {
+      return;
+    }
+
+    this.clearTimeoutFn(session.sessionTimeoutId);
+    session.sessionTimeoutId = null;
+  }
+
+  private scheduleSessionTimeout(session: AgentRunSession): void {
+    if (this.sessionTtlMs === null) {
+      return;
+    }
+
+    this.clearSessionTimeout(session);
+    session.sessionTimeoutId = this.setTimeoutFn(() => {
+      this.cancelRun(session.runId);
+    }, this.sessionTtlMs) as unknown as number;
+  }
+
   private scheduleWaitingTimeout(session: AgentRunSession): void {
     this.clearWaitingTimeout(session);
     session.waitingTimeoutId = this.setTimeoutFn(() => {
       this.cancelRun(session.runId);
     }, this.waitingForToolTtlMs) as unknown as number;
+  }
+
+  private touchSession(session: AgentRunSession): void {
+    if (
+      session.status === "running" || session.status === "waiting"
+    ) {
+      this.scheduleSessionTimeout(session);
+    }
   }
 
   startRun(input: { runId: string; threadId: string }): AbortSignal {
@@ -138,9 +173,11 @@ export class AgentRunSessionManager {
       waitingTool: null,
       submittedResults: new Map(),
       waitingTimeoutId: null,
+      sessionTimeoutId: null,
     };
 
     this.sessions.set(input.runId, session);
+    this.touchSession(session);
     return session.abortController.signal;
   }
 
@@ -160,6 +197,7 @@ export class AgentRunSessionManager {
     const existingResult = session.submittedResults.get(toolCallId);
     if (existingResult) {
       session.status = "running";
+      this.touchSession(session);
       return { result: existingResult.result, isError: existingResult.isError };
     }
 
@@ -169,6 +207,7 @@ export class AgentRunSessionManager {
 
     session.status = "waiting";
     this.scheduleWaitingTimeout(session);
+    this.touchSession(session);
 
     return await new Promise<{ result: unknown; isError: boolean }>((resolve, reject) => {
       const abortHandler = () => {
@@ -186,6 +225,7 @@ export class AgentRunSessionManager {
           this.clearWaitingTimeout(session);
           session.waitingTool = null;
           session.status = "running";
+          this.touchSession(session);
           resolve({ result: value.result, isError: value.isError });
         },
         reject: (reason) => {
@@ -235,6 +275,7 @@ export class AgentRunSessionManager {
     }
 
     session.submittedResults.set(input.toolCallId, normalized);
+    this.touchSession(session);
     session.waitingTool.resolve(normalized);
     return { accepted: true };
   }
@@ -254,6 +295,7 @@ export class AgentRunSessionManager {
 
     session.status = "cancelled";
     this.clearWaitingTimeout(session);
+    this.clearSessionTimeout(session);
     session.abortController.abort(new AgentRunCancelledError());
     session.waitingTool?.reject(new AgentRunCancelledError());
     session.waitingTool = null;
@@ -266,6 +308,7 @@ export class AgentRunSessionManager {
     if (!session) return;
     session.status = "completed";
     this.clearWaitingTimeout(session);
+    this.clearSessionTimeout(session);
     session.waitingTool = null;
     this.sessions.delete(runId);
   }
@@ -275,6 +318,7 @@ export class AgentRunSessionManager {
     if (!session) return;
     session.status = "failed";
     this.clearWaitingTimeout(session);
+    this.clearSessionTimeout(session);
     session.waitingTool = null;
     this.sessions.delete(runId);
   }
@@ -284,8 +328,14 @@ export class AgentRunSessionManager {
   }
 
   reset(): void {
+    for (const session of this.sessions.values()) {
+      this.clearWaitingTimeout(session);
+      this.clearSessionTimeout(session);
+    }
     this.sessions.clear();
   }
 }
 
-export const agentRunSessionManager = new AgentRunSessionManager();
+export const agentRunSessionManager = new AgentRunSessionManager({
+  sessionTtlMs: DEFAULT_SESSION_TTL_MS,
+});

--- a/src/internal-agents/session-manager.ts
+++ b/src/internal-agents/session-manager.ts
@@ -1,0 +1,244 @@
+function stableJsonStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJsonStringify(item)).join(",")}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, item]) => `${JSON.stringify(key)}:${stableJsonStringify(item)}`);
+
+  return `{${entries.join(",")}}`;
+}
+
+function createToolResultKey(result: unknown, isError: boolean): string {
+  return `${isError ? "1" : "0"}:${stableJsonStringify(result)}`;
+}
+
+export class AgentRunCancelledError extends Error {
+  constructor(message = "Run cancelled") {
+    super(message);
+    this.name = "AgentRunCancelledError";
+  }
+}
+
+export class AgentRunAlreadyExistsError extends Error {
+  constructor(runId: string) {
+    super(`Run "${runId}" is already active`);
+    this.name = "AgentRunAlreadyExistsError";
+  }
+}
+
+export class RunNotActiveError extends Error {
+  constructor(runId: string) {
+    super(`Run "${runId}" is not active`);
+    this.name = "RunNotActiveError";
+  }
+}
+
+export class ToolResultNotWaitingError extends Error {
+  constructor(runId: string, toolCallId: string) {
+    super(`Run "${runId}" is not waiting for tool call "${toolCallId}"`);
+    this.name = "ToolResultNotWaitingError";
+  }
+}
+
+export class ToolResultConflictError extends Error {
+  constructor(runId: string, toolCallId: string) {
+    super(`Conflicting tool result for run "${runId}" and tool call "${toolCallId}"`);
+    this.name = "ToolResultConflictError";
+  }
+}
+
+type SessionStatus = "running" | "waiting" | "completed" | "cancelled" | "failed";
+
+interface SubmittedToolResult {
+  toolCallId: string;
+  result: unknown;
+  isError: boolean;
+  key: string;
+}
+
+interface WaitingToolState {
+  toolCallId: string;
+  resolve: (value: SubmittedToolResult) => void;
+  reject: (reason?: unknown) => void;
+}
+
+interface AgentRunSession {
+  runId: string;
+  threadId: string;
+  status: SessionStatus;
+  abortController: AbortController;
+  waitingTool: WaitingToolState | null;
+  submittedResults: Map<string, SubmittedToolResult>;
+}
+
+export interface SubmitToolResultOutcome {
+  accepted: true;
+  duplicate?: true;
+}
+
+export class AgentRunSessionManager {
+  private readonly sessions = new Map<string, AgentRunSession>();
+
+  startRun(input: { runId: string; threadId: string }): AbortSignal {
+    const existing = this.sessions.get(input.runId);
+    if (existing && (existing.status === "running" || existing.status === "waiting")) {
+      throw new AgentRunAlreadyExistsError(input.runId);
+    }
+
+    const session: AgentRunSession = {
+      runId: input.runId,
+      threadId: input.threadId,
+      status: "running",
+      abortController: new AbortController(),
+      waitingTool: null,
+      submittedResults: new Map(),
+    };
+
+    this.sessions.set(input.runId, session);
+    return session.abortController.signal;
+  }
+
+  async waitForToolResult(runId: string, toolCallId: string): Promise<{
+    result: unknown;
+    isError: boolean;
+  }> {
+    const session = this.sessions.get(runId);
+    if (!session || session.status === "completed" || session.status === "failed") {
+      throw new RunNotActiveError(runId);
+    }
+
+    if (session.abortController.signal.aborted || session.status === "cancelled") {
+      throw new AgentRunCancelledError();
+    }
+
+    const existingResult = session.submittedResults.get(toolCallId);
+    if (existingResult) {
+      session.status = "running";
+      return { result: existingResult.result, isError: existingResult.isError };
+    }
+
+    if (session.waitingTool && session.waitingTool.toolCallId !== toolCallId) {
+      throw new ToolResultNotWaitingError(runId, toolCallId);
+    }
+
+    session.status = "waiting";
+
+    return await new Promise<{ result: unknown; isError: boolean }>((resolve, reject) => {
+      const abortHandler = () => {
+        session.waitingTool = null;
+        session.status = "cancelled";
+        reject(new AgentRunCancelledError());
+      };
+
+      session.abortController.signal.addEventListener("abort", abortHandler, { once: true });
+      session.waitingTool = {
+        toolCallId,
+        resolve: (value) => {
+          session.abortController.signal.removeEventListener("abort", abortHandler);
+          session.waitingTool = null;
+          session.status = "running";
+          resolve({ result: value.result, isError: value.isError });
+        },
+        reject: (reason) => {
+          session.abortController.signal.removeEventListener("abort", abortHandler);
+          session.waitingTool = null;
+          reject(reason);
+        },
+      };
+    });
+  }
+
+  submitToolResult(
+    runId: string,
+    input: { toolCallId: string; result: unknown; isError?: boolean },
+  ): SubmitToolResultOutcome {
+    const session = this.sessions.get(runId);
+    if (!session) {
+      throw new RunNotActiveError(runId);
+    }
+
+    const normalized: SubmittedToolResult = {
+      toolCallId: input.toolCallId,
+      result: input.result,
+      isError: Boolean(input.isError),
+      key: createToolResultKey(input.result, Boolean(input.isError)),
+    };
+
+    const existingResult = session.submittedResults.get(input.toolCallId);
+    if (existingResult) {
+      if (existingResult.key === normalized.key) {
+        return { accepted: true, duplicate: true };
+      }
+
+      throw new ToolResultConflictError(runId, input.toolCallId);
+    }
+
+    if (
+      session.status === "completed" || session.status === "failed" ||
+      session.status === "cancelled"
+    ) {
+      throw new RunNotActiveError(runId);
+    }
+
+    if (!session.waitingTool || session.waitingTool.toolCallId !== input.toolCallId) {
+      throw new ToolResultNotWaitingError(runId, input.toolCallId);
+    }
+
+    session.submittedResults.set(input.toolCallId, normalized);
+    session.waitingTool.resolve(normalized);
+    return { accepted: true };
+  }
+
+  cancelRun(runId: string): boolean {
+    const session = this.sessions.get(runId);
+    if (!session) {
+      return false;
+    }
+
+    if (
+      session.status === "completed" || session.status === "failed" ||
+      session.status === "cancelled"
+    ) {
+      return false;
+    }
+
+    session.status = "cancelled";
+    session.abortController.abort(new AgentRunCancelledError());
+    session.waitingTool?.reject(new AgentRunCancelledError());
+    session.waitingTool = null;
+    this.sessions.delete(runId);
+    return true;
+  }
+
+  completeRun(runId: string): void {
+    const session = this.sessions.get(runId);
+    if (!session) return;
+    session.status = "completed";
+    session.waitingTool = null;
+    this.sessions.delete(runId);
+  }
+
+  failRun(runId: string): void {
+    const session = this.sessions.get(runId);
+    if (!session) return;
+    session.status = "failed";
+    session.waitingTool = null;
+    this.sessions.delete(runId);
+  }
+
+  getRunStatus(runId: string): SessionStatus | null {
+    return this.sessions.get(runId)?.status ?? null;
+  }
+
+  reset(): void {
+    this.sessions.clear();
+  }
+}
+
+export const agentRunSessionManager = new AgentRunSessionManager();

--- a/src/internal-agents/session-manager.ts
+++ b/src/internal-agents/session-manager.ts
@@ -1,15 +1,19 @@
-function stableJsonStringify(value: unknown): string {
+function stableJsonStringify(value: unknown, depth = 0): string {
+  if (depth > 64) {
+    return JSON.stringify(value);
+  }
+
   if (value === null || typeof value !== "object") {
     return JSON.stringify(value);
   }
 
   if (Array.isArray(value)) {
-    return `[${value.map((item) => stableJsonStringify(item)).join(",")}]`;
+    return `[${value.map((item) => stableJsonStringify(item, depth + 1)).join(",")}]`;
   }
 
   const entries = Object.entries(value as Record<string, unknown>)
     .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, item]) => `${JSON.stringify(key)}:${stableJsonStringify(item)}`);
+    .map(([key, item]) => `${JSON.stringify(key)}:${stableJsonStringify(item, depth + 1)}`);
 
   return `{${entries.join(",")}}`;
 }
@@ -55,6 +59,7 @@ export class ToolResultConflictError extends Error {
 
 const DEFAULT_WAITING_FOR_TOOL_TTL_MS = 5 * 60 * 1000;
 const DEFAULT_SESSION_TTL_MS = 15 * 60 * 1000;
+const DEFAULT_MAX_CONCURRENT_SESSIONS = 100;
 
 type SessionStatus = "running" | "waiting" | "completed" | "cancelled" | "failed";
 
@@ -94,6 +99,7 @@ export class AgentRunSessionManager {
     private readonly options: {
       waitingForToolTtlMs?: number;
       sessionTtlMs?: number | null;
+      maxConcurrentSessions?: number;
       setTimeoutFn?: typeof setTimeout;
       clearTimeoutFn?: typeof clearTimeout;
     } = {},
@@ -159,10 +165,20 @@ export class AgentRunSessionManager {
     }
   }
 
+  private get maxConcurrentSessions(): number {
+    return this.options.maxConcurrentSessions ?? DEFAULT_MAX_CONCURRENT_SESSIONS;
+  }
+
   startRun(input: { runId: string; threadId: string }): AbortSignal {
     const existing = this.sessions.get(input.runId);
     if (existing && (existing.status === "running" || existing.status === "waiting")) {
       throw new AgentRunAlreadyExistsError(input.runId);
+    }
+
+    if (this.sessions.size >= this.maxConcurrentSessions) {
+      throw new Error(
+        `Maximum concurrent sessions (${this.maxConcurrentSessions}) reached`,
+      );
     }
 
     const session: AgentRunSession = {

--- a/src/internal-agents/session-manager.ts
+++ b/src/internal-agents/session-manager.ts
@@ -53,6 +53,8 @@ export class ToolResultConflictError extends Error {
   }
 }
 
+const DEFAULT_WAITING_FOR_TOOL_TTL_MS = 5 * 60 * 1000;
+
 type SessionStatus = "running" | "waiting" | "completed" | "cancelled" | "failed";
 
 interface SubmittedToolResult {
@@ -75,6 +77,7 @@ interface AgentRunSession {
   abortController: AbortController;
   waitingTool: WaitingToolState | null;
   submittedResults: Map<string, SubmittedToolResult>;
+  waitingTimeoutId: number | null;
 }
 
 export interface SubmitToolResultOutcome {
@@ -84,6 +87,42 @@ export interface SubmitToolResultOutcome {
 
 export class AgentRunSessionManager {
   private readonly sessions = new Map<string, AgentRunSession>();
+
+  constructor(
+    private readonly options: {
+      waitingForToolTtlMs?: number;
+      setTimeoutFn?: typeof setTimeout;
+      clearTimeoutFn?: typeof clearTimeout;
+    } = {},
+  ) {}
+
+  private get waitingForToolTtlMs(): number {
+    return this.options.waitingForToolTtlMs ?? DEFAULT_WAITING_FOR_TOOL_TTL_MS;
+  }
+
+  private get setTimeoutFn(): typeof setTimeout {
+    return this.options.setTimeoutFn ?? setTimeout;
+  }
+
+  private get clearTimeoutFn(): typeof clearTimeout {
+    return this.options.clearTimeoutFn ?? clearTimeout;
+  }
+
+  private clearWaitingTimeout(session: AgentRunSession): void {
+    if (session.waitingTimeoutId === null) {
+      return;
+    }
+
+    this.clearTimeoutFn(session.waitingTimeoutId);
+    session.waitingTimeoutId = null;
+  }
+
+  private scheduleWaitingTimeout(session: AgentRunSession): void {
+    this.clearWaitingTimeout(session);
+    session.waitingTimeoutId = this.setTimeoutFn(() => {
+      this.cancelRun(session.runId);
+    }, this.waitingForToolTtlMs) as unknown as number;
+  }
 
   startRun(input: { runId: string; threadId: string }): AbortSignal {
     const existing = this.sessions.get(input.runId);
@@ -98,6 +137,7 @@ export class AgentRunSessionManager {
       abortController: new AbortController(),
       waitingTool: null,
       submittedResults: new Map(),
+      waitingTimeoutId: null,
     };
 
     this.sessions.set(input.runId, session);
@@ -128,9 +168,11 @@ export class AgentRunSessionManager {
     }
 
     session.status = "waiting";
+    this.scheduleWaitingTimeout(session);
 
     return await new Promise<{ result: unknown; isError: boolean }>((resolve, reject) => {
       const abortHandler = () => {
+        this.clearWaitingTimeout(session);
         session.waitingTool = null;
         session.status = "cancelled";
         reject(new AgentRunCancelledError());
@@ -141,12 +183,14 @@ export class AgentRunSessionManager {
         toolCallId,
         resolve: (value) => {
           session.abortController.signal.removeEventListener("abort", abortHandler);
+          this.clearWaitingTimeout(session);
           session.waitingTool = null;
           session.status = "running";
           resolve({ result: value.result, isError: value.isError });
         },
         reject: (reason) => {
           session.abortController.signal.removeEventListener("abort", abortHandler);
+          this.clearWaitingTimeout(session);
           session.waitingTool = null;
           reject(reason);
         },
@@ -209,6 +253,7 @@ export class AgentRunSessionManager {
     }
 
     session.status = "cancelled";
+    this.clearWaitingTimeout(session);
     session.abortController.abort(new AgentRunCancelledError());
     session.waitingTool?.reject(new AgentRunCancelledError());
     session.waitingTool = null;
@@ -220,6 +265,7 @@ export class AgentRunSessionManager {
     const session = this.sessions.get(runId);
     if (!session) return;
     session.status = "completed";
+    this.clearWaitingTimeout(session);
     session.waitingTool = null;
     this.sessions.delete(runId);
   }
@@ -228,6 +274,7 @@ export class AgentRunSessionManager {
     const session = this.sessions.get(runId);
     if (!session) return;
     session.status = "failed";
+    this.clearWaitingTimeout(session);
     session.waitingTool = null;
     this.sessions.delete(runId);
   }

--- a/src/internal-agents/session-manager.ts
+++ b/src/internal-agents/session-manager.ts
@@ -101,11 +101,11 @@ export class AgentRunSessionManager {
   }
 
   private get setTimeoutFn(): typeof setTimeout {
-    return this.options.setTimeoutFn ?? setTimeout;
+    return this.options.setTimeoutFn ?? globalThis.setTimeout.bind(globalThis);
   }
 
   private get clearTimeoutFn(): typeof clearTimeout {
-    return this.options.clearTimeoutFn ?? clearTimeout;
+    return this.options.clearTimeoutFn ?? globalThis.clearTimeout.bind(globalThis);
   }
 
   private clearWaitingTimeout(session: AgentRunSession): void {

--- a/src/platform/adapters/runtime/deno/adapter.ts
+++ b/src/platform/adapters/runtime/deno/adapter.ts
@@ -16,7 +16,12 @@ import type {
   WebSocketUpgrade,
 } from "../../base.ts";
 import { serverLogger } from "#veryfront/utils";
-import { getEnvOverlayStorage } from "../../../compat/process.ts";
+import {
+  env as getEnvObject,
+  getEnv,
+  getEnvOverlayStorage,
+  setEnv,
+} from "../../../compat/process.ts";
 import {
   createFileWatcher,
   createWatcherIterator,
@@ -271,22 +276,15 @@ class DenoFileSystemAdapter implements FileSystemAdapter {
 
 class DenoEnvironmentAdapter implements EnvironmentAdapter {
   get(key: string): string | undefined {
-    if (typeof Deno === "undefined" || typeof Deno.env === "undefined") return undefined;
-    return Deno.env.get(key);
+    return getEnv(key);
   }
 
   set(key: string, value: string): void {
-    if (typeof Deno === "undefined" || typeof Deno.env === "undefined") {
-      throw NOT_SUPPORTED.create({
-        detail: "DenoEnvironmentAdapter.set() can only be used in Deno runtime",
-      });
-    }
-    Deno.env.set(key, value);
+    setEnv(key, value);
   }
 
   toObject(): Record<string, string> {
-    if (typeof Deno === "undefined" || typeof Deno.env === "undefined") return {};
-    return Deno.env.toObject();
+    return getEnvObject();
   }
 }
 

--- a/src/platform/adapters/veryfront-api-client.test.ts
+++ b/src/platform/adapters/veryfront-api-client.test.ts
@@ -1,18 +1,7 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { VeryfrontApiClient, VeryfrontError } from "./veryfront-api-client/index.ts";
-
-function withMockFetch<T>(
-  mockFetch: typeof globalThis.fetch,
-  fn: () => Promise<T>,
-): Promise<T> {
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = mockFetch;
-
-  return fn().finally(() => {
-    globalThis.fetch = originalFetch;
-  });
-}
 
 function assertVeryfrontError(error: unknown): VeryfrontError {
   assertEquals(error instanceof VeryfrontError, true);

--- a/src/platform/compat/process.test.ts
+++ b/src/platform/compat/process.test.ts
@@ -93,6 +93,22 @@ describe("Process Compat", () => {
       setEnv(testKey, specialValue);
       assertEquals(getEnv(testKey), specialValue);
     });
+
+    it("keeps direct env readers aligned inside the test overlay", () => {
+      setEnv(testKey, testValue);
+
+      try {
+        assertEquals(getEnv(testKey), testValue);
+        assertEquals(process.env[testKey], testValue);
+        assertEquals(Deno.env.get(testKey), testValue);
+        assertEquals(env()[testKey], testValue);
+      } finally {
+        deleteEnv(testKey);
+      }
+
+      assertEquals(process.env[testKey], undefined);
+      assertEquals(Deno.env.get(testKey), undefined);
+    });
   });
 
   describe("getHostEnv", () => {

--- a/src/platform/compat/process.ts
+++ b/src/platform/compat/process.ts
@@ -56,10 +56,46 @@ export function chdir(directory: string): void {
   throw new Error("chdir() is not supported in this runtime");
 }
 
+type EnvOverlayValue = string | null;
+type EnvOverlayStore = Map<string, EnvOverlayValue>;
+
+function getEnvOverlayStore(): EnvOverlayStore | null {
+  const storage = getEnvOverlayStorage();
+  const store = storage?.getStore();
+  return store instanceof Map ? store as EnvOverlayStore : null;
+}
+
+function getOverlayEnvValue(
+  store: EnvOverlayStore | null,
+  key: string,
+): { hasValue: boolean; value: string | undefined } {
+  if (!store?.has(key)) {
+    return { hasValue: false, value: undefined };
+  }
+
+  const value = store.get(key);
+  return { hasValue: true, value: value ?? undefined };
+}
+
 export function env(): Record<string, string> {
-  if (IS_DENO) return Deno.env.toObject();
-  if (runtimeProcess) return runtimeProcess.env as Record<string, string>;
-  return {};
+  const base = IS_DENO
+    ? Deno.env.toObject()
+    : runtimeProcess
+    ? { ...runtimeProcess.env } as Record<string, string>
+    : {};
+
+  const overlay = getEnvOverlayStore();
+  if (!overlay) return base;
+
+  for (const [key, value] of overlay.entries()) {
+    if (value === null) {
+      delete base[key];
+      continue;
+    }
+    base[key] = value;
+  }
+
+  return base;
 }
 
 /**
@@ -67,6 +103,11 @@ export function env(): Record<string, string> {
  * Use this for framework-owned runtime configuration that should not be shadowed by tenant env.
  */
 export function getHostEnv(key: string): string | undefined {
+  const overlayResult = getOverlayEnvValue(getEnvOverlayStore(), key);
+  if (overlayResult.hasValue) {
+    return overlayResult.value;
+  }
+
   if (IS_DENO) return Deno.env.get(key);
   if (runtimeProcess) return runtimeProcess.env[key];
   return undefined;
@@ -183,6 +224,12 @@ export function getEnvBoolean(
 }
 
 export function setEnv(key: string, value: string): void {
+  const overlay = getEnvOverlayStore();
+  if (overlay) {
+    overlay.set(key, value);
+    return;
+  }
+
   if (IS_DENO) {
     Deno.env.set(key, value);
     return;
@@ -195,6 +242,12 @@ export function setEnv(key: string, value: string): void {
 }
 
 export function deleteEnv(key: string): void {
+  const overlay = getEnvOverlayStore();
+  if (overlay) {
+    overlay.set(key, null);
+    return;
+  }
+
   if (IS_DENO) {
     Deno.env.delete(key);
     return;

--- a/src/server/handlers/request/agent-run-cancel.handler.test.ts
+++ b/src/server/handlers/request/agent-run-cancel.handler.test.ts
@@ -30,4 +30,52 @@ describe("server/handlers/request/agent-run-cancel.handler", () => {
     assertEquals(await result.response.json(), { accepted: true });
     assertEquals(sessionManager.getRunStatus("run_1"), null);
   });
+
+  it("returns 204 when the run is already inactive", async () => {
+    const handler = new AgentRunCancelHandler(new AgentRunSessionManager());
+    const body = JSON.stringify({ runId: "run_1" });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/runs/run_1", {
+        method: "DELETE",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 204);
+    assertEquals(await result.response.text(), "");
+  });
+
+  it("returns 500 when cancel handling fails unexpectedly", async () => {
+    const handler = new AgentRunCancelHandler({
+      cancelRun() {
+        throw new Error("cancel boom");
+      },
+    } as unknown as AgentRunSessionManager);
+    const body = JSON.stringify({ runId: "run_1" });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/runs/run_1", {
+        method: "DELETE",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 500);
+    assertEquals(await result.response.json(), { error: "Internal cancel failed" });
+  });
 });

--- a/src/server/handlers/request/agent-run-cancel.handler.test.ts
+++ b/src/server/handlers/request/agent-run-cancel.handler.test.ts
@@ -1,73 +1,8 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import type { HandlerContext } from "#veryfront/types";
-import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
-import { AgentRunCancelHandler } from "./agent-run-cancel.handler.ts";
 import { AgentRunSessionManager } from "#veryfront/internal-agents/session-manager.ts";
-
-const encoder = new TextEncoder();
-
-function encodePem(label: string, der: ArrayBuffer): string {
-  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
-  const lines = base64.match(/.{1,64}/g) ?? [base64];
-  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
-}
-
-async function sha256Base64url(body: string): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(body));
-  return base64urlEncodeBytes(new Uint8Array(digest));
-}
-
-async function createControlPlaneSignature(
-  body: string,
-): Promise<{ jws: string; publicKeyPem: string }> {
-  const keyPair = await crypto.subtle.generateKey(
-    "Ed25519",
-    true,
-    ["sign", "verify"],
-  ) as CryptoKeyPair;
-  const publicKeyDer = await crypto.subtle.exportKey("spki", keyPair.publicKey);
-  const publicKeyPem = encodePem("PUBLIC KEY", publicKeyDer);
-  const now = Math.floor(Date.now() / 1000);
-
-  const header = base64urlEncode(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
-  const payload = base64urlEncode(JSON.stringify({
-    iss: "veryfront-api",
-    aud: "demo-project",
-    sub: "run_1",
-    surface: "studio",
-    project_id: "proj-1",
-    request_hash: await sha256Base64url(body),
-    iat: now,
-    exp: now + 60,
-  }));
-
-  const signingInput = encoder.encode(`${header}.${payload}`);
-  const signature = await crypto.subtle.sign("Ed25519", keyPair.privateKey, signingInput);
-
-  return {
-    publicKeyPem,
-    jws: `${header}.${payload}.${base64urlEncodeBytes(new Uint8Array(signature))}`,
-  };
-}
-
-function createCtx(publicKeyPem?: string): HandlerContext {
-  return {
-    projectDir: "/project",
-    adapter: {
-      env: {
-        get: (key: string) =>
-          key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? publicKeyPem : undefined,
-      },
-      fs: {},
-    },
-    securityConfig: null,
-    cspUserHeader: null,
-    projectSlug: "demo-project",
-    projectId: "proj-1",
-    isLocalProject: false,
-  } as unknown as HandlerContext;
-}
+import { AgentRunCancelHandler } from "./agent-run-cancel.handler.ts";
+import { createControlPlaneSignature, createCtx } from "./internal-agent-run.test-helpers.ts";
 
 describe("server/handlers/request/agent-run-cancel.handler", () => {
   it("cancels an active run with a valid control-plane signature", async () => {
@@ -76,7 +11,7 @@ describe("server/handlers/request/agent-run-cancel.handler", () => {
 
     const handler = new AgentRunCancelHandler(sessionManager);
     const body = JSON.stringify({ runId: "run_1" });
-    const { jws, publicKeyPem } = await createControlPlaneSignature(body);
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
       new Request("https://example.com/internal/agents/runs/run_1", {

--- a/src/server/handlers/request/agent-run-cancel.handler.test.ts
+++ b/src/server/handlers/request/agent-run-cancel.handler.test.ts
@@ -78,4 +78,35 @@ describe("server/handlers/request/agent-run-cancel.handler", () => {
     assertEquals(result.response.status, 500);
     assertEquals(await result.response.json(), { error: "Internal cancel failed" });
   });
+
+  it("returns 401 when the control-plane signature is missing", async () => {
+    const handler = new AgentRunCancelHandler(new AgentRunSessionManager());
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/runs/run_1", {
+        method: "DELETE",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ runId: "run_1" }),
+      }),
+      createCtx("-----BEGIN PUBLIC KEY-----\nZmFrZQ==\n-----END PUBLIC KEY-----"),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 401);
+    assertEquals(await result.response.json(), { error: "Missing control-plane signature" });
+  });
+
+  it("ignores non-matching cancel routes", async () => {
+    const handler = new AgentRunCancelHandler(new AgentRunSessionManager());
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/runs/run_1/extra", {
+        method: "DELETE",
+      }),
+      createCtx(),
+    );
+
+    assertEquals(result.response, undefined);
+  });
 });

--- a/src/server/handlers/request/agent-run-cancel.handler.test.ts
+++ b/src/server/handlers/request/agent-run-cancel.handler.test.ts
@@ -1,0 +1,98 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+import { AgentRunCancelHandler } from "./agent-run-cancel.handler.ts";
+import { AgentRunSessionManager } from "#veryfront/internal-agents/session-manager.ts";
+
+const encoder = new TextEncoder();
+
+function encodePem(label: string, der: ArrayBuffer): string {
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = base64.match(/.{1,64}/g) ?? [base64];
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
+}
+
+async function sha256Base64url(body: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(body));
+  return base64urlEncodeBytes(new Uint8Array(digest));
+}
+
+async function createControlPlaneSignature(
+  body: string,
+): Promise<{ jws: string; publicKeyPem: string }> {
+  const keyPair = await crypto.subtle.generateKey(
+    "Ed25519",
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+  const publicKeyDer = await crypto.subtle.exportKey("spki", keyPair.publicKey);
+  const publicKeyPem = encodePem("PUBLIC KEY", publicKeyDer);
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = base64urlEncode(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
+  const payload = base64urlEncode(JSON.stringify({
+    iss: "veryfront-api",
+    aud: "demo-project",
+    sub: "run_1",
+    surface: "studio",
+    project_id: "proj-1",
+    request_hash: await sha256Base64url(body),
+    iat: now,
+    exp: now + 60,
+  }));
+
+  const signingInput = encoder.encode(`${header}.${payload}`);
+  const signature = await crypto.subtle.sign("Ed25519", keyPair.privateKey, signingInput);
+
+  return {
+    publicKeyPem,
+    jws: `${header}.${payload}.${base64urlEncodeBytes(new Uint8Array(signature))}`,
+  };
+}
+
+function createCtx(publicKeyPem?: string): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter: {
+      env: {
+        get: (key: string) =>
+          key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? publicKeyPem : undefined,
+      },
+      fs: {},
+    },
+    securityConfig: null,
+    cspUserHeader: null,
+    projectSlug: "demo-project",
+    projectId: "proj-1",
+    isLocalProject: false,
+  } as unknown as HandlerContext;
+}
+
+describe("server/handlers/request/agent-run-cancel.handler", () => {
+  it("cancels an active run with a valid control-plane signature", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    const handler = new AgentRunCancelHandler(sessionManager);
+    const body = JSON.stringify({ runId: "run_1" });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body);
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/runs/run_1", {
+        method: "DELETE",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 202);
+    assertEquals(await result.response.json(), { accepted: true });
+    assertEquals(sessionManager.getRunStatus("run_1"), null);
+  });
+});

--- a/src/server/handlers/request/agent-run-cancel.handler.ts
+++ b/src/server/handlers/request/agent-run-cancel.handler.ts
@@ -1,0 +1,73 @@
+import {
+  ControlPlaneRequestError,
+  verifyControlPlaneRequest,
+} from "#veryfront/internal-agents/control-plane-auth.ts";
+import {
+  type AgentRunSessionManager,
+  agentRunSessionManager,
+} from "#veryfront/internal-agents/session-manager.ts";
+import { BaseHandler } from "../response/base.ts";
+import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
+import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
+
+const CANCEL_PATH_REGEX = /^\/internal\/agents\/runs\/([^/]+)$/;
+
+function getRunId(pathname: string): string | null {
+  return CANCEL_PATH_REGEX.exec(pathname)?.[1] ?? null;
+}
+
+export class AgentRunCancelHandler extends BaseHandler {
+  metadata: HandlerMetadata = {
+    name: "AgentRunCancelHandler",
+    priority: PRIORITY_MEDIUM_API as HandlerPriority,
+    patterns: [{ pattern: "/internal/agents/runs/", prefix: true, method: "DELETE" }],
+  };
+
+  constructor(private readonly sessionManager: AgentRunSessionManager = agentRunSessionManager) {
+    super();
+  }
+
+  async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
+    if (!this.shouldHandle(req, ctx)) {
+      return this.continue();
+    }
+
+    const runId = getRunId(new URL(req.url).pathname);
+    if (!runId) {
+      return this.continue();
+    }
+
+    return this.withProxyContext(ctx, async () => {
+      const builder = this.createResponseBuilder(ctx)
+        .withCORS(req, ctx.securityConfig?.cors)
+        .withSecurity(ctx.securityConfig ?? undefined, req);
+
+      const rawBody = await req.text();
+      try {
+        await verifyControlPlaneRequest(req, ctx, rawBody, {
+          expectedSubject: runId,
+          expectedSurface: "studio",
+        });
+
+        const accepted = this.sessionManager.cancelRun(runId);
+        if (accepted) {
+          return this.respond(builder.json({ accepted: true }, 202));
+        }
+
+        return this.respond(builder.build(null, 204));
+      } catch (error) {
+        if (error instanceof ControlPlaneRequestError) {
+          return this.respond(builder.json({ error: error.message }, error.status));
+        }
+
+        this.logWarn("Internal agent run cancel failed", {
+          error: error instanceof Error ? error.message : String(error),
+          runId,
+          projectId: ctx.projectId,
+          projectSlug: ctx.projectSlug,
+        });
+        return this.respond(builder.json({ error: "Internal cancel failed" }, 500));
+      }
+    });
+  }
+}

--- a/src/server/handlers/request/agent-run-cancel.handler.ts
+++ b/src/server/handlers/request/agent-run-cancel.handler.ts
@@ -6,6 +6,11 @@ import {
   type AgentRunSessionManager,
   agentRunSessionManager,
 } from "#veryfront/internal-agents/session-manager.ts";
+import {
+  INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES,
+  InternalAgentRequestBodyTooLargeError,
+  readInternalAgentRequestBody,
+} from "#veryfront/internal-agents/request-body.ts";
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
@@ -42,8 +47,11 @@ export class AgentRunCancelHandler extends BaseHandler {
         .withCORS(req, ctx.securityConfig?.cors)
         .withSecurity(ctx.securityConfig ?? undefined, req);
 
-      const rawBody = await req.text();
       try {
+        const rawBody = await readInternalAgentRequestBody(
+          req,
+          INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES,
+        );
         await verifyControlPlaneRequest(req, ctx, rawBody, {
           expectedSubject: runId,
           expectedSurface: "studio",
@@ -56,6 +64,10 @@ export class AgentRunCancelHandler extends BaseHandler {
 
         return this.respond(builder.build(null, 204));
       } catch (error) {
+        if (error instanceof InternalAgentRequestBodyTooLargeError) {
+          return this.respond(builder.json({ error: error.message }, error.status));
+        }
+
         if (error instanceof ControlPlaneRequestError) {
           return this.respond(builder.json({ error: error.message }, error.status));
         }

--- a/src/server/handlers/request/agent-run-resume.handler.test.ts
+++ b/src/server/handlers/request/agent-run-resume.handler.test.ts
@@ -94,4 +94,143 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
     assertEquals(result.response.status, 413);
     assertEquals(await result.response.json(), { error: "Payload too large" });
   });
+
+  it("returns 400 for malformed resume payloads", async () => {
+    const handler = new AgentRunResumeHandler(new AgentRunSessionManager());
+    const body = '{"type":"tool_result"';
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/runs/run_1/resume", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 400);
+    assertEquals(await result.response.json(), { error: "Invalid resume request" });
+  });
+
+  it("returns 409 for conflicting duplicate tool results", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    const pending = sessionManager.waitForToolResult("run_1", "tool_1");
+    sessionManager.submitToolResult("run_1", { toolCallId: "tool_1", result: { ok: true } });
+    await pending;
+
+    const handler = new AgentRunResumeHandler(sessionManager);
+    const body = JSON.stringify({
+      type: "tool_result",
+      toolCallId: "tool_1",
+      result: { ok: false },
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/runs/run_1/resume", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 409);
+    assertEquals(await result.response.json(), { error: "TOOL_RESULT_CONFLICT" });
+  });
+
+  it("returns 409 when the run is not waiting for the submitted tool call", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    const handler = new AgentRunResumeHandler(sessionManager);
+    const body = JSON.stringify({
+      type: "tool_result",
+      toolCallId: "tool_1",
+      result: { ok: true },
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/runs/run_1/resume", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 409);
+    assertEquals(await result.response.json(), { error: "TOOL_RESULT_NOT_WAITING" });
+  });
+
+  it("returns 410 when the run is no longer active", async () => {
+    const handler = new AgentRunResumeHandler(new AgentRunSessionManager());
+    const body = JSON.stringify({
+      type: "tool_result",
+      toolCallId: "tool_1",
+      result: { ok: true },
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/runs/run_1/resume", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 410);
+    assertEquals(await result.response.json(), { error: "RUN_NOT_ACTIVE" });
+  });
+
+  it("returns 500 when session resume fails unexpectedly", async () => {
+    const handler = new AgentRunResumeHandler({
+      submitToolResult() {
+        throw new Error("resume boom");
+      },
+    } as unknown as AgentRunSessionManager);
+    const body = JSON.stringify({
+      type: "tool_result",
+      toolCallId: "tool_1",
+      result: { ok: true },
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/runs/run_1/resume", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 500);
+    assertEquals(await result.response.json(), { error: "Internal resume failed" });
+  });
 });

--- a/src/server/handlers/request/agent-run-resume.handler.test.ts
+++ b/src/server/handlers/request/agent-run-resume.handler.test.ts
@@ -1,0 +1,135 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+import { AgentRunResumeHandler } from "./agent-run-resume.handler.ts";
+import { AgentRunSessionManager } from "#veryfront/internal-agents/session-manager.ts";
+
+const encoder = new TextEncoder();
+
+function encodePem(label: string, der: ArrayBuffer): string {
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = base64.match(/.{1,64}/g) ?? [base64];
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
+}
+
+async function sha256Base64url(body: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(body));
+  return base64urlEncodeBytes(new Uint8Array(digest));
+}
+
+async function createControlPlaneSignature(
+  body: string,
+): Promise<{ jws: string; publicKeyPem: string }> {
+  const keyPair = await crypto.subtle.generateKey(
+    "Ed25519",
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+  const publicKeyDer = await crypto.subtle.exportKey("spki", keyPair.publicKey);
+  const publicKeyPem = encodePem("PUBLIC KEY", publicKeyDer);
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = base64urlEncode(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
+  const payload = base64urlEncode(JSON.stringify({
+    iss: "veryfront-api",
+    aud: "demo-project",
+    sub: "run_1",
+    surface: "studio",
+    project_id: "proj-1",
+    request_hash: await sha256Base64url(body),
+    iat: now,
+    exp: now + 60,
+  }));
+
+  const signingInput = encoder.encode(`${header}.${payload}`);
+  const signature = await crypto.subtle.sign("Ed25519", keyPair.privateKey, signingInput);
+
+  return {
+    publicKeyPem,
+    jws: `${header}.${payload}.${base64urlEncodeBytes(new Uint8Array(signature))}`,
+  };
+}
+
+function createCtx(publicKeyPem?: string): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter: {
+      env: {
+        get: (key: string) =>
+          key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? publicKeyPem : undefined,
+      },
+      fs: {},
+    },
+    securityConfig: null,
+    cspUserHeader: null,
+    projectSlug: "demo-project",
+    projectId: "proj-1",
+    isLocalProject: false,
+  } as unknown as HandlerContext;
+}
+
+describe("server/handlers/request/agent-run-resume.handler", () => {
+  it("accepts a signed tool result for a waiting run", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    const pending = sessionManager.waitForToolResult("run_1", "tool_1");
+
+    const handler = new AgentRunResumeHandler(sessionManager);
+    const body = JSON.stringify({
+      type: "tool_result",
+      toolCallId: "tool_1",
+      result: { ok: true },
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body);
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/runs/run_1/resume", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(await result.response.json(), { accepted: true });
+    assertEquals(await pending, { result: { ok: true }, isError: false });
+  });
+
+  it("returns duplicate=true for a repeated identical tool result", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    const pending = sessionManager.waitForToolResult("run_1", "tool_1");
+    sessionManager.submitToolResult("run_1", { toolCallId: "tool_1", result: { ok: true } });
+    await pending;
+
+    const handler = new AgentRunResumeHandler(sessionManager);
+    const body = JSON.stringify({
+      type: "tool_result",
+      toolCallId: "tool_1",
+      result: { ok: true },
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body);
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/runs/run_1/resume", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(await result.response.json(), { accepted: true, duplicate: true });
+  });
+});

--- a/src/server/handlers/request/agent-run-resume.handler.test.ts
+++ b/src/server/handlers/request/agent-run-resume.handler.test.ts
@@ -1,73 +1,9 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import type { HandlerContext } from "#veryfront/types";
-import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
-import { AgentRunResumeHandler } from "./agent-run-resume.handler.ts";
 import { AgentRunSessionManager } from "#veryfront/internal-agents/session-manager.ts";
-
-const encoder = new TextEncoder();
-
-function encodePem(label: string, der: ArrayBuffer): string {
-  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
-  const lines = base64.match(/.{1,64}/g) ?? [base64];
-  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
-}
-
-async function sha256Base64url(body: string): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(body));
-  return base64urlEncodeBytes(new Uint8Array(digest));
-}
-
-async function createControlPlaneSignature(
-  body: string,
-): Promise<{ jws: string; publicKeyPem: string }> {
-  const keyPair = await crypto.subtle.generateKey(
-    "Ed25519",
-    true,
-    ["sign", "verify"],
-  ) as CryptoKeyPair;
-  const publicKeyDer = await crypto.subtle.exportKey("spki", keyPair.publicKey);
-  const publicKeyPem = encodePem("PUBLIC KEY", publicKeyDer);
-  const now = Math.floor(Date.now() / 1000);
-
-  const header = base64urlEncode(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
-  const payload = base64urlEncode(JSON.stringify({
-    iss: "veryfront-api",
-    aud: "demo-project",
-    sub: "run_1",
-    surface: "studio",
-    project_id: "proj-1",
-    request_hash: await sha256Base64url(body),
-    iat: now,
-    exp: now + 60,
-  }));
-
-  const signingInput = encoder.encode(`${header}.${payload}`);
-  const signature = await crypto.subtle.sign("Ed25519", keyPair.privateKey, signingInput);
-
-  return {
-    publicKeyPem,
-    jws: `${header}.${payload}.${base64urlEncodeBytes(new Uint8Array(signature))}`,
-  };
-}
-
-function createCtx(publicKeyPem?: string): HandlerContext {
-  return {
-    projectDir: "/project",
-    adapter: {
-      env: {
-        get: (key: string) =>
-          key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? publicKeyPem : undefined,
-      },
-      fs: {},
-    },
-    securityConfig: null,
-    cspUserHeader: null,
-    projectSlug: "demo-project",
-    projectId: "proj-1",
-    isLocalProject: false,
-  } as unknown as HandlerContext;
-}
+import { INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES } from "#veryfront/internal-agents/request-body.ts";
+import { AgentRunResumeHandler } from "./agent-run-resume.handler.ts";
+import { createControlPlaneSignature, createCtx } from "./internal-agent-run.test-helpers.ts";
 
 describe("server/handlers/request/agent-run-resume.handler", () => {
   it("accepts a signed tool result for a waiting run", async () => {
@@ -81,7 +17,7 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
       toolCallId: "tool_1",
       result: { ok: true },
     });
-    const { jws, publicKeyPem } = await createControlPlaneSignature(body);
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
       new Request("https://example.com/internal/agents/runs/run_1/resume", {
@@ -114,7 +50,7 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
       toolCallId: "tool_1",
       result: { ok: true },
     });
-    const { jws, publicKeyPem } = await createControlPlaneSignature(body);
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
       new Request("https://example.com/internal/agents/runs/run_1/resume", {
@@ -131,5 +67,31 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
     assertExists(result.response);
     assertEquals(result.response.status, 200);
     assertEquals(await result.response.json(), { accepted: true, duplicate: true });
+  });
+
+  it("rejects oversized resume payloads before parsing", async () => {
+    const handler = new AgentRunResumeHandler(new AgentRunSessionManager());
+    const body = JSON.stringify({
+      type: "tool_result",
+      toolCallId: "tool_1",
+      result: "x".repeat(INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES + 1024),
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/runs/run_1/resume", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 413);
+    assertEquals(await result.response.json(), { error: "Payload too large" });
   });
 });

--- a/src/server/handlers/request/agent-run-resume.handler.ts
+++ b/src/server/handlers/request/agent-run-resume.handler.ts
@@ -1,0 +1,95 @@
+import {
+  ControlPlaneRequestError,
+  verifyControlPlaneRequest,
+} from "#veryfront/internal-agents/control-plane-auth.ts";
+import {
+  type AgentRunSessionManager,
+  agentRunSessionManager,
+  RunNotActiveError,
+  ToolResultConflictError,
+  ToolResultNotWaitingError,
+} from "#veryfront/internal-agents/session-manager.ts";
+import { ResumeSignalSchema } from "#veryfront/internal-agents/schema.ts";
+import { BaseHandler } from "../response/base.ts";
+import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
+import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
+
+const RESUME_PATH_REGEX = /^\/internal\/agents\/runs\/([^/]+)\/resume$/;
+
+function getRunId(pathname: string): string | null {
+  return RESUME_PATH_REGEX.exec(pathname)?.[1] ?? null;
+}
+
+export class AgentRunResumeHandler extends BaseHandler {
+  metadata: HandlerMetadata = {
+    name: "AgentRunResumeHandler",
+    priority: PRIORITY_MEDIUM_API as HandlerPriority,
+    patterns: [{ pattern: "/internal/agents/runs/", prefix: true, method: "POST" }],
+  };
+
+  constructor(private readonly sessionManager: AgentRunSessionManager = agentRunSessionManager) {
+    super();
+  }
+
+  async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
+    if (!this.shouldHandle(req, ctx)) {
+      return this.continue();
+    }
+
+    const runId = getRunId(new URL(req.url).pathname);
+    if (!runId) {
+      return this.continue();
+    }
+
+    return this.withProxyContext(ctx, async () => {
+      const builder = this.createResponseBuilder(ctx)
+        .withCORS(req, ctx.securityConfig?.cors)
+        .withSecurity(ctx.securityConfig ?? undefined, req);
+
+      const rawBody = await req.text();
+      try {
+        await verifyControlPlaneRequest(req, ctx, rawBody, {
+          expectedSubject: runId,
+          expectedSurface: "studio",
+        });
+
+        const signal = ResumeSignalSchema.parse(JSON.parse(rawBody));
+        const outcome = this.sessionManager.submitToolResult(runId, {
+          toolCallId: signal.toolCallId,
+          result: signal.result,
+          isError: signal.isError,
+        });
+
+        return this.respond(builder.json(outcome, 200));
+      } catch (error) {
+        if (error instanceof ControlPlaneRequestError) {
+          return this.respond(builder.json({ error: error.message }, error.status));
+        }
+
+        if (error instanceof SyntaxError || (error instanceof Error && error.name === "ZodError")) {
+          return this.respond(builder.json({ error: "Invalid resume request" }, 400));
+        }
+
+        if (error instanceof ToolResultConflictError) {
+          return this.respond(builder.json({ error: "TOOL_RESULT_CONFLICT" }, 409));
+        }
+
+        if (error instanceof ToolResultNotWaitingError) {
+          return this.respond(builder.json({ error: "TOOL_RESULT_NOT_WAITING" }, 409));
+        }
+
+        if (error instanceof RunNotActiveError) {
+          return this.respond(builder.json({ error: "RUN_NOT_ACTIVE" }, 410));
+        }
+
+        this.logWarn("Internal agent run resume failed", {
+          error: error instanceof Error ? error.message : String(error),
+          runId,
+          projectId: ctx.projectId,
+          projectSlug: ctx.projectSlug,
+        });
+        return this.respond(builder.json({ error: "Internal resume failed" }, 500));
+      }
+    });
+  }
+}

--- a/src/server/handlers/request/agent-run-resume.handler.ts
+++ b/src/server/handlers/request/agent-run-resume.handler.ts
@@ -9,6 +9,11 @@ import {
   ToolResultConflictError,
   ToolResultNotWaitingError,
 } from "#veryfront/internal-agents/session-manager.ts";
+import {
+  INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES,
+  InternalAgentRequestBodyTooLargeError,
+  readInternalAgentRequestBody,
+} from "#veryfront/internal-agents/request-body.ts";
 import { ResumeSignalSchema } from "#veryfront/internal-agents/schema.ts";
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
@@ -46,8 +51,11 @@ export class AgentRunResumeHandler extends BaseHandler {
         .withCORS(req, ctx.securityConfig?.cors)
         .withSecurity(ctx.securityConfig ?? undefined, req);
 
-      const rawBody = await req.text();
       try {
+        const rawBody = await readInternalAgentRequestBody(
+          req,
+          INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES,
+        );
         await verifyControlPlaneRequest(req, ctx, rawBody, {
           expectedSubject: runId,
           expectedSurface: "studio",
@@ -62,6 +70,10 @@ export class AgentRunResumeHandler extends BaseHandler {
 
         return this.respond(builder.json(outcome, 200));
       } catch (error) {
+        if (error instanceof InternalAgentRequestBodyTooLargeError) {
+          return this.respond(builder.json({ error: error.message }, error.status));
+        }
+
         if (error instanceof ControlPlaneRequestError) {
           return this.respond(builder.json({ error: error.message }, error.status));
         }

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -218,6 +218,40 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(await result.response.json(), { error: "Invalid internal agent stream request" });
   });
 
+  it("returns 400 when the runtime input exceeds the message limit", async () => {
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: () => createAgent("assistant-1"),
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager: new AgentRunSessionManager(),
+    });
+
+    const body = createAgentStreamRequestBody({
+      messages: Array.from({ length: 101 }, (_, index) => ({
+        id: `msg_${index}`,
+        role: "user",
+        parts: [{ type: "text", text: "hello" }],
+      })),
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 400);
+    assertEquals(await result.response.json(), { error: "Invalid internal agent stream request" });
+  });
+
   it("returns 409 when the same run is started twice", async () => {
     const sessionManager = new AgentRunSessionManager();
     const handler = new AgentStreamHandler({

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -6,9 +6,9 @@ import { AgentRunResumeHandler } from "./agent-run-resume.handler.ts";
 import { AgentStreamHandler } from "./agent-stream.handler.ts";
 import {
   createAgent,
-  createInjectedToolRuntime,
   createControlPlaneSignature,
   createCtx,
+  createInjectedToolRuntime,
   encodeDataStreamEvent,
   readRemainingText,
   readUntil,
@@ -375,6 +375,14 @@ describe("server/handlers/request/agent-stream.handler", () => {
     await readUntil(reader, (chunk) => chunk.includes("event: ToolCallEnd"));
     await reader.cancel();
 
+    for (
+      let attempt = 0;
+      attempt < 20 && sessionManager.getRunStatus("run_1") !== "waiting";
+      attempt += 1
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
     assertEquals(sessionManager.getRunStatus("run_1"), "waiting");
     assertEquals(sessionManager.stats.cancelCalls, 0);
 
@@ -400,7 +408,11 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertExists(resumeResult.response);
     assertEquals(resumeResult.response.status, 200);
 
-    for (let attempt = 0; attempt < 20 && sessionManager.getRunStatus("run_1") !== null; attempt += 1) {
+    for (
+      let attempt = 0;
+      attempt < 20 && sessionManager.getRunStatus("run_1") !== null;
+      attempt += 1
+    ) {
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
 

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -1,0 +1,203 @@
+import type { Agent } from "#veryfront/agent";
+import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+import { AgentStreamHandler } from "./agent-stream.handler.ts";
+
+const encoder = new TextEncoder();
+
+function encodePem(label: string, der: ArrayBuffer): string {
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = base64.match(/.{1,64}/g) ?? [base64];
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
+}
+
+async function sha256Base64url(body: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(body));
+  return base64urlEncodeBytes(new Uint8Array(digest));
+}
+
+async function createControlPlaneSignature(
+  body: string,
+  overrides: Partial<{
+    audience: string;
+    projectId: string;
+    requestId: string;
+    surface: "studio" | "channels" | "a2a" | "mcp";
+  }> = {},
+): Promise<{ jws: string; publicKeyPem: string }> {
+  const keyPair = await crypto.subtle.generateKey(
+    "Ed25519",
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+  const publicKeyDer = await crypto.subtle.exportKey("spki", keyPair.publicKey);
+  const publicKeyPem = encodePem("PUBLIC KEY", publicKeyDer);
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = base64urlEncode(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
+  const payload = base64urlEncode(JSON.stringify({
+    iss: "veryfront-api",
+    aud: overrides.audience ?? "demo-project",
+    sub: overrides.requestId ?? "run_1",
+    surface: overrides.surface ?? "studio",
+    project_id: overrides.projectId ?? "proj-1",
+    request_hash: await sha256Base64url(body),
+    iat: now,
+    exp: now + 60,
+  }));
+
+  const signingInput = encoder.encode(`${header}.${payload}`);
+  const signature = await crypto.subtle.sign("Ed25519", keyPair.privateKey, signingInput);
+
+  return {
+    publicKeyPem,
+    jws: `${header}.${payload}.${base64urlEncodeBytes(new Uint8Array(signature))}`,
+  };
+}
+
+function createCtx(publicKeyPem?: string): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter: {
+      env: {
+        get: (key: string) =>
+          key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? publicKeyPem : undefined,
+      },
+      fs: {},
+    },
+    securityConfig: null,
+    cspUserHeader: null,
+    projectSlug: "demo-project",
+    projectId: "proj-1",
+    isLocalProject: false,
+  } as unknown as HandlerContext;
+}
+
+function createAgent(): Agent {
+  return {
+    id: "assistant-1",
+    config: {
+      system: "You are Support.",
+      model: "anthropic/claude-sonnet-4-6",
+      name: "Support",
+      description: "Helps with support issues",
+      version: "1.0.0",
+    } as unknown as Agent["config"],
+    generate: async () => ({}) as never,
+    stream: async () => ({ toDataStreamResponse: () => new Response() } as never),
+    respond: async () => new Response(),
+    getMemory: () => ({} as never),
+    getMemoryStats: async () => ({
+      totalMessages: 0,
+      estimatedTokens: 0,
+      type: "conversation",
+    }),
+    clearMemory: async () => {},
+  };
+}
+
+function encodeRuntimeEvent(payload: Record<string, unknown>): Uint8Array {
+  return encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+describe("server/handlers/request/agent-stream.handler", () => {
+  it("streams AG-UI events for a valid signed request", async () => {
+    let discoveryCalls = 0;
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {
+        discoveryCalls += 1;
+      },
+      getAgent: (id) => id === "assistant-1" ? createAgent() : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager: {
+        startRun: () => new AbortController().signal,
+        waitForToolResult: async () => ({ result: { ok: true }, isError: false }),
+        submitToolResult: () => ({ accepted: true }),
+        cancelRun: () => true,
+        completeRun: () => {},
+        failRun: () => {},
+        getRunStatus: () => "running",
+        reset: () => {},
+      },
+      createRuntime: () => ({
+        stream: async (_messages, _context, callbacks) => {
+          callbacks?.onFinish?.({
+            text: "hello from runtime",
+            messages: [],
+            toolCalls: [],
+            status: "completed",
+            usage: {
+              promptTokens: 21,
+              completionTokens: 13,
+              totalTokens: 34,
+            },
+            metadata: {
+              finishReason: "stop",
+            },
+          });
+
+          return new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encodeRuntimeEvent({ type: "message-start", messageId: "assistant-msg-1" }),
+              );
+              controller.enqueue(encodeRuntimeEvent({ type: "step-start" }));
+              controller.enqueue(encodeRuntimeEvent({ type: "text-start", id: "text-1" }));
+              controller.enqueue(
+                encodeRuntimeEvent({
+                  type: "text-delta",
+                  id: "text-1",
+                  delta: "hello from runtime",
+                }),
+              );
+              controller.enqueue(encodeRuntimeEvent({ type: "text-end", id: "text-1" }));
+              controller.enqueue(encodeRuntimeEvent({ type: "step-end" }));
+              controller.close();
+            },
+          });
+        },
+      }),
+    });
+
+    const body = JSON.stringify({
+      agentId: "assistant-1",
+      threadId: "10000000-1000-4000-8000-100000000001",
+      runId: "run_1",
+      messages: [
+        {
+          id: "msg_1",
+          role: "user",
+          parts: [{ type: "text", text: "hello" }],
+        },
+      ],
+      tools: [{ name: "studio_focus_component" }],
+      context: [{ type: "text", text: "Current file: app.tsx" }],
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(discoveryCalls, 1);
+    assertEquals(result.response.headers.get("content-type"), "text/event-stream");
+
+    const text = await result.response.text();
+    assertStringIncludes(text, "event: RunStarted");
+    assertStringIncludes(text, "event: TextMessageContent");
+    assertStringIncludes(text, "event: RunFinished");
+    assertStringIncludes(text, '"inputTokens":21');
+  });
+});

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -1,105 +1,56 @@
-import type { Agent } from "#veryfront/agent";
 import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { AgentRunSessionManager } from "#veryfront/internal-agents/session-manager.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import type { HandlerContext } from "#veryfront/types";
-import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+import { DEFAULT_MAX_BODY_SIZE_BYTES } from "#veryfront/utils/constants/index.ts";
 import { AgentStreamHandler } from "./agent-stream.handler.ts";
+import {
+  createAgent,
+  createControlPlaneSignature,
+  createCtx,
+  encodeDataStreamEvent,
+  readRemainingText,
+  readUntil,
+} from "./internal-agent-run.test-helpers.ts";
 
-const encoder = new TextEncoder();
-
-function encodePem(label: string, der: ArrayBuffer): string {
-  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
-  const lines = base64.match(/.{1,64}/g) ?? [base64];
-  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
-}
-
-async function sha256Base64url(body: string): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(body));
-  return base64urlEncodeBytes(new Uint8Array(digest));
-}
-
-async function createControlPlaneSignature(
-  body: string,
-  overrides: Partial<{
-    audience: string;
-    projectId: string;
-    requestId: string;
-    surface: "studio" | "channels" | "a2a" | "mcp";
-  }> = {},
-): Promise<{ jws: string; publicKeyPem: string }> {
-  const keyPair = await crypto.subtle.generateKey(
-    "Ed25519",
-    true,
-    ["sign", "verify"],
-  ) as CryptoKeyPair;
-  const publicKeyDer = await crypto.subtle.exportKey("spki", keyPair.publicKey);
-  const publicKeyPem = encodePem("PUBLIC KEY", publicKeyDer);
-  const now = Math.floor(Date.now() / 1000);
-
-  const header = base64urlEncode(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
-  const payload = base64urlEncode(JSON.stringify({
-    iss: "veryfront-api",
-    aud: overrides.audience ?? "demo-project",
-    sub: overrides.requestId ?? "run_1",
-    surface: overrides.surface ?? "studio",
-    project_id: overrides.projectId ?? "proj-1",
-    request_hash: await sha256Base64url(body),
-    iat: now,
-    exp: now + 60,
-  }));
-
-  const signingInput = encoder.encode(`${header}.${payload}`);
-  const signature = await crypto.subtle.sign("Ed25519", keyPair.privateKey, signingInput);
-
-  return {
-    publicKeyPem,
-    jws: `${header}.${payload}.${base64urlEncodeBytes(new Uint8Array(signature))}`,
-  };
-}
-
-function createCtx(publicKeyPem?: string): HandlerContext {
-  return {
-    projectDir: "/project",
-    adapter: {
-      env: {
-        get: (key: string) =>
-          key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? publicKeyPem : undefined,
+function createAgentStreamRequestBody(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    agentId: "assistant-1",
+    threadId: "10000000-1000-4000-8000-100000000001",
+    runId: "run_1",
+    messages: [
+      {
+        id: "msg_1",
+        role: "user",
+        parts: [{ type: "text", text: "hello" }],
       },
-      fs: {},
-    },
-    securityConfig: null,
-    cspUserHeader: null,
-    projectSlug: "demo-project",
-    projectId: "proj-1",
-    isLocalProject: false,
-  } as unknown as HandlerContext;
+    ],
+    tools: [{ name: "studio_focus_component" }],
+    context: [{ type: "text", text: "Current file: app.tsx" }],
+    ...overrides,
+  });
 }
 
-function createAgent(): Agent {
-  return {
-    id: "assistant-1",
-    config: {
-      system: "You are Support.",
-      model: "anthropic/claude-sonnet-4-6",
-      name: "Support",
-      description: "Helps with support issues",
-      version: "1.0.0",
-    } as unknown as Agent["config"],
-    generate: async () => ({}) as never,
-    stream: async () => ({ toDataStreamResponse: () => new Response() } as never),
-    respond: async () => new Response(),
-    getMemory: () => ({} as never),
-    getMemoryStats: async () => ({
-      totalMessages: 0,
-      estimatedTokens: 0,
-      type: "conversation",
-    }),
-    clearMemory: async () => {},
+class TrackingSessionManager extends AgentRunSessionManager {
+  readonly stats = {
+    cancelCalls: 0,
+    completeCalls: 0,
+    failCalls: 0,
   };
-}
 
-function encodeRuntimeEvent(payload: Record<string, unknown>): Uint8Array {
-  return encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
+  override cancelRun(runId: string): boolean {
+    this.stats.cancelCalls += 1;
+    return super.cancelRun(runId);
+  }
+
+  override completeRun(runId: string): void {
+    this.stats.completeCalls += 1;
+    super.completeRun(runId);
+  }
+
+  override failRun(runId: string): void {
+    this.stats.failCalls += 1;
+    super.failRun(runId);
+  }
 }
 
 describe("server/handlers/request/agent-stream.handler", () => {
@@ -109,18 +60,9 @@ describe("server/handlers/request/agent-stream.handler", () => {
       ensureProjectDiscovery: async () => {
         discoveryCalls += 1;
       },
-      getAgent: (id) => id === "assistant-1" ? createAgent() : undefined,
+      getAgent: (id) => id === "assistant-1" ? createAgent("assistant-1") : undefined,
       getAllAgentIds: () => ["assistant-1"],
-      sessionManager: {
-        startRun: () => new AbortController().signal,
-        waitForToolResult: async () => ({ result: { ok: true }, isError: false }),
-        submitToolResult: () => ({ accepted: true }),
-        cancelRun: () => true,
-        completeRun: () => {},
-        failRun: () => {},
-        getRunStatus: () => "running",
-        reset: () => {},
-      },
+      sessionManager: new AgentRunSessionManager(),
       createRuntime: () => ({
         stream: async (_messages, _context, callbacks) => {
           callbacks?.onFinish?.({
@@ -141,19 +83,19 @@ describe("server/handlers/request/agent-stream.handler", () => {
           return new ReadableStream<Uint8Array>({
             start(controller) {
               controller.enqueue(
-                encodeRuntimeEvent({ type: "message-start", messageId: "assistant-msg-1" }),
+                encodeDataStreamEvent({ type: "message-start", messageId: "assistant-msg-1" }),
               );
-              controller.enqueue(encodeRuntimeEvent({ type: "step-start" }));
-              controller.enqueue(encodeRuntimeEvent({ type: "text-start", id: "text-1" }));
+              controller.enqueue(encodeDataStreamEvent({ type: "step-start" }));
+              controller.enqueue(encodeDataStreamEvent({ type: "text-start", id: "text-1" }));
               controller.enqueue(
-                encodeRuntimeEvent({
+                encodeDataStreamEvent({
                   type: "text-delta",
                   id: "text-1",
                   delta: "hello from runtime",
                 }),
               );
-              controller.enqueue(encodeRuntimeEvent({ type: "text-end", id: "text-1" }));
-              controller.enqueue(encodeRuntimeEvent({ type: "step-end" }));
+              controller.enqueue(encodeDataStreamEvent({ type: "text-end", id: "text-1" }));
+              controller.enqueue(encodeDataStreamEvent({ type: "step-end" }));
               controller.close();
             },
           });
@@ -161,20 +103,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
       }),
     });
 
-    const body = JSON.stringify({
-      agentId: "assistant-1",
-      threadId: "10000000-1000-4000-8000-100000000001",
-      runId: "run_1",
-      messages: [
-        {
-          id: "msg_1",
-          role: "user",
-          parts: [{ type: "text", text: "hello" }],
-        },
-      ],
-      tools: [{ name: "studio_focus_component" }],
-      context: [{ type: "text", text: "Current file: app.tsx" }],
-    });
+    const body = createAgentStreamRequestBody();
     const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
 
     const result = await handler.handle(
@@ -199,5 +128,84 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertStringIncludes(text, "event: TextMessageContent");
     assertStringIncludes(text, "event: RunFinished");
     assertStringIncludes(text, '"inputTokens":21');
+  });
+
+  it("rejects oversized internal agent stream payloads before parsing", async () => {
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: () => createAgent("assistant-1"),
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager: new AgentRunSessionManager(),
+    });
+
+    const body = createAgentStreamRequestBody({
+      context: [{ type: "text", text: "x".repeat(DEFAULT_MAX_BODY_SIZE_BYTES + 1024) }],
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 413);
+    assertEquals(await result.response.json(), { error: "Payload too large" });
+  });
+
+  it("emits a cancellation error instead of finishing after an abort during a pending read", async () => {
+    const sessionManager = new TrackingSessionManager();
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: (id) => id === "assistant-1" ? createAgent("assistant-1") : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager,
+      createRuntime: () => ({
+        stream: async () =>
+          new ReadableStream<Uint8Array>({
+            cancel() {
+              return Promise.resolve();
+            },
+          }),
+      }),
+    });
+
+    const body = createAgentStreamRequestBody();
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertExists(result.response.body);
+
+    const reader = result.response.body.getReader();
+    let text = await readUntil(reader, (chunk) => chunk.includes("event: RunStarted"));
+
+    assertEquals(sessionManager.cancelRun("run_1"), true);
+
+    text += await readRemainingText(reader);
+
+    assertStringIncludes(text, "event: RunError");
+    assertStringIncludes(text, '"code":"CANCELLED"');
+    assertEquals(text.includes("event: RunFinished"), false);
+    assertEquals(sessionManager.stats.completeCalls, 0);
+    assertEquals(sessionManager.stats.failCalls, 0);
   });
 });

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -160,6 +160,133 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(await result.response.json(), { error: "Payload too large" });
   });
 
+  it("returns 404 when the requested agent is not available", async () => {
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: () => undefined,
+      getAllAgentIds: () => [],
+      sessionManager: new AgentRunSessionManager(),
+    });
+
+    const body = createAgentStreamRequestBody();
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 404);
+    assertEquals(await result.response.json(), { error: "Agent not found" });
+  });
+
+  it("returns 400 for malformed internal agent stream payloads", async () => {
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: () => createAgent("assistant-1"),
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager: new AgentRunSessionManager(),
+    });
+
+    const body = '{"agentId":"assistant-1"';
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 400);
+    assertEquals(await result.response.json(), { error: "Invalid internal agent stream request" });
+  });
+
+  it("returns 409 when the same run is started twice", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: (id) => id === "assistant-1" ? createAgent("assistant-1") : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager,
+      createRuntime: () => ({
+        stream: async () =>
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encodeDataStreamEvent({ type: "message-start", messageId: "assistant-msg-1" }),
+              );
+            },
+          }),
+      }),
+    });
+
+    const body = createAgentStreamRequestBody();
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+    const request = new Request("https://example.com/internal/agents/stream", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-veryfront-control-plane-jws": jws,
+      },
+      body,
+    });
+
+    const firstResult = await handler.handle(request.clone(), createCtx(publicKeyPem));
+    assertExists(firstResult.response);
+    assertEquals(firstResult.response.status, 200);
+
+    const secondResult = await handler.handle(request, createCtx(publicKeyPem));
+    assertExists(secondResult.response);
+    assertEquals(secondResult.response.status, 409);
+    assertEquals(await secondResult.response.json(), { error: 'Run "run_1" is already active' });
+  });
+
+  it("returns 500 when runtime execution setup fails unexpectedly", async () => {
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: (id) => id === "assistant-1" ? createAgent("assistant-1") : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager: new AgentRunSessionManager(),
+      createRuntime: () => {
+        throw new Error("runtime boom");
+      },
+    });
+
+    const body = createAgentStreamRequestBody();
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 500);
+    assertEquals(await result.response.json(), { error: "Internal agent stream failed" });
+  });
+
   it("emits a cancellation error instead of finishing after an abort during a pending read", async () => {
     const sessionManager = new TrackingSessionManager();
     const handler = new AgentStreamHandler({

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -2,9 +2,11 @@ import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/tes
 import { AgentRunSessionManager } from "#veryfront/internal-agents/session-manager.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { DEFAULT_MAX_BODY_SIZE_BYTES } from "#veryfront/utils/constants/index.ts";
+import { AgentRunResumeHandler } from "./agent-run-resume.handler.ts";
 import { AgentStreamHandler } from "./agent-stream.handler.ts";
 import {
   createAgent,
+  createInjectedToolRuntime,
   createControlPlaneSignature,
   createCtx,
   encodeDataStreamEvent,
@@ -333,6 +335,78 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertStringIncludes(text, '"code":"CANCELLED"');
     assertEquals(text.includes("event: RunFinished"), false);
     assertEquals(sessionManager.stats.completeCalls, 0);
+    assertEquals(sessionManager.stats.failCalls, 0);
+  });
+
+  it("keeps a waiting run resumable after the client disconnects", async () => {
+    const sessionManager = new TrackingSessionManager();
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: (id) => id === "assistant-1" ? createAgent("assistant-1") : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager,
+      createRuntime: createInjectedToolRuntime(
+        "studio_focus_component",
+        "tool-1",
+        { focused: true },
+      ),
+    });
+    const resumeHandler = new AgentRunResumeHandler(sessionManager);
+
+    const body = createAgentStreamRequestBody();
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertExists(result.response.body);
+
+    const reader = result.response.body.getReader();
+    await readUntil(reader, (chunk) => chunk.includes("event: ToolCallEnd"));
+    await reader.cancel();
+
+    assertEquals(sessionManager.getRunStatus("run_1"), "waiting");
+    assertEquals(sessionManager.stats.cancelCalls, 0);
+
+    const resumeBody = JSON.stringify({
+      type: "tool_result",
+      toolCallId: "tool-1",
+      result: { focused: true },
+    });
+    const resumeSignature = await createControlPlaneSignature(resumeBody, { requestId: "run_1" });
+
+    const resumeResult = await resumeHandler.handle(
+      new Request("https://example.com/internal/agents/runs/run_1/resume", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": resumeSignature.jws,
+        },
+        body: resumeBody,
+      }),
+      createCtx(resumeSignature.publicKeyPem),
+    );
+
+    assertExists(resumeResult.response);
+    assertEquals(resumeResult.response.status, 200);
+
+    for (let attempt = 0; attempt < 20 && sessionManager.getRunStatus("run_1") !== null; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    assertEquals(sessionManager.getRunStatus("run_1"), null);
+    assertEquals(sessionManager.stats.completeCalls, 1);
+    assertEquals(sessionManager.stats.cancelCalls, 0);
     assertEquals(sessionManager.stats.failCalls, 0);
   });
 });

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -10,6 +10,11 @@ import {
   verifyControlPlaneRequest,
 } from "#veryfront/internal-agents/control-plane-auth.ts";
 import {
+  INTERNAL_AGENT_STREAM_MAX_BODY_BYTES,
+  InternalAgentRequestBodyTooLargeError,
+  readInternalAgentRequestBody,
+} from "#veryfront/internal-agents/request-body.ts";
+import {
   AgentRunAlreadyExistsError,
   agentRunSessionManager,
 } from "#veryfront/internal-agents/session-manager.ts";
@@ -62,8 +67,11 @@ export class AgentStreamHandler extends BaseHandler {
         .withCORS(req, ctx.securityConfig?.cors)
         .withSecurity(ctx.securityConfig ?? undefined, req);
 
-      const rawBody = await req.text();
       try {
+        const rawBody = await readInternalAgentRequestBody(
+          req,
+          INTERNAL_AGENT_STREAM_MAX_BODY_BYTES,
+        );
         const payload = RuntimeRunAgentInputSchema.parse(JSON.parse(rawBody));
         await verifyControlPlaneRequest(req, ctx, rawBody, {
           expectedSubject: payload.runId,
@@ -80,6 +88,10 @@ export class AgentStreamHandler extends BaseHandler {
         const response = await createRuntimeAgentStreamResponse(payload, agent as Agent, this.deps);
         return this.respond(applyBuilderHeaders(response, builder.headers));
       } catch (error) {
+        if (error instanceof InternalAgentRequestBodyTooLargeError) {
+          return this.respond(builder.json({ error: error.message }, error.status));
+        }
+
         if (error instanceof ControlPlaneRequestError) {
           return this.respond(builder.json({ error: error.message }, error.status));
         }

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -1,0 +1,112 @@
+import type { Agent } from "#veryfront/agent";
+import { defaultChannelInvokeDeps } from "#veryfront/channels/invoke.ts";
+import { type RuntimeAgentDiscoveryDeps } from "#veryfront/channels/control-plane.ts";
+import {
+  createRuntimeAgentStreamResponse,
+  type RuntimeAgentStreamExecutionDeps,
+} from "#veryfront/internal-agents/run-stream.ts";
+import {
+  ControlPlaneRequestError,
+  verifyControlPlaneRequest,
+} from "#veryfront/internal-agents/control-plane-auth.ts";
+import {
+  AgentRunAlreadyExistsError,
+  agentRunSessionManager,
+} from "#veryfront/internal-agents/session-manager.ts";
+import { RuntimeRunAgentInputSchema } from "#veryfront/internal-agents/schema.ts";
+import { BaseHandler } from "../response/base.ts";
+import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
+import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
+
+export interface AgentStreamHandlerDeps
+  extends RuntimeAgentDiscoveryDeps, RuntimeAgentStreamExecutionDeps {}
+
+const defaultDeps: AgentStreamHandlerDeps = {
+  ...defaultChannelInvokeDeps,
+  sessionManager: agentRunSessionManager,
+};
+
+function applyBuilderHeaders(target: Response, source: Headers): Response {
+  const headers = new Headers(target.headers);
+  for (const [key, value] of source.entries()) {
+    if (!headers.has(key)) {
+      headers.set(key, value);
+    }
+  }
+
+  return new Response(target.body, {
+    status: target.status,
+    statusText: target.statusText,
+    headers,
+  });
+}
+
+export class AgentStreamHandler extends BaseHandler {
+  metadata: HandlerMetadata = {
+    name: "AgentStreamHandler",
+    priority: PRIORITY_MEDIUM_API as HandlerPriority,
+    patterns: [{ pattern: "/internal/agents/stream", exact: true, method: "POST" }],
+  };
+
+  constructor(private readonly deps: AgentStreamHandlerDeps = defaultDeps) {
+    super();
+  }
+
+  async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
+    if (!this.shouldHandle(req, ctx)) {
+      return this.continue();
+    }
+
+    return this.withProxyContext(ctx, async () => {
+      const builder = this.createResponseBuilder(ctx)
+        .withCORS(req, ctx.securityConfig?.cors)
+        .withSecurity(ctx.securityConfig ?? undefined, req);
+
+      const rawBody = await req.text();
+      try {
+        const payload = RuntimeRunAgentInputSchema.parse(JSON.parse(rawBody));
+        await verifyControlPlaneRequest(req, ctx, rawBody, {
+          expectedSubject: payload.runId,
+          expectedSurface: "studio",
+        });
+
+        await this.deps.ensureProjectDiscovery(ctx);
+
+        const agent = this.deps.getAgent(payload.agentId);
+        if (!agent) {
+          return this.respond(builder.json({ error: "Agent not found" }, 404));
+        }
+
+        const response = await createRuntimeAgentStreamResponse(payload, agent as Agent, this.deps);
+        return this.respond(applyBuilderHeaders(response, builder.headers));
+      } catch (error) {
+        if (error instanceof ControlPlaneRequestError) {
+          return this.respond(builder.json({ error: error.message }, error.status));
+        }
+
+        if (error instanceof SyntaxError) {
+          return this.respond(
+            builder.json({ error: "Invalid internal agent stream request" }, 400),
+          );
+        }
+
+        if (error instanceof AgentRunAlreadyExistsError) {
+          return this.respond(builder.json({ error: error.message }, 409));
+        }
+
+        if (error instanceof Error && error.name === "ZodError") {
+          return this.respond(
+            builder.json({ error: "Invalid internal agent stream request" }, 400),
+          );
+        }
+
+        this.logWarn("Internal agent stream request failed", {
+          error: error instanceof Error ? error.message : String(error),
+          projectId: ctx.projectId,
+          projectSlug: ctx.projectSlug,
+        });
+        return this.respond(builder.json({ error: "Internal agent stream failed" }, 500));
+      }
+    });
+  }
+}

--- a/src/server/handlers/request/channel-assistants.handler.ts
+++ b/src/server/handlers/request/channel-assistants.handler.ts
@@ -1,6 +1,7 @@
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import {
+  type ChannelAssistantsRequest,
   ChannelAssistantsRequestSchema,
   type ChannelInvokeDeps,
   defaultChannelInvokeDeps,
@@ -59,8 +60,9 @@ export class ChannelAssistantsHandler extends BaseHandler {
       }
 
       const rawBody = await req.text();
+      let claims: Awaited<ReturnType<typeof verifyDispatchJws>> | undefined;
       try {
-        await verifyDispatchJws(dispatchJws, rawBody, {
+        claims = await verifyDispatchJws(dispatchJws, rawBody, {
           audience: projectSlug,
           expectedProjectId: ctx.projectId,
           publicKeyPem,
@@ -75,8 +77,9 @@ export class ChannelAssistantsHandler extends BaseHandler {
         return this.respond(builder.json({ error: "Invalid dispatch signature" }, 401));
       }
 
+      let payload: ChannelAssistantsRequest;
       try {
-        ChannelAssistantsRequestSchema.parse(JSON.parse(rawBody));
+        payload = ChannelAssistantsRequestSchema.parse(JSON.parse(rawBody));
       } catch (error) {
         this.logWarn("Channel assistants request validation failed", {
           error: error instanceof Error ? error.message : String(error),
@@ -84,6 +87,22 @@ export class ChannelAssistantsHandler extends BaseHandler {
           projectId: ctx.projectId,
         });
         return this.respond(builder.json({ error: "Invalid channel assistants request" }, 400));
+      }
+
+      if (
+        !claims ||
+        payload.projectId !== claims.project_id ||
+        (ctx.projectId !== undefined && payload.projectId !== ctx.projectId) ||
+        payload.requestId !== claims.sub ||
+        payload.platform !== claims.platform
+      ) {
+        this.logWarn("Channel assistants request body did not match signed claims", {
+          projectSlug,
+          projectId: ctx.projectId,
+          requestId: payload.requestId,
+          signedRequestId: claims?.sub,
+        });
+        return this.respond(builder.json({ error: "Invalid dispatch signature" }, 401));
       }
 
       const response = await listChannelAssistants(ctx, this.deps);

--- a/src/server/handlers/request/internal-agent-run.test-helpers.ts
+++ b/src/server/handlers/request/internal-agent-run.test-helpers.ts
@@ -94,6 +94,21 @@ export function createAgent(id = "agent-1"): Agent {
   };
 }
 
+export function createAgentWithConfig(
+  id = "agent-1",
+  configOverrides: Record<string, unknown> = {},
+): Agent {
+  return {
+    ...createAgent(id),
+    config: {
+      id,
+      system: "You are helpful.",
+      model: "anthropic/claude-sonnet-4-6",
+      ...configOverrides,
+    } as Agent["config"],
+  };
+}
+
 export function encodeDataStreamEvent(payload: Record<string, unknown>): Uint8Array {
   return encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
 }
@@ -212,5 +227,21 @@ export async function readUntil(
     if (matcher(output)) {
       return output;
     }
+  }
+}
+
+export async function readRemainingText(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<string> {
+  const decoder = new TextDecoder();
+  let output = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      return output;
+    }
+
+    output += decoder.decode(value, { stream: true });
   }
 }

--- a/src/server/handlers/request/internal-agent-run.test-helpers.ts
+++ b/src/server/handlers/request/internal-agent-run.test-helpers.ts
@@ -1,0 +1,216 @@
+import type { Agent, AgentResponse } from "#veryfront/agent";
+import { type Tool } from "#veryfront/tool";
+import type { HandlerContext } from "#veryfront/types";
+import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+
+const encoder = new TextEncoder();
+
+function encodePem(label: string, der: ArrayBuffer): string {
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = base64.match(/.{1,64}/g) ?? [base64];
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
+}
+
+async function sha256Base64url(body: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(body));
+  return base64urlEncodeBytes(new Uint8Array(digest));
+}
+
+export async function createControlPlaneSignature(
+  body: string,
+  overrides: Partial<{
+    audience: string;
+    projectId: string;
+    requestId: string;
+    surface: "studio" | "channels" | "a2a" | "mcp";
+  }> = {},
+): Promise<{ jws: string; publicKeyPem: string }> {
+  const keyPair = await crypto.subtle.generateKey(
+    "Ed25519",
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+  const publicKeyDer = await crypto.subtle.exportKey("spki", keyPair.publicKey);
+  const publicKeyPem = encodePem("PUBLIC KEY", publicKeyDer);
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = base64urlEncode(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
+  const payload = base64urlEncode(JSON.stringify({
+    iss: "veryfront-api",
+    aud: overrides.audience ?? "demo-project",
+    sub: overrides.requestId ?? "run-1",
+    surface: overrides.surface ?? "studio",
+    project_id: overrides.projectId ?? "proj-1",
+    request_hash: await sha256Base64url(body),
+    iat: now,
+    exp: now + 60,
+  }));
+
+  const signingInput = encoder.encode(`${header}.${payload}`);
+  const signature = await crypto.subtle.sign("Ed25519", keyPair.privateKey, signingInput);
+
+  return {
+    publicKeyPem,
+    jws: `${header}.${payload}.${base64urlEncodeBytes(new Uint8Array(signature))}`,
+  };
+}
+
+export function createCtx(publicKeyPem?: string): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter: {
+      env: {
+        get: (key: string) =>
+          key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? publicKeyPem : undefined,
+      },
+      fs: {},
+    },
+    securityConfig: null,
+    cspUserHeader: null,
+    projectSlug: "demo-project",
+    projectId: "proj-1",
+    isLocalProject: false,
+  } as unknown as HandlerContext;
+}
+
+export function createAgent(id = "agent-1"): Agent {
+  return {
+    id,
+    config: {
+      id,
+      system: "You are helpful.",
+      model: "anthropic/claude-sonnet-4-6",
+    } as Agent["config"],
+    generate: async () => ({}) as never,
+    stream: async () => ({ toDataStreamResponse: () => new Response() } as never),
+    respond: async () => new Response(),
+    getMemory: () => ({} as never),
+    getMemoryStats: async () => ({
+      totalMessages: 0,
+      estimatedTokens: 0,
+      type: "conversation",
+    }),
+    clearMemory: async () => {},
+  };
+}
+
+export function encodeDataStreamEvent(payload: Record<string, unknown>): Uint8Array {
+  return encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+export function createInjectedToolRuntime(toolName: string, toolCallId: string, result: unknown) {
+  return (_agent: Agent, mergedTools: Agent["config"]["tools"]) => ({
+    async stream(
+      _messages: Array<Record<string, unknown>>,
+      _context?: Record<string, unknown>,
+      callbacks?: { onFinish?: (response: AgentResponse) => void },
+    ) {
+      const tool = mergedTools && mergedTools !== true
+        ? mergedTools[toolName] as Tool | boolean | undefined
+        : undefined;
+      if (!tool || tool === true) {
+        throw new Error(`Injected tool "${toolName}" was not available`);
+      }
+
+      const stream = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          controller.enqueue(
+            encodeDataStreamEvent({ type: "message-start", messageId: "assistant-1" }),
+          );
+          controller.enqueue(encodeDataStreamEvent({
+            type: "data",
+            data: {
+              model: "anthropic/claude-sonnet-4-6",
+              inferenceMode: "cloud",
+            },
+          }));
+          controller.enqueue(encodeDataStreamEvent({ type: "text-start", id: "assistant-1" }));
+          controller.enqueue(encodeDataStreamEvent({ type: "step-start" }));
+          controller.enqueue(encodeDataStreamEvent({
+            type: "tool-input-start",
+            toolCallId,
+            toolName,
+          }));
+          controller.enqueue(encodeDataStreamEvent({
+            type: "tool-input-delta",
+            toolCallId,
+            inputTextDelta: '{"target":"hero"}',
+          }));
+          controller.enqueue(encodeDataStreamEvent({
+            type: "tool-input-available",
+            toolCallId,
+            toolName,
+            input: { target: "hero" },
+          }));
+
+          const output = await tool.execute(
+            { target: "hero" },
+            { toolCallId },
+          );
+          controller.enqueue(encodeDataStreamEvent({
+            type: "tool-output-available",
+            toolCallId,
+            output,
+          }));
+          controller.enqueue(
+            encodeDataStreamEvent({ type: "text-delta", id: "assistant-1", delta: "Done." }),
+          );
+          controller.enqueue(encodeDataStreamEvent({ type: "step-end" }));
+          controller.close();
+          callbacks?.onFinish?.({
+            text: "Done.",
+            messages: [
+              {
+                id: "assistant-1",
+                role: "assistant",
+                parts: [{ type: "text", text: "Done." }],
+              },
+            ],
+            toolCalls: [{
+              id: toolCallId,
+              name: toolName,
+              args: { target: "hero" },
+              status: "completed",
+              result,
+            }],
+            status: "completed",
+            usage: {
+              promptTokens: 10,
+              completionTokens: 5,
+              totalTokens: 15,
+            },
+            metadata: {
+              finishReason: "stop",
+            },
+          });
+        },
+      });
+
+      return stream;
+    },
+  });
+}
+
+export async function readResponseText(response: Response): Promise<string> {
+  return await response.text();
+}
+
+export async function readUntil(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  matcher: (text: string) => boolean,
+): Promise<string> {
+  const decoder = new TextDecoder();
+  let output = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      return output;
+    }
+
+    output += decoder.decode(value, { stream: true });
+    if (matcher(output)) {
+      return output;
+    }
+  }
+}

--- a/src/server/handlers/request/internal-agents-list.handler.test.ts
+++ b/src/server/handlers/request/internal-agents-list.handler.test.ts
@@ -155,4 +155,33 @@ describe("server/handlers/request/internal-agents-list.handler", () => {
     assertEquals(result.response.status, 413);
     assertEquals(await result.response.json(), { error: "Payload too large" });
   });
+
+  it("returns 400 for malformed internal agents requests", async () => {
+    const handler = new InternalAgentsListHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: () => undefined,
+      getAllAgentIds: () => [],
+    });
+
+    const body = '{"requestId":"agents-1"';
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "agents-1",
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 400);
+    assertEquals(await result.response.json(), { error: "Invalid internal agents request" });
+  });
 });

--- a/src/server/handlers/request/internal-agents-list.handler.test.ts
+++ b/src/server/handlers/request/internal-agents-list.handler.test.ts
@@ -1,0 +1,205 @@
+import type { Agent } from "#veryfront/agent";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+import { InternalAgentsListHandler } from "./internal-agents-list.handler.ts";
+
+const encoder = new TextEncoder();
+
+function encodePem(label: string, der: ArrayBuffer): string {
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = base64.match(/.{1,64}/g) ?? [base64];
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
+}
+
+async function sha256Base64url(body: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(body));
+  return base64urlEncodeBytes(new Uint8Array(digest));
+}
+
+async function createControlPlaneSignature(
+  body: string,
+  overrides: Partial<{
+    audience: string;
+    projectId: string;
+    requestId: string;
+    surface: "studio" | "channels" | "a2a" | "mcp";
+  }> = {},
+): Promise<{ jws: string; publicKeyPem: string }> {
+  const keyPair = await crypto.subtle.generateKey(
+    "Ed25519",
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+  const publicKeyDer = await crypto.subtle.exportKey("spki", keyPair.publicKey);
+  const publicKeyPem = encodePem("PUBLIC KEY", publicKeyDer);
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = base64urlEncode(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
+  const payload = base64urlEncode(JSON.stringify({
+    iss: "veryfront-api",
+    aud: overrides.audience ?? "demo-project",
+    sub: overrides.requestId ?? "agents-1",
+    surface: overrides.surface ?? "studio",
+    project_id: overrides.projectId ?? "proj-1",
+    request_hash: await sha256Base64url(body),
+    iat: now,
+    exp: now + 60,
+  }));
+
+  const signingInput = encoder.encode(`${header}.${payload}`);
+  const signature = await crypto.subtle.sign("Ed25519", keyPair.privateKey, signingInput);
+
+  return {
+    publicKeyPem,
+    jws: `${header}.${payload}.${base64urlEncodeBytes(new Uint8Array(signature))}`,
+  };
+}
+
+function createCtx(publicKeyPem?: string): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter: {
+      env: {
+        get: (key: string) =>
+          key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? publicKeyPem : undefined,
+      },
+      fs: {},
+    },
+    securityConfig: null,
+    cspUserHeader: null,
+    projectSlug: "demo-project",
+    projectId: "proj-1",
+    isLocalProject: false,
+  } as unknown as HandlerContext;
+}
+
+function createAgent(): Agent {
+  return {
+    id: "assistant-1",
+    config: {
+      system: "You are Support.",
+      model: "anthropic/claude-sonnet-4-6",
+      name: "Support",
+      description: "Helps with support issues",
+      version: "1.0.0",
+    } as unknown as Agent["config"],
+    generate: async () => ({}) as never,
+    stream: async () => ({ toDataStreamResponse: () => new Response() } as never),
+    respond: async () => new Response(),
+    getMemory: () => ({} as never),
+    getMemoryStats: async () => ({
+      totalMessages: 0,
+      estimatedTokens: 0,
+      type: "conversation",
+    }),
+    clearMemory: async () => {},
+  };
+}
+
+describe("server/handlers/request/internal-agents-list.handler", () => {
+  it("returns discovered agents for a valid signed request", async () => {
+    let discoveryCalls = 0;
+    const handler = new InternalAgentsListHandler({
+      ensureProjectDiscovery: async () => {
+        discoveryCalls += 1;
+      },
+      getAgent: (id) => id === "assistant-1" ? createAgent() : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+    });
+
+    const body = JSON.stringify({
+      requestId: "agents-1",
+      projectId: "proj-1",
+      surface: "studio",
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body);
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(discoveryCalls, 1);
+    assertEquals(await result.response.json(), {
+      agents: [
+        {
+          id: "assistant-1",
+          name: "Support",
+          description: "Helps with support issues",
+          model: "anthropic/claude-sonnet-4-6",
+          version: "1.0.0",
+          skills: [],
+        },
+      ],
+    });
+  });
+
+  it("returns 401 when the control-plane signature is missing", async () => {
+    const handler = new InternalAgentsListHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: () => undefined,
+      getAllAgentIds: () => [],
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/list", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          requestId: "agents-1",
+          projectId: "proj-1",
+          surface: "studio",
+        }),
+      }),
+      createCtx("-----BEGIN PUBLIC KEY-----\nZmFrZQ==\n-----END PUBLIC KEY-----"),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 401);
+    assertEquals(await result.response.json(), { error: "Missing control-plane signature" });
+  });
+
+  it("returns 401 when the signed claims do not match the request body", async () => {
+    const handler = new InternalAgentsListHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: () => undefined,
+      getAllAgentIds: () => [],
+    });
+
+    const body = JSON.stringify({
+      requestId: "agents-body",
+      projectId: "proj-1",
+      surface: "studio",
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "agents-signed",
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 401);
+    assertEquals(await result.response.json(), { error: "Invalid control-plane signature" });
+  });
+});

--- a/src/server/handlers/request/internal-agents-list.handler.test.ts
+++ b/src/server/handlers/request/internal-agents-list.handler.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES } from "#veryfront/internal-agents/request-body.ts";
 import { InternalAgentsListHandler } from "./internal-agents-list.handler.ts";
@@ -122,6 +122,43 @@ describe("server/handlers/request/internal-agents-list.handler", () => {
     assertEquals(await result.response.json(), { error: "Invalid control-plane signature" });
   });
 
+  it("returns 401 when the project id in the signed claims does not match the body", async () => {
+    const handler = new InternalAgentsListHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: () => undefined,
+      getAllAgentIds: () => [],
+    });
+
+    const body = JSON.stringify({
+      requestId: "agents-1",
+      projectId: "proj-1",
+      surface: "studio",
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      projectId: "proj-2",
+      requestId: "agents-1",
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      {
+        ...createCtx(publicKeyPem),
+        projectId: undefined,
+      },
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 401);
+    assertEquals(await result.response.json(), { error: "Invalid control-plane signature" });
+  });
+
   it("rejects oversized list payloads before parsing", async () => {
     const handler = new InternalAgentsListHandler({
       ensureProjectDiscovery: async () => {},
@@ -183,5 +220,91 @@ describe("server/handlers/request/internal-agents-list.handler", () => {
     assertExists(result.response);
     assertEquals(result.response.status, 400);
     assertEquals(await result.response.json(), { error: "Invalid internal agents request" });
+  });
+
+  it("returns 400 when the request body shape is invalid", async () => {
+    const handler = new InternalAgentsListHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: () => undefined,
+      getAllAgentIds: () => [],
+    });
+
+    const body = JSON.stringify({
+      requestId: "agents-1",
+      projectId: "proj-1",
+      surface: 123,
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "agents-1",
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 400);
+    assertEquals(await result.response.json(), { error: "Invalid internal agents request" });
+  });
+
+  it("rethrows unexpected discovery failures", async () => {
+    const handler = new InternalAgentsListHandler({
+      ensureProjectDiscovery: async () => {
+        throw new Error("discovery boom");
+      },
+      getAgent: () => undefined,
+      getAllAgentIds: () => [],
+    });
+
+    const body = JSON.stringify({
+      requestId: "agents-1",
+      projectId: "proj-1",
+      surface: "studio",
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "agents-1",
+    });
+
+    await assertRejects(
+      () =>
+        handler.handle(
+          new Request("https://example.com/internal/agents/list", {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "x-veryfront-control-plane-jws": jws,
+            },
+            body,
+          }),
+          createCtx(publicKeyPem),
+        ),
+      Error,
+      "discovery boom",
+    );
+  });
+
+  it("ignores non-matching agents list routes", async () => {
+    const handler = new InternalAgentsListHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: () => undefined,
+      getAllAgentIds: () => [],
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/other", {
+        method: "POST",
+      }),
+      createCtx(),
+    );
+
+    assertEquals(result.response, undefined);
   });
 });

--- a/src/server/handlers/request/internal-agents-list.handler.test.ts
+++ b/src/server/handlers/request/internal-agents-list.handler.test.ts
@@ -1,102 +1,12 @@
-import type { Agent } from "#veryfront/agent";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import type { HandlerContext } from "#veryfront/types";
-import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+import { INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES } from "#veryfront/internal-agents/request-body.ts";
 import { InternalAgentsListHandler } from "./internal-agents-list.handler.ts";
-
-const encoder = new TextEncoder();
-
-function encodePem(label: string, der: ArrayBuffer): string {
-  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
-  const lines = base64.match(/.{1,64}/g) ?? [base64];
-  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
-}
-
-async function sha256Base64url(body: string): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(body));
-  return base64urlEncodeBytes(new Uint8Array(digest));
-}
-
-async function createControlPlaneSignature(
-  body: string,
-  overrides: Partial<{
-    audience: string;
-    projectId: string;
-    requestId: string;
-    surface: "studio" | "channels" | "a2a" | "mcp";
-  }> = {},
-): Promise<{ jws: string; publicKeyPem: string }> {
-  const keyPair = await crypto.subtle.generateKey(
-    "Ed25519",
-    true,
-    ["sign", "verify"],
-  ) as CryptoKeyPair;
-  const publicKeyDer = await crypto.subtle.exportKey("spki", keyPair.publicKey);
-  const publicKeyPem = encodePem("PUBLIC KEY", publicKeyDer);
-  const now = Math.floor(Date.now() / 1000);
-
-  const header = base64urlEncode(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
-  const payload = base64urlEncode(JSON.stringify({
-    iss: "veryfront-api",
-    aud: overrides.audience ?? "demo-project",
-    sub: overrides.requestId ?? "agents-1",
-    surface: overrides.surface ?? "studio",
-    project_id: overrides.projectId ?? "proj-1",
-    request_hash: await sha256Base64url(body),
-    iat: now,
-    exp: now + 60,
-  }));
-
-  const signingInput = encoder.encode(`${header}.${payload}`);
-  const signature = await crypto.subtle.sign("Ed25519", keyPair.privateKey, signingInput);
-
-  return {
-    publicKeyPem,
-    jws: `${header}.${payload}.${base64urlEncodeBytes(new Uint8Array(signature))}`,
-  };
-}
-
-function createCtx(publicKeyPem?: string): HandlerContext {
-  return {
-    projectDir: "/project",
-    adapter: {
-      env: {
-        get: (key: string) =>
-          key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? publicKeyPem : undefined,
-      },
-      fs: {},
-    },
-    securityConfig: null,
-    cspUserHeader: null,
-    projectSlug: "demo-project",
-    projectId: "proj-1",
-    isLocalProject: false,
-  } as unknown as HandlerContext;
-}
-
-function createAgent(): Agent {
-  return {
-    id: "assistant-1",
-    config: {
-      system: "You are Support.",
-      model: "anthropic/claude-sonnet-4-6",
-      name: "Support",
-      description: "Helps with support issues",
-      version: "1.0.0",
-    } as unknown as Agent["config"],
-    generate: async () => ({}) as never,
-    stream: async () => ({ toDataStreamResponse: () => new Response() } as never),
-    respond: async () => new Response(),
-    getMemory: () => ({} as never),
-    getMemoryStats: async () => ({
-      totalMessages: 0,
-      estimatedTokens: 0,
-      type: "conversation",
-    }),
-    clearMemory: async () => {},
-  };
-}
+import {
+  createAgentWithConfig,
+  createControlPlaneSignature,
+  createCtx,
+} from "./internal-agent-run.test-helpers.ts";
 
 describe("server/handlers/request/internal-agents-list.handler", () => {
   it("returns discovered agents for a valid signed request", async () => {
@@ -105,7 +15,14 @@ describe("server/handlers/request/internal-agents-list.handler", () => {
       ensureProjectDiscovery: async () => {
         discoveryCalls += 1;
       },
-      getAgent: (id) => id === "assistant-1" ? createAgent() : undefined,
+      getAgent: (id) =>
+        id === "assistant-1"
+          ? createAgentWithConfig("assistant-1", {
+            name: "Support",
+            description: "Helps with support issues",
+            version: "1.0.0",
+          })
+          : undefined,
       getAllAgentIds: () => ["assistant-1"],
     });
 
@@ -114,7 +31,9 @@ describe("server/handlers/request/internal-agents-list.handler", () => {
       projectId: "proj-1",
       surface: "studio",
     });
-    const { jws, publicKeyPem } = await createControlPlaneSignature(body);
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "agents-1",
+    });
 
     const result = await handler.handle(
       new Request("https://example.com/internal/agents/list", {
@@ -201,5 +120,39 @@ describe("server/handlers/request/internal-agents-list.handler", () => {
     assertExists(result.response);
     assertEquals(result.response.status, 401);
     assertEquals(await result.response.json(), { error: "Invalid control-plane signature" });
+  });
+
+  it("rejects oversized list payloads before parsing", async () => {
+    const handler = new InternalAgentsListHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: () => undefined,
+      getAllAgentIds: () => [],
+    });
+
+    const body = JSON.stringify({
+      requestId: "agents-1",
+      projectId: "proj-1",
+      surface: "studio",
+      metadata: "x".repeat(INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES + 1024),
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "agents-1",
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 413);
+    assertEquals(await result.response.json(), { error: "Payload too large" });
   });
 });

--- a/src/server/handlers/request/internal-agents-list.handler.ts
+++ b/src/server/handlers/request/internal-agents-list.handler.ts
@@ -1,0 +1,114 @@
+import { BaseHandler } from "../response/base.ts";
+import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
+import {
+  type ControlPlaneAgentsListRequest,
+  ControlPlaneAgentsListRequestSchema,
+  listRuntimeAgents,
+  type RuntimeAgentDiscoveryDeps,
+  verifyControlPlaneJws,
+} from "../../../channels/control-plane.ts";
+import { defaultChannelInvokeDeps } from "../../../channels/invoke.ts";
+import {
+  HTTP_INTERNAL_SERVER_ERROR,
+  PRIORITY_MEDIUM_API,
+} from "#veryfront/utils/constants/index.ts";
+
+const CONTROL_PLANE_JWS_HEADER = "x-veryfront-control-plane-jws";
+const MAX_CONTROL_PLANE_SIGNATURE_AGE_SECONDS = 60;
+
+export class InternalAgentsListHandler extends BaseHandler {
+  metadata: HandlerMetadata = {
+    name: "InternalAgentsListHandler",
+    priority: PRIORITY_MEDIUM_API as HandlerPriority,
+    patterns: [{ pattern: "/internal/agents/list", exact: true, method: "POST" }],
+  };
+
+  constructor(private readonly deps: RuntimeAgentDiscoveryDeps = defaultChannelInvokeDeps) {
+    super();
+  }
+
+  async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
+    if (!this.shouldHandle(req, ctx)) {
+      return this.continue();
+    }
+
+    return this.withProxyContext(ctx, async () => {
+      const builder = this.createResponseBuilder(ctx)
+        .withCORS(req, ctx.securityConfig?.cors)
+        .withSecurity(ctx.securityConfig ?? undefined, req);
+
+      const publicKeyPem = ctx.adapter.env.get("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
+      if (!publicKeyPem) {
+        this.logWarn("Missing CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY for internal agents list");
+        return this.respond(
+          builder.json(
+            { error: "Control-plane verification is not configured" },
+            HTTP_INTERNAL_SERVER_ERROR,
+          ),
+        );
+      }
+
+      const projectSlug = ctx.projectSlug;
+      if (!projectSlug) {
+        this.logWarn("Internal agents list request arrived without resolved project slug");
+        return this.respond(builder.json({ error: "Project context is unavailable" }, 400));
+      }
+
+      const controlPlaneJws = req.headers.get(CONTROL_PLANE_JWS_HEADER);
+      if (!controlPlaneJws) {
+        return this.respond(builder.json({ error: "Missing control-plane signature" }, 401));
+      }
+
+      const rawBody = await req.text();
+      let claims: Awaited<ReturnType<typeof verifyControlPlaneJws>> | undefined;
+      try {
+        claims = await verifyControlPlaneJws(controlPlaneJws, rawBody, {
+          audience: projectSlug,
+          expectedProjectId: ctx.projectId,
+          publicKeyPem,
+          maxAgeSeconds: MAX_CONTROL_PLANE_SIGNATURE_AGE_SECONDS,
+        });
+      } catch (error) {
+        this.logWarn("Internal agents list signature verification failed", {
+          error: error instanceof Error ? error.message : String(error),
+          projectSlug,
+          projectId: ctx.projectId,
+        });
+        return this.respond(builder.json({ error: "Invalid control-plane signature" }, 401));
+      }
+
+      let payload: ControlPlaneAgentsListRequest;
+      try {
+        payload = ControlPlaneAgentsListRequestSchema.parse(JSON.parse(rawBody));
+      } catch (error) {
+        this.logWarn("Internal agents list request validation failed", {
+          error: error instanceof Error ? error.message : String(error),
+          projectSlug,
+          projectId: ctx.projectId,
+        });
+        return this.respond(builder.json({ error: "Invalid internal agents request" }, 400));
+      }
+
+      if (
+        !claims ||
+        payload.projectId !== claims.project_id ||
+        (ctx.projectId !== undefined && payload.projectId !== ctx.projectId) ||
+        payload.requestId !== claims.sub ||
+        payload.surface !== claims.surface
+      ) {
+        this.logWarn("Internal agents list request body did not match signed claims", {
+          projectSlug,
+          projectId: ctx.projectId,
+          requestId: payload.requestId,
+          signedRequestId: claims?.sub,
+          surface: payload.surface,
+          signedSurface: claims?.surface,
+        });
+        return this.respond(builder.json({ error: "Invalid control-plane signature" }, 401));
+      }
+
+      const response = await listRuntimeAgents(ctx, this.deps);
+      return this.respond(builder.json(response, 200));
+    });
+  }
+}

--- a/src/server/handlers/request/internal-agents-list.handler.ts
+++ b/src/server/handlers/request/internal-agents-list.handler.ts
@@ -17,6 +17,7 @@ import {
   readInternalAgentRequestBody,
 } from "#veryfront/internal-agents/request-body.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
+import { ZodError } from "zod";
 
 export class InternalAgentsListHandler extends BaseHandler {
   metadata: HandlerMetadata = {
@@ -82,7 +83,7 @@ export class InternalAgentsListHandler extends BaseHandler {
           return this.respond(builder.json({ error: error.message }, error.status));
         }
 
-        if (error instanceof SyntaxError || (error instanceof Error && error.name === "ZodError")) {
+        if (error instanceof SyntaxError || error instanceof ZodError) {
           this.logWarn("Internal agents list request validation failed", {
             error: error instanceof Error ? error.message : String(error),
             projectSlug: ctx.projectSlug,

--- a/src/server/handlers/request/internal-agents-list.handler.ts
+++ b/src/server/handlers/request/internal-agents-list.handler.ts
@@ -5,16 +5,18 @@ import {
   ControlPlaneAgentsListRequestSchema,
   listRuntimeAgents,
   type RuntimeAgentDiscoveryDeps,
-  verifyControlPlaneJws,
 } from "../../../channels/control-plane.ts";
 import { defaultChannelInvokeDeps } from "../../../channels/invoke.ts";
 import {
-  HTTP_INTERNAL_SERVER_ERROR,
-  PRIORITY_MEDIUM_API,
-} from "#veryfront/utils/constants/index.ts";
-
-const CONTROL_PLANE_JWS_HEADER = "x-veryfront-control-plane-jws";
-const MAX_CONTROL_PLANE_SIGNATURE_AGE_SECONDS = 60;
+  ControlPlaneRequestError,
+  verifyControlPlaneRequest,
+} from "#veryfront/internal-agents/control-plane-auth.ts";
+import {
+  INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES,
+  InternalAgentRequestBodyTooLargeError,
+  readInternalAgentRequestBody,
+} from "#veryfront/internal-agents/request-body.ts";
+import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 
 export class InternalAgentsListHandler extends BaseHandler {
   metadata: HandlerMetadata = {
@@ -37,78 +39,60 @@ export class InternalAgentsListHandler extends BaseHandler {
         .withCORS(req, ctx.securityConfig?.cors)
         .withSecurity(ctx.securityConfig ?? undefined, req);
 
-      const publicKeyPem = ctx.adapter.env.get("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
-      if (!publicKeyPem) {
-        this.logWarn("Missing CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY for internal agents list");
-        return this.respond(
-          builder.json(
-            { error: "Control-plane verification is not configured" },
-            HTTP_INTERNAL_SERVER_ERROR,
-          ),
+      try {
+        const rawBody = await readInternalAgentRequestBody(
+          req,
+          INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES,
         );
-      }
-
-      const projectSlug = ctx.projectSlug;
-      if (!projectSlug) {
-        this.logWarn("Internal agents list request arrived without resolved project slug");
-        return this.respond(builder.json({ error: "Project context is unavailable" }, 400));
-      }
-
-      const controlPlaneJws = req.headers.get(CONTROL_PLANE_JWS_HEADER);
-      if (!controlPlaneJws) {
-        return this.respond(builder.json({ error: "Missing control-plane signature" }, 401));
-      }
-
-      const rawBody = await req.text();
-      let claims: Awaited<ReturnType<typeof verifyControlPlaneJws>> | undefined;
-      try {
-        claims = await verifyControlPlaneJws(controlPlaneJws, rawBody, {
-          audience: projectSlug,
-          expectedProjectId: ctx.projectId,
-          publicKeyPem,
-          maxAgeSeconds: MAX_CONTROL_PLANE_SIGNATURE_AGE_SECONDS,
+        const payload: ControlPlaneAgentsListRequest = ControlPlaneAgentsListRequestSchema.parse(
+          JSON.parse(rawBody),
+        );
+        const claims = await verifyControlPlaneRequest(req, ctx, rawBody, {
+          expectedSubject: payload.requestId,
+          expectedSurface: payload.surface,
         });
+
+        if (
+          payload.projectId !== claims.project_id ||
+          (ctx.projectId !== undefined && payload.projectId !== ctx.projectId)
+        ) {
+          this.logWarn("Internal agents list request body did not match signed claims", {
+            projectSlug: ctx.projectSlug,
+            projectId: ctx.projectId,
+            requestId: payload.requestId,
+            signedRequestId: claims.sub,
+            surface: payload.surface,
+            signedSurface: claims.surface,
+          });
+          return this.respond(builder.json({ error: "Invalid control-plane signature" }, 401));
+        }
+        const response = await listRuntimeAgents(ctx, this.deps);
+        return this.respond(builder.json(response, 200));
       } catch (error) {
-        this.logWarn("Internal agents list signature verification failed", {
-          error: error instanceof Error ? error.message : String(error),
-          projectSlug,
-          projectId: ctx.projectId,
-        });
-        return this.respond(builder.json({ error: "Invalid control-plane signature" }, 401));
-      }
+        if (error instanceof InternalAgentRequestBodyTooLargeError) {
+          return this.respond(builder.json({ error: error.message }, error.status));
+        }
 
-      let payload: ControlPlaneAgentsListRequest;
-      try {
-        payload = ControlPlaneAgentsListRequestSchema.parse(JSON.parse(rawBody));
-      } catch (error) {
-        this.logWarn("Internal agents list request validation failed", {
-          error: error instanceof Error ? error.message : String(error),
-          projectSlug,
-          projectId: ctx.projectId,
-        });
-        return this.respond(builder.json({ error: "Invalid internal agents request" }, 400));
-      }
+        if (error instanceof ControlPlaneRequestError) {
+          this.logWarn("Internal agents list signature verification failed", {
+            error: error.message,
+            projectSlug: ctx.projectSlug,
+            projectId: ctx.projectId,
+          });
+          return this.respond(builder.json({ error: error.message }, error.status));
+        }
 
-      if (
-        !claims ||
-        payload.projectId !== claims.project_id ||
-        (ctx.projectId !== undefined && payload.projectId !== ctx.projectId) ||
-        payload.requestId !== claims.sub ||
-        payload.surface !== claims.surface
-      ) {
-        this.logWarn("Internal agents list request body did not match signed claims", {
-          projectSlug,
-          projectId: ctx.projectId,
-          requestId: payload.requestId,
-          signedRequestId: claims?.sub,
-          surface: payload.surface,
-          signedSurface: claims?.surface,
-        });
-        return this.respond(builder.json({ error: "Invalid control-plane signature" }, 401));
-      }
+        if (error instanceof SyntaxError || (error instanceof Error && error.name === "ZodError")) {
+          this.logWarn("Internal agents list request validation failed", {
+            error: error instanceof Error ? error.message : String(error),
+            projectSlug: ctx.projectSlug,
+            projectId: ctx.projectId,
+          });
+          return this.respond(builder.json({ error: "Invalid internal agents request" }, 400));
+        }
 
-      const response = await listRuntimeAgents(ctx, this.deps);
-      return this.respond(builder.json(response, 200));
+        throw error;
+      }
     });
   }
 }

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -55,7 +55,6 @@ import { InternalAgentsListHandler } from "../handlers/request/internal-agents-l
 import { AgentStreamHandler } from "../handlers/request/agent-stream.handler.ts";
 import { AgentRunResumeHandler } from "../handlers/request/agent-run-resume.handler.ts";
 import { AgentRunCancelHandler } from "../handlers/request/agent-run-cancel.handler.ts";
-import { ChannelAssistantsHandler } from "../handlers/request/channel-assistants.handler.ts";
 import { ChannelInvokeHandler } from "../handlers/request/channel-invoke.handler.ts";
 import { DevDashboardHandler } from "../handlers/dev/dashboard/index.ts";
 import { ProjectsHandler } from "../handlers/dev/projects/index.ts";
@@ -212,7 +211,6 @@ export function createVeryfrontHandler(
     new AgentStreamHandler(),
     new AgentRunResumeHandler(),
     new AgentRunCancelHandler(),
-    new ChannelAssistantsHandler(),
     new ChannelInvokeHandler(),
     new DevDashboardHandler(),
     new ProjectsHandler(),

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -52,6 +52,9 @@ import { MarkdownPreviewHandler } from "../handlers/preview/markdown-preview.han
 import { OpenAPIHandler } from "../handlers/request/openapi.handler.ts";
 import { OpenAPIDocsHandler } from "../handlers/request/openapi-docs.handler.ts";
 import { InternalAgentsListHandler } from "../handlers/request/internal-agents-list.handler.ts";
+import { AgentStreamHandler } from "../handlers/request/agent-stream.handler.ts";
+import { AgentRunResumeHandler } from "../handlers/request/agent-run-resume.handler.ts";
+import { AgentRunCancelHandler } from "../handlers/request/agent-run-cancel.handler.ts";
 import { ChannelAssistantsHandler } from "../handlers/request/channel-assistants.handler.ts";
 import { ChannelInvokeHandler } from "../handlers/request/channel-invoke.handler.ts";
 import { DevDashboardHandler } from "../handlers/dev/dashboard/index.ts";
@@ -206,6 +209,9 @@ export function createVeryfrontHandler(
     new OpenAPIHandler(),
     new OpenAPIDocsHandler(),
     new InternalAgentsListHandler(),
+    new AgentStreamHandler(),
+    new AgentRunResumeHandler(),
+    new AgentRunCancelHandler(),
     new ChannelAssistantsHandler(),
     new ChannelInvokeHandler(),
     new DevDashboardHandler(),

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -51,6 +51,7 @@ import { HMRHandler } from "../handlers/preview/hmr.handler.ts";
 import { MarkdownPreviewHandler } from "../handlers/preview/markdown-preview.handler.ts";
 import { OpenAPIHandler } from "../handlers/request/openapi.handler.ts";
 import { OpenAPIDocsHandler } from "../handlers/request/openapi-docs.handler.ts";
+import { InternalAgentsListHandler } from "../handlers/request/internal-agents-list.handler.ts";
 import { ChannelAssistantsHandler } from "../handlers/request/channel-assistants.handler.ts";
 import { ChannelInvokeHandler } from "../handlers/request/channel-invoke.handler.ts";
 import { DevDashboardHandler } from "../handlers/dev/dashboard/index.ts";
@@ -204,6 +205,7 @@ export function createVeryfrontHandler(
     new DebugContextHandler(),
     new OpenAPIHandler(),
     new OpenAPIDocsHandler(),
+    new InternalAgentsListHandler(),
     new ChannelAssistantsHandler(),
     new ChannelInvokeHandler(),
     new DevDashboardHandler(),

--- a/src/testing/bdd.ts
+++ b/src/testing/bdd.ts
@@ -36,11 +36,53 @@ export interface BddTestContext {
 /** Hook function */
 type HookFn = (ctx?: BddTestContext) => void | Promise<void>;
 
+type EnvOverlayStorageShim = {
+  storage: {
+    getStore: () => unknown;
+    run?: <T>(store: unknown, fn: () => T) => T;
+    enterWith?: (store: unknown) => void;
+  };
+};
+
+async function installDenoEnvOverlayStorage(): Promise<void> {
+  if (!isDeno) return;
+
+  const globalAny = globalThis as Record<string, unknown>;
+  if (globalAny["__vfTestDenoEnvOverlay"]) return;
+
+  const { AsyncLocalStorage } = await import("node:async_hooks");
+
+  globalAny["__vfTestDenoEnvOverlay"] = {
+    storage: new AsyncLocalStorage<Map<string, string | null>>(),
+  } satisfies EnvOverlayStorageShim;
+}
+
+function withEnvOverlay<T extends TestFn | (() => void)>(fn: T): T {
+  const overlay = getEnvOverlayStorage();
+  if (!overlay) return fn;
+
+  return ((...args: unknown[]) => {
+    if (overlay.run) {
+      return overlay.run(
+        new Map<string, string | null>(),
+        () => Promise.resolve().then(() => fn(...(args as []))),
+      );
+    }
+
+    if (overlay.enterWith) {
+      overlay.enterWith(new Map<string, string | null>());
+    }
+
+    return fn(...(args as []));
+  }) as T;
+}
+
 // For Deno, we directly use @std/testing/bdd - no wrapper needed
 // This avoids creating a "global" test suite from top-level await
 let denoBdd: typeof import("#std/testing/bdd") | null = null;
 
 if (isDeno) {
+  await installDenoEnvOverlayStorage();
   denoBdd = await import("#std/testing/bdd");
 }
 
@@ -166,19 +208,6 @@ function createBunImpl(bunTest: BunTestModule): BddImpl {
     const parsed = Number(raw);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : 30000;
   })();
-
-  function withEnvOverlay(fn: TestFn): TestFn {
-    return async () => {
-      const overlay = getEnvOverlayStorage();
-      if (overlay?.run) {
-        return await overlay.run(new Map(), () => Promise.resolve().then(fn));
-      }
-      if (overlay?.enterWith) {
-        overlay.enterWith(new Map());
-      }
-      return await fn();
-    };
-  }
 
   return {
     describe(nameOrOptions, optionsOrFn, fn): void {
@@ -364,14 +393,15 @@ export function it(
 
   const { name, options, testFn } = parseBddArgs(nameOrOptions, optionsOrFn, fn);
   if (!testFn) throw new Error("it requires a test function");
+  const testWithEnv = withEnvOverlay(testFn);
 
   const denoOptions = normalizeDenoOptions(options);
   if (hasOptions(denoOptions)) {
-    denoBdd.it({ name, ...denoOptions }, testFn);
+    denoBdd.it({ name, ...denoOptions }, testWithEnv);
     return;
   }
 
-  denoBdd.it(name, testFn);
+  denoBdd.it(name, testWithEnv);
 }
 
 it.skip = function skip(
@@ -380,13 +410,14 @@ it.skip = function skip(
   fn?: TestFn,
 ): void {
   const { name, testFn } = getNameAndFn(nameOrOptions, optionsOrFn, fn);
+  const testWithEnv = withEnvOverlay(testFn);
 
   if (denoBdd) {
-    denoBdd.it({ name, ignore: true }, testFn);
+    denoBdd.it({ name, ignore: true }, testWithEnv);
     return;
   }
 
-  requireImpl().it({ name, ignore: true }, testFn);
+  requireImpl().it({ name, ignore: true }, testWithEnv);
 };
 
 it.ignore = it.skip;
@@ -397,13 +428,14 @@ it.only = function only(
   fn?: TestFn,
 ): void {
   const { name, testFn } = getNameAndFn(nameOrOptions, optionsOrFn, fn);
+  const testWithEnv = withEnvOverlay(testFn);
 
   if (denoBdd) {
-    denoBdd.it({ name, only: true }, testFn);
+    denoBdd.it({ name, only: true }, testWithEnv);
     return;
   }
 
-  requireImpl().it({ name, only: true }, testFn);
+  requireImpl().it({ name, only: true }, testWithEnv);
 };
 
 export function beforeEach(fn: HookFn): void {

--- a/src/testing/bdd.ts
+++ b/src/testing/bdd.ts
@@ -44,17 +44,149 @@ type EnvOverlayStorageShim = {
   };
 };
 
+type EnvOverlayValue = string | null;
+type EnvOverlayStore = Map<string, EnvOverlayValue>;
+
+type DenoEnvFacade = {
+  get: (key: string) => string | undefined;
+  set: (key: string, value: string) => void;
+  delete: (key: string) => void;
+  has: (key: string) => boolean;
+  toObject: () => Record<string, string>;
+};
+
+function getActiveEnvOverlay(): EnvOverlayStore | null {
+  const storage = getEnvOverlayStorage();
+  const store = storage?.getStore();
+  return store instanceof Map ? store as EnvOverlayStore : null;
+}
+
+function applyEnvOverlay(
+  base: Record<string, string>,
+  overlay: EnvOverlayStore | null,
+): Record<string, string> {
+  if (!overlay) return { ...base };
+
+  const merged = { ...base };
+  for (const [key, value] of overlay.entries()) {
+    if (value === null) {
+      delete merged[key];
+      continue;
+    }
+    merged[key] = value;
+  }
+  return merged;
+}
+
+function installDenoEnvOverlayFacade(): void {
+  if (!isDeno || typeof Deno === "undefined" || typeof Deno.env === "undefined") return;
+
+  const globalAny = globalThis as Record<string, unknown>;
+  if (globalAny["__vfTestDenoEnvOverlayFacadeInstalled"]) return;
+  globalAny["__vfTestDenoEnvOverlayFacadeInstalled"] = true;
+
+  const originalDenoEnv = {
+    get: Deno.env.get.bind(Deno.env),
+    set: Deno.env.set.bind(Deno.env),
+    delete: Deno.env.delete.bind(Deno.env),
+    has: Deno.env.has.bind(Deno.env),
+    toObject: Deno.env.toObject.bind(Deno.env),
+  } satisfies DenoEnvFacade;
+
+  Deno.env.get = (key: string): string | undefined => {
+    const overlay = getActiveEnvOverlay();
+    if (overlay?.has(key)) return overlay.get(key) ?? undefined;
+    return originalDenoEnv.get(key);
+  };
+
+  Deno.env.set = (key: string, value: string): void => {
+    const overlay = getActiveEnvOverlay();
+    if (overlay) {
+      overlay.set(key, value);
+      return;
+    }
+    originalDenoEnv.set(key, value);
+  };
+
+  Deno.env.delete = (key: string): void => {
+    const overlay = getActiveEnvOverlay();
+    if (overlay) {
+      overlay.set(key, null);
+      return;
+    }
+    originalDenoEnv.delete(key);
+  };
+
+  Deno.env.has = (key: string): boolean => {
+    const overlay = getActiveEnvOverlay();
+    if (overlay?.has(key)) return overlay.get(key) !== null;
+    return originalDenoEnv.has(key);
+  };
+
+  Deno.env.toObject = (): Record<string, string> => {
+    return applyEnvOverlay(originalDenoEnv.toObject(), getActiveEnvOverlay());
+  };
+
+  const processAny = globalAny["process"] as
+    | { env?: Record<string, string | undefined> }
+    | undefined;
+  if (!processAny?.env) return;
+
+  const baseProcessEnv = processAny.env;
+  processAny.env = new Proxy(baseProcessEnv, {
+    get(target, prop, receiver) {
+      if (typeof prop !== "string") return Reflect.get(target, prop, receiver);
+      return Deno.env.get(prop);
+    },
+    set(target, prop, value, receiver) {
+      if (typeof prop !== "string") return Reflect.set(target, prop, value, receiver);
+      Deno.env.set(prop, String(value));
+      return true;
+    },
+    deleteProperty(target, prop) {
+      if (typeof prop !== "string") return Reflect.deleteProperty(target, prop);
+      Deno.env.delete(prop);
+      return true;
+    },
+    has(target, prop) {
+      if (typeof prop !== "string") return Reflect.has(target, prop);
+      return Deno.env.has(prop);
+    },
+    ownKeys() {
+      return Object.keys(Deno.env.toObject());
+    },
+    getOwnPropertyDescriptor(target, prop) {
+      if (typeof prop !== "string") return Reflect.getOwnPropertyDescriptor(target, prop);
+      const value = Deno.env.get(prop);
+      if (value === undefined) return undefined;
+      return {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value,
+      };
+    },
+  });
+}
+
 async function installDenoEnvOverlayStorage(): Promise<void> {
   if (!isDeno) return;
 
   const globalAny = globalThis as Record<string, unknown>;
-  if (globalAny["__vfTestDenoEnvOverlay"]) return;
+  if (!globalAny["__vfTestDenoEnvOverlay"]) {
+    const { AsyncLocalStorage } = await import("node:async_hooks");
+    const storage = new AsyncLocalStorage<EnvOverlayStore>();
 
-  const { AsyncLocalStorage } = await import("node:async_hooks");
+    globalAny["__vfTestDenoEnvOverlay"] = {
+      storage: {
+        getStore: () => storage.getStore(),
+        run: <T>(store: unknown, fn: () => T) => storage.run(store as EnvOverlayStore, fn),
+        enterWith: (store: unknown) => storage.enterWith(store as EnvOverlayStore),
+      },
+    } satisfies EnvOverlayStorageShim;
+  }
 
-  globalAny["__vfTestDenoEnvOverlay"] = {
-    storage: new AsyncLocalStorage<Map<string, string | null>>(),
-  } satisfies EnvOverlayStorageShim;
+  installDenoEnvOverlayFacade();
 }
 
 function withEnvOverlay<T extends TestFn | (() => void)>(fn: T): T {

--- a/src/testing/mock-fetch.ts
+++ b/src/testing/mock-fetch.ts
@@ -1,0 +1,38 @@
+type FetchMock = typeof globalThis.fetch | undefined;
+
+const FETCH_MOCK_QUEUE_KEY = "__vfTestFetchMockQueue";
+
+function getFetchMockQueue(): Promise<void> {
+  const globalAny = globalThis as Record<string, unknown>;
+  const queue = globalAny[FETCH_MOCK_QUEUE_KEY];
+  return queue instanceof Promise ? queue : Promise.resolve();
+}
+
+function setFetchMockQueue(queue: Promise<void>): void {
+  (globalThis as Record<string, unknown>)[FETCH_MOCK_QUEUE_KEY] = queue;
+}
+
+export async function withMockFetch<T>(
+  mockFetch: FetchMock,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prior = getFetchMockQueue().catch(() => undefined);
+  let release: (() => void) | null = null;
+  const next = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  setFetchMockQueue(prior.finally(() => next));
+  await prior;
+
+  const originalFetch = globalThis.fetch;
+  // @ts-ignore tests intentionally override the host fetch implementation
+  globalThis.fetch = mockFetch;
+
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = originalFetch;
+    release?.();
+  }
+}

--- a/src/utils/env-loader.test.ts
+++ b/src/utils/env-loader.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { deleteEnv, getEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import { __resetEnvLoaderForTests, loadEnv, supportsEnvFiles } from "./env-loader.ts";
 import { __resetLoggerConfigForTests, type LogEntry, serverLogger } from "./logger/index.ts";
 
@@ -48,7 +49,7 @@ describe("env-loader", () => {
   }
 
   function cleanupKeys(...keys: string[]): void {
-    for (const key of keys) Deno.env.delete(key);
+    for (const key of keys) deleteEnv(key);
   }
 
   describe("supportsEnvFiles", () => {
@@ -63,7 +64,7 @@ describe("env-loader", () => {
       await writeEnvFile(".env", `${key}=hello`);
 
       await loadEnv({ cwd: tempDir, override: true });
-      assertEquals(Deno.env.get(key), "hello");
+      assertEquals(getEnv(key), "hello");
 
       cleanupKeys(key);
     });
@@ -76,7 +77,7 @@ describe("env-loader", () => {
       );
 
       await loadEnv({ cwd: tempDir, override: true });
-      assertEquals(Deno.env.get(key), "value");
+      assertEquals(getEnv(key), "value");
 
       cleanupKeys(key);
     });
@@ -86,7 +87,7 @@ describe("env-loader", () => {
       await writeEnvFile(".env", `${key}="hello world"`);
 
       await loadEnv({ cwd: tempDir, override: true });
-      assertEquals(Deno.env.get(key), "hello world");
+      assertEquals(getEnv(key), "hello world");
 
       cleanupKeys(key);
     });
@@ -96,7 +97,7 @@ describe("env-loader", () => {
       await writeEnvFile(".env", `${key}='hello world'`);
 
       await loadEnv({ cwd: tempDir, override: true });
-      assertEquals(Deno.env.get(key), "hello world");
+      assertEquals(getEnv(key), "hello world");
 
       cleanupKeys(key);
     });
@@ -106,7 +107,7 @@ describe("env-loader", () => {
       await writeEnvFile(".env", `${key}=value # comment`);
 
       await loadEnv({ cwd: tempDir, override: true });
-      assertEquals(Deno.env.get(key), "value");
+      assertEquals(getEnv(key), "value");
 
       cleanupKeys(key);
     });
@@ -117,29 +118,29 @@ describe("env-loader", () => {
       await writeEnvFile(".env", `${key1}=hello\n${key2}=\${${key1}}_world`);
 
       await loadEnv({ cwd: tempDir, override: true });
-      assertEquals(Deno.env.get(key2), "hello_world");
+      assertEquals(getEnv(key2), "hello_world");
 
       cleanupKeys(key1, key2);
     });
 
     it("should not override existing env vars by default", async () => {
       const key = createKey("NOOVERRIDE");
-      Deno.env.set(key, "existing");
+      setEnv(key, "existing");
       await writeEnvFile(".env", `${key}=new`);
 
       await loadEnv({ cwd: tempDir });
-      assertEquals(Deno.env.get(key), "existing");
+      assertEquals(getEnv(key), "existing");
 
       cleanupKeys(key);
     });
 
     it("should override existing env vars when override is true", async () => {
       const key = createKey("OVERRIDE");
-      Deno.env.set(key, "existing");
+      setEnv(key, "existing");
       await writeEnvFile(".env", `${key}=new`);
 
       await loadEnv({ cwd: tempDir, override: true });
-      assertEquals(Deno.env.get(key), "new");
+      assertEquals(getEnv(key), "new");
 
       cleanupKeys(key);
     });
@@ -149,7 +150,7 @@ describe("env-loader", () => {
       await writeEnvFile(".env", `${key}="line1\nline2"`);
 
       await loadEnv({ cwd: tempDir, override: true });
-      assertEquals(Deno.env.get(key), "line1\nline2");
+      assertEquals(getEnv(key), "line1\nline2");
 
       cleanupKeys(key);
     });
@@ -160,7 +161,7 @@ describe("env-loader", () => {
       await writeEnvFile(".env.local", `${key}=from_local`);
 
       await loadEnv({ cwd: tempDir, override: true });
-      assertEquals(Deno.env.get(key), "from_local");
+      assertEquals(getEnv(key), "from_local");
 
       cleanupKeys(key);
     });
@@ -170,7 +171,7 @@ describe("env-loader", () => {
       await writeEnvFile(".env", `noequalssign\n${key}=valid`);
 
       await loadEnv({ cwd: tempDir, override: true });
-      assertEquals(Deno.env.get(key), "valid");
+      assertEquals(getEnv(key), "valid");
 
       cleanupKeys(key);
     });
@@ -184,7 +185,7 @@ describe("env-loader", () => {
       await writeEnvFile(".env", `${key}=`);
 
       await loadEnv({ cwd: tempDir, override: true });
-      assertEquals(Deno.env.get(key), "");
+      assertEquals(getEnv(key), "");
 
       cleanupKeys(key);
     });
@@ -194,7 +195,7 @@ describe("env-loader", () => {
       await writeEnvFile(".env", `${key}=a=b=c`);
 
       await loadEnv({ cwd: tempDir, override: true });
-      assertEquals(Deno.env.get(key), "a=b=c");
+      assertEquals(getEnv(key), "a=b=c");
 
       cleanupKeys(key);
     });
@@ -204,19 +205,19 @@ describe("env-loader", () => {
       await writeEnvFile(".env", `  ${key}  =value`);
 
       await loadEnv({ cwd: tempDir, override: true });
-      assertEquals(Deno.env.get(key), "value");
+      assertEquals(getEnv(key), "value");
 
       cleanupKeys(key);
     });
 
     it("should refresh logger format after loading NODE_ENV from .env", async () => {
-      const previousNodeEnv = Deno.env.get("NODE_ENV");
-      const previousLogFormat = Deno.env.get("LOG_FORMAT");
+      const previousNodeEnv = getEnv("NODE_ENV");
+      const previousLogFormat = getEnv("LOG_FORMAT");
       const { getOutput, reset, restore } = captureConsoleLog();
 
       try {
-        Deno.env.delete("NODE_ENV");
-        Deno.env.delete("LOG_FORMAT");
+        deleteEnv("NODE_ENV");
+        deleteEnv("LOG_FORMAT");
         __resetLoggerConfigForTests();
 
         serverLogger.info("Text before loadEnv");
@@ -233,10 +234,10 @@ describe("env-loader", () => {
         assertEquals(entry.message, "JSON after loadEnv");
       } finally {
         restore();
-        if (previousNodeEnv === undefined) Deno.env.delete("NODE_ENV");
-        else Deno.env.set("NODE_ENV", previousNodeEnv);
-        if (previousLogFormat === undefined) Deno.env.delete("LOG_FORMAT");
-        else Deno.env.set("LOG_FORMAT", previousLogFormat);
+        if (previousNodeEnv === undefined) deleteEnv("NODE_ENV");
+        else setEnv("NODE_ENV", previousNodeEnv);
+        if (previousLogFormat === undefined) deleteEnv("LOG_FORMAT");
+        else setEnv("LOG_FORMAT", previousLogFormat);
         __resetLoggerConfigForTests();
       }
     });


### PR DESCRIPTION
## Summary

This PR adds the runtime-side support for durable project-agent execution.

It introduces the internal discovery, stream, resume, and cancel surfaces that the API control plane uses to execute project-agent runs against veryfront-code.

## Changes

- add internal runtime agent discovery endpoint
- add internal project-agent stream handler
- add resume and cancel handlers for durable runs
- translate runtime activity into AG-UI SSE events
- add control-plane auth validation and session lifecycle management
- add targeted tests for stream, resume, cancel, and session behavior

## Verification

- `deno task verify:quick`
- `deno test --no-check --allow-all src/internal-agents/session-manager.test.ts src/server/handlers/request/agent-stream.handler.test.ts src/server/handlers/request/agent-run-resume.handler.test.ts src/server/handlers/request/agent-run-cancel.handler.test.ts`
