### PR TITLE
Extract rendering HTML head helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.170",
+  "version": "0.1.171",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/rendering/orchestrator/html-head.ts
+++ b/src/rendering/orchestrator/html-head.ts
@@ -1,0 +1,74 @@
+import type { CollectedHead } from "#veryfront/react/head-collector.ts";
+import type { MdxBundle, MDXFrontmatter } from "#veryfront/types";
+
+interface FrontmatterContextLike {
+  pageInfo: { entity: { frontmatter?: Record<string, unknown> } };
+  pageBundle: Pick<MdxBundle, "frontmatter">;
+  collectedMetadata?: Record<string, unknown>;
+}
+
+export function buildHeadElements(head?: CollectedHead): { scripts: string; other: string } {
+  if (!head) return { scripts: "", other: "" };
+
+  const scriptParts: string[] = [];
+  const otherParts: string[] = [];
+
+  for (const script of head.scripts ?? []) {
+    const { content, ...attrs } = script;
+    const attrPairs: [string, string][] = [["data-vf-head", "true"]];
+
+    for (const [k, v] of Object.entries(attrs)) {
+      if (v != null) attrPairs.push([k, v]);
+    }
+
+    if (content && !attrs.id) {
+      let sum = 0;
+      for (let i = 0; i < Math.min(content.length, 200); i++) {
+        sum = ((sum << 5) - sum + content.charCodeAt(i)) | 0;
+      }
+      attrPairs.push(["data-vf-hash", "vf" + Math.abs(sum).toString(36)]);
+    }
+
+    const attrStr = attrPairs.map(([k, v]) => `${k}="${v}"`).join(" ");
+    if (content) {
+      scriptParts.push(`<script ${attrStr}>${content}</script>`);
+    } else if (attrs.src) {
+      scriptParts.push(`<script ${attrStr}></script>`);
+    }
+  }
+
+  for (const meta of head.metas) {
+    if (meta.name === "description") continue;
+
+    const attrs: string[] = [];
+    if (meta.name) attrs.push(`name="${meta.name}"`);
+    if (meta.property) attrs.push(`property="${meta.property}"`);
+    if (meta.content) attrs.push(`content="${meta.content}"`);
+    if (attrs.length) otherParts.push(`<meta ${attrs.join(" ")}>`);
+  }
+
+  for (const link of head.links) {
+    const attrs = Object.entries(link)
+      .filter(([, v]) => v != null)
+      .map(([k, v]) => `${k}="${v}"`)
+      .join(" ");
+    if (attrs) otherParts.push(`<link ${attrs}>`);
+  }
+
+  for (const style of head.styles) {
+    otherParts.push(`<style>${style}</style>`);
+  }
+
+  return {
+    scripts: scriptParts.join("\n  "),
+    other: otherParts.join("\n  "),
+  };
+}
+
+export function mergeFrontmatter(context: FrontmatterContextLike): MDXFrontmatter {
+  return {
+    ...context.pageInfo.entity.frontmatter,
+    ...context.pageBundle.frontmatter,
+    ...(context.collectedMetadata ?? {}),
+  } as MDXFrontmatter;
+}

--- a/src/rendering/orchestrator/html.test.ts
+++ b/src/rendering/orchestrator/html.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { HTMLGenerator, type HTMLGeneratorConfig } from "./html.ts";
+import { buildHeadElements, mergeFrontmatter } from "./html-head.ts";
 
 type Head = {
   metas: Array<{ name?: string; property?: string; content?: string }>;
@@ -8,62 +9,17 @@ type Head = {
   styles: string[];
 };
 
-// ---- Inline reimplementation of non-exported helpers ----
-
-function buildHeadElements(head?: Head): string {
-  if (!head) return "";
-
-  const parts: string[] = [];
-
-  for (const meta of head.metas) {
-    if (meta.name === "description") continue;
-
-    const attrs: string[] = [];
-    if (meta.name) attrs.push(`name="${meta.name}"`);
-    if (meta.property) attrs.push(`property="${meta.property}"`);
-    if (meta.content) attrs.push(`content="${meta.content}"`);
-
-    if (attrs.length) parts.push(`<meta ${attrs.join(" ")}>`);
-  }
-
-  for (const link of head.links) {
-    const attrs = Object.entries(link)
-      .filter(([, v]) => v != null)
-      .map(([k, v]) => `${k}="${v}"`)
-      .join(" ");
-
-    if (attrs) parts.push(`<link ${attrs}>`);
-  }
-
-  for (const style of head.styles) {
-    parts.push(`<style>${style}</style>`);
-  }
-
-  return parts.join("\n  ");
-}
-
-function mergeFrontmatter(context: {
-  pageInfo: { entity: { frontmatter?: Record<string, unknown> } };
-  pageBundle: { frontmatter?: Record<string, unknown> };
-  collectedMetadata?: Record<string, unknown>;
-}): Record<string, unknown> {
-  return {
-    ...context.pageInfo.entity.frontmatter,
-    ...context.pageBundle.frontmatter,
-    ...(context.collectedMetadata ?? {}),
-  };
-}
-
-// ---- Tests ----
-
 describe("HTMLGenerator helpers", () => {
   describe("buildHeadElements", () => {
     it("should return empty string for undefined head", () => {
-      assertEquals(buildHeadElements(undefined), "");
+      assertEquals(buildHeadElements(undefined), { scripts: "", other: "" });
     });
 
     it("should return empty string for empty head", () => {
-      assertEquals(buildHeadElements({ metas: [], links: [], styles: [] }), "");
+      assertEquals(buildHeadElements({ metas: [], links: [], styles: [], scripts: [] } as any), {
+        scripts: "",
+        other: "",
+      });
     });
 
     it("should skip description meta tags", () => {
@@ -72,7 +28,7 @@ describe("HTMLGenerator helpers", () => {
         links: [],
         styles: [],
       };
-      assertEquals(buildHeadElements(head), "");
+      assertEquals(buildHeadElements({ ...head, scripts: [] } as any), { scripts: "", other: "" });
     });
 
     it("should render meta tags with name attribute", () => {
@@ -81,7 +37,7 @@ describe("HTMLGenerator helpers", () => {
         links: [],
         styles: [],
       };
-      const result = buildHeadElements(head);
+      const result = buildHeadElements({ ...head, scripts: [] } as any).other;
       assertEquals(result.includes('name="viewport"'), true);
       assertEquals(result.includes('content="width=device-width"'), true);
     });
@@ -92,7 +48,7 @@ describe("HTMLGenerator helpers", () => {
         links: [],
         styles: [],
       };
-      const result = buildHeadElements(head);
+      const result = buildHeadElements({ ...head, scripts: [] } as any).other;
       assertEquals(result.includes('property="og:title"'), true);
       assertEquals(result.includes('content="My Page"'), true);
     });
@@ -103,7 +59,7 @@ describe("HTMLGenerator helpers", () => {
         links: [{ rel: "stylesheet", href: "/style.css", integrity: null }],
         styles: [],
       };
-      const result = buildHeadElements(head);
+      const result = buildHeadElements({ ...head, scripts: [] } as any).other;
       assertEquals(result.includes('rel="stylesheet"'), true);
       assertEquals(result.includes('href="/style.css"'), true);
       assertEquals(result.includes("integrity"), false);
@@ -115,7 +71,7 @@ describe("HTMLGenerator helpers", () => {
         links: [],
         styles: [".body { color: red; }", ".header { font-size: 2rem; }"],
       };
-      const result = buildHeadElements(head);
+      const result = buildHeadElements({ ...head, scripts: [] } as any).other;
       assertEquals(result.includes("<style>.body { color: red; }</style>"), true);
       assertEquals(result.includes("<style>.header { font-size: 2rem; }</style>"), true);
     });
@@ -129,7 +85,7 @@ describe("HTMLGenerator helpers", () => {
         links: [{ rel: "icon", href: "/favicon.ico" }],
         styles: [".body { margin: 0; }"],
       };
-      const result = buildHeadElements(head);
+      const result = buildHeadElements({ ...head, scripts: [] } as any).other;
       assertEquals(result.includes("<meta"), true);
       assertEquals(result.includes("<link"), true);
       assertEquals(result.includes("<style>"), true);

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -37,6 +37,10 @@ import {
   startPreparedCSSWarmup,
   startProjectCSSPreparation,
 } from "./html-project-css.ts";
+import {
+  buildHeadElements as buildCollectedHeadElements,
+  mergeFrontmatter as mergeCollectedFrontmatter,
+} from "./html-head.ts";
 
 const logger = rendererLogger.component("html-generator");
 
@@ -130,7 +134,7 @@ export class HTMLGenerator {
     if (isFullHTMLDocument(context.html)) {
       let projectCSSPromise: Promise<ProjectCSSResult> | undefined;
       if (this.config.mode === "production" && context.options?.environment === "production") {
-        const mergedFrontmatter = this.mergeFrontmatter(context);
+        const mergedFrontmatter = mergeCollectedFrontmatter(context);
         const htmlOptions = await profilePhase(
           "html.build_options",
           () => this.buildHTMLOptions(context, mergedFrontmatter),
@@ -156,7 +160,7 @@ export class HTMLGenerator {
     context: Omit<HTMLGenerationContext, "html">,
   ): Promise<ReadableStream> {
     const fullContext = context as HTMLGenerationContext;
-    const mergedFrontmatter = this.mergeFrontmatter(fullContext);
+    const mergedFrontmatter = mergeCollectedFrontmatter(fullContext);
     const htmlOptions = await profilePhase(
       "html.build_options",
       () => this.buildHTMLOptions(fullContext, mergedFrontmatter),
@@ -313,7 +317,7 @@ export class HTMLGenerator {
   }
 
   private async wrapHTMLFragment(context: HTMLGenerationContext): Promise<string> {
-    const mergedFrontmatter = this.mergeFrontmatter(context);
+    const mergedFrontmatter = mergeCollectedFrontmatter(context);
     const htmlOptions = await profilePhase(
       "html.build_options",
       () => this.buildHTMLOptions(context, mergedFrontmatter),
@@ -369,7 +373,7 @@ export class HTMLGenerator {
       projectCSSPromise,
     );
 
-    const { scripts, other } = this.buildHeadElements(head);
+    const { scripts, other } = buildCollectedHeadElements(head);
     if (!scripts && !other) return { start, end };
 
     let modifiedStart = start;
@@ -391,74 +395,6 @@ export class HTMLGenerator {
     }
 
     return { start: modifiedStart, end };
-  }
-
-  private buildHeadElements(head?: CollectedHead): { scripts: string; other: string } {
-    if (!head) return { scripts: "", other: "" };
-
-    const scriptParts: string[] = [];
-    const otherParts: string[] = [];
-
-    // Scripts go at TOP of head (before CSS) to prevent flash
-    for (const script of head.scripts ?? []) {
-      const { content, ...attrs } = script;
-      const attrPairs: [string, string][] = [["data-vf-head", "true"]];
-
-      for (const [k, v] of Object.entries(attrs)) {
-        if (v != null) attrPairs.push([k, v]);
-      }
-
-      // For inline scripts without id, add hash for client-side deduplication
-      if (content && !attrs.id) {
-        let sum = 0;
-        for (let i = 0; i < Math.min(content.length, 200); i++) {
-          sum = ((sum << 5) - sum + content.charCodeAt(i)) | 0;
-        }
-        attrPairs.push(["data-vf-hash", "vf" + Math.abs(sum).toString(36)]);
-      }
-
-      const attrStr = attrPairs.map(([k, v]) => `${k}="${v}"`).join(" ");
-      if (content) {
-        scriptParts.push(`<script ${attrStr}>${content}</script>`);
-      } else if (attrs.src) {
-        scriptParts.push(`<script ${attrStr}></script>`);
-      }
-    }
-
-    for (const meta of head.metas) {
-      if (meta.name === "description") continue;
-
-      const attrs: string[] = [];
-      if (meta.name) attrs.push(`name="${meta.name}"`);
-      if (meta.property) attrs.push(`property="${meta.property}"`);
-      if (meta.content) attrs.push(`content="${meta.content}"`);
-      if (attrs.length) otherParts.push(`<meta ${attrs.join(" ")}>`);
-    }
-
-    for (const link of head.links) {
-      const attrs = Object.entries(link)
-        .filter(([, v]) => v != null)
-        .map(([k, v]) => `${k}="${v}"`)
-        .join(" ");
-      if (attrs) otherParts.push(`<link ${attrs}>`);
-    }
-
-    for (const style of head.styles) {
-      otherParts.push(`<style>${style}</style>`);
-    }
-
-    return {
-      scripts: scriptParts.join("\n  "),
-      other: otherParts.join("\n  "),
-    };
-  }
-
-  private mergeFrontmatter(context: HTMLGenerationContext): MDXFrontmatter {
-    return {
-      ...context.pageInfo.entity.frontmatter,
-      ...(context.pageBundle as MdxBundle).frontmatter,
-      ...(context.collectedMetadata || {}),
-    } as MDXFrontmatter;
   }
 
   private resolveAppPath(): Promise<string | null> {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.170";
+export const VERSION = "0.1.171";


### PR DESCRIPTION
## Summary
- extract head/frontmatter helper logic from html.ts into html-head.ts
- make html.test.ts exercise the real helper module instead of inline reimplementations
- bump the release version to 0.1.171

## Verification
- deno test --no-check --allow-all src/rendering/orchestrator/html.test.ts src/utils/version.test.ts
- deno fmt --check src/rendering/orchestrator/html.ts src/rendering/orchestrator/html-head.ts src/rendering/orchestrator/html.test.ts deno.json src/utils/version-constant.ts
- deno lint src/rendering/orchestrator/html.ts src/rendering/orchestrator/html-head.ts src/rendering/orchestrator/html.test.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick