### PR TITLE
feat(mcp): emit listChanged notifications on registry updates

### DIFF
--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1746,4 +1746,42 @@ describe("mcp/server", () => {
     });
     assertExists(result.error);
   });
+
+  it("calls onNotification when tools list changes", () => {
+    const notifications: Array<{ method: string }> = [];
+    const server = createMCPServer({ enabled: true });
+    server.onNotification = (notification) => {
+      notifications.push(notification as { method: string });
+    };
+    server.notifyToolsChanged();
+    assertEquals(notifications.length, 1);
+    assertEquals(notifications[0].method, "notifications/tools/list_changed");
+  });
+
+  it("calls onNotification for resources list changes", () => {
+    const notifications: Array<{ method: string }> = [];
+    const server = createMCPServer({ enabled: true });
+    server.onNotification = (notification) => {
+      notifications.push(notification as { method: string });
+    };
+    server.notifyResourcesChanged();
+    assertEquals(notifications.length, 1);
+    assertEquals(notifications[0].method, "notifications/resources/list_changed");
+  });
+
+  it("calls onNotification for prompts list changes", () => {
+    const notifications: Array<{ method: string }> = [];
+    const server = createMCPServer({ enabled: true });
+    server.onNotification = (notification) => {
+      notifications.push(notification as { method: string });
+    };
+    server.notifyPromptsChanged();
+    assertEquals(notifications.length, 1);
+    assertEquals(notifications[0].method, "notifications/prompts/list_changed");
+  });
+
+  it("does not throw when onNotification is not set", () => {
+    const server = createMCPServer({ enabled: true });
+    server.notifyToolsChanged(); // should not throw
+  });
 });

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1747,41 +1747,74 @@ describe("mcp/server", () => {
     assertExists(result.error);
   });
 
-  it("calls onNotification when tools list changes", () => {
-    const notifications: Array<{ method: string }> = [];
-    const server = createMCPServer({ enabled: true });
-    server.onNotification = (notification) => {
-      notifications.push(notification as { method: string });
-    };
-    server.notifyToolsChanged();
-    assertEquals(notifications.length, 1);
-    assertEquals(notifications[0].method, "notifications/tools/list_changed");
-  });
+  describe("listChanged notifications", () => {
+    it("calls onNotification when tools list changes", () => {
+      const notifications: Array<{ method: string }> = [];
+      const server = createMCPServer({ enabled: true });
+      server.onNotification = (notification) => {
+        notifications.push(notification as { method: string });
+      };
+      server.notifyToolsChanged();
+      assertEquals(notifications.length, 1);
+      assertEquals(notifications[0].method, "notifications/tools/list_changed");
+    });
 
-  it("calls onNotification for resources list changes", () => {
-    const notifications: Array<{ method: string }> = [];
-    const server = createMCPServer({ enabled: true });
-    server.onNotification = (notification) => {
-      notifications.push(notification as { method: string });
-    };
-    server.notifyResourcesChanged();
-    assertEquals(notifications.length, 1);
-    assertEquals(notifications[0].method, "notifications/resources/list_changed");
-  });
+    it("calls onNotification for resources list changes", () => {
+      const notifications: Array<{ method: string }> = [];
+      const server = createMCPServer({ enabled: true });
+      server.onNotification = (notification) => {
+        notifications.push(notification as { method: string });
+      };
+      server.notifyResourcesChanged();
+      assertEquals(notifications.length, 1);
+      assertEquals(notifications[0].method, "notifications/resources/list_changed");
+    });
 
-  it("calls onNotification for prompts list changes", () => {
-    const notifications: Array<{ method: string }> = [];
-    const server = createMCPServer({ enabled: true });
-    server.onNotification = (notification) => {
-      notifications.push(notification as { method: string });
-    };
-    server.notifyPromptsChanged();
-    assertEquals(notifications.length, 1);
-    assertEquals(notifications[0].method, "notifications/prompts/list_changed");
-  });
+    it("calls onNotification for prompts list changes", () => {
+      const notifications: Array<{ method: string }> = [];
+      const server = createMCPServer({ enabled: true });
+      server.onNotification = (notification) => {
+        notifications.push(notification as { method: string });
+      };
+      server.notifyPromptsChanged();
+      assertEquals(notifications.length, 1);
+      assertEquals(notifications[0].method, "notifications/prompts/list_changed");
+    });
 
-  it("does not throw when onNotification is not set", () => {
-    const server = createMCPServer({ enabled: true });
-    server.notifyToolsChanged(); // should not throw
+    it("does not throw when onNotification is not set", () => {
+      const server = createMCPServer({ enabled: true });
+      server.notifyToolsChanged(); // should not throw
+    });
+
+    it("emits tools/list_changed when loadRemoteIntegrationTools succeeds", async () => {
+      const server = createMCPServer({ enabled: true });
+      server.setIntegrationLoader({
+        integrations: { github: {} },
+        apiBaseUrl: "https://api.example.com",
+        apiToken: "test-token",
+      });
+
+      const notifications: Array<{ method: string }> = [];
+      server.onNotification = (notification) => {
+        notifications.push(notification as { method: string });
+      };
+
+      globalThis.fetch = async (input: string | URL | Request) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "https://api.example.com/integrations/config") {
+          return new Response(JSON.stringify({ synced: 1 }), {
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response("Not Found", { status: 404 });
+      };
+
+      await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+
+      const toolsChanged = notifications.find(
+        (n) => n.method === "notifications/tools/list_changed",
+      );
+      assertExists(toolsChanged);
+    });
   });
 });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -800,7 +800,11 @@ export class MCPServer {
       };
     }
     await syncIntegrationConfig(apiBaseUrl, apiToken, integrationConfigs);
