### PR TITLE
feat(mcp): add vf_run_lint tool for running linter via MCP

### DIFF
--- a/cli/mcp/advanced-tools.ts
+++ b/cli/mcp/advanced-tools.ts
@@ -21,6 +21,7 @@ import {
   vfListLocalProjects,
   vfListRoutes,
 } from "./tools/project-tools.ts";
+import { vfRunLint } from "./tools/run-lint-tool.ts";
 import { vfRunTests } from "./tools/run-tests-tool.ts";
 import { vfGetConventions, vfScaffold } from "./tools/scaffold-tools.ts";
 import { vfGetSkillReference, vfGetSkills } from "./tools/skill-tools.ts";
@@ -48,6 +49,7 @@ export const advancedTools: MCPTool[] = [
   vfHotReload,
   vfTriggerHmr,
   vfWaitForReady,
+  vfRunLint,
   vfGetFlywheelStatus,
   vfRunTests,
 ];

--- a/cli/mcp/standalone.ts
+++ b/cli/mcp/standalone.ts
@@ -448,17 +448,21 @@ export class StandaloneMCPServer {
           "Run the linter. Returns structured diagnostics with file, line, column, rule code, and message. " +
           "Do not use for test results — use vf_run_tests instead. " +
           "Do not use for compile/runtime errors — use vf_get_errors instead.",
-        inputSchema: { type: "object", properties: {} },
-        async execute() {
-          const { parseLintJsonOutput } = await import("../commands/lint/command.ts");
-          const cmd = new Deno.Command("deno", {
-            args: ["lint", "--json"],
-            stdout: "piped",
-            stderr: "piped",
+        inputSchema: {
+          type: "object",
+          properties: {
+            timeout: {
+              type: "number",
+              description:
+                "Maximum time to wait for lint completion in milliseconds (default: 120000)",
+            },
+          },
+        },
+        async execute(args) {
+          const { executeLint } = await import("./tools/run-lint-tool.ts");
+          return executeLint({
+            timeout: args.timeout as number | undefined,
           });
-          const { code, stdout } = await cmd.output();
-          const output = new TextDecoder().decode(stdout);
-          return parseLintJsonOutput(output, code);
         },
       },
       ...this.createContext7Tools(),

--- a/cli/mcp/standalone.ts
+++ b/cli/mcp/standalone.ts
@@ -442,6 +442,25 @@ export class StandaloneMCPServer {
           });
         },
       },
+      {
+        name: "vf_run_lint",
+        description:
+          "Run the linter. Returns structured diagnostics with file, line, column, rule code, and message. " +
+          "Do not use for test results — use vf_run_tests instead. " +
+          "Do not use for compile/runtime errors — use vf_get_errors instead.",
+        inputSchema: { type: "object", properties: {} },
+        async execute() {
+          const { parseLintJsonOutput } = await import("../commands/lint/command.ts");
+          const cmd = new Deno.Command("deno", {
+            args: ["lint", "--json"],
+            stdout: "piped",
+            stderr: "piped",
+          });
+          const { code, stdout } = await cmd.output();
+          const output = new TextDecoder().decode(stdout);
+          return parseLintJsonOutput(output, code);
+        },
+      },
       ...this.createContext7Tools(),
     ];
   }

--- a/cli/mcp/tools/run-lint-tool.test.ts
+++ b/cli/mcp/tools/run-lint-tool.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Tests for MCP run-lint tool
+ */
+
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { vfRunLint } from "./run-lint-tool.ts";
+
+describe("mcp/tools/run-lint-tool", () => {
+  describe("vfRunLint", () => {
+    it("has correct tool name", () => {
+      assertEquals(vfRunLint.name, "vf_run_lint");
+    });
+
+    it("has description mentioning lint", () => {
+      assertExists(vfRunLint.description);
+      assertEquals(vfRunLint.description.toLowerCase().includes("lint"), true);
+    });
+
+    it("has execute function", () => {
+      assertEquals(typeof vfRunLint.execute, "function");
+    });
+
+    it("has correct annotations", () => {
+      assertExists(vfRunLint.annotations);
+      assertEquals(vfRunLint.annotations!.readOnlyHint, true);
+      assertEquals(vfRunLint.annotations!.destructiveHint, false);
+      assertEquals(vfRunLint.annotations!.idempotentHint, true);
+      assertEquals(vfRunLint.annotations!.openWorldHint, false);
+    });
+
+    it("has title", () => {
+      assertEquals(vfRunLint.title, "Run Lint");
+    });
+  });
+});

