### PR TITLE
feat: add cwd, timeout, and env options to sandbox exec methods

### DIFF
--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -22,6 +22,7 @@ export {
   type CommandJobHeartbeatStatus,
   type CommandJobOutput,
   type CommandJobStatus,
+  type ExecOptions,
   type ExecResult,
   type ExecStreamEvent,
   Sandbox,

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -442,6 +442,104 @@ describe("Sandbox", () => {
     });
   });
 
+  describe("executeCommand() with ExecOptions", () => {
+    it("should pass cwd, timeout_seconds, and env in the request body", async () => {
+      mockFetch([
+        jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
+        ndjsonResponse([
+          { type: "stdout", data: "ok\n" },
+          { type: "exit", exitCode: 0 },
+        ]),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      const result = await sandbox.executeCommand("ls", {
+        cwd: "/workspace/app",
+        timeout_seconds: 30,
+        env: { NODE_ENV: "test" },
+      });
+
+      assertEquals(result.stdout, "ok\n");
+      assertEquals(result.exitCode, 0);
+      assertEquals(jsonBody(1), {
+        command: "ls",
+        cwd: "/workspace/app",
+        timeout_seconds: 30,
+        env: { NODE_ENV: "test" },
+      });
+    });
+
+    it("should not include undefined options in request body", async () => {
+      mockFetch([
+        jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
+        ndjsonResponse([
+          { type: "exit", exitCode: 0 },
+        ]),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      await sandbox.executeCommand("pwd");
+
+      assertEquals(jsonBody(1), { command: "pwd" });
+    });
+  });
+
+  describe("executeStream() with ExecOptions", () => {
+    it("should pass options in the request body", async () => {
+      mockFetch([
+        jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
+        ndjsonResponse([
+          { type: "stdout", data: "out\n" },
+          { type: "exit", exitCode: 0 },
+        ]),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      const events: ExecStreamEvent[] = [];
+      for await (const event of sandbox.executeStream("cmd", { cwd: "/tmp" })) {
+        events.push(event);
+      }
+
+      assertEquals(events.length, 2);
+      assertEquals(jsonBody(1), { command: "cmd", cwd: "/tmp" });
+    });
+  });
+
+  describe("startCommandJob() with ExecOptions", () => {
+    it("should pass options in the request body", async () => {
+      mockFetch([
+        jsonResponse({ id: "s1", endpoint: "https://sb.test", status: "running" }),
+        jsonResponse({
+          id: "job-opts",
+          status: "running",
+          exit_code: null,
+          signal: null,
+          started_at: "2026-01-01T00:00:00Z",
+          finished_at: null,
+          heartbeat_status: "disabled",
+          last_heartbeat_at: null,
+          last_heartbeat_error: null,
+          heartbeat_failure_count: 0,
+        }),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+      const job = await sandbox.startCommandJob("npm test", {
+        cwd: "/workspace",
+        timeout_seconds: 120,
+        env: { CI: "true" },
+      });
+
+      assertEquals(job.id, "job-opts");
+      assertEquals(jsonBody(1), {
+        command: "npm test",
+        cwd: "/workspace",
+        timeout_seconds: 120,
+        env: { CI: "true" },
+      });
+    });
+  });
+
   describe("readFile()", () => {
     it("should read a file from sandbox", async () => {
       mockFetch([

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -17,6 +17,16 @@ import {
 import { getVeryfrontCloudAuthToken } from "#veryfront/platform/cloud/resolver.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 
+/** Options for command execution: working directory, timeout, and environment variables. */
+export interface ExecOptions {
+  /** Working directory for the command. */
+  cwd?: string;
+  /** Timeout in seconds for the command. */
+  timeout_seconds?: number;
+  /** Additional environment variables for the command. */
+  env?: Record<string, string>;
+}
+
 /** Options for creating a sandbox session. */
 export interface SandboxOptions {
   /** Base URL of the Veryfront API. Defaults to VERYFRONT_API_URL env. */
@@ -240,12 +250,12 @@ export class Sandbox {
   }
 
   /** Execute a bash command in the sandbox and return buffered result. */
-  async executeCommand(command: string): Promise<ExecResult> {
+  async executeCommand(command: string, options?: ExecOptions): Promise<ExecResult> {
     let stdout = "";
     let stderr = "";
     let exitCode = 1;
 
-    for await (const event of this.executeStream(command)) {
+    for await (const event of this.executeStream(command, options)) {
       switch (event.type) {
         case "stdout":
           stdout += event.data ?? "";
@@ -263,14 +273,14 @@ export class Sandbox {
   }
 
   /** Execute a bash command with streaming output (NDJSON). */
-  async *executeStream(command: string): AsyncGenerator<ExecStreamEvent> {
+  async *executeStream(command: string, options?: ExecOptions): AsyncGenerator<ExecStreamEvent> {
     const res = await fetch(`${this.endpoint}/exec`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${this.authToken}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ command }),
+      body: JSON.stringify({ command, ...options }),
     });
 
     if (!res.ok) {
@@ -341,14 +351,14 @@ export class Sandbox {
   }
 
   /** Start an async command job in the sandbox. */
-  async startCommandJob(command: string): Promise<CommandJob> {
+  async startCommandJob(command: string, options?: ExecOptions): Promise<CommandJob> {
     const res = await fetch(`${this.endpoint}/exec/jobs`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${this.authToken}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ command }),
+      body: JSON.stringify({ command, ...options }),
     });
 
     if (!res.ok) {


### PR DESCRIPTION
## Summary
- Adds `ExecOptions` interface with optional `cwd`, `timeout_seconds`, and `env` fields
- Updates `executeCommand()`, `executeStream()`, and `startCommandJob()` to accept and forward these options to the data plane
- Exports `ExecOptions` from `src/sandbox/index.ts`
- Adds tests verifying options are passed through in the request body

## Test plan
- [x] Existing sandbox tests pass (1198 passed)
- [x] New tests verify `cwd`, `timeout_seconds`, and `env` are included in the POST body
- [x] Verify undefined options are not sent in the request body