### PR TITLE
Fix browser HTML sanitizer CSP import leak

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/security/client/html-sanitizer.ts
+++ b/src/security/client/html-sanitizer.ts
@@ -8,7 +8,7 @@
  */
 
 import { escapeHtml } from "#veryfront/html/html-escape.ts";
-import { SECURITY_VIOLATION } from "#veryfront/errors";
+import { SECURITY_VIOLATION } from "#veryfront/errors/error-registry.ts";
 
 export { escapeHtml };
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.120";
+export const VERSION = "0.1.121";

--- a/tests/integration/server/dev-server-handlers.test.ts
+++ b/tests/integration/server/dev-server-handlers.test.ts
@@ -381,11 +381,17 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
       await withTestContext("dev-server-framework-chat-error-csp", async (context) => {
         const { server, port } = await createTestDevServer(context);
         const modulePaths = [
+          "/_vf_modules/_veryfront/chat/index.js",
           "/_vf_modules/_veryfront/react/components/ai/color-mode.js",
+          "/_vf_modules/_veryfront/react/components/ai/chat.js",
           "/_vf_modules/_veryfront/react/components/ai/chat/contexts/chat-context.js",
           "/_vf_modules/_veryfront/react/components/ai/chat/contexts/composer-context.js",
           "/_vf_modules/_veryfront/react/components/ai/chat/contexts/message-context.js",
           "/_vf_modules/_veryfront/react/components/ai/chat/contexts/thread-list-context.js",
+          "/_vf_modules/_veryfront/react/components/ai/markdown.js",
+          "/_vf_modules/_veryfront/security/client/html-sanitizer.js",
+          "/_vf_modules/_veryfront/rendering/rsc/client-boot.js",
+          "/_vf_modules/_veryfront/rendering/rsc/client-dom.js",
           "/_vf_modules/_veryfront/routing/client/page-loader.js",
           "/_vf_modules/_veryfront/rendering/rsc/client-hydrator.js",
           "/_vf_modules/_veryfront/client/spa/ClientApp.js",


### PR DESCRIPTION
## Summary
- switch the browser HTML sanitizer to import `SECURITY_VIOLATION` from the narrow error registry instead of the heavyweight `#veryfront/errors` barrel
- extend dev-server browser module coverage to include chat, markdown, RSC client, and html-sanitizer modules so CSP-unsafe transitive imports are caught directly
- bump the framework patch version to `0.1.121`

## Testing
- `deno check src/security/client/html-sanitizer.ts tests/integration/server/dev-server-handlers.test.ts src/utils/version-constant.ts`
- `deno test --no-check --allow-all src/security/client/html-sanitizer.test.ts src/utils/version.test.ts src/modules/server/module-server.test.ts`
- `deno test --no-check --allow-all tests/integration/server/dev-server-handlers.test.ts --unstable-worker-options --unstable-net`
- `git push` pre-push suite (format, lint, typecheck, unit tests)