### PR TITLE
Preserve streamed tool input in canonical runtime messages

### DIFF
--- a/src/agent/runtime/index.test.ts
+++ b/src/agent/runtime/index.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  captureStreamedToolCallInput,
   collectFinalStreamToolResults,
   collectGeneratedToolResults,
   collectPersistedToolResults,
@@ -110,5 +111,25 @@ describe("agent runtime streamed tool result collection", () => {
 
     assertEquals(generatedToolResults.size, 1);
     assertEquals(generatedToolResults.get("tool-4")?.result, { ok: true });
+  });
+
+  it("preserves raw streamed tool input text when parsing fails", () => {
+    const captured = captureStreamedToolCallInput({
+      arguments: '{"query":"AI ontologies research"',
+    });
+
+    assertEquals(captured.args, {});
+    assertEquals(captured.inputText, '{"query":"AI ontologies research"');
+    assertEquals(typeof captured.parseError, "string");
+  });
+
+  it("preserves raw streamed tool input text when parsing succeeds", () => {
+    const captured = captureStreamedToolCallInput({
+      arguments: '{"query":"AI ontologies research"}',
+    });
+
+    assertEquals(captured.args, { query: "AI ontologies research" });
+    assertEquals(captured.inputText, '{"query":"AI ontologies research"}');
+    assertEquals(captured.parseError, undefined);
   });
 });

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -40,6 +40,7 @@ import {
   type ChatStreamState,
   createStreamState,
   processStream,
+  type StreamingToolCall,
   type StreamingToolResult,
 } from "./chat-stream-handler.ts";
 import { repairToolCall } from "./repair-tool-call.ts";
@@ -180,6 +181,21 @@ export function collectGeneratedToolResults(
   }
 
   return generatedToolResults;
+}
+
+export function captureStreamedToolCallInput(
+  toolCall: Pick<StreamingToolCall, "arguments">,
+): {
+  args: Record<string, unknown>;
+  inputText?: string;
+  parseError?: string;
+} {
+  const { args, error } = parseToolArgs(toolCall.arguments);
+  return {
+    args,
+    ...(toolCall.arguments.length > 0 ? { inputText: toolCall.arguments } : {}),
+    ...(error ? { parseError: error } : {}),
+  };
 }
 
 function isToolResultPart(part: MessagePart): part is ToolResultPart {
@@ -945,18 +961,19 @@ export class AgentRuntime {
       if (state.accumulatedText) streamParts.push({ type: "text", text: state.accumulatedText });
 
       for (const tc of state.toolCalls.values()) {
-        const { args, error } = parseToolArgs(tc.arguments);
-        if (error) {
+        const capturedInput = captureStreamedToolCallInput(tc);
+        if (capturedInput.parseError) {
           logger.warn("Failed to parse streamed tool arguments", {
             toolCallId: tc.id,
-            error,
+            error: capturedInput.parseError,
           });
         }
         streamParts.push({
           type: `tool-${tc.name}`,
           toolCallId: tc.id,
           toolName: tc.name,
-          args,
+          args: capturedInput.args,
+          ...(capturedInput.inputText ? { inputText: capturedInput.inputText } : {}),
         });
       }
 
@@ -1016,8 +1033,14 @@ export class AgentRuntime {
 
       for (const tc of streamedToolCalls) {
         throwIfAborted(abortSignal);
-        const { args, error: argError } = parseToolArgs(tc.arguments);
-        const toolCall: ToolCall = { id: tc.id, name: tc.name, args, status: "pending" };
+        const capturedInput = captureStreamedToolCallInput(tc);
+        const toolCall: ToolCall = {
+          id: tc.id,
+          name: tc.name,
+          args: capturedInput.args,
+          ...(capturedInput.inputText ? { inputText: capturedInput.inputText } : {}),
+          status: "pending",
+        };
         const matchingResult = finalToolResults.get(tc.id);
         const persistedResult = currentStepToolResults.get(tc.id);
 
@@ -1041,23 +1064,23 @@ export class AgentRuntime {
           continue;
         }
 
-        if (argError) {
+        if (capturedInput.parseError) {
           logger.warn("Invalid streamed tool arguments", {
             toolCallId: tc.id,
-            error: argError,
+            error: capturedInput.parseError,
           });
 
           const dynamic = isDynamicTool(tc.name);
           sendSSE(controller, encoder, {
             type: "tool-input-error",
             toolCallId: tc.id,
-            errorText: `Invalid tool arguments: ${argError}`,
+            errorText: `Invalid tool arguments: ${capturedInput.parseError}`,
             ...(dynamic ? { dynamic: true } : {}),
           });
 
           await this.recordToolError(
             toolCall,
-            `Invalid tool arguments: ${argError}`,
+            `Invalid tool arguments: ${capturedInput.parseError}`,
             controller,
             encoder,
             currentMessages,

--- a/src/agent/schemas/agent.schema.test.ts
+++ b/src/agent/schemas/agent.schema.test.ts
@@ -385,6 +385,7 @@ describe("agent/schema", () => {
         id: "tool-2",
         name: "calculator",
         args: { x: 5, y: 3 },
+        inputText: '{"x":5,"y":3}',
         status: "completed",
         result: 8,
       });
@@ -461,6 +462,7 @@ describe("agent/schema", () => {
                 toolCallId: "call-1",
                 toolName: "calculator",
                 args: { x: 10, y: 5 },
+                inputText: '{"x":10,"y":5}',
               },
             ],
           },
@@ -470,6 +472,7 @@ describe("agent/schema", () => {
             id: "call-1",
             name: "calculator",
             args: { x: 10, y: 5 },
+            inputText: '{"x":10,"y":5}',
             status: "completed",
             result: 15,
             executionTime: 50,

--- a/src/agent/schemas/agent.schema.ts
+++ b/src/agent/schemas/agent.schema.ts
@@ -29,6 +29,7 @@ export const ToolCallPartWithArgsSchema = z.object({
   toolCallId: z.string(),
   toolName: z.string(),
   args: z.record(z.string(), z.unknown()),
+  inputText: z.string().optional(),
 });
 
 export const ToolCallPartWithInputSchema = z.object({
@@ -36,6 +37,7 @@ export const ToolCallPartWithInputSchema = z.object({
   toolCallId: z.string(),
   toolName: z.string(),
   input: z.record(z.string(), z.unknown()),
+  inputText: z.string().optional(),
 });
 
 export const ToolCallPartSchema = z.union([
@@ -83,6 +85,7 @@ export const ToolCallSchema = z.object({
   id: z.string(),
   name: z.string(),
   args: z.record(z.string(), z.unknown()),
+  inputText: z.string().optional(),
   status: z.enum(["pending", "executing", "completed", "error"]),
   result: z.unknown().optional(),
   error: z.string().optional(),


### PR DESCRIPTION
## Summary
- preserve raw streamed tool input on canonical tool-call messages as 
- keep parsed  for execution while retaining the original streamed bytes for parity/debugging
- lock the behavior with runtime and schema regression tests

## Verification
- deno test --no-check --allow-all src/agent/runtime/index.test.ts src/agent/schemas/agent.schema.test.ts
- deno check src/agent/runtime/index.ts
- deno check src/agent/schemas/agent.schema.ts