### PR TITLE
Add proxy header guard coverage

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.123",
+  "version": "0.1.124",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/proxy/mode-parity.test.ts
+++ b/src/proxy/mode-parity.test.ts
@@ -7,7 +7,12 @@
  */
 import { assertEquals } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
-import { createProxyHandler, injectContextHeaders, type ProxyContext } from "./handler.ts";
+import {
+  createProxyHandler,
+  injectContextHeaders,
+  INTERNAL_PROXY_HEADERS,
+  type ProxyContext,
+} from "./handler.ts";
 import { createMockServer } from "../../tests/_helpers/utils.ts";
 
 function extractProxyHeaders(req: Request): Record<string, string | null> {
@@ -15,6 +20,7 @@ function extractProxyHeaders(req: Request): Record<string, string | null> {
     "x-token": req.headers.get("x-token"),
     "x-project-slug": req.headers.get("x-project-slug"),
     "x-environment": req.headers.get("x-environment"),
+    "x-environment-id": req.headers.get("x-environment-id"),
     "x-content-source-id": req.headers.get("x-content-source-id"),
     "x-forwarded-host": req.headers.get("x-forwarded-host"),
     "x-project-path": req.headers.get("x-project-path"),
@@ -207,6 +213,57 @@ describe("Proxy-Renderer Mode Parity", () => {
       assertEquals(injected.headers.get("x-project-path"), null);
       assertEquals(injected.headers.get("x-token"), null);
       assertEquals(injected.headers.get("x-environment"), "preview");
+    });
+
+    it("replaces every internal proxy header with proxy-derived values", () => {
+      const ctx: ProxyContext = {
+        token: "proxy-token",
+        projectSlug: "proj",
+        projectId: "proj-id",
+        releaseId: "rel-id",
+        branchId: "branch-id",
+        branchName: "feature-branch",
+        environmentId: "env-id",
+        environment: "production",
+        contentSourceId: "release-rel-id",
+        host: "proj.production.veryfront.com",
+        parsedDomain: {
+          slug: "proj",
+          isVeryfrontDomain: true,
+          environment: "production",
+          branch: null,
+          isDraft: false,
+          allowIframeEmbed: true,
+        },
+        isLocalProject: false,
+      };
+
+      const attackerHeaders = Object.fromEntries(
+        INTERNAL_PROXY_HEADERS.map((header) => [header, `attacker-${header}`]),
+      );
+
+      const originalReq = new Request("http://proj.production.veryfront.com/page", {
+        headers: {
+          ...attackerHeaders,
+          accept: "text/html",
+        },
+      });
+
+      const injected = injectContextHeaders(originalReq, ctx);
+      const headers = extractProxyHeaders(injected);
+
+      assertEquals(headers["x-token"], "proxy-token");
+      assertEquals(headers["x-project-slug"], "proj");
+      assertEquals(headers["x-environment"], "production");
+      assertEquals(headers["x-environment-id"], "env-id");
+      assertEquals(headers["x-content-source-id"], "release-rel-id");
+      assertEquals(headers["x-forwarded-host"], "proj.production.veryfront.com");
+      assertEquals(headers["x-project-path"], null);
+      assertEquals(headers["x-project-id"], "proj-id");
+      assertEquals(headers["x-release-id"], "rel-id");
+      assertEquals(headers["x-branch-id"], "branch-id");
+      assertEquals(headers["x-branch-name"], "feature-branch");
+      assertEquals(injected.headers.get("accept"), "text/html");
     });
   });
 

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -1,0 +1,106 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { HMRHandler } from "../handlers/preview/hmr.handler.ts";
+import { createVeryfrontHandler } from "./index.ts";
+import { __injectDepsForTests as injectIsolationDepsForTests } from "./isolation.ts";
+
+function createMockAdapter(): RuntimeAdapter {
+  return {
+    id: "test",
+    name: "test",
+    capabilities: {},
+    fs: {} as RuntimeAdapter["fs"],
+    env: {
+      get: (_key: string) => undefined,
+      set: () => {},
+      delete: () => {},
+      has: () => false,
+      toObject: () => ({}),
+    },
+    server: {} as RuntimeAdapter["server"],
+    serve: () => Promise.resolve({ close: () => Promise.resolve() }),
+  } as unknown as RuntimeAdapter;
+}
+
+function createProxyModeHandler() {
+  injectIsolationDepsForTests({
+    checkRequest: () => ({ allowed: true }),
+    startRequest: () => {},
+    completeRequest: () => {},
+  });
+
+  return createVeryfrontHandler("/tmp/test-project", createMockAdapter(), {
+    projectDir: "/tmp/test-project",
+    config: {
+      fs: { veryfront: { proxyMode: true } },
+    } as any,
+  });
+}
+
+describe("server/runtime-handler/index", () => {
+  afterEach(() => {
+    injectIsolationDepsForTests(null);
+    HMRHandler.shutdown();
+  });
+
+  it("returns 502 when x-project-slug is missing in proxy mode", async () => {
+    const handler = createProxyModeHandler();
+
+    const response = await handler(
+      new Request("http://localhost/page", {
+        headers: { "x-token": "proxy-token" },
+      }),
+    );
+
+    assertEquals(response.status, 502);
+    assertEquals(response.headers.get("Content-Type"), "application/json");
+    assertEquals(await response.json(), {
+      error: "Missing project context",
+      detail: "x-project-slug header is required in proxy mode",
+    });
+  });
+
+  it("returns 502 when x-token is missing in proxy mode", async () => {
+    const handler = createProxyModeHandler();
+
+    const response = await handler(
+      new Request("http://localhost/page", {
+        headers: { "x-project-slug": "my-project" },
+      }),
+    );
+
+    assertEquals(response.status, 502);
+    assertEquals(response.headers.get("Content-Type"), "application/json");
+    assertEquals(await response.json(), {
+      error: "Missing authentication context",
+      detail: "x-token header is required in proxy mode",
+    });
+  });
+
+  it("skips the proxy header guard for websocket requests", async () => {
+    const handler = createProxyModeHandler();
+
+    const response = await handler(
+      new Request(
+        "http://localhost/_ws?x-environment=preview&x-project-slug=test-project",
+      ),
+    );
+
+    assertEquals(response.status, 200);
+    const body = await response.json();
+    assertEquals(body.status, "ok");
+    assertExists(body.metrics);
+  });
+
+  it("skips the proxy header guard for lightweight module requests", async () => {
+    const handler = createProxyModeHandler();
+
+    const response = await handler(new Request("http://localhost/_vf_modules/_dnt.shims.js"));
+
+    assertEquals(response.status === 502, false);
+    const body = await response.text();
+    assertEquals(body.includes("x-project-slug header is required in proxy mode"), false);
+    assertEquals(body.includes("x-token header is required in proxy mode"), false);
+  });
+});

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.123";
+export const VERSION = "0.1.124";


### PR DESCRIPTION
## Summary
- add proxy parity coverage proving every internal proxy header is stripped and replaced with proxy-derived values
- add direct runtime-handler tests for proxy-mode 502 guard behavior and the `/_ws` plus lightweight-path exemptions
- bump the release version to 0.1.124

## Notes
- this branch stacks on #809; once #809 merges, this PR diff will reduce to the proxy-side follow-up automatically

## Testing
- deno check src/proxy/mode-parity.test.ts src/server/runtime-handler/index.test.ts src/server/runtime-handler/index.ts
- deno test --no-check --allow-all src/proxy/mode-parity.test.ts src/server/runtime-handler/index.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/modules/server/module-server.test.ts
- git push (pre-push format, lint, typecheck, unit tests)