### PR TITLE
Bump veryfront version to 0.1.76

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [


### PR DESCRIPTION
## Summary
- bump the framework semver in deno.json to 0.1.76
- allow the merged task-discovery runtime changes to flow through the normal release/publish pipeline

## Verification
- git push pre-push suite (format, lint, typecheck, unit, integration, binary e2e)