### PR TITLE
Add SSR stream lifecycle coverage

### DIFF
--- a/src/react/compat/ssr-adapter/server-loader.ts
+++ b/src/react/compat/ssr-adapter/server-loader.ts
@@ -26,6 +26,10 @@ export function resetReactCache(): void {
   reactDOMServerCache = null;
 }
 
+export function __injectReactDOMServerForTests(server: ReactDOMServer | null): void {
+  reactDOMServerCache = server;
+}
+
 async function loadFromCachedHttpModule<T>(url: string, label: string): Promise<T> {
   const cacheDir = getHttpBundleCacheDir();
   const cachedPath = await cacheModuleToLocal(url, cacheDir);

--- a/src/react/compat/ssr-adapter/stream-renderer.test.ts
+++ b/src/react/compat/ssr-adapter/stream-renderer.test.ts
@@ -1,0 +1,216 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import * as React from "react";
+import type { ReactDOMServer } from "./server-loader.ts";
+import { __injectReactDOMServerForTests, resetReactCache } from "./server-loader.ts";
+import {
+  __resetSSRStreamRendererForTests,
+  __setSSRStreamTimeoutForTests,
+  renderToStreamAdapter,
+} from "./stream-renderer.ts";
+
+type ReadableSSRStream = Awaited<
+  ReturnType<NonNullable<ReactDOMServer["renderToReadableStream"]>>
+>;
+type PipeableSSRStream = ReturnType<NonNullable<ReactDOMServer["renderToPipeableStream"]>>;
+
+async function readStream(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let output = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    output += decoder.decode(value, { stream: true });
+  }
+
+  output += decoder.decode();
+  return output;
+}
+
+async function readPipe(
+  pipe: (writable: NodeJS.WritableStream) => void,
+): Promise<string> {
+  const { PassThrough } = await import("node:stream");
+  const { Buffer } = await import("node:buffer");
+
+  return await new Promise((resolve, reject) => {
+    const chunks: Uint8Array[] = [];
+    const passThrough = new PassThrough();
+
+    passThrough.on("data", (chunk: Uint8Array) => chunks.push(chunk));
+    passThrough.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    passThrough.on("error", reject);
+
+    pipe(passThrough);
+  });
+}
+
+function createMockServer(overrides: Partial<ReactDOMServer> = {}): ReactDOMServer {
+  return {
+    renderToString: () => "<div>string</div>",
+    renderToStaticMarkup: () => "<div>static</div>",
+    ...overrides,
+  };
+}
+
+function createReadableSSRStream(html: string): ReadableSSRStream {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(html));
+      controller.close();
+    },
+  }) as ReadableStream<Uint8Array> & { allReady: Promise<void> };
+
+  stream.allReady = Promise.resolve();
+  return stream as ReadableSSRStream;
+}
+
+function createPipeableSSRStream(
+  pipeImpl: (writable: NodeJS.WritableStream) => void,
+  abortImpl: () => void = () => {},
+): PipeableSSRStream {
+  return {
+    pipe<Writable extends NodeJS.WritableStream>(writable: Writable): Writable {
+      pipeImpl(writable);
+      return writable;
+    },
+    abort: abortImpl,
+  };
+}
+
+describe("react/compat/ssr-adapter/stream-renderer", () => {
+  afterEach(() => {
+    __injectReactDOMServerForTests(null);
+    resetReactCache();
+    __resetSSRStreamRendererForTests();
+  });
+
+  it("returns a readable stream when renderToReadableStream succeeds", async () => {
+    __injectReactDOMServerForTests(
+      createMockServer({
+        renderToReadableStream: async () => createReadableSSRStream("<div>streamed</div>"),
+      }),
+    );
+
+    const result = await renderToStreamAdapter(React.createElement("div"), {
+      nonce: "nonce-1",
+    });
+
+    assertEquals(result.stream instanceof ReadableStream, true);
+    assertEquals(await readStream(result.stream!), "<div>streamed</div>");
+  });
+
+  it("falls back to string rendering when readable stream setup fails", async () => {
+    const errors: string[] = [];
+    __injectReactDOMServerForTests(
+      createMockServer({
+        renderToReadableStream: async () => {
+          throw new Error("readable failed");
+        },
+        renderToString: () => "<div>fallback</div>",
+      }),
+    );
+
+    const result = await renderToStreamAdapter(React.createElement("div"), {
+      onError: (error) => errors.push(error.message),
+    });
+
+    assertEquals(result.html, "<div>fallback</div>");
+    assertEquals(errors, ["readable failed"]);
+  });
+
+  it("aborts readable stream setup when it exceeds the timeout", async () => {
+    let aborted = false;
+    __setSSRStreamTimeoutForTests(5);
+    __injectReactDOMServerForTests(
+      createMockServer({
+        renderToReadableStream: (_element, options) =>
+          new Promise((_resolve, reject) => {
+            const signal = options?.signal;
+            if (!signal) {
+              reject(new Error("missing signal"));
+              return;
+            }
+
+            signal.addEventListener("abort", () => {
+              aborted = true;
+              reject(signal.reason ?? new Error("aborted"));
+            }, { once: true });
+          }),
+      }),
+    );
+
+    await assertRejects(
+      () => renderToStreamAdapter(React.createElement("div")),
+      Error,
+      "SSR timeout",
+    );
+    assertEquals(aborted, true);
+  });
+
+  it("returns a pipeable stream result when renderToPipeableStream is ready", async () => {
+    __injectReactDOMServerForTests(
+      createMockServer({
+        renderToReadableStream: undefined,
+        renderToPipeableStream: (_element, options) => {
+          queueMicrotask(() => options?.onShellReady?.());
+          return createPipeableSSRStream((writable) => {
+            writable.write("<div>pipeable</div>");
+            writable.end();
+          });
+        },
+      }),
+    );
+
+    const result = await renderToStreamAdapter(React.createElement("div"));
+
+    assertEquals(typeof result.pipe, "function");
+    assertEquals(await readPipe(result.pipe!), "<div>pipeable</div>");
+  });
+
+  it("falls back to string rendering when pipeable stream setup fails", async () => {
+    const errors: string[] = [];
+    __injectReactDOMServerForTests(
+      createMockServer({
+        renderToReadableStream: undefined,
+        renderToPipeableStream: () => {
+          throw new Error("pipe failed");
+        },
+        renderToString: () => "<div>pipe-fallback</div>",
+      }),
+    );
+
+    const result = await renderToStreamAdapter(React.createElement("div"), {
+      onError: (error) => errors.push(error.message),
+    });
+
+    assertEquals(result.html, "<div>pipe-fallback</div>");
+    assertEquals(errors, ["pipe failed"]);
+  });
+
+  it("aborts pipeable stream rendering when shell readiness never arrives", async () => {
+    let abortCalled = false;
+    __setSSRStreamTimeoutForTests(5);
+    __injectReactDOMServerForTests(
+      createMockServer({
+        renderToReadableStream: undefined,
+        renderToPipeableStream: () =>
+          createPipeableSSRStream(
+            () => {},
+            () => {
+              abortCalled = true;
+            },
+          ),
+      }),
+    );
+
+    await assertRejects(
+      () => renderToStreamAdapter(React.createElement("div")),
+      Error,
+      "SSR timeout",
+    );
+    assertEquals(abortCalled, true);
+  });
+});

