### PR TITLE
fix(mcp): remove CI/CD stub tools that return not_implemented

### DIFF
--- a/cli/mcp/tools/cicd-tools.test.ts
+++ b/cli/mcp/tools/cicd-tools.test.ts
@@ -3,23 +3,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { cicdTools } from "./cicd-tools.ts";
 
 describe("CI/CD MCP Tools", () => {
-  it("exports vf_get_pipeline_status tool", () => {
-    const tool = cicdTools.find((t) => t.name === "vf_get_pipeline_status");
-    assertEquals(tool !== undefined, true);
-  });
-
-  it("exports vf_get_deploy_history tool", () => {
-    const tool = cicdTools.find((t) => t.name === "vf_get_deploy_history");
-    assertEquals(tool !== undefined, true);
-  });
-
-  it("exports vf_get_build_logs tool", () => {
-    const tool = cicdTools.find((t) => t.name === "vf_get_build_logs");
-    assertEquals(tool !== undefined, true);
-  });
-
-  it("exports vf_trigger_deploy tool", () => {
-    const tool = cicdTools.find((t) => t.name === "vf_trigger_deploy");
-    assertEquals(tool !== undefined, true);
+  it("exports an empty array (stubs removed until backend API is available)", () => {
+    assertEquals(cicdTools.length, 0);
   });
 });

--- a/cli/mcp/tools/cicd-tools.ts
+++ b/cli/mcp/tools/cicd-tools.ts
@@ -1,94 +1,17 @@
-import { z } from "zod";
+/**
+ * CI/CD MCP tools — placeholder
+ *
+ * These tools require backend API support that is not yet available.
+ * They were previously registered as stubs returning "not_implemented",
+ * which misled agents into wasting tool calls.
+ *
+ * Re-add tools here when the deploy API is available:
+ * - vf_get_pipeline_status
+ * - vf_get_deploy_history
+ * - vf_get_build_logs
+ * - vf_trigger_deploy
+ */
+
 import type { MCPTool } from "veryfront/mcp";
 
-const getPipelineStatusInput = z.object({
-  projectSlug: z.string().describe("Project slug"),
-  environment: z.string().optional().default("production").describe("Target environment"),
-});
-
-const vfGetPipelineStatus: MCPTool = {
-  name: "vf_get_pipeline_status",
-  title: "Pipeline Status",
-  annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
-  description: "Get the current build/deploy pipeline state for a project environment.",
-  inputSchema: getPipelineStatusInput,
-  execute: async (input: { projectSlug: string; environment: string }) => {
-    return {
-      status: "not_implemented",
-      message: "CI/CD pipeline API not yet available. This tool requires backend support.",
-      projectSlug: input.projectSlug,
-      environment: input.environment,
-    };
-  },
-};
-
-const getDeployHistoryInput = z.object({
-  projectSlug: z.string().describe("Project slug"),
-  limit: z.number().optional().default(10).describe("Number of recent deployments to return"),
-});
-
-const vfGetDeployHistory: MCPTool = {
-  name: "vf_get_deploy_history",
-  title: "Deploy History",
-  annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
-  description: "List recent deployments with status, version, URL, and timestamp.",
-  inputSchema: getDeployHistoryInput,
-  execute: async (input: { projectSlug: string; limit: number }) => {
-    return {
-      status: "not_implemented",
-      message: "Deploy history API not yet available.",
-      projectSlug: input.projectSlug,
-    };
-  },
-};
-
-const getBuildLogsInput = z.object({
-  projectSlug: z.string().describe("Project slug"),
-  deployId: z.string().optional().describe("Specific deployment ID (latest if omitted)"),
-});
-
-const vfGetBuildLogs: MCPTool = {
-  name: "vf_get_build_logs",
-  title: "Build Logs",
-  annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
-  description: "Get build logs from an active or recent build/deployment.",
-  inputSchema: getBuildLogsInput,
-  execute: async (input: { projectSlug: string; deployId?: string }) => {
-    return {
-      status: "not_implemented",
-      message: "Build logs API not yet available.",
-      projectSlug: input.projectSlug,
-    };
-  },
-};
-
-const triggerDeployInput = z.object({
-  projectSlug: z.string().describe("Project slug"),
-  environment: z.string().optional().default("production").describe("Target environment"),
-  branch: z.string().optional().default("main").describe("Branch to deploy"),
-});
-
-const vfTriggerDeploy: MCPTool = {
-  name: "vf_trigger_deploy",
-  title: "Trigger Deploy",
-  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
-  description:
-    "Trigger a deployment to an environment. Returns a deployment ID for status tracking.",
-  inputSchema: triggerDeployInput,
-  execute: async (input: { projectSlug: string; environment: string; branch: string }) => {
-    return {
-      status: "not_implemented",
-      message: "Deploy trigger API not yet available.",
-      projectSlug: input.projectSlug,
-      environment: input.environment,
-      branch: input.branch,
-    };
-  },
-};
-
-export const cicdTools: MCPTool[] = [
-  vfGetPipelineStatus,
-  vfGetDeployHistory,
-  vfGetBuildLogs,
-  vfTriggerDeploy,
-];
+export const cicdTools: MCPTool[] = [];


### PR DESCRIPTION
## Summary

- Remove 4 CI/CD stub tools that returned `"not_implemented"` and misled agents into wasting tool calls
- `cicdTools` export stays as empty array — zero changes to `advanced-tools.ts`
- Placeholder comment documents which tools to re-add when backend API is available

Closes #1012

## Changes

**Modified files:**
- `cli/mcp/tools/cicd-tools.ts` — Replace 4 stub tool definitions with empty array + placeholder comment
- `cli/mcp/tools/cicd-tools.test.ts` — Replace 4 tool-existence assertions with single `cicdTools.length === 0`

**NOT modified:**
- `cli/mcp/advanced-tools.ts` — `...cicdTools` spread stays, just spreads nothing now

## Removed tools

| Tool | Previously returned |
|------|-------------------|
| `vf_get_pipeline_status` | `{ status: "not_implemented" }` |
| `vf_get_deploy_history` | `{ status: "not_implemented" }` |
| `vf_get_build_logs` | `{ status: "not_implemented" }` |
| `vf_trigger_deploy` | `{ status: "not_implemented" }` |

## Test plan

- [x] `deno test --no-check --allow-all cli/mcp/tools/cicd-tools.test.ts` — 1 step passes
- [x] `deno test --no-check --allow-all --parallel cli/mcp/` — 21 suites, 435 steps, 0 failed
- [x] `deno task build` — full build succeeds
- [x] Removed tools do NOT appear in `allTools` (50 total tools)
- [x] Removed tools do NOT appear in standalone `tools/list`
- [x] `...cicdTools` spread in `advanced-tools.ts` unchanged (spreads empty array)
- [x] Placeholder comment lists all 4 tool names for future re-implementation
- [x] No other test files reference the removed tool names
- [x] Security review: no vulnerabilities (pure code removal)