### PR TITLE
fix: upgrade esbuild 0.20.2 → 0.27.4 (CVE-2024-23334)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -230,8 +230,8 @@
     "rehype-raw": "npm:rehype-raw@7.0.0",
     "rehype-sanitize": "npm:rehype-sanitize@6.0.0",
     "rehype-stringify": "npm:rehype-stringify@10.0.1",
-    "esbuild": "npm:esbuild@0.20.2",
-    "esbuild/mod.js": "npm:esbuild@0.20.2",
+    "esbuild": "npm:esbuild@0.27.4",
+    "esbuild/mod.js": "npm:esbuild@0.27.4",
     "es-module-lexer": "npm:es-module-lexer@1.5.0",
     "gray-matter": "npm:gray-matter@4.0.3",
     "zod": "npm:zod@3.25.76",
@@ -409,7 +409,7 @@
       "npm:onnxruntime-node@1.21.0"
     ],
     "deny": [
-      "npm:esbuild@0.20.2",
+      "npm:esbuild@0.27.4",
       "npm:protobufjs@7.5.4"
     ]
   }

--- a/src/platform/compat/esbuild-shared.ts
+++ b/src/platform/compat/esbuild-shared.ts
@@ -1,4 +1,4 @@
-export const ESBUILD_VERSION = "0.20.2";
+export const ESBUILD_VERSION = "0.27.4";
 
 export function getEsbuildBinaryName(): string {
   const archMap: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Upgrades esbuild from 0.20.2 to 0.27.4
- Fixes CVE-2024-23334: dev server allows cross-origin request reading, potentially exposing sensitive data
- Updates allowScripts deny list to match new version

## Test plan
- [ ] CI unit tests pass
- [ ] CI integration tests pass