### PR TITLE
fix: preserve cold style artifact recovery telemetry

### DIFF
--- a/src/config/environment-config.ts
+++ b/src/config/environment-config.ts
@@ -188,7 +188,7 @@ function readEnvSnapshot(): EnvironmentConfig {
       ? parseNumber(v8MaxOldSpaceSizeRaw, 0) || undefined
       : undefined,
 
-    veryfrontVersion: getEnv("VERYFRONT_VERSION") || undefined,
+    veryfrontVersion: getEnv("VERYFRONT_VERSION") || getEnv("RELEASE_VERSION") || undefined,
   };
 }
 

--- a/src/observability/metrics/manager.ts
+++ b/src/observability/metrics/manager.ts
@@ -10,7 +10,7 @@ import { loadConfig } from "./config.ts";
 import { initializeInstruments } from "../instruments/index.ts";
 import { MetricsRecorder } from "./recorder.ts";
 import type { MetricsConfig, MetricsInstruments, OpenTelemetryAPI, RuntimeState } from "./types.ts";
-import { VERSION } from "#veryfront/utils/version.ts";
+import { RUNTIME_VERSION } from "#veryfront/utils/version.ts";
 
 const logger = serverLogger.component("metrics");
 
@@ -80,7 +80,7 @@ export class MetricsManager {
 
     try {
       this.api = await import("@opentelemetry/api");
-      this.meter = this.api.metrics.getMeter(finalConfig.prefix, VERSION);
+      this.meter = this.api.metrics.getMeter(finalConfig.prefix, RUNTIME_VERSION);
 
       this.instruments = initializeInstruments(this.meter, finalConfig, this.runtimeState);
       this.recorder.instruments = this.instruments;

--- a/src/observability/tracing/otlp-setup.ts
+++ b/src/observability/tracing/otlp-setup.ts
@@ -11,7 +11,7 @@
 
 import { getOtelTracingConfig } from "#veryfront/config/env.ts";
 import { serverLogger } from "#veryfront/utils";
-import { VERSION } from "#veryfront/utils/version.ts";
+import { RUNTIME_VERSION } from "#veryfront/utils/version.ts";
 
 const logger = serverLogger.component("otel");
 
@@ -116,7 +116,7 @@ export async function initializeOTLP(): Promise<void> {
 
     const resource = new Resource({
       [ATTR_SERVICE_NAME]: config.serviceName,
-      [ATTR_SERVICE_VERSION]: VERSION,
+      [ATTR_SERVICE_VERSION]: RUNTIME_VERSION,
     });
 
     const endpointBase = config.endpoint.replace(/\/$/, "");

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -460,6 +460,140 @@ describe("VeryfrontFSAdapter", () => {
       assertEquals(cached?.[0]?.path, "pages/index.tsx");
     });
 
+    it("does not pregenerate CSS during branch initialization", async () => {
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          cache: { enabled: true },
+        },
+      });
+
+      const client = (adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          listAllFiles: () => Promise<Array<{ path: string; content?: string }>>;
+        };
+      }).client;
+
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+      client.listAllFiles = () =>
+        Promise.resolve([{
+          path: "pages/index.tsx",
+          content: "export default function Page() {}",
+        }]);
+
+      let pregenerationCalls = 0;
+      (
+        adapter as unknown as {
+          triggerCSSPregeneration: (
+            files: Array<{ path: string; content?: string }>,
+          ) => Promise<void>;
+        }
+      ).triggerCSSPregeneration = async () => {
+        pregenerationCalls++;
+      };
+
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      adapter.setContentContext({
+        sourceType: "branch",
+        projectSlug: "test-project",
+        branch: "main",
+      });
+
+      await adapter.initialize();
+
+      assertEquals(pregenerationCalls, 0);
+    });
+
+    it("does not pregenerate CSS during branch cache warmup", async () => {
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          cache: { enabled: true },
+        },
+      });
+
+      const files = [{
+        path: "pages/index.tsx",
+        content: "export default function Page() { return null }",
+      }];
+
+      let listAllFilesCalls = 0;
+      const client = (adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          listAllFiles: () => Promise<Array<{ path: string; content?: string }>>;
+        };
+      }).client;
+
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+      client.listAllFiles = () => {
+        listAllFilesCalls++;
+        return Promise.resolve(files);
+      };
+
+      let pregenerationCalls = 0;
+      (
+        adapter as unknown as {
+          triggerCSSPregeneration: (
+            files: Array<{ path: string; content?: string }>,
+          ) => Promise<void>;
+        }
+      ).triggerCSSPregeneration = async () => {
+        pregenerationCalls++;
+      };
+
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      adapter.setContentContext({
+        sourceType: "branch",
+        projectSlug: "test-project",
+        branch: "main",
+      });
+
+      await adapter.initialize();
+      assertEquals(listAllFilesCalls, 1);
+      assertEquals(pregenerationCalls, 0);
+
+      const cacheKey = buildFileListCacheKey(adapter.getContentContext());
+      const cache = (adapter as unknown as {
+        cache: {
+          delete: (key: string) => boolean;
+          getAsync: <T>(key: string) => Promise<T | undefined>;
+        };
+      }).cache;
+
+      assertEquals(cache.delete(cacheKey), true);
+      assertEquals(await adapter.getAllSourceFiles(), []);
+
+      await waitFor(async () => {
+        const cached = await cache.getAsync<Array<{ path: string; content?: string }>>(cacheKey);
+        return Array.isArray(cached) && cached.length === 1;
+      });
+
+      assertEquals(listAllFilesCalls, 2);
+      assertEquals(pregenerationCalls, 0);
+    });
+
     it("should deduplicate concurrent background file list warmups", async () => {
       const adapter = createAdapter({
         veryfront: {

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -350,10 +350,10 @@ export class VeryfrontFSAdapter implements FSAdapter {
         sourceFilesWithContent: fileSummary.sourceFilesWithContent,
       });
 
-      // Trigger CSS pre-generation after the initial file snapshot is ready.
-      // This keeps stylesheet generation off the first styles request for both
-      // preview branches and published content.
-      if (fileSummary.sourceFilesWithContent > 0) {
+      // Trigger CSS pre-generation after the initial file snapshot is ready for
+      // published contexts. Branch previews should first try remote metadata
+      // recovery on cold starts instead of repopulating the prepared cache here.
+      if (fileSummary.sourceFilesWithContent > 0 && this.shouldBackgroundPregenerateStyles()) {
         this.triggerCSSPregeneration(files).catch(() => {
           // Error already logged in triggerCSSPregeneration
         });
@@ -403,6 +403,13 @@ export class VeryfrontFSAdapter implements FSAdapter {
     return isPrefixBeingInvalidated(prefix);
   }
 
+  private shouldBackgroundPregenerateStyles(): boolean {
+    // Branch previews should recover the last registered stylesheet artifact on
+    // cold starts before rebuilding CSS locally. Live edit pokes still
+    // pregenerate through the WebSocket path after branch content changes.
+    return this.contentContext?.sourceType !== "branch";
+  }
+
   private scheduleFileListWarmup(reason: string, cacheKey?: string): void {
     if (!this.initialized || !this.contentContext) return;
 
@@ -446,7 +453,7 @@ export class VeryfrontFSAdapter implements FSAdapter {
         await this.cache.setAsync(effectiveCacheKey, files);
         const fileSummary = summarizeFileList(files);
 
-        if (fileSummary.sourceFilesWithContent > 0) {
+        if (fileSummary.sourceFilesWithContent > 0 && this.shouldBackgroundPregenerateStyles()) {
           this.triggerCSSPregeneration(files).catch(() => {
             // Error already logged in triggerCSSPregeneration
           });

--- a/src/proxy/logger.ts
+++ b/src/proxy/logger.ts
@@ -1,8 +1,7 @@
-// Import version from root deno.json (the source of truth)
-import denoConfig from "#deno-config" with { type: "json" };
 import { getEnv } from "./env.ts";
 import { getTraceContext } from "./tracing.ts";
 import { AsyncLocalStorage } from "node:async_hooks";
+import { PROXY_RUNTIME_VERSION } from "./version.ts";
 
 // NOTE: Formatting utilities are INLINED below instead of imported from ../utils/logger/core.ts
 // because the proxy Docker build only copies src/proxy/ and has no access to src/utils/.
@@ -42,10 +41,6 @@ export function runWithProxyRequestContext<T>(
 function getProxyRequestContext(): ProxyRequestContext | undefined {
   return requestContextStore.getStore();
 }
-
-// Get version from environment variable or root deno.json
-const VERYFRONT_VERSION: string = getEnv("VERYFRONT_VERSION") ??
-  (typeof denoConfig.version === "string" ? denoConfig.version : "0.0.0");
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
@@ -293,7 +288,7 @@ class ProxyLogger {
       timestamp: new Date().toISOString(),
       level,
       service: "proxy",
-      veryfrontVersion: VERYFRONT_VERSION,
+      veryfrontVersion: PROXY_RUNTIME_VERSION,
       message,
       ...(traceCtx.traceId && { traceId: traceCtx.traceId, spanId: traceCtx.spanId }),
       // Include request context fields at top level (like renderer logs)

--- a/src/proxy/tracing.ts
+++ b/src/proxy/tracing.ts
@@ -4,13 +4,9 @@
  */
 
 import type { Context, Span, Tracer } from "@opentelemetry/api";
-import denoConfig from "#deno-config" with { type: "json" };
 import { getEnv } from "./env.ts";
 import { proxyLogger } from "./logger.ts";
-
-// Get version from environment variable or root deno.json
-const VERYFRONT_VERSION: string = getEnv("VERYFRONT_VERSION") ??
-  (typeof denoConfig.version === "string" ? denoConfig.version : "0.0.0");
+import { PROXY_RUNTIME_VERSION } from "./version.ts";
 
 let initialized = false;
 let tracerProvider: { shutdown: () => Promise<void> } | null = null;
@@ -98,7 +94,7 @@ export async function initializeOTLPWithApis(): Promise<void> {
     const resourceAttrs = parseResourceAttributes(getEnv("OTEL_RESOURCE_ATTRIBUTES"));
     const resource = new Resource({
       [ATTR_SERVICE_NAME]: config.serviceName,
-      [ATTR_SERVICE_VERSION]: VERYFRONT_VERSION,
+      [ATTR_SERVICE_VERSION]: PROXY_RUNTIME_VERSION,
       ...resourceAttrs,
     });
 

--- a/src/proxy/version.ts
+++ b/src/proxy/version.ts
@@ -1,0 +1,21 @@
+import denoConfig from "#deno-config" with { type: "json" };
+import { getEnv } from "./env.ts";
+
+function normalizeVersion(version: string | undefined): string | undefined {
+  if (!version) return undefined;
+  return version.replace(/^v(?=\d)/, "");
+}
+
+function getVersionEnv(name: string): string | undefined {
+  try {
+    return getEnv(name);
+  } catch {
+    return undefined;
+  }
+}
+
+export const PROXY_RUNTIME_VERSION = normalizeVersion(
+  getVersionEnv("VERYFRONT_VERSION") ?? getVersionEnv("RELEASE_VERSION"),
+) ??
+  normalizeVersion(typeof denoConfig.version === "string" ? denoConfig.version : undefined) ??
+  "0.0.0";

--- a/src/server/handlers/monitoring/health.handler.ts
+++ b/src/server/handlers/monitoring/health.handler.ts
@@ -3,7 +3,7 @@ import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } 
 import { joinPath } from "#veryfront/utils/path-utils.ts";
 import { HTTP_OK, HTTP_UNAVAILABLE, PRIORITY_HIGH } from "#veryfront/utils/constants/index.ts";
 import { isTracingDegraded, isTracingEnabled } from "#veryfront/observability/tracing/index.ts";
-import { VERSION } from "#veryfront/utils/version.ts";
+import { RUNTIME_VERSION } from "#veryfront/utils/version.ts";
 
 let serverInitialized = false;
 
@@ -73,7 +73,7 @@ export class HealthHandler extends BaseHandler {
           status: tracingDegraded ? "degraded" : "ok",
           timestamp: new Date().toISOString(),
           mode: hasStaticBuild ? "static+ssr" : "ssr",
-          version: VERSION,
+          version: RUNTIME_VERSION,
           tracing: {
             enabled: isTracingEnabled(),
             degraded: tracingDegraded,

--- a/src/utils/logger/logger.ts
+++ b/src/utils/logger/logger.ts
@@ -1,6 +1,6 @@
 import { getEnv } from "#veryfront/platform/compat/process.ts";
 import { hasDenoRuntime, hasNodeProcess } from "../runtime-guards.ts";
-import { VERSION } from "../version.ts";
+import { RUNTIME_VERSION } from "../version.ts";
 import {
   ANSI,
   colorize,
@@ -286,7 +286,7 @@ class ConsoleLogger implements Logger {
       timestamp: new Date().toISOString(),
       level,
       service: this.prefix.toLowerCase(),
-      veryfrontVersion: VERSION,
+      veryfrontVersion: RUNTIME_VERSION,
       message,
     };
 

--- a/src/utils/version.test.ts
+++ b/src/utils/version.test.ts
@@ -1,6 +1,13 @@
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { createBuildVersion, SERVER_START_TIME, VERSION } from "./version.ts";
+import {
+  createBuildVersion,
+  normalizeVeryfrontVersion,
+  resolveRuntimeVersion,
+  RUNTIME_VERSION,
+  SERVER_START_TIME,
+  VERSION,
+} from "./version.ts";
 
 describe("version", () => {
   describe("VERSION", () => {
@@ -11,6 +18,51 @@ describe("version", () => {
 
     it("should look like a semver version", () => {
       assert(/^\d+\.\d+\.\d+/.test(VERSION), `VERSION "${VERSION}" does not match semver pattern`);
+    });
+  });
+
+  describe("normalizeVeryfrontVersion", () => {
+    it("strips a leading v from release tags", () => {
+      assertEquals(normalizeVeryfrontVersion("v1.2.3"), "1.2.3");
+    });
+
+    it("preserves plain semver values", () => {
+      assertEquals(normalizeVeryfrontVersion("1.2.3"), "1.2.3");
+    });
+  });
+
+  describe("resolveRuntimeVersion", () => {
+    it("prefers VERYFRONT_VERSION over other sources", () => {
+      assertEquals(
+        resolveRuntimeVersion({
+          veryfrontVersion: "v1.2.3",
+          releaseVersion: "v2.0.0",
+          denoVersion: "3.0.0",
+          fallbackVersion: "4.0.0",
+        }),
+        "1.2.3",
+      );
+    });
+
+    it("falls back to release version before deno metadata", () => {
+      assertEquals(
+        resolveRuntimeVersion({
+          releaseVersion: "v2.0.0",
+          denoVersion: "3.0.0",
+          fallbackVersion: "4.0.0",
+        }),
+        "2.0.0",
+      );
+    });
+
+    it("falls back to deno metadata before the hard-coded fallback", () => {
+      assertEquals(
+        resolveRuntimeVersion({
+          denoVersion: "3.0.0",
+          fallbackVersion: "4.0.0",
+        }),
+        "3.0.0",
+      );
     });
   });
 
@@ -28,7 +80,7 @@ describe("version", () => {
 
   describe("createBuildVersion", () => {
     it("should return object with framework version", () => {
-      assertEquals(createBuildVersion().framework, VERSION);
+      assertEquals(createBuildVersion().framework, RUNTIME_VERSION);
     });
 
     it("should return object with server start time", () => {

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,6 +1,41 @@
+import denoConfig from "#deno-config" with { type: "json" };
+import { getEnv } from "#veryfront/platform/compat/process.ts";
+
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.89";
+export const VERSION = "0.1.91";
+
+export function normalizeVeryfrontVersion(version: string | undefined): string | undefined {
+  if (!version) return undefined;
+  return version.replace(/^v(?=\d)/, "");
+}
+
+function getVersionEnv(name: string): string | undefined {
+  try {
+    return getEnv(name);
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveRuntimeVersion(options: {
+  veryfrontVersion?: string;
+  releaseVersion?: string;
+  denoVersion?: string;
+  fallbackVersion?: string;
+} = {}): string {
+  return normalizeVeryfrontVersion(options.veryfrontVersion ?? options.releaseVersion) ??
+    normalizeVeryfrontVersion(options.denoVersion) ??
+    options.fallbackVersion ??
+    VERSION;
+}
+
+export const RUNTIME_VERSION = resolveRuntimeVersion({
+  veryfrontVersion: getVersionEnv("VERYFRONT_VERSION"),
+  releaseVersion: getVersionEnv("RELEASE_VERSION"),
+  denoVersion: typeof denoConfig.version === "string" ? denoConfig.version : undefined,
+  fallbackVersion: VERSION,
+});
 
 export const SERVER_START_TIME: number = Date.now();
 
@@ -12,7 +47,7 @@ export interface BuildVersion {
 
 export function createBuildVersion(projectUpdatedAt?: string): BuildVersion {
   return {
-    framework: VERSION,
+    framework: RUNTIME_VERSION,
     serverStart: SERVER_START_TIME,
     projectUpdated: projectUpdatedAt,
   };


### PR DESCRIPTION
## Summary
- keep branch preview cold starts on the remote style-artifact recovery path instead of repopulating prepared CSS during file-list warmup
- report the runtime Veryfront version consistently in logs, tracing, metrics, and health responses
- normalize release-tag versions and add focused regressions for branch warmups and runtime version resolution

## Verification
- deno test --allow-env src/utils/version.test.ts src/utils/logger/logger.test.ts src/config/environment-config.test.ts src/server/handlers/dev/styles-css.handler.test.ts src/platform/adapters/fs/veryfront/adapter.test.ts
- deno fmt --check src/utils/version.ts src/utils/version.test.ts src/utils/logger/logger.ts src/server/handlers/monitoring/health.handler.ts src/observability/tracing/otlp-setup.ts src/observability/metrics/manager.ts src/config/environment-config.ts src/proxy/version.ts src/proxy/logger.ts src/proxy/tracing.ts src/platform/adapters/fs/veryfront/adapter.ts src/platform/adapters/fs/veryfront/adapter.test.ts
- deno lint src/utils/version.ts src/utils/version.test.ts src/utils/logger/logger.ts src/server/handlers/monitoring/health.handler.ts src/observability/tracing/otlp-setup.ts src/observability/metrics/manager.ts src/config/environment-config.ts src/proxy/version.ts src/proxy/logger.ts src/proxy/tracing.ts src/platform/adapters/fs/veryfront/adapter.ts src/platform/adapters/fs/veryfront/adapter.test.ts
- deno check src/utils/version.ts src/utils/logger/logger.ts src/server/handlers/monitoring/health.handler.ts src/observability/tracing/otlp-setup.ts src/observability/metrics/manager.ts src/config/environment-config.ts src/proxy/version.ts src/proxy/logger.ts src/proxy/tracing.ts src/platform/adapters/fs/veryfront/adapter.ts
- repo pre-push suite: 1198 passed, 0 failed