### PR TITLE
feat(mcp): distinguish protocol errors from tool execution errors (isError)

### DIFF
--- a/cli/mcp/jsonrpc.ts
+++ b/cli/mcp/jsonrpc.ts
@@ -44,6 +44,18 @@ export const JSONRPC_ERRORS = {
 } as const;
 
 /**
+ * Error with a JSON-RPC error code attached.
+ * Preserves stack traces unlike throwing plain objects.
+ */
+export class JsonRpcError extends Error {
+  readonly code: number;
+  constructor(code: number, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+/**
  * Create a JSON-RPC parse error response
  */
 export function parseError(e: unknown): JSONRPCResponse {
@@ -70,15 +82,18 @@ export function successResponse(id: string | number | undefined, result: unknown
 export function errorResponse(
   id: string | number | undefined,
   e: unknown,
-  code = JSONRPC_ERRORS.INTERNAL_ERROR,
+  code?: number,
 ): JSONRPCResponse {
+  const resolvedCode = code ?? (e as { code?: number }).code ?? JSONRPC_ERRORS.INTERNAL_ERROR;
+  const message = e instanceof Error
+    ? e.message
+    : typeof e === "object" && e !== null && "message" in e
+      ? String((e as { message: unknown }).message)
+      : String(e);
   return {
     jsonrpc: "2.0",
     id,
-    error: {
-      code,
-      message: e instanceof Error ? e.message : String(e),
-    },
+    error: { code: resolvedCode, message },
   };
 }
 

--- a/cli/mcp/jsonrpc.ts
+++ b/cli/mcp/jsonrpc.ts
@@ -88,8 +88,8 @@ export function errorResponse(
   const message = e instanceof Error
     ? e.message
     : typeof e === "object" && e !== null && "message" in e
-      ? String((e as { message: unknown }).message)
-      : String(e);
+    ? String((e as { message: unknown }).message)
+    : String(e);
   return {
     jsonrpc: "2.0",
     id,

--- a/cli/mcp/jsonrpc.ts
+++ b/cli/mcp/jsonrpc.ts
@@ -84,7 +84,11 @@ export function errorResponse(
   e: unknown,
   code?: number,
 ): JSONRPCResponse {
-  const resolvedCode = code ?? (e as { code?: number }).code ?? JSONRPC_ERRORS.INTERNAL_ERROR;
+  const errorCode = typeof e === "object" && e !== null && "code" in e
+    ? (e as { code: unknown }).code
+    : undefined;
+  const resolvedCode = code ??
+    (typeof errorCode === "number" ? errorCode : JSONRPC_ERRORS.INTERNAL_ERROR);
   const message = e instanceof Error
     ? e.message
     : typeof e === "object" && e !== null && "message" in e

--- a/cli/mcp/server.ts
+++ b/cli/mcp/server.ts
@@ -19,6 +19,7 @@ import {
   buildInitializeResult,
   errorResponse,
   type JSONRPCRequest,
+  JSONRPC_ERRORS,
   JSONRPCRequestSchema,
   type JSONRPCResponse,
   parseError,
@@ -168,7 +169,17 @@ export class MCPDevServer {
           const result = await this.dispatchMethod(method, params);
           return successResponse(id, result);
         } catch (e) {
-          return errorResponse(id, e);
+          const code = (e as { code?: number }).code ?? JSONRPC_ERRORS.INTERNAL_ERROR;
+          const message = e instanceof Error
+            ? e.message
+            : typeof e === "object" && e !== null && "message" in e
+              ? String((e as { message: unknown }).message)
+              : String(e);
+          return {
+            jsonrpc: "2.0" as const,
+            id,
+            error: { code, message },
+          };
         }
       },
       { "mcp.method": method },
@@ -228,27 +239,33 @@ export class MCPDevServer {
   }
 
   private handleToolsCall(params: unknown): Promise<unknown> {
-    const { name, arguments: args } = ToolsCallParamsSchema.parse(params);
+    const { name: toolName, arguments: args } = ToolsCallParamsSchema.parse(params);
+
+    const tool = getTool(toolName);
+    if (!tool) {
+      throw { code: -32602, message: `Unknown tool: ${toolName}` };
+    }
 
     return withSpan(
       "cli.mcp.handleToolsCall",
       async () => {
-        const tool = getTool(name);
-        if (!tool) throw new Error(`Unknown tool: ${name}`);
+        try {
+          const input = tool.inputSchema.parse(args ?? {});
+          const result = await tool.execute(input);
 
-        const input = tool.inputSchema.parse(args ?? {});
-        const result = await tool.execute(input);
-
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            isError: false,
+          };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return {
+            content: [{ type: "text", text: message }],
+            isError: true,
+          };
+        }
       },
-      { "mcp.tool.name": name },
+      { "mcp.tool.name": toolName },
     );
   }
 

--- a/cli/mcp/server.ts
+++ b/cli/mcp/server.ts
@@ -236,11 +236,18 @@ export class MCPDevServer {
       throw new JsonRpcError(-32602, `Unknown tool: ${toolName}`);
     }
 
+    let input: unknown;
+    try {
+      input = tool.inputSchema.parse(args ?? {});
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new JsonRpcError(-32602, `Invalid arguments for tool ${toolName}: ${message}`);
+    }
+
     return withSpan(
       "cli.mcp.handleToolsCall",
       async () => {
         try {
-          const input = tool.inputSchema.parse(args ?? {});
           const result = await tool.execute(input);
 
           return {

--- a/cli/mcp/server.ts
+++ b/cli/mcp/server.ts
@@ -19,7 +19,7 @@ import {
   buildInitializeResult,
   errorResponse,
   type JSONRPCRequest,
-  JSONRPC_ERRORS,
+  JsonRpcError,
   JSONRPCRequestSchema,
   type JSONRPCResponse,
   parseError,
@@ -169,17 +169,7 @@ export class MCPDevServer {
           const result = await this.dispatchMethod(method, params);
           return successResponse(id, result);
         } catch (e) {
-          const code = (e as { code?: number }).code ?? JSONRPC_ERRORS.INTERNAL_ERROR;
-          const message = e instanceof Error
-            ? e.message
-            : typeof e === "object" && e !== null && "message" in e
-              ? String((e as { message: unknown }).message)
-              : String(e);
-          return {
-            jsonrpc: "2.0" as const,
-            id,
-            error: { code, message },
-          };
+          return errorResponse(id, e);
         }
       },
       { "mcp.method": method },
@@ -243,7 +233,7 @@ export class MCPDevServer {
 
     const tool = getTool(toolName);
     if (!tool) {
-      throw { code: -32602, message: `Unknown tool: ${toolName}` };
+      throw new JsonRpcError(-32602, `Unknown tool: ${toolName}`);
     }
 
     return withSpan(

--- a/cli/mcp/server.ts
+++ b/cli/mcp/server.ts
@@ -18,8 +18,8 @@ import { startStdioJsonRpc } from "./stdio.ts";
 import {
   buildInitializeResult,
   errorResponse,
-  type JSONRPCRequest,
   JsonRpcError,
+  type JSONRPCRequest,
   JSONRPCRequestSchema,
   type JSONRPCResponse,
   parseError,

--- a/cli/mcp/standalone.ts
+++ b/cli/mcp/standalone.ts
@@ -13,6 +13,7 @@ import { startStdioJsonRpc } from "./stdio.ts";
 import {
   buildInitializeResult,
   errorResponse,
+  JsonRpcError,
   type JSONRPCRequest,
   JSONRPCRequestSchema,
   type JSONRPCResponse,
@@ -116,13 +117,24 @@ export class StandaloneMCPServer {
   }
 
   private async handleToolsCall(params: unknown): Promise<unknown> {
-    const { name, arguments: args } = ToolsCallParamsSchema.parse(params);
+    const { name: toolName, arguments: args } = ToolsCallParamsSchema.parse(params);
 
-    const tool = this.tools.find((t) => t.name === name);
-    if (!tool) throw new Error(`Unknown tool: ${name}`);
+    const tool = this.tools.find((t) => t.name === toolName);
+    if (!tool) throw new JsonRpcError(-32602, `Unknown tool: ${toolName}`);
 
-    const result = await tool.execute(args ?? {});
-    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    try {
+      const result = await tool.execute(args ?? {});
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        isError: false,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        content: [{ type: "text", text: message }],
+        isError: true,
+      };
+    }
   }
 
   private handleResourcesList(): unknown {

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -664,6 +664,78 @@ describe("mcp/server", () => {
     assertEquals(tool.annotations, { readOnlyHint: true });
   });
 
+  describe("callTool error handling", () => {
+    it("returns isError false on successful tool execution", async () => {
+      const server = createMCPServer({ enabled: true });
+
+      registerTool(
+        "test:echo",
+        dynamicTool({
+          id: "test:echo",
+          description: "Echo tool",
+          inputSchema: z.object({}),
+          execute: async () => ({ hello: "world" }),
+        }),
+      );
+
+      const response = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "test:echo", arguments: {} },
+      });
+
+      assertEquals(response.error, undefined);
+      const result = response.result as { content: { type: string; text: string }[]; isError: boolean };
+      assertEquals(result.isError, false);
+      assertEquals(result.content[0].type, "text");
+      assertEquals(JSON.parse(result.content[0].text).hello, "world");
+    });
+
+    it("returns isError true when tool execution throws", async () => {
+      const server = createMCPServer({ enabled: true });
+
+      registerTool(
+        "test:fail",
+        dynamicTool({
+          id: "test:fail",
+          description: "Failing tool",
+          inputSchema: z.object({}),
+          execute: async () => {
+            throw new Error("tool broke");
+          },
+        }),
+      );
+
+      const response = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "test:fail", arguments: {} },
+      });
+
+      assertEquals(response.error, undefined);
+      const result = response.result as { content: { type: string; text: string }[]; isError: boolean };
+      assertEquals(result.isError, true);
+      assertEquals(result.content[0].text, "tool broke");
+    });
+
+    it("returns JSON-RPC error with code -32602 for unknown tool", async () => {
+      const server = createMCPServer({ enabled: true });
+
+      const response = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "nonexistent:tool", arguments: {} },
+      });
+
+      assertExists(response.error);
+      assertEquals(response.error.code, -32602);
+      assertStringIncludes(response.error.message, "Unknown tool");
+    });
+  });
+
   it("syncs integration config to API on first tools/list call", async () => {
     const server = createMCPServer({ enabled: true });
     server.setIntegrationLoader({

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -686,7 +686,10 @@ describe("mcp/server", () => {
       });
 
       assertEquals(response.error, undefined);
-      const result = response.result as { content: { type: string; text: string }[]; isError: boolean };
+      const result = response.result as {
+        content: { type: string; text: string }[];
+        isError: boolean;
+      };
       assertEquals(result.isError, false);
       assertEquals(result.content[0].type, "text");
       assertEquals(JSON.parse(result.content[0].text).hello, "world");
@@ -715,7 +718,10 @@ describe("mcp/server", () => {
       });
 
       assertEquals(response.error, undefined);
-      const result = response.result as { content: { type: string; text: string }[]; isError: boolean };
+      const result = response.result as {
+        content: { type: string; text: string }[];
+        isError: boolean;
+      };
       assertEquals(result.isError, true);
       assertEquals(result.content[0].text, "tool broke");
     });

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -740,6 +740,32 @@ describe("mcp/server", () => {
       assertEquals(response.error.code, -32602);
       assertStringIncludes(response.error.message, "Unknown tool");
     });
+
+    it("returns JSON-RPC error with code -32602 for invalid arguments", async () => {
+      const server = createMCPServer({ enabled: true });
+
+      registerTool(
+        "test:strict",
+        dynamicTool({
+          id: "test:strict",
+          description: "Tool with required arg",
+          inputSchema: z.object({ required_field: z.string() }),
+          execute: async (input) => input,
+        }),
+      );
+
+      const response = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 4,
+        method: "tools/call",
+        params: { name: "test:strict", arguments: { wrong_field: 123 } },
+      });
+
+      assertExists(response.error);
+      assertEquals(response.error.code, -32602);
+      assertStringIncludes(response.error.message, "Invalid arguments");
+      assertEquals(response.result, undefined);
+    });
   });
 
   it("syncs integration config to API on first tools/list call", async () => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -32,7 +32,11 @@ class JsonRpcError extends Error {
 }
 
 function errorCode(error: unknown): number {
-  return (error as { code?: number }).code ?? -32603;
+  if (typeof error === "object" && error !== null && "code" in error) {
+    const code = (error as { code: unknown }).code;
+    if (typeof code === "number") return code;
+  }
+  return -32603;
 }
 
 function errorMessage(error: unknown): string {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -116,13 +116,16 @@ export class MCPServer {
           const result = await this.dispatch(request.method, request.params, context);
           return { jsonrpc: "2.0", id: request.id, result };
         } catch (error) {
+          const code = (error as { code?: number }).code ?? -32603;
+          const message = error instanceof Error
+            ? error.message
+            : typeof error === "object" && error !== null && "message" in error
+              ? String((error as { message: unknown }).message)
+              : String(error);
           return {
             jsonrpc: "2.0",
             id: request.id,
-            error: {
-              code: -32603,
-              message: error instanceof Error ? error.message : String(error),
-            },
+            error: { code, message },
           };
         }
       },
@@ -224,29 +227,32 @@ export class MCPServer {
     const { name, arguments: args } = toParamsRecord(params);
 
     if (!name) {
-      throw toError(
-        createError({
-          type: "agent",
-          message: "Tool name is required",
-        }),
-      );
+      throw toError(createError({ type: "agent", message: "Tool name is required" }));
     }
 
     const toolName = String(name);
 
+    const registry = getMCPRegistry();
+    if (!registry.tools.has(toolName)) {
+      return Promise.reject({ code: -32602, message: `Unknown tool: ${toolName}` });
+    }
+
     return withSpan(
       "mcp.callTool",
       async () => {
-        const result = await executeTool(toolName, args, context);
-
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
+        try {
+          const result = await executeTool(toolName, args, context);
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            isError: false,
+          };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return {
+            content: [{ type: "text", text: message }],
+            isError: true,
+          };
+        }
       },
       { "mcp.tool.name": toolName },
     );

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -247,8 +247,18 @@ export class MCPServer {
     const toolName = String(name);
 
     const registry = getMCPRegistry();
-    if (!registry.tools.has(toolName)) {
+    const tool = registry.tools.get(toolName);
+    if (!tool) {
       throw new JsonRpcError(-32602, `Unknown tool: ${toolName}`);
+    }
+
+    if (tool.inputSchema && typeof tool.inputSchema.parse === "function") {
+      try {
+        tool.inputSchema.parse(args ?? {});
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new JsonRpcError(-32602, `Invalid arguments for tool ${toolName}: ${message}`);
+      }
     }
 
     return withSpan(

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -23,6 +23,26 @@ const PROJECT_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
 
 type JSONRPCParams = Record<string, unknown> | unknown[];
 
+class JsonRpcError extends Error {
+  readonly code: number;
+  constructor(code: number, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+function errorCode(error: unknown): number {
+  return (error as { code?: number }).code ?? -32603;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "object" && error !== null && "message" in error) {
+    return String((error as { message: unknown }).message);
+  }
+  return String(error);
+}
+
 function toParamsRecord(params: JSONRPCParams | undefined): Record<string, unknown> {
   if (!params || Array.isArray(params)) return {};
   return params;
@@ -116,16 +136,10 @@ export class MCPServer {
           const result = await this.dispatch(request.method, request.params, context);
           return { jsonrpc: "2.0", id: request.id, result };
         } catch (error) {
-          const code = (error as { code?: number }).code ?? -32603;
-          const message = error instanceof Error
-            ? error.message
-            : typeof error === "object" && error !== null && "message" in error
-              ? String((error as { message: unknown }).message)
-              : String(error);
           return {
             jsonrpc: "2.0",
             id: request.id,
-            error: { code, message },
+            error: { code: errorCode(error), message: errorMessage(error) },
           };
         }
       },
@@ -234,7 +248,7 @@ export class MCPServer {
 
     const registry = getMCPRegistry();
     if (!registry.tools.has(toolName)) {
-      return Promise.reject({ code: -32602, message: `Unknown tool: ${toolName}` });
+      throw new JsonRpcError(-32602, `Unknown tool: ${toolName}`);
     }
 
     return withSpan(


### PR DESCRIPTION
## Summary

- Successful `tools/call` now returns `isError: false` alongside `content`
- Tool execution errors return `{ content, isError: true }` instead of JSON-RPC errors
- Unknown tool returns JSON-RPC error with code `-32602` (protocol error)
- Invalid tool arguments return JSON-RPC error with code `-32602` (Zod validation runs before execution)
- Agents can now distinguish recoverable tool errors from protocol failures
- Same pattern applied to all three MCP servers (src, CLI dev, CLI standalone)
- Added `JsonRpcError` class for proper stack traces instead of throwing plain objects
- Deduplicated error message/code extraction into shared helpers
- Error code/message extraction guards against nullish throws

Closes #834

## Changes

### `cli/mcp/jsonrpc.ts`
- Added `JsonRpcError extends Error` with a `code` field for typed protocol errors
- Updated `errorResponse()` to auto-extract `.code` from thrown values with null-safety guards

### `cli/mcp/server.ts`
- Unknown tool throws `JsonRpcError(-32602)` instead of generic `Error`
- Input schema validation moved before execution try/catch — Zod failures are protocol errors, not tool errors
- Tool execution errors caught and returned as `{ content, isError: true }`
- Successful results include `isError: false`

### `cli/mcp/standalone.ts`
- Same error handling pattern applied to the standalone MCP server (`veryfront mcp`)

### `src/mcp/server.ts`
- Added module-private `JsonRpcError`, `errorCode()`, and `errorMessage()` helpers
- Unknown tool throws `JsonRpcError(-32602)` instead of `Promise.reject` with plain object
- Pre-validates tool input schema before calling `executeTool()`
- Tool execution errors return `{ content, isError: true }` instead of JSON-RPC errors

### `src/mcp/server.test.ts`
- Test: successful tool call returns `isError: false`
- Test: tool execution throw returns `isError: true` (not a JSON-RPC error)
- Test: unknown tool returns JSON-RPC error with code `-32602`
- Test: invalid arguments return JSON-RPC error with code `-32602`

## Test plan

- [x] Successful tool call returns `isError: false`
- [x] Tool execution throw returns `isError: true` (not a JSON-RPC error)
- [x] Unknown tool returns JSON-RPC error with code `-32602`
- [x] Invalid arguments return JSON-RPC error with code `-32602` (not `isError: true`)
- [x] CLI dev MCP server follows same pattern
- [x] CLI standalone MCP server follows same pattern
- [x] Nullish throw values handled safely in error extraction
- [x] Unit tests pass (1291 tests, 46 MCP server test steps)
- [x] Live `veryfront mcp` stdio test confirms correct responses