--- a/src/react/compat/ssr-adapter/stream-renderer.ts
+++ b/src/react/compat/ssr-adapter/stream-renderer.ts
@@ -12,8 +12,18 @@ interface VeryfrontGlobal {
   __VERYFRONT_DEBUG__?: boolean;
 }
 
+let ssrTimeoutMs = SSR_TIMEOUT_MS;
+
 function isDebugMode(): boolean {
   return Boolean((globalThis as VeryfrontGlobal).__VERYFRONT_DEBUG__ || isDebugEnvEnabled());
+}
+
+export function __setSSRStreamTimeoutForTests(timeoutMs: number): void {
+  ssrTimeoutMs = timeoutMs;
+}
+
+export function __resetSSRStreamRendererForTests(): void {
+  ssrTimeoutMs = SSR_TIMEOUT_MS;
 }
 
 async function renderToReadableStreamImpl(
@@ -36,9 +46,9 @@ async function renderToReadableStreamImpl(
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => {
-    logger.error("SSR_TIMEOUT aborting React render", { timeoutMs: SSR_TIMEOUT_MS });
-    controller.abort(new Error(`SSR timeout: React render exceeded ${SSR_TIMEOUT_MS}ms`));
-  }, SSR_TIMEOUT_MS);
+    logger.error("SSR_TIMEOUT aborting React render", { timeoutMs: ssrTimeoutMs });
+    controller.abort(new Error(`SSR timeout: React render exceeded ${ssrTimeoutMs}ms`));
+  }, ssrTimeoutMs);
 
   try {
     if (debug) logger.info("SSR renderToReadableStream started");
@@ -82,7 +92,7 @@ async function renderToReadableStreamImpl(
     if (isAbort) {
       logger.error("SSR_TIMEOUT React render was aborted", {
         durationMs,
-        timeoutMs: SSR_TIMEOUT_MS,
+        timeoutMs: ssrTimeoutMs,
       });
       throw error;
     }
@@ -128,7 +138,7 @@ function renderToPipeableStreamImpl(
       if (settled) return;
       settled = true;
 
-      logger.error("SSR_TIMEOUT aborting pipeable React render", { timeoutMs: SSR_TIMEOUT_MS });
+      logger.error("SSR_TIMEOUT aborting pipeable React render", { timeoutMs: ssrTimeoutMs });
 
       if (abortFn) {
         try {
@@ -140,10 +150,10 @@ function renderToPipeableStreamImpl(
 
       reject(
         new Error(
-          `SSR timeout: React render exceeded ${SSR_TIMEOUT_MS}ms - likely a hanging data fetch`,
+          `SSR timeout: React render exceeded ${ssrTimeoutMs}ms - likely a hanging data fetch`,
         ),
       );
-    }, SSR_TIMEOUT_MS);
+    }, ssrTimeoutMs);
 
     try {
       const { pipe, abort } = renderToPipeableStream(element, {

--- a/src/rendering/ssr-renderer.test.ts
+++ b/src/rendering/ssr-renderer.test.ts
@@ -1,0 +1,60 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import * as React from "react";
+import type { ReactDOMServer } from "../react/compat/ssr-adapter/server-loader.ts";
+import {
+  __injectReactDOMServerForTests,
+  resetReactCache,
+} from "../react/compat/ssr-adapter/server-loader.ts";
+import { SSRRenderer } from "./ssr-renderer.ts";
+
+type PipeableSSRStream = ReturnType<NonNullable<ReactDOMServer["renderToPipeableStream"]>>;
+
+function createPipeableSSRStream(
+  pipeImpl: (writable: NodeJS.WritableStream) => void,
+  abortImpl: () => void = () => {},
+): PipeableSSRStream {
+  return {
+    pipe<Writable extends NodeJS.WritableStream>(writable: Writable): Writable {
+      pipeImpl(writable);
+      return writable;
+    },
+    abort: abortImpl,
+  };
+}
+
+describe("rendering/ssr-renderer", () => {
+  afterEach(() => {
+    __injectReactDOMServerForTests(null);
+    resetReactCache();
+  });
+
+  it("propagates stream cancellation to the pipeable render abort function", async () => {
+    let abortCalled = false;
+
+    __injectReactDOMServerForTests({
+      renderToString: () => "<div>unused</div>",
+      renderToStaticMarkup: () => "<div>static</div>",
+      renderToReadableStream: undefined,
+      renderToPipeableStream: (_element, options) => {
+        queueMicrotask(() => options?.onShellReady?.());
+        return createPipeableSSRStream(
+          () => {},
+          () => {
+            abortCalled = true;
+          },
+        );
+      },
+    });
+
+    const renderer = new SSRRenderer("production");
+    const result = await renderer.renderToHTML(
+      React.createElement("div"),
+      { mode: "production", wantsStream: true },
+    );
+
+    assertEquals(result.stream instanceof ReadableStream, true);
+    await result.stream?.cancel(new Error("stop"));
+    assertEquals(abortCalled, true);
+  });
+});

--- a/src/rendering/ssr-renderer.ts
+++ b/src/rendering/ssr-renderer.ts
@@ -42,20 +42,46 @@ async function pipeToString(
 
 function pipeToReadableStream(
   pipeFn: (writable: NodeJS.WritableStream) => void,
+  abortFn?: () => void,
 ): ReadableStream<Uint8Array> {
+  let passThrough: import("node:stream").PassThrough | null = null;
+  let cancelled = false;
+
   return new ReadableStream<Uint8Array>({
     async start(controller) {
       const { PassThrough } = await import("node:stream");
-      const passThrough = new PassThrough();
+      passThrough = new PassThrough();
 
-      passThrough.on("data", (chunk: Uint8Array) => controller.enqueue(new Uint8Array(chunk)));
-      passThrough.on("end", () => controller.close());
-      passThrough.on("error", (err: Error) => controller.error(err));
+      passThrough.on("data", (chunk: Uint8Array) => {
+        if (cancelled) return;
+        controller.enqueue(new Uint8Array(chunk));
+      });
+      passThrough.on("end", () => {
+        if (!cancelled) controller.close();
+      });
+      passThrough.on("error", (err: Error) => {
+        if (!cancelled) controller.error(err);
+      });
 
       try {
         pipeFn(passThrough);
       } catch (error) {
-        controller.error(error);
+        if (!cancelled) controller.error(error);
+      }
+    },
+    cancel(reason) {
+      cancelled = true;
+
+      if (abortFn) {
+        try {
+          abortFn();
+        } catch (error) {
+          logger.warn("Error aborting pipeable SSR stream", error);
+        }
+      }
+
+      if (passThrough && !passThrough.destroyed) {
+        passThrough.destroy(reason instanceof Error ? reason : undefined);
       }
     },
   });
@@ -182,7 +208,7 @@ export class SSRRenderer {
     if (renderResult.pipe) {
       if (options.wantsStream) {
         logger.debug("Converting pipeable stream to ReadableStream for true streaming");
-        return { html: "", stream: pipeToReadableStream(renderResult.pipe) };
+        return { html: "", stream: pipeToReadableStream(renderResult.pipe, renderResult.abort) };
       }
 
       logger.debug("Converting pipeable stream to string (Node.js renderToPipeableStream)");

--- a/src/server/handlers/request/ssr/ssr.handler.test.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.test.ts
@@ -230,6 +230,29 @@ describe("server/handlers/request/ssr/ssr.handler", () => {
       assertEquals(result.response!.status, 404);
     });
 
+    it("returns redirect responses for redirect error type", async () => {
+      const mockService = createMockSSRService({
+        renderPage: () =>
+          Promise.resolve({
+            status: 302,
+            isStreaming: false,
+            cacheStrategy: "no-cache" as const,
+            errorType: "redirect" as const,
+            redirectLocation: "/login",
+            slug: "redirect-source",
+          }),
+      });
+      const handler = new SSRHandler(mockService);
+      const req = new Request("http://localhost/redirect-source");
+      const ctx = makeCtx();
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.continue, false);
+      assertEquals(result.response!.status, 302);
+      assertEquals(result.response!.headers.get("location"), "/login");
+      assertEquals(result.response!.body, null);
+    });
+
     it("returns 500 for server-error type", async () => {
       const mockService = createMockSSRService({
         renderPage: () =>
@@ -534,6 +557,28 @@ describe("server/handlers/request/ssr/ssr.handler", () => {
 
       assertEquals(result.continue, false);
       assertEquals(result.response instanceof Response, true);
+    });
+
+    it("keeps HEAD redirect responses bodyless", async () => {
+      const mockService = createMockSSRService({
+        renderPage: () =>
+          Promise.resolve({
+            status: 301,
+            isStreaming: false,
+            cacheStrategy: "no-cache" as const,
+            errorType: "redirect" as const,
+            redirectLocation: "/moved",
+            slug: "redirect-source",
+          }),
+      });
+      const handler = new SSRHandler(mockService);
+      const req = new Request("http://localhost/redirect-source", { method: "HEAD" });
+      const result = await handler.handle(req, makeCtx());
+
+      assertEquals(result.continue, false);
+      assertEquals(result.response!.status, 301);
+      assertEquals(result.response!.headers.get("location"), "/moved");
+      assertEquals(result.response!.body, null);
     });
 
     it("continues for HEAD requests with file extension", async () => {

--- a/src/server/handlers/request/ssr/ssr.handler.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.ts
@@ -207,6 +207,10 @@ export class SSRHandler extends BaseHandler {
 
         endRequest(requestId);
 
+        if (result.errorType === "redirect" && result.redirectLocation) {
+          return this.handleRedirect(req, ctx, result, nonce);
+        }
+
         if (result.errorType === "not-found") {
           return this.handleNotFound(req, ctx, slug, nonce);
         }
@@ -220,6 +224,22 @@ export class SSRHandler extends BaseHandler {
       },
       { "ssr.slug": slug, "ssr.projectSlug": ctx.projectSlug || "unknown" },
     );
+  }
+
+  private handleRedirect(
+    req: Request,
+    ctx: HandlerContext,
+    result: SSRRenderResult,
+    nonce: string,
+  ): HandlerResult {
+    const response = this.createResponseBuilder(ctx, nonce)
+      .withCORS(req, ctx.securityConfig?.cors)
+      .withSecurity(ctx.securityConfig ?? undefined, req)
+      .withCache(result.cacheStrategy)
+      .withHeaders({ Location: result.redirectLocation ?? "/" })
+      .build(null, result.status);
+
+    return this.respond(response);
   }
 
   private async handleNotFound(

--- a/src/server/services/rendering/ssr.service.test.ts
+++ b/src/server/services/rendering/ssr.service.test.ts
@@ -193,17 +193,17 @@ describe("server/services/rendering/ssr.service", () => {
       });
 
       it("passes handler context to the provider", async () => {
-        let receivedCtx: HandlerContext | null = null;
+        let receivedProjectSlug = "";
         const provider: RendererProvider = {
           getRenderer: (ctx) => {
-            receivedCtx = ctx;
+            receivedProjectSlug = ctx.projectSlug ?? "";
             return Promise.resolve(createMockRendererAdapter());
           },
         };
         const service = new SSRService({ rendererProvider: provider });
         const ctx = makeCtx({ projectSlug: "my-project" });
         await service.getRenderer(ctx);
-        assertEquals(receivedCtx?.projectSlug, "my-project");
+        assertEquals(receivedProjectSlug, "my-project");
       });
     });
 
@@ -215,6 +215,7 @@ describe("server/services/rendering/ssr.service", () => {
               html: "<html>rendered</html>",
               stream: undefined,
               ssrHash: "hash123",
+              frontmatter: {},
             }),
         });
         const service = new SSRService({
@@ -236,7 +237,13 @@ describe("server/services/rendering/ssr.service", () => {
           },
         });
         const adapter = createMockRendererAdapter({
-          renderPage: () => Promise.resolve({ html: undefined, stream, ssrHash: undefined }),
+          renderPage: () =>
+            Promise.resolve({
+              html: "",
+              stream,
+              ssrHash: undefined,
+              frontmatter: {},
+            }),
         });
         const service = new SSRService({
           rendererProvider: createMockRendererProvider(adapter),
@@ -280,7 +287,7 @@ describe("server/services/rendering/ssr.service", () => {
           renderPage: () => {
             throw new VeryfrontError("Not found", {
               slug: "file-not-found",
-              category: "not-found",
+              category: "ROUTE",
               status: 404,
               title: "File not found",
             });
@@ -302,7 +309,7 @@ describe("server/services/rendering/ssr.service", () => {
           renderPage: () => {
             throw new VeryfrontError("API error", {
               slug: "api-client-error",
-              category: "client",
+              category: "SERVER",
               status: 404,
               title: "API Client Error",
               context: {
@@ -318,6 +325,34 @@ describe("server/services/rendering/ssr.service", () => {
         const result = await service.renderPage(makeCtx(), makeRenderOptions());
         assertEquals(result.status, 404);
         assertEquals(result.errorType, "undeployed");
+      });
+
+      it("maps render redirects to redirect results", async () => {
+        const adapter = createMockRendererAdapter({
+          renderPage: () => {
+            throw new VeryfrontError("Redirect to /login", {
+              slug: "render-error",
+              category: "RUNTIME",
+              status: 500,
+              title: "Component render failed",
+              context: {
+                redirect: {
+                  destination: "/login",
+                  permanent: false,
+                },
+              },
+            });
+          },
+        });
+        const service = new SSRService({
+          rendererProvider: createMockRendererProvider(adapter),
+        });
+
+        const result = await service.renderPage(makeCtx(), makeRenderOptions());
+        assertEquals(result.status, 302);
+        assertEquals(result.errorType, "redirect");
+        assertEquals(result.redirectLocation, "/login");
+        assertEquals(result.cacheStrategy, "no-cache");
       });
 
       it("returns server-error for generic errors in production", async () => {

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -20,6 +20,7 @@ import {
   HTTP_INTERNAL_SERVER_ERROR,
   HTTP_NOT_FOUND,
   HTTP_OK,
+  HTTP_REDIRECT_FOUND,
   HTTP_UNAVAILABLE,
 } from "#veryfront/utils/constants/index.ts";
 import type { CacheRepository } from "#veryfront/repositories/types.ts";
@@ -60,8 +61,9 @@ export interface SSRRenderResult {
   etag?: string;
   cacheStrategy: "no-cache" | "short";
   error?: Error;
-  errorType?: "not-found" | "undeployed" | "server-error" | "runtime";
+  errorType?: "not-found" | "undeployed" | "redirect" | "server-error" | "runtime";
   showDevOverlay?: boolean;
+  redirectLocation?: string;
   slug: string;
 }
 
@@ -82,6 +84,25 @@ export interface MemoryStatus {
   heapUsedMB: number;
   heapLimitMB: number;
   heapUsedPercent: number;
+}
+
+interface RedirectResultContext {
+  redirect?: {
+    destination?: unknown;
+    permanent?: unknown;
+  };
+}
+
+function extractRedirectLocation(
+  error: VeryfrontError,
+): { destination: string; permanent: boolean } | null {
+  const redirect = (error.context as RedirectResultContext | undefined)?.redirect;
+  if (!redirect || typeof redirect.destination !== "string") return null;
+
+  return {
+    destination: redirect.destination,
+    permanent: redirect.permanent === true,
+  };
 }
 
 export class SSRService implements SSRServiceLike {
@@ -252,6 +273,27 @@ export class SSRService implements SSRServiceLike {
           isStreaming: false,
           cacheStrategy: "no-cache",
           errorType: "undeployed",
+          slug,
+        };
+      }
+    }
+
+    if (error instanceof VeryfrontError && error.slug === "render-error") {
+      const redirect = extractRedirectLocation(error);
+      if (redirect) {
+        logger.debug("SSR redirect", {
+          slug,
+          destination: redirect.destination,
+          permanent: redirect.permanent,
+          projectSlug: ctx.projectSlug,
+        });
+        return {
+          status: redirect.permanent ? 301 : HTTP_REDIRECT_FOUND,
+          isStreaming: false,
+          cacheStrategy: "no-cache",
+          error: errorObj,
+          errorType: "redirect",
+          redirectLocation: redirect.destination,
           slug,
         };
       }

--- a/tests/integration/server/production/server.test.ts
+++ b/tests/integration/server/production/server.test.ts
@@ -260,6 +260,45 @@ describe(
       });
     });
 
+    it("returns HTTP redirects from getServerData in the adapter-backed server path", async () => {
+      await withTestContext("production-server-adapter-redirects", async (context: TestContext) => {
+        const pagesDir = join(context.projectDir, "pages");
+        await mkdir(pagesDir, { recursive: true });
+        await writeTextFile(
+          join(pagesDir, "redirect.tsx"),
+          `export function getServerData(){ return { redirect: { destination: '/login', permanent: false } }; }
+           export default function Page(){ return <div>Redirect source</div>; }`,
+        );
+        await writeTextFile(
+          join(pagesDir, "permanent.tsx"),
+          `export function getServerData(){ return { redirect: { destination: '/moved', permanent: true } }; }
+           export default function Page(){ return <div>Permanent redirect</div>; }`,
+        );
+
+        const port = await context.allocatePort();
+        const controller = new AbortController();
+        const server = await startServer(context, port, controller.signal);
+
+        const res = await fetch(`http://127.0.0.1:${port}/redirect`, {
+          redirect: "manual",
+        });
+        assertEquals(res.status, 302);
+        assertEquals(res.headers.get("location"), "/login");
+        assertEquals(await res.text(), "");
+
+        const head = await fetch(`http://127.0.0.1:${port}/permanent`, {
+          method: "HEAD",
+          redirect: "manual",
+        });
+        assertEquals(head.status, 301);
+        assertEquals(head.headers.get("location"), "/moved");
+        assertEquals(head.body, null);
+
+        controller.abort();
+        await server.stop();
+      });
+    });
+
     it("renders App Router loading fallback HTML when a suspended page later errors", async () => {
       await withTestContext("production-server-app-loading-error", async (context: TestContext) => {
         try {

--- a/tests/integration/server/production/ssr.test.ts
+++ b/tests/integration/server/production/ssr.test.ts
@@ -206,6 +206,53 @@ describe(
       });
     });
 
+    it("returns HTTP redirects from getServerData instead of rendering a 500 page", async () => {
+      await withTestContext("production-server-ssr-redirects", async (context: TestContext) => {
+        const pagesDir = join(context.projectDir, "pages");
+        await mkdir(pagesDir, { recursive: true });
+        await writeTextFile(
+          join(pagesDir, "redirect.tsx"),
+          `export function getServerData(){ return { redirect: { destination: '/login', permanent: false } }; }
+           export default function Page(){ return <div>Redirect source</div>; }`,
+        );
+        await writeTextFile(
+          join(pagesDir, "permanent.tsx"),
+          `export function getServerData(){ return { redirect: { destination: '/moved', permanent: true } }; }
+           export default function Page(){ return <div>Permanent redirect</div>; }`,
+        );
+
+        const port = await context.allocatePort();
+        const server = await startProductionServer({
+          projectDir: context.projectDir,
+          port,
+          bindAddress: "127.0.0.1",
+          defaultProjectSlug: context.projectId,
+          defaultProjectId: context.projectId,
+        });
+        context.trackResource(server);
+        await server.ready;
+
+        try {
+          const res = await fetch(`http://127.0.0.1:${port}/redirect`, {
+            redirect: "manual",
+          });
+          assertEquals(res.status, 302);
+          assertEquals(res.headers.get("location"), "/login");
+          assertEquals(await res.text(), "");
+
+          const head = await fetch(`http://127.0.0.1:${port}/permanent`, {
+            method: "HEAD",
+            redirect: "manual",
+          });
+          assertEquals(head.status, 301);
+          assertEquals(head.headers.get("location"), "/moved");
+          assertEquals(head.body, null);
+        } finally {
+          await server.stop();
+        }
+      });
+    });
+
     it("includes metadata (title, description) in SSR HTML", async () => {
       await withTestContext("production-server-metadata", async (context: TestContext) => {
         const appDir = join(context.projectDir, "app");


### PR DESCRIPTION
## Summary
- add direct lifecycle coverage for the SSR stream adapter, including readable-stream timeout, pipeable-stream timeout, and string fallback paths
- add coverage for cancelling the pipeable-stream bridge and propagate cancellation back to React's abort callback
- expose minimal test hooks for injected ReactDOMServer mocks and timeout control

## Verification
- deno check src/react/compat/ssr-adapter/stream-renderer.ts src/react/compat/ssr-adapter/stream-renderer.test.ts src/rendering/ssr-renderer.ts src/rendering/ssr-renderer.test.ts
- deno test --no-check --allow-all src/react/compat/ssr-adapter/stream-renderer.test.ts src/rendering/ssr-renderer.test.ts src/rendering/orchestrator/ssr-orchestrator.test.ts src/server/handlers/request/ssr/ssr-response-builder.test.ts
- git push (passed full pre-push suite: format, lint, typecheck, unit tests)