--- a/cli/mcp/tools/run-lint-tool.test.ts
+++ b/cli/mcp/tools/run-lint-tool.test.ts
@@ -2,12 +2,17 @@
  * Tests for MCP run-lint tool
  */
 
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { vfRunLint } from "./run-lint-tool.ts";
+import { parseLintJsonOutput } from "../../commands/lint/command.ts";
+import { executeLint, vfRunLint } from "./run-lint-tool.ts";
+
+// ---------------------------------------------------------------------------
+// Tool definition (shape)
+// ---------------------------------------------------------------------------
 
 describe("mcp/tools/run-lint-tool", () => {
-  describe("vfRunLint", () => {
+  describe("vfRunLint tool definition", () => {
     it("has correct tool name", () => {
       assertEquals(vfRunLint.name, "vf_run_lint");
     });
@@ -17,20 +22,141 @@ describe("mcp/tools/run-lint-tool", () => {
       assertEquals(vfRunLint.description.toLowerCase().includes("lint"), true);
     });
 
+    it("has description cross-referencing vf_run_tests", () => {
+      assertEquals(vfRunLint.description.includes("vf_run_tests"), true);
+    });
+
+    it("has description cross-referencing vf_get_errors", () => {
+      assertEquals(vfRunLint.description.includes("vf_get_errors"), true);
+    });
+
     it("has execute function", () => {
       assertEquals(typeof vfRunLint.execute, "function");
     });
 
-    it("has correct annotations", () => {
-      assertExists(vfRunLint.annotations);
-      assertEquals(vfRunLint.annotations!.readOnlyHint, true);
-      assertEquals(vfRunLint.annotations!.destructiveHint, false);
-      assertEquals(vfRunLint.annotations!.idempotentHint, true);
-      assertEquals(vfRunLint.annotations!.openWorldHint, false);
+    it("has correct annotations — read-only, not destructive", () => {
+      assertEquals(vfRunLint.annotations?.readOnlyHint, true);
+      assertEquals(vfRunLint.annotations?.destructiveHint, false);
+      assertEquals(vfRunLint.annotations?.idempotentHint, true);
+      assertEquals(vfRunLint.annotations?.openWorldHint, false);
     });
 
     it("has title", () => {
       assertEquals(vfRunLint.title, "Run Lint");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // parseLintJsonOutput (validates the parser the tool depends on)
+  // ---------------------------------------------------------------------------
+
+  describe("parseLintJsonOutput integration", () => {
+    it("parses clean lint output with no diagnostics", () => {
+      const output = JSON.stringify({ diagnostics: [] });
+      const result = parseLintJsonOutput(output, 0);
+      assertEquals(result.success, true);
+      assertEquals(result.diagnostics.length, 0);
+      assertEquals(result.summary.total, 0);
+      assertEquals(result.summary.files_checked, 0);
+    });
+
+    it("parses lint output with diagnostics", () => {
+      const output = JSON.stringify({
+        diagnostics: [
+          {
+            filename: "src/app.ts",
+            range: { start: { line: 10, col: 5 } },
+            code: "no-unused-vars",
+            message: "'x' is declared but never used",
+          },
+          {
+            filename: "src/utils.ts",
+            range: { start: { line: 3, col: 1 } },
+            code: "no-explicit-any",
+            message: "Unexpected any. Specify a different type.",
+          },
+        ],
+      });
+      const result = parseLintJsonOutput(output, 1);
+      assertEquals(result.success, false);
+      assertEquals(result.diagnostics.length, 2);
+      assertEquals(result.summary.total, 2);
+      assertEquals(result.summary.files_checked, 2);
+
+      assertEquals(result.diagnostics[0].file, "src/app.ts");
+      assertEquals(result.diagnostics[0].line, 10);
+      assertEquals(result.diagnostics[0].col, 5);
+      assertEquals(result.diagnostics[0].code, "no-unused-vars");
+      assertEquals(result.diagnostics[0].message, "'x' is declared but never used");
+
+      assertEquals(result.diagnostics[1].file, "src/utils.ts");
+    });
+
+    it("counts unique files correctly when multiple diagnostics in same file", () => {
+      const output = JSON.stringify({
+        diagnostics: [
+          {
+            filename: "src/app.ts",
+            range: { start: { line: 1, col: 1 } },
+            code: "no-unused-vars",
+            message: "a",
+          },
+          {
+            filename: "src/app.ts",
+            range: { start: { line: 5, col: 1 } },
+            code: "no-explicit-any",
+            message: "b",
+          },
+          {
+            filename: "src/other.ts",
+            range: { start: { line: 1, col: 1 } },
+            code: "no-unused-vars",
+            message: "c",
+          },
+        ],
+      });
+      const result = parseLintJsonOutput(output, 1);
+      assertEquals(result.summary.total, 3);
+      assertEquals(result.summary.files_checked, 2);
+    });
+
+    it("handles empty output gracefully", () => {
+      const result = parseLintJsonOutput("", 0);
+      assertEquals(result.success, true);
+      assertEquals(result.diagnostics.length, 0);
+    });
+
+    it("handles invalid JSON gracefully", () => {
+      const result = parseLintJsonOutput("not json at all", 1);
+      assertEquals(result.success, false);
+      assertEquals(result.diagnostics.length, 0);
+    });
+
+    it("handles missing fields in diagnostics gracefully", () => {
+      const output = JSON.stringify({
+        diagnostics: [{ filename: "foo.ts" }],
+      });
+      const result = parseLintJsonOutput(output, 1);
+      assertEquals(result.diagnostics.length, 1);
+      assertEquals(result.diagnostics[0].file, "foo.ts");
+      assertEquals(result.diagnostics[0].line, 0);
+      assertEquals(result.diagnostics[0].col, 0);
+      assertEquals(result.diagnostics[0].code, "");
+      assertEquals(result.diagnostics[0].message, "");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // executeLint timeout
+  // ---------------------------------------------------------------------------
+
+  describe("executeLint", () => {
+    it("rejects on timeout", async () => {
+      await assertRejects(
+        () => executeLint({ timeout: 1 }),
+        Error,
+        "timed out",
+      );
     });
   });
 });

--- a/cli/mcp/tools/run-lint-tool.ts
+++ b/cli/mcp/tools/run-lint-tool.ts
@@ -1,22 +1,53 @@
 /**
- * MCP tool for running the linter via MCP.
+ * MCP tool: vf_run_lint
  *
- * Spawns `deno lint --json` and returns structured diagnostics.
- *
- * @module cli/mcp/tools/run-lint-tool
+ * Runs the linter via subprocess and returns structured diagnostics.
+ * Reuses parseLintJsonOutput from the CLI lint command.
  */
 
 import { z } from "zod";
 import type { MCPTool } from "../tools.ts";
 import { type LintResult, parseLintJsonOutput } from "../../commands/lint/command.ts";
 
-// ============================================================================
-// Tool: vf_run_lint
-// ============================================================================
-
-const runLintInput = z.object({});
+const runLintInput = z.object({
+  timeout: z.number().optional().default(120000).describe(
+    "Maximum time to wait for lint completion in milliseconds. Defaults to 120000 (2 minutes).",
+  ),
+});
 
 type RunLintInput = z.infer<typeof runLintInput>;
+
+/** Spawn deno lint and return structured results. Exported for standalone reuse. */
+export async function executeLint(
+  input: { timeout?: number } = {},
+): Promise<LintResult> {
+  const cmd = new Deno.Command("deno", {
+    args: ["lint", "--json"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const child = cmd.spawn();
+  const timeoutMs = input.timeout ?? 120000;
+
+  const result = await Promise.race([
+    child.output(),
+    new Promise<never>((_, reject) => {
+      const timer = setTimeout(() => {
+        try {
+          child.kill();
+        } catch {
+          // Process may have already exited
+        }
+        reject(new Error(`Lint execution timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      Deno.unrefTimer(timer);
+    }),
+  ]);
+
+  const stdout = new TextDecoder().decode(result.stdout);
+  return parseLintJsonOutput(stdout, result.code);
+}
 
 export const vfRunLint: MCPTool<RunLintInput, LintResult> = {
   name: "vf_run_lint",
@@ -27,19 +58,10 @@ export const vfRunLint: MCPTool<RunLintInput, LintResult> = {
     idempotentHint: true,
     openWorldHint: false,
   },
-  description:
-    "Use this when you need to check the project for lint errors and style violations. Runs `deno lint` and returns structured diagnostics with file, line, column, code, and message. Do not use for runtime errors — use vf_get_errors instead. Do not use for formatting — use a formatter tool instead.",
+  description: "Use this when you need to check for lint issues in the project. " +
+    "Returns structured diagnostics with file path, line, column, rule code, and message for each issue. " +
+    "Do not use for test results — use vf_run_tests instead. " +
+    "Do not use for compile/runtime errors — use vf_get_errors instead.",
   inputSchema: runLintInput,
-  execute: async () => {
-    const command = new Deno.Command("deno", {
-      args: ["lint", "--json"],
-      stdout: "piped",
-      stderr: "piped",
-    });
-
-    const { code, stdout } = await command.output();
-    const output = new TextDecoder().decode(stdout);
-
-    return parseLintJsonOutput(output, code);
-  },
+  execute: (input) => executeLint(input),
 };

--- a/cli/mcp/tools/run-lint-tool.ts
+++ b/cli/mcp/tools/run-lint-tool.ts
@@ -1,0 +1,45 @@
+/**
+ * MCP tool for running the linter via MCP.
+ *
+ * Spawns `deno lint --json` and returns structured diagnostics.
+ *
+ * @module cli/mcp/tools/run-lint-tool
+ */
+
+import { z } from "zod";
+import type { MCPTool } from "../tools.ts";
+import { type LintResult, parseLintJsonOutput } from "../../commands/lint/command.ts";
+
+// ============================================================================
+// Tool: vf_run_lint
+// ============================================================================
+
+const runLintInput = z.object({});
+
+type RunLintInput = z.infer<typeof runLintInput>;
+
+export const vfRunLint: MCPTool<RunLintInput, LintResult> = {
+  name: "vf_run_lint",
+  title: "Run Lint",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  description:
+    "Use this when you need to check the project for lint errors and style violations. Runs `deno lint` and returns structured diagnostics with file, line, column, code, and message. Do not use for runtime errors — use vf_get_errors instead. Do not use for formatting — use a formatter tool instead.",
+  inputSchema: runLintInput,
+  execute: async () => {
+    const command = new Deno.Command("deno", {
+      args: ["lint", "--json"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const { code, stdout } = await command.output();
+    const output = new TextDecoder().decode(stdout);
+
+    return parseLintJsonOutput(output, code);
+  },
+};


### PR DESCRIPTION
## Summary

- Add `vf_run_lint` MCP tool that spawns `deno lint --json` and returns structured `LintResult`
- Register in both connected mode (`advanced-tools.ts`) and standalone mode (`standalone.ts`)
- Reuses `parseLintJsonOutput()` from existing CLI lint command
- Extracted shared `executeLint()` to eliminate duplication between connected and standalone modes

Closes #1006

## Changes

**New files:**
- `cli/mcp/tools/run-lint-tool.ts` — Tool definition with `executeLint()` shared helper
- `cli/mcp/tools/run-lint-tool.test.ts` — 17 test steps covering shape, cross-references, parser integration, and timeout

**Modified files (additive only):**
- `cli/mcp/advanced-tools.ts` — Import + array entry
- `cli/mcp/standalone.ts` — Standalone tool entry (imports `executeLint()`, no duplication)

## Tool specification

| Field | Value |
|-------|-------|
| Name | `vf_run_lint` |
| Title | `Run Lint` |
| Annotations | `readOnlyHint: true`, `destructiveHint: false`, `idempotentHint: true`, `openWorldHint: false` |
| Input | `timeout` (optional number, default 120000ms) |
| Output | `LintResult` with `{ success, diagnostics: [{ file, line, col, code, message }], summary: { total, files_checked } }` |

## Design decisions

- **`readOnlyHint: true`** — Unlike tests, `deno lint` is genuinely read-only (static analysis, no code execution)
- **`timeout` parameter** — Configurable subprocess timeout (default 2 min) with `child.kill()` via `Promise.race`
- **Shared `executeLint()` export** — Standalone imports it directly instead of duplicating subprocess logic
- **No restricted env** — Unlike `vf_run_tests`, lint does not execute user code, so inheriting parent env is safe and necessary (needs PATH to find deno)

## Test plan

- [x] `deno check cli/mcp/tools/run-lint-tool.ts` — no type errors
- [x] `deno test --no-check --allow-all cli/mcp/tools/run-lint-tool.test.ts` — 17 steps pass
- [x] `deno test --no-check --allow-all --parallel cli/mcp/` — 19 suites, 404 steps, 0 failed
- [x] `deno task build` — full build succeeds
- [x] Tool appears in `tools/list` via standalone MCP
- [x] `tools/call` returns valid `LintResult` with `{ success, diagnostics, summary }`
- [x] Timeout kills subprocess and returns error response
- [x] `getTool("vf_run_lint")` resolves in connected mode (52 total tools)
- [x] Zod schema validates timeout type, rejects non-numbers
- [x] `parseLintJsonOutput` handles: clean output, diagnostics, multi-file dedup, empty, invalid JSON, missing fields
- [x] Security review passed — no vulnerabilities found
- [x] No existing tool files modified (only additive changes)