### PR TITLE
feat: add Context7 documentation tool source and CLI MCP tools

### DIFF
--- a/cli/mcp/standalone.test.ts
+++ b/cli/mcp/standalone.test.ts
@@ -92,6 +92,17 @@ describe("mcp/standalone", () => {
       assertEquals(names.includes("vf_get_project_info"), true);
     });
 
+    it("tools/list includes context7 tools", async () => {
+      const server = new StandaloneMCPServer();
+      const resp = await dispatch(server, "tools/list");
+      const result = resp.result as {
+        tools: { name: string }[];
+      };
+      const names = result.tools.map((t) => t.name);
+      assertEquals(names.includes("c7_resolve_library"), true);
+      assertEquals(names.includes("c7_query_docs"), true);
+    });
+
     it("tools/list includes dev server tools", async () => {
       const server = new StandaloneMCPServer();
       const resp = await dispatch(server, "tools/list");

--- a/cli/mcp/standalone.ts
+++ b/cli/mcp/standalone.ts
@@ -409,6 +409,98 @@ export class StandaloneMCPServer {
           }
         },
       },
+      ...this.createContext7Tools(),
+    ];
+  }
+
+  private createContext7Tools(): StandaloneTool[] {
+    const isAvailable = () => Boolean(Deno.env.get("CONTEXT7_API_KEY"));
+
+    let source: {
+      executeTool: (name: string, args: Record<string, unknown>) => Promise<unknown>;
+    } | undefined;
+
+    const getSource = async () => {
+      if (!source) {
+        const { createContext7ToolSource } = await import("veryfront/tool");
+        source = createContext7ToolSource();
+      }
+      return source;
+    };
+
+    const notConfigured = {
+      error: "context7_not_configured",
+      message: "Context7 API key not configured. Set the CONTEXT7_API_KEY environment variable.",
+    };
+
+    return [
+      {
+        name: "c7_resolve_library",
+        description: "Resolves a package or product name to a Context7-compatible library ID. " +
+          "Call this before c7_query_docs to obtain the correct library ID. " +
+          "Returns matching libraries with metadata (name, description, snippet count, reputation).",
+        inputSchema: {
+          type: "object",
+          properties: {
+            libraryName: {
+              type: "string",
+              description:
+                "Library name to search for. Use the official name with proper punctuation — e.g., 'Next.js' not 'nextjs'.",
+            },
+            query: {
+              type: "string",
+              description:
+                "The question or task you need help with. Used to rank results by relevance.",
+            },
+          },
+          required: ["libraryName", "query"],
+        },
+        async execute(args) {
+          if (!isAvailable()) return notConfigured;
+          try {
+            return await (await getSource()).executeTool("resolve-library-id", args);
+          } catch (error) {
+            return {
+              error: "context7_request_failed",
+              message: error instanceof Error ? error.message : String(error),
+            };
+          }
+        },
+      },
+      {
+        name: "c7_query_docs",
+        description:
+          "Retrieves up-to-date documentation and code examples from Context7 for a library. " +
+          "You must call c7_resolve_library first to obtain the library ID, unless the user " +
+          "provides one directly in '/org/project' format.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            libraryId: {
+              type: "string",
+              description:
+                "Context7-compatible library ID (e.g., '/vercel/next.js', '/supabase/supabase').",
+            },
+            query: {
+              type: "string",
+              description:
+                "The question or task you need help with. Be specific and include relevant details.",
+            },
+          },
+          required: ["libraryId", "query"],
+        },
+        async execute(args) {
+          if (!isAvailable()) return notConfigured;
+          try {
+            return await (await getSource()).executeTool("query-docs", args);
+          } catch (error) {
+            return {
+              error: "context7_request_failed",
+              message: error instanceof Error ? error.message : String(error),
+            };
+          }
+        },
+      },
     ];
   }
 }

--- a/cli/mcp/tools.ts
+++ b/cli/mcp/tools.ts
@@ -17,6 +17,7 @@ import type { MCPTool } from "veryfront/mcp";
 import { advancedTools } from "./advanced-tools.ts";
 import { remoteFileTools } from "./remote-file-tools.ts";
 import { issuesMcpTools } from "veryfront/issues";
+import { context7Tools } from "./tools/context7-tools.ts";
 import { DEFAULT_MCP_PORT } from "#cli/shared/constants";
 
 export type { MCPTool };
@@ -235,6 +236,7 @@ export const allTools: MCPTool[] = [
   ...advancedTools,
   ...remoteFileTools,
   ...issuesMcpTools,
+  ...context7Tools,
   vfGetErrors,
   vfGetLogs,
   vfClearCache,

--- a/cli/mcp/tools/context7-tools.test.ts
+++ b/cli/mcp/tools/context7-tools.test.ts
@@ -1,0 +1,81 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { context7Tools } from "./context7-tools.ts";
+
+describe("cli/mcp/tools/context7-tools", () => {
+  it("exports two tools with correct names", () => {
+    const names = context7Tools.map((t) => t.name);
+    assertEquals(names, ["c7_resolve_library", "c7_query_docs"]);
+  });
+
+  it("all tools have required fields", () => {
+    for (const tool of context7Tools) {
+      assertExists(tool.name);
+      assertExists(tool.description);
+      assertExists(tool.inputSchema);
+      assertExists(tool.execute);
+      assertExists(tool.title);
+      assertExists(tool.annotations);
+    }
+  });
+
+  it("all tools are marked as read-only and open-world", () => {
+    for (const tool of context7Tools) {
+      assertEquals(tool.annotations?.readOnlyHint, true);
+      assertEquals(tool.annotations?.destructiveHint, false);
+      assertEquals(tool.annotations?.openWorldHint, true);
+    }
+  });
+
+  it("c7_resolve_library returns graceful error when CONTEXT7_API_KEY is unset", async () => {
+    const originalKey = Deno.env.get("CONTEXT7_API_KEY");
+    try {
+      Deno.env.delete("CONTEXT7_API_KEY");
+
+      const resolveTool = context7Tools.find(
+        (t) => t.name === "c7_resolve_library",
+      )!;
+
+      const result = await resolveTool.execute({
+        libraryName: "React",
+        query: "hooks",
+      });
+
+      assertEquals(result, {
+        error: "context7_not_configured",
+        message:
+          "Context7 API key not configured. Set the CONTEXT7_API_KEY environment variable.",
+      });
+    } finally {
+      if (originalKey !== undefined) {
+        Deno.env.set("CONTEXT7_API_KEY", originalKey);
+      }
+    }
+  });
+
+  it("c7_query_docs returns graceful error when CONTEXT7_API_KEY is unset", async () => {
+    const originalKey = Deno.env.get("CONTEXT7_API_KEY");
+    try {
+      Deno.env.delete("CONTEXT7_API_KEY");
+
+      const queryTool = context7Tools.find(
+        (t) => t.name === "c7_query_docs",
+      )!;
+
+      const result = await queryTool.execute({
+        libraryId: "/vercel/next.js",
+        query: "routing",
+      });
+
+      assertEquals(result, {
+        error: "context7_not_configured",
+        message:
+          "Context7 API key not configured. Set the CONTEXT7_API_KEY environment variable.",
+      });
+    } finally {
+      if (originalKey !== undefined) {
+        Deno.env.set("CONTEXT7_API_KEY", originalKey);
+      }
+    }
+  });
+});

--- a/cli/mcp/tools/context7-tools.test.ts
+++ b/cli/mcp/tools/context7-tools.test.ts
@@ -44,8 +44,7 @@ describe("cli/mcp/tools/context7-tools", () => {
 
       assertEquals(result, {
         error: "context7_not_configured",
-        message:
-          "Context7 API key not configured. Set the CONTEXT7_API_KEY environment variable.",
+        message: "Context7 API key not configured. Set the CONTEXT7_API_KEY environment variable.",
       });
     } finally {
       if (originalKey !== undefined) {
@@ -72,8 +71,7 @@ describe("cli/mcp/tools/context7-tools", () => {
 
       assertEquals(result, {
         error: "context7_not_configured",
-        message:
-          "Context7 API key not configured. Set the CONTEXT7_API_KEY environment variable.",
+        message: "Context7 API key not configured. Set the CONTEXT7_API_KEY environment variable.",
       });
     } finally {
       if (originalKey !== undefined) {

--- a/cli/mcp/tools/context7-tools.test.ts
+++ b/cli/mcp/tools/context7-tools.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { context7Tools } from "./context7-tools.ts";
 
 describe("cli/mcp/tools/context7-tools", () => {
@@ -75,6 +76,179 @@ describe("cli/mcp/tools/context7-tools", () => {
     } finally {
       if (originalKey !== undefined) {
         Deno.env.set("CONTEXT7_API_KEY", originalKey);
+      }
+    }
+  });
+
+  it("c7_resolve_library forwards call to Context7 and returns result", async () => {
+    const originalKey = Deno.env.get("CONTEXT7_API_KEY");
+    try {
+      Deno.env.set("CONTEXT7_API_KEY", "test-key");
+      let capturedBody: Record<string, unknown> | undefined;
+
+      const resolveTool = context7Tools.find(
+        (t) => t.name === "c7_resolve_library",
+      )!;
+
+      const result = await withMockFetch(
+        async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          capturedBody = await request.json();
+          return Response.json({
+            jsonrpc: "2.0",
+            id: "context7:tools:call:resolve-library-id",
+            result: {
+              content: [
+                {
+                  text: JSON.stringify({
+                    libraryId: "/vercel/next.js",
+                    name: "Next.js",
+                  }),
+                },
+              ],
+            },
+          });
+        },
+        async () =>
+          await resolveTool.execute({
+            libraryName: "Next.js",
+            query: "app router",
+          }),
+      );
+
+      assertEquals(capturedBody?.method, "tools/call");
+      assertEquals(
+        (capturedBody?.params as Record<string, unknown>)?.name,
+        "resolve-library-id",
+      );
+      assertEquals(result, { libraryId: "/vercel/next.js", name: "Next.js" });
+    } finally {
+      if (originalKey !== undefined) {
+        Deno.env.set("CONTEXT7_API_KEY", originalKey);
+      } else {
+        Deno.env.delete("CONTEXT7_API_KEY");
+      }
+    }
+  });
+
+  it("c7_query_docs forwards call to Context7 and returns result", async () => {
+    const originalKey = Deno.env.get("CONTEXT7_API_KEY");
+    try {
+      Deno.env.set("CONTEXT7_API_KEY", "test-key");
+      let capturedBody: Record<string, unknown> | undefined;
+
+      const queryTool = context7Tools.find(
+        (t) => t.name === "c7_query_docs",
+      )!;
+
+      const result = await withMockFetch(
+        async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          capturedBody = await request.json();
+          return Response.json({
+            jsonrpc: "2.0",
+            id: "context7:tools:call:query-docs",
+            result: {
+              content: [
+                {
+                  text: JSON.stringify({
+                    docs: "## App Router\nNext.js uses file-based routing...",
+                  }),
+                },
+              ],
+            },
+          });
+        },
+        async () =>
+          await queryTool.execute({
+            libraryId: "/vercel/next.js",
+            query: "app router setup",
+          }),
+      );
+
+      assertEquals(capturedBody?.method, "tools/call");
+      assertEquals(
+        (capturedBody?.params as Record<string, unknown>)?.name,
+        "query-docs",
+      );
+      assertEquals(result, {
+        docs: "## App Router\nNext.js uses file-based routing...",
+      });
+    } finally {
+      if (originalKey !== undefined) {
+        Deno.env.set("CONTEXT7_API_KEY", originalKey);
+      } else {
+        Deno.env.delete("CONTEXT7_API_KEY");
+      }
+    }
+  });
+
+  it("c7_resolve_library returns structured error on network failure", async () => {
+    const originalKey = Deno.env.get("CONTEXT7_API_KEY");
+    try {
+      Deno.env.set("CONTEXT7_API_KEY", "test-key");
+
+      const resolveTool = context7Tools.find(
+        (t) => t.name === "c7_resolve_library",
+      )!;
+
+      const result = await withMockFetch(
+        async () => new Response("Service Unavailable", { status: 503 }),
+        async () =>
+          await resolveTool.execute({
+            libraryName: "React",
+            query: "hooks",
+          }),
+      );
+
+      assertEquals(
+        (result as Record<string, unknown>).error,
+        "context7_request_failed",
+      );
+      assertEquals(
+        typeof (result as Record<string, unknown>).message,
+        "string",
+      );
+    } finally {
+      if (originalKey !== undefined) {
+        Deno.env.set("CONTEXT7_API_KEY", originalKey);
+      } else {
+        Deno.env.delete("CONTEXT7_API_KEY");
+      }
+    }
+  });
+
+  it("c7_query_docs returns structured error on network failure", async () => {
+    const originalKey = Deno.env.get("CONTEXT7_API_KEY");
+    try {
+      Deno.env.set("CONTEXT7_API_KEY", "test-key");
+
+      const queryTool = context7Tools.find(
+        (t) => t.name === "c7_query_docs",
+      )!;
+
+      const result = await withMockFetch(
+        async () => new Response("Service Unavailable", { status: 503 }),
+        async () =>
+          await queryTool.execute({
+            libraryId: "/vercel/next.js",
+            query: "routing",
+          }),
+      );
+
+      assertEquals(
+        (result as Record<string, unknown>).error,
+        "context7_request_failed",
+      );
+      assertEquals(
+        typeof (result as Record<string, unknown>).message,
+        "string",
+      );
+    } finally {
+      if (originalKey !== undefined) {
+        Deno.env.set("CONTEXT7_API_KEY", originalKey);
+      } else {
+        Deno.env.delete("CONTEXT7_API_KEY");
       }
     }
   });

--- a/cli/mcp/tools/context7-tools.test.ts
+++ b/cli/mcp/tools/context7-tools.test.ts
@@ -50,6 +50,8 @@ describe("cli/mcp/tools/context7-tools", () => {
     } finally {
       if (originalKey !== undefined) {
         Deno.env.set("CONTEXT7_API_KEY", originalKey);
+      } else {
+        Deno.env.delete("CONTEXT7_API_KEY");
       }
     }
   });
@@ -76,6 +78,8 @@ describe("cli/mcp/tools/context7-tools", () => {
     } finally {
       if (originalKey !== undefined) {
         Deno.env.set("CONTEXT7_API_KEY", originalKey);
+      } else {
+        Deno.env.delete("CONTEXT7_API_KEY");
       }
     }
   });

--- a/cli/mcp/tools/context7-tools.ts
+++ b/cli/mcp/tools/context7-tools.ts
@@ -21,8 +21,7 @@ const c7ResolveLibrary: MCPTool<
 > = {
   name: "c7_resolve_library",
   title: "Context7: Resolve Library ID",
-  description:
-    "Resolves a package or product name to a Context7-compatible library ID. " +
+  description: "Resolves a package or product name to a Context7-compatible library ID. " +
     "Call this before c7_query_docs to obtain the correct library ID. " +
     "Returns matching libraries with metadata (name, description, snippet count, reputation).",
   annotations: {
@@ -47,8 +46,7 @@ const c7ResolveLibrary: MCPTool<
     if (!isContext7Available()) {
       return {
         error: "context7_not_configured",
-        message:
-          "Context7 API key not configured. Set the CONTEXT7_API_KEY environment variable.",
+        message: "Context7 API key not configured. Set the CONTEXT7_API_KEY environment variable.",
       };
     }
     try {
@@ -94,8 +92,7 @@ const c7QueryDocs: MCPTool<
     if (!isContext7Available()) {
       return {
         error: "context7_not_configured",
-        message:
-          "Context7 API key not configured. Set the CONTEXT7_API_KEY environment variable.",
+        message: "Context7 API key not configured. Set the CONTEXT7_API_KEY environment variable.",
       };
     }
     try {

--- a/cli/mcp/tools/context7-tools.ts
+++ b/cli/mcp/tools/context7-tools.ts
@@ -51,7 +51,14 @@ const c7ResolveLibrary: MCPTool<
           "Context7 API key not configured. Set the CONTEXT7_API_KEY environment variable.",
       };
     }
-    return await getSource().executeTool("resolve-library-id", input);
+    try {
+      return await getSource().executeTool("resolve-library-id", input);
+    } catch (error) {
+      return {
+        error: "context7_request_failed",
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
   },
 };
 
@@ -91,7 +98,14 @@ const c7QueryDocs: MCPTool<
           "Context7 API key not configured. Set the CONTEXT7_API_KEY environment variable.",
       };
     }
-    return await getSource().executeTool("query-docs", input);
+    try {
+      return await getSource().executeTool("query-docs", input);
+    } catch (error) {
+      return {
+        error: "context7_request_failed",
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
   },
 };
 

--- a/cli/mcp/tools/context7-tools.ts
+++ b/cli/mcp/tools/context7-tools.ts
@@ -1,0 +1,98 @@
+import { z } from "zod";
+import type { MCPTool } from "veryfront/mcp";
+import { createContext7ToolSource } from "veryfront/tool";
+
+let _source: ReturnType<typeof createContext7ToolSource> | undefined;
+
+function getSource() {
+  if (!_source) {
+    _source = createContext7ToolSource();
+  }
+  return _source;
+}
+
+function isContext7Available(): boolean {
+  return Boolean(Deno.env.get("CONTEXT7_API_KEY"));
+}
+
+const c7ResolveLibrary: MCPTool<
+  { libraryName: string; query: string },
+  unknown
+> = {
+  name: "c7_resolve_library",
+  title: "Context7: Resolve Library ID",
+  description:
+    "Resolves a package or product name to a Context7-compatible library ID. " +
+    "Call this before c7_query_docs to obtain the correct library ID. " +
+    "Returns matching libraries with metadata (name, description, snippet count, reputation).",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  inputSchema: z.object({
+    libraryName: z
+      .string()
+      .describe(
+        "Library name to search for. Use the official name with proper punctuation — e.g., 'Next.js' not 'nextjs'.",
+      ),
+    query: z
+      .string()
+      .describe(
+        "The question or task you need help with. Used to rank results by relevance.",
+      ),
+  }),
+  execute: async (input) => {
+    if (!isContext7Available()) {
+      return {
+        error: "context7_not_configured",
+        message:
+          "Context7 API key not configured. Set the CONTEXT7_API_KEY environment variable.",
+      };
+    }
+    return await getSource().executeTool("resolve-library-id", input);
+  },
+};
+
+const c7QueryDocs: MCPTool<
+  { libraryId: string; query: string },
+  unknown
+> = {
+  name: "c7_query_docs",
+  title: "Context7: Query Documentation",
+  description:
+    "Retrieves up-to-date documentation and code examples from Context7 for a library. " +
+    "You must call c7_resolve_library first to obtain the library ID, unless the user " +
+    "provides one directly in '/org/project' format.",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  inputSchema: z.object({
+    libraryId: z
+      .string()
+      .describe(
+        "Context7-compatible library ID (e.g., '/vercel/next.js', '/supabase/supabase').",
+      ),
+    query: z
+      .string()
+      .describe(
+        "The question or task you need help with. Be specific and include relevant details.",
+      ),
+  }),
+  execute: async (input) => {
+    if (!isContext7Available()) {
+      return {
+        error: "context7_not_configured",
+        message:
+          "Context7 API key not configured. Set the CONTEXT7_API_KEY environment variable.",
+      };
+    }
+    return await getSource().executeTool("query-docs", input);
+  },
+};
+
+export const context7Tools: MCPTool[] = [c7ResolveLibrary, c7QueryDocs];

--- a/src/tool/context7.test.ts
+++ b/src/tool/context7.test.ts
@@ -112,6 +112,58 @@ describe("tool/context7", () => {
     assertEquals(result, { libraryId: "/vercel/next.js" });
   });
 
+  it("falls back to CONTEXT7_API_KEY env var when apiKey config is omitted", async () => {
+    const originalEnv = Deno.env.get("CONTEXT7_API_KEY");
+    try {
+      Deno.env.set("CONTEXT7_API_KEY", "env-fallback-key");
+      let capturedHeaders: Headers | undefined;
+
+      const source = createContext7ToolSource({ endpoint: "https://mcp.test/mcp" });
+
+      await withMockFetch(
+        async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          capturedHeaders = request.headers;
+          return Response.json({
+            jsonrpc: "2.0",
+            id: "context7:tools:list",
+            result: { tools: [] },
+          });
+        },
+        async () => await source.listTools(),
+      );
+
+      assertEquals(capturedHeaders?.get("CONTEXT7_API_KEY"), "env-fallback-key");
+    } finally {
+      if (originalEnv !== undefined) {
+        Deno.env.set("CONTEXT7_API_KEY", originalEnv);
+      } else {
+        Deno.env.delete("CONTEXT7_API_KEY");
+      }
+    }
+  });
+
+  it("uses the default endpoint when none is provided", async () => {
+    let capturedUrl = "";
+
+    const source = createContext7ToolSource({ apiKey: "test-key" });
+
+    await withMockFetch(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        capturedUrl = request.url;
+        return Response.json({
+          jsonrpc: "2.0",
+          id: "context7:tools:list",
+          result: { tools: [] },
+        });
+      },
+      async () => await source.listTools(),
+    );
+
+    assertEquals(capturedUrl, "https://mcp.context7.com/mcp");
+  });
+
   it("throws when no API key is provided and CONTEXT7_API_KEY env is unset", async () => {
     const originalEnv = Deno.env.get("CONTEXT7_API_KEY");
     try {

--- a/src/tool/context7.test.ts
+++ b/src/tool/context7.test.ts
@@ -1,0 +1,135 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
+import { createContext7ToolSource } from "./context7.ts";
+
+describe("tool/context7", () => {
+  it("creates a remote tool source with the correct id", () => {
+    const source = createContext7ToolSource({ apiKey: "test-key" });
+    assertEquals(source.id, "context7");
+  });
+
+  it("sends the API key header and lists tools via JSON-RPC", async () => {
+    let capturedHeaders: Headers | undefined;
+    let capturedBody: Record<string, unknown> | undefined;
+
+    const source = createContext7ToolSource({
+      apiKey: "c7-test-key",
+      endpoint: "https://mcp.test/mcp",
+    });
+
+    const tools = await withMockFetch(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        capturedHeaders = request.headers;
+        capturedBody = await request.json();
+        return Response.json({
+          jsonrpc: "2.0",
+          id: "context7:tools:list",
+          result: {
+            tools: [
+              {
+                name: "resolve-library-id",
+                description: "Resolve a library name to a Context7 library ID",
+                inputSchema: {
+                  type: "object",
+                  properties: {
+                    libraryName: { type: "string" },
+                    query: { type: "string" },
+                  },
+                  required: ["query", "libraryName"],
+                },
+              },
+              {
+                name: "query-docs",
+                description: "Query documentation for a library",
+                inputSchema: {
+                  type: "object",
+                  properties: {
+                    libraryId: { type: "string" },
+                    query: { type: "string" },
+                  },
+                  required: ["libraryId", "query"],
+                },
+              },
+            ],
+          },
+        });
+      },
+      async () => await source.listTools(),
+    );
+
+    assertEquals(capturedHeaders?.get("CONTEXT7_API_KEY"), "c7-test-key");
+    assertEquals(capturedBody, {
+      jsonrpc: "2.0",
+      id: "context7:tools:list",
+      method: "tools/list",
+    });
+    assertEquals(tools.length, 2);
+    assertEquals(tools[0]?.name, "resolve-library-id");
+    assertEquals(tools[1]?.name, "query-docs");
+  });
+
+  it("executes a tool call and returns the normalized result", async () => {
+    let capturedBody: Record<string, unknown> | undefined;
+
+    const source = createContext7ToolSource({
+      apiKey: "c7-test-key",
+      endpoint: "https://mcp.test/mcp",
+    });
+
+    const result = await withMockFetch(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        capturedBody = await request.json();
+        return Response.json({
+          jsonrpc: "2.0",
+          id: "context7:tools:call:resolve-library-id",
+          result: {
+            content: [{ text: JSON.stringify({ libraryId: "/vercel/next.js" }) }],
+          },
+        });
+      },
+      async () =>
+        await source.executeTool("resolve-library-id", {
+          libraryName: "Next.js",
+          query: "How to set up routing",
+        }),
+    );
+
+    assertEquals(capturedBody, {
+      jsonrpc: "2.0",
+      id: "context7:tools:call:resolve-library-id",
+      method: "tools/call",
+      params: {
+        name: "resolve-library-id",
+        arguments: {
+          libraryName: "Next.js",
+          query: "How to set up routing",
+        },
+      },
+    });
+    assertEquals(result, { libraryId: "/vercel/next.js" });
+  });
+
+  it("throws when no API key is provided and CONTEXT7_API_KEY env is unset", async () => {
+    const originalEnv = Deno.env.get("CONTEXT7_API_KEY");
+    try {
+      Deno.env.delete("CONTEXT7_API_KEY");
+      const source = createContext7ToolSource();
+      await assertRejects(
+        () =>
+          withMockFetch(
+            async () => Response.json({}),
+            async () => await source.listTools(),
+          ),
+        Error,
+        "Context7 API key is required",
+      );
+    } finally {
+      if (originalEnv !== undefined) {
+        Deno.env.set("CONTEXT7_API_KEY", originalEnv);
+      }
+    }
+  });
+});

--- a/src/tool/context7.ts
+++ b/src/tool/context7.ts
@@ -1,0 +1,33 @@
+import { createRemoteMCPToolSource } from "./remote-mcp.ts";
+import type { RemoteToolSource } from "./types.ts";
+
+export interface Context7ToolSourceConfig {
+  /** Context7 API key. Falls back to Deno.env.get("CONTEXT7_API_KEY"). */
+  apiKey?: string;
+  /** Override the default endpoint (useful for testing). */
+  endpoint?: string;
+}
+
+const DEFAULT_ENDPOINT = "https://mcp.context7.com/mcp";
+
+function resolveApiKey(config: Context7ToolSourceConfig): string {
+  const key = config.apiKey ?? Deno.env.get("CONTEXT7_API_KEY");
+  if (!key) {
+    throw new Error(
+      "Context7 API key is required. Pass apiKey or set the CONTEXT7_API_KEY environment variable.",
+    );
+  }
+  return key;
+}
+
+export function createContext7ToolSource(
+  config: Context7ToolSourceConfig = {},
+): RemoteToolSource {
+  return createRemoteMCPToolSource({
+    id: "context7",
+    endpoint: config.endpoint ?? DEFAULT_ENDPOINT,
+    headers: () => ({
+      CONTEXT7_API_KEY: resolveApiKey(config),
+    }),
+  });
+}

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -55,6 +55,8 @@ export { dynamicTool, tool } from "./factory.ts";
 export type { DynamicToolConfig } from "./factory.ts";
 export { createRemoteMCPToolSource } from "./remote-mcp.ts";
 export type { RemoteMCPToolSourceConfig } from "./remote-mcp.ts";
+export { createContext7ToolSource } from "./context7.ts";
+export type { Context7ToolSourceConfig } from "./context7.ts";
 export {
   createToolsFromRemoteDefinitions,
   loadRemoteToolsFromSource,


### PR DESCRIPTION
## Summary

- Add `createContext7ToolSource()` factory in `veryfront/tool` that wraps `createRemoteMCPToolSource()` with Context7-specific defaults (endpoint, API key header)
- Add two CLI MCP tools (`c7_resolve_library`, `c7_query_docs`) for editor integration (Claude Code, Cursor) with graceful degradation when `CONTEXT7_API_KEY` is unset
- Register Context7 tools in both dev-server MCP (`allTools`) and standalone stdio MCP (`vf mcp`)

## How it works

**Agent integration (programmatic):**
```typescript
import { agent } from "veryfront/agent";
import { createContext7ToolSource } from "veryfront/tool";

const assistant = agent({
  model: "anthropic/claude-sonnet-4-20250514",
  system: "You help developers write code using current library docs.",
  remoteTools: [createContext7ToolSource()],
});
```

**Editor integration (CLI MCP):**
When `CONTEXT7_API_KEY` is set, `c7_resolve_library` and `c7_query_docs` appear automatically in both the dev server MCP and standalone `vf mcp` stdio mode.

## Acceptance Criteria

- [x] `createContext7ToolSource()` is exported from `veryfront/tool` — verified at `src/tool/index.ts:58`
- [x] `Context7ToolSourceConfig` type is exported from `veryfront/tool` — verified at `src/tool/index.ts:59`
- [x] Factory returns a `RemoteToolSource` with id `"context7"` — test: `creates a remote tool source with the correct id`
- [x] Factory uses `https://mcp.context7.com/mcp` as default endpoint — test: `uses the default endpoint when none is provided`
- [x] Factory sends `CONTEXT7_API_KEY` header (from config or env var) — tests: `sends the API key header` + `falls back to CONTEXT7_API_KEY env var`
- [x] Factory throws when no API key is available (neither config nor env) — test: `throws when no API key is provided`
- [x] `c7_resolve_library` tool appears in dev-server MCP `allTools` — test: `tool names are unique` (cli/mcp/tools.test.ts passes with c7 tools)
- [x] `c7_query_docs` tool appears in dev-server MCP `allTools` — test: `exports two tools with correct names`
- [x] `c7_resolve_library` tool appears in standalone stdio MCP `tools/list` — test: `tools/list includes context7 tools`
- [x] `c7_query_docs` tool appears in standalone stdio MCP `tools/list` — test: `tools/list includes context7 tools`
- [x] Both CLI tools return `{ error: "context7_not_configured" }` when `CONTEXT7_API_KEY` is unset — tests: `returns graceful error when CONTEXT7_API_KEY is unset` (x2)
- [x] Both CLI tools return `{ error: "context7_request_failed" }` on network errors — tests: `returns structured error on network failure` (x2)
- [x] Both CLI tools are annotated as `readOnlyHint: true`, `openWorldHint: true` — test: `all tools are marked as read-only and open-world`
- [x] All tools have `title`, `description`, `inputSchema`, and `annotations` — test: `all tools have required fields`
- [x] All existing CLI MCP tests pass (unique names, annotation consistency) — 32/32 steps pass
- [x] Type-check passes for all new and modified files — `deno check` passes for all 4 files

## Test plan

- [x] `deno test --allow-env src/tool/context7.test.ts` — 6/6 tests pass (id, listTools, executeTool, env fallback, default endpoint, missing key)
- [x] `deno test --allow-env cli/mcp/tools/context7-tools.test.ts` — 9/9 tests pass (structure, annotations, graceful degradation, happy path, network errors)
- [x] `deno test --allow-env cli/mcp/tools.test.ts` — 32/32 steps pass (unique names, annotations, tool structure)
- [x] `deno test --no-check --allow-env --allow-net cli/mcp/standalone.test.ts` — 28/28 steps pass (context7 tools in tools/list)
- [x] `deno check src/tool/index.ts src/tool/context7.ts cli/mcp/tools.ts cli/mcp/standalone.ts` — all 4 files type-check clean