### PR TITLE
Extract rendering imported CSS helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.173",
+  "version": "0.1.174",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/rendering/orchestrator/html-imported-css.ts
+++ b/src/rendering/orchestrator/html-imported-css.ts
@@ -1,0 +1,81 @@
+import { join } from "#veryfront/compat/path";
+import {
+  normalizeCssModuleKey,
+  rewriteCssModuleContent,
+} from "#veryfront/transforms/css-modules/naming.ts";
+
+interface CssFsAdapterLike {
+  readFile(path: string): Promise<string>;
+}
+
+interface CssLoggerLike {
+  debug(message: string, context?: Record<string, unknown>): void;
+}
+
+interface MergeImportedCssOptions {
+  fs: CssFsAdapterLike;
+  logger: CssLoggerLike;
+  projectDir: string;
+  globalCSS: string | undefined;
+  cssImports: string[] | undefined;
+  stylesheetPath: string;
+}
+
+export async function mergeImportedCSS({
+  fs,
+  logger,
+  projectDir,
+  globalCSS,
+  cssImports,
+  stylesheetPath,
+}: MergeImportedCssOptions): Promise<string | undefined> {
+  if (!cssImports || cssImports.length === 0) return globalCSS;
+
+  const normalizedStylesheetPath = stylesheetPath.replace(/^\/+/, "");
+  const configuredStylesheetAbsolute = normalizeCssModuleKey(
+    join(projectDir, normalizedStylesheetPath),
+  );
+  const uniqueImports = new Map<string, string>();
+  for (const cssPath of cssImports) {
+    const normalized = normalizeCssModuleKey(cssPath);
+    if (!uniqueImports.has(normalized)) {
+      uniqueImports.set(normalized, cssPath);
+    }
+  }
+
+  const sortedImports = [...uniqueImports.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  const regularCssSegments: string[] = [];
+  const moduleCssSegments: string[] = [];
+
+  for (const [normalizedCssPath, cssPath] of sortedImports) {
+    if (normalizedCssPath === configuredStylesheetAbsolute) {
+      continue;
+    }
+
+    try {
+      const content = await fs.readFile(cssPath);
+      if (!content) continue;
+
+      if (normalizedCssPath.endsWith(".module.css")) {
+        moduleCssSegments.push(rewriteCssModuleContent(content, normalizedCssPath));
+      } else {
+        regularCssSegments.push(content);
+      }
+    } catch (_) {
+      logger.debug("Could not load imported CSS file", { cssPath });
+    }
+  }
+
+  if (regularCssSegments.length === 0 && moduleCssSegments.length === 0) return globalCSS;
+
+  const combined = [globalCSS, ...regularCssSegments, ...moduleCssSegments]
+    .filter(Boolean)
+    .join("\n");
+  logger.debug("Merged imported CSS with global stylesheet", {
+    importedCount: regularCssSegments.length + moduleCssSegments.length,
+    regularCount: regularCssSegments.length,
+    moduleCount: moduleCssSegments.length,
+    totalLength: combined.length,
+  });
+  return combined;
+}

--- a/src/rendering/orchestrator/html.test.ts
+++ b/src/rendering/orchestrator/html.test.ts
@@ -2,6 +2,7 @@ import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { HTMLGenerator, type HTMLGeneratorConfig } from "./html.ts";
 import { buildHeadElements, mergeFrontmatter } from "./html-head.ts";
+import { mergeImportedCSS } from "./html-imported-css.ts";
 
 type Head = {
   metas: Array<{ name?: string; property?: string; content?: string }>;
@@ -720,7 +721,7 @@ describe("HTMLGenerator helpers", () => {
   describe("mergeImportedCSS", () => {
     it("deduplicates only exact configured stylesheet path", async () => {
       const readPaths: string[] = [];
-      const mockAdapter = {
+      const merged = await mergeImportedCSS({
         fs: {
           readFile: async (path: string) => {
             readPaths.push(path);
@@ -728,32 +729,13 @@ describe("HTMLGenerator helpers", () => {
             if (path === "/project/globals.css") return ".duplicate { color: blue; }";
             return "";
           },
-          exists: async () => false,
-          stat: async () => ({
-            isFile: false,
-            isDirectory: false,
-            isSymlink: false,
-            size: 0,
-            mtime: null,
-          }),
-          readDir: async function* () {},
-          mkdir: async () => {},
-          writeFile: async () => {},
         },
-      };
-
-      const generator = new HTMLGenerator({
+        logger: { debug: () => {} },
         projectDir: "/project",
-        adapter: mockAdapter as any,
-        config: {} as any,
-        mode: "development",
+        globalCSS: "/* global */",
+        cssImports: ["/project/styles/globals.css", "/project/globals.css"],
+        stylesheetPath: "globals.css",
       });
-
-      const merged = await (generator as any).mergeImportedCSS(
-        "/* global */",
-        ["/project/styles/globals.css", "/project/globals.css"],
-        "globals.css",
-      );
 
       assertEquals(readPaths, ["/project/styles/globals.css"]);
       assertEquals(merged?.includes("/* global */"), true);
@@ -762,39 +744,20 @@ describe("HTMLGenerator helpers", () => {
     });
 
     it("orders imported css deterministically and rewrites module selectors", async () => {
-      const mockAdapter = {
+      const merged = await mergeImportedCSS({
         fs: {
           readFile: async (path: string) => {
             if (path === "/project/b.css") return ".b { color: blue; }";
             if (path === "/project/a.module.css") return ".root { color: red; }";
             return "";
           },
-          exists: async () => false,
-          stat: async () => ({
-            isFile: false,
-            isDirectory: false,
-            isSymlink: false,
-            size: 0,
-            mtime: null,
-          }),
-          readDir: async function* () {},
-          mkdir: async () => {},
-          writeFile: async () => {},
         },
-      };
-
-      const generator = new HTMLGenerator({
+        logger: { debug: () => {} },
         projectDir: "/project",
-        adapter: mockAdapter as any,
-        config: {} as any,
-        mode: "development",
+        globalCSS: "/* global */",
+        cssImports: ["/project/a.module.css", "/project/b.css"],
+        stylesheetPath: "globals.css",
       });
-
-      const merged = await (generator as any).mergeImportedCSS(
-        "/* global */",
-        ["/project/a.module.css", "/project/b.css"],
-        "globals.css",
-      );
 
       assertEquals(
         merged?.indexOf(".b { color: blue; }")! > merged?.indexOf("/* global */")!,

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -28,10 +28,6 @@ import { resolveAppComponentPath } from "../layouts/utils/app-resolver.ts";
 import { StreamTimeoutError, streamToString } from "../utils/stream-utils.ts";
 import { profilePhase, profileSyncPhase } from "#veryfront/observability/request-profiler.ts";
 import {
-  normalizeCssModuleKey,
-  rewriteCssModuleContent,
-} from "#veryfront/transforms/css-modules/naming.ts";
-import {
   extractProjectClassesForRoute,
   type ProjectCSSResult,
   startPreparedCSSWarmup,
@@ -41,6 +37,7 @@ import {
   buildHeadElements as buildCollectedHeadElements,
   mergeFrontmatter as mergeCollectedFrontmatter,
 } from "./html-head.ts";
+import { mergeImportedCSS as mergeImportedProjectCss } from "./html-imported-css.ts";
 
 const logger = rendererLogger.component("html-generator");
 
@@ -508,57 +505,13 @@ export class HTMLGenerator {
     cssImports: string[] | undefined,
     stylesheetPath: string,
   ): Promise<string | undefined> {
-    if (!cssImports || cssImports.length === 0) return globalCSS;
-
-    const normalizedStylesheetPath = stylesheetPath.replace(/^\/+/, "");
-    const configuredStylesheetAbsolute = normalizeCssModuleKey(
-      join(this.config.projectDir, normalizedStylesheetPath),
-    );
-    const uniqueImports = new Map<string, string>();
-    for (const cssPath of cssImports) {
-      const normalized = normalizeCssModuleKey(cssPath);
-      if (!uniqueImports.has(normalized)) {
-        uniqueImports.set(normalized, cssPath);
-      }
-    }
-
-    const sortedImports = [...uniqueImports.entries()].sort((a, b) => a[0].localeCompare(b[0]));
-    const regularCssSegments: string[] = [];
-    const moduleCssSegments: string[] = [];
-
-    for (const [normalizedCssPath, cssPath] of sortedImports) {
-      // Deduplicate only exact path matches to avoid skipping unrelated files
-      // like /styles/globals.css when the configured stylesheet is /globals.css.
-      if (normalizedCssPath === configuredStylesheetAbsolute) {
-        continue;
-      }
-
-      try {
-        const content = await this.config.adapter.fs.readFile(cssPath);
-        if (!content) continue;
-
-        if (normalizedCssPath.endsWith(".module.css")) {
-          moduleCssSegments.push(rewriteCssModuleContent(content, normalizedCssPath));
-        } else {
-          regularCssSegments.push(content);
-        }
-      } catch (_) {
-        /* expected: imported CSS file may not exist */
-        logger.debug("Could not load imported CSS file", { cssPath });
-      }
-    }
-
-    if (regularCssSegments.length === 0 && moduleCssSegments.length === 0) return globalCSS;
-
-    const combined = [globalCSS, ...regularCssSegments, ...moduleCssSegments]
-      .filter(Boolean)
-      .join("\n");
-    logger.debug("Merged imported CSS with global stylesheet", {
-      importedCount: regularCssSegments.length + moduleCssSegments.length,
-      regularCount: regularCssSegments.length,
-      moduleCount: moduleCssSegments.length,
-      totalLength: combined.length,
+    return mergeImportedProjectCss({
+      fs: this.config.adapter.fs,
+      logger,
+      projectDir: this.config.projectDir,
+      globalCSS,
+      cssImports,
+      stylesheetPath,
     });
-    return combined;
   }
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.173";
+export const VERSION = "0.1.174";


### PR DESCRIPTION
## Summary
- extract imported CSS merge logic from html.ts into html-imported-css.ts
- make html.test.ts exercise the real imported CSS helper directly
- bump the release version to 0.1.174

## Verification
- deno test --no-check --allow-all src/rendering/orchestrator/html.test.ts src/utils/version.test.ts
- deno fmt --check src/rendering/orchestrator/html.ts src/rendering/orchestrator/html-imported-css.ts src/rendering/orchestrator/html.test.ts deno.json src/utils/version-constant.ts
- deno lint src/rendering/orchestrator/html.ts src/rendering/orchestrator/html-imported-css.ts src/rendering/orchestrator/html.test.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick