### PR TITLE
Extract render-pipeline appPath helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.179",
+  "version": "0.1.180",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -160,6 +160,25 @@ describe("RenderPipeline behavior", () => {
     assertEquals(pageData.headings, [{ id: "intro", text: "Intro", level: 2 }]);
   });
 
+  it("resolvePageData includes appPath when an app component exists", async () => {
+    const slug = "/behavior-app-path";
+    const projectId = "proj-app-path";
+    const pipeline = createPipeline("/project/pages/behavior-app-path.tsx");
+    primeCssCache(slug, projectId);
+
+    (pipeline as any).loadModule = async () => ({});
+    (pipeline as any).config.adapter.fs.exists = async (path: string) =>
+      path === "/project/components/app.tsx";
+
+    const pageData = await pipeline.resolvePageData(slug, {
+      projectId,
+      request: new Request(`http://localhost${slug}`),
+      url: new URL(`http://localhost${slug}`),
+    });
+
+    assertEquals(pageData.appPath, "components/app.tsx");
+  });
+
   it("resolvePageData reuses the SSR hashed stylesheet for SPA CSS", async () => {
     const slug = "/behavior-ssr-css";
     const projectId = "proj-ssr-css";

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -696,14 +696,7 @@ export class RenderPipeline {
       projectUpdatedAt = wrappedAdapter.getProjectData?.()?.updated_at;
     }
 
-    let appPath: string | undefined;
-    for (const ext of LAYOUT_EXTENSIONS) {
-      const candidatePath = join(this.config.projectDir, `components/app.${ext}`);
-      if (await this.config.adapter.fs.exists(candidatePath)) {
-        appPath = extractRelativePathShared(candidatePath, this.config.projectDir);
-        break;
-      }
-    }
+    const appPath = await this.resolveAppPath();
 
     const { css, cssError } = await this.resolvePageDataCss(slug, options, projectUpdatedAt);
 
@@ -777,6 +770,17 @@ export class RenderPipeline {
       });
       return { frontmatter: {}, headings: [] };
     }
+  }
+
+  private async resolveAppPath(): Promise<string | undefined> {
+    for (const ext of LAYOUT_EXTENSIONS) {
+      const candidatePath = join(this.config.projectDir, `components/app.${ext}`);
+      if (await this.config.adapter.fs.exists(candidatePath)) {
+        return extractRelativePathShared(candidatePath, this.config.projectDir);
+      }
+    }
+
+    return undefined;
   }
 
   private async resolvePageDataCss(

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.179";
+export const VERSION = "0.1.180";


### PR DESCRIPTION
## Summary
- extract the app component path lookup from `resolvePageData()`
- add behavior coverage that page data exposes `appPath` when `components/app.tsx` exists
- bump the release version to `0.1.180`

## Verification
- deno test --no-check --allow-all src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version.test.ts
- deno fmt --check src/rendering/orchestrator/pipeline.ts src/rendering/orchestrator/pipeline.behavior.test.ts deno.json src/utils/version-constant.ts
- deno lint src/rendering/orchestrator/pipeline.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick