### PR TITLE
fix(runtime): use server api token for internal agent discovery

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/security/http/base-handler.ts
+++ b/src/security/http/base-handler.ts
@@ -107,6 +107,7 @@ export abstract class BaseHandler implements Handler {
     fn: () => Promise<T>,
     options: { requireToken?: boolean } = {},
   ): Promise<T> {
+    const effectiveToken = ctx.proxyToken || ctx.adapter.env.get("VERYFRONT_API_TOKEN") || "";
     const fsWrapper = ctx.adapter.fs as {
       setRequestToken?: (t: string) => void;
       setRequestBranch?: (b: string | null) => void;
@@ -129,7 +130,7 @@ export abstract class BaseHandler implements Handler {
     }
 
     const requireToken = options.requireToken ?? false;
-    if (!ctx.projectSlug || (requireToken && !ctx.proxyToken)) return fn();
+    if (!ctx.projectSlug || (requireToken && !effectiveToken)) return fn();
 
     if (fsWrapper.isMultiProjectMode?.()) {
       const isProduction = (ctx.resolvedEnvironment ?? ctx.requestContext?.mode) === "production";
@@ -148,15 +149,15 @@ export abstract class BaseHandler implements Handler {
 
       return fsWrapper.runWithContext!(
         ctx.projectSlug,
-        ctx.proxyToken ?? "",
+        effectiveToken,
         fn,
         ctx.projectId,
         { productionMode: isProduction, releaseId: ctx.releaseId, branch },
       );
     }
 
-    if (typeof fsWrapper.setRequestToken === "function" && ctx.proxyToken) {
-      fsWrapper.setRequestToken(ctx.proxyToken);
+    if (typeof fsWrapper.setRequestToken === "function" && effectiveToken) {
+      fsWrapper.setRequestToken(effectiveToken);
     }
 
     return runWithCacheBatching(fn);

--- a/src/server/handlers/request/internal-agents-list.handler.test.ts
+++ b/src/server/handlers/request/internal-agents-list.handler.test.ts
@@ -255,6 +255,89 @@ describe("server/handlers/request/internal-agents-list.handler", () => {
     assertEquals(await result.response.json(), { error: "Invalid internal agents request" });
   });
 
+  it("uses VERYFRONT_API_TOKEN for multi-project proxy context when request token is absent", async () => {
+    let discoveryCalls = 0;
+    let receivedToken: string | undefined;
+
+    const handler = new InternalAgentsListHandler({
+      ensureProjectDiscovery: async () => {
+        discoveryCalls += 1;
+      },
+      getAgent: (id) =>
+        id === "assistant-1"
+          ? createAgentWithConfig("assistant-1", { name: "Project Smoke Agent" })
+          : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+    });
+
+    const body = JSON.stringify({
+      requestId: "agents-1",
+      projectId: "proj-1",
+      surface: "studio",
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "agents-1",
+    });
+
+    const ctx = {
+      ...createCtx(publicKeyPem),
+      adapter: {
+        env: {
+          get: (key: string) => {
+            if (key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY") return publicKeyPem;
+            if (key === "VERYFRONT_API_TOKEN") return "server-api-token";
+            return undefined;
+          },
+          set: () => {},
+          toObject: () => ({}),
+        },
+        fs: {
+          isMultiProjectMode: () => true,
+          runWithContext: async (
+            _projectSlug: string,
+            token: string,
+            fn: () => Promise<unknown>,
+          ) => {
+            receivedToken = token;
+            return await fn();
+          },
+        },
+      },
+      proxyToken: undefined,
+      resolvedEnvironment: "production",
+      requestContext: { token: "", slug: "demo-project", branch: null, mode: "production" },
+    } as unknown as ReturnType<typeof createCtx>;
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      ctx,
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(receivedToken, "server-api-token");
+    assertEquals(discoveryCalls, 1);
+    assertEquals(await result.response.json(), {
+      agents: [
+        {
+          id: "assistant-1",
+          name: "Project Smoke Agent",
+          description: null,
+          model: "anthropic/claude-sonnet-4-6",
+          version: null,
+          skills: [],
+        },
+      ],
+    });
+  });
+
   it("rethrows unexpected discovery failures", async () => {
     const handler = new InternalAgentsListHandler({
       ensureProjectDiscovery: async () => {


### PR DESCRIPTION
## Summary

Fixes hosted project-agent discovery in proxy-mode runtimes after the control-plane public key rollout.

## Problem

Production project runtimes now receive `CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY`, so control-plane JWS verification succeeds. But `/internal/agents/list` still returned `500` for hosted projects because multi-project proxy context was entered with an empty request token.

In production internal control-plane requests, `ctx.proxyToken` is absent. `BaseHandler.withProxyContext()` passed that empty token into `runWithContext(...)`, which breaks the multi-project filesystem adapter before agent discovery can run.

## Fix

- fall back to `VERYFRONT_API_TOKEN` when `ctx.proxyToken` is absent in proxy-mode handler context
- use the same effective token for `runWithContext(...)` and `setRequestToken(...)`
- fail the token requirement only if both request token and server token are absent
- add regression coverage for internal agent discovery in multi-project proxy mode without a request token
- bump `deno.json` version to `0.1.68` for release

## Verification

Passed locally:
- `deno test --allow-all src/server/handlers/request/internal-agents-list.handler.test.ts`
- `deno check src/security/http/base-handler.ts src/server/handlers/request/internal-agents-list.handler.test.ts`
- `deno fmt --check src/security/http/base-handler.ts src/server/handlers/request/internal-agents-list.handler.test.ts deno.json`
- `git diff --check`

## Why now

This is the last blocker for the final live smoke:
- select `Project Agents`
- select `Production`
- select a real project agent
- verify the assistant header shows the real agent name
