### PR TITLE
chore: add dependency audit script for supply chain risk detection

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -342,6 +342,7 @@
     "dupes": "deno run --allow-read scripts/lint/find-duplicate-functions.ts",
     "lint:platform": "deno run --allow-read scripts/lint/lint-platform-agnostic.ts",
     "lint:wildcard-exports": "deno run --allow-read scripts/lint/ban-wildcard-exports.ts",
+    "lint:deps": "deno run --allow-read scripts/lint/audit-deps.ts",
     "lint:barrel-jsdoc": "deno run --allow-read scripts/lint/check-barrel-jsdoc.ts",
     "test:cross-runtime": "deno run --allow-all src/platform/compat/cross-runtime.test.ts",
     "test:node": "node ./tests/node/run-tests.mjs 'src/**/*.test.ts'",

--- a/scripts/lint/audit-deps.ts
+++ b/scripts/lint/audit-deps.ts
@@ -1,0 +1,129 @@
+/**
+ * Dependency audit script — flags supply chain risks in deno.json imports.
+ *
+ * Checks for:
+ * - Unpinned npm versions (e.g., "npm:foo" without @version)
+ * - git:// or tarball URLs
+ * - Non-https URLs (except local paths)
+ * - esm.sh URLs without pinned versions
+ *
+ * Usage: deno run --allow-read scripts/lint/audit-deps.ts
+ */
+
+const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
+const imports: Record<string, string> = denoConfig.imports ?? {};
+
+interface Issue {
+  specifier: string;
+  target: string;
+  severity: "error" | "warning";
+  message: string;
+}
+
+const issues: Issue[] = [];
+
+for (const [specifier, target] of Object.entries(imports)) {
+  // Skip local path imports
+  if (target.startsWith("./") || target.startsWith("../")) continue;
+  // Skip jsr: imports (managed by Deno)
+  if (target.startsWith("jsr:")) continue;
+
+  // Check for git:// or tarball URLs
+  if (target.startsWith("git://") || target.startsWith("git+")) {
+    issues.push({
+      specifier,
+      target,
+      severity: "error",
+      message: "Git URL import — vulnerable to repo compromise",
+    });
+    continue;
+  }
+
+  if (target.match(/\.(tar\.gz|tgz|tar)$/)) {
+    issues.push({
+      specifier,
+      target,
+      severity: "error",
+      message: "Tarball import — cannot verify integrity",
+    });
+    continue;
+  }
+
+  // Check npm: imports for version pinning
+  if (target.startsWith("npm:")) {
+    const hasVersion = target.match(/npm:.+@\d/);
+    if (!hasVersion) {
+      issues.push({
+        specifier,
+        target,
+        severity: "warning",
+        message: "Unpinned npm version — specify exact version for reproducibility",
+      });
+    }
+    continue;
+  }
+
+  // Check https:// URLs (esm.sh etc.)
+  if (target.startsWith("https://")) {
+    if (!target.startsWith("https://esm.sh/") && !target.startsWith("https://jsr.io/")) {
+      issues.push({
+        specifier,
+        target,
+        severity: "warning",
+        message: "Non-standard CDN URL — ensure this source is trusted",
+      });
+    }
+
+    // Check esm.sh for version pinning
+    if (target.startsWith("https://esm.sh/")) {
+      const hasVersion = target.match(/esm\.sh\/.+@\d/);
+      if (!hasVersion) {
+        issues.push({
+          specifier,
+          target,
+          severity: "warning",
+          message: "Unpinned esm.sh version — specify exact version",
+        });
+      }
+    }
+    continue;
+  }
+
+  // Check for http:// (non-TLS)
+  if (target.startsWith("http://")) {
+    issues.push({
+      specifier,
+      target,
+      severity: "error",
+      message: "Non-HTTPS import — vulnerable to MITM attacks",
+    });
+  }
+}
+
+// Report results
+if (issues.length === 0) {
+  console.log("✅ No supply chain issues found in dependency imports.");
+  Deno.exit(0);
+}
+
+const errors = issues.filter((i) => i.severity === "error");
+const warnings = issues.filter((i) => i.severity === "warning");
+
+if (warnings.length > 0) {
+  console.log(`\n⚠️  ${warnings.length} warning(s):`);
+  for (const w of warnings) {
+    console.log(`  ${w.specifier}: ${w.message}`);
+    console.log(`    → ${w.target}`);
+  }
+}
+
+if (errors.length > 0) {
+  console.log(`\n❌ ${errors.length} error(s):`);
+  for (const e of errors) {
+    console.log(`  ${e.specifier}: ${e.message}`);
+    console.log(`    → ${e.target}`);
+  }
+  Deno.exit(1);
+}
+
+console.log("\n✅ No blocking issues (warnings only).");

--- a/scripts/lint/audit-deps.ts
+++ b/scripts/lint/audit-deps.ts
@@ -39,7 +39,7 @@ for (const [specifier, target] of Object.entries(imports)) {
     continue;
   }
 
-  if (target.match(/\.(tar\.gz|tgz|tar)$/)) {
+  if (target.match(/\.(tar\.gz|tgz|tar)([?#]|$)/)) {
     issues.push({
       specifier,
       target,
@@ -51,13 +51,14 @@ for (const [specifier, target] of Object.entries(imports)) {
 
   // Check npm: imports for version pinning
   if (target.startsWith("npm:")) {
-    const hasVersion = target.match(/npm:.+@\d/);
-    if (!hasVersion) {
+    // Require exact semver (x.y.z), not just major-only like @1
+    const hasExactVersion = target.match(/npm:.+@\d+\.\d+\.\d/);
+    if (!hasExactVersion) {
       issues.push({
         specifier,
         target,
         severity: "warning",
-        message: "Unpinned npm version — specify exact version for reproducibility",
+        message: "Unpinned npm version — specify exact version (x.y.z) for reproducibility",
       });
     }
     continue;
@@ -76,7 +77,9 @@ for (const [specifier, target] of Object.entries(imports)) {
 
     // Check esm.sh for version pinning
     if (target.startsWith("https://esm.sh/")) {
-      const hasVersion = target.match(/esm\.sh\/.+@\d/);
+      // Check package path (before ?) for version, not query string params
+      const urlPath = target.split("?")[0];
+      const hasVersion = urlPath.match(/esm\.sh\/.+@\d/);
       if (!hasVersion) {
         issues.push({
           specifier,


### PR DESCRIPTION
## Summary
- Adds `scripts/lint/audit-deps.ts` — scans deno.json imports for supply chain risks
- Flags git://, tarball, non-HTTPS imports as errors
- Flags unpinned versions and non-standard CDNs as warnings
- Adds `lint:deps` task to deno.json

Part of supply chain security hardening (Phase 3).

## Test plan
- [x] `deno run --allow-read scripts/lint/audit-deps.ts` exits cleanly
- [x] CI passes