### PR TITLE
fix: migrate zod from v3 to v4

### DIFF
--- a/cli/commands/files/command.ts
+++ b/cli/commands/files/command.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+type SafeParseResult<T> = { success: true; data: T } | { success: false; error: z.ZodError };
 import { createFileSystem } from "veryfront/platform";
 import { dirname, normalize } from "veryfront/platform/path";
 import { withSpan } from "veryfront/observability/otlp-setup";
@@ -94,7 +95,7 @@ function normalizeProjectFilePath(remotePath: string): string {
 
 export function parseFilesListArgs(
   args: ParsedArgs,
-): z.SafeParseReturnType<unknown, FilesListOptions> {
+): SafeParseResult<FilesListOptions> {
   return FilesListArgsSchema.safeParse({
     projectSlug: getStringArg(args, "project", "p", "project-slug"),
     projectDir: getStringArg(args, "project-dir", "dir", "d"),
@@ -106,7 +107,7 @@ export function parseFilesListArgs(
 
 export function parseFilesGetArgs(
   args: ParsedArgs,
-): z.SafeParseReturnType<unknown, FilesGetOptions> {
+): SafeParseResult<FilesGetOptions> {
   return FilesGetArgsSchema.safeParse({
     projectSlug: getStringArg(args, "project", "p", "project-slug"),
     projectDir: getStringArg(args, "project-dir", "dir", "d"),
@@ -119,7 +120,7 @@ export function parseFilesGetArgs(
 
 export function parseFilesPutArgs(
   args: ParsedArgs,
-): z.SafeParseReturnType<unknown, FilesPutOptions> {
+): SafeParseResult<FilesPutOptions> {
   return FilesPutArgsSchema.safeParse({
     projectSlug: getStringArg(args, "project", "p", "project-slug"),
     projectDir: getStringArg(args, "project-dir", "dir", "d"),
@@ -132,7 +133,7 @@ export function parseFilesPutArgs(
 
 export function parseFilesDeleteArgs(
   args: ParsedArgs,
-): z.SafeParseReturnType<unknown, FilesDeleteOptions> {
+): SafeParseResult<FilesDeleteOptions> {
   return FilesDeleteArgsSchema.safeParse({
     projectSlug: getStringArg(args, "project", "p", "project-slug"),
     projectDir: getStringArg(args, "project-dir", "dir", "d"),

--- a/cli/commands/knowledge/command.ts
+++ b/cli/commands/knowledge/command.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+type SafeParseResult<T> = { success: true; data: T } | { success: false; error: z.ZodError };
 import { createFileSystem, getEnv } from "veryfront/platform";
 import { basename, extname, join, normalize, relative } from "veryfront/platform/path";
 import { withSpan } from "veryfront/observability/otlp-setup";
@@ -160,7 +161,7 @@ Subcommands:
 
 export function parseKnowledgeIngestArgs(
   args: ParsedArgs,
-): z.SafeParseReturnType<unknown, KnowledgeIngestOptions> {
+): SafeParseResult<KnowledgeIngestOptions> {
   return KnowledgeIngestArgsSchema.safeParse({
     projectSlug: getStringArg(args, "project", "p", "project-slug"),
     projectDir: getStringArg(args, "project-dir", "dir", "d"),

--- a/cli/commands/uploads/command.ts
+++ b/cli/commands/uploads/command.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+
+type SafeParseResult<T> = { success: true; data: T } | { success: false; error: z.ZodError };
 import { createFileSystem, cwd, lookupMimeType } from "veryfront/platform";
 import { dirname, join, normalize, resolve } from "veryfront/platform/path";
 import { withSpan } from "veryfront/observability/otlp-setup";
@@ -136,7 +138,7 @@ function normalizeUploadPath(uploadPath: string): string {
 
 export function parseUploadsListArgs(
   args: ParsedArgs,
-): z.SafeParseReturnType<unknown, UploadListOptions> {
+): SafeParseResult<UploadListOptions> {
   return UploadListArgsSchema.safeParse({
     projectSlug: getStringArg(args, "project", "p", "project-slug"),
     projectDir: getStringArg(args, "project-dir", "dir", "d"),
@@ -150,7 +152,7 @@ export function parseUploadsListArgs(
 
 export function parseUploadsPullArgs(
   args: ParsedArgs,
-): z.SafeParseReturnType<unknown, UploadPullOptions> {
+): SafeParseResult<UploadPullOptions> {
   return UploadPullArgsSchema.safeParse({
     projectSlug: getStringArg(args, "project", "p", "project-slug"),
     projectDir: getStringArg(args, "project-dir", "dir", "d"),
@@ -165,7 +167,7 @@ export function parseUploadsPullArgs(
 
 export function parseUploadsPutArgs(
   args: ParsedArgs,
-): z.SafeParseReturnType<unknown, UploadPutOptions> {
+): SafeParseResult<UploadPutOptions> {
   return UploadPutArgsSchema.safeParse({
     projectSlug: getStringArg(args, "project", "p", "project-slug"),
     projectDir: getStringArg(args, "project-dir", "dir", "d"),
@@ -179,7 +181,7 @@ export function parseUploadsPutArgs(
 
 export function parseUploadsDeleteArgs(
   args: ParsedArgs,
-): z.SafeParseReturnType<unknown, UploadDeleteOptions> {
+): SafeParseResult<UploadDeleteOptions> {
   return UploadDeleteArgsSchema.safeParse({
     projectSlug: getStringArg(args, "project", "p", "project-slug"),
     projectDir: getStringArg(args, "project-dir", "dir", "d"),

--- a/cli/mcp/jsonrpc.ts
+++ b/cli/mcp/jsonrpc.ts
@@ -87,7 +87,7 @@ export function errorResponse(
  */
 export const ToolsCallParamsSchema = z.object({
   name: z.string(),
-  arguments: z.record(z.unknown()).optional(),
+  arguments: z.record(z.string(), z.unknown()).optional(),
 });
 
 /**

--- a/cli/shared/args.ts
+++ b/cli/shared/args.ts
@@ -109,14 +109,16 @@ export function extractArgs<T extends z.ZodRawShape>(
  * }
  * ```
  */
-export function createArgParser<T extends z.ZodRawShape>(
-  schema: z.ZodObject<T>,
-  argMap: ArgMap<z.infer<z.ZodObject<T>>>,
-): (args: ParsedArgs) => z.SafeParseReturnType<unknown, z.infer<z.ZodObject<T>>> {
+// deno-lint-ignore no-explicit-any
+export function createArgParser<T = any>(
+  schema: z.ZodType<T>,
+  argMap: ArgMap<T>,
+): (args: ParsedArgs) => z.SafeParseReturnType<unknown, T> {
   return function parseArgs(
     args: ParsedArgs,
-  ): z.SafeParseReturnType<unknown, z.infer<z.ZodObject<T>>> {
-    return schema.safeParse(extractArgs(args, argMap));
+  ): z.SafeParseReturnType<unknown, T> {
+    // deno-lint-ignore no-explicit-any
+    return schema.safeParse(extractArgs(args, argMap as any)) as any;
   };
 }
 

--- a/cli/shared/args.ts
+++ b/cli/shared/args.ts
@@ -75,16 +75,16 @@ export function extractArg(
 /**
  * Extract all arguments according to an arg map
  */
-export function extractArgs(
+export function extractArgs<T>(
   args: ParsedArgs,
-  argMap: ArgMap<Record<string, unknown>>,
+  argMap: ArgMap<T>,
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
 
   for (const [field, spec] of Object.entries(argMap)) {
     if (!spec) continue;
 
-    const value = extractArg(args, spec);
+    const value = extractArg(args, spec as ArgSpec);
     if (value !== undefined) result[field] = value;
   }
 
@@ -114,14 +114,16 @@ export function extractArgs(
  * }
  * ```
  */
-// deno-lint-ignore no-explicit-any
-export function createArgParser<T = any>(
+export function createArgParser<T>(
   schema: z.ZodType<T>,
   argMap: ArgMap<T>,
 ): (args: ParsedArgs) => SafeParseResult<T> {
   return function parseArgs(args: ParsedArgs): SafeParseResult<T> {
-    // deno-lint-ignore no-explicit-any
-    return schema.safeParse(extractArgs(args, argMap as any)) as any;
+    const result = schema.safeParse(extractArgs(args, argMap));
+    if (result.success) {
+      return { success: true, data: result.data };
+    }
+    return { success: false, error: result.error };
   };
 }
 

--- a/cli/shared/args.ts
+++ b/cli/shared/args.ts
@@ -9,6 +9,11 @@
 import { z } from "zod";
 import type { ParsedArgs } from "./types.ts";
 
+/** Compat type for safeParse result (SafeParseReturnType removed in zod v4). */
+export type SafeParseResult<T> =
+  | { success: true; data: T; error?: never }
+  | { success: false; data?: never; error: z.ZodError };
+
 /**
  * Argument specification for a single option
  */
@@ -70,9 +75,9 @@ export function extractArg(
 /**
  * Extract all arguments according to an arg map
  */
-export function extractArgs<T extends z.ZodRawShape>(
+export function extractArgs(
   args: ParsedArgs,
-  argMap: ArgMap<z.infer<z.ZodObject<T>>>,
+  argMap: ArgMap<Record<string, unknown>>,
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
 
@@ -113,10 +118,8 @@ export function extractArgs<T extends z.ZodRawShape>(
 export function createArgParser<T = any>(
   schema: z.ZodType<T>,
   argMap: ArgMap<T>,
-): (args: ParsedArgs) => z.SafeParseReturnType<unknown, T> {
-  return function parseArgs(
-    args: ParsedArgs,
-  ): z.SafeParseReturnType<unknown, T> {
+): (args: ParsedArgs) => SafeParseResult<T> {
+  return function parseArgs(args: ParsedArgs): SafeParseResult<T> {
     // deno-lint-ignore no-explicit-any
     return schema.safeParse(extractArgs(args, argMap as any)) as any;
   };
@@ -127,7 +130,7 @@ export function createArgParser<T = any>(
  * Eliminates the repeated parse-validate-throw boilerplate in handlers.
  */
 export function parseArgsOrThrow<T>(
-  parser: (args: ParsedArgs) => z.SafeParseReturnType<unknown, T>,
+  parser: (args: ParsedArgs) => SafeParseResult<T>,
   commandName: string,
   args: ParsedArgs,
 ): T {

--- a/cli/shared/handler-utils.ts
+++ b/cli/shared/handler-utils.ts
@@ -1,5 +1,4 @@
 import { cwd } from "veryfront/platform";
-import type { z } from "zod";
 import { parseArgsOrThrow, type SafeParseResult } from "./args.ts";
 import type { ParsedArgs } from "./types.ts";
 import { showLogo } from "#cli/utils";

--- a/cli/shared/handler-utils.ts
+++ b/cli/shared/handler-utils.ts
@@ -1,10 +1,10 @@
 import { cwd } from "veryfront/platform";
 import type { z } from "zod";
-import { parseArgsOrThrow } from "./args.ts";
+import { parseArgsOrThrow, type SafeParseResult } from "./args.ts";
 import type { ParsedArgs } from "./types.ts";
 import { showLogo } from "#cli/utils";
 
-type ArgParser<T> = (args: ParsedArgs) => z.SafeParseReturnType<unknown, T>;
+type ArgParser<T> = (args: ParsedArgs) => SafeParseResult<T>;
 
 export async function handleProjectDirCommand<T extends { projectDir: string }>(
   args: ParsedArgs,

--- a/cli/templates/features/ai/files/app/api/chat/route.ts
+++ b/cli/templates/features/ai/files/app/api/chat/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: Request): Promise<Response> {
   } catch (error) {
     if (error instanceof z.ZodError) {
       return Response.json(
-        { error: "Invalid request", details: error.errors },
+        { error: "Invalid request", details: error.issues },
         { status: 400 },
       );
     }

--- a/cli/templates/integrations/supabase/files/tools/update-row.ts
+++ b/cli/templates/integrations/supabase/files/tools/update-row.ts
@@ -15,7 +15,7 @@ export default tool({
       .record(z.unknown())
       .optional()
       .describe('Filter conditions to match rows to update (e.g., {"status": "pending"})'),
-    data: z.record(z.unknown()).describe("The data to update as key-value pairs"),
+    data: z.record(z.string(), z.unknown()).describe("The data to update as key-value pairs"),
   }),
   async execute({ tableName, id, filter, data }) {
     if (id == null && filter == null) {

--- a/deno.json
+++ b/deno.json
@@ -239,7 +239,7 @@
     "esbuild/mod.js": "npm:esbuild@0.27.4",
     "es-module-lexer": "npm:es-module-lexer@2.0.0",
     "gray-matter": "npm:gray-matter@4.0.3",
-    "zod": "npm:zod@3.25.76",
+    "zod": "npm:zod@4.3.6",
     "mime-types": "npm:mime-types@3.0.2",
     "mdast": "npm:@types/mdast@4.0.3",
     "hast": "npm:@types/hast@3.0.3",

--- a/src/agent/chat-handler.ts
+++ b/src/agent/chat-handler.ts
@@ -402,7 +402,7 @@ export function createChatHandler(
         return Response.json(
           {
             error: "Invalid request",
-            details: error.errors.map((e) => ({ path: e.path, message: e.message })),
+            details: error.issues.map((e) => ({ path: e.path, message: e.message })),
           },
           { status: 400 },
         );

--- a/src/agent/schemas/agent.schema.ts
+++ b/src/agent/schemas/agent.schema.ts
@@ -28,14 +28,14 @@ export const ToolCallPartWithArgsSchema = z.object({
   type: z.string().regex(/^tool-.+$/),
   toolCallId: z.string(),
   toolName: z.string(),
-  args: z.record(z.unknown()),
+  args: z.record(z.string(), z.unknown()),
 });
 
 export const ToolCallPartWithInputSchema = z.object({
   type: z.string().regex(/^tool-.+$/),
   toolCallId: z.string(),
   toolName: z.string(),
-  input: z.record(z.unknown()),
+  input: z.record(z.string(), z.unknown()),
 });
 
 export const ToolCallPartSchema = z.union([
@@ -60,7 +60,7 @@ export const MessagePartSchema = z.union([
     type: z.literal("tool-call"),
     toolCallId: z.string(),
     toolName: z.string(),
-    args: z.record(z.unknown()),
+    args: z.record(z.string(), z.unknown()),
   }),
   ToolResultPartSchema,
 ]);
@@ -70,19 +70,19 @@ export const MessageSchema = z.object({
   role: z.enum(["user", "assistant", "system", "tool"]),
   parts: z.array(MessagePartSchema),
   timestamp: z.number().int().nonnegative().optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export const StreamToolCallSchema = z.object({
   id: z.string(),
   name: z.string(),
-  arguments: z.record(z.unknown()),
+  arguments: z.record(z.string(), z.unknown()),
 });
 
 export const ToolCallSchema = z.object({
   id: z.string(),
   name: z.string(),
-  args: z.record(z.unknown()),
+  args: z.record(z.string(), z.unknown()),
   status: z.enum(["pending", "executing", "completed", "error"]),
   result: z.unknown().optional(),
   error: z.string().optional(),
@@ -102,16 +102,16 @@ export const AgentResponseSchema = z.object({
       totalTokens: z.number().int().nonnegative(),
     })
     .optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export const AgentContextSchema = z.object({
   agentId: z.string(),
   model: z.string().optional(),
   input: z.union([z.string(), z.array(MessageSchema)]),
-  data: z.record(z.unknown()).optional(),
+  data: z.record(z.string(), z.unknown()).optional(),
   platform: z.any(), // Platform type is complex
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 // Inferred types

--- a/src/channels/invoke.ts
+++ b/src/channels/invoke.ts
@@ -28,7 +28,7 @@ const channelInvokeHistoryMessageSchema = z.object({
   id: z.string(),
   role: z.enum(["user", "assistant", "system", "tool"]),
   parts: z.array(rawHistoryPartSchema),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
   createdAt: z.string().optional(),
 });
 
@@ -79,7 +79,7 @@ const channelToolCallPartSchema = z.object({
   type: z.literal("tool_call"),
   id: z.string(),
   name: z.string(),
-  input: z.record(z.unknown()),
+  input: z.record(z.string(), z.unknown()),
   state: z.enum(["streaming", "pending", "completed", "error"]),
 });
 

--- a/src/config/schemas/config.schema.ts
+++ b/src/config/schemas/config.schema.ts
@@ -142,7 +142,7 @@ export const veryfrontConfigSchema = z
         importMap: z
           .object({
             imports: z.record(z.string(), z.string()).optional(),
-            scopes: z.record(z.string(), z.record(z.string())).optional(),
+            scopes: z.record(z.string(), z.record(z.string(), z.string())).optional(),
           })
           .partial()
           .optional(),
@@ -366,6 +366,7 @@ export const veryfrontConfigSchema = z
       .object({
         enabled: z.boolean().optional(),
         providers: z.record(
+          z.string(),
           z.object({
             apiKey: z.string().optional(),
             baseURL: z.string().optional(),

--- a/src/config/schemas/config.schema.ts
+++ b/src/config/schemas/config.schema.ts
@@ -57,7 +57,7 @@ export const veryfrontConfigSchema = z
     layout: z.union([z.string(), z.literal(false)]).optional(),
     /** Path to the app wrapper component (e.g., 'components/app.tsx'), or false to disable */
     app: z.union([z.string(), z.literal(false)]).optional(),
-    theme: z.object({ colors: z.record(z.string()).optional() }).partial().optional(),
+    theme: z.object({ colors: z.record(z.string(), z.string()).optional() }).partial().optional(),
     build: z
       .object({
         outDir: z.string().optional(),
@@ -141,8 +141,8 @@ export const veryfrontConfigSchema = z
       .object({
         importMap: z
           .object({
-            imports: z.record(z.string()).optional(),
-            scopes: z.record(z.record(z.string())).optional(),
+            imports: z.record(z.string(), z.string()).optional(),
+            scopes: z.record(z.string(), z.record(z.string())).optional(),
           })
           .partial()
           .optional(),
@@ -158,7 +158,7 @@ export const veryfrontConfigSchema = z
           })
           .partial()
           .optional(),
-        csp: z.record(z.array(z.string())).optional(),
+        csp: z.record(z.string(), z.array(z.string())).optional(),
         remoteHosts: z.array(z.string().url()).optional(),
         cors: corsSchema.optional(),
         /**
@@ -326,7 +326,7 @@ export const veryfrontConfigSchema = z
           .optional(),
         memory: z
           .object({
-            files: z.record(z.union([z.string(), z.instanceof(Uint8Array)])).optional(),
+            files: z.record(z.string(), z.union([z.string(), z.instanceof(Uint8Array)])).optional(),
           })
           .partial()
           .optional(),
@@ -462,7 +462,7 @@ export const veryfrontConfigSchema = z
         /** Extend the Tailwind theme (merged with veryfront defaults) */
         theme: z
           .object({
-            extend: z.record(z.unknown()).optional(),
+            extend: z.record(z.string(), z.unknown()).optional(),
           })
           .partial()
           .optional(),

--- a/src/data/schemas/data.schema.ts
+++ b/src/data/schemas/data.schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 /** Context passed to data fetching functions */
 export const DataContextSchema = z.object({
-  params: z.record(z.union([z.string(), z.array(z.string())])),
+  params: z.record(z.string(), z.union([z.string(), z.array(z.string())])),
   query: z.instanceof(URLSearchParams),
   request: z.instanceof(Request),
   url: z.instanceof(URL),
@@ -22,7 +22,7 @@ export const DataResultSchema = z.object({
 });
 
 export const StaticPathEntrySchema = z.object({
-  params: z.record(z.union([z.string(), z.array(z.string())])),
+  params: z.record(z.string(), z.union([z.string(), z.array(z.string())])),
 });
 
 export const StaticPathsResultSchema = z.object({

--- a/src/html/schemas/html.schema.ts
+++ b/src/html/schemas/html.schema.ts
@@ -9,7 +9,7 @@ export const pageTypeSchema = z.enum(["mdx", "md", "tsx", "jsx", "ts", "js"]);
 export const HTMLGenerationOptionsSchema = z.object({
   mode: z.enum(["development", "production"]),
   config: z.any(), // VeryfrontConfig is complex, use any
-  importMap: z.record(z.string()).optional(),
+  importMap: z.record(z.string(), z.string()).optional(),
   nestedLayouts: z
     .array(
       z.object({
@@ -25,8 +25,8 @@ export const HTMLGenerationOptionsSchema = z.object({
   nonce: z.string().optional(),
   projectDir: z.string().optional(),
   globalCSS: z.string().optional(),
-  frontmatter: z.record(z.unknown()).optional(),
-  layoutProps: z.record(z.record(z.unknown())).optional(),
+  frontmatter: z.record(z.string(), z.unknown()).optional(),
+  layoutProps: z.record(z.string(), z.record(z.unknown())).optional(),
   studioEmbed: z.boolean().optional(),
   projectId: z.string().optional(),
   pageId: z.string().optional(),
@@ -51,8 +51,8 @@ export const HTMLGenerationOptionsSchema = z.object({
 
 export const HydrationDataSchema = z.object({
   slug: z.string(),
-  props: z.record(z.unknown()),
-  params: z.record(z.union([z.string(), z.array(z.string())])),
+  props: z.record(z.string(), z.unknown()),
+  params: z.record(z.string(), z.union([z.string(), z.array(z.string())])),
   layouts: z.array(
     z.object({
       kind: z.string(),

--- a/src/html/schemas/html.schema.ts
+++ b/src/html/schemas/html.schema.ts
@@ -26,7 +26,7 @@ export const HTMLGenerationOptionsSchema = z.object({
   projectDir: z.string().optional(),
   globalCSS: z.string().optional(),
   frontmatter: z.record(z.string(), z.unknown()).optional(),
-  layoutProps: z.record(z.string(), z.record(z.unknown())).optional(),
+  layoutProps: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
   studioEmbed: z.boolean().optional(),
   projectId: z.string().optional(),
   pageId: z.string().optional(),

--- a/src/integrations/schema.ts
+++ b/src/integrations/schema.ts
@@ -92,7 +92,7 @@ export const OAuthConfigSchema = z.object({
   additionalAuthParams: z.record(z.string(), z.string()).optional(),
   fields: z.array(OAuthFieldSchema).optional(),
   envVars: z
-    .record(z.object({ description: z.string(), required: z.boolean() }))
+    .record(z.string(), z.object({ description: z.string(), required: z.boolean() }))
     .optional(),
   keyName: z.string().optional(),
   headerName: z.string().optional(),

--- a/src/integrations/schema.ts
+++ b/src/integrations/schema.ts
@@ -88,8 +88,8 @@ export const OAuthConfigSchema = z.object({
   requiredApis: z
     .array(z.object({ name: z.string(), enableUrl: z.string() }))
     .optional(),
-  additionalParams: z.record(z.string()).optional(),
-  additionalAuthParams: z.record(z.string()).optional(),
+  additionalParams: z.record(z.string(), z.string()).optional(),
+  additionalAuthParams: z.record(z.string(), z.string()).optional(),
   fields: z.array(OAuthFieldSchema).optional(),
   envVars: z
     .record(z.object({ description: z.string(), required: z.boolean() }))
@@ -127,7 +127,7 @@ export const IntegrationConfigSchema = z.object({
   tools: z.array(IntegrationToolSchema),
   prompts: z.array(IntegrationPromptSchema).optional(),
   suggestedWith: z.array(z.string()).optional(),
-  dependencies: z.record(z.string()).optional(),
+  dependencies: z.record(z.string(), z.string()).optional(),
   category: z.string().optional(),
 });
 

--- a/src/integrations/tool-factory.ts
+++ b/src/integrations/tool-factory.ts
@@ -42,7 +42,7 @@ function paramTypeToZod(
       schema = z.array(z.string()).describe(description);
       break;
     case "object":
-      schema = z.record(z.unknown()).describe(description);
+      schema = z.record(z.string(), z.unknown()).describe(description);
       break;
     case "array":
       schema = z.array(z.unknown()).describe(description);

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -17,7 +17,7 @@ import {
 import { AgentRunCancelledError, type AgentRunSessionManager } from "./session-manager.ts";
 import type { RuntimeRunAgentInput } from "./schema.ts";
 
-const anyObjectSchema = z.record(z.unknown());
+const anyObjectSchema = z.record(z.string(), z.unknown());
 
 export interface RuntimeAgentStreamExecutionDeps {
   sessionManager: AgentRunSessionManager;

--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -34,7 +34,7 @@ export const ClientToolNameSchema = z
 export const RuntimeInjectedToolSchema = z.object({
   name: ClientToolNameSchema,
   description: z.string().max(1024).optional(),
-  parameters: z.record(z.unknown()).optional().refine(
+  parameters: z.record(z.string(), z.unknown()).optional().refine(
     (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_TOOL_PARAMETERS_BYTES),
     { message: "Tool parameters must be less than 16 KB" },
   ),
@@ -49,7 +49,7 @@ export const RuntimeContextItemSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("json"),
     title: z.string().max(256).optional(),
-    data: z.record(z.unknown()).refine(
+    data: z.record(z.string(), z.unknown()).refine(
       (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_ITEM_BYTES),
       { message: "JSON context item must be less than 16 KB" },
     ),
@@ -88,7 +88,7 @@ export const RuntimeRunAgentInputSchema = z.object({
       id: z.string().min(1),
       role: z.enum(["user", "assistant", "system", "tool"]),
       parts: z.array(z.object({ type: z.string().min(1) }).passthrough()).default([]),
-      metadata: z.record(z.unknown()).optional(),
+      metadata: z.record(z.string(), z.unknown()).optional(),
       createdAt: z.string().optional(),
     }),
   ).max(MAX_RUNTIME_MESSAGES),
@@ -98,7 +98,7 @@ export const RuntimeRunAgentInputSchema = z.object({
     { message: "context must be less than 64 KB total" },
   ),
   agentSource: RuntimeAgentSourceContextSchema.optional(),
-  forwardedProps: z.record(z.unknown()).optional().refine(
+  forwardedProps: z.record(z.string(), z.unknown()).optional().refine(
     (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_FORWARDED_PROPS_BYTES),
     { message: "forwardedProps must be less than 64 KB" },
   ),

--- a/src/jobs/schemas.ts
+++ b/src/jobs/schemas.ts
@@ -20,7 +20,7 @@ export const PageInfoSchema = z.object({
   prev: z.string().nullable(),
 });
 
-const JsonObjectSchema = z.record(z.unknown());
+const JsonObjectSchema = z.record(z.string(), z.unknown());
 const KnowledgeIngestSkipReasonSchema = z.enum([
   "hidden_path",
   "ignored_directory",
@@ -159,7 +159,7 @@ export const JobEventSchema = z.object({
   service: z.string(),
   trace_id: z.string().optional(),
   request_id: z.string().optional(),
-  metadata: z.record(z.string()).optional(),
+  metadata: z.record(z.string(), z.string()).optional(),
 });
 
 export const JobEventsResponseSchema = z.object({

--- a/src/mcp/schemas/mcp.schema.ts
+++ b/src/mcp/schemas/mcp.schema.ts
@@ -6,7 +6,7 @@ export const MCPServerConfigSchema = z.object({
   auth: z
     .object({
       type: z.enum(["bearer", "api-key", "none"]),
-      validate: z.function(z.tuple([z.string()]), z.union([z.promise(z.boolean()), z.boolean()]))
+      validate: z.function()
         .optional(),
     })
     .optional(),

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -424,7 +424,9 @@ export class MCPServer {
       return false;
     }
 
-    return await (auth.validate as (token: string) => Promise<boolean>)(token);
+    // z.function() in v4 doesn't carry arg/return types — cast to expected signature
+    const validate = auth.validate as (token: string) => Promise<boolean>;
+    return await validate(token);
   }
 
   private handleCORS(requestOrigin?: string | null): Response {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -424,7 +424,7 @@ export class MCPServer {
       return false;
     }
 
-    return await auth.validate(token);
+    return await (auth.validate as (token: string) => Promise<boolean>)(token);
   }
 
   private handleCORS(requestOrigin?: string | null): Response {

--- a/src/oauth/schemas/oauth.schema.ts
+++ b/src/oauth/schemas/oauth.schema.ts
@@ -9,8 +9,8 @@ export const OAuthProviderConfigSchema = z.object({
   revocationUrl: z.string().url().optional(),
   clientIdEnvVar: z.string(),
   clientSecretEnvVar: z.string(),
-  additionalAuthParams: z.record(z.string()).optional(),
-  additionalTokenParams: z.record(z.string()).optional(),
+  additionalAuthParams: z.record(z.string(), z.string()).optional(),
+  additionalTokenParams: z.record(z.string(), z.string()).optional(),
   useBasicAuth: z.boolean().optional(),
   tokenResponseMapping: z
     .object({
@@ -46,7 +46,7 @@ export const OAuthStateSchema = z.object({
   redirectUri: z.string().url(),
   scopes: z.array(z.string()),
   createdAt: z.number().int(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export const TokenExchangeResultSchema = z.object({
@@ -60,7 +60,7 @@ export const AuthorizationUrlOptionsSchema = z.object({
   scopes: z.array(z.string()).optional(),
   state: z.string().optional(),
   usePkce: z.boolean().optional(),
-  additionalParams: z.record(z.string()).optional(),
+  additionalParams: z.record(z.string(), z.string()).optional(),
   redirectUri: z.string().optional(),
 });
 

--- a/src/platform/adapters/fs/veryfront/proxy-manager.ts
+++ b/src/platform/adapters/fs/veryfront/proxy-manager.ts
@@ -158,7 +158,7 @@ export class ProxyFSAdapterManager {
 
     if (!validationResult.success) {
       logger.error("Validation failed", {
-        errors: validationResult.error.errors,
+        errors: validationResult.error.issues,
         params: {
           projectSlug,
           productionMode: effectiveProductionMode,

--- a/src/platform/adapters/veryfront-api-client.test.ts
+++ b/src/platform/adapters/veryfront-api-client.test.ts
@@ -155,7 +155,7 @@ describe("VeryfrontApiClient", () => {
               new Response(
                 JSON.stringify({
                   data: [{
-                    id: "00000000-0000-0000-0000-000000000001",
+                    id: "00000000-0000-4000-a000-000000000001",
                     name: "Test",
                     slug: "test-project",
                     created_at: "2024-01-01",
@@ -229,7 +229,7 @@ describe("VeryfrontApiClient", () => {
           return Promise.resolve(
             new Response(
               JSON.stringify({
-                id: "00000000-0000-0000-0000-000000000001",
+                id: "00000000-0000-4000-a000-000000000001",
                 name: "Test",
                 slug: "test-project",
                 created_at: "2024-01-01",
@@ -261,7 +261,7 @@ describe("VeryfrontApiClient", () => {
               new Response(
                 JSON.stringify({
                   data: [{
-                    id: "00000000-0000-0000-0000-000000000001",
+                    id: "00000000-0000-4000-a000-000000000001",
                     name: "Test",
                     slug: "test-project",
                     created_at: "2024-01-01",
@@ -311,7 +311,7 @@ describe("VeryfrontApiClient", () => {
           return Promise.resolve(
             new Response(
               JSON.stringify({
-                id: "00000000-0000-0000-0000-000000000001",
+                id: "00000000-0000-4000-a000-000000000001",
                 name: "Test",
                 slug: "test-project",
                 created_at: "2024-01-01",
@@ -356,7 +356,7 @@ describe("VeryfrontApiClient", () => {
           return Promise.resolve(
             new Response(
               JSON.stringify({
-                id: "00000000-0000-0000-0000-000000000001",
+                id: "00000000-0000-4000-a000-000000000001",
                 name: "Test",
                 slug: "test-project",
                 created_at: "2024-01-01",

--- a/src/platform/adapters/veryfront-api-client/schemas/api.schema.ts
+++ b/src/platform/adapters/veryfront-api-client/schemas/api.schema.ts
@@ -54,7 +54,7 @@ export const ProjectSchema = z.object({
   provider_id: z.string().nullish(),
   layout: z.string().nullish(),
   layout_id: z.string().nullish(),
-  config: z.union([z.string(), z.record(z.unknown())]).optional(),
+  config: z.union([z.string(), z.record(z.string(), z.unknown())]).optional(),
 });
 
 export const ProjectFileSchema = z.object({

--- a/src/prompt/factory.ts
+++ b/src/prompt/factory.ts
@@ -17,9 +17,9 @@ export function prompt(config: PromptConfig): Prompt {
       }
 
       if (config.generate) {
-        return (config.generate as (vars: Record<string, unknown>) => string | Promise<string>)(
-          vars,
-        );
+        // z.function() in v4 doesn't carry arg/return types — cast to expected signature
+        type GenerateFn = (vars: Record<string, unknown>) => string | Promise<string>;
+        return (config.generate as GenerateFn)(vars);
       }
 
       throw toError(

--- a/src/prompt/factory.ts
+++ b/src/prompt/factory.ts
@@ -17,7 +17,9 @@ export function prompt(config: PromptConfig): Prompt {
       }
 
       if (config.generate) {
-        return (config.generate as (vars: Record<string, unknown>) => string | Promise<string>)(vars);
+        return (config.generate as (vars: Record<string, unknown>) => string | Promise<string>)(
+          vars,
+        );
       }
 
       throw toError(

--- a/src/prompt/factory.ts
+++ b/src/prompt/factory.ts
@@ -17,7 +17,7 @@ export function prompt(config: PromptConfig): Prompt {
       }
 
       if (config.generate) {
-        return config.generate(vars);
+        return (config.generate as (vars: Record<string, unknown>) => string | Promise<string>)(vars);
       }
 
       throw toError(

--- a/src/prompt/schemas/prompt.schema.ts
+++ b/src/prompt/schemas/prompt.schema.ts
@@ -5,7 +5,7 @@ export const PromptConfigSchema = z.object({
   description: z.string(),
   content: z.string().optional(),
   generate: z
-    .function(z.tuple([z.record(z.unknown())]), z.union([z.string(), z.promise(z.string())]))
+    .function(z.tuple([z.record(z.string(), z.unknown())]), z.union([z.string(), z.promise(z.string())]))
     .optional(),
   /** Example message text to use as a chat suggestion */
   suggestion: z.string().optional(),

--- a/src/prompt/schemas/prompt.schema.ts
+++ b/src/prompt/schemas/prompt.schema.ts
@@ -4,12 +4,7 @@ export const PromptConfigSchema = z.object({
   id: z.string().optional(),
   description: z.string(),
   content: z.string().optional(),
-  generate: z
-    .function(
-      z.tuple([z.record(z.string(), z.unknown())]),
-      z.union([z.string(), z.promise(z.string())]),
-    )
-    .optional(),
+  generate: z.function().optional(),
   /** Example message text to use as a chat suggestion */
   suggestion: z.string().optional(),
 });

--- a/src/prompt/schemas/prompt.schema.ts
+++ b/src/prompt/schemas/prompt.schema.ts
@@ -5,7 +5,10 @@ export const PromptConfigSchema = z.object({
   description: z.string(),
   content: z.string().optional(),
   generate: z
-    .function(z.tuple([z.record(z.string(), z.unknown())]), z.union([z.string(), z.promise(z.string())]))
+    .function(
+      z.tuple([z.record(z.string(), z.unknown())]),
+      z.union([z.string(), z.promise(z.string())]),
+    )
     .optional(),
   /** Example message text to use as a chat suggestion */
   suggestion: z.string().optional(),

--- a/src/provider/schemas/provider.schema.ts
+++ b/src/provider/schemas/provider.schema.ts
@@ -4,7 +4,7 @@ export const ProviderConfigSchema = z.object({
   apiKey: z.string().optional(),
   baseURL: z.string().url().optional(),
   organizationId: z.string().optional(),
-  options: z.record(z.unknown()).optional(),
+  options: z.record(z.string(), z.unknown()).optional(),
 });
 
 export const OpenAIConfigSchema = ProviderConfigSchema.extend({
@@ -62,7 +62,7 @@ export const CompletionRequestSchema = z.object({
 const completionToolCallSchema = z.object({
   id: z.string(),
   name: z.string(),
-  arguments: z.record(z.unknown()),
+  arguments: z.record(z.string(), z.unknown()),
 });
 
 export const CompletionResponseSchema = z.object({

--- a/src/routing/api/openapi/mcp-tools.ts
+++ b/src/routing/api/openapi/mcp-tools.ts
@@ -98,7 +98,7 @@ function buildInputSchema(operation: OpenAPIOperation): z.ZodTypeAny {
   addParamGroup(shape, params, "header", "headers", "Request headers");
 
   if (operation.requestBody) {
-    shape.body = z.record(z.unknown()).optional().describe("Request body (JSON)");
+    shape.body = z.record(z.string(), z.unknown()).optional().describe("Request body (JSON)");
   }
 
   return z.object(shape);

--- a/src/schemas/primitives.ts
+++ b/src/schemas/primitives.ts
@@ -24,7 +24,7 @@ export const jsonValue: z.ZodType<
     z.boolean(),
     z.null(),
     z.array(jsonValue),
-    z.record(jsonValue),
+    z.record(z.string(), jsonValue),
   ])
 );
 export type JsonValue = z.infer<typeof jsonValue>;

--- a/src/security/input-validation/parsers.ts
+++ b/src/security/input-validation/parsers.ts
@@ -31,7 +31,7 @@ export async function parseJsonBody<T>(
     if (!(error instanceof z.ZodError)) throw error;
 
     throw createValidationError("Validation failed", {
-      errors: error.errors.map((e) => ({
+      errors: error.issues.map((e) => ({
         path: e.path.join("."),
         message: e.message,
         code: e.code,
@@ -69,7 +69,7 @@ export async function parseFormData<T>(
     if (!(error instanceof z.ZodError)) throw error;
 
     throw createValidationError("Form validation failed", {
-      errors: error.errors,
+      errors: error.issues,
     });
   }
 }
@@ -100,7 +100,7 @@ export function parseQueryParams<T>(request: Request, schema: z.ZodSchema<T>): T
     if (!(error instanceof z.ZodError)) throw error;
 
     throw createValidationError("Query parameter validation failed", {
-      errors: error.errors,
+      errors: error.issues,
     });
   }
 }

--- a/src/skill/tools.ts
+++ b/src/skill/tools.ts
@@ -157,7 +157,9 @@ export function createExecuteSkillScriptTool(): Tool {
       skillId: z.string().describe("The ID of the skill"),
       script: z.string().describe("Relative path to the script (e.g. 'scripts/setup.sh')"),
       args: z.array(z.string()).optional().describe("Arguments to pass to the script"),
-      env: z.record(z.string(), z.string()).optional().describe("Environment variables for the script"),
+      env: z.record(z.string(), z.string()).optional().describe(
+        "Environment variables for the script",
+      ),
       timeoutMs: z
         .number()
         .int()

--- a/src/skill/tools.ts
+++ b/src/skill/tools.ts
@@ -157,7 +157,7 @@ export function createExecuteSkillScriptTool(): Tool {
       skillId: z.string().describe("The ID of the skill"),
       script: z.string().describe("Relative path to the script (e.g. 'scripts/setup.sh')"),
       args: z.array(z.string()).optional().describe("Arguments to pass to the script"),
-      env: z.record(z.string()).optional().describe("Environment variables for the script"),
+      env: z.record(z.string(), z.string()).optional().describe("Environment variables for the script"),
       timeoutMs: z
         .number()
         .int()

--- a/src/studio/schemas/studio.schema.ts
+++ b/src/studio/schemas/studio.schema.ts
@@ -87,7 +87,7 @@ export const MessageFromRendererSchema = z.discriminatedUnion("action", [
     id: z.string().optional(),
     isInitialLoad: z.boolean().optional(),
     hasError: z.boolean().optional(),
-    nodesStore: z.record(z.unknown()).optional(),
+    nodesStore: z.record(z.string(), z.unknown()).optional(),
     errors: z.array(ErrorMessageSchema).optional(),
     warnings: z.array(ErrorMessageSchema).optional(),
   }),
@@ -124,7 +124,7 @@ export const MessageFromRendererSchema = z.discriminatedUnion("action", [
     url: z.string(),
     projectId: z.string(),
     id: z.string(),
-    params: z.record(z.string()),
+    params: z.record(z.string(), z.string()),
   }),
   z.object({
     action: z.literal("colorMode"),

--- a/src/tool/factory.ts
+++ b/src/tool/factory.ts
@@ -16,7 +16,9 @@ interface ZodLikeSchema {
 function hasValidZodTypeName(schema: unknown): schema is ZodLikeSchema {
   if (schema === null || typeof schema !== "object") return false;
   if (!("_def" in schema)) return false;
-  return !!(schema as ZodLikeSchema)._def?.typeName;
+  // zod v3 uses _def.typeName, v4 uses _def.type
+  const def = (schema as ZodLikeSchema)._def;
+  return !!(def?.typeName ?? (def as Record<string, unknown>)?.type);
 }
 
 function getSchemaShape(schema: ZodLikeSchema): Record<string, unknown> | null {

--- a/src/tool/factory.ts
+++ b/src/tool/factory.ts
@@ -7,7 +7,8 @@ import { createError, getErrorMessage, toError } from "#veryfront/errors/veryfro
 
 interface ZodLikeSchema {
   _def?: {
-    typeName?: string;
+    typeName?: string; // v3
+    type?: string; // v4
     shape?: (() => Record<string, unknown>) | Record<string, unknown>;
   };
   parse?: (input: unknown) => void;
@@ -16,9 +17,8 @@ interface ZodLikeSchema {
 function hasValidZodTypeName(schema: unknown): schema is ZodLikeSchema {
   if (schema === null || typeof schema !== "object") return false;
   if (!("_def" in schema)) return false;
-  // zod v3 uses _def.typeName, v4 uses _def.type
   const def = (schema as ZodLikeSchema)._def;
-  return !!(def?.typeName ?? (def as Record<string, unknown>)?.type);
+  return !!(def?.typeName ?? def?.type);
 }
 
 function getSchemaShape(schema: ZodLikeSchema): Record<string, unknown> | null {

--- a/src/tool/schema/zod-json-schema.ts
+++ b/src/tool/schema/zod-json-schema.ts
@@ -1,5 +1,4 @@
 import type { z } from "zod";
-import { ZodFirstPartyTypeKind } from "zod";
 import type { JsonSchema } from "./json-schema.ts";
 import { INVALID_ARGUMENT } from "#veryfront/errors";
 
@@ -11,6 +10,13 @@ const LITERAL_TYPE_MAP: Record<string, "string" | "number" | "boolean"> = {
 
 function getLiteralType(value: unknown): "string" | "number" | "boolean" | undefined {
   return LITERAL_TYPE_MAP[typeof value];
+}
+
+/** Get the internal type tag from a zod schema (_def.typeName in v3, _def.type in v4). */
+function getTypeTag(schema: z.ZodTypeAny): string | undefined {
+  // deno-lint-ignore no-explicit-any
+  const def = schema._def as any;
+  return def.typeName ?? def.type;
 }
 
 export function zodToJsonSchema(schema: z.ZodTypeAny): JsonSchema {
@@ -30,43 +36,53 @@ export function isOptionalSchema(schema: z.ZodTypeAny): boolean {
 }
 
 function convert(schema: z.ZodTypeAny): JsonSchema {
-  switch (schema._def.typeName) {
-    case ZodFirstPartyTypeKind.ZodString:
+  const tag = getTypeTag(schema);
+  // deno-lint-ignore no-explicit-any
+  const def = schema._def as any;
+
+  switch (tag) {
+    case "ZodString":
+    case "string":
       return { type: "string" };
 
-    case ZodFirstPartyTypeKind.ZodNumber:
+    case "ZodNumber":
+    case "number":
       return { type: "number" };
 
-    case ZodFirstPartyTypeKind.ZodBoolean:
+    case "ZodBoolean":
+    case "boolean":
       return { type: "boolean" };
 
-    case ZodFirstPartyTypeKind.ZodBigInt:
+    case "ZodBigInt":
+    case "bigint":
       return { type: "integer" };
 
-    case ZodFirstPartyTypeKind.ZodLiteral: {
-      const literal = (schema as z.ZodLiteral<unknown>)._def.value;
+    case "ZodLiteral":
+    case "literal": {
+      // v3: _def.value, v4: _def.values (array of accepted values)
+      const literal = def.value ?? (Array.isArray(def.values) ? def.values[0] : def.values);
       return { const: literal, type: getLiteralType(literal) };
     }
 
-    case ZodFirstPartyTypeKind.ZodEnum:
+    case "ZodEnum":
+    case "ZodNativeEnum":
+    case "enum": {
+      // v3: _def.values (array), v4: _def.entries (object {key: value})
+      const values = def.values ?? (def.entries ? Object.values(def.entries) : []);
+      if (Array.isArray(values)) {
+        return { type: "string", enum: values };
+      }
+      // Native enum: filter out reverse-mapped numeric keys
       return {
-        type: "string",
-        enum: (schema as z.ZodEnum<[string, ...string[]]>)._def.values,
+        enum: Object.values(values).filter((value) => typeof value !== "number"),
       };
+    }
 
-    case ZodFirstPartyTypeKind.ZodNativeEnum:
-      return {
-        enum: Object.values((schema as z.ZodNativeEnum<z.EnumLike>)._def.values).filter(
-          (value) => typeof value !== "number",
-        ),
-      };
-
-    case ZodFirstPartyTypeKind.ZodObject: {
-      const obj = schema as z.ZodObject<z.ZodRawShape>;
+    case "ZodObject":
+    case "object": {
+      const shape = typeof def.shape === "function" ? def.shape() : def.shape;
       const properties: Record<string, JsonSchema> = {};
       const required: string[] = [];
-
-      const shape = typeof obj._def.shape === "function" ? obj._def.shape() : obj._def.shape;
 
       for (const [key, value] of Object.entries(shape ?? {})) {
         const zodSchema = value as z.ZodTypeAny;
@@ -80,63 +96,65 @@ function convert(schema: z.ZodTypeAny): JsonSchema {
       return json;
     }
 
-    case ZodFirstPartyTypeKind.ZodArray: {
-      const array = schema as z.ZodArray<z.ZodTypeAny>;
-      return { type: "array", items: zodToJsonSchema(array._def.type) };
+    case "ZodArray":
+    case "array": {
+      // v3: _def.type (item schema), v4: _def.element (item schema)
+      const itemType = def.element ?? def.type;
+      return { type: "array", items: zodToJsonSchema(itemType) };
     }
 
-    case ZodFirstPartyTypeKind.ZodTuple: {
-      const tuple = schema as z.ZodTuple;
-      const items = tuple._def.items;
-
+    case "ZodTuple":
+    case "tuple": {
+      const items = def.items;
       return {
         type: "array",
-        prefixItems: items.map((item) => zodToJsonSchema(item)),
+        prefixItems: items.map((item: z.ZodTypeAny) => zodToJsonSchema(item)),
         minItems: items.length,
         maxItems: items.length,
       };
     }
 
-    case ZodFirstPartyTypeKind.ZodUnion: {
-      const union = schema as z.ZodUnion<[z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]>;
-      return { anyOf: union._def.options.map((option) => zodToJsonSchema(option)) };
+    case "ZodUnion":
+    case "ZodDiscriminatedUnion":
+    case "union": {
+      const options = def.options ?? [];
+      const optionArray = options instanceof Map ? Array.from(options.values()) : options;
+      return { anyOf: optionArray.map((option: z.ZodTypeAny) => zodToJsonSchema(option)) };
     }
 
-    case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
-      const union = schema as z.ZodDiscriminatedUnion<
-        string,
-        z.ZodDiscriminatedUnionOption<string>[]
-      >;
-      return {
-        anyOf: Array.from(union._def.options.values()).map((option) => zodToJsonSchema(option)),
-      };
-    }
-
-    case ZodFirstPartyTypeKind.ZodRecord:
+    case "ZodRecord":
+    case "record":
       return {
         type: "object",
-        additionalProperties: zodToJsonSchema(
-          (schema as z.ZodRecord<z.ZodString, z.ZodTypeAny>)._def.valueType,
-        ),
+        additionalProperties: zodToJsonSchema(def.valueType ?? def.element),
       };
 
-    case ZodFirstPartyTypeKind.ZodDefault: {
-      const def = schema as z.ZodDefault<z.ZodTypeAny>;
-      const inner = zodToJsonSchema(def._def.innerType);
-      const defaultValue = def._def.defaultValue();
+    case "ZodDefault":
+    case "default": {
+      const innerType = def.innerType ?? def.schema;
+      const inner = zodToJsonSchema(innerType);
+      const defaultValue = typeof def.defaultValue === "function"
+        ? def.defaultValue()
+        : def.defaultValue;
 
-      if (typeof inner === "object" && !("anyOf" in inner)) {
+      if (typeof inner === "object" && !("anyOf" in inner) && defaultValue !== undefined) {
         inner.default = defaultValue;
       }
 
       return inner;
     }
 
-    case ZodFirstPartyTypeKind.ZodLazy:
-      return convert((schema as z.ZodLazy<z.ZodTypeAny>)._def.getter());
+    case "ZodLazy":
+    case "lazy":
+      return convert(def.getter());
 
-    case ZodFirstPartyTypeKind.ZodEffects:
-      return convert((schema as z.ZodEffects<z.ZodTypeAny>)._def.schema);
+    case "ZodEffects":
+    case "pipe": {
+      // v3: ZodEffects wraps schema in _def.schema
+      // v4: pipe wraps in _def.in (input schema)
+      const innerSchema = def.schema ?? def.in;
+      return innerSchema ? convert(innerSchema) : { type: "object" };
+    }
 
     default:
       return { type: "object" };
@@ -151,19 +169,27 @@ function unwrapSchema(
   let optional = false;
 
   while (true) {
-    switch (current._def.typeName) {
-      case ZodFirstPartyTypeKind.ZodNullable:
+    const tag = getTypeTag(current);
+    // deno-lint-ignore no-explicit-any
+    const def = current._def as any;
+
+    switch (tag) {
+      case "ZodNullable":
+      case "nullable":
         nullable = true;
-        current = (current as z.ZodNullable<z.ZodTypeAny>)._def.innerType;
+        current = def.innerType ?? def.schema;
         break;
 
-      case ZodFirstPartyTypeKind.ZodOptional:
+      case "ZodOptional":
+      case "optional":
         optional = true;
-        current = (current as z.ZodOptional<z.ZodTypeAny>)._def.innerType;
+        current = def.innerType ?? def.schema;
         break;
 
-      case ZodFirstPartyTypeKind.ZodEffects:
-        current = (current as z.ZodEffects<z.ZodTypeAny>)._def.schema;
+      case "ZodEffects":
+      case "pipe":
+        current = def.schema ?? def.in ?? current;
+        if (current === schema) return { schema: current, nullable, optional };
         break;
 
       default:

--- a/src/tool/schema/zod-json-schema.ts
+++ b/src/tool/schema/zod-json-schema.ts
@@ -2,6 +2,25 @@ import type { z } from "zod";
 import type { JsonSchema } from "./json-schema.ts";
 import { INVALID_ARGUMENT } from "#veryfront/errors";
 
+/** Zod internal _def shape — covers fields from both v3 and v4. */
+interface ZodDef {
+  typeName?: string; // v3
+  type?: string; // v4
+  value?: unknown; // v3 literal
+  values?: unknown; // v3 enum / v4 literal
+  entries?: Record<string, unknown>; // v4 enum
+  shape?: (() => Record<string, z.ZodTypeAny>) | Record<string, z.ZodTypeAny>;
+  element?: z.ZodTypeAny; // v4 array/record
+  items?: z.ZodTypeAny[]; // tuple
+  options?: z.ZodTypeAny[] | Map<string, z.ZodTypeAny>; // union
+  valueType?: z.ZodTypeAny; // record
+  innerType?: z.ZodTypeAny; // optional/nullable/default (v3)
+  schema?: z.ZodTypeAny; // effects/optional/nullable (v3/v4)
+  in?: z.ZodTypeAny; // pipe input (v4)
+  getter?: () => z.ZodTypeAny; // lazy
+  defaultValue?: (() => unknown) | unknown;
+}
+
 const LITERAL_TYPE_MAP: Record<string, "string" | "number" | "boolean"> = {
   string: "string",
   number: "number",
@@ -12,10 +31,13 @@ function getLiteralType(value: unknown): "string" | "number" | "boolean" | undef
   return LITERAL_TYPE_MAP[typeof value];
 }
 
+function getDef(schema: z.ZodTypeAny): ZodDef {
+  return schema._def as ZodDef;
+}
+
 /** Get the internal type tag from a zod schema (_def.typeName in v3, _def.type in v4). */
 function getTypeTag(schema: z.ZodTypeAny): string | undefined {
-  // deno-lint-ignore no-explicit-any
-  const def = schema._def as any;
+  const def = getDef(schema);
   return def.typeName ?? def.type;
 }
 
@@ -37,8 +59,7 @@ export function isOptionalSchema(schema: z.ZodTypeAny): boolean {
 
 function convert(schema: z.ZodTypeAny): JsonSchema {
   const tag = getTypeTag(schema);
-  // deno-lint-ignore no-explicit-any
-  const def = schema._def as any;
+  const def = getDef(schema);
 
   switch (tag) {
     case "ZodString":
@@ -99,13 +120,14 @@ function convert(schema: z.ZodTypeAny): JsonSchema {
     case "ZodArray":
     case "array": {
       // v3: _def.type (item schema), v4: _def.element (item schema)
-      const itemType = def.element ?? def.type;
+      const itemType = def.element ?? (def.type as unknown as z.ZodTypeAny | undefined);
+      if (!itemType || typeof itemType === "string") return { type: "array" };
       return { type: "array", items: zodToJsonSchema(itemType) };
     }
 
     case "ZodTuple":
     case "tuple": {
-      const items = def.items;
+      const items = def.items ?? [];
       return {
         type: "array",
         prefixItems: items.map((item: z.ZodTypeAny) => zodToJsonSchema(item)),
@@ -124,14 +146,16 @@ function convert(schema: z.ZodTypeAny): JsonSchema {
 
     case "ZodRecord":
     case "record":
-      return {
-        type: "object",
-        additionalProperties: zodToJsonSchema(def.valueType ?? def.element),
-      };
+      {
+        const valueSchema = def.valueType ?? def.element;
+        if (!valueSchema) return { type: "object" };
+        return { type: "object", additionalProperties: zodToJsonSchema(valueSchema) };
+      }
 
     case "ZodDefault":
     case "default": {
       const innerType = def.innerType ?? def.schema;
+      if (!innerType) return { type: "object" };
       const inner = zodToJsonSchema(innerType);
       const defaultValue = typeof def.defaultValue === "function"
         ? def.defaultValue()
@@ -146,7 +170,7 @@ function convert(schema: z.ZodTypeAny): JsonSchema {
 
     case "ZodLazy":
     case "lazy":
-      return convert(def.getter());
+      return def.getter ? convert(def.getter()) : { type: "object" };
 
     case "ZodEffects":
     case "pipe": {
@@ -170,20 +194,19 @@ function unwrapSchema(
 
   while (true) {
     const tag = getTypeTag(current);
-    // deno-lint-ignore no-explicit-any
-    const def = current._def as any;
+    const def = getDef(current);
 
     switch (tag) {
       case "ZodNullable":
       case "nullable":
         nullable = true;
-        current = def.innerType ?? def.schema;
+        current = (def.innerType ?? def.schema)!;
         break;
 
       case "ZodOptional":
       case "optional":
         optional = true;
-        current = def.innerType ?? def.schema;
+        current = (def.innerType ?? def.schema)!;
         break;
 
       case "ZodEffects":

--- a/src/tool/schema/zod-json-schema.ts
+++ b/src/tool/schema/zod-json-schema.ts
@@ -145,12 +145,11 @@ function convert(schema: z.ZodTypeAny): JsonSchema {
     }
 
     case "ZodRecord":
-    case "record":
-      {
-        const valueSchema = def.valueType ?? def.element;
-        if (!valueSchema) return { type: "object" };
-        return { type: "object", additionalProperties: zodToJsonSchema(valueSchema) };
-      }
+    case "record": {
+      const valueSchema = def.valueType ?? def.element;
+      if (!valueSchema) return { type: "object" };
+      return { type: "object", additionalProperties: zodToJsonSchema(valueSchema) };
+    }
 
     case "ZodDefault":
     case "default": {

--- a/src/workflow/blob/veryfront-cloud-storage.ts
+++ b/src/workflow/blob/veryfront-cloud-storage.ts
@@ -18,7 +18,7 @@ const UploadCreateResponseSchema = z.object({
   file_upload_url: z.string().url(),
   file_path: z.string(),
   upload_id: z.string(),
-  required_headers: z.record(z.string()),
+  required_headers: z.record(z.string(), z.string()),
 });
 
 const UploadMetadataResponseSchema = z.object({
@@ -47,7 +47,7 @@ const BlobMetadataSchema = z.object({
   mimeType: z.string(),
   createdAt: z.string(),
   expiresAt: z.string().optional(),
-  metadata: z.record(z.string()).optional(),
+  metadata: z.record(z.string(), z.string()).optional(),
 });
 
 type UploadMetadataResponse = z.infer<typeof UploadMetadataResponseSchema>;

--- a/src/workflow/schemas/workflow.schema.ts
+++ b/src/workflow/schemas/workflow.schema.ts
@@ -100,7 +100,7 @@ export const CheckpointSchema = z.object({
   nodeId: z.string(),
   timestamp: z.date(),
   context: WorkflowContextSchema,
-  nodeStates: z.record(NodeStateSchema),
+  nodeStates: z.record(z.string(), NodeStateSchema),
 });
 
 /**

--- a/tests/integration/core/config-loader-edge-cases.test.ts
+++ b/tests/integration/core/config-loader-edge-cases.test.ts
@@ -352,7 +352,7 @@ describe("Config Loader - Edge Cases and Error Handling", () => {
           await assertRejects(
             () => getConfig(projectDir, adapter),
             Error,
-            "Expected object, received null",
+            "expected object, received null",
           );
         },
       );


### PR DESCRIPTION
## Summary
Migrates zod from 3.25.76 to 4.3.6 across 40 files — the final Phase 5 major version migration in the supply chain security plan.

### Breaking changes addressed

| Change | Files | Details |
|--------|-------|---------|
| `z.record(value)` → `z.record(z.string(), value)` | 25 | v4 requires explicit key type |
| `ZodError.errors` → `.issues` | 5 | `.errors` removed in v4 |
| `z.SafeParseReturnType` removed | 5 | Define local `SafeParseResult<T>` compat type |
| `z.ZodRawShape` removed | 1 | Simplify `createArgParser` generic |
| `z.function()` args/returns removed | 2 | Use bare `z.function()`, cast at call sites |
| `ZodFirstPartyTypeKind` removed | 1 | Rewrite zod-json-schema converter for v4 `_def.type` strings |
| `_def.typeName` → `_def.type` | 1 | Update tool factory schema detection |
| Stricter UUID validation | 1 | Update test UUIDs to RFC 9562 |
| Error message format changed | 1 | Update integration test assertion |

### What still works (v3 compat in v4)
- `.passthrough()`, `.strict()` — deprecated but functional
- `{ message: ... }` error customization
- `.email()`, `.uuid()`, `.url()` methods
- `z.infer<>` type inference

### Key files
- `src/tool/schema/zod-json-schema.ts` — full rewrite with typed `ZodDef` interface (no `as any`)
- `src/tool/factory.ts` — v4 schema detection
- `cli/shared/args.ts` — `SafeParseResult<T>` compat type, reworked generics
- `src/security/input-validation/parsers.ts` — `.issues` migration
- `src/agent/chat-handler.ts` — `.issues` migration

Part of supply chain security hardening (Phase 5 — final migration).

## Test plan
- [x] 1206 unit tests pass locally
- [x] 0 typecheck errors (cli/main.ts + src/index.ts)
- [x] Built and tested with legal-app (`veryfront dev`)
- [x] Security review — no vulnerabilities identified
- [x] CI unit tests pass
- [x] CI integration tests pass
- [x] CI binary e2e tests pass