### PR TITLE
Support injected AG-UI tools for package-hosted runtimes

### DIFF
--- a/docs/reference/agent-runtime-ag-ui.md
+++ b/docs/reference/agent-runtime-ag-ui.md
@@ -26,19 +26,37 @@ Use `createAgUiHandler()` as a convenience wrapper when you want a direct
 route handler:
 
 ```ts
-import { agent, createAgUiHandler } from "veryfront/agent";
+import {
+  agent,
+  createAgUiCancelHandler,
+  createAgUiHandler,
+  createAgUiResumeHandler,
+  RunResumeSessionManager,
+} from "veryfront/agent";
 
 const assistant = agent({
   system: "You are a helpful assistant.",
 });
 
+const sessionManager = new RunResumeSessionManager<{
+  result: unknown;
+  isError: boolean;
+}>();
+
 export const POST = createAgUiHandler({
   agent: assistant,
+  sessionManager,
 });
+
+// Mount the hosted run-control routes with the same session manager:
+const resumeHandler = createAgUiResumeHandler({ sessionManager });
+const cancelHandler = createAgUiCancelHandler({ sessionManager });
 ```
 
 `createAgUiHandler()` validates the higher-level `AgUiRequestSchema` convenience
-shape and normalizes it into the canonical hosted runtime contract.
+shape and normalizes it into the canonical hosted runtime contract. When a host
+accepts injected client tools in `tools`, pass the same public
+`RunResumeSessionManager` used by the hosted resume/cancel handlers.
 
 For resumable hosted runs, the package also exposes:
 
@@ -98,8 +116,10 @@ export const DELETE = createAgUiCancelHandler({ sessionManager });
 These handlers are generic package surfaces. They do not include Veryfront
 control-plane auth/signature requirements.
 
-## Current Limitation
+## Injected Client Tools
 
-Injected client tools in `tools` are not supported yet by the package AG-UI
-handler. Requests that include them receive `501` until the package exposes
-generic wait/resume primitives for client-mediated tool execution.
+Injected client tools in `tools` are supported when the host wires
+`createAgUiHandler()` to a public `RunResumeSessionManager`.
+
+If `tools` are present and no `sessionManager` is configured, the handler
+returns `501` with guidance to provide the public run-control seam.

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -234,6 +234,8 @@ The handler:
 - clears server memory before each run
 - converts the package data-stream output into AG-UI SSE events
 - normalizes the wrapper request into the canonical hosted runtime contract
+- supports injected client tools in `tools` when `options.sessionManager` is
+  provided
 - passes AG-UI request metadata into `agent.stream()` context as:
 
 ```ts
@@ -247,15 +249,18 @@ The handler:
 }
 ```
 
-Current limitation:
+Injected client tools:
 
-- injected client tools in `tools` are rejected with `501` until the package
-  exposes generic wait/resume primitives for them
+- accepted when `options.sessionManager` is a public
+  `RunResumeSessionManager<{ result: unknown; isError: boolean }>`
+- rejected with `501` when `tools` are present but `options.sessionManager` is
+  omitted
 
-| Property           | Type                                                                                                                                                           | Description                                         |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| `agentIdOrConfig`  | `string \| { agent: Agent, context?: ... }`                                                                                                                    | Agent registry id or direct agent instance          |
-| `options?.context` | <code>Record&lt;string, unknown&gt; &#124; ((request: Request) =&gt; Record&lt;string, unknown&gt; &#124; Promise&lt;Record&lt;string, unknown&gt;&gt;)</code> | Extra context merged into the AG-UI runtime context |
+| Property                  | Type                                                                                                                                                           | Description                                                   |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `agentIdOrConfig`         | `string \| { agent: Agent, context?: ..., sessionManager?: ... }`                                                                                              | Agent registry id or direct agent instance                    |
+| `options?.context`        | <code>Record&lt;string, unknown&gt; &#124; ((request: Request) =&gt; Record&lt;string, unknown&gt; &#124; Promise&lt;Record&lt;string, unknown&gt;&gt;)</code> | Extra context merged into the AG-UI runtime context           |
+| `options?.sessionManager` | `RunResumeSessionManager<{ result: unknown; isError: boolean }>`                                                                                               | Required when the request can include injected client `tools` |
 
 ### `AgUiRequestSchema`
 

--- a/src/agent/ag-ui-handler.test.ts
+++ b/src/agent/ag-ui-handler.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertMatch, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { AgUiRequestSchema, createAgUiHandler } from "./ag-ui-handler.ts";
+import { AgentRuntime, RunResumeSessionManager } from "./index.ts";
 import type { Agent, Message } from "./types.ts";
 
 const encoder = new TextEncoder();
@@ -195,7 +196,139 @@ describe("agent/ag-ui-handler", () => {
     assertMatch(String(testAgent.capturedContext?.runId), /^run_[a-z0-9]+$/);
   });
 
