### PR TITLE
fix(security): sanitize bridge routeChange URL to prevent XSS and open redirect

### DIFF
--- a/src/studio/bridge/bridge-message-handler.test.ts
+++ b/src/studio/bridge/bridge-message-handler.test.ts
@@ -146,6 +146,33 @@ Deno.test("routeChange: blocks javascript: URL", () => {
   });
 });
 
+Deno.test("routeChange: assigns normalized URL, not raw input", () => {
+  resetState();
+  let navigatedTo = "";
+  Object.defineProperty(globalThis.location, "href", {
+    set(v: string) {
+      navigatedTo = v;
+    },
+    get() {
+      return "https://test.veryfront.com/test";
+    },
+    configurable: true,
+  });
+
+  // Path traversal gets normalized by new URL().href — proves the handler uses
+  // the sanitized value rather than the raw postMessage input.
+  handleStudioMessage(
+    makeEvent({ action: "routeChange", url: "https://test.veryfront.com/a/../b" }),
+  );
+  assertEquals(navigatedTo, "https://test.veryfront.com/b");
+
+  Object.defineProperty(globalThis.location, "href", {
+    value: "https://test.veryfront.com/test",
+    writable: true,
+    configurable: true,
+  });
+});
+
 Deno.test("routeChange: clears existing selection before navigating", () => {
   resetState();
   state.selectedNodeId = "node-123";
@@ -239,6 +266,11 @@ Deno.test("sanitizeNavigationUrl: blocks non-veryfront domains", () => {
 
 Deno.test("sanitizeNavigationUrl: blocks javascript: protocol", () => {
   assertEquals(sanitizeNavigationUrl("javascript:alert(1)"), null);
+});
+
+Deno.test("sanitizeNavigationUrl: blocks data: protocol", () => {
+  assertEquals(sanitizeNavigationUrl("data:text/html,<script>alert(1)</script>"), null);
+  assertEquals(sanitizeNavigationUrl("data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=="), null);
 });
 
 Deno.test("sanitizeNavigationUrl: blocks empty and invalid input", () => {

--- a/src/studio/bridge/bridge-message-handler.test.ts
+++ b/src/studio/bridge/bridge-message-handler.test.ts
@@ -270,7 +270,10 @@ Deno.test("sanitizeNavigationUrl: blocks javascript: protocol", () => {
 
 Deno.test("sanitizeNavigationUrl: blocks data: protocol", () => {
   assertEquals(sanitizeNavigationUrl("data:text/html,<script>alert(1)</script>"), null);
-  assertEquals(sanitizeNavigationUrl("data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=="), null);
+  assertEquals(
+    sanitizeNavigationUrl("data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=="),
+    null,
+  );
 });
 
 Deno.test("sanitizeNavigationUrl: blocks empty and invalid input", () => {

--- a/src/studio/bridge/bridge-message-handler.test.ts
+++ b/src/studio/bridge/bridge-message-handler.test.ts
@@ -4,7 +4,11 @@
 
 import { assertEquals } from "@std/assert";
 import { setConfigForTest } from "./bridge-config.ts";
-import { handleStudioMessage, isSafeNavigationUrl } from "./bridge-message-handler.ts";
+import {
+  handleStudioMessage,
+  isSafeNavigationUrl,
+  sanitizeNavigationUrl,
+} from "./bridge-message-handler.ts";
 import { state } from "./bridge-state.ts";
 
 // ---------------------------------------------------------------------------
@@ -56,12 +60,18 @@ Deno.test("isSafeNavigationUrl: allows relative URLs", () => {
   assertEquals(isSafeNavigationUrl("/some/deep/path"), true);
 });
 
-Deno.test("isSafeNavigationUrl: allows https URLs", () => {
-  assertEquals(isSafeNavigationUrl("https://example.com/page"), true);
+Deno.test("isSafeNavigationUrl: allows same-origin https URLs", () => {
+  assertEquals(isSafeNavigationUrl("https://test.veryfront.com/page"), true);
 });
 
-Deno.test("isSafeNavigationUrl: allows http URLs", () => {
-  assertEquals(isSafeNavigationUrl("http://example.com/page"), true);
+Deno.test("isSafeNavigationUrl: allows veryfront.com URLs", () => {
+  assertEquals(isSafeNavigationUrl("https://veryfront.com/page"), true);
+  assertEquals(isSafeNavigationUrl("https://slug.preview.veryfront.com/page"), true);
+});
+
+Deno.test("isSafeNavigationUrl: blocks non-veryfront URLs", () => {
+  assertEquals(isSafeNavigationUrl("https://example.com/page"), false);
+  assertEquals(isSafeNavigationUrl("http://evil.com/page"), false);
 });
 
 Deno.test("isSafeNavigationUrl: blocks javascript: URLs", () => {
@@ -195,4 +205,44 @@ Deno.test("toggleInspectMode: deselectElements also clears selection", () => {
   assertEquals(state.inspectMode, false);
   assertEquals(state.selectedNodeId, null);
   assertEquals(state.selectionOverlay?.style.display, "none");
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeNavigationUrl
+// ---------------------------------------------------------------------------
+
+Deno.test("sanitizeNavigationUrl: returns relative paths as-is", () => {
+  assertEquals(sanitizeNavigationUrl("/page"), "/page");
+  assertEquals(sanitizeNavigationUrl("/a/b/c"), "/a/b/c");
+});
+
+Deno.test("sanitizeNavigationUrl: returns normalized href for same-origin URLs", () => {
+  const result = sanitizeNavigationUrl("https://test.veryfront.com/page");
+  assertEquals(result, "https://test.veryfront.com/page");
+});
+
+Deno.test("sanitizeNavigationUrl: allows veryfront.com subdomains", () => {
+  assertEquals(
+    sanitizeNavigationUrl("https://slug.preview.veryfront.com/page"),
+    "https://slug.preview.veryfront.com/page",
+  );
+  assertEquals(
+    sanitizeNavigationUrl("https://veryfront.com/dashboard"),
+    "https://veryfront.com/dashboard",
+  );
+});
+
+Deno.test("sanitizeNavigationUrl: blocks non-veryfront domains", () => {
+  assertEquals(sanitizeNavigationUrl("https://evil.com/page"), null);
+  assertEquals(sanitizeNavigationUrl("https://notveryfront.com/page"), null);
+});
+
+Deno.test("sanitizeNavigationUrl: blocks javascript: protocol", () => {
+  assertEquals(sanitizeNavigationUrl("javascript:alert(1)"), null);
+});
+
+Deno.test("sanitizeNavigationUrl: blocks empty and invalid input", () => {
+  assertEquals(sanitizeNavigationUrl(""), null);
+  assertEquals(sanitizeNavigationUrl(null as unknown as string), null);
+  assertEquals(sanitizeNavigationUrl(123 as unknown as string), null);
 });

--- a/src/studio/bridge/bridge-message-handler.test.ts
+++ b/src/studio/bridge/bridge-message-handler.test.ts
@@ -69,6 +69,11 @@ Deno.test("isSafeNavigationUrl: allows veryfront.com URLs", () => {
   assertEquals(isSafeNavigationUrl("https://slug.preview.veryfront.com/page"), true);
 });
 
+Deno.test("isSafeNavigationUrl: blocks protocol-relative URLs", () => {
+  assertEquals(isSafeNavigationUrl("//evil.com/path"), false);
+  assertEquals(isSafeNavigationUrl("//evil.com"), false);
+});
+
 Deno.test("isSafeNavigationUrl: blocks non-veryfront URLs", () => {
   assertEquals(isSafeNavigationUrl("https://example.com/page"), false);
   assertEquals(isSafeNavigationUrl("http://evil.com/page"), false);
@@ -113,6 +118,30 @@ Deno.test("routeChange: navigates for safe relative URL", () => {
 
   handleStudioMessage(makeEvent({ action: "routeChange", url: "/new-page" }));
   assertEquals(navigatedTo, "/new-page");
+
+  // Restore
+  Object.defineProperty(globalThis.location, "href", {
+    value: "https://test.veryfront.com/test",
+    writable: true,
+    configurable: true,
+  });
+});
+
+Deno.test("routeChange: blocks protocol-relative URL", () => {
+  resetState();
+  let navigatedTo = "";
+  Object.defineProperty(globalThis.location, "href", {
+    set(v: string) {
+      navigatedTo = v;
+    },
+    get() {
+      return "https://test.veryfront.com/test";
+    },
+    configurable: true,
+  });
+
+  handleStudioMessage(makeEvent({ action: "routeChange", url: "//evil.com/path" }));
+  assertEquals(navigatedTo, ""); // Should NOT navigate
 
   // Restore
   Object.defineProperty(globalThis.location, "href", {
@@ -262,6 +291,11 @@ Deno.test("sanitizeNavigationUrl: allows veryfront.com subdomains", () => {
 Deno.test("sanitizeNavigationUrl: blocks non-veryfront domains", () => {
   assertEquals(sanitizeNavigationUrl("https://evil.com/page"), null);
   assertEquals(sanitizeNavigationUrl("https://notveryfront.com/page"), null);
+});
+
+Deno.test("sanitizeNavigationUrl: blocks protocol-relative URLs", () => {
+  assertEquals(sanitizeNavigationUrl("//evil.com/path"), null);
+  assertEquals(sanitizeNavigationUrl("//evil.com"), null);
 });
 
 Deno.test("sanitizeNavigationUrl: blocks javascript: protocol", () => {

--- a/src/studio/bridge/bridge-message-handler.ts
+++ b/src/studio/bridge/bridge-message-handler.ts
@@ -34,8 +34,9 @@ export function isSafeNavigationUrl(url: string): boolean {
 export function sanitizeNavigationUrl(url: string): string | null {
   if (typeof url !== "string" || url.length === 0) return null;
 
-  // Relative paths are same-origin by definition
-  if (url.startsWith("/")) return url;
+  // Relative paths are same-origin by definition.
+  // Exclude protocol-relative URLs (//evil.com) which browsers resolve cross-origin.
+  if (url[0] === "/" && url[1] !== "/") return url;
 
   try {
     const parsed = new URL(url, window.location.origin);

--- a/src/studio/bridge/bridge-message-handler.ts
+++ b/src/studio/bridge/bridge-message-handler.ts
@@ -21,14 +21,36 @@ const SAFE_PROTOCOLS = new Set(["http:", "https:"]);
 
 /** Returns true if the URL is safe for navigation (relative or http/https only). */
 export function isSafeNavigationUrl(url: string): boolean {
-  // Relative URLs starting with / are always safe
-  if (url.startsWith("/")) return true;
+  return sanitizeNavigationUrl(url) !== null;
+}
+
+/**
+ * Return a sanitized URL safe for `window.location.href` assignment, or null
+ * if the URL must be blocked. Relative paths are returned as-is; absolute URLs
+ * must use http/https and target veryfront.com (or a subdomain) to prevent
+ * open-redirect. The browser-normalized `parsed.href` is returned instead of
+ * the raw input so tainted values never reach the DOM sink.
+ */
+export function sanitizeNavigationUrl(url: string): string | null {
+  if (typeof url !== "string" || url.length === 0) return null;
+
+  // Relative paths are same-origin by definition
+  if (url.startsWith("/")) return url;
 
   try {
     const parsed = new URL(url, window.location.origin);
-    return SAFE_PROTOCOLS.has(parsed.protocol);
+    if (!SAFE_PROTOCOLS.has(parsed.protocol)) return null;
+
+    // Allow same-origin navigation unconditionally
+    if (parsed.origin === window.location.origin) return parsed.href;
+
+    // For cross-origin, restrict to veryfront.com
+    const host = parsed.hostname;
+    if (host !== "veryfront.com" && !host.endsWith(".veryfront.com")) return null;
+
+    return parsed.href;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -97,23 +119,23 @@ export function handleStudioMessage(event: MessageEvent): void {
   const config = getConfig();
 
   switch (message.action) {
-    case "routeChange":
-      if (message.url) {
-        if (!isSafeNavigationUrl(message.url)) {
-          logger.warn("[StudioBridge] Blocked unsafe URL in routeChange", { url: message.url });
-          return;
-        }
-        if (state.selectedNodeId) {
-          clearSelection(true);
-        }
-        postToStudio({
-          action: "onPageTransitionStart",
-          url: message.url,
-          projectId: config.projectId,
-        });
-        window.location.href = message.url;
+    case "routeChange": {
+      const safeUrl = sanitizeNavigationUrl(message.url);
+      if (!safeUrl) {
+        logger.warn("[StudioBridge] Blocked unsafe URL in routeChange", { url: message.url });
+        return;
       }
+      if (state.selectedNodeId) {
+        clearSelection(true);
+      }
+      postToStudio({
+        action: "onPageTransitionStart",
+        url: safeUrl,
+        projectId: config.projectId,
+      });
+      window.location.href = safeUrl;
       return;
+    }
 
     case "reload":
       window.location.reload();


### PR DESCRIPTION
## Summary

- Add `sanitizeNavigationUrl()` that returns the browser-normalized `parsed.href` instead of raw postMessage input, breaking the taint flow to `window.location.href`
- Restrict cross-origin navigation to `veryfront.com` subdomains only (prevents open redirect)
- Update `isSafeNavigationUrl()` to delegate to the new sanitizer
- Update existing tests and add 6 new tests for `sanitizeNavigationUrl`

Resolves CodeQL alerts #51 (XSS) and #25 (open redirect).

## Test plan

- [x] Relative URLs returned as-is
- [x] Same-origin URLs normalized and allowed
- [x] veryfront.com subdomains allowed
- [x] Non-veryfront domains blocked
- [x] javascript:/data:/vbscript: protocols blocked
- [x] Empty/invalid input returns null
- [x] routeChange handler uses sanitized URL
- [x] All 19 bridge handler tests pass