### PR TITLE
feat(extensions): multi-source extension discovery

### DIFF
--- a/src/extensions/discovery.test.ts
+++ b/src/extensions/discovery.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Extension discovery tests.
+ *
+ * Verifies multi-source extension discovery: package metadata parsing,
+ * merge priority, disable directives, and deduplication.
+ *
+ * @module extensions/discovery.test
+ */
+
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { Extension, ResolvedExtension } from "./types.ts";
+import { mergeExtensions, parsePackageMetadata } from "./discovery.ts";
+
+function stubExtension(overrides: Partial<Extension> = {}): Extension {
+  return {
+    name: "stub",
+    version: "1.0.0",
+    capabilities: [],
+    ...overrides,
+  };
+}
+
+describe("parsePackageMetadata()", () => {
+  it("should detect extension package", () => {
+    const result = parsePackageMetadata({
+      name: "@veryfront/ext-tailwind",
+      veryfront: { extension: true, capabilities: [{ type: "css" }] },
+    });
+    assertEquals(result?.isExtension, true);
+    assertEquals(result?.capabilities.length, 1);
+    assertEquals(result?.capabilities[0]?.type, "css");
+  });
+
+  it("should return undefined for non-extension package", () => {
+    const result = parsePackageMetadata({ name: "lodash" });
+    assertEquals(result, undefined);
+  });
+
+  it("should return undefined when extension is false", () => {
+    const result = parsePackageMetadata({
+      name: "some-pkg",
+      veryfront: { extension: false },
+    });
+    assertEquals(result, undefined);
+  });
+});
+
+describe("mergeExtensions()", () => {
+  it("should give config highest priority", () => {
+    const configExt = stubExtension({ name: "shared", version: "2.0.0" });
+    const packageExt = stubExtension({ name: "shared", version: "1.0.0" });
+
+    const configResolved: ResolvedExtension[] = [
+      { extension: configExt, source: "config", origin: "veryfront.config.ts" },
+    ];
+    const packageResolved: ResolvedExtension[] = [
+      { extension: packageExt, source: "package", origin: "node_modules/@veryfront/ext-shared" },
+    ];
+
+    const result = mergeExtensions(configResolved, packageResolved, [], []);
+    assertEquals(result.length, 1);
+    assertEquals(result[0]?.extension.version, "2.0.0");
+    assertEquals(result[0]?.source, "config");
+  });
+
+  it("should filter disabled extensions", () => {
+    const ext = stubExtension({ name: "disabled-ext" });
+    const configResolved: ResolvedExtension[] = [
+      { extension: ext, source: "config", origin: "veryfront.config.ts" },
+    ];
+
+    const result = mergeExtensions(
+      configResolved,
+      [],
+      [],
+      [],
+      [{ name: "disabled-ext", enabled: false }],
+    );
+    assertEquals(result.length, 0);
+  });
+
+  it("should deduplicate by name keeping highest priority", () => {
+    const configExt = stubExtension({ name: "alpha", version: "3.0.0" });
+    const packageExt = stubExtension({ name: "alpha", version: "2.0.0" });
+    const projectExt = stubExtension({ name: "alpha", version: "1.0.0" });
+    const localExt = stubExtension({ name: "beta", version: "1.0.0" });
+
+    const result = mergeExtensions(
+      [{ extension: configExt, source: "config", origin: "config" }],
+      [{ extension: packageExt, source: "package", origin: "pkg" }],
+      [{ extension: projectExt, source: "project", origin: "project" }],
+      [{ extension: localExt, source: "local-file", origin: "local" }],
+    );
+    assertEquals(result.length, 2);
+    assertEquals(result[0]?.extension.name, "alpha");
+    assertEquals(result[0]?.extension.version, "3.0.0");
+    assertEquals(result[1]?.extension.name, "beta");
+  });
+});

--- a/src/extensions/discovery.test.ts
+++ b/src/extensions/discovery.test.ts
@@ -4,6 +4,10 @@
  * Verifies multi-source extension discovery: package metadata parsing,
  * merge priority, disable directives, and deduplication.
  *
+ * Note: symlink handling for pnpm-style node_modules is covered by the
+ * `isDirectory || isSymlink` check in discoverPackageExtensions() and
+ * validated via pre-push integration tests against real filesystems.
+ *
  * @module extensions/discovery.test
  */
 

--- a/src/extensions/discovery.test.ts
+++ b/src/extensions/discovery.test.ts
@@ -1,20 +1,23 @@
 /**
  * Extension discovery tests.
  *
- * Verifies multi-source extension discovery: package metadata parsing,
- * merge priority, disable directives, and deduplication.
- *
- * Note: symlink handling for pnpm-style node_modules is covered by the
- * `isDirectory || isSymlink` check in discoverPackageExtensions() and
- * validated via pre-push integration tests against real filesystems.
+ * Covers pure logic (parse/merge) and filesystem discovery against
+ * real tempdir fixtures (scoped packages, symlinks, malformed package.json).
  *
  * @module extensions/discovery.test
  */
 
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { join } from "@std/path";
 import type { Extension, ResolvedExtension } from "./types.ts";
-import { mergeExtensions, parsePackageMetadata } from "./discovery.ts";
+import {
+  discoverLocalExtensions,
+  discoverPackageExtensions,
+  discoverProjectExtensions,
+  mergeExtensions,
+  parsePackageMetadata,
+} from "./discovery.ts";
 
 function stubExtension(overrides: Partial<Extension> = {}): Extension {
   return {
@@ -48,6 +51,44 @@ describe("parsePackageMetadata()", () => {
     });
     assertEquals(result, undefined);
   });
+
+  it("should return undefined when veryfront field is array", () => {
+    const result = parsePackageMetadata({ veryfront: [] });
+    assertEquals(result, undefined);
+  });
+
+  it("should return undefined when veryfront field is null", () => {
+    const result = parsePackageMetadata({ veryfront: null });
+    assertEquals(result, undefined);
+  });
+
+  it("should filter malformed capability entries", () => {
+    const result = parsePackageMetadata({
+      veryfront: {
+        extension: true,
+        capabilities: [
+          { type: "css" },
+          null,
+          42,
+          "string",
+          [],
+          { notAType: "x" },
+          { type: "" },
+          { type: "valid" },
+        ],
+      },
+    });
+    assertEquals(result?.capabilities.length, 2);
+    assertEquals(result?.capabilities[0]?.type, "css");
+    assertEquals(result?.capabilities[1]?.type, "valid");
+  });
+
+  it("should treat non-array capabilities as empty", () => {
+    const result = parsePackageMetadata({
+      veryfront: { extension: true, capabilities: "not-an-array" },
+    });
+    assertEquals(result?.capabilities.length, 0);
+  });
 });
 
 describe("mergeExtensions()", () => {
@@ -59,7 +100,11 @@ describe("mergeExtensions()", () => {
       { extension: configExt, source: "config", origin: "veryfront.config.ts" },
     ];
     const packageResolved: ResolvedExtension[] = [
-      { extension: packageExt, source: "package", origin: "node_modules/@veryfront/ext-shared" },
+      {
+        extension: packageExt,
+        source: "package",
+        origin: "node_modules/@veryfront/ext-shared",
+      },
     ];
 
     const result = mergeExtensions(configResolved, packageResolved, [], []);
@@ -100,5 +145,226 @@ describe("mergeExtensions()", () => {
     assertEquals(result[0]?.extension.name, "alpha");
     assertEquals(result[0]?.extension.version, "3.0.0");
     assertEquals(result[1]?.extension.name, "beta");
+  });
+
+  it("should return empty for empty inputs", () => {
+    assertEquals(mergeExtensions([], [], [], []), []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filesystem discovery fixtures
+// ---------------------------------------------------------------------------
+
+async function writePkg(
+  dir: string,
+  name: string,
+  veryfront?: Record<string, unknown>,
+): Promise<void> {
+  await Deno.mkdir(dir, { recursive: true });
+  const pkg: Record<string, unknown> = { name, version: "1.0.0" };
+  if (veryfront) pkg.veryfront = veryfront;
+  await Deno.writeTextFile(join(dir, "package.json"), JSON.stringify(pkg));
+}
+
+describe("discoverPackageExtensions()", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await Deno.makeTempDir({ prefix: "vf-disc-pkg-" });
+  });
+
+  afterEach(async () => {
+    await Deno.remove(tmp, { recursive: true });
+  });
+
+  it("returns empty when node_modules is missing", async () => {
+    assertEquals(await discoverPackageExtensions(tmp), []);
+  });
+
+  it("finds a top-level extension package", async () => {
+    await writePkg(join(tmp, "node_modules", "ext-a"), "ext-a", {
+      extension: true,
+      capabilities: [{ type: "bundler" }],
+    });
+    const found = await discoverPackageExtensions(tmp);
+    assertEquals(found.length, 1);
+    assertEquals(found[0]?.packageName, "ext-a");
+    assertEquals(found[0]?.metadata.capabilities[0]?.type, "bundler");
+  });
+
+  it("skips packages without veryfront.extension", async () => {
+    await writePkg(join(tmp, "node_modules", "lodash"), "lodash");
+    await writePkg(join(tmp, "node_modules", "ext-a"), "ext-a", {
+      extension: true,
+    });
+    const found = await discoverPackageExtensions(tmp);
+    assertEquals(found.length, 1);
+    assertEquals(found[0]?.packageName, "ext-a");
+  });
+
+  it("finds scoped packages under @scope/", async () => {
+    await writePkg(
+      join(tmp, "node_modules", "@veryfront", "ext-tailwind"),
+      "@veryfront/ext-tailwind",
+      { extension: true },
+    );
+    const found = await discoverPackageExtensions(tmp);
+    assertEquals(found.length, 1);
+    assertEquals(found[0]?.packageName, "@veryfront/ext-tailwind");
+  });
+
+  it("finds symlinked packages (pnpm layout)", async () => {
+    // Real package lives outside node_modules; a symlink points to it.
+    const realPkg = join(tmp, ".store", "ext-pnpm@1.0.0");
+    await writePkg(realPkg, "ext-pnpm", { extension: true });
+    await Deno.mkdir(join(tmp, "node_modules"), { recursive: true });
+    await Deno.symlink(realPkg, join(tmp, "node_modules", "ext-pnpm"));
+
+    const found = await discoverPackageExtensions(tmp);
+    assertEquals(found.length, 1);
+    assertEquals(found[0]?.packageName, "ext-pnpm");
+  });
+
+  it("finds symlinked scoped packages (pnpm scoped layout)", async () => {
+    const realPkg = join(tmp, ".store", "ext-scoped@1.0.0");
+    await writePkg(realPkg, "@veryfront/ext-scoped", { extension: true });
+    await Deno.mkdir(join(tmp, "node_modules", "@veryfront"), {
+      recursive: true,
+    });
+    await Deno.symlink(
+      realPkg,
+      join(tmp, "node_modules", "@veryfront", "ext-scoped"),
+    );
+
+    const found = await discoverPackageExtensions(tmp);
+    assertEquals(found.length, 1);
+    assertEquals(found[0]?.packageName, "@veryfront/ext-scoped");
+  });
+
+  it("tolerates malformed package.json", async () => {
+    const pkgDir = join(tmp, "node_modules", "ext-broken");
+    await Deno.mkdir(pkgDir, { recursive: true });
+    await Deno.writeTextFile(join(pkgDir, "package.json"), "{not valid json");
+
+    await writePkg(join(tmp, "node_modules", "ext-ok"), "ext-ok", {
+      extension: true,
+    });
+
+    const found = await discoverPackageExtensions(tmp);
+    assertEquals(found.length, 1);
+    assertEquals(found[0]?.packageName, "ext-ok");
+  });
+
+  it("tolerates packages missing package.json", async () => {
+    await Deno.mkdir(join(tmp, "node_modules", "empty-dir"), {
+      recursive: true,
+    });
+    await writePkg(join(tmp, "node_modules", "ext-ok"), "ext-ok", {
+      extension: true,
+    });
+    const found = await discoverPackageExtensions(tmp);
+    assertEquals(found.length, 1);
+  });
+});
+
+describe("discoverProjectExtensions()", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await Deno.makeTempDir({ prefix: "vf-disc-proj-" });
+  });
+
+  afterEach(async () => {
+    await Deno.remove(tmp, { recursive: true });
+  });
+
+  it("returns empty when extensions dir is missing", async () => {
+    assertEquals(await discoverProjectExtensions(tmp), []);
+  });
+
+  it("finds src/index.ts", async () => {
+    const dir = join(tmp, "extensions", "my-ext", "src");
+    await Deno.mkdir(dir, { recursive: true });
+    await Deno.writeTextFile(join(dir, "index.ts"), "export default {};");
+    const found = await discoverProjectExtensions(tmp);
+    assertEquals(found.length, 1);
+    assertEquals(found[0], join(tmp, "extensions", "my-ext", "src", "index.ts"));
+  });
+
+  it("falls back to index.ts when src/index.ts is absent", async () => {
+    const dir = join(tmp, "extensions", "flat-ext");
+    await Deno.mkdir(dir, { recursive: true });
+    await Deno.writeTextFile(join(dir, "index.ts"), "export default {};");
+    const found = await discoverProjectExtensions(tmp);
+    assertEquals(found.length, 1);
+    assertEquals(found[0], join(tmp, "extensions", "flat-ext", "index.ts"));
+  });
+
+  it("prefers src/index.ts over index.ts", async () => {
+    const dir = join(tmp, "extensions", "both");
+    await Deno.mkdir(join(dir, "src"), { recursive: true });
+    await Deno.writeTextFile(join(dir, "index.ts"), "root");
+    await Deno.writeTextFile(join(dir, "src", "index.ts"), "src");
+    const found = await discoverProjectExtensions(tmp);
+    assertEquals(found.length, 1);
+    assertEquals(found[0], join(dir, "src", "index.ts"));
+  });
+
+  it("skips extension dirs with no index", async () => {
+    const dir = join(tmp, "extensions", "empty-ext");
+    await Deno.mkdir(dir, { recursive: true });
+    const found = await discoverProjectExtensions(tmp);
+    assertEquals(found, []);
+  });
+
+  it("skips non-directory entries in extensions/", async () => {
+    await Deno.mkdir(join(tmp, "extensions"), { recursive: true });
+    await Deno.writeTextFile(join(tmp, "extensions", "README.md"), "x");
+    const found = await discoverProjectExtensions(tmp);
+    assertEquals(found, []);
+  });
+});
+
+describe("discoverLocalExtensions()", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await Deno.makeTempDir({ prefix: "vf-disc-local-" });
+  });
+
+  afterEach(async () => {
+    await Deno.remove(tmp, { recursive: true });
+  });
+
+  it("returns empty for missing dir", async () => {
+    assertEquals(
+      await discoverLocalExtensions(join(tmp, "does-not-exist")),
+      [],
+    );
+  });
+
+  it("finds *.extension.ts files", async () => {
+    await Deno.writeTextFile(join(tmp, "foo.extension.ts"), "x");
+    await Deno.writeTextFile(join(tmp, "bar.extension.ts"), "x");
+    const found = await discoverLocalExtensions(tmp);
+    assertEquals(found.length, 2);
+  });
+
+  it("ignores non-matching files", async () => {
+    await Deno.writeTextFile(join(tmp, "index.ts"), "x");
+    await Deno.writeTextFile(join(tmp, "foo.test.ts"), "x");
+    await Deno.writeTextFile(join(tmp, "my.extension.ts"), "x");
+    const found = await discoverLocalExtensions(tmp);
+    assertEquals(found.length, 1);
+    assertEquals(found[0], join(tmp, "my.extension.ts"));
+  });
+
+  it("ignores directories even if they match the pattern", async () => {
+    await Deno.mkdir(join(tmp, "weird.extension.ts"), { recursive: true });
+    await Deno.writeTextFile(join(tmp, "real.extension.ts"), "x");
+    const found = await discoverLocalExtensions(tmp);
+    assertEquals(found.length, 1);
+    assertEquals(found[0], join(tmp, "real.extension.ts"));
   });
 });

