### PR TITLE
Keep static HTML compatible with nonce-based CSP

### DIFF
--- a/src/html/html-injection.test.ts
+++ b/src/html/html-injection.test.ts
@@ -106,6 +106,28 @@ describe("html/html-injection", () => {
       assertEquals(hydrationData.clientModuleStrategy, "rsc-module");
     });
 
+    it("adds the provided nonce to client-page hydration data", () => {
+      const html = injectHTMLContent(
+        baseTemplate,
+        "<p>content</p>",
+        minMeta,
+        {
+          mode: "production",
+          slug: "test",
+          pagePath: "/app/page.tsx",
+          isClientPage: true,
+          nonce: "nonce-123",
+        },
+      );
+
+      assertEquals(
+        html.includes(
+          '<script id="veryfront-hydration-data" type="application/json" nonce="nonce-123">',
+        ),
+        true,
+      );
+    });
+
     it("should use fs hydration strategy for local development client pages", () => {
       const html = injectHTMLContent(
         baseTemplate,
@@ -138,6 +160,57 @@ describe("html/html-injection", () => {
       );
 
       assertEquals(html.includes("studio-bridge.js"), true);
+    });
+
+    it("propagates the nonce to injected development styles and scripts", () => {
+      const html = injectHTMLContent(
+        baseTemplate,
+        "<p>content</p>",
+        minMeta,
+        {
+          mode: "development",
+          slug: "test",
+          nonce: "nonce-123",
+        },
+      );
+
+      assertEquals(html.includes('<style nonce="nonce-123">'), true);
+      assertEquals(
+        html.includes(
+          '<script type="module" src="/_veryfront/rsc/client.js" nonce="nonce-123"></script>',
+        ),
+        true,
+      );
+      assertEquals(
+        html.includes('<script type="module" src="/_veryfront/hmr.js" nonce="nonce-123"></script>'),
+        true,
+      );
+    });
+
+    it("propagates the nonce to injected production scripts", () => {
+      const html = injectHTMLContent(
+        baseTemplate,
+        "<p>content</p>",
+        minMeta,
+        {
+          mode: "production",
+          slug: "my-slug",
+          nonce: "nonce-123",
+        },
+      );
+
+      assertEquals(
+        html.includes(
+          '<script type="module" src="/_veryfront/rsc/client.js" nonce="nonce-123"></script>',
+        ),
+        true,
+      );
+      assertEquals(
+        html.includes(
+          '<script type="module" src="/_veryfront/hydrate.js?slug=my-slug" nonce="nonce-123"></script>',
+        ),
+        true,
+      );
     });
 
     it("injects preview utility CSS for remote preview full HTML documents", () => {

--- a/src/html/html-injection.ts
+++ b/src/html/html-injection.ts
@@ -116,8 +116,9 @@ export function injectHTMLContent(
         environment: options.environment,
       }),
     });
+    const nonceAttr = buildNonceAttribute(options.nonce);
     const hydrationScript =
-      `<script id="veryfront-hydration-data" type="application/json">${hydrationData}</script>`;
+      `<script id="veryfront-hydration-data" type="application/json"${nonceAttr}>${hydrationData}</script>`;
     html = html.replace(/<\/body>/i, `${hydrationScript}</body>`);
   }
 
@@ -125,19 +126,22 @@ export function injectHTMLContent(
     const hasDevScriptsPlaceholder = /{{\s*devScripts\s*}}/i.test(html);
 
     if (hasDevScriptsPlaceholder) {
-      html = html.replace(/{{\s*devScripts\s*}}/gi, getDevScripts());
+      html = html.replace(/{{\s*devScripts\s*}}/gi, getDevScripts(options.devPort, options.nonce));
     }
 
-    html = html.replace(/{{\s*devStyles\s*}}/gi, getDevStyles());
+    html = html.replace(/{{\s*devStyles\s*}}/gi, getDevStyles(options.nonce));
 
     if (!hasDevScriptsPlaceholder && hasBodyClose) {
-      html = html.replace(/<\/body>/i, `${getDevStyles()}${getDevScripts()}</body>`);
+      html = html.replace(
+        /<\/body>/i,
+        `${getDevStyles(options.nonce)}${getDevScripts(options.devPort, options.nonce)}</body>`,
+      );
     }
   } else {
     html = html.replace(/{{\s*devScripts\s*}}/gi, "");
     html = html.replace(/{{\s*devStyles\s*}}/gi, "");
 
-    const prodScripts = getProdScripts(options.slug);
+    const prodScripts = getProdScripts(options.slug, options.nonce);
     const hasProdScriptsPlaceholder = /{{\s*prodScripts\s*}}/i.test(html);
 
     if (hasProdScriptsPlaceholder) {

--- a/src/html/nonce-injection.test.ts
+++ b/src/html/nonce-injection.test.ts
@@ -39,4 +39,32 @@ describe("html/nonce-injection", () => {
     assertEquals(html.includes('<script nonce="nonce-123">alert(1)'), false);
     assertEquals(html.includes('<style nonce="nonce-123">.x{color:red}'), false);
   });
+
+  it("does not terminate raw-text mode on lookalike closing-tag prefixes inside script literals", () => {
+    const html = addNonceToHtmlTags(
+      `<script>window.tpl="</scripture><style>.x{color:red}</style>";</script><style>.chat{color:red}</style>`,
+      "nonce-123",
+    );
+
+    assertEquals(
+      html.includes(
+        '<script nonce="nonce-123">window.tpl="</scripture><style>.x{color:red}</style>";</script>',
+      ),
+      true,
+    );
+    assertEquals(html.includes('<style nonce="nonce-123">.chat{color:red}</style>'), true);
+    assertEquals(html.includes('<style nonce="nonce-123">.x{color:red}</style>'), false);
+  });
+
+  it("does not treat data-nonce as an existing nonce attribute", () => {
+    const html = addNonceToHtmlTags(
+      `<script data-nonce="existing">window.__vf=1</script>`,
+      "nonce-123",
+    );
+
+    assertEquals(
+      html.includes('<script data-nonce="existing" nonce="nonce-123">window.__vf=1</script>'),
+      true,
+    );
+  });
 });

