### PR TITLE
Fix preview full-document utility CSS injection

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.127",
+  "version": "0.1.128",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/html/dev-scripts.test.ts
+++ b/src/html/dev-scripts.test.ts
@@ -1,8 +1,22 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { getDevScripts, getDevStyles, getProdScripts, getStudioScripts } from "./dev-scripts.ts";
+import {
+  getDevScripts,
+  getDevStyles,
+  getPreviewStylesheetLink,
+  getProdScripts,
+  getStudioScripts,
+} from "./dev-scripts.ts";
 
 describe("html/dev-scripts", () => {
+  describe("getPreviewStylesheetLink", () => {
+    it("returns the preview utility stylesheet link", () => {
+      const link = getPreviewStylesheetLink();
+      assertEquals(link.includes('id="vf-tailwind-css"'), true);
+      assertEquals(link.includes("/_vf_styles/styles.css?t="), true);
+    });
+  });
+
   describe("getDevStyles", () => {
     it("should return style tag", () => {
       const styles = getDevStyles();

--- a/src/html/dev-scripts.ts
+++ b/src/html/dev-scripts.ts
@@ -1,5 +1,9 @@
 import { escapeHtml } from "./html-escape.ts";
 
+export function getPreviewStylesheetLink(): string {
+  return `<link id="vf-tailwind-css" rel="stylesheet" href="/_vf_styles/styles.css?t=${Date.now()}">`;
+}
+
 export function getDevStyles(nonce?: string): string {
   const nonceAttr = nonce ? ` nonce="${escapeHtml(nonce)}"` : "";
 

--- a/src/html/html-injection.test.ts
+++ b/src/html/html-injection.test.ts
@@ -139,5 +139,21 @@ describe("html/html-injection", () => {
 
       assertEquals(html.includes("studio-bridge.js"), true);
     });
+
+    it("injects preview utility CSS for remote preview full HTML documents", () => {
+      const html = injectHTMLContent(
+        baseTemplate,
+        "<p>content</p>",
+        minMeta,
+        {
+          mode: "production",
+          environment: "preview",
+          slug: "test",
+        },
+      );
+
+      assertEquals(html.includes('id="vf-tailwind-css"'), true);
+      assertEquals(html.includes("/_vf_styles/styles.css?t="), true);
+    });
   });
 });

--- a/src/html/html-injection.ts
+++ b/src/html/html-injection.ts
@@ -8,7 +8,13 @@ import {
   generateStyleTags,
 } from "./tag-generators.ts";
 import { escapeHtml } from "./html-escape.ts";
-import { getDevScripts, getDevStyles, getProdScripts, getStudioScripts } from "./dev-scripts.ts";
+import {
+  getDevScripts,
+  getDevStyles,
+  getPreviewStylesheetLink,
+  getProdScripts,
+  getStudioScripts,
+} from "./dev-scripts.ts";
 
 export interface InjectHTMLContentOptions {
   mode: string;
@@ -48,6 +54,12 @@ function toProjectRelativePath(absolutePath: string, projectDir?: string): strin
   return resolveRelativePath(normalizedPath, projectDir);
 }
 
+function hasProjectStylesheet(html: string): boolean {
+  return /id=["']vf-tailwind-css["']/i.test(html) ||
+    /href=["'][^"']*\/_vf_styles\/styles\.css(?:\?[^"']*)?["']/i.test(html) ||
+    /href=["'][^"']*\/_vf\/css\/[^"']+\.css["']/i.test(html);
+}
+
 export function injectHTMLContent(
   template: string,
   content: string,
@@ -82,6 +94,13 @@ export function injectHTMLContent(
     const importMapTag =
       `<script type="importmap"${nonceAttr}>\n${options.importMapJson}\n</script>`;
     html = html.replace(/<\/head>/i, `${importMapTag}\n</head>`);
+  }
+
+  const shouldUsePreviewStylesheet = options.mode === "development" ||
+    options.environment === "preview";
+
+  if (shouldUsePreviewStylesheet && /<\/head>/i.test(html) && !hasProjectStylesheet(html)) {
+    html = html.replace(/<\/head>/i, `${getPreviewStylesheetLink()}\n</head>`);
   }
 
   const hasBodyClose = /<\/body>/i.test(html);

--- a/src/html/html-shell-generator.ts
+++ b/src/html/html-shell-generator.ts
@@ -14,7 +14,7 @@ import {
   getDevScripts,
   getProdScripts,
 } from "./hydration-script-builder/index.ts";
-import { getStudioScripts } from "./dev-scripts.ts";
+import { getPreviewStylesheetLink, getStudioScripts } from "./dev-scripts.ts";
 import { processMetadata } from "./metadata-builder.ts";
 import { extractCandidates, getDevStyles, getProjectCSS } from "./styles-builder/index.ts";
 import type { HTMLGenerationOptions } from "./types.ts";
@@ -270,8 +270,7 @@ async function generateHTMLShellPartsImpl(
     }
   } else {
     // Dev/preview: use link tag for HMR cache-busting
-    tailwindCSSBlock =
-      `<link id="vf-tailwind-css" rel="stylesheet" href="/_vf_styles/styles.css?t=${Date.now()}">`;
+    tailwindCSSBlock = getPreviewStylesheetLink();
   }
 
   // Markdown styles: .md files with prose !== false get GitHub markdown CSS

--- a/src/rendering/orchestrator/html.test.ts
+++ b/src/rendering/orchestrator/html.test.ts
@@ -260,6 +260,46 @@ describe("HTMLGenerator helpers", () => {
       assertEquals(html.includes('<script type="importmap" nonce="nonce-123">'), true);
     });
 
+    it("injects preview utility CSS into full HTML documents for preview rendering", async () => {
+      const mockAdapter = {
+        fs: {
+          readFile: async () => `'use client';`,
+          exists: async () => false,
+          stat: async () => ({ isFile: false, isDirectory: false, isSymlink: false }),
+          readDir: async function* () {},
+          mkdir: async () => {},
+          writeFile: async () => {},
+        },
+      };
+
+      const generator = new HTMLGenerator({
+        projectDir: "/project",
+        adapter: mockAdapter as any,
+        config: {} as any,
+        mode: "production",
+      });
+
+      const html = await generator.generateFullHTML({
+        html: "<!DOCTYPE html><html><head></head><body><main>Hello</main></body></html>",
+        pageInfo: {
+          entity: {
+            path: "/project/app/page.tsx",
+            frontmatter: {},
+          },
+        } as any,
+        pageBundle: {} as any,
+        layoutBundle: undefined,
+        nestedLayouts: [],
+        collectedMetadata: {},
+        slug: "test-page",
+        ssrHash: "hash123",
+        options: { environment: "preview" },
+      });
+
+      assertEquals(html.includes('id="vf-tailwind-css"'), true);
+      assertEquals(html.includes("/_vf_styles/styles.css?t="), true);
+    });
+
     it("adds nonce to inline style and script tags in rendered HTML", async () => {
       const mockAdapter = {
         fs: {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.127";
+export const VERSION = "0.1.128";


### PR DESCRIPTION
## Summary
- inject the preview utility stylesheet into full-document HTML pages in preview/local rendering
- reuse the same preview stylesheet helper across both HTML generation paths
- add regression coverage for remote preview full-document pages and bump version to 0.1.128

## Verification
- deno check src/html/dev-scripts.ts src/html/html-injection.ts src/html/html-shell-generator.ts src/html/dev-scripts.test.ts src/html/html-injection.test.ts src/rendering/orchestrator/html.test.ts
- deno test --no-check --allow-all src/html/html-shell-generator.test.ts src/html/dev-scripts.test.ts src/html/html-injection.test.ts src/rendering/orchestrator/html.test.ts src/utils/version.test.ts
- git push (full pre-push suite passed: format, lint, typecheck, unit tests)
