### PR TITLE
feat(cli): use kreuzberg for knowledge ingest parsing

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -57,8 +57,8 @@ Run `veryfront <command> --help` for options:
 | `files`         | List, get, put, and delete files    |
 | `knowledge`     | Knowledge-base ingestion workflow   |
 
-Use `uploads/...` for remote project-upload references in `veryfront knowledge ingest`; use `./uploads/...` or `/workspace/uploads/...` to force a local sandbox path.
-`veryfront knowledge ingest` requires `python3`; non-text formats also need the supported parser packages unless you run inside the Veryfront sandbox image.
+Use one or more `uploads/...` paths for remote project-upload references in `veryfront knowledge ingest`; use `./uploads/...` or `/workspace/uploads/...` to force a local sandbox path.
+`veryfront knowledge ingest` requires `python3`; inside the Veryfront sandbox it prefers `kreuzberg` for PDF, Office, and HTML extraction, and outside the sandbox it falls back to the supported parser packages when `kreuzberg` is unavailable.
 
 ## Adding a New Command
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -58,7 +58,7 @@ Run `veryfront <command> --help` for options:
 | `knowledge`     | Knowledge-base ingestion workflow   |
 
 Use one or more `uploads/...` paths for remote project-upload references in `veryfront knowledge ingest`; use `./uploads/...` or `/workspace/uploads/...` to force a local sandbox path.
-`veryfront knowledge ingest` requires `python3`; inside the Veryfront sandbox it prefers `kreuzberg` for PDF, Office, and HTML extraction, and outside the sandbox it falls back to the supported parser packages when `kreuzberg` is unavailable.
+`veryfront knowledge ingest` requires `python3`; inside the Veryfront sandbox it prefers `kreuzberg` for PDF, Office, and HTML extraction, and outside the sandbox it falls back to the supported parser packages when `kreuzberg` is unavailable or extraction fails.
 
 ## Adding a New Command
 

--- a/cli/commands/knowledge/command-help.ts
+++ b/cli/commands/knowledge/command-help.ts
@@ -37,6 +37,6 @@ export const knowledgeHelp: CommandHelp = {
     "`uploads/...` means a remote project upload; use `./uploads/...` or `/workspace/uploads/...` to force a local file",
     "`ingest` orchestrates upload resolution, parsing, and project file writes",
     "Requires python3; non-text formats also require the supported parser packages unless you run inside the Veryfront sandbox",
-    "The Veryfront sandbox image includes `kreuzberg`, and knowledge ingest prefers it for PDF, Office, and HTML extraction when available",
+    "The Veryfront sandbox image includes `kreuzberg`, and knowledge ingest falls back to the built-in parser when `kreuzberg` is unavailable or extraction fails",
   ],
 };

