### PR TITLE
Use workflows/ as the canonical framework workflow directory

### DIFF
--- a/cli/commands/workflow/command-help.ts
+++ b/cli/commands/workflow/command-help.ts
@@ -3,7 +3,7 @@ import type { CommandHelp } from "../../help/types.ts";
 export const workflowHelp: CommandHelp = {
   name: "workflow",
   category: "ai",
-  description: "Run a workflow from the app/workflows directory",
+  description: "Run a workflow from the workflows directory",
   usage: "veryfront workflow run <id> [options]",
   options: [
     {

--- a/cli/commands/workflow/command.ts
+++ b/cli/commands/workflow/command.ts
@@ -104,7 +104,7 @@ export async function workflowCommand(options: WorkflowOptions): Promise<void> {
       ? `branch ${proxyContext.branchRef}`
       : proxyContext
       ? "main"
-      : `${Deno.cwd()}/app/workflows/...`;
+      : `${Deno.cwd()}/workflows/...`;
 
     cliLogger.info(`Discovering workflows in ${sourceLabel}`);
 
@@ -130,7 +130,7 @@ export async function workflowCommand(options: WorkflowOptions): Promise<void> {
           cliLogger.info(`  - ${candidate.id}`);
         }
       } else {
-        cliLogger.info("No workflows found. Create a workflow file in app/workflows/.");
+        cliLogger.info("No workflows found. Create a workflow file in workflows/.");
       }
       exitProcess(1);
       return;

--- a/src/workflow/discovery/workflow-discovery.test.ts
+++ b/src/workflow/discovery/workflow-discovery.test.ts
@@ -113,7 +113,7 @@ describe(
 
     it("discovers workflow DSL exports through the discovery module loader", async () => {
       const adapter = createRuntimeAdapter({
-        "/project/app/workflows/ping.ts": [
+        "/project/workflows/ping.ts": [
           'import { workflow } from "veryfront/workflow";',
           "export default workflow({",
           '  id: "ping",',
@@ -136,7 +136,7 @@ describe(
 
     it("finds workflows by id through the discovery module loader", async () => {
       const adapter = createRuntimeAdapter({
-        "/project/app/workflows/ping.ts": [
+        "/project/workflows/ping.ts": [
           'import { workflow } from "veryfront/workflow";',
           "export const pingWorkflow = workflow({",
           '  id: "ping",',
@@ -153,6 +153,27 @@ describe(
 
       assertEquals(workflow?.id, "ping");
       assertEquals(workflow?.exportName, "pingWorkflow");
+    });
+
+    it("does not discover legacy app/workflows files by default", async () => {
+      const adapter = createRuntimeAdapter({
+        "/project/app/workflows/legacy-ping.ts": [
+          'import { workflow } from "veryfront/workflow";',
+          "export default workflow({",
+          '  id: "legacy-ping",',
+          "  steps: [],",
+          "});",
+        ].join("\n"),
+      });
+
+      const result = await discoverWorkflows({
+        projectDir: "/project",
+        adapter,
+        config: { fs: { type: "veryfront-api" } } as never,
+      });
+
+      assertEquals(result.errors, []);
+      assertEquals(result.workflows, []);
     });
   },
 );

--- a/src/workflow/discovery/workflow-discovery.ts
+++ b/src/workflow/discovery/workflow-discovery.ts
@@ -5,8 +5,8 @@
  * Uses the same patterns as API route discovery.
  *
  * Scans:
- * - app/workflows/*.ts - workflow definition files
- * - app/workflows/**\/*.ts - nested workflow files
+ * - workflows/*.ts - workflow definition files
+ * - workflows/**\/*.ts - nested workflow files
  *
  * Workflow files should export a workflow definition:
  * ```typescript
@@ -62,7 +62,7 @@ export interface WorkflowDiscoveryOptions {
   /** Veryfront config (for import maps, etc.) */
   config?: VeryfrontConfig;
 
-  /** Base directory for workflows (default: "app/workflows") */
+  /** Base directory for workflows (default: "workflows") */
   workflowsDir?: string;
 
   /** Enable debug logging */
@@ -125,7 +125,7 @@ export async function discoverWorkflows(
     projectDir,
     adapter,
     config,
-    workflowsDir = "app/workflows",
+    workflowsDir = "workflows",
     debug = false,
   } = options;
 


### PR DESCRIPTION
## Summary
- switch framework workflow discovery defaults from `app/workflows` to `workflows`
- update CLI messaging and help text to reference `workflows/` only
- add regression coverage that legacy `app/workflows/*` is not discovered by default

## Verification
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --parallel --unstable-worker-options --unstable-net src/workflow/discovery/workflow-discovery.test.ts`
- `deno fmt --check src/workflow/discovery/workflow-discovery.ts src/workflow/discovery/workflow-discovery.test.ts cli/commands/workflow/command.ts cli/commands/workflow/command-help.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/workflow/discovery/workflow-discovery.ts src/workflow/discovery/workflow-discovery.test.ts cli/commands/workflow/command.ts cli/commands/workflow/command-help.ts`
- `deno task typecheck`

## Migration impact
Projects should treat `workflows/*` as the only supported default workflow directory. Legacy `app/workflows/*` files need to be moved rather than relying on dual-directory discovery.

## Notes
`deno task verify:quick` remains blocked in this checkout by a pre-existing formatting issue in `cli/commands/knowledge/command.test.ts`.
