### PR TITLE
Close text before orphan tool-input deltas reach AG-UI

### DIFF
--- a/src/agent/ag-ui-browser-encoder.test.ts
+++ b/src/agent/ag-ui-browser-encoder.test.ts
@@ -203,6 +203,67 @@ describe("agent/ag-ui-browser-encoder", () => {
     );
   });
 
+  it("closes open reasoning before orphan tool-input-delta is forwarded", () => {
+    const state = createAgUiBrowserEncoderState();
+
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "message-start",
+        messageId: "assistant-orphan-reasoning",
+      }),
+      [],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "reasoning-start",
+        id: "reasoning-orphan",
+      }),
+      [{
+        event: "ReasoningMessageStart",
+        payload: {
+          messageId: "assistant-orphan-reasoning:reasoning:reasoning-orphan",
+          role: "reasoning",
+        },
+      }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "reasoning-delta",
+        id: "reasoning-orphan",
+        delta: "I should gather one more source before calling the tool.",
+      }),
+      [{
+        event: "ReasoningMessageContent",
+        payload: {
+          messageId: "assistant-orphan-reasoning:reasoning:reasoning-orphan",
+          delta: "I should gather one more source before calling the tool.",
+        },
+      }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "tool-input-delta",
+        toolCallId: "tool-orphan-reasoning",
+        inputTextDelta: '{"query":"ai ontologies"}',
+      }),
+      [
+        {
+          event: "ReasoningMessageEnd",
+          payload: {
+            messageId: "assistant-orphan-reasoning:reasoning:reasoning-orphan",
+          },
+        },
+        {
+          event: "ToolCallArgs",
+          payload: {
+            toolCallId: "tool-orphan-reasoning",
+            delta: '{"query":"ai ontologies"}',
+          },
+        },
+      ],
+    );
+  });
+
   it("closes reasoning when non-reasoning events interrupt it", () => {
     const state = createAgUiBrowserEncoderState();
 

--- a/src/agent/ag-ui-browser-encoder.test.ts
+++ b/src/agent/ag-ui-browser-encoder.test.ts
@@ -155,6 +155,54 @@ describe("agent/ag-ui-browser-encoder", () => {
     );
   });
 
+  it("closes open text before orphan tool-input-delta is forwarded", () => {
+    const state = createAgUiBrowserEncoderState();
+
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "message-start",
+        messageId: "assistant-orphan",
+      }),
+      [],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "text-delta",
+        delta: "Now I have enough material to write the file.",
+      }),
+      [
+        {
+          event: "TextMessageStart",
+          payload: { messageId: "assistant-orphan", role: "assistant" },
+        },
+        {
+          event: "TextMessageContent",
+          payload: {
+            messageId: "assistant-orphan",
+            delta: "Now I have enough material to write the file.",
+          },
+        },
+      ],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "tool-input-delta",
+        toolCallId: "tool-orphan",
+        inputTextDelta: '{"path":"research/ai-ontologies.md"',
+      }),
+      [
+        {
+          event: "TextMessageEnd",
+          payload: { messageId: "assistant-orphan" },
+        },
+        {
+          event: "ToolCallArgs",
+          payload: { toolCallId: "tool-orphan", delta: '{"path":"research/ai-ontologies.md"' },
+        },
+      ],
+    );
+  });
+
   it("closes reasoning when non-reasoning events interrupt it", () => {
     const state = createAgUiBrowserEncoderState();
 

--- a/src/agent/ag-ui-browser-encoder.ts
+++ b/src/agent/ag-ui-browser-encoder.ts
@@ -360,13 +360,17 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
       if (typeof event.toolCallId === "string") {
         state.streamedToolInputIds.add(event.toolCallId);
       }
-      return [{
-        event: "ToolCallArgs",
-        payload: {
-          toolCallId: event.toolCallId,
-          delta: typeof event.inputTextDelta === "string" ? event.inputTextDelta : "",
+      return [
+        ...closeOpenTextEvent(state),
+        ...closeOpenReasoningEvent(state),
+        {
+          event: "ToolCallArgs",
+          payload: {
+            toolCallId: event.toolCallId,
+            delta: typeof event.inputTextDelta === "string" ? event.inputTextDelta : "",
+          },
         },
-      }];
+      ];
 
     case "tool-input-available": {
       state.sawVisibleOutput = true;


### PR DESCRIPTION
## Summary
Close open assistant text segments before forwarding orphan `tool-input-delta` chunks as AG-UI `ToolCallArgs`.

## Problem
In staging, delegated child runs could emit:
- `TEXT_MESSAGE_START`
- `TEXT_MESSAGE_CONTENT`
- raw tool arg chunks for a local `create_file` draft

without an intervening `TEXT_MESSAGE_END`.

That happened specifically when a local tool draft only produced `tool-input-delta` and never materialized into a fuller lifecycle event before the browser encoder forwarded it.

## Reference
As a reference point, the AI SDK's UI message stream handling expects tool-input deltas to belong to an established tool lifecycle and treats tool activity as a hard boundary for text segments. This PR adopts the minimal boundary lesson without changing Veryfront's broader stream semantics.

## Solution
Keep the change minimal in `ag-ui-browser-encoder`:
- when `tool-input-delta` is received, close any open text segment first
- also close any open reasoning segment first
- then forward the `ToolCallArgs`

This preserves the visible assistant/tool boundary even for orphan tool-input drafts.

## Reduced Repro
Added a local reduced test for the exact shape:
- start assistant text
- emit orphan `tool-input-delta` with no prior `tool-input-start`
- assert `TextMessageEnd` is emitted before `ToolCallArgs`

## Verification
- `deno test --no-check --allow-all src/agent/ag-ui-browser-encoder.test.ts src/internal-agents/ag-ui-sse.test.ts`
- `deno check src/agent/ag-ui-browser-encoder.ts src/agent/ag-ui-browser-encoder.test.ts src/internal-agents/ag-ui-sse.ts`
- `deno fmt --check src/agent/ag-ui-browser-encoder.ts src/agent/ag-ui-browser-encoder.test.ts`
