### PR TITLE
Advertise MCP accept types in remote framework tool requests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.145",
+  "version": "0.1.146",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/tool/remote-mcp.test.ts
+++ b/src/tool/remote-mcp.test.ts
@@ -8,6 +8,7 @@ describe("tool/remote-mcp", () => {
     let requestUrl = "";
     let requestMethod = "";
     let projectHeader = "";
+    let acceptHeader = "";
     let requestBody: Record<string, unknown> | undefined;
 
     const source = createRemoteMCPToolSource({
@@ -25,6 +26,7 @@ describe("tool/remote-mcp", () => {
         requestUrl = request.url;
         requestMethod = request.method;
         projectHeader = request.headers.get("x-project-id") ?? "";
+        acceptHeader = request.headers.get("accept") ?? "";
         requestBody = await request.json();
 
         return Response.json({
@@ -47,6 +49,7 @@ describe("tool/remote-mcp", () => {
     assertEquals(requestUrl, "https://mcp.test/proj_123");
     assertEquals(requestMethod, "POST");
     assertEquals(projectHeader, "proj_123");
+    assertEquals(acceptHeader, "application/json, text/event-stream");
     assertEquals(requestBody, {
       jsonrpc: "2.0",
       id: "docs:tools:list",
@@ -87,6 +90,39 @@ describe("tool/remote-mcp", () => {
       error: "authentication_required",
       connectUrl: "/oauth/docs",
     });
+  });
+
+  it("preserves caller accept types while adding the MCP-required media types", async () => {
+    let acceptHeader = "";
+
+    const source = createRemoteMCPToolSource({
+      id: "docs",
+      endpoint: "https://mcp.test",
+      headers: {
+        Accept: "application/vnd.custom+json",
+      },
+    });
+
+    await withMockFetch(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        acceptHeader = request.headers.get("accept") ?? "";
+
+        return Response.json({
+          jsonrpc: "2.0",
+          id: "docs:tools:list",
+          result: {
+            tools: [],
+          },
+        });
+      },
+      async () => await source.listTools(),
+    );
+
+    assertEquals(
+      acceptHeader,
+      "application/vnd.custom+json, application/json, text/event-stream",
+    );
   });
 
   it("throws when the remote MCP server responds with a JSON-RPC error", async () => {

--- a/src/tool/remote-mcp.test.ts
+++ b/src/tool/remote-mcp.test.ts
@@ -125,6 +125,37 @@ describe("tool/remote-mcp", () => {
     );
   });
 
+  it("parses JSON-RPC results from SSE responses when the MCP server negotiates text/event-stream", async () => {
+    const source = createRemoteMCPToolSource({
+      id: "docs",
+      endpoint: "https://mcp.test",
+    });
+
+    const tools = await withMockFetch(
+      async () =>
+        new Response(
+          [
+            "event: message",
+            'data: {"jsonrpc":"2.0","id":"docs:tools:list","result":{"tools":[{"name":"search_docs","description":"Search documentation","inputSchema":{}}]}}',
+            "",
+            "",
+          ].join("\n"),
+          {
+            headers: {
+              "Content-Type": "text/event-stream; charset=utf-8",
+            },
+          },
+        ),
+      async () => await source.listTools(),
+    );
+
+    assertEquals(tools, [{
+      name: "search_docs",
+      description: "Search documentation",
+      parameters: { type: "object", properties: {} },
+    }]);
+  });
+
   it("throws when the remote MCP server responds with a JSON-RPC error", async () => {
     const source = createRemoteMCPToolSource({
       id: "docs",

--- a/src/tool/remote-mcp.ts
+++ b/src/tool/remote-mcp.ts
@@ -22,6 +22,10 @@ interface JsonRpcCallToolContentItem {
   text?: unknown;
 }
 
+interface SseEvent {
+  data: string[];
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -125,6 +129,67 @@ function extractJsonRpcErrorMessage(payload: Record<string, unknown>): string {
   return "Remote MCP server returned an error";
 }
 
+function parseSseEvents(text: string): SseEvent[] {
+  const events: SseEvent[] = [];
+  let currentEvent: SseEvent = { data: [] };
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+
+    if (line.length === 0) {
+      if (currentEvent.data.length > 0) {
+        events.push(currentEvent);
+      }
+      currentEvent = { data: [] };
+      continue;
+    }
+
+    if (line.startsWith(":")) {
+      continue;
+    }
+
+    if (line.startsWith("data:")) {
+      currentEvent.data.push(line.slice(5).trimStart());
+    }
+  }
+
+  if (currentEvent.data.length > 0) {
+    events.push(currentEvent);
+  }
+
+  return events;
+}
+
+function parseJsonRpcSsePayload(text: string): unknown {
+  const parsedPayloads = parseSseEvents(text)
+    .map((event) => parseJsonText(event.data.join("\n")))
+    .filter((payload): payload is unknown => payload !== undefined);
+
+  const jsonRpcPayload = parsedPayloads.find(
+    (payload) => isRecord(payload) && ("result" in payload || "error" in payload),
+  );
+
+  if (jsonRpcPayload !== undefined) {
+    return jsonRpcPayload;
+  }
+
+  if (parsedPayloads.length > 0) {
+    return parsedPayloads[0];
+  }
+
+  throw new Error("Remote MCP SSE response did not include a JSON-RPC payload");
+}
+
+async function parseJsonRpcResponse(response: Response): Promise<unknown> {
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+
+  if (contentType.includes("text/event-stream")) {
+    return parseJsonRpcSsePayload(await response.text());
+  }
+
+  return await response.json();
+}
+
 async function resolveValue<T>(
   value: ResolvableValue<T>,
   context?: ToolExecutionContext,
@@ -184,7 +249,7 @@ async function postJsonRpc(
     );
   }
 
-  return await response.json();
+  return await parseJsonRpcResponse(response);
 }
 
 function getJsonRpcResult(payload: unknown): unknown {

--- a/src/tool/remote-mcp.ts
+++ b/src/tool/remote-mcp.ts
@@ -142,7 +142,27 @@ async function resolveHeaders(
   const resolvedHeaders = headers ? await resolveValue(headers, context) : undefined;
   const finalHeaders = new Headers(resolvedHeaders);
   finalHeaders.set("Content-Type", "application/json");
+  finalHeaders.set("Accept", mergeAcceptHeader(finalHeaders.get("Accept")));
   return finalHeaders;
+}
+
+function mergeAcceptHeader(existingAccept: string | null): string {
+  const requiredTypes = ["application/json", "text/event-stream"];
+  const existingTypes = (existingAccept ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  const existingKeys = new Set(
+    existingTypes.map((entry) => entry.split(";")[0]?.trim().toLowerCase()).filter(Boolean),
+  );
+
+  for (const requiredType of requiredTypes) {
+    if (!existingKeys.has(requiredType)) {
+      existingTypes.push(requiredType);
+    }
+  }
+
+  return existingTypes.join(", ");
 }
 
 async function postJsonRpc(

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.145";
+export const VERSION = "0.1.146";


### PR DESCRIPTION
## Summary
- include the MCP-required `Accept` media types on remote JSON-RPC tool requests
- preserve caller-provided `Accept` values while appending `application/json` and `text/event-stream`
- add regression coverage for the default and custom-accept cases

## Why
Staging framework-default agent runs fail during setup with:
- `Remote MCP request failed (406)`
- `Not Acceptable: Client must accept both application/json and text/event-stream`

This fixes the shared framework client rather than special-casing one host.

## Verification
- `deno test --no-check --allow-all src/tool/remote-mcp.test.ts`
- `deno test --no-check --allow-all src/tool/remote-mcp.test.ts src/agent/runtime/tool-helpers.test.ts`
- full repo pre-push lane passed during `git push`
