### PR TITLE
fix: bypass render context for internal agent control plane

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.106",
+  "version": "0.1.107",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/server/runtime-handler/handler-context-builder.test.ts
+++ b/src/server/runtime-handler/handler-context-builder.test.ts
@@ -125,6 +125,20 @@ describe("buildHandlerContext", () => {
 
     assertEquals(ctx.enriched!.token, "");
   });
+
+  it("skips enriched render context for internal control-plane requests without a release id", () => {
+    const opts = makeOpts({
+      releaseId: undefined,
+      resolvedEnvironment: "production",
+      skipEnrichedContext: true,
+    });
+
+    const ctx = buildHandlerContext(opts);
+
+    assertEquals(ctx.releaseId, undefined);
+    assertEquals(ctx.projectSlug, "my-project");
+    assertEquals(ctx.enriched, undefined);
+  });
 });
 
 describe("buildMinimalContext", () => {

--- a/src/server/runtime-handler/handler-context-builder.ts
+++ b/src/server/runtime-handler/handler-context-builder.ts
@@ -56,13 +56,15 @@ interface HandlerContextOptions {
   moduleServerUrl: string | undefined;
   /** Environment ID for env var resolution (from proxy x-environment-id header) */
   environmentId: string | undefined;
+  /** Skip render-specific enriched context requirements for non-render control-plane routes */
+  skipEnrichedContext?: boolean;
 }
 
 /**
  * Build the HandlerContext for route handlers.
  */
 export function buildHandlerContext(opts: HandlerContextOptions): HandlerContext {
-  const contentSourceId = computeContentSourceId(
+  const contentSourceId = opts.skipEnrichedContext ? undefined : computeContentSourceId(
     opts.isLocalProject,
     opts.resolvedEnvironment,
     opts.requestContext.branch,
@@ -70,7 +72,8 @@ export function buildHandlerContext(opts: HandlerContextOptions): HandlerContext
   );
 
   // Build enriched context if we have config and project slug
-  const enrichedContext = opts.config && opts.projectSlug
+  const enrichedContext = !opts.skipEnrichedContext && opts.config && opts.projectSlug &&
+      contentSourceId
     ? buildEnrichedContext({
       projectId: opts.projectId ?? opts.projectSlug,
       projectSlug: opts.projectSlug,

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -549,6 +549,8 @@ export function createVeryfrontHandler(
             return envRes.errorResponse;
           }
 
+          const isInternalAgentControlPlanePath = url.pathname.startsWith("/internal/agents/");
+
           // Build handler context
           const ctx = buildHandlerContext({
             projectDir: adapterRes.projectDir,
@@ -569,6 +571,7 @@ export function createVeryfrontHandler(
             isLocalProject: adapterRes.isLocalProject,
             moduleServerUrl: opts.moduleServerUrl,
             environmentId: headers.environmentId,
+            skipEnrichedContext: isInternalAgentControlPlanePath,
           });
 
           // Fetch per-project env vars for remote projects

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -3,7 +3,7 @@ import { getEnv } from "#veryfront/platform/compat/process.ts";
 
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.106";
+export const VERSION = "0.1.107";
 
 export function normalizeVeryfrontVersion(version: string | undefined): string | undefined {
   if (!version) return undefined;


### PR DESCRIPTION
## Summary
- skip render/enriched handler context for signed internal agent control-plane routes
- avoid requiring a production releaseId for `/internal/agents/*` request context building
- bump veryfront-code to 0.1.107 for rollout

## Testing
- deno test --no-check --allow-all src/server/runtime-handler/environment-resolution.test.ts src/server/runtime-handler/handler-context-builder.test.ts src/server/handlers/request/agent-run-cancel.handler.test.ts src/server/handlers/request/agent-run-resume.handler.test.ts src/server/handlers/request/agent-stream.handler.test.ts
- deno task verify:quick
