### PR TITLE
Advertise runtime owner URLs for agent streams

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/internal-agents/runtime-owner.test.ts
+++ b/src/internal-agents/runtime-owner.test.ts
@@ -1,23 +1,28 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import {
-  resolveRuntimeOwnerInvokeUrl,
-} from "./runtime-owner.ts";
+import { resolveRuntimeOwnerInvokeUrl } from "./runtime-owner.ts";
 
 function createDynamicImportStub(
-  module: { networkInterfaces: () => Record<string, Array<{ address?: string; family?: string; internal?: boolean }> | undefined> },
+  module: {
+    networkInterfaces: () => Record<
+      string,
+      Array<{ address?: string; family?: string; internal?: boolean }> | undefined
+    >;
+  },
 ): <T = unknown>(specifier: string) => Promise<T> {
   return async <T>(_specifier: string) => module as T;
 }
 
 describe("internal-agents/runtime-owner", () => {
   it("prefers explicit pod env overrides for the runtime owner url", async () => {
-    const request = new Request("https://demo-project.preview.veryfront.org/internal/agents/stream");
+    const request = new Request(
+      "https://demo-project.preview.veryfront.org/internal/agents/stream",
+    );
 
     const ownerUrl = await resolveRuntimeOwnerInvokeUrl(request, {
       getHostEnv: (key) => {
         if (key === "POD_IP") return "10.0.0.7";
-        if (key === "PORT") return "20000";
+        if (key === "VERYFRONT_RUNTIME_OWNER_PORT") return "20000";
         return undefined;
       },
       getDenoNetworkInterfaces: () => [],
@@ -30,7 +35,9 @@ describe("internal-agents/runtime-owner", () => {
   });
 
   it("falls back to detected runtime interfaces when no explicit pod host is configured", async () => {
-    const request = new Request("https://demo-project.preview.veryfront.org/internal/agents/stream");
+    const request = new Request(
+      "https://demo-project.preview.veryfront.org/internal/agents/stream",
+    );
 
     const ownerUrl = await resolveRuntimeOwnerInvokeUrl(request, {
       getHostEnv: (key) => {
@@ -49,8 +56,51 @@ describe("internal-agents/runtime-owner", () => {
     assertEquals(ownerUrl, "http://10.0.0.9:20000/channels/invoke");
   });
 
+  it("does not let a generic PORT env override the runtime listener port", async () => {
+    const request = new Request(
+      "https://demo-project.preview.veryfront.org:21000/internal/agents/stream",
+    );
+
+    const ownerUrl = await resolveRuntimeOwnerInvokeUrl(request, {
+      getHostEnv: (key) => {
+        if (key === "PORT") return "3000";
+        return undefined;
+      },
+      getDenoNetworkInterfaces: () => [
+        { address: "10.0.0.9", family: "IPv4", internal: false },
+      ],
+      dynamicImport: createDynamicImportStub({
+        networkInterfaces: () => ({}),
+      }),
+    });
+
+    assertEquals(ownerUrl, "http://10.0.0.9:21000/channels/invoke");
+  });
+
+  it("returns a null owner url when Deno interface probing throws", async () => {
+    const request = new Request(
+      "https://demo-project.preview.veryfront.org/internal/agents/stream",
+    );
+
+    const ownerUrl = await resolveRuntimeOwnerInvokeUrl(request, {
+      getHostEnv: () => undefined,
+      getDenoNetworkInterfaces: () => {
+        throw new Error("Requires sys access");
+      },
+      dynamicImport: createDynamicImportStub({
+        networkInterfaces: () => ({
+          lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+        }),
+      }),
+    });
+
+    assertEquals(ownerUrl, null);
+  });
+
   it("returns null when no routable runtime owner host can be determined", async () => {
-    const request = new Request("https://demo-project.preview.veryfront.org/internal/agents/stream");
+    const request = new Request(
+      "https://demo-project.preview.veryfront.org/internal/agents/stream",
+    );
 
     const ownerUrl = await resolveRuntimeOwnerInvokeUrl(request, {
       getHostEnv: () => undefined,

--- a/src/internal-agents/runtime-owner.test.ts
+++ b/src/internal-agents/runtime-owner.test.ts
@@ -1,0 +1,67 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  resolveRuntimeOwnerInvokeUrl,
+} from "./runtime-owner.ts";
+
+function createDynamicImportStub(
+  module: { networkInterfaces: () => Record<string, Array<{ address?: string; family?: string; internal?: boolean }> | undefined> },
+): <T = unknown>(specifier: string) => Promise<T> {
+  return async <T>(_specifier: string) => module as T;
+}
+
+describe("internal-agents/runtime-owner", () => {
+  it("prefers explicit pod env overrides for the runtime owner url", async () => {
+    const request = new Request("https://demo-project.preview.veryfront.org/internal/agents/stream");
+
+    const ownerUrl = await resolveRuntimeOwnerInvokeUrl(request, {
+      getHostEnv: (key) => {
+        if (key === "POD_IP") return "10.0.0.7";
+        if (key === "PORT") return "20000";
+        return undefined;
+      },
+      getDenoNetworkInterfaces: () => [],
+      dynamicImport: createDynamicImportStub({
+        networkInterfaces: () => ({}),
+      }),
+    });
+
+    assertEquals(ownerUrl, "http://10.0.0.7:20000/channels/invoke");
+  });
+
+  it("falls back to detected runtime interfaces when no explicit pod host is configured", async () => {
+    const request = new Request("https://demo-project.preview.veryfront.org/internal/agents/stream");
+
+    const ownerUrl = await resolveRuntimeOwnerInvokeUrl(request, {
+      getHostEnv: (key) => {
+        if (key === "PROXY_MODE") return "1";
+        return undefined;
+      },
+      getDenoNetworkInterfaces: () => [
+        { address: "127.0.0.1", family: "IPv4", internal: true },
+        { address: "10.0.0.9", family: "IPv4", internal: false },
+      ],
+      dynamicImport: createDynamicImportStub({
+        networkInterfaces: () => ({}),
+      }),
+    });
+
+    assertEquals(ownerUrl, "http://10.0.0.9:20000/channels/invoke");
+  });
+
+  it("returns null when no routable runtime owner host can be determined", async () => {
+    const request = new Request("https://demo-project.preview.veryfront.org/internal/agents/stream");
+
+    const ownerUrl = await resolveRuntimeOwnerInvokeUrl(request, {
+      getHostEnv: () => undefined,
+      getDenoNetworkInterfaces: () => [],
+      dynamicImport: createDynamicImportStub({
+        networkInterfaces: () => ({
+          lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+        }),
+      }),
+    });
+
+    assertEquals(ownerUrl, null);
+  });
+});

--- a/src/internal-agents/runtime-owner.ts
+++ b/src/internal-agents/runtime-owner.ts
@@ -102,12 +102,22 @@ function selectNetworkIpv4Address(
   return null;
 }
 
+function getDenoNetworkInterfacesSafe(
+  deps: RuntimeOwnerResolverDeps,
+): ReadonlyArray<DenoNetworkInterface> {
+  try {
+    return deps.getDenoNetworkInterfaces?.() ??
+      ((globalThis as RuntimeOwnerGlobal).Deno?.networkInterfaces?.() ?? []);
+  } catch {
+    return [];
+  }
+}
+
 async function detectRuntimeOwnerHost(
   deps: RuntimeOwnerResolverDeps,
 ): Promise<string | null> {
   const readHostEnv = deps.getHostEnv ?? getHostEnv;
-  const explicitHost =
-    readHostEnv("VERYFRONT_RUNTIME_OWNER_HOST") ??
+  const explicitHost = readHostEnv("VERYFRONT_RUNTIME_OWNER_HOST") ??
     readHostEnv("POD_IP") ??
     null;
 
@@ -115,8 +125,7 @@ async function detectRuntimeOwnerHost(
     return explicitHost.trim();
   }
 
-  const denoInterfaces = deps.getDenoNetworkInterfaces?.() ??
-    ((globalThis as RuntimeOwnerGlobal).Deno?.networkInterfaces?.() ?? []);
+  const denoInterfaces = getDenoNetworkInterfacesSafe(deps);
   const denoHost = selectNetworkIpv4Address(denoInterfaces);
   if (denoHost) {
     return denoHost;
@@ -146,10 +155,10 @@ function resolveRuntimeOwnerPort(
 
   return (
     parsePort(readHostEnv("VERYFRONT_RUNTIME_OWNER_PORT")) ??
-    parsePort(readHostEnv("PORT")) ??
-    parsePort(readHostEnv("VERYFRONT_SERVER_PORT")) ??
-    parsePort(new URL(req.url).port) ??
-    (isTruthyEnv(readHostEnv("PROXY_MODE")) ? DEFAULT_PROXY_RUNTIME_PORT : null)
+      parsePort(readHostEnv("VERYFRONT_SERVER_PORT")) ??
+      parsePort(new URL(req.url).port) ??
+      parsePort(readHostEnv("PORT")) ??
+      (isTruthyEnv(readHostEnv("PROXY_MODE")) ? DEFAULT_PROXY_RUNTIME_PORT : null)
   );
 }
 

--- a/src/internal-agents/runtime-owner.ts
+++ b/src/internal-agents/runtime-owner.ts
@@ -1,0 +1,179 @@
+import { dynamicImport } from "#veryfront/platform/compat/dynamic-import.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
+
+const DEFAULT_PROXY_RUNTIME_PORT = "20000";
+
+export const RUNTIME_OWNER_INVOKE_URL_HEADER = "x-veryfront-runtime-owner-invoke-url";
+
+interface NetworkAddressInfo {
+  address?: string;
+  family?: string | number;
+  internal?: boolean;
+}
+
+type DenoNetworkInterface = {
+  address: string;
+  family?: string | number;
+  internal?: boolean;
+};
+
+type NodeOsModule = {
+  networkInterfaces(): Record<string, NetworkAddressInfo[] | undefined>;
+};
+
+type RuntimeOwnerGlobal = typeof globalThis & {
+  Deno?: {
+    networkInterfaces?: () => ReadonlyArray<DenoNetworkInterface>;
+  };
+};
+
+interface RuntimeOwnerResolverDeps {
+  getHostEnv?: typeof getHostEnv;
+  dynamicImport?: typeof dynamicImport;
+  getDenoNetworkInterfaces?: () => ReadonlyArray<DenoNetworkInterface>;
+}
+
+function parsePort(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return null;
+  }
+
+  const port = Number(trimmed);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    return null;
+  }
+
+  return String(port);
+}
+
+function isTruthyEnv(value: string | null | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+function isIpv4Address(value: string | undefined): value is string {
+  if (!value) {
+    return false;
+  }
+
+  const parts = value.split(".");
+  if (parts.length !== 4) {
+    return false;
+  }
+
+  return parts.every((part) => {
+    if (!/^\d+$/.test(part)) {
+      return false;
+    }
+
+    const octet = Number(part);
+    return octet >= 0 && octet <= 255;
+  });
+}
+
+function isLoopbackIpv4(address: string): boolean {
+  return address.startsWith("127.");
+}
+
+function selectNetworkIpv4Address(
+  candidates: ReadonlyArray<NetworkAddressInfo | DenoNetworkInterface>,
+): string | null {
+  for (const candidate of candidates) {
+    if (
+      candidate.internal === true ||
+      !isIpv4Address(candidate.address) ||
+      isLoopbackIpv4(candidate.address)
+    ) {
+      continue;
+    }
+
+    return candidate.address;
+  }
+
+  return null;
+}
+
+async function detectRuntimeOwnerHost(
+  deps: RuntimeOwnerResolverDeps,
+): Promise<string | null> {
+  const readHostEnv = deps.getHostEnv ?? getHostEnv;
+  const explicitHost =
+    readHostEnv("VERYFRONT_RUNTIME_OWNER_HOST") ??
+    readHostEnv("POD_IP") ??
+    null;
+
+  if (explicitHost?.trim()) {
+    return explicitHost.trim();
+  }
+
+  const denoInterfaces = deps.getDenoNetworkInterfaces?.() ??
+    ((globalThis as RuntimeOwnerGlobal).Deno?.networkInterfaces?.() ?? []);
+  const denoHost = selectNetworkIpv4Address(denoInterfaces);
+  if (denoHost) {
+    return denoHost;
+  }
+
+  try {
+    const nodeOs = await (deps.dynamicImport ?? dynamicImport)<NodeOsModule>("node:os");
+    const nodeInterfaces = Object.values(nodeOs.networkInterfaces()).flatMap(
+      (entries) => entries ?? [],
+    );
+    const nodeHost = selectNetworkIpv4Address(nodeInterfaces);
+    if (nodeHost) {
+      return nodeHost;
+    }
+  } catch {
+    // Ignore runtime-specific interface lookup failures and fall through.
+  }
+
+  return null;
+}
+
+function resolveRuntimeOwnerPort(
+  req: Request,
+  deps: RuntimeOwnerResolverDeps,
+): string | null {
+  const readHostEnv = deps.getHostEnv ?? getHostEnv;
+
+  return (
+    parsePort(readHostEnv("VERYFRONT_RUNTIME_OWNER_PORT")) ??
+    parsePort(readHostEnv("PORT")) ??
+    parsePort(readHostEnv("VERYFRONT_SERVER_PORT")) ??
+    parsePort(new URL(req.url).port) ??
+    (isTruthyEnv(readHostEnv("PROXY_MODE")) ? DEFAULT_PROXY_RUNTIME_PORT : null)
+  );
+}
+
+function buildRuntimeOwnerInvokeUrl(host: string, port: string | null): string | null {
+  try {
+    const url = new URL("http://127.0.0.1/channels/invoke");
+    url.hostname = host;
+    if (port) {
+      url.port = port;
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveRuntimeOwnerInvokeUrl(
+  req: Request,
+  deps: RuntimeOwnerResolverDeps = {},
+): Promise<string | null> {
+  const host = await detectRuntimeOwnerHost(deps);
+  if (!host) {
+    return null;
+  }
+
+  return buildRuntimeOwnerInvokeUrl(host, resolveRuntimeOwnerPort(req, deps));
+}

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -140,6 +140,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
       getAgent: (id) => id === "assistant-1" ? createAgent("assistant-1") : undefined,
       getAllAgentIds: () => ["assistant-1"],
       sessionManager: new AgentRunSessionManager(),
+      resolveRuntimeOwnerInvokeUrl: async () => "http://10.0.0.7:20000/channels/invoke",
       createRuntime: () => ({
         stream: async (_messages, _context, callbacks) => {
           callbacks?.onFinish?.({
@@ -199,6 +200,10 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(result.response.status, 200);
     assertEquals(discoveryCalls, 1);
     assertEquals(result.response.headers.get("content-type"), "text/event-stream");
+    assertEquals(
+      result.response.headers.get("x-veryfront-runtime-owner-invoke-url"),
+      "http://10.0.0.7:20000/channels/invoke",
+    );
 
     const text = await result.response.text();
     assertStringIncludes(text, "event: RunStarted");

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -6,6 +6,10 @@ import {
   type RuntimeAgentStreamExecutionDeps,
 } from "#veryfront/internal-agents/run-stream.ts";
 import {
+  resolveRuntimeOwnerInvokeUrl,
+  RUNTIME_OWNER_INVOKE_URL_HEADER,
+} from "#veryfront/internal-agents/runtime-owner.ts";
+import {
   ControlPlaneRequestError,
   verifyControlPlaneRequest,
 } from "#veryfront/internal-agents/control-plane-auth.ts";
@@ -28,11 +32,14 @@ import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 export interface AgentStreamHandlerDeps
-  extends RuntimeAgentDiscoveryDeps, RuntimeAgentStreamExecutionDeps {}
+  extends RuntimeAgentDiscoveryDeps, RuntimeAgentStreamExecutionDeps {
+  resolveRuntimeOwnerInvokeUrl?: typeof resolveRuntimeOwnerInvokeUrl;
+}
 
 const defaultDeps: AgentStreamHandlerDeps = {
   ...defaultChannelInvokeDeps,
   sessionManager: agentRunSessionManager,
+  resolveRuntimeOwnerInvokeUrl,
 };
 
 type SourceContextFsWrapper = {
@@ -85,6 +92,16 @@ function applyBuilderHeaders(target: Response, source: Headers): Response {
     }
   }
 
+  return new Response(target.body, {
+    status: target.status,
+    statusText: target.statusText,
+    headers,
+  });
+}
+
+function setResponseHeader(target: Response, key: string, value: string): Response {
+  const headers = new Headers(target.headers);
+  headers.set(key, value);
   return new Response(target.body, {
     status: target.status,
     statusText: target.statusText,
@@ -164,7 +181,16 @@ export class AgentStreamHandler extends BaseHandler {
               agent as Agent,
               this.deps,
             );
-            return this.respond(applyBuilderHeaders(response, builder.headers));
+            const runtimeOwnerInvokeUrl = await this.deps.resolveRuntimeOwnerInvokeUrl?.(req) ??
+              null;
+            const responseWithOwner = runtimeOwnerInvokeUrl
+              ? setResponseHeader(
+                response,
+                RUNTIME_OWNER_INVOKE_URL_HEADER,
+                runtimeOwnerInvokeUrl,
+              )
+              : response;
+            return this.respond(applyBuilderHeaders(responseWithOwner, builder.headers));
           },
         );
       } catch (error) {

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -3,7 +3,7 @@ import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.102";
+export const VERSION = "0.1.103";
 
 export function normalizeVeryfrontVersion(version: string | undefined): string | undefined {
   if (!version) return undefined;


### PR DESCRIPTION
## Summary
- add a runtime owner resolver that exposes the owning pod's direct invoke URL
- attach the owner invoke URL to  responses for downstream control-plane routing
- add focused coverage for runtime owner resolution and stream header emission

## Testing
- deno test --allow-env src/internal-agents/runtime-owner.test.ts src/server/handlers/request/agent-stream.handler.test.ts
- deno check src/server/handlers/request/agent-stream.handler.ts src/internal-agents/runtime-owner.ts