### PR TITLE
feat(mcp): add vf_build tool for production builds via MCP

### DIFF
--- a/cli/mcp/advanced-tools.ts
+++ b/cli/mcp/advanced-tools.ts
@@ -21,6 +21,7 @@ import {
   vfListLocalProjects,
   vfListRoutes,
 } from "./tools/project-tools.ts";
+import { vfBuild } from "./tools/build-tool.ts";
 import { vfRunLint } from "./tools/run-lint-tool.ts";
 import { vfRunTests } from "./tools/run-tests-tool.ts";
 import { vfGetConventions, vfScaffold } from "./tools/scaffold-tools.ts";
@@ -46,6 +47,7 @@ export const advancedTools: MCPTool[] = [
   vfPreviewRoute,
   vfGetDebugContext,
   vfGetComponentTree,
+  vfBuild,
   vfHotReload,
   vfTriggerHmr,
   vfWaitForReady,

--- a/cli/mcp/tools/build-tool.test.ts
+++ b/cli/mcp/tools/build-tool.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Tests for MCP build tool
+ */
+
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { vfBuild } from "./build-tool.ts";
+
+describe("mcp/tools/build-tool", () => {
+  describe("vfBuild", () => {
+    it("has correct tool name", () => {
+      assertEquals(vfBuild.name, "vf_build");
+    });
+
+    it("has description mentioning production build", () => {
+      assertExists(vfBuild.description);
+      assertEquals(vfBuild.description.includes("production build"), true);
+    });
+
+    it("has execute function", () => {
+      assertEquals(typeof vfBuild.execute, "function");
+    });
+
+    it("has correct annotations", () => {
+      assertExists(vfBuild.annotations);
+      assertEquals(vfBuild.annotations!.readOnlyHint, false);
+      assertEquals(vfBuild.annotations!.destructiveHint, false);
+      assertEquals(vfBuild.annotations!.idempotentHint, true);
+      assertEquals(vfBuild.annotations!.openWorldHint, false);
+    });
+
+    it("has title", () => {
+      assertEquals(vfBuild.title, "Production Build");
+    });
+  });
+});

--- a/cli/mcp/tools/build-tool.test.ts
+++ b/cli/mcp/tools/build-tool.test.ts
@@ -6,8 +6,12 @@ import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { vfBuild } from "./build-tool.ts";
 
+// ---------------------------------------------------------------------------
+// Tool definition (shape)
+// ---------------------------------------------------------------------------
+
 describe("mcp/tools/build-tool", () => {
-  describe("vfBuild", () => {
+  describe("vfBuild tool definition", () => {
     it("has correct tool name", () => {
       assertEquals(vfBuild.name, "vf_build");
     });
@@ -17,20 +21,102 @@ describe("mcp/tools/build-tool", () => {
       assertEquals(vfBuild.description.includes("production build"), true);
     });
 
+    it("has description mentioning dryRun", () => {
+      assertEquals(vfBuild.description.includes("dryRun"), true);
+    });
+
+    it("has description cross-referencing dev server", () => {
+      assertEquals(vfBuild.description.includes("dev server"), true);
+    });
+
     it("has execute function", () => {
       assertEquals(typeof vfBuild.execute, "function");
     });
 
-    it("has correct annotations", () => {
-      assertExists(vfBuild.annotations);
-      assertEquals(vfBuild.annotations!.readOnlyHint, false);
-      assertEquals(vfBuild.annotations!.destructiveHint, false);
-      assertEquals(vfBuild.annotations!.idempotentHint, true);
-      assertEquals(vfBuild.annotations!.openWorldHint, false);
+    it("has correct annotations — not read-only, not destructive, idempotent", () => {
+      assertEquals(vfBuild.annotations?.readOnlyHint, false);
+      assertEquals(vfBuild.annotations?.destructiveHint, false);
+      assertEquals(vfBuild.annotations?.idempotentHint, true);
+      assertEquals(vfBuild.annotations?.openWorldHint, false);
     });
 
     it("has title", () => {
       assertEquals(vfBuild.title, "Production Build");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Input schema validation
+  // ---------------------------------------------------------------------------
+
+  describe("input schema", () => {
+    it("accepts empty input with correct defaults", () => {
+      const parsed = vfBuild.inputSchema.parse({});
+      assertEquals(parsed.splitting, true);
+      assertEquals(parsed.compress, true);
+      assertEquals(parsed.ssg, true);
+      assertEquals(parsed.dryRun, false);
+      assertEquals(parsed.outputDir, undefined);
+    });
+
+    it("accepts all fields", () => {
+      const parsed = vfBuild.inputSchema.parse({
+        outputDir: "/tmp/build",
+        splitting: false,
+        compress: false,
+        ssg: false,
+        dryRun: true,
+      });
+      assertEquals(parsed.outputDir, "/tmp/build");
+      assertEquals(parsed.splitting, false);
+      assertEquals(parsed.compress, false);
+      assertEquals(parsed.ssg, false);
+      assertEquals(parsed.dryRun, true);
+    });
+
+    it("rejects invalid types", () => {
+      let threw = false;
+      try {
+        vfBuild.inputSchema.parse({ splitting: "yes" });
+      } catch {
+        threw = true;
+      }
+      assertEquals(threw, true);
+    });
+
+    it("rejects non-string outputDir", () => {
+      let threw = false;
+      try {
+        vfBuild.inputSchema.parse({ outputDir: 123 });
+      } catch {
+        threw = true;
+      }
+      assertEquals(threw, true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // BuildResult interface (execute returns correct shape on error)
+  // ---------------------------------------------------------------------------
+
+  describe("execute error handling", () => {
+    it("returns BuildResult with success false on build failure", async () => {
+      // Execute against a non-existent project dir to trigger a build error
+      const result = await vfBuild.execute({
+        outputDir: "/tmp/vf-build-test-nonexistent",
+        splitting: true,
+        compress: true,
+        ssg: true,
+        dryRun: true,
+      });
+      // buildProduction will fail because cwd() may not be a valid project
+      // Either way, it should return a structured result, not throw
+      assertExists(result);
+      assertEquals(typeof result.success, "boolean");
+      if (!result.success) {
+        assertEquals(typeof result.error, "string");
+        assertEquals(typeof result.duration_ms, "number");
+      }
     });
   });
 });

--- a/cli/mcp/tools/build-tool.ts
+++ b/cli/mcp/tools/build-tool.ts
@@ -64,8 +64,11 @@ export const vfBuild: MCPTool<BuildInput, BuildResult> = {
     idempotentHint: true,
     openWorldHint: false,
   },
-  description:
-    "Use this when you need to run a production build for the current project. Bundles, optimises, and writes output to the dist directory. Use dryRun=true to preview the build without writing files. Do not use for development — use the dev server tools instead.",
+  description: "Use this when you need to run a production build for the current project. " +
+    "Bundles, optimises, and writes output to the dist directory. " +
+    "Use dryRun=true to preview the build without writing files. " +
+    "Do not use for development — use the dev server tools instead. " +
+    "Do not use for lint checks — use vf_run_lint instead.",
   inputSchema: buildInput,
   execute: (input) =>
     withSpan(
@@ -107,6 +110,6 @@ export const vfBuild: MCPTool<BuildInput, BuildResult> = {
           };
         }
       },
-      {},
+      { "tool.dryRun": input.dryRun },
     ),
 };

--- a/cli/mcp/tools/build-tool.ts
+++ b/cli/mcp/tools/build-tool.ts
@@ -1,0 +1,112 @@
+/**
+ * MCP tool for production builds.
+ */
+
+import { z } from "zod";
+import { cwd } from "veryfront/platform";
+import { join } from "veryfront/platform/path";
+import { buildProduction } from "veryfront/build";
+import { withSpan } from "veryfront/observability/otlp-setup";
+import type { MCPTool } from "../tools.ts";
+
+// ============================================================================
+// Tool: vf_build
+// ============================================================================
+
+const buildInput = z.object({
+  outputDir: z
+    .string()
+    .optional()
+    .describe("Output directory for the build. Defaults to '<projectDir>/dist'."),
+  splitting: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe("Enable code splitting. Defaults to true."),
+  compress: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe("Enable compression (gzip/brotli). Defaults to true."),
+  ssg: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe("Enable static site generation. Defaults to true."),
+  dryRun: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("Preview the build without writing files to disk. Defaults to false."),
+});
+
+type BuildInput = z.infer<typeof buildInput>;
+
+interface BuildResult {
+  success: boolean;
+  pages?: number;
+  chunks?: number;
+  assets?: number;
+  totalSize?: number;
+  duration_ms?: number;
+  outputDir?: string;
+  dryRun?: boolean;
+  ssgPaths?: string[];
+  error?: string;
+}
+
+export const vfBuild: MCPTool<BuildInput, BuildResult> = {
+  name: "vf_build",
+  title: "Production Build",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  description:
+    "Use this when you need to run a production build for the current project. Bundles, optimises, and writes output to the dist directory. Use dryRun=true to preview the build without writing files. Do not use for development — use the dev server tools instead.",
+  inputSchema: buildInput,
+  execute: (input) =>
+    withSpan(
+      "cli.mcp.tool.vf_build",
+      async () => {
+        const projectDir = cwd();
+        const outputDir = input.outputDir ?? join(projectDir, "dist");
+        const startTime = Date.now();
+
+        try {
+          const stats = await buildProduction({
+            projectDir,
+            outputDir,
+            enableSplitting: input.splitting,
+            enableCompression: input.compress,
+            ssg: input.ssg,
+            dryRun: input.dryRun,
+          });
+
+          const duration_ms = Date.now() - startTime;
+
+          return {
+            success: true,
+            pages: stats.pages,
+            chunks: stats.chunks,
+            assets: stats.assets,
+            totalSize: stats.totalSize,
+            duration_ms,
+            outputDir,
+            dryRun: input.dryRun,
+            ssgPaths: stats.ssgPaths,
+          };
+        } catch (error) {
+          const duration_ms = Date.now() - startTime;
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+            duration_ms,
+          };
+        }
+      },
+      {},
+    ),
+};


### PR DESCRIPTION
## Summary

- Add `vf_build` MCP tool that calls `buildProduction()` directly and returns structured `BuildResult`
- Register in connected mode only (`advanced-tools.ts`) — not standalone (requires in-process project context)
- Supports `dryRun`, `splitting`, `compress`, `ssg`, and `outputDir` options

Closes #1007

## Changes

**New files:**
- `cli/mcp/tools/build-tool.ts` — Tool definition calling `buildProduction()` directly
- `cli/mcp/tools/build-tool.test.ts` — 15 test steps covering shape, schema validation, and error handling

**Modified files (additive only):**
- `cli/mcp/advanced-tools.ts` — Import + array entry

## Tool specification

| Field | Value |
|-------|-------|
| Name | `vf_build` |
| Title | `Production Build` |
| Annotations | `readOnlyHint: false`, `destructiveHint: false`, `idempotentHint: true`, `openWorldHint: false` |
| Input | `outputDir` (optional string), `splitting` (default true), `compress` (default true), `ssg` (default true), `dryRun` (default false) |
| Output | `BuildResult` with `{ success, pages, chunks, assets, totalSize, duration_ms, outputDir, dryRun, ssgPaths, error? }` |

## Design decisions

- **Connected mode only** — `buildProduction()` runs in-process, requires full project context. Not available in standalone stdio mode.
- **`readOnlyHint: false`** — Build writes to disk (unless `dryRun: true`)
- **Options mapping** — `splitting` maps to `enableSplitting`, `compress` maps to `enableCompression` for the `buildProduction()` API
- **Error catching** — On failure returns `{ success: false, error, duration_ms }` instead of throwing, so agents get structured feedback
- **`withSpan` observability** — Traces build execution with tool attributes

## Test plan

- [x] `deno check cli/mcp/tools/build-tool.ts` — no type errors
- [x] `deno test --no-check --allow-all cli/mcp/tools/build-tool.test.ts` — 15 steps pass
- [x] `deno test --no-check --allow-all --parallel cli/mcp/` — 20 suites, 419 steps, 0 failed
- [x] `deno task build` — full build succeeds
- [x] `getTool("vf_build")` resolves in connected mode (53 total tools)
- [x] Tool is NOT in standalone mode (verified)
- [x] Input schema validates types and applies defaults correctly
- [x] Execute catches build errors and returns structured `{ success: false, error }`
- [x] Description cross-references dev server tools and vf_run_lint
- [x] No existing tool files modified