### PR TITLE
feat: add sandbox async job helpers and list to SDK

### DIFF
--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -17,4 +17,16 @@
  * @module
  */
 
-export { type ExecResult, type ExecStreamEvent, Sandbox, type SandboxOptions } from "./sandbox.ts";
+export {
+  type CommandJob,
+  type CommandJobHeartbeatStatus,
+  type CommandJobOutput,
+  type CommandJobStatus,
+  type ExecResult,
+  type ExecStreamEvent,
+  Sandbox,
+  type SandboxListOptions,
+  type SandboxListResult,
+  type SandboxOptions,
+  type SandboxSession,
+} from "./sandbox.ts";

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -3,7 +3,7 @@ import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/te
 import { deleteEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 import { runWithProjectEnv } from "../server/project-env/storage.ts";
-import type { ExecStreamEvent } from "./sandbox.ts";
+import type { CommandJob, CommandJobOutput, ExecStreamEvent } from "./sandbox.ts";
 import { Sandbox } from "./sandbox.ts";
 
 // Mock fetch for testing
@@ -527,6 +527,271 @@ describe("Sandbox", () => {
       assertStringIncludes(call(1).url, "/sandbox-sessions/s7");
       assertEquals(call(1).init?.method, "DELETE");
       assertEquals(headerValue(1, "Authorization"), "Bearer token");
+    });
+  });
+
+  describe("list()", () => {
+    it("should list sandbox sessions", async () => {
+      mockFetch([
+        jsonResponse({
+          data: [
+            {
+              id: "sess-1",
+              short_id: "s1",
+              endpoint: "https://sb1.test",
+              status: "running",
+              created_at: "2026-01-01T00:00:00Z",
+            },
+            {
+              id: "sess-2",
+              short_id: "s2",
+              endpoint: "https://sb2.test",
+              status: "stopped",
+              created_at: "2026-01-02T00:00:00Z",
+            },
+          ],
+          page_info: {
+            self: "/sandbox-sessions?cursor=abc",
+            next: "/sandbox-sessions?cursor=def",
+            prev: null,
+          },
+        }),
+      ]);
+
+      const result = await Sandbox.list({ authToken: "test-token", apiUrl: "https://api.test.com" });
+
+      assertEquals(result.data.length, 2);
+      assertEquals(result.data[0]!.id, "sess-1");
+      assertEquals(result.data[0]!.shortId, "s1");
+      assertEquals(result.data[0]!.createdAt, "2026-01-01T00:00:00Z");
+      assertEquals(result.data[1]!.status, "stopped");
+      assertEquals(result.pageInfo.next, "/sandbox-sessions?cursor=def");
+      assertEquals(result.pageInfo.prev, null);
+      assertEquals(result.pageInfo.first, null);
+
+      assertStringIncludes(call(0).url, "/sandbox-sessions");
+      assertEquals(headerValue(0, "Authorization"), "Bearer test-token");
+    });
+
+    it("should pass cursor and limit as query params", async () => {
+      mockFetch([
+        jsonResponse({ data: [], page_info: { self: null, next: null, prev: null } }),
+      ]);
+
+      await Sandbox.list({
+        authToken: "test-token",
+        apiUrl: "https://api.test.com",
+        cursor: "abc123",
+        limit: 10,
+      });
+
+      assertStringIncludes(call(0).url, "cursor=abc123");
+      assertStringIncludes(call(0).url, "limit=10");
+    });
+
+    it("should throw on list failure", async () => {
+      mockFetch([
+        textResponse("Forbidden", 403),
+      ]);
+
+      await assertRejects(
+        () => Sandbox.list({ authToken: "bad-token", apiUrl: "https://api.test.com" }),
+        Error,
+        "Failed to list sandboxes",
+      );
+    });
+  });
+
+  describe("startCommandJob()", () => {
+    it("should start a command job", async () => {
+      mockFetch([
+        jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
+        jsonResponse({
+          id: "job-1",
+          status: "running",
+          exit_code: null,
+          signal: null,
+          started_at: "2026-01-01T00:00:00Z",
+          finished_at: null,
+          heartbeat_status: "disabled",
+          last_heartbeat_at: null,
+          last_heartbeat_error: null,
+          heartbeat_failure_count: 0,
+        }),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      const job = await sandbox.startCommandJob("npm test");
+
+      assertEquals(job.id, "job-1");
+      assertEquals(job.status, "running");
+      assertEquals(job.exitCode, null);
+      assertEquals(job.startedAt, "2026-01-01T00:00:00Z");
+      assertEquals(job.heartbeatStatus, "disabled");
+      assertEquals(job.heartbeatFailureCount, 0);
+
+      assertEquals(call(1).init?.method, "POST");
+      assertStringIncludes(call(1).url, "/exec/jobs");
+      assertEquals(headerValue(1, "Authorization"), "Bearer token");
+      assertEquals(headerValue(1, "Content-Type"), "application/json");
+      assertEquals(jsonBody(1), { command: "npm test" });
+    });
+
+    it("should throw on start failure", async () => {
+      mockFetch([
+        jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
+        textResponse("Internal Server Error", 500),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      await assertRejects(
+        () => sandbox.startCommandJob("bad-cmd"),
+        Error,
+        "Start command job failed",
+      );
+    });
+  });
+
+  describe("getCommandJob()", () => {
+    it("should get a command job by id", async () => {
+      mockFetch([
+        jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
+        jsonResponse({
+          id: "job-2",
+          status: "completed",
+          exit_code: 0,
+          signal: null,
+          started_at: "2026-01-01T00:00:00Z",
+          finished_at: "2026-01-01T00:01:00Z",
+          heartbeat_status: "healthy",
+          last_heartbeat_at: "2026-01-01T00:00:30Z",
+          last_heartbeat_error: null,
+          heartbeat_failure_count: 0,
+        }),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      const job = await sandbox.getCommandJob("job-2");
+
+      assertEquals(job.id, "job-2");
+      assertEquals(job.status, "completed");
+      assertEquals(job.exitCode, 0);
+      assertEquals(job.finishedAt, "2026-01-01T00:01:00Z");
+      assertEquals(job.heartbeatStatus, "healthy");
+      assertEquals(job.lastHeartbeatAt, "2026-01-01T00:00:30Z");
+
+      assertStringIncludes(call(1).url, "/exec/jobs/job-2");
+      assertEquals(headerValue(1, "Authorization"), "Bearer token");
+    });
+
+    it("should throw on get failure", async () => {
+      mockFetch([
+        jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
+        textResponse("Not found", 404),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      await assertRejects(
+        () => sandbox.getCommandJob("nonexistent"),
+        Error,
+        "Get command job failed",
+      );
+    });
+  });
+
+  describe("getCommandJobOutput()", () => {
+    it("should get command job output", async () => {
+      mockFetch([
+        jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
+        jsonResponse({
+          id: "job-3",
+          status: "completed",
+          exit_code: 0,
+          signal: null,
+          started_at: "2026-01-01T00:00:00Z",
+          finished_at: "2026-01-01T00:01:00Z",
+          heartbeat_status: "disabled",
+          last_heartbeat_at: null,
+          last_heartbeat_error: null,
+          heartbeat_failure_count: 0,
+          stdout: "hello world\n",
+          stderr: "",
+          stdout_truncated: false,
+          stderr_truncated: false,
+        }),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      const output = await sandbox.getCommandJobOutput("job-3");
+
+      assertEquals(output.id, "job-3");
+      assertEquals(output.stdout, "hello world\n");
+      assertEquals(output.stderr, "");
+      assertEquals(output.stdoutTruncated, false);
+      assertEquals(output.stderrTruncated, false);
+      assertEquals(output.exitCode, 0);
+
+      assertStringIncludes(call(1).url, "/exec/jobs/job-3/output");
+      assertEquals(headerValue(1, "Authorization"), "Bearer token");
+    });
+
+    it("should throw on output fetch failure", async () => {
+      mockFetch([
+        jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
+        textResponse("Not found", 404),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      await assertRejects(
+        () => sandbox.getCommandJobOutput("nonexistent"),
+        Error,
+        "Get command job output failed",
+      );
+    });
+  });
+
+  describe("cancelCommandJob()", () => {
+    it("should cancel a command job", async () => {
+      mockFetch([
+        jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
+        jsonResponse({
+          id: "job-4",
+          status: "canceled",
+          exit_code: null,
+          signal: "SIGTERM",
+          started_at: "2026-01-01T00:00:00Z",
+          finished_at: "2026-01-01T00:00:30Z",
+          heartbeat_status: "disabled",
+          last_heartbeat_at: null,
+          last_heartbeat_error: null,
+          heartbeat_failure_count: 0,
+        }),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      const job = await sandbox.cancelCommandJob("job-4");
+
+      assertEquals(job.id, "job-4");
+      assertEquals(job.status, "canceled");
+      assertEquals(job.signal, "SIGTERM");
+
+      assertStringIncludes(call(1).url, "/exec/jobs/job-4/cancel");
+      assertEquals(call(1).init?.method, "POST");
+      assertEquals(headerValue(1, "Authorization"), "Bearer token");
+    });
+
+    it("should throw on cancel failure", async () => {
+      mockFetch([
+        jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
+        textResponse("Not found", 404),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      await assertRejects(
+        () => sandbox.cancelCommandJob("nonexistent"),
+        Error,
+        "Cancel command job failed",
+      );
     });
   });
 

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -3,7 +3,7 @@ import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/te
 import { deleteEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 import { runWithProjectEnv } from "../server/project-env/storage.ts";
-import type { CommandJob, CommandJobOutput, ExecStreamEvent } from "./sandbox.ts";
+import type { ExecStreamEvent } from "./sandbox.ts";
 import { Sandbox } from "./sandbox.ts";
 
 // Mock fetch for testing
@@ -558,7 +558,10 @@ describe("Sandbox", () => {
         }),
       ]);
 
-      const result = await Sandbox.list({ authToken: "test-token", apiUrl: "https://api.test.com" });
+      const result = await Sandbox.list({
+        authToken: "test-token",
+        apiUrl: "https://api.test.com",
+      });
 
       assertEquals(result.data.length, 2);
       assertEquals(result.data[0]!.id, "sess-1");

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -39,6 +39,60 @@ export interface ExecStreamEvent {
   exitCode?: number;
 }
 
+/** Status of an async command job. */
+export type CommandJobStatus = "running" | "completed" | "failed" | "canceled";
+
+/** Heartbeat health status for a command job. */
+export type CommandJobHeartbeatStatus = "disabled" | "healthy" | "degraded";
+
+/** An async command job running in a sandbox. */
+export interface CommandJob {
+  id: string;
+  status: CommandJobStatus;
+  exitCode: number | null;
+  signal: string | null;
+  startedAt: string;
+  finishedAt: string | null;
+  heartbeatStatus: CommandJobHeartbeatStatus;
+  lastHeartbeatAt: string | null;
+  lastHeartbeatError: string | null;
+  heartbeatFailureCount: number;
+}
+
+/** A command job with its captured output. */
+export interface CommandJobOutput extends CommandJob {
+  stdout: string;
+  stderr: string;
+  stdoutTruncated: boolean;
+  stderrTruncated: boolean;
+}
+
+/** A sandbox session summary returned by list. */
+export interface SandboxSession {
+  id: string;
+  shortId: string;
+  endpoint: string;
+  status: string;
+  createdAt: string;
+}
+
+/** Options for listing sandbox sessions. */
+export interface SandboxListOptions extends SandboxOptions {
+  cursor?: string;
+  limit?: number;
+}
+
+/** Paginated result of sandbox sessions. */
+export interface SandboxListResult {
+  data: SandboxSession[];
+  pageInfo: {
+    self: string | null;
+    first: null;
+    next: string | null;
+    prev: string | null;
+  };
+}
+
 /** Client for isolated ephemeral compute environments with command execution and file I/O. */
 export class Sandbox {
   private constructor(
@@ -113,6 +167,47 @@ export class Sandbox {
 
     const { endpoint } = await res.json();
     return new Sandbox(endpoint, id, authToken, apiUrl);
+  }
+
+  /** List sandbox sessions with optional pagination. */
+  static async list(options: SandboxListOptions = {}): Promise<SandboxListResult> {
+    const apiUrl = Sandbox.resolveApiUrl(options);
+    const authToken = Sandbox.resolveAuthToken(options);
+
+    const params = new URLSearchParams();
+    if (options.cursor) params.set("cursor", options.cursor);
+    if (options.limit !== undefined) params.set("limit", String(options.limit));
+
+    const query = params.toString();
+    const url = `${apiUrl}/sandbox-sessions${query ? `?${query}` : ""}`;
+
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${authToken}` },
+    });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({
+        detail: `Failed to list sandboxes: ${res.status} ${await res.text()}`,
+      });
+    }
+
+    const json = await res.json();
+
+    return {
+      data: json.data.map((s: Record<string, unknown>) => ({
+        id: s.id,
+        shortId: s.short_id,
+        endpoint: s.endpoint,
+        status: s.status,
+        createdAt: s.created_at,
+      })),
+      pageInfo: {
+        self: json.page_info?.self ?? null,
+        first: null,
+        next: json.page_info?.next ?? null,
+        prev: json.page_info?.prev ?? null,
+      },
+    };
   }
 
   private static async waitForReady(
@@ -243,6 +338,94 @@ export class Sandbox {
         detail: `Write files failed: ${res.status} ${await res.text()}`,
       });
     }
+  }
+
+  /** Start an async command job in the sandbox. */
+  async startCommandJob(command: string): Promise<CommandJob> {
+    const res = await fetch(`${this.endpoint}/exec/jobs`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.authToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ command }),
+    });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({
+        detail: `Start command job failed: ${res.status} ${await res.text()}`,
+      });
+    }
+
+    return Sandbox.mapCommandJob(await res.json());
+  }
+
+  /** Get the status of an async command job. */
+  async getCommandJob(jobId: string): Promise<CommandJob> {
+    const res = await fetch(`${this.endpoint}/exec/jobs/${jobId}`, {
+      headers: { Authorization: `Bearer ${this.authToken}` },
+    });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({
+        detail: `Get command job failed: ${res.status} ${await res.text()}`,
+      });
+    }
+
+    return Sandbox.mapCommandJob(await res.json());
+  }
+
+  /** Get the output of an async command job. */
+  async getCommandJobOutput(jobId: string): Promise<CommandJobOutput> {
+    const res = await fetch(`${this.endpoint}/exec/jobs/${jobId}/output`, {
+      headers: { Authorization: `Bearer ${this.authToken}` },
+    });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({
+        detail: `Get command job output failed: ${res.status} ${await res.text()}`,
+      });
+    }
+
+    const json = await res.json();
+    return {
+      ...Sandbox.mapCommandJob(json),
+      stdout: json.stdout,
+      stderr: json.stderr,
+      stdoutTruncated: json.stdout_truncated,
+      stderrTruncated: json.stderr_truncated,
+    };
+  }
+
+  /** Cancel an async command job. */
+  async cancelCommandJob(jobId: string): Promise<CommandJob> {
+    const res = await fetch(`${this.endpoint}/exec/jobs/${jobId}/cancel`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${this.authToken}` },
+    });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({
+        detail: `Cancel command job failed: ${res.status} ${await res.text()}`,
+      });
+    }
+
+    return Sandbox.mapCommandJob(await res.json());
+  }
+
+  private static mapCommandJob(json: Record<string, unknown>): CommandJob {
+    return {
+      id: json.id as string,
+      status: json.status as CommandJobStatus,
+      exitCode: json.exit_code as number | null,
+      signal: json.signal as string | null,
+      startedAt: json.started_at as string,
+      finishedAt: json.finished_at as string | null,
+      heartbeatStatus: json.heartbeat_status as CommandJobHeartbeatStatus,
+      lastHeartbeatAt: json.last_heartbeat_at as string | null,
+      lastHeartbeatError: json.last_heartbeat_error as string | null,
+      heartbeatFailureCount: json.heartbeat_failure_count as number,
+    };
   }
 
   /** Send a heartbeat to prevent idle timeout. */


### PR DESCRIPTION
## Summary
- Add `Sandbox.list()` static method for paginated session listing
- Add instance methods: `startCommandJob()`, `getCommandJob()`, `getCommandJobOutput()`, `cancelCommandJob()`
- Extract these from Studio's private `LazySandbox` agent tool into the public SDK
- All new types exported: `CommandJob`, `CommandJobOutput`, `SandboxSession`, `SandboxListResult`, etc.

## Context
SBX-5: Studio's `sandboxTools.ts` had private implementations of async job helpers that CLI and other consumers couldn't use. This surfaces them as first-class SDK methods.

## Test plan
- [x] All 48 existing + new test cases pass
- [ ] Verify on staging that sandbox session list returns expected data
- [ ] Verify async job creation/polling works against a live sandbox