### PR TITLE
feat(extensions): validation and conflict detection

### DIFF
--- a/src/extensions/validation.test.ts
+++ b/src/extensions/validation.test.ts
@@ -73,6 +73,22 @@ describe("validateExtension", () => {
     assertEquals(issues.length > 0, true);
     assertEquals(issues.some((i) => i.includes("type")), true);
   });
+
+  it("should reject null input", () => {
+    const issues = validateExtension(null as unknown as Extension);
+    assertEquals(issues.length, 1);
+    assertEquals(issues[0].includes("object"), true);
+  });
+
+  it("should reject undefined input", () => {
+    const issues = validateExtension(undefined as unknown as Extension);
+    assertEquals(issues.length, 1);
+  });
+
+  it("should reject non-object input", () => {
+    const issues = validateExtension("not-an-object" as unknown as Extension);
+    assertEquals(issues.length, 1);
+  });
 });
 
 describe("detectConflicts", () => {

--- a/src/extensions/validation.test.ts
+++ b/src/extensions/validation.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Extension validation and conflict detection tests.
+ *
+ * @module extensions/validation.test
+ */
+
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { detectConflicts, validateExtension } from "./validation.ts";
+import type { Extension, ResolvedExtension } from "./types.ts";
+
+describe("validateExtension", () => {
+  it("accepts a valid extension", () => {
+    const ext: Extension = {
+      name: "test-ext",
+      version: "1.0.0",
+      capabilities: [{ type: "render" }],
+    };
+    assertEquals(validateExtension(ext), []);
+  });
+
+  it("rejects missing name", () => {
+    const ext = {
+      name: "",
+      version: "1.0.0",
+      capabilities: [],
+    } as Extension;
+    const issues = validateExtension(ext);
+    assertEquals(issues.length > 0, true);
+    assertEquals(issues.some((i) => i.includes("name")), true);
+  });
+
+  it("rejects missing version", () => {
+    const ext = {
+      name: "test-ext",
+      version: "",
+      capabilities: [],
+    } as Extension;
+    const issues = validateExtension(ext);
+    assertEquals(issues.length > 0, true);
+    assertEquals(issues.some((i) => i.includes("version")), true);
+  });
+
+  it("rejects missing capabilities array", () => {
+    const ext = {
+      name: "test-ext",
+      version: "1.0.0",
+      capabilities: undefined,
+    } as unknown as Extension;
+    const issues = validateExtension(ext);
+    assertEquals(issues.length > 0, true);
+    assertEquals(issues.some((i) => i.includes("capabilities")), true);
+  });
+
+  it("rejects non-object capabilities", () => {
+    const ext = {
+      name: "test-ext",
+      version: "1.0.0",
+      capabilities: ["not-an-object"] as unknown as Extension["capabilities"],
+    };
+    const issues = validateExtension(ext);
+    assertEquals(issues.length > 0, true);
+    assertEquals(issues.some((i) => i.includes("capabilities[0]")), true);
+  });
+
+  it("rejects capabilities missing type", () => {
+    const ext = {
+      name: "test-ext",
+      version: "1.0.0",
+      capabilities: [{ scope: "global" }] as unknown as Extension["capabilities"],
+    };
+    const issues = validateExtension(ext);
+    assertEquals(issues.length > 0, true);
+    assertEquals(issues.some((i) => i.includes("type")), true);
+  });
+});
+
+describe("detectConflicts", () => {
+  it("detects two extensions providing the same contract", () => {
+    const extensions: ResolvedExtension[] = [
+      {
+        extension: {
+          name: "ext-a",
+          version: "1.0.0",
+          capabilities: [],
+          provides: { Bundler: {} },
+        },
+        source: "package",
+        origin: "node_modules/ext-a",
+      },
+      {
+        extension: {
+          name: "ext-b",
+          version: "1.0.0",
+          capabilities: [],
+          provides: { Bundler: {} },
+        },
+        source: "package",
+        origin: "node_modules/ext-b",
+      },
+    ];
+    const conflicts = detectConflicts(extensions);
+    assertEquals(conflicts.length, 1);
+    assertEquals(conflicts[0].contract, "Bundler");
+    assertEquals(conflicts[0].providers.length, 2);
+  });
+
+  it("allows config-sourced to win over package-sourced", () => {
+    const extensions: ResolvedExtension[] = [
+      {
+        extension: {
+          name: "ext-config",
+          version: "1.0.0",
+          capabilities: [],
+          provides: { Bundler: {} },
+        },
+        source: "config",
+        origin: "veryfront.config.ts",
+      },
+      {
+        extension: {
+          name: "ext-pkg",
+          version: "1.0.0",
+          capabilities: [],
+          provides: { Bundler: {} },
+        },
+        source: "package",
+        origin: "node_modules/ext-pkg",
+      },
+    ];
+    const conflicts = detectConflicts(extensions);
+    assertEquals(conflicts.length, 0);
+  });
+});

--- a/src/extensions/validation.test.ts
+++ b/src/extensions/validation.test.ts
@@ -20,131 +20,165 @@ describe("validateExtension", () => {
   });
 
   it("rejects missing name", () => {
-    const ext = {
+    const issues = validateExtension({
       name: "",
       version: "1.0.0",
       capabilities: [],
-    } as Extension;
-    const issues = validateExtension(ext);
-    assertEquals(issues.length > 0, true);
+    });
     assertEquals(issues.some((i) => i.includes("name")), true);
   });
 
   it("rejects missing version", () => {
-    const ext = {
+    const issues = validateExtension({
       name: "test-ext",
       version: "",
       capabilities: [],
-    } as Extension;
-    const issues = validateExtension(ext);
-    assertEquals(issues.length > 0, true);
+    });
     assertEquals(issues.some((i) => i.includes("version")), true);
   });
 
   it("rejects missing capabilities array", () => {
-    const ext = {
+    const issues = validateExtension({
       name: "test-ext",
       version: "1.0.0",
-      capabilities: undefined,
-    } as unknown as Extension;
-    const issues = validateExtension(ext);
-    assertEquals(issues.length > 0, true);
+    });
     assertEquals(issues.some((i) => i.includes("capabilities")), true);
   });
 
-  it("rejects non-object capabilities", () => {
-    const ext = {
+  it("rejects non-object capability entries", () => {
+    const issues = validateExtension({
       name: "test-ext",
       version: "1.0.0",
-      capabilities: ["not-an-object"] as unknown as Extension["capabilities"],
-    };
-    const issues = validateExtension(ext);
-    assertEquals(issues.length > 0, true);
+      capabilities: ["not-an-object"],
+    });
     assertEquals(issues.some((i) => i.includes("capabilities[0]")), true);
   });
 
-  it("rejects capabilities missing type", () => {
-    const ext = {
+  it("rejects capability missing type field", () => {
+    const issues = validateExtension({
       name: "test-ext",
       version: "1.0.0",
-      capabilities: [{ scope: "global" }] as unknown as Extension["capabilities"],
-    };
-    const issues = validateExtension(ext);
-    assertEquals(issues.length > 0, true);
+      capabilities: [{ scope: "global" }],
+    });
     assertEquals(issues.some((i) => i.includes("type")), true);
   });
 
-  it("should reject null input", () => {
-    const issues = validateExtension(null as unknown as Extension);
-    assertEquals(issues.length, 1);
-    assertEquals(issues[0].includes("object"), true);
+  it("rejects array capability entry", () => {
+    const issues = validateExtension({
+      name: "test-ext",
+      version: "1.0.0",
+      capabilities: [[]],
+    });
+    assertEquals(issues.some((i) => i.includes("capabilities[0]")), true);
   });
 
-  it("should reject undefined input", () => {
-    const issues = validateExtension(undefined as unknown as Extension);
+  it("rejects null input", () => {
+    const issues = validateExtension(null);
+    assertEquals(issues.length, 1);
+    assertEquals(issues[0]?.includes("object"), true);
+  });
+
+  it("rejects undefined input", () => {
+    const issues = validateExtension(undefined);
     assertEquals(issues.length, 1);
   });
 
-  it("should reject non-object input", () => {
-    const issues = validateExtension("not-an-object" as unknown as Extension);
+  it("rejects string input", () => {
+    const issues = validateExtension("not-an-object");
+    assertEquals(issues.length, 1);
+  });
+
+  it("rejects array input", () => {
+    const issues = validateExtension([]);
+    assertEquals(issues.length, 1);
+  });
+
+  it("rejects number input", () => {
+    const issues = validateExtension(42);
     assertEquals(issues.length, 1);
   });
 });
 
+const pkg = (name: string, provides: Record<string, unknown>): ResolvedExtension => ({
+  extension: { name, version: "1.0.0", capabilities: [], provides },
+  source: "package",
+  origin: `node_modules/${name}`,
+});
+
+const config = (name: string, provides: Record<string, unknown>): ResolvedExtension => ({
+  extension: { name, version: "1.0.0", capabilities: [], provides },
+  source: "config",
+  origin: "veryfront.config.ts",
+});
+
 describe("detectConflicts", () => {
   it("detects two extensions providing the same contract", () => {
-    const extensions: ResolvedExtension[] = [
-      {
-        extension: {
-          name: "ext-a",
-          version: "1.0.0",
-          capabilities: [],
-          provides: { Bundler: {} },
-        },
-        source: "package",
-        origin: "node_modules/ext-a",
-      },
-      {
-        extension: {
-          name: "ext-b",
-          version: "1.0.0",
-          capabilities: [],
-          provides: { Bundler: {} },
-        },
-        source: "package",
-        origin: "node_modules/ext-b",
-      },
-    ];
-    const conflicts = detectConflicts(extensions);
+    const conflicts = detectConflicts([
+      pkg("ext-a", { Bundler: {} }),
+      pkg("ext-b", { Bundler: {} }),
+    ]);
     assertEquals(conflicts.length, 1);
-    assertEquals(conflicts[0].contract, "Bundler");
-    assertEquals(conflicts[0].providers.length, 2);
+    assertEquals(conflicts[0]?.contract, "Bundler");
+    assertEquals(conflicts[0]?.providers.length, 2);
   });
 
   it("allows config-sourced to win over package-sourced", () => {
-    const extensions: ResolvedExtension[] = [
-      {
-        extension: {
-          name: "ext-config",
-          version: "1.0.0",
-          capabilities: [],
-          provides: { Bundler: {} },
-        },
-        source: "config",
-        origin: "veryfront.config.ts",
-      },
-      {
-        extension: {
-          name: "ext-pkg",
-          version: "1.0.0",
-          capabilities: [],
-          provides: { Bundler: {} },
-        },
-        source: "package",
-        origin: "node_modules/ext-pkg",
-      },
-    ];
-    const conflicts = detectConflicts(extensions);
+    const conflicts = detectConflicts([
+      config("ext-config", { Bundler: {} }),
+      pkg("ext-pkg", { Bundler: {} }),
+    ]);
     assertEquals(conflicts.length, 0);
+  });
+
+  it("reports conflict when two config-sourced providers tie", () => {
+    const conflicts = detectConflicts([
+      config("ext-config-a", { Bundler: {} }),
+      config("ext-config-b", { Bundler: {} }),
+    ]);
+    assertEquals(conflicts.length, 1);
+    assertEquals(conflicts[0]?.contract, "Bundler");
+    assertEquals(conflicts[0]?.providers.length, 2);
+  });
+
+  it("allows single high-priority winner among three providers", () => {
+    const conflicts = detectConflicts([
+      config("ext-config", { Bundler: {} }),
+      pkg("ext-a", { Bundler: {} }),
+      pkg("ext-b", { Bundler: {} }),
+    ]);
+    assertEquals(conflicts.length, 0);
+  });
+
+  it("returns no conflicts when no extensions provide contracts", () => {
+    const conflicts = detectConflicts([
+      {
+        extension: { name: "ext-a", version: "1.0.0", capabilities: [] },
+        source: "package",
+        origin: "node_modules/ext-a",
+      },
+    ]);
+    assertEquals(conflicts.length, 0);
+  });
+
+  it("reports multiple contracts independently", () => {
+    const conflicts = detectConflicts([
+      pkg("ext-a", { Bundler: {}, CacheStore: {} }),
+      pkg("ext-b", { Bundler: {}, CacheStore: {} }),
+    ]);
+    assertEquals(conflicts.length, 2);
+    const contracts = conflicts.map((c) => c.contract).sort();
+    assertEquals(contracts, ["Bundler", "CacheStore"]);
+  });
+
+  it("returns empty for empty extension list", () => {
+    assertEquals(detectConflicts([]), []);
+  });
+
+  it("preserves ExtensionSource type on providers", () => {
+    const conflicts = detectConflicts([
+      pkg("ext-a", { Bundler: {} }),
+      pkg("ext-b", { Bundler: {} }),
+    ]);
+    assertEquals(conflicts[0]?.providers[0]?.source, "package");
   });
 });

--- a/src/extensions/validation.ts
+++ b/src/extensions/validation.ts
@@ -11,7 +11,7 @@ import type { Extension, ExtensionSource, ResolvedExtension } from "./types.ts";
  */
 export interface ConflictInfo {
   contract: string;
-  providers: Array<{ name: string; source: string }>;
+  providers: Array<{ name: string; source: ExtensionSource }>;
 }
 
 /**
@@ -28,30 +28,35 @@ const SOURCE_PRIORITY: Record<ExtensionSource, number> = {
 /**
  * Validate the shape of an extension object.
  * Returns an array of issue descriptions (empty array = valid).
+ *
+ * Accepts `unknown` so callers at module-boundary / config-loading paths can
+ * validate arbitrary imported values without casting.
  */
-export function validateExtension(ext: Extension): string[] {
+export function validateExtension(ext: unknown): string[] {
   const issues: string[] = [];
 
-  if (ext === null || ext === undefined || typeof ext !== "object") {
-    issues.push("Extension must be a non-null object.");
+  if (ext === null || typeof ext !== "object" || Array.isArray(ext)) {
+    issues.push("extension must be a non-null object");
     return issues;
   }
 
-  if (typeof ext.name !== "string" || ext.name.length === 0) {
+  const candidate = ext as Partial<Extension>;
+
+  if (typeof candidate.name !== "string" || candidate.name.length === 0) {
     issues.push("name must be a non-empty string");
   }
 
-  if (typeof ext.version !== "string" || ext.version.length === 0) {
+  if (typeof candidate.version !== "string" || candidate.version.length === 0) {
     issues.push("version must be a non-empty string");
   }
 
-  if (!Array.isArray(ext.capabilities)) {
+  if (!Array.isArray(candidate.capabilities)) {
     issues.push("capabilities must be an array");
     return issues;
   }
 
-  for (let i = 0; i < ext.capabilities.length; i++) {
-    const cap = ext.capabilities[i];
+  for (let i = 0; i < candidate.capabilities.length; i++) {
+    const cap = candidate.capabilities[i];
     if (typeof cap !== "object" || cap === null || Array.isArray(cap)) {
       issues.push(`capabilities[${i}] must be an object`);
       continue;
@@ -81,10 +86,12 @@ export function detectConflicts(extensions: ResolvedExtension[]): ConflictInfo[]
     if (!provides) continue;
 
     for (const contract of Object.keys(provides)) {
-      if (!contractProviders.has(contract)) {
-        contractProviders.set(contract, []);
+      let list = contractProviders.get(contract);
+      if (!list) {
+        list = [];
+        contractProviders.set(contract, list);
       }
-      contractProviders.get(contract)!.push({
+      list.push({
         name: resolved.extension.name,
         source: resolved.source,
       });

--- a/src/extensions/validation.ts
+++ b/src/extensions/validation.ts
@@ -32,6 +32,11 @@ const SOURCE_PRIORITY: Record<ExtensionSource, number> = {
 export function validateExtension(ext: Extension): string[] {
   const issues: string[] = [];
 
+  if (ext === null || ext === undefined || typeof ext !== "object") {
+    issues.push("Extension must be a non-null object.");
+    return issues;
+  }
+
   if (typeof ext.name !== "string" || ext.name.length === 0) {
     issues.push("name must be a non-empty string");
   }

--- a/src/extensions/validation.ts
+++ b/src/extensions/validation.ts
@@ -1,0 +1,109 @@
+/**
+ * Extension validation and conflict detection.
+ *
+ * @module extensions/validation
+ */
+
+import type { Extension, ExtensionSource, ResolvedExtension } from "./types.ts";
+
+/**
+ * Information about a contract conflict between extensions.
+ */
+export interface ConflictInfo {
+  contract: string;
+  providers: Array<{ name: string; source: string }>;
+}
+
+/**
+ * Priority map for extension sources.
+ * Lower number = higher priority.
+ */
+const SOURCE_PRIORITY: Record<ExtensionSource, number> = {
+  config: 0,
+  package: 1,
+  project: 2,
+  "local-file": 3,
+};
+
+/**
+ * Validate the shape of an extension object.
+ * Returns an array of issue descriptions (empty array = valid).
+ */
+export function validateExtension(ext: Extension): string[] {
+  const issues: string[] = [];
+
+  if (typeof ext.name !== "string" || ext.name.length === 0) {
+    issues.push("name must be a non-empty string");
+  }
+
+  if (typeof ext.version !== "string" || ext.version.length === 0) {
+    issues.push("version must be a non-empty string");
+  }
+
+  if (!Array.isArray(ext.capabilities)) {
+    issues.push("capabilities must be an array");
+    return issues;
+  }
+
+  for (let i = 0; i < ext.capabilities.length; i++) {
+    const cap = ext.capabilities[i];
+    if (typeof cap !== "object" || cap === null || Array.isArray(cap)) {
+      issues.push(`capabilities[${i}] must be an object`);
+      continue;
+    }
+    if (typeof cap.type !== "string" || cap.type.length === 0) {
+      issues.push(`capabilities[${i}].type must be a non-empty string`);
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * Detect contract conflicts between resolved extensions.
+ *
+ * A conflict exists when two or more extensions provide the same contract
+ * and no single provider has strictly higher source priority than all others.
+ */
+export function detectConflicts(extensions: ResolvedExtension[]): ConflictInfo[] {
+  const contractProviders = new Map<
+    string,
+    Array<{ name: string; source: ExtensionSource }>
+  >();
+
+  for (const resolved of extensions) {
+    const provides = resolved.extension.provides;
+    if (!provides) continue;
+
+    for (const contract of Object.keys(provides)) {
+      if (!contractProviders.has(contract)) {
+        contractProviders.set(contract, []);
+      }
+      contractProviders.get(contract)!.push({
+        name: resolved.extension.name,
+        source: resolved.source,
+      });
+    }
+  }
+
+  const conflicts: ConflictInfo[] = [];
+
+  for (const [contract, providers] of contractProviders) {
+    if (providers.length < 2) continue;
+
+    // Find the highest priority (lowest number) among providers
+    const priorities = providers.map((p) => SOURCE_PRIORITY[p.source]);
+    const bestPriority = Math.min(...priorities);
+    const winnersCount = priorities.filter((p) => p === bestPriority).length;
+
+    // If exactly one provider has the best priority, no conflict
+    if (winnersCount === 1) continue;
+
+    conflicts.push({
+      contract,
+      providers: providers.map((p) => ({ name: p.name, source: p.source })),
+    });
+  }
+
+  return conflicts;
+}


### PR DESCRIPTION
## Summary
Adds two pure functions to the extension system (issue #1014):
- `validateExtension(ext: unknown) -> string[]` — shape check returning issue descriptions (empty = valid)
- `detectConflicts(extensions) -> ConflictInfo[]` — finds multiple extensions providing the same contract, respects source priority

Closes #1014

## Scope after rebase onto main
PR now adds **only** `src/extensions/validation.ts` + `validation.test.ts` (305 lines). Foundation files (`types.ts`, `errors.ts`, `recommendations.ts`) already landed via #1022 — the original duplicate commit was dropped during rebase, leaving a clean focused diff.

## Review fixes applied
**From Codex automated review:**
- Null/non-object guard: `validateExtension` returns a validation issue instead of crashing with `TypeError` when passed `null`, `undefined`, `string`, `number`, or array values
- CONFIG errors use 4xx status codes (422 for validation/circular, 409 for conflict) — landed via #1022
- Recommendations use `Map` for prototype-safe lookup — landed via #1022

**From `/review` follow-up:**
- `validateExtension` parameter type changed from `Extension` to `unknown` — config-loader callers no longer need to cast untrusted imported values
- `ConflictInfo.providers[].source` tightened from `string` to `ExtensionSource`
- Replaced non-null assertion in `detectConflicts` with local-variable pattern
- Test file now passes `deno check` under `noUncheckedIndexedAccess`

## Security review
- Pure in-memory functions; no I/O, no network, no shell, no `eval`, no deserialization sinks
- Input trust boundary: extension objects come from developer-authored packages, not end-user input
- `Object.keys(provides)` result populates a `Map`, not a plain object — no prototype pollution surface
- No secrets, no PII, no HTML output
- `/security-review` returned no findings meeting the confidence bar

## Acceptance criteria
- [x] `validateExtension(ext)` returns `string[]` of issues (empty = valid)
- [x] Accepts `unknown` and guards against null/undefined/non-object/array input without crashing
- [x] Validates: name is non-empty string, version is non-empty string, capabilities is array
- [x] Each capability must be a non-null, non-array object with a string `type` field
- [x] `detectConflicts(extensions)` returns `ConflictInfo[]`
- [x] `ConflictInfo` has `contract` and `providers` with `name` and typed `source`
- [x] Conflict suppressed when exactly one provider has strictly higher source priority
- [x] Source priority order: config (0) > package (1) > project (2) > local-file (3)
- [x] Zero external dependencies

## Test plan
- [x] `deno test --no-check --allow-all src/extensions/validation.test.ts` — 20 tests pass (12 validateExtension + 8 detectConflicts)
- [x] `deno check src/extensions/validation.ts src/extensions/validation.test.ts` — typechecks clean under strict settings
- [x] `deno task lint src/extensions/` — clean
- [x] `deno fmt --check src/extensions/` — clean
- [x] Full test suite via pre-push hook: 1351 passed, 0 failed

## Test coverage added beyond original scope
- `validateExtension`: string input, number input, array input, array-as-capability-entry
- `detectConflicts`: two config-sourced tie, three-provider single-winner, extension with no `provides`, multi-contract independence, empty list, source-type preservation
