### PR TITLE
Extract shared framework stream parsing helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.192",
+  "version": "0.1.193",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/ag-ui-handler.test.ts
+++ b/src/agent/ag-ui-handler.test.ts
@@ -173,6 +173,69 @@ describe("agent/ag-ui-handler", () => {
     assertStringIncludes(body, '"delta":"hello from runtime"');
   });
 
+  it("flushes the final runtime data event when the upstream stream ends without a trailing blank line", async () => {
+    const agent: Agent = {
+      id: "assistant-1",
+      config: {
+        id: "assistant-1",
+        system: "You are helpful.",
+        model: "anthropic/claude-sonnet-4-6",
+      } as Agent["config"],
+      generate: async () => {
+        throw new Error("not used");
+      },
+      stream: async () => {
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              encodeDataStreamEvent({ type: "message-start", messageId: "assistant-msg-1" }),
+            );
+            controller.enqueue(
+              encoder.encode('data: {"type":"text-delta","delta":"tail event survives"}'),
+            );
+            controller.close();
+          },
+        });
+
+        return {
+          toDataStreamResponse: () =>
+            new Response(stream, {
+              headers: { "Content-Type": "text/event-stream" },
+            }),
+        };
+      },
+      respond: async () => new Response("not used"),
+      getMemory: () => {
+        throw new Error("not used");
+      },
+      getMemoryStats: async () => ({
+        totalMessages: 0,
+        estimatedTokens: 0,
+        type: "conversation",
+      }),
+      clearMemory: async () => {},
+    };
+    const handler = createAgUiHandler({ agent });
+
+    const response = await handler(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [{
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          }],
+        }),
+      }),
+    );
+
+    const body = await response.text();
+    assertStringIncludes(body, "event: TextMessageStart");
+    assertStringIncludes(body, '"delta":"tail event survives"');
+  });
+
   it("accepts a Pages Router style request wrapper and generates default ids", async () => {
     const testAgent = createTestAgent();
     const handler = createAgUiHandler({ agent: testAgent.agent });

--- a/src/agent/ag-ui-handler.ts
+++ b/src/agent/ag-ui-handler.ts
@@ -14,8 +14,8 @@ import {
   finalizeRunEvents,
   formatAgUiEvent,
   mapRuntimeEventToAgUi,
-  parseSseJsonEvents,
 } from "#veryfront/internal-agents/ag-ui-sse.ts";
+import { streamDataStreamEvents } from "./data-stream.ts";
 
 const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const MAX_TOOL_PARAMETERS_BYTES = 16_384;
@@ -295,9 +295,6 @@ async function createAgUiStreamResponse(
   const stream = new ReadableStream<Uint8Array>({
     start: async (controller) => {
       const state = createStreamTransformState();
-      let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
-      let remainder = "";
-      const decoder = new TextDecoder();
       const prepareToolResultIfNeeded = (event: string, payload: Record<string, unknown>) => {
         if (
           event !== "ToolCallStart" && event !== "ToolCallArgs" &&
@@ -334,29 +331,9 @@ async function createAgUiStreamResponse(
           return;
         }
 
-        reader = upstreamBody.getReader();
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          remainder += decoder.decode(value, { stream: true });
-          const parsed = parseSseJsonEvents(remainder);
-          remainder = parsed.remainder;
-
-          for (const event of parsed.events as AgUiRuntimePart[]) {
-            for (const mapped of mapRuntimeEventToAgUi(state, event)) {
-              prepareToolResultIfNeeded(mapped.event, mapped.payload);
-              if (!enqueueEvent(controller, mapped.event, mapped.payload)) {
-                return;
-              }
-            }
-          }
-        }
-
-        remainder += decoder.decode();
-        const parsed = parseSseJsonEvents(remainder);
-        for (const event of parsed.events as AgUiRuntimePart[]) {
+        for await (
+          const event of streamDataStreamEvents(upstreamBody) as AsyncIterable<AgUiRuntimePart>
+        ) {
           for (const mapped of mapRuntimeEventToAgUi(state, event)) {
             prepareToolResultIfNeeded(mapped.event, mapped.payload);
             if (!enqueueEvent(controller, mapped.event, mapped.payload)) {
@@ -377,7 +354,6 @@ async function createAgUiStreamResponse(
           message: error instanceof Error ? error.message : "Agent run failed",
         });
       } finally {
-        await reader?.cancel().catch(() => undefined);
         closeController(controller);
       }
     },

--- a/src/agent/data-stream.test.ts
+++ b/src/agent/data-stream.test.ts
@@ -1,0 +1,86 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  mergeToolCallInput,
+  mergeToolInputDelta,
+  parseDataStreamSseEvents,
+  parseToolInputObject,
+  streamDataStreamEvents,
+  stripLeadingEmptyObjectPlaceholder,
+} from "./data-stream.ts";
+
+const encoder = new TextEncoder();
+
+function encodeEvent(payload: Record<string, unknown>): Uint8Array {
+  return encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+describe("agent/data-stream", () => {
+  it("parses complete frames and preserves incomplete remainder", () => {
+    const parsed = parseDataStreamSseEvents(
+      'data: {"type":"text-delta","id":"text-1","delta":"hello"}\n\n' +
+        'data: {"type":"step-end"}\n\n' +
+        'data: {"type":"message-start"',
+    );
+
+    assertEquals(parsed.events, [
+      { type: "text-delta", id: "text-1", delta: "hello" },
+      { type: "step-end" },
+    ]);
+    assertEquals(parsed.remainder, 'data: {"type":"message-start"');
+  });
+
+  it("streams trailing final frames even when the upstream body omits the closing blank line", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode('data: {"type":"message-start","messageId":"assistant-1"}\n\n'),
+        );
+        controller.enqueue(encoder.encode('data: {"type":"text-delta","delta":"hello"}'));
+        controller.close();
+      },
+    });
+
+    const events: Array<Record<string, unknown>> = [];
+    for await (const event of streamDataStreamEvents(stream)) {
+      events.push(event);
+    }
+
+    assertEquals(events, [
+      { type: "message-start", messageId: "assistant-1" },
+      { type: "text-delta", delta: "hello" },
+    ]);
+  });
+
+  it("propagates upstream stream read errors", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encodeEvent({ type: "message-start", messageId: "assistant-1" }));
+        controller.error(new Error("stream exploded"));
+      },
+    });
+
+    await assertRejects(
+      async () => {
+        for await (const _event of streamDataStreamEvents(stream)) {
+          // drain until the read rejects
+        }
+      },
+      Error,
+      "stream exploded",
+    );
+  });
+
+  it("normalizes streamed tool input placeholders consistently", () => {
+    assertEquals(
+      stripLeadingEmptyObjectPlaceholder('{} {"query":"Veryfront"}'),
+      '{"query":"Veryfront"}',
+    );
+    assertEquals(mergeToolInputDelta("{}", '{"query":"Veryfront"}'), '{"query":"Veryfront"}');
+    assertEquals(mergeToolCallInput('{"query":"Veryfront"}', "{}"), '{"query":"Veryfront"}');
+    assertEquals(
+      parseToolInputObject('{} {"query":"Veryfront"}'),
+      { query: "Veryfront" },
+    );
+  });
+});

