### PR TITLE
fix: recover missing mdx vfmod dependencies

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/modules/react-loader/ssr-module-loader/loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.test.ts
@@ -11,6 +11,11 @@ import { computeConfigHashSync } from "../../../cache/config-hash.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import { makeTempDir, mkdir, remove, writeTextFile } from "#veryfront/testing/deno-compat.ts";
 import { injectNodePositions } from "#veryfront/transforms/plugins/babel-node-positions.ts";
+import type { CacheBackend } from "#veryfront/cache/types.ts";
+import { __injectCachesForTests } from "#veryfront/transforms/esm/transform-cache.ts";
+import { tokenizeAllVeryFrontPaths } from "#veryfront/cache";
+import { buildMdxEsmModuleRecoveryCacheKey } from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
+import { getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
 
 /** Hash source as the loader sees it (after node position injection for .tsx in dev/preview) */
 function hashAsLoader(source: string, filePath: string, projectDir: string): string {
@@ -18,6 +23,25 @@ function hashAsLoader(source: string, filePath: string, projectDir: string): str
     ? filePath.slice(projectDir.length).replace(/^\/+/, "")
     : filePath;
   return hashCodeHex(injectNodePositions(source, { filePath: rel }));
+}
+
+class FakeDistributedCache implements CacheBackend {
+  readonly type = "redis" as const;
+  private values = new Map<string, string>();
+
+  get(key: string): Promise<string | null> {
+    return Promise.resolve(this.values.get(key) ?? null);
+  }
+
+  set(key: string, value: string): Promise<void> {
+    this.values.set(key, value);
+    return Promise.resolve();
+  }
+
+  del(key: string): Promise<void> {
+    this.values.delete(key);
+    return Promise.resolve();
+  }
 }
 
 describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, () => {
@@ -62,7 +86,7 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
     }
   });
 
