### PR TITLE
fix: return safe 404 for missing preview projects

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/proxy/error-response.test.ts
+++ b/src/proxy/error-response.test.ts
@@ -1,0 +1,49 @@
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
+import { createProxyErrorResponse } from "./error-response.ts";
+
+describe("createProxyErrorResponse", () => {
+  it("renders a not found HTML page for missing preview projects", async () => {
+    const response = createProxyErrorResponse({
+      status: 404,
+      message: "Preview project not found",
+      slug: "project-not-found",
+    });
+
+    assertEquals(response.status, 404);
+    assertEquals(response.headers.get("Content-Type"), "text/html; charset=utf-8");
+
+    const body = await response.text();
+    assertStringIncludes(body, "<title>404 Not Found");
+    assertStringIncludes(body, "The page you requested could not be found.");
+    assertEquals(body.includes("x-token header is required in proxy mode"), false);
+  });
+
+  it("preserves sign-in redirects for protected projects", () => {
+    const response = createProxyErrorResponse({
+      status: 302,
+      message: "Authentication required",
+      redirectUrl: "https://veryfront.com/sign-in?from=%2F",
+    });
+
+    assertEquals(response.status, 302);
+    assertEquals(response.headers.get("Location"), "https://veryfront.com/sign-in?from=%2F");
+  });
+
+  it("keeps generic errors as JSON", async () => {
+    const response = createProxyErrorResponse({
+      status: 502,
+      message: "Failed to authenticate preview request",
+    });
+
+    assertEquals(response.status, 502);
+    assertEquals(response.headers.get("Content-Type"), "application/json");
+    assertEquals(
+      await response.text(),
+      JSON.stringify({
+        error: "Failed to authenticate preview request",
+        status: 502,
+      }),
+    );
+  });
+});

