### PR TITLE
feat(extensions): add core types, errors, and recommendations

### DIFF
--- a/src/extensions/errors.ts
+++ b/src/extensions/errors.ts
@@ -1,0 +1,39 @@
+/**
+ * Extension system error definitions.
+ *
+ * @module extensions/errors
+ */
+
+import { defineError } from "#veryfront/errors";
+
+export const MISSING_EXTENSION_ERROR = defineError({
+  slug: "missing-extension",
+  category: "RUNTIME",
+  status: 500,
+  title: "Required extension not found",
+  suggestion: "Install the missing extension package and add it to your configuration",
+});
+
+export const EXTENSION_VALIDATION_ERROR = defineError({
+  slug: "extension-validation",
+  category: "CONFIG",
+  status: 500,
+  title: "Extension validation failed",
+  suggestion: "Check that the extension exports a valid name, version, and capabilities array",
+});
+
+export const CIRCULAR_DEPENDENCY_ERROR = defineError({
+  slug: "extension-circular-dependency",
+  category: "CONFIG",
+  status: 500,
+  title: "Circular dependency detected between extensions",
+  suggestion: "Review the 'extends' fields in your extensions to break the cycle",
+});
+
+export const EXTENSION_CONFLICT_ERROR = defineError({
+  slug: "extension-conflict",
+  category: "CONFIG",
+  status: 500,
+  title: "Conflicting extensions detected",
+  suggestion: "Remove or disable one of the conflicting extensions in your configuration",
+});