--- a/src/html/nonce-injection.test.ts
+++ b/src/html/nonce-injection.test.ts
@@ -1,0 +1,42 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { addNonceToHtmlTags } from "./nonce-injection.ts";
+
+describe("html/nonce-injection", () => {
+  it("adds a nonce to inline script and style tags", () => {
+    const html = addNonceToHtmlTags(
+      `<style>.chat{color:red}</style><script>window.__vf=1</script>`,
+      "nonce-123",
+    );
+
+    assertEquals(html.includes('<style nonce="nonce-123">.chat{color:red}</style>'), true);
+    assertEquals(html.includes('<script nonce="nonce-123">window.__vf=1</script>'), true);
+  });
+
+  it("does not duplicate an existing nonce attribute", () => {
+    const html = addNonceToHtmlTags(
+      `<script nonce="existing">window.__vf=1</script>`,
+      "nonce-123",
+    );
+
+    assertEquals((html.match(/nonce="/g) ?? []).length, 1);
+    assertEquals(html.includes('nonce="nonce-123" nonce="existing"'), false);
+  });
+
+  it("does not inject nonce markup into script or style literals inside scripts", () => {
+    const html = addNonceToHtmlTags(
+      `<script>window.tpl="<script>alert(1)";window.css="<style>.x{color:red}";</script><style>.chat{color:red}</style>`,
+      "nonce-123",
+    );
+
+    assertEquals(
+      html.includes(
+        '<script nonce="nonce-123">window.tpl="<script>alert(1)";window.css="<style>.x{color:red}";</script>',
+      ),
+      true,
+    );
+    assertEquals(html.includes('<style nonce="nonce-123">.chat{color:red}</style>'), true);
+    assertEquals(html.includes('<script nonce="nonce-123">alert(1)'), false);
+    assertEquals(html.includes('<style nonce="nonce-123">.x{color:red}'), false);
+  });
+});

--- a/src/html/nonce-injection.ts
+++ b/src/html/nonce-injection.ts
@@ -1,0 +1,103 @@
+import { escapeHtml } from "#veryfront/utils/html-escape.ts";
+
+function findTagEnd(html: string, start: number): number {
+  let activeQuote: '"' | "'" | null = null;
+
+  for (let index = start + 1; index < html.length; index++) {
+    const char = html[index];
+
+    if (activeQuote) {
+      if (char === activeQuote) activeQuote = null;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      activeQuote = char;
+      continue;
+    }
+
+    if (char === ">") return index;
+  }
+
+  return -1;
+}
+
+function getOpeningTagName(tag: string): "script" | "style" | undefined {
+  const match = /^<\s*([a-zA-Z][\w:-]*)/u.exec(tag);
+  const tagName = match?.[1]?.toLowerCase();
+  if (tagName === "script" || tagName === "style") return tagName;
+  return undefined;
+}
+
+function injectNonceIntoOpeningTag(tag: string, escapedNonce: string): string {
+  if (/\bnonce\s*=/iu.test(tag)) return tag;
+
+  const closeIndex = tag.lastIndexOf(">");
+  if (closeIndex === -1) return tag;
+
+  const insertAt = /\/\s*>$/u.test(tag) ? closeIndex - 1 : closeIndex;
+  return `${tag.slice(0, insertAt)} nonce="${escapedNonce}"${tag.slice(insertAt)}`;
+}
+
+export function addNonceToHtmlTags(html: string, nonce?: string): string {
+  if (!nonce) return html;
+
+  const escapedNonce = escapeHtml(nonce);
+  const lowerHtml = html.toLowerCase();
+  let result = "";
+  let index = 0;
+  let rawTextTag: "script" | "style" | null = null;
+
+  while (index < html.length) {
+    if (rawTextTag) {
+      const closingIndex = lowerHtml.indexOf(`</${rawTextTag}`, index);
+      if (closingIndex === -1) {
+        result += html.slice(index);
+        break;
+      }
+
+      result += html.slice(index, closingIndex);
+      index = closingIndex;
+      rawTextTag = null;
+      continue;
+    }
+
+    if (html.startsWith("<!--", index)) {
+      const commentEnd = html.indexOf("-->", index + 4);
+      const endIndex = commentEnd === -1 ? html.length : commentEnd + 3;
+      result += html.slice(index, endIndex);
+      index = endIndex;
+      continue;
+    }
+
+    if (html[index] !== "<") {
+      result += html[index];
+      index++;
+      continue;
+    }
+
+    const tagEnd = findTagEnd(html, index);
+    if (tagEnd === -1) {
+      result += html.slice(index);
+      break;
+    }
+
+    const tag = html.slice(index, tagEnd + 1);
+    const tagName = getOpeningTagName(tag);
+
+    if (!tagName) {
+      result += tag;
+      index = tagEnd + 1;
+      continue;
+    }
+
+    result += injectNonceIntoOpeningTag(tag, escapedNonce);
+    index = tagEnd + 1;
+
+    if (!/\/\s*>$/u.test(tag)) {
+      rawTextTag = tagName;
+    }
+  }
+
+  return result;
+}

--- a/src/html/nonce-injection.ts
+++ b/src/html/nonce-injection.ts
@@ -29,8 +29,34 @@ function getOpeningTagName(tag: string): "script" | "style" | undefined {
   return undefined;
 }
 
+function isTagBoundary(char: string | undefined): boolean {
+  return char === undefined || /\s|\/|>/u.test(char);
+}
+
+function findRawTextClosingTagStart(
+  lowerHtml: string,
+  tagName: "script" | "style",
+  fromIndex: number,
+): number {
+  const needle = `</${tagName}`;
+  let searchIndex = fromIndex;
+
+  while (searchIndex < lowerHtml.length) {
+    const closingIndex = lowerHtml.indexOf(needle, searchIndex);
+    if (closingIndex === -1) return -1;
+
+    if (isTagBoundary(lowerHtml[closingIndex + needle.length])) {
+      return closingIndex;
+    }
+
+    searchIndex = closingIndex + needle.length;
+  }
+
+  return -1;
+}
+
 function injectNonceIntoOpeningTag(tag: string, escapedNonce: string): string {
-  if (/\bnonce\s*=/iu.test(tag)) return tag;
+  if (/(?:\s|<)nonce\s*=/iu.test(tag)) return tag;
 
   const closeIndex = tag.lastIndexOf(">");
   if (closeIndex === -1) return tag;
@@ -50,7 +76,7 @@ export function addNonceToHtmlTags(html: string, nonce?: string): string {
 
   while (index < html.length) {
     if (rawTextTag) {
-      const closingIndex = lowerHtml.indexOf(`</${rawTextTag}`, index);
+      const closingIndex = findRawTextClosingTagStart(lowerHtml, rawTextTag, index);
       if (closingIndex === -1) {
         result += html.slice(index);
         break;

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -19,7 +19,7 @@ import type {
   PageBundle,
 } from "#veryfront/types";
 import { DEFAULT_DASHBOARD_PORT, rendererLogger } from "#veryfront/utils";
-import { escapeHtml } from "#veryfront/utils/html-escape.ts";
+import { addNonceToHtmlTags } from "#veryfront/html/nonce-injection.ts";
 import type { RenderOptions } from "./types.ts";
 import { injectElementSelectors } from "#veryfront/studio/element-selector-injector.ts";
 import { computeSourceHash } from "#veryfront/studio/hash-utils.ts";
@@ -40,108 +40,6 @@ import type { ResolvedContentContext } from "#veryfront/platform/adapters/fs/ver
 
 const logger = rendererLogger.component("html-generator");
 type ProjectCSSResult = Awaited<ReturnType<typeof getProjectCSS>> | null;
-
-function findTagEnd(html: string, start: number): number {
-  let activeQuote: '"' | "'" | null = null;
-
-  for (let index = start + 1; index < html.length; index++) {
-    const char = html[index];
-
-    if (activeQuote) {
-      if (char === activeQuote) activeQuote = null;
-      continue;
-    }
-
-    if (char === '"' || char === "'") {
-      activeQuote = char;
-      continue;
-    }
-
-    if (char === ">") return index;
-  }
-
-  return -1;
-}
-
-function getOpeningTagName(tag: string): "script" | "style" | undefined {
-  const match = /^<\s*([a-zA-Z][\w:-]*)/u.exec(tag);
-  const tagName = match?.[1]?.toLowerCase();
-  if (tagName === "script" || tagName === "style") return tagName;
-  return undefined;
-}
-
-function injectNonceIntoOpeningTag(tag: string, escapedNonce: string): string {
-  if (/\bnonce\s*=/iu.test(tag)) return tag;
-
-  const closeIndex = tag.lastIndexOf(">");
-  if (closeIndex === -1) return tag;
-
-  const insertAt = /\/\s*>$/u.test(tag) ? closeIndex - 1 : closeIndex;
-  return `${tag.slice(0, insertAt)} nonce="${escapedNonce}"${tag.slice(insertAt)}`;
-}
-
-function addNonceToRenderedTags(html: string, nonce?: string): string {
-  if (!nonce) return html;
-
-  const escapedNonce = escapeHtml(nonce);
-  const lowerHtml = html.toLowerCase();
-  let result = "";
-  let index = 0;
-  let rawTextTag: "script" | "style" | null = null;
-
-  while (index < html.length) {
-    if (rawTextTag) {
-      const closingIndex = lowerHtml.indexOf(`</${rawTextTag}`, index);
-      if (closingIndex === -1) {
-        result += html.slice(index);
-        break;
-      }
-
-      result += html.slice(index, closingIndex);
-      index = closingIndex;
-      rawTextTag = null;
-      continue;
-    }
-
-    if (html.startsWith("<!--", index)) {
-      const commentEnd = html.indexOf("-->", index + 4);
-      const endIndex = commentEnd === -1 ? html.length : commentEnd + 3;
-      result += html.slice(index, endIndex);
-      index = endIndex;
-      continue;
-    }
-
-    if (html[index] !== "<") {
-      result += html[index];
-      index++;
-      continue;
-    }
-
-    const tagEnd = findTagEnd(html, index);
-    if (tagEnd === -1) {
-      result += html.slice(index);
-      break;
-    }
-
-    const tag = html.slice(index, tagEnd + 1);
-    const tagName = getOpeningTagName(tag);
-
-    if (!tagName) {
-      result += tag;
-      index = tagEnd + 1;
-      continue;
-    }
-
-    result += injectNonceIntoOpeningTag(tag, escapedNonce);
-    index = tagEnd + 1;
-
-    if (!/\/\s*>$/u.test(tag)) {
-      rawTextTag = tagName;
-    }
-  }
-
-  return result;
-}
 
 export interface HTMLGeneratorConfig {
   projectDir: string;
@@ -182,7 +80,7 @@ export class HTMLGenerator {
       logger.debug("Injected element selectors for Studio");
     }
 
-    return addNonceToRenderedTags(finalHtml, context.options?.nonce);
+    return addNonceToHtmlTags(finalHtml, context.options?.nonce);
   }
 
   async generateHTMLStream(
@@ -223,7 +121,7 @@ export class HTMLGenerator {
     );
 
     const encoder = new TextEncoder();
-    const fullHtml = addNonceToRenderedTags(
+    const fullHtml = addNonceToHtmlTags(
       `${start}${reactContent}${end}`,
       context.options?.nonce,
     );

--- a/src/rendering/script-page-handling.test.ts
+++ b/src/rendering/script-page-handling.test.ts
@@ -1,5 +1,7 @@
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { handleScriptPage } from "./script-page-handling.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 
 type ScriptModuleOutput =
   | string
@@ -294,6 +296,58 @@ describe("script-page-handling helpers", () => {
 
     it("should have exactly 6 extensions", () => {
       assertEquals(APP_COMPONENT_EXTENSIONS.length, 6);
+    });
+  });
+
+  describe("handleScriptPage", () => {
+    it("forwards the request nonce when enhancing full HTML script pages", async () => {
+      const projectDir = await Deno.makeTempDir({ prefix: "vf-script-page-" });
+
+      try {
+        const pagePath = `${projectDir}/page.js`;
+        await Deno.writeTextFile(
+          pagePath,
+          `export default \`<!DOCTYPE html><html><head><title>Script</title></head><body><main>Hello</main></body></html>\`;`,
+        );
+
+        const adapter = {
+          fs: {
+            exists: async () => false,
+          },
+        } as unknown as RuntimeAdapter;
+
+        const result = await handleScriptPage(
+          {
+            entity: {
+              path: pagePath,
+              frontmatter: {},
+            },
+          } as never,
+          "script-page",
+          {
+            mode: "production",
+            config: {} as never,
+            projectDir,
+            adapter,
+            nonce: "nonce-123",
+          },
+        );
+
+        assertEquals(
+          result.html.includes(
+            '<script type="module" src="/_veryfront/rsc/client.js" nonce="nonce-123"></script>',
+          ),
+          true,
+        );
+        assertEquals(
+          result.html.includes(
+            '<script type="module" src="/_veryfront/hydrate.js?slug=script-page" nonce="nonce-123"></script>',
+          ),
+          true,
+        );
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
     });
   });
 });

--- a/src/rendering/script-page-handling.ts
+++ b/src/rendering/script-page-handling.ts
@@ -237,6 +237,7 @@ async function generateFullHtml(
       mode: options.mode,
       slug,
       devPort: options.config?.dev?.port ?? DEFAULT_DASHBOARD_PORT,
+      nonce: options.nonce,
     });
   }
 

--- a/src/server/handlers/request/static.handler.test.ts
+++ b/src/server/handlers/request/static.handler.test.ts
@@ -1,0 +1,76 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { HandlerContext } from "../types.ts";
+import { StaticHandler } from "./static.handler.ts";
+
+function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    projectDir: "/tmp/test-project",
+    adapter: {
+      name: "test",
+      env: { get: () => undefined },
+      fs: {},
+    },
+    securityConfig: {},
+    cspUserHeader: null,
+    isLocalProject: false,
+    requestContext: {
+      mode: "production",
+    } as HandlerContext["requestContext"],
+    ...overrides,
+  } as unknown as HandlerContext;
+}
+
+describe("server/handlers/request/static.handler", () => {
+  it("adds matching nonces to static HTML responses before applying CSP", async () => {
+    const handler = new StaticHandler();
+    (handler as any).staticService = {
+      resolveFile: async () => ({
+        path: "/tmp/test-project/dist/index.html",
+        data: new TextEncoder().encode(
+          [
+            "<!doctype html>",
+            "<html><head>",
+            '<script type="importmap">{"imports":{"react":"https://esm.sh/react"}}</script>',
+            "<style>.chat{color:red}</style>",
+            "</head><body>",
+            '<script id="veryfront-hydration-data" type="application/json">{"page":"index"}</script>',
+            `<script type="module">window.tpl="<script>alert(1)";</script>`,
+            "</body></html>",
+          ].join(""),
+        ),
+        etag: '"stale-etag"',
+        contentType: "text/html; charset=utf-8",
+        cacheStrategy: "medium",
+        source: "dist",
+      }),
+      isAssetRequest: () => true,
+    };
+
+    const result = await handler.handle(new Request("http://localhost/"), makeCtx());
+    assertExists(result.response);
+
+    const response = result.response;
+    const body = await response.text();
+    const csp = response.headers.get("content-security-policy") ?? "";
+    const nonceMatch = csp.match(/nonce-([^' ;]+)/);
+
+    assertEquals(Boolean(nonceMatch), true);
+    const nonce = nonceMatch![1]!;
+
+    assertEquals(body.includes(`<script type="importmap" nonce="${nonce}">`), true);
+    assertEquals(body.includes(`<style nonce="${nonce}">.chat{color:red}</style>`), true);
+    assertEquals(
+      body.includes(
+        `<script id="veryfront-hydration-data" type="application/json" nonce="${nonce}">{"page":"index"}</script>`,
+      ),
+      true,
+    );
+    assertEquals(
+      body.includes(`window.tpl="<script>alert(1)";</script>`),
+      true,
+    );
+    assertEquals(body.includes(`<script nonce="${nonce}">alert(1)`), false);
+    assertEquals(response.headers.get("etag") === '"stale-etag"', false);
+  });
+});

--- a/src/server/handlers/request/static.handler.ts
+++ b/src/server/handlers/request/static.handler.ts
@@ -19,6 +19,12 @@ import {
 } from "#veryfront/utils/constants/index.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { StaticFileService } from "../../services/static/index.ts";
+import { addNonceToHtmlTags } from "#veryfront/html/nonce-injection.ts";
+import { computeEtag } from "../utils/etag.ts";
+
+function isHtmlResponse(contentType: string): boolean {
+  return /\btext\/html\b/i.test(contentType);
+}
 
 export class StaticHandler extends BaseHandler {
   metadata: HandlerMetadata = {
@@ -57,6 +63,8 @@ export class StaticHandler extends BaseHandler {
         const isHead = method === "HEAD";
         const isLocal = !!ctx.isLocalProject;
         const isPreviewMode = ctx.requestContext?.mode === "preview" && !isLocal;
+        const builder = this.createResponseBuilder(ctx)
+          .withCORS(req, ctx.securityConfig?.cors);
 
         const result = await this.staticService.resolveFile(pathname, {
           projectDir: ctx.projectDir,
@@ -68,8 +76,7 @@ export class StaticHandler extends BaseHandler {
         if (!result) {
           if (!this.staticService.isAssetRequest(pathname)) return null;
 
-          return this.createResponseBuilder(ctx)
-            .withCORS(req, ctx.securityConfig?.cors)
+          return builder
             .withSecurity(ctx.securityConfig ?? undefined, req)
             .withCache("no-cache")
             .withContentType(
@@ -79,19 +86,24 @@ export class StaticHandler extends BaseHandler {
             );
         }
 
-        if (hasMatchingEtag(req, result.etag)) {
-          return this.createResponseBuilder(ctx)
-            .withCORS(req, ctx.securityConfig?.cors)
+        const responseData = isHtmlResponse(result.contentType)
+          ? new TextEncoder().encode(
+            addNonceToHtmlTags(new TextDecoder().decode(result.data), builder.nonce),
+          )
+          : result.data;
+        const etag = computeEtag(responseData);
+
+        if (hasMatchingEtag(req, etag)) {
+          return builder
             .withSecurity(ctx.securityConfig ?? undefined, req)
-            .notModified(result.etag);
+            .notModified(etag);
         }
 
-        const body: BodyInit | null = isHead ? null : result.data.slice();
-        const response = this.createResponseBuilder(ctx)
-          .withCORS(req, ctx.securityConfig?.cors)
+        const body: BodyInit | null = isHead ? null : responseData.slice();
+        const response = builder
           .withSecurity(ctx.securityConfig ?? undefined, req)
           .withCache(result.cacheStrategy)
-          .withETag(result.etag)
+          .withETag(etag)
           .withContentType(result.contentType, body, HTTP_OK);
 
         this.logDebug(

--- a/tests/integration/server/production-server.test.ts
+++ b/tests/integration/server/production-server.test.ts
@@ -171,6 +171,47 @@ describe(
             assert(html.includes("<html"), "Should include layout wrapper");
           });
         });
+
+        it("keeps static App Router inline bootstrap tags aligned with the response CSP nonce", async () => {
+          await withTestContext("prod-app-router-csp-static-html", async (context) => {
+            context.setEnv({ VF_CACHE_ALLOW_CLOSE: "1" });
+
+            await mkdir(join(context.projectDir, "app"), { recursive: true });
+            await writeTextFile(
+              join(context.projectDir, "app", "page.tsx"),
+              `export default function HomePage() {
+                return <h1>Nonce-safe App Router</h1>;
+              }`,
+            );
+
+            await buildProduction({
+              projectDir: context.projectDir,
+              outputDir: join(context.projectDir, "dist"),
+              enableSplitting: false,
+              enableCompression: false,
+              enablePrefetch: false,
+            });
+
+            const server = await context.createProductionServer();
+            const response = await fetch(`http://127.0.0.1:${server.port}/`);
+            const html = await response.text();
+
+            assertEquals(response.status, 200, "Should serve built App Router HTML");
+            const csp = response.headers.get("content-security-policy") ?? "";
+            const nonceMatch = csp.match(/nonce-([^' ;]+)/);
+            assertExists(nonceMatch, "CSP should include a nonce");
+            const nonce = nonceMatch[1]!;
+
+            assert(
+              html.includes(`<script type="importmap" nonce="${nonce}">`),
+              "Static App Router importmap should use the response nonce",
+            );
+            assert(
+              html.includes(`<script type="module" nonce="${nonce}">`),
+              "Static App Router bootstrap module should use the response nonce",
+            );
+          });
+        });
       },
     );
 
@@ -319,6 +360,48 @@ describe(
 
             assertEquals(response.status, 200, "Should render MDX page");
             assert(html.includes("Test Page") || html.includes("<h1>"), "Should render page title");
+          });
+        });
+
+        it("keeps built Pages Router hydration tags aligned with the response CSP nonce", async () => {
+          await withTestContext("prod-pages-router-csp-static-html", async (context) => {
+            context.setEnv({ VF_CACHE_ALLOW_CLOSE: "1" });
+
+            await writeTextFile(
+              join(context.projectDir, "pages", "index.tsx"),
+              `export default function Home() {
+                return <h1>Nonce-safe Pages Router</h1>;
+              }`,
+            );
+
+            await buildProduction({
+              projectDir: context.projectDir,
+              outputDir: join(context.projectDir, "dist"),
+              enableSplitting: false,
+              enableCompression: false,
+              enablePrefetch: false,
+            });
+
+            const server = await context.createProductionServer();
+            const response = await fetch(`http://127.0.0.1:${server.port}/`);
+            const html = await response.text();
+
+            assertEquals(response.status, 200, "Should serve built Pages Router HTML");
+            const csp = response.headers.get("content-security-policy") ?? "";
+            const nonceMatch = csp.match(/nonce-([^' ;]+)/);
+            assertExists(nonceMatch, "CSP should include a nonce");
+            const nonce = nonceMatch[1]!;
+
+            assert(
+              html.includes(`<script type="importmap" nonce="${nonce}">`),
+              "Pages Router importmap should use the response nonce",
+            );
+            assert(
+              html.includes(
+                `id="veryfront-hydration-data" type="application/json" nonce="${nonce}"`,
+              ),
+              "Pages Router hydration payload should use the response nonce",
+            );
           });
         });
       },


### PR DESCRIPTION
## Summary
- rewrite static HTML responses with the response CSP nonce before sending them
- share nonce injection logic between HTML generation and static serving
- add regressions for static HTML nonce rewriting and safe inline tag handling

## Testing
- deno test --allow-all src/html/nonce-injection.test.ts src/server/handlers/request/static.handler.test.ts
- deno check src/html/nonce-injection.ts src/rendering/orchestrator/html.ts src/server/handlers/request/static.handler.ts src/html/nonce-injection.test.ts src/server/handlers/request/static.handler.test.ts
- deno test --allow-all src/rendering/orchestrator/html.test.ts src/server/services/static/static-file.service.test.ts
- pre-push checks (format, lint, typecheck, unit tests)