### PR TITLE
Remove npm self-upgrade from the stable release job

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -358,8 +358,6 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - run: npm install -g npm@latest
-
       - name: Build and publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
Remove the failing `npm install -g npm@latest` step from the stable release job.

## Why
`veryfront-code` main `CI/CD` for #869 passed all product tests and build jobs, but the rollout still failed in the `release` job on:
- `npm install -g npm@latest`
- `Cannot find module 'promise-retry'`

That step is not part of the product build or test surface; it is an avoidable workflow mutation of the runner-provided npm installation.

## Fix
- use the `actions/setup-node` provisioned Node/npm toolchain as-is
- remove the extra global npm self-upgrade step from the stable release path

## Evidence
Failing run:
- `veryfront-code` main `CI/CD` run `24043960451`
- failed job: `release`
- failing command: `npm install -g npm@latest`

## Scope
Workflow-only change. No product/runtime code changes.
