### PR TITLE
Extract render-pipeline layout serialization helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.180",
+  "version": "0.1.181",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -210,6 +210,34 @@ describe("RenderPipeline behavior", () => {
     assertEquals(pageData.buildVersion.projectUpdated, projectUpdated);
   });
 
+  it("resolvePageData serializes non-empty layouts with project-relative paths", async () => {
+    const slug = "/behavior-layouts";
+    const projectId = "proj-layouts";
+    const pipeline = createPipeline("/project/pages/behavior-layouts.tsx");
+    primeCssCache(slug, projectId);
+
+    (pipeline as any).loadModule = async () => ({});
+    (pipeline as any).config.layoutOrchestrator.collectLayouts = async () => ({
+      layoutBundle: undefined,
+      nestedLayouts: [
+        { kind: "tsx", componentPath: "/project/layouts/root.tsx" },
+        { kind: "mdx", path: "/project/layouts/docs.mdx" },
+        { kind: "tsx" },
+      ],
+    });
+
+    const pageData = await pipeline.resolvePageData(slug, {
+      projectId,
+      request: new Request(`http://localhost${slug}`),
+      url: new URL(`http://localhost${slug}`),
+    });
+
+    assertEquals(pageData.layouts, [
+      { kind: "tsx", path: "layouts/root.tsx" },
+      { kind: "mdx", path: "layouts/docs.mdx" },
+    ]);
+  });
+
   it("resolvePageData reuses the SSR hashed stylesheet for SPA CSS", async () => {
     const slug = "/behavior-ssr-css";
     const projectId = "proj-ssr-css";

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -678,12 +678,7 @@ export class RenderPipeline {
       params,
     );
 
-    const layouts = layoutResult.nestedLayouts
-      .filter((l: LayoutItem) => l.componentPath || l.path)
-      .map((l: LayoutItem) => ({
-        kind: l.kind,
-        path: extractRelativePathShared(l.componentPath || l.path || "", this.config.projectDir),
-      }));
+    const layouts = this.serializeLayouts(layoutResult.nestedLayouts);
 
     const providers: string[] = [];
 
@@ -763,6 +758,20 @@ export class RenderPipeline {
       });
       return { frontmatter: {}, headings: [] };
     }
+  }
+
+  private serializeLayouts(
+    nestedLayouts: LayoutItem[],
+  ): Array<{ kind: LayoutItem["kind"]; path: string }> {
+    return nestedLayouts
+      .filter((layout: LayoutItem) => layout.componentPath || layout.path)
+      .map((layout: LayoutItem) => ({
+        kind: layout.kind,
+        path: extractRelativePathShared(
+          layout.componentPath || layout.path || "",
+          this.config.projectDir,
+        ),
+      }));
   }
 
   private async resolveAppPath(): Promise<string | undefined> {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.180";
+export const VERSION = "0.1.181";


### PR DESCRIPTION
## Summary
- extract the nested-layout serialization from `resolvePageData()`
- add behavior coverage that only non-empty layouts are surfaced with project-relative paths
- bump the release version to `0.1.181`

## Verification
- deno test --no-check --allow-all src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version.test.ts
- deno fmt --check src/rendering/orchestrator/pipeline.ts src/rendering/orchestrator/pipeline.behavior.test.ts deno.json src/utils/version-constant.ts
- deno lint src/rendering/orchestrator/pipeline.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick