### PR TITLE
Handle closed SSE controllers during run cancellation

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/runtime/ai-stream-handler.ts
+++ b/src/agent/runtime/ai-stream-handler.ts
@@ -38,6 +38,23 @@ export interface AIStreamCallbacks {
   }) => void;
 }
 
+function createAbortError(reason?: unknown): Error {
+  if (reason instanceof Error) {
+    return reason;
+  }
+
+  return new DOMException(
+    typeof reason === "string" && reason.length > 0 ? reason : "The operation was aborted",
+    "AbortError",
+  );
+}
+
+function throwIfAborted(abortSignal?: AbortSignal): void {
+  if (abortSignal?.aborted) {
+    throw createAbortError(abortSignal.reason);
+  }
+}
+
 export function createStreamState(): AIStreamState {
   return {
     accumulatedText: "",
@@ -64,11 +81,15 @@ export function processStream(
   encoder: TextEncoder,
   textPartId: string | undefined,
   callbacks?: AIStreamCallbacks,
+  abortSignal?: AbortSignal,
 ): Promise<void> {
   return withSpan("agent.runtime.processStream", async () => {
     let eventCount = 0;
 
+    throwIfAborted(abortSignal);
+
     for await (const part of result.fullStream) {
+      throwIfAborted(abortSignal);
       eventCount++;
 
       switch (part.type) {
@@ -169,7 +190,11 @@ export function processStream(
           // Ignore other stream parts (source, file, reasoning-*, etc.)
           break;
       }
+
+      throwIfAborted(abortSignal);
     }
+
+    throwIfAborted(abortSignal);
 
     setActiveSpanAttributes({
       "stream.event_count": eventCount,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -76,6 +76,31 @@ import { resolveConfiguredAgentModel } from "./model-resolution.ts";
 const logger = serverLogger.component("agent");
 const LOAD_SKILL_TOOL_ID = "load-skill";
 
+function createAbortError(reason?: unknown): Error {
+  if (reason instanceof Error) {
+    return reason;
+  }
+
+  return new DOMException(
+    typeof reason === "string" && reason.length > 0 ? reason : "The operation was aborted",
+    "AbortError",
+  );
+}
+
+function throwIfAborted(abortSignal?: AbortSignal): void {
+  if (abortSignal?.aborted) {
+    throw createAbortError(abortSignal.reason);
+  }
+}
+
+function isAbortError(error: unknown, abortSignal?: AbortSignal): boolean {
+  if (abortSignal?.aborted && error === abortSignal.reason) {
+    return true;
+  }
+
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
 function getSkillActivationRequiredError(toolName: string): string {
   return `Tool "${toolName}" cannot run before load-skill succeeds in the same step. ` +
     `Call "${LOAD_SKILL_TOOL_ID}" first to establish the active skill context.`;
@@ -256,6 +281,7 @@ export class AgentRuntime {
     },
     modelOverride?: string,
     maxOutputTokensOverride?: number,
+    abortSignal?: AbortSignal,
   ): Promise<ReadableStream<Uint8Array>> {
     const requestedModel = resolveConfiguredAgentModel(modelOverride || this.config.model);
     // Auto-upgrade local/* to a cloud provider when API keys are available.
@@ -267,7 +293,19 @@ export class AgentRuntime {
     const systemPrompt = await this.resolveSystemPrompt();
 
     const encoder = new TextEncoder();
-    const toolContext = { agentId: this.id, ...context };
+    const streamAbortController = new AbortController();
+    const forwardAbort = () => {
+      streamAbortController.abort(abortSignal?.reason);
+    };
+    if (abortSignal) {
+      if (abortSignal.aborted) {
+        streamAbortController.abort(abortSignal.reason);
+      } else {
+        abortSignal.addEventListener("abort", forwardAbort, { once: true });
+      }
+    }
+    const streamAbortSignal = streamAbortController.signal;
+    const toolContext = { agentId: this.id, abortSignal: streamAbortSignal, ...context };
     const textPartId = generateId("text");
 
     // Resolve model BEFORE creating the ReadableStream — if this throws
@@ -289,6 +327,7 @@ export class AgentRuntime {
     return new ReadableStream<Uint8Array>({
       start: async (controller) => {
         try {
+          throwIfAborted(streamAbortSignal);
           this.status = "streaming";
 
           const messageId = generateMessageId();
@@ -319,13 +358,21 @@ export class AgentRuntime {
             resolvedModelString,
             languageModel,
             maxOutputTokensOverride,
+            streamAbortSignal,
           );
+          throwIfAborted(streamAbortSignal);
           callbacks?.onFinish?.(response);
+          throwIfAborted(streamAbortSignal);
 
           sendSSE(controller, encoder, { type: "text-end", id: textPartId });
           sendSSE(controller, encoder, { type: "message-finish" });
           closeSSEStream(controller);
         } catch (error) {
+          if (isAbortError(error, streamAbortSignal)) {
+            closeSSEStream(controller);
+            return;
+          }
+
           this.status = "error";
           logger.error("Agent stream error", { error });
           sendSSE(controller, encoder, {
@@ -333,7 +380,12 @@ export class AgentRuntime {
             error: "An internal error occurred",
           });
           closeSSEStream(controller);
+        } finally {
+          abortSignal?.removeEventListener("abort", forwardAbort);
         }
+      },
+      cancel(reason) {
+        streamAbortController.abort(reason);
       },
     });
   }
@@ -587,6 +639,7 @@ export class AgentRuntime {
     modelString?: string,
     resolvedModel?: LanguageModel,
     maxOutputTokensOverride?: number,
+    abortSignal?: AbortSignal,
   ): Promise<AgentResponse> {
     const { maxAgentSteps } = getPlatformCapabilities();
     const maxSteps = this.computeMaxSteps(maxAgentSteps);
@@ -613,6 +666,7 @@ export class AgentRuntime {
     let finalFinishReason: string | undefined;
 
     for (let step = 0; step < maxSteps; step++) {
+      throwIfAborted(abortSignal);
       sendSSE(controller, encoder, { type: "step-start" });
 
       let tools = isLocalStreaming ? [] : getAvailableTools(this.config.tools, {
@@ -631,13 +685,15 @@ export class AgentRuntime {
         tools: convertToolsToAISDK(tools),
         maxOutputTokens: this.resolveMaxOutputTokens(maxOutputTokensOverride),
         temperature: DEFAULT_TEMPERATURE,
+        abortSignal,
       });
 
       const state = createStreamState();
       await processStream(result, state, controller, encoder, textPartId, {
         onChunk: callbacks?.onChunk,
         onUsage: (usage) => accumulateUsage(totalUsage, usage),
-      });
+      }, abortSignal);
+      throwIfAborted(abortSignal);
       finalFinishReason = state.finishReason ?? finalFinishReason;
 
       const streamParts: MessagePart[] = [];
@@ -680,6 +736,7 @@ export class AgentRuntime {
         streamedToolCalls.some((tc) => tc.name === LOAD_SKILL_TOOL_ID);
 
       for (const tc of streamedToolCalls) {
+        throwIfAborted(abortSignal);
         const { args, error: argError } = parseToolArgs(tc.arguments);
         const toolCall: ToolCall = { id: tc.id, name: tc.name, args, status: "pending" };
 
@@ -737,6 +794,7 @@ export class AgentRuntime {
               ...toolContext,
             },
           );
+          throwIfAborted(abortSignal);
 
           toolCall.status = "completed";
           toolCall.result = result;
@@ -785,6 +843,7 @@ export class AgentRuntime {
         }
       }
 
+      throwIfAborted(abortSignal);
       sendSSE(controller, encoder, { type: "step-end" });
       this.status = "thinking";
     }

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -39,7 +39,7 @@ import { generateText, type LanguageModel, streamText } from "ai";
 import { AGENT_DEFAULTS } from "../ai-defaults.ts";
 
 // Re-export from submodules
-export { generateMessageId, sendSSE } from "./sse-utils.ts";
+export { closeSSEStream, generateMessageId, sendSSE } from "./sse-utils.ts";
 export {
   executeConfiguredTool,
   getAvailableTools,
@@ -58,7 +58,7 @@ export {
 } from "./constants.ts";
 
 import { DEFAULT_MAX_TOKENS, DEFAULT_TEMPERATURE } from "./constants.ts";
-import { generateMessageId, sendSSE } from "./sse-utils.ts";
+import { closeSSEStream, generateMessageId, sendSSE } from "./sse-utils.ts";
 import {
   executeConfiguredTool,
   getAvailableTools,
@@ -324,7 +324,7 @@ export class AgentRuntime {
 
           sendSSE(controller, encoder, { type: "text-end", id: textPartId });
           sendSSE(controller, encoder, { type: "message-finish" });
-          controller.close();
+          closeSSEStream(controller);
         } catch (error) {
           this.status = "error";
           logger.error("Agent stream error", { error });
@@ -332,7 +332,7 @@ export class AgentRuntime {
             type: "error",
             error: "An internal error occurred",
           });
-          controller.close();
+          closeSSEStream(controller);
         }
       },
     });

--- a/src/agent/runtime/sse-utils.test.ts
+++ b/src/agent/runtime/sse-utils.test.ts
@@ -36,17 +36,6 @@ describe("sse-utils", () => {
       assertEquals(parsed.type, "complex");
       assertEquals(parsed.data.nested, true);
     });
-
-    it("ignores closed stream controller enqueue errors", () => {
-      const encoder = new TextEncoder();
-      const controller = {
-        enqueue() {
-          throw new TypeError("The stream controller cannot close or enqueue");
-        },
-      } as unknown as ReadableStreamDefaultController;
-
-      sendSSE(controller, encoder, { type: "test" });
-    });
   });
 
   describe("closeSSEStream", () => {

--- a/src/agent/runtime/sse-utils.test.ts
+++ b/src/agent/runtime/sse-utils.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { generateMessageId, sendSSE } from "./sse-utils.ts";
+import { closeSSEStream, generateMessageId, sendSSE } from "./sse-utils.ts";
 
 function createController(chunks: Uint8Array[]): ReadableStreamDefaultController {
   return {
@@ -35,6 +35,29 @@ describe("sse-utils", () => {
       const parsed = JSON.parse(decoded.replace("data: ", "").trim());
       assertEquals(parsed.type, "complex");
       assertEquals(parsed.data.nested, true);
+    });
+
+    it("ignores closed stream controller enqueue errors", () => {
+      const encoder = new TextEncoder();
+      const controller = {
+        enqueue() {
+          throw new TypeError("The stream controller cannot close or enqueue");
+        },
+      } as unknown as ReadableStreamDefaultController;
+
+      sendSSE(controller, encoder, { type: "test" });
+    });
+  });
+
+  describe("closeSSEStream", () => {
+    it("ignores closed stream controller close errors", () => {
+      const controller = {
+        close() {
+          throw new TypeError("The stream controller cannot close or enqueue");
+        },
+      } as unknown as ReadableStreamDefaultController;
+
+      closeSSEStream(controller);
     });
   });
 

--- a/src/agent/runtime/sse-utils.ts
+++ b/src/agent/runtime/sse-utils.ts
@@ -6,29 +6,21 @@
  * @module ai/agent/runtime/sse-utils
  */
 
-/**
- * Encode and enqueue a Server-Sent Event (SSE) to the stream controller.
- * Formats event as: data: {json}\n\n
- */
 function isClosedStreamControllerError(error: unknown): error is TypeError {
   return error instanceof TypeError &&
     error.message.includes("The stream controller cannot close or enqueue");
 }
 
+/**
+ * Encode and enqueue a Server-Sent Event (SSE) to the stream controller.
+ * Formats event as: data: {json}\n\n
+ */
 export function sendSSE(
   controller: ReadableStreamDefaultController,
   encoder: TextEncoder,
   event: Record<string, unknown>,
 ): void {
-  try {
-    controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
-  } catch (error) {
-    if (isClosedStreamControllerError(error)) {
-      return;
-    }
-
-    throw error;
-  }
+  controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
 }
 
 export function closeSSEStream(controller: ReadableStreamDefaultController): void {

--- a/src/agent/runtime/sse-utils.ts
+++ b/src/agent/runtime/sse-utils.ts
@@ -10,12 +10,37 @@
  * Encode and enqueue a Server-Sent Event (SSE) to the stream controller.
  * Formats event as: data: {json}\n\n
  */
+function isClosedStreamControllerError(error: unknown): error is TypeError {
+  return error instanceof TypeError &&
+    error.message.includes("The stream controller cannot close or enqueue");
+}
+
 export function sendSSE(
   controller: ReadableStreamDefaultController,
   encoder: TextEncoder,
   event: Record<string, unknown>,
 ): void {
-  controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+  try {
+    controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+  } catch (error) {
+    if (isClosedStreamControllerError(error)) {
+      return;
+    }
+
+    throw error;
+  }
+}
+
+export function closeSSEStream(controller: ReadableStreamDefaultController): void {
+  try {
+    controller.close();
+  } catch (error) {
+    if (isClosedStreamControllerError(error)) {
+      return;
+    }
+
+    throw error;
+  }
 }
 
 /**

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -31,6 +31,9 @@ export interface RuntimeAgentStreamExecutionDeps {
       callbacks?: {
         onFinish?: (response: AgentResponse) => void;
       },
+      modelOverride?: string,
+      maxOutputTokensOverride?: number,
+      abortSignal?: AbortSignal,
     ) => Promise<ReadableStream<Uint8Array>>;
   };
 }
@@ -233,6 +236,9 @@ export async function createRuntimeAgentStreamResponse(
           completedResponse = response;
         },
       },
+      undefined,
+      undefined,
+      abortSignal,
     );
   } catch (error) {
     deps.sessionManager.failRun(input.runId);

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -3,7 +3,7 @@ import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.103";
+export const VERSION = "0.1.104";
 
 export function normalizeVeryfrontVersion(version: string | undefined): string | undefined {
   if (!version) return undefined;

--- a/tests/ai/agent-runtime-streaming.test.ts
+++ b/tests/ai/agent-runtime-streaming.test.ts
@@ -1,9 +1,6 @@
 import { describe, it } from "#veryfront/testing/bdd";
 import { deleteEnv, getEnv, setEnv } from "#veryfront/testing/deno-compat";
-import {
-  type AgentConfig,
-  type Message,
-} from "../../src/agent/types.ts";
+import { type AgentConfig, type Message } from "../../src/agent/types.ts";
 
 function assert(condition: unknown, message?: string): void {
   if (!condition) throw new Error(message || "Assertion failed");
@@ -19,9 +16,11 @@ describe("AgentRuntime streaming with AI SDK", () => {
   it("should stream text content via AI SDK model registry", async () => {
     const originalLogLevel = getEnv("LOG_LEVEL");
     const originalNodeEnv = getEnv("NODE_ENV");
+    const originalDisableLruInterval = getEnv("VF_DISABLE_LRU_INTERVAL");
 
     setEnv("LOG_LEVEL", "silent");
     setEnv("NODE_ENV", "test");
+    setEnv("VF_DISABLE_LRU_INTERVAL", "1");
 
     try {
       const { AgentRuntime } = await import("../../src/agent/runtime/index.ts");
@@ -46,7 +45,12 @@ describe("AgentRuntime streaming with AI SDK", () => {
                 type: "finish" as const,
                 finishReason: { unified: "stop" as const, raw: "stop" },
                 usage: {
-                  inputTokens: { total: 5, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
+                  inputTokens: {
+                    total: 5,
+                    noCache: undefined,
+                    cacheRead: undefined,
+                    cacheWrite: undefined,
+                  },
                   outputTokens: { total: 3, text: undefined, reasoning: undefined },
                 },
               },
@@ -97,6 +101,122 @@ describe("AgentRuntime streaming with AI SDK", () => {
     } finally {
       restoreEnv("LOG_LEVEL", originalLogLevel);
       restoreEnv("NODE_ENV", originalNodeEnv);
+      restoreEnv("VF_DISABLE_LRU_INTERVAL", originalDisableLruInterval);
+    }
+  });
+
+  it("should propagate abort signals into the streaming model call and close cleanly", async () => {
+    const originalLogLevel = getEnv("LOG_LEVEL");
+    const originalNodeEnv = getEnv("NODE_ENV");
+    const originalDisableLruInterval = getEnv("VF_DISABLE_LRU_INTERVAL");
+
+    setEnv("LOG_LEVEL", "silent");
+    setEnv("NODE_ENV", "test");
+    setEnv("VF_DISABLE_LRU_INTERVAL", "1");
+
+    try {
+      const { AgentRuntime } = await import("../../src/agent/runtime/index.ts");
+      const { registerModelProvider, clearModelProviders } = await import(
+        "../../src/provider/model-registry.ts"
+      );
+      const { MockLanguageModelV3 } = await import("ai/test");
+
+      clearModelProviders();
+
+      let providerAbortSignal: AbortSignal | undefined;
+
+      const mockModel = new MockLanguageModelV3({
+        provider: "mock",
+        modelId: "mock-model",
+        doStream: async (options) => {
+          providerAbortSignal = options.abortSignal;
+
+          return {
+            stream: new ReadableStream({
+              start(controller) {
+                options.abortSignal?.addEventListener("abort", () => {
+                  controller.error(
+                    options.abortSignal?.reason ??
+                      new DOMException("The operation was aborted", "AbortError"),
+                  );
+                }, { once: true });
+              },
+            }),
+            rawCall: { rawPrompt: null, rawSettings: {} },
+          };
+        },
+      });
+
+      registerModelProvider("mock", () => mockModel);
+
+      const runtime = new AgentRuntime("test", {
+        id: "test-agent",
+        model: "mock/mock-model",
+        system: "You are a tester",
+        memory: { type: "conversation", maxTokens: 4000 },
+      });
+      const messages: Message[] = [{
+        id: "m1",
+        role: "user",
+        parts: [{ type: "text", text: "hi" }],
+      }];
+
+      const abortController = new AbortController();
+      const stream = await runtime.stream(
+        messages,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        abortController.signal,
+      );
+      const reader = stream.getReader();
+      const decoder = new TextDecoder();
+      let output = "";
+
+      const readAll = (async () => {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+
+          output += decoder.decode(value, { stream: true });
+        }
+      })();
+
+      for (let attempt = 0; attempt < 10 && !providerAbortSignal; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+
+      abortController.abort(new DOMException("The operation was aborted", "AbortError"));
+
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      await Promise.race([
+        readAll,
+        new Promise((_, reject) => {
+          timeoutId = setTimeout(
+            () => reject(new Error("Timed out waiting for aborted stream")),
+            1_000,
+          );
+        }),
+      ]);
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+
+      assert(providerAbortSignal, "provider abort signal should be passed to streamText");
+      assert(providerAbortSignal.aborted, "provider abort signal should be aborted");
+      assert(
+        !output.includes('"type":"error"'),
+        "aborted streams should close without emitting a generic error",
+      );
+
+      clearModelProviders();
+    } finally {
+      restoreEnv("LOG_LEVEL", originalLogLevel);
+      restoreEnv("NODE_ENV", originalNodeEnv);
+      restoreEnv("VF_DISABLE_LRU_INTERVAL", originalDisableLruInterval);
     }
   });
 });


### PR DESCRIPTION
## Summary
- guard SSE enqueue/close helpers against the closed-controller error raised after cancellation
- use the guarded close helper in the runtime stream shutdown path
- add focused runtime tests for closed-controller enqueue and close cases

## Testing
- VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --unstable-net src/agent/runtime/sse-utils.test.ts
- deno check src/agent/runtime/index.ts
- deno fmt --check src/agent/runtime/index.ts src/agent/runtime/sse-utils.ts src/agent/runtime/sse-utils.test.ts
- DENO_NO_PACKAGE_JSON=1 deno lint src/agent/runtime/index.ts src/agent/runtime/sse-utils.ts src/agent/runtime/sse-utils.test.ts