### PR TITLE
fix: avoid preview re-transform on missing bundle manifest

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/rendering/orchestrator/module-loader/index.ts
+++ b/src/rendering/orchestrator/module-loader/index.ts
@@ -21,8 +21,7 @@ import {
   setCachedTransformAsync,
 } from "#veryfront/transforms/esm/transform-cache.ts";
 import { TRANSFORM_DISTRIBUTED_TTL_SEC } from "#veryfront/utils/constants/cache.ts";
-import { ensureHttpBundlesExist } from "#veryfront/transforms/esm/http-cache.ts";
-import { validateBundleGroup } from "#veryfront/transforms/esm/bundle-manifest.ts";
+import { validateCachedBundlesByManifestOrCode } from "#veryfront/transforms/esm/cached-bundle-validation.ts";
 import { getHttpBundleCacheDir, getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { dirname, join, normalize } from "#veryfront/compat/path/index.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
@@ -32,7 +31,6 @@ import {
   lookupMdxEsmCache,
   saveModulePathCache,
 } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
-import { extractHttpBundlePaths } from "#veryfront/modules/react-loader/ssr-module-loader/http-bundle-helpers.ts";
 
 const logger = rendererLogger.component("module-loader");
 
@@ -344,27 +342,21 @@ export async function transformModuleWithDeps(
   const cacheDir = getHttpBundleCacheDir();
   let bundlesValid = true;
 
-  if (transformResult.cacheHit && transformResult.bundleManifestId) {
-    const validation = await validateBundleGroup(transformResult.bundleManifestId, cacheDir);
+  if (transformResult.cacheHit) {
+    const validation = await validateCachedBundlesByManifestOrCode(
+      transformedCode,
+      transformResult.bundleManifestId,
+      cacheDir,
+    );
     if (!validation.valid) {
-      logger.warn("Bundle manifest validation failed, re-transforming", {
+      logger.warn("Cached HTTP bundle validation failed, re-transforming", {
         filePath,
-        manifestId: transformResult.bundleManifestId.slice(0, 12),
+        manifestId: transformResult.bundleManifestId?.slice(0, 12),
         failedHashes: validation.failedHashes,
+        reason: validation.reason,
+        source: validation.source,
       });
       bundlesValid = false;
-    }
-  } else {
-    const bundlePaths = extractHttpBundlePaths(transformedCode);
-    if (bundlePaths.length > 0) {
-      const failed = await ensureHttpBundlesExist(bundlePaths, cacheDir);
-      if (failed.length > 0) {
-        logger.warn("HTTP bundle recovery failed, re-transforming", {
-          filePath,
-          failed,
-        });
-        bundlesValid = false;
-      }
     }
   }
 

--- a/src/transforms/esm/bundle-manifest.test.ts
+++ b/src/transforms/esm/bundle-manifest.test.ts
@@ -94,6 +94,7 @@ describe("Bundle Manifest", { sanitizeResources: false, sanitizeOps: false }, ()
 
       assertEquals(result.valid, false);
       assertEquals(result.failedHashes.length, 0);
+      assertEquals(result.reason, "manifest_missing");
     });
   });
 });

--- a/src/transforms/esm/bundle-manifest.ts
+++ b/src/transforms/esm/bundle-manifest.ts
@@ -38,10 +38,13 @@ interface BundleManifest {
   ttlSeconds: number;
 }
 
+export type ManifestValidationReason = "manifest_missing" | "bundle_missing";
+
 /** Result of manifest validation. */
