### PR TITLE
Add SSR redirect lifecycle coverage

### DIFF
--- a/src/server/handlers/request/ssr/ssr.handler.test.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.test.ts
@@ -230,6 +230,29 @@ describe("server/handlers/request/ssr/ssr.handler", () => {
       assertEquals(result.response!.status, 404);
     });
 
+    it("returns redirect responses for redirect error type", async () => {
+      const mockService = createMockSSRService({
+        renderPage: () =>
+          Promise.resolve({
+            status: 302,
+            isStreaming: false,
+            cacheStrategy: "no-cache" as const,
+            errorType: "redirect" as const,
+            redirectLocation: "/login",
+            slug: "redirect-source",
+          }),
+      });
+      const handler = new SSRHandler(mockService);
+      const req = new Request("http://localhost/redirect-source");
+      const ctx = makeCtx();
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.continue, false);
+      assertEquals(result.response!.status, 302);
+      assertEquals(result.response!.headers.get("location"), "/login");
+      assertEquals(result.response!.body, null);
+    });
+
     it("returns 500 for server-error type", async () => {
       const mockService = createMockSSRService({
         renderPage: () =>
@@ -534,6 +557,28 @@ describe("server/handlers/request/ssr/ssr.handler", () => {
 
       assertEquals(result.continue, false);
       assertEquals(result.response instanceof Response, true);
+    });
+
+    it("keeps HEAD redirect responses bodyless", async () => {
+      const mockService = createMockSSRService({
+        renderPage: () =>
+          Promise.resolve({
+            status: 301,
+            isStreaming: false,
+            cacheStrategy: "no-cache" as const,
+            errorType: "redirect" as const,
+            redirectLocation: "/moved",
+            slug: "redirect-source",
+          }),
+      });
+      const handler = new SSRHandler(mockService);
+      const req = new Request("http://localhost/redirect-source", { method: "HEAD" });
+      const result = await handler.handle(req, makeCtx());
+
+      assertEquals(result.continue, false);
+      assertEquals(result.response!.status, 301);
+      assertEquals(result.response!.headers.get("location"), "/moved");
+      assertEquals(result.response!.body, null);
     });
 
     it("continues for HEAD requests with file extension", async () => {

--- a/src/server/handlers/request/ssr/ssr.handler.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.ts
@@ -207,6 +207,10 @@ export class SSRHandler extends BaseHandler {
 
         endRequest(requestId);
 
+        if (result.errorType === "redirect" && result.redirectLocation) {
+          return this.handleRedirect(req, ctx, result, nonce);
+        }
+
         if (result.errorType === "not-found") {
           return this.handleNotFound(req, ctx, slug, nonce);
         }
@@ -220,6 +224,22 @@ export class SSRHandler extends BaseHandler {
       },
       { "ssr.slug": slug, "ssr.projectSlug": ctx.projectSlug || "unknown" },
     );
+  }
+
+  private handleRedirect(
+    req: Request,
+    ctx: HandlerContext,
+    result: SSRRenderResult,
+    nonce: string,
+  ): HandlerResult {
+    const response = this.createResponseBuilder(ctx, nonce)
+      .withCORS(req, ctx.securityConfig?.cors)
+      .withSecurity(ctx.securityConfig ?? undefined, req)
+      .withCache(result.cacheStrategy)
+      .withHeaders({ Location: result.redirectLocation ?? "/" })
+      .build(null, result.status);
+
+    return this.respond(response);
   }
 
   private async handleNotFound(

--- a/src/server/services/rendering/ssr.service.test.ts
+++ b/src/server/services/rendering/ssr.service.test.ts
@@ -193,17 +193,17 @@ describe("server/services/rendering/ssr.service", () => {
       });
 
       it("passes handler context to the provider", async () => {
-        let receivedCtx: HandlerContext | null = null;
+        let receivedProjectSlug = "";
         const provider: RendererProvider = {
           getRenderer: (ctx) => {
-            receivedCtx = ctx;
+            receivedProjectSlug = ctx.projectSlug ?? "";
             return Promise.resolve(createMockRendererAdapter());
           },
         };
         const service = new SSRService({ rendererProvider: provider });
         const ctx = makeCtx({ projectSlug: "my-project" });
         await service.getRenderer(ctx);
-        assertEquals(receivedCtx?.projectSlug, "my-project");
+        assertEquals(receivedProjectSlug, "my-project");
       });
     });
 
@@ -215,6 +215,7 @@ describe("server/services/rendering/ssr.service", () => {
               html: "<html>rendered</html>",
               stream: undefined,
               ssrHash: "hash123",
+              frontmatter: {},
             }),
         });
         const service = new SSRService({
@@ -236,7 +237,13 @@ describe("server/services/rendering/ssr.service", () => {
           },
         });
         const adapter = createMockRendererAdapter({
-          renderPage: () => Promise.resolve({ html: undefined, stream, ssrHash: undefined }),
+          renderPage: () =>
+            Promise.resolve({
+              html: "",
+              stream,
+              ssrHash: undefined,
+              frontmatter: {},
+            }),
         });
         const service = new SSRService({
           rendererProvider: createMockRendererProvider(adapter),
@@ -280,7 +287,7 @@ describe("server/services/rendering/ssr.service", () => {
           renderPage: () => {
             throw new VeryfrontError("Not found", {
               slug: "file-not-found",
-              category: "not-found",
+              category: "ROUTE",
               status: 404,
               title: "File not found",
             });
@@ -302,7 +309,7 @@ describe("server/services/rendering/ssr.service", () => {
           renderPage: () => {
             throw new VeryfrontError("API error", {
               slug: "api-client-error",
-              category: "client",
+              category: "SERVER",
               status: 404,
               title: "API Client Error",
               context: {
@@ -318,6 +325,34 @@ describe("server/services/rendering/ssr.service", () => {
         const result = await service.renderPage(makeCtx(), makeRenderOptions());
         assertEquals(result.status, 404);
         assertEquals(result.errorType, "undeployed");
+      });
+
+      it("maps render redirects to redirect results", async () => {
+        const adapter = createMockRendererAdapter({
+          renderPage: () => {
+            throw new VeryfrontError("Redirect to /login", {
+              slug: "render-error",
+              category: "RUNTIME",
+              status: 500,
+              title: "Component render failed",
+              context: {
+                redirect: {
+                  destination: "/login",
+                  permanent: false,
+                },
+              },
+            });
+          },
+        });
+        const service = new SSRService({
+          rendererProvider: createMockRendererProvider(adapter),
+        });
+
+        const result = await service.renderPage(makeCtx(), makeRenderOptions());
+        assertEquals(result.status, 302);
+        assertEquals(result.errorType, "redirect");
+        assertEquals(result.redirectLocation, "/login");
+        assertEquals(result.cacheStrategy, "no-cache");
       });
 
       it("returns server-error for generic errors in production", async () => {

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -20,6 +20,7 @@ import {
   HTTP_INTERNAL_SERVER_ERROR,
   HTTP_NOT_FOUND,
   HTTP_OK,
+  HTTP_REDIRECT_FOUND,
   HTTP_UNAVAILABLE,
 } from "#veryfront/utils/constants/index.ts";
 import type { CacheRepository } from "#veryfront/repositories/types.ts";
@@ -60,8 +61,9 @@ export interface SSRRenderResult {
   etag?: string;
   cacheStrategy: "no-cache" | "short";
   error?: Error;
-  errorType?: "not-found" | "undeployed" | "server-error" | "runtime";
+  errorType?: "not-found" | "undeployed" | "redirect" | "server-error" | "runtime";
   showDevOverlay?: boolean;
+  redirectLocation?: string;
   slug: string;
 }
 
@@ -82,6 +84,25 @@ export interface MemoryStatus {
   heapUsedMB: number;
   heapLimitMB: number;
   heapUsedPercent: number;
+}
+
+interface RedirectResultContext {
+  redirect?: {
+    destination?: unknown;
+    permanent?: unknown;
+  };
+}
+
+function extractRedirectLocation(
+  error: VeryfrontError,
+): { destination: string; permanent: boolean } | null {
+  const redirect = (error.context as RedirectResultContext | undefined)?.redirect;
+  if (!redirect || typeof redirect.destination !== "string") return null;
+
+  return {
+    destination: redirect.destination,
+    permanent: redirect.permanent === true,
+  };
 }
 
 export class SSRService implements SSRServiceLike {
@@ -252,6 +273,27 @@ export class SSRService implements SSRServiceLike {
           isStreaming: false,
           cacheStrategy: "no-cache",
           errorType: "undeployed",
+          slug,
+        };
+      }
+    }
+
+    if (error instanceof VeryfrontError && error.slug === "render-error") {
+      const redirect = extractRedirectLocation(error);
+      if (redirect) {
+        logger.debug("SSR redirect", {
+          slug,
+          destination: redirect.destination,
+          permanent: redirect.permanent,
+          projectSlug: ctx.projectSlug,
+        });
+        return {
+          status: redirect.permanent ? 301 : HTTP_REDIRECT_FOUND,
+          isStreaming: false,
+          cacheStrategy: "no-cache",
+          error: errorObj,
+          errorType: "redirect",
+          redirectLocation: redirect.destination,
           slug,
         };
       }

--- a/tests/integration/server/production/server.test.ts
+++ b/tests/integration/server/production/server.test.ts
@@ -260,6 +260,45 @@ describe(
       });
     });
 
+    it("returns HTTP redirects from getServerData in the adapter-backed server path", async () => {
+      await withTestContext("production-server-adapter-redirects", async (context: TestContext) => {
+        const pagesDir = join(context.projectDir, "pages");
+        await mkdir(pagesDir, { recursive: true });
+        await writeTextFile(
+          join(pagesDir, "redirect.tsx"),
+          `export function getServerData(){ return { redirect: { destination: '/login', permanent: false } }; }
+           export default function Page(){ return <div>Redirect source</div>; }`,
+        );
+        await writeTextFile(
+          join(pagesDir, "permanent.tsx"),
+          `export function getServerData(){ return { redirect: { destination: '/moved', permanent: true } }; }
+           export default function Page(){ return <div>Permanent redirect</div>; }`,
+        );
+
+        const port = await context.allocatePort();
+        const controller = new AbortController();
+        const server = await startServer(context, port, controller.signal);
+
+        const res = await fetch(`http://127.0.0.1:${port}/redirect`, {
+          redirect: "manual",
+        });
+        assertEquals(res.status, 302);
+        assertEquals(res.headers.get("location"), "/login");
+        assertEquals(await res.text(), "");
+
+        const head = await fetch(`http://127.0.0.1:${port}/permanent`, {
+          method: "HEAD",
+          redirect: "manual",
+        });
+        assertEquals(head.status, 301);
+        assertEquals(head.headers.get("location"), "/moved");
+        assertEquals(head.body, null);
+
+        controller.abort();
+        await server.stop();
+      });
+    });
+
     it("renders App Router loading fallback HTML when a suspended page later errors", async () => {
       await withTestContext("production-server-app-loading-error", async (context: TestContext) => {
         try {

--- a/tests/integration/server/production/ssr.test.ts
+++ b/tests/integration/server/production/ssr.test.ts
@@ -206,6 +206,53 @@ describe(
       });
     });
 
+    it("returns HTTP redirects from getServerData instead of rendering a 500 page", async () => {
+      await withTestContext("production-server-ssr-redirects", async (context: TestContext) => {
+        const pagesDir = join(context.projectDir, "pages");
+        await mkdir(pagesDir, { recursive: true });
+        await writeTextFile(
+          join(pagesDir, "redirect.tsx"),
+          `export function getServerData(){ return { redirect: { destination: '/login', permanent: false } }; }
+           export default function Page(){ return <div>Redirect source</div>; }`,
+        );
+        await writeTextFile(
+          join(pagesDir, "permanent.tsx"),
+          `export function getServerData(){ return { redirect: { destination: '/moved', permanent: true } }; }
+           export default function Page(){ return <div>Permanent redirect</div>; }`,
+        );
+
+        const port = await context.allocatePort();
+        const server = await startProductionServer({
+          projectDir: context.projectDir,
+          port,
+          bindAddress: "127.0.0.1",
+          defaultProjectSlug: context.projectId,
+          defaultProjectId: context.projectId,
+        });
+        context.trackResource(server);
+        await server.ready;
+
+        try {
+          const res = await fetch(`http://127.0.0.1:${port}/redirect`, {
+            redirect: "manual",
+          });
+          assertEquals(res.status, 302);
+          assertEquals(res.headers.get("location"), "/login");
+          assertEquals(await res.text(), "");
+
+          const head = await fetch(`http://127.0.0.1:${port}/permanent`, {
+            method: "HEAD",
+            redirect: "manual",
+          });
+          assertEquals(head.status, 301);
+          assertEquals(head.headers.get("location"), "/moved");
+          assertEquals(head.body, null);
+        } finally {
+          await server.stop();
+        }
+      });
+    });
+
     it("includes metadata (title, description) in SSR HTML", async () => {
       await withTestContext("production-server-metadata", async (context: TestContext) => {
         const appDir = join(context.projectDir, "app");


### PR DESCRIPTION
## Summary\n- map SSR data redirects to real HTTP redirect responses instead of 500 fallback pages\n- cover redirect handling in SSR service and handler tests, including HEAD semantics\n- add production integration coverage for both production server entrypoints\n\n## Verification\n- deno check src/server/services/rendering/ssr.service.ts src/server/services/rendering/ssr.service.test.ts src/server/handlers/request/ssr/ssr.handler.ts src/server/handlers/request/ssr/ssr.handler.test.ts tests/integration/server/production/ssr.test.ts tests/integration/server/production/server.test.ts\n- deno test --no-check --allow-all src/server/services/rendering/ssr.service.test.ts src/server/handlers/request/ssr/ssr.handler.test.ts tests/integration/server/production/ssr.test.ts tests/integration/server/production/server.test.ts --unstable-worker-options --unstable-net\n- git push (pre-push passed format, lint, typecheck, and unit tests)