### PR TITLE
Extract Deno npm rewrite helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.168",
+  "version": "0.1.169",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -6,6 +6,7 @@ import {
   loadHandlerModule,
   rewriteCompiledBinaryUserDependencyImports,
   rewriteCompiledBinaryVeryfrontImports,
+  rewriteDenoNpmDependencyImports,
   rewriteNodeExternalImports,
   toCjsDestructureBindings,
 } from "./loader.ts";
@@ -385,6 +386,48 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
     );
     assertMatch(rewritten, /const widget = require\("my-lib\/subpath"\)/);
     assertMatch(rewritten, /Promise\.resolve\(require\("my-lib\/subpath"\)\)/);
+  });
+
+  it("rewrites non-compiled deno user dependency imports to npm: specifiers with resolved versions", async () => {
+    const tmpDir = await makeTempDir();
+    const depDir = join(tmpDir, "node_modules", "my-lib");
+    await fs.mkdir(depDir, { recursive: true });
+    await fs.writeTextFile(
+      join(depDir, "package.json"),
+      JSON.stringify({
+        version: "1.2.3",
+      }),
+    );
+
+    const source = [
+      'import thing from "my-lib";',
+      'import widget from "my-lib/subpath";',
+      'const loaded = import("my-lib/subpath");',
+    ].join("\n");
+
+    const rewritten = await rewriteDenoNpmDependencyImports(
+      source,
+      tmpDir,
+      fs,
+      new Map([["my-lib", "^1.0.0"]]),
+    );
+
+    assertMatch(rewritten, /from "npm:my-lib@1\.2\.3"/);
+    assertMatch(rewritten, /from "npm:my-lib@1\.2\.3\/subpath"/);
+    assertMatch(rewritten, /import\("npm:my-lib@1\.2\.3\/subpath"\)/);
+  });
+
+  it("falls back to declared ranges when node_modules package versions are unavailable", async () => {
+    const tmpDir = await makeTempDir();
+
+    const rewritten = await rewriteDenoNpmDependencyImports(
+      'import thing from "my-lib";',
+      tmpDir,
+      fs,
+      new Map([["my-lib", "^1.0.0"]]),
+    );
+
+    assertMatch(rewritten, /from "npm:my-lib@\^1\.0\.0"/);
   });
 
   it("rejects module path that escapes project directory via traversal", async () => {

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -879,6 +879,39 @@ export function rewriteCompiledBinaryUserDependencyImports(
   return transformed;
 }
 
+export async function rewriteDenoNpmDependencyImports(
+  code: string,
+  projectDir: string,
+  fs: FileSystem,
+  userDeps: Map<string, string>,
+): Promise<string> {
+  let transformed = code;
+
+  for (const [name, version] of userDeps) {
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    let resolvedVersion = version;
+    try {
+      const pkgPath = pathHelper.join(projectDir, "node_modules", name, "package.json");
+      const pkgContent = await fs.readTextFile(pkgPath);
+      const pkg = JSON.parse(pkgContent) as { version?: string };
+      if (pkg.version) resolvedVersion = pkg.version;
+    } catch (_) {
+      /* expected: installed package.json may not exist, fall back to declared range */
+    }
+
+    transformed = transformed.replace(
+      new RegExp(`from\\s+["']${escaped}(/[^"']*)?["']`, "g"),
+      (_, subpath) => `from "npm:${name}@${resolvedVersion}${subpath || ""}"`,
+    );
+    transformed = transformed.replace(
+      new RegExp(`import\\s*\\(\\s*["']${escaped}(/[^"']*)?["']\\s*\\)`, "g"),
+      (_, subpath) => `import("npm:${name}@${resolvedVersion}${subpath || ""}")`,
+    );
+  }
+
+  return transformed;
+}
+
 async function rewriteExternalImports(
   code: string,
   projectDir: string,
@@ -920,29 +953,7 @@ async function rewriteExternalImports(
     if (isCompiledBinary()) {
       transformed = rewriteCompiledBinaryUserDependencyImports(transformed, userDeps);
     } else {
-      for (const [name, version] of userDeps) {
-        const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        // Resolve exact installed version from node_modules (falls back to range)
-        let resolvedVersion = version;
-        try {
-          const pkgPath = pathHelper.join(projectDir, "node_modules", name, "package.json");
-          const pkgContent = await fs.readTextFile(pkgPath);
-          const pkg = JSON.parse(pkgContent) as { version?: string };
-          if (pkg.version) resolvedVersion = pkg.version;
-        } catch (_) {
-          /* expected: installed package.json may not exist, fall back to declared range */
-        }
-        // Static: from "pkg" and from "pkg/sub"
-        transformed = transformed.replace(
-          new RegExp(`from\\s+["']${escaped}(/[^"']*)?["']`, "g"),
-          (_, subpath) => `from "npm:${name}@${resolvedVersion}${subpath || ""}"`,
-        );
-        // Dynamic: import("pkg") and import("pkg/sub")
-        transformed = transformed.replace(
-          new RegExp(`import\\s*\\(\\s*["']${escaped}(/[^"']*)?["']\\s*\\)`, "g"),
-          (_, subpath) => `import("npm:${name}@${resolvedVersion}${subpath || ""}")`,
-        );
-      }
+      transformed = await rewriteDenoNpmDependencyImports(transformed, projectDir, fs, userDeps);
     }
 
     // In compiled binaries, "veryfront" resolves to embedded source that can't be

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.168";
+export const VERSION = "0.1.169";


### PR DESCRIPTION
## Summary
- extract non-compiled Deno npm dependency rewriting into a dedicated helper
- add focused tests for resolved versions, subpaths, dynamic imports, and range fallback
- bump the release version to 0.1.169

## Verification
- deno test --no-check --allow-all src/routing/api/module-loader/loader.test.ts src/utils/version.test.ts
- deno fmt --check src/routing/api/module-loader/loader.ts src/routing/api/module-loader/loader.test.ts deno.json src/utils/version-constant.ts
- deno lint src/routing/api/module-loader/loader.ts src/routing/api/module-loader/loader.test.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick