### PR TITLE
chore: upgrade @kreuzberg/wasm 4.4.2 → 4.5.2

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -268,8 +268,8 @@
     "class-variance-authority": "npm:class-variance-authority@0.7.1",
     "clsx": "npm:clsx@2.1.1",
     "tailwind-merge": "npm:tailwind-merge@2.6.0",
-    "@kreuzberg/wasm": "npm:@kreuzberg/wasm@4.4.2",
-    "#kreuzberg-wasm-glue": "npm:@kreuzberg/wasm@4.4.2/dist/pkg/kreuzberg_wasm.js"
+    "@kreuzberg/wasm": "npm:@kreuzberg/wasm@4.5.2",
+    "#kreuzberg-wasm-glue": "npm:@kreuzberg/wasm@4.5.2/dist/pkg/kreuzberg_wasm.js"
   },
   "compilerOptions": {
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
- Upgrades @kreuzberg/wasm from 4.4.2 to 4.5.2 (both main import and WASM glue entry)

## Test plan
- [x] CI unit tests pass
- [x] CI integration tests pass