### PR TITLE
Support reasoning stream events across providers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.197",
+  "version": "0.1.198",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.198",
+  "version": "0.1.197",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -284,6 +284,72 @@ describe("provider/runtime-loader", () => {
     ]);
   });
 
+  it("parses OpenAI-compatible reasoning_content deltas into reasoning parts", async () => {
+    const encoder = new TextEncoder();
+    const runtime = createOpenAIModelRuntime({
+      apiKey: "test-openai-key",
+      baseURL: "https://example.openai.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            ReadableStream.from([
+              encoder.encode(
+                'data: {"choices":[{"delta":{"reasoning_content":"Let me think."}}]}\n\n',
+              ),
+              encoder.encode(
+                'data: {"choices":[{"delta":{"content":"Done."}}]}\n\n',
+              ),
+              encoder.encode(
+                'data: {"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":8,"completion_tokens":2,"total_tokens":10}}\n\n',
+              ),
+              encoder.encode("data: [DONE]\n\n"),
+            ]),
+            {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            },
+          ),
+        ),
+    }, "moonshotai/kimi-k2.5");
+
+    const result = await runtime.doStream({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Think before answering" }],
+      }],
+    });
+
+    const parts = await collectAsync(result.stream);
+    assertEquals(parts, [
+      {
+        type: "reasoning-start",
+        id: "reasoning-0",
+      },
+      {
+        type: "reasoning-delta",
+        id: "reasoning-0",
+        delta: "Let me think.",
+      },
+      {
+        type: "reasoning-end",
+        id: "reasoning-0",
+      },
+      {
+        type: "text-delta",
+        delta: "Done.",
+      },
+      {
+        type: "finish",
+        finishReason: "stop",
+        usage: {
+          inputTokens: 8,
+          outputTokens: 2,
+          totalTokens: 10,
+        },
+      },
+    ]);
+  });
+
   it("keeps OpenAI providerOptions scoped to the active provider and alias", async () => {
     let requestedInit: RequestInit | undefined;
 
@@ -859,6 +925,80 @@ describe("provider/runtime-loader", () => {
     ]);
   });
 
