### PR TITLE
Fix compiled-binary framework hook resolution

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.129",
+  "version": "0.1.130",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/platform/compat/framework-source-resolver.test.ts
+++ b/src/platform/compat/framework-source-resolver.test.ts
@@ -20,6 +20,7 @@ describe("platform/compat/framework-source-resolver", () => {
             return {
               isFile: true,
               isDirectory: false,
+              isSymlink: false,
               isSymbolicLink: false,
               size: 0,
               mtime: null,
@@ -43,6 +44,7 @@ describe("platform/compat/framework-source-resolver", () => {
             return {
               isFile: true,
               isDirectory: false,
+              isSymlink: false,
               isSymbolicLink: false,
               size: 0,
               mtime: null,

--- a/src/platform/compat/framework-source-resolver.ts
+++ b/src/platform/compat/framework-source-resolver.ts
@@ -1,9 +1,10 @@
 import { join } from "#veryfront/compat/path/index.ts";
 import type { FileInfo } from "#veryfront/platform/adapters/base.ts";
 import { createFileSystem } from "./fs.ts";
-import { getFrameworkRootFromMeta } from "./vfs-paths.ts";
+import { getFrameworkRoot, getFrameworkRootFromMeta } from "./vfs-paths.ts";
 
 export const FRAMEWORK_ROOT = getFrameworkRootFromMeta(import.meta.url);
+export const FRAMEWORK_SRC_DIR = join(FRAMEWORK_ROOT, "src");
 export const FRAMEWORK_EMBEDDED_SRC_DIR = join(FRAMEWORK_ROOT, "dist", "framework-src");
 
 export const DEFAULT_FRAMEWORK_SOURCE_EXTENSIONS = [
@@ -37,6 +38,12 @@ export interface ResolveFrameworkSourcePathOptions {
   includeIndexFallback?: boolean;
 }
 
+export interface ResolveRelativeFrameworkSourceImportOptions {
+  fileSystem?: FrameworkSourceFileSystem;
+  exists?: (path: string) => Promise<boolean>;
+  extensions?: readonly string[];
+}
+
 export function getFrameworkSourceLookupDirs(extraLookupDirs: string[] = []): string[] {
   const seen = new Set<string>();
   const ordered = [
@@ -50,6 +57,48 @@ export function getFrameworkSourceLookupDirs(extraLookupDirs: string[] = []): st
     seen.add(dir);
     return true;
   });
+}
+
+export function isFrameworkSourcePath(path: string): boolean {
+  return path.startsWith(`${FRAMEWORK_SRC_DIR}/`) ||
+    path.startsWith(`${FRAMEWORK_EMBEDDED_SRC_DIR}/`);
+}
+
+function expandFrameworkCandidatePaths(candidatePath: string): string[] {
+  const candidates = [candidatePath];
+  const candidateRoot = getFrameworkRoot(candidatePath);
+  const candidateSrcDir = candidateRoot ? join(candidateRoot, "src") : FRAMEWORK_SRC_DIR;
+  const candidateEmbeddedDir = candidateRoot
+    ? join(candidateRoot, "dist", "framework-src")
+    : FRAMEWORK_EMBEDDED_SRC_DIR;
+
+  if (candidatePath.startsWith(`${candidateSrcDir}/`)) {
+    const relativePath = candidatePath.slice(candidateSrcDir.length + 1);
+    candidates.push(join(candidateEmbeddedDir, relativePath));
+  }
+
+  return [...new Set(candidates)];
+}
+
+async function findExistingFrameworkCandidate(
+  candidatePath: string,
+  options: ResolveRelativeFrameworkSourceImportOptions = {},
+): Promise<string | null> {
+  const fs = options.fileSystem ?? createFileSystem();
+  const exists = options.exists ?? (async (path: string) => {
+    try {
+      const stat = await fs.stat(path);
+      return stat.isFile;
+    } catch {
+      return false;
+    }
+  });
+
+  for (const candidate of expandFrameworkCandidatePaths(candidatePath)) {
+    if (await exists(candidate)) return candidate;
+  }
+
+  return null;
 }
 
 export async function resolveFrameworkSourcePath(
@@ -83,6 +132,57 @@ export async function resolveFrameworkSourcePath(
         }
       }
     }
+  }
+
+  return null;
+}
+
+export async function resolveRelativeFrameworkSourceImport(
+  specifier: string,
+  fromSourcePath: string,
+  options: ResolveRelativeFrameworkSourceImportOptions = {},
+): Promise<string | null> {
+  const extensions = options.extensions ?? DEFAULT_FRAMEWORK_SOURCE_EXTENSIONS;
+  const fromDir = fromSourcePath.substring(0, fromSourcePath.lastIndexOf("/"));
+  const parts = fromDir.split("/").filter(Boolean);
+  const importParts = specifier.split("/").filter(Boolean);
+
+  for (const part of importParts) {
+    if (part === "..") {
+      parts.pop();
+    } else if (part !== ".") {
+      parts.push(part);
+    }
+  }
+
+  const basePath = "/" + parts.join("/");
+
+  if (/\.(tsx?|jsx?|mjs)$/.test(specifier)) {
+    const explicitCandidates = [basePath, `${basePath}.src`];
+
+    if (basePath.endsWith(".js") || basePath.endsWith(".mjs")) {
+      const stem = basePath.replace(/\.(?:m?js)$/, "");
+      for (const ext of [".ts", ".tsx", ".jsx", ".js", ".mjs"]) {
+        explicitCandidates.push(`${stem}${ext}.src`, `${stem}${ext}`);
+      }
+    }
+
+    for (const candidate of explicitCandidates) {
+      const resolved = await findExistingFrameworkCandidate(candidate, options);
+      if (resolved) return resolved;
+    }
+
+    return null;
+  }
+
+  for (const ext of extensions) {
+    const candidate = await findExistingFrameworkCandidate(basePath + ext, options);
+    if (candidate) return candidate;
+  }
+
+  for (const ext of extensions) {
+    const candidate = await findExistingFrameworkCandidate(join(basePath, "index" + ext), options);
+    if (candidate) return candidate;
   }
 
   return null;

--- a/src/transforms/esm/import-parser.ts
+++ b/src/transforms/esm/import-parser.ts
@@ -1,6 +1,10 @@
 import { getEsbuild } from "#veryfront/platform/compat/esbuild.ts";
 import { join } from "#veryfront/compat/path";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import {
+  isFrameworkSourcePath,
+  resolveRelativeFrameworkSourceImport,
+} from "#veryfront/platform/compat/framework-source-resolver.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { isCrossProjectImport, parseCrossProjectImport } from "./path-resolver.ts";
 import { parseImports } from "./lexer.ts";
@@ -138,6 +142,14 @@ async function resolveLocalImportPath(
   importSpecifier: string,
   adapter?: RuntimeAdapter,
 ): Promise<string | null> {
+  if (isFrameworkSourcePath(fromFile)) {
+    const resolvedFrameworkImport = await resolveRelativeFrameworkSourceImport(
+      importSpecifier,
+      fromFile,
+    );
+    if (resolvedFrameworkImport) return resolvedFrameworkImport;
+  }
+
   const fromDir = fromFile.substring(0, fromFile.lastIndexOf("/"));
   const basePath = resolveRelative(fromDir, importSpecifier);
 

--- a/src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.test.ts
@@ -137,4 +137,21 @@ describe("resolveRelativeFrameworkImport", () => {
     );
     assertEquals(result, "/foo/bar/csp-nonce.ts.src");
   });
+
+  it("falls back from extracted framework src paths to embedded framework sources in compiled binaries", async () => {
+    const files: Record<string, string> = {
+      "/tmp/deno-compile-veryfront/dist/framework-src/react/runtime/core.ts.src": "embedded",
+    };
+    const fs = createMockFs(files);
+    const result = await resolveRelativeFrameworkImport(
+      "../runtime/core.ts",
+      "/tmp/deno-compile-veryfront/src/react/context/index.tsx",
+      fs,
+      createExistsFn(files),
+    );
+    assertEquals(
+      result,
+      "/tmp/deno-compile-veryfront/dist/framework-src/react/runtime/core.ts.src",
+    );
+  });
 });

--- a/src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.test.ts
@@ -154,4 +154,21 @@ describe("resolveRelativeFrameworkImport", () => {
       "/tmp/deno-compile-veryfront/dist/framework-src/react/runtime/core.ts.src",
     );
   });
+
+  it("resolves sibling framework component imports from compiled-binary extracted paths", async () => {
+    const files: Record<string, string> = {
+      "/tmp/deno-compile-veryfront/dist/framework-src/react/components/Head.tsx.src": "embedded",
+    };
+    const fs = createMockFs(files);
+    const result = await resolveRelativeFrameworkImport(
+      "../components/Head.tsx",
+      "/tmp/deno-compile-veryfront/src/react/fonts/index.ts",
+      fs,
+      createExistsFn(files),
+    );
+    assertEquals(
+      result,
+      "/tmp/deno-compile-veryfront/dist/framework-src/react/components/Head.tsx.src",
+    );
+  });
 });

