### PR TITLE
Preserve streamed tool arguments across placeholder frames

### DIFF
--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -167,6 +167,40 @@ describe("chat-stream-handler", () => {
       });
     });
 
+    it("replaces a transient empty-object placeholder when real streamed tool JSON begins", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        { type: "tool-input-start", id: "tc-placeholder", toolName: "load_skill" },
+        { type: "tool-input-delta", id: "tc-placeholder", delta: "{}" },
+        { type: "tool-input-delta", id: "tc-placeholder", delta: '{"skillId":"' },
+        { type: "tool-input-delta", id: "tc-placeholder", delta: 'plan"}' },
+        { type: "finish", finishReason: "tool-calls", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      const tc = state.toolCalls.get("tc-placeholder")!;
+      assertEquals(tc.arguments, '{"skillId":"plan"}');
+
+      assertEquals(events[1], {
+        type: "tool-input-delta",
+        toolCallId: "tc-placeholder",
+        inputTextDelta: "{}",
+      });
+      assertEquals(events[2], {
+        type: "tool-input-delta",
+        toolCallId: "tc-placeholder",
+        inputTextDelta: '{"skillId":"',
+      });
+      assertEquals(events[3], {
+        type: "tool-input-delta",
+        toolCallId: "tc-placeholder",
+        inputTextDelta: 'plan"}',
+      });
+    });
+
     it("handles tool-call with full input object", async () => {
       const { events, controller, encoder } = createSSECollector();
       const state = createStreamState();
@@ -222,6 +256,28 @@ describe("chat-stream-handler", () => {
         toolName: "web_search",
         input: { query: "Veryfront", maxUses: 1 },
       });
+    });
+
+    it("keeps streamed tool JSON when the later tool-call payload is only an empty-object placeholder", async () => {
+      const { controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        { type: "tool-input-start", id: "tc-tool-call-placeholder", toolName: "load_skill" },
+        { type: "tool-input-delta", id: "tc-tool-call-placeholder", delta: '{"skillId":"plan"}' },
+        {
+          type: "tool-call",
+          toolCallId: "tc-tool-call-placeholder",
+          toolName: "load_skill",
+          input: {},
+        },
+        { type: "finish", finishReason: "tool-calls", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      const tc = state.toolCalls.get("tc-tool-call-placeholder")!;
+      assertEquals(tc.arguments, '{"skillId":"plan"}');
     });
     it("preserves provider-executed tool calls in stream state and SSE output", async () => {
       const { events, controller, encoder } = createSSECollector();

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -66,6 +66,30 @@ function normalizeToolInputString(input: unknown): string {
   return JSON.stringify(input ?? null) ?? "null";
 }
 
+function mergeToolInputDelta(currentArguments: string, nextDelta: string): string {
+  if (currentArguments === "{}" && nextDelta.trimStart().startsWith("{")) {
+    return nextDelta;
+  }
+
+  return currentArguments + nextDelta;
+}
+
+function mergeToolCallInput(currentArguments: string, nextInput: string): string {
+  if (currentArguments.length === 0) {
+    return nextInput;
+  }
+
+  if (nextInput.trim() === "{}" && currentArguments.trim().startsWith("{")) {
+    return currentArguments;
+  }
+
+  if (currentArguments.trim() === "{}" && nextInput.trim().startsWith("{")) {
+    return nextInput;
+  }
+
+  return nextInput;
+}
+
 function normalizeToolInputObject(input: unknown): Record<string, unknown> {
   if (isRecord(input)) {
     return input;
@@ -225,7 +249,7 @@ export function processStream(
           const tc = state.toolCalls.get(toolId);
           if (!tc) break;
 
-          tc.arguments += typedPart.delta;
+          tc.arguments = mergeToolInputDelta(tc.arguments, typedPart.delta);
           sendSSE(controller, encoder, {
             type: "tool-input-delta",
             toolCallId: toolId,
@@ -238,10 +262,12 @@ export function processStream(
           // tool-call fires when the full tool call is available
           const toolId = typedPart.toolCallId;
           const inputStr = normalizeToolInputString(typedPart.input);
+          const previousArguments = state.toolCalls.get(toolId)?.arguments ?? "";
+          const resolvedArguments = mergeToolCallInput(previousArguments, inputStr);
           state.toolCalls.set(toolId, {
             id: toolId,
             name: typedPart.toolName,
-            arguments: inputStr,
+            arguments: resolvedArguments,
             providerExecuted: typedPart.providerExecuted,
             dynamic: typedPart.dynamic,
           });

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -84,6 +84,18 @@ describe("tool-helpers", () => {
       assertEquals(result.error, undefined);
     });
 
+    it("strips a transient leading empty-object placeholder before parsing real JSON", () => {
+      const result = parseToolArgs('{}{"skillId":"plan"}');
+      assertEquals(result.args, { skillId: "plan" });
+      assertEquals(result.error, undefined);
+    });
+
+    it("strips repeated empty-object placeholders before parsing real JSON", () => {
+      const result = parseToolArgs('{}  {}{"skillId":"plan"}');
+      assertEquals(result.args, { skillId: "plan" });
+      assertEquals(result.error, undefined);
+    });
+
     it("handles empty object passed directly", () => {
       const result = parseToolArgs({});
       assertEquals(result.args, {});

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -27,6 +27,16 @@ export interface ParsedToolArgs {
   error?: string;
 }
 
+function stripLeadingEmptyObjectPlaceholder(rawArgs: string): string {
+  let normalized = rawArgs.trim();
+
+  while (normalized.startsWith("{}") && normalized.slice(2).trimStart().startsWith("{")) {
+    normalized = normalized.slice(2).trimStart();
+  }
+
+  return normalized;
+}
+
 /**
  * Parse tool arguments from raw string or object.
  * Returns parsed args and optional error message.
@@ -37,10 +47,12 @@ export function parseToolArgs(
   try {
     // Handle empty string or whitespace-only string as empty object
     if (typeof rawArgs === "string") {
-      const trimmed = rawArgs.trim();
+      const trimmed = stripLeadingEmptyObjectPlaceholder(rawArgs);
       if (trimmed === "" || trimmed === "{}") {
         return { args: {} };
       }
+
+      rawArgs = trimmed;
     }
 
     const parsed = typeof rawArgs === "string" ? JSON.parse(rawArgs) : rawArgs;


### PR DESCRIPTION
## Summary
- normalize transient empty-object placeholder frames in the shared runtime tool-argument assembly path
- preserve the real streamed JSON payload when a later tool-call snapshot still reports 
- add regression coverage at both the stream merge layer and the tool-argument parser

## Verification
- deno test --no-check --allow-all src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/tool-helpers.test.ts
- deno test --no-check --allow-all src/runtime/runtime-bridge.test.ts src/provider/runtime-loader.test.ts
- deno task verify