### PR TITLE
Fix preview hydration regressions and bump version to 0.1.115

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.114",
+  "version": "0.1.115",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/server/handlers/dev/files/dev-file.handler.test.ts
+++ b/src/server/handlers/dev/files/dev-file.handler.test.ts
@@ -1,0 +1,62 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
+import { base64urlEncode } from "#veryfront/utils/base64url.ts";
+import type { HandlerContext } from "../../types.ts";
+import { DevFileHandler } from "./dev-file.handler.ts";
+
+function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    projectDir: "/project",
+    adapter: createMockAdapter(),
+    securityConfig: null,
+    cspUserHeader: null,
+    ...overrides,
+  } as HandlerContext;
+}
+
+describe("server/handlers/dev/files/dev-file.handler", () => {
+  afterEach(async () => {
+    const esbuild = await import("esbuild");
+    esbuild.stop();
+  });
+
+  it("serves preview file modules for remote preview mode", async () => {
+    const handler = new DevFileHandler();
+    const adapter = createMockAdapter();
+    const modulePath = "/project/app/page.tsx";
+    adapter.fs.files.set(
+      modulePath,
+      "export default function Page() { return 'preview'; }",
+    );
+
+    const encodedPath = base64urlEncode("app/page.tsx");
+    const req = new Request(`http://localhost/_veryfront/fs/${encodedPath}.js`);
+    const ctx = makeCtx({
+      adapter,
+      isLocalProject: false,
+      requestContext: { mode: "preview" } as HandlerContext["requestContext"],
+    });
+
+    const result = await handler.handle(req, ctx);
+
+    assertEquals(result.continue, false);
+    assertEquals(result.response?.status, 200);
+    const body = await result.response!.text();
+    assertEquals(body.includes("preview"), true);
+  });
+
+  it("continues for non-local production requests", async () => {
+    const handler = new DevFileHandler();
+    const encodedPath = base64urlEncode("app/page.tsx");
+    const req = new Request(`http://localhost/_veryfront/fs/${encodedPath}.js`);
+    const ctx = makeCtx({
+      isLocalProject: false,
+      requestContext: { mode: "production" } as HandlerContext["requestContext"],
+    });
+
+    const result = await handler.handle(req, ctx);
+
+    assertEquals(result.continue, true);
+  });
+});

--- a/src/server/handlers/dev/files/dev-file.handler.test.ts
+++ b/src/server/handlers/dev/files/dev-file.handler.test.ts
@@ -15,7 +15,13 @@ function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
   } as HandlerContext;
 }
 
