### PR TITLE
Refresh preview project discovery per request

### DIFF
--- a/src/server/handlers/request/api/project-discovery.test.ts
+++ b/src/server/handlers/request/api/project-discovery.test.ts
@@ -1,0 +1,111 @@
+import { getAgent } from "#veryfront/agent";
+import { toolRegistry } from "#veryfront/tool";
+import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "../../types.ts";
+import { ensureProjectDiscovery } from "./project-discovery.ts";
+import { agentRegistry } from "#veryfront/agent/composition/composition.ts";
+import { stop as stopEsbuild } from "esbuild";
+
+function createHandlerContext(
+  projectDir: string,
+  projectSlug: string,
+  environment: "preview" | "production",
+  releaseId?: string,
+): HandlerContext {
+  return {
+    projectDir,
+    projectSlug,
+    releaseId,
+    resolvedEnvironment: environment,
+    requestContext: {
+      slug: projectSlug,
+      branch: "main",
+      mode: environment,
+      token: "",
+    },
+    adapter: createMockAdapter(),
+    securityConfig: null,
+    cspUserHeader: null,
+    isLocalProject: false,
+  } as HandlerContext;
+}
+
+async function writeAgentFile(
+  ctx: HandlerContext,
+  agentId: string,
+  systemPrompt: string,
+): Promise<void> {
+  await ctx.adapter.fs.writeFile(
+    `${ctx.projectDir}/agents/${agentId}.ts`,
+    [
+      'import { agent } from "veryfront/agent";',
+      "",
+      "export default agent({",
+      `  id: "${agentId}",`,
+      `  system: "${systemPrompt}",`,
+      "});",
+      "",
+    ].join("\n"),
+  );
+}
+
+describe(
+  "server/handlers/request/api/project-discovery",
+  { sanitizeOps: false, sanitizeResources: false },
+  () => {
+    afterAll(async () => {
+      await stopEsbuild();
+    });
+
+    it("re-runs preview discovery after source changes", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+
+      const ctx = createHandlerContext("/preview-project", "preview-project", "preview");
+      const agentId = "preview-agent";
+
+      await writeAgentFile(ctx, agentId, "FIRST");
+      await ensureProjectDiscovery(ctx);
+
+      const firstAgent = getAgent(agentId);
+      assertExists(firstAgent);
+      assertEquals(firstAgent.config.system, "FIRST");
+
+      await writeAgentFile(ctx, agentId, "SECOND");
+      await ensureProjectDiscovery(ctx);
+
+      const updatedAgent = getAgent(agentId);
+      assertExists(updatedAgent);
+      assertEquals(updatedAgent.config.system, "SECOND");
+    });
+
+    it("keeps production discovery cached for the same release", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+
+      const ctx = createHandlerContext(
+        "/production-project",
+        "production-project",
+        "production",
+        "release-123",
+      );
+      const agentId = "production-agent";
+
+      await writeAgentFile(ctx, agentId, "FIRST");
+      await ensureProjectDiscovery(ctx);
+
+      const firstAgent = getAgent(agentId);
+      assertExists(firstAgent);
+      assertEquals(firstAgent.config.system, "FIRST");
+
+      await writeAgentFile(ctx, agentId, "SECOND");
+      await ensureProjectDiscovery(ctx);
+
+      const cachedAgent = getAgent(agentId);
+      assertExists(cachedAgent);
+      assertEquals(cachedAgent.config.system, "FIRST");
+    });
+  },
+);

--- a/src/server/handlers/request/api/project-discovery.ts
+++ b/src/server/handlers/request/api/project-discovery.ts
@@ -1,4 +1,5 @@
 import { serverLogger } from "#veryfront/utils";
+import { clearTrackedAgents } from "#veryfront/discovery";
 import type { HandlerContext } from "../../types.ts";
 
 const logger = serverLogger.component("api-wrapper");
@@ -17,8 +18,22 @@ const discoveredProjects = new Map<string, Promise<void>>();
 /** Build a discovery cache key that incorporates the release/version. */
 function discoveryKey(ctx: HandlerContext): string {
   const slug = ctx.projectSlug ?? ctx.projectDir;
-  const version = ctx.releaseId ?? "preview";
-  return `${slug}:${version}`;
+  const environment = ctx.enriched?.environment ?? ctx.resolvedEnvironment ??
+    (ctx.releaseId ? "production" : "preview");
+
+  if (environment === "production") {
+    return `${slug}:release:${ctx.releaseId ?? "unknown"}`;
+  }
+
+  const branch = ctx.requestContext?.branch ?? ctx.enriched?.branch ?? ctx.parsedDomain?.branch ??
+    "main";
+  return `${slug}:preview:${branch}`;
+}
+
+function shouldCacheCompletedDiscovery(ctx: HandlerContext): boolean {
+  const environment = ctx.enriched?.environment ?? ctx.resolvedEnvironment ??
+    (ctx.releaseId ? "production" : "preview");
+  return environment === "production";
 }
 
 /**
@@ -29,12 +44,13 @@ function discoveryKey(ctx: HandlerContext): string {
  */
 export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<void> {
   const key = discoveryKey(ctx);
+  const cacheCompletedDiscovery = shouldCacheCompletedDiscovery(ctx);
 
   const existing = discoveredProjects.get(key);
   if (existing) return existing;
 
   const promise = (async () => {
-    const { discoverAll } = await import("#veryfront/discovery");
+    const { clearTranspileCache, discoverAll } = await import("#veryfront/discovery");
     const { agentRegistry } = await import(
       "#veryfront/agent/composition/composition.ts"
     );
@@ -42,6 +58,8 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<void>
 
     // Clear stale entries for this project scope before re-discovery.
     // This prevents agents/tools removed in a new release from lingering.
+    clearTrackedAgents();
+    clearTranspileCache();
     agentRegistry.clear();
     toolRegistry.clear();
 
@@ -82,5 +100,9 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<void>
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
+  } finally {
+    if (!cacheCompletedDiscovery) {
+      discoveredProjects.delete(key);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- rerun preview project discovery on each request while keeping production discovery cached by release
- clear tracked agent paths and the transpile cache before rediscovery so updated preview agent config is picked up immediately
- add a regression test covering preview refresh vs production caching

## Verification
- deno lint src/server/handlers/request/api/project-discovery.ts src/server/handlers/request/api/project-discovery.test.ts
- deno check src/server/handlers/request/api/project-discovery.ts src/server/handlers/request/api/project-discovery.test.ts
- VF_DISABLE_LRU_INTERVAL=1 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all src/server/handlers/request/api/project-discovery.test.ts