### PR TITLE
fix: replace SHA-256 with PBKDF2 for password hashing in auth template

### DIFF
--- a/cli/templates/features/auth/files/lib/auth.ts
+++ b/cli/templates/features/auth/files/lib/auth.ts
@@ -1,12 +1,89 @@
-export async function hashPassword(password: string): Promise<string> {
-  const msgBuffer = new TextEncoder().encode(password);
-  const hashBuffer = await crypto.subtle.digest("SHA-256", msgBuffer);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
+const PBKDF2_ITERATIONS = 100_000;
+const SALT_LENGTH = 16;
+const HASH_LENGTH = 256; // bits
 
-  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+function toHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
 
-export async function verifyPassword(password: string, hash: string): Promise<boolean> {
-  const computedHash = await hashPassword(password);
-  return computedHash === hash;
+function fromHex(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+async function deriveKey(password: string, salt: Uint8Array): Promise<ArrayBuffer> {
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(password),
+    "PBKDF2",
+    false,
+    ["deriveBits"],
+  );
+
+  return crypto.subtle.deriveBits(
+    {
+      name: "PBKDF2",
+      salt,
+      iterations: PBKDF2_ITERATIONS,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    HASH_LENGTH,
+  );
+}
+
+/**
+ * Hash a password using PBKDF2-SHA256 with a random salt.
+ * Returns a string in the format "hex(salt):hex(hash)".
+ */
+export async function hashPassword(password: string): Promise<string> {
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_LENGTH));
+  const hashBuffer = await deriveKey(password, salt);
+  return `${toHex(salt)}:${toHex(hashBuffer)}`;
+}
+
+/**
+ * Verify a password against a stored PBKDF2-SHA256 hash.
+ * Uses constant-time comparison to prevent timing attacks.
+ */
+export async function verifyPassword(password: string, storedHash: string): Promise<boolean> {
+  const separatorIndex = storedHash.indexOf(":");
+  if (separatorIndex === -1) {
+    return false;
+  }
+
+  const salt = fromHex(storedHash.substring(0, separatorIndex));
+  const expectedHash = fromHex(storedHash.substring(separatorIndex + 1));
+  const computedHashBuffer = await deriveKey(password, salt);
+  const computedHash = new Uint8Array(computedHashBuffer);
+
+  // Constant-time comparison to prevent timing attacks
+  if (expectedHash.length !== computedHash.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expectedHash, computedHash);
+}
+
+/**
+ * Constant-time byte array comparison.
+ * Compares all bytes regardless of where a mismatch occurs,
+ * preventing timing side-channel attacks.
+ */
+function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a[i] ^ b[i];
+  }
+
+  return result === 0;
 }

--- a/cli/templates/features/auth/files/lib/db.ts
+++ b/cli/templates/features/auth/files/lib/db.ts
@@ -10,7 +10,8 @@ const users: User[] = [
   {
     id: "user_1",
     email: "demo@example.com",
-    passwordHash: "deadbeefcafebabe0123456789abcdef:0f09709d32356f0ca33abf7ddb6ffc7c23a373c2d21661a71170de868df74eee",
+    passwordHash:
+      "deadbeefcafebabe0123456789abcdef:0f09709d32356f0ca33abf7ddb6ffc7c23a373c2d21661a71170de868df74eee",
     name: "Demo User",
     createdAt: Date.now(),
   },

--- a/cli/templates/features/auth/files/lib/db.ts
+++ b/cli/templates/features/auth/files/lib/db.ts
@@ -10,7 +10,7 @@ const users: User[] = [
   {
     id: "user_1",
     email: "demo@example.com",
-    passwordHash: "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+    passwordHash: "deadbeefcafebabe0123456789abcdef:0f09709d32356f0ca33abf7ddb6ffc7c23a373c2d21661a71170de868df74eee",
     name: "Demo User",
     createdAt: Date.now(),
   },


### PR DESCRIPTION
## Summary
- Replaces raw SHA-256 (unsalted, no cost factor) with PBKDF2-SHA256 (100k iterations, random salt) in the auth template
- Uses only Web Crypto APIs — no external dependencies
- Updates demo user hash in `db.ts` to match new format
- Stores salt alongside hash in `salt:hash` format

This was the real security issue behind Aikido PR #756 (which was closed because its timing-safe comparison fix introduced an import shadowing bug). SHA-256 is unsuitable for password hashing — brute-forceable at billions/sec on commodity hardware.

## Test plan
- [ ] Scaffold auth feature with `veryfront generate feature auth`
- [ ] Verify login works with demo credentials (email: user@example.com, password: password)
- [ ] Verify password hashing produces different output each time (random salt)
- [ ] Verify verification succeeds with correct password and fails with wrong password