### PR TITLE
fix(bootstrap): don't crash on missing signing key in local proxy mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,13 @@ VERYFRONT_PROXY_API_CLIENT_ID=
 VERYFRONT_PROXY_API_CLIENT_SECRET=
 REDIS_URL=
 
+# Proxy Mode (deployed pods)
+# Set PROXY_MODE=1 only for hosted/deployed runtimes.
+# Requires NODE_ENV=production and a valid signing key.
+# PROXY_MODE=1
+# NODE_ENV=production
+# CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY=
+
 # Binary compilation
 # Set to 1 to always rebuild binary, even if source unchanged
 VERYFRONT_BINARY_FRESH=1

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -278,7 +278,12 @@ function validateProductionEnvironment(_adapter: RuntimeAdapter): void {
       );
     }
 
-    if (!controlPlanePublicKey && nodeEnv === "production") {
+    if (!controlPlanePublicKey && nodeEnv === "development") {
+      logger.warn(
+        "[Bootstrap:Prod] CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY is not set. " +
+          "Channel dispatch verification will be unavailable (local dev mode).",
+      );
+    } else if (!controlPlanePublicKey) {
       logger.error(
         "[Bootstrap:Prod] CRITICAL: CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY is not set in proxy mode. " +
           "Hosted runtimes cannot verify control-plane requests without it.",
@@ -287,11 +292,6 @@ function validateProductionEnvironment(_adapter: RuntimeAdapter): void {
         detail:
           "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY must be set when running in proxy mode (PROXY_MODE=1)",
       });
-    } else if (!controlPlanePublicKey) {
-      logger.warn(
-        "[Bootstrap:Prod] CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY is not set. " +
-          "Channel dispatch verification will be unavailable.",
-      );
     }
   }
 

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -278,7 +278,7 @@ function validateProductionEnvironment(_adapter: RuntimeAdapter): void {
       );
     }
 
-    if (!controlPlanePublicKey) {
+    if (!controlPlanePublicKey && nodeEnv === "production") {
       logger.error(
         "[Bootstrap:Prod] CRITICAL: CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY is not set in proxy mode. " +
           "Hosted runtimes cannot verify control-plane requests without it.",
@@ -287,6 +287,11 @@ function validateProductionEnvironment(_adapter: RuntimeAdapter): void {
         detail:
           "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY must be set when running in proxy mode (PROXY_MODE=1)",
       });
+    } else if (!controlPlanePublicKey) {
+      logger.warn(
+        "[Bootstrap:Prod] CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY is not set. " +
+          "Channel dispatch verification will be unavailable.",
+      );
     }
   }
 


### PR DESCRIPTION
## Problem

Running `deno task start` crashes with:

```
[Bootstrap:Prod] CRITICAL: CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY is not set in proxy mode.
[invalid-argument] Invalid function argument
```

The `start` command uses `startCliProxyModeServer` which sets `PROXY_MODE=1`, triggering `validateProductionEnvironment` in `bootstrap.ts`. This validation requires `CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY` for **all** proxy mode instances — but locally there's no control plane sending signed requests, so the key isn't needed.

The `NODE_ENV` case was already handled (the CLI sets `NODE_ENV=development` as a fallback), but the signing key had no equivalent escape hatch.

## Fix

- Only require `CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY` when `NODE_ENV=production` (actual deployed pods)
- For local dev (`NODE_ENV=development`), log a warning instead of crashing
- Document proxy mode env vars in `.env.example`

## Test plan

- [x] `deno task start` no longer crashes without `CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY`
- [x] Bootstrap integration tests pass (they set `NODE_ENV=production`, so the strict check still applies)
- [x] Pre-existing flaky test (`adapter.test.ts` resource leak) is unrelated — also fails on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)