### PR TITLE
Fix preview dev file proxy context

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.115",
+  "version": "0.1.116",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/server/handlers/dev/files/dev-file.handler.test.ts
+++ b/src/server/handlers/dev/files/dev-file.handler.test.ts
@@ -15,6 +15,63 @@ function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
   } as HandlerContext;
 }
 
+function createProxyPreviewAdapter() {
+  const base = createMockAdapter();
+  const calls: string[] = [];
+  let inContext = false;
+
+  const fs = {
+    ...base.fs,
+    stat: async (path: string) => {
+      calls.push(`stat:${path}`);
+      if (!inContext) throw new Error("missing proxy context");
+      return await base.fs.stat(path);
+    },
+    readFile: async (path: string) => {
+      calls.push(`readFile:${path}`);
+      if (!inContext) throw new Error("missing proxy context");
+      return await base.fs.readFile(path);
+    },
+    isVeryfrontAdapter: () => true,
+    getUnderlyingAdapter: () => ({}),
+    getAdapterType: () => "VeryfrontFSAdapter",
+    isMultiProjectMode: () => true,
+    isContextualMode: () => true,
+    runWithContext: async (
+      _slug: string,
+      _token: string,
+      fn: () => Promise<unknown>,
+      _projectId?: string,
+      _options?: Record<string, unknown>,
+    ) => {
+      calls.push("runWithContext");
+      inContext = true;
+      try {
+        return await fn();
+      } finally {
+        inContext = false;
+      }
+    },
+    setRequestToken: (_token: string) => {
+      calls.push("setRequestToken");
+    },
+    setRequestBranch: (_branch: string | null) => {
+      calls.push("setRequestBranch");
+    },
+    setProductionMode: (_enabled: boolean, _releaseId?: string | null) => {
+      calls.push("setProductionMode");
+    },
+  };
+
+  return {
+    adapter: {
+      ...base,
+      fs,
+    },
+    calls,
+  };
+}
+
 describe(
   "server/handlers/dev/files/dev-file.handler",
   {
@@ -50,6 +107,38 @@ describe(
       assertEquals(result.response?.status, 200);
       const body = await result.response!.text();
       assertEquals(body.includes("preview"), true);
+    });
+
+    it("uses proxy fs context for remote preview modules", async () => {
+      const handler = new DevFileHandler();
+      const { adapter, calls } = createProxyPreviewAdapter();
+      const modulePath = "/project/app/page.tsx";
+      adapter.fs.files.set(
+        modulePath,
+        "export default function Page() { return 'preview-proxy'; }",
+      );
+
+      const encodedPath = base64urlEncode("app/page.tsx");
+      const req = new Request(`http://localhost/_veryfront/fs/${encodedPath}.js`);
+      const ctx = makeCtx({
+        adapter: adapter as HandlerContext["adapter"],
+        isLocalProject: false,
+        projectSlug: "test-project",
+        projectId: "proj-123",
+        proxyToken: "test-token",
+        releaseId: "rel-1",
+        environmentName: "staging",
+        parsedDomain: { branch: "feature-x" } as HandlerContext["parsedDomain"],
+        requestContext: { mode: "preview" } as HandlerContext["requestContext"],
+      });
+
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.continue, false);
+      assertEquals(result.response?.status, 200);
+      assertEquals(calls.includes("runWithContext"), true);
+      const body = await result.response!.text();
+      assertEquals(body.includes("preview-proxy"), true);
     });
 
     it("continues for non-local production requests", async () => {

--- a/src/server/handlers/dev/files/dev-file.handler.ts
+++ b/src/server/handlers/dev/files/dev-file.handler.ts
@@ -12,6 +12,8 @@ import {
   HTTP_NOT_FOUND,
   PRIORITY_MEDIUM_DEV_FILES,
 } from "#veryfront/utils/constants/index.ts";
+import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 export class DevFileHandler extends BaseHandler {
   metadata: HandlerMetadata = {
@@ -31,6 +33,45 @@ export class DevFileHandler extends BaseHandler {
       return this.continue();
     }
 
+    const fsAdapter = ctx.adapter.fs;
+    const isExtended = isExtendedFSAdapter(fsAdapter);
+
+    if (!ctx.isLocalProject && ctx.projectSlug && isExtended && fsAdapter.isMultiProjectMode()) {
+      const effectiveToken = ctx.proxyToken || getHostEnv("VERYFRONT_API_TOKEN") || "";
+      const branch = ctx.parsedDomain?.branch ?? null;
+
+      return await fsAdapter.runWithContext(
+        ctx.projectSlug,
+        effectiveToken,
+        () => this.handleWithContext(req, pathname, ctx),
+        ctx.projectId,
+        {
+          productionMode: false,
+          releaseId: ctx.releaseId,
+          branch,
+          environmentName: ctx.environmentName,
+        },
+      );
+    }
+
+    if (isExtended && fsAdapter.isContextualMode()) {
+      try {
+        if (ctx.proxyToken) fsAdapter.setRequestToken(ctx.proxyToken);
+        fsAdapter.setRequestBranch(ctx.parsedDomain?.branch ?? null);
+        fsAdapter.setProductionMode(false, ctx.releaseId);
+      } catch (_) {
+        /* expected: some fs adapter operations may not be supported */
+      }
+    }
+
+    return await this.handleWithContext(req, pathname, ctx);
+  }
+
+  private async handleWithContext(
+    req: Request,
+    pathname: string,
+    ctx: HandlerContext,
+  ): Promise<HandlerResult> {
     const encoded = pathname.slice("/_veryfront/fs/".length).replace(/\.js$/, "");
     const absPath = await validateDevFilePath(encoded, ctx);
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.115";
+export const VERSION = "0.1.116";


### PR DESCRIPTION
## Summary
- enter proxy FS context before validating and bundling /_veryfront/fs modules in preview
- add a regression test for remote preview proxy mode

## Testing
- deno test --no-check --allow-all src/server/handlers/dev/files/dev-file.handler.test.ts
- deno test --no-check --allow-all src/server/handlers/dev/files/path-validator.test.ts src/server/handlers/dev/scripts/dev-loader.test.ts tests/integration/server/production/fs-bundling.test.ts
- pre-push checks: format, lint, type-check, full unit tests