### PR TITLE
Buffer early tool resumes for active runs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.191",
+  "version": "0.1.192",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/ag-ui-handler.ts
+++ b/src/agent/ag-ui-handler.ts
@@ -276,6 +276,7 @@ async function createAgUiStreamResponse(
     upstreamStatusText?: string;
     onFinish?: () => void;
     onError?: (error: unknown) => void;
+    onToolCallSeen?: (toolCallId: string) => void;
   },
 ): Promise<Response> {
   const {
@@ -288,6 +289,7 @@ async function createAgUiStreamResponse(
     upstreamStatusText,
     onFinish,
     onError,
+    onToolCallSeen,
   } = options;
 
   const stream = new ReadableStream<Uint8Array>({
@@ -296,6 +298,19 @@ async function createAgUiStreamResponse(
       let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
       let remainder = "";
       const decoder = new TextDecoder();
+      const prepareToolResultIfNeeded = (event: string, payload: Record<string, unknown>) => {
+        if (
+          event !== "ToolCallStart" && event !== "ToolCallArgs" &&
+          event !== "ToolCallEnd"
+        ) {
+          return;
+        }
+
+        const toolCallId = typeof payload.toolCallId === "string" ? payload.toolCallId : null;
+        if (toolCallId) {
+          onToolCallSeen?.(toolCallId);
+        }
+      };
 
       if (!enqueueEvent(controller, "RunStarted", { runId, threadId, agentId })) {
         return;
@@ -331,6 +346,7 @@ async function createAgUiStreamResponse(
 
           for (const event of parsed.events as AgUiRuntimePart[]) {
             for (const mapped of mapRuntimeEventToAgUi(state, event)) {
+              prepareToolResultIfNeeded(mapped.event, mapped.payload);
               if (!enqueueEvent(controller, mapped.event, mapped.payload)) {
                 return;
               }
@@ -342,6 +358,7 @@ async function createAgUiStreamResponse(
         const parsed = parseSseJsonEvents(remainder);
         for (const event of parsed.events as AgUiRuntimePart[]) {
           for (const mapped of mapRuntimeEventToAgUi(state, event)) {
+            prepareToolResultIfNeeded(mapped.event, mapped.payload);
             if (!enqueueEvent(controller, mapped.event, mapped.payload)) {
               return;
             }
@@ -420,6 +437,7 @@ function createInjectedAgUiTool(
         throw new Error(`Missing toolCallId for injected tool "${tool.name}"`);
       }
 
+      sessionManager.prepareForSignal(runId, toolCallId);
       const submitted = await sessionManager.waitForSignal(runId, toolCallId);
       if (submitted.isError) {
         throw new Error(
@@ -499,6 +517,9 @@ async function createAgUiInjectedToolsStreamResponse(
     },
     onError: () => {
       sessionManager.failRun(runId);
+    },
+    onToolCallSeen: (toolCallId) => {
+      sessionManager.prepareForSignal(runId, toolCallId);
     },
   });
 }

--- a/src/agent/human-input.ts
+++ b/src/agent/human-input.ts
@@ -130,6 +130,7 @@ export class InvalidHumanInputResultError extends Error {
 export async function waitForHumanInput(
   options: WaitForHumanInputOptions,
 ): Promise<HumanInputResult> {
+  options.sessionManager.prepareForSignal(options.runId, options.toolCallId);
   const pendingRequest = HumanInputPendingRequestSchema.parse({
     runId: options.runId,
     toolCallId: options.toolCallId,

--- a/src/agent/runtime/resume-session.test.ts
+++ b/src/agent/runtime/resume-session.test.ts
@@ -55,6 +55,22 @@ describe("agent/runtime/resume-session", () => {
     );
   });
 
+  it("buffers submissions for wait keys that were prepared before waiting starts", async () => {
+    const manager = new RunResumeSessionManager<{ ok: boolean }>();
+    manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    manager.prepareForSignal("run_1", "tool_1");
+
+    assertEquals(
+      manager.submitSignal("run_1", {
+        waitKey: "tool_1",
+        value: { ok: true },
+      }),
+      { accepted: true },
+    );
+
+    assertEquals(await manager.waitForSignal("run_1", "tool_1"), { ok: true });
+  });
+
   it("cancels waiting runs and rejects the parked wait promise", async () => {
     const manager = new RunResumeSessionManager<{ ok: boolean }>();
     manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });

--- a/src/agent/runtime/resume-session.ts
+++ b/src/agent/runtime/resume-session.ts
@@ -56,6 +56,7 @@ type RunSession<T> = {
   status: RunSessionStatus;
   abortController: AbortController;
   waitingState: WaitingState<T> | null;
+  preparedWaitKeys: Set<string>;
   submittedValues: Map<string, SubmittedValue<T>>;
   waitingTimeoutId: number | null;
   sessionTimeoutId: number | null;
@@ -170,6 +171,7 @@ export class RunResumeSessionManager<T> {
       status: "running",
       abortController: new AbortController(),
       waitingState: null,
+      preparedWaitKeys: new Set(),
       submittedValues: new Map(),
       waitingTimeoutId: null,
       sessionTimeoutId: null,
@@ -178,6 +180,23 @@ export class RunResumeSessionManager<T> {
     this.sessions.set(input.runId, session);
     this.touchSession(session);
     return session.abortController.signal;
+  }
+
+  prepareForSignal(runId: string, waitKey: string): void {
+    const session = this.sessions.get(runId);
+    if (!session) {
+      throw new RunNotActiveError(runId);
+    }
+
+    if (
+      session.status === "completed" || session.status === "failed" ||
+      session.status === "cancelled"
+    ) {
+      throw new RunNotActiveError(runId);
+    }
+
+    session.preparedWaitKeys.add(waitKey);
+    this.touchSession(session);
   }
 
   async waitForSignal(runId: string, waitKey: string): Promise<T> {
@@ -190,6 +209,7 @@ export class RunResumeSessionManager<T> {
       throw new RunCancelledError();
     }
 
+    session.preparedWaitKeys.add(waitKey);
     const existingValue = session.submittedValues.get(waitKey);
     if (existingValue) {
       session.status = "running";
@@ -265,6 +285,10 @@ export class RunResumeSessionManager<T> {
     }
 
     if (!session.waitingState) {
+      if (!session.preparedWaitKeys.has(input.waitKey)) {
+        throw new WaitNotPendingError(runId, input.waitKey);
+      }
+
       session.submittedValues.set(input.waitKey, normalized);
       this.touchSession(session);
       return { accepted: true };

--- a/src/agent/runtime/resume-session.ts
+++ b/src/agent/runtime/resume-session.ts
@@ -264,7 +264,13 @@ export class RunResumeSessionManager<T> {
       throw new RunNotActiveError(runId);
     }
 
-    if (!session.waitingState || session.waitingState.waitKey !== input.waitKey) {
+    if (!session.waitingState) {
+      session.submittedValues.set(input.waitKey, normalized);
+      this.touchSession(session);
+      return { accepted: true };
+    }
+
+    if (session.waitingState.waitKey !== input.waitKey) {
       throw new WaitNotPendingError(runId, input.waitKey);
     }
 

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -66,6 +66,7 @@ function createInjectedStudioTool(
         throw new Error(`Missing toolCallId for injected tool "${toolName}"`);
       }
 
+      sessionManager.prepareForToolResult(runId, toolCallId);
       const waitResult = await sessionManager.waitForToolResult(runId, toolCallId);
       if (waitResult.isError) {
         throw new Error(
@@ -284,6 +285,21 @@ export async function createRuntimeAgentStreamResponse(
           clientAttached = false;
         }
       };
+      const prepareToolResultIfNeeded = (event: string, payload: Record<string, unknown>) => {
+        if (
+          event !== "ToolCallStart" && event !== "ToolCallArgs" &&
+          event !== "ToolCallEnd"
+        ) {
+          return;
+        }
+
+        const toolCallId = typeof payload.toolCallId === "string" ? payload.toolCallId : null;
+        if (!toolCallId) {
+          return;
+        }
+
+        deps.sessionManager.prepareForToolResult(input.runId, toolCallId);
+      };
 
       const throwIfAborted = () => {
         if (aborted || abortSignal.aborted) {
@@ -330,6 +346,7 @@ export async function createRuntimeAgentStreamResponse(
 
           for (const event of parsed.events) {
             for (const mappedEvent of mapRuntimeEventToAgUi(state, event)) {
+              prepareToolResultIfNeeded(mappedEvent.event, mappedEvent.payload);
               enqueueIfAttached(mappedEvent.event, mappedEvent.payload);
             }
           }
@@ -340,6 +357,7 @@ export async function createRuntimeAgentStreamResponse(
         const trailingEvents = parseSseJsonEvents(`${remainder}\n\n`);
         for (const event of trailingEvents.events) {
           for (const mappedEvent of mapRuntimeEventToAgUi(state, event)) {
+            prepareToolResultIfNeeded(mappedEvent.event, mappedEvent.payload);
             enqueueIfAttached(mappedEvent.event, mappedEvent.payload);
           }
         }

--- a/src/internal-agents/session-manager.test.ts
+++ b/src/internal-agents/session-manager.test.ts
@@ -39,18 +39,47 @@ describe("internal-agents/session-manager", () => {
     );
   });
 
-  it("rejects submissions for tool calls that are not currently waiting", async () => {
+  it("buffers submissions that arrive before the tool call starts waiting", async () => {
     const sessionManager = new AgentRunSessionManager();
     sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    assertEquals(
+      sessionManager.submitToolResult("run_1", {
+        toolCallId: "tool_1",
+        result: { ok: true },
+      }),
+      { accepted: true },
+    );
+
+    assertEquals(await sessionManager.waitForToolResult("run_1", "tool_1"), {
+      result: { ok: true },
+      isError: false,
+    });
+    sessionManager.completeRun("run_1");
+  });
+
+  it("still rejects tool results for a different wait key while another wait is pending", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    const pending = sessionManager.waitForToolResult("run_1", "tool_1");
 
     await assertRejects(
       async () => {
         sessionManager.submitToolResult("run_1", {
-          toolCallId: "tool_1",
+          toolCallId: "tool_2",
           result: { ok: true },
         });
       },
       ToolResultNotWaitingError,
+    );
+
+    assertEquals(sessionManager.cancelRun("run_1"), true);
+    await assertRejects(
+      async () => {
+        await pending;
+      },
+      AgentRunCancelledError,
     );
   });
 

--- a/src/internal-agents/session-manager.test.ts
+++ b/src/internal-agents/session-manager.test.ts
@@ -42,6 +42,7 @@ describe("internal-agents/session-manager", () => {
   it("buffers submissions that arrive before the tool call starts waiting", async () => {
     const sessionManager = new AgentRunSessionManager();
     sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    sessionManager.prepareForToolResult("run_1", "tool_1");
 
     assertEquals(
       sessionManager.submitToolResult("run_1", {

--- a/src/internal-agents/session-manager.ts
+++ b/src/internal-agents/session-manager.ts
@@ -128,6 +128,10 @@ export class AgentRunSessionManager {
     }
   }
 
+  prepareForToolResult(runId: string, toolCallId: string): void {
+    this.sessions.prepareForSignal(runId, toolCallId);
+  }
+
   submitToolResult(
     runId: string,
     input: { toolCallId: string; result: unknown; isError?: boolean },

--- a/src/server/handlers/request/agent-run-resume.handler.test.ts
+++ b/src/server/handlers/request/agent-run-resume.handler.test.ts
@@ -149,7 +149,7 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
     assertEquals(await result.response.json(), { error: "TOOL_RESULT_CONFLICT" });
   });
 
-  it("returns 409 when the run is not waiting for the submitted tool call", async () => {
+  it("accepts a tool result before the runtime registers the wait", async () => {
     const sessionManager = new AgentRunSessionManager();
     sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
 
@@ -174,8 +174,45 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
     );
 
     assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(await result.response.json(), { accepted: true });
+    assertEquals(await sessionManager.waitForToolResult("run_1", "tool_1"), {
+      result: { ok: true },
+      isError: false,
+    });
+    sessionManager.completeRun("run_1");
+  });
+
+  it("returns 409 when a different tool call is submitted while another wait is active", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    const pending = sessionManager.waitForToolResult("run_1", "tool_1");
+
+    const handler = new AgentRunResumeHandler(sessionManager);
+    const body = JSON.stringify({
+      type: "tool_result",
+      toolCallId: "tool_2",
+      result: { ok: true },
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/runs/run_1/resume", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
     assertEquals(result.response.status, 409);
     assertEquals(await result.response.json(), { error: "TOOL_RESULT_NOT_WAITING" });
+    assertEquals(sessionManager.cancelRun("run_1"), true);
+    await pending.catch(() => undefined);
   });
 
   it("returns 410 when the run is no longer active", async () => {

--- a/src/server/handlers/request/agent-run-resume.handler.test.ts
+++ b/src/server/handlers/request/agent-run-resume.handler.test.ts
@@ -152,6 +152,7 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
   it("accepts a tool result before the runtime registers the wait", async () => {
     const sessionManager = new AgentRunSessionManager();
     sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    sessionManager.prepareForToolResult("run_1", "tool_1");
 
     const handler = new AgentRunResumeHandler(sessionManager);
     const body = JSON.stringify({

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -954,4 +954,136 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertEquals(sessionManager.stats.cancelCalls, 0);
     assertEquals(sessionManager.stats.failCalls, 0);
   });
+
+  it("accepts an early resume before the runtime registers the tool wait", async () => {
+    const sessionManager = new TrackingSessionManager();
+    const resumeHandler = new AgentRunResumeHandler(sessionManager);
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: (id) => id === "assistant-1" ? createAgent("assistant-1") : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager,
+      createRuntime: (_agent, mergedTools) => ({
+        async stream(_messages, _context, callbacks) {
+          const tool = mergedTools && mergedTools !== true
+            ? mergedTools["studio_focus_component"] as {
+              execute: (input: unknown, context?: unknown) => Promise<unknown>;
+            }
+            : undefined;
+          if (!tool) {
+            throw new Error("Expected injected tool");
+          }
+
+          return new ReadableStream<Uint8Array>({
+            async start(controller) {
+              controller.enqueue(
+                encodeDataStreamEvent({ type: "message-start", messageId: "assistant-1" }),
+              );
+              controller.enqueue(encodeDataStreamEvent({ type: "text-start", id: "assistant-1" }));
+              controller.enqueue(encodeDataStreamEvent({
+                type: "tool-input-start",
+                toolCallId: "tool-1",
+                toolName: "studio_focus_component",
+              }));
+              controller.enqueue(encodeDataStreamEvent({
+                type: "tool-input-available",
+                toolCallId: "tool-1",
+                toolName: "studio_focus_component",
+                input: { target: "hero" },
+              }));
+
+              await new Promise((resolve) => setTimeout(resolve, 0));
+
+              const output = await tool.execute(
+                { target: "hero" },
+                { toolCallId: "tool-1" },
+              );
+
+              controller.enqueue(encodeDataStreamEvent({
+                type: "tool-output-available",
+                toolCallId: "tool-1",
+                output,
+              }));
+              controller.enqueue(encodeDataStreamEvent({
+                type: "text-delta",
+                id: "assistant-1",
+                delta: "Done.",
+              }));
+              controller.enqueue(encodeDataStreamEvent({ type: "text-end", id: "assistant-1" }));
+              controller.close();
+
+              callbacks?.onFinish?.({
+                text: "Done.",
+                messages: [],
+                toolCalls: [],
+                status: "completed",
+                usage: {
+                  promptTokens: 5,
+                  completionTokens: 3,
+                  totalTokens: 8,
+                },
+                metadata: {
+                  finishReason: "stop",
+                },
+              });
+            },
+          });
+        },
+      }),
+    });
+
+    const body = createAgentStreamRequestBody();
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/internal/agents/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertExists(result.response.body);
+
+    const reader = result.response.body.getReader();
+    const initialText = await readUntil(reader, (chunk) => chunk.includes("event: ToolCallEnd"));
+    assertEquals(sessionManager.getRunStatus("run_1"), "running");
+    assertStringIncludes(initialText, "event: ToolCallStart");
+
+    const resumeBody = JSON.stringify({
+      type: "tool_result",
+      toolCallId: "tool-1",
+      result: { focused: true },
+    });
+    const resumeSignature = await createControlPlaneSignature(resumeBody, { requestId: "run_1" });
+
+    const resumeResult = await resumeHandler.handle(
+      new Request("https://example.com/internal/agents/runs/run_1/resume", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": resumeSignature.jws,
+        },
+        body: resumeBody,
+      }),
+      createCtx(resumeSignature.publicKeyPem),
+    );
+
+    assertExists(resumeResult.response);
+    assertEquals(resumeResult.response.status, 200);
+    assertEquals(await resumeResult.response.json(), { accepted: true });
+
+    const finalText = initialText + await readRemainingText(reader);
+    assertStringIncludes(finalText, "event: ToolCallResult");
+    assertStringIncludes(finalText, "event: RunFinished");
+    assertEquals(sessionManager.getRunStatus("run_1"), null);
+    assertEquals(sessionManager.stats.completeCalls, 1);
+    assertEquals(sessionManager.stats.cancelCalls, 0);
+    assertEquals(sessionManager.stats.failCalls, 0);
+  });
 });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.191";
+export const VERSION = "0.1.192";


### PR DESCRIPTION
## Summary
- buffer early tool resume payloads for active runs before the runtime registers its wait
- keep conflicting or mismatched active waits failing fast
- add regression coverage for the session manager, resume handler, and stream handler
- bump the package version to `0.1.192`

## Verification
- `deno test --no-check --allow-all src/utils/version.test.ts src/internal-agents/ag-ui-sse.test.ts src/internal-agents/session-manager.test.ts src/server/handlers/request/agent-run-resume.handler.test.ts src/server/handlers/request/agent-stream.handler.test.ts`
- `deno check src/agent/runtime/resume-session.ts`
- `deno fmt --check src/agent/runtime/resume-session.ts src/internal-agents/session-manager.test.ts src/server/handlers/request/agent-run-resume.handler.test.ts src/server/handlers/request/agent-stream.handler.test.ts src/utils/version-constant.ts deno.json`
