### PR TITLE
feat(extensions): contract registry

### DIFF
--- a/src/extensions/contracts.test.ts
+++ b/src/extensions/contracts.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the contract registry.
+ *
+ * @module extensions/contracts.test
+ */
+
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { register, reset, resolve, tryResolve } from "./contracts.ts";
+
+describe("extensions/contracts", () => {
+  afterEach(() => {
+    reset();
+  });
+
+  describe("resolve()", () => {
+    it("returns registered implementation", () => {
+      const impl = { run: () => "ok" };
+      register("Bundler", impl);
+      assertEquals(resolve("Bundler"), impl);
+    });
+
+    it("throws MissingExtensionError for unregistered contract", () => {
+      assertThrows(
+        () => resolve("UnknownContract"),
+        Error,
+        'Missing extension for contract "UnknownContract"',
+      );
+    });
+
+    it("includes recommendation in error message when available", () => {
+      assertThrows(
+        () => resolve("Bundler"),
+        Error,
+        "Recommended: @veryfront/ext-esbuild",
+      );
+    });
+  });
+
+  describe("tryResolve()", () => {
+    it("returns registered implementation", () => {
+      const impl = { query: () => [] };
+      register("DatabaseClient", impl);
+      assertEquals(tryResolve("DatabaseClient"), impl);
+    });
+
+    it("returns undefined for unregistered contract", () => {
+      assertEquals(tryResolve("Nonexistent"), undefined);
+    });
+  });
+
+  describe("register()", () => {
+    it("overwrites previous registration", () => {
+      register("CSSProcessor", { v: 1 });
+      register("CSSProcessor", { v: 2 });
+      assertEquals(resolve<{ v: number }>("CSSProcessor").v, 2);
+    });
+  });
+
+  describe("reset()", () => {
+    it("clears all registrations", () => {
+      register("Bundler", {});
+      register("CacheStore", {});
+      reset();
+      assertEquals(tryResolve("Bundler"), undefined);
+      assertEquals(tryResolve("CacheStore"), undefined);
+    });
+  });
+});

--- a/src/extensions/contracts.ts
+++ b/src/extensions/contracts.ts
@@ -1,0 +1,37 @@
+/**
+ * Contract registry — runtime resolution of extension-provided implementations.
+ *
+ * @module extensions/contracts
+ */
+
+import { MISSING_EXTENSION_ERROR } from "./errors.ts";
+import { getRecommendation } from "./recommendations.ts";
+
+const contracts = new Map<string, unknown>();
+
+export function resolve<T>(name: string): T {
+  const impl = contracts.get(name);
+  if (impl === undefined) {
+    const recommendation = getRecommendation(name);
+    const suggestion = recommendation ? `Install it with: deno add ${recommendation}` : undefined;
+    throw MISSING_EXTENSION_ERROR.create({
+      message: `Missing extension for contract "${name}"${
+        recommendation ? `. Recommended: ${recommendation}` : ""
+      }`,
+      suggestion,
+    });
+  }
+  return impl as T;
+}
+
+export function tryResolve<T>(name: string): T | undefined {
+  return contracts.get(name) as T | undefined;
+}
+
+export function register<T>(name: string, impl: T): void {
+  contracts.set(name, impl);
+}
+
+export function reset(): void {
+  contracts.clear();
+}

--- a/src/extensions/contracts.ts
+++ b/src/extensions/contracts.ts
@@ -13,12 +13,11 @@ export function resolve<T>(name: string): T {
   const impl = contracts.get(name);
   if (impl === undefined) {
     const recommendation = getRecommendation(name);
-    const suggestion = recommendation ? `Install it with: deno add ${recommendation}` : undefined;
     throw MISSING_EXTENSION_ERROR.create({
       message: `Missing extension for contract "${name}"${
         recommendation ? `. Recommended: ${recommendation}` : ""
       }`,
-      suggestion,
+      detail: recommendation ? `Install it with: deno add ${recommendation}` : undefined,
     });
   }
   return impl as T;

--- a/src/extensions/errors.ts
+++ b/src/extensions/errors.ts
@@ -1,0 +1,39 @@
+/**
+ * Extension system error definitions.
+ *
+ * @module extensions/errors
+ */
+
+import { defineError } from "#veryfront/errors";
+
+export const MISSING_EXTENSION_ERROR = defineError({
+  slug: "missing-extension",
+  category: "RUNTIME",
+  status: 500,
+  title: "Required extension not found",
+  suggestion: "Install the missing extension package and add it to your configuration",
+});
+
+export const EXTENSION_VALIDATION_ERROR = defineError({
+  slug: "extension-validation",
+  category: "CONFIG",
+  status: 500,
+  title: "Extension validation failed",
+  suggestion: "Check that the extension exports a valid name, version, and capabilities array",
+});
+
+export const CIRCULAR_DEPENDENCY_ERROR = defineError({
+  slug: "extension-circular-dependency",
+  category: "CONFIG",
+  status: 500,
+  title: "Circular dependency detected between extensions",
+  suggestion: "Review the 'extends' fields in your extensions to break the cycle",
+});
+
+export const EXTENSION_CONFLICT_ERROR = defineError({
+  slug: "extension-conflict",
+  category: "CONFIG",
+  status: 500,
+  title: "Conflicting extensions detected",
+  suggestion: "Remove or disable one of the conflicting extensions in your configuration",
+});

--- a/src/extensions/errors.ts
+++ b/src/extensions/errors.ts
@@ -17,7 +17,7 @@ export const MISSING_EXTENSION_ERROR = defineError({
 export const EXTENSION_VALIDATION_ERROR = defineError({
   slug: "extension-validation",
   category: "CONFIG",
-  status: 500,
+  status: 422,
   title: "Extension validation failed",
   suggestion: "Check that the extension exports a valid name, version, and capabilities array",
 });
@@ -25,7 +25,7 @@ export const EXTENSION_VALIDATION_ERROR = defineError({
 export const CIRCULAR_DEPENDENCY_ERROR = defineError({
   slug: "extension-circular-dependency",
   category: "CONFIG",
-  status: 500,
+  status: 422,
   title: "Circular dependency detected between extensions",
   suggestion: "Review the 'extends' fields in your extensions to break the cycle",
 });
@@ -33,7 +33,7 @@ export const CIRCULAR_DEPENDENCY_ERROR = defineError({
 export const EXTENSION_CONFLICT_ERROR = defineError({
   slug: "extension-conflict",
   category: "CONFIG",
-  status: 500,
+  status: 409,
   title: "Conflicting extensions detected",
   suggestion: "Remove or disable one of the conflicting extensions in your configuration",
 });

--- a/src/extensions/recommendations.ts
+++ b/src/extensions/recommendations.ts
@@ -1,0 +1,24 @@
+/**
+ * Maps contract names to recommended first-party extension packages.
+ *
+ * @module extensions/recommendations
+ */
+
+const recommendations: Record<string, string> = {
+  Bundler: "@veryfront/ext-esbuild",
+  CacheStore: "@veryfront/ext-redis",
+  CSSProcessor: "@veryfront/ext-tailwind",
+  ContentTransformer: "@veryfront/ext-mdx",
+  DatabaseClient: "@veryfront/ext-postgres",
+  AuthProvider: "@veryfront/ext-jwt",
+  TracingExporter: "@veryfront/ext-opentelemetry",
+  AIModelProvider: "@veryfront/ext-openai",
+  EmbeddingProvider: "@veryfront/ext-embeddings",
+  CodeParser: "@veryfront/ext-babel",
+  SchemaValidator: "@veryfront/ext-zod",
+  NodeCompat: "@veryfront/ext-node-compat",
+};
+
+export function getRecommendation(contractName: string): string | undefined {
+  return recommendations[contractName];
+}

--- a/src/extensions/recommendations.ts
+++ b/src/extensions/recommendations.ts
@@ -4,21 +4,21 @@
  * @module extensions/recommendations
  */
 
-const recommendations: Record<string, string> = {
-  Bundler: "@veryfront/ext-esbuild",
-  CacheStore: "@veryfront/ext-redis",
-  CSSProcessor: "@veryfront/ext-tailwind",
-  ContentTransformer: "@veryfront/ext-mdx",
-  DatabaseClient: "@veryfront/ext-postgres",
-  AuthProvider: "@veryfront/ext-jwt",
-  TracingExporter: "@veryfront/ext-opentelemetry",
-  AIModelProvider: "@veryfront/ext-openai",
-  EmbeddingProvider: "@veryfront/ext-embeddings",
-  CodeParser: "@veryfront/ext-babel",
-  SchemaValidator: "@veryfront/ext-zod",
-  NodeCompat: "@veryfront/ext-node-compat",
-};
+const recommendations = new Map<string, string>([
+  ["Bundler", "@veryfront/ext-esbuild"],
+  ["CacheStore", "@veryfront/ext-redis"],
+  ["CSSProcessor", "@veryfront/ext-tailwind"],
+  ["ContentTransformer", "@veryfront/ext-mdx"],
+  ["DatabaseClient", "@veryfront/ext-postgres"],
+  ["AuthProvider", "@veryfront/ext-jwt"],
+  ["TracingExporter", "@veryfront/ext-opentelemetry"],
+  ["AIModelProvider", "@veryfront/ext-openai"],
+  ["EmbeddingProvider", "@veryfront/ext-embeddings"],
+  ["CodeParser", "@veryfront/ext-babel"],
+  ["SchemaValidator", "@veryfront/ext-zod"],
+  ["NodeCompat", "@veryfront/ext-node-compat"],
+]);
 
 export function getRecommendation(contractName: string): string | undefined {
-  return recommendations[contractName];
+  return recommendations.get(contractName);
 }

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -1,0 +1,57 @@
+/**
+ * Core types for the veryfront extension system.
+ *
+ * @module extensions/types
+ */
+
+/**
+ * Declares a system capability an extension requires.
+ * Object-based for extensibility -- scoping fields vary by type.
+ */
+export interface Capability {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface ExtensionContext {
+  get<T>(contract: string): T | undefined;
+  require<T>(contract: string): T;
+  provide<T>(contract: string, impl: T): void;
+  config: Record<string, unknown>;
+  logger: ExtensionLogger;
+}
+
+export interface ExtensionLogger {
+  debug(message: string, ...args: unknown[]): void;
+  info(message: string, ...args: unknown[]): void;
+  warn(message: string, ...args: unknown[]): void;
+  error(message: string, ...args: unknown[]): void;
+}
+
+export interface Extension {
+  name: string;
+  version: string;
+  capabilities: Capability[];
+  setup?(ctx: ExtensionContext): Promise<void> | void;
+  teardown?(): Promise<void> | void;
+  provides?: Record<string, unknown>;
+  extends?: Extension[];
+}
+
+export type ExtensionFactory = (config?: unknown) => Extension;
+
+export type ExtensionConfigEntry =
+  | Extension
+  | { name: string; enabled: false };
+
+export type ExtensionSource =
+  | "config"
+  | "package"
+  | "project"
+  | "local-file";
+
+export interface ResolvedExtension {
+  extension: Extension;
+  source: ExtensionSource;
+  origin: string;
+}


### PR DESCRIPTION
## Summary
- `resolve<T>(name)` — get contract impl or throw with install recommendation
- `tryResolve<T>(name)` — get contract impl or undefined
- `register(name, impl)` — store a contract implementation
- `reset()` — clear all (for tests and HMR)

Closes #1010

## Review fixes applied
- Dynamic install hint now uses `detail` field instead of `suggestion` — `defineError().create()` reads `detail` but ignores `suggestion`, so the contract-specific install command was being silently dropped
- Cherry-picked foundation fixes: CONFIG errors use 4xx status codes, recommendations use Map for prototype-safe lookup

## Security review
- Contract registry uses Map (no prototype pollution)
- `name` parameter is developer-controlled, not user input
- Error messages interpolate developer strings and static Map values only — no injection risk
- No file I/O, network access, or process spawning
- Zero external dependencies

## Acceptance criteria
- [x] resolve<T>(name) returns the registered implementation or throws MissingExtensionError
- [x] Error message includes the recommended package from recommendations.ts
- [x] Error detail field contains deno add install command
- [x] tryResolve<T>(name) returns implementation or undefined (no throw)
- [x] register(name, impl) stores implementation, overwrites previous
- [x] reset() clears all registrations (for tests and HMR teardown)
- [x] afterEach(() => reset()) in tests to prevent cross-test leakage
- [x] All 7 tests pass
- [x] Zero external dependencies

## Test plan
- [x] `deno test --no-check --allow-all src/extensions/contracts.test.ts` — 7 tests pass
- [x] Full test suite: 1340 passed, 0 failed