### PR TITLE
Align AG-UI startup framing and lock a canonical trace

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.150",
+  "version": "0.1.151",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/ag-ui-handler.test.ts
+++ b/src/agent/ag-ui-handler.test.ts
@@ -159,6 +159,10 @@ describe("agent/ag-ui-handler", () => {
 
     const body = await response.text();
     assertStringIncludes(body, "event: RunStarted");
+    assertStringIncludes(body, "event: StateSnapshot");
+    assertStringIncludes(body, 'data: {"snapshot":{}');
+    assertStringIncludes(body, "event: MessagesSnapshot");
+    assertStringIncludes(body, '"messages":[{"id":"msg-1","role":"user"');
     assertStringIncludes(body, "event: TextMessageStart");
     assertStringIncludes(body, "event: TextMessageContent");
     assertStringIncludes(body, "event: TextMessageEnd");

--- a/src/agent/ag-ui-handler.ts
+++ b/src/agent/ag-ui-handler.ts
@@ -287,6 +287,12 @@ async function createAgUiStreamResponse(
       if (!enqueueEvent(controller, "RunStarted", { runId, threadId, agentId: agent.id })) {
         return;
       }
+      if (!enqueueEvent(controller, "StateSnapshot", { snapshot: {} })) {
+        return;
+      }
+      if (!enqueueEvent(controller, "MessagesSnapshot", { messages: request.messages })) {
+        return;
+      }
 
       try {
         if (!upstreamBody) {

--- a/src/internal-agents/ag-ui-sse.test.ts
+++ b/src/internal-agents/ag-ui-sse.test.ts
@@ -9,6 +9,11 @@ import {
 } from "./ag-ui-sse.ts";
 
 describe("internal-agents/ag-ui-sse", () => {
+  const CANONICAL_TOOL_CALL_ID = "tool-call-1";
+  const CANONICAL_TOOL_NAME = "web_search";
+  const CANONICAL_TOOL_ARGS = '{"query":"Veryfront"}';
+  const CANONICAL_TOOL_RESULT = { ok: true, result: "Veryfront search result" };
+
   it("parses complete SSE data frames and preserves incomplete remainder", () => {
     const parsed = parseSseJsonEvents(
       'data: {"type":"text-delta","id":"text-1","delta":"hello"}\n\n' +
@@ -232,5 +237,101 @@ describe("internal-agents/ag-ui-sse", () => {
       new TextDecoder().decode(payload),
       'event: RunStarted\ndata: {"runId":"run_1","threadId":"thread-1","agentId":"assistant-1"}\n\n',
     );
+  });
+
+  it("matches the canonical assistant text and tool trace used across repos", () => {
+    const state = createStreamTransformState();
+
+    const mappedEvents = [
+      { type: "message-start", messageId: "assistant-msg-1" },
+      { type: "text-start", id: "text-1" },
+      { type: "text-delta", id: "text-1", delta: "Let me check." },
+      { type: "text-end", id: "text-1" },
+      {
+        type: "tool-input-start",
+        toolCallId: CANONICAL_TOOL_CALL_ID,
+        toolName: CANONICAL_TOOL_NAME,
+      },
+      {
+        type: "tool-input-delta",
+        toolCallId: CANONICAL_TOOL_CALL_ID,
+        inputTextDelta: CANONICAL_TOOL_ARGS,
+      },
+      {
+        type: "tool-input-available",
+        toolCallId: CANONICAL_TOOL_CALL_ID,
+      },
+      {
+        type: "tool-output-available",
+        toolCallId: CANONICAL_TOOL_CALL_ID,
+        output: CANONICAL_TOOL_RESULT,
+      },
+    ].flatMap((event) => mapRuntimeEventToAgUi(state, event));
+
+    const finalizedEvents = finalizeRunEvents(state, {
+      text: "Let me check.",
+      messages: [],
+      toolCalls: [],
+      status: "completed",
+      usage: {
+        promptTokens: 3,
+        completionTokens: 5,
+        totalTokens: 8,
+      },
+      metadata: {
+        finishReason: "stop",
+      },
+    });
+
+    assertEquals([...mappedEvents, ...finalizedEvents], [
+      {
+        event: "TextMessageStart",
+        payload: { messageId: "assistant-msg-1", role: "assistant" },
+      },
+      {
+        event: "TextMessageContent",
+        payload: { messageId: "assistant-msg-1", delta: "Let me check." },
+      },
+      {
+        event: "TextMessageEnd",
+        payload: { messageId: "assistant-msg-1" },
+      },
+      {
+        event: "ToolCallStart",
+        payload: {
+          toolCallId: CANONICAL_TOOL_CALL_ID,
+          toolCallName: CANONICAL_TOOL_NAME,
+        },
+      },
+      {
+        event: "ToolCallArgs",
+        payload: {
+          toolCallId: CANONICAL_TOOL_CALL_ID,
+          delta: CANONICAL_TOOL_ARGS,
+        },
+      },
+      {
+        event: "ToolCallEnd",
+        payload: { toolCallId: CANONICAL_TOOL_CALL_ID },
+      },
+      {
+        event: "ToolCallResult",
+        payload: {
+          toolCallId: CANONICAL_TOOL_CALL_ID,
+          result: CANONICAL_TOOL_RESULT,
+        },
+      },
+      {
+        event: "RunFinished",
+        payload: {
+          metadata: {
+            inputTokens: 3,
+            outputTokens: 5,
+            totalTokens: 8,
+            finishReason: "stop",
+          },
+        },
+      },
+    ]);
   });
 });

--- a/src/internal-agents/ag-ui-sse.ts
+++ b/src/internal-agents/ag-ui-sse.ts
@@ -40,6 +40,18 @@ const agUiEventPayloadSchemas = {
     threadId: z.string().min(1),
     agentId: z.string().min(1),
   }),
+  StateSnapshot: z.object({
+    snapshot: z.record(z.string(), z.unknown()),
+  }),
+  MessagesSnapshot: z.object({
+    messages: z.array(z.object({
+      id: z.string().min(1),
+      role: z.enum(["user", "assistant", "system", "tool"]),
+      parts: z.array(z.record(z.string(), z.unknown())),
+      metadata: z.record(z.string(), z.unknown()).optional(),
+      createdAt: z.string().optional(),
+    })),
+  }),
   TextMessageStart: z.object({
     messageId: z.string().min(1),
     role: z.literal("assistant"),

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.150";
+export const VERSION = "0.1.151";


### PR DESCRIPTION
## Summary
- align the direct AG-UI handler startup sequence with the agent/API transport contract
- add one canonical assistant/tool trace regression in the AG-UI transport tests
- keep the follow-up scoped to transport parity after #919 merged

## Why
The main cleanup PR merged before these final transport-parity follow-ups landed. These changes make the direct `veryfront-code` AG-UI handler emit the same startup frames as `veryfront-agent` and `veryfront-api`, and they lock one representative assistant/tool trace at the framework transport boundary.

## Changes
- emit `StateSnapshot` and `MessagesSnapshot` from the direct AG-UI handler after `RunStarted`
- validate those two event payloads in the internal AG-UI SSE formatter
- add a canonical text/tool exchange regression to `internal-agents/ag-ui-sse.test.ts`
- tighten `agent/ag-ui-handler.test.ts` to assert the startup frames

## Verification
- `deno test --no-check --allow-all src/internal-agents/ag-ui-sse.test.ts src/agent/ag-ui-handler.test.ts`
- full `veryfront-code` pre-push gate passed on push

## Risks
- narrow transport-surface change only
- still no full multi-repo end-to-end CI lane; this is a stronger parity lock, not the final integration harness
