### PR TITLE
Fix inline style CSP under strict defaults

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.124",
+  "version": "0.1.126",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/security/http/response/security-handler.test.ts
+++ b/src/security/http/response/security-handler.test.ts
@@ -177,12 +177,13 @@ describe("security/http/response/security-handler", () => {
       assert(b.includes("'nonce-nonce-bbb'"), "second nonce embedded");
     });
 
-    it("default CSP should contain all 12 directives", () => {
+    it("default CSP should contain all 13 directives", () => {
       const result = buildCSP(false, "n", null);
       const directives = [
         "default-src",
         "script-src",
         "style-src",
+        "style-src-elem",
         "style-src-attr",
         "img-src",
         "font-src",
@@ -439,13 +440,18 @@ describe("security/http/response/security-handler", () => {
       );
     });
 
-    it("default CSP should include nonce in style-src for migration path", () => {
+    it("default CSP should allow inline styles without adding a style nonce", () => {
       const headers = new Headers();
       applySecurityHeaders(headers, false, "my-nonce", null);
       const csp = headers.get("Content-Security-Policy")!;
+      const styleSources = getDirectiveSources(csp, "style-src");
       assert(
-        csp.includes("style-src 'self' 'unsafe-inline' 'nonce-my-nonce'"),
-        "style-src should include both unsafe-inline and nonce for migration",
+        styleSources.includes("'unsafe-inline'"),
+        "style-src should keep unsafe-inline for framework and app inline styles",
+      );
+      assert(
+        !styleSources.some((source) => source.startsWith("'nonce-")),
+        "style-src should not include a nonce because that disables unsafe-inline in browsers",
       );
     });
 
@@ -453,9 +459,29 @@ describe("security/http/response/security-handler", () => {
       const headers = new Headers();
       applySecurityHeaders(headers, false, "my-nonce", null);
       const csp = headers.get("Content-Security-Policy")!;
+      const styleAttrSources = getDirectiveSources(csp, "style-src-attr");
       assert(
-        csp.includes("style-src-attr 'unsafe-inline'"),
+        styleAttrSources.includes("'unsafe-inline'"),
         "style-src-attr should explicitly allow React style attributes",
+      );
+    });
+
+    it("default CSP should scope style nonces to style-src-elem", () => {
+      const headers = new Headers();
+      applySecurityHeaders(headers, false, "my-nonce", null);
+      const csp = headers.get("Content-Security-Policy")!;
+      const styleElemSources = getDirectiveSources(csp, "style-src-elem");
+      assert(
+        styleElemSources.includes("'nonce-my-nonce'"),
+        "style-src-elem should carry the style nonce for inline style tags",
+      );
+      assert(
+        styleElemSources.includes("https://fonts.googleapis.com"),
+        "style-src-elem should keep Google Fonts",
+      );
+      assert(
+        styleElemSources.includes("https://cdn.veryfront.com"),
+        "style-src-elem should keep the Veryfront CDN",
       );
     });
 
@@ -544,19 +570,19 @@ describe("security/http/response/security-handler", () => {
       assert(fontSources.includes("https://cdn.veryfront.com"), "veryfront CDN in font-src");
     });
 
-    it("default CSP nonce should match across script-src and style-src", () => {
+    it("default CSP should keep the nonce on script-src but not on style-src", () => {
       const headers = new Headers();
       applySecurityHeaders(headers, false, "unique-nonce-123", null);
       const csp = headers.get("Content-Security-Policy")!;
-      const scriptSrc = csp.split(";").find((d) => d.trim().startsWith("script-src"))!;
-      const styleSrc = csp.split(";").find((d) => d.trim().startsWith("style-src"))!;
+      const scriptSources = getDirectiveSources(csp, "script-src");
+      const styleSources = getDirectiveSources(csp, "style-src");
       assert(
-        scriptSrc.includes("'nonce-unique-nonce-123'"),
+        scriptSources.includes("'nonce-unique-nonce-123'"),
         "script-src should have the nonce",
       );
       assert(
-        styleSrc.includes("'nonce-unique-nonce-123'"),
-        "style-src should have the same nonce",
+        !styleSources.includes("'nonce-unique-nonce-123'"),
+        "style-src should omit the nonce so unsafe-inline remains effective",
       );
     });
 

--- a/src/security/http/response/security-handler.test.ts
+++ b/src/security/http/response/security-handler.test.ts
@@ -471,17 +471,17 @@ describe("security/http/response/security-handler", () => {
       applySecurityHeaders(headers, false, "my-nonce", null);
       const csp = headers.get("Content-Security-Policy")!;
       const styleElemSources = getDirectiveSources(csp, "style-src-elem");
+      const remoteStyleElemSources = styleElemSources
+        .filter((source) => source.startsWith("https://"))
+        .sort();
       assert(
         styleElemSources.includes("'nonce-my-nonce'"),
         "style-src-elem should carry the style nonce for inline style tags",
       );
-      assert(
-        styleElemSources.includes("https://fonts.googleapis.com"),
-        "style-src-elem should keep Google Fonts",
-      );
-      assert(
-        styleElemSources.includes("https://cdn.veryfront.com"),
-        "style-src-elem should keep the Veryfront CDN",
+      assertEquals(
+        remoteStyleElemSources,
+        ["https://cdn.veryfront.com", "https://fonts.googleapis.com"],
+        "style-src-elem should keep the exact Google Fonts and Veryfront CDN hosts",
       );
     });
 

--- a/src/security/http/response/security-handler.ts
+++ b/src/security/http/response/security-handler.ts
@@ -19,9 +19,16 @@ export function generateNonce(): string {
  *
  * - Scripts: nonce-based + cdn.jsdelivr.net + esm.sh (Scalar API docs,
  *   html2canvas, legacy/browser ESM hydration)
- * - Styles: 'self' + 'unsafe-inline' + nonce + Google Fonts + cdn.veryfront.com
- *   plus style-src-attr 'unsafe-inline' so React style="" attributes remain
- *   compatible while inline <style> tags continue to use the nonce
+ * - Styles:
+ *   - style-src: 'self' + 'unsafe-inline' + Google Fonts + cdn.veryfront.com
+ *     so React style="" attributes and framework inline styles remain
+ *     compatible. Do not include a nonce in style-src here: browsers ignore
+ *     'unsafe-inline' when a nonce/hash is present on the directive, which
+ *     breaks React style attributes.
+ *   - style-src-elem: nonce-based + Google Fonts + cdn.veryfront.com for
+ *     inline <style> tags and stylesheet elements
+ *   - style-src-attr: 'unsafe-inline' for modern browsers with directive-level
+ *     style attribute support
  * - Images/media/fonts: 'self' + data: + https: + cdn.veryfront.com
  * - Connections: 'self' + wss: + https: (WebSocket for HMR/live reload, API calls)
  * - Objects: 'none' (block Flash/plugins)
@@ -34,7 +41,8 @@ function buildDefaultCSP(nonce: string): string {
   return [
     `default-src 'self'`,
     `script-src 'self' 'nonce-${nonce}' https://cdn.jsdelivr.net https://esm.sh`,
-    `style-src 'self' 'unsafe-inline' 'nonce-${nonce}' https://fonts.googleapis.com https://cdn.veryfront.com`,
+    `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.veryfront.com`,
+    `style-src-elem 'self' 'nonce-${nonce}' https://fonts.googleapis.com https://cdn.veryfront.com`,
     `style-src-attr 'unsafe-inline'`,
     `img-src 'self' data: https:`,
     `font-src 'self' data: https://fonts.gstatic.com https://cdn.veryfront.com`,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.124";
+export const VERSION = "0.1.126";

--- a/tests/_helpers/playwright.ts
+++ b/tests/_helpers/playwright.ts
@@ -26,7 +26,9 @@ export function collectBrowserErrors(
   const pageErrors: string[] = [];
 
   page.on("console", (message) => {
-    if (message.type() === "error") consoleErrors.push(message.text());
+    if (message.type() === "error" || message.type() === "warning") {
+      consoleErrors.push(message.text());
+    }
   });
   page.on("pageerror", (error) => {
     pageErrors.push(error.message);

--- a/tests/integration/compiled-binary-e2e.test.ts
+++ b/tests/integration/compiled-binary-e2e.test.ts
@@ -1860,6 +1860,15 @@ export default function HomePage() {
       id="counter"
       data-hydrated={hydrated ? "yes" : "no"}
       onClick={() => setCount((value) => value + 1)}
+      style={{
+        backgroundColor: hydrated
+          ? (count > 0 ? "rgb(22, 101, 52)" : "rgb(37, 99, 235)")
+          : "rgb(156, 163, 175)",
+        color: "rgb(255, 255, 255)",
+        padding: String(12 + count) + "px",
+        border: "none",
+        borderRadius: "8px",
+      }}
     >
       Count: {count}
     </button>
@@ -1883,11 +1892,29 @@ export default function HomePage() {
             csp.includes("https://esm.sh"),
             `Expected CSP to allow esm.sh scripts, got: ${csp}`,
           );
+          assert(
+            csp.includes("style-src-elem"),
+            `Expected CSP to include style-src-elem, got: ${csp}`,
+          );
+          assert(
+            !csp.includes("style-src 'self' 'unsafe-inline' 'nonce-"),
+            `style-src should not mix unsafe-inline with a nonce, got: ${csp}`,
+          );
 
           await page.waitForSelector('#counter[data-hydrated="yes"]');
 
           const initialText = await page.textContent("#counter");
           assertEquals(initialText?.trim(), "Count: 0");
+          const initialBackground = await page.$eval(
+            "#counter",
+            (element) => globalThis.getComputedStyle(element).backgroundColor,
+          );
+          const initialPadding = await page.$eval(
+            "#counter",
+            (element) => globalThis.getComputedStyle(element).paddingTop,
+          );
+          assertEquals(initialBackground, "rgb(37, 99, 235)");
+          assertEquals(initialPadding, "12px");
 
           await page.click("#counter");
           await page.waitForFunction(
@@ -1896,6 +1923,16 @@ export default function HomePage() {
 
           const hydratedText = await page.textContent("#counter");
           assertEquals(hydratedText?.trim(), "Count: 1");
+          const clickedBackground = await page.$eval(
+            "#counter",
+            (element) => globalThis.getComputedStyle(element).backgroundColor,
+          );
+          const clickedPadding = await page.$eval(
+            "#counter",
+            (element) => globalThis.getComputedStyle(element).paddingTop,
+          );
+          assertEquals(clickedBackground, "rgb(22, 101, 52)");
+          assertEquals(clickedPadding, "13px");
 
           const hydrationErrors = getHydrationErrors([...consoleErrors, ...pageErrors]);
           assertEquals(
@@ -1907,6 +1944,99 @@ export default function HomePage() {
           const serverErrors = server.logs.filter((line) =>
             line.includes("Page hydration failed") ||
             line.includes("Refused to load the script") ||
+            line.includes("violates the following Content Security Policy directive")
+          );
+          assertEquals(
+            serverErrors.length,
+            0,
+            `Unexpected server/browser CSP errors: ${serverErrors.join("\n")}`,
+          );
+        } finally {
+          await browserContext.close();
+        }
+      });
+    } finally {
+      await browser.close();
+    }
+  });
+
+  it("should allow hydrated client inline styles under the default CSP in the compiled binary", async () => {
+    const browser = await launchChromium();
+    if (!browser) return;
+
+    const projectDir = await createTestProject(
+      "pages-browser-csp-inline-style",
+      `
+import { useEffect, useState } from "react";
+
+export default function HomePage() {
+  const [hydrated, setHydrated] = useState(false);
+  const [backgroundColor, setBackgroundColor] = useState("rgb(255, 0, 0)");
+
+  useEffect(() => {
+    setHydrated(true);
+    setBackgroundColor("rgb(0, 128, 0)");
+  }, []);
+
+  return (
+    <div
+      id="styled-box"
+      data-hydrated={hydrated ? "yes" : "no"}
+      style={{ backgroundColor, padding: "12px" }}
+    >
+      Styled Box
+    </div>
+  );
+}
+`,
+    );
+
+    try {
+      await withServer(projectDir, async (server) => {
+        const browserContext = await browser.newContext();
+        const page = await browserContext.newPage();
+        const { consoleErrors, pageErrors } = collectBrowserErrors(page);
+
+        try {
+          const response = await page.goto(`http://127.0.0.1:${server.port}/`);
+          assertEquals(response?.status(), 200, "Should return 200");
+
+          await page.waitForSelector('#styled-box[data-hydrated="yes"]');
+
+          const csp = response?.headers()["content-security-policy"] ?? "";
+          assert(
+            csp.includes("style-src 'self' 'unsafe-inline'"),
+            `Expected CSP to allow inline styles, got: ${csp}`,
+          );
+          assert(
+            !/style-src[^;]*'nonce-/.test(csp),
+            `style-src should not include a nonce when unsafe-inline is enabled, got: ${csp}`,
+          );
+
+          const styles = await page.evaluate(() => {
+            const el = document.querySelector("#styled-box");
+            if (!(el instanceof HTMLElement)) return null;
+            const computed = getComputedStyle(el);
+            return {
+              backgroundColor: computed.backgroundColor,
+              paddingTop: computed.paddingTop,
+            };
+          });
+
+          assert(styles !== null, "Expected styled element to exist");
+          assertEquals(styles.backgroundColor, "rgb(0, 128, 0)");
+          assertEquals(styles.paddingTop, "12px");
+
+          const hydrationErrors = getHydrationErrors([...consoleErrors, ...pageErrors]);
+          assertEquals(
+            hydrationErrors.length,
+            0,
+            `Unexpected hydration/CSP errors: ${hydrationErrors.join("\n")}`,
+          );
+
+          const serverErrors = server.logs.filter((line) =>
+            line.includes("Page hydration failed") ||
+            line.includes("Content Security Policy") ||
             line.includes("violates the following Content Security Policy directive")
           );
           assertEquals(

--- a/tests/integration/compiled-binary-e2e.test.ts
+++ b/tests/integration/compiled-binary-e2e.test.ts
@@ -47,6 +47,16 @@ function stripReactSSRMarkers(html: string): string {
   return html.replaceAll("<!-- -->", "");
 }
 
+function getDirectiveSources(csp: string, directiveName: string): string[] {
+  const directive = csp
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(`${directiveName} `));
+
+  if (!directive) return [];
+  return directive.split(/\s+/).slice(1);
+}
+
 /** Get an available port using OS-assigned port 0. */
 async function getAvailablePort(): Promise<number> {
   const listener = Deno.listen({ hostname: "127.0.0.1", port: 0 });
@@ -2004,12 +2014,13 @@ export default function HomePage() {
           await page.waitForSelector('#styled-box[data-hydrated="yes"]');
 
           const csp = response?.headers()["content-security-policy"] ?? "";
+          const styleSources = getDirectiveSources(csp, "style-src");
           assert(
             csp.includes("style-src 'self' 'unsafe-inline'"),
             `Expected CSP to allow inline styles, got: ${csp}`,
           );
           assert(
-            !/style-src[^;]*'nonce-/.test(csp),
+            !styleSources.some((source) => source.startsWith("'nonce-")),
             `style-src should not include a nonce when unsafe-inline is enabled, got: ${csp}`,
           );
 


### PR DESCRIPTION
## Summary
- remove the default style-src nonce so inline styles remain allowed under the shipped CSP
- add exact security-handler regressions for style-src/style-src-attr behavior
- add a compiled-binary browser regression for hydrated inline styles under default CSP and bump the version to 0.1.125

## Verification
- deno check src/security/http/response/security-handler.ts src/security/http/response/security-handler.test.ts tests/_helpers/playwright.ts tests/integration/compiled-binary-e2e.test.ts
- deno test --no-check --allow-all src/security/http/response/security-handler.test.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/modules/server/module-server.test.ts
- full git push pre-push suite passed: format, lint, typecheck, and unit tests
- compiled-binary browser suite output included:
  - should hydrate pages-router client pages under strict CSP in the compiled binary ... ok
  - should allow hydrated client inline styles under the default CSP in the compiled binary ... ok