### PR TITLE
Fix resumed runtime tool-result replay duplication

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.148",
+  "version": "0.1.149",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/runtime/index.test.ts
+++ b/src/agent/runtime/index.test.ts
@@ -1,0 +1,92 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { collectFinalStreamToolResults, collectPersistedToolResults } from "./index.ts";
+import type { AIStreamState } from "./ai-stream-handler.ts";
+import type { Message } from "../types.ts";
+
+function createState(
+  toolResults: AIStreamState["toolResults"],
+): Pick<AIStreamState, "toolResults"> {
+  return { toolResults };
+}
+
+describe("agent runtime streamed tool result collection", () => {
+  it("ignores preliminary streamed tool results when a final result exists", () => {
+    const finalToolResults = collectFinalStreamToolResults(
+      createState([
+        {
+          toolCallId: "tool-1",
+          toolName: "list_files",
+          output: { files: [] },
+          preliminary: true,
+        },
+        {
+          toolCallId: "tool-1",
+          toolName: "list_files",
+          output: { files: ["app.tsx"] },
+        },
+      ]),
+    );
+
+    assertEquals(finalToolResults.size, 1);
+    assertEquals(finalToolResults.get("tool-1")?.output, { files: ["app.tsx"] });
+  });
+
+  it("keeps only one final streamed tool result per tool call id", () => {
+    const finalToolResults = collectFinalStreamToolResults(
+      createState([
+        {
+          toolCallId: "tool-2",
+          toolName: "create_file",
+          output: { ok: false, retry: true },
+        },
+        {
+          toolCallId: "tool-2",
+          toolName: "create_file",
+          output: { ok: true },
+        },
+      ]),
+    );
+
+    assertEquals(finalToolResults.size, 1);
+    assertEquals(finalToolResults.get("tool-2")?.output, { ok: true });
+  });
+
+  it("collects the latest persisted tool result from message history", () => {
+    const persistedToolResults = collectPersistedToolResults([
+      {
+        id: "assistant_1",
+        role: "assistant",
+        parts: [{
+          type: "tool-form_input",
+          toolCallId: "tool-3",
+          toolName: "form_input",
+          args: { label: "What kind of bank?" },
+        }],
+      } as Message,
+      {
+        id: "tool_3_old",
+        role: "tool",
+        parts: [{
+          type: "tool-result",
+          toolCallId: "tool-3",
+          toolName: "form_input",
+          result: { submitted: false },
+        }],
+      },
+      {
+        id: "tool_3_new",
+        role: "tool",
+        parts: [{
+          type: "tool-result",
+          toolCallId: "tool-3",
+          toolName: "form_input",
+          result: { submitted: true },
+        }],
+      },
+    ]);
+
+    assertEquals(persistedToolResults.size, 1);
+    assertEquals(persistedToolResults.get("tool-3")?.result, { submitted: true });
+  });
+});

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -182,11 +182,11 @@ export function collectPersistedToolResults(
       continue;
     }
 
-    for (const part of message.parts) {
-      if (part.type !== "tool-result") {
-        continue;
-      }
-
+    for (
+      const part of message.parts.filter((messagePart): messagePart is ToolResultPart =>
+        messagePart.type === "tool-result"
+      )
+    ) {
       persistedToolResults.set(part.toolCallId, part);
     }
   }

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -20,6 +20,7 @@ import {
   type Message,
   type MessagePart,
   type ToolCall,
+  type ToolResultPart,
 } from "../types.ts";
 import { ensureModelReady, resolveModel } from "#veryfront/provider";
 import { generateId } from "#veryfront/utils/id.ts";
@@ -33,7 +34,12 @@ import {
 } from "#veryfront/observability/tracing/index.ts";
 import { convertToModelMessages } from "./model-message-converter.ts";
 import { convertToolsToAISDK } from "./model-tool-converter.ts";
-import { createStreamState, processStream } from "./ai-stream-handler.ts";
+import {
+  type AIStreamState,
+  createStreamState,
+  processStream,
+  type StreamingToolResult,
+} from "./ai-stream-handler.ts";
 import { repairToolCall } from "./repair-tool-call.ts";
 import { MiddlewareChain } from "../middleware/chain.ts";
 import { generateText, type LanguageModel, streamText } from "ai";
@@ -137,9 +143,55 @@ function stringifyToolError(error: unknown): string {
   }
 }
 
+function getToolResultError(result: unknown): string | undefined {
+  if (!result || typeof result !== "object" || !("error" in result)) {
+    return undefined;
+  }
+
+  return stringifyToolError(result.error);
+}
+
 function getSkillActivationRequiredError(toolName: string): string {
   return `Tool "${toolName}" cannot run before load-skill succeeds in the same step. ` +
     `Call "${LOAD_SKILL_TOOL_ID}" first to establish the active skill context.`;
+}
+
+export function collectFinalStreamToolResults(
+  state: Pick<AIStreamState, "toolResults">,
+): Map<string, StreamingToolResult> {
+  const finalToolResults = new Map<string, StreamingToolResult>();
+
+  for (const toolResult of state.toolResults) {
+    if (toolResult.preliminary === true) {
+      continue;
+    }
+
+    finalToolResults.set(toolResult.toolCallId, toolResult);
+  }
+
+  return finalToolResults;
+}
+
+export function collectPersistedToolResults(
+  messages: Message[],
+): Map<string, ToolResultPart> {
+  const persistedToolResults = new Map<string, ToolResultPart>();
+
+  for (const message of messages) {
+    if (message.role !== "tool") {
+      continue;
+    }
+
+    for (const part of message.parts) {
+      if (part.type !== "tool-result") {
+        continue;
+      }
+
+      persistedToolResults.set(part.toolCallId, part);
+    }
+  }
+
+  return persistedToolResults;
 }
 
 /**
@@ -731,6 +783,7 @@ export class AgentRuntime {
     for (let step = 0; step < maxSteps; step++) {
       throwIfAborted(abortSignal);
       sendSSE(controller, encoder, { type: "step-start" });
+      const persistedToolResults = collectPersistedToolResults(currentMessages);
 
       let tools = isLocalStreaming ? [] : await getAvailableTools(this.config.tools, {
         includeSkillTools: Boolean(this.config.skills),
@@ -795,29 +848,40 @@ export class AgentRuntime {
       currentMessages.push(assistantMessage);
       await this.memory.add(assistantMessage);
 
-      for (const tr of state.toolResults) {
-        if (tr.preliminary) {
-          continue;
+      const finalToolResults = collectFinalStreamToolResults(state);
+
+      const persistToolResult = async (toolResult: StreamingToolResult): Promise<void> => {
+        if (persistedToolResults.has(toolResult.toolCallId)) {
+          return;
         }
 
         const toolResultMessage: Message = {
-          id: `tool_${tr.toolCallId}`,
+          id: `tool_${toolResult.toolCallId}`,
           role: "tool",
           parts: [
             {
               type: "tool-result",
-              toolCallId: tr.toolCallId,
-              toolName: tr.toolName,
-              result: tr.error === undefined ? tr.output : { error: stringifyToolError(tr.error) },
+              toolCallId: toolResult.toolCallId,
+              toolName: toolResult.toolName,
+              result: toolResult.error === undefined
+                ? toolResult.output
+                : { error: stringifyToolError(toolResult.error) },
             },
           ],
           timestamp: Date.now(),
         };
         currentMessages.push(toolResultMessage);
         await this.memory.add(toolResultMessage);
-      }
+        persistedToolResults.set(
+          toolResult.toolCallId,
+          toolResultMessage.parts[0] as ToolResultPart,
+        );
+      };
 
       if (state.finishReason !== "tool-calls" || !state.toolCalls.size) {
+        for (const toolResult of finalToolResults.values()) {
+          await persistToolResult(toolResult);
+        }
         sendSSE(controller, encoder, { type: "step-end" });
         break;
       }
@@ -832,20 +896,26 @@ export class AgentRuntime {
         throwIfAborted(abortSignal);
         const { args, error: argError } = parseToolArgs(tc.arguments);
         const toolCall: ToolCall = { id: tc.id, name: tc.name, args, status: "pending" };
+        const matchingResult = finalToolResults.get(tc.id);
+        const persistedResult = persistedToolResults.get(tc.id);
 
-        if (tc.providerExecuted === true) {
-          const matchingResult = state.toolResults.find((result) =>
-            result.toolCallId === tc.id && result.preliminary !== true
-          );
+        if (matchingResult) {
+          await persistToolResult(matchingResult);
+          toolCall.status = matchingResult.error === undefined ? "completed" : "error";
+          toolCall.result = matchingResult.output;
+          toolCall.error = matchingResult.error === undefined
+            ? undefined
+            : stringifyToolError(matchingResult.error);
+          toolCalls.push(toolCall);
+          continue;
+        }
 
-          if (matchingResult) {
-            toolCall.status = matchingResult.error === undefined ? "completed" : "error";
-            toolCall.result = matchingResult.output;
-            toolCall.error = matchingResult.error === undefined
-              ? undefined
-              : stringifyToolError(matchingResult.error);
-            toolCalls.push(toolCall);
-          }
+        if (persistedResult) {
+          const persistedError = getToolResultError(persistedResult.result);
+          toolCall.status = persistedError === undefined ? "completed" : "error";
+          toolCall.result = persistedResult.result;
+          toolCall.error = persistedError;
+          toolCalls.push(toolCall);
           continue;
         }
 
@@ -938,8 +1008,11 @@ export class AgentRuntime {
             ],
             timestamp: Date.now(),
           };
-          currentMessages.push(toolResultMessage);
-          await this.memory.add(toolResultMessage);
+          if (!persistedToolResults.has(tc.id)) {
+            currentMessages.push(toolResultMessage);
+            await this.memory.add(toolResultMessage);
+            persistedToolResults.set(tc.id, toolResultMessage.parts[0] as ToolResultPart);
+          }
         } catch (error) {
           const errorStr = error instanceof Error ? error.message : String(error);
           await this.recordToolError(
@@ -951,6 +1024,10 @@ export class AgentRuntime {
             toolCalls,
           );
         }
+      }
+
+      for (const toolResult of finalToolResults.values()) {
+        await persistToolResult(toolResult);
       }
 
       throwIfAborted(abortSignal);

--- a/src/agent/runtime/model-message-converter.test.ts
+++ b/src/agent/runtime/model-message-converter.test.ts
@@ -133,30 +133,6 @@ describe("model-message-converter", () => {
       assertEquals(content[0].toolName, "unknown");
     });
 
-    it("handles multiple tool results in one tool message", () => {
-      const msg: Message = {
-        id: "t3",
-        role: "tool",
-        parts: [
-          {
-            type: "tool-result",
-            toolCallId: "tc1",
-            toolName: "a",
-            result: "r1",
-          },
-          {
-            type: "tool-result",
-            toolCallId: "tc2",
-            toolName: "b",
-            result: "r2",
-          },
-        ],
-      };
-      const result = convertToModelMessage(msg);
-      const content = result.content as Array<Record<string, unknown>>;
-      assertEquals(content.length, 2);
-    });
-
     it("falls back to user role for unknown message roles", () => {
       const msg = {
         id: "x1",
@@ -222,6 +198,87 @@ describe("model-message-converter", () => {
 
     it("returns empty array for empty input", () => {
       assertEquals(convertToModelMessages([]), []);
+    });
+
+    it("splits multiple tool results into one provider message per tool call", () => {
+      const messages: Message[] = [{
+        id: "tool_batch",
+        role: "tool",
+        parts: [
+          {
+            type: "tool-result",
+            toolCallId: "tc1",
+            toolName: "a",
+            result: "r1",
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tc2",
+            toolName: "b",
+            result: "r2",
+          },
+        ],
+      }];
+
+      const result = convertToModelMessages(messages);
+
+      assertEquals(result.length, 2);
+      assertEquals(result[0], {
+        role: "tool",
+        content: [{
+          type: "tool-result",
+          toolCallId: "tc1",
+          toolName: "a",
+          output: { type: "json", value: "r1" },
+        }],
+      });
+      assertEquals(result[1], {
+        role: "tool",
+        content: [{
+          type: "tool-result",
+          toolCallId: "tc2",
+          toolName: "b",
+          output: { type: "json", value: "r2" },
+        }],
+      });
+    });
+
+    it("keeps only the latest tool result for a repeated tool call id", () => {
+      const messages: Message[] = [
+        {
+          id: "tool_1",
+          role: "tool",
+          parts: [{
+            type: "tool-result",
+            toolCallId: "tc1",
+            toolName: "search",
+            result: { files: ["old.ts"] },
+          }],
+        },
+        {
+          id: "tool_2",
+          role: "tool",
+          parts: [{
+            type: "tool-result",
+            toolCallId: "tc1",
+            toolName: "search",
+            result: { files: ["new.ts"] },
+          }],
+        },
+      ];
+
+      const result = convertToModelMessages(messages);
+
+      assertEquals(result.length, 1);
+      assertEquals(result[0], {
+        role: "tool",
+        content: [{
+          type: "tool-result",
+          toolCallId: "tc1",
+          toolName: "search",
+          output: { type: "json", value: { files: ["new.ts"] } },
+        }],
+      });
     });
   });
 });

--- a/src/agent/runtime/model-message-converter.ts
+++ b/src/agent/runtime/model-message-converter.ts
@@ -108,9 +108,55 @@ export function convertToModelMessage(msg: Message): ModelMessage {
   }
 }
 
+function convertToolResultPart(
+  part: ToolResultPart,
+): ModelMessage {
+  return {
+    role: "tool",
+    content: [{
+      type: "tool-result",
+      toolCallId: part.toolCallId,
+      toolName: part.toolName ?? "unknown",
+      output: { type: "json", value: part.result },
+    }],
+  } as ModelMessage;
+}
+
 /**
  * Convert an array of veryfront Messages to AI SDK ModelMessage format.
  */
 export function convertToModelMessages(messages: Message[]): ModelMessage[] {
-  return messages.map(convertToModelMessage);
+  const modelMessages: ModelMessage[] = [];
+  const toolResultMessageIndexes = new Map<string, number>();
+
+  for (const message of messages) {
+    if (message.role !== "tool") {
+      modelMessages.push(convertToModelMessage(message));
+      continue;
+    }
+
+    const toolResultParts = message.parts.filter((part): part is ToolResultPart =>
+      part.type === "tool-result"
+    );
+
+    if (toolResultParts.length === 0) {
+      modelMessages.push(convertToModelMessage(message));
+      continue;
+    }
+
+    for (const toolResultPart of toolResultParts) {
+      const toolResultMessage = convertToolResultPart(toolResultPart);
+      const existingIndex = toolResultMessageIndexes.get(toolResultPart.toolCallId);
+
+      if (existingIndex === undefined) {
+        toolResultMessageIndexes.set(toolResultPart.toolCallId, modelMessages.length);
+        modelMessages.push(toolResultMessage);
+        continue;
+      }
+
+      modelMessages[existingIndex] = toolResultMessage;
+    }
+  }
+
+  return modelMessages;
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.148";
+export const VERSION = "0.1.149";


### PR DESCRIPTION
## Summary
- treat persisted tool results in runtime history as authoritative during resumed streaming runs
- avoid re-appending or re-executing the same toolCallId when a durable result already exists
- keep only the latest tool result per toolCallId when converting history for provider requests

## Testing
- deno check src/index.ts
- deno test --no-check --allow-all src/agent/runtime/*.test.ts