### PR TITLE
Extract shared FS file-list loading helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.161",
+  "version": "0.1.162",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/platform/adapters/fs/veryfront/base-operations.ts
+++ b/src/platform/adapters/fs/veryfront/base-operations.ts
@@ -1,7 +1,7 @@
 import type { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
 import { FileCache } from "../cache/file-cache.ts";
+import type { ContentContextProvider } from "./file-list-access.ts";
 import { PathNormalizer } from "./path-normalizer.ts";
-import type { ContentContextProvider } from "./read-operations.ts";
 
 export class VeryfrontOperationsBase {
   constructor(

--- a/src/platform/adapters/fs/veryfront/directory-operations.ts
+++ b/src/platform/adapters/fs/veryfront/directory-operations.ts
@@ -2,13 +2,9 @@ import { logger as baseLogger } from "#veryfront/utils";
 import type { DirectoryEntry } from "./types.ts";
 import type { ProjectFile } from "../../veryfront-api-client/index.ts";
 import { VeryfrontOperationsBase } from "./base-operations.ts";
-import {
-  buildDirCacheKeyPrefix,
-  buildFileCacheKeyPrefix,
-  buildFileListCacheKey,
-} from "./cache-keys.ts";
+import { buildDirCacheKeyPrefix } from "./cache-keys.ts";
+import { loadAllProjectFiles } from "./file-list-access.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
-import { withRetryOnTransient } from "./retry.ts";
 
 const logger = baseLogger.component("directory-operations");
 
@@ -154,74 +150,13 @@ export class DirectoryOperations extends VeryfrontOperationsBase {
   }
 
   private getAllFilesRaw(): Promise<ProjectFile[]> {
-    return withSpan("fs.veryfront.getAllFilesRaw", async () => {
-      const cacheStart = performance.now();
-      const ctx = this.contextProvider?.getContentContext();
-      const cacheKeyPrefix = buildFileCacheKeyPrefix(ctx);
-      const skipPersistentCache =
-        this.contextProvider?.isPersistentCacheInvalidated?.(cacheKeyPrefix) ?? false;
-
-      const adapterFiles = !skipPersistentCache
-        ? await this.contextProvider?.getFileList?.()
-        : undefined;
-
-      if (adapterFiles) {
-        const cacheMs = Math.round(performance.now() - cacheStart);
-        logger.debug("getAllFilesRaw - from adapter cache", {
-          cacheMs,
-          fileCount: adapterFiles.length,
-        });
-        return adapterFiles as ProjectFile[];
-      }
-
-      const cacheKey = buildFileListCacheKey(ctx);
-
-      if (skipPersistentCache) {
-        logger.debug("getAllFilesRaw - skipping persistent cache", {
-          cacheKey,
-          cacheKeyPrefix,
-        });
-      }
-
-      const cached = skipPersistentCache
-        ? undefined
-        : await this.cache.getAsync<ProjectFile[]>(cacheKey);
-
-      const cacheMs = Math.round(performance.now() - cacheStart);
-      if (cached) {
-        logger.debug("getAllFilesRaw - fallback cache HIT", {
-          cacheKey,
-          cacheMs,
-          fileCount: cached.length,
-        });
-        return cached;
-      }
-
-      logger.warn("getAllFilesRaw - cache MISS, fetching from API", {
-        cacheKey,
-        cacheMs,
-      });
-
-      const isPublished = ctx?.sourceType !== "branch";
-      logger.debug("Fetching files from API", {
-        sourceType: ctx?.sourceType,
-        cacheKey,
-      });
-
-      const files = await withRetryOnTransient(
-        () =>
-          isPublished
-            ? this.client.listPublishedFiles(
-              undefined,
-              ctx?.releaseId ?? undefined,
-              ctx?.environmentName ?? undefined,
-            )
-            : this.client.listAllFiles(),
-        "getAllFilesRaw (dir)",
-      );
-
-      this.cache.set(cacheKey, files);
-      return files;
-    });
+    return withSpan("fs.veryfront.getAllFilesRaw", () =>
+      loadAllProjectFiles({
+        client: this.client,
+        cache: this.cache,
+        contextProvider: this.contextProvider,
+        logger,
+        operationLabel: "dir",
+      }));
   }
 }

--- a/src/platform/adapters/fs/veryfront/file-list-access.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-access.test.ts
@@ -1,0 +1,137 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ProjectFile } from "../../veryfront-api-client/index.ts";
+import { FileCache } from "../cache/file-cache.ts";
+import { type ContentContextProvider, loadAllProjectFiles } from "./file-list-access.ts";
+
+function makeFile(path: string): ProjectFile {
+  return {
+    id: path,
+    path,
+    type: "file",
+    updated_at: "2024-01-01T00:00:00.000Z",
+    size: 0,
+  };
+}
+
+function createLogger() {
+  return {
+    debug: () => {},
+    warn: () => {},
+  };
+}
+
+describe("veryfront/file-list-access", () => {
+  it("prefers the adapter-provided file list when caches are valid", async () => {
+    let apiCalls = 0;
+    const files = [makeFile("pages/index.tsx")];
+    const contextProvider: ContentContextProvider = {
+      isProductionMode: () => false,
+      getReleaseId: () => null,
+      getContentContext: () => ({
+        sourceType: "branch",
+        projectSlug: "test",
+        branch: "main",
+      }),
+      getFileList: () => Promise.resolve(files),
+      isPersistentCacheInvalidated: () => false,
+    };
+
+    const loaded = await loadAllProjectFiles({
+      client: {
+        listAllFiles: () => {
+          apiCalls++;
+          return Promise.resolve([]);
+        },
+        listPublishedFiles: () => {
+          apiCalls++;
+          return Promise.resolve([]);
+        },
+      } as any,
+      cache: new FileCache({ enabled: true, ttl: 60_000, maxSize: 100 }),
+      contextProvider,
+      logger: createLogger(),
+      operationLabel: "test",
+    });
+
+    assertEquals(loaded, files);
+    assertEquals(apiCalls, 0);
+  });
+
+  it("uses the published files API for release contexts", async () => {
+    let publishedArgs: [string | undefined, string | undefined, string | undefined] | null = null;
+    const files = [makeFile("pages/index.tsx")];
+    const contextProvider: ContentContextProvider = {
+      isProductionMode: () => true,
+      getReleaseId: () => "rel-1",
+      getContentContext: () => ({
+        sourceType: "release",
+        projectSlug: "test",
+        releaseId: "rel-1",
+        environmentName: "prod",
+      }),
+      isPersistentCacheInvalidated: () => false,
+    };
+
+    const loaded = await loadAllProjectFiles({
+      client: {
+        listAllFiles: () => Promise.resolve([]),
+        listPublishedFiles: (
+          cursor?: string,
+          releaseId?: string,
+          environmentName?: string,
+        ) => {
+          publishedArgs = [cursor, releaseId, environmentName];
+          return Promise.resolve(files);
+        },
+      } as any,
+      cache: new FileCache({ enabled: true, ttl: 60_000, maxSize: 100 }),
+      contextProvider,
+      logger: createLogger(),
+      operationLabel: "test",
+    });
+
+    assertEquals(loaded, files);
+    assertEquals(publishedArgs, [undefined, "rel-1", "prod"]);
+  });
+
+  it("skips provider and persistent cache reads while invalidation is active", async () => {
+    let providerCalls = 0;
+    let apiCalls = 0;
+    const cache = new FileCache({ enabled: true, ttl: 60_000, maxSize: 100 });
+    const contextProvider: ContentContextProvider = {
+      isProductionMode: () => false,
+      getReleaseId: () => null,
+      getContentContext: () => ({
+        sourceType: "branch",
+        projectSlug: "test",
+        branch: "main",
+      }),
+      getFileList: () => {
+        providerCalls++;
+        return Promise.resolve([makeFile("stale.tsx")]);
+      },
+      isPersistentCacheInvalidated: () => true,
+    };
+
+    cache.set("files:branch:test:main", [makeFile("cached.tsx")]);
+
+    const loaded = await loadAllProjectFiles({
+      client: {
+        listAllFiles: () => {
+          apiCalls++;
+          return Promise.resolve([makeFile("fresh.tsx")]);
+        },
+        listPublishedFiles: () => Promise.resolve([]),
+      } as any,
+      cache,
+      contextProvider,
+      logger: createLogger(),
+      operationLabel: "test",
+    });
+
+    assertEquals(providerCalls, 0);
+    assertEquals(apiCalls, 1);
+    assertEquals(loaded.map((file) => file.path), ["fresh.tsx"]);
+  });
+});

--- a/src/platform/adapters/fs/veryfront/file-list-access.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-access.ts
@@ -1,0 +1,109 @@
+import type { ProjectFile, VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
+import { FileCache } from "../cache/file-cache.ts";
+import { buildFileCacheKeyPrefix, buildFileListCacheKey } from "./cache-keys.ts";
+import { withRetryOnTransient } from "./retry.ts";
+import type { ResolvedContentContext } from "./types.ts";
+
+export interface ContentContextProvider {
+  isProductionMode: () => boolean;
+  getReleaseId: () => string | null;
+  getContentContext: () => ResolvedContentContext | null;
+  getFileList?: () => Promise<
+    Array<{
+      id?: string;
+      path: string;
+      content?: string;
+      type?: string;
+      size?: number;
+      updated_at?: string;
+    }> | undefined
+  >;
+  hasCachedFileList?: () => Promise<boolean>;
+  isPersistentCacheInvalidated?: (prefix: string) => boolean;
+  isReleaseBeingInvalidated?: (releaseId: string) => boolean;
+}
+
+interface FileListLogger {
+  debug(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+}
+
+interface LoadAllProjectFilesOptions {
+  client: VeryfrontApiClient;
+  cache: FileCache;
+  contextProvider?: ContentContextProvider;
+  logger: FileListLogger;
+  operationLabel: string;
+}
+
+export async function loadAllProjectFiles({
+  client,
+  cache,
+  contextProvider,
+  logger,
+  operationLabel,
+}: LoadAllProjectFilesOptions): Promise<ProjectFile[]> {
+  const cacheStart = performance.now();
+  const ctx = contextProvider?.getContentContext();
+  const cacheKeyPrefix = buildFileCacheKeyPrefix(ctx);
+  const skipPersistentCache = contextProvider?.isPersistentCacheInvalidated?.(cacheKeyPrefix) ??
+    false;
+
+  const adapterFiles = !skipPersistentCache ? await contextProvider?.getFileList?.() : undefined;
+
+  if (adapterFiles) {
+    const cacheMs = Math.round(performance.now() - cacheStart);
+    logger.debug("getAllFilesRaw - from adapter cache", {
+      cacheMs,
+      fileCount: adapterFiles.length,
+    });
+    return adapterFiles as ProjectFile[];
+  }
+
+  const cacheKey = buildFileListCacheKey(ctx);
+
+  if (skipPersistentCache) {
+    logger.debug("getAllFilesRaw - skipping persistent cache", {
+      cacheKey,
+      cacheKeyPrefix,
+    });
+  }
+
+  const cached = skipPersistentCache ? undefined : await cache.getAsync<ProjectFile[]>(cacheKey);
+  const cacheMs = Math.round(performance.now() - cacheStart);
+
+  if (cached) {
+    logger.debug("getAllFilesRaw - fallback cache HIT", {
+      cacheKey,
+      cacheMs,
+      fileCount: cached.length,
+    });
+    return cached;
+  }
+
+  logger.warn("getAllFilesRaw - cache MISS, fetching from API", {
+    cacheKey,
+    cacheMs,
+  });
+
+  const isPublished = ctx?.sourceType !== "branch";
+  logger.debug("Fetching files from API", {
+    sourceType: ctx?.sourceType,
+    cacheKey,
+  });
+
+  const files = await withRetryOnTransient(
+    () =>
+      isPublished
+        ? client.listPublishedFiles(
+          undefined,
+          ctx?.releaseId ?? undefined,
+          ctx?.environmentName ?? undefined,
+        )
+        : client.listAllFiles(),
+    `getAllFilesRaw (${operationLabel})`,
+  );
+
+  cache.set(cacheKey, files);
+  return files;
+}

--- a/src/platform/adapters/fs/veryfront/read-operations.test.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.test.ts
@@ -2,10 +2,10 @@ import { assert, assertEquals, assertExists, assertRejects } from "#veryfront/te
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
 import { FileCache } from "../cache/file-cache.ts";
+import type { ContentContextProvider } from "./file-list-access.ts";
 import { runWithRequestContext } from "./multi-project-adapter.ts";
 import { PathNormalizer } from "./path-normalizer.ts";
 import { ReadOperations } from "./read-operations.ts";
-import type { ContentContextProvider } from "./read-operations.ts";
 
 function createMockClient(
   overrides: Record<string, unknown> = {},

--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -7,6 +7,7 @@ import { FileListIndex, type FileListMatchResult } from "./file-list-index.ts";
 import { InFlightRequestDeduper } from "./in-flight-dedupe.ts";
 import { getRequestScopedFile, setRequestScopedFile } from "./multi-project-adapter.ts";
 import { PathNormalizer } from "./path-normalizer.ts";
+import type { ContentContextProvider } from "./file-list-access.ts";
 import {
   assertProjectSourcePath,
   buildExtensionCandidatePaths,
@@ -27,28 +28,6 @@ export {
 } from "./content-metrics.ts";
 
 const logger = baseLogger.component("read-operations");
-
-export interface ContentContextProvider {
-  isProductionMode: () => boolean;
-  getReleaseId: () => string | null;
-  getContentContext: () => ResolvedContentContext | null;
-  /** Cached file list from adapter initialization (single source of truth) */
-  getFileList?: () => Promise<
-    Array<{
-      id?: string;
-      path: string;
-      content?: string;
-      type?: string;
-      size?: number;
-      updated_at?: string;
-    }> | undefined
-  >;
-  hasCachedFileList?: () => Promise<boolean>;
-  /** True if cache prefix is being deleted - skip persistent cache reads */
-  isPersistentCacheInvalidated?: (prefix: string) => boolean;
-  /** Back-compat: release-scoped invalidation */
-  isReleaseBeingInvalidated?: (releaseId: string) => boolean;
-}
 
 const IN_FLIGHT_REQUEST_TIMEOUT_MS = 15_000;
 const MAX_IN_FLIGHT_REQUESTS = 100;

--- a/src/platform/adapters/fs/veryfront/stat-operations.test.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.test.ts
@@ -2,7 +2,7 @@ import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ProjectFile, VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
 import { FileCache } from "../cache/file-cache.ts";
-import type { ContentContextProvider } from "./read-operations.ts";
+import type { ContentContextProvider } from "./file-list-access.ts";
 import { PathNormalizer } from "./path-normalizer.ts";
 import { StatOperations } from "./stat-operations.ts";
 

--- a/src/platform/adapters/fs/veryfront/stat-operations.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.ts
@@ -4,12 +4,7 @@ import type { FileInfo, ResolveFileOptions } from "../../base.ts";
 import type { ProjectFile } from "../../veryfront-api-client/index.ts";
 import { VeryfrontOperationsBase } from "./base-operations.ts";
 import { createError, toError } from "#veryfront/errors";
-import {
-  buildFileCacheKeyPrefix,
-  buildFileListCacheKey,
-  buildStatCacheKeyPrefix,
-} from "./cache-keys.ts";
-import { withRetryOnTransient } from "./retry.ts";
+import { buildStatCacheKeyPrefix } from "./cache-keys.ts";
 import { STAT_OPERATION_EXTENSION_PRIORITY as EXTENSION_PRIORITY } from "./extension-priority.ts";
 import {
   collectParentDirectories,
@@ -21,6 +16,7 @@ import {
 } from "./stat-operations-helpers.ts";
 import { ApiSearchCircuitBreaker } from "./api-search-circuit-breaker.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { loadAllProjectFiles } from "./file-list-access.ts";
 
 const logger = baseLogger.component("stat-operations");
 
@@ -258,72 +254,13 @@ export class StatOperations extends VeryfrontOperationsBase {
   }
 
   private async getAllFilesRaw(): Promise<ProjectFile[]> {
-    const cacheStart = performance.now();
-    const ctx = this.contextProvider?.getContentContext();
-    const cacheKeyPrefix = buildFileCacheKeyPrefix(ctx);
-    const skipPersistentCache =
-      this.contextProvider?.isPersistentCacheInvalidated?.(cacheKeyPrefix) ?? false;
-
-    if (!skipPersistentCache) {
-      const files = await this.contextProvider?.getFileList?.();
-      if (files) {
-        const cacheMs = Math.round(performance.now() - cacheStart);
-        logger.debug("getAllFilesRaw - from adapter cache", {
-          cacheMs,
-          fileCount: files.length,
-        });
-        return files as ProjectFile[];
-      }
-    }
-
-    const cacheKey = buildFileListCacheKey(ctx);
-
-    if (skipPersistentCache) {
-      logger.debug("getAllFilesRaw - skipping persistent cache (invalidation)", {
-        cacheKey,
-        cacheKeyPrefix,
-      });
-    }
-
-    const cached = skipPersistentCache
-      ? undefined
-      : await this.cache.getAsync<ProjectFile[]>(cacheKey);
-    const cacheMs = Math.round(performance.now() - cacheStart);
-
-    if (cached) {
-      logger.debug("getAllFilesRaw - fallback cache HIT", {
-        cacheKey,
-        cacheMs,
-        fileCount: cached.length,
-      });
-      return cached;
-    }
-
-    logger.warn("getAllFilesRaw - cache MISS, fetching from API", {
-      cacheKey,
-      cacheMs,
+    return await loadAllProjectFiles({
+      client: this.client,
+      cache: this.cache,
+      contextProvider: this.contextProvider,
+      logger,
+      operationLabel: "stat",
     });
-
-    const isPublished = ctx?.sourceType !== "branch";
-    logger.debug("Fetching files from API", {
-      sourceType: ctx?.sourceType,
-      cacheKey,
-    });
-
-    const files = await withRetryOnTransient(
-      () =>
-        isPublished
-          ? this.client.listPublishedFiles(
-            undefined,
-            ctx?.releaseId ?? undefined,
-            ctx?.environmentName ?? undefined,
-          )
-          : this.client.listAllFiles(),
-      "getAllFilesRaw (stat)",
-    );
-
-    this.cache.set(cacheKey, files);
-    return files;
   }
 
   private buildResolveSearchPatterns(

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.161";
+export const VERSION = "0.1.162";


### PR DESCRIPTION
## Summary
- extract shared file-list loading/cache invalidation logic for FS adapter operations
- reuse the helper from directory and stat operations while keeping read/context types aligned
- add focused helper tests and bump the release version to 0.1.162

## Verification
- deno test --no-check --allow-all src/platform/adapters/fs/veryfront/file-list-access.test.ts src/platform/adapters/fs/veryfront/directory-operations.test.ts src/platform/adapters/fs/veryfront/stat-operations.test.ts src/platform/adapters/fs/veryfront/read-operations.test.ts src/utils/version.test.ts
- deno fmt --check src/platform/adapters/fs/veryfront/base-operations.ts src/platform/adapters/fs/veryfront/directory-operations.ts src/platform/adapters/fs/veryfront/read-operations.ts src/platform/adapters/fs/veryfront/read-operations.test.ts src/platform/adapters/fs/veryfront/stat-operations.ts src/platform/adapters/fs/veryfront/stat-operations.test.ts src/platform/adapters/fs/veryfront/file-list-access.ts src/platform/adapters/fs/veryfront/file-list-access.test.ts deno.json src/utils/version-constant.ts
- deno lint src/platform/adapters/fs/veryfront/base-operations.ts src/platform/adapters/fs/veryfront/directory-operations.ts src/platform/adapters/fs/veryfront/read-operations.ts src/platform/adapters/fs/veryfront/read-operations.test.ts src/platform/adapters/fs/veryfront/stat-operations.ts src/platform/adapters/fs/veryfront/stat-operations.test.ts src/platform/adapters/fs/veryfront/file-list-access.ts src/platform/adapters/fs/veryfront/file-list-access.test.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick