### PR TITLE
Expose the canonical AG-UI runtime request contract from veryfront/agent

### DIFF
--- a/docs/reference/agent-runtime-ag-ui-contract.md
+++ b/docs/reference/agent-runtime-ag-ui-contract.md
@@ -6,7 +6,7 @@ The goal is to make downstream consumers target one explicit AG-UI-aligned input
 
 ## Canonical Contract
 
-The canonical runtime contract is defined in [`src/internal-agents/schema.ts`](../../src/internal-agents/schema.ts) by [`RuntimeRunAgentInputSchema`](../../src/internal-agents/schema.ts).
+The canonical runtime contract is defined in [`src/agent/runtime-ag-ui-contract.ts`](../../src/agent/runtime-ag-ui-contract.ts) by [`AgUiRuntimeRequestSchema`](../../src/agent/runtime-ag-ui-contract.ts).
 
 It is based on the AG-UI `RunAgentInput` shape:
 
@@ -85,7 +85,7 @@ Current internal compatibility route:
 
 Downstream package/framework consumers should target:
 
-- the canonical `RuntimeRunAgentInputSchema`
+- the canonical `AgUiRuntimeRequestSchema`
 - AG-UI SSE responses
 - the default endpoint convention `/api/ag-ui` unless a host explicitly documents another route
 

--- a/docs/reference/agent-runtime-ag-ui.md
+++ b/docs/reference/agent-runtime-ag-ui.md
@@ -11,7 +11,7 @@ agent runtimes.
 
 ## Contract
 
-- request body: validated by `AgUiRequestSchema`
+- canonical hosted runtime request contract: `AgUiRuntimeRequestSchema`
 - response body: AG-UI SSE
 - default endpoint convention: `/api/ag-ui`
 - host path: overrideable by the application
@@ -20,7 +20,8 @@ The package defines the runtime contract. The host chooses where to mount it.
 
 ## Package API
 
-Use `createAgUiHandler()`:
+Use `createAgUiHandler()` as a convenience wrapper when you want a direct
+route handler:
 
 ```ts
 import { agent, createAgUiHandler } from "veryfront/agent";
@@ -34,7 +35,10 @@ export const POST = createAgUiHandler({
 });
 ```
 
-## Request Shape
+`createAgUiHandler()` validates the higher-level `AgUiRequestSchema` convenience
+shape and normalizes it into the canonical hosted runtime contract.
+
+## Convenience Request Shape
 
 `AgUiRequestSchema` accepts:
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -227,9 +227,10 @@ is `/api/ag-ui`, but the host application owns the actual path.
 
 The handler:
 
-- validates the AG-UI runtime request body
+- validates the higher-level `AgUiRequestSchema` wrapper body
 - clears server memory before each run
 - converts the package data-stream output into AG-UI SSE events
