### PR TITLE
fix: allow signed preview control-plane proxy requests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.101",
+  "version": "0.1.102-rc.1",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -839,6 +839,61 @@ describe("Proxy Handler", () => {
       }
     });
 
+    it("allows signed internal agent stream requests through protected preview using inbound token", async () => {
+      let tokenEndpointHits = 0;
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") {
+          tokenEndpointHits += 1;
+          return createTokenResponse();
+        }
+
+        if (pathname.startsWith("/projects/")) {
+          return Response.json({
+            id: "proj-123",
+            slug: "protected-project",
+            name: "Protected Project",
+            environments: [{
+              id: "env-1",
+              name: "preview",
+              active_release_id: "rel-123",
+              protected: true,
+            }],
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+
+        const req = new Request(
+          "http://protected-project.preview.veryfront.com/internal/agents/stream",
+          {
+            headers: {
+              host: "protected-project.preview.veryfront.com",
+              "x-token": "project-agent-token",
+              "x-veryfront-control-plane-jws": "signed-request",
+            },
+          },
+        );
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error, undefined);
+        assertEquals(ctx.projectSlug, "protected-project");
+        assertEquals(ctx.environmentId, "env-1");
+        assertEquals(ctx.token, "project-agent-token");
+        assertEquals(tokenEndpointHits, 0);
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
     it("returns 404 for missing preview project with auth token", async () => {
       const memberToken = await createFakeJwt("user-123");
       const { server, port } = createMockServer((_req: Request) => {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -385,11 +385,14 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     if (!matchingEnv?.protected) return null;
 
     if (isSignedInternalControlPlaneRequest(req)) {
-      logger?.debug("Allowing signed internal control-plane request through protected environment", {
-        ...logContext,
-        environmentName: matchingEnv.name,
-        pathname: new URL(req.url).pathname,
-      });
+      logger?.debug(
+        "Allowing signed internal control-plane request through protected environment",
+        {
+          ...logContext,
+          environmentName: matchingEnv.name,
+          pathname: new URL(req.url).pathname,
+        },
+      );
       return null;
     }
 

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -22,6 +22,34 @@ export const INTERNAL_PROXY_HEADERS = [
   "x-branch-name",
 ] as const;
 
+const INTERNAL_CONTROL_PLANE_SIGNATURE_HEADERS = [
+  "x-veryfront-control-plane-jws",
+  "x-veryfront-dispatch-jws",
+] as const;
+
+function isInternalControlPlanePath(pathname: string): boolean {
+  return pathname === "/channels/invoke" ||
+    pathname.startsWith("/internal/agents/") ||
+    pathname.startsWith("/internal/tasks/") ||
+    pathname.startsWith("/internal/workflows/");
+}
+
+function isSignedInternalControlPlaneRequest(req: Request): boolean {
+  const pathname = new URL(req.url).pathname;
+  if (!isInternalControlPlanePath(pathname)) {
+    return false;
+  }
+
+  const hasSignature = INTERNAL_CONTROL_PLANE_SIGNATURE_HEADERS.some((header) =>
+    !!req.headers.get(header)
+  );
+  if (!hasSignature) {
+    return false;
+  }
+
+  return !!req.headers.get("x-token");
+}
+
 interface DomainLookupResult {
   id: string;
   slug: string;
@@ -356,6 +384,15 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
   ): Promise<{ status: number; message: string; redirectUrl?: string } | null> {
     if (!matchingEnv?.protected) return null;
 
+    if (isSignedInternalControlPlaneRequest(req)) {
+      logger?.debug("Allowing signed internal control-plane request through protected environment", {
+        ...logContext,
+        environmentName: matchingEnv.name,
+        pathname: new URL(req.url).pathname,
+      });
+      return null;
+    }
+
     if (!userToken) {
       const redirectUrl = makeAuthRedirectUrl(req);
       logger?.info("Protected environment requires authentication", {
@@ -464,6 +501,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
     const cookieHeader = req.headers.get("cookie") ?? "";
     const userToken = extractUserToken(cookieHeader);
+    const signedInternalControlPlaneRequest = isSignedInternalControlPlaneRequest(req);
 
     let token: string | undefined;
     let tokenFetchError: unknown;
@@ -471,7 +509,13 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     if (isLocalProject) {
       logger?.debug("Local project, skipping token fetch", { localPath });
     } else {
-      if (scope === "preview" && userToken) {
+      if (signedInternalControlPlaneRequest) {
+        token = req.headers.get("x-token") ?? undefined;
+        logger?.debug("Using signed control-plane token for internal request", {
+          pathname: new URL(req.url).pathname,
+          scope,
+        });
+      } else if (scope === "preview" && userToken) {
         token = userToken;
         logger?.debug("Using user auth token for preview");
       }

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -3,7 +3,7 @@ import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.101";
+export const VERSION = "0.1.102-rc.1";
 
 export function normalizeVeryfrontVersion(version: string | undefined): string | undefined {
   if (!version) return undefined;


### PR DESCRIPTION
## Summary
- allow signed internal control-plane requests through protected preview domains
- reuse the inbound project-scoped token instead of minting a proxy token for those requests
- cut `0.1.102-rc.1` so staging can actually pull a binary with this fix

## Testing
- `deno test src/proxy/handler.test.ts --allow-env --allow-net --allow-read --allow-write`
