### PR TITLE
fix: stop leaking internal error details in production HTTP responses

### DIFF
--- a/src/server/handlers/request/module/data-endpoint-handler.ts
+++ b/src/server/handlers/request/module/data-endpoint-handler.ts
@@ -3,6 +3,7 @@ import { computeEtag, hasMatchingEtag } from "../../utils/etag.ts";
 import { ResponseBuilder } from "#veryfront/security/index.ts";
 import { getRendererForProject } from "../../../shared/renderer-factory.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { serverLogger } from "#veryfront/utils";
 
 export function handleDataEndpoint(
   req: Request,
@@ -51,9 +52,15 @@ export function handleDataEndpoint(
           (e instanceof Error && e.message.toLowerCase().includes("no page"));
         const status = isNotFound ? 404 : 500;
 
+        serverLogger.error("[data-endpoint] Failed to resolve data", {
+          pathname,
+          error: errorMessage,
+          status,
+        });
+
         return respond(
           ResponseBuilder.json(
-            { error: errorMessage, status },
+            { error: isNotFound ? "Page not found" : "Internal server error", status },
             req,
             {
               securityConfig: ctx.securityConfig,

--- a/src/server/handlers/request/module/page-data-endpoint-handler.ts
+++ b/src/server/handlers/request/module/page-data-endpoint-handler.ts
@@ -5,6 +5,7 @@ import { getRendererForProject } from "../../../shared/renderer-factory.ts";
 import { TimeoutError, withTimeoutThrow } from "#veryfront/rendering/utils/stream-utils.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { HTTP_GATEWAY_TIMEOUT } from "#veryfront/utils/constants/http.ts";
+import { serverLogger } from "#veryfront/utils";
 
 const PAGE_DATA_TIMEOUT_MS = 25_000;
 
@@ -54,9 +55,13 @@ export function handlePageDataEndpoint(
         );
       } catch (e) {
         if (e instanceof TimeoutError) {
+          serverLogger.warn("[page-data] Request timed out", {
+            pathname,
+            detail: e.message,
+          });
           return respond(
             ResponseBuilder.json(
-              { error: `Page data request timed out: ${e.message}`, status: HTTP_GATEWAY_TIMEOUT },
+              { error: "Page data request timed out", status: HTTP_GATEWAY_TIMEOUT },
               req,
               {
                 securityConfig: ctx.securityConfig,
@@ -74,9 +79,17 @@ export function handlePageDataEndpoint(
           (e instanceof Error && e.message.toLowerCase().includes("no page"));
         const status = isNotFound ? 404 : 500;
 
+        // Log the full error server-side but return a generic message
+        // to avoid leaking internal details (file paths, DB schema, etc.)
+        serverLogger.error("[page-data] Failed to resolve page data", {
+          pathname,
+          error: errorMessage,
+          status,
+        });
+
         return respond(
           ResponseBuilder.json(
-            { error: errorMessage, status },
+            { error: isNotFound ? "Page not found" : "Internal server error", status },
             req,
             {
               securityConfig: ctx.securityConfig,

--- a/src/server/handlers/request/module/page-module-handler.ts
+++ b/src/server/handlers/request/module/page-module-handler.ts
@@ -4,6 +4,7 @@ import { ResponseBuilder } from "#veryfront/security/index.ts";
 import { getRendererForProject } from "../../../shared/renderer-factory.ts";
 import { shouldUseNoCacheHeadersFromHandler } from "../../../context/enriched-context.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { serverLogger } from "#veryfront/utils";
 
 export function handlePageModule(
   req: Request,
@@ -54,10 +55,17 @@ export function handlePageModule(
           builder.withCache(cacheMode).withETag(etag).javascript(code, 200),
         );
       } catch (error) {
+        // Log the full error server-side but return a generic message
+        // to avoid leaking internal details (Babel/TS errors, file paths, etc.)
+        serverLogger.error("[page-module] Failed to generate module", {
+          pathname,
+          error: getErrorMessage(error),
+        });
+
         return respond(
           ResponseBuilder.error(
             500,
-            `Failed to generate module: ${getErrorMessage(error)}`,
+            "Failed to generate module",
             req,
             {
               securityConfig: ctx.securityConfig,

--- a/src/server/handlers/request/module/virtual-module-handler.ts
+++ b/src/server/handlers/request/module/virtual-module-handler.ts
@@ -2,6 +2,7 @@ import type { HandlerContext, HandlerResult } from "../../types.ts";
 import { ResponseBuilder } from "#veryfront/security/index.ts";
 import { getRendererForProject } from "../../../shared/renderer-factory.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { serverLogger } from "#veryfront/utils";
 
 export function handleVirtualModule(
   req: Request,
@@ -36,8 +37,13 @@ export function handleVirtualModule(
 
         return respond(response);
       } catch (error) {
+        serverLogger.error("[virtual-module] Failed to handle module", {
+          pathname: url.pathname,
+          error: getErrorMessage(error),
+        });
+
         return respond(
-          ResponseBuilder.error(500, `Virtual Module Error: ${getErrorMessage(error)}`, req, {
+          ResponseBuilder.error(500, "Failed to load virtual module", req, {
             securityConfig: ctx.securityConfig,
             corsConfig: ctx.securityConfig?.cors,
           }),


### PR DESCRIPTION
## Summary
Penetration testing flagged verbose error messages leaking schema details. Two production handlers returned raw `error.message` in HTTP responses, which could expose file paths, database schema, Babel/TypeScript errors, or renderer internals.

## Vulnerable endpoints
| Handler | Path | What leaked |
|---------|------|------------|
| `page-data-endpoint-handler` | `/_veryfront/page-data/*.json` | `getErrorMessage(e)` — renderer errors, DB errors, timeout details |
| `page-module-handler` | `/_veryfront/pages/*.js` | `"Failed to generate module: {error}"` — Babel/TS compilation errors |

## Fix
Both handlers now return **generic error messages** to clients while logging the full error server-side:

| Before | After |
|--------|-------|
| `{ error: "Page data request timed out: resolvePageData for /about" }` | `{ error: "Page data request timed out" }` |
| `{ error: "Cannot read property 'x' of undefined at /app/pages/foo.tsx:42" }` | `{ error: "Internal server error" }` |
| `{ error: "Failed to generate module: Unexpected token at line 5" }` | `{ error: "Failed to generate module" }` |

## Not affected (already safe)
- `channel-invoke`, `channel-assistants` — return generic messages, log details
- `agent-run-resume`, `agent-run-cancel` — `ControlPlaneRequestError` messages are generic by design
- `not-found` — returns generic "Internal Server Error"
- Dev-only handlers (`styles-css`, `error-overlay`, `hmr`) — intentionally verbose for developers

## Test plan
- [x] Lint passes
- [x] Generic error messages returned for 404, 500, and timeout cases
- [x] Full error details logged server-side via `serverLogger.error`
- [x] 404 detection logic preserved (checks for "not found" / "404" / "no page")