### PR TITLE
debug(runtime): instrument provider web tool stream payloads

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.139",
+  "version": "0.1.140",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/runtime/ai-stream-handler.ts
+++ b/src/agent/runtime/ai-stream-handler.ts
@@ -12,7 +12,9 @@ import type { StreamTextResult, ToolSet } from "ai";
 import { sendSSE } from "./sse-utils.ts";
 import { isDynamicTool } from "./tool-helpers.ts";
 import { serverLogger } from "#veryfront/utils";
+import { isAnyDebugEnabled } from "#veryfront/utils/constants/env.ts";
 import { setActiveSpanAttributes, withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 const logger = serverLogger.component("agent");
 
@@ -113,6 +115,65 @@ function stringifyToolError(output: unknown): string {
   } catch {
     return String(output);
   }
+}
+
+function summarizeDebugValue(value: unknown): unknown {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+    };
+  }
+
+  if (typeof value === "string") {
+    return value.length > 500 ? `${value.slice(0, 500)}…` : value;
+  }
+
+  return value;
+}
+
+function logProviderToolPart(
+  partType: "tool-result" | "tool-error",
+  part: {
+    toolCallId: string;
+    toolName: string;
+    providerExecuted?: boolean;
+    dynamic?: boolean;
+    output?: unknown;
+    error?: unknown;
+    input?: unknown;
+    preliminary?: boolean;
+    isError?: boolean;
+  },
+): void {
+  if (!isAnyDebugEnabled({ get: getHostEnv })) {
+    return;
+  }
+
+  if (part.providerExecuted !== true) {
+    return;
+  }
+
+  if (part.toolName !== "web_search" && part.toolName !== "web_fetch") {
+    return;
+  }
+
+  logger.debug("Provider tool stream part observed", {
+    partType,
+    toolCallId: part.toolCallId,
+    toolName: part.toolName,
+    providerExecuted: part.providerExecuted,
+    dynamic: part.dynamic,
+    preliminary: part.preliminary,
+    isError: part.isError,
+    outputType: typeof part.output,
+    errorType: typeof part.error,
+    inputType: typeof part.input,
+    output: summarizeDebugValue(part.output),
+    error: summarizeDebugValue(part.error),
+    input: summarizeDebugValue(part.input),
+  });
 }
 
 export function createStreamState(): AIStreamState {
@@ -228,6 +289,16 @@ export function processStream(
 
         case "tool-result": {
           const isError = "isError" in part && part.isError === true;
+          logProviderToolPart("tool-result", {
+            toolCallId: part.toolCallId,
+            toolName: part.toolName,
+            providerExecuted: "providerExecuted" in part ? part.providerExecuted : undefined,
+            dynamic: "dynamic" in part ? part.dynamic : undefined,
+            output: part.output,
+            input: "input" in part ? part.input : undefined,
+            preliminary: "preliminary" in part ? part.preliminary : undefined,
+            isError,
+          });
           if (isError) {
             state.toolResults.push({
               toolCallId: part.toolCallId,
@@ -278,6 +349,14 @@ export function processStream(
         }
 
         case "tool-error": {
+          logProviderToolPart("tool-error", {
+            toolCallId: part.toolCallId,
+            toolName: part.toolName,
+            providerExecuted: "providerExecuted" in part ? part.providerExecuted : undefined,
+            dynamic: "dynamic" in part ? part.dynamic : undefined,
+            error: part.error,
+            input: "input" in part ? part.input : undefined,
+          });
           state.toolResults.push({
             toolCallId: part.toolCallId,
             toolName: part.toolName,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.139";
+export const VERSION = "0.1.140";


### PR DESCRIPTION
## Summary
- instrument provider-executed `web_search` and `web_fetch` stream parts in the runtime
- log raw provider tool `input`, `output`, and `error` shapes for `tool-result` and `tool-error`
- bump version to `0.1.140` to force staging deployment for log capture

## Testing
- `deno test --allow-all src/agent/runtime/ai-stream-handler.test.ts`
- `deno check src/agent/runtime/index.ts`
- full repo pre-push checks

Refs veryfront-studio#1239