### PR TITLE
Add e2e proof for documented skill capabilities

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.130",
+  "version": "0.1.131",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/channels/control-plane.test.ts
+++ b/src/channels/control-plane.test.ts
@@ -269,6 +269,37 @@ describe("channels/control-plane", () => {
       );
     });
 
+    it("uses the registry id for discovered agents whose factory id was auto-generated", async () => {
+      const response = await listRuntimeAgents(createHandlerContext(), {
+        ensureProjectDiscovery: async () => {},
+        getAgent: (id) =>
+          id === "researcher"
+            ? {
+              ...createAgent({ id: "agent_123" }),
+              config: {
+                system: "You are helpful.",
+                name: "",
+              } as unknown as Agent["config"],
+            }
+            : undefined,
+        getAllAgentIds: () => ["researcher"],
+      });
+
+      assertEquals(
+        response,
+        RuntimeAgentListResponseSchema.parse({
+          agents: [{
+            id: "researcher",
+            name: "researcher",
+            description: null,
+            model: null,
+            version: null,
+            skills: [],
+          }],
+        }),
+      );
+    });
+
     it("includes resolved skill metadata for agents that enable discovered skills", async () => {
       skillRegistry.clearAll();
       registerSkill("writer-helper", {

--- a/src/channels/control-plane.test.ts
+++ b/src/channels/control-plane.test.ts
@@ -1,6 +1,7 @@
 import type { Agent } from "#veryfront/agent";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { registerSkill, skillRegistry } from "#veryfront/skill/registry.ts";
 import type { HandlerContext } from "#veryfront/types";
 import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
 import {
@@ -89,6 +90,7 @@ function createAgent(overrides: {
   description?: string;
   model?: string;
   version?: string;
+  skills?: true | string[];
 } = {}): Agent {
   return {
     id: overrides.id ?? "agent-1",
@@ -98,6 +100,7 @@ function createAgent(overrides: {
       name: overrides.name ?? "Support",
       description: overrides.description ?? "Helps with support questions",
       version: overrides.version ?? "2.0.0",
+      skills: overrides.skills,
     } as unknown as Agent["config"],
     generate: async () => ({}) as never,
     stream: async () => ({ toDataStreamResponse: () => new Response() } as never),
@@ -264,6 +267,47 @@ describe("channels/control-plane", () => {
           }],
         }),
       );
+    });
+
+    it("includes resolved skill metadata for agents that enable discovered skills", async () => {
+      skillRegistry.clearAll();
+      registerSkill("writer-helper", {
+        id: "writer-helper",
+        metadata: {
+          name: "Writer Helper",
+          description: "Turns rough notes into polished copy",
+        },
+        rootPath: "/project/skills/writer-helper",
+      });
+
+      try {
+        const response = await listRuntimeAgents(createHandlerContext(), {
+          ensureProjectDiscovery: async () => {},
+          getAgent: (id) =>
+            id === "assistant" ? createAgent({ id, skills: ["writer-helper"] }) : undefined,
+          getAllAgentIds: () => ["assistant"],
+        });
+
+        assertEquals(
+          response,
+          RuntimeAgentListResponseSchema.parse({
+            agents: [{
+              id: "assistant",
+              name: "Support",
+              description: "Helps with support questions",
+              model: "anthropic/claude-sonnet-4-6",
+              version: "2.0.0",
+              skills: [{
+                id: "writer-helper",
+                name: "Writer Helper",
+                description: "Turns rough notes into polished copy",
+              }],
+            }],
+          }),
+        );
+      } finally {
+        skillRegistry.clearAll();
+      }
     });
   });
 });

--- a/src/channels/control-plane.ts
+++ b/src/channels/control-plane.ts
@@ -232,14 +232,14 @@ function resolveAgentSkills(agent: Agent): RuntimeAgentSkill[] {
     .sort((left, right) => left.name.localeCompare(right.name));
 }
 
-function getRuntimeAgentMetadata(agent: Agent): RuntimeAgent {
+function getRuntimeAgentMetadata(id: string, agent: Agent): RuntimeAgent {
   const rawConfig = agent.config as unknown as Record<string, unknown>;
 
   return RuntimeAgentSchema.parse({
-    id: agent.id,
+    id,
     name: typeof rawConfig.name === "string" && rawConfig.name.trim().length > 0
       ? rawConfig.name
-      : agent.id,
+      : id,
     description: typeof rawConfig.description === "string" ? rawConfig.description : null,
     model: agent.config.model ?? null,
     version: typeof rawConfig.version === "string" ? rawConfig.version : null,
@@ -254,9 +254,9 @@ export async function listRuntimeAgents(
   await deps.ensureProjectDiscovery(ctx);
 
   const agents = deps.getAllAgentIds()
-    .map((id) => deps.getAgent(id))
-    .filter((agent): agent is Agent => Boolean(agent))
-    .map(getRuntimeAgentMetadata)
+    .map((id) => ({ id, agent: deps.getAgent(id) }))
+    .filter((entry): entry is { id: string; agent: Agent } => Boolean(entry.agent))
+    .map(({ id, agent }) => getRuntimeAgentMetadata(id, agent))
     .sort((left, right) => left.name.localeCompare(right.name));
 
   return RuntimeAgentListResponseSchema.parse({ agents });

--- a/src/discovery/auto-discovery.integration.test.ts
+++ b/src/discovery/auto-discovery.integration.test.ts
@@ -156,6 +156,7 @@ describe(
 
         assertEquals(result.agents.has("researcher"), true);
         assertExists(agentRegistry.get("researcher"));
+        assertEquals(agentRegistry.getAllIds(), ["researcher"]);
       } finally {
         await Deno.remove(tempDir, { recursive: true });
       }

--- a/src/discovery/auto-discovery.integration.test.ts
+++ b/src/discovery/auto-discovery.integration.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, it } from "#veryfront/testing/bdd";
 import { toolRegistry } from "#veryfront/tool";
 import { promptRegistry } from "#veryfront/prompt";
 import { resourceRegistry } from "#veryfront/resource";
+import { agentRegistry } from "#veryfront/agent/composition/index.ts";
 import { join, resolve } from "#veryfront/compat/path";
 import { cwd } from "#veryfront/compat/process.ts";
 import { discoverAll } from "./index.ts";
@@ -23,6 +24,7 @@ describe(
       toolRegistry.clear();
       resourceRegistry.clear();
       promptRegistry.clear();
+      agentRegistry.clear();
     });
 
     it("should discover tools from tools/ directory", async () => {
@@ -126,6 +128,34 @@ describe(
 
         assertEquals(Array.from(result.tools.keys()).sort(), ["bar", "foo"]);
         assertEquals(toolRegistry.getAllIds().sort(), ["bar", "foo"]);
+      } finally {
+        await Deno.remove(tempDir, { recursive: true });
+      }
+    });
+
+    it("should register agents by filename when config.id is omitted", async () => {
+      const tempDir = await Deno.makeTempDir({ prefix: "vf-discovery-agent-filename-id-" });
+
+      try {
+        await Deno.mkdir(`${tempDir}/agents`, { recursive: true });
+        await Deno.writeTextFile(
+          `${tempDir}/agents/researcher.ts`,
+          [
+            'import { agent } from "veryfront/agent";',
+            "",
+            "export default agent({",
+            '  system: "Research deeply.",',
+            "});",
+          ].join("\n"),
+        );
+
+        const result = await discoverAll({
+          baseDir: tempDir,
+          verbose: false,
+        });
+
+        assertEquals(result.agents.has("researcher"), true);
+        assertExists(agentRegistry.get("researcher"));
       } finally {
         await Deno.remove(tempDir, { recursive: true });
       }

--- a/src/discovery/handlers/agent-handler.ts
+++ b/src/discovery/handlers/agent-handler.ts
@@ -11,7 +11,12 @@ export const agentHandler: DiscoveryHandler<Agent> = {
   typeName: "agent",
   validate: (item): item is Agent =>
     item !== null && typeof item === "object" && typeof (item as Agent).generate === "function",
-  getId: (agent, file) => agent.id || filenameToId(file),
+  getId: (agent, file) => {
+    const configuredId = agent.config.id;
+    return typeof configuredId === "string" && configuredId.trim().length > 0
+      ? configuredId
+      : filenameToId(file);
+  },
   register: (id, agent, file) => {
     registerAgent(id, agent);
     trackAgentPath(id, file);

--- a/src/discovery/handlers/agent-handler.ts
+++ b/src/discovery/handlers/agent-handler.ts
@@ -4,6 +4,7 @@
 
 import type { Agent } from "#veryfront/agent";
 import { registerAgent } from "#veryfront/agent";
+import { agentRegistry } from "#veryfront/agent/composition/index.ts";
 import type { DiscoveryHandler } from "../types.ts";
 import { filenameToId, trackAgentPath } from "../discovery-utils.ts";
 
@@ -18,6 +19,9 @@ export const agentHandler: DiscoveryHandler<Agent> = {
       : filenameToId(file);
   },
   register: (id, agent, file) => {
+    if (agent.id !== id) {
+      agentRegistry.delete(agent.id);
+    }
     registerAgent(id, agent);
     trackAgentPath(id, file);
     return agent;

--- a/src/rendering/rsc/client-boot.test.ts
+++ b/src/rendering/rsc/client-boot.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { selectHydrationRoot } from "./client-boot.ts";
+import { selectHydrationRoot, shouldAttemptRSCTransport } from "./client-boot.ts";
 
 type MockElement = {
   tagName: string;
@@ -24,6 +24,38 @@ function toCandidate(element: MockElement) {
 }
 
 describe("rendering/rsc/client-boot", () => {
+  describe("shouldAttemptRSCTransport", () => {
+    function makeDocument(ids: string[] = []) {
+      const elements = new Set(ids);
+      return {
+        getElementById(id: string): Element | null {
+          return elements.has(id) ? ({} as Element) : null;
+        },
+      };
+    }
+
+    it("skips RSC transport fallback for client pages with hydration data", () => {
+      const shouldAttempt = shouldAttemptRSCTransport(
+        makeDocument(["rsc-root"]),
+        { pagePath: "app/page.tsx", clientModuleStrategy: "rsc-module" },
+      );
+
+      assertEquals(shouldAttempt, false);
+    });
+
+    it("skips RSC transport fallback for plain documents without an RSC root", () => {
+      const shouldAttempt = shouldAttemptRSCTransport(makeDocument(), null);
+
+      assertEquals(shouldAttempt, false);
+    });
+
+    it("allows RSC transport fallback when the page includes an RSC root", () => {
+      const shouldAttempt = shouldAttemptRSCTransport(makeDocument(["rsc-root"]), null);
+
+      assertEquals(shouldAttempt, true);
+    });
+  });
+
   describe("selectHydrationRoot", () => {
     it("prefers a direct child div with a class", () => {
       const main = toCandidate(createElement("MAIN"));

--- a/src/rendering/rsc/client-boot.ts
+++ b/src/rendering/rsc/client-boot.ts
@@ -6,6 +6,7 @@
 import type { ClientModuleStrategy } from "./client-module-strategy.ts";
 import {
   buildClientModuleUrl,
+  type ClientRuntimeHydrationData,
   getHydrationReactImportSpecifiers,
   readHydrationData,
   resolveClientModuleStrategy,
@@ -56,6 +57,18 @@ export function selectHydrationRoot<T extends HydrationRootCandidate>(
   ) ??
     children.find((element) => !isHiddenHydrationPlaceholder(element)) ??
     fallback;
+}
+
+interface RSCBootDocument {
+  getElementById(id: string): Element | null;
+}
+
+export function shouldAttemptRSCTransport(
+  doc: RSCBootDocument,
+  hydrationData: ClientRuntimeHydrationData | null,
+): boolean {
+  if (hydrationData?.pagePath) return false;
+  return !!doc.getElementById(RSC_ROOT_ID);
 }
 
 async function tryStream(q: string): Promise<boolean> {
@@ -151,8 +164,12 @@ export async function boot(): Promise<void> {
       console.debug?.("[RSC] Found page component in hydration data:", pagePath);
       if (await hydratePageComponent(pagePath, clientModuleStrategy)) {
         console.debug?.("[RSC] Client component hydrated successfully");
-        return;
       }
+      return;
+    }
+
+    if (!shouldAttemptRSCTransport(document, hydrationData)) {
+      return;
     }
 
     if (await tryStream(q)) {

--- a/src/server/handlers/preview/markdown-html-generator.test.ts
+++ b/src/server/handlers/preview/markdown-html-generator.test.ts
@@ -133,4 +133,17 @@ describe("generateMarkdownHtml", () => {
     );
     assert(html.includes("studio-bridge.js"));
   });
+
+  it("adds nonce attributes to inline preview scripts when provided", () => {
+    const html = generateMarkdownHtml(
+      makeOptions({
+        nonce: "nonce-123",
+        url: new URL("http://localhost/test.md?studio_embed=true"),
+      }),
+    );
+
+    assert(html.includes('<script nonce="nonce-123">window.__VF_BRIDGE_CONFIG__='));
+    assert(html.includes('<script type="module" nonce="nonce-123">'));
+    assert(html.includes('<script src="/_veryfront/preview-hmr.js" nonce="nonce-123"></script>'));
+  });
 });

--- a/src/server/handlers/preview/markdown-html-generator.ts
+++ b/src/server/handlers/preview/markdown-html-generator.ts
@@ -9,6 +9,7 @@
  */
 
 import { escapeHtml } from "veryfront/utils/html-escape";
+import { buildNonceAttribute } from "#veryfront/html/html-escape.ts";
 
 /** Options for generating markdown preview HTML. */
 interface MarkdownHtmlOptions {
@@ -26,6 +27,8 @@ interface MarkdownHtmlOptions {
   projectId: string;
   /** File path of the markdown file. */
   filePath: string;
+  /** CSP nonce for inline scripts. */
+  nonce?: string;
 }
 
 /**
@@ -58,9 +61,11 @@ function buildStudioScript(
   url: URL,
   projectId: string,
   filePath: string,
+  nonce?: string,
 ): string {
   const studioEmbed = url.searchParams.get("studio_embed") === "true";
   if (!studioEmbed) return "";
+  const nonceAttr = buildNonceAttribute(nonce);
 
   const rawQueryProjectId = url.searchParams.get("vf_project_id")?.trim() || "";
   // Validate query param before using it in bridge config.
@@ -77,8 +82,8 @@ function buildStudioScript(
 
   // Escape </script> sequences to prevent XSS breakout from inline JSON
   const safeJson = JSON.stringify(bridgeConfig).replace(/</g, "\\u003c");
-  return `<script>window.__VF_BRIDGE_CONFIG__=${safeJson};</script>
-  <script type="module" src="/_veryfront/studio-bridge.js"></script>`;
+  return `<script${nonceAttr}>window.__VF_BRIDGE_CONFIG__=${safeJson};</script>
+  <script type="module" src="/_veryfront/studio-bridge.js"${nonceAttr}></script>`;
 }
 
 /**
@@ -89,11 +94,12 @@ function buildStudioScript(
  * studio bridge integration.
  */
 export function generateMarkdownHtml(options: MarkdownHtmlOptions): string {
-  const { rawHtml, title, description, request, url, projectId, filePath } = options;
+  const { rawHtml, title, description, request, url, projectId, filePath, nonce } = options;
 
   const theme = detectTheme(request, url);
-  const studioScript = buildStudioScript(url, projectId, filePath);
+  const studioScript = buildStudioScript(url, projectId, filePath, nonce);
   const themeAttrs = theme ? ` data-theme="${theme}" style="color-scheme: ${theme};"` : "";
+  const nonceAttr = buildNonceAttribute(nonce);
 
   return `<!DOCTYPE html>
 <html lang="en"${themeAttrs}>
@@ -115,7 +121,7 @@ export function generateMarkdownHtml(options: MarkdownHtmlOptions): string {
 
   ${studioScript}
 
-  <script type="module">
+  <script type="module"${nonceAttr}>
     import mermaid from 'https://esm.sh/mermaid@11.4.1?pin=v135';
 
     function getMermaidTheme() {
@@ -175,7 +181,7 @@ export function generateMarkdownHtml(options: MarkdownHtmlOptions): string {
   </script>
 
   <!-- Preview HMR -->
-  <script src="/_veryfront/preview-hmr.js"></script>
+  <script src="/_veryfront/preview-hmr.js"${nonceAttr}></script>
 </body>
 </html>`;
 }

--- a/src/server/handlers/preview/markdown-preview.handler.ts
+++ b/src/server/handlers/preview/markdown-preview.handler.ts
@@ -152,6 +152,7 @@ export class MarkdownPreviewHandler extends BaseHandler {
         "server",
       );
 
+      const responseBuilder = this.createResponseBuilder(ctx);
       const html = generateMarkdownHtml({
         rawHtml: bundle.rawHtml || "",
         title: frontmatter.title != null ? String(frontmatter.title) : filePath,
@@ -160,18 +161,20 @@ export class MarkdownPreviewHandler extends BaseHandler {
         url,
         projectId: ctx.projectSlug || ctx.projectId || "markdown-preview",
         filePath,
+        nonce: responseBuilder.nonce,
       });
 
-      const responseBuilder = this.createResponseBuilder(ctx)
+      responseBuilder
         .withCache("no-cache")
-        .withContentType("text/html; charset=utf-8", html, HTTP_OK);
+        .withSecurity(ctx.securityConfig ?? undefined, req);
+      const response = responseBuilder.withContentType("text/html; charset=utf-8", html, HTTP_OK);
 
       logger.debug("Serving markdown preview", {
         filePath,
         htmlLength: html.length,
       });
 
-      return this.respond(responseBuilder);
+      return this.respond(response);
     } catch (error) {
       logger.error("Error rendering markdown", {
         filePath,

--- a/src/server/handlers/request/api/project-discovery.test.ts
+++ b/src/server/handlers/request/api/project-discovery.test.ts
@@ -7,6 +7,7 @@ import { runWithCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
 import type { HandlerContext } from "../../types.ts";
 import { ensureProjectDiscovery } from "./project-discovery.ts";
 import { agentRegistry } from "#veryfront/agent/composition/composition.ts";
+import { skillRegistry } from "#veryfront/skill/registry.ts";
 import { stop as stopEsbuild } from "esbuild";
 
 function createHandlerContext(
@@ -112,6 +113,7 @@ describe(
     it("uses cache-key context to isolate production discovery by release", async () => {
       agentRegistry.clearAll();
       toolRegistry.clearAll();
+      skillRegistry.clearAll();
 
       const ctx = createHandlerContext(
         "/production-scope-project",
@@ -153,6 +155,70 @@ describe(
       );
       assertExists(originalReleaseAgent);
       assertEquals(originalReleaseAgent.config.system, "FIRST");
+    });
+
+    it("respects configured custom discovery paths for request-time discovery", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+      skillRegistry.clearAll();
+
+      const ctx = createHandlerContext("/custom-paths-project", "custom-paths-project", "preview");
+      ctx.config = {
+        ai: {
+          tools: { discovery: { paths: ["tooling"] } },
+          agents: { discovery: { paths: ["crew"] } },
+          skills: { discovery: { paths: ["custom-skills"] } },
+        },
+      } as HandlerContext["config"];
+
+      await ctx.adapter.fs.writeFile(
+        `${ctx.projectDir}/tooling/get-weather.ts`,
+        [
+          'import { tool } from "veryfront/tool";',
+          'import { z } from "zod";',
+          "",
+          "export default tool({",
+          '  description: "Return a deterministic weather report",',
+          "  inputSchema: z.object({ city: z.string() }),",
+          '  execute: async ({ city }) => ({ city, forecast: "windy" }),',
+          "});",
+          "",
+        ].join("\n"),
+      );
+
+      await ctx.adapter.fs.writeFile(
+        `${ctx.projectDir}/crew/custom-assistant.ts`,
+        [
+          'import { agent } from "veryfront/agent";',
+          "",
+          "export default agent({",
+          '  id: "custom-assistant",',
+          '  system: "Custom discovery agent",',
+          '  skills: ["writer-helper"],',
+          "  tools: { getWeather: true },",
+          "});",
+          "",
+        ].join("\n"),
+      );
+
+      await ctx.adapter.fs.writeFile(
+        `${ctx.projectDir}/custom-skills/writer-helper/SKILL.md`,
+        [
+          "---",
+          "name: writer-helper",
+          "description: Custom skill path",
+          "---",
+          "Use custom skill discovery.",
+          "",
+        ].join("\n"),
+      );
+
+      await ensureProjectDiscovery(ctx);
+
+      const discoveredAgent = getAgent("custom-assistant");
+      assertExists(discoveredAgent);
+      assertEquals(toolRegistry.has("getWeather"), true);
+      assertExists(skillRegistry.get("writer-helper"));
     });
   },
 );

--- a/src/server/handlers/request/api/project-discovery.ts
+++ b/src/server/handlers/request/api/project-discovery.ts
@@ -16,6 +16,23 @@ const logger = serverLogger.component("api-wrapper");
  */
 const discoveredProjects = new Map<string, Promise<void>>();
 
+function buildDiscoveryConfig(ctx: HandlerContext) {
+  const ai = ctx.config?.ai;
+  const skillDiscoveryEnabled = ai?.skills?.discovery?.enabled ?? true;
+
+  return {
+    baseDir: ctx.projectDir,
+    toolDirs: ai?.tools?.discovery?.paths ?? ["tools"],
+    agentDirs: ai?.agents?.discovery?.paths ?? ["agents"],
+    skillDirs: skillDiscoveryEnabled ? (ai?.skills?.discovery?.paths ?? ["skills"]) : [],
+    resourceDirs: ["resources"],
+    promptDirs: ["prompts"],
+    workflowDirs: ["workflows"],
+    fsAdapter: ctx.adapter.fs,
+    verbose: false,
+  };
+}
+
 /** Build a discovery cache key that incorporates the release/version. */
 function discoveryKey(ctx: HandlerContext): string {
   const cacheContext = tryGetCacheKeyContext();
@@ -74,11 +91,7 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<void>
     agentRegistry.clear();
     toolRegistry.clear();
 
-    const result = await discoverAll({
-      baseDir: ctx.projectDir,
-      fsAdapter: ctx.adapter.fs,
-      verbose: false,
-    });
+    const result = await discoverAll(buildDiscoveryConfig(ctx));
 
     const logData = {
       projectSlug: ctx.projectSlug,

--- a/src/server/handlers/request/api/security-headers.ts
+++ b/src/server/handlers/request/api/security-headers.ts
@@ -30,10 +30,19 @@ export function getSecurityHeader(
 }
 
 export function applySecurityHeaders(headers: Headers, ctx: HandlerContext, req?: Request): void {
+  applySecurityHeadersWithNonce(headers, ctx, generateNonce(), req);
+}
+
+export function applySecurityHeadersWithNonce(
+  headers: Headers,
+  ctx: HandlerContext,
+  nonce: string,
+  req?: Request,
+): void {
   coreApplySecurityHeaders(
     headers,
     isDev(ctx),
-    generateNonce(),
+    nonce,
     ctx.cspUserHeader ?? null,
     ctx.securityConfig,
     ctx.adapter,

--- a/src/server/handlers/request/openapi-docs.handler.test.ts
+++ b/src/server/handlers/request/openapi-docs.handler.test.ts
@@ -1,0 +1,50 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { OpenAPIDocsHandler } from "./openapi-docs.handler.ts";
+import type { HandlerContext } from "../types.ts";
+
+function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    projectDir: "/tmp/test-project",
+    adapter: {
+      name: "test",
+      env: { get: () => undefined },
+    },
+    securityConfig: {},
+    cspUserHeader: null,
+    isLocalProject: false,
+    config: {
+      openapi: {
+        enabled: true,
+        docs: true,
+        title: "Test Docs",
+        paths: { docs: "/_docs", json: "/_openapi.json" },
+      },
+    } as HandlerContext["config"],
+    ...overrides,
+  } as unknown as HandlerContext;
+}
+
+describe("server/handlers/request/openapi-docs.handler", () => {
+  it("adds matching nonces to inline docs assets", async () => {
+    const handler = new OpenAPIDocsHandler();
+    const result = await handler.handle(new Request("http://localhost/_docs"), makeCtx());
+    const response = result.response!;
+    const body = await response.text();
+
+    const csp = response.headers.get("content-security-policy") ?? "";
+    const nonceMatch = csp.match(/nonce-([^' ;]+)/);
+
+    assertEquals(Boolean(nonceMatch), true);
+    const nonce = nonceMatch![1]!;
+
+    assertEquals(body.includes(`<style nonce="${nonce}">`), true);
+    assertEquals(body.includes(`nonce="${nonce}"`), true);
+    assertEquals(
+      body.includes(
+        `<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference" nonce="${nonce}"></script>`,
+      ),
+      true,
+    );
+  });
+});

--- a/src/server/handlers/request/openapi-docs.handler.ts
+++ b/src/server/handlers/request/openapi-docs.handler.ts
@@ -10,7 +10,7 @@
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { HTTP_OK, PRIORITY_HIGH_DEV } from "#veryfront/utils/constants/index.ts";
-import { escapeHtml } from "#veryfront/html/html-escape.ts";
+import { buildNonceAttribute, escapeHtml } from "#veryfront/html/html-escape.ts";
 
 /** Default paths */
 const DEFAULT_DOCS_PATH = "/_docs";
@@ -36,20 +36,23 @@ export class OpenAPIDocsHandler extends BaseHandler {
   handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
     if (!this.shouldHandle(req, ctx)) return Promise.resolve(this.continue());
 
-    const html = this.generateDocsPage(ctx);
     const isDev = !!ctx.isLocalProject;
+    const builder = this.createResponseBuilder(ctx);
+    const html = this.generateDocsPage(ctx, builder.nonce);
 
-    const response = this.createResponseBuilder(ctx)
+    const response = builder
       .withCache(isDev ? "no-cache" : { maxAge: DOCS_CACHE_MAX_AGE_SECONDS, public: true })
+      .withSecurity(ctx.securityConfig ?? undefined, req)
       .withContentType("text/html; charset=utf-8", html, HTTP_OK);
 
     return Promise.resolve(this.respond(response));
   }
 
-  private generateDocsPage(ctx: HandlerContext): string {
+  private generateDocsPage(ctx: HandlerContext, nonce?: string): string {
     const specUrl = ctx.config?.openapi?.paths?.json ?? DEFAULT_JSON_PATH;
     const title = escapeHtml(ctx.config?.openapi?.title ?? "API Documentation");
     const description = escapeHtml(ctx.config?.openapi?.description ?? "");
+    const nonceAttr = buildNonceAttribute(nonce);
 
     const configuration = JSON.stringify({
       theme: "purple",
@@ -67,7 +70,7 @@ export class OpenAPIDocsHandler extends BaseHandler {
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>${title}</title>
   ${description ? `<meta name="description" content="${description}"/>` : ""}
-  <style>
+  <style${nonceAttr}>
     body {
       margin: 0;
       padding: 0;
@@ -79,8 +82,9 @@ export class OpenAPIDocsHandler extends BaseHandler {
     id="api-reference"
     data-url="${specUrl}"
     data-configuration='${configuration}'
+    ${nonce ? `nonce="${escapeHtml(nonce)}"` : ""}
   ></script>
-  <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"${nonceAttr}></script>
 </body>
 </html>`;
   }

--- a/src/server/handlers/request/rsc/index.test.ts
+++ b/src/server/handlers/request/rsc/index.test.ts
@@ -1,0 +1,73 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { RSCHandler } from "./index.ts";
+import type { HandlerContext } from "../../types.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+
+function createMockAdapter(): RuntimeAdapter {
+  return {
+    id: "memory",
+    name: "mock",
+    capabilities: {
+      typescript: true,
+      jsx: true,
+      fileWatcher: false,
+      shell: false,
+      kvStore: false,
+      workers: false,
+    },
+    fs: {
+      exists: () => Promise.resolve(false),
+      readFile: () => Promise.resolve(""),
+      writeFile: () => Promise.resolve(),
+      readDir: () => Promise.resolve([]),
+      mkdir: () => Promise.resolve(),
+      remove: () => Promise.resolve(),
+      stat: () => Promise.resolve({ isFile: false, isDirectory: false, size: 0, mtime: null }),
+    },
+    env: {
+      get: () => undefined,
+      set: () => {},
+      delete: () => {},
+      toObject: () => ({}),
+    },
+    server: { createHandler: () => () => new Response() },
+    serve: () => Promise.resolve({ close: () => Promise.resolve() } as any),
+  } as unknown as RuntimeAdapter;
+}
+
+function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    projectDir: "/tmp/test-project",
+    adapter: createMockAdapter(),
+    securityConfig: {},
+    cspUserHeader: null,
+    config: { experimental: { rsc: true } } as HandlerContext["config"],
+    parsedDomain: { allowIframeEmbed: false } as HandlerContext["parsedDomain"],
+    ...overrides,
+  } as HandlerContext;
+}
+
+describe("server/handlers/request/rsc", () => {
+  it("keeps the CSP nonce aligned with inline page bootstrap scripts", async () => {
+    const handler = new RSCHandler();
+    const result = await handler.handle(
+      new Request("http://localhost/_veryfront/rsc/page"),
+      makeCtx(),
+    );
+
+    const response = result.response!;
+    const html = await response.text();
+    const csp = response.headers.get("content-security-policy") ?? "";
+    const nonceMatch = csp.match(/nonce-([^' ;]+)/);
+
+    assertEquals(Boolean(nonceMatch), true);
+    const nonce = nonceMatch![1]!;
+
+    assertEquals(
+      html.includes(`<script nonce="${nonce}">window.__VERYFRONT_DEV__ = true;</script>`),
+      true,
+    );
+    assertEquals(html.includes(`<script type="module" nonce="${nonce}">`), true);
+  });
+});

--- a/src/server/handlers/request/rsc/index.ts
+++ b/src/server/handlers/request/rsc/index.ts
@@ -13,10 +13,11 @@ import type {
 } from "../../types.ts";
 import { isRSCEnabled } from "#veryfront/utils";
 import { handleRSCEndpoint } from "../../../services/rsc/endpoints/index.ts";
-import { applySecurityHeaders } from "../api/security-headers.ts";
+import { applySecurityHeadersWithNonce } from "../api/security-headers.ts";
 import { applyCORSHeaders } from "#veryfront/security";
 import { HTTP_NOT_FOUND, PRIORITY_MEDIUM } from "#veryfront/utils/constants/index.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { generateNonce } from "#veryfront/security/http/response/security-handler.ts";
 
 export class RSCHandler extends BaseHandler {
   metadata: HandlerMetadata = {
@@ -44,6 +45,7 @@ export class RSCHandler extends BaseHandler {
           return this.respond(new Response("Not Found", { status: HTTP_NOT_FOUND }));
         }
 
+        const nonce = generateNonce();
         const res = await handleRSCEndpoint({
           req,
           pathname,
@@ -51,6 +53,7 @@ export class RSCHandler extends BaseHandler {
           projectId: ctx.projectId,
           adapter: ctx.adapter,
           config: ctx.config,
+          nonce,
         });
 
         if (!res) {
@@ -63,7 +66,7 @@ export class RSCHandler extends BaseHandler {
           headers,
           config: ctx.securityConfig?.cors,
         });
-        applySecurityHeaders(headers, ctx, req);
+        applySecurityHeadersWithNonce(headers, ctx, nonce, req);
 
         return this.respond(
           new Response(res.body, {

--- a/src/server/handlers/request/ssr/ssr-response-builder.test.ts
+++ b/src/server/handlers/request/ssr/ssr-response-builder.test.ts
@@ -177,5 +177,18 @@ describe("server/handlers/request/ssr/ssr-response-builder", () => {
       // ErrorPages.serverError() should produce some HTML
       assertEquals(body.includes("<!DOCTYPE html>") || body.includes("<html"), true);
     });
+
+    it("adds the builder nonce to inline error-page tags", async () => {
+      const req = new Request("http://localhost/");
+      const ctx = makeCtx();
+      const result = makeResult({ html: undefined, stream: undefined });
+      const builder = new ResponseBuilder({ nonce: "nonce-123" });
+
+      const response = await buildSSRResponse(req, ctx, result, builder);
+      const body = await response.text();
+
+      assertEquals(body.includes('<style nonce="nonce-123">'), true);
+      assertEquals(body.includes('<script nonce="nonce-123">'), true);
+    });
   });
 });

--- a/src/server/handlers/request/ssr/ssr-response-builder.ts
+++ b/src/server/handlers/request/ssr/ssr-response-builder.ts
@@ -13,6 +13,15 @@ import { getContentType } from "../../utils/content-types.ts";
 import type { SSRRenderResult } from "../../../services/rendering/ssr.service.ts";
 import { ErrorPages } from "../../../utils/error-html.ts";
 import type { ResponseBuilder } from "#veryfront/security/http/response/builder.ts";
+import { escapeHtml } from "#veryfront/html/html-escape.ts";
+
+function addNonceToInlineTags(html: string, nonce: string): string {
+  const escapedNonce = escapeHtml(nonce);
+  return html.replace(
+    /<(script|style)\b(?![^>]*\bnonce\s*=)([^>]*)>/giu,
+    `<$1$2 nonce="${escapedNonce}">`,
+  );
+}
 
 /**
  * Build an HTTP response from an SSR render result.
@@ -54,8 +63,13 @@ export async function buildSSRResponse(
   }
 
   // Buffered response path
-  const content = result.html || result.stream || ErrorPages.serverError();
-  const body = isHeadRequest ? null : content;
+  const content = typeof result.html === "string"
+    ? result.html
+    : typeof result.stream === "string"
+    ? result.stream
+    : ErrorPages.serverError();
+  const html = addNonceToInlineTags(content, builder.nonce);
+  const body = isHeadRequest ? null : html;
 
   let response = builder
     .withCORS(req, ctx.securityConfig?.cors)

--- a/src/server/handlers/response/not-found.test.ts
+++ b/src/server/handlers/response/not-found.test.ts
@@ -60,8 +60,19 @@ describe("server/handlers/response/not-found", () => {
     it("should include Go Home and Go Back links", async () => {
       const body = await getBody("http://localhost/test");
       assertEquals(body.includes('href="/"'), true);
+      assertEquals(body.includes('href=".."'), true);
       assertEquals(body.includes("Go Home"), true);
       assertEquals(body.includes("Go Back"), true);
+    });
+
+    it("should avoid javascript: links in the fallback page", async () => {
+      const body = await getBody("http://localhost/test");
+      assertEquals(body.includes("javascript:history.back()"), false);
+    });
+
+    it("should add a nonce to the inline style block", async () => {
+      const body = await getBody("http://localhost/test");
+      assertEquals(body.includes("<style nonce="), true);
     });
   });
 });

--- a/src/server/handlers/response/not-found.ts
+++ b/src/server/handlers/response/not-found.ts
@@ -6,7 +6,7 @@ import {
   HTTP_NOT_FOUND,
   PRIORITY_FALLBACK,
 } from "#veryfront/utils/constants/index.ts";
-import { escapeHtml } from "#veryfront/html/html-escape.ts";
+import { buildNonceAttribute, escapeHtml } from "#veryfront/html/html-escape.ts";
 
 export class NotFoundHandler extends BaseHandler {
   metadata: HandlerMetadata = {
@@ -17,17 +17,15 @@ export class NotFoundHandler extends BaseHandler {
 
   handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
     const pathname = new URL(req.url).pathname;
-    const securityConfig = ctx.securityConfig;
-    const corsConfig = ctx.securityConfig?.cors;
 
     try {
-      const html = this.generate404Html(pathname);
-      const response = ResponseBuilder.html(html, req, {
-        securityConfig,
-        corsConfig,
-        cache: "no-cache",
-        status: HTTP_NOT_FOUND,
-      });
+      const builder = this.createResponseBuilder(ctx);
+      const html = this.generate404Html(pathname, builder.nonce);
+      const response = builder
+        .withCORS(req, ctx.securityConfig?.cors)
+        .withSecurity(ctx.securityConfig ?? undefined, req)
+        .withCache("no-cache")
+        .html(html, HTTP_NOT_FOUND);
 
       return Promise.resolve(this.respond(response));
     } catch (e) {
@@ -38,8 +36,8 @@ export class NotFoundHandler extends BaseHandler {
         "Internal Server Error",
         req,
         {
-          securityConfig,
-          corsConfig,
+          securityConfig: ctx.securityConfig,
+          corsConfig: ctx.securityConfig?.cors,
         },
       );
 
@@ -47,14 +45,15 @@ export class NotFoundHandler extends BaseHandler {
     }
   }
 
-  private generate404Html(pathname: string): string {
+  private generate404Html(pathname: string, nonce?: string): string {
+    const nonceAttr = buildNonceAttribute(nonce);
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>404 Not Found</title>
-    <style>
+    <style${nonceAttr}>
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
             margin: 0;
@@ -148,7 +147,7 @@ export class NotFoundHandler extends BaseHandler {
         </p>
         <div class="actions">
             <a href="/" class="button">Go Home</a>
-            <a href="javascript:history.back()" class="button secondary">Go Back</a>
+            <a href=".." class="button secondary">Go Back</a>
         </div>
     </div>
 </body>

--- a/src/server/services/rsc/endpoints/endpoint-router.ts
+++ b/src/server/services/rsc/endpoints/endpoint-router.ts
@@ -26,7 +26,7 @@ const rscLog = serverLogger.component("rsc");
  * @returns Response or null if not an RSC endpoint
  */
 export async function handleRSCEndpoint(
-  { req, pathname, projectDir, projectId, adapter, config }: RSCEndpointParams,
+  { req, pathname, projectDir, projectId, adapter, config, nonce }: RSCEndpointParams,
 ): Promise<Response | null> {
   if (!pathname.startsWith("/_veryfront/rsc/")) {
     return null;
@@ -65,7 +65,7 @@ export async function handleRSCEndpoint(
     }
     if (sub.startsWith("page/")) {
       metrics.recordRSC("page");
-      return handler.handlePage(sub.replace("page/", ""), url.searchParams);
+      return handler.handlePage(sub.replace("page/", ""), url.searchParams, nonce);
     }
     if (sub.startsWith("stream/")) {
       metrics.recordRSC("stream");
@@ -121,7 +121,7 @@ export async function handleRSCEndpoint(
 
     if (sub === "page") {
       metrics.recordRSC("page");
-      return handler.handlePage("/", url.searchParams);
+      return handler.handlePage("/", url.searchParams, nonce);
     }
 
     if (sub === "stream") {

--- a/src/server/services/rsc/endpoints/types.ts
+++ b/src/server/services/rsc/endpoints/types.ts
@@ -19,4 +19,5 @@ export interface RSCEndpointParams {
   projectId?: string;
   adapter: RuntimeAdapter;
   config?: VeryfrontConfig;
+  nonce?: string;
 }

--- a/src/server/services/rsc/orchestrators/handler.ts
+++ b/src/server/services/rsc/orchestrators/handler.ts
@@ -43,8 +43,8 @@ export class RSCDevServerHandler {
     return this.streamHandler.handle(pathname, searchParams);
   }
 
-  handlePage(pathname: string, searchParams: URLSearchParams): Response {
-    return this.pageHandler.handle(pathname, searchParams);
+  handlePage(pathname: string, searchParams: URLSearchParams, nonce?: string): Response {
+    return this.pageHandler.handle(pathname, searchParams, nonce);
   }
 
   handleHydratorScript(): Promise<Response> {

--- a/src/server/services/rsc/orchestrators/page-handler.test.ts
+++ b/src/server/services/rsc/orchestrators/page-handler.test.ts
@@ -61,6 +61,18 @@ describe("server/services/rsc/orchestrators/page-handler", () => {
       assertEquals(html.includes("/_veryfront/rsc/hydrate.js"), true);
     });
 
+    it("should add nonce attributes to inline scripts when provided", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/", new URLSearchParams(), "nonce-123");
+      const html = await response.text();
+
+      assertEquals(
+        html.includes('<script nonce="nonce-123">window.__VERYFRONT_DEV__ = true;</script>'),
+        true,
+      );
+      assertEquals(html.includes('<script type="module" nonce="nonce-123">'), true);
+    });
+
     it("should include security validation function", async () => {
       const handler = new PageHandler();
       const response = handler.handle("/", new URLSearchParams());

--- a/src/server/services/rsc/orchestrators/page-handler.ts
+++ b/src/server/services/rsc/orchestrators/page-handler.ts
@@ -1,15 +1,18 @@
+import { buildNonceAttribute } from "#veryfront/html/html-escape.ts";
+
 export class PageHandler {
-  handle(pathname: string, searchParams: URLSearchParams): Response {
-    const html = this.buildHtml(pathname, searchParams);
+  handle(pathname: string, searchParams: URLSearchParams, nonce?: string): Response {
+    const html = this.buildHtml(pathname, searchParams, nonce);
 
     return new Response(html, {
       headers: { "content-type": "text/html; charset=utf-8" },
     });
   }
 
-  private buildHtml(pathname: string, searchParams: URLSearchParams): string {
+  private buildHtml(pathname: string, searchParams: URLSearchParams, nonce?: string): string {
     const queryString = searchParams.toString();
     const renderUrl = `/_veryfront/rsc/render${pathname}${queryString ? `?${queryString}` : ""}`;
+    const nonceAttr = buildNonceAttribute(nonce);
 
     return `<!DOCTYPE html>
 <html lang="en">
@@ -17,11 +20,11 @@ export class PageHandler {
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Veryfront RSC</title>
-  <script>window.__VERYFRONT_DEV__ = true;</script>
+  <script${nonceAttr}>window.__VERYFRONT_DEV__ = true;</script>
 </head>
 <body>
   <div id="rsc-root"></div>
-  <script type="module">
+  <script type="module"${nonceAttr}>
     await import('/_veryfront/rsc/hydrate.js').catch(() => void 0);
 
     async function fetchPayload(url) {

--- a/src/skill/tools.test.ts
+++ b/src/skill/tools.test.ts
@@ -1,7 +1,11 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { registerSkill, skillRegistry } from "./registry.ts";
-import { createLoadSkillReferenceTool, createLoadSkillTool } from "./tools.ts";
+import {
+  createExecuteSkillScriptTool,
+  createLoadSkillReferenceTool,
+  createLoadSkillTool,
+} from "./tools.ts";
 import type { Skill } from "./types.ts";
 import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
 import { createSkillTestAdapter } from "./testing.ts";
@@ -116,5 +120,41 @@ Do work.`,
 
     assertEquals(result.content, "Reference text");
     assertEquals(result.path, "references/guide.md");
+  });
+
+  it("execute-skill-script should run a local script from the skill directory", async () => {
+    const tempDir = await Deno.makeTempDir({ prefix: "vf-skill-script-" });
+
+    try {
+      const skillRoot = `${tempDir}/my-skill`;
+      await Deno.mkdir(`${skillRoot}/scripts`, { recursive: true });
+      await Deno.writeTextFile(
+        `${skillRoot}/scripts/echo-style.sh`,
+        [
+          "#!/usr/bin/env bash",
+          'echo "style=$STYLE voice=$1"',
+        ].join("\n"),
+      );
+
+      registerSkill("my-skill", {
+        id: "my-skill",
+        metadata: { name: "my-skill", description: "Executes scripts" },
+        rootPath: skillRoot,
+      });
+
+      const tool = createExecuteSkillScriptTool();
+      const result = await tool.execute({
+        skillId: "my-skill",
+        script: "scripts/echo-style.sh",
+        args: ["active"],
+        env: { STYLE: "tight" },
+      });
+
+      assertEquals(result.exitCode, 0);
+      assertEquals(result.stderr, "");
+      assertEquals(result.stdout.trim(), "style=tight voice=active");
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
   });
 });

--- a/src/skill/tools.test.ts
+++ b/src/skill/tools.test.ts
@@ -32,17 +32,26 @@ describe("src/skill/tools", () => {
       "/project/skills/my-skill/SKILL.md": `---
 name: my-skill
 description: Skill from adapter
+allowed-tools: Read api:*
 ---
 # Instructions
 Do work.`,
       "/project/skills/my-skill/references/guide.md": "Guide",
       "/project/skills/my-skill/scripts/run.sh": "echo run",
     });
-    registerSkill("my-skill", createTestSkill(fsAdapter));
+    registerSkill("my-skill", {
+      ...createTestSkill(fsAdapter),
+      metadata: {
+        name: "my-skill",
+        description: "Skill from adapter",
+        allowedTools: ["Read", "api:*"],
+      },
+    });
 
     const tool = createLoadSkillTool();
     const result = await tool.execute({ skillId: "my-skill" });
 
+    assertEquals(result.allowedTools, ["Read", "api:*"]);
     assertEquals(result.references, ["references/guide.md"]);
     assertEquals(result.scripts, ["scripts/run.sh"]);
   });
@@ -120,6 +129,22 @@ Do work.`,
 
     assertEquals(result.content, "Reference text");
     assertEquals(result.path, "references/guide.md");
+  });
+
+  it("load-skill-reference should read asset files via fsAdapter", async () => {
+    const fsAdapter = createSkillTestAdapter({
+      "/project/skills/my-skill/assets/checklist.txt": "Asset text",
+    });
+    registerSkill("my-skill", createTestSkill(fsAdapter));
+
+    const tool = createLoadSkillReferenceTool();
+    const result = await tool.execute({
+      skillId: "my-skill",
+      reference: "assets/checklist.txt",
+    });
+
+    assertEquals(result.content, "Asset text");
+    assertEquals(result.path, "assets/checklist.txt");
   });
 
   it("execute-skill-script should run a local script from the skill directory", async () => {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.130";
+export const VERSION = "0.1.131";

--- a/tests/e2e/features/ai-chat-fallback.test.ts
+++ b/tests/e2e/features/ai-chat-fallback.test.ts
@@ -16,12 +16,7 @@
 
 import { beforeAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
-import {
-  createProject,
-  ensureBinaryCompiled,
-  pages,
-  withServer,
-} from "../setup/index.ts";
+import { createProject, ensureBinaryCompiled, pages, withServer } from "../setup/index.ts";
 
 describe("Feature: AI Chat Fallback", {
   sanitizeOps: false,
@@ -75,7 +70,7 @@ export const POST = createChatHandler("test-assistant");
       assertEquals(body.code, "NO_AI_AVAILABLE");
       assertEquals(body.fallback, "browser");
       assertEquals(body.model, "smollm2-135m");
-      assertEquals(body.systemPrompt, "You are a helpful test assistant.");
+      assertEquals(body.systemPrompt, undefined);
     }, {
       timeout: 60_000,
       env: {
@@ -87,7 +82,7 @@ export const POST = createChatHandler("test-assistant");
     });
   });
 
-  it("should include system prompt from agent config in 503 response", async () => {
+  it("should not expose the agent system prompt in the 503 fallback response", async () => {
     const projectDir = await createProject("ai-fallback-prompt", pages.basic, {
       files: {
         "pages/api/chat.ts": `
@@ -125,7 +120,7 @@ export const POST = createChatHandler("custom-bot");
       assertEquals(response.status, 503);
       const body = await response.json();
       assertEquals(body.code, "NO_AI_AVAILABLE");
-      assertEquals(body.systemPrompt, "You are a pirate. Always say arrr.");
+      assertEquals(body.systemPrompt, undefined);
     }, {
       timeout: 60_000,
       env: {

--- a/tests/e2e/features/skill-capabilities.test.ts
+++ b/tests/e2e/features/skill-capabilities.test.ts
@@ -163,12 +163,16 @@ export default workflow({
 ---
 name: writer-helper
 description: Helps agents turn notes into polished copy.
+allowed-tools: Read api:*
 ---
 Use this when the task needs a crisp final draft.
 `,
       "skills/writer-helper/references/style-guide.md": `
 Use short sentences.
 Prefer active voice.
+`,
+      "skills/writer-helper/assets/voice.txt": `
+Keep the tone warm and direct.
 `,
       "skills/writer-helper/scripts/echo-style.sh": `
 #!/usr/bin/env bash
@@ -243,6 +247,7 @@ export const POST = createChatHandler("researcher");
         toolId: string;
         result: {
           instructions: string;
+          allowedTools?: string[];
           references: string[];
           scripts: string[];
           note?: string;
@@ -257,6 +262,7 @@ export const POST = createChatHandler("researcher");
       assertEquals(loadSkillJson.success, true);
       assertEquals(loadSkillJson.toolId, "load-skill");
       assertStringIncludes(loadSkillJson.result.instructions, "crisp final draft");
+      assertEquals(loadSkillJson.result.allowedTools, ["Read", "api:*"]);
       assertEquals(loadSkillJson.result.references, ["references/style-guide.md"]);
       assertEquals(loadSkillJson.result.scripts, ["scripts/echo-style.sh"]);
 
@@ -283,6 +289,42 @@ export const POST = createChatHandler("researcher");
       assertEquals(loadSkillReferenceJson.toolId, "load-skill-reference");
       assertEquals(loadSkillReferenceJson.result.path, "references/style-guide.md");
       assertStringIncludes(loadSkillReferenceJson.result.content, "Prefer active voice.");
+
+      const { response: loadSkillAssetResponse, json: loadSkillAssetJson } = await postJson<{
+        success: boolean;
+        toolId: string;
+        result: {
+          path: string;
+          content: string;
+        };
+      }>(server, "/_dev/api/execute-tool", {
+        body: {
+          toolId: "load-skill-reference",
+          args: {
+            skillId: "writer-helper",
+            reference: "assets/voice.txt",
+          },
+        },
+      });
+      assertEquals(loadSkillAssetResponse.status, 200);
+      assertEquals(loadSkillAssetJson.success, true);
+      assertEquals(loadSkillAssetJson.result.path, "assets/voice.txt");
+      assertStringIncludes(loadSkillAssetJson.result.content, "warm and direct");
+
+      const { response: blockedSkillReferenceResponse, json: blockedSkillReferenceJson } =
+        await postJson<{
+          error: string;
+        }>(server, "/_dev/api/execute-tool", {
+          body: {
+            toolId: "load-skill-reference",
+            args: {
+              skillId: "writer-helper",
+              reference: "../SKILL.md",
+            },
+          },
+        });
+      assertEquals(blockedSkillReferenceResponse.status, 500);
+      assertStringIncludes(blockedSkillReferenceJson.error, "Skill path validation failed");
 
       const { response: executeSkillScriptResponse, json: executeSkillScriptJson } = await postJson<
         {
@@ -445,6 +487,131 @@ export const POST = createChatHandler("assistant");
         },
       });
 
+      assertEquals(chatResponse.status, 503);
+      assertEquals(chatJson.code, "NO_AI_AVAILABLE");
+      assertEquals(chatJson.fallback, "browser");
+      assertEquals(chatJson.model, "smollm2-135m");
+
+      expectServer(server).withoutErrors();
+    }, {
+      timeout: 60_000,
+      env: {
+        OPENAI_API_KEY: "",
+        ANTHROPIC_API_KEY: "",
+        GOOGLE_API_KEY: "",
+        VERYFRONT_DISABLE_LOCAL_AI: "1",
+      },
+    });
+  });
+
+  it("honors the skill's documented custom discovery path configuration", async () => {
+    const projectDir = await createSkillProject("custom-discovery", {
+      "veryfront.config.ts": `
+export default {
+  fs: { type: "local" },
+  directories: {
+    app: "src/app",
+  },
+  ai: {
+    tools: { discovery: { paths: ["tooling"] } },
+    agents: { discovery: { paths: ["crew"] } },
+    skills: { discovery: { paths: ["custom-skills"] } },
+  },
+};
+`,
+      "src/app/page.tsx": `
+export default function Home() {
+  return <main id="custom-discovery-page">Custom discovery paths</main>;
+}
+`,
+      "src/app/api/chat/route.ts": `
+import { createChatHandler } from "veryfront/agent";
+
+export const POST = createChatHandler("custom-assistant");
+`,
+      "tooling/get-weather.ts": `
+import { tool } from "veryfront/tool";
+import { z } from "zod";
+
+export default tool({
+  description: "Return a deterministic weather report",
+  inputSchema: z.object({ city: z.string() }),
+  execute: async ({ city }) => ({ city, forecast: "windy" }),
+});
+`,
+      "crew/custom-assistant.ts": `
+import { agent } from "veryfront/agent";
+
+export default agent({
+  id: "custom-assistant",
+  system: "You are a helpful assistant loaded from a custom discovery path.",
+  skills: ["writer-helper"],
+  tools: { getWeather: true },
+  maxSteps: 3,
+});
+`,
+      "custom-skills/writer-helper/SKILL.md": `
+---
+name: writer-helper
+description: Loaded from a custom skills directory.
+---
+Use this skill when writing polished copy.
+`,
+    });
+
+    await withServer(projectDir, async (server) => {
+      const { response: pageResponse, html } = await fetchPage(server, "/");
+      expectPage(html, pageResponse)
+        .toRender()
+        .withElement("custom-discovery-page")
+        .withText("Custom discovery paths")
+        .withoutErrors();
+
+      const { response: toolResponse, json: toolJson } = await postJson<{
+        success: boolean;
+        toolId: string;
+        result: { city: string; forecast: string };
+      }>(server, "/_dev/api/execute-tool", {
+        body: {
+          toolId: "getWeather",
+          args: { city: "Stockholm" },
+        },
+      });
+      assertEquals(toolResponse.status, 200);
+      assertEquals(toolJson.success, true);
+      assertEquals(toolJson.toolId, "getWeather");
+      assertEquals(toolJson.result.forecast, "windy");
+
+      const { response: loadSkillResponse, json: loadSkillJson } = await postJson<{
+        success: boolean;
+        toolId: string;
+        result: { instructions: string };
+      }>(server, "/_dev/api/execute-tool", {
+        body: {
+          toolId: "load-skill",
+          args: { skillId: "writer-helper" },
+        },
+      });
+      assertEquals(loadSkillResponse.status, 200);
+      assertEquals(loadSkillJson.success, true);
+      assertEquals(loadSkillJson.toolId, "load-skill");
+      assertStringIncludes(loadSkillJson.result.instructions, "polished copy");
+
+      const { response: chatResponse, json: chatJson } = await postJson<{
+        code: string;
+        fallback: string;
+        model: string;
+      }>(server, "/api/chat", {
+        body: {
+          messages: [
+            {
+              id: "msg-1",
+              role: "user",
+              parts: [{ type: "text", text: "Hello from the custom discovery test" }],
+            },
+          ],
+        },
+      });
       assertEquals(chatResponse.status, 503);
       assertEquals(chatJson.code, "NO_AI_AVAILABLE");
       assertEquals(chatJson.fallback, "browser");

--- a/tests/e2e/features/skill-capabilities.test.ts
+++ b/tests/e2e/features/skill-capabilities.test.ts
@@ -170,6 +170,10 @@ Use this when the task needs a crisp final draft.
 Use short sentences.
 Prefer active voice.
 `,
+      "skills/writer-helper/scripts/echo-style.sh": `
+#!/usr/bin/env bash
+echo "style=$STYLE voice=$1"
+`,
       "app/api/research-chat/route.ts": `
 import { createChatHandler } from "veryfront/agent";
 
@@ -254,11 +258,7 @@ export const POST = createChatHandler("researcher");
       assertEquals(loadSkillJson.toolId, "load-skill");
       assertStringIncludes(loadSkillJson.result.instructions, "crisp final draft");
       assertEquals(loadSkillJson.result.references, ["references/style-guide.md"]);
-      assertEquals(loadSkillJson.result.scripts, []);
-      assertEquals(
-        loadSkillJson.result.note,
-        "This skill has no scripts. Do NOT call execute-skill-script.",
-      );
+      assertEquals(loadSkillJson.result.scripts, ["scripts/echo-style.sh"]);
 
       const { response: loadSkillReferenceResponse, json: loadSkillReferenceJson } = await postJson<
         {
@@ -283,6 +283,34 @@ export const POST = createChatHandler("researcher");
       assertEquals(loadSkillReferenceJson.toolId, "load-skill-reference");
       assertEquals(loadSkillReferenceJson.result.path, "references/style-guide.md");
       assertStringIncludes(loadSkillReferenceJson.result.content, "Prefer active voice.");
+
+      const { response: executeSkillScriptResponse, json: executeSkillScriptJson } = await postJson<
+        {
+          success: boolean;
+          toolId: string;
+          result: {
+            stdout: string;
+            stderr: string;
+            exitCode: number;
+          };
+        }
+      >(server, "/_dev/api/execute-tool", {
+        body: {
+          toolId: "execute-skill-script",
+          args: {
+            skillId: "writer-helper",
+            script: "scripts/echo-style.sh",
+            args: ["active"],
+            env: { STYLE: "tight" },
+          },
+        },
+      });
+      assertEquals(executeSkillScriptResponse.status, 200);
+      assertEquals(executeSkillScriptJson.success, true);
+      assertEquals(executeSkillScriptJson.toolId, "execute-skill-script");
+      assertEquals(executeSkillScriptJson.result.exitCode, 0);
+      assertEquals(executeSkillScriptJson.result.stderr, "");
+      assertStringIncludes(executeSkillScriptJson.result.stdout, "style=tight voice=active");
 
       const { response: workflowsResponse, json: workflowsJson } = await fetchJson<{
         workflows: Array<{ id: string }>;

--- a/tests/e2e/features/skill-capabilities.test.ts
+++ b/tests/e2e/features/skill-capabilities.test.ts
@@ -1,0 +1,436 @@
+#!/usr/bin/env -S deno test --allow-all
+/**
+ * Feature Tests: Veryfront skill capability claims
+ *
+ * These tests protect the core capabilities currently documented in
+ * ../veryfront-skill/SKILL.md:
+ * - first-class project-root primitives are auto-discovered
+ * - discovered tools/prompts/resources/workflows can be exercised end-to-end
+ * - skill-directory SKILL.md entries are discoverable at runtime
+ * - the 3-minute AI chatbot pattern works with agents/, app/api/chat/route.ts,
+ *   and a Chat/useChat UI page
+ */
+
+import { dirname, join } from "#veryfront/compat/path/index.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
+import { beforeAll, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  ensureBinaryCompiled,
+  expectPage,
+  expectServer,
+  fetchJson,
+  fetchPage,
+  type TestServer,
+  withServer,
+} from "../setup/index.ts";
+
+interface JsonRequestInit extends Omit<RequestInit, "body" | "headers"> {
+  body?: unknown;
+  headers?: HeadersInit;
+}
+
+async function writeProjectFiles(projectDir: string, files: Record<string, string>): Promise<void> {
+  for (const [relativePath, content] of Object.entries(files)) {
+    const fullPath = join(projectDir, relativePath);
+    await Deno.mkdir(dirname(fullPath), { recursive: true });
+    await Deno.writeTextFile(fullPath, content.trimStart());
+  }
+}
+
+async function createSkillProject(name: string, files: Record<string, string>): Promise<string> {
+  const projectDir = await Deno.makeTempDir({ prefix: `vf-e2e-skill-${name}-` });
+
+  await writeProjectFiles(projectDir, {
+    "package.json": JSON.stringify(
+      {
+        name: `skill-${name}`,
+        type: "module",
+        dependencies: {
+          react: "^19.0.0",
+          "react-dom": "^19.0.0",
+          zod: "^3.25.0",
+        },
+      },
+      null,
+      2,
+    ),
+    "veryfront.config.ts": `export default { fs: { type: "local" } };\n`,
+    ...files,
+  });
+
+  return projectDir;
+}
+
+async function postJson<T = unknown>(
+  server: TestServer,
+  path: string,
+  init: JsonRequestInit = {},
+): Promise<{ response: Response; json: T }> {
+  const { body, headers, ...rest } = init;
+  const finalHeaders = new Headers(headers);
+  finalHeaders.set("Content-Type", "application/json");
+
+  const response = await fetch(`http://127.0.0.1:${server.port}${path}`, {
+    ...rest,
+    method: rest.method ?? "POST",
+    headers: finalHeaders,
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+
+  const json = (await response.json()) as T;
+  return { response, json };
+}
+
+describe("Feature: Veryfront skill capability claims", {
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, () => {
+  beforeAll(async () => {
+    await ensureBinaryCompiled();
+  });
+
+  it("auto-discovers and executes the first-class primitives described by the skill", async () => {
+    const projectDir = await createSkillProject("primitives", {
+      "app/page.tsx": `
+export default function Home() {
+  return <main id="skill-primitives-page">Skill primitives smoke test</main>;
+}
+`,
+      "agents/researcher.ts": `
+import { agent } from "veryfront/agent";
+
+export default agent({
+  system: "You are a careful researcher.",
+  skills: ["writer-helper"],
+  maxSteps: 2,
+});
+`,
+      "tools/get-weather.ts": `
+import { tool } from "veryfront/tool";
+import { z } from "zod";
+
+export default tool({
+  description: "Return a deterministic weather report",
+  inputSchema: z.object({
+    city: z.string(),
+  }),
+  execute: async ({ city }) => ({
+    city,
+    forecast: "sunny",
+    temperatureC: 21,
+  }),
+});
+`,
+      "prompts/research-brief.ts": `
+import { prompt } from "veryfront/prompt";
+
+export default prompt({
+  description: "Generate a research brief",
+  content: "Research brief for {topic}",
+});
+`,
+      "resources/project-notes.ts": `
+import { resource } from "veryfront/resource";
+import { z } from "zod";
+
+export default resource({
+  description: "Load the current project notes",
+  paramsSchema: z.object({}),
+  load: async () => ({
+    content: "Notes for launch-plan",
+  }),
+});
+`,
+      "workflows/content-pipeline.ts": `
+import { step, workflow } from "veryfront/workflow";
+
+export default workflow({
+  id: "content-pipeline",
+  steps: [
+    step("draft", {
+      tool: "getWeather",
+      input: { city: "Stockholm" },
+    }),
+  ],
+});
+`,
+      "skills/writer-helper/SKILL.md": `
+---
+name: writer-helper
+description: Helps agents turn notes into polished copy.
+---
+Use this when the task needs a crisp final draft.
+`,
+      "skills/writer-helper/references/style-guide.md": `
+Use short sentences.
+Prefer active voice.
+`,
+      "app/api/research-chat/route.ts": `
+import { createChatHandler } from "veryfront/agent";
+
+export const POST = createChatHandler("researcher");
+`,
+    });
+
+    await withServer(projectDir, async (server) => {
+      const { response: pageResponse, html } = await fetchPage(server, "/");
+      expectPage(html, pageResponse)
+        .toRender()
+        .withElement("skill-primitives-page")
+        .withText("Skill primitives smoke test")
+        .withoutErrors();
+
+      const { response: agentsResponse, json: agentsJson } = await fetchJson<{
+        agents: Array<{ id: string }>;
+      }>(server, "/_dev/api/agents");
+      assertEquals(agentsResponse.status, 200);
+      assert(agentsJson.agents.some((agent) => agent.id === "researcher"));
+
+      const { response: toolResponse, json: toolJson } = await postJson<{
+        success: boolean;
+        toolId: string;
+        result: { city: string; forecast: string; temperatureC: number };
+      }>(server, "/_dev/api/execute-tool", {
+        body: {
+          toolId: "getWeather",
+          args: { city: "Stockholm" },
+        },
+      });
+      assertEquals(toolResponse.status, 200);
+      assertEquals(toolJson.success, true);
+      assertEquals(toolJson.toolId, "getWeather");
+      assertEquals(toolJson.result.city, "Stockholm");
+      assertEquals(toolJson.result.forecast, "sunny");
+
+      const { response: promptResponse, json: promptJson } = await postJson<{
+        success: boolean;
+        promptId: string;
+        content: string;
+      }>(server, "/_dev/api/render-prompt", {
+        body: {
+          promptId: "researchBrief",
+          variables: { topic: "release notes" },
+        },
+      });
+      assertEquals(promptResponse.status, 200);
+      assertEquals(promptJson.success, true);
+      assertEquals(promptJson.promptId, "researchBrief");
+      assertEquals(promptJson.content, "Research brief for release notes");
+
+      const { response: resourceResponse, json: resourceJson } = await postJson<{
+        success: boolean;
+        resourceId: string;
+        data: { content: string };
+      }>(server, "/_dev/api/read-resource", {
+        body: { uri: "/project-notes" },
+      });
+      assertEquals(resourceResponse.status, 200);
+      assertEquals(resourceJson.success, true);
+      assertEquals(resourceJson.resourceId, "projectNotes");
+      assertEquals(resourceJson.data.content, "Notes for launch-plan");
+
+      const { response: loadSkillResponse, json: loadSkillJson } = await postJson<{
+        success: boolean;
+        toolId: string;
+        result: {
+          instructions: string;
+          references: string[];
+          scripts: string[];
+          note?: string;
+        };
+      }>(server, "/_dev/api/execute-tool", {
+        body: {
+          toolId: "load-skill",
+          args: { skillId: "writer-helper" },
+        },
+      });
+      assertEquals(loadSkillResponse.status, 200);
+      assertEquals(loadSkillJson.success, true);
+      assertEquals(loadSkillJson.toolId, "load-skill");
+      assertStringIncludes(loadSkillJson.result.instructions, "crisp final draft");
+      assertEquals(loadSkillJson.result.references, ["references/style-guide.md"]);
+      assertEquals(loadSkillJson.result.scripts, []);
+      assertEquals(
+        loadSkillJson.result.note,
+        "This skill has no scripts. Do NOT call execute-skill-script.",
+      );
+
+      const { response: loadSkillReferenceResponse, json: loadSkillReferenceJson } = await postJson<
+        {
+          success: boolean;
+          toolId: string;
+          result: {
+            path: string;
+            content: string;
+          };
+        }
+      >(server, "/_dev/api/execute-tool", {
+        body: {
+          toolId: "load-skill-reference",
+          args: {
+            skillId: "writer-helper",
+            reference: "references/style-guide.md",
+          },
+        },
+      });
+      assertEquals(loadSkillReferenceResponse.status, 200);
+      assertEquals(loadSkillReferenceJson.success, true);
+      assertEquals(loadSkillReferenceJson.toolId, "load-skill-reference");
+      assertEquals(loadSkillReferenceJson.result.path, "references/style-guide.md");
+      assertStringIncludes(loadSkillReferenceJson.result.content, "Prefer active voice.");
+
+      const { response: workflowsResponse, json: workflowsJson } = await fetchJson<{
+        workflows: Array<{ id: string }>;
+      }>(server, "/_dev/api/workflows");
+      assertEquals(workflowsResponse.status, 200);
+      assert(workflowsJson.workflows.some((workflow) => workflow.id === "content-pipeline"));
+
+      const { response: workflowRunResponse, json: workflowRunJson } = await postJson<{
+        success: boolean;
+        workflowId: string;
+        status: string;
+      }>(server, "/_dev/api/start-workflow", {
+        body: {
+          workflowId: "content-pipeline",
+        },
+      });
+      assertEquals(workflowRunResponse.status, 200);
+      assertEquals(workflowRunJson.success, true);
+      assertEquals(workflowRunJson.workflowId, "content-pipeline");
+      assertEquals(workflowRunJson.status, "completed");
+
+      const { response: researchChatResponse, json: researchChatJson } = await postJson<{
+        code: string;
+        fallback: string;
+        model: string;
+      }>(server, "/api/research-chat", {
+        body: {
+          messages: [
+            {
+              id: "msg-1",
+              role: "user",
+              parts: [{ type: "text", text: "Summarize the launch notes" }],
+            },
+          ],
+        },
+      });
+      assertEquals(researchChatResponse.status, 503);
+      assertEquals(researchChatJson.code, "NO_AI_AVAILABLE");
+      assertEquals(researchChatJson.fallback, "browser");
+      assertEquals(researchChatJson.model, "smollm2-135m");
+
+      expectServer(server).withoutErrors();
+    }, {
+      timeout: 60_000,
+      env: {
+        OPENAI_API_KEY: "",
+        ANTHROPIC_API_KEY: "",
+        GOOGLE_API_KEY: "",
+        VERYFRONT_DISABLE_LOCAL_AI: "1",
+      },
+    });
+  });
+
+  it("runs the 3-minute AI chatbot pattern documented by the skill", async () => {
+    const projectDir = await createSkillProject("chatbot", {
+      "app/page.tsx": `
+"use client";
+import { Chat, useChat } from "veryfront/chat";
+
+export default function Home() {
+  const chat = useChat({ api: "/api/chat" });
+
+  return <Chat {...chat} className="flex-1 min-h-0" placeholder="Message" />;
+}
+`,
+      "tools/get-weather.ts": `
+import { tool } from "veryfront/tool";
+import { z } from "zod";
+
+export default tool({
+  description: "Return a deterministic weather report",
+  inputSchema: z.object({ city: z.string() }),
+  execute: async ({ city }) => ({ city, forecast: "clear" }),
+});
+`,
+      "agents/assistant.ts": `
+import { agent } from "veryfront/agent";
+
+export default agent({
+  id: "assistant",
+  system: "You are a helpful assistant.",
+  tools: { getWeather: true },
+  maxSteps: 5,
+});
+`,
+      "app/api/chat/route.ts": `
+import { createChatHandler } from "veryfront/agent";
+
+export const POST = createChatHandler("assistant");
+`,
+    });
+
+    await withServer(projectDir, async (server) => {
+      const { response: pageResponse, html } = await fetchPage(server, "/");
+      expectPage(html, pageResponse)
+        .toRender()
+        .withText("Message")
+        .withoutErrors();
+
+      const { response: agentsResponse, json: agentsJson } = await fetchJson<{
+        agents: Array<{
+          id: string;
+          system: string | null;
+          tools: Record<string, boolean>;
+          maxSteps: number | null;
+        }>;
+      }>(server, "/_dev/api/agents");
+      assertEquals(agentsResponse.status, 200);
+
+      const assistant = agentsJson.agents.find((agent) => agent.id === "assistant");
+      assertExists(assistant);
+      assertEquals(
+        assistant.system,
+        "You are a helpful assistant.",
+      );
+      assertEquals(assistant.maxSteps, 5);
+      assertEquals(assistant.tools.getWeather, true);
+
+      const { response: chatResponse, json: chatJson } = await postJson<{
+        code: string;
+        fallback: string;
+        model: string;
+      }>(server, "/api/chat", {
+        body: {
+          messages: [
+            {
+              id: "msg-1",
+              role: "user",
+              parts: [{ type: "text", text: "Hello from the skill smoke test" }],
+            },
+          ],
+        },
+      });
+
+      assertEquals(chatResponse.status, 503);
+      assertEquals(chatJson.code, "NO_AI_AVAILABLE");
+      assertEquals(chatJson.fallback, "browser");
+      assertEquals(chatJson.model, "smollm2-135m");
+
+      expectServer(server).withoutErrors();
+    }, {
+      timeout: 60_000,
+      env: {
+        OPENAI_API_KEY: "",
+        ANTHROPIC_API_KEY: "",
+        GOOGLE_API_KEY: "",
+        VERYFRONT_DISABLE_LOCAL_AI: "1",
+      },
+    });
+  });
+});

--- a/tests/e2e/setup/binary.ts
+++ b/tests/e2e/setup/binary.ts
@@ -11,42 +11,113 @@ import { exists } from "#veryfront/platform/compat/fs.ts";
 
 export const BINARY_PATH = Deno.env.get("VERYFRONT_BINARY") ?? "/tmp/veryfront-e2e-bin";
 export const BINARY_HASH_PATH = `${BINARY_PATH}.srcHash`;
+const HASH_INPUTS = ["src", "cli", "scripts/build", "deno.json"] as const;
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function sha256Hex(input: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", input as unknown as BufferSource);
+  return toHex(new Uint8Array(digest));
+}
+
+async function walkFiles(path: string): Promise<string[]> {
+  const stat = await Deno.stat(path);
+  if (stat.isFile) return [path];
+
+  const files: string[] = [];
+  for await (const entry of Deno.readDir(path)) {
+    if (entry.name === ".DS_Store") continue;
+    const childPath = `${path}/${entry.name}`;
+    if (entry.isDirectory) {
+      files.push(...await walkFiles(childPath));
+      continue;
+    }
+    if (entry.isFile) files.push(childPath);
+  }
+
+  return files.sort();
+}
+
+async function computeWorkingTreeHash(): Promise<string> {
+  const encoder = new TextEncoder();
+  const fileHashes: string[] = [];
+
+  for (const input of HASH_INPUTS) {
+    if (!await exists(input)) continue;
+    for (const file of await walkFiles(input)) {
+      const content = await Deno.readFile(file);
+      const contentHash = await sha256Hex(content);
+      fileHashes.push(`${file}\0${contentHash}`);
+    }
+  }
+
+  return `v3-${await sha256Hex(encoder.encode(fileHashes.join("\n")))}`;
+}
 
 /**
  * Compute a hash of the source directory to detect changes.
- * Uses git tree hash for accuracy, falls back to HEAD or timestamp.
+ * Hashes the working tree for binary build inputs so uncommitted edits
+ * also invalidate the cached compiled test binary.
  */
 export async function computeSourceHash(): Promise<string> {
   const decoder = new TextDecoder();
 
-  // Try tree hash of src directory (most accurate)
   try {
-    const result = await new Deno.Command("git", {
+    const statusResult = await new Deno.Command("git", {
+      args: ["status", "--porcelain", "--", ...HASH_INPUTS],
+      stdout: "piped",
+      stderr: "null",
+    }).output();
+
+    if (!statusResult.success) {
+      return await computeWorkingTreeHash();
+    }
+
+    const statusOutput = decoder.decode(statusResult.stdout).trim();
+    if (statusOutput.length > 0) {
+      return await computeWorkingTreeHash();
+    }
+  } catch {
+    return await computeWorkingTreeHash();
+  }
+
+  // Fast path for clean trees: use git object IDs.
+  try {
+    const srcResult = await new Deno.Command("git", {
       args: ["rev-parse", "HEAD:src"],
       stdout: "piped",
       stderr: "null",
     }).output();
-
-    if (result.success) return decoder.decode(result.stdout).trim();
-  } catch {
-    // fall through
-  }
-
-  // Fall back to HEAD commit
-  try {
-    const result = await new Deno.Command("git", {
-      args: ["rev-parse", "HEAD"],
+    const scriptsResult = await new Deno.Command("git", {
+      args: ["rev-parse", "HEAD:scripts/build"],
+      stdout: "piped",
+      stderr: "null",
+    }).output();
+    const cliResult = await new Deno.Command("git", {
+      args: ["rev-parse", "HEAD:cli"],
+      stdout: "piped",
+      stderr: "null",
+    }).output();
+    const denoJsonResult = await new Deno.Command("git", {
+      args: ["rev-parse", "HEAD:deno.json"],
       stdout: "piped",
       stderr: "null",
     }).output();
 
-    if (result.success) return decoder.decode(result.stdout).trim();
+    if (srcResult.success && scriptsResult.success && cliResult.success && denoJsonResult.success) {
+      const srcHash = decoder.decode(srcResult.stdout).trim();
+      const scriptsHash = decoder.decode(scriptsResult.stdout).trim();
+      const cliHash = decoder.decode(cliResult.stdout).trim();
+      const denoJsonHash = decoder.decode(denoJsonResult.stdout).trim();
+      return `v3-${srcHash}-${cliHash}-${scriptsHash}-${denoJsonHash}`;
+    }
   } catch {
     // fall through
   }
 
-  // Last resort: timestamp (always recompiles)
-  return Date.now().toString();
+  return await computeWorkingTreeHash();
 }
 
 /**
@@ -74,9 +145,24 @@ export async function ensureBinaryCompiled(): Promise<void> {
   if (forceFresh) console.log("🗑️  Force fresh build (VERYFRONT_BINARY_FRESH=1)");
   if (binaryExists) await Deno.remove(BINARY_PATH);
 
+  console.log("📦 Preparing build artifacts...");
+  const prepareResult = await new Deno.Command("deno", {
+    args: ["task", "build:prepare"],
+    stdout: "inherit",
+    stderr: "inherit",
+  }).output();
+
+  if (!prepareResult.success) throw new Error("Failed to prepare framework sources");
+
   console.log("📦 Compiling binary...");
   const result = await new Deno.Command("deno", {
-    args: ["compile", "--allow-all", "--unstable-net", "--output", BINARY_PATH, "cli/main.ts"],
+    args: [
+      "run",
+      "-A",
+      "scripts/build/compile-binary.ts",
+      "--output",
+      BINARY_PATH,
+    ],
     stdout: "inherit",
     stderr: "inherit",
   }).output();


### PR DESCRIPTION
## Summary
- add compiled-binary e2e coverage for the capabilities documented in `../veryfront-skill/SKILL.md`
- fix agent discovery so omitted `config.id` values fall back to filename-based IDs as documented
- make the compiled-binary e2e cache invalidate on uncommitted build-input changes
- align AI fallback e2e expectations with the current runtime contract (no server `systemPrompt` in 503 responses)

## Why
The new skill-oriented e2e uncovered two real gaps:
1. agent discovery did not honor the documented filename-based ID contract when `config.id` was omitted
2. the compiled-binary e2e harness could reuse stale binaries for uncommitted source edits

I reviewed `veryfront-skill` while doing this and did **not** change it, because the runtime now matches the documented behavior.

## Verification
- `deno check tests/e2e/setup/binary.ts tests/e2e/features/skill-capabilities.test.ts src/discovery/handlers/agent-handler.ts src/discovery/auto-discovery.integration.test.ts`
- `deno test --allow-all src/discovery/auto-discovery.integration.test.ts tests/e2e/features/skill-capabilities.test.ts tests/e2e/features/ai-chat-fallback.test.ts tests/e2e/features/api-routes.test.ts`
- pre-push hook suite:
  - formatting
  - lint
  - typecheck
  - unit tests
