### PR TITLE
chore: bump veryfront version to v0.1.94

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -3,7 +3,7 @@ import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.93";
+export const VERSION = "0.1.94";
 
 export function normalizeVeryfrontVersion(version: string | undefined): string | undefined {
   if (!version) return undefined;


### PR DESCRIPTION
## Summary
- bump `deno.json` version to `0.1.94`
- bump the hard-coded runtime fallback version to `0.1.94`
- unblock publishing the already-merged preview-style HMR changes as a new immutable release

## Verification
- deno test src/utils/version.test.ts
- deno check src/utils/version.ts
- deno fmt --check deno.json src/utils/version.ts
- git diff --check
- repo pre-push checks (`1200 passed, 0 failed`)