### PR TITLE
Bump stable release to 0.1.188

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.187",
+  "version": "0.1.188",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.187";
+export const VERSION = "0.1.188";


### PR DESCRIPTION
## Summary
- bump the stable package version to `0.1.188`
- keep `src/utils/version-constant.ts` in sync with `deno.json`

## Why
The provider-native inventory helper merged on `main`, but `deno.json` still said `0.1.187`, which is already published to npm. The release workflow skips stable publish when that version already exists, so this follow-up is required to actually ship the helper.

## Verification
- repo pre-push checks
