### PR TITLE
chore: add project-level Claude Code skills

### DIFF
--- a/.claude/skills/vf-cli-output/SKILL.md
+++ b/.claude/skills/vf-cli-output/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: vf-cli-output
+description: Use when writing CLI commands, TUI output, terminal messages, error formatting, or machine-readable output in veryfront CLI
+---
+
+# Veryfront CLI Output Patterns
+
+## Overview
+
+Veryfront CLI follows a strict style guide for terminal output. Human-first by default, machine output via `--json`.
+
+**Core principle:** Simple, empathetic, consistent. Red is only for errors.
+
+## Output Helpers
+
+```typescript
+import { brand, dim, error, muted, success, warning } from "#cli/ui";
+
+// Success
+console.log("  " + success("✓") + " Done");
+
+// Error
+console.log("  " + error("✗") + " Failed to compile");
+console.log("  " + dim("Try running: deno task typecheck"));
+
+// Active/Info
+console.log("  " + brand("●") + " Building project...");
+
+// Inactive
+console.log("  " + muted("○") + " Waiting");
+
+// Warning
+console.log("  " + warning("!") + " This option is deprecated");
+```
+
+## Formatting Rules
+
+| Rule | Example |
+|------|---------|
+| 2-space indent for all content | `"  ✓ Done"` |
+| Blank line between logical sections | Separate status groups |
+| Red only for errors | Never red for warnings or info |
+| Yellow for warnings | `warning("!")` |
+| No emoji in standard output | Use text icons: `✓ ✗ ● ○ !` |
+| Respect `NO_COLOR` env var | Colors auto-disable |
+
+## Icons
+
+| Icon | Meaning | Helper |
+|------|---------|--------|
+| `✓` | Success/complete | `success()` |
+| `✗` | Error/failure | `error()` |
+| `●` | Active/running | `brand()` |
+| `○` | Inactive/pending | `muted()` |
+| `!` | Warning/caution | `warning()` |
+
+## Error Messages
+
+Errors must be empathetic and actionable:
+
+```typescript
+// Good: specific, actionable
+console.log("  " + error("✗") + " Config file not found");
+console.log("  " + dim("Expected: veryfront.config.ts in project root"));
+console.log("  " + dim("Run: veryfront init to create one"));
+
+// Bad: vague, unhelpful
+console.log("Error: config error");
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | General error |
+| `2` | Invalid usage (wrong args, missing required) |
+| `130` | Interrupted (Ctrl+C) |
+
+## Machine Output (`--json`)
+
+```typescript
+// Success
+console.log(JSON.stringify({
+  success: true,
+  data: { url: "https://app.veryfront.com", projectId: "abc" }
+}));
+
+// Error
+console.log(JSON.stringify({
+  success: false,
+  error: { code: "PROJECT_NOT_FOUND", message: "No project found in current directory" }
+}));
+```
+
+**Rules for `--json`:**
+- One JSON object per line
+- Always include `success` boolean
+- Success: `data` field with structured result
+- Error: `error` field with `code` and `message`
+- No colors, no icons, no formatting
+- Stderr for progress/debug, stdout for result
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Red for warnings | Use `warning()` (yellow) |
+| Missing indent | Always 2-space prefix |
+| No actionable fix in error | Add `dim("Try: ...")` suggestion |
+| Console emoji | Use text icons `✓ ✗ ● ○ !` |
+| `process.exit(1)` without message | Print error first, then exit |
+| Mixed stdout for progress + result | Progress to stderr, result to stdout |

--- a/.claude/skills/vf-error-handling/SKILL.md
+++ b/.claude/skills/vf-error-handling/SKILL.md
@@ -17,15 +17,15 @@ Veryfront uses a centralized error registry with slug-based identification. All 
 
 ```typescript
 // In src/errors/error-registry.ts
-import { defineError } from "./define-error.ts";
+import { defineError } from "./types.ts";
 
-export const MY_NEW_ERROR = defineError(
-  "my-new-error",        // slug (kebab-case, unique)
-  "RUNTIME",             // category: CONFIG | BUILD | RUNTIME | ROUTE | MODULE | SERVER | BOUNDARY | DEV | DEPLOY | AGENT | GENERAL
-  500,                   // default HTTP status
-  "Something went wrong", // title (human-readable)
-  "Try doing X instead"  // suggestion (actionable fix)
-);
+export const MY_NEW_ERROR = defineError({
+  slug: "my-new-error",           // kebab-case, unique
+  category: "RUNTIME",            // CONFIG | BUILD | RUNTIME | ROUTE | MODULE | SERVER | BOUNDARY | DEV | DEPLOY | AGENT | GENERAL
+  status: 500,                    // default HTTP status
+  title: "Something went wrong",  // human-readable
+  suggestion: "Try doing X instead", // actionable fix
+});
 ```
 
 ### Throwing Errors
@@ -64,13 +64,13 @@ When replacing `class FooError extends Error`:
 
 ```typescript
 // src/errors/error-registry.ts
