### PR TITLE
Default Anthropic thinking on in AgentRuntime (project-agent parity)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.201",
+  "version": "0.1.202",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/runtime/default-provider-options.test.ts
+++ b/src/agent/runtime/default-provider-options.test.ts
@@ -1,0 +1,115 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { resolveProviderOptionsWithDefaults } from "./default-provider-options.ts";
+
+describe("resolveProviderOptionsWithDefaults", () => {
+  it("enables Anthropic thinking by default for Anthropic models", () => {
+    const result = resolveProviderOptionsWithDefaults(
+      "anthropic/claude-opus-4-6",
+      undefined,
+    );
+
+    assertEquals(result, {
+      anthropic: {
+        temperature: 1,
+        thinking: { type: "enabled", budget_tokens: 2048 },
+      },
+    });
+  });
+
+  it("recognizes the veryfront-cloud prefix as Anthropic when applicable", () => {
+    const result = resolveProviderOptionsWithDefaults(
+      "veryfront-cloud/anthropic/claude-sonnet-4-6",
+      undefined,
+    );
+
+    assertEquals(result, {
+      anthropic: {
+        temperature: 1,
+        thinking: { type: "enabled", budget_tokens: 2048 },
+      },
+    });
+  });
+
+  it("does not enable thinking for non-Anthropic models", () => {
+    assertEquals(
+      resolveProviderOptionsWithDefaults("openai/gpt-5.2", undefined),
+      undefined,
+    );
+    assertEquals(
+      resolveProviderOptionsWithDefaults("google/gemini-2.5-pro", undefined),
+      undefined,
+    );
+  });
+
+  it("respects an existing anthropic.thinking config from the app instead of overriding", () => {
+    const existing = {
+      anthropic: {
+        thinking: { type: "enabled" as const, budget_tokens: 8000 },
+      },
+    };
+
+    const result = resolveProviderOptionsWithDefaults(
+      "anthropic/claude-opus-4-6",
+      existing,
+    );
+
+    assertEquals(result, existing);
+  });
+
+  it("respects an explicit opt-out (anthropic.thinking.type === 'disabled') from the app", () => {
+    const existing = {
+      anthropic: {
+        thinking: { type: "disabled" as const },
+      },
+    };
+
+    const result = resolveProviderOptionsWithDefaults(
+      "anthropic/claude-opus-4-6",
+      existing,
+    );
+
+    assertEquals(result, existing);
+  });
+
+  it("merges anthropic-thinking default into app providerOptions that don't mention thinking", () => {
+    const existing = {
+      anthropic: {
+        cacheControl: { type: "ephemeral" as const },
+      },
+    };
+
+    const result = resolveProviderOptionsWithDefaults(
+      "anthropic/claude-opus-4-6",
+      existing,
+    );
+
+    assertEquals(result, {
+      anthropic: {
+        cacheControl: { type: "ephemeral" },
+        temperature: 1,
+        thinking: { type: "enabled", budget_tokens: 2048 },
+      },
+    });
+  });
+
+  it("preserves a host-supplied anthropic.temperature instead of forcing 1", () => {
+    const existing = {
+      anthropic: {
+        temperature: 0,
+      },
+    };
+
+    const result = resolveProviderOptionsWithDefaults(
+      "anthropic/claude-opus-4-6",
+      existing,
+    );
+
+    assertEquals(result, {
+      anthropic: {
+        temperature: 0,
+        thinking: { type: "enabled", budget_tokens: 2048 },
+      },
+    });
+  });
+});

--- a/src/agent/runtime/default-provider-options.ts
+++ b/src/agent/runtime/default-provider-options.ts
@@ -1,0 +1,52 @@
+/**
+ * Framework-default `providerOptions` for known providers.
+ *
+ * Currently: enable Anthropic extended thinking by default for any
+ * Anthropic model, since the `reasoning-*` event surface in this framework
+ * relies on the provider-side feature being on. Apps can override or opt
+ * out by returning their own `providerOptions.anthropic.thinking` from
+ * `AgentConfig.resolveModelTransport`.
+ */
+
+const VERYFRONT_CLOUD_PREFIX = "veryfront-cloud/";
+const ANTHROPIC_PREFIX = "anthropic/";
+const DEFAULT_ANTHROPIC_THINKING_BUDGET_TOKENS = 2048;
+
+function isAnthropicModel(modelString: string): boolean {
+  const normalized = modelString.startsWith(VERYFRONT_CLOUD_PREFIX)
+    ? modelString.slice(VERYFRONT_CLOUD_PREFIX.length)
+    : modelString;
+  return normalized.startsWith(ANTHROPIC_PREFIX);
+}
+
+function hasAnthropicThinkingConfig(existing: Record<string, unknown> | undefined): boolean {
+  if (!existing || typeof existing !== "object") return false;
+  const anthropic = (existing as { anthropic?: unknown }).anthropic;
+  if (!anthropic || typeof anthropic !== "object") return false;
+  return "thinking" in (anthropic as Record<string, unknown>);
+}
+
+export function resolveProviderOptionsWithDefaults(
+  modelString: string,
+  existing: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!isAnthropicModel(modelString)) {
+    return existing;
+  }
+
+  if (hasAnthropicThinkingConfig(existing)) {
+    return existing;
+  }
+
+  const existingAnthropic = (existing?.anthropic ?? {}) as Record<string, unknown>;
+  return {
+    ...(existing ?? {}),
+    anthropic: {
+      // Defaults first; host-supplied fields (e.g. temperature) override them.
+      // Only `thinking` is forced because we already confirmed it isn't set.
+      temperature: 1,
+      ...existingAnthropic,
+      thinking: { type: "enabled", budget_tokens: DEFAULT_ANTHROPIC_THINKING_BUDGET_TOKENS },
+    },
+  };
+}

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -35,6 +35,7 @@ import {
 } from "#veryfront/observability/tracing/index.ts";
 import { convertToModelMessages } from "./model-message-converter.ts";
 import { convertToolsToRuntimeTools } from "./model-tool-converter.ts";
+import { resolveProviderOptionsWithDefaults } from "./default-provider-options.ts";
 import {
   type ChatStreamState,
   createStreamState,
@@ -313,7 +314,10 @@ export class AgentRuntime {
       resolvedModelString,
       languageModel: transport?.model ?? resolveModel(resolvedModelString),
       headers: transport?.headers,
-      providerOptions: transport?.providerOptions,
+      providerOptions: resolveProviderOptionsWithDefaults(
+        resolvedModelString,
+        transport?.providerOptions,
+      ),
     };
   }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.201";
+export const VERSION = "0.1.202";


### PR DESCRIPTION
## Summary
The framework's `AgentRuntime.resolveModelTransport` only forwarded `providerOptions` when the host app supplied a `resolveModelTransport` callback that returned them. Project agents (e.g. the staging \`screamer\` agent at \`anthropic/claude-opus-4-6\`) don't supply one, so Anthropic never got \`thinking: { type: 'enabled' }\` and reasoning was silent — even though the stream handler already forwards \`reasoning-*\` parts as SSE events (`src/agent/runtime/chat-stream-handler.ts:318-335`).

## Change
- New pure helper `resolveProviderOptionsWithDefaults(modelString, existing)` in `src/agent/runtime/default-provider-options.ts` — adds `anthropic.thinking` (2048 budget, temperature 1) when the model is Anthropic and no thinking config is present.
- Wire it into `AgentRuntime.resolveModelTransport` so the default applies even when the app config doesn't override.
- App-supplied providerOptions win (including explicit opt-out via `thinking: { type: 'disabled' }`).
- Recognises the `veryfront-cloud/anthropic/...` prefix.
