### PR TITLE
Add browser hydration matrix coverage

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -91,6 +91,8 @@ jobs:
       - uses: ./.github/actions/setup-deno
         with:
           warm-cache: "true"
+      - name: Install Chromium
+        run: deno run -A npm:playwright install --with-deps chromium
       - uses: nick-fields/retry@v3
         with:
           timeout_minutes: 15

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.119",
+  "version": "0.1.120",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.119";
+export const VERSION = "0.1.120";

--- a/tests/_helpers/playwright.ts
+++ b/tests/_helpers/playwright.ts
@@ -1,0 +1,46 @@
+import { type Browser, chromium, type Page } from "npm:playwright";
+
+export function isMissingBrowserExecutable(error: unknown): boolean {
+  return String(error).includes("Executable doesn't exist");
+}
+
+export async function launchChromium(): Promise<Browser | null> {
+  try {
+    return await chromium.launch({ headless: true });
+  } catch (error) {
+    if (isMissingBrowserExecutable(error)) {
+      console.warn(
+        "SKIP: Playwright Chromium is not installed. Run `deno run -A npm:playwright install chromium`.",
+      );
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+export function collectBrowserErrors(
+  page: Page,
+): { consoleErrors: string[]; pageErrors: string[] } {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+  page.on("pageerror", (error) => {
+    pageErrors.push(error.message);
+  });
+
+  return { consoleErrors, pageErrors };
+}
+
+export function getHydrationErrors(messages: string[]): string[] {
+  return messages.filter((message) =>
+    message.includes("Page hydration failed") ||
+    message.includes("unsafe-eval") ||
+    message.includes("Failed to fetch dynamically imported module") ||
+    message.includes("WebAssembly.compile()") ||
+    message.includes("Hydration")
+  );
+}

--- a/tests/e2e/regressions/rsc-proxy-hydration.test.ts
+++ b/tests/e2e/regressions/rsc-proxy-hydration.test.ts
@@ -4,28 +4,13 @@ import "../../_helpers/log-guard.ts";
 import { join } from "#veryfront/compat/path";
 import { mkdir, remove, writeTextFile } from "#veryfront/compat/fs.ts";
 import { withTestContext } from "../../_helpers/context.ts";
+import {
+  collectBrowserErrors,
+  getHydrationErrors,
+  launchChromium,
+} from "../../_helpers/playwright.ts";
 import { cleanupBundler } from "../../../src/rendering/cleanup.ts";
 import { startProductionServer } from "../../../src/server/production-server.ts";
-import { type Browser, chromium } from "npm:playwright";
-
-function isMissingBrowserExecutable(error: unknown): boolean {
-  return String(error).includes("Executable doesn't exist");
-}
-
-async function launchChromium(): Promise<Browser | null> {
-  try {
-    return await chromium.launch({ headless: true });
-  } catch (error) {
-    if (isMissingBrowserExecutable(error)) {
-      console.warn(
-        "SKIP: Playwright Chromium is not installed. Run `deno run -A npm:playwright install chromium`.",
-      );
-      return null;
-    }
-
-    throw error;
-  }
-}
 
 async function waitForReady(port: number, timeoutMs = 5000): Promise<void> {
   const start = Date.now();
@@ -48,56 +33,25 @@ async function waitForReady(port: number, timeoutMs = 5000): Promise<void> {
   throw new Error("Server reported not-ready via /readyz");
 }
 
-function getHydrationErrors(messages: string[]): string[] {
-  return messages.filter((message) =>
-    message.includes("Page hydration failed") ||
-    message.includes("unsafe-eval") ||
-    message.includes("Failed to fetch dynamically imported module") ||
-    message.includes("WebAssembly.compile()") ||
-    message.includes("Hydration")
-  );
-}
+async function writeClientCounterApp(
+  projectDir: string,
+  configSource: string,
+): Promise<void> {
+  await writeTextFile(join(projectDir, "veryfront.config.js"), configSource);
 
-describe(
-  "RSC Proxy Hydration Browser Tests",
-  { sanitizeOps: false, sanitizeResources: false },
-  () => {
-    afterAll(async () => {
-      await cleanupBundler();
-    });
+  await remove(join(projectDir, "app"), { recursive: true });
+  await remove(join(projectDir, "pages"), { recursive: true });
 
-    it("hydrates a remote-production client page and becomes interactive", async () => {
-      const browser = await launchChromium();
-      if (!browser) return;
-
-      try {
-        await withTestContext("rsc-proxy-browser-hydration", async (context) => {
-          await writeTextFile(
-            join(context.projectDir, "veryfront.config.js"),
-            `export default {
-            experimental: { rsc: true },
-            fs: {
-              veryfront: {
-                proxyMode: true,
-                apiBaseUrl: "https://api.veryfront.com"
-              }
-            }
-          };`,
-          );
-
-          await remove(join(context.projectDir, "app"), { recursive: true });
-          await remove(join(context.projectDir, "pages"), { recursive: true });
-
-          await mkdir(join(context.projectDir, "app"), { recursive: true });
-          await writeTextFile(
-            join(context.projectDir, "app", "layout.tsx"),
-            `export default function RootLayout({ children }: { children: React.ReactNode }) {
+  await mkdir(join(projectDir, "app"), { recursive: true });
+  await writeTextFile(
+    join(projectDir, "app", "layout.tsx"),
+    `export default function RootLayout({ children }: { children: React.ReactNode }) {
             return <html><body>{children}</body></html>;
           }`,
-          );
-          await writeTextFile(
-            join(context.projectDir, "app", "page.tsx"),
-            `"use client";
+  );
+  await writeTextFile(
+    join(projectDir, "app", "page.tsx"),
+    `"use client";
 import { useEffect, useState } from "react";
 
 export default function Page() {
@@ -119,6 +73,102 @@ export default function Page() {
   );
 }
 `,
+  );
+}
+
+async function assertCounterHydration(
+  page: import("npm:playwright").Page,
+  options: { expectedStrategy: string; expectedModulePath: string },
+): Promise<void> {
+  await page.waitForSelector('#counter[data-hydrated="yes"]');
+
+  const initialText = await page.textContent("#counter");
+  assertEquals(initialText?.trim(), "Count: 0");
+
+  const hydrationData = JSON.parse(
+    (await page.textContent("#veryfront-hydration-data")) ?? "{}",
+  ) as { clientModuleStrategy?: string; pagePath?: string };
+  assertEquals(hydrationData.clientModuleStrategy, options.expectedStrategy);
+  assertEquals(hydrationData.pagePath, "app/page.tsx");
+
+  await page.click("#counter");
+  await page.waitForFunction(
+    () => document.querySelector("#counter")?.textContent?.trim() === "Count: 1",
+  );
+
+  const hydratedText = await page.textContent("#counter");
+  assertEquals(hydratedText?.trim(), "Count: 1");
+
+  const resources = await page.evaluate(() =>
+    performance.getEntriesByType("resource").map((entry) => entry.name)
+  );
+  assertEquals(
+    resources.some((name) => name.includes(options.expectedModulePath)),
+    true,
+  );
+}
+
+describe(
+  "RSC Hydration Browser Tests",
+  { sanitizeOps: false, sanitizeResources: false },
+  () => {
+    afterAll(async () => {
+      await cleanupBundler();
+    });
+
+    it("hydrates a local-production client page and becomes interactive", async () => {
+      const browser = await launchChromium();
+      if (!browser) return;
+
+      try {
+        await withTestContext("rsc-local-browser-hydration", async (context) => {
+          await writeClientCounterApp(
+            context.projectDir,
+            `export default { experimental: { rsc: true } };`,
+          );
+
+          const server = await context.createProductionServer({ hostname: "127.0.0.1" });
+          const browserContext = await browser.newContext();
+          const page = await browserContext.newPage();
+          const { consoleErrors, pageErrors } = collectBrowserErrors(page);
+
+          try {
+            const response = await page.goto(`http://127.0.0.1:${server.port}/`);
+            assertEquals(response?.status(), 200);
+
+            await assertCounterHydration(page, {
+              expectedStrategy: "fs",
+              expectedModulePath: "/_veryfront/fs/",
+            });
+
+            const hydrationErrors = getHydrationErrors([...consoleErrors, ...pageErrors]);
+            assertEquals(hydrationErrors.length, 0);
+          } finally {
+            await browserContext.close();
+          }
+        });
+      } finally {
+        await browser.close();
+      }
+    });
+
+    it("hydrates a remote-production client page and becomes interactive", async () => {
+      const browser = await launchChromium();
+      if (!browser) return;
+
+      try {
+        await withTestContext("rsc-proxy-browser-hydration", async (context) => {
+          await writeClientCounterApp(
+            context.projectDir,
+            `export default {
+            experimental: { rsc: true },
+            fs: {
+              veryfront: {
+                proxyMode: true,
+                apiBaseUrl: "https://api.veryfront.com"
+              }
+            }
+          };`,
           );
 
           const port = await context.allocatePort();
@@ -142,38 +192,16 @@ export default function Page() {
             },
           });
           const page = await browserContext.newPage();
-          const consoleErrors: string[] = [];
-          const pageErrors: string[] = [];
-
-          page.on("console", (message) => {
-            if (message.type() === "error") consoleErrors.push(message.text());
-          });
-          page.on("pageerror", (error) => {
-            pageErrors.push(error.message);
-          });
+          const { consoleErrors, pageErrors } = collectBrowserErrors(page);
 
           try {
             const response = await page.goto(`http://127.0.0.1:${port}/`);
             assertEquals(response?.status(), 200);
 
-            await page.waitForSelector('#counter[data-hydrated="yes"]');
-
-            const initialText = await page.textContent("#counter");
-            assertEquals(initialText?.trim(), "Count: 0");
-
-            const hydrationData = JSON.parse(
-              (await page.textContent("#veryfront-hydration-data")) ?? "{}",
-            ) as { clientModuleStrategy?: string; pagePath?: string };
-            assertEquals(hydrationData.clientModuleStrategy, "rsc-module");
-            assertEquals(hydrationData.pagePath, "app/page.tsx");
-
-            await page.click("#counter");
-            await page.waitForFunction(
-              () => document.querySelector("#counter")?.textContent?.trim() === "Count: 1",
-            );
-
-            const hydratedText = await page.textContent("#counter");
-            assertEquals(hydratedText?.trim(), "Count: 1");
+            await assertCounterHydration(page, {
+              expectedStrategy: "rsc-module",
+              expectedModulePath: "/_veryfront/rsc/module?",
+            });
 
             const hydrationErrors = getHydrationErrors([...consoleErrors, ...pageErrors]);
             assertEquals(hydrationErrors.length, 0);

--- a/tests/integration/compiled-binary-e2e.test.ts
+++ b/tests/integration/compiled-binary-e2e.test.ts
@@ -24,6 +24,11 @@ import { afterAll, beforeAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { exists } from "#veryfront/platform/compat/fs.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { load as loadEnv } from "#veryfront/platform/compat/std/dotenv.ts";
+import {
+  collectBrowserErrors,
+  getHydrationErrors,
+  launchChromium,
+} from "../_helpers/playwright.ts";
 import { withProxyModeControlPlaneKey } from "../_helpers/proxy-mode.ts";
 
 // Load .env file for test configuration (VERYFRONT_BINARY_FRESH, etc.)
@@ -1709,6 +1714,128 @@ export default function ClientPage() {
       );
       assertEquals(errors.length, 0, "Should have no React errors");
     });
+  });
+
+  it("should hydrate app-router client pages interactively in the compiled binary", async () => {
+    const browser = await launchChromium();
+    if (!browser) return;
+
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-e2e-binary-browser-hydration-" });
+
+    await Deno.writeTextFile(
+      join(projectDir, "package.json"),
+      JSON.stringify(
+        {
+          name: "test-binary-browser-hydration",
+          type: "module",
+          dependencies: { react: "^19.0.0", "react-dom": "^19.0.0" },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await Deno.writeTextFile(
+      join(projectDir, "veryfront.config.ts"),
+      `export default {
+  fs: { type: "local" },
+  experimental: { rsc: true }
+};`,
+    );
+
+    await Deno.mkdir(join(projectDir, "app"), { recursive: true });
+    await Deno.writeTextFile(
+      join(projectDir, "app", "layout.tsx"),
+      `export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return <html><body>{children}</body></html>;
+}
+`,
+    );
+    await Deno.writeTextFile(
+      join(projectDir, "app", "page.tsx"),
+      `
+"use client";
+import { useEffect, useState } from "react";
+
+export default function ClientPage() {
+  const [count, setCount] = useState(0);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  return (
+    <button
+      id="counter"
+      data-hydrated={hydrated ? "yes" : "no"}
+      onClick={() => setCount((value) => value + 1)}
+    >
+      Count: {count}
+    </button>
+  );
+}
+`,
+    );
+
+    try {
+      await withServer(projectDir, async (server) => {
+        const browserContext = await browser.newContext();
+        const page = await browserContext.newPage();
+        const { consoleErrors, pageErrors } = collectBrowserErrors(page);
+
+        try {
+          const response = await page.goto(`http://127.0.0.1:${server.port}/`);
+          assertEquals(response?.status(), 200, "Should return 200");
+
+          await page.waitForSelector('#counter[data-hydrated="yes"]');
+
+          const initialText = await page.textContent("#counter");
+          assertEquals(initialText?.trim(), "Count: 0");
+
+          const hydrationData = JSON.parse(
+            (await page.textContent("#veryfront-hydration-data")) ?? "{}",
+          ) as { clientModuleStrategy?: string; pagePath?: string };
+          assertEquals(hydrationData.clientModuleStrategy, "fs");
+          assertEquals(hydrationData.pagePath, "app/page.tsx");
+
+          await page.click("#counter");
+          await page.waitForFunction(
+            () => document.querySelector("#counter")?.textContent?.trim() === "Count: 1",
+          );
+
+          const hydratedText = await page.textContent("#counter");
+          assertEquals(hydratedText?.trim(), "Count: 1");
+
+          const hydrationErrors = getHydrationErrors([...consoleErrors, ...pageErrors]);
+          assertEquals(
+            hydrationErrors.length,
+            0,
+            `Unexpected hydration errors: ${hydrationErrors.join("\n")}`,
+          );
+
+          const resources = await page.evaluate(() =>
+            performance.getEntriesByType("resource").map((entry) => entry.name)
+          );
+          assertEquals(resources.some((name) => name.includes("/_veryfront/fs/")), true);
+
+          const serverErrors = server.logs.filter((line) =>
+            line.includes("Invalid hook call") ||
+            line.includes("more than one copy of React") ||
+            line.includes("Page hydration failed")
+          );
+          assertEquals(
+            serverErrors.length,
+            0,
+            `Unexpected server errors: ${serverErrors.join("\n")}`,
+          );
+        } finally {
+          await browserContext.close();
+        }
+      });
+    } finally {
+      await browser.close();
+    }
   });
 
   // Test: Multiple pages accessing same framework import


### PR DESCRIPTION
## Summary
- add shared Playwright helpers for browser-backed hydration assertions
- extend RSC hydration coverage across local production, remote-production proxy, and compiled binary paths
- install Chromium in the binary e2e CI lane and bump the framework version to 0.1.120

## Testing
- deno check tests/_helpers/playwright.ts tests/e2e/regressions/rsc-proxy-hydration.test.ts tests/integration/compiled-binary-e2e.test.ts
- deno test --no-check --allow-all tests/e2e/regressions/rsc-proxy-hydration.test.ts --unstable-worker-options --unstable-net
- VERYFRONT_BINARY_FRESH=1 deno test --allow-all tests/integration/compiled-binary-e2e.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/modules/server/module-server.test.ts