### PR TITLE
Keep knowledge ingest parser spawning portable across runtimes

### DIFF
--- a/cli/commands/knowledge/command.test.ts
+++ b/cli/commands/knowledge/command.test.ts
@@ -13,6 +13,7 @@ import {
   createKnowledgeIngestResult,
   deriveKnowledgeRemotePath,
   ensureUniqueSlugs,
+  executeKnowledgeParserCommand,
   formatKnowledgeUploadSource,
   ingestResolvedSources,
   isLikelyLocalPath,
@@ -1066,6 +1067,63 @@ describe("knowledgeIngestPythonSource", () => {
     assertStringIncludes(
       knowledgeIngestPythonSource,
       String.raw`return f"{CODE_FENCE}json\n{rendered}\n{CODE_FENCE}", stats, warnings`,
+    );
+  });
+});
+
+describe("executeKnowledgeParserCommand", () => {
+  it("uses the cross-runtime command runner for python execution", async () => {
+    const calls: Array<{
+      cmd: string;
+      args: string[];
+      env?: Record<string, string>;
+      capture: true;
+    }> = [];
+
+    await executeKnowledgeParserCommand(
+      {
+        scriptPath: "/tmp/ingest.py",
+        inputJsonPath: "/tmp/input.json",
+        outputJsonPath: "/tmp/output.json",
+        env: { PYTHONPATH: "/tmp/python" },
+      },
+      {
+        runCommandFn: async (cmd, options) => {
+          calls.push({ cmd, ...options });
+          return { success: true, code: 0, stdout: "", stderr: "" };
+        },
+      },
+    );
+
+    assertEquals(calls, [{
+      cmd: "python3",
+      args: [
+        "/tmp/ingest.py",
+        "--input-json",
+        "/tmp/input.json",
+        "--output-json",
+        "/tmp/output.json",
+      ],
+      env: { PYTHONPATH: "/tmp/python" },
+      capture: true,
+    }]);
+  });
+
+  it("maps an empty spawn failure to the existing python3-required error", async () => {
+    await assertRejects(
+      () =>
+        executeKnowledgeParserCommand(
+          {
+            scriptPath: "/tmp/ingest.py",
+            inputJsonPath: "/tmp/input.json",
+            outputJsonPath: "/tmp/output.json",
+          },
+          {
+            runCommandFn: async () => ({ success: false, code: 1 }),
+          },
+        ),
+      Error,
+      "python3 is required. Install python3 and the supported parser packages, or run the command inside the Veryfront sandbox.",
     );
   });
 });

--- a/cli/commands/knowledge/command.test.ts
+++ b/cli/commands/knowledge/command.test.ts
@@ -1126,6 +1126,28 @@ describe("executeKnowledgeParserCommand", () => {
       "python3 is required. Install python3 and the supported parser packages, or run the command inside the Veryfront sandbox.",
     );
   });
