### PR TITLE
Stabilize fallback AG-UI reasoning ids

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.194",
+  "version": "0.1.195",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/chat/ag-ui.test.ts
+++ b/src/chat/ag-ui.test.ts
@@ -166,6 +166,33 @@ describe("chat/ag-ui", () => {
     assertEquals(result.events[0]?.chatEvents, [{ type: "abort" }]);
   });
 
+  it("keeps fallback reasoning ids stable across start, delta, and end", () => {
+    const state = createAgUiChatEventDecoderState();
+    const result = decodeAgUiSseChunk(
+      state,
+      [
+        "event: ReasoningMessageStart",
+        'data: {"role":"assistant"}',
+        "",
+        "event: ReasoningMessageContent",
+        'data: {"delta":"Thinking"}',
+        "",
+        "event: ReasoningMessageEnd",
+        "data: {}",
+        "",
+        "",
+      ].join("\n"),
+    );
+
+    const chatEvents = result.events.flatMap((entry) => entry.chatEvents);
+    assertEquals(chatEvents, [
+      { type: "reasoning-start", id: "agui-reasoning:1" },
+      { type: "reasoning-delta", id: "agui-reasoning:1", delta: "Thinking" },
+      { type: "reasoning-end", id: "agui-reasoning:1" },
+    ]);
+    assertEquals(state.activeFallbackReasoningPartId, null);
+  });
+
   it("preserves non-renderable custom events as data chunks", () => {
     const state = createAgUiChatEventDecoderState();
     const result = decodeAgUiSseChunk(

--- a/src/chat/ag-ui.ts
+++ b/src/chat/ag-ui.ts
@@ -41,6 +41,7 @@ export type AgUiChatEventDecoderState = {
   lastEventId: number;
   toolCalls: Map<string, ToolCallState>;
   reasoningFallbackIndex: number;
+  activeFallbackReasoningPartId: string | null;
 };
 
 export const AgUiRunFinishedMetadataSchema = z.object({
@@ -407,6 +408,7 @@ function mapFinishReason(reason: string | undefined): ChatFinishReason | undefin
 function getReasoningPartId(
   state: AgUiChatEventDecoderState,
   payload: { id?: string; messageId?: string },
+  phase: "start" | "content" | "end",
 ): string {
   if (typeof payload.id === "string" && payload.id.length > 0) {
     return payload.id;
@@ -416,8 +418,20 @@ function getReasoningPartId(
     return `agui-reasoning:${payload.messageId}`;
   }
 
+  if (state.activeFallbackReasoningPartId) {
+    const fallbackId = state.activeFallbackReasoningPartId;
+    if (phase === "end") {
+      state.activeFallbackReasoningPartId = null;
+    }
+    return fallbackId;
+  }
+
   state.reasoningFallbackIndex += 1;
-  return `agui-reasoning:${state.reasoningFallbackIndex}`;
+  const fallbackId = `agui-reasoning:${state.reasoningFallbackIndex}`;
+  if (phase !== "end") {
+    state.activeFallbackReasoningPartId = fallbackId;
+  }
+  return fallbackId;
 }
 
 function splitSseFrames(value: string): { frames: string[]; remainder: string } {
@@ -496,20 +510,20 @@ function mapWireEventToChatEvents(
     case "ReasoningMessageStart":
       return [{
         type: "reasoning-start",
-        id: getReasoningPartId(state, wireEvent.payload),
+        id: getReasoningPartId(state, wireEvent.payload, "start"),
       }];
 
     case "ReasoningMessageContent":
       return [{
         type: "reasoning-delta",
-        id: getReasoningPartId(state, wireEvent.payload),
+        id: getReasoningPartId(state, wireEvent.payload, "content"),
         delta: wireEvent.payload.delta,
       }];
 
     case "ReasoningMessageEnd":
       return [{
         type: "reasoning-end",
-        id: getReasoningPartId(state, wireEvent.payload),
+        id: getReasoningPartId(state, wireEvent.payload, "end"),
       }];
 
     case "ToolCallStart":
@@ -679,6 +693,7 @@ export function createAgUiChatEventDecoderState(
     lastEventId: input.lastEventId ?? -1,
     toolCalls: new Map<string, ToolCallState>(),
     reasoningFallbackIndex: 0,
+    activeFallbackReasoningPartId: null,
   };
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.194";
+export const VERSION = "0.1.195";


### PR DESCRIPTION
## Summary\n- keep fallback AG-UI reasoning ids stable across start, delta, and end events\n- clear the active fallback id when the reasoning block ends\n- add regression coverage and bump the patch version to 0.1.195\n\n## Testing\n- deno test --no-check --allow-all src/chat/index.test.ts src/chat/ag-ui.test.ts\n- deno check src/chat/ag-ui.ts\n- deno fmt --check src/chat/ag-ui.ts src/chat/ag-ui.test.ts deno.json src/utils/version-constant.ts\n