### PR TITLE
feat(errors): structured error reporting from renderer to Studio

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -208,6 +208,14 @@ async function generateHTMLShellPartsImpl(
 
   const nonceAttr = nonce ? ` nonce="${nonce}"` : "";
 
+  // Expose project slug for runtime error overlay "Fix in Veryfront" button
+  const overlaySlug = options.projectId || meta.slug;
+  const slugForOverlay = useDevScripts && overlaySlug
+    ? `<script${nonceAttr}>window.__VF_PROJECT_SLUG__=${
+      JSON.stringify(overlaySlug).replace(/</g, "\\u003c")
+    };</script>`
+    : "";
+
   const hydrationErrorSuppression = useDevScripts ? "" : `<script${nonceAttr}>
 (function(){
   var origError = console.error;
@@ -303,6 +311,7 @@ async function generateHTMLShellPartsImpl(
   ${linkTags}
   ${styleTags}
   ${modeStyles}
+  ${slugForOverlay}
 </head>
 <body${bodyClass ? ` class="${bodyClass}"` : ""} suppressHydrationWarning>
   <div ${rootAttributes}>`;

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -391,191 +391,205 @@ export class RenderPipeline {
           );
           timing.pageResolve = Math.round(performance.now() - pageResolveStart);
 
-          const skipLayouts = isDotPath(slug, pageInfo.entity.path);
-
-          const layoutCollectStart = performance.now();
-          const layoutResult = skipLayouts ? EMPTY_LAYOUT_RESULT : await withSpan(
-            "render.collect_layouts",
-            () => this.config.layoutOrchestrator.collectLayouts(pageInfo),
-            { "render.slug": slug },
+          const sourceFile = extractRelativePathShared(
+            pageInfo.entity.path,
+            this.config.projectDir,
           );
-          timing.layoutCollect = Math.round(performance.now() - layoutCollectStart);
 
-          const layoutPreloadPromise = !skipLayouts && layoutResult.nestedLayouts.length > 0
-            ? this.config.layoutOrchestrator.preloadLayoutModules(layoutResult.nestedLayouts)
-            : Promise.resolve();
+          try {
+            const skipLayouts = isDotPath(slug, pageInfo.entity.path);
 
-          let dataFetchingProps: Record<string, unknown> | undefined;
-          let resolvedParams: Record<string, string | string[]> = options?.params
-            ? { ...options.params }
-            : {};
-          let layoutDataMap = new Map<string, Record<string, unknown>>();
-
-          const dataFetchStart = performance.now();
-          if (options?.request && options?.url) {
-            await withSpan(
-              "render.data_fetching",
-              async () => {
-                try {
-                  const dataResolution = await this.resolveDataFetching(
-                    slug,
-                    pageInfo.entity.path,
-                    layoutResult.nestedLayouts,
-                    options,
-                  );
-                  resolvedParams = dataResolution.params;
-                  dataFetchingProps = Object.keys(dataResolution.pageProps).length > 0
-                    ? dataResolution.pageProps
-                    : undefined;
-                  layoutDataMap = dataResolution.layoutProps;
-                } catch (error) {
-                  if (error instanceof VeryfrontError) throw error;
-
-                  renderPageLog.error("Data fetching error", {
-                    slug,
-                    error: error instanceof Error ? error.message : String(error),
-                  });
-                  throw error;
-                }
-              },
+            const layoutCollectStart = performance.now();
+            const layoutResult = skipLayouts ? EMPTY_LAYOUT_RESULT : await withSpan(
+              "render.collect_layouts",
+              () => this.config.layoutOrchestrator.collectLayouts(pageInfo),
               { "render.slug": slug },
             );
-          }
-          timing.dataFetch = Math.round(performance.now() - dataFetchStart);
+            timing.layoutCollect = Math.round(performance.now() - layoutCollectStart);
 
-          const hasResolvedParams = Object.keys(resolvedParams).length > 0;
-          const mergedOptions = (dataFetchingProps || hasResolvedParams)
-            ? {
-              ...options,
-              ...(hasResolvedParams ? { params: resolvedParams } : {}),
-              ...(dataFetchingProps ? { props: { ...options?.props, ...dataFetchingProps } } : {}),
+            const layoutPreloadPromise = !skipLayouts && layoutResult.nestedLayouts.length > 0
+              ? this.config.layoutOrchestrator.preloadLayoutModules(layoutResult.nestedLayouts)
+              : Promise.resolve();
+
+            let dataFetchingProps: Record<string, unknown> | undefined;
+            let resolvedParams: Record<string, string | string[]> = options?.params
+              ? { ...options.params }
+              : {};
+            let layoutDataMap = new Map<string, Record<string, unknown>>();
+
+            const dataFetchStart = performance.now();
+            if (options?.request && options?.url) {
+              await withSpan(
+                "render.data_fetching",
+                async () => {
+                  try {
+                    const dataResolution = await this.resolveDataFetching(
+                      slug,
+                      pageInfo.entity.path,
+                      layoutResult.nestedLayouts,
+                      options,
+                    );
+                    resolvedParams = dataResolution.params;
+                    dataFetchingProps = Object.keys(dataResolution.pageProps).length > 0
+                      ? dataResolution.pageProps
+                      : undefined;
+                    layoutDataMap = dataResolution.layoutProps;
+                  } catch (error) {
+                    if (error instanceof VeryfrontError) throw error;
+
+                    renderPageLog.error("Data fetching error", {
+                      slug,
+                      error: error instanceof Error ? error.message : String(error),
+                    });
+                    throw error;
+                  }
+                },
+                { "render.slug": slug },
+              );
             }
-            : options;
+            timing.dataFetch = Math.round(performance.now() - dataFetchStart);
 
-          const bundlePrepStart = performance.now();
-          const pageBundleResult = await withSpan(
-            "render.prepare_bundles",
-            () =>
-              this.config.pageRenderer.preparePageBundles(
-                pageInfo,
-                slug,
-                cacheResult?.cachedModule,
-                mergedOptions,
-              ),
-            { "render.slug": slug },
-          );
-          timing.bundlePrep = Math.round(performance.now() - bundlePrepStart);
+            const hasResolvedParams = Object.keys(resolvedParams).length > 0;
+            const mergedOptions = (dataFetchingProps || hasResolvedParams)
+              ? {
+                ...options,
+                ...(hasResolvedParams ? { params: resolvedParams } : {}),
+                ...(dataFetchingProps
+                  ? { props: { ...options?.props, ...dataFetchingProps } }
+                  : {}),
+              }
+              : options;
 
-          if (pageBundleResult.scriptResult) return pageBundleResult.scriptResult;
-
-          if (!pageBundleResult.pageElement || !pageBundleResult.pageBundle) {
-            throw RENDER_ERROR.create({
-              detail: "Failed to prepare page bundle",
-              context: { slug },
-            });
-          }
-
-          const { pageElement, pageBundle } = pageBundleResult;
-
-          const mergedFrontmatter = {
-            ...pageInfo.entity.frontmatter,
-            ...(pageBundle as MdxBundle).frontmatter,
-          };
-
-          const headings = (pageBundle as PageBundle).headings || [];
-
-          await layoutPreloadPromise;
-
-          const layoutApplyStart = performance.now();
-          const wrappedElement = await withSpan(
-            "render.apply_layouts",
-            () =>
-              this.config.layoutOrchestrator.applyLayoutsAndWrappers(
-                pageElement,
-                pageInfo,
-                layoutResult.layoutBundle,
-                layoutResult.nestedLayouts,
-                layoutDataMap,
-                options?.url,
-                mergedFrontmatter,
-                headings,
-                options?.projectSlug,
-              ),
-            { "render.slug": slug, "render.layout_count": layoutResult.nestedLayouts.length },
-          );
-          timing.layoutApply = Math.round(performance.now() - layoutApplyStart);
-
-          // Snapshot CSS imports collected during module loading (before SSR rendering).
-          // These are passed to the HTML generator to be included in the output.
-          const collectedCSSImports = getCSSImports();
-
-          const ssrStart = performance.now();
-          const ssrResult = await withSpan(
-            "render.ssr",
-            () =>
-              withTimeoutThrow(
-                this.config.ssrOrchestrator.performSSRRendering(
-                  wrappedElement,
-                  {
-                    pageInfo,
-                    pageBundle,
-                    layoutBundle: layoutResult.layoutBundle,
-                    nestedLayouts: layoutResult.nestedLayouts,
-                    collectedMetadata: pageBundleResult.collectedMetadata,
-                    slug,
-                    cssImports: collectedCSSImports,
-                  },
+            const bundlePrepStart = performance.now();
+            const pageBundleResult = await withSpan(
+              "render.prepare_bundles",
+              () =>
+                this.config.pageRenderer.preparePageBundles(
+                  pageInfo,
+                  slug,
+                  cacheResult?.cachedModule,
                   mergedOptions,
                 ),
-                SSR_RENDER_TIMEOUT_MS,
-                `SSR rendering for ${slug}`,
-              ),
-            { "render.slug": slug, "render.delivery": mergedOptions?.delivery || "full" },
-          );
-          timing.ssr = Math.round(performance.now() - ssrStart);
-
-          if (collectedCSSImports.length > 0) {
-            renderPipelineLog.debug("CSS imports collected for HTML generation", {
-              slug,
-              count: collectedCSSImports.length,
-              paths: collectedCSSImports.map((p) => p.split("/").pop()),
-            });
-          }
-
-          const pageModule = pageBundleResult.clientModuleCode && pageBundleResult.pageModuleType
-            ? {
-              slug,
-              code: pageBundleResult.clientModuleCode,
-              type: pageBundleResult.pageModuleType,
-            }
-            : undefined;
-
-          const result: RenderResult = {
-            html: ssrResult.fullHtml,
-            frontmatter: (pageBundleResult.pageBundle as MdxBundle).frontmatter || {},
-            headings: pageBundleResult.pageBundle.headings || [],
-            nodeMap: pageBundleResult.pageBundle.nodeMap,
-            stream: ssrResult.finalStream,
-            ssrHash: ssrResult.ssrHash,
-            ...(pageModule ? { pageModule } : {}),
-          };
-
-          if (shouldCache && !options?.skipCachePersist) {
-            void this.config.cacheCoordinator.persistResult(result, slug, cacheKey).catch(
-              (error) => {
-                renderPipelineLog.error("Cache persist failed", {
-                  slug,
-                  error: error instanceof Error ? error.message : String(error),
-                  stack: error instanceof Error ? error.stack : undefined,
-                });
-              },
+              { "render.slug": slug },
             );
+            timing.bundlePrep = Math.round(performance.now() - bundlePrepStart);
+
+            if (pageBundleResult.scriptResult) return pageBundleResult.scriptResult;
+
+            if (!pageBundleResult.pageElement || !pageBundleResult.pageBundle) {
+              throw RENDER_ERROR.create({
+                detail: "Failed to prepare page bundle",
+                context: { slug },
+              });
+            }
+
+            const { pageElement, pageBundle } = pageBundleResult;
+
+            const mergedFrontmatter = {
+              ...pageInfo.entity.frontmatter,
+              ...(pageBundle as MdxBundle).frontmatter,
+            };
+
+            const headings = (pageBundle as PageBundle).headings || [];
+
+            await layoutPreloadPromise;
+
+            const layoutApplyStart = performance.now();
+            const wrappedElement = await withSpan(
+              "render.apply_layouts",
+              () =>
+                this.config.layoutOrchestrator.applyLayoutsAndWrappers(
+                  pageElement,
+                  pageInfo,
+                  layoutResult.layoutBundle,
+                  layoutResult.nestedLayouts,
+                  layoutDataMap,
+                  options?.url,
+                  mergedFrontmatter,
+                  headings,
+                  options?.projectSlug,
+                ),
+              { "render.slug": slug, "render.layout_count": layoutResult.nestedLayouts.length },
+            );
+            timing.layoutApply = Math.round(performance.now() - layoutApplyStart);
+
+            // Snapshot CSS imports collected during module loading (before SSR rendering).
+            // These are passed to the HTML generator to be included in the output.
+            const collectedCSSImports = getCSSImports();
+
+            const ssrStart = performance.now();
+            const ssrResult = await withSpan(
+              "render.ssr",
+              () =>
+                withTimeoutThrow(
+                  this.config.ssrOrchestrator.performSSRRendering(
+                    wrappedElement,
+                    {
+                      pageInfo,
+                      pageBundle,
+                      layoutBundle: layoutResult.layoutBundle,
+                      nestedLayouts: layoutResult.nestedLayouts,
+                      collectedMetadata: pageBundleResult.collectedMetadata,
+                      slug,
+                      cssImports: collectedCSSImports,
+                    },
+                    mergedOptions,
+                  ),
+                  SSR_RENDER_TIMEOUT_MS,
+                  `SSR rendering for ${slug}`,
+                ),
+              { "render.slug": slug, "render.delivery": mergedOptions?.delivery || "full" },
+            );
+            timing.ssr = Math.round(performance.now() - ssrStart);
+
+            if (collectedCSSImports.length > 0) {
+              renderPipelineLog.debug("CSS imports collected for HTML generation", {
+                slug,
+                count: collectedCSSImports.length,
+                paths: collectedCSSImports.map((p) => p.split("/").pop()),
+              });
+            }
+
+            const pageModule = pageBundleResult.clientModuleCode && pageBundleResult.pageModuleType
+              ? {
+                slug,
+                code: pageBundleResult.clientModuleCode,
+                type: pageBundleResult.pageModuleType,
+              }
+              : undefined;
+
+            const result: RenderResult = {
+              html: ssrResult.fullHtml,
+              frontmatter: (pageBundleResult.pageBundle as MdxBundle).frontmatter || {},
+              headings: pageBundleResult.pageBundle.headings || [],
+              nodeMap: pageBundleResult.pageBundle.nodeMap,
+              stream: ssrResult.finalStream,
+              ssrHash: ssrResult.ssrHash,
+              ...(pageModule ? { pageModule } : {}),
+            };
+
+            if (shouldCache && !options?.skipCachePersist) {
+              void this.config.cacheCoordinator.persistResult(result, slug, cacheKey).catch(
+                (error) => {
+                  renderPipelineLog.error("Cache persist failed", {
+                    slug,
+                    error: error instanceof Error ? error.message : String(error),
+                    stack: error instanceof Error ? error.stack : undefined,
+                  });
+                },
+              );
+            }
+
+            timing.total = Math.round(performance.now() - pipelineStartTime);
+            renderPipelineLog.debug("Complete", { slug, timing });
+
+            return result;
+          } catch (error) {
+            if (error instanceof Error) {
+              (error as Error & { sourceFile?: string }).sourceFile = sourceFile;
+            }
+            throw error;
           }
-
-          timing.total = Math.round(performance.now() - pipelineStartTime);
-          renderPipelineLog.debug("Complete", { slug, timing });
-
-          return result;
         });
         return result;
       },

--- a/src/server/dev-server/error-overlay/error-formatter.test.ts
+++ b/src/server/dev-server/error-overlay/error-formatter.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { formatErrorType, getSuggestion } from "./error-formatter.ts";
+import { formatErrorType, getSuggestion, parseErrorLocation } from "./error-formatter.ts";
 
 function assertSuggestion(errorMessage: string, expectedSubstring: string): void {
   const suggestion = getSuggestion(new Error(errorMessage));
@@ -32,6 +32,50 @@ describe("server/dev-server/error-overlay/error-formatter", () => {
 
     it("should return undefined for unrecognized errors", () => {
       assertEquals(getSuggestion(new Error("xyzzy")), undefined);
+    });
+  });
+
+  describe("parseErrorLocation", () => {
+    it("should extract line and column from stack trace when file is known", () => {
+      const error = new Error("something broke");
+      error.stack = `Error: something broke
+    at RootLayout (file:///projects/css-test/app/layout.tsx:12:9)
+    at renderWithHooks (node_modules/react-dom/server.js:100:5)`;
+
+      const location = parseErrorLocation(error, "app/layout.tsx");
+      assertEquals(location.line, 12);
+      assertEquals(location.column, 9);
+    });
+
+    it("should extract line and column from first frame when file is not in stack (bundled SSR)", () => {
+      const error = new Error("SSR test error: something broke during render");
+      error.stack = `Error: SSR test error: something broke during render
+    at Module.RootLayout (file:///tmp/vf-ssr-bundle-abc123.js:42:11)
+    at renderWithHooks (node_modules/react-dom/server.js:100:5)
+    at processChild (node_modules/react-dom/server.js:200:3)`;
+
+      const location = parseErrorLocation(error, "app/layout.tsx");
+      assertEquals(location.line, 42);
+      assertEquals(location.column, 11);
+    });
+
+    it("should return undefined line/column when stack is missing", () => {
+      const error = new Error("no stack");
+      error.stack = undefined;
+
+      const location = parseErrorLocation(error, "app/layout.tsx");
+      assertEquals(location.line, undefined);
+      assertEquals(location.column, undefined);
+    });
+
+    it("should match file path as suffix (not require exact match)", () => {
+      const error = new Error("fail");
+      error.stack = `Error: fail
+    at Page (file:///Users/matt/Sites/veryfront-code/projects/css-test/app/page.tsx:7:15)`;
+
+      const location = parseErrorLocation(error, "app/page.tsx");
+      assertEquals(location.line, 7);
+      assertEquals(location.column, 15);
     });
   });
 

--- a/src/server/dev-server/error-overlay/error-formatter.test.ts
+++ b/src/server/dev-server/error-overlay/error-formatter.test.ts
@@ -47,7 +47,7 @@ describe("server/dev-server/error-overlay/error-formatter", () => {
       assertEquals(location.column, 9);
     });
 
-    it("should extract line and column from first frame when file is not in stack (bundled SSR)", () => {
+    it("should not fabricate source line and column from bundled SSR frames", () => {
       const error = new Error("SSR test error: something broke during render");
       error.stack = `Error: SSR test error: something broke during render
     at Module.RootLayout (file:///tmp/vf-ssr-bundle-abc123.js:42:11)
@@ -55,8 +55,8 @@ describe("server/dev-server/error-overlay/error-formatter", () => {
     at processChild (node_modules/react-dom/server.js:200:3)`;
 
       const location = parseErrorLocation(error, "app/layout.tsx");
-      assertEquals(location.line, 42);
-      assertEquals(location.column, 11);
+      assertEquals(location.line, undefined);
+      assertEquals(location.column, undefined);
     });
 
     it("should return undefined line/column when stack is missing", () => {

--- a/src/server/dev-server/error-overlay/error-formatter.ts
+++ b/src/server/dev-server/error-overlay/error-formatter.ts
@@ -71,14 +71,6 @@ export function parseErrorLocation(
     }
   }
 
-  // Fallback: use the first stack frame (for bundled SSR where paths don't match)
-  for (const stackLine of lines) {
-    const match = stackLine.match(/^\s+at\s+.*:(\d+):(\d+)\)?$/);
-    if (match) {
-      return { line: Number(match[1]), column: Number(match[2]) };
-    }
-  }
-
   return {};
 }
 

--- a/src/server/dev-server/error-overlay/error-formatter.ts
+++ b/src/server/dev-server/error-overlay/error-formatter.ts
@@ -53,6 +53,35 @@ export function getSuggestion(error: Error): string | undefined {
   return undefined;
 }
 
+export function parseErrorLocation(
+  error: Error,
+  file: string,
+): { line?: number; column?: number } {
+  if (!error.stack || !file) return {};
+
+  const lines = error.stack.split("\n");
+
+  // First try to match the known source file
+  for (const stackLine of lines) {
+    if (!stackLine.includes(file)) continue;
+
+    const match = stackLine.match(/:(\d+):(\d+)\)?$/);
+    if (match) {
+      return { line: Number(match[1]), column: Number(match[2]) };
+    }
+  }
+
+  // Fallback: use the first stack frame (for bundled SSR where paths don't match)
+  for (const stackLine of lines) {
+    const match = stackLine.match(/^\s+at\s+.*:(\d+):(\d+)\)?$/);
+    if (match) {
+      return { line: Number(match[1]), column: Number(match[2]) };
+    }
+  }
+
+  return {};
+}
+
 export function formatErrorType(type: ErrorType): string {
   const firstChar = type[0];
   if (!firstChar) return "";

--- a/src/server/dev-server/error-overlay/html-template.test.ts
+++ b/src/server/dev-server/error-overlay/html-template.test.ts
@@ -139,9 +139,20 @@ describe("server/dev-server/error-overlay/html-template", () => {
         error: new Error('He said "hello" & <goodbye>'),
         file: "path/with spaces/file.tsx",
       });
-      // JSON.stringify handles special chars safely for JS embedding
-      assertEquals(html.includes(JSON.stringify('He said "hello" & <goodbye>')), true);
+      // < is escaped to \u003c to prevent </script> injection
+      assertEquals(html.includes("\\u003cgoodbye>"), true);
       assertEquals(html.includes(JSON.stringify("path/with spaces/file.tsx")), true);
+    });
+
+    it("should escape </script> in error messages to prevent XSS", () => {
+      const html = generateErrorHTML({
+        type: "runtime",
+        error: new Error("</script><img src=x onerror=alert(1)>"),
+      });
+      // Must not contain literal </script> from error message
+      // The only </script> should be the actual closing tag
+      const scriptCloseCount = (html.match(/<\/script>/gi) || []).length;
+      assertEquals(scriptCloseCount, 1);
     });
   });
 });

--- a/src/server/dev-server/error-overlay/html-template.test.ts
+++ b/src/server/dev-server/error-overlay/html-template.test.ts
@@ -20,6 +20,12 @@ describe("server/dev-server/error-overlay/html-template", () => {
       const script = generateRuntimeScript();
       assertEquals(script.includes("escapeHtml"), true);
     });
+
+    it("should include url in runtimeError postMessage payload", () => {
+      const script = generateRuntimeScript();
+      assertEquals(script.includes("action: 'runtimeError'"), true);
+      assertEquals(script.includes("url: window.location.href"), true);
+    });
   });
 
   describe("generateErrorHTML", () => {

--- a/src/server/dev-server/error-overlay/html-template.test.ts
+++ b/src/server/dev-server/error-overlay/html-template.test.ts
@@ -66,8 +66,82 @@ describe("server/dev-server/error-overlay/html-template", () => {
         type: "build",
         error: new Error("<script>alert(1)</script>"),
       });
-      assertEquals(html.includes("<script>alert(1)</script>"), false);
+      // The escaped version must appear in the visible HTML error display
       assertEquals(html.includes("&lt;script&gt;"), true);
+      // The raw tag must NOT appear in the visible HTML sections (error-name, error-message).
+      // It may appear inside JSON.stringify() in the postMessage script, which is safe.
+      const htmlBodySection = html.split("<script>")[0];
+      assertEquals(
+        htmlBodySection!.includes("<script>alert(1)</script>"),
+        false,
+      );
+    });
+
+    it("should include error details in postMessage using errors[] array format", () => {
+      const html = generateErrorHTML({
+        type: "runtime",
+        error: new Error("Something broke"),
+        file: "src/components/Button.tsx",
+        line: 42,
+        column: 7,
+      });
+      // postMessage should use errors[] array with { type, message, file, line, column }
+      assertEquals(html.includes("action: 'appUpdated'"), true);
+      assertEquals(html.includes("hasError: true"), true);
+      assertEquals(html.includes("errors: ["), true);
+      assertEquals(html.includes("type: 'error'"), true);
+      assertEquals(html.includes(JSON.stringify("Something broke")), true); // message
+      assertEquals(html.includes(JSON.stringify("src/components/Button.tsx")), true); // file
+      // line and column are emitted as bare values (not JSON-stringified)
+      assertEquals(html.includes("line: 42"), true);
+      assertEquals(html.includes("column: 7"), true);
+    });
+
+    it("should use undefined for missing file/line/column in postMessage errors[]", () => {
+      const html = generateErrorHTML({
+        type: "build",
+        error: new Error("No file info"),
+      });
+      assertEquals(html.includes("action: 'appUpdated'"), true);
+      assertEquals(html.includes("hasError: true"), true);
+      assertEquals(html.includes("errors: ["), true);
+      assertEquals(html.includes("type: 'error'"), true);
+      assertEquals(html.includes(JSON.stringify("No file info")), true); // message
+      // file should be JSON.stringify(undefined) which is undefined (bare)
+      // line and column should be undefined when not provided
+      assertEquals(html.includes("line: undefined"), true);
+      assertEquals(html.includes("column: undefined"), true);
+    });
+
+    it("should include 'Fix in Veryfront' button when projectSlug is provided", () => {
+      const html = generateErrorHTML(
+        { type: "runtime", error: new Error("fail"), file: "src/app.tsx" },
+        undefined,
+        "my-project",
+      );
+      assertEquals(html.includes("Fix in Veryfront"), true);
+      assertEquals(html.includes("vf-fix-btn"), true);
+      assertEquals(html.includes('"my-project"'), true);
+      assertEquals(html.includes("chatMessage"), true);
+    });
+
+    it("should not include 'Fix in Veryfront' button when projectSlug is not provided", () => {
+      const html = generateErrorHTML(
+        { type: "runtime", error: new Error("fail") },
+      );
+      assertEquals(html.includes("Fix in Veryfront"), false);
+      assertEquals(html.includes("vf-fix-btn"), false);
+    });
+
+    it("should safely embed special characters in postMessage via JSON.stringify", () => {
+      const html = generateErrorHTML({
+        type: "runtime",
+        error: new Error('He said "hello" & <goodbye>'),
+        file: "path/with spaces/file.tsx",
+      });
+      // JSON.stringify handles special chars safely for JS embedding
+      assertEquals(html.includes(JSON.stringify('He said "hello" & <goodbye>')), true);
+      assertEquals(html.includes(JSON.stringify("path/with spaces/file.tsx")), true);
     });
   });
 });

