### PR TITLE
Publish provider-native fork tool inventory

### DIFF
--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -15,15 +15,17 @@ import {
   agent,
   agentAsTool,
   AgentRuntime,
-  createAgUiBrowserEncoderState,
   AgUiRequestSchema,
   AgUiResumeSignalSchema,
   AgUiRuntimeRequestSchema,
+  createAgUiBrowserEncoderState,
   createAgUiCancelHandler,
   createAgUiHandler,
   createAgUiResumeHandler,
   createMemory,
+  expandAllowedRemoteToolNames,
   getAgentsAsTools,
+  getProviderNativeToolNames,
   HumanInputRequestSchema,
   registerAgent,
   RunResumeSessionManager,
@@ -149,6 +151,21 @@ const events = mapRuntimeStreamEventToAgUiBrowserEvents(state, {
 const finalEvents = finalizeAgUiBrowserEvents(state, null);
 ```
 
+### Provider-native tool inventory
+
+```ts
+import { expandAllowedRemoteToolNames, getProviderNativeToolNames } from "veryfront/agent";
+
+const providerNativeToolNames = getProviderNativeToolNames({
+  model: "anthropic/claude-sonnet-4-6",
+});
+
+const allowedRemoteToolNames = expandAllowedRemoteToolNames({
+  model: "anthropic/claude-sonnet-4-6",
+  toolNames: ["create_file"],
+});
+```
+
 ### Human input over hosted AG-UI runs
 
 ```ts
@@ -238,11 +255,22 @@ Use these helpers when a host needs to turn the framework runtime stream event
 family into browser/public AG-UI events without importing internal transport
 modules.
 
-| Export | Type | Description |
-| ------ | ---- | ----------- |
-| `createAgUiBrowserEncoderState()` | `() => AgUiBrowserEncoderState` | Create mutable encoder state for one browser AG-UI stream. |
-| `mapRuntimeStreamEventToAgUiBrowserEvents(state, event)` | `(state, event) => AgUiBrowserEncodedEvent[]` | Map one runtime stream event into zero or more browser/public AG-UI events. |
-| `finalizeAgUiBrowserEvents(state, response)` | `(state, response) => AgUiBrowserEncodedEvent[]` | Emit terminal browser/public AG-UI events after the runtime stream finishes. |
+| Export                                                   | Type                                             | Description                                                                  |
+| -------------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------- |
+| `createAgUiBrowserEncoderState()`                        | `() => AgUiBrowserEncoderState`                  | Create mutable encoder state for one browser AG-UI stream.                   |
+| `mapRuntimeStreamEventToAgUiBrowserEvents(state, event)` | `(state, event) => AgUiBrowserEncodedEvent[]`    | Map one runtime stream event into zero or more browser/public AG-UI events.  |
+| `finalizeAgUiBrowserEvents(state, response)`             | `(state, response) => AgUiBrowserEncodedEvent[]` | Emit terminal browser/public AG-UI events after the runtime stream finishes. |
+
+### Provider-native tool inventory
+
+Use these helpers when a host needs to derive provider-native remote-tool
+allowlists for forked or runtime-isolated executions without hardcoding
+provider/tool mappings outside the package.
+
+| Export                                  | Type                                                                       | Description                                                                                                   |
+| --------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `getProviderNativeToolNames(options)`   | `({ model?: string; provider?: string }) => string[]`                      | Return the provider-native tool ids currently available for the provider/model.                               |
+| `expandAllowedRemoteToolNames(options)` | `({ model?: string; provider?: string; toolNames: string[] }) => string[]` | Expand a local remote-tool allowlist with the package-owned provider-native tool ids for that provider/model. |
 
 ### Request-aware model transport
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -159,6 +159,11 @@ export {
   mapRuntimeStreamEventToAgUiBrowserEvents,
 } from "./ag-ui-browser-encoder.ts";
 export {
+  expandAllowedRemoteToolNames,
+  getProviderNativeToolNames,
+  type ProviderNativeToolInventoryOptions,
+} from "./provider-native-tool-inventory.ts";
+export {
   type AgUiCancelHandlerOptions,
   type AgUiResumeHandlerOptions,
   type AgUiResumeSignal,

--- a/src/agent/provider-native-tool-inventory.test.ts
+++ b/src/agent/provider-native-tool-inventory.test.ts
@@ -1,0 +1,52 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { expandAllowedRemoteToolNames, getProviderNativeToolNames } from "./index.ts";
+
+describe("provider-native-tool-inventory", () => {
+  it("returns anthropic provider-native tool names for an explicit provider", () => {
+    assertEquals(getProviderNativeToolNames({ provider: "anthropic" }), [
+      "web_fetch",
+      "web_search",
+    ]);
+  });
+
+  it("returns anthropic provider-native tool names from a direct anthropic model", () => {
+    assertEquals(
+      getProviderNativeToolNames({ model: "anthropic/claude-sonnet-4-6" }),
+      ["web_fetch", "web_search"],
+    );
+  });
+
+  it("returns anthropic provider-native tool names from a veryfront-cloud anthropic model", () => {
+    assertEquals(
+      getProviderNativeToolNames({
+        model: "veryfront-cloud/anthropic/claude-sonnet-4-6",
+      }),
+      ["web_fetch", "web_search"],
+    );
+  });
+
+  it("returns no provider-native tool names for non-anthropic models", () => {
+    assertEquals(getProviderNativeToolNames({ model: "openai/gpt-4o-mini" }), []);
+  });
+
+  it("expands a fork/runtime allowlist with provider-native tools", () => {
+    assertEquals(
+      expandAllowedRemoteToolNames({
+        provider: "anthropic",
+        toolNames: ["create_file", "web_search"],
+      }),
+      ["create_file", "web_fetch", "web_search"],
+    );
+  });
+
+  it("preserves the local allowlist when the provider has no provider-native tools", () => {
+    assertEquals(
+      expandAllowedRemoteToolNames({
+        provider: "openai",
+        toolNames: ["create_file"],
+      }),
+      ["create_file"],
+    );
+  });
+});

--- a/src/agent/provider-native-tool-inventory.ts
+++ b/src/agent/provider-native-tool-inventory.ts
@@ -1,0 +1,60 @@
+const ANTHROPIC_PROVIDER_NATIVE_TOOL_NAMES = [
+  "web_fetch",
+  "web_search",
+] as const;
+
+export interface ProviderNativeToolInventoryOptions {
+  model?: string;
+  provider?: string;
+}
+
+interface ExpandAllowedRemoteToolNamesOptions extends ProviderNativeToolInventoryOptions {
+  toolNames: readonly string[];
+}
+
+function resolveHostedProvider(model?: string): string | undefined {
+  if (!model) {
+    return undefined;
+  }
+
+  const [provider, second] = model.split("/", 3);
+  if (!provider) {
+    return undefined;
+  }
+
+  if (provider === "veryfront-cloud") {
+    return second || undefined;
+  }
+
+  return provider;
+}
+
+function resolveProvider(options?: ProviderNativeToolInventoryOptions): string | undefined {
+  if (options?.provider && options.provider.length > 0) {
+    return options.provider;
+  }
+
+  return resolveHostedProvider(options?.model);
+}
+
+export function getProviderNativeToolNames(
+  options?: ProviderNativeToolInventoryOptions,
+): string[] {
+  switch (resolveProvider(options)) {
+    case "anthropic":
+      return [...ANTHROPIC_PROVIDER_NATIVE_TOOL_NAMES];
+    default:
+      return [];
+  }
+}
+
+export function expandAllowedRemoteToolNames(
+  options: ExpandAllowedRemoteToolNamesOptions,
+): string[] {
+  return [
+    ...new Set([
+      ...options.toolNames,
+      ...getProviderNativeToolNames(options),
+    ]),
+  ].sort();
+}

--- a/src/agent/runtime/model-tool-converter.ts
+++ b/src/agent/runtime/model-tool-converter.ts
@@ -7,6 +7,7 @@
  * @module agent/runtime/model-tool-converter
  */
 import type { ToolDefinition } from "#veryfront/tool";
+import { getProviderNativeToolNames } from "../provider-native-tool-inventory.ts";
 import type { RuntimeToolSet } from "./runtime-tool-types.ts";
 import {
   addRuntimeTool,
@@ -23,37 +24,32 @@ export interface ConvertToolsToRuntimeToolsOptions {
   allowedToolNames?: string[];
 }
 
-function resolveHostedProvider(model?: string): string | undefined {
-  if (!model) return undefined;
-
-  const [provider, second] = model.split("/", 3);
-  if (!provider) return undefined;
-  if (provider === "veryfront-cloud") {
-    return second || undefined;
-  }
-
-  return provider;
-}
-
 function resolveProviderNativeTools(
   options?: ConvertToolsToRuntimeToolsOptions,
 ): RuntimeToolSet | undefined {
-  if (
-    !options?.allowedToolNames?.some((toolName) =>
-      toolName === "web_search" || toolName === "web_fetch"
-    )
-  ) {
+  const providerNativeToolNames = new Set(getProviderNativeToolNames({
+    model: options?.model,
+  }));
+
+  if (providerNativeToolNames.size === 0) {
     return undefined;
   }
 
-  if (resolveHostedProvider(options.model) !== "anthropic") {
+  const allowedProviderNativeToolNames =
+    options?.allowedToolNames?.filter((toolName) => providerNativeToolNames.has(toolName)) ?? [];
+  if (allowedProviderNativeToolNames.length === 0) {
     return undefined;
   }
 
-  return {
-    ...createAnthropicWebSearchToolSet(),
-    ...createAnthropicWebFetchToolSet(),
-  };
+  const toolSet: RuntimeToolSet = {};
+  if (allowedProviderNativeToolNames.includes("web_search")) {
+    Object.assign(toolSet, createAnthropicWebSearchToolSet());
+  }
+  if (allowedProviderNativeToolNames.includes("web_fetch")) {
+    Object.assign(toolSet, createAnthropicWebFetchToolSet());
+  }
+
+  return Object.keys(toolSet).length > 0 ? toolSet : undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary
- publish a public helper for provider-native tool inventory lookup
- reuse that helper inside the runtime model tool converter
- document the API for package consumers that need to expand remote allowlists

## Why
Remote or forked runtimes need the same provider-native tool inventory that the framework runtime already knows internally. Without a public helper, package consumers have to duplicate provider-specific rules.

Closes #985

## Verification
- deno test --allow-all src/agent/provider-native-tool-inventory.test.ts src/agent/runtime/model-tool-converter.test.ts
- deno task verify
