### PR TITLE
fix(runtime): preserve provider web tool stream metadata

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/runtime/ai-stream-handler.test.ts
+++ b/src/agent/runtime/ai-stream-handler.test.ts
@@ -214,6 +214,34 @@ describe("ai-stream-handler", () => {
       });
     });
 
+    it("preserves provider-executed tool calls in stream state and SSE output", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        {
+          type: "tool-call",
+          toolCallId: "tc-provider",
+          toolName: "web_search",
+          input: { query: "Veryfront" },
+          providerExecuted: true,
+        },
+        { type: "finish", finishReason: "tool-calls", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      const tc = state.toolCalls.get("tc-provider")!;
+      assertEquals(tc.providerExecuted, true);
+      assertEquals(events[0], {
+        type: "tool-input-available",
+        toolCallId: "tc-provider",
+        toolName: "web_search",
+        input: { query: "Veryfront" },
+        providerExecuted: true,
+      });
+    });
+
     it("handles multiple tool calls in a single stream", async () => {
       const { events, controller, encoder } = createSSECollector();
       const state = createStreamState();
@@ -279,6 +307,32 @@ describe("ai-stream-handler", () => {
         type: "tool-output-error",
         toolCallId: "tc-web",
         errorText: '{"error":"Search failed"}',
+      });
+    });
+
+    it("forwards tool-error parts as tool-output-error SSE events", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        {
+          type: "tool-error",
+          toolCallId: "tc-provider-error",
+          toolName: "web_search",
+          input: { query: "Veryfront" },
+          error: "Expected object, received string",
+          providerExecuted: true,
+        },
+        { type: "finish", finishReason: "error", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      assertEquals(events[0], {
+        type: "tool-output-error",
+        toolCallId: "tc-provider-error",
+        errorText: "Expected object, received string",
+        providerExecuted: true,
       });
     });
 

--- a/src/agent/runtime/ai-stream-handler.ts
+++ b/src/agent/runtime/ai-stream-handler.ts
@@ -20,6 +20,8 @@ export interface StreamingToolCall {
   id: string;
   name: string;
   arguments: string;
+  providerExecuted?: boolean;
+  dynamic?: boolean;
 }
 
 export interface AIStreamState {
@@ -153,6 +155,8 @@ export function processStream(
             id: toolId,
             name: part.toolName,
             arguments: "",
+            providerExecuted: "providerExecuted" in part ? part.providerExecuted : undefined,
+            dynamic: "dynamic" in part ? part.dynamic : undefined,
           });
 
           const dynamic = isDynamicTool(part.toolName);
@@ -187,6 +191,8 @@ export function processStream(
             id: toolId,
             name: part.toolName,
             arguments: inputStr,
+            providerExecuted: "providerExecuted" in part ? part.providerExecuted : undefined,
+            dynamic: "dynamic" in part ? part.dynamic : undefined,
           });
 
           const dynamic = isDynamicTool(part.toolName);
@@ -196,6 +202,9 @@ export function processStream(
             toolCallId: toolId,
             toolName: part.toolName,
             input: inputObj,
+            ...("providerExecuted" in part && part.providerExecuted !== undefined
+              ? { providerExecuted: part.providerExecuted }
+              : {}),
             ...(dynamic ? { dynamic: true } : {}),
           });
           break;
@@ -207,7 +216,11 @@ export function processStream(
             sendSSE(controller, encoder, {
               type: "tool-output-error",
               toolCallId: part.toolCallId,
-              errorText: stringifyToolError(part.output),
+              errorText: stringifyToolError("output" in part ? part.output : undefined),
+              ...("providerExecuted" in part && part.providerExecuted !== undefined
+                ? { providerExecuted: part.providerExecuted }
+                : {}),
+              ...("dynamic" in part && part.dynamic ? { dynamic: true } : {}),
             });
             break;
           }
@@ -216,6 +229,26 @@ export function processStream(
             type: "tool-output-available",
             toolCallId: part.toolCallId,
             output: part.output,
+            ...("providerExecuted" in part && part.providerExecuted !== undefined
+              ? { providerExecuted: part.providerExecuted }
+              : {}),
+            ...("dynamic" in part && part.dynamic ? { dynamic: true } : {}),
+            ...("preliminary" in part && part.preliminary !== undefined
+              ? { preliminary: part.preliminary }
+              : {}),
+          });
+          break;
+        }
+
+        case "tool-error": {
+          sendSSE(controller, encoder, {
+            type: "tool-output-error",
+            toolCallId: part.toolCallId,
+            errorText: stringifyToolError(part.error),
+            ...("providerExecuted" in part && part.providerExecuted !== undefined
+              ? { providerExecuted: part.providerExecuted }
+              : {}),
+            ...("dynamic" in part && part.dynamic ? { dynamic: true } : {}),
           });
           break;
         }

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -768,6 +768,10 @@ export class AgentRuntime {
         const { args, error: argError } = parseToolArgs(tc.arguments);
         const toolCall: ToolCall = { id: tc.id, name: tc.name, args, status: "pending" };
 
+        if (tc.providerExecuted === true) {
+          continue;
+        }
+
         if (argError) {
           logger.warn("Invalid streamed tool arguments", {
             toolCallId: tc.id,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.137";
+export const VERSION = "0.1.138";


### PR DESCRIPTION
## Summary
- preserve provider-executed metadata on streamed tool calls
- forward real AI SDK `tool-error` chunks to the data stream protocol
- skip local tool execution for provider-executed tool calls in the streaming runtime
- bump version to 0.1.138 to trigger deployment

## Testing
- deno test --allow-all src/agent/runtime/ai-stream-handler.test.ts
- deno check src/agent/runtime/index.ts
- repo pre-push checks (format, lint, typecheck, unit tests)

Refs veryfront-studio#1239