### PR TITLE
Expose a public AG-UI client decoder

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.193",
+  "version": "0.1.194",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [
@@ -21,6 +21,7 @@
     "./context": "./src/react/context/index.tsx",
     "./fonts": "./src/react/fonts/index.ts",
     "./chat": "./src/chat/index.ts",
+    "./chat/ag-ui": "./src/chat/ag-ui.ts",
     "./chat/protocol": "./src/chat/protocol.ts",
     "./markdown": "./src/markdown/index.ts",
     "./mdx": "./src/mdx/index.ts",
@@ -51,6 +52,7 @@
     "veryfront/context": "./src/react/runtime/core.ts",
     "veryfront/fonts": "./src/react/fonts/index.ts",
     "veryfront/chat": "./src/chat/index.ts",
+    "veryfront/chat/ag-ui": "./src/chat/ag-ui.ts",
     "veryfront/chat/protocol": "./src/chat/protocol.ts",
     "veryfront/markdown": "./src/markdown/index.ts",
     "veryfront/mdx": "./src/mdx/index.ts",

--- a/src/chat/ag-ui.test.ts
+++ b/src/chat/ag-ui.test.ts
@@ -1,0 +1,230 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  createAgUiChatEventDecoderState,
+  decodeAgUiSseChunk,
+  flushAgUiSseChunk,
+  parseSseEvent,
+} from "./ag-ui.ts";
+
+describe("chat/ag-ui", () => {
+  it("parses SSE frames with ids, events, and multi-line data", () => {
+    const parsed = parseSseEvent(
+      'id: 12\nevent: Custom\ndata: {"name":"alpha",\ndata: "value":1}\n',
+    );
+
+    assertEquals(parsed.id, 12);
+    assertEquals(parsed.event, "Custom");
+    assertEquals(parsed.data, '{"name":"alpha",\n"value":1}');
+  });
+
+  it("decodes AG-UI SSE chunks into canonical chat stream events", () => {
+    const state = createAgUiChatEventDecoderState();
+    const result = decodeAgUiSseChunk(
+      state,
+      [
+        "id: 1",
+        "event: RunStarted",
+        'data: {"runId":"run-1","threadId":"thread-1","agentId":"veryfront"}',
+        "",
+        "id: 2",
+        "event: TextMessageStart",
+        'data: {"messageId":"msg-1","role":"assistant"}',
+        "",
+        "id: 3",
+        "event: TextMessageContent",
+        'data: {"messageId":"msg-1","delta":"Hello"}',
+        "",
+        "id: 4",
+        "event: ToolCallStart",
+        'data: {"toolCallId":"tool-1","toolCallName":"load_skill"}',
+        "",
+        "id: 5",
+        "event: ToolCallArgs",
+        'data: {"toolCallId":"tool-1","delta":"{}"}',
+        "",
+        "id: 6",
+        "event: ToolCallArgs",
+        'data: {"toolCallId":"tool-1","delta":"{\\"skillId\\":\\"plan\\"}"}',
+        "",
+        "id: 7",
+        "event: ToolCallEnd",
+        'data: {"toolCallId":"tool-1"}',
+        "",
+        "id: 8",
+        "event: ToolCallResult",
+        'data: {"toolCallId":"tool-1","result":"{\\"loaded\\":true}"}',
+        "",
+        "id: 9",
+        "event: Custom",
+        'data: {"name":"file","value":{"type":"file","url":"https://cdn.example.com/spec.md","mediaType":"text/markdown","filename":"spec.md"}}',
+        "",
+        "id: 10",
+        "event: RunFinished",
+        'data: {"metadata":{"finishReason":"stop"}}',
+        "",
+        "",
+      ].join("\n"),
+    );
+
+    assertEquals(result.events.map((entry) => entry.eventId), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    assertEquals(state.lastEventId, 10);
+    assertEquals(result.remainder, "");
+
+    const chatEvents = result.events.flatMap((entry) => entry.chatEvents);
+    assertEquals(chatEvents, [
+      {
+        type: "start",
+        messageMetadata: { agentId: "veryfront", runId: "run-1", threadId: "thread-1" },
+      },
+      { type: "text-start", id: "msg-1" },
+      { type: "text-delta", id: "msg-1", delta: "Hello" },
+      {
+        type: "tool-input-start",
+        toolCallId: "tool-1",
+        toolName: "load_skill",
+        providerExecuted: true,
+      },
+      { type: "tool-input-delta", toolCallId: "tool-1", inputTextDelta: "{}" },
+      { type: "tool-input-delta", toolCallId: "tool-1", inputTextDelta: '{"skillId":"plan"}' },
+      {
+        type: "tool-input-available",
+        toolCallId: "tool-1",
+        toolName: "load_skill",
+        input: { skillId: "plan" },
+        providerExecuted: true,
+      },
+      {
+        type: "tool-output-available",
+        toolCallId: "tool-1",
+        output: { loaded: true },
+        providerExecuted: true,
+      },
+      {
+        type: "file",
+        url: "https://cdn.example.com/spec.md",
+        mediaType: "text/markdown",
+        filename: "spec.md",
+      },
+      { type: "finish", finishReason: "stop" },
+    ]);
+  });
+
+  it("flushes a final AG-UI SSE frame without a trailing blank line", () => {
+    const state = createAgUiChatEventDecoderState();
+    const initial = decodeAgUiSseChunk(
+      state,
+      'id: 1\nevent: TextMessageContent\ndata: {"messageId":"msg-1","delta":"partial"}',
+    );
+
+    assertEquals(initial.events, []);
+    assertEquals(initial.remainder.length > 0, true);
+
+    const flushed = flushAgUiSseChunk(state);
+    assertEquals(flushed.events.map((entry) => entry.eventId), [1]);
+    assertEquals(flushed.events[0]?.chatEvents, [{
+      type: "text-delta",
+      id: "msg-1",
+      delta: "partial",
+    }]);
+    assertEquals(flushed.remainder, "");
+  });
+
+  it("ignores duplicate and malformed frames while advancing the SSE cursor", () => {
+    const state = createAgUiChatEventDecoderState({ lastEventId: 2 });
+    const result = decodeAgUiSseChunk(
+      state,
+      [
+        "id: 2",
+        "event: TextMessageContent",
+        'data: {"messageId":"msg-1","delta":"old"}',
+        "",
+        "id: 3",
+        "event: ToolCallStart",
+        "data: not-json",
+        "",
+        "id: 4",
+        "event: UnsupportedEvent",
+        'data: {"foo":"bar"}',
+        "",
+        "",
+      ].join("\n"),
+    );
+
+    assertEquals(result.events, []);
+    assertEquals(state.lastEventId, 4);
+  });
+
+  it("maps cancellation errors to abort events", () => {
+    const state = createAgUiChatEventDecoderState();
+    const result = decodeAgUiSseChunk(
+      state,
+      'event: RunError\ndata: {"code":"CANCELLED","message":"Stopped"}\n\n',
+    );
+
+    assertEquals(result.events.length, 1);
+    assertEquals(result.events[0]?.chatEvents, [{ type: "abort" }]);
+  });
+
+  it("preserves non-renderable custom events as data chunks", () => {
+    const state = createAgUiChatEventDecoderState();
+    const result = decodeAgUiSseChunk(
+      state,
+      'event: Custom\ndata: {"name":"progress","value":{"percent":42}}\n\n',
+    );
+
+    assertEquals(result.events.length, 1);
+    assertEquals(result.events[0]?.chatEvents, [
+      { type: "data-progress", data: { percent: 42 } },
+    ]);
+  });
+
+  it("emits tool output errors when AG-UI result payloads are marked as failures", () => {
+    const state = createAgUiChatEventDecoderState();
+    const result = decodeAgUiSseChunk(
+      state,
+      [
+        "event: ToolCallStart",
+        'data: {"toolCallId":"tool-err","toolCallName":"search"}',
+        "",
+        "event: ToolCallResult",
+        'data: {"toolCallId":"tool-err","result":{"message":"No results"},"isError":true}',
+        "",
+        "",
+      ].join("\n"),
+    );
+
+    const chatEvents = result.events.flatMap((entry) => entry.chatEvents);
+    assertEquals(chatEvents, [
+      {
+        type: "tool-input-start",
+        toolCallId: "tool-err",
+        toolName: "search",
+        providerExecuted: true,
+      },
+      {
+        type: "tool-output-error",
+        toolCallId: "tool-err",
+        errorText: "No results",
+        providerExecuted: true,
+      },
+    ]);
+  });
+
+  it("retains decoded wire events alongside canonical chat events", () => {
+    const state = createAgUiChatEventDecoderState();
+    const result = decodeAgUiSseChunk(
+      state,
+      'id: 7\nevent: StateDelta\ndata: {"delta":{"phase":"planning"}}\n\n',
+    );
+
+    assertEquals(result.events.length, 1);
+    assertExists(result.events[0]);
+    assertEquals(result.events[0].eventId, 7);
+    assertEquals(result.events[0].wireEvent.eventName, "StateDelta");
+    assertEquals(result.events[0].chatEvents, [{
+      type: "data-state-delta",
+      data: { phase: "planning" },
+    }]);
+  });
+});

--- a/src/chat/ag-ui.ts
+++ b/src/chat/ag-ui.ts
@@ -1,0 +1,737 @@
+import { mergeToolInputDelta, parseToolInputObject } from "../agent/data-stream.ts";
+import type { ChatFinishReason, ChatStreamEvent } from "./protocol.ts";
+import { z } from "zod";
+
+type JsonPatchOperation = {
+  op: "add" | "remove" | "replace" | "move" | "copy" | "test";
+  path: string;
+  from?: string;
+  value?: unknown;
+};
+
+type ParsedRenderableCustomChunk = Extract<
+  ChatStreamEvent,
+  { type: "source-url" | "source-document" | "file" }
+>;
+
+type ToolCallState = {
+  toolName: string;
+  argsText: string;
+};
+
+export type ParsedSseEvent = {
+  id: number | null;
+  event: string | null;
+  data: string;
+};
+
+export type AgUiDecodedEvent = {
+  eventId: number | null;
+  wireEvent: AgUiWireEvent;
+  chatEvents: ChatStreamEvent[];
+};
+
+export type AgUiDecodedChunk = {
+  events: AgUiDecodedEvent[];
+  remainder: string;
+};
+
+export type AgUiChatEventDecoderState = {
+  remainder: string;
+  lastEventId: number;
+  toolCalls: Map<string, ToolCallState>;
+  reasoningFallbackIndex: number;
+};
+
+export const AgUiRunFinishedMetadataSchema = z.object({
+  provider: z.string().optional(),
+  model: z.string().optional(),
+  inputTokens: z.number().int().nonnegative().optional(),
+  outputTokens: z.number().int().nonnegative().optional(),
+  totalTokens: z.number().int().nonnegative().optional(),
+  cachedInputTokens: z.number().int().nonnegative().optional(),
+  reasoningTokens: z.number().int().nonnegative().optional(),
+  finishReason: z.string().optional(),
+  providerRequestId: z.string().optional(),
+});
+
+export const AgUiSnapshotToolCallSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal("function"),
+  function: z.object({
+    name: z.string().min(1),
+    arguments: z.string(),
+  }),
+  encryptedValue: z.string().optional(),
+});
+
+const AgUiUserInputContentSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("text"),
+    text: z.string(),
+  }),
+  z.object({
+    type: z.literal("binary"),
+    mimeType: z.string(),
+    id: z.string().optional(),
+    url: z.string().optional(),
+    data: z.string().optional(),
+    filename: z.string().optional(),
+  }),
+]);
+
+export const AgUiSnapshotMessageSchema = z.discriminatedUnion("role", [
+  z.object({
+    id: z.string(),
+    role: z.literal("assistant"),
+    content: z.string().optional(),
+    name: z.string().optional(),
+    encryptedValue: z.string().optional(),
+    toolCalls: z.array(AgUiSnapshotToolCallSchema).optional(),
+  }),
+  z.object({
+    id: z.string(),
+    role: z.literal("user"),
+    content: z.union([z.string(), z.array(AgUiUserInputContentSchema)]),
+    name: z.string().optional(),
+    encryptedValue: z.string().optional(),
+  }),
+  z.object({
+    id: z.string(),
+    role: z.literal("tool"),
+    toolCallId: z.string(),
+    content: z.string(),
+    error: z.string().optional(),
+    encryptedValue: z.string().optional(),
+  }),
+  z.object({
+    id: z.string(),
+    role: z.literal("reasoning"),
+    content: z.string(),
+    name: z.string().optional(),
+    encryptedValue: z.string().optional(),
+  }),
+]);
+
+export const AgUiWireEventNameSchema = z.enum([
+  "RunStarted",
+  "Custom",
+  "TextMessageStart",
+  "TextMessageContent",
+  "TextMessageEnd",
+  "ToolCallStart",
+  "ToolCallArgs",
+  "ToolCallChunk",
+  "ToolCallEnd",
+  "ToolCallResult",
+  "StateSnapshot",
+  "MessagesSnapshot",
+  "ReasoningMessageStart",
+  "ReasoningMessageContent",
+  "ReasoningMessageEnd",
+  "StateDelta",
+  "RunFinished",
+  "RunError",
+]);
+
+export const AgUiWireEventSchema = z.discriminatedUnion("eventName", [
+  z.object({
+    eventName: z.literal("RunStarted"),
+    payload: z.object({
+      runId: z.string().optional(),
+      threadId: z.string().optional(),
+      agentId: z.string().optional(),
+    }),
+  }),
+  z.object({
+    eventName: z.literal("Custom"),
+    payload: z.object({
+      name: z.string(),
+      value: z.unknown(),
+    }),
+  }),
+  z.object({
+    eventName: z.literal("TextMessageStart"),
+    payload: z.object({
+      messageId: z.string().min(1),
+      id: z.string().min(1).optional(),
+      contentId: z.string().min(1).optional(),
+      role: z.string().optional(),
+    }),
+  }),
+  z.object({
+    eventName: z.literal("TextMessageContent"),
+    payload: z.object({
+      messageId: z.string().min(1),
+      id: z.string().min(1).optional(),
+      contentId: z.string().min(1).optional(),
+      delta: z.string(),
+    }),
+  }),
+  z.object({
+    eventName: z.literal("TextMessageEnd"),
+    payload: z.object({
+      messageId: z.string().min(1),
+      id: z.string().min(1).optional(),
+      contentId: z.string().min(1).optional(),
+    }),
+  }),
+  z.object({
+    eventName: z.literal("ToolCallStart"),
+    payload: z.object({
+      toolCallId: z.string().min(1),
+      toolCallName: z.string().min(1),
+    }),
+  }),
+  z.object({
+    eventName: z.literal("ToolCallArgs"),
+    payload: z.object({
+      toolCallId: z.string().min(1),
+      delta: z.string(),
+    }),
+  }),
+  z.object({
+    eventName: z.literal("ToolCallChunk"),
+    payload: z.object({
+      toolCallId: z.string().min(1),
+      delta: z.string(),
+    }),
+  }),
+  z.object({
+    eventName: z.literal("ToolCallEnd"),
+    payload: z.object({
+      toolCallId: z.string().min(1),
+    }),
+  }),
+  z.object({
+    eventName: z.literal("ToolCallResult"),
+    payload: z.object({
+      messageId: z.string().min(1).optional(),
+      toolCallId: z.string().min(1),
+      content: z.unknown().optional(),
+      result: z.unknown().optional(),
+      role: z.literal("tool").optional(),
+      isError: z.boolean().optional(),
+    }),
+  }),
+  z.object({
+    eventName: z.literal("StateSnapshot"),
+    payload: z.object({
+      snapshot: z.record(z.string(), z.unknown()),
+    }),
+  }),
+  z.object({
+    eventName: z.literal("MessagesSnapshot"),
+    payload: z.object({
+      messages: z.array(AgUiSnapshotMessageSchema),
+    }),
+  }),
+  z.object({
+    eventName: z.literal("ReasoningMessageStart"),
+    payload: z.object({
+      id: z.string().optional(),
+      messageId: z.string().min(1).optional(),
+      role: z.string().optional(),
+    }),
+  }),
+  z.object({
+    eventName: z.literal("ReasoningMessageContent"),
+    payload: z.object({
+      id: z.string().optional(),
+      messageId: z.string().min(1).optional(),
+      delta: z.string(),
+    }),
+  }),
+  z.object({
+    eventName: z.literal("ReasoningMessageEnd"),
+    payload: z.object({
+      id: z.string().optional(),
+      messageId: z.string().min(1).optional(),
+    }),
+  }),
+  z.object({
+    eventName: z.literal("StateDelta"),
+    payload: z.object({
+      delta: z.union([
+        z.record(z.string(), z.unknown()),
+        z.array(
+          z.object({
+            op: z.enum(["add", "remove", "replace", "move", "copy", "test"]),
+            path: z.string().min(1),
+            from: z.string().min(1).optional(),
+            value: z.unknown().optional(),
+          }),
+        ),
+      ]),
+    }),
+  }),
+  z.object({
+    eventName: z.literal("RunFinished"),
+    payload: z.object({
+      metadata: AgUiRunFinishedMetadataSchema.optional(),
+    }),
+  }),
+  z.object({
+    eventName: z.literal("RunError"),
+    payload: z.object({
+      code: z.string().optional(),
+      message: z.string().optional(),
+    }),
+  }),
+]);
+
+export type AgUiRunFinishedMetadata = z.infer<typeof AgUiRunFinishedMetadataSchema>;
+export type AgUiSnapshotMessage = z.infer<typeof AgUiSnapshotMessageSchema>;
+export type AgUiWireEventName = z.infer<typeof AgUiWireEventNameSchema>;
+export type AgUiWireEvent = z.infer<typeof AgUiWireEventSchema>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeNewlines(value: string): string {
+  return value.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function toRenderableCustomChunk(value: unknown): ParsedRenderableCustomChunk | null {
+  if (!isRecord(value) || typeof value.type !== "string") {
+    return null;
+  }
+
+  if (value.type === "source-url" && typeof value.url === "string") {
+    return {
+      type: "source-url",
+      sourceId: typeof value.sourceId === "string" && value.sourceId.length > 0
+        ? value.sourceId
+        : value.url,
+      url: value.url,
+      ...(typeof value.title === "string" ? { title: value.title } : {}),
+    };
+  }
+
+  if (
+    value.type === "source-document" &&
+    typeof value.sourceId === "string" &&
+    typeof value.mediaType === "string" &&
+    typeof value.title === "string"
+  ) {
+    return {
+      type: "source-document",
+      sourceId: value.sourceId,
+      mediaType: value.mediaType,
+      title: value.title,
+      ...(typeof value.filename === "string" ? { filename: value.filename } : {}),
+    };
+  }
+
+  if (
+    value.type === "file" && typeof value.url === "string" && typeof value.mediaType === "string"
+  ) {
+    return {
+      type: "file",
+      url: value.url,
+      mediaType: value.mediaType,
+      ...(typeof value.filename === "string" ? { filename: value.filename } : {}),
+    };
+  }
+
+  return null;
+}
+
+function parseSerializedToolResult(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const trimmed = value.trim();
+  if (
+    !trimmed.startsWith("{") &&
+    !trimmed.startsWith("[") &&
+    trimmed !== "null" &&
+    trimmed !== "true" &&
+    trimmed !== "false" &&
+    !/^[-]?\d+(\.\d+)?$/.test(trimmed)
+  ) {
+    return value;
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
+function formatToolErrorText(result: unknown): string {
+  if (typeof result === "string" && result.length > 0) {
+    return result;
+  }
+
+  if (isRecord(result)) {
+    if (typeof result.error === "string" && result.error.length > 0) {
+      return result.error;
+    }
+
+    if (typeof result.message === "string" && result.message.length > 0) {
+      return result.message;
+    }
+  }
+
+  return JSON.stringify(result ?? { error: "Tool execution failed" });
+}
+
+function mapFinishReason(reason: string | undefined): ChatFinishReason | undefined {
+  if (!reason) return undefined;
+
+  switch (reason.trim().toLowerCase()) {
+    case "stop":
+    case "end_turn":
+    case "stop_sequence":
+      return "stop";
+    case "length":
+    case "max_tokens":
+      return "length";
+    case "tool_calls":
+    case "tool_use":
+      return "tool-calls";
+    case "content_filter":
+    case "content-filter":
+      return "content-filter";
+    case "error":
+      return "error";
+    default:
+      return "other";
+  }
+}
+
+function getReasoningPartId(
+  state: AgUiChatEventDecoderState,
+  payload: { id?: string; messageId?: string },
+): string {
+  if (typeof payload.id === "string" && payload.id.length > 0) {
+    return payload.id;
+  }
+
+  if (typeof payload.messageId === "string" && payload.messageId.length > 0) {
+    return `agui-reasoning:${payload.messageId}`;
+  }
+
+  state.reasoningFallbackIndex += 1;
+  return `agui-reasoning:${state.reasoningFallbackIndex}`;
+}
+
+function splitSseFrames(value: string): { frames: string[]; remainder: string } {
+  const blocks = value.split("\n\n");
+  return {
+    frames: blocks.slice(0, -1),
+    remainder: blocks.at(-1) ?? "",
+  };
+}
+
+function isCommentOnlySseFrame(raw: string): boolean {
+  return raw
+    .split("\n")
+    .every((line) => line.trim().length === 0 || line.trimStart().startsWith(":"));
+}
+
+function parseAgUiWireEvent(frame: ParsedSseEvent): AgUiWireEvent | null {
+  if (frame.data === "[DONE]" || !frame.event || !frame.data) {
+    return null;
+  }
+
+  const eventName = AgUiWireEventNameSchema.safeParse(frame.event);
+  if (!eventName.success) {
+    return null;
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(frame.data);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const parsed = AgUiWireEventSchema.safeParse({
+    eventName: eventName.data,
+    payload,
+  });
+
+  return parsed.success ? parsed.data : null;
+}
+
+function mapWireEventToChatEvents(
+  state: AgUiChatEventDecoderState,
+  wireEvent: AgUiWireEvent,
+): ChatStreamEvent[] {
+  switch (wireEvent.eventName) {
+    case "RunStarted":
+      return [{
+        type: "start",
+        messageMetadata: wireEvent.payload,
+      }];
+
+    case "TextMessageStart":
+      return [{
+        type: "text-start",
+        id: wireEvent.payload.messageId,
+      }];
+
+    case "TextMessageContent":
+      return [{
+        type: "text-delta",
+        id: wireEvent.payload.messageId,
+        delta: wireEvent.payload.delta,
+      }];
+
+    case "TextMessageEnd":
+      return [{
+        type: "text-end",
+        id: wireEvent.payload.messageId,
+      }];
+
+    case "ReasoningMessageStart":
+      return [{
+        type: "reasoning-start",
+        id: getReasoningPartId(state, wireEvent.payload),
+      }];
+
+    case "ReasoningMessageContent":
+      return [{
+        type: "reasoning-delta",
+        id: getReasoningPartId(state, wireEvent.payload),
+        delta: wireEvent.payload.delta,
+      }];
+
+    case "ReasoningMessageEnd":
+      return [{
+        type: "reasoning-end",
+        id: getReasoningPartId(state, wireEvent.payload),
+      }];
+
+    case "ToolCallStart":
+      state.toolCalls.set(wireEvent.payload.toolCallId, {
+        toolName: wireEvent.payload.toolCallName,
+        argsText: "",
+      });
+      return [{
+        type: "tool-input-start",
+        toolCallId: wireEvent.payload.toolCallId,
+        toolName: wireEvent.payload.toolCallName,
+        providerExecuted: true,
+      }];
+
+    case "ToolCallArgs":
+    case "ToolCallChunk": {
+      const toolCall = state.toolCalls.get(wireEvent.payload.toolCallId);
+      if (!toolCall) {
+        return [];
+      }
+
+      toolCall.argsText = mergeToolInputDelta(toolCall.argsText, wireEvent.payload.delta);
+      return [{
+        type: "tool-input-delta",
+        toolCallId: wireEvent.payload.toolCallId,
+        inputTextDelta: wireEvent.payload.delta,
+      }];
+    }
+
+    case "ToolCallEnd": {
+      const toolCall = state.toolCalls.get(wireEvent.payload.toolCallId);
+      if (!toolCall) {
+        return [];
+      }
+
+      return [{
+        type: "tool-input-available",
+        toolCallId: wireEvent.payload.toolCallId,
+        toolName: toolCall.toolName,
+        input: parseToolInputObject(toolCall.argsText),
+        providerExecuted: true,
+      }];
+    }
+
+    case "ToolCallResult": {
+      const toolCall = state.toolCalls.get(wireEvent.payload.toolCallId);
+      const parsedResult = parseSerializedToolResult(
+        wireEvent.payload.content ?? wireEvent.payload.result,
+      );
+
+      if (wireEvent.payload.isError) {
+        return [{
+          type: "tool-output-error",
+          toolCallId: wireEvent.payload.toolCallId,
+          errorText: formatToolErrorText(parsedResult),
+          providerExecuted: true,
+        }];
+      }
+
+      const events: ChatStreamEvent[] = [];
+      if (!toolCall) {
+        events.push({
+          type: "tool-input-available",
+          toolCallId: wireEvent.payload.toolCallId,
+          toolName: "tool",
+          input: {},
+          dynamic: true,
+          providerExecuted: true,
+        });
+      }
+
+      events.push({
+        type: "tool-output-available",
+        toolCallId: wireEvent.payload.toolCallId,
+        output: parsedResult,
+        providerExecuted: true,
+      });
+      return events;
+    }
+
+    case "StateSnapshot":
+      return [{ type: "data-state-snapshot", data: wireEvent.payload.snapshot }];
+
+    case "StateDelta":
+      return [{
+        type: "data-state-delta",
+        data: wireEvent.payload.delta as Record<string, unknown> | JsonPatchOperation[],
+      }];
+
+    case "MessagesSnapshot":
+      return [{ type: "data-messages-snapshot", data: wireEvent.payload.messages }];
+
+    case "Custom": {
+      const renderableChunk = toRenderableCustomChunk(wireEvent.payload.value);
+      if (renderableChunk) {
+        return [renderableChunk];
+      }
+
+      return [{
+        type: `data-${wireEvent.payload.name}`,
+        data: wireEvent.payload.value,
+      }];
+    }
+
+    case "RunFinished":
+      return [{
+        type: "finish",
+        ...(mapFinishReason(wireEvent.payload.metadata?.finishReason)
+          ? { finishReason: mapFinishReason(wireEvent.payload.metadata?.finishReason) }
+          : {}),
+      }];
+
+    case "RunError":
+      if (wireEvent.payload.code === "CANCELLED") {
+        return [{ type: "abort" }];
+      }
+
+      return [{
+        type: "error",
+        errorText: wireEvent.payload.message?.length
+          ? wireEvent.payload.message
+          : "Conversation agent run failed",
+      }];
+  }
+}
+
+export function parseSseEvent(raw: string): ParsedSseEvent {
+  let id: number | null = null;
+  let event: string | null = null;
+  const dataLines: string[] = [];
+
+  for (const line of raw.split("\n")) {
+    if (!line || line.startsWith(":")) {
+      continue;
+    }
+
+    if (line.startsWith("id:")) {
+      const parsed = Number(line.slice(3).trim());
+      if (Number.isFinite(parsed)) {
+        id = parsed;
+      }
+      continue;
+    }
+
+    if (line.startsWith("event:")) {
+      const value = line.slice(6).trim();
+      event = value.length > 0 ? value : null;
+      continue;
+    }
+
+    if (line.startsWith("data:")) {
+      const value = line.slice(5);
+      dataLines.push(value.startsWith(" ") ? value.slice(1) : value);
+    }
+  }
+
+  return { id, event, data: dataLines.join("\n") };
+}
+
+export function createAgUiChatEventDecoderState(
+  input: {
+    lastEventId?: number;
+  } = {},
+): AgUiChatEventDecoderState {
+  return {
+    remainder: "",
+    lastEventId: input.lastEventId ?? -1,
+    toolCalls: new Map<string, ToolCallState>(),
+    reasoningFallbackIndex: 0,
+  };
+}
+
+export function decodeAgUiSseChunk(
+  state: AgUiChatEventDecoderState,
+  chunk: string,
+): AgUiDecodedChunk {
+  const normalized = `${state.remainder}${normalizeNewlines(chunk)}`;
+  const { frames, remainder } = splitSseFrames(normalized);
+  state.remainder = remainder;
+
+  const events: AgUiDecodedEvent[] = [];
+
+  for (const rawFrame of frames) {
+    if (isCommentOnlySseFrame(rawFrame)) {
+      continue;
+    }
+
+    const frame = parseSseEvent(rawFrame);
+    if (frame.id !== null) {
+      if (frame.id <= state.lastEventId) {
+        continue;
+      }
+      state.lastEventId = frame.id;
+    }
+
+    const wireEvent = parseAgUiWireEvent(frame);
+    if (!wireEvent) {
+      continue;
+    }
+
+    events.push({
+      eventId: frame.id,
+      wireEvent,
+      chatEvents: mapWireEventToChatEvents(state, wireEvent),
+    });
+  }
+
+  return {
+    events,
+    remainder: state.remainder,
+  };
+}
+
+export function flushAgUiSseChunk(state: AgUiChatEventDecoderState): AgUiDecodedChunk {
+  if (state.remainder.length === 0) {
+    return { events: [], remainder: "" };
+  }
+
+  const flushed = decodeAgUiSseChunk(state, "\n\n");
+  state.remainder = "";
+  return {
+    events: flushed.events,
+    remainder: "",
+  };
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.193";
+export const VERSION = "0.1.194";


### PR DESCRIPTION
## Summary
- add a public `veryfront/chat/ag-ui` client-side decoder for AG-UI SSE streams
- centralize AG-UI wire-event validation and canonical chat-event mapping
- bump the package patch version to `0.1.194`

## Testing
- `deno test --no-check --allow-all src/chat/index.test.ts src/chat/ag-ui.test.ts`
- `deno check src/chat/ag-ui.ts`
- `deno fmt --check src/chat/ag-ui.ts src/chat/ag-ui.test.ts deno.json src/utils/version-constant.ts`
- `deno eval` import smoke for `veryfront/chat/ag-ui`