### PR TITLE
Fix style artifact source binding

### DIFF
--- a/cli/commands/styles/command.test.ts
+++ b/cli/commands/styles/command.test.ts
@@ -1,0 +1,40 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { getUnderlyingVeryfrontClient } from "./command.ts";
+
+describe("getUnderlyingVeryfrontClient", () => {
+  it("binds getAllSourceFiles to the underlying adapter", async () => {
+    const files = [{ path: "pages/index.tsx", content: "export default function Page() {}" }];
+    const client = { id: "client" };
+    const underlyingAdapter = {
+      files,
+      getAllSourceFiles() {
+        return Promise.resolve(this.files);
+      },
+      getContentContext() {
+        return { branch: "main" };
+      },
+      getClient() {
+        return client;
+      },
+    };
+
+    const sourceAdapter = getUnderlyingVeryfrontClient({
+      fs: {
+        isVeryfrontAdapter() {
+          return true;
+        },
+        getUnderlyingAdapter() {
+          return underlyingAdapter;
+        },
+        isMultiProjectMode() {
+          return false;
+        },
+      },
+    } as never);
+
+    assertEquals(sourceAdapter.client, client as never);
+    assertEquals(sourceAdapter.contentContext, { branch: "main" });
+    assertEquals(await sourceAdapter.getAllSourceFiles(), files);
+  });
+});

--- a/cli/commands/styles/command.ts
+++ b/cli/commands/styles/command.ts
@@ -131,7 +131,9 @@ function requireEnv(name: string): string {
   return value;
 }
 
-function getUnderlyingVeryfrontClient(adapter: Awaited<ReturnType<typeof enhanceAdapterWithFS>>): {
+export function getUnderlyingVeryfrontClient(
+  adapter: Awaited<ReturnType<typeof enhanceAdapterWithFS>>,
+): {
   client: VeryfrontApiClient;
   contentContext: StyleBuildContentContext | null;
   getAllSourceFiles: () => Promise<Array<{ path: string; content?: string }>>;
@@ -158,7 +160,7 @@ function getUnderlyingVeryfrontClient(adapter: Awaited<ReturnType<typeof enhance
     contentContext: typeof fsAdapter.getContentContext === "function"
       ? fsAdapter.getContentContext()
       : null,
-    getAllSourceFiles: fsAdapter.getAllSourceFiles,
+    getAllSourceFiles: fsAdapter.getAllSourceFiles.bind(fsAdapter),
   };
 }
 

--- a/src/react/components/ai/chat/index.tsx
+++ b/src/react/components/ai/chat/index.tsx
@@ -508,7 +508,17 @@ Chat.displayName = "Chat";
 // ChatComponents — Compound API via Object.assign
 // ---------------------------------------------------------------------------
 
-export const ChatComponents = Object.assign(Chat, {
+export type ChatComponentsType = typeof Chat & {
+  Root: typeof ChatRoot;
+  MessageList: typeof ChatMessageList;
+  Composer: typeof ChatComposer;
+  Empty: typeof ChatEmpty;
+  If: typeof ChatIf;
+  Message: typeof Message;
+  ErrorBanner: typeof ErrorBanner;
+};
+
+export const ChatComponents: ChatComponentsType = Object.assign(Chat, {
   Root: ChatRoot,
   MessageList: ChatMessageList,
   Composer: ChatComposer,


### PR DESCRIPTION
## Summary
- bind the Veryfront FS adapter getAllSourceFiles method before invoking the style artifact build path
- add a regression test for the bound source adapter helper
- narrow ChatComponents to a named public type so npm packaging on main succeeds

## Verification
- deno test -A cli/commands/styles/command.test.ts
- deno check src/react/components/ai/chat/index.tsx cli/commands/styles/command.ts cli/commands/styles/command.test.ts
- deno task build:npm
- live smoke: styles build-artifact against probe-1774218872 and veryfront-sound-design
- git push pre-push suite: fmt, lint, typecheck, 1205 unit tests