-export const FOO_ERROR = defineError(
-  "foo-error",
-  "RUNTIME",
-  500,
-  "Foo operation failed",
-  "Check the foo configuration"
-);
+export const FOO_ERROR = defineError({
+  slug: "foo-error",
+  category: "RUNTIME",
+  status: 500,
+  title: "Foo operation failed",
+  suggestion: "Check the foo configuration",
+});
 ```
 
 ### Step 2: Update Usage Sites

--- a/.claude/skills/vf-error-handling/SKILL.md
+++ b/.claude/skills/vf-error-handling/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: vf-error-handling
+description: Use when creating new errors, migrating error classes to registry, catching/handling errors, or working with the VeryfrontError system
+---
+
+# Veryfront Error Handling
+
+## Overview
+
+Veryfront uses a centralized error registry with slug-based identification. All errors extend `VeryfrontError` and are created via `defineError()`.
+
+**Core principle:** Never throw raw `Error`. Use the registry. Never identify errors by class name. Use slugs.
+
+## Error Registry Pattern
+
+### Defining New Errors
+
+```typescript
+// In src/errors/error-registry.ts
+import { defineError } from "./define-error.ts";
+
+export const MY_NEW_ERROR = defineError(
+  "my-new-error",        // slug (kebab-case, unique)
+  "RUNTIME",             // category: CONFIG | BUILD | RUNTIME | ROUTE | MODULE | SERVER | BOUNDARY | DEV | DEPLOY | AGENT | GENERAL
+  500,                   // default HTTP status
+  "Something went wrong", // title (human-readable)
+  "Try doing X instead"  // suggestion (actionable fix)
+);
+```
+
+### Throwing Errors
+
+```typescript
+import { MY_NEW_ERROR } from "#veryfront/errors";
+
+throw MY_NEW_ERROR.create({
+  detail: "Specific description of what happened",
+  context: { key: "value", relevantData: data },
+  cause: originalError,  // optional: chain the original error
+});
+```
+
+### Catching Errors
+
+```typescript
+import { VeryfrontError } from "#veryfront/errors";
+
+try {
+  riskyOperation();
+} catch (error) {
+  if (error instanceof VeryfrontError && error.slug === "my-new-error") {
+    // Handle specific error
+    console.log(error.context.relevantData);
+  }
+  throw error; // Re-throw unknown errors
+}
+```
+
+## Migrating Class-Based Errors to Registry
+
+When replacing `class FooError extends Error`:
+
+### Step 1: Define in Registry
+
+```typescript
+// src/errors/error-registry.ts
+export const FOO_ERROR = defineError(
+  "foo-error",
+  "RUNTIME",
+  500,
+  "Foo operation failed",
+  "Check the foo configuration"
+);
+```
+
+### Step 2: Update Usage Sites
+
+```typescript
+// Before
+throw new FooError("something failed", { details: data });
+
+// After
+throw FOO_ERROR.create({
+  detail: "something failed",
+  context: { details: data },
+});
+```
+
+### Step 3: Update Error Checks
+
+```typescript
+// Before
+if (error instanceof FooError) { ... }
+
+// After
+if (error instanceof VeryfrontError && error.slug === "foo-error") { ... }
+```
+
+### Step 4: Update Export Chains
+
+Follow the re-export chain and update each level:
+1. `src/module/types.ts` — remove class, add registry import if needed
+2. `src/module/index.ts` — change export
+3. Parent `index.ts` files up the chain
+4. `src/module/index.test.ts` — change `typeof X === "function"` to `typeof X === "object"`
+
+### Step 5: Remove Old Class
+
+Delete the old error class file entirely. No backwards-compatibility shims.
+
+## VeryfrontError Fields
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `slug` | `string` | Unique identifier (kebab-case) |
+| `category` | `ErrorCategory` | Error domain |
+| `status` | `number` | HTTP status code |
+| `title` | `string` | Human-readable title |
+| `suggestion` | `string` | Actionable fix |
+| `detail` | `string` | Specific instance description |
+| `context` | `Record<string, unknown>` | Structured metadata |
+| `cause` | `Error` | Original error (chain) |
+| `instance` | `string` | Request/instance identifier |
+
+## RFC 9457 Support
+
+```typescript
+// Convert to Problem Details format for HTTP APIs
+const problemDetails = error.toRFC9457();
+// Returns: { type, title, status, detail, instance, ...extensions }
+```
+
+## Intentionally Local Errors
+
+Five errors remain as local classes by design (not in registry):
+- `SemaphoreTimeoutError`
+- `TransformTreeTimeoutError`
+- `NotSupportedError`
+- `TimeoutError`
+- `StreamTimeoutError`
+
+Do not migrate these to the registry.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| `throw new Error("msg")` | Use registry: `MY_ERROR.create({ detail: "msg" })` |
+| `instanceof FooError` | `instanceof VeryfrontError && error.slug === "foo-error"` |
+| Storing data in `error.message` | Use `error.detail` and `error.context` |
+| Forgetting to update index.test.ts | Change function→object type check |
+| Creating error class in module | Define in `src/errors/error-registry.ts` |

--- a/.claude/skills/vf-module-development/SKILL.md
+++ b/.claude/skills/vf-module-development/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: vf-module-development
+description: Use when creating new modules, adding exports, modifying module boundaries, or restructuring code in src/ - covers layer architecture, hash imports, barrel exports, and dependency rules
+---
+
+# Veryfront Module Development
+
+## Overview
+
+Veryfront has 45+ modules in `src/`, organized in strict dependency layers. Each module has a clear public API via barrel exports.
+
+**Core principle:** Modules communicate through their public API. Never import from another module's internals.
+
+## Dependency Layers
+
+```
+Layer 5 (top):    Orchestrators  → server/, proxy/, build/, cli/
+Layer 4:          Features       → data/, html/, react/, rendering/
+Layer 3:          Module System  → modules/, transforms/, cache/
+Layer 2:          Infrastructure → security/, routing/, middleware/
+Layer 1 (bottom): Foundation     → config/, types/, utils/, errors/, platform/
+```
+
+**Rules:**
+- A module may only import from its own layer or lower layers
+- Never import upward (e.g., Foundation must not import from Features)
+- Validate with: `deno task validate:architecture`
+
+## Module Structure
+
+```
+src/my-module/
+├── index.ts              # Public API (barrel exports only)
+├── index.test.ts         # Export verification test
+├── types.ts              # Public types and interfaces
+├── implementation.ts     # Core logic
+├── factory.ts            # Factory functions (if needed)
+├── utils.ts              # Module-internal utilities
+└── sub-feature/          # Sub-directories for complex modules
+    ├── index.ts
+    └── implementation.ts
+```
+
+## Hash Imports
+
+All internal imports use hash-based aliases defined in `deno.json`:
+
+```typescript
+// Correct
+import { VeryfrontError } from "#veryfront/errors";
+import { defineConfig } from "#veryfront/config";
+import { logger } from "#veryfront/utils/logger";
+
+// Wrong - never use relative paths across modules
+import { VeryfrontError } from "../../errors/types.ts";
+```
+
+Within the same module, use relative imports:
+
+```typescript
+// Within src/my-module/
+import { MyType } from "./types.ts";
+import { helper } from "./utils.ts";
+```
+
+## Barrel Exports (index.ts)
+
+Every module's `index.ts` is its public API:
+
+```typescript
+// src/my-module/index.ts
+
+// Re-export public types
+export type { MyConfig, MyOptions } from "./types.ts";
+
+// Re-export public functions/constants
+export { createMyThing } from "./factory.ts";
+export { MY_ERROR_CONSTANT } from "#veryfront/errors";
+```
+
+**Rules:**
+- Named exports only (no default exports)
+- No logic in index.ts — only re-exports
+- Every export must have JSDoc (enforced by `deno task lint:barrel-jsdoc`)
+- No wildcard exports (enforced by `deno task lint:wildcard-exports`)
+
+## Export Verification Test
+
+Every module needs an `index.test.ts`:
+
+```typescript
+import * as mod from "./index.ts";
+import { describe, it } from "#veryfront/testing/bdd";
+import { assertEquals } from "#veryfront/testing/assert";
+
+describe("my-module/index", () => {
+  it("should export expected API", () => {
+    assertEquals(typeof mod.createMyThing, "function");
+    assertEquals(typeof mod.MY_ERROR_CONSTANT, "object");
+    // Types are verified at compile time, not here
+  });
+});
+```
+
+## Adding a New Module
+
+1. Create directory: `src/my-module/`
+2. Add types: `src/my-module/types.ts`
+3. Add implementation
+4. Add barrel: `src/my-module/index.ts`
+5. Add export test: `src/my-module/index.test.ts`
+6. Add hash import to `deno.json`:
+   ```json
+   "#veryfront/my-module": "./src/my-module/index.ts"
+   ```
+7. Add export to `deno.json` exports (if public API):
+   ```json
+   "./my-module": "./src/my-module/index.ts"
+   ```
+8. Verify: `deno task lint && deno task typecheck`
+
+## Linting & Validation
+
+```bash
+deno task lint:style          # Named exports, no public keyword, casing
+deno task lint:imports        # No cross-boundary relative imports
+deno task lint:wildcard-exports  # No wildcard re-exports
+deno task lint:barrel-jsdoc   # JSDoc on barrel exports
+deno task validate:architecture  # Layer dependency rules
+deno task check:circular      # No circular dependencies
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Relative import across modules | Use `#veryfront/module` hash import |
+| Default export | Use named exports only |
+| Logic in index.ts | Move to implementation file, re-export |
+| Missing index.test.ts | Add export verification test |
+| Importing from higher layer | Restructure or move shared code to lower layer |
+| `export *` wildcard | List explicit named exports |
+| Missing JSDoc on export | Add `/** description */` above each export |
+| No `public` keyword | Omit it — enforced by linter |

