### PR TITLE
Add internal workflow discovery endpoint

### DIFF
--- a/src/server/handlers/request/internal-workflows-list.handler.test.ts
+++ b/src/server/handlers/request/internal-workflows-list.handler.test.ts
@@ -1,0 +1,198 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { z } from "zod";
+import { INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES } from "#veryfront/internal-agents/request-body.ts";
+import { InternalWorkflowsListHandler } from "./internal-workflows-list.handler.ts";
+import { createControlPlaneSignature, createCtx } from "./internal-agent-run.test-helpers.ts";
+
+describe("server/handlers/request/internal-workflows-list.handler", () => {
+  it("returns discovered workflows for a valid signed request", async () => {
+    let discoveryCalls = 0;
+    const handler = new InternalWorkflowsListHandler({
+      discoverWorkflows: async () => {
+        discoveryCalls += 1;
+        return {
+          workflows: [
+            {
+              id: "publish-site",
+              filePath: "app/workflows/publish-site.ts",
+              exportName: "default",
+              definition: {
+                id: "publish-site",
+                description: "Build and publish the site",
+                version: "3",
+                inputSchema: z.object({
+                  dryRun: z.boolean().optional(),
+                }),
+                steps: [],
+              },
+            },
+          ],
+          errors: [],
+        };
+      },
+    });
+
+    const body = JSON.stringify({
+      requestId: "workflows-1",
+      projectId: "proj-1",
+      surface: "studio",
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "workflows-1",
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/workflows/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(discoveryCalls, 1);
+    assertEquals(await result.response.json(), {
+      workflows: [
+        {
+          id: "publish-site",
+          name: "publish-site",
+          description: "Build and publish the site",
+          target: "workflow:publish-site",
+          sourcePath: "app/workflows/publish-site.ts",
+          version: "3",
+          inputSchema: {
+            properties: {
+              dryRun: { type: "boolean" },
+            },
+            type: "object",
+          },
+          outputSchema: null,
+          schedulable: true,
+        },
+      ],
+    });
+  });
+
+  it("returns 401 when the control-plane signature is missing", async () => {
+    const handler = new InternalWorkflowsListHandler({
+      discoverWorkflows: async () => ({ workflows: [], errors: [] }),
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/workflows/list", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          requestId: "workflows-1",
+          projectId: "proj-1",
+          surface: "studio",
+        }),
+      }),
+      createCtx("-----BEGIN PUBLIC KEY-----\nZmFrZQ==\n-----END PUBLIC KEY-----"),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 401);
+    assertEquals(await result.response.json(), { error: "Missing control-plane signature" });
+  });
+
+  it("returns 401 when the signed claims do not match the request body", async () => {
+    const handler = new InternalWorkflowsListHandler({
+      discoverWorkflows: async () => ({ workflows: [], errors: [] }),
+    });
+
+    const body = JSON.stringify({
+      requestId: "workflows-body",
+      projectId: "proj-1",
+      surface: "studio",
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "workflows-signed",
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/workflows/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 401);
+    assertEquals(await result.response.json(), { error: "Invalid control-plane signature" });
+  });
+
+  it("rejects oversized list payloads before parsing", async () => {
+    const handler = new InternalWorkflowsListHandler({
+      discoverWorkflows: async () => ({ workflows: [], errors: [] }),
+    });
+
+    const body = JSON.stringify({
+      requestId: "workflows-1",
+      projectId: "proj-1",
+      surface: "studio",
+      metadata: "x".repeat(INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES + 1024),
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "workflows-1",
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/workflows/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 413);
+    assertEquals(await result.response.json(), { error: "Payload too large" });
+  });
+
+  it("returns 400 when the request body shape is invalid", async () => {
+    const handler = new InternalWorkflowsListHandler({
+      discoverWorkflows: async () => ({ workflows: [], errors: [] }),
+    });
+
+    const body = JSON.stringify({
+      requestId: "workflows-1",
+      projectId: "proj-1",
+      surface: 123,
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "workflows-1",
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/workflows/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 400);
+    assertEquals(await result.response.json(), { error: "Invalid internal workflows request" });
+  });
+});

--- a/src/server/handlers/request/internal-workflows-list.handler.ts
+++ b/src/server/handlers/request/internal-workflows-list.handler.ts
@@ -1,0 +1,101 @@
+import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
+import { ZodError } from "zod";
+import {
+  ControlPlaneRequestError,
+  verifyControlPlaneRequest,
+} from "#veryfront/internal-agents/control-plane-auth.ts";
+import {
+  INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES,
+  InternalAgentRequestBodyTooLargeError,
+  readInternalAgentRequestBody,
+} from "#veryfront/internal-agents/request-body.ts";
+import {
+  type ControlPlaneWorkflowsListRequest,
+  ControlPlaneWorkflowsListRequestSchema,
+  defaultRuntimeWorkflowDiscoveryDeps,
+  listRuntimeWorkflows,
+  type RuntimeWorkflowDiscoveryDeps,
+} from "../../../workflow/control-plane.ts";
+import { BaseHandler } from "../response/base.ts";
+import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
+
+export class InternalWorkflowsListHandler extends BaseHandler {
+  metadata: HandlerMetadata = {
+    name: "InternalWorkflowsListHandler",
+    priority: PRIORITY_MEDIUM_API as HandlerPriority,
+    patterns: [{ pattern: "/internal/workflows/list", exact: true, method: "POST" }],
+  };
+
+  constructor(
+    private readonly deps: RuntimeWorkflowDiscoveryDeps = defaultRuntimeWorkflowDiscoveryDeps,
+  ) {
+    super();
+  }
+
+  async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
+    if (!this.shouldHandle(req, ctx)) {
+      return this.continue();
+    }
+
+    return this.withProxyContext(ctx, async () => {
+      const builder = this.createResponseBuilder(ctx)
+        .withCORS(req, ctx.securityConfig?.cors)
+        .withSecurity(ctx.securityConfig ?? undefined, req);
+
+      try {
+        const rawBody = await readInternalAgentRequestBody(
+          req,
+          INTERNAL_AGENT_CONTROL_PLANE_MAX_BODY_BYTES,
+        );
+        const payload: ControlPlaneWorkflowsListRequest = ControlPlaneWorkflowsListRequestSchema
+          .parse(JSON.parse(rawBody));
+        const claims = await verifyControlPlaneRequest(req, ctx, rawBody, {
+          expectedSubject: payload.requestId,
+          expectedSurface: payload.surface,
+        });
+
+        if (
+          payload.projectId !== claims.project_id ||
+          (ctx.projectId !== undefined && payload.projectId !== ctx.projectId)
+        ) {
+          this.logWarn("Internal workflows list request body did not match signed claims", {
+            projectSlug: ctx.projectSlug,
+            projectId: ctx.projectId,
+            requestId: payload.requestId,
+            signedRequestId: claims.sub,
+            surface: payload.surface,
+            signedSurface: claims.surface,
+          });
+          return this.respond(builder.json({ error: "Invalid control-plane signature" }, 401));
+        }
+
+        const response = await listRuntimeWorkflows(ctx, this.deps);
+        return this.respond(builder.json(response, 200));
+      } catch (error) {
+        if (error instanceof InternalAgentRequestBodyTooLargeError) {
+          return this.respond(builder.json({ error: error.message }, error.status));
+        }
+
+        if (error instanceof ControlPlaneRequestError) {
+          this.logWarn("Internal workflows list signature verification failed", {
+            error: error.message,
+            projectSlug: ctx.projectSlug,
+            projectId: ctx.projectId,
+          });
+          return this.respond(builder.json({ error: error.message }, error.status));
+        }
+
+        if (error instanceof SyntaxError || error instanceof ZodError) {
+          this.logWarn("Internal workflows list request validation failed", {
+            error: error instanceof Error ? error.message : String(error),
+            projectSlug: ctx.projectSlug,
+            projectId: ctx.projectId,
+          });
+          return this.respond(builder.json({ error: "Invalid internal workflows request" }, 400));
+        }
+
+        throw error;
+      }
+    });
+  }
+}

--- a/src/server/runtime-handler/handler-registry-factory.test.ts
+++ b/src/server/runtime-handler/handler-registry-factory.test.ts
@@ -82,6 +82,7 @@ describe("server/runtime-handler/createHandlerRegistry", () => {
     assertEquals(names.includes("NotFoundHandler"), true);
     assertEquals(names.includes("ApiHandlerWrapper"), true);
     assertEquals(names.includes("HMRHandler"), true);
+    assertEquals(names.includes("InternalWorkflowsListHandler"), true);
   });
 
   it("returns handlers sorted by priority (lowest number = highest priority)", () => {
@@ -165,7 +166,7 @@ describe("server/runtime-handler/createHandlerRegistry", () => {
     const stats = registry.getStats();
 
     // Total count should remain the same
-    assertEquals(stats.totalHandlers, 33);
+    assertEquals(stats.totalHandlers, 34);
 
     // AuthHandler should still be the real one (not overridden)
     assertEquals(stats.handlerNames.includes("AuthHandler"), true);
@@ -219,7 +220,7 @@ describe("server/runtime-handler/createHandlerRegistry", () => {
     assertEquals(authHandler, mockAuth as Handler);
     assertEquals(ssrHandler, mockSSR as Handler);
     assertEquals(healthHandler, mockHealth as Handler);
-    assertEquals(registry.getStats().totalHandlers, 33);
+    assertEquals(registry.getStats().totalHandlers, 34);
   });
 
   it("ignores overrides with non-existent handler names", () => {
@@ -233,7 +234,7 @@ describe("server/runtime-handler/createHandlerRegistry", () => {
 
     // FakeHandler is not in the default list, so it should be ignored
     const stats = registry.getStats();
-    assertEquals(stats.totalHandlers, 33);
+    assertEquals(stats.totalHandlers, 34);
     assertEquals(stats.handlerNames.includes("FakeHandler"), false);
   });
 
@@ -242,7 +243,7 @@ describe("server/runtime-handler/createHandlerRegistry", () => {
       overrides: {},
     });
 
-    assertEquals(registry.getStats().totalHandlers, 33);
+    assertEquals(registry.getStats().totalHandlers, 34);
   });
 
   it("works with debug mode enabled", () => {
@@ -250,7 +251,7 @@ describe("server/runtime-handler/createHandlerRegistry", () => {
       debug: true,
     });
 
-    assertEquals(registry.getStats().totalHandlers, 33);
+    assertEquals(registry.getStats().totalHandlers, 34);
   });
 
   it("contains all security handler group", () => {

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -54,6 +54,7 @@ import { OpenAPIHandler } from "../handlers/request/openapi.handler.ts";
 import { OpenAPIDocsHandler } from "../handlers/request/openapi-docs.handler.ts";
 import { InternalAgentsListHandler } from "../handlers/request/internal-agents-list.handler.ts";
 import { InternalTasksListHandler } from "../handlers/request/internal-tasks-list.handler.ts";
+import { InternalWorkflowsListHandler } from "../handlers/request/internal-workflows-list.handler.ts";
 import { AgentStreamHandler } from "../handlers/request/agent-stream.handler.ts";
 import { AgentRunResumeHandler } from "../handlers/request/agent-run-resume.handler.ts";
 import { AgentRunCancelHandler } from "../handlers/request/agent-run-cancel.handler.ts";
@@ -131,6 +132,7 @@ export const HANDLER_NAMES = [
   "OpenAPIDocsHandler",
   "InternalAgentsListHandler",
   "InternalTasksListHandler",
+  "InternalWorkflowsListHandler",
   "AgentStreamHandler",
   "AgentRunResumeHandler",
   "AgentRunCancelHandler",
@@ -186,6 +188,7 @@ const handlerFactories: Record<
   OpenAPIDocsHandler: () => new OpenAPIDocsHandler(),
   InternalAgentsListHandler: () => new InternalAgentsListHandler(),
   InternalTasksListHandler: () => new InternalTasksListHandler(),
+  InternalWorkflowsListHandler: () => new InternalWorkflowsListHandler(),
   AgentStreamHandler: () => new AgentStreamHandler(),
   AgentRunResumeHandler: () => new AgentRunResumeHandler(),
   AgentRunCancelHandler: () => new AgentRunCancelHandler(),

--- a/src/workflow/control-plane.test.ts
+++ b/src/workflow/control-plane.test.ts
@@ -1,0 +1,108 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "#veryfront/types";
+import { z } from "zod";
+import { listRuntimeWorkflows, RuntimeWorkflowListResponseSchema } from "./control-plane.ts";
+
+function createHandlerContext(): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter: {
+      env: { get: () => undefined },
+      fs: {},
+    },
+    securityConfig: null,
+    cspUserHeader: null,
+    projectSlug: "demo-project",
+    projectId: "proj-1",
+    isLocalProject: false,
+  } as unknown as HandlerContext;
+}
+
+describe("workflow/control-plane", () => {
+  describe("listRuntimeWorkflows", () => {
+    it("returns canonical runtime workflows sorted by name", async () => {
+      let discoveryCalls = 0;
+
+      const response = await listRuntimeWorkflows(createHandlerContext(), {
+        discoverWorkflows: async () => {
+          discoveryCalls += 1;
+          return {
+            workflows: [
+              {
+                id: "sync-b",
+                filePath: "app/workflows/sync-b.ts",
+                exportName: "default",
+                definition: {
+                  id: "sync-b",
+                  description: "Second sync workflow",
+                  version: "2",
+                  steps: [],
+                },
+              },
+              {
+                id: "sync-a",
+                filePath: "app/workflows/sync-a.ts",
+                exportName: "default",
+                definition: {
+                  id: "sync-a",
+                  description: "Primary sync workflow",
+                  inputSchema: z.object({ dryRun: z.boolean().optional() }),
+                  outputSchema: z.object({ ok: z.boolean() }),
+                  steps: [],
+                },
+              },
+            ],
+            errors: [],
+          };
+        },
+      });
+
+      assertEquals(discoveryCalls, 1);
+      assertEquals(
+        response,
+        RuntimeWorkflowListResponseSchema.parse({
+          workflows: [
+            {
+              id: "sync-a",
+              name: "sync-a",
+              description: "Primary sync workflow",
+              target: "workflow:sync-a",
+              sourcePath: "app/workflows/sync-a.ts",
+              version: null,
+              inputSchema: {
+                properties: {
+                  dryRun: {
+                    type: "boolean",
+                  },
+                },
+                type: "object",
+              },
+              outputSchema: {
+                properties: {
+                  ok: {
+                    type: "boolean",
+                  },
+                },
+                required: ["ok"],
+                type: "object",
+              },
+              schedulable: true,
+            },
+            {
+              id: "sync-b",
+              name: "sync-b",
+              description: "Second sync workflow",
+              target: "workflow:sync-b",
+              sourcePath: "app/workflows/sync-b.ts",
+              version: "2",
+              inputSchema: null,
+              outputSchema: null,
+              schedulable: true,
+            },
+          ],
+        }),
+      );
+    });
+  });
+});

--- a/src/workflow/control-plane.ts
+++ b/src/workflow/control-plane.ts
@@ -1,0 +1,97 @@
+import { ControlPlaneSurfaceSchema } from "#veryfront/channels/control-plane.ts";
+import { zodToJsonSchema } from "#veryfront/tool/schema";
+import type { HandlerContext } from "#veryfront/types";
+import { z, type ZodTypeAny } from "zod";
+import {
+  discoverWorkflows,
+  type WorkflowDiscoveryOptions,
+} from "./discovery/workflow-discovery.ts";
+
+export const ControlPlaneWorkflowsListRequestSchema = z.object({
+  requestId: z.string().min(1),
+  projectId: z.string().min(1),
+  surface: ControlPlaneSurfaceSchema,
+});
+
+const JsonSchemaRecordSchema = z.record(z.unknown());
+
+export const RuntimeWorkflowSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().nullable(),
+  target: z.string().min(1),
+  sourcePath: z.string().min(1),
+  version: z.string().nullable(),
+  inputSchema: JsonSchemaRecordSchema.nullable(),
+  outputSchema: JsonSchemaRecordSchema.nullable(),
+  schedulable: z.boolean(),
+});
+
+export const RuntimeWorkflowListResponseSchema = z.object({
+  workflows: z.array(RuntimeWorkflowSchema),
+});
+
+export type ControlPlaneWorkflowsListRequest = z.infer<
+  typeof ControlPlaneWorkflowsListRequestSchema
+>;
+export type RuntimeWorkflow = z.infer<typeof RuntimeWorkflowSchema>;
+export type RuntimeWorkflowListResponse = z.infer<
+  typeof RuntimeWorkflowListResponseSchema
+>;
+
+export interface RuntimeWorkflowDiscoveryDeps {
+  discoverWorkflows: (
+    options: WorkflowDiscoveryOptions,
+  ) => ReturnType<typeof discoverWorkflows>;
+}
+
+export const defaultRuntimeWorkflowDiscoveryDeps: RuntimeWorkflowDiscoveryDeps = {
+  discoverWorkflows,
+};
+
+function normalizeJsonSchema(value: unknown): Record<string, unknown> | null {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  try {
+    const jsonSchema = zodToJsonSchema(value as ZodTypeAny);
+    if (jsonSchema != null && typeof jsonSchema === "object" && !Array.isArray(jsonSchema)) {
+      return jsonSchema as Record<string, unknown>;
+    }
+  } catch {
+    // Not every Zod schema can be converted; surface null instead of breaking discovery.
+  }
+
+  return null;
+}
+
+export async function listRuntimeWorkflows(
+  ctx: HandlerContext,
+  deps: RuntimeWorkflowDiscoveryDeps = defaultRuntimeWorkflowDiscoveryDeps,
+): Promise<RuntimeWorkflowListResponse> {
+  const discovery = await deps.discoverWorkflows({
+    projectDir: ctx.projectDir,
+    adapter: ctx.adapter,
+    config: ctx.config,
+    debug: ctx.debug ?? false,
+  });
+
+  const workflows = discovery.workflows
+    .map((workflow) =>
+      RuntimeWorkflowSchema.parse({
+        id: workflow.id,
+        name: workflow.id,
+        description: workflow.definition.description ?? null,
+        target: `workflow:${workflow.id}`,
+        sourcePath: workflow.filePath,
+        version: workflow.definition.version ?? null,
+        inputSchema: normalizeJsonSchema(workflow.definition.inputSchema),
+        outputSchema: normalizeJsonSchema(workflow.definition.outputSchema),
+        schedulable: true,
+      })
+    )
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  return RuntimeWorkflowListResponseSchema.parse({ workflows });
+}


### PR DESCRIPTION
## Summary
- add a signed internal runtime endpoint for workflow discovery
- expose canonical runtime workflow metadata and register the new handler
- cover the control-plane response and handler registration in tests

## Testing
- deno test --allow-env --allow-read src/workflow/control-plane.test.ts src/server/handlers/request/internal-workflows-list.handler.test.ts src/server/runtime-handler/handler-registry-factory.test.ts
- deno task verify:quick
