### PR TITLE
Fix preview host and slug fallback resolution

### DIFF
--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -284,6 +284,32 @@ describe("Proxy Handler", () => {
         await server.shutdown();
       }
     });
+
+    it("falls back to the request URL host when the Host header is absent", async () => {
+      const handler = createProxyHandler({
+        config: {
+          apiBaseUrl: "http://localhost:9999",
+          apiClientId: "",
+          apiClientSecret: "",
+          previewApiClientId: "",
+          previewApiClientSecret: "",
+          localProjects: {
+            "my-project": ".",
+          },
+        },
+      });
+
+      const req = new Request("http://my-project.preview.lvh.me:3001/page");
+
+      const ctx = await handler.processRequest(req);
+
+      assertEquals(ctx.projectSlug, "my-project");
+      assertEquals(ctx.environment, "preview");
+      assertEquals(ctx.localPath, ".");
+      assertEquals(ctx.error, undefined);
+
+      await handler.close();
+    });
   });
 
   describe("protected environments", () => {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -165,6 +165,10 @@ export interface ProxyHandlerOptions {
   logger?: ProxyLogger;
 }
 
+function getRequestHost(req: Request): string {
+  return req.headers.get("host") ?? new URL(req.url).host;
+}
+
 function getScope(environment: string | null): TokenScope {
   return environment === "preview" ? "preview" : "production";
 }
@@ -425,7 +429,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
   }
 
   async function processRequest(req: Request): Promise<ProxyContext> {
-    const rawHost = req.headers.get("host") ?? "";
+    const rawHost = getRequestHost(req);
     const host = rawHost.replace(/:\d+$/, "");
     const parsedDomain = parseProjectDomain(host);
     const scope = getScope(parsedDomain.environment);
@@ -685,7 +689,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
   }
 
   async function getTokenForApi(req: Request): Promise<string | undefined> {
-    const rawHost = req.headers.get("host") ?? "";
+    const rawHost = getRequestHost(req);
     const host = rawHost.replace(/:\d+$/, "");
     const parsedDomain = parseProjectDomain(host);
     const scope = getScope(parsedDomain.environment);

--- a/src/server/context/request-context.test.ts
+++ b/src/server/context/request-context.test.ts
@@ -153,6 +153,14 @@ describe("createRequestContext", () => {
       assertEquals(ctx.slug, "my-app");
     });
 
+    it("takes the first entry from a comma-separated x-forwarded-host", () => {
+      const req = makeRequest("https://127.0.0.1/page", {
+        "x-forwarded-host": "my-app.preview.lvh.me, proxy2.internal",
+      });
+      const ctx = createRequestContext(req);
+      assertEquals(ctx.slug, "my-app");
+    });
+
     it("defaults token to empty string when no header and no env", () => {
       const req = makeRequest("https://example.com/page", {
         host: "example.com",

--- a/src/server/context/request-context.test.ts
+++ b/src/server/context/request-context.test.ts
@@ -135,6 +135,15 @@ describe("createRequestContext", () => {
       assertEquals(ctx.slug, "override-slug");
     });
 
+    it("falls back to the parsed domain slug when x-project-slug is blank", () => {
+      const req = makeRequest("https://127.0.0.1/page", {
+        "x-forwarded-host": "my-app.preview.lvh.me",
+        "x-project-slug": "   ",
+      });
+      const ctx = createRequestContext(req);
+      assertEquals(ctx.slug, "my-app");
+    });
+
     it("defaults token to empty string when no header and no env", () => {
       const req = makeRequest("https://example.com/page", {
         host: "example.com",

--- a/src/server/context/request-context.test.ts
+++ b/src/server/context/request-context.test.ts
@@ -144,6 +144,15 @@ describe("createRequestContext", () => {
       assertEquals(ctx.slug, "my-app");
     });
 
+    it("falls back to the parsed domain slug when x-project-slug is empty string", () => {
+      const req = makeRequest("https://127.0.0.1/page", {
+        "x-forwarded-host": "my-app.preview.lvh.me",
+        "x-project-slug": "",
+      });
+      const ctx = createRequestContext(req);
+      assertEquals(ctx.slug, "my-app");
+    });
+
     it("defaults token to empty string when no header and no env", () => {
       const req = makeRequest("https://example.com/page", {
         host: "example.com",

--- a/src/server/context/request-context.ts
+++ b/src/server/context/request-context.ts
@@ -17,6 +17,7 @@ export function createRequestContext(req: Request): RequestContext {
   // is in the Host header (e.g., "flow-ops.lvh.me:3010"). Prefer Host header.
   const effectiveHost = forwardedHost ?? hostHeader ?? hostname;
   const parsed = parseProjectDomain(effectiveHost);
+  const headerProjectSlug = req.headers.get("x-project-slug")?.trim() || undefined;
 
   const xEnvironment = req.headers.get("x-environment");
 
@@ -30,7 +31,7 @@ export function createRequestContext(req: Request): RequestContext {
     // Framework-owned token: bypass project env overlay so proxy mode works
     // when a remote project overlay is active.
     token: req.headers.get("x-token") ?? getHostEnv("VERYFRONT_API_TOKEN") ?? "",
-    slug: req.headers.get("x-project-slug") ?? parsed.slug ?? "",
+    slug: headerProjectSlug ?? parsed.slug ?? "",
     branch: parsed.branch,
     mode,
   };

--- a/src/server/context/request-context.ts
+++ b/src/server/context/request-context.ts
@@ -10,7 +10,11 @@ export interface RequestContext {
 
 export function createRequestContext(req: Request): RequestContext {
   const { hostname } = new URL(req.url);
-  const forwardedHost = req.headers.get("x-forwarded-host");
+  const rawForwardedHost = req.headers.get("x-forwarded-host");
+  // x-forwarded-host can be comma-separated (multiple proxies); take the first entry.
+  const forwardedHost = rawForwardedHost
+    ? (rawForwardedHost.split(",")[0]?.trim() || undefined)
+    : undefined;
   const hostHeader = req.headers.get("host");
 
   // In proxy mode, req.url hostname may be 127.0.0.1 while the real domain

--- a/src/server/runtime-handler/project-resolution.test.ts
+++ b/src/server/runtime-handler/project-resolution.test.ts
@@ -101,6 +101,17 @@ describe("server/runtime-handler/project-resolution", () => {
       assertEquals(headers.projectSlug, "my-project");
     });
 
+    it("derives project slug from x-forwarded-host when x-project-slug is empty string", () => {
+      const req = new Request("http://127.0.0.1:3001/", {
+        headers: {
+          "x-forwarded-host": "my-project.preview.lvh.me",
+          "x-project-slug": "",
+        },
+      });
+      const headers = extractRequestHeaders(req, new URL(req.url));
+      assertEquals(headers.projectSlug, "my-project");
+    });
+
     it("extracts content-source-id from header", () => {
       const req = new Request("http://localhost/", {
         headers: { "x-content-source-id": "cs-1" },

--- a/src/server/runtime-handler/project-resolution.test.ts
+++ b/src/server/runtime-handler/project-resolution.test.ts
@@ -112,6 +112,16 @@ describe("server/runtime-handler/project-resolution", () => {
       assertEquals(headers.projectSlug, "my-project");
     });
 
+    it("takes the first entry from a comma-separated x-forwarded-host", () => {
+      const req = new Request("http://127.0.0.1:3001/", {
+        headers: {
+          "x-forwarded-host": "my-project.preview.lvh.me, proxy2.internal",
+        },
+      });
+      const headers = extractRequestHeaders(req, new URL(req.url));
+      assertEquals(headers.projectSlug, "my-project");
+    });
+
     it("extracts content-source-id from header", () => {
       const req = new Request("http://localhost/", {
         headers: { "x-content-source-id": "cs-1" },
@@ -229,6 +239,28 @@ describe("server/runtime-handler/project-resolution", () => {
 
       assertEquals(result.projectSlug, "request-slug");
       assertEquals(result.projectId, undefined);
+    });
+
+    it("preserves defaultProjectId when resolved slug matches defaultProjectSlug", async () => {
+      __injectDepsForTests({
+        parseProjectDomain: () => defaultParsedDomain,
+        lookupProjectByDomain: () => Promise.resolve(null),
+        getEnvironmentType: () => undefined,
+      });
+
+      const req = new Request("http://localhost/");
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+      const result = await resolveProject(req, url, headers, {
+        config: undefined,
+        reqCtx: { slug: "default-slug", mode: undefined, branch: null, token: undefined },
+        defaultProjectSlug: "default-slug",
+        defaultProjectId: "default-id",
+        wsSlugOverride: undefined,
+      });
+
+      assertEquals(result.projectSlug, "default-slug");
+      assertEquals(result.projectId, "default-id");
     });
 
     it("uses configured slug from config", async () => {

--- a/src/server/runtime-handler/project-resolution.test.ts
+++ b/src/server/runtime-handler/project-resolution.test.ts
@@ -82,6 +82,25 @@ describe("server/runtime-handler/project-resolution", () => {
       assertEquals(headers.environmentId, "env-1");
     });
 
+    it("derives project slug from x-forwarded-host when proxy header is absent", () => {
+      const req = new Request("http://127.0.0.1:3001/", {
+        headers: { "x-forwarded-host": "my-project.preview.lvh.me" },
+      });
+      const headers = extractRequestHeaders(req, new URL(req.url));
+      assertEquals(headers.projectSlug, "my-project");
+    });
+
+    it("derives project slug from x-forwarded-host when x-project-slug is blank", () => {
+      const req = new Request("http://127.0.0.1:3001/", {
+        headers: {
+          "x-forwarded-host": "my-project.preview.lvh.me",
+          "x-project-slug": "   ",
+        },
+      });
+      const headers = extractRequestHeaders(req, new URL(req.url));
+      assertEquals(headers.projectSlug, "my-project");
+    });
+
     it("extracts content-source-id from header", () => {
       const req = new Request("http://localhost/", {
         headers: { "x-content-source-id": "cs-1" },
@@ -177,6 +196,28 @@ describe("server/runtime-handler/project-resolution", () => {
 
       assertEquals(result.projectSlug, "default-slug");
       assertEquals(result.projectId, "default-id");
+    });
+
+    it("does not apply defaultProjectId when request resolved slug is different", async () => {
+      __injectDepsForTests({
+        parseProjectDomain: () => defaultParsedDomain,
+        lookupProjectByDomain: () => Promise.resolve(null),
+        getEnvironmentType: () => undefined,
+      });
+
+      const req = new Request("http://localhost/");
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+      const result = await resolveProject(req, url, headers, {
+        config: undefined,
+        reqCtx: { slug: "request-slug", mode: undefined, branch: null, token: undefined },
+        defaultProjectSlug: "default-slug",
+        defaultProjectId: "default-id",
+        wsSlugOverride: undefined,
+      });
+
+      assertEquals(result.projectSlug, "request-slug");
+      assertEquals(result.projectId, undefined);
     });
 
     it("uses configured slug from config", async () => {

--- a/src/server/runtime-handler/project-resolution.ts
+++ b/src/server/runtime-handler/project-resolution.ts
@@ -71,12 +71,21 @@ interface RequestHeaders {
   projectPath: string | undefined;
 }
 
+function getEffectiveHost(req: Request, url: URL): string {
+  const forwardedHost = req.headers.get("x-forwarded-host") ?? undefined;
+  return forwardedHost ?? req.headers.get("host") ?? url.host;
+}
+
 /**
  * Extract project-related headers from a request.
+ *
+ * When `x-project-slug` is absent or blank, the slug is derived from
+ * the effective host (x-forwarded-host > host header > url.host) via
+ * domain parsing. This allows proxy-forwarded requests to resolve
+ * project context from the hostname alone.
  */
 export function extractRequestHeaders(req: Request, url: URL): RequestHeaders {
-  const forwardedHost = req.headers.get("x-forwarded-host") ?? undefined;
-  const host = forwardedHost ?? req.headers.get("host") ?? url.host;
+  const host = getEffectiveHost(req, url);
   const parsedDomain = parseProjectDomain(host);
   const projectSlugHeader = req.headers.get("x-project-slug")?.trim() || undefined;
 
@@ -144,9 +153,7 @@ export async function resolveProject(
   headers: RequestHeaders,
   opts: ProjectResolutionOptions,
 ): Promise<ProjectResolutionResult> {
-  const hostHeader = req.headers.get("host") ?? url.host;
-  const forwardedHost = req.headers.get("x-forwarded-host") ?? undefined;
-  const host = forwardedHost ?? hostHeader;
+  const host = getEffectiveHost(req, url);
 
   const deps = getDeps();
   const parsedDomain = deps.parseProjectDomain(host);
@@ -177,7 +184,6 @@ export async function resolveProject(
     if (effectiveToken) {
       logger.debug("Custom domain detected, looking up project", {
         host,
-        forwardedHost,
       });
 
       const lookupResult = await withSpan(

--- a/src/server/runtime-handler/project-resolution.ts
+++ b/src/server/runtime-handler/project-resolution.ts
@@ -75,8 +75,13 @@ interface RequestHeaders {
  * Extract project-related headers from a request.
  */
 export function extractRequestHeaders(req: Request, url: URL): RequestHeaders {
+  const forwardedHost = req.headers.get("x-forwarded-host") ?? undefined;
+  const host = forwardedHost ?? req.headers.get("host") ?? url.host;
+  const parsedDomain = parseProjectDomain(host);
+  const projectSlugHeader = req.headers.get("x-project-slug")?.trim() || undefined;
+
   return {
-    projectSlug: req.headers.get("x-project-slug") ?? undefined,
+    projectSlug: projectSlugHeader ?? parsedDomain.slug ?? undefined,
     projectId: req.headers.get("x-project-id") ?? undefined,
     releaseId: req.headers.get("x-release-id") ?? undefined,
     branchId: req.headers.get("x-branch-id") ?? undefined,
@@ -146,12 +151,13 @@ export async function resolveProject(
   const deps = getDeps();
   const parsedDomain = deps.parseProjectDomain(host);
   const configuredSlug = opts.config?.fs?.veryfront?.projectSlug;
+  const resolvedSlugBeforeDefault = opts.reqCtx.slug || opts.wsSlugOverride || configuredSlug;
 
   // Initial resolution from headers/config/context
   // Use || for slug (empty string should fall through to defaults)
-  let projectSlug = opts.reqCtx.slug || opts.wsSlugOverride || configuredSlug ||
-    opts.defaultProjectSlug;
-  let projectId: string | undefined = headers.projectId ?? opts.defaultProjectId;
+  let projectSlug = resolvedSlugBeforeDefault || opts.defaultProjectSlug;
+  let projectId: string | undefined = headers.projectId ??
+    (!resolvedSlugBeforeDefault ? opts.defaultProjectId : undefined);
   let releaseId: string | undefined = headers.releaseId;
   let environmentName: string | undefined;
   let proxyEnv = parseProxyEnvironment(headers.environment ?? null);

--- a/src/server/runtime-handler/project-resolution.ts
+++ b/src/server/runtime-handler/project-resolution.ts
@@ -71,8 +71,16 @@ interface RequestHeaders {
   projectPath: string | undefined;
 }
 
+function parseForwardedHost(raw: string | null): string | undefined {
+  if (!raw) return undefined;
+  // x-forwarded-host can be a comma-separated list when multiple proxies
+  // are chained. Take the first (client-facing) entry and trim whitespace.
+  const first = raw.split(",")[0]?.trim();
+  return first || undefined;
+}
+
 function getEffectiveHost(req: Request, url: URL): string {
-  const forwardedHost = req.headers.get("x-forwarded-host") ?? undefined;
+  const forwardedHost = parseForwardedHost(req.headers.get("x-forwarded-host"));
   return forwardedHost ?? req.headers.get("host") ?? url.host;
 }
 
@@ -163,8 +171,13 @@ export async function resolveProject(
   // Initial resolution from headers/config/context
   // Use || for slug (empty string should fall through to defaults)
   let projectSlug = resolvedSlugBeforeDefault || opts.defaultProjectSlug;
+  // Only apply defaultProjectId when the resolved slug matches the default
+  // or no slug was resolved at all. Suppressing the ID when a *different*
+  // slug was resolved prevents cache/invalidation state splits.
+  const slugMatchesDefault = !resolvedSlugBeforeDefault ||
+    resolvedSlugBeforeDefault === opts.defaultProjectSlug;
   let projectId: string | undefined = headers.projectId ??
-    (!resolvedSlugBeforeDefault ? opts.defaultProjectId : undefined);
+    (slugMatchesDefault ? opts.defaultProjectId : undefined);
   let releaseId: string | undefined = headers.releaseId;
   let environmentName: string | undefined;
   let proxyEnv = parseProxyEnvironment(headers.environment ?? null);


### PR DESCRIPTION
## Summary
- fall back to the request URL host when the Host header is absent in proxy handling
- derive project slugs from forwarded hosts when explicit slug headers are missing or blank
- avoid applying the default project id when the request already resolved a different slug

## Verification
- `deno test --allow-all src/server/context/request-context.test.ts src/server/runtime-handler/project-resolution.test.ts src/proxy/handler.test.ts`
