### PR TITLE
Fail closed on empty internal agent completions

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -43,7 +43,7 @@ cli/
    import type { CommandHelp } from "../../help/types.ts";
    export const fooHelp: CommandHelp = {
      name: "foo",
-     category: "development",  // development | deploy | project | files | ai | auth
+     category: "development", // development | deploy | project | files | ai | auth
      description: "...",
      usage: "veryfront foo [options]",
      options: [{ flag: "--bar", description: "..." }],
@@ -70,6 +70,7 @@ cli/
 ## Global Flags
 
 Handled in `routeCommand()` in `router.ts`:
+
 - `--json` / `-j` → `setJsonMode(true)` — enables structured JSON output
 - `--output` / `-o` → `setOutputPath(path)` — write JSON to file
 - `--yes` / `-y` → `setNonInteractive(true)` — skip prompts (auto-detected in CI)
@@ -78,8 +79,9 @@ Handled in `routeCommand()` in `router.ts`:
 ## JSON Output Pattern
 
 Commands that support `--json` use the envelope format:
+
 ```typescript
-import { isJsonMode, outputJson, createSuccessEnvelope } from "../../shared/json-output.ts";
+import { createSuccessEnvelope, isJsonMode, outputJson } from "../../shared/json-output.ts";
 
 if (isJsonMode()) {
   await outputJson(createSuccessEnvelope("command-name", { key: "value" }));

--- a/cli/mcp/skills/deploy-safely/skill.json
+++ b/cli/mcp/skills/deploy-safely/skill.json
@@ -7,7 +7,11 @@
     "mcp": ["vf_get_errors"]
   },
   "inputs": {
-    "environment": { "type": "string", "default": "production", "description": "Target environment" },
+    "environment": {
+      "type": "string",
+      "default": "production",
+      "description": "Target environment"
+    },
     "branch": { "type": "string", "default": "main", "description": "Branch to deploy" }
   }
 }

--- a/cli/mcp/skills/scaffold-ai-app/skill.json
+++ b/cli/mcp/skills/scaffold-ai-app/skill.json
@@ -8,6 +8,10 @@
   },
   "inputs": {
     "name": { "type": "string", "description": "Project name" },
-    "provider": { "type": "string", "default": "anthropic", "description": "AI provider to configure" }
+    "provider": {
+      "type": "string",
+      "default": "anthropic",
+      "description": "AI provider to configure"
+    }
   }
 }

--- a/src/internal-agents/ag-ui-sse.test.ts
+++ b/src/internal-agents/ag-ui-sse.test.ts
@@ -191,6 +191,36 @@ describe("internal-agents/ag-ui-sse", () => {
     );
   });
 
+  it("fails closed when the runtime completed without assistant-visible output", () => {
+    const state = createStreamTransformState();
+
+    assertEquals(
+      finalizeRunEvents(state, {
+        text: "",
+        messages: [],
+        toolCalls: [],
+        status: "completed",
+        usage: {
+          promptTokens: 0,
+          completionTokens: 0,
+          totalTokens: 0,
+        },
+        metadata: {
+          finishReason: "stop",
+        },
+      }),
+      [
+        {
+          event: "RunError",
+          payload: {
+            code: "EMPTY_ASSISTANT_OUTPUT",
+            message: "Agent run produced no assistant-visible output",
+          },
+        },
+      ],
+    );
+  });
+
   it("formats AG-UI events as SSE frames", () => {
     const payload = formatAgUiEvent("RunStarted", {
       runId: "run_1",

--- a/src/internal-agents/ag-ui-sse.ts
+++ b/src/internal-agents/ag-ui-sse.ts
@@ -19,6 +19,7 @@ export interface RunFinishedMetadata {
 export interface StreamTransformState {
   messageId: string | null;
   textOpen: boolean;
+  sawVisibleOutput: boolean;
   sawTerminalError: boolean;
   metadata: RunFinishedMetadata;
 }
@@ -27,6 +28,7 @@ export function createStreamTransformState(): StreamTransformState {
   return {
     messageId: null,
     textOpen: false,
+    sawVisibleOutput: false,
     sawTerminalError: false,
     metadata: {},
   };
@@ -180,6 +182,7 @@ export function mapRuntimeEventToAgUi(
       if (state.textOpen) return [];
       const messageId = getMessageId(state, event);
       state.textOpen = true;
+      state.sawVisibleOutput = true;
       return [{
         event: "TextMessageStart",
         payload: { messageId, role: "assistant" },
@@ -188,6 +191,7 @@ export function mapRuntimeEventToAgUi(
 
     case "text-delta": {
       const messageId = getMessageId(state, event);
+      state.sawVisibleOutput = true;
       if (!state.textOpen) {
         state.textOpen = true;
         return [
@@ -215,6 +219,7 @@ export function mapRuntimeEventToAgUi(
     }
 
     case "tool-input-start":
+      state.sawVisibleOutput = true;
       return [{
         event: "ToolCallStart",
         payload: {
@@ -224,6 +229,7 @@ export function mapRuntimeEventToAgUi(
       }];
 
     case "tool-input-delta":
+      state.sawVisibleOutput = true;
       return [{
         event: "ToolCallArgs",
         payload: {
@@ -233,12 +239,14 @@ export function mapRuntimeEventToAgUi(
       }];
 
     case "tool-input-available":
+      state.sawVisibleOutput = true;
       return [{
         event: "ToolCallEnd",
         payload: { toolCallId: event.toolCallId },
       }];
 
     case "tool-output-available":
+      state.sawVisibleOutput = true;
       return [{
         event: "ToolCallResult",
         payload: {
@@ -248,6 +256,7 @@ export function mapRuntimeEventToAgUi(
       }];
 
     case "tool-output-error":
+      state.sawVisibleOutput = true;
       return [{
         event: "ToolCallResult",
         payload: {
@@ -289,6 +298,17 @@ export function finalizeRunEvents(
 
   if (state.sawTerminalError) {
     return [];
+  }
+
+  if (!state.sawVisibleOutput) {
+    state.sawTerminalError = true;
+    return [{
+      event: "RunError",
+      payload: {
+        code: "EMPTY_ASSISTANT_OUTPUT",
+        message: "Agent run produced no assistant-visible output",
+      },
+    }];
   }
 
   const events: Array<{ event: string; payload: Record<string, unknown> }> = [];

--- a/src/react/components/Head.tsx
+++ b/src/react/components/Head.tsx
@@ -1,1 +1,10 @@
+/**
+ * React head exports for document metadata rendering.
+ *
+ * @module
+ * @example
+ * ```tsx
+ * import { Head } from "veryfront/head";
+ * ```
+ */
 export { Head } from "../runtime/core.ts";

--- a/src/react/context/index.tsx
+++ b/src/react/context/index.tsx
@@ -1,2 +1,11 @@
+/**
+ * React page-context exports for MDX and route-aware rendering.
+ *
+ * @module
+ * @example
+ * ```tsx
+ * import { PageContextProvider, usePageContext } from "veryfront/context";
+ * ```
+ */
 export { PageContextProvider, usePageContext } from "../runtime/core.ts";
 export type { MdxHeading, PageContextProviderProps, PageContextValue } from "../runtime/core.ts";

--- a/src/react/router/index.tsx
+++ b/src/react/router/index.tsx
@@ -1,2 +1,11 @@
+/**
+ * React router exports for client navigation and route context.
+ *
+ * @module
+ * @example
+ * ```tsx
+ * import { Link, RouterProvider, useRouter } from "veryfront/router";
+ * ```
+ */
 export { Link, Router, RouterProvider, useRouter } from "../runtime/core.ts";
 export type { LinkProps, RouterProviderProps, RouterValue } from "../runtime/core.ts";


### PR DESCRIPTION
## Summary
- fail closed in the internal AG-UI stream adapter when a run finishes without any assistant-visible output
- emit `RunError` with `EMPTY_ASSISTANT_OUTPUT` instead of a synthetic success in that case
- include the same repo-wide formatting/JSDoc housekeeping needed for `veryfront-code` CI parity on current `main`

## Testing
- `deno test --allow-env --allow-read src/internal-agents/ag-ui-sse.test.ts`
- `deno test --allow-env --allow-read src/internal-agents/*.test.ts`
- `deno task verify`
