### PR TITLE
refactor: derive cache namespaces automatically

### DIFF
--- a/cli/commands/init/init.integration.test.ts
+++ b/cli/commands/init/init.integration.test.ts
@@ -121,11 +121,13 @@ describe("init command integration", () => {
   });
 
   describe("file generation", () => {
-    it("should create .env file for templates with env vars", async () => {
+    it("should create .env file when scaffolded integrations declare env vars", async () => {
       const result = await runInitCommand([
         projectName,
         "-t",
         "ai-agent",
+        "--integrations",
+        "github",
         "--skip-install",
         "--skip-env-prompt",
       ]);
@@ -134,11 +136,13 @@ describe("init command integration", () => {
       assertEquals(await exists(join(projectDir, ".env")), true);
     });
 
-    it("should create .env.example file for templates with env vars", async () => {
+    it("should create .env.example file when scaffolded integrations declare env vars", async () => {
       const result = await runInitCommand([
         projectName,
         "-t",
         "ai-agent",
+        "--integrations",
+        "github",
         "--skip-install",
         "--skip-env-prompt",
       ]);

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.88",
+  "version": "0.1.89",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/build/vendor-cache.test.ts
+++ b/src/build/vendor-cache.test.ts
@@ -1,9 +1,13 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { generateVendorCacheKey } from "./vendor-cache.ts";
+import { generateVendorCacheKey, VENDOR_CACHE_NAMESPACE } from "./vendor-cache.ts";
 
 describe("build/vendor-cache", () => {
   describe("generateVendorCacheKey", () => {
+    it("uses a derived namespace instead of a manually bumped transform version", () => {
+      assertEquals(VENDOR_CACHE_NAMESPACE.startsWith("vendor-build-"), true);
+    });
+
     it("should return a key with vendor prefix and project id", async () => {
       const key = await generateVendorCacheKey("proj1", "18.3.1", {});
       assertEquals(key.startsWith("vendor:proj1:"), true);

--- a/src/build/vendor-cache.ts
+++ b/src/build/vendor-cache.ts
@@ -5,7 +5,28 @@
  * Provides per-project vendor bundle management with automatic invalidation.
  **************************************************/
 
-const TRANSFORM_VERSION = "3";
+import { createCacheNamespace } from "#veryfront/utils/cache-namespace.ts";
+
+function buildVendorCacheConfig(
+  reactVersion: string,
+  dependencies: Record<string, string>,
+): {
+  react: string;
+  deps: Array<[string, string]>;
+} {
+  return {
+    react: reactVersion,
+    deps: Object.entries(dependencies).sort(([left], [right]) => left.localeCompare(right)),
+  };
+}
+
+export const VENDOR_CACHE_NAMESPACE = createCacheNamespace("vendor-build", {
+  configSample: buildVendorCacheConfig("19.1.1", {
+    "@radix-ui/react-slot": "1.2.3",
+    react: "19.1.1",
+  }),
+  digest: "sha256-16hex",
+});
 
 export async function generateVendorCacheKey(
   projectId: string,
@@ -13,9 +34,8 @@ export async function generateVendorCacheKey(
   dependencies: Record<string, string>,
 ): Promise<string> {
   const configStr = JSON.stringify({
-    transformVersion: TRANSFORM_VERSION,
-    react: reactVersion,
-    deps: Object.entries(dependencies).sort(([a], [b]) => a.localeCompare(b)),
+    namespace: VENDOR_CACHE_NAMESPACE,
+    ...buildVendorCacheConfig(reactVersion, dependencies),
   });
 
   const data = new TextEncoder().encode(configStr);

--- a/src/rendering/orchestrator/module-loader/index.ts
+++ b/src/rendering/orchestrator/module-loader/index.ts
@@ -25,12 +25,12 @@ import { validateCachedBundlesByManifestOrCode } from "#veryfront/transforms/esm
 import { getHttpBundleCacheDir, getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { dirname, join, normalize } from "#veryfront/compat/path/index.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
-import { VERSION } from "#veryfront/utils/version.ts";
 import {
   getModulePathCache,
   lookupMdxEsmCache,
   saveModulePathCache,
 } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
+import { buildMdxEsmPathCacheKey } from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
 
 const logger = rendererLogger.component("module-loader");
 
@@ -455,7 +455,7 @@ export async function transformModuleWithDeps(
 
   if (contentSourceId) {
     const normalizedPath = `_vf_modules/${relativePath.replace(/\.(tsx?|jsx|mdx)$/, ".js")}`;
-    const mdxCacheKey = `v${VERSION}:${normalizedPath}`;
+    const mdxCacheKey = buildMdxEsmPathCacheKey(normalizedPath);
     const cache = await getModulePathCache(tmpDir);
     cache.set(mdxCacheKey, tempFilePath);
 

--- a/src/transforms/mdx/esm-module-loader/cache-format.ts
+++ b/src/transforms/mdx/esm-module-loader/cache-format.ts
@@ -1,0 +1,121 @@
+import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
+import { createCacheNamespace } from "#veryfront/utils/cache-namespace.ts";
+import { UNRESOLVED_VF_MODULES_PATTERN } from "./constants.ts";
+import { hashString } from "./utils/hash.ts";
+
+const ALL_FILE_URL_PATTERN_SOURCE = /file:\/\/([^"'\s]+)/.source;
+const MJS_FILE_URL_PATTERN_SOURCE = /file:\/\/([^"'\s]+\.mjs)/.source;
+const CACHE_NAMESPACE_SENTINEL = "__vf_cache_namespace__";
+
+function formatMdxEsmTransformCacheKey(
+  namespace: string,
+  projectId: string,
+  normalizedPath: string,
+  contentHash: string,
+): string {
+  return `${namespace}:${projectId}:${normalizedPath}:${contentHash}:ssr`;
+}
+
+function formatMdxEsmPathCacheKey(namespace: string, normalizedPath: string): string {
+  return `${namespace}:${normalizedPath}`;
+}
+
+function formatMdxEsmModuleFileName(namespace: string, contentHash: string): string {
+  return `vfmod-${namespace}-${contentHash}.mjs`;
+}
+
+function formatMdxJsxCacheFileName(namespace: string, filePath: string): string {
+  return `jsx-${namespace}-${hashString(filePath)}.mjs`;
+}
+
+function formatFrameworkVfModuleCacheFileName(
+  namespace: string,
+  pathHash: string,
+  envKey: string,
+  contentHash: string,
+): string {
+  return `vfmod-${namespace}-${pathHash}-${envKey}-${contentHash}.mjs`;
+}
+
+function buildMdxEsmCacheSchemaSample() {
+  return {
+    transformKey: formatMdxEsmTransformCacheKey(
+      CACHE_NAMESPACE_SENTINEL,
+      "__vf_project__",
+      "_vf_modules/pages/index.js",
+      "deadbeef",
+    ),
+    pathKey: formatMdxEsmPathCacheKey(CACHE_NAMESPACE_SENTINEL, "_vf_modules/pages/index.js"),
+    moduleFile: formatMdxEsmModuleFileName(CACHE_NAMESPACE_SENTINEL, "deadbeef"),
+    jsxFile: formatMdxJsxCacheFileName(CACHE_NAMESPACE_SENTINEL, "/tmp/project/Button.tsx"),
+    unresolvedVfModulesPattern: UNRESOLVED_VF_MODULES_PATTERN.source,
+    allFileUrlPattern: ALL_FILE_URL_PATTERN_SOURCE,
+    mjsFileUrlPattern: MJS_FILE_URL_PATTERN_SOURCE,
+    sourceHashing: [
+      hashString("_vf_modules/pages/index.jsexport default 1;"),
+      hashString("/tmp/project/Button.tsx"),
+    ],
+  };
+}
+
+function buildFrameworkVfModuleCacheSchemaSample() {
+  return {
+    moduleFile: formatFrameworkVfModuleCacheFileName(
+      CACHE_NAMESPACE_SENTINEL,
+      hashCodeHex("_vf_modules/_veryfront/react/components/Head.js"),
+      hashCodeHex("/app/.cache/veryfront-mdx-esm").slice(0, 8),
+      hashCodeHex("export default function Head() {}"),
+    ),
+  };
+}
+
+export const MDX_ESM_ALL_FILE_URL_PATTERN_SOURCE = ALL_FILE_URL_PATTERN_SOURCE;
+export const MDX_ESM_MJS_FILE_URL_PATTERN_SOURCE = MJS_FILE_URL_PATTERN_SOURCE;
+
+export const MDX_ESM_CACHE_NAMESPACE = createCacheNamespace(
+  "mdx-esm",
+  buildMdxEsmCacheSchemaSample(),
+);
+
+export const FRAMEWORK_VF_MODULE_CACHE_NAMESPACE = createCacheNamespace(
+  "vf-framework",
+  buildFrameworkVfModuleCacheSchemaSample(),
+);
+
+export function buildMdxEsmTransformCacheKey(
+  projectId: string,
+  normalizedPath: string,
+  contentHash: string,
+): string {
+  return formatMdxEsmTransformCacheKey(
+    MDX_ESM_CACHE_NAMESPACE,
+    projectId,
+    normalizedPath,
+    contentHash,
+  );
+}
+
+export function buildMdxEsmPathCacheKey(normalizedPath: string): string {
+  return formatMdxEsmPathCacheKey(MDX_ESM_CACHE_NAMESPACE, normalizedPath);
+}
+
+export function buildMdxEsmModuleFileName(contentHash: string): string {
+  return formatMdxEsmModuleFileName(MDX_ESM_CACHE_NAMESPACE, contentHash);
+}
+
+export function buildMdxJsxCacheFileName(filePath: string): string {
+  return formatMdxJsxCacheFileName(MDX_ESM_CACHE_NAMESPACE, filePath);
+}
+
+export function buildFrameworkVfModuleCacheFileName(
+  pathHash: string,
+  envKey: string,
+  contentHash: string,
+): string {
+  return formatFrameworkVfModuleCacheFileName(
+    FRAMEWORK_VF_MODULE_CACHE_NAMESPACE,
+    pathHash,
+    envKey,
+    contentHash,
+  );
+}

--- a/src/transforms/mdx/esm-module-loader/cache/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.test.ts
@@ -11,9 +11,9 @@ import {
 } from "./index.ts";
 import { makeTempDir } from "#veryfront/testing/deno-compat.ts";
 import { exists, remove, writeTextFile } from "#veryfront/compat/fs.ts";
-import { VERSION } from "#veryfront/utils/version.ts";
 import { cacheModule } from "../module-fetcher/module-cache.ts";
 import { rendererLogger as log } from "#veryfront/utils";
+import { buildMdxEsmModuleFileName, buildMdxEsmPathCacheKey } from "../cache-format.ts";
 
 describe("MDX module path cache", () => {
   it("isolates per cache dir", async () => {
@@ -57,8 +57,8 @@ describe("invalidateModulePaths — disk persistence", () => {
     clearModulePathCache();
 
     const cacheDir = await makeTempDir({ prefix: "vf-mdx-invalidate-" });
-    const versionedKey = `v${VERSION}:_vf_modules/components/EmptyState.js`;
-    const staleMjsPath = join(cacheDir, `vfmod-v${VERSION}-stale1234.mjs`);
+    const versionedKey = buildMdxEsmPathCacheKey("_vf_modules/components/EmptyState.js");
+    const staleMjsPath = join(cacheDir, buildMdxEsmModuleFileName("stale1234"));
 
     try {
       // Simulate a cached module: _index.json entry + .mjs file on disk
@@ -103,8 +103,8 @@ describe("invalidateModulePaths — disk persistence", () => {
     clearModulePathCache();
 
     const cacheDir = await makeTempDir({ prefix: "vf-mdx-invalidate-disk-" });
-    const versionedKey = `v${VERSION}:_vf_modules/components/EmptyState.js`;
-    const staleMjsPath = join(cacheDir, `vfmod-v${VERSION}-stale5678.mjs`);
+    const versionedKey = buildMdxEsmPathCacheKey("_vf_modules/components/EmptyState.js");
+    const staleMjsPath = join(cacheDir, buildMdxEsmModuleFileName("stale5678"));
 
     try {
       // Create the stale .mjs file
@@ -191,8 +191,8 @@ describe("invalidateModulePaths — edge cases", () => {
     clearModulePathCache();
 
     const cacheDir = await makeTempDir({ prefix: "vf-mdx-verified-deps-" });
-    const versionedKey = `v${VERSION}:_vf_modules/components/EmptyState.js`;
-    const staleMjsPath = join(cacheDir, `vfmod-v${VERSION}-verified1234.mjs`);
+    const versionedKey = buildMdxEsmPathCacheKey("_vf_modules/components/EmptyState.js");
+    const staleMjsPath = join(cacheDir, buildMdxEsmModuleFileName("verified1234"));
     const verifyKey = `${staleMjsPath}:${versionedKey}`;
 
     try {
@@ -229,10 +229,10 @@ describe("invalidateModulePaths — edge cases", () => {
 
     const cacheDirA = await makeTempDir({ prefix: "vf-mdx-rapid-a-" });
     const cacheDirB = await makeTempDir({ prefix: "vf-mdx-rapid-b-" });
-    const keyA = `v${VERSION}:_vf_modules/components/Header.js`;
-    const keyB = `v${VERSION}:_vf_modules/components/Footer.js`;
-    const mjsA = join(cacheDirA, `vfmod-v${VERSION}-header.mjs`);
-    const mjsB = join(cacheDirB, `vfmod-v${VERSION}-footer.mjs`);
+    const keyA = buildMdxEsmPathCacheKey("_vf_modules/components/Header.js");
+    const keyB = buildMdxEsmPathCacheKey("_vf_modules/components/Footer.js");
+    const mjsA = join(cacheDirA, buildMdxEsmModuleFileName("header"));
+    const mjsB = join(cacheDirB, buildMdxEsmModuleFileName("footer"));
 
     try {
       // Set up two entries in two different cache dirs
@@ -286,10 +286,10 @@ describe("invalidateModulePaths — edge cases", () => {
     clearModulePathCache();
 
     const cacheDir = await makeTempDir({ prefix: "vf-mdx-selective-" });
-    const emptyStateKey = `v${VERSION}:_vf_modules/components/EmptyState.js`;
-    const headerKey = `v${VERSION}:_vf_modules/components/Header.js`;
-    const emptyStateMjs = join(cacheDir, `vfmod-v${VERSION}-empty.mjs`);
-    const headerMjs = join(cacheDir, `vfmod-v${VERSION}-header.mjs`);
+    const emptyStateKey = buildMdxEsmPathCacheKey("_vf_modules/components/EmptyState.js");
+    const headerKey = buildMdxEsmPathCacheKey("_vf_modules/components/Header.js");
+    const emptyStateMjs = join(cacheDir, buildMdxEsmModuleFileName("empty"));
+    const headerMjs = join(cacheDir, buildMdxEsmModuleFileName("header"));
 
     try {
       await writeTextFile(emptyStateMjs, `export default "EmptyState";`);
@@ -330,8 +330,8 @@ describe("invalidateModulePaths — edge cases", () => {
     clearModulePathCache();
 
     const cacheDir = await makeTempDir({ prefix: "vf-mdx-no-false-" });
-    const newKey = `v${VERSION}:_vf_modules/components/EmptyStateNew.js`;
-    const newMjs = join(cacheDir, `vfmod-v${VERSION}-new.mjs`);
+    const newKey = buildMdxEsmPathCacheKey("_vf_modules/components/EmptyStateNew.js");
+    const newMjs = join(cacheDir, buildMdxEsmModuleFileName("new"));
 
     try {
       await writeTextFile(newMjs, `export default "EmptyStateNew";`);
@@ -362,8 +362,8 @@ describe("invalidateModulePaths — edge cases", () => {
     clearModulePathCache();
 
     const cacheDir = await makeTempDir({ prefix: "vf-mdx-leadslash-" });
-    const versionedKey = `v${VERSION}:_vf_modules/components/EmptyState.js`;
-    const mjsPath = join(cacheDir, `vfmod-v${VERSION}-slash.mjs`);
+    const versionedKey = buildMdxEsmPathCacheKey("_vf_modules/components/EmptyState.js");
+    const mjsPath = join(cacheDir, buildMdxEsmModuleFileName("slash"));
 
     try {
       await writeTextFile(mjsPath, `export default "test";`);
@@ -392,8 +392,8 @@ describe("invalidateModulePaths — edge cases", () => {
 
     for (const ext of extensions) {
       const cacheDir = await makeTempDir({ prefix: `vf-mdx-ext-${ext.slice(1)}-` });
-      const versionedKey = `v${VERSION}:_vf_modules/utils/helper.js`;
-      const mjsPath = join(cacheDir, `vfmod-v${VERSION}-ext.mjs`);
+      const versionedKey = buildMdxEsmPathCacheKey("_vf_modules/utils/helper.js");
+      const mjsPath = join(cacheDir, buildMdxEsmModuleFileName("ext"));
 
       try {
         await writeTextFile(mjsPath, `export default "test";`);
@@ -425,8 +425,8 @@ describe("invalidateModulePaths — edge cases", () => {
     clearModulePathCache();
 
     const cacheDir = await makeTempDir({ prefix: "vf-mdx-deep-" });
-    const versionedKey = `v${VERSION}:_vf_modules/lib/utils/formatting/date.js`;
-    const mjsPath = join(cacheDir, `vfmod-v${VERSION}-deep.mjs`);
+    const versionedKey = buildMdxEsmPathCacheKey("_vf_modules/lib/utils/formatting/date.js");
+    const mjsPath = join(cacheDir, buildMdxEsmModuleFileName("deep"));
 
     try {
       await writeTextFile(mjsPath, `export default "date";`);
@@ -455,9 +455,9 @@ describe("invalidateModulePaths — edge cases", () => {
 
     const cacheDirA = await makeTempDir({ prefix: "vf-mdx-multi-a-" });
     const cacheDirB = await makeTempDir({ prefix: "vf-mdx-multi-b-" });
-    const key = `v${VERSION}:_vf_modules/components/EmptyState.js`;
-    const mjsA = join(cacheDirA, `vfmod-v${VERSION}-a.mjs`);
-    const mjsB = join(cacheDirB, `vfmod-v${VERSION}-b.mjs`);
+    const key = buildMdxEsmPathCacheKey("_vf_modules/components/EmptyState.js");
+    const mjsA = join(cacheDirA, buildMdxEsmModuleFileName("a"));
+    const mjsB = join(cacheDirB, buildMdxEsmModuleFileName("b"));
 
     try {
       await writeTextFile(mjsA, `export default "A";`);
@@ -510,7 +510,7 @@ describe("invalidateModulePaths — edge cases", () => {
       // Verify _index.json has the entry
       clearModulePathCache();
       const loaded1 = await getModulePathCache(cacheDir);
-      const versionedKey = `v${VERSION}:${normalizedPath}`;
+      const versionedKey = buildMdxEsmPathCacheKey(normalizedPath);
       assertEquals(loaded1.get(versionedKey), oldPath, "phase 1: _index.json has old entry");
 
       // Phase 2: Invalidate (simulates poke)

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -18,9 +18,9 @@ import {
   type FileSystem,
   isNotFoundError,
 } from "#veryfront/platform/compat/fs.ts";
-import { VERSION } from "#veryfront/utils/version.ts";
 import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
+import { buildMdxEsmPathCacheKey, MDX_ESM_ALL_FILE_URL_PATTERN_SOURCE } from "../cache-format.ts";
 
 export type CacheLookupResult =
   | { status: "hit"; path: string }
@@ -33,8 +33,6 @@ export const verifiedModuleDeps = new LRUCache<string, true>({
   maxEntries: MAX_VERIFIED_MODULE_DEPS,
 });
 
-const FILE_PATH_PATTERN = /file:\/\/([^"'\s]+)/gi;
-
 /**
  * Check if cached code has file:// paths from a different environment.
  * Checks both HTTP bundle paths and MDX ESM cache paths.
@@ -43,7 +41,7 @@ function hasIncompatibleCachePaths(code: string): boolean {
   const localCacheBaseDir = getCacheBaseDir();
   const localHttpCacheDir = getHttpBundleCacheDir();
   const localMdxCacheDir = getMdxEsmCacheDir();
-  const pattern = new RegExp(FILE_PATH_PATTERN.source, "gi");
+  const pattern = new RegExp(MDX_ESM_ALL_FILE_URL_PATTERN_SOURCE, "gi");
 
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(code)) !== null) {
@@ -87,7 +85,7 @@ function hasIncompatibleCachePaths(code: string): boolean {
  */
 async function findMissingFileDependencies(code: string): Promise<string[]> {
   const localFs = getLocalFs();
-  const pattern = new RegExp(FILE_PATH_PATTERN.source, "gi");
+  const pattern = new RegExp(MDX_ESM_ALL_FILE_URL_PATTERN_SOURCE, "gi");
   const missing: string[] = [];
   let match;
   while ((match = pattern.exec(code)) !== null) {
@@ -335,7 +333,7 @@ function toMdxEsmCacheKey(filePath: string, projectDir?: string): string {
   relativePath = relativePath.replace(/^\/+/, "");
   const jsPath = relativePath.replace(/\.(tsx?|jsx|mdx)$/, ".js");
 
-  return `v${VERSION}:_vf_modules/${jsPath}`;
+  return buildMdxEsmPathCacheKey(`_vf_modules/${jsPath}`);
 }
 
 export async function lookupMdxEsmCache(
@@ -429,9 +427,9 @@ export async function lookupMdxEsmCache(
     }
 
     // Note: We intentionally skip contentHash validation for MDX-ESM cached files.
-    // The MDX-ESM cache uses transformed-code hashes in filenames (vfmod-v{VERSION}-{hash}.mjs),
+    // The MDX-ESM cache uses transformed-code hashes in namespaced filenames,
     // while the SSR loader provides source-code hashes. These will never match.
-    // The cache version in the key (v{VERSION}:) provides sufficient staleness protection,
+    // The cache namespace in the key provides sufficient staleness protection,
     // and the file's existence confirms it's a valid transform for this codebase.
     // This allows both loaders to share the same module instance, preventing
     // duplicate React contexts which break hooks like useContext.

--- a/src/transforms/mdx/esm-module-loader/import-transformer.ts
+++ b/src/transforms/mdx/esm-module-loader/import-transformer.ts
@@ -11,7 +11,6 @@ import { join } from "#veryfront/compat/path";
 import { rendererLogger as logger } from "#veryfront/utils";
 import { transformImportsWithMap } from "#veryfront/modules/import-map/index.ts";
 import type { ImportMapConfig } from "#veryfront/modules/import-map/index.ts";
-import { VERSION } from "#veryfront/utils/version.ts";
 import { replaceSpecifiers } from "../../esm/lexer.ts";
 import { getLocalReactPaths, isReactSpecifier } from "#veryfront/platform/compat/react-paths.ts";
 import {
@@ -23,7 +22,7 @@ import {
   REACT_IMPORT_PATTERN,
 } from "./constants.ts";
 import { getLocalFs } from "./cache/index.ts";
-import { hashString } from "./utils/hash.ts";
+import { buildMdxJsxCacheFileName } from "./cache-format.ts";
 import { rewriteDntImports } from "./module-fetcher/index.ts";
 import { ensureCachedJsxModulePatched } from "./jsx-cache.ts";
 import type { ESMLoaderContext } from "./types.ts";
@@ -128,7 +127,7 @@ export async function transformJsxImports(
   const transformResults = await Promise.all(
     importsToProcess.map(async ({ fullMatch, importClause, filePath, ext }) => {
       try {
-        const transformedFileName = `jsx-v${VERSION}-${hashString(filePath)}.mjs`;
+        const transformedFileName = buildMdxJsxCacheFileName(filePath);
         const transformedPath = join(esmCacheDir, transformedFileName);
 
         try {

--- a/src/transforms/mdx/esm-module-loader/jsx-cache.test.ts
+++ b/src/transforms/mdx/esm-module-loader/jsx-cache.test.ts
@@ -10,6 +10,7 @@ import {
 } from "#veryfront/testing/deno-compat.ts";
 import { join } from "#veryfront/compat/path";
 import { FRAMEWORK_ROOT } from "./constants.ts";
+import { buildMdxJsxCacheFileName } from "./cache-format.ts";
 import { ensureCachedJsxModulePatched } from "./jsx-cache.ts";
 
 describe("ensureCachedJsxModulePatched", () => {
@@ -17,7 +18,7 @@ describe("ensureCachedJsxModulePatched", () => {
     const tempDir = await makeTempDir({ prefix: "vf-jsx-cache-test-" });
 
     try {
-      const cachedPath = join(tempDir, "jsx-v1-deadbeef.mjs");
+      const cachedPath = join(tempDir, buildMdxJsxCacheFileName("/tmp/source/Head.tsx"));
       const badCode = [
         `import "../../../_dnt.polyfills.js";`,
         `export const value = 1;`,

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/cache-keys.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/cache-keys.test.ts
@@ -1,13 +1,13 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { getTransformCacheKey, getVersionedPathCacheKey } from "./cache-keys.ts";
-import { VERSION } from "#veryfront/utils/version.ts";
+import { MDX_ESM_CACHE_NAMESPACE } from "../cache-format.ts";
 
 describe("transforms/mdx/esm-module-loader/module-fetcher/cache-keys", () => {
   describe("getTransformCacheKey", () => {
-    it("includes version, projectId, path, hash, and ssr suffix", () => {
+    it("includes cache namespace, projectId, path, hash, and ssr suffix", () => {
       const key = getTransformCacheKey("proj1", "lib/utils.ts", "abc123");
-      assertEquals(key, `v${VERSION}:proj1:lib/utils.ts:abc123:ssr`);
+      assertEquals(key, `${MDX_ESM_CACHE_NAMESPACE}:proj1:lib/utils.ts:abc123:ssr`);
     });
 
     it("always ends with :ssr", () => {
@@ -17,7 +17,7 @@ describe("transforms/mdx/esm-module-loader/module-fetcher/cache-keys", () => {
 
     it("handles empty strings", () => {
       const key = getTransformCacheKey("", "", "");
-      assertEquals(key, `v${VERSION}::::ssr`);
+      assertEquals(key, `${MDX_ESM_CACHE_NAMESPACE}::::ssr`);
     });
 
     it("preserves special characters in path", () => {
@@ -27,19 +27,19 @@ describe("transforms/mdx/esm-module-loader/module-fetcher/cache-keys", () => {
   });
 
   describe("getVersionedPathCacheKey", () => {
-    it("includes version and path", () => {
+    it("includes cache namespace and path", () => {
       const key = getVersionedPathCacheKey("lib/utils.ts");
-      assertEquals(key, `v${VERSION}:lib/utils.ts`);
+      assertEquals(key, `${MDX_ESM_CACHE_NAMESPACE}:lib/utils.ts`);
     });
 
     it("handles empty path", () => {
       const key = getVersionedPathCacheKey("");
-      assertEquals(key, `v${VERSION}:`);
+      assertEquals(key, `${MDX_ESM_CACHE_NAMESPACE}:`);
     });
 
-    it("starts with version prefix", () => {
+    it("starts with cache namespace prefix", () => {
       const key = getVersionedPathCacheKey("any/path");
-      assertEquals(key.startsWith(`v${VERSION}:`), true);
+      assertEquals(key.startsWith(`${MDX_ESM_CACHE_NAMESPACE}:`), true);
     });
   });
 });

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/cache-keys.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/cache-keys.ts
@@ -4,7 +4,7 @@
  * @module transforms/mdx/esm-module-loader/module-fetcher/cache-keys
  */
 
-import { VERSION } from "#veryfront/utils/version.ts";
+import { buildMdxEsmPathCacheKey, buildMdxEsmTransformCacheKey } from "../cache-format.ts";
 
 /**
  * Build cache key for transformed module.
@@ -18,9 +18,9 @@ export function getTransformCacheKey(
   normalizedPath: string,
   contentHash: string,
 ): string {
-  return `v${VERSION}:${projectId}:${normalizedPath}:${contentHash}:ssr`;
+  return buildMdxEsmTransformCacheKey(projectId, normalizedPath, contentHash);
 }
 
 export function getVersionedPathCacheKey(normalizedPath: string): string {
-  return `v${VERSION}:${normalizedPath}`;
+  return buildMdxEsmPathCacheKey(normalizedPath);
 }

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/framework-validator.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/framework-validator.ts
@@ -13,6 +13,7 @@ import { FRAMEWORK_ROOT, LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 import { getLocalFs } from "../cache/index.ts";
 import { extractHttpBundlePaths } from "#veryfront/modules/react-loader/ssr-module-loader/http-bundle-helpers.ts";
 import { ensureHttpBundlesExist } from "../../../esm/http-cache.ts";
+import { MDX_ESM_MJS_FILE_URL_PATTERN_SOURCE } from "../cache-format.ts";
 
 /**
  * Check if cached code has file:// paths that are incompatible with this environment.
@@ -110,7 +111,7 @@ export async function findMissingFileDependenciesInCode(
   log: Logger,
 ): Promise<string[]> {
   const localFs = getLocalFs();
-  const pattern = /file:\/\/([^"'\s]+\.mjs)/gi;
+  const pattern = new RegExp(MDX_ESM_MJS_FILE_URL_PATTERN_SOURCE, "gi");
   const missing: string[] = [];
   const checked = new Set<string>();
 

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts
@@ -12,20 +12,20 @@ import {
   rewriteDntImports,
   startRenderSession,
 } from "./index.ts";
-import { VERSION } from "#veryfront/utils/version.ts";
 import { FRAMEWORK_ROOT, HASH_SEED_FNV1A } from "../constants.ts";
 import { resolveVeryfrontModuleUrl } from "../../../veryfront-module-urls.ts";
+import { MDX_ESM_CACHE_NAMESPACE } from "../cache-format.ts";
 
 function getTransformCacheKey(
   projectId: string,
   normalizedPath: string,
   contentHash: string,
 ): string {
-  return `v${VERSION}:${projectId}:${normalizedPath}:${contentHash}`;
+  return `${MDX_ESM_CACHE_NAMESPACE}:${projectId}:${normalizedPath}:${contentHash}`;
 }
 
 function getVersionedPathCacheKey(normalizedPath: string): string {
-  return `v${VERSION}:${normalizedPath}`;
+  return `${MDX_ESM_CACHE_NAMESPACE}:${normalizedPath}`;
 }
 
 function rewriteVeryfrontImports(code: string): string {
@@ -104,9 +104,12 @@ function hashString(input: string): string {
 
 describe("module-fetcher", { sanitizeResources: false, sanitizeOps: false }, () => {
   describe("getTransformCacheKey", () => {
-    it("includes version, project, path, and hash", () => {
+    it("includes namespace, project, path, and hash", () => {
       const key = getTransformCacheKey("proj1", "_vf_modules/pages/index.js", "abc123");
-      assertEquals(key, `v${VERSION}:proj1:_vf_modules/pages/index.js:abc123`);
+      assertEquals(
+        key,
+        `${MDX_ESM_CACHE_NAMESPACE}:proj1:_vf_modules/pages/index.js:abc123`,
+      );
     });
 
     it("produces different keys for different content hashes", () => {
@@ -123,9 +126,9 @@ describe("module-fetcher", { sanitizeResources: false, sanitizeOps: false }, () 
   });
 
   describe("getVersionedPathCacheKey", () => {
-    it("prefixes with version", () => {
+    it("prefixes with cache namespace", () => {
       const key = getVersionedPathCacheKey("_vf_modules/pages/index.js");
-      assertEquals(key, `v${VERSION}:_vf_modules/pages/index.js`);
+      assertEquals(key, `${MDX_ESM_CACHE_NAMESPACE}:_vf_modules/pages/index.js`);
     });
   });
 

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.ts
@@ -10,11 +10,10 @@
 import { join } from "#veryfront/compat/path";
 import * as posix from "#std/path/posix";
 import type { Logger } from "#veryfront/utils/logger/logger.ts";
-import { VERSION } from "#veryfront/utils/version.ts";
 import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 import { getLocalFs, saveModulePathCache } from "../cache/index.ts";
 import { hashString } from "../utils/hash.ts";
-import { getVersionedPathCacheKey } from "./cache-keys.ts";
+import { buildMdxEsmModuleFileName, buildMdxEsmPathCacheKey } from "../cache-format.ts";
 import { hasUnresolvedImports } from "./nested-imports.ts";
 import { recordModuleToSession } from "./render-sessions.ts";
 
@@ -60,13 +59,14 @@ export async function cacheModule(
   }
 
   const contentHash = hashString(normalizedPath + moduleCode);
-  const cachePath = join(esmCacheDir, `vfmod-v${VERSION}-${contentHash}.mjs`);
+  const cachePath = join(esmCacheDir, buildMdxEsmModuleFileName(contentHash));
+  const pathCacheKey = buildMdxEsmPathCacheKey(normalizedPath);
 
   const localFs = getLocalFs();
   try {
     const stat = await localFs.stat(cachePath);
     if (stat?.isFile) {
-      pathCache.set(getVersionedPathCacheKey(normalizedPath), cachePath);
+      pathCache.set(pathCacheKey, cachePath);
       log.debug(`${LOG_PREFIX_MDX_LOADER} Content cache hit: ${normalizedPath}`);
       recordModuleToSession(normalizedPath);
       return cachePath;
@@ -77,7 +77,7 @@ export async function cacheModule(
 
   await localFs.mkdir(esmCacheDir, { recursive: true });
   await localFs.writeTextFile(cachePath, moduleCode);
-  pathCache.set(getVersionedPathCacheKey(normalizedPath), cachePath);
+  pathCache.set(pathCacheKey, cachePath);
   await saveModulePathCache(esmCacheDir);
   log.debug(`${LOG_PREFIX_MDX_LOADER} Cached vf_module: ${normalizedPath} -> ${cachePath}`);
 

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
@@ -15,7 +15,6 @@ import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import { getHttpBundleCacheDir, getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { cacheHttpImportsToLocal } from "../../../esm/http-cache.ts";
 import { loadImportMap } from "#veryfront/modules/import-map/index.ts";
-import { VERSION } from "#veryfront/utils/version.ts";
 import { buildReactUrl, getReactImportMap } from "../../../import-rewriter/url-builder.ts";
 import { findRelativeImports } from "./import-finder.ts";
 import { resolveRelativeFrameworkImport, resolveVeryfrontSourcePath } from "./path-resolver.ts";
@@ -30,6 +29,7 @@ import {
   transformingFiles,
   veryfrontTransformCache,
 } from "./constants.ts";
+import { buildFrameworkVfModuleCacheFileName } from "../../../mdx/esm-module-loader/cache-format.ts";
 
 const DENO_CONFIG_STUB_CODE = `export default ${JSON.stringify(denoConfig)};`;
 
@@ -46,10 +46,10 @@ export function isCyclePlaceholder(code: string): boolean {
 /**
  * Cache transformed framework code and return the file:// path.
  *
- * Cache key format: vfmod-{VERSION}-{pathHash}-{envKey}-{contentHash}.mjs
+ * Cache key format: vfmod-{namespace}-{pathHash}-{envKey}-{contentHash}.mjs
  *
  * Cache invalidation is handled by:
- * - VERSION prefix: Auto-invalidates on framework releases
+ * - namespace prefix: Auto-rolls when the framework vfmod cache shape changes
  * - envKey (FRAMEWORK_ROOT hash): Prevents cross-environment contamination
  *   (compiled binary vs source have different FRAMEWORK_ROOT values)
  * - contentHash: Content-based invalidation
@@ -66,7 +66,7 @@ export async function cacheTransformedCode(
   const envKey = hashCodeHex(FRAMEWORK_ROOT).slice(0, 8);
   const contentHash = hashCodeHex(transformed);
   const pathHash = hashCodeHex(vfModulePath);
-  const fileName = `vfmod-${VERSION}-${pathHash}-${envKey}-${contentHash}.mjs`;
+  const fileName = buildFrameworkVfModuleCacheFileName(pathHash, envKey, contentHash);
   const frameworkCacheDir = join(cacheDir, "framework");
   const cachePath = join(frameworkCacheDir, fileName);
 

--- a/src/utils/cache-namespace.test.ts
+++ b/src/utils/cache-namespace.test.ts
@@ -1,0 +1,27 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createCacheNamespace } from "./cache-namespace.ts";
+
+describe("utils/cache-namespace", () => {
+  it("is stable for equivalent objects with different key order", () => {
+    const left = createCacheNamespace("demo", {
+      digest: "sha256-16hex",
+      samples: ["alpha", "beta"],
+      nested: { a: true, b: false },
+    });
+    const right = createCacheNamespace("demo", {
+      nested: { b: false, a: true },
+      samples: ["alpha", "beta"],
+      digest: "sha256-16hex",
+    });
+
+    assertEquals(left, right);
+  });
+
+  it("changes when the schema changes", () => {
+    const left = createCacheNamespace("demo", { sample: "alpha" });
+    const right = createCacheNamespace("demo", { sample: "beta" });
+
+    assertEquals(left === right, false);
+  });
+});

--- a/src/utils/cache-namespace.ts
+++ b/src/utils/cache-namespace.ts
@@ -1,0 +1,42 @@
+import { fnv1aHash } from "./hash-utils.ts";
+
+type CacheNamespaceValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly CacheNamespaceValue[]
+  | { readonly [key: string]: CacheNamespaceValue };
+
+function serializeCacheNamespaceValue(value: CacheNamespaceValue): string {
+  if (value === null) return "null";
+
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => serializeCacheNamespaceValue(entry)).join(",")}]`;
+  }
+
+  if (typeof value === "object") {
+    const entries = Object.entries(value).sort(([left], [right]) => left.localeCompare(right));
+    return `{${
+      entries
+        .map(([key, entry]) => `${JSON.stringify(key)}:${serializeCacheNamespaceValue(entry)}`)
+        .join(",")
+    }}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+/**
+ * Build a deterministic cache namespace from a declarative schema description.
+ * Keep the schema close to the cache builders so format changes roll the
+ * namespace automatically instead of relying on a manually bumped constant.
+ */
+export function createCacheNamespace(
+  scope: string,
+  schema: CacheNamespaceValue,
+  length = 10,
+): string {
+  const serialized = serializeCacheNamespaceValue(schema);
+  return `${scope}-${fnv1aHash(serialized).slice(0, length)}`;
+}

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,6 +1,6 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.88";
+export const VERSION = "0.1.89";
 
 export const SERVER_START_TIME: number = Date.now();
 


### PR DESCRIPTION
## Summary
- replace manual cache version prefixes in the touched vendor/MDX/vfmod paths with derived namespaces
- centralize MDX ESM cache key and filename generation in a single cache format module
- fix the broken init integration assertions so `deno task verify` passes on current main semantics

## Testing
- deno task verify
- git push pre-push checks (fmt, lint, typecheck, unit tests)