### PR TITLE
fix: clear pending style marker after HMR swap

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/server/handlers/dev/scripts/hmr-scripts.test.ts
+++ b/src/server/handlers/dev/scripts/hmr-scripts.test.ts
@@ -7,6 +7,7 @@ describe("server/handlers/dev/scripts/hmr-scripts", () => {
     const script = getHMRScript(3000);
     assertStringIncludes(script, "async function swapTailwindStylesheet(nextHref)");
     assertStringIncludes(script, "pending.setAttribute('data-vf-tailwind-pending', 'true');");
+    assertStringIncludes(script, "pending.removeAttribute('data-vf-tailwind-pending');");
     assertStringIncludes(script, "pending.id = 'vf-tailwind-css';");
     assertStringIncludes(script, "current.remove();");
   });

--- a/src/server/handlers/dev/scripts/hmr-scripts.ts
+++ b/src/server/handlers/dev/scripts/hmr-scripts.ts
@@ -99,6 +99,7 @@ function getUpdateJSFunction(logPrefix: string): string {
           return;
         }
 
+        pending.removeAttribute('data-vf-tailwind-pending');
         pending.id = 'vf-tailwind-css';
         current.remove();
         resolve(true);

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -3,7 +3,7 @@ import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.94";
+export const VERSION = "0.1.95";
 
 export function normalizeVeryfrontVersion(version: string | undefined): string | undefined {
   if (!version) return undefined;


### PR DESCRIPTION
## Summary
- remove the temporary `data-vf-tailwind-pending` marker when the hashed stylesheet is promoted after load
- keep the preview HMR atomic stylesheet swap behavior clean across subsequent updates
- bump `veryfront-code` to `0.1.95` so the fix ships as a new immutable release

## Verification
- deno test --allow-env src/server/handlers/dev/scripts/hmr-scripts.test.ts src/utils/version.test.ts
- deno fmt --check deno.json src/utils/version.ts src/server/handlers/dev/scripts/hmr-scripts.ts src/server/handlers/dev/scripts/hmr-scripts.test.ts
- deno lint src/utils/version.ts src/server/handlers/dev/scripts/hmr-scripts.ts src/server/handlers/dev/scripts/hmr-scripts.test.ts
- deno check src/utils/version.ts src/server/handlers/dev/scripts/hmr-scripts.ts src/server/handlers/dev/scripts/hmr-scripts.test.ts
- git diff --check
- repo pre-push checks (`1200 passed, 0 failed`)

## Staging finding that triggered this fix
A live staged browser run showed the stylesheet href correctly switching to the hashed asset, but the promoted link retained `data-vf-tailwind-pending`, so the swap was not fully cleaned up after success.