### PR TITLE
Add runtime task discovery endpoint

### DIFF
--- a/src/server/handlers/request/internal-tasks-list.handler.test.ts
+++ b/src/server/handlers/request/internal-tasks-list.handler.test.ts
@@ -1,0 +1,200 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES } from "#veryfront/internal-agents/request-body.ts";
+import { InternalTasksListHandler } from "./internal-tasks-list.handler.ts";
+import { createControlPlaneSignature, createCtx } from "./internal-agent-run.test-helpers.ts";
+
+describe("server/handlers/request/internal-tasks-list.handler", () => {
+  it("returns discovered tasks for a valid signed request", async () => {
+    let discoveryCalls = 0;
+    const handler = new InternalTasksListHandler({
+      discoverTasks: async () => {
+        discoveryCalls += 1;
+        return {
+          tasks: [
+            {
+              id: "sync-data",
+              name: "Sync external data",
+              filePath: "tasks/sync-data.ts",
+              exportName: "default",
+              definition: {
+                name: "Sync external data",
+                description: "Pull the latest records from the upstream API",
+                inputSchema: {
+                  type: "object",
+                  properties: {
+                    dryRun: { type: "boolean" },
+                  },
+                },
+                schedulable: false,
+                run: async () => undefined,
+              },
+            },
+          ],
+          errors: [],
+        };
+      },
+    });
+
+    const body = JSON.stringify({
+      requestId: "tasks-1",
+      projectId: "proj-1",
+      surface: "studio",
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "tasks-1",
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/tasks/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(discoveryCalls, 1);
+    assertEquals(await result.response.json(), {
+      tasks: [
+        {
+          id: "sync-data",
+          name: "Sync external data",
+          description: "Pull the latest records from the upstream API",
+          target: "task:sync-data",
+          sourcePath: "tasks/sync-data.ts",
+          inputSchema: {
+            type: "object",
+            properties: {
+              dryRun: { type: "boolean" },
+            },
+          },
+          outputSchema: null,
+          schedulable: false,
+        },
+      ],
+    });
+  });
+
+  it("returns 401 when the control-plane signature is missing", async () => {
+    const handler = new InternalTasksListHandler({
+      discoverTasks: async () => ({ tasks: [], errors: [] }),
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/tasks/list", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          requestId: "tasks-1",
+          projectId: "proj-1",
+          surface: "studio",
+        }),
+      }),
+      createCtx("-----BEGIN PUBLIC KEY-----\nZmFrZQ==\n-----END PUBLIC KEY-----"),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 401);
+    assertEquals(await result.response.json(), { error: "Missing control-plane signature" });
+  });
+
+  it("returns 401 when the signed claims do not match the request body", async () => {
+    const handler = new InternalTasksListHandler({
+      discoverTasks: async () => ({ tasks: [], errors: [] }),
+    });
+
+    const body = JSON.stringify({
+      requestId: "tasks-body",
+      projectId: "proj-1",
+      surface: "studio",
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "tasks-signed",
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/tasks/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 401);
+    assertEquals(await result.response.json(), { error: "Invalid control-plane signature" });
+  });
+
+  it("rejects oversized list payloads before parsing", async () => {
+    const handler = new InternalTasksListHandler({
+      discoverTasks: async () => ({ tasks: [], errors: [] }),
+    });
+
+    const body = JSON.stringify({
+      requestId: "tasks-1",
+      projectId: "proj-1",
+      surface: "studio",
+      metadata: "x".repeat(INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES + 1024),
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "tasks-1",
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/tasks/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 413);
+    assertEquals(await result.response.json(), { error: "Payload too large" });
+  });
+
+  it("returns 400 when the request body shape is invalid", async () => {
+    const handler = new InternalTasksListHandler({
+      discoverTasks: async () => ({ tasks: [], errors: [] }),
+    });
+
+    const body = JSON.stringify({
+      requestId: "tasks-1",
+      projectId: "proj-1",
+      surface: 123,
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "tasks-1",
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/tasks/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 400);
+    assertEquals(await result.response.json(), { error: "Invalid internal tasks request" });
+  });
+});

--- a/src/server/handlers/request/internal-tasks-list.handler.ts
+++ b/src/server/handlers/request/internal-tasks-list.handler.ts
@@ -1,0 +1,102 @@
+import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
+import { ZodError } from "zod";
+import {
+  type ControlPlaneTasksListRequest,
+  ControlPlaneTasksListRequestSchema,
+  defaultRuntimeTaskDiscoveryDeps,
+  listRuntimeTasks,
+  type RuntimeTaskDiscoveryDeps,
+} from "../../../task/control-plane.ts";
+import {
+  ControlPlaneRequestError,
+  verifyControlPlaneRequest,
+} from "#veryfront/internal-agents/control-plane-auth.ts";
+import {
+  INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES,
+  InternalAgentRequestBodyTooLargeError,
+  readInternalAgentRequestBody,
+} from "#veryfront/internal-agents/request-body.ts";
+import { BaseHandler } from "../response/base.ts";
+import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
+
+export class InternalTasksListHandler extends BaseHandler {
+  metadata: HandlerMetadata = {
+    name: "InternalTasksListHandler",
+    priority: PRIORITY_MEDIUM_API as HandlerPriority,
+    patterns: [{ pattern: "/internal/tasks/list", exact: true, method: "POST" }],
+  };
+
+  constructor(
+    private readonly deps: RuntimeTaskDiscoveryDeps = defaultRuntimeTaskDiscoveryDeps,
+  ) {
+    super();
+  }
+
+  async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
+    if (!this.shouldHandle(req, ctx)) {
+      return this.continue();
+    }
+
+    return this.withProxyContext(ctx, async () => {
+      const builder = this.createResponseBuilder(ctx)
+        .withCORS(req, ctx.securityConfig?.cors)
+        .withSecurity(ctx.securityConfig ?? undefined, req);
+
+      try {
+        const rawBody = await readInternalAgentRequestBody(
+          req,
+          INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES,
+        );
+        const payload: ControlPlaneTasksListRequest = ControlPlaneTasksListRequestSchema.parse(
+          JSON.parse(rawBody),
+        );
+        const claims = await verifyControlPlaneRequest(req, ctx, rawBody, {
+          expectedSubject: payload.requestId,
+          expectedSurface: payload.surface,
+        });
+
+        if (
+          payload.projectId !== claims.project_id ||
+          (ctx.projectId !== undefined && payload.projectId !== ctx.projectId)
+        ) {
+          this.logWarn("Internal tasks list request body did not match signed claims", {
+            projectSlug: ctx.projectSlug,
+            projectId: ctx.projectId,
+            requestId: payload.requestId,
+            signedRequestId: claims.sub,
+            surface: payload.surface,
+            signedSurface: claims.surface,
+          });
+          return this.respond(builder.json({ error: "Invalid control-plane signature" }, 401));
+        }
+
+        const response = await listRuntimeTasks(ctx, this.deps);
+        return this.respond(builder.json(response, 200));
+      } catch (error) {
+        if (error instanceof InternalAgentRequestBodyTooLargeError) {
+          return this.respond(builder.json({ error: error.message }, error.status));
+        }
+
+        if (error instanceof ControlPlaneRequestError) {
+          this.logWarn("Internal tasks list signature verification failed", {
+            error: error.message,
+            projectSlug: ctx.projectSlug,
+            projectId: ctx.projectId,
+          });
+          return this.respond(builder.json({ error: error.message }, error.status));
+        }
+
+        if (error instanceof SyntaxError || error instanceof ZodError) {
+          this.logWarn("Internal tasks list request validation failed", {
+            error: error instanceof Error ? error.message : String(error),
+            projectSlug: ctx.projectSlug,
+            projectId: ctx.projectId,
+          });
+          return this.respond(builder.json({ error: "Invalid internal tasks request" }, 400));
+        }
+
+        throw error;
+      }
+    });
+  }
+}

--- a/src/server/runtime-handler/handler-registry-factory.test.ts
+++ b/src/server/runtime-handler/handler-registry-factory.test.ts
@@ -90,13 +90,18 @@ describe("server/runtime-handler/createHandlerRegistry", () => {
 
     // Verify the handlers are sorted by priority
     for (let i = 1; i < handlers.length; i++) {
-      const prevPriority = handlers[i - 1].metadata.priority;
-      const currPriority = handlers[i].metadata.priority;
+      const previousHandler = handlers[i - 1];
+      const currentHandler = handlers[i];
+      assertExists(previousHandler);
+      assertExists(currentHandler);
+
+      const prevPriority = previousHandler.metadata.priority;
+      const currPriority = currentHandler.metadata.priority;
       assertEquals(
         prevPriority <= currPriority,
         true,
-        `Handler "${handlers[i - 1].metadata.name}" (priority ${prevPriority}) ` +
-          `should come before "${handlers[i].metadata.name}" (priority ${currPriority})`,
+        `Handler "${previousHandler.metadata.name}" (priority ${prevPriority}) ` +
+          `should come before "${currentHandler.metadata.name}" (priority ${currPriority})`,
       );
     }
   });
@@ -118,6 +123,7 @@ describe("server/runtime-handler/createHandlerRegistry", () => {
     const { registry } = createHandlerRegistry(projectDir, adapter);
     const handlers = registry.getHandlers();
     const last = handlers[handlers.length - 1];
+    assertExists(last);
 
     assertEquals(last.metadata.name, "NotFoundHandler");
     assertEquals(last.metadata.priority, HandlerPriority.FALLBACK);
@@ -159,7 +165,7 @@ describe("server/runtime-handler/createHandlerRegistry", () => {
     const stats = registry.getStats();
 
     // Total count should remain the same
-    assertEquals(stats.totalHandlers, 32);
+    assertEquals(stats.totalHandlers, 33);
 
     // AuthHandler should still be the real one (not overridden)
     assertEquals(stats.handlerNames.includes("AuthHandler"), true);
@@ -213,7 +219,7 @@ describe("server/runtime-handler/createHandlerRegistry", () => {
     assertEquals(authHandler, mockAuth as Handler);
     assertEquals(ssrHandler, mockSSR as Handler);
     assertEquals(healthHandler, mockHealth as Handler);
-    assertEquals(registry.getStats().totalHandlers, 32);
+    assertEquals(registry.getStats().totalHandlers, 33);
   });
 
   it("ignores overrides with non-existent handler names", () => {
@@ -222,12 +228,12 @@ describe("server/runtime-handler/createHandlerRegistry", () => {
     const { registry } = createHandlerRegistry(projectDir, adapter, {
       overrides: {
         FakeHandler: mockFake,
-      },
+      } as unknown as Partial<Record<(typeof HANDLER_NAMES)[number], Handler>>,
     });
 
     // FakeHandler is not in the default list, so it should be ignored
     const stats = registry.getStats();
-    assertEquals(stats.totalHandlers, 32);
+    assertEquals(stats.totalHandlers, 33);
     assertEquals(stats.handlerNames.includes("FakeHandler"), false);
   });
 
@@ -236,7 +242,7 @@ describe("server/runtime-handler/createHandlerRegistry", () => {
       overrides: {},
     });
 
-    assertEquals(registry.getStats().totalHandlers, 32);
+    assertEquals(registry.getStats().totalHandlers, 33);
   });
 
   it("works with debug mode enabled", () => {
@@ -244,7 +250,7 @@ describe("server/runtime-handler/createHandlerRegistry", () => {
       debug: true,
     });
 
-    assertEquals(registry.getStats().totalHandlers, 32);
+    assertEquals(registry.getStats().totalHandlers, 33);
   });
 
   it("contains all security handler group", () => {

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -53,6 +53,7 @@ import { MarkdownPreviewHandler } from "../handlers/preview/markdown-preview.han
 import { OpenAPIHandler } from "../handlers/request/openapi.handler.ts";
 import { OpenAPIDocsHandler } from "../handlers/request/openapi-docs.handler.ts";
 import { InternalAgentsListHandler } from "../handlers/request/internal-agents-list.handler.ts";
+import { InternalTasksListHandler } from "../handlers/request/internal-tasks-list.handler.ts";
 import { AgentStreamHandler } from "../handlers/request/agent-stream.handler.ts";
 import { AgentRunResumeHandler } from "../handlers/request/agent-run-resume.handler.ts";
 import { AgentRunCancelHandler } from "../handlers/request/agent-run-cancel.handler.ts";
@@ -129,6 +130,7 @@ export const HANDLER_NAMES = [
   "OpenAPIHandler",
   "OpenAPIDocsHandler",
   "InternalAgentsListHandler",
+  "InternalTasksListHandler",
   "AgentStreamHandler",
   "AgentRunResumeHandler",
   "AgentRunCancelHandler",
@@ -183,6 +185,7 @@ const handlerFactories: Record<
   OpenAPIHandler: () => new OpenAPIHandler(),
   OpenAPIDocsHandler: () => new OpenAPIDocsHandler(),
   InternalAgentsListHandler: () => new InternalAgentsListHandler(),
+  InternalTasksListHandler: () => new InternalTasksListHandler(),
   AgentStreamHandler: () => new AgentStreamHandler(),
   AgentRunResumeHandler: () => new AgentRunResumeHandler(),
   AgentRunCancelHandler: () => new AgentRunCancelHandler(),

--- a/src/task/control-plane.test.ts
+++ b/src/task/control-plane.test.ts
@@ -1,0 +1,92 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { listRuntimeTasks, RuntimeTaskListResponseSchema } from "./control-plane.ts";
+
+function createHandlerContext(): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter: {
+      env: { get: () => undefined },
+      fs: {},
+    },
+    securityConfig: null,
+    cspUserHeader: null,
+    projectSlug: "demo-project",
+    projectId: "proj-1",
+    isLocalProject: false,
+  } as unknown as HandlerContext;
+}
+
+describe("task/control-plane", () => {
+  describe("listRuntimeTasks", () => {
+    it("returns canonical runtime tasks sorted by name", async () => {
+      let discoveryCalls = 0;
+
+      const response = await listRuntimeTasks(createHandlerContext(), {
+        discoverTasks: async () => {
+          discoveryCalls += 1;
+          return {
+            tasks: [
+              {
+                id: "sync-b",
+                name: "Sync Beta",
+                filePath: "tasks/sync-b.ts",
+                exportName: "default",
+                definition: {
+                  name: "Sync Beta",
+                  description: "Second sync task",
+                  schedulable: false,
+                  run: async () => undefined,
+                },
+              },
+              {
+                id: "sync-a",
+                name: "Sync Alpha",
+                filePath: "tasks/sync-a.ts",
+                exportName: "default",
+                definition: {
+                  name: "Sync Alpha",
+                  description: "Primary sync task",
+                  inputSchema: { type: "object" },
+                  outputSchema: { type: "object" },
+                  run: async () => undefined,
+                },
+              },
+            ],
+            errors: [],
+          };
+        },
+      });
+
+      assertEquals(discoveryCalls, 1);
+      assertEquals(
+        response,
+        RuntimeTaskListResponseSchema.parse({
+          tasks: [
+            {
+              id: "sync-a",
+              name: "Sync Alpha",
+              description: "Primary sync task",
+              target: "task:sync-a",
+              sourcePath: "tasks/sync-a.ts",
+              inputSchema: { type: "object" },
+              outputSchema: { type: "object" },
+              schedulable: true,
+            },
+            {
+              id: "sync-b",
+              name: "Sync Beta",
+              description: "Second sync task",
+              target: "task:sync-b",
+              sourcePath: "tasks/sync-b.ts",
+              inputSchema: null,
+              outputSchema: null,
+              schedulable: false,
+            },
+          ],
+        }),
+      );
+    });
+  });
+});

--- a/src/task/control-plane.ts
+++ b/src/task/control-plane.ts
@@ -1,0 +1,76 @@
+import { ControlPlaneSurfaceSchema } from "#veryfront/channels/control-plane.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { z } from "zod";
+import { discoverTasks, type TaskDiscoveryOptions } from "./discovery.ts";
+
+export const ControlPlaneTasksListRequestSchema = z.object({
+  requestId: z.string().min(1),
+  projectId: z.string().min(1),
+  surface: ControlPlaneSurfaceSchema,
+});
+
+const JsonSchemaRecordSchema = z.record(z.unknown());
+
+export const RuntimeTaskSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().nullable(),
+  target: z.string().min(1),
+  sourcePath: z.string().min(1),
+  inputSchema: JsonSchemaRecordSchema.nullable(),
+  outputSchema: JsonSchemaRecordSchema.nullable(),
+  schedulable: z.boolean(),
+});
+
+export const RuntimeTaskListResponseSchema = z.object({
+  tasks: z.array(RuntimeTaskSchema),
+});
+
+export type ControlPlaneTasksListRequest = z.infer<typeof ControlPlaneTasksListRequestSchema>;
+export type RuntimeTask = z.infer<typeof RuntimeTaskSchema>;
+export type RuntimeTaskListResponse = z.infer<typeof RuntimeTaskListResponseSchema>;
+
+export interface RuntimeTaskDiscoveryDeps {
+  discoverTasks: (options: TaskDiscoveryOptions) => ReturnType<typeof discoverTasks>;
+}
+
+export const defaultRuntimeTaskDiscoveryDeps: RuntimeTaskDiscoveryDeps = {
+  discoverTasks,
+};
+
+function normalizeJsonSchema(value: unknown): Record<string, unknown> | null {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+export async function listRuntimeTasks(
+  ctx: HandlerContext,
+  deps: RuntimeTaskDiscoveryDeps = defaultRuntimeTaskDiscoveryDeps,
+): Promise<RuntimeTaskListResponse> {
+  const discovery = await deps.discoverTasks({
+    projectDir: ctx.projectDir,
+    adapter: ctx.adapter,
+    config: ctx.config,
+    debug: ctx.debug ?? false,
+  });
+
+  const tasks = discovery.tasks
+    .map((task) =>
+      RuntimeTaskSchema.parse({
+        id: task.id,
+        name: task.name,
+        description: task.definition.description ?? null,
+        target: `task:${task.id}`,
+        sourcePath: task.filePath,
+        inputSchema: normalizeJsonSchema(task.definition.inputSchema),
+        outputSchema: normalizeJsonSchema(task.definition.outputSchema),
+        schedulable: task.definition.schedulable ?? true,
+      })
+    )
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  return RuntimeTaskListResponseSchema.parse({ tasks });
+}

--- a/src/task/types.ts
+++ b/src/task/types.ts
@@ -26,6 +26,12 @@ export interface TaskDefinition {
   name?: string;
   /** Task description */
   description?: string;
+  /** Optional JSON-schema-like input contract surfaced in APIs/UIs */
+  inputSchema?: Record<string, unknown>;
+  /** Optional JSON-schema-like output contract surfaced in APIs/UIs */
+  outputSchema?: Record<string, unknown>;
+  /** Whether this task can be scheduled via cron jobs */
+  schedulable?: boolean;
   /** The function to execute */
   run: (ctx: TaskContext) => Promise<unknown> | unknown;
 }


### PR DESCRIPTION
## Summary
- add a signed internal runtime endpoint for listing project tasks
- surface canonical task metadata from runtime discovery
- register and test the new handler in the runtime handler registry

## Verification
- deno test --allow-env --allow-read src/task/control-plane.test.ts src/server/handlers/request/internal-tasks-list.handler.test.ts src/server/runtime-handler/handler-registry-factory.test.ts
- deno task verify:quick