-  it("rejects injected client tools until wait/resume primitives exist", async () => {
+  it("supports injected client tools when a public session manager is provided", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    const originalStream = AgentRuntime.prototype.stream;
+
+    AgentRuntime.prototype.stream = async function (
+      messages,
+      context,
+    ): Promise<ReadableStream<Uint8Array>> {
+      const runtimeConfig = this as unknown as {
+        config: {
+          tools?: Record<string, {
+            execute: (
+              input: Record<string, unknown>,
+              context?: { toolCallId?: string },
+            ) => Promise<unknown>;
+          }>;
+        };
+      };
+
+      const injectedTool = runtimeConfig.config.tools?.client_confirm;
+      if (!injectedTool) {
+        throw new Error("Expected injected tool to be merged into the runtime config");
+      }
+
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          void (async () => {
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "message-start",
+                messageId: "assistant-msg-1",
+              }),
+            );
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "data",
+                data: {
+                  model: "anthropic/claude-sonnet-4-6",
+                  inferenceMode: "cloud",
+                },
+              }),
+            );
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "tool-input-start",
+                toolCallId: "tool-call-1",
+                toolName: "client_confirm",
+              }),
+            );
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "tool-input-delta",
+                toolCallId: "tool-call-1",
+                inputTextDelta: '{"approved":true}',
+              }),
+            );
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "tool-input-available",
+                toolCallId: "tool-call-1",
+              }),
+            );
+
+            const result = await injectedTool.execute(
+              { approved: true },
+              { toolCallId: "tool-call-1" },
+            );
+
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "tool-output-available",
+                toolCallId: "tool-call-1",
+                output: result,
+              }),
+            );
+            controller.close();
+          })();
+        },
+      });
+
+      assertEquals(messages[0]?.role, "user");
+      assertEquals(context?.runId, "run_1");
+      return stream;
+    };
+
+    try {
+      const handler = createAgUiHandler({
+        agent: createTestAgent().agent,
+        sessionManager,
+      });
+
+      const response = await handler(
+        new Request("http://localhost/api/ag-ui", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            runId: "run_1",
+            threadId: crypto.randomUUID(),
+            messages: [{
+              id: "msg-1",
+              role: "user",
+              parts: [{ type: "text", text: "hello" }],
+            }],
+            tools: [{ name: "client_confirm" }],
+          }),
+        }),
+      );
+
+      assertEquals(response.status, 200);
+
+      const bodyPromise = response.text();
+      const submitOutcome = sessionManager.submitSignal("run_1", {
+        waitKey: "tool-call-1",
+        value: { result: { approved: true }, isError: false },
+      });
+      assertEquals(submitOutcome, { accepted: true });
+
+      const body = await bodyPromise;
+      assertStringIncludes(body, "event: ToolCallStart");
+      assertStringIncludes(body, "event: ToolCallEnd");
+      assertStringIncludes(body, "event: ToolCallResult");
+      assertStringIncludes(body, '"toolCallId":"tool-call-1"');
+      assertStringIncludes(body, '"approved":true');
+      assertStringIncludes(body, "event: RunFinished");
+    } finally {
+      AgentRuntime.prototype.stream = originalStream;
+    }
+  });
+
+  it("rejects injected client tools when no public session manager is provided", async () => {
     const testAgent = createTestAgent();
     const handler = createAgUiHandler({ agent: testAgent.agent });
 
@@ -216,6 +349,9 @@ describe("agent/ag-ui-handler", () => {
 
     assertEquals(response.status, 501);
     assertEquals(testAgent.clearMemoryCalls, 0);
-    assertStringIncludes(await response.text(), "Injected AG-UI tools are not supported");
+    assertStringIncludes(
+      await response.text(),
+      "Injected AG-UI tools require a public RunResumeSessionManager",
+    );
   });
 });

--- a/src/agent/ag-ui-handler.ts
+++ b/src/agent/ag-ui-handler.ts
@@ -1,7 +1,14 @@
 import { z } from "zod";
 import { getAgent } from "./composition/index.ts";
 import type { Agent, Message } from "./types.ts";
+import {
+  AgentRuntime,
+  RunAlreadyExistsError,
+  type RunResumeSessionManager,
+} from "./runtime/index.ts";
 import { INVALID_ARGUMENT } from "#veryfront/errors";
+import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
+import { type Tool, toolRegistry } from "#veryfront/tool";
 import {
   createStreamTransformState,
   finalizeRunEvents,
@@ -100,6 +107,7 @@ export type AgUiContextItem = z.infer<typeof AgUiContextItemSchema>;
 export type AgUiRequest = z.infer<typeof AgUiRequestSchema>;
 
 type AgUiRuntimePart = Record<string, unknown> & { type: string };
+type AgUiResumeValue = { result: unknown; isError: boolean };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -258,24 +266,29 @@ function enqueueEvent(
 }
 
 async function createAgUiStreamResponse(
-  agent: Agent,
-  request: AgUiRequest,
-  baseContext: Record<string, unknown>,
+  options: {
+    agentId: string;
+    request: AgUiRequest;
+    runId: string;
+    threadId: string;
+    upstreamBody: ReadableStream<Uint8Array> | null;
+    upstreamStatus: number;
+    upstreamStatusText?: string;
+    onFinish?: () => void;
+    onError?: (error: unknown) => void;
+  },
 ): Promise<Response> {
-  const threadId = request.threadId ?? crypto.randomUUID();
-  const runId = request.runId ?? generateRunId();
-
-  await agent.clearMemory();
-
-  const result = await agent.stream({
-    messages: normalizeMessages(request.messages),
-    context: buildStreamContext(request, baseContext, threadId, runId),
-    ...(request.model ? { model: request.model } : {}),
-    ...(request.maxOutputTokens ? { maxOutputTokens: request.maxOutputTokens } : {}),
-  });
-
-  const upstream = result.toDataStreamResponse();
-  const upstreamBody = upstream.body;
+  const {
+    agentId,
+    request,
+    runId,
+    threadId,
+    upstreamBody,
+    upstreamStatus,
+    upstreamStatusText,
+    onFinish,
+    onError,
+  } = options;
 
   const stream = new ReadableStream<Uint8Array>({
     start: async (controller) => {
@@ -284,7 +297,7 @@ async function createAgUiStreamResponse(
       let remainder = "";
       const decoder = new TextDecoder();
 
-      if (!enqueueEvent(controller, "RunStarted", { runId, threadId, agentId: agent.id })) {
+      if (!enqueueEvent(controller, "RunStarted", { runId, threadId, agentId })) {
         return;
       }
       if (!enqueueEvent(controller, "StateSnapshot", { snapshot: {} })) {
@@ -301,6 +314,7 @@ async function createAgUiStreamResponse(
               return;
             }
           }
+          onFinish?.();
           closeController(controller);
           return;
         }
@@ -339,7 +353,9 @@ async function createAgUiStreamResponse(
             return;
           }
         }
+        onFinish?.();
       } catch (error) {
+        onError?.(error);
         enqueueEvent(controller, "RunError", {
           message: error instanceof Error ? error.message : "Agent run failed",
         });
@@ -351,9 +367,139 @@ async function createAgUiStreamResponse(
   });
 
   return new Response(stream, {
-    status: upstream.status,
-    statusText: upstream.statusText,
+    status: upstreamStatus,
+    statusText: upstreamStatusText,
     headers: { ...AG_UI_HEADERS },
+  });
+}
+
+async function createAgUiDirectStreamResponse(
+  agent: Agent,
+  request: AgUiRequest,
+  baseContext: Record<string, unknown>,
+): Promise<Response> {
+  const threadId = request.threadId ?? crypto.randomUUID();
+  const runId = request.runId ?? generateRunId();
+
+  await agent.clearMemory();
+
+  const result = await agent.stream({
+    messages: normalizeMessages(request.messages),
+    context: buildStreamContext(request, baseContext, threadId, runId),
+    ...(request.model ? { model: request.model } : {}),
+    ...(request.maxOutputTokens ? { maxOutputTokens: request.maxOutputTokens } : {}),
+  });
+
+  const upstream = result.toDataStreamResponse();
+  return await createAgUiStreamResponse({
+    agentId: agent.id,
+    request,
+    runId,
+    threadId,
+    upstreamBody: upstream.body,
+    upstreamStatus: upstream.status,
+    upstreamStatusText: upstream.statusText,
+  });
+}
+
+function createInjectedAgUiTool(
+  runId: string,
+  tool: AgUiInjectedTool,
+  sessionManager: RunResumeSessionManager<AgUiResumeValue>,
+): Tool {
+  return {
+    id: tool.name,
+    type: "function",
+    description: tool.description ?? tool.name,
+    inputSchema: z.record(z.string(), z.unknown()),
+    inputSchemaJson: (tool.parameters ??
+      { type: "object", properties: {}, additionalProperties: true }) as Tool["inputSchemaJson"],
+    execute: async (_input, context) => {
+      const toolCallId = typeof context?.toolCallId === "string" ? context.toolCallId : null;
+      if (!toolCallId) {
+        throw new Error(`Missing toolCallId for injected tool "${tool.name}"`);
+      }
+
+      const submitted = await sessionManager.waitForSignal(runId, toolCallId);
+      if (submitted.isError) {
+        throw new Error(
+          typeof submitted.result === "string"
+            ? submitted.result
+            : JSON.stringify(submitted.result),
+        );
+      }
+      return submitted.result;
+    },
+  };
+}
+
+async function createAgUiInjectedToolsStreamResponse(
+  agent: Agent,
+  request: AgUiRequest,
+  baseContext: Record<string, unknown>,
+  sessionManager: RunResumeSessionManager<AgUiResumeValue>,
+): Promise<Response> {
+  const threadId = request.threadId ?? crypto.randomUUID();
+  const runId = request.runId ?? generateRunId();
+
+  try {
+    sessionManager.startRun({ runId, threadId });
+  } catch (error) {
+    if (error instanceof RunAlreadyExistsError) {
+      return Response.json({ error: "Run already active" }, { status: 409 });
+    }
+    throw error;
+  }
+
+  const injectedTools = Object.fromEntries(
+    request.tools.map((tool) => [tool.name, createInjectedAgUiTool(runId, tool, sessionManager)]),
+  );
+
+  const mergedTools: Agent["config"]["tools"] = !agent.config.tools
+    ? injectedTools
+    : agent.config.tools === true
+    ? {
+      ...Object.fromEntries(
+        [...toolRegistry.getAll()]
+          .filter(([toolId]) => agent.config.skills || !SKILL_TOOL_IDS.has(toolId))
+          .map(([toolId]) => [toolId, true]),
+      ),
+      ...injectedTools,
+    }
+    : { ...agent.config.tools, ...injectedTools };
+
+  const runtime = new AgentRuntime(agent.id, {
+    ...agent.config,
+    tools: mergedTools,
+  });
+
+  let upstreamBody: ReadableStream<Uint8Array>;
+  try {
+    upstreamBody = await runtime.stream(
+      normalizeMessages(request.messages),
+      buildStreamContext(request, baseContext, threadId, runId),
+      undefined,
+      request.model,
+      request.maxOutputTokens,
+    );
+  } catch (error) {
+    sessionManager.failRun(runId);
+    throw error;
+  }
+
+  return await createAgUiStreamResponse({
+    agentId: agent.id,
+    request,
+    runId,
+    threadId,
+    upstreamBody,
+    upstreamStatus: 200,
+    onFinish: () => {
+      sessionManager.completeRun(runId);
+    },
+    onError: () => {
+      sessionManager.failRun(runId);
+    },
   });
 }
 
@@ -361,6 +507,7 @@ export interface AgUiHandlerOptions {
   context?:
     | Record<string, unknown>
     | ((request: Request) => Record<string, unknown> | Promise<Record<string, unknown>>);
+  sessionManager?: RunResumeSessionManager<AgUiResumeValue>;
 }
 
 export interface AgUiHandlerConfigWithAgent extends AgUiHandlerOptions {
@@ -417,12 +564,25 @@ export function createAgUiHandler(
       const parsed = AgUiRequestSchema.parse(await request.json());
 
       if (parsed.tools.length > 0) {
-        return Response.json(
-          {
-            error:
-              "Injected AG-UI tools are not supported by createAgUiHandler yet. Use package-level wait/resume runtime primitives instead.",
-          },
-          { status: 501 },
+        if (!options?.sessionManager) {
+          return Response.json(
+            {
+              error:
+                "Injected AG-UI tools require a public RunResumeSessionManager on createAgUiHandler().",
+            },
+            { status: 501 },
+          );
+        }
+
+        const context = typeof options?.context === "function"
+          ? await options.context(request)
+          : options?.context ?? {};
+
+        return await createAgUiInjectedToolsStreamResponse(
+          agent,
+          parsed,
+          context,
+          options.sessionManager,
         );
       }
 
@@ -430,7 +590,7 @@ export function createAgUiHandler(
         ? await options.context(request)
         : options?.context ?? {};
 
-      return await createAgUiStreamResponse(agent, parsed, context);
+      return await createAgUiDirectStreamResponse(agent, parsed, context);
     } catch (error) {
       if (error instanceof z.ZodError) {
         return Response.json(


### PR DESCRIPTION
## Summary
- support injected AG-UI client tools in `createAgUiHandler()` when callers provide a public `RunResumeSessionManager`
- keep the rejection path explicit when injected tools are configured without the public session manager
- document the supported open-source contract instead of the previous hosted-runtime limitation

## Why
`veryfront-agent` is converging on `veryfront-code` as its runtime substrate, so the package-hosted AG-UI surface needs to expose the same public run-control seam instead of relying on internal-only tooling hooks. This closes the next roadmap gap after the public resume/cancel handlers landed.

## Testing
- `deno test --allow-all src/agent/ag-ui-handler.test.ts src/agent/ag-ui-run-control.test.ts src/agent/runtime-ag-ui-contract.test.ts src/internal-agents/schema.test.ts`
- `deno task verify`

## Related
- Closes #929
- Related veryfront-agent#172