### PR TITLE
Add project-agent web_search runtime support

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -43,7 +43,7 @@ cli/
    import type { CommandHelp } from "../../help/types.ts";
    export const fooHelp: CommandHelp = {
      name: "foo",
-     category: "development",  // development | deploy | project | files | ai | auth
+     category: "development", // development | deploy | project | files | ai | auth
      description: "...",
      usage: "veryfront foo [options]",
      options: [{ flag: "--bar", description: "..." }],
@@ -70,6 +70,7 @@ cli/
 ## Global Flags
 
 Handled in `routeCommand()` in `router.ts`:
+
 - `--json` / `-j` → `setJsonMode(true)` — enables structured JSON output
 - `--output` / `-o` → `setOutputPath(path)` — write JSON to file
 - `--yes` / `-y` → `setNonInteractive(true)` — skip prompts (auto-detected in CI)
@@ -78,8 +79,9 @@ Handled in `routeCommand()` in `router.ts`:
 ## JSON Output Pattern
 
 Commands that support `--json` use the envelope format:
+
 ```typescript
-import { isJsonMode, outputJson, createSuccessEnvelope } from "../../shared/json-output.ts";
+import { createSuccessEnvelope, isJsonMode, outputJson } from "../../shared/json-output.ts";
 
 if (isJsonMode()) {
   await outputJson(createSuccessEnvelope("command-name", { key: "value" }));

--- a/cli/mcp/skills/deploy-safely/skill.json
+++ b/cli/mcp/skills/deploy-safely/skill.json
@@ -7,7 +7,11 @@
     "mcp": ["vf_get_errors"]
   },
   "inputs": {
-    "environment": { "type": "string", "default": "production", "description": "Target environment" },
+    "environment": {
+      "type": "string",
+      "default": "production",
+      "description": "Target environment"
+    },
     "branch": { "type": "string", "default": "main", "description": "Branch to deploy" }
   }
 }

--- a/cli/mcp/skills/scaffold-ai-app/skill.json
+++ b/cli/mcp/skills/scaffold-ai-app/skill.json
@@ -8,6 +8,10 @@
   },
   "inputs": {
     "name": { "type": "string", "description": "Project name" },
-    "provider": { "type": "string", "default": "anthropic", "description": "AI provider to configure" }
+    "provider": {
+      "type": "string",
+      "default": "anthropic",
+      "description": "AI provider to configure"
+    }
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.134",
+  "version": "0.1.135",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/runtime/ai-stream-handler.test.ts
+++ b/src/agent/runtime/ai-stream-handler.test.ts
@@ -205,6 +205,55 @@ describe("ai-stream-handler", () => {
       assertEquals(events.length, 2);
     });
 
+    it("forwards tool results as tool-output-available SSE events", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        {
+          type: "tool-result",
+          toolCallId: "tc-web",
+          toolName: "web_search",
+          input: { query: "latest ai news" },
+          output: { results: [{ title: "AI" }] },
+        },
+        { type: "finish", finishReason: "stop", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      assertEquals(events[0], {
+        type: "tool-output-available",
+        toolCallId: "tc-web",
+        output: { results: [{ title: "AI" }] },
+      });
+    });
+
+    it("forwards errored tool results as tool-output-error SSE events", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        {
+          type: "tool-result",
+          toolCallId: "tc-web",
+          toolName: "web_search",
+          input: { query: "latest ai news" },
+          output: { error: "Search failed" },
+          isError: true,
+        },
+        { type: "finish", finishReason: "error", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      assertEquals(events[0], {
+        type: "tool-output-error",
+        toolCallId: "tc-web",
+        errorText: '{"error":"Search failed"}',
+      });
+    });
+
     it("ignores tool-input-delta for unknown tool call IDs", async () => {
       const { events, controller, encoder } = createSSECollector();
       const state = createStreamState();
@@ -264,7 +313,7 @@ describe("ai-stream-handler", () => {
 
       // Only text-delta should produce an event
       assertEquals(events.length, 1);
-      assertEquals(events[0].type, "text-delta");
+      assertEquals(events[0]?.type, "text-delta");
     });
   });
 });

--- a/src/agent/runtime/ai-stream-handler.ts
+++ b/src/agent/runtime/ai-stream-handler.ts
@@ -55,6 +55,18 @@ function throwIfAborted(abortSignal?: AbortSignal): void {
   }
 }
 
+function stringifyToolError(output: unknown): string {
+  if (typeof output === "string" && output.length > 0) {
+    return output;
+  }
+
+  try {
+    return JSON.stringify(output);
+  } catch {
+    return String(output);
+  }
+}
+
 export function createStreamState(): AIStreamState {
   return {
     accumulatedText: "",
@@ -158,6 +170,25 @@ export function processStream(
             toolName: part.toolName,
             input: inputObj,
             ...(dynamic ? { dynamic: true } : {}),
+          });
+          break;
+        }
+
+        case "tool-result": {
+          const isError = "isError" in part && part.isError === true;
+          if (isError) {
+            sendSSE(controller, encoder, {
+              type: "tool-output-error",
+              toolCallId: part.toolCallId,
+              errorText: stringifyToolError(part.output),
+            });
+            break;
+          }
+
+          sendSSE(controller, encoder, {
+            type: "tool-output-available",
+            toolCallId: part.toolCallId,
+            output: part.output,
           });
           break;
         }

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -701,7 +701,10 @@ export class AgentRuntime {
         model: languageModel,
         system: systemPrompt,
         messages: convertToModelMessages(currentMessages),
-        tools: convertToolsToAISDK(tools),
+        tools: convertToolsToAISDK(tools, {
+          model: effectiveModel,
+          allowedToolNames: allowedRemoteToolNames,
+        }),
         maxOutputTokens: this.resolveMaxOutputTokens(maxOutputTokensOverride),
         temperature: DEFAULT_TEMPERATURE,
         abortSignal,

--- a/src/agent/runtime/model-tool-converter.test.ts
+++ b/src/agent/runtime/model-tool-converter.test.ts
@@ -92,4 +92,51 @@ describe("model-tool-converter", () => {
     assertEquals(result !== undefined, true);
     assertEquals("create_file" in result!, true);
   });
+
+  it("adds provider-native web_search for anthropic models when explicitly allowed", () => {
+    const result = convertToolsToAISDK([], {
+      model: "anthropic/claude-sonnet-4-6",
+      allowedToolNames: ["web_search"],
+    });
+
+    assertEquals(result !== undefined, true);
+    assertEquals("web_search" in result!, true);
+  });
+
+  it("adds provider-native web_search for veryfront-cloud anthropic models when explicitly allowed", () => {
+    const result = convertToolsToAISDK([], {
+      model: "veryfront-cloud/anthropic/claude-sonnet-4-6",
+      allowedToolNames: ["web_search"],
+    });
+
+    assertEquals(result !== undefined, true);
+    assertEquals("web_search" in result!, true);
+  });
+
+  it("does not add provider-native web_search for non-anthropic models", () => {
+    const result = convertToolsToAISDK([], {
+      model: "openai/gpt-4o-mini",
+      allowedToolNames: ["web_search"],
+    });
+
+    assertEquals(result, undefined);
+  });
+
+  it("does not override an explicit local tool named web_search", () => {
+    const tools: ToolDefinition[] = [
+      {
+        name: "web_search",
+        description: "Project-owned search tool",
+        parameters: { type: "object", properties: {} },
+      },
+    ];
+
+    const result = convertToolsToAISDK(tools, {
+      model: "anthropic/claude-sonnet-4-6",
+      allowedToolNames: ["web_search"],
+    });
+
+    assertEquals(result !== undefined, true);
+    assertEquals(Object.keys(result!).filter((name) => name === "web_search").length, 1);
+  });
 });

--- a/src/agent/runtime/model-tool-converter.ts
+++ b/src/agent/runtime/model-tool-converter.ts
@@ -10,6 +10,42 @@
 import { jsonSchema, tool } from "ai";
 import type { ToolSet } from "ai";
 import type { ToolDefinition } from "#veryfront/tool";
+import { anthropic } from "@ai-sdk/anthropic";
+
+export interface ConvertToolsToAISDKOptions {
+  model?: string;
+  allowedToolNames?: string[];
+}
+
+function resolveHostedProvider(model?: string): string | undefined {
+  if (!model) return undefined;
+
+  const [provider, second] = model.split("/", 3);
+  if (!provider) return undefined;
+  if (provider === "veryfront-cloud") {
+    return second || undefined;
+  }
+
+  return provider;
+}
+
+function resolveProviderNativeTools(
+  options?: ConvertToolsToAISDKOptions,
+): ToolSet | undefined {
+  if (!options?.allowedToolNames?.includes("web_search")) {
+    return undefined;
+  }
+
+  if (resolveHostedProvider(options.model) !== "anthropic") {
+    return undefined;
+  }
+
+  return {
+    web_search: anthropic.tools.webSearch_20250305({
+      maxUses: 5,
+    }),
+  };
+}
 
 /**
  * Convert veryfront tool definitions to AI SDK ToolSet.
@@ -19,9 +55,8 @@ import type { ToolDefinition } from "#veryfront/tool";
  */
 export function convertToolsToAISDK(
   tools: ToolDefinition[],
+  options?: ConvertToolsToAISDKOptions,
 ): ToolSet | undefined {
-  if (!tools.length) return undefined;
-
   const toolSet: ToolSet = {};
 
   for (const def of tools) {
@@ -31,5 +66,14 @@ export function convertToolsToAISDK(
     });
   }
 
-  return toolSet;
+  const providerNativeTools = resolveProviderNativeTools(options);
+  if (providerNativeTools) {
+    for (const [name, providerTool] of Object.entries(providerNativeTools)) {
+      if (!Object.hasOwn(toolSet, name)) {
+        toolSet[name] = providerTool;
+      }
+    }
+  }
+
+  return Object.keys(toolSet).length > 0 ? toolSet : undefined;
 }

--- a/src/react/components/Head.tsx
+++ b/src/react/components/Head.tsx
@@ -1,1 +1,10 @@
+/**
+ * React head exports for document metadata rendering.
+ *
+ * @module
+ * @example
+ * ```tsx
+ * import { Head } from "veryfront/head";
+ * ```
+ */
 export { Head } from "../runtime/core.ts";

--- a/src/react/context/index.tsx
+++ b/src/react/context/index.tsx
@@ -1,2 +1,11 @@
+/**
+ * React page-context exports for MDX and route-aware rendering.
+ *
+ * @module
+ * @example
+ * ```tsx
+ * import { PageContextProvider, usePageContext } from "veryfront/context";
+ * ```
+ */
 export { PageContextProvider, usePageContext } from "../runtime/core.ts";
 export type { MdxHeading, PageContextProviderProps, PageContextValue } from "../runtime/core.ts";

--- a/src/react/router/index.tsx
+++ b/src/react/router/index.tsx
@@ -1,2 +1,11 @@
+/**
+ * React router exports for client navigation and route context.
+ *
+ * @module
+ * @example
+ * ```tsx
+ * import { Link, RouterProvider, useRouter } from "veryfront/router";
+ * ```
+ */
 export { Link, Router, RouterProvider, useRouter } from "../runtime/core.ts";
 export type { LinkProps, RouterProviderProps, RouterValue } from "../runtime/core.ts";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.134";
+export const VERSION = "0.1.135";


### PR DESCRIPTION
## Summary
- add provider-native Anthropic web_search support on the project-agent runtime streaming path when the run explicitly allows it
- forward streamed AI SDK tool-result parts into AG-UI tool-output events so Studio can render provider tool results
- bump the patch version to 0.1.135 and include the minimal formatting/docs cleanups needed to pass the repo verification gate

## Testing
- deno test --allow-env --allow-read src/agent/runtime/model-tool-converter.test.ts
- deno test --allow-env --allow-read src/agent/runtime/ai-stream-handler.test.ts
- deno task verify

Refs veryfront-studio#1239