+- normalizes the wrapper request into the canonical hosted runtime contract
 - passes AG-UI request metadata into `agent.stream()` context as:
 
 ```ts
@@ -255,7 +256,7 @@ Current limitation:
 
 ### `AgUiRequestSchema`
 
-Validate AG-UI runtime requests for `createAgUiHandler()`.
+Validate the convenience wrapper request shape for `createAgUiHandler()`.
 
 ### `AgUiRuntimeRequestSchema`
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -16,6 +16,7 @@ import {
   agentAsTool,
   AgentRuntime,
   AgUiRequestSchema,
+  AgUiRuntimeRequestSchema,
   createAgUiHandler,
   createMemory,
   getAgentsAsTools,
@@ -256,6 +257,13 @@ Current limitation:
 
 Validate AG-UI runtime requests for `createAgUiHandler()`.
 
+### `AgUiRuntimeRequestSchema`
+
+Validate the canonical open-source AG-UI runtime request contract for hosted
+agent execution. This is the package-facing schema downstream runtimes should
+target; the older internal compatibility route remains a wrapper around this
+contract.
+
 ### `RunResumeSessionManager`
 
 Coordinate resumable waits for hosted agent runs without depending on any
@@ -314,6 +322,13 @@ Clear all stored messages from memory.
 | `RedisMemory`             | Redis-backed persistent memory                    |
 | `RunResumeSessionManager` | Generic wait/resume manager for hosted agent runs |
 | `SummaryMemory`           | Compresses old messages into summaries            |
+
+### Schemas
+
+| Name                       | Description                                                          |
+| -------------------------- | -------------------------------------------------------------------- |
+| `AgUiRequestSchema`        | Convenience request schema for `createAgUiHandler()`                 |
+| `AgUiRuntimeRequestSchema` | Canonical open-source AG-UI runtime request contract for hosted runs |
 
 ### Types
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -134,6 +134,16 @@ export {
 
 export { agent } from "./factory.ts";
 export {
+  type AgUiRuntimeContextItem,
+  AgUiRuntimeContextItemSchema,
+  type AgUiRuntimeInjectedTool,
+  AgUiRuntimeInjectedToolSchema,
+  type AgUiRuntimeMessage,
+  AgUiRuntimeMessageSchema,
+  type AgUiRuntimeRequest,
+  AgUiRuntimeRequestSchema,
+} from "./runtime-ag-ui-contract.ts";
+export {
   type AgUiContextItem,
   type AgUiHandlerConfigWithAgent,
   type AgUiHandlerOptions,

--- a/src/agent/runtime-ag-ui-contract.test.ts
+++ b/src/agent/runtime-ag-ui-contract.test.ts
@@ -1,0 +1,48 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { AgUiRuntimeRequestSchema } from "./index.ts";
+
+describe("agent/runtime-ag-ui-contract", () => {
+  it("exports the canonical runtime AG-UI request schema from veryfront/agent", () => {
+    const parsed = AgUiRuntimeRequestSchema.parse({
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      parentRunId: "run_parent",
+      state: { phase: "draft" },
+      messages: [
+        {
+          id: "sys_1",
+          role: "system",
+          content: "You are helpful",
+        },
+        {
+          id: "user_1",
+          role: "user",
+          content: "Hello",
+        },
+        {
+          id: "assistant_1",
+          role: "assistant",
+          content: "Working on it",
+          toolCalls: [{
+            id: "tool_1",
+            type: "function",
+            function: {
+              name: "search_docs",
+              arguments: JSON.stringify({ query: "ag-ui" }),
+            },
+          }],
+        },
+      ],
+      context: [{
+        description: "Current file",
+        value: "src/main.ts",
+      }],
+    });
+
+    assertEquals(parsed.parentRunId, "run_parent");
+    assertEquals(parsed.state, { phase: "draft" });
+    assertEquals(parsed.tools, []);
+    assertEquals(parsed.context, [{ description: "Current file", value: "src/main.ts" }]);
+  });
+});

--- a/src/agent/runtime-ag-ui-contract.ts
+++ b/src/agent/runtime-ag-ui-contract.ts
@@ -1,0 +1,144 @@
+import { z } from "zod";
+
+const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const MAX_TOOL_PARAMETERS_BYTES = 16_384;
+const MAX_CONTEXT_ITEM_BYTES = 16_384;
+const MAX_CONTEXT_TOTAL_BYTES = 65_536;
+const MAX_FORWARDED_PROPS_BYTES = 65_536;
+const MAX_RUNTIME_MESSAGES = 100;
+
+const encoder = new TextEncoder();
+
+function isWithinJsonSizeLimit(value: unknown, maxBytes: number): boolean {
+  try {
+    return encoder.encode(JSON.stringify(value)).byteLength <= maxBytes;
+  } catch {
+    return false;
+  }
+}
+
+export const AgUiRuntimeRunIdSchema = z.string().min(1).max(128).regex(AGENT_ID_PATTERN);
+
+export const AgUiRuntimeInjectedToolSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .max(128)
+    .regex(
+      /^[a-zA-Z][a-zA-Z0-9._:-]*$/,
+      "Tool names must start with a letter and use a valid client-tool format",
+    ),
+  description: z.string().max(1024).optional(),
+  parameters: z.record(z.string(), z.unknown()).optional().refine(
+    (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_TOOL_PARAMETERS_BYTES),
+    { message: "Tool parameters must be less than 16 KB" },
+  ),
+});
+
+export const AgUiRuntimeContextItemSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("text"),
+    title: z.string().max(256).optional(),
+    text: z.string().max(MAX_CONTEXT_ITEM_BYTES),
+  }),
+  z.object({
+    type: z.literal("json"),
+    title: z.string().max(256).optional(),
+    data: z.record(z.string(), z.unknown()).refine(
+      (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_ITEM_BYTES),
+      { message: "JSON context item must be less than 16 KB" },
+    ),
+  }),
+  z.object({
+    type: z.literal("resource"),
+    title: z.string().max(256).optional(),
+    uri: z.string().max(2048),
+    mimeType: z.string().max(256).optional(),
+    text: z.string().max(MAX_CONTEXT_ITEM_BYTES).optional(),
+  }),
+]);
+
+const RuntimeMessageExtensionFieldsSchema = {
+  name: z.string().max(256).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  createdAt: z.string().optional(),
+} as const;
+
+export const AgUiRuntimeToolFunctionCallSchema = z.object({
+  name: AgUiRuntimeInjectedToolSchema.shape.name,
+  arguments: z.string().max(MAX_TOOL_PARAMETERS_BYTES),
+}).strict();
+
+export const AgUiRuntimeToolCallSchema = z.object({
+  id: z.string().min(1).max(128),
+  type: z.literal("function"),
+  function: AgUiRuntimeToolFunctionCallSchema,
+}).strict();
+
+export const AgUiRuntimeSystemMessageSchema = z.object({
+  id: z.string().min(1),
+  role: z.literal("system"),
+  content: z.string(),
+  ...RuntimeMessageExtensionFieldsSchema,
+}).strict();
+
+export const AgUiRuntimeUserMessageSchema = z.object({
+  id: z.string().min(1),
+  role: z.literal("user"),
+  content: z.string(),
+  ...RuntimeMessageExtensionFieldsSchema,
+}).strict();
+
+export const AgUiRuntimeAssistantMessageSchema = z.object({
+  id: z.string().min(1),
+  role: z.literal("assistant"),
+  content: z.string().optional(),
+  toolCalls: z.array(AgUiRuntimeToolCallSchema).optional(),
+  ...RuntimeMessageExtensionFieldsSchema,
+}).strict();
+
+export const AgUiRuntimeToolMessageSchema = z.object({
+  id: z.string().min(1),
+  role: z.literal("tool"),
+  toolCallId: z.string().min(1).max(128),
+  content: z.string(),
+  error: z.string().optional(),
+  ...RuntimeMessageExtensionFieldsSchema,
+}).strict();
+
+export const AgUiRuntimeMessageSchema = z.discriminatedUnion("role", [
+  AgUiRuntimeSystemMessageSchema,
+  AgUiRuntimeUserMessageSchema,
+  AgUiRuntimeAssistantMessageSchema,
+  AgUiRuntimeToolMessageSchema,
+]);
+
+export const AgUiRuntimeContextSchema = z.union([
+  z.object({
+    description: z.string().max(1024),
+    value: z.string().max(MAX_CONTEXT_ITEM_BYTES),
+  }),
+  AgUiRuntimeContextItemSchema,
+]);
+
+export const AgUiRuntimeRequestSchema = z.object({
+  threadId: z.string().uuid(),
+  runId: AgUiRuntimeRunIdSchema,
+  parentRunId: AgUiRuntimeRunIdSchema.optional(),
+  state: z.unknown().optional(),
+  messages: z.array(AgUiRuntimeMessageSchema).max(MAX_RUNTIME_MESSAGES),
+  tools: z.array(AgUiRuntimeInjectedToolSchema).max(50).default([]),
+  context: z.array(AgUiRuntimeContextSchema).max(10).default([]).refine(
+    (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_TOTAL_BYTES),
+    { message: "context must be less than 64 KB total" },
+  ),
+  forwardedProps: z.record(z.string(), z.unknown()).optional().refine(
+    (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_FORWARDED_PROPS_BYTES),
+    { message: "forwardedProps must be less than 64 KB" },
+  ),
+});
+
+export type AgUiRuntimeInjectedTool = z.infer<typeof AgUiRuntimeInjectedToolSchema>;
+export type AgUiRuntimeContextItem = z.infer<typeof AgUiRuntimeContextItemSchema>;
+export type AgUiRuntimeMessage = z.infer<typeof AgUiRuntimeMessageSchema>;
+export type AgUiRuntimeRequest = z.infer<typeof AgUiRuntimeRequestSchema>;

--- a/src/internal-agents/schema.test.ts
+++ b/src/internal-agents/schema.test.ts
@@ -113,7 +113,7 @@ describe("internal-agents/schema", () => {
 
     assertEquals(parsed.parentRunId, "run_parent");
     assertEquals(parsed.state, { phase: "draft" });
-    assertEquals(parsed.messages[2].role, "assistant");
+    assertEquals(parsed.messages[2]?.role, "assistant");
     assertEquals(parsed.context, [{ description: "Current file", value: "src/main.ts" }]);
   });
 

--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -1,9 +1,17 @@
 import { z } from "zod";
+import {
+  AgUiRuntimeContextItemSchema,
+  AgUiRuntimeContextSchema,
+  AgUiRuntimeInjectedToolSchema,
+  type AgUiRuntimeMessage,
+  AgUiRuntimeMessageSchema,
+  type AgUiRuntimeRequest,
+  AgUiRuntimeRequestSchema,
+  AgUiRuntimeRunIdSchema,
+  AgUiRuntimeToolCallSchema,
+} from "#veryfront/agent/runtime-ag-ui-contract.ts";
 
 const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
-const MAX_TOOL_PARAMETERS_BYTES = 16_384;
-const MAX_CONTEXT_ITEM_BYTES = 16_384;
-const MAX_CONTEXT_TOTAL_BYTES = 65_536;
 const MAX_FORWARDED_PROPS_BYTES = 65_536;
 const MAX_TOOL_RESULT_BYTES = 65_536;
 const MAX_RUNTIME_MESSAGES = 100;
@@ -18,50 +26,9 @@ function isWithinJsonSizeLimit(value: unknown, maxBytes: number): boolean {
   }
 }
 
-export const RunIdSchema = z.string().min(1).max(128).regex(AGENT_ID_PATTERN);
+export const RunIdSchema = AgUiRuntimeRunIdSchema;
 
 export const AgentIdSchema = z.string().min(1).max(128).regex(AGENT_ID_PATTERN);
-
-export const ClientToolNameSchema = z
-  .string()
-  .min(1)
-  .max(128)
-  .regex(
-    /^[a-zA-Z][a-zA-Z0-9._:-]*$/,
-    "Tool names must start with a letter and use a valid client-tool format",
-  );
-
-export const RuntimeInjectedToolSchema = z.object({
-  name: ClientToolNameSchema,
-  description: z.string().max(1024).optional(),
-  parameters: z.record(z.string(), z.unknown()).optional().refine(
-    (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_TOOL_PARAMETERS_BYTES),
-    { message: "Tool parameters must be less than 16 KB" },
-  ),
-});
-
-export const RuntimeContextItemSchema = z.discriminatedUnion("type", [
-  z.object({
-    type: z.literal("text"),
-    title: z.string().max(256).optional(),
-    text: z.string().max(MAX_CONTEXT_ITEM_BYTES),
-  }),
-  z.object({
-    type: z.literal("json"),
-    title: z.string().max(256).optional(),
-    data: z.record(z.string(), z.unknown()).refine(
-      (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_ITEM_BYTES),
-      { message: "JSON context item must be less than 16 KB" },
-    ),
-  }),
-  z.object({
-    type: z.literal("resource"),
-    title: z.string().max(256).optional(),
-    uri: z.string().max(2048),
-    mimeType: z.string().max(256).optional(),
-    text: z.string().max(MAX_CONTEXT_ITEM_BYTES).optional(),
-  }),
-]);
 
 export const RuntimeAgentSourceContextSchema = z.discriminatedUnion("type", [
   z.object({
@@ -79,85 +46,11 @@ export const RuntimeAgentSourceContextSchema = z.discriminatedUnion("type", [
   }),
 ]);
 
-const RuntimeMessageExtensionFieldsSchema = {
-  name: z.string().max(256).optional(),
-  metadata: z.record(z.string(), z.unknown()).optional(),
-  createdAt: z.string().optional(),
-} as const;
-
-export const RuntimeToolFunctionCallSchema = z.object({
-  name: ClientToolNameSchema,
-  arguments: z.string().max(MAX_TOOL_PARAMETERS_BYTES),
-}).strict();
-
-export const RuntimeToolCallSchema = z.object({
-  id: z.string().min(1).max(128),
-  type: z.literal("function"),
-  function: RuntimeToolFunctionCallSchema,
-}).strict();
-
-export const RuntimeSystemMessageSchema = z.object({
-  id: z.string().min(1),
-  role: z.literal("system"),
-  content: z.string(),
-  ...RuntimeMessageExtensionFieldsSchema,
-}).strict();
-
-export const RuntimeUserMessageSchema = z.object({
-  id: z.string().min(1),
-  role: z.literal("user"),
-  content: z.string(),
-  ...RuntimeMessageExtensionFieldsSchema,
-}).strict();
-
-export const RuntimeAssistantMessageSchema = z.object({
-  id: z.string().min(1),
-  role: z.literal("assistant"),
-  content: z.string().optional(),
-  toolCalls: z.array(RuntimeToolCallSchema).optional(),
-  ...RuntimeMessageExtensionFieldsSchema,
-}).strict();
-
-export const RuntimeToolMessageSchema = z.object({
-  id: z.string().min(1),
-  role: z.literal("tool"),
-  toolCallId: z.string().min(1).max(128),
-  content: z.string(),
-  error: z.string().optional(),
-  ...RuntimeMessageExtensionFieldsSchema,
-}).strict();
-
-export const RuntimeMessageSchema = z.discriminatedUnion("role", [
-  RuntimeSystemMessageSchema,
-  RuntimeUserMessageSchema,
-  RuntimeAssistantMessageSchema,
-  RuntimeToolMessageSchema,
-]);
-
-export const RuntimeContextSchema = z.union([
-  z.object({
-    description: z.string().max(1024),
-    value: z.string().max(MAX_CONTEXT_ITEM_BYTES),
-  }),
-  RuntimeContextItemSchema,
-]);
-
-export const RuntimeRunAgentInputSchema = z.object({
-  threadId: z.string().uuid(),
-  runId: RunIdSchema,
-  parentRunId: RunIdSchema.optional(),
-  state: z.unknown().optional(),
-  messages: z.array(RuntimeMessageSchema).max(MAX_RUNTIME_MESSAGES),
-  tools: z.array(RuntimeInjectedToolSchema).max(50).default([]),
-  context: z.array(RuntimeContextSchema).max(10).default([]).refine(
-    (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_TOTAL_BYTES),
-    { message: "context must be less than 64 KB total" },
-  ),
-  forwardedProps: z.record(z.string(), z.unknown()).optional().refine(
-    (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_FORWARDED_PROPS_BYTES),
-    { message: "forwardedProps must be less than 64 KB" },
-  ),
-});
+export const RuntimeInjectedToolSchema = AgUiRuntimeInjectedToolSchema;
+export const RuntimeContextItemSchema = AgUiRuntimeContextItemSchema;
+export const RuntimeMessageSchema = AgUiRuntimeMessageSchema;
+export const RuntimeContextSchema = AgUiRuntimeContextSchema;
+export const RuntimeRunAgentInputSchema = AgUiRuntimeRequestSchema;
 
 export const InternalAgentCompatibilityMessageSchema = z.object({
   id: z.string().min(1),
@@ -178,7 +71,7 @@ export const InternalAgentStreamRequestSchema = z.object({
   ),
   tools: z.array(RuntimeInjectedToolSchema).max(50).default([]),
   context: z.array(RuntimeContextSchema).max(10).default([]).refine(
-    (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_TOTAL_BYTES),
+    (value) => isWithinJsonSizeLimit(value, 65_536),
     { message: "context must be less than 64 KB total" },
   ),
   agentSource: RuntimeAgentSourceContextSchema.optional(),
@@ -188,7 +81,7 @@ export const InternalAgentStreamRequestSchema = z.object({
   ),
 });
 
-type RuntimeMessage = z.infer<typeof RuntimeMessageSchema>;
+type RuntimeMessage = AgUiRuntimeMessage;
 type InternalAgentCompatibilityMessage = z.infer<typeof InternalAgentCompatibilityMessageSchema>;
 
 function extractToolArgs(
@@ -243,7 +136,7 @@ function isCanonicalToolCallPart(part: Record<string, unknown>): boolean {
 
 function getToolCallShape(
   part: Record<string, unknown>,
-): z.infer<typeof RuntimeToolCallSchema> | null {
+): z.infer<typeof AgUiRuntimeToolCallSchema> | null {
   const id = getPartString(part, "toolCallId", "tool_call_id", "id");
   const name = getPartString(part, "toolName", "tool_name", "name");
 
@@ -357,7 +250,7 @@ function toRuntimeMessage(
 
 export function toRuntimeRunAgentInput(
   input: z.infer<typeof InternalAgentStreamRequestSchema>,
-): z.infer<typeof RuntimeRunAgentInputSchema> {
+): AgUiRuntimeRequest {
   return {
     threadId: input.threadId,
     runId: input.runId,
@@ -385,6 +278,6 @@ export const ResumeSignalSchema = z.discriminatedUnion("type", [
 export type RuntimeInjectedTool = z.infer<typeof RuntimeInjectedToolSchema>;
 export type RuntimeContextItem = z.infer<typeof RuntimeContextItemSchema>;
 export type RuntimeAgentSourceContext = z.infer<typeof RuntimeAgentSourceContextSchema>;
-export type RuntimeRunAgentInput = z.infer<typeof RuntimeRunAgentInputSchema>;
+export type RuntimeRunAgentInput = AgUiRuntimeRequest;
 export type InternalAgentStreamRequest = z.infer<typeof InternalAgentStreamRequestSchema>;
 export type ResumeSignal = z.infer<typeof ResumeSignalSchema>;


### PR DESCRIPTION
## Summary
- add a first-class public AG-UI runtime contract module under `veryfront/agent`
- move the canonical hosted runtime request schema onto that public surface with open-source-facing names
- keep `/internal/agents/stream` framed as a compatibility wrapper around the public contract

## Why
Downstream runtimes should not have to import `internal-agents/*` files or internal names just to target the hosted agent runtime contract.

## Changes
- add `src/agent/runtime-ag-ui-contract.ts`
- export `AgUiRuntimeRequestSchema` and related types/schemas from `veryfront/agent`
- switch `src/internal-agents/schema.ts` to consume the public contract module instead of owning the canonical schema
- add a public regression test covering the exported runtime schema
- update the public docs to point consumers at the public contract rather than the internal schema path

## Verification
- `deno test --allow-all src/agent/runtime-ag-ui-contract.test.ts src/internal-agents/schema.test.ts src/agent/ag-ui-handler.test.ts`
- `deno lint src/agent/runtime-ag-ui-contract.ts src/agent/runtime-ag-ui-contract.test.ts src/agent/index.ts src/internal-agents/schema.ts src/internal-agents/schema.test.ts`
- `deno check src/agent/runtime-ag-ui-contract.ts src/agent/runtime-ag-ui-contract.test.ts src/agent/index.ts src/internal-agents/schema.ts src/internal-agents/schema.test.ts src/agent/ag-ui-handler.test.ts`
- `deno task verify`

## Related
- veryfront-agent#172
- supersedes the need for downstreams to target the internal contract path documented in veryfront-code#898