### PR TITLE
Deslop browser diagnostics helpers

### DIFF
--- a/tests/_helpers/playwright.ts
+++ b/tests/_helpers/playwright.ts
@@ -1,4 +1,20 @@
-import { type Browser, chromium, type Page } from "npm:playwright";
+import type { Browser, ConsoleMessage, Page } from "npm:playwright";
+
+export interface BrowserDiagnostics {
+  consoleMessages: string[];
+  pageErrors: string[];
+}
+
+const HYDRATION_OR_CSP_FAILURE_PATTERNS = [
+  "Page hydration failed",
+  "unsafe-eval",
+  "Failed to fetch dynamically imported module",
+  "WebAssembly.compile()",
+  "Content Security Policy",
+  "violates the following Content Security Policy directive",
+  "Refused to load the script",
+  "Hydration",
+] as const;
 
 export function isMissingBrowserExecutable(error: unknown): boolean {
   return String(error).includes("Executable doesn't exist");
@@ -6,6 +22,7 @@ export function isMissingBrowserExecutable(error: unknown): boolean {
 
 export async function launchChromium(): Promise<Browser | null> {
   try {
+    const { chromium } = await import("npm:playwright");
     return await chromium.launch({ headless: true });
   } catch (error) {
     if (isMissingBrowserExecutable(error)) {
@@ -19,33 +36,28 @@ export async function launchChromium(): Promise<Browser | null> {
   }
 }
 
-export function collectBrowserErrors(
-  page: Page,
-): { consoleErrors: string[]; pageErrors: string[] } {
-  const consoleErrors: string[] = [];
+export function captureBrowserDiagnostics(page: Page): BrowserDiagnostics {
+  const consoleMessages: string[] = [];
   const pageErrors: string[] = [];
 
-  page.on("console", (message) => {
+  page.on("console", (message: ConsoleMessage) => {
     if (message.type() === "error" || message.type() === "warning") {
-      consoleErrors.push(message.text());
+      consoleMessages.push(message.text());
     }
   });
   page.on("pageerror", (error) => {
     pageErrors.push(error.message);
   });
 
-  return { consoleErrors, pageErrors };
+  return { consoleMessages, pageErrors };
 }
 
-export function getHydrationErrors(messages: string[]): string[] {
+export function getBrowserDiagnosticMessages(diagnostics: BrowserDiagnostics): string[] {
+  return [...diagnostics.consoleMessages, ...diagnostics.pageErrors];
+}
+
+export function findHydrationOrCspFailures(messages: string[]): string[] {
   return messages.filter((message) =>
-    message.includes("Page hydration failed") ||
-    message.includes("unsafe-eval") ||
-    message.includes("Failed to fetch dynamically imported module") ||
-    message.includes("WebAssembly.compile()") ||
-    message.includes("Content Security Policy") ||
-    message.includes("violates the following Content Security Policy directive") ||
-    message.includes("Refused to load the script") ||
-    message.includes("Hydration")
+    HYDRATION_OR_CSP_FAILURE_PATTERNS.some((pattern) => message.includes(pattern))
   );
 }

--- a/tests/e2e/helpers/assertions.ts
+++ b/tests/e2e/helpers/assertions.ts
@@ -5,6 +5,7 @@
  */
 
 import { ConsoleMessage, expect, Page } from "@playwright/test";
+import { findHydrationOrCspFailures } from "../../_helpers/playwright.ts";
 
 /**
  * Console error collection for a page.
@@ -26,6 +27,8 @@ export function setupErrorCollection(page: Page): string[] {
 
   return errors;
 }
+
+export { findHydrationOrCspFailures };
 
 /**
  * Check if an error is known and ignorable
@@ -77,12 +80,7 @@ export async function assertHydrationWorks(page: Page, errors: string[]): Promis
     }
   }
 
-  const hydrationErrors = errors.filter(
-    (e) =>
-      e.includes("hydrat") || e.includes("Minified React error") || e.includes("did not match"),
-  );
-
-  expect(hydrationErrors).toEqual([]);
+  expect(findHydrationOrCspFailures(errors)).toEqual([]);
 }
 
 /**

--- a/tests/e2e/regressions/rsc-proxy-hydration.test.ts
+++ b/tests/e2e/regressions/rsc-proxy-hydration.test.ts
@@ -5,8 +5,9 @@ import { join } from "#veryfront/compat/path";
 import { mkdir, remove, writeTextFile } from "#veryfront/compat/fs.ts";
 import { withTestContext } from "../../_helpers/context.ts";
 import {
-  collectBrowserErrors,
-  getHydrationErrors,
+  captureBrowserDiagnostics,
+  findHydrationOrCspFailures,
+  getBrowserDiagnosticMessages,
   launchChromium,
 } from "../../_helpers/playwright.ts";
 import { cleanupBundler } from "../../../src/rendering/cleanup.ts";
@@ -164,7 +165,7 @@ async function withProxyBrowserPage(
   headers: Record<string, string>,
   run: (
     page: import("npm:playwright").Page,
-    errors: { consoleErrors: string[]; pageErrors: string[] },
+    diagnostics: import("../../_helpers/playwright.ts").BrowserDiagnostics,
   ) => Promise<void>,
 ): Promise<void> {
   const port = await context.allocatePort();
@@ -182,12 +183,12 @@ async function withProxyBrowserPage(
 
   const browserContext = await browser.newContext({ extraHTTPHeaders: headers });
   const page = await browserContext.newPage();
-  const errors = collectBrowserErrors(page);
+  const diagnostics = captureBrowserDiagnostics(page);
 
   try {
     const response = await page.goto(`http://127.0.0.1:${port}/`);
     assertEquals(response?.status(), 200);
-    await run(page, errors);
+    await run(page, diagnostics);
   } finally {
     await browserContext.close();
     controller.abort();
@@ -279,7 +280,7 @@ describe(
           const server = await context.createProductionServer({ hostname: "127.0.0.1" });
           const browserContext = await browser.newContext();
           const page = await browserContext.newPage();
-          const { consoleErrors, pageErrors } = collectBrowserErrors(page);
+          const diagnostics = captureBrowserDiagnostics(page);
 
           try {
             const response = await page.goto(`http://127.0.0.1:${server.port}/`);
@@ -290,7 +291,9 @@ describe(
               expectedModulePath: "/_veryfront/fs/",
             });
 
-            const hydrationErrors = getHydrationErrors([...consoleErrors, ...pageErrors]);
+            const hydrationErrors = findHydrationOrCspFailures(
+              getBrowserDiagnosticMessages(diagnostics),
+            );
             assertEquals(hydrationErrors.length, 0);
           } finally {
             await browserContext.close();
@@ -316,13 +319,15 @@ describe(
             browser,
             context,
             getProxyHeaders("production"),
-            async (page, { consoleErrors, pageErrors }) => {
+            async (page, diagnostics) => {
               await assertCounterHydration(page, {
                 expectedStrategy: "rsc-module",
                 expectedModulePath: "/_veryfront/rsc/module?",
               });
 
-              const hydrationErrors = getHydrationErrors([...consoleErrors, ...pageErrors]);
+              const hydrationErrors = findHydrationOrCspFailures(
+                getBrowserDiagnosticMessages(diagnostics),
+              );
               assertEquals(hydrationErrors.length, 0);
             },
           );
@@ -347,13 +352,15 @@ describe(
             browser,
             context,
             getProxyHeaders("preview"),
-            async (page, { consoleErrors, pageErrors }) => {
+            async (page, diagnostics) => {
               await assertCounterHydration(page, {
                 expectedStrategy: "fs",
                 expectedModulePath: "/_veryfront/fs/",
               });
 
-              const hydrationErrors = getHydrationErrors([...consoleErrors, ...pageErrors]);
+              const hydrationErrors = findHydrationOrCspFailures(
+                getBrowserDiagnosticMessages(diagnostics),
+              );
               assertEquals(hydrationErrors.length, 0);
             },
           );
@@ -378,10 +385,12 @@ describe(
             browser,
             context,
             getProxyHeaders("preview"),
-            async (page, { consoleErrors, pageErrors }) => {
+            async (page, diagnostics) => {
               await assertPreviewChatStyling(page);
 
-              const hydrationErrors = getHydrationErrors([...consoleErrors, ...pageErrors]);
+              const hydrationErrors = findHydrationOrCspFailures(
+                getBrowserDiagnosticMessages(diagnostics),
+              );
               assertEquals(hydrationErrors.length, 0);
             },
           );

--- a/tests/e2e/smoke.playwright.ts
+++ b/tests/e2e/smoke.playwright.ts
@@ -9,7 +9,7 @@
  */
 
 import { expect, test } from "@playwright/test";
-import { setupErrorCollection } from "./helpers/assertions.js";
+import { findHydrationOrCspFailures, setupErrorCollection } from "./helpers/assertions.js";
 
 /**
  * Projects to test.
@@ -48,13 +48,6 @@ async function expectPageRenders(page: import("@playwright/test").Page): Promise
   expect(body.length).toBeGreaterThan(0);
 }
 
-function getHydrationErrors(errors: string[]): string[] {
-  return errors.filter(
-    (e) =>
-      e.includes("hydrat") || e.includes("Minified React error") || e.includes("did not match"),
-  );
-}
-
 /**
  * Test each project in each mode
  */
@@ -90,7 +83,7 @@ for (const subdomain of PROJECTS) {
           }
         }
 
-        expect(getHydrationErrors(errors)).toEqual([]);
+        expect(findHydrationOrCspFailures(errors)).toEqual([]);
       });
 
       test("color_mode=dark works", async ({ page }) => {

--- a/tests/integration/compiled-binary-e2e.test.ts
+++ b/tests/integration/compiled-binary-e2e.test.ts
@@ -25,8 +25,9 @@ import { exists } from "#veryfront/platform/compat/fs.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { load as loadEnv } from "#veryfront/platform/compat/std/dotenv.ts";
 import {
-  collectBrowserErrors,
-  getHydrationErrors,
+  captureBrowserDiagnostics,
+  findHydrationOrCspFailures,
+  getBrowserDiagnosticMessages,
   launchChromium,
 } from "../_helpers/playwright.ts";
 import { withProxyModeControlPlaneKey } from "../_helpers/proxy-mode.ts";
@@ -112,7 +113,7 @@ interface TestServer {
   kill: () => Promise<void>;
 }
 
-type BrowserDiagnostics = ReturnType<typeof collectBrowserErrors>;
+type BrowserDiagnostics = ReturnType<typeof captureBrowserDiagnostics>;
 
 interface BrowserPageSession {
   page: import("npm:playwright").Page;
@@ -348,7 +349,7 @@ async function withBrowserPageAgainstServer(
   try {
     const browserContext = await browser.newContext();
     const page = await browserContext.newPage();
-    const diagnostics = collectBrowserErrors(page);
+    const diagnostics = captureBrowserDiagnostics(page);
 
     try {
       const response = await page.goto(`http://127.0.0.1:${server.port}/`);
@@ -366,10 +367,9 @@ function assertNoBrowserHydrationErrors(
   diagnostics: BrowserDiagnostics,
   label = "Unexpected hydration/CSP errors",
 ): void {
-  const hydrationErrors = getHydrationErrors([
-    ...diagnostics.consoleErrors,
-    ...diagnostics.pageErrors,
-  ]);
+  const hydrationErrors = findHydrationOrCspFailures(
+    getBrowserDiagnosticMessages(diagnostics),
+  );
   assertEquals(hydrationErrors.length, 0, `${label}: ${hydrationErrors.join("\n")}`);
 }
 


### PR DESCRIPTION
## Summary\n- rename the shared browser error collector to match what it actually captures\n- centralize hydration/CSP failure matching in one shared helper\n- reuse that helper from the Deno browser suites and the Playwright smoke lane\n\n## Testing\n- deno task test:e2e:rsc-browser --no-lock\n- deno task test:e2e:binary --no-lock\n- attempted: npx playwright test --config=tests/e2e/playwright.config.ts tests/e2e/smoke.playwright.ts (fails in this checkout because @playwright/test is not installed as a resolvable local package)