### PR TITLE
fix(runtime): align binary plugin includes with loader

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -203,16 +203,9 @@ jobs:
       - name: Compile binary
         shell: bash
         run: |
-          # React is fetched at runtime through the module server (SSR transform pipeline)
-          # Include Tailwind CSS v4 plugins (versions must match PINNED_PLUGIN_VERSIONS in tailwind-compiler.ts)
           deno run -A scripts/build/compile-binary.ts \
             --target ${{ matrix.target }} \
-            --output ${{ matrix.name }} \
-            --include "https://esm.sh/tailwindcss-animate@1.0.7" \
-            --include "https://esm.sh/@tailwindcss/typography@0.5.19" \
-            --include "https://esm.sh/@tailwindcss/forms@0.5.11" \
-            --include "https://esm.sh/tailwind-scrollbar-hide@2.0.0" \
-            --include "https://esm.sh/daisyui@5.5.14"
+            --output ${{ matrix.name }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.69",
+  "version": "0.1.70",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/scripts/build/compile-binary.ts
+++ b/scripts/build/compile-binary.ts
@@ -8,6 +8,7 @@
 
 import { parseArgs } from "jsr:@std/cli/parse-args";
 import { fromFileUrl, isAbsolute, join } from "#std/path.ts";
+import { getBinaryPluginBundleIncludes } from "../../src/build/binary-plugin-includes.ts";
 
 const PROJECT_ROOT = fromFileUrl(new URL("../..", import.meta.url));
 const DEFAULT_INCLUDES = [
@@ -52,6 +53,7 @@ export function createCompileArgs(options: CompileBinaryOptions): string[] {
 
   for (const include of [
     ...DEFAULT_INCLUDES,
+    ...getBinaryPluginBundleIncludes(),
     ...resolveKreuzbergCompileIncludes(),
     ...options.extraIncludes,
   ]) {

--- a/src/build/binary-plugin-includes.test.ts
+++ b/src/build/binary-plugin-includes.test.ts
@@ -1,0 +1,25 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  BINARY_TAILWIND_PLUGIN_PACKAGES,
+  getBinaryPluginBundleIncludes,
+  getTailwindPluginBundleUrl,
+} from "./binary-plugin-includes.ts";
+
+describe("build/binary-plugin-includes", () => {
+  it("builds bundle URLs that match the runtime plugin loader contract", () => {
+    assertEquals(
+      getTailwindPluginBundleUrl("tailwindcss-animate@1.0.7"),
+      "https://esm.sh/tailwindcss-animate@1.0.7?bundle&external=tailwindcss&target=denonext",
+    );
+  });
+
+  it("returns bundle includes for every pinned binary plugin", () => {
+    assertEquals(
+      getBinaryPluginBundleIncludes(),
+      BINARY_TAILWIND_PLUGIN_PACKAGES.map((pkg) =>
+        `https://esm.sh/${pkg}?bundle&external=tailwindcss&target=denonext`
+      ),
+    );
+  });
+});

--- a/src/build/binary-plugin-includes.ts
+++ b/src/build/binary-plugin-includes.ts
@@ -1,0 +1,17 @@
+const BINARY_TAILWIND_PLUGIN_PACKAGES = [
+  "tailwindcss-animate@1.0.7",
+  "@tailwindcss/typography@0.5.19",
+  "@tailwindcss/forms@0.5.11",
+  "tailwind-scrollbar-hide@2.0.0",
+  "daisyui@5.5.14",
+] as const;
+
+export function getTailwindPluginBundleUrl(packageName: string): string {
+  return `https://esm.sh/${packageName}?bundle&external=tailwindcss&target=denonext`;
+}
+
+export function getBinaryPluginBundleIncludes(): string[] {
+  return BINARY_TAILWIND_PLUGIN_PACKAGES.map(getTailwindPluginBundleUrl);
+}
+
+export { BINARY_TAILWIND_PLUGIN_PACKAGES };

--- a/src/html/styles-builder/plugin-loader.ts
+++ b/src/html/styles-builder/plugin-loader.ts
@@ -18,6 +18,7 @@ import {
   NETWORK_ERROR,
   VeryfrontError,
 } from "#veryfront/errors";
+import { getTailwindPluginBundleUrl } from "#veryfront/build/binary-plugin-includes.ts";
 
 const logger = serverLogger.component("tailwind");
 
@@ -106,7 +107,7 @@ async function importBundledModule(code: string): Promise<unknown> {
  * dynamic imports from URLs. Fetches bundled code, rewrites imports, loads via temp file.
  */
 export async function loadModuleFromEsmSh(packageName: string): Promise<unknown> {
-  const stubUrl = `https://esm.sh/${packageName}?bundle&external=tailwindcss&target=denonext`;
+  const stubUrl = getTailwindPluginBundleUrl(packageName);
   logger.debug("Fetching esm.sh stub", { url: stubUrl });
 
   const stubResponse = await fetch(stubUrl);


### PR DESCRIPTION
## Summary

This fixes the post-merge release blocker in `veryfront-code` main CI/CD.

The binary build workflow was still including raw `esm.sh` Tailwind plugin URLs, while the runtime Tailwind plugin loader had already moved to the bundled stub URL contract. That mismatch caused `deno compile` to fail on the macOS x64 build.

## What Changed

- added a shared binary plugin include helper
- made the runtime Tailwind plugin loader reuse the same bundle URL builder
- made `scripts/build/compile-binary.ts` include the bundled plugin URLs by default
- removed the duplicated raw plugin include list from `.github/workflows/cicd.yml`
- bumped `deno.json` version to `0.1.70`

## Why

We had two different sources of truth for the same pinned Tailwind plugin set:
- runtime loader: bundled stub URLs
- binary workflow: raw esm.sh package URLs

The binary workflow needs to follow the same contract as the runtime loader. This PR centralizes that rule so future plugin-version changes only need to happen in one place.

## Verification

Passed locally:
- `deno test -A src/build/binary-plugin-includes.test.ts src/html/styles-builder/tailwind-compiler.test.ts`
- `deno task build:prepare`
- `deno run -A scripts/build/compile-binary.ts --target x86_64-apple-darwin --output /tmp/veryfront-macos-x64-smoke`
- `deno task verify:quick`
- full pre-push gate

## Follow-up

This unblocks the current release so the merged control-plane env fix can actually ship. Least-privilege runtime token scope narrowing is tracked separately in the API repo.
