### PR TITLE
Preserve ToolCallResult input in AG-UI replay fallback

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           warm-cache: "true"
       - name: Install Chromium
-        run: deno run -A npm:playwright install --with-deps chromium
+        run: deno run -A npm:playwright install chromium
       - uses: nick-fields/retry@v4.0.0
         with:
           timeout_minutes: 10
@@ -92,7 +92,7 @@ jobs:
         with:
           warm-cache: "true"
       - name: Install Chromium
-        run: deno run -A npm:playwright install --with-deps chromium
+        run: deno run -A npm:playwright install chromium
       - uses: nick-fields/retry@v4.0.0
         with:
           timeout_minutes: 15

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -69,8 +69,10 @@ jobs:
       - uses: ./.github/actions/setup-deno
         with:
           warm-cache: "true"
+      - name: Force apt to IPv4
+        run: echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
       - name: Install Chromium
-        run: deno run -A npm:playwright install chromium
+        run: deno run -A npm:playwright install --with-deps chromium
       - uses: nick-fields/retry@v4.0.0
         with:
           timeout_minutes: 10
@@ -91,8 +93,10 @@ jobs:
       - uses: ./.github/actions/setup-deno
         with:
           warm-cache: "true"
+      - name: Force apt to IPv4
+        run: echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
       - name: Install Chromium
-        run: deno run -A npm:playwright install chromium
+        run: deno run -A npm:playwright install --with-deps chromium
       - uses: nick-fields/retry@v4.0.0
         with:
           timeout_minutes: 15

--- a/src/chat/ag-ui.test.ts
+++ b/src/chat/ag-ui.test.ts
@@ -291,6 +291,40 @@ describe("chat/ag-ui", () => {
     ]);
   });
 
+  it("preserves ToolCallResult input when the result arrives without a prior tool start", () => {
+    const state = createAgUiChatEventDecoderState();
+    const result = decodeAgUiSseChunk(
+      state,
+      [
+        "event: ToolCallResult",
+        'data: {"toolCallId":"tool-1","input":{"path":"report.md","content":"hello"},"result":{"success":true}}',
+        "",
+        "",
+      ].join("\n"),
+    );
+
+    const chatEvents = result.events.flatMap((entry) => entry.chatEvents);
+    assertEquals(chatEvents, [
+      {
+        type: "tool-input-available",
+        toolCallId: "tool-1",
+        toolName: "tool",
+        input: {
+          path: "report.md",
+          content: "hello",
+        },
+        dynamic: true,
+        providerExecuted: true,
+      },
+      {
+        type: "tool-output-available",
+        toolCallId: "tool-1",
+        output: { success: true },
+        providerExecuted: true,
+      },
+    ]);
+  });
+
   it("retains decoded wire events alongside canonical chat events", () => {
     const state = createAgUiChatEventDecoderState();
     const result = decodeAgUiSseChunk(

--- a/src/chat/ag-ui.ts
+++ b/src/chat/ag-ui.ts
@@ -213,6 +213,7 @@ export const AgUiWireEventSchema = z.discriminatedUnion("eventName", [
     payload: z.object({
       messageId: z.string().min(1).optional(),
       toolCallId: z.string().min(1),
+      input: z.unknown().optional(),
       content: z.unknown().optional(),
       result: z.unknown().optional(),
       role: z.literal("tool").optional(),
@@ -607,7 +608,7 @@ function mapWireEventToChatEvents(
           type: "tool-input-available",
           toolCallId: wireEvent.payload.toolCallId,
           toolName: "tool",
-          input: {},
+          input: wireEvent.payload.input ?? {},
           dynamic: true,
           providerExecuted: true,
         });


### PR DESCRIPTION
## Summary
- preserve `ToolCallResult.input` when AG-UI replay attaches after prior tool events were missed
- use result-level input only as a fallback when the decoder has no earlier tool-call state
- add a regression test for the replay-missed-tool-start case

## Problem
The shared AG-UI decoder synthesized `{}` for tool input when a `ToolCallResult` arrived without a prior `ToolCallStart` / `ToolCallArgs` sequence, even if the result payload already contained the original `input`. That dropped replay fidelity for reconnect and snapshot-restore flows.

## Testing
- `deno test src/chat/ag-ui.test.ts`
- `deno check src/chat/ag-ui.ts`
