### PR TITLE
Harden HMR forwarded host resolution

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.122",
+  "version": "0.1.123",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/server/context/request-context.ts
+++ b/src/server/context/request-context.ts
@@ -1,5 +1,6 @@
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { parseProjectDomain } from "../utils/domain-parser.ts";
+import { getEffectiveRequestHost } from "../utils/request-host.ts";
 
 export interface RequestContext {
   token: string;
@@ -9,17 +10,7 @@ export interface RequestContext {
 }
 
 export function createRequestContext(req: Request): RequestContext {
-  const { hostname } = new URL(req.url);
-  const rawForwardedHost = req.headers.get("x-forwarded-host");
-  // x-forwarded-host can be comma-separated (multiple proxies); take the first entry.
-  const forwardedHost = rawForwardedHost
-    ? (rawForwardedHost.split(",")[0]?.trim() || undefined)
-    : undefined;
-  const hostHeader = req.headers.get("host");
-
-  // In proxy mode, req.url hostname may be 127.0.0.1 while the real domain
-  // is in the Host header (e.g., "flow-ops.lvh.me:3010"). Prefer Host header.
-  const effectiveHost = forwardedHost ?? hostHeader ?? hostname;
+  const effectiveHost = getEffectiveRequestHost(req);
   const parsed = parseProjectDomain(effectiveHost);
   const headerProjectSlug = req.headers.get("x-project-slug")?.trim() || undefined;
 

--- a/src/server/handlers/dev/projects/api.ts
+++ b/src/server/handlers/dev/projects/api.ts
@@ -1,4 +1,5 @@
 import type { HandlerContext } from "../../types.ts";
+import { getEffectiveRequestHost } from "../../../utils/request-host.ts";
 
 const JSON_HEADERS = {
   "Content-Type": "application/json",
@@ -20,11 +21,7 @@ export function handleProjectsAPI(req: Request, ctx: HandlerContext): Response |
 
 function handleGetConfig(req: Request, ctx: HandlerContext): Response {
   const url = new URL(req.url);
-
-  const host = req.headers.get("x-forwarded-host") ??
-    req.headers.get("host") ??
-    url.host ??
-    "lvh.me";
+  const host = getEffectiveRequestHost(req, url) || "lvh.me";
 
   const hostWithoutPort = host.replace(/:\d+$/, "") || "lvh.me";
   const port = host.includes(":") ? host.split(":")[1] ?? "" : "";

--- a/src/server/handlers/preview/hmr.handler.test.ts
+++ b/src/server/handlers/preview/hmr.handler.test.ts
@@ -61,7 +61,7 @@ describe("server/handlers/preview/hmr.handler", () => {
       const handler = new HMRHandler();
       assertEquals(
         typeof handler.metadata.enabled === "function"
-          ? handler.metadata.enabled()
+          ? handler.metadata.enabled(makeCtx())
           : handler.metadata.enabled,
         true,
       );
@@ -171,6 +171,38 @@ describe("server/handlers/preview/hmr.handler", () => {
       });
       const result = await handler.handle(req, ctx);
       assertEquals(result.continue, false);
+    });
+
+    it("proceeds when x-forwarded-host is a local preview host", async () => {
+      const handler = new HMRHandler();
+      const req = new Request("http://example.com/_ws", {
+        headers: {
+          host: "internal.proxy:3000",
+          "x-forwarded-host": "preview.veryfront.me:3000",
+        },
+      });
+      const ctx = makeCtx({
+        isLocalProject: false,
+        adapter: createMockAdapter({ upgradeWebSocket: undefined }),
+      });
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, false);
+    });
+
+    it("continues when x-forwarded-host is external even if host header is localhost", async () => {
+      const handler = new HMRHandler();
+      const req = new Request("http://example.com/_ws", {
+        headers: {
+          host: "localhost:3000",
+          "x-forwarded-host": "evil.example.com",
+        },
+      });
+      const ctx = makeCtx({
+        isLocalProject: false,
+        requestContext: { mode: "production" } as any,
+      });
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, true);
     });
   });
 

--- a/src/server/handlers/preview/hmr.handler.ts
+++ b/src/server/handlers/preview/hmr.handler.ts
@@ -27,6 +27,7 @@ import {
 } from "./hmr-client-manager.ts";
 import { getPingIntervalMs, startPingInterval, stopPingInterval } from "./hmr-ping-keepalive.ts";
 import { broadcastUpdate, getMetrics } from "./hmr-message-router.ts";
