### PR TITLE
Keep npm package parity checks aligned with executable exports

### DIFF
--- a/scripts/docs/verify-npm-exports.mjs
+++ b/scripts/docs/verify-npm-exports.mjs
@@ -10,7 +10,7 @@
  *   (run after `deno task build:npm`)
  */
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -21,12 +21,17 @@ const NPM_DIR = resolve(ROOT, "npm");
 // Read deno.json to get export paths
 const denoConfig = JSON.parse(readFileSync(resolve(ROOT, "deno.json"), "utf8"));
 const exports = denoConfig.exports ?? {};
+const npmPackage = JSON.parse(readFileSync(resolve(NPM_DIR, "package.json"), "utf8"));
+const npmExports = npmPackage.exports ?? {};
 
-// Top-level export paths only (no sub-paths like ./workflow/worker)
-const topLevelExports = Object.keys(exports).filter((p) => {
+// Top-level module export paths only (no sub-paths like ./workflow/worker)
+// Skip executable/assets surfaces that are verified separately.
+const moduleExports = Object.keys(exports).filter((p) => {
   const parts = p.split("/");
-  return parts.length <= 2;
+  return parts.length <= 2 && p !== "./cli" && p !== "./tsconfig.json";
 });
+
+const CLI_EXPORT = "./cli";
 
 // Key named exports per module that MUST exist (subset — the most important ones)
 const REQUIRED_EXPORTS = {
@@ -38,8 +43,17 @@ const REQUIRED_EXPORTS = {
   "./chat": ["Chat", "useChat", "useAgent", "AgentCard", "Message", "AIErrorBoundary"],
   "./markdown": ["Markdown"],
   "./mdx": ["MDXProvider", "useMDXComponents"],
-  "./agent": ["agent", "AgentRuntime", "registerAgent", "getAgentsAsTools", "agentAsTool", "createMemory"],
-  "./tool": ["tool", "dynamicTool", "executeTool", "toolRegistry"],
+  "./agent": [
+    "agent",
+    "AgentRuntime",
+    "RunResumeSessionManager",
+    "createAgUiHandler",
+    "registerAgent",
+    "getAgentsAsTools",
+    "agentAsTool",
+    "createMemory",
+  ],
+  "./tool": ["tool", "dynamicTool", "executeTool", "toolRegistry", "createRemoteMCPToolSource"],
   "./workflow": ["workflow", "step", "parallel", "branch", "dag", "waitForApproval", "createWorkflowClient"],
   "./prompt": ["prompt", "promptRegistry"],
   "./resource": ["resource", "resourceRegistry"],
@@ -54,7 +68,7 @@ let passed = 0;
 let failed = 0;
 const errors = [];
 
-for (const exportPath of topLevelExports) {
+for (const exportPath of moduleExports) {
   const importPath = resolve(NPM_DIR, "esm", exports[exportPath].replace(/\.tsx?$/, ".js"));
   const label = exportPath === "." ? "veryfront" : `veryfront/${exportPath.replace("./", "")}`;
 
@@ -82,11 +96,38 @@ for (const exportPath of topLevelExports) {
   }
 }
 
+const cliEntry = npmExports[CLI_EXPORT];
+if (!cliEntry) {
+  failed++;
+  const label = "veryfront/cli";
+  errors.push(`  ${label}: missing export map entry`);
+  console.log(`  FAIL  ${label} — missing export map entry`);
+} else {
+  const cliImportTarget = typeof cliEntry === "string" ? cliEntry : cliEntry.import;
+  const cliImportPath = resolve(NPM_DIR, cliImportTarget);
+  const cliBinPath = resolve(NPM_DIR, "bin/veryfront.js");
+
+  if (!existsSync(cliImportPath)) {
+    failed++;
+    errors.push(`  veryfront/cli: missing import target ${cliImportTarget}`);
+    console.log(`  FAIL  veryfront/cli — missing import target ${cliImportTarget}`);
+  } else if (!existsSync(cliBinPath)) {
+    failed++;
+    errors.push("  veryfront/cli: missing npm bin/veryfront.js");
+    console.log("  FAIL  veryfront/cli — missing npm bin/veryfront.js");
+  } else {
+    passed++;
+    console.log("  OK    veryfront/cli (entrypoints exist)");
+  }
+}
+
 console.log();
-console.log(`${passed} passed, ${failed} failed out of ${topLevelExports.length} export paths`);
+console.log(`${passed} passed, ${failed} failed out of ${moduleExports.length + 1} export paths`);
 
 if (errors.length > 0) {
   console.log("\nErrors:");
   for (const e of errors) console.log(e);
   process.exit(1);
 }
+
+process.exit(0);

--- a/scripts/docs/verify-npm-node.mjs
+++ b/scripts/docs/verify-npm-node.mjs
@@ -9,8 +9,9 @@
  *   (run after `deno task build:npm`)
  */
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -93,12 +94,14 @@ console.log("veryfront/agent:");
 try {
   const agentMod = await imp("./agent");
   assertType(agentMod.agent, "function", "agent() is function");
+  assertType(agentMod.createAgUiHandler, "function", "createAgUiHandler is function");
   assertType(agentMod.registerAgent, "function", "registerAgent is function");
   assertType(agentMod.getAgentsAsTools, "function", "getAgentsAsTools is function");
   assertType(agentMod.agentAsTool, "function", "agentAsTool is function");
   assertType(agentMod.createMemory, "function", "createMemory is function");
   assert(agentMod.AgentRuntime !== undefined, "AgentRuntime exists");
-  console.log("  OK    agent — 6 checks");
+  assert(agentMod.RunResumeSessionManager !== undefined, "RunResumeSessionManager exists");
+  console.log("  OK    agent — 8 checks");
 } catch (err) {
   failed++;
   errors.push(`agent: ${err.message}`);
@@ -112,6 +115,7 @@ try {
   assertType(toolMod.tool, "function", "tool() is function");
   assertType(toolMod.dynamicTool, "function", "dynamicTool is function");
   assertType(toolMod.executeTool, "function", "executeTool is function");
+  assertType(toolMod.createRemoteMCPToolSource, "function", "createRemoteMCPToolSource is function");
   assert(toolMod.toolRegistry !== undefined, "toolRegistry exists");
 
   // Sanity: create a tool and verify it has the right shape
@@ -129,7 +133,7 @@ try {
   // Execute the tool
   const result = await testTool.execute({ query: "hello" });
   assert(result.result === "hello", "tool execute returns correct result");
-  console.log("  OK    tool — 8 checks");
+  console.log("  OK    tool — 9 checks");
 } catch (err) {
   failed++;
   errors.push(`tool: ${err.message}`);
@@ -234,6 +238,34 @@ try {
   failed++;
   errors.push(`oauth: ${err.message}`);
   console.log(`  FAIL  oauth — ${err.message}`);
+}
+
+// --- CLI ---
+console.log("veryfront/cli:");
+try {
+  const cliExport = npmExports["./cli"];
+  assert(cliExport !== undefined, "cli export map entry exists");
+
+  const cliImportTarget = typeof cliExport === "string" ? cliExport : cliExport.import;
+  const cliImportPath = resolve(NPM, cliImportTarget);
+  const cliBinPath = resolve(NPM, "bin/veryfront.js");
+
+  assert(existsSync(cliImportPath), "cli import target exists");
+  assert(existsSync(cliBinPath), "cli bin entry exists");
+
+  const help = spawnSync(process.execPath, [cliImportPath, "--help"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+
+  assert(help.status === 0, `cli --help exits cleanly (status ${help.status ?? "null"})`);
+  assert(help.stdout.includes("Usage:") || help.stdout.includes("veryfront <command>"), "cli --help prints usage");
+  console.log("  OK    cli — 5 checks");
+} catch (err) {
+  failed++;
+  errors.push(`cli: ${err.message}`);
+  console.log(`  FAIL  cli — ${err.message}`);
 }
 
 // --- FS ---
@@ -347,10 +379,12 @@ try {
 
 // --- Summary ---
 console.log(`\n${"=".repeat(50)}`);
-console.log(`${passed} passed, ${failed} failed (${passed + failed} total checks across 18 modules)`);
+console.log(`${passed} passed, ${failed} failed (${passed + failed} total checks across 19 modules)`);
 
 if (errors.length > 0) {
   console.log("\nFailures:");
   for (const e of errors) console.log(`  ${e}`);
   process.exit(1);
 }
+
+process.exit(0);


### PR DESCRIPTION
## Summary
- harden npm export verification for the new agent/runtime surfaces
- treat `veryfront/cli` as an executable contract instead of importing it like a library module
- make both npm verifier scripts exit cleanly on success so the docs lane does not appear hung

## Why
Fixes #903.

The package build already contains the newer runtime exports after `build:npm`, but the docs verification lane was a weak signal: it booted the CLI while trying to import every top-level export and could hang even after succeeding. This PR makes the package guardrail reflect the actual npm contract and protects the newly added agent/runtime exports.

## Testing
- `deno task build:npm`
- `time node scripts/docs/verify-npm-exports.mjs`
- `time node scripts/docs/verify-npm-node.mjs`
- `time deno task docs:verify-npm`