--- a/src/proxy/error-response.ts
+++ b/src/proxy/error-response.ts
@@ -1,0 +1,32 @@
+import { ErrorPages } from "../server/utils/error-html.ts";
+import type { ProxyContext } from "./handler.ts";
+
+type ProxyError = NonNullable<ProxyContext["error"]>;
+
+export function jsonErrorResponse(status: number, body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function createProxyErrorResponse(error: ProxyError): Response {
+  if (error.redirectUrl) {
+    return new Response(null, {
+      status: 302,
+      headers: { Location: error.redirectUrl },
+    });
+  }
+
+  if (error.slug === "release-not-found" || error.slug === "project-not-found") {
+    return new Response(ErrorPages.notFound(), {
+      status: 404,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+
+  return jsonErrorResponse(error.status, {
+    error: error.message,
+    status: error.status,
+  });
+}

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -234,31 +234,55 @@ describe("Proxy Handler", () => {
       }
     });
 
-    it("extracts project slug from veryfront subdomain without lookup", async () => {
-      const handler = createProxyHandler({
-        config: {
-          apiBaseUrl: "http://localhost:9999",
-          apiClientId: "",
-          apiClientSecret: "",
-          previewApiClientId: "",
-          previewApiClientSecret: "",
-          apiToken: "fallback-token",
-        },
+    it("extracts project slug from veryfront subdomain with static API token fallback", async () => {
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname.startsWith("/projects/")) {
+          return Response.json({
+            id: "proj-123",
+            slug: "my-project",
+            name: "My Project",
+            environments: [{
+              id: "env-1",
+              name: "preview",
+              active_release_id: null,
+              protected: false,
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
       });
 
-      // Use preview subdomain to avoid production releaseId requirement
-      const req = new Request("http://my-project.preview.veryfront.com/page", {
-        headers: { host: "my-project.preview.veryfront.com" },
-      });
+      try {
+        const handler = createProxyHandler({
+          config: {
+            apiBaseUrl: `http://127.0.0.1:${port}`,
+            apiClientId: "",
+            apiClientSecret: "",
+            previewApiClientId: "",
+            previewApiClientSecret: "",
+            apiToken: "fallback-token",
+          },
+        });
 
-      const ctx = await handler.processRequest(req);
+        const req = new Request("http://my-project.preview.veryfront.com/page", {
+          headers: { host: "my-project.preview.veryfront.com" },
+        });
 
-      assertEquals(ctx.projectSlug, "my-project");
-      assertEquals(ctx.error, undefined);
-      assertEquals(ctx.token, "fallback-token");
-      assertEquals(ctx.environment, "preview");
+        const ctx = await handler.processRequest(req);
 
-      await handler.close();
+        assertEquals(ctx.projectSlug, "my-project");
+        assertEquals(ctx.projectId, "proj-123");
+        assertEquals(ctx.error, undefined);
+        assertEquals(ctx.token, "fallback-token");
+        assertEquals(ctx.environment, "preview");
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
     });
   });
 
@@ -737,6 +761,34 @@ describe("Proxy Handler", () => {
       }
     });
 
+    it("returns 404 for missing preview project without auth token", async () => {
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") return createNotFoundResponse();
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+
+        const req = new Request("http://missing-project.preview.veryfront.com/page", {
+          headers: { host: "missing-project.preview.veryfront.com" },
+        });
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error?.status, 404);
+        assertEquals(ctx.error?.message, "Preview project not found");
+        assertEquals(ctx.error?.slug, "project-not-found");
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
     it("allows access to protected preview domain with auth token for project member", async () => {
       const memberToken = await createFakeJwt("user-123");
       const { server, port } = createMockServer((req: Request) => {
@@ -780,6 +832,34 @@ describe("Proxy Handler", () => {
         assertEquals(ctx.error, undefined);
         assertEquals(ctx.projectSlug, "protected-project");
         assertEquals(ctx.environmentId, "env-1");
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
+    it("returns 404 for missing preview project with auth token", async () => {
+      const memberToken = await createFakeJwt("user-123");
+      const { server, port } = createMockServer((_req: Request) => {
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+
+        const req = new Request("http://missing-project.preview.veryfront.com/page", {
+          headers: {
+            host: "missing-project.preview.veryfront.com",
+            cookie: `authToken=${memberToken}`,
+          },
+        });
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error?.status, 404);
+        assertEquals(ctx.error?.message, "Preview project not found");
+        assertEquals(ctx.error?.slug, "project-not-found");
 
         await handler.close();
       } finally {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -174,6 +174,12 @@ function extractUserToken(cookieHeader: string): string | undefined {
   return match?.[1] ? decodeURIComponent(match[1]) : undefined;
 }
 
+function getStatusFromError(error: unknown): number | null {
+  const message = error instanceof Error ? error.message : String(error);
+  const match = message.match(/failed: (\d+)/);
+  return match ? Number(match[1]) : null;
+}
+
 async function extractUserIdFromToken(
   token: string,
   apiBaseUrl: string,
@@ -460,6 +466,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     const userToken = extractUserToken(cookieHeader);
 
     let token: string | undefined;
+    let tokenFetchError: unknown;
 
     if (isLocalProject) {
       logger?.debug("Local project, skipping token fetch", { localPath });
@@ -475,6 +482,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
           try {
             token = await tokenManager.getToken(scope, projectSlug, customDomain);
           } catch (error) {
+            tokenFetchError = error;
             logger?.error("Token fetch failed", error as Error, { projectSlug, customDomain });
           }
         }
@@ -486,6 +494,29 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
       }
 
       const base = { scope, host, parsedDomain };
+
+      if (projectSlug && scope === "preview" && !token) {
+        const status = getStatusFromError(tokenFetchError);
+        if (status === 404) {
+          logger?.info("Preview project not found", { projectSlug, host });
+          return makeErrorContext(
+            base,
+            404,
+            "Preview project not found",
+            undefined,
+            undefined,
+            "project-not-found",
+          );
+        }
+
+        logger?.warn("Preview request has no usable token", {
+          projectSlug,
+          host,
+          hadUserToken: !!userToken,
+          hadTokenFetchError: !!tokenFetchError,
+        });
+        return makeErrorContext(base, 502, "Failed to authenticate preview request");
+      }
 
       if (isCustomDomain && !projectSlug) {
         if (!token) {
@@ -586,6 +617,18 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
             resolved.error.message,
             token,
             resolved.error.redirectUrl,
+          );
+        }
+
+        if (!resolved.projectId) {
+          logger?.info("Preview project not found after lookup", { projectSlug, host });
+          return makeErrorContext(
+            base,
+            404,
+            "Preview project not found",
+            token,
+            undefined,
+            "project-not-found",
           );
         }
 

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -35,12 +35,12 @@ import {
   withSpan,
 } from "./tracing.ts";
 import { proxyLogger, runWithProxyRequestContext } from "./logger.ts";
-import { ErrorPages } from "../server/utils/error-html.ts";
 import { RendererRouter } from "./renderer-router.ts";
 import { ServerResolver } from "./server-resolver.ts";
 import { parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
 import { exit, getEnv, onSignal } from "#veryfront/platform/compat/process.ts";
 import { createHttpServer, upgradeWebSocket } from "#veryfront/platform/compat/http/index.ts";
+import { createProxyErrorResponse, jsonErrorResponse } from "./error-response.ts";
 
 function getLocalProjects(): Record<string, string> {
   const raw = getEnv("LOCAL_PROJECTS");
@@ -272,13 +272,6 @@ function handleWebSocketUpgrade(req: Request): Response {
   return response;
 }
 
-function jsonErrorResponse(status: number, body: Record<string, unknown>): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
-}
-
 function forwardToServer(req: Request): Promise<Response> {
   const startTime = performance.now();
   const url = new URL(req.url);
@@ -309,25 +302,7 @@ function forwardToServer(req: Request): Promise<Response> {
             const logLevel = ctx.error.status < 500 ? "warn" : "error";
             proxyLogger[logLevel](`${ctx.error.status} ${req.method} ${url.pathname}`, { ms });
             endSpan(spanInfo?.span, ctx.error.status);
-
-            if (ctx.error.redirectUrl) {
-              return new Response(null, {
-                status: 302,
-                headers: { Location: ctx.error.redirectUrl },
-              });
-            }
-
-            if (ctx.error.slug === "release-not-found") {
-              return new Response(ErrorPages.notFound(), {
-                status: 404,
-                headers: { "Content-Type": "text/html; charset=utf-8" },
-              });
-            }
-
-            return jsonErrorResponse(ctx.error.status, {
-              error: ctx.error.message,
-              status: ctx.error.status,
-            });
+            return createProxyErrorResponse(ctx.error);
           }
 
           const reqLogger = proxyLogger.child({

--- a/src/proxy/mode-parity.test.ts
+++ b/src/proxy/mode-parity.test.ts
@@ -222,6 +222,19 @@ describe("Proxy-Renderer Mode Parity", () => {
             expires_in: 3600,
           });
         }
+        if (pathname.startsWith("/projects/")) {
+          return Response.json({
+            id: "proj-123",
+            slug: "test-project",
+            name: "Test Project",
+            environments: [{
+              id: "env-1",
+              name: "preview",
+              active_release_id: null,
+              protected: false,
+            }],
+          });
+        }
         return new Response("Not found", { status: 404 });
       });
 

--- a/src/proxy/token-priority.test.ts
+++ b/src/proxy/token-priority.test.ts
@@ -32,6 +32,19 @@ function createTokenServer(token: string) {
         expires_in: 3600,
       });
     }
+    if (pathname.startsWith("/projects/")) {
+      return Response.json({
+        id: "proj-123",
+        slug: "my-project",
+        name: "My Project",
+        environments: [{
+          id: "env-1",
+          name: "preview",
+          active_release_id: null,
+          protected: false,
+        }],
+      });
+    }
     return new Response("Not found", { status: 404 });
   });
 }
@@ -140,27 +153,50 @@ describe("Token Priority Cascade", () => {
 
   describe("static API token fallback", () => {
     it("uses static API token when OAuth credentials are empty", async () => {
-      const handler = createProxyHandler({
-        config: {
-          apiBaseUrl: "http://localhost:9999",
-          apiClientId: "",
-          apiClientSecret: "",
-          previewApiClientId: "",
-          previewApiClientSecret: "",
-          apiToken: "static-api-token",
-        },
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+        if (pathname.startsWith("/projects/")) {
+          return Response.json({
+            id: "proj-123",
+            slug: "my-project",
+            name: "My Project",
+            environments: [{
+              id: "env-1",
+              name: "preview",
+              active_release_id: null,
+              protected: false,
+            }],
+          });
+        }
+
+        return new Response("Not found", { status: 404 });
       });
 
-      const req = new Request("http://my-project.preview.veryfront.com/page", {
-        headers: { host: "my-project.preview.veryfront.com" },
-      });
+      try {
+        const handler = createProxyHandler({
+          config: {
+            apiBaseUrl: `http://127.0.0.1:${port}`,
+            apiClientId: "",
+            apiClientSecret: "",
+            previewApiClientId: "",
+            previewApiClientSecret: "",
+            apiToken: "static-api-token",
+          },
+        });
 
-      const ctx = await handler.processRequest(req);
+        const req = new Request("http://my-project.preview.veryfront.com/page", {
+          headers: { host: "my-project.preview.veryfront.com" },
+        });
 
-      assertEquals(ctx.token, "static-api-token");
-      assertEquals(ctx.error, undefined);
+        const ctx = await handler.processRequest(req);
 
-      await handler.close();
+        assertEquals(ctx.token, "static-api-token");
+        assertEquals(ctx.error, undefined);
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- return a clean 404 for preview hosts that do not resolve to a project instead of leaking proxy/runtime internals
- render the shared not-found HTML page for `project-not-found` errors in split proxy mode
- update preview proxy tests to require real project lookup for valid preview requests and cover the missing-project branches

## Testing
- deno lint src/proxy/error-response.ts src/proxy/error-response.test.ts src/proxy/handler.ts src/proxy/handler.test.ts src/proxy/main.ts src/proxy/token-priority.test.ts src/proxy/mode-parity.test.ts
- deno fmt --check src/proxy/error-response.ts src/proxy/error-response.test.ts src/proxy/handler.ts src/proxy/handler.test.ts src/proxy/main.ts src/proxy/token-priority.test.ts src/proxy/mode-parity.test.ts
- deno check src/proxy/main.ts src/proxy/handler.ts src/proxy/error-response.ts
- deno test --allow-all --no-check src/proxy/cache/memory-cache.test.ts src/proxy/error-response.test.ts src/proxy/handler.test.ts src/proxy/mode-parity.test.ts src/proxy/oauth-client.test.ts src/proxy/renderer-router.test.ts src/proxy/retry.test.ts src/proxy/server-resolver.test.ts src/proxy/token-manager.test.ts src/proxy/token-priority.test.ts src/proxy/websocket-proxy.test.ts
- full pre-push suite (`1190 passed, 0 failed`)
