### PR TITLE
Add request context compatibility coverage

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.117",
+  "version": "0.1.118",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/modules/react-loader/component-loader.ts
+++ b/src/modules/react-loader/component-loader.ts
@@ -11,19 +11,19 @@ import { SSRModuleLoader } from "./ssr-module-loader/index.ts";
 import { extractComponent } from "./extract-component.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 
-export function loadComponentFromSource(
+export async function loadModuleFromSource(
   source: string,
   filePath: string,
   projectDir: string,
   adapter: RuntimeAdapter,
   options?: LoadComponentOptions,
-): Promise<React.ComponentType<Record<string, unknown>>> {
+): Promise<Record<string, unknown>> {
   const fileName = filePath.split("/").pop() ?? filePath;
   const projectId = options?.projectId ?? projectDir;
   const dev = options?.dev ?? true;
   const ssr = options?.ssr ?? true;
 
-  return withSpan(
+  return await withSpan(
     "modules.react.loadComponentFromSource",
     async () => {
       if (ssr) {
@@ -38,7 +38,7 @@ export function loadComponentFromSource(
           mode: options?.mode,
         });
 
-        return loader.loadModule(filePath, source);
+        return await loader.loadRawModule(filePath, source);
       }
 
       const transformOpts: TransformOptions = {
@@ -67,8 +67,7 @@ export function loadComponentFromSource(
       await fs.mkdir(componentDir, { recursive: true });
       await fs.writeTextFile(componentFile, transformedCode);
 
-      const mod = await import(`file://${componentFile}?t=${Date.now()}`);
-      return extractComponent(mod, filePath);
+      return await import(`file://${componentFile}?t=${Date.now()}`);
     },
     {
       "react.file": fileName,
@@ -77,4 +76,15 @@ export function loadComponentFromSource(
       "react.sourceLength": source.length,
     },
   );
+}
+
+export async function loadComponentFromSource(
+  source: string,
+  filePath: string,
+  projectDir: string,
+  adapter: RuntimeAdapter,
+  options?: LoadComponentOptions,
+): Promise<React.ComponentType<Record<string, unknown>>> {
+  const mod = await loadModuleFromSource(source, filePath, projectDir, adapter, options);
+  return extractComponent(mod, filePath);
 }

--- a/src/modules/react-loader/index.ts
+++ b/src/modules/react-loader/index.ts
@@ -4,7 +4,7 @@
  * @module modules/react-loader
  */
 
-export { loadComponentFromSource } from "./component-loader.ts";
+export { loadComponentFromSource, loadModuleFromSource } from "./component-loader.ts";
 export { loadComponentsUnified } from "./unified-loader.ts";
 export { clearSSRModuleCache, clearSSRModuleCacheForProject } from "./ssr-module-loader/index.ts";
 

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -275,10 +275,10 @@ export class SSRModuleLoader {
     }
   }
 
-  loadModule(
+  loadRawModule(
     filePath: string,
     source: string,
-  ): Promise<React.ComponentType<Record<string, unknown>>> {
+  ): Promise<Record<string, unknown>> {
     const fileName = filePath.split("/").pop() || filePath;
 
     return withSpan(
@@ -311,7 +311,7 @@ export class SSRModuleLoader {
           const mod = await this.importModuleFromCacheEntry(filePath, fileName, cacheEntry);
 
           this.circuitBreaker.recordSuccess(circuitKey);
-          return extractComponent(mod, filePath);
+          return mod;
         } catch (error) {
           this.circuitBreaker.recordFailure(circuitKey);
           throw error;
@@ -323,6 +323,14 @@ export class SSRModuleLoader {
         "ssr.source_length": source.length,
       },
     );
+  }
+
+  async loadModule(
+    filePath: string,
+    source: string,
+  ): Promise<React.ComponentType<Record<string, unknown>>> {
+    const mod = await this.loadRawModule(filePath, source);
+    return extractComponent(mod, filePath);
   }
 
   private async transformCrossProjectImport(

--- a/src/react/context/index.tsx
+++ b/src/react/context/index.tsx
@@ -51,7 +51,13 @@ const defaultPageContext: PageContextValue = {
   mdxHeadings: [],
 };
 
-const PageContextContext = React.createContext(defaultPageContext);
+const PAGE_CONTEXT_SYMBOL = Symbol.for("veryfront.react.page-context");
+const globalPageContext = globalThis as typeof globalThis & {
+  [PAGE_CONTEXT_SYMBOL]?: React.Context<PageContextValue>;
+};
+
+const PageContextContext = globalPageContext[PAGE_CONTEXT_SYMBOL] ??
+  (globalPageContext[PAGE_CONTEXT_SYMBOL] = React.createContext(defaultPageContext));
 
 export interface PageContextProviderProps {
   children: React.ReactNode;

--- a/src/react/router/index.tsx
+++ b/src/react/router/index.tsx
@@ -48,7 +48,13 @@ const defaultRouter: RouterValue = {
   reload: async () => {},
 };
 
-const RouterContext = React.createContext<RouterValue>(defaultRouter);
+const ROUTER_CONTEXT_SYMBOL = Symbol.for("veryfront.react.router-context");
+const globalRouterContext = globalThis as typeof globalThis & {
+  [ROUTER_CONTEXT_SYMBOL]?: React.Context<RouterValue>;
+};
+
+const RouterContext = globalRouterContext[ROUTER_CONTEXT_SYMBOL] ??
+  (globalRouterContext[ROUTER_CONTEXT_SYMBOL] = React.createContext<RouterValue>(defaultRouter));
 
 export interface RouterProviderProps {
   children: React.ReactNode;

--- a/src/rendering/layouts/layout-applicator.test.ts
+++ b/src/rendering/layouts/layout-applicator.test.ts
@@ -12,11 +12,12 @@ function buildSSRRouter(
   requestUrl: URL | undefined,
   pageFilePath: string,
   pageSlug: string,
+  params?: Record<string, string | string[]>,
 ): {
   domain: string;
   path: string;
   pathname: string;
-  params: Record<string, never>;
+  params: Record<string, string>;
   query: Record<string, string>;
   isPreview: false;
   isMounted: false;
@@ -25,11 +26,19 @@ function buildSSRRouter(
   replace: () => void;
   reload: () => void;
 } {
+  const flatParams = params
+    ? Object.fromEntries(
+      Object.entries(params)
+        .map(([key, value]) => [key, Array.isArray(value) ? value[0] : value])
+        .filter((entry): entry is [string, string] => entry[1] !== undefined),
+    )
+    : {};
+
   return {
     domain: requestUrl?.origin ?? "",
     path: requestUrl?.pathname ?? pageFilePath,
     pathname: requestUrl?.pathname ?? `/${pageSlug}`,
-    params: {},
+    params: flatParams,
     query: requestUrl ? Object.fromEntries(requestUrl.searchParams) : {},
     isPreview: false,
     isMounted: false,
@@ -45,13 +54,15 @@ type Heading = { id: string; text: string; level: number };
 function buildPageContext(
   slug: string,
   path: string,
+  params: Record<string, string>,
+  query: Record<string, string>,
   frontmatter: Record<string, unknown>,
   headings: Heading[],
 ): {
   slug: string;
   path: string;
-  params: Record<string, never>;
-  query: Record<string, never>;
+  params: Record<string, string>;
+  query: Record<string, string>;
   frontmatter: Record<string, unknown>;
   headings: Heading[];
   mdxHeadings: Heading[];
@@ -59,8 +70,8 @@ function buildPageContext(
   return {
     slug,
     path,
-    params: {},
-    query: {},
+    params,
+    query,
     frontmatter,
     headings,
     mdxHeadings: headings,
@@ -111,10 +122,12 @@ describe("LayoutApplicator helpers", () => {
       assertEquals(router.query, {});
     });
 
-    it("should always have empty params", () => {
+    it("should flatten params into string values", () => {
       const url = new URL("https://example.com/blog/123");
-      const router = buildSSRRouter(url, "/pages/blog/[id].tsx", "blog/123");
-      assertEquals(router.params, {});
+      const router = buildSSRRouter(url, "/pages/blog/[id].tsx", "blog/123", {
+        id: ["123", "ignored"],
+      });
+      assertEquals(router.params, { id: "123" });
     });
 
     it("should handle URL with multiple search params", () => {
@@ -135,22 +148,31 @@ describe("LayoutApplicator helpers", () => {
   describe("buildPageContext", () => {
     it("should build context with all fields", () => {
       const headings = [{ id: "intro", text: "Introduction", level: 1 }];
-      const ctx = buildPageContext("about", "/pages/about.tsx", { title: "About" }, headings);
+      const ctx = buildPageContext(
+        "about",
+        "/pages/about.tsx",
+        { id: "123" },
+        { tab: "details" },
+        { title: "About" },
+        headings,
+      );
       assertEquals(ctx.slug, "about");
       assertEquals(ctx.path, "/pages/about.tsx");
+      assertEquals(ctx.params, { id: "123" });
+      assertEquals(ctx.query, { tab: "details" });
       assertEquals(ctx.frontmatter, { title: "About" });
       assertEquals(ctx.headings, headings);
       assertEquals(ctx.mdxHeadings, headings);
     });
 
-    it("should always have empty params and query", () => {
-      const ctx = buildPageContext("home", "/pages/index.tsx", {}, []);
+    it("should preserve empty params and query", () => {
+      const ctx = buildPageContext("home", "/pages/index.tsx", {}, {}, {}, []);
       assertEquals(ctx.params, {});
       assertEquals(ctx.query, {});
     });
 
     it("should handle empty frontmatter", () => {
-      const ctx = buildPageContext("test", "/test.tsx", {}, []);
+      const ctx = buildPageContext("test", "/test.tsx", {}, {}, {}, []);
       assertEquals(ctx.frontmatter, {});
     });
 
@@ -160,7 +182,7 @@ describe("LayoutApplicator helpers", () => {
         { id: "h2", text: "Subtitle", level: 2 },
         { id: "h3", text: "Section", level: 3 },
       ];
-      const ctx = buildPageContext("docs", "/docs.tsx", {}, headings);
+      const ctx = buildPageContext("docs", "/docs.tsx", {}, {}, {}, headings);
       assertEquals(ctx.headings.length, 3);
       assertEquals(ctx.mdxHeadings.length, 3);
     });
@@ -189,6 +211,13 @@ describe("LayoutApplicator helpers", () => {
         requestUrl: new URL("https://example.com/about"),
       };
       assertEquals(opts.requestUrl?.pathname, "/about");
+    });
+
+    it("should accept optional params", () => {
+      const opts: Partial<LayoutApplicationOptions> = {
+        params: { slug: "post-1" },
+      };
+      assertEquals(opts.params, { slug: "post-1" });
     });
 
     it("should accept optional frontmatter", () => {

--- a/src/rendering/layouts/layout-applicator.ts
+++ b/src/rendering/layouts/layout-applicator.ts
@@ -19,8 +19,9 @@ import {
 import { detectAppRouter } from "../router-detection.ts";
 import { getProjectReact } from "#veryfront/react";
 import { extract } from "#std/front-matter/yaml.ts";
-import { RouterProvider } from "veryfront/router";
-import { PageContextProvider } from "veryfront/context";
+import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { resolveFrameworkSourcePath } from "#veryfront/platform/compat/framework-source-resolver.ts";
+import { loadModuleFromSource } from "#veryfront/modules/react-loader/index.ts";
 
 const logger = rendererLogger.component("layout-applicator");
 
@@ -37,6 +38,7 @@ export interface LayoutApplicationOptions {
   mode: "development" | "production";
   moduleServerUrl?: string;
   requestUrl?: URL;
+  params?: Record<string, string | string[]>;
   frontmatter?: Record<string, unknown>;
   headings?: Array<{ id: string; text: string; level: number }>;
 }
@@ -49,12 +51,17 @@ export class LayoutApplicator {
   private mergedComponents: MDXComponents;
   private mode: "development" | "production";
   private requestUrl?: URL;
+  private params?: Record<string, string | string[]>;
   private frontmatter?: Record<string, unknown>;
   private headings?: Array<{ id: string; text: string; level: number }>;
   private projectId: string;
   private projectSlug: string;
   private contentSourceId: string;
   private preloadedImportMap?: ImportMapConfig | null;
+  private frameworkProviderModulesPromise?: Promise<{
+    PageContextProvider: BundledReact.ComponentType<Record<string, unknown>>;
+    RouterProvider: BundledReact.ComponentType<Record<string, unknown>>;
+  }>;
 
   constructor(options: LayoutApplicationOptions) {
     this.projectDir = options.projectDir;
@@ -68,6 +75,7 @@ export class LayoutApplicator {
     this.mergedComponents = options.mergedComponents;
     this.mode = options.mode;
     this.requestUrl = options.requestUrl;
+    this.params = options.params;
     this.frontmatter = options.frontmatter;
     this.headings = options.headings;
   }
@@ -109,11 +117,19 @@ export class LayoutApplicator {
         const React = await getProjectReact();
 
         const headingsArray = this.headings ?? [];
+        const flatParams = this.params
+          ? Object.fromEntries(
+            Object.entries(this.params)
+              .map(([key, value]) => [key, Array.isArray(value) ? value[0] : value])
+              .filter((entry): entry is [string, string] => entry[1] !== undefined),
+          )
+          : {};
+        const query = this.requestUrl ? Object.fromEntries(this.requestUrl.searchParams) : {};
         const pageContext = {
           slug: pageInfo.entity.slug || "",
           path: pageFilePath,
-          params: {},
-          query: {},
+          params: flatParams,
+          query,
           frontmatter: this.frontmatter ?? pageInfo.entity.frontmatter ?? {},
           headings: headingsArray,
           mdxHeadings: headingsArray,
@@ -123,6 +139,8 @@ export class LayoutApplicator {
           frontmatterKeys: Object.keys(pageContext.frontmatter),
           headingsCount: headingsArray.length,
         });
+
+        const { PageContextProvider, RouterProvider } = await this.loadFrameworkProviders();
 
         wrappedElement = React.createElement(PageContextProvider, {
           pageContext,
@@ -135,8 +153,8 @@ export class LayoutApplicator {
           domain: this.requestUrl?.origin ?? "",
           path: this.requestUrl?.pathname ?? pageFilePath,
           pathname: this.requestUrl?.pathname ?? `/${pageInfo.entity.slug || ""}`,
-          params: {},
-          query: this.requestUrl ? Object.fromEntries(this.requestUrl.searchParams) : {},
+          params: flatParams,
+          query,
           isPreview: false,
           isMounted: false,
           navigate: async () => {},
@@ -216,6 +234,77 @@ export class LayoutApplicator {
         "layout.use_esm": Boolean(this.config?.experimental?.esmLayouts),
       },
     );
+  }
+
+  private async loadFrameworkProviders(): Promise<{
+    PageContextProvider: BundledReact.ComponentType<Record<string, unknown>>;
+    RouterProvider: BundledReact.ComponentType<Record<string, unknown>>;
+  }> {
+    if (!this.frameworkProviderModulesPromise) {
+      this.frameworkProviderModulesPromise = this.loadFrameworkProvidersInternal();
+    }
+
+    return await this.frameworkProviderModulesPromise;
+  }
+
+  private async loadFrameworkProvidersInternal(): Promise<{
+    PageContextProvider: BundledReact.ComponentType<Record<string, unknown>>;
+    RouterProvider: BundledReact.ComponentType<Record<string, unknown>>;
+  }> {
+    const fs = createFileSystem();
+    const decoder = new TextDecoder();
+    const [contextModuleInfo, routerModuleInfo] = await Promise.all([
+      resolveFrameworkSourcePath("react/context"),
+      resolveFrameworkSourcePath("react/router"),
+    ]);
+
+    if (!contextModuleInfo?.path || !routerModuleInfo?.path) {
+      throw new Error("Failed to resolve framework context or router source modules");
+    }
+
+    const [contextSource, routerSource] = await Promise.all([
+      fs.readFile(contextModuleInfo.path),
+      fs.readFile(routerModuleInfo.path),
+    ]);
+
+    const loadOptions = {
+      projectId: this.projectId,
+      projectSlug: this.projectSlug,
+      contentSourceId: this.contentSourceId,
+      dev: this.mode === "development",
+      mode: this.mode,
+    } as const;
+
+    const [contextModule, routerModule] = await Promise.all([
+      loadModuleFromSource(
+        decoder.decode(contextSource),
+        contextModuleInfo.path,
+        this.projectDir,
+        this.adapter,
+        loadOptions,
+      ),
+      loadModuleFromSource(
+        decoder.decode(routerSource),
+        routerModuleInfo.path,
+        this.projectDir,
+        this.adapter,
+        loadOptions,
+      ),
+    ]);
+
+    const PageContextProvider = contextModule.PageContextProvider;
+    const RouterProvider = routerModule.RouterProvider;
+
+    if (typeof PageContextProvider !== "function" || typeof RouterProvider !== "function") {
+      throw new Error("Failed to load framework context or router providers");
+    }
+
+    return {
+      PageContextProvider: PageContextProvider as BundledReact.ComponentType<
+        Record<string, unknown>
+      >,
+      RouterProvider: RouterProvider as BundledReact.ComponentType<Record<string, unknown>>,
+    };
   }
 
   private async wrapWithAppComponent(

--- a/src/rendering/orchestrator/layout.ts
+++ b/src/rendering/orchestrator/layout.ts
@@ -263,6 +263,7 @@ export class LayoutOrchestrator {
     nestedLayouts: LayoutItem[],
     layoutDataMap?: Map<string, Record<string, unknown>>,
     requestUrl?: URL,
+    params?: Record<string, string | string[]>,
     frontmatter?: Record<string, unknown>,
     headings?: Array<{ id: string; text: string; level: number }>,
     projectSlug?: string,
@@ -288,6 +289,7 @@ export class LayoutOrchestrator {
           mode: this.config.mode,
           moduleServerUrl: this.config.moduleServerUrl,
           requestUrl,
+          params,
           frontmatter,
           headings,
         });

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -510,6 +510,7 @@ export class RenderPipeline {
                   layoutResult.nestedLayouts,
                   layoutDataMap,
                   options?.url,
+                  resolvedParams,
                   mergedFrontmatter,
                   headings,
                   options?.projectSlug,
@@ -651,7 +652,10 @@ export class RenderPipeline {
           pageInfo,
           slug,
           undefined,
-          options,
+          {
+            ...options,
+            ...(Object.keys(params).length > 0 ? { params } : {}),
+          },
         );
 
         if (bundleResult.pageBundle && "frontmatter" in bundleResult.pageBundle) {

--- a/src/rendering/page-renderer.ts
+++ b/src/rendering/page-renderer.ts
@@ -16,6 +16,7 @@ import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 
 interface PageRenderOptions {
   params?: Record<string, string | string[]>;
+  url?: URL;
   props?: ComponentProps;
   nonce?: string;
   /** Project ID for multi-project SSR module isolation */
@@ -124,6 +125,7 @@ export class PageRenderer {
                 projectDir: this.projectDir,
                 adapter: this.adapter,
                 params: options?.params,
+                url: options?.url,
                 props: options?.props,
                 nonce: options?.nonce,
               }),
@@ -190,6 +192,7 @@ export class PageRenderer {
               this.adapter,
               {
                 params: options?.params,
+                url: options?.url,
                 precompiledModule: cachedModule?.type === "mdx" ? cachedModule.code : undefined,
                 projectId: options?.projectId,
                 studioEmbed: options?.studioEmbed,

--- a/src/rendering/page-rendering.ts
+++ b/src/rendering/page-rendering.ts
@@ -86,6 +86,7 @@ export function handleMDXPage(
   adapter: RuntimeAdapter,
   options?: {
     params?: Record<string, string | string[]>;
+    url?: URL;
     precompiledModule?: string;
     /** Project ID for cache isolation */
     projectId?: string;
@@ -137,9 +138,11 @@ export function handleMDXPage(
                   .filter((entry): entry is [string, string] => entry[1] !== undefined),
               ) as Record<string, string>)
               : {};
+            const query = options?.url ? Object.fromEntries(options.url.searchParams) : {};
 
             const gen = await mod.generateMetadata({
               params,
+              query,
               slug,
               path,
               frontmatter: frontmatter || {},

--- a/src/rendering/script-page-handling.test.ts
+++ b/src/rendering/script-page-handling.test.ts
@@ -32,6 +32,7 @@ function extractHtmlAndMetadata(output: ScriptModuleOutput): {
 
 interface PageContext {
   params: Record<string, string>;
+  query: Record<string, string>;
   slug: string;
   path: string;
   frontmatter: Record<string, unknown>;
@@ -41,17 +42,19 @@ function buildPageContext(
   pageInfo: { entity: { path: string; frontmatter: Record<string, unknown> } },
   slug: string,
   params?: Record<string, string | string[]>,
+  url?: URL,
 ): PageContext {
   const flatParams: Record<string, string> = params
     ? Object.fromEntries(
       Object.entries(params)
-        .map(([k, v]) => [k, Array.isArray(v) ? v[0] : v] as const)
-        .filter(([, v]): v is string => v !== undefined),
+        .map(([k, v]) => [k, Array.isArray(v) ? v[0] : v])
+        .filter((entry): entry is [string, string] => entry[1] !== undefined),
     )
     : {};
 
   return {
     params: flatParams,
+    query: url ? Object.fromEntries(url.searchParams) : {},
     slug,
     path: pageInfo.entity.path,
     frontmatter: pageInfo.entity.frontmatter ?? {},
@@ -147,10 +150,16 @@ describe("script-page-handling helpers", () => {
     };
 
     it("should build context with all fields", () => {
-      const ctx = buildPageContext(mockPageInfo, "about", { id: "123" });
+      const ctx = buildPageContext(
+        mockPageInfo,
+        "about",
+        { id: "123" },
+        new URL("https://example.com/about?tab=details"),
+      );
       assertEquals(ctx.slug, "about");
       assertEquals(ctx.path, "/project/pages/about.tsx");
       assertEquals(ctx.params, { id: "123" });
+      assertEquals(ctx.query, { tab: "details" });
       assertEquals(ctx.frontmatter, { title: "About" });
     });
 
@@ -162,17 +171,29 @@ describe("script-page-handling helpers", () => {
     it("should handle empty params", () => {
       const ctx = buildPageContext(mockPageInfo, "home");
       assertEquals(ctx.params, {});
+      assertEquals(ctx.query, {});
     });
 
     it("should handle undefined params", () => {
       const ctx = buildPageContext(mockPageInfo, "home", undefined);
       assertEquals(ctx.params, {});
+      assertEquals(ctx.query, {});
     });
 
     it("should use empty object when frontmatter is falsy", () => {
       const info = { entity: { path: "/p.tsx", frontmatter: {} } };
       const ctx = buildPageContext(info, "test");
       assertEquals(ctx.frontmatter, {});
+    });
+
+    it("should capture query params from the request URL", () => {
+      const ctx = buildPageContext(
+        mockPageInfo,
+        "search",
+        undefined,
+        new URL("https://example.com/search?q=test&page=2"),
+      );
+      assertEquals(ctx.query, { q: "test", page: "2" });
     });
   });
 

--- a/src/rendering/script-page-handling.ts
+++ b/src/rendering/script-page-handling.ts
@@ -41,6 +41,7 @@ interface ScriptPageOptions {
   projectDir: string;
   adapter: RuntimeAdapter;
   params?: Record<string, string | string[]>;
+  url?: URL;
   props?: ComponentProps;
   nonce?: string;
 }
@@ -127,6 +128,7 @@ function buildPageContext(
   pageInfo: EntityInfo,
   slug: string,
   params?: Record<string, string | string[]>,
+  url?: URL,
 ): PageContext {
   const flatParams: Record<string, string> = params
     ? Object.fromEntries(
@@ -138,6 +140,7 @@ function buildPageContext(
 
   return {
     params: flatParams,
+    query: url ? Object.fromEntries(url.searchParams) : {},
     slug,
     path: pageInfo.entity.path,
     frontmatter: pageInfo.entity.frontmatter || {},
@@ -169,7 +172,7 @@ export async function handleScriptPage(
     logger.debug(`Loading TS/JS page module: ${pageInfo.entity.path}`);
 
     const mod = await loadScriptModule(pageInfo.entity.path, options.projectDir, options.adapter);
-    const ctx = buildPageContext(pageInfo, slug, options.params);
+    const ctx = buildPageContext(pageInfo, slug, options.params, options.url);
 
     let output = await executeModuleRender(mod, ctx);
     const generatedMetadata = await collectModuleMetadata(mod, ctx);

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.117";
+export const VERSION = "0.1.118";

--- a/tests/integration/compiled-binary-e2e.test.ts
+++ b/tests/integration/compiled-binary-e2e.test.ts
@@ -37,6 +37,11 @@ try {
 // test suites run concurrently (e.g., deno task test picking up this file)
 const BINARY_PATH = Deno.env.get("VERYFRONT_BINARY") ?? `/tmp/veryfront-e2e-bin-${Deno.pid}`;
 const BINARY_HASH_PATH = `${BINARY_PATH}.srcHash`;
+
+function stripReactSSRMarkers(html: string): string {
+  return html.replaceAll("<!-- -->", "");
+}
+
 /** Get an available port using OS-assigned port 0. */
 async function getAvailablePort(): Promise<number> {
   const listener = Deno.listen({ hostname: "127.0.0.1", port: 0 });
@@ -714,6 +719,62 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       assertEquals(response.status, 200, "Should return 200");
       assertStringIncludes(html, "layout-wrapper", "Should have layout wrapper");
       assertStringIncludes(html, "page-content", "Should have page content");
+
+      const errors = server.logs.filter((l) =>
+        l.includes("Invalid hook call") || l.includes("Module not found")
+      );
+      assertEquals(errors.length, 0, `Should have no errors: ${errors.join("\n")}`);
+    });
+  });
+
+  it("should expose params and query through usePageContext in the compiled runtime", async () => {
+    const projectDir = await createTestProject(
+      "page-context-request-values-test",
+      `
+export default function Home() {
+  return <div>Unused home page</div>;
+}
+`,
+      {
+        "pages/blog/[slug].tsx": `
+import { usePageContext } from "veryfront/context";
+
+export default function BlogPost() {
+  const ctx = usePageContext();
+  return (
+    <div id="page-context">
+      Page params: {ctx?.params?.slug || "none"} | Page query: {ctx?.query?.tab || "none"}
+    </div>
+  );
+}
+`,
+        "pages/layout.tsx": `
+import { usePageContext } from "veryfront/context";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const ctx = usePageContext();
+  return (
+    <div id="layout-wrapper">
+      <header id="layout-context">
+        Layout params: {ctx?.params?.slug || "none"} | Layout query: {ctx?.query?.lang || "none"}
+      </header>
+      <main>{children}</main>
+    </div>
+  );
+}
+`,
+      },
+    );
+
+    await withServer(projectDir, async (server) => {
+      const response = await fetch(`http://127.0.0.1:${server.port}/blog/hello?tab=files&lang=en`);
+      const html = await response.text();
+
+      assertEquals(response.status, 200, "Should return 200");
+      assertStringIncludes(html, "layout-wrapper", "Should render layout wrapper");
+      const normalizedHtml = stripReactSSRMarkers(html);
+      assertStringIncludes(normalizedHtml, "Layout params: hello | Layout query: en");
+      assertStringIncludes(normalizedHtml, "Page params: hello | Page query: files");
 
       const errors = server.logs.filter((l) =>
         l.includes("Invalid hook call") || l.includes("Module not found")

--- a/tests/integration/renderer/renderer-core-features.test.ts
+++ b/tests/integration/renderer/renderer-core-features.test.ts
@@ -192,6 +192,41 @@ export const metadata = {
           assertStringIncludes(result.html, "<title>Meta Test</title>");
         });
       });
+
+      it("should pass query params into MDX generateMetadata context", async () => {
+        await withTestContext("renderer-core-metadata-query", async (context) => {
+          await remove(join(context.projectDir, "app"), { recursive: true });
+
+          await writeTextFile(
+            join(context.projectDir, "pages", "query-meta.mdx"),
+            `---
+title: Base Title
+---
+
+export async function generateMetadata(ctx) {
+  return {
+    title: \`Query title: \${ctx.query.tab || "none"}\`,
+    description: \`Search: \${ctx.query.q || "none"}\`,
+  };
+}
+
+# Query Metadata
+`,
+          );
+
+          const renderer = await createRenderer({
+            projectDir: context.projectDir,
+            mode: "development",
+          });
+
+          const result = await renderer.renderPage("query-meta", {
+            url: new URL("https://example.com/query-meta?tab=details&q=search-term"),
+          });
+
+          assertStringIncludes(result.html, "<title>Query title: details</title>");
+          assertStringIncludes(result.html, 'content="Search: search-term"');
+        });
+      });
     });
 
     describe("getAllPages", () => {

--- a/tests/integration/renderer/renderer-core-foundation.test.ts
+++ b/tests/integration/renderer/renderer-core-foundation.test.ts
@@ -19,6 +19,10 @@ import { describe, it } from "#veryfront/testing/bdd";
 import { createRenderer } from "../../../src/rendering/index.ts";
 import { withTestContext } from "../../_helpers/context.ts";
 
+function stripReactSSRMarkers(html: string): string {
+  return html.replaceAll("<!-- -->", "");
+}
+
 // Skip tests on non-Deno runtimes (SSR uses URL-based imports)
 // Note: Sanitizers disabled due to React 19 SSR MessagePort cleanup issue
 // See: https://github.com/facebook/react/issues/24669
@@ -614,6 +618,95 @@ title: Stream Test
 
           const result = await renderer.renderPage("data");
           assertExists(result);
+        });
+      });
+
+      it("should pass params and query to script page context", async () => {
+        await withTestContext("renderer-core-script-page-request-context", async (context) => {
+          await remove(join(context.projectDir, "app"), { recursive: true });
+          await mkdir(join(context.projectDir, "pages", "reports"), { recursive: true });
+
+          await writeTextFile(
+            join(context.projectDir, "pages", "reports", "[id].ts"),
+            `export function generateMetadata(ctx) {
+              return { title: \`Report \${ctx.params.id} (\${ctx.query.view || "none"})\` };
+            }
+
+export default function ReportPage(ctx) {
+  return {
+    html: \`<div id="request-context">report=\${ctx.params.id};view=\${ctx.query.view || "none"};tab=\${ctx.query.tab || "none"}</div>\`,
+  };
+}
+`,
+          );
+
+          const renderer = await createRenderer({
+            projectDir: context.projectDir,
+            mode: "development",
+          });
+
+          const result = await renderer.renderPage("reports/42", {
+            params: { id: "42" },
+            url: new URL("https://example.com/reports/42?view=full&tab=summary"),
+          });
+
+          assertStringIncludes(result.html, 'id="request-context"');
+          assertStringIncludes(result.html, "report=42;view=full;tab=summary");
+          assertEquals(result.frontmatter.title, "Report 42 (full)");
+        });
+      });
+
+      it("should expose params and query through usePageContext during SSR", async () => {
+        await withTestContext("renderer-core-page-context-request-values", async (context) => {
+          await remove(join(context.projectDir, "app"), { recursive: true });
+          await mkdir(join(context.projectDir, "pages", "blog"), { recursive: true });
+
+          await writeTextFile(
+            join(context.projectDir, "pages", "blog", "[slug].tsx"),
+            `import { usePageContext } from "veryfront/context";
+
+export default function BlogPost() {
+  const ctx = usePageContext();
+  return (
+    <div id="page-context">
+      Page params: {ctx?.params?.slug || "none"} | Page query: {ctx?.query?.tab || "none"}
+    </div>
+  );
+}
+`,
+          );
+
+          await writeTextFile(
+            join(context.projectDir, "pages", "layout.tsx"),
+            `import { usePageContext } from "veryfront/context";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const ctx = usePageContext();
+  return (
+    <div id="layout-wrapper">
+      <header id="layout-context">
+        Layout params: {ctx?.params?.slug || "none"} | Layout query: {ctx?.query?.lang || "none"}
+      </header>
+      <main>{children}</main>
+    </div>
+  );
+}
+`,
+          );
+
+          const renderer = await createRenderer({
+            projectDir: context.projectDir,
+            mode: "development",
+          });
+
+          const result = await renderer.renderPage("blog/hello", {
+            params: { slug: "hello" },
+            url: new URL("https://example.com/blog/hello?tab=files&lang=en"),
+          });
+
+          const normalizedHtml = stripReactSSRMarkers(result.html);
+          assertStringIncludes(normalizedHtml, "Layout params: hello | Layout query: en");
+          assertStringIncludes(normalizedHtml, "Page params: hello | Page query: files");
         });
       });
     });


### PR DESCRIPTION
## Summary
- add request-context coverage for script pages, MDX metadata, SSR layout/page rendering, and the compiled binary runtime
- make the SSR layout/provider loading path share page/router context across layout and page modules
- bump the release version to `0.1.118` in `deno.json` and `src/utils/version-constant.ts`

## Verification
- `deno check src/rendering/script-page-handling.ts src/rendering/page-rendering.ts src/rendering/page-renderer.ts src/rendering/orchestrator/layout.ts src/rendering/orchestrator/pipeline.ts src/rendering/layouts/layout-applicator.ts tests/integration/renderer/renderer-core-foundation.test.ts tests/integration/renderer/renderer-core-features.test.ts tests/integration/compiled-binary-e2e.test.ts src/utils/version-constant.ts src/utils/version.test.ts`
- `deno test --no-check --allow-all src/utils/version.test.ts src/modules/server/module-server.test.ts`
- `deno test --no-check --allow-all tests/integration/renderer/renderer-core-foundation.test.ts tests/integration/renderer/renderer-core-features.test.ts src/rendering/script-page-handling.test.ts src/rendering/layouts/layout-applicator.test.ts --unstable-worker-options --unstable-net`
- `deno test --no-check --allow-all tests/integration/compiled-binary-e2e.test.ts`
- `git push -u origin test/request-api-compat-coverage` (passed format, lint, typecheck, and unit tests via pre-push hooks)
