### PR TITLE
feat(mcp): elicitation support (form + URL modes)

### DIFF
--- a/src/mcp/elicitation.test.ts
+++ b/src/mcp/elicitation.test.ts
@@ -1,0 +1,42 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { buildFormElicitation, buildUrlElicitation } from "./elicitation.ts";
+
+describe("mcp/elicitation", () => {
+  it("builds a form mode elicitation request", () => {
+    const request = buildFormElicitation({
+      message: "Confirm deletion?",
+      schema: {
+        type: "object",
+        properties: {
+          confirm: { type: "boolean", title: "Confirm", default: false },
+        },
+        required: ["confirm"],
+      },
+    });
+    assertEquals(request.method, "elicitation/create");
+    assertEquals(request.params.mode, "form");
+    assertEquals(request.params.message, "Confirm deletion?");
+    assertEquals(
+      (
+        request.params.requestedSchema as Record<
+          string,
+          Record<string, Record<string, unknown>>
+        >
+      ).properties.confirm.type,
+      "boolean",
+    );
+  });
+
+  it("builds a URL mode elicitation request", () => {
+    const request = buildUrlElicitation({
+      message: "Please authorize with GitHub",
+      url: "https://example.com/auth",
+      elicitationId: "elicit-123",
+    });
+    assertEquals(request.method, "elicitation/create");
+    assertEquals(request.params.mode, "url");
+    assertEquals(request.params.url, "https://example.com/auth");
+    assertEquals(request.params.elicitationId, "elicit-123");
+  });
+});

--- a/src/mcp/elicitation.ts
+++ b/src/mcp/elicitation.ts
@@ -1,0 +1,42 @@
+interface FormElicitationOptions {
+  message: string;
+  schema: Record<string, unknown>;
+}
+
+interface UrlElicitationOptions {
+  message: string;
+  url: string;
+  elicitationId: string;
+}
+
+interface ElicitationRequest {
+  method: "elicitation/create";
+  params: Record<string, unknown>;
+}
+
+export function buildFormElicitation(
+  options: FormElicitationOptions,
+): ElicitationRequest {
+  return {
+    method: "elicitation/create",
+    params: {
+      mode: "form",
+      message: options.message,
+      requestedSchema: options.schema,
+    },
+  };
+}
+
+export function buildUrlElicitation(
+  options: UrlElicitationOptions,
+): ElicitationRequest {
+  return {
+    method: "elicitation/create",
+    params: {
+      mode: "url",
+      message: options.message,
+      url: options.url,
+      elicitationId: options.elicitationId,
+    },
+  };
+}

