### PR TITLE
Harden provider stream parsing for CRLF-framed SSE

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.151",
+  "version": "0.1.152",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -234,6 +234,56 @@ describe("provider/runtime-loader", () => {
     ]);
   });
 
+  it("parses OpenAI-compatible SSE streams when events use CRLF delimiters", async () => {
+    const encoder = new TextEncoder();
+    const runtime = createOpenAIModelRuntime({
+      apiKey: "test-openai-key",
+      baseURL: "https://example.openai.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            ReadableStream.from([
+              encoder.encode(
+                'data: {"choices":[{"delta":{"content":"Hello"}}]}\r\n\r\n',
+              ),
+              encoder.encode(
+                'data: {"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":8,"completion_tokens":2,"total_tokens":10}}\r\n\r\n',
+              ),
+              encoder.encode("data: [DONE]\r\n\r\n"),
+            ]),
+            {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            },
+          ),
+        ),
+    }, "gpt-4o-mini");
+
+    const result = await runtime.doStream({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Say hello" }],
+      }],
+    });
+
+    const parts = await collectAsync(result.stream);
+    assertEquals(parts, [
+      {
+        type: "text-delta",
+        delta: "Hello",
+      },
+      {
+        type: "finish",
+        finishReason: "stop",
+        usage: {
+          inputTokens: 8,
+          outputTokens: 2,
+          totalTokens: 10,
+        },
+      },
+    ]);
+  });
+
   it("keeps OpenAI providerOptions scoped to the active provider and alias", async () => {
     let requestedInit: RequestInit | undefined;
 
@@ -501,6 +551,62 @@ describe("provider/runtime-loader", () => {
           encryptedContent: "opaque",
         }],
         providerExecuted: true,
+      },
+      {
+        type: "finish",
+        finishReason: { unified: "stop", raw: "end_turn" },
+        usage: {
+          inputTokens: 8,
+          outputTokens: 5,
+          totalTokens: 13,
+        },
+      },
+    ]);
+  });
+
+  it("parses Anthropic-compatible SSE streams when events use CRLF delimiters", async () => {
+    const encoder = new TextEncoder();
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            ReadableStream.from([
+              encoder.encode(
+                'event: message_start\r\ndata: {"type":"message_start","message":{"usage":{"input_tokens":8}}}\r\n\r\n',
+              ),
+              encoder.encode(
+                'event: content_block_delta\r\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\r\n\r\n',
+              ),
+              encoder.encode(
+                'event: message_delta\r\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}\r\n\r\n',
+              ),
+              encoder.encode(
+                'event: message_stop\r\ndata: {"type":"message_stop"}\r\n\r\n',
+              ),
+            ]),
+            {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            },
+          ),
+        ),
+    }, "claude-sonnet-4-20250514");
+
+    const result = await runtime.doStream({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Say hello" }],
+      }],
+      maxOutputTokens: 64,
+    });
+
+    const parts = await collectAsync(result.stream);
+    assertEquals(parts, [
+      {
+        type: "text-delta",
+        delta: "Hello",
       },
       {
         type: "finish",

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -731,14 +731,14 @@ function buildAnthropicGenerateResult(payload: unknown): {
   };
 }
 
-function parseAnthropicSseChunk(chunk: string): {
+function parseSseChunk(chunk: string): {
   events: Array<unknown | "[DONE]">;
   remainder: string;
 } {
-  const blocks = chunk.split("\n\n");
+  const blocks = chunk.split(/\r?\n\r?\n/);
   const remainder = blocks.pop() ?? "";
   const events = blocks.flatMap((block) => {
-    const dataLines = block.split("\n")
+    const dataLines = block.split(/\r?\n/)
       .filter((line) => line.startsWith("data:"))
       .map((line) => line.slice(5).trimStart());
 
@@ -772,7 +772,7 @@ async function* streamAnthropicCompatibleParts(
 
   for await (const chunk of stream) {
     buffer += decoder.decode(chunk, { stream: true });
-    const parsed = parseAnthropicSseChunk(buffer);
+    const parsed = parseSseChunk(buffer);
     buffer = parsed.remainder;
 
     for (const event of parsed.events) {
@@ -911,7 +911,7 @@ async function* streamAnthropicCompatibleParts(
   }
 
   if (buffer.trim().length > 0) {
-    const parsed = parseAnthropicSseChunk(`${buffer}\n\n`);
+    const parsed = parseSseChunk(`${buffer}\n\n`);
     for (const event of parsed.events) {
       if (event === "[DONE]") {
         continue;
@@ -1312,7 +1312,7 @@ async function* streamGoogleCompatibleParts(
 
   for await (const chunk of stream) {
     buffer += decoder.decode(chunk, { stream: true });
-    const parsed = parseOpenAISseChunk(buffer);
+    const parsed = parseSseChunk(buffer);
     buffer = parsed.remainder;
 
     for (const event of parsed.events) {
@@ -1366,7 +1366,7 @@ async function* streamGoogleCompatibleParts(
   }
 
   if (buffer.trim().length > 0) {
-    const parsed = parseOpenAISseChunk(`${buffer}\n\n`);
+    const parsed = parseSseChunk(`${buffer}\n\n`);
     for (const event of parsed.events) {
       if (event === "[DONE]") {
         continue;
@@ -1429,36 +1429,6 @@ function buildOpenAIGenerateResult(payload: unknown): {
   };
 }
 
-function parseOpenAISseChunk(chunk: string): {
-  events: Array<unknown | "[DONE]">;
-  remainder: string;
-} {
-  const blocks = chunk.split("\n\n");
-  const remainder = blocks.pop() ?? "";
-  const events = blocks.flatMap((block) => {
-    const dataLines = block.split("\n")
-      .filter((line) => line.startsWith("data:"))
-      .map((line) => line.slice(5).trimStart());
-
-    if (!dataLines.length) {
-      return [];
-    }
-
-    const payload = dataLines.join("\n").trim();
-    if (payload === "[DONE]") {
-      return ["[DONE]" as const];
-    }
-
-    try {
-      return [JSON.parse(payload) as unknown];
-    } catch {
-      return [];
-    }
-  });
-
-  return { events, remainder };
-}
-
 async function* streamOpenAICompatibleParts(
   stream: ReadableStream<Uint8Array>,
 ): AsyncIterable<unknown> {
@@ -1470,7 +1440,7 @@ async function* streamOpenAICompatibleParts(
 
   for await (const chunk of stream) {
     buffer += decoder.decode(chunk, { stream: true });
-    const parsed = parseOpenAISseChunk(buffer);
+    const parsed = parseSseChunk(buffer);
     buffer = parsed.remainder;
 
     for (const event of parsed.events) {
@@ -1544,7 +1514,7 @@ async function* streamOpenAICompatibleParts(
   }
 
   if (buffer.trim().length > 0) {
-    const parsed = parseOpenAISseChunk(`${buffer}\n\n`);
+    const parsed = parseSseChunk(`${buffer}\n\n`);
     for (const event of parsed.events) {
       if (event === "[DONE]") {
         continue;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.151";
+export const VERSION = "0.1.152";


### PR DESCRIPTION
## Summary
- add regression coverage for CRLF-delimited SSE provider streams
- replace duplicated provider SSE chunk parsers with a shared helper
- bump the release version to `0.1.152`

## Why
Some providers emit server-sent events with `\r\n` delimiters. This PR keeps stream behavior stable while hardening parsing across OpenAI-, Anthropic-, and Google-compatible runtimes.

## TDD
- RED: verified the new CRLF stream tests fail in an isolated test-only worktree
- GREEN: updated runtime parsing to pass the new coverage
- REFACTOR: consolidated duplicated SSE parsing into `parseSseChunk()`

## Verification
- pre-push checks: 1322 passed / 0 failed
- `deno test --no-check --allow-all src/provider/runtime-loader.test.ts src/utils/version.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts src/provider/runtime-loader.ts src/provider/runtime-loader.test.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/provider/runtime-loader.ts src/provider/runtime-loader.test.ts src/utils/version-constant.ts`
- `deno task typecheck`
- `deno task verify:quick`
