### PR TITLE
Extract read-operations resolved-content helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.175",
+  "version": "0.1.176",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -316,26 +316,15 @@ export class ReadOperations {
       if (!resolved) return null;
 
       const resolvedPath = this.normalizer.normalize(resolved.path);
-      const resolvedCacheKey = getResolvedCacheKey(cacheKeyPrefix, resolvedPath);
-
-      // Cache the path mapping to avoid future API resolution calls
-      this.extensionResolutionCache.set(apiPath, resolvedPath);
-
-      logger.debug("Resolved extension for base path", {
-        basePath: apiPath,
+      return this.finalizeResolvedExtension({
+        requestedPath: apiPath,
         resolvedPath,
+        cacheKeyPrefix,
         cacheKey,
-        resolvedCacheKey: resolvedCacheKey === cacheKey ? undefined : resolvedCacheKey,
+        content: resolved.content,
+        persistToCache: isProduction && !skipPersistentCaches,
+        logMessage: "Resolved extension for base path",
       });
-
-      this.cacheResolvedContent(
-        cacheKey,
-        resolvedCacheKey,
-        resolved.content,
-        isProduction && !skipPersistentCaches,
-      );
-
-      return resolved.content;
     } catch (error) {
       logger.debug("resolveFileWithExtension failed", {
         basePath: apiPath,
@@ -357,10 +346,6 @@ export class ReadOperations {
     const resolved = await this.fileListIndex.findFirstMatch(candidatePaths);
     if (resolved.status !== "hit" || !resolved.path || !resolved.content) return resolved;
 
-    const resolvedCacheKey = getResolvedCacheKey(cacheKeyPrefix, resolved.path);
-
-    this.extensionResolutionCache.set(normalizedPath, resolved.path);
-
     logContentMetric("FILE_LIST_HIT", {
       path: normalizedPath,
       resolvedPath: resolved.path,
@@ -368,16 +353,53 @@ export class ReadOperations {
       cacheKey,
       isPreviewMode,
     });
-    logger.debug("Resolved extension from file list index", {
-      basePath: normalizedPath,
+
+    this.finalizeResolvedExtension({
+      requestedPath: normalizedPath,
       resolvedPath: resolved.path,
+      cacheKeyPrefix,
+      cacheKey,
+      content: resolved.content,
+      persistToCache: isProduction,
+      logMessage: "Resolved extension from file list index",
+    });
+
+    return resolved;
+  }
+
+  private finalizeResolvedExtension(
+    {
+      requestedPath,
+      resolvedPath,
+      cacheKeyPrefix,
+      cacheKey,
+      content,
+      persistToCache,
+      logMessage,
+    }: {
+      requestedPath: string;
+      resolvedPath: string;
+      cacheKeyPrefix: string;
+      cacheKey: string;
+      content: string;
+      persistToCache: boolean;
+      logMessage: string;
+    },
+  ): string {
+    const resolvedCacheKey = getResolvedCacheKey(cacheKeyPrefix, resolvedPath);
+
+    // Cache the path mapping to avoid future API resolution calls.
+    this.extensionResolutionCache.set(requestedPath, resolvedPath);
+
+    logger.debug(logMessage, {
+      basePath: requestedPath,
+      resolvedPath,
       cacheKey,
       resolvedCacheKey: resolvedCacheKey === cacheKey ? undefined : resolvedCacheKey,
     });
 
-    this.cacheResolvedContent(cacheKey, resolvedCacheKey, resolved.content, isProduction);
-
-    return resolved;
+    this.cacheResolvedContent(cacheKey, resolvedCacheKey, content, persistToCache);
+    return content;
   }
 
   private cacheResolvedContent(

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.175";
+export const VERSION = "0.1.176";


### PR DESCRIPTION
## Summary
- extract the shared resolved-content finalization path used by extensionless read resolution
- keep API-based and file-list-based resolution paths aligned on cache updates and logging
- bump the release version to `0.1.176`

## Verification
- deno test --no-check --allow-all src/platform/adapters/fs/veryfront/read-operations.test.ts src/utils/version.test.ts
- deno fmt --check src/platform/adapters/fs/veryfront/read-operations.ts deno.json src/utils/version-constant.ts
- deno lint src/platform/adapters/fs/veryfront/read-operations.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick
- VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --parallel '--ignore=tests,src/ai/workflow/__tests__,src/cli/commands/*.integration.test.ts'