### PR TITLE
Fix unstyled markdown pages in pages/ and app/

### DIFF
--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -275,8 +275,7 @@ async function generateHTMLShellPartsImpl(
   }
 
   // Markdown styles: .md files with prose !== false get GitHub markdown CSS
-  const isMarkdownPreview =
-    options.pageType === "md" &&
+  const isMarkdownPreview = options.pageType === "md" &&
     checkMarkdownPreview(options.pagePath, options.frontmatter);
 
   const markdownPreviewStyles = isMarkdownPreview

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -274,9 +274,8 @@ async function generateHTMLShellPartsImpl(
       `<link id="vf-tailwind-css" rel="stylesheet" href="/_vf_styles/styles.css?t=${Date.now()}">`;
   }
 
-  // Markdown preview mode: .md files in preview/local dev with prose !== false
-  // Only applies to standalone markdown files (not in pages/ or app/)
-  const isMarkdownPreview = (isLocalProject || isPreviewMode) &&
+  // Markdown styles: .md files with prose !== false get GitHub markdown CSS
+  const isMarkdownPreview =
     options.pageType === "md" &&
     checkMarkdownPreview(options.pagePath, options.frontmatter);
 

--- a/src/transforms/md/utils.test.ts
+++ b/src/transforms/md/utils.test.ts
@@ -12,20 +12,20 @@ describe("transforms/md/utils", () => {
       assertEquals(isMarkdownPreview(undefined), true);
     });
 
-    it("returns false for file in pages/ directory", () => {
-      assertEquals(isMarkdownPreview("pages/about.md"), false);
+    it("returns true for file in pages/ directory", () => {
+      assertEquals(isMarkdownPreview("pages/about.md"), true);
     });
 
-    it("returns false for file in app/ directory", () => {
-      assertEquals(isMarkdownPreview("app/docs/intro.md"), false);
+    it("returns true for file in app/ directory", () => {
+      assertEquals(isMarkdownPreview("app/docs/intro.md"), true);
     });
 
-    it("returns false for nested pages/ directory", () => {
-      assertEquals(isMarkdownPreview("src/pages/about.md"), false);
+    it("returns true for nested pages/ directory", () => {
+      assertEquals(isMarkdownPreview("src/pages/about.md"), true);
     });
 
-    it("returns false for nested app/ directory", () => {
-      assertEquals(isMarkdownPreview("src/app/docs/intro.md"), false);
+    it("returns true for nested app/ directory", () => {
+      assertEquals(isMarkdownPreview("src/app/docs/intro.md"), true);
     });
 
     it("returns false when frontmatter has prose: false", () => {
@@ -42,6 +42,10 @@ describe("transforms/md/utils", () => {
 
     it("returns true for deeply nested non-routable path", () => {
       assertEquals(isMarkdownPreview("docs/guides/getting-started.md"), true);
+    });
+
+    it("returns false for pages/ with prose: false", () => {
+      assertEquals(isMarkdownPreview("pages/about.md", { prose: false }), false);
     });
   });
 });

--- a/src/transforms/md/utils.ts
+++ b/src/transforms/md/utils.ts
@@ -12,7 +12,7 @@
  * This includes both standalone files and routable pages (pages/, app/).
  */
 export function isMarkdownPreview(
-  filePath: string | undefined,
+  _filePath: string | undefined,
   frontmatter?: Record<string, unknown>,
 ): boolean {
   if (frontmatter?.prose === false) return false;

--- a/src/transforms/md/utils.ts
+++ b/src/transforms/md/utils.ts
@@ -7,30 +7,14 @@
  */
 
 /**
- * Check if a file path is inside pages/ or app/ directories.
- * Files in these directories are routed normally, not as standalone markdown.
- */
-function isInRoutableDir(filePath: string | undefined): boolean {
-  if (!filePath) return false;
-
-  return (
-    filePath.startsWith("pages/") ||
-    filePath.startsWith("app/") ||
-    filePath.includes("/pages/") ||
-    filePath.includes("/app/")
-  );
-}
-
-/**
  * Check if a markdown file should be rendered with GitHub preview styles.
- * Returns true for standalone .md files not in pages/app directories,
- * unless opted out via `prose: false` frontmatter.
+ * Returns true for all .md files unless opted out via `prose: false` frontmatter.
+ * This includes both standalone files and routable pages (pages/, app/).
  */
 export function isMarkdownPreview(
   filePath: string | undefined,
   frontmatter?: Record<string, unknown>,
 ): boolean {
-  if (isInRoutableDir(filePath)) return false;
   if (frontmatter?.prose === false) return false;
   return true;
 }


### PR DESCRIPTION
## Summary
- `.md` files in `pages/` and `app/` were rendering without any styles (no heading sizes, no margins, plain text)
- Root cause: `isMarkdownPreview()` excluded routable directories, so no `markdown-body` class or GitHub CSS was applied
- Now all `.md` files get GitHub markdown styles unless opted out via `prose: false` frontmatter
- Also removed the local/preview-only gate so CSS works in production too

## Test plan
- [ ] Create a project with `pages/index.md` containing `# Hello` — should render as styled h1
- [ ] Verify `prose: false` frontmatter still disables styles
- [ ] Verify standalone `.md` files (e.g. `README.md`) still render correctly