--- a/src/server/dev-server/error-overlay/html-template.ts
+++ b/src/server/dev-server/error-overlay/html-template.ts
@@ -110,21 +110,57 @@ export function generateRuntimeScript(): string {
             </div>
 
             <button type="button" onclick="document.getElementById('veryfront-error-overlay').remove()" style="
-              background: #333;
-              border: 1px solid #555;
-              color: #ccc;
-              padding: 8px 16px;
-              border-radius: 4px;
+              background: #fff;
+              border: none;
+              color: #000;
+              padding: 10px 20px;
+              border-radius: 9999px;
               cursor: pointer;
               font-family: inherit;
             ">
               Dismiss
             </button>
+            \${window.__VF_PROJECT_SLUG__ ? \`
+            <button type="button" id="vf-fix-btn-runtime" style="
+              background: #fff;
+              border: none;
+              color: #000;
+              padding: 10px 20px;
+              border-radius: 9999px;
+              cursor: pointer;
+              font-family: inherit;
+              margin-left: 8px;
+            ">
+              Fix in Veryfront
+            </button>
+            \` : ''}
           </div>
         </div>
       \`;
 
       document.body.appendChild(overlay);
+
+      if (window.__VF_PROJECT_SLUG__) {
+        var fixBtn = document.getElementById('vf-fix-btn-runtime');
+        if (fixBtn) {
+          fixBtn.addEventListener('click', function() {
+            var rawName = (errorInfo.error && errorInfo.error.name) || 'Error';
+            var rawMessage = (errorInfo.error && errorInfo.error.message) || 'Unknown error';
+            var rawFile = errorInfo.file ? String(errorInfo.file) : null;
+            var rawLine = errorInfo.line ? String(errorInfo.line) : null;
+            var rawColumn = errorInfo.column ? String(errorInfo.column) : null;
+            var loc = rawFile ? rawFile + (rawLine ? ':' + rawLine : '') + (rawColumn ? ':' + rawColumn : '') : null;
+            var prompt = 'Find and fix the following error' +
+              (loc ? ' in ' + loc : '') +
+              ':\\n\\n' + rawName + ': ' + rawMessage;
+            if (window.parent !== window) {
+              window.parent.postMessage({ action: 'chatMessage', prompt: prompt }, '*');
+            } else {
+              window.open('https://veryfront.com/projects/' + window.__VF_PROJECT_SLUG__ + '?prompt=' + encodeURIComponent(prompt));
+            }
+          });
+        }
+      }
     };
 
     window.addEventListener('error', (event) => {
@@ -146,7 +182,11 @@ export function generateRuntimeScript(): string {
   `;
 }
 
-export function generateErrorHTML(errorInfo: ErrorInfo, suggestion?: string): string {
+export function generateErrorHTML(
+  errorInfo: ErrorInfo,
+  suggestion?: string,
+  projectSlug?: string,
+): string {
   const errorType = escapeHtml(formatErrorType(errorInfo.type));
   const errorName = escapeHtml(errorInfo.error.name);
   const errorMessage = escapeHtml(errorInfo.error.message);
@@ -180,6 +220,10 @@ export function generateErrorHTML(errorInfo: ErrorInfo, suggestion?: string): st
         <pre>${errorStack}</pre>
       </details>
     `
+    : "";
+
+  const fixButtonHtml = projectSlug
+    ? `<button type="button" id="vf-fix-btn" class="btn btn-fix">Fix in Veryfront</button>`
     : "";
 
   return `
@@ -253,6 +297,29 @@ export function generateErrorHTML(errorInfo: ErrorInfo, suggestion?: string): st
       overflow-x: auto;
       font-size: 12px;
     }
+    .btn {
+      padding: 10px 20px;
+      border-radius: 9999px;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 14px;
+      border: none;
+    }
+    .btn-dismiss {
+      background: #fff;
+      color: #000;
+    }
+    .btn-dismiss:hover {
+      background: #e5e5e5;
+    }
+    .btn-fix {
+      background: #fff;
+      color: #000;
+      margin-left: 8px;
+    }
+    .btn-fix:hover {
+      background: #e5e5e5;
+    }
   </style>
 </head>
 <body>
@@ -267,8 +334,35 @@ export function generateErrorHTML(errorInfo: ErrorInfo, suggestion?: string): st
       ${suggestionSection}
       ${stackSection}
     </div>
+    ${fixButtonHtml}
   </div>
-  <script>
+  <script>${
+    projectSlug
+      ? `
+    (function() {
+      var slug = ${JSON.stringify(projectSlug)};
+      var errorName = ${JSON.stringify(errorInfo.error.name)};
+      var errorMessage = ${JSON.stringify(errorInfo.error.message)};
+      var errorFile = ${JSON.stringify(errorInfo.file ?? null)};
+      var errorLine = ${JSON.stringify(errorInfo.line ?? null)};
+      var errorColumn = ${JSON.stringify(errorInfo.column ?? null)};
+      var btn = document.getElementById('vf-fix-btn');
+      if (btn) {
+        btn.addEventListener('click', function() {
+          var loc = errorFile ? errorFile + (errorLine ? ':' + errorLine : '') + (errorColumn ? ':' + errorColumn : '') : null;
+          var prompt = 'Find and fix the following error' +
+            (loc ? ' in ' + loc : '') +
+            ':\\n\\n' + errorName + ': ' + errorMessage;
+          if (window.parent !== window) {
+            window.parent.postMessage({ action: 'chatMessage', prompt: prompt }, '*');
+          } else {
+            window.open('https://veryfront.com/projects/' + slug + '?prompt=' + encodeURIComponent(prompt));
+          }
+        });
+      }
+    })();`
+      : ""
+  }
     // Notify Studio (parent) that page has loaded with an error
     // This hides the loading spinner in Studio's preview iframe
     if (window.parent !== window) {
@@ -277,7 +371,14 @@ export function generateErrorHTML(errorInfo: ErrorInfo, suggestion?: string): st
           action: 'appUpdated',
           isInitialLoad: true,
           hasError: true,
-          url: window.location.href
+          url: window.location.href,
+          errors: [{
+            type: 'error',
+            message: ${JSON.stringify(errorInfo.error.message)},
+            file: ${JSON.stringify(errorInfo.file || undefined)},
+            line: ${errorInfo.line ? String(errorInfo.line) : "undefined"},
+            column: ${errorInfo.column ? String(errorInfo.column) : "undefined"}
+          }]
         }, '*');
       } catch (e) { /* postMessage may fail in cross-origin iframes */ }
     }

--- a/src/server/dev-server/error-overlay/html-template.ts
+++ b/src/server/dev-server/error-overlay/html-template.ts
@@ -10,6 +10,13 @@ const WS_RECONNECT_MAX_DELAY_MS = 5_000;
 /** Maximum number of WebSocket reconnection attempts before giving up */
 const WS_MAX_RECONNECT_ATTEMPTS = 10;
 
+/** JSON.stringify that escapes `<` to prevent `</script>` breaking inline scripts */
+function jsonForScript(value: unknown): string {
+  const json = JSON.stringify(value);
+  // JSON.stringify(undefined) returns undefined (not a string)
+  return json === undefined ? "undefined" : json.replace(/</g, "\\u003c");
+}
+
 export function generateRuntimeScript(): string {
   return `
     // Veryfront Error Overlay Runtime
@@ -340,12 +347,12 @@ export function generateErrorHTML(
     projectSlug
       ? `
     (function() {
-      var slug = ${JSON.stringify(projectSlug)};
-      var errorName = ${JSON.stringify(errorInfo.error.name)};
-      var errorMessage = ${JSON.stringify(errorInfo.error.message)};
-      var errorFile = ${JSON.stringify(errorInfo.file ?? null)};
-      var errorLine = ${JSON.stringify(errorInfo.line ?? null)};
-      var errorColumn = ${JSON.stringify(errorInfo.column ?? null)};
+      var slug = ${jsonForScript(projectSlug)};
+      var errorName = ${jsonForScript(errorInfo.error.name)};
+      var errorMessage = ${jsonForScript(errorInfo.error.message)};
+      var errorFile = ${jsonForScript(errorInfo.file ?? null)};
+      var errorLine = ${jsonForScript(errorInfo.line ?? null)};
+      var errorColumn = ${jsonForScript(errorInfo.column ?? null)};
       var btn = document.getElementById('vf-fix-btn');
       if (btn) {
         btn.addEventListener('click', function() {
@@ -374,8 +381,8 @@ export function generateErrorHTML(
           url: window.location.href,
           errors: [{
             type: 'error',
-            message: ${JSON.stringify(errorInfo.error.message)},
-            file: ${JSON.stringify(errorInfo.file || undefined)},
+            message: ${jsonForScript(errorInfo.error.message)},
+            file: ${jsonForScript(errorInfo.file || undefined)},
             line: ${errorInfo.line ? String(errorInfo.line) : "undefined"},
             column: ${errorInfo.column ? String(errorInfo.column) : "undefined"}
           }]

--- a/src/server/dev-server/error-overlay/html-template.ts
+++ b/src/server/dev-server/error-overlay/html-template.ts
@@ -129,9 +129,9 @@ export function generateRuntimeScript(): string {
             </button>
             \${window.__VF_PROJECT_SLUG__ ? \`
             <button type="button" id="vf-fix-btn-runtime" style="
-              background: #fff;
-              border: none;
-              color: #000;
+              background: transparent;
+              border: 1px solid rgba(255, 255, 255, 0.2);
+              color: rgba(255, 255, 255, 0.7);
               padding: 10px 20px;
               border-radius: 9999px;
               cursor: pointer;
@@ -146,6 +146,24 @@ export function generateRuntimeScript(): string {
       \`;
 
       document.body.appendChild(overlay);
+
+      // Notify Studio of runtime error
+      if (window.parent !== window) {
+        try {
+          window.parent.postMessage({
+            action: 'runtimeError',
+            hasError: true,
+            errors: [{
+              type: 'error',
+              message: (errorInfo.error && errorInfo.error.message) || 'Unknown error',
+              stack: (errorInfo.error && errorInfo.error.stack) || undefined,
+              file: errorInfo.file ? String(errorInfo.file) : undefined,
+              line: errorInfo.line ? Number(errorInfo.line) : undefined,
+              column: errorInfo.column ? Number(errorInfo.column) : undefined
+            }]
+          }, '*');
+        } catch (e) { /* postMessage may fail */ }
+      }
 
       if (window.__VF_PROJECT_SLUG__) {
         var fixBtn = document.getElementById('vf-fix-btn-runtime');
@@ -320,12 +338,15 @@ export function generateErrorHTML(
       background: #e5e5e5;
     }
     .btn-fix {
-      background: #fff;
-      color: #000;
+      background: transparent;
+      color: rgba(255, 255, 255, 0.7);
+      border: 1px solid rgba(255, 255, 255, 0.2);
       margin-left: 8px;
     }
     .btn-fix:hover {
-      background: #e5e5e5;
+      background: rgba(255, 255, 255, 0.1);
+      color: #fff;
+      border-color: rgba(255, 255, 255, 0.4);
     }
   </style>
 </head>

--- a/src/server/dev-server/error-overlay/html-template.ts
+++ b/src/server/dev-server/error-overlay/html-template.ts
@@ -152,11 +152,11 @@ export function generateRuntimeScript(): string {
         try {
           window.parent.postMessage({
             action: 'runtimeError',
+            url: window.location.href,
             hasError: true,
             errors: [{
               type: 'error',
               message: (errorInfo.error && errorInfo.error.message) || 'Unknown error',
-              stack: (errorInfo.error && errorInfo.error.stack) || undefined,
               file: errorInfo.file ? String(errorInfo.file) : undefined,
               line: errorInfo.line ? Number(errorInfo.line) : undefined,
               column: errorInfo.column ? Number(errorInfo.column) : undefined

--- a/src/server/dev-server/error-overlay/html-template.ts
+++ b/src/server/dev-server/error-overlay/html-template.ts
@@ -175,9 +175,10 @@ export function generateRuntimeScript(): string {
             var rawLine = errorInfo.line ? String(errorInfo.line) : null;
             var rawColumn = errorInfo.column ? String(errorInfo.column) : null;
             var loc = rawFile ? rawFile + (rawLine ? ':' + rawLine : '') + (rawColumn ? ':' + rawColumn : '') : null;
+            var bt = String.fromCharCode(96);
             var prompt = 'Find and fix the following error' +
-              (loc ? ' in ' + loc : '') +
-              ':\\n\\n' + rawName + ': ' + rawMessage;
+              (loc ? ' in ' + bt + loc + bt : '') +
+              '\\n\\n' + bt + rawMessage + bt;
             if (window.parent !== window) {
               window.parent.postMessage({ action: 'chatMessage', prompt: prompt }, '*');
             } else {
@@ -378,9 +379,10 @@ export function generateErrorHTML(
       if (btn) {
         btn.addEventListener('click', function() {
           var loc = errorFile ? errorFile + (errorLine ? ':' + errorLine : '') + (errorColumn ? ':' + errorColumn : '') : null;
+          var bt = String.fromCharCode(96);
           var prompt = 'Find and fix the following error' +
-            (loc ? ' in ' + loc : '') +
-            ':\\n\\n' + errorName + ': ' + errorMessage;
+            (loc ? ' in ' + bt + loc + bt : '') +
+            '\\n\\n' + bt + errorMessage + bt;
           if (window.parent !== window) {
             window.parent.postMessage({ action: 'chatMessage', prompt: prompt }, '*');
           } else {

--- a/src/server/dev-server/error-overlay/index.ts
+++ b/src/server/dev-server/error-overlay/index.ts
@@ -10,6 +10,7 @@ export {
   type ErrorType,
   formatErrorType,
   getSuggestion,
+  parseErrorLocation,
 } from "./error-formatter.ts";
 export { generateErrorHTML, generateRuntimeScript } from "./html-template.ts";
 export {

--- a/src/server/dev-server/error-overlay/overlay-renderer.ts
+++ b/src/server/dev-server/error-overlay/overlay-renderer.ts
@@ -4,10 +4,11 @@ import { generateErrorHTML, generateRuntimeScript } from "./html-template.ts";
 export const ErrorOverlay = {
   getRuntime: generateRuntimeScript,
   getSuggestion,
-  createHTML(errorInfo: ErrorInfo): string {
+  createHTML(errorInfo: ErrorInfo, projectSlug?: string): string {
     return generateErrorHTML(
       errorInfo,
       errorInfo.suggestion ?? getSuggestion(errorInfo.error),
+      projectSlug,
     );
   },
 };

--- a/src/server/dev-server/request-handler.ts
+++ b/src/server/dev-server/request-handler.ts
@@ -9,7 +9,7 @@ import {
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { clearConfigCache } from "#veryfront/config";
-import { ErrorOverlay } from "./error-overlay/index.ts";
+import { ErrorOverlay, parseErrorLocation } from "./error-overlay/index.ts";
 import { createResponseBuilder } from "#veryfront/security/index.ts";
 import { resetApiHandler } from "../handlers/request/api/pages-api-handler.ts";
 import { clearLayoutDiscoveryCache } from "#veryfront/rendering/layouts/index.ts";
@@ -169,11 +169,13 @@ export class RequestHandler {
     getErrorCollector().addRuntimeError(err.message, err.stack, { source: "request-handler" });
 
     const sourceFile = (err as Error & { sourceFile?: string }).sourceFile;
+    const location = sourceFile ? parseErrorLocation(err, sourceFile) : {};
     return new Response(
       ErrorOverlay.createHTML({
         type: "runtime",
         error: err,
         ...(sourceFile ? { file: sourceFile } : {}),
+        ...location,
       }, this.defaultProjectSlug),
       {
         status: HTTP_SERVER_ERROR,

--- a/src/server/dev-server/request-handler.ts
+++ b/src/server/dev-server/request-handler.ts
@@ -168,11 +168,13 @@ export class RequestHandler {
     const err = error as Error;
     getErrorCollector().addRuntimeError(err.message, err.stack, { source: "request-handler" });
 
+    const sourceFile = (err as Error & { sourceFile?: string }).sourceFile;
     return new Response(
       ErrorOverlay.createHTML({
         type: "runtime",
         error: err,
-      }),
+        ...(sourceFile ? { file: sourceFile } : {}),
+      }, this.defaultProjectSlug),
       {
         status: HTTP_SERVER_ERROR,
         headers: { "content-type": "text/html; charset=utf-8" },

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -239,9 +239,14 @@ export class SSRService {
         slug,
       });
 
+      const sourceFile = (errorObj as Error & { sourceFile?: string }).sourceFile;
       return {
         status: HTTP_INTERNAL_SERVER_ERROR,
-        html: ErrorOverlay.createHTML({ error: errorObj, type: "runtime" }),
+        html: ErrorOverlay.createHTML({
+          error: errorObj,
+          type: "runtime",
+          ...(sourceFile ? { file: sourceFile } : {}),
+        }, ctx.projectSlug),
         isStreaming: false,
         cacheStrategy: "no-cache",
         error: errorObj,

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -14,7 +14,7 @@ import {
   startRenderSession,
 } from "#veryfront/transforms/mdx/esm-module-loader/module-fetcher/index.ts";
 import { getErrorCollector } from "#veryfront/observability/error-collector.ts";
-import { ErrorOverlay } from "../../dev-server/error-overlay/index.ts";
+import { ErrorOverlay, parseErrorLocation } from "../../dev-server/error-overlay/index.ts";
 import { ErrorPages } from "../../utils/error-html.ts";
 import {
   HTTP_INTERNAL_SERVER_ERROR,
@@ -240,12 +240,14 @@ export class SSRService {
       });
 
       const sourceFile = (errorObj as Error & { sourceFile?: string }).sourceFile;
+      const location = sourceFile ? parseErrorLocation(errorObj, sourceFile) : {};
       return {
         status: HTTP_INTERNAL_SERVER_ERROR,
         html: ErrorOverlay.createHTML({
           error: errorObj,
           type: "runtime",
           ...(sourceFile ? { file: sourceFile } : {}),
+          ...location,
         }, ctx.projectSlug),
         isStreaming: false,
         cacheStrategy: "no-cache",

--- a/src/server/utils/error-html.test.ts
+++ b/src/server/utils/error-html.test.ts
@@ -47,7 +47,7 @@ describe("server/utils/error-html", () => {
         minimal: true,
       });
 
-      assertIncludes(html, '"/foo/bar"');
+      assertIncludes(html, "&quot;/foo/bar&quot;");
     });
 
     it("should include Veryfront favicon in styled mode", () => {

--- a/src/server/utils/error-html.test.ts
+++ b/src/server/utils/error-html.test.ts
@@ -101,4 +101,32 @@ describe("server/utils/error-html", () => {
       assertIncludes(html, "Service Temporarily Unavailable");
     });
   });
+
+  describe("postMessage errors", () => {
+    it("should emit postMessage with type 'warning' for 404 pages", () => {
+      const html = ErrorPages.notFound("/missing");
+
+      assertIncludes(html, "type: 'warning'");
+      assertIncludes(html, "appUpdated");
+      assertIncludes(html, "hasError: true");
+    });
+
+    it("should emit postMessage with type 'warning' for undeployed pages", () => {
+      const html = ErrorPages.undeployed();
+
+      assertIncludes(html, "type: 'warning'");
+    });
+
+    it("should emit postMessage with type 'error' for 500 pages", () => {
+      const html = ErrorPages.serverError();
+
+      assertIncludes(html, "type: 'error'");
+    });
+
+    it("should emit postMessage with type 'error' for 503 pages", () => {
+      const html = ErrorPages.memoryPressure();
+
+      assertIncludes(html, "type: 'error'");
+    });
+  });
 });

--- a/src/server/utils/error-html.ts
+++ b/src/server/utils/error-html.ts
@@ -1,3 +1,5 @@
+import { escapeHTML } from "#veryfront/html/html-escape.ts";
+
 interface ErrorHtmlOptions {
   statusCode: number;
   title: string;
@@ -30,7 +32,7 @@ function generateStyledErrorHtml(statusCode: number, title: string, message: str
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <link rel="icon" type="image/png" href="https://cdn.veryfront.com/images/veryfront-favicon.png">
-  <title>${statusCode} ${title} — Veryfront</title>
+  <title>${statusCode} ${escapeHTML(title)} — Veryfront</title>
   <style>
     :root {
       --bg: #ffffff;
@@ -79,8 +81,8 @@ function generateStyledErrorHtml(statusCode: number, title: string, message: str
 </head>
 <body>
   <div class="container">
-    <h1 class="title">${title}</h1>
-    <p class="message">${message}</p>
+    <h1 class="title">${escapeHTML(title)}</h1>
+    <p class="message">${escapeHTML(message)}</p>
   </div>
   <script>
     if (window.parent !== window) {
@@ -115,11 +117,11 @@ function generateMinimalErrorHtml(
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>${statusCode} ${title}</title>
+  <title>${statusCode} ${escapeHTML(title)}</title>
 </head>
 <body>
-  <h1>${statusCode} ${title}</h1>
-  <p>${fullMessage}</p>
+  <h1>${statusCode} ${escapeHTML(title)}</h1>
+  <p>${escapeHTML(fullMessage)}</p>
 </body>
 </html>`;
 }

--- a/src/server/utils/error-html.ts
+++ b/src/server/utils/error-html.ts
@@ -19,6 +19,13 @@ export function generateErrorHtml(options: ErrorHtmlOptions): string {
 }
 
 function generateStyledErrorHtml(statusCode: number, title: string, message: string): string {
+  const errorMessage = title === "Not Found"
+    ? `Page not found: ${message}`
+    : message;
+
+  // 4xx = warning (routing/config issue), 5xx = error (something broke)
+  const errorType = statusCode >= 500 ? "error" : "warning";
+
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -77,6 +84,22 @@ function generateStyledErrorHtml(statusCode: number, title: string, message: str
     <h1 class="title">${title}</h1>
     <p class="message">${message}</p>
   </div>
+  <script>
+    if (window.parent !== window) {
+      try {
+        window.parent.postMessage({
+          action: 'appUpdated',
+          isInitialLoad: true,
+          hasError: true,
+          url: window.location.href,
+          errors: [{
+            type: '${errorType}',
+            message: ${JSON.stringify(errorMessage)}
+          }]
+        }, '*');
+      } catch (e) { /* postMessage may fail in cross-origin iframes */ }
+    }
+  </script>
 </body>
 </html>`;
 }

--- a/src/server/utils/error-html.ts
+++ b/src/server/utils/error-html.ts
@@ -92,7 +92,7 @@ function generateStyledErrorHtml(statusCode: number, title: string, message: str
           url: window.location.href,
           errors: [{
             type: '${errorType}',
-            message: ${JSON.stringify(errorMessage)}
+            message: ${JSON.stringify(errorMessage).replace(/</g, "\\u003c")}
           }]
         }, '*');
       } catch (e) { /* postMessage may fail in cross-origin iframes */ }

--- a/src/server/utils/error-html.ts
+++ b/src/server/utils/error-html.ts
@@ -19,9 +19,7 @@ export function generateErrorHtml(options: ErrorHtmlOptions): string {
 }
 
 function generateStyledErrorHtml(statusCode: number, title: string, message: string): string {
-  const errorMessage = title === "Not Found"
-    ? `Page not found: ${message}`
-    : message;
+  const errorMessage = title === "Not Found" ? `Page not found: ${message}` : message;
 
   // 4xx = warning (routing/config issue), 5xx = error (something broke)
   const errorType = statusCode >= 500 ? "error" : "warning";

--- a/src/studio/schemas/index.ts
+++ b/src/studio/schemas/index.ts
@@ -5,8 +5,8 @@
  */
 
 export {
-  type BundlerMessage,
-  BundlerMessageSchema,
+  type ErrorMessage,
+  ErrorMessageSchema,
   type LogMessage,
   LogMessageSchema,
   type LogMethod,

--- a/src/studio/schemas/studio.schema.test.ts
+++ b/src/studio/schemas/studio.schema.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
-  BundlerMessageSchema,
+  ErrorMessageSchema,
   LogMessageSchema,
   MessageFromRendererSchema,
   MessageFromStudioSchema,
@@ -158,9 +158,9 @@ describe("studio/schema", () => {
     });
   });
 
-  describe("BundlerMessageSchema", () => {
+  describe("ErrorMessageSchema", () => {
     it("should accept error message", () => {
-      const result = BundlerMessageSchema.safeParse({
+      const result = ErrorMessageSchema.safeParse({
         type: "error",
         message: "Syntax error",
         file: "app.tsx",
@@ -171,7 +171,7 @@ describe("studio/schema", () => {
     });
 
     it("should accept warning message", () => {
-      const result = BundlerMessageSchema.safeParse({
+      const result = ErrorMessageSchema.safeParse({
         type: "warning",
         message: "Unused variable",
       });
@@ -179,7 +179,7 @@ describe("studio/schema", () => {
     });
 
     it("should reject invalid type", () => {
-      const result = BundlerMessageSchema.safeParse({
+      const result = ErrorMessageSchema.safeParse({
         type: "info",
         message: "Info message",
       });
@@ -319,12 +319,90 @@ describe("studio/schema", () => {
       assertEquals(result.success, false);
     });
 
+    it("should accept chatMessage action", () => {
+      const result = MessageFromRendererSchema.safeParse({
+        action: "chatMessage",
+        prompt: "Fix the error in src/app.tsx",
+      });
+      assertEquals(result.success, true);
+    });
+
+    it("should reject chatMessage without prompt", () => {
+      const result = MessageFromRendererSchema.safeParse({
+        action: "chatMessage",
+      });
+      assertEquals(result.success, false);
+    });
+
     it("should reject invalid action", () => {
       const result = MessageFromRendererSchema.safeParse({
         action: "invalidAction",
         url: "https://example.com",
       });
       assertEquals(result.success, false);
+    });
+
+    it("should accept appUpdated with hasError and errors[] array", () => {
+      const result = MessageFromRendererSchema.safeParse({
+        action: "appUpdated",
+        url: "https://example.com",
+        id: "page-123",
+        isInitialLoad: true,
+        hasError: true,
+        errors: [
+          {
+            type: "error",
+            message: "Cannot read property of undefined",
+            file: "src/components/Button.tsx",
+            line: 42,
+            column: 7,
+          },
+        ],
+      });
+      assertEquals(result.success, true);
+    });
+
+    it("should accept appUpdated without id when hasError is true and errors[] is provided", () => {
+      const result = MessageFromRendererSchema.safeParse({
+        action: "appUpdated",
+        url: "https://example.com",
+        isInitialLoad: true,
+        hasError: true,
+        errors: [
+          {
+            type: "error",
+            message: "Unexpected token",
+            file: "src/app.tsx",
+            line: 10,
+            column: 3,
+          },
+        ],
+      });
+      assertEquals(result.success, true);
+    });
+
+    it("should accept appUpdated with only hasError and no errors[] array", () => {
+      const result = MessageFromRendererSchema.safeParse({
+        action: "appUpdated",
+        url: "https://example.com",
+        hasError: true,
+      });
+      assertEquals(result.success, true);
+    });
+
+    it("should accept appUpdated with errors[] containing minimal fields", () => {
+      const result = MessageFromRendererSchema.safeParse({
+        action: "appUpdated",
+        url: "https://example.com",
+        hasError: true,
+        errors: [
+          {
+            type: "error",
+            message: "Something failed",
+          },
+        ],
+      });
+      assertEquals(result.success, true);
     });
   });
 

--- a/src/studio/schemas/studio.schema.ts
+++ b/src/studio/schemas/studio.schema.ts
@@ -115,10 +115,6 @@ export const MessageFromRendererSchema = z.discriminatedUnion("action", [
     }).optional(),
   }),
   z.object({
-    action: z.literal("errorPageLoaded"),
-    url: z.string(),
-  }),
-  z.object({
     action: z.literal("onPageTransitionStart"),
     url: z.string(),
     projectId: z.string(),

--- a/src/studio/schemas/studio.schema.ts
+++ b/src/studio/schemas/studio.schema.ts
@@ -63,7 +63,7 @@ export const NavigatorNodeSchema: z.ZodType<{
   })
 );
 
-export const BundlerMessageSchema = z.object({
+export const ErrorMessageSchema = z.object({
   type: z.enum(["error", "warning"]),
   message: z.string(),
   file: z.string().optional(),
@@ -84,16 +84,17 @@ export const MessageFromRendererSchema = z.discriminatedUnion("action", [
   z.object({
     action: z.literal("appUpdated"),
     url: z.string(),
-    id: z.string(),
+    id: z.string().optional(),
     isInitialLoad: z.boolean().optional(),
+    hasError: z.boolean().optional(),
     nodesStore: z.record(z.unknown()).optional(),
-    errors: z.array(BundlerMessageSchema).optional(),
-    warnings: z.array(BundlerMessageSchema).optional(),
+    errors: z.array(ErrorMessageSchema).optional(),
+    warnings: z.array(ErrorMessageSchema).optional(),
   }),
   z.object({
     action: z.literal("runtimeError"),
     url: z.string(),
-    errors: z.array(BundlerMessageSchema).optional(),
+    errors: z.array(ErrorMessageSchema).optional(),
   }),
   z.object({
     action: z.literal("treeUpdated"),
@@ -174,6 +175,10 @@ export const MessageFromRendererSchema = z.discriminatedUnion("action", [
     action: z.literal("editNodeProps"),
     id: z.string(),
   }),
+  z.object({
+    action: z.literal("chatMessage"),
+    prompt: z.string(),
+  }),
 ]);
 
 /** postMessage events from Studio to Renderer */
@@ -228,6 +233,6 @@ export type LogMethod = z.infer<typeof logMethodSchema>;
 export type LogMessage = z.infer<typeof LogMessageSchema>;
 export type NavigatorNodeType = z.infer<typeof navigatorNodeTypeSchema>;
 export type NavigatorNode = z.infer<typeof NavigatorNodeSchema>;
-export type BundlerMessage = z.infer<typeof BundlerMessageSchema>;
+export type ErrorMessage = z.infer<typeof ErrorMessageSchema>;
 export type MessageFromRenderer = z.infer<typeof MessageFromRendererSchema>;
 export type MessageFromStudio = z.infer<typeof MessageFromStudioSchema>;

--- a/src/studio/types.ts
+++ b/src/studio/types.ts
@@ -7,7 +7,7 @@
 
 // Re-export schema-based types
 export type {
-  BundlerMessage,
+  ErrorMessage,
   LogMessage,
   LogMethod,
   MessageFromRenderer,


### PR DESCRIPTION
## Summary

Builds a structured error reporting pipeline between the renderer and Studio, covering SSR errors, runtime errors, and error pages.

```
┌─────────────────────────────────────────────────────────────┐
│  Renderer (iframe / standalone)                             │
│                                                             │
│  SSR Error ──► Error Overlay ──► appUpdated + errors[]      │
│                                  + "Fix in Veryfront" btn   │
│                                                             │
│  Runtime Error ──► Error Overlay ──► (shows overlay)        │
│                                     + "Fix in Veryfront" btn│
│                                                             │
│  404 / Undeployed ──► Error Page ──► appUpdated (warning)   │
│  500 / 503        ──► Error Page ──► appUpdated (error)     │
├─────────────────────────────────────────────────────────────┤
│  Studio (parent)                                            │
│                                                             │
│  ◄── appUpdated { hasError, errors[] } ── stops spinner,    │
│                                           shows error state │
│  ◄── chatMessage { prompt }            ── triggers AI fix   │
└─────────────────────────────────────────────────────────────┘
```

### What's new

- **Structured error messages** — `appUpdated` now carries `hasError` and `errors[]` (typed as `"error"` or `"warning"`) so Studio knows what happened
- **"Fix in Veryfront" button** — on SSR and runtime error overlays; sends `chatMessage` to Studio (iframe) or opens Studio with prompt (standalone)
- **Error page reporting** — 404, undeployed, 500, 503 pages now emit `appUpdated` to Studio so the loading spinner stops and error state is shown
- **Error location** — pipeline errors carry `sourceFile` for precise file:line:column in prompts
- **XSS hardening** — `jsonForScript()` escapes `<` as `\u003c` in inline scripts; HTML-escape user-controlled content in error pages

### Schema changes

- New `chatMessage` action in `MessageFromRendererSchema`
- `appUpdated` gains optional `hasError: boolean` and `errors: ErrorMessage[]`
- `appUpdated.id` now optional (error pages don't have one)
- Rename `BundlerMessageSchema` → `ErrorMessageSchema`

## Files changed

| File | Change |
|------|--------|
| `studio.schema.ts` | `chatMessage` action, `hasError` + `errors[]`, schema rename |
| `html-template.ts` | Fix button (SSR + runtime), `jsonForScript()` XSS helper |
| `overlay-renderer.ts` | Forward `projectSlug` |
| `ssr.service.ts` | Pass `ctx.projectSlug` + `sourceFile` |
| `request-handler.ts` | Pass `defaultProjectSlug` + `sourceFile` |
| `html-shell-generator.ts` | Inject `window.__VF_PROJECT_SLUG__` global |
| `pipeline.ts` | Attach `sourceFile` to pipeline errors |
| `error-html.ts` | `appUpdated` postMessage with typed errors, HTML escaping |

## Test plan

- [x] Schema: chatMessage validation, rejection without prompt
- [x] Overlay: button presence/absence, XSS `</script>` prevention
- [x] Error pages: `type: 'warning'` for 4xx, `type: 'error'` for 5xx
- [ ] Manual: SSR error → overlay + Fix button + postMessage
- [ ] Manual: runtime error → overlay + Fix button
- [ ] Manual: 404 → `appUpdated` with `type: 'warning'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)