+
+  it("maps thrown missing-executable errors to the existing python3-required error", async () => {
+    await assertRejects(
+      () =>
+        executeKnowledgeParserCommand(
+          {
+            scriptPath: "/tmp/ingest.py",
+            inputJsonPath: "/tmp/input.json",
+            outputJsonPath: "/tmp/output.json",
+          },
+          {
+            runCommandFn: async () => {
+              const error = new Error("spawn python3 ENOENT");
+              (error as Error & { code?: string }).code = "ENOENT";
+              throw error;
+            },
+          },
+        ),
+      Error,
+      "python3 is required. Install python3 and the supported parser packages, or run the command inside the Veryfront sandbox.",
+    );
+  });
 });
 
 describe("runKnowledgeParser", () => {

--- a/cli/commands/knowledge/command.ts
+++ b/cli/commands/knowledge/command.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 type SafeParseResult<T> = { success: true; data: T } | { success: false; error: z.ZodError };
 import { createFileSystem, getEnv } from "veryfront/platform";
 import { basename, extname, join, normalize, relative } from "veryfront/platform/path";
+import { type CommandResult, runCommand } from "#veryfront/platform/compat/process.ts";
 import { withSpan } from "veryfront/observability/otlp-setup";
 import { cliLogger } from "#cli/utils";
 import { type ApiClient, createApiClient, resolveConfigWithAuth } from "#cli/shared/config";
@@ -484,6 +485,50 @@ export async function runKnowledgeParser(input: {
   return result;
 }
 
+export async function executeKnowledgeParserCommand(input: {
+  scriptPath: string;
+  inputJsonPath: string;
+  outputJsonPath: string;
+  env?: Record<string, string>;
+}, deps: {
+  runCommandFn?: (
+    cmd: string,
+    options: {
+      args: string[];
+      env?: Record<string, string>;
+      capture: true;
+    },
+  ) => Promise<CommandResult>;
+} = {}): Promise<void> {
+  const runCommandFn = deps.runCommandFn ?? runCommand;
+  const result = await runCommandFn("python3", {
+    args: [
+      input.scriptPath,
+      "--input-json",
+      input.inputJsonPath,
+      "--output-json",
+      input.outputJsonPath,
+    ],
+    ...(input.env ? { env: input.env } : {}),
+    capture: true,
+  });
+
+  if (result.success) {
+    return;
+  }
+
+  const stderr = result.stderr?.trim();
+  const stdout = result.stdout?.trim();
+
+  if (result.code === 1 && !stderr && !stdout) {
+    throw new Error(
+      "python3 is required. Install python3 and the supported parser packages, or run the command inside the Veryfront sandbox.",
+    );
+  }
+
+  throw new Error(stderr || stdout || "parser exited unsuccessfully");
+}
+
 export async function runKnowledgeParsers(input: {
   files: KnowledgeParserInput[];
   outputDir: string;
@@ -514,27 +559,12 @@ export async function runKnowledgeParsers(input: {
       );
       await Deno.writeTextFile(scriptPath, knowledgeIngestPythonSource);
 
-      let result: Deno.CommandOutput;
-      try {
-        result = await new Deno.Command("python3", {
-          args: [scriptPath, "--input-json", inputJsonPath, "--output-json", outputJsonPath],
-          ...(input.env ? { env: input.env } : {}),
-          stdout: "piped",
-          stderr: "piped",
-        }).output();
-      } catch (error) {
-        if (error instanceof Deno.errors.NotFound) {
-          throw new Error(
-            "python3 is required. Install python3 and the supported parser packages, or run the command inside the Veryfront sandbox.",
-          );
-        }
-        throw error;
-      }
-
-      if (result.code !== 0) {
-        const stderr = new TextDecoder().decode(result.stderr).trim();
-        throw new Error(stderr || "parser exited unsuccessfully");
-      }
+      await executeKnowledgeParserCommand({
+        scriptPath,
+        inputJsonPath,
+        outputJsonPath,
+        env: input.env,
+      });
 
       const raw = await Deno.readTextFile(outputJsonPath);
       const parsed = JSON.parse(raw) as KnowledgeParserResult | KnowledgeParserResult[];

--- a/cli/commands/knowledge/command.ts
+++ b/cli/commands/knowledge/command.ts
@@ -485,6 +485,22 @@ export async function runKnowledgeParser(input: {
   return result;
 }
 
+function isMissingPythonExecutableError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const errorWithCode = error as Error & { code?: unknown };
+  if (errorWithCode.code === "ENOENT") {
+    return true;
+  }
+
+  return error.name === "NotFound" ||
+    /\bENOENT\b/i.test(error.message) ||
+    /not found/i.test(error.message) ||
+    /no such file or directory/i.test(error.message);
+}
+
 export async function executeKnowledgeParserCommand(input: {
   scriptPath: string;
   inputJsonPath: string;
@@ -501,17 +517,27 @@ export async function executeKnowledgeParserCommand(input: {
   ) => Promise<CommandResult>;
 } = {}): Promise<void> {
   const runCommandFn = deps.runCommandFn ?? runCommand;
-  const result = await runCommandFn("python3", {
-    args: [
-      input.scriptPath,
-      "--input-json",
-      input.inputJsonPath,
-      "--output-json",
-      input.outputJsonPath,
-    ],
-    ...(input.env ? { env: input.env } : {}),
-    capture: true,
-  });
+  let result: CommandResult;
+  try {
+    result = await runCommandFn("python3", {
+      args: [
+        input.scriptPath,
+        "--input-json",
+        input.inputJsonPath,
+        "--output-json",
+        input.outputJsonPath,
+      ],
+      ...(input.env ? { env: input.env } : {}),
+      capture: true,
+    });
+  } catch (error) {
+    if (isMissingPythonExecutableError(error)) {
+      throw new Error(
+        "python3 is required. Install python3 and the supported parser packages, or run the command inside the Veryfront sandbox.",
+      );
+    }
+    throw error;
+  }
 
   if (result.success) {
     return;

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.200",
+  "version": "0.1.201",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.200";
+export const VERSION = "0.1.201";


### PR DESCRIPTION
Refs veryfront/veryfront-studio#1319

## Summary
- replace the knowledge-ingest python subprocess launch with the existing cross-runtime `runCommand()` helper
- preserve the current `python3 is required` error mapping when the runner cannot spawn python
- bump the framework patch version to `0.1.200` for the release containing this fix

## Testing
- `deno test --no-check --allow-all cli/commands/knowledge/command.test.ts`
- `deno run -A scripts/build/build-npm-dnt.ts`
- exact Node CLI repro against the built npm package and a stub local API:
  - `node npm/bin/veryfront.js knowledge ingest <staged _knowledge-ingest/.../2c7e2940-..._rest.css> --json`
  - result: exit code `0`, `failed_count = 0`, `ingested_count = 1`, and a successful `PUT /projects/test-project/files/knowledge/...` upload
  - previous failure `dntShim.Deno.Command is not a constructor` did not occur