### PR TITLE
Add generic remote MCP tool sources to the package runtime

### DIFF
--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -54,6 +54,24 @@ const assistant = agent({
 });
 ```
 
+### Agent with remote MCP tools
+
+```ts
+import { agent } from "veryfront/agent";
+import { createRemoteMCPToolSource } from "veryfront/tool";
+
+const docsTools = createRemoteMCPToolSource({
+  id: "docs-mcp",
+  endpoint: "https://docs.example.com/mcp",
+  headers: { Authorization: `Bearer ${Deno.env.get("DOCS_TOKEN")}` },
+});
+
+const assistant = agent({
+  system: "Use the docs tools when the question needs external product docs.",
+  remoteTools: [docsTools],
+});
+```
+
 ### Agent with skills
 
 ```ts
@@ -119,6 +137,7 @@ when bootstrap credentials are present.
 | `model?`         | `ModelString`                                                                        | Provider/model override. Omit or use `"auto"` for runtime defaults. |
 | `system`         | <code>string &#124; (() =&gt; string) &#124; (() =&gt; Promise&lt;string&gt;)</code> | System prompt — string, function, or async function                 |
 | `tools?`         | <code>true &#124; Record&lt;string, Tool &#124; boolean&gt;</code>                   | Tools available to the agent                                        |
+| `remoteTools?`   | `RemoteToolSource[]`                                                                 | Remote tool sources queried per request (for example remote MCP)    |
 | `maxSteps?`      | `number`                                                                             | Max tool-call iterations per request                                |
 | `streaming?`     | `boolean`                                                                            | Enable streaming responses                                          |
 | `memory?`        | `MemoryConfig`                                                                       | Conversation memory settings                                        |
@@ -256,6 +275,7 @@ Clear all stored messages from memory.
 | `MessagePart`                    | Multi-part message segment                                                   |
 | `ModelProvider`                  | Model provider interface                                                     |
 | `ModelString`                    | Model configuration string format: "provider/model-name"                     |
+| `RemoteToolSource`               | Runtime-discovered remote tool source                                        |
 | `RedisClient`                    | Redis client interface (compatible with ioredis and node-redis)              |
 | `RedisMemoryConfig`              | Redis memory configuration                                                   |
 | `StreamToolCall`                 | Streaming tool call                                                          |

--- a/docs/reference/tool.md
+++ b/docs/reference/tool.md
@@ -12,10 +12,11 @@ Define tools with Zod schemas for agents and MCP.
 
 ```ts
 import {
-  tool,
+  createRemoteMCPToolSource,
   dynamicTool,
-  toolRegistry,
   executeTool,
+  tool,
+  toolRegistry,
 } from "veryfront/tool";
 ```
 
