### PR TITLE
chore: bump version to 0.1.148

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.147",
+  "version": "0.1.148",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [
@@ -424,13 +424,7 @@
     "proseWrap": "preserve"
   },
   "allowScripts": {
-    "allow": [
-      "npm:sharp@0.33.5",
-      "npm:onnxruntime-node@1.21.0"
-    ],
-    "deny": [
-      "npm:esbuild@0.27.4",
-      "npm:protobufjs@7.5.4"
-    ]
+    "allow": ["npm:onnxruntime-node@1.21.0", "npm:sharp@0.33.5"],
+    "deny": ["npm:esbuild@0.27.4", "npm:onnxruntime-node@1.20.1", "npm:protobufjs@7.5.4"]
   }
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.147";
+export const VERSION = "0.1.148";


### PR DESCRIPTION
## Summary

Bump version from 0.1.147 to 0.1.148.

Updates both `deno.json` and `src/utils/version-constant.ts`.