### PR TITLE
feat: add listCommandJobs() to Sandbox SDK

### DIFF
--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -753,6 +753,95 @@ describe("Sandbox", () => {
     });
   });
 
+  describe("listCommandJobs()", () => {
+    it("should list command jobs", async () => {
+      mockFetch([
+        jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
+        jsonResponse({
+          jobs: [
+            {
+              id: "job-1",
+              status: "running",
+              exit_code: null,
+              signal: null,
+              started_at: "2026-01-01T00:00:00Z",
+              finished_at: null,
+              heartbeat_status: "disabled",
+              last_heartbeat_at: null,
+              last_heartbeat_error: null,
+              heartbeat_failure_count: 0,
+            },
+            {
+              id: "job-2",
+              status: "completed",
+              exit_code: 0,
+              signal: null,
+              started_at: "2026-01-01T00:00:00Z",
+              finished_at: "2026-01-01T00:01:00Z",
+              heartbeat_status: "disabled",
+              last_heartbeat_at: null,
+              last_heartbeat_error: null,
+              heartbeat_failure_count: 0,
+            },
+          ],
+        }),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      const jobs = await sandbox.listCommandJobs();
+
+      assertEquals(jobs.length, 2);
+      assertEquals(jobs[0]!.id, "job-1");
+      assertEquals(jobs[0]!.status, "running");
+      assertEquals(jobs[1]!.id, "job-2");
+      assertEquals(jobs[1]!.status, "completed");
+      assertEquals(jobs[1]!.exitCode, 0);
+
+      assertStringIncludes(call(1).url, "/exec/jobs");
+      assertEquals(headerValue(1, "Authorization"), "Bearer token");
+    });
+
+    it("should handle array response format", async () => {
+      mockFetch([
+        jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
+        jsonResponse([
+          {
+            id: "job-1",
+            status: "running",
+            exit_code: null,
+            signal: null,
+            started_at: "2026-01-01T00:00:00Z",
+            finished_at: null,
+            heartbeat_status: "disabled",
+            last_heartbeat_at: null,
+            last_heartbeat_error: null,
+            heartbeat_failure_count: 0,
+          },
+        ]),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      const jobs = await sandbox.listCommandJobs();
+
+      assertEquals(jobs.length, 1);
+      assertEquals(jobs[0]!.id, "job-1");
+    });
+
+    it("should throw on list failure", async () => {
+      mockFetch([
+        jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
+        textResponse("Internal Server Error", 500),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      await assertRejects(
+        () => sandbox.listCommandJobs(),
+        Error,
+        "List command jobs failed",
+      );
+    });
+  });
+
   describe("cancelCommandJob()", () => {
     it("should cancel a command job", async () => {
       mockFetch([

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -397,6 +397,23 @@ export class Sandbox {
     };
   }
 
+  /** List all command jobs in the sandbox. */
+  async listCommandJobs(): Promise<CommandJob[]> {
+    const res = await fetch(`${this.endpoint}/exec/jobs`, {
+      headers: { Authorization: `Bearer ${this.authToken}` },
+    });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({
+        detail: `List command jobs failed: ${res.status} ${await res.text()}`,
+      });
+    }
+
+    const json = await res.json();
+    const jobs = Array.isArray(json) ? json : (json.jobs ?? []);
+    return jobs.map((j: Record<string, unknown>) => Sandbox.mapCommandJob(j));
+  }
+
   /** Cancel an async command job. */
   async cancelCommandJob(jobId: string): Promise<CommandJob> {
     const res = await fetch(`${this.endpoint}/exec/jobs/${jobId}/cancel`, {


### PR DESCRIPTION
## Summary
- Adds `listCommandJobs()` instance method to the `Sandbox` class
- Calls `GET {endpoint}/exec/jobs` and maps response through `mapCommandJob`
- Handles both array and `{jobs: [...]}` response formats for data plane compatibility

## Test plan
- [x] Unit test for listing jobs with `{jobs: [...]}` response format
- [x] Unit test for listing jobs with array response format
- [x] Unit test for error on non-OK response