### PR TITLE
Normalize repeated CLI string-arg helpers

### DIFF
--- a/cli/commands/files/command.ts
+++ b/cli/commands/files/command.ts
@@ -6,6 +6,7 @@ import { withSpan } from "veryfront/observability/otlp-setup";
 import { cliLogger } from "#cli/utils";
 import { type ApiClient, createApiClient, resolveConfigWithAuth } from "#cli/shared/config";
 import type { ParsedArgs } from "#cli/shared/types";
+import { getStringArg } from "../../shared/parsed-args.ts";
 import { getFileContent, listAllFiles } from "../pull/command.ts";
 
 const MAIN_SOURCE = { type: "main" } as const;
@@ -50,14 +51,6 @@ export type FilesListOptions = z.infer<typeof FilesListArgsSchema>;
 export type FilesGetOptions = z.infer<typeof FilesGetArgsSchema>;
 export type FilesPutOptions = z.infer<typeof FilesPutArgsSchema>;
 export type FilesDeleteOptions = z.infer<typeof FilesDeleteArgsSchema>;
-
-function getStringArg(args: ParsedArgs, ...keys: string[]): string | undefined {
-  for (const key of keys) {
-    const value = args[key];
-    if (typeof value === "string" && value) return value;
-  }
-  return undefined;
-}
 
 function getBooleanArg(args: ParsedArgs, ...keys: string[]): boolean {
   return keys.some((key) => Boolean(args[key]));

--- a/cli/commands/issues/command.ts
+++ b/cli/commands/issues/command.ts
@@ -10,15 +10,7 @@ import { createIssuesManager, type Issue, type IssuePrefix, parseState } from "v
 import { bold, muted, success } from "#cli/ui";
 
 import type { ParsedArgs } from "#cli/shared/types";
-
-/** Extract a string value from parsed args by checking multiple keys */
-function str(args: ParsedArgs, ...keys: string[]): string | undefined {
-  for (const k of keys) {
-    const v = args[k];
-    if (typeof v === "string" && v) return v;
-  }
-  return undefined;
-}
+import { getStringArg } from "../../shared/parsed-args.ts";
 
 /** Extract a boolean value from parsed args by checking multiple keys */
 function bool(args: ParsedArgs, ...keys: string[]): boolean {
@@ -123,18 +115,18 @@ export async function issuesCommand(args: ParsedArgs): Promise<void> {
 
   switch (subcommand) {
     case "create": {
-      const title = str(args, "title", "t") || getId(args, 2);
+      const title = getStringArg(args, "title", "t") || getId(args, 2);
       if (!title) {
         throw new Error("Title is required. Usage: veryfront issues create --title 'My issue'");
       }
 
       const issue = await manager.create({
         title,
-        body: str(args, "body", "b"),
-        labels: parseLabels(str(args, "labels", "l")),
-        milestone: str(args, "milestone", "m"),
-        assignees: parseLabels(str(args, "assignees", "a")),
-        prefix: getPrefix(str(args, "prefix"), "ISSUE")!,
+        body: getStringArg(args, "body", "b"),
+        labels: parseLabels(getStringArg(args, "labels", "l")),
+        milestone: getStringArg(args, "milestone", "m"),
+        assignees: parseLabels(getStringArg(args, "assignees", "a")),
+        prefix: getPrefix(getStringArg(args, "prefix"), "ISSUE")!,
       });
 
       if (json) {
@@ -149,15 +141,16 @@ export async function issuesCommand(args: ParsedArgs): Promise<void> {
 
     case "list":
     case "ls": {
-      const stateArg = str(args, "state");
+      const stateArg = getStringArg(args, "state");
       const result = await manager.list({
         state: stateArg ? parseState(stateArg) ?? undefined : undefined,
-        labels: parseLabels(str(args, "labels", "l")),
-        milestone: str(args, "milestone", "m"),
-        assignee: str(args, "assignee"),
-        prefix: getPrefix(str(args, "prefix")),
-        sortBy: (str(args, "sort") as "created_at" | "updated_at" | "id") || "created_at",
-        sortDirection: (str(args, "dir") as "asc" | "desc") || "desc",
+        labels: parseLabels(getStringArg(args, "labels", "l")),
+        milestone: getStringArg(args, "milestone", "m"),
+        assignee: getStringArg(args, "assignee"),
+        prefix: getPrefix(getStringArg(args, "prefix")),
+        sortBy: (getStringArg(args, "sort") as "created_at" | "updated_at" | "id") ||
+          "created_at",
+        sortDirection: (getStringArg(args, "dir") as "asc" | "desc") || "desc",
         limit: num(args, "limit"),
       });
 
@@ -221,25 +214,25 @@ export async function issuesCommand(args: ParsedArgs): Promise<void> {
 
       const updates: Parameters<typeof manager.update>[1] = {};
 
-      const title = str(args, "title", "t");
+      const title = getStringArg(args, "title", "t");
       if (title) updates.title = title;
 
-      const body = str(args, "body", "b");
+      const body = getStringArg(args, "body", "b");
       if (body) updates.body = body;
 
-      const stateArg = str(args, "state");
+      const stateArg = getStringArg(args, "state");
       if (stateArg) {
         const state = parseState(stateArg);
         if (state) updates.state = state;
       }
 
-      const labels = parseLabels(str(args, "labels", "l"));
+      const labels = parseLabels(getStringArg(args, "labels", "l"));
       if (labels) updates.labels = labels;
 
-      const assignees = parseLabels(str(args, "assignees", "a"));
+      const assignees = parseLabels(getStringArg(args, "assignees", "a"));
       if (assignees) updates.assignees = assignees;
 
-      const milestone = str(args, "milestone", "m");
+      const milestone = getStringArg(args, "milestone", "m");
       if (milestone) updates.milestone = milestone;
 
       if (!Object.keys(updates).length) {

--- a/cli/commands/knowledge/command.ts
+++ b/cli/commands/knowledge/command.ts
@@ -6,6 +6,7 @@ import { withSpan } from "veryfront/observability/otlp-setup";
 import { cliLogger } from "#cli/utils";
 import { type ApiClient, createApiClient, resolveConfigWithAuth } from "#cli/shared/config";
 import type { ParsedArgs } from "#cli/shared/types";
+import { getStringArg } from "../../shared/parsed-args.ts";
 import { downloadUploadToFile, listAllUploads, type UploadItem } from "../uploads/command.ts";
 import { putRemoteFileFromLocal } from "../files/command.ts";
 import { knowledgeIngestPythonSource } from "./parser-source.ts";
@@ -108,14 +109,6 @@ const KnowledgeIngestArgsSchema = z.object({
 });
 
 export type KnowledgeIngestOptions = z.infer<typeof KnowledgeIngestArgsSchema>;
-
-function getStringArg(args: ParsedArgs, ...keys: string[]): string | undefined {
-  for (const key of keys) {
-    const value = args[key];
-    if (typeof value === "string" && value) return value;
-  }
-  return undefined;
-}
 
 function getBooleanArg(args: ParsedArgs, ...keys: string[]): boolean {
   return keys.some((key) => Boolean(args[key]));

--- a/cli/commands/uploads/command.ts
+++ b/cli/commands/uploads/command.ts
@@ -7,6 +7,7 @@ import { withSpan } from "veryfront/observability/otlp-setup";
 import { cliLogger } from "#cli/utils";
 import { type ApiClient, createApiClient, resolveConfigWithAuth } from "#cli/shared/config";
 import type { ParsedArgs } from "#cli/shared/types";
+import { getStringArg } from "../../shared/parsed-args.ts";
 
 export interface UploadItem {
   type: "file" | "folder";
@@ -86,14 +87,6 @@ const UploadDeleteArgsSchema = z.object({
 });
 
 export type UploadDeleteOptions = z.infer<typeof UploadDeleteArgsSchema>;
-
-function getStringArg(args: ParsedArgs, ...keys: string[]): string | undefined {
-  for (const key of keys) {
-    const value = args[key];
-    if (typeof value === "string" && value) return value;
-  }
-  return undefined;
-}
 
 function getBooleanArg(args: ParsedArgs, ...keys: string[]): boolean {
   return keys.some((key) => Boolean(args[key]));

--- a/cli/shared/parsed-args.test.ts
+++ b/cli/shared/parsed-args.test.ts
@@ -1,0 +1,26 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ParsedArgs } from "./types.ts";
+import { getStringArg } from "./parsed-args.ts";
+
+describe("cli/shared/parsed-args", () => {
+  it("returns the first non-empty string value across aliases", () => {
+    const args = {
+      project: "",
+      p: "my-project",
+      "project-slug": "ignored-project",
+    } as ParsedArgs;
+
+    assertEquals(getStringArg(args, "project", "p", "project-slug"), "my-project");
+  });
+
+  it("returns undefined when no provided alias has a non-empty string", () => {
+    const args = {
+      project: "",
+      p: false,
+      "project-slug": 123,
+    } as ParsedArgs;
+
+    assertEquals(getStringArg(args, "project", "p", "project-slug"), undefined);
+  });
+});

--- a/cli/shared/parsed-args.ts
+++ b/cli/shared/parsed-args.ts
@@ -1,0 +1,9 @@
+import type { ParsedArgs } from "./types.ts";
+
+export function getStringArg(args: ParsedArgs, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = args[key];
+    if (typeof value === "string" && value) return value;
+  }
+  return undefined;
+}

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.155",
+  "version": "0.1.156",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.155";
+export const VERSION = "0.1.156";


### PR DESCRIPTION
## Summary
- extract repeated CLI string-arg lookup into a shared helper
- switch files/issues/knowledge/uploads commands to the shared helper
- bump the release version to `0.1.156`

## Why
Several CLI commands carried identical non-empty string alias lookup helpers. This slice removes that duplication while keeping command-specific parsing logic unchanged.

## Verification
- pre-push checks: 1326 passed / 0 failed
- `deno test --no-check --allow-all cli/shared/parsed-args.test.ts cli/commands/files/handler.test.ts cli/commands/uploads/handler.test.ts cli/commands/knowledge/handler.test.ts cli/commands/issues/command.test.ts src/utils/version.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts cli/shared/parsed-args.ts cli/shared/parsed-args.test.ts cli/commands/files/command.ts cli/commands/issues/command.ts cli/commands/knowledge/command.ts cli/commands/uploads/command.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/utils/version-constant.ts cli/shared/parsed-args.ts cli/shared/parsed-args.test.ts cli/commands/files/command.ts cli/commands/issues/command.ts cli/commands/knowledge/command.ts cli/commands/uploads/command.ts`
- `deno task typecheck`
- `deno task verify:quick`
