### PR TITLE
Bump stable release to 0.1.189

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.188",
+  "version": "0.1.189",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.188";
+export const VERSION = "0.1.189";


### PR DESCRIPTION
## Summary
- bump the stable package version to `0.1.189`
- keep `src/utils/version-constant.ts` in sync with `deno.json`

## Why
63 commits have landed on `main` since the `0.1.188` tag (including AG-UI protocol work, runtime-loader additions, chat-protocol canonicalization, rendering pipeline refactors, and the provider-native inventory helper follow-ups). `deno.json` still reads `0.1.188`, which is already published, so the release workflow would skip npm publish. Bumping to `0.1.189` lets the next release workflow actually publish.

## Verification
- repo pre-push checks (format, lint, type check, unit tests) ran on push