### PR TITLE
Extract testable Node import-rewrite helpers from module-loader

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.158",
+  "version": "0.1.159",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -1,7 +1,12 @@
 import { assertEquals, assertMatch, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path";
-import { loadHandlerModule, toCjsDestructureBindings } from "./loader.ts";
+import {
+  getNodeExternalPackagesToResolve,
+  loadHandlerModule,
+  rewriteNodeExternalImports,
+  toCjsDestructureBindings,
+} from "./loader.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { env, getEnv, setEnv } from "#veryfront/compat/process.ts";
@@ -280,6 +285,62 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
       toCjsDestructureBindings("{ foo, bar }"),
       "{ foo, bar }",
     );
+  });
+
+  it("builds the node external package resolution list without duplicates", () => {
+    const packages = getNodeExternalPackagesToResolve(
+      new Map([
+        ["pdf-parse", "^1.1.1"],
+        ["zod", "^3.22.0"],
+        ["another-lib", "^1.0.0"],
+      ]),
+    );
+
+    assertEquals(packages, ["zod", "pdf-parse", "another-lib"]);
+  });
+
+  it("rewrites bare veryfront imports using the package export map", async () => {
+    const tmpDir = await makeTempDir();
+    const vfDir = join(tmpDir, "node_modules", "veryfront");
+    await fs.mkdir(vfDir, { recursive: true });
+    await fs.writeTextFile(
+      join(vfDir, "package.json"),
+      JSON.stringify({
+        exports: {
+          ".": { import: "./dist/index.js" },
+        },
+      }),
+    );
+
+    const rewritten = await rewriteNodeExternalImports(
+      'import { defineConfig } from "veryfront";',
+      tmpDir,
+      fs,
+      new Map(),
+    );
+
+    assertMatch(rewritten, /from "file:\/\/.*node_modules\/veryfront\/dist\/index\.js"/);
+  });
+
+  it("rewrites imported user dependencies to resolved node_modules file URLs", async () => {
+    const tmpDir = await makeTempDir();
+    const depDir = join(tmpDir, "node_modules", "my-lib");
+    await fs.mkdir(depDir, { recursive: true });
+    await fs.writeTextFile(
+      join(depDir, "package.json"),
+      JSON.stringify({
+        main: "./dist/index.js",
+      }),
+    );
+
+    const rewritten = await rewriteNodeExternalImports(
+      'import thing from "my-lib";',
+      tmpDir,
+      fs,
+      new Map([["my-lib", "^1.0.0"]]),
+    );
+
+    assertMatch(rewritten, /from "file:\/\/.*node_modules\/my-lib\/dist\/index\.js"/);
   });
 
   it("rejects module path that escapes project directory via traversal", async () => {

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -660,6 +660,145 @@ async function loadModuleFromCode(
   }
 }
 
+export function getNodeExternalPackagesToResolve(userDeps: Map<string, string>): string[] {
+  const externalPackagesToResolve = ["zod"];
+
+  for (const name of userDeps.keys()) {
+    if (!externalPackagesToResolve.includes(name)) {
+      externalPackagesToResolve.push(name);
+    }
+  }
+
+  return externalPackagesToResolve;
+}
+
+export async function resolveNodePackageToFileUrl(
+  projectDir: string,
+  packageName: string,
+  fs: FileSystem,
+  pathToFileURL: typeof import("node:url").pathToFileURL,
+): Promise<string | null> {
+  const packagePath = pathHelper.join(projectDir, "node_modules", packageName);
+  const packageJsonPath = pathHelper.join(packagePath, "package.json");
+
+  try {
+    const pkgJson = JSON.parse(await fs.readTextFile(packageJsonPath));
+    let entryPoint: string | undefined;
+
+    if (pkgJson.exports) {
+      entryPoint = resolveExportEntry(pkgJson.exports["."]);
+    }
+
+    entryPoint ||= pkgJson.module || pkgJson.main || "index.js";
+    if (!entryPoint) return null;
+
+    return pathToFileURL(pathHelper.join(packagePath, entryPoint)).href;
+  } catch (_) {
+    /* expected: package.json may not exist or be invalid */
+    return null;
+  }
+}
+
+export async function loadVeryfrontExportsMap(
+  projectDir: string,
+  fs: FileSystem,
+): Promise<Record<string, { import?: string }>> {
+  const vfPackagePath = pathHelper.join(projectDir, "node_modules", "veryfront");
+  const vfPackageJsonPath = pathHelper.join(vfPackagePath, "package.json");
+
+  try {
+    const pkgJson = JSON.parse(await fs.readTextFile(vfPackageJsonPath));
+    return pkgJson.exports || {};
+  } catch (_error) {
+    logger.debug("Could not read veryfront package.json");
+    return {};
+  }
+}
+
+export async function rewriteNodeExternalImports(
+  code: string,
+  projectDir: string,
+  fs: FileSystem,
+  userDeps: Map<string, string>,
+): Promise<string> {
+  const { pathToFileURL } = await import("node:url");
+  let transformed = code;
+
+  logger.debug(`Rewriting external imports for Node.js, projectDir: ${projectDir}`);
+
+  for (const pkg of getNodeExternalPackagesToResolve(userDeps)) {
+    const escapedPkg = pkg.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+    const staticImportRegex = new RegExp(`from\\s*["']${escapedPkg}(/[^"']*)?["']`, "g");
+    const dynamicImportRegex = new RegExp(
+      `import\\s*\\(\\s*["']${escapedPkg}(/[^"']*)?["']\\s*\\)`,
+      "g",
+    );
+
+    const needsStatic = staticImportRegex.test(transformed);
+    staticImportRegex.lastIndex = 0;
+    const needsDynamic = dynamicImportRegex.test(transformed);
+    dynamicImportRegex.lastIndex = 0;
+    if (!needsStatic && !needsDynamic) continue;
+
+    const packageDir = pathToFileURL(pathHelper.join(projectDir, "node_modules", pkg)).href;
+    const resolvedUrl = await resolveNodePackageToFileUrl(projectDir, pkg, fs, pathToFileURL);
+
+    if (needsStatic) {
+      transformed = transformed.replace(staticImportRegex, (_, subpath) => {
+        if (subpath) {
+          const subUrl = `${packageDir}${subpath}`;
+          logger.debug(`Resolved ${pkg}${subpath} -> ${subUrl}`);
+          return `from "${subUrl}"`;
+        }
+        if (!resolvedUrl) return `from "${pkg}"`;
+        logger.debug(`Resolved ${pkg} -> ${resolvedUrl}`);
+        return `from "${resolvedUrl}"`;
+      });
+    }
+
+    if (needsDynamic) {
+      transformed = transformed.replace(dynamicImportRegex, (_, subpath) => {
+        if (subpath) {
+          return `import("${packageDir}${subpath}")`;
+        }
+        if (!resolvedUrl) return `import("${pkg}")`;
+        return `import("${resolvedUrl}")`;
+      });
+    }
+  }
+
+  const vfPackagePath = pathHelper.join(projectDir, "node_modules", "veryfront");
+  const exportsMap = await loadVeryfrontExportsMap(projectDir, fs);
+
+  transformed = transformed.replace(
+    /from\s+["'](veryfront\/[^"']+)["']/g,
+    (match, fullSpecifier: string) => {
+      const subpath = "./" + fullSpecifier.replace("veryfront/", "");
+      const exportEntry = exportsMap[subpath];
+      if (!exportEntry?.import) {
+        logger.warn(`No export found for ${subpath}`);
+        return match;
+      }
+
+      const resolvedPath = pathHelper.join(vfPackagePath, exportEntry.import);
+      logger.debug(`Resolved ${fullSpecifier} -> ${resolvedPath}`);
+      return `from "${pathToFileURL(resolvedPath).href}"`;
+    },
+  );
+
+  transformed = transformed.replace(/from\s+["']veryfront["']/g, () => {
+    const exportEntry = exportsMap["."];
+    if (!exportEntry?.import) return 'from "veryfront"';
+
+    const resolvedPath = pathHelper.join(vfPackagePath, exportEntry.import);
+    logger.debug(`Resolved veryfront -> ${resolvedPath}`);
+    return `from "${pathToFileURL(resolvedPath).href}"`;
+  });
+
+  return transformed;
+}
+
 async function rewriteExternalImports(
   code: string,
   projectDir: string,
@@ -670,119 +809,7 @@ async function rewriteExternalImports(
 
   if (isNode) {
     try {
-      const { pathToFileURL } = await import("node:url");
-
-      logger.debug(`Rewriting external imports for Node.js, projectDir: ${projectDir}`);
-
-      const resolvePackageToFileUrl = async (packageName: string): Promise<string | null> => {
-        const packagePath = pathHelper.join(projectDir, "node_modules", packageName);
-        const packageJsonPath = pathHelper.join(packagePath, "package.json");
-
-        try {
-          const pkgJson = JSON.parse(await fs.readTextFile(packageJsonPath));
-          let entryPoint: string | undefined;
-
-          if (pkgJson.exports) {
-            entryPoint = resolveExportEntry(pkgJson.exports["."]);
-          }
-
-          entryPoint ||= pkgJson.module || pkgJson.main || "index.js";
-          if (!entryPoint) return null;
-
-          return pathToFileURL(pathHelper.join(packagePath, entryPoint)).href;
-        } catch (_) {
-          /* expected: package.json may not exist or be invalid */
-          return null;
-        }
-      };
-
-      const externalPackagesToResolve = ["zod"];
-
-      for (const name of userDeps.keys()) {
-        if (!externalPackagesToResolve.includes(name)) {
-          externalPackagesToResolve.push(name);
-        }
-      }
-
-      for (const pkg of externalPackagesToResolve) {
-        const escapedPkg = pkg.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
-        // Match both exact imports (from "pkg") and subpath imports (from "pkg/sub")
-        const staticImportRegex = new RegExp(`from\\s*["']${escapedPkg}(/[^"']*)?["']`, "g");
-        const dynamicImportRegex = new RegExp(
-          `import\\s*\\(\\s*["']${escapedPkg}(/[^"']*)?["']\\s*\\)`,
-          "g",
-        );
-
-        const needsStatic = staticImportRegex.test(transformed);
-        staticImportRegex.lastIndex = 0;
-        const needsDynamic = dynamicImportRegex.test(transformed);
-        dynamicImportRegex.lastIndex = 0;
-        if (!needsStatic && !needsDynamic) continue;
-
-        const packageDir = pathToFileURL(pathHelper.join(projectDir, "node_modules", pkg)).href;
-        const resolvedUrl = await resolvePackageToFileUrl(pkg);
-
-        if (needsStatic) {
-          transformed = transformed.replace(staticImportRegex, (_, subpath) => {
-            if (subpath) {
-              const subUrl = `${packageDir}${subpath}`;
-              logger.debug(`Resolved ${pkg}${subpath} -> ${subUrl}`);
-              return `from "${subUrl}"`;
-            }
-            if (!resolvedUrl) return `from "${pkg}"`;
-            logger.debug(`Resolved ${pkg} -> ${resolvedUrl}`);
-            return `from "${resolvedUrl}"`;
-          });
-        }
-
-        if (needsDynamic) {
-          transformed = transformed.replace(dynamicImportRegex, (_, subpath) => {
-            if (subpath) {
-              const subUrl = `${packageDir}${subpath}`;
-              return `import("${subUrl}")`;
-            }
-            if (!resolvedUrl) return `import("${pkg}")`;
-            return `import("${resolvedUrl}")`;
-          });
-        }
-      }
-
-      const vfPackagePath = pathHelper.join(projectDir, "node_modules", "veryfront");
-      const vfPackageJsonPath = pathHelper.join(vfPackagePath, "package.json");
-
-      let exportsMap: Record<string, { import?: string }> = {};
-      try {
-        const pkgJson = JSON.parse(await fs.readTextFile(vfPackageJsonPath));
-        exportsMap = pkgJson.exports || {};
-      } catch (_error) {
-        logger.debug(`Could not read veryfront package.json: `);
-      }
-
-      transformed = transformed.replace(
-        /from\s+["'](veryfront\/[^"']+)["']/g,
-        (match, fullSpecifier: string) => {
-          const subpath = "./" + fullSpecifier.replace("veryfront/", "");
-          const exportEntry = exportsMap[subpath];
-          if (!exportEntry?.import) {
-            logger.warn(`No export found for ${subpath}`);
-            return match;
-          }
-
-          const resolvedPath = pathHelper.join(vfPackagePath, exportEntry.import);
-          logger.debug(`Resolved ${fullSpecifier} -> ${resolvedPath}`);
-          return `from "${pathToFileURL(resolvedPath).href}"`;
-        },
-      );
-
-      transformed = transformed.replace(/from\s+["']veryfront["']/g, () => {
-        const exportEntry = exportsMap["."];
-        if (!exportEntry?.import) return 'from "veryfront"';
-
-        const resolvedPath = pathHelper.join(vfPackagePath, exportEntry.import);
-        logger.debug(`Resolved veryfront -> ${resolvedPath}`);
-        return `from "${pathToFileURL(resolvedPath).href}"`;
-      });
+      transformed = await rewriteNodeExternalImports(transformed, projectDir, fs, userDeps);
     } catch (e) {
       logger.warn(`Failed to import node:module: ${e}`);
     }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.158";
+export const VERSION = "0.1.159";


### PR DESCRIPTION
## Summary
- extract Node-side package and `veryfront` import rewrite logic into focused helpers
- add helper-level regression tests for package resolution and root `veryfront` import rewriting
- bump the release version to `0.1.159`

## Why
`rewriteExternalImports()` was carrying too many responsibilities inside one hotspot. This slice only pulls out the Node-specific package/import rewrite responsibilities so the module-loader becomes easier to reason about and test incrementally.

## Verification
- `deno test --no-check --allow-all src/routing/api/module-loader/loader.test.ts src/utils/version.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts src/routing/api/module-loader/loader.ts src/routing/api/module-loader/loader.test.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/utils/version-constant.ts src/routing/api/module-loader/loader.ts src/routing/api/module-loader/loader.test.ts`
- `deno task typecheck`
- `deno task verify:quick`
- architect review: APPROVE
