### PR TITLE
Preserve FS adapter resolve fallback patterns

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.160",
+  "version": "0.1.161",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/platform/adapters/fs/veryfront/stat-operations.test.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.test.ts
@@ -425,6 +425,75 @@ describe("StatOperations", () => {
       assertEquals(listAllFilesCallCount, 0);
     });
 
+    it("should retry pages-prefixed API patterns after an incomplete index miss", async () => {
+      const patterns: string[] = [];
+
+      const client = createMockClient({
+        searchFiles: (pattern: string) => {
+          patterns.push(pattern);
+          if (pattern === "pages/about.*") {
+            return Promise.resolve([{ path: "pages/about.tsx" }]);
+          }
+          return Promise.resolve([]);
+        },
+      });
+
+      const statOps = createStatOps(
+        client,
+        new PathNormalizer(),
+        createBranchContextWithFiles([makeFile("pages/index.tsx")]),
+      );
+
+      assertEquals(await statOps.resolveFile("about"), "pages/about.tsx");
+      assertEquals(patterns, ["about.*", "pages/about.*"]);
+    });
+
+    it("should retry index-file API patterns after an incomplete index miss", async () => {
+      const patterns: string[] = [];
+
+      const client = createMockClient({
+        searchFiles: (pattern: string) => {
+          patterns.push(pattern);
+          if (pattern === "components/index.*") {
+            return Promise.resolve([{ path: "components/index.tsx" }]);
+          }
+          return Promise.resolve([]);
+        },
+      });
+
+      const statOps = createStatOps(
+        client,
+        new PathNormalizer(),
+        createBranchContextWithFiles([makeFile("pages/index.tsx")]),
+      );
+
+      assertEquals(await statOps.resolveFile("components"), "components/index.tsx");
+      assertEquals(patterns, ["components.*", "pages/components.*", "components/index.*"]);
+    });
+
+    it("should keep wildcard extension fallback after an incomplete index miss", async () => {
+      const patterns: string[] = [];
+
+      const client = createMockClient({
+        searchFiles: (pattern: string) => {
+          patterns.push(pattern);
+          if (pattern === "components/Button.*") {
+            return Promise.resolve([{ path: "components/Button.ts" }]);
+          }
+          return Promise.resolve([]);
+        },
+      });
+
+      const statOps = createStatOps(
+        client,
+        new PathNormalizer(),
+        createBranchContextWithFiles([makeFile("pages/index.tsx")]),
+      );
+
+      assertEquals(await statOps.resolveFile("components/Button.tsx"), "components/Button.ts");
+      assertEquals(patterns, ["components/Button.*"]);
+    });
+
     it("should skip pages/ API search patterns when pages prefix is disabled", async () => {
       const patterns: string[] = [];
 

--- a/src/platform/adapters/fs/veryfront/stat-operations.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.ts
@@ -329,6 +329,7 @@ export class StatOperations extends VeryfrontOperationsBase {
   private buildResolveSearchPatterns(
     normalizedPath: string,
     options?: ResolveFileOptions,
+    knownExtensionFallback: "exact" | "wildcard" = "exact",
   ): string[] {
     const patterns = new Set<string>();
     const pathWithoutExt = stripKnownExtension(normalizedPath, EXTENSION_PRIORITY);
@@ -338,7 +339,9 @@ export class StatOperations extends VeryfrontOperationsBase {
     };
 
     if (EXTENSION_PRIORITY.some((ext) => normalizedPath.endsWith(ext))) {
-      addPattern(normalizedPath);
+      addPattern(
+        knownExtensionFallback === "wildcard" ? `${pathWithoutExt}.*` : normalizedPath,
+      );
       return [...patterns];
     }
 
@@ -366,6 +369,7 @@ export class StatOperations extends VeryfrontOperationsBase {
   private async tryResolveViaApiSearch(
     normalizedPath: string,
     options?: ResolveFileOptions,
+    knownExtensionFallback: "exact" | "wildcard" = "exact",
   ): Promise<string | null | undefined> {
     if (isFrameworkSourcePath(normalizedPath)) {
       logger.debug("Skipping API search for framework path", { normalizedPath });
@@ -377,7 +381,11 @@ export class StatOperations extends VeryfrontOperationsBase {
       return undefined;
     }
 
-    const patterns = this.buildResolveSearchPatterns(normalizedPath, options);
+    const patterns = this.buildResolveSearchPatterns(
+      normalizedPath,
+      options,
+      knownExtensionFallback,
+    );
     let sawSuccessfulSearch = false;
 
     for (const pattern of patterns) {
@@ -573,55 +581,17 @@ export class StatOperations extends VeryfrontOperationsBase {
       return null;
     }
 
-    // NOTE: Removed optimization that skipped API search for paths with extensions.
-    // This was causing layout files and other project files to not be found when
-    // they were missing from the file index (due to cache issues, incomplete fetch, etc.).
-    // The API pattern search is the fallback to ensure files can still be found.
-
-    if (!this.apiSearchCircuitBreaker.canSearch()) {
-      logger.warn("API search circuit breaker open, skipping", { normalizedPath });
-      return null;
+    // NOTE: Keep the post-index API fallback aligned with the pre-index helper for extensionless
+    // paths, while preserving the older wildcard sibling-extension lookup for known-extension
+    // paths. Incomplete file-list snapshots otherwise hide valid files until the cache refreshes.
+    const apiResolved = await this.tryResolveViaApiSearch(normalizedPath, options, "wildcard");
+    if (typeof apiResolved === "string") {
+      this.cache.set(cacheKey, apiResolved);
+      return apiResolved;
     }
-
-    const searchPattern = `${pathWithoutExt}.*`;
-    logger.debug("Searching for file via API", {
-      pattern: searchPattern,
-      normalizedPath,
-    });
-
-    try {
-      const matches = await this.client.searchFiles(searchPattern);
-      this.apiSearchCircuitBreaker.recordSuccess();
-
-      logger.debug("API search result", {
-        pattern: searchPattern,
-        matchCount: matches.length,
-        matches: matches.map((m) => m.path).slice(0, 5),
-      });
-
-      const sortedMatches = sortPathsByExtensionPriority(matches, EXTENSION_PRIORITY);
-      const first = sortedMatches[0];
-      if (first) {
-        logger.debug("resolveFile found via API search", { path: first.path });
-        this.cache.set(cacheKey, first.path);
-        return first.path;
-      }
-    } catch (error) {
-      const result = this.apiSearchCircuitBreaker.recordFailure();
-      if (result.tripped) {
-        logger.warn("API search circuit breaker tripped", {
-          failures: result.failures,
-        });
-      }
-      logger.error("API pattern search failed", { pattern: searchPattern, error });
+    if (apiResolved === null) {
+      this.cache.set(cacheKey, NOT_FOUND_SENTINEL);
     }
-
-    logger.debug("resolveFile not found after API search", {
-      normalizedPath,
-      pathWithoutExt,
-    });
-
-    this.cache.set(cacheKey, NOT_FOUND_SENTINEL);
     return null;
   }
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.160";
+export const VERSION = "0.1.161";


### PR DESCRIPTION
## Summary
- add regression coverage for incomplete-index resolve fallbacks in StatOperations
- reuse the shared API-search helper after index misses so pages/ and index-file patterns stay consistent
- bump the release version to 0.1.161

## Verification
- RED: `deno test --no-check --allow-all src/platform/adapters/fs/veryfront/stat-operations.test.ts` (new tests failed before the refactor)
- `deno test --no-check --allow-all src/platform/adapters/fs/veryfront/stat-operations.test.ts src/utils/version.test.ts`
- `deno fmt --check src/platform/adapters/fs/veryfront/stat-operations.ts src/platform/adapters/fs/veryfront/stat-operations.test.ts deno.json src/utils/version-constant.ts`
- `deno lint src/platform/adapters/fs/veryfront/stat-operations.ts src/platform/adapters/fs/veryfront/stat-operations.test.ts src/utils/version-constant.ts`
- `deno task typecheck`
- `deno task verify:quick`