### PR TITLE
Deslop dev server CSP browser module tests

### DIFF
--- a/tests/integration/server/dev-server-handlers.test.ts
+++ b/tests/integration/server/dev-server-handlers.test.ts
@@ -81,6 +81,72 @@ function extractImportSpecifiers(code: string): string[] {
   return [...specifiers];
 }
 
+const BROWSER_SAFE_ERROR_MODULES = new Set([
+  "/_vf_modules/_veryfront/errors/error-registry.js",
+  "/_vf_modules/_veryfront/errors/http-error.js",
+]);
+
+const BROWSER_CSP_SAFE_MODULE_PATHS = [
+  "/_vf_modules/_veryfront/chat/index.js",
+  "/_vf_modules/_veryfront/react/components/ai/color-mode.js",
+  "/_vf_modules/_veryfront/react/components/ai/chat.js",
+  "/_vf_modules/_veryfront/react/components/ai/chat/contexts/chat-context.js",
+  "/_vf_modules/_veryfront/react/components/ai/chat/contexts/composer-context.js",
+  "/_vf_modules/_veryfront/react/components/ai/chat/contexts/message-context.js",
+  "/_vf_modules/_veryfront/react/components/ai/chat/contexts/thread-list-context.js",
+  "/_vf_modules/_veryfront/react/components/ai/markdown.js",
+  "/_vf_modules/_veryfront/security/client/html-sanitizer.js",
+  "/_vf_modules/_veryfront/rendering/rsc/client-boot.js",
+  "/_vf_modules/_veryfront/rendering/rsc/client-dom.js",
+  "/_vf_modules/_veryfront/routing/client/page-loader.js",
+  "/_vf_modules/_veryfront/rendering/rsc/client-hydrator.js",
+  "/_vf_modules/_veryfront/client/spa/ClientApp.js",
+];
+
+async function fetchServedFrameworkModule(
+  port: number,
+  modulePath: string,
+): Promise<{ body: string; specifiers: string[] }> {
+  const response = await fetch(`http://127.0.0.1:${port}${modulePath}`);
+  assertEquals(response.status, 200, `Expected ${modulePath} to be served`);
+
+  const body = await response.text();
+  const specifiers = extractImportSpecifiers(body);
+
+  return { body, specifiers };
+}
+
+function assertBrowserSafeFrameworkModule(
+  modulePath: string,
+  body: string,
+  specifiers: string[],
+): void {
+  const errorSpecifiers = specifiers.filter((specifier) =>
+    specifier.startsWith("/_vf_modules/_veryfront/errors/")
+  );
+
+  assert(
+    !body.includes("new Function("),
+    `${modulePath} should not use unsafe-eval`,
+  );
+  assert(
+    !specifiers.includes("/_vf_modules/_veryfront/errors/index.js"),
+    `${modulePath} should not import the heavyweight errors barrel`,
+  );
+  assert(
+    !specifiers.includes("/_vf_modules/_veryfront/platform/compat/process.js"),
+    `${modulePath} should not import process compat`,
+  );
+  assert(
+    !specifiers.includes("/_vf_modules/_veryfront/platform/compat/dynamic-import.js"),
+    `${modulePath} should not import dynamic-import compat`,
+  );
+  assert(
+    errorSpecifiers.every((specifier) => BROWSER_SAFE_ERROR_MODULES.has(specifier)),
+    `${modulePath} should only import narrow browser-safe error modules`,
+  );
+}
+
 describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: false }, () => {
   afterAll(async () => {
     await cleanupBundler();
@@ -362,16 +428,9 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
     it("serves framework markdown module without unsafe-eval helpers", async () => {
       await withTestContext("dev-server-framework-markdown-csp", async (context) => {
         const { server, port } = await createTestDevServer(context);
-        const response = await fetch(
-          `http://127.0.0.1:${port}/_vf_modules/_veryfront/react/components/ai/markdown.js`,
-        );
-
-        assertEquals(response.status, 200);
-        const body = await response.text();
-        assert(
-          !body.includes("new Function("),
-          "Framework markdown module should not use unsafe-eval",
-        );
+        const modulePath = "/_vf_modules/_veryfront/react/components/ai/markdown.js";
+        const { body, specifiers } = await fetchServedFrameworkModule(port, modulePath);
+        assertBrowserSafeFrameworkModule(modulePath, body, specifiers);
 
         await stopServer(server);
       });
@@ -380,56 +439,9 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
     it("serves browser framework modules with narrow CSP-safe imports", async () => {
       await withTestContext("dev-server-framework-chat-error-csp", async (context) => {
         const { server, port } = await createTestDevServer(context);
-        const modulePaths = [
-          "/_vf_modules/_veryfront/chat/index.js",
-          "/_vf_modules/_veryfront/react/components/ai/color-mode.js",
-          "/_vf_modules/_veryfront/react/components/ai/chat.js",
-          "/_vf_modules/_veryfront/react/components/ai/chat/contexts/chat-context.js",
-          "/_vf_modules/_veryfront/react/components/ai/chat/contexts/composer-context.js",
-          "/_vf_modules/_veryfront/react/components/ai/chat/contexts/message-context.js",
-          "/_vf_modules/_veryfront/react/components/ai/chat/contexts/thread-list-context.js",
-          "/_vf_modules/_veryfront/react/components/ai/markdown.js",
-          "/_vf_modules/_veryfront/security/client/html-sanitizer.js",
-          "/_vf_modules/_veryfront/rendering/rsc/client-boot.js",
-          "/_vf_modules/_veryfront/rendering/rsc/client-dom.js",
-          "/_vf_modules/_veryfront/routing/client/page-loader.js",
-          "/_vf_modules/_veryfront/rendering/rsc/client-hydrator.js",
-          "/_vf_modules/_veryfront/client/spa/ClientApp.js",
-        ];
-
-        for (const modulePath of modulePaths) {
-          const response = await fetch(`http://127.0.0.1:${port}${modulePath}`);
-          assertEquals(response.status, 200, `Expected ${modulePath} to be served`);
-
-          const body = await response.text();
-          const specifiers = extractImportSpecifiers(body);
-          const errorSpecifiers = specifiers.filter((specifier) =>
-            specifier.startsWith("/_vf_modules/_veryfront/errors/")
-          );
-
-          assert(
-            !body.includes("new Function("),
-            `${modulePath} should not use unsafe-eval`,
-          );
-          assert(
-            !specifiers.includes("/_vf_modules/_veryfront/errors/index.js"),
-            `${modulePath} should not import the heavyweight errors barrel`,
-          );
-          assert(
-            !specifiers.includes("/_vf_modules/_veryfront/platform/compat/process.js"),
-            `${modulePath} should not import process compat`,
-          );
-          assert(
-            !specifiers.includes("/_vf_modules/_veryfront/platform/compat/dynamic-import.js"),
-            `${modulePath} should not import dynamic-import compat`,
-          );
-          assert(
-            errorSpecifiers.every((specifier) =>
-              specifier === "/_vf_modules/_veryfront/errors/error-registry.js" ||
-              specifier === "/_vf_modules/_veryfront/errors/http-error.js"
-            ),
-            `${modulePath} should only import narrow browser-safe error modules`,
-          );
+        for (const modulePath of BROWSER_CSP_SAFE_MODULE_PATHS) {
+          const { body, specifiers } = await fetchServedFrameworkModule(port, modulePath);
+          assertBrowserSafeFrameworkModule(modulePath, body, specifiers);
         }
 
         await stopServer(server);


### PR DESCRIPTION
## Summary\n- factor the browser framework module fetch and CSP-safe import checks into shared file-local helpers\n- keep the markdown-specific regression on the same shared contract instead of reasserting unsafe-eval inline\n- hoist the served module list into one constant so future CSP regressions update in one place\n\n## Testing\n- deno check tests/integration/server/dev-server-handlers.test.ts\n- deno test --no-check --allow-all tests/integration/server/dev-server-handlers.test.ts