+  it("parses Anthropic extended thinking stream events into reasoning parts", async () => {
+    const encoder = new TextEncoder();
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            ReadableStream.from([
+              encoder.encode(
+                'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":12}}}\n\n',
+              ),
+              encoder.encode(
+                'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}\n\n',
+              ),
+              encoder.encode(
+                'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think."}}\n\n',
+              ),
+              encoder.encode(
+                'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig_123"}}\n\n',
+              ),
+              encoder.encode(
+                'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+              ),
+              encoder.encode(
+                'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":6}}\n\n',
+              ),
+              encoder.encode(
+                'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+              ),
+            ]),
+            {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            },
+          ),
+        ),
+    }, "claude-sonnet-4-20250514");
+
+    const result = await runtime.doStream({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Think before answering" }],
+      }],
+      maxOutputTokens: 64,
+    });
+
+    const parts = await collectAsync(result.stream);
+    assertEquals(parts, [
+      {
+        type: "reasoning-start",
+        id: "thinking-0",
+      },
+      {
+        type: "reasoning-delta",
+        id: "thinking-0",
+        delta: "Let me think.",
+      },
+      {
+        type: "reasoning-end",
+        id: "thinking-0",
+      },
+      {
+        type: "finish",
+        finishReason: { unified: "stop", raw: "end_turn" },
+        usage: {
+          inputTokens: 12,
+          outputTokens: 6,
+          totalTokens: 18,
+        },
+      },
+    ]);
+  });
+
   it("keeps Anthropic providerOptions scoped to the active provider and alias", async () => {
     let requestedInit: RequestInit | undefined;
 
@@ -1118,6 +1258,73 @@ describe("provider/runtime-loader", () => {
         toolCallId: "tool_weather",
         toolName: "weather",
         input: '{"city":"Tokyo"}',
+      },
+      {
+        type: "finish",
+        finishReason: { unified: "stop", raw: "STOP" },
+        usage: {
+          inputTokens: 8,
+          outputTokens: 2,
+          totalTokens: 10,
+        },
+      },
+    ]);
+  });
+
+  it("parses Google thought parts into reasoning events", async () => {
+    const encoder = new TextEncoder();
+
+    const runtime = createGoogleModelRuntime({
+      apiKey: "test-google-key",
+      baseURL: "https://example.google.test/v1beta",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            ReadableStream.from([
+              encoder.encode(
+                'data: {"candidates":[{"content":{"role":"model","parts":[{"text":"Let me think.","thought":true}]}}]}\n\n',
+              ),
+              encoder.encode(
+                'data: {"candidates":[{"content":{"role":"model","parts":[{"text":"Done."}]}}]}\n\n',
+              ),
+              encoder.encode(
+                'data: {"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":2,"totalTokenCount":10}}\n\n',
+              ),
+              encoder.encode("data: [DONE]\n\n"),
+            ]),
+            {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            },
+          ),
+        ),
+    }, "gemini-2.0-flash");
+
+    const result = await runtime.doStream({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Think before answering" }],
+      }],
+    });
+
+    const parts = await collectAsync(result.stream);
+    assertEquals(parts, [
+      {
+        type: "reasoning-start",
+        id: "reasoning-0",
+      },
+      {
+        type: "reasoning-delta",
+        id: "reasoning-0",
+        delta: "Let me think.",
+      },
+      {
+        type: "reasoning-end",
+        id: "reasoning-0",
+      },
+      {
+        type: "text-delta",
+        delta: "Done.",
       },
       {
         type: "finish",

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -350,6 +350,72 @@ describe("provider/runtime-loader", () => {
     ]);
   });
 
+  it("ignores secondary streamed choices for OpenAI-compatible reasoning deltas", async () => {
+    const encoder = new TextEncoder();
+    const runtime = createOpenAIModelRuntime({
+      apiKey: "test-openai-key",
+      baseURL: "https://example.openai.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            ReadableStream.from([
+              encoder.encode(
+                'data: {"choices":[{"index":0,"delta":{"reasoning_content":"Let me think."}},{"index":1,"delta":{"content":"Ignore me."}}]}\n\n',
+              ),
+              encoder.encode(
+                'data: {"choices":[{"index":0,"delta":{"content":"Done."}},{"index":1,"delta":{"content":"Still ignored."}}]}\n\n',
+              ),
+              encoder.encode(
+                'data: {"choices":[{"index":0,"finish_reason":"stop"},{"index":1,"finish_reason":"stop"}],"usage":{"prompt_tokens":8,"completion_tokens":2,"total_tokens":10}}\n\n',
+              ),
+              encoder.encode("data: [DONE]\n\n"),
+            ]),
+            {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            },
+          ),
+        ),
+    }, "moonshotai/kimi-k2.5");
+
+    const result = await runtime.doStream({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Think before answering" }],
+      }],
+    });
+
+    const parts = await collectAsync(result.stream);
+    assertEquals(parts, [
+      {
+        type: "reasoning-start",
+        id: "reasoning-0",
+      },
+      {
+        type: "reasoning-delta",
+        id: "reasoning-0",
+        delta: "Let me think.",
+      },
+      {
+        type: "reasoning-end",
+        id: "reasoning-0",
+      },
+      {
+        type: "text-delta",
+        delta: "Done.",
+      },
+      {
+        type: "finish",
+        finishReason: "stop",
+        usage: {
+          inputTokens: 8,
+          outputTokens: 2,
+          totalTokens: 10,
+        },
+      },
+    ]);
+  });
+
   it("keeps OpenAI providerOptions scoped to the active provider and alias", async () => {
     let requestedInit: RequestInit | undefined;
 

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -1065,6 +1065,102 @@ describe("provider/runtime-loader", () => {
     ]);
   });
 
