### PR TITLE
fix(runtime): fail fast when control-plane signing key is missing

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -10,7 +10,7 @@ import { getErrorMessage } from "#veryfront/errors/veryfront-error.ts";
 import { INVALID_ARGUMENT } from "#veryfront/errors";
 import { enhanceAdapterWithFS } from "#veryfront/platform/adapters/fs/integration.ts";
 import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
-import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { getEnv, getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { initializeEsbuild } from "#veryfront/platform/compat/esbuild.ts";
 import { logger } from "#veryfront/utils";
 import { isDebugEnabled } from "#veryfront/utils/constants/env.ts";
@@ -256,6 +256,7 @@ export async function bootstrapProd(
 function validateProductionEnvironment(_adapter: RuntimeAdapter): void {
   const nodeEnv = getEnv("NODE_ENV") ?? getEnv("DENO_ENV");
   const proxyMode = getEnv("PROXY_MODE");
+  const controlPlanePublicKey = getHostEnv("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
 
   // In proxy mode (deployed pods), NODE_ENV must be explicitly set to production
   if (proxyMode === "1") {
@@ -275,6 +276,17 @@ function validateProductionEnvironment(_adapter: RuntimeAdapter): void {
           "Expected 'production'. This may enable dev features.",
         nodeEnv,
       );
+    }
+
+    if (!controlPlanePublicKey) {
+      logger.error(
+        "[Bootstrap:Prod] CRITICAL: CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY is not set in proxy mode. " +
+          "Hosted runtimes cannot verify control-plane requests without it.",
+      );
+      throw INVALID_ARGUMENT.create({
+        detail:
+          "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY must be set when running in proxy mode (PROXY_MODE=1)",
+      });
     }
   }
 

--- a/tests/integration/core/bootstrap.test.ts
+++ b/tests/integration/core/bootstrap.test.ts
@@ -19,6 +19,7 @@ import { clearConfigCache } from "#veryfront/config";
 import { join } from "#veryfront/compat/path";
 import { mkdir, remove, writeTextFile } from "#veryfront/compat/fs.ts";
 import { getAdapter } from "#veryfront/platform/adapters/detect.ts";
+import { deleteEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import { makeTempDir } from "#veryfront/testing/deno-compat";
 import { isBun, isDeno, isNode } from "../../../src/platform/compat/runtime.ts";
 import { delay } from "#std/async";
@@ -92,6 +93,28 @@ async function expectBootstrapThrows(projectDir: string, adapter: unknown): Prom
   } catch (error) {
     assertExists(error);
   }
+}
+
+function withEnvOverrides(vars: Record<string, string | undefined>): () => void {
+  const previous = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(vars)) {
+    previous.set(key, Deno.env.get(key));
+    if (value === undefined) {
+      deleteEnv(key);
+    } else {
+      setEnv(key, value);
+    }
+  }
+
+  return () => {
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        deleteEnv(key);
+      } else {
+        setEnv(key, value);
+      }
+    }
+  };
 }
 
 // ============================================================================
@@ -896,6 +919,29 @@ describe("bootstrap - Dev and Prod Modes", () => {
 
       await assertRejects(() => bootstrapProd(projectDir, adapter), Error);
     });
+  });
+
+  it("should reject proxy mode startup when control-plane signing key is missing", async () => {
+    const adapter = await getAdapter();
+    const restore = withEnvOverrides({
+      NODE_ENV: "production",
+      PROXY_MODE: "1",
+      CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY: undefined,
+    });
+
+    try {
+      await withTempProjectDir("prod_missing_control_plane_key", async (projectDir) => {
+        await writeConfigFile(projectDir, "veryfront.config.js", createBasicConfig());
+
+        await assertRejects(
+          () => bootstrapProd(projectDir, adapter),
+          Error,
+          "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY must be set",
+        );
+      });
+    } finally {
+      restore();
+    }
   });
 
   it("should log FSAdapter info in dev mode", async () => {

--- a/tests/validation/014-deployment-modes/014.1-node-env-validation.test.ts
+++ b/tests/validation/014-deployment-modes/014.1-node-env-validation.test.ts
@@ -30,6 +30,10 @@ describe("014.1 NODE_ENV Validation", () => {
         content.includes("NODE_ENV must be set"),
         "Should have error message for missing NODE_ENV",
       );
+      assert(
+        content.includes("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY"),
+        "Should validate control-plane signing key in proxy mode",
+      );
     });
 
     it("should check NODE_ENV before proceeding in bootstrapProd", async () => {
@@ -57,6 +61,19 @@ describe("014.1 NODE_ENV Validation", () => {
       assert(
         content.includes("proxy mode"),
         "Error message should mention proxy mode",
+      );
+    });
+
+    it("should throw error when control-plane signing key is missing in proxy mode", async () => {
+      const content = await readBootstrap();
+
+      assert(
+        content.includes("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY must be set"),
+        "Should throw error when control-plane signing key is missing in proxy mode",
+      );
+      assert(
+        content.includes("Hosted runtimes cannot verify control-plane requests"),
+        "Should explain why the signing key is required",
       );
     });
   });


### PR DESCRIPTION
## Summary

Fail hosted runtime startup fast when `CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY` is missing in proxy-mode production.

## Why

We hit a production failure mode where hosted project agents returned runtime `500`s because control-plane verification was not configured. The runtime started successfully and only failed later on `/internal/agents/list`.

This PR turns that into an explicit boot-time failure instead of a latent runtime regression.

## Changes

- validate `CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY` during `bootstrapProd()` when `PROXY_MODE=1`
- keep the existing `NODE_ENV` proxy-mode validation and extend the same guardrail pattern
- add integration coverage for the new startup failure
- extend the deployment validation test to assert the control-plane key requirement
- bump `deno.json` version to `0.1.66`

## Verification

Passed locally:
- `deno test -A tests/validation/014-deployment-modes/014.1-node-env-validation.test.ts tests/integration/core/bootstrap.test.ts`
- `deno task verify:quick`
- full pre-push gate on push (`fmt`, `lint`, `typecheck`, `test:unit`)

## Impact

A misconfigured hosted runtime will now fail at startup instead of serving broken `/internal/agents/*` requests.
