### PR TITLE
Extract stat-operations indexed resolution helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.174",
+  "version": "0.1.175",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/platform/adapters/fs/veryfront/stat-operations.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.ts
@@ -390,6 +390,67 @@ export class StatOperations extends VeryfrontOperationsBase {
     return Array.isArray(files) && files.length > 0;
   }
 
+  private resolveFromIndex(
+    fileIdx: Map<string, ProjectFile>,
+    normalizedPath: string,
+    options: ResolveFileOptions | undefined,
+    indexMs: number,
+    resolveStart: number,
+  ): string | null {
+    if (fileIdx.has(normalizedPath)) {
+      const totalMs = Math.round(performance.now() - resolveStart);
+      logger.debug("resolveFile exact match found", {
+        normalizedPath,
+        indexMs,
+        totalMs,
+      });
+      return normalizedPath;
+    }
+
+    const pathWithoutExt = stripKnownExtension(normalizedPath, EXTENSION_PRIORITY);
+
+    const resolvedDirect = resolveByExtensionPriority(fileIdx, pathWithoutExt, EXTENSION_PRIORITY);
+    if (resolvedDirect) {
+      const totalMs = Math.round(performance.now() - resolveStart);
+      logger.debug("resolveFile found with extension", {
+        pathWithExt: resolvedDirect,
+        indexMs,
+        totalMs,
+      });
+      return resolvedDirect;
+    }
+
+    if (options?.allowPagesPrefix !== false && !pathWithoutExt.startsWith("pages/")) {
+      const resolvedPages = resolveByExtensionPriority(
+        fileIdx,
+        `pages/${pathWithoutExt}`,
+        EXTENSION_PRIORITY,
+      );
+      if (resolvedPages) {
+        const totalMs = Math.round(performance.now() - resolveStart);
+        logger.debug("resolveFile found with pages prefix", {
+          pathWithExt: resolvedPages,
+          indexMs,
+          totalMs,
+        });
+        return resolvedPages;
+      }
+    }
+
+    const indexPath = resolveIndexByExtensionPriority(fileIdx, pathWithoutExt, EXTENSION_PRIORITY);
+    if (indexPath) {
+      const totalMs = Math.round(performance.now() - resolveStart);
+      logger.debug("resolveFile found index file", {
+        indexPath,
+        indexMs,
+        totalMs,
+      });
+      return indexPath;
+    }
+
+    return null;
+  }
+
   async exists(path: string): Promise<boolean> {
     const normalizedPath = this.normalizer.normalize(path);
     try {
@@ -453,55 +514,15 @@ export class StatOperations extends VeryfrontOperationsBase {
       return null;
     }
 
-    if (fileIdx.has(normalizedPath)) {
-      const totalMs = Math.round(performance.now() - resolveStart);
-      logger.debug("resolveFile exact match found", {
-        normalizedPath,
-        indexMs,
-        totalMs,
-      });
-      return normalizedPath;
-    }
-
-    const pathWithoutExt = stripKnownExtension(normalizedPath, EXTENSION_PRIORITY);
-
-    const resolvedDirect = resolveByExtensionPriority(fileIdx, pathWithoutExt, EXTENSION_PRIORITY);
-    if (resolvedDirect) {
-      const totalMs = Math.round(performance.now() - resolveStart);
-      logger.debug("resolveFile found with extension", {
-        pathWithExt: resolvedDirect,
-        indexMs,
-        totalMs,
-      });
-      return resolvedDirect;
-    }
-
-    if (options?.allowPagesPrefix !== false && !pathWithoutExt.startsWith("pages/")) {
-      const resolvedPages = resolveByExtensionPriority(
-        fileIdx,
-        `pages/${pathWithoutExt}`,
-        EXTENSION_PRIORITY,
-      );
-      if (resolvedPages) {
-        const totalMs = Math.round(performance.now() - resolveStart);
-        logger.debug("resolveFile found with pages prefix", {
-          pathWithExt: resolvedPages,
-          indexMs,
-          totalMs,
-        });
-        return resolvedPages;
-      }
-    }
-
-    const indexPath = resolveIndexByExtensionPriority(fileIdx, pathWithoutExt, EXTENSION_PRIORITY);
-    if (indexPath) {
-      const totalMs = Math.round(performance.now() - resolveStart);
-      logger.debug("resolveFile found index file", {
-        indexPath,
-        indexMs,
-        totalMs,
-      });
-      return indexPath;
+    const indexedResolution = this.resolveFromIndex(
+      fileIdx,
+      normalizedPath,
+      options,
+      indexMs,
+      resolveStart,
+    );
+    if (indexedResolution) {
+      return indexedResolution;
     }
 
     if (attemptedApiResolve) {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.174";
+export const VERSION = "0.1.175";


### PR DESCRIPTION
## Summary
- extract the indexed resolution branch from `StatOperations.resolveFile()` into a dedicated helper
- keep the existing exact/extension/pages-prefix/index lookup order and logging behavior intact
- bump the release version to `0.1.175`

## Verification
- deno test --no-check --allow-all src/platform/adapters/fs/veryfront/stat-operations.test.ts src/utils/version.test.ts
- deno fmt --check src/platform/adapters/fs/veryfront/stat-operations.ts deno.json src/utils/version-constant.ts
- deno lint src/platform/adapters/fs/veryfront/stat-operations.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick
- VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --parallel '--ignore=tests,src/ai/workflow/__tests__,src/cli/commands/*.integration.test.ts'