--- a/src/extensions/discovery.ts
+++ b/src/extensions/discovery.ts
@@ -7,6 +7,7 @@
  * @module extensions/discovery
  */
 
+import { join } from "@std/path";
 import type { Capability, ResolvedExtension } from "./types.ts";
 
 /**
@@ -18,11 +19,20 @@ export interface PackageMetadata {
   capabilities: Capability[];
 }
 
+function isCapability(value: unknown): value is Capability {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const cap = value as Record<string, unknown>;
+  return typeof cap.type === "string" && cap.type.length > 0;
+}
+
 /**
  * Parse veryfront extension metadata from a package.json-like object.
  *
  * Returns `PackageMetadata` when the package declares
- * `veryfront.extension: true`, otherwise `undefined`.
+ * `veryfront.extension: true`, otherwise `undefined`. Malformed capability
+ * entries are filtered out; the caller receives only valid shapes.
  */
 export function parsePackageMetadata(
   pkg: Record<string, unknown>,
@@ -41,7 +51,7 @@ export function parsePackageMetadata(
   }
 
   const capabilities: Capability[] = Array.isArray(meta.capabilities)
-    ? (meta.capabilities as Capability[])
+    ? meta.capabilities.filter(isCapability)
     : [];
 
   return { isExtension: true, capabilities };
@@ -91,17 +101,16 @@ export function mergeExtensions(
 // Filesystem discovery helpers
 // ---------------------------------------------------------------------------
 
-async function readDir(
-  path: string,
-): Promise<Deno.DirEntry[]> {
+async function readDir(path: string): Promise<Deno.DirEntry[]> {
   try {
     const entries: Deno.DirEntry[] = [];
     for await (const entry of Deno.readDir(path)) {
       entries.push(entry);
     }
     return entries;
-  } catch {
-    return [];
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return [];
+    throw err;
   }
 }
 
@@ -109,8 +118,9 @@ async function fileExists(path: string): Promise<boolean> {
   try {
     await Deno.stat(path);
     return true;
-  } catch {
-    return false;
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return false;
+    throw err;
   }
 }
 
@@ -121,7 +131,7 @@ async function fileExists(path: string): Promise<boolean> {
 export async function discoverPackageExtensions(
   baseDir: string,
 ): Promise<Array<{ packageName: string; metadata: PackageMetadata }>> {
-  const nmDir = `${baseDir}/node_modules`;
+  const nmDir = join(baseDir, "node_modules");
   const results: Array<{ packageName: string; metadata: PackageMetadata }> = [];
   const entries = await readDir(nmDir);
 
@@ -131,18 +141,18 @@ export async function discoverPackageExtensions(
 
     if (entry.name.startsWith("@")) {
       // Scoped packages -- iterate one level deeper.
-      const scopeDir = `${nmDir}/${entry.name}`;
+      const scopeDir = join(nmDir, entry.name);
       const scopeEntries = await readDir(scopeDir);
       for (const scopeEntry of scopeEntries) {
         if (!scopeEntry.isDirectory && !scopeEntry.isSymlink) continue;
         const pkgName = `${entry.name}/${scopeEntry.name}`;
         const meta = await tryReadPackageMeta(
-          `${scopeDir}/${scopeEntry.name}`,
+          join(scopeDir, scopeEntry.name),
         );
         if (meta) results.push({ packageName: pkgName, metadata: meta });
       }
     } else {
-      const meta = await tryReadPackageMeta(`${nmDir}/${entry.name}`);
+      const meta = await tryReadPackageMeta(join(nmDir, entry.name));
       if (meta) results.push({ packageName: entry.name, metadata: meta });
     }
   }
@@ -153,11 +163,18 @@ export async function discoverPackageExtensions(
 async function tryReadPackageMeta(
   pkgDir: string,
 ): Promise<PackageMetadata | undefined> {
+  let raw: string;
   try {
-    const raw = await Deno.readTextFile(`${pkgDir}/package.json`);
+    raw = await Deno.readTextFile(join(pkgDir, "package.json"));
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return undefined;
+    throw err;
+  }
+  try {
     const pkg = JSON.parse(raw) as Record<string, unknown>;
     return parsePackageMetadata(pkg);
   } catch {
+    // Malformed JSON -- treat as non-extension package.
     return undefined;
   }
 }
@@ -170,14 +187,14 @@ async function tryReadPackageMeta(
 export async function discoverProjectExtensions(
   baseDir: string,
 ): Promise<string[]> {
-  const extDir = `${baseDir}/extensions`;
+  const extDir = join(baseDir, "extensions");
   const entries = await readDir(extDir);
   const results: string[] = [];
 
   for (const entry of entries) {
     if (!entry.isDirectory) continue;
-    const srcIndex = `${extDir}/${entry.name}/src/index.ts`;
-    const rootIndex = `${extDir}/${entry.name}/index.ts`;
+    const srcIndex = join(extDir, entry.name, "src", "index.ts");
+    const rootIndex = join(extDir, entry.name, "index.ts");
 
     if (await fileExists(srcIndex)) {
       results.push(srcIndex);
@@ -198,5 +215,5 @@ export async function discoverLocalExtensions(
   const entries = await readDir(baseDir);
   return entries
     .filter((e) => !e.isDirectory && e.name.endsWith(".extension.ts"))
-    .map((e) => `${baseDir}/${e.name}`);
+    .map((e) => join(baseDir, e.name));
 }

--- a/src/extensions/discovery.ts
+++ b/src/extensions/discovery.ts
@@ -126,14 +126,15 @@ export async function discoverPackageExtensions(
   const entries = await readDir(nmDir);
 
   for (const entry of entries) {
-    if (!entry.isDirectory) continue;
+    // Accept symlinks so pnpm-style node_modules layouts are discovered.
+    if (!entry.isDirectory && !entry.isSymlink) continue;
 
     if (entry.name.startsWith("@")) {
       // Scoped packages -- iterate one level deeper.
       const scopeDir = `${nmDir}/${entry.name}`;
       const scopeEntries = await readDir(scopeDir);
       for (const scopeEntry of scopeEntries) {
-        if (!scopeEntry.isDirectory) continue;
+        if (!scopeEntry.isDirectory && !scopeEntry.isSymlink) continue;
         const pkgName = `${entry.name}/${scopeEntry.name}`;
         const meta = await tryReadPackageMeta(
           `${scopeDir}/${scopeEntry.name}`,

--- a/src/extensions/discovery.ts
+++ b/src/extensions/discovery.ts
@@ -1,0 +1,201 @@
+/**
+ * Multi-source extension discovery.
+ *
+ * Discovers extensions from four sources with priority:
+ *   config > package > project > local-file
+ *
+ * @module extensions/discovery
+ */
+
+import type { Capability, ResolvedExtension } from "./types.ts";
+
+/**
+ * Metadata extracted from a package.json that declares itself
+ * as a veryfront extension.
+ */
+export interface PackageMetadata {
+  isExtension: true;
+  capabilities: Capability[];
+}
+
+/**
+ * Parse veryfront extension metadata from a package.json-like object.
+ *
+ * Returns `PackageMetadata` when the package declares
+ * `veryfront.extension: true`, otherwise `undefined`.
+ */
+export function parsePackageMetadata(
+  pkg: Record<string, unknown>,
+): PackageMetadata | undefined {
+  const vf = pkg.veryfront;
+  if (
+    vf === null || vf === undefined || typeof vf !== "object" ||
+    Array.isArray(vf)
+  ) {
+    return undefined;
+  }
+
+  const meta = vf as Record<string, unknown>;
+  if (meta.extension !== true) {
+    return undefined;
+  }
+
+  const capabilities: Capability[] = Array.isArray(meta.capabilities)
+    ? (meta.capabilities as Capability[])
+    : [];
+
+  return { isExtension: true, capabilities };
+}
+
+/**
+ * Merge extensions from all four sources in priority order.
+ *
+ * Priority (highest first): config > package > project > local-file.
+ * Duplicates are resolved by keeping the highest-priority entry.
+ * Disable directives (`{ name, enabled: false }`) remove matching
+ * extensions regardless of source.
+ */
+export function mergeExtensions(
+  config: ResolvedExtension[],
+  packages: ResolvedExtension[],
+  project: ResolvedExtension[],
+  local: ResolvedExtension[],
+  disableDirectives?: Array<{ name: string; enabled: false }>,
+): ResolvedExtension[] {
+  const disabledNames = new Set(
+    (disableDirectives ?? []).map((d) => d.name),
+  );
+
+  const seen = new Map<string, ResolvedExtension>();
+
+  // Process sources in priority order -- first write wins.
+  const ordered: ResolvedExtension[] = [
+    ...config,
+    ...packages,
+    ...project,
+    ...local,
+  ];
+
+  for (const resolved of ordered) {
+    const name = resolved.extension.name;
+    if (disabledNames.has(name)) continue;
+    if (!seen.has(name)) {
+      seen.set(name, resolved);
+    }
+  }
+
+  return [...seen.values()];
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem discovery helpers
+// ---------------------------------------------------------------------------
+
+async function readDir(
+  path: string,
+): Promise<Deno.DirEntry[]> {
+  try {
+    const entries: Deno.DirEntry[] = [];
+    for await (const entry of Deno.readDir(path)) {
+      entries.push(entry);
+    }
+    return entries;
+  } catch {
+    return [];
+  }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Scan `node_modules` (including `@scoped` packages) for packages
+ * that declare veryfront extension metadata in their `package.json`.
+ */
+export async function discoverPackageExtensions(
+  baseDir: string,
+): Promise<Array<{ packageName: string; metadata: PackageMetadata }>> {
+  const nmDir = `${baseDir}/node_modules`;
+  const results: Array<{ packageName: string; metadata: PackageMetadata }> = [];
+  const entries = await readDir(nmDir);
+
+  for (const entry of entries) {
+    if (!entry.isDirectory) continue;
+
+    if (entry.name.startsWith("@")) {
+      // Scoped packages -- iterate one level deeper.
+      const scopeDir = `${nmDir}/${entry.name}`;
+      const scopeEntries = await readDir(scopeDir);
+      for (const scopeEntry of scopeEntries) {
+        if (!scopeEntry.isDirectory) continue;
+        const pkgName = `${entry.name}/${scopeEntry.name}`;
+        const meta = await tryReadPackageMeta(
+          `${scopeDir}/${scopeEntry.name}`,
+        );
+        if (meta) results.push({ packageName: pkgName, metadata: meta });
+      }
+    } else {
+      const meta = await tryReadPackageMeta(`${nmDir}/${entry.name}`);
+      if (meta) results.push({ packageName: entry.name, metadata: meta });
+    }
+  }
+
+  return results;
+}
+
+async function tryReadPackageMeta(
+  pkgDir: string,
+): Promise<PackageMetadata | undefined> {
+  try {
+    const raw = await Deno.readTextFile(`${pkgDir}/package.json`);
+    const pkg = JSON.parse(raw) as Record<string, unknown>;
+    return parsePackageMetadata(pkg);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Discover project extensions living under `extensions/` in the project root.
+ *
+ * Looks for `extensions/<name>/src/index.ts` and `extensions/<name>/index.ts`.
+ */
+export async function discoverProjectExtensions(
+  baseDir: string,
+): Promise<string[]> {
+  const extDir = `${baseDir}/extensions`;
+  const entries = await readDir(extDir);
+  const results: string[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory) continue;
+    const srcIndex = `${extDir}/${entry.name}/src/index.ts`;
+    const rootIndex = `${extDir}/${entry.name}/index.ts`;
+
+    if (await fileExists(srcIndex)) {
+      results.push(srcIndex);
+    } else if (await fileExists(rootIndex)) {
+      results.push(rootIndex);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Find `*.extension.ts` files in the project root.
+ */
+export async function discoverLocalExtensions(
+  baseDir: string,
+): Promise<string[]> {
+  const entries = await readDir(baseDir);
+  return entries
+    .filter((e) => !e.isDirectory && e.name.endsWith(".extension.ts"))
+    .map((e) => `${baseDir}/${e.name}`);
+}


### PR DESCRIPTION
## Summary
Multi-source extension discovery (issue #1015):
- `parsePackageMetadata(pkg)` — detects `veryfront.extension: true` in package.json, filters malformed capability entries
- `mergeExtensions(config, packages, project, local, disableDirectives?)` — merges with priority + dedup + disable
- `discoverPackageExtensions(baseDir)` — scans `node_modules` (including `@scoped` and symlinked)
- `discoverProjectExtensions(baseDir)` — scans `extensions/<name>/src/index.ts` (with `index.ts` fallback)
- `discoverLocalExtensions(baseDir)` — finds `*.extension.ts` files in project root

Closes #1015

## Scope after rebase onto main
PR now adds **only** `src/extensions/discovery.ts` + `discovery.test.ts` (589 lines). The duplicate foundation commit (superseded by #1022 on main) was dropped during rebase; the 4xx-status cherry-pick was auto-dropped as "patch contents already upstream".

## Review fixes applied
**From Codex automated review:**
- Symlink support: `discoverPackageExtensions` now accepts `isSymlink` entries (both top-level and `@scoped`), so pnpm-style `node_modules` layouts are discovered
- 4xx status for CONFIG errors — landed on main via #1022

**From `/review` follow-up:**
- `parsePackageMetadata` filters malformed capability entries (null, non-object, missing/empty `type`) so downstream consumers receive only well-shaped `Capability` objects
- `readDir` / `fileExists` re-throw non-`NotFound` errors — permission issues and disk problems surface instead of being silently swallowed as "no extensions found"
- `tryReadPackageMeta` distinguishes missing `package.json` (swallowed) from read errors (re-thrown); malformed JSON still tolerated
- Migrated path construction to `@std/path` `join` (consistent with rest of codebase, safer on non-POSIX hosts)
- Removed misleading test-file comment claiming integration coverage existed when it didn't

## Security review
- Read-only filesystem access scoped to `baseDir`/`node_modules/`, `baseDir`/`extensions/`, `baseDir` itself
- No network, no shell, no `eval`, no dynamic `import`, no subprocess spawning
- V8 `JSON.parse` treats `__proto__` as own-property (not setter), and parsed metadata flows into `Map`/`Set` structures — no prototype pollution surface
- `baseDir` is a trusted Veryfront config value, not end-user input
- Symlink following in `node_modules` intended (pnpm support); `node_modules` contents are already within the developer's supply-chain trust boundary
- `/security-review` returned no findings meeting the confidence bar

## Acceptance criteria
- [x] `parsePackageMetadata(pkg)` detects `veryfront.extension: true` in `package.json`
- [x] Returns `PackageMetadata` with `isExtension` and validated `capabilities`
- [x] Returns `undefined` for non-extension, array-typed, null-typed, or missing `veryfront` field
- [x] Filters out malformed capability entries (null / non-object / missing `type` / empty `type`)
- [x] `mergeExtensions()` combines extensions from four sources with priority and disable directives
- [x] `discoverPackageExtensions(baseDir)` scans `node_modules` (including scoped and pnpm symlinks)
- [x] `discoverProjectExtensions(baseDir)` scans `extensions/*/src/index.ts` with `index.ts` fallback
- [x] `discoverLocalExtensions(baseDir)` finds `*.extension.ts` files
- [x] Missing directories handled gracefully; permission/IO errors surface
- [x] Zero external dependencies (uses `@std/path` already in import map)

## Test plan
- [x] `deno test --no-check --allow-all src/extensions/discovery.test.ts` — 5 suites, 29 steps pass
- [x] `deno check src/extensions/discovery.ts src/extensions/discovery.test.ts` — clean under strict settings (`noUncheckedIndexedAccess`)
- [x] `deno task lint src/extensions/` — clean
- [x] `deno fmt --check src/extensions/` — clean
- [x] Full test suite via pre-push hook: 1356 passed, 0 failed

## Test coverage added beyond original scope
**parsePackageMetadata:** array-typed `veryfront`, null-typed `veryfront`, malformed capability filtering, non-array capabilities.

**discoverPackageExtensions (all new — 8 fixture tests):** missing `node_modules`, top-level package, skip non-extension, `@scoped` package, pnpm symlink, pnpm scoped symlink, malformed `package.json`, missing `package.json`.

**discoverProjectExtensions (all new — 6 fixture tests):** missing `extensions/`, `src/index.ts`, `index.ts` fallback, precedence when both present, empty extension dir, non-directory entries.

**discoverLocalExtensions (all new — 4 fixture tests):** missing dir, `*.extension.ts` discovery, non-matching exclusion, directory-entry exclusion.
