### PR TITLE
fix(cli): batch explicit upload downloads during ingest

### DIFF
--- a/cli/commands/knowledge/command.test.ts
+++ b/cli/commands/knowledge/command.test.ts
@@ -306,7 +306,7 @@ describe("collectKnowledgeSources", () => {
   });
 
   it("resolves multiple explicit sources in input order", async () => {
-    const calls: string[] = [];
+    const downloadCalls: string[][] = [];
     const sources = await collectKnowledgeSources(
       {
         sources: [
@@ -322,7 +322,7 @@ describe("collectKnowledgeSources", () => {
         client: createMockClient(),
         projectSlug: "my-project",
         downloadUploads: async (uploadPaths) => {
-          calls.push(...uploadPaths);
+          downloadCalls.push(uploadPaths);
           return uploadPaths.map((uploadPath) => ({
             uploadPath,
             localPath: `/workspace/uploads/${uploadPath}`,
@@ -331,11 +331,69 @@ describe("collectKnowledgeSources", () => {
       },
     );
 
-    assertEquals(calls, ["contracts/a.pdf", "contracts/b.pdf", "contracts/c.pdf"]);
+    assertEquals(downloadCalls, [["contracts/a.pdf", "contracts/b.pdf", "contracts/c.pdf"]]);
     assertEquals(
       sources.map((source) => source.kind === "upload" ? source.uploadPath : source.localPath),
       ["contracts/a.pdf", "contracts/b.pdf", "contracts/c.pdf"],
     );
+  });
+
+  it("batches explicit upload downloads while preserving mixed-source order", async () => {
+    const tempDir = await Deno.makeTempDir();
+    const localPath = `${tempDir}/notes.txt`;
+    await Deno.writeTextFile(localPath, "stub");
+
+    try {
+      const downloadCalls: string[][] = [];
+      const sources = await collectKnowledgeSources(
+        {
+          sources: ["uploads/contracts/a.pdf", localPath, "uploads/contracts/b.pdf"],
+          path: undefined,
+          all: false,
+          recursive: false,
+        },
+        {
+          client: createMockClient(),
+          projectSlug: "my-project",
+          downloadUploads: async (uploadPaths) => {
+            downloadCalls.push(uploadPaths);
+            return [
+              {
+                uploadPath: "contracts/b.pdf",
+                localPath: "/workspace/uploads/contracts/b.pdf",
+              },
+              {
+                uploadPath: "contracts/a.pdf",
+                localPath: "/workspace/uploads/contracts/a.pdf",
+              },
+            ];
+          },
+        },
+      );
+
+      assertEquals(downloadCalls, [["contracts/a.pdf", "contracts/b.pdf"]]);
+      assertEquals(sources, [
+        {
+          kind: "upload",
+          input: "uploads/contracts/a.pdf",
+          uploadPath: "contracts/a.pdf",
+          localPath: "/workspace/uploads/contracts/a.pdf",
+        },
+        {
+          kind: "local",
+          input: localPath,
+          localPath,
+        },
+        {
+          kind: "upload",
+          input: "uploads/contracts/b.pdf",
+          uploadPath: "contracts/b.pdf",
+          localPath: "/workspace/uploads/contracts/b.pdf",
+        },
+      ]);
+    } finally {
+      await Deno.remove(tempDir, { recursive: true }).catch(() => undefined);
+    }
   });
 });
 

--- a/cli/commands/knowledge/command.ts
+++ b/cli/commands/knowledge/command.ts
@@ -369,32 +369,64 @@ export async function collectKnowledgeSources(
 ): Promise<KnowledgeSource[]> {
   const fs = createFileSystem();
 
-  const resolveExplicitSource = async (input: string): Promise<KnowledgeSource[]> => {
-    if (!isProjectUploadReference(input) && await fs.exists(input)) {
-      const localFiles = await collectLocalFiles(input, options.recursive);
-      if (!localFiles.length) throw new Error(`No supported files found at ${input}`);
-      return localFiles.map((localPath) => ({ kind: "local", input, localPath }));
-    }
-
-    if (isLikelyLocalPath(input)) {
-      throw new Error(`Local file not found: ${input}`);
-    }
-
-    const uploadPath = normalizeProjectUploadPath(input);
-    const downloads = await deps.downloadUploads([uploadPath]);
-    return downloads.map((download) => ({
-      kind: "upload",
-      input,
-      uploadPath: download.uploadPath,
-      localPath: download.localPath,
-    }));
-  };
-
   if (options.sources.length > 0) {
-    const resolvedSources = await Promise.all(
-      options.sources.map((source) => resolveExplicitSource(source)),
-    );
-    return resolvedSources.flat();
+    const explicitSources: Array<
+      | { kind: "local"; sources: KnowledgeSource[] }
+      | { kind: "upload"; input: string; uploadPath: string }
+    > = [];
+    const uploadTargets: string[] = [];
+
+    for (const input of options.sources) {
+      if (!isProjectUploadReference(input) && await fs.exists(input)) {
+        const localFiles = await collectLocalFiles(input, options.recursive);
+        if (!localFiles.length) throw new Error(`No supported files found at ${input}`);
+        explicitSources.push({
+          kind: "local",
+          sources: localFiles.map((localPath) => ({ kind: "local", input, localPath })),
+        });
+        continue;
+      }
+
+      if (isLikelyLocalPath(input)) {
+        throw new Error(`Local file not found: ${input}`);
+      }
+
+      const uploadPath = normalizeProjectUploadPath(input);
+      explicitSources.push({ kind: "upload", input, uploadPath });
+      uploadTargets.push(uploadPath);
+    }
+
+    const downloads = uploadTargets.length > 0 ? await deps.downloadUploads(uploadTargets) : [];
+    const downloadsByPath = new Map<string, DownloadResult[]>();
+
+    for (const download of downloads) {
+      const existing = downloadsByPath.get(download.uploadPath) ?? [];
+      existing.push(download);
+      downloadsByPath.set(download.uploadPath, existing);
+    }
+
+    const resolvedSources: KnowledgeSource[] = [];
+    for (const source of explicitSources) {
+      if (source.kind === "local") {
+        resolvedSources.push(...source.sources);
+        continue;
+      }
+
+      const matchingDownloads = downloadsByPath.get(source.uploadPath);
+      const download = matchingDownloads?.shift();
+      if (!download) {
+        throw new Error(`Upload not found: ${formatKnowledgeUploadSource(source.uploadPath)}`);
+      }
+
+      resolvedSources.push({
+        kind: "upload",
+        input: source.input,
+        uploadPath: download.uploadPath,
+        localPath: download.localPath,
+      });
+    }
+
+    return resolvedSources;
   }
 
   if (!options.path || !options.all) {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [


### PR DESCRIPTION
## Summary
- batch explicit upload-path downloads for `veryfront knowledge ingest`
- preserve mixed local/upload source ordering even when downloaded uploads are returned out of order
- retarget the PR to the remaining follow-up after the multi-source ingest work merged in #649

## Verification
- `deno fmt --check cli/commands/knowledge/command.ts cli/commands/knowledge/command.test.ts`
- `deno test --allow-env --allow-read --allow-write --allow-run cli/commands/knowledge/command.test.ts`