### PR TITLE
Fix preview chat hydration CSP regression

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.118",
+  "version": "0.1.119",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/runtime/input-utils.ts
+++ b/src/agent/runtime/input-utils.ts
@@ -1,5 +1,5 @@
 import type { Message } from "../types.ts";
-import { INVALID_ARGUMENT } from "#veryfront/errors";
+import { INVALID_ARGUMENT } from "#veryfront/errors/error-registry.ts";
 
 export function normalizeInput(input: string | Message[]): Message[] {
   const now = Date.now();

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -3,7 +3,7 @@
  **************************/
 
 import type { Tool } from "#veryfront/tool";
-import { INVALID_ARGUMENT } from "#veryfront/errors";
+import { INVALID_ARGUMENT } from "#veryfront/errors/error-registry.ts";
 import type { Memory } from "./memory/memory-interface.ts";
 
 // Re-export schema-based types

--- a/src/client/spa/ClientApp.tsx
+++ b/src/client/spa/ClientApp.tsx
@@ -3,7 +3,7 @@ import { type Router, RouterProvider } from "veryfront/router";
 import { type PageContext, PageContextProvider } from "veryfront/context";
 import { type LayoutInfo, LayoutShell } from "./LayoutShell.tsx";
 import { getCachedComponent, loadComponent, preloadComponent } from "./component-loader.ts";
-import { PAGE_NOT_FOUND } from "#veryfront/errors";
+import { PAGE_NOT_FOUND } from "#veryfront/errors/error-registry.ts";
 
 export interface PageDataResponse {
   slug: string;

--- a/src/react/compat/ssr-adapter/server-loader.ts
+++ b/src/react/compat/ssr-adapter/server-loader.ts
@@ -1,5 +1,5 @@
 import { getReactVersionInfo } from "../version-detector/index.ts";
-import { INITIALIZATION_ERROR } from "#veryfront/errors";
+import { INITIALIZATION_ERROR } from "#veryfront/errors/error-registry.ts";
 import { Singleflight } from "#veryfront/utils/singleflight.ts";
 import { cacheModuleToLocal } from "#veryfront/transforms/esm/http-cache.ts";
 import { getReactUrls } from "#veryfront/transforms/esm/package-registry.ts";

--- a/src/react/components/ai/chat/contexts/chat-context.tsx
+++ b/src/react/components/ai/chat/contexts/chat-context.tsx
@@ -7,7 +7,7 @@
  */
 
 import * as React from "react";
-import { COMPONENT_ERROR } from "#veryfront/errors";
+import { COMPONENT_ERROR } from "#veryfront/errors/error-registry.ts";
 import type { UIMessage } from "#veryfront/agent/react";
 import type { ChatTheme } from "../../theme.ts";
 import type { ModelOption } from "../../model-selector.tsx";

--- a/src/react/components/ai/chat/contexts/composer-context.tsx
+++ b/src/react/components/ai/chat/contexts/composer-context.tsx
@@ -8,7 +8,7 @@
  */
 
 import * as React from "react";
-import { COMPONENT_ERROR } from "#veryfront/errors";
+import { COMPONENT_ERROR } from "#veryfront/errors/error-registry.ts";
 import type { AttachmentInfo } from "../components/attachment-pill.tsx";
 import type { ModelOption } from "../../model-selector.tsx";
 

--- a/src/react/components/ai/chat/contexts/message-context.tsx
+++ b/src/react/components/ai/chat/contexts/message-context.tsx
@@ -8,7 +8,7 @@
  */
 
 import * as React from "react";
-import { COMPONENT_ERROR } from "#veryfront/errors";
+import { COMPONENT_ERROR } from "#veryfront/errors/error-registry.ts";
 import type { BranchInfo, UIMessage } from "#veryfront/agent/react";
 import type { FeedbackValue } from "../components/message-feedback.tsx";
 import type { PartGroup } from "../utils/message-parts.ts";

--- a/src/react/components/ai/chat/contexts/thread-list-context.tsx
+++ b/src/react/components/ai/chat/contexts/thread-list-context.tsx
@@ -8,7 +8,7 @@
  */
 
 import * as React from "react";
-import { COMPONENT_ERROR } from "#veryfront/errors";
+import { COMPONENT_ERROR } from "#veryfront/errors/error-registry.ts";
 import type { Thread } from "../hooks/use-threads.ts";
 
 export interface ThreadListContextValue {

--- a/src/react/components/ai/color-mode.tsx
+++ b/src/react/components/ai/color-mode.tsx
@@ -7,7 +7,7 @@
  */
 
 import * as React from "react";
-import { COMPONENT_ERROR } from "#veryfront/errors";
+import { COMPONENT_ERROR } from "#veryfront/errors/error-registry.ts";
 
 type ColorMode = "light" | "dark" | "system";
 type ResolvedColorMode = "light" | "dark";

--- a/src/rendering/rsc/client-hydrator.ts
+++ b/src/rendering/rsc/client-hydrator.ts
@@ -3,10 +3,10 @@ import { createRoot, hydrateRoot } from "react-dom/client";
 import { rscLogger } from "../client/browser-logger.ts";
 import {
   COMPILATION_ERROR,
-  isVeryfrontError,
   MODULE_NOT_FOUND,
   NETWORK_ERROR,
-} from "#veryfront/errors/index.ts";
+} from "#veryfront/errors/error-registry.ts";
+import { isVeryfrontError } from "#veryfront/errors/http-error.ts";
 import { createErrorDisplay } from "#veryfront/security/client/html-sanitizer.ts";
 import type { RSCHydratorOptions } from "./types.ts";
 

--- a/src/routing/client/page-loader.ts
+++ b/src/routing/client/page-loader.ts
@@ -1,5 +1,5 @@
 import { rendererLogger } from "#veryfront/utils";
-import { NETWORK_ERROR } from "#veryfront/errors/index.ts";
+import { NETWORK_ERROR } from "#veryfront/errors/error-registry.ts";
 import { parsePageDataFromHTML } from "./dom-utils.ts";
 
 export type {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.118";
+export const VERSION = "0.1.119";

--- a/tests/e2e/regressions/rsc-proxy-hydration.test.ts
+++ b/tests/e2e/regressions/rsc-proxy-hydration.test.ts
@@ -48,6 +48,16 @@ async function waitForReady(port: number, timeoutMs = 5000): Promise<void> {
   throw new Error("Server reported not-ready via /readyz");
 }
 
+function getHydrationErrors(messages: string[]): string[] {
+  return messages.filter((message) =>
+    message.includes("Page hydration failed") ||
+    message.includes("unsafe-eval") ||
+    message.includes("Failed to fetch dynamically imported module") ||
+    message.includes("WebAssembly.compile()") ||
+    message.includes("Hydration")
+  );
+}
+
 describe(
   "RSC Proxy Hydration Browser Tests",
   { sanitizeOps: false, sanitizeResources: false },
@@ -165,12 +175,7 @@ export default function Page() {
             const hydratedText = await page.textContent("#counter");
             assertEquals(hydratedText?.trim(), "Count: 1");
 
-            const hydrationErrors = [...consoleErrors, ...pageErrors].filter((message) =>
-              message.includes("Page hydration failed") ||
-              message.includes("unsafe-eval") ||
-              message.includes("Failed to fetch dynamically imported module") ||
-              message.includes("Hydration")
-            );
+            const hydrationErrors = getHydrationErrors([...consoleErrors, ...pageErrors]);
             assertEquals(hydrationErrors.length, 0);
           } finally {
             await browserContext.close();

--- a/tests/integration/server/dev-server-handlers.test.ts
+++ b/tests/integration/server/dev-server-handlers.test.ts
@@ -65,6 +65,22 @@ function assertJsNoCache(response: Response): void {
   );
 }
 
+function extractImportSpecifiers(code: string): string[] {
+  const specifiers = new Set<string>();
+  const patterns = [
+    /(?:import|export)\s+(?:[^"'`]*?\s+from\s+)?["']([^"'`]+)["']/g,
+    /import\(\s*["']([^"'`]+)["']\s*\)/g,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of code.matchAll(pattern)) {
+      if (match[1]) specifiers.add(match[1]);
+    }
+  }
+
+  return [...specifiers];
+}
+
 describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: false }, () => {
   afterAll(async () => {
     await cleanupBundler();
@@ -361,10 +377,11 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
       });
     });
 
-    it("serves browser chat modules without the heavyweight errors barrel", async () => {
+    it("serves browser framework modules with narrow CSP-safe imports", async () => {
       await withTestContext("dev-server-framework-chat-error-csp", async (context) => {
         const { server, port } = await createTestDevServer(context);
         const modulePaths = [
+          "/_vf_modules/_veryfront/react/components/ai/color-mode.js",
           "/_vf_modules/_veryfront/react/components/ai/chat/contexts/chat-context.js",
           "/_vf_modules/_veryfront/react/components/ai/chat/contexts/composer-context.js",
           "/_vf_modules/_veryfront/react/components/ai/chat/contexts/message-context.js",
@@ -379,17 +396,33 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
           assertEquals(response.status, 200, `Expected ${modulePath} to be served`);
 
           const body = await response.text();
+          const specifiers = extractImportSpecifiers(body);
+          const errorSpecifiers = specifiers.filter((specifier) =>
+            specifier.startsWith("/_vf_modules/_veryfront/errors/")
+          );
+
           assert(
-            !body.includes("/_vf_modules/_veryfront/errors/index.js"),
+            !body.includes("new Function("),
+            `${modulePath} should not use unsafe-eval`,
+          );
+          assert(
+            !specifiers.includes("/_vf_modules/_veryfront/errors/index.js"),
             `${modulePath} should not import the heavyweight errors barrel`,
           );
           assert(
-            !body.includes("/_vf_modules/_veryfront/platform/compat/process.js"),
+            !specifiers.includes("/_vf_modules/_veryfront/platform/compat/process.js"),
             `${modulePath} should not import process compat`,
           );
           assert(
-            !body.includes("/_vf_modules/_veryfront/platform/compat/dynamic-import.js"),
+            !specifiers.includes("/_vf_modules/_veryfront/platform/compat/dynamic-import.js"),
             `${modulePath} should not import dynamic-import compat`,
+          );
+          assert(
+            errorSpecifiers.every((specifier) =>
+              specifier === "/_vf_modules/_veryfront/errors/error-registry.js" ||
+              specifier === "/_vf_modules/_veryfront/errors/http-error.js"
+            ),
+            `${modulePath} should only import narrow browser-safe error modules`,
           );
         }
 

--- a/tests/integration/server/dev-server-handlers.test.ts
+++ b/tests/integration/server/dev-server-handlers.test.ts
@@ -360,6 +360,42 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
         await stopServer(server);
       });
     });
+
+    it("serves browser chat modules without the heavyweight errors barrel", async () => {
+      await withTestContext("dev-server-framework-chat-error-csp", async (context) => {
+        const { server, port } = await createTestDevServer(context);
+        const modulePaths = [
+          "/_vf_modules/_veryfront/react/components/ai/chat/contexts/chat-context.js",
+          "/_vf_modules/_veryfront/react/components/ai/chat/contexts/composer-context.js",
+          "/_vf_modules/_veryfront/react/components/ai/chat/contexts/message-context.js",
+          "/_vf_modules/_veryfront/react/components/ai/chat/contexts/thread-list-context.js",
+          "/_vf_modules/_veryfront/routing/client/page-loader.js",
+          "/_vf_modules/_veryfront/rendering/rsc/client-hydrator.js",
+          "/_vf_modules/_veryfront/client/spa/ClientApp.js",
+        ];
+
+        for (const modulePath of modulePaths) {
+          const response = await fetch(`http://127.0.0.1:${port}${modulePath}`);
+          assertEquals(response.status, 200, `Expected ${modulePath} to be served`);
+
+          const body = await response.text();
+          assert(
+            !body.includes("/_vf_modules/_veryfront/errors/index.js"),
+            `${modulePath} should not import the heavyweight errors barrel`,
+          );
+          assert(
+            !body.includes("/_vf_modules/_veryfront/platform/compat/process.js"),
+            `${modulePath} should not import process compat`,
+          );
+          assert(
+            !body.includes("/_vf_modules/_veryfront/platform/compat/dynamic-import.js"),
+            `${modulePath} should not import dynamic-import compat`,
+          );
+        }
+
+        await stopServer(server);
+      });
+    });
   });
 
   describe("DevServer - Error Handler", {}, () => {


### PR DESCRIPTION
## Summary
- stop browser-reachable modules from importing the heavyweight `#veryfront/errors` barrel
- keep chat/SPA/RSC client modules on `error-registry.ts` / `http-error.ts` so they do not pull `utils/version.ts` -> `process.ts` -> `dynamic-import.ts`
- add a dev-server regression that asserts these browser modules do not import `errors/index.js`, `process.js`, or `dynamic-import.js`
- bump the framework version to `0.1.119`

## Verification
- `deno check src/react/components/ai/chat/contexts/chat-context.tsx src/react/components/ai/chat/contexts/composer-context.tsx src/react/components/ai/chat/contexts/message-context.tsx src/react/components/ai/chat/contexts/thread-list-context.tsx src/react/components/ai/color-mode.tsx src/agent/types.ts src/agent/runtime/input-utils.ts src/routing/client/page-loader.ts src/rendering/rsc/client-hydrator.ts src/react/compat/ssr-adapter/server-loader.ts tests/integration/server/dev-server-handlers.test.ts`
- `deno test --no-check --allow-all tests/integration/server/dev-server-handlers.test.ts`
- `deno test --no-check --allow-all src/utils/version.test.ts src/modules/server/module-server.test.ts`
- `git push` pre-push suite passed: format, lint, typecheck, and unit tests