### PR TITLE
feat(cli): add env management command stubs (pending backend API)

### DIFF
--- a/cli/commands/env/command-help.ts
+++ b/cli/commands/env/command-help.ts
@@ -1,0 +1,27 @@
+import type { CommandHelp } from "../../help/types.ts";
+
+export const envHelp: CommandHelp = {
+  name: "env",
+  category: "deploy",
+  description: "Manage environment variables for deployments",
+  usage: "veryfront env <subcommand> [options]",
+  options: [
+    {
+      flag: "--env <name>",
+      description: "Target environment",
+      default: "production",
+    },
+    { flag: "--json", description: "Output as JSON" },
+  ],
+  examples: [
+    "veryfront env list",
+    "veryfront env set KEY=value",
+    "veryfront env remove KEY",
+    "veryfront env pull .env.local",
+    "veryfront env push .env.production",
+  ],
+  notes: [
+    "Requires authentication. Run 'veryfront login' first.",
+    "Subcommands: list, set, remove, pull, push",
+  ],
+};

--- a/cli/commands/env/handler.test.ts
+++ b/cli/commands/env/handler.test.ts
@@ -1,0 +1,9 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+
+describe("Env Command", () => {
+  it("handler is a function", async () => {
+    const { handleEnvCommand } = await import("./handler.ts");
+    assertEquals(typeof handleEnvCommand, "function");
+  });
+});

--- a/cli/commands/env/handler.ts
+++ b/cli/commands/env/handler.ts
@@ -1,0 +1,29 @@
+import type { ParsedArgs } from "#cli/shared/types";
+import { createErrorEnvelope, isJsonMode, outputJson } from "../../shared/json-output.ts";
+
+const NOT_IMPLEMENTED =
+  "Environment variable management requires backend API support. This feature is coming soon.";
+
+export async function handleEnvCommand(args: ParsedArgs): Promise<void> {
+  const subcommand = args._[1] as string | undefined;
+
+  if (isJsonMode()) {
+    await outputJson(
+      createErrorEnvelope("env", {
+        code: "NOT_IMPLEMENTED",
+        slug: "env-not-implemented",
+        message: NOT_IMPLEMENTED,
+      }),
+    );
+    Deno.exit(1);
+    return;
+  }
+
+  console.error(`  ${NOT_IMPLEMENTED}`);
+
+  if (!subcommand) {
+    console.error("\n  Subcommands: list, set, remove, pull, push");
+  }
+
+  Deno.exit(1);
+}

--- a/cli/help/command-definitions.ts
+++ b/cli/help/command-definitions.ts
@@ -42,6 +42,7 @@ import { schemaHelp } from "../commands/schema/command-help.ts";
 import { testHelp } from "../commands/test/command-help.ts";
 import { lintHelp } from "../commands/lint/command-help.ts";
 import { skillsHelp } from "../commands/skills/command-help.ts";
+import { envHelp } from "../commands/env/command-help.ts";
 
 /**
  * Central registry of all command help definitions.
@@ -83,4 +84,5 @@ export const COMMANDS: CommandRegistry = {
   test: testHelp,
   lint: lintHelp,
   skills: skillsHelp,
+  env: envHelp,
 };

--- a/cli/router.ts
+++ b/cli/router.ts
@@ -38,6 +38,7 @@ import { handleSchemaCommand } from "./commands/schema/handler.ts";
 import { handleTestCommand } from "./commands/test/handler.ts";
 import { handleLintCommand } from "./commands/lint/handler.ts";
 import { handleSkillsCommand } from "./commands/skills/handler.ts";
+import { handleEnvCommand } from "./commands/env/handler.ts";
 import { login, logout, whoami } from "./auth/index.ts";
 import { parseLoginMethod } from "./auth/utils.ts";
 import { showCommandHelp, showMainHelp } from "./help/index.ts";
@@ -96,6 +97,7 @@ const commands: Record<string, (args: ParsedArgs) => Promise<void>> = {
   "test": handleTestCommand,
   "lint": handleLintCommand,
   "skills": handleSkillsCommand,
+  "env": handleEnvCommand,
 };
 
 /**


### PR DESCRIPTION
## Summary
Stub for `veryfront env list|set|remove|pull|push`. Returns NOT_IMPLEMENTED error. Ready for backend API integration.

## Files
- `cli/commands/env/` — handler, help, tests
- `cli/router.ts` + `cli/help/command-definitions.ts` — registration

## Acceptance Criteria
- [ ] `veryfront env list` shows all environment variables with masked values
- [ ] `veryfront env set KEY=value` sets an environment variable
- [ ] `veryfront env remove KEY` removes an environment variable
- [ ] `veryfront env pull .env.local` downloads env vars to a local file
- [ ] `veryfront env push .env.production` uploads env vars from a local file
- [ ] All subcommands support --json output
- [ ] --env flag selects target environment (production, staging, etc.)
- [ ] Requires authentication — shows error if not logged in
- [ ] Registered in router and help with category deploy
- [ ] Unit tests cover: argument parsing, subcommand routing
- [ ] All existing CLI tests still pass

> **Note:** Currently returns NOT_IMPLEMENTED. Blocked on backend API.