### PR TITLE
Deduplicate observability collector file-context helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.154",
+  "version": "0.1.155",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/observability/error-collector.test.ts
+++ b/src/observability/error-collector.test.ts
@@ -35,6 +35,60 @@ describe("cli/mc./error-collector", () => {
       assertEquals(counts.module, 1);
     });
 
+    it("should preserve file, context, and slug metadata for file-context error helpers", () => {
+      const ec = new ErrorCollector();
+      const sharedContext = { source: "dev-server" };
+
+      ec.addBundleError("bundle fail", "bundle.ts", sharedContext, "bundle-failed");
+      ec.addHMRError("hmr fail", "hmr.ts", sharedContext, "hmr-failed");
+      ec.addModuleError("module fail", "module.ts", sharedContext, "module-failed");
+
+      assertEquals(
+        ec.getAll({ type: "bundle" }).map((error) => ({
+          file: error.file,
+          context: error.context,
+          slug: error.slug,
+          category: error.category,
+        })),
+        [{
+          file: "bundle.ts",
+          context: sharedContext,
+          slug: "bundle-failed",
+          category: "BUILD",
+        }],
+      );
+
+      assertEquals(
+        ec.getAll({ type: "hmr" }).map((error) => ({
+          file: error.file,
+          context: error.context,
+          slug: error.slug,
+          category: error.category,
+        })),
+        [{
+          file: "hmr.ts",
+          context: sharedContext,
+          slug: "hmr-failed",
+          category: "DEV",
+        }],
+      );
+
+      assertEquals(
+        ec.getAll({ type: "module" }).map((error) => ({
+          file: error.file,
+          context: error.context,
+          slug: error.slug,
+          category: error.category,
+        })),
+        [{
+          file: "module.ts",
+          context: sharedContext,
+          slug: "module-failed",
+          category: "MODULE",
+        }],
+      );
+    });
+
     it("should enforce maxErrors", () => {
       const ec = new ErrorCollector({ maxErrors: 2 });
       ec.add({ type: "compile", category: "BUILD", message: "1" });

--- a/src/observability/error-collector.ts
+++ b/src/observability/error-collector.ts
@@ -150,6 +150,16 @@ export class ErrorCollector {
     return this.addTypedError("runtime", message, { stack, context, slug });
   }
 
+  private addFileContextError(
+    type: "bundle" | "hmr" | "module",
+    message: string,
+    file?: string,
+    context?: Record<string, unknown>,
+    slug?: string,
+  ): DevError {
+    return this.addTypedError(type, message, { file, context, slug });
+  }
+
   /**
    * Add a bundle error
    * @param message Error message
@@ -163,7 +173,7 @@ export class ErrorCollector {
     context?: Record<string, unknown>,
     slug?: string,
   ): DevError {
-    return this.addTypedError("bundle", message, { file, context, slug });
+    return this.addFileContextError("bundle", message, file, context, slug);
   }
 
   /**
@@ -179,7 +189,7 @@ export class ErrorCollector {
     context?: Record<string, unknown>,
     slug?: string,
   ): DevError {
-    return this.addTypedError("hmr", message, { file, context, slug });
+    return this.addFileContextError("hmr", message, file, context, slug);
   }
 
   /**
@@ -195,7 +205,7 @@ export class ErrorCollector {
     context?: Record<string, unknown>,
     slug?: string,
   ): DevError {
-    return this.addTypedError("module", message, { file, context, slug });
+    return this.addFileContextError("module", message, file, context, slug);
   }
 
   getAll(filter?: ErrorFilter): DevError[] {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.154";
+export const VERSION = "0.1.155";


### PR DESCRIPTION
## Summary
- extract shared file-context error helper logic in the observability error collector
- add a regression test that locks file/context/slug/category behavior for bundle, hmr, and module helpers
- bump release version to `0.1.155`

## Why
This slice removes a small exact duplication hotspot in the dev error collector while preserving emitted error metadata. It keeps the repo-wide cleanup lane moving through small, reversible, regression-tested PRs.

## Verification
- pre-push checks: 1325 passed / 0 failed
- `deno test --no-check --allow-all src/observability/error-collector.test.ts src/utils/version.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts src/observability/error-collector.ts src/observability/error-collector.test.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/observability/error-collector.ts src/observability/error-collector.test.ts src/utils/version-constant.ts`
- `deno task typecheck`
- `deno task verify:quick`

## Notes
- architect review: APPROVE
- downstream consumer updates: not needed for this internal slice
