### PR TITLE
Add RSC and App Router SSR lifecycle regression coverage

### DIFF
--- a/src/rendering/rsc/client-dom.test.ts
+++ b/src/rendering/rsc/client-dom.test.ts
@@ -1,0 +1,174 @@
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { RSC_ROOT_ID } from "./constants.ts";
+import { consumeNdjsonStream } from "./client-dom.ts";
+
+class MockElement {
+  id = "";
+  dataset: Record<string, string> = {};
+  children: MockElement[] = [];
+  private rawInnerHtml = "";
+
+  constructor(readonly tagName: string) {}
+
+  get innerHTML(): string {
+    return this.rawInnerHtml;
+  }
+
+  set innerHTML(value: string) {
+    this.rawInnerHtml = value;
+    this.children = parseChildren(value);
+  }
+
+  appendChild(child: MockElement): MockElement {
+    this.children.push(child);
+    return child;
+  }
+
+  querySelector(selector: string): MockElement | null {
+    const match = selector.match(/^\[data-client-ref='(.+)'\]$/);
+    if (!match) return null;
+
+    const target = match[1];
+    return findByPredicate(this, (node) => node.dataset.clientRef === target);
+  }
+}
+
+class MockDocument {
+  readonly body = new MockElement("body");
+
+  createElement(tagName: string): MockElement {
+    return new MockElement(tagName.toUpperCase());
+  }
+
+  getElementById(id: string): MockElement | null {
+    return findByPredicate(this.body, (node) => node.id === id);
+  }
+}
+
+function createDocument(): Document {
+  return new MockDocument() as unknown as Document;
+}
+
+function createStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+function findByPredicate(
+  node: MockElement,
+  predicate: (node: MockElement) => boolean,
+): MockElement | null {
+  for (const child of node.children) {
+    if (predicate(child)) return child;
+    const nested = findByPredicate(child, predicate);
+    if (nested) return nested;
+  }
+  return null;
+}
+
+function parseChildren(html: string): MockElement[] {
+  const elementPattern = /<([a-zA-Z0-9-]+)([^>]*)>([\s\S]*?)<\/\1>/g;
+  const children: MockElement[] = [];
+
+  for (const match of html.matchAll(elementPattern)) {
+    const tagName = match[1] ?? "div";
+    const attrs = match[2] ?? "";
+    const inner = match[3] ?? "";
+    const element = new MockElement(tagName.toUpperCase());
+
+    for (const attrMatch of attrs.matchAll(/([a-zA-Z0-9:-]+)="([^"]*)"/g)) {
+      const name = attrMatch[1] ?? "";
+      const value = attrMatch[2] ?? "";
+      if (name === "id") {
+        element.id = value;
+        continue;
+      }
+
+      if (name.startsWith("data-")) {
+        element.dataset[toDatasetKey(name.slice(5))] = value;
+      }
+    }
+
+    element.innerHTML = inner;
+    children.push(element);
+  }
+
+  return children;
+}
+
+function toDatasetKey(value: string): string {
+  return value.replace(/-([a-z])/g, (_match, char: string) => char.toUpperCase());
+}
+
+describe("rendering/rsc/client-dom", () => {
+  it("applies streamed slot HTML and marks client boundaries as hydrated", async () => {
+    const doc = createDocument();
+
+    await consumeNdjsonStream(
+      createStream([
+        '{"type":"slot","id":"root","html":"<button data-client-ref=\\"Counter\\">Click</button>"}\n',
+      ]),
+      doc,
+    );
+
+    const root = doc.getElementById(RSC_ROOT_ID);
+    assertExists(root);
+    assertEquals(root.innerHTML.includes("Click"), true);
+
+    const button = root.querySelector("[data-client-ref='Counter']") as HTMLElement | null;
+    assertExists(button);
+    assertEquals(button.dataset.hydrated, "true");
+  });
+
+  it("buffers partial NDJSON lines and ignores malformed chunks", async () => {
+    const doc = createDocument();
+
+    await consumeNdjsonStream(
+      createStream([
+        '{"type":"slot","id":"root","html":"<div>Par',
+        'sed</div>"}\nnot-json\n{"type":"slot","id":"sidebar","html":"<div>Ready</div>"}\n',
+      ]),
+      doc,
+    );
+
+    const root = doc.getElementById(RSC_ROOT_ID);
+    const sidebar = doc.getElementById("rsc-slot-sidebar");
+
+    assertExists(root);
+    assertExists(sidebar);
+    assertEquals(root.innerHTML.includes("Parsed"), true);
+    assertEquals(sidebar.innerHTML.includes("Ready"), true);
+  });
+
+  it("aborts pending reads and cancels the underlying stream", async () => {
+    const doc = createDocument();
+    const controller = new AbortController();
+    let cancelCount = 0;
+
+    const stream = new ReadableStream<Uint8Array>({
+      start() {
+        // Leave the stream open so consumeNdjsonStream blocks on reader.read().
+      },
+      cancel() {
+        cancelCount++;
+      },
+    });
+
+    const pending = consumeNdjsonStream(stream, doc, controller.signal);
+    controller.abort();
+
+    await assertRejects(
+      () => pending,
+      DOMException,
+      "aborted",
+    );
+    assertEquals(cancelCount > 0, true);
+  });
+});

