### PR TITLE
fix: share internal agent sessions across duplicate module loads

### DIFF
--- a/src/internal-agents/session-manager.test.ts
+++ b/src/internal-agents/session-manager.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  _resetGlobalAgentRunSessionManagerForTesting,
   AgentRunCancelledError,
   AgentRunSessionManager,
   ToolResultConflictError,
@@ -112,5 +113,33 @@ describe("internal-agents/session-manager", () => {
     timerCallbacks[0]?.();
 
     assertEquals(sessionManager.getRunStatus("run_1"), null);
+  });
+
+  it("reuses the global session manager across duplicate module evaluations", async () => {
+    _resetGlobalAgentRunSessionManagerForTesting();
+
+    try {
+      const firstModule = await import(
+        new URL(`./session-manager.ts?instance=${crypto.randomUUID()}`, import.meta.url).href
+      ) as typeof import("./session-manager.ts");
+      const duplicateModule = await import(
+        new URL(`./session-manager.ts?instance=${crypto.randomUUID()}`, import.meta.url).href
+      ) as typeof import("./session-manager.ts");
+
+      assertEquals(
+        duplicateModule.agentRunSessionManager === firstModule.agentRunSessionManager,
+        true,
+      );
+
+      firstModule.agentRunSessionManager.startRun({
+        runId: "run_global",
+        threadId: crypto.randomUUID(),
+      });
+      assertEquals(duplicateModule.agentRunSessionManager.getRunStatus("run_global"), "running");
+      assertEquals(duplicateModule.agentRunSessionManager.cancelRun("run_global"), true);
+      assertEquals(firstModule.agentRunSessionManager.getRunStatus("run_global"), null);
+    } finally {
+      _resetGlobalAgentRunSessionManagerForTesting();
+    }
   });
 });

--- a/src/internal-agents/session-manager.ts
+++ b/src/internal-agents/session-manager.ts
@@ -60,6 +60,7 @@ export class ToolResultConflictError extends Error {
 const DEFAULT_WAITING_FOR_TOOL_TTL_MS = 5 * 60 * 1000;
 const DEFAULT_SESSION_TTL_MS = 15 * 60 * 1000;
 const DEFAULT_MAX_CONCURRENT_SESSIONS = 100;
+const AGENT_RUN_SESSION_MANAGER_GLOBAL_KEY = "__veryfrontAgentRunSessionManager" as const;
 
 type SessionStatus = "running" | "waiting" | "completed" | "cancelled" | "failed";
 
@@ -352,6 +353,27 @@ export class AgentRunSessionManager {
   }
 }
 
-export const agentRunSessionManager = new AgentRunSessionManager({
-  sessionTtlMs: DEFAULT_SESSION_TTL_MS,
-});
+type AgentRunSessionManagerGlobal = typeof globalThis & {
+  [AGENT_RUN_SESSION_MANAGER_GLOBAL_KEY]?: AgentRunSessionManager;
+};
+
+function getGlobalAgentRunSessionManager(): AgentRunSessionManager {
+  const runtimeGlobal = globalThis as AgentRunSessionManagerGlobal;
+  const existing = runtimeGlobal[AGENT_RUN_SESSION_MANAGER_GLOBAL_KEY];
+  if (existing) {
+    return existing;
+  }
+
+  const sessionManager = new AgentRunSessionManager({
+    sessionTtlMs: DEFAULT_SESSION_TTL_MS,
+  });
+  runtimeGlobal[AGENT_RUN_SESSION_MANAGER_GLOBAL_KEY] = sessionManager;
+  return sessionManager;
+}
+
+export function _resetGlobalAgentRunSessionManagerForTesting(): void {
+  const runtimeGlobal = globalThis as AgentRunSessionManagerGlobal;
+  delete runtimeGlobal[AGENT_RUN_SESSION_MANAGER_GLOBAL_KEY];
+}
+
+export const agentRunSessionManager = getGlobalAgentRunSessionManager();


### PR DESCRIPTION
## Summary
- make the internal agent run session manager process-global so duplicate module evaluations reuse the same session registry
- add a regression test that imports the module twice and proves both evaluations see the same run state
- preserve existing waiting-run resumability semantics while fixing the cancel/start 404/409 split seen in staging

## Testing
- deno fmt --check src/internal-agents/session-manager.ts src/internal-agents/session-manager.test.ts
- deno lint src/internal-agents/session-manager.ts src/internal-agents/session-manager.test.ts
- VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --unstable-net src/internal-agents/session-manager.test.ts src/server/handlers/request/agent-stream.handler.test.ts src/server/handlers/request/agent-run-cancel.handler.test.ts src/server/handlers/request/agent-run-resume.handler.test.ts
- git push -u origin fix/global-agent-run-session-manager
