### PR TITLE
perf: cache preview stylesheet generation

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/rendering/orchestrator/css-candidate-manifest.test.ts
+++ b/src/rendering/orchestrator/css-candidate-manifest.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  getProjectCandidates,
   getRouteCandidates,
   invalidateProjectCandidateManifests,
 } from "./css-candidate-manifest.ts";
@@ -122,6 +123,32 @@ describe("rendering/orchestrator/css-candidate-manifest", () => {
         developmentMode: true,
       });
       assertEquals(result.size, 0);
+    });
+  });
+
+  describe("getProjectCandidates", () => {
+    it("should return all extracted candidates for a project manifest", () => {
+      invalidateProjectCandidateManifests();
+      const result = getProjectCandidates({
+        projectScope: "project-all",
+        projectVersion: "v1",
+        projectDir: "/project",
+        files: [
+          {
+            path: "/project/pages/index.tsx",
+            content: '<div className="text-red-500">Home</div>',
+          },
+          {
+            path: "/project/components/Card.tsx",
+            content: '<div className="rounded-lg shadow-sm">Card</div>',
+          },
+        ],
+        developmentMode: false,
+      });
+
+      assertEquals(result.has("text-red-500"), true);
+      assertEquals(result.has("rounded-lg"), true);
+      assertEquals(result.has("shadow-sm"), true);
     });
   });
 });

--- a/src/rendering/orchestrator/css-candidate-manifest.ts
+++ b/src/rendering/orchestrator/css-candidate-manifest.ts
@@ -23,6 +23,14 @@ interface RouteCandidateOptions {
   developmentMode: boolean;
 }
 
+interface ProjectCandidateOptions {
+  projectScope: string;
+  projectVersion: string;
+  projectDir: string;
+  files: SourceFileLike[];
+  developmentMode: boolean;
+}
+
 const logger = rendererLogger.component("css-candidate-manifest");
 const SOURCE_EXTENSIONS = [".tsx", ".jsx", ".mdx", ".ts", ".js"];
 const DEV_MANIFEST_TTL_MS = 2_000;
@@ -90,6 +98,29 @@ function buildCandidateManifest(files: SourceFileLike[], projectDir: string): Ca
   return { fileCandidates, allCandidates, builtAt: Date.now() };
 }
 
+function getOrBuildManifest(
+  options: Pick<
+    ProjectCandidateOptions,
+    "projectScope" | "projectVersion" | "projectDir" | "files" | "developmentMode"
+  >,
+): CandidateManifest {
+  const manifestKey = buildManifestCacheKey(options.projectScope, options.projectVersion);
+  const existingManifest = manifestCache.get(manifestKey);
+  const manifest = shouldRebuildManifest(existingManifest, options.developmentMode)
+    ? buildCandidateManifest(options.files, options.projectDir)
+    : existingManifest!;
+
+  if (manifest !== existingManifest) {
+    manifestCache.set(manifestKey, manifest);
+
+    for (const key of routeCandidateCache.keys()) {
+      if (key.startsWith(`${manifestKey}:`)) routeCandidateCache.delete(key);
+    }
+  }
+
+  return manifest;
+}
+
 function addCandidatesForPath(
   target: Set<string>,
   manifest: CandidateManifest,
@@ -109,20 +140,7 @@ function addCandidatesForPath(
  */
 export function getRouteCandidates(options: RouteCandidateOptions): Set<string> {
   const manifestKey = buildManifestCacheKey(options.projectScope, options.projectVersion);
-  const existingManifest = manifestCache.get(manifestKey);
-  const manifest = shouldRebuildManifest(existingManifest, options.developmentMode)
-    ? buildCandidateManifest(options.files, options.projectDir)
-    : existingManifest!;
-
-  if (manifest !== existingManifest) {
-    manifestCache.set(manifestKey, manifest);
-
-    // Clear route subsets when project-level file manifest is rebuilt.
-    for (const key of routeCandidateCache.keys()) {
-      if (key.startsWith(`${manifestKey}:`)) routeCandidateCache.delete(key);
-    }
-  }
-
+  const manifest = getOrBuildManifest(options);
   const routeCacheKey = `${manifestKey}:${options.routeKey}`;
   const cachedRoute = routeCandidateCache.get(routeCacheKey);
   if (cachedRoute) return new Set(cachedRoute);
@@ -154,6 +172,14 @@ export function getRouteCandidates(options: RouteCandidateOptions): Set<string> 
   });
 
   return new Set(routeCandidates);
+}
+
+/**
+ * Resolve full-project Tailwind candidates from a precomputed per-project manifest.
+ */
+export function getProjectCandidates(options: ProjectCandidateOptions): Set<string> {
+  const manifest = getOrBuildManifest(options);
+  return new Set(manifest.allCandidates);
 }
 
 /**

--- a/src/server/handlers/dev/styles-candidate-scanner.ts
+++ b/src/server/handlers/dev/styles-candidate-scanner.ts
@@ -12,6 +12,8 @@ import { extractCandidates } from "#veryfront/html/styles-builder/tailwind-compi
 import { serverLogger } from "#veryfront/utils";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { join } from "#veryfront/compat/path/index.ts";
+import { getProjectCandidates } from "#veryfront/rendering/orchestrator/css-candidate-manifest.ts";
+import type { ResolvedContentContext } from "#veryfront/platform/adapters/fs/veryfront/types.ts";
 import type { HandlerContext } from "../types.ts";
 import { FRAMEWORK_CANDIDATES } from "./framework-candidates.generated.ts";
 
@@ -22,6 +24,25 @@ const SKIP_DIRS = new Set(["node_modules", ".cache", ".git", "dist", "build", ".
 
 /** De-duplicated set of framework candidates, computed once at import time. */
 const frameworkCandidates = new Set<string>(FRAMEWORK_CANDIDATES);
+
+interface SourceFileProvider {
+  getAllSourceFiles?: () =>
+    | Array<{ path: string; content?: string }>
+    | Promise<Array<{ path: string; content?: string }>>;
+  getContentContext?: () => ResolvedContentContext | null;
+}
+
+function resolveProjectVersion(
+  ctx: HandlerContext,
+  contentContext: ResolvedContentContext | null,
+): string {
+  if (contentContext?.releaseId) return `release:${contentContext.releaseId}`;
+  if (contentContext?.branch) return `branch:${contentContext.branch}`;
+  if (contentContext?.environmentName) return `environment:${contentContext.environmentName}`;
+  if (ctx.releaseId) return `release:${ctx.releaseId}`;
+  if (ctx.parsedDomain?.branch) return `branch:${ctx.parsedDomain.branch}`;
+  return "live";
+}
 
 /**
  * Extract Tailwind CSS candidate class names from all project source files.
@@ -42,9 +63,8 @@ export async function extractProjectCandidates(ctx: HandlerContext): Promise<Set
 
   // Call method directly on wrappedFs to preserve 'this' context
   const fsAdapter = wrappedFs.getUnderlyingAdapter() as {
-    getAllSourceFiles?: () =>
-      | Array<{ path: string; content?: string }>
-      | Promise<Array<{ path: string; content?: string }>>;
+    getAllSourceFiles?: SourceFileProvider["getAllSourceFiles"];
+    getContentContext?: SourceFileProvider["getContentContext"];
   };
 
   if (typeof fsAdapter.getAllSourceFiles !== "function") {
@@ -56,14 +76,20 @@ export async function extractProjectCandidates(ctx: HandlerContext): Promise<Set
 
   const candidates = new Set<string>(frameworkCandidates);
   const files = await fsAdapter.getAllSourceFiles();
+  const contentContext = typeof fsAdapter.getContentContext === "function"
+    ? fsAdapter.getContentContext()
+    : null;
 
-  for (const file of files) {
-    if (!file.content) continue;
-    if (!SOURCE_EXTENSIONS.some((ext) => file.path.endsWith(ext))) continue;
-
-    for (const cls of extractCandidates(file.content)) {
-      candidates.add(cls);
-    }
+  for (
+    const cls of getProjectCandidates({
+      projectScope: ctx.projectSlug ?? contentContext?.projectSlug ?? ctx.projectDir,
+      projectVersion: resolveProjectVersion(ctx, contentContext),
+      projectDir: ctx.projectDir,
+      files,
+      developmentMode: contentContext?.sourceType === "branch",
+    })
+  ) {
+    candidates.add(cls);
   }
 
   return candidates;

--- a/src/server/handlers/dev/styles-css.handler.test.ts
+++ b/src/server/handlers/dev/styles-css.handler.test.ts
@@ -1,0 +1,115 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { HandlerContext } from "../types.ts";
+import type { ResolvedContentContext } from "#veryfront/platform/adapters/fs/veryfront/types.ts";
+import {
+  clearCSSCache,
+  invalidateCompiler,
+  invalidateProjectCSS,
+} from "#veryfront/html/styles-builder/tailwind-compiler.ts";
+import { StylesCSSHandler } from "./styles-css.handler.ts";
+
+const TEST_STYLESHEET = `@import "tailwindcss";`;
+const PROJECT_SLUG = "dreamy-haven";
+
+function mockTailwindFetch(): { restore: () => void; getCallCount: () => number } {
+  const originalFetch = globalThis.fetch;
+  let fetchCallCount = 0;
+
+  globalThis.fetch = ((input: URL | Request | string) => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.toString()
+      : input.url;
+
+    if (!url.includes("tailwindcss")) {
+      return Promise.reject(new Error(`Unexpected fetch URL during test: ${url}`));
+    }
+
+    fetchCallCount++;
+    return Promise.resolve(
+      new Response("@layer theme, base, components, utilities;", { status: 200 }),
+    );
+  }) as typeof fetch;
+
+  return {
+    restore: () => {
+      globalThis.fetch = originalFetch;
+    },
+    getCallCount: () => fetchCallCount,
+  };
+}
+
+function createHandlerAdapter(
+  files: Array<{ path: string; content?: string }>,
+  contentContext: ResolvedContentContext,
+): RuntimeAdapter {
+  const adapter = createMockAdapter();
+  adapter.fs.files.set("/project/globals.css", TEST_STYLESHEET);
+
+  return {
+    ...adapter,
+    fs: {
+      ...adapter.fs,
+      getUnderlyingAdapter: () => ({
+        getAllSourceFiles: async () => files,
+        getContentContext: () => contentContext,
+      }),
+    },
+  } as unknown as RuntimeAdapter;
+}
+
+function makeCtx(adapter: RuntimeAdapter): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter,
+    securityConfig: null,
+    cspUserHeader: null,
+    projectSlug: PROJECT_SLUG,
+  };
+}
+
+describe("server/handlers/dev/styles-css.handler", () => {
+  it("serves project CSS from the project cache after the first request", async () => {
+    const fetchMock = mockTailwindFetch();
+    const handler = new StylesCSSHandler();
+    const adapter = createHandlerAdapter(
+      [{ path: "/project/pages/index.tsx", content: '<div className="text-red-500">Hello</div>' }],
+      { sourceType: "release", projectSlug: PROJECT_SLUG, releaseId: "rel-1" },
+    );
+    const ctx = makeCtx(adapter);
+    const req = new Request("http://localhost/_vf_styles/styles.css");
+
+    try {
+      clearCSSCache();
+      invalidateCompiler();
+      invalidateProjectCSS(PROJECT_SLUG);
+
+      const first = await handler.handle(req, ctx);
+      const firstBody = await first.response!.text();
+      const initialFetchCount = fetchMock.getCallCount();
+
+      assertEquals(first.continue, false);
+      assertEquals(first.response!.status, 200);
+      assertEquals(firstBody.length > 0, true);
+      assertEquals(initialFetchCount > 0, true);
+
+      invalidateCompiler();
+
+      const second = await handler.handle(req, ctx);
+      const secondBody = await second.response!.text();
+
+      assertEquals(second.response!.status, 200);
+      assertEquals(secondBody, firstBody);
+      assertEquals(fetchMock.getCallCount(), initialFetchCount);
+    } finally {
+      fetchMock.restore();
+      clearCSSCache();
+      invalidateCompiler();
+      invalidateProjectCSS(PROJECT_SLUG);
+    }
+  });
+});

--- a/src/server/handlers/dev/styles-css.handler.ts
+++ b/src/server/handlers/dev/styles-css.handler.ts
@@ -12,12 +12,17 @@ import { joinPath } from "#veryfront/utils/path-utils.ts";
 import {
   formatCSSError,
   generateTailwindCSS,
+  getProjectCSS,
 } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
 import { DEFAULT_STYLESHEET } from "#veryfront/html/styles-builder/css-hash-cache.ts";
 import { serverLogger } from "#veryfront/utils";
 import { extractProjectCandidates } from "./styles-candidate-scanner.ts";
 
 const logger = serverLogger.component("styles-css-handler");
+
+type GeneratedStylesResult =
+  | Awaited<ReturnType<typeof generateTailwindCSS>>
+  | Awaited<ReturnType<typeof getProjectCSS>>;
 
 export class StylesCSSHandler extends BaseHandler {
   metadata: HandlerMetadata = {
@@ -52,11 +57,9 @@ export class StylesCSSHandler extends BaseHandler {
           });
           candidates = new Set<string>();
         }
-        const result = await generateTailwindCSS(rawCss, candidates, {
-          projectSlug: ctx.projectSlug,
-        });
+        const result = await this.generateStylesheet(ctx, rawCss, candidates);
 
-        if (result.error) {
+        if ("error" in result && result.error) {
           const formatted = formatCSSError(result.error);
           logger.error("Tailwind error", {
             error: formatted.message,
@@ -102,6 +105,8 @@ body::before {
         logger.debug("CSS generated", {
           candidates: candidates.size,
           cssLength: result.css.length,
+          fromCache: "fromCache" in result ? result.fromCache : false,
+          cssHash: "hash" in result ? result.hash : undefined,
         });
 
         return this.respond(
@@ -141,5 +146,21 @@ body::before {
       logger.debug("No stylesheet found, using default");
       return DEFAULT_STYLESHEET;
     }
+  }
+
+  private generateStylesheet(
+    ctx: HandlerContext,
+    rawCss: string,
+    candidates: Set<string>,
+  ): Promise<GeneratedStylesResult> {
+    if (!ctx.projectSlug) {
+      return generateTailwindCSS(rawCss, candidates);
+    }
+
+    return getProjectCSS(ctx.projectSlug, rawCss, candidates, {
+      minify: true,
+      environment: "preview",
+      buildMode: "production",
+    });
   }
 }


### PR DESCRIPTION
## Summary
- serve `/_vf_styles/styles.css` through the existing project CSS cache path
- reuse the project candidate manifest for full-project candidate extraction
- add regression coverage for stylesheet cache hits and project candidate manifests
- bump the next release line to `0.1.85`

## Verification
- `deno test --allow-env src/server/handlers/dev/styles-css.handler.test.ts src/rendering/orchestrator/css-candidate-manifest.test.ts src/html/styles-builder/project-css-cache.test.ts`
- `deno task verify:quick`
- full pre-push unit suite (`1191 passed, 0 failed`)