### PR TITLE
Unwrap runtime tool schemas before sending provider tool definitions

### DIFF
--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createAnthropicModelRuntime } from "./runtime-loader.ts";
+import { createRuntimeJsonSchema } from "../agent/runtime/runtime-tool-builder.ts";
 import {
   createGoogleEmbeddingRuntime,
   createGoogleModelRuntime,
@@ -568,6 +569,74 @@ describe("provider/runtime-loader", () => {
         totalTokens: 10,
       },
     });
+  });
+
+  it("unwraps runtime tool schemas before sending Anthropic tool definitions", async () => {
+    let requestedInit: RequestInit | undefined;
+
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: (_input, init) => {
+        requestedInit = init;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: [],
+              stop_reason: "end_turn",
+              usage: {
+                input_tokens: 8,
+                output_tokens: 2,
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        );
+      },
+    }, "claude-sonnet-4-20250514");
+
+    await runtime.doGenerate({
+      prompt: [{
+        role: "user",
+        content: [{ type: "text", text: "Write a file" }],
+      }],
+      tools: [{
+        type: "function",
+        name: "create_file",
+        description: "Create a project file",
+        inputSchema: createRuntimeJsonSchema({
+          type: "object",
+          properties: {
+            project_reference: { type: "string" },
+            path: { type: "string" },
+            content: { type: "string" },
+          },
+          required: ["project_reference", "path", "content"],
+          additionalProperties: false,
+        }),
+      }],
+      toolChoice: "auto",
+      maxOutputTokens: 64,
+    });
+
+    const requestBody = typeof requestedInit?.body === "string"
+      ? JSON.parse(requestedInit.body)
+      : undefined;
+
+    assertEquals(requestBody?.tools, [{
+      name: "create_file",
+      description: "Create a project file",
+      input_schema: {
+        type: "object",
+        properties: {
+          project_reference: { type: "string" },
+          path: { type: "string" },
+          content: { type: "string" },
+        },
+        required: ["project_reference", "path", "content"],
+        additionalProperties: false,
+      },
+    }]);
   });
 
   it("merges tool-result replay with consecutive user retries into one Anthropic user message", async () => {

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -412,7 +412,7 @@ function toOpenAICompatibleTools(
         type: "function" as const,
         function: {
           name: tool.name,
-          parameters: tool.inputSchema,
+          parameters: unwrapToolInputSchema(tool.inputSchema),
           ...(typeof tool.description === "string" ? { description: tool.description } : {}),
         },
       }]
@@ -623,7 +623,7 @@ function toAnthropicTools(
       normalized.push({
         name: tool.name,
         ...(typeof tool.description === "string" ? { description: tool.description } : {}),
-        input_schema: tool.inputSchema,
+        input_schema: unwrapToolInputSchema(tool.inputSchema),
       });
       continue;
     }
@@ -1257,12 +1257,21 @@ function toGoogleTools(
       ? [{
         name: tool.name,
         ...(typeof tool.description === "string" ? { description: tool.description } : {}),
-        parameters: tool.inputSchema,
+        parameters: unwrapToolInputSchema(tool.inputSchema),
       }]
       : []
   );
 
   return functionDeclarations.length > 0 ? [{ functionDeclarations }] : undefined;
+}
+
+function unwrapToolInputSchema(inputSchema: unknown): unknown {
+  if (typeof inputSchema !== "object" || inputSchema === null || Array.isArray(inputSchema)) {
+    return inputSchema;
+  }
+
+  const candidate = Reflect.get(inputSchema, "jsonSchema");
+  return candidate ?? inputSchema;
 }
 
 function normalizeGoogleToolChoice(toolChoice: unknown):


### PR DESCRIPTION
## Summary
Unwrap `RuntimeJsonSchema` wrappers before sending function tool definitions to providers.

## Problem
The provider request builders in `runtime-loader.ts` were serializing `tool.inputSchema` directly for function tools.

For runtime-defined tools, `tool.inputSchema` is a wrapper object:

```ts
{ jsonSchema: <actual schema> }
```

So providers could receive:

```json
{"input_schema":{"jsonSchema":{...}}}
```

instead of the actual JSON schema object.

That is a strong root-cause candidate for the abandoned local `create_file` drafts seen in staging delegated child runs.

## Reduced Repro
Added a focused Anthropic request-body test that passes a wrapped runtime schema and asserts the outbound request contains the unwrapped JSON schema.

## Solution
Add a tiny helper that unwraps `.jsonSchema` when present and use it for function-tool request serialization in:
- OpenAI tool conversion
- Anthropic tool conversion
- Google tool conversion

## Verification
- `deno test --no-check --allow-all src/provider/runtime-loader.test.ts`
- `deno check src/provider/runtime-loader.ts src/provider/runtime-loader.test.ts`

## Related
- `veryfront-code#1040`
- `veryfront-agent#391`
