### PR TITLE
Extract Deno node builtin rewrite helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.169",
+  "version": "0.1.170",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -6,6 +6,7 @@ import {
   loadHandlerModule,
   rewriteCompiledBinaryUserDependencyImports,
   rewriteCompiledBinaryVeryfrontImports,
+  rewriteDenoNodeBuiltinImports,
   rewriteDenoNpmDependencyImports,
   rewriteNodeExternalImports,
   toCjsDestructureBindings,
@@ -428,6 +429,20 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
     );
 
     assertMatch(rewritten, /from "npm:my-lib@\^1\.0\.0"/);
+  });
+
+  it("rewrites bare node builtins to node:-prefixed specifiers for deno compatibility", () => {
+    const source = [
+      'import { readFile } from "fs";',
+      'const path = import("path");',
+      'import { join } from "node:path";',
+    ].join("\n");
+
+    const rewritten = rewriteDenoNodeBuiltinImports(source);
+
+    assertMatch(rewritten, /from "node:fs"/);
+    assertMatch(rewritten, /import\("node:path"\)/);
+    assertMatch(rewritten, /from "node:path"/);
   });
 
   it("rejects module path that escapes project directory via traversal", async () => {

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -912,6 +912,24 @@ export async function rewriteDenoNpmDependencyImports(
   return transformed;
 }
 
+export function rewriteDenoNodeBuiltinImports(code: string): string {
+  let transformed = code;
+
+  for (const mod of NODE_BUILTINS) {
+    const escaped = mod.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    transformed = transformed.replace(
+      new RegExp(`from\\s+["']${escaped}["']`, "g"),
+      `from "node:${mod}"`,
+    );
+    transformed = transformed.replace(
+      new RegExp(`import\\s*\\(\\s*["']${escaped}["']\\s*\\)`, "g"),
+      `import("node:${mod}")`,
+    );
+  }
+
+  return transformed;
+}
+
 async function rewriteExternalImports(
   code: string,
   projectDir: string,
@@ -930,20 +948,7 @@ async function rewriteExternalImports(
 
   if (isDeno) {
     transformed = rewriteNpmImports(transformed);
-
-    // Rewrite bare Node.js built-in imports to node: prefix for Deno compatibility.
-    // npm packages often use require('fs') / from "fs" without the node: prefix.
-    for (const mod of NODE_BUILTINS) {
-      const escaped = mod.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      transformed = transformed.replace(
-        new RegExp(`from\\s+["']${escaped}["']`, "g"),
-        `from "node:${mod}"`,
-      );
-      transformed = transformed.replace(
-        new RegExp(`import\\s*\\(\\s*["']${escaped}["']\\s*\\)`, "g"),
-        `import("node:${mod}")`,
-      );
-    }
+    transformed = rewriteDenoNodeBuiltinImports(transformed);
 
     // Rewrite user-installed npm dependencies.
     // In non-compiled Deno: use npm: specifiers (resolved by Deno's npm support).

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.169";
+export const VERSION = "0.1.170";


### PR DESCRIPTION
## Summary
- extract Deno node-builtin import rewriting into a dedicated helper
- add focused test coverage for static and dynamic builtin rewrites
- bump the release version to 0.1.170

## Verification
- deno test --no-check --allow-all src/routing/api/module-loader/loader.test.ts src/utils/version.test.ts
- deno fmt --check src/routing/api/module-loader/loader.ts src/routing/api/module-loader/loader.test.ts deno.json src/utils/version-constant.ts
- deno lint src/routing/api/module-loader/loader.ts src/routing/api/module-loader/loader.test.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick