### PR TITLE
feat(mcp): accept cursor param on list endpoints for pagination

### DIFF
--- a/cli/mcp/server.test.ts
+++ b/cli/mcp/server.test.ts
@@ -272,6 +272,60 @@ describe("cli/mcp/server", { sanitizeOps: false, sanitizeResources: false }, () 
       }
     });
 
+    it("tools/list accepts cursor param without erroring", async () => {
+      const portNum = 19889;
+      server = new MCPDevServer({ httpPort: portNum });
+      server.start();
+      await waitForServerBind();
+
+      const response = await postMcp(portNum, {
+        jsonrpc: "2.0",
+        id: 11,
+        method: "tools/list",
+        params: { cursor: "abc123" },
+      });
+
+      const data = await response.json();
+      assertExists(data.result);
+      assertEquals(data.error, undefined);
+    });
+
+    it("resources/list accepts cursor param without erroring", async () => {
+      const portNum = 19890;
+      server = new MCPDevServer({ httpPort: portNum });
+      server.start();
+      await waitForServerBind();
+
+      const response = await postMcp(portNum, {
+        jsonrpc: "2.0",
+        id: 12,
+        method: "resources/list",
+        params: { cursor: "abc123" },
+      });
+
+      const data = await response.json();
+      assertExists(data.result);
+      assertEquals(data.error, undefined);
+    });
+
+    it("prompts/list accepts cursor param without erroring", async () => {
+      const portNum = 19891;
+      server = new MCPDevServer({ httpPort: portNum });
+      server.start();
+      await waitForServerBind();
+
+      const response = await postMcp(portNum, {
+        jsonrpc: "2.0",
+        id: 13,
+        method: "prompts/list",
+        params: { cursor: "abc123" },
+      });
+
+      const data = await response.json();
+      assertExists(data.result);
+      assertEquals(data.error, undefined);
+    });
+
     it("should return error for unknown method", async () => {
       const portNum = 19881;
       server = new MCPDevServer({ httpPort: portNum });

--- a/cli/mcp/server.ts
+++ b/cli/mcp/server.ts
@@ -183,15 +183,15 @@ export class MCPDevServer {
       case "notifications/initialized":
         return Promise.resolve({});
       case "tools/list":
-        return Promise.resolve(this.handleToolsList());
+        return Promise.resolve(this.handleToolsList(params));
       case "tools/call":
         return this.handleToolsCall(params);
       case "resources/list":
-        return Promise.resolve(this.handleResourcesList());
+        return Promise.resolve(this.handleResourcesList(params));
       case "resources/read":
         return this.handleResourcesRead(params);
       case "prompts/list":
-        return Promise.resolve(this.handlePromptsList());
+        return Promise.resolve(this.handlePromptsList(params));
       case "prompts/get":
         return this.handlePromptsGet(params);
       default:
@@ -213,7 +213,7 @@ export class MCPDevServer {
     );
   }
 
-  private handleToolsList(): { tools: ToolListEntry[] } {
+  private handleToolsList(_params?: unknown): { tools: ToolListEntry[] } {
     return {
       tools: allTools.map((tool) => {
         const entry: ToolListEntry = {
@@ -266,7 +266,7 @@ export class MCPDevServer {
     );
   }
 
-  private handleResourcesList(): unknown {
+  private handleResourcesList(_params?: unknown): unknown {
     return {
       resources: [
         {
@@ -454,7 +454,7 @@ export class MCPDevServer {
     );
   }
 
-  private handlePromptsList(): unknown {
+  private handlePromptsList(_params?: unknown): unknown {
     return {
       prompts: [
         {

--- a/cli/mcp/standalone.test.ts
+++ b/cli/mcp/standalone.test.ts
@@ -214,6 +214,27 @@ describe("mcp/standalone", () => {
       assertEquals(typeof info.version, "string");
     });
 
+    it("tools/list accepts cursor param without erroring", async () => {
+      const server = new StandaloneMCPServer();
+      const resp = await dispatch(server, "tools/list", { cursor: "abc123" });
+      assertExists(resp.result);
+      assertEquals(resp.error, undefined);
+    });
+
+    it("resources/list accepts cursor param without erroring", async () => {
+      const server = new StandaloneMCPServer();
+      const resp = await dispatch(server, "resources/list", { cursor: "abc123" });
+      assertExists(resp.result);
+      assertEquals(resp.error, undefined);
+    });
+
+    it("prompts/list accepts cursor param without erroring", async () => {
+      const server = new StandaloneMCPServer();
+      const resp = await dispatch(server, "prompts/list", { cursor: "abc123" });
+      assertExists(resp.result);
+      assertEquals(resp.error, undefined);
+    });
+
     it("unknown method returns error", async () => {
       const server = new StandaloneMCPServer();
       const resp = await dispatch(server, "nonexistent/method");

--- a/cli/mcp/standalone.ts
+++ b/cli/mcp/standalone.ts
@@ -94,21 +94,15 @@ export class StandaloneMCPServer {
       case "notifications/initialized":
         return Promise.resolve({});
       case "tools/list":
-        return Promise.resolve({
-          tools: this.tools.map(({ name, description, inputSchema }) => ({
-            name,
-            description,
-            inputSchema,
-          })),
-        });
+        return Promise.resolve(this.handleToolsList(params));
       case "tools/call":
         return this.handleToolsCall(params);
       case "resources/list":
-        return Promise.resolve(this.handleResourcesList());
+        return Promise.resolve(this.handleResourcesList(params));
       case "resources/read":
         return this.handleResourcesRead(params);
       case "prompts/list":
-        return Promise.resolve(this.handlePromptsList());
+        return Promise.resolve(this.handlePromptsList(params));
       case "prompts/get":
         return this.handlePromptsGet(params);
       default:
@@ -137,7 +131,17 @@ export class StandaloneMCPServer {
     }
   }
 
-  private handleResourcesList(): unknown {
+  private handleToolsList(_params?: unknown): unknown {
+    return {
+      tools: this.tools.map(({ name, description, inputSchema }) => ({
+        name,
+        description,
+        inputSchema,
+      })),
+    };
+  }
+
+  private handleResourcesList(_params?: unknown): unknown {
     return {
       resources: [
         {
@@ -207,7 +211,7 @@ export class StandaloneMCPServer {
     throw new Error(`Unknown resource: ${uri}`);
   }
 
-  private handlePromptsList(): unknown {
+  private handlePromptsList(_params?: unknown): unknown {
     return {
       prompts: [
         {

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -768,6 +768,71 @@ describe("mcp/server", () => {
     });
   });
 
+  describe("list endpoint pagination", () => {
+    it("tools/list accepts cursor param without erroring", async () => {
+      const server = createMCPServer({ enabled: true });
+      const response = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: { cursor: "abc123" },
+      });
+
+      assertEquals(response.error, undefined);
+      assertExists(response.result);
+    });
+
+    it("tools/list does not include nextCursor when all results fit", async () => {
+      const server = createMCPServer({ enabled: true });
+
+      registerTool(
+        "test:pagination",
+        dynamicTool({
+          id: "test:pagination",
+          description: "Pagination test tool",
+          inputSchema: z.object({}),
+          execute: async () => ({ ok: true }),
+        }),
+      );
+
+      const response = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+      });
+
+      assertEquals(response.error, undefined);
+      const result = response.result as { tools: unknown[]; nextCursor?: string };
+      assertEquals(result.nextCursor, undefined);
+    });
+
+    it("resources/list accepts cursor param without erroring", async () => {
+      const server = createMCPServer({ enabled: true });
+      const response = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "resources/list",
+        params: { cursor: "abc123" },
+      });
+
+      assertEquals(response.error, undefined);
+      assertExists(response.result);
+    });
+
+    it("prompts/list accepts cursor param without erroring", async () => {
+      const server = createMCPServer({ enabled: true });
+      const response = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "prompts/list",
+        params: { cursor: "abc123" },
+      });
+
+      assertEquals(response.error, undefined);
+      assertExists(response.result);
+    });
+  });
+
   it("syncs integration config to API on first tools/list call", async () => {
     const server = createMCPServer({ enabled: true });
     server.setIntegrationLoader({

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -158,15 +158,15 @@ export class MCPServer {
   ): Promise<unknown> {
     switch (method) {
       case "tools/list":
-        return this.listTools();
+        return this.listTools(params);
       case "tools/call":
         return this.callTool(params, context);
       case "resources/list":
-        return this.listResources();
+        return this.listResources(params);
       case "resources/read":
         return this.readResource(params);
       case "prompts/list":
-        return this.listPrompts();
+        return this.listPrompts(params);
       case "prompts/get":
         return this.getPrompt(params);
       case "initialize":
@@ -209,7 +209,7 @@ export class MCPServer {
     });
   }
 
-  private async listTools(): Promise<{ tools: ToolListEntry[] }> {
+  private async listTools(_params?: JSONRPCParams): Promise<{ tools: ToolListEntry[] }> {
     // Sync integration config to API on first tools/list call
     if (this.integrationLoader && !this.integrationsLoaded) {
       try {
@@ -286,7 +286,9 @@ export class MCPServer {
     );
   }
 
-  private listResources(): Promise<{ resources: Array<Record<string, unknown>> }> {
+  private listResources(
+    _params?: JSONRPCParams,
+  ): Promise<{ resources: Array<Record<string, unknown>> }> {
     const registry = getMCPRegistry();
     const resources: Array<Record<string, unknown>> = [];
 
@@ -347,7 +349,9 @@ export class MCPServer {
     );
   }
 
-  private listPrompts(): Promise<{ prompts: Array<Record<string, unknown>> }> {
+  private listPrompts(
+    _params?: JSONRPCParams,
+  ): Promise<{ prompts: Array<Record<string, unknown>> }> {
     const registry = getMCPRegistry();
     const prompts: Array<Record<string, unknown>> = [];
 


### PR DESCRIPTION
## Summary

- `tools/list`, `resources/list`, and `prompts/list` now accept optional `cursor` param without erroring
- List methods pass through params from dispatch (previously ignored)
- All results returned in single page (no splitting for our small dataset)
- Spec-compliant: `nextCursor` omitted when all results fit
- Same pattern applied to all three MCP servers (src, CLI dev, CLI standalone)

Closes #836

## Changes

### `src/mcp/server.ts`
- `dispatch` passes `params` to `listTools`, `listResources`, `listPrompts`
- All three methods accept `_params?: JSONRPCParams`

### `cli/mcp/server.ts`
- `dispatchMethod` passes `params` to `handleToolsList`, `handleResourcesList`, `handlePromptsList`
- All three methods accept `_params?: unknown`

### `cli/mcp/standalone.ts`
- Extracted inline `tools/list` logic into `handleToolsList(_params?)` method
- `dispatchMethod` passes `params` to all three list handlers
- `handleResourcesList` and `handlePromptsList` accept `_params?: unknown`

### Tests
- `src/mcp/server.test.ts` — 4 tests: cursor accepted on all list endpoints, `nextCursor` absent
- `cli/mcp/server.test.ts` — 3 tests: cursor accepted on all list endpoints (HTTP transport)
- `cli/mcp/standalone.test.ts` — 3 tests: cursor accepted on all list endpoints (dispatch helper)

## Test plan

- [x] `tools/list` with cursor param returns without error
- [x] `tools/list` without cursor returns all results, no `nextCursor`
- [x] `resources/list` with cursor param returns without error
- [x] `prompts/list` with cursor param returns without error
- [x] CLI dev MCP server accepts cursor on all list endpoints
- [x] CLI standalone MCP server accepts cursor on all list endpoints
- [x] Unit tests pass (1291 tests)
- [x] Live `veryfront mcp` stdio test confirms correct responses