-interface ManifestValidationResult {
+export interface ManifestValidationResult {
   valid: boolean;
   failedHashes: string[];
+  reason?: ManifestValidationReason;
 }
 
 /**
@@ -148,7 +151,7 @@ export async function validateBundleGroup(
     logger.debug(`${LOG_PREFIX} Manifest not found in distributed cache`, {
       manifestId: manifestId.slice(0, 12),
     });
-    return { valid: false, failedHashes: [] };
+    return { valid: false, failedHashes: [], reason: "manifest_missing" };
   }
 
   const missingBundles: Array<{ path: string; hash: string }> = [];
@@ -178,7 +181,7 @@ export async function validateBundleGroup(
       manifestId: manifestId.slice(0, 12),
       unrecoverable: unrecoverableHashes,
     });
-    return { valid: false, failedHashes: unrecoverableHashes };
+    return { valid: false, failedHashes: unrecoverableHashes, reason: "bundle_missing" };
   }
 
   logger.info(`${LOG_PREFIX} All missing bundles recovered successfully`, {

--- a/src/transforms/esm/cached-bundle-validation.test.ts
+++ b/src/transforms/esm/cached-bundle-validation.test.ts
@@ -1,0 +1,47 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { join } from "#veryfront/compat/path/index.ts";
+import { makeTempDir, remove, writeTextFile } from "#veryfront/testing/deno-compat.ts";
+import { validateCachedBundlesByManifestOrCode } from "./cached-bundle-validation.ts";
+
+describe("validateCachedBundlesByManifestOrCode", () => {
+  async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+    const dir = await makeTempDir({ prefix: "vf-cached-bundle-validation-" });
+    try {
+      await fn(dir);
+    } finally {
+      await remove(dir, { recursive: true });
+    }
+  }
+
+  it("falls back to code validation when the manifest is missing", async () => {
+    await withTempDir(async (cacheDir) => {
+      await writeTextFile(join(cacheDir, "http-111111.mjs"), "export const a = 1;");
+
+      const result = await validateCachedBundlesByManifestOrCode(
+        'import "./http-111111.mjs";',
+        "missing-manifest-id",
+        cacheDir,
+      );
+
+      assertEquals(result.valid, true);
+      assertEquals(result.source, "code");
+      assertEquals(result.failedHashes, []);
+    });
+  });
+
+  it("returns bundle_missing when code fallback cannot recover bundles", async () => {
+    await withTempDir(async (cacheDir) => {
+      const result = await validateCachedBundlesByManifestOrCode(
+        'import "./http-222222.mjs";',
+        "missing-manifest-id",
+        cacheDir,
+      );
+
+      assertEquals(result.valid, false);
+      assertEquals(result.source, "code");
+      assertEquals(result.reason, "bundle_missing");
+      assertEquals(result.failedHashes, ["222222"]);
+    });
+  });
+});

--- a/src/transforms/esm/cached-bundle-validation.ts
+++ b/src/transforms/esm/cached-bundle-validation.ts
@@ -1,0 +1,40 @@
+import { extractHttpBundlePaths } from "#veryfront/modules/react-loader/ssr-module-loader/http-bundle-helpers.ts";
+import { ensureHttpBundlesExist } from "./http-cache.ts";
+import { type ManifestValidationReason, validateBundleGroup } from "./bundle-manifest.ts";
+
+export interface CachedBundleValidationResult {
+  valid: boolean;
+  failedHashes: string[];
+  reason?: ManifestValidationReason;
+  source: "manifest" | "code";
+}
+
+export async function validateCachedBundlesByManifestOrCode(
+  code: string,
+  bundleManifestId: string | undefined,
+  cacheDir: string,
+): Promise<CachedBundleValidationResult> {
+  if (bundleManifestId) {
+    const validation = await validateBundleGroup(bundleManifestId, cacheDir);
+    if (validation.valid || validation.reason === "bundle_missing") {
+      return { ...validation, source: "manifest" };
+    }
+  }
+
+  const bundlePaths = extractHttpBundlePaths(code);
+  if (bundlePaths.length === 0) {
+    return { valid: true, failedHashes: [], source: "code" };
+  }
+
+  const failedHashes = await ensureHttpBundlesExist(bundlePaths, cacheDir);
+  if (failedHashes.length === 0) {
+    return { valid: true, failedHashes: [], source: "code" };
+  }
+
+  return {
+    valid: false,
+    failedHashes,
+    reason: "bundle_missing",
+    source: "code",
+  };
+}

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts
@@ -9,14 +9,11 @@
 
 import type { Logger } from "#veryfront/utils/logger/logger.ts";
 import { detokenizeAllCachePaths, tokenizeAllVeryFrontPaths } from "#veryfront/cache";
-import { cacheHttpImportsToLocal, ensureHttpBundlesExist } from "../../../esm/http-cache.ts";
+import { cacheHttpImportsToLocal } from "../../../esm/http-cache.ts";
 import { loadImportMap } from "#veryfront/modules/import-map/index.ts";
 import { extractHttpBundlePaths } from "#veryfront/modules/react-loader/ssr-module-loader/http-bundle-helpers.ts";
-import {
-  createBundleManifest,
-  storeBundleManifest,
-  validateBundleGroup,
-} from "../../../esm/bundle-manifest.ts";
+import { createBundleManifest, storeBundleManifest } from "../../../esm/bundle-manifest.ts";
+import { validateCachedBundlesByManifestOrCode } from "../../../esm/cached-bundle-validation.ts";
 import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { FRAMEWORK_ROOT, LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 import { getDistributedTransformBackend } from "#veryfront/transforms/esm/transform-cache.ts";
@@ -86,30 +83,22 @@ export async function readDistributedCache(
     const bundleManifestKey = `${transformCacheKey}:bm`;
     const manifestId = await distributedCache.get(bundleManifestKey).catch(() => null);
 
-    if (manifestId) {
+    if (moduleCode) {
       const cacheDir = getHttpBundleCacheDir();
-      const validation = await validateBundleGroup(manifestId, cacheDir);
+      const validation = await validateCachedBundlesByManifestOrCode(
+        moduleCode,
+        manifestId ?? undefined,
+        cacheDir,
+      );
       if (!validation.valid) {
-        log.warn(`${LOG_PREFIX_MDX_LOADER} Bundle manifest validation failed`, {
+        log.warn(`${LOG_PREFIX_MDX_LOADER} Cached HTTP bundle validation failed`, {
           normalizedPath,
-          manifestId: manifestId.slice(0, 12),
+          manifestId: manifestId?.slice(0, 12),
           failedHashes: validation.failedHashes,
+          reason: validation.reason,
+          source: validation.source,
         });
         moduleCode = null;
-      }
-    } else {
-      // Use detokenized code for bundle path extraction
-      const bundlePaths = extractHttpBundlePaths(moduleCode);
-      if (bundlePaths.length > 0) {
-        const cacheDir = getHttpBundleCacheDir();
-        const failed = await ensureHttpBundlesExist(bundlePaths, cacheDir);
-        if (failed.length > 0) {
-          log.warn(`${LOG_PREFIX_MDX_LOADER} Some HTTP bundles could not be recovered`, {
-            normalizedPath,
-            failed,
-          });
-          moduleCode = null;
-        }
       }
     }
 

--- a/src/transforms/pipeline/index.ts
+++ b/src/transforms/pipeline/index.ts
@@ -31,10 +31,8 @@ import {
   ssrVfModulesPlugin,
 } from "./stages/index.ts";
 import { createFileSystem, exists } from "#veryfront/platform/compat/fs.ts";
-import { ensureHttpBundlesExist } from "../esm/http-cache.ts";
-import { extractHttpBundlePaths } from "#veryfront/modules/react-loader/ssr-module-loader/http-bundle-helpers.ts";
 import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
-import { validateBundleGroup } from "../esm/bundle-manifest.ts";
+import { validateCachedBundlesByManifestOrCode } from "../esm/cached-bundle-validation.ts";
 import { extractFrameworkBundlePaths } from "../shared/framework-bundle-paths.ts";
 
 const SSR_PIPELINE: TransformPlugin[] = [
@@ -130,31 +128,15 @@ async function validateCachedBundles(
   cacheKey: string,
 ): Promise<boolean> {
   const cacheDir = getHttpBundleCacheDir();
+  const validation = await validateCachedBundlesByManifestOrCode(code, bundleManifestId, cacheDir);
+  if (validation.valid) return true;
 
-  // If we have a manifest ID, use the faster manifest-based validation
-  if (bundleManifestId) {
-    const validation = await validateBundleGroup(bundleManifestId, cacheDir);
-    if (validation.valid) return true;
-
-    logger.debug("Bundle manifest validation failed", {
-      cacheKey: cacheKey.slice(-40),
-      manifestId: bundleManifestId.slice(0, 12),
-      failedCount: validation.failedHashes.length,
-    });
-    return false;
-  }
-
-  // Fall back to extracting bundle paths from code and validating each
-  const bundlePaths = extractHttpBundlePaths(code);
-  if (bundlePaths.length === 0) return true;
-
-  const failed = await ensureHttpBundlesExist(bundlePaths, cacheDir);
-  if (failed.length === 0) return true;
-
-  logger.debug("HTTP bundle validation failed", {
+  logger.debug("Cached HTTP bundle validation failed", {
     cacheKey: cacheKey.slice(-40),
-    failedCount: failed.length,
-    totalBundles: bundlePaths.length,
+    manifestId: bundleManifestId?.slice(0, 12),
+    failedCount: validation.failedHashes.length,
+    reason: validation.reason,
+    source: validation.source,
   });
   return false;
 }


### PR DESCRIPTION
## Summary
- avoid synchronous re-transform when bundle manifest metadata is missing but cached bundles are still recoverable from code
- add an explicit manifest validation reason and reuse one cached-bundle validation path across the renderer/cache callers
- bump the package version to `0.1.82` for rollout

## Verification
- `deno test --allow-env --allow-read --allow-write src/transforms/esm/bundle-manifest.test.ts src/transforms/esm/cached-bundle-validation.test.ts src/modules/react-loader/ssr-module-loader/http-bundle-helpers.test.ts`
- `deno check src/transforms/esm/cached-bundle-validation.ts src/transforms/pipeline/index.ts src/rendering/orchestrator/module-loader/index.ts src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts`
- `deno fmt --check src/transforms/esm/bundle-manifest.ts src/transforms/esm/cached-bundle-validation.ts src/transforms/esm/cached-bundle-validation.test.ts src/transforms/pipeline/index.ts src/rendering/orchestrator/module-loader/index.ts src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts src/transforms/esm/bundle-manifest.test.ts`
- `deno lint src/transforms/esm/bundle-manifest.ts src/transforms/esm/cached-bundle-validation.ts src/transforms/esm/cached-bundle-validation.test.ts src/transforms/pipeline/index.ts src/rendering/orchestrator/module-loader/index.ts src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts src/transforms/esm/bundle-manifest.test.ts`