### PR TITLE
chore: bump version to 0.1.102

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.102-rc.1",
+  "version": "0.1.102",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -3,7 +3,7 @@ import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.102-rc.1";
+export const VERSION = "0.1.102";
 
 export function normalizeVeryfrontVersion(version: string | undefined): string | undefined {
   if (!version) return undefined;


### PR DESCRIPTION
## Summary
- Bumps version from 0.1.102-rc.1 to 0.1.102
- Updates both `deno.json` and `src/utils/version.ts`

## Test plan
- [ ] CI passes