### PR TITLE
Extract read-operations published fetch helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.176",
+  "version": "0.1.177",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/platform/adapters/fs/veryfront/read-operations.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.ts
@@ -428,6 +428,18 @@ export class ReadOperations {
     return content;
   }
 
+  private fetchPublishedVariant(
+    apiPath: string,
+    releaseId: string | null,
+    environmentName?: string | null,
+  ): Promise<string> {
+    return this.client.getPublishedFileContent(
+      apiPath,
+      releaseId ?? undefined,
+      environmentName ?? undefined,
+    );
+  }
+
   private async fetchContent(normalizedPath: string): Promise<string> {
     // Framework paths should NEVER be fetched from API - they must be read from local filesystem.
     // If we reach here for a framework path, the module server's local resolution failed.
@@ -601,11 +613,7 @@ export class ReadOperations {
     });
 
     try {
-      const content = await this.client.getPublishedFileContent(
-        apiPath,
-        releaseId ?? undefined,
-        environmentName ?? undefined,
-      );
+      const content = await this.fetchPublishedVariant(apiPath, releaseId, environmentName);
 
       logger.debug("Fetched published content", {
         path: normalizedPath,
@@ -708,11 +716,7 @@ export class ReadOperations {
     const startTime = performance.now();
 
     const promises = candidates.map(async (ext) => {
-      const content = await this.client.getPublishedFileContent(
-        basePath + ext,
-        releaseId ?? undefined,
-        environmentName ?? undefined,
-      );
+      const content = await this.fetchPublishedVariant(basePath + ext, releaseId, environmentName);
       return { ext, content };
     });
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.176";
+export const VERSION = "0.1.177";


### PR DESCRIPTION
## Summary
- extract the shared published-content fetch helper used by direct reads and fallback variant fetches
- keep published read and fallback paths aligned on release/environment argument handling
- bump the release version to `0.1.177`

## Verification
- deno test --no-check --allow-all src/platform/adapters/fs/veryfront/read-operations.test.ts src/utils/version.test.ts
- deno fmt --check src/platform/adapters/fs/veryfront/read-operations.ts deno.json src/utils/version-constant.ts
- deno lint src/platform/adapters/fs/veryfront/read-operations.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick