### PR TITLE
fix: separate SSR and client MDX bundles

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.96",
+  "version": "0.1.97",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/rendering/page-rendering.test.ts
+++ b/src/rendering/page-rendering.test.ts
@@ -1,0 +1,64 @@
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { EntityInfo } from "#veryfront/types";
+import { prepareMDXPageBundles } from "./page-rendering.ts";
+
+function createMDXPageInfo(content: string): EntityInfo {
+  return {
+    entity: {
+      id: "page-1",
+      path: "/project/pages/probe.mdx",
+      slug: "probe",
+      type: "page",
+      content,
+      frontmatter: {},
+      kind: "mdx",
+      isPage: true,
+      isLayout: false,
+      isComponent: false,
+    },
+  };
+}
+
+describe("rendering/page-rendering", () => {
+  it("keeps SSR module code separate from the browser client bundle", async () => {
+    const pageInfo = createMDXPageInfo(
+      [
+        'import { Marker } from "../components/Marker.tsx";',
+        "",
+        "# MDX Probe",
+        "",
+        "<Marker />",
+      ].join("\n"),
+    );
+
+    const { pageBundle, serverModuleCode } = await prepareMDXPageBundles(pageInfo, "/project");
+
+    assert(serverModuleCode.includes("file:///project/components/Marker.tsx"));
+    assertEquals(serverModuleCode.includes("/_veryfront/fs/"), false);
+
+    assert(pageBundle.clientModuleCode?.includes("/_veryfront/fs/"));
+    assertEquals(pageBundle.compiledCode, serverModuleCode);
+  });
+
+  it("preserves a precompiled browser bundle without leaking it into SSR", async () => {
+    const pageInfo = createMDXPageInfo(
+      [
+        'import { Marker } from "../components/Marker.tsx";',
+        "",
+        "# MDX Probe",
+        "",
+        "<Marker />",
+      ].join("\n"),
+    );
+
+    const precompiledModule = 'export default function MDXContent() { return "client"; }';
+    const { pageBundle, serverModuleCode } = await prepareMDXPageBundles(pageInfo, "/project", {
+      precompiledModule,
+    });
+
+    assertEquals(pageBundle.clientModuleCode, precompiledModule);
+    assert(serverModuleCode.includes("file:///project/components/Marker.tsx"));
+    assertEquals(serverModuleCode.includes("/_veryfront/fs/"), false);
+  });
+});

--- a/src/rendering/page-rendering.ts
+++ b/src/rendering/page-rendering.ts
@@ -15,6 +15,64 @@ interface MDXPageResult {
   collectedMetadata: Record<string, unknown>;
 }
 
