### PR TITLE
chore: bump version to 0.1.81

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [


### PR DESCRIPTION
## Summary
- bump `deno.json` from `0.1.80` to `0.1.81`
- trigger the stable release workflow on `main`
- trigger downstream production deploy dispatch for `veryfront-server`

## Context
- PR #668 fixed the proxy JWKS verification issue, but the release/deploy pipeline is gated on the version in `deno.json`
- `.github/workflows/cicd.yml` only dispatches `veryfront-server` from the `release`/`prerelease` jobs after a versioned merge to `main`

## Verification
- [x] local pre-commit `verify:quick` passed during commit
- [x] branch push succeeded
- [ ] merge this PR to start the stable release + deploy path