### PR TITLE
Deduplicate proxy not-found context helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.156",
+  "version": "0.1.157",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -998,6 +998,7 @@ describe("Proxy Handler", () => {
         assertEquals(ctx.error?.status, 404);
         assertEquals(ctx.error?.message, "Project not found");
         assertEquals(ctx.error?.slug, "project-not-found");
+        assertEquals(ctx.token, "test-token");
 
         await handler.close();
       } finally {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -391,36 +391,19 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     return `https://veryfront.com/sign-in?from=${encodeURIComponent(returnPath)}`;
   }
 
-  function makePreviewProjectNotFoundContext(
-    base: {
-      scope: TokenScope;
-      host: string;
-      parsedDomain: ParsedDomain;
-    },
-    token?: string,
-  ): ProxyContext {
-    return makeErrorContext(
-      base,
-      404,
-      "Preview project not found",
-      token,
-      undefined,
-      "project-not-found",
-    );
-  }
-
   function makeProjectNotFoundContext(
     base: {
       scope: TokenScope;
       host: string;
       parsedDomain: ParsedDomain;
     },
+    message: "Preview project not found" | "Project not found",
     token?: string,
   ): ProxyContext {
     return makeErrorContext(
       base,
       404,
-      "Project not found",
+      message,
       token,
       undefined,
       "project-not-found",
@@ -629,11 +612,11 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
         if (status === 404) {
           if (scope === "preview") {
             logger?.info("Preview project not found", { projectSlug, host });
-            return makePreviewProjectNotFoundContext(base);
+            return makeProjectNotFoundContext(base, "Preview project not found");
           }
 
           logger?.info("Project not found", { projectSlug, host, scope });
-          return makeProjectNotFoundContext(base);
+          return makeProjectNotFoundContext(base, "Project not found");
         }
 
         const message = scope === "preview"
@@ -726,7 +709,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
             scope,
             targetEnvName: parsedDomain.environment,
           });
-          return makeProjectNotFoundContext(base, token);
+          return makeProjectNotFoundContext(base, "Project not found", token);
         }
 
         projectId = resolved.projectId;
@@ -764,7 +747,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
         if (!resolved.projectId) {
           logger?.info("Preview project not found after lookup", { projectSlug, host });
-          return makePreviewProjectNotFoundContext(base, token);
+          return makeProjectNotFoundContext(base, "Preview project not found", token);
         }
 
         projectId = resolved.projectId;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.156";
+export const VERSION = "0.1.157";


### PR DESCRIPTION
## Summary
- deduplicate preview/project not-found proxy context creation into one shared helper
- add regression coverage for token preservation on post-lookup production 404s
- bump the release version to `0.1.157`

## Why
The proxy handler had two near-identical not-found context builders that only differed by message text. This slice removes the duplication while explicitly locking the token-preservation behavior that matters on the authenticated production lookup path.

## Verification
- `deno test --no-check --allow-all src/proxy/handler.test.ts src/utils/version.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts src/proxy/handler.ts src/proxy/handler.test.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/utils/version-constant.ts src/proxy/handler.ts src/proxy/handler.test.ts`
- `deno task typecheck`
- `deno task verify:quick`
- architect review: APPROVE
