### PR TITLE
Publish Anthropic web_fetch parity for hosted and forked runtimes

### DIFF
--- a/src/agent/runtime/model-tool-converter.test.ts
+++ b/src/agent/runtime/model-tool-converter.test.ts
@@ -113,10 +113,39 @@ describe("model-tool-converter", () => {
     assertEquals("web_search" in result!, true);
   });
 
+  it("adds provider-native web_fetch for anthropic models when explicitly allowed", () => {
+    const result = convertToolsToRuntimeTools([], {
+      model: "anthropic/claude-sonnet-4-6",
+      allowedToolNames: ["web_fetch"],
+    });
+
+    assertEquals(result !== undefined, true);
+    assertEquals("web_fetch" in result!, true);
+  });
+
+  it("adds provider-native web_fetch for veryfront-cloud anthropic models when explicitly allowed", () => {
+    const result = convertToolsToRuntimeTools([], {
+      model: "veryfront-cloud/anthropic/claude-sonnet-4-6",
+      allowedToolNames: ["web_fetch"],
+    });
+
+    assertEquals(result !== undefined, true);
+    assertEquals("web_fetch" in result!, true);
+  });
+
   it("does not add provider-native web_search for non-anthropic models", () => {
     const result = convertToolsToRuntimeTools([], {
       model: "openai/gpt-4o-mini",
       allowedToolNames: ["web_search"],
+    });
+
+    assertEquals(result, undefined);
+  });
+
+  it("does not add provider-native web_fetch for non-anthropic models", () => {
+    const result = convertToolsToRuntimeTools([], {
+      model: "openai/gpt-4o-mini",
+      allowedToolNames: ["web_fetch"],
     });
 
     assertEquals(result, undefined);

--- a/src/agent/runtime/model-tool-converter.ts
+++ b/src/agent/runtime/model-tool-converter.ts
@@ -13,7 +13,10 @@ import {
   createRuntimeJsonSchema,
   createRuntimeTool,
 } from "./runtime-tool-builder.ts";
-import { createAnthropicWebSearchToolSet } from "./provider-native-tools.ts";
+import {
+  createAnthropicWebFetchToolSet,
+  createAnthropicWebSearchToolSet,
+} from "./provider-native-tools.ts";
 
 export interface ConvertToolsToRuntimeToolsOptions {
   model?: string;
@@ -35,7 +38,11 @@ function resolveHostedProvider(model?: string): string | undefined {
 function resolveProviderNativeTools(
   options?: ConvertToolsToRuntimeToolsOptions,
 ): RuntimeToolSet | undefined {
-  if (!options?.allowedToolNames?.includes("web_search")) {
+  if (
+    !options?.allowedToolNames?.some((toolName) =>
+      toolName === "web_search" || toolName === "web_fetch"
+    )
+  ) {
     return undefined;
   }
 
@@ -43,7 +50,10 @@ function resolveProviderNativeTools(
     return undefined;
   }
 
-  return createAnthropicWebSearchToolSet();
+  return {
+    ...createAnthropicWebSearchToolSet(),
+    ...createAnthropicWebFetchToolSet(),
+  };
 }
 
 /**

--- a/src/agent/runtime/provider-native-tools.ts
+++ b/src/agent/runtime/provider-native-tools.ts
@@ -46,6 +46,63 @@ const WEB_SEARCH_OUTPUT_SCHEMA: JsonSchema = {
   },
 };
 
+const WEB_FETCH_INPUT_SCHEMA: JsonSchema = {
+  type: "object",
+  properties: {
+    url: {
+      type: "string",
+    },
+  },
+  required: ["url"],
+  additionalProperties: false,
+};
+
+const WEB_FETCH_OUTPUT_SCHEMA: JsonSchema = {
+  type: "object",
+  properties: {
+    type: {
+      type: "string",
+      const: "web_fetch_result",
+    },
+    url: {
+      type: "string",
+    },
+    content: {
+      type: "object",
+      properties: {
+        type: {
+          type: "string",
+          const: "document",
+        },
+        source: {
+          type: "object",
+          properties: {
+            type: {
+              type: "string",
+              enum: ["text", "base64"],
+            },
+            mediaType: {
+              type: "string",
+            },
+            data: {
+              type: "string",
+            },
+          },
+          required: ["type", "mediaType", "data"],
+          additionalProperties: true,
+        },
+      },
+      required: ["type", "source"],
+      additionalProperties: true,
+    },
+    retrievedAt: {
+      type: "string",
+    },
+  },
+  required: ["type", "url", "content", "retrievedAt"],
+  additionalProperties: false,
+};
+
 export function createAnthropicWebSearchToolSet(): RuntimeToolSet {
   return {
     web_search: createRuntimeProviderTool({
@@ -55,6 +112,18 @@ export function createAnthropicWebSearchToolSet(): RuntimeToolSet {
       },
       inputSchema: createLazyRuntimeJsonSchema(WEB_SEARCH_INPUT_SCHEMA),
       outputSchema: createLazyRuntimeJsonSchema(WEB_SEARCH_OUTPUT_SCHEMA),
+      supportsDeferredResults: true,
+    }),
+  };
+}
+
+export function createAnthropicWebFetchToolSet(): RuntimeToolSet {
+  return {
+    web_fetch: createRuntimeProviderTool({
+      id: "anthropic.web_fetch_20250910",
+      args: {},
+      inputSchema: createLazyRuntimeJsonSchema(WEB_FETCH_INPUT_SCHEMA),
+      outputSchema: createLazyRuntimeJsonSchema(WEB_FETCH_OUTPUT_SCHEMA),
       supportsDeferredResults: true,
     }),
   };

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -564,6 +564,245 @@ describe("provider/runtime-loader", () => {
     ]);
   });
 
+  it("creates an Anthropic-compatible language runtime for provider-native web_fetch generate", async () => {
+    let requestedUrl = "";
+    let requestedInit: RequestInit | undefined;
+
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: (input, init) => {
+        requestedUrl = String(input);
+        requestedInit = init;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: [{
+                type: "server_tool_use",
+                id: "srvtool_fetch_1",
+                name: "web_fetch",
+                input: { url: "https://veryfront.com/docs" },
+              }, {
+                type: "web_fetch_tool_result",
+                tool_use_id: "srvtool_fetch_1",
+                content: {
+                  type: "web_fetch_result",
+                  url: "https://veryfront.com/docs",
+                  content: {
+                    type: "document",
+                    source: {
+                      type: "text",
+                      mediaType: "text/plain",
+                      data: "Veryfront docs",
+                    },
+                    title: "Docs",
+                  },
+                  retrievedAt: "2026-04-11T10:00:00Z",
+                },
+              }],
+              stop_reason: "end_turn",
+              usage: {
+                input_tokens: 12,
+                output_tokens: 7,
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        );
+      },
+    }, "claude-sonnet-4-20250514");
+
+    const result = await runtime.doGenerate({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Fetch the docs page" }],
+      }],
+      tools: [{
+        type: "provider",
+        name: "web_fetch",
+        id: "anthropic.web_fetch_20250910",
+        args: {},
+      }],
+      maxOutputTokens: 64,
+    });
+
+    assertEquals(requestedUrl, "https://example.anthropic.test/v1/messages");
+    const requestBody = typeof requestedInit?.body === "string"
+      ? JSON.parse(requestedInit.body)
+      : undefined;
+    assertEquals(requestBody, {
+      model: "claude-sonnet-4-20250514",
+      messages: [{
+        role: "user",
+        content: [{ type: "text", text: "Fetch the docs page" }],
+      }],
+      max_tokens: 64,
+      tools: [{
+        type: "web_fetch_20250910",
+        name: "web_fetch",
+      }],
+    });
+    assertEquals(result, {
+      content: [{
+        type: "tool-call",
+        toolCallId: "srvtool_fetch_1",
+        toolName: "web_fetch",
+        input: '{"url":"https://veryfront.com/docs"}',
+      }, {
+        type: "tool-result",
+        toolCallId: "srvtool_fetch_1",
+        toolName: "web_fetch",
+        result: {
+          type: "web_fetch_result",
+          url: "https://veryfront.com/docs",
+          content: {
+            type: "document",
+            source: {
+              type: "text",
+              mediaType: "text/plain",
+              data: "Veryfront docs",
+            },
+            title: "Docs",
+          },
+          retrievedAt: "2026-04-11T10:00:00Z",
+        },
+      }],
+      finishReason: { unified: "stop", raw: "end_turn" },
+      usage: {
+        inputTokens: 12,
+        outputTokens: 7,
+        totalTokens: 19,
+      },
+    });
+  });
+
+  it("creates an Anthropic-compatible language runtime for provider-native web_fetch stream", async () => {
+    let requestedUrl = "";
+    let requestedInit: RequestInit | undefined;
+    const encoder = new TextEncoder();
+
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: (input, init) => {
+        requestedUrl = String(input);
+        requestedInit = init;
+        return Promise.resolve(
+          new Response(
+            ReadableStream.from([
+              encoder.encode(
+                'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":10}}}\n\n',
+              ),
+              encoder.encode(
+                'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtool_fetch_2","name":"web_fetch"}}\n\n',
+              ),
+              encoder.encode(
+                'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"url\\":\\"https://veryfront.com/docs\\"}"}}\n\n',
+              ),
+              encoder.encode(
+                'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+              ),
+              encoder.encode(
+                'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"web_fetch_tool_result","tool_use_id":"srvtool_fetch_2","content":{"type":"web_fetch_result","url":"https://veryfront.com/docs","content":{"type":"document","source":{"type":"text","mediaType":"text/plain","data":"Veryfront docs"}},"retrievedAt":"2026-04-11T10:05:00Z"}}}\n\n',
+              ),
+              encoder.encode(
+                'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":4}}\n\n',
+              ),
+              encoder.encode(
+                'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+              ),
+            ]),
+            {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            },
+          ),
+        );
+      },
+    }, "claude-sonnet-4-20250514");
+
+    const result = await runtime.doStream({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Fetch the docs page" }],
+      }],
+      tools: [{
+        type: "provider",
+        name: "web_fetch",
+        id: "anthropic.web_fetch_20250910",
+        args: {},
+      }],
+      maxOutputTokens: 64,
+    });
+
+    assertEquals(requestedUrl, "https://example.anthropic.test/v1/messages");
+    const requestBody = typeof requestedInit?.body === "string"
+      ? JSON.parse(requestedInit.body)
+      : undefined;
+    assertEquals(requestBody, {
+      model: "claude-sonnet-4-20250514",
+      messages: [{
+        role: "user",
+        content: [{ type: "text", text: "Fetch the docs page" }],
+      }],
+      max_tokens: 64,
+      stream: true,
+      tools: [{
+        type: "web_fetch_20250910",
+        name: "web_fetch",
+      }],
+    });
+
+    const parts = await collectAsync(result.stream);
+    assertEquals(parts.length, 5);
+    assertEquals(parts[0], {
+      type: "tool-input-start",
+      id: "srvtool_fetch_2",
+      toolName: "web_fetch",
+      providerExecuted: true,
+    });
+    assertEquals(parts[1], {
+      type: "tool-input-delta",
+      id: "srvtool_fetch_2",
+      delta: '{"url":"https://veryfront.com/docs"}',
+    });
+    assertEquals(parts[2], {
+      type: "tool-call",
+      toolCallId: "srvtool_fetch_2",
+      toolName: "web_fetch",
+      input: '{"url":"https://veryfront.com/docs"}',
+      providerExecuted: true,
+    });
+    assertEquals(parts[3], {
+      type: "tool-result",
+      toolCallId: "srvtool_fetch_2",
+      toolName: "web_fetch",
+      result: {
+        type: "web_fetch_result",
+        url: "https://veryfront.com/docs",
+        content: {
+          type: "document",
+          source: {
+            type: "text",
+            mediaType: "text/plain",
+            data: "Veryfront docs",
+          },
+        },
+        retrievedAt: "2026-04-11T10:05:00Z",
+      },
+      providerExecuted: true,
+    });
+    assertEquals(parts[4], {
+      type: "finish",
+      finishReason: { unified: "stop", raw: "end_turn" },
+      usage: {
+        inputTokens: 10,
+        outputTokens: 4,
+        totalTokens: 14,
+      },
+    });
+  });
+
   it("parses Anthropic-compatible SSE streams when events use CRLF delimiters", async () => {
     const encoder = new TextEncoder();
     const runtime = createAnthropicModelRuntime({

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -722,6 +722,19 @@ function buildAnthropicGenerateResult(payload: unknown): {
         result: block.content,
       });
     }
+
+    if (
+      blockType === "web_fetch_tool_result" &&
+      typeof block?.tool_use_id === "string" &&
+      readRecord(block?.content)
+    ) {
+      normalized.push({
+        type: "tool-result",
+        toolCallId: block.tool_use_id,
+        toolName: "web_fetch",
+        result: block.content,
+      });
+    }
   }
 
   return {
@@ -845,6 +858,20 @@ async function* streamAnthropicCompatibleParts(
             type: "tool-result",
             toolCallId: contentBlock.tool_use_id,
             toolName: "web_search",
+            result: contentBlock.content,
+            providerExecuted: true,
+          };
+        }
+
+        if (
+          blockType === "web_fetch_tool_result" &&
+          typeof contentBlock?.tool_use_id === "string" &&
+          readRecord(contentBlock?.content)
+        ) {
+          yield {
+            type: "tool-result",
+            toolCallId: contentBlock.tool_use_id,
+            toolName: "web_fetch",
             result: contentBlock.content,
             providerExecuted: true,
           };

--- a/src/runtime/runtime-bridge.test.ts
+++ b/src/runtime/runtime-bridge.test.ts
@@ -529,4 +529,241 @@ describe("runtime-bridge", () => {
       }],
     }]);
   });
+
+  it("uses the direct stream path for provider-native web_fetch", async () => {
+    const model = createStreamModel(
+      "anthropic",
+      "anthropic/test-direct-provider-web-fetch-stream",
+      async (options) => {
+        assertEquals(options.prompt, [{
+          role: "user",
+          content: [{ type: "text", text: "Fetch the docs page" }],
+        }]);
+        assertEquals(options.tools, [{
+          type: "provider",
+          name: "web_fetch",
+          id: "anthropic.web_fetch_20250910",
+          args: {},
+        }]);
+
+        return {
+          stream: ReadableStream.from([
+            {
+              type: "tool-call",
+              toolCallId: "tool-fetch-1",
+              toolName: "web_fetch",
+              input: '{"url":"https://veryfront.com/docs"}',
+              providerExecuted: true,
+            },
+            {
+              type: "tool-result",
+              toolCallId: "tool-fetch-1",
+              toolName: "web_fetch",
+              result: {
+                type: "web_fetch_result",
+                url: "https://veryfront.com/docs",
+                content: {
+                  type: "document",
+                  source: {
+                    type: "text",
+                    mediaType: "text/plain",
+                    data: "Veryfront docs",
+                  },
+                },
+                retrievedAt: "2026-04-11T10:10:00Z",
+              },
+              providerExecuted: true,
+            },
+            {
+              type: "finish",
+              finishReason: { unified: "stop", raw: "stop" },
+              usage: {
+                inputTokens: { total: 5 },
+                outputTokens: { total: 8 },
+              },
+            },
+          ]),
+        };
+      },
+    );
+
+    const result = streamText({
+      model,
+      messages: [{ role: "user", content: "Fetch the docs page" }],
+      tools: {
+        web_fetch: {
+          type: "provider",
+          id: "anthropic.web_fetch_20250910",
+          args: {},
+          inputSchema: () => ({
+            jsonSchema: {
+              type: "object",
+              properties: {
+                url: { type: "string" },
+              },
+              required: ["url"],
+              additionalProperties: false,
+            },
+          }),
+          outputSchema: () => ({
+            jsonSchema: {
+              type: "object",
+            },
+          }),
+          supportsDeferredResults: true,
+        },
+      },
+      temperature: 0,
+    });
+
+    const [textDeltas, fullStreamParts] = await Promise.all([
+      collectAsync(result.textStream),
+      collectAsync(result.fullStream),
+    ]);
+
+    assertEquals(textDeltas, []);
+    assertEquals(fullStreamParts, [
+      {
+        type: "tool-call",
+        toolCallId: "tool-fetch-1",
+        toolName: "web_fetch",
+        input: '{"url":"https://veryfront.com/docs"}',
+        providerExecuted: true,
+      },
+      {
+        type: "tool-result",
+        toolCallId: "tool-fetch-1",
+        toolName: "web_fetch",
+        result: {
+          type: "web_fetch_result",
+          url: "https://veryfront.com/docs",
+          content: {
+            type: "document",
+            source: {
+              type: "text",
+              mediaType: "text/plain",
+              data: "Veryfront docs",
+            },
+          },
+          retrievedAt: "2026-04-11T10:10:00Z",
+        },
+        providerExecuted: true,
+      },
+      {
+        type: "finish",
+        finishReason: "stop",
+        totalUsage: {
+          inputTokens: 5,
+          outputTokens: 8,
+        },
+      },
+    ]);
+  });
+
+  it("uses the direct generate path for provider-native web_fetch", async () => {
+    const model = createGenerateModel(
+      "anthropic",
+      "anthropic/test-direct-provider-web-fetch-generate",
+      async (options) => {
+        assertEquals(options.prompt, [{
+          role: "user",
+          content: [{ type: "text", text: "Fetch the docs page" }],
+        }]);
+        assertEquals(options.tools, [{
+          type: "provider",
+          name: "web_fetch",
+          id: "anthropic.web_fetch_20250910",
+          args: {},
+        }]);
+
+        return {
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "tool-fetch-2",
+              toolName: "web_fetch",
+              input: '{"url":"https://veryfront.com/docs"}',
+            },
+            {
+              type: "tool-result",
+              toolCallId: "tool-fetch-2",
+              toolName: "web_fetch",
+              result: {
+                type: "web_fetch_result",
+                url: "https://veryfront.com/docs",
+                content: {
+                  type: "document",
+                  source: {
+                    type: "text",
+                    mediaType: "text/plain",
+                    data: "Veryfront docs",
+                  },
+                },
+                retrievedAt: "2026-04-11T10:12:00Z",
+              },
+            },
+          ],
+          finishReason: { unified: "stop", raw: "stop" },
+          usage: {
+            inputTokens: { total: 4 },
+            outputTokens: { total: 6 },
+          },
+        };
+      },
+    );
+
+    const result = await generateText({
+      model,
+      messages: [{ role: "user", content: "Fetch the docs page" }],
+      tools: {
+        web_fetch: {
+          type: "provider",
+          id: "anthropic.web_fetch_20250910",
+          args: {},
+          inputSchema: () => ({
+            jsonSchema: {
+              type: "object",
+              properties: {
+                url: { type: "string" },
+              },
+              required: ["url"],
+              additionalProperties: false,
+            },
+          }),
+          outputSchema: () => ({
+            jsonSchema: {
+              type: "object",
+            },
+          }),
+          supportsDeferredResults: true,
+        },
+      },
+      temperature: 0,
+    });
+
+    assertEquals(result.text, "");
+    assertEquals(result.finishReason, "stop");
+    assertEquals(result.toolCalls, [{
+      toolCallId: "tool-fetch-2",
+      toolName: "web_fetch",
+      input: { url: "https://veryfront.com/docs" },
+    }]);
+    assertEquals(result.toolResults, [{
+      toolCallId: "tool-fetch-2",
+      toolName: "web_fetch",
+      result: {
+        type: "web_fetch_result",
+        url: "https://veryfront.com/docs",
+        content: {
+          type: "document",
+          source: {
+            type: "text",
+            mediaType: "text/plain",
+            data: "Veryfront docs",
+          },
+        },
+        retrievedAt: "2026-04-11T10:12:00Z",
+      },
+    }]);
+  });
 });


### PR DESCRIPTION
## Summary
- publish Anthropic `web_fetch` as a provider-native framework tool next to `web_search`
- parse `web_fetch_tool_result` blocks in both raw generate and raw stream Anthropic runtime paths
- lock the direct runtime bridge with provider-native `web_fetch` parity tests

## Why
`veryfront-agent` still has to inject a repo-local Anthropic-only `web_fetch` shim in forked runtime paths. This upstream slice moves that behavior into the framework/runtime seam so more downstream compatibility code can be deleted.

## Verification
- `deno test --no-check --allow-all src/agent/runtime/model-tool-converter.test.ts src/provider/runtime-loader.test.ts src/runtime/runtime-bridge.test.ts`
- `deno task verify`

Related:
- veryfront-code#958
- veryfront-agent#172