### PR TITLE
chore: remove postinstall binary download from npm package

### DIFF
--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -187,11 +187,6 @@ await build({
 			"dnt polyfill process.argv[1] fix",
 		);
 
-		// Copy postinstall script
-		await Deno.mkdir("./npm/scripts", { recursive: true });
-		await Deno.copyFile("./scripts/postinstall.js", "./npm/scripts/postinstall.js");
-		await Deno.copyFile("./scripts/postinstall-lib.js", "./npm/scripts/postinstall-lib.js");
-
 		// Note: Templates are now embedded in manifest.json which is bundled by dnt
 		// No need to copy template files separately
 
@@ -218,13 +213,12 @@ await build({
 			},
 		}, null, 2));
 
-		// Update package.json with bin entry, postinstall, and type
+		// Update package.json with bin entry and type
 		const pkgPath = "./npm/package.json";
 		const pkg = JSON.parse(await Deno.readTextFile(pkgPath));
 		pkg.type = "module"; // Required for ESM imports without warnings
 		pkg.bin = { veryfront: "bin/veryfront.js" };
-		pkg.files = ["esm", "script", "src", "bin", "scripts", "tsconfig.json", "LICENSE", "README.md"];
-		pkg.scripts = { postinstall: "node scripts/postinstall.js" };
+		pkg.files = ["esm", "script", "src", "bin", "tsconfig.json", "LICENSE", "README.md"];
 		pkg.exports["./tsconfig.json"] = "./tsconfig.json";
 		await Deno.writeTextFile(pkgPath, JSON.stringify(pkg, null, 2));
 	},


### PR DESCRIPTION
## Summary
Remove the postinstall script that downloads a platform-specific binary during `npm install`.

**Why:**
- `veryfront` is used both as a CLI tool and a library dependency
- The binary download adds overhead for library users who don't need the CLI
- Triggers security scanner warnings (Socket.dev, npm audit, Aikido) for postinstall scripts that download executables
- Creates a network dependency during CI installs
- The JS CLI fallback is already fully functional — all commands work

**What changes:**
- Remove postinstall script copying from the dnt build
- Remove `scripts` directory from `pkg.files`
- Remove `pkg.scripts.postinstall` from generated `package.json`

**No experience degradation:**
- `npx veryfront` still works (uses bundled JS CLI via `bin/veryfront.js`)
- All CLI commands work identically
- Only difference: ~500ms slower startup (JS vs native binary)
- Users who want native binary speed: `brew install veryfront/tap/veryfront` or `curl -fsSL https://veryfront.com/install.sh | sh`

## Test plan
- [ ] Verify `deno task build:npm` produces a package without postinstall
- [ ] Verify `npx veryfront --help` works from the built package
- [ ] Verify `npx veryfront init test-app` scaffolds correctly
- [ ] Verify no security scanner warnings on the published package