### PR TITLE
Use real helper modules in pipeline tests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.171",
+  "version": "0.1.172",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/rendering/orchestrator/pipeline.test.ts
+++ b/src/rendering/orchestrator/pipeline.test.ts
@@ -1,26 +1,9 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { RenderPipelineConfig } from "./pipeline.ts";
-
-function isHiddenSegment(segment: string): boolean {
-  return segment.startsWith(".") && segment !== "." && segment !== "..";
-}
-
-function isDotPath(slug: string, filePath?: string): boolean {
-  const hasDotSegment = (path: string) => path.split("/").some(isHiddenSegment);
-  return hasDotSegment(slug) || (filePath ? hasDotSegment(filePath) : false);
-}
-
-function getPageCssCacheKey(
-  projectId: string | undefined,
-  environment: string | undefined,
-  slug: string,
-  projectUpdatedAt: string | undefined,
-): string {
-  return `${projectId ?? "default"}:${environment ?? "preview"}:${slug}:${
-    projectUpdatedAt ?? "draft"
-  }`;
-}
+import { isDotPath, isHiddenSegment } from "./path-helpers.ts";
+import { getPageCssCacheKey } from "./css-cache.ts";
+import { collectModulesToLoad, hasDataFetchingFunction } from "./module-collection.ts";
 
 const PAGE_CSS_CACHE_MAX_SIZE = 200;
 const pageCssCache = new Map<string, string>();
@@ -35,39 +18,6 @@ function cachePageCss(cacheKey: string, css: string): void {
     if (firstKey) pageCssCache.delete(firstKey);
   }
   pageCssCache.set(cacheKey, css);
-}
-
-function hasDataFetchingFunction(mod: unknown): boolean {
-  if (!mod || typeof mod !== "object") return false;
-
-  const m = mod as Record<string, unknown>;
-  return typeof m.getServerData === "function" || typeof m.getStaticData === "function";
-}
-
-interface ModuleToLoad {
-  type: "page" | "layout";
-  id: string;
-  path: string;
-}
-
-function collectModulesToLoad(
-  pagePath: string,
-  isComponentPage: boolean,
-  isInPagesOrAppDir: boolean,
-  nestedLayouts: Array<{ kind: string; componentPath?: string }>,
-): ModuleToLoad[] {
-  const modules: ModuleToLoad[] = [];
-
-  if (isComponentPage && isInPagesOrAppDir) {
-    modules.push({ type: "page", id: pagePath, path: pagePath });
-  }
-
-  for (const { kind, componentPath } of nestedLayouts) {
-    if (kind !== "tsx" || !componentPath) continue;
-    modules.push({ type: "layout", id: componentPath, path: componentPath });
-  }
-
-  return modules;
 }
 
 describe("RenderPipeline helpers", () => {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.171";
+export const VERSION = "0.1.172";


### PR DESCRIPTION
## Summary
- switch pipeline.test.ts to exercise exported helper modules instead of inline copies
- keep CSS cache-map assertions local where the production module intentionally hides internals
- bump the release version to 0.1.172

## Verification
- deno test --no-check --allow-all src/rendering/orchestrator/pipeline.test.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version.test.ts
- deno fmt --check src/rendering/orchestrator/pipeline.test.ts deno.json src/utils/version-constant.ts
- deno lint src/rendering/orchestrator/pipeline.test.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick