### PR TITLE
chore: upgrade mime-types 2.1.35 → 3.0.2

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -240,7 +240,7 @@
     "es-module-lexer": "npm:es-module-lexer@2.0.0",
     "gray-matter": "npm:gray-matter@4.0.3",
     "zod": "npm:zod@3.25.76",
-    "mime-types": "npm:mime-types@2.1.35",
+    "mime-types": "npm:mime-types@3.0.2",
     "mdast": "npm:@types/mdast@4.0.3",
     "hast": "npm:@types/hast@3.0.3",
     "unist": "npm:@types/unist@3.0.2",


### PR DESCRIPTION
## Summary
- Upgrades mime-types from 2.1.35 to 3.0.2
- API unchanged: `lookup()`, `charset()`, `extension()` all work identically
- v3 requires Node.js >=18 (satisfied by Deno runtime)
- Well-encapsulated in `src/platform/compat/media-types.ts` wrapper

Part of supply chain security hardening (Phase 5).

## Test plan
- [x] media-types.test.ts passes (17 steps)
- [x] CI unit tests pass