### PR TITLE
Keep browser-facing framework exports free of dnt polyfills

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.197",
+  "version": "0.1.198",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/scripts/build/browser-safe-exports.mjs
+++ b/scripts/build/browser-safe-exports.mjs
@@ -9,3 +9,14 @@ export const BROWSER_SAFE_EXPORTS = [
   "./markdown",
   "./mdx",
 ];
+
+export const BROWSER_SAFE_CLIENT_MODULES = [
+  "src/agent/react/use-voice-input.js",
+  "src/react/components/chat/chat/components/code-block.js",
+  "src/react/components/chat/chat/components/inline-citation.js",
+  "src/react/components/chat/chat/components/message-actions.js",
+  "src/react/components/chat/chat/components/reasoning.js",
+  "src/react/components/chat/chat/hooks/use-threads.js",
+  "src/security/client/html-sanitizer.js",
+  "src/platform/compat/runtime.js",
+];

--- a/scripts/build/browser-safe-exports.mjs
+++ b/scripts/build/browser-safe-exports.mjs
@@ -1,0 +1,11 @@
+export const BROWSER_SAFE_EXPORTS = [
+  "./head",
+  "./router",
+  "./context",
+  "./fonts",
+  "./chat",
+  "./chat/ag-ui",
+  "./chat/protocol",
+  "./markdown",
+  "./mdx",
+];

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -12,18 +12,7 @@
  */
 
 import { build, emptyDir } from "jsr:@deno/dnt";
-import { BROWSER_SAFE_EXPORTS } from "./browser-safe-exports.mjs";
-
-const BROWSER_SAFE_CLIENT_MODULES = [
-	"./npm/esm/src/agent/react/use-voice-input.js",
-	"./npm/esm/src/react/components/chat/chat/components/code-block.js",
-	"./npm/esm/src/react/components/chat/chat/components/inline-citation.js",
-	"./npm/esm/src/react/components/chat/chat/components/message-actions.js",
-	"./npm/esm/src/react/components/chat/chat/components/reasoning.js",
-	"./npm/esm/src/react/components/chat/chat/hooks/use-threads.js",
-	"./npm/esm/src/security/client/html-sanitizer.js",
-	"./npm/esm/src/platform/compat/runtime.js",
-];
+import { BROWSER_SAFE_CLIENT_MODULES, BROWSER_SAFE_EXPORTS } from "./browser-safe-exports.mjs";
 
 const denoJson = JSON.parse(await Deno.readTextFile("./deno.json"));
 const version = denoJson.version;
