### PR TITLE
feat: resolve preview css artifacts via api metadata

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.90",
+  "version": "0.1.91",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/platform/adapters/veryfront-api-client.test.ts
+++ b/src/platform/adapters/veryfront-api-client.test.ts
@@ -328,5 +328,94 @@ describe("VeryfrontApiClient", () => {
         },
       );
     });
+
+    it("should resolve a ready style artifact for the current project selector", async () => {
+      await withMockFetch(
+        (url, init) => {
+          const urlStr = typeof url === "string" ? url : url.toString();
+
+          if (urlStr.includes("/projects/test-project/style-artifacts/current?")) {
+            assertEquals(init?.method ?? "GET", "GET");
+            assertEquals(urlStr.includes("style_profile_hash=profile-1"), true);
+            assertEquals(urlStr.includes("branch=main"), true);
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  status: "ready",
+                  artifact_hash: "hash-1",
+                  asset_path: "/_vf/css/hash-1.css",
+                  content_type: "text/css; charset=utf-8",
+                  etag: '"hash-1"',
+                  updated_at: "2026-03-22T00:00:00.000Z",
+                }),
+                { status: 200, headers: { "Content-Type": "application/json" } },
+              ),
+            );
+          }
+
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                id: "00000000-0000-0000-0000-000000000001",
+                name: "Test",
+                slug: "test-project",
+                created_at: "2024-01-01",
+                updated_at: "2024-01-01",
+              }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            ),
+          );
+        },
+        async () => {
+          const result = await client.resolveStyleArtifact({
+            styleProfileHash: "profile-1",
+            branch: "main",
+          });
+
+          assertEquals(result.status, "ready");
+          assertEquals(result.artifactHash, "hash-1");
+        },
+      );
+    });
+
+    it("should register a style artifact with a PUT request", async () => {
+      await withMockFetch(
+        async (url, init) => {
+          const urlStr = typeof url === "string" ? url : url.toString();
+
+          if (urlStr.endsWith("/projects/test-project/style-artifacts/current")) {
+            assertEquals(init?.method, "PUT");
+            const body = typeof init?.body === "string" ? JSON.parse(init.body) : null;
+            assertEquals(body?.style_profile_hash, "profile-2");
+            assertEquals(body?.environment_name, "Preview");
+            assertEquals(body?.artifact_hash, "hash-2");
+
+            return new Response(
+              JSON.stringify({
+                status: "ready",
+                artifact_hash: "hash-2",
+                asset_path: "/_vf/css/hash-2.css",
+                content_type: "text/css; charset=utf-8",
+                etag: '"hash-2"',
+                updated_at: "2026-03-22T00:00:00.000Z",
+              }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          }
+
+          return new Response("Not found", { status: 404, statusText: "Not Found" });
+        },
+        async () => {
+          const result = await client.upsertStyleArtifact({
+            styleProfileHash: "profile-2",
+            environmentName: "Preview",
+            artifactHash: "hash-2",
+          });
+
+          assertEquals(result.status, "ready");
+          assertEquals(result.assetPath, "/_vf/css/hash-2.css");
+        },
+      );
+    });
   });
 });

--- a/src/platform/adapters/veryfront-api-client/client.ts
+++ b/src/platform/adapters/veryfront-api-client/client.ts
@@ -3,7 +3,10 @@ import {
   type FileDetail,
   type FileListResult,
   type ListFilesOptions,
+  type ProjectStyleArtifactResolution,
+  type ResolveStyleArtifactInput,
   type TokenProvider,
+  type UpsertStyleArtifactInput,
   VeryfrontAPIOperations,
 } from "./operations.ts";
 import { API_CLIENT_ERROR, type VeryfrontAPIConfig } from "./types.ts";
