### PR TITLE
chore: upgrade tailwind-merge 2.6.0 → 3.5.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -275,7 +275,7 @@
     "@babel/types": "npm:@babel/types@7.29.0",
     "class-variance-authority": "npm:class-variance-authority@0.7.1",
     "clsx": "npm:clsx@2.1.1",
-    "tailwind-merge": "npm:tailwind-merge@2.6.0",
+    "tailwind-merge": "npm:tailwind-merge@3.5.0",
     "@kreuzberg/wasm": "npm:@kreuzberg/wasm@4.5.2",
     "#kreuzberg-wasm-glue": "npm:@kreuzberg/wasm@4.5.2/dist/pkg/kreuzberg_wasm.js"
   },


### PR DESCRIPTION
## Summary
- Upgrades tailwind-merge from 2.6.0 to 3.5.0
- Only API used is `twMerge()` in `src/react/components/ai/theme.ts` — unchanged in v3
- v3 aligns theme scale keys with Tailwind CSS v4

Part of supply chain security hardening (Phase 5).

## Test plan
- [x] `twMerge()` produces correct output with v3
- [x] CI unit tests pass