### PR TITLE
Hoist lowercasing in streaming nonce injection

### DIFF
--- a/src/html/nonce-injection.ts
+++ b/src/html/nonce-injection.ts
@@ -143,10 +143,9 @@ export function addNonceToHtmlStream(
   function transformBuffer(flush: boolean): string {
     let result = "";
     let index = 0;
+    const lowerBuffer = buffer.toLowerCase();
 
     while (index < buffer.length) {
-      const lowerBuffer = buffer.toLowerCase();
-
       if (rawTextTag) {
         const closingIndex = findRawTextClosingTagStart(lowerBuffer, rawTextTag, index);
         if (closingIndex === -1) {


### PR DESCRIPTION
## Summary
- hoist `buffer.toLowerCase()` out of the inner loop in `addNonceToHtmlStream`
- keep the streaming-safe nonce injection behavior from #856
- leave the rest of the transform logic unchanged

## Testing
- deno test --allow-read --allow-env src/server/handlers/request/ssr/ssr-response-builder.test.ts
- full pre-push suite