+  it("keeps Anthropic streamed reasoning scoped to its content block index", async () => {
+    const encoder = new TextEncoder();
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: () =>
+        Promise.resolve(
+          new Response(
+            ReadableStream.from([
+              encoder.encode(
+                'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}\n\n',
+              ),
+              encoder.encode(
+                'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"First thought."}}\n\n',
+              ),
+              encoder.encode(
+                'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"thinking","thinking":""}}\n\n',
+              ),
+              encoder.encode(
+                'event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"thinking_delta","thinking":"Second thought."}}\n\n',
+              ),
+              encoder.encode(
+                'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+              ),
+              encoder.encode(
+                'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n',
+              ),
+              encoder.encode(
+                'event: content_block_start\ndata: {"type":"content_block_start","index":2,"content_block":{"type":"text","text":"Done."}}\n\n',
+              ),
+              encoder.encode(
+                'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":8,"output_tokens":2}}\n\n',
+              ),
+              encoder.encode(
+                'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+              ),
+            ]),
+            {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            },
+          ),
+        ),
+    }, "claude-sonnet-4-20250514");
+
+    const result = await runtime.doStream({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Think twice before answering" }],
+      }],
+    });
+
+    const parts = await collectAsync(result.stream);
+    assertEquals(parts, [
+      {
+        type: "reasoning-start",
+        id: "thinking-0",
+      },
+      {
+        type: "reasoning-delta",
+        id: "thinking-0",
+        delta: "First thought.",
+      },
+      {
+        type: "reasoning-start",
+        id: "thinking-1",
+      },
+      {
+        type: "reasoning-delta",
+        id: "thinking-1",
+        delta: "Second thought.",
+      },
+      {
+        type: "reasoning-end",
+        id: "thinking-0",
+      },
+      {
+        type: "reasoning-end",
+        id: "thinking-1",
+      },
+      {
+        type: "text-delta",
+        delta: "Done.",
+      },
+      {
+        type: "finish",
+        finishReason: { unified: "stop", raw: "end_turn" },
+        usage: {
+          inputTokens: 8,
+          outputTokens: 2,
+          totalTokens: 10,
+        },
+      },
+    ]);
+  });
+
   it("keeps Anthropic providerOptions scoped to the active provider and alias", async () => {
     let requestedInit: RequestInit | undefined;
 

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -1563,96 +1563,92 @@ async function* streamOpenAICompatibleParts(
 
       const record = readRecord(event);
       usage = extractOpenAIUsage(record) ?? usage;
-      const choices = Array.isArray(record?.choices) ? record.choices : [];
+      const choice = extractFirstChoice(record);
+      if (!choice) {
+        continue;
+      }
 
-      for (const choiceValue of choices) {
-        const choice = readRecord(choiceValue);
-        if (!choice) {
-          continue;
-        }
-
-        const delta = readRecord(choice.delta);
-        if (typeof delta?.reasoning_content === "string" && delta.reasoning_content.length > 0) {
-          if (!reasoningId) {
-            reasoningId = `reasoning-${reasoningIndex++}`;
-            yield {
-              type: "reasoning-start",
-              id: reasoningId,
-            };
-          }
-
+      const delta = readRecord(choice.delta);
+      if (typeof delta?.reasoning_content === "string" && delta.reasoning_content.length > 0) {
+        if (!reasoningId) {
+          reasoningId = `reasoning-${reasoningIndex++}`;
           yield {
-            type: "reasoning-delta",
+            type: "reasoning-start",
             id: reasoningId,
-            delta: delta.reasoning_content,
           };
         }
 
-        const textDelta = extractOpenAIContentText(delta?.content);
-        if (textDelta.length > 0) {
-          if (reasoningId) {
-            yield {
-              type: "reasoning-end",
-              id: reasoningId,
-            };
-            reasoningId = null;
-          }
-          yield { type: "text-delta", delta: textDelta };
-        }
+        yield {
+          type: "reasoning-delta",
+          id: reasoningId,
+          delta: delta.reasoning_content,
+        };
+      }
 
-        const rawToolCalls = Array.isArray(delta?.tool_calls) ? delta.tool_calls : [];
-        for (const rawToolCall of rawToolCalls) {
-          if (reasoningId) {
-            yield {
-              type: "reasoning-end",
-              id: reasoningId,
-            };
-            reasoningId = null;
-          }
-
-          const toolCallRecord = readRecord(rawToolCall);
-          const index = typeof toolCallRecord?.index === "number" ? toolCallRecord.index : 0;
-          const current = toolCalls.get(index) ?? {
-            id: typeof toolCallRecord?.id === "string" ? toolCallRecord.id : `tool-${index}`,
-            name: "",
-            arguments: "",
-            started: false,
+      const textDelta = extractOpenAIContentText(delta?.content);
+      if (textDelta.length > 0) {
+        if (reasoningId) {
+          yield {
+            type: "reasoning-end",
+            id: reasoningId,
           };
+          reasoningId = null;
+        }
+        yield { type: "text-delta", delta: textDelta };
+      }
 
-          if (typeof toolCallRecord?.id === "string") {
-            current.id = toolCallRecord.id;
-          }
-
-          const fn = readRecord(toolCallRecord?.function);
-          if (typeof fn?.name === "string") {
-            current.name = fn.name;
-          }
-
-          if (!current.started && current.name.length > 0) {
-            current.started = true;
-            yield {
-              type: "tool-input-start",
-              id: current.id,
-              toolName: current.name,
-            };
-          }
-
-          if (typeof fn?.arguments === "string" && fn.arguments.length > 0) {
-            current.arguments += fn.arguments;
-            yield {
-              type: "tool-input-delta",
-              id: current.id,
-              delta: fn.arguments,
-            };
-          }
-
-          toolCalls.set(index, current);
+      const rawToolCalls = Array.isArray(delta?.tool_calls) ? delta.tool_calls : [];
+      for (const rawToolCall of rawToolCalls) {
+        if (reasoningId) {
+          yield {
+            type: "reasoning-end",
+            id: reasoningId,
+          };
+          reasoningId = null;
         }
 
-        const normalizedFinishReason = normalizeOpenAIFinishReason(choice.finish_reason);
-        if (normalizedFinishReason) {
-          finishReason = normalizedFinishReason;
+        const toolCallRecord = readRecord(rawToolCall);
+        const index = typeof toolCallRecord?.index === "number" ? toolCallRecord.index : 0;
+        const current = toolCalls.get(index) ?? {
+          id: typeof toolCallRecord?.id === "string" ? toolCallRecord.id : `tool-${index}`,
+          name: "",
+          arguments: "",
+          started: false,
+        };
+
+        if (typeof toolCallRecord?.id === "string") {
+          current.id = toolCallRecord.id;
         }
+
+        const fn = readRecord(toolCallRecord?.function);
+        if (typeof fn?.name === "string") {
+          current.name = fn.name;
+        }
+
+        if (!current.started && current.name.length > 0) {
+          current.started = true;
+          yield {
+            type: "tool-input-start",
+            id: current.id,
+            toolName: current.name,
+          };
+        }
+
+        if (typeof fn?.arguments === "string" && fn.arguments.length > 0) {
+          current.arguments += fn.arguments;
+          yield {
+            type: "tool-input-delta",
+            id: current.id,
+            delta: fn.arguments,
+          };
+        }
+
+        toolCalls.set(index, current);
+      }
+
+      const normalizedFinishReason = normalizeOpenAIFinishReason(choice.finish_reason);
+      if (normalizedFinishReason) {
+        finishReason = normalizedFinishReason;
       }
     }
   }

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -156,6 +156,9 @@ type AnthropicStreamToolCallState = {
   input: string;
   providerExecuted?: boolean;
 };
+type AnthropicStreamReasoningState = {
+  id: string;
+};
 type GoogleCompatibleContent = {
   role: "user" | "model";
   parts: Array<Record<string, unknown>>;
@@ -780,6 +783,7 @@ async function* streamAnthropicCompatibleParts(
   const decoder = new TextDecoder();
   let buffer = "";
   const toolCalls = new Map<number, AnthropicStreamToolCallState>();
+  const reasoningBlocks = new Map<number, AnthropicStreamReasoningState>();
   let finishReason: string | { unified: string; raw: string } | null = null;
   let usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number } | undefined;
 
@@ -812,6 +816,24 @@ async function* streamAnthropicCompatibleParts(
           contentBlock.text.length > 0
         ) {
           yield { type: "text-delta", delta: contentBlock.text };
+          continue;
+        }
+
+        if (blockType === "thinking") {
+          const reasoningId = `thinking-${index}`;
+          reasoningBlocks.set(index, { id: reasoningId });
+          yield {
+            type: "reasoning-start",
+            id: reasoningId,
+          };
+
+          if (typeof contentBlock?.thinking === "string" && contentBlock.thinking.length > 0) {
+            yield {
+              type: "reasoning-delta",
+              id: reasoningId,
+              delta: contentBlock.thinking,
+            };
+          }
           continue;
         }
 
@@ -892,6 +914,23 @@ async function* streamAnthropicCompatibleParts(
           continue;
         }
 
+        if (
+          deltaType === "thinking_delta" && typeof delta?.thinking === "string" &&
+          delta.thinking.length > 0
+        ) {
+          const current = reasoningBlocks.get(index);
+          if (!current) {
+            continue;
+          }
+
+          yield {
+            type: "reasoning-delta",
+            id: current.id,
+            delta: delta.thinking,
+          };
+          continue;
+        }
+
         if (deltaType === "input_json_delta" && typeof delta?.partial_json === "string") {
           const current = toolCalls.get(index);
           if (!current) {
@@ -911,6 +950,16 @@ async function* streamAnthropicCompatibleParts(
 
       if (eventType === "content_block_stop") {
         const index = typeof record?.index === "number" ? record.index : 0;
+        const reasoning = reasoningBlocks.get(index);
+        if (reasoning) {
+          yield {
+            type: "reasoning-end",
+            id: reasoning.id,
+          };
+          reasoningBlocks.delete(index);
+          continue;
+        }
+
         const current = toolCalls.get(index);
         if (!current) {
           continue;
@@ -1334,6 +1383,8 @@ async function* streamGoogleCompatibleParts(
   const decoder = new TextDecoder();
   let buffer = "";
   const seenToolCalls = new Set<string>();
+  let reasoningId: string | null = null;
+  let reasoningIndex = 0;
   let finishReason: string | { unified: string; raw: string } | null = null;
   let usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number } | undefined;
 
@@ -1355,6 +1406,32 @@ async function* streamGoogleCompatibleParts(
       }
 
       for (const [index, part] of extractGoogleCandidateParts(event).entries()) {
+        const isThought = part.thought === true;
+        if (isThought && typeof part.text === "string" && part.text.length > 0) {
+          if (!reasoningId) {
+            reasoningId = `reasoning-${reasoningIndex++}`;
+            yield {
+              type: "reasoning-start",
+              id: reasoningId,
+            };
+          }
+
+          yield {
+            type: "reasoning-delta",
+            id: reasoningId,
+            delta: part.text,
+          };
+          continue;
+        }
+
+        if (reasoningId) {
+          yield {
+            type: "reasoning-end",
+            id: reasoningId,
+          };
+          reasoningId = null;
+        }
+
         if (typeof part.text === "string" && part.text.length > 0) {
           yield { type: "text-delta", delta: part.text };
           continue;
@@ -1400,6 +1477,13 @@ async function* streamGoogleCompatibleParts(
       }
       usage = extractGoogleUsage(event) ?? usage;
     }
+  }
+
+  if (reasoningId) {
+    yield {
+      type: "reasoning-end",
+      id: reasoningId,
+    };
   }
 
   yield {
@@ -1462,6 +1546,8 @@ async function* streamOpenAICompatibleParts(
   const decoder = new TextDecoder();
   let buffer = "";
   const toolCalls = new Map<number, OpenAIStreamToolCallState>();
+  let reasoningId: string | null = null;
+  let reasoningIndex = 0;
   let finishReason: string | { unified: string; raw: string } | null = null;
   let usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number } | undefined;
 
@@ -1486,13 +1572,44 @@ async function* streamOpenAICompatibleParts(
         }
 
         const delta = readRecord(choice.delta);
+        if (typeof delta?.reasoning_content === "string" && delta.reasoning_content.length > 0) {
+          if (!reasoningId) {
+            reasoningId = `reasoning-${reasoningIndex++}`;
+            yield {
+              type: "reasoning-start",
+              id: reasoningId,
+            };
+          }
+
+          yield {
+            type: "reasoning-delta",
+            id: reasoningId,
+            delta: delta.reasoning_content,
+          };
+        }
+
         const textDelta = extractOpenAIContentText(delta?.content);
         if (textDelta.length > 0) {
+          if (reasoningId) {
+            yield {
+              type: "reasoning-end",
+              id: reasoningId,
+            };
+            reasoningId = null;
+          }
           yield { type: "text-delta", delta: textDelta };
         }
 
         const rawToolCalls = Array.isArray(delta?.tool_calls) ? delta.tool_calls : [];
         for (const rawToolCall of rawToolCalls) {
+          if (reasoningId) {
+            yield {
+              type: "reasoning-end",
+              id: reasoningId,
+            };
+            reasoningId = null;
+          }
+
           const toolCallRecord = readRecord(rawToolCall);
           const index = typeof toolCallRecord?.index === "number" ? toolCallRecord.index : 0;
           const current = toolCalls.get(index) ?? {
@@ -1550,6 +1667,13 @@ async function* streamOpenAICompatibleParts(
       const record = readRecord(event);
       usage = extractOpenAIUsage(record) ?? usage;
     }
+  }
+
+  if (reasoningId) {
+    yield {
+      type: "reasoning-end",
+      id: reasoningId,
+    };
   }
 
   if (

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.197";
+export const VERSION = "0.1.198";


### PR DESCRIPTION
## Summary
- add red tests for provider reasoning stream parsing in the runtime loader
- emit runtime reasoning parts for Anthropic thinking blocks, OpenAI-compatible `reasoning_content` streams, and Gemini thought parts
- preserve existing text/tool stream behavior while closing reasoning blocks before visible output

## Verification
- `deno test --no-check --allow-all src/provider/runtime-loader.test.ts`
- `deno fmt --check src/provider/runtime-loader.ts src/provider/runtime-loader.test.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/provider/runtime-loader.ts src/provider/runtime-loader.test.ts`
- `deno task build`

## Context
This isolates the missing AG-UI reasoning events to provider stream parsing rather than the AG-UI encoder layer. The added tests cover Anthropic extended thinking, Kimi-style OpenAI-compatible reasoning deltas, and Gemini thought parts.