### PR TITLE
Stop emitting unsupported step events on the brokered runtime path

### DIFF
--- a/src/internal-agents/ag-ui-sse.test.ts
+++ b/src/internal-agents/ag-ui-sse.test.ts
@@ -126,11 +126,11 @@ describe("internal-agents/ag-ui-sse", () => {
     );
     assertEquals(
       mapRuntimeEventToAgUi(state, { type: "step-start" }),
-      [{ event: "StepStarted", payload: { stepIndex: 1 } }],
+      [],
     );
     assertEquals(
       mapRuntimeEventToAgUi(state, { type: "step-end" }),
-      [{ event: "StepFinished", payload: { stepIndex: 1 } }],
+      [],
     );
     assertEquals(
       mapRuntimeEventToAgUi(state, {

--- a/src/internal-agents/ag-ui-sse.ts
+++ b/src/internal-agents/ag-ui-sse.ts
@@ -19,7 +19,6 @@ export interface RunFinishedMetadata {
 export interface StreamTransformState {
   messageId: string | null;
   textOpen: boolean;
-  stepIndex: number;
   sawTerminalError: boolean;
   metadata: RunFinishedMetadata;
 }
@@ -28,7 +27,6 @@ export function createStreamTransformState(): StreamTransformState {
   return {
     messageId: null,
     textOpen: false,
-    stepIndex: 0,
     sawTerminalError: false,
     metadata: {},
   };
@@ -66,12 +64,6 @@ const agUiEventPayloadSchemas = {
     toolCallId: z.string().min(1),
     result: z.unknown(),
     isError: z.boolean().optional(),
-  }),
-  StepStarted: z.object({
-    stepIndex: z.number().int().positive(),
-  }),
-  StepFinished: z.object({
-    stepIndex: z.number().int().positive(),
   }),
   RunError: z.object({
     code: z.string().min(1).optional(),
@@ -266,17 +258,10 @@ export function mapRuntimeEventToAgUi(
       }];
 
     case "step-start":
-      state.stepIndex += 1;
-      return [{
-        event: "StepStarted",
-        payload: { stepIndex: state.stepIndex },
-      }];
+      return [];
 
     case "step-end":
-      return [{
-        event: "StepFinished",
-        payload: { stepIndex: state.stepIndex },
-      }];
+      return [];
 
     case "data":
       applyDataMetadata(state, event);

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -210,6 +210,14 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertStringIncludes(text, "event: TextMessageContent");
     assertStringIncludes(text, "event: RunFinished");
     assertStringIncludes(text, '"inputTokens":21');
+    assertEquals(text.includes("event: StepStarted"), false);
+    assertEquals(text.includes("event: StepFinished"), false);
+    assertEquals(text.includes("event: Custom"), false);
+    assertEquals(text.includes("event: ActivitySnapshot"), false);
+    assertEquals(text.includes("event: ActivityDelta"), false);
+    assertEquals(text.includes("event: ReasoningStart"), false);
+    assertEquals(text.includes("event: ReasoningContent"), false);
+    assertEquals(text.includes("event: ReasoningEnd"), false);
   });
 
   it("rejects oversized internal agent stream payloads before parsing", async () => {


### PR DESCRIPTION
## Why
The frozen public AG-UI subset excludes  and . The internal broker-to-runtime bridge should stop forwarding those events toward the brokered public stream.

## What changed
- removed step event emission from 
- updated the focused runtime mapping tests accordingly

## Verification
- 
- 

## Status
Draft. This is an early runtime-boundary slice of the larger 100% AG-UI compliance rollout.