### PR TITLE
Expose public hosted AG-UI run control handlers

### DIFF
--- a/docs/reference/agent-runtime-ag-ui-contract.md
+++ b/docs/reference/agent-runtime-ag-ui-contract.md
@@ -74,12 +74,23 @@ The package should standardize the runtime contract, not force one hardcoded rou
 Recommended default convention:
 
 - `POST /api/ag-ui`
+- `POST /api/ag-ui/runs/:runId/resume`
+- `DELETE /api/ag-ui/runs/:runId`
 
 Hosts may override the route when needed.
 
 Current internal compatibility route:
 
 - `POST /internal/agents/stream`
+
+Current internal signed control-plane wrappers:
+
+- `POST /internal/agents/runs/:runId/resume`
+- `DELETE /internal/agents/runs/:runId`
+
+Those internal handlers are Veryfront-specific wrappers around the generic
+package-hosted run-control surface. Downstream package consumers should target
+the public `veryfront/agent` handlers instead of these internal routes.
 
 ## What Downstream Consumers Should Target
 

--- a/docs/reference/agent-runtime-ag-ui.md
+++ b/docs/reference/agent-runtime-ag-ui.md
@@ -14,6 +14,8 @@ agent runtimes.
 - canonical hosted runtime request contract: `AgUiRuntimeRequestSchema`
 - response body: AG-UI SSE
 - default endpoint convention: `/api/ag-ui`
+- default hosted resume endpoint: `POST /api/ag-ui/runs/:runId/resume`
+- default hosted cancel endpoint: `DELETE /api/ag-ui/runs/:runId`
 - host path: overrideable by the application
 
 The package defines the runtime contract. The host chooses where to mount it.
