### PR TITLE
Add opt-in strict validation for AG-UI SSE decoding

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.196",
+  "version": "0.1.197",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/chat/ag-ui.test.ts
+++ b/src/chat/ag-ui.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   createAgUiChatEventDecoderState,
@@ -153,6 +153,59 @@ describe("chat/ag-ui", () => {
 
     assertEquals(result.events, []);
     assertEquals(state.lastEventId, 4);
+  });
+
+  it("reports invalid JSON frames in strict mode without throwing", () => {
+    const invalidFrames: Array<{ eventName: string | null; dataLength: number }> = [];
+    const state = createAgUiChatEventDecoderState({
+      validationMode: "strict",
+      onInvalidJson: (details) => invalidFrames.push(details),
+    });
+    const result = decodeAgUiSseChunk(
+      state,
+      [
+        "id: 3",
+        "event: ToolCallStart",
+        "data: not-json",
+        "",
+        "",
+      ].join("\n"),
+    );
+
+    assertEquals(result.events, []);
+    assertEquals(state.lastEventId, 3);
+    assertEquals(invalidFrames, [{ eventName: "ToolCallStart", dataLength: 8 }]);
+  });
+
+  it("throws on malformed handled payloads in strict mode", () => {
+    const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
+
+    assertThrows(
+      () =>
+        decodeAgUiSseChunk(
+          state,
+          'id: 1\nevent: RunFinished\ndata: {"metadata":"bad"}\n\n',
+        ),
+      Error,
+      "Malformed AG-UI event payload for RunFinished",
+    );
+  });
+
+  it("throws on malformed trailing handled payloads when flushed in strict mode", () => {
+    const state = createAgUiChatEventDecoderState({ validationMode: "strict" });
+    const initial = decodeAgUiSseChunk(
+      state,
+      'id: 1\nevent: RunFinished\ndata: {"metadata":"bad"}',
+    );
+
+    assertEquals(initial.events, []);
+    assertEquals(initial.remainder.length > 0, true);
+
+    assertThrows(
+      () => flushAgUiSseChunk(state),
+      Error,
+      "Malformed AG-UI event payload for RunFinished",
+    );
   });
 
   it("maps cancellation errors to abort events", () => {

--- a/src/chat/ag-ui.ts
+++ b/src/chat/ag-ui.ts
@@ -36,12 +36,16 @@ export type AgUiDecodedChunk = {
   remainder: string;
 };
 
+export type AgUiDecoderValidationMode = "permissive" | "strict";
+
 export type AgUiChatEventDecoderState = {
   remainder: string;
   lastEventId: number;
   toolCalls: Map<string, ToolCallState>;
   reasoningFallbackIndex: number;
   activeFallbackReasoningPartId: string | null;
+  validationMode: AgUiDecoderValidationMode;
+  onInvalidJson: ((details: { eventName: string | null; dataLength: number }) => void) | null;
 };
 
 export const AgUiRunFinishedMetadataSchema = z.object({
@@ -448,7 +452,13 @@ function isCommentOnlySseFrame(raw: string): boolean {
     .every((line) => line.trim().length === 0 || line.trimStart().startsWith(":"));
 }
 
-function parseAgUiWireEvent(frame: ParsedSseEvent): AgUiWireEvent | null {
+function parseAgUiWireEvent(
+  frame: ParsedSseEvent,
+  input: {
+    validationMode: AgUiDecoderValidationMode;
+    onInvalidJson: ((details: { eventName: string | null; dataLength: number }) => void) | null;
+  },
+): AgUiWireEvent | null {
   if (frame.data === "[DONE]" || !frame.event || !frame.data) {
     return null;
   }
@@ -462,6 +472,10 @@ function parseAgUiWireEvent(frame: ParsedSseEvent): AgUiWireEvent | null {
   try {
     payload = JSON.parse(frame.data);
   } catch {
+    input.onInvalidJson?.({
+      eventName: frame.event,
+      dataLength: frame.data.length,
+    });
     return null;
   }
 
@@ -473,6 +487,10 @@ function parseAgUiWireEvent(frame: ParsedSseEvent): AgUiWireEvent | null {
     eventName: eventName.data,
     payload,
   });
+
+  if (!parsed.success && input.validationMode === "strict") {
+    throw new Error(`Malformed AG-UI event payload for ${eventName.data}`);
+  }
 
   return parsed.success ? parsed.data : null;
 }
@@ -686,6 +704,8 @@ export function parseSseEvent(raw: string): ParsedSseEvent {
 export function createAgUiChatEventDecoderState(
   input: {
     lastEventId?: number;
+    validationMode?: AgUiDecoderValidationMode;
+    onInvalidJson?: (details: { eventName: string | null; dataLength: number }) => void;
   } = {},
 ): AgUiChatEventDecoderState {
   return {
@@ -694,6 +714,8 @@ export function createAgUiChatEventDecoderState(
     toolCalls: new Map<string, ToolCallState>(),
     reasoningFallbackIndex: 0,
     activeFallbackReasoningPartId: null,
+    validationMode: input.validationMode ?? "permissive",
+    onInvalidJson: input.onInvalidJson ?? null,
   };
 }
 
@@ -720,7 +742,10 @@ export function decodeAgUiSseChunk(
       state.lastEventId = frame.id;
     }
 
-    const wireEvent = parseAgUiWireEvent(frame);
+    const wireEvent = parseAgUiWireEvent(frame, {
+      validationMode: state.validationMode,
+      onInvalidJson: state.onInvalidJson,
+    });
     if (!wireEvent) {
       continue;
     }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.196";
+export const VERSION = "0.1.197";


### PR DESCRIPTION
## Summary
- add an opt-in strict validation mode to the AG-UI SSE decoder state
- surface an invalid-JSON callback for callers that want visibility into skipped frames
- keep permissive decoding as the default behavior
- bump the package version to `0.1.197`

## Why
Some consumers need stricter malformed-event handling than the default decoder currently provides. This exposes that policy at the package level so they can stop reimplementing the wire parser locally.

## Verification
- `deno test --no-check --allow-all src/chat/ag-ui.test.ts src/chat/index.test.ts src/utils/version.test.ts`
- `deno check src/chat/ag-ui.ts`
- `deno fmt --check src/chat/ag-ui.ts src/chat/ag-ui.test.ts deno.json src/utils/version-constant.ts`