--- a/.claude/skills/vf-performance/SKILL.md
+++ b/.claude/skills/vf-performance/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: vf-performance
+description: Use when reviewing code for performance issues, profiling hot paths, benchmarking before/after changes, or optimizing runtime, build, request latency, or bundle size
+---
+
+# Veryfront Performance Review & Benchmark
+
+## Overview
+
+This skill covers performance analysis across all layers of veryfront: runtime hot paths, request latency, build/compile time, and bundle size. Use it to identify regressions before they ship and to measure the impact of optimizations.
+
+**Core principle:** Measure first, optimize second. Never optimize without a baseline.
+
+## When to Use
+
+- Before merging performance-sensitive PRs
+- When investigating latency complaints or slowdowns
+- After adding new middleware, transforms, or rendering paths
+- When modifying hot paths (SSR, data fetching, API routing, transforms)
+- When adding dependencies or changing build configuration
+
+---
+
+## Part 1: Performance Review Checklist
+
+Run through this checklist when reviewing code for performance. Flag items that apply.
+
+### Runtime Hot Paths
+
+| Pattern | Risk | Where to Check |
+|---------|------|----------------|
+| Sync I/O in request path | Blocks event loop | API handlers, middleware, SSR |
+| `await` in a loop (N+1) | Multiplied latency | Data fetchers, module loaders |
+| Unbounded `Promise.all` | Memory spike | Batch operations, parallel fetches |
+| Missing cache / cache miss storm | Redundant work | `FileCache`, module cache, transform cache |
+| Regex on untrusted input | ReDoS potential | Route matching, content parsing |
+| Large JSON.stringify/parse | CPU spike per request | Request/response serialization, SSR props |
+| Module re-import on each request | Startup cost repeated | Worker script, dynamic imports |
+| Unnecessary cloning | Memory churn | `request.clone()`, deep copies |
+
+### Memory & Allocation
+
+| Pattern | Risk | Where to Check |
+|---------|------|----------------|
+| Growing Map/Set without eviction | Memory leak | Caches, registries, module maps |
+| Holding large buffers across requests | Heap pressure | SSR streams, file uploads |
+| Closures capturing request scope | Prevents GC | Event handlers, callbacks |
+| `new TextEncoder()` per call | Allocation churn | Use module-level singleton |
+| Accumulating strings via `+=` | O(n^2) copying | HTML building, log formatting |
+
+### Build & Compile
+
+| Pattern | Risk | Where to Check |
+|---------|------|----------------|
+| New `--include` in compile args | Binary size increase | `compile-binary.ts` |
+| Heavy dependency added | Compile time + size | `deno.json`, import maps |
+| Unused imports in hot modules | Tree-shaking bloat | Barrel exports, re-exports |
+| Type-only imports without `type` keyword | Runtime bundle inclusion | Missing `import type` |
+
+### Request Latency
+
+| Pattern | Risk | Where to Check |
+|---------|------|----------------|
+| Serial awaits that could parallelize | Wasted wall time | Data fetching, layout loading |
+| Middleware running on static assets | Unnecessary overhead | Security, auth, CORS checks |
+| Cold-start penalty per worker | First-request latency | Worker pool, module loading |
+| DNS/TCP for every external call | Connection overhead | API clients, data fetchers |
+
+---
+
+## Part 2: Benchmarking
+
+### Quick Profiling (No Setup)
+
+```bash
+# Time a single request
+time curl -s -o /dev/null http://localhost:3000/
+
+# Multiple requests with timing
+for i in {1..10}; do
+  curl -s -o /dev/null -w "%{time_total}\n" http://localhost:3000/
+done | awk '{sum+=$1; count++} END {printf "avg: %.3fs, count: %d\n", sum/count, count}'
+
+# Request with detailed timing breakdown
+curl -w "\n  DNS: %{time_namelookup}s\n  Connect: %{time_connect}s\n  TTFB: %{time_starttransfer}s\n  Total: %{time_total}s\n" -o /dev/null -s http://localhost:3000/
+```
+
+### Deno Built-in Profiling
+
+```bash
+# CPU profile (generates V8 .cpuprofile)
+deno run --allow-all --v8-flags=--prof src/index.ts
+# Then process with: deno run --v8-flags=--prof-process isolate-*.log > profile.txt
+
+# Heap snapshot
+deno run --allow-all --inspect src/index.ts
+# Connect Chrome DevTools to deno inspect URL, take heap snapshot
+```
+
+### Structured Benchmark (Before/After)
+
+When measuring an optimization, follow this protocol:
+
+```
+1. BASELINE: Run benchmark on main branch
+2. CHANGE: Apply optimization
+3. MEASURE: Run same benchmark on feature branch
+4. COMPARE: Report delta with confidence
+```
+
+#### Benchmark Script Template
+
+```typescript
+// bench/name.bench.ts
+const WARMUP = 50;
+const ITERATIONS = 500;
+
+async function benchmark(name: string, fn: () => Promise<void> | void): Promise<void> {
+  // Warmup
+  for (let i = 0; i < WARMUP; i++) await fn();
+
+  // Measure
+  const times: number[] = [];
+  for (let i = 0; i < ITERATIONS; i++) {
+    const start = performance.now();
+    await fn();
+    times.push(performance.now() - start);
+  }
+
+  times.sort((a, b) => a - b);
+  const p50 = times[Math.floor(times.length * 0.5)];
+  const p95 = times[Math.floor(times.length * 0.95)];
+  const p99 = times[Math.floor(times.length * 0.99)];
+  const avg = times.reduce((a, b) => a + b, 0) / times.length;
+
+  console.log(`${name}: avg=${avg.toFixed(2)}ms p50=${p50.toFixed(2)}ms p95=${p95.toFixed(2)}ms p99=${p99.toFixed(2)}ms`);
+}
+```
+
+#### Deno Bench (Built-in)
+
+```typescript
+// name.bench.ts — run with: deno bench --allow-all
+Deno.bench("operation name", async () => {
+  // code to benchmark
+});
+
+Deno.bench({
+  name: "operation with setup",
+  fn: async () => { /* measured code */ },
+  group: "feature-name",
+  baseline: true,
+});
+```
+
+### Load Testing
+
+```bash
+# Simple load test with hey (install: go install github.com/rakyll/hey@latest)
+hey -n 1000 -c 50 http://localhost:3000/
+
+# With wrk (if available)
+wrk -t4 -c100 -d30s http://localhost:3000/
+
+# Watch memory during load test
+watch -n1 'curl -s http://localhost:3000/_vf_internal/health | grep -o "heap[^,]*"'
+```
+
+### Binary Size Tracking
+
+```bash
+# Check binary size before and after
+ls -lh bin/veryfront | awk '{print $5}'
+
+# Detailed size breakdown (what's in the binary)
+deno info --json cli/main.ts | deno eval 'const d=JSON.parse(await new Response(Deno.stdin.readable).text()); console.log("Modules:", d.modules.length, "Size:", (d.modules.reduce((a,m)=>a+(m.size||0),0)/1024/1024).toFixed(1)+"MB")'
+```
+
+---
+
+## Part 3: Common Veryfront Performance Patterns
+
+### Cache Effectively
+
+```typescript
+// BAD: Compute on every request
+function getConfig() {
+  return JSON.parse(Deno.readTextFileSync("config.json"));
+}
+
+// GOOD: Cache with TTL
+let cached: Config | null = null;
+let cachedAt = 0;
+function getConfig(): Config {
+  if (cached && Date.now() - cachedAt < 60_000) return cached;
+  cached = JSON.parse(Deno.readTextFileSync("config.json"));
+  cachedAt = Date.now();
+  return cached;
+}
+```
+
+### Parallelize Independent Work
+
+```typescript
+// BAD: Serial awaits
+const user = await getUser(id);
+const posts = await getPosts(id);
+const comments = await getComments(id);
+
+// GOOD: Parallel
+const [user, posts, comments] = await Promise.all([
+  getUser(id),
+  getPosts(id),
+  getComments(id),
+]);
+```
+
+### Avoid Unnecessary Serialization
+
+```typescript
+// BAD: Clone via JSON round-trip
+const copy = JSON.parse(JSON.stringify(obj));
+
+// GOOD: structuredClone (if needed) or spread
+const copy = structuredClone(obj);
+const shallow = { ...obj };
+```
+
+### Stream Large Responses
+
+```typescript
+// BAD: Buffer entire response
+const html = await renderToString(element);
+return new Response(html);
+
+// GOOD: Stream
+const stream = await renderToReadableStream(element);
+return new Response(stream);
+```
+
+### Use Singleton Instances
+
+```typescript
+// BAD: New encoder per call
+function encode(s: string) {
+  return new TextEncoder().encode(s);
+}
+
+// GOOD: Module-level singleton
+const encoder = new TextEncoder();
+function encode(s: string) {
+  return encoder.encode(s);
+}
+```
+
+---
+
+## Part 4: Performance Review Report Format
+
+When reporting performance findings, use this structure:
+
+```markdown
+## Performance Review: [PR/Feature Name]
+
+### Summary
+- [One-line verdict: "No regressions" or "N issues found"]
+
+### Hot Path Analysis
+| Location | Issue | Impact | Severity |
+|----------|-------|--------|----------|
+| file:line | Description | Estimated impact | High/Med/Low |
+
+### Benchmark Results (if applicable)
+| Metric | Before | After | Delta |
+|--------|--------|-------|-------|
+| p50 latency | Xms | Yms | +/-Z% |
+| p99 latency | Xms | Yms | +/-Z% |
+| Memory (RSS) | XMB | YMB | +/-Z% |
+| Binary size | XMB | YMB | +/-Z% |
+
+### Recommendations
+1. [Actionable fix with code reference]
+```
+
+---
+
+## Quick Reference: Performance Budgets
+
+| Metric | Budget | Measurement |
+|--------|--------|-------------|
+| SSR render (p95) | < 100ms | `withSpan("ssr.*")` traces |
+| API route (p95) | < 50ms | Request tracker logs |
+| Data fetch (p95) | < 200ms | `data.fetch_server` spans |
+| Module load | < 500ms | `render.load_modules` spans |
+| Cold start (first request) | < 3s | Time to first 200 |
+| Binary size | < 1.2GB | `ls -lh bin/veryfront` |
+| Build time (compile) | < 3min | `time deno task build` |
+| Memory (idle) | < 200MB RSS | `Deno.memoryUsage()` |
+| Memory (under load) | < 1GB RSS | Load test + monitoring |

