### PR TITLE
chore: add Socket.dev CI integration for automatic PR scanning

### DIFF
--- a/.github/workflows/socket-security.yml
+++ b/.github/workflows/socket-security.yml
@@ -1,0 +1,22 @@
+name: Socket Security
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  socket-security:
+    runs-on: ubuntu-latest
+    name: Socket.dev Security Review
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Socket Security Review
+        uses: SocketDev/socket-sdk-js@v1
+        with:
+          api_key: ${{ secrets.SOCKET_API_KEY }}

--- a/.github/workflows/socket-security.yml
+++ b/.github/workflows/socket-security.yml
@@ -17,6 +17,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Socket Security Review
-        uses: SocketDev/socket-sdk-js@v1
+        uses: SocketDev/action@v1
         with:
-          api_key: ${{ secrets.SOCKET_API_KEY }}
+          socket-token: ${{ secrets.SOCKET_API_KEY }}


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow (`.github/workflows/socket-security.yml`) that runs Socket.dev security review on every PR targeting `main`.

### What it does
- Scans dependency changes for supply chain risks on every PR
- Detects malware, typosquatting, install scripts, network access, obfuscated code
- Posts findings as PR comments
- Uses the `socket.yml` config (merged in #747) to suppress verified false positives

### Setup required
- Add `SOCKET_API_KEY` secret to repository settings (get from [socket.dev/dashboard](https://socket.dev))

Part of supply chain security hardening (Phase 6).

## Test plan
- [ ] Configure `SOCKET_API_KEY` secret
- [ ] Open a test PR with a dependency change to verify scanning works