### PR TITLE
test(runtime): restore proxy-mode release pipeline

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/tests/_helpers/proxy-mode.ts
+++ b/tests/_helpers/proxy-mode.ts
@@ -1,0 +1,16 @@
+export const TEST_CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY_PEM = `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAfhOk6ZikxNjGIMFLYW4kpA+Kf01Delncn1qTke0Ifcg=
+-----END PUBLIC KEY-----`;
+
+export function withProxyModeControlPlaneKey(
+  env: Record<string, string>,
+): Record<string, string> {
+  if (env.PROXY_MODE !== "1" || env.CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY) {
+    return env;
+  }
+
+  return {
+    ...env,
+    CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY: TEST_CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY_PEM,
+  };
+}

--- a/tests/integration/compiled-binary-e2e.test.ts
+++ b/tests/integration/compiled-binary-e2e.test.ts
@@ -24,6 +24,7 @@ import { afterAll, beforeAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { exists } from "#veryfront/platform/compat/fs.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { load as loadEnv } from "#veryfront/platform/compat/std/dotenv.ts";
+import { withProxyModeControlPlaneKey } from "../_helpers/proxy-mode.ts";
 
 // Load .env file for test configuration (VERYFRONT_BINARY_FRESH, etc.)
 try {
@@ -189,13 +190,13 @@ async function startBinaryServer(
     const process = new Deno.Command(BINARY_PATH, {
       args: ["serve", "--mode=production", "-p", String(port)],
       cwd: projectDir,
-      env: {
+      env: withProxyModeControlPlaneKey({
         ...Deno.env.toObject(),
         NODE_ENV: nodeEnv,
         LOG_FORMAT: "text",
         VERYFRONT_CACHE_DIR: cacheDir,
         ...extraEnv,
-      },
+      }),
       stdout: "piped",
       stderr: "piped",
     }).spawn();

--- a/tests/integration/vfs-proxy-mode-e2e.test.ts
+++ b/tests/integration/vfs-proxy-mode-e2e.test.ts
@@ -14,6 +14,7 @@ import { afterAll, beforeAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { exists } from "#veryfront/platform/compat/fs.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { load as loadEnv } from "#veryfront/platform/compat/std/dotenv.ts";
+import { withProxyModeControlPlaneKey } from "../_helpers/proxy-mode.ts";
 
 try {
   await loadEnv({ export: true, allowEmptyValues: true, examplePath: null });
@@ -103,7 +104,7 @@ async function startVFSServer(projectDir: string, extraEnv?: Record<string, stri
   const port = await getAvailablePort();
   const cacheDir = await Deno.makeTempDir({ prefix: "vf-vfs-cache-" });
 
-  const env: Record<string, string> = {
+  const env = withProxyModeControlPlaneKey({
     ...Deno.env.toObject(),
     NODE_ENV: "production",
     PROXY_MODE: "1",
@@ -111,7 +112,7 @@ async function startVFSServer(projectDir: string, extraEnv?: Record<string, stri
     LOG_FORMAT: "text",
     VERYFRONT_CACHE_DIR: cacheDir,
     ...extraEnv,
-  };
+  });
 
   const process = new Deno.Command(BINARY_PATH, {
     args: ["serve", "--mode=production", "-p", String(port)],


### PR DESCRIPTION
## Summary
- seed a synthetic control-plane public key in proxy-mode binary test harnesses
- keep the production bootstrap guardrail intact while fixing the test environment
- bump `deno.json` version to `0.1.67` for the next runtime release

## Why
The previous runtime fix correctly made hosted proxy-mode boot fail fast without `CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY`, but one compiled-binary integration suite and the binary proxy-mode harness still booted with `PROXY_MODE=1` and no key. That broke `main` CI and blocked the downstream server deploy.

## Verification
- `deno test --allow-all tests/integration/vfs-proxy-mode-e2e.test.ts`
- `deno test --allow-all tests/integration/compiled-binary-e2e.test.ts`
- `deno task verify:quick`
- repo pre-push checks passed (`fmt`, `lint`, `typecheck`, full unit suite)`