### PR TITLE
chore: bump veryfront to 0.1.92

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -3,7 +3,7 @@ import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.91";
+export const VERSION = "0.1.92";
 
 export function normalizeVeryfrontVersion(version: string | undefined): string | undefined {
   if (!version) return undefined;


### PR DESCRIPTION
## Summary
- bump the published Veryfront version from 0.1.91 to 0.1.92
- carry the merged cold style artifact recovery and runtime version telemetry fixes into a real release

## Why
- #686 merged code changes without changing deno.json, so the release workflow would only target the already-published 0.1.91 package
- this follow-up makes the rollout deployable in staging and production

## Verification
- deno test --allow-env src/utils/version.test.ts
- deno fmt --check deno.json src/utils/version.ts
- git diff --check
- pre-push suite: 1198 passed, 0 failed