### PR TITLE
fix: use original filename for knowledge ingest

### DIFF
--- a/cli/commands/knowledge/command.test.ts
+++ b/cli/commands/knowledge/command.test.ts
@@ -8,9 +8,11 @@ import {
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "veryfront/platform/path";
 import {
+  buildSuggestedSlug,
   collectKnowledgeSources,
   createKnowledgeIngestResult,
   deriveKnowledgeRemotePath,
+  ensureUniqueSlugs,
   formatKnowledgeUploadSource,
   ingestResolvedSources,
   isLikelyLocalPath,
@@ -18,6 +20,7 @@ import {
   normalizeProjectUploadPath,
   resolveKnowledgeDownloadOutputDir,
   runKnowledgeParser,
+  stripChatUploadPrefix,
 } from "./command.ts";
 import { knowledgeIngestPythonSource } from "./parser-source.ts";
 import type { ApiClient } from "#cli/shared/config";
@@ -932,6 +935,114 @@ describe("ingestResolvedSources", () => {
       Error,
       "--slug can only be used with a single explicit source.",
     );
+  });
+});
+
+describe("stripChatUploadPrefix", () => {
+  it("strips a Studio chat-upload prefix from a filename", () => {
+    assertEquals(
+      stripChatUploadPrefix(
+        "chat-909d3dbc-5a9a-4156-97e4-bcceb5c2ec0d-1773942180291-fv1qg5-agents",
+      ),
+      "agents",
+    );
+  });
+
+  it("returns the original string when no prefix is present", () => {
+    assertEquals(stripChatUploadPrefix("agents"), "agents");
+    assertEquals(stripChatUploadPrefix("my-report"), "my-report");
+  });
+
+  it("handles uppercase hex in UUIDs", () => {
+    assertEquals(
+      stripChatUploadPrefix(
+        "chat-909D3DBC-5A9A-4156-97E4-BCCEB5C2EC0D-1773942180291-fv1qg5-report",
+      ),
+      "report",
+    );
+  });
+
+  it("preserves filenames that start with chat- but lack the full prefix", () => {
+    assertEquals(stripChatUploadPrefix("chat-summary"), "chat-summary");
+  });
+});
+
+describe("buildSuggestedSlug", () => {
+  it("uses the original filename for uploads with a chat prefix", () => {
+    const slug = buildSuggestedSlug(
+      {
+        kind: "upload",
+        input: "uploads/chat-909d3dbc-5a9a-4156-97e4-bcceb5c2ec0d-1773942180291-fv1qg5-agents.md",
+        uploadPath: "chat-909d3dbc-5a9a-4156-97e4-bcceb5c2ec0d-1773942180291-fv1qg5-agents.md",
+        localPath:
+          "/workspace/uploads/chat-909d3dbc-5a9a-4156-97e4-bcceb5c2ec0d-1773942180291-fv1qg5-agents.md",
+      },
+      0,
+    );
+    assertEquals(slug, "agents");
+  });
+
+  it("preserves clean upload filenames without a chat prefix", () => {
+    const slug = buildSuggestedSlug(
+      {
+        kind: "upload",
+        input: "uploads/contracts/q1.pdf",
+        uploadPath: "contracts/q1.pdf",
+        localPath: "/workspace/uploads/contracts/q1.pdf",
+      },
+      0,
+    );
+    assertEquals(slug, "contracts-q1");
+  });
+
+  it("strips the chat prefix from nested upload paths", () => {
+    const slug = buildSuggestedSlug(
+      {
+        kind: "upload",
+        input:
+          "uploads/docs/chat-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-1700000000000-abc12-readme.txt",
+        uploadPath:
+          "docs/chat-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-1700000000000-abc12-readme.txt",
+        localPath:
+          "/workspace/uploads/docs/chat-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-1700000000000-abc12-readme.txt",
+      },
+      0,
+    );
+    assertEquals(slug, "docs-readme");
+  });
+
+  it("uses basename only for absolute local paths outside /workspace", () => {
+    const slug = buildSuggestedSlug(
+      {
+        kind: "local",
+        input: "/var/folders/random/AGENTS.md",
+        localPath: "/var/folders/random/AGENTS.md",
+      },
+      0,
+    );
+    assertEquals(slug, "agents");
+  });
+});
+
+describe("ensureUniqueSlugs", () => {
+  it("appends a numeric suffix for duplicate slugs", () => {
+    const slugs = ensureUniqueSlugs([
+      {
+        kind: "upload",
+        input: "uploads/chat-909d3dbc-5a9a-4156-97e4-bcceb5c2ec0d-1773942180291-fv1qg5-agents.md",
+        uploadPath: "chat-909d3dbc-5a9a-4156-97e4-bcceb5c2ec0d-1773942180291-fv1qg5-agents.md",
+        localPath:
+          "/workspace/uploads/chat-909d3dbc-5a9a-4156-97e4-bcceb5c2ec0d-1773942180291-fv1qg5-agents.md",
+      },
+      {
+        kind: "upload",
+        input: "uploads/chat-11111111-2222-3333-4444-555555555555-1700000000000-xyz99-agents.md",
+        uploadPath: "chat-11111111-2222-3333-4444-555555555555-1700000000000-xyz99-agents.md",
+        localPath:
+          "/workspace/uploads/chat-11111111-2222-3333-4444-555555555555-1700000000000-xyz99-agents.md",
+      },
+    ]);
+    assertEquals(slugs, ["agents", "agents-2"]);
   });
 });
 

