### PR TITLE
Fix MCP remote file pathing and session capability isolation

### DIFF
--- a/cli/mcp/remote-file-tools.test.ts
+++ b/cli/mcp/remote-file-tools.test.ts
@@ -1,5 +1,10 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
+import {
+  _resetEnvironmentConfig,
+  _setEnvironmentConfigForTesting,
+} from "#veryfront/config/environment-config.ts";
 import {
   remoteFileTools,
   vfRemoteCloneProject,
@@ -398,8 +403,99 @@ describe("cli/mcp/remote-file-tools", () => {
     });
   });
 
+  describe("tool execute happy-path behavior", () => {
+    const resetEnv = () => {
+      _setEnvironmentConfigForTesting({
+        apiBaseUrl: "https://api.remote-vf.test",
+        apiToken: "token-123",
+        nodeEnv: "test",
+        veryfrontEnv: "test",
+        veryfrontMode: "test",
+        debug: false,
+        ci: false,
+        denoTesting: false,
+        perfEnabled: false,
+        publicApiBaseUrl: "https://api.remote-vf.test",
+        apiUrl: "https://api.remote-vf.test/graphql",
+        projectSlug: "project",
+      });
+    };
+
+    it("loads a file via API with encoded path and returns typed payload", async () => {
+      resetEnv();
+
+      let requestUrl = "";
+      let requestMethod = "";
+      let requestAuth = "";
+      const response = {
+        id: "1",
+        path: "pages/index.tsx",
+        content: "export default function Page() {}",
+        size: 42,
+        type: "file",
+        updated_at: "2024-01-01T00:00:00.000Z",
+      };
+
+      const result = await withMockFetch(async () => {
+        return new Response(
+          JSON.stringify(response),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }, async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (input: string | URL | Request, init?: RequestInit) => {
+          const request = new Request(input, init);
+          requestUrl = request.url;
+          requestMethod = request.method;
+          requestAuth = request.headers.get("Authorization") ?? "";
+          return originalFetch(input, init);
+        };
+
+        try {
+          return await vfRemoteGetFile.execute({
+            project: "my-project",
+            path: "pages/index.tsx",
+          });
+        } finally {
+          globalThis.fetch = originalFetch;
+        }
+      });
+
+      assertEquals(requestUrl, "https://api.remote-vf.test/api/my-project/files/pages/index.tsx");
+      assertEquals(requestMethod, "GET");
+      assertEquals(requestAuth, "Bearer token-123");
+      assertEquals(result.success, true);
+      assertEquals(result.file?.path, "pages/index.tsx");
+      assertEquals(result.file?.size, 42);
+    });
+
+    it("returns error response when API responds with unauthorized JSON error", async () => {
+      resetEnv();
+      let requestUrl = "";
+
+      const result = await withMockFetch(async (input: string | URL | Request) => {
+        const request = input instanceof Request ? input : new Request(input);
+        requestUrl = request.url;
+        return new Response(
+          JSON.stringify({ message: "Unauthorized" }),
+          { status: 401, headers: { "Content-Type": "application/json" } },
+        );
+      }, async () => {
+        return await vfRemoteGetFile.execute({
+          project: "my-project",
+          path: "pages/index.tsx",
+        });
+      });
+
+      assertEquals(requestUrl, "https://api.remote-vf.test/api/my-project/files/pages/index.tsx");
+      assertEquals(result.success, false);
+      assertEquals(result.error, "Unauthorized");
+    });
+  });
+
   describe("tool execute without API token", () => {
     it("should return error for list files without token", async () => {
+      _resetEnvironmentConfig();
       await assertExecuteError(
         vfRemoteListFiles.execute({
           project: "test",
@@ -409,6 +505,7 @@ describe("cli/mcp/remote-file-tools", () => {
     });
 
     it("should return error for get file without token", async () => {
+      _resetEnvironmentConfig();
       await assertExecuteError(
         vfRemoteGetFile.execute({
           project: "test",
@@ -418,6 +515,7 @@ describe("cli/mcp/remote-file-tools", () => {
     });
 
     it("should return error for delete file without token", async () => {
+      _resetEnvironmentConfig();
       await assertExecuteError(
         vfRemoteDeleteFile.execute({
           project: "test",
@@ -427,6 +525,7 @@ describe("cli/mcp/remote-file-tools", () => {
     });
 
     it("should return error for move file without token", async () => {
+      _resetEnvironmentConfig();
       await assertExecuteError(
         vfRemoteMoveFile.execute({
           project: "test",
@@ -437,6 +536,7 @@ describe("cli/mcp/remote-file-tools", () => {
     });
 
     it("should return error for list branches without token", async () => {
+      _resetEnvironmentConfig();
       await assertExecuteError(
         vfRemoteListBranches.execute({
           project: "test",
@@ -446,6 +546,7 @@ describe("cli/mcp/remote-file-tools", () => {
     });
 
     it("should return error for create branch without token", async () => {
+      _resetEnvironmentConfig();
       await assertExecuteError(
         vfRemoteCreateBranch.execute({
           project: "test",
@@ -455,6 +556,7 @@ describe("cli/mcp/remote-file-tools", () => {
     });
 
     it("should return error for merge branch without token", async () => {
+      _resetEnvironmentConfig();
       await assertExecuteError(
         vfRemoteMergeBranch.execute({
           project: "test",
@@ -464,6 +566,7 @@ describe("cli/mcp/remote-file-tools", () => {
     });
 
     it("should return error for delete branch without token", async () => {
+      _resetEnvironmentConfig();
       await assertExecuteError(
         vfRemoteDeleteBranch.execute({
           project: "test",
@@ -473,6 +576,7 @@ describe("cli/mcp/remote-file-tools", () => {
     });
 
     it("should return error for create project without token", async () => {
+      _resetEnvironmentConfig();
       await assertExecuteError(
         vfRemoteCreateProject.execute({
           slug: "test",

--- a/cli/mcp/remote-file-tools.ts
+++ b/cli/mcp/remote-file-tools.ts
@@ -85,6 +85,15 @@ function getBranchParam(branch?: string): string {
   return branch ? `?branch_id=${branch}` : "";
 }
 
+function buildProjectApiPath(project: string, resource: string, branch?: string): string {
+  const normalizedResource = resource.startsWith("/") ? resource.slice(1) : resource;
+  return `/${project}${getBranchPath(branch)}/${normalizedResource}`;
+}
+
+function buildProjectFilePath(project: string, filePath: string, branch?: string): string {
+  return buildProjectApiPath(project, `files/${encodeFilePath(filePath)}`, branch);
+}
+
 interface RemoteFile {
   id?: string;
   path: string;
@@ -212,9 +221,9 @@ export const vfRemoteListFiles: MCPTool<RemoteListFilesInput, RemoteListFilesOut
         params.set("limit", String(input.limit));
         params.set("fields", "(path,type,size)");
 
-        const apiPath = `/${input.project}${
-          getBranchPath(input.branch)
-        }/files?${params.toString()}`;
+        const apiPath = `${
+          buildProjectApiPath(input.project, "files", input.branch)
+        }?${params.toString()}`;
         const result = await apiRequest<FileListResponse>("GET", apiPath);
         if (!result.ok) return { success: false, error: result.error };
 
@@ -258,9 +267,7 @@ export const vfRemoteGetFile: MCPTool<RemoteGetFileInput, RemoteGetFileOutput> =
     withSpan(
       "cli.mcp.tool.vf_remote_get_file",
       async () => {
-        const apiPath = `/${input.project}${getBranchPath(input.branch)}/files/${
-          encodeFilePath(input.path)
-        }`;
+        const apiPath = buildProjectFilePath(input.project, input.path, input.branch);
         const result = await apiRequest<RemoteFile>("GET", apiPath);
         if (!result.ok) return { success: false, error: result.error };
 
@@ -312,7 +319,7 @@ export const vfRemoteUpdateFile: MCPTool<RemoteUpdateFileInput, RemoteUpdateFile
     withSpan(
       "cli.mcp.tool.vf_remote_update_file",
       async () => {
-        const apiPath = `/${input.project}/files/${encodeFilePath(input.path)}${
+        const apiPath = `${buildProjectFilePath(input.project, input.path)}${
           getBranchParam(input.branch)
         }`;
         const result = await apiRequest<{ id: string; path: string }>("PUT", apiPath, {
@@ -360,7 +367,7 @@ export const vfRemoteDeleteFile: MCPTool<RemoteDeleteFileInput, RemoteDeleteFile
   description: "Delete a file from a remote Veryfront project.",
   inputSchema: remoteDeleteFileInput,
   execute: async (input) => {
-    const apiPath = `/${input.project}/files/${encodeFilePath(input.path)}${
+    const apiPath = `${buildProjectFilePath(input.project, input.path)}${
       getBranchParam(input.branch)
     }`;
     const result = await apiRequest<void>("DELETE", apiPath);
@@ -403,7 +410,7 @@ export const vfRemoteSearchFiles: MCPTool<RemoteSearchFilesInput, RemoteSearchFi
     withSpan(
       "cli.mcp.tool.vf_remote_search_files",
       async () => {
-        const apiPath = `/${input.project}${getBranchPath(input.branch)}/files/search`;
+        const apiPath = buildProjectApiPath(input.project, "files/search", input.branch);
         const result = await apiRequest<SearchResponse>("POST", apiPath, {
           body: {
             query: input.query,
@@ -453,7 +460,11 @@ export const vfRemoteMoveFile: MCPTool<RemoteMoveFileInput, RemoteMoveFileOutput
   description: "Move or rename a file in a remote Veryfront project.",
   inputSchema: remoteMoveFileInput,
   execute: async (input) => {
-    const apiPath = `/${input.project}/files/move${getBranchParam(input.branch)}`;
+    const apiPath = `${buildProjectApiPath(input.project, "files/move")}${
+      getBranchParam(
+        input.branch,
+      )
+    }`;
     const result = await apiRequest<{ source_path: string; destination_path: string }>(
       "POST",
       apiPath,
@@ -730,7 +741,7 @@ export const vfRemoteCloneProject: MCPTool<RemoteCloneProjectInput, RemoteCloneP
 
         const listResult = await apiRequest<FileListResponse>(
           "GET",
-          `/${input.source_project}/files?${params.toString()}`,
+          `${buildProjectApiPath(input.source_project, "files")}?${params.toString()}`,
         );
 
         if (!listResult.ok) {
@@ -748,7 +759,7 @@ export const vfRemoteCloneProject: MCPTool<RemoteCloneProjectInput, RemoteCloneP
         for (const file of sourceFiles) {
           const getResult = await apiRequest<RemoteFile>(
             "GET",
-            `/${input.source_project}/files/${encodeFilePath(file.path)}`,
+            buildProjectFilePath(input.source_project, file.path),
           );
 
           if (!getResult.ok || !getResult.data) {
@@ -758,7 +769,7 @@ export const vfRemoteCloneProject: MCPTool<RemoteCloneProjectInput, RemoteCloneP
 
           const createFileResult = await apiRequest<{ id: string; path: string }>(
             "PUT",
-            `/${createResult.slug}/files/${encodeFilePath(file.path)}`,
+            buildProjectFilePath(createResult.slug, file.path),
             { body: { content: getResult.data.content } },
           );
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.157",
+  "version": "0.1.158",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -9,6 +9,13 @@ import type { ToolListEntry } from "./types.ts";
 const originalFetch = globalThis.fetch;
 
 async function initSession(handler: (req: Request) => Promise<Response>): Promise<string> {
+  return initSessionWithCapabilities(handler, {});
+}
+
+async function initSessionWithCapabilities(
+  handler: (req: Request) => Promise<Response>,
+  capabilities: Record<string, unknown>,
+): Promise<string> {
   const response = await handler(
     new Request("http://localhost/mcp", {
       method: "POST",
@@ -19,7 +26,7 @@ async function initSession(handler: (req: Request) => Promise<Response>): Promis
         method: "initialize",
         params: {
           protocolVersion: "2025-11-25",
-          capabilities: {},
+          capabilities,
           clientInfo: { name: "test", version: "1.0" },
         },
       }),
@@ -1080,6 +1087,19 @@ describe("mcp/server", () => {
     });
     assertEquals(server.clientSupportsElicitation("form"), false);
     assertEquals(server.clientSupportsElicitation("url"), false);
+  });
+
+  it("keeps elicitation capabilities isolated per HTTP session", async () => {
+    const server = createMCPServer({ enabled: true });
+    const handler = server.createHTTPHandler();
+
+    const sessionA = await initSessionWithCapabilities(handler, { elicitation: { form: {} } });
+    const sessionB = await initSessionWithCapabilities(handler, { elicitation: { url: {} } });
+
+    assertEquals(server.clientSupportsElicitation("form", sessionA), true);
+    assertEquals(server.clientSupportsElicitation("url", sessionA), false);
+    assertEquals(server.clientSupportsElicitation("form", sessionB), false);
+    assertEquals(server.clientSupportsElicitation("url", sessionB), true);
   });
 
   it("syncs integration config to API on first tools/list call", async () => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -127,9 +127,8 @@ export class MCPServer {
   private sessionManager = new SessionManager();
   private taskStore = new TaskStore();
   private pendingTasks = new Map<string, Promise<void>>();
-  // TODO(#842): capabilities should be stored per-session (keyed by MCP-Session-Id)
-  // so concurrent clients don't overwrite each other's capability flags.
   private clientCapabilities: Record<string, unknown> = {};
+  private sessionCapabilities = new Map<string, Record<string, unknown>>();
 
   /** Callback for server-initiated notifications. Set by transport layer. */
   onNotification?: (notification: { jsonrpc: "2.0"; method: string; params?: unknown }) => void;
@@ -166,8 +165,11 @@ export class MCPServer {
     this.integrationsLoaded = false;
   }
 
-  clientSupportsElicitation(mode: "form" | "url"): boolean {
-    const raw = this.clientCapabilities.elicitation;
+  clientSupportsElicitation(mode: "form" | "url", sessionId?: string): boolean {
+    const capabilities = sessionId
+      ? this.sessionCapabilities.get(sessionId) ?? {}
+      : this.clientCapabilities;
+    const raw = capabilities.elicitation;
     if (!raw || typeof raw !== "object" || Array.isArray(raw)) return false;
     const elicitation = raw as Record<string, unknown>;
     // Per MCP spec: empty elicitation object implies basic form support (backwards compat)
@@ -649,7 +651,10 @@ export class MCPServer {
       // DELETE = terminate session
       if (request.method === "DELETE") {
         const sessionId = request.headers.get("MCP-Session-Id");
-        if (sessionId) this.sessionManager.terminate(sessionId);
+        if (sessionId) {
+          this.sessionManager.terminate(sessionId);
+          this.sessionCapabilities.delete(sessionId);
+        }
         return new Response(null, { status: 200, headers: this.getCORSHeaders(requestOrigin) });
       }
 
@@ -691,7 +696,11 @@ export class MCPServer {
       if (rpcRequest.method === "initialize") {
         const context = this.extractRequestContext(request);
         const rpcResponse = await this.handleRequest(rpcRequest, context);
+        const clientCaps =
+          toParamsRecord(rpcRequest.params).capabilities as Record<string, unknown> ??
+            {};
         const sessionId = this.sessionManager.create();
+        this.sessionCapabilities.set(sessionId, clientCaps);
         responseHeaders["MCP-Session-Id"] = sessionId;
         return createJSONResponse(rpcResponse, { headers: responseHeaders });
       }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.157";
+export const VERSION = "0.1.158";


### PR DESCRIPTION
## Summary
- consolidate remote MCP file API path building helpers
- add happy-path remote file execution coverage
- store MCP client capabilities per HTTP session instead of globally
- bump the release version to `0.1.158`

## Why
This tightens two MCP correctness issues:
1. remote file endpoint path construction was duplicated across several tools
2. HTTP-session client capabilities could leak across sessions because they were stored globally

## Verification
- `deno test --no-check --allow-all cli/mcp/remote-file-tools.test.ts src/mcp/server.test.ts src/utils/version.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts cli/mcp/remote-file-tools.ts cli/mcp/remote-file-tools.test.ts src/mcp/server.ts src/mcp/server.test.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/utils/version-constant.ts cli/mcp/remote-file-tools.ts cli/mcp/remote-file-tools.test.ts src/mcp/server.ts src/mcp/server.test.ts`
- `deno task typecheck`
- `deno task verify:quick`
