### PR TITLE
Define a canonical AG-UI runtime contract for package consumers

### DIFF
--- a/docs/reference/agent-runtime-ag-ui-contract.md
+++ b/docs/reference/agent-runtime-ag-ui-contract.md
@@ -1,0 +1,92 @@
+# Agent Runtime AG-UI Contract
+
+This document defines the canonical runtime-facing request contract for the `veryfront` package.
+
+The goal is to make downstream consumers target one explicit AG-UI-aligned input model instead of treating the current runtime transport as a custom side protocol.
+
+## Canonical Contract
+
+The canonical runtime contract is defined in [`src/internal-agents/schema.ts`](/Users/kojiwakayama/Documents/CODE/veryfront-platform/veryfront-code/src/internal-agents/schema.ts) by [`RuntimeRunAgentInputSchema`](/Users/kojiwakayama/Documents/CODE/veryfront-platform/veryfront-code/src/internal-agents/schema.ts).
+
+It is based on the AG-UI `RunAgentInput` shape:
+
+- `threadId`
+- `runId`
+- `parentRunId`
+- `state`
+- `messages`
+- `tools`
+- `context`
+- `forwardedProps`
+
+The runtime response contract remains AG-UI SSE.
+
+## Supported AG-UI Subset
+
+The package runtime currently accepts a text-first subset of AG-UI messages:
+
+- `system`
+- `user`
+- `assistant`
+- `tool`
+
+Current message support is intentionally narrower than the full AG-UI type catalog:
+
+- text content is supported for `system`, `user`, `assistant`, and `tool`
+- assistant `toolCalls` are supported
+- tool messages use `toolCallId` + text content
+
+The package runtime does not currently treat `developer`, `activity`, or `reasoning` messages as canonical input roles for this contract.
+
+## Package/Runtime Extensions
+
+The canonical runtime contract keeps a small number of package/runtime extensions:
+
+- message `metadata`
+- message `createdAt`
+- structured context entries beyond plain AG-UI `{ description, value }`
+
+Structured runtime context currently supports:
+
+- `{ type: "text", text, title? }`
+- `{ type: "json", data, title? }`
+- `{ type: "resource", uri, text?, mimeType?, title? }`
+
+These extensions are part of the package runtime contract, not AG-UI core.
+
+## Transitional Transport Wrapper
+
+The current internal transport route, `/internal/agents/stream`, is a compatibility wrapper, not the canonical package contract.
+
+That wrapper currently adds transport-only fields:
+
+- `agentId`
+- `agentSource`
+
+It also accepts the legacy message shape based on `parts`.
+
+The wrapper is defined by [`InternalAgentStreamRequestSchema`](/Users/kojiwakayama/Documents/CODE/veryfront-platform/veryfront-code/src/internal-agents/schema.ts) and normalized into the canonical runtime input with [`toRuntimeRunAgentInput()`](/Users/kojiwakayama/Documents/CODE/veryfront-platform/veryfront-code/src/internal-agents/schema.ts).
+
+## Endpoint Convention
+
+The package should standardize the runtime contract, not force one hardcoded route.
+
+Recommended default convention:
+
+- `POST /api/ag-ui`
+
+Hosts may override the route when needed.
+
+Current internal compatibility route:
+
+- `POST /internal/agents/stream`
+
+## What Downstream Consumers Should Target
+
+Downstream package/framework consumers should target:
+
+- the canonical `RuntimeRunAgentInputSchema`
+- AG-UI SSE responses
+- the default endpoint convention `/api/ag-ui` unless a host explicitly documents another route
+
+They should not treat `/internal/agents/stream` and its extra wrapper fields as the long-term package contract.

--- a/docs/reference/agent-runtime-ag-ui-contract.md
+++ b/docs/reference/agent-runtime-ag-ui-contract.md
@@ -6,7 +6,7 @@ The goal is to make downstream consumers target one explicit AG-UI-aligned input
 
 ## Canonical Contract
 
-The canonical runtime contract is defined in [`src/internal-agents/schema.ts`](/Users/kojiwakayama/Documents/CODE/veryfront-platform/veryfront-code/src/internal-agents/schema.ts) by [`RuntimeRunAgentInputSchema`](/Users/kojiwakayama/Documents/CODE/veryfront-platform/veryfront-code/src/internal-agents/schema.ts).
+The canonical runtime contract is defined in [`src/internal-agents/schema.ts`](../../src/internal-agents/schema.ts) by [`RuntimeRunAgentInputSchema`](../../src/internal-agents/schema.ts).
 
 It is based on the AG-UI `RunAgentInput` shape:
 
@@ -65,7 +65,7 @@ That wrapper currently adds transport-only fields:
 
 It also accepts the legacy message shape based on `parts`.
 
-The wrapper is defined by [`InternalAgentStreamRequestSchema`](/Users/kojiwakayama/Documents/CODE/veryfront-platform/veryfront-code/src/internal-agents/schema.ts) and normalized into the canonical runtime input with [`toRuntimeRunAgentInput()`](/Users/kojiwakayama/Documents/CODE/veryfront-platform/veryfront-code/src/internal-agents/schema.ts).
+The wrapper is defined by [`InternalAgentStreamRequestSchema`](../../src/internal-agents/schema.ts) and normalized into the canonical runtime input with [`toRuntimeRunAgentInput()`](../../src/internal-agents/schema.ts).
 
 ## Endpoint Convention
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -14,6 +14,10 @@ Complete API reference for the Veryfront framework.
 npm install veryfront
 ```
 
+## Additional References
+
+- [Agent runtime AG-UI contract](./agent-runtime-ag-ui-contract.md) - Canonical runtime-facing request contract, compatibility wrapper, and endpoint conventions for AG-UI execution.
+
 ## Modules
 
 | Import | Description |

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -119,95 +119,60 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function normalizeToolArgs(part: Record<string, unknown>): Record<string, unknown> {
-  if (isRecord(part.args)) {
-    return part.args;
+function parseToolArguments(serializedArguments: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(serializedArguments);
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
   }
-
-  if (isRecord(part.input)) {
-    return part.input;
-  }
-
-  return {};
-}
-
-function normalizeMessagePart(part: Record<string, unknown>): Message["parts"][number] | null {
-  if (part.type === "text" && typeof part.text === "string") {
-    return { type: "text", text: part.text };
-  }
-
-  if (
-    part.type === "tool_call" &&
-    typeof part.id === "string" &&
-    typeof part.name === "string"
-  ) {
-    return {
-      type: "tool-call",
-      toolCallId: part.id,
-      toolName: part.name,
-      args: normalizeToolArgs(part),
-    };
-  }
-
-  if (
-    part.type === "tool-call" &&
-    typeof part.toolCallId === "string" &&
-    typeof part.toolName === "string"
-  ) {
-    return {
-      type: "tool-call",
-      toolCallId: part.toolCallId,
-      toolName: part.toolName,
-      args: normalizeToolArgs(part),
-    };
-  }
-
-  if (
-    typeof part.type === "string" &&
-    part.type.startsWith("tool-") &&
-    part.type !== "tool-result" &&
-    typeof part.toolCallId === "string" &&
-    typeof part.toolName === "string"
-  ) {
-    return {
-      type: part.type,
-      toolCallId: part.toolCallId,
-      toolName: part.toolName,
-      args: normalizeToolArgs(part),
-    };
-  }
-
-  if (part.type === "tool_result" && typeof part.tool_call_id === "string") {
-    return {
-      type: "tool-result",
-      toolCallId: part.tool_call_id,
-      toolName: typeof part.tool_name === "string" ? part.tool_name : "unknown",
-      result: "output" in part ? part.output : undefined,
-    };
-  }
-
-  if (part.type === "tool-result" && typeof part.toolCallId === "string") {
-    return {
-      type: "tool-result",
-      toolCallId: part.toolCallId,
-      toolName: typeof part.toolName === "string" ? part.toolName : "unknown",
-      result: "result" in part ? part.result : undefined,
-    };
-  }
-
-  return null;
 }
 
 function normalizeRuntimeMessages(messages: RuntimeRunAgentInput["messages"]): Message[] {
-  return messages.map((message) => ({
-    id: message.id,
-    role: message.role,
-    parts: message.parts
-      .map((part) => isRecord(part) ? normalizeMessagePart(part) : null)
-      .filter((part): part is Message["parts"][number] => part !== null),
-    ...(message.createdAt ? { timestamp: Date.parse(message.createdAt) || undefined } : {}),
-    ...(message.metadata ? { metadata: message.metadata } : {}),
-  }));
+  return messages.map((message) => {
+    const parts: Message["parts"] = [];
+
+    switch (message.role) {
+      case "system":
+      case "user":
+        parts.push({ type: "text", text: message.content });
+        break;
+      case "assistant":
+        if (typeof message.content === "string" && message.content.length > 0) {
+          parts.push({ type: "text", text: message.content });
+        }
+        for (const toolCall of message.toolCalls ?? []) {
+          parts.push({
+            type: "tool-call",
+            toolCallId: toolCall.id,
+            toolName: toolCall.function.name,
+            args: parseToolArguments(toolCall.function.arguments),
+          });
+        }
+        break;
+      case "tool":
+        parts.push({
+          type: "tool-result",
+          toolCallId: message.toolCallId,
+          toolName: "unknown",
+          result: message.error
+            ? {
+              content: message.content,
+              error: message.error,
+            }
+            : message.content,
+        });
+        break;
+    }
+
+    return {
+      id: message.id,
+      role: message.role,
+      parts,
+      ...(message.createdAt ? { timestamp: Date.parse(message.createdAt) || undefined } : {}),
+      ...(message.metadata ? { metadata: message.metadata } : {}),
+    };
+  });
 }
 
 function getAllowedRemoteToolNames(
@@ -234,7 +199,7 @@ export async function createRuntimeAgentStreamResponse(
   logger.info("Starting internal agent runtime stream", {
     runId: input.runId,
     threadId: input.threadId,
-    agentId: input.agentId,
+    agentId: agent.id,
     messageCount: input.messages.length,
     toolCount: input.tools.length,
     contextCount: input.context.length,
@@ -269,6 +234,8 @@ export async function createRuntimeAgentStreamResponse(
       {
         threadId: input.threadId,
         runId: input.runId,
+        ...(input.parentRunId ? { parentRunId: input.parentRunId } : {}),
+        ...(input.state !== undefined ? { state: input.state } : {}),
         context: input.context,
         forwardedProps: input.forwardedProps,
       },
@@ -284,14 +251,14 @@ export async function createRuntimeAgentStreamResponse(
     logger.info("Internal agent runtime stream attached", {
       runId: input.runId,
       threadId: input.threadId,
-      agentId: input.agentId,
+      agentId: agent.id,
     });
   } catch (error) {
     deps.sessionManager.failRun(input.runId);
     logger.error("Internal agent runtime stream setup failed", {
       runId: input.runId,
       threadId: input.threadId,
-      agentId: input.agentId,
+      agentId: agent.id,
       error: error instanceof Error ? error.message : String(error),
     });
     throw error;
@@ -329,7 +296,7 @@ export async function createRuntimeAgentStreamResponse(
         logger.warn("Internal agent runtime stream aborted", {
           runId: input.runId,
           threadId: input.threadId,
-          agentId: input.agentId,
+          agentId: agent.id,
         });
         reader.cancel(new AgentRunCancelledError()).catch(() => {});
       };
@@ -338,7 +305,7 @@ export async function createRuntimeAgentStreamResponse(
       enqueueIfAttached("RunStarted", {
         runId: input.runId,
         threadId: input.threadId,
-        agentId: input.agentId,
+        agentId: agent.id,
       });
 
       try {
@@ -352,7 +319,7 @@ export async function createRuntimeAgentStreamResponse(
             logger.info("Internal agent runtime stream reader completed", {
               runId: input.runId,
               threadId: input.threadId,
-              agentId: input.agentId,
+              agentId: agent.id,
             });
             break;
           }
@@ -386,7 +353,7 @@ export async function createRuntimeAgentStreamResponse(
         logger.info("Internal agent runtime stream finalized", {
           runId: input.runId,
           threadId: input.threadId,
-          agentId: input.agentId,
+          agentId: agent.id,
           sawVisibleOutput: state.sawVisibleOutput,
           sawTerminalError: state.sawTerminalError,
           finishReason: state.metadata.finishReason,
@@ -397,7 +364,7 @@ export async function createRuntimeAgentStreamResponse(
           logger.warn("Internal agent runtime stream cancelled", {
             runId: input.runId,
             threadId: input.threadId,
-            agentId: input.agentId,
+            agentId: agent.id,
             error: error.message,
           });
           enqueueIfAttached("RunError", {
@@ -409,7 +376,7 @@ export async function createRuntimeAgentStreamResponse(
           logger.error("Internal agent runtime stream failed", {
             runId: input.runId,
             threadId: input.threadId,
-            agentId: input.agentId,
+            agentId: agent.id,
             error: error instanceof Error ? error.message : String(error),
           });
           enqueueIfAttached("RunError", {
@@ -425,7 +392,7 @@ export async function createRuntimeAgentStreamResponse(
         logger.debug("Internal agent runtime stream response closed", {
           runId: input.runId,
           threadId: input.threadId,
-          agentId: input.agentId,
+          agentId: agent.id,
           clientAttached,
         });
       }
@@ -435,7 +402,7 @@ export async function createRuntimeAgentStreamResponse(
       logger.info("Internal agent runtime client detached", {
         runId: input.runId,
         threadId: input.threadId,
-        agentId: input.agentId,
+        agentId: agent.id,
       });
       return Promise.resolve();
     },

--- a/src/internal-agents/schema.test.ts
+++ b/src/internal-agents/schema.test.ts
@@ -172,4 +172,107 @@ describe("internal-agents/schema", () => {
       context: [{ type: "text", text: "Current file: src/main.ts" }],
     });
   });
+
+  it("preserves canonical runtime messages on the compatibility route", () => {
+    const internalRequest = InternalAgentStreamRequestSchema.parse({
+      agentId: "agent_1",
+      threadId: "10000000-1000-4000-8000-100000000001",
+      runId: "run_1",
+      messages: [
+        {
+          id: "assistant_1",
+          role: "assistant",
+          content: "Working on it",
+          toolCalls: [{
+            id: "tool_1",
+            type: "function",
+            function: {
+              name: "search_docs",
+              arguments: JSON.stringify({ query: "ag-ui" }),
+            },
+          }],
+        },
+        {
+          id: "tool_1",
+          role: "tool",
+          toolCallId: "tool_1",
+          content: "Found docs",
+        },
+      ],
+      context: [],
+    });
+
+    assertEquals(toRuntimeRunAgentInput(internalRequest).messages, [
+      {
+        id: "assistant_1",
+        role: "assistant",
+        content: "Working on it",
+        toolCalls: [{
+          id: "tool_1",
+          type: "function",
+          function: {
+            name: "search_docs",
+            arguments: JSON.stringify({ query: "ag-ui" }),
+          },
+        }],
+      },
+      {
+        id: "tool_1",
+        role: "tool",
+        toolCallId: "tool_1",
+        content: "Found docs",
+      },
+    ]);
+  });
+
+  it("normalizes legacy tool_call and tool_result parts", () => {
+    const internalRequest = InternalAgentStreamRequestSchema.parse({
+      agentId: "agent_1",
+      threadId: "10000000-1000-4000-8000-100000000001",
+      runId: "run_1",
+      messages: [
+        {
+          id: "assistant_1",
+          role: "assistant",
+          parts: [{
+            type: "tool_call",
+            id: "tool_legacy",
+            name: "search_docs",
+            args: { query: "ag-ui" },
+          }],
+        },
+        {
+          id: "tool_message_1",
+          role: "tool",
+          parts: [{
+            type: "tool_result",
+            tool_call_id: "tool_legacy",
+            output: { ok: true },
+          }],
+        },
+      ],
+      context: [],
+    });
+
+    assertEquals(toRuntimeRunAgentInput(internalRequest).messages, [
+      {
+        id: "assistant_1",
+        role: "assistant",
+        toolCalls: [{
+          id: "tool_legacy",
+          type: "function",
+          function: {
+            name: "search_docs",
+            arguments: JSON.stringify({ query: "ag-ui" }),
+          },
+        }],
+      },
+      {
+        id: "tool_message_1",
+        role: "tool",
+        toolCallId: "tool_legacy",
+        content: JSON.stringify({ ok: true }),
+      },
+    ]);
+  });
 });

--- a/src/internal-agents/schema.test.ts
+++ b/src/internal-agents/schema.test.ts
@@ -1,11 +1,15 @@
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { ResumeSignalSchema, RuntimeRunAgentInputSchema } from "./schema.ts";
+import {
+  InternalAgentStreamRequestSchema,
+  ResumeSignalSchema,
+  RuntimeRunAgentInputSchema,
+  toRuntimeRunAgentInput,
+} from "./schema.ts";
 
 describe("internal-agents/schema", () => {
   it("applies defaults for optional runtime collections", () => {
     const parsed = RuntimeRunAgentInputSchema.parse({
-      agentId: "agent_1",
       threadId: crypto.randomUUID(),
       runId: "run_1",
       messages: [],
@@ -19,7 +23,6 @@ describe("internal-agents/schema", () => {
     assertThrows(
       () =>
         RuntimeRunAgentInputSchema.parse({
-          agentId: "agent_1",
           threadId: crypto.randomUUID(),
           runId: "run_1",
           messages: [],
@@ -37,7 +40,6 @@ describe("internal-agents/schema", () => {
     assertThrows(
       () =>
         RuntimeRunAgentInputSchema.parse({
-          agentId: "agent_1",
           threadId: crypto.randomUUID(),
           runId: "run_1",
           messages: [],
@@ -65,5 +67,109 @@ describe("internal-agents/schema", () => {
         isError: false,
       },
     );
+  });
+
+  it("accepts a canonical AG-UI-aligned runtime payload", () => {
+    const parsed = RuntimeRunAgentInputSchema.parse({
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      parentRunId: "run_parent",
+      state: { phase: "draft" },
+      messages: [
+        {
+          id: "sys_1",
+          role: "system",
+          content: "You are helpful",
+        },
+        {
+          id: "user_1",
+          role: "user",
+          content: "Hello",
+        },
+        {
+          id: "assistant_1",
+          role: "assistant",
+          content: "Working on it",
+          toolCalls: [{
+            id: "tool_1",
+            type: "function",
+            function: {
+              name: "search_docs",
+              arguments: JSON.stringify({ query: "ag-ui" }),
+            },
+          }],
+        },
+      ],
+      context: [{
+        description: "Current file",
+        value: "src/main.ts",
+      }],
+      forwardedProps: {
+        runtimeOverrides: {
+          allowedTools: ["search_docs"],
+        },
+      },
+    });
+
+    assertEquals(parsed.parentRunId, "run_parent");
+    assertEquals(parsed.state, { phase: "draft" });
+    assertEquals(parsed.messages[2].role, "assistant");
+    assertEquals(parsed.context, [{ description: "Current file", value: "src/main.ts" }]);
+  });
+
+  it("normalizes legacy internal stream payloads into the canonical runtime input", () => {
+    const internalRequest = InternalAgentStreamRequestSchema.parse({
+      agentId: "agent_1",
+      threadId: "10000000-1000-4000-8000-100000000001",
+      runId: "run_1",
+      messages: [
+        {
+          id: "user_1",
+          role: "user",
+          parts: [{ type: "text", text: "Hello" }],
+        },
+        {
+          id: "assistant_1",
+          role: "assistant",
+          parts: [
+            { type: "text", text: "Let me check" },
+            {
+              type: "tool-call",
+              toolCallId: "tool_1",
+              toolName: "search_docs",
+              args: { query: "ag-ui" },
+            },
+          ],
+        },
+      ],
+      context: [{ type: "text", text: "Current file: src/main.ts" }],
+    });
+
+    assertEquals(toRuntimeRunAgentInput(internalRequest), {
+      threadId: "10000000-1000-4000-8000-100000000001",
+      runId: "run_1",
+      messages: [
+        {
+          id: "user_1",
+          role: "user",
+          content: "Hello",
+        },
+        {
+          id: "assistant_1",
+          role: "assistant",
+          content: "Let me check",
+          toolCalls: [{
+            id: "tool_1",
+            type: "function",
+            function: {
+              name: "search_docs",
+              arguments: JSON.stringify({ query: "ag-ui" }),
+            },
+          }],
+        },
+      ],
+      tools: [],
+      context: [{ type: "text", text: "Current file: src/main.ts" }],
+    });
   });
 });

--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -79,21 +79,105 @@ export const RuntimeAgentSourceContextSchema = z.discriminatedUnion("type", [
   }),
 ]);
 
+const RuntimeMessageExtensionFieldsSchema = {
+  name: z.string().max(256).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  createdAt: z.string().optional(),
+} as const;
+
+export const RuntimeToolFunctionCallSchema = z.object({
+  name: ClientToolNameSchema,
+  arguments: z.string().max(MAX_TOOL_PARAMETERS_BYTES),
+});
+
+export const RuntimeToolCallSchema = z.object({
+  id: z.string().min(1).max(128),
+  type: z.literal("function"),
+  function: RuntimeToolFunctionCallSchema,
+});
+
+export const RuntimeSystemMessageSchema = z.object({
+  id: z.string().min(1),
+  role: z.literal("system"),
+  content: z.string(),
+  ...RuntimeMessageExtensionFieldsSchema,
+});
+
+export const RuntimeUserMessageSchema = z.object({
+  id: z.string().min(1),
+  role: z.literal("user"),
+  content: z.string(),
+  ...RuntimeMessageExtensionFieldsSchema,
+});
+
+export const RuntimeAssistantMessageSchema = z.object({
+  id: z.string().min(1),
+  role: z.literal("assistant"),
+  content: z.string().optional(),
+  toolCalls: z.array(RuntimeToolCallSchema).optional(),
+  ...RuntimeMessageExtensionFieldsSchema,
+});
+
+export const RuntimeToolMessageSchema = z.object({
+  id: z.string().min(1),
+  role: z.literal("tool"),
+  toolCallId: z.string().min(1).max(128),
+  content: z.string(),
+  error: z.string().optional(),
+  ...RuntimeMessageExtensionFieldsSchema,
+});
+
+export const RuntimeMessageSchema = z.discriminatedUnion("role", [
+  RuntimeSystemMessageSchema,
+  RuntimeUserMessageSchema,
+  RuntimeAssistantMessageSchema,
+  RuntimeToolMessageSchema,
+]);
+
+export const RuntimeContextSchema = z.union([
+  z.object({
+    description: z.string().max(1024),
+    value: z.string().max(MAX_CONTEXT_ITEM_BYTES),
+  }),
+  RuntimeContextItemSchema,
+]);
+
 export const RuntimeRunAgentInputSchema = z.object({
+  threadId: z.string().uuid(),
+  runId: RunIdSchema,
+  parentRunId: RunIdSchema.optional(),
+  state: z.unknown().optional(),
+  messages: z.array(RuntimeMessageSchema).max(MAX_RUNTIME_MESSAGES),
+  tools: z.array(RuntimeInjectedToolSchema).max(50).default([]),
+  context: z.array(RuntimeContextSchema).max(10).default([]).refine(
+    (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_TOTAL_BYTES),
+    { message: "context must be less than 64 KB total" },
+  ),
+  forwardedProps: z.record(z.string(), z.unknown()).optional().refine(
+    (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_FORWARDED_PROPS_BYTES),
+    { message: "forwardedProps must be less than 64 KB" },
+  ),
+});
+
+export const InternalAgentCompatibilityMessageSchema = z.object({
+  id: z.string().min(1),
+  role: z.enum(["user", "assistant", "system", "tool"]),
+  parts: z.array(z.object({ type: z.string().min(1) }).passthrough()).default([]),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  createdAt: z.string().optional(),
+});
+
+export const InternalAgentStreamRequestSchema = z.object({
   agentId: AgentIdSchema,
   threadId: z.string().uuid(),
   runId: RunIdSchema,
-  messages: z.array(
-    z.object({
-      id: z.string().min(1),
-      role: z.enum(["user", "assistant", "system", "tool"]),
-      parts: z.array(z.object({ type: z.string().min(1) }).passthrough()).default([]),
-      metadata: z.record(z.string(), z.unknown()).optional(),
-      createdAt: z.string().optional(),
-    }),
-  ).max(MAX_RUNTIME_MESSAGES),
+  parentRunId: RunIdSchema.optional(),
+  state: z.unknown().optional(),
+  messages: z.array(z.union([InternalAgentCompatibilityMessageSchema, RuntimeMessageSchema])).max(
+    MAX_RUNTIME_MESSAGES,
+  ),
   tools: z.array(RuntimeInjectedToolSchema).max(50).default([]),
-  context: z.array(RuntimeContextItemSchema).max(10).default([]).refine(
+  context: z.array(RuntimeContextSchema).max(10).default([]).refine(
     (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_TOTAL_BYTES),
     { message: "context must be less than 64 KB total" },
   ),
@@ -103,6 +187,145 @@ export const RuntimeRunAgentInputSchema = z.object({
     { message: "forwardedProps must be less than 64 KB" },
   ),
 });
+
+type RuntimeMessage = z.infer<typeof RuntimeMessageSchema>;
+type InternalAgentCompatibilityMessage = z.infer<typeof InternalAgentCompatibilityMessageSchema>;
+
+function extractToolArgs(
+  part: Record<string, unknown>,
+): Record<string, unknown> {
+  const args = part.args;
+  if (args && typeof args === "object" && !Array.isArray(args)) {
+    return args as Record<string, unknown>;
+  }
+
+  const input = part.input;
+  if (input && typeof input === "object" && !Array.isArray(input)) {
+    return input as Record<string, unknown>;
+  }
+
+  return {};
+}
+
+function serializeToolArguments(args: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(args);
+  } catch {
+    return "{}";
+  }
+}
+
+function stringifyToolResult(result: unknown): string {
+  if (typeof result === "string") {
+    return result;
+  }
+
+  try {
+    return JSON.stringify(result);
+  } catch {
+    return String(result);
+  }
+}
+
+function toRuntimeMessage(
+  message: RuntimeMessage | InternalAgentCompatibilityMessage,
+): RuntimeMessage {
+  if (!("parts" in message)) {
+    return message;
+  }
+
+  const textContent = message.parts
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("\n");
+
+  const sharedFields = {
+    ...(message.metadata ? { metadata: message.metadata } : {}),
+    ...(message.createdAt ? { createdAt: message.createdAt } : {}),
+  };
+
+  switch (message.role) {
+    case "system":
+      return {
+        id: message.id,
+        role: "system",
+        content: textContent,
+        ...sharedFields,
+      };
+    case "user":
+      return {
+        id: message.id,
+        role: "user",
+        content: textContent,
+        ...sharedFields,
+      };
+    case "assistant": {
+      const toolCalls = message.parts.flatMap((part) => {
+        const isToolCallPart = part.type === "tool-call" ||
+          (part.type.startsWith("tool-") && part.type !== "tool-result");
+        if (
+          !isToolCallPart ||
+          typeof part.toolCallId !== "string" ||
+          typeof part.toolName !== "string"
+        ) {
+          return [];
+        }
+
+        return [{
+          id: part.toolCallId,
+          type: "function" as const,
+          function: {
+            name: part.toolName,
+            arguments: serializeToolArguments(extractToolArgs(part)),
+          },
+        }];
+      });
+
+      return {
+        id: message.id,
+        role: "assistant",
+        ...(textContent ? { content: textContent } : {}),
+        ...(toolCalls.length ? { toolCalls } : {}),
+        ...sharedFields,
+      };
+    }
+    case "tool": {
+      const toolResultPart = message.parts.find(
+        (part) => part.type === "tool-result" && typeof part.toolCallId === "string",
+      );
+
+      return {
+        id: message.id,
+        role: "tool",
+        toolCallId: toolResultPart && typeof toolResultPart.toolCallId === "string"
+          ? toolResultPart.toolCallId
+          : message.id,
+        content: toolResultPart && "result" in toolResultPart
+          ? stringifyToolResult(toolResultPart.result)
+          : textContent,
+        ...(toolResultPart && typeof toolResultPart.error === "string"
+          ? { error: toolResultPart.error }
+          : {}),
+        ...sharedFields,
+      };
+    }
+  }
+}
+
+export function toRuntimeRunAgentInput(
+  input: z.infer<typeof InternalAgentStreamRequestSchema>,
+): z.infer<typeof RuntimeRunAgentInputSchema> {
+  return {
+    threadId: input.threadId,
+    runId: input.runId,
+    ...(input.parentRunId ? { parentRunId: input.parentRunId } : {}),
+    ...(input.state !== undefined ? { state: input.state } : {}),
+    messages: input.messages.map(toRuntimeMessage),
+    tools: input.tools,
+    context: input.context,
+    ...(input.forwardedProps ? { forwardedProps: input.forwardedProps } : {}),
+  };
+}
 
 export const ResumeSignalSchema = z.discriminatedUnion("type", [
   z.object({
@@ -120,4 +343,5 @@ export type RuntimeInjectedTool = z.infer<typeof RuntimeInjectedToolSchema>;
 export type RuntimeContextItem = z.infer<typeof RuntimeContextItemSchema>;
 export type RuntimeAgentSourceContext = z.infer<typeof RuntimeAgentSourceContextSchema>;
 export type RuntimeRunAgentInput = z.infer<typeof RuntimeRunAgentInputSchema>;
+export type InternalAgentStreamRequest = z.infer<typeof InternalAgentStreamRequestSchema>;
 export type ResumeSignal = z.infer<typeof ResumeSignalSchema>;

--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -88,27 +88,27 @@ const RuntimeMessageExtensionFieldsSchema = {
 export const RuntimeToolFunctionCallSchema = z.object({
   name: ClientToolNameSchema,
   arguments: z.string().max(MAX_TOOL_PARAMETERS_BYTES),
-});
+}).strict();
 
 export const RuntimeToolCallSchema = z.object({
   id: z.string().min(1).max(128),
   type: z.literal("function"),
   function: RuntimeToolFunctionCallSchema,
-});
+}).strict();
 
 export const RuntimeSystemMessageSchema = z.object({
   id: z.string().min(1),
   role: z.literal("system"),
   content: z.string(),
   ...RuntimeMessageExtensionFieldsSchema,
-});
+}).strict();
 
 export const RuntimeUserMessageSchema = z.object({
   id: z.string().min(1),
   role: z.literal("user"),
   content: z.string(),
   ...RuntimeMessageExtensionFieldsSchema,
-});
+}).strict();
 
 export const RuntimeAssistantMessageSchema = z.object({
   id: z.string().min(1),
@@ -116,7 +116,7 @@ export const RuntimeAssistantMessageSchema = z.object({
   content: z.string().optional(),
   toolCalls: z.array(RuntimeToolCallSchema).optional(),
   ...RuntimeMessageExtensionFieldsSchema,
-});
+}).strict();
 
 export const RuntimeToolMessageSchema = z.object({
   id: z.string().min(1),
@@ -125,7 +125,7 @@ export const RuntimeToolMessageSchema = z.object({
   content: z.string(),
   error: z.string().optional(),
   ...RuntimeMessageExtensionFieldsSchema,
-});
+}).strict();
 
 export const RuntimeMessageSchema = z.discriminatedUnion("role", [
   RuntimeSystemMessageSchema,
@@ -173,7 +173,7 @@ export const InternalAgentStreamRequestSchema = z.object({
   runId: RunIdSchema,
   parentRunId: RunIdSchema.optional(),
   state: z.unknown().optional(),
-  messages: z.array(z.union([InternalAgentCompatibilityMessageSchema, RuntimeMessageSchema])).max(
+  messages: z.array(z.union([RuntimeMessageSchema, InternalAgentCompatibilityMessageSchema])).max(
     MAX_RUNTIME_MESSAGES,
   ),
   tools: z.array(RuntimeInjectedToolSchema).max(50).default([]),
@@ -213,6 +213,57 @@ function serializeToolArguments(args: Record<string, unknown>): string {
   } catch {
     return "{}";
   }
+}
+
+function getPartString(
+  part: Record<string, unknown>,
+  ...keys: string[]
+): string | null {
+  for (const key of keys) {
+    const value = part[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function isLegacyToolCallPart(part: Record<string, unknown>): boolean {
+  return getPartString(part, "type") === "tool_call";
+}
+
+function isCanonicalToolCallPart(part: Record<string, unknown>): boolean {
+  const type = getPartString(part, "type");
+
+  return type === "tool-call" ||
+    (typeof type === "string" && type.startsWith("tool-") && type !== "tool-result" &&
+      type !== "tool_result");
+}
+
+function getToolCallShape(
+  part: Record<string, unknown>,
+): z.infer<typeof RuntimeToolCallSchema> | null {
+  const id = getPartString(part, "toolCallId", "tool_call_id", "id");
+  const name = getPartString(part, "toolName", "tool_name", "name");
+
+  if (!id || !name) {
+    return null;
+  }
+
+  return {
+    id,
+    type: "function",
+    function: {
+      name,
+      arguments: serializeToolArguments(extractToolArgs(part)),
+    },
+  };
+}
+
+function isToolResultPart(part: Record<string, unknown>): boolean {
+  const type = getPartString(part, "type");
+  return type === "tool-result" || type === "tool_result";
 }
 
 function stringifyToolResult(result: unknown): string {
@@ -261,24 +312,12 @@ function toRuntimeMessage(
       };
     case "assistant": {
       const toolCalls = message.parts.flatMap((part) => {
-        const isToolCallPart = part.type === "tool-call" ||
-          (part.type.startsWith("tool-") && part.type !== "tool-result");
-        if (
-          !isToolCallPart ||
-          typeof part.toolCallId !== "string" ||
-          typeof part.toolName !== "string"
-        ) {
+        if (!isCanonicalToolCallPart(part) && !isLegacyToolCallPart(part)) {
           return [];
         }
 
-        return [{
-          id: part.toolCallId,
-          type: "function" as const,
-          function: {
-            name: part.toolName,
-            arguments: serializeToolArguments(extractToolArgs(part)),
-          },
-        }];
+        const toolCall = getToolCallShape(part);
+        return toolCall ? [toolCall] : [];
       });
 
       return {
@@ -291,21 +330,25 @@ function toRuntimeMessage(
     }
     case "tool": {
       const toolResultPart = message.parts.find(
-        (part) => part.type === "tool-result" && typeof part.toolCallId === "string",
+        (part) =>
+          isToolResultPart(part) && getPartString(part, "toolCallId", "tool_call_id") !== null,
       );
+      const toolCallId = toolResultPart
+        ? getPartString(toolResultPart, "toolCallId", "tool_call_id")
+        : null;
+      const toolResult = toolResultPart && "result" in toolResultPart
+        ? toolResultPart.result
+        : toolResultPart && "output" in toolResultPart
+        ? toolResultPart.output
+        : undefined;
+      const toolError = toolResultPart ? getPartString(toolResultPart, "error") : null;
 
       return {
         id: message.id,
         role: "tool",
-        toolCallId: toolResultPart && typeof toolResultPart.toolCallId === "string"
-          ? toolResultPart.toolCallId
-          : message.id,
-        content: toolResultPart && "result" in toolResultPart
-          ? stringifyToolResult(toolResultPart.result)
-          : textContent,
-        ...(toolResultPart && typeof toolResultPart.error === "string"
-          ? { error: toolResultPart.error }
-          : {}),
+        toolCallId: toolCallId ?? message.id,
+        content: toolResult !== undefined ? stringifyToolResult(toolResult) : textContent,
+        ...(toolError ? { error: toolError } : {}),
         ...sharedFields,
       };
     }

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -221,6 +221,105 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(text.includes("event: ReasoningEnd"), false);
   });
 
+  it("accepts the canonical runtime AG-UI request shape on the existing internal stream route", async () => {
+    let streamContext: Record<string, unknown> | undefined;
+
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: (id) => id === "assistant-1" ? createAgent("assistant-1") : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager: new AgentRunSessionManager(),
+      createRuntime: () => ({
+        stream: async (_messages, context, callbacks) => {
+          streamContext = context;
+          callbacks?.onFinish?.({
+            text: "hello from runtime",
+            messages: [],
+            toolCalls: [],
+            status: "completed",
+            usage: {
+              promptTokens: 2,
+              completionTokens: 3,
+              totalTokens: 5,
+            },
+            metadata: {
+              finishReason: "stop",
+            },
+          });
+
+          return new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encodeDataStreamEvent({ type: "message-start", messageId: "assistant-msg-1" }),
+              );
+              controller.enqueue(encodeDataStreamEvent({ type: "text-start", id: "text-1" }));
+              controller.enqueue(
+                encodeDataStreamEvent({
+                  type: "text-delta",
+                  id: "text-1",
+                  delta: "hello from runtime",
+                }),
+              );
+              controller.enqueue(encodeDataStreamEvent({ type: "text-end", id: "text-1" }));
+              controller.close();
+            },
+          });
+        },
+      }),
+    });
+
+    const body = JSON.stringify({
+      agentId: "assistant-1",
+      threadId: "10000000-1000-4000-8000-100000000001",
+      runId: "run_1",
+      parentRunId: "run_parent",
+      state: { phase: "draft" },
+      messages: [
+        {
+          id: "sys_1",
+          role: "system",
+          content: "You are helpful",
+        },
+        {
+          id: "user_1",
+          role: "user",
+          content: "hello",
+        },
+      ],
+      context: [{
+        description: "Current file",
+        value: "src/main.ts",
+      }],
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(streamContext, {
+      threadId: "10000000-1000-4000-8000-100000000001",
+      runId: "run_1",
+      parentRunId: "run_parent",
+      state: { phase: "draft" },
+      context: [{
+        description: "Current file",
+        value: "src/main.ts",
+      }],
+      forwardedProps: undefined,
+    });
+  });
+
   it("passes runtime integration tool allowlists from forwarded props into the runtime agent config", async () => {
     let capturedAllowedTools: string[] | undefined;
 

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -23,8 +23,9 @@ import {
   agentRunSessionManager,
 } from "#veryfront/internal-agents/session-manager.ts";
 import {
+  InternalAgentStreamRequestSchema,
   type RuntimeAgentSourceContext,
-  RuntimeRunAgentInputSchema,
+  toRuntimeRunAgentInput,
 } from "#veryfront/internal-agents/schema.ts";
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
@@ -161,7 +162,7 @@ export class AgentStreamHandler extends BaseHandler {
           req,
           INTERNAL_AGENT_STREAM_MAX_BODY_BYTES,
         );
-        const payload = RuntimeRunAgentInputSchema.parse(JSON.parse(rawBody));
+        const payload = InternalAgentStreamRequestSchema.parse(JSON.parse(rawBody));
         await verifyControlPlaneRequest(req, ctx, rawBody, {
           expectedSubject: payload.runId,
           expectedSurface: "studio",
@@ -194,8 +195,9 @@ export class AgentStreamHandler extends BaseHandler {
               return this.respond(builder.json({ error: "Agent not found" }, 404));
             }
 
+            const runtimeInput = toRuntimeRunAgentInput(payload);
             const response = await createRuntimeAgentStreamResponse(
-              payload,
+              runtimeInput,
               agent as Agent,
               this.deps,
             );


### PR DESCRIPTION
## Summary
- split the canonical runtime request shape from the transitional internal stream wrapper
- normalize legacy parts-based internal payloads into the canonical AG-UI-aligned runtime input
- document the runtime contract and default endpoint convention for downstream hosts

## Testing
- VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/internal-agents/schema.test.ts src/server/handlers/request/agent-stream.handler.test.ts src/internal-agents/ag-ui-sse.test.ts
- VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --parallel --allow-all --v8-flags=--max-old-space-size=8192 '--ignore=tests,src/ai/workflow/__tests__' --unstable-worker-options --unstable-net   $(find src cli -name '*.test.ts' ! -name '*.integration.test.ts')

Closes #898