### PR TITLE
release: bump veryfront to 0.1.75

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.74",
+  "version": "0.1.75",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [


### PR DESCRIPTION
## Summary
- bump `deno.json` version to `0.1.75`
- unblock npm publish for the merged job user events work
- let downstream `veryfront-job-runner` rebuild against the correct CLI package

## Why
The merged `job_user_log` / knowledge-ingest event changes are on `main`, but `deno.json` was still `0.1.74`, which is already published. The release workflow skips npm publish when that stable version exists, so production job-runner pods were still installing an older CLI without the new event logs.

## Testing
- release metadata only
