### PR TITLE
Publish a public browser AG-UI encoder for agent hosts

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.180",
+  "version": "0.1.181",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -15,6 +15,7 @@ import {
   agent,
   agentAsTool,
   AgentRuntime,
+  createAgUiBrowserEncoderState,
   AgUiRequestSchema,
   AgUiResumeSignalSchema,
   AgUiRuntimeRequestSchema,
@@ -128,6 +129,26 @@ export const POST = createAgUiHandler({
 });
 ```
 
+### Browser AG-UI encoder
+
+```ts
+import {
+  createAgUiBrowserEncoderState,
+  finalizeAgUiBrowserEvents,
+  mapRuntimeStreamEventToAgUiBrowserEvents,
+} from "veryfront/agent";
+
+const state = createAgUiBrowserEncoderState();
+const events = mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+  type: "tool-input-available",
+  toolCallId: "tool-1",
+  toolName: "web_search",
+  input: { query: "Veryfront" },
+});
+
+const finalEvents = finalizeAgUiBrowserEvents(state, null);
+```
+
 ### Human input over hosted AG-UI runs
 
 ```ts
@@ -210,6 +231,18 @@ when bootstrap credentials are present.
 | `skills?`                | `true \| string[]`                                                                                                                                  | Enable skills for this agent.                                                        |
 
 **Returns:** `Agent`
+
+### Browser AG-UI stream encoder
+
+Use these helpers when a host needs to turn the framework runtime stream event
+family into browser/public AG-UI events without importing internal transport
+modules.
+
+| Export | Type | Description |
+| ------ | ---- | ----------- |
+| `createAgUiBrowserEncoderState()` | `() => AgUiBrowserEncoderState` | Create mutable encoder state for one browser AG-UI stream. |
+| `mapRuntimeStreamEventToAgUiBrowserEvents(state, event)` | `(state, event) => AgUiBrowserEncodedEvent[]` | Map one runtime stream event into zero or more browser/public AG-UI events. |
+| `finalizeAgUiBrowserEvents(state, response)` | `(state, response) => AgUiBrowserEncodedEvent[]` | Emit terminal browser/public AG-UI events after the runtime stream finishes. |
 
 ### Request-aware model transport
 

--- a/src/agent/ag-ui-browser-encoder.test.ts
+++ b/src/agent/ag-ui-browser-encoder.test.ts
@@ -1,0 +1,209 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  createAgUiBrowserEncoderState,
+  finalizeAgUiBrowserEvents,
+  mapRuntimeStreamEventToAgUiBrowserEvents,
+} from "./ag-ui-browser-encoder.ts";
+
+describe("agent/ag-ui-browser-encoder", () => {
+  it("maps text, reasoning, step, and tool lifecycle events into browser AG-UI payloads", () => {
+    const state = createAgUiBrowserEncoderState();
+
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "message-start",
+        messageId: "assistant-1",
+      }),
+      [],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "reasoning-start",
+        id: "reasoning-1",
+      }),
+      [{
+        event: "ReasoningMessageStart",
+        payload: { messageId: "assistant-1:reasoning:reasoning-1", role: "reasoning" },
+      }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "reasoning-delta",
+        id: "reasoning-1",
+        delta: "Thinking",
+      }),
+      [{
+        event: "ReasoningMessageContent",
+        payload: { messageId: "assistant-1:reasoning:reasoning-1", delta: "Thinking" },
+      }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, { type: "reasoning-end", id: "reasoning-1" }),
+      [{
+        event: "ReasoningMessageEnd",
+        payload: { messageId: "assistant-1:reasoning:reasoning-1" },
+      }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, { type: "step-start" }),
+      [{ event: "StepStarted", payload: { stepName: "step-1" } }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, { type: "text-delta", delta: "hello" }),
+      [
+        { event: "TextMessageStart", payload: { messageId: "assistant-1", role: "assistant" } },
+        { event: "TextMessageContent", payload: { messageId: "assistant-1", delta: "hello" } },
+      ],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "tool-input-start",
+        toolCallId: "tool-1",
+        toolName: "web_search",
+      }),
+      [{
+        event: "ToolCallStart",
+        payload: { toolCallId: "tool-1", toolCallName: "web_search" },
+      }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "tool-input-available",
+        toolCallId: "tool-1",
+        toolName: "web_search",
+        input: { query: "Veryfront" },
+      }),
+      [
+        {
+          event: "ToolCallArgs",
+          payload: { toolCallId: "tool-1", delta: '{"query":"Veryfront"}' },
+        },
+        {
+          event: "ToolCallEnd",
+          payload: { toolCallId: "tool-1" },
+        },
+      ],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "tool-output-available",
+        toolCallId: "tool-1",
+        output: { ok: true },
+      }),
+      [{
+        event: "ToolCallResult",
+        payload: { toolCallId: "tool-1", result: { ok: true } },
+      }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, { type: "step-end" }),
+      [{ event: "StepFinished", payload: { stepName: "step-1" } }],
+    );
+  });
+
+  it("maps custom data events and tool fallback error events", () => {
+    const state = createAgUiBrowserEncoderState();
+
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "data-message-metadata",
+        data: { status: "running" },
+      }),
+      [{
+        event: "Custom",
+        payload: { name: "message-metadata", value: { status: "running" } },
+      }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "tool-input-error",
+        toolCallId: "tool-2",
+        input: { url: "https://example.com" },
+        errorText: "invalid url",
+      }),
+      [
+        {
+          event: "ToolCallArgs",
+          payload: { toolCallId: "tool-2", delta: '{"url":"https://example.com"}' },
+        },
+        {
+          event: "ToolCallEnd",
+          payload: { toolCallId: "tool-2" },
+        },
+        {
+          event: "ToolCallResult",
+          payload: { toolCallId: "tool-2", result: { error: "invalid url" }, isError: true },
+        },
+      ],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "tool-output-denied",
+        toolCallId: "tool-3",
+      }),
+      [{
+        event: "ToolCallResult",
+        payload: { toolCallId: "tool-3", result: { error: "Tool output denied" }, isError: true },
+      }],
+    );
+  });
+
+  it("finalizes metadata and emits terminal errors for empty output", () => {
+    const visibleState = createAgUiBrowserEncoderState();
+    mapRuntimeStreamEventToAgUiBrowserEvents(visibleState, {
+      type: "message-start",
+      messageId: "assistant-2",
+    });
+    mapRuntimeStreamEventToAgUiBrowserEvents(visibleState, {
+      type: "text-start",
+      id: "text-1",
+    });
+
+    assertEquals(
+      finalizeAgUiBrowserEvents(visibleState, {
+        text: "done",
+        messages: [],
+        toolCalls: [],
+        status: "completed",
+        usage: {
+          promptTokens: 12,
+          completionTokens: 8,
+          totalTokens: 20,
+        },
+        metadata: {
+          finishReason: "stop",
+        },
+      }),
+      [
+        {
+          event: "TextMessageEnd",
+          payload: { messageId: "assistant-2" },
+        },
+        {
+          event: "RunFinished",
+          payload: {
+            metadata: {
+              inputTokens: 12,
+              outputTokens: 8,
+              totalTokens: 20,
+              finishReason: "stop",
+            },
+          },
+        },
+      ],
+    );
+
+    const emptyState = createAgUiBrowserEncoderState();
+    assertEquals(
+      finalizeAgUiBrowserEvents(emptyState, null),
+      [{
+        event: "RunError",
+        payload: {
+          code: "EMPTY_ASSISTANT_OUTPUT",
+          message: "Agent run produced no assistant-visible output",
+        },
+      }],
+    );
+  });
+});

--- a/src/agent/ag-ui-browser-encoder.ts
+++ b/src/agent/ag-ui-browser-encoder.ts
@@ -1,0 +1,416 @@
+import type { AgentResponse } from "./types.ts";
+
+export type AgUiRuntimeStreamEvent = Record<string, unknown> & { type: string };
+
+export interface AgUiBrowserRunFinishedMetadata {
+  provider?: string;
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  finishReason?: string;
+}
+
+export interface AgUiBrowserEncoderState {
+  messageId: string | null;
+  textOpen: boolean;
+  reasoningMessageId: string | null;
+  activeStepName: string | null;
+  stepCount: number;
+  streamedToolInputIds: Set<string>;
+  sawVisibleOutput: boolean;
+  sawTerminalError: boolean;
+  metadata: AgUiBrowserRunFinishedMetadata;
+}
+
+export interface AgUiBrowserEncodedEvent {
+  event: string;
+  payload: Record<string, unknown>;
+}
+
+export function createAgUiBrowserEncoderState(): AgUiBrowserEncoderState {
+  return {
+    messageId: null,
+    textOpen: false,
+    reasoningMessageId: null,
+    activeStepName: null,
+    stepCount: 0,
+    streamedToolInputIds: new Set<string>(),
+    sawVisibleOutput: false,
+    sawTerminalError: false,
+    metadata: {},
+  };
+}
+
+function serializeToolInput(input: unknown): string {
+  try {
+    return JSON.stringify(input ?? {});
+  } catch {
+    return "{}";
+  }
+}
+
+function getMessageId(state: AgUiBrowserEncoderState, event: AgUiRuntimeStreamEvent): string {
+  if (typeof event.messageId === "string") {
+    state.messageId = event.messageId;
+    return event.messageId;
+  }
+
+  if (!state.messageId && typeof event.id === "string") {
+    state.messageId = event.id;
+  }
+
+  if (!state.messageId) {
+    state.messageId = crypto.randomUUID();
+  }
+
+  return state.messageId;
+}
+
+function getReasoningMessageId(
+  state: AgUiBrowserEncoderState,
+  event: AgUiRuntimeStreamEvent,
+): string {
+  if (typeof event.id === "string" && event.id.length > 0) {
+    state.reasoningMessageId = state.messageId
+      ? `${state.messageId}:reasoning:${event.id}`
+      : event.id;
+    return state.reasoningMessageId;
+  }
+
+  if (!state.reasoningMessageId) {
+    state.reasoningMessageId = state.messageId
+      ? `${state.messageId}:reasoning:${crypto.randomUUID()}`
+      : crypto.randomUUID();
+  }
+
+  return state.reasoningMessageId;
+}
+
+function nextStepName(state: AgUiBrowserEncoderState): string {
+  state.stepCount += 1;
+  state.activeStepName = `step-${state.stepCount}`;
+  return state.activeStepName;
+}
+
+function finishStepName(state: AgUiBrowserEncoderState): string {
+  const stepName = state.activeStepName ?? `step-${Math.max(state.stepCount, 1)}`;
+  state.activeStepName = null;
+  return stepName;
+}
+
+function applyDataMetadata(state: AgUiBrowserEncoderState, event: AgUiRuntimeStreamEvent): void {
+  const data = event.data && typeof event.data === "object" && !Array.isArray(event.data)
+    ? event.data as Record<string, unknown>
+    : event;
+
+  if (typeof data.model === "string") {
+    state.metadata.model = data.model;
+    const provider = data.model.split("/")[0];
+    if (provider) {
+      state.metadata.provider = provider;
+    }
+  }
+}
+
+function applyResponseMetadata(
+  state: AgUiBrowserEncoderState,
+  response: AgentResponse | null,
+): void {
+  if (!response) return;
+
+  if (response.usage) {
+    state.metadata.inputTokens = response.usage.promptTokens;
+    state.metadata.outputTokens = response.usage.completionTokens;
+    state.metadata.totalTokens = response.usage.totalTokens;
+  }
+
+  const finishReason = response.metadata && typeof response.metadata === "object"
+    ? response.metadata.finishReason
+    : undefined;
+  if (typeof finishReason === "string") {
+    state.metadata.finishReason = finishReason;
+  }
+}
+
+export function mapRuntimeStreamEventToAgUiBrowserEvents(
+  state: AgUiBrowserEncoderState,
+  event: AgUiRuntimeStreamEvent,
+): AgUiBrowserEncodedEvent[] {
+  if (event.type.startsWith("data-")) {
+    const name = event.type.slice("data-".length);
+    if (name.length === 0) {
+      return [];
+    }
+
+    state.sawVisibleOutput = true;
+    return [{
+      event: "Custom",
+      payload: {
+        name,
+        value: "data" in event ? event.data : null,
+      },
+    }];
+  }
+
+  switch (event.type) {
+    case "message-start":
+      getMessageId(state, event);
+      return [];
+
+    case "text-start": {
+      if (state.textOpen) return [];
+      const messageId = getMessageId(state, event);
+      state.textOpen = true;
+      state.sawVisibleOutput = true;
+      return [{
+        event: "TextMessageStart",
+        payload: { messageId, role: "assistant" },
+      }];
+    }
+
+    case "text-delta": {
+      const messageId = getMessageId(state, event);
+      state.sawVisibleOutput = true;
+      if (!state.textOpen) {
+        state.textOpen = true;
+        return [
+          { event: "TextMessageStart", payload: { messageId, role: "assistant" } },
+          {
+            event: "TextMessageContent",
+            payload: { messageId, delta: typeof event.delta === "string" ? event.delta : "" },
+          },
+        ];
+      }
+
+      return [{
+        event: "TextMessageContent",
+        payload: { messageId, delta: typeof event.delta === "string" ? event.delta : "" },
+      }];
+    }
+
+    case "text-end": {
+      if (!state.textOpen) return [];
+      state.textOpen = false;
+      return [{
+        event: "TextMessageEnd",
+        payload: { messageId: getMessageId(state, event) },
+      }];
+    }
+
+    case "reasoning-start":
+      state.sawVisibleOutput = true;
+      return [{
+        event: "ReasoningMessageStart",
+        payload: { messageId: getReasoningMessageId(state, event), role: "reasoning" },
+      }];
+
+    case "reasoning-delta":
+      state.sawVisibleOutput = true;
+      return [{
+        event: "ReasoningMessageContent",
+        payload: {
+          messageId: getReasoningMessageId(state, event),
+          delta: typeof event.delta === "string" ? event.delta : "",
+        },
+      }];
+
+    case "reasoning-end": {
+      const messageId = getReasoningMessageId(state, event);
+      state.reasoningMessageId = null;
+      return [{
+        event: "ReasoningMessageEnd",
+        payload: { messageId },
+      }];
+    }
+
+    case "tool-input-start":
+      state.sawVisibleOutput = true;
+      return [{
+        event: "ToolCallStart",
+        payload: {
+          toolCallId: event.toolCallId,
+          toolCallName: event.toolName,
+        },
+      }];
+
+    case "tool-input-delta":
+      state.sawVisibleOutput = true;
+      if (typeof event.toolCallId === "string") {
+        state.streamedToolInputIds.add(event.toolCallId);
+      }
+      return [{
+        event: "ToolCallArgs",
+        payload: {
+          toolCallId: event.toolCallId,
+          delta: typeof event.inputTextDelta === "string" ? event.inputTextDelta : "",
+        },
+      }];
+
+    case "tool-input-available": {
+      state.sawVisibleOutput = true;
+      const toolCallId = typeof event.toolCallId === "string" ? event.toolCallId : "";
+      const events: AgUiBrowserEncodedEvent[] = [];
+
+      if (toolCallId.length > 0 && !state.streamedToolInputIds.has(toolCallId)) {
+        events.push({
+          event: "ToolCallArgs",
+          payload: {
+            toolCallId,
+            delta: serializeToolInput("input" in event ? event.input : {}),
+          },
+        });
+      }
+
+      if (toolCallId.length > 0) {
+        state.streamedToolInputIds.delete(toolCallId);
+      }
+
+      events.push({
+        event: "ToolCallEnd",
+        payload: { toolCallId: event.toolCallId },
+      });
+      return events;
+    }
+
+    case "tool-input-error": {
+      state.sawVisibleOutput = true;
+      const toolCallId = typeof event.toolCallId === "string" ? event.toolCallId : "";
+      const events: AgUiBrowserEncodedEvent[] = [];
+
+      if (toolCallId.length > 0 && !state.streamedToolInputIds.has(toolCallId)) {
+        events.push({
+          event: "ToolCallArgs",
+          payload: {
+            toolCallId,
+            delta: serializeToolInput("input" in event ? event.input : {}),
+          },
+        });
+      }
+
+      if (toolCallId.length > 0) {
+        state.streamedToolInputIds.delete(toolCallId);
+      }
+
+      events.push({
+        event: "ToolCallEnd",
+        payload: { toolCallId: event.toolCallId },
+      });
+      events.push({
+        event: "ToolCallResult",
+        payload: {
+          toolCallId: event.toolCallId,
+          result: {
+            error: typeof event.errorText === "string" ? event.errorText : "Tool input failed",
+          },
+          isError: true,
+        },
+      });
+      return events;
+    }
+
+    case "tool-output-available":
+      state.sawVisibleOutput = true;
+      return [{
+        event: "ToolCallResult",
+        payload: {
+          toolCallId: event.toolCallId,
+          result: event.output,
+        },
+      }];
+
+    case "tool-output-error":
+      state.sawVisibleOutput = true;
+      return [{
+        event: "ToolCallResult",
+        payload: {
+          toolCallId: event.toolCallId,
+          result: { error: event.errorText },
+          isError: true,
+        },
+      }];
+
+    case "tool-output-denied":
+      state.sawVisibleOutput = true;
+      return [{
+        event: "ToolCallResult",
+        payload: {
+          toolCallId: event.toolCallId,
+          result: { error: "Tool output denied" },
+          isError: true,
+        },
+      }];
+
+    case "step-start":
+    case "start-step":
+      state.sawVisibleOutput = true;
+      return [{
+        event: "StepStarted",
+        payload: { stepName: nextStepName(state) },
+      }];
+
+    case "step-end":
+    case "finish-step":
+      state.sawVisibleOutput = true;
+      return [{
+        event: "StepFinished",
+        payload: { stepName: finishStepName(state) },
+      }];
+
+    case "data":
+      applyDataMetadata(state, event);
+      return [];
+
+    case "error":
+      state.sawTerminalError = true;
+      return [{
+        event: "RunError",
+        payload: {
+          message: typeof event.error === "string" ? event.error : "Agent run failed",
+        },
+      }];
+
+    default:
+      return [];
+  }
+}
+
+export function finalizeAgUiBrowserEvents(
+  state: AgUiBrowserEncoderState,
+  response: AgentResponse | null,
+): AgUiBrowserEncodedEvent[] {
+  applyResponseMetadata(state, response);
+
+  if (state.sawTerminalError) {
+    return [];
+  }
+
+  if (!state.sawVisibleOutput) {
+    state.sawTerminalError = true;
+    return [{
+      event: "RunError",
+      payload: {
+        code: "EMPTY_ASSISTANT_OUTPUT",
+        message: "Agent run produced no assistant-visible output",
+      },
+    }];
+  }
+
+  const events: AgUiBrowserEncodedEvent[] = [];
+  if (state.textOpen) {
+    state.textOpen = false;
+    events.push({
+      event: "TextMessageEnd",
+      payload: { messageId: getMessageId(state, { type: "text-end" }) },
+    });
+  }
+
+  events.push({
+    event: "RunFinished",
+    payload: {
+      metadata: state.metadata,
+    },
+  });
+
+  return events;
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -150,6 +150,15 @@ export {
   AgUiRuntimeRequestSchema,
 } from "./runtime-ag-ui-contract.ts";
 export {
+  type AgUiBrowserEncodedEvent,
+  type AgUiBrowserEncoderState,
+  type AgUiBrowserRunFinishedMetadata,
+  type AgUiRuntimeStreamEvent,
+  createAgUiBrowserEncoderState,
+  finalizeAgUiBrowserEvents,
+  mapRuntimeStreamEventToAgUiBrowserEvents,
+} from "./ag-ui-browser-encoder.ts";
+export {
   type AgUiCancelHandlerOptions,
   type AgUiResumeHandlerOptions,
   type AgUiResumeSignal,

--- a/src/internal-agents/ag-ui-sse.ts
+++ b/src/internal-agents/ag-ui-sse.ts
@@ -1,53 +1,27 @@
-import type { AgentResponse } from "#veryfront/agent";
+import type {
+  AgUiBrowserEncodedEvent,
+  AgUiBrowserEncoderState,
+  AgUiBrowserRunFinishedMetadata,
+  AgUiRuntimeStreamEvent,
+} from "../agent/ag-ui-browser-encoder.ts";
+import {
+  createAgUiBrowserEncoderState,
+  finalizeAgUiBrowserEvents,
+  mapRuntimeStreamEventToAgUiBrowserEvents,
+} from "../agent/ag-ui-browser-encoder.ts";
 import { serverLogger } from "#veryfront/utils";
 import { z } from "zod";
 
 const encoder = new TextEncoder();
 const logger = serverLogger.component("internal-agents-ag-ui-sse");
 
-type RuntimeDataEvent = Record<string, unknown> & { type: string };
-
-export interface RunFinishedMetadata {
-  provider?: string;
-  model?: string;
-  inputTokens?: number;
-  outputTokens?: number;
-  totalTokens?: number;
-  finishReason?: string;
-}
-
-export interface StreamTransformState {
-  messageId: string | null;
-  textOpen: boolean;
-  reasoningMessageId: string | null;
-  activeStepName: string | null;
-  stepCount: number;
-  streamedToolInputIds: Set<string>;
-  sawVisibleOutput: boolean;
-  sawTerminalError: boolean;
-  metadata: RunFinishedMetadata;
-}
+type RuntimeDataEvent = AgUiRuntimeStreamEvent;
+export type RunFinishedMetadata = AgUiBrowserRunFinishedMetadata;
+export type StreamTransformState = AgUiBrowserEncoderState;
+export type MappedAgUiEvent = AgUiBrowserEncodedEvent;
 
 export function createStreamTransformState(): StreamTransformState {
-  return {
-    messageId: null,
-    textOpen: false,
-    reasoningMessageId: null,
-    activeStepName: null,
-    stepCount: 0,
-    streamedToolInputIds: new Set<string>(),
-    sawVisibleOutput: false,
-    sawTerminalError: false,
-    metadata: {},
-  };
-}
-
-function serializeToolInput(input: unknown): string {
-  try {
-    return JSON.stringify(input ?? {});
-  } catch {
-    return "{}";
-  }
+  return createAgUiBrowserEncoderState();
 }
 
 const agUiEventPayloadSchemas = {
@@ -170,361 +144,16 @@ export function parseSseJsonEvents(chunk: string): {
   return { events, remainder };
 }
 
-function getMessageId(state: StreamTransformState, event: RuntimeDataEvent): string {
-  if (typeof event.messageId === "string") {
-    state.messageId = event.messageId;
-    return event.messageId;
-  }
-
-  if (!state.messageId && typeof event.id === "string") {
-    state.messageId = event.id;
-  }
-
-  if (!state.messageId) {
-    state.messageId = crypto.randomUUID();
-  }
-
-  return state.messageId;
-}
-
-function getReasoningMessageId(state: StreamTransformState, event: RuntimeDataEvent): string {
-  if (typeof event.id === "string" && event.id.length > 0) {
-    state.reasoningMessageId = state.messageId
-      ? `${state.messageId}:reasoning:${event.id}`
-      : event.id;
-    return state.reasoningMessageId;
-  }
-
-  if (!state.reasoningMessageId) {
-    state.reasoningMessageId = state.messageId
-      ? `${state.messageId}:reasoning:${crypto.randomUUID()}`
-      : crypto.randomUUID();
-  }
-
-  return state.reasoningMessageId;
-}
-
-function nextStepName(state: StreamTransformState): string {
-  state.stepCount += 1;
-  state.activeStepName = `step-${state.stepCount}`;
-  return state.activeStepName;
-}
-
-function finishStepName(state: StreamTransformState): string {
-  const stepName = state.activeStepName ?? `step-${Math.max(state.stepCount, 1)}`;
-  state.activeStepName = null;
-  return stepName;
-}
-
-function applyDataMetadata(state: StreamTransformState, event: RuntimeDataEvent): void {
-  const data = event.data && typeof event.data === "object" && !Array.isArray(event.data)
-    ? event.data as Record<string, unknown>
-    : event;
-
-  if (typeof data.model === "string") {
-    state.metadata.model = data.model;
-    const provider = data.model.split("/")[0];
-    if (provider) {
-      state.metadata.provider = provider;
-    }
-  }
-}
-
-function applyResponseMetadata(state: StreamTransformState, response: AgentResponse | null): void {
-  if (!response) return;
-
-  if (response.usage) {
-    state.metadata.inputTokens = response.usage.promptTokens;
-    state.metadata.outputTokens = response.usage.completionTokens;
-    state.metadata.totalTokens = response.usage.totalTokens;
-  }
-
-  const finishReason = response.metadata && typeof response.metadata === "object"
-    ? response.metadata.finishReason
-    : undefined;
-  if (typeof finishReason === "string") {
-    state.metadata.finishReason = finishReason;
-  }
-}
-
 export function mapRuntimeEventToAgUi(
   state: StreamTransformState,
   event: RuntimeDataEvent,
-): Array<{ event: string; payload: Record<string, unknown> }> {
-  if (event.type.startsWith("data-")) {
-    const name = event.type.slice("data-".length);
-    if (name.length === 0) {
-      return [];
-    }
-
-    state.sawVisibleOutput = true;
-    return [{
-      event: "Custom",
-      payload: {
-        name,
-        value: "data" in event ? event.data : null,
-      },
-    }];
-  }
-
-  switch (event.type) {
-    case "message-start":
-      getMessageId(state, event);
-      return [];
-
-    case "text-start": {
-      if (state.textOpen) return [];
-      const messageId = getMessageId(state, event);
-      state.textOpen = true;
-      state.sawVisibleOutput = true;
-      return [{
-        event: "TextMessageStart",
-        payload: { messageId, role: "assistant" },
-      }];
-    }
-
-    case "text-delta": {
-      const messageId = getMessageId(state, event);
-      state.sawVisibleOutput = true;
-      if (!state.textOpen) {
-        state.textOpen = true;
-        return [
-          { event: "TextMessageStart", payload: { messageId, role: "assistant" } },
-          {
-            event: "TextMessageContent",
-            payload: { messageId, delta: typeof event.delta === "string" ? event.delta : "" },
-          },
-        ];
-      }
-
-      return [{
-        event: "TextMessageContent",
-        payload: { messageId, delta: typeof event.delta === "string" ? event.delta : "" },
-      }];
-    }
-
-    case "text-end": {
-      if (!state.textOpen) return [];
-      state.textOpen = false;
-      return [{
-        event: "TextMessageEnd",
-        payload: { messageId: getMessageId(state, event) },
-      }];
-    }
-
-    case "reasoning-start":
-      state.sawVisibleOutput = true;
-      return [{
-        event: "ReasoningMessageStart",
-        payload: { messageId: getReasoningMessageId(state, event), role: "reasoning" },
-      }];
-
-    case "reasoning-delta":
-      state.sawVisibleOutput = true;
-      return [{
-        event: "ReasoningMessageContent",
-        payload: {
-          messageId: getReasoningMessageId(state, event),
-          delta: typeof event.delta === "string" ? event.delta : "",
-        },
-      }];
-
-    case "reasoning-end": {
-      const messageId = getReasoningMessageId(state, event);
-      state.reasoningMessageId = null;
-      return [{
-        event: "ReasoningMessageEnd",
-        payload: { messageId },
-      }];
-    }
-
-    case "tool-input-start":
-      state.sawVisibleOutput = true;
-      return [{
-        event: "ToolCallStart",
-        payload: {
-          toolCallId: event.toolCallId,
-          toolCallName: event.toolName,
-        },
-      }];
-
-    case "tool-input-delta":
-      state.sawVisibleOutput = true;
-      if (typeof event.toolCallId === "string") {
-        state.streamedToolInputIds.add(event.toolCallId);
-      }
-      return [{
-        event: "ToolCallArgs",
-        payload: {
-          toolCallId: event.toolCallId,
-          delta: typeof event.inputTextDelta === "string" ? event.inputTextDelta : "",
-        },
-      }];
-
-    case "tool-input-available": {
-      state.sawVisibleOutput = true;
-      const toolCallId = typeof event.toolCallId === "string" ? event.toolCallId : "";
-      const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
-
-      if (toolCallId.length > 0 && !state.streamedToolInputIds.has(toolCallId)) {
-        events.push({
-          event: "ToolCallArgs",
-          payload: {
-            toolCallId,
-            delta: serializeToolInput("input" in event ? event.input : {}),
-          },
-        });
-      }
-
-      if (toolCallId.length > 0) {
-        state.streamedToolInputIds.delete(toolCallId);
-      }
-
-      events.push({
-        event: "ToolCallEnd",
-        payload: { toolCallId: event.toolCallId },
-      });
-      return events;
-    }
-
-    case "tool-input-error": {
-      state.sawVisibleOutput = true;
-      const toolCallId = typeof event.toolCallId === "string" ? event.toolCallId : "";
-      const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
-
-      if (toolCallId.length > 0 && !state.streamedToolInputIds.has(toolCallId)) {
-        events.push({
-          event: "ToolCallArgs",
-          payload: {
-            toolCallId,
-            delta: serializeToolInput("input" in event ? event.input : {}),
-          },
-        });
-      }
-
-      if (toolCallId.length > 0) {
-        state.streamedToolInputIds.delete(toolCallId);
-      }
-
-      events.push({
-        event: "ToolCallEnd",
-        payload: { toolCallId: event.toolCallId },
-      });
-      events.push({
-        event: "ToolCallResult",
-        payload: {
-          toolCallId: event.toolCallId,
-          result: {
-            error: typeof event.errorText === "string" ? event.errorText : "Tool input failed",
-          },
-          isError: true,
-        },
-      });
-      return events;
-    }
-
-    case "tool-output-available":
-      state.sawVisibleOutput = true;
-      return [{
-        event: "ToolCallResult",
-        payload: {
-          toolCallId: event.toolCallId,
-          result: event.output,
-        },
-      }];
-
-    case "tool-output-error":
-      state.sawVisibleOutput = true;
-      return [{
-        event: "ToolCallResult",
-        payload: {
-          toolCallId: event.toolCallId,
-          result: { error: event.errorText },
-          isError: true,
-        },
-      }];
-
-    case "tool-output-denied":
-      state.sawVisibleOutput = true;
-      return [{
-        event: "ToolCallResult",
-        payload: {
-          toolCallId: event.toolCallId,
-          result: { error: "Tool output denied" },
-          isError: true,
-        },
-      }];
-
-    case "step-start":
-    case "start-step":
-      state.sawVisibleOutput = true;
-      return [{
-        event: "StepStarted",
-        payload: { stepName: nextStepName(state) },
-      }];
-
-    case "step-end":
-    case "finish-step":
-      state.sawVisibleOutput = true;
-      return [{
-        event: "StepFinished",
-        payload: { stepName: finishStepName(state) },
-      }];
-
-    case "data":
-      applyDataMetadata(state, event);
-      return [];
-
-    case "error":
-      state.sawTerminalError = true;
-      return [{
-        event: "RunError",
-        payload: {
-          message: typeof event.error === "string" ? event.error : "Agent run failed",
-        },
-      }];
-
-    default:
-      return [];
-  }
+): MappedAgUiEvent[] {
+  return mapRuntimeStreamEventToAgUiBrowserEvents(state, event);
 }
 
 export function finalizeRunEvents(
   state: StreamTransformState,
-  response: AgentResponse | null,
-): Array<{ event: string; payload: Record<string, unknown> }> {
-  applyResponseMetadata(state, response);
-
-  if (state.sawTerminalError) {
-    return [];
-  }
-
-  if (!state.sawVisibleOutput) {
-    state.sawTerminalError = true;
-    return [{
-      event: "RunError",
-      payload: {
-        code: "EMPTY_ASSISTANT_OUTPUT",
-        message: "Agent run produced no assistant-visible output",
-      },
-    }];
-  }
-
-  const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
-  if (state.textOpen) {
-    state.textOpen = false;
-    events.push({
-      event: "TextMessageEnd",
-      payload: { messageId: getMessageId(state, { type: "text-end" }) },
-    });
-  }
-
-  events.push({
-    event: "RunFinished",
-    payload: {
-      metadata: state.metadata,
-    },
-  });
-
-  return events;
+  response: Parameters<typeof finalizeAgUiBrowserEvents>[1],
+): MappedAgUiEvent[] {
+  return finalizeAgUiBrowserEvents(state, response);
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.180";
+export const VERSION = "0.1.181";


### PR DESCRIPTION
## Summary
- publish the browser AG-UI runtime-event encoder from `veryfront/agent`
- make the hosted runtime formatter reuse that public encoder instead of owning a second copy
- document the new seam for downstream agent hosts

## Testing
- `deno test --no-check --allow-all src/agent/ag-ui-browser-encoder.test.ts src/internal-agents/ag-ui-sse.test.ts src/agent/ag-ui-handler.test.ts`
- `deno lint src/agent/ag-ui-browser-encoder.ts src/agent/ag-ui-browser-encoder.test.ts src/internal-agents/ag-ui-sse.ts src/agent/index.ts`
- `deno check src/agent/ag-ui-browser-encoder.ts src/agent/ag-ui-browser-encoder.test.ts src/internal-agents/ag-ui-sse.ts src/agent/index.ts`
- `deno task verify`