--- a/src/extensions/errors.ts
+++ b/src/extensions/errors.ts
@@ -17,7 +17,7 @@ export const MISSING_EXTENSION_ERROR = defineError({
 export const EXTENSION_VALIDATION_ERROR = defineError({
   slug: "extension-validation",
   category: "CONFIG",
-  status: 500,
+  status: 422,
   title: "Extension validation failed",
   suggestion: "Check that the extension exports a valid name, version, and capabilities array",
 });
@@ -25,7 +25,7 @@ export const EXTENSION_VALIDATION_ERROR = defineError({
 export const CIRCULAR_DEPENDENCY_ERROR = defineError({
   slug: "extension-circular-dependency",
   category: "CONFIG",
-  status: 500,
+  status: 422,
   title: "Circular dependency detected between extensions",
   suggestion: "Review the 'extends' fields in your extensions to break the cycle",
 });
@@ -33,7 +33,7 @@ export const CIRCULAR_DEPENDENCY_ERROR = defineError({
 export const EXTENSION_CONFLICT_ERROR = defineError({
   slug: "extension-conflict",
   category: "CONFIG",
-  status: 500,
+  status: 409,
   title: "Conflicting extensions detected",
   suggestion: "Remove or disable one of the conflicting extensions in your configuration",
 });

--- a/src/extensions/recommendations.ts
+++ b/src/extensions/recommendations.ts
@@ -1,0 +1,24 @@
+/**
+ * Maps contract names to recommended first-party extension packages.
+ *
+ * @module extensions/recommendations
+ */
+
+const recommendations: Record<string, string> = {
+  Bundler: "@veryfront/ext-esbuild",
+  CacheStore: "@veryfront/ext-redis",
+  CSSProcessor: "@veryfront/ext-tailwind",
+  ContentTransformer: "@veryfront/ext-mdx",
+  DatabaseClient: "@veryfront/ext-postgres",
+  AuthProvider: "@veryfront/ext-jwt",
+  TracingExporter: "@veryfront/ext-opentelemetry",
+  AIModelProvider: "@veryfront/ext-openai",
+  EmbeddingProvider: "@veryfront/ext-embeddings",
+  CodeParser: "@veryfront/ext-babel",
+  SchemaValidator: "@veryfront/ext-zod",
+  NodeCompat: "@veryfront/ext-node-compat",
+};
+
+export function getRecommendation(contractName: string): string | undefined {
+  return recommendations[contractName];
+}

--- a/src/extensions/recommendations.ts
+++ b/src/extensions/recommendations.ts
@@ -4,21 +4,21 @@
  * @module extensions/recommendations
  */
 
-const recommendations: Record<string, string> = {
-  Bundler: "@veryfront/ext-esbuild",
-  CacheStore: "@veryfront/ext-redis",
-  CSSProcessor: "@veryfront/ext-tailwind",
-  ContentTransformer: "@veryfront/ext-mdx",
-  DatabaseClient: "@veryfront/ext-postgres",
-  AuthProvider: "@veryfront/ext-jwt",
-  TracingExporter: "@veryfront/ext-opentelemetry",
-  AIModelProvider: "@veryfront/ext-openai",
-  EmbeddingProvider: "@veryfront/ext-embeddings",
-  CodeParser: "@veryfront/ext-babel",
-  SchemaValidator: "@veryfront/ext-zod",
-  NodeCompat: "@veryfront/ext-node-compat",
-};
+const recommendations = new Map<string, string>([
+  ["Bundler", "@veryfront/ext-esbuild"],
+  ["CacheStore", "@veryfront/ext-redis"],
+  ["CSSProcessor", "@veryfront/ext-tailwind"],
+  ["ContentTransformer", "@veryfront/ext-mdx"],
+  ["DatabaseClient", "@veryfront/ext-postgres"],
+  ["AuthProvider", "@veryfront/ext-jwt"],
+  ["TracingExporter", "@veryfront/ext-opentelemetry"],
+  ["AIModelProvider", "@veryfront/ext-openai"],
+  ["EmbeddingProvider", "@veryfront/ext-embeddings"],
+  ["CodeParser", "@veryfront/ext-babel"],
+  ["SchemaValidator", "@veryfront/ext-zod"],
+  ["NodeCompat", "@veryfront/ext-node-compat"],
+]);
 
 export function getRecommendation(contractName: string): string | undefined {
-  return recommendations[contractName];
+  return recommendations.get(contractName);
 }

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -1,0 +1,57 @@
+/**
+ * Core types for the veryfront extension system.
+ *
+ * @module extensions/types
+ */
+
+/**
+ * Declares a system capability an extension requires.
+ * Object-based for extensibility -- scoping fields vary by type.
+ */
+export interface Capability {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface ExtensionContext {
+  get<T>(contract: string): T | undefined;
+  require<T>(contract: string): T;
+  provide<T>(contract: string, impl: T): void;
+  config: Record<string, unknown>;
+  logger: ExtensionLogger;
+}
+
+export interface ExtensionLogger {
+  debug(message: string, ...args: unknown[]): void;
+  info(message: string, ...args: unknown[]): void;
+  warn(message: string, ...args: unknown[]): void;
+  error(message: string, ...args: unknown[]): void;
+}
+
+export interface Extension {
+  name: string;
+  version: string;
+  capabilities: Capability[];
+  setup?(ctx: ExtensionContext): Promise<void> | void;
+  teardown?(): Promise<void> | void;
+  provides?: Record<string, unknown>;
+  extends?: Extension[];
+}
+
+export type ExtensionFactory = (config?: unknown) => Extension;
+
+export type ExtensionConfigEntry =
+  | Extension
+  | { name: string; enabled: false };
+
+export type ExtensionSource =
+  | "config"
+  | "package"
+  | "project"
+  | "local-file";
+
+export interface ResolvedExtension {
+  extension: Extension;
+  source: ExtensionSource;
+  origin: string;
+}


### PR DESCRIPTION
## Summary
- `src/extensions/types.ts` — Extension, ExtensionFactory, Capability (object-based), ExtensionContext, ExtensionLogger, ResolvedExtension, ExtensionSource, ExtensionConfigEntry
- `src/extensions/errors.ts` — 4 error definitions using `defineError()`: missing-extension (RUNTIME/500), extension-validation (CONFIG/422), extension-circular-dependency (CONFIG/422), extension-conflict (CONFIG/409)
- `src/extensions/recommendations.ts` — Map-based lookup of 12 contract names to `@veryfront/ext-*` packages via `getRecommendation()`

Closes #1005

## Review fixes applied
- CONFIG errors now use 4xx status codes (422 for validation/circular, 409 for conflict) — matches project convention where all existing CONFIG errors use 4xx
- Recommendations use Map instead of plain object — prevents prototype key leakage (constructor, toString, etc.)

## Security review
- No user input flows into these modules — contract names are developer-controlled strings
- Prototype pollution vector in getRecommendation() fixed by switching from Record indexing to Map.get()
- Error messages contain only developer-supplied extension names, no end-user data
- No file I/O, network access, or process spawning
- Zero external dependencies

## Acceptance criteria
- [x] src/extensions/types.ts exists with all types from the spec
- [x] Capability is an object interface with type: string and [key: string]: unknown (extensible)
- [x] Extension interface includes name, version, capabilities, setup?, teardown?, provides?, extends?
- [x] ExtensionFactory type is (config?: unknown) => Extension
- [x] src/extensions/errors.ts uses defineError() from #veryfront/errors with appropriate categories
- [x] All 4 errors defined: missing-extension (RUNTIME), extension-validation (CONFIG), extension-circular-dependency (CONFIG), extension-conflict (CONFIG)
- [x] src/extensions/recommendations.ts maps all 12 contracts to @veryfront/ext-* package names
- [x] deno check passes with no errors
- [x] Zero external dependencies added
- [x] No files outside src/extensions/ modified

## Test plan
- [x] deno check passes on all 3 files
- [x] Full test suite: 1339 passed, 0 failed