### PR TITLE
Add Tailwind entry styles to starter templates

### DIFF
--- a/cli/templates/files/agentic-workflow/app/layout.tsx
+++ b/cli/templates/files/agentic-workflow/app/layout.tsx
@@ -1,3 +1,4 @@
+import "../globals.css";
 import { Head } from "veryfront/head";
 
 export default function RootLayout({

--- a/cli/templates/files/agentic-workflow/globals.css
+++ b/cli/templates/files/agentic-workflow/globals.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/cli/templates/files/ai-agent/app/layout.tsx
+++ b/cli/templates/files/ai-agent/app/layout.tsx
@@ -1,3 +1,4 @@
+import "../globals.css";
 import { Head } from "veryfront/head";
 
 export default function RootLayout({

--- a/cli/templates/files/ai-agent/globals.css
+++ b/cli/templates/files/ai-agent/globals.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/cli/templates/files/coding-agent/app/layout.tsx
+++ b/cli/templates/files/coding-agent/app/layout.tsx
@@ -1,3 +1,4 @@
+import "../globals.css";
 import { Head } from "veryfront/head";
 
 export default function RootLayout({

--- a/cli/templates/files/coding-agent/globals.css
+++ b/cli/templates/files/coding-agent/globals.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/cli/templates/files/docs-agent/app/layout.tsx
+++ b/cli/templates/files/docs-agent/app/layout.tsx
@@ -1,3 +1,4 @@
+import "../globals.css";
 import { Head } from "veryfront/head";
 
 export default function RootLayout({ children }: { children: React.ReactNode }): React.ReactNode {

--- a/cli/templates/files/docs-agent/globals.css
+++ b/cli/templates/files/docs-agent/globals.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/cli/templates/files/multi-agent-system/app/layout.tsx
+++ b/cli/templates/files/multi-agent-system/app/layout.tsx
@@ -1,3 +1,4 @@
+import "../globals.css";
 import { Head } from "veryfront/head";
 
 export default function RootLayout({

--- a/cli/templates/files/multi-agent-system/globals.css
+++ b/cli/templates/files/multi-agent-system/globals.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/cli/templates/files/saas-starter/app/layout.tsx
+++ b/cli/templates/files/saas-starter/app/layout.tsx
@@ -1,3 +1,4 @@
+import "../globals.css";
 import { Head } from "veryfront/head";
 
 export default function RootLayout({

--- a/cli/templates/files/saas-starter/globals.css
+++ b/cli/templates/files/saas-starter/globals.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/cli/templates/index.test.ts
+++ b/cli/templates/index.test.ts
@@ -1,0 +1,43 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+
+import type { TemplateName } from "./types.ts";
+
+const STYLED_STARTER_TEMPLATES: TemplateName[] = [
+  "ai-agent",
+  "docs-agent",
+  "multi-agent-system",
+  "agentic-workflow",
+  "coding-agent",
+  "saas-starter",
+];
+
+describe("cli/templates", () => {
+  it("ships a Tailwind entry stylesheet for styled starter templates", async () => {
+    for (const templateName of STYLED_STARTER_TEMPLATES) {
+      const globalsPath = new URL(`./files/${templateName}/globals.css`, import.meta.url);
+      const globals = await Deno.readTextFile(globalsPath);
+      assertExists(globals, `${templateName} should include globals.css`);
+      assertEquals(
+        globals.includes('@import "tailwindcss";'),
+        true,
+        `${templateName} globals.css should import tailwindcss`,
+      );
+    }
+  });
+
+  it("imports globals.css from each styled starter root layout", async () => {
+    for (const templateName of STYLED_STARTER_TEMPLATES) {
+      const layoutPath = new URL(`./files/${templateName}/app/layout.tsx`, import.meta.url);
+      const layout = await Deno.readTextFile(layoutPath);
+      assertExists(layout, `${templateName} should include app/layout.tsx`);
+      assertEquals(
+        layout.includes('import "../globals.css";') ||
+          layout.includes('import "./globals.css";') ||
+          layout.includes('import "@/globals.css";'),
+        true,
+        `${templateName} layout should import globals.css`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a root `globals.css` Tailwind entry stylesheet to the styled starter templates
- import that stylesheet from each starter template root layout so Tailwind utility classes actually render
- add template-level regression coverage for the stylesheet + layout import contract

## Testing
- `deno test --allow-read cli/templates/index.test.ts`
- `deno test --allow-read cli/templates/index.test.ts cli/commands/init/catalog.test.ts`
- full pre-push gate on `git push`
