### PR TITLE
fix: disable gray-matter JS engine to prevent code execution

### DIFF
--- a/src/platform/compat/shims/std-front-matter.ts
+++ b/src/platform/compat/shims/std-front-matter.ts
@@ -7,7 +7,8 @@ interface FrontMatterResult<T = Record<string, unknown>> {
 }
 
 type GrayMatterResult<T> = { data: T; content: string; matter?: string };
-type GrayMatterOptions = { engines?: Record<string, boolean> };
+type GrayMatterEngine = { parse: () => never };
+type GrayMatterOptions = { engines?: Record<string, GrayMatterEngine> };
 type GrayMatterFn = <T = Record<string, unknown>>(
   content: string,
   options?: GrayMatterOptions,
@@ -16,8 +17,15 @@ type GrayMatterFn = <T = Record<string, unknown>>(
 const grayMatter = (grayMatterImport as { default?: GrayMatterFn }).default ??
   (grayMatterImport as GrayMatterFn);
 
-/** Security: JS engine disabled to prevent arbitrary code execution from untrusted frontmatter */
-const SAFE_OPTIONS: GrayMatterOptions = { engines: { js: false } };
+/** Security: override both "js" and "javascript" engine aliases to block eval on untrusted frontmatter */
+const DISABLED_ENGINE: GrayMatterEngine = {
+  parse: () => {
+    throw new Error("JavaScript frontmatter is disabled for security");
+  },
+};
+const SAFE_OPTIONS: GrayMatterOptions = {
+  engines: { js: DISABLED_ENGINE, javascript: DISABLED_ENGINE },
+};
 
 export function extract<T = Record<string, unknown>>(
   content: string,

--- a/src/platform/compat/shims/std-front-matter.ts
+++ b/src/platform/compat/shims/std-front-matter.ts
@@ -7,15 +7,22 @@ interface FrontMatterResult<T = Record<string, unknown>> {
 }
 
 type GrayMatterResult<T> = { data: T; content: string; matter?: string };
-type GrayMatterFn = <T = Record<string, unknown>>(content: string) => GrayMatterResult<T>;
+type GrayMatterOptions = { engines?: Record<string, boolean> };
+type GrayMatterFn = <T = Record<string, unknown>>(
+  content: string,
+  options?: GrayMatterOptions,
+) => GrayMatterResult<T>;
 
 const grayMatter = (grayMatterImport as { default?: GrayMatterFn }).default ??
   (grayMatterImport as GrayMatterFn);
 
+/** Security: JS engine disabled to prevent arbitrary code execution from untrusted frontmatter */
+const SAFE_OPTIONS: GrayMatterOptions = { engines: { js: false } };
+
 export function extract<T = Record<string, unknown>>(
   content: string,
 ): FrontMatterResult<T> {
-  const { data, content: body, matter } = grayMatter<T>(content);
+  const { data, content: body, matter } = grayMatter<T>(content, SAFE_OPTIONS);
   return {
     attrs: data,
     body,

--- a/src/platform/compat/std/front-matter-yaml.ts
+++ b/src/platform/compat/std/front-matter-yaml.ts
@@ -14,13 +14,20 @@ export interface Extract<T> {
 }
 
 type GrayMatterResult<T> = { data: T; content: string; matter?: string };
-type GrayMatterFn = <T = Record<string, unknown>>(content: string) => GrayMatterResult<T>;
+type GrayMatterOptions = { engines?: Record<string, boolean> };
+type GrayMatterFn = <T = Record<string, unknown>>(
+  content: string,
+  options?: GrayMatterOptions,
+) => GrayMatterResult<T>;
 
 const grayMatter: GrayMatterFn = (grayMatterImport as { default?: GrayMatterFn }).default ??
   (grayMatterImport as GrayMatterFn);
 
+/** Security: JS engine disabled to prevent arbitrary code execution from untrusted frontmatter */
+const SAFE_OPTIONS: GrayMatterOptions = { engines: { js: false } };
+
 export function extract<T = Record<string, unknown>>(text: string): Extract<T> {
-  const result = grayMatter<T>(text);
+  const result = grayMatter<T>(text, SAFE_OPTIONS);
   return {
     attrs: result.data,
     body: result.content,

--- a/src/platform/compat/std/front-matter-yaml.ts
+++ b/src/platform/compat/std/front-matter-yaml.ts
@@ -14,7 +14,8 @@ export interface Extract<T> {
 }
 
 type GrayMatterResult<T> = { data: T; content: string; matter?: string };
-type GrayMatterOptions = { engines?: Record<string, boolean> };
+type GrayMatterEngine = { parse: () => never };
+type GrayMatterOptions = { engines?: Record<string, GrayMatterEngine> };
 type GrayMatterFn = <T = Record<string, unknown>>(
   content: string,
   options?: GrayMatterOptions,
@@ -23,8 +24,15 @@ type GrayMatterFn = <T = Record<string, unknown>>(
 const grayMatter: GrayMatterFn = (grayMatterImport as { default?: GrayMatterFn }).default ??
   (grayMatterImport as GrayMatterFn);
 
-/** Security: JS engine disabled to prevent arbitrary code execution from untrusted frontmatter */
-const SAFE_OPTIONS: GrayMatterOptions = { engines: { js: false } };
+/** Security: override both "js" and "javascript" engine aliases to block eval on untrusted frontmatter */
+const DISABLED_ENGINE: GrayMatterEngine = {
+  parse: () => {
+    throw new Error("JavaScript frontmatter is disabled for security");
+  },
+};
+const SAFE_OPTIONS: GrayMatterOptions = {
+  engines: { js: DISABLED_ENGINE, javascript: DISABLED_ENGINE },
+};
 
 export function extract<T = Record<string, unknown>>(text: string): Extract<T> {
   const result = grayMatter<T>(text, SAFE_OPTIONS);


### PR DESCRIPTION
## Summary
- Disables gray-matter JavaScript engine in both frontmatter parsing shims
- Prevents arbitrary code execution from untrusted markdown frontmatter
- Affects `src/platform/compat/std/front-matter-yaml.ts` and `src/platform/compat/shims/std-front-matter.ts`

## Test plan
- [x] CI unit tests pass
- [x] CI integration tests pass