### PR TITLE
Preserve streaming when injecting CSP nonces

### DIFF
--- a/cli/shared/animation.test.ts
+++ b/cli/shared/animation.test.ts
@@ -3,11 +3,23 @@ import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { isAnimationDisabled, setAnimationDisabled } from "./animation.ts";
 
 describe("animation", () => {
+  let originalTerm: string | undefined;
+
+  beforeEach(() => {
+    originalTerm = Deno.env.get("TERM");
+  });
+
   afterEach(() => {
+    if (originalTerm !== undefined) {
+      Deno.env.set("TERM", originalTerm);
+    } else {
+      Deno.env.delete("TERM");
+    }
     setAnimationDisabled(false);
   });
 
   it("defaults to false", () => {
+    Deno.env.set("TERM", "xterm-256color");
     assertEquals(isAnimationDisabled(), false);
   });
 
@@ -17,27 +29,13 @@ describe("animation", () => {
   });
 
   it("can toggle back to false", () => {
+    Deno.env.set("TERM", "xterm-256color");
     setAnimationDisabled(true);
     setAnimationDisabled(false);
     assertEquals(isAnimationDisabled(), false);
   });
 
   describe("TERM=dumb detection", () => {
-    let originalTerm: string | undefined;
-
-    beforeEach(() => {
-      originalTerm = Deno.env.get("TERM");
-    });
-
-    afterEach(() => {
-      if (originalTerm !== undefined) {
-        Deno.env.set("TERM", originalTerm);
-      } else {
-        Deno.env.delete("TERM");
-      }
-      setAnimationDisabled(false);
-    });
-
     it("returns true when TERM=dumb", () => {
       Deno.env.set("TERM", "dumb");
       assertEquals(isAnimationDisabled(), true);

--- a/src/html/nonce-injection.ts
+++ b/src/html/nonce-injection.ts
@@ -127,3 +127,114 @@ export function addNonceToHtmlTags(html: string, nonce?: string): string {
 
   return result;
 }
+
+export function addNonceToHtmlStream(
+  stream: ReadableStream<Uint8Array>,
+  nonce?: string,
+): ReadableStream<Uint8Array> {
+  if (!nonce) return stream;
+
+  const escapedNonce = escapeHtml(nonce);
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let buffer = "";
+  let rawTextTag: "script" | "style" | null = null;
+
+  function transformBuffer(flush: boolean): string {
+    let result = "";
+    let index = 0;
+
+    while (index < buffer.length) {
+      const lowerBuffer = buffer.toLowerCase();
+
+      if (rawTextTag) {
+        const closingIndex = findRawTextClosingTagStart(lowerBuffer, rawTextTag, index);
+        if (closingIndex === -1) {
+          if (flush) {
+            result += buffer.slice(index);
+            index = buffer.length;
+            break;
+          }
+
+          const retainLength = `</${rawTextTag}`.length;
+          const safeEnd = Math.max(index, buffer.length - retainLength);
+          result += buffer.slice(index, safeEnd);
+          index = safeEnd;
+          break;
+        }
+
+        result += buffer.slice(index, closingIndex);
+        index = closingIndex;
+        rawTextTag = null;
+        continue;
+      }
+
+      if (buffer.startsWith("<!--", index)) {
+        const commentEnd = buffer.indexOf("-->", index + 4);
+        if (commentEnd === -1) {
+          if (flush) {
+            result += buffer.slice(index);
+            index = buffer.length;
+          }
+          break;
+        }
+
+        const endIndex = commentEnd + 3;
+        result += buffer.slice(index, endIndex);
+        index = endIndex;
+        continue;
+      }
+
+      if (buffer[index] !== "<") {
+        const nextTagIndex = buffer.indexOf("<", index);
+        const endIndex = nextTagIndex === -1 ? buffer.length : nextTagIndex;
+        result += buffer.slice(index, endIndex);
+        index = endIndex;
+        continue;
+      }
+
+      const tagEnd = findTagEnd(buffer, index);
+      if (tagEnd === -1) {
+        if (flush) {
+          result += buffer.slice(index);
+          index = buffer.length;
+        }
+        break;
+      }
+
+      const tag = buffer.slice(index, tagEnd + 1);
+      const tagName = getOpeningTagName(tag);
+
+      if (!tagName) {
+        result += tag;
+        index = tagEnd + 1;
+        continue;
+      }
+
+      result += injectNonceIntoOpeningTag(tag, escapedNonce);
+      index = tagEnd + 1;
+
+      if (!/\/\s*>$/u.test(tag)) {
+        rawTextTag = tagName;
+      }
+    }
+
+    buffer = buffer.slice(index);
+    return result;
+  }
+
+  return stream.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        buffer += decoder.decode(chunk, { stream: true });
+        const transformed = transformBuffer(false);
+        if (transformed) controller.enqueue(encoder.encode(transformed));
+      },
+      flush(controller) {
+        buffer += decoder.decode();
+        const transformed = transformBuffer(true);
+        if (transformed) controller.enqueue(encoder.encode(transformed));
+      },
+    }),
+  );
+}

--- a/src/server/handlers/request/ssr/ssr-response-builder.test.ts
+++ b/src/server/handlers/request/ssr/ssr-response-builder.test.ts
@@ -138,6 +138,52 @@ describe("server/handlers/request/ssr/ssr-response-builder", () => {
       assertEquals(body, "<p>Streamed</p>");
     });
 
+    it("preserves streaming while adding nonces to inline tags", async () => {
+      let releaseSecondChunk: (() => void) | undefined;
+      const secondChunkReady = new Promise<void>((resolve) => {
+        releaseSecondChunk = resolve;
+      });
+
+      const stream = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          controller.enqueue(new TextEncoder().encode("<script>"));
+          await secondChunkReady;
+          controller.enqueue(new TextEncoder().encode("window.__vf = true;</script>"));
+          controller.close();
+        },
+      });
+      const req = new Request("http://localhost/");
+      const ctx = makeCtx();
+      const result = makeResult({ isStreaming: true, stream, html: undefined });
+      const builder = new ResponseBuilder({ nonce: "nonce-123" });
+
+      const response = await buildSSRResponse(req, ctx, result, builder);
+      const reader = response.body?.getReader();
+
+      if (!reader) throw new Error("Expected streaming response body");
+
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const firstChunk = await Promise.race([
+        reader.read(),
+        new Promise<never>((_, reject) =>
+          timeoutId = setTimeout(
+            () => reject(new Error("First streamed chunk did not arrive promptly")),
+            50,
+          )
+        ),
+      ]);
+      if (timeoutId) clearTimeout(timeoutId);
+
+      assertEquals(new TextDecoder().decode(firstChunk.value), '<script nonce="nonce-123">');
+
+      releaseSecondChunk?.();
+      const secondChunk = await reader.read();
+      const finalChunk = await reader.read();
+
+      assertEquals(new TextDecoder().decode(secondChunk.value), "window.__vf = true;</script>");
+      assertEquals(finalChunk.done, true);
+    });
+
     it("returns null body for HEAD request with streaming", async () => {
       const stream = new ReadableStream<Uint8Array>({
         start(controller) {

--- a/src/server/handlers/request/ssr/ssr-response-builder.ts
+++ b/src/server/handlers/request/ssr/ssr-response-builder.ts
@@ -13,16 +13,7 @@ import { getContentType } from "../../utils/content-types.ts";
 import type { SSRRenderResult } from "../../../services/rendering/ssr.service.ts";
 import { ErrorPages } from "../../../utils/error-html.ts";
 import type { ResponseBuilder } from "#veryfront/security/http/response/builder.ts";
-import { escapeHtml } from "#veryfront/html/html-escape.ts";
-import { streamToString } from "../../../../rendering/utils/stream-utils.ts";
-
-function addNonceToInlineTags(html: string, nonce: string): string {
-  const escapedNonce = escapeHtml(nonce);
-  return html.replace(
-    /<(script|style)\b(?![^>]*\bnonce\s*=)([^>]*)>/giu,
-    `<$1$2 nonce="${escapedNonce}">`,
-  );
-}
+import { addNonceToHtmlStream, addNonceToHtmlTags } from "#veryfront/html/nonce-injection.ts";
 
 /**
  * Build an HTTP response from an SSR render result.
@@ -41,26 +32,16 @@ export async function buildSSRResponse(
 
   // Streaming response path
   if (result.isStreaming && result.stream) {
-    if (!isHeadRequest) {
-      const streamedHtml = addNonceToInlineTags(
-        await streamToString(result.stream),
-        builder.nonce,
-      );
-
-      return builder
-        .withCORS(req, ctx.securityConfig?.cors)
-        .withSecurity(ctx.securityConfig ?? undefined, req)
-        .withClientHints()
-        .withCache("no-cache")
-        .withContentType(getContentType(".html"), streamedHtml, result.status);
-    }
-
     const response = builder
       .withCORS(req, ctx.securityConfig?.cors)
       .withSecurity(ctx.securityConfig ?? undefined, req)
       .withClientHints()
       .withCache("no-cache")
-      .withContentType(getContentType(".html"), result.stream, result.status);
+      .withContentType(
+        getContentType(".html"),
+        addNonceToHtmlStream(result.stream, builder.nonce),
+        result.status,
+      );
 
     if (!isHeadRequest) return response;
 
@@ -83,7 +64,7 @@ export async function buildSSRResponse(
     : typeof result.stream === "string"
     ? result.stream
     : ErrorPages.serverError();
-  const html = addNonceToInlineTags(content, builder.nonce);
+  const html = addNonceToHtmlTags(content, builder.nonce);
   const body = isHeadRequest ? null : html;
 
   let response = builder


### PR DESCRIPTION
## Summary
- preserve SSR streaming while still injecting CSP nonces into inline script/style tags
- add a regression test proving the first streamed chunk arrives before the full HTML is buffered
- stabilize CLI animation tests across ambient TERM values so pre-push passes reliably

## Testing
- deno test --allow-all cli/shared/animation.test.ts
- deno test --allow-read --allow-env src/server/handlers/request/ssr/ssr-response-builder.test.ts
- deno test --allow-read src/react/components/ai/csp-nonce.test.tsx
- deno check src/server/handlers/request/ssr/ssr-response-builder.ts src/html/nonce-injection.ts
- full pre-push suite