### PR TITLE
Fix knowledge ingest upload staging and keep the CLI releasable

### DIFF
--- a/cli/commands/doctor/server-checks.test.ts
+++ b/cli/commands/doctor/server-checks.test.ts
@@ -6,6 +6,17 @@ import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { checkRSCCounters, checkRSCEndpoints, checkRSCFlag } from "./server-checks.ts";
 
+async function withUnreachableFetch<T>(fn: () => Promise<T>): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (() => Promise.reject(new Error("unreachable"))) as typeof fetch;
+
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
 describe("doctor/server-checks", () => {
   describe("checkRSCFlag", () => {
     it("is a function", () => {
@@ -48,8 +59,7 @@ describe("doctor/server-checks", () => {
     });
 
     it("handles unreachable server gracefully", async () => {
-      // With no server running, should return warnings
-      const results = await checkRSCEndpoints();
+      const results = await withUnreachableFetch(() => checkRSCEndpoints());
       const hasWarning = results.some((r) => r.status === "warn");
       assertEquals(hasWarning, true);
     });
@@ -73,8 +83,7 @@ describe("doctor/server-checks", () => {
     });
 
     it("handles unreachable server gracefully", async () => {
-      const result = await checkRSCCounters();
-      // Should be warn when server is not running
+      const result = await withUnreachableFetch(() => checkRSCCounters());
       assertEquals(["pass", "warn"].includes(result.status), true);
     });
   });

--- a/cli/commands/knowledge/command.test.ts
+++ b/cli/commands/knowledge/command.test.ts
@@ -56,7 +56,10 @@ describe("normalizeKnowledgeInputPath", () => {
 
 describe("normalizeProjectUploadPath", () => {
   it("preserves the uploads/ prefix for upload-store API calls", () => {
-    assertEquals(normalizeProjectUploadPath("uploads/contracts/q1.pdf"), "uploads/contracts/q1.pdf");
+    assertEquals(
+      normalizeProjectUploadPath("uploads/contracts/q1.pdf"),
+      "uploads/contracts/q1.pdf",
+    );
     assertEquals(normalizeProjectUploadPath("uploads/"), "uploads");
   });
 });
@@ -344,7 +347,11 @@ describe("collectKnowledgeSources", () => {
       },
     );
 
-    assertEquals(downloadCalls, [["uploads/contracts/a.pdf", "uploads/contracts/b.pdf", "uploads/contracts/c.pdf"]]);
+    assertEquals(downloadCalls, [[
+      "uploads/contracts/a.pdf",
+      "uploads/contracts/b.pdf",
+      "uploads/contracts/c.pdf",
+    ]]);
     assertEquals(
       collection.sources.map((source) =>
         source.kind === "upload" ? source.uploadPath : source.localPath
@@ -974,7 +981,8 @@ describe("buildSuggestedSlug", () => {
       {
         kind: "upload",
         input: "uploads/chat-909d3dbc-5a9a-4156-97e4-bcceb5c2ec0d-1773942180291-fv1qg5-agents.md",
-        uploadPath: "uploads/chat-909d3dbc-5a9a-4156-97e4-bcceb5c2ec0d-1773942180291-fv1qg5-agents.md",
+        uploadPath:
+          "uploads/chat-909d3dbc-5a9a-4156-97e4-bcceb5c2ec0d-1773942180291-fv1qg5-agents.md",
         localPath:
           "/workspace/uploads/chat-909d3dbc-5a9a-4156-97e4-bcceb5c2ec0d-1773942180291-fv1qg5-agents.md",
       },

--- a/cli/commands/knowledge/command.test.ts
+++ b/cli/commands/knowledge/command.test.ts
@@ -55,9 +55,9 @@ describe("normalizeKnowledgeInputPath", () => {
 });
 
 describe("normalizeProjectUploadPath", () => {
-  it("strips the uploads/ prefix before upload-store API calls", () => {
-    assertEquals(normalizeProjectUploadPath("uploads/contracts/q1.pdf"), "contracts/q1.pdf");
-    assertEquals(normalizeProjectUploadPath("uploads/"), "");
+  it("preserves the uploads/ prefix for upload-store API calls", () => {
+    assertEquals(normalizeProjectUploadPath("uploads/contracts/q1.pdf"), "uploads/contracts/q1.pdf");
+    assertEquals(normalizeProjectUploadPath("uploads/"), "uploads");
   });
 });
 
@@ -169,20 +169,20 @@ describe("collectKnowledgeSources", () => {
         downloadUploads: async (uploadPaths) => {
           calls.push(...uploadPaths);
           return [{
-            uploadPath: "contracts/q1.pdf",
+            uploadPath: "uploads/contracts/q1.pdf",
             localPath: "/workspace/uploads/contracts/q1.pdf",
           }];
         },
       },
     );
 
-    assertEquals(calls, ["contracts/q1.pdf"]);
+    assertEquals(calls, ["uploads/contracts/q1.pdf"]);
     assertEquals(collection, {
       sources: [
         {
           kind: "upload",
           input: "uploads/contracts/q1.pdf",
-          uploadPath: "contracts/q1.pdf",
+          uploadPath: "uploads/contracts/q1.pdf",
           localPath: "/workspace/uploads/contracts/q1.pdf",
         },
       ],
@@ -212,14 +212,14 @@ describe("collectKnowledgeSources", () => {
           downloadUploads: async (uploadPaths) => {
             calls.push(...uploadPaths);
             return [{
-              uploadPath: "contracts/q1.pdf",
+              uploadPath: "uploads/contracts/q1.pdf",
               localPath: "/workspace/uploads/contracts/q1.pdf",
             }];
           },
         },
       );
 
-      assertEquals(calls, ["contracts/q1.pdf"]);
+      assertEquals(calls, ["uploads/contracts/q1.pdf"]);
       assertEquals(collection.sources[0]?.kind, "upload");
       assertEquals(collection.skipped, []);
     } finally {
@@ -235,7 +235,7 @@ describe("collectKnowledgeSources", () => {
       get: (path, params) => {
         listCalls.push({ path, params });
         return Promise.resolve({
-          data: [{ path: "a.pdf" }, { path: "b.pdf" }],
+          data: [{ path: "uploads/a.pdf" }, { path: "uploads/b.pdf" }],
           page_info: { next: null },
         });
       },
@@ -262,8 +262,8 @@ describe("collectKnowledgeSources", () => {
     );
 
     assertEquals(listCalls.length, 1);
-    assertEquals(listCalls[0]?.params?.path, undefined);
-    assertEquals(downloadCalls, [["a.pdf", "b.pdf"]]);
+    assertEquals(listCalls[0]?.params?.path, "uploads");
+    assertEquals(downloadCalls, [["uploads/a.pdf", "uploads/b.pdf"]]);
     assertEquals(collection.sources.length, 2);
     assert(collection.sources.every((source) => source.kind === "upload"));
     assertEquals(collection.skipped, []);
@@ -275,14 +275,14 @@ describe("collectKnowledgeSources", () => {
     const client = createMockClient({
       get: (_path, params) => {
         listCalls.push({ path: _path, params });
-        if (params?.path === "contracts") {
+        if (params?.path === "uploads/contracts") {
           return Promise.resolve({
-            data: [{ type: "folder", path: "contracts/" }],
+            data: [{ type: "folder", path: "uploads/contracts/" }],
             page_info: { next: null },
           });
         }
         return Promise.resolve({
-          data: [{ type: "file", path: "contracts/q1.pdf" }],
+          data: [{ type: "file", path: "uploads/contracts/q1.pdf" }],
           page_info: { next: null },
         });
       },
@@ -309,10 +309,10 @@ describe("collectKnowledgeSources", () => {
     );
 
     assertEquals(listCalls.length, 2);
-    assertEquals(listCalls[0]?.params?.path, "contracts");
-    assertEquals(listCalls[1]?.params?.path, "contracts/");
+    assertEquals(listCalls[0]?.params?.path, "uploads/contracts");
+    assertEquals(listCalls[1]?.params?.path, "uploads/contracts/");
     assertEquals(listCalls[1]?.params?.recursive, "false");
-    assertEquals(downloadCalls, [["contracts/q1.pdf"]]);
+    assertEquals(downloadCalls, [["uploads/contracts/q1.pdf"]]);
     assertEquals(collection.sources.length, 1);
     assertEquals(collection.sources[0]?.kind, "upload");
     assertEquals(collection.skipped, []);
@@ -338,18 +338,18 @@ describe("collectKnowledgeSources", () => {
           downloadCalls.push(uploadPaths);
           return uploadPaths.map((uploadPath) => ({
             uploadPath,
-            localPath: `/workspace/uploads/${uploadPath}`,
+            localPath: `/workspace/${uploadPath}`,
           }));
         },
       },
     );
 
-    assertEquals(downloadCalls, [["contracts/a.pdf", "contracts/b.pdf", "contracts/c.pdf"]]);
+    assertEquals(downloadCalls, [["uploads/contracts/a.pdf", "uploads/contracts/b.pdf", "uploads/contracts/c.pdf"]]);
     assertEquals(
       collection.sources.map((source) =>
         source.kind === "upload" ? source.uploadPath : source.localPath
       ),
-      ["contracts/a.pdf", "contracts/b.pdf", "contracts/c.pdf"],
+      ["uploads/contracts/a.pdf", "uploads/contracts/b.pdf", "uploads/contracts/c.pdf"],
     );
     assertEquals(collection.skipped, []);
   });
@@ -375,11 +375,11 @@ describe("collectKnowledgeSources", () => {
             downloadCalls.push(uploadPaths);
             return [
               {
-                uploadPath: "contracts/b.pdf",
+                uploadPath: "uploads/contracts/b.pdf",
                 localPath: "/workspace/uploads/contracts/b.pdf",
               },
               {
-                uploadPath: "contracts/a.pdf",
+                uploadPath: "uploads/contracts/a.pdf",
                 localPath: "/workspace/uploads/contracts/a.pdf",
               },
             ];
@@ -387,13 +387,13 @@ describe("collectKnowledgeSources", () => {
         },
       );
 
-      assertEquals(downloadCalls, [["contracts/a.pdf", "contracts/b.pdf"]]);
+      assertEquals(downloadCalls, [["uploads/contracts/a.pdf", "uploads/contracts/b.pdf"]]);
       assertEquals(collection, {
         sources: [
           {
             kind: "upload",
             input: "uploads/contracts/a.pdf",
-            uploadPath: "contracts/a.pdf",
+            uploadPath: "uploads/contracts/a.pdf",
             localPath: "/workspace/uploads/contracts/a.pdf",
           },
           {
@@ -404,7 +404,7 @@ describe("collectKnowledgeSources", () => {
           {
             kind: "upload",
             input: "uploads/contracts/b.pdf",
-            uploadPath: "contracts/b.pdf",
+            uploadPath: "uploads/contracts/b.pdf",
             localPath: "/workspace/uploads/contracts/b.pdf",
           },
         ],
@@ -437,18 +437,18 @@ describe("collectKnowledgeSources", () => {
           downloadCalls.push(uploadPaths);
           return uploadPaths.map((uploadPath) => ({
             uploadPath,
-            localPath: `/workspace/uploads/${uploadPath}`,
+            localPath: `/workspace/${uploadPath}`,
           }));
         },
       },
     );
 
-    assertEquals(downloadCalls, [["contracts/spec.pdf", "tools/run_benchmark.py"]]);
+    assertEquals(downloadCalls, [["uploads/contracts/spec.pdf", "uploads/tools/run_benchmark.py"]]);
     assertEquals(
       collection.sources.map((source) =>
         source.kind === "upload" ? source.uploadPath : source.localPath
       ),
-      ["contracts/spec.pdf", "tools/run_benchmark.py"],
+      ["uploads/contracts/spec.pdf", "uploads/tools/run_benchmark.py"],
     );
     assertEquals(collection.skipped, [
       {
@@ -558,11 +558,11 @@ describe("collectKnowledgeSources", () => {
       get: () =>
         Promise.resolve({
           data: [
-            { type: "file", path: "docs/guide.md" },
-            { type: "file", path: "docs/.env" },
-            { type: "file", path: "docs/node_modules/react/index.js" },
-            { type: "file", path: "docs/archive.zip" },
-            { type: "file", path: "docs/run_benchmark.py" },
+            { type: "file", path: "uploads/docs/guide.md" },
+            { type: "file", path: "uploads/docs/.env" },
+            { type: "file", path: "uploads/docs/node_modules/react/index.js" },
+            { type: "file", path: "uploads/docs/archive.zip" },
+            { type: "file", path: "uploads/docs/run_benchmark.py" },
           ],
           page_info: { next: null },
         }),
@@ -589,12 +589,12 @@ describe("collectKnowledgeSources", () => {
       },
     );
 
-    assertEquals(downloadCalls, [["docs/guide.md", "docs/run_benchmark.py"]]);
+    assertEquals(downloadCalls, [["uploads/docs/guide.md", "uploads/docs/run_benchmark.py"]]);
     assertEquals(
       collection.sources.map((source) =>
         source.kind === "upload" ? source.uploadPath : source.localPath
       ),
-      ["docs/guide.md", "docs/run_benchmark.py"],
+      ["uploads/docs/guide.md", "uploads/docs/run_benchmark.py"],
     );
     assertEquals(collection.skipped.length, 3);
   });
@@ -606,7 +606,7 @@ describe("ingestResolvedSources", () => {
       [{
         kind: "upload",
         input: "uploads/contracts/q1.pdf",
-        uploadPath: "contracts/q1.pdf",
+        uploadPath: "uploads/contracts/q1.pdf",
         localPath: "/workspace/uploads/contracts/q1.pdf",
       }],
       {
@@ -974,7 +974,7 @@ describe("buildSuggestedSlug", () => {
       {
         kind: "upload",
         input: "uploads/chat-909d3dbc-5a9a-4156-97e4-bcceb5c2ec0d-1773942180291-fv1qg5-agents.md",
-        uploadPath: "chat-909d3dbc-5a9a-4156-97e4-bcceb5c2ec0d-1773942180291-fv1qg5-agents.md",
+        uploadPath: "uploads/chat-909d3dbc-5a9a-4156-97e4-bcceb5c2ec0d-1773942180291-fv1qg5-agents.md",
         localPath:
           "/workspace/uploads/chat-909d3dbc-5a9a-4156-97e4-bcceb5c2ec0d-1773942180291-fv1qg5-agents.md",
       },
@@ -988,7 +988,7 @@ describe("buildSuggestedSlug", () => {
       {
         kind: "upload",
         input: "uploads/contracts/q1.pdf",
-        uploadPath: "contracts/q1.pdf",
+        uploadPath: "uploads/contracts/q1.pdf",
         localPath: "/workspace/uploads/contracts/q1.pdf",
       },
       0,
@@ -1002,7 +1002,8 @@ describe("buildSuggestedSlug", () => {
         kind: "upload",
         input:
           "uploads/docs/chat-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-1700000000000-abc12-readme.txt",
-        uploadPath: "docs/chat-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-1700000000000-abc12-readme.txt",
+        uploadPath:
+          "uploads/docs/chat-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-1700000000000-abc12-readme.txt",
         localPath:
           "/workspace/uploads/docs/chat-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-1700000000000-abc12-readme.txt",
       },

--- a/cli/commands/knowledge/command.ts
+++ b/cli/commands/knowledge/command.ts
@@ -201,7 +201,10 @@ function resolveExplicitUploadPath(inputPath: string): string {
   const normalizedInput = normalizeKnowledgeInputPath(inputPath);
   const displayInput = inputPath.replace(/\\/g, "/");
   const uploadPath = normalizeProjectUploadPath(inputPath);
-  if (!uploadPath || uploadPath === "uploads" || normalizedInput === "uploads" || normalizedInput.endsWith("/")) {
+  if (
+    !uploadPath || uploadPath === "uploads" || normalizedInput === "uploads" ||
+    normalizedInput.endsWith("/")
+  ) {
     throw new Error(
       `Directory upload references require --path <prefix> --all: ${displayInput}`,
     );

--- a/cli/commands/knowledge/command.ts
+++ b/cli/commands/knowledge/command.ts
@@ -187,8 +187,7 @@ export function normalizeKnowledgeInputPath(inputPath: string): string {
 }
 
 export function normalizeProjectUploadPath(inputPath: string): string {
-  const normalizedPath = normalizeKnowledgeInputPath(inputPath);
-  return normalizedPath === "uploads" ? "" : normalizedPath.replace(/^uploads\/+/, "");
+  return normalizeKnowledgeInputPath(inputPath);
 }
 
 export function formatKnowledgeUploadSource(uploadPath: string): string {
@@ -202,7 +201,7 @@ function resolveExplicitUploadPath(inputPath: string): string {
   const normalizedInput = normalizeKnowledgeInputPath(inputPath);
   const displayInput = inputPath.replace(/\\/g, "/");
   const uploadPath = normalizeProjectUploadPath(inputPath);
-  if (!uploadPath || normalizedInput.endsWith("/")) {
+  if (!uploadPath || uploadPath === "uploads" || normalizedInput === "uploads" || normalizedInput.endsWith("/")) {
     throw new Error(
       `Directory upload references require --path <prefix> --all: ${displayInput}`,
     );

--- a/cli/shared/config.test.ts
+++ b/cli/shared/config.test.ts
@@ -100,4 +100,64 @@ describe("resolveConfigWithAuth", () => {
 
     assertEquals(config.apiUrl, "https://api.veryfront.com");
   });
+
+  it("uses tenant project context when explicit project slug is absent", async () => {
+    const env = createMockEnv({
+      apiToken: "env-token",
+      projectSlug: undefined,
+    });
+    const previousTenantProjectSlug = Deno.env.get("TENANT_PROJECT_SLUG");
+    const previousTenantProjectId = Deno.env.get("TENANT_PROJECT_ID");
+
+    try {
+      Deno.env.set("TENANT_PROJECT_SLUG", "tenant-project");
+      Deno.env.set("TENANT_PROJECT_ID", "tenant-project-id");
+
+      const config = await resolveConfigWithAuth("/tmp/test-dir", env);
+
+      assertEquals(config.projectSlug, "tenant-project");
+    } finally {
+      if (previousTenantProjectSlug === undefined) {
+        Deno.env.delete("TENANT_PROJECT_SLUG");
+      } else {
+        Deno.env.set("TENANT_PROJECT_SLUG", previousTenantProjectSlug);
+      }
+
+      if (previousTenantProjectId === undefined) {
+        Deno.env.delete("TENANT_PROJECT_ID");
+      } else {
+        Deno.env.set("TENANT_PROJECT_ID", previousTenantProjectId);
+      }
+    }
+  });
+
+  it("uses tenant project id when no project slug is available", async () => {
+    const env = createMockEnv({
+      apiToken: "env-token",
+      projectSlug: undefined,
+    });
+    const previousTenantProjectSlug = Deno.env.get("TENANT_PROJECT_SLUG");
+    const previousTenantProjectId = Deno.env.get("TENANT_PROJECT_ID");
+
+    try {
+      Deno.env.delete("TENANT_PROJECT_SLUG");
+      Deno.env.set("TENANT_PROJECT_ID", "tenant-project-id");
+
+      const config = await resolveConfigWithAuth("/tmp/test-dir", env);
+
+      assertEquals(config.projectSlug, "tenant-project-id");
+    } finally {
+      if (previousTenantProjectSlug === undefined) {
+        Deno.env.delete("TENANT_PROJECT_SLUG");
+      } else {
+        Deno.env.set("TENANT_PROJECT_SLUG", previousTenantProjectSlug);
+      }
+
+      if (previousTenantProjectId === undefined) {
+        Deno.env.delete("TENANT_PROJECT_ID");
+      } else {
+        Deno.env.set("TENANT_PROJECT_ID", previousTenantProjectId);
+      }
+    }
+  });
 });

--- a/cli/shared/config.ts
+++ b/cli/shared/config.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { join } from "veryfront/platform/path";
 import { cwd } from "veryfront/platform";
 import { createFileSystem } from "veryfront/platform";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
 import { type EnvironmentConfig, getEnvironmentConfig } from "veryfront/config";
 import { cliLogger } from "#cli/utils";
 import { readToken } from "../auth/token-store.ts";
@@ -100,6 +101,14 @@ async function inferProjectSlug(projectDir: string): Promise<string | null> {
   return dirName ? slugify(dirName) : null;
 }
 
+function resolveTenantProjectReference(): string | undefined {
+  return getEnv("VERYFRONT_PROJECT_SLUG") ||
+    getEnv("TENANT_PROJECT_SLUG") ||
+    getEnv("VERYFRONT_PROJECT_ID") ||
+    getEnv("TENANT_PROJECT_ID") ||
+    undefined;
+}
+
 async function resolveConfigBase(
   projectDir: string | undefined,
   env: EnvironmentConfig,
@@ -125,10 +134,13 @@ async function resolveConfigBase(
     );
   }
 
-  const projectSlug = env.projectSlug ?? configFile?.projectSlug ?? (await inferProjectSlug(dir));
+  const projectSlug = env.projectSlug ??
+    resolveTenantProjectReference() ??
+    configFile?.projectSlug ??
+    (await inferProjectSlug(dir));
   if (!projectSlug) {
     throw new Error(
-      "Could not determine project slug. Set VERYFRONT_PROJECT_SLUG environment variable or add projectSlug to veryfront.config.ts",
+      "Could not determine project reference. Set VERYFRONT_PROJECT_SLUG, TENANT_PROJECT_SLUG, VERYFRONT_PROJECT_ID, or add projectSlug to veryfront.config.ts",
     );
   }
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.142";
+export const VERSION = "0.1.143";


### PR DESCRIPTION
## Summary
- preserve uploads-prefixed knowledge sources so sandbox/project ingest uses the right remote paths
- resolve tenant project context when explicit project slug is absent
- stabilize the doctor unreachable-server test and bump the CLI patch version to 0.1.144

## Verification
- VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all cli/shared/config.test.ts cli/commands/knowledge/command.test.ts cli/commands/doctor/server-checks.test.ts src/utils/version.test.ts src/utils/logger/logger.test.ts
- full pre-push suite via git push