+import { getEffectiveRequestHost } from "../../utils/request-host.ts";
 
 const logger = serverLogger.component("hmr-handler");
 
@@ -94,7 +95,7 @@ export class HMRHandler extends BaseHandler {
     const queryEnv = url.searchParams.get("x-environment");
     const isPreviewMode = ctx.requestContext?.mode === "preview" || queryEnv === "preview";
     const isLocal = !!ctx.isLocalProject;
-    const host = req.headers.get("host") ?? "";
+    const host = getEffectiveRequestHost(req, url);
     const isLocalhost = isLocalDevHost(host);
 
     if (!isPreviewMode && !isLocal && !isLocalhost) {

--- a/src/server/runtime-handler/project-resolution.ts
+++ b/src/server/runtime-handler/project-resolution.ts
@@ -17,6 +17,7 @@ import { getEnvironmentType, lookupProjectByDomain } from "../utils/domain-looku
 import { parseProxyEnvironment, type ProxyEnvironment } from "./proxy-environment.ts";
 import { SpanNames, withSpan } from "./tracing.ts";
 import { isInternalHost } from "./request-utils.ts";
+import { getEffectiveRequestHost } from "../utils/request-host.ts";
 
 const baseLogger = getBaseLogger("SERVER");
 
@@ -71,17 +72,8 @@ interface RequestHeaders {
   projectPath: string | undefined;
 }
 
-function parseForwardedHost(raw: string | null): string | undefined {
-  if (!raw) return undefined;
-  // x-forwarded-host can be a comma-separated list when multiple proxies
-  // are chained. Take the first (client-facing) entry and trim whitespace.
-  const first = raw.split(",")[0]?.trim();
-  return first || undefined;
-}
-
 function getEffectiveHost(req: Request, url: URL): string {
-  const forwardedHost = parseForwardedHost(req.headers.get("x-forwarded-host"));
-  return forwardedHost ?? req.headers.get("host") ?? url.host;
+  return getEffectiveRequestHost(req, url);
 }
 
 /**

--- a/src/server/utils/request-host.test.ts
+++ b/src/server/utils/request-host.test.ts
@@ -1,0 +1,54 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { getEffectiveRequestHost, parseForwardedHost } from "./request-host.ts";
+
+describe("server/utils/request-host", () => {
+  describe("parseForwardedHost", () => {
+    it("returns undefined for null or empty values", () => {
+      assertEquals(parseForwardedHost(null), undefined);
+      assertEquals(parseForwardedHost(""), undefined);
+      assertEquals(parseForwardedHost("   "), undefined);
+    });
+
+    it("returns the first forwarded host entry", () => {
+      assertEquals(
+        parseForwardedHost("preview.veryfront.me:3000, proxy.internal"),
+        "preview.veryfront.me:3000",
+      );
+    });
+
+    it("trims surrounding whitespace from the selected entry", () => {
+      assertEquals(
+        parseForwardedHost("  preview.veryfront.me:3000  , proxy.internal"),
+        "preview.veryfront.me:3000",
+      );
+    });
+  });
+
+  describe("getEffectiveRequestHost", () => {
+    it("prefers x-forwarded-host over host and url host", () => {
+      const req = new Request("http://127.0.0.1:3000/test", {
+        headers: {
+          "x-forwarded-host": "preview.veryfront.me:3000, proxy.internal",
+          "host": "localhost:3000",
+        },
+      });
+
+      assertEquals(getEffectiveRequestHost(req), "preview.veryfront.me:3000");
+    });
+
+    it("falls back to host when x-forwarded-host is absent", () => {
+      const req = new Request("http://127.0.0.1:3000/test", {
+        headers: { "host": "localhost:3000" },
+      });
+
+      assertEquals(getEffectiveRequestHost(req), "localhost:3000");
+    });
+
+    it("falls back to request url host when no forwarded or host headers exist", () => {
+      const req = new Request("http://preview.veryfront.me:3000/test");
+
+      assertEquals(getEffectiveRequestHost(req), "preview.veryfront.me:3000");
+    });
+  });
+});

--- a/src/server/utils/request-host.ts
+++ b/src/server/utils/request-host.ts
@@ -1,0 +1,12 @@
+export function parseForwardedHost(raw: string | null): string | undefined {
+  if (!raw) return undefined;
+
+  const first = raw.split(",")[0]?.trim();
+  return first || undefined;
+}
+
+export function getEffectiveRequestHost(req: Request, url?: URL): string {
+  return parseForwardedHost(req.headers.get("x-forwarded-host")) ??
+    req.headers.get("host") ??
+    (url ?? new URL(req.url)).host;
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.122";
+export const VERSION = "0.1.123";

--- a/tests/integration/server/modules/hmr-handler.test.ts
+++ b/tests/integration/server/modules/hmr-handler.test.ts
@@ -105,7 +105,7 @@ describe("HMR Handler Tests", { sanitizeOps: false, sanitizeResources: false }, 
     it("handle returns continue for non-preview/non-localdev requests", async () => {
       const handler = new HMRHandler();
 
-      const req = new Request("http://localhost:3000/_ws");
+      const req = new Request("http://production.example.com/_ws");
       const ctx = {
         requestContext: { mode: "production" },
         projectDir: "/tmp/test",
@@ -198,6 +198,52 @@ describe("HMR Handler Tests", { sanitizeOps: false, sanitizeResources: false }, 
 
       assertExists(result.response);
       assertEquals(result.response.status, 200);
+    });
+
+    it("prefers x-forwarded-host over host when allowing local preview traffic", async () => {
+      const handler = new HMRHandler();
+
+      const req = new Request("http://localhost:3000/_ws", {
+        headers: {
+          host: "internal.proxy:3000",
+          "x-forwarded-host": "preview.veryfront.me:3000",
+        },
+      });
+      const ctx = {
+        requestContext: { mode: "production" },
+        projectDir: "/tmp/test",
+        securityConfig: null,
+        cspUserHeader: null,
+        adapter: { fs: {}, server: null },
+      } as unknown as Parameters<typeof handler.handle>[1];
+
+      const result = await handler.handle(req, ctx);
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 200);
+    });
+
+    it("rejects localhost host-header bypass when x-forwarded-host is external", async () => {
+      const handler = new HMRHandler();
+
+      const req = new Request("http://localhost:3000/_ws", {
+        headers: {
+          host: "localhost:3000",
+          "x-forwarded-host": "evil.example.com",
+        },
+      });
+      const ctx = {
+        requestContext: { mode: "production" },
+        projectDir: "/tmp/test",
+        securityConfig: null,
+        cspUserHeader: null,
+        adapter: { fs: {}, server: null },
+      } as unknown as Parameters<typeof handler.handle>[1];
+
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
     });
 
     it("handle accepts preview via query param (for proxy WebSocket)", async () => {
@@ -389,7 +435,7 @@ describe("HMR Handler Tests", { sanitizeOps: false, sanitizeResources: false }, 
 
       const unregisterExternalSource = HMRHandler.registerExternalBroadcastSource();
       const unsubscribeExternalReload = ReloadNotifier.subscribe((changedPaths, project) => {
-        broadcastUpdate(changedPaths, project?.projectSlug);
+        broadcastUpdate(changedPaths, project);
       });
 
       try {


### PR DESCRIPTION
## Summary
- centralize effective request host resolution so forwarded hosts are parsed consistently
- make the HMR host gate trust x-forwarded-host before Host/URL host
- add regressions for forwarded-host precedence and localhost bypass attempts
- bump the release version to 0.1.123

## Testing
- deno check src/server/utils/request-host.ts src/server/utils/request-host.test.ts src/server/context/request-context.ts src/server/runtime-handler/project-resolution.ts src/server/handlers/dev/projects/api.ts src/server/handlers/preview/hmr.handler.ts src/server/handlers/preview/hmr.handler.test.ts tests/integration/server/modules/hmr-handler.test.ts
- deno test --no-check --allow-all src/server/utils/request-host.test.ts src/server/context/request-context.test.ts src/server/runtime-handler/project-resolution.test.ts src/server/handlers/preview/hmr.handler.test.ts tests/integration/server/modules/hmr-handler.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/modules/server/module-server.test.ts
- git push (pre-push format, lint, typecheck, unit tests)