### PR TITLE
Extract AG-UI custom data event helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.184",
+  "version": "0.1.185",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/ag-ui-browser-encoder.ts
+++ b/src/agent/ag-ui-browser-encoder.ts
@@ -177,6 +177,16 @@ function createToolResultEvent(
   };
 }
 
+function createCustomDataEvent(
+  name: string,
+  value: unknown,
+): AgUiBrowserEncodedEvent {
+  return {
+    event: "Custom",
+    payload: { name, value },
+  };
+}
+
 export function mapRuntimeStreamEventToAgUiBrowserEvents(
   state: AgUiBrowserEncoderState,
   event: AgUiRuntimeStreamEvent,
@@ -188,13 +198,7 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
     }
 
     state.sawVisibleOutput = true;
-    return [{
-      event: "Custom",
-      payload: {
-        name,
-        value: "data" in event ? event.data : null,
-      },
-    }];
+    return [createCustomDataEvent(name, "data" in event ? event.data : null)];
   }
 
   switch (event.type) {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.184";
+export const VERSION = "0.1.185";


### PR DESCRIPTION
## Summary
- extract the shared Custom event builder for runtime data-* events in the browser AG-UI encoder
- keep custom data event payloads aligned on the same name/value structure
- bump the release version to `0.1.185`

## Verification
- deno test --no-check --allow-all src/agent/ag-ui-browser-encoder.test.ts src/utils/version.test.ts
- deno fmt --check src/agent/ag-ui-browser-encoder.ts deno.json src/utils/version-constant.ts
- deno lint src/agent/ag-ui-browser-encoder.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick