### PR TITLE
test: smoke test starter templates

### DIFF
--- a/tests/integration/templates/starter-templates-smoke.test.ts
+++ b/tests/integration/templates/starter-templates-smoke.test.ts
@@ -1,0 +1,56 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { dirname, join } from "#veryfront/compat/path";
+import { mkdir, writeTextFile } from "#veryfront/testing/deno-compat.ts";
+
+import { getTemplate } from "../../../cli/templates/index.ts";
+import type { TemplateName } from "../../../cli/templates/types.ts";
+import { withTestContext } from "../../_helpers/context.ts";
+import { createTestDenoConfig } from "../../_helpers/import-maps.ts";
+
+const STARTER_TEMPLATES: TemplateName[] = [
+  "minimal",
+  "ai-agent",
+  "docs-agent",
+  "multi-agent-system",
+  "agentic-workflow",
+  "coding-agent",
+  "saas-starter",
+];
+
+async function scaffoldTemplate(projectDir: string, templateName: TemplateName): Promise<void> {
+  const files = await getTemplate(templateName);
+  if (!files) {
+    throw new Error(`Template ${templateName} was not found`);
+  }
+
+  for (const file of files) {
+    const targetPath = join(projectDir, file.path);
+    await mkdir(dirname(targetPath), { recursive: true });
+    await writeTextFile(targetPath, file.content);
+  }
+}
+
+describe("starter templates smoke", {
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, () => {
+  for (const templateName of STARTER_TEMPLATES) {
+    it(`renders ${templateName} root route`, async () => {
+      await withTestContext(`starter-template-${templateName}`, async (context) => {
+        await writeTextFile(join(context.projectDir, "deno.json"), createTestDenoConfig());
+        await scaffoldTemplate(context.projectDir, templateName);
+
+        const port = await context.allocatePort();
+        const server = await context.startDevServer({ port, enableHMR: false });
+
+        const response = await fetch(`http://127.0.0.1:${server.port}/`);
+        assertEquals(
+          response.status,
+          200,
+          `${templateName} should render / successfully`,
+        );
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add a runtime smoke harness for the first-party starter templates
- scaffold each starter into a temp project and boot the real dev server
- assert the root route returns `200` for each starter

## Scope
This covers the seven first-party starter templates:
- `minimal`
- `ai-agent`
- `docs-agent`
- `multi-agent-system`
- `agentic-workflow`
- `coding-agent`
- `saas-starter`

It does not yet cover every integration/community template, so `#109` stays open for the broader tracker.

## Verification
- deno test --allow-env --allow-net --allow-read --allow-write --allow-run tests/integration/templates/starter-templates-smoke.test.ts
- pre-push (format, lint, typecheck, unit, integration)