--- a/src/agent/data-stream.ts
+++ b/src/agent/data-stream.ts
@@ -1,0 +1,121 @@
+import type { AgUiRuntimeStreamEvent } from "./ag-ui-browser-encoder.ts";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function stripLeadingEmptyObjectPlaceholder(rawArgs: string): string {
+  let normalized = rawArgs.trim();
+
+  while (normalized.startsWith("{}") && normalized.slice(2).trimStart().startsWith("{")) {
+    normalized = normalized.slice(2).trimStart();
+  }
+
+  return normalized;
+}
+
+export function mergeToolInputDelta(currentArguments: string, nextDelta: string): string {
+  if (currentArguments === "{}" && nextDelta.trimStart().startsWith("{")) {
+    return nextDelta;
+  }
+
+  return currentArguments + nextDelta;
+}
+
+export function mergeToolCallInput(currentArguments: string, nextInput: string): string {
+  if (currentArguments.length === 0) {
+    return nextInput;
+  }
+
+  if (nextInput.trim() === "{}" && currentArguments.trim().startsWith("{")) {
+    return currentArguments;
+  }
+
+  if (currentArguments.trim() === "{}" && nextInput.trim().startsWith("{")) {
+    return nextInput;
+  }
+
+  return nextInput;
+}
+
+export function parseToolInputObject(input: unknown): Record<string, unknown> {
+  if (isRecord(input)) {
+    return input;
+  }
+
+  if (typeof input === "string") {
+    try {
+      const parsed = JSON.parse(stripLeadingEmptyObjectPlaceholder(input));
+      if (isRecord(parsed)) {
+        return parsed;
+      }
+    } catch {
+      return {};
+    }
+  }
+
+  return {};
+}
+
+export function parseDataStreamSseEvents(chunk: string): {
+  events: AgUiRuntimeStreamEvent[];
+  remainder: string;
+} {
+  const blocks = chunk.split("\n\n");
+  const remainder = blocks.pop() ?? "";
+  const events = blocks.flatMap((block) => {
+    const dataLines = block.split("\n")
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trimStart());
+
+    if (!dataLines.length) {
+      return [];
+    }
+
+    try {
+      return [JSON.parse(dataLines.join("\n")) as AgUiRuntimeStreamEvent];
+    } catch {
+      return [];
+    }
+  });
+
+  return { events, remainder };
+}
+
+export async function* streamDataStreamEvents(
+  stream: ReadableStream<Uint8Array>,
+): AsyncGenerator<AgUiRuntimeStreamEvent> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let remainder = "";
+  let completed = false;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        completed = true;
+        break;
+      }
+
+      remainder += decoder.decode(value, { stream: true });
+      const parsed = parseDataStreamSseEvents(remainder);
+      remainder = parsed.remainder;
+
+      for (const event of parsed.events) {
+        yield event;
+      }
+    }
+
+    remainder += decoder.decode();
+    const parsed = parseDataStreamSseEvents(`${remainder}\n\n`);
+    for (const event of parsed.events) {
+      yield event;
+    }
+  } finally {
+    if (!completed) {
+      await reader.cancel().catch(() => undefined);
+    }
+    reader.releaseLock();
+  }
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -159,6 +159,14 @@ export {
   mapRuntimeStreamEventToAgUiBrowserEvents,
 } from "./ag-ui-browser-encoder.ts";
 export {
+  mergeToolCallInput,
+  mergeToolInputDelta,
+  parseDataStreamSseEvents,
+  parseToolInputObject,
+  streamDataStreamEvents,
+  stripLeadingEmptyObjectPlaceholder,
+} from "./data-stream.ts";
+export {
   expandAllowedRemoteToolNames,
   getProviderNativeToolNames,
   type ProviderNativeToolInventoryOptions,

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -10,6 +10,7 @@
 
 import type { RuntimeStreamPart, RuntimeStreamResult } from "./runtime-tool-types.ts";
 import { sendSSE } from "./sse-utils.ts";
+import { mergeToolCallInput, mergeToolInputDelta, parseToolInputObject } from "../data-stream.ts";
 import { isDynamicTool } from "./tool-helpers.ts";
 import { serverLogger } from "#veryfront/utils";
 import { isAnyDebugEnabled } from "#veryfront/utils/constants/env.ts";
@@ -64,49 +65,6 @@ function normalizeToolInputString(input: unknown): string {
   }
 
   return JSON.stringify(input ?? null) ?? "null";
-}
-
-function mergeToolInputDelta(currentArguments: string, nextDelta: string): string {
-  if (currentArguments === "{}" && nextDelta.trimStart().startsWith("{")) {
-    return nextDelta;
-  }
-
-  return currentArguments + nextDelta;
-}
-
-function mergeToolCallInput(currentArguments: string, nextInput: string): string {
-  if (currentArguments.length === 0) {
-    return nextInput;
-  }
-
-  if (nextInput.trim() === "{}" && currentArguments.trim().startsWith("{")) {
-    return currentArguments;
-  }
-
-  if (currentArguments.trim() === "{}" && nextInput.trim().startsWith("{")) {
-    return nextInput;
-  }
-
-  return nextInput;
-}
-
-function normalizeToolInputObject(input: unknown): Record<string, unknown> {
-  if (isRecord(input)) {
-    return input;
-  }
-
-  if (typeof input === "string") {
-    try {
-      const parsed = JSON.parse(input);
-      if (isRecord(parsed)) {
-        return parsed;
-      }
-    } catch {
-      return {};
-    }
-  }
-
-  return {};
 }
 
 function summarizeDebugValue(value: unknown): unknown {
@@ -298,7 +256,7 @@ export function processStream(
           });
 
           const dynamic = isDynamicTool(typedPart.toolName);
-          const inputObj = normalizeToolInputObject(typedPart.input);
+          const inputObj = parseToolInputObject(typedPart.input);
           sendSSE(controller, encoder, {
             type: "tool-input-available",
             toolCallId: toolId,

--- a/src/internal-agents/ag-ui-sse.ts
+++ b/src/internal-agents/ag-ui-sse.ts
@@ -4,16 +4,15 @@ import type {
   AgUiBrowserRunFinishedMetadata,
   AgUiRuntimeStreamEvent,
 } from "../agent/ag-ui-browser-encoder.ts";
+import { parseDataStreamSseEvents } from "../agent/data-stream.ts";
 import {
   createAgUiBrowserEncoderState,
   finalizeAgUiBrowserEvents,
   mapRuntimeStreamEventToAgUiBrowserEvents,
 } from "../agent/ag-ui-browser-encoder.ts";
-import { serverLogger } from "#veryfront/utils";
 import { z } from "zod";
 
 const encoder = new TextEncoder();
-const logger = serverLogger.component("internal-agents-ag-ui-sse");
 
 type RuntimeDataEvent = AgUiRuntimeStreamEvent;
 export type RunFinishedMetadata = AgUiBrowserRunFinishedMetadata;
@@ -118,30 +117,11 @@ export function parseSseJsonEvents(chunk: string): {
   events: RuntimeDataEvent[];
   remainder: string;
 } {
-  const blocks = chunk.split("\n\n");
-  const remainder = blocks.pop() ?? "";
-  const events = blocks.flatMap((block) => {
-    const dataLines = block.split("\n")
-      .filter((line) => line.startsWith("data:"))
-      .map((line) => line.slice(5).trimStart());
-
-    if (!dataLines.length) {
-      return [];
-    }
-
-    try {
-      const payload = JSON.parse(dataLines.join("\n")) as RuntimeDataEvent;
-      return [payload];
-    } catch (error) {
-      logger.warn("Skipping malformed runtime SSE event payload", {
-        error,
-        dataLength: dataLines.join("\n").length,
-      });
-      return [];
-    }
-  });
-
-  return { events, remainder };
+  const parsed = parseDataStreamSseEvents(chunk);
+  return {
+    events: parsed.events,
+    remainder: parsed.remainder,
+  };
 }
 
 export function mapRuntimeEventToAgUi(

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.192";
+export const VERSION = "0.1.193";


### PR DESCRIPTION
## Summary
- add a public `veryfront/agent` stream helper for SSE frame parsing and tool-input normalization
- switch existing AG-UI and runtime consumers to the shared helper instead of keeping duplicated protocol logic
- bump the package version to `0.1.192`

## Why
The package had the same data-stream parsing and streamed tool-input placeholder handling in multiple places. Centralizing that logic makes the protocol surface easier to maintain and prevents downstream integrations from having to fork the same behavior.

## Tests
- `deno test --no-check --allow-all src/utils/version.test.ts src/agent/data-stream.test.ts src/internal-agents/ag-ui-sse.test.ts src/agent/ag-ui-handler.test.ts src/agent/runtime/chat-stream-handler.test.ts`
- `deno check src/utils/version-constant.ts src/agent/data-stream.ts src/agent/ag-ui-handler.ts src/agent/runtime/chat-stream-handler.ts src/internal-agents/ag-ui-sse.ts src/agent/index.ts`
- repo pre-push checks passed, including formatting, lint, typecheck, and unit tests
