### PR TITLE
Support source-scoped runtime agent lookup

### DIFF
--- a/src/ai/registry-manager.test.ts
+++ b/src/ai/registry-manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "#veryfront/testing/bdd";
 import { assert, assertEquals } from "#veryfront/testing/assert";
+import { runWithCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
 import { ProjectScopedRegistryManager } from "./registry-manager.ts";
 
 describe("ProjectScopedRegistryManager", () => {
@@ -38,6 +39,33 @@ describe("ProjectScopedRegistryManager", () => {
       const agent = { name: "test-agent", version: 2 };
       manager.register("agent-1", agent);
       assertEquals(manager.get("agent-1"), agent);
+    });
+
+    it("isolates registries by cache scope for the same project", () => {
+      const manager = createManager<string>("tool");
+
+      runWithCacheKeyContext(
+        { projectId: "proj-1", mode: "preview", versionId: "main" },
+        () => manager.register("shared-tool", "main-value"),
+      );
+
+      runWithCacheKeyContext(
+        { projectId: "proj-1", mode: "preview", versionId: "feature-a" },
+        () => {
+          assertEquals(manager.get("shared-tool"), undefined);
+          manager.register("shared-tool", "feature-value");
+        },
+      );
+
+      runWithCacheKeyContext(
+        { projectId: "proj-1", mode: "preview", versionId: "main" },
+        () => assertEquals(manager.get("shared-tool"), "main-value"),
+      );
+
+      runWithCacheKeyContext(
+        { projectId: "proj-1", mode: "preview", versionId: "feature-a" },
+        () => assertEquals(manager.get("shared-tool"), "feature-value"),
+      );
     });
   });
 
@@ -232,6 +260,30 @@ describe("ProjectScopedRegistryManager", () => {
 
       assertEquals(manager.get("shared-a"), "sv");
       assertEquals(manager.get("proj-a"), "pv");
+    });
+
+    it("clears all cache scopes for the same project", () => {
+      const manager = createManager<string>("tool");
+
+      runWithCacheKeyContext(
+        { projectId: "proj-1", mode: "preview", versionId: "main" },
+        () => manager.register("tool-a", "main-value"),
+      );
+      runWithCacheKeyContext(
+        { projectId: "proj-1", mode: "preview", versionId: "feature-a" },
+        () => manager.register("tool-a", "feature-value"),
+      );
+
+      manager.clearProject("proj-1");
+
+      runWithCacheKeyContext(
+        { projectId: "proj-1", mode: "preview", versionId: "main" },
+        () => assertEquals(manager.get("tool-a"), undefined),
+      );
+      runWithCacheKeyContext(
+        { projectId: "proj-1", mode: "preview", versionId: "feature-a" },
+        () => assertEquals(manager.get("tool-a"), undefined),
+      );
     });
   });
 

--- a/src/ai/registry-manager.ts
+++ b/src/ai/registry-manager.ts
@@ -25,7 +25,16 @@
 import { tryGetCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
 import { agentLogger } from "#veryfront/utils/logger/logger.ts";
 
-const DEFAULT_PROJECT_ID = "__default__";
+const DEFAULT_SCOPE_ID = "__default__";
+
+function buildRegistryScopeId(): string {
+  const cacheContext = tryGetCacheKeyContext();
+  if (!cacheContext) {
+    return DEFAULT_SCOPE_ID;
+  }
+
+  return `${cacheContext.projectId}:${cacheContext.mode}:${cacheContext.versionId}`;
+}
 
 /**
  * Base class for project-scoped registries.
@@ -33,7 +42,7 @@ const DEFAULT_PROJECT_ID = "__default__";
  * cross-project sharing of explicitly shared items.
  */
 export class ProjectScopedRegistryManager<T> {
-  private registriesByProject = new Map<string, Map<string, T>>();
+  private registriesByScope = new Map<string, Map<string, T>>();
   private sharedRegistry = new Map<string, T>();
 
   constructor(private registryName: string) {}
@@ -42,19 +51,19 @@ export class ProjectScopedRegistryManager<T> {
    * Get the current project ID from AsyncLocalStorage context.
    * Falls back to default for CLI/test scenarios.
    */
-  private getCurrentProjectId(): string {
-    return tryGetCacheKeyContext()?.projectId ?? DEFAULT_PROJECT_ID;
+  private getCurrentScopeId(): string {
+    return buildRegistryScopeId();
   }
 
   /**
    * Get or create registry for a specific project.
    */
-  private getProjectRegistry(projectId: string): Map<string, T> {
-    const existing = this.registriesByProject.get(projectId);
+  private getScopeRegistry(scopeId: string): Map<string, T> {
+    const existing = this.registriesByScope.get(scopeId);
     if (existing) return existing;
 
     const registry = new Map<string, T>();
-    this.registriesByProject.set(projectId, registry);
+    this.registriesByScope.set(scopeId, registry);
     return registry;
   }
 
@@ -62,17 +71,17 @@ export class ProjectScopedRegistryManager<T> {
    * Register an item for the current project.
    */
   register(id: string, item: T): void {
-    const projectId = this.getCurrentProjectId();
-    const registry = this.getProjectRegistry(projectId);
+    const scopeId = this.getCurrentScopeId();
+    const registry = this.getScopeRegistry(scopeId);
 
     if (registry.has(id)) {
       agentLogger.debug(
-        `[${this.registryName}] "${id}" already registered for project ${projectId}. Overwriting.`,
+        `[${this.registryName}] "${id}" already registered for scope ${scopeId}. Overwriting.`,
       );
     }
 
     registry.set(id, item);
-    agentLogger.debug(`[${this.registryName}] Registered "${id}" for project ${projectId}`);
+    agentLogger.debug(`[${this.registryName}] Registered "${id}" for scope ${scopeId}`);
   }
 
   /**
@@ -93,16 +102,16 @@ export class ProjectScopedRegistryManager<T> {
    * Falls back to shared registry for items not found in project registry.
    */
   get(id: string): T | undefined {
-    const projectId = this.getCurrentProjectId();
-    return this.registriesByProject.get(projectId)?.get(id) ?? this.sharedRegistry.get(id);
+    const scopeId = this.getCurrentScopeId();
+    return this.registriesByScope.get(scopeId)?.get(id) ?? this.sharedRegistry.get(id);
   }
 
   /**
    * Check if item exists for the current project.
    */
   has(id: string): boolean {
-    const projectId = this.getCurrentProjectId();
-    return (this.registriesByProject.get(projectId)?.has(id) ?? false) ||
+    const scopeId = this.getCurrentScopeId();
+    return (this.registriesByScope.get(scopeId)?.has(id) ?? false) ||
       this.sharedRegistry.has(id);
   }
 
@@ -110,8 +119,8 @@ export class ProjectScopedRegistryManager<T> {
    * Get all IDs for the current project (includes shared items).
    */
   getAllIds(): string[] {
-    const projectId = this.getCurrentProjectId();
-    const projectIds = this.registriesByProject.get(projectId)?.keys() ?? [];
+    const scopeId = this.getCurrentScopeId();
+    const projectIds = this.registriesByScope.get(scopeId)?.keys() ?? [];
     const sharedIds = this.sharedRegistry.keys();
     return Array.from(new Set([...projectIds, ...sharedIds]));
   }
@@ -120,8 +129,8 @@ export class ProjectScopedRegistryManager<T> {
    * Get all items for the current project (includes shared items).
    */
   getAll(): Map<string, T> {
-    const projectId = this.getCurrentProjectId();
-    const projectRegistry = this.registriesByProject.get(projectId);
+    const scopeId = this.getCurrentScopeId();
+    const projectRegistry = this.registriesByScope.get(scopeId);
     if (!projectRegistry) return new Map(this.sharedRegistry);
 
     const result = new Map<string, T>(this.sharedRegistry);
@@ -133,12 +142,12 @@ export class ProjectScopedRegistryManager<T> {
    * Delete an item from the current project's registry.
    */
   delete(id: string): boolean {
-    const projectId = this.getCurrentProjectId();
-    const registry = this.registriesByProject.get(projectId);
+    const scopeId = this.getCurrentScopeId();
+    const registry = this.registriesByScope.get(scopeId);
     if (!registry?.has(id)) return false;
 
     registry.delete(id);
-    agentLogger.debug(`[${this.registryName}] Deleted "${id}" from project ${projectId}`);
+    agentLogger.debug(`[${this.registryName}] Deleted "${id}" from scope ${scopeId}`);
     return true;
   }
 
@@ -146,22 +155,31 @@ export class ProjectScopedRegistryManager<T> {
    * Clear all items for the current project.
    */
   clear(): void {
-    this.clearProject(this.getCurrentProjectId());
+    this.clearProject(this.getCurrentScopeId());
   }
 
   /**
    * Clear a specific project's registry.
    */
   clearProject(projectId: string): void {
-    this.registriesByProject.delete(projectId);
-    agentLogger.debug(`[${this.registryName}] Cleared registry for project ${projectId}`);
+    let cleared = false;
+    for (const scopeId of Array.from(this.registriesByScope.keys())) {
+      if (scopeId === projectId || scopeId.startsWith(`${projectId}:`)) {
+        this.registriesByScope.delete(scopeId);
+        cleared = true;
+      }
+    }
+
+    if (cleared) {
+      agentLogger.debug(`[${this.registryName}] Cleared registry for project ${projectId}`);
+    }
   }
 
   /**
    * Clear everything (for testing).
    */
   clearAll(): void {
-    this.registriesByProject.clear();
+    this.registriesByScope.clear();
     this.sharedRegistry.clear();
     agentLogger.debug(`[${this.registryName}] Cleared all registries`);
   }
@@ -175,18 +193,18 @@ export class ProjectScopedRegistryManager<T> {
     totalItems: number;
     currentProjectItems: number;
   } {
-    const projectId = this.getCurrentProjectId();
+    const scopeId = this.getCurrentScopeId();
     const totalItems = this.sharedRegistry.size +
-      Array.from(this.registriesByProject.values()).reduce(
+      Array.from(this.registriesByScope.values()).reduce(
         (sum, registry) => sum + registry.size,
         0,
       );
 
     return {
-      projectCount: this.registriesByProject.size,
+      projectCount: this.registriesByScope.size,
       sharedCount: this.sharedRegistry.size,
       totalItems,
-      currentProjectItems: this.registriesByProject.get(projectId)?.size ?? 0,
+      currentProjectItems: this.registriesByScope.get(scopeId)?.size ?? 0,
     };
   }
 }

--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -63,6 +63,22 @@ export const RuntimeContextItemSchema = z.discriminatedUnion("type", [
   }),
 ]);
 
+export const RuntimeAgentSourceContextSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("branch"),
+    branch: z.string().min(1).max(255),
+  }),
+  z.object({
+    type: z.literal("environment"),
+    environmentName: z.string().min(1).max(255),
+    releaseId: z.string().min(1).max(255).optional(),
+  }),
+  z.object({
+    type: z.literal("release"),
+    releaseId: z.string().min(1).max(255),
+  }),
+]);
+
 export const RuntimeRunAgentInputSchema = z.object({
   agentId: AgentIdSchema,
   threadId: z.string().uuid(),
@@ -81,6 +97,7 @@ export const RuntimeRunAgentInputSchema = z.object({
     (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_TOTAL_BYTES),
     { message: "context must be less than 64 KB total" },
   ),
+  agentSource: RuntimeAgentSourceContextSchema.optional(),
   forwardedProps: z.record(z.unknown()).optional().refine(
     (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_FORWARDED_PROPS_BYTES),
     { message: "forwardedProps must be less than 64 KB" },
@@ -101,5 +118,6 @@ export const ResumeSignalSchema = z.discriminatedUnion("type", [
 
 export type RuntimeInjectedTool = z.infer<typeof RuntimeInjectedToolSchema>;
 export type RuntimeContextItem = z.infer<typeof RuntimeContextItemSchema>;
+export type RuntimeAgentSourceContext = z.infer<typeof RuntimeAgentSourceContextSchema>;
 export type RuntimeRunAgentInput = z.infer<typeof RuntimeRunAgentInputSchema>;
 export type ResumeSignal = z.infer<typeof ResumeSignalSchema>;

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -2,7 +2,6 @@ import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/tes
 import { AgentRunSessionManager } from "#veryfront/internal-agents/session-manager.ts";
 import type {
   EnvironmentAdapter,
-  FileChangeEvent,
   FileInfo,
   FileSystemAdapter,
 } from "#veryfront/platform/adapters/base.ts";

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -1,5 +1,11 @@
 import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { AgentRunSessionManager } from "#veryfront/internal-agents/session-manager.ts";
+import type {
+  EnvironmentAdapter,
+  FileChangeEvent,
+  FileInfo,
+  FileSystemAdapter,
+} from "#veryfront/platform/adapters/base.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { DEFAULT_MAX_BODY_SIZE_BYTES } from "#veryfront/utils/constants/index.ts";
 import { AgentRunResumeHandler } from "./agent-run-resume.handler.ts";
@@ -53,6 +59,76 @@ class TrackingSessionManager extends AgentRunSessionManager {
     this.stats.failCalls += 1;
     super.failRun(runId);
   }
+}
+
+function createNoopEnvAdapter(publicKeyPem: string): EnvironmentAdapter {
+  const values = new Map<string, string>();
+  values.set("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY", publicKeyPem);
+
+  return {
+    get: (key) => values.get(key),
+    set: (key, value) => {
+      values.set(key, value);
+    },
+    toObject: () => Object.fromEntries(values),
+  };
+}
+
+type SourceContextTestFsAdapter = FileSystemAdapter & {
+  isMultiProjectMode(): boolean;
+  runWithContext<R>(
+    slug: string,
+    token: string,
+    fn: () => Promise<R>,
+    projectId?: string,
+    options?: {
+      productionMode?: boolean;
+      releaseId?: string | null;
+      branch?: string | null;
+      environmentName?: string | null;
+    },
+  ): Promise<R>;
+};
+
+function createNoopFsAdapter(
+  runWithContextCalls: Array<{
+    productionMode?: boolean;
+    releaseId?: string | null;
+    branch?: string | null;
+    environmentName?: string | null;
+  }>,
+): SourceContextTestFsAdapter {
+  return {
+    readFile: async () => "",
+    writeFile: async () => {},
+    exists: async () => false,
+    async *readDir() {},
+    stat: async (): Promise<FileInfo> => ({
+      size: 0,
+      isFile: false,
+      isDirectory: false,
+      isSymlink: false,
+      mtime: null,
+    }),
+    mkdir: async () => {},
+    remove: async () => {},
+    makeTempDir: async () => "/tmp/agent-stream-handler-test",
+    watch: () => ({
+      close: () => {},
+      async *[Symbol.asyncIterator]() {},
+    }),
+    isMultiProjectMode: () => true,
+    runWithContext: async (
+      _projectSlug,
+      _token,
+      fn,
+      _projectId,
+      options,
+    ) => {
+      runWithContextCalls.push(options ?? {});
+      return await fn();
+    },
+  };
 }
 
 describe("server/handlers/request/agent-stream.handler", () => {
@@ -320,6 +396,103 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertStringIncludes(text, "event: RunStarted");
     assertStringIncludes(text, "event: TextMessageContent");
     assertStringIncludes(text, "event: RunFinished");
+  });
+
+  it("uses explicit agent source context when the control plane requests a different source", async () => {
+    const runWithContextCalls: Array<{
+      productionMode?: boolean;
+      releaseId?: string | null;
+      branch?: string | null;
+      environmentName?: string | null;
+    }> = [];
+
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: (id) => id === "assistant-1" ? createAgent("assistant-1") : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager: new AgentRunSessionManager(),
+      createRuntime: () => ({
+        stream: async (_messages, _context, callbacks) => {
+          callbacks?.onFinish?.({
+            text: "resolved from main",
+            messages: [],
+            toolCalls: [],
+            status: "completed",
+            usage: {
+              promptTokens: 5,
+              completionTokens: 3,
+              totalTokens: 8,
+            },
+            metadata: {
+              finishReason: "stop",
+            },
+          });
+
+          return new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encodeDataStreamEvent({ type: "message-start", messageId: "assistant-msg-1" }),
+              );
+              controller.enqueue(encodeDataStreamEvent({ type: "text-start", id: "text-1" }));
+              controller.enqueue(
+                encodeDataStreamEvent({
+                  type: "text-delta",
+                  id: "text-1",
+                  delta: "resolved from main",
+                }),
+              );
+              controller.enqueue(encodeDataStreamEvent({ type: "text-end", id: "text-1" }));
+              controller.close();
+            },
+          });
+        },
+      }),
+    });
+
+    const body = createAgentStreamRequestBody({
+      agentSource: { type: "branch", branch: "main" },
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+    const ctx = createCtx(publicKeyPem);
+    ctx.parsedDomain = {
+      slug: "demo-project",
+      branch: "feature-a",
+      environment: "preview",
+      isVeryfrontDomain: true,
+      isDraft: true,
+      allowIframeEmbed: true,
+    };
+    ctx.resolvedEnvironment = "preview";
+    ctx.requestContext = {
+      slug: "demo-project",
+      branch: "feature-a",
+      mode: "preview",
+      token: "",
+    };
+    ctx.adapter = {
+      ...ctx.adapter,
+      env: createNoopEnvAdapter(publicKeyPem),
+      fs: createNoopFsAdapter(runWithContextCalls),
+    };
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      ctx,
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(runWithContextCalls.length, 2);
+    assertEquals(runWithContextCalls[0]?.branch, "feature-a");
+    assertEquals(runWithContextCalls[1]?.branch, "main");
+    assertEquals(runWithContextCalls[1]?.productionMode, false);
   });
 
   it("returns 409 when the same run is started twice", async () => {

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -18,10 +18,14 @@ import {
   AgentRunAlreadyExistsError,
   agentRunSessionManager,
 } from "#veryfront/internal-agents/session-manager.ts";
-import { RuntimeRunAgentInputSchema } from "#veryfront/internal-agents/schema.ts";
+import {
+  type RuntimeAgentSourceContext,
+  RuntimeRunAgentInputSchema,
+} from "#veryfront/internal-agents/schema.ts";
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 export interface AgentStreamHandlerDeps
   extends RuntimeAgentDiscoveryDeps, RuntimeAgentStreamExecutionDeps {}
@@ -30,6 +34,48 @@ const defaultDeps: AgentStreamHandlerDeps = {
   ...defaultChannelInvokeDeps,
   sessionManager: agentRunSessionManager,
 };
+
+type SourceContextFsWrapper = {
+  isMultiProjectMode?: () => boolean;
+  runWithContext?: <R>(
+    slug: string,
+    token: string,
+    fn: () => Promise<R>,
+    projectId?: string,
+    options?: {
+      productionMode?: boolean;
+      releaseId?: string | null;
+      branch?: string | null;
+      environmentName?: string | null;
+    },
+  ) => Promise<R>;
+};
+
+function buildAgentSourceRunOptions(sourceContext: RuntimeAgentSourceContext): {
+  productionMode: boolean;
+  releaseId?: string | null;
+  branch?: string | null;
+  environmentName?: string | null;
+} {
+  switch (sourceContext.type) {
+    case "branch":
+      return {
+        productionMode: false,
+        branch: sourceContext.branch,
+      };
+    case "environment":
+      return {
+        productionMode: true,
+        environmentName: sourceContext.environmentName,
+        releaseId: sourceContext.releaseId ?? null,
+      };
+    case "release":
+      return {
+        productionMode: true,
+        releaseId: sourceContext.releaseId,
+      };
+  }
+}
 
 function applyBuilderHeaders(target: Response, source: Headers): Response {
   const headers = new Headers(target.headers);
@@ -57,6 +103,30 @@ export class AgentStreamHandler extends BaseHandler {
     super();
   }
 
+  private withAgentSourceContext<T>(
+    ctx: HandlerContext,
+    sourceContext: RuntimeAgentSourceContext | undefined,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    if (!sourceContext) {
+      return fn();
+    }
+
+    const fsWrapper = ctx.adapter.fs as SourceContextFsWrapper;
+    if (!ctx.projectSlug || !fsWrapper.isMultiProjectMode?.() || !fsWrapper.runWithContext) {
+      throw new Error("Alternate agent source requires a multi-project runtime context");
+    }
+
+    const token = ctx.proxyToken || getHostEnv("VERYFRONT_API_TOKEN") || "";
+    return fsWrapper.runWithContext(
+      ctx.projectSlug,
+      token,
+      fn,
+      ctx.projectId,
+      buildAgentSourceRunOptions(sourceContext),
+    );
+  }
+
   async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
     if (!this.shouldHandle(req, ctx)) {
       return this.continue();
@@ -78,15 +148,25 @@ export class AgentStreamHandler extends BaseHandler {
           expectedSurface: "studio",
         });
 
-        await this.deps.ensureProjectDiscovery(ctx);
+        return await this.withAgentSourceContext(
+          ctx,
+          payload.agentSource,
+          async () => {
+            await this.deps.ensureProjectDiscovery(ctx);
 
-        const agent = this.deps.getAgent(payload.agentId);
-        if (!agent) {
-          return this.respond(builder.json({ error: "Agent not found" }, 404));
-        }
+            const agent = this.deps.getAgent(payload.agentId);
+            if (!agent) {
+              return this.respond(builder.json({ error: "Agent not found" }, 404));
+            }
 
-        const response = await createRuntimeAgentStreamResponse(payload, agent as Agent, this.deps);
-        return this.respond(applyBuilderHeaders(response, builder.headers));
+            const response = await createRuntimeAgentStreamResponse(
+              payload,
+              agent as Agent,
+              this.deps,
+            );
+            return this.respond(applyBuilderHeaders(response, builder.headers));
+          },
+        );
       } catch (error) {
         if (error instanceof InternalAgentRequestBodyTooLargeError) {
           return this.respond(builder.json({ error: error.message }, error.status));

--- a/src/server/handlers/request/api/project-discovery.test.ts
+++ b/src/server/handlers/request/api/project-discovery.test.ts
@@ -3,6 +3,7 @@ import { toolRegistry } from "#veryfront/tool";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
+import { runWithCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
 import type { HandlerContext } from "../../types.ts";
 import { ensureProjectDiscovery } from "./project-discovery.ts";
 import { agentRegistry } from "#veryfront/agent/composition/composition.ts";
@@ -106,6 +107,52 @@ describe(
       const cachedAgent = getAgent(agentId);
       assertExists(cachedAgent);
       assertEquals(cachedAgent.config.system, "FIRST");
+    });
+
+    it("uses cache-key context to isolate production discovery by release", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+
+      const ctx = createHandlerContext(
+        "/production-scope-project",
+        "production-scope-project",
+        "production",
+        "release-stale",
+      );
+      const agentId = "production-scope-agent";
+
+      await writeAgentFile(ctx, agentId, "FIRST");
+      await runWithCacheKeyContext(
+        { projectId: "proj-1", mode: "production", versionId: "release-1" },
+        () => ensureProjectDiscovery(ctx),
+      );
+
+      const firstAgent = await runWithCacheKeyContext(
+        { projectId: "proj-1", mode: "production", versionId: "release-1" },
+        async () => getAgent(agentId),
+      );
+      assertExists(firstAgent);
+      assertEquals(firstAgent.config.system, "FIRST");
+
+      await writeAgentFile(ctx, agentId, "SECOND");
+      await runWithCacheKeyContext(
+        { projectId: "proj-1", mode: "production", versionId: "release-2" },
+        () => ensureProjectDiscovery(ctx),
+      );
+
+      const updatedAgent = await runWithCacheKeyContext(
+        { projectId: "proj-1", mode: "production", versionId: "release-2" },
+        async () => getAgent(agentId),
+      );
+      assertExists(updatedAgent);
+      assertEquals(updatedAgent.config.system, "SECOND");
+
+      const originalReleaseAgent = await runWithCacheKeyContext(
+        { projectId: "proj-1", mode: "production", versionId: "release-1" },
+        async () => getAgent(agentId),
+      );
+      assertExists(originalReleaseAgent);
+      assertEquals(originalReleaseAgent.config.system, "FIRST");
     });
   },
 );

--- a/src/server/handlers/request/api/project-discovery.ts
+++ b/src/server/handlers/request/api/project-discovery.ts
@@ -1,5 +1,6 @@
 import { serverLogger } from "#veryfront/utils";
 import { clearTrackedAgents } from "#veryfront/discovery";
+import { tryGetCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
 import type { HandlerContext } from "../../types.ts";
 
 const logger = serverLogger.component("api-wrapper");
@@ -17,6 +18,11 @@ const discoveredProjects = new Map<string, Promise<void>>();
 
 /** Build a discovery cache key that incorporates the release/version. */
 function discoveryKey(ctx: HandlerContext): string {
+  const cacheContext = tryGetCacheKeyContext();
+  if (cacheContext) {
+    return `${cacheContext.projectId}:${cacheContext.mode}:${cacheContext.versionId}`;
+  }
+
   const slug = ctx.projectSlug ?? ctx.projectDir;
   const environment = ctx.enriched?.environment ?? ctx.resolvedEnvironment ??
     (ctx.releaseId ? "production" : "preview");
@@ -31,6 +37,11 @@ function discoveryKey(ctx: HandlerContext): string {
 }
 
 function shouldCacheCompletedDiscovery(ctx: HandlerContext): boolean {
+  const cacheContext = tryGetCacheKeyContext();
+  if (cacheContext) {
+    return cacheContext.mode === "production";
+  }
+
   const environment = ctx.enriched?.environment ?? ctx.resolvedEnvironment ??
     (ctx.releaseId ? "production" : "preview");
   return environment === "production";


### PR DESCRIPTION
## Summary
- add first-class `agentSource` support to the runtime internal agent stream contract
- scope runtime project discovery and registries by cache-key context so child runs can resolve agents from project/main, releases, or environments without polluting the preview runtime scope
- cover the new source-context behavior in registry, discovery, and agent stream handler tests

## Testing
- deno test --allow-all src/ai/registry-manager.test.ts src/server/handlers/request/api/project-discovery.test.ts src/server/handlers/request/agent-stream.handler.test.ts
- deno task typecheck
- repo pre-push checks (format, lint, typecheck, unit tests)
