### PR TITLE
Add generic run wait/resume hooks to the package runtime

### DIFF
--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -20,6 +20,7 @@ import {
   createMemory,
   getAgentsAsTools,
   registerAgent,
+  RunResumeSessionManager,
 } from "veryfront/agent";
 ```
 
@@ -255,6 +256,14 @@ Current limitation:
 
 Validate AG-UI runtime requests for `createAgUiHandler()`.
 
+### `RunResumeSessionManager`
+
+Coordinate resumable waits for hosted agent runs without depending on any
+product-specific control plane.
+
+Use this when a host runtime needs to start a resumable run-local session,
+pause on an external signal, and later submit a resume value for that run.
+
 ### `agent.getMemory()`
 
 Get the agent's memory instance.
@@ -297,13 +306,14 @@ Clear all stored messages from memory.
 
 ### Classes
 
-| Name                 | Description                            |
-| -------------------- | -------------------------------------- |
-| `AgentRuntime`       | Agent execution runtime                |
-| `BufferMemory`       | In-memory message buffer               |
-| `ConversationMemory` | Full conversation history              |
-| `RedisMemory`        | Redis-backed persistent memory         |
-| `SummaryMemory`      | Compresses old messages into summaries |
+| Name                      | Description                                       |
+| ------------------------- | ------------------------------------------------- |
+| `AgentRuntime`            | Agent execution runtime                           |
+| `BufferMemory`            | In-memory message buffer                          |
+| `ConversationMemory`      | Full conversation history                         |
+| `RedisMemory`             | Redis-backed persistent memory                    |
+| `RunResumeSessionManager` | Generic wait/resume manager for hosted agent runs |
+| `SummaryMemory`           | Compresses old messages into summaries            |
 
 ### Types
 
@@ -321,6 +331,9 @@ Clear all stored messages from memory.
 | `AgUiHandlerOptions`             | Options for `createAgUiHandler`                                              |
 | `AgUiInjectedTool`               | AG-UI client-injected tool descriptor                                        |
 | `AgUiRequest`                    | Validated AG-UI runtime request body                                         |
+| `RunResumeSessionManagerOptions` | Options for `RunResumeSessionManager`                                        |
+| `RunSessionStatus`               | Status of a resumable run session                                            |
+| `SubmitResumeValueOutcome`       | Result of submitting an accepted or duplicate resume value                   |
 | `ChatHandlerBeforeStream`        | Hook signature for `createChatHandler` customization before streaming.       |
 | `ChatHandlerBeforeStreamContext` | Input passed to `beforeStream` hook.                                         |
 | `ChatHandlerBeforeStreamResult`  | Message/context mutations returned from `beforeStream`.                      |

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -151,4 +151,15 @@ export {
   type ChatHandlerOptions,
   createChatHandler,
 } from "./chat-handler.ts";
-export { AgentRuntime } from "./runtime/index.ts";
+export {
+  AgentRuntime,
+  RunAlreadyExistsError,
+  RunCancelledError,
+  RunNotActiveError,
+  RunResumeSessionManager,
+  type RunResumeSessionManagerOptions,
+  type RunSessionStatus,
+  type SubmitResumeValueOutcome,
+  WaitConflictError,
+  WaitNotPendingError,
+} from "./runtime/index.ts";

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -44,6 +44,19 @@ import type { ToolExecutionContext } from "#veryfront/tool";
 // Re-export from submodules
 export { closeSSEStream, generateMessageId, sendSSE } from "./sse-utils.ts";
 export {
+  RunAlreadyExistsError,
+  RunCancelledError,
+  RunNotActiveError,
+  RunResumeSessionManager,
+  WaitConflictError,
+  WaitNotPendingError,
+} from "./resume-session.ts";
+export type {
+  RunResumeSessionManagerOptions,
+  RunSessionStatus,
+  SubmitResumeValueOutcome,
+} from "./resume-session.ts";
+export {
   executeConfiguredTool,
   getAvailableTools,
   isDynamicTool,

--- a/src/agent/runtime/resume-session.test.ts
+++ b/src/agent/runtime/resume-session.test.ts
@@ -1,0 +1,129 @@
+import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  RunCancelledError,
+  RunResumeSessionManager,
+  WaitConflictError,
+  WaitNotPendingError,
+} from "./resume-session.ts";
+
+describe("agent/runtime/resume-session", () => {
+  it("accepts duplicate resume values and rejects conflicting ones", async () => {
+    const manager = new RunResumeSessionManager<{ ok: boolean }>({
+      getConflictKey: (value) => JSON.stringify(value),
+    });
+    manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    const pending = manager.waitForSignal("run_1", "tool_1");
+
+    const first = manager.submitSignal("run_1", {
+      waitKey: "tool_1",
+      value: { ok: true },
+    });
+    assertEquals(first, { accepted: true });
+    assertEquals(await pending, { ok: true });
+
+    const duplicate = manager.submitSignal("run_1", {
+      waitKey: "tool_1",
+      value: { ok: true },
+    });
+    assertEquals(duplicate, { accepted: true, duplicate: true });
+
+    assertThrows(
+      () => {
+        manager.submitSignal("run_1", {
+          waitKey: "tool_1",
+          value: { ok: false },
+        });
+      },
+      WaitConflictError,
+    );
+  });
+
+  it("rejects submissions for wait keys that are not currently pending", () => {
+    const manager = new RunResumeSessionManager<{ ok: boolean }>();
+    manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    assertThrows(
+      () => {
+        manager.submitSignal("run_1", {
+          waitKey: "tool_1",
+          value: { ok: true },
+        });
+      },
+      WaitNotPendingError,
+    );
+  });
+
+  it("cancels waiting runs and rejects the parked wait promise", async () => {
+    const manager = new RunResumeSessionManager<{ ok: boolean }>();
+    manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    const pending = manager.waitForSignal("run_1", "tool_1");
+    assertEquals(manager.cancelRun("run_1"), true);
+
+    await assertRejects(
+      async () => {
+        await pending;
+      },
+      RunCancelledError,
+    );
+    assertEquals(manager.getRunStatus("run_1"), null);
+  });
+
+  it("expires waiting runs after the configured TTL", async () => {
+    const timerCallbacks: Array<() => void> = [];
+    const manager = new RunResumeSessionManager<{ ok: boolean }>({
+      waitingTtlMs: 1,
+      setTimeoutFn: ((callback: () => void) => {
+        timerCallbacks.push(callback);
+        return timerCallbacks.length as unknown as number;
+      }) as typeof setTimeout,
+      clearTimeoutFn: (() => {}) as typeof clearTimeout,
+    });
+    manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    const pending = manager.waitForSignal("run_1", "tool_1");
+    assertEquals(manager.getRunStatus("run_1"), "waiting");
+
+    timerCallbacks[0]?.();
+
+    await assertRejects(
+      async () => {
+        await pending;
+      },
+      RunCancelledError,
+    );
+    assertEquals(manager.getRunStatus("run_1"), null);
+  });
+
+  it("evicts stale running sessions after the configured session TTL", () => {
+    const timerCallbacks: Array<() => void> = [];
+    const manager = new RunResumeSessionManager<{ ok: boolean }>({
+      sessionTtlMs: 1,
+      setTimeoutFn: ((callback: () => void) => {
+        timerCallbacks.push(callback);
+        return timerCallbacks.length as unknown as number;
+      }) as typeof setTimeout,
+      clearTimeoutFn: (() => {}) as typeof clearTimeout,
+    });
+
+    manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    assertEquals(manager.getRunStatus("run_1"), "running");
+
+    timerCallbacks[0]?.();
+
+    assertEquals(manager.getRunStatus("run_1"), null);
+  });
+
+  it("rejects runs that exceed the configured concurrency limit", () => {
+    const manager = new RunResumeSessionManager<{ ok: boolean }>({ maxConcurrentSessions: 1 });
+    manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    assertThrows(
+      () => manager.startRun({ runId: "run_2", threadId: crypto.randomUUID() }),
+      Error,
+      "Maximum concurrent sessions (1) reached",
+    );
+  });
+});

--- a/src/agent/runtime/resume-session.ts
+++ b/src/agent/runtime/resume-session.ts
@@ -1,0 +1,318 @@
+export type RunSessionStatus = "running" | "waiting" | "completed" | "cancelled" | "failed";
+
+export class RunCancelledError extends Error {
+  constructor(message = "Run cancelled") {
+    super(message);
+    this.name = "RunCancelledError";
+  }
+}
+
+export class RunAlreadyExistsError extends Error {
+  constructor(runId: string) {
+    super(`Run "${runId}" is already active`);
+    this.name = "RunAlreadyExistsError";
+  }
+}
+
+export class RunNotActiveError extends Error {
+  constructor(runId: string) {
+    super(`Run "${runId}" is not active`);
+    this.name = "RunNotActiveError";
+  }
+}
+
+export class WaitNotPendingError extends Error {
+  constructor(runId: string, waitKey: string) {
+    super(`Run "${runId}" is not waiting for "${waitKey}"`);
+    this.name = "WaitNotPendingError";
+  }
+}
+
+export class WaitConflictError extends Error {
+  constructor(runId: string, waitKey: string) {
+    super(`Conflicting resume value for run "${runId}" and wait key "${waitKey}"`);
+    this.name = "WaitConflictError";
+  }
+}
+
+export interface SubmitResumeValueOutcome {
+  accepted: true;
+  duplicate?: true;
+}
+
+type SubmittedValue<T> = {
+  value: T;
+  key: string;
+};
+
+type WaitingState<T> = {
+  waitKey: string;
+  resolve: (value: SubmittedValue<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+type RunSession<T> = {
+  runId: string;
+  status: RunSessionStatus;
+  abortController: AbortController;
+  waitingState: WaitingState<T> | null;
+  submittedValues: Map<string, SubmittedValue<T>>;
+  waitingTimeoutId: number | null;
+  sessionTimeoutId: number | null;
+};
+
+const DEFAULT_WAITING_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_MAX_CONCURRENT_SESSIONS = 100;
+
+export interface RunResumeSessionManagerOptions<T> {
+  waitingTtlMs?: number;
+  sessionTtlMs?: number | null;
+  maxConcurrentSessions?: number;
+  setTimeoutFn?: typeof setTimeout;
+  clearTimeoutFn?: typeof clearTimeout;
+  getConflictKey?: (value: T) => string;
+}
+
+function defaultConflictKey(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+export class RunResumeSessionManager<T> {
+  private readonly sessions = new Map<string, RunSession<T>>();
+
+  constructor(
+    private readonly options: RunResumeSessionManagerOptions<T> = {},
+  ) {}
+
+  private get waitingTtlMs(): number {
+    return this.options.waitingTtlMs ?? DEFAULT_WAITING_TTL_MS;
+  }
+
+  private get sessionTtlMs(): number | null {
+    return this.options.sessionTtlMs ?? null;
+  }
+
+  private get maxConcurrentSessions(): number {
+    return this.options.maxConcurrentSessions ?? DEFAULT_MAX_CONCURRENT_SESSIONS;
+  }
+
+  private get setTimeoutFn(): typeof setTimeout {
+    return this.options.setTimeoutFn ?? globalThis.setTimeout.bind(globalThis);
+  }
+
+  private get clearTimeoutFn(): typeof clearTimeout {
+    return this.options.clearTimeoutFn ?? globalThis.clearTimeout.bind(globalThis);
+  }
+
+  private getConflictKey(value: T): string {
+    const createConflictKey = this.options.getConflictKey ?? defaultConflictKey;
+    return createConflictKey(value);
+  }
+
+  private clearWaitingTimeout(session: RunSession<T>): void {
+    if (session.waitingTimeoutId === null) return;
+    this.clearTimeoutFn(session.waitingTimeoutId);
+    session.waitingTimeoutId = null;
+  }
+
+  private clearSessionTimeout(session: RunSession<T>): void {
+    if (session.sessionTimeoutId === null) return;
+    this.clearTimeoutFn(session.sessionTimeoutId);
+    session.sessionTimeoutId = null;
+  }
+
+  private scheduleSessionTimeout(session: RunSession<T>): void {
+    if (this.sessionTtlMs === null) return;
+    this.clearSessionTimeout(session);
+    session.sessionTimeoutId = this.setTimeoutFn(() => {
+      this.cancelRun(session.runId);
+    }, this.sessionTtlMs) as unknown as number;
+  }
+
+  private scheduleWaitingTimeout(session: RunSession<T>): void {
+    this.clearWaitingTimeout(session);
+    session.waitingTimeoutId = this.setTimeoutFn(() => {
+      this.cancelRun(session.runId);
+    }, this.waitingTtlMs) as unknown as number;
+  }
+
+  private touchSession(session: RunSession<T>): void {
+    if (session.status === "running" || session.status === "waiting") {
+      this.scheduleSessionTimeout(session);
+    }
+  }
+
+  private finalizeSession(
+    session: RunSession<T>,
+    status: Exclude<RunSessionStatus, "running" | "waiting">,
+  ): void {
+    session.status = status;
+    this.clearWaitingTimeout(session);
+    this.clearSessionTimeout(session);
+    session.waitingState = null;
+    this.sessions.delete(session.runId);
+  }
+
+  startRun(input: { runId: string; threadId: string }): AbortSignal {
+    const existing = this.sessions.get(input.runId);
+    if (existing && (existing.status === "running" || existing.status === "waiting")) {
+      throw new RunAlreadyExistsError(input.runId);
+    }
+
+    if (this.sessions.size >= this.maxConcurrentSessions) {
+      throw new Error(
+        `Maximum concurrent sessions (${this.maxConcurrentSessions}) reached`,
+      );
+    }
+
+    const session: RunSession<T> = {
+      runId: input.runId,
+      status: "running",
+      abortController: new AbortController(),
+      waitingState: null,
+      submittedValues: new Map(),
+      waitingTimeoutId: null,
+      sessionTimeoutId: null,
+    };
+
+    this.sessions.set(input.runId, session);
+    this.touchSession(session);
+    return session.abortController.signal;
+  }
+
+  async waitForSignal(runId: string, waitKey: string): Promise<T> {
+    const session = this.sessions.get(runId);
+    if (!session || session.status === "completed" || session.status === "failed") {
+      throw new RunNotActiveError(runId);
+    }
+
+    if (session.abortController.signal.aborted || session.status === "cancelled") {
+      throw new RunCancelledError();
+    }
+
+    const existingValue = session.submittedValues.get(waitKey);
+    if (existingValue) {
+      session.status = "running";
+      this.touchSession(session);
+      return existingValue.value;
+    }
+
+    if (session.waitingState && session.waitingState.waitKey !== waitKey) {
+      throw new WaitNotPendingError(runId, waitKey);
+    }
+
+    session.status = "waiting";
+    this.scheduleWaitingTimeout(session);
+    this.touchSession(session);
+
+    return await new Promise<T>((resolve, reject) => {
+      const abortHandler = () => {
+        this.clearWaitingTimeout(session);
+        session.waitingState = null;
+        session.status = "cancelled";
+        reject(new RunCancelledError());
+      };
+
+      session.abortController.signal.addEventListener("abort", abortHandler, { once: true });
+      session.waitingState = {
+        waitKey,
+        resolve: (value) => {
+          session.abortController.signal.removeEventListener("abort", abortHandler);
+          this.clearWaitingTimeout(session);
+          session.waitingState = null;
+          session.status = "running";
+          this.touchSession(session);
+          resolve(value.value);
+        },
+        reject: (reason) => {
+          session.abortController.signal.removeEventListener("abort", abortHandler);
+          this.clearWaitingTimeout(session);
+          session.waitingState = null;
+          reject(reason);
+        },
+      };
+    });
+  }
+
+  submitSignal(
+    runId: string,
+    input: { waitKey: string; value: T },
+  ): SubmitResumeValueOutcome {
+    const session = this.sessions.get(runId);
+    if (!session) {
+      throw new RunNotActiveError(runId);
+    }
+
+    const normalized: SubmittedValue<T> = {
+      value: input.value,
+      key: this.getConflictKey(input.value),
+    };
+
+    const existingValue = session.submittedValues.get(input.waitKey);
+    if (existingValue) {
+      if (existingValue.key === normalized.key) {
+        return { accepted: true, duplicate: true };
+      }
+
+      throw new WaitConflictError(runId, input.waitKey);
+    }
+
+    if (
+      session.status === "completed" || session.status === "failed" ||
+      session.status === "cancelled"
+    ) {
+      throw new RunNotActiveError(runId);
+    }
+
+    if (!session.waitingState || session.waitingState.waitKey !== input.waitKey) {
+      throw new WaitNotPendingError(runId, input.waitKey);
+    }
+
+    session.submittedValues.set(input.waitKey, normalized);
+    this.touchSession(session);
+    session.waitingState.resolve(normalized);
+    return { accepted: true };
+  }
+
+  cancelRun(runId: string): boolean {
+    const session = this.sessions.get(runId);
+    if (!session) return false;
+
+    if (
+      session.status === "completed" || session.status === "failed" ||
+      session.status === "cancelled"
+    ) {
+      return false;
+    }
+
+    const waitingState = session.waitingState;
+    session.abortController.abort(new RunCancelledError());
+    waitingState?.reject(new RunCancelledError());
+    this.finalizeSession(session, "cancelled");
+    return true;
+  }
+
+  completeRun(runId: string): void {
+    const session = this.sessions.get(runId);
+    if (!session) return;
+    this.finalizeSession(session, "completed");
+  }
+
+  failRun(runId: string): void {
+    const session = this.sessions.get(runId);
+    if (!session) return;
+    this.finalizeSession(session, "failed");
+  }
+
+  getRunStatus(runId: string): RunSessionStatus | null {
+    return this.sessions.get(runId)?.status ?? null;
+  }
+
+  reset(): void {
+    for (const session of this.sessions.values()) {
+      this.clearWaitingTimeout(session);
+      this.clearSessionTimeout(session);
+    }
+    this.sessions.clear();
+  }
+}

--- a/src/internal-agents/session-manager.ts
+++ b/src/internal-agents/session-manager.ts
@@ -1,3 +1,17 @@
+import {
+  RunAlreadyExistsError,
+  RunCancelledError,
+  RunNotActiveError,
+  RunResumeSessionManager,
+  type RunResumeSessionManagerOptions,
+  type RunSessionStatus,
+  type SubmitResumeValueOutcome,
+  WaitConflictError,
+  WaitNotPendingError,
+} from "#veryfront/agent/runtime/resume-session.ts";
+
+export { RunNotActiveError };
+
 function stableJsonStringify(value: unknown, depth = 0): string {
   if (depth > 64) {
     return JSON.stringify(value);
@@ -22,77 +36,48 @@ function createToolResultKey(result: unknown, isError: boolean): string {
   return `${isError ? "1" : "0"}:${stableJsonStringify(result)}`;
 }
 
-export class AgentRunCancelledError extends Error {
+export class AgentRunCancelledError extends RunCancelledError {
   constructor(message = "Run cancelled") {
     super(message);
     this.name = "AgentRunCancelledError";
   }
 }
 
-export class AgentRunAlreadyExistsError extends Error {
+export class AgentRunAlreadyExistsError extends RunAlreadyExistsError {
   constructor(runId: string) {
-    super(`Run "${runId}" is already active`);
+    super(runId);
     this.name = "AgentRunAlreadyExistsError";
   }
 }
 
-export class RunNotActiveError extends Error {
-  constructor(runId: string) {
-    super(`Run "${runId}" is not active`);
-    this.name = "RunNotActiveError";
-  }
-}
-
-export class ToolResultNotWaitingError extends Error {
+export class ToolResultNotWaitingError extends WaitNotPendingError {
   constructor(runId: string, toolCallId: string) {
-    super(`Run "${runId}" is not waiting for tool call "${toolCallId}"`);
+    super(runId, toolCallId);
     this.name = "ToolResultNotWaitingError";
   }
 }
 
-export class ToolResultConflictError extends Error {
+export class ToolResultConflictError extends WaitConflictError {
   constructor(runId: string, toolCallId: string) {
-    super(`Conflicting tool result for run "${runId}" and tool call "${toolCallId}"`);
+    super(runId, toolCallId);
     this.name = "ToolResultConflictError";
   }
 }
 
 const DEFAULT_WAITING_FOR_TOOL_TTL_MS = 5 * 60 * 1000;
 const DEFAULT_SESSION_TTL_MS = 15 * 60 * 1000;
-const DEFAULT_MAX_CONCURRENT_SESSIONS = 100;
 const AGENT_RUN_SESSION_MANAGER_GLOBAL_KEY = "__veryfrontAgentRunSessionManager" as const;
-
-type SessionStatus = "running" | "waiting" | "completed" | "cancelled" | "failed";
 
 interface SubmittedToolResult {
   result: unknown;
   isError: boolean;
   key: string;
 }
-
-interface WaitingToolState {
-  toolCallId: string;
-  resolve: (value: SubmittedToolResult) => void;
-  reject: (reason?: unknown) => void;
-}
-
-interface AgentRunSession {
-  runId: string;
-  status: SessionStatus;
-  abortController: AbortController;
-  waitingTool: WaitingToolState | null;
-  submittedResults: Map<string, SubmittedToolResult>;
-  waitingTimeoutId: number | null;
-  sessionTimeoutId: number | null;
-}
-
-export interface SubmitToolResultOutcome {
-  accepted: true;
-  duplicate?: true;
-}
+export type SessionStatus = RunSessionStatus;
+export type SubmitToolResultOutcome = SubmitResumeValueOutcome;
 
 export class AgentRunSessionManager {
-  private readonly sessions = new Map<string, AgentRunSession>();
+  private readonly sessions: RunResumeSessionManager<SubmittedToolResult>;
 
   constructor(
     private readonly options: {
@@ -102,250 +87,91 @@ export class AgentRunSessionManager {
       setTimeoutFn?: typeof setTimeout;
       clearTimeoutFn?: typeof clearTimeout;
     } = {},
-  ) {}
-
-  private get waitingForToolTtlMs(): number {
-    return this.options.waitingForToolTtlMs ?? DEFAULT_WAITING_FOR_TOOL_TTL_MS;
-  }
-
-  private get sessionTtlMs(): number | null {
-    return this.options.sessionTtlMs ?? null;
-  }
-
-  private get setTimeoutFn(): typeof setTimeout {
-    return this.options.setTimeoutFn ?? globalThis.setTimeout.bind(globalThis);
-  }
-
-  private get clearTimeoutFn(): typeof clearTimeout {
-    return this.options.clearTimeoutFn ?? globalThis.clearTimeout.bind(globalThis);
-  }
-
-  private clearWaitingTimeout(session: AgentRunSession): void {
-    if (session.waitingTimeoutId === null) {
-      return;
-    }
-
-    this.clearTimeoutFn(session.waitingTimeoutId);
-    session.waitingTimeoutId = null;
-  }
-
-  private clearSessionTimeout(session: AgentRunSession): void {
-    if (session.sessionTimeoutId === null) {
-      return;
-    }
-
-    this.clearTimeoutFn(session.sessionTimeoutId);
-    session.sessionTimeoutId = null;
-  }
-
-  private scheduleSessionTimeout(session: AgentRunSession): void {
-    if (this.sessionTtlMs === null) {
-      return;
-    }
-
-    this.clearSessionTimeout(session);
-    session.sessionTimeoutId = this.setTimeoutFn(() => {
-      this.cancelRun(session.runId);
-    }, this.sessionTtlMs) as unknown as number;
-  }
-
-  private scheduleWaitingTimeout(session: AgentRunSession): void {
-    this.clearWaitingTimeout(session);
-    session.waitingTimeoutId = this.setTimeoutFn(() => {
-      this.cancelRun(session.runId);
-    }, this.waitingForToolTtlMs) as unknown as number;
-  }
-
-  private touchSession(session: AgentRunSession): void {
-    if (
-      session.status === "running" || session.status === "waiting"
-    ) {
-      this.scheduleSessionTimeout(session);
-    }
-  }
-
-  private finalizeSession(
-    session: AgentRunSession,
-    status: Exclude<SessionStatus, "running" | "waiting">,
-  ): void {
-    session.status = status;
-    this.clearWaitingTimeout(session);
-    this.clearSessionTimeout(session);
-    session.waitingTool = null;
-    this.sessions.delete(session.runId);
-  }
-
-  private get maxConcurrentSessions(): number {
-    return this.options.maxConcurrentSessions ?? DEFAULT_MAX_CONCURRENT_SESSIONS;
+  ) {
+    const managerOptions: RunResumeSessionManagerOptions<SubmittedToolResult> = {
+      waitingTtlMs: this.options.waitingForToolTtlMs ?? DEFAULT_WAITING_FOR_TOOL_TTL_MS,
+      sessionTtlMs: this.options.sessionTtlMs ?? null,
+      maxConcurrentSessions: this.options.maxConcurrentSessions,
+      setTimeoutFn: this.options.setTimeoutFn,
+      clearTimeoutFn: this.options.clearTimeoutFn,
+      getConflictKey: (value) => value.key,
+    };
+    this.sessions = new RunResumeSessionManager(managerOptions);
   }
 
   startRun(input: { runId: string; threadId: string }): AbortSignal {
-    const existing = this.sessions.get(input.runId);
-    if (existing && (existing.status === "running" || existing.status === "waiting")) {
-      throw new AgentRunAlreadyExistsError(input.runId);
+    try {
+      return this.sessions.startRun(input);
+    } catch (error) {
+      if (error instanceof RunAlreadyExistsError) {
+        throw new AgentRunAlreadyExistsError(input.runId);
+      }
+      throw error;
     }
-
-    if (this.sessions.size >= this.maxConcurrentSessions) {
-      throw new Error(
-        `Maximum concurrent sessions (${this.maxConcurrentSessions}) reached`,
-      );
-    }
-
-    const session: AgentRunSession = {
-      runId: input.runId,
-      status: "running",
-      abortController: new AbortController(),
-      waitingTool: null,
-      submittedResults: new Map(),
-      waitingTimeoutId: null,
-      sessionTimeoutId: null,
-    };
-
-    this.sessions.set(input.runId, session);
-    this.touchSession(session);
-    return session.abortController.signal;
   }
 
   async waitForToolResult(runId: string, toolCallId: string): Promise<{
     result: unknown;
     isError: boolean;
   }> {
-    const session = this.sessions.get(runId);
-    if (!session || session.status === "completed" || session.status === "failed") {
-      throw new RunNotActiveError(runId);
+    try {
+      const value = await this.sessions.waitForSignal(runId, toolCallId);
+      return { result: value.result, isError: value.isError };
+    } catch (error) {
+      if (error instanceof RunCancelledError) {
+        throw new AgentRunCancelledError();
+      }
+      if (error instanceof WaitNotPendingError) {
+        throw new ToolResultNotWaitingError(runId, toolCallId);
+      }
+      throw error;
     }
-
-    if (session.abortController.signal.aborted || session.status === "cancelled") {
-      throw new AgentRunCancelledError();
-    }
-
-    const existingResult = session.submittedResults.get(toolCallId);
-    if (existingResult) {
-      session.status = "running";
-      this.touchSession(session);
-      return { result: existingResult.result, isError: existingResult.isError };
-    }
-
-    if (session.waitingTool && session.waitingTool.toolCallId !== toolCallId) {
-      throw new ToolResultNotWaitingError(runId, toolCallId);
-    }
-
-    session.status = "waiting";
-    this.scheduleWaitingTimeout(session);
-    this.touchSession(session);
-
-    return await new Promise<{ result: unknown; isError: boolean }>((resolve, reject) => {
-      const abortHandler = () => {
-        this.clearWaitingTimeout(session);
-        session.waitingTool = null;
-        session.status = "cancelled";
-        reject(new AgentRunCancelledError());
-      };
-
-      session.abortController.signal.addEventListener("abort", abortHandler, { once: true });
-      session.waitingTool = {
-        toolCallId,
-        resolve: (value) => {
-          session.abortController.signal.removeEventListener("abort", abortHandler);
-          this.clearWaitingTimeout(session);
-          session.waitingTool = null;
-          session.status = "running";
-          this.touchSession(session);
-          resolve({ result: value.result, isError: value.isError });
-        },
-        reject: (reason) => {
-          session.abortController.signal.removeEventListener("abort", abortHandler);
-          this.clearWaitingTimeout(session);
-          session.waitingTool = null;
-          reject(reason);
-        },
-      };
-    });
   }
 
   submitToolResult(
     runId: string,
     input: { toolCallId: string; result: unknown; isError?: boolean },
   ): SubmitToolResultOutcome {
-    const session = this.sessions.get(runId);
-    if (!session) {
-      throw new RunNotActiveError(runId);
-    }
-
     const normalized: SubmittedToolResult = {
       result: input.result,
       isError: Boolean(input.isError),
       key: createToolResultKey(input.result, Boolean(input.isError)),
     };
 
-    const existingResult = session.submittedResults.get(input.toolCallId);
-    if (existingResult) {
-      if (existingResult.key === normalized.key) {
-        return { accepted: true, duplicate: true };
+    try {
+      return this.sessions.submitSignal(runId, {
+        waitKey: input.toolCallId,
+        value: normalized,
+      });
+    } catch (error) {
+      if (error instanceof WaitConflictError) {
+        throw new ToolResultConflictError(runId, input.toolCallId);
       }
-
-      throw new ToolResultConflictError(runId, input.toolCallId);
+      if (error instanceof WaitNotPendingError) {
+        throw new ToolResultNotWaitingError(runId, input.toolCallId);
+      }
+      throw error;
     }
-
-    if (
-      session.status === "completed" || session.status === "failed" ||
-      session.status === "cancelled"
-    ) {
-      throw new RunNotActiveError(runId);
-    }
-
-    if (!session.waitingTool || session.waitingTool.toolCallId !== input.toolCallId) {
-      throw new ToolResultNotWaitingError(runId, input.toolCallId);
-    }
-
-    session.submittedResults.set(input.toolCallId, normalized);
-    this.touchSession(session);
-    session.waitingTool.resolve(normalized);
-    return { accepted: true };
   }
 
   cancelRun(runId: string): boolean {
-    const session = this.sessions.get(runId);
-    if (!session) {
-      return false;
-    }
-
-    if (
-      session.status === "completed" || session.status === "failed" ||
-      session.status === "cancelled"
-    ) {
-      return false;
-    }
-
-    const waitingTool = session.waitingTool;
-    session.abortController.abort(new AgentRunCancelledError());
-    waitingTool?.reject(new AgentRunCancelledError());
-    this.finalizeSession(session, "cancelled");
-    return true;
+    return this.sessions.cancelRun(runId);
   }
 
   completeRun(runId: string): void {
-    const session = this.sessions.get(runId);
-    if (!session) return;
-    this.finalizeSession(session, "completed");
+    this.sessions.completeRun(runId);
   }
 
   failRun(runId: string): void {
-    const session = this.sessions.get(runId);
-    if (!session) return;
-    this.finalizeSession(session, "failed");
+    this.sessions.failRun(runId);
   }
 
   getRunStatus(runId: string): SessionStatus | null {
-    return this.sessions.get(runId)?.status ?? null;
+    return this.sessions.getRunStatus(runId);
   }
 
   reset(): void {
-    for (const session of this.sessions.values()) {
-      this.clearWaitingTimeout(session);
-      this.clearSessionTimeout(session);
-    }
-    this.sessions.clear();
+    this.sessions.reset();
   }
 }
 


### PR DESCRIPTION
## Summary
- add a generic RunResumeSessionManager to the public package runtime
- refactor the internal agent session manager into a thin wrapper over that generic primitive
- document and export the new wait/resume surface for downstream hosts

## Testing
- deno check src/agent/runtime/resume-session.ts src/internal-agents/session-manager.ts src/agent/runtime/index.ts src/agent/index.ts
- deno test --no-check --allow-all src/server/handlers/request/agent-run-resume.handler.test.ts src/internal-agents/session-manager.test.ts src/agent/runtime/resume-session.test.ts src/agent/ag-ui-handler.test.ts src/agent/chat-handler.test.ts
- full pre-push lane (1316 passed, 0 failed)

Related: #898
