### PR TITLE
Release v0.1.99

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.98",
+  "version": "0.1.99",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -3,7 +3,7 @@ import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.98";
+export const VERSION = "0.1.99";
 
 export function normalizeVeryfrontVersion(version: string | undefined): string | undefined {
   if (!version) return undefined;


### PR DESCRIPTION
## Summary
- publish a new stable release after the style artifact hotfix merged after v0.1.98 was cut
- bump the runtime version constant to stay in sync with the stable release version

## Why
v0.1.98 was published before the style artifact binding fix merged, so job-runner pulled a broken package even though main was fixed.