### PR TITLE
Deduplicate shared agent runtime error helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.152",
+  "version": "0.1.153",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -15,6 +15,7 @@ import { serverLogger } from "#veryfront/utils";
 import { isAnyDebugEnabled } from "#veryfront/utils/constants/env.ts";
 import { setActiveSpanAttributes, withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
+import { stringifyToolError, throwIfAborted } from "./error-utils.ts";
 
 const logger = serverLogger.component("agent");
 
@@ -82,39 +83,6 @@ function normalizeToolInputObject(input: unknown): Record<string, unknown> {
   }
 
   return {};
-}
-
-function createAbortError(reason?: unknown): Error {
-  if (reason instanceof Error) {
-    return reason;
-  }
-
-  return new DOMException(
-    typeof reason === "string" && reason.length > 0 ? reason : "The operation was aborted",
-    "AbortError",
-  );
-}
-
-function throwIfAborted(abortSignal?: AbortSignal): void {
-  if (abortSignal?.aborted) {
-    throw createAbortError(abortSignal.reason);
-  }
-}
-
-function stringifyToolError(output: unknown): string {
-  if (typeof output === "string" && output.length > 0) {
-    return output;
-  }
-
-  if (output instanceof Error && typeof output.message === "string" && output.message.length > 0) {
-    return output.message;
-  }
-
-  try {
-    return JSON.stringify(output);
-  } catch {
-    return String(output);
-  }
 }
 
 function summarizeDebugValue(value: unknown): unknown {

--- a/src/agent/runtime/error-utils.test.ts
+++ b/src/agent/runtime/error-utils.test.ts
@@ -1,0 +1,68 @@
+import { assertEquals, assertStrictEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createAbortError, stringifyToolError, throwIfAborted } from "./error-utils.ts";
+
+describe("agent/runtime/error-utils", () => {
+  describe("createAbortError", () => {
+    it("returns the original Error instance when the reason is already an Error", () => {
+      const reason = new Error("boom");
+      assertStrictEquals(createAbortError(reason), reason);
+    });
+
+    it("creates an AbortError DOMException from a string reason", () => {
+      const error = createAbortError("stop now");
+      assertEquals(error instanceof DOMException, true);
+      assertEquals(error.name, "AbortError");
+      assertEquals(error.message, "stop now");
+    });
+
+    it("uses a default abort message when the reason is empty", () => {
+      const error = createAbortError();
+      assertEquals(error instanceof DOMException, true);
+      assertEquals(error.name, "AbortError");
+      assertEquals(error.message, "The operation was aborted");
+    });
+  });
+
+  describe("throwIfAborted", () => {
+    it("does nothing when the signal is not aborted", () => {
+      const controller = new AbortController();
+      assertEquals(throwIfAborted(controller.signal), undefined);
+    });
+
+    it("throws an AbortError when the signal has been aborted", () => {
+      const controller = new AbortController();
+      controller.abort("cancelled");
+
+      assertThrows(
+        () => throwIfAborted(controller.signal),
+        DOMException,
+        "cancelled",
+      );
+    });
+  });
+
+  describe("stringifyToolError", () => {
+    it("returns non-empty strings unchanged", () => {
+      assertEquals(stringifyToolError("tool failed"), "tool failed");
+    });
+
+    it("returns an Error message when available", () => {
+      assertEquals(stringifyToolError(new Error("tool exploded")), "tool exploded");
+    });
+
+    it("stringifies structured values as JSON", () => {
+      assertEquals(
+        stringifyToolError({ code: "E_TOOL", retryable: true }),
+        '{"code":"E_TOOL","retryable":true}',
+      );
+    });
+
+    it("falls back to String() when JSON serialization fails", () => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+
+      assertEquals(stringifyToolError(circular), "[object Object]");
+    });
+  });
+});

--- a/src/agent/runtime/error-utils.ts
+++ b/src/agent/runtime/error-utils.ts
@@ -1,0 +1,32 @@
+export function createAbortError(reason?: unknown): Error {
+  if (reason instanceof Error) {
+    return reason;
+  }
+
+  return new DOMException(
+    typeof reason === "string" && reason.length > 0 ? reason : "The operation was aborted",
+    "AbortError",
+  );
+}
+
+export function throwIfAborted(abortSignal?: AbortSignal): void {
+  if (abortSignal?.aborted) {
+    throw createAbortError(abortSignal.reason);
+  }
+}
+
+export function stringifyToolError(error: unknown): string {
+  if (typeof error === "string" && error.length > 0) {
+    return error;
+  }
+
+  if (error instanceof Error && typeof error.message === "string" && error.message.length > 0) {
+    return error.message;
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -100,6 +100,7 @@ import {
 } from "#veryfront/skill/allowed-tools.ts";
 import { resolveConfiguredAgentModel, resolveRuntimeModel } from "./model-resolution.ts";
 import type { RuntimeGenerateToolResult } from "./runtime-tool-types.ts";
+import { stringifyToolError, throwIfAborted } from "./error-utils.ts";
 
 const logger = serverLogger.component("agent");
 const LOAD_SKILL_TOOL_ID = "load-skill";
@@ -108,45 +109,12 @@ type RuntimeToolFilterConfig = AgentConfig & {
   __vfAllowedRemoteTools?: string[];
 };
 
-function createAbortError(reason?: unknown): Error {
-  if (reason instanceof Error) {
-    return reason;
-  }
-
-  return new DOMException(
-    typeof reason === "string" && reason.length > 0 ? reason : "The operation was aborted",
-    "AbortError",
-  );
-}
-
-function throwIfAborted(abortSignal?: AbortSignal): void {
-  if (abortSignal?.aborted) {
-    throw createAbortError(abortSignal.reason);
-  }
-}
-
 function isAbortError(error: unknown, abortSignal?: AbortSignal): boolean {
   if (abortSignal?.aborted && error === abortSignal.reason) {
     return true;
   }
 
   return error instanceof DOMException && error.name === "AbortError";
-}
-
-function stringifyToolError(error: unknown): string {
-  if (typeof error === "string" && error.length > 0) {
-    return error;
-  }
-
-  if (error instanceof Error && typeof error.message === "string" && error.message.length > 0) {
-    return error.message;
-  }
-
-  try {
-    return JSON.stringify(error);
-  } catch {
-    return String(error);
-  }
 }
 
 function getToolResultError(result: unknown): string | undefined {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.152";
+export const VERSION = "0.1.153";


### PR DESCRIPTION
## Summary
- extract shared abort and tool-error formatting helpers for agent runtime paths
- lock the shared behavior with focused runtime helper tests
- bump the release version to `0.1.153`

## Why
The core agent runtime and the chat stream handler carried identical abort/error helper logic. This PR removes the duplication while keeping the runtime behavior locked with tests so the two paths cannot drift.

## TDD
- RED: added helper tests against a missing shared module and confirmed they failed
- GREEN: implemented the shared helper module and wired both runtime paths to it
- REFACTOR: removed the duplicated inline helpers from both files

## Verification
- pre-push checks: 1324 passed / 0 failed
- `deno test --no-check --allow-all src/agent/runtime/error-utils.test.ts src/agent/runtime/index.test.ts src/agent/runtime/chat-stream-handler.test.ts src/utils/version.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts src/agent/runtime/error-utils.ts src/agent/runtime/error-utils.test.ts src/agent/runtime/index.ts src/agent/runtime/chat-stream-handler.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/utils/version-constant.ts src/agent/runtime/error-utils.ts src/agent/runtime/error-utils.test.ts src/agent/runtime/index.ts src/agent/runtime/chat-stream-handler.ts`
- `deno task typecheck`
- `deno task verify:quick`
