### PR TITLE
Deduplicate read-operations fetched-content storage

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.172",
+  "version": "0.1.173",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -396,6 +396,16 @@ export class ReadOperations {
     }
   }
 
+  private storeFetchedContent(
+    cacheKey: string,
+    content: string,
+    shouldCache: boolean,
+  ): string {
+    if (shouldCache) this.cache.set(cacheKey, content);
+    setRequestScopedFile(cacheKey, content);
+    return content;
+  }
+
   private async fetchContent(normalizedPath: string): Promise<string> {
     // Framework paths should NEVER be fetched from API - they must be read from local filesystem.
     // If we reach here for a framework path, the module server's local resolution failed.
@@ -581,9 +591,7 @@ export class ReadOperations {
         releaseId,
       });
 
-      if (shouldCache) this.cache.set(cacheKey, content);
-      setRequestScopedFile(cacheKey, content);
-      return content;
+      return this.storeFetchedContent(cacheKey, content, shouldCache);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       const is404Error = isNotFoundLikeError(error);
@@ -642,9 +650,7 @@ export class ReadOperations {
         contentLength: result.content.length,
       });
 
-      if (shouldCache) this.cache.set(cacheKey, result.content);
-      setRequestScopedFile(cacheKey, result.content);
-      return result.content;
+      return this.storeFetchedContent(cacheKey, result.content, shouldCache);
     } catch (error) {
       logger.debug("Pattern search failed, trying sequential fallback", {
         originalPath: apiPath,
@@ -713,9 +719,7 @@ export class ReadOperations {
           candidateCount: candidates.length,
         });
 
-        if (shouldCache) this.cache.set(cacheKey, content);
-        setRequestScopedFile(cacheKey, content);
-        return content;
+        return this.storeFetchedContent(cacheKey, content, shouldCache);
       } catch (_) {
         /* expected: this extension variant does not exist, try next priority */
         continue;
@@ -746,8 +750,6 @@ export class ReadOperations {
       willCache: shouldCache,
     });
 
-    if (shouldCache) this.cache.set(cacheKey, content);
-    setRequestScopedFile(cacheKey, content);
-    return content;
+    return this.storeFetchedContent(cacheKey, content, shouldCache);
   }
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.172";
+export const VERSION = "0.1.173";


### PR DESCRIPTION
## Summary
- centralize fetched-content caching/request-scope writes in read-operations
- reuse the helper across published fetches, fallback successes, and draft fetches
- bump the release version to 0.1.173

## Verification
- deno test --no-check --allow-all src/platform/adapters/fs/veryfront/read-operations.test.ts src/utils/version.test.ts
- deno fmt --check src/platform/adapters/fs/veryfront/read-operations.ts deno.json src/utils/version-constant.ts
- deno lint src/platform/adapters/fs/veryfront/read-operations.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick