### PR TITLE
fix(runtime): repair provider web search input

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.136",
+  "version": "0.1.137",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -460,7 +460,10 @@ export class AgentRuntime {
             model: languageModel,
             system: systemPrompt,
             messages: convertToModelMessages(currentMessages),
-            tools: convertToolsToAISDK(tools),
+            tools: convertToolsToAISDK(tools, {
+              model: effectiveModel,
+              allowedToolNames: allowedRemoteToolNames,
+            }),
             experimental_repairToolCall: repairToolCall,
             maxOutputTokens: this.resolveMaxOutputTokens(maxOutputTokensOverride),
             temperature: DEFAULT_TEMPERATURE,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -34,6 +34,7 @@ import {
 import { convertToModelMessages } from "./model-message-converter.ts";
 import { convertToolsToAISDK } from "./model-tool-converter.ts";
 import { createStreamState, processStream } from "./ai-stream-handler.ts";
+import { repairToolCall } from "./repair-tool-call.ts";
 import { MiddlewareChain } from "../middleware/chain.ts";
 import { generateText, type LanguageModel, streamText } from "ai";
 import { AGENT_DEFAULTS } from "../ai-defaults.ts";
@@ -460,6 +461,7 @@ export class AgentRuntime {
             system: systemPrompt,
             messages: convertToModelMessages(currentMessages),
             tools: convertToolsToAISDK(tools),
+            experimental_repairToolCall: repairToolCall,
             maxOutputTokens: this.resolveMaxOutputTokens(maxOutputTokensOverride),
             temperature: DEFAULT_TEMPERATURE,
           });
@@ -705,6 +707,7 @@ export class AgentRuntime {
           model: effectiveModel,
           allowedToolNames: allowedRemoteToolNames,
         }),
+        experimental_repairToolCall: repairToolCall,
         maxOutputTokens: this.resolveMaxOutputTokens(maxOutputTokensOverride),
         temperature: DEFAULT_TEMPERATURE,
         abortSignal,

--- a/src/agent/runtime/repair-tool-call.test.ts
+++ b/src/agent/runtime/repair-tool-call.test.ts
@@ -27,7 +27,7 @@ describe("repair-tool-call", () => {
       system: undefined,
       toolCall: {
         input: "Veryfront",
-        providerExecuted: undefined,
+        providerExecuted: true,
         toolCallId: "tool-1",
         toolName: "web_search",
         type: "tool-call",
@@ -37,7 +37,7 @@ describe("repair-tool-call", () => {
 
     assertEquals(repaired, {
       input: JSON.stringify({ query: "Veryfront" }),
-      providerExecuted: undefined,
+      providerExecuted: true,
       toolCallId: "tool-1",
       toolName: "web_search",
       type: "tool-call",
@@ -59,7 +59,7 @@ describe("repair-tool-call", () => {
       system: undefined,
       toolCall: {
         input: '"Veryfront"',
-        providerExecuted: undefined,
+        providerExecuted: true,
         toolCallId: "tool-2",
         toolName: "web_search",
         type: "tool-call",
@@ -69,11 +69,69 @@ describe("repair-tool-call", () => {
 
     assertEquals(repaired, {
       input: JSON.stringify({ query: "Veryfront" }),
-      providerExecuted: undefined,
+      providerExecuted: true,
       toolCallId: "tool-2",
       toolName: "web_search",
       type: "tool-call",
     });
+  });
+
+  it("repairs numeric JSON literals by preserving the raw query text", async () => {
+    const repaired = await repairToolCall({
+      error: buildInvalidToolInputError("web_search", "2026"),
+      inputSchema: async () => ({
+        additionalProperties: false,
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+        type: "object",
+      }),
+      messages: [],
+      system: undefined,
+      toolCall: {
+        input: "2026",
+        providerExecuted: true,
+        toolCallId: "tool-3",
+        toolName: "web_search",
+        type: "tool-call",
+      },
+      tools: {},
+    });
+
+    assertEquals(repaired, {
+      input: JSON.stringify({ query: "2026" }),
+      providerExecuted: true,
+      toolCallId: "tool-3",
+      toolName: "web_search",
+      type: "tool-call",
+    });
+  });
+
+  it("returns null for client-executed tools named web_search", async () => {
+    const repaired = await repairToolCall({
+      error: buildInvalidToolInputError("web_search", "Veryfront"),
+      inputSchema: async () => ({
+        additionalProperties: false,
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+        type: "object",
+      }),
+      messages: [],
+      system: undefined,
+      toolCall: {
+        input: "Veryfront",
+        providerExecuted: false,
+        toolCallId: "tool-4",
+        toolName: "web_search",
+        type: "tool-call",
+      },
+      tools: {},
+    });
+
+    assertEquals(repaired, null);
   });
 
   it("returns null for unsupported tools", async () => {
@@ -84,8 +142,8 @@ describe("repair-tool-call", () => {
       system: undefined,
       toolCall: {
         input: "README.md",
-        providerExecuted: undefined,
-        toolCallId: "tool-3",
+        providerExecuted: true,
+        toolCallId: "tool-5",
         toolName: "create_file",
         type: "tool-call",
       },

--- a/src/agent/runtime/repair-tool-call.test.ts
+++ b/src/agent/runtime/repair-tool-call.test.ts
@@ -46,7 +46,7 @@ describe("repair-tool-call", () => {
 
   it("repairs JSON string literal web_search input into the expected object shape", async () => {
     const repaired = await repairToolCall({
-      error: buildInvalidToolInputError("web_search", "\"Veryfront\""),
+      error: buildInvalidToolInputError("web_search", '"Veryfront"'),
       inputSchema: async () => ({
         additionalProperties: false,
         properties: {
@@ -58,7 +58,7 @@ describe("repair-tool-call", () => {
       messages: [],
       system: undefined,
       toolCall: {
-        input: "\"Veryfront\"",
+        input: '"Veryfront"',
         providerExecuted: undefined,
         toolCallId: "tool-2",
         toolName: "web_search",

--- a/src/agent/runtime/repair-tool-call.test.ts
+++ b/src/agent/runtime/repair-tool-call.test.ts
@@ -1,0 +1,97 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { InvalidToolInputError } from "ai";
+import { repairToolCall } from "./repair-tool-call.ts";
+
+function buildInvalidToolInputError(toolName: string, toolInput: string): InvalidToolInputError {
+  return new InvalidToolInputError({
+    cause: new Error("Expected object, received string"),
+    toolInput,
+    toolName,
+  });
+}
+
+describe("repair-tool-call", () => {
+  it("repairs raw string web_search input into the expected object shape", async () => {
+    const repaired = await repairToolCall({
+      error: buildInvalidToolInputError("web_search", "Veryfront"),
+      inputSchema: async () => ({
+        additionalProperties: false,
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+        type: "object",
+      }),
+      messages: [],
+      system: undefined,
+      toolCall: {
+        input: "Veryfront",
+        providerExecuted: undefined,
+        toolCallId: "tool-1",
+        toolName: "web_search",
+        type: "tool-call",
+      },
+      tools: {},
+    });
+
+    assertEquals(repaired, {
+      input: JSON.stringify({ query: "Veryfront" }),
+      providerExecuted: undefined,
+      toolCallId: "tool-1",
+      toolName: "web_search",
+      type: "tool-call",
+    });
+  });
+
+  it("repairs JSON string literal web_search input into the expected object shape", async () => {
+    const repaired = await repairToolCall({
+      error: buildInvalidToolInputError("web_search", "\"Veryfront\""),
+      inputSchema: async () => ({
+        additionalProperties: false,
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+        type: "object",
+      }),
+      messages: [],
+      system: undefined,
+      toolCall: {
+        input: "\"Veryfront\"",
+        providerExecuted: undefined,
+        toolCallId: "tool-2",
+        toolName: "web_search",
+        type: "tool-call",
+      },
+      tools: {},
+    });
+
+    assertEquals(repaired, {
+      input: JSON.stringify({ query: "Veryfront" }),
+      providerExecuted: undefined,
+      toolCallId: "tool-2",
+      toolName: "web_search",
+      type: "tool-call",
+    });
+  });
+
+  it("returns null for unsupported tools", async () => {
+    const repaired = await repairToolCall({
+      error: buildInvalidToolInputError("create_file", "README.md"),
+      inputSchema: async () => ({ type: "object" }),
+      messages: [],
+      system: undefined,
+      toolCall: {
+        input: "README.md",
+        providerExecuted: undefined,
+        toolCallId: "tool-3",
+        toolName: "create_file",
+        type: "tool-call",
+      },
+      tools: {},
+    });
+
+    assertEquals(repaired, null);
+  });
+});

--- a/src/agent/runtime/repair-tool-call.ts
+++ b/src/agent/runtime/repair-tool-call.ts
@@ -1,0 +1,52 @@
+import {
+  InvalidToolInputError,
+  NoSuchToolError,
+  type ToolCallRepairFunction,
+  type ToolSet,
+} from "ai";
+
+const REPAIRABLE_PROVIDER_TOOL_NAMES = new Set(["web_search"]);
+
+export const repairToolCall: ToolCallRepairFunction<ToolSet> = async ({
+  toolCall,
+  error,
+}) => {
+  if (NoSuchToolError.isInstance(error)) {
+    return null;
+  }
+
+  if (!REPAIRABLE_PROVIDER_TOOL_NAMES.has(toolCall.toolName)) {
+    return null;
+  }
+
+  if (!InvalidToolInputError.isInstance(error) || typeof toolCall.input !== "string") {
+    return null;
+  }
+
+  const trimmedInput = toolCall.input.trim();
+  if (trimmedInput.length === 0) {
+    return null;
+  }
+
+  let normalizedQuery = trimmedInput;
+
+  try {
+    const parsedInput = JSON.parse(trimmedInput) as unknown;
+    if (typeof parsedInput === "string") {
+      normalizedQuery = parsedInput.trim();
+    } else {
+      return null;
+    }
+  } catch {
+    // Raw string input is also repairable for provider-native web_search.
+  }
+
+  if (normalizedQuery.length === 0) {
+    return null;
+  }
+
+  return {
+    ...toolCall,
+    input: JSON.stringify({ query: normalizedQuery }),
+  };
+};

--- a/src/agent/runtime/repair-tool-call.ts
+++ b/src/agent/runtime/repair-tool-call.ts
@@ -19,6 +19,10 @@ export const repairToolCall: ToolCallRepairFunction<ToolSet> = async ({
     return null;
   }
 
+  if (toolCall.providerExecuted !== true) {
+    return null;
+  }
+
   if (!InvalidToolInputError.isInstance(error) || typeof toolCall.input !== "string") {
     return null;
   }
@@ -34,8 +38,6 @@ export const repairToolCall: ToolCallRepairFunction<ToolSet> = async ({
     const parsedInput = JSON.parse(trimmedInput) as unknown;
     if (typeof parsedInput === "string") {
       normalizedQuery = parsedInput.trim();
-    } else {
-      return null;
     }
   } catch {
     // Raw string input is also repairable for provider-native web_search.

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.136";
+export const VERSION = "0.1.137";


### PR DESCRIPTION
## Summary
- add a runtime repair hook for provider-native `web_search` when the AI SDK delivers a bare string or JSON string literal
- install that repair hook on both `generateText()` and `streamText()` in the veryfront runtime
- bump the patch version to `0.1.137` and sync the runtime version constant

## Verification
- deno test --allow-all src/agent/runtime/repair-tool-call.test.ts src/agent/runtime/model-tool-converter.test.ts
- deno check src/agent/runtime/index.ts
- deno test --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/agent/runtime/repair-tool-call.test.ts src/agent/runtime/model-tool-converter.test.ts
- full pre-push checks passed

## Context
Staging repro for veryfront-studio#1239 is executing on `veryfront-server` and still persisted `web_search` tool_result errors with `Expected object, received string` after the agent-side fix. This targets the actual runtime boundary handling provider-native web search.