### PR TITLE
fix: rewarm preview file list cache in background

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/discovery/transpiler.test.ts
+++ b/src/discovery/transpiler.test.ts
@@ -87,7 +87,8 @@ describe("embedding module static import", () => {
   });
 });
 
-describe("discovery/transpiler", () => {
+// esbuild starts a child process that lives across tests, so we disable sanitizers
+describe("discovery/transpiler", { sanitizeOps: false, sanitizeResources: false }, () => {
   afterEach(() => {
     clearTranspileCache();
   });

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { VeryfrontFSAdapter } from "./adapter.ts";
+import { buildFileListCacheKey } from "./cache-keys.ts";
 import type { FSAdapterConfig, ResolvedContentContext } from "./types.ts";
 
 function createAdapter(
@@ -15,6 +16,20 @@ function createAdapter(
     },
     ...overrides,
   });
+}
+
+async function waitFor(
+  predicate: () => Promise<boolean>,
+  timeoutMs = 200,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  throw new Error("Timed out waiting for condition");
 }
 
 describe("VeryfrontFSAdapter", () => {
@@ -376,6 +391,144 @@ describe("VeryfrontFSAdapter", () => {
           processRef.off("unhandledRejection", nodeStyleHandler);
         }
       }
+    });
+
+    it("should rehydrate a missing file list cache in the background", async () => {
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          cache: { enabled: true },
+        },
+      });
+
+      const files = [{
+        path: "pages/index.tsx",
+        content: "export default function Page() { return null }",
+      }];
+
+      let listAllFilesCalls = 0;
+      const client = (adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          listAllFiles: () => Promise<Array<{ path: string; content?: string }>>;
+        };
+      }).client;
+
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+      client.listAllFiles = () => {
+        listAllFilesCalls++;
+        return Promise.resolve(files);
+      };
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      adapter.setContentContext({
+        sourceType: "branch",
+        projectSlug: "test-project",
+        branch: "main",
+      });
+
+      await adapter.initialize();
+      assertEquals(listAllFilesCalls, 1);
+
+      const cacheKey = buildFileListCacheKey(adapter.getContentContext());
+      const cache = (adapter as unknown as {
+        cache: {
+          delete: (key: string) => boolean;
+          getAsync: <T>(key: string) => Promise<T | undefined>;
+        };
+      }).cache;
+
+      assertEquals(cache.delete(cacheKey), true);
+      assertEquals(await adapter.getAllSourceFiles(), []);
+
+      await waitFor(async () => {
+        const cached = await cache.getAsync<Array<{ path: string; content?: string }>>(cacheKey);
+        return Array.isArray(cached) && cached.length === 1;
+      });
+
+      const cached = await cache.getAsync<Array<{ path: string; content?: string }>>(cacheKey);
+      assertEquals(listAllFilesCalls, 2);
+      assertEquals(cached?.[0]?.path, "pages/index.tsx");
+    });
+
+    it("should deduplicate concurrent background file list warmups", async () => {
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          cache: { enabled: true },
+        },
+      });
+
+      const files = [{
+        path: "pages/index.tsx",
+        content: "export default function Page() { return null }",
+      }];
+
+      let listAllFilesCalls = 0;
+      const client = (adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          listAllFiles: () => Promise<Array<{ path: string; content?: string }>>;
+        };
+      }).client;
+
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+      client.listAllFiles = async () => {
+        listAllFilesCalls++;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return files;
+      };
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      adapter.setContentContext({
+        sourceType: "branch",
+        projectSlug: "test-project",
+        branch: "main",
+      });
+
+      await adapter.initialize();
+      assertEquals(listAllFilesCalls, 1);
+
+      const cacheKey = buildFileListCacheKey(adapter.getContentContext());
+      const cache = (adapter as unknown as {
+        cache: {
+          delete: (key: string) => boolean;
+          getAsync: <T>(key: string) => Promise<T | undefined>;
+        };
+      }).cache;
+
+      assertEquals(cache.delete(cacheKey), true);
+
+      await Promise.all([
+        adapter.getAllSourceFiles(),
+        adapter.getAllSourceFiles(),
+        adapter.getAllSourceFiles(),
+      ]);
+
+      await waitFor(async () => {
+        const cached = await cache.getAsync<Array<{ path: string; content?: string }>>(cacheKey);
+        return Array.isArray(cached) && cached.length === 1;
+      });
+
+      assertEquals(listAllFilesCalls, 2);
     });
   });
 });

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -49,6 +49,9 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
   /** Resolves when file list initialization is complete (for coordinating reads) */
   private fileListReadyResolve: (() => void) | null = null;
+  /** Single-flight background rewarm when the file list cache disappears */
+  private fileListWarmupPromise: Promise<void> | null = null;
+  private fileListWarmupKey: string | null = null;
 
   private projectData?: Project;
   private apiBaseUrl: string;
@@ -140,6 +143,10 @@ export class VeryfrontFSAdapter implements FSAdapter {
           resultSize: result?.length ?? 0,
         });
 
+        if (!result?.length) {
+          this.scheduleFileListWarmup("getFileList miss", cacheKey);
+        }
+
         return result;
       },
       hasCachedFileList: async () => {
@@ -157,6 +164,10 @@ export class VeryfrontFSAdapter implements FSAdapter {
           hasResult,
           resultSize: result?.length ?? 0,
         });
+
+        if (!hasResult) {
+          this.scheduleFileListWarmup("hasCachedFileList miss", cacheKey);
+        }
 
         return hasResult;
       },
@@ -201,6 +212,10 @@ export class VeryfrontFSAdapter implements FSAdapter {
           resultSize: result?.length ?? 0,
           hasContent: result?.filter((f) => f.content)?.length ?? 0,
         });
+
+        if (!result?.length) {
+          this.scheduleFileListWarmup("getFileListCache miss", cacheKey);
+        }
 
         return result;
       },
@@ -389,6 +404,73 @@ export class VeryfrontFSAdapter implements FSAdapter {
     return isPrefixBeingInvalidated(prefix);
   }
 
+  private scheduleFileListWarmup(reason: string, cacheKey?: string): void {
+    if (!this.initialized || !this.contentContext) return;
+
+    const effectiveCacheKey = cacheKey ?? buildFileListCacheKey(this.contentContext);
+
+    if (this.fileListWarmupPromise && this.fileListWarmupKey === effectiveCacheKey) {
+      logger.debug("File list warmup already in progress", {
+        reason,
+        cacheKey: effectiveCacheKey,
+      });
+      return;
+    }
+
+    const warmupContext = this.contentContext;
+    let warmupPromise: Promise<void> | null = null;
+    warmupPromise = (async () => {
+      try {
+        const existing = await this.cache.getAsync<Array<{ path: string; content?: string }>>(
+          effectiveCacheKey,
+        );
+
+        if (existing?.length) {
+          logger.debug("Skipping file list warmup because cache is already populated", {
+            reason,
+            cacheKey: effectiveCacheKey,
+            fileCount: existing.length,
+          });
+          return;
+        }
+
+        logger.debug("Starting file list warmup", {
+          reason,
+          cacheKey: effectiveCacheKey,
+          sourceType: warmupContext.sourceType,
+          branch: warmupContext.branch,
+          environmentName: warmupContext.environmentName,
+          releaseId: warmupContext.releaseId,
+        });
+
+        const files = await fetchFileListForContext(this.client, warmupContext);
+        await this.cache.setAsync(effectiveCacheKey, files);
+
+        logger.debug("File list warmup complete", {
+          reason,
+          cacheKey: effectiveCacheKey,
+          totalFiles: files.length,
+          filesWithContent: files.filter((file) => file.content).length,
+        });
+      } catch (error) {
+        logger.warn("File list warmup failed", {
+          reason,
+          cacheKey: effectiveCacheKey,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      } finally {
+        if (warmupPromise && this.fileListWarmupPromise === warmupPromise) {
+          this.fileListWarmupPromise = null;
+          this.fileListWarmupKey = null;
+        }
+      }
+    })();
+
+    this.fileListWarmupPromise = warmupPromise;
+    this.fileListWarmupKey = effectiveCacheKey;
+    this.readOps.setFileListReadyPromise(warmupPromise);
+  }
+
   getPokeMetrics(): {
     received: number;
     invalidationsTriggered: number;
@@ -442,6 +524,8 @@ export class VeryfrontFSAdapter implements FSAdapter {
     this.statOps.clearIndex();
     this.dirOps.clearTree();
     this.initialized = false;
+    this.fileListWarmupPromise = null;
+    this.fileListWarmupKey = null;
 
     logger.debug("Disposed");
   }
@@ -473,6 +557,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
         hasFiles: !!files,
         fileCount: files?.length ?? 0,
       });
+      this.scheduleFileListWarmup("getAllSourceFiles miss", cacheKey);
       return [];
     }
 
@@ -584,6 +669,8 @@ export class VeryfrontFSAdapter implements FSAdapter {
     if (contextChanged) {
       this.statOps.clearIndex();
       this.dirOps.clearTree();
+      this.fileListWarmupPromise = null;
+      this.fileListWarmupKey = null;
       logger.debug("Cleared index and dirTree due to context change", {
         oldContext,
         newContext: context,


### PR DESCRIPTION
## Summary\n- rehydrate missing preview file-list caches in the background instead of staying permanently cold\n- deduplicate concurrent rewarm attempts with single-flight behavior\n- add regression tests for cache rehydration and warmup deduplication\n\n## Verification\n- deno test --allow-env src/platform/adapters/fs/veryfront/adapter.test.ts\n- deno fmt --check src/platform/adapters/fs/veryfront/adapter.ts src/platform/adapters/fs/veryfront/adapter.test.ts\n- deno lint src/platform/adapters/fs/veryfront/adapter.ts src/platform/adapters/fs/veryfront/adapter.test.ts\n- deno check src/platform/adapters/fs/veryfront/adapter.ts\n- deno check src/platform/adapters/fs/veryfront/adapter.test.ts