### PR TITLE
Extract compiled-binary npm rewrite helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.167",
+  "version": "0.1.168",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -4,6 +4,7 @@ import { join } from "#veryfront/compat/path";
 import {
   getNodeExternalPackagesToResolve,
   loadHandlerModule,
+  rewriteCompiledBinaryUserDependencyImports,
   rewriteCompiledBinaryVeryfrontImports,
   rewriteNodeExternalImports,
   toCjsDestructureBindings,
@@ -358,6 +359,32 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
     assertMatch(rewritten, /import\("\.\/_vf_runtime\.mjs"\)/);
     assertMatch(rewritten, /from "\.\/_vf_agent\.mjs"/);
     assertMatch(rewritten, /import\("\.\/_vf_tool\.mjs"\)/);
+  });
+
+  it("rewrites compiled-binary user dependency imports to require-based shims", () => {
+    const source = [
+      'import thing from "my-lib";',
+      'import { alpha as beta } from "my-lib";',
+      'import * as namespace from "my-lib";',
+      'import combo, { gamma } from "my-lib";',
+      'import widget from "my-lib/subpath";',
+      'const loaded = import("my-lib/subpath");',
+    ].join("\n");
+
+    const rewritten = rewriteCompiledBinaryUserDependencyImports(
+      source,
+      new Map([["my-lib", "^1.0.0"]]),
+    );
+
+    assertMatch(rewritten, /const thing = __vf_interopDefault\(require\("my-lib"\)\)/);
+    assertMatch(rewritten, /const \{ alpha: beta \} = require\("my-lib"\)/);
+    assertMatch(rewritten, /const namespace = require\("my-lib"\)/);
+    assertMatch(
+      rewritten,
+      /const __vf_tmp_combo = require\("my-lib"\); const combo = __vf_interopDefault\(__vf_tmp_combo\); const \{ gamma \} = __vf_tmp_combo/,
+    );
+    assertMatch(rewritten, /const widget = require\("my-lib\/subpath"\)/);
+    assertMatch(rewritten, /Promise\.resolve\(require\("my-lib\/subpath"\)\)/);
   });
 
   it("rejects module path that escapes project directory via traversal", async () => {

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -822,6 +822,63 @@ export function rewriteCompiledBinaryVeryfrontImports(code: string): string {
   return transformed;
 }
 
+export function rewriteCompiledBinaryUserDependencyImports(
+  code: string,
+  userDeps: Map<string, string>,
+): string {
+  let transformed = code;
+
+  for (const name of userDeps.keys()) {
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    transformed = transformed.replace(
+      new RegExp(`import\\s+(\\w+)\\s+from\\s+["']${escaped}["']`, "g"),
+      (_, localName) => `const ${localName} = __vf_interopDefault(require("${name}"))`,
+    );
+    transformed = transformed.replace(
+      new RegExp(`import\\s+(\\{[^}]+\\})\\s+from\\s+["']${escaped}["']`, "g"),
+      (_, bindings) => `const ${toCjsDestructureBindings(bindings)} = require("${name}")`,
+    );
+    transformed = transformed.replace(
+      new RegExp(`import\\s+\\*\\s+as\\s+(\\w+)\\s+from\\s+["']${escaped}["']`, "g"),
+      (_, localName) => `const ${localName} = require("${name}")`,
+    );
+    transformed = transformed.replace(
+      new RegExp(
+        `import\\s+(\\w+)\\s*,\\s*(\\{[^}]+\\})\\s+from\\s+["']${escaped}["']`,
+        "g",
+      ),
+      (_, defaultName, bindings) => {
+        const tmp = `__vf_tmp_${defaultName}`;
+        return `const ${tmp} = require("${name}"); const ${defaultName} = __vf_interopDefault(${tmp}); const ${
+          toCjsDestructureBindings(bindings)
+        } = ${tmp}`;
+      },
+    );
+    transformed = transformed.replace(
+      new RegExp(
+        `import\\s+(\\w+|\\*\\s+as\\s+\\w+|\\{[^}]+\\})\\s+from\\s+["']${escaped}(/[^"']+)["']`,
+        "g",
+      ),
+      (_, binding, subpath) => {
+        const trimmedBinding = String(binding).trim();
+        if (trimmedBinding.startsWith("{")) {
+          return `const ${toCjsDestructureBindings(trimmedBinding)} = require("${name}${subpath}")`;
+        }
+        const name_ = trimmedBinding.startsWith("*")
+          ? trimmedBinding.replace(/\*\s+as\s+/, "")
+          : trimmedBinding;
+        return `const ${name_} = require("${name}${subpath}")`;
+      },
+    );
+    transformed = transformed.replace(
+      new RegExp(`import\\s*\\(\\s*["']${escaped}(/[^"']*)?["']\\s*\\)`, "g"),
+      (_, subpath) => `Promise.resolve(require("${name}${subpath || ""}"))`,
+    );
+  }
+
+  return transformed;
+}
+
 async function rewriteExternalImports(
   code: string,
   projectDir: string,
@@ -861,62 +918,7 @@ async function rewriteExternalImports(
     // injected by the esbuild banner) to load CJS packages from node_modules,
     // since npm: specifiers only work for packages embedded at compile time.
     if (isCompiledBinary()) {
-      for (const name of userDeps.keys()) {
-        const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        // Default imports: import foo from "pkg" → const foo = __vf_interopDefault(require("pkg"))
-        // interopDefault unwraps .default for ESM packages transpiled to CJS
-        transformed = transformed.replace(
-          new RegExp(`import\\s+(\\w+)\\s+from\\s+["']${escaped}["']`, "g"),
-          (_, localName) => `const ${localName} = __vf_interopDefault(require("${name}"))`,
-        );
-        // Named imports: import { a, b } from "pkg" → const { a, b } = require("pkg")
-        transformed = transformed.replace(
-          new RegExp(`import\\s+(\\{[^}]+\\})\\s+from\\s+["']${escaped}["']`, "g"),
-          (_, bindings) => `const ${toCjsDestructureBindings(bindings)} = require("${name}")`,
-        );
-        // Namespace imports: import * as foo from "pkg" → const foo = require("pkg")
-        transformed = transformed.replace(
-          new RegExp(`import\\s+\\*\\s+as\\s+(\\w+)\\s+from\\s+["']${escaped}["']`, "g"),
-          (_, localName) => `const ${localName} = require("${name}")`,
-        );
-        // Mixed imports: import foo, { bar } from "pkg"
-        transformed = transformed.replace(
-          new RegExp(
-            `import\\s+(\\w+)\\s*,\\s*(\\{[^}]+\\})\\s+from\\s+["']${escaped}["']`,
-            "g",
-          ),
-          (_, defaultName, bindings) => {
-            const tmp = `__vf_tmp_${defaultName}`;
-            return `const ${tmp} = require("${name}"); const ${defaultName} = __vf_interopDefault(${tmp}); const ${
-              toCjsDestructureBindings(bindings)
-            } = ${tmp}`;
-          },
-        );
-        // Subpath static imports: from "pkg/sub" → require("pkg/sub")
-        transformed = transformed.replace(
-          new RegExp(
-            `import\\s+(\\w+|\\*\\s+as\\s+\\w+|\\{[^}]+\\})\\s+from\\s+["']${escaped}(/[^"']+)["']`,
-            "g",
-          ),
-          (_, binding, subpath) => {
-            const trimmedBinding = String(binding).trim();
-            if (trimmedBinding.startsWith("{")) {
-              return `const ${
-                toCjsDestructureBindings(trimmedBinding)
-              } = require("${name}${subpath}")`;
-            }
-            const name_ = trimmedBinding.startsWith("*")
-              ? trimmedBinding.replace(/\*\s+as\s+/, "")
-              : trimmedBinding;
-            return `const ${name_} = require("${name}${subpath}")`;
-          },
-        );
-        // Dynamic imports: import("pkg") → Promise.resolve(require("pkg"))
-        transformed = transformed.replace(
-          new RegExp(`import\\s*\\(\\s*["']${escaped}(/[^"']*)?["']\\s*\\)`, "g"),
-          (_, subpath) => `Promise.resolve(require("${name}${subpath || ""}"))`,
-        );
-      }
+      transformed = rewriteCompiledBinaryUserDependencyImports(transformed, userDeps);
     } else {
       for (const [name, version] of userDeps) {
         const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.167";
+export const VERSION = "0.1.168";


### PR DESCRIPTION
## Summary
- extract compiled-binary npm dependency rewriting into a dedicated helper
- add focused tests for default, named, mixed, subpath, and dynamic rewrites
- bump the release version to 0.1.168

## Verification
- deno test --no-check --allow-all src/routing/api/module-loader/loader.test.ts src/utils/version.test.ts
- deno fmt --check src/routing/api/module-loader/loader.ts src/routing/api/module-loader/loader.test.ts deno.json src/utils/version-constant.ts
- deno lint src/routing/api/module-loader/loader.ts src/routing/api/module-loader/loader.test.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick