### PR TITLE
Normalize provider-native tool-call input on project-agent replay

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.135",
+  "version": "0.1.136",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/runtime/ai-stream-handler.test.ts
+++ b/src/agent/runtime/ai-stream-handler.test.ts
@@ -186,6 +186,34 @@ describe("ai-stream-handler", () => {
       });
     });
 
+    it("preserves tool-call input when the provider already emits a JSON string", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        {
+          type: "tool-call",
+          toolCallId: "tc-quoted",
+          toolName: "web_search",
+          input: '{"query":"Veryfront","maxUses":1}',
+        },
+        { type: "finish", finishReason: "tool-calls", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      assertEquals(state.toolCalls.size, 1);
+      const tc = state.toolCalls.get("tc-quoted")!;
+      assertEquals(tc.arguments, '{"query":"Veryfront","maxUses":1}');
+
+      assertEquals(events[0], {
+        type: "tool-input-available",
+        toolCallId: "tc-quoted",
+        toolName: "web_search",
+        input: { query: "Veryfront", maxUses: 1 },
+      });
+    });
+
     it("handles multiple tool calls in a single stream", async () => {
       const { events, controller, encoder } = createSSECollector();
       const state = createStreamState();

--- a/src/agent/runtime/ai-stream-handler.ts
+++ b/src/agent/runtime/ai-stream-handler.ts
@@ -38,6 +38,37 @@ export interface AIStreamCallbacks {
   }) => void;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeToolInputString(input: unknown): string {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  return JSON.stringify(input ?? {});
+}
+
+function normalizeToolInputObject(input: unknown): Record<string, unknown> {
+  if (isRecord(input)) {
+    return input;
+  }
+
+  if (typeof input === "string") {
+    try {
+      const parsed = JSON.parse(input);
+      if (isRecord(parsed)) {
+        return parsed;
+      }
+    } catch {
+      return {};
+    }
+  }
+
+  return {};
+}
+
 function createAbortError(reason?: unknown): Error {
   if (reason instanceof Error) {
     return reason;
@@ -151,7 +182,7 @@ export function processStream(
         case "tool-call": {
           // tool-call fires when the full tool call is available
           const toolId = part.toolCallId;
-          const inputStr = JSON.stringify(part.input);
+          const inputStr = normalizeToolInputString(part.input);
           state.toolCalls.set(toolId, {
             id: toolId,
             name: part.toolName,
@@ -159,11 +190,7 @@ export function processStream(
           });
 
           const dynamic = isDynamicTool(part.toolName);
-          // part.input is already a parsed object — pass directly to avoid double serialization
-          const inputObj =
-            (part.input && typeof part.input === "object" && !Array.isArray(part.input))
-              ? part.input as Record<string, unknown>
-              : {};
+          const inputObj = normalizeToolInputObject(part.input);
           sendSSE(controller, encoder, {
             type: "tool-input-available",
             toolCallId: toolId,

--- a/src/agent/runtime/ai-stream-handler.ts
+++ b/src/agent/runtime/ai-stream-handler.ts
@@ -47,7 +47,7 @@ function normalizeToolInputString(input: unknown): string {
     return input;
   }
 
-  return JSON.stringify(input ?? {});
+  return JSON.stringify(input ?? null) ?? "null";
 }
 
 function normalizeToolInputObject(input: unknown): Record<string, unknown> {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.135";
+export const VERSION = "0.1.136";


### PR DESCRIPTION
## Summary
Fix the project-agent replay path so provider-native tool calls preserve JSON-text input without double-stringifying it.

## Why
`veryfront-studio#1239` still reproduces on staging for `Demo Agent` with `web_search`.
The durable run evidence shows `web_search` is invoked, but the execution path later fails with `Expected object, received string`.

This PR addresses the `veryfront-code` side of that boundary by normalizing provider-native `tool-call` input before it is stored/replayed.

## TDD Evidence
Red:
- `deno test --no-check --allow-all src/agent/runtime/ai-stream-handler.test.ts`
- failing assertion: a provider-native `tool-call` with string input was stored as a doubly-quoted JSON string

Green:
- `deno test --no-check --allow-all src/agent/runtime/ai-stream-handler.test.ts`
- `deno task verify:quick`

## Scope
- normalize `part.input` when it is already JSON text
- keep AG-UI `tool-input-available` events object-shaped
- add regression coverage for provider-native `web_search`

## Related
- veryfront-studio#1239
