### PR TITLE
Add a package-native AG-UI handler for hosted agents

### DIFF
--- a/docs/reference/agent-runtime-ag-ui.md
+++ b/docs/reference/agent-runtime-ag-ui.md
@@ -1,0 +1,69 @@
+---
+title: "Agent Runtime AG-UI"
+description: "Canonical AG-UI request and transport conventions for package-hosted agent runtimes."
+order: 10
+---
+
+# Agent Runtime AG-UI
+
+The `veryfront/agent` package supports a generic AG-UI transport for hosted
+agent runtimes.
+
+## Contract
+
+- request body: validated by `AgUiRequestSchema`
+- response body: AG-UI SSE
+- default endpoint convention: `/api/ag-ui`
+- host path: overrideable by the application
+
+The package defines the runtime contract. The host chooses where to mount it.
+
+## Package API
+
+Use `createAgUiHandler()`:
+
+```ts
+import { agent, createAgUiHandler } from "veryfront/agent";
+
+const assistant = agent({
+  system: "You are a helpful assistant.",
+});
+
+export const POST = createAgUiHandler({
+  agent: assistant,
+});
+```
+
+## Request Shape
+
+`AgUiRequestSchema` accepts:
+
+- `messages`
+- optional `threadId`
+- optional `runId`
+- optional `context`
+- optional `forwardedProps`
+- optional `model`
+- optional `maxOutputTokens`
+- optional `tools`
+
+## Runtime Context
+
+The handler forwards AG-UI metadata into `agent.stream()` context as:
+
+```ts
+{
+  threadId,
+  runId,
+  agUi: {
+    context,
+    forwardedProps,
+  }
+}
+```
+
+## Current Limitation
+
+Injected client tools in `tools` are not supported yet by the package AG-UI
+handler. Requests that include them receive `501` until the package exposes
+generic wait/resume primitives for client-mediated tool execution.

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -15,6 +15,8 @@ import {
   agent,
   agentAsTool,
   AgentRuntime,
+  AgUiRequestSchema,
+  createAgUiHandler,
   createMemory,
   getAgentsAsTools,
   registerAgent,
@@ -84,6 +86,21 @@ export async function POST(req: Request) {
   const result = await assistant.stream({ messages });
   return result.toDataStreamResponse();
 }
+```
+
+### AG-UI route
+
+```ts
+// app/api/ag-ui/route.ts
+import { agent, createAgUiHandler } from "veryfront/agent";
+
+const assistant = agent({
+  system: "You are a helpful assistant.",
+});
+
+export const POST = createAgUiHandler({
+  agent: assistant,
+});
 ```
 
 ### Multi-agent composition
@@ -182,6 +199,43 @@ Create a POST chat route handler with built-in request validation, UI-message no
 | `context`      | <code>Record&lt;string, unknown&gt;</code> | Resolved context (default `{ userId: "current-user" }`)          |
 | `lastUserText` | `string`                                   | Text extracted from the last user message (empty string if none) |
 
+### `createAgUiHandler(agentIdOrConfig, options?)`
+
+Create a POST route handler for AG-UI requests. The package default convention
+is `/api/ag-ui`, but the host application owns the actual path.
+
+The handler:
+
+- validates the AG-UI runtime request body
+- clears server memory before each run
+- converts the package data-stream output into AG-UI SSE events
+- passes AG-UI request metadata into `agent.stream()` context as:
+
+```ts
+{
+  threadId,
+  runId,
+  agUi: {
+    context,
+    forwardedProps,
+  }
+}
+```
+
+Current limitation:
+
+- injected client tools in `tools` are rejected with `501` until the package
+  exposes generic wait/resume primitives for them
+
+| Property           | Type                                                                                                                                                           | Description                                         |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `agentIdOrConfig`  | `string \| { agent: Agent, context?: ... }`                                                                                                                    | Agent registry id or direct agent instance          |
+| `options?.context` | <code>Record&lt;string, unknown&gt; &#124; ((request: Request) =&gt; Record&lt;string, unknown&gt; &#124; Promise&lt;Record&lt;string, unknown&gt;&gt;)</code> | Extra context merged into the AG-UI runtime context |
+
+### `AgUiRequestSchema`
+
+Validate AG-UI runtime requests for `createAgUiHandler()`.
+
 ### `agent.getMemory()`
 
 Get the agent's memory instance.
@@ -208,6 +262,7 @@ Clear all stored messages from memory.
 | ------------------- | --------------------------------------------- |
 | `agent`             | Create an agent                               |
 | `agentAsTool`       | Wrap agent as callable tool                   |
+| `createAgUiHandler` | Create a POST handler for an AG-UI route      |
 | `createChatHandler` | Create a POST handler for a chat API route.   |
 | `createMemory`      | Create memory (buffer, conversation, summary) |
 | `createRedisMemory` | Create Redis-backed memory                    |
@@ -242,6 +297,11 @@ Clear all stored messages from memory.
 | `AgentResponse`                  | Agent execution response                                                     |
 | `AgentStatus`                    | Agent status (idle, running, etc.)                                           |
 | `AgentStreamResult`              | Streaming result (`.toDataStreamResponse()`)                                 |
+| `AgUiContextItem`                | AG-UI runtime context item                                                   |
+| `AgUiHandlerConfigWithAgent`     | Direct-agent form for `createAgUiHandler`                                    |
+| `AgUiHandlerOptions`             | Options for `createAgUiHandler`                                              |
+| `AgUiInjectedTool`               | AG-UI client-injected tool descriptor                                        |
+| `AgUiRequest`                    | Validated AG-UI runtime request body                                         |
 | `ChatHandlerBeforeStream`        | Hook signature for `createChatHandler` customization before streaming.       |
 | `ChatHandlerBeforeStreamContext` | Input passed to `beforeStream` hook.                                         |
 | `ChatHandlerBeforeStreamResult`  | Message/context mutations returned from `beforeStream`.                      |

--- a/src/agent/ag-ui-handler.test.ts
+++ b/src/agent/ag-ui-handler.test.ts
@@ -1,0 +1,217 @@
+import { assertEquals, assertMatch, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { AgUiRequestSchema, createAgUiHandler } from "./ag-ui-handler.ts";
+import type { Agent, Message } from "./types.ts";
+
+const encoder = new TextEncoder();
+
+function encodeDataStreamEvent(payload: Record<string, unknown>): Uint8Array {
+  return encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+function createTestAgent() {
+  let clearMemoryCalls = 0;
+  let capturedMessages: Message[] = [];
+  let capturedContext: Record<string, unknown> | undefined;
+  let capturedModel: string | undefined;
+  let capturedMaxOutputTokens: number | undefined;
+
+  const agent: Agent = {
+    id: "assistant-1",
+    config: {
+      id: "assistant-1",
+      system: "You are helpful.",
+      model: "anthropic/claude-sonnet-4-6",
+    } as Agent["config"],
+    generate: async () => {
+      throw new Error("not used");
+    },
+    stream: async (input) => {
+      capturedMessages = input.messages ?? [];
+      capturedContext = input.context;
+      capturedModel = input.model;
+      capturedMaxOutputTokens = input.maxOutputTokens;
+
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            encodeDataStreamEvent({ type: "message-start", messageId: "assistant-msg-1" }),
+          );
+          controller.enqueue(
+            encodeDataStreamEvent({
+              type: "data",
+              data: {
+                model: "anthropic/claude-sonnet-4-6",
+                inferenceMode: "cloud",
+              },
+            }),
+          );
+          controller.enqueue(encodeDataStreamEvent({ type: "text-start", id: "text-1" }));
+          controller.enqueue(
+            encodeDataStreamEvent({
+              type: "text-delta",
+              id: "text-1",
+              delta: "hello from runtime",
+            }),
+          );
+          controller.enqueue(encodeDataStreamEvent({ type: "text-end", id: "text-1" }));
+          controller.close();
+        },
+      });
+
+      return {
+        toDataStreamResponse: () =>
+          new Response(stream, {
+            headers: { "Content-Type": "text/event-stream" },
+          }),
+      };
+    },
+    respond: async () => new Response("not used"),
+    getMemory: () => {
+      throw new Error("not used");
+    },
+    getMemoryStats: async () => ({
+      totalMessages: 0,
+      estimatedTokens: 0,
+      type: "conversation",
+    }),
+    clearMemory: async () => {
+      clearMemoryCalls += 1;
+    },
+  };
+
+  return {
+    agent,
+    get clearMemoryCalls() {
+      return clearMemoryCalls;
+    },
+    get capturedMessages() {
+      return capturedMessages;
+    },
+    get capturedContext() {
+      return capturedContext;
+    },
+    get capturedModel() {
+      return capturedModel;
+    },
+    get capturedMaxOutputTokens() {
+      return capturedMaxOutputTokens;
+    },
+  };
+}
+
+describe("agent/ag-ui-handler", () => {
+  it("applies defaults for optional AG-UI fields", () => {
+    const parsed = AgUiRequestSchema.parse({
+      messages: [{
+        id: "msg-1",
+        role: "user",
+        parts: [{ type: "text", text: "hello" }],
+      }],
+    });
+
+    assertEquals(parsed.tools, []);
+    assertEquals(parsed.context, []);
+  });
+
+  it("streams AG-UI events from a direct agent instance", async () => {
+    const testAgent = createTestAgent();
+    const handler = createAgUiHandler({
+      agent: testAgent.agent,
+      context: { tenant: "acme" },
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [{
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          }],
+          context: [{ type: "text", text: "Current file: app.tsx" }],
+          forwardedProps: { traceId: "trace-1" },
+          model: "anthropic/claude-sonnet-4-6",
+          maxOutputTokens: 512,
+        }),
+      }),
+    );
+
+    assertEquals(response.status, 200);
+    assertEquals(response.headers.get("content-type"), "text/event-stream");
+    assertEquals(testAgent.clearMemoryCalls, 1);
+    assertEquals(testAgent.capturedMessages.length, 1);
+    assertEquals(testAgent.capturedMessages[0]?.role, "user");
+    assertEquals(testAgent.capturedModel, "anthropic/claude-sonnet-4-6");
+    assertEquals(testAgent.capturedMaxOutputTokens, 512);
+    assertEquals(testAgent.capturedContext?.tenant, "acme");
+    assertEquals(testAgent.capturedContext?.threadId !== undefined, true);
+    assertEquals(testAgent.capturedContext?.runId !== undefined, true);
+    assertEquals(
+      testAgent.capturedContext?.agUi,
+      {
+        context: [{ type: "text", text: "Current file: app.tsx" }],
+        forwardedProps: { traceId: "trace-1" },
+      },
+    );
+
+    const body = await response.text();
+    assertStringIncludes(body, "event: RunStarted");
+    assertStringIncludes(body, "event: TextMessageStart");
+    assertStringIncludes(body, "event: TextMessageContent");
+    assertStringIncludes(body, "event: TextMessageEnd");
+    assertStringIncludes(body, "event: RunFinished");
+    assertStringIncludes(body, '"provider":"anthropic"');
+    assertStringIncludes(body, '"model":"anthropic/claude-sonnet-4-6"');
+    assertStringIncludes(body, '"delta":"hello from runtime"');
+  });
+
+  it("accepts a Pages Router style request wrapper and generates default ids", async () => {
+    const testAgent = createTestAgent();
+    const handler = createAgUiHandler({ agent: testAgent.agent });
+
+    const request = new Request("http://localhost/api/ag-ui", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: [{
+          id: "msg-1",
+          role: "user",
+          parts: [{ type: "text", text: "hello" }],
+        }],
+      }),
+    });
+
+    const response = await handler({ request });
+
+    assertEquals(response.status, 200);
+    assertMatch(String(testAgent.capturedContext?.threadId), /^[0-9a-f-]{36}$/);
+    assertMatch(String(testAgent.capturedContext?.runId), /^run_[a-z0-9]+$/);
+  });
+
+  it("rejects injected client tools until wait/resume primitives exist", async () => {
+    const testAgent = createTestAgent();
+    const handler = createAgUiHandler({ agent: testAgent.agent });
+
+    const response = await handler(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [{
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          }],
+          tools: [{ name: "client_confirm" }],
+        }),
+      }),
+    );
+
+    assertEquals(response.status, 501);
+    assertEquals(testAgent.clearMemoryCalls, 0);
+    assertStringIncludes(await response.text(), "Injected AG-UI tools are not supported");
+  });
+});

--- a/src/agent/ag-ui-handler.ts
+++ b/src/agent/ag-ui-handler.ts
@@ -1,0 +1,450 @@
+import { z } from "zod";
+import { getAgent } from "./composition/index.ts";
+import type { Agent, Message } from "./types.ts";
+import { INVALID_ARGUMENT } from "#veryfront/errors";
+import {
+  createStreamTransformState,
+  finalizeRunEvents,
+  formatAgUiEvent,
+  mapRuntimeEventToAgUi,
+  parseSseJsonEvents,
+} from "#veryfront/internal-agents/ag-ui-sse.ts";
+
+const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const MAX_TOOL_PARAMETERS_BYTES = 16_384;
+const MAX_CONTEXT_ITEM_BYTES = 16_384;
+const MAX_CONTEXT_TOTAL_BYTES = 65_536;
+const MAX_FORWARDED_PROPS_BYTES = 65_536;
+const MAX_TEXT_PART_LENGTH = 10_000;
+const MAX_MESSAGES_PER_REQUEST = 100;
+
+const encoder = new TextEncoder();
+
+const AG_UI_HEADERS: Record<string, string> = {
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache",
+  Connection: "keep-alive",
+};
+
+function isWithinJsonSizeLimit(value: unknown, maxBytes: number): boolean {
+  try {
+    return encoder.encode(JSON.stringify(value)).byteLength <= maxBytes;
+  } catch {
+    return false;
+  }
+}
+
+const AgUiRunIdSchema = z.string().min(1).max(128).regex(AGENT_ID_PATTERN);
+
+const AgUiInjectedToolSchema = z.object({
+  name: z.string().min(1).max(128),
+  description: z.string().max(1024).optional(),
+  parameters: z.record(z.string(), z.unknown()).optional().refine(
+    (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_TOOL_PARAMETERS_BYTES),
+    { message: "Tool parameters must be less than 16 KB" },
+  ),
+});
+
+const AgUiContextItemSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("text"),
+    title: z.string().max(256).optional(),
+    text: z.string().max(MAX_CONTEXT_ITEM_BYTES),
+  }),
+  z.object({
+    type: z.literal("json"),
+    title: z.string().max(256).optional(),
+    data: z.record(z.string(), z.unknown()).refine(
+      (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_ITEM_BYTES),
+      { message: "JSON context item must be less than 16 KB" },
+    ),
+  }),
+  z.object({
+    type: z.literal("resource"),
+    title: z.string().max(256).optional(),
+    uri: z.string().max(2048),
+    mimeType: z.string().max(256).optional(),
+    text: z.string().max(MAX_CONTEXT_ITEM_BYTES).optional(),
+  }),
+]);
+
+const AgUiMessagePartSchema = z.object({ type: z.string().min(1) }).passthrough();
+
+const AgUiMessageSchema = z.object({
+  id: z.string().min(1),
+  role: z.enum(["user", "assistant", "system", "tool"]),
+  parts: z.array(AgUiMessagePartSchema).default([]),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  createdAt: z.string().optional(),
+});
+
+export const AgUiRequestSchema = z.object({
+  threadId: z.string().uuid().optional(),
+  runId: AgUiRunIdSchema.optional(),
+  messages: z.array(AgUiMessageSchema).min(1).max(MAX_MESSAGES_PER_REQUEST),
+  tools: z.array(AgUiInjectedToolSchema).max(50).default([]),
+  context: z.array(AgUiContextItemSchema).max(10).default([]).refine(
+    (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_TOTAL_BYTES),
+    { message: "context must be less than 64 KB total" },
+  ),
+  forwardedProps: z.record(z.string(), z.unknown()).optional().refine(
+    (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_FORWARDED_PROPS_BYTES),
+    { message: "forwardedProps must be less than 64 KB" },
+  ),
+  model: z.string().optional(),
+  maxOutputTokens: z.number().int().positive().optional(),
+});
+
+export type AgUiInjectedTool = z.infer<typeof AgUiInjectedToolSchema>;
+export type AgUiContextItem = z.infer<typeof AgUiContextItemSchema>;
+export type AgUiRequest = z.infer<typeof AgUiRequestSchema>;
+
+type AgUiRuntimePart = Record<string, unknown> & { type: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeToolArgs(part: Record<string, unknown>): Record<string, unknown> {
+  if (isRecord(part.args)) return part.args;
+  if (isRecord(part.input)) return part.input;
+  return {};
+}
+
+function normalizeMessagePart(part: Record<string, unknown>): Message["parts"][number] | null {
+  if (
+    part.type === "text" && typeof part.text === "string" &&
+    part.text.length <= MAX_TEXT_PART_LENGTH
+  ) {
+    return { type: "text", text: part.text };
+  }
+
+  if (part.type === "tool_call" && typeof part.id === "string" && typeof part.name === "string") {
+    return {
+      type: "tool-call",
+      toolCallId: part.id,
+      toolName: part.name,
+      args: normalizeToolArgs(part),
+    };
+  }
+
+  if (
+    part.type === "tool-call" &&
+    typeof part.toolCallId === "string" &&
+    typeof part.toolName === "string"
+  ) {
+    return {
+      type: "tool-call",
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      args: normalizeToolArgs(part),
+    };
+  }
+
+  if (
+    typeof part.type === "string" &&
+    part.type.startsWith("tool-") &&
+    part.type !== "tool-result" &&
+    typeof part.toolCallId === "string" &&
+    typeof part.toolName === "string"
+  ) {
+    return {
+      type: part.type,
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      args: normalizeToolArgs(part),
+    };
+  }
+
+  if (part.type === "tool_result" && typeof part.tool_call_id === "string") {
+    return {
+      type: "tool-result",
+      toolCallId: part.tool_call_id,
+      toolName: typeof part.tool_name === "string" ? part.tool_name : "unknown",
+      result: "output" in part ? part.output : undefined,
+    };
+  }
+
+  if (part.type === "tool-result" && typeof part.toolCallId === "string") {
+    return {
+      type: "tool-result",
+      toolCallId: part.toolCallId,
+      toolName: typeof part.toolName === "string" ? part.toolName : "unknown",
+      result: "result" in part ? part.result : undefined,
+    };
+  }
+
+  return null;
+}
+
+function normalizeMessages(messages: AgUiRequest["messages"]): Message[] {
+  return messages.map((message) => ({
+    id: message.id,
+    role: message.role,
+    parts: message.parts
+      .map((part) => normalizeMessagePart(part))
+      .filter((part): part is Message["parts"][number] => part !== null),
+    ...(message.createdAt ? { timestamp: Date.parse(message.createdAt) || undefined } : {}),
+    ...(message.metadata ? { metadata: message.metadata } : {}),
+  }));
+}
+
+function isRequest(obj: unknown): obj is Request {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "json" in obj &&
+    typeof obj.json === "function" &&
+    "url" in obj &&
+    typeof obj.url === "string" &&
+    "method" in obj &&
+    typeof obj.method === "string"
+  );
+}
+
+function extractRequest(requestOrCtx: unknown): Request {
+  if (isRequest(requestOrCtx)) return requestOrCtx;
+
+  if (typeof requestOrCtx === "object" && requestOrCtx !== null && "request" in requestOrCtx) {
+    const candidate = (requestOrCtx as Record<string, unknown>).request;
+    if (isRequest(candidate)) return candidate;
+  }
+
+  throw INVALID_ARGUMENT.create({
+    detail: "Invalid handler argument: expected Request or APIContext",
+  });
+}
+
+function generateRunId(): string {
+  return `run_${crypto.randomUUID().replaceAll("-", "")}`;
+}
+
+function buildStreamContext(
+  request: AgUiRequest,
+  baseContext: Record<string, unknown>,
+  threadId: string,
+  runId: string,
+): Record<string, unknown> {
+  return {
+    ...baseContext,
+    threadId,
+    runId,
+    agUi: {
+      context: request.context,
+      forwardedProps: request.forwardedProps,
+    },
+  };
+}
+
+function closeController(controller: ReadableStreamDefaultController<Uint8Array>): void {
+  try {
+    controller.close();
+  } catch {
+    return;
+  }
+}
+
+function enqueueEvent(
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  event: string,
+  payload: Record<string, unknown>,
+): boolean {
+  try {
+    controller.enqueue(formatAgUiEvent(event, payload));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function createAgUiStreamResponse(
+  agent: Agent,
+  request: AgUiRequest,
+  baseContext: Record<string, unknown>,
+): Promise<Response> {
+  const threadId = request.threadId ?? crypto.randomUUID();
+  const runId = request.runId ?? generateRunId();
+
+  await agent.clearMemory();
+
+  const result = await agent.stream({
+    messages: normalizeMessages(request.messages),
+    context: buildStreamContext(request, baseContext, threadId, runId),
+    ...(request.model ? { model: request.model } : {}),
+    ...(request.maxOutputTokens ? { maxOutputTokens: request.maxOutputTokens } : {}),
+  });
+
+  const upstream = result.toDataStreamResponse();
+  const upstreamBody = upstream.body;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start: async (controller) => {
+      const state = createStreamTransformState();
+      let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+      let remainder = "";
+      const decoder = new TextDecoder();
+
+      if (!enqueueEvent(controller, "RunStarted", { runId, threadId, agentId: agent.id })) {
+        return;
+      }
+
+      try {
+        if (!upstreamBody) {
+          for (const event of finalizeRunEvents(state, null)) {
+            if (!enqueueEvent(controller, event.event, event.payload)) {
+              return;
+            }
+          }
+          closeController(controller);
+          return;
+        }
+
+        reader = upstreamBody.getReader();
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          remainder += decoder.decode(value, { stream: true });
+          const parsed = parseSseJsonEvents(remainder);
+          remainder = parsed.remainder;
+
+          for (const event of parsed.events as AgUiRuntimePart[]) {
+            for (const mapped of mapRuntimeEventToAgUi(state, event)) {
+              if (!enqueueEvent(controller, mapped.event, mapped.payload)) {
+                return;
+              }
+            }
+          }
+        }
+
+        remainder += decoder.decode();
+        const parsed = parseSseJsonEvents(remainder);
+        for (const event of parsed.events as AgUiRuntimePart[]) {
+          for (const mapped of mapRuntimeEventToAgUi(state, event)) {
+            if (!enqueueEvent(controller, mapped.event, mapped.payload)) {
+              return;
+            }
+          }
+        }
+
+        for (const event of finalizeRunEvents(state, null)) {
+          if (!enqueueEvent(controller, event.event, event.payload)) {
+            return;
+          }
+        }
+      } catch (error) {
+        enqueueEvent(controller, "RunError", {
+          message: error instanceof Error ? error.message : "Agent run failed",
+        });
+      } finally {
+        await reader?.cancel().catch(() => undefined);
+        closeController(controller);
+      }
+    },
+  });
+
+  return new Response(stream, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: { ...AG_UI_HEADERS },
+  });
+}
+
+export interface AgUiHandlerOptions {
+  context?:
+    | Record<string, unknown>
+    | ((request: Request) => Record<string, unknown> | Promise<Record<string, unknown>>);
+}
+
+export interface AgUiHandlerConfigWithAgent extends AgUiHandlerOptions {
+  agent: Agent;
+}
+
+function mergeConfig(
+  config: AgUiHandlerConfigWithAgent,
+  options?: AgUiHandlerOptions,
+): AgUiHandlerConfigWithAgent {
+  if (!options) return config;
+  return { ...options, ...config };
+}
+
+export function createAgUiHandler(
+  agentId: string,
+  options?: AgUiHandlerOptions,
+): (requestOrCtx: unknown) => Promise<Response>;
+export function createAgUiHandler(
+  config: AgUiHandlerConfigWithAgent,
+  options?: AgUiHandlerOptions,
+): (requestOrCtx: unknown) => Promise<Response>;
+export function createAgUiHandler(
+  agentIdOrConfig: string | AgUiHandlerConfigWithAgent,
+  options?: AgUiHandlerOptions,
+) {
+  return async function POST(requestOrCtx: unknown): Promise<Response> {
+    const request = extractRequest(requestOrCtx);
+
+    let agent: Agent | undefined;
+
+    if (
+      typeof agentIdOrConfig === "object" &&
+      agentIdOrConfig !== null &&
+      "agent" in agentIdOrConfig
+    ) {
+      const config = mergeConfig(agentIdOrConfig, options);
+      agent = config.agent;
+      options = config;
+    } else {
+      const agentId = agentIdOrConfig as string;
+      try {
+        agent = getAgent(agentId);
+      } catch {
+        return Response.json({ error: "Agent not found" }, { status: 404 });
+      }
+    }
+
+    if (!agent) {
+      return Response.json({ error: "Agent not found" }, { status: 404 });
+    }
+
+    try {
+      const parsed = AgUiRequestSchema.parse(await request.json());
+
+      if (parsed.tools.length > 0) {
+        return Response.json(
+          {
+            error:
+              "Injected AG-UI tools are not supported by createAgUiHandler yet. Use package-level wait/resume runtime primitives instead.",
+          },
+          { status: 501 },
+        );
+      }
+
+      const context = typeof options?.context === "function"
+        ? await options.context(request)
+        : options?.context ?? {};
+
+      return await createAgUiStreamResponse(agent, parsed, context);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return Response.json(
+          {
+            error: "Invalid AG-UI request",
+            details: error.issues.map((issue) => ({
+              path: issue.path,
+              message: issue.message,
+            })),
+          },
+          { status: 400 },
+        );
+      }
+
+      return Response.json(
+        {
+          error: error instanceof Error ? error.message : "Internal server error",
+        },
+        { status: 500 },
+      );
+    }
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -134,6 +134,15 @@ export {
 
 export { agent } from "./factory.ts";
 export {
+  type AgUiContextItem,
+  type AgUiHandlerConfigWithAgent,
+  type AgUiHandlerOptions,
+  type AgUiInjectedTool,
+  type AgUiRequest,
+  AgUiRequestSchema,
+  createAgUiHandler,
+} from "./ag-ui-handler.ts";
+export {
   type ChatHandlerBeforeStream,
   type ChatHandlerBeforeStreamContext,
   type ChatHandlerBeforeStreamResult,


### PR DESCRIPTION
## Summary
- add `createAgUiHandler()` and `AgUiRequestSchema` to `veryfront/agent`
- document `/api/ag-ui` as the package convention while keeping the host path overrideable
- convert package data-stream SSE into AG-UI SSE and reject injected client tools until generic wait/resume exists

## Testing
- `deno check src/agent/ag-ui-handler.ts src/agent/ag-ui-handler.test.ts src/agent/index.ts`
- `deno test --no-check --allow-all src/agent/chat-handler.test.ts src/agent/ag-ui-handler.test.ts src/internal-agents/ag-ui-sse.test.ts`
- package unit lane via pre-push (`1314 passed, 0 failed`)

Related: #898
