### PR TITLE
Extract HTML project CSS helpers from rendering orchestrator

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.162",
+  "version": "0.1.163",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/rendering/orchestrator/html-project-css.test.ts
+++ b/src/rendering/orchestrator/html-project-css.test.ts
@@ -1,0 +1,139 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  buildRouteManifestKey,
+  extractProjectClassesForRoute,
+  getProjectContentVersion,
+  startProjectCSSPreparation,
+} from "./html-project-css.ts";
+
+describe("rendering/orchestrator/html-project-css", () => {
+  describe("buildRouteManifestKey", () => {
+    it("strips the project root, extension, and pages prefix", () => {
+      assertEquals(
+        buildRouteManifestKey("/project/pages/docs/getting-started.tsx", "/project"),
+        "docs/getting-started",
+      );
+    });
+
+    it("preserves app-router paths outside pages/", () => {
+      assertEquals(
+        buildRouteManifestKey("/project/app/blog/page.tsx", "/project"),
+        "app/blog/page",
+      );
+    });
+  });
+
+  describe("getProjectContentVersion", () => {
+    it("prefers the adapter content context version", () => {
+      const version = getProjectContentVersion({
+        adapter: {
+          fs: {
+            getUnderlyingAdapter: () => ({
+              getContentContext: () => ({
+                sourceType: "branch",
+                projectSlug: "demo",
+                branch: "feature/refactor",
+              }),
+              getProjectData: () => ({ updated_at: "2025-01-01T00:00:00Z" }),
+            }),
+          },
+        } as any,
+      });
+
+      assertEquals(version, "branch:feature/refactor");
+    });
+
+    it("falls back to project updated_at when no content context is available", () => {
+      const version = getProjectContentVersion({
+        adapter: {
+          fs: {
+            getUnderlyingAdapter: () => ({
+              getProjectData: () => ({ updated_at: "2025-01-01T00:00:00Z" }),
+            }),
+          },
+        } as any,
+      });
+
+      assertEquals(version, "2025-01-01T00:00:00Z");
+    });
+  });
+
+  describe("startProjectCSSPreparation", () => {
+    it("skips project CSS generation outside production published contexts", () => {
+      let called = false;
+
+      const result = startProjectCSSPreparation(
+        {
+          slug: "docs",
+        } as any,
+        {
+          environment: "preview",
+          isLocalProject: false,
+          projectSlug: "demo",
+          globalCSS: "body{}",
+          projectClasses: new Set(["prose"]),
+          mode: "production",
+        } as any,
+        {
+          getProjectCSS: () => {
+            called = true;
+            return Promise.resolve({ hash: "abc123" } as any);
+          },
+        },
+      );
+
+      assertEquals(result, undefined);
+      assertEquals(called, false);
+    });
+  });
+
+  describe("extractProjectClassesForRoute", () => {
+    it("delegates route metadata and returns the candidate set", async () => {
+      const calls: Array<Record<string, unknown>> = [];
+
+      const classes = await extractProjectClassesForRoute(
+        {
+          projectDir: "/project",
+          adapter: {
+            fs: {
+              getUnderlyingAdapter: () => ({
+                getAllSourceFiles: () => Promise.resolve([{ path: "/project/pages/docs.tsx" }]),
+              }),
+            },
+          } as any,
+          config: {} as any,
+          mode: "production",
+        },
+        {
+          slug: "docs",
+          pageInfo: { entity: { path: "/project/pages/docs.tsx" } },
+          nestedLayouts: [{
+            path: "/project/layouts/docs.tsx",
+            componentPath: "/project/layouts/docs.tsx",
+          }],
+          options: { projectSlug: "demo-project" },
+        } as any,
+        "/project/app.tsx",
+        {
+          getRouteCandidates: (input) => {
+            calls.push(input as Record<string, unknown>);
+            return new Set(["prose", "docs-page"]);
+          },
+          createStyleScopeProfile: () => ({ mode: "test" }) as any,
+          getProjectContentVersion: () => "version-123",
+        },
+      );
+
+      assertEquals([...classes], ["prose", "docs-page"]);
+      assertEquals(calls.length, 1);
+      assertEquals(calls[0]?.routeKey, "docs");
+      assertEquals(calls[0]?.projectScope, "demo-project");
+      assertEquals(calls[0]?.projectVersion, "version-123");
+      assertEquals(
+        calls[0]?.routeFilePaths,
+        ["/project/pages/docs.tsx", "/project/layouts/docs.tsx", "/project/app.tsx"],
+      );
+    });
+  });
+});

--- a/src/rendering/orchestrator/html-project-css.ts
+++ b/src/rendering/orchestrator/html-project-css.ts
@@ -1,0 +1,203 @@
+import type { VeryfrontConfig } from "#veryfront/config";
+import type { HTMLGenerationOptions } from "#veryfront/html";
+import { getProjectCSS } from "#veryfront/html/styles-builder/index.ts";
+import { warmPreparedCSSArtifactFromFiles } from "#veryfront/html/styles-builder/css-pregeneration.ts";
+import { resolveStyleContentVersion } from "#veryfront/html/styles-builder/content-version.ts";
+import { createStyleScopeProfile } from "#veryfront/html/styles-builder/style-scope-profile.ts";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { ResolvedContentContext } from "#veryfront/platform/adapters/fs/veryfront/types.ts";
+import { rendererLogger } from "#veryfront/utils";
+import { extractRelativePath } from "#veryfront/utils/route-path-utils.ts";
+import { getRouteCandidates } from "./css-candidate-manifest.ts";
+import type { HTMLGenerationContext } from "./html.ts";
+
+const logger = rendererLogger.component("html-project-css");
+
+export type ProjectCSSResult = Awaited<ReturnType<typeof getProjectCSS>> | null;
+
+interface ProjectCssConfig {
+  projectDir: string;
+  adapter: RuntimeAdapter;
+  config: VeryfrontConfig;
+  mode: "development" | "production";
+}
+
+interface ProjectCssDeps {
+  createStyleScopeProfile?: typeof createStyleScopeProfile;
+  getProjectCSS?: typeof getProjectCSS;
+  getProjectContentVersion?: (
+    config: Pick<ProjectCssConfig, "adapter" | "mode">,
+  ) => string | undefined;
+  getRouteCandidates?: typeof getRouteCandidates;
+  resolveStyleContentVersion?: typeof resolveStyleContentVersion;
+  warmPreparedCSSArtifactFromFiles?: typeof warmPreparedCSSArtifactFromFiles;
+}
+
+type SourceFileEntry = { path: string; content?: string };
+
+function getUnderlyingFsAdapter(adapter: RuntimeAdapter): unknown {
+  const wrappedFs = adapter.fs as unknown as { getUnderlyingAdapter?: () => unknown };
+  if (typeof wrappedFs.getUnderlyingAdapter !== "function") return undefined;
+  return wrappedFs.getUnderlyingAdapter();
+}
+
+export function buildRouteManifestKey(pagePath: string, projectDir: string): string {
+  const relativePagePath = extractRelativePath(pagePath, projectDir);
+  return relativePagePath
+    .replace(/\.(tsx|ts|jsx|mdx|md|js)$/, "")
+    .replace(/^pages\//, "");
+}
+
+export function getProjectContentVersion(
+  config: Pick<ProjectCssConfig, "adapter" | "mode">,
+  deps: Pick<ProjectCssDeps, "resolveStyleContentVersion"> = {},
+): string | undefined {
+  const fsAdapter = getUnderlyingFsAdapter(config.adapter) as {
+    getContentContext?: () => ResolvedContentContext | null;
+    getProjectData?: () => { updated_at?: string } | undefined;
+  } | undefined;
+
+  if (!fsAdapter) return undefined;
+
+  const contentContext = typeof fsAdapter.getContentContext === "function"
+    ? fsAdapter.getContentContext()
+    : null;
+  if (contentContext) {
+    const resolveContentVersion = deps.resolveStyleContentVersion ?? resolveStyleContentVersion;
+    return resolveContentVersion(contentContext);
+  }
+
+  return fsAdapter.getProjectData?.()?.updated_at;
+}
+
+export function startProjectCSSPreparation(
+  context: HTMLGenerationContext,
+  htmlOptions: HTMLGenerationOptions,
+  deps: Pick<ProjectCssDeps, "getProjectCSS"> = {},
+): Promise<ProjectCSSResult> | undefined {
+  const isLocalProject = htmlOptions.isLocalProject ?? false;
+  if (isLocalProject || htmlOptions.environment !== "production") return undefined;
+
+  const projectScope = htmlOptions.projectSlug || htmlOptions.projectId || context.slug;
+  if (!projectScope || projectScope === "default") return undefined;
+
+  const getProjectCss = deps.getProjectCSS ?? getProjectCSS;
+  return getProjectCss(
+    projectScope,
+    htmlOptions.globalCSS,
+    new Set([...(htmlOptions.projectClasses ?? [])]),
+    {
+      minify: true,
+      environment: htmlOptions.environment,
+      buildMode: htmlOptions.mode,
+    },
+  );
+}
+
+export function startPreparedCSSWarmup(
+  config: ProjectCssConfig,
+  context: HTMLGenerationContext,
+  htmlOptions: HTMLGenerationOptions,
+  deps: Pick<
+    ProjectCssDeps,
+    "createStyleScopeProfile" | "getProjectContentVersion" | "warmPreparedCSSArtifactFromFiles"
+  > = {},
+): void {
+  const isLocalProject = htmlOptions.isLocalProject ?? false;
+  const usesPreviewStylesheet = isLocalProject || htmlOptions.environment !== "production";
+  if (!usesPreviewStylesheet) return;
+
+  const fsAdapter = getUnderlyingFsAdapter(config.adapter) as {
+    getAllSourceFiles?: () => SourceFileEntry[] | Promise<SourceFileEntry[]>;
+  } | undefined;
+  if (typeof fsAdapter?.getAllSourceFiles !== "function") return;
+
+  const projectScope = htmlOptions.projectSlug || htmlOptions.projectId || context.slug;
+  if (!projectScope || projectScope === "default") return;
+
+  const resolveProjectContentVersion = deps.getProjectContentVersion ?? getProjectContentVersion;
+  const projectVersion = resolveProjectContentVersion(config) ??
+    (config.mode === "development" ? "dev" : "unknown");
+  const createStyleProfile = deps.createStyleScopeProfile ?? createStyleScopeProfile;
+  const warmPreparedCss = deps.warmPreparedCSSArtifactFromFiles ?? warmPreparedCSSArtifactFromFiles;
+  const styleProfile = createStyleProfile(config.config);
+  const stylesheetPath = config.config?.tailwind?.stylesheet;
+
+  Promise.resolve(fsAdapter.getAllSourceFiles())
+    .then((files) =>
+      warmPreparedCss({
+        projectSlug: projectScope,
+        projectVersion,
+        projectDir: config.projectDir,
+        files,
+        styleProfile,
+        stylesheetPath,
+        minify: true,
+        environment: "preview",
+        buildMode: "production",
+      })
+    )
+    .catch((error) => {
+      logger.debug("Prepared CSS warmup skipped after source scan failure", {
+        projectScope,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+}
+
+export async function extractProjectClassesForRoute(
+  config: ProjectCssConfig,
+  context: HTMLGenerationContext,
+  appComponentPath?: string,
+  deps: Pick<
+    ProjectCssDeps,
+    "createStyleScopeProfile" | "getProjectContentVersion" | "getRouteCandidates"
+  > = {},
+): Promise<Set<string>> {
+  const classes = new Set<string>();
+  const fsAdapter = getUnderlyingFsAdapter(config.adapter) as {
+    getAllSourceFiles?: () => SourceFileEntry[] | Promise<SourceFileEntry[]>;
+  } | undefined;
+
+  if (typeof fsAdapter?.getAllSourceFiles !== "function") return classes;
+
+  const files = await fsAdapter.getAllSourceFiles();
+  const projectScope = context.options?.projectSlug || context.options?.projectId ||
+    config.projectDir;
+  const resolveProjectContentVersion = deps.getProjectContentVersion ?? getProjectContentVersion;
+  const projectVersion = resolveProjectContentVersion(config) ??
+    (config.mode === "development" ? "dev" : "unknown");
+  const routeKey = buildRouteManifestKey(context.pageInfo.entity.path, config.projectDir);
+  const routeLayoutPaths = context.nestedLayouts
+    .map((layout) => layout.componentPath || layout.path)
+    .filter((path): path is string => Boolean(path));
+  const routeFilePaths = [
+    context.pageInfo.entity.path,
+    ...routeLayoutPaths,
+    ...(appComponentPath ? [appComponentPath] : []),
+  ];
+
+  const createStyleProfile = deps.createStyleScopeProfile ?? createStyleScopeProfile;
+  const getRouteCssCandidates = deps.getRouteCandidates ?? getRouteCandidates;
+  const routeCandidates = getRouteCssCandidates({
+    projectScope,
+    projectVersion,
+    projectDir: config.projectDir,
+    styleProfile: createStyleProfile(config.config),
+    routeKey,
+    routeFilePaths,
+    files,
+    developmentMode: config.mode === "development",
+  });
+
+  for (const cls of routeCandidates) classes.add(cls);
+
+  logger.debug("extractProjectClasses", {
+    filesProcessed: files.length,
+    routeKey,
+    routeFileCount: routeFilePaths.length,
+    totalClasses: classes.size,
+  });
+
+  return classes;
+}

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -31,15 +31,14 @@ import {
   normalizeCssModuleKey,
   rewriteCssModuleContent,
 } from "#veryfront/transforms/css-modules/naming.ts";
-import { getProjectCSS } from "#veryfront/html/styles-builder/index.ts";
-import { warmPreparedCSSArtifactFromFiles } from "#veryfront/html/styles-builder/css-pregeneration.ts";
-import { getRouteCandidates } from "./css-candidate-manifest.ts";
-import { resolveStyleContentVersion } from "#veryfront/html/styles-builder/content-version.ts";
-import { createStyleScopeProfile } from "#veryfront/html/styles-builder/style-scope-profile.ts";
-import type { ResolvedContentContext } from "#veryfront/platform/adapters/fs/veryfront/types.ts";
+import {
+  extractProjectClassesForRoute,
+  type ProjectCSSResult,
+  startPreparedCSSWarmup,
+  startProjectCSSPreparation,
+} from "./html-project-css.ts";
 
 const logger = rendererLogger.component("html-generator");
-type ProjectCSSResult = Awaited<ReturnType<typeof getProjectCSS>> | null;
 
 function applyExplicitThemeToDocument(
   html: string,
@@ -136,7 +135,7 @@ export class HTMLGenerator {
           "html.build_options",
           () => this.buildHTMLOptions(context, mergedFrontmatter),
         );
-        projectCSSPromise = this.startProjectCSSPreparation(context, htmlOptions);
+        projectCSSPromise = startProjectCSSPreparation(context, htmlOptions);
       }
 
       html = await this.handleFullHTMLDocument(context, projectCSSPromise);
@@ -162,8 +161,8 @@ export class HTMLGenerator {
       "html.build_options",
       () => this.buildHTMLOptions(fullContext, mergedFrontmatter),
     );
-    const projectCSSPromise = this.startProjectCSSPreparation(fullContext, htmlOptions);
-    this.startPreparedCSSWarmup(fullContext, htmlOptions);
+    const projectCSSPromise = startProjectCSSPreparation(fullContext, htmlOptions);
+    startPreparedCSSWarmup(this.config, fullContext, htmlOptions);
 
     let reactContent: string;
     try {
@@ -319,8 +318,8 @@ export class HTMLGenerator {
       "html.build_options",
       () => this.buildHTMLOptions(context, mergedFrontmatter),
     );
-    const projectCSSPromise = this.startProjectCSSPreparation(context, htmlOptions);
-    this.startPreparedCSSWarmup(context, htmlOptions);
+    const projectCSSPromise = startProjectCSSPreparation(context, htmlOptions);
+    startPreparedCSSWarmup(this.config, context, htmlOptions);
     const reactContent = context.html.trim();
 
     const { start, end } = await profilePhase(
@@ -392,76 +391,6 @@ export class HTMLGenerator {
     }
 
     return { start: modifiedStart, end };
-  }
-
-  private startProjectCSSPreparation(
-    context: HTMLGenerationContext,
-    htmlOptions: HTMLGenerationOptions,
-  ): Promise<ProjectCSSResult> | undefined {
-    const isLocalProject = htmlOptions.isLocalProject ?? false;
-    if (isLocalProject || htmlOptions.environment !== "production") return undefined;
-
-    const projectScope = htmlOptions.projectSlug || htmlOptions.projectId || context.slug;
-    if (!projectScope || projectScope === "default") return undefined;
-
-    return getProjectCSS(
-      projectScope,
-      htmlOptions.globalCSS,
-      new Set([...(htmlOptions.projectClasses ?? [])]),
-      {
-        minify: true,
-        environment: htmlOptions.environment,
-        buildMode: htmlOptions.mode,
-      },
-    );
-  }
-
-  private startPreparedCSSWarmup(
-    context: HTMLGenerationContext,
-    htmlOptions: HTMLGenerationOptions,
-  ): void {
-    const isLocalProject = htmlOptions.isLocalProject ?? false;
-    const usesPreviewStylesheet = isLocalProject || htmlOptions.environment !== "production";
-    if (!usesPreviewStylesheet) return;
-
-    const wrappedFs = this.config.adapter.fs as unknown as {
-      getUnderlyingAdapter?: () => unknown;
-    };
-    if (typeof wrappedFs.getUnderlyingAdapter !== "function") return;
-
-    const fsAdapter = wrappedFs.getUnderlyingAdapter() as {
-      getAllSourceFiles?: () =>
-        | Array<{ path: string; content?: string }>
-        | Promise<Array<{ path: string; content?: string }>>;
-    };
-    if (typeof fsAdapter.getAllSourceFiles !== "function") return;
-
-    const projectScope = htmlOptions.projectSlug || htmlOptions.projectId || context.slug;
-    if (!projectScope || projectScope === "default") return;
-
-    const projectVersion = this.getProjectContentVersion() ??
-      (this.config.mode === "development" ? "dev" : "unknown");
-    const styleProfile = createStyleScopeProfile(this.config.config);
-    const stylesheetPath = this.config.config?.tailwind?.stylesheet;
-
-    Promise.resolve(fsAdapter.getAllSourceFiles()).then((files) =>
-      warmPreparedCSSArtifactFromFiles({
-        projectSlug: projectScope,
-        projectVersion,
-        projectDir: this.config.projectDir,
-        files,
-        styleProfile,
-        stylesheetPath,
-        minify: true,
-        environment: "preview",
-        buildMode: "production",
-      })
-    ).catch((error) => {
-      logger.debug("Prepared CSS warmup skipped after source scan failure", {
-        projectScope,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    });
   }
 
   private buildHeadElements(head?: CollectedHead): { scripts: string; other: string } {
@@ -565,7 +494,7 @@ export class HTMLGenerator {
     const appComponentPath = appComponentPathOrNull ?? undefined;
     const projectClasses = await profilePhase(
       "html.route_candidates",
-      () => this.extractProjectClassesForRoute(context, appComponentPath),
+      () => extractProjectClassesForRoute(this.config, context, appComponentPath),
     );
 
     // Load CSS imported by components and merge with globalCSS.
@@ -695,91 +624,5 @@ export class HTMLGenerator {
       totalLength: combined.length,
     });
     return combined;
-  }
-
-  private getProjectContentVersion(): string | undefined {
-    const wrappedFs = this.config.adapter.fs as unknown as {
-      getUnderlyingAdapter?: () => unknown;
-    };
-
-    if (typeof wrappedFs.getUnderlyingAdapter !== "function") return undefined;
-
-    const fsAdapter = wrappedFs.getUnderlyingAdapter() as {
-      getContentContext?: () => ResolvedContentContext | null;
-      getProjectData?: () => { updated_at?: string } | undefined;
-    };
-
-    const contentContext = typeof fsAdapter.getContentContext === "function"
-      ? fsAdapter.getContentContext()
-      : null;
-
-    if (contentContext) return resolveStyleContentVersion(contentContext);
-
-    return fsAdapter.getProjectData?.()?.updated_at;
-  }
-
-  private buildRouteManifestKey(pagePath: string): string {
-    const relativePagePath = extractRelativePath(pagePath, this.config.projectDir);
-    return relativePagePath
-      .replace(/\.(tsx|ts|jsx|mdx|md|js)$/, "")
-      .replace(/^pages\//, "");
-  }
-
-  private async extractProjectClassesForRoute(
-    context: HTMLGenerationContext,
-    appComponentPath?: string,
-  ): Promise<Set<string>> {
-    const classes = new Set<string>();
-
-    const wrappedFs = this.config.adapter.fs as unknown as {
-      getUnderlyingAdapter?: () => unknown;
-    };
-
-    if (typeof wrappedFs.getUnderlyingAdapter !== "function") return classes;
-
-    const fsAdapter = wrappedFs.getUnderlyingAdapter() as {
-      getAllSourceFiles?: () =>
-        | Array<{ path: string; content?: string }>
-        | Promise<Array<{ path: string; content?: string }>>;
-    };
-
-    if (typeof fsAdapter.getAllSourceFiles !== "function") return classes;
-
-    const files = await fsAdapter.getAllSourceFiles();
-    const projectScope = context.options?.projectSlug || context.options?.projectId ||
-      this.config.projectDir;
-    const projectVersion = this.getProjectContentVersion() ??
-      (this.config.mode === "development" ? "dev" : "unknown");
-    const routeKey = this.buildRouteManifestKey(context.pageInfo.entity.path);
-    const routeLayoutPaths = context.nestedLayouts
-      .map((layout) => layout.componentPath || layout.path)
-      .filter((path): path is string => Boolean(path));
-    const routeFilePaths = [
-      context.pageInfo.entity.path,
-      ...routeLayoutPaths,
-      ...(appComponentPath ? [appComponentPath] : []),
-    ];
-
-    const routeCandidates = getRouteCandidates({
-      projectScope,
-      projectVersion,
-      projectDir: this.config.projectDir,
-      styleProfile: createStyleScopeProfile(this.config.config),
-      routeKey,
-      routeFilePaths,
-      files,
-      developmentMode: this.config.mode === "development",
-    });
-
-    for (const cls of routeCandidates) classes.add(cls);
-
-    logger.debug("extractProjectClasses", {
-      filesProcessed: files.length,
-      routeKey,
-      routeFileCount: routeFilePaths.length,
-      totalClasses: classes.size,
-    });
-
-    return classes;
   }
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.162";
+export const VERSION = "0.1.163";


### PR DESCRIPTION
## Summary
- extract project stylesheet/candidate/content-version logic from html.ts into html-project-css.ts
- keep HTMLGenerator focused on HTML assembly while preserving production stylesheet and preview warmup behavior
- add focused helper tests and bump the release version to 0.1.163

## Verification
- deno test --no-check --allow-all src/rendering/orchestrator/html.test.ts src/rendering/orchestrator/html-project-css.test.ts src/utils/version.test.ts
- deno fmt --check src/rendering/orchestrator/html.ts src/rendering/orchestrator/html-project-css.ts src/rendering/orchestrator/html-project-css.test.ts deno.json src/utils/version-constant.ts
- deno lint src/rendering/orchestrator/html.ts src/rendering/orchestrator/html-project-css.ts src/rendering/orchestrator/html-project-css.test.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick