### PR TITLE
chore: bump version to 0.1.73

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.72",
+  "version": "0.1.73",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [


### PR DESCRIPTION
## Summary
- Bump patch version from 0.1.72 to 0.1.73 in deno.json

## Test plan
- [ ] CI passes