### PR TITLE
feat(cli): add shell completion generators for bash, zsh, fish

### DIFF
--- a/cli/commands/completions/command-help.ts
+++ b/cli/commands/completions/command-help.ts
@@ -1,0 +1,15 @@
+import type { CommandHelp } from "../../help/types.ts";
+
+export const completionsHelp: CommandHelp = {
+  name: "completions",
+  category: "development",
+  description: "Generate shell completion scripts",
+  usage: "veryfront completions <shell>",
+  options: [],
+  examples: [
+    "veryfront completions bash",
+    "veryfront completions zsh",
+    "veryfront completions fish",
+    'eval "$(veryfront completions bash)"',
+  ],
+};

--- a/cli/commands/completions/command.ts
+++ b/cli/commands/completions/command.ts
@@ -1,0 +1,104 @@
+/**
+ * Shell completion generators
+ *
+ * Generates completion scripts from the COMMANDS registry.
+ *
+ * @module cli/commands/completions
+ */
+
+import { COMMANDS } from "../../help/command-definitions.ts";
+
+const GLOBAL_FLAGS = [
+  "--json",
+  "--yes",
+  "--quiet",
+  "--verbose",
+  "--help",
+  "--version",
+  "--no-color",
+  "--output",
+];
+
+export function generateBashCompletions(): string {
+  const commands = Object.values(COMMANDS);
+  const cmdNames = commands.map((c) => c.name).join(" ");
+
+  let script = `# Veryfront CLI bash completions\n_veryfront_completions() {\n`;
+  script += `  local cur prev commands\n`;
+  script += `  cur="\${COMP_WORDS[COMP_CWORD]}"\n`;
+  script += `  prev="\${COMP_WORDS[COMP_CWORD-1]}"\n`;
+  script += `  commands="${cmdNames}"\n\n`;
+  script += `  if [[ \${COMP_CWORD} -eq 1 ]]; then\n`;
+  script += `    COMPREPLY=( $(compgen -W "\${commands}" -- "\${cur}") )\n`;
+  script += `    return\n`;
+  script += `  fi\n\n`;
+  script += `  case "\${COMP_WORDS[1]}" in\n`;
+
+  for (const cmd of commands) {
+    const flags = (cmd.options ?? [])
+      .map((o) => o.flag.split(",")[0]!.trim().split(" ")[0])
+      .filter((f) => f?.startsWith("--"))
+      .concat(GLOBAL_FLAGS)
+      .join(" ");
+    script += `    ${cmd.name}) COMPREPLY=( $(compgen -W "${flags}" -- "\${cur}") ) ;;\n`;
+  }
+
+  script += `    *) COMPREPLY=( $(compgen -W "${GLOBAL_FLAGS.join(" ")}" -- "\${cur}") ) ;;\n`;
+  script += `  esac\n`;
+  script += `}\n`;
+  script += `complete -F _veryfront_completions veryfront\n`;
+  return script;
+}
+
+export function generateZshCompletions(): string {
+  const commands = Object.values(COMMANDS);
+  let script = `#compdef veryfront\n# Veryfront CLI zsh completions\n\n`;
+  script += `_veryfront() {\n`;
+  script += `  local -a commands\n`;
+  script += `  commands=(\n`;
+
+  for (const cmd of commands) {
+    const desc = cmd.description.replace(/'/g, "\\'");
+    script += `    '${cmd.name}:${desc}'\n`;
+  }
+
+  script += `  )\n\n`;
+  script += `  _arguments -C \\\n`;
+  script += `    '1:command:->command' \\\n`;
+  script += `    '*::arg:->args'\n\n`;
+  script += `  case $state in\n`;
+  script += `    command)\n`;
+  script += `      _describe 'command' commands\n`;
+  script += `      ;;\n`;
+  script += `  esac\n`;
+  script += `}\n\n`;
+  script += `_veryfront\n`;
+  return script;
+}
+
+export function generateFishCompletions(): string {
+  const commands = Object.values(COMMANDS);
+  let script = `# Veryfront CLI fish completions\n`;
+
+  for (const cmd of commands) {
+    const desc = cmd.description.replace(/'/g, "\\'");
+    script += `complete -c veryfront -n '__fish_use_subcommand' -a '${cmd.name}' -d '${desc}'\n`;
+  }
+
+  script += `\n`;
+
+  for (const cmd of commands) {
+    for (const opt of cmd.options ?? []) {
+      const flag = opt.flag.split(",")[0]!.trim().replace(/^--/, "").split(
+        " ",
+      )[0];
+      if (flag) {
+        const desc = opt.description.replace(/'/g, "\\'");
+        script +=
+          `complete -c veryfront -n '__fish_seen_subcommand_from ${cmd.name}' -l '${flag}' -d '${desc}'\n`;
+      }
+    }
+  }
+
+  return script;
+}

--- a/cli/commands/completions/command.ts
+++ b/cli/commands/completions/command.ts
@@ -8,6 +8,11 @@
 
 import { COMMANDS } from "../../help/command-definitions.ts";
 
+/** Escape a string for use in shell single-quoted contexts */
+function shellEscape(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
 const GLOBAL_FLAGS = [
   "--json",
   "--yes",
@@ -58,7 +63,7 @@ export function generateZshCompletions(): string {
   script += `  commands=(\n`;
 
   for (const cmd of commands) {
-    const desc = cmd.description.replace(/'/g, "\\'");
+    const desc = shellEscape(cmd.description);
     script += `    '${cmd.name}:${desc}'\n`;
   }
 
@@ -81,7 +86,7 @@ export function generateFishCompletions(): string {
   let script = `# Veryfront CLI fish completions\n`;
 
   for (const cmd of commands) {
-    const desc = cmd.description.replace(/'/g, "\\'");
+    const desc = shellEscape(cmd.description);
     script += `complete -c veryfront -n '__fish_use_subcommand' -a '${cmd.name}' -d '${desc}'\n`;
   }
 
@@ -93,7 +98,7 @@ export function generateFishCompletions(): string {
         " ",
       )[0];
       if (flag) {
-        const desc = opt.description.replace(/'/g, "\\'");
+        const desc = shellEscape(opt.description);
         script +=
           `complete -c veryfront -n '__fish_seen_subcommand_from ${cmd.name}' -l '${flag}' -d '${desc}'\n`;
       }

--- a/cli/commands/completions/command.ts
+++ b/cli/commands/completions/command.ts
@@ -7,10 +7,39 @@
  */
 
 import { COMMANDS } from "../../help/command-definitions.ts";
+import type { CommandOption } from "../../help/types.ts";
 
 /** Escape a string for use in shell single-quoted contexts */
-function shellEscape(s: string): string {
+export function shellEscape(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+/**
+ * Extract long flags (--name) from a CommandOption flag string.
+ * Handles formats like: "--port", "-p, --port", "-p, --port <number>"
+ */
+export function extractLongFlags(options: CommandOption[]): string[] {
+  return options.flatMap((o) =>
+    o.flag
+      .split(",")
+      .map((f) => f.trim().split(" ")[0]!)
+      .filter((f) => f.startsWith("--"))
+  );
+}
+
+/**
+ * Extract short and long flags for fish completions.
+ * Returns { short: "p", long: "port" } pairs.
+ */
+export function extractFishFlags(
+  options: CommandOption[],
+): Array<{ short?: string; long?: string; description: string }> {
+  return options.map((o) => {
+    const parts = o.flag.split(",").map((f) => f.trim().split(" ")[0]!);
+    const short = parts.find((p) => p.match(/^-[a-zA-Z]$/))?.slice(1);
+    const long = parts.find((p) => p.startsWith("--"))?.slice(2);
+    return { short, long, description: o.description };
+  });
 }
 
 const GLOBAL_FLAGS = [
@@ -40,9 +69,7 @@ export function generateBashCompletions(): string {
   script += `  case "\${COMP_WORDS[1]}" in\n`;
 
   for (const cmd of commands) {
-    const flags = (cmd.options ?? [])
-      .map((o) => o.flag.split(",")[0]!.trim().split(" ")[0])
-      .filter((f) => f?.startsWith("--"))
+    const flags = extractLongFlags(cmd.options ?? [])
       .concat(GLOBAL_FLAGS)
       .join(" ");
     script += `    ${cmd.name}) COMPREPLY=( $(compgen -W "${flags}" -- "\${cur}") ) ;;\n`;
@@ -75,6 +102,26 @@ export function generateZshCompletions(): string {
   script += `    command)\n`;
   script += `      _describe 'command' commands\n`;
   script += `      ;;\n`;
+  script += `    args)\n`;
+  script += `      case \${words[1]} in\n`;
+
+  for (const cmd of commands) {
+    const flags = extractLongFlags(cmd.options ?? []).concat(GLOBAL_FLAGS);
+    if (flags.length > 0) {
+      const zshFlags = flags.map((f) =>
+        `'${f}[${
+          shellEscape(
+            (cmd.options ?? []).find((o) => o.flag.includes(f))?.description ??
+              "",
+          )
+        }]'`
+      ).join(" ");
+      script += `        ${cmd.name}) _arguments ${zshFlags} ;;\n`;
+    }
+  }
+
+  script += `      esac\n`;
+  script += `      ;;\n`;
   script += `  esac\n`;
   script += `}\n\n`;
   script += `_veryfront\n`;
@@ -93,14 +140,21 @@ export function generateFishCompletions(): string {
   script += `\n`;
 
   for (const cmd of commands) {
-    for (const opt of cmd.options ?? []) {
-      const flag = opt.flag.split(",")[0]!.trim().replace(/^--/, "").split(
-        " ",
-      )[0];
-      if (flag) {
-        const desc = shellEscape(opt.description);
+    const flags = extractFishFlags(cmd.options ?? []);
+    for (const flag of flags) {
+      if (flag.long) {
+        const desc = shellEscape(flag.description);
+        let line =
+          `complete -c veryfront -n '__fish_seen_subcommand_from ${cmd.name}' -l '${flag.long}'`;
+        if (flag.short) {
+          line += ` -s '${flag.short}'`;
+        }
+        line += ` -d '${desc}'\n`;
+        script += line;
+      } else if (flag.short) {
+        const desc = shellEscape(flag.description);
         script +=
-          `complete -c veryfront -n '__fish_seen_subcommand_from ${cmd.name}' -l '${flag}' -d '${desc}'\n`;
+          `complete -c veryfront -n '__fish_seen_subcommand_from ${cmd.name}' -s '${flag.short}' -d '${desc}'\n`;
       }
     }
   }

--- a/cli/commands/completions/handler.test.ts
+++ b/cli/commands/completions/handler.test.ts
@@ -1,12 +1,103 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  extractFishFlags,
+  extractLongFlags,
   generateBashCompletions,
   generateFishCompletions,
   generateZshCompletions,
+  shellEscape,
 } from "./command.ts";
 
 describe("Completions Command", () => {
+  describe("shellEscape", () => {
+    it("escapes backslashes", () => {
+      assertEquals(shellEscape("a\\b"), "a\\\\b");
+    });
+
+    it("escapes single quotes", () => {
+      assertEquals(shellEscape("it's"), "it\\'s");
+    });
+
+    it("escapes both backslashes and quotes", () => {
+      assertEquals(shellEscape("a\\'b"), "a\\\\\\'b");
+    });
+
+    it("returns empty string unchanged", () => {
+      assertEquals(shellEscape(""), "");
+    });
+
+    it("leaves normal text unchanged", () => {
+      assertEquals(shellEscape("hello world"), "hello world");
+    });
+  });
+
+  describe("extractLongFlags", () => {
+    it("extracts --flag from simple flag", () => {
+      const flags = extractLongFlags([
+        { flag: "--port", description: "Port" },
+      ]);
+      assertEquals(flags, ["--port"]);
+    });
+
+    it("extracts --flag from short,long combo", () => {
+      const flags = extractLongFlags([
+        { flag: "-p, --port <number>", description: "Port" },
+      ]);
+      assertEquals(flags, ["--port"]);
+    });
+
+    it("handles multiple options", () => {
+      const flags = extractLongFlags([
+        { flag: "-p, --port <number>", description: "Port" },
+        { flag: "--env <name>", description: "Environment" },
+        { flag: "-f, --force", description: "Force" },
+      ]);
+      assertEquals(flags.includes("--port"), true);
+      assertEquals(flags.includes("--env"), true);
+      assertEquals(flags.includes("--force"), true);
+      assertEquals(flags.length, 3);
+    });
+
+    it("excludes short-only flags", () => {
+      const flags = extractLongFlags([
+        { flag: "-v", description: "Verbose" },
+      ]);
+      assertEquals(flags.length, 0);
+    });
+
+    it("handles empty options", () => {
+      assertEquals(extractLongFlags([]).length, 0);
+    });
+  });
+
+  describe("extractFishFlags", () => {
+    it("extracts short and long from combo", () => {
+      const flags = extractFishFlags([
+        { flag: "-p, --port <number>", description: "Port" },
+      ]);
+      assertEquals(flags[0]?.short, "p");
+      assertEquals(flags[0]?.long, "port");
+      assertEquals(flags[0]?.description, "Port");
+    });
+
+    it("extracts long-only flag", () => {
+      const flags = extractFishFlags([
+        { flag: "--env <name>", description: "Environment" },
+      ]);
+      assertEquals(flags[0]?.short, undefined);
+      assertEquals(flags[0]?.long, "env");
+    });
+
+    it("extracts short-only flag", () => {
+      const flags = extractFishFlags([
+        { flag: "-v", description: "Verbose" },
+      ]);
+      assertEquals(flags[0]?.short, "v");
+      assertEquals(flags[0]?.long, undefined);
+    });
+  });
+
   describe("generateBashCompletions", () => {
     it("includes command names", () => {
       const script = generateBashCompletions();
@@ -18,6 +109,30 @@ describe("Completions Command", () => {
     it("includes complete function", () => {
       const script = generateBashCompletions();
       assertEquals(script.includes("complete -F"), true);
+      assertEquals(script.includes("_veryfront_completions"), true);
+    });
+
+    it("includes global flags", () => {
+      const script = generateBashCompletions();
+      assertEquals(script.includes("--json"), true);
+      assertEquals(script.includes("--yes"), true);
+      assertEquals(script.includes("--quiet"), true);
+      assertEquals(script.includes("--verbose"), true);
+      assertEquals(script.includes("--help"), true);
+      assertEquals(script.includes("--version"), true);
+    });
+
+    it("includes per-command long flags", () => {
+      const script = generateBashCompletions();
+      assertEquals(script.includes("--branch"), true);
+      assertEquals(script.includes("--force"), true);
+    });
+
+    it("includes case statement for commands", () => {
+      const script = generateBashCompletions();
+      assertEquals(script.includes("case"), true);
+      assertEquals(script.includes("deploy)"), true);
+      assertEquals(script.includes("build)"), true);
     });
   });
 
@@ -30,6 +145,23 @@ describe("Completions Command", () => {
     it("includes command descriptions", () => {
       const script = generateZshCompletions();
       assertEquals(script.includes("deploy:"), true);
+      assertEquals(script.includes("build:"), true);
+    });
+
+    it("includes _describe for command completion", () => {
+      const script = generateZshCompletions();
+      assertEquals(script.includes("_describe"), true);
+    });
+
+    it("includes args state for per-command flags", () => {
+      const script = generateZshCompletions();
+      assertEquals(script.includes("args)"), true);
+      assertEquals(script.includes("_arguments"), true);
+    });
+
+    it("includes _veryfront function", () => {
+      const script = generateZshCompletions();
+      assertEquals(script.includes("_veryfront()"), true);
     });
   });
 
@@ -37,7 +169,28 @@ describe("Completions Command", () => {
     it("includes complete commands", () => {
       const script = generateFishCompletions();
       assertEquals(script.includes("complete -c veryfront"), true);
-      assertEquals(script.includes("deploy"), true);
+    });
+
+    it("includes subcommand condition", () => {
+      const script = generateFishCompletions();
+      assertEquals(script.includes("__fish_use_subcommand"), true);
+      assertEquals(script.includes("__fish_seen_subcommand_from"), true);
+    });
+
+    it("uses -l for long flags (not raw --flag)", () => {
+      const script = generateFishCompletions();
+      assertEquals(script.includes("-l 'branch'"), true);
+      assertEquals(script.includes("-l '--branch'"), false);
+    });
+
+    it("includes -s for short flags", () => {
+      const script = generateFishCompletions();
+      assertEquals(script.includes("-s 'b'"), true);
+    });
+
+    it("includes command descriptions with -d", () => {
+      const script = generateFishCompletions();
+      assertEquals(script.includes("-d '"), true);
     });
   });
 });

--- a/cli/commands/completions/handler.test.ts
+++ b/cli/commands/completions/handler.test.ts
@@ -1,0 +1,43 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  generateBashCompletions,
+  generateFishCompletions,
+  generateZshCompletions,
+} from "./command.ts";
+
+describe("Completions Command", () => {
+  describe("generateBashCompletions", () => {
+    it("includes command names", () => {
+      const script = generateBashCompletions();
+      assertEquals(script.includes("deploy"), true);
+      assertEquals(script.includes("build"), true);
+      assertEquals(script.includes("dev"), true);
+    });
+
+    it("includes complete function", () => {
+      const script = generateBashCompletions();
+      assertEquals(script.includes("complete -F"), true);
+    });
+  });
+
+  describe("generateZshCompletions", () => {
+    it("includes compdef", () => {
+      const script = generateZshCompletions();
+      assertEquals(script.includes("#compdef veryfront"), true);
+    });
+
+    it("includes command descriptions", () => {
+      const script = generateZshCompletions();
+      assertEquals(script.includes("deploy:"), true);
+    });
+  });
+
+  describe("generateFishCompletions", () => {
+    it("includes complete commands", () => {
+      const script = generateFishCompletions();
+      assertEquals(script.includes("complete -c veryfront"), true);
+      assertEquals(script.includes("deploy"), true);
+    });
+  });
+});

--- a/cli/commands/completions/handler.ts
+++ b/cli/commands/completions/handler.ts
@@ -1,0 +1,28 @@
+import type { ParsedArgs } from "#cli/shared/types";
+import {
+  generateBashCompletions,
+  generateFishCompletions,
+  generateZshCompletions,
+} from "./command.ts";
+
+export async function handleCompletionsCommand(
+  args: ParsedArgs,
+): Promise<void> {
+  const shell = args._[1] as string | undefined;
+
+  switch (shell) {
+    case "bash":
+      console.log(generateBashCompletions());
+      break;
+    case "zsh":
+      console.log(generateZshCompletions());
+      break;
+    case "fish":
+      console.log(generateFishCompletions());
+      break;
+    default:
+      console.error("Usage: veryfront completions <bash|zsh|fish>");
+      console.error('Example: eval "$(veryfront completions bash)"');
+      Deno.exit(1);
+  }
+}

--- a/cli/help/command-definitions.ts
+++ b/cli/help/command-definitions.ts
@@ -42,6 +42,7 @@ import { schemaHelp } from "../commands/schema/command-help.ts";
 import { testHelp } from "../commands/test/command-help.ts";
 import { lintHelp } from "../commands/lint/command-help.ts";
 import { skillsHelp } from "../commands/skills/command-help.ts";
+import { completionsHelp } from "../commands/completions/command-help.ts";
 
 /**
  * Central registry of all command help definitions.
@@ -83,4 +84,5 @@ export const COMMANDS: CommandRegistry = {
   test: testHelp,
   lint: lintHelp,
   skills: skillsHelp,
+  completions: completionsHelp,
 };

--- a/cli/router.ts
+++ b/cli/router.ts
@@ -38,6 +38,7 @@ import { handleSchemaCommand } from "./commands/schema/handler.ts";
 import { handleTestCommand } from "./commands/test/handler.ts";
 import { handleLintCommand } from "./commands/lint/handler.ts";
 import { handleSkillsCommand } from "./commands/skills/handler.ts";
+import { handleCompletionsCommand } from "./commands/completions/handler.ts";
 import { login, logout, whoami } from "./auth/index.ts";
 import { parseLoginMethod } from "./auth/utils.ts";
 import { showCommandHelp, showMainHelp } from "./help/index.ts";
@@ -96,6 +97,7 @@ const commands: Record<string, (args: ParsedArgs) => Promise<void>> = {
   "test": handleTestCommand,
   "lint": handleLintCommand,
   "skills": handleSkillsCommand,
+  "completions": handleCompletionsCommand,
 };
 
 /**


### PR DESCRIPTION
## Summary
- `veryfront completions bash|zsh|fish` generates shell completion scripts
- Derived from COMMANDS registry — no hardcoded lists
- Supports `eval "$(veryfront completions bash)"` pattern

## Files
- `cli/commands/completions/` — command, handler, help, tests
- `cli/router.ts` + `cli/help/command-definitions.ts` — registration

## Acceptance Criteria
- [x] `veryfront completions bash` outputs a valid bash completion script to stdout
- [x] `veryfront completions zsh` outputs a valid zsh completion script to stdout
- [x] `veryfront completions fish` outputs a valid fish completion script to stdout
- [x] Generated scripts complete all registered command names (including schema, test, lint, skills)
- [x] Generated scripts complete per-command flags (e.g. deploy shows --branch, --env, --force)
- [x] Generated scripts include global flags (--json, --yes, --quiet, --verbose, --help, --version)
- [x] `eval "$(veryfront completions bash)"` works in a bash shell without errors
- [x] Completions are derived from COMMANDS registry — no hardcoded command lists
- [x] Unit tests verify generated scripts contain expected command names and flags
- [x] All existing CLI tests still pass