### PR TITLE
docs: add agent workflow recipes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,29 @@ MCP auto-starts on `--port` + 2 (default: 3002) with `veryfront dev`. With `very
 
 **Resources:** `veryfront://skill`, `veryfront://errors`, `veryfront://logs`, `veryfront://schema`, `veryfront://agents-md`
 
+## Agent Workflows
+
+### Session Start
+Call `vf_bootstrap` once at session start for full project context:
+```
+# Single call replaces: vf_get_project_context + vf_get_conventions + vf_get_errors + vf_get_status
+vf_bootstrap()
+```
+
+### Development Loop (Flywheel)
+1. Edit code
+2. `vf_trigger_hmr({ path: "app/page.tsx" })` — push changes to browser
+3. `vf_get_errors()` — check for compile/runtime errors
+4. `vf_run_tests({ filter: "page" })` — run related tests
+5. `vf_run_lint()` — check for lint issues
+6. Iterate
+
+### Build & Deploy
+1. `vf_run_tests({ parallel: true })` — full test suite
+2. `vf_run_lint()` — verify no lint issues
+3. `vf_build({ dryRun: true })` — preview build output
+4. `vf_build()` — production build
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## Summary

Adds an "Agent Workflows" section to `AGENTS.md` with three recipes that tell agents which MCP tools to call and in what order. No code changes.

### What changed
- **AGENTS.md** (+23 lines): new section covering
  - **Session Start** — single `vf_bootstrap()` call replacing four individual context tools
  - **Development Loop (Flywheel)** — edit → `vf_trigger_hmr` → `vf_get_errors` → `vf_run_tests` → `vf_run_lint`
  - **Build & Deploy** — tests → lint → `vf_build({ dryRun: true })` → `vf_build()`

### Why
Agents previously had to infer the correct tool-call sequence from individual tool descriptions. A single playbook in `AGENTS.md` (which is loaded at session start) gives the canonical order up front and explicitly points at `vf_bootstrap` as the session primer.

### Tool name verification
All six tool names referenced (`vf_bootstrap`, `vf_trigger_hmr`, `vf_get_errors`, `vf_run_tests`, `vf_run_lint`, `vf_build`) resolve to tools defined in `cli/mcp/tools/` with matching input schemas. `vf_trigger_hmr`'s `path` param and `vf_build`'s `dryRun` param are both real, documented fields.

Closes #1013

## Test plan

- [x] Rebased onto `main` — clean, no conflicts
- [x] Referenced tool names and input signatures verified against `cli/mcp/tools/`
- [x] Pre-push hook: 1356 tests, 0 failures
- [x] Docs-only change — no runtime impact
