### PR TITLE
Fail fast when configured tool ids drift from canonical names

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -406,7 +406,7 @@ export class AgentRuntime {
           logger.error("Agent stream error", { error });
           sendSSE(controller, encoder, {
             type: "error",
-            error: "An internal error occurred",
+            error: error instanceof Error ? error.message : String(error),
           });
           closeSSEStream(controller);
         } finally {

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -175,7 +175,34 @@ describe("tool-helpers", () => {
   });
 
   describe("getAvailableTools", () => {
+    it("fails loudly when an explicit configured tool name does not match a discovered tool id", async () => {
+      toolRegistry.clearAll();
+
+      toolRegistry.register(
+        "roll-dice",
+        tool({
+          id: "roll-dice",
+          description: "Roll a die",
+          inputSchema: z.object({}),
+          execute: async () => ({ total: 4 }),
+        }),
+      );
+
+      await assertRejects(
+        () =>
+          getAvailableTools(
+            {
+              rollDice: true,
+            },
+            { includeIntegrationTools: false },
+          ),
+        Error,
+        'Unknown tool reference: rollDice. Tool names must exactly match tool({ id: "..." }). Available tools: roll-dice',
+      );
+    });
+
     it("filters remote integration tool definitions by the runtime allowlist", async () => {
+      toolRegistry.clearAll();
       const originalFetch = globalThis.fetch;
       const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_URL");
       const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
@@ -205,6 +232,7 @@ describe("tool-helpers", () => {
 
         assertEquals(defs.map((def) => def.name), ["gmail:get-email"]);
       } finally {
+        toolRegistry.clearAll();
         if (originalApiBaseUrl === undefined) Deno.env.delete("VERYFRONT_API_URL");
         else Deno.env.set("VERYFRONT_API_URL", originalApiBaseUrl);
         if (originalApiToken === undefined) Deno.env.delete("VERYFRONT_API_TOKEN");

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -9,6 +9,35 @@ import {
   resolveConfiguredTool,
 } from "./tool-helpers.ts";
 
+async function withMockRemoteIntegrationTools<T>(
+  remoteToolNames: string[],
+  callback: () => Promise<T>,
+): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_URL");
+  const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+  globalThis.fetch = async () =>
+    Response.json({
+      tools: remoteToolNames.map((name) => ({
+        name,
+        description: `${name} description`,
+        inputSchema: { type: "object", properties: {} },
+      })),
+    });
+
+  try {
+    Deno.env.set("VERYFRONT_API_URL", "https://api.test");
+    Deno.env.set("VERYFRONT_API_TOKEN", "token");
+    return await callback();
+  } finally {
+    if (originalApiBaseUrl === undefined) Deno.env.delete("VERYFRONT_API_URL");
+    else Deno.env.set("VERYFRONT_API_URL", originalApiBaseUrl);
+    if (originalApiToken === undefined) Deno.env.delete("VERYFRONT_API_TOKEN");
+    else Deno.env.set("VERYFRONT_API_TOKEN", originalApiToken);
+    globalThis.fetch = originalFetch;
+  }
+}
+
 describe("tool-helpers", () => {
   describe("parseToolArgs", () => {
     it("parses a valid JSON string into args", () => {
@@ -203,41 +232,60 @@ describe("tool-helpers", () => {
 
     it("filters remote integration tool definitions by the runtime allowlist", async () => {
       toolRegistry.clearAll();
-      const originalFetch = globalThis.fetch;
-      const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_URL");
-      const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
-      globalThis.fetch = async () =>
-        Response.json({
-          tools: [
-            {
-              name: "gmail:list-emails",
-              description: "List emails",
-              inputSchema: { type: "object", properties: {} },
-            },
-            {
-              name: "gmail:get-email",
-              description: "Get email",
-              inputSchema: { type: "object", properties: {} },
-            },
-          ],
-        });
-
       try {
-        Deno.env.set("VERYFRONT_API_URL", "https://api.test");
-        Deno.env.set("VERYFRONT_API_TOKEN", "token");
-
-        const defs = await getAvailableTools(true, {
-          allowedRemoteToolNames: ["gmail:get-email"],
-        });
+        const defs = await withMockRemoteIntegrationTools([
+          "gmail:list-emails",
+          "gmail:get-email",
+        ], () =>
+          getAvailableTools(true, {
+            allowedRemoteToolNames: ["gmail:get-email"],
+          }));
 
         assertEquals(defs.map((def) => def.name), ["gmail:get-email"]);
       } finally {
         toolRegistry.clearAll();
-        if (originalApiBaseUrl === undefined) Deno.env.delete("VERYFRONT_API_URL");
-        else Deno.env.set("VERYFRONT_API_URL", originalApiBaseUrl);
-        if (originalApiToken === undefined) Deno.env.delete("VERYFRONT_API_TOKEN");
-        else Deno.env.set("VERYFRONT_API_TOKEN", originalApiToken);
-        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("fails loudly when an explicit remote tool is missing from the discovered allowlist", async () => {
+      toolRegistry.clearAll();
+
+      try {
+        await assertRejects(
+          () =>
+            withMockRemoteIntegrationTools(["gmail:list-emails"], () =>
+              getAvailableTools(
+                {
+                  "gmail:get-email": true,
+                },
+                { allowedRemoteToolNames: ["gmail:list-emails"] },
+              )),
+          Error,
+          'Unknown tool reference: gmail:get-email. Tool names must exactly match tool({ id: "..." }). Available tools: gmail:list-emails',
+        );
+      } finally {
+        toolRegistry.clearAll();
+      }
+    });
+
+    it("only appends explicitly requested remote definitions for explicit tool maps", async () => {
+      toolRegistry.clearAll();
+
+      try {
+        const defs = await withMockRemoteIntegrationTools([
+          "gmail:list-emails",
+          "gmail:get-email",
+        ], () =>
+          getAvailableTools(
+            {
+              "gmail:get-email": true,
+            },
+            { allowedRemoteToolNames: ["gmail:list-emails", "gmail:get-email"] },
+          ));
+
+        assertEquals(defs.map((def) => def.name), ["gmail:get-email"]);
+      } finally {
+        toolRegistry.clearAll();
       }
     });
   });

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -238,6 +238,7 @@ export async function getAvailableTools(
   const tools: ToolDefinition[] = [];
   const remoteDefs = await getRemoteToolDefinitions(options);
   const remoteToolNames = new Set(remoteDefs.map((def) => def.name));
+  const explicitlyRequestedRemoteToolNames = new Set<string>();
   const unresolvedConfiguredToolNames: string[] = [];
 
   for (const [name, entry] of Object.entries(toolsConfig)) {
@@ -248,9 +249,12 @@ export async function getAvailableTools(
         continue;
       }
 
-      if (!remoteToolNames.has(name) && !isRemoteIntegrationTool(name)) {
-        unresolvedConfiguredToolNames.push(name);
+      if (remoteToolNames.has(name)) {
+        explicitlyRequestedRemoteToolNames.add(name);
+        continue;
       }
+
+      unresolvedConfiguredToolNames.push(name);
       continue;
     }
 
@@ -259,10 +263,14 @@ export async function getAvailableTools(
     }
   }
 
-  // Also append remote integration tools for explicit-object configs.
-  // The internal streaming path converts `tools: true` to an explicit object
-  // from the local registry, so remote tools would be missed without this.
-  for (const def of remoteDefs) {
+  // Explicit-object configs should only expose remote definitions that were
+  // explicitly requested, except for the internal runtime path that expands
+  // `tools: true` into an explicit local-tool map and passes the remote allowlist.
+  const remoteDefsToAppend = explicitlyRequestedRemoteToolNames.size > 0
+    ? remoteDefs.filter((def) => explicitlyRequestedRemoteToolNames.has(def.name))
+    : remoteDefs.filter((def) => options?.allowedRemoteToolNames?.includes(def.name));
+
+  for (const def of remoteDefsToAppend) {
     // Skip if already present (e.g., explicitly configured by name)
     if (!tools.some((t) => t.name === def.name)) {
       logToolDefinition(def.name, def);

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -11,6 +11,7 @@ import { executeTool, toolRegistry } from "#veryfront/tool";
 import { toolToProviderDefinition } from "#veryfront/tool/registry.ts";
 import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
 import { serverLogger } from "#veryfront/utils";
+import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import {
   executeRemoteIntegrationTool,
   isRemoteIntegrationTool,
@@ -70,6 +71,52 @@ export function isDynamicTool(name: string): boolean {
  */
 // deno-lint-ignore no-explicit-any -- generic erasure: accepts Tool with any input/output types
 export type ToolConfigEntry = Tool<any, any> | boolean;
+
+function formatAvailableToolNames(names: Iterable<string>): string {
+  const sorted = [...new Set(names)].sort();
+  return sorted.length > 0 ? sorted.join(", ") : "(none)";
+}
+
+function throwUnknownConfiguredToolsError(
+  unknownToolNames: string[],
+  availableLocalToolNames: Iterable<string>,
+  availableRemoteToolNames: Iterable<string>,
+): never {
+  const unknownList = unknownToolNames.sort().join(", ");
+  const availableNames = formatAvailableToolNames([
+    ...availableLocalToolNames,
+    ...availableRemoteToolNames,
+  ]);
+
+  throw toError(
+    createError({
+      type: "agent",
+      message:
+        `Unknown tool reference${unknownToolNames.length === 1 ? "" : "s"}: ${unknownList}. ` +
+        `Tool names must exactly match tool({ id: "..." }). Available tools: ${availableNames}`,
+    }),
+  );
+}
+
+async function getRemoteToolDefinitions(options?: {
+  includeIntegrationTools?: boolean;
+  allowedRemoteToolNames?: string[];
+}): Promise<ToolDefinition[]> {
+  if (options?.includeIntegrationTools === false) {
+    return [];
+  }
+
+  try {
+    const { getRemoteIntegrationToolDefinitions } = await import(
+      "#veryfront/integrations/remote-tools.ts"
+    );
+    return (await getRemoteIntegrationToolDefinitions()).filter((def) =>
+      !options?.allowedRemoteToolNames || options.allowedRemoteToolNames.includes(def.name)
+    );
+  } catch {
+    return [];
+  }
+}
 
 export function resolveConfiguredTool(
   toolsConfig: true | Record<string, ToolConfigEntry> | undefined,
@@ -179,32 +226,31 @@ export async function getAvailableTools(
     });
 
     // Append remote integration tools (per-request, project-scoped)
-    if (options?.includeIntegrationTools !== false) {
-      try {
-        const { getRemoteIntegrationToolDefinitions } = await import(
-          "#veryfront/integrations/remote-tools.ts"
-        );
-        const remoteDefs = (await getRemoteIntegrationToolDefinitions()).filter((def) =>
-          !options?.allowedRemoteToolNames || options.allowedRemoteToolNames.includes(def.name)
-        );
-        for (const def of remoteDefs) {
-          logToolDefinition(def.name, def);
-        }
-        tools.push(...remoteDefs);
-      } catch {
-        // Integration tools unavailable — non-fatal
-      }
+    const remoteDefs = await getRemoteToolDefinitions(options);
+    for (const def of remoteDefs) {
+      logToolDefinition(def.name, def);
     }
+    tools.push(...remoteDefs);
 
     return tools;
   }
 
   const tools: ToolDefinition[] = [];
+  const remoteDefs = await getRemoteToolDefinitions(options);
+  const remoteToolNames = new Set(remoteDefs.map((def) => def.name));
+  const unresolvedConfiguredToolNames: string[] = [];
 
   for (const [name, entry] of Object.entries(toolsConfig)) {
     if (entry === true) {
       const tool = toolRegistry.get(name);
-      if (tool) addToolDefinition(tools, name, tool);
+      if (tool) {
+        addToolDefinition(tools, name, tool);
+        continue;
+      }
+
+      if (!remoteToolNames.has(name) && !isRemoteIntegrationTool(name)) {
+        unresolvedConfiguredToolNames.push(name);
+      }
       continue;
     }
 
@@ -216,24 +262,20 @@ export async function getAvailableTools(
   // Also append remote integration tools for explicit-object configs.
   // The internal streaming path converts `tools: true` to an explicit object
   // from the local registry, so remote tools would be missed without this.
-  if (options?.includeIntegrationTools !== false) {
-    try {
-      const { getRemoteIntegrationToolDefinitions } = await import(
-        "#veryfront/integrations/remote-tools.ts"
-      );
-      const remoteDefs = (await getRemoteIntegrationToolDefinitions()).filter((def) =>
-        !options?.allowedRemoteToolNames || options.allowedRemoteToolNames.includes(def.name)
-      );
-      for (const def of remoteDefs) {
-        // Skip if already present (e.g., explicitly configured by name)
-        if (!tools.some((t) => t.name === def.name)) {
-          logToolDefinition(def.name, def);
-          tools.push(def);
-        }
-      }
-    } catch {
-      // Integration tools unavailable — non-fatal
+  for (const def of remoteDefs) {
+    // Skip if already present (e.g., explicitly configured by name)
+    if (!tools.some((t) => t.name === def.name)) {
+      logToolDefinition(def.name, def);
+      tools.push(def);
     }
+  }
+
+  if (unresolvedConfiguredToolNames.length > 0) {
+    throwUnknownConfiguredToolsError(
+      unresolvedConfiguredToolNames,
+      toolRegistry.getAll().keys(),
+      remoteToolNames,
+    );
   }
 
   return tools;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.141";
+export const VERSION = "0.1.142";


### PR DESCRIPTION
## Summary
- fail fast when an explicit configured tool name does not resolve to a discovered or allowed tool
- surface the real runtime error in the internal agent stream instead of a generic internal error
- bump the patch version in `deno.json` to `0.1.142`

## Problem
A staging investigation showed a hidden failure mode in project-agent runs:
- the runtime loaded `tools/roll-dice.ts` and registered `roll-dice`
- a child run was allowlisted with `allowedTools: ["rollDice"]`
- the unresolved name was silently omitted from the runtime toolset
- the model then emitted fake `<tool_call>` / `<tool_response>` text as plain assistant output
- there were `0` real `TOOL_CALL_*` events and no `console.log("rolling dice...")` output

This produced a plausible-looking answer without any real tool execution.

## What changed
- `getAvailableTools()` now throws when explicit configured tool names do not resolve, instead of silently dropping them
- the error lists the unresolved name and the currently available tool ids
- stream errors now forward the actual runtime message so misconfiguration is visible immediately
- added a regression test for the `roll-dice` vs `rollDice` mismatch

## Why this fixes the hallucination
The framework now keeps one canonical tool namespace only: the exact `tool({ id: "..." })` string, or the filename-derived id if `id` is omitted for a discovered tool. If config, prompt, or allowlist strings drift from that canonical name, the run fails before model generation instead of giving the model a chance to invent textual tool transcripts.

## Testing
- `deno test --no-check --allow-all src/agent/runtime/tool-helpers.test.ts`
- `deno test --no-check --allow-all src/server/handlers/request/agent-stream.handler.test.ts`
- `deno eval --no-check 'import "./src/agent/runtime/index.ts"'

## Notes
The motivating RFC and evidence were captured from the staging investigation, including the hallucinated child-run transcript and the missing real `TOOL_CALL_*` events.