@@ -37,6 +39,12 @@ export const POST = createAgUiHandler({
 
 `createAgUiHandler()` validates the higher-level `AgUiRequestSchema` convenience
 shape and normalizes it into the canonical hosted runtime contract.
+
+For resumable hosted runs, the package also exposes:
+
+- `createAgUiResumeHandler()`
+- `createAgUiCancelHandler()`
+- `AgUiResumeSignalSchema`
 
 ## Convenience Request Shape
 
@@ -65,6 +73,30 @@ The handler forwards AG-UI metadata into `agent.stream()` context as:
   }
 }
 ```
+
+## Hosted Run Control
+
+Package-hosted resumable runs can expose generic control endpoints using the
+same `RunResumeSessionManager` that the runtime uses internally:
+
+```ts
+import {
+  createAgUiCancelHandler,
+  createAgUiResumeHandler,
+  RunResumeSessionManager,
+} from "veryfront/agent";
+
+const sessionManager = new RunResumeSessionManager<{
+  result: unknown;
+  isError: boolean;
+}>();
+
+export const POST = createAgUiResumeHandler({ sessionManager });
+export const DELETE = createAgUiCancelHandler({ sessionManager });
+```
+
+These handlers are generic package surfaces. They do not include Veryfront
+control-plane auth/signature requirements.
 
 ## Current Limitation
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -16,8 +16,11 @@ import {
   agentAsTool,
   AgentRuntime,
   AgUiRequestSchema,
+  AgUiResumeSignalSchema,
   AgUiRuntimeRequestSchema,
+  createAgUiCancelHandler,
   createAgUiHandler,
+  createAgUiResumeHandler,
   createMemory,
   getAgentsAsTools,
   registerAgent,
@@ -265,6 +268,27 @@ agent execution. This is the package-facing schema downstream runtimes should
 target; the older internal compatibility route remains a wrapper around this
 contract.
 
+### `AgUiResumeSignalSchema`
+
+Validate the canonical hosted-run resume payload for AG-UI tool-result
+continuations.
+
+### `createAgUiResumeHandler(options)`
+
+Create a generic POST handler for hosted resumable AG-UI runs.
+
+Default route convention:
+
+- `POST /api/ag-ui/runs/:runId/resume`
+
+### `createAgUiCancelHandler(options)`
+
+Create a generic DELETE handler for cancelling hosted resumable AG-UI runs.
+
+Default route convention:
+
+- `DELETE /api/ag-ui/runs/:runId`
+
 ### `RunResumeSessionManager`
 
 Coordinate resumable waits for hosted agent runs without depending on any
@@ -295,23 +319,25 @@ Clear all stored messages from memory.
 
 ### Functions
 
-| Name                | Description                                   |
-| ------------------- | --------------------------------------------- |
-| `agent`             | Create an agent                               |
-| `agentAsTool`       | Wrap agent as callable tool                   |
-| `createAgUiHandler` | Create a POST handler for an AG-UI route      |
-| `createChatHandler` | Create a POST handler for a chat API route.   |
-| `createMemory`      | Create memory (buffer, conversation, summary) |
-| `createRedisMemory` | Create Redis-backed memory                    |
-| `createWorkflow`    | Create sequential agent workflow              |
-| `getAgent`          | Get agent by ID                               |
-| `getAgentsAsTools`  | Get agents as tools (multi-agent)             |
-| `getAllAgentIds`    | List registered agent IDs                     |
-| `getTextFromParts`  | Extract text from multi-part message          |
-| `getToolArguments`  | Extract parsed tool call args                 |
-| `hasArgs`           | Check for parsed args on tool call            |
-| `hasInput`          | Check for raw input on tool call              |
-| `registerAgent`     | Register agent for discovery                  |
+| Name                      | Description                                               |
+| ------------------------- | --------------------------------------------------------- |
+| `agent`                   | Create an agent                                           |
+| `agentAsTool`             | Wrap agent as callable tool                               |
+| `createAgUiCancelHandler` | Create a DELETE handler for hosted AG-UI run cancellation |
+| `createAgUiHandler`       | Create a POST handler for an AG-UI route                  |
+| `createAgUiResumeHandler` | Create a POST handler for hosted AG-UI run resume values  |
+| `createChatHandler`       | Create a POST handler for a chat API route.               |
+| `createMemory`            | Create memory (buffer, conversation, summary)             |
+| `createRedisMemory`       | Create Redis-backed memory                                |
+| `createWorkflow`          | Create sequential agent workflow                          |
+| `getAgent`                | Get agent by ID                                           |
+| `getAgentsAsTools`        | Get agents as tools (multi-agent)                         |
+| `getAllAgentIds`          | List registered agent IDs                                 |
+| `getTextFromParts`        | Extract text from multi-part message                      |
+| `getToolArguments`        | Extract parsed tool call args                             |
+| `hasArgs`                 | Check for parsed args on tool call                        |
+| `hasInput`                | Check for raw input on tool call                          |
+| `registerAgent`           | Register agent for discovery                              |
 
 ### Classes
 
@@ -326,10 +352,11 @@ Clear all stored messages from memory.
 
 ### Schemas
 
-| Name                       | Description                                                          |
-| -------------------------- | -------------------------------------------------------------------- |
-| `AgUiRequestSchema`        | Convenience request schema for `createAgUiHandler()`                 |
-| `AgUiRuntimeRequestSchema` | Canonical open-source AG-UI runtime request contract for hosted runs |
+| Name                       | Description                                                            |
+| -------------------------- | ---------------------------------------------------------------------- |
+| `AgUiRequestSchema`        | Convenience request schema for `createAgUiHandler()`                   |
+| `AgUiRuntimeRequestSchema` | Canonical open-source AG-UI runtime request contract for hosted runs   |
+| `AgUiResumeSignalSchema`   | Canonical hosted-run resume payload for AG-UI tool-result continuation |
 
 ### Types
 
@@ -345,8 +372,11 @@ Clear all stored messages from memory.
 | `AgUiContextItem`                | AG-UI runtime context item                                                   |
 | `AgUiHandlerConfigWithAgent`     | Direct-agent form for `createAgUiHandler`                                    |
 | `AgUiHandlerOptions`             | Options for `createAgUiHandler`                                              |
+| `AgUiCancelHandlerOptions`       | Options for `createAgUiCancelHandler`                                        |
 | `AgUiInjectedTool`               | AG-UI client-injected tool descriptor                                        |
 | `AgUiRequest`                    | Validated AG-UI runtime request body                                         |
+| `AgUiResumeHandlerOptions`       | Options for `createAgUiResumeHandler`                                        |
+| `AgUiResumeSignal`               | Validated hosted-run resume payload                                          |
 | `RunResumeSessionManagerOptions` | Options for `RunResumeSessionManager`                                        |
 | `RunSessionStatus`               | Status of a resumable run session                                            |
 | `SubmitResumeValueOutcome`       | Result of submitting an accepted or duplicate resume value                   |

--- a/src/agent/ag-ui-run-control.test.ts
+++ b/src/agent/ag-ui-run-control.test.ts
@@ -1,0 +1,178 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  AgUiResumeSignalSchema,
+  createAgUiCancelHandler,
+  createAgUiResumeHandler,
+  RunResumeSessionManager,
+} from "./index.ts";
+
+describe("agent/ag-ui-run-control", () => {
+  it("exports the canonical public resume signal schema", () => {
+    assertEquals(
+      AgUiResumeSignalSchema.parse({
+        type: "tool_result",
+        toolCallId: "tool_1",
+        result: { ok: true },
+      }),
+      {
+        type: "tool_result",
+        toolCallId: "tool_1",
+        result: { ok: true },
+        isError: false,
+      },
+    );
+  });
+
+  it("submits a tool result through the public resume handler", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    const pending = sessionManager.waitForSignal("run_1", "tool_1");
+
+    const handler = createAgUiResumeHandler({ sessionManager });
+    const response = await handler(
+      new Request("https://example.com/api/ag-ui/runs/run_1/resume", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "tool_result",
+          toolCallId: "tool_1",
+          result: { ok: true },
+        }),
+      }),
+    );
+
+    assertEquals(response.status, 200);
+    assertEquals(await response.json(), { accepted: true });
+    assertEquals(await pending, { result: { ok: true }, isError: false });
+  });
+
+  it("cancels a waiting run through the public cancel handler", async () => {
+    const sessionManager = new RunResumeSessionManager<{ ok: boolean }>();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    void sessionManager.waitForSignal("run_1", "tool_1").catch(() => undefined);
+
+    const handler = createAgUiCancelHandler({ sessionManager });
+    const response = await handler(
+      new Request("https://example.com/api/ag-ui/runs/run_1", {
+        method: "DELETE",
+      }),
+    );
+
+    assertEquals(response.status, 202);
+    assertEquals(await response.json(), { accepted: true });
+  });
+
+  it("accepts a request wrapper and returns 410 for inactive runs", async () => {
+    const handler = createAgUiResumeHandler({
+      sessionManager: new RunResumeSessionManager<{ result: unknown; isError: boolean }>(),
+    });
+
+    const response = await handler({
+      request: new Request("https://example.com/api/ag-ui/runs/run_1/resume", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "tool_result",
+          toolCallId: "tool_1",
+          result: { ok: true },
+        }),
+      }),
+    });
+
+    assertEquals(response.status, 410);
+    assertEquals(await response.json(), { error: "RUN_NOT_ACTIVE" });
+  });
+
+  it("returns 404 when the route does not include a run id", async () => {
+    const handler = createAgUiResumeHandler({
+      sessionManager: new RunResumeSessionManager<{ result: unknown; isError: boolean }>(),
+    });
+
+    const response = await handler(
+      new Request("https://example.com/api/ag-ui/resume", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "tool_result",
+          toolCallId: "tool_1",
+          result: { ok: true },
+        }),
+      }),
+    );
+
+    assertEquals(response.status, 404);
+    assertEquals(await response.json(), { error: "Run not found" });
+  });
+
+  it("returns 400 for malformed resume payloads", async () => {
+    const handler = createAgUiResumeHandler({
+      sessionManager: new RunResumeSessionManager<{ result: unknown; isError: boolean }>(),
+    });
+
+    const response = await handler(
+      new Request("https://example.com/api/ag-ui/runs/run_1/resume", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "tool_result",
+        }),
+      }),
+    );
+
+    assertEquals(response.status, 400);
+    const payload = await response.json();
+    assertExists(payload);
+    assertEquals(payload.error, "Invalid AG-UI resume request");
+  });
+
+  it("returns 409 for conflicting duplicate tool results", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>({
+      getConflictKey: (value) => JSON.stringify(value),
+    });
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    const pending = sessionManager.waitForSignal("run_1", "tool_1");
+    sessionManager.submitSignal("run_1", {
+      waitKey: "tool_1",
+      value: { result: { ok: true }, isError: false },
+    });
+    await pending;
+
+    const handler = createAgUiResumeHandler({ sessionManager });
+    const response = await handler(
+      new Request("https://example.com/api/ag-ui/runs/run_1/resume", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "tool_result",
+          toolCallId: "tool_1",
+          result: { ok: false },
+        }),
+      }),
+    );
+
+    assertEquals(response.status, 409);
+    assertEquals(await response.json(), { error: "TOOL_RESULT_CONFLICT" });
+  });
+
+  it("returns 204 when cancelling an already inactive run", async () => {
+    const handler = createAgUiCancelHandler({
+      sessionManager: new RunResumeSessionManager<{ ok: boolean }>(),
+    });
+
+    const response = await handler(
+      new Request("https://example.com/api/ag-ui/runs/run_1", {
+        method: "DELETE",
+      }),
+    );
+
+    assertEquals(response.status, 204);
+    assertEquals(await response.text(), "");
+  });
+});

--- a/src/agent/ag-ui-run-control.ts
+++ b/src/agent/ag-ui-run-control.ts
@@ -1,0 +1,160 @@
+import { z } from "zod";
+import { INVALID_ARGUMENT } from "#veryfront/errors";
+import {
+  RunNotActiveError,
+  RunResumeSessionManager,
+  WaitConflictError,
+  WaitNotPendingError,
+} from "./runtime/resume-session.ts";
+
+const RESUME_PATH_REGEX = /^\/api\/ag-ui\/runs\/([^/]+)\/resume$/;
+const CANCEL_PATH_REGEX = /^\/api\/ag-ui\/runs\/([^/]+)$/;
+
+export const AgUiResumeSignalSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("tool_result"),
+    toolCallId: z.string().min(1).max(128),
+    result: z.unknown(),
+    isError: z.boolean().optional().default(false),
+  }),
+]);
+
+export type AgUiResumeSignal = z.infer<typeof AgUiResumeSignalSchema>;
+
+type ResumeValue = {
+  result: unknown;
+  isError: boolean;
+};
+
+function isRequest(value: unknown): value is Request {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "json" in value &&
+    typeof value.json === "function" &&
+    "url" in value &&
+    typeof value.url === "string" &&
+    "method" in value &&
+    typeof value.method === "string"
+  );
+}
+
+function extractRequest(requestOrCtx: unknown): Request {
+  if (isRequest(requestOrCtx)) return requestOrCtx;
+
+  if (typeof requestOrCtx === "object" && requestOrCtx !== null && "request" in requestOrCtx) {
+    const candidate = (requestOrCtx as Record<string, unknown>).request;
+    if (isRequest(candidate)) return candidate;
+  }
+
+  throw INVALID_ARGUMENT.create({
+    detail: "Invalid handler argument: expected Request or APIContext",
+  });
+}
+
+function getRunId(pathname: string, regex: RegExp): string | null {
+  return regex.exec(pathname)?.[1] ?? null;
+}
+
+export interface AgUiRunControlHandlerOptions {
+  resolveRunId?:
+    | ((input: { request: Request; requestOrCtx: unknown }) => string | null)
+    | ((input: { request: Request; requestOrCtx: unknown }) => Promise<string | null>);
+}
+
+export interface AgUiResumeHandlerOptions extends AgUiRunControlHandlerOptions {
+  sessionManager: RunResumeSessionManager<ResumeValue>;
+}
+
+export interface AgUiCancelHandlerOptions<T = unknown> extends AgUiRunControlHandlerOptions {
+  sessionManager: RunResumeSessionManager<T>;
+}
+
+async function resolveRunId(
+  requestOrCtx: unknown,
+  request: Request,
+  options: AgUiRunControlHandlerOptions | undefined,
+  regex: RegExp,
+): Promise<string | null> {
+  const explicit = await options?.resolveRunId?.({ request, requestOrCtx });
+  if (explicit) return explicit;
+  return getRunId(new URL(request.url).pathname, regex);
+}
+
+export function createAgUiResumeHandler(
+  options: AgUiResumeHandlerOptions,
+): (requestOrCtx: unknown) => Promise<Response> {
+  return async function POST(requestOrCtx: unknown): Promise<Response> {
+    const request = extractRequest(requestOrCtx);
+    const runId = await resolveRunId(requestOrCtx, request, options, RESUME_PATH_REGEX);
+
+    if (!runId) {
+      return Response.json({ error: "Run not found" }, { status: 404 });
+    }
+
+    try {
+      const parsed = AgUiResumeSignalSchema.parse(await request.json());
+      const outcome = options.sessionManager.submitSignal(runId, {
+        waitKey: parsed.toolCallId,
+        value: {
+          result: parsed.result,
+          isError: parsed.isError,
+        },
+      });
+
+      return Response.json(outcome, { status: 200 });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return Response.json(
+          {
+            error: "Invalid AG-UI resume request",
+            details: error.issues.map((issue) => ({
+              path: issue.path,
+              message: issue.message,
+            })),
+          },
+          { status: 400 },
+        );
+      }
+
+      if (error instanceof WaitConflictError) {
+        return Response.json({ error: "TOOL_RESULT_CONFLICT" }, { status: 409 });
+      }
+
+      if (error instanceof WaitNotPendingError) {
+        return Response.json({ error: "TOOL_RESULT_NOT_WAITING" }, { status: 409 });
+      }
+
+      if (error instanceof RunNotActiveError) {
+        return Response.json({ error: "RUN_NOT_ACTIVE" }, { status: 410 });
+      }
+
+      return Response.json(
+        {
+          error: error instanceof Error ? error.message : "Internal resume failed",
+        },
+        { status: 500 },
+      );
+    }
+  };
+}
+
+export function createAgUiCancelHandler<T = unknown>(
+  options: AgUiCancelHandlerOptions<T>,
+): (requestOrCtx: unknown) => Promise<Response> {
+  return async function DELETE(requestOrCtx: unknown): Promise<Response> {
+    const request = extractRequest(requestOrCtx);
+    const runId = await resolveRunId(requestOrCtx, request, options, CANCEL_PATH_REGEX);
+
+    if (!runId) {
+      return Response.json({ error: "Run not found" }, { status: 404 });
+    }
+
+    const accepted = options.sessionManager.cancelRun(runId);
+    if (accepted) {
+      return Response.json({ accepted: true }, { status: 202 });
+    }
+
+    return new Response(null, { status: 204 });
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -144,6 +144,14 @@ export {
   AgUiRuntimeRequestSchema,
 } from "./runtime-ag-ui-contract.ts";
 export {
+  type AgUiCancelHandlerOptions,
+  type AgUiResumeHandlerOptions,
+  type AgUiResumeSignal,
+  AgUiResumeSignalSchema,
+  createAgUiCancelHandler,
+  createAgUiResumeHandler,
+} from "./ag-ui-run-control.ts";
+export {
   type AgUiContextItem,
   type AgUiHandlerConfigWithAgent,
   type AgUiHandlerOptions,


### PR DESCRIPTION
## Summary
- expose a public AG-UI hosted-run control surface from `veryfront/agent`
- add canonical resume/cancel handlers around `RunResumeSessionManager`
- document the default hosted route conventions and the boundary from internal Veryfront control-plane wrappers

## Why
`veryfront/agent#172` needs the hosted runtime surface to stand on open-source package APIs rather than internal Veryfront-only handlers. Package consumers could already host `POST /api/ag-ui`, but resume and cancel still required depending on internal run-control handlers.

This PR closes that gap with a generic public surface:
- `AgUiResumeSignalSchema`
- `createAgUiResumeHandler()`
- `createAgUiCancelHandler()`

It keeps the internal `/internal/agents/runs/*` handlers as signed Veryfront wrappers instead of treating them as the package contract.

## Verification
- `deno test --allow-all src/agent/ag-ui-run-control.test.ts src/agent/runtime-ag-ui-contract.test.ts src/agent/ag-ui-handler.test.ts src/internal-agents/schema.test.ts`
- `deno lint src/agent/ag-ui-run-control.ts src/agent/ag-ui-run-control.test.ts src/agent/index.ts`
- `deno check src/agent/ag-ui-run-control.ts src/agent/ag-ui-run-control.test.ts src/agent/index.ts`
- `deno task verify`

Closes #925
Related: veryfront-agent#172
