### PR TITLE
fix: bypass project env overlay for framework-owned config

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/security/http/base-handler.ts
+++ b/src/security/http/base-handler.ts
@@ -6,6 +6,7 @@ import type {
   RoutePattern,
 } from "#veryfront/types";
 import { runWithCacheBatching } from "#veryfront/cache/request-cache-batcher.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { serverLogger } from "#veryfront/utils";
 import { ResponseBuilder } from "./response/index.ts";
 
@@ -77,7 +78,7 @@ export abstract class BaseHandler implements Handler {
   }
 
   protected logDebug(message: string, extra?: Record<string, unknown>, ctx?: HandlerContext): void {
-    if (!ctx?.debug && !ctx?.adapter.env.get("VERYFRONT_DEBUG")) return;
+    if (!ctx?.debug && !getHostEnv("VERYFRONT_DEBUG")) return;
     serverLogger.debug(`[${this.metadata.name}] ${message}`, extra ?? undefined);
   }
 
@@ -107,7 +108,9 @@ export abstract class BaseHandler implements Handler {
     fn: () => Promise<T>,
     options: { requireToken?: boolean } = {},
   ): Promise<T> {
-    const effectiveToken = ctx.proxyToken || ctx.adapter.env.get("VERYFRONT_API_TOKEN") || "";
+    // Framework-owned token: bypass project env overlay so proxy mode works
+    // when a remote project overlay is active.
+    const effectiveToken = ctx.proxyToken || getHostEnv("VERYFRONT_API_TOKEN") || "";
     const fsWrapper = ctx.adapter.fs as {
       setRequestToken?: (t: string) => void;
       setRequestBranch?: (b: string | null) => void;

--- a/src/server/context/request-context.ts
+++ b/src/server/context/request-context.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { parseProjectDomain } from "../utils/domain-parser.ts";
 
 export interface RequestContext {
@@ -27,7 +27,9 @@ export function createRequestContext(req: Request): RequestContext {
     : "production";
 
   return {
-    token: req.headers.get("x-token") ?? getEnv("VERYFRONT_API_TOKEN") ?? "",
+    // Framework-owned token: bypass project env overlay so proxy mode works
+    // when a remote project overlay is active.
+    token: req.headers.get("x-token") ?? getHostEnv("VERYFRONT_API_TOKEN") ?? "",
     slug: req.headers.get("x-project-slug") ?? parsed.slug ?? "",
     branch: parsed.branch,
     mode,

--- a/src/server/handlers/preview/markdown-preview.handler.ts
+++ b/src/server/handlers/preview/markdown-preview.handler.ts
@@ -14,7 +14,7 @@ import { HTTP_OK } from "#veryfront/utils/constants/index.ts";
 import { compileMarkdownRuntime } from "#veryfront/transforms/md/compiler/md-compiler.ts";
 import { extract } from "#std/front-matter/yaml.ts";
 import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
-import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { tryNotFoundFallback } from "../request/ssr/not-found-fallback.ts";
 import { generateMarkdownHtml } from "./markdown-html-generator.ts";
 import { validatePathSync } from "#veryfront/security";
@@ -68,7 +68,9 @@ export class MarkdownPreviewHandler extends BaseHandler {
     const hasMultiProjectSupport = isExtendedFSAdapter(fsAdapter) && fsAdapter.isMultiProjectMode();
 
     if (ctx.projectSlug && hasMultiProjectSupport) {
-      const effectiveToken = ctx.proxyToken || getEnv("VERYFRONT_API_TOKEN") || "";
+      // Framework-owned token: bypass project env overlay so proxy mode works
+      // when a remote project overlay is active.
+      const effectiveToken = ctx.proxyToken || getHostEnv("VERYFRONT_API_TOKEN") || "";
       const branch = ctx.parsedDomain?.branch ?? null;
 
       return await fsAdapter.runWithContext(

--- a/src/server/handlers/request/css.handler.ts
+++ b/src/server/handlers/request/css.handler.ts
@@ -9,7 +9,7 @@ import {
   extractCacheKeyContext,
   runWithCacheKeyContext,
 } from "#veryfront/cache/cache-key-builder.ts";
-import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 
 /** Pattern to match hashed CSS URLs: /_vf/css/[8-char-hash].css */
@@ -49,7 +49,9 @@ export class CSSHandler extends BaseHandler {
     // the distributed API cache backend can't authenticate and silently returns
     // null — causing cross-pod cache misses. Wrap the lookup in request context
     // so the API backend can resolve the token and project.
-    const effectiveToken = ctx.proxyToken || getEnv("VERYFRONT_API_TOKEN") || "";
+    // Framework-owned token: bypass project env overlay so proxy mode works
+    // when a remote project overlay is active.
+    const effectiveToken = ctx.proxyToken || getHostEnv("VERYFRONT_API_TOKEN") || "";
     const lookup = () =>
       runWithCacheKeyContext(cacheCtx, () =>
         getCSSWithJITFallback(

--- a/src/server/handlers/request/internal-agents-list.handler.test.ts
+++ b/src/server/handlers/request/internal-agents-list.handler.test.ts
@@ -281,63 +281,76 @@ describe("server/handlers/request/internal-agents-list.handler", () => {
       requestId: "agents-1",
     });
 
-    const ctx = {
-      ...createCtx(publicKeyPem),
-      adapter: {
-        env: {
-          get: (key: string) => {
-            if (key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY") return publicKeyPem;
-            if (key === "VERYFRONT_API_TOKEN") return "server-api-token";
-            return undefined;
-          },
-          set: () => {},
-          toObject: () => ({}),
-        },
-        fs: {
-          isMultiProjectMode: () => true,
-          runWithContext: async (
-            _projectSlug: string,
-            token: string,
-            fn: () => Promise<unknown>,
-          ) => {
-            receivedToken = token;
-            return await fn();
-          },
-        },
-      },
-      proxyToken: undefined,
-      resolvedEnvironment: "production",
-      requestContext: { token: "", slug: "demo-project", branch: null, mode: "production" },
-    } as unknown as ReturnType<typeof createCtx>;
+    // withProxyContext now reads VERYFRONT_API_TOKEN via getHostEnv() (bypassing
+    // project env overlays), so we set it on the real host environment.
+    const tokenKey = "VERYFRONT_API_TOKEN";
+    const originalToken = Deno.env.get(tokenKey);
+    Deno.env.set(tokenKey, "server-api-token");
 
-    const result = await handler.handle(
-      new Request("https://example.com/internal/agents/list", {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-veryfront-control-plane-jws": jws,
+    try {
+      const ctx = {
+        ...createCtx(publicKeyPem),
+        adapter: {
+          env: {
+            get: (key: string) => {
+              if (key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY") return publicKeyPem;
+              return getEnv(key);
+            },
+            set: () => {},
+            toObject: () => ({}),
+          },
+          fs: {
+            isMultiProjectMode: () => true,
+            runWithContext: async (
+              _projectSlug: string,
+              token: string,
+              fn: () => Promise<unknown>,
+            ) => {
+              receivedToken = token;
+              return await fn();
+            },
+          },
         },
-        body,
-      }),
-      ctx,
-    );
+        proxyToken: undefined,
+        resolvedEnvironment: "production",
+        requestContext: { token: "", slug: "demo-project", branch: null, mode: "production" },
+      } as unknown as ReturnType<typeof createCtx>;
 
-    assertExists(result.response);
-    assertEquals(result.response.status, 200);
-    assertEquals(receivedToken, "server-api-token");
-    assertEquals(discoveryCalls, 1);
-    assertEquals(await result.response.json(), {
-      agents: [
-        {
-          id: "assistant-1",
-          name: "Project Smoke Agent",
-          description: null,
-          model: "anthropic/claude-sonnet-4-6",
-          version: null,
-          skills: [],
-        },
-      ],
-    });
+      const result = await handler.handle(
+        new Request("https://example.com/internal/agents/list", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-veryfront-control-plane-jws": jws,
+          },
+          body,
+        }),
+        ctx,
+      );
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 200);
+      assertEquals(receivedToken, "server-api-token");
+      assertEquals(discoveryCalls, 1);
+      assertEquals(await result.response.json(), {
+        agents: [
+          {
+            id: "assistant-1",
+            name: "Project Smoke Agent",
+            description: null,
+            model: "anthropic/claude-sonnet-4-6",
+            version: null,
+            skills: [],
+          },
+        ],
+      });
+    } finally {
+      if (originalToken === undefined) {
+        Deno.env.delete(tokenKey);
+      } else {
+        Deno.env.set(tokenKey, originalToken);
+      }
+    }
   });
 
   it("uses the host verification key when project overlays hide adapter env reads", async () => {

--- a/src/server/handlers/request/ssr/ssr.handler.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.ts
@@ -17,7 +17,7 @@ import type {
 import { PRIORITY_LOW } from "#veryfront/utils/constants/index.ts";
 import { generateNonce } from "#veryfront/security/http/response/security-handler.ts";
 import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
-import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { shouldUseNoCacheHeadersFromHandler } from "../../../context/enriched-context.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { serverLogger } from "#veryfront/utils";
@@ -115,7 +115,9 @@ export class SSRHandler extends BaseHandler {
       if (ctx.projectSlug && isExtended && fsAdapter.isMultiProjectMode()) {
         const prodMode = isProductionMode(ctx, url);
         const branch = ctx.parsedDomain?.branch ?? null;
-        const effectiveToken = ctx.proxyToken || getEnv("VERYFRONT_API_TOKEN") || "";
+        // Framework-owned token: bypass project env overlay so proxy mode works
+        // when a remote project overlay is active.
+        const effectiveToken = ctx.proxyToken || getHostEnv("VERYFRONT_API_TOKEN") || "";
 
         logger.debug("Using multi-project context", {
           projectSlug: ctx.projectSlug,

--- a/src/server/project-env/framework-env-bypass.test.ts
+++ b/src/server/project-env/framework-env-bypass.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression tests for framework-owned env reads under project overlays.
+ *
+ * When a remote project env overlay is active, getEnv() intentionally blocks
+ * host env fallthrough. Framework-owned configuration (e.g. VERYFRONT_API_TOKEN,
+ * VERYFRONT_DEBUG) must use getHostEnv() to bypass the overlay, otherwise
+ * proxy mode breaks for framework operations.
+ *
+ * See: https://github.com/veryfront/veryfront-code/issues/635
+ *
+ * @module server/project-env/framework-env-bypass.test
+ */
+
+import { assertEquals } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
+import { getEnv, getHostEnv } from "#veryfront/platform/compat/process.ts";
+
+// Import storage to register globalThis hooks
+import { runWithProjectEnv } from "./storage.ts";
+
+describe("framework-owned env bypass under project overlay", () => {
+  /**
+   * Simulates proxy mode: a project env overlay is active with tenant-specific
+   * vars, but framework-owned keys like VERYFRONT_API_TOKEN must still be
+   * reachable via getHostEnv().
+   */
+  it("getHostEnv reads VERYFRONT_API_TOKEN from host env when overlay is active", () => {
+    const envKey = "VERYFRONT_API_TOKEN";
+    const original = Deno.env.get(envKey);
+    Deno.env.set(envKey, "host-framework-token");
+
+    try {
+      runWithProjectEnv({ TENANT_SECRET: "tenant-value" }, () => {
+        // getEnv must NOT return the host token (overlay blocks it)
+        assertEquals(getEnv(envKey), undefined);
+
+        // getHostEnv must return the host token (bypasses overlay)
+        assertEquals(getHostEnv(envKey), "host-framework-token");
+      });
+    } finally {
+      if (original === undefined) {
+        Deno.env.delete(envKey);
+      } else {
+        Deno.env.set(envKey, original);
+      }
+    }
+  });
+
+  it("getHostEnv reads VERYFRONT_DEBUG from host env when overlay is active", () => {
+    const envKey = "VERYFRONT_DEBUG";
+    const original = Deno.env.get(envKey);
+    Deno.env.set(envKey, "1");
+
+    try {
+      runWithProjectEnv({}, () => {
+        assertEquals(getEnv(envKey), undefined);
+        assertEquals(getHostEnv(envKey), "1");
+      });
+    } finally {
+      if (original === undefined) {
+        Deno.env.delete(envKey);
+      } else {
+        Deno.env.set(envKey, original);
+      }
+    }
+  });
+
+  it("getHostEnv reads CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY from host env when overlay is active", () => {
+    const envKey = "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY";
+    const original = Deno.env.get(envKey);
+    Deno.env.set(envKey, "host-public-key");
+
+    try {
+      runWithProjectEnv({}, () => {
+        assertEquals(getEnv(envKey), undefined);
+        assertEquals(getHostEnv(envKey), "host-public-key");
+      });
+    } finally {
+      if (original === undefined) {
+        Deno.env.delete(envKey);
+      } else {
+        Deno.env.set(envKey, original);
+      }
+    }
+  });
+
+  it("tenant overlay vars are accessible via getEnv but NOT via host fallthrough for other keys", () => {
+    runWithProjectEnv({ OPENAI_API_KEY: "tenant-openai-key" }, () => {
+      // Tenant-scoped env is available through getEnv
+      assertEquals(getEnv("OPENAI_API_KEY"), "tenant-openai-key");
+
+      // Host env is blocked for non-framework keys
+      assertEquals(getEnv("PATH"), undefined);
+    });
+  });
+
+  it("without overlay, getEnv and getHostEnv return the same value", () => {
+    const envKey = "VERYFRONT_API_TOKEN";
+    const original = Deno.env.get(envKey);
+    Deno.env.set(envKey, "test-token-no-overlay");
+
+    try {
+      // No overlay active — both should return the same value
+      assertEquals(getEnv(envKey), "test-token-no-overlay");
+      assertEquals(getHostEnv(envKey), "test-token-no-overlay");
+    } finally {
+      if (original === undefined) {
+        Deno.env.delete(envKey);
+      } else {
+        Deno.env.set(envKey, original);
+      }
+    }
+  });
+
+  it("overlay can provide its own VERYFRONT_API_TOKEN that shadows host via getEnv", () => {
+    const envKey = "VERYFRONT_API_TOKEN";
+    const original = Deno.env.get(envKey);
+    Deno.env.set(envKey, "host-token");
+
+    try {
+      runWithProjectEnv({ VERYFRONT_API_TOKEN: "overlay-token" }, () => {
+        // getEnv returns the overlay value
+        assertEquals(getEnv(envKey), "overlay-token");
+
+        // getHostEnv still returns the host value
+        assertEquals(getHostEnv(envKey), "host-token");
+      });
+    } finally {
+      if (original === undefined) {
+        Deno.env.delete(envKey);
+      } else {
+        Deno.env.set(envKey, original);
+      }
+    }
+  });
+
+  it("empty overlay blocks getEnv but getHostEnv still works for framework keys", () => {
+    const envKey = "VERYFRONT_API_TOKEN";
+    const original = Deno.env.get(envKey);
+    Deno.env.set(envKey, "host-token-empty-overlay");
+
+    try {
+      runWithProjectEnv({}, () => {
+        assertEquals(getEnv(envKey), undefined);
+        assertEquals(getHostEnv(envKey), "host-token-empty-overlay");
+      });
+    } finally {
+      if (original === undefined) {
+        Deno.env.delete(envKey);
+      } else {
+        Deno.env.set(envKey, original);
+      }
+    }
+  });
+});

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -3,7 +3,7 @@ import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.92";
+export const VERSION = "0.1.93";
 
 export function normalizeVeryfrontVersion(version: string | undefined): string | undefined {
   if (!version) return undefined;


### PR DESCRIPTION
## Summary

- Replace `getEnv()` / `ctx.adapter.env.get()` with `getHostEnv()` for framework-owned env vars (`VERYFRONT_API_TOKEN`, `VERYFRONT_DEBUG`) in all request handlers
- Affected handlers: `BaseHandler.withProxyContext`, `BaseHandler.logDebug`, `CSSHandler`, `SSRHandler`, `MarkdownPreviewHandler`, `createRequestContext`
- Add regression tests verifying `getHostEnv` bypasses project env overlays for framework-owned keys

## Context

When a remote project env overlay is active (proxy mode), `getEnv()` blocks host env fallthrough to prevent tenant code from reading host secrets. This is correct for tenant-scoped vars (API keys, etc.) but was also blocking framework-owned configuration like `VERYFRONT_API_TOKEN` — the token the framework itself uses to authenticate against the Veryfront API. This caused proxy mode to fail when serving requests for remote projects with env overlays.

`getHostEnv()` already existed (used for `CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY` in a prior fix) and correctly reads from the host environment while still respecting test overlays.

## Test plan

- [x] New test file `src/server/project-env/framework-env-bypass.test.ts` with 7 test cases
- [x] Updated `internal-agents-list.handler.test.ts` to set host env instead of mock adapter env
- [x] All 1199 unit tests pass
- [x] Lint passes

Closes #635