+interface PreparedMDXPageBundles {
+  pageBundle: PageBundle;
+  serverModuleCode: string;
+}
+
+export async function prepareMDXPageBundles(
+  pageInfo: EntityInfo,
+  projectDir: string,
+  options?: {
+    precompiledModule?: string;
+    studioEmbed?: boolean;
+  },
+): Promise<PreparedMDXPageBundles> {
+  const { frontmatter, content, path } = pageInfo.entity;
+  const fmArg = frontmatter && Object.keys(frontmatter).length > 0 ? frontmatter : undefined;
+
+  const ssrBundle = await compileContent(
+    "development",
+    projectDir,
+    content,
+    fmArg,
+    path,
+    "server",
+    undefined,
+    options?.studioEmbed,
+  );
+
+  const pageBundle = ssrBundle as PageBundle;
+
+  if (options?.precompiledModule) {
+    pageBundle.clientModuleCode = options.precompiledModule;
+  } else {
+    const browserBundle = await compileContent(
+      "development",
+      projectDir,
+      content,
+      fmArg,
+      path,
+      "browser",
+      undefined,
+      options?.studioEmbed,
+    );
+    pageBundle.clientModuleCode = browserBundle.compiledCode;
+  }
+
+  const clientModuleCode = pageBundle.clientModuleCode;
+  if (!clientModuleCode) {
+    throw RENDER_ERROR.create({
+      detail: "MDX compilation produced no client module code",
+    });
+  }
+
+  return {
+    pageBundle,
+    serverModuleCode: ssrBundle.compiledCode,
+  };
+}
+
 export function handleMDXPage(
   pageInfo: EntityInfo,
   slug: string,
@@ -42,49 +100,16 @@ export function handleMDXPage(
   return withSpan(
     "rendering.handleMDXPage",
     async () => {
-      const { frontmatter, content, path } = pageInfo.entity;
-      const fmArg = frontmatter && Object.keys(frontmatter).length > 0 ? frontmatter : undefined;
-
-      const ssrBundle = await compileContent(
-        "development",
-        projectDir,
-        content,
-        fmArg,
-        path,
-        "server",
-        undefined,
-        options?.studioEmbed,
-      );
-
-      const pageBundle = ssrBundle as PageBundle;
+      const { frontmatter, path } = pageInfo.entity;
+      const { pageBundle, serverModuleCode } = await prepareMDXPageBundles(pageInfo, projectDir, {
+        precompiledModule: options?.precompiledModule,
+        studioEmbed: options?.studioEmbed,
+      });
       let collectedMetadata: Record<string, unknown> = {};
 
       try {
-        if (options?.precompiledModule) {
-          pageBundle.clientModuleCode = options.precompiledModule;
-        } else {
-          const browserBundle = await compileContent(
-            "development",
-            projectDir,
-            content,
-            fmArg,
-            path,
-            "browser",
-            undefined,
-            options?.studioEmbed,
-          );
-          pageBundle.clientModuleCode = browserBundle.compiledCode;
-        }
-
-        const clientModuleCode = pageBundle.clientModuleCode;
-        if (!clientModuleCode) {
-          throw RENDER_ERROR.create({
-            detail: "MDX compilation produced no client module code",
-          });
-        }
-
         const mod = (await mdxRenderer.loadModuleESM(
-          clientModuleCode,
+          serverModuleCode,
           adapter,
           options?.projectId,
           projectDir,

--- a/src/transforms/mdx/compiler/import-rewriter.test.ts
+++ b/src/transforms/mdx/compiler/import-rewriter.test.ts
@@ -8,7 +8,7 @@ describe("transforms/mdx/compiler/import-rewriter", () => {
     it("rewrites relative import for SSR", () => {
       const config: ImportRewriterConfig = {
         filePath: "/project/app/page.mdx",
-        target: "ssr",
+        target: "server",
       };
       const body = `import { foo } from "./utils.js";`;
       const result = rewriteBodyImports(body, config);
@@ -28,7 +28,7 @@ describe("transforms/mdx/compiler/import-rewriter", () => {
     it("leaves bare imports unchanged", () => {
       const config: ImportRewriterConfig = {
         filePath: "/project/app/page.mdx",
-        target: "ssr",
+        target: "server",
       };
       const body = `import React from "react";`;
       const result = rewriteBodyImports(body, config);
@@ -48,7 +48,7 @@ describe("transforms/mdx/compiler/import-rewriter", () => {
     it("leaves @/ alias unchanged for SSR", () => {
       const config: ImportRewriterConfig = {
         filePath: "/project/app/page.mdx",
-        target: "ssr",
+        target: "server",
       };
       const body = `import { Button } from "@/components/Button";`;
       const result = rewriteBodyImports(body, config);
@@ -58,7 +58,7 @@ describe("transforms/mdx/compiler/import-rewriter", () => {
     it("does not touch non-import lines", () => {
       const config: ImportRewriterConfig = {
         filePath: "/project/app/page.mdx",
-        target: "ssr",
+        target: "server",
       };
       const body = `const x = 1;\nimport React from "react";`;
       const result = rewriteBodyImports(body, config);
@@ -68,7 +68,7 @@ describe("transforms/mdx/compiler/import-rewriter", () => {
     it("handles export from statement", () => {
       const config: ImportRewriterConfig = {
         filePath: "/project/app/page.mdx",
-        target: "ssr",
+        target: "server",
       };
       const body = `export { foo } from "./utils.js";`;
       const result = rewriteBodyImports(body, config);
@@ -89,7 +89,7 @@ describe("transforms/mdx/compiler/import-rewriter", () => {
     it("handles empty body", () => {
       const config: ImportRewriterConfig = {
         filePath: "/project/app/page.mdx",
-        target: "ssr",
+        target: "server",
       };
       assertEquals(rewriteBodyImports("", config), "");
     });
@@ -109,7 +109,7 @@ describe("transforms/mdx/compiler/import-rewriter", () => {
     it("rewrites relative from imports for SSR", () => {
       const config: ImportRewriterConfig = {
         filePath: "/project/app/page.mdx",
-        target: "ssr",
+        target: "server",
       };
       const code = `from "./utils.js"`;
       const result = rewriteCompiledImports(code, config);

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -3,7 +3,7 @@ import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.96";
+export const VERSION = "0.1.97";
 
 export function normalizeVeryfrontVersion(version: string | undefined): string | undefined {
   if (!version) return undefined;


### PR DESCRIPTION
## Summary
- separate the server-side MDX bundle from the browser bundle in page rendering
- add regression coverage for MDX imports that should stay server-resolved during SSR
- bump the CLI version to ship the hosted preview fix

## Verification
- deno task verify
- deno test -A src/rendering/page-rendering.test.ts src/transforms/mdx/compiler/import-rewriter.test.ts
- deno check src/rendering/page-rendering.ts src/rendering/page-rendering.test.ts src/transforms/mdx/compiler/import-rewriter.test.ts
- deno lint src/rendering/page-rendering.ts src/rendering/page-rendering.test.ts src/transforms/mdx/compiler/import-rewriter.test.ts
- deno fmt --check src/rendering/page-rendering.ts src/rendering/page-rendering.test.ts src/transforms/mdx/compiler/import-rewriter.test.ts