### PR TITLE
Extract render-pipeline data result application helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.165",
+  "version": "0.1.166",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -111,6 +111,13 @@ interface DataResolutionResult {
   layoutProps: Map<string, Record<string, unknown>>;
 }
 
+interface FetchedDataResult {
+  type: "page" | "layout";
+  id: string;
+  result: Awaited<ReturnType<RenderPipeline["dataFetcher"]["fetchData"]>> | null;
+  error: Error | null;
+}
+
 export class RenderPipeline {
   private config: RenderPipelineConfig;
   private dataFetcher: DataFetcher;
@@ -322,6 +329,17 @@ export class RenderPipeline {
       { "render.data_job_count": dataJobs.length },
     );
 
+    this.applyFetchedDataResults(slug, dataResults, pageProps, layoutProps);
+
+    return { params, pageProps, layoutProps };
+  }
+
+  private applyFetchedDataResults(
+    slug: string,
+    dataResults: FetchedDataResult[],
+    pageProps: Record<string, unknown>,
+    layoutProps: Map<string, Record<string, unknown>>,
+  ): void {
     for (const { type, id, result, error } of dataResults) {
       if (error) throw error;
       if (!result) continue;
@@ -348,8 +366,6 @@ export class RenderPipeline {
         layoutProps.set(id, result.props as Record<string, unknown>);
       }
     }
-
-    return { params, pageProps, layoutProps };
   }
 
   async renderPage(slug: string, options?: RenderOptions): Promise<RenderResult> {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.165";
+export const VERSION = "0.1.166";


### PR DESCRIPTION
## Summary
- extract fetched-data result application from resolveDataFetching into a dedicated helper
- keep notFound/redirect/page-vs-layout prop handling centralized
- bump the release version to 0.1.166

## Verification
- deno test --no-check --allow-all src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version.test.ts
- deno fmt --check src/rendering/orchestrator/pipeline.ts deno.json src/utils/version-constant.ts
- deno lint src/rendering/orchestrator/pipeline.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick