### PR TITLE
Split MCP HTTP transport from server protocol core

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.159",
+  "version": "0.1.160",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -1,0 +1,162 @@
+import type { ToolExecutionContext } from "#veryfront/tool";
+import { VeryfrontError } from "#veryfront/security/input-validation/errors.ts";
+import { validateContentType } from "#veryfront/security/input-validation/limits.ts";
+import { SessionManager } from "./session.ts";
+
+const MAX_REQUEST_BODY_SIZE = 1_048_576; // 1 MB
+const JSON_CONTENT_TYPE = "application/json";
+
+type JSONRPCParams = Record<string, unknown> | unknown[];
+
+interface JSONRPCRequest {
+  jsonrpc: "2.0";
+  id?: string | number;
+  method: string;
+  params?: JSONRPCParams;
+}
+
+interface JSONRPCResponse {
+  jsonrpc: "2.0";
+  id?: string | number;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+export interface MCPHTTPTransportDependencies {
+  authEnabled: boolean;
+  getCORSHeaders: (requestOrigin?: string | null) => Record<string, string>;
+  validateAuth: (request: Request) => Promise<boolean>;
+  handleRequest: (
+    request: JSONRPCRequest,
+    context?: ToolExecutionContext,
+  ) => Promise<JSONRPCResponse>;
+  extractRequestContext: (request: Request) => ToolExecutionContext | undefined;
+  isOriginAllowed: (requestOrigin?: string | null) => boolean;
+  sessionCapabilities: Map<string, Record<string, unknown>>;
+  sessionManager: SessionManager;
+}
+
+function createJSONResponse(body: unknown, init?: ResponseInit): Response {
+  const headers = new Headers(init?.headers);
+  headers.set("Content-Type", JSON_CONTENT_TYPE);
+  return new Response(JSON.stringify(body), { ...init, headers });
+}
+
+function createJSONRPCErrorResponse(status: number, code: number, message: string): Response {
+  return createJSONResponse(
+    {
+      jsonrpc: "2.0",
+      id: null,
+      error: { code, message },
+    },
+    { status },
+  );
+}
+
+export function createMCPHTTPHandler(
+  dependencies: MCPHTTPTransportDependencies,
+): (request: Request) => Promise<Response> {
+  const {
+    authEnabled,
+    getCORSHeaders,
+    validateAuth,
+    handleRequest,
+    extractRequestContext,
+    isOriginAllowed,
+    sessionCapabilities,
+    sessionManager,
+  } = dependencies;
+
+  return async (request: Request) => {
+    const requestOrigin = request.headers.get("Origin");
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: getCORSHeaders(requestOrigin) });
+    }
+
+    if (!isOriginAllowed(requestOrigin)) {
+      return createJSONRPCErrorResponse(403, -32600, "Forbidden: Origin not allowed");
+    }
+
+    if (authEnabled) {
+      const authorized = await validateAuth(request);
+      if (!authorized) return new Response("Unauthorized", { status: 401 });
+    }
+
+    if (request.method === "DELETE") {
+      const sessionId = request.headers.get("MCP-Session-Id");
+      if (sessionId) {
+        sessionManager.terminate(sessionId);
+        sessionCapabilities.delete(sessionId);
+      }
+      return new Response(null, { status: 200, headers: getCORSHeaders(requestOrigin) });
+    }
+
+    if (request.method !== "POST") {
+      return new Response("Method Not Allowed", { status: 405 });
+    }
+
+    const contentLength = request.headers.get("content-length");
+    if (contentLength && Number(contentLength) > MAX_REQUEST_BODY_SIZE) {
+      return createJSONRPCErrorResponse(413, -32600, "Request body too large");
+    }
+
+    try {
+      validateContentType(request, JSON_CONTENT_TYPE);
+    } catch (error) {
+      const message = error instanceof VeryfrontError ? error.message : "Invalid Content-Type";
+      return createJSONRPCErrorResponse(400, -32700, message);
+    }
+
+    let rpcRequest: JSONRPCRequest;
+    try {
+      const bodyText = await request.text();
+      if (bodyText.length > MAX_REQUEST_BODY_SIZE) {
+        return createJSONRPCErrorResponse(413, -32600, "Request body too large");
+      }
+      rpcRequest = JSON.parse(bodyText) as JSONRPCRequest;
+    } catch (_) {
+      return createJSONRPCErrorResponse(400, -32700, "Parse error");
+    }
+
+    const responseHeaders: Record<string, string> = {
+      ...getCORSHeaders(requestOrigin),
+    };
+
+    if (rpcRequest.method === "initialize") {
+      const context = extractRequestContext(request);
+      const rpcResponse = await handleRequest(rpcRequest, context);
+      const clientCaps =
+        ((rpcRequest.params as Record<string, unknown> | undefined)?.capabilities ??
+          {}) as Record<string, unknown>;
+      const sessionId = sessionManager.create();
+      sessionCapabilities.set(sessionId, clientCaps);
+      responseHeaders["MCP-Session-Id"] = sessionId;
+      return createJSONResponse(rpcResponse, { headers: responseHeaders });
+    }
+
+    if (sessionManager.size > 0) {
+      const sessionId = request.headers.get("MCP-Session-Id");
+      if (!sessionId) {
+        return createJSONRPCErrorResponse(400, -32600, "Missing MCP-Session-Id header");
+      }
+      if (!sessionManager.isValid(sessionId)) {
+        return createJSONRPCErrorResponse(404, -32600, "Session not found or expired");
+      }
+    }
+
+    if (rpcRequest.id === undefined) {
+      const context = extractRequestContext(request);
+      await handleRequest(rpcRequest, context);
+      return new Response(null, { status: 202, headers: responseHeaders });
+    }
+
+    const context = extractRequestContext(request);
+    const rpcResponse = await handleRequest(rpcRequest, context);
+    return createJSONResponse(rpcResponse, { headers: responseHeaders });
+  };
+}

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1176,6 +1176,15 @@ describe("mcp/server", () => {
       const sessionId = response.headers.get("MCP-Session-Id");
       assertExists(sessionId);
       assertEquals(sessionId.length > 0, true);
+
+      const body = await response.json() as {
+        result: {
+          protocolVersion: string;
+          serverInfo: { name: string };
+        };
+      };
+      assertEquals(body.result.protocolVersion, "2025-11-25");
+      assertEquals(body.result.serverInfo.name, "veryfront-mcp");
     });
 
     it("returns 400 when MCP-Session-Id is missing on post-init request", async () => {
@@ -1258,6 +1267,23 @@ describe("mcp/server", () => {
         }),
       );
       assertEquals(okResponse.status, 200);
+    });
+
+    it("clears session-scoped elicitation capabilities after DELETE", async () => {
+      const server = createMCPServer({ enabled: true });
+      const handler = server.createHTTPHandler();
+
+      const sessionId = await initSessionWithCapabilities(handler, { elicitation: { form: {} } });
+      assertEquals(server.clientSupportsElicitation("form", sessionId), true);
+
+      const deleteResponse = await handler(
+        new Request("http://localhost/mcp", {
+          method: "DELETE",
+          headers: { "MCP-Session-Id": sessionId },
+        }),
+      );
+      assertEquals(deleteResponse.status, 200);
+      assertEquals(server.clientSupportsElicitation("form", sessionId), false);
     });
 
     it("returns 202 for JSON-RPC notifications", async () => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,18 +8,14 @@ import type { MCPServerConfig, ToolListEntry } from "./types.ts";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { VERSION } from "#veryfront/utils/version.ts";
-import { validateContentType } from "#veryfront/security/input-validation/limits.ts";
-import { VeryfrontError } from "#veryfront/security/input-validation/errors.ts";
 import type { IntegrationRuntimeConfig } from "../integrations/types.ts";
 import { logger as baseLogger } from "#veryfront/utils";
+import { createMCPHTTPHandler } from "./http-transport.ts";
 import { SessionManager } from "./session.ts";
 import { TaskStore } from "./task-store.ts";
 
 const logger = baseLogger.component("mcp-server");
-
-const MAX_REQUEST_BODY_SIZE = 1_048_576; // 1 MB
 const MAX_CONTEXT_HEADER_LENGTH = 255;
-const JSON_CONTENT_TYPE = "application/json";
 const END_USER_ID_PATTERN = /^[a-zA-Z0-9._@-]+$/;
 const PROJECT_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
 
@@ -52,23 +48,6 @@ function errorMessage(error: unknown): string {
 function toParamsRecord(params: JSONRPCParams | undefined): Record<string, unknown> {
   if (!params || Array.isArray(params)) return {};
   return params;
-}
-
-function createJSONResponse(body: unknown, init?: ResponseInit): Response {
-  const headers = new Headers(init?.headers);
-  headers.set("Content-Type", JSON_CONTENT_TYPE);
-  return new Response(JSON.stringify(body), { ...init, headers });
-}
-
-function createJSONRPCErrorResponse(status: number, code: number, message: string): Response {
-  return createJSONResponse(
-    {
-      jsonrpc: "2.0",
-      id: null,
-      error: { code, message },
-    },
-    { status },
-  );
 }
 
 function readAllowedHeader(
@@ -627,107 +606,20 @@ export class MCPServer {
   }
 
   createHTTPHandler(): (request: Request) => Promise<Response> {
-    return async (request: Request) => {
-      const requestOrigin = request.headers.get("Origin");
-
-      // CORS preflight
-      if (request.method === "OPTIONS") {
-        return new Response(null, { status: 204, headers: this.getCORSHeaders(requestOrigin) });
-      }
-
-      // Origin validation (DNS rebinding protection)
-      if (requestOrigin && this.config.cors?.enabled && this.config.cors.origins?.length) {
-        if (!this.config.cors.origins.includes(requestOrigin)) {
-          return createJSONRPCErrorResponse(403, -32600, "Forbidden: Origin not allowed");
-        }
-      }
-
-      // Auth check (applies to all methods including DELETE)
-      if (this.config.auth?.type && this.config.auth.type !== "none") {
-        const authorized = await this.validateAuth(request);
-        if (!authorized) return new Response("Unauthorized", { status: 401 });
-      }
-
-      // DELETE = terminate session
-      if (request.method === "DELETE") {
-        const sessionId = request.headers.get("MCP-Session-Id");
-        if (sessionId) {
-          this.sessionManager.terminate(sessionId);
-          this.sessionCapabilities.delete(sessionId);
-        }
-        return new Response(null, { status: 200, headers: this.getCORSHeaders(requestOrigin) });
-      }
-
-      // Only POST allowed for JSON-RPC messages
-      if (request.method !== "POST") {
-        return new Response("Method Not Allowed", { status: 405 });
-      }
-
-      // Enforce request body size limit (fast path via Content-Length header)
-      const contentLength = request.headers.get("content-length");
-      if (contentLength && Number(contentLength) > MAX_REQUEST_BODY_SIZE) {
-        return createJSONRPCErrorResponse(413, -32600, "Request body too large");
-      }
-
-      try {
-        validateContentType(request, JSON_CONTENT_TYPE);
-      } catch (error) {
-        const message = error instanceof VeryfrontError ? error.message : "Invalid Content-Type";
-        return createJSONRPCErrorResponse(400, -32700, message);
-      }
-
-      let rpcRequest: JSONRPCRequest;
-      try {
-        const bodyText = await request.text();
-        if (bodyText.length > MAX_REQUEST_BODY_SIZE) {
-          return createJSONRPCErrorResponse(413, -32600, "Request body too large");
-        }
-        rpcRequest = JSON.parse(bodyText) as JSONRPCRequest;
-      } catch (_) {
-        // expected: malformed JSON in request body
-        return createJSONRPCErrorResponse(400, -32700, "Parse error");
-      }
-
-      // Session management: initialize creates session, everything else requires it
-      const responseHeaders: Record<string, string> = {
-        ...this.getCORSHeaders(requestOrigin),
-      };
-
-      if (rpcRequest.method === "initialize") {
-        const context = this.extractRequestContext(request);
-        const rpcResponse = await this.handleRequest(rpcRequest, context);
-        const clientCaps =
-          toParamsRecord(rpcRequest.params).capabilities as Record<string, unknown> ??
-            {};
-        const sessionId = this.sessionManager.create();
-        this.sessionCapabilities.set(sessionId, clientCaps);
-        responseHeaders["MCP-Session-Id"] = sessionId;
-        return createJSONResponse(rpcResponse, { headers: responseHeaders });
-      }
-
-      // Post-init: require session ID when sessions are active
-      if (this.sessionManager.size > 0) {
-        const sessionId = request.headers.get("MCP-Session-Id");
-        if (!sessionId) {
-          return createJSONRPCErrorResponse(400, -32600, "Missing MCP-Session-Id header");
-        }
-        if (!this.sessionManager.isValid(sessionId)) {
-          return createJSONRPCErrorResponse(404, -32600, "Session not found or expired");
-        }
-      }
-
-      // Notifications have no id member — return 202 Accepted
-      // Note: id:0 is a valid request ID per JSON-RPC 2.0, so check for undefined
-      if (rpcRequest.id === undefined) {
-        const context = this.extractRequestContext(request);
-        await this.handleRequest(rpcRequest, context);
-        return new Response(null, { status: 202, headers: responseHeaders });
-      }
-
-      const context = this.extractRequestContext(request);
-      const rpcResponse = await this.handleRequest(rpcRequest, context);
-      return createJSONResponse(rpcResponse, { headers: responseHeaders });
-    };
+    return createMCPHTTPHandler({
+      authEnabled: Boolean(this.config.auth?.type && this.config.auth.type !== "none"),
+      getCORSHeaders: (requestOrigin) => this.getCORSHeaders(requestOrigin),
+      validateAuth: (request) => this.validateAuth(request),
+      handleRequest: (request, context) => this.handleRequest(request, context),
+      extractRequestContext: (request) => this.extractRequestContext(request),
+      isOriginAllowed: (requestOrigin) =>
+        !requestOrigin ||
+        !this.config.cors?.enabled ||
+        !this.config.cors.origins?.length ||
+        this.config.cors.origins.includes(requestOrigin),
+      sessionCapabilities: this.sessionCapabilities,
+      sessionManager: this.sessionManager,
+    });
   }
 
   private extractRequestContext(request: Request): ToolExecutionContext | undefined {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.159";
+export const VERSION = "0.1.160";


### PR DESCRIPTION
## Summary
- extract MCP HTTP transport handling into `src/mcp/http-transport.ts`
- keep `MCPServer` focused on protocol dispatch and handlers
- add seam tests for initialize response shape and DELETE capability cleanup
- bump the release version to `0.1.160`

## Why
`src/mcp/server.ts` mixed protocol dispatch with a large HTTP transport block. This slice splits the HTTP transport orchestration into a dedicated module so the seam is easier to reason about and test independently.

## Verification
- `deno test --no-check --allow-all src/mcp/server.test.ts src/utils/version.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts src/mcp/http-transport.ts src/mcp/server.ts src/mcp/server.test.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/utils/version-constant.ts src/mcp/http-transport.ts src/mcp/server.ts src/mcp/server.test.ts`
- `deno task typecheck`
- `deno task verify:quick`
- architect review: APPROVE
