### PR TITLE
fix(runtime): read control-plane keys from host env

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/internal-agents/control-plane-auth.test.ts
+++ b/src/internal-agents/control-plane-auth.test.ts
@@ -1,0 +1,47 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { runWithProjectEnv } from "../server/project-env/storage.ts";
+import { getControlPlaneVerificationPublicKey } from "./control-plane-auth.ts";
+
+function createCtx(envGet: (key: string) => string | undefined): HandlerContext {
+  return {
+    adapter: {
+      env: {
+        get: envGet,
+        set: () => {},
+        toObject: () => ({}),
+      },
+      fs: {},
+    },
+  } as unknown as HandlerContext;
+}
+
+describe("internal-agents/control-plane-auth", () => {
+  it("prefers adapter-provided verification keys", () => {
+    const ctx = createCtx((key) =>
+      key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? "adapter-key" : undefined
+    );
+
+    assertEquals(getControlPlaneVerificationPublicKey(ctx), "adapter-key");
+  });
+
+  it("falls back to host env when project overlays hide adapter env reads", () => {
+    const envKey = "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY";
+    const originalValue = Deno.env.get(envKey);
+    Deno.env.set(envKey, "host-key");
+
+    try {
+      const ctx = createCtx((key) => getEnv(key));
+      const resolvedKey = runWithProjectEnv({}, () => getControlPlaneVerificationPublicKey(ctx));
+      assertEquals(resolvedKey, "host-key");
+    } finally {
+      if (originalValue === undefined) {
+        Deno.env.delete(envKey);
+      } else {
+        Deno.env.set(envKey, originalValue);
+      }
+    }
+  });
+});

--- a/src/internal-agents/control-plane-auth.ts
+++ b/src/internal-agents/control-plane-auth.ts
@@ -1,4 +1,5 @@
 import { verifyControlPlaneJws } from "#veryfront/channels/control-plane.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import type { HandlerContext } from "#veryfront/types";
 import { serverLogger } from "#veryfront/utils";
 import { HTTP_INTERNAL_SERVER_ERROR } from "#veryfront/utils/constants/index.ts";
@@ -17,6 +18,14 @@ export class ControlPlaneRequestError extends Error {
   }
 }
 
