### PR TITLE
Extract AG-UI text event helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.189",
+  "version": "0.1.190",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/ag-ui-browser-encoder.ts
+++ b/src/agent/ag-ui-browser-encoder.ts
@@ -218,6 +218,21 @@ function createReasoningEvent(
   };
 }
 
+function createTextEvent(
+  messageId: string,
+  type: "TextMessageStart" | "TextMessageContent" | "TextMessageEnd",
+  delta = "",
+): AgUiBrowserEncodedEvent {
+  return {
+    event: type,
+    payload: type === "TextMessageStart"
+      ? { messageId, role: "assistant" }
+      : type === "TextMessageContent"
+      ? { messageId, delta }
+      : { messageId },
+  };
+}
+
 export function mapRuntimeStreamEventToAgUiBrowserEvents(
   state: AgUiBrowserEncoderState,
   event: AgUiRuntimeStreamEvent,
@@ -242,10 +257,7 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
       const messageId = getMessageId(state, event);
       state.textOpen = true;
       state.sawVisibleOutput = true;
-      return [{
-        event: "TextMessageStart",
-        payload: { messageId, role: "assistant" },
-      }];
+      return [createTextEvent(messageId, "TextMessageStart")];
     }
 
     case "text-delta": {
@@ -254,27 +266,26 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
       if (!state.textOpen) {
         state.textOpen = true;
         return [
-          { event: "TextMessageStart", payload: { messageId, role: "assistant" } },
-          {
-            event: "TextMessageContent",
-            payload: { messageId, delta: typeof event.delta === "string" ? event.delta : "" },
-          },
+          createTextEvent(messageId, "TextMessageStart"),
+          createTextEvent(
+            messageId,
+            "TextMessageContent",
+            typeof event.delta === "string" ? event.delta : "",
+          ),
         ];
       }
 
-      return [{
-        event: "TextMessageContent",
-        payload: { messageId, delta: typeof event.delta === "string" ? event.delta : "" },
-      }];
+      return [createTextEvent(
+        messageId,
+        "TextMessageContent",
+        typeof event.delta === "string" ? event.delta : "",
+      )];
     }
 
     case "text-end": {
       if (!state.textOpen) return [];
       state.textOpen = false;
-      return [{
-        event: "TextMessageEnd",
-        payload: { messageId: getMessageId(state, event) },
-      }];
+      return [createTextEvent(getMessageId(state, event), "TextMessageEnd")];
     }
 
     case "reasoning-start":

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.189";
+export const VERSION = "0.1.190";


### PR DESCRIPTION
## Summary
- extract the shared text event builder from the browser AG-UI encoder
- keep text start/content/end branches aligned
- bump the release version to `0.1.188`

## Verification
- deno test --no-check --allow-all src/agent/ag-ui-browser-encoder.test.ts src/utils/version.test.ts
- deno fmt --check src/agent/ag-ui-browser-encoder.ts deno.json src/utils/version-constant.ts
- deno lint src/agent/ag-ui-browser-encoder.ts src/utils/version-constant.ts
- deno task typecheck
- deno task verify:quick