### PR TITLE
fix: unbreak Node 22 dev server (SSR undici 404 + CloseEvent crash)

### DIFF
--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -65,12 +65,20 @@ await build({
 	skipNpmInstall: true,
 
 	// Package metadata
+	//
+	// `undici` and `blob` shims are intentionally disabled. With those enabled,
+	// dnt injects `_dnt.shims.js → undici` (and `buffer`) imports into every
+	// file that references fetch/Headers/Response/Blob — including client-bound
+	// React runtime files like `src/react/runtime/core.ts`. The SSR http-cache
+	// pipeline then tries to fetch `undici` from esm.sh, which returns 404
+	// (esm.sh refuses to build Node-only packages with `external=react`).
+	//
+	// Node 18+ (our minimum engine) provides fetch/Headers/Response/Request/
+	// FormData/File/Blob as globals natively, so no shim is needed.
 	shims: {
 		deno: true,
 		timers: true,
 		crypto: true,
-		blob: true,
-		undici: true,
 	},
 
 	// Compiler options for declaration generation

--- a/src/embedding/upload-handler.ts
+++ b/src/embedding/upload-handler.ts
@@ -3,6 +3,9 @@ import { VeryfrontCloudBlobStorage } from "#veryfront/workflow/blob/veryfront-cl
 import { serverLogger } from "#veryfront/utils";
 import type { RagStore } from "./types.ts";
 import { loadUpload } from "./upload-loader.ts";
+// `File` is a global only on Node 20+; import from `node:buffer` for Node 18
+// compatibility (engines.node >= 18.0.0).
+import { File } from "node:buffer";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 const MAX_FILE_NAME_LENGTH = 200;

--- a/src/platform/adapters/runtime/node/websocket-adapter.test.ts
+++ b/src/platform/adapters/runtime/node/websocket-adapter.test.ts
@@ -1,0 +1,122 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { EventEmitter } from "node:events";
+import { Buffer } from "node:buffer";
+import { NodeWebSocket } from "./websocket-adapter.ts";
+import type { WSWebSocket } from "./types.ts";
+
+/**
+ * Build a minimal EventEmitter-backed mock that satisfies the `WSWebSocket`
+ * interface for the methods `_attachRealSocket` actually uses (`on`, `send`,
+ * `close`). The underlying EventEmitter drives `emit("close", ...)` etc. in
+ * tests, mirroring the real `ws` library's close-callback shape
+ * `(code?: number, reason?: Buffer)`.
+ */
+function createMockWs(): WSWebSocket & EventEmitter {
+  const ee = new EventEmitter() as EventEmitter & {
+    send: (data: string | ArrayBuffer) => void;
+    close: (code?: number, reason?: string) => void;
+  };
+  ee.send = () => {};
+  ee.close = () => {};
+  return ee as unknown as WSWebSocket & EventEmitter;
+}
+
+function attach(): { socket: NodeWebSocket; ws: WSWebSocket & EventEmitter } {
+  const socket = new NodeWebSocket();
+  const ws = createMockWs();
+  socket._attachRealSocket(ws);
+  return { socket, ws };
+}
+
+describe("NodeWebSocket close handling", () => {
+  it("invokes onclose with a CloseEvent-shaped object on a clean close", () => {
+    const { socket, ws } = attach();
+    let received: CloseEvent | null = null;
+    socket.onclose = (event) => {
+      received = event;
+    };
+
+    ws.emit("close", 1000, Buffer.from("bye"));
+
+    assertExists(received);
+    const event = received as unknown as CloseEvent;
+    assertEquals(event.type, "close");
+    assertEquals(event.code, 1000);
+    assertEquals(event.reason, "bye");
+    assertEquals(event.wasClean, true);
+  });
+
+  it("defaults to code 1006 and wasClean=false when ws emits no arguments", () => {
+    const { socket, ws } = attach();
+    let received: CloseEvent | null = null;
+    socket.onclose = (event) => {
+      received = event;
+    };
+
+    ws.emit("close");
+
+    assertExists(received);
+    const event = received as unknown as CloseEvent;
+    assertEquals(event.code, 1006);
+    assertEquals(event.reason, "");
+    assertEquals(event.wasClean, false);
+  });
+
+  it("treats any non-1006 code (e.g. 1001 going away) as clean", () => {
+    const { socket, ws } = attach();
+    let received: CloseEvent | null = null;
+    socket.onclose = (event) => {
+      received = event;
+    };
+
+    ws.emit("close", 1001, Buffer.from("going away"));
+
+    const event = received as unknown as CloseEvent;
+    assertEquals(event.code, 1001);
+    assertEquals(event.reason, "going away");
+    assertEquals(event.wasClean, true);
+  });
+
+  it("accepts a string reason in addition to a Buffer", () => {
+    const { socket, ws } = attach();
+    let received: CloseEvent | null = null;
+    socket.onclose = (event) => {
+      received = event;
+    };
+
+    ws.emit("close", 1000, "farewell");
+
+    const event = received as unknown as CloseEvent;
+    assertEquals(event.reason, "farewell");
+    assertEquals(event.wasClean, true);
+  });
+
+  it("does not throw ReferenceError on close when CloseEvent is not a global", () => {
+    // Regression test: Node <23 does not expose `CloseEvent` as a global. The
+    // previous implementation used `new CloseEvent("close")`, which crashed
+    // the dev server with an unhandled `ReferenceError` on every socket
+    // teardown. The handler must complete without throwing regardless of the
+    // runtime's `CloseEvent` support.
+    const { socket, ws } = attach();
+    socket.onclose = () => {};
+
+    ws.emit("close", 1000, Buffer.from("ok"));
+    // Reaching this line without throwing proves the regression is fixed.
+  });
+
+  it("transitions readyState to CLOSED after close", () => {
+    const { socket, ws } = attach();
+    socket.onclose = () => {};
+
+    ws.emit("close", 1000, Buffer.from("ok"));
+
+    assertEquals(socket.readyState, 3); // NodeWebSocket.CLOSED
+  });
+
+  it("is safe when onclose is not set (no listener attached)", () => {
+    const { ws } = attach();
+    // onclose left null — emitting should be a no-op, not a crash.
+    ws.emit("close", 1000, Buffer.from("ok"));
+  });
+});

--- a/src/platform/adapters/runtime/node/websocket-adapter.ts
+++ b/src/platform/adapters/runtime/node/websocket-adapter.ts
@@ -6,6 +6,31 @@ import { registerWebSocketUpgrade } from "./http-server.ts";
 import * as crypto from "node:crypto";
 import { Buffer } from "node:buffer";
 
+/**
+ * Build a structurally-compatible `CloseEvent` without relying on the
+ * `CloseEvent` constructor, which is not exposed as a global in Node.js
+ * before 23.0.0 (the framework supports Node 18+). Uses a plain `Event`
+ * decorated with the standard `code`/`reason`/`wasClean` fields.
+ *
+ * `wasClean` follows the `ws` library convention: any code other than
+ * `1006` (abnormal closure — no close frame received) is considered
+ * clean, because a received close frame implies the closing handshake
+ * completed. Code `1006` is what `ws` substitutes when the peer
+ * disappears without sending a close frame.
+ */
+function createCloseEvent(
+  code?: number,
+  reason?: Buffer | string,
+): CloseEvent {
+  const resolvedCode = typeof code === "number" ? code : 1006;
+  const resolvedReason = typeof reason === "string" ? reason : reason?.toString() ?? "";
+  return Object.assign(new Event("close"), {
+    code: resolvedCode,
+    reason: resolvedReason,
+    wasClean: resolvedCode !== 1006,
+  }) as CloseEvent;
+}
+
 export class NodeServerAdapter implements ServerAdapter {
   upgradeWebSocket(request: Request): WebSocketUpgrade {
     const key = request.headers.get("sec-websocket-key");
@@ -88,15 +113,7 @@ export class NodeWebSocket {
 
     ws.on("close", (code?: number, reason?: Buffer | string) => {
       this.readyState = 3;
-      // `CloseEvent` is a global in Deno/browsers but not in Node <23. Fall
-      // back to a plain `Event` with duck-typed code/reason/wasClean fields
-      // so consumers that read `event.code` / `event.reason` still work.
-      const event = Object.assign(new Event("close"), {
-        code: typeof code === "number" ? code : 1006,
-        reason: reason != null ? reason.toString() : "",
-        wasClean: code === 1000,
-      }) as unknown as CloseEvent;
-      this.onclose?.(event);
+      this.onclose?.(createCloseEvent(code, reason));
     });
 
     ws.on("error", (error: Error) => {

--- a/src/platform/adapters/runtime/node/websocket-adapter.ts
+++ b/src/platform/adapters/runtime/node/websocket-adapter.ts
@@ -4,6 +4,7 @@ import { createError, toError } from "#veryfront/errors";
 import { serverLogger } from "#veryfront/utils";
 import { registerWebSocketUpgrade } from "./http-server.ts";
 import * as crypto from "node:crypto";
+import { Buffer } from "node:buffer";
 
 export class NodeServerAdapter implements ServerAdapter {
   upgradeWebSocket(request: Request): WebSocketUpgrade {
@@ -85,9 +86,17 @@ export class NodeWebSocket {
       this.onmessage?.(new MessageEvent("message", { data: data.toString() }));
     });
 
-    ws.on("close", () => {
+    ws.on("close", (code?: number, reason?: Buffer | string) => {
       this.readyState = 3;
-      this.onclose?.(new CloseEvent("close"));
+      // `CloseEvent` is a global in Deno/browsers but not in Node <23. Fall
+      // back to a plain `Event` with duck-typed code/reason/wasClean fields
+      // so consumers that read `event.code` / `event.reason` still work.
+      const event = Object.assign(new Event("close"), {
+        code: typeof code === "number" ? code : 1006,
+        reason: reason != null ? reason.toString() : "",
+        wasClean: code === 1000,
+      }) as unknown as CloseEvent;
+      this.onclose?.(event);
     });
 
     ws.on("error", (error: Error) => {

--- a/src/security/input-validation/parsers.ts
+++ b/src/security/input-validation/parsers.ts
@@ -3,6 +3,9 @@ import { createValidationError, VeryfrontError } from "./errors.ts";
 import { readBodyWithLimit, validateContentType, validateRequestLimits } from "./limits.ts";
 import { sanitizeData } from "./sanitizers.ts";
 import { DEFAULT_LIMITS, type ParseFormOptions, type ParseJsonOptions } from "./types.ts";
+// `File` is a global only on Node 20+; import from `node:buffer` for Node 18
+// compatibility (engines.node >= 18.0.0).
+import { File } from "node:buffer";
 
 export async function parseJsonBody<T>(
   request: Request,


### PR DESCRIPTION
## Summary

Two independent bugs both surface on `npm create veryfront` → `npm run dev` with Node 22 and block the dev server end-to-end:

1. **SSR http-cache fails to resolve `undici`** → 500 on every page render, `VeryfrontError[build]: Component has missing dependencies`.
2. **`CloseEvent` is not a global in Node <23** → unhandled `ReferenceError` on WebSocket teardown crashes the dev server process (exit 1).

Reproduced on `docs-agent` template, Node v22.21.1.

## Bug 1 — `fix(build): drop undici/blob dnt shims to unbreak client SSR`

With `shims: { undici: true, blob: true }`, dnt injects `_dnt.shims.js` imports into every file that touches `fetch`/`Headers`/`Response`/`Blob`/`FormData` — including client-bound React runtime modules such as `src/react/runtime/core.ts`. When the SSR http-cache pipeline walks imports, it tries to resolve `undici` via:

```
https://esm.sh/undici?external=react&target=es2022
```

which **404s** (esm.sh refuses to build Node-only packages with `external=react`). `https://esm.sh/undici?target=es2022` alone returns 200; the `external=react` query appended by `normalizeEsmShUrl()` is what breaks it.

Node 18+ (our minimum `engines.node`) exposes `fetch`, `Headers`, `Response`, `Request`, `FormData`, `File`, and `Blob` as globals, so these shims are unnecessary. Removing them keeps `_dnt.shims.js` free of undici and buffer imports and lets React runtime files stay portable.

## Bug 2 — `fix(platform/node): avoid CloseEvent reference on Node <23`

`NodeWebSocket._attachRealSocket` used `new CloseEvent("close")`. `CloseEvent` is a global in Deno and browsers, but only exposed in Node v23+. On Node 22.x the handler throws `ReferenceError: CloseEvent is not defined`, and because it runs async on socket teardown the uncaught error terminates the dev server.

Replaces with a plain `Event("close")` decorated with the standard `code`/`reason`/`wasClean` fields so downstream consumers that read `event.code`/`event.reason` still work. Also captures the `code` and `reason` the `ws` library passes to its close callback (previously discarded).

## Test plan

- [x] Rebuilt npm package via `deno run -A scripts/build/build-npm-dnt.ts` — confirmed `npm/esm/_dnt.shims.js` no longer imports `undici`/`buffer`
- [x] Linked into a fresh `docs-agent` scaffold (`veryfront init my-app --template docs-agent`)
- [x] Verified `npm run dev` serves `/` with HTTP 200 and full chat UI renders (previously 500)
- [x] Verified HMR WebSocket connects + disconnects cleanly across page reloads and navigations with no `ReferenceError` and server process stays up
- [x] End-to-end RAG test: uploaded a PDF with fictional facts and confirmed Claude cites them back through the `beforeStream` retrieval hook
- [x] Pre-push hook passed: format, Deno lint, type check, codegen, and **1334 unit tests / 16224 steps** all green