### PR TITLE
Add public remote MCP tool materialization helpers

### DIFF
--- a/docs/reference/tool.md
+++ b/docs/reference/tool.md
@@ -65,12 +65,17 @@ const assistant = agent({
 ### Remote MCP tool source
 
 ```ts
-import { createRemoteMCPToolSource } from "veryfront/tool";
+import { createRemoteMCPToolSource, loadRemoteToolsFromSource } from "veryfront/tool";
 
 const docsTools = createRemoteMCPToolSource({
   id: "docs-mcp",
   endpoint: "https://docs.example.com/mcp",
   headers: { Authorization: `Bearer ${Deno.env.get("DOCS_TOKEN")}` },
+});
+
+const runtimeTools = await loadRemoteToolsFromSource(docsTools, {
+  context: { projectId: "proj_123" },
+  toolNameAliases: { search_docs: "docs_search" },
 });
 ```
 
@@ -106,29 +111,40 @@ Create a per-request remote tool source backed by an MCP `tools/list` + `tools/c
 
 **Returns:** `RemoteToolSource`
 
+### `createToolsFromRemoteDefinitions(source, definitions, options?)`
+
+Materialize runtime `Tool` instances from remote definitions while preserving the remote JSON schema.
+
+### `loadRemoteToolsFromSource(source, options?)`
+
+List tools from a remote source and materialize them into runtime `Tool` instances.
+
 ## Exports
 
 ### Functions
 
-| Name                        | Description                            |
-| --------------------------- | -------------------------------------- |
-| `dynamicTool`               | Create tool with runtime schema        |
-| `createRemoteMCPToolSource` | Create a remote MCP-backed tool source |
-| `executeTool`               | Execute tool by ID                     |
-| `tool`                      | Create typed tool (Zod-validated)      |
+| Name                               | Description                                       |
+| ---------------------------------- | ------------------------------------------------- |
+| `createToolsFromRemoteDefinitions` | Materialize runtime tools from remote definitions |
+| `dynamicTool`                      | Create tool with runtime schema                   |
+| `createRemoteMCPToolSource`        | Create a remote MCP-backed tool source            |
+| `executeTool`                      | Execute tool by ID                                |
+| `loadRemoteToolsFromSource`        | Load and materialize tools from a remote source   |
+| `tool`                             | Create typed tool (Zod-validated)                 |
 
 ### Types
 
-| Name                        | Description                                                       |
-| --------------------------- | ----------------------------------------------------------------- |
-| `DynamicToolConfig`         | `dynamicTool()` config                                            |
-| `JsonSchema`                | JSON Schema for tool input                                        |
-| `RemoteMCPToolSourceConfig` | `createRemoteMCPToolSource()` config                              |
-| `RemoteToolSource`          | Runtime-discovered remote tool source                             |
-| `Tool`                      | Tool instance (returned by tool() function)                       |
-| `ToolConfig`                | Tool configuration options                                        |
-| `ToolDefinition`            | Provider-facing tool definition used for model/tool registration. |
-| `ToolExecutionContext`      | Context passed to tool execution                                  |
+| Name                               | Description                                                       |
+| ---------------------------------- | ----------------------------------------------------------------- |
+| `DynamicToolConfig`                | `dynamicTool()` config                                            |
+| `JsonSchema`                       | JSON Schema for tool input                                        |
+| `RemoteMCPToolSourceConfig`        | `createRemoteMCPToolSource()` config                              |
+| `RemoteToolMaterializationOptions` | Options for loading/materializing remote tools                    |
+| `RemoteToolSource`                 | Runtime-discovered remote tool source                             |
+| `Tool`                             | Tool instance (returned by tool() function)                       |
+| `ToolConfig`                       | Tool configuration options                                        |
+| `ToolDefinition`                   | Provider-facing tool definition used for model/tool registration. |
+| `ToolExecutionContext`             | Context passed to tool execution                                  |
 
 ### Constants
 

--- a/src/tool/factory.test.ts
+++ b/src/tool/factory.test.ts
@@ -233,6 +233,29 @@ describe("tool factory", () => {
       });
       assertStringIncludes(t.id, "tool_");
     });
+
+    it("should preserve an explicit JSON schema override", () => {
+      const t = dynamicTool({
+        id: "remote-dynamic",
+        description: "Remote dynamic tool",
+        inputSchema: z.object({}).passthrough(),
+        inputSchemaJson: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+          },
+          required: ["query"],
+        },
+        execute: async () => null,
+      });
+      assertEquals(t.inputSchemaJson, {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+      });
+    });
   });
 
   describe("dynamicTool input validation", () => {

--- a/src/tool/factory.ts
+++ b/src/tool/factory.ts
@@ -179,20 +179,18 @@ export interface DynamicToolConfig {
   id?: string;
   description: string;
   inputSchema: unknown;
+  inputSchemaJson?: JsonSchema;
   execute: (input: unknown, context?: ToolExecutionContext) => Promise<unknown> | unknown;
   toModelOutput?: (output: unknown) => unknown;
-  mcp?: {
-    enabled?: boolean;
-    requiresAuth?: boolean;
-    cachePolicy?: "no-cache" | "cache" | "cache-first";
-  };
+  mcp?: ToolConfig["mcp"];
 }
 
 export function dynamicTool(config: DynamicToolConfig): Tool<unknown, unknown> {
   const explicitId = typeof config.id === "string" && config.id.length > 0 ? config.id : undefined;
   const id = explicitId ?? generateToolId();
 
-  const inputSchemaJson = convertSchemaToJson(config.inputSchema, id, "DYNAMIC_TOOL", true);
+  const inputSchemaJson = config.inputSchemaJson ??
+    convertSchemaToJson(config.inputSchema, id, "DYNAMIC_TOOL", true);
 
   const createdTool: Tool<unknown, unknown> = {
     id,

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -55,6 +55,11 @@ export { dynamicTool, tool } from "./factory.ts";
 export type { DynamicToolConfig } from "./factory.ts";
 export { createRemoteMCPToolSource } from "./remote-mcp.ts";
 export type { RemoteMCPToolSourceConfig } from "./remote-mcp.ts";
+export {
+  createToolsFromRemoteDefinitions,
+  loadRemoteToolsFromSource,
+} from "./remote-source-tools.ts";
+export type { RemoteToolMaterializationOptions } from "./remote-source-tools.ts";
 
 export { toolRegistry } from "./registry.ts";
 

--- a/src/tool/remote-source-tools.test.ts
+++ b/src/tool/remote-source-tools.test.ts
@@ -1,0 +1,103 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { RemoteToolSource } from "./types.ts";
+import {
+  createToolsFromRemoteDefinitions,
+  loadRemoteToolsFromSource,
+} from "./remote-source-tools.ts";
+
+describe("tool/remote-source-tools", () => {
+  it("materializes runtime tools from remote definitions while preserving remote schemas", async () => {
+    let executedToolName = "";
+    let executedArgs: Record<string, unknown> | undefined;
+    let executedContextProjectId = "";
+    let executedContextToolCallId = "";
+
+    const source: RemoteToolSource = {
+      id: "docs-source",
+      async listTools() {
+        return [];
+      },
+      async executeTool(toolName, args, context) {
+        executedToolName = toolName;
+        executedArgs = args;
+        executedContextProjectId = String(context?.projectId ?? "");
+        executedContextToolCallId = String(context?.toolCallId ?? "");
+        return { ok: true };
+      },
+    };
+
+    const tools = createToolsFromRemoteDefinitions(
+      source,
+      [{
+        name: "search_docs",
+        description: "Search docs",
+        parameters: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+          },
+          required: ["query"],
+        },
+        title: "Search documentation",
+        annotations: { readOnlyHint: true },
+      }],
+      {
+        toolNameAliases: {
+          search_docs: "docs_search",
+        },
+      },
+    );
+
+    assertEquals(Object.keys(tools), ["docs_search"]);
+    assertEquals(tools.docs_search?.id, "docs_search");
+    assertEquals(tools.docs_search?.inputSchemaJson, {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+      },
+      required: ["query"],
+    });
+    assertEquals(tools.docs_search?.mcp, {
+      title: "Search documentation",
+      annotations: { readOnlyHint: true },
+    });
+
+    const result = await tools.docs_search?.execute(
+      { query: "Veryfront" },
+      { projectId: "proj_123", toolCallId: "tool-call-1" },
+    );
+
+    assertEquals(result, { ok: true });
+    assertEquals(executedToolName, "search_docs");
+    assertEquals(executedArgs, { query: "Veryfront" });
+    assertEquals(executedContextProjectId, "proj_123");
+    assertEquals(executedContextToolCallId, "tool-call-1");
+  });
+
+  it("loads remote tools from a source with request context", async () => {
+    let listedProjectId = "";
+
+    const source: RemoteToolSource = {
+      id: "docs-source",
+      async listTools(context) {
+        listedProjectId = String(context?.projectId ?? "");
+        return [{
+          name: "search_docs",
+          description: "Search docs",
+          parameters: { type: "object", properties: {} },
+        }];
+      },
+      async executeTool() {
+        return null;
+      },
+    };
+
+    const tools = await loadRemoteToolsFromSource(source, {
+      context: { projectId: "proj_456" },
+    });
+
+    assertEquals(listedProjectId, "proj_456");
+    assertEquals(Object.keys(tools), ["search_docs"]);
+  });
+});

--- a/src/tool/remote-source-tools.ts
+++ b/src/tool/remote-source-tools.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import { dynamicTool } from "./factory.ts";
+import type { RemoteToolSource, Tool, ToolDefinition, ToolExecutionContext } from "./types.ts";
+
+export interface RemoteToolMaterializationOptions {
+  context?: ToolExecutionContext;
+  toolNameAliases?: Record<string, string>;
+}
+
+function toToolInputRecord(input: unknown): Record<string, unknown> {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return {};
+  }
+
+  return Object.fromEntries(Object.entries(input));
+}
+
+export function createToolsFromRemoteDefinitions(
+  source: RemoteToolSource,
+  definitions: readonly ToolDefinition[],
+  options: Omit<RemoteToolMaterializationOptions, "context"> = {},
+): Record<string, Tool<unknown, unknown>> {
+  return Object.fromEntries(
+    definitions.map((definition) => {
+      const toolName = options.toolNameAliases?.[definition.name] ?? definition.name;
+
+      return [
+        toolName,
+        dynamicTool({
+          id: toolName,
+          description: definition.description,
+          inputSchema: z.object({}).passthrough(),
+          inputSchemaJson: definition.parameters,
+          mcp: {
+            title: definition.title,
+            annotations: definition.annotations,
+          },
+          execute: async (input, context) =>
+            await source.executeTool(definition.name, toToolInputRecord(input), context),
+        }),
+      ];
+    }),
+  );
+}
+
+export async function loadRemoteToolsFromSource(
+  source: RemoteToolSource,
+  options: RemoteToolMaterializationOptions = {},
+): Promise<Record<string, Tool<unknown, unknown>>> {
+  const definitions = await source.listTools(options.context);
+  return createToolsFromRemoteDefinitions(source, definitions, {
+    toolNameAliases: options.toolNameAliases,
+  });
+}


### PR DESCRIPTION
## Summary
- add public `veryfront/tool` helpers to materialize runtime tools from remote MCP definitions
- preserve remote JSON schemas and remote execution names while allowing local runtime aliases
- document and test the hosted-runtime seam so downstream agent work can consume the public package surface

## Why
`veryfront-agent` needs a framework-owned helper for turning remote MCP metadata into runtime `Tool` instances. That logic should live in the open-source `veryfront/tool` surface rather than a repo-local private adapter so hosted runtimes and downstream consumers use the same contract.

## Testing
- `deno test --allow-all src/tool/factory.test.ts src/tool/remote-mcp.test.ts src/tool/remote-source-tools.test.ts`
- `deno lint src/tool/factory.ts src/tool/factory.test.ts src/tool/remote-source-tools.ts src/tool/remote-source-tools.test.ts src/tool/index.ts docs/reference/tool.md`
- `deno check src/tool/index.ts src/tool/remote-source-tools.ts src/tool/remote-source-tools.test.ts`
- `deno task verify`

Related:
- veryfront-code#940
- veryfront-agent#172