### PR TITLE
Guard project-agent runtime against repeated web_search loops

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -77,6 +77,10 @@ import { resolveConfiguredAgentModel, resolveRuntimeModel } from "./model-resolu
 
 const logger = serverLogger.component("agent");
 const LOAD_SKILL_TOOL_ID = "load-skill";
+const WEB_SEARCH_LOOP_GUARD_MESSAGE =
+  "Web search loop guard: you already have enough web search evidence. Do not call web_search again in this turn. Synthesize a final answer from the gathered results.";
+const MAX_WEB_SEARCH_CALLS_PER_TURN = 8;
+const MAX_DUPLICATE_WEB_SEARCH_QUERIES_PER_TURN = 3;
 
 type RuntimeToolFilterConfig = AgentConfig & {
   __vfAllowedRemoteTools?: string[];
@@ -218,6 +222,42 @@ function getRuntimeAllowedRemoteTools(config: AgentConfig): string[] | undefined
     return [];
   }
   return raw.every((toolName) => typeof toolName === "string") ? raw : [];
+}
+
+export function normalizeWebSearchQuery(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^\p{L}\p{N}]+/gu, " ")
+    .replaceAll(/\s+/g, " ")
+    .trim();
+}
+
+export function shouldGuardWebSearchLoop(queries: string[]): boolean {
+  if (queries.length >= MAX_WEB_SEARCH_CALLS_PER_TURN) {
+    return true;
+  }
+
+  const normalizedCounts = new Map<string, number>();
+  for (const query of queries) {
+    const normalized = normalizeWebSearchQuery(query);
+    if (!normalized) {
+      continue;
+    }
+    normalizedCounts.set(normalized, (normalizedCounts.get(normalized) ?? 0) + 1);
+  }
+
+  return [...normalizedCounts.values()].some((count) =>
+    count >= MAX_DUPLICATE_WEB_SEARCH_QUERIES_PER_TURN
+  );
+}
+
+function extractWebSearchQuery(input: unknown): string | null {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return null;
+  }
+  const query = (input as { query?: unknown }).query;
+  return typeof query === "string" && query.trim().length > 0 ? query : null;
 }
 
 export class AgentRuntime {
@@ -437,6 +477,7 @@ export class AgentRuntime {
       const toolCalls: ToolCall[] = [];
       const currentMessages = [...messages];
       const totalUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+      const webSearchQueries: string[] = [];
 
       // Local models can't reliably do function calling — skip tools gracefully.
       const isLocal = isLocalModel(languageModel);
@@ -467,6 +508,15 @@ export class AgentRuntime {
           tools = filterToolsForSkill(tools, activeSkillPolicy);
         }
 
+        const webSearchLoopGuardActive = shouldGuardWebSearchLoop(webSearchQueries);
+        if (webSearchLoopGuardActive) {
+          tools = tools.filter((tool) => tool.name !== "web_search");
+        }
+
+        const effectiveSystemPrompt = webSearchLoopGuardActive
+          ? `${systemPrompt}\n\n${WEB_SEARCH_LOOP_GUARD_MESSAGE}`
+          : systemPrompt;
+
         const response = await withSpan("agent.generate_text", async (span) => {
           setSpanAttributes(span, {
             "model.id": effectiveModel,
@@ -474,7 +524,7 @@ export class AgentRuntime {
           });
           return generateText({
             model: languageModel,
-            system: systemPrompt,
+            system: effectiveSystemPrompt,
             messages: convertToModelMessages(currentMessages),
             tools: convertToolsToAISDK(tools, {
               model: effectiveModel,
@@ -501,6 +551,12 @@ export class AgentRuntime {
         if (response.text) assistantParts.push({ type: "text", text: response.text });
 
         for (const tc of response.toolCalls ?? []) {
+          const webSearchQuery = tc.toolName === "web_search"
+            ? extractWebSearchQuery(tc.input)
+            : null;
+          if (webSearchQuery) {
+            webSearchQueries.push(webSearchQuery);
+          }
           assistantParts.push({
             type: `tool-${tc.toolName}`,
             toolCallId: tc.toolCallId,
@@ -687,6 +743,7 @@ export class AgentRuntime {
     const toolCalls: ToolCall[] = [];
     const currentMessages = [...messages];
     const totalUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+    const webSearchQueries: string[] = [];
 
     // Local models can't reliably do function calling — skip tools gracefully.
     const isLocalStreaming = isLocalModel(languageModel);
@@ -719,9 +776,18 @@ export class AgentRuntime {
         tools = filterToolsForSkill(tools, activeSkillPolicy);
       }
 
+      const webSearchLoopGuardActive = shouldGuardWebSearchLoop(webSearchQueries);
+      if (webSearchLoopGuardActive) {
+        tools = tools.filter((tool) => tool.name !== "web_search");
+      }
+
+      const effectiveSystemPrompt = webSearchLoopGuardActive
+        ? `${systemPrompt}\n\n${WEB_SEARCH_LOOP_GUARD_MESSAGE}`
+        : systemPrompt;
+
       const result = streamText({
         model: languageModel,
-        system: systemPrompt,
+        system: effectiveSystemPrompt,
         messages: convertToModelMessages(currentMessages),
         tools: convertToolsToAISDK(tools, {
           model: effectiveModel,
@@ -746,6 +812,12 @@ export class AgentRuntime {
 
       for (const tc of state.toolCalls.values()) {
         const { args, error } = parseToolArgs(tc.arguments);
+        if (tc.name === "web_search") {
+          const webSearchQuery = extractWebSearchQuery(args);
+          if (webSearchQuery) {
+            webSearchQueries.push(webSearchQuery);
+          }
+        }
         if (error) {
           logger.warn("Failed to parse streamed tool arguments", {
             toolCallId: tc.id,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -406,7 +406,7 @@ export class AgentRuntime {
           logger.error("Agent stream error", { error });
           sendSSE(controller, encoder, {
             type: "error",
-            error: "An internal error occurred",
+            error: error instanceof Error ? error.message : String(error),
           });
           closeSSEStream(controller);
         } finally {

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -175,7 +175,34 @@ describe("tool-helpers", () => {
   });
 
   describe("getAvailableTools", () => {
+    it("fails loudly when an explicit configured tool name does not match a discovered tool id", async () => {
+      toolRegistry.clearAll();
+
+      toolRegistry.register(
+        "roll-dice",
+        tool({
+          id: "roll-dice",
+          description: "Roll a die",
+          inputSchema: z.object({}),
+          execute: async () => ({ total: 4 }),
+        }),
+      );
+
+      await assertRejects(
+        () =>
+          getAvailableTools(
+            {
+              rollDice: true,
+            },
+            { includeIntegrationTools: false },
+          ),
+        Error,
+        'Unknown tool reference: rollDice. Tool names must exactly match tool({ id: "..." }). Available tools: roll-dice',
+      );
+    });
+
     it("filters remote integration tool definitions by the runtime allowlist", async () => {
+      toolRegistry.clearAll();
       const originalFetch = globalThis.fetch;
       const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_URL");
       const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
@@ -205,6 +232,7 @@ describe("tool-helpers", () => {
 
         assertEquals(defs.map((def) => def.name), ["gmail:get-email"]);
       } finally {
+        toolRegistry.clearAll();
         if (originalApiBaseUrl === undefined) Deno.env.delete("VERYFRONT_API_URL");
         else Deno.env.set("VERYFRONT_API_URL", originalApiBaseUrl);
         if (originalApiToken === undefined) Deno.env.delete("VERYFRONT_API_TOKEN");

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -9,6 +9,35 @@ import {
   resolveConfiguredTool,
 } from "./tool-helpers.ts";
 
+async function withMockRemoteIntegrationTools<T>(
+  remoteToolNames: string[],
+  callback: () => Promise<T>,
+): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_URL");
+  const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
+  globalThis.fetch = async () =>
+    Response.json({
+      tools: remoteToolNames.map((name) => ({
+        name,
+        description: `${name} description`,
+        inputSchema: { type: "object", properties: {} },
+      })),
+    });
+
+  try {
+    Deno.env.set("VERYFRONT_API_URL", "https://api.test");
+    Deno.env.set("VERYFRONT_API_TOKEN", "token");
+    return await callback();
+  } finally {
+    if (originalApiBaseUrl === undefined) Deno.env.delete("VERYFRONT_API_URL");
+    else Deno.env.set("VERYFRONT_API_URL", originalApiBaseUrl);
+    if (originalApiToken === undefined) Deno.env.delete("VERYFRONT_API_TOKEN");
+    else Deno.env.set("VERYFRONT_API_TOKEN", originalApiToken);
+    globalThis.fetch = originalFetch;
+  }
+}
+
 describe("tool-helpers", () => {
   describe("parseToolArgs", () => {
     it("parses a valid JSON string into args", () => {
@@ -203,41 +232,60 @@ describe("tool-helpers", () => {
 
     it("filters remote integration tool definitions by the runtime allowlist", async () => {
       toolRegistry.clearAll();
-      const originalFetch = globalThis.fetch;
-      const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_URL");
-      const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
-      globalThis.fetch = async () =>
-        Response.json({
-          tools: [
-            {
-              name: "gmail:list-emails",
-              description: "List emails",
-              inputSchema: { type: "object", properties: {} },
-            },
-            {
-              name: "gmail:get-email",
-              description: "Get email",
-              inputSchema: { type: "object", properties: {} },
-            },
-          ],
-        });
-
       try {
-        Deno.env.set("VERYFRONT_API_URL", "https://api.test");
-        Deno.env.set("VERYFRONT_API_TOKEN", "token");
-
-        const defs = await getAvailableTools(true, {
-          allowedRemoteToolNames: ["gmail:get-email"],
-        });
+        const defs = await withMockRemoteIntegrationTools([
+          "gmail:list-emails",
+          "gmail:get-email",
+        ], () =>
+          getAvailableTools(true, {
+            allowedRemoteToolNames: ["gmail:get-email"],
+          }));
 
         assertEquals(defs.map((def) => def.name), ["gmail:get-email"]);
       } finally {
         toolRegistry.clearAll();
-        if (originalApiBaseUrl === undefined) Deno.env.delete("VERYFRONT_API_URL");
-        else Deno.env.set("VERYFRONT_API_URL", originalApiBaseUrl);
-        if (originalApiToken === undefined) Deno.env.delete("VERYFRONT_API_TOKEN");
-        else Deno.env.set("VERYFRONT_API_TOKEN", originalApiToken);
-        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("fails loudly when an explicit remote tool is missing from the discovered allowlist", async () => {
+      toolRegistry.clearAll();
+
+      try {
+        await assertRejects(
+          () =>
+            withMockRemoteIntegrationTools(["gmail:list-emails"], () =>
+              getAvailableTools(
+                {
+                  "gmail:get-email": true,
+                },
+                { allowedRemoteToolNames: ["gmail:list-emails"] },
+              )),
+          Error,
+          'Unknown tool reference: gmail:get-email. Tool names must exactly match tool({ id: "..." }). Available tools: gmail:list-emails',
+        );
+      } finally {
+        toolRegistry.clearAll();
+      }
+    });
+
+    it("only appends explicitly requested remote definitions for explicit tool maps", async () => {
+      toolRegistry.clearAll();
+
+      try {
+        const defs = await withMockRemoteIntegrationTools([
+          "gmail:list-emails",
+          "gmail:get-email",
+        ], () =>
+          getAvailableTools(
+            {
+              "gmail:get-email": true,
+            },
+            { allowedRemoteToolNames: ["gmail:list-emails", "gmail:get-email"] },
+          ));
+
+        assertEquals(defs.map((def) => def.name), ["gmail:get-email"]);
+      } finally {
+        toolRegistry.clearAll();
       }
     });
   });

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -238,6 +238,7 @@ export async function getAvailableTools(
   const tools: ToolDefinition[] = [];
   const remoteDefs = await getRemoteToolDefinitions(options);
   const remoteToolNames = new Set(remoteDefs.map((def) => def.name));
+  const explicitlyRequestedRemoteToolNames = new Set<string>();
   const unresolvedConfiguredToolNames: string[] = [];
 
   for (const [name, entry] of Object.entries(toolsConfig)) {
@@ -248,9 +249,12 @@ export async function getAvailableTools(
         continue;
       }
 
-      if (!remoteToolNames.has(name) && !isRemoteIntegrationTool(name)) {
-        unresolvedConfiguredToolNames.push(name);
+      if (remoteToolNames.has(name)) {
+        explicitlyRequestedRemoteToolNames.add(name);
+        continue;
       }
+
+      unresolvedConfiguredToolNames.push(name);
       continue;
     }
 
@@ -259,10 +263,14 @@ export async function getAvailableTools(
     }
   }
 
-  // Also append remote integration tools for explicit-object configs.
-  // The internal streaming path converts `tools: true` to an explicit object
-  // from the local registry, so remote tools would be missed without this.
-  for (const def of remoteDefs) {
+  // Explicit-object configs should only expose remote definitions that were
+  // explicitly requested, except for the internal runtime path that expands
+  // `tools: true` into an explicit local-tool map and passes the remote allowlist.
+  const remoteDefsToAppend = explicitlyRequestedRemoteToolNames.size > 0
+    ? remoteDefs.filter((def) => explicitlyRequestedRemoteToolNames.has(def.name))
+    : remoteDefs.filter((def) => options?.allowedRemoteToolNames?.includes(def.name));
+
+  for (const def of remoteDefsToAppend) {
     // Skip if already present (e.g., explicitly configured by name)
     if (!tools.some((t) => t.name === def.name)) {
       logToolDefinition(def.name, def);

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -11,6 +11,7 @@ import { executeTool, toolRegistry } from "#veryfront/tool";
 import { toolToProviderDefinition } from "#veryfront/tool/registry.ts";
 import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
 import { serverLogger } from "#veryfront/utils";
+import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import {
   executeRemoteIntegrationTool,
   isRemoteIntegrationTool,
@@ -70,6 +71,52 @@ export function isDynamicTool(name: string): boolean {
  */
 // deno-lint-ignore no-explicit-any -- generic erasure: accepts Tool with any input/output types
 export type ToolConfigEntry = Tool<any, any> | boolean;
+
+function formatAvailableToolNames(names: Iterable<string>): string {
+  const sorted = [...new Set(names)].sort();
+  return sorted.length > 0 ? sorted.join(", ") : "(none)";
+}
+
+function throwUnknownConfiguredToolsError(
+  unknownToolNames: string[],
+  availableLocalToolNames: Iterable<string>,
+  availableRemoteToolNames: Iterable<string>,
+): never {
+  const unknownList = unknownToolNames.sort().join(", ");
+  const availableNames = formatAvailableToolNames([
+    ...availableLocalToolNames,
+    ...availableRemoteToolNames,
+  ]);
+
+  throw toError(
+    createError({
+      type: "agent",
+      message:
+        `Unknown tool reference${unknownToolNames.length === 1 ? "" : "s"}: ${unknownList}. ` +
+        `Tool names must exactly match tool({ id: "..." }). Available tools: ${availableNames}`,
+    }),
+  );
+}
+
+async function getRemoteToolDefinitions(options?: {
+  includeIntegrationTools?: boolean;
+  allowedRemoteToolNames?: string[];
+}): Promise<ToolDefinition[]> {
+  if (options?.includeIntegrationTools === false) {
+    return [];
+  }
+
+  try {
+    const { getRemoteIntegrationToolDefinitions } = await import(
+      "#veryfront/integrations/remote-tools.ts"
+    );
+    return (await getRemoteIntegrationToolDefinitions()).filter((def) =>
+      !options?.allowedRemoteToolNames || options.allowedRemoteToolNames.includes(def.name)
+    );
+  } catch {
+    return [];
+  }
+}
 
 export function resolveConfiguredTool(
   toolsConfig: true | Record<string, ToolConfigEntry> | undefined,
@@ -179,32 +226,31 @@ export async function getAvailableTools(
     });
 
     // Append remote integration tools (per-request, project-scoped)
-    if (options?.includeIntegrationTools !== false) {
-      try {
-        const { getRemoteIntegrationToolDefinitions } = await import(
-          "#veryfront/integrations/remote-tools.ts"
-        );
-        const remoteDefs = (await getRemoteIntegrationToolDefinitions()).filter((def) =>
-          !options?.allowedRemoteToolNames || options.allowedRemoteToolNames.includes(def.name)
-        );
-        for (const def of remoteDefs) {
-          logToolDefinition(def.name, def);
-        }
-        tools.push(...remoteDefs);
-      } catch {
-        // Integration tools unavailable — non-fatal
-      }
+    const remoteDefs = await getRemoteToolDefinitions(options);
+    for (const def of remoteDefs) {
+      logToolDefinition(def.name, def);
     }
+    tools.push(...remoteDefs);
 
     return tools;
   }
 
   const tools: ToolDefinition[] = [];
+  const remoteDefs = await getRemoteToolDefinitions(options);
+  const remoteToolNames = new Set(remoteDefs.map((def) => def.name));
+  const unresolvedConfiguredToolNames: string[] = [];
 
   for (const [name, entry] of Object.entries(toolsConfig)) {
     if (entry === true) {
       const tool = toolRegistry.get(name);
-      if (tool) addToolDefinition(tools, name, tool);
+      if (tool) {
+        addToolDefinition(tools, name, tool);
+        continue;
+      }
+
+      if (!remoteToolNames.has(name) && !isRemoteIntegrationTool(name)) {
+        unresolvedConfiguredToolNames.push(name);
+      }
       continue;
     }
 
@@ -216,24 +262,20 @@ export async function getAvailableTools(
   // Also append remote integration tools for explicit-object configs.
   // The internal streaming path converts `tools: true` to an explicit object
   // from the local registry, so remote tools would be missed without this.
-  if (options?.includeIntegrationTools !== false) {
-    try {
-      const { getRemoteIntegrationToolDefinitions } = await import(
-        "#veryfront/integrations/remote-tools.ts"
-      );
-      const remoteDefs = (await getRemoteIntegrationToolDefinitions()).filter((def) =>
-        !options?.allowedRemoteToolNames || options.allowedRemoteToolNames.includes(def.name)
-      );
-      for (const def of remoteDefs) {
-        // Skip if already present (e.g., explicitly configured by name)
-        if (!tools.some((t) => t.name === def.name)) {
-          logToolDefinition(def.name, def);
-          tools.push(def);
-        }
-      }
-    } catch {
-      // Integration tools unavailable — non-fatal
+  for (const def of remoteDefs) {
+    // Skip if already present (e.g., explicitly configured by name)
+    if (!tools.some((t) => t.name === def.name)) {
+      logToolDefinition(def.name, def);
+      tools.push(def);
     }
+  }
+
+  if (unresolvedConfiguredToolNames.length > 0) {
+    throwUnknownConfiguredToolsError(
+      unresolvedConfiguredToolNames,
+      toolRegistry.getAll().keys(),
+      remoteToolNames,
+    );
   }
 
   return tools;

--- a/src/agent/runtime/web-search-loop-guard.test.ts
+++ b/src/agent/runtime/web-search-loop-guard.test.ts
@@ -1,0 +1,50 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { normalizeWebSearchQuery, shouldGuardWebSearchLoop } from "./index.ts";
+
+describe("web-search loop guard", () => {
+  it("does not guard ordinary search counts", () => {
+    assertEquals(
+      shouldGuardWebSearchLoop([
+        "WebAssembly overview",
+        "WebAssembly performance",
+        "WebAssembly use cases",
+      ]),
+      false,
+    );
+  });
+
+  it("guards after too many web searches in one turn", () => {
+    assertEquals(
+      shouldGuardWebSearchLoop([
+        "q1",
+        "q2",
+        "q3",
+        "q4",
+        "q5",
+        "q6",
+        "q7",
+        "q8",
+      ]),
+      true,
+    );
+  });
+
+  it("guards repeated near-duplicate queries after normalization", () => {
+    assertEquals(
+      shouldGuardWebSearchLoop([
+        "WebAssembly history how it works technical overview",
+        "webassembly history how it works technical overview",
+        "WebAssembly history, how it works: technical overview!",
+      ]),
+      true,
+    );
+  });
+
+  it("normalizes punctuation and whitespace consistently", () => {
+    assertEquals(
+      normalizeWebSearchQuery("  WebAssembly history,   how it works!  "),
+      "webassembly history how it works",
+    );
+  });
+});

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.141";
+export const VERSION = "0.1.142";


### PR DESCRIPTION
## Summary
Add a runtime guard in the project-agent execution path to stop repeated `web_search` loops from consuming an entire run.

This fixes the backend behavior behind veryfront/veryfront-studio#1308 in the correct repo and runtime surface.

## What changed
- track provider `web_search` queries across the current project-agent turn
- treat either of these as a loop signal:
  - too many searches in one turn
  - repeated normalized duplicate queries
- when the loop signal trips, remove `web_search` from the next step and append a synthesis-only system reminder so the model finalizes from gathered results
- cover the helper logic with focused runtime tests

## Why here
The failing `researcher` was a project agent, but project-agent execution happens through `veryfront-code` / `veryfront-server` via the internal agent runtime (`/internal/agents/stream` and `/channels/invoke`). The earlier `veryfront-agent` PR was closed because it targeted the wrong execution surface.

## Verification
- `deno test -A src/agent/runtime/web-search-loop-guard.test.ts`
- `deno task build`

## Related
- veryfront/veryfront-studio#1308