-    this.notifyToolsChanged();
+    try {
+      this.notifyToolsChanged();
+    } catch (_) {
+      // Notification delivery failure is non-fatal — sync already succeeded
+    }
     return true;
   }
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -131,12 +131,27 @@ export class MCPServer {
   // so concurrent clients don't overwrite each other's capability flags.
   private clientCapabilities: Record<string, unknown> = {};
 
+  /** Callback for server-initiated notifications. Set by transport layer. */
+  onNotification?: (notification: { jsonrpc: "2.0"; method: string; params?: unknown }) => void;
+
   constructor(config: MCPServerConfig) {
     this.config = config;
 
     if (!config.auth || config.auth.type === "none") {
       logger.warn("MCP server has no authentication configured — all requests will be accepted");
     }
+  }
+
+  notifyToolsChanged(): void {
+    this.onNotification?.({ jsonrpc: "2.0", method: "notifications/tools/list_changed" });
+  }
+
+  notifyResourcesChanged(): void {
+    this.onNotification?.({ jsonrpc: "2.0", method: "notifications/resources/list_changed" });
+  }
+
+  notifyPromptsChanged(): void {
+    this.onNotification?.({ jsonrpc: "2.0", method: "notifications/prompts/list_changed" });
   }
 
   /**
@@ -785,6 +800,7 @@ export class MCPServer {
       };
     }
     await syncIntegrationConfig(apiBaseUrl, apiToken, integrationConfigs);
+    this.notifyToolsChanged();
     return true;
   }
 }


### PR DESCRIPTION
## Summary

Implements PR 13 from the MCP 2025-11-25 compliance plan. Emits listChanged notifications.

- `onNotification` callback on MCPServer for transport-layer delivery
- `notifyToolsChanged()`, `notifyResourcesChanged()`, `notifyPromptsChanged()`
- `loadRemoteIntegrationTools()` triggers `notifyToolsChanged()` on success

Closes #844
Depends on #895 (merge that first)

## Test plan

- [x] All three notification methods fire with correct method names
- [x] No-op when callback not set
- [x] All MCP tests pass (100 steps, 0 failures)