--- a/.claude/skills/vf-security-checklist/SKILL.md
+++ b/.claude/skills/vf-security-checklist/SKILL.md
@@ -30,7 +30,7 @@ Run through these when modifying security-sensitive code:
 ### Network & Routing
 - [ ] Redirects validate URL scheme (block `javascript:`, `data:`, `vbscript:`)
 - [ ] CORS origins explicitly listed (no wildcard `*` in production)
-- [ ] Rate limiting keys use actual connection IP, not `X-Forwarded-For` alone
+- [ ] Rate limiting uses `trustProxy: false` (default) unless behind a trusted reverse proxy
 - [ ] WebSocket enforces `wss://` in production (not plain `ws://`)
 
 ### File System
@@ -93,11 +93,23 @@ res.redirect(userProvidedUrl);  // javascript: XSS risk
 
 ### Rate Limiting
 ```typescript
-// Correct: use connection info
-const clientIp = request.connection.remoteAddr;
+import { createRateLimiter } from "#veryfront/security";
 
-// Wrong: trust client header
-const clientIp = request.headers.get("X-Forwarded-For");  // SPOOFABLE
+// Correct: trustProxy=false (default) uses rightmost X-Forwarded-For IP
+// (added by nearest proxy, not client-controlled)
+const limiter = createRateLimiter({
+  maxRequests: 100,
+  windowMs: 60_000,
+  trustProxy: false,
+});
+
+// Wrong: trustProxy=true uses leftmost IP (client-spoofable)
+// Only safe behind a trusted reverse proxy that overwrites X-Forwarded-For
+const limiter = createRateLimiter({
+  maxRequests: 100,
+  windowMs: 60_000,
+  trustProxy: true,  // SPOOFABLE without trusted proxy
+});
 ```
 
 ## Verified Secure Areas
