### PR TITLE
Bump veryfront-code to 0.1.203

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.202",
+  "version": "0.1.203",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.202";
+export const VERSION = "0.1.203";


### PR DESCRIPTION
## Summary
Bump `veryfront-code` from `0.1.202` to `0.1.203`.

## Scope
Minimal patch-version bump only:
- `deno.json`
- `src/utils/version-constant.ts`

## Rationale
Keep the canonical version sources aligned for the next patch release. This matches the repo's release tooling contract.

## Verification
- confirmed `deno.json` and `src/utils/version-constant.ts` both read `0.1.203`
