### PR TITLE
feat: add style artifact runtime recovery

### DIFF
--- a/cli/commands/styles/command-help.ts
+++ b/cli/commands/styles/command-help.ts
@@ -1,0 +1,21 @@
+import type { CommandHelp } from "../../help/types.ts";
+
+export const stylesHelp: CommandHelp = {
+  name: "styles",
+  description: "Build project CSS artifacts",
+  usage: "veryfront styles build-artifact --config <json>",
+  options: [
+    {
+      flag: "--config <json>",
+      description: "JSON build config with exactly one selector and an optional style_profile_hash",
+    },
+    {
+      flag: "--debug",
+      description: "Enable debug logging",
+    },
+  ],
+  examples: [
+    'veryfront styles build-artifact --config \'{"branch":"main"}\'',
+    'veryfront styles build-artifact --config \'{"style_profile_hash":"profile-1","environment_name":"Production"}\'',
+  ],
+};

--- a/cli/commands/styles/command.ts
+++ b/cli/commands/styles/command.ts
@@ -1,0 +1,285 @@
+import { z } from "zod";
+import { getConfig } from "veryfront/config";
+import { enhanceAdapterWithFS, getEnv, isExtendedFSAdapter, runtime } from "veryfront/platform";
+import { cliLogger, exitProcess } from "#cli/utils";
+import {
+  buildPreparedCSSArtifactFromFiles,
+} from "#veryfront/html/styles-builder/css-pregeneration.ts";
+import { resolveStyleContentVersion } from "#veryfront/html/styles-builder/content-version.ts";
+import { createStyleScopeProfile } from "#veryfront/html/styles-builder/style-scope-profile.ts";
+import type { ResolvedContentContext } from "#veryfront/platform/adapters/fs/veryfront/types.ts";
+import type { VeryfrontApiClient } from "#veryfront/platform/adapters/veryfront-api-client/index.ts";
+import type { StylesArgs } from "./handler.ts";
+import { writeJobResultIfConfigured } from "../../utils/write-job-result.ts";
+
+const StyleArtifactBuildConfigSchema = z.object({
+  style_profile_hash: z.string().min(1).optional(),
+  branch: z.string().min(1).optional(),
+  environment_name: z.string().min(1).optional(),
+  release_id: z.string().min(1).optional(),
+}).superRefine((value, ctx) => {
+  const selectorCount = [value.branch, value.environment_name, value.release_id].filter(Boolean)
+    .length;
+  if (selectorCount !== 1) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Exactly one of branch, environment_name, or release_id is required.",
+    });
+  }
+});
+
+type StyleArtifactBuildConfig = z.infer<typeof StyleArtifactBuildConfigSchema>;
+
+interface StyleArtifactBuildResult {
+  kind: "style_artifact";
+  status: "ready";
+  style_profile_hash: string;
+  artifact_hash: string;
+  asset_path: string;
+  content_type: string;
+  etag: string;
+  selector: {
+    type: "branch" | "environment" | "release";
+    value: string;
+  };
+}
+
+type StyleArtifactSelector =
+  | { branch: string; environmentName?: never; releaseId?: never; type: "branch"; value: string }
+  | {
+    branch?: never;
+    environmentName: string;
+    releaseId?: never;
+    type: "environment";
+    value: string;
+  }
+  | { branch?: never; environmentName?: never; releaseId: string; type: "release"; value: string };
+
+function parseStyleArtifactBuildConfig(rawConfig: string | undefined): StyleArtifactBuildConfig {
+  if (!rawConfig) {
+    throw new Error("Missing --config JSON");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawConfig);
+  } catch {
+    throw new Error("Invalid --config JSON");
+  }
+
+  return StyleArtifactBuildConfigSchema.parse(parsed);
+}
+
+function resolveStyleArtifactSelector(
+  config: StyleArtifactBuildConfig,
+): StyleArtifactSelector {
+  if (config.branch) {
+    return {
+      branch: config.branch,
+      type: "branch",
+      value: config.branch,
+    };
+  }
+
+  if (config.environment_name) {
+    return {
+      environmentName: config.environment_name,
+      type: "environment",
+      value: config.environment_name,
+    };
+  }
+
+  return {
+    releaseId: config.release_id!,
+    type: "release",
+    value: config.release_id!,
+  };
+}
+
+function resolveContentContextSelector(
+  selector: StyleArtifactSelector,
+): { type: "branch"; branch: string } | { type: "environment"; name: string } | {
+  type: "release";
+  releaseId: string;
+} {
+  if (selector.type === "branch") {
+    return { type: "branch", branch: selector.branch };
+  }
+
+  if (selector.type === "environment") {
+    return { type: "environment", name: selector.environmentName };
+  }
+
+  return { type: "release", releaseId: selector.releaseId };
+}
+
+function requireEnv(name: string): string {
+  const value = getEnv(name)?.trim();
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function getUnderlyingVeryfrontClient(adapter: Awaited<ReturnType<typeof enhanceAdapterWithFS>>): {
+  client: VeryfrontApiClient;
+  contentContext: ResolvedContentContext | null;
+  getAllSourceFiles: () => Promise<Array<{ path: string; content?: string }>>;
+} {
+  if (!isExtendedFSAdapter(adapter.fs)) {
+    throw new Error("Styles build requires a Veryfront FS adapter");
+  }
+
+  const fsAdapter = adapter.fs.getUnderlyingAdapter() as {
+    getAllSourceFiles?: () => Promise<Array<{ path: string; content?: string }>>;
+    getContentContext?: () => ResolvedContentContext | null;
+    getClient?: () => VeryfrontApiClient;
+  };
+
+  if (
+    typeof fsAdapter.getAllSourceFiles !== "function" ||
+    typeof fsAdapter.getClient !== "function"
+  ) {
+    throw new Error("Styles build requires a Veryfront source adapter");
+  }
+
+  return {
+    client: fsAdapter.getClient(),
+    contentContext: typeof fsAdapter.getContentContext === "function"
+      ? fsAdapter.getContentContext()
+      : null,
+    getAllSourceFiles: fsAdapter.getAllSourceFiles,
+  };
+}
+
+async function markStyleArtifactFailed(
+  client: VeryfrontApiClient | null,
+  selector: StyleArtifactSelector,
+  styleProfileHash: string | null | undefined,
+  error: string,
+): Promise<void> {
+  if (!client || !styleProfileHash) return;
+
+  try {
+    await client.upsertStyleArtifact({
+      ...(selector.type === "branch" ? { branch: selector.branch } : {}),
+      ...(selector.type === "environment" ? { environmentName: selector.environmentName } : {}),
+      ...(selector.type === "release" ? { releaseId: selector.releaseId } : {}),
+      styleProfileHash,
+      status: "failed",
+      failureReason: error,
+    });
+  } catch (updateError) {
+    cliLogger.warn("Failed to mark style artifact as failed", updateError);
+  }
+}
+
+export async function stylesCommand(options: StylesArgs): Promise<void> {
+  const buildConfig = parseStyleArtifactBuildConfig(options.config);
+  const selector = resolveStyleArtifactSelector(buildConfig);
+  const projectSlug = requireEnv("VERYFRONT_PROJECT_SLUG");
+  const apiToken = requireEnv("VERYFRONT_API_TOKEN");
+  const apiBaseUrl = requireEnv("VERYFRONT_API_BASE_URL");
+  const projectId = getEnv("VERYFRONT_PROJECT_ID")?.trim();
+  const projectDir = Deno.cwd();
+
+  const baseAdapter = await runtime.get();
+  const adapter = await enhanceAdapterWithFS(
+    baseAdapter,
+    {
+      fs: {
+        type: "veryfront-api",
+        projectDir,
+        veryfront: {
+          apiBaseUrl,
+          apiToken,
+          projectSlug,
+          projectId,
+          contentSource: resolveContentContextSelector(selector),
+        },
+      },
+    },
+    projectDir,
+  );
+
+  let client: VeryfrontApiClient | null = null;
+  let resolvedStyleProfileHash: string | null = buildConfig.style_profile_hash ?? null;
+
+  try {
+    const sourceAdapter = getUnderlyingVeryfrontClient(adapter);
+    client = sourceAdapter.client;
+    const cacheKey = projectId || projectSlug;
+    const config = await getConfig(projectDir, adapter, { cacheKey });
+    const styleProfile = createStyleScopeProfile(config);
+    resolvedStyleProfileHash = styleProfile.hash;
+
+    if (buildConfig.style_profile_hash && styleProfile.hash !== buildConfig.style_profile_hash) {
+      const message =
+        `Style profile hash mismatch: expected ${buildConfig.style_profile_hash}, got ${styleProfile.hash}`;
+      await markStyleArtifactFailed(client, selector, buildConfig.style_profile_hash, message);
+      throw new Error(message);
+    }
+
+    const files = await sourceAdapter.getAllSourceFiles();
+    if (files.length === 0) {
+      throw new Error("No project files were available to build the style artifact");
+    }
+
+    const projectVersion = resolveStyleContentVersion(sourceAdapter.contentContext, {
+      branch: sourceAdapter.contentContext?.branch ?? null,
+      releaseId: sourceAdapter.contentContext?.releaseId ?? null,
+      environmentName: sourceAdapter.contentContext?.environmentName ?? null,
+    });
+    const build = await buildPreparedCSSArtifactFromFiles({
+      projectSlug,
+      projectVersion,
+      projectDir,
+      files,
+      styleProfile,
+      stylesheetPath: config?.tailwind?.stylesheet,
+      minify: true,
+      environment: "preview",
+      buildMode: "production",
+    });
+
+    const resolution = await client.upsertStyleArtifact({
+      ...(selector.type === "branch" ? { branch: selector.branch } : {}),
+      ...(selector.type === "environment" ? { environmentName: selector.environmentName } : {}),
+      ...(selector.type === "release" ? { releaseId: selector.releaseId } : {}),
+      styleProfileHash: styleProfile.hash,
+      status: "ready",
+      artifactHash: build.hash,
+    });
+
+    const result: StyleArtifactBuildResult = {
+      kind: "style_artifact",
+      status: "ready",
+      style_profile_hash: styleProfile.hash,
+      artifact_hash: build.hash,
+      asset_path: resolution.assetPath ?? `/_vf/css/${build.hash}.css`,
+      content_type: resolution.contentType ?? "text/css; charset=utf-8",
+      etag: resolution.etag ?? `"${build.hash}"`,
+      selector: {
+        type: selector.type,
+        value: selector.value,
+      },
+    };
+
+    await writeJobResultIfConfigured(result);
+    cliLogger.info(`Built style artifact ${build.hash}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await markStyleArtifactFailed(
+      client,
+      selector,
+      resolvedStyleProfileHash ?? buildConfig.style_profile_hash,
+      message,
+    );
+    cliLogger.error(message);
+    exitProcess(1);
+  } finally {
+    if (isExtendedFSAdapter(adapter.fs)) {
+      await adapter.fs.shutdown();
+    }
+  }
+}

--- a/cli/commands/styles/command.ts
+++ b/cli/commands/styles/command.ts
@@ -1,14 +1,18 @@
 import { z } from "zod";
 import { getConfig } from "veryfront/config";
-import { enhanceAdapterWithFS, getEnv, isExtendedFSAdapter, runtime } from "veryfront/platform";
-import { cliLogger, exitProcess } from "#cli/utils";
+import {
+  enhanceAdapterWithFS,
+  getEnv,
+  isExtendedFSAdapter,
+  runtime,
+  type VeryfrontApiClient,
+} from "veryfront/platform";
 import {
   buildPreparedCSSArtifactFromFiles,
-} from "#veryfront/html/styles-builder/css-pregeneration.ts";
-import { resolveStyleContentVersion } from "#veryfront/html/styles-builder/content-version.ts";
-import { createStyleScopeProfile } from "#veryfront/html/styles-builder/style-scope-profile.ts";
-import type { ResolvedContentContext } from "#veryfront/platform/adapters/fs/veryfront/types.ts";
-import type { VeryfrontApiClient } from "#veryfront/platform/adapters/veryfront-api-client/index.ts";
+  createStyleScopeProfile,
+  resolveStyleContentVersion,
+} from "veryfront/rendering/styles";
+import { cliLogger, exitProcess } from "#cli/utils";
 import type { StylesArgs } from "./handler.ts";
 import { writeJobResultIfConfigured } from "../../utils/write-job-result.ts";
 
@@ -29,6 +33,12 @@ const StyleArtifactBuildConfigSchema = z.object({
 });
 
 type StyleArtifactBuildConfig = z.infer<typeof StyleArtifactBuildConfigSchema>;
+
+interface StyleBuildContentContext {
+  branch?: string;
+  environmentName?: string;
+  releaseId?: string;
+}
 
 interface StyleArtifactBuildResult {
   kind: "style_artifact";
@@ -123,7 +133,7 @@ function requireEnv(name: string): string {
 
 function getUnderlyingVeryfrontClient(adapter: Awaited<ReturnType<typeof enhanceAdapterWithFS>>): {
   client: VeryfrontApiClient;
-  contentContext: ResolvedContentContext | null;
+  contentContext: StyleBuildContentContext | null;
   getAllSourceFiles: () => Promise<Array<{ path: string; content?: string }>>;
 } {
   if (!isExtendedFSAdapter(adapter.fs)) {
@@ -132,7 +142,7 @@ function getUnderlyingVeryfrontClient(adapter: Awaited<ReturnType<typeof enhance
 
   const fsAdapter = adapter.fs.getUnderlyingAdapter() as {
     getAllSourceFiles?: () => Promise<Array<{ path: string; content?: string }>>;
-    getContentContext?: () => ResolvedContentContext | null;
+    getContentContext?: () => StyleBuildContentContext | null;
     getClient?: () => VeryfrontApiClient;
   };
 
@@ -225,7 +235,7 @@ export async function stylesCommand(options: StylesArgs): Promise<void> {
       throw new Error("No project files were available to build the style artifact");
     }
 
-    const projectVersion = resolveStyleContentVersion(sourceAdapter.contentContext, {
+    const projectVersion = resolveStyleContentVersion(null, {
       branch: sourceAdapter.contentContext?.branch ?? null,
       releaseId: sourceAdapter.contentContext?.releaseId ?? null,
       environmentName: sourceAdapter.contentContext?.environmentName ?? null,

--- a/cli/commands/styles/handler.ts
+++ b/cli/commands/styles/handler.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { createArgParser, parseArgsOrThrow } from "#cli/shared/args";
+import type { ParsedArgs } from "#cli/shared/types";
+
+const StylesArgsSchema = z.object({
+  subcommand: z.literal("build-artifact"),
+  config: z.string().optional(),
+  debug: z.boolean().default(false),
+});
+
+export type StylesArgs = z.infer<typeof StylesArgsSchema>;
+
+export const parseStylesArgs = createArgParser(StylesArgsSchema, {
+  subcommand: { keys: ["subcommand"], type: "string", positional: 0 },
+  config: { keys: ["config"], type: "string" },
+  debug: { keys: ["debug"], type: "boolean" },
+});
+
+export async function handleStylesCommand(args: ParsedArgs): Promise<void> {
+  const opts = parseArgsOrThrow(parseStylesArgs, "styles", args);
+  const { stylesCommand } = await import("./command.ts");
+  await stylesCommand(opts);
+}

--- a/cli/commands/styles/index.ts
+++ b/cli/commands/styles/index.ts
@@ -1,0 +1,2 @@
+export { handleStylesCommand, type StylesArgs, parseStylesArgs } from "./handler.ts";
+export { stylesCommand } from "./command.ts";

--- a/cli/commands/styles/index.ts
+++ b/cli/commands/styles/index.ts
@@ -1,2 +1,2 @@
-export { handleStylesCommand, type StylesArgs, parseStylesArgs } from "./handler.ts";
+export { handleStylesCommand, parseStylesArgs, type StylesArgs } from "./handler.ts";
 export { stylesCommand } from "./command.ts";

--- a/cli/help/command-definitions.ts
+++ b/cli/help/command-definitions.ts
@@ -16,6 +16,7 @@ import { doctorHelp } from "../commands/doctor/command-help.ts";
 import { cleanHelp } from "../commands/clean/command-help.ts";
 import { routesHelp } from "../commands/routes/command-help.ts";
 import { studioHelp } from "../commands/studio/command-help.ts";
+import { stylesHelp } from "../commands/styles/command-help.ts";
 import { lockHelp } from "../commands/lock/command-help.ts";
 import { analyzeChunksHelp } from "../commands/analyze-chunks/command-help.ts";
 import { generateHelp } from "../commands/generate/command-help.ts";
@@ -51,6 +52,7 @@ export const COMMANDS: CommandRegistry = {
   clean: cleanHelp,
   routes: routesHelp,
   studio: studioHelp,
+  styles: stylesHelp,
   lock: lockHelp,
   "analyze-chunks": analyzeChunksHelp,
   generate: generateHelp,

--- a/cli/router.test.ts
+++ b/cli/router.test.ts
@@ -47,6 +47,7 @@ describe("cli/command-definitions integrity", () => {
       "clean",
       "routes",
       "studio",
+      "styles",
       "lock",
       "generate",
       "pull",

--- a/cli/router.ts
+++ b/cli/router.ts
@@ -29,6 +29,7 @@ import { handleRoutesCommand } from "./commands/routes/handler.ts";
 import { handleServeCommand } from "./commands/serve/handler.ts";
 import { handleStartCommand } from "./commands/start/handler.ts";
 import { handleStudioCommand } from "./commands/studio/handler.ts";
+import { handleStylesCommand } from "./commands/styles/handler.ts";
 import { handleUpCommand } from "./commands/up/index.ts";
 import { handleTaskCommand } from "./commands/task/handler.ts";
 import { handleWorkflowCommand } from "./commands/workflow/handler.ts";
@@ -55,6 +56,7 @@ const commands: Record<string, (args: ParsedArgs) => Promise<void>> = {
   "analyze-chunks": handleAnalyzeChunksCommand,
   "routes": handleRoutesCommand,
   "studio": handleStudioCommand,
+  "styles": handleStylesCommand,
   "lock": handleLockCommand,
   "generate": handleGenerateCommand,
   "g": handleGenerateCommand,

--- a/deno.json
+++ b/deno.json
@@ -97,6 +97,7 @@
     "veryfront/config": "./src/config/index.ts",
     "veryfront/build": "./src/build/index.ts",
     "veryfront/rendering": "./src/rendering/index.ts",
+    "veryfront/rendering/styles": "./src/rendering/styles.ts",
     "veryfront/cache": "./src/cache/index.ts",
     "veryfront/security": "./src/security/index.ts",
     "veryfront/errors": "./src/errors/index.ts",

--- a/src/html/styles-builder/css-pregeneration.ts
+++ b/src/html/styles-builder/css-pregeneration.ts
@@ -39,6 +39,60 @@ interface CSSPregenerationOptions {
   buildMode?: "development" | "production";
 }
 
+export interface PreparedCSSArtifactBuildResult {
+  css: string;
+  hash: string;
+  candidateCount: number;
+  fromCache: boolean;
+  context: ReturnType<typeof createPreparedProjectCSSContext>;
+}
+
+export async function buildPreparedCSSArtifactFromFiles(
+  options: CSSPregenerationOptions,
+): Promise<PreparedCSSArtifactBuildResult> {
+  const {
+    projectSlug,
+    projectVersion,
+    projectDir,
+    files,
+    styleProfile,
+    stylesheet,
+    stylesheetPath,
+    minify = true,
+    environment = "preview",
+    buildMode = "production",
+  } = options;
+
+  const resolvedStylesheet = stylesheet ?? findStylesheetFromFiles(files, stylesheetPath);
+  const candidates = extractCandidatesFromFiles(files, {
+    projectDir,
+    styleProfile,
+  });
+
+  const result = await getProjectCSS(projectSlug, resolvedStylesheet, candidates, {
+    minify,
+    environment,
+    buildMode,
+  });
+  const context = createPreparedProjectCSSContext(
+    projectSlug,
+    projectVersion,
+    resolvedStylesheet,
+    styleProfile.hash,
+    { minify, environment, buildMode },
+  );
+
+  await storePreparedProjectCSS(context, { css: result.css, hash: result.hash });
+
+  return {
+    css: result.css,
+    hash: result.hash,
+    candidateCount: candidates.size,
+    fromCache: result.fromCache,
+    context,
+  };
+}
+
 /**
  * Pre-generate and cache CSS from file list.
  *
@@ -57,54 +111,28 @@ export async function pregenerateCSSFromFiles(
   const {
     projectSlug,
     projectVersion,
-    projectDir,
     files,
     styleProfile,
     stylesheet,
-    stylesheetPath,
-    minify = true,
-    environment = "preview",
-    buildMode = "production",
   } = options;
   const startTime = performance.now();
 
   try {
-    const resolvedStylesheet = stylesheet ?? findStylesheetFromFiles(files, stylesheetPath);
-    const candidates = extractCandidatesFromFiles(files, {
-      projectDir,
-      styleProfile,
-    });
-
     logger.debug("Starting", {
       projectSlug,
       projectVersion,
       fileCount: files.length,
-      candidateCount: candidates.size,
-      hasStylesheet: Boolean(resolvedStylesheet),
+      hasStylesheet: Boolean(stylesheet),
       styleProfileHash: styleProfile.hash,
     });
 
-    const result = await getProjectCSS(projectSlug, resolvedStylesheet, candidates, {
-      minify,
-      environment,
-      buildMode,
-    });
-    await storePreparedProjectCSS(
-      createPreparedProjectCSSContext(
-        projectSlug,
-        projectVersion,
-        resolvedStylesheet,
-        styleProfile.hash,
-        { minify, environment, buildMode },
-      ),
-      { css: result.css, hash: result.hash },
-    );
+    const result = await buildPreparedCSSArtifactFromFiles(options);
     const duration = performance.now() - startTime;
 
     logger.debug("Complete", {
       projectSlug,
       projectVersion,
-      candidateCount: candidates.size,
+      candidateCount: result.candidateCount,
       cssLength: result.css.length,
       cssHash: result.hash,
       fromCache: result.fromCache,

--- a/src/platform/adapters/veryfront-api-client.test.ts
+++ b/src/platform/adapters/veryfront-api-client.test.ts
@@ -409,11 +409,87 @@ describe("VeryfrontApiClient", () => {
           const result = await client.upsertStyleArtifact({
             styleProfileHash: "profile-2",
             environmentName: "Preview",
+            status: "ready",
             artifactHash: "hash-2",
           });
 
           assertEquals(result.status, "ready");
           assertEquals(result.assetPath, "/_vf/css/hash-2.css");
+        },
+      );
+    });
+
+    it("should parse non-ready style artifact states", async () => {
+      await withMockFetch(
+        (url, init) => {
+          const urlStr = typeof url === "string" ? url : url.toString();
+
+          if (urlStr.includes("/projects/test-project/style-artifacts/current?")) {
+            assertEquals(init?.method ?? "GET", "GET");
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  status: "building",
+                  build_job_id: "11111111-1111-4111-a111-111111111111",
+                  updated_at: "2026-03-22T00:00:00.000Z",
+                }),
+                { status: 200, headers: { "Content-Type": "application/json" } },
+              ),
+            );
+          }
+
+          return Promise.resolve(
+            new Response("Not found", { status: 404, statusText: "Not Found" }),
+          );
+        },
+        async () => {
+          const result = await client.resolveStyleArtifact({
+            styleProfileHash: "profile-3",
+            branch: "main",
+          });
+
+          assertEquals(result.status, "building");
+          assertEquals(result.buildJobId, "11111111-1111-4111-a111-111111111111");
+        },
+      );
+    });
+
+    it("should enqueue a style artifact build with a POST request", async () => {
+      await withMockFetch(
+        (url, init) => {
+          const urlStr = typeof url === "string" ? url : url.toString();
+
+          if (urlStr.endsWith("/projects/test-project/style-artifacts/current/builds")) {
+            assertEquals(init?.method, "POST");
+            const body = typeof init?.body === "string" ? JSON.parse(init.body) : null;
+            assertEquals(body?.style_profile_hash, "profile-4");
+            assertEquals(body?.environment_name, "Production");
+            assertEquals(body?.force, false);
+
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  status: "building",
+                  build_job_id: "22222222-2222-4222-a222-222222222222",
+                  updated_at: "2026-03-22T00:00:00.000Z",
+                }),
+                { status: 200, headers: { "Content-Type": "application/json" } },
+              ),
+            );
+          }
+
+          return Promise.resolve(
+            new Response("Not found", { status: 404, statusText: "Not Found" }),
+          );
+        },
+        async () => {
+          const result = await client.ensureStyleArtifactBuild({
+            styleProfileHash: "profile-4",
+            environmentName: "Production",
+          });
+
+          assertEquals(result.status, "building");
+          assertEquals(result.buildJobId, "22222222-2222-4222-a222-222222222222");
         },
       );
     });

--- a/src/platform/adapters/veryfront-api-client/client.ts
+++ b/src/platform/adapters/veryfront-api-client/client.ts
@@ -1,5 +1,6 @@
 import { logger as baseLogger } from "#veryfront/utils";
 import {
+  type EnsureStyleArtifactBuildInput,
   type FileDetail,
   type FileListResult,
   type ListFilesOptions,
@@ -348,6 +349,13 @@ export class VeryfrontApiClient {
     projectRef = this.getProjectSlug()!,
   ): Promise<ProjectStyleArtifactResolution> {
     return this.operations.resolveStyleArtifact(projectRef, input);
+  }
+
+  ensureStyleArtifactBuild(
+    input: EnsureStyleArtifactBuildInput,
+    projectRef = this.getProjectSlug()!,
+  ): Promise<ProjectStyleArtifactResolution> {
+    return this.operations.ensureStyleArtifactBuild(projectRef, input);
   }
 
   upsertStyleArtifact(

--- a/src/platform/adapters/veryfront-api-client/index.ts
+++ b/src/platform/adapters/veryfront-api-client/index.ts
@@ -6,6 +6,7 @@
 
 export { type FileContext, VeryfrontApiClient } from "./client.ts";
 export {
+  type EnsureStyleArtifactBuildInput,
   type FileDetail,
   type FileListResult,
   type ListFilesOptions,

--- a/src/platform/adapters/veryfront-api-client/operations.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.ts
@@ -64,19 +64,28 @@ export interface ResolveStyleArtifactInput extends StyleArtifactSelector {
   styleProfileHash: string;
 }
 
+export interface EnsureStyleArtifactBuildInput extends ResolveStyleArtifactInput {
+  force?: boolean;
+}
+
 export interface UpsertStyleArtifactInput extends ResolveStyleArtifactInput {
-  artifactHash: string;
+  status?: "building" | "ready" | "failed";
+  artifactHash?: string;
   assetPath?: string;
   contentType?: string;
   etag?: string;
+  buildJobId?: string;
+  failureReason?: string;
 }
 
 export interface ProjectStyleArtifactResolution {
-  status: "ready" | "missing";
+  status: "ready" | "missing" | "building" | "failed";
   artifactHash?: string;
   assetPath?: string;
   etag?: string;
   contentType?: string;
+  buildJobId?: string;
+  failureReason?: string;
   updatedAt?: string;
 }
 
@@ -128,6 +137,8 @@ function mapStyleArtifactResolution(raw: unknown): ProjectStyleArtifactResolutio
     assetPath: response.asset_path,
     etag: response.etag,
     contentType: response.content_type,
+    buildJobId: response.build_job_id,
+    failureReason: response.failure_reason,
     updatedAt: response.updated_at,
   };
 }
@@ -491,6 +502,37 @@ export class VeryfrontAPIOperations {
     return mapStyleArtifactResolution(await this.request(url));
   }
 
+  async ensureStyleArtifactBuild(
+    projectRef: string,
+    input: EnsureStyleArtifactBuildInput,
+  ): Promise<ProjectStyleArtifactResolution> {
+    const url = `/projects/${encodeURIComponent(projectRef)}/style-artifacts/current/builds`;
+    logger.debug("ensureStyleArtifactBuild", {
+      projectRef,
+      branch: input.branch,
+      environmentName: input.environmentName,
+      releaseId: input.releaseId,
+      styleProfileHash: input.styleProfileHash,
+      force: input.force ?? false,
+    });
+
+    return mapStyleArtifactResolution(
+      await this.request(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          style_profile_hash: input.styleProfileHash,
+          branch: input.branch,
+          environment_name: input.environmentName,
+          release_id: input.releaseId,
+          force: input.force ?? false,
+        }),
+      }),
+    );
+  }
+
   async upsertStyleArtifact(
     projectRef: string,
     input: UpsertStyleArtifactInput,
@@ -502,6 +544,7 @@ export class VeryfrontAPIOperations {
       environmentName: input.environmentName,
       releaseId: input.releaseId,
       styleProfileHash: input.styleProfileHash,
+      status: input.status ?? "ready",
       artifactHash: input.artifactHash,
     });
 
@@ -516,10 +559,13 @@ export class VeryfrontAPIOperations {
           branch: input.branch,
           environment_name: input.environmentName,
           release_id: input.releaseId,
+          status: input.status ?? "ready",
           artifact_hash: input.artifactHash,
           asset_path: input.assetPath,
           content_type: input.contentType,
           etag: input.etag,
+          build_job_id: input.buildJobId,
+          failure_reason: input.failureReason,
         }),
       }),
     );

--- a/src/platform/adapters/veryfront-api-client/schemas/api.schema.test.ts
+++ b/src/platform/adapters/veryfront-api-client/schemas/api.schema.test.ts
@@ -247,6 +247,7 @@ describe("schemas", () => {
         "getReleaseFile",
         "lookupDomain",
         "resolveStyleArtifact",
+        "ensureStyleArtifactBuild",
       ] as const;
 
       for (const key of expectedKeys) {
@@ -264,10 +265,15 @@ describe("schemas", () => {
       }
     });
 
-    it("should use GET method for all endpoints", () => {
+    it("should use supported HTTP methods for all endpoints", () => {
       for (const endpoint of Object.values(API_ENDPOINTS)) {
-        assertEquals(endpoint.method, "GET");
+        assertEquals(["GET", "POST"].includes(endpoint.method), true);
       }
+    });
+
+    it("should use the expected methods for style artifact endpoints", () => {
+      assertEquals(API_ENDPOINTS.resolveStyleArtifact.method, "GET");
+      assertEquals(API_ENDPOINTS.ensureStyleArtifactBuild.method, "POST");
     });
 
     it("should have paths starting with /", () => {

--- a/src/platform/adapters/veryfront-api-client/schemas/api.schema.ts
+++ b/src/platform/adapters/veryfront-api-client/schemas/api.schema.ts
@@ -148,11 +148,13 @@ export const LookupDomainResponseSchema = z.object({
 });
 
 export const StyleArtifactResolveResponseSchema = z.object({
-  status: z.enum(["ready", "missing"]),
+  status: z.enum(["ready", "missing", "building", "failed"]),
   artifact_hash: z.string().optional(),
   asset_path: z.string().optional(),
   etag: z.string().optional(),
   content_type: z.string().optional(),
+  build_job_id: z.string().uuid().optional(),
+  failure_reason: z.string().optional(),
   updated_at: z.string().optional(),
 });
 
@@ -227,5 +229,11 @@ export const API_ENDPOINTS = {
     path: "/projects/{projectRef}/style-artifacts/current",
     description:
       "Resolve metadata for the latest ready style artifact for a branch, environment, or release selector",
+  },
+  ensureStyleArtifactBuild: {
+    method: "POST" as const,
+    path: "/projects/{projectRef}/style-artifacts/current/builds",
+    description:
+      "Ensure a background style artifact build exists for a branch, environment, or release selector",
   },
 } as const;

--- a/src/rendering/styles.ts
+++ b/src/rendering/styles.ts
@@ -1,0 +1,15 @@
+/**
+ * Public style artifact helpers used by CLI and worker entrypoints.
+ *
+ * @module rendering/styles
+ */
+
+export {
+  buildPreparedCSSArtifactFromFiles,
+  type PreparedCSSArtifactBuildResult,
+} from "../html/styles-builder/css-pregeneration.ts";
+export {
+  createStyleScopeProfile,
+  type StyleScopeProfile,
+} from "../html/styles-builder/style-scope-profile.ts";
+export { resolveStyleContentVersion } from "../html/styles-builder/content-version.ts";

--- a/src/server/handlers/dev/styles-css.handler.test.ts
+++ b/src/server/handlers/dev/styles-css.handler.test.ts
@@ -49,7 +49,10 @@ function mockTailwindFetch(): { restore: () => void; getCallCount: () => number 
 function createHandlerAdapter(
   files: Array<{ path: string; content?: string }>,
   contentContext: ResolvedContentContext,
-  client?: Pick<VeryfrontApiClient, "resolveStyleArtifact" | "upsertStyleArtifact">,
+  client?: Pick<
+    VeryfrontApiClient,
+    "ensureStyleArtifactBuild" | "resolveStyleArtifact" | "upsertStyleArtifact"
+  >,
 ): RuntimeAdapter & { setFiles: (nextFiles: Array<{ path: string; content?: string }>) => void } {
   const adapter = createMockAdapter();
   adapter.fs.files.set("/project/globals.css", TEST_STYLESHEET);
@@ -57,7 +60,10 @@ function createHandlerAdapter(
   const underlyingAdapter: {
     getAllSourceFiles: () => Promise<Array<{ path: string; content?: string }>>;
     getContentContext: () => ResolvedContentContext;
-    getClient?: () => Pick<VeryfrontApiClient, "resolveStyleArtifact" | "upsertStyleArtifact">;
+    getClient?: () => Pick<
+      VeryfrontApiClient,
+      "ensureStyleArtifactBuild" | "resolveStyleArtifact" | "upsertStyleArtifact"
+    >;
   } = {
     getAllSourceFiles: async () => currentFiles,
     getContentContext: () => contentContext,
@@ -195,7 +201,11 @@ describe("server/handlers/dev/styles-css.handler", () => {
           ? { status: "ready" as const, artifactHash: storedHash }
           : { status: "missing" as const };
       },
-      upsertStyleArtifact: async (input: { artifactHash: string }) => {
+      ensureStyleArtifactBuild: async () => ({ status: "building" as const }),
+      upsertStyleArtifact: async (input: { artifactHash?: string }) => {
+        if (!input.artifactHash) {
+          throw new Error("artifactHash is required");
+        }
         storedHash = input.artifactHash;
         return {
           status: "ready" as const,
@@ -244,6 +254,67 @@ describe("server/handlers/dev/styles-css.handler", () => {
       assertEquals(secondBody, firstBody);
       assertEquals(fetchMock.getCallCount(), initialFetchCount);
       assertEquals(resolveCalls > 0, true);
+    } finally {
+      fetchMock.restore();
+      clearCSSCache();
+      invalidateCompiler();
+      invalidateProjectCSS(PROJECT_SLUG);
+      invalidatePreparedProjectCSS(PROJECT_SLUG);
+      invalidateProjectCandidateManifests(PROJECT_SLUG);
+    }
+  });
+
+  it("ensures background style artifact builds for environment selectors before local fallback", async () => {
+    const fetchMock = mockTailwindFetch();
+    let ensureCalls = 0;
+    let upsertCalls = 0;
+    const client = {
+      resolveStyleArtifact: async () => ({ status: "missing" as const }),
+      ensureStyleArtifactBuild: async () => {
+        ensureCalls++;
+        return {
+          status: "building" as const,
+          buildJobId: "11111111-1111-4111-a111-111111111111",
+        };
+      },
+      upsertStyleArtifact: async (input: { artifactHash?: string }) => {
+        if (!input.artifactHash) {
+          throw new Error("artifactHash is required");
+        }
+        upsertCalls++;
+        return {
+          status: "ready" as const,
+          artifactHash: input.artifactHash,
+          assetPath: `/_vf/css/${input.artifactHash}.css`,
+        };
+      },
+    };
+    const handler = new StylesCSSHandler();
+    const adapter = createHandlerAdapter(
+      [{
+        path: "/project/pages/index.tsx",
+        content: '<div className="text-sky-500">Hello</div>',
+      }],
+      { sourceType: "environment", projectSlug: PROJECT_SLUG, environmentName: "Preview" },
+      client,
+    );
+    const ctx = makeCtx(adapter);
+    const req = new Request("http://localhost/_vf_styles/styles.css");
+
+    try {
+      clearCSSCache();
+      invalidateCompiler();
+      invalidateProjectCSS(PROJECT_SLUG);
+      invalidatePreparedProjectCSS(PROJECT_SLUG);
+      invalidateProjectCandidateManifests(PROJECT_SLUG);
+
+      const result = await handler.handle(req, ctx);
+      const body = await result.response!.text();
+
+      assertEquals(result.response!.status, 200);
+      assertEquals(body.length > 0, true);
+      assertEquals(ensureCalls, 1);
+      assertEquals(upsertCalls, 1);
     } finally {
       fetchMock.restore();
       clearCSSCache();

--- a/src/server/handlers/dev/styles-css.handler.ts
+++ b/src/server/handlers/dev/styles-css.handler.ts
@@ -27,6 +27,7 @@ import { createStyleScopeProfile } from "#veryfront/html/styles-builder/style-sc
 import { serverLogger } from "#veryfront/utils";
 import type { ResolvedContentContext } from "#veryfront/platform/adapters/fs/veryfront/types.ts";
 import type {
+  EnsureStyleArtifactBuildInput,
   ResolveStyleArtifactInput,
   VeryfrontApiClient,
 } from "#veryfront/platform/adapters/veryfront-api-client/index.ts";
@@ -351,6 +352,9 @@ body::before {
       });
 
       if (resolved.status !== "ready" || !resolved.artifactHash) {
+        if (resolved.status !== "building") {
+          await this.ensureRemotePreparedCSSBuild(client, selector, styleProfileHash);
+        }
         return undefined;
       }
 
@@ -408,6 +412,33 @@ body::before {
     } catch (error) {
       logger.debug("Failed to register prepared CSS artifact", {
         cssHash,
+        styleProfileHash,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private shouldEnsureRemoteStyleArtifactBuild(selector: StyleArtifactSelectorContext): boolean {
+    return Boolean(selector.environmentName || selector.releaseId);
+  }
+
+  private async ensureRemotePreparedCSSBuild(
+    client: VeryfrontApiClient,
+    selector: StyleArtifactSelectorContext,
+    styleProfileHash: string,
+  ): Promise<void> {
+    if (!this.shouldEnsureRemoteStyleArtifactBuild(selector)) return;
+
+    try {
+      await client.ensureStyleArtifactBuild(
+        {
+          ...selector,
+          styleProfileHash,
+        } satisfies EnsureStyleArtifactBuildInput,
+      );
+    } catch (error) {
+      logger.debug("Failed to ensure remote prepared CSS build", {
+        selector,
         styleProfileHash,
         error: error instanceof Error ? error.message : String(error),
       });


### PR DESCRIPTION
## Summary
- add the worker-facing `veryfront styles build-artifact` command and style-artifact API client support
- recover preview CSS through style-artifact metadata before rescanning, while keeping local fail-open fallback
- expose a narrow public `veryfront/rendering/styles` surface so the CLI uses public exports instead of internal `#veryfront/**` paths

## Verification
- deno task verify
- deno task lint:cli-boundary

## Rollout notes
- merge this before the job-runner task and API queueing changes so the published CLI already contains `styles build-artifact`