+export function getControlPlaneVerificationPublicKey(ctx: HandlerContext): string | undefined {
+  // Project env overlays intentionally hide host secrets from request-scoped reads.
+  // Control-plane verification is framework-owned config, so it must fall back to
+  // the host environment when the runtime adapter env is overlay-aware.
+  return ctx.adapter.env.get("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY") ??
+    getHostEnv("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
+}
+
 export async function verifyControlPlaneRequest(
   req: Request,
   ctx: HandlerContext,
@@ -26,7 +35,7 @@ export async function verifyControlPlaneRequest(
     expectedSurface?: "studio" | "channels" | "a2a" | "mcp";
   } = {},
 ) {
-  const publicKeyPem = ctx.adapter.env.get("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
+  const publicKeyPem = getControlPlaneVerificationPublicKey(ctx);
   if (!publicKeyPem) {
     throw new ControlPlaneRequestError(
       HTTP_INTERNAL_SERVER_ERROR,

--- a/src/server/handlers/request/channel-assistants.handler.ts
+++ b/src/server/handlers/request/channel-assistants.handler.ts
@@ -8,6 +8,7 @@ import {
   listChannelAssistants,
   verifyDispatchJws,
 } from "../../../channels/invoke.ts";
+import { getControlPlaneVerificationPublicKey } from "#veryfront/internal-agents/control-plane-auth.ts";
 import {
   HTTP_INTERNAL_SERVER_ERROR,
   PRIORITY_MEDIUM_API,
@@ -37,7 +38,7 @@ export class ChannelAssistantsHandler extends BaseHandler {
         .withCORS(req, ctx.securityConfig?.cors)
         .withSecurity(ctx.securityConfig ?? undefined, req);
 
-      const publicKeyPem = ctx.adapter.env.get("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
+      const publicKeyPem = getControlPlaneVerificationPublicKey(ctx);
       if (!publicKeyPem) {
         this.logWarn("Missing CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY for channel assistants endpoint");
         return this.respond(

--- a/src/server/handlers/request/channel-invoke.handler.ts
+++ b/src/server/handlers/request/channel-invoke.handler.ts
@@ -7,6 +7,7 @@ import {
   executeChannelInvoke,
   verifyDispatchJws,
 } from "../../../channels/invoke.ts";
+import { getControlPlaneVerificationPublicKey } from "#veryfront/internal-agents/control-plane-auth.ts";
 import {
   HTTP_INTERNAL_SERVER_ERROR,
   PRIORITY_MEDIUM_API,
@@ -36,7 +37,7 @@ export class ChannelInvokeHandler extends BaseHandler {
         .withCORS(req, ctx.securityConfig?.cors)
         .withSecurity(ctx.securityConfig ?? undefined, req);
 
-      const publicKeyPem = ctx.adapter.env.get("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
+      const publicKeyPem = getControlPlaneVerificationPublicKey(ctx);
       if (!publicKeyPem) {
         this.logWarn("Missing CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY for channel invoke endpoint");
         return this.respond(

--- a/src/server/handlers/request/internal-agents-list.handler.test.ts
+++ b/src/server/handlers/request/internal-agents-list.handler.test.ts
@@ -1,7 +1,9 @@
 import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES } from "#veryfront/internal-agents/request-body.ts";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
 import { InternalAgentsListHandler } from "./internal-agents-list.handler.ts";
+import { runWithProjectEnv } from "../../project-env/storage.ts";
 import {
   createAgentWithConfig,
   createControlPlaneSignature,
@@ -336,6 +338,78 @@ describe("server/handlers/request/internal-agents-list.handler", () => {
         },
       ],
     });
+  });
+
+  it("uses the host verification key when project overlays hide adapter env reads", async () => {
+    const handler = new InternalAgentsListHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: (id) =>
+        id === "assistant-1"
+          ? createAgentWithConfig("assistant-1", { name: "Project Smoke Agent" })
+          : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+    });
+
+    const body = JSON.stringify({
+      requestId: "agents-1",
+      projectId: "proj-1",
+      surface: "studio",
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "agents-1",
+    });
+
+    const envKey = "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY";
+    const originalValue = Deno.env.get(envKey);
+    Deno.env.set(envKey, publicKeyPem);
+
+    try {
+      const ctx = {
+        ...createCtx(undefined),
+        adapter: {
+          env: {
+            get: (key: string) => getEnv(key),
+            set: () => {},
+            toObject: () => ({}),
+          },
+          fs: {},
+        },
+      } as unknown as ReturnType<typeof createCtx>;
+
+      const result = await runWithProjectEnv({}, () =>
+        handler.handle(
+          new Request("https://example.com/internal/agents/list", {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "x-veryfront-control-plane-jws": jws,
+            },
+            body,
+          }),
+          ctx,
+        ));
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 200);
+      assertEquals(await result.response.json(), {
+        agents: [
+          {
+            id: "assistant-1",
+            name: "Project Smoke Agent",
+            description: null,
+            model: "anthropic/claude-sonnet-4-6",
+            version: null,
+            skills: [],
+          },
+        ],
+      });
+    } finally {
+      if (originalValue === undefined) {
+        Deno.env.delete(envKey);
+      } else {
+        Deno.env.set(envKey, originalValue);
+      }
+    }
   });
 
   it("rethrows unexpected discovery failures", async () => {


### PR DESCRIPTION
## Summary
- fix proxy-mode control-plane verification when a project env overlay is active
- read the control-plane verification key via a shared host-env-aware helper
- add regression coverage for the exact internal agents list failure
- bump deno.json version to 0.1.69 for release

## Why
Request handlers in hosted runtime pods were reading CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY through overlay-aware env access. In proxy mode, project env overlays intentionally block host env fallthrough, so internal control-plane requests could fail with "Control-plane verification is not configured" even though the pod had the key.

## Validation
- deno test -A src/internal-agents/control-plane-auth.test.ts src/server/handlers/request/internal-agents-list.handler.test.ts src/server/handlers/request/channel-invoke.handler.test.ts src/server/handlers/request/channel-assistants.handler.test.ts
- deno test -A src/server/handlers/request/agent-stream.handler.test.ts src/server/handlers/request/agent-run-resume.handler.test.ts src/server/handlers/request/agent-run-cancel.handler.test.ts
- deno task verify:quick
- full pre-push checks passed, including unit tests

## Follow-up
- closes the live production blocker for hosted project-agent discovery
- follow-up issue for broader audit: #635