### PR TITLE
Extract render-pipeline MDX metadata helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.177",
+  "version": "0.1.178",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -136,6 +136,30 @@ describe("RenderPipeline behavior", () => {
     );
   });
 
+  it("resolvePageData includes mdx frontmatter and headings from prepared bundles", async () => {
+    const slug = "/behavior-mdx-metadata";
+    const projectId = "proj-mdx-metadata";
+    const pipeline = createPipeline("/project/pages/behavior-mdx-metadata.mdx");
+    primeCssCache(slug, projectId);
+
+    (pipeline as any).loadModule = async () => ({});
+    (pipeline as any).config.pageRenderer.preparePageBundles = async () => ({
+      pageBundle: {
+        frontmatter: { title: "MDX Title", author: "Veryfront" },
+        headings: [{ id: "intro", text: "Intro", level: 2 }],
+      },
+    });
+
+    const pageData = await pipeline.resolvePageData(slug, {
+      projectId,
+      request: new Request(`http://localhost${slug}`),
+      url: new URL(`http://localhost${slug}`),
+    });
+
+    assertEquals(pageData.frontmatter, { title: "MDX Title", author: "Veryfront" });
+    assertEquals(pageData.headings, [{ id: "intro", text: "Intro", level: 2 }]);
+  });
+
   it("resolvePageData reuses the SSR hashed stylesheet for SPA CSS", async () => {
     const slug = "/behavior-ssr-css";
     const projectId = "proj-ssr-css";

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -111,6 +111,11 @@ interface DataResolutionResult {
   layoutProps: Map<string, Record<string, unknown>>;
 }
 
+interface MdxMetadataResult {
+  frontmatter: Record<string, unknown>;
+  headings: Array<{ id: string; text: string; level: number }>;
+}
+
 interface FetchedDataResult {
   type: "page" | "layout";
   id: string;
@@ -660,39 +665,13 @@ export class RenderPipeline {
       layoutProps[layoutId] = props;
     }
 
-    let frontmatter: Record<string, unknown> = {};
-    let headings: Array<{ id: string; text: string; level: number }> = [];
-    if (pageType === "mdx") {
-      try {
-        const bundleResult = await this.config.pageRenderer.preparePageBundles(
-          pageInfo,
-          slug,
-          undefined,
-          {
-            ...options,
-            ...(Object.keys(params).length > 0 ? { params } : {}),
-          },
-        );
-
-        if (bundleResult.pageBundle && "frontmatter" in bundleResult.pageBundle) {
-          frontmatter =
-            (bundleResult.pageBundle as { frontmatter?: Record<string, unknown> }).frontmatter ||
-            {};
-        }
-
-        if (bundleResult.pageBundle && "headings" in bundleResult.pageBundle) {
-          headings = (bundleResult.pageBundle as {
-            headings?: Array<{ id: string; text: string; level: number }>;
-          }).headings || [];
-        }
-      } catch (error) {
-        renderPipelineLog.error("Frontmatter/headings extraction failed", {
-          slug,
-          error: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-        });
-      }
-    }
+    const { frontmatter, headings } = await this.extractMdxMetadata(
+      pageType,
+      pageInfo,
+      slug,
+      options,
+      params,
+    );
 
     const layouts = layoutResult.nestedLayouts
       .filter((l: LayoutItem) => l.componentPath || l.path)
@@ -814,6 +793,49 @@ export class RenderPipeline {
       css,
       cssError,
     };
+  }
+
+  private async extractMdxMetadata(
+    pageType: PageDataResponse["pageType"],
+    pageInfo: Awaited<ReturnType<PageResolver["resolvePage"]>>,
+    slug: string,
+    options: RenderOptions | undefined,
+    params: Record<string, string | string[]>,
+  ): Promise<MdxMetadataResult> {
+    if (pageType !== "mdx") {
+      return { frontmatter: {}, headings: [] };
+    }
+
+    try {
+      const bundleResult = await this.config.pageRenderer.preparePageBundles(
+        pageInfo,
+        slug,
+        undefined,
+        {
+          ...options,
+          ...(Object.keys(params).length > 0 ? { params } : {}),
+        },
+      );
+
+      const pageBundle = bundleResult.pageBundle;
+      return {
+        frontmatter: pageBundle && "frontmatter" in pageBundle
+          ? (pageBundle as { frontmatter?: Record<string, unknown> }).frontmatter || {}
+          : {},
+        headings: pageBundle && "headings" in pageBundle
+          ? (pageBundle as {
+            headings?: Array<{ id: string; text: string; level: number }>;
+          }).headings || []
+          : [],
+      };
+    } catch (error) {
+      renderPipelineLog.error("Frontmatter/headings extraction failed", {
+        slug,
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+      return { frontmatter: {}, headings: [] };
+    }
   }
 
   /**

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.177";
+export const VERSION = "0.1.178";


### PR DESCRIPTION
## Summary
- extract the mdx-only frontmatter/headings loading path from `resolvePageData()`
- add behavior coverage that mdx bundle metadata is surfaced through page data
- bump the release version to `0.1.178`

## Verification
- deno test --no-check --allow-all src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version.test.ts
- deno fmt --check src/rendering/orchestrator/pipeline.ts src/rendering/orchestrator/pipeline.behavior.test.ts deno.json src/utils/version-constant.ts
- deno lint src/rendering/orchestrator/pipeline.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick