### PR TITLE
perf: skip preview probes proven missing by file list

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/platform/adapters/fs/veryfront/content-metrics.ts
+++ b/src/platform/adapters/fs/veryfront/content-metrics.ts
@@ -8,7 +8,12 @@ import {
 const logger = baseLogger.component("content-metrics");
 
 type FileType = "page" | "layout" | "component" | "api" | "data" | "config" | "other";
-export type MissReason = "cold_start" | "not_in_filelist" | "invalidation" | "no_filelist_cache";
+export type MissReason =
+  | "cold_start"
+  | "not_in_filelist"
+  | "invalidation"
+  | "no_filelist_cache"
+  | "indexed_without_content";
 
 interface PerRequestMetrics {
   startTime: number;
@@ -52,7 +57,13 @@ function createFreshRequestMetrics(): PerRequestMetrics {
     networkFetches: 0,
     networkMs: 0,
     fetchesByType: { page: 0, layout: 0, component: 0, api: 0, data: 0, config: 0, other: 0 },
-    missReasons: { cold_start: 0, not_in_filelist: 0, invalidation: 0, no_filelist_cache: 0 },
+    missReasons: {
+      cold_start: 0,
+      not_in_filelist: 0,
+      invalidation: 0,
+      no_filelist_cache: 0,
+      indexed_without_content: 0,
+    },
     isPreviewMode: null,
     filesAccessed: new Set(),
   };

--- a/src/platform/adapters/fs/veryfront/file-list-index.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-index.test.ts
@@ -42,6 +42,34 @@ describe("platform/adapters/fs/veryfront/file-list-index", () => {
       const index = new FileListIndex(async () => []);
       assertEquals(await index.lookup("test.ts"), undefined);
     });
+
+    it("should report exact path presence even when inline content is missing", async () => {
+      const index = new FileListIndex(async () => [
+        { path: "deno.json" },
+      ]);
+
+      assertEquals(await index.match("deno.json"), {
+        status: "present_without_content",
+        fresh: true,
+        path: "deno.json",
+      });
+    });
+
+    it("should find the first existing candidate path in priority order", async () => {
+      const index = new FileListIndex(async () => [
+        { path: "pages/home.tsx" },
+        { path: "pages/home.jsx", content: "jsx content" },
+      ]);
+
+      assertEquals(
+        await index.findFirstMatch(["pages/home.tsx", "pages/home.jsx"]),
+        {
+          status: "present_without_content",
+          fresh: true,
+          path: "pages/home.tsx",
+        },
+      );
+    });
   });
 
   describe("clear", () => {

--- a/src/platform/adapters/fs/veryfront/file-list-index.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-index.ts
@@ -7,6 +7,13 @@ interface FileListCacheEntry {
   content?: string;
 }
 
+export interface FileListMatchResult {
+  status: "unavailable" | "missing" | "present_without_content" | "hit";
+  fresh: boolean;
+  path?: string;
+  content?: string;
+}
+
 function hashPreview(content: string): number {
   return content
     .slice(0, 100)
@@ -22,8 +29,10 @@ const INDEX_STALENESS_LIMIT_MS = 5 * 60 * 1000; // 5 minutes
 
 export class FileListIndex {
   private index: Map<string, string> | null = null;
+  private pathSet: Set<string> | null = null;
   private indexKey: string | null = null;
   private indexBuiltAt = 0;
+  private indexFresh = false;
   private readyPromise: Promise<void> | null = null;
 
   constructor(
@@ -39,8 +48,10 @@ export class FileListIndex {
 
     const indexedWithContent = this.index.size;
     this.index = null;
+    this.pathSet = null;
     this.indexKey = null;
     this.indexBuiltAt = 0;
+    this.indexFresh = false;
     logger.debug("Cleared file list index", { indexedWithContent });
   }
 
@@ -56,21 +67,39 @@ export class FileListIndex {
   }
 
   async lookup(normalizedPath: string): Promise<string | undefined> {
+    const match = await this.match(normalizedPath);
+    return match.status === "hit" ? match.content : undefined;
+  }
+
+  async match(normalizedPath: string): Promise<FileListMatchResult> {
     await this.ensureReady();
 
-    const index = await this.getOrBuild();
-    if (!index) {
+    const snapshot = await this.getOrBuild();
+    if (!snapshot) {
       logger.debug("No file list cache available");
-      return undefined;
+      return { status: "unavailable", fresh: false };
     }
 
-    const content = index.get(normalizedPath);
-    if (!content) {
+    if (!snapshot.paths.has(normalizedPath)) {
       logger.debug("Content not in file list index", {
         path: normalizedPath,
-        indexSize: index.size,
+        indexSize: snapshot.content.size,
+        fresh: snapshot.fresh,
       });
-      return undefined;
+      return { status: "missing", fresh: snapshot.fresh };
+    }
+
+    const content = snapshot.content.get(normalizedPath);
+    if (!content) {
+      logger.debug("File list index contains path without inline content", {
+        path: normalizedPath,
+        fresh: snapshot.fresh,
+      });
+      return {
+        status: "present_without_content",
+        fresh: snapshot.fresh,
+        path: normalizedPath,
+      };
     }
 
     logger.debug("FILE_LIST_CACHE_HIT - serving from file list cache", {
@@ -80,26 +109,60 @@ export class FileListIndex {
       contentPreview: previewText(content, 200).replace(/\n/g, "\\n"),
     });
 
-    return content;
+    return {
+      status: "hit",
+      fresh: snapshot.fresh,
+      path: normalizedPath,
+      content,
+    };
   }
 
   async findFirstWithContent(
     normalizedPaths: string[],
   ): Promise<{ path: string; content: string } | undefined> {
-    await this.ensureReady();
-
-    const index = await this.getOrBuild();
-    if (!index) return undefined;
-
-    for (const path of normalizedPaths) {
-      const content = index.get(path);
-      if (content) return { path, content };
-    }
-
-    return undefined;
+    const match = await this.findFirstMatch(normalizedPaths);
+    if (match.status !== "hit" || !match.path || !match.content) return undefined;
+    return { path: match.path, content: match.content };
   }
 
-  private async getOrBuild(): Promise<Map<string, string> | null> {
+  async findFirstMatch(
+    normalizedPaths: string[],
+  ): Promise<FileListMatchResult> {
+    await this.ensureReady();
+
+    const snapshot = await this.getOrBuild();
+    if (!snapshot) return { status: "unavailable", fresh: false };
+
+    for (const path of normalizedPaths) {
+      if (!snapshot.paths.has(path)) continue;
+
+      const content = snapshot.content.get(path);
+      if (content) {
+        return {
+          status: "hit",
+          fresh: snapshot.fresh,
+          path,
+          content,
+        };
+      }
+
+      return {
+        status: "present_without_content",
+        fresh: snapshot.fresh,
+        path,
+      };
+    }
+
+    return { status: "missing", fresh: snapshot.fresh };
+  }
+
+  private async getOrBuild(): Promise<
+    {
+      content: Map<string, string>;
+      paths: Set<string>;
+      fresh: boolean;
+    } | null
+  > {
     if (!this.getFileListCache) {
       logger.debug("getOrBuildFileListIndex: no getFileListCache function");
       return null;
@@ -118,7 +181,12 @@ export class FileListIndex {
             indexSize: this.index.size,
             indexAgeMs: age,
           });
-          return this.index;
+          this.indexFresh = false;
+          return {
+            content: this.index,
+            paths: this.pathSet ?? new Set<string>(),
+            fresh: false,
+          };
         }
         logger.debug("getOrBuildFileListIndex: in-memory index too stale, discarding", {
           indexSize: this.index.size,
@@ -126,7 +194,9 @@ export class FileListIndex {
           staleLimitMs: INDEX_STALENESS_LIMIT_MS,
         });
         this.index = null;
+        this.pathSet = null;
         this.indexKey = null;
+        this.indexFresh = false;
       }
       logger.debug(
         "[ReadOperations] getOrBuildFileListIndex: getFileListCache returned null/undefined",
@@ -146,19 +216,28 @@ export class FileListIndex {
     const indexKey = `${fileList.length}:${fileList[0]?.path ?? ""}:${
       fileList[fileList.length - 1]?.path ?? ""
     }`;
-    if (this.index && this.indexKey === indexKey) {
+    if (this.index && this.pathSet && this.indexKey === indexKey) {
       this.indexBuiltAt = Date.now();
-      return this.index;
+      this.indexFresh = true;
+      return {
+        content: this.index,
+        paths: this.pathSet,
+        fresh: true,
+      };
     }
 
     const index = new Map<string, string>();
+    const pathSet = new Set<string>();
     for (const file of fileList) {
+      pathSet.add(file.path);
       if (file.content) index.set(file.path, file.content);
     }
 
     this.index = index;
+    this.pathSet = pathSet;
     this.indexKey = indexKey;
     this.indexBuiltAt = Date.now();
+    this.indexFresh = true;
 
     const sampleFile = fileList.find((f) => /welcome/i.test(f.path));
     const sampleContent = sampleFile?.content;
@@ -171,6 +250,10 @@ export class FileListIndex {
       sampleContentPreview: sampleContent?.slice(0, 200)?.replace(/\n/g, "\\n"),
     });
 
-    return index;
+    return {
+      content: index,
+      paths: pathSet,
+      fresh: true,
+    };
   }
 }

--- a/src/platform/adapters/fs/veryfront/read-operations-helpers.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations-helpers.ts
@@ -6,6 +6,8 @@ import type { ResolvedContentContext } from "./types.ts";
 
 export { READ_OPERATION_EXTENSION_PRIORITY };
 
+export type NotFoundLikeError = Error & { code?: string };
+
 interface ReadContextProviderLike {
   isProductionMode: () => boolean;
   isPersistentCacheInvalidated?: (prefix: string) => boolean;
@@ -78,6 +80,10 @@ export function getResolvedCacheKey(
   return `${cacheKeyPrefix}:${normalizedResolvedPath}`;
 }
 
+export function buildExtensionCandidatePaths(basePath: string): string[] {
+  return READ_OPERATION_EXTENSION_PRIORITY.map((ext) => `${basePath}${ext}`);
+}
+
 export function splitKnownFileExtension(
   apiPath: string,
 ): { originalExtension: string; basePath: string } | null {
@@ -94,4 +100,8 @@ export function splitKnownFileExtension(
 export function isNotFoundLikeError(error: unknown): boolean {
   const errorMessage = error instanceof Error ? error.message : String(error);
   return errorMessage.includes("404") || errorMessage.includes("Not Found");
+}
+
+export function createNotFoundLikeError(path: string): NotFoundLikeError {
+  return Object.assign(new Error(`404 Not Found: ${path}`), { code: "ENOENT" });
 }

--- a/src/platform/adapters/fs/veryfront/read-operations.test.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
 import { FileCache } from "../cache/file-cache.ts";
@@ -50,7 +50,7 @@ function createReadOps(
   cacheEnabled: boolean,
   contextProvider?: ContentContextProvider,
   pathResolver?: (path: string) => string,
-  getFileListCache?: () => Promise<Array<{ path: string; content: string }>>,
+  getFileListCache?: () => Promise<Array<{ path: string; content?: string }>>,
   pathNormalizer = new PathNormalizer(),
 ): ReadOperations {
   return new ReadOperations(
@@ -370,7 +370,7 @@ describe("ReadOperations", () => {
       assertEquals(apiFetchCount, 0);
     });
 
-    it("should fall back to API for explicit dotted files missing from file list cache", async () => {
+    it("should fail fast for explicit files missing from a fresh file list cache", async () => {
       let resolveCallCount = 0;
       let apiFetchCount = 0;
 
@@ -395,11 +395,75 @@ describe("ReadOperations", () => {
 
       readOps.setFileListReadyPromise(Promise.resolve());
 
+      await assertRejects(
+        () => readOps.readTextFile("deno.json"),
+        Error,
+        "404 Not Found",
+      );
+
+      assertEquals(resolveCallCount, 0);
+      assertEquals(apiFetchCount, 0);
+    });
+
+    it("should fetch an exact indexed file when the file list omits inline content", async () => {
+      let fileFetchCount = 0;
+
+      const client = createMockClient({
+        getPublishedFileContent: (path: string) => {
+          fileFetchCount++;
+          return Promise.resolve(`content for ${path}`);
+        },
+      });
+
+      const readOps = createReadOps(
+        client,
+        true,
+        createReleaseContext("rel-deno-inline-miss"),
+        (path: string) => path,
+        () => Promise.resolve([{ path: "deno.json" }]),
+      );
+
+      readOps.setFileListReadyPromise(Promise.resolve());
+
       const content = await readOps.readTextFile("deno.json");
 
-      assertEquals(content, "published API content");
-      assertEquals(resolveCallCount, 1);
-      assertEquals(apiFetchCount, 1);
+      assertEquals(content, "content for deno.json");
+      assertEquals(fileFetchCount, 1);
+    });
+
+    it("should fetch the resolved extension candidate directly when the file list knows the path", async () => {
+      let resolveCallCount = 0;
+      let publishedFetchPath: string | undefined;
+
+      const client = createMockClient({
+        resolveFileWithExtension: () => {
+          resolveCallCount++;
+          return Promise.resolve({
+            path: "pages/home.tsx",
+            content: "resolved via API",
+          });
+        },
+        getPublishedFileContent: (path: string) => {
+          publishedFetchPath = path;
+          return Promise.resolve("content from exact fetch");
+        },
+      });
+
+      const readOps = createReadOps(
+        client,
+        true,
+        createReleaseContext("rel-candidate-inline-miss"),
+        (path: string) => path,
+        () => Promise.resolve([{ path: "pages/home.tsx" }]),
+      );
+
+      readOps.setFileListReadyPromise(Promise.resolve());
+
+      const content = await readOps.readTextFile("pages/home");
+
+      assertEquals(content, "content from exact fetch");
+      assertEquals(resolveCallCount, 0);
+      assertEquals(publishedFetchPath, "pages/home.tsx");
     });
 
     it("should cache extension resolution to avoid repeated API calls", async () => {

--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -3,13 +3,15 @@ import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import type { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
 import { FileCache } from "../cache/file-cache.ts";
 import { logContentMetric, type MissReason } from "./content-metrics.ts";
-import { FileListIndex } from "./file-list-index.ts";
+import { FileListIndex, type FileListMatchResult } from "./file-list-index.ts";
 import { InFlightRequestDeduper } from "./in-flight-dedupe.ts";
 import { getRequestScopedFile, setRequestScopedFile } from "./multi-project-adapter.ts";
 import { PathNormalizer } from "./path-normalizer.ts";
 import {
   assertProjectSourcePath,
+  buildExtensionCandidatePaths,
   buildReadFetchState,
+  createNotFoundLikeError,
   getResolvedCacheKey,
   isNotFoundLikeError,
   READ_OPERATION_EXTENSION_PRIORITY as EXTENSION_PRIORITY,
@@ -184,17 +186,23 @@ export class ReadOperations {
     skipPersistentCaches: boolean,
     isPreviewMode: boolean,
     ctx: ResolvedContentContext | null,
-  ): Promise<string | null> {
+  ): Promise<FileListMatchResult> {
     // File list cache is enabled for BOTH preview and production modes.
     // The file list is an in-memory index built from API response at init, updated by WebSocket pokes.
     // This is safe because:
     // - File list is refreshed on every WebSocket poke (websocket-manager.ts:483-500)
     // - Request-scoped cache ensures consistency within a single render
     // - Persistent cache is only written for production mode (to avoid staleness risk in preview)
-    if (!skipPersistentCaches) {
-      const fileListContent = await this.fileListIndex.lookup(normalizedPath);
-      if (!fileListContent) return null;
+    if (skipPersistentCaches) {
+      logger.debug("Skipping file list cache due to invalidation", {
+        path: normalizedPath,
+        cacheKeyPrefix,
+      });
+      return { status: "unavailable", fresh: false };
+    }
 
+    const match = await this.fileListIndex.match(normalizedPath);
+    if (match.status === "hit" && match.content) {
       logContentMetric("FILE_LIST_HIT", {
         path: normalizedPath,
         mode: ctx?.sourceType ?? "unknown",
@@ -204,24 +212,12 @@ export class ReadOperations {
       // Only cache to persistent storage for production mode
       // Preview mode uses file list cache directly without persisting (fresher, WebSocket-driven)
       if (isProduction) {
-        this.cache.set(cacheKey, fileListContent);
+        this.cache.set(cacheKey, match.content);
       }
-      setRequestScopedFile(cacheKey, fileListContent);
-      return fileListContent;
+      setRequestScopedFile(cacheKey, match.content);
     }
 
-    // Skip only happens during cache invalidation (both preview and production)
-    logContentMetric("CACHE_MISS", {
-      path: normalizedPath,
-      mode: ctx?.sourceType ?? "unknown",
-      missReason: "invalidation" as MissReason,
-      isPreviewMode,
-    });
-    logger.debug("Skipping file list cache due to invalidation", {
-      path: normalizedPath,
-      cacheKeyPrefix,
-    });
-    return null;
+    return match;
   }
 
   private setupInFlightFetch(
@@ -232,6 +228,7 @@ export class ReadOperations {
     isProduction: boolean,
     isPreviewMode: boolean,
     ctx: ResolvedContentContext | null,
+    missReason: MissReason,
   ): Promise<string> {
     const cleanupResult = this.inFlightRequests.cleanup();
     if (cleanupResult) {
@@ -249,11 +246,10 @@ export class ReadOperations {
     }
 
     // Track why we're making a network fetch (for optimization analysis)
-    const hasFileListCache = !!this.getFileListCache;
     logContentMetric("CACHE_MISS", {
       path: normalizedPath,
       mode: ctx?.sourceType ?? "unknown",
-      missReason: (hasFileListCache ? "not_in_filelist" : "no_filelist_cache") as MissReason,
+      missReason,
       isPreviewMode,
     });
 
@@ -377,10 +373,10 @@ export class ReadOperations {
     isProduction: boolean,
     ctx: ResolvedContentContext | null,
     isPreviewMode: boolean,
-  ): Promise<string | null> {
-    const candidatePaths = EXTENSION_PRIORITY.map((ext) => `${normalizedPath}${ext}`);
-    const resolved = await this.fileListIndex.findFirstWithContent(candidatePaths);
-    if (!resolved) return null;
+  ): Promise<FileListMatchResult> {
+    const candidatePaths = buildExtensionCandidatePaths(normalizedPath);
+    const resolved = await this.fileListIndex.findFirstMatch(candidatePaths);
+    if (resolved.status !== "hit" || !resolved.path || !resolved.content) return resolved;
 
     const resolvedCacheKey = getResolvedCacheKey(cacheKeyPrefix, resolved.path);
 
@@ -402,7 +398,7 @@ export class ReadOperations {
 
     this.cacheResolvedContent(cacheKey, resolvedCacheKey, resolved.content, isProduction);
 
-    return resolved.content;
+    return resolved;
   }
 
   private cacheResolvedContent(
@@ -472,7 +468,7 @@ export class ReadOperations {
     );
     if (persistentCached) return persistentCached;
 
-    const fileListCached = await this.getFileListCacheHit(
+    const fileListMatch = await this.getFileListCacheHit(
       normalizedPath,
       cacheKeyPrefix,
       cacheKey,
@@ -481,7 +477,19 @@ export class ReadOperations {
       isPreviewMode,
       ctx,
     );
-    if (fileListCached) return fileListCached;
+    if (fileListMatch.status === "hit" && fileListMatch.content) return fileListMatch.content;
+    if (fileListMatch.status === "present_without_content") {
+      return this.setupInFlightFetch(
+        normalizedPath,
+        apiPath,
+        cacheKey,
+        isPublished,
+        isProduction,
+        isPreviewMode,
+        ctx,
+        "indexed_without_content",
+      );
+    }
 
     if (!hasKnownExt) {
       if (!skipPersistentCaches) {
@@ -493,7 +501,47 @@ export class ReadOperations {
           ctx,
           isPreviewMode,
         );
-        if (resolvedFromFileList) return resolvedFromFileList;
+        if (resolvedFromFileList.status === "hit" && resolvedFromFileList.content) {
+          return resolvedFromFileList.content;
+        }
+
+        if (
+          resolvedFromFileList.status === "present_without_content" &&
+          resolvedFromFileList.path
+        ) {
+          const resolvedCacheKey = getResolvedCacheKey(cacheKeyPrefix, resolvedFromFileList.path);
+          const resolvedApiPath = this.getOriginalApiPath?.(resolvedFromFileList.path) ??
+            resolvedFromFileList.path;
+          const fetchedResolved = await this.setupInFlightFetch(
+            resolvedFromFileList.path,
+            resolvedApiPath,
+            resolvedCacheKey,
+            isPublished,
+            isProduction,
+            isPreviewMode,
+            ctx,
+            "indexed_without_content",
+          );
+
+          this.extensionResolutionCache.set(normalizedPath, resolvedFromFileList.path);
+          this.cacheResolvedContent(
+            cacheKey,
+            resolvedCacheKey,
+            fetchedResolved,
+            isProduction && !skipPersistentCaches,
+          );
+
+          return fetchedResolved;
+        }
+
+        if (
+          fileListMatch.status === "missing" &&
+          fileListMatch.fresh &&
+          resolvedFromFileList.status === "missing" &&
+          resolvedFromFileList.fresh
+        ) {
+          throw createNotFoundLikeError(normalizedPath);
+        }
       }
 
       const resolved = await this.tryResolveExtensionlessPath(
@@ -506,6 +554,10 @@ export class ReadOperations {
       if (resolved) return resolved;
     }
 
+    if (fileListMatch.status === "missing" && fileListMatch.fresh) {
+      throw createNotFoundLikeError(normalizedPath);
+    }
+
     return this.setupInFlightFetch(
       normalizedPath,
       apiPath,
@@ -514,6 +566,11 @@ export class ReadOperations {
       isProduction,
       isPreviewMode,
       ctx,
+      skipPersistentCaches
+        ? "invalidation"
+        : fileListMatch.status === "missing" && fileListMatch.fresh
+        ? "not_in_filelist"
+        : "no_filelist_cache",
     );
   }
 

--- a/src/rendering/page-resolution/page-resolver.test.ts
+++ b/src/rendering/page-resolution/page-resolver.test.ts
@@ -117,15 +117,19 @@ describe("rendering/page-resolution/page-resolver", () => {
     });
 
     it("falls back to pages router when app routes are absent", async () => {
+      const resolveCalls: string[] = [];
+      const readCalls: string[] = [];
       const adapter = {
         fs: {
           readFile: async (path: string) => {
+            readCalls.push(path);
             if (path === "/project/pages/index.tsx") {
               return "export default function Page() { return null; }";
             }
             throw new Error("File not found");
           },
           resolveFile: async (path: string) => {
+            resolveCalls.push(path);
             if (path === "/project/app/page") {
               return null;
             }
@@ -176,6 +180,8 @@ describe("rendering/page-resolution/page-resolver", () => {
 
       assertEquals(page.entity.path, "/project/pages/index.tsx");
       assertEquals(routerMode, "pages");
+      assertEquals(resolveCalls.includes("/project/app/page"), false);
+      assertEquals(readCalls.some((path) => path.startsWith("/project/app")), false);
     });
 
     it("does not poison auto router detection from a pages fallback", async () => {

--- a/src/rendering/page-resolution/page-resolver.ts
+++ b/src/rendering/page-resolution/page-resolver.ts
@@ -86,15 +86,26 @@ export class PageResolver {
             primeRouterDetectionCache(cacheKey, "pages");
           }
         } else {
-          // Auto mode stays structural: a single resolved route must not pin router mode
-          // for projects that are still transitioning between app/ and pages/.
-          pageInfo = await getAppRouteEntity(
+          // Auto mode stays structural: detect the dominant router once, then keep
+          // pages fallback available for mixed or in-transition projects.
+          const useAppRouter = await detectAppRouter(
             this.projectDir,
-            slug,
+            this.config,
             this.adapter,
-            appDirName,
+            { projectId: this.projectId },
           );
-          if (!pageInfo) {
+
+          if (useAppRouter) {
+            pageInfo = await getAppRouteEntity(
+              this.projectDir,
+              slug,
+              this.adapter,
+              appDirName,
+            );
+            if (!pageInfo) {
+              pageInfo = await getEntityBySlug(this.projectDir, slug, this.adapter);
+            }
+          } else {
             pageInfo = await getEntityBySlug(this.projectDir, slug, this.adapter);
           }
         }

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,6 +1,6 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.59";
+export const VERSION = "0.1.87";
 
 export const SERVER_START_TIME: number = Date.now();
 


### PR DESCRIPTION
## Summary
- fast-fail fresh file-list negatives instead of fetching paths the index already proves are absent
- fetch indexed-without-content files directly by their resolved path without extra API resolve work
- stop pages-only projects in auto router mode from probing `app/page.*` first
- sync the runtime version constant with `deno.json` and bump to `0.1.87`

## Details
This follows the earlier preview cold-path work by removing repeated remote probes that still showed up in staging logs even with a warm file-list cache.

Key changes:
- extend the file-list index so it can answer path-presence queries, not just inline-content lookups
- treat fresh negative file-list lookups as authoritative in the Veryfront read layer
- resolve extension candidates directly from the file list when the index knows the matching path but not the content
- in auto router mode, consult structural detection first so pages-only projects do not burn time probing `app/page.*`
- add regression coverage for exact-path misses, extension-candidate direct fetches, and pages-only router behavior

## Notes
- this supersedes the narrower `deno.json`-only optimization direction from #610
- local verification passed: fmt, lint, check, focused tests, and the full pre-push suite (`1191 passed, 0 failed`)
