### PR TITLE
Evict stale preview adapters after websocket invalidation

### DIFF
--- a/src/platform/adapters/fs/veryfront/proxy-manager.ts
+++ b/src/platform/adapters/fs/veryfront/proxy-manager.ts
@@ -397,9 +397,11 @@ export class ProxyFSAdapterManager {
         projectId,
         apiToken: effectiveToken,
       },
-      invalidationCallbacks: createDefaultInvalidationCallbacks(
-        this.baseConfig.invalidationCallbacks,
-      ),
+      invalidationCallbacks: createDefaultInvalidationCallbacks({
+        ...this.baseConfig.invalidationCallbacks,
+        evictCurrentAdapter: () =>
+          this.evictAdapter(projectSlug, productionMode, releaseId, branch),
+      }),
     };
 
     const adapter = new VeryfrontFSAdapter(config);
@@ -554,6 +556,30 @@ export class ProxyFSAdapterManager {
       branch ?? null,
     );
     return this.adapters.has(cacheKey);
+  }
+
+  evictAdapter(
+    projectSlug: string,
+    productionMode?: boolean,
+    releaseId?: string | null,
+    branch?: string | null,
+  ): void {
+    const cacheKey = buildProxyManagerCacheKey(
+      projectSlug,
+      productionMode ?? false,
+      releaseId ?? null,
+      branch ?? null,
+    );
+
+    const adapter = this.adapters.get(cacheKey);
+    if (!adapter) {
+      logger.debug("No adapter to evict", { cacheKey });
+      return;
+    }
+
+    logger.debug("Evicting adapter", { cacheKey });
+    adapter.adapter.dispose();
+    this.adapters.delete(cacheKey);
   }
 
   getStats(): { adapters: number; stats: Record<string, CacheStats> } {

--- a/src/platform/adapters/fs/veryfront/types.ts
+++ b/src/platform/adapters/fs/veryfront/types.ts
@@ -137,4 +137,6 @@ export interface InvalidationCallbacks {
   clearProjectCSSCache?: (projectSlug: string) => void;
   /** Clear domain lookup cache to refresh release IDs after publishing */
   clearDomainCache?: () => void;
+  /** Evict the current shared proxy adapter after successful invalidation */
+  evictCurrentAdapter?: () => void;
 }

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -680,4 +680,49 @@ describe("WebSocketManager", () => {
 
     manager.dispose();
   });
+
+  it("evicts the current adapter after successful selective invalidation", async () => {
+    let evicted = 0;
+
+    const manager = createWebSocketManager({
+      client: {
+        listAllFiles: async () => [{
+          path: "pages/index.mdx",
+          type: "page",
+          size: 10,
+          updated_at: "2026-04-03T00:00:00.000Z",
+          content: "# Hello",
+        }],
+      },
+      invalidationCallbacks: {
+        evictCurrentAdapter: () => {
+          evicted++;
+        },
+      },
+    });
+
+    manager.connect("project-1");
+    const socket = MockWebSocket.instances[0];
+    assertExists(socket);
+
+    socket.onmessage?.call(
+      socket as unknown as WebSocket,
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          type: "poke",
+          data: {
+            changedPaths: ["pages/index.mdx"],
+            branchName: "main",
+          },
+        }),
+      }),
+    );
+
+    assertEquals(runOnlyScheduledTimer(), 100);
+    await flushMicrotasks();
+
+    assertEquals(evicted, 1);
+
+    manager.dispose();
+  });
 });

--- a/src/platform/adapters/fs/veryfront/websocket-manager.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.ts
@@ -692,6 +692,7 @@ export class WebSocketManager {
           previewInvalidationPrefixes,
           previewInvalidationVersion,
         );
+        this.deps.invalidationCallbacks.evictCurrentAdapter?.();
       }
     }
   }
@@ -836,6 +837,7 @@ export class WebSocketManager {
           previewInvalidationPrefixes,
           previewInvalidationVersion,
         );
+        this.deps.invalidationCallbacks.evictCurrentAdapter?.();
       }
     }
   }

--- a/tests/integration/adapters/proxy-fs-adapter-manager.test.ts
+++ b/tests/integration/adapters/proxy-fs-adapter-manager.test.ts
@@ -49,7 +49,7 @@ describe("ProxyFSAdapterManager - Cache Isolation", () => {
       baseConfig: {
         type: "veryfront-api",
         veryfront: {
-          baseUrl: "http://localhost:4000/api",
+          apiBaseUrl: "http://localhost:4000/api",
           apiToken: "test-token",
           proxyMode: false,
         },
@@ -89,6 +89,39 @@ describe("ProxyFSAdapterManager - Cache Isolation", () => {
         manager.hasAdapter("my-project", false, null),
         manager.hasAdapter("my-project", false, "ignored-in-preview"),
       );
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it("evictAdapter removes and disposes a cached preview adapter", () => {
+    const manager = createLocalManager();
+    let disposed = false;
+
+    try {
+      (manager as unknown as {
+        adapters: Map<
+          string,
+          { adapter: { dispose: () => void; getCacheStats: () => unknown }; lastAccessed: number }
+        >;
+      }).adapters.set("proxy:my-project:preview:main", {
+        adapter: {
+          dispose: () => {
+            disposed = true;
+          },
+          getCacheStats: () => ({
+            cache: { size: 0, memoryUsed: 0, hits: 0, misses: 0, hitRate: 0 },
+          }),
+        },
+        lastAccessed: Date.now(),
+      });
+
+      assertEquals(manager.hasAdapter("my-project", false, null, "main"), true);
+
+      manager.evictAdapter("my-project", false, null, "main");
+
+      assertEquals(disposed, true);
+      assertEquals(manager.hasAdapter("my-project", false, null, "main"), false);
     } finally {
       manager.dispose();
     }


### PR DESCRIPTION
## Summary
- evict shared proxy adapters after a successful websocket invalidation cycle
- keep the eviction at the end of invalidation so the current poke can finish cleanly
- add regressions for websocket invalidation and explicit adapter eviction

## Why
Staging preview for `ai-agent-kitchen-sink` showed a stale cached adapter graph even after `pages/index.mdx` was replaced with a minimal static page. Server logs showed `REUSING_CACHED_ADAPTER` for `proxy:ai-agent-kitchen-sink:preview:main` and repeated resolution attempts against files that were no longer present in the live Files API response. The invalidation path was refreshing Redis-backed file lists and renderer caches, but it was not evicting the shared proxy adapter itself.

## Validation
- `deno test --allow-env --allow-read --allow-write --allow-net tests/integration/adapters/proxy-fs-adapter-manager.test.ts src/platform/adapters/fs/veryfront/websocket-manager.test.ts`
- `deno test --allow-env --allow-read --allow-write --allow-net tests/integration/adapters/cache-invalidation.test.ts`
- `deno task verify:quick`

## Related
- veryfront-studio#1166