--- a/src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.ts
@@ -8,6 +8,7 @@
 import { createFileSystem, exists } from "#veryfront/platform/compat/fs.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { rendererLogger as logger } from "#veryfront/utils";
+import { resolveRelativeFrameworkSourceImport } from "#veryfront/platform/compat/framework-source-resolver.ts";
 import { resolveInternalModuleTarget } from "../../../veryfront-module-urls.ts";
 import {
   EMBEDDED_SRC_DIR,
@@ -201,75 +202,15 @@ export async function resolveVeryfrontSourcePath(
 export async function resolveRelativeFrameworkImport(
   specifier: string,
   fromSourcePath: string,
-  _fs: ReturnType<typeof createFileSystem>,
+  fs: ReturnType<typeof createFileSystem>,
   existsFn: (path: string) => Promise<boolean> = exists,
 ): Promise<string | null> {
-  const fromDir = fromSourcePath.substring(0, fromSourcePath.lastIndexOf("/"));
-  const parts = fromDir.split("/").filter(Boolean);
-  const importParts = specifier.split("/").filter(Boolean);
-
-  for (const part of importParts) {
-    if (part === "..") {
-      parts.pop();
-    } else if (part !== ".") {
-      parts.push(part);
-    }
-  }
-
-  const basePath = "/" + parts.join("/");
-
-  // If specifier already has extension (e.g., ./Head.tsx), we need to try:
-  // 1. The exact path (basePath)
-  // 2. The path with .src suffix (basePath.src) for embedded sources
-  // 3. For transpiled .js/.mjs imports, fall back to sibling TS/TSX/JSX sources
-  if (/\.(tsx?|jsx?|mjs)$/.test(specifier)) {
-    const explicitCandidates = [basePath, `${basePath}.src`];
-
-    // esbuild rewrites TS/TSX relative imports to .js in transformed output.
-    // When the original source only exists as .ts/.tsx (or embedded .src),
-    // probe those sibling source extensions before giving up.
-    if (basePath.endsWith(".js") || basePath.endsWith(".mjs")) {
-      const stem = basePath.replace(/\.(?:m?js)$/, "");
-      for (const ext of [".ts", ".tsx", ".jsx", ".js", ".mjs"]) {
-        explicitCandidates.push(`${stem}${ext}.src`, `${stem}${ext}`);
-      }
-    }
-
-    for (const candidate of explicitCandidates) {
-      try {
-        if (await existsFn(candidate)) return candidate;
-      } catch (_) {
-        /* expected: file may not exist at this path */
-      }
-    }
-
-    return null;
-  }
-
-  // No extension provided - try all extensions (including .src for embedded sources)
-  const allExtensions = [
-    ...EXTENSIONS.map((ext) => ext + ".src"),
-    ...EXTENSIONS,
-  ];
-
-  for (const ext of allExtensions) {
-    const pathWithExt = basePath + ext;
-    try {
-      if (await existsFn(pathWithExt)) return pathWithExt;
-    } catch (_) {
-      /* expected: file may not exist at this path */
-    }
-  }
-
-  // Try index file
-  for (const ext of allExtensions) {
-    const indexPath = join(basePath, "index" + ext);
-    try {
-      if (await existsFn(indexPath)) return indexPath;
-    } catch (_) {
-      /* expected: file may not exist at this path */
-    }
-  }
-
-  return null;
+  return await resolveRelativeFrameworkSourceImport(specifier, fromSourcePath, {
+    fileSystem: fs,
+    exists: existsFn,
+    extensions: [
+      ...EXTENSIONS.map((ext) => `${ext}.src`),
+      ...EXTENSIONS,
+    ],
+  });
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.129";
+export const VERSION = "0.1.130";

--- a/tests/integration/compiled-binary-e2e.test.ts
+++ b/tests/integration/compiled-binary-e2e.test.ts
@@ -19,7 +19,12 @@
  *   VERYFRONT_BINARY_FRESH=1         # Force recompilation
  */
 
-import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertMatch,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { afterAll, beforeAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { exists } from "#veryfront/platform/compat/fs.ts";
 import { join } from "#veryfront/compat/path/index.ts";
@@ -1903,6 +1908,103 @@ export default function ClientPage() {
           "Unexpected server errors",
         );
       });
+    });
+  });
+
+  it("should render app-router layouts using veryfront/router and veryfront/context in the compiled binary", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-e2e-binary-app-router-hooks-" });
+
+    await Deno.writeTextFile(
+      join(projectDir, "package.json"),
+      JSON.stringify(
+        {
+          name: "test-binary-app-router-hooks",
+          type: "module",
+          dependencies: { react: "^19.0.0", "react-dom": "^19.0.0" },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await Deno.writeTextFile(
+      join(projectDir, "veryfront.config.ts"),
+      `export default {
+  fs: { type: "local" },
+  experimental: { rsc: true }
+};`,
+    );
+
+    await Deno.mkdir(join(projectDir, "app"), { recursive: true });
+    await Deno.writeTextFile(
+      join(projectDir, "app", "layout.tsx"),
+      `
+import { Head } from "veryfront/head";
+import { useRouter } from "veryfront/router";
+import { usePageContext } from "veryfront/context";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const ctx = usePageContext();
+
+  return (
+    <html lang="en">
+      <body>
+        <Head><title>{ctx?.frontmatter?.title || "fallback"}</title></Head>
+        <div id="app-router-layout">
+          <header id="app-router-header">
+            Layout path: {router.pathname} / Title: {ctx?.frontmatter?.title || "none"}
+          </header>
+          <main>{children}</main>
+        </div>
+      </body>
+    </html>
+  );
+}
+`,
+    );
+    await Deno.writeTextFile(
+      join(projectDir, "app", "page.tsx"),
+      `
+export const frontmatter = {
+  title: "App Router Hooks",
+};
+
+export default function HomePage() {
+  return <div id="app-router-page">App router page content</div>;
+}
+`,
+    );
+
+    await withServer(projectDir, async (server) => {
+      const response = await fetch(`http://127.0.0.1:${server.port}/`);
+      const html = await response.text();
+
+      assertEquals(response.status, 200, `Should return 200, got ${response.status}`);
+      assertStringIncludes(html, "app-router-layout", "Should render app-router layout");
+      assertStringIncludes(html, "app-router-header", "Should render app-router header");
+      assertStringIncludes(
+        html,
+        "App router page content",
+        "Should render app-router page content",
+      );
+      assertMatch(
+        html,
+        /Layout path:\s*<!-- -->\/<!-- -->\s*\/\s*Title:\s*<!-- -->(?:App Router Hooks|none)/,
+        "Should render router pathname and keep usePageContext available in the layout",
+      );
+
+      const frameworkErrors = server.logs.filter((l) =>
+        l.includes("Component has missing dependencies") ||
+        l.includes("../runtime/core.ts") ||
+        l.includes("Missing dependencies detected") ||
+        l.includes("Render failed")
+      );
+      assertEquals(
+        frameworkErrors.length,
+        0,
+        `Should have no framework dependency errors: ${frameworkErrors.join("\n")}`,
+      );
     });
   });
 

--- a/tests/integration/compiled-binary-e2e.test.ts
+++ b/tests/integration/compiled-binary-e2e.test.ts
@@ -510,6 +510,50 @@ export default function Home() {
     });
   });
 
+  it("should render page with veryfront/fonts import correctly", async () => {
+    const projectDir = await createTestProject(
+      "fonts-test",
+      `
+import { GoogleFonts } from "veryfront/fonts";
+
+export default function Home() {
+  return (
+    <>
+      <GoogleFonts
+        fonts={[
+          { name: "Inter", weights: [400, 700], variable: "--font-inter" },
+        ]}
+      />
+      <div id="content">Fonts import works</div>
+    </>
+  );
+}
+`,
+    );
+
+    await withServer(projectDir, async (server) => {
+      const response = await fetch(`http://127.0.0.1:${server.port}/`);
+      const html = await response.text();
+
+      assertEquals(response.status, 200);
+      assertStringIncludes(html, "Fonts import works", "Should render page content");
+      assertStringIncludes(html, "fonts.googleapis.com", "Should render Google Fonts link");
+      assertStringIncludes(html, "--font-inter", "Should render generated CSS variables");
+
+      const frameworkErrors = server.logs.filter((l) =>
+        l.includes("Component has missing dependencies") ||
+        l.includes("../components/Head.tsx") ||
+        l.includes("Missing dependencies detected") ||
+        l.includes("Render failed")
+      );
+      assertEquals(
+        frameworkErrors.length,
+        0,
+        `Should have no framework dependency errors: ${frameworkErrors.join("\n")}`,
+      );
+    });
+  });
+
   it("should handle multiple framework imports without React errors", async () => {
     const projectDir = await createTestProject(
       "multi-test",


### PR DESCRIPTION
## Summary
- fix compiled-binary framework source resolution when extracted `/tmp/deno-compile-veryfront/src/...` paths import relative framework modules
- add regression coverage for the staging preview failure involving `veryfront/router` and `veryfront/context`
- add same-class compiled-binary regression coverage for `veryfront/fonts`
- bump the framework version to `0.1.130`

## Root cause
On **April 2, 2026**, staging requests for `test-26e82e.preview.veryfront.org` started failing in the compiled preview runtime with missing dependencies:

- `../runtime/core.ts` from `src/react/context/index.tsx`
- `../runtime/core.ts` from `src/react/router/index.tsx`

The compiled Deno binary extracts framework sources under `/tmp/deno-compile-veryfront/src/...`, but relative framework imports were only resolving against the extracted tree. They were not falling back to the embedded `dist/framework-src/...` sources that the binary actually ships.

## What changed
- added compiled-binary-aware relative framework source resolution in the shared framework source resolver
- routed SSR Veryfront module path resolution and ESM import parsing through that shared resolver
- added focused regression tests for compiled-binary fallback from extracted framework paths to embedded framework sources
- added compiled-binary E2E coverage for:
  - `veryfront/router` + `veryfront/context` hooks in app-router layouts
  - `veryfront/fonts` imports, which use the same class of relative framework dependency
- updated the version to `0.1.130`

## Verification
- `deno test --allow-all src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.test.ts src/platform/compat/framework-source-resolver.test.ts`
- `deno check tests/integration/compiled-binary-e2e.test.ts`
- `deno task test:e2e:binary`

Latest binary result:
- `ok | 1 passed (58 steps) | 0 failed (4m13s)`

## Notes
I also reviewed the `veryfront-skill` surface while looking for same-class regressions. The broader skill docs still describe areas without full end-to-end coverage, but this PR stays intentionally narrow to unblock the remote compiled-binary regression safely.
