### PR TITLE
Preserve reasoning events in hosted AG-UI streams

### DIFF
--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -430,13 +430,32 @@ describe("chat-stream-handler", () => {
       assertEquals(events[0], { type: "error", error: "raw string error" });
     });
 
+    it("forwards reasoning stream parts", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        { type: "reasoning-start", id: "reasoning-1" },
+        { type: "reasoning-delta", id: "reasoning-1", delta: "thinking..." },
+        { type: "reasoning-end", id: "reasoning-1" },
+        { type: "finish", finishReason: "stop", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      assertEquals(events, [
+        { type: "reasoning-start", id: "reasoning-1" },
+        { type: "reasoning-delta", id: "reasoning-1", delta: "thinking..." },
+        { type: "reasoning-end", id: "reasoning-1" },
+      ]);
+    });
+
     it("ignores unrecognized stream part types", async () => {
       const { events, controller, encoder } = createSSECollector();
       const state = createStreamState();
 
       const result = createMockResult([
         { type: "source", source: { id: "s1" } },
-        { type: "reasoning-delta", delta: "thinking..." },
         { type: "text-delta", text: "ok" },
         { type: "finish", finishReason: "stop", totalUsage: null },
       ]);

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -200,6 +200,31 @@ export function processStream(
           break;
         }
 
+        case "reasoning-start": {
+          sendSSE(controller, encoder, {
+            type: "reasoning-start",
+            id: typeof typedPart.id === "string" ? typedPart.id : "reasoning",
+          });
+          break;
+        }
+
+        case "reasoning-delta": {
+          sendSSE(controller, encoder, {
+            type: "reasoning-delta",
+            id: typeof typedPart.id === "string" ? typedPart.id : "reasoning",
+            delta: typeof typedPart.delta === "string" ? typedPart.delta : "",
+          });
+          break;
+        }
+
+        case "reasoning-end": {
+          sendSSE(controller, encoder, {
+            type: "reasoning-end",
+            id: typeof typedPart.id === "string" ? typedPart.id : "reasoning",
+          });
+          break;
+        }
+
         case "tool-input-start": {
           const toolId = typedPart.id;
           state.toolCalls.set(toolId, {

--- a/src/agent/runtime/runtime-tool-types.ts
+++ b/src/agent/runtime/runtime-tool-types.ts
@@ -59,6 +59,9 @@ export type RuntimeToolCallRepairFunction = (
 
 export type RuntimeStreamPart =
   | { type: "text-delta"; text: string }
+  | { type: "reasoning-start"; id: string }
+  | { type: "reasoning-delta"; id: string; delta: string }
+  | { type: "reasoning-end"; id: string }
   | {
     type: "tool-input-start";
     id: string;

--- a/src/internal-agents/ag-ui-sse.test.ts
+++ b/src/internal-agents/ag-ui-sse.test.ts
@@ -156,6 +156,40 @@ describe("internal-agents/ag-ui-sse", () => {
     assertEquals(finalizeRunEvents(state, null), []);
   });
 
+  it("maps runtime reasoning events to AG-UI reasoning message events", () => {
+    const state = createStreamTransformState();
+
+    assertEquals(
+      mapRuntimeEventToAgUi(state, { type: "message-start", messageId: "assistant-3" }),
+      [],
+    );
+    assertEquals(
+      mapRuntimeEventToAgUi(state, { type: "reasoning-start", id: "reasoning-1" }),
+      [{
+        event: "ReasoningMessageStart",
+        payload: { messageId: "assistant-3:reasoning:reasoning-1", role: "reasoning" },
+      }],
+    );
+    assertEquals(
+      mapRuntimeEventToAgUi(state, {
+        type: "reasoning-delta",
+        id: "reasoning-1",
+        delta: "thinking...",
+      }),
+      [{
+        event: "ReasoningMessageContent",
+        payload: { messageId: "assistant-3:reasoning:reasoning-1", delta: "thinking..." },
+      }],
+    );
+    assertEquals(
+      mapRuntimeEventToAgUi(state, { type: "reasoning-end", id: "reasoning-1" }),
+      [{
+        event: "ReasoningMessageEnd",
+        payload: { messageId: "assistant-3:reasoning:reasoning-1" },
+      }],
+    );
+  });
+
   it("finalizes open assistant text with usage metadata", () => {
     const state = createStreamTransformState();
     mapRuntimeEventToAgUi(state, { type: "message-start", messageId: "assistant-1" });

--- a/src/internal-agents/ag-ui-sse.ts
+++ b/src/internal-agents/ag-ui-sse.ts
@@ -19,6 +19,7 @@ export interface RunFinishedMetadata {
 export interface StreamTransformState {
   messageId: string | null;
   textOpen: boolean;
+  reasoningMessageId: string | null;
   sawVisibleOutput: boolean;
   sawTerminalError: boolean;
   metadata: RunFinishedMetadata;
@@ -28,6 +29,7 @@ export function createStreamTransformState(): StreamTransformState {
   return {
     messageId: null,
     textOpen: false,
+    reasoningMessageId: null,
     sawVisibleOutput: false,
     sawTerminalError: false,
     metadata: {},
@@ -61,6 +63,17 @@ const agUiEventPayloadSchemas = {
     delta: z.string(),
   }),
   TextMessageEnd: z.object({
+    messageId: z.string().min(1),
+  }),
+  ReasoningMessageStart: z.object({
+    messageId: z.string().min(1),
+    role: z.literal("reasoning"),
+  }),
+  ReasoningMessageContent: z.object({
+    messageId: z.string().min(1),
+    delta: z.string(),
+  }),
+  ReasoningMessageEnd: z.object({
     messageId: z.string().min(1),
   }),
   ToolCallStart: z.object({
@@ -150,6 +163,23 @@ function getMessageId(state: StreamTransformState, event: RuntimeDataEvent): str
   return state.messageId;
 }
 
+function getReasoningMessageId(state: StreamTransformState, event: RuntimeDataEvent): string {
+  if (typeof event.id === "string" && event.id.length > 0) {
+    state.reasoningMessageId = state.messageId
+      ? `${state.messageId}:reasoning:${event.id}`
+      : event.id;
+    return state.reasoningMessageId;
+  }
+
+  if (!state.reasoningMessageId) {
+    state.reasoningMessageId = state.messageId
+      ? `${state.messageId}:reasoning:${crypto.randomUUID()}`
+      : crypto.randomUUID();
+  }
+
+  return state.reasoningMessageId;
+}
+
 function applyDataMetadata(state: StreamTransformState, event: RuntimeDataEvent): void {
   const data = event.data && typeof event.data === "object" && !Array.isArray(event.data)
     ? event.data as Record<string, unknown>
@@ -227,6 +257,32 @@ export function mapRuntimeEventToAgUi(
       return [{
         event: "TextMessageEnd",
         payload: { messageId: getMessageId(state, event) },
+      }];
+    }
+
+    case "reasoning-start":
+      state.sawVisibleOutput = true;
+      return [{
+        event: "ReasoningMessageStart",
+        payload: { messageId: getReasoningMessageId(state, event), role: "reasoning" },
+      }];
+
+    case "reasoning-delta":
+      state.sawVisibleOutput = true;
+      return [{
+        event: "ReasoningMessageContent",
+        payload: {
+          messageId: getReasoningMessageId(state, event),
+          delta: typeof event.delta === "string" ? event.delta : "",
+        },
+      }];
+
+    case "reasoning-end": {
+      const messageId = getReasoningMessageId(state, event);
+      state.reasoningMessageId = null;
+      return [{
+        event: "ReasoningMessageEnd",
+        payload: { messageId },
       }];
     }
 

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -165,6 +165,19 @@ describe("server/handlers/request/agent-stream.handler", () => {
                 encodeDataStreamEvent({ type: "message-start", messageId: "assistant-msg-1" }),
               );
               controller.enqueue(encodeDataStreamEvent({ type: "step-start" }));
+              controller.enqueue(
+                encodeDataStreamEvent({ type: "reasoning-start", id: "reasoning-1" }),
+              );
+              controller.enqueue(
+                encodeDataStreamEvent({
+                  type: "reasoning-delta",
+                  id: "reasoning-1",
+                  delta: "thinking through the answer",
+                }),
+              );
+              controller.enqueue(
+                encodeDataStreamEvent({ type: "reasoning-end", id: "reasoning-1" }),
+              );
               controller.enqueue(encodeDataStreamEvent({ type: "text-start", id: "text-1" }));
               controller.enqueue(
                 encodeDataStreamEvent({
@@ -216,9 +229,9 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(text.includes("event: Custom"), false);
     assertEquals(text.includes("event: ActivitySnapshot"), false);
     assertEquals(text.includes("event: ActivityDelta"), false);
-    assertEquals(text.includes("event: ReasoningStart"), false);
-    assertEquals(text.includes("event: ReasoningContent"), false);
-    assertEquals(text.includes("event: ReasoningEnd"), false);
+    assertStringIncludes(text, "event: ReasoningMessageStart");
+    assertStringIncludes(text, "event: ReasoningMessageContent");
+    assertStringIncludes(text, "event: ReasoningMessageEnd");
   });
 
   it("accepts the canonical runtime AG-UI request shape on the existing internal stream route", async () => {

--- a/src/server/handlers/request/internal-agent-run.test-helpers.ts
+++ b/src/server/handlers/request/internal-agent-run.test-helpers.ts
@@ -139,6 +139,19 @@ export function createInjectedToolRuntime(toolName: string, toolCallId: string, 
               inferenceMode: "cloud",
             },
           }));
+          controller.enqueue(
+            encodeDataStreamEvent({ type: "reasoning-start", id: "reasoning-1" }),
+          );
+          controller.enqueue(
+            encodeDataStreamEvent({
+              type: "reasoning-delta",
+              id: "reasoning-1",
+              delta: "Thinking through the change.",
+            }),
+          );
+          controller.enqueue(
+            encodeDataStreamEvent({ type: "reasoning-end", id: "reasoning-1" }),
+          );
           controller.enqueue(encodeDataStreamEvent({ type: "text-start", id: "assistant-1" }));
           controller.enqueue(encodeDataStreamEvent({ type: "step-start" }));
           controller.enqueue(encodeDataStreamEvent({


### PR DESCRIPTION
## Summary
- forward reasoning stream parts through the hosted runtime SSE path
- map reasoning parts into AG-UI reasoning message events for browser-facing consumers
- lock the route-level behavior with regression coverage

## Why
`veryfront-agent` still needs local compatibility because the hosted `veryfront-code` runtime was dropping reasoning parts before the AG-UI formatter saw them. This narrows `veryfront-code#953` to the first high-value parity slice without mixing in step/custom event work.

## Testing
- deno test --no-check --allow-all src/agent/ag-ui-handler.test.ts src/agent/runtime/chat-stream-handler.test.ts src/internal-agents/ag-ui-sse.test.ts src/server/handlers/request/agent-stream.handler.test.ts
- deno lint src/agent/runtime/chat-stream-handler.ts src/agent/runtime/runtime-tool-types.ts src/agent/runtime/chat-stream-handler.test.ts src/internal-agents/ag-ui-sse.ts src/internal-agents/ag-ui-sse.test.ts src/server/handlers/request/internal-agent-run.test-helpers.ts src/server/handlers/request/agent-stream.handler.test.ts
- deno check src/agent/runtime/chat-stream-handler.ts src/agent/runtime/runtime-tool-types.ts src/agent/runtime/chat-stream-handler.test.ts src/internal-agents/ag-ui-sse.ts src/internal-agents/ag-ui-sse.test.ts src/server/handlers/request/internal-agent-run.test-helpers.ts src/server/handlers/request/agent-stream.handler.test.ts
- deno task verify

Related: #953