### PR TITLE
feat(mcp): add resources/templates/list method and resource titles

### DIFF
--- a/cli/mcp/server.ts
+++ b/cli/mcp/server.ts
@@ -188,6 +188,8 @@ export class MCPDevServer {
         return this.handleToolsCall(params);
       case "resources/list":
         return Promise.resolve(this.handleResourcesList(params));
+      case "resources/templates/list":
+        return Promise.resolve(this.handleResourceTemplatesList());
       case "resources/read":
         return this.handleResourcesRead(params);
       case "prompts/list":
@@ -264,6 +266,10 @@ export class MCPDevServer {
       },
       { "mcp.tool.name": toolName },
     );
+  }
+
+  private handleResourceTemplatesList(): { resourceTemplates: Array<Record<string, unknown>> } {
+    return { resourceTemplates: [] };
   }
 
   private handleResourcesList(_params?: unknown): unknown {

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -387,6 +387,7 @@ describe("mcp/server", () => {
     });
   });
 
+<<<<<<< HEAD
   describe("initialize version negotiation", () => {
     it("echoes 2025-11-25 when client requests it", async () => {
       const server = createMCPServer({ enabled: true });
@@ -831,6 +832,20 @@ describe("mcp/server", () => {
       assertEquals(response.error, undefined);
       assertExists(response.result);
     });
+
+  it("resources/templates/list returns array without error", async () => {
+    const server = createMCPServer({ enabled: true });
+    const response = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "resources/templates/list",
+    });
+
+    assertEquals(response.jsonrpc, "2.0");
+    assertEquals(response.id, 1);
+    assertEquals(response.error, undefined);
+    const result = response.result as { resourceTemplates: unknown[] };
+    assertEquals(Array.isArray(result.resourceTemplates), true);
   });
 
   it("syncs integration config to API on first tools/list call", async () => {

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -2,7 +2,7 @@ import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/tes
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { dynamicTool } from "#veryfront/tool";
 import { z } from "zod";
-import { clearMCPRegistry, registerTool } from "./registry.ts";
+import { clearMCPRegistry, registerResource, registerTool } from "./registry.ts";
 import { createMCPServer } from "./server.ts";
 import type { ToolListEntry } from "./types.ts";
 
@@ -387,7 +387,6 @@ describe("mcp/server", () => {
     });
   });
 
-<<<<<<< HEAD
   describe("initialize version negotiation", () => {
     it("echoes 2025-11-25 when client requests it", async () => {
       const server = createMCPServer({ enabled: true });
@@ -832,20 +831,97 @@ describe("mcp/server", () => {
       assertEquals(response.error, undefined);
       assertExists(response.result);
     });
+  });
 
-  it("resources/templates/list returns array without error", async () => {
-    const server = createMCPServer({ enabled: true });
-    const response = await server.handleRequest({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "resources/templates/list",
+  describe("resources/templates/list", () => {
+    it("returns array without error", async () => {
+      const server = createMCPServer({ enabled: true });
+      const response = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "resources/templates/list",
+      });
+
+      assertEquals(response.jsonrpc, "2.0");
+      assertEquals(response.id, 1);
+      assertEquals(response.error, undefined);
+      const result = response.result as { resourceTemplates: unknown[] };
+      assertEquals(Array.isArray(result.resourceTemplates), true);
     });
 
-    assertEquals(response.jsonrpc, "2.0");
-    assertEquals(response.id, 1);
-    assertEquals(response.error, undefined);
-    const result = response.result as { resourceTemplates: unknown[] };
-    assertEquals(Array.isArray(result.resourceTemplates), true);
+    it("includes parameterized resources as templates", async () => {
+      const server = createMCPServer({ enabled: true });
+      registerResource("test:users", {
+        id: "test:users",
+        pattern: "/users/:id",
+        description: "Get user by id",
+        paramsSchema: z.object({ id: z.string() }),
+        load: async () => ({}),
+      });
+
+      const response = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "resources/templates/list",
+      });
+
+      const result = response.result as {
+        resourceTemplates: Array<Record<string, unknown>>;
+      };
+      const tmpl = result.resourceTemplates.find((t) => t.name === "test:users");
+      assertExists(tmpl);
+      assertEquals(tmpl.uriTemplate, "/users/{id}");
+      assertEquals(tmpl.description, "Get user by id");
+    });
+
+    it("excludes scheme-only colons like openapi://spec", async () => {
+      const server = createMCPServer({ enabled: true });
+      registerResource("test:openapi", {
+        id: "test:openapi",
+        pattern: "openapi://spec",
+        description: "OpenAPI spec",
+        paramsSchema: z.object({}),
+        load: async () => ({}),
+      });
+
+      const response = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "resources/templates/list",
+      });
+
+      const result = response.result as {
+        resourceTemplates: Array<Record<string, unknown>>;
+      };
+      const tmpl = result.resourceTemplates.find((t) => t.name === "test:openapi");
+      assertEquals(tmpl, undefined);
+    });
+
+    it("includes title when set on resource", async () => {
+      const server = createMCPServer({ enabled: true });
+      registerResource("test:posts", {
+        id: "test:posts",
+        pattern: "/posts/:slug",
+        description: "Get post",
+        title: "Blog Post",
+        paramsSchema: z.object({ slug: z.string() }),
+        load: async () => ({}),
+      });
+
+      const response = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "resources/templates/list",
+      });
+
+      const result = response.result as {
+        resourceTemplates: Array<Record<string, unknown>>;
+      };
+      const tmpl = result.resourceTemplates.find((t) => t.name === "test:posts");
+      assertExists(tmpl);
+      assertEquals(tmpl.title, "Blog Post");
+      assertEquals(tmpl.uriTemplate, "/posts/{slug}");
+    });
   });
 
   it("syncs integration config to API on first tools/list call", async () => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -297,12 +297,14 @@ export class MCPServer {
     for (const [id, resource] of registry.resources.entries()) {
       if (/:(\w+)/.test(resource.pattern)) {
         const uriTemplate = resource.pattern.replace(/:(\w+)/g, "{$1}");
-        templates.push({
+        const entry: Record<string, unknown> = {
           uriTemplate,
           name: id,
           description: resource.description,
           mimeType: "application/json",
-        });
+        };
+        if (resource.title) entry.title = resource.title;
+        templates.push(entry);
       }
     }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -316,12 +316,14 @@ export class MCPServer {
     const resources: Array<Record<string, unknown>> = [];
 
     for (const [id, resource] of registry.resources.entries()) {
-      resources.push({
+      const entry: Record<string, unknown> = {
         uri: resource.pattern,
         name: id,
         description: resource.description,
         mimeType: "application/json",
-      });
+      };
+      if (resource.title) entry.title = resource.title;
+      resources.push(entry);
     }
 
     return Promise.resolve({ resources });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -165,6 +165,8 @@ export class MCPServer {
         return this.listResources(params);
       case "resources/read":
         return this.readResource(params);
+      case "resources/templates/list":
+        return this.listResourceTemplates(params);
       case "prompts/list":
         return this.listPrompts(params);
       case "prompts/get":
@@ -284,6 +286,27 @@ export class MCPServer {
       },
       { "mcp.tool.name": toolName },
     );
+  }
+
+  private listResourceTemplates(
+    _params?: JSONRPCParams,
+  ): Promise<{ resourceTemplates: Array<Record<string, unknown>> }> {
+    const registry = getMCPRegistry();
+    const templates: Array<Record<string, unknown>> = [];
+
+    for (const [id, resource] of registry.resources.entries()) {
+      if (/:(\w+)/.test(resource.pattern)) {
+        const uriTemplate = resource.pattern.replace(/:(\w+)/g, "{$1}");
+        templates.push({
+          uriTemplate,
+          name: id,
+          description: resource.description,
+          mimeType: "application/json",
+        });
+      }
+    }
+
+    return Promise.resolve({ resourceTemplates: templates });
   }
 
   private listResources(

--- a/src/resource/factory.ts
+++ b/src/resource/factory.ts
@@ -19,6 +19,7 @@ export function resource<TParams = unknown, TData = unknown>(
     id,
     pattern,
     description: config.description,
+    title: config.title,
     paramsSchema: config.paramsSchema,
     load: async (params: TParams): Promise<TData> => {
       try {

--- a/src/resource/types.ts
+++ b/src/resource/types.ts
@@ -17,6 +17,7 @@ import type { McpConfig } from "./schemas/index.ts";
 export interface ResourceConfig<TParams = unknown, TData = unknown> {
   pattern?: string;
   description: string;
+  title?: string;
   paramsSchema: z.ZodSchema<TParams>;
   load: (params: TParams) => Promise<TData> | TData;
   subscribe?: (params: TParams) => AsyncIterable<TData>;
@@ -27,6 +28,7 @@ export interface Resource<TParams = unknown, TData = unknown> {
   id: string;
   pattern: string;
   description: string;
+  title?: string;
   paramsSchema: z.ZodSchema<TParams>;
   load: (params: TParams) => Promise<TData>;
   subscribe?: (params: TParams) => AsyncIterable<TData>;


### PR DESCRIPTION
## Summary

- Add `resources/templates/list` method to framework MCP server — discovers parameterized resources as RFC 6570 URI templates
- Add optional `title` field to `ResourceConfig` and `Resource` types
- `resources/list` now includes `title` when set
- CLI MCP server returns empty templates list (uses static URIs)
- Fix template detection: use `/:(\w+)/.test()` instead of `includes(":")` to avoid false-positives on scheme URIs like `openapi://spec`
- Include `title` in template entries when set on the resource

Closes #837

## Test plan

- [x] `resources/templates/list` returns array without error
- [x] Parameterized resources (with `:param`) appear as templates with `{param}` syntax
- [x] Scheme-only URIs like `openapi://spec` are excluded from templates
- [x] `resources/list` includes `title` when resource has one
- [x] Template entries include `title` when set on resource
- [x] `ResourceConfig` and `Resource` types support optional `title`
- [x] CLI MCP server handles `resources/templates/list` without error
- [x] Typecheck, format, lint pass
- [x] All pre-push checks pass (1291 unit tests, 0 failures)