### PR TITLE
fix: verify browser auth tokens via api jwks

### DIFF
--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -69,10 +69,10 @@ async function createRs256Jwt(userId: string): Promise<{
   };
 }
 
-function createHandler(port: number) {
+function createHandler(port: number, apiBasePath = "") {
   return createProxyHandler({
     config: {
-      apiBaseUrl: `http://127.0.0.1:${port}`,
+      apiBaseUrl: `http://127.0.0.1:${port}${apiBasePath}`,
       apiClientId: "test-client",
       apiClientSecret: "test-secret",
       previewApiClientId: "test-client",
@@ -837,6 +837,70 @@ describe("Proxy Handler", () => {
         assertEquals(ctx.projectSlug, "protected-project");
         assertEquals(ctx.environmentId, "env-1");
         assertEquals(jwksRequestCount, 1);
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
+    it("preserves a path-prefixed API base when resolving JWKS", async () => {
+      const { token: memberToken, jwks } = await createRs256Jwt("user-123");
+      let prefixedJwksRequestCount = 0;
+      let rootJwksRequestCount = 0;
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/api/auth/token") return createTokenResponse();
+
+        if (pathname === "/api/.well-known/jwks.json") {
+          prefixedJwksRequestCount += 1;
+          return Response.json(jwks);
+        }
+
+        if (pathname === "/.well-known/jwks.json") {
+          rootJwksRequestCount += 1;
+          return createNotFoundResponse();
+        }
+
+        if (pathname.startsWith("/api/projects/")) {
+          return Response.json({
+            id: "proj-123",
+            slug: "protected-project",
+            name: "Protected Project",
+            users: [{ id: "user-123" }],
+            environments: [{
+              id: "env-1",
+              name: "preview",
+              active_release_id: "rel-123",
+              protected: true,
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port, "/api");
+
+        const req = new Request(
+          "http://protected-project.preview.veryfront.com/page",
+          {
+            headers: {
+              host: "protected-project.preview.veryfront.com",
+              cookie: `authToken=${memberToken}`,
+            },
+          },
+        );
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error, undefined);
+        assertEquals(ctx.projectSlug, "protected-project");
+        assertEquals(ctx.environmentId, "env-1");
+        assertEquals(prefixedJwksRequestCount, 1);
+        assertEquals(rootJwksRequestCount, 0);
 
         await handler.close();
       } finally {

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import { createMockServer } from "../../tests/_helpers/utils.ts";
 import { createProxyHandler, injectContextHeaders, type ProxyContext } from "./handler.ts";
-import { SignJWT } from "jose";
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
 
 const TEST_JWT_SECRET = "test-jwt-secret-for-proxy-handler-tests";
 
@@ -27,6 +27,46 @@ async function createFakeJwt(userId: string): Promise<string> {
     .setProtectedHeader({ alg: "HS256" })
     .setExpirationTime("1h")
     .sign(secret);
+}
+
+async function createRs256Jwt(userId: string): Promise<{
+  token: string;
+  jwks: {
+    keys: Array<{
+      alg: "RS256";
+      e: string;
+      kid: string;
+      kty: "RSA";
+      n: string;
+      use: "sig";
+    }>;
+  };
+}> {
+  const kid = "test-rs256-key";
+  const { privateKey, publicKey } = await generateKeyPair("RS256");
+  const token = await new SignJWT({ userId })
+    .setProtectedHeader({ alg: "RS256", kid })
+    .setExpirationTime("1h")
+    .sign(privateKey);
+  const exported = await exportJWK(publicKey);
+
+  if (exported.kty !== "RSA" || !exported.n || !exported.e) {
+    throw new Error("Expected RSA public JWK");
+  }
+
+  return {
+    token,
+    jwks: {
+      keys: [{
+        alg: "RS256",
+        e: exported.e,
+        kid,
+        kty: "RSA",
+        n: exported.n,
+        use: "sig",
+      }],
+    },
+  };
 }
 
 function createHandler(port: number) {
@@ -740,6 +780,63 @@ describe("Proxy Handler", () => {
         assertEquals(ctx.error, undefined);
         assertEquals(ctx.projectSlug, "protected-project");
         assertEquals(ctx.environmentId, "env-1");
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
+    it("allows access to protected preview domain with RS256 auth token verified via JWKS", async () => {
+      const { token: memberToken, jwks } = await createRs256Jwt("user-123");
+      let jwksRequestCount = 0;
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") return createTokenResponse();
+
+        if (pathname === "/.well-known/jwks.json") {
+          jwksRequestCount += 1;
+          return Response.json(jwks);
+        }
+
+        if (pathname.startsWith("/projects/")) {
+          return Response.json({
+            id: "proj-123",
+            slug: "protected-project",
+            name: "Protected Project",
+            users: [{ id: "user-123" }],
+            environments: [{
+              id: "env-1",
+              name: "preview",
+              active_release_id: "rel-123",
+              protected: true,
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+
+        const req = new Request(
+          "http://protected-project.preview.veryfront.com/page",
+          {
+            headers: {
+              host: "protected-project.preview.veryfront.com",
+              cookie: `authToken=${memberToken}`,
+            },
+          },
+        );
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error, undefined);
+        assertEquals(ctx.projectSlug, "protected-project");
+        assertEquals(ctx.environmentId, "env-1");
+        assertEquals(jwksRequestCount, 1);
 
         await handler.close();
       } finally {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -6,7 +6,7 @@ import { cwd, getEnv } from "#veryfront/platform/compat/process.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { injectContext, ProxySpanNames, withSpan } from "./tracing.ts";
 import { computeContentSourceId } from "#veryfront/cache/keys.ts";
-import { jwtVerify } from "jose";
+import { createRemoteJWKSet, decodeProtectedHeader, jwtVerify } from "jose";
 
 export const INTERNAL_PROXY_HEADERS = [
   "x-token",
@@ -34,6 +34,28 @@ interface DomainLookupResult {
     active_release_id?: string | null;
     protected?: boolean;
   }>;
+}
+
+const remoteJwksByUrl = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
+
+function getApiJwks(apiBaseUrl: string, logger?: ProxyLogger) {
+  try {
+    const jwksUrl = new URL("/.well-known/jwks.json", apiBaseUrl);
+    const cacheKey = jwksUrl.toString();
+    let jwks = remoteJwksByUrl.get(cacheKey);
+
+    if (!jwks) {
+      jwks = createRemoteJWKSet(jwksUrl);
+      remoteJwksByUrl.set(cacheKey, jwks);
+    }
+
+    return jwks;
+  } catch (error) {
+    logger?.error("Invalid API base URL for JWKS lookup", error as Error, {
+      apiBaseUrl,
+    });
+    return undefined;
+  }
 }
 
 async function lookupProjectByDomain(
@@ -153,8 +175,42 @@ function extractUserToken(cookieHeader: string): string | undefined {
 
 async function extractUserIdFromToken(
   token: string,
+  apiBaseUrl: string,
   log?: ProxyLogger,
 ): Promise<string | undefined> {
+  let algorithm: string | undefined;
+
+  try {
+    algorithm = decodeProtectedHeader(token).alg;
+  } catch (error) {
+    log?.debug("Failed to decode JWT header", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+
+  if (algorithm === "RS256") {
+    const jwks = getApiJwks(apiBaseUrl, log);
+    if (!jwks) return undefined;
+
+    try {
+      const { payload } = await jwtVerify(token, jwks, {
+        algorithms: ["RS256"],
+      });
+      return (payload as { userId?: string }).userId;
+    } catch (error) {
+      log?.debug("RS256 JWT verification failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
+
+  if (algorithm !== "HS256") {
+    log?.debug("Unsupported JWT algorithm", { algorithm: algorithm ?? null });
+    return undefined;
+  }
+
   const jwtSecret = getEnv("JWT_SECRET");
 
   if (!jwtSecret) {
@@ -303,7 +359,11 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
       return { status: 302, message: "Authentication required", redirectUrl };
     }
 
-    const userId = await extractUserIdFromToken(userToken, logger);
+    const userId = await extractUserIdFromToken(
+      userToken,
+      config.apiBaseUrl,
+      logger,
+    );
     if (!userId) {
       const redirectUrl = makeAuthRedirectUrl(req);
       logger?.info("Could not extract userId from token", {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -40,7 +40,8 @@ const remoteJwksByUrl = new Map<string, ReturnType<typeof createRemoteJWKSet>>()
 
 function getApiJwks(apiBaseUrl: string, logger?: ProxyLogger) {
   try {
-    const jwksUrl = new URL("/.well-known/jwks.json", apiBaseUrl);
+    const normalizedBaseUrl = apiBaseUrl.endsWith("/") ? apiBaseUrl : `${apiBaseUrl}/`;
+    const jwksUrl = new URL(".well-known/jwks.json", normalizedBaseUrl);
     const cacheKey = jwksUrl.toString();
     let jwks = remoteJwksByUrl.get(cacheKey);
 


### PR DESCRIPTION
## Summary
- verify browser `authToken` JWTs against the API JWKS instead of relying on local HS256-only validation
- preserve protected preview access for API-issued `RS256` user tokens
- add a proxy regression proving protected preview auth succeeds via `/.well-known/jwks.json`

## Context
- API user tokens are signed as `RS256`
- the proxy on `main` only verified `HS256` user tokens with `JWT_SECRET`
- protected preview requests with valid browser auth cookies were therefore being downgraded to unauthenticated and redirected to sign-in

## Evidence
- live JWKS check: `curl -I https://api.veryfront.com/.well-known/jwks.json` returned `HTTP/2 200` with `Cache-Control: public, max-age=300`
- live JWKS body check confirmed an RSA signing key with `alg=RS256`, `use=sig`, `kid`, `n`, and `e`
- local crypto verification using the API test RSA keypair and a JWKS document succeeded for an `RS256` user token
- red-green proxy regression:
  - before the fix, `allows access to protected preview domain with RS256 auth token verified via JWKS` failed with `302 Authentication required`
  - after the fix, it passes and confirms the proxy fetches `/.well-known/jwks.json`

## Test Plan
- [x] `deno test -A src/proxy/handler.test.ts`
- [x] `deno fmt --check src/proxy/handler.ts src/proxy/handler.test.ts`
- [x] pre-commit `verify:quick` hook during `git commit` (generate, fmt, lint, docs validate, typecheck)

## Notes
- supersedes #667, which used a `/me` fallback; this PR replaces that approach with direct JWT verification against JWKS
