### PR TITLE
Extract AG-UI step event helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.185",
+  "version": "0.1.186",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/ag-ui-browser-encoder.ts
+++ b/src/agent/ag-ui-browser-encoder.ts
@@ -187,6 +187,18 @@ function createCustomDataEvent(
   };
 }
 
+function createStepEvent(
+  state: AgUiBrowserEncoderState,
+  type: "StepStarted" | "StepFinished",
+): AgUiBrowserEncodedEvent {
+  return {
+    event: type,
+    payload: {
+      stepName: type === "StepStarted" ? nextStepName(state) : finishStepName(state),
+    },
+  };
+}
+
 export function mapRuntimeStreamEventToAgUiBrowserEvents(
   state: AgUiBrowserEncoderState,
   event: AgUiRuntimeStreamEvent,
@@ -331,18 +343,12 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
     case "step-start":
     case "start-step":
       state.sawVisibleOutput = true;
-      return [{
-        event: "StepStarted",
-        payload: { stepName: nextStepName(state) },
-      }];
+      return [createStepEvent(state, "StepStarted")];
 
     case "step-end":
     case "finish-step":
       state.sawVisibleOutput = true;
-      return [{
-        event: "StepFinished",
-        payload: { stepName: finishStepName(state) },
-      }];
+      return [createStepEvent(state, "StepFinished")];
 
     case "data":
       applyDataMetadata(state, event);

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.185";
+export const VERSION = "0.1.186";


### PR DESCRIPTION
## Summary
- extract the shared step event builder from the browser AG-UI encoder
- keep step-start/start-step and step-end/finish-step branches aligned
- bump the release version to `0.1.186`

## Verification
- deno test --no-check --allow-all src/agent/ag-ui-browser-encoder.test.ts src/utils/version.test.ts
- deno fmt --check src/agent/ag-ui-browser-encoder.ts deno.json src/utils/version-constant.ts
- deno lint src/agent/ag-ui-browser-encoder.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick