### PR TITLE
fix: execute run-scoped Studio tools at runtime

### DIFF
--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -22,7 +22,6 @@ import {
   type ToolCall,
 } from "../types.ts";
 import { ensureModelReady, findAvailableCloudModel, resolveModel } from "#veryfront/provider";
-import { executeTool } from "#veryfront/tool";
 import { generateId } from "#veryfront/utils/id.ts";
 import { detectPlatform, getPlatformCapabilities } from "#veryfront/platform/core-platform.ts";
 import { createMemory, type Memory } from "../memory/index.ts";
@@ -41,7 +40,12 @@ import { AGENT_DEFAULTS } from "../ai-defaults.ts";
 
 // Re-export from submodules
 export { generateMessageId, sendSSE } from "./sse-utils.ts";
-export { getAvailableTools, isDynamicTool, parseToolArgs } from "./tool-helpers.ts";
+export {
+  executeConfiguredTool,
+  getAvailableTools,
+  isDynamicTool,
+  parseToolArgs,
+} from "./tool-helpers.ts";
 export type { ParsedToolArgs, ToolConfigEntry } from "./tool-helpers.ts";
 export { accumulateUsage, getMaxSteps, normalizeInput } from "./input-utils.ts";
 export { createStreamState, processStream } from "./ai-stream-handler.ts";
@@ -55,7 +59,12 @@ export {
 
 import { DEFAULT_MAX_TOKENS, DEFAULT_TEMPERATURE } from "./constants.ts";
 import { generateMessageId, sendSSE } from "./sse-utils.ts";
-import { getAvailableTools, isDynamicTool, parseToolArgs } from "./tool-helpers.ts";
+import {
+  executeConfiguredTool,
+  getAvailableTools,
+  isDynamicTool,
+  parseToolArgs,
+} from "./tool-helpers.ts";
 import { accumulateUsage, getMaxSteps, normalizeInput } from "./input-utils.ts";
 import {
   filterToolsForSkill,
@@ -481,10 +490,15 @@ export class AgentRuntime {
               toolCall.status = "executing";
               const startTime = Date.now();
 
-              const result = await executeTool(tc.toolName, toolCall.args, {
-                agentId: this.id,
-                toolCallId: tc.toolCallId,
-              });
+              const result = await executeConfiguredTool(
+                tc.toolName,
+                toolCall.args,
+                this.config.tools,
+                {
+                  agentId: this.id,
+                  toolCallId: tc.toolCallId,
+                },
+              );
 
               toolCall.status = "completed";
               toolCall.result = result;
@@ -713,11 +727,16 @@ export class AgentRuntime {
 
           callbacks?.onToolCall?.(toolCall);
 
-          const result = await executeTool(tc.name, toolCall.args, {
-            agentId: this.id,
-            toolCallId: tc.id,
-            ...toolContext,
-          });
+          const result = await executeConfiguredTool(
+            tc.name,
+            toolCall.args,
+            this.config.tools,
+            {
+              agentId: this.id,
+              toolCallId: tc.id,
+              ...toolContext,
+            },
+          );
 
           toolCall.status = "completed";
           toolCall.result = result;

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -1,6 +1,8 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { parseToolArgs } from "./tool-helpers.ts";
+import { z } from "zod";
+import { tool, toolRegistry } from "#veryfront/tool";
+import { executeConfiguredTool, parseToolArgs, resolveConfiguredTool } from "./tool-helpers.ts";
 
 describe("tool-helpers", () => {
   describe("parseToolArgs", () => {
@@ -51,6 +53,104 @@ describe("tool-helpers", () => {
       const result = parseToolArgs({});
       assertEquals(result.args, {});
       assertEquals(result.error, undefined);
+    });
+  });
+
+  describe("resolveConfiguredTool", () => {
+    it("returns an inline configured tool without requiring registry registration", () => {
+      const injectedTool = tool({
+        id: "studio_invoke_agent",
+        description: "Invoke another project agent",
+        inputSchema: z.object({ prompt: z.string() }),
+        execute: async ({ prompt }) => ({ echoed: prompt }),
+      });
+
+      const resolvedTool = resolveConfiguredTool(
+        {
+          studio_invoke_agent: injectedTool,
+        },
+        "studio_invoke_agent",
+      );
+
+      assertEquals(resolvedTool, injectedTool);
+    });
+
+    it("falls back to the shared registry when the config entry is true", () => {
+      toolRegistry.clearAll();
+
+      const sharedTool = tool({
+        id: "shared-search",
+        description: "Shared search",
+        inputSchema: z.object({ query: z.string() }),
+        execute: async ({ query }) => ({ query }),
+      });
+      toolRegistry.register("shared-search", sharedTool);
+
+      const resolvedTool = resolveConfiguredTool(
+        {
+          "shared-search": true,
+        },
+        "shared-search",
+      );
+
+      assertEquals(resolvedTool, sharedTool);
+      toolRegistry.clearAll();
+    });
+  });
+
+  describe("executeConfiguredTool", () => {
+    it("executes an inline configured tool before consulting the registry", async () => {
+      toolRegistry.clearAll();
+
+      const injectedTool = tool({
+        id: "studio_invoke_agent",
+        description: "Invoke another project agent",
+        inputSchema: z.object({ prompt: z.string() }),
+        execute: async ({ prompt }) => ({ text: prompt.toUpperCase() }),
+      });
+
+      const result = await executeConfiguredTool(
+        "studio_invoke_agent",
+        { prompt: "childself" },
+        {
+          studio_invoke_agent: injectedTool,
+        },
+        { toolCallId: "tool-1" },
+      );
+
+      assertEquals(result, { text: "CHILDSELF" });
+    });
+
+    it("falls back to the registry when no inline tool is configured", async () => {
+      toolRegistry.clearAll();
+
+      const sharedTool = tool({
+        id: "shared-search",
+        description: "Shared search",
+        inputSchema: z.object({ query: z.string() }),
+        execute: async ({ query }) => ({ source: "registry", query }),
+      });
+      toolRegistry.register("shared-search", sharedTool);
+
+      const result = await executeConfiguredTool(
+        "shared-search",
+        { query: "docs" },
+        undefined,
+        { toolCallId: "tool-2" },
+      );
+
+      assertEquals(result, { source: "registry", query: "docs" });
+      toolRegistry.clearAll();
+    });
+
+    it("preserves the missing-tool error when nothing is configured", async () => {
+      toolRegistry.clearAll();
+
+      await assertRejects(
+        () => executeConfiguredTool("studio_invoke_agent", { prompt: "test" }, undefined),
+        Error,
+        'Tool "studio_invoke_agent" not found',
+      );
     });
   });
 });

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -6,8 +6,8 @@
  * @module ai/agent/runtime/tool-helpers
  */
 
-import type { Tool, ToolDefinition } from "#veryfront/tool";
-import { toolRegistry } from "#veryfront/tool";
+import type { Tool, ToolDefinition, ToolExecutionContext } from "#veryfront/tool";
+import { executeTool, toolRegistry } from "#veryfront/tool";
 import { toolToProviderDefinition } from "#veryfront/tool/registry.ts";
 import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
 import { serverLogger } from "#veryfront/utils";
@@ -66,6 +66,44 @@ export function isDynamicTool(name: string): boolean {
  */
 // deno-lint-ignore no-explicit-any -- generic erasure: accepts Tool with any input/output types
 export type ToolConfigEntry = Tool<any, any> | boolean;
+
+export function resolveConfiguredTool(
+  toolsConfig: true | Record<string, ToolConfigEntry> | undefined,
+  toolName: string,
+): Tool | null {
+  if (!toolsConfig) {
+    return null;
+  }
+
+  if (toolsConfig === true) {
+    return toolRegistry.get(toolName) ?? null;
+  }
+
+  const configuredEntry = toolsConfig[toolName];
+  if (configuredEntry === true) {
+    return toolRegistry.get(toolName) ?? null;
+  }
+
+  if (configuredEntry && typeof configuredEntry === "object") {
+    return configuredEntry;
+  }
+
+  return null;
+}
+
+export async function executeConfiguredTool(
+  toolName: string,
+  input: Record<string, unknown>,
+  toolsConfig: true | Record<string, ToolConfigEntry> | undefined,
+  context?: ToolExecutionContext,
+): Promise<unknown> {
+  const configuredTool = resolveConfiguredTool(toolsConfig, toolName);
+  if (configuredTool) {
+    return await configuredTool.execute(input, context);
+  }
+
+  return await executeTool(toolName, input, context);
+}
 
 function logToolDefinition(name: string, def: ToolDefinition): void {
   logger.debug(


### PR DESCRIPTION
## Summary
- execute run-scoped injected Studio tools from the agent runtime before falling back to the shared registry
- keep registry-backed tools working unchanged when the config entry is `true`
- add runtime regression tests for inline configured tool resolution and execution

## Testing
- deno test --no-check --allow-all src/agent/runtime/tool-helpers.test.ts src/server/handlers/request/agent-stream.handler.test.ts src/internal-agents/control-plane-auth.test.ts src/internal-agents/ag-ui-sse.test.ts src/internal-agents/session-manager.test.ts
- deno task verify:quick
- pre-push hook: formatting, lint, typecheck, `deno task test:unit` (1208 passed)