### PR TITLE
Extract AG-UI reasoning event helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.186",
+  "version": "0.1.187",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/ag-ui-browser-encoder.ts
+++ b/src/agent/ag-ui-browser-encoder.ts
@@ -199,6 +199,25 @@ function createStepEvent(
   };
 }
 
+function createReasoningEvent(
+  state: AgUiBrowserEncoderState,
+  event: AgUiRuntimeStreamEvent,
+  type: "ReasoningMessageStart" | "ReasoningMessageContent" | "ReasoningMessageEnd",
+): AgUiBrowserEncodedEvent {
+  const messageId = getReasoningMessageId(state, event);
+  return {
+    event: type,
+    payload: type === "ReasoningMessageStart"
+      ? { messageId, role: "reasoning" }
+      : type === "ReasoningMessageContent"
+      ? {
+        messageId,
+        delta: typeof event.delta === "string" ? event.delta : "",
+      }
+      : { messageId },
+  };
+}
+
 export function mapRuntimeStreamEventToAgUiBrowserEvents(
   state: AgUiBrowserEncoderState,
   event: AgUiRuntimeStreamEvent,
@@ -260,28 +279,16 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
 
     case "reasoning-start":
       state.sawVisibleOutput = true;
-      return [{
-        event: "ReasoningMessageStart",
-        payload: { messageId: getReasoningMessageId(state, event), role: "reasoning" },
-      }];
+      return [createReasoningEvent(state, event, "ReasoningMessageStart")];
 
     case "reasoning-delta":
       state.sawVisibleOutput = true;
-      return [{
-        event: "ReasoningMessageContent",
-        payload: {
-          messageId: getReasoningMessageId(state, event),
-          delta: typeof event.delta === "string" ? event.delta : "",
-        },
-      }];
+      return [createReasoningEvent(state, event, "ReasoningMessageContent")];
 
     case "reasoning-end": {
-      const messageId = getReasoningMessageId(state, event);
+      const reasoningEvent = createReasoningEvent(state, event, "ReasoningMessageEnd");
       state.reasoningMessageId = null;
-      return [{
-        event: "ReasoningMessageEnd",
-        payload: { messageId },
-      }];
+      return [reasoningEvent];
     }
 
     case "tool-input-start":

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.186";
+export const VERSION = "0.1.187";


### PR DESCRIPTION
## Summary
- extract the shared reasoning event builder from the browser AG-UI encoder
- keep reasoning start/content/end branches aligned
- bump the release version to `0.1.187`

## Verification
- deno test --no-check --allow-all src/agent/ag-ui-browser-encoder.test.ts src/utils/version.test.ts
- deno fmt --check src/agent/ag-ui-browser-encoder.ts deno.json src/utils/version-constant.ts
- deno lint src/agent/ag-ui-browser-encoder.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick