### PR TITLE
Close AG-UI text segments around tool interruptions

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.199",
+  "version": "0.1.200",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/ag-ui-browser-encoder.test.ts
+++ b/src/agent/ag-ui-browser-encoder.test.ts
@@ -62,10 +62,16 @@ describe("agent/ag-ui-browser-encoder", () => {
         toolCallId: "tool-1",
         toolName: "web_search",
       }),
-      [{
-        event: "ToolCallStart",
-        payload: { toolCallId: "tool-1", toolCallName: "web_search" },
-      }],
+      [
+        {
+          event: "TextMessageEnd",
+          payload: { messageId: "assistant-1" },
+        },
+        {
+          event: "ToolCallStart",
+          payload: { toolCallId: "tool-1", toolCallName: "web_search" },
+        },
+      ],
     );
     assertEquals(
       mapRuntimeStreamEventToAgUiBrowserEvents(state, {
@@ -149,6 +155,56 @@ describe("agent/ag-ui-browser-encoder", () => {
     );
   });
 
+  it("closes reasoning when non-reasoning events interrupt it", () => {
+    const state = createAgUiBrowserEncoderState();
+
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "message-start",
+        messageId: "assistant-3",
+      }),
+      [],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "reasoning-start",
+        id: "reasoning-1",
+      }),
+      [{
+        event: "ReasoningMessageStart",
+        payload: { messageId: "assistant-3:reasoning:reasoning-1", role: "reasoning" },
+      }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "reasoning-delta",
+        id: "reasoning-1",
+        delta: "thinking",
+      }),
+      [{
+        event: "ReasoningMessageContent",
+        payload: { messageId: "assistant-3:reasoning:reasoning-1", delta: "thinking" },
+      }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "tool-input-start",
+        toolCallId: "tool-4",
+        toolName: "web_search",
+      }),
+      [
+        {
+          event: "ReasoningMessageEnd",
+          payload: { messageId: "assistant-3:reasoning:reasoning-1" },
+        },
+        {
+          event: "ToolCallStart",
+          payload: { toolCallId: "tool-4", toolCallName: "web_search" },
+        },
+      ],
+    );
+  });
+
   it("finalizes metadata and emits terminal errors for empty output", () => {
     const visibleState = createAgUiBrowserEncoderState();
     mapRuntimeStreamEventToAgUiBrowserEvents(visibleState, {
@@ -187,6 +243,55 @@ describe("agent/ag-ui-browser-encoder", () => {
               inputTokens: 12,
               outputTokens: 8,
               totalTokens: 20,
+              finishReason: "stop",
+            },
+          },
+        },
+      ],
+    );
+
+    const reasoningState = createAgUiBrowserEncoderState();
+    mapRuntimeStreamEventToAgUiBrowserEvents(reasoningState, {
+      type: "message-start",
+      messageId: "assistant-4",
+    });
+    mapRuntimeStreamEventToAgUiBrowserEvents(reasoningState, {
+      type: "reasoning-start",
+      id: "reasoning-2",
+    });
+    mapRuntimeStreamEventToAgUiBrowserEvents(reasoningState, {
+      type: "reasoning-delta",
+      id: "reasoning-2",
+      delta: "Thinking",
+    });
+
+    assertEquals(
+      finalizeAgUiBrowserEvents(reasoningState, {
+        text: "done",
+        messages: [],
+        toolCalls: [],
+        status: "completed",
+        usage: {
+          promptTokens: 2,
+          completionTokens: 1,
+          totalTokens: 3,
+        },
+        metadata: {
+          finishReason: "stop",
+        },
+      }),
+      [
+        {
+          event: "ReasoningMessageEnd",
+          payload: { messageId: "assistant-4:reasoning:reasoning-2" },
+        },
+        {
+          event: "RunFinished",
+          payload: {
+            metadata: {
+              inputTokens: 2,
+              outputTokens: 1,
+              totalTokens: 3,
               finishReason: "stop",
             },
           },

--- a/src/agent/ag-ui-browser-encoder.ts
+++ b/src/agent/ag-ui-browser-encoder.ts
@@ -233,6 +233,28 @@ function createTextEvent(
   };
 }
 
+function closeOpenTextEvent(state: AgUiBrowserEncoderState): AgUiBrowserEncodedEvent[] {
+  if (!state.textOpen) {
+    return [];
+  }
+
+  state.textOpen = false;
+  return [createTextEvent(getMessageId(state, { type: "text-end" }), "TextMessageEnd")];
+}
+
+function closeOpenReasoningEvent(state: AgUiBrowserEncoderState): AgUiBrowserEncodedEvent[] {
+  if (state.reasoningMessageId === null) {
+    return [];
+  }
+
+  const messageId = state.reasoningMessageId;
+  state.reasoningMessageId = null;
+  return [{
+    event: "ReasoningMessageEnd",
+    payload: { messageId },
+  }];
+}
+
 export function mapRuntimeStreamEventToAgUiBrowserEvents(
   state: AgUiBrowserEncoderState,
   event: AgUiRuntimeStreamEvent,
@@ -253,33 +275,38 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
       return [];
 
     case "text-start": {
+      const events = closeOpenReasoningEvent(state);
       if (state.textOpen) return [];
       const messageId = getMessageId(state, event);
       state.textOpen = true;
       state.sawVisibleOutput = true;
-      return [createTextEvent(messageId, "TextMessageStart")];
+      events.push(createTextEvent(messageId, "TextMessageStart"));
+      return events;
     }
 
     case "text-delta": {
+      const events = closeOpenReasoningEvent(state);
       const messageId = getMessageId(state, event);
       state.sawVisibleOutput = true;
       if (!state.textOpen) {
         state.textOpen = true;
-        return [
+        events.push(
           createTextEvent(messageId, "TextMessageStart"),
           createTextEvent(
             messageId,
             "TextMessageContent",
             typeof event.delta === "string" ? event.delta : "",
           ),
-        ];
+        );
+        return events;
       }
 
-      return [createTextEvent(
+      events.push(createTextEvent(
         messageId,
         "TextMessageContent",
         typeof event.delta === "string" ? event.delta : "",
-      )];
+      ));
+      return events;
     }
 
     case "text-end": {
@@ -288,13 +315,23 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
       return [createTextEvent(getMessageId(state, event), "TextMessageEnd")];
     }
 
-    case "reasoning-start":
+    case "reasoning-start": {
+      const events = closeOpenTextEvent(state);
+      events.push(...closeOpenReasoningEvent(state));
       state.sawVisibleOutput = true;
-      return [createReasoningEvent(state, event, "ReasoningMessageStart")];
+      events.push(createReasoningEvent(state, event, "ReasoningMessageStart"));
+      return events;
+    }
 
-    case "reasoning-delta":
+    case "reasoning-delta": {
+      const events = closeOpenTextEvent(state);
       state.sawVisibleOutput = true;
-      return [createReasoningEvent(state, event, "ReasoningMessageContent")];
+      if (state.reasoningMessageId === null) {
+        events.push(createReasoningEvent(state, event, "ReasoningMessageStart"));
+      }
+      events.push(createReasoningEvent(state, event, "ReasoningMessageContent"));
+      return events;
+    }
 
     case "reasoning-end": {
       const reasoningEvent = createReasoningEvent(state, event, "ReasoningMessageEnd");
@@ -302,15 +339,21 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
       return [reasoningEvent];
     }
 
-    case "tool-input-start":
+    case "tool-input-start": {
+      const events = [
+        ...closeOpenTextEvent(state),
+        ...closeOpenReasoningEvent(state),
+      ];
       state.sawVisibleOutput = true;
-      return [{
+      events.push({
         event: "ToolCallStart",
         payload: {
           toolCallId: event.toolCallId,
           toolCallName: event.toolName,
         },
-      }];
+      });
+      return events;
+    }
 
     case "tool-input-delta":
       state.sawVisibleOutput = true;
@@ -327,12 +370,20 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
 
     case "tool-input-available": {
       state.sawVisibleOutput = true;
-      return completeToolInput(state, event);
+      return [
+        ...closeOpenTextEvent(state),
+        ...closeOpenReasoningEvent(state),
+        ...completeToolInput(state, event),
+      ];
     }
 
     case "tool-input-error": {
       state.sawVisibleOutput = true;
-      const events = completeToolInput(state, event);
+      const events = [
+        ...closeOpenTextEvent(state),
+        ...closeOpenReasoningEvent(state),
+        ...completeToolInput(state, event),
+      ];
       events.push({
         event: "ToolCallResult",
         payload: {
@@ -348,25 +399,45 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
 
     case "tool-output-available":
       state.sawVisibleOutput = true;
-      return [createToolResultEvent(event.toolCallId, event.output)];
+      return [
+        ...closeOpenTextEvent(state),
+        ...closeOpenReasoningEvent(state),
+        createToolResultEvent(event.toolCallId, event.output),
+      ];
 
     case "tool-output-error":
       state.sawVisibleOutput = true;
-      return [createToolResultEvent(event.toolCallId, { error: event.errorText }, true)];
+      return [
+        ...closeOpenTextEvent(state),
+        ...closeOpenReasoningEvent(state),
+        createToolResultEvent(event.toolCallId, { error: event.errorText }, true),
+      ];
 
     case "tool-output-denied":
       state.sawVisibleOutput = true;
-      return [createToolResultEvent(event.toolCallId, { error: "Tool output denied" }, true)];
+      return [
+        ...closeOpenTextEvent(state),
+        ...closeOpenReasoningEvent(state),
+        createToolResultEvent(event.toolCallId, { error: "Tool output denied" }, true),
+      ];
 
     case "step-start":
     case "start-step":
       state.sawVisibleOutput = true;
-      return [createStepEvent(state, "StepStarted")];
+      return [
+        ...closeOpenTextEvent(state),
+        ...closeOpenReasoningEvent(state),
+        createStepEvent(state, "StepStarted"),
+      ];
 
     case "step-end":
     case "finish-step":
       state.sawVisibleOutput = true;
-      return [createStepEvent(state, "StepFinished")];
+      return [
+        ...closeOpenTextEvent(state),
+        ...closeOpenReasoningEvent(state),
+        createStepEvent(state, "StepFinished"),
+      ];
 
     case "data":
       applyDataMetadata(state, event);
@@ -374,7 +445,10 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
 
     case "error":
       state.sawTerminalError = true;
-      return [{
+      return [
+        ...closeOpenTextEvent(state),
+        ...closeOpenReasoningEvent(state),
+        {
         event: "RunError",
         payload: {
           message: typeof event.error === "string" ? event.error : "Agent run failed",
@@ -408,13 +482,8 @@ export function finalizeAgUiBrowserEvents(
   }
 
   const events: AgUiBrowserEncodedEvent[] = [];
-  if (state.textOpen) {
-    state.textOpen = false;
-    events.push({
-      event: "TextMessageEnd",
-      payload: { messageId: getMessageId(state, { type: "text-end" }) },
-    });
-  }
+  events.push(...closeOpenTextEvent(state));
+  events.push(...closeOpenReasoningEvent(state));
 
   events.push({
     event: "RunFinished",

--- a/src/agent/ag-ui-browser-encoder.ts
+++ b/src/agent/ag-ui-browser-encoder.ts
@@ -449,11 +449,12 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
         ...closeOpenTextEvent(state),
         ...closeOpenReasoningEvent(state),
         {
-        event: "RunError",
-        payload: {
-          message: typeof event.error === "string" ? event.error : "Agent run failed",
+          event: "RunError",
+          payload: {
+            message: typeof event.error === "string" ? event.error : "Agent run failed",
+          },
         },
-      }];
+      ];
 
     default:
       return [];

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -397,11 +397,20 @@ describe("chat-stream-handler", () => {
         toolName: "web_search",
         output: { results: [{ title: "AI" }] },
       }]);
-      assertEquals(events[0], {
-        type: "tool-output-available",
-        toolCallId: "tc-web",
-        output: { results: [{ title: "AI" }] },
-      });
+      assertEquals(events, [
+        { type: "tool-input-start", toolCallId: "tc-web", toolName: "web_search" },
+        {
+          type: "tool-input-available",
+          toolCallId: "tc-web",
+          toolName: "web_search",
+          input: { query: "latest ai news" },
+        },
+        {
+          type: "tool-output-available",
+          toolCallId: "tc-web",
+          output: { results: [{ title: "AI" }] },
+        },
+      ]);
     });
 
     it("forwards errored tool results as tool-output-error SSE events", async () => {
@@ -427,11 +436,20 @@ describe("chat-stream-handler", () => {
         toolName: "web_search",
         error: { error: "Search failed" },
       }]);
-      assertEquals(events[0], {
-        type: "tool-output-error",
-        toolCallId: "tc-web",
-        errorText: '{"error":"Search failed"}',
-      });
+      assertEquals(events, [
+        { type: "tool-input-start", toolCallId: "tc-web", toolName: "web_search" },
+        {
+          type: "tool-input-available",
+          toolCallId: "tc-web",
+          toolName: "web_search",
+          input: { query: "latest ai news" },
+        },
+        {
+          type: "tool-output-error",
+          toolCallId: "tc-web",
+          errorText: '{"error":"Search failed"}',
+        },
+      ]);
     });
 
     it("forwards tool-error parts as tool-output-error SSE events", async () => {
@@ -458,12 +476,22 @@ describe("chat-stream-handler", () => {
         error: "Expected object, received string",
         providerExecuted: true,
       }]);
-      assertEquals(events[0], {
-        type: "tool-output-error",
-        toolCallId: "tc-provider-error",
-        errorText: "Expected object, received string",
-        providerExecuted: true,
-      });
+      assertEquals(events, [
+        { type: "tool-input-start", toolCallId: "tc-provider-error", toolName: "web_search" },
+        {
+          type: "tool-input-available",
+          toolCallId: "tc-provider-error",
+          toolName: "web_search",
+          input: { query: "Veryfront" },
+          providerExecuted: true,
+        },
+        {
+          type: "tool-output-error",
+          toolCallId: "tc-provider-error",
+          errorText: "Expected object, received string",
+          providerExecuted: true,
+        },
+      ]);
     });
 
     it("uses Error.message for streamed tool-error SSE events", async () => {
@@ -484,12 +512,22 @@ describe("chat-stream-handler", () => {
 
       await processStream(result, state, controller, encoder, "t", undefined);
 
-      assertEquals(events[0], {
-        type: "tool-output-error",
-        toolCallId: "tc-provider-error-object",
-        errorText: "Provider timeout",
-        providerExecuted: true,
-      });
+      assertEquals(events, [
+        { type: "tool-input-start", toolCallId: "tc-provider-error-object", toolName: "web_search" },
+        {
+          type: "tool-input-available",
+          toolCallId: "tc-provider-error-object",
+          toolName: "web_search",
+          input: { query: "Veryfront" },
+          providerExecuted: true,
+        },
+        {
+          type: "tool-output-error",
+          toolCallId: "tc-provider-error-object",
+          errorText: "Provider timeout",
+          providerExecuted: true,
+        },
+      ]);
     });
     it("ignores tool-input-delta for unknown tool call IDs", async () => {
       const { events, controller, encoder } = createSSECollector();
@@ -543,6 +581,63 @@ describe("chat-stream-handler", () => {
         { type: "reasoning-start", id: "reasoning-1" },
         { type: "reasoning-delta", id: "reasoning-1", delta: "thinking..." },
         { type: "reasoning-end", id: "reasoning-1" },
+        { type: "finish", finishReason: "stop", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      assertEquals(events, [
+        { type: "reasoning-start", id: "reasoning-1" },
+        { type: "reasoning-delta", id: "reasoning-1", delta: "thinking..." },
+        { type: "reasoning-end", id: "reasoning-1" },
+      ]);
+    });
+
+    it("closes reasoning when tool activity interrupts it and synthesizes missing tool lifecycle before raw tool results", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        { type: "reasoning-start", id: "reasoning-1" },
+        { type: "reasoning-delta", id: "reasoning-1", delta: "thinking..." },
+        {
+          type: "tool-result",
+          toolCallId: "tc-standalone",
+          toolName: "web_search",
+          input: { query: "Veryfront" },
+          output: { ok: true },
+        },
+        { type: "finish", finishReason: "stop", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      assertEquals(events, [
+        { type: "reasoning-start", id: "reasoning-1" },
+        { type: "reasoning-delta", id: "reasoning-1", delta: "thinking..." },
+        { type: "reasoning-end", id: "reasoning-1" },
+        { type: "tool-input-start", toolCallId: "tc-standalone", toolName: "web_search" },
+        {
+          type: "tool-input-available",
+          toolCallId: "tc-standalone",
+          toolName: "web_search",
+          input: { query: "Veryfront" },
+        },
+        {
+          type: "tool-output-available",
+          toolCallId: "tc-standalone",
+          output: { ok: true },
+        },
+      ]);
+    });
+
+    it("closes reasoning when the run finishes without an explicit reasoning-end", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        { type: "reasoning-start", id: "reasoning-1" },
+        { type: "reasoning-delta", id: "reasoning-1", delta: "thinking..." },
         { type: "finish", finishReason: "stop", totalUsage: null },
       ]);
 

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -74,9 +74,58 @@ describe("chat-stream-handler", () => {
       await processStream(result, state, controller, encoder, "text-1", undefined);
 
       assertEquals(state.accumulatedText, "Hello world");
-      assertEquals(events.length, 2);
-      assertEquals(events[0], { type: "text-delta", id: "text-1", delta: "Hello " });
-      assertEquals(events[1], { type: "text-delta", id: "text-1", delta: "world" });
+      assertEquals(events.length, 4);
+      assertEquals(events[0], { type: "text-start", id: "text-1" });
+      assertEquals(events[1], { type: "text-delta", id: "text-1", delta: "Hello " });
+      assertEquals(events[2], { type: "text-delta", id: "text-1", delta: "world" });
+      assertEquals(events[3], { type: "text-end", id: "text-1" });
+    });
+
+    it("closes and reopens text segments when a tool interrupts assistant text", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        { type: "text-delta", text: "Before tool." },
+        { type: "tool-input-start", id: "tc-form", toolName: "form_input" },
+        {
+          type: "tool-call",
+          toolCallId: "tc-form",
+          toolName: "form_input",
+          input: { title: "Need more detail" },
+        },
+        {
+          type: "tool-result",
+          toolCallId: "tc-form",
+          toolName: "form_input",
+          output: { submitted: false },
+        },
+        { type: "text-delta", text: " After tool." },
+        { type: "finish", finishReason: "stop", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "text-1", undefined);
+
+      assertEquals(events, [
+        { type: "text-start", id: "text-1" },
+        { type: "text-delta", id: "text-1", delta: "Before tool." },
+        { type: "text-end", id: "text-1" },
+        { type: "tool-input-start", toolCallId: "tc-form", toolName: "form_input" },
+        {
+          type: "tool-input-available",
+          toolCallId: "tc-form",
+          toolName: "form_input",
+          input: { title: "Need more detail" },
+        },
+        {
+          type: "tool-output-available",
+          toolCallId: "tc-form",
+          output: { submitted: false },
+        },
+        { type: "text-start", id: "text-1" },
+        { type: "text-delta", id: "text-1", delta: " After tool." },
+        { type: "text-end", id: "text-1" },
+      ]);
     });
 
     it("calls onChunk callback for each text delta", async () => {
@@ -518,9 +567,11 @@ describe("chat-stream-handler", () => {
 
       await processStream(result, state, controller, encoder, "t", undefined);
 
-      // Only text-delta should produce an event
-      assertEquals(events.length, 1);
-      assertEquals(events[0]?.type, "text-delta");
+      assertEquals(events, [
+        { type: "text-start", id: "t" },
+        { type: "text-delta", id: "t", delta: "ok" },
+        { type: "text-end", id: "t" },
+      ]);
     });
   });
 });

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -513,7 +513,11 @@ describe("chat-stream-handler", () => {
       await processStream(result, state, controller, encoder, "t", undefined);
 
       assertEquals(events, [
-        { type: "tool-input-start", toolCallId: "tc-provider-error-object", toolName: "web_search" },
+        {
+          type: "tool-input-start",
+          toolCallId: "tc-provider-error-object",
+          toolName: "web_search",
+        },
         {
           type: "tool-input-available",
           toolCallId: "tc-provider-error-object",

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -157,6 +157,31 @@ export function processStream(
 ): Promise<void> {
   return withSpan("agent.runtime.processStream", async () => {
     let eventCount = 0;
+    let textOpen = false;
+
+    const openTextSegment = () => {
+      if (textOpen) {
+        return;
+      }
+
+      textOpen = true;
+      sendSSE(controller, encoder, {
+        type: "text-start",
+        id: textPartId,
+      });
+    };
+
+    const closeTextSegment = () => {
+      if (!textOpen) {
+        return;
+      }
+
+      textOpen = false;
+      sendSSE(controller, encoder, {
+        type: "text-end",
+        id: textPartId,
+      });
+    };
 
     throwIfAborted(abortSignal);
 
@@ -172,6 +197,7 @@ export function processStream(
 
       switch (typedPart.type) {
         case "text-delta": {
+          openTextSegment();
           state.accumulatedText += typedPart.text;
           sendSSE(controller, encoder, {
             type: "text-delta",
@@ -183,6 +209,7 @@ export function processStream(
         }
 
         case "reasoning-start": {
+          closeTextSegment();
           sendSSE(controller, encoder, {
             type: "reasoning-start",
             id: typeof typedPart.id === "string" ? typedPart.id : "reasoning",
@@ -191,6 +218,7 @@ export function processStream(
         }
 
         case "reasoning-delta": {
+          closeTextSegment();
           sendSSE(controller, encoder, {
             type: "reasoning-delta",
             id: typeof typedPart.id === "string" ? typedPart.id : "reasoning",
@@ -200,6 +228,7 @@ export function processStream(
         }
 
         case "reasoning-end": {
+          closeTextSegment();
           sendSSE(controller, encoder, {
             type: "reasoning-end",
             id: typeof typedPart.id === "string" ? typedPart.id : "reasoning",
@@ -208,6 +237,7 @@ export function processStream(
         }
 
         case "tool-input-start": {
+          closeTextSegment();
           const toolId = typedPart.id;
           state.toolCalls.set(toolId, {
             id: toolId,
@@ -242,6 +272,7 @@ export function processStream(
         }
 
         case "tool-call": {
+          closeTextSegment();
           // tool-call fires when the full tool call is available
           const toolId = typedPart.toolCallId;
           const inputStr = normalizeToolInputString(typedPart.input);
@@ -271,6 +302,7 @@ export function processStream(
         }
 
         case "tool-result": {
+          closeTextSegment();
           const isError = typedPart.isError === true;
           logProviderToolPart("tool-result", {
             toolCallId: typedPart.toolCallId,
@@ -328,6 +360,7 @@ export function processStream(
         }
 
         case "tool-error": {
+          closeTextSegment();
           logProviderToolPart("tool-error", {
             toolCallId: typedPart.toolCallId,
             toolName: typedPart.toolName,
@@ -358,6 +391,7 @@ export function processStream(
         }
 
         case "finish": {
+          closeTextSegment();
           state.finishReason = typedPart.finishReason ?? null;
           if (typedPart.totalUsage) {
             const input = typedPart.totalUsage.inputTokens ?? 0;
@@ -373,6 +407,7 @@ export function processStream(
         }
 
         case "error": {
+          closeTextSegment();
           logger.warn("Runtime stream error:", typedPart.error);
           sendSSE(controller, encoder, {
             type: "error",

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -24,6 +24,7 @@ export interface StreamingToolCall {
   id: string;
   name: string;
   arguments: string;
+  inputAvailable?: boolean;
   providerExecuted?: boolean;
   dynamic?: boolean;
 }
@@ -158,6 +159,10 @@ export function processStream(
   return withSpan("agent.runtime.processStream", async () => {
     let eventCount = 0;
     let textOpen = false;
+    let activeReasoningId: string | null = null;
+
+    const normalizeReasoningId = (part: { id?: string }) =>
+      typeof part.id === "string" && part.id.length > 0 ? part.id : "reasoning";
 
     const openTextSegment = () => {
       if (textOpen) {
@@ -183,6 +188,107 @@ export function processStream(
       });
     };
 
+    const openReasoningSegment = (reasoningId: string) => {
+      if (activeReasoningId === reasoningId) {
+        return;
+      }
+
+      if (activeReasoningId !== null) {
+        sendSSE(controller, encoder, {
+          type: "reasoning-end",
+          id: activeReasoningId,
+        });
+      }
+
+      activeReasoningId = reasoningId;
+      sendSSE(controller, encoder, {
+        type: "reasoning-start",
+        id: reasoningId,
+      });
+    };
+
+    const closeReasoningSegment = () => {
+      if (activeReasoningId === null) {
+        return;
+      }
+
+      sendSSE(controller, encoder, {
+        type: "reasoning-end",
+        id: activeReasoningId,
+      });
+      activeReasoningId = null;
+    };
+
+    const ensureToolLifecycle = (part: {
+      toolCallId: string;
+      toolName: string;
+      input?: unknown;
+      providerExecuted?: boolean;
+      dynamic?: boolean;
+    }) => {
+      const dynamic = part.dynamic ?? isDynamicTool(part.toolName);
+      const existing = state.toolCalls.get(part.toolCallId);
+
+      if (!existing) {
+        const normalizedInput = parseToolInputObject(part.input);
+        state.toolCalls.set(part.toolCallId, {
+          id: part.toolCallId,
+          name: part.toolName,
+          arguments: normalizeToolInputString(part.input),
+          inputAvailable: true,
+          ...(part.providerExecuted !== undefined
+            ? { providerExecuted: part.providerExecuted }
+            : {}),
+          ...(dynamic ? { dynamic: true } : {}),
+        });
+        sendSSE(controller, encoder, {
+          type: "tool-input-start",
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          ...(dynamic ? { dynamic: true } : {}),
+        });
+        sendSSE(controller, encoder, {
+          type: "tool-input-available",
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          input: normalizedInput,
+          ...(part.providerExecuted !== undefined
+            ? { providerExecuted: part.providerExecuted }
+            : {}),
+          ...(dynamic ? { dynamic: true } : {}),
+        });
+        return;
+      }
+
+      if (existing.inputAvailable) {
+        return;
+      }
+
+      const resolvedArguments = part.input !== undefined
+        ? mergeToolCallInput(existing.arguments, normalizeToolInputString(part.input))
+        : existing.arguments;
+      const resolvedInput = parseToolInputObject(resolvedArguments);
+      existing.arguments = resolvedArguments;
+      existing.inputAvailable = true;
+      if (part.providerExecuted !== undefined) {
+        existing.providerExecuted = part.providerExecuted;
+      }
+      if (dynamic) {
+        existing.dynamic = true;
+      }
+
+      sendSSE(controller, encoder, {
+        type: "tool-input-available",
+        toolCallId: part.toolCallId,
+        toolName: existing.name,
+        input: resolvedInput,
+        ...(existing.providerExecuted !== undefined
+          ? { providerExecuted: existing.providerExecuted }
+          : {}),
+        ...(existing.dynamic ? { dynamic: true } : {}),
+      });
+    };
+
     throwIfAborted(abortSignal);
 
     for await (const part of result.fullStream) {
@@ -197,6 +303,7 @@ export function processStream(
 
       switch (typedPart.type) {
         case "text-delta": {
+          closeReasoningSegment();
           openTextSegment();
           state.accumulatedText += typedPart.text;
           sendSSE(controller, encoder, {
@@ -210,18 +317,16 @@ export function processStream(
 
         case "reasoning-start": {
           closeTextSegment();
-          sendSSE(controller, encoder, {
-            type: "reasoning-start",
-            id: typeof typedPart.id === "string" ? typedPart.id : "reasoning",
-          });
+          openReasoningSegment(normalizeReasoningId(typedPart));
           break;
         }
 
         case "reasoning-delta": {
           closeTextSegment();
+          openReasoningSegment(normalizeReasoningId(typedPart));
           sendSSE(controller, encoder, {
             type: "reasoning-delta",
-            id: typeof typedPart.id === "string" ? typedPart.id : "reasoning",
+            id: normalizeReasoningId(typedPart),
             delta: typeof typedPart.delta === "string" ? typedPart.delta : "",
           });
           break;
@@ -229,20 +334,22 @@ export function processStream(
 
         case "reasoning-end": {
           closeTextSegment();
-          sendSSE(controller, encoder, {
-            type: "reasoning-end",
-            id: typeof typedPart.id === "string" ? typedPart.id : "reasoning",
-          });
+          if (activeReasoningId === null) {
+            activeReasoningId = normalizeReasoningId(typedPart);
+          }
+          closeReasoningSegment();
           break;
         }
 
         case "tool-input-start": {
           closeTextSegment();
+          closeReasoningSegment();
           const toolId = typedPart.id;
           state.toolCalls.set(toolId, {
             id: toolId,
             name: typedPart.toolName,
             arguments: "",
+            inputAvailable: false,
             providerExecuted: typedPart.providerExecuted,
             dynamic: typedPart.dynamic,
           });
@@ -258,6 +365,7 @@ export function processStream(
         }
 
         case "tool-input-delta": {
+          closeReasoningSegment();
           const toolId = typedPart.id;
           const tc = state.toolCalls.get(toolId);
           if (!tc) break;
@@ -273,6 +381,7 @@ export function processStream(
 
         case "tool-call": {
           closeTextSegment();
+          closeReasoningSegment();
           // tool-call fires when the full tool call is available
           const toolId = typedPart.toolCallId;
           const inputStr = normalizeToolInputString(typedPart.input);
@@ -282,6 +391,7 @@ export function processStream(
             id: toolId,
             name: typedPart.toolName,
             arguments: resolvedArguments,
+            inputAvailable: true,
             providerExecuted: typedPart.providerExecuted,
             dynamic: typedPart.dynamic,
           });
@@ -303,6 +413,14 @@ export function processStream(
 
         case "tool-result": {
           closeTextSegment();
+          closeReasoningSegment();
+          ensureToolLifecycle({
+            toolCallId: typedPart.toolCallId,
+            toolName: typedPart.toolName,
+            input: typedPart.input,
+            providerExecuted: typedPart.providerExecuted,
+            dynamic: typedPart.dynamic,
+          });
           const isError = typedPart.isError === true;
           logProviderToolPart("tool-result", {
             toolCallId: typedPart.toolCallId,
@@ -361,6 +479,14 @@ export function processStream(
 
         case "tool-error": {
           closeTextSegment();
+          closeReasoningSegment();
+          ensureToolLifecycle({
+            toolCallId: typedPart.toolCallId,
+            toolName: typedPart.toolName,
+            input: typedPart.input,
+            providerExecuted: typedPart.providerExecuted,
+            dynamic: typedPart.dynamic,
+          });
           logProviderToolPart("tool-error", {
             toolCallId: typedPart.toolCallId,
             toolName: typedPart.toolName,
@@ -392,6 +518,7 @@ export function processStream(
 
         case "finish": {
           closeTextSegment();
+          closeReasoningSegment();
           state.finishReason = typedPart.finishReason ?? null;
           if (typedPart.totalUsage) {
             const input = typedPart.totalUsage.inputTokens ?? 0;
@@ -408,6 +535,7 @@ export function processStream(
 
         case "error": {
           closeTextSegment();
+          closeReasoningSegment();
           logger.warn("Runtime stream error:", typedPart.error);
           sendSSE(controller, encoder, {
             type: "error",

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -488,8 +488,6 @@ export class AgentRuntime {
               model: effectiveModel,
             },
           });
-          sendSSE(controller, encoder, { type: "text-start", id: textPartId });
-
           const response = await this.executeAgentLoopStreaming(
             systemPrompt,
             memoryMessages,
@@ -510,7 +508,6 @@ export class AgentRuntime {
           callbacks?.onFinish?.(response);
           throwIfAborted(streamAbortSignal);
 
-          sendSSE(controller, encoder, { type: "text-end", id: textPartId });
           sendSSE(controller, encoder, { type: "message-finish" });
           closeSSEStream(controller);
         } catch (error) {

--- a/src/internal-agents/ag-ui-sse.test.ts
+++ b/src/internal-agents/ag-ui-sse.test.ts
@@ -63,10 +63,16 @@ describe("internal-agents/ag-ui-sse", () => {
         toolCallId: "tool-1",
         toolName: "studio_focus_component",
       }),
-      [{
-        event: "ToolCallStart",
-        payload: { toolCallId: "tool-1", toolCallName: "studio_focus_component" },
-      }],
+      [
+        {
+          event: "TextMessageEnd",
+          payload: { messageId: "assistant-1" },
+        },
+        {
+          event: "ToolCallStart",
+          payload: { toolCallId: "tool-1", toolCallName: "studio_focus_component" },
+        },
+      ],
     );
     assertEquals(
       mapRuntimeEventToAgUi(state, {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.199";
+export const VERSION = "0.1.200";


### PR DESCRIPTION
## Summary
- close open assistant text segments when tool, reasoning, error, or finish events interrupt the stream
- reopen text segments when text resumes after a tool boundary
- add a regression test for the observed `text -> form_input -> text` run shape

## Reproduction
A durable run can currently emit:
- `TEXT_MESSAGE_START`
- `TEXT_MESSAGE_CONTENT`
- `TOOL_CALL_START` / `TOOL_CALL_RESULT`
- more `TEXT_MESSAGE_CONTENT` on the same `messageId`

without an intervening `TEXT_MESSAGE_END`.

That leaves replay and snapshot builders to infer a missing text boundary downstream.

## Root Cause
`veryfront-code` opened one text span before the full streaming loop and only closed it after the whole turn finished. Tool interruptions did not close the active text segment.

## Fix
Move text segment lifecycle into the raw stream handler so non-text interruptions close any open text segment and later text deltas reopen it.

## Verification
- `deno test --no-check --allow-all src/agent/runtime/chat-stream-handler.test.ts src/agent/ag-ui-browser-encoder.test.ts src/internal-agents/ag-ui-sse.test.ts src/agent/runtime/index.test.ts`
- `deno check src/agent/runtime/chat-stream-handler.ts src/agent/runtime/index.ts src/agent/runtime/chat-stream-handler.test.ts`
- `deno fmt --check src/agent/runtime/chat-stream-handler.ts src/agent/runtime/index.ts src/agent/runtime/chat-stream-handler.test.ts`