--- a/cli/commands/knowledge/command.test.ts
+++ b/cli/commands/knowledge/command.test.ts
@@ -1001,8 +1001,7 @@ describe("buildSuggestedSlug", () => {
         kind: "upload",
         input:
           "uploads/docs/chat-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-1700000000000-abc12-readme.txt",
-        uploadPath:
-          "docs/chat-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-1700000000000-abc12-readme.txt",
+        uploadPath: "docs/chat-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-1700000000000-abc12-readme.txt",
         localPath:
           "/workspace/uploads/docs/chat-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-1700000000000-abc12-readme.txt",
       },

--- a/cli/commands/knowledge/command.ts
+++ b/cli/commands/knowledge/command.ts
@@ -218,6 +218,23 @@ function slugify(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "document";
 }
 
+/**
+ * Strip the chat-upload prefix that Studio prepends to uploaded files.
+ *
+ * Studio stores uploads with a generated prefix like:
+ *   chat-<uuid>-<timestamp>-<shortid>-<original-filename>
+ *
+ * This function removes the prefix so knowledge files use the clean
+ * original filename (e.g. "agents" instead of
+ * "chat-909d3dbc-5a9a-4156-97e4-bcceb5c2ec0d-1773942180291-fv1qg5-agents").
+ */
+const CHAT_UPLOAD_PREFIX_RE =
+  /^chat-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-\d+-[a-z0-9]+-/i;
+
+export function stripChatUploadPrefix(name: string): string {
+  return name.replace(CHAT_UPLOAD_PREFIX_RE, "");
+}
+
 function defaultOutputRoot(): Promise<string> {
   return Deno.makeTempDir({ prefix: "veryfront-knowledge-" });
 }
@@ -360,7 +377,7 @@ function buildSourceReference(source: KnowledgeSource): string {
     : source.localPath;
 }
 
-function buildSuggestedSlug(source: KnowledgeSource, index: number): string {
+export function buildSuggestedSlug(source: KnowledgeSource, index: number): string {
   const normalized = normalize(
     source.kind === "upload" ? source.uploadPath : source.localPath,
   ).replace(/\\/g, "/");
@@ -382,9 +399,20 @@ function buildSuggestedSlug(source: KnowledgeSource, index: number): string {
     stripped = normalized.replace(/\.[^.]+$/, "");
   }
 
+  // Strip Studio's chat-upload prefix from the filename portion so that
+  // knowledge files use the original clean filename.
+  const lastSlash = stripped.lastIndexOf("/");
+  if (lastSlash >= 0) {
+    const dir = stripped.slice(0, lastSlash + 1);
+    const file = stripChatUploadPrefix(stripped.slice(lastSlash + 1));
+    stripped = file ? `${dir}${file}` : stripped;
+  } else {
+    stripped = stripChatUploadPrefix(stripped) || stripped;
+  }
+
   return slugify(stripped || basename(normalized, extname(normalized)) || `document-${index + 1}`);
 }
-function ensureUniqueSlugs(sources: KnowledgeSource[]): string[] {
+export function ensureUniqueSlugs(sources: KnowledgeSource[]): string[] {
   const counts = new Map<string, number>();
   return sources.map((source, index) => {
     const baseSlug = buildSuggestedSlug(source, index);

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.89",
+  "version": "0.1.90",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [


### PR DESCRIPTION
## Summary
- Strip Studio's chat-upload prefix (`chat-<uuid>-<timestamp>-<shortid>-`) from uploaded filenames during knowledge ingestion so knowledge files get clean paths like `knowledge/agents.md` instead of `knowledge/chat-909d3dbc-...-fv1qg5-agents.md`
- Add `stripChatUploadPrefix` helper with regex matching the Studio naming convention
- Apply prefix stripping in `buildSuggestedSlug` on the filename portion of the path
- Duplicate slugs still get numeric suffixes via `ensureUniqueSlugs`

## Test plan
- [x] Added unit tests for `stripChatUploadPrefix` (strips prefix, preserves clean names, handles uppercase hex, ignores partial matches)
- [x] Added unit tests for `buildSuggestedSlug` with chat-prefixed uploads (flat and nested paths)
- [x] Added unit test for `ensureUniqueSlugs` deduplication with stripped prefixes
- [x] All 1197 existing tests pass
- [x] Lint passes

Closes veryfront/veryfront-studio#743