### PR TITLE
fix(esm): preserve esm.sh external commas in SSR cache

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/transforms/esm/http-cache-helpers.test.ts
+++ b/src/transforms/esm/http-cache-helpers.test.ts
@@ -159,6 +159,14 @@ describe("transforms/esm/http-cache-helpers", () => {
       assertEquals(result.includes("external="), true);
       assertEquals(result.includes("react"), true);
     });
+
+    it("preserves comma-separated esm.sh external params", () => {
+      const result = normalizeHttpUrl(
+        "https://esm.sh/recharts@2.15.3?external=react,react-dom&target=es2022",
+      );
+      assertEquals(result.includes("external=react,react-dom"), true);
+      assertEquals(result.includes("%2C"), false);
+    });
   });
 
   describe("ensureAbsoluteDir", () => {

--- a/src/transforms/esm/http-cache-helpers.test.ts
+++ b/src/transforms/esm/http-cache-helpers.test.ts
@@ -167,6 +167,14 @@ describe("transforms/esm/http-cache-helpers", () => {
       assertEquals(result.includes("external=react,react-dom"), true);
       assertEquals(result.includes("%2C"), false);
     });
+
+    it("preserves encoding for non-external comma-separated params", () => {
+      const result = normalizeHttpUrl(
+        "https://esm.sh/pkg@1.0?deps=a,b&external=react,react-dom&target=es2022",
+      );
+      assertEquals(result.includes("external=react,react-dom"), true);
+      assertEquals(result.includes("deps=a%2Cb"), true);
+    });
   });
 
   describe("ensureAbsoluteDir", () => {

--- a/src/transforms/esm/http-cache-helpers.ts
+++ b/src/transforms/esm/http-cache-helpers.ts
@@ -107,9 +107,17 @@ export function normalizeHttpUrl(raw: string): string {
 
     // esm.sh misbehaves when list-valued params such as
     // `external=react,react-dom` are percent-encoded as `%2C`.
-    // Preserve literal commas after sorting so direct CDN imports remain valid.
+    // Preserve literal commas only for the affected param so unrelated
+    // query values remain canonically encoded.
     if (url.hostname === "esm.sh") {
-      return normalized.replace(/%2C/gi, ",");
+      const external = url.searchParams.get("external");
+      if (!external) return normalized;
+
+      const encodedExternal = encodeURIComponent(external);
+      return normalized.replace(
+        `external=${encodedExternal}`,
+        `external=${encodedExternal.replace(/%2C/gi, ",")}`,
+      );
     }
 
     return normalized;

--- a/src/transforms/esm/http-cache-helpers.ts
+++ b/src/transforms/esm/http-cache-helpers.ts
@@ -103,7 +103,16 @@ export function normalizeHttpUrl(raw: string): string {
     const url = new URL(raw);
     normalizeEsmShUrl(url);
     url.searchParams.sort();
-    return url.toString();
+    const normalized = url.toString();
+
+    // esm.sh misbehaves when list-valued params such as
+    // `external=react,react-dom` are percent-encoded as `%2C`.
+    // Preserve literal commas after sorting so direct CDN imports remain valid.
+    if (url.hostname === "esm.sh") {
+      return normalized.replace(/%2C/gi, ",");
+    }
+
+    return normalized;
   } catch (_) {
     /* expected: URL may be malformed */
     return raw;


### PR DESCRIPTION
## Summary
- preserve literal commas in `esm.sh` query params during SSR URL normalization
- add a regression test for direct `https://esm.sh/recharts@2.15.3` imports
- bump `deno.json` version to `0.1.71`

## Root Cause
`normalizeHttpUrl()` sorted query params and serialized `external=react,react-dom` as `external=react%2Creact-dom`.

`esm.sh` returns malformed JavaScript for that encoded-comma form, which then surfaced as `Parse error @:6:39` in `ssr-http-cache`.

## Verification
- `deno test --config deno.json --allow-env src/transforms/esm/http-cache-helpers.test.ts`
- SSR repro via `deno eval --config deno.json ...` with `OK direct` and `OK bare`
- `deno task build`
