### PR TITLE
Extract AG-UI tool-result builder

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.183",
+  "version": "0.1.184",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/ag-ui-browser-encoder.ts
+++ b/src/agent/ag-ui-browser-encoder.ts
@@ -162,6 +162,21 @@ function completeToolInput(
   return events;
 }
 
+function createToolResultEvent(
+  toolCallId: unknown,
+  result: Record<string, unknown> | unknown,
+  isError = false,
+): AgUiBrowserEncodedEvent {
+  return {
+    event: "ToolCallResult",
+    payload: {
+      toolCallId,
+      result,
+      ...(isError ? { isError: true } : {}),
+    },
+  };
+}
+
 export function mapRuntimeStreamEventToAgUiBrowserEvents(
   state: AgUiBrowserEncoderState,
   event: AgUiRuntimeStreamEvent,
@@ -299,35 +314,15 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
 
     case "tool-output-available":
       state.sawVisibleOutput = true;
-      return [{
-        event: "ToolCallResult",
-        payload: {
-          toolCallId: event.toolCallId,
-          result: event.output,
-        },
-      }];
+      return [createToolResultEvent(event.toolCallId, event.output)];
 
     case "tool-output-error":
       state.sawVisibleOutput = true;
-      return [{
-        event: "ToolCallResult",
-        payload: {
-          toolCallId: event.toolCallId,
-          result: { error: event.errorText },
-          isError: true,
-        },
-      }];
+      return [createToolResultEvent(event.toolCallId, { error: event.errorText }, true)];
 
     case "tool-output-denied":
       state.sawVisibleOutput = true;
-      return [{
-        event: "ToolCallResult",
-        payload: {
-          toolCallId: event.toolCallId,
-          result: { error: "Tool output denied" },
-          isError: true,
-        },
-      }];
+      return [createToolResultEvent(event.toolCallId, { error: "Tool output denied" }, true)];
 
     case "step-start":
     case "start-step":

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.183";
+export const VERSION = "0.1.184";


### PR DESCRIPTION
## Summary
- extract the shared ToolCallResult event builder from the browser AG-UI encoder
- keep success and error tool-output branches aligned on payload structure
- bump the release version to `0.1.183`

## Verification
- deno test --no-check --allow-all src/agent/ag-ui-browser-encoder.test.ts src/utils/version.test.ts
- deno fmt --check src/agent/ag-ui-browser-encoder.ts deno.json src/utils/version-constant.ts
- deno lint src/agent/ag-ui-browser-encoder.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick