### PR TITLE
Allow internal agent control-plane routes without releaseId

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/server/runtime-handler/environment-resolution.test.ts
+++ b/src/server/runtime-handler/environment-resolution.test.ts
@@ -46,6 +46,46 @@ describe("environment-resolution", () => {
     assertEquals(result.releaseId, undefined);
   });
 
+  it("allows signed internal agent control-plane paths without releaseId in proxy production", () => {
+    const result = resolveEnvironment({
+      proxyEnv: "production",
+      reqCtxMode: "production",
+      releaseId: undefined,
+      projectSlug: "my-project",
+      projectId: "proj_123",
+      environmentName: undefined,
+      host: "10.192.2.245:20000",
+      isLocalProject: false,
+      isProxyMode: true,
+      pathname: "/internal/agents/runs/run_1",
+      defaultEnvironment: undefined,
+    });
+
+    assertEquals(result.errorResponse, undefined);
+    assertEquals(result.resolvedEnvironment, "production");
+    assertEquals(result.releaseId, undefined);
+  });
+
+  it("still requires releaseId for non-control-plane proxy production paths", () => {
+    const result = resolveEnvironment({
+      proxyEnv: "production",
+      reqCtxMode: "production",
+      releaseId: undefined,
+      projectSlug: "my-project",
+      projectId: "proj_123",
+      environmentName: undefined,
+      host: "10.192.2.245:20000",
+      isLocalProject: false,
+      isProxyMode: true,
+      pathname: "/api/health",
+      defaultEnvironment: undefined,
+    });
+
+    assertEquals(result.errorResponse?.status, 404);
+    assertEquals(result.resolvedEnvironment, "production");
+    assertEquals(result.releaseId, undefined);
+  });
+
   it("falls back to preview in standalone production without releaseId", () => {
     const result = resolveEnvironment({
       proxyEnv: undefined,

--- a/src/server/runtime-handler/environment-resolution.ts
+++ b/src/server/runtime-handler/environment-resolution.ts
@@ -62,9 +62,15 @@ export function resolveEnvironment(
 
   let releaseId = opts.releaseId;
 
-  // Skip releaseId validation for WebSocket/HMR endpoints - they're for development
-  // features and shouldn't require release context
-  const isWebSocketOrHMR = opts.pathname === "/_ws" || opts.pathname.startsWith("/_veryfront/");
+  // Some internal framework surfaces are routed directly to a runtime owner pod and
+  // rely on signed control-plane auth instead of a user-facing release address.
+  const isInternalAgentControlPlanePath = opts.pathname.startsWith("/internal/agents/");
+
+  // Skip releaseId validation for development assets and signed internal control-plane
+  // requests because they do not require a user-facing release context.
+  const canSkipReleaseIdValidation = opts.pathname === "/_ws" ||
+    opts.pathname.startsWith("/_veryfront/") ||
+    isInternalAgentControlPlanePath;
 
   // Validate releaseId in proxy mode production
   if (
@@ -73,7 +79,7 @@ export function resolveEnvironment(
     opts.projectSlug &&
     !releaseId &&
     !opts.isLocalProject &&
-    !isWebSocketOrHMR
+    !canSkipReleaseIdValidation
   ) {
     logger.warn("No active release found (proxy mode)", {
       projectSlug: opts.projectSlug,

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -3,7 +3,7 @@ import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.105";
+export const VERSION = "0.1.106";
 
 export function normalizeVeryfrontVersion(version: string | undefined): string | undefined {
   if (!version) return undefined;


### PR DESCRIPTION
## Summary
- allow signed internal `/internal/agents/*` requests to bypass proxy-mode releaseId gating
- keep normal proxy production 404 behavior for non-control-plane paths
- bump framework version to `0.1.106` for release on merge

## Verification
- `deno test --no-check --allow-all src/server/runtime-handler/environment-resolution.test.ts src/server/handlers/request/agent-stream.handler.test.ts src/server/handlers/request/agent-run-cancel.handler.test.ts src/server/handlers/request/agent-run-resume.handler.test.ts`
- `deno task verify:quick`
- repo pre-push checks (`fmt`, `lint`, `typecheck`, full unit suite)