@@ -338,6 +341,20 @@ export class VeryfrontApiClient {
 
   lookupProjectByDomain(domain: string) {
     return this.operations.lookupProjectByDomain(domain);
+  }
+
+  resolveStyleArtifact(
+    input: ResolveStyleArtifactInput,
+    projectRef = this.getProjectSlug()!,
+  ): Promise<ProjectStyleArtifactResolution> {
+    return this.operations.resolveStyleArtifact(projectRef, input);
+  }
+
+  upsertStyleArtifact(
+    input: UpsertStyleArtifactInput,
+    projectRef = this.getProjectSlug()!,
+  ): Promise<ProjectStyleArtifactResolution> {
+    return this.operations.upsertStyleArtifact(projectRef, input);
   }
 
   // =============================================================================

--- a/src/platform/adapters/veryfront-api-client/index.ts
+++ b/src/platform/adapters/veryfront-api-client/index.ts
@@ -9,6 +9,10 @@ export {
   type FileDetail,
   type FileListResult,
   type ListFilesOptions,
+  type ProjectStyleArtifactResolution,
+  type ResolveStyleArtifactInput,
+  type StyleArtifactSelector,
+  type UpsertStyleArtifactInput,
   VeryfrontAPIOperations,
 } from "./operations.ts";
 export { type RequestOptions, requestWithRetry, type RetryConfig } from "./retry-handler.ts";
@@ -39,4 +43,6 @@ export {
   ProjectSchema,
   ReleaseFileDetailSchema,
   ReleaseFileListItemSchema,
+  type StyleArtifactResolveResponse,
+  StyleArtifactResolveResponseSchema,
 } from "./schemas/index.ts";

--- a/src/platform/adapters/veryfront-api-client/operations.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.ts
@@ -1,6 +1,6 @@
 import { logger as baseLogger } from "#veryfront/utils";
 import { z } from "zod";
-import { requestWithRetry, type RetryConfig } from "./retry-handler.ts";
+import { type RequestOptions, requestWithRetry, type RetryConfig } from "./retry-handler.ts";
 import { API_CLIENT_ERROR } from "./types.ts";
 import {
   BranchFileDetailSchema,
@@ -15,6 +15,7 @@ import {
   type ProjectFile,
   ProjectSchema,
   ReleaseFileDetailSchema,
+  StyleArtifactResolveResponseSchema,
 } from "./schemas/index.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { SpanNames } from "#veryfront/observability/tracing/span-names.ts";
@@ -53,6 +54,32 @@ export interface FileDetail {
   release_version?: string | null;
 }
 
+export interface StyleArtifactSelector {
+  branch?: string;
+  environmentName?: string;
+  releaseId?: string;
+}
+
+export interface ResolveStyleArtifactInput extends StyleArtifactSelector {
+  styleProfileHash: string;
+}
+
+export interface UpsertStyleArtifactInput extends ResolveStyleArtifactInput {
+  artifactHash: string;
+  assetPath?: string;
+  contentType?: string;
+  etag?: string;
+}
+
+export interface ProjectStyleArtifactResolution {
+  status: "ready" | "missing";
+  artifactHash?: string;
+  assetPath?: string;
+  etag?: string;
+  contentType?: string;
+  updatedAt?: string;
+}
+
 function buildListParams(options: ListFilesOptions): URLSearchParams {
   const { cursor, limit = DEFAULT_PAGE_LIMIT, pattern, sortBy = "updated_at", sortOrder = "desc" } =
     options;
@@ -78,6 +105,30 @@ function mapProjectFile<T extends ProjectFile>(file: T): ProjectFile {
     type: file.type,
     size: file.size,
     updated_at: file.updated_at,
+  };
+}
+
+function buildStyleArtifactParams(input: ResolveStyleArtifactInput): URLSearchParams {
+  const params = new URLSearchParams({
+    style_profile_hash: input.styleProfileHash,
+  });
+
+  if (input.branch) params.set("branch", input.branch);
+  if (input.environmentName) params.set("environment_name", input.environmentName);
+  if (input.releaseId) params.set("release_id", input.releaseId);
+
+  return params;
+}
+
+function mapStyleArtifactResolution(raw: unknown): ProjectStyleArtifactResolution {
+  const response = StyleArtifactResolveResponseSchema.parse(raw);
+  return {
+    status: response.status,
+    artifactHash: response.artifact_hash,
+    assetPath: response.asset_path,
+    etag: response.etag,
+    contentType: response.content_type,
+    updatedAt: response.updated_at,
   };
 }
 
@@ -423,11 +474,67 @@ export class VeryfrontAPIOperations {
     );
   }
 
-  private request(endpoint: string): Promise<unknown> {
+  async resolveStyleArtifact(
+    projectRef: string,
+    input: ResolveStyleArtifactInput,
+  ): Promise<ProjectStyleArtifactResolution> {
+    const params = buildStyleArtifactParams(input);
+    const url = `/projects/${encodeURIComponent(projectRef)}/style-artifacts/current?${params}`;
+    logger.debug("resolveStyleArtifact", {
+      projectRef,
+      branch: input.branch,
+      environmentName: input.environmentName,
+      releaseId: input.releaseId,
+      styleProfileHash: input.styleProfileHash,
+    });
+
+    return mapStyleArtifactResolution(await this.request(url));
+  }
+
+  async upsertStyleArtifact(
+    projectRef: string,
+    input: UpsertStyleArtifactInput,
+  ): Promise<ProjectStyleArtifactResolution> {
+    const url = `/projects/${encodeURIComponent(projectRef)}/style-artifacts/current`;
+    logger.debug("upsertStyleArtifact", {
+      projectRef,
+      branch: input.branch,
+      environmentName: input.environmentName,
+      releaseId: input.releaseId,
+      styleProfileHash: input.styleProfileHash,
+      artifactHash: input.artifactHash,
+    });
+
+    return mapStyleArtifactResolution(
+      await this.request(url, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          style_profile_hash: input.styleProfileHash,
+          branch: input.branch,
+          environment_name: input.environmentName,
+          release_id: input.releaseId,
+          artifact_hash: input.artifactHash,
+          asset_path: input.assetPath,
+          content_type: input.contentType,
+          etag: input.etag,
+        }),
+      }),
+    );
+  }
+
+  private request(endpoint: string, options: RequestOptions = {}): Promise<unknown> {
     return withSpan(
       SpanNames.API_REQUEST,
       () =>
-        requestWithRetry(`${this.apiBaseUrl}${endpoint}`, this.tokenProvider(), this.retryConfig),
+        requestWithRetry(
+          `${this.apiBaseUrl}${endpoint}`,
+          this.tokenProvider(),
+          this.retryConfig,
+          options,
+        ),
       { "api.endpoint": endpoint, "api.base_url": this.apiBaseUrl },
     );
   }

