### PR TITLE
Preserve CSP protection when upstream scripts emit empty nonces

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.134",
+  "version": "0.1.135",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.135",
+  "version": "0.1.134",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/html/nonce-injection.test.ts
+++ b/src/html/nonce-injection.test.ts
@@ -23,6 +23,18 @@ describe("html/nonce-injection", () => {
     assertEquals(html.includes('nonce="nonce-123" nonce="existing"'), false);
   });
 
+  it("replaces an empty nonce attribute with the response nonce", () => {
+    const html = addNonceToHtmlTags(
+      `<script nonce="">window.__vf=1</script><style nonce='   '>.chat{color:red}</style>`,
+      "nonce-123",
+    );
+
+    assertEquals(html.includes('<script nonce="nonce-123">window.__vf=1</script>'), true);
+    assertEquals(html.includes('<style nonce="nonce-123">.chat{color:red}</style>'), true);
+    assertEquals(html.includes('nonce=""'), false);
+    assertEquals(html.includes("nonce='   '"), false);
+  });
+
   it("does not inject nonce markup into script or style literals inside scripts", () => {
     const html = addNonceToHtmlTags(
       `<script>window.tpl="<script>alert(1)";window.css="<style>.x{color:red}";</script><style>.chat{color:red}</style>`,

--- a/src/html/nonce-injection.test.ts
+++ b/src/html/nonce-injection.test.ts
@@ -79,4 +79,18 @@ describe("html/nonce-injection", () => {
       true,
     );
   });
+
+  it("ignores nonce-like text inside another attribute value", () => {
+    const html = addNonceToHtmlTags(
+      `<script data-info="prefix nonce='' suffix">window.__vf=1</script>`,
+      "nonce-123",
+    );
+
+    assertEquals(
+      html.includes(
+        '<script data-info="prefix nonce=\'\' suffix" nonce="nonce-123">window.__vf=1</script>',
+      ),
+      true,
+    );
+  });
 });

--- a/src/html/nonce-injection.ts
+++ b/src/html/nonce-injection.ts
@@ -55,15 +55,67 @@ function findRawTextClosingTagStart(
   return -1;
 }
 
-function injectNonceIntoOpeningTag(tag: string, escapedNonce: string): string {
-  const existingNonce = /(\snonce\s*=\s*)(?:"([^"]*)"|'([^']*)'|([^\s>]+))/iu.exec(tag);
-  if (existingNonce) {
-    const currentValue = existingNonce[2] ?? existingNonce[3] ?? existingNonce[4] ?? "";
-    if (currentValue.trim()) return tag;
+interface ParsedAttribute {
+  name: string;
+  start: number;
+  end: number;
+  value: string | null;
+}
 
-    const replacement = ` nonce="${escapedNonce}"`;
-    return `${tag.slice(0, existingNonce.index)}${replacement}${
-      tag.slice(existingNonce.index + existingNonce[0].length)
+function findAttribute(tag: string, attributeName: string): ParsedAttribute | undefined {
+  const closeIndex = tag.lastIndexOf(">");
+  if (closeIndex <= 0) return undefined;
+
+  let index = 1;
+  while (index < closeIndex && !/\s|\/|>/u.test(tag[index] ?? "")) index++;
+
+  while (index < closeIndex) {
+    while (index < closeIndex && /\s/u.test(tag[index] ?? "")) index++;
+    if (index >= closeIndex) break;
+
+    const char = tag[index];
+    if (char === "/" || char === ">") break;
+
+    const start = index;
+    while (index < closeIndex && !/[\s=/>]/u.test(tag[index] ?? "")) index++;
+    const name = tag.slice(start, index);
+
+    while (index < closeIndex && /\s/u.test(tag[index] ?? "")) index++;
+
+    let value: string | null = null;
+    if (tag[index] === "=") {
+      index++;
+      while (index < closeIndex && /\s/u.test(tag[index] ?? "")) index++;
+
+      const quote = tag[index];
+      if (quote === '"' || quote === "'") {
+        index++;
+        const valueStart = index;
+        while (index < closeIndex && tag[index] !== quote) index++;
+        value = tag.slice(valueStart, index);
+        if (index < closeIndex) index++;
+      } else {
+        const valueStart = index;
+        while (index < closeIndex && !/[\s>]/u.test(tag[index] ?? "")) index++;
+        value = tag.slice(valueStart, index);
+      }
+    }
+
+    if (name.toLowerCase() === attributeName) {
+      return { name, start, end: index, value };
+    }
+  }
+
+  return undefined;
+}
+
+function injectNonceIntoOpeningTag(tag: string, escapedNonce: string): string {
+  const existingNonce = findAttribute(tag, "nonce");
+  if (existingNonce) {
+    if (existingNonce.value?.trim()) return tag;
+
+    return `${tag.slice(0, existingNonce.start)}nonce="${escapedNonce}"${
+      tag.slice(existingNonce.end)
     }`;
   }
 

--- a/src/html/nonce-injection.ts
+++ b/src/html/nonce-injection.ts
@@ -56,7 +56,16 @@ function findRawTextClosingTagStart(
 }
 
 function injectNonceIntoOpeningTag(tag: string, escapedNonce: string): string {
-  if (/(?:\s|<)nonce\s*=/iu.test(tag)) return tag;
+  const existingNonce = /(\snonce\s*=\s*)(?:"([^"]*)"|'([^']*)'|([^\s>]+))/iu.exec(tag);
+  if (existingNonce) {
+    const currentValue = existingNonce[2] ?? existingNonce[3] ?? existingNonce[4] ?? "";
+    if (currentValue.trim()) return tag;
+
+    const replacement = ` nonce="${escapedNonce}"`;
+    return `${tag.slice(0, existingNonce.index)}${replacement}${
+      tag.slice(existingNonce.index + existingNonce[0].length)
+    }`;
+  }
 
   const closeIndex = tag.lastIndexOf(">");
   if (closeIndex === -1) return tag;


### PR DESCRIPTION
## Summary
- replace empty or whitespace-only `nonce` attributes with the response CSP nonce during HTML post-processing
- keep non-empty nonce attributes untouched
- add a regression test covering `nonce=""` and whitespace-only nonce values

## Root Cause
Production preview HTML can include an inline `next-themes` bootstrap script rendered as `<script nonce="">...</script>`. The shared Veryfront nonce injector treated any existing `nonce=` attribute as authoritative, so the empty value survived HTML post-processing even though the response CSP required a concrete nonce.

That leaves the page in an inconsistent state:
- CSP header: `script-src 'self' 'nonce-<response-nonce>' ...`
- HTML body: inline script with `nonce=""`

Browsers block that inline script, which is the CSP error seen on the `Agent Creator Widget` preview repro.

Related issue: veryfront/veryfront-studio#1207

## Verification
- `deno test --no-check --allow-all src/html/nonce-injection.test.ts`
- `deno check src/html/nonce-injection.ts src/html/nonce-injection.test.ts`
- `deno lint src/html/nonce-injection.ts src/html/nonce-injection.test.ts`

## Risks
- Not yet verified against a deployed production preview after rollout
