### PR TITLE
perf: initialize http module distributed cache at startup

### DIFF
--- a/.github/actions/setup-deno/action.yml
+++ b/.github/actions/setup-deno/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - uses: denoland/setup-deno@v2
       with:
-        deno-version: lts
+        deno-version: 2.6.7
         cache: true
         cache-hash: ${{ hashFiles('deno.json') }}
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: lts
+          deno-version: 2.6.7
 
       - name: Compile binary
         run: deno task build
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: lts
+          deno-version: 2.6.7
 
       - run: deno task build:prepare
 
@@ -231,7 +231,7 @@ jobs:
 
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: lts
+          deno-version: 2.6.7
 
       - uses: actions/setup-node@v4
         with:
@@ -339,7 +339,7 @@ jobs:
 
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: lts
+          deno-version: 2.6.7
 
       - uses: actions/setup-node@v4
         with:

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/cache/distributed-cache-init.test.ts
+++ b/src/cache/distributed-cache-init.test.ts
@@ -1,0 +1,38 @@
+import { assertEquals } from "#std/assert";
+import { __runDistributedCacheInitializationForTests } from "./distributed-cache-init.ts";
+
+Deno.test("distributed cache init includes httpModule cache status", async () => {
+  const status = await __runDistributedCacheInitializationForTests("api", {
+    transformCache: async () => true,
+    ssrModuleCache: async () => true,
+    fileCache: async () => true,
+    projectCSSCache: async () => true,
+    httpModuleCache: async () => true,
+  });
+
+  assertEquals(status.backend, "api");
+  assertEquals(status.transformCache, true);
+  assertEquals(status.ssrModuleCache, true);
+  assertEquals(status.fileCache, true);
+  assertEquals(status.projectCSSCache, true);
+  assertEquals(status.httpModuleCache, true);
+});
+
+Deno.test("distributed cache init marks rejected initializers as disabled", async () => {
+  const status = await __runDistributedCacheInitializationForTests("api", {
+    transformCache: async () => true,
+    ssrModuleCache: async () => true,
+    fileCache: async () => {
+      throw new Error("boom");
+    },
+    projectCSSCache: async () => true,
+    httpModuleCache: async () => false,
+  });
+
+  assertEquals(status.backend, "api");
+  assertEquals(status.transformCache, true);
+  assertEquals(status.ssrModuleCache, true);
+  assertEquals(status.fileCache, false);
+  assertEquals(status.projectCSSCache, true);
+  assertEquals(status.httpModuleCache, false);
+});

--- a/src/cache/distributed-cache-init.ts
+++ b/src/cache/distributed-cache-init.ts
@@ -1,6 +1,7 @@
 import { initializeFileCacheBackend } from "#veryfront/platform/adapters/fs/cache/file-cache.ts";
 import { initializeSSRDistributedCache } from "#veryfront/modules/react-loader/ssr-module-loader/index.ts";
 import { initializeTransformCache } from "#veryfront/transforms/esm/transform-cache.ts";
+import { initializeHttpModuleDistributedCache } from "#veryfront/transforms/esm/http-cache-wrapper.ts";
 import { SpanNames } from "#veryfront/observability/tracing/span-names.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { initializeProjectCSSCache } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
@@ -16,7 +17,24 @@ interface DistributedCacheStatus {
   ssrModuleCache: boolean;
   fileCache: boolean;
   projectCSSCache: boolean;
+  httpModuleCache: boolean;
 }
+
+type DistributedCacheInitializers = {
+  transformCache: () => Promise<boolean>;
+  ssrModuleCache: () => Promise<boolean>;
+  fileCache: () => Promise<boolean>;
+  projectCSSCache: () => Promise<boolean>;
+  httpModuleCache: () => Promise<boolean>;
+};
+
+const defaultInitializers: DistributedCacheInitializers = {
+  transformCache: initializeTransformCache,
+  ssrModuleCache: initializeSSRDistributedCache,
+  fileCache: initializeFileCacheBackend,
+  projectCSSCache: initializeProjectCSSCache,
+  httpModuleCache: initializeHttpModuleDistributedCache,
+};
 
 function determineBackend(): DistributedCacheStatus["backend"] {
   if (isApiCacheAvailable()) return "api";
@@ -29,6 +47,81 @@ function wasSuccessful(result: PromiseSettledResult<boolean>): boolean {
   return result.status === "fulfilled" && result.value;
 }
 
+async function initializeDistributedCachesWithInitializers(
+  backend: DistributedCacheStatus["backend"],
+  initializers: DistributedCacheInitializers,
+): Promise<DistributedCacheStatus> {
+  logger.info("Initializing caches...", { backend });
+
+  const cacheNames = [
+    "transformCache",
+    "ssrModuleCache",
+    "fileCache",
+    "projectCSSCache",
+    "httpModuleCache",
+  ] as const;
+  const results = await Promise.allSettled([
+    initializers.transformCache(),
+    initializers.ssrModuleCache(),
+    initializers.fileCache(),
+    initializers.projectCSSCache(),
+    initializers.httpModuleCache(),
+  ]);
+
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result && result.status === "rejected") {
+      logger.error(`Cache initialization failed: ${cacheNames[i]}`, {
+        backend,
+        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+      });
+    }
+  }
+
+  const status: DistributedCacheStatus = {
+    backend,
+    transformCache: wasSuccessful(results[0]),
+    ssrModuleCache: wasSuccessful(results[1]),
+    fileCache: wasSuccessful(results[2]),
+    projectCSSCache: wasSuccessful(results[3]),
+    httpModuleCache: wasSuccessful(results[4]),
+  };
+
+  const enabled = [
+    status.transformCache,
+    status.ssrModuleCache,
+    status.fileCache,
+    status.projectCSSCache,
+    status.httpModuleCache,
+  ].filter(Boolean).length;
+
+  if (enabled === 0) {
+    logger.warn("No caches enabled despite backend being available", {
+      backend,
+    });
+    return status;
+  }
+
+  logger.info("Initialization complete", {
+    backend,
+    enabled,
+    transform: status.transformCache,
+    ssrModule: status.ssrModuleCache,
+    file: status.fileCache,
+    projectCSS: status.projectCSSCache,
+    httpModule: status.httpModuleCache,
+  });
+
+  return status;
+}
+
+export function __runDistributedCacheInitializationForTests(
+  backend: DistributedCacheStatus["backend"],
+  initializers: DistributedCacheInitializers,
+): Promise<DistributedCacheStatus> {
+  return initializeDistributedCachesWithInitializers(backend, initializers);
+}
+
 export function initializeDistributedCaches(): Promise<DistributedCacheStatus> {
   const backend = determineBackend();
 
@@ -39,70 +132,13 @@ export function initializeDistributedCaches(): Promise<DistributedCacheStatus> {
       ssrModuleCache: false,
       fileCache: false,
       projectCSSCache: false,
+      httpModuleCache: false,
     });
   }
 
   return withSpan(
     SpanNames.CACHE_DISTRIBUTED_INIT,
-    async (): Promise<DistributedCacheStatus> => {
-      logger.info("Initializing caches...", { backend });
-
-      const cacheNames = [
-        "transformCache",
-        "ssrModuleCache",
-        "fileCache",
-        "projectCSSCache",
-      ] as const;
-      const results = await Promise.allSettled([
-        initializeTransformCache(),
-        initializeSSRDistributedCache(),
-        initializeFileCacheBackend(),
-        initializeProjectCSSCache(),
-      ]);
-
-      for (let i = 0; i < results.length; i++) {
-        const result = results[i];
-        if (result && result.status === "rejected") {
-          logger.error(`Cache initialization failed: ${cacheNames[i]}`, {
-            backend,
-            error: result.reason instanceof Error ? result.reason.message : String(result.reason),
-          });
-        }
-      }
-
-      const status: DistributedCacheStatus = {
-        backend,
-        transformCache: wasSuccessful(results[0]),
-        ssrModuleCache: wasSuccessful(results[1]),
-        fileCache: wasSuccessful(results[2]),
-        projectCSSCache: wasSuccessful(results[3]),
-      };
-
-      const enabled = [
-        status.transformCache,
-        status.ssrModuleCache,
-        status.fileCache,
-        status.projectCSSCache,
-      ].filter(Boolean).length;
-
-      if (enabled === 0) {
-        logger.warn("No caches enabled despite backend being available", {
-          backend,
-        });
-        return status;
-      }
-
-      logger.info("Initialization complete", {
-        backend,
-        enabled,
-        transform: status.transformCache,
-        ssrModule: status.ssrModuleCache,
-        file: status.fileCache,
-        projectCSS: status.projectCSSCache,
-      });
-
-      return status;
-    },
+    () => initializeDistributedCachesWithInitializers(backend, defaultInitializers),
     { "cache.backend": backend },
   );
 }

--- a/src/transforms/esm/http-cache-wrapper.test.ts
+++ b/src/transforms/esm/http-cache-wrapper.test.ts
@@ -1,10 +1,40 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { detokenize, tokenize } from "./http-cache-wrapper.ts";
+import { ApiCacheBackend } from "#veryfront/cache/backend.ts";
+import {
+  __setDistributedCacheAccessorForTests,
+  detokenize,
+  initializeHttpModuleDistributedCache,
+  tokenize,
+} from "./http-cache-wrapper.ts";
 import { CACHE_DIR_TOKEN } from "./http-cache-invariants.ts";
 import { getCacheBaseDir } from "#veryfront/utils/cache-dir.ts";
 
 describe("transforms/esm/http-cache-wrapper", () => {
+  describe("initializeHttpModuleDistributedCache", () => {
+    it("returns false when no distributed cache is available", async () => {
+      __setDistributedCacheAccessorForTests(async () => null);
+
+      try {
+        assertEquals(await initializeHttpModuleDistributedCache(), false);
+      } finally {
+        __setDistributedCacheAccessorForTests(null);
+      }
+    });
+
+    it("returns true when a distributed cache backend is available", async () => {
+      __setDistributedCacheAccessorForTests(
+        async () => new ApiCacheBackend({ apiBaseUrl: "http://veryfront-api:80" }),
+      );
+
+      try {
+        assertEquals(await initializeHttpModuleDistributedCache(), true);
+      } finally {
+        __setDistributedCacheAccessorForTests(null);
+      }
+    });
+  });
+
   describe("tokenize / detokenize roundtrip", () => {
     it("roundtrips local cache paths through tokenize and detokenize", () => {
       const cacheDir = getCacheBaseDir().replace(/\/$/, "");

--- a/src/transforms/esm/http-cache-wrapper.ts
+++ b/src/transforms/esm/http-cache-wrapper.ts
@@ -16,6 +16,7 @@ import { rendererLogger } from "#veryfront/utils";
 import { VERSION } from "#veryfront/utils/version.ts";
 import { getCacheBaseDir } from "#veryfront/utils/cache-dir.ts";
 import { CacheBackends, createDistributedCacheAccessor } from "#veryfront/cache/backend.ts";
+import type { CacheBackend } from "#veryfront/cache/types.ts";
 import { HTTP_MODULE_DISTRIBUTED_TTL_SEC } from "#veryfront/utils/constants/cache.ts";
 import type {
   BundleHash,
@@ -43,6 +44,26 @@ const getDistributedCache = createDistributedCacheAccessor(
   () => CacheBackends.httpModule(),
   "HTTP-CACHE-WRAPPER",
 );
+
+let testDistributedCacheAccessor: (() => Promise<CacheBackend | null>) | null = null;
+
+function resolveDistributedCache(): Promise<CacheBackend | null> {
+  return testDistributedCacheAccessor ? testDistributedCacheAccessor() : getDistributedCache();
+}
+
+export function __setDistributedCacheAccessorForTests(
+  accessor: (() => Promise<CacheBackend | null>) | null,
+): void {
+  testDistributedCacheAccessor = accessor;
+}
+
+export async function initializeHttpModuleDistributedCache(): Promise<boolean> {
+  const distributed = await resolveDistributedCache();
+  if (!distributed) return false;
+
+  logger.info("Initialized distributed cache backend", { backend: distributed.type });
+  return true;
+}
 
 /**
  * Generate versioned cache key for HTTP bundles.
@@ -158,7 +179,7 @@ class HttpBundleCache {
    * @returns Result containing local code or failure reason
    */
   async getCodeByHash(hash: BundleHash | string): Promise<GetCodeResult> {
-    const distributed = await getDistributedCache();
+    const distributed = await resolveDistributedCache();
     if (!distributed) {
       return { code: null, wasGzipped: false, failReason: "not_found" };
     }
@@ -214,7 +235,7 @@ class HttpBundleCache {
    * @returns Result containing local code or failure reason
    */
   async getCodeByUrl(hash: BundleHash | string): Promise<GetCodeResult> {
-    const distributed = await getDistributedCache();
+    const distributed = await resolveDistributedCache();
     if (!distributed) {
       return { code: null, wasGzipped: false, failReason: "not_found" };
     }
@@ -265,7 +286,7 @@ class HttpBundleCache {
     url: NormalizedUrl | string,
     ttl: number = HTTP_MODULE_DISTRIBUTED_TTL_SEC,
   ): Promise<void> {
-    const distributed = await getDistributedCache();
+    const distributed = await resolveDistributedCache();
     if (!distributed) return;
 
     const hashStr = typeof hash === "string" ? hash : (hash as unknown as string);
@@ -305,7 +326,7 @@ class HttpBundleCache {
   async getBatchCodes(
     hashes: Array<BundleHash | string>,
   ): Promise<Map<string, LocalModuleCode>> {
-    const distributed = await getDistributedCache();
+    const distributed = await resolveDistributedCache();
     if (!distributed) return new Map();
 
     const results = new Map<string, LocalModuleCode>();
@@ -357,7 +378,7 @@ class HttpBundleCache {
    * @returns Original URL or null
    */
   async getOriginalUrl(hash: BundleHash | string): Promise<string | null> {
-    const distributed = await getDistributedCache();
+    const distributed = await resolveDistributedCache();
     if (!distributed) return null;
 
     const hashStr = typeof hash === "string" ? hash : (hash as unknown as string);
@@ -378,7 +399,7 @@ class HttpBundleCache {
    * @returns true if deletion was attempted, false if cache unavailable
    */
   async deleteCode(hash: BundleHash | string): Promise<boolean> {
-    const distributed = await getDistributedCache();
+    const distributed = await resolveDistributedCache();
     if (!distributed) return false;
 
     const hashStr = typeof hash === "string" ? hash : (hash as unknown as string);
@@ -403,7 +424,7 @@ class HttpBundleCache {
    * Check if distributed cache is available.
    */
   async isAvailable(): Promise<boolean> {
-    const distributed = await getDistributedCache();
+    const distributed = await resolveDistributedCache();
     return distributed !== null;
   }
 }

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,6 +1,6 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.87";
+export const VERSION = "0.1.88";
 
 export const SERVER_START_TIME: number = Date.now();
 


### PR DESCRIPTION
## Summary
- initialize the http module distributed cache during startup instead of leaving it lazy
- include http module status in distributed cache startup reporting
- bump veryfront-code to 0.1.88 and add focused tests for cache init orchestration

## Why
Production preview is still showing slow first-hit behavior after v0.1.87. The live pods report only four distributed caches initialized at startup (`transform`, `ssrModule`, `file`, `projectCSS`) while `httpModule` is missing, and some fresh production pods log `No distributed cache available for bundle recovery` before re-transforming bundles locally. This change makes `httpModule` a first-class startup-initialized distributed cache so cross-pod bundle recovery is available immediately instead of depending on a lazy late path.

## Verification
- `deno test --allow-env src/cache/distributed-cache-init.test.ts src/transforms/esm/http-cache-wrapper.test.ts src/utils/version.test.ts`
- `deno fmt --check deno.json src/utils/version.ts src/cache/distributed-cache-init.ts src/cache/distributed-cache-init.test.ts src/transforms/esm/http-cache-wrapper.ts src/transforms/esm/http-cache-wrapper.test.ts`
- `deno lint src/cache/distributed-cache-init.ts src/cache/distributed-cache-init.test.ts src/transforms/esm/http-cache-wrapper.ts src/transforms/esm/http-cache-wrapper.test.ts src/utils/version.ts src/utils/version.test.ts`
- `deno check src/cache/distributed-cache-init.ts src/cache/distributed-cache-init.test.ts src/transforms/esm/http-cache-wrapper.ts src/transforms/esm/http-cache-wrapper.test.ts src/utils/version.ts src/utils/version.test.ts`
- full pre-push suite: `1193 passed, 0 failed`