--- a/src/platform/adapters/veryfront-api-client/schemas/api.schema.test.ts
+++ b/src/platform/adapters/veryfront-api-client/schemas/api.schema.test.ts
@@ -246,6 +246,7 @@ describe("schemas", () => {
         "listReleaseFiles",
         "getReleaseFile",
         "lookupDomain",
+        "resolveStyleArtifact",
       ] as const;
 
       for (const key of expectedKeys) {

--- a/src/platform/adapters/veryfront-api-client/schemas/api.schema.ts
+++ b/src/platform/adapters/veryfront-api-client/schemas/api.schema.ts
@@ -147,6 +147,15 @@ export const LookupDomainResponseSchema = z.object({
   release_id: z.string().uuid().nullable(),
 });
 
+export const StyleArtifactResolveResponseSchema = z.object({
+  status: z.enum(["ready", "missing"]),
+  artifact_hash: z.string().optional(),
+  asset_path: z.string().optional(),
+  etag: z.string().optional(),
+  content_type: z.string().optional(),
+  updated_at: z.string().optional(),
+});
+
 export type Project = z.infer<typeof ProjectSchema>;
 export type ProjectFile = z.infer<typeof ProjectFileSchema>;
 export type PageInfo = z.infer<typeof PageInfoSchema>;
@@ -165,6 +174,7 @@ export type ListReleaseFilesResponse = z.infer<typeof ListReleaseFilesResponseSc
 export type ReleaseFileDetail = z.infer<typeof ReleaseFileDetailSchema>;
 
 export type LookupDomainResponse = z.infer<typeof LookupDomainResponseSchema>;
+export type StyleArtifactResolveResponse = z.infer<typeof StyleArtifactResolveResponseSchema>;
 
 export const API_ENDPOINTS = {
   listProjects: {
@@ -211,5 +221,11 @@ export const API_ENDPOINTS = {
     method: "GET" as const,
     path: "/projects/{domain}",
     description: "Look up project by custom domain (resolved via project_reference)",
+  },
+  resolveStyleArtifact: {
+    method: "GET" as const,
+    path: "/projects/{projectRef}/style-artifacts/current",
+    description:
+      "Resolve metadata for the latest ready style artifact for a branch, environment, or release selector",
   },
 } as const;

--- a/src/platform/adapters/veryfront-api-client/schemas/index.ts
+++ b/src/platform/adapters/veryfront-api-client/schemas/index.ts
@@ -35,4 +35,6 @@ export {
   ReleaseFileDetailSchema,
   type ReleaseFileListItem,
   ReleaseFileListItemSchema,
+  type StyleArtifactResolveResponse,
+  StyleArtifactResolveResponseSchema,
 } from "./api.schema.ts";

--- a/src/server/handlers/dev/styles-css.handler.test.ts
+++ b/src/server/handlers/dev/styles-css.handler.test.ts
@@ -2,6 +2,7 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { VeryfrontApiClient } from "#veryfront/platform/adapters/veryfront-api-client/index.ts";
 import type { HandlerContext } from "../types.ts";
 import type { ResolvedContentContext } from "#veryfront/platform/adapters/fs/veryfront/types.ts";
 import {
@@ -48,10 +49,23 @@ function mockTailwindFetch(): { restore: () => void; getCallCount: () => number 
 function createHandlerAdapter(
   files: Array<{ path: string; content?: string }>,
   contentContext: ResolvedContentContext,
+  client?: Pick<VeryfrontApiClient, "resolveStyleArtifact" | "upsertStyleArtifact">,
 ): RuntimeAdapter & { setFiles: (nextFiles: Array<{ path: string; content?: string }>) => void } {
   const adapter = createMockAdapter();
   adapter.fs.files.set("/project/globals.css", TEST_STYLESHEET);
   let currentFiles = files;
+  const underlyingAdapter: {
+    getAllSourceFiles: () => Promise<Array<{ path: string; content?: string }>>;
+    getContentContext: () => ResolvedContentContext;
+    getClient?: () => Pick<VeryfrontApiClient, "resolveStyleArtifact" | "upsertStyleArtifact">;
+  } = {
+    getAllSourceFiles: async () => currentFiles,
+    getContentContext: () => contentContext,
+  };
+
+  if (client) {
+    underlyingAdapter.getClient = () => client;
+  }
 
   return {
     ...adapter,
@@ -60,10 +74,7 @@ function createHandlerAdapter(
     },
     fs: {
       ...adapter.fs,
-      getUnderlyingAdapter: () => ({
-        getAllSourceFiles: async () => currentFiles,
-        getContentContext: () => contentContext,
-      }),
+      getUnderlyingAdapter: () => underlyingAdapter,
     },
   } as RuntimeAdapter & {
     setFiles: (nextFiles: Array<{ path: string; content?: string }>) => void;
@@ -163,6 +174,76 @@ describe("server/handlers/dev/styles-css.handler", () => {
       assertEquals(second.response!.status, 200);
       assertEquals(secondBody, firstBody);
       assertEquals(fetchMock.getCallCount(), initialFetchCount);
+    } finally {
+      fetchMock.restore();
+      clearCSSCache();
+      invalidateCompiler();
+      invalidateProjectCSS(PROJECT_SLUG);
+      invalidatePreparedProjectCSS(PROJECT_SLUG);
+      invalidateProjectCandidateManifests(PROJECT_SLUG);
+    }
+  });
+
+  it("resolves prepared CSS through style artifact metadata before rescanning files", async () => {
+    const fetchMock = mockTailwindFetch();
+    let storedHash: string | undefined;
+    let resolveCalls = 0;
+    const client = {
+      resolveStyleArtifact: async () => {
+        resolveCalls++;
+        return storedHash
+          ? { status: "ready" as const, artifactHash: storedHash }
+          : { status: "missing" as const };
+      },
+      upsertStyleArtifact: async (input: { artifactHash: string }) => {
+        storedHash = input.artifactHash;
+        return {
+          status: "ready" as const,
+          artifactHash: input.artifactHash,
+          assetPath: `/_vf/css/${input.artifactHash}.css`,
+        };
+      },
+    };
+    const handler = new StylesCSSHandler();
+    const adapter = createHandlerAdapter(
+      [{
+        path: "/project/pages/index.tsx",
+        content: '<div className="text-emerald-500">Hello</div>',
+      }],
+      { sourceType: "branch", projectSlug: PROJECT_SLUG, branch: "main" },
+      client,
+    );
+    const ctx = makeCtx(adapter);
+    const req = new Request("http://localhost/_vf_styles/styles.css");
+
+    try {
+      clearCSSCache();
+      invalidateCompiler();
+      invalidateProjectCSS(PROJECT_SLUG);
+      invalidatePreparedProjectCSS(PROJECT_SLUG);
+      invalidateProjectCandidateManifests(PROJECT_SLUG);
+
+      const first = await handler.handle(req, ctx);
+      const firstBody = await first.response!.text();
+      const initialFetchCount = fetchMock.getCallCount();
+
+      assertEquals(first.response!.status, 200);
+      assertEquals(firstBody.length > 0, true);
+      assertEquals(!!storedHash, true);
+
+      invalidateCompiler();
+      invalidateProjectCSS(PROJECT_SLUG);
+      invalidatePreparedProjectCSS(PROJECT_SLUG);
+      invalidateProjectCandidateManifests(PROJECT_SLUG);
+      adapter.setFiles([]);
+
+      const second = await handler.handle(req, ctx);
+      const secondBody = await second.response!.text();
+
+      assertEquals(second.response!.status, 200);
+      assertEquals(secondBody, firstBody);
+      assertEquals(fetchMock.getCallCount(), initialFetchCount);
+      assertEquals(resolveCalls > 0, true);
     } finally {
       fetchMock.restore();
       clearCSSCache();

--- a/src/server/handlers/dev/styles-css.handler.ts
+++ b/src/server/handlers/dev/styles-css.handler.ts
@@ -9,22 +9,33 @@ import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { HTTP_OK, PRIORITY_HIGH_DEV } from "#veryfront/utils/constants/index.ts";
 import { joinPath } from "#veryfront/utils/path-utils.ts";
-import { formatCSSError, getProjectCSS } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
+import {
+  formatCSSError,
+  getCSSByHashAsync,
+  getProjectCSS,
+  regenerateCSSByHash,
+} from "#veryfront/html/styles-builder/tailwind-compiler.ts";
 import { DEFAULT_STYLESHEET } from "#veryfront/html/styles-builder/css-hash-cache.ts";
 import { resolveStyleContentVersion } from "#veryfront/html/styles-builder/content-version.ts";
 import {
   createPreparedProjectCSSContext,
+  type PreparedProjectCSSRequestContext,
   storePreparedProjectCSS,
   tryGetPreparedProjectCSS,
 } from "#veryfront/html/styles-builder/prepared-project-css-cache.ts";
 import { createStyleScopeProfile } from "#veryfront/html/styles-builder/style-scope-profile.ts";
 import { serverLogger } from "#veryfront/utils";
 import type { ResolvedContentContext } from "#veryfront/platform/adapters/fs/veryfront/types.ts";
+import type {
+  ResolveStyleArtifactInput,
+  VeryfrontApiClient,
+} from "#veryfront/platform/adapters/veryfront-api-client/index.ts";
 import { extractProjectCandidates } from "./styles-candidate-scanner.ts";
 
 const logger = serverLogger.component("styles-css-handler");
 
 type GeneratedStylesResult = Awaited<ReturnType<typeof getProjectCSS>>;
+type StyleArtifactSelectorContext = Omit<ResolveStyleArtifactInput, "styleProfileHash">;
 
 export class StylesCSSHandler extends BaseHandler {
   metadata: HandlerMetadata = {
@@ -74,6 +85,25 @@ export class StylesCSSHandler extends BaseHandler {
               responseBuilder.withContentType("text/css; charset=utf-8", prepared.css, HTTP_OK),
             );
           }
+        }
+
+        const remotePrepared = await this.tryResolveRemotePreparedCSS(
+          ctx,
+          projectScope,
+          styleProfile.hash,
+          contentContext,
+          preparedContext,
+        );
+        if (remotePrepared) {
+          logger.debug("Prepared CSS resolved via style artifact metadata", {
+            projectScope,
+            styleProfileHash: styleProfile.hash,
+            cssHash: remotePrepared.hash,
+          });
+
+          return this.respond(
+            responseBuilder.withContentType("text/css; charset=utf-8", remotePrepared.css, HTTP_OK),
+          );
         }
 
         let candidates: Set<string>;
@@ -146,6 +176,15 @@ body::before {
           });
         }
 
+        if ("hash" in result) {
+          await this.registerPreparedCSSArtifact(
+            ctx,
+            styleProfile.hash,
+            contentContext,
+            result.hash,
+          );
+        }
+
         return this.respond(
           responseBuilder.withContentType("text/css; charset=utf-8", result.css, HTTP_OK),
         );
@@ -210,6 +249,17 @@ body::before {
     return typeof fsAdapter.getContentContext === "function" ? fsAdapter.getContentContext() : null;
   }
 
+  private getVeryfrontApiClient(ctx: HandlerContext): VeryfrontApiClient | null {
+    const wrappedFs = ctx.adapter.fs as { getUnderlyingAdapter?: () => unknown };
+    if (typeof wrappedFs.getUnderlyingAdapter !== "function") return null;
+
+    const fsAdapter = wrappedFs.getUnderlyingAdapter() as {
+      getClient?: () => VeryfrontApiClient;
+    };
+
+    return typeof fsAdapter.getClient === "function" ? fsAdapter.getClient() : null;
+  }
+
   private createPreparedCSSContext(
     projectScope: string | undefined,
     rawCss: string,
@@ -234,5 +284,133 @@ body::before {
         buildMode: "production",
       },
     );
+  }
+
+  private resolveStyleArtifactSelector(
+    contentContext: ResolvedContentContext | null,
+    ctx: HandlerContext,
+  ): StyleArtifactSelectorContext | null {
+    if (contentContext?.sourceType === "branch" && contentContext.branch) {
+      return {
+        branch: contentContext.branch,
+      };
+    }
+
+    if (contentContext?.sourceType === "environment" && contentContext.environmentName) {
+      return {
+        environmentName: contentContext.environmentName,
+      };
+    }
+
+    if (contentContext?.sourceType === "release" && contentContext.releaseId) {
+      return {
+        releaseId: contentContext.releaseId,
+      };
+    }
+
+    if (ctx.parsedDomain?.branch) {
+      return {
+        branch: ctx.parsedDomain.branch,
+      };
+    }
+
+    if (ctx.environmentName) {
+      return {
+        environmentName: ctx.environmentName,
+      };
+    }
+
+    if (ctx.releaseId) {
+      return {
+        releaseId: ctx.releaseId,
+      };
+    }
+
+    return null;
+  }
+
+  private async tryResolveRemotePreparedCSS(
+    ctx: HandlerContext,
+    projectScope: string | undefined,
+    styleProfileHash: string,
+    contentContext: ResolvedContentContext | null,
+    preparedContext?: PreparedProjectCSSRequestContext,
+  ): Promise<{ css: string; hash: string } | undefined> {
+    if (!projectScope) return undefined;
+
+    const selector = this.resolveStyleArtifactSelector(contentContext, ctx);
+    if (!selector) return undefined;
+
+    const client = this.getVeryfrontApiClient(ctx);
+    if (!client) return undefined;
+
+    try {
+      const resolved = await client.resolveStyleArtifact({
+        ...selector,
+        styleProfileHash,
+      });
+
+      if (resolved.status !== "ready" || !resolved.artifactHash) {
+        return undefined;
+      }
+
+      const css = await this.getPreparedCSSByHash(resolved.artifactHash, projectScope);
+      if (!css) return undefined;
+
+      if (preparedContext) {
+        await storePreparedProjectCSS(preparedContext, {
+          css,
+          hash: resolved.artifactHash,
+        });
+      }
+
+      return {
+        css,
+        hash: resolved.artifactHash,
+      };
+    } catch (error) {
+      logger.debug("Failed to resolve prepared CSS via style artifact metadata", {
+        projectScope,
+        styleProfileHash,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
+
+  private async getPreparedCSSByHash(
+    cssHash: string,
+    projectScope: string,
+  ): Promise<string | undefined> {
+    const cached = await getCSSByHashAsync(cssHash);
+    if (cached) return cached;
+    return regenerateCSSByHash(cssHash, projectScope);
+  }
+
+  private async registerPreparedCSSArtifact(
+    ctx: HandlerContext,
+    styleProfileHash: string,
+    contentContext: ResolvedContentContext | null,
+    cssHash: string,
+  ): Promise<void> {
+    const selector = this.resolveStyleArtifactSelector(contentContext, ctx);
+    if (!selector) return;
+
+    const client = this.getVeryfrontApiClient(ctx);
+    if (!client) return;
+
+    try {
+      await client.upsertStyleArtifact({
+        ...selector,
+        styleProfileHash,
+        artifactHash: cssHash,
+      });
+    } catch (error) {
+      logger.debug("Failed to register prepared CSS artifact", {
+        cssHash,
+        styleProfileHash,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 }


### PR DESCRIPTION
## Summary
- resolve preview style artifacts from the API before falling back to a local rescan and rebuild
- register newly prepared CSS artifacts back to the API so last-known-good recovery works across runtime instances
- keep the shared API endpoint catalog read-only and move the write path into the operations layer so the client contract stays consistent

## Testing
- deno test --allow-all src/platform/adapters/veryfront-api-client/schemas/api.schema.test.ts src/platform/adapters/veryfront-api-client.test.ts src/server/handlers/dev/styles-css.handler.test.ts
- deno check src/platform/adapters/veryfront-api-client/index.ts src/server/handlers/dev/styles-css.handler.ts
- deno fmt --check src/platform/adapters/veryfront-api-client/schemas/api.schema.ts src/platform/adapters/veryfront-api-client/schemas/api.schema.test.ts
- DENO_NO_PACKAGE_JSON=1 deno lint src/platform/adapters/veryfront-api-client/schemas/api.schema.ts src/platform/adapters/veryfront-api-client/schemas/api.schema.test.ts
- repo pre-push checks (1198 passed, 0 failed)