### PR TITLE
fix: expose injected job envs in task context

### DIFF
--- a/src/jobs/runtime-env.ts
+++ b/src/jobs/runtime-env.ts
@@ -1,0 +1,132 @@
+import { logger as baseLogger } from "#veryfront/utils";
+
+const logger = baseLogger.component("job-runtime-env");
+
+export const INJECTED_TASK_ENV_JSON = "VERYFRONT_TASK_ENV_JSON";
+
+const UNSAFE_INJECTED_ENV_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+const HIDDEN_TASK_CONTEXT_ENV_KEYS = new Set([
+  "VERYFRONT_API_TOKEN",
+  "VERYFRONT_API_URL",
+  "VERYFRONT_PROJECT_API_URL",
+  "VERYFRONT_API_BASE_URL",
+  "VERYFRONT_PROJECT_ID",
+  "VERYFRONT_PROJECT_SLUG",
+  "VERYFRONT_BRANCH_REF",
+  "VERYFRONT_API_USER",
+  "VERYFRONT_API_PASS",
+  "VERYFRONT_JOB_RESULT_PATH",
+  INJECTED_TASK_ENV_JSON,
+]);
+
+const DISALLOWED_INJECTED_ENV_KEYS = new Set([
+  "VERYFRONT_API_TOKEN",
+  "VERYFRONT_API_URL",
+  "VERYFRONT_PROJECT_API_URL",
+  "VERYFRONT_API_BASE_URL",
+  "VERYFRONT_PROJECT_ID",
+  "VERYFRONT_PROJECT_SLUG",
+  "VERYFRONT_BRANCH_REF",
+  "VERYFRONT_API_USER",
+  "VERYFRONT_API_PASS",
+  "VERYFRONT_JOB_RESULT_PATH",
+  INJECTED_TASK_ENV_JSON,
+]);
+
+function isHiddenTaskContextEnvKey(key: string): boolean {
+  return key.startsWith("TENANT_") || HIDDEN_TASK_CONTEXT_ENV_KEYS.has(key);
+}
+
+function isDisallowedInjectedEnvKey(key: string): boolean {
+  return key.startsWith("TENANT_") || DISALLOWED_INJECTED_ENV_KEYS.has(key);
+}
+
+function filterExistingProjectEnv(
+  env: Record<string, string> | undefined,
+): Record<string, string> {
+  const filtered: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env ?? {})) {
+    if (
+      UNSAFE_INJECTED_ENV_KEYS.has(key) ||
+      isDisallowedInjectedEnvKey(key) ||
+      typeof value !== "string"
+    ) {
+      continue;
+    }
+    filtered[key] = value;
+  }
+  return filtered;
+}
+
+export function readInjectedProjectEnv(
+  allEnv: Record<string, string>,
+): Record<string, string> {
+  const raw = allEnv[INJECTED_TASK_ENV_JSON];
+  if (!raw) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+
+    const injectedEnv = Object.create(null) as Record<string, string>;
+    for (const [key, value] of Object.entries(parsed)) {
+      if (
+        UNSAFE_INJECTED_ENV_KEYS.has(key) ||
+        isDisallowedInjectedEnvKey(key) ||
+        typeof value !== "string"
+      ) {
+        continue;
+      }
+      injectedEnv[key] = value;
+    }
+
+    return injectedEnv;
+  } catch {
+    logger.warn(`Ignoring invalid ${INJECTED_TASK_ENV_JSON}`);
+    return {};
+  }
+}
+
+export function buildTaskContextEnv(
+  allEnv: Record<string, string>,
+  envAllowlist?: string[],
+): Record<string, string> {
+  const allowlistedEnvKeys = envAllowlist ? new Set(envAllowlist) : null;
+  const env: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(allEnv)) {
+    if (isHiddenTaskContextEnvKey(key)) {
+      continue;
+    }
+    if (allowlistedEnvKeys && !allowlistedEnvKeys.has(key)) {
+      continue;
+    }
+    env[key] = value;
+  }
+
+  for (const [key, value] of Object.entries(readInjectedProjectEnv(allEnv))) {
+    if (allowlistedEnvKeys && !allowlistedEnvKeys.has(key)) {
+      continue;
+    }
+    env[key] = value;
+  }
+
+  return env;
+}
+
+export function mergeInjectedWorkflowEnv(
+  existingEnv: Record<string, string> | undefined,
+  allEnv: Record<string, string>,
+): Record<string, string> | undefined {
+  const mergedEnv = {
+    ...filterExistingProjectEnv(existingEnv),
+    ...readInjectedProjectEnv(allEnv),
+  };
+
+  return Object.keys(mergedEnv).length > 0 ? mergedEnv : undefined;
+}

