### PR TITLE
chore: allow aikido-autofix bot to bypass CLA check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,7 +14,8 @@ jobs:
     if: >-
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.user.login != 'github-actions[bot]' &&
-      github.event.pull_request.user.login != 'renovate[bot]'
+      github.event.pull_request.user.login != 'renovate[bot]' &&
+      github.event.pull_request.user.login != 'aikido-autofix[bot]'
     steps:
       - name: Checkout base branch
         uses: actions/checkout@v4
@@ -44,7 +45,7 @@ jobs:
           missing=()
           for login in "${contributors[@]}"; do
             case "${login}" in
-              dependabot\[bot\]|github-actions\[bot\]|renovate\[bot\])
+              dependabot\[bot\]|github-actions\[bot\]|renovate\[bot\]|aikido-autofix\[bot\])
                 continue
                 ;;
             esac


### PR DESCRIPTION
## Summary
- Adds `aikido-autofix[bot]` to the CLA bot allowlist in both the job-level `if` condition and the contributor check loop
- Matches existing pattern for `dependabot[bot]`, `github-actions[bot]`, and `renovate[bot]`

This unblocks all Aikido autofix PRs (#755, #757, #758, #760, #761) which are currently failing the CLA check because bot accounts can't sign a CLA.

## Test plan
- [ ] Verify CLA check passes on a new Aikido autofix PR
- [ ] Re-run CLA check on existing Aikido PRs after merge