--- a/src/server/handlers/request/ssr/not-found-fallback.test.ts
+++ b/src/server/handlers/request/ssr/not-found-fallback.test.ts
@@ -1,9 +1,14 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { mkdir, writeTextFile } from "#veryfront/compat/fs.ts";
+import { join } from "#veryfront/compat/path";
+import { getAdapter } from "#veryfront/platform/adapters/detect.ts";
+import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { tryNotFoundFallback } from "./not-found-fallback.ts";
 import { ResponseBuilder } from "#veryfront/security/http/response/builder.ts";
 import type { HandlerContext } from "../../types.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { cleanupBundler } from "../../../../rendering/cleanup.ts";
+import { withTestContext } from "../../../../../tests/_helpers/context.ts";
 
 function createMockAdapter(
   overrides: {
@@ -54,42 +59,82 @@ function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
   };
 }
 
-describe("server/handlers/request/ssr/not-found-fallback", () => {
-  describe("tryNotFoundFallback", () => {
-    it("returns null when app directory does not exist", async () => {
-      const adapter = createMockAdapter({
-        stat: () => Promise.reject(new Error("ENOENT")),
-      });
-      const ctx = makeCtx({ adapter });
-      const req = new Request("http://localhost/not-found");
-      const builder = new ResponseBuilder();
-
-      const result = await tryNotFoundFallback(req, "not-found", ctx, builder);
-      assertEquals(result, null);
+describe(
+  "server/handlers/request/ssr/not-found-fallback",
+  { sanitizeOps: false, sanitizeResources: false },
+  () => {
+    afterAll(async () => {
+      await cleanupBundler();
     });
 
-    it("returns null when app path is not a directory", async () => {
-      const adapter = createMockAdapter({
-        stat: () => Promise.resolve({ isFile: true, isDirectory: false, size: 0, mtime: null }),
+    describe("tryNotFoundFallback", () => {
+      it("returns null when app directory does not exist", async () => {
+        const adapter = createMockAdapter({
+          stat: () => Promise.reject(new Error("ENOENT")),
+        });
+        const ctx = makeCtx({ adapter });
+        const req = new Request("http://localhost/not-found");
+        const builder = new ResponseBuilder();
+
+        const result = await tryNotFoundFallback(req, "not-found", ctx, builder);
+        assertEquals(result, null);
       });
-      const ctx = makeCtx({ adapter });
-      const req = new Request("http://localhost/not-found");
-      const builder = new ResponseBuilder();
 
-      const result = await tryNotFoundFallback(req, "not-found", ctx, builder);
-      assertEquals(result, null);
-    });
+      it("returns null when app path is not a directory", async () => {
+        const adapter = createMockAdapter({
+          stat: () => Promise.resolve({ isFile: true, isDirectory: false, size: 0, mtime: null }),
+        });
+        const ctx = makeCtx({ adapter });
+        const req = new Request("http://localhost/not-found");
+        const builder = new ResponseBuilder();
 
-    it("returns null when slug is empty and app directory doesn't exist", async () => {
-      const adapter = createMockAdapter({
-        stat: () => Promise.reject(new Error("ENOENT")),
+        const result = await tryNotFoundFallback(req, "not-found", ctx, builder);
+        assertEquals(result, null);
       });
-      const ctx = makeCtx({ adapter });
-      const req = new Request("http://localhost/");
-      const builder = new ResponseBuilder();
 
-      const result = await tryNotFoundFallback(req, "", ctx, builder);
-      assertEquals(result, null);
+      it("returns null when slug is empty and app directory doesn't exist", async () => {
+        const adapter = createMockAdapter({
+          stat: () => Promise.reject(new Error("ENOENT")),
+        });
+        const ctx = makeCtx({ adapter });
+        const req = new Request("http://localhost/");
+        const builder = new ResponseBuilder();
+
+        const result = await tryNotFoundFallback(req, "", ctx, builder);
+        assertEquals(result, null);
+      });
+
+      it("renders the nearest ancestor app not-found component", async () => {
+        const adapter = await getAdapter();
+
+        await withTestContext("not-found-fallback-success", async (context) => {
+          const segDir = join(context.projectDir, "app", "a", "b");
+          await mkdir(segDir, { recursive: true });
+          await writeTextFile(
+            join(context.projectDir, "app", "not-found.tsx"),
+            `export default function RootNotFound(){ return <p>Root Missing</p>; }`,
+          );
+          await writeTextFile(
+            join(segDir, "not-found.tsx"),
+            `export default function NotFound(){ return <p>Missing B</p>; }`,
+          );
+
+          const ctx = makeCtx({
+            projectDir: context.projectDir,
+            adapter,
+          });
+          const req = new Request("http://localhost/a/b/missing");
+          const builder = new ResponseBuilder();
+
+          const result = await tryNotFoundFallback(req, "a/b/missing", ctx, builder);
+          assertExists(result);
+          assertEquals(result.status, 404);
+          const html = await result.text();
+          assertStringIncludes(html, "Missing B");
+          assertStringIncludes(html, 'data-node-file="app/a/b/not-found.tsx"');
+          assertEquals(html.includes("Root Missing"), false);
+        });
+      });
     });
-  });
-});
+  },
+);

--- a/tests/integration/server/production/server.test.ts
+++ b/tests/integration/server/production/server.test.ts
@@ -260,7 +260,7 @@ describe(
       });
     });
 
-    it("renders App Router loading/error via production server", async () => {
+    it("renders App Router loading fallback HTML when a suspended page later errors", async () => {
       await withTestContext("production-server-app-loading-error", async (context: TestContext) => {
         try {
           await remove(join(context.projectDir, "app"), { recursive: true });
@@ -294,17 +294,57 @@ describe(
         const server = await startServer(context, port, controller.signal);
 
         const res = await fetch(`http://127.0.0.1:${port}/a/b`);
+        assertEquals(res.status, 200);
+        assertMatch(res.headers.get("content-type") ?? "", /text\/html/i);
         const html = await res.text();
-        if (!html.includes("ErrA:") && !html.includes("Loading A...")) {
-          throw new Error("Expected loading or error content in HTML");
-        }
+        assertStringIncludes(html, "Loading A...");
+        assertStringIncludes(html, "veryfront-hydration-data");
 
         controller.abort();
         await server.stop();
       });
     });
 
-    it.ignore("renders not-found.tsx for missing App Router page", async () => {
+    it("returns runtime error HTML instead of app/error.tsx when page throws synchronously", async () => {
+      await withTestContext("production-server-app-error-boundary-ssr", async (context) => {
+        try {
+          await remove(join(context.projectDir, "app"), { recursive: true });
+        } catch (e) {
+          if (!isNotFoundError(e)) console.warn("[TEST] cleanup: failed to remove app dir", e);
+        }
+
+        await mkdir(join(context.projectDir, "app", "a", "b"), { recursive: true });
+        await writeTextFile(
+          join(context.projectDir, "app", "layout.tsx"),
+          `export default function Root({ children }: any){ return (<html><body><main data-router-focus>{children}</main></body></html>); }`,
+        );
+        await writeTextFile(
+          join(context.projectDir, "app", "a", "error.tsx"),
+          `export default function Error({ error }: any){ return <p>ErrA:{String(error&&error.message||error)}</p>; }`,
+        );
+        await writeTextFile(
+          join(context.projectDir, "app", "a", "b", "page.tsx"),
+          `export default function Page(){ throw new Error('boom'); }`,
+        );
+
+        const port = await context.allocatePort();
+        const controller = new AbortController();
+        const server = await startServer(context, port, controller.signal);
+
+        const res = await fetch(`http://127.0.0.1:${port}/a/b`);
+        assertEquals(res.status, 500);
+        assertMatch(res.headers.get("content-type") ?? "", /text\/html/i);
+        const html = await res.text();
+        assertStringIncludes(html, "Runtime Error");
+        assertStringIncludes(html, "boom");
+        assertEquals(html.includes("ErrA:"), false);
+
+        controller.abort();
+        await server.stop();
+      });
+    });
+
+    it("renders the nearest app not-found.tsx for missing App Router pages", async () => {
       await withTestContext("production-server-app-not-found", async (context: TestContext) => {
         try {
           await remove(join(context.projectDir, "app"), { recursive: true });
@@ -314,6 +354,10 @@ describe(
 
         const segDir = join(context.projectDir, "app", "a", "b");
         await mkdir(segDir, { recursive: true });
+        await writeTextFile(
+          join(context.projectDir, "app", "not-found.tsx"),
+          `export default function RootNotFound(){ return <p>Root Missing</p>; }`,
+        );
         await writeTextFile(
           join(segDir, "not-found.tsx"),
           `export default function NotFound(){ return <p>Missing B</p>; }`,
@@ -325,8 +369,11 @@ describe(
 
         const res = await fetch(`http://127.0.0.1:${port}/a/b/missing`);
         assertEquals(res.status, 404);
+        assertMatch(res.headers.get("content-type") ?? "", /text\/html/i);
         const html = await res.text();
         assertStringIncludes(html, "Missing B");
+        assertStringIncludes(html, 'data-node-file="app/a/b/not-found.tsx"');
+        assertEquals(html.includes("Root Missing"), false);
 
         controller.abort();
         await server.stop();

--- a/tests/integration/server/production/ssr.test.ts
+++ b/tests/integration/server/production/ssr.test.ts
@@ -74,7 +74,7 @@ describe(
       });
     });
 
-    it("renders App Router loading/error via production server", async () => {
+    it("renders App Router loading fallback HTML when a suspended page later errors", async () => {
       await withTestContext("production-server-app-loading-error", async (context: TestContext) => {
         await removeAppDir(context.projectDir);
 
@@ -112,21 +112,70 @@ describe(
 
         try {
           const res = await fetch(`http://127.0.0.1:${port}/a/b`);
+          assertEquals(res.status, 200);
+          assertMatch(res.headers.get("content-type") ?? "", /text\/html/i);
           const html = await res.text();
-          if (html.includes("ErrA:") || html.includes("Loading A...")) return;
-          throw new Error("Expected loading or error content in HTML");
+          assertStringIncludes(html, "Loading A...");
+          assertStringIncludes(html, "veryfront-hydration-data");
         } finally {
           await server.stop();
         }
       });
     });
 
-    it.ignore("renders not-found.tsx for missing App Router page", async () => {
+    it("returns runtime error HTML instead of app/error.tsx when page throws synchronously", async () => {
+      await withTestContext("production-server-app-error-boundary-ssr", async (context) => {
+        await removeAppDir(context.projectDir);
+
+        await mkdir(join(context.projectDir, "app", "a", "b"), { recursive: true });
+        await writeTextFile(
+          join(context.projectDir, "app", "layout.tsx"),
+          `export default function Root({ children }: any){ return (<html><body><main data-router-focus>{children}</main></body></html>); }`,
+        );
+        await writeTextFile(
+          join(context.projectDir, "app", "a", "error.tsx"),
+          `export default function Error({ error }: any){ return <p>ErrA:{String(error&&error.message||error)}</p>; }`,
+        );
+        await writeTextFile(
+          join(context.projectDir, "app", "a", "b", "page.tsx"),
+          `export default function Page(){ throw new Error('boom'); }`,
+        );
+
+        const port = await context.allocatePort();
+        const server = await startProductionServer({
+          projectDir: context.projectDir,
+          port,
+          bindAddress: "127.0.0.1",
+          defaultProjectSlug: context.projectId,
+          defaultProjectId: context.projectId,
+        });
+        context.trackResource(server);
+        await server.ready;
+
+        try {
+          const res = await fetch(`http://127.0.0.1:${port}/a/b`);
+          assertEquals(res.status, 500);
+          assertMatch(res.headers.get("content-type") ?? "", /text\/html/i);
+          const html = await res.text();
+          assertStringIncludes(html, "Runtime Error");
+          assertStringIncludes(html, "boom");
+          assertEquals(html.includes("ErrA:"), false);
+        } finally {
+          await server.stop();
+        }
+      });
+    });
+
+    it("renders the nearest app not-found.tsx for missing App Router pages", async () => {
       await withTestContext("production-server-app-not-found", async (context: TestContext) => {
         await removeAppDir(context.projectDir);
 
         const segDir = join(context.projectDir, "app", "a", "b");
         await mkdir(segDir, { recursive: true });
+        await writeTextFile(
+          join(context.projectDir, "app", "not-found.tsx"),
+          `export default function RootNotFound(){ return <p>Root Missing</p>; }`,
+        );
         await writeTextFile(
           join(segDir, "not-found.tsx"),
           `export default function NotFound(){ return <p>Missing B</p>; }`,
@@ -146,8 +195,11 @@ describe(
         try {
           const res = await fetch(`http://127.0.0.1:${port}/a/b/missing`);
           assertEquals(res.status, 404);
+          assertMatch(res.headers.get("content-type") ?? "", /text\/html/i);
           const html = await res.text();
           assertStringIncludes(html, "Missing B");
+          assertStringIncludes(html, 'data-node-file="app/a/b/not-found.tsx"');
+          assertEquals(html.includes("Root Missing"), false);
         } finally {
           await server.stop();
         }

--- a/tests/integration/server/rsc/streaming-nested.test.ts
+++ b/tests/integration/server/rsc/streaming-nested.test.ts
@@ -13,7 +13,7 @@ describe("RSC Stream Nested Tests", { sanitizeOps: false, sanitizeResources: fal
   });
 
   describe("RSC stream nested", {}, () => {
-    it("with loading/error returns 200", async () => {
+    it("emits loading placeholders before final slot replacements", async () => {
       await withTestContext("rsc-stream-nested", async (context) => {
         await writeTextFile(
           join(context.projectDir, "veryfront.config.js"),
@@ -31,7 +31,6 @@ describe("RSC Stream Nested Tests", { sanitizeOps: false, sanitizeResources: fal
         try {
           await remove(join(context.projectDir, "app"), { recursive: true });
           await remove(join(context.projectDir, "pages"), { recursive: true });
-
           await mkdir(join(context.projectDir, "pages"), { recursive: true });
           await writeTextFile(join(context.projectDir, "pages", "index.mdx"), "# Home");
 
@@ -46,10 +45,32 @@ describe("RSC Stream Nested Tests", { sanitizeOps: false, sanitizeResources: fal
           await server.ready;
 
           const res = await fetch(
-            `http://127.0.0.1:${port}/_veryfront/rsc/stream?page=/nested`,
+            `http://127.0.0.1:${port}/_veryfront/rsc/stream?name=Eve`,
           );
           assertEquals(res.status, 200);
-          await res.text();
+
+          const slotLines = (await res.text())
+            .split(/\n+/)
+            .filter((line) => line.trim().startsWith("{"))
+            .map((line) => {
+              try {
+                return JSON.parse(line) as { type: string; id: string; html: string };
+              } catch {
+                return null;
+              }
+            })
+            .filter((line): line is { type: string; id: string; html: string } => line !== null)
+            .filter((line) => line.type === "slot");
+
+          assertEquals(slotLines.length, 4);
+          assertEquals(slotLines[0]?.id, "root");
+          assertEquals(slotLines[0]?.html, "<div>Loading Eve…</div>");
+          assertEquals(slotLines[1]?.id, "sidebar");
+          assertEquals(slotLines[1]?.html, '<aside data-state="loading">Sidebar loading…</aside>');
+          assertEquals(slotLines[2]?.id, "root");
+          assertEquals(slotLines[2]?.html, "<div>Hello Eve</div>");
+          assertEquals(slotLines[3]?.id, "sidebar");
+          assertEquals(slotLines[3]?.html, "<aside><ul><li>Eve ready</li></ul></aside>");
         } finally {
           try {
             await server?.stop?.();


### PR DESCRIPTION
## Summary
- add direct unit coverage for RSC client NDJSON consumption, malformed chunk tolerance, and abort cleanup
- strengthen production App Router SSR tests for loading fallback HTML, synchronous error behavior, and nearest-ancestor not-found selection
- add a direct success-path test for `tryNotFoundFallback()` and tighten RSC stream endpoint slot assertions

## Verification
- deno check src/rendering/rsc/client-dom.test.ts tests/integration/server/rsc/streaming-nested.test.ts src/server/handlers/request/ssr/not-found-fallback.test.ts tests/integration/server/production/ssr.test.ts tests/integration/server/production/server.test.ts
- deno test --no-check --allow-all src/rendering/rsc/client-dom.test.ts tests/integration/server/rsc/streaming-nested.test.ts src/server/handlers/request/ssr/not-found-fallback.test.ts tests/integration/server/production/ssr.test.ts tests/integration/server/production/server.test.ts --unstable-worker-options --unstable-net
- repo pre-push checks: format, lint, typecheck, and unit tests