--- a/cli/commands/knowledge/command-help.ts
+++ b/cli/commands/knowledge/command-help.ts
@@ -3,7 +3,7 @@ import type { CommandHelp } from "../../help/types.ts";
 export const knowledgeHelp: CommandHelp = {
   name: "knowledge",
   description: "Ingest documents into the project knowledge base",
-  usage: "veryfront knowledge ingest <source> [options]",
+  usage: "veryfront knowledge ingest <source...> [options]",
   options: [
     {
       flag: "--project, -p <slug>",
@@ -28,6 +28,7 @@ export const knowledgeHelp: CommandHelp = {
   ],
   examples: [
     "veryfront knowledge ingest uploads/contracts/q1.pdf --json",
+    "veryfront knowledge ingest uploads/contracts/a.pdf uploads/contracts/b.pdf uploads/contracts/c.pdf --json",
     "veryfront knowledge ingest /workspace/uploads/q1.pdf --json",
     "veryfront knowledge ingest --path uploads/ --all --json",
   ],
@@ -36,5 +37,6 @@ export const knowledgeHelp: CommandHelp = {
     "`uploads/...` means a remote project upload; use `./uploads/...` or `/workspace/uploads/...` to force a local file",
     "`ingest` orchestrates upload resolution, parsing, and project file writes",
     "Requires python3; non-text formats also require the supported parser packages unless you run inside the Veryfront sandbox",
+    "The Veryfront sandbox image includes `kreuzberg`, and knowledge ingest prefers it for PDF, Office, and HTML extraction when available",
   ],
 };

--- a/cli/commands/knowledge/command.test.ts
+++ b/cli/commands/knowledge/command.test.ts
@@ -597,17 +597,16 @@ describe("runKnowledgeParser", () => {
       prefix: "veryfront-knowledge-parser-kreuzberg-fallback-",
     });
     const binDir = join(tempDir, "bin");
-    const filePath = join(tempDir, "landing.html");
+    const pythonDir = join(tempDir, "python");
+    const filePath = join(tempDir, "fallback.pdf");
     const outputDir = join(tempDir, "knowledge-output");
     const kreuzbergPath = join(binDir, "kreuzberg");
     const originalPath = Deno.env.get("PATH") ?? "";
 
     try {
       await Deno.mkdir(binDir, { recursive: true });
-      await Deno.writeTextFile(
-        filePath,
-        "<html><body><h1>Hello</h1><p>World</p></body></html>",
-      );
+      await Deno.mkdir(pythonDir, { recursive: true });
+      await Deno.writeTextFile(filePath, "stub pdf bytes");
       await Deno.writeTextFile(
         kreuzbergPath,
         [
@@ -616,17 +615,47 @@ describe("runKnowledgeParser", () => {
           "exit 2",
         ].join("\n"),
       );
+      await Deno.writeTextFile(
+        join(pythonDir, "pdfplumber.py"),
+        [
+          "class _Page:",
+          "    def __init__(self, text):",
+          "        self._text = text",
+          "",
+          "    def extract_text(self):",
+          "        return self._text",
+          "",
+          "    def extract_tables(self):",
+          "        return []",
+          "",
+          "class _Pdf:",
+          "    def __init__(self, path):",
+          '        self.pages = [_Page("Fallback PDF text")]',
+          "",
+          "    def __enter__(self):",
+          "        return self",
+          "",
+          "    def __exit__(self, exc_type, exc, tb):",
+          "        return False",
+          "",
+          "def open(path):",
+          "    return _Pdf(path)",
+        ].join("\n"),
+      );
       await Deno.chmod(kreuzbergPath, 0o755);
 
       const result = await runKnowledgeParser({
         filePath,
         outputDir,
-        sourceReference: "uploads/sites/landing.html",
-        env: { PATH: `${binDir}:${originalPath}` },
+        sourceReference: "uploads/offers/fallback.pdf",
+        env: {
+          PATH: `${binDir}:${originalPath}`,
+          PYTHONPATH: pythonDir,
+        },
       });
 
-      assertEquals(result.source_type, "html");
-      assertStringIncludes(result.summary, "Converted HTML");
+      assertEquals(result.source_type, "pdf");
+      assertStringIncludes(result.summary, "Extracted 1 page");
       assertEquals(result.stats.engine, undefined);
       assertEquals(result.warnings.length, 1);
       assertStringIncludes(
@@ -635,9 +664,9 @@ describe("runKnowledgeParser", () => {
       );
 
       const markdown = await Deno.readTextFile(result.sandbox_output_path);
-      assertStringIncludes(markdown, "# Landing");
-      assertStringIncludes(markdown, "Hello");
-      assertStringIncludes(markdown, "World");
+      assertStringIncludes(markdown, "# Fallback");
+      assertStringIncludes(markdown, "## Page 1");
+      assertStringIncludes(markdown, "Fallback PDF text");
     } finally {
       await Deno.remove(tempDir, { recursive: true }).catch(() => undefined);
     }

--- a/cli/commands/knowledge/command.test.ts
+++ b/cli/commands/knowledge/command.test.ts
@@ -126,7 +126,7 @@ describe("collectKnowledgeSources", () => {
     try {
       const sources = await collectKnowledgeSources(
         {
-          source: localPath,
+          sources: [localPath],
           path: undefined,
           all: false,
           recursive: false,
@@ -150,7 +150,7 @@ describe("collectKnowledgeSources", () => {
     const calls: string[] = [];
     const sources = await collectKnowledgeSources(
       {
-        source: "uploads/contracts/q1.pdf",
+        sources: ["uploads/contracts/q1.pdf"],
         path: undefined,
         all: false,
         recursive: false,
@@ -190,7 +190,7 @@ describe("collectKnowledgeSources", () => {
       const calls: string[] = [];
       const sources = await collectKnowledgeSources(
         {
-          source: "uploads/contracts/q1.pdf",
+          sources: ["uploads/contracts/q1.pdf"],
           path: undefined,
           all: false,
           recursive: false,
@@ -231,7 +231,7 @@ describe("collectKnowledgeSources", () => {
 
     const sources = await collectKnowledgeSources(
       {
-        source: undefined,
+        sources: [],
         path: "uploads/",
         all: true,
         recursive: true,
@@ -277,7 +277,7 @@ describe("collectKnowledgeSources", () => {
 
     const sources = await collectKnowledgeSources(
       {
-        source: undefined,
+        sources: [],
         path: "uploads/contracts",
         all: true,
         recursive: false,
@@ -303,6 +303,39 @@ describe("collectKnowledgeSources", () => {
     assertEquals(sources.length, 1);
     assertEquals(sources[0]?.kind, "upload");
   });
+
+  it("resolves multiple explicit sources in input order", async () => {
+    const calls: string[] = [];
+    const sources = await collectKnowledgeSources(
+      {
+        sources: [
+          "uploads/contracts/a.pdf",
+          "uploads/contracts/b.pdf",
+          "uploads/contracts/c.pdf",
+        ],
+        path: undefined,
+        all: false,
+        recursive: false,
+      },
+      {
+        client: createMockClient(),
+        projectSlug: "my-project",
+        downloadUploads: async (uploadPaths) => {
+          calls.push(...uploadPaths);
+          return uploadPaths.map((uploadPath) => ({
+            uploadPath,
+            localPath: `/workspace/uploads/${uploadPath}`,
+          }));
+        },
+      },
+    );
+
+    assertEquals(calls, ["contracts/a.pdf", "contracts/b.pdf", "contracts/c.pdf"]);
+    assertEquals(
+      sources.map((source) => source.kind === "upload" ? source.uploadPath : source.localPath),
+      ["contracts/a.pdf", "contracts/b.pdf", "contracts/c.pdf"],
+    );
+  });
 });
 
 describe("ingestResolvedSources", () => {
@@ -315,7 +348,7 @@ describe("ingestResolvedSources", () => {
         localPath: "/workspace/uploads/contracts/q1.pdf",
       }],
       {
-        source: undefined,
+        sources: [],
         path: undefined,
         all: false,
         recursive: false,
@@ -373,7 +406,7 @@ describe("ingestResolvedSources", () => {
         localPath: "/var/folders/random/report.pdf",
       }],
       {
-        source: undefined,
+        sources: [],
         path: undefined,
         all: false,
         recursive: false,
@@ -457,6 +490,55 @@ describe("runKnowledgeParser", () => {
       assertStringIncludes(markdown, "# Q1 Report");
       assertStringIncludes(markdown, "Quarterly revenue increased 12% year over year.");
     } finally {
+      await Deno.remove(tempDir, { recursive: true }).catch(() => undefined);
+    }
+  });
+
+  it("prefers kreuzberg for PDF extraction when the binary is available", async () => {
+    const tempDir = await Deno.makeTempDir({ prefix: "veryfront-knowledge-parser-kreuzberg-" });
+    const binDir = join(tempDir, "bin");
+    const filePath = join(tempDir, "offer.pdf");
+    const outputDir = join(tempDir, "knowledge-output");
+    const kreuzbergPath = join(binDir, "kreuzberg");
+    const originalPath = Deno.env.get("PATH") ?? "";
+
+    try {
+      await Deno.mkdir(binDir, { recursive: true });
+      await Deno.writeTextFile(filePath, "stub pdf bytes");
+      await Deno.writeTextFile(
+        kreuzbergPath,
+        [
+          "#!/bin/sh",
+          "if [ \"$1\" != \"extract\" ]; then",
+          "  echo \"unexpected command\" >&2",
+          "  exit 64",
+          "fi",
+          "printf '%s\\n' '{\"content\":\"## Fake PDF\\n\\nParsed by kreuzberg\",\"metadata\":{\"mime_type\":\"application/pdf\"}}'",
+        ].join("\n"),
+      );
+      await Deno.chmod(kreuzbergPath, 0o755);
+      Deno.env.set("PATH", `${binDir}:${originalPath}`);
+
+      const result = await runKnowledgeParser({
+        filePath,
+        outputDir,
+        description: "Offer PDF",
+        slug: "offer-pdf",
+        sourceReference: "uploads/offers/offer.pdf",
+      });
+
+      assertEquals(result.source_type, "pdf");
+      assertEquals(result.slug, "offer-pdf");
+      assertEquals(result.stats.engine, "kreuzberg");
+      assertStringIncludes(result.summary, "Converted PDF to markdown");
+
+      const markdown = await Deno.readTextFile(result.sandbox_output_path);
+      assertStringIncludes(markdown, 'source: "uploads/offers/offer.pdf"');
+      assertStringIncludes(markdown, 'description: "Offer PDF"');
+      assertStringIncludes(markdown, "# Offer");
+      assertStringIncludes(markdown, "Parsed by kreuzberg");
+    } finally {
+      Deno.env.set("PATH", originalPath);
       await Deno.remove(tempDir, { recursive: true }).catch(() => undefined);
     }
   });

--- a/cli/commands/knowledge/command.test.ts
+++ b/cli/commands/knowledge/command.test.ts
@@ -1,6 +1,7 @@
 import {
   assert,
   assertEquals,
+  assertRejects,
   assertStringIncludes,
   assertThrows,
 } from "#veryfront/testing/assert.ts";
@@ -446,6 +447,53 @@ describe("ingestResolvedSources", () => {
 
     assertEquals(parserSlug, "report");
   });
+
+  it("rejects a custom slug when more than one resolved source would be written", async () => {
+    await assertRejects(
+      () =>
+        ingestResolvedSources(
+          [
+            {
+              kind: "local",
+              input: "./contracts/a.pdf",
+              localPath: "/workspace/contracts/a.pdf",
+            },
+            {
+              kind: "local",
+              input: "./contracts/b.pdf",
+              localPath: "/workspace/contracts/b.pdf",
+            },
+          ],
+          {
+            sources: ["./contracts"],
+            path: undefined,
+            all: false,
+            recursive: false,
+            outputDir: "/workspace/knowledge",
+            knowledgePath: "knowledge",
+            description: undefined,
+            slug: "contracts-batch",
+            json: true,
+            quiet: false,
+            projectDir: undefined,
+            projectSlug: undefined,
+          },
+          {
+            client: createMockClient(),
+            projectSlug: "my-project",
+            outputDir: "/workspace/knowledge",
+            runParser: async () => {
+              throw new Error("runParser should not be called");
+            },
+            uploadKnowledgeFile: async () => {
+              throw new Error("uploadKnowledgeFile should not be called");
+            },
+          },
+        ),
+      Error,
+      "--slug can only be used with a single explicit source.",
+    );
+  });
 });
 
 describe("knowledgeIngestPythonSource", () => {
@@ -509,15 +557,14 @@ describe("runKnowledgeParser", () => {
         kreuzbergPath,
         [
           "#!/bin/sh",
-          "if [ \"$1\" != \"extract\" ]; then",
-          "  echo \"unexpected command\" >&2",
+          'if [ "$1" != "extract" ]; then',
+          '  echo "unexpected command" >&2',
           "  exit 64",
           "fi",
-          "printf '%s\\n' '{\"content\":\"## Fake PDF\\n\\nParsed by kreuzberg\",\"metadata\":{\"mime_type\":\"application/pdf\"}}'",
+          'printf \'%s\\n\' \'{"content":"## Fake PDF\\n\\nParsed by kreuzberg","metadata":{"mime_type":"application/pdf","page_count":3,"table_count":1}}\'',
         ].join("\n"),
       );
       await Deno.chmod(kreuzbergPath, 0o755);
-      Deno.env.set("PATH", `${binDir}:${originalPath}`);
 
       const result = await runKnowledgeParser({
         filePath,
@@ -525,11 +572,14 @@ describe("runKnowledgeParser", () => {
         description: "Offer PDF",
         slug: "offer-pdf",
         sourceReference: "uploads/offers/offer.pdf",
+        env: { PATH: `${binDir}:${originalPath}` },
       });
 
       assertEquals(result.source_type, "pdf");
       assertEquals(result.slug, "offer-pdf");
       assertEquals(result.stats.engine, "kreuzberg");
+      assertEquals(result.stats.pages, 3);
+      assertEquals(result.stats.tables, 1);
       assertStringIncludes(result.summary, "Converted PDF to markdown");
 
       const markdown = await Deno.readTextFile(result.sandbox_output_path);
@@ -538,7 +588,57 @@ describe("runKnowledgeParser", () => {
       assertStringIncludes(markdown, "# Offer");
       assertStringIncludes(markdown, "Parsed by kreuzberg");
     } finally {
-      Deno.env.set("PATH", originalPath);
+      await Deno.remove(tempDir, { recursive: true }).catch(() => undefined);
+    }
+  });
+
+  it("falls back to the built-in parser when kreuzberg extraction fails", async () => {
+    const tempDir = await Deno.makeTempDir({
+      prefix: "veryfront-knowledge-parser-kreuzberg-fallback-",
+    });
+    const binDir = join(tempDir, "bin");
+    const filePath = join(tempDir, "landing.html");
+    const outputDir = join(tempDir, "knowledge-output");
+    const kreuzbergPath = join(binDir, "kreuzberg");
+    const originalPath = Deno.env.get("PATH") ?? "";
+
+    try {
+      await Deno.mkdir(binDir, { recursive: true });
+      await Deno.writeTextFile(
+        filePath,
+        "<html><body><h1>Hello</h1><p>World</p></body></html>",
+      );
+      await Deno.writeTextFile(
+        kreuzbergPath,
+        [
+          "#!/bin/sh",
+          'echo "boom" >&2',
+          "exit 2",
+        ].join("\n"),
+      );
+      await Deno.chmod(kreuzbergPath, 0o755);
+
+      const result = await runKnowledgeParser({
+        filePath,
+        outputDir,
+        sourceReference: "uploads/sites/landing.html",
+        env: { PATH: `${binDir}:${originalPath}` },
+      });
+
+      assertEquals(result.source_type, "html");
+      assertStringIncludes(result.summary, "Converted HTML");
+      assertEquals(result.stats.engine, undefined);
+      assertEquals(result.warnings.length, 1);
+      assertStringIncludes(
+        result.warnings[0] ?? "",
+        "kreuzberg extraction failed; fell back to the built-in parser",
+      );
+
+      const markdown = await Deno.readTextFile(result.sandbox_output_path);
+      assertStringIncludes(markdown, "# Landing");
+      assertStringIncludes(markdown, "Hello");
+      assertStringIncludes(markdown, "World");
+    } finally {
       await Deno.remove(tempDir, { recursive: true }).catch(() => undefined);
     }
   });

--- a/cli/commands/knowledge/command.ts
+++ b/cli/commands/knowledge/command.ts
@@ -103,7 +103,7 @@ const KnowledgeIngestArgsSchema = z.object({
     });
   }
 
-  if (value.slug && value.sources.length > 1) {
+  if (value.slug && value.sources.length !== 1) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       message: "--slug can only be used with a single explicit source.",
@@ -310,6 +310,7 @@ export async function runKnowledgeParser(input: {
   description?: string;
   slug?: string;
   sourceReference?: string;
+  env?: Record<string, string>;
 }): Promise<KnowledgeParserResult> {
   const tempDir = await Deno.makeTempDir({ prefix: "veryfront-knowledge-parser-" });
   const inputJsonPath = `${tempDir}/input.json`;
@@ -333,7 +334,7 @@ export async function runKnowledgeParser(input: {
     try {
       result = await new Deno.Command("python3", {
         args: [scriptPath, "--input-json", inputJsonPath, "--output-json", outputJsonPath],
-        env: Deno.env.toObject(),
+        ...(input.env ? { env: input.env } : {}),
         stdout: "piped",
         stderr: "piped",
       }).output();
@@ -452,7 +453,11 @@ export async function ingestResolvedSources(
     uploadKnowledgeFile: (remotePath: string, localPath: string) => Promise<{ path: string }>;
   },
 ): Promise<KnowledgeIngestFileResult[]> {
-  const slugs = options.slug && sources.length === 1 ? [options.slug] : ensureUniqueSlugs(sources);
+  if (options.slug && sources.length !== 1) {
+    throw new Error("--slug can only be used with a single explicit source.");
+  }
+
+  const slugs = options.slug ? [options.slug] : ensureUniqueSlugs(sources);
   const results: KnowledgeIngestFileResult[] = [];
 
   for (const [index, source] of sources.entries()) {

--- a/cli/commands/knowledge/command.ts
+++ b/cli/commands/knowledge/command.ts
@@ -61,7 +61,7 @@ type DownloadResult = { uploadPath: string; localPath: string; bytes?: number };
 const KnowledgeIngestArgsSchema = z.object({
   projectSlug: z.string().optional(),
   projectDir: z.string().optional(),
-  source: z.string().optional(),
+  sources: z.array(z.string()).default([]),
   path: z.string().optional(),
   all: z.boolean().default(false),
   recursive: z.boolean().default(false),
@@ -71,6 +71,44 @@ const KnowledgeIngestArgsSchema = z.object({
   slug: z.string().optional(),
   json: z.boolean().default(false),
   quiet: z.boolean().default(false),
+}).superRefine((value, ctx) => {
+  const hasExplicitSources = value.sources.length > 0;
+  const hasPath = typeof value.path === "string" && value.path.length > 0;
+
+  if (hasExplicitSources && (hasPath || value.all)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Use either explicit source paths or --path with --all, not both.",
+    });
+  }
+
+  if (!hasExplicitSources && !hasPath && !value.all) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Provide one or more source paths or use --path with --all.",
+    });
+  }
+
+  if (hasPath && !value.all) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "--path requires --all.",
+    });
+  }
+
+  if (!hasPath && value.all) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "--all requires --path.",
+    });
+  }
+
+  if (value.slug && value.sources.length > 1) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "--slug can only be used with a single explicit source.",
+    });
+  }
 });
 
 export type KnowledgeIngestOptions = z.infer<typeof KnowledgeIngestArgsSchema>;
@@ -96,7 +134,7 @@ function showKnowledgeUsage(): void {
 Veryfront Knowledge
 
 Usage:
-  veryfront knowledge ingest <source> [options]
+  veryfront knowledge ingest <source...> [options]
   veryfront knowledge ingest --path <prefix-or-dir> --all [options]
 
 Subcommands:
@@ -110,7 +148,7 @@ export function parseKnowledgeIngestArgs(
   return KnowledgeIngestArgsSchema.safeParse({
     projectSlug: getStringArg(args, "project", "p", "project-slug"),
     projectDir: getStringArg(args, "project-dir", "dir", "d"),
-    source: typeof args._[2] === "string" ? args._[2] : undefined,
+    sources: args._.slice(2).filter((value): value is string => typeof value === "string"),
     path: getStringArg(args, "path"),
     all: getBooleanArg(args, "all"),
     recursive: getBooleanArg(args, "recursive"),
@@ -295,6 +333,7 @@ export async function runKnowledgeParser(input: {
     try {
       result = await new Deno.Command("python3", {
         args: [scriptPath, "--input-json", inputJsonPath, "--output-json", outputJsonPath],
+        env: Deno.env.toObject(),
         stdout: "piped",
         stderr: "piped",
       }).output();
@@ -320,7 +359,7 @@ export async function runKnowledgeParser(input: {
 }
 
 export async function collectKnowledgeSources(
-  options: Pick<KnowledgeIngestOptions, "source" | "path" | "all" | "recursive">,
+  options: Pick<KnowledgeIngestOptions, "sources" | "path" | "all" | "recursive">,
   deps: {
     client: ApiClient;
     projectSlug: string;
@@ -329,29 +368,36 @@ export async function collectKnowledgeSources(
 ): Promise<KnowledgeSource[]> {
   const fs = createFileSystem();
 
-  if (options.source) {
-    if (!isProjectUploadReference(options.source) && await fs.exists(options.source)) {
-      const localFiles = await collectLocalFiles(options.source, options.recursive);
-      if (!localFiles.length) throw new Error(`No supported files found at ${options.source}`);
-      return localFiles.map((localPath) => ({ kind: "local", input: options.source!, localPath }));
+  const resolveExplicitSource = async (input: string): Promise<KnowledgeSource[]> => {
+    if (!isProjectUploadReference(input) && await fs.exists(input)) {
+      const localFiles = await collectLocalFiles(input, options.recursive);
+      if (!localFiles.length) throw new Error(`No supported files found at ${input}`);
+      return localFiles.map((localPath) => ({ kind: "local", input, localPath }));
     }
 
-    if (isLikelyLocalPath(options.source)) {
-      throw new Error(`Local file not found: ${options.source}`);
+    if (isLikelyLocalPath(input)) {
+      throw new Error(`Local file not found: ${input}`);
     }
 
-    const uploadPath = normalizeProjectUploadPath(options.source);
+    const uploadPath = normalizeProjectUploadPath(input);
     const downloads = await deps.downloadUploads([uploadPath]);
     return downloads.map((download) => ({
       kind: "upload",
-      input: options.source!,
+      input,
       uploadPath: download.uploadPath,
       localPath: download.localPath,
     }));
+  };
+
+  if (options.sources.length > 0) {
+    const resolvedSources = await Promise.all(
+      options.sources.map((source) => resolveExplicitSource(source)),
+    );
+    return resolvedSources.flat();
   }
 
   if (!options.path || !options.all) {
-    throw new Error("Provide a source path or use --path with --all.");
+    throw new Error("Provide one or more source paths or use --path with --all.");
   }
 
   if (!isProjectUploadReference(options.path) && await fs.exists(options.path)) {

--- a/cli/commands/knowledge/handler.test.ts
+++ b/cli/commands/knowledge/handler.test.ts
@@ -30,8 +30,30 @@ describe("Knowledge Handler", () => {
       } as ParsedArgs);
 
       assertSuccess(result);
-      assertEquals(result.data.source, "/workspace/uploads/q1.pdf");
+      assertEquals(result.data.sources, ["/workspace/uploads/q1.pdf"]);
       assertEquals(result.data.json, true);
+      assertEquals(result.data.all, false);
+    });
+
+    it("parses multiple explicit source paths", () => {
+      const result = parseKnowledgeIngestArgs({
+        _: [
+          "knowledge",
+          "ingest",
+          "uploads/contracts/a.pdf",
+          "uploads/contracts/b.pdf",
+          "./notes/c.txt",
+        ],
+        json: true,
+      } as ParsedArgs);
+
+      assertSuccess(result);
+      assertEquals(result.data.sources, [
+        "uploads/contracts/a.pdf",
+        "uploads/contracts/b.pdf",
+        "./notes/c.txt",
+      ]);
+      assertEquals(result.data.path, undefined);
       assertEquals(result.data.all, false);
     });
 
@@ -49,6 +71,25 @@ describe("Knowledge Handler", () => {
       assertEquals(result.data.all, true);
       assertEquals(result.data.recursive, true);
       assertEquals(result.data.json, true);
+    });
+
+    it("rejects mixing explicit sources with --path --all batch mode", () => {
+      const result = parseKnowledgeIngestArgs({
+        _: ["knowledge", "ingest", "uploads/contracts/a.pdf"],
+        path: "uploads/contracts",
+        all: true,
+      } as ParsedArgs);
+
+      assertEquals(result.success, false);
+    });
+
+    it("rejects --slug when multiple explicit sources are provided", () => {
+      const result = parseKnowledgeIngestArgs({
+        _: ["knowledge", "ingest", "uploads/contracts/a.pdf", "uploads/contracts/b.pdf"],
+        slug: "contracts-batch",
+      } as ParsedArgs);
+
+      assertEquals(result.success, false);
     });
   });
 });

--- a/cli/commands/knowledge/handler.test.ts
+++ b/cli/commands/knowledge/handler.test.ts
@@ -91,5 +91,16 @@ describe("Knowledge Handler", () => {
 
       assertEquals(result.success, false);
     });
+
+    it("rejects --slug when using --path --all batch mode", () => {
+      const result = parseKnowledgeIngestArgs({
+        _: ["knowledge", "ingest"],
+        path: "uploads/contracts",
+        all: true,
+        slug: "contracts-batch",
+      } as ParsedArgs);
+
+      assertEquals(result.success, false);
+    });
   });
 });

--- a/cli/commands/knowledge/parser-source.ts
+++ b/cli/commands/knowledge/parser-source.ts
@@ -72,7 +72,52 @@ def build_frontmatter(source: str, source_type: str, description: str) -> str:
     ])
 
 
-def parse_with_kreuzberg(path: str):
+def metadata_int(metadata: dict[str, Any], *keys: str) -> Optional[int]:
+    for key in keys:
+        value = metadata.get(key)
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+    return None
+
+
+def metadata_string_list(metadata: dict[str, Any], *keys: str) -> Optional[list[str]]:
+    for key in keys:
+        value = metadata.get(key)
+        if isinstance(value, list) and all(isinstance(item, str) for item in value):
+            return value
+    return None
+
+
+def build_kreuzberg_stats(source_type: str, content: str, metadata: dict[str, Any]):
+    stats: dict[str, Any] = {
+        "characters": len(content),
+        "lines": len(content.splitlines()) if content else 0,
+        "engine": "kreuzberg",
+    }
+
+    if isinstance(metadata.get("mime_type"), str):
+        stats["mime_type"] = metadata["mime_type"]
+
+    if source_type == "pdf":
+        stats["pages"] = metadata_int(metadata, "page_count") or 0
+        stats["tables"] = metadata_int(metadata, "table_count") or 0
+    elif source_type in {"xlsx", "xls"}:
+        stats["sheets"] = metadata_int(metadata, "sheet_count") or 0
+        stats["rows"] = metadata_int(metadata, "row_count") or 0
+        stats["sheet_names"] = metadata_string_list(metadata, "sheet_names") or []
+    elif source_type == "docx":
+        stats["paragraphs"] = metadata_int(metadata, "paragraph_count") or 0
+        stats["tables"] = metadata_int(metadata, "table_count") or 0
+    elif source_type == "pptx":
+        stats["slides"] = metadata_int(metadata, "slide_count", "page_count") or 0
+        stats["tables"] = metadata_int(metadata, "table_count") or 0
+    elif source_type == "html":
+        stats["tables"] = metadata_int(metadata, "table_count") or 0
+
+    return stats
+
+
+def parse_with_kreuzberg(path: str, source_type: str):
     warnings: list[str] = []
     completed = subprocess.run(
         [
@@ -104,25 +149,26 @@ def parse_with_kreuzberg(path: str):
 
     metadata = payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {}
     normalized_content = clean_text(content)
-    stats: dict[str, Any] = {
-        "characters": len(normalized_content),
-        "lines": len(normalized_content.splitlines()) if normalized_content else 0,
-        "engine": "kreuzberg",
-    }
-    if isinstance(metadata.get("mime_type"), str):
-        stats["mime_type"] = metadata["mime_type"]
+    stats = build_kreuzberg_stats(source_type, normalized_content, metadata)
 
     return normalized_content or "_No extractable text found in document._", stats, warnings
 
 
-def prefer_kreuzberg(fallback_parser):
+def prefer_kreuzberg(source_type: str, fallback_parser):
     def parser(path: str):
         try:
-            return parse_with_kreuzberg(path)
+            return parse_with_kreuzberg(path, source_type)
         except FileNotFoundError as error:
             if getattr(error, "filename", "") == "kreuzberg":
                 return fallback_parser(path)
             raise
+        except RuntimeError as error:
+            content, stats, warnings = fallback_parser(path)
+            warnings.append(
+                "kreuzberg extraction failed; fell back to the built-in parser: "
+                + str(error)
+            )
+            return content, stats, warnings
 
     return parser
 
@@ -361,18 +407,19 @@ def parse_json(path: str):
 def select_parser(path: Path):
     ext = path.suffix.lower()
     if ext == ".pdf":
-        return "pdf", prefer_kreuzberg(parse_pdf)
+        return "pdf", prefer_kreuzberg("pdf", parse_pdf)
     if ext in {".csv", ".tsv"}:
         delimiter = "\t" if ext == ".tsv" else ","
         return ext.lstrip("."), lambda file_path: parse_csv_like(file_path, delimiter)
     if ext in {".xlsx", ".xls"}:
-        return ext.lstrip("."), prefer_kreuzberg(parse_excel)
+        source_type = ext.lstrip(".")
+        return source_type, prefer_kreuzberg(source_type, parse_excel)
     if ext == ".docx":
-        return "docx", prefer_kreuzberg(parse_docx)
+        return "docx", prefer_kreuzberg("docx", parse_docx)
     if ext == ".pptx":
-        return "pptx", prefer_kreuzberg(parse_pptx)
+        return "pptx", prefer_kreuzberg("pptx", parse_pptx)
     if ext in {".html", ".htm"}:
-        return "html", prefer_kreuzberg(parse_html)
+        return "html", prefer_kreuzberg("html", parse_html)
     if ext in {".txt", ".md", ".mdx"}:
         return ext.lstrip("."), parse_text
     if ext == ".json":

--- a/cli/commands/knowledge/parser-source.ts
+++ b/cli/commands/knowledge/parser-source.ts
@@ -3,6 +3,7 @@ import argparse
 import csv
 import json
 import re
+import subprocess
 from datetime import date
 from pathlib import Path
 from typing import Any, Optional
@@ -69,6 +70,61 @@ def build_frontmatter(source: str, source_type: str, description: str) -> str:
         f"description: {yaml_quote(description)}",
         "---",
     ])
+
+
+def parse_with_kreuzberg(path: str):
+    warnings: list[str] = []
+    completed = subprocess.run(
+        [
+            "kreuzberg",
+            "extract",
+            path,
+            "--format",
+            "json",
+            "--output-format",
+            "markdown",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or f"exit code {completed.returncode}"
+        raise RuntimeError(f"kreuzberg extract failed: {detail}")
+
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(f"kreuzberg extract returned invalid JSON: {error}") from error
+
+    content = payload.get("content", "")
+    if not isinstance(content, str):
+        raise RuntimeError("kreuzberg extract did not return string content")
+
+    metadata = payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {}
+    normalized_content = clean_text(content)
+    stats: dict[str, Any] = {
+        "characters": len(normalized_content),
+        "lines": len(normalized_content.splitlines()) if normalized_content else 0,
+        "engine": "kreuzberg",
+    }
+    if isinstance(metadata.get("mime_type"), str):
+        stats["mime_type"] = metadata["mime_type"]
+
+    return normalized_content or "_No extractable text found in document._", stats, warnings
+
+
+def prefer_kreuzberg(fallback_parser):
+    def parser(path: str):
+        try:
+            return parse_with_kreuzberg(path)
+        except FileNotFoundError as error:
+            if getattr(error, "filename", "") == "kreuzberg":
+                return fallback_parser(path)
+            raise
+
+    return parser
 
 
 def parse_csv_like(path: str, delimiter: str = ","):
@@ -305,18 +361,18 @@ def parse_json(path: str):
 def select_parser(path: Path):
     ext = path.suffix.lower()
     if ext == ".pdf":
-        return "pdf", parse_pdf
+        return "pdf", prefer_kreuzberg(parse_pdf)
     if ext in {".csv", ".tsv"}:
         delimiter = "\t" if ext == ".tsv" else ","
         return ext.lstrip("."), lambda file_path: parse_csv_like(file_path, delimiter)
     if ext in {".xlsx", ".xls"}:
-        return ext.lstrip("."), parse_excel
+        return ext.lstrip("."), prefer_kreuzberg(parse_excel)
     if ext == ".docx":
-        return "docx", parse_docx
+        return "docx", prefer_kreuzberg(parse_docx)
     if ext == ".pptx":
-        return "pptx", parse_pptx
+        return "pptx", prefer_kreuzberg(parse_pptx)
     if ext in {".html", ".htm"}:
-        return "html", parse_html
+        return "html", prefer_kreuzberg(parse_html)
     if ext in {".txt", ".md", ".mdx"}:
         return ext.lstrip("."), parse_text
     if ext == ".json":
@@ -325,6 +381,8 @@ def select_parser(path: Path):
 
 
 def build_summary(source_type: str, stats: dict[str, Any]) -> str:
+    if stats.get("engine") == "kreuzberg":
+        return f"Converted {source_type.upper()} to markdown ({stats.get('characters', 0)} chars)."
     if source_type in {"csv", "tsv"}:
         return f"Parsed {stats.get('rows', 0)} rows across {stats.get('columns', 0)} columns."
     if source_type in {"xlsx", "xls"}:

--- a/cli/help/command-help.test.ts
+++ b/cli/help/command-help.test.ts
@@ -44,7 +44,7 @@ describe("command-help", () => {
 
     it("renders knowledge help", () => {
       const output = captureConsoleLog(() => showCommandHelp("knowledge"));
-      assertStringIncludes(output, "veryfront knowledge ingest <source> [options]");
+      assertStringIncludes(output, "veryfront knowledge ingest <source...> [options]");
       assertStringIncludes(output, "Primary subcommand: ingest");
       assertStringIncludes(output, "Requires python3");
     });

--- a/docs/guides/cli-knowledge-ingestion.md
+++ b/docs/guides/cli-knowledge-ingestion.md
@@ -1,0 +1,238 @@
+---
+title: "CLI-First Knowledge Ingestion"
+description: "Turn uploads and local documents into project knowledge files with one command."
+order: 20
+---
+
+# CLI-First Knowledge Ingestion
+
+`veryfront knowledge ingest` is the primary CLI workflow for getting documents into a project's knowledge base.
+
+Before this flow, agents often had to stitch together several low-level steps by hand:
+
+1. Find an uploaded file
+2. Download it into the workspace
+3. Run parser code manually
+4. Save the generated markdown back into the project
+
+Now the happy path is one command:
+
+```bash
+veryfront knowledge ingest uploads/contracts/q1.pdf --json
+```
+
+That also works for an exact list of uploaded files:
+
+```bash
+veryfront knowledge ingest uploads/contracts/a.pdf uploads/contracts/b.pdf uploads/contracts/c.pdf --json
+```
+
+The command handles the orchestration for you:
+
+- Resolves whether the input is a remote upload or a local file
+- Pulls remote uploads into the workspace when needed
+- Parses supported documents into markdown
+- Writes the resulting `knowledge/*.md` file back into the project
+
+## Why this matters
+
+This flow is especially useful for agent workflows and demos:
+
+- A user drops one or more files into `uploads/`
+- A knowledge agent starts a sandbox
+- The agent runs `veryfront knowledge ingest ...`
+- The parsed markdown lands in the project's knowledge base
+
+That keeps knowledge ingestion predictable, scriptable, and much easier to explain than ad-hoc parser scripts.
+
+## Prerequisites
+
+Authenticate with the CLI and make sure the target project is known:
+
+```bash
+export VERYFRONT_API_TOKEN=vf_your_api_key
+export VERYFRONT_PROJECT_SLUG=my-project
+```
+
+Or log in interactively:
+
+```bash
+veryfront login
+```
+
+`veryfront knowledge ingest` requires `python3`.
+
+Inside the Veryfront sandbox image, the embedded parser prefers `kreuzberg` for PDF, Office, and HTML extraction.
+
+If you are running outside the Veryfront sandbox image and do not have `kreuzberg` installed, non-text formats fall back to the parser dependencies:
+
+```bash
+pip install pandas openpyxl xlrd pdfplumber python-docx python-pptx beautifulsoup4 lxml
+```
+
+## Single-file examples
+
+### Ingest a remote upload
+
+Use `uploads/...` to reference a file from the project's remote uploads store:
+
+```bash
+veryfront knowledge ingest uploads/contracts/q1.pdf --json
+```
+
+### Ingest a local file
+
+Use a local path to ingest a file that already exists on disk:
+
+```bash
+veryfront knowledge ingest ./contracts/q1.pdf --json
+```
+
+Inside a sandbox, `/workspace/uploads/...` is also treated as a local file path:
+
+```bash
+veryfront knowledge ingest /workspace/uploads/contracts/q1.pdf --json
+```
+
+## Exact-file batch ingestion
+
+To ingest a specific list of files without ingesting the entire folder:
+
+```bash
+veryfront knowledge ingest uploads/contracts/a.pdf uploads/contracts/b.pdf uploads/contracts/c.pdf --json
+```
+
+The command preserves input order in the JSON result array, so agent workflows can match each output back to the original source path.
+
+## Batch ingestion
+
+To ingest every supported file under a remote uploads prefix:
+
+```bash
+veryfront knowledge ingest --path uploads/contracts --all --json
+```
+
+To recurse through a local directory:
+
+```bash
+veryfront knowledge ingest --path ./contracts --all --recursive --json
+```
+
+Each source document becomes its own markdown file in the project knowledge tree.
+
+Use `--path ... --all` only when you want everything under that uploads prefix or local directory. For an exact file list, pass the file paths as positional arguments instead.
+
+## What the JSON output looks like
+
+With `--json`, the command returns a machine-readable summary for each ingested file:
+
+```json
+[
+  {
+    "source": "uploads/demo/notes.txt",
+    "remotePath": "knowledge/demo-notes.md",
+    "slug": "demo-notes",
+    "sourceType": "txt",
+    "summary": "Converted document to markdown (87 chars).",
+    "stats": {
+      "characters": 87,
+      "lines": 3
+    },
+    "warnings": []
+  }
+]
+```
+
+This is useful for agent pipelines that want to confirm exactly what was created.
+
+## Path rules
+
+The source path determines how the command behaves:
+
+- `uploads/...` means a remote project upload
+- `./uploads/...` means a local file or directory relative to the current working directory
+- `/workspace/uploads/...` means a local file inside the sandbox workspace
+- multiple explicit sources are passed as positional arguments: `veryfront knowledge ingest <source...> --json`
+
+That distinction matters because `uploads/...` triggers the remote upload download step, while local paths skip it.
+
+## Supported file types
+
+`veryfront knowledge ingest` supports these source formats:
+
+- `pdf`
+- `csv`
+- `tsv`
+- `docx`
+- `xlsx`
+- `xls`
+- `pptx`
+- `html`
+- `htm`
+- `txt`
+- `json`
+- `md`
+- `mdx`
+
+## Low-level commands still exist
+
+If you need finer control, the lower-level building blocks are still available:
+
+```bash
+veryfront uploads list
+veryfront uploads pull uploads/contracts/q1.pdf --output /tmp/q1.pdf
+veryfront files get knowledge/demo-notes.md
+veryfront files put knowledge/demo-notes.md --from ./demo-notes.md
+```
+
+But for most agent-facing knowledge ingestion, `veryfront knowledge ingest` should be the default.
+
+## Troubleshooting
+
+### `Unknown command: knowledge`
+
+Your installed CLI is older than the branch or release that added the command. Update the CLI or run the current source tree directly with:
+
+```bash
+cd veryfront-code
+deno run -A cli/main.ts knowledge ingest uploads/contracts/q1.pdf --json
+```
+
+### `Missing API token`
+
+Set `VERYFRONT_API_TOKEN`, run `veryfront login`, or make sure your local CLI config already has a saved token.
+
+### `Could not determine project slug`
+
+Set `VERYFRONT_PROJECT_SLUG` or pass the project explicitly:
+
+```bash
+veryfront knowledge ingest uploads/contracts/q1.pdf --project my-project --json
+```
+
+### Python package errors
+
+Install the parser packages listed above, or run the command inside the Veryfront sandbox image where the knowledge-ingestion stack is already available.
+
+### `kreuzberg` is not installed
+
+Inside the sandbox image, `kreuzberg` is preinstalled. Outside the sandbox, the command falls back to the Python parser stack for supported formats, so install the parser packages above if you do not want to install `kreuzberg` locally.
+
+## Recommended agent flow
+
+For agent prompts and system instructions, this is the simplest reliable pattern:
+
+1. Prefer `veryfront knowledge ingest` for adding documents to knowledge
+2. Use `uploads/...` for files that came from the project's upload store
+3. Use local paths only when the file is already present in the workspace
+4. Fall back to `uploads` and `files` CRUD commands only when you need manual control
+
+## Next
+
+- [Sandbox](./sandbox.md) — run CLI workflows inside isolated workspaces
+- [Agents](./agents.md) — build agent workflows that can call tools and shell commands
+- [Workflows](./workflows.md) — orchestrate repeatable multi-step automation
+
+## Related
+
+- [`veryfront/cli`](../reference/cli.md) — CLI entry point reference

--- a/docs/guides/cli-knowledge-ingestion.md
+++ b/docs/guides/cli-knowledge-ingestion.md
@@ -64,7 +64,7 @@ veryfront login
 
 Inside the Veryfront sandbox image, the embedded parser prefers `kreuzberg` for PDF, Office, and HTML extraction.
 
-If you are running outside the Veryfront sandbox image and do not have `kreuzberg` installed, non-text formats fall back to the parser dependencies:
+If you are running outside the Veryfront sandbox image and do not have `kreuzberg` installed, or if `kreuzberg` fails to extract a specific file, non-text formats fall back to the parser dependencies:
 
 ```bash
 pip install pandas openpyxl xlrd pdfplumber python-docx python-pptx beautifulsoup4 lxml
@@ -130,6 +130,8 @@ With `--json`, the command returns a machine-readable summary for each ingested 
 [
   {
     "source": "uploads/demo/notes.txt",
+    "localSourcePath": "/workspace/uploads/demo/notes.txt",
+    "outputPath": "/workspace/knowledge-output/demo-notes.md",
     "remotePath": "knowledge/demo-notes.md",
     "slug": "demo-notes",
     "sourceType": "txt",
@@ -143,7 +145,8 @@ With `--json`, the command returns a machine-readable summary for each ingested 
 ]
 ```
 
-This is useful for agent pipelines that want to confirm exactly what was created.
+This is useful for agent pipelines that want to confirm exactly what was created. The exact `stats`
+shape varies by source type, but the top-level result fields are the same.
 
 ## Path rules
 
@@ -216,7 +219,7 @@ Install the parser packages listed above, or run the command inside the Veryfron
 
 ### `kreuzberg` is not installed
 
-Inside the sandbox image, `kreuzberg` is preinstalled. Outside the sandbox, the command falls back to the Python parser stack for supported formats, so install the parser packages above if you do not want to install `kreuzberg` locally.
+Inside the sandbox image, `kreuzberg` is preinstalled. Outside the sandbox, the command falls back to the Python parser stack for supported formats when `kreuzberg` is not installed or extraction fails, so install the parser packages above if you do not want to install `kreuzberg` locally.
 
 ## Recommended agent flow
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -10,45 +10,46 @@ Learn Veryfront from the ground up — pages, routing, AI agents, and production
 
 ## Getting Started
 
-| Guide | Description |
-|-------|-------------|
+| Guide                         | Description                                                           |
+| ----------------------------- | --------------------------------------------------------------------- |
 | [Quickstart](./quickstart.md) | Install, create a project, and run the dev server in under 2 minutes. |
 
 ## Basics
 
-| Guide | Description |
-|-------|-------------|
+| Guide                                       | Description                                                       |
+| ------------------------------------------- | ----------------------------------------------------------------- |
 | [Project Structure](./project-structure.md) | File conventions, directory layout, and how auto-discovery works. |
-| [Pages & Routing](./pages-and-routing.md) | File-based routing, layouts, dynamic routes, and MDX pages. |
-| [Data Fetching](./data-fetching.md) | Server data, static generation, and client-side fetching. |
-| [API Routes](./api-routes.md) | HTTP handlers, request parsing, and streaming responses. |
+| [Pages & Routing](./pages-and-routing.md)   | File-based routing, layouts, dynamic routes, and MDX pages.       |
+| [Data Fetching](./data-fetching.md)         | Server data, static generation, and client-side fetching.         |
+| [API Routes](./api-routes.md)               | HTTP handlers, request parsing, and streaming responses.          |
 
 ## AI
 
-| Guide | Description |
-|-------|-------------|
-| [Agents](./agents.md) | Create an AI agent with a system prompt, tools, and memory. |
-| [Tools](./tools.md) | Define tools with Zod schemas that agents can call. |
-| [Memory & Streaming](./memory-and-streaming.md) | Conversation memory strategies and streaming responses. |
-| [Chat UI](./chat-ui.md) | Pre-built chat components and React hooks for AI interfaces. |
-| [Workflows](./workflows.md) | DAG-based multi-step workflows with branching and parallelism. |
-| [Multi-Agent](./multi-agent.md) | Agent composition, delegation, and agent-as-tool patterns. |
+| Guide                                                   | Description                                                                         |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [Agents](./agents.md)                                   | Create an AI agent with a system prompt, tools, and memory.                         |
+| [CLI Knowledge Ingestion](./cli-knowledge-ingestion.md) | Turn uploads and local documents into project knowledge files with one CLI command. |
+| [Tools](./tools.md)                                     | Define tools with Zod schemas that agents can call.                                 |
+| [Memory & Streaming](./memory-and-streaming.md)         | Conversation memory strategies and streaming responses.                             |
+| [Chat UI](./chat-ui.md)                                 | Pre-built chat components and React hooks for AI interfaces.                        |
+| [Workflows](./workflows.md)                             | DAG-based multi-step workflows with branching and parallelism.                      |
+| [Multi-Agent](./multi-agent.md)                         | Agent composition, delegation, and agent-as-tool patterns.                          |
 
 ## Infrastructure
 
-| Guide | Description |
-|-------|-------------|
-| [Providers](./providers.md) | Unified LLM interface for OpenAI, Anthropic, and Google. |
-| [Middleware](./middleware.md) | CORS, rate limiting, logging, and custom middleware pipelines. |
-| [OAuth](./oauth.md) | OAuth 2.0 with 37 pre-configured providers. |
-| [MCP Server](./mcp-server.md) | Expose tools, prompts, and resources over Model Context Protocol. |
-| [Sandbox](./sandbox.md) | Run isolated commands and file operations in ephemeral sandbox sessions. |
+| Guide                              | Description                                                                                       |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------- |
+| [Providers](./providers.md)        | Unified LLM interface for OpenAI, Anthropic, and Google.                                          |
+| [Middleware](./middleware.md)      | CORS, rate limiting, logging, and custom middleware pipelines.                                    |
+| [OAuth](./oauth.md)                | OAuth 2.0 with 37 pre-configured providers.                                                       |
+| [MCP Server](./mcp-server.md)      | Expose tools, prompts, and resources over Model Context Protocol.                                 |
+| [Sandbox](./sandbox.md)            | Run isolated commands and file operations in ephemeral sandbox sessions.                          |
 | [Integrations](../integrations.md) | Config-driven integration tools with OAuth, token management, and API execution for 37+ services. |
 
 ## Production
 
-| Guide | Description |
-|-------|-------------|
-| [Configuration](./configuration.md) | `veryfront.config.ts` options, environment variables, and runtime settings. |
-| [Building & Deploying](./deploying.md) | Production builds, static export, and deployment targets. |
-| [Head & SEO](./head-and-seo.md) | Declarative metadata, Open Graph, and structured data. |
+| Guide                                  | Description                                                                 |
+| -------------------------------------- | --------------------------------------------------------------------------- |
+| [Configuration](./configuration.md)    | `veryfront.config.ts` options, environment variables, and runtime settings. |
+| [Building & Deploying](./deploying.md) | Production builds, static export, and deployment targets.                   |
+| [Head & SEO](./head-and-seo.md)        | Declarative metadata, Open Graph, and structured data.                      |


### PR DESCRIPTION
## Summary
- teach knowledge ingest to prefer the `kreuzberg` CLI for PDF, Office, and HTML extraction while keeping the current Python parser fallback
- keep the existing markdown/frontmatter result contract and surface the `kreuzberg` engine in parser stats
- document the sandbox/runtime behavior and add coverage for the new extraction path

## Testing
- deno test --allow-all cli/commands/knowledge/command.test.ts cli/commands/knowledge/handler.test.ts cli/help/command-help.test.ts
- local parser smoke test with `<local-path>`