### PR TITLE
feat(extensions): extension loader with topo sort and lifecycle

### DIFF
--- a/src/extensions/loader.test.ts
+++ b/src/extensions/loader.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Extension loader tests — topological sort and lifecycle management.
+ *
+ * @module extensions/loader.test
+ */
+
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { ExtensionLoader } from "./loader.ts";
+import { reset } from "./contracts.ts";
+import type { Extension, ResolvedExtension } from "./types.ts";
+
+function makeResolved(ext: Extension): ResolvedExtension {
+  return { extension: ext, source: "config", origin: ext.name };
+}
+
+function makeExt(name: string, overrides: Partial<Extension> = {}): Extension {
+  return { name, version: "1.0.0", capabilities: [], ...overrides };
+}
+
+const noopLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+describe("ExtensionLoader", () => {
+  afterEach(() => {
+    reset();
+  });
+
+  describe("topologicalSort()", () => {
+    it("should sort providers before consumers", () => {
+      const provider = makeExt("provider", { provides: { CacheStore: {} } });
+      const consumer = makeExt("consumer", {
+        capabilities: [{ type: "contract", name: "CacheStore" }],
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      const sorted = loader.topologicalSort([
+        makeResolved(consumer),
+        makeResolved(provider),
+      ]);
+
+      assertEquals(sorted[0].extension.name, "provider");
+      assertEquals(sorted[1].extension.name, "consumer");
+    });
+
+    it("should keep original order when no dependencies exist", () => {
+      const a = makeExt("alpha");
+      const b = makeExt("beta");
+
+      const loader = new ExtensionLoader(noopLogger);
+      const sorted = loader.topologicalSort([makeResolved(a), makeResolved(b)]);
+      assertEquals(sorted[0].extension.name, "alpha");
+      assertEquals(sorted[1].extension.name, "beta");
+    });
+
+    it("should throw on circular dependencies", () => {
+      const a = makeExt("ext-a", {
+        provides: { A: {} },
+        capabilities: [{ type: "contract", name: "B" }],
+      });
+      const b = makeExt("ext-b", {
+        provides: { B: {} },
+        capabilities: [{ type: "contract", name: "A" }],
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      assertThrows(
+        () => loader.topologicalSort([makeResolved(a), makeResolved(b)]),
+        Error,
+        "Circular",
+      );
+    });
+  });
+
+  describe("setupAll()", () => {
+    it("should call setup() on each extension in order", async () => {
+      const order: string[] = [];
+      const a = makeExt("ext-a", {
+        setup: () => {
+          order.push("a");
+        },
+      });
+      const b = makeExt("ext-b", {
+        setup: () => {
+          order.push("b");
+        },
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      await loader.setupAll([makeResolved(a), makeResolved(b)], {});
+      assertEquals(order, ["a", "b"]);
+    });
+
+    it("should register static provides before calling setup()", async () => {
+      let resolved: unknown;
+      const provider = makeExt("provider", {
+        provides: { CacheStore: { id: "redis" } },
+      });
+      const consumer = makeExt("consumer", {
+        setup: (ctx) => {
+          resolved = ctx.get("CacheStore");
+        },
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      await loader.setupAll([makeResolved(provider), makeResolved(consumer)], {});
+      assertEquals((resolved as { id: string }).id, "redis");
+    });
+  });
+
+  describe("teardownAll()", () => {
+    it("should call teardown() in reverse order", async () => {
+      const order: string[] = [];
+      const a = makeExt("ext-a", {
+        teardown: () => {
+          order.push("a");
+        },
+      });
+      const b = makeExt("ext-b", {
+        teardown: () => {
+          order.push("b");
+        },
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      await loader.setupAll([makeResolved(a), makeResolved(b)], {});
+      await loader.teardownAll();
+      assertEquals(order, ["b", "a"]);
+    });
+  });
+
+  describe("flattenPresets()", () => {
+    it("should expand extensions with extends arrays", () => {
+      const child1 = makeExt("child1");
+      const child2 = makeExt("child2");
+      const preset = makeExt("preset", { extends: [child1, child2] });
+
+      const loader = new ExtensionLoader(noopLogger);
+      const flat = loader.flattenPresets([makeResolved(preset)]);
+      assertEquals(flat.length, 2);
+      assertEquals(flat[0].extension.name, "child1");
+      assertEquals(flat[1].extension.name, "child2");
+    });
+
+    it("should keep non-preset extensions as-is", () => {
+      const ext = makeExt("standalone");
+      const loader = new ExtensionLoader(noopLogger);
+      const flat = loader.flattenPresets([makeResolved(ext)]);
+      assertEquals(flat.length, 1);
+      assertEquals(flat[0].extension.name, "standalone");
+    });
+  });
+});

--- a/src/extensions/loader.test.ts
+++ b/src/extensions/loader.test.ts
@@ -7,11 +7,14 @@
 import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { ExtensionLoader } from "./loader.ts";
-import { reset } from "./contracts.ts";
-import type { Extension, ResolvedExtension } from "./types.ts";
+import { reset, tryResolve } from "./contracts.ts";
+import type { Extension, ExtensionSource, ResolvedExtension } from "./types.ts";
 
-function makeResolved(ext: Extension): ResolvedExtension {
-  return { extension: ext, source: "config", origin: ext.name };
+function makeResolved(
+  ext: Extension,
+  source: ExtensionSource = "config",
+): ResolvedExtension {
+  return { extension: ext, source, origin: ext.name };
 }
 
 function makeExt(name: string, overrides: Partial<Extension> = {}): Extension {
@@ -203,6 +206,167 @@ describe("ExtensionLoader", () => {
       const flat = loader.flattenPresets([makeResolved(ext)]);
       assertEquals(flat.length, 1);
       assertEquals(flat[0]?.extension.name, "standalone");
+    });
+
+    it("should throw controlled error on cyclic extends (A -> B -> A)", () => {
+      const a = makeExt("ext-a");
+      const b = makeExt("ext-b", { extends: [a] });
+      a.extends = [b];
+
+      const loader = new ExtensionLoader(noopLogger);
+      assertThrows(
+        () => loader.flattenPresets([makeResolved(a)]),
+        Error,
+        "Circular preset extends",
+      );
+    });
+
+    it("should throw on self-referential extends (A -> A)", () => {
+      const a = makeExt("ext-a");
+      a.extends = [a];
+
+      const loader = new ExtensionLoader(noopLogger);
+      assertThrows(
+        () => loader.flattenPresets([makeResolved(a)]),
+        Error,
+        "Circular preset extends",
+      );
+    });
+
+    it("should accept diamond graph with shared leaf (not a cycle)", () => {
+      const leaf = makeExt("leaf");
+      const preset = makeExt("preset", { extends: [leaf, leaf] });
+
+      const loader = new ExtensionLoader(noopLogger);
+      const flat = loader.flattenPresets([makeResolved(preset)]);
+      assertEquals(flat.length, 2);
+      assertEquals(flat[0]?.extension.name, "leaf");
+      assertEquals(flat[1]?.extension.name, "leaf");
+    });
+  });
+
+  describe("setupAll() — source priority on register()", () => {
+    it("should register the higher-priority provider's impl when two sources provide the same contract", async () => {
+      const configProvider = makeExt("config-cache", {
+        provides: { Cache: { id: "config-impl" } },
+      });
+      const packageProvider = makeExt("package-cache", {
+        provides: { Cache: { id: "package-impl" } },
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      await loader.setupAll(
+        [
+          makeResolved(configProvider, "config"),
+          makeResolved(packageProvider, "package"),
+        ],
+        {},
+      );
+
+      assertEquals((tryResolve("Cache") as { id: string }).id, "config-impl");
+    });
+
+    it("should win regardless of iteration order (lower-priority first)", async () => {
+      const configProvider = makeExt("config-cache", {
+        provides: { Cache: { id: "config-impl" } },
+      });
+      const projectProvider = makeExt("project-cache", {
+        provides: { Cache: { id: "project-impl" } },
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      // Pass project first to prove order-insensitivity.
+      await loader.setupAll(
+        [
+          makeResolved(projectProvider, "project"),
+          makeResolved(configProvider, "config"),
+        ],
+        {},
+      );
+
+      assertEquals((tryResolve("Cache") as { id: string }).id, "config-impl");
+    });
+  });
+
+  describe("setupAll() — rollback on setup failure", () => {
+    it("should teardown previously-loaded extensions when a later setup throws", async () => {
+      const order: string[] = [];
+      const a = makeExt("ext-a", {
+        setup: () => {
+          order.push("a-setup");
+        },
+        teardown: () => {
+          order.push("a-teardown");
+        },
+      });
+      const b = makeExt("ext-b", {
+        setup: () => {
+          throw new Error("boom");
+        },
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      await assertRejects(
+        () => loader.setupAll([makeResolved(a), makeResolved(b)], {}),
+        Error,
+        "boom",
+      );
+      assertEquals(order, ["a-setup", "a-teardown"]);
+    });
+
+    it("should call teardown() on the failing extension (best-effort)", async () => {
+      const order: string[] = [];
+      const failing = makeExt("failing", {
+        setup: () => {
+          order.push("setup");
+          throw new Error("boom");
+        },
+        teardown: () => {
+          order.push("teardown");
+        },
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      await assertRejects(
+        () => loader.setupAll([makeResolved(failing)], {}),
+        Error,
+        "boom",
+      );
+      assertEquals(order, ["setup", "teardown"]);
+    });
+
+    it("should clear the contract registry so failed provides do not leak", async () => {
+      const a = makeExt("ext-a", {
+        provides: { Cache: { id: "a-impl" } },
+      });
+      const failing = makeExt("failing", {
+        setup: () => {
+          throw new Error("boom");
+        },
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      await assertRejects(
+        () => loader.setupAll([makeResolved(a), makeResolved(failing)], {}),
+        Error,
+        "boom",
+      );
+      assertEquals(tryResolve("Cache"), undefined);
+    });
+
+    it("should not throw when failing extension has no teardown hook", async () => {
+      const failing = makeExt("failing", {
+        setup: () => {
+          throw new Error("boom");
+        },
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      await assertRejects(
+        () => loader.setupAll([makeResolved(failing)], {}),
+        Error,
+        "boom",
+      );
     });
   });
 });

--- a/src/extensions/loader.test.ts
+++ b/src/extensions/loader.test.ts
@@ -43,8 +43,8 @@ describe("ExtensionLoader", () => {
         makeResolved(provider),
       ]);
 
-      assertEquals(sorted[0].extension.name, "provider");
-      assertEquals(sorted[1].extension.name, "consumer");
+      assertEquals(sorted[0]?.extension.name, "provider");
+      assertEquals(sorted[1]?.extension.name, "consumer");
     });
 
     it("should keep original order when no dependencies exist", () => {
@@ -53,8 +53,8 @@ describe("ExtensionLoader", () => {
 
       const loader = new ExtensionLoader(noopLogger);
       const sorted = loader.topologicalSort([makeResolved(a), makeResolved(b)]);
-      assertEquals(sorted[0].extension.name, "alpha");
-      assertEquals(sorted[1].extension.name, "beta");
+      assertEquals(sorted[0]?.extension.name, "alpha");
+      assertEquals(sorted[1]?.extension.name, "beta");
     });
 
     it("should handle duplicate extension names without false circular error", () => {
@@ -65,7 +65,7 @@ describe("ExtensionLoader", () => {
         makeResolved(ext),
       ]);
       assertEquals(sorted.length, 1);
-      assertEquals(sorted[0].extension.name, "shared");
+      assertEquals(sorted[0]?.extension.name, "shared");
     });
 
     it("should throw on circular dependencies", () => {
@@ -182,8 +182,8 @@ describe("ExtensionLoader", () => {
       const loader = new ExtensionLoader(noopLogger);
       const flat = loader.flattenPresets([makeResolved(preset)]);
       assertEquals(flat.length, 2);
-      assertEquals(flat[0].extension.name, "child1");
-      assertEquals(flat[1].extension.name, "child2");
+      assertEquals(flat[0]?.extension.name, "child1");
+      assertEquals(flat[1]?.extension.name, "child2");
     });
 
     it("should recursively flatten nested presets", () => {
@@ -194,7 +194,7 @@ describe("ExtensionLoader", () => {
       const loader = new ExtensionLoader(noopLogger);
       const flat = loader.flattenPresets([makeResolved(outerPreset)]);
       assertEquals(flat.length, 1);
-      assertEquals(flat[0].extension.name, "leaf");
+      assertEquals(flat[0]?.extension.name, "leaf");
     });
 
     it("should keep non-preset extensions as-is", () => {
@@ -202,7 +202,7 @@ describe("ExtensionLoader", () => {
       const loader = new ExtensionLoader(noopLogger);
       const flat = loader.flattenPresets([makeResolved(ext)]);
       assertEquals(flat.length, 1);
-      assertEquals(flat[0].extension.name, "standalone");
+      assertEquals(flat[0]?.extension.name, "standalone");
     });
   });
 });

--- a/src/extensions/loader.test.ts
+++ b/src/extensions/loader.test.ts
@@ -57,6 +57,17 @@ describe("ExtensionLoader", () => {
       assertEquals(sorted[1].extension.name, "beta");
     });
 
+    it("should handle duplicate extension names without false circular error", () => {
+      const ext = makeExt("shared");
+      const loader = new ExtensionLoader(noopLogger);
+      const sorted = loader.topologicalSort([
+        makeResolved(ext),
+        makeResolved(ext),
+      ]);
+      assertEquals(sorted.length, 1);
+      assertEquals(sorted[0].extension.name, "shared");
+    });
+
     it("should throw on circular dependencies", () => {
       const a = makeExt("ext-a", {
         provides: { A: {} },
@@ -173,6 +184,17 @@ describe("ExtensionLoader", () => {
       assertEquals(flat.length, 2);
       assertEquals(flat[0].extension.name, "child1");
       assertEquals(flat[1].extension.name, "child2");
+    });
+
+    it("should recursively flatten nested presets", () => {
+      const leaf = makeExt("leaf");
+      const innerPreset = makeExt("inner-preset", { extends: [leaf] });
+      const outerPreset = makeExt("outer-preset", { extends: [innerPreset] });
+
+      const loader = new ExtensionLoader(noopLogger);
+      const flat = loader.flattenPresets([makeResolved(outerPreset)]);
+      assertEquals(flat.length, 1);
+      assertEquals(flat[0].extension.name, "leaf");
     });
 
     it("should keep non-preset extensions as-is", () => {

--- a/src/extensions/loader.test.ts
+++ b/src/extensions/loader.test.ts
@@ -4,7 +4,7 @@
  * @module extensions/loader.test
  */
 
-import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { ExtensionLoader } from "./loader.ts";
 import { reset } from "./contracts.ts";
@@ -93,6 +93,35 @@ describe("ExtensionLoader", () => {
       const loader = new ExtensionLoader(noopLogger);
       await loader.setupAll([makeResolved(a), makeResolved(b)], {});
       assertEquals(order, ["a", "b"]);
+    });
+
+    it("should teardown previous extensions when called twice", async () => {
+      const order: string[] = [];
+      const ext = makeExt("ext-a", {
+        setup: () => {
+          order.push("setup");
+        },
+        teardown: () => {
+          order.push("teardown");
+        },
+      });
+
+      const loader = new ExtensionLoader(noopLogger);
+      await loader.setupAll([makeResolved(ext)], {});
+      await loader.setupAll([makeResolved(ext)], {});
+      assertEquals(order, ["setup", "teardown", "setup"]);
+    });
+
+    it("should throw on contract conflicts", async () => {
+      const a = makeExt("ext-a", { provides: { Bundler: {} } });
+      const b = makeExt("ext-b", { provides: { Bundler: {} } });
+
+      const loader = new ExtensionLoader(noopLogger);
+      await assertRejects(
+        () => loader.setupAll([makeResolved(a), makeResolved(b)], {}),
+        Error,
+        "Extension conflicts",
+      );
     });
 
     it("should register static provides before calling setup()", async () => {

--- a/src/extensions/loader.ts
+++ b/src/extensions/loader.ts
@@ -4,10 +4,14 @@
  * @module extensions/loader
  */
 
-import { CIRCULAR_DEPENDENCY_ERROR, EXTENSION_VALIDATION_ERROR } from "./errors.ts";
+import {
+  CIRCULAR_DEPENDENCY_ERROR,
+  EXTENSION_CONFLICT_ERROR,
+  EXTENSION_VALIDATION_ERROR,
+} from "./errors.ts";
 import { register, reset, resolve as resolveContract, tryResolve } from "./contracts.ts";
 import { auditCapabilities } from "./capabilities.ts";
-import { validateExtension } from "./validation.ts";
+import { detectConflicts, validateExtension } from "./validation.ts";
 import type { ExtensionContext, ExtensionLogger, ResolvedExtension } from "./types.ts";
 
 export class ExtensionLoader {
@@ -121,13 +125,28 @@ export class ExtensionLoader {
 
   /**
    * Run the full setup lifecycle for all extensions.
+   * If called while extensions are already loaded, tears them down first.
    */
   async setupAll(
     extensions: ResolvedExtension[],
     projectConfig: Record<string, unknown>,
   ): Promise<void> {
+    if (this.setupOrder.length > 0) {
+      await this.teardownAll();
+    }
     reset();
     this.setupOrder = [];
+
+    // Check for contract conflicts before loading
+    const conflicts = detectConflicts(extensions);
+    if (conflicts.length > 0) {
+      const details = conflicts
+        .map((c) => `"${c.contract}" provided by: ${c.providers.map((p) => p.name).join(", ")}`)
+        .join("; ");
+      throw EXTENSION_CONFLICT_ERROR.create({
+        message: `Extension conflicts detected: ${details}`,
+      });
+    }
 
     for (const resolved of extensions) {
       const ext = resolved.extension;

--- a/src/extensions/loader.ts
+++ b/src/extensions/loader.ts
@@ -1,0 +1,183 @@
+/**
+ * Extension loader — topological sort, lifecycle management, preset flattening.
+ *
+ * @module extensions/loader
+ */
+
+import { CIRCULAR_DEPENDENCY_ERROR, EXTENSION_VALIDATION_ERROR } from "./errors.ts";
+import { register, reset, resolve as resolveContract, tryResolve } from "./contracts.ts";
+import { auditCapabilities } from "./capabilities.ts";
+import { validateExtension } from "./validation.ts";
+import type { ExtensionContext, ExtensionLogger, ResolvedExtension } from "./types.ts";
+
+export class ExtensionLoader {
+  private logger: ExtensionLogger;
+  private setupOrder: ResolvedExtension[] = [];
+
+  constructor(logger: ExtensionLogger) {
+    this.logger = logger;
+  }
+
+  /**
+   * Flatten presets: extensions with `extends` are replaced by their children.
+   */
+  flattenPresets(extensions: ResolvedExtension[]): ResolvedExtension[] {
+    const result: ResolvedExtension[] = [];
+
+    for (const resolved of extensions) {
+      const ext = resolved.extension;
+      if (ext.extends && ext.extends.length > 0) {
+        for (const child of ext.extends) {
+          result.push({ extension: child, source: resolved.source, origin: resolved.origin });
+        }
+      } else {
+        result.push(resolved);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Topological sort: providers load before consumers.
+   * Throws on circular dependencies.
+   */
+  topologicalSort(extensions: ResolvedExtension[]): ResolvedExtension[] {
+    const providerOf = new Map<string, string>();
+    const extByName = new Map<string, ResolvedExtension>();
+    const consumesContracts = new Map<string, string[]>();
+
+    for (const resolved of extensions) {
+      const ext = resolved.extension;
+      extByName.set(ext.name, resolved);
+
+      if (ext.provides) {
+        for (const contract of Object.keys(ext.provides)) {
+          providerOf.set(contract, ext.name);
+        }
+      }
+
+      const contracts = ext.capabilities
+        .filter((c) => c.type === "contract")
+        .map((c) => c.name as string);
+      if (contracts.length > 0) {
+        consumesContracts.set(ext.name, contracts);
+      }
+    }
+
+    // Build adjacency list
+    const graph = new Map<string, Set<string>>();
+    const inDegree = new Map<string, number>();
+
+    for (const resolved of extensions) {
+      const name = resolved.extension.name;
+      if (!graph.has(name)) graph.set(name, new Set());
+      if (!inDegree.has(name)) inDegree.set(name, 0);
+    }
+
+    for (const [consumer, contracts] of consumesContracts) {
+      for (const contract of contracts) {
+        const provider = providerOf.get(contract);
+        if (provider && provider !== consumer) {
+          const edges = graph.get(provider)!;
+          if (!edges.has(consumer)) {
+            edges.add(consumer);
+            inDegree.set(consumer, (inDegree.get(consumer) || 0) + 1);
+          }
+        }
+      }
+    }
+
+    // Kahn's algorithm
+    const queue: string[] = [];
+    for (const [name, degree] of inDegree) {
+      if (degree === 0) queue.push(name);
+    }
+
+    const sorted: ResolvedExtension[] = [];
+
+    while (queue.length > 0) {
+      const name = queue.shift()!;
+      sorted.push(extByName.get(name)!);
+
+      for (const dependent of graph.get(name) || []) {
+        const newDegree = (inDegree.get(dependent) || 1) - 1;
+        inDegree.set(dependent, newDegree);
+        if (newDegree === 0) queue.push(dependent);
+      }
+    }
+
+    if (sorted.length !== extensions.length) {
+      const unsorted = extensions
+        .filter((r) => !sorted.includes(r))
+        .map((r) => r.extension.name);
+      throw CIRCULAR_DEPENDENCY_ERROR.create({
+        message: `Circular extension dependency detected among: ${unsorted.join(", ")}`,
+      });
+    }
+
+    return sorted;
+  }
+
+  /**
+   * Run the full setup lifecycle for all extensions.
+   */
+  async setupAll(
+    extensions: ResolvedExtension[],
+    projectConfig: Record<string, unknown>,
+  ): Promise<void> {
+    reset();
+    this.setupOrder = [];
+
+    for (const resolved of extensions) {
+      const ext = resolved.extension;
+
+      const issues = validateExtension(ext);
+      if (issues.length > 0) {
+        throw EXTENSION_VALIDATION_ERROR.create({
+          message: `Extension "${ext.name}" is invalid:\n  ${issues.join("\n  ")}`,
+        });
+      }
+
+      auditCapabilities(ext.name, ext.capabilities, this.logger);
+
+      if (ext.provides) {
+        for (const [contract, impl] of Object.entries(ext.provides)) {
+          register(contract, impl);
+        }
+      }
+
+      if (ext.setup) {
+        const ctx: ExtensionContext = {
+          get: <T>(contract: string) => tryResolve<T>(contract),
+          require: <T>(contract: string) => resolveContract<T>(contract),
+          provide: <T>(contract: string, impl: T) => register(contract, impl),
+          config: projectConfig,
+          logger: this.logger,
+        };
+        await ext.setup(ctx);
+      }
+
+      this.setupOrder.push(resolved);
+      this.logger.info(`Extension "${ext.name}" v${ext.version} loaded from ${resolved.source}`);
+    }
+  }
+
+  /**
+   * Teardown all loaded extensions in reverse order.
+   */
+  async teardownAll(): Promise<void> {
+    const reversed = [...this.setupOrder].reverse();
+    for (const resolved of reversed) {
+      if (resolved.extension.teardown) {
+        try {
+          await resolved.extension.teardown();
+        } catch (err) {
+          this.logger.error(`Error tearing down "${resolved.extension.name}":`, err);
+        }
+      }
+    }
+    this.setupOrder = [];
+    reset();
+  }
+}

--- a/src/extensions/loader.ts
+++ b/src/extensions/loader.ts
@@ -11,8 +11,8 @@ import {
 } from "./errors.ts";
 import { register, reset, resolve as resolveContract, tryResolve } from "./contracts.ts";
 import { auditCapabilities } from "./capabilities.ts";
-import { detectConflicts, validateExtension } from "./validation.ts";
-import type { ExtensionContext, ExtensionLogger, ResolvedExtension } from "./types.ts";
+import { detectConflicts, selectContractProviders, validateExtension } from "./validation.ts";
+import type { Extension, ExtensionContext, ExtensionLogger, ResolvedExtension } from "./types.ts";
 
 export class ExtensionLoader {
   private logger: ExtensionLogger;
@@ -24,20 +24,35 @@ export class ExtensionLoader {
 
   /**
    * Flatten presets: extensions with `extends` are replaced by their children.
+   * Recurses through nested presets; throws on cyclic `extends` graphs rather
+   * than stack-overflowing.
    */
   flattenPresets(extensions: ResolvedExtension[]): ResolvedExtension[] {
+    return this.flattenPresetsInner(extensions, new Set());
+  }
+
+  private flattenPresetsInner(
+    extensions: ResolvedExtension[],
+    path: Set<Extension>,
+  ): ResolvedExtension[] {
     const result: ResolvedExtension[] = [];
 
     for (const resolved of extensions) {
       const ext = resolved.extension;
       if (ext.extends && ext.extends.length > 0) {
+        if (path.has(ext)) {
+          throw EXTENSION_VALIDATION_ERROR.create({
+            message: `Circular preset extends chain detected via "${ext.name}"`,
+          });
+        }
+        path.add(ext);
         const children = ext.extends.map((child) => ({
           extension: child,
           source: resolved.source,
           origin: resolved.origin,
         }));
-        // Recursively flatten in case children are also presets
-        result.push(...this.flattenPresets(children));
+        result.push(...this.flattenPresetsInner(children, path));
+        path.delete(ext);
       } else {
         result.push(resolved);
       }
@@ -150,6 +165,12 @@ export class ExtensionLoader {
       });
     }
 
+    // Precompute the priority winner per contract so that a lower-priority
+    // provider later in the iteration order cannot overwrite the winning impl
+    // via register(). Without this, merged inputs (config -> package ->
+    // project -> local-file) silently invert the documented source priority.
+    const contractWinner = selectContractProviders(extensions);
+
     for (const resolved of extensions) {
       const ext = resolved.extension;
 
@@ -164,7 +185,9 @@ export class ExtensionLoader {
 
       if (ext.provides) {
         for (const [contract, impl] of Object.entries(ext.provides)) {
-          register(contract, impl);
+          if (contractWinner.get(contract) === resolved) {
+            register(contract, impl);
+          }
         }
       }
 
@@ -176,7 +199,25 @@ export class ExtensionLoader {
           config: projectConfig,
           logger: this.logger,
         };
-        await ext.setup(ctx);
+        try {
+          await ext.setup(ctx);
+        } catch (err) {
+          // Best-effort teardown of the partially-initialized extension so
+          // any resources it opened before throwing get a chance to close.
+          if (ext.teardown) {
+            try {
+              await ext.teardown();
+            } catch (teardownErr) {
+              this.logger.error(
+                `Error during rollback teardown of "${ext.name}":`,
+                teardownErr,
+              );
+            }
+          }
+          // Roll back everything loaded so far and clear the registry.
+          await this.teardownAll();
+          throw err;
+        }
       }
 
       this.setupOrder.push(resolved);

--- a/src/extensions/loader.ts
+++ b/src/extensions/loader.ts
@@ -31,9 +31,13 @@ export class ExtensionLoader {
     for (const resolved of extensions) {
       const ext = resolved.extension;
       if (ext.extends && ext.extends.length > 0) {
-        for (const child of ext.extends) {
-          result.push({ extension: child, source: resolved.source, origin: resolved.origin });
-        }
+        const children = ext.extends.map((child) => ({
+          extension: child,
+          source: resolved.source,
+          origin: resolved.origin,
+        }));
+        // Recursively flatten in case children are also presets
+        result.push(...this.flattenPresets(children));
       } else {
         result.push(resolved);
       }
@@ -111,8 +115,8 @@ export class ExtensionLoader {
       }
     }
 
-    if (sorted.length !== extensions.length) {
-      const unsorted = extensions
+    if (sorted.length !== extByName.size) {
+      const unsorted = [...extByName.values()]
         .filter((r) => !sorted.includes(r))
         .map((r) => r.extension.name);
       throw CIRCULAR_DEPENDENCY_ERROR.create({

--- a/src/extensions/loader.ts
+++ b/src/extensions/loader.ts
@@ -135,11 +135,9 @@ export class ExtensionLoader {
     extensions: ResolvedExtension[],
     projectConfig: Record<string, unknown>,
   ): Promise<void> {
-    if (this.setupOrder.length > 0) {
-      await this.teardownAll();
-    }
-    reset();
-    this.setupOrder = [];
+    // Idempotent: teardownAll clears setupOrder and resets the contract
+    // registry even when nothing is loaded yet.
+    await this.teardownAll();
 
     // Check for contract conflicts before loading
     const conflicts = detectConflicts(extensions);

--- a/src/extensions/validation.ts
+++ b/src/extensions/validation.ts
@@ -18,12 +18,38 @@ export interface ConflictInfo {
  * Priority map for extension sources.
  * Lower number = higher priority.
  */
-const SOURCE_PRIORITY: Record<ExtensionSource, number> = {
+export const SOURCE_PRIORITY: Record<ExtensionSource, number> = {
   config: 0,
   package: 1,
   project: 2,
   "local-file": 3,
 };
+
+/**
+ * Select the highest-priority provider for each contract across a list of
+ * resolved extensions. When multiple extensions provide the same contract,
+ * the one whose source has the lowest `SOURCE_PRIORITY` number wins.
+ * Ties break on first-seen order (mirrors detectConflicts semantics).
+ */
+export function selectContractProviders(
+  extensions: ResolvedExtension[],
+): Map<string, ResolvedExtension> {
+  const winner = new Map<string, ResolvedExtension>();
+  for (const resolved of extensions) {
+    const provides = resolved.extension.provides;
+    if (!provides) continue;
+    for (const contract of Object.keys(provides)) {
+      const current = winner.get(contract);
+      if (
+        !current ||
+        SOURCE_PRIORITY[resolved.source] < SOURCE_PRIORITY[current.source]
+      ) {
+        winner.set(contract, resolved);
+      }
+    }
+  }
+  return winner;
+}
 
 /**
  * Validate the shape of an extension object.


### PR DESCRIPTION
## Summary
- `ExtensionLoader.flattenPresets()` — recursively expand preset `extends` arrays (supports nested presets); cycle-guarded so malformed graphs raise a controlled error instead of stack-overflowing
- `ExtensionLoader.topologicalSort()` — Kahn's algorithm, contract dependency ordering, tolerant of duplicate extension names
- `ExtensionLoader.setupAll()` — validate, audit, register provides, call setup(); idempotent (auto-teardown on re-entry); rolls back on setup failure; honors source-priority at `register()` time
- `ExtensionLoader.teardownAll()` — reverse-order teardown with error isolation

## Review feedback addressed
- **P1 (topo sort dedup)**: cycle detection now compares against the set of unique extension names rather than the input array length, so duplicate entries with the same name no longer trigger false `CIRCULAR_DEPENDENCY_ERROR`.
- **P2 (recursive preset flattening)**: a preset whose children are themselves presets now resolves down to leaf extensions in one call.
- **P1 (source priority on `register()`)**: `selectContractProviders()` helper in `validation.ts` returns the priority-winning `ResolvedExtension` per contract; `setupAll()` gates static `register()` calls on that map, so a lower-priority extension later in iteration order no longer overwrites a higher-priority winner.
- **P1 (rollback on setup failure)**: `ext.setup()` wrapped in try/catch; on throw, best-effort teardown of the failing extension (error-isolated), then `teardownAll()` unwinds prior extensions and resets the registry, then rethrows. Previously-loaded extensions no longer leak on mid-setup failures.
- **P2 (preset cycle guard)**: `flattenPresetsInner()` threads a DFS path-set through recursion and raises `EXTENSION_VALIDATION_ERROR` on a back edge. A diamond (shared leaf reachable via two parents) is still accepted — the set tracks path membership, not global visits.
- **Simplification**: removed redundant `reset()` / `setupOrder = []` after `teardownAll()` — teardown is already idempotent and handles both clears.

## Test plan
- [x] 27 loader test steps: `deno task test src/extensions/loader.test.ts`
- [x] Full extensions suite (10 files, 101 steps): `deno task test src/extensions/`
- [x] `deno check` clean under `noUncheckedIndexedAccess` on `loader.ts`, `validation.ts`, `loader.test.ts`
- [x] Pre-push suite: 1359 tests pass
- [x] `/simplify`, `/review`, `/security-review` clean — no issues flagged at threshold

Closes #1017