@@ -115,7 +127,7 @@ These have been audited and are safe — don't over-engineer:
 | Mistake | Fix |
 |---------|-----|
 | Extracting JWT payload without verification | Verify signature first |
-| `X-Forwarded-For` for rate limit key | Use `request.connection.remoteAddr` |
+| `trustProxy: true` without trusted proxy | Use `trustProxy: false` (default) for rightmost IP |
 | `ws://` WebSocket in production | Enforce `wss://` |
 | `SecureFS.unsafeReadFile` in prod code | Use safe variant with path validation |
 | Missing auth on upload endpoint | Add auth middleware |

--- a/.claude/skills/vf-security-checklist/SKILL.md
+++ b/.claude/skills/vf-security-checklist/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: vf-security-checklist
+description: Use when touching auth, user input validation, file paths, redirects, WebSocket, uploads, rate limiting, CORS, or any security-sensitive code in veryfront
+---
+
+# Veryfront Security Checklist
+
+## Overview
+
+Veryfront has undergone a comprehensive security audit. This checklist captures the verified patterns and known pitfalls.
+
+**Core principle:** Validate at boundaries, use framework security utilities, never trust client input.
+
+## Before You Ship: Quick Check
+
+Run through these when modifying security-sensitive code:
+
+### Input & Validation
+- [ ] User input validated with Zod schemas before use
+- [ ] Path inputs validated with `validatePathSync()` from `#veryfront/security`
+- [ ] No string concatenation for SQL/commands — use parameterized queries / array args
+- [ ] HTML user content escaped or wrapped with `validateTrustedHtml()`
+
+### Authentication & Tokens
+- [ ] JWT signatures verified (not just payload extraction)
+- [ ] Tokens in headers or cookies (never in URL query params)
+- [ ] WebSocket auth uses subprotocol header, not query string
+- [ ] Session tokens stored securely (compliance-approved method)
+
+### Network & Routing
+- [ ] Redirects validate URL scheme (block `javascript:`, `data:`, `vbscript:`)
+- [ ] CORS origins explicitly listed (no wildcard `*` in production)
+- [ ] Rate limiting keys use actual connection IP, not `X-Forwarded-For` alone
+- [ ] WebSocket enforces `wss://` in production (not plain `ws://`)
+
+### File System
+- [ ] File paths validated against traversal (`../`) attacks
+- [ ] Use `SecureFS` methods for file operations
+- [ ] `SecureFS` unsafe methods (`unsafeReadFile`, etc.) not used in production paths
+- [ ] Upload handlers have auth middleware
+- [ ] Sandbox code execution has size/time limits
+
+### Commands
+- [ ] External commands use array arguments (no shell interpolation)
+- [ ] No `shell: true` option in subprocess calls
+- [ ] User input never concatenated into command strings
+
+## Security Module Utilities
+
+```typescript
+import {
+  validatePathSync,
+  validateTrustedHtml,
+  // Rate limiting, CORS, input validation
+} from "#veryfront/security";
+
+// Path validation — prevents traversal
+const safePath = validatePathSync(userInput, { baseDir: projectRoot });
+
+// HTML safety — wraps trusted HTML
+const html = validateTrustedHtml(content);
+```
+
+## Secure Patterns
+
+### Command Execution (Safe)
+```typescript
+// Correct: array arguments, no shell
+const cmd = new Deno.Command("git", {
+  args: ["log", "--oneline", "-n", "10"],
+});
+
+// Wrong: string interpolation
+const cmd = new Deno.Command("sh", {
+  args: ["-c", `git log ${userInput}`],  // INJECTION RISK
+});
+```
+
+### Redirect Validation
+```typescript
+// Correct: validate scheme
+const url = new URL(redirectTarget);
+if (!["http:", "https:"].includes(url.protocol)) {
+  throw SECURITY_VIOLATION.create({
+    detail: "Invalid redirect scheme",
+    context: { protocol: url.protocol },
+  });
+}
+
+// Wrong: no validation
+res.redirect(userProvidedUrl);  // javascript: XSS risk
+```
+
+### Rate Limiting
+```typescript
+// Correct: use connection info
+const clientIp = request.connection.remoteAddr;
+
+// Wrong: trust client header
+const clientIp = request.headers.get("X-Forwarded-For");  // SPOOFABLE
+```
+
+## Verified Secure Areas
+
+These have been audited and are safe — don't over-engineer:
+- Command injection: protected (array args throughout)
+- XSS: protected (`validateTrustedHtml` wrapper)
+- HTML escaping: comprehensive (5 characters: `& < > " '`)
+- Path traversal: protected (`src/security/path-validation/`)
+- CSRF: protected (double-submit, constant-time compare)
+- Cryptographic randomness: uses `crypto.getRandomValues()`
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Extracting JWT payload without verification | Verify signature first |
+| `X-Forwarded-For` for rate limit key | Use `request.connection.remoteAddr` |
+| `ws://` WebSocket in production | Enforce `wss://` |
+| `SecureFS.unsafeReadFile` in prod code | Use safe variant with path validation |
+| Missing auth on upload endpoint | Add auth middleware |
+| Redirect without scheme check | Validate `http:` / `https:` only |
+| String-concatenated commands | Use array `args` parameter |