@@ -230,8 +219,8 @@ await build({
 
 		for (const path of BROWSER_SAFE_CLIENT_MODULES) {
 			normalizeBrowserTimerShim(
-				path,
-				`${path.replace("./npm/esm/", "")} browser-safe dnt shim removal`,
+				`./npm/esm/${path}`,
+				`${path} browser-safe dnt shim removal`,
 			);
 		}
 

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -12,6 +12,7 @@
  */
 
 import { build, emptyDir } from "jsr:@deno/dnt";
+import { BROWSER_SAFE_EXPORTS } from "./browser-safe-exports.mjs";
 
 const denoJson = JSON.parse(await Deno.readTextFile("./deno.json"));
 const version = denoJson.version;
@@ -195,22 +196,25 @@ await build({
 			"dnt polyfill process.argv[1] fix",
 		);
 
-		// Keep browser-safe chat helpers free of dnt Node polyfill imports.
-		// These modules are consumed directly in client bundles and do not rely on
+		// Keep browser-safe client exports free of dnt Node polyfill imports.
+		// These modules are consumed directly in browser bundles and do not rely on
 		// any Node-only globals, so retaining the injected side-effect import only
 		// bloats the graph and breaks browser builds.
-		for (const path of [
-			"./npm/esm/src/chat/ag-ui.js",
-			"./npm/esm/src/chat/ag-ui.d.ts",
-			"./npm/esm/src/chat/protocol.js",
-			"./npm/esm/src/chat/protocol.d.ts",
-		]) {
-			patchFile(
-				path,
-				'import "../../_dnt.polyfills.js";\n',
-				"",
-				"browser-safe chat module polyfill removal",
-			);
+		for (const exportPath of BROWSER_SAFE_EXPORTS) {
+			const sourcePath = (denoJson.exports as Record<string, string>)[exportPath];
+			if (!sourcePath) {
+				throw new Error(`Missing browser-safe export source for ${exportPath}`);
+			}
+
+			const builtJsPath = `./npm/esm/${sourcePath.replace(/\.tsx?$/, ".js").replace(/^\.\//, "")}`;
+			const builtDtsPath = `./npm/esm/${sourcePath.replace(/\.tsx?$/, ".d.ts").replace(/^\.\//, "")}`;
+
+			for (const path of [builtJsPath, builtDtsPath]) {
+				stripPolyfillImportIfPresent(
+					path,
+					`${exportPath} browser-safe polyfill removal`,
+				);
+			}
 		}
 
 		// Note: Templates are now embedded in manifest.json which is bundled by dnt
@@ -267,6 +271,22 @@ function patchFile(
 				`dnt output may have changed — update the patch or remove it if the bug is fixed.`,
 		);
 	}
+	Deno.writeTextFileSync(path, patched);
+	console.log(`📝 Patched ${description} in ${path}`);
+}
+
+function stripPolyfillImportIfPresent(
+	path: string,
+	description: string,
+): void {
+	const content = Deno.readTextFileSync(path);
+	const polyfillImportPattern = /^import ["'](?:\.\.\/)+_dnt\.polyfills\.js["'];\n/m;
+	const patched = content.replace(polyfillImportPattern, "");
+	if (patched === content) {
+		console.log(`ℹ️  ${description} not needed for ${path}`);
+		return;
+	}
+
 	Deno.writeTextFileSync(path, patched);
 	console.log(`📝 Patched ${description} in ${path}`);
 }

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -14,6 +14,17 @@
 import { build, emptyDir } from "jsr:@deno/dnt";
 import { BROWSER_SAFE_EXPORTS } from "./browser-safe-exports.mjs";
 
+const BROWSER_SAFE_CLIENT_MODULES = [
+	"./npm/esm/src/agent/react/use-voice-input.js",
+	"./npm/esm/src/react/components/chat/chat/components/code-block.js",
+	"./npm/esm/src/react/components/chat/chat/components/inline-citation.js",
+	"./npm/esm/src/react/components/chat/chat/components/message-actions.js",
+	"./npm/esm/src/react/components/chat/chat/components/reasoning.js",
+	"./npm/esm/src/react/components/chat/chat/hooks/use-threads.js",
+	"./npm/esm/src/security/client/html-sanitizer.js",
+	"./npm/esm/src/platform/compat/runtime.js",
+];
+
 const denoJson = JSON.parse(await Deno.readTextFile("./deno.json"));
 const version = denoJson.version;
 if (!version) {
@@ -217,6 +228,13 @@ await build({
 			}
 		}
 
+		for (const path of BROWSER_SAFE_CLIENT_MODULES) {
+			normalizeBrowserTimerShim(
+				path,
+				`${path.replace("./npm/esm/", "")} browser-safe dnt shim removal`,
+			);
+		}
+
 		// Note: Templates are now embedded in manifest.json which is bundled by dnt
 		// No need to copy template files separately
 
@@ -282,6 +300,29 @@ function stripPolyfillImportIfPresent(
 	const content = Deno.readTextFileSync(path);
 	const polyfillImportPattern = /^import ["'](?:\.\.\/)+_dnt\.polyfills\.js["'];\n/m;
 	const patched = content.replace(polyfillImportPattern, "");
+	if (patched === content) {
+		console.log(`ℹ️  ${description} not needed for ${path}`);
+		return;
+	}
+
+	Deno.writeTextFileSync(path, patched);
+	console.log(`📝 Patched ${description} in ${path}`);
+}
+
+function normalizeBrowserTimerShim(
+	path: string,
+	description: string,
+): void {
+	const content = Deno.readTextFileSync(path);
+	const patched = content
+		.replace(/^import \* as dntShim from ["'](?:\.\.\/)+_dnt\.shims\.js["'];\n/m, "")
+		.replaceAll("dntShim.dntGlobalThis", "globalThis")
+		.replaceAll("dntShim.Deno", "globalThis.Deno")
+		.replaceAll("dntShim.dntGlobalThis.setTimeout", "globalThis.setTimeout")
+		.replaceAll("dntShim.setTimeout", "globalThis.setTimeout")
+		.replaceAll("dntShim.dntGlobalThis.clearTimeout", "globalThis.clearTimeout")
+		.replaceAll("dntShim.clearTimeout", "globalThis.clearTimeout");
+
 	if (patched === content) {
 		console.log(`ℹ️  ${description} not needed for ${path}`);
 		return;

--- a/scripts/docs/verify-npm-exports.mjs
+++ b/scripts/docs/verify-npm-exports.mjs
@@ -15,6 +15,17 @@ import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { BROWSER_SAFE_EXPORTS } from "../build/browser-safe-exports.mjs";
 
+const BROWSER_SAFE_CLIENT_MODULES = [
+  "src/agent/react/use-voice-input.js",
+  "src/react/components/chat/chat/components/code-block.js",
+  "src/react/components/chat/chat/components/inline-citation.js",
+  "src/react/components/chat/chat/components/message-actions.js",
+  "src/react/components/chat/chat/components/reasoning.js",
+  "src/react/components/chat/chat/hooks/use-threads.js",
+  "src/security/client/html-sanitizer.js",
+  "src/platform/compat/runtime.js",
+];
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "../..");
 const NPM_DIR = resolve(ROOT, "npm");
@@ -162,8 +173,35 @@ for (const exportPath of BROWSER_SAFE_EXPORTS) {
   console.log(`  OK    ${label} (browser-safe entry)`);
 }
 
+for (const relativePath of BROWSER_SAFE_CLIENT_MODULES) {
+  const builtFile = resolve(NPM_DIR, "esm", relativePath);
+  const label = `veryfront/${relativePath}`;
+
+  if (!existsSync(builtFile)) {
+    failed++;
+    errors.push(`  ${label}: missing built file ${builtFile}`);
+    console.log(`  FAIL  ${label} — missing built file`);
+    continue;
+  }
+
+  const content = readFileSync(builtFile, "utf8");
+  if (content.includes("_dnt.shims.js")) {
+    failed++;
+    errors.push(`  ${label}: should not import _dnt.shims.js`);
+    console.log(`  FAIL  ${label} — still imports _dnt.shims.js`);
+    continue;
+  }
+
+  passed++;
+  console.log(`  OK    ${label} (browser-safe module)`);
+}
+
 console.log();
-console.log(`${passed} passed, ${failed} failed out of ${moduleExports.length + 1 + BROWSER_SAFE_EXPORTS.length} export paths`);
+console.log(
+  `${passed} passed, ${failed} failed out of ${
+    moduleExports.length + 1 + BROWSER_SAFE_EXPORTS.length + BROWSER_SAFE_CLIENT_MODULES.length
+  } export paths`,
+);
 
 if (errors.length > 0) {
   console.log("\nErrors:");

--- a/scripts/docs/verify-npm-exports.mjs
+++ b/scripts/docs/verify-npm-exports.mjs
@@ -13,6 +13,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { BROWSER_SAFE_EXPORTS } from "../build/browser-safe-exports.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "../..");
@@ -40,7 +41,7 @@ const REQUIRED_EXPORTS = {
   "./router": ["Link", "useRouter", "RouterProvider"],
   "./context": ["usePageContext", "PageContextProvider"],
   "./fonts": ["GoogleFonts"],
-  "./chat": ["Chat", "useChat", "useAgent", "AgentCard", "Message", "AIErrorBoundary"],
+  "./chat": ["Chat", "useChat", "useAgent", "AgentCard", "Message", "ChatErrorBoundary"],
   "./markdown": ["Markdown"],
   "./mdx": ["MDXProvider", "useMDXComponents"],
   "./agent": [
@@ -72,8 +73,6 @@ const REQUIRED_EXPORTS = {
   ],
   "./fs": ["readTextFile", "writeTextFile", "join", "resolve", "exists", "mkdir"],
 };
-
-const BROWSER_SAFE_EXPORTS = ["./chat/ag-ui", "./chat/protocol"];
 
 let passed = 0;
 let failed = 0;

--- a/scripts/docs/verify-npm-exports.mjs
+++ b/scripts/docs/verify-npm-exports.mjs
@@ -13,18 +13,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { BROWSER_SAFE_EXPORTS } from "../build/browser-safe-exports.mjs";
-
-const BROWSER_SAFE_CLIENT_MODULES = [
-  "src/agent/react/use-voice-input.js",
-  "src/react/components/chat/chat/components/code-block.js",
-  "src/react/components/chat/chat/components/inline-citation.js",
-  "src/react/components/chat/chat/components/message-actions.js",
-  "src/react/components/chat/chat/components/reasoning.js",
-  "src/react/components/chat/chat/hooks/use-threads.js",
-  "src/security/client/html-sanitizer.js",
-  "src/platform/compat/runtime.js",
-];
+import { BROWSER_SAFE_CLIENT_MODULES, BROWSER_SAFE_EXPORTS } from "../build/browser-safe-exports.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "../..");

--- a/scripts/docs/verify-npm-node.mjs
+++ b/scripts/docs/verify-npm-node.mjs
@@ -151,7 +151,7 @@ try {
   assert(chat.useAgent !== undefined, "useAgent exists");
   assert(chat.AgentCard !== undefined, "AgentCard exists");
   assert(chat.Message !== undefined, "Message exists");
-  assert(chat.AIErrorBoundary !== undefined, "AIErrorBoundary exists");
+  assert(chat.ChatErrorBoundary !== undefined, "ChatErrorBoundary exists");
   console.log("  OK    chat — 6 checks");
 } catch (err) {
   failed++;

--- a/src/react/components/chat/markdown.tsx
+++ b/src/react/components/chat/markdown.tsx
@@ -22,7 +22,7 @@ export interface CodeBlockProps {
 }
 
 const ESM_REACT_MARKDOWN =
-  "https://esm.sh/react-markdown@9.0.3?external=react&target=es2022&pin=v135";
+  "https://esm.sh/react-markdown@9.0.3?target=es2022&pin=v135&deps=react@19.2.4";
 const ESM_REMARK_GFM = "https://esm.sh/remark-gfm@4.0.1?target=es2022&pin=v135";
 const ESM_REHYPE_HIGHLIGHT = "https://esm.sh/rehype-highlight@7.0.2?target=es2022&pin=v135";
 const ESM_MERMAID = "https://esm.sh/mermaid@11.4.1?pin=v135";
@@ -41,7 +41,7 @@ type MermaidModule = {
 };
 
 async function importFromUrl<T>(url: string): Promise<T> {
-  return await import(url) as T;
+  return await import(/* @vite-ignore */ url) as T;
 }
 
 // deno-lint-ignore no-explicit-any

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.197";
+export const VERSION = "0.1.198";


### PR DESCRIPTION
## Summary
- centralize the browser-safe export list for the npm build and verifier
- strip injected  imports from all browser-facing framework entrypoints, not just chat helper subpaths
- verify browser-facing exports like , , , , , , and  stay browser-safe

## Verification
- 
- 

## Notes
- this fixes the framework packaging bug that broke the local agent playground/browser path
- the build cleanup is now generic over the shared browser-safe export list rather than hardcoding just a few chat entries