### PR TITLE
perf: prepare versioned preview css artifacts

### DIFF
--- a/src/html/styles-builder/candidate-extractor.ts
+++ b/src/html/styles-builder/candidate-extractor.ts
@@ -6,6 +6,9 @@
  * @module html/styles-builder/candidate-extractor
  */
 
+import type { StyleScopeProfile } from "./style-scope-profile.ts";
+import { shouldIncludeStylePath } from "./style-scope-profile.ts";
+
 /**
  * Extract potential Tailwind class name candidates from source code content.
  * Uses a comprehensive regex pattern matching Tailwind v4 utility patterns.
@@ -17,12 +20,22 @@ export function extractCandidates(content: string): string[] {
 
 export function extractCandidatesFromFiles(
   files: Array<{ path: string; content?: string }>,
+  options: {
+    projectDir?: string;
+    styleProfile?: StyleScopeProfile;
+  } = {},
 ): Set<string> {
   const candidates = new Set<string>();
   const sourceExtensions = [".tsx", ".jsx", ".ts", ".js", ".mdx"];
 
   for (const file of files) {
     if (!file.content) continue;
+    if (
+      options.styleProfile &&
+      !shouldIncludeStylePath(options.styleProfile, file.path, options.projectDir)
+    ) {
+      continue;
+    }
     if (!sourceExtensions.some((ext) => file.path.endsWith(ext))) continue;
 
     for (const candidate of extractCandidates(file.content)) {

--- a/src/html/styles-builder/content-version.ts
+++ b/src/html/styles-builder/content-version.ts
@@ -1,0 +1,20 @@
+import type { ResolvedContentContext } from "#veryfront/platform/adapters/fs/veryfront/types.ts";
+
+interface ContentVersionFallback {
+  releaseId?: string | null;
+  branch?: string | null;
+  environmentName?: string | null;
+}
+
+export function resolveStyleContentVersion(
+  contentContext: ResolvedContentContext | null,
+  fallback: ContentVersionFallback = {},
+): string {
+  if (contentContext?.releaseId) return `release:${contentContext.releaseId}`;
+  if (contentContext?.branch) return `branch:${contentContext.branch}`;
+  if (contentContext?.environmentName) return `environment:${contentContext.environmentName}`;
+  if (fallback.releaseId) return `release:${fallback.releaseId}`;
+  if (fallback.branch) return `branch:${fallback.branch}`;
+  if (fallback.environmentName) return `environment:${fallback.environmentName}`;
+  return "live";
+}

--- a/src/html/styles-builder/css-pregeneration.ts
+++ b/src/html/styles-builder/css-pregeneration.ts
@@ -8,20 +8,35 @@
 
 import { serverLogger } from "#veryfront/utils";
 import { extractCandidatesFromFiles, getProjectCSS } from "./tailwind-compiler.ts";
+import {
+  createPreparedProjectCSSContext,
+  storePreparedProjectCSS,
+} from "./prepared-project-css-cache.ts";
+import type { StyleScopeProfile } from "./style-scope-profile.ts";
 
 const logger = serverLogger.component("css-pregeneration");
 
 interface CSSPregenerationOptions {
   /** Project slug for cache keying */
   projectSlug: string;
+  /** Current content version for the prepared stylesheet artifact */
+  projectVersion: string;
+  /** Project root used for style scope filtering */
+  projectDir?: string;
   /** List of files with content to extract candidates from */
   files: Array<{ path: string; content?: string }>;
+  /** Style scope profile for convention-based filtering */
+  styleProfile: StyleScopeProfile;
   /** Optional custom stylesheet (globals.css content) */
   stylesheet?: string;
   /** Optional stylesheet path (from config) to locate content in files */
   stylesheetPath?: string;
   /** Enable minification (default: true) */
   minify?: boolean;
+  /** Environment segment used for prepared artifact cache partitioning */
+  environment?: string;
+  /** Build mode recorded in the prepared artifact profile */
+  buildMode?: "development" | "production";
 }
 
 /**
@@ -39,34 +54,56 @@ interface CSSPregenerationOptions {
 export async function pregenerateCSSFromFiles(
   options: CSSPregenerationOptions,
 ): Promise<void> {
-  const { projectSlug, files, stylesheet, stylesheetPath, minify = true } = options;
+  const {
+    projectSlug,
+    projectVersion,
+    projectDir,
+    files,
+    styleProfile,
+    stylesheet,
+    stylesheetPath,
+    minify = true,
+    environment = "preview",
+    buildMode = "production",
+  } = options;
   const startTime = performance.now();
 
   try {
-    const candidates = extractCandidatesFromFiles(files);
-
-    if (candidates.size === 0) {
-      logger.debug("No candidates found, skipping", {
-        projectSlug,
-        fileCount: files.length,
-      });
-      return;
-    }
-
     const resolvedStylesheet = stylesheet ?? findStylesheetFromFiles(files, stylesheetPath);
+    const candidates = extractCandidatesFromFiles(files, {
+      projectDir,
+      styleProfile,
+    });
 
     logger.debug("Starting", {
       projectSlug,
+      projectVersion,
       fileCount: files.length,
       candidateCount: candidates.size,
       hasStylesheet: Boolean(resolvedStylesheet),
+      styleProfileHash: styleProfile.hash,
     });
 
-    const result = await getProjectCSS(projectSlug, resolvedStylesheet, candidates, { minify });
+    const result = await getProjectCSS(projectSlug, resolvedStylesheet, candidates, {
+      minify,
+      environment,
+      buildMode,
+    });
+    await storePreparedProjectCSS(
+      createPreparedProjectCSSContext(
+        projectSlug,
+        projectVersion,
+        resolvedStylesheet,
+        styleProfile.hash,
+        { minify, environment, buildMode },
+      ),
+      { css: result.css, hash: result.hash },
+    );
     const duration = performance.now() - startTime;
 
     logger.debug("Complete", {
       projectSlug,
+      projectVersion,
       candidateCount: candidates.size,
       cssLength: result.css.length,
       cssHash: result.hash,

--- a/src/html/styles-builder/prepared-project-css-cache.ts
+++ b/src/html/styles-builder/prepared-project-css-cache.ts
@@ -1,0 +1,228 @@
+import {
+  type CacheBackend,
+  createCacheBackend,
+  MemoryCacheBackend,
+} from "#veryfront/cache/backend.ts";
+import { registerCache } from "#veryfront/utils/memory/index.ts";
+import { serverLogger } from "#veryfront/utils";
+import { DEFAULT_STYLESHEET } from "./css-hash-cache.ts";
+import { resolveStylesheet } from "./tailwind-compiler-utils.ts";
+
+const logger = serverLogger.component("prepared-project-css-cache");
+
+interface PreparedProjectCSSCacheEntry {
+  css: string;
+  hash: string;
+}
+
+interface PreparedProjectCSSLocalEntry extends PreparedProjectCSSCacheEntry {
+  expiresAt: number;
+}
+
+interface PreparedProjectCSSProfile {
+  minify?: boolean;
+  environment?: string;
+  buildMode?: "development" | "production";
+}
+
+export interface PreparedProjectCSSRequestContext {
+  projectSlug: string;
+  projectVersion: string;
+  stylesheet: string;
+  stylesheetHash: string;
+  styleProfileHash: string;
+  environment: string;
+  profileHash: string;
+  cacheKey: string;
+}
+
+const PREPARED_PROJECT_CSS_CACHE_TTL_SECONDS = 24 * 3600;
+const PREPARED_PROJECT_CSS_LOCAL_MAX = 50;
+const PREPARED_PROJECT_CSS_LOCAL_TTL_MS = PREPARED_PROJECT_CSS_CACHE_TTL_SECONDS * 1000;
+
+let preparedProjectCSSBackend: CacheBackend | null = null;
+let preparedProjectCSSInitialized = false;
+let preparedProjectCSSInitPromise: Promise<void> | null = null;
+
+const localPreparedProjectCSS = new Map<string, PreparedProjectCSSLocalEntry>();
+
+registerCache("prepared-project-css-cache", () => ({
+  name: "prepared-project-css-cache",
+  entries: localPreparedProjectCSS.size,
+  maxEntries: PREPARED_PROJECT_CSS_LOCAL_MAX,
+  backend: preparedProjectCSSBackend?.type ?? "uninitialized",
+}));
+
+function hashValue(input: string): string {
+  let hash = 0;
+  for (let index = 0; index < input.length; index++) {
+    hash = ((hash << 5) - hash) + input.charCodeAt(index);
+    hash |= 0;
+  }
+  return hash.toString(36);
+}
+
+function setLocalEntry(key: string, entry: PreparedProjectCSSCacheEntry): void {
+  localPreparedProjectCSS.set(key, {
+    ...entry,
+    expiresAt: Date.now() + PREPARED_PROJECT_CSS_LOCAL_TTL_MS,
+  });
+
+  if (localPreparedProjectCSS.size <= PREPARED_PROJECT_CSS_LOCAL_MAX) return;
+
+  const keys = localPreparedProjectCSS.keys();
+  while (localPreparedProjectCSS.size > PREPARED_PROJECT_CSS_LOCAL_MAX) {
+    const result = keys.next();
+    if (result.done) break;
+    localPreparedProjectCSS.delete(result.value);
+  }
+}
+
+function parsePreparedProjectCSSCacheEntry(
+  raw: string,
+): PreparedProjectCSSCacheEntry | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<PreparedProjectCSSCacheEntry>;
+    if (typeof parsed.css !== "string" || typeof parsed.hash !== "string") return null;
+    return { css: parsed.css, hash: parsed.hash };
+  } catch {
+    return null;
+  }
+}
+
+export async function initializePreparedProjectCSSCache(): Promise<boolean> {
+  if (preparedProjectCSSInitialized) return preparedProjectCSSBackend?.type !== "memory";
+
+  if (!preparedProjectCSSInitPromise) {
+    preparedProjectCSSInitPromise = (async () => {
+      try {
+        preparedProjectCSSBackend = await createCacheBackend({
+          keyPrefix: "prepared-project-css",
+        });
+        logger.debug("Initialized", { backend: preparedProjectCSSBackend.type });
+      } catch (error) {
+        logger.warn("Backend init failed, using memory", { error });
+        preparedProjectCSSBackend = new MemoryCacheBackend(PREPARED_PROJECT_CSS_LOCAL_MAX);
+      } finally {
+        preparedProjectCSSInitialized = true;
+      }
+    })();
+  }
+
+  await preparedProjectCSSInitPromise;
+  preparedProjectCSSInitPromise = null;
+
+  return preparedProjectCSSBackend?.type !== "memory";
+}
+
+export function createPreparedProjectCSSContext(
+  projectSlug: string,
+  projectVersion: string,
+  stylesheet: string | undefined,
+  styleProfileHash: string,
+  profile?: PreparedProjectCSSProfile,
+): PreparedProjectCSSRequestContext {
+  const resolvedStylesheet = resolveStylesheet(stylesheet, DEFAULT_STYLESHEET);
+  const stylesheetHash = hashValue(resolvedStylesheet);
+  const environment = profile?.environment ?? "preview";
+  const profileHash = hashValue(
+    JSON.stringify({
+      cacheSchema: "v1",
+      minify: profile?.minify ?? false,
+      buildMode: profile?.buildMode ?? "production",
+      environment,
+    }),
+  );
+
+  return {
+    projectSlug,
+    projectVersion,
+    stylesheet: resolvedStylesheet,
+    stylesheetHash,
+    styleProfileHash,
+    environment,
+    profileHash,
+    cacheKey:
+      `${projectSlug}:${environment}:prepared:${projectVersion}:${stylesheetHash}:${styleProfileHash}:${profileHash}`,
+  };
+}
+
+export async function tryGetPreparedProjectCSS(
+  context: PreparedProjectCSSRequestContext,
+): Promise<{ css: string; hash: string; fromCache: true } | undefined> {
+  const local = localPreparedProjectCSS.get(context.cacheKey);
+  if (local && local.expiresAt > Date.now()) {
+    return { css: local.css, hash: local.hash, fromCache: true };
+  }
+
+  if (local) {
+    localPreparedProjectCSS.delete(context.cacheKey);
+  }
+
+  if (!preparedProjectCSSInitialized) {
+    await initializePreparedProjectCSSCache();
+  }
+
+  if (!preparedProjectCSSBackend) return undefined;
+
+  try {
+    const raw = await preparedProjectCSSBackend.get(context.cacheKey);
+    if (!raw) return undefined;
+
+    const entry = parsePreparedProjectCSSCacheEntry(raw);
+    if (!entry) return undefined;
+
+    setLocalEntry(context.cacheKey, entry);
+    return { css: entry.css, hash: entry.hash, fromCache: true };
+  } catch (error) {
+    logger.debug("Failed to read prepared project CSS", {
+      cacheKey: context.cacheKey,
+      error,
+    });
+    return undefined;
+  }
+}
+
+export async function storePreparedProjectCSS(
+  context: PreparedProjectCSSRequestContext,
+  entry: PreparedProjectCSSCacheEntry,
+): Promise<void> {
+  if (!preparedProjectCSSInitialized) {
+    await initializePreparedProjectCSSCache();
+  }
+
+  setLocalEntry(context.cacheKey, entry);
+
+  if (!preparedProjectCSSBackend) return;
+
+  preparedProjectCSSBackend
+    .set(context.cacheKey, JSON.stringify(entry), PREPARED_PROJECT_CSS_CACHE_TTL_SECONDS)
+    .catch((error) => {
+      logger.debug("Failed to store prepared project CSS", {
+        cacheKey: context.cacheKey,
+        error,
+      });
+    });
+}
+
+export function invalidatePreparedProjectCSS(projectSlug: string): void {
+  for (const key of localPreparedProjectCSS.keys()) {
+    if (key.startsWith(`${projectSlug}:`)) {
+      localPreparedProjectCSS.delete(key);
+    }
+  }
+
+  invalidatePreparedProjectCSSAsync(projectSlug).catch((error) => {
+    logger.debug("Failed to invalidate prepared project CSS", { projectSlug, error });
+  });
+}
+
+export async function invalidatePreparedProjectCSSAsync(projectSlug: string): Promise<void> {
+  if (!preparedProjectCSSBackend?.delByPattern) return;
+
+  try {
+    await preparedProjectCSSBackend.delByPattern(`${projectSlug}:*`);
+  } catch (error) {
+    logger.debug("Failed to delete prepared project CSS", { projectSlug, error });
+  }
+}

--- a/src/html/styles-builder/style-scope-profile.test.ts
+++ b/src/html/styles-builder/style-scope-profile.test.ts
@@ -1,0 +1,62 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  createStyleScopeProfile,
+  shouldIncludeStylePath,
+  shouldTraverseStyleDirectory,
+} from "./style-scope-profile.ts";
+
+describe("styles-builder/style-scope-profile", () => {
+  it("ignores knowledge content by default for style scanning", () => {
+    const profile = createStyleScopeProfile();
+
+    assertEquals(
+      shouldIncludeStylePath(profile, "/project/knowledge/reference/button.tsx", "/project"),
+      false,
+    );
+    assertEquals(
+      shouldTraverseStyleDirectory(profile, "/project/knowledge", "/project"),
+      false,
+    );
+  });
+
+  it("keeps runtime roots included by default", () => {
+    const profile = createStyleScopeProfile();
+
+    assertEquals(shouldIncludeStylePath(profile, "/project/pages/index.tsx", "/project"), true);
+    assertEquals(shouldIncludeStylePath(profile, "/project/app/page.tsx", "/project"), true);
+    assertEquals(
+      shouldIncludeStylePath(profile, "/project/src/components/Button.tsx", "/project"),
+      true,
+    );
+  });
+
+  it("protects configured runtime directories even under conventionally ignored roots", () => {
+    const profile = createStyleScopeProfile({
+      directories: {
+        app: "knowledge/app",
+        components: ["knowledge/components"],
+      },
+      tailwind: {
+        stylesheet: "knowledge/theme/globals.css",
+      },
+    });
+
+    assertEquals(
+      shouldIncludeStylePath(profile, "/project/knowledge/app/page.tsx", "/project"),
+      true,
+    );
+    assertEquals(
+      shouldIncludeStylePath(profile, "/project/knowledge/components/Hero.tsx", "/project"),
+      true,
+    );
+    assertEquals(
+      shouldTraverseStyleDirectory(profile, "/project/knowledge", "/project"),
+      true,
+    );
+    assertEquals(
+      shouldIncludeStylePath(profile, "/project/knowledge/theme/globals.css", "/project"),
+      true,
+    );
+  });
+});

--- a/src/html/styles-builder/style-scope-profile.ts
+++ b/src/html/styles-builder/style-scope-profile.ts
@@ -1,0 +1,164 @@
+import type { VeryfrontConfig } from "#veryfront/config";
+
+const DEFAULT_IGNORED_ROOTS = [
+  "knowledge",
+  "coverage",
+  "dist",
+  "build",
+  ".git",
+  "node_modules",
+  ".cache",
+];
+
+const DEFAULT_PROTECTED_ROOTS = [
+  "app",
+  "pages",
+  "components",
+  "src/app",
+  "src/pages",
+  "src/components",
+];
+
+export interface StyleScopeProfile {
+  hash: string;
+  ignoredRoots: string[];
+  protectedRoots: string[];
+  protectedPaths: string[];
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/{2,}/g, "/");
+}
+
+function normalizeRelativePath(path: string): string {
+  return normalizePath(path).replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+function toRelativeProjectPath(path: string, projectDir?: string): string {
+  const normalized = normalizePath(path);
+  const normalizedProjectDir = projectDir
+    ? normalizePath(projectDir).replace(/\/+$/, "")
+    : undefined;
+
+  if (normalizedProjectDir && normalized.startsWith(normalizedProjectDir)) {
+    return normalized.slice(normalizedProjectDir.length).replace(/^\/+/, "");
+  }
+
+  return normalized.replace(/^\/+/, "");
+}
+
+function isWithinPath(path: string, root: string): boolean {
+  return path === root || path.startsWith(`${root}/`);
+}
+
+function getParentDirectory(path: string): string | null {
+  const normalized = normalizeRelativePath(path);
+  const slashIndex = normalized.lastIndexOf("/");
+  if (slashIndex <= 0) return null;
+  return normalized.slice(0, slashIndex);
+}
+
+function stableHash(input: string): string {
+  let hash = 0;
+  for (let index = 0; index < input.length; index++) {
+    hash = ((hash << 5) - hash) + input.charCodeAt(index);
+    hash |= 0;
+  }
+  return hash.toString(36);
+}
+
+function addNormalizedPath(target: Set<string>, value: string | null | undefined): void {
+  if (!value) return;
+  const normalized = normalizeRelativePath(value);
+  if (!normalized) return;
+  target.add(normalized);
+}
+
+export function createStyleScopeProfile(config?: VeryfrontConfig): StyleScopeProfile {
+  const ignoredRoots = new Set<string>(DEFAULT_IGNORED_ROOTS);
+  const protectedRoots = new Set<string>(DEFAULT_PROTECTED_ROOTS);
+  const protectedPaths = new Set<string>();
+
+  addNormalizedPath(protectedRoots, config?.directories?.app);
+  addNormalizedPath(protectedRoots, config?.directories?.pages);
+
+  for (const path of config?.directories?.components ?? []) {
+    addNormalizedPath(protectedRoots, path);
+  }
+
+  const explicitPaths = [
+    typeof config?.layout === "string" ? config.layout : undefined,
+    typeof config?.app === "string" ? config.app : undefined,
+    config?.tailwind?.stylesheet,
+  ];
+
+  for (const path of explicitPaths) {
+    addNormalizedPath(protectedPaths, path);
+    addNormalizedPath(protectedRoots, getParentDirectory(path ?? ""));
+  }
+
+  for (const root of protectedRoots) {
+    ignoredRoots.delete(root);
+  }
+
+  const sortedIgnoredRoots = [...ignoredRoots].sort();
+  const sortedProtectedRoots = [...protectedRoots].sort();
+  const sortedProtectedPaths = [...protectedPaths].sort();
+
+  return {
+    ignoredRoots: sortedIgnoredRoots,
+    protectedRoots: sortedProtectedRoots,
+    protectedPaths: sortedProtectedPaths,
+    hash: stableHash(
+      JSON.stringify({
+        ignoredRoots: sortedIgnoredRoots,
+        protectedRoots: sortedProtectedRoots,
+        protectedPaths: sortedProtectedPaths,
+      }),
+    ),
+  };
+}
+
+function isProtectedPath(
+  profile: StyleScopeProfile,
+  relativePath: string,
+): boolean {
+  return profile.protectedPaths.some((path) => isWithinPath(relativePath, path)) ||
+    profile.protectedRoots.some((path) => isWithinPath(relativePath, path));
+}
+
+export function shouldIncludeStylePath(
+  profile: StyleScopeProfile,
+  path: string,
+  projectDir?: string,
+): boolean {
+  const relativePath = normalizeRelativePath(toRelativeProjectPath(path, projectDir));
+  if (!relativePath) return true;
+  if (isProtectedPath(profile, relativePath)) return true;
+
+  return !profile.ignoredRoots.some((root) => isWithinPath(relativePath, root));
+}
+
+export function shouldTraverseStyleDirectory(
+  profile: StyleScopeProfile,
+  directoryPath: string,
+  projectDir?: string,
+): boolean {
+  const relativePath = normalizeRelativePath(toRelativeProjectPath(directoryPath, projectDir));
+  if (!relativePath) return true;
+  if (isProtectedPath(profile, relativePath)) return true;
+
+  const ignoredRoot = profile.ignoredRoots.find((root) => isWithinPath(relativePath, root));
+  if (!ignoredRoot) return true;
+
+  return profile.protectedRoots.some((root) => isWithinPath(root, relativePath)) ||
+    profile.protectedPaths.some((path) => isWithinPath(path, relativePath));
+}
+
+export function filterFilesForStyleScope<T extends { path: string }>(
+  files: T[],
+  profile: StyleScopeProfile,
+  projectDir?: string,
+): T[] {
+  return files.filter((file) => shouldIncludeStylePath(profile, file.path, projectDir));
+}

--- a/src/platform/adapters/fs/factory.ts
+++ b/src/platform/adapters/fs/factory.ts
@@ -1,19 +1,7 @@
 import type { FSAdapter, FSAdapterConfig } from "./veryfront/types.ts";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
-import {
-  clearSSRModuleCache,
-  clearSSRModuleCacheForProject,
-} from "#veryfront/modules/react-loader/ssr-module-loader/cache/index.ts";
-import { clearRouterDetectionCacheForProject } from "#veryfront/rendering/router-detection.ts";
-import {
-  clearModulePathCache,
-  invalidateModulePaths,
-} from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
-import { clearSnippetCacheForProject } from "#veryfront/rendering/snippet-renderer.ts";
-import { clearRendererCacheForProject } from "#veryfront/rendering/renderer.ts";
-import { invalidateProjectCSS } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
-import { invalidateProjectCandidateManifests } from "#veryfront/rendering/orchestrator/css-candidate-manifest.ts";
+import { createDefaultInvalidationCallbacks } from "./veryfront/default-invalidation-callbacks.ts";
 
 export function createFSAdapter(config: FSAdapterConfig): Promise<FSAdapter> {
   const type = config.type ?? "local";
@@ -36,20 +24,7 @@ export function createFSAdapter(config: FSAdapterConfig): Promise<FSAdapter> {
       if (type === "veryfront-api") {
         const configWithCallbacks: FSAdapterConfig = {
           ...config,
-          invalidationCallbacks: {
-            clearSSRModuleCache,
-            clearModulePathCache,
-            invalidateModulePaths,
-            clearSSRModuleCacheForProject,
-            clearRouterDetectionCacheForProject,
-            clearSnippetCacheForProject,
-            clearRendererCacheForProject,
-            clearProjectCSSCache: (projectSlug: string) => {
-              invalidateProjectCSS(projectSlug);
-              invalidateProjectCandidateManifests(projectSlug);
-            },
-            ...config.invalidationCallbacks,
-          },
+          invalidationCallbacks: createDefaultInvalidationCallbacks(config.invalidationCallbacks),
         };
 
         if (proxyMode) {

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -245,6 +245,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
       },
       clearFileListIndex: () => this.readOps.clearFileListIndex(),
       setFileListCache: (cacheKey, files) => this.cache.setAsync(cacheKey, files),
+      pregenerateStyles: (files) => this.triggerCSSPregeneration(files),
     });
 
     logger.debug("Created", {
@@ -349,12 +350,10 @@ export class VeryfrontFSAdapter implements FSAdapter {
         sourceFilesWithContent: fileSummary.sourceFilesWithContent,
       });
 
-      // Trigger CSS pre-generation for non-branch environments (fire-and-forget)
-      // This runs in parallel with the rest of initialization
-      if (
-        this.contentContext.sourceType !== "branch" &&
-        fileSummary.sourceFilesWithContent > 0
-      ) {
+      // Trigger CSS pre-generation after the initial file snapshot is ready.
+      // This keeps stylesheet generation off the first styles request for both
+      // preview branches and published content.
+      if (fileSummary.sourceFilesWithContent > 0) {
         this.triggerCSSPregeneration(files).catch(() => {
           // Error already logged in triggerCSSPregeneration
         });
@@ -445,6 +444,13 @@ export class VeryfrontFSAdapter implements FSAdapter {
 
         const files = await fetchFileListForContext(this.client, warmupContext);
         await this.cache.setAsync(effectiveCacheKey, files);
+        const fileSummary = summarizeFileList(files);
+
+        if (fileSummary.sourceFilesWithContent > 0) {
+          this.triggerCSSPregeneration(files).catch(() => {
+            // Error already logged in triggerCSSPregeneration
+          });
+        }
 
         logger.debug("File list warmup complete", {
           reason,
@@ -716,34 +722,57 @@ export class VeryfrontFSAdapter implements FSAdapter {
       const { pregenerateCSSFromFiles, findStylesheetFromFiles } = await import(
         "../../../../html/styles-builder/css-pregeneration.ts"
       );
+      const { resolveStyleContentVersion } = await import(
+        "../../../../html/styles-builder/content-version.ts"
+      );
+      const { createStyleScopeProfile } = await import(
+        "../../../../html/styles-builder/style-scope-profile.ts"
+      );
 
       let stylesheetPath: string | undefined;
+      let styleProfile = createStyleScopeProfile();
       const projectDir = this.normalizer.getProjectDir();
 
-      if (projectDir) {
-        try {
-          const { runtime } = await import("#veryfront/platform/adapters/registry.ts");
-          const { getConfig } = await import("#veryfront/config");
-          const adapter = await runtime.get();
-          const cacheKey = this.client.getProjectId() || this.projectSlug;
-          const config = await getConfig(projectDir, adapter, { cacheKey });
-          stylesheetPath = config?.tailwind?.stylesheet;
-        } catch (error) {
-          logger.debug("Failed to load config for CSS pre-generation", {
-            projectSlug: this.projectSlug,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
+      if (!projectDir) {
+        logger.debug("Skipping CSS pre-generation without projectDir", {
+          projectSlug: this.projectSlug,
+        });
+        return;
+      }
+
+      try {
+        const { runtime } = await import("#veryfront/platform/adapters/registry.ts");
+        const { getConfig } = await import("#veryfront/config");
+        const adapter = await runtime.get();
+        const cacheKey = this.client.getProjectId() || this.projectSlug;
+        const config = await getConfig(projectDir, adapter, { cacheKey });
+        stylesheetPath = config?.tailwind?.stylesheet;
+        styleProfile = createStyleScopeProfile(config);
+      } catch (error) {
+        logger.debug("Failed to load config for CSS pre-generation", {
+          projectSlug: this.projectSlug,
+          error: error instanceof Error ? error.message : String(error),
+        });
       }
 
       const stylesheet = findStylesheetFromFiles(files, stylesheetPath);
+      const projectVersion = resolveStyleContentVersion(this.contentContext, {
+        branch: this.contentContext?.branch ?? null,
+        releaseId: this.contentContext?.releaseId ?? null,
+        environmentName: this.contentContext?.environmentName ?? null,
+      });
 
       await pregenerateCSSFromFiles({
         projectSlug: this.projectSlug,
+        projectVersion,
+        projectDir,
         files,
+        styleProfile,
         stylesheet,
         stylesheetPath,
         minify: true,
+        environment: "preview",
+        buildMode: "production",
       });
     } catch (error) {
       logger.warn("CSS pre-generation failed", {

--- a/src/platform/adapters/fs/veryfront/default-invalidation-callbacks.ts
+++ b/src/platform/adapters/fs/veryfront/default-invalidation-callbacks.ts
@@ -1,0 +1,35 @@
+import {
+  clearSSRModuleCache,
+  clearSSRModuleCacheForProject,
+} from "#veryfront/modules/react-loader/ssr-module-loader/cache/index.ts";
+import { clearRouterDetectionCacheForProject } from "#veryfront/rendering/router-detection.ts";
+import {
+  clearModulePathCache,
+  invalidateModulePaths,
+} from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
+import { clearSnippetCacheForProject } from "#veryfront/rendering/snippet-renderer.ts";
+import { clearRendererCacheForProject } from "#veryfront/rendering/renderer.ts";
+import { invalidateProjectCSS } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
+import { invalidatePreparedProjectCSS } from "#veryfront/html/styles-builder/prepared-project-css-cache.ts";
+import { invalidateProjectCandidateManifests } from "#veryfront/rendering/orchestrator/css-candidate-manifest.ts";
+import type { InvalidationCallbacks } from "./types.ts";
+
+export function createDefaultInvalidationCallbacks(
+  callbacks?: InvalidationCallbacks,
+): InvalidationCallbacks {
+  return {
+    clearSSRModuleCache,
+    clearModulePathCache,
+    invalidateModulePaths,
+    clearSSRModuleCacheForProject,
+    clearRouterDetectionCacheForProject,
+    clearSnippetCacheForProject,
+    clearRendererCacheForProject,
+    clearProjectCSSCache: (projectSlug: string) => {
+      invalidateProjectCSS(projectSlug);
+      invalidatePreparedProjectCSS(projectSlug);
+      invalidateProjectCandidateManifests(projectSlug);
+    },
+    ...callbacks,
+  };
+}

--- a/src/platform/adapters/fs/veryfront/proxy-manager.ts
+++ b/src/platform/adapters/fs/veryfront/proxy-manager.ts
@@ -3,18 +3,8 @@ import { CACHE_INVARIANT_VIOLATION, INVALID_ARGUMENT } from "#veryfront/errors";
 import { buildProxyManagerCacheKey } from "#veryfront/cache";
 import { VeryfrontFSAdapter } from "./index.ts";
 import type { CacheStats, FSAdapterConfig, ResolvedContentContext } from "./types.ts";
-import {
-  clearSSRModuleCache,
-  clearSSRModuleCacheForProject,
-} from "#veryfront/modules/react-loader/ssr-module-loader/cache/index.ts";
-import { clearRouterDetectionCacheForProject } from "#veryfront/rendering/router-detection.ts";
-import {
-  clearModulePathCache,
-  invalidateModulePaths,
-} from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
-import { clearSnippetCacheForProject } from "#veryfront/rendering/snippet-renderer.ts";
-import { clearRendererCacheForProject } from "#veryfront/rendering/renderer.ts";
 import { GetAdapterParamsSchema } from "./schemas/index.ts";
+import { createDefaultInvalidationCallbacks } from "./default-invalidation-callbacks.ts";
 
 const logger = baseLogger.component("proxy-fs-adapter-manager");
 
@@ -305,16 +295,9 @@ export class ProxyFSAdapterManager {
         projectId,
         apiToken: effectiveToken,
       },
-      invalidationCallbacks: {
-        clearSSRModuleCache,
-        clearModulePathCache,
-        invalidateModulePaths,
-        clearSSRModuleCacheForProject,
-        clearRouterDetectionCacheForProject,
-        clearSnippetCacheForProject,
-        clearRendererCacheForProject,
-        ...this.baseConfig.invalidationCallbacks,
-      },
+      invalidationCallbacks: createDefaultInvalidationCallbacks(
+        this.baseConfig.invalidationCallbacks,
+      ),
     };
 
     const adapter = new VeryfrontFSAdapter(config);

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -42,6 +42,7 @@ interface WebSocketDeps {
     cacheKey: string,
     files: Array<{ path: string; content?: string }>,
   ) => Promise<void>;
+  pregenerateStyles?: (files: Array<{ path: string; content?: string }>) => Promise<void>;
 }
 
 export class WebSocketManager {
@@ -628,6 +629,7 @@ export class WebSocketManager {
           const cacheKey = buildFileListCacheKey(contentContext);
           await this.deps.setFileListCache(cacheKey, files);
           this.deps.clearFileListIndex();
+          await this.deps.pregenerateStyles?.(files);
 
           logger.debug("Fresh files cached (memory + Redis)", {
             cacheKey,
@@ -770,6 +772,7 @@ export class WebSocketManager {
           const cacheKey = buildFileListCacheKey(contentContext);
           await this.deps.setFileListCache(cacheKey, files);
           this.deps.clearFileListIndex();
+          await this.deps.pregenerateStyles?.(files);
 
           logger.debug("FRESH FILES FETCHED", {
             cacheKey,

--- a/src/rendering/orchestrator/css-candidate-manifest.test.ts
+++ b/src/rendering/orchestrator/css-candidate-manifest.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createStyleScopeProfile } from "#veryfront/html/styles-builder/style-scope-profile.ts";
 import {
   getProjectCandidates,
   getRouteCandidates,
@@ -149,6 +150,53 @@ describe("rendering/orchestrator/css-candidate-manifest", () => {
       assertEquals(result.has("text-red-500"), true);
       assertEquals(result.has("rounded-lg"), true);
       assertEquals(result.has("shadow-sm"), true);
+    });
+
+    it("applies the default style scope conventions when building manifests", () => {
+      invalidateProjectCandidateManifests();
+      const result = getProjectCandidates({
+        projectScope: "project-scope-defaults",
+        projectVersion: "v1",
+        projectDir: "/project",
+        styleProfile: createStyleScopeProfile(),
+        files: [
+          {
+            path: "/project/pages/index.tsx",
+            content: '<div className="text-red-500">Home</div>',
+          },
+          {
+            path: "/project/knowledge/reference.tsx",
+            content: '<div className="text-blue-500">Reference</div>',
+          },
+        ],
+        developmentMode: false,
+      });
+
+      assertEquals(result.has("text-red-500"), true);
+      assertEquals(result.has("text-blue-500"), false);
+    });
+
+    it("keeps configured runtime roots in the candidate graph", () => {
+      invalidateProjectCandidateManifests();
+      const result = getProjectCandidates({
+        projectScope: "project-scope-protected",
+        projectVersion: "v1",
+        projectDir: "/project",
+        styleProfile: createStyleScopeProfile({
+          directories: {
+            app: "knowledge/app",
+          },
+        }),
+        files: [
+          {
+            path: "/project/knowledge/app/page.tsx",
+            content: '<div className="text-emerald-500">Hello</div>',
+          },
+        ],
+        developmentMode: false,
+      });
+
+      assertEquals(result.has("text-emerald-500"), true);
     });
   });
 });

--- a/src/rendering/orchestrator/css-candidate-manifest.ts
+++ b/src/rendering/orchestrator/css-candidate-manifest.ts
@@ -1,4 +1,8 @@
 import { extractCandidates } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
+import {
+  filterFilesForStyleScope,
+  type StyleScopeProfile,
+} from "#veryfront/html/styles-builder/style-scope-profile.ts";
 import { getRouteModulePaths } from "#veryfront/modules/manifest/route-module-manifest.ts";
 import { rendererLogger } from "#veryfront/utils";
 
@@ -17,6 +21,7 @@ interface RouteCandidateOptions {
   projectScope: string;
   projectVersion: string;
   projectDir: string;
+  styleProfile?: StyleScopeProfile;
   routeKey: string;
   routeFilePaths: string[];
   files: SourceFileLike[];
@@ -27,6 +32,7 @@ interface ProjectCandidateOptions {
   projectScope: string;
   projectVersion: string;
   projectDir: string;
+  styleProfile?: StyleScopeProfile;
   files: SourceFileLike[];
   developmentMode: boolean;
 }
@@ -51,8 +57,12 @@ function toRelativeProjectPath(path: string, projectDir: string): string {
   return normalized.replace(/^\/+/, "");
 }
 
-function buildManifestCacheKey(projectScope: string, projectVersion: string): string {
-  return `${projectScope}:${projectVersion}`;
+function buildManifestCacheKey(
+  projectScope: string,
+  projectVersion: string,
+  styleProfileHash?: string,
+): string {
+  return `${projectScope}:${projectVersion}:${styleProfileHash ?? "default"}`;
 }
 
 function shouldRebuildManifest(
@@ -101,13 +111,20 @@ function buildCandidateManifest(files: SourceFileLike[], projectDir: string): Ca
 function getOrBuildManifest(
   options: Pick<
     ProjectCandidateOptions,
-    "projectScope" | "projectVersion" | "projectDir" | "files" | "developmentMode"
+    "projectScope" | "projectVersion" | "projectDir" | "files" | "developmentMode" | "styleProfile"
   >,
 ): CandidateManifest {
-  const manifestKey = buildManifestCacheKey(options.projectScope, options.projectVersion);
+  const manifestKey = buildManifestCacheKey(
+    options.projectScope,
+    options.projectVersion,
+    options.styleProfile?.hash,
+  );
   const existingManifest = manifestCache.get(manifestKey);
+  const scopedFiles = options.styleProfile
+    ? filterFilesForStyleScope(options.files, options.styleProfile, options.projectDir)
+    : options.files;
   const manifest = shouldRebuildManifest(existingManifest, options.developmentMode)
-    ? buildCandidateManifest(options.files, options.projectDir)
+    ? buildCandidateManifest(scopedFiles, options.projectDir)
     : existingManifest!;
 
   if (manifest !== existingManifest) {
@@ -139,7 +156,11 @@ function addCandidatesForPath(
  * Resolve route-scoped Tailwind candidates from a precomputed per-project manifest.
  */
 export function getRouteCandidates(options: RouteCandidateOptions): Set<string> {
-  const manifestKey = buildManifestCacheKey(options.projectScope, options.projectVersion);
+  const manifestKey = buildManifestCacheKey(
+    options.projectScope,
+    options.projectVersion,
+    options.styleProfile?.hash,
+  );
   const manifest = getOrBuildManifest(options);
   const routeCacheKey = `${manifestKey}:${options.routeKey}`;
   const cachedRoute = routeCandidateCache.get(routeCacheKey);
@@ -167,6 +188,7 @@ export function getRouteCandidates(options: RouteCandidateOptions): Set<string> 
   logger.debug("Resolved route candidates", {
     projectScope: options.projectScope,
     projectVersion: options.projectVersion,
+    styleProfileHash: options.styleProfile?.hash,
     route: options.routeKey,
     count: routeCandidates.size,
   });

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -29,6 +29,9 @@ import {
   rewriteCssModuleContent,
 } from "#veryfront/transforms/css-modules/naming.ts";
 import { getRouteCandidates } from "./css-candidate-manifest.ts";
+import { resolveStyleContentVersion } from "#veryfront/html/styles-builder/content-version.ts";
+import { createStyleScopeProfile } from "#veryfront/html/styles-builder/style-scope-profile.ts";
+import type { ResolvedContentContext } from "#veryfront/platform/adapters/fs/veryfront/types.ts";
 
 const logger = rendererLogger.component("html-generator");
 
@@ -453,8 +456,15 @@ export class HTMLGenerator {
     if (typeof wrappedFs.getUnderlyingAdapter !== "function") return undefined;
 
     const fsAdapter = wrappedFs.getUnderlyingAdapter() as {
+      getContentContext?: () => ResolvedContentContext | null;
       getProjectData?: () => { updated_at?: string } | undefined;
     };
+
+    const contentContext = typeof fsAdapter.getContentContext === "function"
+      ? fsAdapter.getContentContext()
+      : null;
+
+    if (contentContext) return resolveStyleContentVersion(contentContext);
 
     return fsAdapter.getProjectData?.()?.updated_at;
   }
@@ -505,6 +515,7 @@ export class HTMLGenerator {
       projectScope,
       projectVersion,
       projectDir: this.config.projectDir,
+      styleProfile: createStyleScopeProfile(this.config.config),
       routeKey,
       routeFilePaths,
       files,

--- a/src/server/handlers/dev/styles-candidate-scanner.ts
+++ b/src/server/handlers/dev/styles-candidate-scanner.ts
@@ -9,6 +9,12 @@
  */
 
 import { extractCandidates } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
+import { resolveStyleContentVersion } from "#veryfront/html/styles-builder/content-version.ts";
+import {
+  createStyleScopeProfile,
+  shouldIncludeStylePath,
+  shouldTraverseStyleDirectory,
+} from "#veryfront/html/styles-builder/style-scope-profile.ts";
 import { serverLogger } from "#veryfront/utils";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { join } from "#veryfront/compat/path/index.ts";
@@ -20,7 +26,6 @@ import { FRAMEWORK_CANDIDATES } from "./framework-candidates.generated.ts";
 const logger = serverLogger.component("styles-candidate-scanner");
 
 const SOURCE_EXTENSIONS = [".tsx", ".jsx", ".mdx", ".ts", ".js"];
-const SKIP_DIRS = new Set(["node_modules", ".cache", ".git", "dist", "build", ".vscode"]);
 
 /** De-duplicated set of framework candidates, computed once at import time. */
 const frameworkCandidates = new Set<string>(FRAMEWORK_CANDIDATES);
@@ -32,18 +37,6 @@ interface SourceFileProvider {
   getContentContext?: () => ResolvedContentContext | null;
 }
 
-function resolveProjectVersion(
-  ctx: HandlerContext,
-  contentContext: ResolvedContentContext | null,
-): string {
-  if (contentContext?.releaseId) return `release:${contentContext.releaseId}`;
-  if (contentContext?.branch) return `branch:${contentContext.branch}`;
-  if (contentContext?.environmentName) return `environment:${contentContext.environmentName}`;
-  if (ctx.releaseId) return `release:${ctx.releaseId}`;
-  if (ctx.parsedDomain?.branch) return `branch:${ctx.parsedDomain.branch}`;
-  return "live";
-}
-
 /**
  * Extract Tailwind CSS candidate class names from all project source files.
  *
@@ -52,6 +45,7 @@ function resolveProjectVersion(
  * method is available (local dev mode).
  */
 export async function extractProjectCandidates(ctx: HandlerContext): Promise<Set<string>> {
+  const styleProfile = createStyleScopeProfile(ctx.config);
   const wrappedFs = ctx.adapter.fs as { getUnderlyingAdapter?: () => unknown };
 
   if (typeof wrappedFs.getUnderlyingAdapter !== "function") {
@@ -83,8 +77,13 @@ export async function extractProjectCandidates(ctx: HandlerContext): Promise<Set
   for (
     const cls of getProjectCandidates({
       projectScope: ctx.projectSlug ?? contentContext?.projectSlug ?? ctx.projectDir,
-      projectVersion: resolveProjectVersion(ctx, contentContext),
+      projectVersion: resolveStyleContentVersion(contentContext, {
+        releaseId: ctx.releaseId,
+        branch: ctx.parsedDomain?.branch,
+        environmentName: ctx.environmentName,
+      }),
       projectDir: ctx.projectDir,
+      styleProfile,
       files,
       developmentMode: contentContext?.sourceType === "branch",
     })
@@ -100,6 +99,7 @@ export async function extractProjectCandidates(ctx: HandlerContext): Promise<Set
  * Used in local development mode where projects are read directly from disk.
  */
 async function scanLocalFiles(projectDir: string, ctx: HandlerContext): Promise<Set<string>> {
+  const styleProfile = createStyleScopeProfile(ctx.config);
   const candidates = new Set<string>(frameworkCandidates);
   const fs = createFileSystem();
 
@@ -116,11 +116,14 @@ async function scanLocalFiles(projectDir: string, ctx: HandlerContext): Promise<
       const fullPath = join(dir, entry.name);
 
       if (entry.isDirectory) {
-        if (!SKIP_DIRS.has(entry.name)) await scanDir(fullPath);
+        if (shouldTraverseStyleDirectory(styleProfile, fullPath, projectDir)) {
+          await scanDir(fullPath);
+        }
         continue;
       }
 
       if (!entry.isFile) continue;
+      if (!shouldIncludeStylePath(styleProfile, fullPath, projectDir)) continue;
       if (!SOURCE_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) continue;
 
       try {

--- a/src/server/handlers/dev/styles-css.handler.test.ts
+++ b/src/server/handlers/dev/styles-css.handler.test.ts
@@ -9,6 +9,8 @@ import {
   invalidateCompiler,
   invalidateProjectCSS,
 } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
+import { invalidatePreparedProjectCSS } from "#veryfront/html/styles-builder/prepared-project-css-cache.ts";
+import { invalidateProjectCandidateManifests } from "#veryfront/rendering/orchestrator/css-candidate-manifest.ts";
 import { StylesCSSHandler } from "./styles-css.handler.ts";
 
 const TEST_STYLESHEET = `@import "tailwindcss";`;
@@ -46,20 +48,26 @@ function mockTailwindFetch(): { restore: () => void; getCallCount: () => number 
 function createHandlerAdapter(
   files: Array<{ path: string; content?: string }>,
   contentContext: ResolvedContentContext,
-): RuntimeAdapter {
+): RuntimeAdapter & { setFiles: (nextFiles: Array<{ path: string; content?: string }>) => void } {
   const adapter = createMockAdapter();
   adapter.fs.files.set("/project/globals.css", TEST_STYLESHEET);
+  let currentFiles = files;
 
   return {
     ...adapter,
+    setFiles: (nextFiles) => {
+      currentFiles = nextFiles;
+    },
     fs: {
       ...adapter.fs,
       getUnderlyingAdapter: () => ({
-        getAllSourceFiles: async () => files,
+        getAllSourceFiles: async () => currentFiles,
         getContentContext: () => contentContext,
       }),
     },
-  } as unknown as RuntimeAdapter;
+  } as RuntimeAdapter & {
+    setFiles: (nextFiles: Array<{ path: string; content?: string }>) => void;
+  };
 }
 
 function makeCtx(adapter: RuntimeAdapter): HandlerContext {
@@ -87,6 +95,8 @@ describe("server/handlers/dev/styles-css.handler", () => {
       clearCSSCache();
       invalidateCompiler();
       invalidateProjectCSS(PROJECT_SLUG);
+      invalidatePreparedProjectCSS(PROJECT_SLUG);
+      invalidateProjectCandidateManifests(PROJECT_SLUG);
 
       const first = await handler.handle(req, ctx);
       const firstBody = await first.response!.text();
@@ -110,6 +120,56 @@ describe("server/handlers/dev/styles-css.handler", () => {
       clearCSSCache();
       invalidateCompiler();
       invalidateProjectCSS(PROJECT_SLUG);
+      invalidatePreparedProjectCSS(PROJECT_SLUG);
+      invalidateProjectCandidateManifests(PROJECT_SLUG);
+    }
+  });
+
+  it("serves prepared CSS without rescanning files after the first request", async () => {
+    const fetchMock = mockTailwindFetch();
+    const handler = new StylesCSSHandler();
+    const adapter = createHandlerAdapter(
+      [{
+        path: "/project/pages/index.tsx",
+        content: '<div className="text-fuchsia-500">Hello</div>',
+      }],
+      { sourceType: "branch", projectSlug: PROJECT_SLUG, branch: "main" },
+    );
+    const ctx = makeCtx(adapter);
+    const req = new Request("http://localhost/_vf_styles/styles.css");
+
+    try {
+      clearCSSCache();
+      invalidateCompiler();
+      invalidateProjectCSS(PROJECT_SLUG);
+      invalidatePreparedProjectCSS(PROJECT_SLUG);
+      invalidateProjectCandidateManifests(PROJECT_SLUG);
+
+      const first = await handler.handle(req, ctx);
+      const firstBody = await first.response!.text();
+      const initialFetchCount = fetchMock.getCallCount();
+
+      assertEquals(first.response!.status, 200);
+      assertEquals(firstBody.length > 0, true);
+
+      invalidateCompiler();
+      invalidateProjectCSS(PROJECT_SLUG);
+      invalidateProjectCandidateManifests(PROJECT_SLUG);
+      adapter.setFiles([]);
+
+      const second = await handler.handle(req, ctx);
+      const secondBody = await second.response!.text();
+
+      assertEquals(second.response!.status, 200);
+      assertEquals(secondBody, firstBody);
+      assertEquals(fetchMock.getCallCount(), initialFetchCount);
+    } finally {
+      fetchMock.restore();
+      clearCSSCache();
+      invalidateCompiler();
+      invalidateProjectCSS(PROJECT_SLUG);
+      invalidatePreparedProjectCSS(PROJECT_SLUG);
+      invalidateProjectCandidateManifests(PROJECT_SLUG);
     }
   });
 });

--- a/src/server/handlers/dev/styles-css.handler.ts
+++ b/src/server/handlers/dev/styles-css.handler.ts
@@ -9,20 +9,22 @@ import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { HTTP_OK, PRIORITY_HIGH_DEV } from "#veryfront/utils/constants/index.ts";
 import { joinPath } from "#veryfront/utils/path-utils.ts";
-import {
-  formatCSSError,
-  generateTailwindCSS,
-  getProjectCSS,
-} from "#veryfront/html/styles-builder/tailwind-compiler.ts";
+import { formatCSSError, getProjectCSS } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
 import { DEFAULT_STYLESHEET } from "#veryfront/html/styles-builder/css-hash-cache.ts";
+import { resolveStyleContentVersion } from "#veryfront/html/styles-builder/content-version.ts";
+import {
+  createPreparedProjectCSSContext,
+  storePreparedProjectCSS,
+  tryGetPreparedProjectCSS,
+} from "#veryfront/html/styles-builder/prepared-project-css-cache.ts";
+import { createStyleScopeProfile } from "#veryfront/html/styles-builder/style-scope-profile.ts";
 import { serverLogger } from "#veryfront/utils";
+import type { ResolvedContentContext } from "#veryfront/platform/adapters/fs/veryfront/types.ts";
 import { extractProjectCandidates } from "./styles-candidate-scanner.ts";
 
 const logger = serverLogger.component("styles-css-handler");
 
-type GeneratedStylesResult =
-  | Awaited<ReturnType<typeof generateTailwindCSS>>
-  | Awaited<ReturnType<typeof getProjectCSS>>;
+type GeneratedStylesResult = Awaited<ReturnType<typeof getProjectCSS>>;
 
 export class StylesCSSHandler extends BaseHandler {
   metadata: HandlerMetadata = {
@@ -38,6 +40,9 @@ export class StylesCSSHandler extends BaseHandler {
     try {
       return await this.withProxyContext(ctx, async () => {
         const responseBuilder = this.createResponseBuilder(ctx).withCache("no-cache");
+        const projectScope = ctx.projectSlug ?? ctx.projectDir;
+        const styleProfile = createStyleScopeProfile(ctx.config);
+        const contentContext = this.getContentContext(ctx);
         let rawCss: string;
         try {
           rawCss = await this.loadStylesheet(ctx);
@@ -46,6 +51,29 @@ export class StylesCSSHandler extends BaseHandler {
             error: error instanceof Error ? error.message : String(error),
           });
           rawCss = DEFAULT_STYLESHEET;
+        }
+        const preparedContext = this.createPreparedCSSContext(
+          projectScope,
+          rawCss,
+          styleProfile.hash,
+          contentContext,
+          ctx,
+        );
+
+        if (preparedContext) {
+          const prepared = await tryGetPreparedProjectCSS(preparedContext);
+          if (prepared) {
+            logger.debug("Prepared CSS cache hit", {
+              projectScope,
+              projectVersion: preparedContext.projectVersion,
+              styleProfileHash: styleProfile.hash,
+              cssHash: prepared.hash,
+            });
+
+            return this.respond(
+              responseBuilder.withContentType("text/css; charset=utf-8", prepared.css, HTTP_OK),
+            );
+          }
         }
 
         let candidates: Set<string>;
@@ -57,10 +85,11 @@ export class StylesCSSHandler extends BaseHandler {
           });
           candidates = new Set<string>();
         }
-        const result = await this.generateStylesheet(ctx, rawCss, candidates);
-
-        if ("error" in result && result.error) {
-          const formatted = formatCSSError(result.error);
+        let result: GeneratedStylesResult;
+        try {
+          result = await this.generateStylesheet(ctx, rawCss, candidates);
+        } catch (error) {
+          const formatted = formatCSSError(error instanceof Error ? error : String(error));
           logger.error("Tailwind error", {
             error: formatted.message,
             suggestion: formatted.suggestion,
@@ -103,11 +132,19 @@ body::before {
         }
 
         logger.debug("CSS generated", {
+          projectScope,
           candidates: candidates.size,
           cssLength: result.css.length,
           fromCache: "fromCache" in result ? result.fromCache : false,
           cssHash: "hash" in result ? result.hash : undefined,
         });
+
+        if (preparedContext && "hash" in result) {
+          await storePreparedProjectCSS(preparedContext, {
+            css: result.css,
+            hash: result.hash,
+          });
+        }
 
         return this.respond(
           responseBuilder.withContentType("text/css; charset=utf-8", result.css, HTTP_OK),
@@ -153,14 +190,49 @@ body::before {
     rawCss: string,
     candidates: Set<string>,
   ): Promise<GeneratedStylesResult> {
-    if (!ctx.projectSlug) {
-      return generateTailwindCSS(rawCss, candidates);
-    }
+    const projectScope = ctx.projectSlug ?? ctx.projectDir;
 
-    return getProjectCSS(ctx.projectSlug, rawCss, candidates, {
+    return getProjectCSS(projectScope, rawCss, candidates, {
       minify: true,
       environment: "preview",
       buildMode: "production",
     });
+  }
+
+  private getContentContext(ctx: HandlerContext): ResolvedContentContext | null {
+    const wrappedFs = ctx.adapter.fs as { getUnderlyingAdapter?: () => unknown };
+    if (typeof wrappedFs.getUnderlyingAdapter !== "function") return null;
+
+    const fsAdapter = wrappedFs.getUnderlyingAdapter() as {
+      getContentContext?: () => ResolvedContentContext | null;
+    };
+
+    return typeof fsAdapter.getContentContext === "function" ? fsAdapter.getContentContext() : null;
+  }
+
+  private createPreparedCSSContext(
+    projectScope: string | undefined,
+    rawCss: string,
+    styleProfileHash: string,
+    contentContext: ResolvedContentContext | null,
+    ctx: HandlerContext,
+  ) {
+    if (!projectScope) return undefined;
+
+    return createPreparedProjectCSSContext(
+      projectScope,
+      resolveStyleContentVersion(contentContext, {
+        releaseId: ctx.releaseId,
+        branch: ctx.parsedDomain?.branch,
+        environmentName: ctx.environmentName,
+      }),
+      rawCss,
+      styleProfileHash,
+      {
+        minify: true,
+        environment: "preview",
+        buildMode: "production",
+      },
+    );
   }
 }


### PR DESCRIPTION
## Summary
- add a convention-first `StyleScopeProfile` for style extraction only, while keeping runtime file resolution untouched
- add prepared project CSS artifact caching keyed by project scope, content version, stylesheet hash, candidates hash, and build profile
- make preview stylesheet serving artifact-first, with full candidate extraction only as the recovery path
- trigger CSS pregeneration from Veryfront adapter init and websocket invalidation in a generic runtime-local way
- centralize default invalidation callbacks so CSS, candidate manifests, and renderer/module caches stay aligned

## Notes
- keeps `veryfront-code` generic: no hosted-only job orchestration or internal platform coupling in the runtime implementation
- keeps local/open-source setups working by falling back to `projectDir` when a hosted project slug is unavailable
- keeps the broader styles architecture plan local-only in `.local/plans/styles-jit-architecture.md`

## Verification
- `deno task verify`
- pre-push checks: `1195 passed, 0 failed`

## Staging Verification Plan
1. Confirm authenticated preview still returns `200` and unauthenticated preview still redirects to sign-in.
2. Measure cold and warm `/_vf_styles/styles.css` timings and verify prepared-artifact hits after the first generation.
3. Edit a preview file to add a brand-new Tailwind class and confirm the class appears after the websocket-driven update.
4. Remove that class and confirm stale CSS is not retained.
5. Restart or roll a pod and confirm hashed CSS can still be served cross-pod through `/_vf/css/{hash}.css`.
