### PR TITLE
Add a public human-input wait primitive for hosted agent runs

### DIFF
--- a/docs/reference/agent-runtime-ag-ui.md
+++ b/docs/reference/agent-runtime-ag-ui.md
@@ -63,6 +63,7 @@ For resumable hosted runs, the package also exposes:
 - `createAgUiResumeHandler()`
 - `createAgUiCancelHandler()`
 - `AgUiResumeSignalSchema`
+- `waitForHumanInput()`
 
 ## Convenience Request Shape
 
@@ -115,6 +116,40 @@ export const DELETE = createAgUiCancelHandler({ sessionManager });
 
 These handlers are generic package surfaces. They do not include Veryfront
 control-plane auth/signature requirements.
+
+## Human Input / Approval Waits
+
+Hosts that need a structured user-input or approval step can compose the same
+public run-control seam with `waitForHumanInput()`:
+
+```ts
+import {
+  HumanInputRequestSchema,
+  RunResumeSessionManager,
+  waitForHumanInput,
+} from "veryfront/agent";
+
+const sessionManager = new RunResumeSessionManager<{
+  result: unknown;
+  isError: boolean;
+}>();
+
+const result = await waitForHumanInput({
+  sessionManager,
+  runId: "run_123",
+  toolCallId: "tool_approval",
+  request: HumanInputRequestSchema.parse({
+    title: "Deploy to production?",
+    fields: [{ type: "confirm", name: "approved", label: "Approve deploy?" }],
+  }),
+  onRequest: async (pending) => {
+    // Persist or publish the pending request through your host control plane.
+  },
+});
+```
+
+The host still owns persistence and UI delivery, but the request/result schema
+and the wait/resume loop are now public package substrate.
 
 ## Injected Client Tools
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -23,8 +23,10 @@ import {
   createAgUiResumeHandler,
   createMemory,
   getAgentsAsTools,
+  HumanInputRequestSchema,
   registerAgent,
   RunResumeSessionManager,
+  waitForHumanInput,
 } from "veryfront/agent";
 ```
 
@@ -123,6 +125,42 @@ const assistant = agent({
 
 export const POST = createAgUiHandler({
   agent: assistant,
+});
+```
+
+### Human input over hosted AG-UI runs
+
+```ts
+import {
+  HumanInputRequestSchema,
+  RunResumeSessionManager,
+  waitForHumanInput,
+} from "veryfront/agent";
+
+const sessionManager = new RunResumeSessionManager<{
+  result: unknown;
+  isError: boolean;
+}>();
+
+const request = HumanInputRequestSchema.parse({
+  title: "Deployment confirmation",
+  fields: [
+    {
+      type: "confirm",
+      name: "approved",
+      label: "Ship this change?",
+    },
+  ],
+});
+
+const result = await waitForHumanInput({
+  sessionManager,
+  runId: "run_123",
+  toolCallId: "tool_approve",
+  request,
+  onRequest: async (pending) => {
+    // Persist or publish `pending` through your host control plane.
+  },
 });
 ```
 
@@ -302,6 +340,24 @@ product-specific control plane.
 Use this when a host runtime needs to start a resumable run-local session,
 pause on an external signal, and later submit a resume value for that run.
 
+### `HumanInputRequestSchema`
+
+Validate the canonical request shape for human-input / form-response prompts
+that pause a hosted AG-UI run.
+
+### `HumanInputResultSchema`
+
+Validate the canonical resumed result for a human-input wait. The result is
+submitted through the existing hosted run-control seam as a `tool_result`.
+
+### `waitForHumanInput(options)`
+
+Publish a canonical pending human-input request, wait on a public
+`RunResumeSessionManager`, and validate the resumed result.
+
+Use this when your host runtime needs a generic user-input or approval step
+without re-owning the underlying AG-UI wait/resume mechanics.
+
 ### `agent.getMemory()`
 
 Get the agent's memory instance.
@@ -324,44 +380,52 @@ Clear all stored messages from memory.
 
 ### Functions
 
-| Name                      | Description                                               |
-| ------------------------- | --------------------------------------------------------- |
-| `agent`                   | Create an agent                                           |
-| `agentAsTool`             | Wrap agent as callable tool                               |
-| `createAgUiCancelHandler` | Create a DELETE handler for hosted AG-UI run cancellation |
-| `createAgUiHandler`       | Create a POST handler for an AG-UI route                  |
-| `createAgUiResumeHandler` | Create a POST handler for hosted AG-UI run resume values  |
-| `createChatHandler`       | Create a POST handler for a chat API route.               |
-| `createMemory`            | Create memory (buffer, conversation, summary)             |
-| `createRedisMemory`       | Create Redis-backed memory                                |
-| `createWorkflow`          | Create sequential agent workflow                          |
-| `getAgent`                | Get agent by ID                                           |
-| `getAgentsAsTools`        | Get agents as tools (multi-agent)                         |
-| `getAllAgentIds`          | List registered agent IDs                                 |
-| `getTextFromParts`        | Extract text from multi-part message                      |
-| `getToolArguments`        | Extract parsed tool call args                             |
-| `hasArgs`                 | Check for parsed args on tool call                        |
-| `hasInput`                | Check for raw input on tool call                          |
-| `registerAgent`           | Register agent for discovery                              |
+| Name                      | Description                                                             |
+| ------------------------- | ----------------------------------------------------------------------- |
+| `agent`                   | Create an agent                                                         |
+| `agentAsTool`             | Wrap agent as callable tool                                             |
+| `createAgUiCancelHandler` | Create a DELETE handler for hosted AG-UI run cancellation               |
+| `createAgUiHandler`       | Create a POST handler for an AG-UI route                                |
+| `createAgUiResumeHandler` | Create a POST handler for hosted AG-UI run resume values                |
+| `createChatHandler`       | Create a POST handler for a chat API route.                             |
+| `createMemory`            | Create memory (buffer, conversation, summary)                           |
+| `createRedisMemory`       | Create Redis-backed memory                                              |
+| `createWorkflow`          | Create sequential agent workflow                                        |
+| `getAgent`                | Get agent by ID                                                         |
+| `getAgentsAsTools`        | Get agents as tools (multi-agent)                                       |
+| `getAllAgentIds`          | List registered agent IDs                                               |
+| `getTextFromParts`        | Extract text from multi-part message                                    |
+| `getToolArguments`        | Extract parsed tool call args                                           |
+| `hasArgs`                 | Check for parsed args on tool call                                      |
+| `hasInput`                | Check for raw input on tool call                                        |
+| `registerAgent`           | Register agent for discovery                                            |
+| `waitForHumanInput`       | Wait for a canonical human-input response over hosted AG-UI run control |
 
 ### Classes
 
-| Name                      | Description                                       |
-| ------------------------- | ------------------------------------------------- |
-| `AgentRuntime`            | Agent execution runtime                           |
-| `BufferMemory`            | In-memory message buffer                          |
-| `ConversationMemory`      | Full conversation history                         |
-| `RedisMemory`             | Redis-backed persistent memory                    |
-| `RunResumeSessionManager` | Generic wait/resume manager for hosted agent runs |
-| `SummaryMemory`           | Compresses old messages into summaries            |
+| Name                           | Description                                                              |
+| ------------------------------ | ------------------------------------------------------------------------ |
+| `AgentRuntime`                 | Agent execution runtime                                                  |
+| `BufferMemory`                 | In-memory message buffer                                                 |
+| `ConversationMemory`           | Full conversation history                                                |
+| `HumanInputResumeError`        | Error thrown when a host resumes a human-input wait with `isError: true` |
+| `InvalidHumanInputResultError` | Error thrown when a resumed human-input payload fails schema validation  |
+| `RedisMemory`                  | Redis-backed persistent memory                                           |
+| `RunResumeSessionManager`      | Generic wait/resume manager for hosted agent runs                        |
+| `SummaryMemory`                | Compresses old messages into summaries                                   |
 
 ### Schemas
 
-| Name                       | Description                                                            |
-| -------------------------- | ---------------------------------------------------------------------- |
-| `AgUiRequestSchema`        | Convenience request schema for `createAgUiHandler()`                   |
-| `AgUiRuntimeRequestSchema` | Canonical open-source AG-UI runtime request contract for hosted runs   |
-| `AgUiResumeSignalSchema`   | Canonical hosted-run resume payload for AG-UI tool-result continuation |
+| Name                             | Description                                                            |
+| -------------------------------- | ---------------------------------------------------------------------- |
+| `AgUiRequestSchema`              | Convenience request schema for `createAgUiHandler()`                   |
+| `AgUiRuntimeRequestSchema`       | Canonical open-source AG-UI runtime request contract for hosted runs   |
+| `AgUiResumeSignalSchema`         | Canonical hosted-run resume payload for AG-UI tool-result continuation |
+| `HumanInputFieldSchema`          | Canonical human-input field schema                                     |
+| `HumanInputOptionSchema`         | Canonical human-input option schema                                    |
+| `HumanInputPendingRequestSchema` | Canonical pending human-input request envelope for hosts               |
+| `HumanInputRequestSchema`        | Canonical human-input request payload                                  |
+| `HumanInputResultSchema`         | Canonical human-input resumed result payload                           |
 
 ### Types
 
@@ -382,9 +446,17 @@ Clear all stored messages from memory.
 | `AgUiRequest`                    | Validated AG-UI runtime request body                                         |
 | `AgUiResumeHandlerOptions`       | Options for `createAgUiResumeHandler`                                        |
 | `AgUiResumeSignal`               | Validated hosted-run resume payload                                          |
+| `HumanInputField`                | Canonical form/input field definition                                        |
+| `HumanInputFieldInput`           | Input shape accepted by `waitForHumanInput()` before defaults normalize      |
+| `HumanInputOption`               | Canonical select/radio option definition                                     |
+| `HumanInputPendingRequest`       | Pending human-input envelope passed to `onRequest`                           |
+| `HumanInputRequest`              | Normalized human-input request payload                                       |
+| `HumanInputRequestInput`         | Input shape accepted by `HumanInputRequestSchema`                            |
+| `HumanInputResult`               | Validated human-input resumed result                                         |
 | `RunResumeSessionManagerOptions` | Options for `RunResumeSessionManager`                                        |
 | `RunSessionStatus`               | Status of a resumable run session                                            |
 | `SubmitResumeValueOutcome`       | Result of submitting an accepted or duplicate resume value                   |
+| `WaitForHumanInputOptions`       | Options for `waitForHumanInput()`                                            |
 | `ChatHandlerBeforeStream`        | Hook signature for `createChatHandler` customization before streaming.       |
 | `ChatHandlerBeforeStreamContext` | Input passed to `beforeStream` hook.                                         |
 | `ChatHandlerBeforeStreamResult`  | Message/context mutations returned from `beforeStream`.                      |

--- a/scripts/docs/verify-npm-exports.mjs
+++ b/scripts/docs/verify-npm-exports.mjs
@@ -48,6 +48,8 @@ const REQUIRED_EXPORTS = {
     "AgentRuntime",
     "RunResumeSessionManager",
     "createAgUiHandler",
+    "waitForHumanInput",
+    "HumanInputRequestSchema",
     "registerAgent",
     "getAgentsAsTools",
     "agentAsTool",

--- a/scripts/docs/verify-npm-node.mjs
+++ b/scripts/docs/verify-npm-node.mjs
@@ -95,13 +95,15 @@ try {
   const agentMod = await imp("./agent");
   assertType(agentMod.agent, "function", "agent() is function");
   assertType(agentMod.createAgUiHandler, "function", "createAgUiHandler is function");
+  assertType(agentMod.waitForHumanInput, "function", "waitForHumanInput is function");
   assertType(agentMod.registerAgent, "function", "registerAgent is function");
   assertType(agentMod.getAgentsAsTools, "function", "getAgentsAsTools is function");
   assertType(agentMod.agentAsTool, "function", "agentAsTool is function");
   assertType(agentMod.createMemory, "function", "createMemory is function");
   assert(agentMod.AgentRuntime !== undefined, "AgentRuntime exists");
   assert(agentMod.RunResumeSessionManager !== undefined, "RunResumeSessionManager exists");
-  console.log("  OK    agent — 8 checks");
+  assert(agentMod.HumanInputRequestSchema !== undefined, "HumanInputRequestSchema exists");
+  console.log("  OK    agent — 10 checks");
 } catch (err) {
   failed++;
   errors.push(`agent: ${err.message}`);

--- a/src/agent/human-input.test.ts
+++ b/src/agent/human-input.test.ts
@@ -1,0 +1,166 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { RunCancelledError, RunResumeSessionManager } from "./index.ts";
+import {
+  HumanInputPendingRequestSchema,
+  HumanInputResultSchema,
+  HumanInputResumeError,
+  InvalidHumanInputResultError,
+  waitForHumanInput,
+} from "./human-input.ts";
+
+describe("agent/human-input", () => {
+  it("publishes a canonical pending request and resolves submitted values", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    let published: unknown;
+
+    const pending = waitForHumanInput({
+      sessionManager,
+      runId: "run_1",
+      toolCallId: "tool_1",
+      request: {
+        title: "Repository details",
+        fields: [
+          {
+            type: "text",
+            name: "repo",
+            label: "Repository",
+            required: true,
+          },
+        ],
+      },
+      onRequest: (value) => {
+        published = value;
+      },
+    });
+    await Promise.resolve();
+
+    const submitOutcome = sessionManager.submitSignal("run_1", {
+      waitKey: "tool_1",
+      value: {
+        result: {
+          submitted: true,
+          values: {
+            repo: "veryfront",
+          },
+        },
+        isError: false,
+      },
+    });
+
+    assertEquals(submitOutcome, { accepted: true });
+    assertEquals(HumanInputPendingRequestSchema.parse(published), {
+      runId: "run_1",
+      toolCallId: "tool_1",
+      request: {
+        title: "Repository details",
+        fields: [
+          {
+            type: "text",
+            name: "repo",
+            label: "Repository",
+            required: true,
+            secret: false,
+          },
+        ],
+        submitLabel: "Submit",
+      },
+    });
+    assertEquals(HumanInputResultSchema.parse(await pending), {
+      submitted: true,
+      values: {
+        repo: "veryfront",
+      },
+    });
+  });
+
+  it("rejects malformed resumed values with a stable public error", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    const pending = waitForHumanInput({
+      sessionManager,
+      runId: "run_1",
+      toolCallId: "tool_1",
+      request: {
+        title: "Repository details",
+        fields: [{ type: "text", name: "repo", label: "Repository" }],
+      },
+    });
+    await Promise.resolve();
+
+    sessionManager.submitSignal("run_1", {
+      waitKey: "tool_1",
+      value: {
+        result: { invalid: true },
+        isError: false,
+      },
+    });
+
+    await assertRejects(
+      () => pending,
+      InvalidHumanInputResultError,
+      "Invalid human input resume payload",
+    );
+  });
+
+  it("surfaces explicit resume errors from the host seam", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    const pending = waitForHumanInput({
+      sessionManager,
+      runId: "run_1",
+      toolCallId: "tool_1",
+      request: {
+        title: "Repository details",
+        fields: [{ type: "text", name: "repo", label: "Repository" }],
+      },
+    });
+    await Promise.resolve();
+
+    sessionManager.submitSignal("run_1", {
+      waitKey: "tool_1",
+      value: {
+        result: "input request expired",
+        isError: true,
+      },
+    });
+
+    await assertRejects(() => pending, HumanInputResumeError, "input request expired");
+  });
+
+  it("propagates run cancellation while waiting for input", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    const pending = waitForHumanInput({
+      sessionManager,
+      runId: "run_1",
+      toolCallId: "tool_1",
+      request: {
+        title: "Repository details",
+        fields: [{ type: "text", name: "repo", label: "Repository" }],
+      },
+    });
+    await Promise.resolve();
+
+    sessionManager.cancelRun("run_1");
+
+    await assertRejects(() => pending, RunCancelledError);
+  });
+});

--- a/src/agent/human-input.ts
+++ b/src/agent/human-input.ts
@@ -1,0 +1,152 @@
+import { z } from "zod";
+import { AgUiRuntimeRunIdSchema } from "./runtime-ag-ui-contract.ts";
+import { RunResumeSessionManager } from "./runtime/index.ts";
+
+const TOOL_CALL_ID_SCHEMA = z.string().min(1).max(128);
+
+export const HumanInputOptionSchema = z.object({
+  value: z.string(),
+  label: z.string(),
+  description: z.string().optional(),
+  recommended: z.boolean().optional(),
+});
+
+const BaseHumanInputFieldSchema = z.object({
+  name: z.string().min(1).max(128),
+  label: z.string().min(1).max(256),
+  description: z.string().max(1024).optional(),
+  required: z.boolean().optional().default(false),
+  secret: z.boolean().optional().default(false),
+});
+
+export const HumanInputFieldSchema = z.discriminatedUnion("type", [
+  BaseHumanInputFieldSchema.extend({
+    type: z.enum(["text", "email", "url", "password", "number"]),
+    placeholder: z.string().max(512).optional(),
+    defaultValue: z.string().optional(),
+    pattern: z.string().max(512).optional(),
+    minLength: z.number().int().nonnegative().optional(),
+    maxLength: z.number().int().positive().optional(),
+    min: z.number().optional(),
+    max: z.number().optional(),
+  }),
+  BaseHumanInputFieldSchema.extend({
+    type: z.literal("textarea"),
+    placeholder: z.string().max(512).optional(),
+    defaultValue: z.string().optional(),
+    minLength: z.number().int().nonnegative().optional(),
+    maxLength: z.number().int().positive().optional(),
+    rows: z.number().int().positive().optional().default(3),
+  }),
+  BaseHumanInputFieldSchema.extend({
+    type: z.literal("select"),
+    options: z.array(HumanInputOptionSchema).min(1),
+    defaultValue: z.string().optional(),
+    placeholder: z.string().max(512).optional(),
+  }),
+  BaseHumanInputFieldSchema.extend({
+    type: z.literal("checkbox"),
+    defaultValue: z.boolean().optional().default(false),
+  }),
+  BaseHumanInputFieldSchema.extend({
+    type: z.literal("radio"),
+    options: z.array(HumanInputOptionSchema).min(1),
+    defaultValue: z.string().optional(),
+  }),
+  BaseHumanInputFieldSchema.extend({
+    type: z.literal("confirm"),
+    confirmLabel: z.string().max(64).optional().default("Yes"),
+    denyLabel: z.string().max(64).optional().default("No"),
+  }),
+]);
+
+export const HumanInputRequestSchema = z.object({
+  title: z.string().min(1).max(256),
+  description: z.string().max(2048).optional(),
+  fields: z.array(HumanInputFieldSchema).min(1),
+  submitLabel: z.string().max(64).optional().default("Submit"),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const HumanInputResponseValuesSchema = z.record(
+  z.string(),
+  z.union([z.string(), z.boolean(), z.number(), z.null()]),
+);
+
+export const HumanInputResultSchema = z.discriminatedUnion("submitted", [
+  z.object({
+    submitted: z.literal(true),
+    values: HumanInputResponseValuesSchema,
+  }),
+  z.object({
+    submitted: z.literal(false),
+    values: HumanInputResponseValuesSchema.default({}),
+  }),
+]);
+
+export const HumanInputPendingRequestSchema = z.object({
+  runId: AgUiRuntimeRunIdSchema,
+  toolCallId: TOOL_CALL_ID_SCHEMA,
+  request: HumanInputRequestSchema,
+});
+
+export type HumanInputOption = z.infer<typeof HumanInputOptionSchema>;
+export type HumanInputField = z.infer<typeof HumanInputFieldSchema>;
+export type HumanInputFieldInput = z.input<typeof HumanInputFieldSchema>;
+export type HumanInputRequest = z.infer<typeof HumanInputRequestSchema>;
+export type HumanInputRequestInput = z.input<typeof HumanInputRequestSchema>;
+export type HumanInputResult = z.infer<typeof HumanInputResultSchema>;
+export type HumanInputPendingRequest = z.infer<typeof HumanInputPendingRequestSchema>;
+
+type HumanInputResumeValue = {
+  result: unknown;
+  isError: boolean;
+};
+
+export interface WaitForHumanInputOptions {
+  sessionManager: RunResumeSessionManager<HumanInputResumeValue>;
+  runId: string;
+  toolCallId: string;
+  request: HumanInputRequestInput;
+  onRequest?: ((request: HumanInputPendingRequest) => void | Promise<void>) | undefined;
+}
+
+export class HumanInputResumeError extends Error {
+  constructor(readonly detail: unknown) {
+    super(
+      typeof detail === "string" ? detail : "Human input resume failed",
+    );
+    this.name = "HumanInputResumeError";
+  }
+}
+
+export class InvalidHumanInputResultError extends Error {
+  constructor(readonly detail: z.ZodIssue[]) {
+    super("Invalid human input resume payload");
+    this.name = "InvalidHumanInputResultError";
+  }
+}
+
+export async function waitForHumanInput(
+  options: WaitForHumanInputOptions,
+): Promise<HumanInputResult> {
+  const pendingRequest = HumanInputPendingRequestSchema.parse({
+    runId: options.runId,
+    toolCallId: options.toolCallId,
+    request: options.request,
+  });
+
+  await options.onRequest?.(pendingRequest);
+
+  const resumed = await options.sessionManager.waitForSignal(options.runId, options.toolCallId);
+  if (resumed.isError) {
+    throw new HumanInputResumeError(resumed.result);
+  }
+
+  const parsed = HumanInputResultSchema.safeParse(resumed.result);
+  if (!parsed.success) {
+    throw new InvalidHumanInputResultError(parsed.error.issues);
+  }
+
+  return parsed.data;
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -161,6 +161,24 @@ export {
   createAgUiHandler,
 } from "./ag-ui-handler.ts";
 export {
+  type HumanInputField,
+  type HumanInputFieldInput,
+  HumanInputFieldSchema,
+  type HumanInputOption,
+  HumanInputOptionSchema,
+  type HumanInputPendingRequest,
+  HumanInputPendingRequestSchema,
+  type HumanInputRequest,
+  type HumanInputRequestInput,
+  HumanInputRequestSchema,
+  type HumanInputResult,
+  HumanInputResultSchema,
+  HumanInputResumeError,
+  InvalidHumanInputResultError,
+  waitForHumanInput,
+  type WaitForHumanInputOptions,
+} from "./human-input.ts";
+export {
   type ChatHandlerBeforeStream,
   type ChatHandlerBeforeStreamContext,
   type ChatHandlerBeforeStreamResult,


### PR DESCRIPTION
## Summary
- add a public `veryfront/agent` human-input primitive over `RunResumeSessionManager`
- expose canonical request, pending-request, and result contracts for hosted AG-UI waits
- document the new public surface and extend package export smoke checks for the new agent exports

## Why
- closes `veryfront-code#934`
- removes another `veryfront-agent` migration blocker by giving hosts a framework-owned way to pause on required human input and resume through the existing public AG-UI run-control seam

## Verification
- `deno test --allow-all src/agent/human-input.test.ts src/agent/ag-ui-run-control.test.ts src/agent/ag-ui-handler.test.ts`
- `deno task verify`
- branch pre-push gate passed

## Notes
- `node scripts/docs/verify-npm-node.mjs` and `node scripts/docs/verify-npm-exports.mjs` still hit the pre-existing `veryfront/chat` `AIErrorBoundary` expectation drift; that mismatch is unrelated to this PR and remains out of scope here
