### PR TITLE
Log internal agent stream lifecycle

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -16,8 +16,10 @@ import {
 } from "./ag-ui-sse.ts";
 import { AgentRunCancelledError, type AgentRunSessionManager } from "./session-manager.ts";
 import type { RuntimeRunAgentInput } from "./schema.ts";
+import { serverLogger } from "#veryfront/utils";
 
 const anyObjectSchema = z.record(z.string(), z.unknown());
+const logger = serverLogger.component("internal-agent-run-stream");
 
 type RuntimeFilteredAgent = Agent & {
   config: Agent["config"] & {
@@ -229,6 +231,14 @@ export async function createRuntimeAgentStreamResponse(
   agent: Agent,
   deps: RuntimeAgentStreamExecutionDeps,
 ): Promise<Response> {
+  logger.info("Starting internal agent runtime stream", {
+    runId: input.runId,
+    threadId: input.threadId,
+    agentId: input.agentId,
+    messageCount: input.messages.length,
+    toolCount: input.tools.length,
+    contextCount: input.context.length,
+  });
   const abortSignal = deps.sessionManager.startRun({
     runId: input.runId,
     threadId: input.threadId,
@@ -271,8 +281,19 @@ export async function createRuntimeAgentStreamResponse(
       undefined,
       abortSignal,
     );
+    logger.info("Internal agent runtime stream attached", {
+      runId: input.runId,
+      threadId: input.threadId,
+      agentId: input.agentId,
+    });
   } catch (error) {
     deps.sessionManager.failRun(input.runId);
+    logger.error("Internal agent runtime stream setup failed", {
+      runId: input.runId,
+      threadId: input.threadId,
+      agentId: input.agentId,
+      error: error instanceof Error ? error.message : String(error),
+    });
     throw error;
   }
 
@@ -305,6 +326,11 @@ export async function createRuntimeAgentStreamResponse(
 
       const abortHandler = () => {
         aborted = true;
+        logger.warn("Internal agent runtime stream aborted", {
+          runId: input.runId,
+          threadId: input.threadId,
+          agentId: input.agentId,
+        });
         reader.cancel(new AgentRunCancelledError()).catch(() => {});
       };
 
@@ -323,6 +349,11 @@ export async function createRuntimeAgentStreamResponse(
           throwIfAborted();
 
           if (done) {
+            logger.info("Internal agent runtime stream reader completed", {
+              runId: input.runId,
+              threadId: input.threadId,
+              agentId: input.agentId,
+            });
             break;
           }
 
@@ -352,15 +383,35 @@ export async function createRuntimeAgentStreamResponse(
           enqueueIfAttached(mappedEvent.event, mappedEvent.payload);
         }
         deps.sessionManager.completeRun(input.runId);
+        logger.info("Internal agent runtime stream finalized", {
+          runId: input.runId,
+          threadId: input.threadId,
+          agentId: input.agentId,
+          sawVisibleOutput: state.sawVisibleOutput,
+          sawTerminalError: state.sawTerminalError,
+          finishReason: state.metadata.finishReason,
+        });
       } catch (error) {
         if (error instanceof AgentRunCancelledError) {
           deps.sessionManager.cancelRun(input.runId);
+          logger.warn("Internal agent runtime stream cancelled", {
+            runId: input.runId,
+            threadId: input.threadId,
+            agentId: input.agentId,
+            error: error.message,
+          });
           enqueueIfAttached("RunError", {
             code: "CANCELLED",
             message: error.message,
           });
         } else {
           deps.sessionManager.failRun(input.runId);
+          logger.error("Internal agent runtime stream failed", {
+            runId: input.runId,
+            threadId: input.threadId,
+            agentId: input.agentId,
+            error: error instanceof Error ? error.message : String(error),
+          });
           enqueueIfAttached("RunError", {
             code: "RUNTIME_ERROR",
             message: error instanceof Error ? error.message : String(error),
@@ -371,10 +422,21 @@ export async function createRuntimeAgentStreamResponse(
         if (clientAttached) {
           controller.close();
         }
+        logger.debug("Internal agent runtime stream response closed", {
+          runId: input.runId,
+          threadId: input.threadId,
+          agentId: input.agentId,
+          clientAttached,
+        });
       }
     },
     cancel() {
       clientAttached = false;
+      logger.info("Internal agent runtime client detached", {
+        runId: input.runId,
+        threadId: input.threadId,
+        agentId: input.agentId,
+      });
       return Promise.resolve();
     },
   });

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -30,6 +30,7 @@ import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
+import { serverLogger } from "#veryfront/utils";
 
 export interface AgentStreamHandlerDeps
   extends RuntimeAgentDiscoveryDeps, RuntimeAgentStreamExecutionDeps {
@@ -41,6 +42,7 @@ const defaultDeps: AgentStreamHandlerDeps = {
   sessionManager: agentRunSessionManager,
   resolveRuntimeOwnerInvokeUrl,
 };
+const logger = serverLogger.component("agent-stream-handler");
 
 type SourceContextFsWrapper = {
   isMultiProjectMode?: () => boolean;
@@ -164,6 +166,16 @@ export class AgentStreamHandler extends BaseHandler {
           expectedSubject: payload.runId,
           expectedSurface: "studio",
         });
+        logger.info("Accepted internal agent stream request", {
+          runId: payload.runId,
+          threadId: payload.threadId,
+          agentId: payload.agentId,
+          projectId: ctx.projectId,
+          projectSlug: ctx.projectSlug,
+          messageCount: payload.messages.length,
+          toolCount: payload.tools.length,
+          hasAgentSource: Boolean(payload.agentSource),
+        });
 
         return await this.withAgentSourceContext(
           ctx,
@@ -173,6 +185,12 @@ export class AgentStreamHandler extends BaseHandler {
 
             const agent = this.deps.getAgent(payload.agentId);
             if (!agent) {
+              logger.warn("Internal agent stream request referenced unknown agent", {
+                runId: payload.runId,
+                agentId: payload.agentId,
+                projectId: ctx.projectId,
+                projectSlug: ctx.projectSlug,
+              });
               return this.respond(builder.json({ error: "Agent not found" }, 404));
             }
 
@@ -181,6 +199,13 @@ export class AgentStreamHandler extends BaseHandler {
               agent as Agent,
               this.deps,
             );
+            logger.info("Internal agent stream response created", {
+              runId: payload.runId,
+              threadId: payload.threadId,
+              agentId: payload.agentId,
+              projectId: ctx.projectId,
+              projectSlug: ctx.projectSlug,
+            });
             const runtimeOwnerInvokeUrl = await this.deps.resolveRuntimeOwnerInvokeUrl?.(req) ??
               null;
             const responseWithOwner = runtimeOwnerInvokeUrl
@@ -222,6 +247,11 @@ export class AgentStreamHandler extends BaseHandler {
           error: error instanceof Error ? error.message : String(error),
           projectId: ctx.projectId,
           projectSlug: ctx.projectSlug,
+        });
+        logger.error("Internal agent stream handler failed", {
+          projectId: ctx.projectId,
+          projectSlug: ctx.projectSlug,
+          error: error instanceof Error ? error.message : String(error),
         });
         return this.respond(builder.json({ error: "Internal agent stream failed" }, 500));
       }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.140";
+export const VERSION = "0.1.141";


### PR DESCRIPTION
## Summary
- add run-scoped logs around internal agent stream request acceptance and response creation
- add lifecycle logs for runtime stream attach, reader completion, finalization, cancellation, and failure
- bump version to 0.1.141 for deployment

## Testing
- deno test --allow-all src/server/handlers/request/agent-stream.handler.test.ts src/agent/runtime/ai-stream-handler.test.ts
- deno check src/server/handlers/request/agent-stream.handler.ts

## Context
This is targeted instrumentation for the staging `veryfront-studio#1239` repro, which now hangs with the project-agent run stuck in `running`/`streaming` after the earlier web_search shape fix.