### PR TITLE
Keep repo project config ahead of tenant CLI fallback

### DIFF
--- a/cli/shared/config.test.ts
+++ b/cli/shared/config.test.ts
@@ -7,6 +7,7 @@ import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { resolveConfig, resolveConfigWithAuth } from "./config.ts";
 import type { EnvironmentConfig } from "#veryfront/config/environment-config.ts";
+import { join } from "veryfront/platform/path";
 
 function createMockEnv(overrides: Partial<EnvironmentConfig> = {}): EnvironmentConfig {
   return {
@@ -117,6 +118,43 @@ describe("resolveConfigWithAuth", () => {
 
       assertEquals(config.projectSlug, "tenant-project");
     } finally {
+      if (previousTenantProjectSlug === undefined) {
+        Deno.env.delete("TENANT_PROJECT_SLUG");
+      } else {
+        Deno.env.set("TENANT_PROJECT_SLUG", previousTenantProjectSlug);
+      }
+
+      if (previousTenantProjectId === undefined) {
+        Deno.env.delete("TENANT_PROJECT_ID");
+      } else {
+        Deno.env.set("TENANT_PROJECT_ID", previousTenantProjectId);
+      }
+    }
+  });
+
+  it("prefers repo config projectSlug over tenant fallback", async () => {
+    const env = createMockEnv({
+      apiToken: "env-token",
+      projectSlug: undefined,
+    });
+    const previousTenantProjectSlug = Deno.env.get("TENANT_PROJECT_SLUG");
+    const previousTenantProjectId = Deno.env.get("TENANT_PROJECT_ID");
+    const tempDir = await Deno.makeTempDir();
+
+    try {
+      await Deno.writeTextFile(
+        join(tempDir, "veryfront.json"),
+        JSON.stringify({ projectSlug: "repo-config-project" }),
+      );
+      Deno.env.set("TENANT_PROJECT_SLUG", "tenant-project");
+      Deno.env.set("TENANT_PROJECT_ID", "tenant-project-id");
+
+      const config = await resolveConfigWithAuth(tempDir, env);
+
+      assertEquals(config.projectSlug, "repo-config-project");
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+
       if (previousTenantProjectSlug === undefined) {
         Deno.env.delete("TENANT_PROJECT_SLUG");
       } else {

--- a/cli/shared/config.ts
+++ b/cli/shared/config.ts
@@ -135,8 +135,8 @@ async function resolveConfigBase(
   }
 
   const projectSlug = env.projectSlug ??
-    resolveTenantProjectReference() ??
     configFile?.projectSlug ??
+    resolveTenantProjectReference() ??
     (await inferProjectSlug(dir));
   if (!projectSlug) {
     throw new Error(

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.143",
+  "version": "0.1.144",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.143";
+export const VERSION = "0.1.144";


### PR DESCRIPTION
## Summary
- keep explicit repo config (`veryfront.config` / `veryfront.json`) ahead of tenant project fallback
- preserve tenant fallback when no repo config is present
- add a regression test covering repo-config precedence over tenant env

## Why
Follow-up to the review on #896: tenant project env should not silently override a repository's configured project.

## Verification
- VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all cli/shared/config.test.ts cli/commands/knowledge/command.test.ts
- full pre-push suite via git push