### PR TITLE
Extract render-pipeline buildVersion helper

### DIFF
--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -179,6 +179,37 @@ describe("RenderPipeline behavior", () => {
     assertEquals(pageData.appPath, "components/app.tsx");
   });
 
+  it("resolvePageData includes projectUpdated in buildVersion when available", async () => {
+    const slug = "/behavior-build-version";
+    const projectId = "proj-build-version";
+    const projectUpdated = "2025-01-02T03:04:05Z";
+    const pipeline = createPipeline("/project/pages/behavior-build-version.tsx");
+    primeCssCache(slug, projectId);
+    cachePageCss(
+      getPageCssCacheKey(projectId, undefined, slug, projectUpdated),
+      "/* cached css */",
+    );
+
+    (pipeline as any).loadModule = async () => ({});
+    (pipeline as any).config.adapter.fs = {
+      exists: async () => false,
+      isMultiProjectMode: () => false,
+      isVeryfrontAdapter: () => true,
+      getAdapterType: () => "VeryfrontFSAdapter",
+      getUnderlyingAdapter: () => ({
+        getProjectData: () => ({ updated_at: projectUpdated }),
+      }),
+    };
+
+    const pageData = await pipeline.resolvePageData(slug, {
+      projectId,
+      request: new Request(`http://localhost${slug}`),
+      url: new URL(`http://localhost${slug}`),
+    });
+
+    assertEquals(pageData.buildVersion.projectUpdated, projectUpdated);
+  });
+
   it("resolvePageData reuses the SSR hashed stylesheet for SPA CSS", async () => {
     const slug = "/behavior-ssr-css";
     const projectId = "proj-ssr-css";

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -687,14 +687,7 @@ export class RenderPipeline {
 
     const providers: string[] = [];
 
-    let projectUpdatedAt: string | undefined;
-    const fs = this.config.adapter?.fs;
-    if (fs && isExtendedFSAdapter(fs) && fs.isVeryfrontAdapter()) {
-      const wrappedAdapter = fs.getUnderlyingAdapter() as {
-        getProjectData?: () => { updated_at?: string } | undefined;
-      };
-      projectUpdatedAt = wrappedAdapter.getProjectData?.()?.updated_at;
-    }
+    const projectUpdatedAt = this.resolveProjectUpdatedAt();
 
     const appPath = await this.resolveAppPath();
 
@@ -781,6 +774,18 @@ export class RenderPipeline {
     }
 
     return undefined;
+  }
+
+  private resolveProjectUpdatedAt(): string | undefined {
+    const fs = this.config.adapter?.fs;
+    if (!fs || !isExtendedFSAdapter(fs) || !fs.isVeryfrontAdapter()) {
+      return undefined;
+    }
+
+    const wrappedAdapter = fs.getUnderlyingAdapter() as {
+      getProjectData?: () => { updated_at?: string } | undefined;
+    };
+    return wrappedAdapter.getProjectData?.()?.updated_at;
   }
 
   private async resolvePageDataCss(


### PR DESCRIPTION
## Summary
- extract the project-updated/buildVersion source lookup from `resolvePageData()`
- add behavior coverage that page data carries `buildVersion.projectUpdated` when available from the Veryfront adapter
- bump the release version to `0.1.180`

## Verification
- deno test --no-check --allow-all src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version.test.ts
- deno fmt --check src/rendering/orchestrator/pipeline.ts src/rendering/orchestrator/pipeline.behavior.test.ts deno.json src/utils/version-constant.ts
- deno lint src/rendering/orchestrator/pipeline.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick