### PR TITLE
Fix proxy-mode task and workflow discovery execution

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/discovery/module-import.ts
+++ b/src/discovery/module-import.ts
@@ -1,0 +1,36 @@
+import type { RuntimeAdapter } from "#veryfront/platform";
+import { detectPlatform } from "#veryfront/platform/core-platform.ts";
+import * as pathHelper from "#veryfront/compat/path";
+import { importModule } from "./transpiler.ts";
+
+interface ImportDiscoveryModuleOptions {
+  adapter: RuntimeAdapter;
+  projectDir?: string;
+}
+
+function normalizeModulePath(filePath: string): string {
+  return filePath.startsWith("file://") ? filePath : `file://${filePath}`;
+}
+
+function resolveModulePath(filePath: string, projectDir?: string): string {
+  if (filePath.startsWith("file://")) return filePath;
+  if (pathHelper.isAbsolute(filePath)) return normalizeModulePath(filePath);
+  if (!projectDir || projectDir === "." || projectDir === "") {
+    return normalizeModulePath(`/${filePath.replace(/^\/+/, "")}`);
+  }
+
+  return normalizeModulePath(pathHelper.join(projectDir, filePath));
+}
+
+export async function importDiscoveryModule(
+  filePath: string,
+  options: ImportDiscoveryModuleOptions,
+): Promise<Record<string, unknown>> {
+  const module = await importModule(resolveModulePath(filePath, options.projectDir), {
+    platform: detectPlatform(),
+    fsAdapter: options.adapter.fs,
+    baseDir: options.projectDir || ".",
+  });
+
+  return module as Record<string, unknown>;
+}

--- a/src/task/discovery.ts
+++ b/src/task/discovery.ts
@@ -25,7 +25,7 @@ import { logger as baseLogger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { collectFiles } from "#veryfront/utils/file-discovery.ts";
-import { loadHandlerModule } from "#veryfront/routing/api/module-loader/loader.ts";
+import { importDiscoveryModule } from "#veryfront/discovery/module-import.ts";
 import type { TaskDefinition } from "./types.ts";
 import { isTaskDefinition } from "./types.ts";
 
@@ -144,17 +144,13 @@ export async function discoverTasks(
 
     for (const file of files) {
       try {
-        const module = await loadHandlerModule({
-          projectDir,
-          modulePath: file.path,
+        const module = await importDiscoveryModule(file.path, {
           adapter,
-          config,
+          projectDir,
         });
 
-        if (!module) continue;
-
         // Prefer default export (aligned with discovery-engine behaviour)
-        const defaultExport = (module as Record<string, unknown>).default;
+        const defaultExport = module.default;
         if (isTaskDefinition(defaultExport)) {
           const id = deriveTaskId(file.path, baseDir);
           tasks.push({
@@ -248,16 +244,12 @@ export async function findTaskById(
       if (id !== taskId) continue;
 
       try {
-        const module = await loadHandlerModule({
-          projectDir,
-          modulePath: file.path,
+        const module = await importDiscoveryModule(file.path, {
           adapter,
-          config,
+          projectDir,
         });
 
-        if (!module) continue;
-
-        const defaultExport = (module as Record<string, unknown>).default;
+        const defaultExport = module.default;
         if (isTaskDefinition(defaultExport)) {
           if (debug) {
             logger.info(`Found task "${id}" in ${file.path} (export: default)`);

--- a/src/workflow/discovery/workflow-discovery.test.ts
+++ b/src/workflow/discovery/workflow-discovery.test.ts
@@ -3,8 +3,7 @@ import { afterAll, afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { FileSystemAdapter, RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { stop as stopEsbuild } from "esbuild";
 import { clearTranspileCache } from "#veryfront/discovery/transpiler.ts";
-import { deriveTaskId, discoverTasks, findTaskById } from "./discovery.ts";
-import { isTaskDefinition } from "./types.ts";
+import { discoverWorkflows, findWorkflowById } from "./workflow-discovery.ts";
 
 function createMockAdapter(files: Record<string, string>): FileSystemAdapter {
   const normalize = (path: string): string => path.replace(/^\/project\/?/, "").replace(/^\/+/, "");
@@ -98,7 +97,7 @@ function createRuntimeAdapter(files: Record<string, string>): RuntimeAdapter {
   };
 }
 
-describe("task/discovery", () => {
+describe("workflow/discovery/workflow-discovery", () => {
   afterEach(() => {
     clearTranspileCache();
   });
@@ -107,103 +106,47 @@ describe("task/discovery", () => {
     await stopEsbuild();
   });
 
-  describe("deriveTaskId", () => {
-    it("strips the tasks directory prefix and extension", () => {
-      assertEquals(deriveTaskId("tasks/sync-data.ts", "tasks"), "sync-data");
-    });
-
-    it("handles a trailing slash in the tasks directory", () => {
-      assertEquals(deriveTaskId("tasks/sync-data.ts", "tasks/"), "sync-data");
-    });
-
-    it("handles nested file paths", () => {
-      assertEquals(deriveTaskId("tasks/reports/daily.ts", "tasks"), "reports/daily");
-    });
-
-    it("handles alternate script extensions", () => {
-      assertEquals(deriveTaskId("tasks/render.tsx", "tasks"), "render");
-      assertEquals(deriveTaskId("tasks/legacy.js", "tasks"), "legacy");
-      assertEquals(deriveTaskId("tasks/component.jsx", "tasks"), "component");
-    });
-
-    it("handles absolute project paths", () => {
-      assertEquals(deriveTaskId("/project/tasks/cleanup.ts", "/project/tasks"), "cleanup");
-    });
-
-    it("returns the input path when the prefix does not match", () => {
-      assertEquals(deriveTaskId("other/cleanup.ts", "tasks"), "other/cleanup");
-    });
-  });
-
-  describe("isTaskDefinition", () => {
-    it("accepts objects with a runnable export", () => {
-      assertEquals(isTaskDefinition({ run: () => {} }), true);
-      assertEquals(
-        isTaskDefinition({
-          name: "My Task",
-          description: "Does things",
-          run: async () => ({ ok: true }),
-        }),
-        true,
-      );
-    });
-
-    it("rejects non-task values", () => {
-      assertEquals(isTaskDefinition(null), false);
-      assertEquals(isTaskDefinition(undefined), false);
-      assertEquals(isTaskDefinition("not a task"), false);
-      assertEquals(isTaskDefinition(42), false);
-      assertEquals(isTaskDefinition({ name: "no run" }), false);
-      assertEquals(isTaskDefinition({ run: "not a function" }), false);
-    });
-  });
-
-  it("discovers default-exported tasks through the discovery module loader", async () => {
+  it("discovers workflow DSL exports through the discovery module loader", async () => {
     const adapter = createRuntimeAdapter({
-      "/project/tasks/ping.ts": [
-        'import { label } from "./shared.ts";',
-        "export default {",
-        "  name: label,",
-        "  schedulable: true,",
-        "  run() {",
-        "    return { ok: true };",
-        "  },",
-        "};",
+      "/project/app/workflows/ping.ts": [
+        'import { workflow } from "veryfront/workflow";',
+        "export default workflow({",
+        '  id: "ping",',
+        '  description: "Ping workflow",',
+        "  steps: [],",
+        "});",
       ].join("\n"),
-      "/project/tasks/shared.ts": 'export const label = "Ping task";',
     });
 
-    const result = await discoverTasks({
+    const result = await discoverWorkflows({
       projectDir: "/project",
       adapter,
       config: { fs: { type: "veryfront-api" } } as never,
     });
 
     assertEquals(result.errors, []);
-    assertEquals(result.tasks.map((task) => task.id), ["ping"]);
-    assertEquals(result.tasks[0]?.name, "Ping task");
+    assertEquals(result.workflows.map((workflow) => workflow.id), ["ping"]);
+    assertEquals(result.workflows[0]?.exportName, "default");
   });
 
-  it("finds a task by id through the discovery module loader", async () => {
+  it("finds workflows by id through the discovery module loader", async () => {
     const adapter = createRuntimeAdapter({
-      "/project/tasks/ping.ts": [
-        "export const pingTask = {",
-        '  name: "Ping task",',
-        "  run() {",
-        "    return { ok: true };",
-        "  },",
-        "};",
+      "/project/app/workflows/ping.ts": [
+        'import { workflow } from "veryfront/workflow";',
+        "export const pingWorkflow = workflow({",
+        '  id: "ping",',
+        "  steps: [],",
+        "});",
       ].join("\n"),
     });
 
-    const task = await findTaskById("ping", {
+    const workflow = await findWorkflowById("ping", {
       projectDir: "/project",
       adapter,
       config: { fs: { type: "veryfront-api" } } as never,
     });
 
-    assertEquals(task?.id, "ping");
-    assertEquals(task?.name, "Ping task");
-    assertEquals(task?.exportName, "pingTask");
+    assertEquals(workflow?.id, "ping");
+    assertEquals(workflow?.exportName, "pingWorkflow");
   });
 });

--- a/src/workflow/discovery/workflow-discovery.ts
+++ b/src/workflow/discovery/workflow-discovery.ts
@@ -27,7 +27,7 @@ import { logger as baseLogger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { collectFiles } from "#veryfront/utils/file-discovery.ts";
-import { loadHandlerModule } from "#veryfront/routing/api/module-loader/loader.ts";
+import { importDiscoveryModule } from "#veryfront/discovery/module-import.ts";
 import type { WorkflowDefinition } from "../types.ts";
 
 const logger = baseLogger.component("workflow-discovery");
@@ -167,16 +167,10 @@ export async function discoverWorkflows(
     // Load and extract workflows from each file
     for (const file of files) {
       try {
-        const module = await loadHandlerModule({
-          projectDir,
-          modulePath: file.path,
+        const module = await importDiscoveryModule(file.path, {
           adapter,
-          config,
+          projectDir,
         });
-
-        if (!module) {
-          continue;
-        }
 
         // Extract workflows from module exports
         for (const [exportName, value] of Object.entries(module)) {


### PR DESCRIPTION
## Summary
- switch task and workflow discovery off the API route loader and onto the generic discovery module loader
- normalize discovery module paths so proxy-backed relative imports resolve correctly
- add regression coverage for proxy-backed task and workflow discovery
- bump veryfront to 0.1.78 for release

## Verification
- deno test -A src/task/discovery.test.ts src/workflow/discovery/workflow-discovery.test.ts
- deno task verify:quick
- PROXY_MODE=1 VERYFRONT_API_BASE_URL=https://api.veryfront.com VERYFRONT_API_TOKEN=*** VERYFRONT_PROJECT_SLUG=dreamy-haven deno run -A cli/main.ts task ping
- PROXY_MODE=1 VERYFRONT_API_BASE_URL=https://api.veryfront.com VERYFRONT_API_TOKEN=*** VERYFRONT_PROJECT_SLUG=dreamy-haven deno run -A cli/main.ts workflow run ping