--- a/.claude/skills/vf-testing/SKILL.md
+++ b/.claude/skills/vf-testing/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: vf-testing
+description: Use when writing, modifying, or debugging tests in veryfront - covers BDD structure, deno test flags, test utilities, sanitizer rules, and test file placement
+---
+
+# Veryfront Testing Patterns
+
+## Overview
+
+Veryfront uses Deno's test runner with BDD-style tests. Tests are either colocated unit tests or separate integration tests.
+
+**Core principle:** Tests must be self-contained, use proper cleanup, and never share state.
+
+## Test Command
+
+```bash
+# Unit tests (colocated in src/)
+VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --unstable-net --parallel '--ignore=tests,src/ai/workflow/__tests__,src/cli/commands/*.integration.test.ts'
+
+# All tests (unit + integration)
+VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --unstable-net
+
+# Or use deno tasks
+deno task test:unit
+deno task test:integration
+deno task test
+```
+
+## File Placement
+
+| Type | Location | When |
+|------|----------|------|
+| Unit test | `src/module/name.test.ts` | Pure functions, no I/O, no server |
+| Integration test | `tests/integration/feature/name.test.ts` | Needs TestContext, server, filesystem |
+| E2E test | `tests/e2e/` | Full user flows (Playwright) |
+| Index export test | `src/module/index.test.ts` | Verifies public API exports |
+
+## Test Structure (BDD)
+
+```typescript
+import { describe, it } from "#veryfront/testing/bdd";
+import { assertEquals, assertThrows, assertRejects } from "#veryfront/testing/assert";
+
+describe("ComponentName", () => {
+  describe("methodName", () => {
+    it("should return expected result when given valid input", () => {
+      // Arrange
+      const input = createInput();
+
+      // Act
+      const result = method(input);
+
+      // Assert
+      assertEquals(result, expected, "descriptive message");
+    });
+  });
+});
+```
+
+## Test Utilities
+
+```typescript
+// Resource management (integration tests)
+import { withTestContext } from "#veryfront/testing";
+
+// TestContext provides:
+// - context.allocatePort() — no hard-coded ports
+// - context.createServer() — managed server lifecycle
+// - Automatic cleanup on test end
+
+// Filesystem isolation
+import { withTempDir, withTempFile } from "#veryfront/testing";
+
+// Environment isolation
+import { withEnv } from "#veryfront/testing";
+
+// Async helpers
+import { delay, waitFor } from "#veryfront/testing";
+
+// Cleanup registration
+import { registerTestCleanup } from "#veryfront/testing";
+```
+
+## Sanitizer Rules
+
+Deno sanitizers are **enabled by default**. Only disable when documented:
+
+```typescript
+// ONLY for React 19 SSR tests (known MessagePort limitation)
+it({
+  name: "should render SSR stream",
+  fn: async () => { /* ... */ },
+  sanitizeResources: false,
+  sanitizeOps: false,
+});
+```
+
+Never disable sanitizers for convenience. If a test leaks resources, fix the leak.
+
+## Index Export Tests
+
+Every module's `index.test.ts` verifies the public API:
+
+```typescript
+import * as mod from "./index.ts";
+
+describe("module/index", () => {
+  it("should export expected API", () => {
+    // Functions (from registry, use typeof === "object" for registry constants)
+    assertEquals(typeof mod.CONFIG_NOT_FOUND, "object");
+
+    // Types are verified by TypeScript, not runtime
+  });
+});
+```
+
+When migrating error classes to registry: change `typeof X === "function"` to `typeof X === "object"`.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Using `npx tsx --test` | Use `deno test` with proper flags |
+| Hard-coded port numbers | Use `context.allocatePort()` |
+| Arbitrary `setTimeout` waits | Use `waitFor()` with conditions |
+| Shared mutable state between tests | Each test sets up its own state |
+| Missing assertion messages | Always include descriptive messages |
+| `import from "../../../"` | Use `#veryfront/` hash imports |
+| Forgetting env vars | Use the full env var prefix from test command |

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,8 @@ dist/
 *.backup/
 
 # IDE
-.claude/
+.claude/*
+!.claude/skills/
 .vscode/
 .idea/
 


### PR DESCRIPTION
## Summary
- Add 5 project-level Claude Code skills in `.claude/skills/` covering veryfront conventions
  - **vf-testing** — BDD structure, deno test flags, sanitizer rules, test utilities
  - **vf-error-handling** — error registry patterns, class-to-registry migration, slug-based identification
  - **vf-module-development** — layer architecture, hash imports, barrel exports, dependency rules
  - **vf-security-checklist** — actionable checklist from security audit findings
  - **vf-cli-output** — CLI style guide patterns, icons, colors, error formatting
- Update `.gitignore` to track `.claude/skills/` while keeping rest of `.claude/` ignored

## Test plan
- [x] All pre-push checks pass (fmt, lint, typecheck, 1110 unit tests)
- [ ] Verify skills are discoverable by Claude Code in new sessions