### PR TITLE
Keep AG-UI chat helpers browser-safe in the npm package

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.195",
+  "version": "0.1.196",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -195,6 +195,24 @@ await build({
 			"dnt polyfill process.argv[1] fix",
 		);
 
+		// Keep browser-safe chat helpers free of dnt Node polyfill imports.
+		// These modules are consumed directly in client bundles and do not rely on
+		// any Node-only globals, so retaining the injected side-effect import only
+		// bloats the graph and breaks browser builds.
+		for (const path of [
+			"./npm/esm/src/chat/ag-ui.js",
+			"./npm/esm/src/chat/ag-ui.d.ts",
+			"./npm/esm/src/chat/protocol.js",
+			"./npm/esm/src/chat/protocol.d.ts",
+		]) {
+			patchFile(
+				path,
+				'import "../../_dnt.polyfills.js";\n',
+				"",
+				"browser-safe chat module polyfill removal",
+			);
+		}
+
 		// Note: Templates are now embedded in manifest.json which is bundled by dnt
 		// No need to copy template files separately
 

--- a/scripts/docs/verify-npm-exports.mjs
+++ b/scripts/docs/verify-npm-exports.mjs
@@ -73,6 +73,8 @@ const REQUIRED_EXPORTS = {
   "./fs": ["readTextFile", "writeTextFile", "join", "resolve", "exists", "mkdir"],
 };
 
+const BROWSER_SAFE_EXPORTS = ["./chat/ag-ui", "./chat/protocol"];
+
 let passed = 0;
 let failed = 0;
 const errors = [];
@@ -130,8 +132,39 @@ if (!cliEntry) {
   }
 }
 
+for (const exportPath of BROWSER_SAFE_EXPORTS) {
+  const target = exports[exportPath];
+  const label = `veryfront/${exportPath.replace("./", "")}`;
+
+  if (!target) {
+    failed++;
+    errors.push(`  ${label}: missing deno.json export entry`);
+    console.log(`  FAIL  ${label} — missing deno.json export entry`);
+    continue;
+  }
+
+  const builtFile = resolve(NPM_DIR, "esm", target.replace(/\.tsx?$/, ".js"));
+  if (!existsSync(builtFile)) {
+    failed++;
+    errors.push(`  ${label}: missing built file ${builtFile}`);
+    console.log(`  FAIL  ${label} — missing built file`);
+    continue;
+  }
+
+  const content = readFileSync(builtFile, "utf8");
+  if (content.includes('_dnt.polyfills.js')) {
+    failed++;
+    errors.push(`  ${label}: should not import _dnt.polyfills.js`);
+    console.log(`  FAIL  ${label} — still imports _dnt.polyfills.js`);
+    continue;
+  }
+
+  passed++;
+  console.log(`  OK    ${label} (browser-safe entry)`);
+}
+
 console.log();
-console.log(`${passed} passed, ${failed} failed out of ${moduleExports.length + 1} export paths`);
+console.log(`${passed} passed, ${failed} failed out of ${moduleExports.length + 1 + BROWSER_SAFE_EXPORTS.length} export paths`);
 
 if (errors.length > 0) {
   console.log("\nErrors:");

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.195";
+export const VERSION = "0.1.196";


### PR DESCRIPTION
## Summary
- strip the dnt polyfill side-effect import from the published `chat/ag-ui` and `chat/protocol` npm artifacts
- add a distribution verification step that fails if those browser-safe chat entries regress
- bump the npm package version to `0.1.196`

## Why
The public AG-UI decoder is now consumed in browser bundles. These chat helpers do not need the Node-oriented dnt polyfill shim, and keeping that import in the published output breaks browser builds while also widening the client graph unnecessarily.

## Verification
- `deno task build:npm`
- `deno fmt --check scripts/build/build-npm-dnt.ts scripts/docs/verify-npm-exports.mjs deno.json src/utils/version-constant.ts`
- `rg -n "_dnt\.polyfills\.js" npm/esm/src/chat`
- `npm pack`
- local `veryfront-studio` `npm run build` against `veryfront-0.1.196.tgz`

## Notes
- `node scripts/docs/verify-npm-exports.mjs` still reports the pre-existing unrelated `veryfront/chat` `AIErrorBoundary` expectation; the new browser-safe checks added in this PR pass.
