### PR TITLE
chore: add npm audit CI gate and weekly security scan

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,25 @@
+name: Security Audit
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "deno.json"
+  schedule:
+    # Run weekly on Monday at 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  npm-audit:
+    runs-on: ubuntu-latest
+    name: NPM Dependency Audit
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-deno
+
+      - name: Run npm dependency audit
+        run: deno task audit
+
+      - name: Run dependency lint
+        run: deno task lint:deps

--- a/deno.json
+++ b/deno.json
@@ -366,7 +366,8 @@
     "rlm:audit": "deno run -A scripts/rlm-ts/apps/audit.ts",
     "start-split": "deno task generate && deno run --allow-all cli/main.ts serve --split",
     "start-split:binary": "deno task generate && deno run --allow-all cli/main.ts serve --split --binary",
-    "sbom": "deno run --allow-read --allow-write scripts/build/generate-sbom.ts"
+    "sbom": "deno run --allow-read --allow-write scripts/build/generate-sbom.ts",
+    "audit": "deno run --allow-read --allow-run --allow-write scripts/security/audit-npm.ts"
   },
   "lint": {
     "include": [

--- a/scripts/security/audit-npm.ts
+++ b/scripts/security/audit-npm.ts
@@ -1,0 +1,134 @@
+/**
+ * NPM dependency audit script for Deno projects.
+ *
+ * Extracts npm dependencies from deno.json, runs npm audit against them,
+ * and reports vulnerabilities. Exits with code 1 if high/critical vulns found.
+ *
+ * Usage: deno run --allow-read --allow-run --allow-write scripts/security/audit-npm.ts
+ */
+
+const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
+const imports: Record<string, string> = denoConfig.imports ?? {};
+
+// Extract npm package names and versions
+const npmDeps: Record<string, string> = {};
+for (const [_specifier, target] of Object.entries(imports)) {
+  if (!target.startsWith("npm:")) continue;
+  const match = target.match(/^npm:(.+)@(\d[^/]*)/);
+  if (!match) continue;
+  const [, name, version] = match;
+  npmDeps[name] = version;
+}
+
+if (Object.keys(npmDeps).length === 0) {
+  console.log("No npm dependencies found in deno.json.");
+  Deno.exit(0);
+}
+
+// Create a temporary package.json for npm audit
+const tmpDir = await Deno.makeTempDir({ prefix: "vf-audit-" });
+const packageJson = {
+  name: "veryfront-audit",
+  version: "0.0.0",
+  private: true,
+  dependencies: npmDeps,
+};
+
+await Deno.writeTextFile(
+  `${tmpDir}/package.json`,
+  JSON.stringify(packageJson, null, 2),
+);
+
+console.log(`Auditing ${Object.keys(npmDeps).length} npm dependencies...\n`);
+
+// Run npm audit --json
+const cmd = new Deno.Command("npm", {
+  args: ["audit", "--json", "--omit=dev", "--package-lock-only"],
+  cwd: tmpDir,
+  stdout: "piped",
+  stderr: "piped",
+});
+
+// First generate package-lock.json
+const installCmd = new Deno.Command("npm", {
+  args: ["install", "--package-lock-only", "--ignore-scripts"],
+  cwd: tmpDir,
+  stdout: "piped",
+  stderr: "piped",
+});
+
+const installResult = await installCmd.output();
+if (!installResult.success) {
+  const stderr = new TextDecoder().decode(installResult.stderr);
+  // npm install warnings are normal, only fail on actual errors
+  if (installResult.code > 1) {
+    console.error("Failed to generate package-lock.json:", stderr);
+    await Deno.remove(tmpDir, { recursive: true });
+    Deno.exit(1);
+  }
+}
+
+const result = await cmd.output();
+const stdout = new TextDecoder().decode(result.stdout);
+
+// Clean up
+await Deno.remove(tmpDir, { recursive: true });
+
+// Parse audit results
+let audit: {
+  vulnerabilities?: Record<
+    string,
+    { severity: string; via: unknown[]; fixAvailable?: boolean }
+  >;
+  metadata?: {
+    vulnerabilities: Record<string, number>;
+    totalDependencies: number;
+  };
+};
+
+try {
+  audit = JSON.parse(stdout);
+} catch {
+  // npm audit may return non-JSON on error
+  console.log("npm audit completed (no JSON output — likely no vulnerabilities).");
+  Deno.exit(0);
+}
+
+const meta = audit.metadata?.vulnerabilities;
+const vulns = audit.vulnerabilities ?? {};
+
+if (!meta || Object.values(meta).every((v) => v === 0)) {
+  console.log("✅ No vulnerabilities found.");
+  Deno.exit(0);
+}
+
+// Report
+console.log("Vulnerability Summary:");
+console.log(`  Critical: ${meta.critical ?? 0}`);
+console.log(`  High:     ${meta.high ?? 0}`);
+console.log(`  Moderate: ${meta.moderate ?? 0}`);
+console.log(`  Low:      ${meta.low ?? 0}`);
+console.log(`  Info:     ${meta.info ?? 0}`);
+console.log(`  Total:    ${meta.total ?? 0}`);
+console.log();
+
+// List affected packages
+const sevOrder = ["critical", "high", "moderate", "low", "info"];
+const sortedVulns = Object.entries(vulns).sort(
+  ([, a], [, b]) => sevOrder.indexOf(a.severity) - sevOrder.indexOf(b.severity),
+);
+
+for (const [pkg, info] of sortedVulns) {
+  const fix = info.fixAvailable ? " (fix available)" : "";
+  console.log(`  ${info.severity.toUpperCase().padEnd(10)} ${pkg}${fix}`);
+}
+
+// Exit with error if high or critical vulnerabilities found
+const hasBlocking = (meta.critical ?? 0) > 0 || (meta.high ?? 0) > 0;
+if (hasBlocking) {
+  console.log("\n❌ High/critical vulnerabilities found. Audit failed.");
+  Deno.exit(1);
+} else {
+  console.log("\n⚠️  Non-blocking vulnerabilities found (moderate/low/info only).");
+  Deno.exit(0);
+}

--- a/scripts/security/audit-npm.ts
+++ b/scripts/security/audit-npm.ts
@@ -60,12 +60,9 @@ const installCmd = new Deno.Command("npm", {
 const installResult = await installCmd.output();
 if (!installResult.success) {
   const stderr = new TextDecoder().decode(installResult.stderr);
-  // npm install warnings are normal, only fail on actual errors
-  if (installResult.code > 1) {
-    console.error("Failed to generate package-lock.json:", stderr);
-    await Deno.remove(tmpDir, { recursive: true });
-    Deno.exit(1);
-  }
+  console.error("Failed to generate package-lock.json:", stderr);
+  await Deno.remove(tmpDir, { recursive: true });
+  Deno.exit(1);
 }
 
 const result = await cmd.output();
@@ -89,9 +86,10 @@ let audit: {
 try {
   audit = JSON.parse(stdout);
 } catch {
-  // npm audit may return non-JSON on error
-  console.log("npm audit completed (no JSON output — likely no vulnerabilities).");
-  Deno.exit(0);
+  // Fail closed: non-JSON output means npm audit errored (network, auth, registry)
+  console.error("❌ npm audit failed — non-JSON output (possible network/registry error).");
+  console.error("stdout:", stdout.slice(0, 500));
+  Deno.exit(1);
 }
 
 const meta = audit.metadata?.vulnerabilities;


### PR DESCRIPTION
## Summary
Adds automated npm dependency auditing as a CI gate and scheduled security scan.

### New files
- **`scripts/security/audit-npm.ts`** — extracts npm deps from `deno.json`, generates temp `package.json`, runs `npm audit`, reports findings
- **`.github/workflows/security-audit.yml`** — CI workflow with 3 triggers
- **`deno.json`** — adds `audit` task

### How it works
1. Extracts all `npm:` dependencies from `deno.json` imports
2. Creates a temporary `package.json` with those deps
3. Runs `npm audit --json` against them
4. Reports vulnerability summary (critical/high/moderate/low)
5. **Fails CI** if high or critical vulnerabilities are found
6. Also runs `lint:deps` (exotic dependency audit from #708)

### Triggers
| Trigger | When |
|---------|------|
| PR gate | PRs that modify `deno.json` |
| Weekly schedule | Monday 06:00 UTC |
| Manual | Workflow dispatch |

### Local usage
```bash
deno task audit
```

Part of supply chain security hardening (Phase 6).

## Test plan
- [x] `deno task audit` runs locally — "No vulnerabilities found"
- [x] CI passes