### PR TITLE
Extract AG-UI tool-input completion helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.182",
+  "version": "0.1.183",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/ag-ui-browser-encoder.ts
+++ b/src/agent/ag-ui-browser-encoder.ts
@@ -133,6 +133,35 @@ function applyResponseMetadata(
   }
 }
 
+function completeToolInput(
+  state: AgUiBrowserEncoderState,
+  event: AgUiRuntimeStreamEvent,
+): AgUiBrowserEncodedEvent[] {
+  const toolCallId = typeof event.toolCallId === "string" ? event.toolCallId : "";
+  const events: AgUiBrowserEncodedEvent[] = [];
+
+  if (toolCallId.length > 0 && !state.streamedToolInputIds.has(toolCallId)) {
+    events.push({
+      event: "ToolCallArgs",
+      payload: {
+        toolCallId,
+        delta: serializeToolInput("input" in event ? event.input : {}),
+      },
+    });
+  }
+
+  if (toolCallId.length > 0) {
+    state.streamedToolInputIds.delete(toolCallId);
+  }
+
+  events.push({
+    event: "ToolCallEnd",
+    payload: { toolCallId: event.toolCallId },
+  });
+
+  return events;
+}
+
 export function mapRuntimeStreamEventToAgUiBrowserEvents(
   state: AgUiBrowserEncoderState,
   event: AgUiRuntimeStreamEvent,
@@ -249,53 +278,12 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
 
     case "tool-input-available": {
       state.sawVisibleOutput = true;
-      const toolCallId = typeof event.toolCallId === "string" ? event.toolCallId : "";
-      const events: AgUiBrowserEncodedEvent[] = [];
-
-      if (toolCallId.length > 0 && !state.streamedToolInputIds.has(toolCallId)) {
-        events.push({
-          event: "ToolCallArgs",
-          payload: {
-            toolCallId,
-            delta: serializeToolInput("input" in event ? event.input : {}),
-          },
-        });
-      }
-
-      if (toolCallId.length > 0) {
-        state.streamedToolInputIds.delete(toolCallId);
-      }
-
-      events.push({
-        event: "ToolCallEnd",
-        payload: { toolCallId: event.toolCallId },
-      });
-      return events;
+      return completeToolInput(state, event);
     }
 
     case "tool-input-error": {
       state.sawVisibleOutput = true;
-      const toolCallId = typeof event.toolCallId === "string" ? event.toolCallId : "";
-      const events: AgUiBrowserEncodedEvent[] = [];
-
-      if (toolCallId.length > 0 && !state.streamedToolInputIds.has(toolCallId)) {
-        events.push({
-          event: "ToolCallArgs",
-          payload: {
-            toolCallId,
-            delta: serializeToolInput("input" in event ? event.input : {}),
-          },
-        });
-      }
-
-      if (toolCallId.length > 0) {
-        state.streamedToolInputIds.delete(toolCallId);
-      }
-
-      events.push({
-        event: "ToolCallEnd",
-        payload: { toolCallId: event.toolCallId },
-      });
+      const events = completeToolInput(state, event);
       events.push({
         event: "ToolCallResult",
         payload: {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.182";
+export const VERSION = "0.1.183";


### PR DESCRIPTION
## Summary
- extract the shared AG-UI tool-input completion path from the browser encoder
- keep tool-input available and input-error event sequences aligned
- bump the release version to `0.1.183`

## Verification
- deno test --no-check --allow-all src/agent/ag-ui-browser-encoder.test.ts src/utils/version.test.ts
- deno fmt --check src/agent/ag-ui-browser-encoder.ts deno.json src/utils/version-constant.ts
- deno lint src/agent/ag-ui-browser-encoder.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick