### PR TITLE
Extract compiled-binary veryfront rewrite helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.166",
+  "version": "0.1.167",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -4,6 +4,7 @@ import { join } from "#veryfront/compat/path";
 import {
   getNodeExternalPackagesToResolve,
   loadHandlerModule,
+  rewriteCompiledBinaryVeryfrontImports,
   rewriteNodeExternalImports,
   toCjsDestructureBindings,
 } from "./loader.ts";
@@ -341,6 +342,22 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
     );
 
     assertMatch(rewritten, /from "file:\/\/.*node_modules\/my-lib\/dist\/index\.js"/);
+  });
+
+  it("rewrites compiled-binary veryfront root and subpath imports to local shims", () => {
+    const source = [
+      'import { defineConfig } from "veryfront";',
+      'const runtime = import("veryfront");',
+      'import { createAgent } from "veryfront/agent";',
+      'const tool = import("veryfront/tool");',
+    ].join("\n");
+
+    const rewritten = rewriteCompiledBinaryVeryfrontImports(source);
+
+    assertMatch(rewritten, /from "\.\/_vf_runtime\.mjs"/);
+    assertMatch(rewritten, /import\("\.\/_vf_runtime\.mjs"\)/);
+    assertMatch(rewritten, /from "\.\/_vf_agent\.mjs"/);
+    assertMatch(rewritten, /import\("\.\/_vf_tool\.mjs"\)/);
   });
 
   it("rejects module path that escapes project directory via traversal", async () => {

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -799,6 +799,29 @@ export async function rewriteNodeExternalImports(
   return transformed;
 }
 
+export function rewriteCompiledBinaryVeryfrontImports(code: string): string {
+  let transformed = code;
+
+  transformed = transformed.replace(
+    /from\s+["']veryfront["']/g,
+    'from "./_vf_runtime.mjs"',
+  );
+  transformed = transformed.replace(
+    /import\s*\(\s*["']veryfront["']\s*\)/g,
+    'import("./_vf_runtime.mjs")',
+  );
+  transformed = transformed.replace(
+    /from\s+["']veryfront\/([^"']+)["']/g,
+    (_match, subpath: string) => `from "./_vf_${subpath.replace(/\//g, "_")}.mjs"`,
+  );
+  transformed = transformed.replace(
+    /import\s*\(\s*["']veryfront\/([^"']+)["']\s*\)/g,
+    (_match, subpath: string) => `import("./_vf_${subpath.replace(/\//g, "_")}.mjs")`,
+  );
+
+  return transformed;
+}
+
 async function rewriteExternalImports(
   code: string,
   projectDir: string,
@@ -923,26 +946,7 @@ async function rewriteExternalImports(
     // In compiled binaries, "veryfront" resolves to embedded source that can't be
     // imported from external temp files. Rewrite to use local runtime shims.
     if (isCompiledBinary()) {
-      // Static root imports: from "veryfront"
-      transformed = transformed.replace(
-        /from\s+["']veryfront["']/g,
-        'from "./_vf_runtime.mjs"',
-      );
-      // Dynamic root imports: import("veryfront")
-      transformed = transformed.replace(
-        /import\s*\(\s*["']veryfront["']\s*\)/g,
-        'import("./_vf_runtime.mjs")',
-      );
-      // Subpath static imports: from "veryfront/agent" → from "./_vf_agent.mjs"
-      transformed = transformed.replace(
-        /from\s+["']veryfront\/([^"']+)["']/g,
-        (_match, subpath: string) => `from "./_vf_${subpath.replace(/\//g, "_")}.mjs"`,
-      );
-      // Subpath dynamic imports: import("veryfront/agent") → import("./_vf_agent.mjs")
-      transformed = transformed.replace(
-        /import\s*\(\s*["']veryfront\/([^"']+)["']\s*\)/g,
-        (_match, subpath: string) => `import("./_vf_${subpath.replace(/\//g, "_")}.mjs")`,
-      );
+      transformed = rewriteCompiledBinaryVeryfrontImports(transformed);
     }
   }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.166";
+export const VERSION = "0.1.167";


### PR DESCRIPTION
## Summary
- extract compiled-binary veryfront import rewriting into a dedicated helper
- add focused tests for root and subpath static/dynamic shim rewrites
- bump the release version to 0.1.167

## Verification
- deno test --no-check --allow-all src/routing/api/module-loader/loader.test.ts src/utils/version.test.ts
- deno fmt --check src/routing/api/module-loader/loader.ts src/routing/api/module-loader/loader.test.ts deno.json src/utils/version-constant.ts
- deno lint src/routing/api/module-loader/loader.ts src/routing/api/module-loader/loader.test.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick