### PR TITLE
fix: preserve protected preview auth for browser tokens

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -747,6 +747,60 @@ describe("Proxy Handler", () => {
       }
     });
 
+    it("falls back to /me when protected preview auth token cannot be verified locally", async () => {
+      const memberToken = "opaque-preview-token";
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") return createTokenResponse();
+
+        if (pathname === "/me") {
+          return Response.json({ id: "user-123" });
+        }
+
+        if (pathname.startsWith("/projects/")) {
+          return Response.json({
+            id: "proj-123",
+            slug: "protected-project",
+            name: "Protected Project",
+            users: [{ id: "user-123" }],
+            environments: [{
+              id: "env-1",
+              name: "preview",
+              active_release_id: "rel-123",
+              protected: true,
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+
+        const req = new Request(
+          "http://protected-project.preview.veryfront.com/page",
+          {
+            headers: {
+              host: "protected-project.preview.veryfront.com",
+              cookie: `authToken=${memberToken}`,
+            },
+          },
+        );
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error, undefined);
+        assertEquals(ctx.projectSlug, "protected-project");
+        assertEquals(ctx.environmentId, "env-1");
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
     it("returns 403 for protected preview domain when authenticated user is not a member", async () => {
       const nonMemberToken = await createFakeJwt("other-user");
       const { server, port } = createMockServer((req: Request) => {

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -755,6 +755,7 @@ describe("Proxy Handler", () => {
         if (pathname === "/auth/token") return createTokenResponse();
 
         if (pathname === "/me") {
+          assertEquals(req.headers.get("authorization"), `Bearer ${memberToken}`);
           return Response.json({ id: "user-123" });
         }
 
@@ -853,10 +854,16 @@ describe("Proxy Handler", () => {
     it("redirects to sign-in for protected domain when JWT token is forged", async () => {
       const forgedToken =
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJ1c2VyLTEyMyJ9.invalid-signature";
+      let currentUserLookupCount = 0;
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);
 
         if (pathname === "/auth/token") return createTokenResponse();
+
+        if (pathname === "/me") {
+          currentUserLookupCount += 1;
+          return Response.json({ id: "user-123" });
+        }
 
         if (pathname.startsWith("/projects/")) {
           return Response.json({
@@ -895,6 +902,7 @@ describe("Proxy Handler", () => {
           ctx.error?.redirectUrl,
           "https://veryfront.com/sign-in?from=%2Fpage",
         );
+        assertEquals(currentUserLookupCount, 0);
 
         await handler.close();
       } finally {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -36,6 +36,10 @@ interface DomainLookupResult {
   }>;
 }
 
+interface CurrentUserResult {
+  id?: string;
+}
+
 async function lookupProjectByDomain(
   domain: string,
   apiBaseUrl: string,
@@ -97,6 +101,48 @@ async function lookupProjectByDomain(
   );
 }
 
+async function lookupCurrentUserId(
+  apiBaseUrl: string,
+  token: string,
+  logger?: ProxyLogger,
+): Promise<string | undefined> {
+  return withSpan(
+    ProxySpanNames.HTTP_CLIENT_FETCH,
+    async () => {
+      const url = `${apiBaseUrl}/me`;
+
+      const headers = new Headers({
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+      });
+      injectContext(headers);
+
+      try {
+        const response = await fetch(url, { headers });
+        if (!response.ok) {
+          await response.body?.cancel();
+          logger?.debug("Current user lookup was not authorized", {
+            status: response.status,
+            statusText: response.statusText,
+          });
+          return undefined;
+        }
+
+        const result = (await response.json()) as CurrentUserResult;
+        return typeof result.id === "string" && result.id ? result.id : undefined;
+      } catch (error) {
+        logger?.error("Current user lookup failed", error as Error);
+        return undefined;
+      }
+    },
+    {
+      "http.method": "GET",
+      "http.url": `${apiBaseUrl}/me`,
+      "http.host": new URL(apiBaseUrl).host,
+    },
+  );
+}
+
 export interface ProxyConfig {
   apiBaseUrl: string;
   apiClientId: string;
@@ -153,27 +199,29 @@ function extractUserToken(cookieHeader: string): string | undefined {
 
 async function extractUserIdFromToken(
   token: string,
+  apiBaseUrl: string,
   log?: ProxyLogger,
 ): Promise<string | undefined> {
   const jwtSecret = getEnv("JWT_SECRET");
 
-  if (!jwtSecret) {
-    log?.warn("JWT_SECRET not configured — cannot verify user token");
-    return undefined;
+  if (jwtSecret) {
+    try {
+      const secret = new TextEncoder().encode(jwtSecret);
+      const { payload } = await jwtVerify(token, secret, {
+        algorithms: ["HS256"],
+      });
+      const userId = (payload as { userId?: string }).userId;
+      if (userId) return userId;
+    } catch (error) {
+      log?.debug("JWT verification failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  } else {
+    log?.debug("JWT_SECRET not configured — falling back to current user lookup");
   }
 
-  try {
-    const secret = new TextEncoder().encode(jwtSecret);
-    const { payload } = await jwtVerify(token, secret, {
-      algorithms: ["HS256"],
-    });
-    return (payload as { userId?: string }).userId;
-  } catch (error) {
-    log?.debug("JWT verification failed", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return undefined;
-  }
+  return lookupCurrentUserId(apiBaseUrl, token, log);
 }
 
 function isProjectMember(
@@ -303,7 +351,11 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
       return { status: 302, message: "Authentication required", redirectUrl };
     }
 
-    const userId = await extractUserIdFromToken(userToken, logger);
+    const userId = await extractUserIdFromToken(
+      userToken,
+      config.apiBaseUrl,
+      logger,
+    );
     if (!userId) {
       const redirectUrl = makeAuthRedirectUrl(req);
       logger?.info("Could not extract userId from token", {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -40,6 +40,14 @@ interface CurrentUserResult {
   id?: string;
 }
 
+function getUrlHost(url: string): string | undefined {
+  try {
+    return new URL(url).host;
+  } catch {
+    return undefined;
+  }
+}
+
 async function lookupProjectByDomain(
   domain: string,
   apiBaseUrl: string,
@@ -106,11 +114,12 @@ async function lookupCurrentUserId(
   token: string,
   logger?: ProxyLogger,
 ): Promise<string | undefined> {
+  const url = `${apiBaseUrl}/me`;
+  const httpHost = getUrlHost(apiBaseUrl);
+
   return withSpan(
     ProxySpanNames.HTTP_CLIENT_FETCH,
     async () => {
-      const url = `${apiBaseUrl}/me`;
-
       const headers = new Headers({
         Authorization: `Bearer ${token}`,
         Accept: "application/json",
@@ -121,10 +130,17 @@ async function lookupCurrentUserId(
         const response = await fetch(url, { headers });
         if (!response.ok) {
           await response.body?.cancel();
-          logger?.debug("Current user lookup was not authorized", {
-            status: response.status,
-            statusText: response.statusText,
-          });
+          if (response.status === 401 || response.status === 403) {
+            logger?.debug("Current user lookup was not authorized", {
+              status: response.status,
+              statusText: response.statusText,
+            });
+          } else {
+            logger?.warn("Current user lookup returned unexpected status", {
+              status: response.status,
+              statusText: response.statusText,
+            });
+          }
           return undefined;
         }
 
@@ -137,8 +153,8 @@ async function lookupCurrentUserId(
     },
     {
       "http.method": "GET",
-      "http.url": `${apiBaseUrl}/me`,
-      "http.host": new URL(apiBaseUrl).host,
+      "http.url": url,
+      "http.host": httpHost ?? apiBaseUrl,
     },
   );
 }
@@ -201,6 +217,7 @@ async function extractUserIdFromToken(
   token: string,
   apiBaseUrl: string,
   log?: ProxyLogger,
+  allowCurrentUserLookup = false,
 ): Promise<string | undefined> {
   const jwtSecret = getEnv("JWT_SECRET");
 
@@ -217,9 +234,11 @@ async function extractUserIdFromToken(
         error: error instanceof Error ? error.message : String(error),
       });
     }
-  } else {
+  } else if (allowCurrentUserLookup) {
     log?.debug("JWT_SECRET not configured — falling back to current user lookup");
   }
+
+  if (!allowCurrentUserLookup) return undefined;
 
   return lookupCurrentUserId(apiBaseUrl, token, log);
 }
@@ -338,6 +357,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     userToken: string | undefined,
     users: DomainLookupResult["users"],
     logContext: Record<string, unknown>,
+    allowCurrentUserLookup = false,
   ): Promise<{ status: number; message: string; redirectUrl?: string } | null> {
     if (!matchingEnv?.protected) return null;
 
@@ -355,6 +375,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
       userToken,
       config.apiBaseUrl,
       logger,
+      allowCurrentUserLookup,
     );
     if (!userId) {
       const redirectUrl = makeAuthRedirectUrl(req);
@@ -384,6 +405,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     lookupKey: string,
     envMatcher: (env: NonNullable<DomainLookupResult["environments"]>[number]) => boolean,
     logContext: Record<string, unknown>,
+    allowCurrentUserLookup = false,
   ): Promise<
     | { projectId?: string; releaseId?: string; environmentId?: string }
     | { error: { status: number; message: string; redirectUrl?: string } }
@@ -399,6 +421,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
       userToken,
       lookupResult.users,
       logContext,
+      allowCurrentUserLookup,
     );
     if (protectionError) return { error: protectionError };
 
@@ -507,6 +530,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
           userToken,
           lookupResult.users,
           { domain: host },
+          false,
         );
         if (protectionError) {
           return makeErrorContext(
@@ -535,6 +559,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
           projectSlug,
           (env) => env.name.toLowerCase() === targetEnv,
           { projectSlug },
+          false,
         );
 
         if ("error" in resolved) {
@@ -568,6 +593,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
           projectSlug,
           (env) => env.name.toLowerCase() === "preview",
           { projectSlug },
+          true,
         );
 
         if ("error" in resolved) {

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,6 +1,6 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.59";
+export const VERSION = "0.1.81";
 
 export const SERVER_START_TIME: number = Date.now();
 


### PR DESCRIPTION
## Summary
- fall back to `/me` only for protected preview requests when the proxy cannot locally resolve a `userId` from the browser `authToken`
- keep protected production and custom-domain behavior unchanged when local verification fails
- add regressions for forwarding the preview bearer token to `/me` and for skipping that fallback outside preview

## Context
- authenticated preview requests were redirecting to sign-in even when the browser sent `authToken`
- protected preview access was trying to derive `userId` from local HS256 verification, but browser user tokens are not always locally verifiable by the proxy
- once local verification failed, the proxy treated those preview requests as unauthenticated even though the API could still resolve the current user

## Test Plan
- [x] `deno test -A src/proxy/handler.test.ts`
- [x] `deno fmt --check src/proxy/handler.ts src/proxy/handler.test.ts`
- [x] pre-commit `verify:quick` hook during `git commit` (generate, fmt, lint, docs validate, typecheck)
