### PR TITLE
Write structured job results

### DIFF
--- a/cli/commands/knowledge/command.ts
+++ b/cli/commands/knowledge/command.ts
@@ -9,6 +9,7 @@ import { downloadUploadToFile, listAllUploads, type UploadItem } from "../upload
 import { putRemoteFileFromLocal } from "../files/command.ts";
 import { knowledgeIngestPythonSource } from "./parser-source.ts";
 import { createJobUserLogger, type Logger, serverLogger } from "veryfront/utils";
+import { writeJobResultIfConfigured } from "../../utils/write-job-result.ts";
 
 const SUPPORTED_EXTENSIONS = new Set([
   ".pdf",
@@ -635,6 +636,8 @@ export async function knowledgeCommand(args: ParsedArgs): Promise<void> {
             progress_current: results.length,
             progress_total: results.length,
           });
+
+          await writeJobResultIfConfigured(results);
 
           if (options.json) {
             printJson(results);

--- a/cli/commands/task/command.ts
+++ b/cli/commands/task/command.ts
@@ -9,6 +9,7 @@ import { cliLogger } from "#cli/utils";
 import { exitProcess } from "#cli/utils";
 import { withProjectSourceContext } from "#cli/shared/project-source-context";
 import { sanitizeJobOutputForLogging } from "../../utils/sanitize-job-output.ts";
+import { writeJobResultIfConfigured } from "../../utils/write-job-result.ts";
 import type { TaskArgs } from "./handler.ts";
 
 export interface TaskOptions extends TaskArgs {}
@@ -94,6 +95,7 @@ export async function taskCommand(options: TaskOptions): Promise<void> {
       if (result.success) {
         cliLogger.info(`Task completed in ${result.durationMs}ms`);
         if (result.result !== undefined) {
+          await writeJobResultIfConfigured(result.result);
           cliLogger.info(
             `Result: ${JSON.stringify(sanitizeJobOutputForLogging(result.result), null, 2)}`,
           );

--- a/cli/commands/workflow/command.ts
+++ b/cli/commands/workflow/command.ts
@@ -2,6 +2,7 @@ import { cliLogger } from "#cli/utils";
 import { exitProcess } from "#cli/utils";
 import { withProjectSourceContext } from "#cli/shared/project-source-context";
 import { sanitizeJobOutputForLogging } from "../../utils/sanitize-job-output.ts";
+import { writeJobResultIfConfigured } from "../../utils/write-job-result.ts";
 import { getEnv } from "veryfront/platform";
 import type { WorkflowArgs } from "./handler.ts";
 
@@ -44,6 +45,7 @@ async function waitForWorkflowExit(
     if (run.status === "completed") {
       cliLogger.info(`Workflow completed: ${runId}`);
       if (run.output !== undefined) {
+        await writeJobResultIfConfigured(run.output);
         cliLogger.info(
           `Result: ${JSON.stringify(sanitizeJobOutputForLogging(run.output), null, 2)}`,
         );

--- a/cli/utils/write-job-result.test.ts
+++ b/cli/utils/write-job-result.test.ts
@@ -1,0 +1,47 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { deleteEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import { writeJobResultIfConfigured } from "./write-job-result.ts";
+
+const JOB_RESULT_PATH_ENV = "VERYFRONT_JOB_RESULT_PATH";
+
+afterEach(() => {
+  try {
+    deleteEnv(JOB_RESULT_PATH_ENV);
+  } catch {
+    // env may already be unset
+  }
+});
+
+describe("writeJobResultIfConfigured", () => {
+  it("does nothing when no result path is configured", async () => {
+    await writeJobResultIfConfigured({ ok: true });
+  });
+
+  it("writes sanitized structured job output to the configured path", async () => {
+    const tempDir = await Deno.makeTempDir({ prefix: "veryfront-job-result-" });
+    const resultPath = `${tempDir}/job-result.json`;
+
+    try {
+      setEnv(JOB_RESULT_PATH_ENV, resultPath);
+
+      await writeJobResultIfConfigured({
+        ok: true,
+        nested: {
+          _tenant: { token: "secret" },
+          count: 3,
+        },
+      });
+
+      const raw = await Deno.readTextFile(resultPath);
+      assertEquals(JSON.parse(raw), {
+        ok: true,
+        nested: {
+          count: 3,
+        },
+      });
+    } finally {
+      await Deno.remove(tempDir, { recursive: true }).catch(() => undefined);
+    }
+  });
+});

--- a/cli/utils/write-job-result.ts
+++ b/cli/utils/write-job-result.ts
@@ -1,0 +1,22 @@
+import { dirname } from "veryfront/platform/path";
+import { sanitizeJobOutputForLogging } from "./sanitize-job-output.ts";
+
+const JOB_RESULT_PATH_ENV = "VERYFRONT_JOB_RESULT_PATH";
+
+function getJobResultPath(): string | null {
+  const value = Deno.env.get(JOB_RESULT_PATH_ENV)?.trim();
+  return value ? value : null;
+}
+
+export async function writeJobResultIfConfigured(value: unknown): Promise<void> {
+  const resultPath = getJobResultPath();
+  if (!resultPath) {
+    return;
+  }
+
+  await Deno.mkdir(dirname(resultPath), { recursive: true });
+  await Deno.writeTextFile(
+    resultPath,
+    JSON.stringify(sanitizeJobOutputForLogging(value), null, 2),
+  );
+}

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/jobs/jobs-client.test.ts
+++ b/src/jobs/jobs-client.test.ts
@@ -261,6 +261,38 @@ describe("VeryfrontJobsClient", () => {
     assertEquals(headerValue(0, "Authorization"), "Bearer env-token");
   });
 
+  it("parses generic structured job values", async () => {
+    mockFetch([
+      jsonResponse(
+        makeJob({
+          result: {
+            kind: "value",
+            value: {
+              ok: true,
+              count: 3,
+            },
+          },
+        }),
+      ),
+    ]);
+
+    const client = new VeryfrontJobsClient({
+      apiUrl: "https://api.test.com",
+      authToken: "test-token",
+      projectReference: "dreamy-haven",
+    });
+
+    const job = await client.get("11111111-1111-4111-8111-111111111111");
+
+    assertEquals(job.result, {
+      kind: "value",
+      value: {
+        ok: true,
+        count: 3,
+      },
+    });
+  });
+
   it("returns canonical job events", async () => {
     mockFetch([
       jsonResponse({

--- a/src/jobs/schemas.ts
+++ b/src/jobs/schemas.ts
@@ -40,6 +40,10 @@ export const JobResultSchema = z
       files: z.array(KnowledgeIngestFileResultSchema),
     }),
     z.object({
+      kind: z.literal("value"),
+      value: z.unknown(),
+    }),
+    z.object({
       kind: z.literal("artifacts"),
       artifacts: z.array(z.unknown()),
     }),


### PR DESCRIPTION
## Summary
- write sanitized structured result payloads to `VERYFRONT_JOB_RESULT_PATH` for task, workflow, and knowledge commands
- restore the shared output sanitizer and add generic `kind: "value"` job result support in the jobs client
- bump `deno.json` to `0.1.80` so the framework release publishes the runtime change

## Testing
- deno test --allow-env --allow-read --allow-write cli/utils/write-job-result.test.ts src/jobs/jobs-client.test.ts
- deno task verify:quick