@@ -61,48 +62,78 @@ const assistant = agent({
 });
 ```
 
+### Remote MCP tool source
+
+```ts
+import { createRemoteMCPToolSource } from "veryfront/tool";
+
+const docsTools = createRemoteMCPToolSource({
+  id: "docs-mcp",
+  endpoint: "https://docs.example.com/mcp",
+  headers: { Authorization: `Bearer ${Deno.env.get("DOCS_TOKEN")}` },
+});
+```
+
 ## API
 
 ### `tool(config)`
 
 Create typed tool (Zod-validated)
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `id?` | `string` | Tool identifier (optional, inferred from filename) |
-| `description` | `string` | Tool description for the AI model |
-| `inputSchema` | <code>z.ZodSchema&lt;TInput&gt;</code> | Input schema (Zod schema) |
-| `allowUnknownSchema?` | `boolean` | Allow unknown/non-Zod schemas to fall back to a permissive JSON schema. |
-| `execute` | <code>(input: TInput, context?: ToolExecutionContext) =&gt; Promise&lt;TOutput&gt; &#124; TOutput</code> | Tool execution function |
-| `mcp?` | <code>&#123; enabled?: boolean; requiresAuth?: boolean; cachePolicy?: "no-cache" &#124; "cache" &#124; "cache-first" &#125;</code> | MCP configuration |
+| Property              | Type                                                                                                                               | Description                                                             |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `id?`                 | `string`                                                                                                                           | Tool identifier (optional, inferred from filename)                      |
+| `description`         | `string`                                                                                                                           | Tool description for the AI model                                       |
+| `inputSchema`         | <code>z.ZodSchema&lt;TInput&gt;</code>                                                                                             | Input schema (Zod schema)                                               |
+| `allowUnknownSchema?` | `boolean`                                                                                                                          | Allow unknown/non-Zod schemas to fall back to a permissive JSON schema. |
+| `execute`             | <code>(input: TInput, context?: ToolExecutionContext) =&gt; Promise&lt;TOutput&gt; &#124; TOutput</code>                           | Tool execution function                                                 |
+| `mcp?`                | <code>&#123; enabled?: boolean; requiresAuth?: boolean; cachePolicy?: "no-cache" &#124; "cache" &#124; "cache-first" &#125;</code> | MCP configuration                                                       |
 
 **Returns:** <code>Tool&lt;TInput, TOutput&gt;</code>
+
+### `createRemoteMCPToolSource(config)`
+
+Create a per-request remote tool source backed by an MCP `tools/list` + `tools/call` endpoint.
+
+| Property      | Type                                                                                                                   | Description                                              |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `id?`         | `string`                                                                                                               | Stable source identifier for logs/debugging              |
+| `endpoint`    | <code>string &#124; ((context?: ToolExecutionContext) =&gt; string &#124; Promise&lt;string&gt;)</code>                | Remote MCP endpoint                                      |
+| `headers?`    | <code>HeadersInit &#124; ((context?: ToolExecutionContext) =&gt; HeadersInit &#124; Promise&lt;HeadersInit&gt;)</code> | Optional dynamic headers                                 |
+| `fetch?`      | `typeof fetch`                                                                                                         | Override fetch implementation for custom runtimes/tests  |
+| `listMethod?` | `string`                                                                                                               | JSON-RPC method for discovery (defaults to `tools/list`) |
+| `callMethod?` | `string`                                                                                                               | JSON-RPC method for execution (defaults to `tools/call`) |
+
+**Returns:** `RemoteToolSource`
 
 ## Exports
 
 ### Functions
 
-| Name | Description |
-|------|-------------|
-| `dynamicTool` | Create tool with runtime schema |
-| `executeTool` | Execute tool by ID |
-| `tool` | Create typed tool (Zod-validated) |
+| Name                        | Description                            |
+| --------------------------- | -------------------------------------- |
+| `dynamicTool`               | Create tool with runtime schema        |
+| `createRemoteMCPToolSource` | Create a remote MCP-backed tool source |
+| `executeTool`               | Execute tool by ID                     |
+| `tool`                      | Create typed tool (Zod-validated)      |
 
 ### Types
 
-| Name | Description |
-|------|-------------|
-| `DynamicToolConfig` | `dynamicTool()` config |
-| `JsonSchema` | JSON Schema for tool input |
-| `Tool` | Tool instance (returned by tool() function) |
-| `ToolConfig` | Tool configuration options |
-| `ToolDefinition` | Provider-facing tool definition used for model/tool registration. |
-| `ToolExecutionContext` | Context passed to tool execution |
+| Name                        | Description                                                       |
+| --------------------------- | ----------------------------------------------------------------- |
+| `DynamicToolConfig`         | `dynamicTool()` config                                            |
+| `JsonSchema`                | JSON Schema for tool input                                        |
+| `RemoteMCPToolSourceConfig` | `createRemoteMCPToolSource()` config                              |
+| `RemoteToolSource`          | Runtime-discovered remote tool source                             |
+| `Tool`                      | Tool instance (returned by tool() function)                       |
+| `ToolConfig`                | Tool configuration options                                        |
+| `ToolDefinition`            | Provider-facing tool definition used for model/tool registration. |
+| `ToolExecutionContext`      | Context passed to tool execution                                  |
 
 ### Constants
 
-| Name | Description |
-|------|-------------|
+| Name           | Description          |
+| -------------- | -------------------- |
 | `toolRegistry` | Global tool registry |
 
 ## Related

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -39,6 +39,7 @@ import { MiddlewareChain } from "../middleware/chain.ts";
 import { generateText, type LanguageModel, streamText } from "ai";
 import { AGENT_DEFAULTS } from "../ai-defaults.ts";
 import { tryGetCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
+import type { ToolExecutionContext } from "#veryfront/tool";
 
 // Re-export from submodules
 export { closeSSEStream, generateMessageId, sendSSE } from "./sse-utils.ts";
@@ -279,6 +280,11 @@ export class AgentRuntime {
           this.executeAgentLoop(
             systemPrompt,
             messages,
+            {
+              agentId: this.id,
+              projectId: tryGetCacheKeyContext()?.projectId,
+              ...context,
+            },
             resolvedModelString,
             maxOutputTokensOverride,
           ),
@@ -425,6 +431,7 @@ export class AgentRuntime {
   private async executeAgentLoop(
     systemPrompt: string,
     messages: Message[],
+    toolContext?: ToolExecutionContext,
     modelString?: string,
     maxOutputTokensOverride?: number,
   ): Promise<AgentResponse> {
@@ -460,6 +467,8 @@ export class AgentRuntime {
         let tools = isLocal ? [] : await getAvailableTools(this.config.tools, {
           includeSkillTools: Boolean(this.config.skills),
           allowedRemoteToolNames,
+          remoteToolSources: this.config.remoteTools,
+          remoteToolContext: toolContext,
         });
 
         // Layer 1: Filter tools based on active skill policy (planning-time)
@@ -583,11 +592,12 @@ export class AgentRuntime {
                 toolCall.args,
                 this.config.tools,
                 {
-                  agentId: this.id,
                   toolCallId: tc.toolCallId,
-                  projectId: cacheCtx?.projectId,
+                  ...toolContext,
+                  projectId: cacheCtx?.projectId ?? toolContext?.projectId,
                 },
                 allowedRemoteToolNames,
+                this.config.remoteTools,
               );
 
               toolCall.status = "completed";
@@ -712,6 +722,8 @@ export class AgentRuntime {
       let tools = isLocalStreaming ? [] : await getAvailableTools(this.config.tools, {
         includeSkillTools: Boolean(this.config.skills),
         allowedRemoteToolNames,
+        remoteToolSources: this.config.remoteTools,
+        remoteToolContext: toolContext,
       });
 
       // Layer 1: Filter tools based on active skill policy (planning-time)
@@ -873,11 +885,11 @@ export class AgentRuntime {
             toolCall.args,
             this.config.tools,
             {
-              agentId: this.id,
               toolCallId: tc.id,
               ...toolContext,
             },
             allowedRemoteToolNames,
+            this.config.remoteTools,
           );
           throwIfAborted(abortSignal);
 

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -209,7 +209,7 @@ describe("tool-helpers", () => {
         endpoint: "https://mcp.test",
       });
 
-      let requestMethods: string[] = [];
+      const requestMethods: string[] = [];
 
       const result = await withMockFetch(
         async (input: string | URL | Request, init?: RequestInit) => {

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -1,7 +1,8 @@
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { z } from "zod";
-import { tool, toolRegistry } from "#veryfront/tool";
+import { createRemoteMCPToolSource, tool, toolRegistry } from "#veryfront/tool";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import {
   executeConfiguredTool,
   getAvailableTools,
@@ -201,6 +202,58 @@ describe("tool-helpers", () => {
         'Tool "gmail:list-emails" is not allowed for this run',
       );
     });
+
+    it("executes remote MCP tools from configured remote tool sources", async () => {
+      const remoteSource = createRemoteMCPToolSource({
+        id: "docs",
+        endpoint: "https://mcp.test",
+      });
+
+      let requestMethods: string[] = [];
+
+      const result = await withMockFetch(
+        async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          const body = await request.json();
+          const method = typeof body.method === "string" ? body.method : "";
+          requestMethods.push(method);
+
+          if (method === "tools/list") {
+            return Response.json({
+              jsonrpc: "2.0",
+              id: body.id,
+              result: {
+                tools: [{
+                  name: "search_docs",
+                  description: "Search documentation",
+                  inputSchema: { type: "object", properties: {} },
+                }],
+              },
+            });
+          }
+
+          return Response.json({
+            jsonrpc: "2.0",
+            id: body.id,
+            result: {
+              structuredContent: { matches: ["architecture.md"] },
+            },
+          });
+        },
+        async () =>
+          await executeConfiguredTool(
+            "search_docs",
+            { query: "architecture" },
+            undefined,
+            { projectId: "proj_123" },
+            undefined,
+            [remoteSource],
+          ),
+      );
+
+      assertEquals(requestMethods, ["tools/list", "tools/call"]);
+      assertEquals(result, { matches: ["architecture.md"] });
+    });
   });
 
   describe("getAvailableTools", () => {
@@ -284,6 +337,42 @@ describe("tool-helpers", () => {
           ));
 
         assertEquals(defs.map((def) => def.name), ["gmail:get-email"]);
+      } finally {
+        toolRegistry.clearAll();
+      }
+    });
+
+    it("merges generic remote MCP tool sources into available tools", async () => {
+      toolRegistry.clearAll();
+
+      const remoteSource = createRemoteMCPToolSource({
+        id: "docs",
+        endpoint: (context) => `https://mcp.test/${context?.projectId ?? "default"}`,
+      });
+
+      try {
+        const defs = await withMockFetch(
+          async () =>
+            Response.json({
+              jsonrpc: "2.0",
+              id: "docs:tools:list",
+              result: {
+                tools: [{
+                  name: "search_docs",
+                  description: "Search documentation",
+                  inputSchema: {},
+                }],
+              },
+            }),
+          async () =>
+            await getAvailableTools(true, {
+              includeIntegrationTools: false,
+              remoteToolSources: [remoteSource],
+              remoteToolContext: { projectId: "proj_123" },
+            }),
+        );
+
+        assertEquals(defs.map((def) => def.name), ["search_docs"]);
       } finally {
         toolRegistry.clearAll();
       }

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -104,6 +104,7 @@ async function getRemoteToolDefinitions(options?: {
   remoteToolSources?: RemoteToolSource[];
   remoteToolContext?: ToolExecutionContext;
 }): Promise<ToolDefinition[]> {
+  const remoteToolContext = options?.remoteToolContext;
   const definitions: ToolDefinition[] = [];
   const seenToolNames = new Set<string>();
 
@@ -123,7 +124,7 @@ async function getRemoteToolDefinitions(options?: {
 
   for (const source of options?.remoteToolSources ?? []) {
     try {
-      const sourceDefs = await source.listTools(options.remoteToolContext);
+      const sourceDefs = await source.listTools(remoteToolContext);
       for (const def of sourceDefs) {
         addDefinition(def);
       }

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -6,7 +6,7 @@
  * @module ai/agent/runtime/tool-helpers
  */
 
-import type { Tool, ToolDefinition, ToolExecutionContext } from "#veryfront/tool";
+import type { RemoteToolSource, Tool, ToolDefinition, ToolExecutionContext } from "#veryfront/tool";
 import { executeTool, toolRegistry } from "#veryfront/tool";
 import { toolToProviderDefinition } from "#veryfront/tool/registry.ts";
 import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
@@ -101,21 +101,89 @@ function throwUnknownConfiguredToolsError(
 async function getRemoteToolDefinitions(options?: {
   includeIntegrationTools?: boolean;
   allowedRemoteToolNames?: string[];
+  remoteToolSources?: RemoteToolSource[];
+  remoteToolContext?: ToolExecutionContext;
 }): Promise<ToolDefinition[]> {
+  const definitions: ToolDefinition[] = [];
+  const seenToolNames = new Set<string>();
+
+  const addDefinition = (definition: ToolDefinition): void => {
+    if (seenToolNames.has(definition.name)) {
+      return;
+    }
+    if (
+      options?.allowedRemoteToolNames &&
+      !options.allowedRemoteToolNames.includes(definition.name)
+    ) {
+      return;
+    }
+    seenToolNames.add(definition.name);
+    definitions.push(definition);
+  };
+
+  for (const source of options?.remoteToolSources ?? []) {
+    try {
+      const sourceDefs = await source.listTools(options.remoteToolContext);
+      for (const def of sourceDefs) {
+        addDefinition(def);
+      }
+    } catch (error) {
+      logger.warn("Failed to fetch remote tool definitions from source", {
+        sourceId: source.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   if (options?.includeIntegrationTools === false) {
-    return [];
+    return definitions;
   }
 
   try {
     const { getRemoteIntegrationToolDefinitions } = await import(
       "#veryfront/integrations/remote-tools.ts"
     );
-    return (await getRemoteIntegrationToolDefinitions()).filter((def) =>
-      !options?.allowedRemoteToolNames || options.allowedRemoteToolNames.includes(def.name)
-    );
+    for (const def of await getRemoteIntegrationToolDefinitions()) {
+      addDefinition(def);
+    }
   } catch {
-    return [];
+    return definitions;
   }
+
+  return definitions;
+}
+
+async function sourceHasTool(
+  source: RemoteToolSource,
+  toolName: string,
+  context?: ToolExecutionContext,
+): Promise<boolean> {
+  return (await source.listTools(context)).some((definition) => definition.name === toolName);
+}
+
+async function executeRemoteToolFromSources(
+  toolName: string,
+  input: Record<string, unknown>,
+  context: ToolExecutionContext | undefined,
+  allowedRemoteToolNames: string[] | undefined,
+  remoteToolSources: RemoteToolSource[] | undefined,
+): Promise<{ handled: boolean; result?: unknown }> {
+  for (const source of remoteToolSources ?? []) {
+    if (!(await sourceHasTool(source, toolName, context))) {
+      continue;
+    }
+
+    if (allowedRemoteToolNames && !allowedRemoteToolNames.includes(toolName)) {
+      throw new Error(`Tool "${toolName}" is not allowed for this run`);
+    }
+
+    return {
+      handled: true,
+      result: await source.executeTool(toolName, input, context),
+    };
+  }
+
+  return { handled: false };
 }
 
 export function resolveConfiguredTool(
@@ -148,6 +216,7 @@ export async function executeConfiguredTool(
   toolsConfig: true | Record<string, ToolConfigEntry> | undefined,
   context?: ToolExecutionContext,
   allowedRemoteToolNames?: string[],
+  remoteToolSources?: RemoteToolSource[],
 ): Promise<unknown> {
   const configuredTool = resolveConfiguredTool(toolsConfig, toolName);
   if (configuredTool) {
@@ -158,6 +227,17 @@ export async function executeConfiguredTool(
   const registryTool = toolRegistry.get(toolName);
   if (registryTool) {
     return await registryTool.execute(input, context);
+  }
+
+  const remoteSourceResult = await executeRemoteToolFromSources(
+    toolName,
+    input,
+    context,
+    allowedRemoteToolNames,
+    remoteToolSources,
+  );
+  if (remoteSourceResult.handled) {
+    return remoteSourceResult.result;
   }
 
   // Fall back to remote execution for integration tools (e.g., github:list-repos)
@@ -207,6 +287,8 @@ export async function getAvailableTools(
     includeSkillTools?: boolean;
     includeIntegrationTools?: boolean;
     allowedRemoteToolNames?: string[];
+    remoteToolSources?: RemoteToolSource[];
+    remoteToolContext?: ToolExecutionContext;
   },
 ): Promise<ToolDefinition[]> {
   if (!toolsConfig) return [];

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -2,7 +2,7 @@
  * Agent type definitions
  **************************/
 
-import type { Tool } from "#veryfront/tool";
+import type { RemoteToolSource, Tool } from "#veryfront/tool";
 import { INVALID_ARGUMENT } from "#veryfront/errors/error-registry.ts";
 import type { Memory } from "./memory/memory-interface.ts";
 
@@ -77,6 +77,7 @@ export interface AgentConfig {
   model?: ModelString;
   system: string | (() => string) | (() => Promise<string>);
   tools?: true | Record<string, Tool | boolean>;
+  remoteTools?: RemoteToolSource[];
   maxSteps?: number;
   streaming?: boolean;
   memory?: MemoryConfig;

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -43,10 +43,18 @@
  * ```
  */
 
-export type { Tool, ToolConfig, ToolDefinition, ToolExecutionContext } from "./types.ts";
+export type {
+  RemoteToolSource,
+  Tool,
+  ToolConfig,
+  ToolDefinition,
+  ToolExecutionContext,
+} from "./types.ts";
 
 export { dynamicTool, tool } from "./factory.ts";
 export type { DynamicToolConfig } from "./factory.ts";
+export { createRemoteMCPToolSource } from "./remote-mcp.ts";
+export type { RemoteMCPToolSourceConfig } from "./remote-mcp.ts";
 
 export { toolRegistry } from "./registry.ts";
 

--- a/src/tool/remote-mcp.test.ts
+++ b/src/tool/remote-mcp.test.ts
@@ -1,0 +1,113 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
+import { createRemoteMCPToolSource } from "./remote-mcp.ts";
+
+describe("tool/remote-mcp", () => {
+  it("lists tools from a remote MCP server using the standard JSON-RPC contract", async () => {
+    let requestUrl = "";
+    let requestMethod = "";
+    let projectHeader = "";
+    let requestBody: Record<string, unknown> | undefined;
+
+    const source = createRemoteMCPToolSource({
+      id: "docs",
+      endpoint: (context) => `https://mcp.test/${context?.projectId ?? "default"}`,
+      headers: (context) => ({
+        Authorization: "Bearer remote-token",
+        "x-project-id": String(context?.projectId ?? ""),
+      }),
+    });
+
+    const tools = await withMockFetch(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        requestUrl = request.url;
+        requestMethod = request.method;
+        projectHeader = request.headers.get("x-project-id") ?? "";
+        requestBody = await request.json();
+
+        return Response.json({
+          jsonrpc: "2.0",
+          id: "docs:tools:list",
+          result: {
+            tools: [{
+              name: "search_docs",
+              description: "Search documentation",
+              inputSchema: {},
+              title: "Search docs",
+              annotations: { readOnlyHint: true },
+            }],
+          },
+        });
+      },
+      async () => await source.listTools({ projectId: "proj_123" }),
+    );
+
+    assertEquals(requestUrl, "https://mcp.test/proj_123");
+    assertEquals(requestMethod, "POST");
+    assertEquals(projectHeader, "proj_123");
+    assertEquals(requestBody, {
+      jsonrpc: "2.0",
+      id: "docs:tools:list",
+      method: "tools/list",
+    });
+    assertEquals(tools, [{
+      name: "search_docs",
+      description: "Search documentation",
+      parameters: { type: "object", properties: {} },
+      title: "Search docs",
+      annotations: { readOnlyHint: true },
+    }]);
+  });
+
+  it("returns structured MCP tool errors instead of throwing for callTool isError results", async () => {
+    const source = createRemoteMCPToolSource({
+      id: "docs",
+      endpoint: "https://mcp.test",
+      headers: { Authorization: "Bearer remote-token" },
+    });
+
+    const result = await withMockFetch(async () =>
+      Response.json({
+        jsonrpc: "2.0",
+        id: "docs:tools:call:search_docs",
+        result: {
+          isError: true,
+          content: [{
+            text: JSON.stringify({
+              error: "authentication_required",
+              connectUrl: "/oauth/docs",
+            }),
+          }],
+        },
+      }), async () => await source.executeTool("search_docs", { query: "auth" }));
+
+    assertEquals(result, {
+      error: "authentication_required",
+      connectUrl: "/oauth/docs",
+    });
+  });
+
+  it("throws when the remote MCP server responds with a JSON-RPC error", async () => {
+    const source = createRemoteMCPToolSource({
+      id: "docs",
+      endpoint: "https://mcp.test",
+    });
+
+    await assertRejects(
+      () =>
+        withMockFetch(async () =>
+          Response.json({
+            jsonrpc: "2.0",
+            id: "docs:tools:list",
+            error: {
+              code: -32603,
+              message: "upstream unavailable",
+            },
+          }), async () => await source.listTools()),
+      Error,
+      "upstream unavailable",
+    );
+  });
+});

--- a/src/tool/remote-mcp.ts
+++ b/src/tool/remote-mcp.ts
@@ -1,0 +1,254 @@
+import type { ToolAnnotations } from "#veryfront/mcp/types.ts";
+import type { JsonSchema } from "./schema/json-schema.ts";
+import type { RemoteToolSource, ToolDefinition, ToolExecutionContext } from "./types.ts";
+
+type ResolvableValue<T> = T | ((context?: ToolExecutionContext) => T | Promise<T>);
+
+export interface RemoteMCPToolSourceConfig {
+  id?: string;
+  endpoint: ResolvableValue<string>;
+  headers?: ResolvableValue<HeadersInit | undefined>;
+  fetch?: typeof fetch;
+  listMethod?: string;
+  callMethod?: string;
+}
+
+interface JsonRpcErrorObject {
+  message?: unknown;
+  data?: unknown;
+}
+
+interface JsonRpcCallToolContentItem {
+  text?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isToolAnnotations(value: unknown): value is ToolAnnotations {
+  if (!isRecord(value)) return false;
+
+  for (const key of Object.keys(value)) {
+    if (
+      key !== "readOnlyHint" &&
+      key !== "destructiveHint" &&
+      key !== "idempotentHint" &&
+      key !== "openWorldHint"
+    ) {
+      return false;
+    }
+
+    const entry = value[key];
+    if (entry !== undefined && typeof entry !== "boolean") {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function normalizeParameters(inputSchema: unknown): JsonSchema {
+  if (!isRecord(inputSchema) || Object.keys(inputSchema).length === 0) {
+    return { type: "object", properties: {} };
+  }
+
+  return inputSchema as JsonSchema;
+}
+
+function normalizeToolDefinitions(result: unknown): ToolDefinition[] {
+  if (!isRecord(result)) return [];
+  const rawTools = result.tools;
+  if (!Array.isArray(rawTools)) return [];
+
+  const definitions: ToolDefinition[] = [];
+  for (const entry of rawTools) {
+    if (!isRecord(entry)) continue;
+    if (typeof entry.name !== "string" || entry.name.length === 0) continue;
+    if (typeof entry.description !== "string") continue;
+
+    const definition: ToolDefinition = {
+      name: entry.name,
+      description: entry.description,
+      parameters: normalizeParameters(entry.inputSchema),
+    };
+
+    if (typeof entry.title === "string" && entry.title.length > 0) {
+      definition.title = entry.title;
+    }
+    if (isToolAnnotations(entry.annotations)) {
+      definition.annotations = entry.annotations;
+    }
+
+    definitions.push(definition);
+  }
+
+  return definitions;
+}
+
+function joinCallToolText(content: JsonRpcCallToolContentItem[]): string {
+  return content
+    .map((item) => (typeof item.text === "string" ? item.text : ""))
+    .filter((item) => item.length > 0)
+    .join("\n");
+}
+
+function parseJsonText(text: string): unknown | undefined {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+function extractJsonRpcErrorMessage(payload: Record<string, unknown>): string {
+  const rawError = payload.error;
+  if (!isRecord(rawError)) return "Remote MCP server returned an error";
+
+  const errorObject = rawError as JsonRpcErrorObject;
+  if (typeof errorObject.message === "string" && errorObject.message.length > 0) {
+    return errorObject.message;
+  }
+  if (typeof errorObject.data === "string" && errorObject.data.length > 0) {
+    return errorObject.data;
+  }
+  if (isRecord(errorObject.data) && typeof errorObject.data.detail === "string") {
+    return errorObject.data.detail;
+  }
+
+  return "Remote MCP server returned an error";
+}
+
+async function resolveValue<T>(
+  value: ResolvableValue<T>,
+  context?: ToolExecutionContext,
+): Promise<T> {
+  if (typeof value === "function") {
+    return await value(context);
+  }
+  return value;
+}
+
+async function resolveHeaders(
+  headers: ResolvableValue<HeadersInit | undefined> | undefined,
+  context?: ToolExecutionContext,
+): Promise<Headers> {
+  const resolvedHeaders = headers ? await resolveValue(headers, context) : undefined;
+  const finalHeaders = new Headers(resolvedHeaders);
+  finalHeaders.set("Content-Type", "application/json");
+  return finalHeaders;
+}
+
+async function postJsonRpc(
+  endpoint: string,
+  headers: Headers,
+  body: Record<string, unknown>,
+  fetchImpl: typeof fetch,
+): Promise<unknown> {
+  const response = await fetchImpl(endpoint, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(
+      `Remote MCP request failed (${response.status})${detail ? `: ${detail}` : ""}`,
+    );
+  }
+
+  return await response.json();
+}
+
+function getJsonRpcResult(payload: unknown): unknown {
+  if (!isRecord(payload)) {
+    throw new Error("Remote MCP response was not a JSON object");
+  }
+
+  if ("error" in payload) {
+    throw new Error(extractJsonRpcErrorMessage(payload));
+  }
+
+  if (!("result" in payload)) {
+    throw new Error("Remote MCP response did not include a result");
+  }
+
+  return payload.result;
+}
+
+function normalizeCallToolResult(result: unknown): unknown {
+  if (!isRecord(result)) return result;
+
+  const rawContent = result.content;
+  if (Array.isArray(rawContent)) {
+    const text = joinCallToolText(
+      rawContent.filter((item): item is JsonRpcCallToolContentItem => isRecord(item)),
+    );
+
+    if (result.isError === true) {
+      return parseJsonText(text) ?? { error: "tool_error", message: text };
+    }
+
+    if ("structuredContent" in result) {
+      return result.structuredContent;
+    }
+
+    return parseJsonText(text) ?? text;
+  }
+
+  if ("structuredContent" in result) {
+    return result.structuredContent;
+  }
+
+  return result;
+}
+
+export function createRemoteMCPToolSource(
+  config: RemoteMCPToolSourceConfig,
+): RemoteToolSource {
+  const id = config.id ?? "remote-mcp";
+  const listMethod = config.listMethod ?? "tools/list";
+  const callMethod = config.callMethod ?? "tools/call";
+
+  return {
+    id,
+    async listTools(context) {
+      const endpoint = await resolveValue(config.endpoint, context);
+      const headers = await resolveHeaders(config.headers, context);
+      const payload = await postJsonRpc(
+        endpoint,
+        headers,
+        {
+          jsonrpc: "2.0",
+          id: `${id}:tools:list`,
+          method: listMethod,
+        },
+        config.fetch ?? globalThis.fetch,
+      );
+
+      return normalizeToolDefinitions(getJsonRpcResult(payload));
+    },
+
+    async executeTool(toolName, args, context) {
+      const endpoint = await resolveValue(config.endpoint, context);
+      const headers = await resolveHeaders(config.headers, context);
+      const payload = await postJsonRpc(
+        endpoint,
+        headers,
+        {
+          jsonrpc: "2.0",
+          id: `${id}:tools:call:${toolName}`,
+          method: callMethod,
+          params: {
+            name: toolName,
+            arguments: args,
+          },
+        },
+        config.fetch ?? globalThis.fetch,
+      );
+
+      return normalizeCallToolResult(getJsonRpcResult(payload));
+    },
+  };
+}

--- a/src/tool/remote-mcp.ts
+++ b/src/tool/remote-mcp.ts
@@ -26,6 +26,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+function isResolver<T>(
+  value: ResolvableValue<T>,
+): value is (context?: ToolExecutionContext) => T | Promise<T> {
+  return typeof value === "function";
+}
+
 function isToolAnnotations(value: unknown): value is ToolAnnotations {
   if (!isRecord(value)) return false;
 
@@ -123,7 +129,7 @@ async function resolveValue<T>(
   value: ResolvableValue<T>,
   context?: ToolExecutionContext,
 ): Promise<T> {
-  if (typeof value === "function") {
+  if (isResolver(value)) {
     return await value(context);
   }
   return value;

--- a/src/tool/types.ts
+++ b/src/tool/types.ts
@@ -119,4 +119,21 @@ export interface ToolDefinition {
   name: string;
   description: string;
   parameters: JsonSchema;
+  title?: string;
+  annotations?: ToolAnnotations;
+}
+
+/**
+ * Remote tool source loaded dynamically at runtime.
+ * Hosts can provide these to expose tools from remote MCP-compatible systems
+ * without registering those tools globally inside the framework.
+ */
+export interface RemoteToolSource {
+  id: string;
+  listTools(context?: ToolExecutionContext): Promise<ToolDefinition[]>;
+  executeTool(
+    toolName: string,
+    args: Record<string, unknown>,
+    context?: ToolExecutionContext,
+  ): Promise<unknown>;
 }


### PR DESCRIPTION
## Summary
- add a generic `createRemoteMCPToolSource()` helper to `veryfront/tool`
- let `agent()` merge remote tool sources alongside local and existing integration tools
- document the new package-level runtime contract and cover it with remote MCP/runtime tests

## Testing
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/tool/remote-mcp.test.ts src/agent/runtime/tool-helpers.test.ts src/server/handlers/request/agent-stream.handler.test.ts src/internal-agents/schema.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --parallel --allow-all --v8-flags=--max-old-space-size=8192 '--ignore=tests,src/ai/workflow/__tests__' --unstable-worker-options --unstable-net $(find src cli -name '*.test.ts' ! -name '*.integration.test.ts')`

Closes #898
