### PR TITLE
Fix preview hydration CSP regressions

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.116",
+  "version": "0.1.117",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -478,9 +478,9 @@ async function findSourceFile(
   }
 
   const frameworkLookups: [string, string, string, boolean][] = [
-    // Embedded sources for compiled binaries (.src extensions)
-    ["_veryfront/", EMBEDDED_SRC_DIR, "_veryfront-embedded", true],
     ["_veryfront/", join(FRAMEWORK_ROOT, "src"), "_veryfront", true],
+    // Embedded sources are a fallback for compiled binaries when src/ is unavailable.
+    ["_veryfront/", EMBEDDED_SRC_DIR, "_veryfront-embedded", true],
     // Fallback to projectDir for local dev/proxy setups where FRAMEWORK_ROOT may differ.
     ["_veryfront/", join(projectDir, "src"), "_veryfront-project", true],
   ];

--- a/src/react/components/ai/markdown.tsx
+++ b/src/react/components/ai/markdown.tsx
@@ -27,7 +27,9 @@ const ESM_REMARK_GFM = "https://esm.sh/remark-gfm@4.0.1?target=es2022&pin=v135";
 const ESM_REHYPE_HIGHLIGHT = "https://esm.sh/rehype-highlight@7.0.2?target=es2022&pin=v135";
 const ESM_MERMAID = "https://esm.sh/mermaid@11.4.1?pin=v135";
 
-const dynamicImport = new Function("url", "return import(url)") as (url: string) => Promise<any>;
+async function importFromUrl(url: string): Promise<unknown> {
+  return await import(url);
+}
 
 // deno-lint-ignore no-explicit-any
 let ReactMarkdown: any = null;
