### PR TITLE
Preserve explicit tool ids during discovery

### DIFF
--- a/src/discovery/auto-discovery.integration.test.ts
+++ b/src/discovery/auto-discovery.integration.test.ts
@@ -100,6 +100,40 @@ describe(
       }
     });
 
+    it("preserves an explicit tool id instead of forcing the filename-derived id", async () => {
+      const tempDir = await Deno.makeTempDir({ prefix: "vf-discovery-explicit-tool-id-" });
+
+      try {
+        await Deno.mkdir(`${tempDir}/tools`, { recursive: true });
+        await Deno.writeTextFile(
+          `${tempDir}/tools/write-report.ts`,
+          [
+            'import { tool } from "veryfront/tool";',
+            'import { z } from "zod";',
+            "",
+            "export default tool({",
+            '  id: "write-report",',
+            '  description: "Write a markdown report",',
+            "  inputSchema: z.object({ markdown: z.string() }),",
+            "  execute: async ({ markdown }) => ({ ok: true, markdown }),",
+            "});",
+          ].join("\n"),
+        );
+
+        const result = await discoverAll({
+          baseDir: tempDir,
+          verbose: false,
+        });
+
+        assertEquals(result.tools.has("write-report"), true);
+        assertEquals(toolRegistry.has("write-report"), true);
+        assertEquals(result.tools.has("writeReport"), false);
+        assertEquals(toolRegistry.has("writeReport"), false);
+      } finally {
+        await Deno.remove(tempDir, { recursive: true });
+      }
+    });
+
     it("should keep concrete tool files over index barrel re-exports", async () => {
       const tempDir = await Deno.makeTempDir({ prefix: "vf-discovery-barrel-" });
 

--- a/src/discovery/handlers/tool-handler.ts
+++ b/src/discovery/handlers/tool-handler.ts
@@ -7,13 +7,24 @@ import { registerTool } from "#veryfront/mcp";
 import type { DiscoveryHandler } from "../types.ts";
 import { filenameToId } from "../discovery-utils.ts";
 
+function hasGeneratedToolId(id: string | undefined): boolean {
+  return typeof id === "string" && /^tool_\d+_\d+$/.test(id);
+}
+
 export const toolHandler: DiscoveryHandler<Tool> = {
   typeName: "tool",
   validate: (item): item is Tool =>
     item !== null && typeof item === "object" && typeof (item as Tool).execute === "function",
-  getId: (_item, file) => filenameToId(file),
+  getId: (tool, file) => {
+    const configuredId = tool.id;
+    return typeof configuredId === "string" &&
+        configuredId.trim().length > 0 &&
+        !hasGeneratedToolId(configuredId)
+      ? configuredId
+      : filenameToId(file);
+  },
   register: (id, tool) => {
-    const toolWithId = { ...tool, id };
+    const toolWithId = tool.id === id ? tool : { ...tool, id };
     registerTool(id, toolWithId);
     return toolWithId;
   },

--- a/src/server/handlers/request/api/project-discovery.test.ts
+++ b/src/server/handlers/request/api/project-discovery.test.ts
@@ -220,5 +220,55 @@ describe(
       assertEquals(toolRegistry.has("getWeather"), true);
       assertExists(skillRegistry.get("writer-helper"));
     });
+
+    it("keeps explicit tool ids available for request-time project-agent runs", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+      skillRegistry.clearAll();
+
+      const ctx = createHandlerContext(
+        "/explicit-tool-id-project",
+        "explicit-tool-id-project",
+        "preview",
+      );
+
+      await ctx.adapter.fs.writeFile(
+        `${ctx.projectDir}/tools/write-report.ts`,
+        [
+          'import { tool } from "veryfront/tool";',
+          'import { z } from "zod";',
+          "",
+          "export default tool({",
+          '  id: "write-report",',
+          '  description: "Persist a markdown report",',
+          "  inputSchema: z.object({ markdown: z.string() }),",
+          "  execute: async ({ markdown }) => ({ ok: true, markdown }),",
+          "});",
+          "",
+        ].join("\n"),
+      );
+
+      await ctx.adapter.fs.writeFile(
+        `${ctx.projectDir}/agents/demo-agent.ts`,
+        [
+          'import { agent } from "veryfront/agent";',
+          "",
+          "export default agent({",
+          '  id: "demo-agent",',
+          '  system: "Use the write-report tool when asked.",',
+          '  tools: { "write-report": true },',
+          "});",
+          "",
+        ].join("\n"),
+      );
+
+      await ensureProjectDiscovery(ctx);
+
+      const discoveredAgent = getAgent("demo-agent");
+      assertExists(discoveredAgent);
+      assertEquals(toolRegistry.has("write-report"), true);
+      assertEquals(toolRegistry.has("writeReport"), false);
+      assertEquals(discoveredAgent.config.tools, { "write-report": true });
+    });
   },
 );


### PR DESCRIPTION
## Summary
- preserve explicit tool ids during project discovery instead of always forcing filename-derived camelCase ids
- keep filename-derived ids for tools that only have autogenerated placeholder ids
- add red/green coverage for discovery and request-time project-agent runs

## Testing
- deno test --allow-all src/discovery/auto-discovery.integration.test.ts src/server/handlers/request/api/project-discovery.test.ts src/server/handlers/request/agent-stream.handler.test.ts
- full pre-push suite (1288 passed, 0 failed)