### PR TITLE
feat(cli): add rollback command stubs (pending backend API)

### DIFF
--- a/cli/commands/rollback/command-help.ts
+++ b/cli/commands/rollback/command-help.ts
@@ -1,0 +1,25 @@
+import type { CommandHelp } from "../../help/types.ts";
+
+export const rollbackHelp: CommandHelp = {
+  name: "rollback",
+  category: "deploy",
+  description: "Rollback to a previous deployment",
+  usage: "veryfront rollback [options]",
+  options: [
+    { flag: "--to <version>", description: "Rollback to specific version" },
+    { flag: "--list", description: "Show recent deployments" },
+    {
+      flag: "--env <name>",
+      description: "Target environment",
+      default: "production",
+    },
+    { flag: "--json", description: "Output as JSON" },
+    { flag: "-f, --force", description: "Skip confirmation" },
+  ],
+  examples: [
+    "veryfront rollback",
+    "veryfront rollback --to v42",
+    "veryfront rollback --list",
+    "veryfront rollback --list --json",
+  ],
+};

--- a/cli/commands/rollback/handler.test.ts
+++ b/cli/commands/rollback/handler.test.ts
@@ -1,0 +1,9 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+
+describe("Rollback Command", () => {
+  it("handler is a function", async () => {
+    const { handleRollbackCommand } = await import("./handler.ts");
+    assertEquals(typeof handleRollbackCommand, "function");
+  });
+});

--- a/cli/commands/rollback/handler.ts
+++ b/cli/commands/rollback/handler.ts
@@ -1,0 +1,23 @@
+import type { ParsedArgs } from "#cli/shared/types";
+import { createErrorEnvelope, isJsonMode, outputJson } from "../../shared/json-output.ts";
+
+const NOT_IMPLEMENTED =
+  "Rollback requires deployment history API support. This feature is coming soon.";
+
+export async function handleRollbackCommand(
+  _args: ParsedArgs,
+): Promise<void> {
+  if (isJsonMode()) {
+    await outputJson(
+      createErrorEnvelope("rollback", {
+        code: "NOT_IMPLEMENTED",
+        slug: "rollback-not-implemented",
+        message: NOT_IMPLEMENTED,
+      }),
+    );
+    Deno.exit(1);
+    return;
+  }
+  console.error(`  ${NOT_IMPLEMENTED}`);
+  Deno.exit(1);
+}

--- a/cli/help/command-definitions.ts
+++ b/cli/help/command-definitions.ts
@@ -42,6 +42,7 @@ import { schemaHelp } from "../commands/schema/command-help.ts";
 import { testHelp } from "../commands/test/command-help.ts";
 import { lintHelp } from "../commands/lint/command-help.ts";
 import { skillsHelp } from "../commands/skills/command-help.ts";
+import { rollbackHelp } from "../commands/rollback/command-help.ts";
 
 /**
  * Central registry of all command help definitions.
@@ -83,4 +84,5 @@ export const COMMANDS: CommandRegistry = {
   test: testHelp,
   lint: lintHelp,
   skills: skillsHelp,
+  rollback: rollbackHelp,
 };

--- a/cli/router.ts
+++ b/cli/router.ts
@@ -38,6 +38,7 @@ import { handleSchemaCommand } from "./commands/schema/handler.ts";
 import { handleTestCommand } from "./commands/test/handler.ts";
 import { handleLintCommand } from "./commands/lint/handler.ts";
 import { handleSkillsCommand } from "./commands/skills/handler.ts";
+import { handleRollbackCommand } from "./commands/rollback/handler.ts";
 import { login, logout, whoami } from "./auth/index.ts";
 import { parseLoginMethod } from "./auth/utils.ts";
 import { showCommandHelp, showMainHelp } from "./help/index.ts";
@@ -96,6 +97,7 @@ const commands: Record<string, (args: ParsedArgs) => Promise<void>> = {
   "test": handleTestCommand,
   "lint": handleLintCommand,
   "skills": handleSkillsCommand,
+  "rollback": handleRollbackCommand,
 };
 
 /**


### PR DESCRIPTION
## Summary
Stub for `veryfront rollback [--to version] [--list]`. Returns NOT_IMPLEMENTED error. Ready for deployment history API.

## Files
- `cli/commands/rollback/` — handler, help, tests
- `cli/router.ts` + `cli/help/command-definitions.ts` — registration

## Acceptance Criteria
- [ ] `veryfront rollback` rolls back to the previous deployment
- [ ] `veryfront rollback --to v42` rolls back to a specific version
- [ ] `veryfront rollback --list` shows recent deployments with version, timestamp, status
- [ ] `veryfront rollback --list --json` outputs deployment history as JSON
- [ ] Requires --force or --yes to execute without confirmation
- [ ] Shows rollback progress with spinner/NDJSON streaming
- [ ] Registered in router and help with category deploy
- [ ] Unit tests cover: argument parsing, version validation
- [ ] All existing CLI tests still pass

> **Note:** Currently returns NOT_IMPLEMENTED. Blocked on backend API.