### PR TITLE
Release veryfront 0.1.147 for the MCP transport fix

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.146",
+  "version": "0.1.147",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.146";
+export const VERSION = "0.1.147";


### PR DESCRIPTION
## Summary
- bump `veryfront` to `0.1.147`
- publish the already-merged MCP Accept/SSE transport fix under a new immutable npm version

## Why
`0.1.146` was already on npm before the MCP fix landed, so downstream consumers like `veryfront-agent` still resolve the old tarball. This creates a real publishable patch version for the merged fix.

## Verification
- `deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/tool/remote-mcp.test.ts src/agent/runtime/tool-helpers.test.ts`