### PR TITLE
fix: route hosted provider models through veryfront-cloud

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.104",
+  "version": "0.1.105",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -21,7 +21,7 @@ import {
   type MessagePart,
   type ToolCall,
 } from "../types.ts";
-import { ensureModelReady, findAvailableCloudModel, resolveModel } from "#veryfront/provider";
+import { ensureModelReady, resolveModel } from "#veryfront/provider";
 import { generateId } from "#veryfront/utils/id.ts";
 import { detectPlatform, getPlatformCapabilities } from "#veryfront/platform/core-platform.ts";
 import { createMemory, type Memory } from "../memory/index.ts";
@@ -71,7 +71,7 @@ import {
   isToolAllowedBySkill,
   validateAllowedToolPatterns,
 } from "#veryfront/skill/allowed-tools.ts";
-import { resolveConfiguredAgentModel } from "./model-resolution.ts";
+import { resolveConfiguredAgentModel, resolveRuntimeModel } from "./model-resolution.ts";
 
 const logger = serverLogger.component("agent");
 const LOAD_SKILL_TOOL_ID = "load-skill";
@@ -175,26 +175,6 @@ export function enforceSkillPolicy(
 }
 
 /**
- * Auto-upgrade a local model string to a cloud provider when API keys are available.
- *
- * Returns the upgraded "provider/model" string, or the original string unchanged
- * if no cloud provider is available. This keeps resolveModel as a pure resolver
- * while the runtime owns the upgrade policy.
- */
-function maybeUpgradeLocalModel(modelString: string): string {
-  if (!modelString.startsWith("local/")) return modelString;
-
-  const cloud = findAvailableCloudModel();
-  if (cloud) {
-    logger.info(
-      `⚡ Cloud AI API key found — using "${cloud}" instead of local model.`,
-    );
-    return cloud;
-  }
-  return modelString;
-}
-
-/**
  * Check whether a resolved LanguageModel is a local inference model.
  * Checks the model object properties rather than the requested string,
  * because resolveModel may internally fall back from cloud to local.
@@ -231,7 +211,12 @@ export class AgentRuntime {
     maxOutputTokensOverride?: number,
   ): Promise<AgentResponse> {
     const requestedModel = resolveConfiguredAgentModel(modelOverride || this.config.model);
-    const resolvedModelString = maybeUpgradeLocalModel(requestedModel);
+    const resolvedModelString = resolveRuntimeModel(modelOverride || this.config.model);
+    if (resolvedModelString !== requestedModel) {
+      logger.info(
+        `⚡ Using runtime model "${resolvedModelString}" instead of "${requestedModel}".`,
+      );
+    }
 
     return withSpan("agent.generate", async (span) => {
       setSpanAttributes(span, {
@@ -284,8 +269,12 @@ export class AgentRuntime {
     abortSignal?: AbortSignal,
   ): Promise<ReadableStream<Uint8Array>> {
     const requestedModel = resolveConfiguredAgentModel(modelOverride || this.config.model);
-    // Auto-upgrade local/* to a cloud provider when API keys are available.
-    const resolvedModelString = maybeUpgradeLocalModel(requestedModel);
+    const resolvedModelString = resolveRuntimeModel(modelOverride || this.config.model);
+    if (resolvedModelString !== requestedModel) {
+      logger.info(
+        `⚡ Using runtime model "${resolvedModelString}" instead of "${requestedModel}".`,
+      );
+    }
 
     for (const msg of messages) await this.memory.add(msg);
 
@@ -402,7 +391,7 @@ export class AgentRuntime {
     return withSpan("agent.execution_loop", async (loopSpan) => {
       const { maxAgentSteps } = getPlatformCapabilities();
       const maxSteps = this.computeMaxSteps(maxAgentSteps);
-      const effectiveModel = resolveConfiguredAgentModel(modelString || this.config.model);
+      const effectiveModel = resolveRuntimeModel(modelString || this.config.model);
       const languageModel = resolveModel(effectiveModel);
 
       const toolCalls: ToolCall[] = [];
@@ -643,7 +632,7 @@ export class AgentRuntime {
   ): Promise<AgentResponse> {
     const { maxAgentSteps } = getPlatformCapabilities();
     const maxSteps = this.computeMaxSteps(maxAgentSteps);
-    const effectiveModel = resolveConfiguredAgentModel(modelString || this.config.model);
+    const effectiveModel = resolveRuntimeModel(modelString || this.config.model);
     const languageModel = resolvedModel ?? resolveModel(effectiveModel);
 
     const toolCalls: ToolCall[] = [];

--- a/src/agent/runtime/model-resolution.test.ts
+++ b/src/agent/runtime/model-resolution.test.ts
@@ -1,12 +1,39 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { deleteEnv, setEnv } from "#veryfront/compat/process.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   AUTO_AGENT_MODEL,
   normalizeAgentModelConfig,
   resolveConfiguredAgentModel,
+  resolveRuntimeModel,
 } from "./model-resolution.ts";
 
+const MODEL_ENV_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "GOOGLE_API_KEY",
+  "GOOGLE_GENERATIVE_AI_API_KEY",
+  "OPENAI_API_KEY",
+  "VERYFRONT_API_TOKEN",
+  "VERYFRONT_DEFAULT_MODEL",
+  "VERYFRONT_PROJECT_SLUG",
+  "VERYFRONT_SERVICE_LAYER",
+] as const;
+
+function clearModelEnv(): void {
+  for (const key of MODEL_ENV_KEYS) {
+    try {
+      deleteEnv(key);
+    } catch {
+      // expected: env may already be unset
+    }
+  }
+}
+
 describe("agent/runtime/model-resolution", () => {
+  afterEach(() => {
+    clearModelEnv();
+  });
+
   it("normalizes missing models to auto", () => {
     assertEquals(normalizeAgentModelConfig(), AUTO_AGENT_MODEL);
     assertEquals(normalizeAgentModelConfig("   "), AUTO_AGENT_MODEL);
@@ -28,6 +55,47 @@ describe("agent/runtime/model-resolution", () => {
     assertEquals(
       resolveConfiguredAgentModel("openai/gpt-4o"),
       "openai/gpt-4o",
+    );
+  });
+
+  it("upgrades auto/local models to the default Veryfront cloud model when bootstrap is present", () => {
+    setEnv("VERYFRONT_API_TOKEN", "vf_test_runtime");
+    setEnv("VERYFRONT_PROJECT_SLUG", "demo-project");
+
+    assertEquals(
+      resolveRuntimeModel(),
+      "veryfront-cloud/anthropic/claude-sonnet-4-6",
+    );
+  });
+
+  it("routes explicit openai models through veryfront-cloud when only hosted bootstrap is available", () => {
+    setEnv("VERYFRONT_API_TOKEN", "vf_test_runtime");
+    setEnv("VERYFRONT_PROJECT_SLUG", "demo-project");
+
+    assertEquals(
+      resolveRuntimeModel("openai/gpt-5.4"),
+      "veryfront-cloud/openai/gpt-5.4",
+    );
+  });
+
+  it("keeps explicit provider models unchanged when native credentials are configured", () => {
+    setEnv("VERYFRONT_API_TOKEN", "vf_test_runtime");
+    setEnv("VERYFRONT_PROJECT_SLUG", "demo-project");
+    setEnv("OPENAI_API_KEY", "sk-test");
+
+    assertEquals(
+      resolveRuntimeModel("openai/gpt-5.4"),
+      "openai/gpt-5.4",
+    );
+  });
+
+  it("preserves explicit veryfront-cloud models", () => {
+    setEnv("VERYFRONT_API_TOKEN", "vf_test_runtime");
+    setEnv("VERYFRONT_PROJECT_SLUG", "demo-project");
+
+    assertEquals(
+      resolveRuntimeModel("veryfront-cloud/openai/gpt-5.4"),
+      "veryfront-cloud/openai/gpt-5.4",
     );
   });
 });

--- a/src/agent/runtime/model-resolution.ts
+++ b/src/agent/runtime/model-resolution.ts
@@ -1,6 +1,15 @@
+import {
+  getAnthropicEnvConfig,
+  getGoogleGenAIEnvConfig,
+  getOpenAIEnvConfig,
+} from "#veryfront/config/env.ts";
+import { findAvailableCloudModel } from "#veryfront/provider";
 import { DEFAULT_LOCAL_MODEL } from "#veryfront/provider/local/model-catalog.ts";
+import { isVeryfrontCloudEnabled } from "#veryfront/platform/cloud/resolver.ts";
 
 export const AUTO_AGENT_MODEL = "auto";
+
+const HOSTED_PROVIDER_NAMES = new Set(["anthropic", "google", "openai"]);
 
 export function normalizeAgentModelConfig(model?: string): string {
   const normalized = model?.trim();
@@ -10,4 +19,57 @@ export function normalizeAgentModelConfig(model?: string): string {
 export function resolveConfiguredAgentModel(model?: string): string {
   const normalized = normalizeAgentModelConfig(model);
   return normalized === AUTO_AGENT_MODEL ? `local/${DEFAULT_LOCAL_MODEL}` : normalized;
+}
+
+function hasDirectProviderCredentials(provider: string): boolean {
+  switch (provider) {
+    case "anthropic":
+      return Boolean(getAnthropicEnvConfig().apiKey);
+    case "google":
+      return Boolean(getGoogleGenAIEnvConfig().apiKey);
+    case "openai":
+      return Boolean(getOpenAIEnvConfig().apiKey);
+    default:
+      return false;
+  }
+}
+
+/**
+ * Resolve the effective runtime model string for agent execution.
+ *
+ * Runtime-only rewrites happen here:
+ * - `auto` still defaults to `local/*`
+ * - `local/*` upgrades to the first available cloud model when bootstrap exists
+ * - explicit hosted-provider models (`openai/*`, `anthropic/*`, `google/*`)
+ *   transparently route through `veryfront-cloud/*` when the runtime has
+ *   request-scoped Veryfront bootstrap but no direct provider API key
+ */
+export function resolveRuntimeModel(model?: string): string {
+  const configuredModel = resolveConfiguredAgentModel(model);
+
+  if (configuredModel.startsWith("veryfront-cloud/")) {
+    return configuredModel;
+  }
+
+  if (configuredModel.startsWith("local/")) {
+    return findAvailableCloudModel() ?? configuredModel;
+  }
+
+  const slashIndex = configuredModel.indexOf("/");
+  if (slashIndex === -1) {
+    return configuredModel;
+  }
+
+  const provider = configuredModel.slice(0, slashIndex);
+  const modelId = configuredModel.slice(slashIndex + 1);
+
+  if (!HOSTED_PROVIDER_NAMES.has(provider) || !modelId) {
+    return configuredModel;
+  }
+
+  if (!isVeryfrontCloudEnabled() || hasDirectProviderCredentials(provider)) {
+    return configuredModel;
+  }
+
+  return `veryfront-cloud/${provider}/${modelId}`;
 }

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -3,7 +3,7 @@ import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.104";
+export const VERSION = "0.1.105";
 
 export function normalizeVeryfrontVersion(version: string | undefined): string | undefined {
   if (!version) return undefined;


### PR DESCRIPTION
## Summary
- route explicit hosted provider models like `openai/...` through `veryfront-cloud/...` when request-scoped Veryfront bootstrap is available and native provider credentials are not
- keep explicit provider models unchanged when native credentials are configured, and preserve explicit `veryfront-cloud/...` models
- bump the release version to `0.1.105`

## Why
Project-agent runtime requests in hosted environments already carry request-scoped Veryfront bootstrap auth, but explicit models such as `openai/gpt-5.4` were still resolved as native provider models. In staging this caused runtime stream failures and fallback toward unsupported local ONNX instead of using the hosted Veryfront cloud provider path.

## Testing
- deno test --allow-env src/agent/runtime/model-resolution.test.ts
- deno test --allow-env src/platform/cloud/resolver.test.ts
- deno test --allow-env src/provider/veryfront-cloud/provider.test.ts
- deno test --allow-env src/utils/version.test.ts
- deno test --allow-env src/utils/logger/logger.test.ts
- full pre-push suite passed locally (format, lint, typecheck, 1214 unit tests)