-describe("server/handlers/dev/files/dev-file.handler", () => {
+describe(
+  "server/handlers/dev/files/dev-file.handler",
+  {
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  () => {
   afterEach(async () => {
     const esbuild = await import("esbuild");
     esbuild.stop();
@@ -59,4 +65,5 @@ describe("server/handlers/dev/files/dev-file.handler", () => {
 
     assertEquals(result.continue, true);
   });
-});
+  },
+);

--- a/src/server/handlers/dev/files/dev-file.handler.test.ts
+++ b/src/server/handlers/dev/files/dev-file.handler.test.ts
@@ -22,48 +22,48 @@ describe(
     sanitizeOps: false,
   },
   () => {
-  afterEach(async () => {
-    const esbuild = await import("esbuild");
-    esbuild.stop();
-  });
-
-  it("serves preview file modules for remote preview mode", async () => {
-    const handler = new DevFileHandler();
-    const adapter = createMockAdapter();
-    const modulePath = "/project/app/page.tsx";
-    adapter.fs.files.set(
-      modulePath,
-      "export default function Page() { return 'preview'; }",
-    );
-
-    const encodedPath = base64urlEncode("app/page.tsx");
-    const req = new Request(`http://localhost/_veryfront/fs/${encodedPath}.js`);
-    const ctx = makeCtx({
-      adapter,
-      isLocalProject: false,
-      requestContext: { mode: "preview" } as HandlerContext["requestContext"],
+    afterEach(async () => {
+      const esbuild = await import("esbuild");
+      esbuild.stop();
     });
 
-    const result = await handler.handle(req, ctx);
+    it("serves preview file modules for remote preview mode", async () => {
+      const handler = new DevFileHandler();
+      const adapter = createMockAdapter();
+      const modulePath = "/project/app/page.tsx";
+      adapter.fs.files.set(
+        modulePath,
+        "export default function Page() { return 'preview'; }",
+      );
 
-    assertEquals(result.continue, false);
-    assertEquals(result.response?.status, 200);
-    const body = await result.response!.text();
-    assertEquals(body.includes("preview"), true);
-  });
+      const encodedPath = base64urlEncode("app/page.tsx");
+      const req = new Request(`http://localhost/_veryfront/fs/${encodedPath}.js`);
+      const ctx = makeCtx({
+        adapter,
+        isLocalProject: false,
+        requestContext: { mode: "preview" } as HandlerContext["requestContext"],
+      });
 
-  it("continues for non-local production requests", async () => {
-    const handler = new DevFileHandler();
-    const encodedPath = base64urlEncode("app/page.tsx");
-    const req = new Request(`http://localhost/_veryfront/fs/${encodedPath}.js`);
-    const ctx = makeCtx({
-      isLocalProject: false,
-      requestContext: { mode: "production" } as HandlerContext["requestContext"],
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.continue, false);
+      assertEquals(result.response?.status, 200);
+      const body = await result.response!.text();
+      assertEquals(body.includes("preview"), true);
     });
 
-    const result = await handler.handle(req, ctx);
+    it("continues for non-local production requests", async () => {
+      const handler = new DevFileHandler();
+      const encodedPath = base64urlEncode("app/page.tsx");
+      const req = new Request(`http://localhost/_veryfront/fs/${encodedPath}.js`);
+      const ctx = makeCtx({
+        isLocalProject: false,
+        requestContext: { mode: "production" } as HandlerContext["requestContext"],
+      });
 
-    assertEquals(result.continue, true);
-  });
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.continue, true);
+    });
   },
 );

--- a/src/server/handlers/dev/files/dev-file.handler.ts
+++ b/src/server/handlers/dev/files/dev-file.handler.ts
@@ -18,13 +18,14 @@ export class DevFileHandler extends BaseHandler {
     name: "DevFileHandler",
     priority: PRIORITY_MEDIUM_DEV_FILES as HandlerPriority,
     patterns: [{ pattern: "/_veryfront/fs/", prefix: true, method: "GET" }],
-    enabled: (ctx) => !!ctx.isLocalProject,
+    enabled: (ctx) => !!ctx.isLocalProject || ctx.requestContext?.mode === "preview",
   };
 
   async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
     const { pathname } = new URL(req.url);
 
-    if (!ctx.isLocalProject) return this.continue();
+    const isPreviewMode = ctx.requestContext?.mode === "preview";
+    if (!ctx.isLocalProject && !isPreviewMode) return this.continue();
 
     if (req.method !== "GET" || !pathname.startsWith("/_veryfront/fs/")) {
       return this.continue();

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.114";
+export const VERSION = "0.1.115";


### PR DESCRIPTION
## Summary
- fix preview `/_veryfront/fs/*` module serving so remote preview can hydrate page components
- keep the strict CSP/RSC hydration fixes from the earlier branch stack
- bump framework version to `0.1.115`

## Testing
- deno test --no-check --allow-all src/utils/version.test.ts src/modules/server/module-server.test.ts src/server/handlers/dev/files/dev-file.handler.test.ts src/server/handlers/dev/files/path-validator.test.ts src/server/handlers/dev/scripts/dev-loader.test.ts tests/integration/server/production/fs-bundling.test.ts
- pre-push checks: format, lint, type-check, full unit tests

## Notes
- This PR supersedes #794 with the additional remote preview `/_veryfront/fs/*` fix.