-  it("invalidates cache when import fails with 'Cannot find module' (P1)", async () => {
+  it("invalidates stale cache entries with missing local dependencies and retransforms", async () => {
     clearSSRModuleCache();
 
     const projectDir = await makeTempDir({ prefix: "vf-ssr-loader-p1-" });
@@ -92,16 +116,15 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
 
       const uniqueId = crypto.randomUUID().slice(0, 8);
       const brokenTempPath = join(projectDir, `broken-${uniqueId}.mjs`);
+      const missingDependencyPath = join(projectDir, `this-file-does-not-exist-${uniqueId}.mjs`);
       await writeTextFile(
         brokenTempPath,
-        `import { missing } from "./this-file-does-not-exist-${uniqueId}.mjs";\nexport default function CacheInvalTest() { return null; }`,
+        `import { missing } from "file://${missingDependencyPath}";\nexport default function CacheInvalTest() { return null; }`,
       );
 
       const fakeEntry = { tempPath: brokenTempPath, contentHash };
       globalModuleCache.set(contentCacheKey, fakeEntry);
       globalModuleCache.set(filePathCacheKey, fakeEntry);
-
-      verifiedHttpBundlePaths.set(`${brokenTempPath}:${contentHash}`, true);
 
       await writeTextFile(filePath, source);
 
@@ -113,23 +136,89 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
         dev: true,
       });
 
-      try {
-        await loader.loadModule(filePath, source);
-        assert(false, "Expected loadModule to throw");
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        assert(
-          msg.includes("Cannot find module") || msg.includes("Module not found"),
-          `Expected module-not-found error, got: ${msg}`,
-        );
-      }
+      const component = await loader.loadModule(filePath, source);
+      assertEquals(component.name, "CacheInvalTest");
 
       assertEquals(
         globalModuleCache.has(filePathCacheKey),
-        false,
-        "Cache entry should be invalidated after 'Cannot find module' error",
+        true,
+        "Cache entry should be refreshed after invalidating the stale module",
       );
     } finally {
+      await remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("recovers missing vfmod dependencies before invalidating cached SSR modules", async () => {
+    clearSSRModuleCache();
+
+    const projectDir = await makeTempDir({ prefix: "vf-ssr-loader-recover-vfmod-" });
+    const componentsDir = join(projectDir, "components");
+    const filePath = join(componentsDir, "RecoveredViaCache.tsx");
+    const projectId = "project-recover-vfmod";
+    const contentSourceId = "preview-main";
+    const distributedCache = new FakeDistributedCache();
+
+    try {
+      __injectCachesForTests({ cacheBackend: distributedCache });
+      await mkdir(componentsDir, { recursive: true });
+
+      const source = "export default function RecoveredViaCache() { return null; }";
+      const contentHash = hashAsLoader(source, filePath, projectDir);
+      const configHash = computeConfigHashSync({ dev: true });
+      const reactVersion = "default";
+
+      const filePathCacheKey = buildSSRModuleCacheKey(
+        VERSION,
+        projectId,
+        `${contentSourceId}:${reactVersion}:${configHash}:${filePath}`,
+      );
+      const contentCacheKey = buildSSRModuleCacheKey(
+        VERSION,
+        projectId,
+        `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
+      );
+
+      const vfmodDir = join(getMdxEsmCacheDir(), projectId, contentSourceId);
+      const childPath = join(vfmodDir, "vfmod-child.mjs");
+      const cachedTempPath = join(projectDir, `recover-vfmod-${crypto.randomUUID()}.mjs`);
+
+      await distributedCache.set(
+        buildMdxEsmModuleRecoveryCacheKey(projectId, contentSourceId, "vfmod-child.mjs"),
+        tokenizeAllVeryFrontPaths(`export default null;`),
+      );
+
+      await writeTextFile(
+        cachedTempPath,
+        [
+          `import child from "file://${childPath}";`,
+          `export default function RecoveredViaCache() {`,
+          `  return child;`,
+          `}`,
+        ].join("\n"),
+      );
+
+      const fakeEntry = { tempPath: cachedTempPath, contentHash };
+      globalModuleCache.set(contentCacheKey, fakeEntry);
+      globalModuleCache.set(filePathCacheKey, fakeEntry);
+
+      await writeTextFile(filePath, source);
+
+      const loader = new SSRModuleLoader({
+        projectDir,
+        projectId,
+        contentSourceId,
+        adapter: denoAdapter,
+        dev: true,
+      });
+
+      const component = await loader.loadModule(filePath, source);
+      assertEquals(component.name, "RecoveredViaCache");
+      assertEquals(globalModuleCache.has(filePathCacheKey), true);
+    } finally {
+      __injectCachesForTests(null);
+      await remove(join(getMdxEsmCacheDir(), projectId, contentSourceId), { recursive: true })
+        .catch(() => {});
       await remove(projectDir, { recursive: true });
     }
   });

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -54,6 +54,7 @@ import { preflightLocalImports } from "./preflight-imports.ts";
 import { resolveVfModuleImports } from "./vf-module-resolver.ts";
 import { registerCSSImport } from "../css-import-collector.ts";
 import { injectNodePositions } from "#veryfront/transforms/plugins/babel-node-positions.ts";
+import { ensureMdxModuleDependencies } from "#veryfront/transforms/mdx/esm-module-loader/module-fetcher/dependency-recovery.ts";
 
 const logger = rendererLogger.component("ssr-module-loader");
 
@@ -230,6 +231,35 @@ export class SSRModuleLoader {
       }
 
       if (classifiedError.type === "module-not-found") {
+        if (this.options.contentSourceId) {
+          try {
+            const cachedCode = await this.cache.getFs().readTextFile(cacheEntry.tempPath);
+            const recovered = await ensureMdxModuleDependencies(cachedCode, {
+              projectId: this.options.projectId,
+              contentSourceId: this.options.contentSourceId,
+              log: logger,
+            });
+            if (recovered.missing.length === 0 && recovered.recovered.length > 0) {
+              const retryTempPath = cacheEntry.tempPath.replace(/\.mjs$/, "") +
+                `-recovered-${cacheEntry.contentHash}.mjs`;
+              await this.cache.getFs().writeTextFile(retryTempPath, cachedCode);
+              logger.info("Recovered vfmod dependencies for cached SSR module, retrying import", {
+                file: filePath.slice(-40),
+                recovered: recovered.recovered.slice(0, 5),
+                retryTempPath,
+              });
+              return (await import(
+                `file://${retryTempPath}?v=${cacheEntry.contentHash}&retry=1`
+              )) as Record<string, unknown>;
+            }
+          } catch (recoveryError) {
+            logger.debug("Failed to recover vfmod dependencies for cached SSR module", {
+              file: filePath.slice(-40),
+              error: recoveryError instanceof Error ? recoveryError.message : String(recoveryError),
+            });
+          }
+        }
+
         logger.error(
           "[SSR-MODULE-LOADER] Cached module has missing dependency, invalidating cache",
           {
@@ -426,6 +456,10 @@ export class SSRModuleLoader {
         mdxCacheDir,
         this.options.projectDir,
         contentHash,
+        {
+          projectId: this.options.projectId,
+          contentSourceId: this.options.contentSourceId,
+        },
       );
 
       if (mdxCacheResult.status === "hit") {

--- a/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.test.ts
@@ -1,0 +1,73 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { join } from "#veryfront/compat/path/index.ts";
+import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
+import { makeTempDir, readTextFile, remove } from "#veryfront/testing/deno-compat.ts";
+import type { CacheBackend } from "#veryfront/cache/types.ts";
+import { tokenizeAllVeryFrontPaths } from "#veryfront/cache";
+import { __injectCachesForTests } from "#veryfront/transforms/esm/transform-cache.ts";
+import { buildMdxEsmModuleRecoveryCacheKey } from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
+import { SSRCacheManager } from "./ssr-cache-manager.ts";
+import { getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
+
+class FakeDistributedCache implements CacheBackend {
+  readonly type = "redis" as const;
+  private values = new Map<string, string>();
+
+  get(key: string): Promise<string | null> {
+    return Promise.resolve(this.values.get(key) ?? null);
+  }
+
+  set(key: string, value: string): Promise<void> {
+    this.values.set(key, value);
+    return Promise.resolve();
+  }
+
+  del(key: string): Promise<void> {
+    this.values.delete(key);
+    return Promise.resolve();
+  }
+}
+
+describe("SSRCacheManager", { sanitizeResources: false, sanitizeOps: false }, () => {
+  it("recovers missing vfmod dependencies for redis cache entries", async () => {
+    const projectDir = await makeTempDir({ prefix: "vf-ssr-cache-manager-" });
+    const distributedCache = new FakeDistributedCache();
+    const vfmodDir = join(getMdxEsmCacheDir(), "project-a", "preview-main");
+    const childPath = join(vfmodDir, "vfmod-child.mjs");
+
+    try {
+      __injectCachesForTests({ cacheBackend: distributedCache });
+
+      await distributedCache.set(
+        buildMdxEsmModuleRecoveryCacheKey("project-a", "preview-main", "vfmod-child.mjs"),
+        tokenizeAllVeryFrontPaths(`export default "recovered";`),
+      );
+
+      const cacheManager = new SSRCacheManager({
+        projectDir,
+        projectId: "project-a",
+        contentSourceId: "preview-main",
+        adapter: denoAdapter,
+        dev: true,
+      });
+
+      const isValid = await cacheManager.validateCachedCode(
+        `import child from "file://${childPath}"; export default child;`,
+        join(projectDir, "pages", "index.tsx"),
+        "redis-cache",
+        {
+          checkLocalPaths: true,
+          checkInvalidEsmShPath: true,
+        },
+      );
+
+      assertEquals(isValid, true);
+      assertEquals(await readTextFile(childPath), `export default "recovered";`);
+    } finally {
+      __injectCachesForTests(null);
+      await remove(vfmodDir, { recursive: true }).catch(() => {});
+      await remove(projectDir, { recursive: true });
+    }
+  });
+});

--- a/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.ts
@@ -24,6 +24,7 @@ import {
 } from "./http-bundle-helpers.ts";
 import { buildTempModulePath, buildTmpDirPath, getTmpDirCacheKey } from "./tmp-paths.ts";
 import type { ModuleCacheEntry, SSRModuleLoaderOptions } from "./types.ts";
+import { ensureMdxModuleDependencies } from "#veryfront/transforms/mdx/esm-module-loader/module-fetcher/dependency-recovery.ts";
 
 const logger = rendererLogger.component("ssr-module-loader");
 
@@ -167,7 +168,7 @@ export class SSRCacheManager {
     try {
       const cachedCode = await this.fs.readTextFile(cachedEntry.tempPath);
       const isValid = await this.validateCachedCode(cachedCode, filePath, "memory-cache", {
-        checkLocalPaths: false,
+        checkLocalPaths: true,
         checkInvalidEsmShPath: false,
       });
       if (!isValid) {
@@ -235,11 +236,14 @@ export class SSRCacheManager {
 
   private async hasMissingLocalPaths(code: string, filePath: string): Promise<boolean> {
     const allPaths = extractAllFilePaths(code);
+    let hasMissingPath = false;
+
     for (const path of allPaths) {
       try {
         const stat = await this.fs.stat(path);
         if (!stat.isFile) {
-          return true;
+          hasMissingPath = true;
+          break;
         }
       } catch (error) {
         logger.debug("Redis cache has invalid local path, re-transforming", {
@@ -247,6 +251,34 @@ export class SSRCacheManager {
           missingPath: path.slice(-60),
           error,
         });
+        hasMissingPath = true;
+        break;
+      }
+    }
+
+    if (
+      hasMissingPath &&
+      this.options.projectId &&
+      this.options.contentSourceId
+    ) {
+      const recovered = await ensureMdxModuleDependencies(code, {
+        projectId: this.options.projectId,
+        contentSourceId: this.options.contentSourceId,
+        log: logger,
+      });
+      if (recovered.recovered.length > 0) {
+        logger.debug("Recovered missing local vfmod dependencies for SSR cache entry", {
+          file: filePath.slice(-40),
+          recovered: recovered.recovered.slice(0, 5),
+        });
+      }
+    }
+
+    for (const path of allPaths) {
+      try {
+        const stat = await this.fs.stat(path);
+        if (!stat.isFile) return true;
+      } catch (_) {
         return true;
       }
     }

--- a/src/modules/react-loader/ssr-module-loader/vf-module-resolver.ts
+++ b/src/modules/react-loader/ssr-module-loader/vf-module-resolver.ts
@@ -78,6 +78,7 @@ export async function resolveVfModuleImports(
     options.projectDir,
     options.projectId,
     {
+      contentSourceId: options.contentSourceId,
       reactVersion: options.reactVersion,
       projectSlug: options.projectId,
       strictMissingModules: false,

--- a/src/rendering/orchestrator/module-loader/index.ts
+++ b/src/rendering/orchestrator/module-loader/index.ts
@@ -223,7 +223,18 @@ export async function transformModuleWithDeps(
     const sourceKey = encodeURIComponent(contentSourceId);
     const mdxCacheDir = join(baseCacheDir, projectKey, sourceKey);
 
-    const mdxCacheResult = await lookupMdxEsmCache(filePath, mdxCacheDir, projectDir);
+    const mdxCacheResult = await lookupMdxEsmCache(
+      filePath,
+      mdxCacheDir,
+      projectDir,
+      undefined,
+      contentSourceId
+        ? {
+          projectId,
+          contentSourceId,
+        }
+        : undefined,
+    );
     if (mdxCacheResult.status === "hit") {
       moduleCache.set(cacheKey, mdxCacheResult.path);
       return mdxCacheResult.path;

--- a/src/transforms/mdx/esm-module-loader/cache-format.ts
+++ b/src/transforms/mdx/esm-module-loader/cache-format.ts
@@ -10,10 +10,11 @@ const CACHE_NAMESPACE_SENTINEL = "__vf_cache_namespace__";
 function formatMdxEsmTransformCacheKey(
   namespace: string,
   projectId: string,
+  contentSourceId: string,
   normalizedPath: string,
   contentHash: string,
 ): string {
-  return `${namespace}:${projectId}:${normalizedPath}:${contentHash}:ssr`;
+  return `${namespace}:${projectId}:${contentSourceId}:${normalizedPath}:${contentHash}:ssr`;
 }
 
 function formatMdxEsmPathCacheKey(namespace: string, normalizedPath: string): string {
@@ -22,6 +23,15 @@ function formatMdxEsmPathCacheKey(namespace: string, normalizedPath: string): st
 
 function formatMdxEsmModuleFileName(namespace: string, contentHash: string): string {
   return `vfmod-${namespace}-${contentHash}.mjs`;
+}
+
+function formatMdxEsmModuleRecoveryCacheKey(
+  namespace: string,
+  projectId: string,
+  contentSourceId: string,
+  fileName: string,
+): string {
+  return `${namespace}:${projectId}:${contentSourceId}:${fileName}:vfmod`;
 }
 
 function formatMdxJsxCacheFileName(namespace: string, filePath: string): string {
@@ -42,11 +52,18 @@ function buildMdxEsmCacheSchemaSample() {
     transformKey: formatMdxEsmTransformCacheKey(
       CACHE_NAMESPACE_SENTINEL,
       "__vf_project__",
+      "preview-main",
       "_vf_modules/pages/index.js",
       "deadbeef",
     ),
     pathKey: formatMdxEsmPathCacheKey(CACHE_NAMESPACE_SENTINEL, "_vf_modules/pages/index.js"),
     moduleFile: formatMdxEsmModuleFileName(CACHE_NAMESPACE_SENTINEL, "deadbeef"),
+    moduleRecoveryKey: formatMdxEsmModuleRecoveryCacheKey(
+      CACHE_NAMESPACE_SENTINEL,
+      "__vf_project__",
+      "preview-main",
+      formatMdxEsmModuleFileName(CACHE_NAMESPACE_SENTINEL, "deadbeef"),
+    ),
     jsxFile: formatMdxJsxCacheFileName(CACHE_NAMESPACE_SENTINEL, "/tmp/project/Button.tsx"),
     unresolvedVfModulesPattern: UNRESOLVED_VF_MODULES_PATTERN.source,
     allFileUrlPattern: ALL_FILE_URL_PATTERN_SOURCE,
@@ -84,12 +101,14 @@ export const FRAMEWORK_VF_MODULE_CACHE_NAMESPACE = createCacheNamespace(
 
 export function buildMdxEsmTransformCacheKey(
   projectId: string,
+  contentSourceId: string,
   normalizedPath: string,
   contentHash: string,
 ): string {
   return formatMdxEsmTransformCacheKey(
     MDX_ESM_CACHE_NAMESPACE,
     projectId,
+    contentSourceId,
     normalizedPath,
     contentHash,
   );
@@ -101,6 +120,19 @@ export function buildMdxEsmPathCacheKey(normalizedPath: string): string {
 
 export function buildMdxEsmModuleFileName(contentHash: string): string {
   return formatMdxEsmModuleFileName(MDX_ESM_CACHE_NAMESPACE, contentHash);
+}
+
+export function buildMdxEsmModuleRecoveryCacheKey(
+  projectId: string,
+  contentSourceId: string,
+  fileName: string,
+): string {
+  return formatMdxEsmModuleRecoveryCacheKey(
+    MDX_ESM_CACHE_NAMESPACE,
+    projectId,
+    contentSourceId,
+    fileName,
+  );
 }
 
 export function buildMdxJsxCacheFileName(filePath: string): string {

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -21,6 +21,7 @@ import {
 import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { buildMdxEsmPathCacheKey, MDX_ESM_ALL_FILE_URL_PATTERN_SOURCE } from "../cache-format.ts";
+import { ensureMdxModuleDependencies } from "../module-fetcher/dependency-recovery.ts";
 
 export type CacheLookupResult =
   | { status: "hit"; path: string }
@@ -341,6 +342,7 @@ export async function lookupMdxEsmCache(
   cacheDir: string,
   projectDir?: string,
   _contentHash?: string, // Intentionally unused - kept for API compatibility
+  recoveryOptions?: { projectId: string; contentSourceId: string },
 ): Promise<CacheLookupResult> {
   const cache = await getModulePathCache(cacheDir);
   const cacheKey = toMdxEsmCacheKey(filePath, projectDir);
@@ -408,7 +410,22 @@ export async function lookupMdxEsmCache(
     // CRITICAL: Check that all file:// dependencies actually exist on disk.
     // The distributed cache may contain code referencing file:// paths from other pods
     // that don't exist locally (e.g., HTTP bundles, MDX-ESM modules).
-    const missingDeps = await findMissingFileDependencies(cachedCode);
+    let missingDeps = await findMissingFileDependencies(cachedCode);
+    if (missingDeps.length > 0 && recoveryOptions) {
+      const recovered = await ensureMdxModuleDependencies(cachedCode, {
+        ...recoveryOptions,
+        log: logger,
+      });
+      if (recovered.recovered.length > 0) {
+        logger.debug(`${LOG_PREFIX_MDX_LOADER} Recovered cached MDX-ESM dependencies`, {
+          filePath,
+          cachedPath,
+          recovered: recovered.recovered.slice(0, 5),
+        });
+      }
+      missingDeps = await findMissingFileDependencies(cachedCode);
+    }
+
     if (missingDeps.length > 0) {
       logger.warn(
         `${LOG_PREFIX_MDX_LOADER} Cached module has ${missingDeps.length} missing file dependencies, invalidating`,

--- a/src/transforms/mdx/esm-module-loader/loader-helpers.ts
+++ b/src/transforms/mdx/esm-module-loader/loader-helpers.ts
@@ -151,6 +151,7 @@ export async function processVfModuleImports(
     projectDir,
     context.projectId,
     {
+      contentSourceId: context.contentSourceId,
       reactVersion: context.reactVersion,
       projectSlug: context.projectSlug,
       logger: logger.child({

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/cache-keys.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/cache-keys.test.ts
@@ -5,24 +5,33 @@ import { MDX_ESM_CACHE_NAMESPACE } from "../cache-format.ts";
 
 describe("transforms/mdx/esm-module-loader/module-fetcher/cache-keys", () => {
   describe("getTransformCacheKey", () => {
-    it("includes cache namespace, projectId, path, hash, and ssr suffix", () => {
-      const key = getTransformCacheKey("proj1", "lib/utils.ts", "abc123");
-      assertEquals(key, `${MDX_ESM_CACHE_NAMESPACE}:proj1:lib/utils.ts:abc123:ssr`);
+    it("includes cache namespace, projectId, content source, path, hash, and ssr suffix", () => {
+      const key = getTransformCacheKey("proj1", "preview-main", "lib/utils.ts", "abc123");
+      assertEquals(
+        key,
+        `${MDX_ESM_CACHE_NAMESPACE}:proj1:preview-main:lib/utils.ts:abc123:ssr`,
+      );
     });
 
     it("always ends with :ssr", () => {
-      const key = getTransformCacheKey("p", "/path", "h");
+      const key = getTransformCacheKey("p", "preview-main", "/path", "h");
       assertEquals(key.endsWith(":ssr"), true);
     });
 
     it("handles empty strings", () => {
-      const key = getTransformCacheKey("", "", "");
-      assertEquals(key, `${MDX_ESM_CACHE_NAMESPACE}::::ssr`);
+      const key = getTransformCacheKey("", "", "", "");
+      assertEquals(key, `${MDX_ESM_CACHE_NAMESPACE}:::::ssr`);
     });
 
     it("preserves special characters in path", () => {
-      const key = getTransformCacheKey("proj", "@/components/Button.tsx", "def456");
+      const key = getTransformCacheKey("proj", "preview-main", "@/components/Button.tsx", "def456");
       assertEquals(key.includes("@/components/Button.tsx"), true);
+    });
+
+    it("isolates by content source", () => {
+      const previewKey = getTransformCacheKey("proj", "preview-main", "lib/utils.ts", "abc123");
+      const releaseKey = getTransformCacheKey("proj", "release-42", "lib/utils.ts", "abc123");
+      assertEquals(previewKey === releaseKey, false);
     });
   });
 

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/cache-keys.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/cache-keys.ts
@@ -15,10 +15,11 @@ import { buildMdxEsmPathCacheKey, buildMdxEsmTransformCacheKey } from "../cache-
  */
 export function getTransformCacheKey(
   projectId: string,
+  contentSourceId: string,
   normalizedPath: string,
   contentHash: string,
 ): string {
-  return buildMdxEsmTransformCacheKey(projectId, normalizedPath, contentHash);
+  return buildMdxEsmTransformCacheKey(projectId, contentSourceId, normalizedPath, contentHash);
 }
 
 export function getVersionedPathCacheKey(normalizedPath: string): string {

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/dependency-recovery.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/dependency-recovery.test.ts
@@ -1,0 +1,117 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { join } from "#veryfront/compat/path/index.ts";
+import { makeTempDir, readTextFile, remove } from "#veryfront/testing/deno-compat.ts";
+import type { CacheBackend } from "#veryfront/cache/types.ts";
+import { tokenizeAllVeryFrontPaths } from "#veryfront/cache";
+import { buildMdxEsmModuleRecoveryCacheKey } from "../cache-format.ts";
+import { ensureMdxModuleDependencies } from "./dependency-recovery.ts";
+import { getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
+
+const noopLog = {
+  debug: () => {},
+  warn: () => {},
+  info: () => {},
+  error: () => {},
+  child: () => noopLog,
+} as never;
+
+class FakeDistributedCache implements CacheBackend {
+  readonly type = "redis" as const;
+  private values = new Map<string, string>();
+
+  get(key: string): Promise<string | null> {
+    return Promise.resolve(this.values.get(key) ?? null);
+  }
+
+  set(key: string, value: string): Promise<void> {
+    this.values.set(key, value);
+    return Promise.resolve();
+  }
+
+  del(key: string): Promise<void> {
+    this.values.delete(key);
+    return Promise.resolve();
+  }
+}
+
+describe("module-fetcher/dependency-recovery", () => {
+  it("recovers nested vfmod dependencies for the current content source", async () => {
+    const tempDir = await makeTempDir({ prefix: "vf-vfmod-recovery-" });
+    const distributedCache = new FakeDistributedCache();
+    const sourceDir = join(getMdxEsmCacheDir(), "project-a", "preview-main");
+    const childPath = join(sourceDir, "vfmod-child.mjs");
+    const grandChildPath = join(sourceDir, "vfmod-grandchild.mjs");
+
+    try {
+      await distributedCache.set(
+        buildMdxEsmModuleRecoveryCacheKey("project-a", "preview-main", "vfmod-child.mjs"),
+        tokenizeAllVeryFrontPaths(
+          [
+            `import grandChild from "file://${grandChildPath}";`,
+            `export default grandChild;`,
+          ].join("\n"),
+        ),
+      );
+
+      await distributedCache.set(
+        buildMdxEsmModuleRecoveryCacheKey("project-a", "preview-main", "vfmod-grandchild.mjs"),
+        tokenizeAllVeryFrontPaths(`export default "ok";`),
+      );
+
+      const result = await ensureMdxModuleDependencies(
+        `import child from "file://${childPath}"; export default child;`,
+        {
+          projectId: "project-a",
+          contentSourceId: "preview-main",
+          distributedCache,
+          log: noopLog,
+        },
+      );
+
+      assertEquals(result.missing.length, 0);
+      assertEquals(result.recovered.length, 2);
+      assertEquals(
+        await readTextFile(childPath),
+        [
+          `import grandChild from "file://${grandChildPath}";`,
+          `export default grandChild;`,
+        ].join("\n"),
+      );
+      assertEquals(await readTextFile(grandChildPath), `export default "ok";`);
+    } finally {
+      await remove(sourceDir, { recursive: true }).catch(() => {});
+      await remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("does not recover vfmods from another content source", async () => {
+    const tempDir = await makeTempDir({ prefix: "vf-vfmod-recovery-scope-" });
+    const distributedCache = new FakeDistributedCache();
+    const sourceDir = join(getMdxEsmCacheDir(), "project-a", "preview-main");
+    const childPath = join(sourceDir, "vfmod-child.mjs");
+
+    try {
+      await distributedCache.set(
+        buildMdxEsmModuleRecoveryCacheKey("project-a", "release-42", "vfmod-child.mjs"),
+        tokenizeAllVeryFrontPaths(`export default "wrong-source";`),
+      );
+
+      const result = await ensureMdxModuleDependencies(
+        `import child from "file://${childPath}"; export default child;`,
+        {
+          projectId: "project-a",
+          contentSourceId: "preview-main",
+          distributedCache,
+          log: noopLog,
+        },
+      );
+
+      assertEquals(result.recovered.length, 0);
+      assertEquals(result.missing, [childPath]);
+    } finally {
+      await remove(sourceDir, { recursive: true }).catch(() => {});
+      await remove(tempDir, { recursive: true });
+    }
+  });
+});

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/dependency-recovery.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/dependency-recovery.ts
@@ -1,0 +1,173 @@
+/**
+ * Distributed recovery for missing MDX ESM module dependencies.
+ *
+ * Restores missing vfmod files on fresh pods from the distributed transform
+ * cache, scoped to the current project and content source.
+ *
+ * @module transforms/mdx/esm-module-loader/module-fetcher/dependency-recovery
+ */
+
+import { basename, dirname } from "#veryfront/compat/path/index.ts";
+import { detokenizeAllCachePaths } from "#veryfront/cache";
+import type { CacheBackend } from "#veryfront/cache/types.ts";
+import type { Logger } from "#veryfront/utils/logger/logger.ts";
+import { getDistributedTransformBackend } from "#veryfront/transforms/esm/transform-cache.ts";
+import { ensureHttpBundlesExist } from "#veryfront/transforms/esm/http-cache.ts";
+import { extractHttpBundlePaths } from "#veryfront/modules/react-loader/ssr-module-loader/http-bundle-helpers.ts";
+import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
+import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
+import { getLocalFs } from "../cache/index.ts";
+import { buildMdxEsmModuleRecoveryCacheKey } from "../cache-format.ts";
+
+const MDX_VFMOD_FILE_URL_PATTERN = /file:\/\/([^"'\s]+veryfront-mdx-esm\/[^"'\s]+\.mjs)/gi;
+
+interface EnsureMdxModuleDependenciesOptions {
+  projectId: string;
+  contentSourceId: string;
+  log: Logger;
+  distributedCache?: CacheBackend | null;
+}
+
+interface EnsureMdxModuleDependenciesResult {
+  recovered: string[];
+  missing: string[];
+}
+
+function extractMdxModuleDependencyPaths(code: string): string[] {
+  const paths: string[] = [];
+  const seen = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = MDX_VFMOD_FILE_URL_PATTERN.exec(code)) !== null) {
+    const rawPath = match[1];
+    if (!rawPath) continue;
+    const cleanPath = rawPath.replace(/\?.*$/, "");
+    if (seen.has(cleanPath)) continue;
+    seen.add(cleanPath);
+    paths.push(cleanPath);
+  }
+  return paths;
+}
+
+async function ensureHttpBundleDependencies(code: string, log: Logger): Promise<boolean> {
+  const bundlePaths = extractHttpBundlePaths(code);
+  if (bundlePaths.length === 0) return true;
+
+  const failed = await ensureHttpBundlesExist(bundlePaths, getHttpBundleCacheDir());
+  if (failed.length === 0) return true;
+
+  log.warn(`${LOG_PREFIX_MDX_LOADER} Failed to recover HTTP bundles for vfmod dependency`, {
+    failed,
+    totalBundles: bundlePaths.length,
+  });
+  return false;
+}
+
+async function ensureModuleFileAndDeps(
+  absolutePath: string,
+  distributedCache: CacheBackend,
+  options: EnsureMdxModuleDependenciesOptions,
+  visited: Set<string>,
+  recovered: Set<string>,
+): Promise<boolean> {
+  if (visited.has(absolutePath)) return true;
+  visited.add(absolutePath);
+
+  const localFs = getLocalFs();
+
+  try {
+    const stat = await localFs.stat(absolutePath);
+    if (stat?.isFile) {
+      const existingCode = await localFs.readTextFile(absolutePath);
+      if (!(await ensureHttpBundleDependencies(existingCode, options.log))) return false;
+
+      for (const nestedPath of extractMdxModuleDependencyPaths(existingCode)) {
+        if (
+          !(await ensureModuleFileAndDeps(
+            nestedPath,
+            distributedCache,
+            options,
+            visited,
+            recovered,
+          ))
+        ) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+  } catch (_) {
+    /* expected: dependency may not exist on this pod yet */
+  }
+
+  const recoveryKey = buildMdxEsmModuleRecoveryCacheKey(
+    options.projectId,
+    options.contentSourceId,
+    basename(absolutePath),
+  );
+
+  const portableCode = await distributedCache.get(recoveryKey);
+  if (!portableCode) {
+    options.log.debug(`${LOG_PREFIX_MDX_LOADER} No distributed vfmod recovery entry`, {
+      dependencyPath: absolutePath,
+      recoveryKey,
+    });
+    return false;
+  }
+
+  const recoveredCode = detokenizeAllCachePaths(portableCode);
+  if (!(await ensureHttpBundleDependencies(recoveredCode, options.log))) return false;
+
+  for (const nestedPath of extractMdxModuleDependencyPaths(recoveredCode)) {
+    if (
+      !(await ensureModuleFileAndDeps(
+        nestedPath,
+        distributedCache,
+        options,
+        visited,
+        recovered,
+      ))
+    ) {
+      return false;
+    }
+  }
+
+  await localFs.mkdir(dirname(absolutePath), { recursive: true });
+  await localFs.writeTextFile(absolutePath, recoveredCode);
+  recovered.add(absolutePath);
+
+  options.log.debug(`${LOG_PREFIX_MDX_LOADER} Recovered vfmod dependency from distributed cache`, {
+    dependencyPath: absolutePath,
+    recoveryKey,
+  });
+
+  return true;
+}
+
+export async function ensureMdxModuleDependencies(
+  code: string,
+  options: EnsureMdxModuleDependenciesOptions,
+): Promise<EnsureMdxModuleDependenciesResult> {
+  const distributedCache = options.distributedCache ?? (await getDistributedTransformBackend());
+  if (!distributedCache) return { recovered: [], missing: extractMdxModuleDependencyPaths(code) };
+
+  const visited = new Set<string>();
+  const recovered = new Set<string>();
+  const missing: string[] = [];
+
+  for (const dependencyPath of extractMdxModuleDependencyPaths(code)) {
+    const ok = await ensureModuleFileAndDeps(
+      dependencyPath,
+      distributedCache,
+      options,
+      visited,
+      recovered,
+    );
+    if (!ok) missing.push(dependencyPath);
+  }
+
+  return {
+    recovered: [...recovered],
+    missing,
+  };
+}

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts
@@ -23,6 +23,9 @@ import {
   findMissingFileDependenciesInCode,
   hasIncompatibleFrameworkPaths,
 } from "./framework-validator.ts";
+import { ensureMdxModuleDependencies } from "./dependency-recovery.ts";
+import { buildMdxEsmModuleFileName, buildMdxEsmModuleRecoveryCacheKey } from "../cache-format.ts";
+import { hashString } from "../utils/hash.ts";
 
 /** TTL for cached transforms (uses centralized config) */
 const TRANSFORM_CACHE_TTL_SECONDS = TRANSFORM_DISTRIBUTED_TTL_SEC;
@@ -59,6 +62,8 @@ interface DistributedCacheReadResult {
  */
 export async function readDistributedCache(
   transformCacheKey: string,
+  projectId: string,
+  contentSourceId: string | undefined,
   normalizedPath: string,
   projectSlug: string,
   projectDir: string,
@@ -129,10 +134,26 @@ export async function readDistributedCache(
     // that don't exist on this machine.
     if (moduleCode) {
       const missingDeps = await findMissingFileDependenciesInCode(moduleCode, log);
-      if (missingDeps.length > 0) {
+      if (missingDeps.length > 0 && contentSourceId) {
+        const recovered = await ensureMdxModuleDependencies(moduleCode, {
+          distributedCache,
+          projectId,
+          contentSourceId,
+          log,
+        });
+        if (recovered.recovered.length > 0) {
+          log.debug(`${LOG_PREFIX_MDX_LOADER} Recovered missing vfmod dependencies from cache`, {
+            normalizedPath,
+            recovered: recovered.recovered.slice(0, 5),
+          });
+        }
+      }
+
+      const unresolvedDeps = await findMissingFileDependenciesInCode(moduleCode, log);
+      if (unresolvedDeps.length > 0) {
         log.warn(
-          `${LOG_PREFIX_MDX_LOADER} Cached code has ${missingDeps.length} missing file dependencies, invalidating`,
-          { normalizedPath, missingDeps: missingDeps.slice(0, 5) },
+          `${LOG_PREFIX_MDX_LOADER} Cached code has ${unresolvedDeps.length} missing file dependencies, invalidating`,
+          { normalizedPath, missingDeps: unresolvedDeps.slice(0, 5) },
         );
         moduleCode = null;
       }
@@ -177,6 +198,8 @@ export async function readDistributedCache(
 export function writeDistributedCache(
   distributedCache: DistributedCache,
   transformCacheKey: string,
+  projectId: string,
+  contentSourceId: string,
   moduleCode: string,
   normalizedPath: string,
   log: Logger,
@@ -191,6 +214,23 @@ export function writeDistributedCache(
     .catch((error) => {
       log.debug(`${LOG_PREFIX_MDX_LOADER} Distributed cache set failed`, {
         normalizedPath,
+        error,
+      });
+    });
+
+  const moduleFileName = buildMdxEsmModuleFileName(hashString(normalizedPath + moduleCode));
+  const moduleRecoveryKey = buildMdxEsmModuleRecoveryCacheKey(
+    projectId,
+    contentSourceId,
+    moduleFileName,
+  );
+
+  distributedCache
+    .set(moduleRecoveryKey, portableCode, TRANSFORM_CACHE_TTL_SECONDS)
+    .catch((error) => {
+      log.debug(`${LOG_PREFIX_MDX_LOADER} Distributed vfmod recovery set failed`, {
+        normalizedPath,
+        moduleRecoveryKey,
         error,
       });
     });

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/framework-validator.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/framework-validator.ts
@@ -14,6 +14,12 @@ import { getLocalFs } from "../cache/index.ts";
 import { extractHttpBundlePaths } from "#veryfront/modules/react-loader/ssr-module-loader/http-bundle-helpers.ts";
 import { ensureHttpBundlesExist } from "../../../esm/http-cache.ts";
 import { MDX_ESM_MJS_FILE_URL_PATTERN_SOURCE } from "../cache-format.ts";
+import { ensureMdxModuleDependencies } from "./dependency-recovery.ts";
+
+interface MdxRecoveryOptions {
+  projectId: string;
+  contentSourceId: string;
+}
 
 /**
  * Check if cached code has file:// paths that are incompatible with this environment.
@@ -157,6 +163,7 @@ export async function validateCachedModule(
   log: Logger,
   pathCache: Map<string, string>,
   versionedKey: string,
+  recoveryOptions?: MdxRecoveryOptions,
 ): Promise<boolean> {
   // Reject caches with raw HTTP URLs - all modules should use file:// paths.
   // This ensures consistency between compiled and non-compiled modes.
@@ -190,6 +197,36 @@ export async function validateCachedModule(
       pathCache.delete(versionedKey);
       return false;
     }
+  }
+
+  if (recoveryOptions) {
+    const recovered = await ensureMdxModuleDependencies(cachedCode, {
+      ...recoveryOptions,
+      log,
+    });
+    if (recovered.recovered.length > 0) {
+      log.debug(`${LOG_PREFIX_MDX_LOADER} Recovered cached module vfmod dependencies`, {
+        normalizedPath,
+        cachedPath,
+        recovered: recovered.recovered.slice(0, 5),
+      });
+    }
+  }
+
+  const missingDeps = await findMissingFileDependenciesInCode(cachedCode, log);
+  if (missingDeps.length > 0) {
+    log.warn(`${LOG_PREFIX_MDX_LOADER} Cached module has missing vfmod dependencies`, {
+      normalizedPath,
+      cachedPath,
+      missingDeps: missingDeps.slice(0, 5),
+    });
+    pathCache.delete(versionedKey);
+    try {
+      await getLocalFs().remove(cachedPath);
+    } catch (_) {
+      /* expected: cached file may already be removed */
+    }
+    return false;
   }
 
   if (!(await hasIncompatibleFrameworkPaths(cachedCode, log))) return true;

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.test.ts
@@ -18,10 +18,11 @@ import { MDX_ESM_CACHE_NAMESPACE } from "../cache-format.ts";
 
 function getTransformCacheKey(
   projectId: string,
+  contentSourceId: string,
   normalizedPath: string,
   contentHash: string,
 ): string {
-  return `${MDX_ESM_CACHE_NAMESPACE}:${projectId}:${normalizedPath}:${contentHash}`;
+  return `${MDX_ESM_CACHE_NAMESPACE}:${projectId}:${contentSourceId}:${normalizedPath}:${contentHash}:ssr`;
 }
 
 function getVersionedPathCacheKey(normalizedPath: string): string {
@@ -105,22 +106,33 @@ function hashString(input: string): string {
 describe("module-fetcher", { sanitizeResources: false, sanitizeOps: false }, () => {
   describe("getTransformCacheKey", () => {
     it("includes namespace, project, path, and hash", () => {
-      const key = getTransformCacheKey("proj1", "_vf_modules/pages/index.js", "abc123");
+      const key = getTransformCacheKey(
+        "proj1",
+        "preview-main",
+        "_vf_modules/pages/index.js",
+        "abc123",
+      );
       assertEquals(
         key,
-        `${MDX_ESM_CACHE_NAMESPACE}:proj1:_vf_modules/pages/index.js:abc123`,
+        `${MDX_ESM_CACHE_NAMESPACE}:proj1:preview-main:_vf_modules/pages/index.js:abc123:ssr`,
       );
     });
 
     it("produces different keys for different content hashes", () => {
-      const k1 = getTransformCacheKey("p", "path", "hash1");
-      const k2 = getTransformCacheKey("p", "path", "hash2");
+      const k1 = getTransformCacheKey("p", "preview-main", "path", "hash1");
+      const k2 = getTransformCacheKey("p", "preview-main", "path", "hash2");
       assertEquals(k1 !== k2, true);
     });
 
     it("produces different keys for different projects", () => {
-      const k1 = getTransformCacheKey("proj-a", "path", "hash");
-      const k2 = getTransformCacheKey("proj-b", "path", "hash");
+      const k1 = getTransformCacheKey("proj-a", "preview-main", "path", "hash");
+      const k2 = getTransformCacheKey("proj-b", "preview-main", "path", "hash");
+      assertEquals(k1 !== k2, true);
+    });
+
+    it("produces different keys for different content sources", () => {
+      const k1 = getTransformCacheKey("proj-a", "preview-main", "path", "hash");
+      const k2 = getTransformCacheKey("proj-a", "release-42", "path", "hash");
       assertEquals(k1 !== k2, true);
     });
   });

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
@@ -190,7 +190,7 @@ async function doFetchAndCacheModule(
   parentModulePath?: string,
 ): Promise<string | null> {
   const log = getLog(context);
-  const { esmCacheDir, adapter, projectDir, projectId } = context;
+  const { esmCacheDir, adapter, projectDir, projectId, contentSourceId } = context;
 
   const pathCache = await getModulePathCache(esmCacheDir);
   const versionedKey = getVersionedPathCacheKey(normalizedPath);
@@ -209,6 +209,12 @@ async function doFetchAndCacheModule(
             log,
             pathCache,
             versionedKey,
+            context.contentSourceId
+              ? {
+                projectId: context.projectId,
+                contentSourceId: context.contentSourceId,
+              }
+              : undefined,
           )
         ) {
           recordModuleToSession(normalizedPath);
@@ -252,7 +258,9 @@ async function doFetchAndCacheModule(
     const { sourceCode, actualFilePath } = resolved;
 
     const contentHash = hashString(sourceCode);
-    const transformCacheKey = getTransformCacheKey(projectId, normalizedPath, contentHash);
+    const transformCacheKey = contentSourceId
+      ? getTransformCacheKey(projectId, contentSourceId, normalizedPath, contentHash)
+      : null;
 
     let moduleCode: string | null = null;
     let needsDistributedCacheWrite = false;
@@ -260,14 +268,18 @@ async function doFetchAndCacheModule(
     // Try distributed cache read with full validation.
     // Returns null only if no distributed backend is configured.
     // Otherwise returns { code, distributedCache } where code may be null (miss).
-    const distResult = await readDistributedCache(
-      transformCacheKey,
-      normalizedPath,
-      projectSlug,
-      projectDir,
-      context.reactVersion,
-      log,
-    );
+    const distResult = transformCacheKey
+      ? await readDistributedCache(
+        transformCacheKey,
+        projectId,
+        contentSourceId,
+        normalizedPath,
+        projectSlug,
+        projectDir,
+        context.reactVersion,
+        log,
+      )
+      : null;
     if (distResult?.code) {
       moduleCode = distResult.code;
     }
@@ -402,10 +414,12 @@ async function doFetchAndCacheModule(
 
     // Write to distributed cache AFTER nested imports are resolved.
     // This ensures other pods get fully-resolved code without /_vf_modules/ paths.
-    if (needsDistributedCacheWrite && distResult?.distributedCache) {
+    if (needsDistributedCacheWrite && distResult?.distributedCache && transformCacheKey) {
       writeDistributedCache(
         distResult.distributedCache,
         transformCacheKey,
+        projectId,
+        contentSourceId!,
         moduleCode,
         normalizedPath,
         log,
@@ -449,6 +463,7 @@ export function createModuleFetcherContext(
   projectDir: string,
   projectId: string,
   options?: {
+    contentSourceId?: string;
     isLocalProject?: boolean;
     projectSlug?: string;
     reactVersion?: string;

--- a/src/transforms/mdx/esm-module-loader/types.ts
+++ b/src/transforms/mdx/esm-module-loader/types.ts
@@ -51,6 +51,7 @@ export interface ModuleFetcherContext {
   adapter: RuntimeAdapter;
   projectDir: string;
   projectId: string;
+  contentSourceId?: string;
   projectSlug?: string;
   isLocalProject?: boolean;
   /**

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -3,7 +3,7 @@ import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.95";
+export const VERSION = "0.1.96";
 
 export function normalizeVeryfrontVersion(version: string | undefined): string | undefined {
   if (!version) return undefined;


### PR DESCRIPTION
## Summary
- recover missing `veryfront-mdx-esm` vfmod dependencies from distributed cache before invalidating SSR/MDX caches
- scope distributed MDX transform cache keys by `contentSourceId` so branch/environment artifacts do not cross-rehydrate unsafely
- add regression coverage for SSR memory-cache recovery, redis-cache recovery, and content-source isolation

## Verification
- `deno task verify`
- focused MDX/module-loader recovery tests
