### PR TITLE
Preserve CSP nonces in streamed HTML responses

### DIFF
--- a/src/react/components/ai/csp-nonce.test.tsx
+++ b/src/react/components/ai/csp-nonce.test.tsx
@@ -7,11 +7,18 @@ import { describe, it } from "#veryfront/testing/bdd";
 import { Head } from "../Head.tsx";
 import { ChatStyleProvider } from "./chat-style-provider.tsx";
 import { ChatRoot } from "./chat/composition/chat-root.tsx";
+import { ColorModeScript } from "./color-mode.tsx";
 
 const TEST_NONCE = "nonce-123";
 
 function injectNonceIntoStyleTags(html: string, nonce: string): string {
   return html.replaceAll("<style", `<style nonce="${nonce}"`);
+}
+
+function injectNonceIntoInlineTags(html: string, nonce: string): string {
+  return html
+    .replaceAll("<style", `<style nonce="${nonce}"`)
+    .replaceAll("<script", `<script nonce="${nonce}"`);
 }
 
 function installDomGlobals(dom: JSDOM): () => void {
@@ -89,6 +96,30 @@ async function hydrateAndReadStyleNonce(element: React.ReactElement): Promise<st
 
     hydratedRoot.unmount();
     return style.getAttribute("nonce");
+  } finally {
+    restore();
+  }
+}
+
+async function hydrateAndReadScriptNonce(element: React.ReactElement): Promise<string | null> {
+  const serverMarkup = injectNonceIntoInlineTags(renderToString(element), TEST_NONCE);
+  const dom = new JSDOM(`<!doctype html><div id="root">${serverMarkup}</div>`, {
+    url: "https://example.com/",
+  });
+  const restore = installDomGlobals(dom);
+
+  try {
+    const root = document.getElementById("root");
+    assert(root, "Expected hydration root to exist");
+
+    const hydratedRoot = hydrateRoot(root, element);
+    await waitFor(() => document.querySelector('[data-hydrated="yes"]') !== null);
+
+    const script = root.querySelector("script");
+    assert(script, "Expected hydrated tree to contain an inline script tag");
+
+    hydratedRoot.unmount();
+    return script.getAttribute("nonce");
   } finally {
     restore();
   }
@@ -181,6 +212,20 @@ function HydratingHeadStyleFixture(): React.ReactElement {
   );
 }
 
+function HydratingColorModeScriptFixture(): React.ReactElement {
+  const [hydrated, setHydrated] = React.useState(false);
+
+  React.useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  return (
+    <div data-hydrated={hydrated ? "yes" : "no"}>
+      <ColorModeScript />
+    </div>
+  );
+}
+
 describe("getDocumentNonce hydration behavior", () => {
   it("preserves nonces on ChatStyleProvider style tags after hydration re-renders", async () => {
     const nonce = await hydrateAndReadStyleNonce(<HydratingChatStyleProviderFixture />);
@@ -194,6 +239,11 @@ describe("getDocumentNonce hydration behavior", () => {
 
   it("reuses the document nonce for Head-managed inline styles on the client", async () => {
     const nonce = await hydrateAndReadManagedHeadStyleNonce(<HydratingHeadStyleFixture />);
+    assertEquals(nonce, TEST_NONCE);
+  });
+
+  it("preserves nonces on ColorModeScript after hydration re-renders", async () => {
+    const nonce = await hydrateAndReadScriptNonce(<HydratingColorModeScriptFixture />);
     assertEquals(nonce, TEST_NONCE);
   });
 });

--- a/src/server/handlers/request/ssr/ssr-response-builder.test.ts
+++ b/src/server/handlers/request/ssr/ssr-response-builder.test.ts
@@ -190,5 +190,28 @@ describe("server/handlers/request/ssr/ssr-response-builder", () => {
       assertEquals(body.includes('<style nonce="nonce-123">'), true);
       assertEquals(body.includes('<script nonce="nonce-123">'), true);
     });
+
+    it("adds the builder nonce to inline tags in streaming HTML responses", async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              `<div><style>.app{color:red}</style><script>window.__vf=1</script></div>`,
+            ),
+          );
+          controller.close();
+        },
+      });
+      const req = new Request("http://localhost/");
+      const ctx = makeCtx();
+      const result = makeResult({ isStreaming: true, stream, html: undefined });
+      const builder = new ResponseBuilder({ nonce: "nonce-123" });
+
+      const response = await buildSSRResponse(req, ctx, result, builder);
+      const body = await response.text();
+
+      assertEquals(body.includes('<style nonce="nonce-123">.app{color:red}</style>'), true);
+      assertEquals(body.includes('<script nonce="nonce-123">window.__vf=1</script>'), true);
+    });
   });
 });

--- a/src/server/handlers/request/ssr/ssr-response-builder.ts
+++ b/src/server/handlers/request/ssr/ssr-response-builder.ts
@@ -14,6 +14,7 @@ import type { SSRRenderResult } from "../../../services/rendering/ssr.service.ts
 import { ErrorPages } from "../../../utils/error-html.ts";
 import type { ResponseBuilder } from "#veryfront/security/http/response/builder.ts";
 import { escapeHtml } from "#veryfront/html/html-escape.ts";
+import { streamToString } from "../../../../rendering/utils/stream-utils.ts";
 
 function addNonceToInlineTags(html: string, nonce: string): string {
   const escapedNonce = escapeHtml(nonce);
@@ -40,6 +41,20 @@ export async function buildSSRResponse(
 
   // Streaming response path
   if (result.isStreaming && result.stream) {
+    if (!isHeadRequest) {
+      const streamedHtml = addNonceToInlineTags(
+        await streamToString(result.stream),
+        builder.nonce,
+      );
+
+      return builder
+        .withCORS(req, ctx.securityConfig?.cors)
+        .withSecurity(ctx.securityConfig ?? undefined, req)
+        .withClientHints()
+        .withCache("no-cache")
+        .withContentType(getContentType(".html"), streamedHtml, result.status);
+    }
+
     const response = builder
       .withCORS(req, ctx.securityConfig?.cors)
       .withSecurity(ctx.securityConfig ?? undefined, req)


### PR DESCRIPTION
## Summary
- add a regression test proving streamed SSR HTML was not receiving builder nonce injection
- normalize streamed HTML through the same inline script/style nonce injection used by buffered SSR responses
- keep CSP nonce hydration coverage explicit for inline React script usage

## Verification
- deno test --allow-read --allow-env src/server/handlers/request/ssr/ssr-response-builder.test.ts
- deno test --allow-read src/react/components/ai/csp-nonce.test.tsx

## Notes
- this addresses the backend root cause linked from veryfront-studio#1207
- local pre-push full suite hit an unrelated existing CLI animation test failure