### PR TITLE
Add a public scoped Veryfront Cloud bootstrap hook

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.144",
+  "version": "0.1.145",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/scripts/docs/verify-npm-exports.mjs
+++ b/scripts/docs/verify-npm-exports.mjs
@@ -10,7 +10,7 @@
  *   (run after `deno task build:npm`)
  */
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -21,12 +21,17 @@ const NPM_DIR = resolve(ROOT, "npm");
 // Read deno.json to get export paths
 const denoConfig = JSON.parse(readFileSync(resolve(ROOT, "deno.json"), "utf8"));
 const exports = denoConfig.exports ?? {};
+const npmPackage = JSON.parse(readFileSync(resolve(NPM_DIR, "package.json"), "utf8"));
+const npmExports = npmPackage.exports ?? {};
 
-// Top-level export paths only (no sub-paths like ./workflow/worker)
-const topLevelExports = Object.keys(exports).filter((p) => {
+// Top-level module export paths only (no sub-paths like ./workflow/worker)
+// Skip executable/assets surfaces that are verified separately.
+const moduleExports = Object.keys(exports).filter((p) => {
   const parts = p.split("/");
-  return parts.length <= 2;
+  return parts.length <= 2 && p !== "./cli" && p !== "./tsconfig.json";
 });
+
+const CLI_EXPORT = "./cli";
 
 // Key named exports per module that MUST exist (subset — the most important ones)
 const REQUIRED_EXPORTS = {
@@ -38,8 +43,17 @@ const REQUIRED_EXPORTS = {
   "./chat": ["Chat", "useChat", "useAgent", "AgentCard", "Message", "AIErrorBoundary"],
   "./markdown": ["Markdown"],
   "./mdx": ["MDXProvider", "useMDXComponents"],
-  "./agent": ["agent", "AgentRuntime", "registerAgent", "getAgentsAsTools", "agentAsTool", "createMemory"],
-  "./tool": ["tool", "dynamicTool", "executeTool", "toolRegistry"],
+  "./agent": [
+    "agent",
+    "AgentRuntime",
+    "RunResumeSessionManager",
+    "createAgUiHandler",
+    "registerAgent",
+    "getAgentsAsTools",
+    "agentAsTool",
+    "createMemory",
+  ],
+  "./tool": ["tool", "dynamicTool", "executeTool", "toolRegistry", "createRemoteMCPToolSource"],
   "./workflow": ["workflow", "step", "parallel", "branch", "dag", "waitForApproval", "createWorkflowClient"],
   "./prompt": ["prompt", "promptRegistry"],
   "./resource": ["resource", "resourceRegistry"],
@@ -54,7 +68,7 @@ let passed = 0;
 let failed = 0;
 const errors = [];
 
-for (const exportPath of topLevelExports) {
+for (const exportPath of moduleExports) {
   const importPath = resolve(NPM_DIR, "esm", exports[exportPath].replace(/\.tsx?$/, ".js"));
   const label = exportPath === "." ? "veryfront" : `veryfront/${exportPath.replace("./", "")}`;
 
@@ -82,11 +96,38 @@ for (const exportPath of topLevelExports) {
   }
 }
 
+const cliEntry = npmExports[CLI_EXPORT];
+if (!cliEntry) {
+  failed++;
+  const label = "veryfront/cli";
+  errors.push(`  ${label}: missing export map entry`);
+  console.log(`  FAIL  ${label} — missing export map entry`);
+} else {
+  const cliImportTarget = typeof cliEntry === "string" ? cliEntry : cliEntry.import;
+  const cliImportPath = resolve(NPM_DIR, cliImportTarget);
+  const cliBinPath = resolve(NPM_DIR, "bin/veryfront.js");
+
+  if (!existsSync(cliImportPath)) {
+    failed++;
+    errors.push(`  veryfront/cli: missing import target ${cliImportTarget}`);
+    console.log(`  FAIL  veryfront/cli — missing import target ${cliImportTarget}`);
+  } else if (!existsSync(cliBinPath)) {
+    failed++;
+    errors.push("  veryfront/cli: missing npm bin/veryfront.js");
+    console.log("  FAIL  veryfront/cli — missing npm bin/veryfront.js");
+  } else {
+    passed++;
+    console.log("  OK    veryfront/cli (entrypoints exist)");
+  }
+}
+
 console.log();
-console.log(`${passed} passed, ${failed} failed out of ${topLevelExports.length} export paths`);
+console.log(`${passed} passed, ${failed} failed out of ${moduleExports.length + 1} export paths`);
 
 if (errors.length > 0) {
   console.log("\nErrors:");
   for (const e of errors) console.log(e);
   process.exit(1);
 }
+
+process.exit(0);

--- a/scripts/docs/verify-npm-exports.mjs
+++ b/scripts/docs/verify-npm-exports.mjs
@@ -60,7 +60,14 @@ const REQUIRED_EXPORTS = {
   "./mcp": ["createMCPServer", "registerTool", "registerPrompt", "registerResource"],
   "./middleware": ["cors", "rateLimit", "logger", "timeout", "MiddlewarePipeline"],
   "./oauth": ["createOAuthInitHandler", "createOAuthCallbackHandler", "githubConfig", "slackConfig", "MemoryTokenStore"],
-  "./provider": ["registerModelProvider", "resolveModel", "hasModelProvider", "getRegisteredModelProviders"],
+  "./provider": [
+    "registerModelProvider",
+    "resolveModel",
+    "hasModelProvider",
+    "getRegisteredModelProviders",
+    "runWithVeryfrontCloudContext",
+    "runWithVeryfrontCloudContextAsync",
+  ],
   "./fs": ["readTextFile", "writeTextFile", "join", "resolve", "exists", "mkdir"],
 };
 

--- a/scripts/docs/verify-npm-node.mjs
+++ b/scripts/docs/verify-npm-node.mjs
@@ -9,8 +9,9 @@
  *   (run after `deno task build:npm`)
  */
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -93,12 +94,14 @@ console.log("veryfront/agent:");
 try {
   const agentMod = await imp("./agent");
   assertType(agentMod.agent, "function", "agent() is function");
+  assertType(agentMod.createAgUiHandler, "function", "createAgUiHandler is function");
   assertType(agentMod.registerAgent, "function", "registerAgent is function");
   assertType(agentMod.getAgentsAsTools, "function", "getAgentsAsTools is function");
   assertType(agentMod.agentAsTool, "function", "agentAsTool is function");
   assertType(agentMod.createMemory, "function", "createMemory is function");
   assert(agentMod.AgentRuntime !== undefined, "AgentRuntime exists");
-  console.log("  OK    agent — 6 checks");
+  assert(agentMod.RunResumeSessionManager !== undefined, "RunResumeSessionManager exists");
+  console.log("  OK    agent — 8 checks");
 } catch (err) {
   failed++;
   errors.push(`agent: ${err.message}`);
@@ -112,6 +115,7 @@ try {
   assertType(toolMod.tool, "function", "tool() is function");
   assertType(toolMod.dynamicTool, "function", "dynamicTool is function");
   assertType(toolMod.executeTool, "function", "executeTool is function");
+  assertType(toolMod.createRemoteMCPToolSource, "function", "createRemoteMCPToolSource is function");
   assert(toolMod.toolRegistry !== undefined, "toolRegistry exists");
 
   // Sanity: create a tool and verify it has the right shape
@@ -129,7 +133,7 @@ try {
   // Execute the tool
   const result = await testTool.execute({ query: "hello" });
   assert(result.result === "hello", "tool execute returns correct result");
-  console.log("  OK    tool — 8 checks");
+  console.log("  OK    tool — 9 checks");
 } catch (err) {
   failed++;
   errors.push(`tool: ${err.message}`);
@@ -234,6 +238,34 @@ try {
   failed++;
   errors.push(`oauth: ${err.message}`);
   console.log(`  FAIL  oauth — ${err.message}`);
+}
+
+// --- CLI ---
+console.log("veryfront/cli:");
+try {
+  const cliExport = npmExports["./cli"];
+  assert(cliExport !== undefined, "cli export map entry exists");
+
+  const cliImportTarget = typeof cliExport === "string" ? cliExport : cliExport.import;
+  const cliImportPath = resolve(NPM, cliImportTarget);
+  const cliBinPath = resolve(NPM, "bin/veryfront.js");
+
+  assert(existsSync(cliImportPath), "cli import target exists");
+  assert(existsSync(cliBinPath), "cli bin entry exists");
+
+  const help = spawnSync(process.execPath, [cliImportPath, "--help"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+
+  assert(help.status === 0, `cli --help exits cleanly (status ${help.status ?? "null"})`);
+  assert(help.stdout.includes("Usage:") || help.stdout.includes("veryfront <command>"), "cli --help prints usage");
+  console.log("  OK    cli — 5 checks");
+} catch (err) {
+  failed++;
+  errors.push(`cli: ${err.message}`);
+  console.log(`  FAIL  cli — ${err.message}`);
 }
 
 // --- FS ---
@@ -347,10 +379,12 @@ try {
 
 // --- Summary ---
 console.log(`\n${"=".repeat(50)}`);
-console.log(`${passed} passed, ${failed} failed (${passed + failed} total checks across 18 modules)`);
+console.log(`${passed} passed, ${failed} failed (${passed + failed} total checks across 19 modules)`);
 
 if (errors.length > 0) {
   console.log("\nFailures:");
   for (const e of errors) console.log(`  ${e}`);
   process.exit(1);
 }
+
+process.exit(0);

--- a/scripts/docs/verify-npm-node.mjs
+++ b/scripts/docs/verify-npm-node.mjs
@@ -182,7 +182,13 @@ try {
   assertType(prov.hasModelProvider, "function", "hasModelProvider is function");
   assertType(prov.getRegisteredModelProviders, "function", "getRegisteredModelProviders is function");
   assertType(prov.clearModelProviders, "function", "clearModelProviders is function");
-  console.log("  OK    provider — 5 checks");
+  assertType(prov.runWithVeryfrontCloudContext, "function", "runWithVeryfrontCloudContext is function");
+  assertType(
+    prov.runWithVeryfrontCloudContextAsync,
+    "function",
+    "runWithVeryfrontCloudContextAsync is function",
+  );
+  console.log("  OK    provider — 7 checks");
 } catch (err) {
   failed++;
   errors.push(`provider: ${err.message}`);

--- a/src/platform/cloud/resolver.test.ts
+++ b/src/platform/cloud/resolver.test.ts
@@ -6,10 +6,12 @@ import {
   _setRuntimeConfigForTesting,
   createTestConfig,
 } from "#veryfront/config/runtime-config.ts";
+import { runWithVeryfrontCloudContext } from "#veryfront/provider";
 import {
   getDefaultVeryfrontCloudEmbeddingModel,
   getDefaultVeryfrontCloudModel,
   getVeryfrontCloudAuthToken,
+  getVeryfrontCloudBootstrap,
   getVeryfrontCloudProjectSlug,
   isVeryfrontCloudEnabled,
 } from "./resolver.ts";
@@ -82,5 +84,34 @@ describe("platform/cloud/resolver", () => {
       getDefaultVeryfrontCloudEmbeddingModel(),
       "veryfront-cloud/openai/text-embedding-3-small",
     );
+  });
+
+  it("lets scoped cloud context override env bootstrap values", () => {
+    setEnv("VERYFRONT_API_TOKEN", "vf_env_token");
+    setEnv("VERYFRONT_PROJECT_SLUG", "env-project");
+
+    runWithVeryfrontCloudContext(
+      {
+        apiBaseUrl: "https://api.staging.veryfront.org",
+        apiToken: "vf_scoped_token",
+        projectSlug: "scoped-project",
+      },
+      () => {
+        assertEquals(isVeryfrontCloudEnabled(), true);
+        assertEquals(getVeryfrontCloudAuthToken(), "vf_scoped_token");
+        assertEquals(getVeryfrontCloudProjectSlug(), "scoped-project");
+        assertEquals(getVeryfrontCloudBootstrap().apiBaseUrl, "https://api.staging.veryfront.org");
+      },
+    );
+
+    assertEquals(getVeryfrontCloudAuthToken(), "vf_env_token");
+    assertEquals(getVeryfrontCloudProjectSlug(), "env-project");
+  });
+
+  it("treats scoped cloud context as sufficient runtime context even without projectSlug", () => {
+    runWithVeryfrontCloudContext({ apiToken: "vf_scoped_token" }, () => {
+      assertEquals(isVeryfrontCloudEnabled(), true);
+      assertEquals(getVeryfrontCloudAuthToken(), "vf_scoped_token");
+    });
   });
 });

--- a/src/platform/cloud/resolver.ts
+++ b/src/platform/cloud/resolver.ts
@@ -2,6 +2,7 @@ import { getRuntimeConfig, isRuntimeConfigInitialized } from "#veryfront/config"
 import { getApiBaseUrlEnv } from "#veryfront/config/env.ts";
 import { getCurrentRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { getCurrentVeryfrontCloudContext } from "#veryfront/provider/veryfront-cloud/context.ts";
 
 export const DEFAULT_VERYFRONT_CLOUD_MODEL = "veryfront-cloud/anthropic/claude-sonnet-4-6";
 export const DEFAULT_VERYFRONT_CLOUD_EMBEDDING_MODEL =
@@ -39,19 +40,28 @@ function normalizeCloudModelString(value: string | undefined, fallback: string):
   return resolved.startsWith("veryfront-cloud/") ? resolved : `veryfront-cloud/${resolved}`;
 }
 
+function normalizeServiceLayer(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  return normalized?.length ? normalized : undefined;
+}
+
 function getResolvedVeryfrontCloudContext(): Omit<VeryfrontCloudBootstrap, "apiBaseUrl"> {
   const requestContext = getCurrentRequestContext();
+  const scopedContext = getCurrentVeryfrontCloudContext();
   const runtimeBootstrap = getRuntimeBootstrap();
 
   return {
     apiToken: requestContext?.token ??
+      scopedContext?.apiToken ??
       getEnv("VERYFRONT_API_TOKEN") ??
       runtimeBootstrap.apiToken,
     projectSlug: requestContext?.projectSlug ??
+      scopedContext?.projectSlug ??
       getEnv("VERYFRONT_PROJECT_SLUG") ??
       runtimeBootstrap.projectSlug,
-    serviceLayer: getEnv("VERYFRONT_SERVICE_LAYER")?.trim().toLowerCase(),
-    hasRequestContext: requestContext !== null,
+    serviceLayer: normalizeServiceLayer(scopedContext?.serviceLayer) ??
+      normalizeServiceLayer(getEnv("VERYFRONT_SERVICE_LAYER")),
+    hasRequestContext: requestContext !== null || scopedContext !== undefined,
     usesVeryfrontFs: runtimeBootstrap.usesVeryfrontFs,
   };
 }
@@ -65,8 +75,10 @@ export function getVeryfrontCloudProjectSlug(): string | undefined {
 }
 
 export function getVeryfrontCloudBootstrap(): VeryfrontCloudBootstrap {
+  const scopedContext = getCurrentVeryfrontCloudContext();
+
   return {
-    apiBaseUrl: getApiBaseUrlEnv(),
+    apiBaseUrl: scopedContext?.apiBaseUrl?.trim() || getApiBaseUrlEnv(),
     ...getResolvedVeryfrontCloudContext(),
   };
 }

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -26,3 +26,8 @@ export {
   resolveModel,
 } from "./model-registry.ts";
 export type { ModelProviderFactory } from "./model-registry.ts";
+export {
+  runWithVeryfrontCloudContext,
+  runWithVeryfrontCloudContextAsync,
+} from "./veryfront-cloud/context.ts";
+export type { VeryfrontCloudContext } from "./veryfront-cloud/context.ts";

--- a/src/provider/veryfront-cloud/context.ts
+++ b/src/provider/veryfront-cloud/context.ts
@@ -1,0 +1,28 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface VeryfrontCloudContext {
+  apiBaseUrl?: string;
+  apiToken?: string;
+  projectSlug?: string;
+  serviceLayer?: string;
+}
+
+const veryfrontCloudContextStorage = new AsyncLocalStorage<VeryfrontCloudContext>();
+
+export function runWithVeryfrontCloudContext<T>(
+  context: VeryfrontCloudContext,
+  fn: () => T,
+): T {
+  return veryfrontCloudContextStorage.run(context, fn);
+}
+
+export function runWithVeryfrontCloudContextAsync<T>(
+  context: VeryfrontCloudContext,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return veryfrontCloudContextStorage.run(context, fn);
+}
+
+export function getCurrentVeryfrontCloudContext(): VeryfrontCloudContext | undefined {
+  return veryfrontCloudContextStorage.getStore();
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.144";
+export const VERSION = "0.1.145";


### PR DESCRIPTION
## Summary
- add a public provider-scoped Veryfront Cloud context runner for package consumers
- let the cloud resolver honor scoped api base URL/token/project bootstrap before env/runtime defaults
- lock the new provider exports into the npm verification scripts

## Testing
- VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/platform/cloud/resolver.test.ts
- deno task build:npm
- node scripts/docs/verify-npm-exports.mjs
- node scripts/docs/verify-npm-node.mjs

## Related
- closes #903