### PR TITLE
Deduplicate module-loader namespace plugin loading

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.153",
+  "version": "0.1.154",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -354,29 +354,43 @@ function createImportMapPlugin(
 
       build.onLoad(
         { filter: /.*/, namespace: "import-map" },
-        wrapWithCurrentContext(async (args) => {
-          try {
-            const { filePath, contents } = await readFileWithExtensions(
-              adapter,
-              args.path,
-              FILE_EXTENSIONS,
-              projectDir,
-            );
-
-            return {
-              contents,
-              loader: getLoaderForFile(filePath),
-              resolveDir: pathHelper.dirname(filePath),
-            };
-          } catch (error) {
-            const msg = error instanceof Error ? error.message : String(error);
-            logger.error(`Failed to load file via import map: ${args.path}`, error);
-            return { errors: [{ text: `Failed to load: ${msg}` }] };
-          }
+        createNamespaceOnLoadHandler({
+          adapter,
+          projectDir,
+          errorLabel: "file via import map",
         }),
       );
     },
   };
+}
+
+function createNamespaceOnLoadHandler(options: {
+  adapter: RuntimeAdapter;
+  projectDir: string;
+  errorLabel: string;
+}) {
+  const { adapter, projectDir, errorLabel } = options;
+
+  return wrapWithCurrentContext(async (args: { path: string }) => {
+    try {
+      const { filePath, contents } = await readFileWithExtensions(
+        adapter,
+        args.path,
+        FILE_EXTENSIONS,
+        projectDir,
+      );
+
+      return {
+        contents,
+        loader: getLoaderForFile(filePath),
+        resolveDir: pathHelper.dirname(filePath),
+      };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      logger.error(`Failed to load ${errorLabel}: ${args.path}`, error);
+      return { errors: [{ text: `Failed to load: ${msg}` }] };
+    }
+  });
 }
 
 /** Resolves relative imports through the adapter's virtual FS for remote projects. */
@@ -419,25 +433,10 @@ function createAdapterResolvePlugin(
       // cannot resolve the per-project adapter and all file reads fail silently.
       build.onLoad(
         { filter: /.*/, namespace: "vf-adapter" },
-        wrapWithCurrentContext(async (args) => {
-          try {
-            const { filePath, contents } = await readFileWithExtensions(
-              adapter,
-              args.path,
-              FILE_EXTENSIONS,
-              projectDir,
-            );
-
-            return {
-              contents,
-              loader: getLoaderForFile(filePath),
-              resolveDir: pathHelper.dirname(filePath),
-            };
-          } catch (error) {
-            const msg = error instanceof Error ? error.message : String(error);
-            logger.error(`Failed to load via adapter: ${args.path}`, error);
-            return { errors: [{ text: `Failed to load: ${msg}` }] };
-          }
+        createNamespaceOnLoadHandler({
+          adapter,
+          projectDir,
+          errorLabel: "via adapter",
         }),
       );
     },

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.153";
+export const VERSION = "0.1.154";


### PR DESCRIPTION
## Summary
- remove duplicated namespace `onLoad` file-loading logic from module-loader plugins
- keep the scoped loader behavior locked with existing regression coverage
- bump the release version to `0.1.154`

## Why
`createImportMapPlugin()` and `createAdapterResolvePlugin()` had copy-pasted `onLoad` behavior. This cleanup keeps the error handling and file loading behavior aligned through one shared path so the two plugin branches cannot drift.

## AI slop cleaner workflow
- Behavior lock: reused existing targeted loader regression tests before editing
- Pass 1: no dead code deletion needed in this slice
- Pass 2: extracted the duplicated namespace load path into one helper
- Pass 3: preserved plugin-specific log labels while simplifying the shared error path
- Pass 4: re-ran the targeted tests and full quick verification gates

## Verification
- pre-push checks: 1324 passed / 0 failed
- `deno test --no-check --allow-all src/routing/api/module-loader/loader.test.ts src/utils/version.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts src/routing/api/module-loader/loader.ts src/routing/api/module-loader/loader.test.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/utils/version-constant.ts src/routing/api/module-loader/loader.ts src/routing/api/module-loader/loader.test.ts`
- `deno task typecheck`
- `deno task verify:quick`
