### PR TITLE
fix: return 404 when custom-domain token mint reports missing project

### DIFF
--- a/cli/commands/knowledge/command.ts
+++ b/cli/commands/knowledge/command.ts
@@ -1,8 +1,7 @@
 import { z } from "zod";
 type SafeParseResult<T> = { success: true; data: T } | { success: false; error: z.ZodError };
-import { createFileSystem, getEnv } from "veryfront/platform";
+import { type CommandResult, createFileSystem, getEnv, runCommand } from "veryfront/platform";
 import { basename, extname, join, normalize, relative } from "veryfront/platform/path";
-import { type CommandResult, runCommand } from "#veryfront/platform/compat/process.ts";
 import { withSpan } from "veryfront/observability/otlp-setup";
 import { cliLogger } from "#cli/utils";
 import { type ApiClient, createApiClient, resolveConfigWithAuth } from "#cli/shared/config";

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -14,6 +14,7 @@ export type { RuntimeAdapter } from "./adapters/base.ts";
 // Compat: process
 export {
   chdir,
+  type CommandResult,
   cwd,
   env,
   exit,

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -184,6 +184,46 @@ describe("Proxy Handler", () => {
       await handler.close();
     });
 
+    // Regression test for the ai-chatbot.veryfront.com incident (#1054): bare
+    // {slug}.veryfront.com is intentionally unsupported, so the handler treats it as a
+    // custom domain, the token mint returns "Project not found for domain", and the
+    // user previously saw a misleading 502. Must resolve to a clean 404.
+    it("returns 404 when custom domain token mint reports no project for domain", async () => {
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") {
+          return new Response('{"error":"Project not found for domain"}', {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+
+        const req = new Request("http://ai-chatbot.veryfront.com/robots.txt", {
+          headers: { host: "ai-chatbot.veryfront.com" },
+        });
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.projectSlug, undefined);
+        assertEquals(ctx.error?.status, 404);
+        assertEquals(
+          ctx.error?.message,
+          "No project configured for domain: ai-chatbot.veryfront.com",
+        );
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
     it("strips port from custom domain host before token fetch", async () => {
       const tokenRequests: string[] = [];
       const { server, port } = createMockServer((req: Request) => {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -215,6 +215,15 @@ function parseStatusFromError(error: unknown): number | null {
   return match ? Number(match[1]) : null;
 }
 
+// Brittle on purpose: we string-match the API's OAuth error body. Source of truth is
+// veryfront-api/src/api/http/rest/auth/routes.ts — `oauthError(c, 'Project not found
+// for domain', ...)`. If that string is renamed, this regex silently regresses to 502.
+// Durable fix is a typed error code from the token-mint helper; tracked separately.
+function isMissingCustomDomainProjectError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /project not found for domain/i.test(message);
+}
+
 async function extractUserIdFromToken(
   token: string,
   apiBaseUrl: string,
@@ -635,6 +644,13 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
       if (isCustomDomain && !projectSlug) {
         if (!token) {
+          if (isMissingCustomDomainProjectError(tokenFetchError)) {
+            logger?.info("Custom domain project not found during token fetch", {
+              domain: host,
+            });
+            return makeErrorContext(base, 404, `No project configured for domain: ${host}`);
+          }
+
           logger?.error("Cannot process custom domain without token", undefined, { domain: host });
           return makeErrorContext(base, 502, `Failed to authenticate for domain: ${host}`, token);
         }

--- a/src/server/utils/domain-parser.ts
+++ b/src/server/utils/domain-parser.ts
@@ -171,6 +171,10 @@ export function parseProjectDomain(host: string): ParsedDomain {
     return createParsedDomain(null, null, env, true, env === "preview");
   }
 
+  // Intentionally NOT supported: bare {slug}.veryfront.{com,org}. Projects must use the
+  // explicit {slug}.production.veryfront.com form. Do not re-add — this has been tried
+  // and reverted (PR #1055). It collides with infra subdomains (api/studio/docs/www)
+  // and erases the environment from the URL, which the product decision requires.
   return createParsedDomain(null, null, null, false, false);
 }
 


### PR DESCRIPTION
Closes #1054

## What changed
- Detect the token-mint error for custom domains that no longer map to a project (`OAuth token request failed: 400 - {"error":"Project not found for domain"}`) and return the safe 404 path instead of a misleading 502.
- Add a code comment in `handler.ts` pinning the exact API source string (`veryfront-api/src/api/http/rest/auth/routes.ts` — `oauthError(c, 'Project not found for domain', ...)`) so a future rename is greppable.
- Regression test in `src/proxy/handler.test.ts` using the **actual** incident hostname from production logs (`ai-chatbot.veryfront.com`).
- Add a tombstone comment in `domain-parser.ts` documenting why bare `{slug}.veryfront.com` is intentionally **not** supported. Two prior attempts to re-enable it have been reverted; the comment names PR #1055 so the history is interpretable.
- Small CLI boundary cleanup: re-export `CommandResult` from `veryfront/platform` and route the knowledge CLI import through the public barrel (pre-existing lint violation that was blocking pre-commit).

## Evidence (verified from Loki, past 7 days)
Queried `{service_name="veryfront-proxy"} |= "ai-chatbot"` on `grafanacloud-veryfront-logs`:

- **100%** of `ai-chatbot` proxy traffic hits the bare `ai-chatbot.veryfront.com` form. Zero hits on `ai-chatbot.production.veryfront.com`.
- Split: **67× 502** + **66× 400** (the 400s are the upstream token-mint responses; the 502s are the handler fallthrough this PR fixes).
- Repeating error chain:
  1. `Token fetch failed` — `OAuth token request failed: 400 - {"error":"Project not found for domain"}`
  2. `Cannot process custom domain without token` — `domain: ai-chatbot.veryfront.com`
  3. `502 GET /robots.txt` (also `/sitemaps.xml`)
- Last seen: `2026-04-15T14:27Z` on `veryfrontVersion: 0.1.141`.

## Product decision (documented in tombstone comment)
Bare `{slug}.veryfront.com` subdomains are **not supported**. Customers must use the explicit `{slug}.production.veryfront.com` form. This PR makes such requests return a clean 404 instead of a 502, but does not re-enable bare-subdomain parsing. The `ai-chatbot` project owner needs to migrate their DNS / deploy URL — that's a separate customer-facing follow-up, not a code fix.

## Scope changes from the original PR
- **Dropped:** `domain-parser.ts` change that re-enabled bare `{slug}.veryfront.com` parsing. The log evidence confirmed it was the incident URL shape, but the product decision is to reject the bare form, not support it. Reverted in commit `f5938cc`.
- **Added:** tombstone comment so this doesn't get re-tried a third time.

## Validation
- `deno task test src/proxy/handler.test.ts src/server/utils/domain-parser.test.ts` ✅ — all 98 steps pass.
- `deno task lint:cli-boundary` ✅
- Pre-commit `verify` ✅

## Follow-ups (separate issues)
- Thread a typed error code from the token-mint helper so the regex-match on the error body can be retired.
- `deno task test --headless` forwards `--headless` to `deno test`, which rejects it — tooling bug.
- Customer outreach: tell the `ai-chatbot` project owner to migrate to `ai-chatbot.production.veryfront.com`.
- (Optional UX) Consider a more helpful 404 body on bare-subdomain hits pointing customers at the `.production.` form.