### PR TITLE
feat(cli): add logs command stubs (pending backend streaming endpoint)

### DIFF
--- a/cli/commands/logs/command-help.ts
+++ b/cli/commands/logs/command-help.ts
@@ -1,0 +1,28 @@
+import type { CommandHelp } from "../../help/types.ts";
+
+export const logsHelp: CommandHelp = {
+  name: "logs",
+  category: "deploy",
+  description: "View deployment logs",
+  usage: "veryfront logs [options]",
+  options: [
+    {
+      flag: "--env <name>",
+      description: "Target environment",
+      default: "production",
+    },
+    { flag: "--tail <n>", description: "Show last N log entries" },
+    {
+      flag: "--since <duration>",
+      description: "Show logs since duration (e.g. 1h, 30m)",
+    },
+    { flag: "--filter <pattern>", description: "Filter log lines by pattern" },
+    { flag: "--json", description: "Output each log entry as NDJSON" },
+  ],
+  examples: [
+    "veryfront logs",
+    "veryfront logs --tail 100",
+    "veryfront logs --env staging",
+    "veryfront logs --since 1h --filter ERROR",
+  ],
+};

--- a/cli/commands/logs/handler.test.ts
+++ b/cli/commands/logs/handler.test.ts
@@ -1,0 +1,9 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+
+describe("Logs Command", () => {
+  it("handler is a function", async () => {
+    const { handleLogsCommand } = await import("./handler.ts");
+    assertEquals(typeof handleLogsCommand, "function");
+  });
+});

--- a/cli/commands/logs/handler.ts
+++ b/cli/commands/logs/handler.ts
@@ -1,0 +1,20 @@
+import type { ParsedArgs } from "#cli/shared/types";
+import { createErrorEnvelope, isJsonMode, outputJson } from "../../shared/json-output.ts";
+
+const NOT_IMPLEMENTED = "Log streaming requires a backend endpoint. This feature is coming soon.";
+
+export async function handleLogsCommand(_args: ParsedArgs): Promise<void> {
+  if (isJsonMode()) {
+    await outputJson(
+      createErrorEnvelope("logs", {
+        code: "NOT_IMPLEMENTED",
+        slug: "logs-not-implemented",
+        message: NOT_IMPLEMENTED,
+      }),
+    );
+    Deno.exit(1);
+    return;
+  }
+  console.error(`  ${NOT_IMPLEMENTED}`);
+  Deno.exit(1);
+}

--- a/cli/help/command-definitions.ts
+++ b/cli/help/command-definitions.ts
@@ -42,6 +42,7 @@ import { schemaHelp } from "../commands/schema/command-help.ts";
 import { testHelp } from "../commands/test/command-help.ts";
 import { lintHelp } from "../commands/lint/command-help.ts";
 import { skillsHelp } from "../commands/skills/command-help.ts";
+import { logsHelp } from "../commands/logs/command-help.ts";
 
 /**
  * Central registry of all command help definitions.
@@ -83,4 +84,5 @@ export const COMMANDS: CommandRegistry = {
   test: testHelp,
   lint: lintHelp,
   skills: skillsHelp,
+  logs: logsHelp,
 };

--- a/cli/router.ts
+++ b/cli/router.ts
@@ -38,6 +38,7 @@ import { handleSchemaCommand } from "./commands/schema/handler.ts";
 import { handleTestCommand } from "./commands/test/handler.ts";
 import { handleLintCommand } from "./commands/lint/handler.ts";
 import { handleSkillsCommand } from "./commands/skills/handler.ts";
+import { handleLogsCommand } from "./commands/logs/handler.ts";
 import { login, logout, whoami } from "./auth/index.ts";
 import { parseLoginMethod } from "./auth/utils.ts";
 import { showCommandHelp, showMainHelp } from "./help/index.ts";
@@ -96,6 +97,7 @@ const commands: Record<string, (args: ParsedArgs) => Promise<void>> = {
   "test": handleTestCommand,
   "lint": handleLintCommand,
   "skills": handleSkillsCommand,
+  "logs": handleLogsCommand,
 };
 
 /**


### PR DESCRIPTION
## Summary
Stub for `veryfront logs [--tail N] [--env name] [--since duration] [--filter pattern]`. Returns NOT_IMPLEMENTED error. Ready for backend log streaming.

## Files
- `cli/commands/logs/` — handler, help, tests
- `cli/router.ts` + `cli/help/command-definitions.ts` — registration

## Acceptance Criteria
- [ ] `veryfront logs --tail 100` shows the last 100 log entries
- [ ] `veryfront logs --env staging` targets a specific environment
- [ ] `veryfront logs --filter "ERROR"` filters log lines by pattern
- [ ] `veryfront logs --since 1h` shows logs from the last hour
- [ ] `veryfront logs` (no flags) streams live logs until Ctrl+C
- [ ] --json outputs each log entry as NDJSON
- [ ] Graceful fallback when backend streaming endpoint is unavailable
- [ ] Registered in router and help with category deploy
- [ ] All existing CLI tests still pass

> **Note:** Currently returns NOT_IMPLEMENTED. Blocked on backend streaming endpoint.