--- a/src/task/runner.test.ts
+++ b/src/task/runner.test.ts
@@ -101,5 +101,203 @@ describe("src/task/runner", () => {
 
       assertEquals(receivedProjectId, "proj-123");
     });
+
+    it("should merge injected task env into ctx.env without exposing reserved runtime env", async () => {
+      let receivedEnv: Record<string, string> = {};
+      const originalTaskEnvJson = Deno.env.get("VERYFRONT_TASK_ENV_JSON");
+      const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+      const originalTenantToken = Deno.env.get("TENANT_TOKEN");
+      const task = makeTask({
+        run: (ctx) => {
+          receivedEnv = ctx.env;
+          return null;
+        },
+      });
+
+      try {
+        Deno.env.set(
+          "VERYFRONT_TASK_ENV_JSON",
+          JSON.stringify({
+            SERVICENOW_USERNAME: "automation@example.com",
+            AI_GATEWAY_TOKEN: "project-token",
+            VERYFRONT_API_TOKEN: "should-be-filtered",
+          }),
+        );
+        Deno.env.set("VERYFRONT_API_TOKEN", "tenant-token");
+        Deno.env.set("TENANT_TOKEN", "raw-tenant-token");
+
+        await runTask({ task });
+      } finally {
+        if (originalTaskEnvJson === undefined) {
+          Deno.env.delete("VERYFRONT_TASK_ENV_JSON");
+        } else {
+          Deno.env.set("VERYFRONT_TASK_ENV_JSON", originalTaskEnvJson);
+        }
+
+        if (originalApiToken === undefined) {
+          Deno.env.delete("VERYFRONT_API_TOKEN");
+        } else {
+          Deno.env.set("VERYFRONT_API_TOKEN", originalApiToken);
+        }
+
+        if (originalTenantToken === undefined) {
+          Deno.env.delete("TENANT_TOKEN");
+        } else {
+          Deno.env.set("TENANT_TOKEN", originalTenantToken);
+        }
+      }
+
+      assertEquals(receivedEnv.SERVICENOW_USERNAME, "automation@example.com");
+      assertEquals(receivedEnv.AI_GATEWAY_TOKEN, "project-token");
+      assertEquals(receivedEnv.VERYFRONT_API_TOKEN, undefined);
+      assertEquals(receivedEnv.TENANT_TOKEN, undefined);
+      assertEquals(receivedEnv.VERYFRONT_TASK_ENV_JSON, undefined);
+    });
+
+    it("should ignore unsafe injected env keys", async () => {
+      let receivedEnv: Record<string, string> = {};
+      const originalTaskEnvJson = Deno.env.get("VERYFRONT_TASK_ENV_JSON");
+      const task = makeTask({
+        run: (ctx) => {
+          receivedEnv = ctx.env;
+          return null;
+        },
+      });
+      const injectedEnv = Object.create(null) as Record<string, string>;
+      injectedEnv.SERVICENOW_USERNAME = "automation@example.com";
+      Object.defineProperty(injectedEnv, "__proto__", {
+        value: "polluted",
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(injectedEnv, "constructor", {
+        value: "polluted",
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(injectedEnv, "prototype", {
+        value: "polluted",
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+
+      try {
+        Deno.env.set(
+          "VERYFRONT_TASK_ENV_JSON",
+          JSON.stringify(injectedEnv),
+        );
+
+        await runTask({ task });
+      } finally {
+        if (originalTaskEnvJson === undefined) {
+          Deno.env.delete("VERYFRONT_TASK_ENV_JSON");
+        } else {
+          Deno.env.set("VERYFRONT_TASK_ENV_JSON", originalTaskEnvJson);
+        }
+      }
+
+      assertEquals(receivedEnv.SERVICENOW_USERNAME, "automation@example.com");
+      assertEquals(Object.keys(receivedEnv).includes("__proto__"), false);
+      assertEquals(Object.keys(receivedEnv).includes("constructor"), false);
+      assertEquals(Object.keys(receivedEnv).includes("prototype"), false);
+    });
+
+    it("should apply envAllowlist to injected task env", async () => {
+      let receivedEnv: Record<string, string> = {};
+      const originalTaskEnvJson = Deno.env.get("VERYFRONT_TASK_ENV_JSON");
+      const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+      const task = makeTask({
+        run: (ctx) => {
+          receivedEnv = ctx.env;
+          return null;
+        },
+      });
+
+      try {
+        Deno.env.set(
+          "VERYFRONT_TASK_ENV_JSON",
+          JSON.stringify({
+            SERVICENOW_USERNAME: "automation@example.com",
+            AI_GATEWAY_TOKEN: "project-token",
+            VERYFRONT_API_TOKEN: "should-be-filtered",
+          }),
+        );
+        Deno.env.set("VERYFRONT_API_TOKEN", "tenant-token");
+
+        await runTask({ task, envAllowlist: ["SERVICENOW_USERNAME", "AI_GATEWAY_TOKEN"] });
+      } finally {
+        if (originalTaskEnvJson === undefined) {
+          Deno.env.delete("VERYFRONT_TASK_ENV_JSON");
+        } else {
+          Deno.env.set("VERYFRONT_TASK_ENV_JSON", originalTaskEnvJson);
+        }
+
+        if (originalApiToken === undefined) {
+          Deno.env.delete("VERYFRONT_API_TOKEN");
+        } else {
+          Deno.env.set("VERYFRONT_API_TOKEN", originalApiToken);
+        }
+      }
+
+      assertEquals(receivedEnv.SERVICENOW_USERNAME, "automation@example.com");
+      assertEquals(receivedEnv.AI_GATEWAY_TOKEN, "project-token");
+      assertEquals(receivedEnv.VERYFRONT_API_TOKEN, undefined);
+      assertEquals(receivedEnv.VERYFRONT_TASK_ENV_JSON, undefined);
+    });
+
+    it("should hide platform control env from ctx.env while preserving injected project env", async () => {
+      let receivedEnv: Record<string, string> = {};
+      const originalProjectApiUrl = Deno.env.get("VERYFRONT_PROJECT_API_URL");
+      const originalBranchId = Deno.env.get("TENANT_BRANCH_ID");
+      const originalTaskEnvJson = Deno.env.get("VERYFRONT_TASK_ENV_JSON");
+      const task = makeTask({
+        run: (ctx) => {
+          receivedEnv = ctx.env;
+          return null;
+        },
+      });
+
+      try {
+        Deno.env.set("VERYFRONT_PROJECT_API_URL", "https://api.veryfront.com");
+        Deno.env.set("TENANT_BRANCH_ID", "branch-123");
+        Deno.env.set(
+          "VERYFRONT_TASK_ENV_JSON",
+          JSON.stringify({
+            AI_GATEWAY_TOKEN: "project-token",
+            SERVICENOW_PASSWORD: "servicenow-password",
+            VERYFRONT_API_TOKEN: "should-be-filtered",
+          }),
+        );
+
+        await runTask({ task });
+      } finally {
+        if (originalProjectApiUrl === undefined) {
+          Deno.env.delete("VERYFRONT_PROJECT_API_URL");
+        } else {
+          Deno.env.set("VERYFRONT_PROJECT_API_URL", originalProjectApiUrl);
+        }
+
+        if (originalBranchId === undefined) {
+          Deno.env.delete("TENANT_BRANCH_ID");
+        } else {
+          Deno.env.set("TENANT_BRANCH_ID", originalBranchId);
+        }
+
+        if (originalTaskEnvJson === undefined) {
+          Deno.env.delete("VERYFRONT_TASK_ENV_JSON");
+        } else {
+          Deno.env.set("VERYFRONT_TASK_ENV_JSON", originalTaskEnvJson);
+        }
+      }
+
+      assertEquals(receivedEnv.VERYFRONT_PROJECT_API_URL, undefined);
+      assertEquals(receivedEnv.TENANT_BRANCH_ID, undefined);
+      assertEquals(receivedEnv.VERYFRONT_API_TOKEN, undefined);
+      assertEquals(receivedEnv.AI_GATEWAY_TOKEN, "project-token");
+      assertEquals(receivedEnv.SERVICENOW_PASSWORD, "servicenow-password");
+    });
   });
 });

--- a/src/task/runner.ts
+++ b/src/task/runner.ts
@@ -7,6 +7,7 @@
 
 import { logger as baseLogger } from "#veryfront/utils";
 import { env as getProcessEnv } from "#veryfront/compat/process.ts";
+import { buildTaskContextEnv } from "../jobs/runtime-env.ts";
 import type { DiscoveredTask } from "./discovery.ts";
 import type { TaskContext } from "./types.ts";
 
@@ -61,14 +62,7 @@ export async function runTask(options: RunTaskOptions): Promise<TaskRunResult> {
   }
 
   const allEnv = getProcessEnv();
-  const env: Record<string, string> = envAllowlist
-    ? Object.fromEntries(
-      envAllowlist.flatMap((k) => {
-        const value = allEnv[k];
-        return value === undefined ? [] : [[k, value] as const];
-      }),
-    )
-    : { ...allEnv };
+  const env = buildTaskContextEnv(allEnv, envAllowlist);
 
   const ctx: TaskContext = {
     env,

--- a/src/workflow/api/workflow-client.test.ts
+++ b/src/workflow/api/workflow-client.test.ts
@@ -96,6 +96,44 @@ describe("WorkflowClient", () => {
         assertEquals(error.status, 404);
       }
     });
+
+    it("captures injected project env on the workflow run context", async () => {
+      const originalTaskEnvJson = Deno.env.get("VERYFRONT_TASK_ENV_JSON");
+      const originalProjectApiUrl = Deno.env.get("VERYFRONT_PROJECT_API_URL");
+
+      try {
+        Deno.env.set(
+          "VERYFRONT_TASK_ENV_JSON",
+          JSON.stringify({
+            SERVICENOW_USERNAME: "automation@example.com",
+            AI_GATEWAY_TOKEN: "project-token",
+            VERYFRONT_API_TOKEN: "should-be-filtered",
+          }),
+        );
+        Deno.env.set("VERYFRONT_PROJECT_API_URL", "https://api.veryfront.com");
+
+        const handle = await client.start("test-workflow", { topic: "test" });
+        const run = await backend.getRun(handle.runId);
+
+        assertExists(run);
+        assertEquals(run.context.env, {
+          SERVICENOW_USERNAME: "automation@example.com",
+          AI_GATEWAY_TOKEN: "project-token",
+        });
+      } finally {
+        if (originalTaskEnvJson === undefined) {
+          Deno.env.delete("VERYFRONT_TASK_ENV_JSON");
+        } else {
+          Deno.env.set("VERYFRONT_TASK_ENV_JSON", originalTaskEnvJson);
+        }
+
+        if (originalProjectApiUrl === undefined) {
+          Deno.env.delete("VERYFRONT_PROJECT_API_URL");
+        } else {
+          Deno.env.set("VERYFRONT_PROJECT_API_URL", originalProjectApiUrl);
+        }
+      }
+    });
   });
 
   describe("getRun()", () => {

--- a/src/workflow/executor/workflow-executor.ts
+++ b/src/workflow/executor/workflow-executor.ts
@@ -25,6 +25,8 @@ import type {
 import { generateId, parseDuration } from "../types.ts";
 import { hasLockSupport, type WorkflowBackend } from "../backends/types.ts";
 import { getCurrentRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
+import { env as getProcessEnv } from "#veryfront/compat/process.ts";
+import { mergeInjectedWorkflowEnv } from "../../jobs/runtime-env.ts";
 import { DAGExecutor } from "./dag-executor.ts";
 import { CheckpointManager } from "./checkpoint-manager.ts";
 import { runWithWorkflowTenant, StepExecutor, type StepExecutorConfig } from "./step-executor.ts";
@@ -194,6 +196,7 @@ export class WorkflowExecutor {
         releaseId: requestCtx.releaseId ?? null,
       }
       : undefined;
+    const injectedProjectEnv = mergeInjectedWorkflowEnv(undefined, getProcessEnv());
 
     const run: WorkflowRun<TInput, TOutput> = {
       id: options?.runId ?? generateId("run"),
@@ -203,7 +206,10 @@ export class WorkflowExecutor {
       input,
       nodeStates: {},
       currentNodes: [],
-      context: { input },
+      context: {
+        input,
+        ...(injectedProjectEnv ? { env: injectedProjectEnv } : {}),
+      },
       checkpoints: [],
       pendingApprovals: [],
       createdAt: new Date(),

--- a/src/workflow/types.ts
+++ b/src/workflow/types.ts
@@ -48,6 +48,7 @@ type DurationString = string;
  */
 export interface WorkflowContext {
   input: unknown;
+  env?: Record<string, string>;
   _tenant?: CapturedTenantContext;
   [nodeId: string]: unknown;
 }

--- a/src/workflow/worker/dynamic-job-entrypoint.ts
+++ b/src/workflow/worker/dynamic-job-entrypoint.ts
@@ -27,9 +27,11 @@
 
 import { logger as baseLogger } from "#veryfront/utils";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { env as getProcessEnv } from "#veryfront/compat/process.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 import { enhanceAdapterWithFS } from "#veryfront/platform/adapters/fs/integration.ts";
 import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
+import { mergeInjectedWorkflowEnv } from "../../jobs/runtime-env.ts";
 import { discoverWorkflows } from "../discovery/index.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import type { WorkflowBackend } from "../backends/types.ts";
@@ -109,10 +111,26 @@ export async function runDynamicWorkflowJob(
 
   try {
     // Fetch the workflow run
-    const run = await backend.getRun(runId);
+    let run = await backend.getRun(runId);
     if (!run) {
       logger.error(`Workflow run not found: ${runId}`);
       return DYNAMIC_EXIT_CODES.NOT_FOUND;
+    }
+
+    const injectedEnv = mergeInjectedWorkflowEnv(run.context.env, getProcessEnv());
+    if (injectedEnv) {
+      const currentEnv = run.context.env;
+      const currentSerialized = currentEnv ? JSON.stringify(currentEnv) : "";
+      const nextSerialized = JSON.stringify(injectedEnv);
+      if (currentSerialized !== nextSerialized) {
+        await backend.updateRun(runId, {
+          context: {
+            ...run.context,
+            env: injectedEnv,
+          },
+        });
+        run = (await backend.getRun(runId)) ?? run;
+      }
     }
 
     // Get tenant context (from env or from stored run)

--- a/src/workflow/worker/job-entrypoint.test.ts
+++ b/src/workflow/worker/job-entrypoint.test.ts
@@ -1,0 +1,91 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { MemoryBackend } from "../backends/memory.ts";
+import type { WorkflowRun } from "../types.ts";
+import { EXIT_CODES, runWorkflowJob } from "./job-entrypoint.ts";
+
+const ENV_KEYS = [
+  "WORKFLOW_RUN_ID",
+  "VERYFRONT_TASK_ENV_JSON",
+  "VERYFRONT_PROJECT_API_URL",
+  "TENANT_TOKEN",
+  "TENANT_PROJECT_SLUG",
+] as const;
+
+const savedEnv = new Map<string, string | undefined>();
+
+function rememberEnv(): void {
+  for (const key of ENV_KEYS) {
+    if (!savedEnv.has(key)) {
+      savedEnv.set(key, Deno.env.get(key));
+    }
+  }
+}
+
+function restoreEnv(): void {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv.get(key);
+    if (value === undefined) {
+      Deno.env.delete(key);
+    } else {
+      Deno.env.set(key, value);
+    }
+  }
+  savedEnv.clear();
+}
+
+describe("runWorkflowJob", () => {
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it("hydrates the workflow run context env from injected project env before resume", async () => {
+    rememberEnv();
+
+    const backend = new MemoryBackend();
+    const run: WorkflowRun = {
+      id: "run-1",
+      workflowId: "test-workflow",
+      status: "pending",
+      input: {},
+      nodeStates: {},
+      currentNodes: [],
+      context: { input: {} },
+      checkpoints: [],
+      pendingApprovals: [],
+      createdAt: new Date(),
+    };
+    await backend.createRun(run);
+
+    Deno.env.set("WORKFLOW_RUN_ID", run.id);
+    Deno.env.set(
+      "VERYFRONT_TASK_ENV_JSON",
+      JSON.stringify({
+        SERVICENOW_USERNAME: "automation@example.com",
+        AI_GATEWAY_TOKEN: "project-token",
+        VERYFRONT_API_TOKEN: "should-be-filtered",
+      }),
+    );
+    Deno.env.set("VERYFRONT_PROJECT_API_URL", "https://api.veryfront.com");
+
+    let observedEnv: Record<string, string> | undefined;
+    const executor = {
+      resume: async (runId: string) => {
+        const currentRun = await backend.getRun(runId);
+        observedEnv = currentRun?.context.env;
+        await backend.updateRun(runId, { status: "completed" });
+      },
+    };
+
+    const exitCode = await runWorkflowJob({
+      backend,
+      executor: executor as never,
+    });
+
+    assertEquals(exitCode, EXIT_CODES.SUCCESS);
+    assertEquals(observedEnv, {
+      SERVICENOW_USERNAME: "automation@example.com",
+      AI_GATEWAY_TOKEN: "project-token",
+    });
+  });
+});

--- a/src/workflow/worker/job-entrypoint.ts
+++ b/src/workflow/worker/job-entrypoint.ts
@@ -22,7 +22,9 @@
 
 import { logger as baseLogger } from "#veryfront/utils";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { env as getProcessEnv } from "#veryfront/compat/process.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
+import { mergeInjectedWorkflowEnv } from "../../jobs/runtime-env.ts";
 import type { WorkflowBackend } from "../backends/types.ts";
 import type { WorkflowExecutor } from "../executor/workflow-executor.ts";
 import type { CapturedTenantContext, WorkflowDefinition } from "../types.ts";
@@ -116,10 +118,26 @@ export async function runWorkflowJob(config: JobEntrypointConfig): Promise<numbe
 
   try {
     // Fetch the workflow run
-    const run = await backend.getRun(runId);
+    let run = await backend.getRun(runId);
     if (!run) {
       logger.error(`Workflow run not found: ${runId}`);
       return EXIT_CODES.NOT_FOUND;
+    }
+
+    const injectedEnv = mergeInjectedWorkflowEnv(run.context.env, getProcessEnv());
+    if (injectedEnv) {
+      const currentEnv = run.context.env;
+      const currentSerialized = currentEnv ? JSON.stringify(currentEnv) : "";
+      const nextSerialized = JSON.stringify(injectedEnv);
+      if (currentSerialized !== nextSerialized) {
+        await backend.updateRun(runId, {
+          context: {
+            ...run.context,
+            env: injectedEnv,
+          },
+        });
+        run = (await backend.getRun(runId)) ?? run;
+      }
     }
 
     // Get tenant context (from env or from stored run)


### PR DESCRIPTION
## Summary
- parse `VERYFRONT_TASK_ENV_JSON` inside the task runner
- merge injected project env vars into `TaskContext.env`
- keep the transport blob itself out of `ctx.env`
- let injected project vars override colliding process env values inside the task context only

## Red
- added a task-runner test that fails unless injected env vars appear in `ctx.env`
- the new test also proves collision handling for `VERYFRONT_API_TOKEN`

## Green
- `runTask()` now reads and validates `VERYFRONT_TASK_ENV_JSON`
- injected project env vars are exposed to tasks through `ctx.env`

## Refactor
- isolated the JSON parsing into a dedicated helper instead of inlining it in `runTask()`

## Verification
- `deno test --allow-env src/task/runner.test.ts`
- `deno check src/task/runner.ts`
