### PR TITLE
Extract render-pipeline layoutProps helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.181",
+  "version": "0.1.182",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -238,6 +238,35 @@ describe("RenderPipeline behavior", () => {
     ]);
   });
 
+  it("resolvePageData includes layoutProps from fetched layout data", async () => {
+    const slug = "/behavior-layout-props";
+    const projectId = "proj-layout-props";
+    const pipeline = createPipeline("/project/pages/behavior-layout-props.tsx");
+    primeCssCache(slug, projectId);
+
+    (pipeline as any).loadModule = async (path: string) =>
+      path === "/project/layouts/root.tsx"
+        ? { getServerData: () => ({ props: { theme: "docs" } }) }
+        : {};
+    (pipeline as any).config.layoutOrchestrator.collectLayouts = async () => ({
+      layoutBundle: undefined,
+      nestedLayouts: [{ kind: "tsx", componentPath: "/project/layouts/root.tsx" }],
+    });
+
+    const pageData = await pipeline.resolvePageData(slug, {
+      projectId,
+      request: new Request(`http://localhost${slug}`),
+      url: new URL(`http://localhost${slug}`),
+    });
+
+    assertEquals(
+      {
+        "/project/layouts/root.tsx": { theme: "docs" },
+      },
+      pageData.layoutProps,
+    );
+  });
+
   it("resolvePageData reuses the SSR hashed stylesheet for SPA CSS", async () => {
     const slug = "/behavior-ssr-css";
     const projectId = "proj-ssr-css";

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -664,11 +664,7 @@ export class RenderPipeline {
 
     const pageProps: Record<string, unknown> = dataResolution.pageProps;
     const params = dataResolution.params;
-    const layoutProps: Record<string, Record<string, unknown>> = {};
-
-    for (const [layoutId, props] of dataResolution.layoutProps.entries()) {
-      layoutProps[layoutId] = props;
-    }
+    const layoutProps = this.serializeLayoutProps(dataResolution.layoutProps);
 
     const { frontmatter, headings } = await this.extractMdxMetadata(
       pageType,
@@ -772,6 +768,18 @@ export class RenderPipeline {
           this.config.projectDir,
         ),
       }));
+  }
+
+  private serializeLayoutProps(
+    layoutProps: Map<string, Record<string, unknown>>,
+  ): Record<string, Record<string, unknown>> {
+    const serialized: Record<string, Record<string, unknown>> = {};
+
+    for (const [layoutId, props] of layoutProps.entries()) {
+      serialized[layoutId] = props;
+    }
+
+    return serialized;
   }
 
   private async resolveAppPath(): Promise<string | undefined> {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.181";
+export const VERSION = "0.1.182";


### PR DESCRIPTION
## Summary
- extract layoutProps serialization from `resolvePageData()`
- add behavior coverage that fetched layout props are surfaced in the page-data response
- bump the release version to `0.1.182`

## Verification
- deno test --no-check --allow-all src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version.test.ts
- deno fmt --check src/rendering/orchestrator/pipeline.ts src/rendering/orchestrator/pipeline.behavior.test.ts deno.json src/utils/version-constant.ts
- deno lint src/rendering/orchestrator/pipeline.ts src/rendering/orchestrator/pipeline.behavior.test.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick