### PR TITLE
fix(ci): rebuild sandbox after CLI release

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -306,6 +306,14 @@ jobs:
           event-type: veryfront-code-released
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
 
+      - name: Trigger sandbox deploy
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GH_PAT_VERYFRONT }}
+          repository: veryfront/veryfront-sandbox
+          event-type: veryfront-code-released
+          client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
+
   # ============================================
   # CD: Stable Release (clean semver only)
   # Runs when deno.json version is X.Y.Z (no suffix)
@@ -434,6 +442,14 @@ jobs:
         with:
           token: ${{ secrets.GH_PAT_VERYFRONT }}
           repository: veryfront/veryfront-job-runner
+          event-type: veryfront-code-released
+          client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
+
+      - name: Trigger sandbox deploy
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GH_PAT_VERYFRONT }}
+          repository: veryfront/veryfront-sandbox
           event-type: veryfront-code-released
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
 


### PR DESCRIPTION
## Summary
- dispatch a sandbox rebuild after prerelease publishes
- dispatch a sandbox rebuild after stable releases publish

## Why
Sandbox main builds can run before the matching CLI publish completes. Triggering a follow-up sandbox rebuild with the exact released version keeps the production sandbox image aligned with the CLI release.