### PR TITLE
feat(mcp): protocol version negotiation & lifecycle (MCP 2025-11-25)

### DIFF
--- a/cli/mcp/jsonrpc.test.ts
+++ b/cli/mcp/jsonrpc.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   buildInitializeResult,

--- a/cli/mcp/jsonrpc.test.ts
+++ b/cli/mcp/jsonrpc.test.ts
@@ -1,0 +1,129 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  buildInitializeResult,
+  MCP_SUPPORTED_VERSIONS,
+  negotiateVersion,
+  toParamsRecord,
+} from "./jsonrpc.ts";
+
+describe("cli/mcp/jsonrpc", () => {
+  describe("toParamsRecord", () => {
+    it("returns object params as-is", () => {
+      const params = { foo: "bar" };
+      assertEquals(toParamsRecord(params), { foo: "bar" });
+    });
+
+    it("returns empty record for null", () => {
+      assertEquals(toParamsRecord(null), {});
+    });
+
+    it("returns empty record for undefined", () => {
+      assertEquals(toParamsRecord(undefined), {});
+    });
+
+    it("returns empty record for array params", () => {
+      assertEquals(toParamsRecord([1, 2, 3]), {});
+    });
+
+    it("returns empty record for primitive", () => {
+      assertEquals(toParamsRecord("string"), {});
+      assertEquals(toParamsRecord(42), {});
+      assertEquals(toParamsRecord(true), {});
+    });
+  });
+
+  describe("negotiateVersion", () => {
+    it("echoes supported version 2025-11-25", () => {
+      assertEquals(negotiateVersion({ protocolVersion: "2025-11-25" }), "2025-11-25");
+    });
+
+    it("echoes supported version 2024-11-05", () => {
+      assertEquals(negotiateVersion({ protocolVersion: "2024-11-05" }), "2024-11-05");
+    });
+
+    it("falls back to newest for unknown version", () => {
+      assertEquals(negotiateVersion({ protocolVersion: "1999-01-01" }), MCP_SUPPORTED_VERSIONS[0]);
+    });
+
+    it("falls back to newest when no version provided", () => {
+      assertEquals(negotiateVersion({}), MCP_SUPPORTED_VERSIONS[0]);
+    });
+
+    it("falls back to newest for null params", () => {
+      assertEquals(negotiateVersion(null), MCP_SUPPORTED_VERSIONS[0]);
+    });
+
+    it("falls back to newest for undefined params", () => {
+      assertEquals(negotiateVersion(undefined), MCP_SUPPORTED_VERSIONS[0]);
+    });
+
+    it("falls back to newest when protocolVersion is not a string", () => {
+      assertEquals(negotiateVersion({ protocolVersion: 123 }), MCP_SUPPORTED_VERSIONS[0]);
+    });
+  });
+
+  describe("buildInitializeResult", () => {
+    const serverInfo = {
+      name: "test-server",
+      title: "Test MCP Server",
+      version: "1.0.0",
+      description: "A test server",
+    };
+    const instructions = "Use this for testing.";
+
+    it("includes negotiated protocol version", () => {
+      const result = buildInitializeResult(
+        { protocolVersion: "2024-11-05" },
+        serverInfo,
+        instructions,
+      );
+      assertEquals(result.protocolVersion, "2024-11-05");
+    });
+
+    it("includes serverInfo", () => {
+      const result = buildInitializeResult({}, serverInfo, instructions);
+      const info = result.serverInfo as Record<string, unknown>;
+      assertEquals(info.name, "test-server");
+      assertEquals(info.title, "Test MCP Server");
+      assertEquals(info.version, "1.0.0");
+      assertEquals(info.description, "A test server");
+    });
+
+    it("includes instructions", () => {
+      const result = buildInitializeResult({}, serverInfo, instructions);
+      assertEquals(result.instructions, "Use this for testing.");
+    });
+
+    it("includes listChanged capabilities", () => {
+      const result = buildInitializeResult({}, serverInfo, instructions);
+      const caps = result.capabilities as Record<string, Record<string, unknown>>;
+      assertEquals(caps.tools.listChanged, true);
+      assertEquals(caps.resources.listChanged, true);
+      assertEquals(caps.prompts.listChanged, true);
+    });
+
+    it("falls back to newest version for unknown version", () => {
+      const result = buildInitializeResult(
+        { protocolVersion: "9999-12-31" },
+        serverInfo,
+        instructions,
+      );
+      assertEquals(result.protocolVersion, MCP_SUPPORTED_VERSIONS[0]);
+    });
+  });
+
+  describe("MCP_SUPPORTED_VERSIONS", () => {
+    it("has 2025-11-25 as the newest version", () => {
+      assertEquals(MCP_SUPPORTED_VERSIONS[0], "2025-11-25");
+    });
+
+    it("includes 2024-11-05 for backward compatibility", () => {
+      assertEquals(MCP_SUPPORTED_VERSIONS.includes("2024-11-05"), true);
+    });
+
+    it("contains at least 2 versions", () => {
+      assertEquals(MCP_SUPPORTED_VERSIONS.length >= 2, true);
+    });
+  });
+});

--- a/cli/mcp/jsonrpc.ts
+++ b/cli/mcp/jsonrpc.ts
@@ -83,6 +83,55 @@ export function errorResponse(
 }
 
 /**
+ * Supported MCP protocol versions (newest first).
+ * Shared across all CLI MCP servers so the version list is maintained in one place.
+ */
+export const MCP_SUPPORTED_VERSIONS = ["2025-11-25", "2024-11-05"];
+
+/**
+ * Safely extract a record from unknown params (mirrors src/mcp toParamsRecord).
+ */
+export function toParamsRecord(params: unknown): Record<string, unknown> {
+  if (params && typeof params === "object" && !Array.isArray(params)) {
+    return params as Record<string, unknown>;
+  }
+  return {};
+}
+
+/**
+ * Negotiate MCP protocol version: echo the client's version if supported,
+ * otherwise fall back to the newest supported version.
+ */
+export function negotiateVersion(params: unknown): string {
+  const p = toParamsRecord(params);
+  const requested = typeof p.protocolVersion === "string" ? p.protocolVersion : undefined;
+  return requested && MCP_SUPPORTED_VERSIONS.includes(requested)
+    ? requested
+    : MCP_SUPPORTED_VERSIONS[0];
+}
+
+/**
+ * Build a complete MCP initialize result with negotiated version,
+ * capabilities, serverInfo, and instructions.
+ */
+export function buildInitializeResult(
+  params: unknown,
+  serverInfo: { name: string; title: string; version: string; description: string },
+  instructions: string,
+): Record<string, unknown> {
+  return {
+    protocolVersion: negotiateVersion(params),
+    capabilities: {
+      tools: { listChanged: true },
+      resources: { listChanged: true },
+      prompts: { listChanged: true },
+    },
+    serverInfo,
+    instructions,
+  };
+}
+
+/**
  * Validate and extract tools/call params
  */
 export const ToolsCallParamsSchema = z.object({

--- a/cli/mcp/jsonrpc.ts
+++ b/cli/mcp/jsonrpc.ts
@@ -86,7 +86,7 @@ export function errorResponse(
  * Supported MCP protocol versions (newest first).
  * Shared across all CLI MCP servers so the version list is maintained in one place.
  */
-export const MCP_SUPPORTED_VERSIONS = ["2025-11-25", "2024-11-05"];
+export const MCP_SUPPORTED_VERSIONS: [string, ...string[]] = ["2025-11-25", "2024-11-05"];
 
 /**
  * Safely extract a record from unknown params (mirrors src/mcp toParamsRecord).

--- a/cli/mcp/server.test.ts
+++ b/cli/mcp/server.test.ts
@@ -127,7 +127,7 @@ describe("cli/mcp/server", { sanitizeOps: false, sanitizeResources: false }, () 
       assertEquals(data.jsonrpc, "2.0");
       assertEquals(data.id, 1);
       assertExists(data.result);
-      assertEquals(data.result.protocolVersion, "2024-11-05");
+      assertEquals(data.result.protocolVersion, "2025-11-25");
       assertExists(data.result.capabilities);
       assertExists(data.result.capabilities.tools);
       assertExists(data.result.capabilities.resources);
@@ -344,6 +344,191 @@ describe("cli/mcp/server", { sanitizeOps: false, sanitizeResources: false }, () 
       const data = await response.json();
       assertExists(data.error);
       assertEquals(data.error.code, -32700);
+    });
+
+    it("should negotiate protocol version 2025-11-25", async () => {
+      const portNum = 19890;
+      server = new MCPDevServer({ httpPort: portNum });
+      server.start();
+
+      await waitForServerBind();
+
+      const response = await postMcp(portNum, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-11-25" },
+      });
+
+      const data = await response.json();
+      assertEquals(data.result.protocolVersion, "2025-11-25");
+    });
+
+    it("should negotiate protocol version 2024-11-05", async () => {
+      const portNum = 19891;
+      server = new MCPDevServer({ httpPort: portNum });
+      server.start();
+
+      await waitForServerBind();
+
+      const response = await postMcp(portNum, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2024-11-05" },
+      });
+
+      const data = await response.json();
+      assertEquals(data.result.protocolVersion, "2024-11-05");
+    });
+
+    it("should fall back to newest version for unknown protocol version", async () => {
+      const portNum = 19892;
+      server = new MCPDevServer({ httpPort: portNum });
+      server.start();
+
+      await waitForServerBind();
+
+      const response = await postMcp(portNum, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "1999-01-01" },
+      });
+
+      const data = await response.json();
+      assertEquals(data.result.protocolVersion, "2025-11-25");
+    });
+
+    it("should include serverInfo title and description", async () => {
+      const portNum = 19893;
+      server = new MCPDevServer({ httpPort: portNum });
+      server.start();
+
+      await waitForServerBind();
+
+      const response = await postMcp(portNum, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-11-25" },
+      });
+
+      const data = await response.json();
+      assertExists(data.result.serverInfo.title);
+      assertExists(data.result.serverInfo.description);
+    });
+
+    it("should include instructions field", async () => {
+      const portNum = 19894;
+      server = new MCPDevServer({ httpPort: portNum });
+      server.start();
+
+      await waitForServerBind();
+
+      const response = await postMcp(portNum, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-11-25" },
+      });
+
+      const data = await response.json();
+      assertExists(data.result.instructions);
+    });
+
+    it("should include listChanged in capabilities", async () => {
+      const portNum = 19895;
+      server = new MCPDevServer({ httpPort: portNum });
+      server.start();
+
+      await waitForServerBind();
+
+      const response = await postMcp(portNum, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-11-25" },
+      });
+
+      const data = await response.json();
+      assertEquals(data.result.capabilities.tools.listChanged, true);
+      assertEquals(data.result.capabilities.resources.listChanged, true);
+      assertEquals(data.result.capabilities.prompts.listChanged, true);
+    });
+
+    it("should handle notifications/initialized", async () => {
+      const portNum = 19896;
+      server = new MCPDevServer({ httpPort: portNum });
+      server.start();
+
+      await waitForServerBind();
+
+      const response = await postMcp(portNum, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "notifications/initialized",
+      });
+
+      assertEquals(response.status, 200);
+      const data = await response.json();
+      assertEquals(data.error, undefined);
+    });
+
+    it("should reject disallowed Origin with 403", async () => {
+      const portNum = 19897;
+      server = new MCPDevServer({ httpPort: portNum });
+      server.start();
+
+      await waitForServerBind();
+
+      const response = await postMcp(
+        portNum,
+        { jsonrpc: "2.0", id: 1, method: "tools/list" },
+        {
+          "Content-Type": "application/json",
+          Origin: "https://evil.com",
+        },
+      );
+
+      assertEquals(response.status, 403);
+      const data = await response.json();
+      assertEquals(data.error.message, "Forbidden: Origin not allowed");
+    });
+
+    it("should allow request with no Origin header", async () => {
+      const portNum = 19898;
+      server = new MCPDevServer({ httpPort: portNum });
+      server.start();
+
+      await waitForServerBind();
+
+      const response = await postMcp(portNum, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+      });
+
+      assertEquals(response.status, 200);
+    });
+
+    it("should allow localhost Origin", async () => {
+      const portNum = 19899;
+      server = new MCPDevServer({ httpPort: portNum });
+      server.start();
+
+      await waitForServerBind();
+
+      const response = await postMcp(
+        portNum,
+        { jsonrpc: "2.0", id: 1, method: "tools/list" },
+        {
+          "Content-Type": "application/json",
+          Origin: "http://localhost:3000",
+        },
+      );
+
+      assertEquals(response.status, 200);
     });
 
     it("should return error for unknown tool call", async () => {

--- a/cli/mcp/server.ts
+++ b/cli/mcp/server.ts
@@ -53,6 +53,8 @@ export interface MCPServerConfig {
 }
 
 export class MCPDevServer {
+  private static SUPPORTED_VERSIONS = ["2025-11-25", "2024-11-05"];
+
   private config: MCPServerConfig;
   private running = false;
   private stdinReader: StdinReader | null = null;
@@ -166,6 +168,8 @@ export class MCPDevServer {
     switch (method) {
       case "initialize":
         return Promise.resolve(this.handleInitialize(params));
+      case "notifications/initialized":
+        return Promise.resolve({});
       case "tools/list":
         return Promise.resolve(this.handleToolsList());
       case "tools/call":
@@ -183,18 +187,29 @@ export class MCPDevServer {
     }
   }
 
-  private handleInitialize(_params: unknown): unknown {
+  private handleInitialize(params: unknown): unknown {
+    const p = (params && typeof params === "object" && !Array.isArray(params))
+      ? params as Record<string, unknown>
+      : {};
+    const requested = typeof p.protocolVersion === "string" ? p.protocolVersion : undefined;
+    const negotiated = requested && MCPDevServer.SUPPORTED_VERSIONS.includes(requested)
+      ? requested
+      : MCPDevServer.SUPPORTED_VERSIONS[0];
+
     return {
-      protocolVersion: "2024-11-05",
+      protocolVersion: negotiated,
       capabilities: {
-        tools: {},
-        resources: {},
-        prompts: {},
+        tools: { listChanged: true },
+        resources: { listChanged: true },
+        prompts: { listChanged: true },
       },
       serverInfo: {
         name: this.config.serverName,
+        title: "Veryfront Dev MCP Server",
         version: this.config.serverVersion,
+        description: "Veryfront development server tools for real-time errors, logs, HMR, and scaffolding",
       },
+      instructions: "Veryfront dev MCP server provides development tools. Use vf_get_errors to check for code errors, vf_get_logs for server logs, and vf_trigger_hmr for hot module reload.",
     };
   }
 

--- a/cli/mcp/server.ts
+++ b/cli/mcp/server.ts
@@ -15,6 +15,7 @@ import { getErrorCollector, getLogBuffer } from "veryfront/observability";
 import { allTools, getTool, setServerStartTime } from "./tools.ts";
 import { startStdioJsonRpc } from "./stdio.ts";
 import {
+  buildInitializeResult,
   errorResponse,
   type JSONRPCRequest,
   JSONRPCRequestSchema,
@@ -53,8 +54,6 @@ export interface MCPServerConfig {
 }
 
 export class MCPDevServer {
-  private static SUPPORTED_VERSIONS = ["2025-11-25", "2024-11-05"];
-
   private config: MCPServerConfig;
   private running = false;
   private stdinReader: StdinReader | null = null;
@@ -120,6 +119,17 @@ export class MCPDevServer {
       if (isAllowedOrigin && origin) headers["Access-Control-Allow-Origin"] = origin;
 
       if (req.method === "OPTIONS") return new Response(null, { status: 204, headers });
+
+      if (origin && !isAllowedOrigin) {
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: null,
+            error: { code: -32600, message: "Forbidden: Origin not allowed" },
+          }),
+          { status: 403, headers },
+        );
+      }
 
       if (url.pathname !== "/mcp") {
         return new Response(JSON.stringify({ error: "Not found. MCP endpoint is at /mcp" }), {
@@ -188,29 +198,16 @@ export class MCPDevServer {
   }
 
   private handleInitialize(params: unknown): unknown {
-    const p = (params && typeof params === "object" && !Array.isArray(params))
-      ? params as Record<string, unknown>
-      : {};
-    const requested = typeof p.protocolVersion === "string" ? p.protocolVersion : undefined;
-    const negotiated = requested && MCPDevServer.SUPPORTED_VERSIONS.includes(requested)
-      ? requested
-      : MCPDevServer.SUPPORTED_VERSIONS[0];
-
-    return {
-      protocolVersion: negotiated,
-      capabilities: {
-        tools: { listChanged: true },
-        resources: { listChanged: true },
-        prompts: { listChanged: true },
-      },
-      serverInfo: {
-        name: this.config.serverName,
+    return buildInitializeResult(
+      params,
+      {
+        name: this.config.serverName ?? "veryfront-dev",
         title: "Veryfront Dev MCP Server",
-        version: this.config.serverVersion,
+        version: this.config.serverVersion ?? "1.0.0",
         description: "Veryfront development server tools for real-time errors, logs, HMR, and scaffolding",
       },
-      instructions: "Veryfront dev MCP server provides development tools. Use vf_get_errors to check for code errors, vf_get_logs for server logs, and vf_trigger_hmr for hot module reload.",
-    };
+      "Veryfront dev MCP server provides development tools. Use vf_get_errors to check for code errors, vf_get_logs for server logs, and vf_trigger_hmr for hot module reload.",
+    );
   }
 
   private handleToolsList(): unknown {

--- a/cli/mcp/server.ts
+++ b/cli/mcp/server.ts
@@ -204,7 +204,8 @@ export class MCPDevServer {
         name: this.config.serverName ?? "veryfront-dev",
         title: "Veryfront Dev MCP Server",
         version: this.config.serverVersion ?? "1.0.0",
-        description: "Veryfront development server tools for real-time errors, logs, HMR, and scaffolding",
+        description:
+          "Veryfront development server tools for real-time errors, logs, HMR, and scaffolding",
       },
       "Veryfront dev MCP server provides development tools. Use vf_get_errors to check for code errors, vf_get_logs for server logs, and vf_trigger_hmr for hot module reload.",
     );

--- a/cli/mcp/standalone.ts
+++ b/cli/mcp/standalone.ts
@@ -37,6 +37,8 @@ export interface StandaloneMCPConfig {
 }
 
 export class StandaloneMCPServer {
+  private static SUPPORTED_VERSIONS = ["2025-11-25", "2024-11-05"];
+
   private client: DevServerClient;
   private tools: StandaloneTool[];
   private running = false;
@@ -78,12 +80,31 @@ export class StandaloneMCPServer {
 
   private dispatchMethod(method: string, params: unknown): Promise<unknown> {
     switch (method) {
-      case "initialize":
+      case "initialize": {
+        const p = (params && typeof params === "object" && !Array.isArray(params))
+          ? params as Record<string, unknown>
+          : {};
+        const requested = typeof p.protocolVersion === "string" ? p.protocolVersion : undefined;
+        const negotiated = requested && StandaloneMCPServer.SUPPORTED_VERSIONS.includes(requested)
+          ? requested
+          : StandaloneMCPServer.SUPPORTED_VERSIONS[0];
+
         return Promise.resolve({
-          protocolVersion: "2024-11-05",
-          capabilities: { tools: {}, resources: {}, prompts: {} },
-          serverInfo: { name: "veryfront-mcp", version: "1.0.0" },
+          protocolVersion: negotiated,
+          capabilities: {
+            tools: { listChanged: true },
+            resources: { listChanged: true },
+            prompts: { listChanged: true },
+          },
+          serverInfo: {
+            name: "veryfront-mcp",
+            title: "Veryfront Standalone MCP Server",
+            version: "1.0.0",
+            description: "Veryfront standalone MCP server for CLI-based development tools",
+          },
+          instructions: "Veryfront standalone MCP server provides development tools. Use vf_get_errors to check for code errors, vf_get_logs for server logs, and vf_get_status for dev server health.",
         });
+      }
       case "notifications/initialized":
         return Promise.resolve({});
       case "tools/list":

--- a/cli/mcp/standalone.ts
+++ b/cli/mcp/standalone.ts
@@ -11,6 +11,7 @@ import type { StdinReader } from "veryfront/platform";
 import { DevServerClient } from "./dev-server-client.ts";
 import { startStdioJsonRpc } from "./stdio.ts";
 import {
+  buildInitializeResult,
   errorResponse,
   type JSONRPCRequest,
   JSONRPCRequestSchema,
@@ -37,8 +38,6 @@ export interface StandaloneMCPConfig {
 }
 
 export class StandaloneMCPServer {
-  private static SUPPORTED_VERSIONS = ["2025-11-25", "2024-11-05"];
-
   private client: DevServerClient;
   private tools: StandaloneTool[];
   private running = false;
@@ -80,31 +79,17 @@ export class StandaloneMCPServer {
 
   private dispatchMethod(method: string, params: unknown): Promise<unknown> {
     switch (method) {
-      case "initialize": {
-        const p = (params && typeof params === "object" && !Array.isArray(params))
-          ? params as Record<string, unknown>
-          : {};
-        const requested = typeof p.protocolVersion === "string" ? p.protocolVersion : undefined;
-        const negotiated = requested && StandaloneMCPServer.SUPPORTED_VERSIONS.includes(requested)
-          ? requested
-          : StandaloneMCPServer.SUPPORTED_VERSIONS[0];
-
-        return Promise.resolve({
-          protocolVersion: negotiated,
-          capabilities: {
-            tools: { listChanged: true },
-            resources: { listChanged: true },
-            prompts: { listChanged: true },
-          },
-          serverInfo: {
+      case "initialize":
+        return Promise.resolve(buildInitializeResult(
+          params,
+          {
             name: "veryfront-mcp",
             title: "Veryfront Standalone MCP Server",
             version: "1.0.0",
             description: "Veryfront standalone MCP server for CLI-based development tools",
           },
-          instructions: "Veryfront standalone MCP server provides development tools. Use vf_get_errors to check for code errors, vf_get_logs for server logs, and vf_get_status for dev server health.",
-        });
-      }
+          "Veryfront standalone MCP server provides development tools. Use vf_get_errors to check for code errors, vf_get_logs for server logs, and vf_get_status for dev server health.",
+        ));
       case "notifications/initialized":
         return Promise.resolve({});
       case "tools/list":

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -477,6 +477,17 @@ describe("mcp/server", () => {
     });
   });
 
+  it("handles notifications/initialized without error", async () => {
+    const server = createMCPServer({ enabled: true });
+    const res = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "notifications/initialized",
+    });
+    assertEquals(res.jsonrpc, "2.0");
+    assertEquals(res.error, undefined);
+  });
+
   it("syncs integration config to API on first tools/list call", async () => {
     const server = createMCPServer({ enabled: true });
     server.setIntegrationLoader({

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -541,15 +541,29 @@ describe("mcp/server", () => {
     });
   });
 
-  it("handles notifications/initialized without error", async () => {
-    const server = createMCPServer({ enabled: true });
-    const res = await server.handleRequest({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "notifications/initialized",
+  describe("notifications/initialized", () => {
+    it("handles notifications/initialized with id", async () => {
+      const server = createMCPServer({ enabled: true });
+      const res = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "notifications/initialized",
+      });
+      assertEquals(res.jsonrpc, "2.0");
+      assertEquals(res.id, 1);
+      assertEquals(res.error, undefined);
     });
-    assertEquals(res.jsonrpc, "2.0");
-    assertEquals(res.error, undefined);
+
+    it("handles notifications/initialized without id (proper notification)", async () => {
+      const server = createMCPServer({ enabled: true });
+      const res = await server.handleRequest({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      });
+      assertEquals(res.jsonrpc, "2.0");
+      assertEquals(res.id, undefined);
+      assertEquals(res.error, undefined);
+    });
   });
 
   it("syncs integration config to API on first tools/list call", async () => {

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -477,6 +477,70 @@ describe("mcp/server", () => {
     });
   });
 
+  describe("Origin validation (DNS rebinding protection)", () => {
+    it("returns 403 when Origin is not in allowed list", async () => {
+      const server = createMCPServer({
+        enabled: true,
+        cors: { enabled: true, origins: ["https://allowed.com"] },
+      });
+
+      const handler = server.createHTTPHandler();
+      const response = await handler(
+        new Request("http://localhost/mcp", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Origin": "https://evil.com",
+          },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+        }),
+      );
+
+      assertEquals(response.status, 403);
+      const body = await response.json();
+      assertEquals(body.error.message, "Forbidden: Origin not allowed");
+    });
+
+    it("returns 200 when Origin is in allowed list", async () => {
+      const server = createMCPServer({
+        enabled: true,
+        cors: { enabled: true, origins: ["https://allowed.com"] },
+      });
+
+      const handler = server.createHTTPHandler();
+      const response = await handler(
+        new Request("http://localhost/mcp", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Origin": "https://allowed.com",
+          },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+        }),
+      );
+
+      assertEquals(response.status, 200);
+    });
+
+    it("returns 200 when no Origin header is present", async () => {
+      const server = createMCPServer({
+        enabled: true,
+        cors: { enabled: true, origins: ["https://allowed.com"] },
+      });
+
+      const handler = server.createHTTPHandler();
+      const response = await handler(
+        new Request("http://localhost/mcp", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+        }),
+      );
+
+      assertEquals(response.status, 200);
+    });
+  });
+
   it("handles notifications/initialized without error", async () => {
     const server = createMCPServer({ enabled: true });
     const res = await server.handleRequest({

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -386,6 +386,97 @@ describe("mcp/server", () => {
     });
   });
 
+  describe("initialize version negotiation", () => {
+    it("echoes 2025-11-25 when client requests it", async () => {
+      const server = createMCPServer({ enabled: true });
+      const res = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-11-25" },
+      });
+      const result = res.result as Record<string, unknown>;
+      assertEquals(result.protocolVersion, "2025-11-25");
+    });
+
+    it("echoes 2024-11-05 when client requests it", async () => {
+      const server = createMCPServer({ enabled: true });
+      const res = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2024-11-05" },
+      });
+      const result = res.result as Record<string, unknown>;
+      assertEquals(result.protocolVersion, "2024-11-05");
+    });
+
+    it("returns 2025-11-25 for unknown version", async () => {
+      const server = createMCPServer({ enabled: true });
+      const res = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "1999-01-01" },
+      });
+      const result = res.result as Record<string, unknown>;
+      assertEquals(result.protocolVersion, "2025-11-25");
+    });
+
+    it("returns 2025-11-25 when no version is provided", async () => {
+      const server = createMCPServer({ enabled: true });
+      const res = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+      });
+      const result = res.result as Record<string, unknown>;
+      assertEquals(result.protocolVersion, "2025-11-25");
+    });
+
+    it("serverInfo includes title and description", async () => {
+      const server = createMCPServer({ enabled: true });
+      const res = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-11-25" },
+      });
+      const result = res.result as Record<string, unknown>;
+      const serverInfo = result.serverInfo as Record<string, unknown>;
+      assertEquals(serverInfo.name, "veryfront-mcp");
+      assertExists(serverInfo.title);
+      assertExists(serverInfo.description);
+    });
+
+    it("includes instructions field", async () => {
+      const server = createMCPServer({ enabled: true });
+      const res = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-11-25" },
+      });
+      const result = res.result as Record<string, unknown>;
+      assertExists(result.instructions);
+    });
+
+    it("capabilities include listChanged", async () => {
+      const server = createMCPServer({ enabled: true });
+      const res = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-11-25" },
+      });
+      const result = res.result as Record<string, unknown>;
+      const caps = result.capabilities as Record<string, Record<string, unknown>>;
+      assertEquals(caps.tools.listChanged, true);
+      assertEquals(caps.resources.listChanged, true);
+      assertEquals(caps.prompts.listChanged, true);
+    });
+  });
+
   it("syncs integration config to API on first tools/list call", async () => {
     const server = createMCPServer({ enabled: true });
     server.setIntegrationLoader({

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -368,6 +368,12 @@ export class MCPServer {
         return new Response(null, { status: 204, headers: this.getCORSHeaders(requestOrigin) });
       }
 
+      if (requestOrigin && this.config.cors?.enabled && this.config.cors.origins?.length) {
+        if (!this.config.cors.origins.includes(requestOrigin)) {
+          return createJSONRPCErrorResponse(403, -32600, "Forbidden: Origin not allowed");
+        }
+      }
+
       if (this.config.auth?.type && this.config.auth.type !== "none") {
         const authorized = await this.validateAuth(request);
         if (!authorized) return new Response("Unauthorized", { status: 401 });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -81,9 +81,9 @@ export interface IntegrationLoaderConfig {
   apiToken?: string;
 }
 
-export class MCPServer {
-  private static SUPPORTED_VERSIONS = ["2025-11-25", "2024-11-05"];
+const MCP_SUPPORTED_VERSIONS = ["2025-11-25", "2024-11-05"];
 
+export class MCPServer {
   private config: MCPServerConfig;
   private integrationLoader?: IntegrationLoaderConfig;
   private integrationsLoaded = false;
@@ -165,9 +165,9 @@ export class MCPServer {
   private initialize(params: JSONRPCParams | undefined): Promise<Record<string, unknown>> {
     const p = toParamsRecord(params);
     const requested = typeof p.protocolVersion === "string" ? p.protocolVersion : undefined;
-    const negotiated = requested && MCPServer.SUPPORTED_VERSIONS.includes(requested)
+    const negotiated = requested && MCP_SUPPORTED_VERSIONS.includes(requested)
       ? requested
-      : MCPServer.SUPPORTED_VERSIONS[0];
+      : MCP_SUPPORTED_VERSIONS[0];
 
     return Promise.resolve({
       protocolVersion: negotiated,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -82,6 +82,8 @@ export interface IntegrationLoaderConfig {
 }
 
 export class MCPServer {
+  private static SUPPORTED_VERSIONS = ["2025-11-25", "2024-11-05"];
+
   private config: MCPServerConfig;
   private integrationLoader?: IntegrationLoaderConfig;
   private integrationsLoaded = false;
@@ -158,15 +160,27 @@ export class MCPServer {
     }
   }
 
-  private initialize(_params: JSONRPCParams | undefined): Promise<Record<string, unknown>> {
+  private initialize(params: JSONRPCParams | undefined): Promise<Record<string, unknown>> {
+    const p = toParamsRecord(params);
+    const requested = typeof p.protocolVersion === "string" ? p.protocolVersion : undefined;
+    const negotiated = requested && MCPServer.SUPPORTED_VERSIONS.includes(requested)
+      ? requested
+      : MCPServer.SUPPORTED_VERSIONS[0];
+
     return Promise.resolve({
-      protocolVersion: "2024-11-05",
-      serverInfo: { name: "veryfront-mcp", version: VERSION },
-      capabilities: {
-        tools: {},
-        resources: { subscribe: true },
-        prompts: {},
+      protocolVersion: negotiated,
+      serverInfo: {
+        name: "veryfront-mcp",
+        title: "Veryfront MCP Server",
+        version: VERSION,
+        description: "Veryfront development server tools for real-time errors, route preview, HMR control, and scaffolding",
       },
+      capabilities: {
+        tools: { listChanged: true },
+        resources: { subscribe: true, listChanged: true },
+        prompts: { listChanged: true },
+      },
+      instructions: "Veryfront MCP server provides development tools. Use vf_get_errors to check for code errors, vf_get_logs for server logs, vf_scaffold for code generation, and vf_get_project_context for project structure.",
     });
   }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -175,14 +175,16 @@ export class MCPServer {
         name: "veryfront-mcp",
         title: "Veryfront MCP Server",
         version: VERSION,
-        description: "Veryfront development server tools for real-time errors, route preview, HMR control, and scaffolding",
+        description:
+          "Veryfront development server tools for real-time errors, route preview, HMR control, and scaffolding",
       },
       capabilities: {
         tools: { listChanged: true },
         resources: { subscribe: true, listChanged: true },
         prompts: { listChanged: true },
       },
-      instructions: "Veryfront MCP server provides development tools. Use vf_get_errors to check for code errors, vf_get_logs for server logs, vf_scaffold for code generation, and vf_get_project_context for project structure.",
+      instructions:
+        "Veryfront MCP server provides development tools. Use vf_get_errors to check for code errors, vf_get_logs for server logs, vf_scaffold for code generation, and vf_get_project_context for project structure.",
     });
   }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -150,6 +150,8 @@ export class MCPServer {
         return this.getPrompt(params);
       case "initialize":
         return this.initialize(params);
+      case "notifications/initialized":
+        return Promise.resolve({});
       default:
         throw toError(
           createError({


### PR DESCRIPTION
## Summary

- Upgrade `initialize()` to negotiate protocol version (supports `2025-11-25` and `2024-11-05`)
- Handle `notifications/initialized` notification per JSON-RPC 2.0 spec
- Validate `Origin` header for DNS rebinding protection (returns 403 for disallowed origins)
- Add `serverInfo.title`, `serverInfo.description`, and `instructions` fields to initialize response
- Declare `listChanged: true` for tools, resources, and prompts capabilities
- Extract shared negotiation logic (`negotiateVersion`, `buildInitializeResult`, `toParamsRecord`, `MCP_SUPPORTED_VERSIONS`) into `cli/mcp/jsonrpc.ts` to eliminate duplication across CLI servers
- Add Origin rejection (403) to CLI dev server HTTP handler for parity with core server
- Replace non-null assertions with `??` fallbacks in `MCPDevServer`

Closes #832

## Test plan

- [x] `initialize` with `2025-11-25` echoes it back
- [x] `initialize` with `2024-11-05` echoes it back
- [x] `initialize` with unknown version responds with `2025-11-25`
- [x] `initialize` with no version responds with `2025-11-25`
- [x] `initialize` with non-string version falls back to `2025-11-25`
- [x] `serverInfo` includes `title` and `description`
- [x] `instructions` field is present
- [x] `listChanged: true` in all capability sections
- [x] `notifications/initialized` with `id` returns without error
- [x] `notifications/initialized` without `id` (proper notification) returns without error
- [x] Invalid Origin returns 403 (core server)
- [x] Invalid Origin returns 403 (CLI dev server)
- [x] Valid/allowed Origin returns 200
- [x] No Origin header returns 200
- [x] CLI dev server allows localhost and 127.0.0.1 origins
- [x] Shared `toParamsRecord` handles null, undefined, arrays, primitives
- [x] Shared `negotiateVersion` covers all edge cases
- [x] Shared `buildInitializeResult` produces correct structure
- [x] `MCP_SUPPORTED_VERSIONS` typed as non-empty tuple for strict indexing
- [x] All pre-push checks pass (format, lint, typecheck, 1289 unit tests)