### PR TITLE
Add pages-router strict CSP hydration coverage

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/security/http/response/security-handler.test.ts
+++ b/src/security/http/response/security-handler.test.ts
@@ -398,6 +398,16 @@ describe("security/http/response/security-handler", () => {
       );
     });
 
+    it("default CSP should allow esm.sh scripts for browser ESM hydration", () => {
+      const headers = new Headers();
+      applySecurityHeaders(headers, false, "nonce", null);
+      const csp = headers.get("Content-Security-Policy")!;
+      assert(
+        csp.includes("https://esm.sh"),
+        "should allow esm.sh for the pages-router/browser ESM hydration path",
+      );
+    });
+
     it("default CSP should allow veryfront CDN styles and fonts", () => {
       const headers = new Headers();
       applySecurityHeaders(headers, false, "nonce", null);
@@ -494,6 +504,22 @@ describe("security/http/response/security-handler", () => {
       assert(
         !styleSrc.includes("cdn.jsdelivr.net"),
         "jsdelivr should NOT be in style-src",
+      );
+    });
+
+    it("default CSP should place esm.sh in script-src not style-src", () => {
+      const headers = new Headers();
+      applySecurityHeaders(headers, false, "nonce", null);
+      const csp = headers.get("Content-Security-Policy")!;
+      const scriptSrc = csp.split(";").find((d) => d.trim().startsWith("script-src"))!;
+      const styleSrc = csp.split(";").find((d) => d.trim().startsWith("style-src"))!;
+      assert(
+        scriptSrc.includes("https://esm.sh"),
+        "esm.sh should be in script-src",
+      );
+      assert(
+        !styleSrc.includes("https://esm.sh"),
+        "esm.sh should NOT be in style-src",
       );
     });
 

--- a/src/security/http/response/security-handler.ts
+++ b/src/security/http/response/security-handler.ts
@@ -17,8 +17,8 @@ export function generateNonce(): string {
 /**
  * Build a default CSP that works for typical veryfront apps.
  *
- * - Scripts: nonce-based + cdn.jsdelivr.net (Scalar API docs, html2canvas,
- *   React UMD, browser inference)
+ * - Scripts: nonce-based + cdn.jsdelivr.net + esm.sh (Scalar API docs,
+ *   html2canvas, legacy/browser ESM hydration)
  * - Styles: 'self' + 'unsafe-inline' + nonce + Google Fonts + cdn.veryfront.com
  *   plus style-src-attr 'unsafe-inline' so React style="" attributes remain
  *   compatible while inline <style> tags continue to use the nonce
@@ -33,7 +33,7 @@ export function generateNonce(): string {
 function buildDefaultCSP(nonce: string): string {
   return [
     `default-src 'self'`,
-    `script-src 'self' 'nonce-${nonce}' https://cdn.jsdelivr.net`,
+    `script-src 'self' 'nonce-${nonce}' https://cdn.jsdelivr.net https://esm.sh`,
     `style-src 'self' 'unsafe-inline' 'nonce-${nonce}' https://fonts.googleapis.com https://cdn.veryfront.com`,
     `style-src-attr 'unsafe-inline'`,
     `img-src 'self' data: https:`,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.121";
+export const VERSION = "0.1.122";

--- a/tests/_helpers/playwright.ts
+++ b/tests/_helpers/playwright.ts
@@ -41,6 +41,9 @@ export function getHydrationErrors(messages: string[]): string[] {
     message.includes("unsafe-eval") ||
     message.includes("Failed to fetch dynamically imported module") ||
     message.includes("WebAssembly.compile()") ||
+    message.includes("Content Security Policy") ||
+    message.includes("violates the following Content Security Policy directive") ||
+    message.includes("Refused to load the script") ||
     message.includes("Hydration")
   );
 }

--- a/tests/integration/compiled-binary-e2e.test.ts
+++ b/tests/integration/compiled-binary-e2e.test.ts
@@ -1838,6 +1838,91 @@ export default function ClientPage() {
     }
   });
 
+  it("should hydrate pages-router client pages under strict CSP in the compiled binary", async () => {
+    const browser = await launchChromium();
+    if (!browser) return;
+
+    const projectDir = await createTestProject(
+      "pages-browser-csp-hydration",
+      `
+import { useEffect, useState } from "react";
+
+export default function HomePage() {
+  const [count, setCount] = useState(0);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  return (
+    <button
+      id="counter"
+      data-hydrated={hydrated ? "yes" : "no"}
+      onClick={() => setCount((value) => value + 1)}
+    >
+      Count: {count}
+    </button>
+  );
+}
+`,
+    );
+
+    try {
+      await withServer(projectDir, async (server) => {
+        const browserContext = await browser.newContext();
+        const page = await browserContext.newPage();
+        const { consoleErrors, pageErrors } = collectBrowserErrors(page);
+
+        try {
+          const response = await page.goto(`http://127.0.0.1:${server.port}/`);
+          assertEquals(response?.status(), 200, "Should return 200");
+
+          const csp = response?.headers()["content-security-policy"] ?? "";
+          assert(
+            csp.includes("https://esm.sh"),
+            `Expected CSP to allow esm.sh scripts, got: ${csp}`,
+          );
+
+          await page.waitForSelector('#counter[data-hydrated="yes"]');
+
+          const initialText = await page.textContent("#counter");
+          assertEquals(initialText?.trim(), "Count: 0");
+
+          await page.click("#counter");
+          await page.waitForFunction(
+            () => document.querySelector("#counter")?.textContent?.trim() === "Count: 1",
+          );
+
+          const hydratedText = await page.textContent("#counter");
+          assertEquals(hydratedText?.trim(), "Count: 1");
+
+          const hydrationErrors = getHydrationErrors([...consoleErrors, ...pageErrors]);
+          assertEquals(
+            hydrationErrors.length,
+            0,
+            `Unexpected hydration/CSP errors: ${hydrationErrors.join("\n")}`,
+          );
+
+          const serverErrors = server.logs.filter((line) =>
+            line.includes("Page hydration failed") ||
+            line.includes("Refused to load the script") ||
+            line.includes("violates the following Content Security Policy directive")
+          );
+          assertEquals(
+            serverErrors.length,
+            0,
+            `Unexpected server/browser CSP errors: ${serverErrors.join("\n")}`,
+          );
+        } finally {
+          await browserContext.close();
+        }
+      });
+    } finally {
+      await browser.close();
+    }
+  });
+
   // Test: Multiple pages accessing same framework import
   it("should handle multiple pages with same framework imports", async () => {
     const projectDir = await createTestProject(


### PR DESCRIPTION
## Summary
- allow `https://esm.sh` in the default CSP `script-src` for browser ESM hydration
- add CSP header assertions for the new `esm.sh` allowance
- add a compiled-binary browser regression for pages-router client hydration under strict CSP
- bump version to `0.1.122`

## Verification
- `deno check src/security/http/response/security-handler.ts src/security/http/response/security-handler.test.ts tests/_helpers/playwright.ts tests/integration/compiled-binary-e2e.test.ts`
- `deno test --no-check --allow-all src/security/http/response/security-handler.test.ts`
- `deno test --no-check --allow-all tests/integration/compiled-binary-e2e.test.ts`
- `deno test --no-check --allow-all src/utils/version.test.ts src/modules/server/module-server.test.ts`
- `git push` pre-push suite passed: format, lint, typecheck, and unit tests