@@ -45,7 +47,7 @@ async function loadMermaid(): Promise<any | null> {
   if (!isBrowserEnvironment()) return null;
   if (mermaidModule) return mermaidModule;
 
-  mermaidPromise ??= dynamicImport(ESM_MERMAID);
+  mermaidPromise ??= importFromUrl(ESM_MERMAID);
   mermaidModule = await mermaidPromise;
 
   mermaidModule.default.initialize({
@@ -180,9 +182,9 @@ export function Markdown({
     async function load(): Promise<void> {
       if (!ReactMarkdown) {
         const [rmModule, gfmModule, highlightModule] = await Promise.all([
-          dynamicImport(ESM_REACT_MARKDOWN),
-          dynamicImport(ESM_REMARK_GFM),
-          dynamicImport(ESM_REHYPE_HIGHLIGHT),
+          importFromUrl(ESM_REACT_MARKDOWN),
+          importFromUrl(ESM_REMARK_GFM),
+          importFromUrl(ESM_REHYPE_HIGHLIGHT),
         ]);
 
         ReactMarkdown = rmModule.default;

--- a/src/react/components/ai/markdown.tsx
+++ b/src/react/components/ai/markdown.tsx
@@ -27,8 +27,21 @@ const ESM_REMARK_GFM = "https://esm.sh/remark-gfm@4.0.1?target=es2022&pin=v135";
 const ESM_REHYPE_HIGHLIGHT = "https://esm.sh/rehype-highlight@7.0.2?target=es2022&pin=v135";
 const ESM_MERMAID = "https://esm.sh/mermaid@11.4.1?pin=v135";
 
-async function importFromUrl(url: string): Promise<unknown> {
-  return await import(url);
+type DefaultModule<T> = { default: T };
+
+type MermaidModule = {
+  default: {
+    initialize(config: {
+      startOnLoad: boolean;
+      theme: string;
+      securityLevel: string;
+    }): void;
+    render(id: string, code: string): Promise<{ svg: string }>;
+  };
+};
+
+async function importFromUrl<T>(url: string): Promise<T> {
+  return await import(url) as T;
 }
 
 // deno-lint-ignore no-explicit-any
@@ -39,7 +52,7 @@ let remarkGfm: any = null;
 let rehypeHighlight: any = null;
 
 // deno-lint-ignore no-explicit-any
-let mermaidPromise: Promise<any> | null = null;
+let mermaidPromise: Promise<MermaidModule> | null = null;
 // deno-lint-ignore no-explicit-any
 let mermaidModule: any = null;
 
@@ -47,7 +60,7 @@ async function loadMermaid(): Promise<any | null> {
   if (!isBrowserEnvironment()) return null;
   if (mermaidModule) return mermaidModule;
 
-  mermaidPromise ??= importFromUrl(ESM_MERMAID);
+  mermaidPromise ??= importFromUrl<MermaidModule>(ESM_MERMAID);
   mermaidModule = await mermaidPromise;
 
   mermaidModule.default.initialize({
@@ -182,9 +195,9 @@ export function Markdown({
     async function load(): Promise<void> {
       if (!ReactMarkdown) {
         const [rmModule, gfmModule, highlightModule] = await Promise.all([
-          importFromUrl(ESM_REACT_MARKDOWN),
-          importFromUrl(ESM_REMARK_GFM),
-          importFromUrl(ESM_REHYPE_HIGHLIGHT),
+          importFromUrl<DefaultModule<unknown>>(ESM_REACT_MARKDOWN),
+          importFromUrl<DefaultModule<unknown>>(ESM_REMARK_GFM),
+          importFromUrl<DefaultModule<unknown>>(ESM_REHYPE_HIGHLIGHT),
         ]);
 
         ReactMarkdown = rmModule.default;

--- a/src/server/handlers/dev/files/dev-file.handler.test.ts
+++ b/src/server/handlers/dev/files/dev-file.handler.test.ts
@@ -141,6 +141,70 @@ describe(
       assertEquals(body.includes("preview-proxy"), true);
     });
 
+    it("keeps browser import-map exact specifiers in preview bundles", async () => {
+      const handler = new DevFileHandler();
+      const adapter = createMockAdapter();
+      const modulePath = "/project/app/page.tsx";
+      adapter.fs.files.set(
+        modulePath,
+        [
+          '"use client";',
+          'import { Chat } from "veryfront/chat";',
+          "export default function Page() {",
+          '  return Chat ? "preview-chat" : "missing";',
+          "}",
+        ].join("\n"),
+      );
+
+      const encodedPath = base64urlEncode("app/page.tsx");
+      const req = new Request(`http://localhost/_veryfront/fs/${encodedPath}.js`);
+      const ctx = makeCtx({
+        adapter,
+        isLocalProject: false,
+        requestContext: { mode: "preview" } as HandlerContext["requestContext"],
+      });
+
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.continue, false);
+      assertEquals(result.response?.status, 200);
+      const body = await result.response!.text();
+      assertEquals(body.includes('from "veryfront/chat"'), true);
+      assertEquals(body.includes("https://esm.sh/veryfront/chat"), false);
+    });
+
+    it("keeps browser import-map prefix specifiers in preview bundles", async () => {
+      const handler = new DevFileHandler();
+      const adapter = createMockAdapter();
+      const modulePath = "/project/app/page.tsx";
+      adapter.fs.files.set(
+        modulePath,
+        [
+          '"use client";',
+          'import Button from "@/components/Button";',
+          "export default function Page() {",
+          "  return Button;",
+          "}",
+        ].join("\n"),
+      );
+
+      const encodedPath = base64urlEncode("app/page.tsx");
+      const req = new Request(`http://localhost/_veryfront/fs/${encodedPath}.js`);
+      const ctx = makeCtx({
+        adapter,
+        isLocalProject: false,
+        requestContext: { mode: "preview" } as HandlerContext["requestContext"],
+      });
+
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.continue, false);
+      assertEquals(result.response?.status, 200);
+      const body = await result.response!.text();
+      assertEquals(body.includes('from "@/components/Button"'), true);
+      assertEquals(body.includes("https://esm.sh/@/components/Button"), false);
+    });
+
     it("continues for non-local production requests", async () => {
       const handler = new DevFileHandler();
       const encodedPath = base64urlEncode("app/page.tsx");

--- a/src/server/handlers/dev/files/dev-file.handler.test.ts
+++ b/src/server/handlers/dev/files/dev-file.handler.test.ts
@@ -5,6 +5,10 @@ import { base64urlEncode } from "#veryfront/utils/base64url.ts";
 import type { HandlerContext } from "../../types.ts";
 import { DevFileHandler } from "./dev-file.handler.ts";
 
+function getImportSpecifiers(source: string): string[] {
+  return [...source.matchAll(/\bfrom\s+["']([^"']+)["']/g)].map((match) => match[1]);
+}
+
 function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
   return {
     projectDir: "/project",
@@ -169,8 +173,9 @@ describe(
       assertEquals(result.continue, false);
       assertEquals(result.response?.status, 200);
       const body = await result.response!.text();
-      assertEquals(body.includes('from "veryfront/chat"'), true);
-      assertEquals(body.includes("https://esm.sh/veryfront/chat"), false);
+      const specifiers = getImportSpecifiers(body);
+      assertEquals(specifiers.includes("veryfront/chat"), true);
+      assertEquals(specifiers.some((specifier) => specifier.includes("esm.sh")), false);
     });
 
     it("keeps browser import-map prefix specifiers in preview bundles", async () => {
@@ -201,8 +206,9 @@ describe(
       assertEquals(result.continue, false);
       assertEquals(result.response?.status, 200);
       const body = await result.response!.text();
-      assertEquals(body.includes('from "@/components/Button"'), true);
-      assertEquals(body.includes("https://esm.sh/@/components/Button"), false);
+      const specifiers = getImportSpecifiers(body);
+      assertEquals(specifiers.includes("@/components/Button"), true);
+      assertEquals(specifiers.some((specifier) => specifier.includes("esm.sh")), false);
     });
 
     it("continues for non-local production requests", async () => {

--- a/src/server/handlers/dev/files/esbuild-bundler.ts
+++ b/src/server/handlers/dev/files/esbuild-bundler.ts
@@ -1,4 +1,5 @@
 import type { HandlerContext } from "../../types.ts";
+import { buildImportMapJson } from "#veryfront/html";
 import { getDirectory, getEsbuildLoader } from "#veryfront/utils/path-utils.ts";
 import { createBareExternalPlugin, createRelativeFsPlugin } from "./esbuild-plugins.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
@@ -9,6 +10,11 @@ export function bundleDevFile(absPath: string, ctx: HandlerContext): Promise<str
     async () => {
       const { build } = await import("esbuild");
       const src = await ctx.adapter.fs.readFile(absPath);
+      const importMapJson = await buildImportMapJson({
+        projectDir: ctx.projectDir,
+        config: ctx.config,
+      });
+      const importMap = JSON.parse(importMapJson) as { imports?: Record<string, string> };
 
       const { outputFiles } = await build({
         bundle: true,
@@ -25,7 +31,12 @@ export function bundleDevFile(absPath: string, ctx: HandlerContext): Promise<str
           resolveDir: getDirectory(absPath),
           sourcefile: absPath,
         },
-        plugins: [createRelativeFsPlugin(ctx.projectDir, ctx.adapter), createBareExternalPlugin()],
+        plugins: [
+          createRelativeFsPlugin(ctx.projectDir, ctx.adapter),
+          createBareExternalPlugin({
+            importMapImports: importMap.imports,
+          }),
+        ],
       });
 
       return outputFiles?.[0]?.text ?? "export default null";

--- a/src/server/handlers/dev/files/esbuild-plugins.test.ts
+++ b/src/server/handlers/dev/files/esbuild-plugins.test.ts
@@ -28,7 +28,7 @@ async function bundleWithPlugin(
 describe("server/handlers/dev/files/esbuild-plugins", () => {
   afterEach(async () => {
     const esbuild = await import("esbuild");
-    esbuild.stop();
+    await esbuild.stop();
   });
 
   it("keeps exact import-map specifiers when values are empty sentinels", async () => {

--- a/src/server/handlers/dev/files/esbuild-plugins.test.ts
+++ b/src/server/handlers/dev/files/esbuild-plugins.test.ts
@@ -1,0 +1,43 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { createBareExternalPlugin } from "./esbuild-plugins.ts";
+
+async function bundleWithPlugin(
+  contents: string,
+  importMapImports: Record<string, string>,
+): Promise<string> {
+  const { build } = await import("esbuild");
+  const result = await build({
+    bundle: true,
+    write: false,
+    format: "esm",
+    platform: "browser",
+    target: "es2020",
+    stdin: {
+      contents,
+      loader: "js",
+      sourcefile: "/project/app/page.js",
+      resolveDir: "/project/app",
+    },
+    plugins: [createBareExternalPlugin({ importMapImports })],
+  });
+
+  return result.outputFiles?.[0]?.text ?? "";
+}
+
+describe("server/handlers/dev/files/esbuild-plugins", () => {
+  afterEach(async () => {
+    const esbuild = await import("esbuild");
+    esbuild.stop();
+  });
+
+  it("keeps exact import-map specifiers when values are empty sentinels", async () => {
+    const output = await bundleWithPlugin(
+      'import React from "react"; console.log(React);',
+      { react: "" },
+    );
+
+    assertEquals(output.includes('from "react"'), true);
+    assertEquals(output.includes("esm.sh/react"), false);
+  });
+});

--- a/src/server/handlers/dev/files/esbuild-plugins.ts
+++ b/src/server/handlers/dev/files/esbuild-plugins.ts
@@ -74,14 +74,14 @@ export function createRelativeFsPlugin(projectDir: string, adapter: RuntimeAdapt
  * Bare specifiers that should be kept as-is (not rewritten to esm.sh URLs).
  * These are resolved by the browser's import map injected in the HTML <head>.
  */
-const IMPORT_MAP_RESOLVED = new Set([
-  "react",
-  "react-dom",
-  "react-dom/client",
-  "react-dom/server",
-  "react/jsx-runtime",
-  "react/jsx-dev-runtime",
-]);
+const DEFAULT_IMPORT_MAP_IMPORTS: Record<string, string> = {
+  react: "",
+  "react-dom": "",
+  "react-dom/client": "",
+  "react-dom/server": "",
+  "react/jsx-runtime": "",
+  "react/jsx-dev-runtime": "",
+};
 
 /** Map of common packages to their esm.sh URLs for browser imports */
 const ESM_PACKAGE_MAP: Record<string, string> = {};
@@ -91,6 +91,7 @@ interface BareExternalPluginOptions {
   lockfile?: LockfileManager;
   projectDir?: string;
   strict?: boolean;
+  importMapImports?: Record<string, string>;
 }
 
 function isBareImport(path: string): boolean {
@@ -104,6 +105,19 @@ function isBareImport(path: string): boolean {
 
 function toEsmUrl(path: string): string {
   return ESM_PACKAGE_MAP[path] ?? `https://esm.sh/${path}`;
+}
+
+function isImportMapResolved(
+  path: string,
+  imports: Record<string, string>,
+): boolean {
+  if (imports[path]) return true;
+
+  for (const key of Object.keys(imports)) {
+    if (key.endsWith("/") && path.startsWith(key)) return true;
+  }
+
+  return false;
 }
 
 function resolveAsExternalOrHttps(
@@ -164,6 +178,10 @@ export function createBareExternalPlugin(
   const { bundle = false, strict = false } = opts;
   const lockfile = opts.lockfile ??
     (opts.projectDir && bundle ? createLockfileManager(opts.projectDir) : null);
+  const importMapImports = {
+    ...DEFAULT_IMPORT_MAP_IMPORTS,
+    ...(opts.importMapImports ?? {}),
+  };
 
   return {
     name: "veryfront-bare-ext",
@@ -174,7 +192,7 @@ export function createBareExternalPlugin(
 
         // Keep import-map-resolved specifiers as bare externals — the browser's
         // <script type="importmap"> resolves them to the correct CDN URL.
-        if (IMPORT_MAP_RESOLVED.has(args.path)) {
+        if (isImportMapResolved(args.path, importMapImports)) {
           return { path: args.path, external: true };
         }
 

--- a/src/server/handlers/dev/files/esbuild-plugins.ts
+++ b/src/server/handlers/dev/files/esbuild-plugins.ts
@@ -111,7 +111,7 @@ function isImportMapResolved(
   path: string,
   imports: Record<string, string>,
 ): boolean {
-  if (imports[path]) return true;
+  if (Object.prototype.hasOwnProperty.call(imports, path)) return true;
 
   for (const key of Object.keys(imports)) {
     if (key.endsWith("/") && path.startsWith(key)) return true;

--- a/src/transforms/mdx/esm-module-loader/resolution/file-finder.ts
+++ b/src/transforms/mdx/esm-module-loader/resolution/file-finder.ts
@@ -32,10 +32,11 @@ const FRAMEWORK_EXTENSIONS = [
   ".js", // Regular sources for dev mode
 ];
 
-// Framework lookup directories in priority order
+// Framework lookup directories in priority order.
+// Prefer source files when they exist; embedded .src files are a fallback.
 const FRAMEWORK_LOOKUP_DIRS = [
-  EMBEDDED_SRC_DIR, // Embedded sources for compiled binaries (.src files)
   join(FRAMEWORK_ROOT, "src"), // Regular sources for dev mode
+  EMBEDDED_SRC_DIR, // Embedded sources for compiled binaries (.src files)
 ];
 
 export interface FileResolutionResult {
@@ -145,8 +146,8 @@ export async function resolveModuleFile(
   if (!isFramework) return null;
 
   // Try to resolve framework files from multiple locations:
-  // 1. EMBEDDED_SRC_DIR (dist/framework-src) - for compiled binaries with .src extensions
-  // 2. FRAMEWORK_ROOT/src - for development mode with regular extensions
+  // 1. FRAMEWORK_ROOT/src - source checkouts should prefer current source files
+  // 2. EMBEDDED_SRC_DIR (dist/framework-src) - fallback for compiled binaries
   const localFs = getLocalFs();
 
   logger.debug(`${LOG_PREFIX_MDX_LOADER} Resolving framework file`, {

--- a/src/transforms/pipeline/stages/ssr-vf-modules/constants.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/constants.ts
@@ -26,13 +26,14 @@ export const FRAMEWORK_ROOT = RUNTIME_FRAMEWORK_ROOT;
 // In compiled binaries, files are extracted to the runtime directory.
 export const EMBEDDED_SRC_DIR = join(RUNTIME_FRAMEWORK_ROOT, "dist", "framework-src");
 
-// Map of _vf_modules prefixes to framework directories
-// We try embedded sources first (for compiled binaries), then regular src/
+// Map of _vf_modules prefixes to framework directories.
+// Prefer regular src/ when present so source checkouts never serve stale
+// dist/framework-src copies; compiled binaries fall back to embedded .src files.
 export const FRAMEWORK_LOOKUPS: Array<[prefix: string, frameworkDir: string]> = [
-  // Embedded sources for compiled binaries (these are .src files)
-  ["_veryfront/", EMBEDDED_SRC_DIR],
   // Regular sources for dev mode
   ["_veryfront/", join(FRAMEWORK_ROOT, "src")],
+  // Embedded sources for compiled binaries (these are .src files)
+  ["_veryfront/", EMBEDDED_SRC_DIR],
 ];
 
 // Singleflight for framework module file writes to prevent race conditions

--- a/src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.ts
@@ -116,9 +116,9 @@ export async function resolveFrameworkFile(
  * Resolve a #veryfront/ import to the actual framework source file path.
  * Returns the resolved path if found, null otherwise.
  *
- * IMPORTANT: This function checks embedded sources FIRST (for compiled binaries),
- * then falls back to regular src/. This matches resolveFrameworkFile's behavior
- * and ensures consistent path resolution for cycle detection.
+ * IMPORTANT: This function prefers regular src/ when present, then falls back
+ * to embedded sources for compiled binaries. This matches resolveFrameworkFile's
+ * behavior and ensures consistent path resolution for cycle detection.
  */
 export async function resolveVeryfrontSourcePath(
   specifier: string,
@@ -132,13 +132,13 @@ export async function resolveVeryfrontSourcePath(
   const relativePath = mappedTarget.slice("./src/".length);
   const hasExtension = /\.(tsx?|jsx?|mjs)$/.test(relativePath);
 
-  // Check embedded sources first (for compiled binaries), then regular src/
+  // Prefer regular src/ when present, then fall back to embedded sources.
   // This order matches FRAMEWORK_LOOKUPS and resolveFrameworkFile to ensure
   // consistent path resolution across the codebase, which is critical for
   // cycle detection in transformingFiles.
   const lookupDirs = [
-    EMBEDDED_SRC_DIR, // Embedded sources for compiled binaries (.src files)
     join(FRAMEWORK_ROOT, "src"), // Regular sources for dev mode
+    EMBEDDED_SRC_DIR, // Embedded sources for compiled binaries (.src files)
   ];
 
   for (const dir of lookupDirs) {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.116";
+export const VERSION = "0.1.117";

--- a/tests/integration/server/dev-server-handlers.test.ts
+++ b/tests/integration/server/dev-server-handlers.test.ts
@@ -342,6 +342,24 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
         await stopServer(server);
       });
     });
+
+    it("serves framework markdown module without unsafe-eval helpers", async () => {
+      await withTestContext("dev-server-framework-markdown-csp", async (context) => {
+        const { server, port } = await createTestDevServer(context);
+        const response = await fetch(
+          `http://127.0.0.1:${port}/_vf_modules/_veryfront/react/components/ai/markdown.js`,
+        );
+
+        assertEquals(response.status, 200);
+        const body = await response.text();
+        assert(
+          !body.includes("new Function("),
+          "Framework markdown module should not use unsafe-eval",
+        );
+
+        await stopServer(server);
+      });
+    });
   });
 
   describe("DevServer - Error Handler", {}, () => {


### PR DESCRIPTION
## Summary
- preserve browser import-map-owned specifiers in `/_veryfront/fs/*` bundles instead of rewriting them to `esm.sh`
- remove the remaining client-side `unsafe-eval` from the markdown renderer used by `veryfront/chat`
- prefer live framework `src/` files over `dist/framework-src/` in source checkouts so preview/dev do not serve stale embedded copies
- bump version to `0.1.117`

## Verification
- `deno test --no-check --allow-all src/utils/version.test.ts src/transforms/mdx/esm-module-loader/resolution/file-finder.test.ts src/transforms/pipeline/stages/ssr-vf-modules.test.ts`
- `deno test --no-check --allow-all src/server/handlers/dev/files/dev-file.handler.test.ts tests/integration/server/dev-server-handlers.test.ts tests/integration/server/production/fs-bundling.test.ts`
