### PR TITLE
chore: upgrade es-module-lexer 1.5.0 → 2.0.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -237,7 +237,7 @@
     "rehype-stringify": "npm:rehype-stringify@10.0.1",
     "esbuild": "npm:esbuild@0.27.4",
     "esbuild/mod.js": "npm:esbuild@0.27.4",
-    "es-module-lexer": "npm:es-module-lexer@1.5.0",
+    "es-module-lexer": "npm:es-module-lexer@2.0.0",
     "gray-matter": "npm:gray-matter@4.0.3",
     "zod": "npm:zod@3.25.76",
     "mime-types": "npm:mime-types@2.1.35",

--- a/src/transforms/esm/lexer.ts
+++ b/src/transforms/esm/lexer.ts
@@ -60,7 +60,7 @@ export type ImportSpecifier = {
   ss: number; // Start of import statement
   se: number; // End of import statement
   d: number; // > -1 if dynamic import
-  a: number; // assert index
+  a: number; // import attribute index
 };
 
 function logParseError(error: unknown, code: string): void {


### PR DESCRIPTION
## Summary
- Upgrades es-module-lexer from 1.5.0 to 2.0.0
- Breaking change: import assertions removed, replaced by import attributes
- Only impact: `a` field in `ImportSpecifier` type comment updated ("assert index" → "import attribute index") — field is never read in our codebase

Part of supply chain security hardening (Phase 5).

## Test plan
- [x] ESM lexer tests pass (38 suites, 742 steps)
- [x] CI unit tests pass
- [x] CI integration tests pass