### PR TITLE
Preserve streamed full-document layout theming

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.131",
+  "version": "0.1.132",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/html/html-injection.test.ts
+++ b/src/html/html-injection.test.ts
@@ -228,5 +228,21 @@ describe("html/html-injection", () => {
       assertEquals(html.includes('id="vf-tailwind-css"'), true);
       assertEquals(html.includes("/_vf_styles/styles.css?t="), true);
     });
+
+    it("injects production project stylesheet links for full HTML documents", () => {
+      const html = injectHTMLContent(
+        baseTemplate,
+        "<p>content</p>",
+        minMeta,
+        {
+          mode: "production",
+          environment: "production",
+          slug: "test",
+          projectStylesheetHref: "/_vf/css/abc123.css",
+        },
+      );
+
+      assertEquals(html.includes('<link rel="stylesheet" href="/_vf/css/abc123.css">'), true);
+    });
   });
 });

--- a/src/html/html-injection.ts
+++ b/src/html/html-injection.ts
@@ -44,6 +44,8 @@ export interface InjectHTMLContentOptions {
   yjsGuid?: string;
   /** Pre-built import map JSON for ESM module resolution (injected into <head>) */
   importMapJson?: string;
+  /** Framework-generated project stylesheet for production shells */
+  projectStylesheetHref?: string;
 }
 
 function toProjectRelativePath(absolutePath: string, projectDir?: string): string {
@@ -94,6 +96,11 @@ export function injectHTMLContent(
     const importMapTag =
       `<script type="importmap"${nonceAttr}>\n${options.importMapJson}\n</script>`;
     html = html.replace(/<\/head>/i, `${importMapTag}\n</head>`);
+  }
+
+  if (options.projectStylesheetHref && /<\/head>/i.test(html) && !hasProjectStylesheet(html)) {
+    const projectStylesheetTag = `<link rel="stylesheet" href="${options.projectStylesheetHref}">`;
+    html = html.replace(/<\/head>/i, `${projectStylesheetTag}\n</head>`);
   }
 
   const shouldUsePreviewStylesheet = options.mode === "development" ||

--- a/src/rendering/orchestrator/html.test.ts
+++ b/src/rendering/orchestrator/html.test.ts
@@ -300,6 +300,59 @@ describe("HTMLGenerator helpers", () => {
       assertEquals(html.includes("/_vf_styles/styles.css?t="), true);
     });
 
+    it("preserves full-document layout head/body output for explicit dark-mode requests", async () => {
+      const mockAdapter = {
+        fs: {
+          readFile: async () => `'use client';`,
+          exists: async () => false,
+          stat: async () => ({ isFile: false, isDirectory: false, isSymlink: false }),
+          readDir: async function* () {},
+          mkdir: async () => {},
+          writeFile: async () => {},
+        },
+      };
+
+      const generator = new HTMLGenerator({
+        projectDir: "/project",
+        adapter: mockAdapter as any,
+        config: {} as any,
+        mode: "production",
+      });
+
+      const html = await generator.generateFullHTML({
+        html:
+          '<!DOCTYPE html><html lang="en"><head><title>Layout Title</title><style>body{background:#0f172a;color:#f8fafc}</style></head><body class="theme-dark" style="background:#0f172a;color:#f8fafc"><main>Hello</main></body></html>',
+        pageInfo: {
+          entity: {
+            path: "/project/app/page.tsx",
+            frontmatter: {},
+          },
+        } as any,
+        pageBundle: {} as any,
+        layoutBundle: undefined,
+        nestedLayouts: [],
+        collectedMetadata: {},
+        slug: "test-page",
+        ssrHash: "hash123",
+        options: {
+          nonce: "nonce-123",
+          colorScheme: "dark",
+          colorSchemeFromParam: true,
+        },
+      });
+
+      assertEquals(html.includes("<title>Layout Title</title>"), true);
+      assertEquals(
+        html.includes(
+          '<body class="theme-dark" style="background:#0f172a;color:#f8fafc">',
+        ),
+        true,
+      );
+      assertEquals(html.includes('data-theme="dark"'), true);
+      assertEquals(html.includes("color-scheme: dark;"), true);
+      assertEquals(html.includes(`localStorage.setItem('theme','dark')`), true);
+    });
+
     it("adds nonce to inline style and script tags in rendered HTML", async () => {
       const mockAdapter = {
         fs: {
@@ -531,6 +584,73 @@ describe("HTMLGenerator helpers", () => {
       assertEquals(html.includes('<style nonce="nonce-123">.chat{color:red}</style>'), true);
       assertEquals(html.includes('<script nonce="nonce-123">alert(1)'), false);
       assertEquals(html.includes('<style nonce="nonce-123">.x{color:red}'), false);
+    });
+  });
+
+  describe("generateHTMLStream", () => {
+    it("preserves full-document layout output when streaming app-router pages", async () => {
+      const mockAdapter = {
+        fs: {
+          readFile: async () => `'use client';`,
+          exists: async () => false,
+          stat: async () => ({ isFile: false, isDirectory: false, isSymlink: false }),
+          readDir: async function* () {},
+          mkdir: async () => {},
+          writeFile: async () => {},
+        },
+      };
+
+      const generator = new HTMLGenerator({
+        projectDir: "/project",
+        adapter: mockAdapter as any,
+        config: {} as any,
+        mode: "production",
+      });
+
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              '<!DOCTYPE html><html lang="en"><head><title>Stream Layout Title</title><style>body{background:#0f172a;color:#f8fafc}</style></head><body class="stream-dark" style="background:#0f172a;color:#f8fafc"><main>Hello</main></body></html>',
+            ),
+          );
+          controller.close();
+        },
+      });
+
+      const responseStream = await generator.generateHTMLStream(stream, {
+        pageInfo: {
+          entity: {
+            path: "/project/app/page.tsx",
+            frontmatter: {},
+          },
+        } as any,
+        pageBundle: {} as any,
+        layoutBundle: undefined,
+        nestedLayouts: [],
+        collectedMetadata: {},
+        slug: "test-page",
+        ssrHash: "hash123",
+        options: {
+          nonce: "nonce-123",
+          colorScheme: "dark",
+          colorSchemeFromParam: true,
+          environment: "preview",
+        },
+      });
+
+      const html = await new Response(responseStream).text();
+
+      assertEquals(html.includes("<title>Stream Layout Title</title>"), true);
+      assertEquals(
+        html.includes(
+          '<body class="stream-dark" style="background:#0f172a;color:#f8fafc">',
+        ),
+        true,
+      );
+      assertEquals(html.includes('data-theme="dark"'), true);
+      assertEquals(html.includes('id="vf-tailwind-css"'), true);
+      assertEquals(html.includes(`localStorage.setItem('theme','dark')`), true);
     });
   });
 

--- a/src/rendering/orchestrator/html.test.ts
+++ b/src/rendering/orchestrator/html.test.ts
@@ -300,6 +300,52 @@ describe("HTMLGenerator helpers", () => {
       assertEquals(html.includes("/_vf_styles/styles.css?t="), true);
     });
 
+    it("injects production project stylesheet links into full HTML documents", async () => {
+      const mockAdapter = {
+        fs: {
+          readFile: async (path: string) => {
+            if (path.endsWith("/app/page.tsx")) return `'use client';`;
+            if (path.endsWith("/globals.css")) {
+              return "body { background: #0f172a; color: #f8fafc; }";
+            }
+            return "";
+          },
+          exists: async () => false,
+          stat: async () => ({ isFile: false, isDirectory: false, isSymlink: false }),
+          readDir: async function* () {},
+          mkdir: async () => {},
+          writeFile: async () => {},
+        },
+      };
+
+      const generator = new HTMLGenerator({
+        projectDir: "/project",
+        adapter: mockAdapter as any,
+        config: {} as any,
+        mode: "production",
+      });
+
+      const html = await generator.generateFullHTML({
+        html: "<!DOCTYPE html><html><head></head><body><main>Hello</main></body></html>",
+        pageInfo: {
+          entity: {
+            path: "/project/app/page.tsx",
+            frontmatter: {},
+          },
+        } as any,
+        pageBundle: {} as any,
+        layoutBundle: undefined,
+        nestedLayouts: [],
+        collectedMetadata: {},
+        slug: "test-page",
+        ssrHash: "hash123",
+        options: { environment: "production" },
+      });
+
+      assertEquals(/<link rel="stylesheet" href="\/_vf\/css\/[^"]+\.css">/.test(html), true);
+      assertEquals(html.includes('id="vf-tailwind-css"'), false);
+    });
+
     it("preserves full-document layout head/body output for explicit dark-mode requests", async () => {
       const mockAdapter = {
         fs: {
@@ -651,6 +697,67 @@ describe("HTMLGenerator helpers", () => {
       assertEquals(html.includes('data-theme="dark"'), true);
       assertEquals(html.includes('id="vf-tailwind-css"'), true);
       assertEquals(html.includes(`localStorage.setItem('theme','dark')`), true);
+    });
+
+    it("keeps production project stylesheet links for streamed full-document pages", async () => {
+      const mockAdapter = {
+        fs: {
+          readFile: async (path: string) => {
+            if (path.endsWith("/app/page.tsx")) return `'use client';`;
+            if (path.endsWith("/globals.css")) {
+              return "body { background: #0f172a; color: #f8fafc; }";
+            }
+            return "";
+          },
+          exists: async () => false,
+          stat: async () => ({ isFile: false, isDirectory: false, isSymlink: false }),
+          readDir: async function* () {},
+          mkdir: async () => {},
+          writeFile: async () => {},
+        },
+      };
+
+      const generator = new HTMLGenerator({
+        projectDir: "/project",
+        adapter: mockAdapter as any,
+        config: {} as any,
+        mode: "production",
+      });
+
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              "<!DOCTYPE html><html><head><title>Prod Layout</title></head><body><main>Hello</main></body></html>",
+            ),
+          );
+          controller.close();
+        },
+      });
+
+      const responseStream = await generator.generateHTMLStream(stream, {
+        pageInfo: {
+          entity: {
+            path: "/project/app/page.tsx",
+            frontmatter: {},
+          },
+        } as any,
+        pageBundle: {} as any,
+        layoutBundle: undefined,
+        nestedLayouts: [],
+        collectedMetadata: {},
+        slug: "test-page",
+        ssrHash: "hash123",
+        options: {
+          environment: "production",
+        },
+      });
+
+      const html = await new Response(responseStream).text();
+
+      assertEquals(/<link rel="stylesheet" href="\/_vf\/css\/[^"]+\.css">/.test(html), true);
+      assertEquals(html.includes('id="vf-tailwind-css"'), false);
+      assertEquals(html.includes("hydrate.js?slug=test-page"), true);
     });
   });
 

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -127,9 +127,22 @@ export class HTMLGenerator {
   }
 
   async generateFullHTML(context: HTMLGenerationContext): Promise<string> {
-    const html = isFullHTMLDocument(context.html)
-      ? await this.handleFullHTMLDocument(context)
-      : await this.wrapHTMLFragment(context);
+    let html: string;
+    if (isFullHTMLDocument(context.html)) {
+      let projectCSSPromise: Promise<ProjectCSSResult> | undefined;
+      if (this.config.mode === "production" && context.options?.environment === "production") {
+        const mergedFrontmatter = this.mergeFrontmatter(context);
+        const htmlOptions = await profilePhase(
+          "html.build_options",
+          () => this.buildHTMLOptions(context, mergedFrontmatter),
+        );
+        projectCSSPromise = this.startProjectCSSPreparation(context, htmlOptions);
+      }
+
+      html = await this.handleFullHTMLDocument(context, projectCSSPromise);
+    } else {
+      html = await this.wrapHTMLFragment(context);
+    }
     const finalHtml = context.options?.studioEmbed ? injectElementSelectors(html) : html;
 
     if (context.options?.studioEmbed) {
@@ -167,10 +180,13 @@ export class HTMLGenerator {
     if (isFullHTMLDocument(reactContent)) {
       const encoder = new TextEncoder();
       const fullHtml = addNonceToHtmlTags(
-        await this.handleFullHTMLDocument({
-          ...fullContext,
-          html: reactContent,
-        }),
+        await this.handleFullHTMLDocument(
+          {
+            ...fullContext,
+            html: reactContent,
+          },
+          projectCSSPromise,
+        ),
         context.options?.nonce,
       );
 
@@ -208,7 +224,10 @@ export class HTMLGenerator {
     });
   }
 
-  private async handleFullHTMLDocument(context: HTMLGenerationContext): Promise<string> {
+  private async handleFullHTMLDocument(
+    context: HTMLGenerationContext,
+    projectCSSPromise?: Promise<ProjectCSSResult>,
+  ): Promise<string> {
     const metadata = extractHTMLMetadata(
       (context.pageInfo.entity.frontmatter || {}) as MDXFrontmatter,
       (context.layoutBundle?.frontmatter || {}) as MDXFrontmatter,
@@ -234,6 +253,11 @@ export class HTMLGenerator {
       context.options?.nonce,
     );
 
+    const projectStylesheetHref = await this.resolveProjectStylesheetHref(
+      context,
+      projectCSSPromise,
+    );
+
     const injectedHtml = injectHTMLContent(themedHtml, "", metadata, {
       mode: this.config.mode,
       slug: context.slug,
@@ -245,11 +269,29 @@ export class HTMLGenerator {
       isLocalProject: this.config.mode === "development",
       nonce: context.options?.nonce,
       importMapJson,
+      projectStylesheetHref,
     });
 
     if (injectedHtml.trimStart().toLowerCase().startsWith("<!doctype")) return injectedHtml;
 
     return `<!DOCTYPE html>\n${injectedHtml}`;
+  }
+
+  private async resolveProjectStylesheetHref(
+    context: HTMLGenerationContext,
+    projectCSSPromise?: Promise<ProjectCSSResult>,
+  ): Promise<string | undefined> {
+    if (!projectCSSPromise) return undefined;
+
+    const projectCSS = await profilePhase("html.project_css", () => projectCSSPromise);
+    const cssHash = projectCSS?.hash ?? "";
+    if (cssHash) return `/_vf/css/${cssHash}.css`;
+
+    logger.error("Project CSS hash is empty for full-document HTML", {
+      slug: context.slug,
+      environment: context.options?.environment,
+    });
+    return undefined;
   }
 
   private async detectUseClientDirective(pagePath: string): Promise<boolean> {

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -41,6 +41,62 @@ import type { ResolvedContentContext } from "#veryfront/platform/adapters/fs/ver
 const logger = rendererLogger.component("html-generator");
 type ProjectCSSResult = Awaited<ReturnType<typeof getProjectCSS>> | null;
 
+function applyExplicitThemeToDocument(
+  html: string,
+  colorScheme: "light" | "dark" | undefined,
+  enabled: boolean | undefined,
+): string {
+  if (!enabled || !colorScheme) return html;
+
+  return html.replace(/<html\b([^>]*)>/i, (_match, attrs: string) => {
+    let nextAttrs = attrs;
+
+    if (/\sdata-theme\s*=/i.test(nextAttrs)) {
+      nextAttrs = nextAttrs.replace(/\sdata-theme\s*=\s*(["']).*?\1/i, "");
+    }
+    nextAttrs += ` data-theme="${colorScheme}"`;
+
+    const styleMatch = nextAttrs.match(/\sstyle\s*=\s*(["'])(.*?)\1/i);
+    if (styleMatch) {
+      let styleValue = (styleMatch[2] ?? "").trim();
+
+      if (/color-scheme\s*:/i.test(styleValue)) {
+        styleValue = styleValue.replace(
+          /color-scheme\s*:\s*[^;]+/i,
+          `color-scheme: ${colorScheme}`,
+        );
+      } else {
+        styleValue = styleValue
+          ? `${styleValue.replace(/;?\s*$/, ";")} color-scheme: ${colorScheme};`
+          : `color-scheme: ${colorScheme};`;
+      }
+
+      nextAttrs = nextAttrs.replace(styleMatch[0], ` style="${styleValue}"`);
+    } else {
+      nextAttrs += ` style="color-scheme: ${colorScheme};"`;
+    }
+
+    return `<html${nextAttrs}>`;
+  });
+}
+
+function injectThemePersistenceScript(
+  html: string,
+  colorScheme: "light" | "dark" | undefined,
+  enabled: boolean | undefined,
+  nonce?: string,
+): string {
+  if (!enabled || !colorScheme || !/<\/head>/i.test(html)) return html;
+  if (html.includes(`localStorage.setItem('theme','${colorScheme}')`)) return html;
+
+  const nonceAttr = nonce ? ` nonce="${nonce}"` : "";
+  const script = `<script${nonceAttr}>
+(function(){try{localStorage.setItem('theme','${colorScheme}')}catch(e){/* SILENT: localStorage may be unavailable */}})();
+</script>`;
+
+  return html.replace(/<\/head>/i, `${script}\n</head>`);
+}
+
 export interface HTMLGeneratorConfig {
   projectDir: string;
   adapter: RuntimeAdapter;
@@ -108,6 +164,24 @@ export class HTMLGenerator {
       reactContent = error.partialContent.trim();
     }
 
+    if (isFullHTMLDocument(reactContent)) {
+      const encoder = new TextEncoder();
+      const fullHtml = addNonceToHtmlTags(
+        await this.handleFullHTMLDocument({
+          ...fullContext,
+          html: reactContent,
+        }),
+        context.options?.nonce,
+      );
+
+      return new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(fullHtml));
+          controller.close();
+        },
+      });
+    }
+
     const { start, end } = await profilePhase(
       "html.generate_shell_parts",
       () =>
@@ -149,7 +223,18 @@ export class HTMLGenerator {
       }),
     ]);
 
-    const injectedHtml = injectHTMLContent(context.html, "", metadata, {
+    const themedHtml = injectThemePersistenceScript(
+      applyExplicitThemeToDocument(
+        context.html,
+        context.options?.colorScheme,
+        context.options?.colorSchemeFromParam,
+      ),
+      context.options?.colorScheme,
+      context.options?.colorSchemeFromParam,
+      context.options?.nonce,
+    );
+
+    const injectedHtml = injectHTMLContent(themedHtml, "", metadata, {
       mode: this.config.mode,
       slug: context.slug,
       devPort: this.config.config?.dev?.port || DEFAULT_DASHBOARD_PORT,

--- a/src/transforms/pipeline/stages/ssr-vf-modules.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules.test.ts
@@ -79,6 +79,13 @@ describe("ssr-vf-modules", { sanitizeOps: false, sanitizeResources: false }, () 
       assertEquals(imports.length, 1);
     });
 
+    it("finds file:///_vf_modules imports", () => {
+      const code =
+        `import { usePageContext } from "file:///_vf_modules/_veryfront/react/runtime/core.js?ssr=true";`;
+      const imports = findVfModuleImports(code);
+      assertEquals(imports, ["file:///_vf_modules/_veryfront/react/runtime/core.js?ssr=true"]);
+    });
+
     it("ignores string literals without from keyword", () => {
       const code = `const path = "/_vf_modules/something";`;
       const imports = findVfModuleImports(code);

--- a/src/transforms/pipeline/stages/ssr-vf-modules/import-finder.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/import-finder.ts
@@ -9,8 +9,10 @@
 export function findVfModuleImports(code: string): string[] {
   const imports: string[] = [];
   // Note: \s* allows zero whitespace (minified code: from"..." has no space)
-  // Only match _veryfront/ framework modules, not user project files
-  const pattern = /from\s*["'](\/\_vf\_modules\/_veryfront\/[^"']+)["']/g;
+  // Only match _veryfront/ framework modules, not user project files.
+  // Handle both raw "/_vf_modules/..." specifiers and malformed
+  // "file:///_vf_modules/..." variants that can leak out of stale caches.
+  const pattern = /from\s*["']((?:file:\/\/)?\/_vf_modules\/_veryfront\/[^"']+)["']/g;
 
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(code)) !== null) {

--- a/src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.test.ts
@@ -1,3 +1,4 @@
+import { join } from "#veryfront/compat/path/index.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
@@ -5,6 +6,7 @@ import {
   resolveRelativeFrameworkImport,
   tryReadWithExtensions,
 } from "./path-resolver.ts";
+import { FRAMEWORK_ROOT } from "./constants.ts";
 
 function createMockFs(files: Record<string, string>) {
   return {
@@ -63,6 +65,21 @@ describe("resolveFrameworkFile", () => {
       async () => false,
     );
     assertEquals(result, null);
+  });
+
+  it("normalizes file:///_vf_modules paths before resolving", async () => {
+    const sourcePath = join(FRAMEWORK_ROOT, "src", "react", "runtime", "core.ts");
+    const files: Record<string, string> = {
+      [sourcePath]: "export function usePageContext() {}",
+    };
+    const fs = createMockFs(files);
+    const result = await resolveFrameworkFile(
+      "file:///_vf_modules/_veryfront/react/runtime/core.js?ssr=true",
+      fs,
+      createExistsFn(files),
+    );
+    assertEquals(result?.sourcePath, sourcePath);
+    assertEquals(result?.content, "export function usePageContext() {}");
   });
 });
 

--- a/src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.ts
@@ -51,13 +51,16 @@ export async function resolveFrameworkFile(
   fs: ReturnType<typeof createFileSystem>,
   existsFn: (path: string) => Promise<boolean> = exists,
 ): Promise<{ sourcePath: string; content: string } | null> {
-  const pathWithoutPrefix = vfModulePath
+  const normalizedVfModulePath = vfModulePath.replace(/^file:\/\/(?=\/_vf_modules\/)/, "");
+
+  const pathWithoutPrefix = normalizedVfModulePath
     .replace(/^\/_vf_modules\//, "")
     .replace(/\?.*$/, "")
     .replace(/\.js$/, "");
 
   logger.debug(`${LOG_PREFIX} resolveFrameworkFile`, {
     input: vfModulePath,
+    normalizedVfModulePath,
     pathWithoutPrefix,
     lookupDirs: FRAMEWORK_LOOKUPS.map(([p, d]) => ({ prefix: p, dir: d })),
   });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.131";
+export const VERSION = "0.1.132";

--- a/tests/integration/renderer/renderer-core-foundation.test.ts
+++ b/tests/integration/renderer/renderer-core-foundation.test.ts
@@ -9,6 +9,7 @@ import {
   assert,
   assertEquals,
   assertExists,
+  assertMatch,
   assertRejects,
   assertStringIncludes,
 } from "#veryfront/testing/assert";
@@ -487,6 +488,59 @@ title: Stream Test
           assertStringIncludes(html, "color-scheme: dark;");
           assertStringIncludes(html, "Streaming Layout Content");
         });
+      });
+
+      it("should keep production project CSS links for streamed full-document app-router renders", async () => {
+        await withTestContext(
+          "renderer-core-stream-root-layout-production-css",
+          async (context) => {
+            await remove(join(context.projectDir, "pages"), { recursive: true });
+            await mkdir(join(context.projectDir, "app"), { recursive: true });
+
+            await writeTextFile(
+              join(context.projectDir, "globals.css"),
+              "body { background: #0f172a; color: #f8fafc; }",
+            );
+
+            await writeTextFile(
+              join(context.projectDir, "app", "layout.tsx"),
+              `export default function RootLayout({ children }) {
+              return (
+                <html lang="en">
+                  <head>
+                    <title>Production Stream Layout Title</title>
+                  </head>
+                  <body className="stream-dark">
+                    {children}
+                  </body>
+                </html>
+              );
+            }`,
+            );
+
+            await writeTextFile(
+              join(context.projectDir, "app", "page.tsx"),
+              `export default function Page() { return <main>Production Streaming Layout Content</main>; }`,
+            );
+
+            const renderer = await createRenderer({
+              projectDir: context.projectDir,
+              mode: "production",
+            });
+
+            const result = await renderer.renderPage("/", {
+              delivery: "stream",
+              environment: "production",
+            });
+
+            const html = result.stream ? await new Response(result.stream).text() : result.html;
+
+            assertStringIncludes(html, "<title>Production Stream Layout Title</title>");
+            assertMatch(html, /<link rel="stylesheet" href="\/_vf\/css\/[^"]+\.css">/);
+            assertEquals(html.includes('id="vf-tailwind-css"'), false);
+            assertStringIncludes(html, "Production Streaming Layout Content");
+          },
+        );
       });
 
       it("should use streaming SSR in production mode", async () => {

--- a/tests/integration/renderer/renderer-core-foundation.test.ts
+++ b/tests/integration/renderer/renderer-core-foundation.test.ts
@@ -437,6 +437,58 @@ title: Stream Test
         });
       });
 
+      it("should preserve full-document root layout output during streaming app-router renders", async () => {
+        await withTestContext("renderer-core-stream-root-layout-document", async (context) => {
+          await remove(join(context.projectDir, "pages"), { recursive: true });
+          await mkdir(join(context.projectDir, "app"), { recursive: true });
+
+          await writeTextFile(
+            join(context.projectDir, "app", "layout.tsx"),
+            `export default function RootLayout({ children }) {
+              return (
+                <html lang="en">
+                  <head>
+                    <title>Stream Layout Title</title>
+                    <style>{\`body{background:#0f172a;color:#f8fafc}\`}</style>
+                  </head>
+                  <body className="stream-dark" style={{ background: '#0f172a', color: '#f8fafc' }}>
+                    {children}
+                  </body>
+                </html>
+              );
+            }`,
+          );
+
+          await writeTextFile(
+            join(context.projectDir, "app", "page.tsx"),
+            `export default function Page() { return <main>Streaming Layout Content</main>; }`,
+          );
+
+          const renderer = await createRenderer({
+            projectDir: context.projectDir,
+            mode: "production",
+          });
+
+          const result = await renderer.renderPage("/", {
+            delivery: "stream",
+            colorScheme: "dark",
+            colorSchemeFromParam: true,
+            environment: "preview",
+          });
+
+          const html = result.stream ? await new Response(result.stream).text() : result.html;
+
+          assertStringIncludes(html, "<title>Stream Layout Title</title>");
+          assertStringIncludes(
+            html,
+            '<body class="stream-dark" style="background:#0f172a;color:#f8fafc">',
+          );
+          assertStringIncludes(html, 'data-theme="dark"');
+          assertStringIncludes(html, "color-scheme: dark;");
+          assertStringIncludes(html, "Streaming Layout Content");
+        });
+      });
+
       it("should use streaming SSR in production mode", async () => {
         await withTestContext("renderer-core-ssr-production", async (context) => {
           await remove(join(context.projectDir, "app"), { recursive: true });


### PR DESCRIPTION
## Summary
- preserve app-router full-document layout output during streaming SSR
- keep explicit color_mode theming when the streamed response is already a full HTML document
- add unit and integration regressions for streamed root-layout documents

## Problem
Preview requests were using the streaming SSR path. When a root layout returned a full document (`<html><head><body>`), the streaming HTML generator treated that response like a fragment and wrapped it in the generic shell. That dropped layout-authored `<title>`, `<style>`, and `<body>` attributes, which is why the dark background disappeared on the preview homepage.

## Verification
- deno test --allow-all src/rendering/orchestrator/html.test.ts
- deno test --allow-all --no-check tests/integration/renderer/renderer-core-foundation.test.ts
- deno check src/rendering/orchestrator/html.ts src/rendering/orchestrator/html.test.ts tests/integration/renderer/renderer-core-foundation.test.ts