### PR TITLE
Honor integration allowlists for project agent runs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.131",
+  "version": "0.1.132",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -77,6 +77,10 @@ import { resolveConfiguredAgentModel, resolveRuntimeModel } from "./model-resolu
 const logger = serverLogger.component("agent");
 const LOAD_SKILL_TOOL_ID = "load-skill";
 
+type RuntimeToolFilterConfig = AgentConfig & {
+  __vfAllowedRemoteTools?: string[];
+};
+
 function createAbortError(reason?: unknown): Error {
   if (reason instanceof Error) {
     return reason;
@@ -185,6 +189,14 @@ function isLocalModel(model: LanguageModel): boolean {
   return !!m._isVfLocalModel ||
     m.provider === "local" ||
     (typeof m.modelId === "string" && m.modelId.startsWith("local/"));
+}
+
+function getRuntimeAllowedRemoteTools(config: AgentConfig): string[] | undefined {
+  const raw = (config as RuntimeToolFilterConfig).__vfAllowedRemoteTools;
+  if (!Array.isArray(raw) || !raw.every((toolName) => typeof toolName === "string")) {
+    return undefined;
+  }
+  return raw;
 }
 
 export class AgentRuntime {
@@ -418,6 +430,7 @@ export class AgentRuntime {
 
       // Request-scoped skill policy (not class-level mutable state)
       let activeSkillPolicy: string[] | undefined;
+      const allowedRemoteToolNames = getRuntimeAllowedRemoteTools(this.config);
 
       for (let step = 0; step < maxSteps; step++) {
         this.status = "thinking";
@@ -425,6 +438,7 @@ export class AgentRuntime {
 
         let tools = isLocal ? [] : await getAvailableTools(this.config.tools, {
           includeSkillTools: Boolean(this.config.skills),
+          allowedRemoteToolNames,
         });
 
         // Layer 1: Filter tools based on active skill policy (planning-time)
@@ -548,6 +562,7 @@ export class AgentRuntime {
                   toolCallId: tc.toolCallId,
                   projectId: cacheCtx?.projectId,
                 },
+                allowedRemoteToolNames,
               );
 
               toolCall.status = "completed";
@@ -662,6 +677,7 @@ export class AgentRuntime {
     // Request-scoped skill policy (not class-level mutable state)
     let activeSkillPolicy: string[] | undefined;
     let finalFinishReason: string | undefined;
+    const allowedRemoteToolNames = getRuntimeAllowedRemoteTools(this.config);
 
     for (let step = 0; step < maxSteps; step++) {
       throwIfAborted(abortSignal);
@@ -669,6 +685,7 @@ export class AgentRuntime {
 
       let tools = isLocalStreaming ? [] : await getAvailableTools(this.config.tools, {
         includeSkillTools: Boolean(this.config.skills),
+        allowedRemoteToolNames,
       });
 
       // Layer 1: Filter tools based on active skill policy (planning-time)
@@ -791,6 +808,7 @@ export class AgentRuntime {
               toolCallId: tc.id,
               ...toolContext,
             },
+            allowedRemoteToolNames,
           );
           throwIfAborted(abortSignal);
 

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -192,11 +192,15 @@ function isLocalModel(model: LanguageModel): boolean {
 }
 
 function getRuntimeAllowedRemoteTools(config: AgentConfig): string[] | undefined {
-  const raw = (config as RuntimeToolFilterConfig).__vfAllowedRemoteTools;
-  if (!Array.isArray(raw) || !raw.every((toolName) => typeof toolName === "string")) {
+  const configWithRuntimeFilters = config as RuntimeToolFilterConfig;
+  if (!Object.hasOwn(configWithRuntimeFilters, "__vfAllowedRemoteTools")) {
     return undefined;
   }
-  return raw;
+  const raw = configWithRuntimeFilters.__vfAllowedRemoteTools;
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw.every((toolName) => typeof toolName === "string") ? raw : [];
 }
 
 export class AgentRuntime {

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -2,7 +2,12 @@ import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { z } from "zod";
 import { tool, toolRegistry } from "#veryfront/tool";
-import { executeConfiguredTool, parseToolArgs, resolveConfiguredTool } from "./tool-helpers.ts";
+import {
+  executeConfiguredTool,
+  getAvailableTools,
+  parseToolArgs,
+  resolveConfiguredTool,
+} from "./tool-helpers.ts";
 
 describe("tool-helpers", () => {
   describe("parseToolArgs", () => {
@@ -151,6 +156,61 @@ describe("tool-helpers", () => {
         Error,
         'Tool "studio_invoke_agent" not found',
       );
+    });
+
+    it("rejects remote integration tools excluded by the runtime allowlist", async () => {
+      await assertRejects(
+        () =>
+          executeConfiguredTool(
+            "gmail:list-emails",
+            {},
+            undefined,
+            { toolCallId: "tool-3" },
+            ["gmail:get-email"],
+          ),
+        Error,
+        'Tool "gmail:list-emails" is not allowed for this run',
+      );
+    });
+  });
+
+  describe("getAvailableTools", () => {
+    it("filters remote integration tool definitions by the runtime allowlist", async () => {
+      const originalFetch = globalThis.fetch;
+      const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_URL");
+      const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+      globalThis.fetch = async () =>
+        Response.json({
+          tools: [
+            {
+              name: "gmail:list-emails",
+              description: "List emails",
+              inputSchema: { type: "object", properties: {} },
+            },
+            {
+              name: "gmail:get-email",
+              description: "Get email",
+              inputSchema: { type: "object", properties: {} },
+            },
+          ],
+        });
+
+      try {
+        Deno.env.set("VERYFRONT_API_URL", "https://api.test");
+        Deno.env.set("VERYFRONT_API_TOKEN", "token");
+
+        const defs = await getAvailableTools(true, {
+          allowedRemoteToolNames: ["gmail:get-email"],
+        });
+
+        assertEquals(defs.map((def) => def.name), ["gmail:get-email"]);
+      } finally {
+        if (originalApiBaseUrl === undefined) Deno.env.delete("VERYFRONT_API_URL");
+        else Deno.env.set("VERYFRONT_API_URL", originalApiBaseUrl);
+        if (originalApiToken === undefined) Deno.env.delete("VERYFRONT_API_TOKEN");
+        else Deno.env.set("VERYFRONT_API_TOKEN", originalApiToken);
+        globalThis.fetch = originalFetch;
+      }
     });
   });
 });

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -100,6 +100,7 @@ export async function executeConfiguredTool(
   input: Record<string, unknown>,
   toolsConfig: true | Record<string, ToolConfigEntry> | undefined,
   context?: ToolExecutionContext,
+  allowedRemoteToolNames?: string[],
 ): Promise<unknown> {
   const configuredTool = resolveConfiguredTool(toolsConfig, toolName);
   if (configuredTool) {
@@ -114,6 +115,9 @@ export async function executeConfiguredTool(
 
   // Fall back to remote execution for integration tools (e.g., github:list-repos)
   if (isRemoteIntegrationTool(toolName)) {
+    if (allowedRemoteToolNames && !allowedRemoteToolNames.includes(toolName)) {
+      throw new Error(`Tool "${toolName}" is not allowed for this run`);
+    }
     return await executeRemoteIntegrationTool(
       toolName,
       input,
@@ -152,7 +156,11 @@ function addToolDefinition(
  */
 export async function getAvailableTools(
   toolsConfig: true | Record<string, ToolConfigEntry> | undefined,
-  options?: { includeSkillTools?: boolean; includeIntegrationTools?: boolean },
+  options?: {
+    includeSkillTools?: boolean;
+    includeIntegrationTools?: boolean;
+    allowedRemoteToolNames?: string[];
+  },
 ): Promise<ToolDefinition[]> {
   if (!toolsConfig) return [];
 
@@ -176,7 +184,9 @@ export async function getAvailableTools(
         const { getRemoteIntegrationToolDefinitions } = await import(
           "#veryfront/integrations/remote-tools.ts"
         );
-        const remoteDefs = await getRemoteIntegrationToolDefinitions();
+        const remoteDefs = (await getRemoteIntegrationToolDefinitions()).filter((def) =>
+          !options?.allowedRemoteToolNames || options.allowedRemoteToolNames.includes(def.name)
+        );
         for (const def of remoteDefs) {
           logToolDefinition(def.name, def);
         }
@@ -211,7 +221,9 @@ export async function getAvailableTools(
       const { getRemoteIntegrationToolDefinitions } = await import(
         "#veryfront/integrations/remote-tools.ts"
       );
-      const remoteDefs = await getRemoteIntegrationToolDefinitions();
+      const remoteDefs = (await getRemoteIntegrationToolDefinitions()).filter((def) =>
+        !options?.allowedRemoteToolNames || options.allowedRemoteToolNames.includes(def.name)
+      );
       for (const def of remoteDefs) {
         // Skip if already present (e.g., explicitly configured by name)
         if (!tools.some((t) => t.name === def.name)) {

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -243,7 +243,8 @@ export async function createRuntimeAgentStreamResponse(
       ...(allowedRemoteToolNames ? { __vfAllowedRemoteTools: allowedRemoteToolNames } : {}),
     },
   };
-  const runtime = deps.createRuntime?.(runtimeAgent, mergedTools) ?? new AgentRuntime(runtimeAgent.id, runtimeAgent.config);
+  const runtime = deps.createRuntime?.(runtimeAgent, mergedTools) ??
+    new AgentRuntime(runtimeAgent.id, runtimeAgent.config);
 
   let completedResponse: AgentResponse | null = null;
   const runtimeMessages = normalizeRuntimeMessages(input.messages);

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -19,6 +19,12 @@ import type { RuntimeRunAgentInput } from "./schema.ts";
 
 const anyObjectSchema = z.record(z.string(), z.unknown());
 
+type RuntimeFilteredAgent = Agent & {
+  config: Agent["config"] & {
+    __vfAllowedRemoteTools?: string[];
+  };
+};
+
 export interface RuntimeAgentStreamExecutionDeps {
   sessionManager: AgentRunSessionManager;
   createRuntime?: (
@@ -202,6 +208,21 @@ function normalizeRuntimeMessages(messages: RuntimeRunAgentInput["messages"]): M
   }));
 }
 
+function getAllowedRemoteToolNames(
+  forwardedProps: RuntimeRunAgentInput["forwardedProps"],
+): string[] | undefined {
+  const runtimeOverrides = isRecord(forwardedProps?.runtimeOverrides)
+    ? forwardedProps.runtimeOverrides
+    : null;
+  const allowedTools = runtimeOverrides && Array.isArray(runtimeOverrides.allowedTools)
+    ? runtimeOverrides.allowedTools
+    : null;
+  if (!allowedTools || !allowedTools.every((toolName) => typeof toolName === "string")) {
+    return undefined;
+  }
+  return allowedTools;
+}
+
 export async function createRuntimeAgentStreamResponse(
   input: RuntimeRunAgentInput,
   agent: Agent,
@@ -213,10 +234,16 @@ export async function createRuntimeAgentStreamResponse(
   });
 
   const mergedTools = buildMergedTools(agent, input, deps.sessionManager);
-  const runtime = deps.createRuntime?.(agent, mergedTools) ?? new AgentRuntime(agent.id, {
-    ...agent.config,
-    tools: mergedTools,
-  });
+  const allowedRemoteToolNames = getAllowedRemoteToolNames(input.forwardedProps);
+  const runtimeAgent: RuntimeFilteredAgent = {
+    ...agent,
+    config: {
+      ...agent.config,
+      tools: mergedTools,
+      ...(allowedRemoteToolNames ? { __vfAllowedRemoteTools: allowedRemoteToolNames } : {}),
+    },
+  };
+  const runtime = deps.createRuntime?.(runtimeAgent, mergedTools) ?? new AgentRuntime(runtimeAgent.id, runtimeAgent.config);
 
   let completedResponse: AgentResponse | null = null;
   const runtimeMessages = normalizeRuntimeMessages(input.messages);

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -214,13 +214,14 @@ function getAllowedRemoteToolNames(
   const runtimeOverrides = isRecord(forwardedProps?.runtimeOverrides)
     ? forwardedProps.runtimeOverrides
     : null;
-  const allowedTools = runtimeOverrides && Array.isArray(runtimeOverrides.allowedTools)
-    ? runtimeOverrides.allowedTools
-    : null;
-  if (!allowedTools || !allowedTools.every((toolName) => typeof toolName === "string")) {
+  if (!runtimeOverrides || !Object.hasOwn(runtimeOverrides, "allowedTools")) {
     return undefined;
   }
-  return allowedTools;
+  const allowedTools = runtimeOverrides.allowedTools;
+  if (!Array.isArray(allowedTools)) {
+    return [];
+  }
+  return allowedTools.every((toolName) => typeof toolName === "string") ? allowedTools : [];
 }
 
 export async function createRuntimeAgentStreamResponse(
@@ -240,7 +241,9 @@ export async function createRuntimeAgentStreamResponse(
     config: {
       ...agent.config,
       tools: mergedTools,
-      ...(allowedRemoteToolNames ? { __vfAllowedRemoteTools: allowedRemoteToolNames } : {}),
+      ...(allowedRemoteToolNames !== undefined
+        ? { __vfAllowedRemoteTools: allowedRemoteToolNames }
+        : {}),
     },
   };
   const runtime = deps.createRuntime?.(runtimeAgent, mergedTools) ??

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -1,3 +1,4 @@
+import type { Agent } from "#veryfront/agent";
 import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { AgentRunSessionManager } from "#veryfront/internal-agents/session-manager.ts";
 import type {
@@ -218,6 +219,68 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(text.includes("event: ReasoningStart"), false);
     assertEquals(text.includes("event: ReasoningContent"), false);
     assertEquals(text.includes("event: ReasoningEnd"), false);
+  });
+
+  it("passes runtime integration tool allowlists from forwarded props into the runtime agent config", async () => {
+    let capturedAllowedTools: string[] | undefined;
+
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: (id) => id === "assistant-1" ? createAgent("assistant-1") : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager: new AgentRunSessionManager(),
+      createRuntime: (agent) => {
+        const config = agent.config as Agent["config"] & { __vfAllowedRemoteTools?: string[] };
+        capturedAllowedTools = config.__vfAllowedRemoteTools;
+
+        return {
+          stream: async (_messages, _context, callbacks) => {
+            callbacks?.onFinish?.({
+              text: "ok",
+              messages: [],
+              toolCalls: [],
+              status: "completed",
+              usage: {
+                promptTokens: 1,
+                completionTokens: 1,
+                totalTokens: 2,
+              },
+            });
+
+            return new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.close();
+              },
+            });
+          },
+        };
+      },
+    });
+
+    const body = createAgentStreamRequestBody({
+      forwardedProps: {
+        runtimeOverrides: {
+          allowedTools: ["gmail:list-emails", "gmail:get-email"],
+        },
+      },
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(capturedAllowedTools, ["gmail:list-emails", "gmail:get-email"]);
   });
 
   it("rejects oversized internal agent stream payloads before parsing", async () => {

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -283,6 +283,68 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(capturedAllowedTools, ["gmail:list-emails", "gmail:get-email"]);
   });
 
+  it("fails closed for malformed runtime integration tool allowlists from forwarded props", async () => {
+    let capturedAllowedTools: string[] | undefined;
+
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: (id) => id === "assistant-1" ? createAgent("assistant-1") : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager: new AgentRunSessionManager(),
+      createRuntime: (agent) => {
+        const config = agent.config as Agent["config"] & { __vfAllowedRemoteTools?: string[] };
+        capturedAllowedTools = config.__vfAllowedRemoteTools;
+
+        return {
+          stream: async (_messages, _context, callbacks) => {
+            callbacks?.onFinish?.({
+              text: "ok",
+              messages: [],
+              toolCalls: [],
+              status: "completed",
+              usage: {
+                promptTokens: 1,
+                completionTokens: 1,
+                totalTokens: 2,
+              },
+            });
+
+            return new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.close();
+              },
+            });
+          },
+        };
+      },
+    });
+
+    const body = createAgentStreamRequestBody({
+      forwardedProps: {
+        runtimeOverrides: {
+          allowedTools: ["gmail:list-emails", 123],
+        },
+      },
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(capturedAllowedTools, []);
+  });
+
   it("rejects oversized internal agent stream payloads before parsing", async () => {
     const handler = new AgentStreamHandler({
       ensureProjectDiscovery: async () => {},

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.131";
+export const VERSION = "0.1.132";


### PR DESCRIPTION
## Summary
- honor forwarded runtime integration allowlists for project-agent runs in veryfront-code
- filter remote integration tool enumeration and execution to the selected tool set for the run
- add regression coverage for helper filtering and internal agent-stream forwarding

## Validation
- deno check src/agent/runtime/tool-helpers.ts src/agent/runtime/index.ts src/internal-agents/run-stream.ts src/server/handlers/request/agent-stream.handler.test.ts
- deno test --allow-env src/agent/runtime/tool-helpers.test.ts src/server/handlers/request/agent-stream.handler.test.ts
- repo pre-push checks passed (format, lint, typecheck, unit tests)