### PR TITLE
Fix generic invoke_agent runtime contract

### DIFF
--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -22,14 +22,17 @@ export const RunIdSchema = z.string().min(1).max(128).regex(AGENT_ID_PATTERN);
 
 export const AgentIdSchema = z.string().min(1).max(128).regex(AGENT_ID_PATTERN);
 
-export const StudioToolNameSchema = z
+export const ClientToolNameSchema = z
   .string()
   .min(1)
   .max(128)
-  .regex(/^studio_[a-zA-Z0-9_]+$/, "Tool names must use the studio_ prefix");
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9._:-]*$/,
+    "Tool names must start with a letter and use a valid client-tool format",
+  );
 
 export const RuntimeInjectedToolSchema = z.object({
-  name: StudioToolNameSchema,
+  name: ClientToolNameSchema,
   description: z.string().max(1024).optional(),
   parameters: z.record(z.unknown()).optional().refine(
     (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_TOOL_PARAMETERS_BYTES),

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -252,6 +252,76 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(await result.response.json(), { error: "Invalid internal agent stream request" });
   });
 
+  it("accepts generic control-plane tool names like invoke_agent", async () => {
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: (id) => id === "assistant-1" ? createAgent("assistant-1") : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager: new AgentRunSessionManager(),
+      createRuntime: () => ({
+        stream: async (_messages, _context, callbacks) => {
+          callbacks?.onFinish?.({
+            text: "delegated",
+            messages: [],
+            toolCalls: [],
+            status: "completed",
+            usage: {
+              promptTokens: 5,
+              completionTokens: 2,
+              totalTokens: 7,
+            },
+            metadata: {
+              finishReason: "stop",
+            },
+          });
+
+          return new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encodeDataStreamEvent({ type: "message-start", messageId: "assistant-msg-1" }),
+              );
+              controller.enqueue(encodeDataStreamEvent({ type: "text-start", id: "text-1" }));
+              controller.enqueue(
+                encodeDataStreamEvent({
+                  type: "text-delta",
+                  id: "text-1",
+                  delta: "delegated",
+                }),
+              );
+              controller.enqueue(encodeDataStreamEvent({ type: "text-end", id: "text-1" }));
+              controller.close();
+            },
+          });
+        },
+      }),
+    });
+
+    const body = createAgentStreamRequestBody({
+      tools: [{ name: "invoke_agent" }],
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+
+    const text = await result.response.text();
+    assertStringIncludes(text, "event: RunStarted");
+    assertStringIncludes(text, "event: TextMessageContent");
+    assertStringIncludes(text, "event: RunFinished");
+  });
+
   it("returns 409 when the same run is started twice", async () => {
     const sessionManager = new AgentRunSessionManager();
     const handler = new AgentStreamHandler({


### PR DESCRIPTION
## Summary
- accept generic client tool names in the internal agent stream runtime schema
- add a regression test covering `invoke_agent` on the signed internal stream path
- keep the fix scoped to the runtime contract used by API-controlled child runs

## Testing
- deno test -A src/internal-agents/ag-ui-sse.test.ts src/internal-agents/control-plane-auth.test.ts src/internal-agents/session-manager.test.ts src/server/handlers/request/agent-stream.handler.test.ts src/server/handlers/request/agent-run-resume.handler.test.ts src/server/handlers/request/agent-run-cancel.handler.test.ts src/server/handlers/request/internal-agents-list.handler.test.ts
- repo pre-push gate (format, lint, typecheck, unit)