### PR TITLE
Sanitize workflow job output logging

### DIFF
--- a/cli/commands/task/command.ts
+++ b/cli/commands/task/command.ts
@@ -8,6 +8,7 @@
 import { cliLogger } from "#cli/utils";
 import { exitProcess } from "#cli/utils";
 import { withProjectSourceContext } from "#cli/shared/project-source-context";
+import { sanitizeJobOutputForLogging } from "../../utils/sanitize-job-output.ts";
 import type { TaskArgs } from "./handler.ts";
 
 export interface TaskOptions extends TaskArgs {}
@@ -93,7 +94,9 @@ export async function taskCommand(options: TaskOptions): Promise<void> {
       if (result.success) {
         cliLogger.info(`Task completed in ${result.durationMs}ms`);
         if (result.result !== undefined) {
-          cliLogger.info(`Result: ${JSON.stringify(result.result, null, 2)}`);
+          cliLogger.info(
+            `Result: ${JSON.stringify(sanitizeJobOutputForLogging(result.result), null, 2)}`,
+          );
         }
         return;
       }

--- a/cli/commands/workflow/command.ts
+++ b/cli/commands/workflow/command.ts
@@ -1,6 +1,7 @@
 import { cliLogger } from "#cli/utils";
 import { exitProcess } from "#cli/utils";
 import { withProjectSourceContext } from "#cli/shared/project-source-context";
+import { sanitizeJobOutputForLogging } from "../../utils/sanitize-job-output.ts";
 import { getEnv } from "veryfront/platform";
 import type { WorkflowArgs } from "./handler.ts";
 
@@ -43,7 +44,9 @@ async function waitForWorkflowExit(
     if (run.status === "completed") {
       cliLogger.info(`Workflow completed: ${runId}`);
       if (run.output !== undefined) {
-        cliLogger.info(`Result: ${JSON.stringify(run.output, null, 2)}`);
+        cliLogger.info(
+          `Result: ${JSON.stringify(sanitizeJobOutputForLogging(run.output), null, 2)}`,
+        );
       }
       return;
     }

--- a/cli/utils/sanitize-job-output.test.ts
+++ b/cli/utils/sanitize-job-output.test.ts
@@ -1,0 +1,46 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { sanitizeJobOutputForLogging } from "./sanitize-job-output.ts";
+
+describe("sanitizeJobOutputForLogging", () => {
+  it("removes top-level tenant context", () => {
+    assertEquals(
+      sanitizeJobOutputForLogging({
+        _tenant: { token: "secret", projectSlug: "dreamy-haven" },
+        ok: true,
+      }),
+      { ok: true },
+    );
+  });
+
+  it("removes nested tenant context recursively", () => {
+    assertEquals(
+      sanitizeJobOutputForLogging({
+        run: {
+          step: {
+            _tenant: { token: "secret" },
+            status: "completed",
+          },
+        },
+      }),
+      {
+        run: {
+          step: {
+            status: "completed",
+          },
+        },
+      },
+    );
+  });
+
+  it("preserves arrays and primitive values", () => {
+    assertEquals(
+      sanitizeJobOutputForLogging([
+        { ok: true, _tenant: { token: "secret" } },
+        "done",
+        42,
+      ]),
+      [{ ok: true }, "done", 42],
+    );
+  });
+});

--- a/cli/utils/sanitize-job-output.ts
+++ b/cli/utils/sanitize-job-output.ts
@@ -1,0 +1,23 @@
+function sanitizeValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sanitizeValue);
+  }
+
+  if (value == null || typeof value !== "object") {
+    return value;
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === "_tenant") {
+      continue;
+    }
+    sanitized[key] = sanitizeValue(entry);
+  }
+
+  return sanitized;
+}
+
+export function sanitizeJobOutputForLogging(value: unknown): unknown {
+  return sanitizeValue(value);
+}

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [


### PR DESCRIPTION
## Summary
- strip _tenant data from task and workflow result logging before writing job logs
- share the sanitizing helper across task and workflow CLI commands
- bump deno.json to 0.1.79 for release rollout

## Testing
- deno test -A cli/utils/sanitize-job-output.test.ts
- deno task verify:quick
- local proxy-mode workflow smoke test