--- a/src/mcp/elicitation.ts
+++ b/src/mcp/elicitation.ts
@@ -1,15 +1,15 @@
-interface FormElicitationOptions {
+export interface FormElicitationOptions {
   message: string;
   schema: Record<string, unknown>;
 }
 
-interface UrlElicitationOptions {
+export interface UrlElicitationOptions {
   message: string;
   url: string;
   elicitationId: string;
 }
 
-interface ElicitationRequest {
+export interface ElicitationRequest {
   method: "elicitation/create";
   params: Record<string, unknown>;
 }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -41,7 +41,13 @@ export {
 
 export { createMCPServer, type IntegrationLoaderConfig, MCPServer } from "./server.ts";
 
-export { buildFormElicitation, buildUrlElicitation } from "./elicitation.ts";
+export {
+  buildFormElicitation,
+  buildUrlElicitation,
+  type ElicitationRequest,
+  type FormElicitationOptions,
+  type UrlElicitationOptions,
+} from "./elicitation.ts";
 export { formatSSEEvent, formatSSEPrimingEvent, formatSSERetry } from "./sse.ts";
 export { SessionManager } from "./session.ts";
 export { TaskStore } from "./task-store.ts";

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -41,6 +41,7 @@ export {
 
 export { createMCPServer, type IntegrationLoaderConfig, MCPServer } from "./server.ts";
 
+export { buildFormElicitation, buildUrlElicitation } from "./elicitation.ts";
 export { formatSSEEvent, formatSSEPrimingEvent, formatSSERetry } from "./sse.ts";
 export { SessionManager } from "./session.ts";
 export { TaskStore } from "./task-store.ts";

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1066,6 +1066,22 @@ describe("mcp/server", () => {
     assertEquals(server.clientSupportsElicitation("url"), false);
   });
 
+  it("handles malformed elicitation capability without crashing", async () => {
+    const server = createMCPServer({ enabled: true });
+    await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: { elicitation: true },
+        clientInfo: { name: "test", version: "1.0" },
+      },
+    });
+    assertEquals(server.clientSupportsElicitation("form"), false);
+    assertEquals(server.clientSupportsElicitation("url"), false);
+  });
+
   it("syncs integration config to API on first tools/list call", async () => {
     const server = createMCPServer({ enabled: true });
     server.setIntegrationLoader({

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1050,6 +1050,22 @@ describe("mcp/server", () => {
     assertEquals(server.clientSupportsElicitation("url"), false);
   });
 
+  it("treats empty elicitation capability as form-only support", async () => {
+    const server = createMCPServer({ enabled: true });
+    await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: { elicitation: {} },
+        clientInfo: { name: "test", version: "1.0" },
+      },
+    });
+    assertEquals(server.clientSupportsElicitation("form"), true);
+    assertEquals(server.clientSupportsElicitation("url"), false);
+  });
+
   it("syncs integration config to API on first tools/list call", async () => {
     const server = createMCPServer({ enabled: true });
     server.setIntegrationLoader({

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1018,6 +1018,38 @@ describe("mcp/server", () => {
     assertEquals(data.completion.hasMore, false);
   });
 
+  it("stores client capabilities from initialize request", async () => {
+    const server = createMCPServer({ enabled: true });
+    await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: { elicitation: { form: {}, url: {} } },
+        clientInfo: { name: "test", version: "1.0" },
+      },
+    });
+    assertEquals(server.clientSupportsElicitation("form"), true);
+    assertEquals(server.clientSupportsElicitation("url"), true);
+  });
+
+  it("reports no elicitation support when client does not declare it", async () => {
+    const server = createMCPServer({ enabled: true });
+    await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "test", version: "1.0" },
+      },
+    });
+    assertEquals(server.clientSupportsElicitation("form"), false);
+    assertEquals(server.clientSupportsElicitation("url"), false);
+  });
+
   it("syncs integration config to API on first tools/list call", async () => {
     const server = createMCPServer({ enabled: true });
     server.setIntegrationLoader({

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -154,6 +154,7 @@ export class MCPServer {
       | Record<string, unknown>
       | undefined;
     if (!elicitation) return false;
+    // Per MCP spec: empty elicitation object implies basic form support (backwards compat)
     if (mode === "form" && Object.keys(elicitation).length === 0) return true;
     return mode in elicitation;
   }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -127,6 +127,7 @@ export class MCPServer {
   private sessionManager = new SessionManager();
   private taskStore = new TaskStore();
   private pendingTasks = new Map<string, Promise<void>>();
+  private clientCapabilities: Record<string, unknown> = {};
 
   constructor(config: MCPServerConfig) {
     this.config = config;
@@ -146,6 +147,15 @@ export class MCPServer {
   setIntegrationLoader(config: IntegrationLoaderConfig): void {
     this.integrationLoader = config;
     this.integrationsLoaded = false;
+  }
+
+  clientSupportsElicitation(mode: "form" | "url"): boolean {
+    const elicitation = this.clientCapabilities.elicitation as
+      | Record<string, unknown>
+      | undefined;
+    if (!elicitation) return false;
+    if (mode === "form" && Object.keys(elicitation).length === 0) return true;
+    return mode in elicitation;
   }
 
   handleRequest(request: JSONRPCRequest, context?: ToolExecutionContext): Promise<JSONRPCResponse> {
@@ -222,6 +232,9 @@ export class MCPServer {
     const negotiated = requested && MCP_SUPPORTED_VERSIONS.includes(requested)
       ? requested
       : MCP_SUPPORTED_VERSIONS[0];
+
+    const clientCaps = (p.capabilities ?? {}) as Record<string, unknown>;
+    this.clientCapabilities = clientCaps;
 
     return Promise.resolve({
       protocolVersion: negotiated,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -127,6 +127,8 @@ export class MCPServer {
   private sessionManager = new SessionManager();
   private taskStore = new TaskStore();
   private pendingTasks = new Map<string, Promise<void>>();
+  // TODO(#842): capabilities should be stored per-session (keyed by MCP-Session-Id)
+  // so concurrent clients don't overwrite each other's capability flags.
   private clientCapabilities: Record<string, unknown> = {};
 
   constructor(config: MCPServerConfig) {
@@ -150,10 +152,9 @@ export class MCPServer {
   }
 
   clientSupportsElicitation(mode: "form" | "url"): boolean {
-    const elicitation = this.clientCapabilities.elicitation as
-      | Record<string, unknown>
-      | undefined;
-    if (!elicitation) return false;
+    const raw = this.clientCapabilities.elicitation;
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return false;
+    const elicitation = raw as Record<string, unknown>;
     // Per MCP spec: empty elicitation object implies basic form support (backwards compat)
     if (mode === "form" && Object.keys(elicitation).length === 0) return true;
     return mode in elicitation;


### PR DESCRIPTION
## Summary

Implements PR 12 from the MCP 2025-11-25 compliance plan. Adds elicitation support.

- Stores client capabilities from `initialize` params
- `clientSupportsElicitation(mode)` method for form/URL capability checks
- `buildFormElicitation()` and `buildUrlElicitation()` request builders

Closes #843
Depends on #895 (merge that first)

## Test plan

- [x] Client capabilities stored and queryable
- [x] Form and URL elicitation builders produce correct requests
- [x] All MCP tests pass (100 steps, 0 failures)