### PR TITLE
Document the public jobs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Purpose-built for TypeScript and React, Veryfront gives you everything you need 
 
 - [**Workflows**](https://veryfront.com/docs/code/guides/workflows) — Orchestrate multi-step AI pipelines with branching, parallelism, and human-in-the-loop approval gates.
 
+- [**Jobs & Cron Jobs**](https://veryfront.com/docs/code/guides/jobs) — Run durable project-scoped background work now or on a schedule through the Veryfront platform.
+
 - [**Multi-Agent**](https://veryfront.com/docs/code/guides/multi-agent) — Compose agents that delegate to each other as tools for complex, coordinated tasks.
 
 - [**Memory & Streaming**](https://veryfront.com/docs/code/guides/memory-and-streaming) — Give agents conversation history and streaming responses. Built-in chat UI components for React.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -39,6 +39,7 @@ Learn Veryfront from the ground up — pages, routing, AI agents, and production
 
 | Guide                              | Description                                                                                       |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------- |
+| [Jobs & Cron Jobs](./jobs.md)      | Create one-off jobs, schedule cron jobs, inspect events, and work with batch summaries.           |
 | [Providers](./providers.md)        | Unified LLM interface for OpenAI, Anthropic, and Google.                                          |
 | [Middleware](./middleware.md)      | CORS, rate limiting, logging, and custom middleware pipelines.                                    |
 | [OAuth](./oauth.md)                | OAuth 2.0 with 37 pre-configured providers.                                                       |

--- a/docs/guides/jobs.md
+++ b/docs/guides/jobs.md
@@ -1,0 +1,151 @@
+---
+title: "Jobs & Cron Jobs"
+description: "Run project-scoped background work now or on a schedule through the Veryfront platform."
+order: 15.5
+---
+
+# Jobs & Cron Jobs
+
+Use Veryfront jobs for durable, project-scoped background work.
+
+- A **job** runs once.
+- A **cron job** runs on a schedule and creates jobs over time.
+- A **target** is the named capability being executed.
+- **events** are the canonical user-visible output stream.
+- **logs** are raw debugging output.
+- A **batch** groups related jobs together.
+
+## How users create jobs
+
+Today there are two main creation paths:
+
+1. **Programmatic**: create jobs through the public REST API, MCP tools, or the `veryfront/jobs` SDK.
+2. **Studio-first product flows**: some first-party features, such as knowledge ingestion, create jobs for you and then expose them in the Jobs panel.
+
+Studio is not yet a general-purpose UI for authoring arbitrary custom job targets. If you want to create your own one-off jobs or cron jobs directly, the public SDK and API are the intended entry points.
+
+## Setup
+
+```ts
+import { createJobsClient } from "veryfront/jobs";
+
+const jobs = createJobsClient({
+  authToken: process.env.VERYFRONT_API_TOKEN,
+  projectReference: "dreamy-haven",
+});
+```
+
+If you are already running inside a Veryfront request context, the client can also pick up request-scoped auth and project context automatically.
+
+## Create a one-off job
+
+```ts
+import { createJobsClient } from "veryfront/jobs";
+
+const jobs = createJobsClient({
+  authToken: process.env.VERYFRONT_API_TOKEN,
+  projectReference: "dreamy-haven",
+});
+
+const job = await jobs.create({
+  name: "Ingest 1 file to knowledge base",
+  target: "task:knowledge-ingest",
+  config: {
+    file_count: 1,
+    upload_ids: ["11111111-1111-4111-8111-111111111111"],
+  },
+});
+
+console.log(job.id);
+console.log(job.status);
+```
+
+## Observe a job
+
+Prefer `events()` for progress and user-visible activity:
+
+```ts
+const events = await jobs.events(job.id);
+
+for (const entry of events.entries) {
+  console.log(entry.timestamp, entry.level, entry.message);
+}
+```
+
+Use `logs()` only when you need raw debugging output:
+
+```ts
+const logs = await jobs.logs(job.id);
+console.log(logs.logs);
+```
+
+## Inspect supported first-party targets
+
+Use target discovery if you want to know what first-party contracts exist today:
+
+```ts
+const targets = await jobs.targets.list();
+
+for (const definition of targets.data) {
+  console.log(definition.target, definition.description);
+}
+```
+
+This is the public source of truth for first-party target contracts such as `task:knowledge-ingest`.
+
+## Work with batches
+
+If one user action fans out into multiple related jobs, Veryfront can group them with a shared `batch_id`.
+
+```ts
+const batch = await jobs.batches.get("22222222-2222-4222-8222-222222222222");
+console.log(batch.job_count, batch.status_counts);
+
+const batchJobs = await jobs.batches.listJobs(batch.id, { limit: 50 });
+console.log(batchJobs.data.map((job) => job.name));
+```
+
+## Create a cron job
+
+```ts
+const cronJob = await jobs.cron.create({
+  name: "Nightly knowledge sync",
+  target: "task:knowledge-ingest",
+  schedule: "0 2 * * *",
+  timezone: "Europe/Stockholm",
+  config: {
+    file_count: 1,
+    upload_ids: ["11111111-1111-4111-8111-111111111111"],
+  },
+});
+
+console.log(cronJob.id);
+console.log(cronJob.schedule);
+```
+
+You can later inspect or update it:
+
+```ts
+const cronJob = await jobs.cron.get("33333333-3333-4333-8333-333333333333");
+await jobs.cron.update(cronJob.id, { status: "paused" });
+await jobs.cron.trigger(cronJob.id);
+```
+
+## Choosing between Studio and the API
+
+Use **Studio** when:
+
+- you are using a first-party flow that already creates jobs for you
+- you want to inspect status, events, batches, and retries visually
+
+Use the **SDK / API / MCP** when:
+
+- you need to create jobs directly
+- you need cron scheduling
+- you are building automation or agent-driven project operations
+
+## Related
+
+- [`veryfront/jobs`](../reference/jobs.md) - API reference for the jobs client
+- [CLI Knowledge Ingestion](./cli-knowledge-ingestion.md) - first-party knowledge ingestion flow that creates jobs
+- [MCP Server](./mcp-server.md) - expose or consume programmatic automation through MCP

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -31,6 +31,7 @@ npm install veryfront
 | [`veryfront/workflow`](./workflow.md) | DAG-based agentic workflows with human-in-the-loop support. |
 | [`veryfront/prompt`](./prompt.md) | Declare and register prompts exposable over MCP. |
 | [`veryfront/resource`](./resource.md) | Declare and register resources exposable over MCP. |
+| [`veryfront/jobs`](./jobs.md) | Project-scoped jobs and cron jobs with events, logs, batches, and target discovery. |
 | [`veryfront/mcp`](./mcp.md) | MCP server exposing tools, prompts, and resources. |
 | [`veryfront/middleware`](./middleware.md) | CORS, rate limiting, logging, and timeout middleware. |
 | [`veryfront/oauth`](./oauth.md) | OAuth 2.0 with 37 pre-configured providers. |

--- a/docs/reference/jobs.md
+++ b/docs/reference/jobs.md
@@ -1,0 +1,240 @@
+---
+title: "veryfront/jobs"
+description: "Project-scoped jobs and cron jobs with events, logs, batches, and target discovery."
+order: 13.5
+---
+
+# veryfront/jobs
+
+Project-scoped jobs and cron jobs with events, logs, batches, and target discovery.
+
+## Import
+
+```ts
+import { createJobsClient, VeryfrontJobsClient } from "veryfront/jobs";
+```
+
+## Examples
+
+### Create a one-off job
+
+```ts
+import { createJobsClient } from "veryfront/jobs";
+
+const jobs = createJobsClient({
+  authToken: process.env.VERYFRONT_API_TOKEN,
+  projectReference: "dreamy-haven",
+});
+
+const job = await jobs.create({
+  name: "Ingest 1 file",
+  target: "task:knowledge-ingest",
+  config: {
+    file_count: 1,
+    upload_ids: ["11111111-1111-4111-8111-111111111111"],
+  },
+});
+
+const events = await jobs.events(job.id);
+console.log(events.entries);
+```
+
+### Create a cron job
+
+```ts
+const cronJob = await jobs.cron.create({
+  name: "Nightly knowledge sync",
+  target: "task:knowledge-ingest",
+  schedule: "0 2 * * *",
+  timezone: "UTC",
+  config: {
+    file_count: 1,
+    upload_ids: ["11111111-1111-4111-8111-111111111111"],
+  },
+});
+```
+
+## API
+
+### `createJobsClient(config?)`
+
+Create a project-scoped jobs client.
+
+**Returns:** `VeryfrontJobsClient`
+
+### `new VeryfrontJobsClient(config?)`
+
+Instantiate the jobs client directly.
+
+**Returns:** `VeryfrontJobsClient`
+
+### `jobs.create(input)`
+
+Create a one-off job.
+
+**Returns:** `Promise<Job>`
+
+### `jobs.list(options?)`
+
+List jobs for a project.
+
+**Returns:** `Promise<PaginatedJobsResponse>`
+
+### `jobs.get(jobId, options?)`
+
+Get a single job.
+
+**Returns:** `Promise<Job>`
+
+### `jobs.events(jobId, options?)`
+
+Get canonical user-visible operational output for a job.
+
+**Returns:** `Promise<JobEventsResponse>`
+
+### `jobs.logs(jobId, options?)`
+
+Get raw debugging logs for a job.
+
+**Returns:** `Promise<JobLogsResponse>`
+
+### `jobs.cancel(jobId, options?)`
+
+Cancel a submitted or running job.
+
+**Returns:** `Promise<Job>`
+
+### `jobs.cron.create(input)`
+
+Create a recurring cron job.
+
+**Returns:** `Promise<CronJob>`
+
+### `jobs.cron.list(options?)`
+
+List cron jobs for a project.
+
+**Returns:** `Promise<PaginatedCronJobsResponse>`
+
+### `jobs.cron.get(cronJobId, options?)`
+
+Get a single cron job.
+
+**Returns:** `Promise<CronJob>`
+
+### `jobs.cron.update(cronJobId, input)`
+
+Update a cron job.
+
+**Returns:** `Promise<CronJob>`
+
+### `jobs.cron.delete(cronJobId, options?)`
+
+Delete a cron job.
+
+**Returns:** `Promise<CronJob>`
+
+### `jobs.cron.trigger(cronJobId, options?)`
+
+Trigger a cron job immediately, creating a job run.
+
+**Returns:** `Promise<Job>`
+
+### `jobs.batches.get(batchId, options?)`
+
+Get an aggregate batch summary for related jobs.
+
+**Returns:** `Promise<JobBatch>`
+
+### `jobs.batches.listJobs(batchId, options?)`
+
+List jobs in a specific batch.
+
+**Returns:** `Promise<PaginatedJobsResponse>`
+
+### `jobs.targets.list(options?)`
+
+List reserved job target families and first-party target definitions.
+
+**Returns:** `Promise<JobTargetDefinitionsResponse>`
+
+### `jobs.targets.get(target, options?)`
+
+Get one first-party target definition.
+
+**Returns:** `Promise<JobTargetDefinition>`
+
+## Type Reference
+
+### `VeryfrontJobsClientConfig`
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| `apiUrl?` | `string` | Base URL for the Veryfront API. Defaults to `VERYFRONT_API_URL` or the hosted API. |
+| `authToken?` | `string` | Explicit auth token or API key. Defaults to request-scoped auth or `VERYFRONT_API_TOKEN`. |
+| `projectReference?` | `string` | Project slug or ID used for project-scoped requests. Defaults to request-scoped project or `VERYFRONT_PROJECT_SLUG`. |
+| `retry?` | `Partial<RetryConfig>` | Retry behavior for failed HTTP requests. |
+
+### `CreateJobInput`
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| `name` | `string` | Job name. |
+| `target` | `string` | Job target, for example `task:knowledge-ingest`. |
+| `environmentId?` | `string` | Optional environment scope. |
+| `batchId?` | `string` | Optional batch grouping identifier. |
+| `config?` | `Record<string, unknown>` | Target-specific configuration payload. |
+| `timeoutSeconds?` | `number` | Optional timeout override. |
+| `backoffLimit?` | `number` | Optional retry count override. |
+| `projectReference?` | `string` | Optional per-call project override. |
+
+### `CreateCronJobInput`
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| `name` | `string` | Cron job name. |
+| `target` | `string` | Job target, for example `task:knowledge-ingest`. |
+| `schedule` | `string` | Five-field cron expression. |
+| `timezone?` | `string` | Optional timezone. Defaults to `UTC`. |
+| `environmentId?` | `string` | Optional environment scope. |
+| `config?` | `Record<string, unknown>` | Target-specific configuration payload. |
+| `timeoutSeconds?` | `number` | Optional timeout override. |
+| `backoffLimit?` | `number` | Optional retry count override. |
+| `concurrencyPolicy?` | `"Allow" \| "Forbid" \| "Replace"` | Cron overlap policy. |
+| `projectReference?` | `string` | Optional per-call project override. |
+
+## Exports
+
+### Functions
+
+| Name | Description |
+| ---- | ----------- |
+| `createJobsClient` | Create a project-scoped jobs client. |
+
+### Classes
+
+| Name | Description |
+| ---- | ----------- |
+| `VeryfrontJobsClient` | Public client for one-off jobs, cron jobs, batches, targets, events, and logs. |
+
+### Types
+
+| Name | Description |
+| ---- | ----------- |
+| `CreateCronJobInput` | Input shape for `jobs.cron.create()`. |
+| `CreateJobInput` | Input shape for `jobs.create()`. |
+| `CronJob` | Public cron job resource. |
+| `Job` | Public one-off job resource. |
+| `JobBatch` | Aggregate summary for related jobs. |
+| `JobEventsResponse` | Canonical user-visible event stream. |
+| `JobLogsResponse` | Raw debugging log response. |
+| `JobTargetDefinition` | Public first-party target definition. |
+| `PaginatedCronJobsResponse` | Paginated cron job list response. |
+| `PaginatedJobsResponse` | Paginated job list response. |
+| `VeryfrontJobsClientConfig` | Client configuration. |
+
+## Related
+
+- [Jobs & Cron Jobs](../guides/jobs.md) - guide for creating and observing jobs
+- [`veryfront/workflow`](./workflow.md) - higher-level orchestration for application logic
+- [`veryfront/mcp`](./mcp.md) - expose or consume jobs-related automation through MCP

--- a/tests/docs/guide-examples.test.ts
+++ b/tests/docs/guide-examples.test.ts
@@ -9,6 +9,14 @@
  */
 import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createJobsClient } from "../../src/jobs/index.ts";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
 
 // === Guide: tools.mdx ===
 import { tool } from "../../src/tool/index.ts";
@@ -262,6 +270,181 @@ describe("Guide: workflows.mdx", () => {
 
     assertExists(pipeline);
     assertEquals(pipeline.id, "typed-pipeline");
+  });
+});
+
+// === Guide: jobs.mdx ===
+describe("Guide: jobs.mdx", () => {
+  it("should create a one-off job and read canonical events", async () => {
+    const originalFetch = globalThis.fetch;
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const responses = [
+      jsonResponse({
+        id: "11111111-1111-4111-8111-111111111111",
+        project_id: "22222222-2222-4222-8222-222222222222",
+        environment_id: null,
+        cron_job_id: null,
+        batch_id: null,
+        name: "Ingest 1 file to knowledge base",
+        status: "submitted",
+        target: "task:knowledge-ingest",
+        config: {
+          file_count: 1,
+          upload_ids: ["33333333-3333-4333-8333-333333333333"],
+        },
+        context_id: null,
+        timeout_seconds: 300,
+        backoff_limit: 3,
+        exit_code: null,
+        failed_reason: null,
+        failure_detail: null,
+        result: null,
+        started_at: null,
+        completed_at: null,
+        created_by: "44444444-4444-4444-8444-444444444444",
+        created_at: "2026-03-20T12:00:00.000Z",
+        updated_at: "2026-03-20T12:00:00.000Z",
+      }),
+      jsonResponse({
+        entries: [
+          {
+            timestamp: "2026-03-20T12:01:00.000Z",
+            level: "info",
+            message: "Processing knowledge source",
+            service: "job-runner",
+          },
+        ],
+        next_cursor: null,
+        stats: {
+          bytes_processed: 10,
+          lines_processed: 1,
+          query_time_ms: 2,
+        },
+      }),
+    ];
+
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+      calls.push({ url, init });
+      const next = responses.shift();
+      if (!next) {
+        throw new Error(`No mock response for ${url}`);
+      }
+      return next;
+    }) as typeof fetch;
+
+    try {
+      const jobs = createJobsClient({
+        apiUrl: "https://api.test.com",
+        authToken: "test-token",
+        projectReference: "dreamy-haven",
+      });
+
+      const job = await jobs.create({
+        name: "Ingest 1 file to knowledge base",
+        target: "task:knowledge-ingest",
+        config: {
+          file_count: 1,
+          upload_ids: ["33333333-3333-4333-8333-333333333333"],
+        },
+      });
+
+      const events = await jobs.events(job.id);
+
+      assertEquals(job.target, "task:knowledge-ingest");
+      assertEquals(events.entries.length, 1);
+      assert(calls[0]?.url.includes("/projects/dreamy-haven/jobs"));
+      assert(calls[1]?.url.includes(`/jobs/${job.id}/events`));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("should create a cron job and discover target definitions", async () => {
+    const originalFetch = globalThis.fetch;
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const responses = [
+      jsonResponse({
+        id: "55555555-5555-4555-8555-555555555555",
+        project_id: "22222222-2222-4222-8222-222222222222",
+        environment_id: null,
+        name: "Nightly knowledge sync",
+        status: "active",
+        target: "task:knowledge-ingest",
+        schedule: "0 2 * * *",
+        timezone: "Europe/Stockholm",
+        config: {
+          file_count: 1,
+          upload_ids: ["33333333-3333-4333-8333-333333333333"],
+        },
+        timeout_seconds: 300,
+        backoff_limit: 3,
+        concurrency_policy: "Forbid",
+        last_scheduled_at: null,
+        last_successful_at: null,
+        created_by: "44444444-4444-4444-8444-444444444444",
+        created_at: "2026-03-20T12:00:00.000Z",
+        updated_at: "2026-03-20T12:00:00.000Z",
+      }),
+      jsonResponse({
+        reserved_families: ["task:*", "workflow:*", "deploy:*"],
+        data: [
+          {
+            target: "task:knowledge-ingest",
+            family: "task",
+            description: "Convert uploaded files into knowledge documents.",
+            input_schema: { type: "object" },
+            output_schema: { type: "object" },
+          },
+        ],
+      }),
+    ];
+
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+      calls.push({ url, init });
+      const next = responses.shift();
+      if (!next) {
+        throw new Error(`No mock response for ${url}`);
+      }
+      return next;
+    }) as typeof fetch;
+
+    try {
+      const jobs = createJobsClient({
+        apiUrl: "https://api.test.com",
+        authToken: "test-token",
+        projectReference: "dreamy-haven",
+      });
+
+      const cronJob = await jobs.cron.create({
+        name: "Nightly knowledge sync",
+        target: "task:knowledge-ingest",
+        schedule: "0 2 * * *",
+        timezone: "Europe/Stockholm",
+        config: {
+          file_count: 1,
+          upload_ids: ["33333333-3333-4333-8333-333333333333"],
+        },
+      });
+
+      const targets = await jobs.targets.list();
+
+      assertEquals(cronJob.status, "active");
+      assertEquals(targets.data[0]?.target, "task:knowledge-ingest");
+      assert(calls[0]?.url.includes("/projects/dreamy-haven/cron-jobs"));
+      assert(calls[1]?.url.includes("/projects/dreamy-haven/job-targets"));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- add a public jobs guide covering one-off jobs, cron jobs, events vs logs, targets, batches, and current Studio expectations
- add a public jobs API reference page and surface it from the docs indexes and README
- add guide example coverage so the main jobs examples stay valid over time

## Testing
- deno test --no-check --allow-all tests/docs/guide-examples.test.ts
- deno task verify:quick