### PR TITLE
feat(extensions): capability audit and Deno permission mapping

### DIFF
--- a/src/extensions/capabilities.test.ts
+++ b/src/extensions/capabilities.test.ts
@@ -60,6 +60,12 @@ describe("capabilities", () => {
       assertEquals(perms, ["--allow-run=esbuild"]);
     });
 
+    it("should map net:listen ports to --allow-net with host:port format", () => {
+      const caps: Capability[] = [{ type: "net:listen", ports: [3000, 8080] }];
+      const perms = mapToDenoPermissions(caps);
+      assertEquals(perms, ["--allow-net=0.0.0.0:3000,0.0.0.0:8080"]);
+    });
+
     it("should map fs:read without paths to unscoped --allow-read", () => {
       const caps: Capability[] = [{ type: "fs:read" }];
       const perms = mapToDenoPermissions(caps);

--- a/src/extensions/capabilities.test.ts
+++ b/src/extensions/capabilities.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Capability audit and permission mapping tests.
+ *
+ * @module extensions/capabilities.test
+ */
+
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { formatCapabilities, mapToDenoPermissions } from "./capabilities.ts";
+import type { Capability } from "./types.ts";
+
+describe("capabilities", () => {
+  describe("formatCapabilities()", () => {
+    it("should format a list of capabilities as human-readable strings", () => {
+      const caps: Capability[] = [
+        { type: "fs:read", paths: ["./src"] },
+        { type: "net:outbound", hosts: ["api.example.com"] },
+        { type: "contract", name: "CacheStore" },
+      ];
+      const lines = formatCapabilities(caps);
+      assertEquals(lines.length, 3);
+      assertEquals(lines[0], 'fs:read (paths: ["./src"])');
+      assertEquals(lines[1], 'net:outbound (hosts: ["api.example.com"])');
+      assertEquals(lines[2], "contract: CacheStore");
+    });
+
+    it("should handle capabilities with no extra fields", () => {
+      const caps: Capability[] = [{ type: "native:ffi" }];
+      const lines = formatCapabilities(caps);
+      assertEquals(lines, ["native:ffi"]);
+    });
+
+    it("should return empty array for empty input", () => {
+      assertEquals(formatCapabilities([]), []);
+    });
+  });
+
+  describe("mapToDenoPermissions()", () => {
+    it("should map fs:read to --allow-read with paths", () => {
+      const caps: Capability[] = [{ type: "fs:read", paths: ["./src", "./public"] }];
+      const perms = mapToDenoPermissions(caps);
+      assertEquals(perms, ["--allow-read=./src,./public"]);
+    });
+
+    it("should map net:outbound to --allow-net with hosts", () => {
+      const caps: Capability[] = [{ type: "net:outbound", hosts: ["api.example.com"] }];
+      const perms = mapToDenoPermissions(caps);
+      assertEquals(perms, ["--allow-net=api.example.com"]);
+    });
+
+    it("should map env:read to --allow-env with keys", () => {
+      const caps: Capability[] = [{ type: "env:read", keys: ["DATABASE_URL"] }];
+      const perms = mapToDenoPermissions(caps);
+      assertEquals(perms, ["--allow-env=DATABASE_URL"]);
+    });
+
+    it("should map process:spawn to --allow-run with commands", () => {
+      const caps: Capability[] = [{ type: "process:spawn", commands: ["esbuild"] }];
+      const perms = mapToDenoPermissions(caps);
+      assertEquals(perms, ["--allow-run=esbuild"]);
+    });
+
+    it("should map fs:read without paths to unscoped --allow-read", () => {
+      const caps: Capability[] = [{ type: "fs:read" }];
+      const perms = mapToDenoPermissions(caps);
+      assertEquals(perms, ["--allow-read"]);
+    });
+
+    it("should skip contract capabilities", () => {
+      const caps: Capability[] = [{ type: "contract", name: "Bundler" }];
+      const perms = mapToDenoPermissions(caps);
+      assertEquals(perms, []);
+    });
+
+    it("should deduplicate permission flags", () => {
+      const caps: Capability[] = [
+        { type: "fs:read", paths: ["./src"] },
+        { type: "fs:read", paths: ["./src"] },
+      ];
+      const perms = mapToDenoPermissions(caps);
+      assertEquals(perms, ["--allow-read=./src"]);
+    });
+  });
+});

--- a/src/extensions/capabilities.test.ts
+++ b/src/extensions/capabilities.test.ts
@@ -60,10 +60,16 @@ describe("capabilities", () => {
       assertEquals(perms, ["--allow-run=esbuild"]);
     });
 
-    it("should map net:listen ports to --allow-net with host:port format", () => {
+    it("should map net:listen ports to localhost:port by default", () => {
       const caps: Capability[] = [{ type: "net:listen", ports: [3000, 8080] }];
       const perms = mapToDenoPermissions(caps);
-      assertEquals(perms, ["--allow-net=0.0.0.0:3000,0.0.0.0:8080"]);
+      assertEquals(perms, ["--allow-net=localhost:3000,localhost:8080"]);
+    });
+
+    it("should map net:listen with explicit host", () => {
+      const caps: Capability[] = [{ type: "net:listen", ports: [3000], host: "0.0.0.0" }];
+      const perms = mapToDenoPermissions(caps);
+      assertEquals(perms, ["--allow-net=0.0.0.0:3000"]);
     });
 
     it("should map fs:read without paths to unscoped --allow-read", () => {

--- a/src/extensions/capabilities.ts
+++ b/src/extensions/capabilities.ts
@@ -29,8 +29,8 @@ export function formatCapabilities(capabilities: Capability[]): string[] {
 interface PermissionMapping {
   flag: string;
   scopeKey?: string;
-  /** Transform scope values before joining (e.g., ports → host:port). */
-  transformScope?: (value: string) => string;
+  /** Resolve scopes from the full capability (overrides scopeKey when present). */
+  resolveScopes?: (cap: Capability) => string[];
 }
 
 const DENO_PERMISSION_MAP: Record<string, PermissionMapping> = {
@@ -39,8 +39,12 @@ const DENO_PERMISSION_MAP: Record<string, PermissionMapping> = {
   "net:outbound": { flag: "--allow-net", scopeKey: "hosts" },
   "net:listen": {
     flag: "--allow-net",
-    scopeKey: "ports",
-    transformScope: (port) => `0.0.0.0:${port}`,
+    resolveScopes: (cap) => {
+      const ports = cap.ports as (string | number)[] | undefined;
+      if (!ports || ports.length === 0) return [];
+      const host = (cap.host as string) || "localhost";
+      return ports.map((p) => `${host}:${p}`);
+    },
   },
   "env:read": { flag: "--allow-env", scopeKey: "keys" },
   "process:spawn": { flag: "--allow-run", scopeKey: "commands" },
@@ -60,12 +64,13 @@ export function mapToDenoPermissions(capabilities: Capability[]): string[] {
     if (!mapping) continue;
 
     let flag = mapping.flag;
-    if (mapping.scopeKey) {
-      const scopes = cap[mapping.scopeKey] as string[] | undefined;
-      if (scopes && scopes.length > 0) {
-        const values = mapping.transformScope ? scopes.map(mapping.transformScope) : scopes;
-        flag = `${flag}=${values.join(",")}`;
-      }
+    const scopes = mapping.resolveScopes
+      ? mapping.resolveScopes(cap)
+      : mapping.scopeKey
+      ? (cap[mapping.scopeKey] as string[] | undefined) ?? []
+      : [];
+    if (scopes.length > 0) {
+      flag = `${flag}=${scopes.join(",")}`;
     }
 
     if (!seen.has(flag)) {

--- a/src/extensions/capabilities.ts
+++ b/src/extensions/capabilities.ts
@@ -1,0 +1,80 @@
+/**
+ * Capability audit logging and Deno permission mapping.
+ *
+ * @module extensions/capabilities
+ */
+
+import type { Capability, ExtensionLogger } from "./types.ts";
+
+/**
+ * Format capabilities as human-readable strings for logging.
+ */
+export function formatCapabilities(capabilities: Capability[]): string[] {
+  return capabilities.map((cap) => {
+    if (cap.type === "contract") {
+      return `contract: ${cap.name as string}`;
+    }
+
+    const { type, ...rest } = cap;
+    const extras = Object.keys(rest);
+    if (extras.length === 0) return type;
+
+    const details = extras
+      .map((key) => `${key}: ${JSON.stringify(rest[key])}`)
+      .join(", ");
+    return `${type} (${details})`;
+  });
+}
+
+const DENO_PERMISSION_MAP: Record<string, { flag: string; scopeKey?: string }> = {
+  "fs:read": { flag: "--allow-read", scopeKey: "paths" },
+  "fs:write": { flag: "--allow-write", scopeKey: "paths" },
+  "net:outbound": { flag: "--allow-net", scopeKey: "hosts" },
+  "net:listen": { flag: "--allow-net", scopeKey: "ports" },
+  "env:read": { flag: "--allow-env", scopeKey: "keys" },
+  "process:spawn": { flag: "--allow-run", scopeKey: "commands" },
+  "native:ffi": { flag: "--allow-ffi" },
+};
+
+/**
+ * Map capabilities to Deno CLI permission flags.
+ * Skips non-system capabilities (e.g., "contract").
+ */
+export function mapToDenoPermissions(capabilities: Capability[]): string[] {
+  const seen = new Set<string>();
+  const flags: string[] = [];
+
+  for (const cap of capabilities) {
+    const mapping = DENO_PERMISSION_MAP[cap.type];
+    if (!mapping) continue;
+
+    let flag = mapping.flag;
+    if (mapping.scopeKey) {
+      const scopes = cap[mapping.scopeKey] as string[] | undefined;
+      if (scopes && scopes.length > 0) {
+        flag = `${flag}=${scopes.join(",")}`;
+      }
+    }
+
+    if (!seen.has(flag)) {
+      seen.add(flag);
+      flags.push(flag);
+    }
+  }
+
+  return flags;
+}
+
+/**
+ * Log capabilities for a named extension at startup.
+ */
+export function auditCapabilities(
+  extensionName: string,
+  capabilities: Capability[],
+  logger: ExtensionLogger,
+): void {
+  if (capabilities.length === 0) return;
+
+  const lines = formatCapabilities(capabilities);
+  logger.info(`Extension "${extensionName}" declares capabilities:`, ...lines);
+}

--- a/src/extensions/capabilities.ts
+++ b/src/extensions/capabilities.ts
@@ -26,11 +26,22 @@ export function formatCapabilities(capabilities: Capability[]): string[] {
   });
 }
 
-const DENO_PERMISSION_MAP: Record<string, { flag: string; scopeKey?: string }> = {
+interface PermissionMapping {
+  flag: string;
+  scopeKey?: string;
+  /** Transform scope values before joining (e.g., ports → host:port). */
+  transformScope?: (value: string) => string;
+}
+
+const DENO_PERMISSION_MAP: Record<string, PermissionMapping> = {
   "fs:read": { flag: "--allow-read", scopeKey: "paths" },
   "fs:write": { flag: "--allow-write", scopeKey: "paths" },
   "net:outbound": { flag: "--allow-net", scopeKey: "hosts" },
-  "net:listen": { flag: "--allow-net", scopeKey: "ports" },
+  "net:listen": {
+    flag: "--allow-net",
+    scopeKey: "ports",
+    transformScope: (port) => `0.0.0.0:${port}`,
+  },
   "env:read": { flag: "--allow-env", scopeKey: "keys" },
   "process:spawn": { flag: "--allow-run", scopeKey: "commands" },
   "native:ffi": { flag: "--allow-ffi" },
@@ -52,7 +63,8 @@ export function mapToDenoPermissions(capabilities: Capability[]): string[] {
     if (mapping.scopeKey) {
       const scopes = cap[mapping.scopeKey] as string[] | undefined;
       if (scopes && scopes.length > 0) {
-        flag = `${flag}=${scopes.join(",")}`;
+        const values = mapping.transformScope ? scopes.map(mapping.transformScope) : scopes;
+        flag = `${flag}=${values.join(",")}`;
       }
     }
 

--- a/src/extensions/errors.ts
+++ b/src/extensions/errors.ts
@@ -1,0 +1,39 @@
+/**
+ * Extension system error definitions.
+ *
+ * @module extensions/errors
+ */
+
+import { defineError } from "#veryfront/errors";
+
+export const MISSING_EXTENSION_ERROR = defineError({
+  slug: "missing-extension",
+  category: "RUNTIME",
+  status: 500,
+  title: "Required extension not found",
+  suggestion: "Install the missing extension package and add it to your configuration",
+});
+
+export const EXTENSION_VALIDATION_ERROR = defineError({
+  slug: "extension-validation",
+  category: "CONFIG",
+  status: 500,
+  title: "Extension validation failed",
+  suggestion: "Check that the extension exports a valid name, version, and capabilities array",
+});
+
+export const CIRCULAR_DEPENDENCY_ERROR = defineError({
+  slug: "extension-circular-dependency",
+  category: "CONFIG",
+  status: 500,
+  title: "Circular dependency detected between extensions",
+  suggestion: "Review the 'extends' fields in your extensions to break the cycle",
+});
+
+export const EXTENSION_CONFLICT_ERROR = defineError({
+  slug: "extension-conflict",
+  category: "CONFIG",
+  status: 500,
+  title: "Conflicting extensions detected",
+  suggestion: "Remove or disable one of the conflicting extensions in your configuration",
+});

--- a/src/extensions/errors.ts
+++ b/src/extensions/errors.ts
@@ -17,7 +17,7 @@ export const MISSING_EXTENSION_ERROR = defineError({
 export const EXTENSION_VALIDATION_ERROR = defineError({
   slug: "extension-validation",
   category: "CONFIG",
-  status: 500,
+  status: 422,
   title: "Extension validation failed",
   suggestion: "Check that the extension exports a valid name, version, and capabilities array",
 });
@@ -25,7 +25,7 @@ export const EXTENSION_VALIDATION_ERROR = defineError({
 export const CIRCULAR_DEPENDENCY_ERROR = defineError({
   slug: "extension-circular-dependency",
   category: "CONFIG",
-  status: 500,
+  status: 422,
   title: "Circular dependency detected between extensions",
   suggestion: "Review the 'extends' fields in your extensions to break the cycle",
 });
@@ -33,7 +33,7 @@ export const CIRCULAR_DEPENDENCY_ERROR = defineError({
 export const EXTENSION_CONFLICT_ERROR = defineError({
   slug: "extension-conflict",
   category: "CONFIG",
-  status: 500,
+  status: 409,
   title: "Conflicting extensions detected",
   suggestion: "Remove or disable one of the conflicting extensions in your configuration",
 });

--- a/src/extensions/recommendations.ts
+++ b/src/extensions/recommendations.ts
@@ -1,0 +1,24 @@
+/**
+ * Maps contract names to recommended first-party extension packages.
+ *
+ * @module extensions/recommendations
+ */
+
+const recommendations: Record<string, string> = {
+  Bundler: "@veryfront/ext-esbuild",
+  CacheStore: "@veryfront/ext-redis",
+  CSSProcessor: "@veryfront/ext-tailwind",
+  ContentTransformer: "@veryfront/ext-mdx",
+  DatabaseClient: "@veryfront/ext-postgres",
+  AuthProvider: "@veryfront/ext-jwt",
+  TracingExporter: "@veryfront/ext-opentelemetry",
+  AIModelProvider: "@veryfront/ext-openai",
+  EmbeddingProvider: "@veryfront/ext-embeddings",
+  CodeParser: "@veryfront/ext-babel",
+  SchemaValidator: "@veryfront/ext-zod",
+  NodeCompat: "@veryfront/ext-node-compat",
+};
+
+export function getRecommendation(contractName: string): string | undefined {
+  return recommendations[contractName];
+}

--- a/src/extensions/recommendations.ts
+++ b/src/extensions/recommendations.ts
@@ -4,21 +4,21 @@
  * @module extensions/recommendations
  */
 
-const recommendations: Record<string, string> = {
-  Bundler: "@veryfront/ext-esbuild",
-  CacheStore: "@veryfront/ext-redis",
-  CSSProcessor: "@veryfront/ext-tailwind",
-  ContentTransformer: "@veryfront/ext-mdx",
-  DatabaseClient: "@veryfront/ext-postgres",
-  AuthProvider: "@veryfront/ext-jwt",
-  TracingExporter: "@veryfront/ext-opentelemetry",
-  AIModelProvider: "@veryfront/ext-openai",
-  EmbeddingProvider: "@veryfront/ext-embeddings",
-  CodeParser: "@veryfront/ext-babel",
-  SchemaValidator: "@veryfront/ext-zod",
-  NodeCompat: "@veryfront/ext-node-compat",
-};
+const recommendations = new Map<string, string>([
+  ["Bundler", "@veryfront/ext-esbuild"],
+  ["CacheStore", "@veryfront/ext-redis"],
+  ["CSSProcessor", "@veryfront/ext-tailwind"],
+  ["ContentTransformer", "@veryfront/ext-mdx"],
+  ["DatabaseClient", "@veryfront/ext-postgres"],
+  ["AuthProvider", "@veryfront/ext-jwt"],
+  ["TracingExporter", "@veryfront/ext-opentelemetry"],
+  ["AIModelProvider", "@veryfront/ext-openai"],
+  ["EmbeddingProvider", "@veryfront/ext-embeddings"],
+  ["CodeParser", "@veryfront/ext-babel"],
+  ["SchemaValidator", "@veryfront/ext-zod"],
+  ["NodeCompat", "@veryfront/ext-node-compat"],
+]);
 
 export function getRecommendation(contractName: string): string | undefined {
-  return recommendations[contractName];
+  return recommendations.get(contractName);
 }

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -1,0 +1,57 @@
+/**
+ * Core types for the veryfront extension system.
+ *
+ * @module extensions/types
+ */
+
+/**
+ * Declares a system capability an extension requires.
+ * Object-based for extensibility -- scoping fields vary by type.
+ */
+export interface Capability {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface ExtensionContext {
+  get<T>(contract: string): T | undefined;
+  require<T>(contract: string): T;
+  provide<T>(contract: string, impl: T): void;
+  config: Record<string, unknown>;
+  logger: ExtensionLogger;
+}
+
+export interface ExtensionLogger {
+  debug(message: string, ...args: unknown[]): void;
+  info(message: string, ...args: unknown[]): void;
+  warn(message: string, ...args: unknown[]): void;
+  error(message: string, ...args: unknown[]): void;
+}
+
+export interface Extension {
+  name: string;
+  version: string;
+  capabilities: Capability[];
+  setup?(ctx: ExtensionContext): Promise<void> | void;
+  teardown?(): Promise<void> | void;
+  provides?: Record<string, unknown>;
+  extends?: Extension[];
+}
+
+export type ExtensionFactory = (config?: unknown) => Extension;
+
+export type ExtensionConfigEntry =
+  | Extension
+  | { name: string; enabled: false };
+
+export type ExtensionSource =
+  | "config"
+  | "package"
+  | "project"
+  | "local-file";
+
+export interface ResolvedExtension {
+  extension: Extension;
+  source: ExtensionSource;
+  origin: string;
+}


### PR DESCRIPTION
## Summary
- `formatCapabilities()` — human-readable capability strings for logging
- `mapToDenoPermissions()` — map object capabilities to Deno `--allow-*` flags with scope support
- `auditCapabilities()` — log extension capabilities at startup

Closes #1011

## Review fixes applied
- `net:listen` ports now default to `localhost:port` (loopback only) instead of `0.0.0.0` — extensions must explicitly declare `host: "0.0.0.0"` to bind all interfaces
- Cherry-picked foundation fixes: CONFIG errors use 4xx status codes, recommendations use Map

## Security review
- `net:listen` defaults to localhost (loopback) — extensions cannot silently bind all interfaces without declaring it
- Capability declarations are developer-controlled, not user input
- Permission mapping produces Deno CLI flags for audit/logging — not executed directly
- `formatCapabilities()` uses JSON.stringify for scope values — safe against log injection
- No file I/O, network access, or process spawning
- Zero external dependencies

## Acceptance criteria
- [x] formatCapabilities() produces human-readable strings from Capability objects
- [x] Contract capabilities rendered as `contract: Name`
- [x] Non-contract capabilities rendered as `type (key: value, ...)` or just `type`
- [x] mapToDenoPermissions() maps: fs:read/write -> --allow-read/write, net:outbound -> --allow-net, net:listen -> --allow-net with localhost:port (or explicit host:port), env:read -> --allow-env, process:spawn -> --allow-run, native:ffi -> --allow-ffi
- [x] Scoping fields (paths, hosts, keys, commands) appended as =value1,value2
- [x] Ports default to localhost:port, overridable via host field
- [x] Unscoped capabilities produce unscoped flags
- [x] Duplicates are deduplicated
- [x] auditCapabilities() logs via provided ExtensionLogger, skips if empty
- [x] All 12 tests pass
- [x] Zero external dependencies

## Test plan
- [x] `deno test --no-check --allow-all src/extensions/capabilities.test.ts` — 12 tests pass
- [x] Full test suite: 1340 passed, 0 failed