### PR TITLE
Fix compiled-binary SSR race for shared framework hook imports

### DIFF
--- a/src/transforms/pipeline/stages/ssr-vf-modules.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules.test.ts
@@ -21,7 +21,11 @@ import { ssrVfModulesPlugin } from "./ssr-vf-modules.ts";
 import {
   _testExports,
   cacheTransformedCode,
+  frameworkFileCache,
+  frameworkTransformFlight,
   transformFrameworkSource,
+  transformingFiles,
+  veryfrontTransformCache,
 } from "./ssr-vf-modules/index.ts";
 import type { TransformContext } from "../types.ts";
 
@@ -178,6 +182,40 @@ describe("ssr-vf-modules", { sanitizeOps: false, sanitizeResources: false }, () 
 
       const result = await ssrVfModulesPlugin.transform(ctx);
       assertEquals(result, code);
+    });
+
+    it("rewrites shared framework imports correctly under concurrent SSR transforms", async () => {
+      frameworkFileCache.clear();
+      veryfrontTransformCache.clear();
+      transformingFiles.clear();
+
+      const code =
+        `import { usePageContext } from "file:///_vf_modules/_veryfront/react/runtime/core.js?ssr=true";`;
+
+      const createCtx = () =>
+        ({
+          code,
+          target: "ssr",
+          projectDir: "/tmp/test-project",
+          reactVersion: REACT_DEFAULT_VERSION,
+        }) as TransformContext;
+
+      const [left, right] = await Promise.all([
+        ssrVfModulesPlugin.transform(createCtx()),
+        ssrVfModulesPlugin.transform(createCtx()),
+      ]);
+
+      assertStringIncludes(left, "file://");
+      assertStringIncludes(right, "file://");
+      assertEquals(
+        left.includes("file:///_vf_modules/_veryfront/react/runtime/core.js?ssr=true"),
+        false,
+      );
+      assertEquals(
+        right.includes("file:///_vf_modules/_veryfront/react/runtime/core.js?ssr=true"),
+        false,
+      );
+      assertEquals(frameworkTransformFlight.size, 0);
     });
   });
 

--- a/src/transforms/pipeline/stages/ssr-vf-modules/constants.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/constants.ts
@@ -39,6 +39,10 @@ export const FRAMEWORK_LOOKUPS: Array<[prefix: string, frameworkDir: string]> = 
 // Singleflight for framework module file writes to prevent race conditions
 export const frameworkWriteFlight = new Singleflight<string>();
 
+// Singleflight for top-level framework source transforms so concurrent user
+// modules importing the same veryfront/* module do not receive cycle placeholders.
+export const frameworkTransformFlight = new Singleflight<string>();
+
 // Cache for already-transformed #veryfront/ dependencies to avoid cycles and redundant work
 export const veryfrontTransformCache = new Map<string, string>();
 

--- a/src/transforms/pipeline/stages/ssr-vf-modules/index.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/index.ts
@@ -32,6 +32,7 @@ import {
   EXTENSIONS,
   FRAMEWORK_LOOKUPS,
   FRAMEWORK_ROOT,
+  frameworkTransformFlight,
   LOG_PREFIX,
 } from "./constants.ts";
 
@@ -56,6 +57,7 @@ export {
   FRAMEWORK_LOOKUPS,
   FRAMEWORK_ROOT,
   frameworkFileCache,
+  frameworkTransformFlight,
   frameworkWriteFlight,
   LOG_PREFIX,
   MAX_RELATIVE_IMPORT_DEPTH,
@@ -138,21 +140,22 @@ export const ssrVfModulesPlugin: TransformPlugin = {
           contentLength: resolved.content.length,
         });
 
-        const transformed = await transformFrameworkSource(
-          resolved.content,
-          resolved.sourcePath,
-          ctx.reactVersion ?? REACT_DEFAULT_VERSION,
-          ctx.projectDir,
-          fs,
-        );
+        const cachePath = await frameworkTransformFlight.do(resolved.sourcePath, async () => {
+          const transformed = await transformFrameworkSource(
+            resolved.content,
+            resolved.sourcePath,
+            ctx.reactVersion ?? REACT_DEFAULT_VERSION,
+            ctx.projectDir,
+            fs,
+          );
 
-        // Skip cycle placeholders - don't cache or use them
-        if (isCyclePlaceholder(transformed)) {
-          logger.warn(`${LOG_PREFIX} Cycle detected for ${vfModulePath}, skipping cache`);
-          continue;
-        }
+          // Skip cycle placeholders - don't cache or use them
+          if (isCyclePlaceholder(transformed)) {
+            throw new Error(`Cycle detected while transforming ${vfModulePath}`);
+          }
 
-        const cachePath = await cacheTransformedCode(transformed, vfModulePath, fs);
+          return await cacheTransformedCode(transformed, vfModulePath, fs);
+        });
         replacements.set(vfModulePath, `file://${cachePath}`);
 
         logger.debug(`${LOG_PREFIX} Transformed ${vfModulePath} -> file://${cachePath}`);


### PR DESCRIPTION
## Summary
Fix the compiled-binary SSR path so concurrent page/layout imports of shared framework hooks such as `veryfront/context` do not leave unresolved `file:///_vf_modules/...` imports behind.

## Why
`veryfront-code` main CI/CD failed in `tests (binary e2e)` after merging #868, but the failure is unrelated to the web-search replay change. The failing case is:
- `should share page context between layout and page via usePageContext`

The failure shape is nondeterministic between `pages/layout.tsx` and `pages/index.tsx`, but both report the same underlying problem:
- `Module not found: file:///_vf_modules/_veryfront/react/runtime/core.js?ssr=true`

That points to a concurrency race in SSR framework-module transformation, not to a missing framework file.

## Root Cause
Page and layout can request the same framework source transform concurrently. Without deduplication, the second caller can hit the existing cycle-placeholder path before the first transform finishes caching the resolved framework module, leaving one user module with an unresolved `_vf_modules` import.

## Fix
- singleflight top-level framework source transforms by resolved source path
- keep the true recursive cycle guard intact
- add a regression test that runs two SSR rewrites concurrently against the same framework module

## Verification
- `deno test --allow-all src/transforms/pipeline/stages/ssr-vf-modules.test.ts`
- `deno test --allow-all tests/integration/compiled-binary-e2e.test.ts`
- `deno task verify:quick`

## Related
- fixes the failing `tests (binary e2e)` lane on main after veryfront-code#868
