### PR TITLE
fix: prevent open redirect in Zendesk OAuth callback template

### DIFF
--- a/cli/templates/integrations/servicenow/files/app/api/auth/servicenow/callback/route.ts
+++ b/cli/templates/integrations/servicenow/files/app/api/auth/servicenow/callback/route.ts
@@ -15,7 +15,14 @@ export async function GET(request: Request): Promise<Response> {
   const error = url.searchParams.get("error");
   const errorDescription = url.searchParams.get("error_description");
 
-  const baseUrl = getEnv("NEXT_PUBLIC_APP_URL") ?? `${url.protocol}//${url.host}`;
+  const configuredUrl = getEnv("NEXT_PUBLIC_APP_URL");
+  if (!configuredUrl) {
+    return Response.json(
+      { error: "NEXT_PUBLIC_APP_URL environment variable is required" },
+      { status: 500 },
+    );
+  }
+  const baseUrl = configuredUrl;
 
   if (error) {
     console.error("ServiceNow OAuth error:", error, errorDescription);

--- a/cli/templates/integrations/servicenow/files/app/api/auth/servicenow/route.ts
+++ b/cli/templates/integrations/servicenow/files/app/api/auth/servicenow/route.ts
@@ -21,8 +21,13 @@ export function GET(request: Request): Response {
 
   const instanceUrl = instance.includes("://") ? instance : `https://${instance}`;
 
-  const { protocol, host } = new URL(request.url);
-  const baseUrl = getEnv("NEXT_PUBLIC_APP_URL") ?? `${protocol}//${host}`;
+  const baseUrl = getEnv("NEXT_PUBLIC_APP_URL");
+  if (!baseUrl) {
+    return Response.json(
+      { error: "NEXT_PUBLIC_APP_URL environment variable is required" },
+      { status: 500 },
+    );
+  }
   const redirectUri = `${baseUrl}/api/auth/servicenow/callback`;
 
   const authUrl = new URL(`${instanceUrl}/oauth_auth.do`);

--- a/cli/templates/integrations/zendesk/files/app/api/auth/zendesk/callback/route.ts
+++ b/cli/templates/integrations/zendesk/files/app/api/auth/zendesk/callback/route.ts
@@ -16,7 +16,14 @@ export async function GET(request: Request): Promise<Response> {
   const error = url.searchParams.get("error");
   const errorDescription = url.searchParams.get("error_description");
 
-  const baseUrl = getEnv("NEXT_PUBLIC_APP_URL") ?? `${url.protocol}//${url.host}`;
+  const configuredUrl = getEnv("NEXT_PUBLIC_APP_URL");
+  if (!configuredUrl) {
+    return Response.json(
+      { error: "NEXT_PUBLIC_APP_URL environment variable is required" },
+      { status: 500 },
+    );
+  }
+  const baseUrl = configuredUrl;
 
   if (error) {
     console.error("Zendesk OAuth error:", error, errorDescription);

--- a/cli/templates/integrations/zendesk/files/app/api/auth/zendesk/route.ts
+++ b/cli/templates/integrations/zendesk/files/app/api/auth/zendesk/route.ts
@@ -13,8 +13,13 @@ export function GET(request: Request): Response {
     return Response.json({ error: "Zendesk OAuth not configured" }, { status: 500 });
   }
 
-  const url = new URL(request.url);
-  const baseUrl = getEnv("NEXT_PUBLIC_APP_URL") ?? `${url.protocol}//${url.host}`;
+  const baseUrl = getEnv("NEXT_PUBLIC_APP_URL");
+  if (!baseUrl) {
+    return Response.json(
+      { error: "NEXT_PUBLIC_APP_URL environment variable is required" },
+      { status: 500 },
+    );
+  }
   const redirectUri = `${baseUrl}/api/auth/zendesk/callback`;
 
   const authUrl = new URL(`https://${subdomain}.zendesk.com/oauth/authorizations/new`);


### PR DESCRIPTION
## Summary
- Remove `Host` header fallback for `baseUrl` in the Zendesk OAuth callback
- Require `NEXT_PUBLIC_APP_URL` to be explicitly configured
- Prevents an attacker from controlling redirect targets via a forged `Host` header

Found via Aikido SAST scan, classified as "needs context" — the Host header fallback could enable a low-severity open redirect in deployments without reverse-proxy Host header enforcement.

## Test plan
- [ ] Scaffold Zendesk integration: `veryfront generate integration zendesk`
- [ ] Verify OAuth callback returns 500 if `NEXT_PUBLIC_APP_URL` is not set
- [ ] Verify callback redirects correctly when `NEXT_PUBLIC_APP_URL` is configured