### PR TITLE
fix(security): prevent ReDoS in RSC action parser regex

### DIFF
--- a/src/server/services/rsc/endpoints/action-parser.test.ts
+++ b/src/server/services/rsc/endpoints/action-parser.test.ts
@@ -83,5 +83,21 @@ describe("server/services/rsc/endpoints/action-parser", () => {
       const body = assertActionBody(result);
       assertEquals(body.id, "a/b/c/d/e");
     });
+
+    it("should reject ids with consecutive slashes", async () => {
+      const result = await parseActionBody({ id: "foo//bar", args: [] });
+      assertErrorResponse(result, 400);
+    });
+
+    it("should complete quickly on adversarial input (ReDoS resistance)", async () => {
+      // Crafted input that would cause catastrophic backtracking with the old
+      // regex where `/` appeared in the character classes AND the group separator.
+      const malicious = "a" + "/".repeat(50) + "!";
+      const start = performance.now();
+      const result = await parseActionBody({ id: malicious, args: [] });
+      const elapsed = performance.now() - start;
+      assertErrorResponse(result, 400);
+      assertEquals(elapsed < 100, true, `Regex took ${elapsed}ms, expected <100ms`);
+    });
   });
 });

--- a/src/server/services/rsc/endpoints/action-parser.ts
+++ b/src/server/services/rsc/endpoints/action-parser.ts
@@ -3,7 +3,7 @@ import { HttpStatus, jsonErrorResponse } from "#veryfront/http/responses";
 import type { ActionBody } from "./types.ts";
 import { ActionPayloadSchema } from "../../../schemas/index.ts";
 
-const ACTION_ID_PATTERN = /^[A-Za-z0-9_/-]+(?:\/[A-Za-z0-9_/-]+)*$/;
+const ACTION_ID_PATTERN = /^[A-Za-z0-9_-]+(?:\/[A-Za-z0-9_-]+)*$/;
 
 function isValidActionId(id: string): boolean {
   return (


### PR DESCRIPTION
## Summary

- Remove `/` from both character classes in `ACTION_ID_PATTERN` so slashes are only matched as group separators, eliminating ambiguity that caused catastrophic backtracking
- Add test for consecutive-slash rejection
- Add ReDoS resistance test with adversarial input

Resolves CodeQL alert #54.

## Test plan

- [x] All existing action parser tests pass (13 steps)
- [x] Consecutive slashes (`foo//bar`) rejected
- [x] Adversarial input (`a` + 50 slashes + `!`) completes in <100ms