### PR TITLE
perf: reduce preview cold path filesystem work

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/platform/adapters/base.ts
+++ b/src/platform/adapters/base.ts
@@ -115,7 +115,11 @@ export interface FileSystemAdapter {
   makeTempDir(prefix: string): Promise<string>;
   watch(paths: string | string[], options?: WatchOptions): FileWatcher;
   /** Resolve a file path with extension fallback (e.g., pages/test → pages/test.mdx) */
-  resolveFile?(basePath: string): Promise<string | null>;
+  resolveFile?(basePath: string, options?: ResolveFileOptions): Promise<string | null>;
+}
+
+export interface ResolveFileOptions {
+  allowPagesPrefix?: boolean;
 }
 
 export interface DirEntry {

--- a/src/platform/adapters/fs/github/adapter.ts
+++ b/src/platform/adapters/fs/github/adapter.ts
@@ -1,6 +1,7 @@
 import { logger } from "#veryfront/utils";
 import { CONFIG_INVALID } from "#veryfront/errors";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
+import type { ResolveFileOptions } from "../../base.ts";
 import { FileCache } from "../cache/file-cache.ts";
 import type { FSAdapter, FSAdapterConfig } from "../veryfront/types.ts";
 import { GitHubApiClient } from "./github-api-client.ts";
@@ -115,9 +116,9 @@ export class GitHubFSAdapter implements FSAdapter {
     return this.dirOps.readdir(path);
   }
 
-  async resolveFile(basePath: string): Promise<string | null> {
+  async resolveFile(basePath: string, options?: ResolveFileOptions): Promise<string | null> {
     await this.ensureInitialized();
-    return this.statOps.resolveFile(basePath);
+    return this.statOps.resolveFile(basePath, options);
   }
 
   getCacheStats(): {

--- a/src/platform/adapters/fs/github/stat-operations.ts
+++ b/src/platform/adapters/fs/github/stat-operations.ts
@@ -5,6 +5,7 @@ import {
   buildGitHubStatCacheKey,
   buildGitHubTreeCacheKey,
 } from "#veryfront/cache";
+import type { ResolveFileOptions } from "../../base.ts";
 import type { FileCache } from "../cache/file-cache.ts";
 import type { GitHubApiClient } from "./github-api-client.ts";
 import type { FileIndexEntry, FileInfo, GitHubTreeEntry, ResolvedGitHubConfig } from "./types.ts";
@@ -176,7 +177,7 @@ export class GitHubStatOperations {
     }
   }
 
-  async resolveFile(basePath: string): Promise<string | null> {
+  async resolveFile(basePath: string, options?: ResolveFileOptions): Promise<string | null> {
     await this.ensureIndex();
 
     const normalizedPath = normalizeGitHubPath(basePath, this.projectDir);
@@ -185,7 +186,7 @@ export class GitHubStatOperations {
     if (cached !== undefined) return cached;
 
     const resolved = this.tryResolve(normalizedPath) ??
-      this.tryResolveWithPagesPrefix(normalizedPath);
+      (options?.allowPagesPrefix === false ? null : this.tryResolveWithPagesPrefix(normalizedPath));
 
     this.cache.set(cacheKey, resolved);
     return resolved;

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -9,7 +9,7 @@ import type {
   InvalidationCallbacks,
   ResolvedContentContext,
 } from "./types.ts";
-import type { FileInfo } from "../../base.ts";
+import type { FileInfo, ResolveFileOptions } from "../../base.ts";
 import { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
 import type { Project } from "../../veryfront-api-client/index.ts";
 import { FileCache } from "../cache/file-cache.ts";
@@ -141,6 +141,24 @@ export class VeryfrontFSAdapter implements FSAdapter {
         });
 
         return result;
+      },
+      hasCachedFileList: async () => {
+        if (!this.contentContext) {
+          logger.debug("hasCachedFileList: no contentContext");
+          return false;
+        }
+
+        const cacheKey = buildFileListCacheKey(this.contentContext);
+        const result = await this.cache.getAsync<Array<{ path: string }>>(cacheKey);
+        const hasResult = Array.isArray(result) && result.length > 0;
+
+        logger.debug("hasCachedFileList lookup", {
+          cacheKey,
+          hasResult,
+          resultSize: result?.length ?? 0,
+        });
+
+        return hasResult;
       },
       isPersistentCacheInvalidated: (prefix: string) => this.isPersistentCacheInvalidated(prefix),
       isReleaseBeingInvalidated: (releaseId: string) =>
@@ -410,9 +428,12 @@ export class VeryfrontFSAdapter implements FSAdapter {
     return this.statOps.exists(path);
   }
 
-  async resolveFile(basePath: string): Promise<string | null> {
+  async resolveFile(
+    basePath: string,
+    options?: ResolveFileOptions,
+  ): Promise<string | null> {
     await this.ensureInitialized();
-    return this.statOps.resolveFile(basePath);
+    return this.statOps.resolveFile(basePath, options);
   }
 
   dispose(): void {

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.ts
@@ -2,7 +2,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { logger as baseLogger } from "#veryfront/utils";
 import { INITIALIZATION_ERROR } from "#veryfront/errors";
 import type { DirectoryEntry, FSAdapter, FSAdapterConfig } from "./types.ts";
-import type { FileInfo } from "../../base.ts";
+import type { FileInfo, ResolveFileOptions } from "../../base.ts";
 import { ProxyFSAdapterManager } from "./proxy-manager.ts";
 import type { VeryfrontFSAdapter } from "./index.ts";
 import { runWithCacheBatching } from "#veryfront/cache/request-cache-batcher.ts";
@@ -213,9 +213,12 @@ export class MultiProjectFSAdapter implements FSAdapter {
     }
   }
 
-  async resolveFile(basePath: string): Promise<string | null> {
+  async resolveFile(
+    basePath: string,
+    options?: ResolveFileOptions,
+  ): Promise<string | null> {
     const adapter = await this.getAdapter();
-    return adapter.resolveFile(basePath);
+    return adapter.resolveFile(basePath, options);
   }
 
   dispose(): void {

--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -41,6 +41,7 @@ export interface ContentContextProvider {
       updated_at?: string;
     }> | undefined
   >;
+  hasCachedFileList?: () => Promise<boolean>;
   /** True if cache prefix is being deleted - skip persistent cache reads */
   isPersistentCacheInvalidated?: (prefix: string) => boolean;
   /** Back-compat: release-scoped invalidation */

--- a/src/platform/adapters/fs/veryfront/stat-operations.test.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.test.ts
@@ -36,6 +36,7 @@ function createBranchContextWithFiles(files: ProjectFile[]): ContentContextProvi
       branch: "main",
     }),
     getFileList: () => Promise.resolve(files),
+    hasCachedFileList: () => Promise.resolve(files.length > 0),
     isPersistentCacheInvalidated: () => false,
   };
 }
@@ -344,6 +345,16 @@ describe("StatOperations", () => {
       assertEquals(await statOps.resolveFile("pages/index"), "pages/index.tsx");
     });
 
+    it("should not add pages/ prefix when disabled for source resolution", async () => {
+      const statOps = createStatOps(
+        createMockClient(),
+        new PathNormalizer(),
+        createBranchContextWithFiles([makeFile("pages/about.tsx")]),
+      );
+
+      assertEquals(await statOps.resolveFile("about", { allowPagesPrefix: false }), null);
+    });
+
     it("should resolve with different extension when original not found", async () => {
       const statOps = createStatOps(
         createMockClient(),
@@ -412,6 +423,37 @@ describe("StatOperations", () => {
       assertEquals(await statOps.resolveFile("pages/about"), "pages/about.tsx");
       assertEquals(searchCallCount, 1);
       assertEquals(listAllFilesCallCount, 0);
+    });
+
+    it("should skip pages/ API search patterns when pages prefix is disabled", async () => {
+      const patterns: string[] = [];
+
+      const client = createMockClient({
+        searchFiles: (pattern: string) => {
+          patterns.push(pattern);
+          return Promise.resolve([]);
+        },
+      });
+
+      const statOps = new StatOperations(
+        client,
+        new FileCache({ enabled: true, ttl: 60_000, maxSize: 100 }),
+        new PathNormalizer(),
+        {
+          isProductionMode: () => false,
+          getReleaseId: () => null,
+          getContentContext: () => ({
+            sourceType: "branch" as const,
+            projectSlug: "test",
+            branch: "main",
+          }),
+          hasCachedFileList: () => Promise.resolve(false),
+          isPersistentCacheInvalidated: () => false,
+        },
+      );
+
+      assertEquals(await statOps.resolveFile("about", { allowPagesPrefix: false }), null);
+      assertEquals(patterns, ["about.*", "about/index.*"]);
     });
   });
 
@@ -604,6 +646,8 @@ describe("StatOperations", () => {
         now += 30_001;
 
         await statOps.resolveFile("missing-after-cooldown");
+        // First request exhausts 4 patterns, second request trips the breaker on its first pattern,
+        // and the post-cooldown request gets another full 4-pattern attempt.
         assertEquals(searchCallCount, 9);
       } finally {
         Date.now = originalNow;

--- a/src/platform/adapters/fs/veryfront/stat-operations.test.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.test.ts
@@ -372,7 +372,46 @@ describe("StatOperations", () => {
 
       assertEquals(await statOps.resolveFile("missing/component"), null);
       assertEquals(await statOps.resolveFile("missing/component"), null);
+      assertEquals(searchCallCount, 4);
+    });
+
+    it("should resolve via API search without building the full index", async () => {
+      let listAllFilesCallCount = 0;
+      let searchCallCount = 0;
+
+      const client = createMockClient({
+        listAllFiles: () => {
+          listAllFilesCallCount++;
+          return Promise.resolve([]);
+        },
+        searchFiles: (pattern: string) => {
+          searchCallCount++;
+          if (pattern === "pages/about.*") {
+            return Promise.resolve([{ path: "pages/about.tsx" }]);
+          }
+          return Promise.resolve([]);
+        },
+      });
+
+      const statOps = new StatOperations(
+        client,
+        new FileCache({ enabled: true, ttl: 60_000, maxSize: 100 }),
+        new PathNormalizer(),
+        {
+          isProductionMode: () => false,
+          getReleaseId: () => null,
+          getContentContext: () => ({
+            sourceType: "branch" as const,
+            projectSlug: "test",
+            branch: "main",
+          }),
+          isPersistentCacheInvalidated: () => false,
+        },
+      );
+
+      assertEquals(await statOps.resolveFile("pages/about"), "pages/about.tsx");
       assertEquals(searchCallCount, 1);
+      assertEquals(listAllFilesCallCount, 0);
     });
   });
 
@@ -565,7 +604,7 @@ describe("StatOperations", () => {
         now += 30_001;
 
         await statOps.resolveFile("missing-after-cooldown");
-        assertEquals(searchCallCount, 6);
+        assertEquals(searchCallCount, 9);
       } finally {
         Date.now = originalNow;
       }

--- a/src/platform/adapters/fs/veryfront/stat-operations.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.ts
@@ -326,6 +326,116 @@ export class StatOperations extends VeryfrontOperationsBase {
     return files;
   }
 
+  private buildResolveSearchPatterns(normalizedPath: string): string[] {
+    const patterns = new Set<string>();
+    const pathWithoutExt = stripKnownExtension(normalizedPath, EXTENSION_PRIORITY);
+    const addPattern = (pattern: string): void => {
+      if (pattern.length > 0) patterns.add(pattern);
+    };
+
+    if (EXTENSION_PRIORITY.some((ext) => normalizedPath.endsWith(ext))) {
+      addPattern(normalizedPath);
+      return [...patterns];
+    }
+
+    addPattern(`${pathWithoutExt}.*`);
+    if (!pathWithoutExt.startsWith("pages/")) {
+      addPattern(`pages/${pathWithoutExt}.*`);
+    }
+
+    addPattern(`${pathWithoutExt}/index.*`);
+    if (!pathWithoutExt.startsWith("pages/")) {
+      addPattern(`pages/${pathWithoutExt}/index.*`);
+    }
+
+    return [...patterns];
+  }
+
+  private normalizeMatchedPaths(
+    matches: Array<{ path: string }>,
+  ): Array<{ path: string }> {
+    return matches.map((match) => ({
+      path: normalizeIndexedFilePath(match as ProjectFile).normalizedPath,
+    }));
+  }
+
+  private async tryResolveViaApiSearch(
+    normalizedPath: string,
+  ): Promise<string | null | undefined> {
+    if (isFrameworkSourcePath(normalizedPath)) {
+      logger.debug("Skipping API search for framework path", { normalizedPath });
+      return null;
+    }
+
+    if (!this.apiSearchCircuitBreaker.canSearch()) {
+      logger.warn("API search circuit breaker open, skipping", { normalizedPath });
+      return undefined;
+    }
+
+    const patterns = this.buildResolveSearchPatterns(normalizedPath);
+    let sawSuccessfulSearch = false;
+
+    for (const pattern of patterns) {
+      try {
+        const matches = await this.client.searchFiles(pattern);
+        sawSuccessfulSearch = true;
+        this.apiSearchCircuitBreaker.recordSuccess();
+
+        const normalizedMatches = this.normalizeMatchedPaths(matches);
+        if (pattern === normalizedPath) {
+          const exactMatch = normalizedMatches.find((match) => match.path === normalizedPath);
+          if (exactMatch) {
+            logger.debug("resolveFile found exact file via API search", {
+              normalizedPath,
+              pattern,
+            });
+            return exactMatch.path;
+          }
+          continue;
+        }
+
+        const sortedMatches = sortPathsByExtensionPriority(normalizedMatches, EXTENSION_PRIORITY);
+        const first = sortedMatches[0];
+        if (first) {
+          logger.debug("resolveFile found via API search", {
+            normalizedPath,
+            pattern,
+            resolvedPath: first.path,
+          });
+          return first.path;
+        }
+      } catch (error) {
+        const result = this.apiSearchCircuitBreaker.recordFailure();
+        if (result.tripped) {
+          logger.warn("API search circuit breaker tripped", {
+            failures: result.failures,
+          });
+          return undefined;
+        }
+        logger.error("API pattern search failed", { pattern, error });
+      }
+
+      if (!this.apiSearchCircuitBreaker.canSearch()) {
+        logger.warn("API search circuit breaker open, aborting remaining patterns", {
+          normalizedPath,
+        });
+        return undefined;
+      }
+    }
+
+    if (sawSuccessfulSearch) {
+      logger.debug("resolveFile not found via API search", { normalizedPath, patterns });
+      return null;
+    }
+
+    return undefined;
+  }
+
+  private async hasCachedFileList(): Promise<boolean> {
+    const files = await this.contextProvider?.getFileList?.();
+    return Array.isArray(files) && files.length > 0;
+  }
+
   async exists(path: string): Promise<boolean> {
     const normalizedPath = this.normalizer.normalize(path);
     try {
@@ -348,6 +458,36 @@ export class StatOperations extends VeryfrontOperationsBase {
       normalizedPath,
       cacheKey,
     });
+
+    const cached = await this.cache.getAsync<string>(cacheKey);
+    if (cached === NOT_FOUND_SENTINEL) {
+      logger.debug("resolveFile cached negative result", { normalizedPath });
+      return null;
+    }
+
+    if (cached !== undefined) {
+      logger.debug("resolveFile cache hit", {
+        normalizedPath,
+        cached,
+      });
+      return cached;
+    }
+
+    const hasCachedFileList = await this.hasCachedFileList();
+    const attemptedApiResolve = !hasCachedFileList;
+
+    if (!hasCachedFileList) {
+      const apiResolved = await this.tryResolveViaApiSearch(normalizedPath);
+      if (typeof apiResolved === "string") {
+        this.cache.set(cacheKey, apiResolved);
+        return apiResolved;
+      }
+
+      if (apiResolved === null) {
+        this.cache.set(cacheKey, NOT_FOUND_SENTINEL);
+        return null;
+      }
+    }
 
     const indexStart = performance.now();
     await this.ensureIndexBuilt();
@@ -410,6 +550,15 @@ export class StatOperations extends VeryfrontOperationsBase {
       return indexPath;
     }
 
+    if (attemptedApiResolve) {
+      logger.debug("resolveFile not found after pre-index API search", {
+        normalizedPath,
+        indexMs,
+      });
+      this.cache.set(cacheKey, NOT_FOUND_SENTINEL);
+      return null;
+    }
+
     if (isFrameworkSourcePath(normalizedPath)) {
       logger.debug("Skipping API search for framework path", { normalizedPath });
       return null;
@@ -425,32 +574,10 @@ export class StatOperations extends VeryfrontOperationsBase {
       return null;
     }
 
-    const cacheCheckStart = performance.now();
-    const cached = await this.cache.getAsync<string>(cacheKey);
-    const cacheCheckMs = Math.round(performance.now() - cacheCheckStart);
-
-    if (cached === NOT_FOUND_SENTINEL) {
-      logger.debug("resolveFile cached negative result", {
-        normalizedPath,
-        cacheCheckMs,
-      });
-      return null;
-    }
-
-    if (cached !== undefined) {
-      logger.debug("resolveFile cache hit (unexpected)", {
-        normalizedPath,
-        cached,
-        cacheCheckMs,
-      });
-      return cached;
-    }
-
     const searchPattern = `${pathWithoutExt}.*`;
     logger.debug("Searching for file via API", {
       pattern: searchPattern,
       normalizedPath,
-      cacheCheckMs,
     });
 
     try {

--- a/src/platform/adapters/fs/veryfront/stat-operations.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.ts
@@ -1,6 +1,6 @@
 import { logger as baseLogger } from "#veryfront/utils";
 import { isFrameworkSourcePath } from "#veryfront/utils/path-utils.ts";
-import type { FileInfo } from "../../base.ts";
+import type { FileInfo, ResolveFileOptions } from "../../base.ts";
 import type { ProjectFile } from "../../veryfront-api-client/index.ts";
 import { VeryfrontOperationsBase } from "./base-operations.ts";
 import { createError, toError } from "#veryfront/errors";
@@ -326,9 +326,13 @@ export class StatOperations extends VeryfrontOperationsBase {
     return files;
   }
 
-  private buildResolveSearchPatterns(normalizedPath: string): string[] {
+  private buildResolveSearchPatterns(
+    normalizedPath: string,
+    options?: ResolveFileOptions,
+  ): string[] {
     const patterns = new Set<string>();
     const pathWithoutExt = stripKnownExtension(normalizedPath, EXTENSION_PRIORITY);
+    const allowPagesPrefix = options?.allowPagesPrefix !== false;
     const addPattern = (pattern: string): void => {
       if (pattern.length > 0) patterns.add(pattern);
     };
@@ -339,12 +343,12 @@ export class StatOperations extends VeryfrontOperationsBase {
     }
 
     addPattern(`${pathWithoutExt}.*`);
-    if (!pathWithoutExt.startsWith("pages/")) {
+    if (allowPagesPrefix && !pathWithoutExt.startsWith("pages/")) {
       addPattern(`pages/${pathWithoutExt}.*`);
     }
 
     addPattern(`${pathWithoutExt}/index.*`);
-    if (!pathWithoutExt.startsWith("pages/")) {
+    if (allowPagesPrefix && !pathWithoutExt.startsWith("pages/")) {
       addPattern(`pages/${pathWithoutExt}/index.*`);
     }
 
@@ -361,6 +365,7 @@ export class StatOperations extends VeryfrontOperationsBase {
 
   private async tryResolveViaApiSearch(
     normalizedPath: string,
+    options?: ResolveFileOptions,
   ): Promise<string | null | undefined> {
     if (isFrameworkSourcePath(normalizedPath)) {
       logger.debug("Skipping API search for framework path", { normalizedPath });
@@ -372,7 +377,7 @@ export class StatOperations extends VeryfrontOperationsBase {
       return undefined;
     }
 
-    const patterns = this.buildResolveSearchPatterns(normalizedPath);
+    const patterns = this.buildResolveSearchPatterns(normalizedPath, options);
     let sawSuccessfulSearch = false;
 
     for (const pattern of patterns) {
@@ -432,6 +437,10 @@ export class StatOperations extends VeryfrontOperationsBase {
   }
 
   private async hasCachedFileList(): Promise<boolean> {
+    if (this.contextProvider?.hasCachedFileList) {
+      return await this.contextProvider.hasCachedFileList();
+    }
+
     const files = await this.contextProvider?.getFileList?.();
     return Array.isArray(files) && files.length > 0;
   }
@@ -447,7 +456,7 @@ export class StatOperations extends VeryfrontOperationsBase {
     }
   }
 
-  async resolveFile(basePath: string): Promise<string | null> {
+  async resolveFile(basePath: string, options?: ResolveFileOptions): Promise<string | null> {
     const resolveStart = performance.now();
     const normalizedPath = this.normalizer.normalize(basePath);
     const ctx = this.contextProvider?.getContentContext();
@@ -477,7 +486,7 @@ export class StatOperations extends VeryfrontOperationsBase {
     const attemptedApiResolve = !hasCachedFileList;
 
     if (!hasCachedFileList) {
-      const apiResolved = await this.tryResolveViaApiSearch(normalizedPath);
+      const apiResolved = await this.tryResolveViaApiSearch(normalizedPath, options);
       if (typeof apiResolved === "string") {
         this.cache.set(cacheKey, apiResolved);
         return apiResolved;
@@ -522,7 +531,7 @@ export class StatOperations extends VeryfrontOperationsBase {
       return resolvedDirect;
     }
 
-    if (!pathWithoutExt.startsWith("pages/")) {
+    if (options?.allowPagesPrefix !== false && !pathWithoutExt.startsWith("pages/")) {
       const resolvedPages = resolveByExtensionPriority(
         fileIdx,
         `pages/${pathWithoutExt}`,

--- a/src/platform/adapters/fs/veryfront/types.ts
+++ b/src/platform/adapters/fs/veryfront/types.ts
@@ -1,3 +1,4 @@
+import type { ResolveFileOptions } from "../../base.ts";
 import type { Project } from "../../veryfront-api-client/index.ts";
 import type { GitHubConfig } from "../github/types.ts";
 import type { DirectoryEntry } from "../shared-types.ts";
@@ -26,7 +27,7 @@ export interface FSAdapter {
   initialize?(): Promise<void>;
   shutdown?(): Promise<void>;
 
-  resolveFile?(basePath: string): Promise<string | null>;
+  resolveFile?(basePath: string, options?: ResolveFileOptions): Promise<string | null>;
 }
 
 export interface ContextualFSAdapter extends FSAdapter {

--- a/src/platform/adapters/fs/wrapper.ts
+++ b/src/platform/adapters/fs/wrapper.ts
@@ -1,4 +1,11 @@
-import type { DirEntry, FileInfo, FileSystemAdapter, FileWatcher, WatchOptions } from "../base.ts";
+import type {
+  DirEntry,
+  FileInfo,
+  FileSystemAdapter,
+  FileWatcher,
+  ResolveFileOptions,
+  WatchOptions,
+} from "../base.ts";
 import type { ContextualFSAdapter, DirectoryEntry, FSAdapter } from "./veryfront/types.ts";
 
 export interface ExtendedFileSystemAdapter extends FileSystemAdapter {
@@ -224,9 +231,9 @@ export class FSAdapterWrapper implements ExtendedFileSystemAdapter {
     };
   }
 
-  resolveFile(basePath: string): Promise<string | null> {
+  resolveFile(basePath: string, options?: ResolveFileOptions): Promise<string | null> {
     if (!this._fsAdapter.resolveFile) throw new NotSupportedError("resolveFile", this.adapterType);
-    return this._fsAdapter.resolveFile(basePath);
+    return this._fsAdapter.resolveFile(basePath, options);
   }
 
   async mkdir(path: string, options?: { recursive?: boolean }): Promise<void> {

--- a/src/rendering/app-route-resolver.ts
+++ b/src/rendering/app-route-resolver.ts
@@ -127,14 +127,6 @@ async function tryLoadPageFile(
   slug: string,
   adapter: RuntimeAdapter,
 ): Promise<EntityInfo | null> {
-  try {
-    const info = await adapter.fs.stat(file);
-    if (!info.isFile) return null;
-  } catch (_) {
-    /* expected: file may not exist */
-    return null;
-  }
-
   let raw: string;
   try {
     raw = await adapter.fs.readFile(file);

--- a/src/rendering/orchestrator/file-resolver/index.test.ts
+++ b/src/rendering/orchestrator/file-resolver/index.test.ts
@@ -1,0 +1,36 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ResolveFileOptions, RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { findSourceFile } from "./index.ts";
+
+describe("rendering/orchestrator/file-resolver", () => {
+  it("does not resolve source imports through an implicit pages/ fallback", async () => {
+    const resolveCalls: Array<{ basePath: string; allowPagesPrefix?: boolean }> = [];
+
+    const adapter = {
+      fs: {
+        resolveFile: async (basePath: string, options?: ResolveFileOptions) => {
+          resolveCalls.push({ basePath, allowPagesPrefix: options?.allowPagesPrefix });
+          return null;
+        },
+        stat: async (path: string) => {
+          if (path === "/project/pages/about.tsx") {
+            return {
+              isFile: true,
+              isDirectory: false,
+              isSymlink: false,
+              size: 1,
+              mtime: new Date(),
+            };
+          }
+          throw new Error("File not found");
+        },
+      },
+    } as unknown as RuntimeAdapter;
+
+    const result = await findSourceFile("about", "/project", adapter);
+
+    assertEquals(result, null);
+    assertEquals(resolveCalls, [{ basePath: "/project/about", allowPagesPrefix: false }]);
+  });
+});

--- a/src/rendering/orchestrator/file-resolver/index.ts
+++ b/src/rendering/orchestrator/file-resolver/index.ts
@@ -48,6 +48,22 @@ export async function findSourceFile(
   projectDir: string,
   adapter: RuntimeAdapter,
 ): Promise<string | null> {
+  if (adapter.fs.resolveFile) {
+    const directBases = [joinCandidateBase(projectDir, basePath)];
+    const withoutComponents = basePath.replace(/^components\//, "");
+    if (withoutComponents !== basePath) {
+      directBases.push(joinCandidateBase(projectDir, withoutComponents));
+    }
+
+    for (const candidateBase of directBases) {
+      const resolved = await adapter.fs.resolveFile(candidateBase);
+      if (resolved) {
+        logger.debug("[FileResolver] Found file via resolveFile:", resolved);
+        return resolved;
+      }
+    }
+  }
+
   const candidates = buildCandidatePaths(projectDir, basePath, SOURCE_EXTENSIONS);
 
   const withoutComponents = basePath.replace(/^components\//, "");
@@ -62,4 +78,9 @@ export async function findSourceFile(
   );
 
   return result;
+}
+
+function joinCandidateBase(projectDir: string, basePath: string): string {
+  if (basePath.startsWith("/")) return basePath;
+  return `${projectDir.replace(/\/+$/, "")}/${basePath.replace(/^\/+/, "")}`;
 }

--- a/src/rendering/orchestrator/file-resolver/index.ts
+++ b/src/rendering/orchestrator/file-resolver/index.ts
@@ -6,6 +6,7 @@
  * @module rendering/orchestrator/file-resolver
  */
 
+import { join } from "#veryfront/compat/path";
 import { rendererLogger as logger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { buildCandidatePaths, findFirstExisting } from "./candidates.ts";
@@ -49,14 +50,16 @@ export async function findSourceFile(
   adapter: RuntimeAdapter,
 ): Promise<string | null> {
   if (adapter.fs.resolveFile) {
-    const directBases = [joinCandidateBase(projectDir, basePath)];
+    const directBases = [join(projectDir, basePath)];
     const withoutComponents = basePath.replace(/^components\//, "");
     if (withoutComponents !== basePath) {
-      directBases.push(joinCandidateBase(projectDir, withoutComponents));
+      directBases.push(join(projectDir, withoutComponents));
     }
 
     for (const candidateBase of directBases) {
-      const resolved = await adapter.fs.resolveFile(candidateBase);
+      const resolved = await adapter.fs.resolveFile(candidateBase, {
+        allowPagesPrefix: false,
+      });
       if (resolved) {
         logger.debug("[FileResolver] Found file via resolveFile:", resolved);
         return resolved;
@@ -78,9 +81,4 @@ export async function findSourceFile(
   );
 
   return result;
-}
-
-function joinCandidateBase(projectDir: string, basePath: string): string {
-  if (basePath.startsWith("/")) return basePath;
-  return `${projectDir.replace(/\/+$/, "")}/${basePath.replace(/^\/+/, "")}`;
 }

--- a/src/rendering/page-resolution/page-resolver.test.ts
+++ b/src/rendering/page-resolution/page-resolver.test.ts
@@ -101,6 +101,68 @@ describe("rendering/page-resolution/page-resolver", () => {
       assertEquals(page.entity.path, "/project/app/page.tsx");
       assertEquals(routerMode, "app");
     });
+
+    it("falls back to pages router when app routes are absent", async () => {
+      const adapter = {
+        fs: {
+          readFile: async (path: string) => {
+            if (path === "/project/pages/index.tsx") {
+              return "export default function Page() { return null; }";
+            }
+            throw new Error("File not found");
+          },
+          resolveFile: async (path: string) => {
+            if (path === "/project/app/page") {
+              return null;
+            }
+            if (path === "/project/pages/index") {
+              return "/project/pages/index.tsx";
+            }
+            return null;
+          },
+          stat: async (path: string) => {
+            if (path === "/project/pages/index.tsx") {
+              return {
+                isFile: true,
+                isDirectory: false,
+                isSymlink: false,
+              };
+            }
+            if (path === "/project/pages") {
+              return {
+                isFile: false,
+                isDirectory: true,
+                isSymlink: false,
+              };
+            }
+            throw new Error("File not found");
+          },
+          exists: async (path: string) => path === "/project/pages",
+          readDir: async function* (path: string) {
+            if (path === "/project/pages") {
+              yield { name: "index.tsx", isFile: true, isDirectory: false };
+            }
+          },
+          writeFile: async () => {},
+          mkdir: async () => {},
+        },
+        env: { get: () => undefined },
+      } as unknown as RuntimeAdapter;
+
+      const config = createMockConfig();
+      const resolver = new PageResolver({
+        projectDir: "/project",
+        projectId: "project-switch",
+        config,
+        adapter,
+      });
+
+      const page = await resolver.resolvePage("/");
+      const routerMode = await resolver.getRouterMode();
+
+      assertEquals(page.entity.path, "/project/pages/index.tsx");
+      assertEquals(routerMode, "pages");
+    });
   });
 
   describe("getAllPages - app router discovery", () => {

--- a/src/rendering/page-resolution/page-resolver.test.ts
+++ b/src/rendering/page-resolution/page-resolver.test.ts
@@ -63,6 +63,46 @@ describe("rendering/page-resolution/page-resolver", () => {
     });
   });
 
+  describe("resolvePage", () => {
+    it("primes router detection from the resolved app route", async () => {
+      const adapter = {
+        fs: {
+          readFile: async (path: string) => {
+            if (path === "/project/app/page.tsx") {
+              return "export default function Page() { return null; }";
+            }
+            throw new Error("File not found");
+          },
+          resolveFile: async (path: string) => {
+            if (path === "/project/app/page") {
+              return "/project/app/page.tsx";
+            }
+            return null;
+          },
+          exists: async () => false,
+          readDir: async function* () {},
+          writeFile: async () => {},
+          mkdir: async () => {},
+        },
+        env: { get: () => undefined },
+      } as unknown as RuntimeAdapter;
+
+      const config = createMockConfig();
+      const resolver = new PageResolver({
+        projectDir: "/project",
+        projectId: "project-1",
+        config,
+        adapter,
+      });
+
+      const page = await resolver.resolvePage("/");
+      const routerMode = await resolver.getRouterMode();
+
+      assertEquals(page.entity.path, "/project/app/page.tsx");
+      assertEquals(routerMode, "app");
+    });
+  });
+
   describe("getAllPages - app router discovery", () => {
     it("should discover pages from app directory with page.tsx files", async () => {
       const adapter = createMockAdapter(

--- a/src/rendering/page-resolution/page-resolver.test.ts
+++ b/src/rendering/page-resolution/page-resolver.test.ts
@@ -64,7 +64,7 @@ describe("rendering/page-resolution/page-resolver", () => {
   });
 
   describe("resolvePage", () => {
-    it("primes router detection from the resolved app route", async () => {
+    it("keeps auto router detection aligned with the structural app router", async () => {
       const adapter = {
         fs: {
           readFile: async (path: string) => {
@@ -79,8 +79,22 @@ describe("rendering/page-resolution/page-resolver", () => {
             }
             return null;
           },
-          exists: async () => false,
-          readDir: async function* () {},
+          stat: async (path: string) => {
+            if (path === "/project/app") {
+              return {
+                isFile: false,
+                isDirectory: true,
+                isSymlink: false,
+              };
+            }
+            throw new Error("File not found");
+          },
+          exists: async (path: string) => path === "/project/app",
+          readDir: async function* (path: string) {
+            if (path === "/project/app") {
+              yield { name: "page.tsx", isFile: true, isDirectory: false };
+            }
+          },
           writeFile: async () => {},
           mkdir: async () => {},
         },
@@ -162,6 +176,78 @@ describe("rendering/page-resolution/page-resolver", () => {
 
       assertEquals(page.entity.path, "/project/pages/index.tsx");
       assertEquals(routerMode, "pages");
+    });
+
+    it("does not poison auto router detection from a pages fallback", async () => {
+      const adapter = {
+        fs: {
+          readFile: async (path: string) => {
+            if (path === "/project/pages/index.tsx") {
+              return "export default function Page() { return null; }";
+            }
+            throw new Error("File not found");
+          },
+          resolveFile: async (path: string) => {
+            if (path === "/project/app/page") {
+              return null;
+            }
+            if (path === "/project/pages/index") {
+              return "/project/pages/index.tsx";
+            }
+            return null;
+          },
+          stat: async (path: string) => {
+            if (path === "/project/pages/index.tsx") {
+              return {
+                isFile: true,
+                isDirectory: false,
+                isSymlink: false,
+              };
+            }
+            if (path === "/project/app" || path === "/project/pages") {
+              return {
+                isFile: false,
+                isDirectory: true,
+                isSymlink: false,
+              };
+            }
+            throw new Error("File not found");
+          },
+          exists: async (path: string) => path === "/project/app" || path === "/project/pages",
+          readDir: async function* (path: string) {
+            if (path === "/project/app") {
+              yield { name: "dashboard", isFile: false, isDirectory: true };
+              return;
+            }
+
+            if (path === "/project/app/dashboard") {
+              yield { name: "page.tsx", isFile: true, isDirectory: false };
+              return;
+            }
+
+            if (path === "/project/pages") {
+              yield { name: "index.tsx", isFile: true, isDirectory: false };
+            }
+          },
+          writeFile: async () => {},
+          mkdir: async () => {},
+        },
+        env: { get: () => undefined },
+      } as unknown as RuntimeAdapter;
+
+      const config = createMockConfig();
+      const resolver = new PageResolver({
+        projectDir: "/project",
+        projectId: "mixed-project",
+        config,
+        adapter,
+      });
+
+      const page = await resolver.resolvePage("/");
+      const routerMode = await resolver.getRouterMode();
+
+      assertEquals(page.entity.path, "/project/pages/index.tsx");
+      assertEquals(routerMode, "app");
     });
   });
 

--- a/src/rendering/page-resolution/page-resolver.ts
+++ b/src/rendering/page-resolution/page-resolver.ts
@@ -7,7 +7,11 @@ import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import type { EntityInfo } from "#veryfront/types";
 import { getEntityBySlug } from "#veryfront/types/entities/getEntityInfo.ts";
-import { detectAppRouter, getAppRouteEntity } from "../router-detection.ts";
+import {
+  detectAppRouter,
+  getAppRouteEntity,
+  primeRouterDetectionCache,
+} from "../router-detection.ts";
 
 const PAGE_EXTENSIONS = /\.(mdx|md|tsx|jsx|ts|js)$/;
 const APP_ROUTER_PAGE_PATTERN = /^page\.(mdx|md|tsx|jsx|ts|js)$/;
@@ -61,39 +65,47 @@ export class PageResolver {
     return withSpan(
       "routing.resolve_page",
       async () => {
-        const useAppRouter = await detectAppRouter(
-          this.projectDir,
-          this.config,
-          this.adapter,
-          { projectId: this.projectId },
-        );
-
         const appDirName = this.config.directories?.app ?? "app";
+        const cacheKey = this.projectId ?? this.projectDir;
 
         let pageInfo: EntityInfo | null | undefined;
 
-        if (useAppRouter) {
+        if (this.config.router === "app") {
           pageInfo = await getAppRouteEntity(
             this.projectDir,
             slug,
             this.adapter,
             appDirName,
           );
-
-          if (!pageInfo) {
-            logger.debug(
-              "App Router resolution failed, falling back to Pages Router",
-              { slug },
-            );
+          if (pageInfo) {
+            primeRouterDetectionCache(cacheKey, "app");
+          }
+        } else if (this.config.router === "pages") {
+          pageInfo = await getEntityBySlug(this.projectDir, slug, this.adapter);
+          if (pageInfo) {
+            primeRouterDetectionCache(cacheKey, "pages");
+          }
+        } else {
+          pageInfo = await getAppRouteEntity(
+            this.projectDir,
+            slug,
+            this.adapter,
+            appDirName,
+          );
+          if (pageInfo) {
+            primeRouterDetectionCache(cacheKey, "app");
+          } else {
+            pageInfo = await getEntityBySlug(this.projectDir, slug, this.adapter);
+            if (pageInfo) {
+              primeRouterDetectionCache(cacheKey, "pages");
+            }
           }
         }
-
-        pageInfo ??= await getEntityBySlug(this.projectDir, slug, this.adapter);
 
         if (!pageInfo) {
           throw FILE_NOT_FOUND.create({
             detail: `Page not found: ${slug}`,
-            context: { slug, useAppRouter },
+            context: { slug, router: this.config.router ?? "auto" },
           });
         }
 

--- a/src/rendering/page-resolution/page-resolver.ts
+++ b/src/rendering/page-resolution/page-resolver.ts
@@ -86,19 +86,16 @@ export class PageResolver {
             primeRouterDetectionCache(cacheKey, "pages");
           }
         } else {
+          // Auto mode stays structural: a single resolved route must not pin router mode
+          // for projects that are still transitioning between app/ and pages/.
           pageInfo = await getAppRouteEntity(
             this.projectDir,
             slug,
             this.adapter,
             appDirName,
           );
-          if (pageInfo) {
-            primeRouterDetectionCache(cacheKey, "app");
-          } else {
+          if (!pageInfo) {
             pageInfo = await getEntityBySlug(this.projectDir, slug, this.adapter);
-            if (pageInfo) {
-              primeRouterDetectionCache(cacheKey, "pages");
-            }
           }
         }
 

--- a/src/rendering/router-detection.ts
+++ b/src/rendering/router-detection.ts
@@ -49,6 +49,13 @@ export function clearRouterDetectionCacheForProject(projectId: string): void {
   routerDetectionCache.delete(projectId);
 }
 
+export function primeRouterDetectionCache(
+  projectKey: string,
+  mode: "app" | "pages",
+): void {
+  routerDetectionCache.set(projectKey, mode === "app");
+}
+
 export interface DetectAppRouterOptions {
   /** Project ID for cache isolation in multi-tenant deployments */
   projectId?: string;

--- a/src/types/entities/getEntityInfo.ts
+++ b/src/types/entities/getEntityInfo.ts
@@ -43,49 +43,55 @@ export async function getEntityInfo(
       }
 
       try {
+        const shouldReadDirectly = adapter
+          ? isExtendedFSAdapter(adapter.fs) && adapter.fs.isVeryfrontAdapter()
+          : false;
+
+        let content: string;
         if (adapter) {
-          try {
-            const stat = await withFallback(
-              () => adapter.fs.stat(normalizedPath),
-              async () => {
-                const exists = await fs.exists(filePath);
-                if (!exists) {
-                  throw toError(
-                    createError({
-                      type: "file",
-                      message: "File not found",
-                      context: { path: filePath, operation: "read" },
-                    }),
-                  );
-                }
-                return await fs.stat(filePath);
-              },
-              { operationName: "stat:getEntityInfo", logError: false },
-            );
+          if (!shouldReadDirectly) {
+            try {
+              const stat = await withFallback(
+                () => adapter.fs.stat(normalizedPath),
+                async () => {
+                  const exists = await fs.exists(filePath);
+                  if (!exists) {
+                    throw toError(
+                      createError({
+                        type: "file",
+                        message: "File not found",
+                        context: { path: filePath, operation: "read" },
+                      }),
+                    );
+                  }
+                  return await fs.stat(filePath);
+                },
+                { operationName: "stat:getEntityInfo", logError: false },
+              );
 
-            if (!stat.isFile) return null;
-          } catch (error) {
-            entityInfoScope.runSync(
-              () => {
-                throw error;
-              },
-              { path: filePath, details: { reason: "stat-failed" } },
-              undefined,
-            );
-            return null;
+              if (!stat.isFile) return null;
+            } catch (error) {
+              entityInfoScope.runSync(
+                () => {
+                  throw error;
+                },
+                { path: filePath, details: { reason: "stat-failed" } },
+                undefined,
+              );
+              return null;
+            }
           }
-        } else {
-          const exists = await fs.exists(filePath);
-          if (!exists) return null;
-        }
 
-        const content = adapter
-          ? await withFallback(
+          content = await withFallback(
             () => adapter.fs.readFile(normalizedPath),
             () => fs.readTextFile(filePath),
             { operationName: "readFile:getEntityInfo", logError: false },
-          )
-          : await fs.readTextFile(filePath);
+          );
+        } else {
+          const exists = await fs.exists(filePath);
+          if (!exists) return null;
+          content = await fs.readTextFile(filePath);
+        }
 
         const ext = pathHelper.extname(filePath).toLowerCase();
 

--- a/src/types/entities/getEntityInfo.ts
+++ b/src/types/entities/getEntityInfo.ts
@@ -177,26 +177,29 @@ export async function getEntityBySlug(
   return await withSpan(
     "types.getEntityBySlug",
     async () => {
-      const isVeryfrontRoute = slug.startsWith(".veryfront/") || slug === ".veryfront";
+      const normalizedSlug = slug === "/" ? "" : slug.replace(/^\/+/, "").replace(/\/+$/, "");
+      const isVeryfrontRoute = normalizedSlug.startsWith(".veryfront/") || normalizedSlug === ".veryfront";
       const resolveFile = adapter?.fs.resolveFile;
 
       logger.debug("START", {
         slug,
+        normalizedSlug,
         projectDir,
         isVeryfrontRoute,
         hasResolveFile: !!resolveFile,
       });
 
       if (resolveFile) {
-        const basePaths = [pathHelper.join(projectDir, "pages", slug)];
+        const basePaths = [pathHelper.join(projectDir, "pages", normalizedSlug)];
 
-        if (isVeryfrontRoute) basePaths.unshift(pathHelper.join(projectDir, slug));
-        if (slug === "index" || slug === "") {
+        if (isVeryfrontRoute) basePaths.unshift(pathHelper.join(projectDir, normalizedSlug));
+        if (normalizedSlug === "index" || normalizedSlug === "") {
           basePaths.unshift(pathHelper.join(projectDir, "pages", "index"));
         }
 
         logger.debug("Checking paths (resolveFile branch)", {
           slug,
+          normalizedSlug,
           basePaths,
         });
 
@@ -214,13 +217,14 @@ export async function getEntityBySlug(
           if (info?.entity.isPage) {
             logger.debug("Found page via resolveFile", {
               slug,
+              normalizedSlug,
               path: info.entity.path,
             });
             return info;
           }
         }
 
-        const slugParts = slug.split("/");
+        const slugParts = normalizedSlug === "" ? [] : normalizedSlug.split("/");
         for (let depth = slugParts.length - 1; depth >= 0; depth--) {
           const parentPath = slugParts.slice(0, depth).join("/");
           const pagesDir = parentPath
@@ -265,33 +269,33 @@ export async function getEntityBySlug(
           }
         }
 
-        logger.debug("No page found via resolveFile branch", { slug });
+        logger.debug("No page found via resolveFile branch", { slug, normalizedSlug });
         return null;
       }
 
       const possiblePaths = [
-        pathHelper.join(projectDir, "pages", `${slug}.mdx`),
-        pathHelper.join(projectDir, "pages", `${slug}.md`),
-        pathHelper.join(projectDir, "pages", `${slug}.tsx`),
-        pathHelper.join(projectDir, "pages", `${slug}.jsx`),
-        pathHelper.join(projectDir, "pages", `${slug}.ts`),
-        pathHelper.join(projectDir, "pages", `${slug}/index.mdx`),
-        pathHelper.join(projectDir, "pages", `${slug}/index.md`),
-        pathHelper.join(projectDir, "pages", `${slug}/index.tsx`),
-        pathHelper.join(projectDir, "pages", `${slug}/index.jsx`),
-        pathHelper.join(projectDir, "pages", `${slug}/index.ts`),
+        pathHelper.join(projectDir, "pages", `${normalizedSlug}.mdx`),
+        pathHelper.join(projectDir, "pages", `${normalizedSlug}.md`),
+        pathHelper.join(projectDir, "pages", `${normalizedSlug}.tsx`),
+        pathHelper.join(projectDir, "pages", `${normalizedSlug}.jsx`),
+        pathHelper.join(projectDir, "pages", `${normalizedSlug}.ts`),
+        pathHelper.join(projectDir, "pages", `${normalizedSlug}/index.mdx`),
+        pathHelper.join(projectDir, "pages", `${normalizedSlug}/index.md`),
+        pathHelper.join(projectDir, "pages", `${normalizedSlug}/index.tsx`),
+        pathHelper.join(projectDir, "pages", `${normalizedSlug}/index.jsx`),
+        pathHelper.join(projectDir, "pages", `${normalizedSlug}/index.ts`),
       ];
 
       if (isVeryfrontRoute) {
         possiblePaths.unshift(
-          pathHelper.join(projectDir, `${slug}.mdx`),
-          pathHelper.join(projectDir, `${slug}.md`),
-          pathHelper.join(projectDir, `${slug}.tsx`),
-          pathHelper.join(projectDir, `${slug}.ts`),
+          pathHelper.join(projectDir, `${normalizedSlug}.mdx`),
+          pathHelper.join(projectDir, `${normalizedSlug}.md`),
+          pathHelper.join(projectDir, `${normalizedSlug}.tsx`),
+          pathHelper.join(projectDir, `${normalizedSlug}.ts`),
         );
       }
 
-      if (slug === "index" || slug === "") {
+      if (normalizedSlug === "index" || normalizedSlug === "") {
         possiblePaths.unshift(
           pathHelper.join(projectDir, "pages", "index.mdx"),
           pathHelper.join(projectDir, "pages", "index.md"),
@@ -308,7 +312,7 @@ export async function getEntityBySlug(
         if (info?.entity.isPage) return info;
       }
 
-      const slugParts = slug.split("/");
+      const slugParts = normalizedSlug === "" ? [] : normalizedSlug.split("/");
       for (let depth = slugParts.length - 1; depth >= 0; depth--) {
         const parentPath = slugParts.slice(0, depth).join("/");
         const pagesDir = parentPath
@@ -362,7 +366,7 @@ export async function getEntityBySlug(
 
       return null;
     },
-    { "entity.slug": slug, "entity.projectDir": projectDir },
+    { "entity.slug": slug, "entity.normalized_slug": slug === "/" ? "" : slug.replace(/^\/+/, "").replace(/\/+$/, ""), "entity.projectDir": projectDir },
   );
 }
 

--- a/src/types/entities/getEntityInfo.ts
+++ b/src/types/entities/getEntityInfo.ts
@@ -177,7 +177,7 @@ export async function getEntityBySlug(
   return await withSpan(
     "types.getEntityBySlug",
     async () => {
-      const normalizedSlug = slug === "/" ? "" : slug.replace(/^\/+/, "").replace(/\/+$/, "");
+      const normalizedSlug = normalizeSlug(slug);
       const isVeryfrontRoute = normalizedSlug.startsWith(".veryfront/") ||
         normalizedSlug === ".veryfront";
       const resolveFile = adapter?.fs.resolveFile;
@@ -369,7 +369,7 @@ export async function getEntityBySlug(
     },
     {
       "entity.slug": slug,
-      "entity.normalized_slug": slug === "/" ? "" : slug.replace(/^\/+/, "").replace(/\/+$/, ""),
+      "entity.normalized_slug": normalizeSlug(slug),
       "entity.projectDir": projectDir,
     },
   );
@@ -462,4 +462,8 @@ function getSlugFromPath(filePath: string): string {
 
   const parentDir = parts[parts.length - 2];
   return parentDir === "pages" ? "" : parentDir ?? "";
+}
+
+function normalizeSlug(slug: string): string {
+  return slug === "/" ? "" : slug.replace(/^\/+/, "").replace(/\/+$/, "");
 }

--- a/src/types/entities/getEntityInfo.ts
+++ b/src/types/entities/getEntityInfo.ts
@@ -178,7 +178,8 @@ export async function getEntityBySlug(
     "types.getEntityBySlug",
     async () => {
       const normalizedSlug = slug === "/" ? "" : slug.replace(/^\/+/, "").replace(/\/+$/, "");
-      const isVeryfrontRoute = normalizedSlug.startsWith(".veryfront/") || normalizedSlug === ".veryfront";
+      const isVeryfrontRoute = normalizedSlug.startsWith(".veryfront/") ||
+        normalizedSlug === ".veryfront";
       const resolveFile = adapter?.fs.resolveFile;
 
       logger.debug("START", {
@@ -366,7 +367,11 @@ export async function getEntityBySlug(
 
       return null;
     },
-    { "entity.slug": slug, "entity.normalized_slug": slug === "/" ? "" : slug.replace(/^\/+/, "").replace(/\/+$/, ""), "entity.projectDir": projectDir },
+    {
+      "entity.slug": slug,
+      "entity.normalized_slug": slug === "/" ? "" : slug.replace(/^\/+/, "").replace(/\/+$/, ""),
+      "entity.projectDir": projectDir,
+    },
   );
 }
 


### PR DESCRIPTION
## Summary
- avoid building the full remote file index before resolving the first route and module files
- add a pre-index API resolve path for Veryfront-backed FS lookups
- keep router auto-detection working while falling back cleanly from App Router to Pages Router
- normalize root-slug pages fallback behavior and bump the package version to `0.1.83`

## Testing
- `deno test --allow-env src/platform/adapters/fs/veryfront/stat-operations.test.ts src/rendering/page-resolution/page-resolver.test.ts`
- `deno check src/platform/adapters/fs/veryfront/stat-operations.ts src/types/entities/getEntityInfo.ts src/rendering/page-resolution/page-resolver.ts src/rendering/app-route-resolver.ts src/rendering/orchestrator/file-resolver/index.ts src/rendering/router-detection.ts`
- repo pre-push suite: `format`, `lint`, `typecheck`, `test:unit`
