### PR TITLE
Keep Anthropic tool-result replay attached to the active user turn

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.198",
+  "version": "0.1.199",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -570,6 +570,112 @@ describe("provider/runtime-loader", () => {
     });
   });
 
+  it("merges tool-result replay with consecutive user retries into one Anthropic user message", async () => {
+    let requestedInit: RequestInit | undefined;
+
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: (_input, init) => {
+        requestedInit = init;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: [{ type: "text", text: "done" }],
+              stop_reason: "end_turn",
+              usage: {
+                input_tokens: 6,
+                output_tokens: 1,
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        );
+      },
+    }, "claude-sonnet-4-20250514");
+
+    await runtime.doGenerate({
+      prompt: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "toolu_1",
+              toolName: "get_project",
+              input: { project_reference: "project-1" },
+            },
+            {
+              type: "text",
+              text: "The project slug is `my-project`.",
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [{
+            type: "tool-result",
+            toolCallId: "toolu_1",
+            toolName: "get_project",
+            output: {
+              type: "json",
+              value: { slug: "my-project" },
+            },
+          }],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "What is the project slug now?" }],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "Reply with only the project slug." }],
+        },
+      ],
+      maxOutputTokens: 32,
+    });
+
+    const requestBody = typeof requestedInit?.body === "string"
+      ? JSON.parse(requestedInit.body)
+      : undefined;
+
+    assertEquals(requestBody?.messages, [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_1",
+            name: "get_project",
+            input: { project_reference: "project-1" },
+          },
+          {
+            type: "text",
+            text: "The project slug is `my-project`.",
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_1",
+            content: '{"slug":"my-project"}',
+          },
+          {
+            type: "text",
+            text: "What is the project slug now?",
+          },
+          {
+            type: "text",
+            text: "Reply with only the project slug.",
+          },
+        ],
+      },
+    ]);
+  });
+
   it("creates an Anthropic-compatible language runtime without SDK helpers for stream", async () => {
     let requestedUrl = "";
     let requestedInit: RequestInit | undefined;

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -538,6 +538,26 @@ function toSnakeCaseRecord(record: Record<string, unknown>): Record<string, unkn
   );
 }
 
+function pushAnthropicUserContent(
+  messages: AnthropicCompatibleMessage[],
+  content: Array<Record<string, unknown>>,
+): void {
+  if (content.length === 0) {
+    return;
+  }
+
+  const lastMessage = messages.at(-1);
+  if (lastMessage?.role === "user") {
+    lastMessage.content.push(...content);
+    return;
+  }
+
+  messages.push({
+    role: "user",
+    content,
+  });
+}
+
 function toAnthropicMessages(
   prompt: RuntimePromptMessage[],
 ): { system?: string; messages: AnthropicCompatibleMessage[] } {
@@ -552,10 +572,10 @@ function toAnthropicMessages(
         }
         break;
       case "user":
-        messages.push({
-          role: "user",
-          content: [{ type: "text", text: readTextParts(message.content) }],
-        });
+        pushAnthropicUserContent(messages, [{
+          type: "text",
+          text: readTextParts(message.content),
+        }]);
         break;
       case "assistant":
         messages.push({
@@ -571,14 +591,14 @@ function toAnthropicMessages(
         });
         break;
       case "tool":
-        messages.push({
-          role: "user",
-          content: message.content.map((part) => ({
+        pushAnthropicUserContent(
+          messages,
+          message.content.map((part) => ({
             type: "tool_result",
             tool_use_id: part.toolCallId,
             content: stringifyJsonValue(part.output.value),
           })),
-        });
+        );
         break;
     }
   }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.198";
+export const VERSION = "0.1.199";


### PR DESCRIPTION
## Summary
- merge consecutive Anthropic user-side blocks during prompt serialization
- keep tool_result replay attached to later retry text instead of emitting separate user messages
- cover the replay shape with a provider runtime regression test and bump the package version to 0.1.199

## Testing
- deno fmt src/provider/runtime-loader.ts src/provider/runtime-loader.test.ts deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all src/provider/runtime-loader.test.ts
- full pre-push checks (format, lint, typecheck, unit tests)