### PR TITLE
feat(providers): unified reasoning / thinking request option

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.206",
+  "version": "0.1.207",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.207",
+  "version": "0.1.208",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.208",
+  "version": "0.1.209",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -2053,6 +2053,331 @@ describe("provider/runtime-loader", () => {
     });
   });
 
+  describe("reasoning / thinking request options", () => {
+    const userPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Solve this" }],
+    } as const;
+
+    function createAnthropicCaptureRuntime(modelId = "claude-opus-4-6") {
+      let capturedBody: Record<string, unknown> | null = null;
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          capturedBody = raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, modelId);
+      return { runtime, getBody: () => capturedBody };
+    }
+
+    function createOpenAICaptureRuntime(modelId: string) {
+      let capturedBody: Record<string, unknown> | null = null;
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "test-openai-key",
+        baseURL: "https://example.openai.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          capturedBody = raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                choices: [{
+                  index: 0,
+                  message: { role: "assistant", content: "ok" },
+                  finish_reason: "stop",
+                }],
+                usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, modelId);
+      return { runtime, getBody: () => capturedBody };
+    }
+
+    function createGoogleCaptureRuntime(modelId = "gemini-2.5-pro") {
+      let capturedBody: Record<string, unknown> | null = null;
+      const runtime = createGoogleModelRuntime({
+        apiKey: "test-google-key",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          capturedBody = raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                }],
+                usageMetadata: {
+                  promptTokenCount: 1,
+                  candidatesTokenCount: 1,
+                  totalTokenCount: 2,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, modelId);
+      return { runtime, getBody: () => capturedBody };
+    }
+
+    it("emits Anthropic thinking block with medium effort budget by default", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        maxOutputTokens: 2048,
+        reasoning: { enabled: true },
+      });
+      const body = getBody() as {
+        thinking: { type: string; budget_tokens: number };
+        max_tokens: number;
+      };
+      assertEquals(body.thinking, { type: "enabled", budget_tokens: 4096 });
+      // max_tokens = baseMaxTokens(2048) + budget(4096) = 6144
+      assertEquals(body.max_tokens, 6144);
+    });
+
+    it("maps Anthropic effort levels to budget_tokens", async () => {
+      async function budgetFor(effort: "low" | "medium" | "high" | "max") {
+        const { runtime, getBody } = createAnthropicCaptureRuntime();
+        await runtime.doGenerate({
+          prompt: [userPrompt],
+          maxOutputTokens: 1024,
+          reasoning: { enabled: true, effort },
+        });
+        return (getBody() as { thinking: { budget_tokens: number } }).thinking.budget_tokens;
+      }
+      assertEquals(await budgetFor("low"), 1024);
+      assertEquals(await budgetFor("medium"), 4096);
+      assertEquals(await budgetFor("high"), 16_384);
+      assertEquals(await budgetFor("max"), 32_768);
+    });
+
+    it("honours Anthropic explicit budgetTokens over effort", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        maxOutputTokens: 1024,
+        reasoning: { enabled: true, effort: "low", budgetTokens: 12_345 },
+      });
+      const body = getBody() as { thinking: { budget_tokens: number } };
+      assertEquals(body.thinking.budget_tokens, 12_345);
+    });
+
+    it("clamps Anthropic max_tokens at the model cap when thinking is enabled", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime("claude-opus-4-6");
+      // Opus 4.6 caps at 128k. 100k base + 64k budget would be 164k — clamp to 128k.
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        maxOutputTokens: 100_000,
+        reasoning: { enabled: true, budgetTokens: 64_000 },
+      });
+      const body = getBody() as { max_tokens: number };
+      assertEquals(body.max_tokens, 128_000);
+    });
+
+    it("drops Anthropic temperature and top_p when thinking is enabled", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+        reasoning: { enabled: true },
+      });
+      const body = getBody() as Record<string, unknown>;
+      assertEquals("temperature" in body, false);
+      assertEquals("top_p" in body, false);
+    });
+
+    it("preserves Anthropic sampling params when reasoning is disabled", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+      });
+      const body = getBody() as { temperature: number; top_p: number };
+      assertEquals(body.temperature, 0.7);
+      assertEquals(body.top_p, 0.9);
+    });
+
+    it("omits Anthropic thinking field when reasoning.enabled is false", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: false, effort: "high" },
+      });
+      const body = getBody() as Record<string, unknown>;
+      assertEquals("thinking" in body, false);
+    });
+
+    it("emits OpenAI reasoning_effort when reasoning is enabled", async () => {
+      const { runtime, getBody } = createOpenAICaptureRuntime("gpt-4o-mini");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: true, effort: "high" },
+      });
+      const body = getBody() as { reasoning_effort: string };
+      assertEquals(body.reasoning_effort, "high");
+    });
+
+    it("collapses OpenAI 'max' effort to 'high'", async () => {
+      const { runtime, getBody } = createOpenAICaptureRuntime("gpt-4o-mini");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: true, effort: "max" },
+      });
+      const body = getBody() as { reasoning_effort: string };
+      assertEquals(body.reasoning_effort, "high");
+    });
+
+    it("drops OpenAI sampling params on reasoning models (o1/o3/o4)", async () => {
+      const { runtime, getBody } = createOpenAICaptureRuntime("o3-mini");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+        presencePenalty: 0.1,
+        frequencyPenalty: 0.1,
+      });
+      const body = getBody() as Record<string, unknown>;
+      assertEquals("temperature" in body, false);
+      assertEquals("top_p" in body, false);
+      assertEquals("presence_penalty" in body, false);
+      assertEquals("frequency_penalty" in body, false);
+    });
+
+    it("preserves OpenAI sampling params on non-reasoning models", async () => {
+      const { runtime, getBody } = createOpenAICaptureRuntime("gpt-4o-mini");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+      });
+      const body = getBody() as { temperature: number; top_p: number };
+      assertEquals(body.temperature, 0.7);
+      assertEquals(body.top_p, 0.9);
+    });
+
+    it("emits Google thinkingConfig when reasoning is enabled", async () => {
+      const { runtime, getBody } = createGoogleCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: true, effort: "high" },
+      });
+      const body = getBody() as {
+        generationConfig: { thinkingConfig: { includeThoughts: boolean; thinkingBudget: number } };
+      };
+      assertEquals(body.generationConfig.thinkingConfig, {
+        includeThoughts: true,
+        thinkingBudget: 8192,
+      });
+    });
+
+    it("maps Google effort 'max' to thinkingBudget: -1 (dynamic)", async () => {
+      const { runtime, getBody } = createGoogleCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: true, effort: "max" },
+      });
+      const body = getBody() as {
+        generationConfig: { thinkingConfig: { thinkingBudget: number } };
+      };
+      assertEquals(body.generationConfig.thinkingConfig.thinkingBudget, -1);
+    });
+
+    it("honours Google explicit budgetTokens over effort", async () => {
+      const { runtime, getBody } = createGoogleCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: true, effort: "low", budgetTokens: 4096 },
+      });
+      const body = getBody() as {
+        generationConfig: { thinkingConfig: { thinkingBudget: number } };
+      };
+      assertEquals(body.generationConfig.thinkingConfig.thinkingBudget, 4096);
+    });
+
+    it("omits Google thinkingConfig when reasoning is disabled", async () => {
+      const { runtime, getBody } = createGoogleCaptureRuntime();
+      await runtime.doGenerate({ prompt: [userPrompt] });
+      const body = getBody() as {
+        generationConfig?: { thinkingConfig?: unknown };
+      };
+      assertEquals(body.generationConfig?.thinkingConfig, undefined);
+    });
+
+    it("passes redacted_thinking blocks through as reasoning events without leaking content", async () => {
+      const encoder = new TextEncoder();
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              ReadableStream.from([
+                encoder.encode(
+                  'event: message_start\ndata: {"type":"message_start","message":{"id":"m1","type":"message","role":"assistant","content":[],"model":"claude-opus-4-6","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"redacted_thinking","data":"encrypted-opaque-blob"}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"ok"}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n',
+                ),
+                encoder.encode(
+                  'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n',
+                ),
+                encoder.encode(
+                  'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+                ),
+              ]),
+              { status: 200, headers: { "content-type": "text/event-stream" } },
+            ),
+          ),
+      }, "claude-opus-4-6");
+
+      const result = await runtime.doStream({ prompt: [userPrompt] });
+      const parts = await collectAsync(result.stream);
+      // Redacted thinking emits reasoning-start (block 0) + reasoning-end, but no delta.
+      const reasoningStarts = parts.filter((p) =>
+        (p as { type: string }).type === "reasoning-start"
+      );
+      const reasoningDeltas = parts.filter((p) =>
+        (p as { type: string }).type === "reasoning-delta"
+      );
+      const reasoningEnds = parts.filter((p) => (p as { type: string }).type === "reasoning-end");
+      assertEquals(reasoningStarts.length, 1);
+      assertEquals(reasoningDeltas.length, 0);
+      assertEquals(reasoningEnds.length, 1);
+    });
+  });
+
   describe("cache usage reporting (cache_creation / cache_read / cached_tokens)", () => {
     const userPrompt = {
       role: "user",

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -1888,14 +1888,14 @@ describe("provider/runtime-loader", () => {
       };
     }
 
-    const systemPrompt: RuntimePromptMessage = {
+    const systemPrompt = {
       role: "system",
       content: "You are a helpful assistant.",
-    };
-    const userPrompt: RuntimePromptMessage = {
+    } as const;
+    const userPrompt = {
       role: "user",
       content: [{ type: "text", text: "Hi" }],
-    };
+    } as const;
 
     const weatherTool = {
       type: "function" as const,
@@ -2050,6 +2050,248 @@ describe("provider/runtime-loader", () => {
       });
       const body = getBody() as Record<string, unknown>;
       assertEquals("tools" in body, false);
+    });
+  });
+
+  describe("cache usage reporting (cache_creation / cache_read / cached_tokens)", () => {
+    const userPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Hi" }],
+    } as const;
+
+    it("surfaces Anthropic cache_creation_input_tokens and cache_read_input_tokens on generate", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: {
+                  input_tokens: 12,
+                  output_tokens: 34,
+                  cache_creation_input_tokens: 2056,
+                  cache_read_input_tokens: 128,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "claude-sonnet-4-20250514");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.usage, {
+        inputTokens: 12,
+        outputTokens: 34,
+        totalTokens: 46,
+        cacheCreationInputTokens: 2056,
+        cacheReadInputTokens: 128,
+      });
+    });
+
+    it("propagates Anthropic cache fields through the stream usage accumulator", async () => {
+      const encoder = new TextEncoder();
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              ReadableStream.from([
+                // message_start carries input + cache token counts up front.
+                encoder.encode(
+                  'event: message_start\ndata: {"type":"message_start","message":{"id":"m1","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":12,"output_tokens":1,"cache_creation_input_tokens":2056,"cache_read_input_tokens":128}}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+                ),
+                // message_delta only updates output_tokens; cache fields absent here.
+                encoder.encode(
+                  'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":34}}\n\n',
+                ),
+                encoder.encode(
+                  'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+                ),
+              ]),
+              { status: 200, headers: { "content-type": "text/event-stream" } },
+            ),
+          ),
+      }, "claude-sonnet-4-20250514");
+
+      const result = await runtime.doStream({ prompt: [userPrompt] });
+      const parts = await collectAsync(result.stream);
+      const finish = parts.find((p) => (p as { type: string }).type === "finish") as {
+        usage: {
+          inputTokens?: number;
+          outputTokens?: number;
+          cacheCreationInputTokens?: number;
+          cacheReadInputTokens?: number;
+        };
+      };
+      assertEquals(finish.usage.inputTokens, 12);
+      assertEquals(finish.usage.outputTokens, 34);
+      assertEquals(finish.usage.cacheCreationInputTokens, 2056);
+      assertEquals(finish.usage.cacheReadInputTokens, 128);
+    });
+
+    it("leaves Anthropic cache fields undefined when the provider omits them", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 4, output_tokens: 2 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "claude-sonnet-4-20250514");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      // Cache fields should be absent (not zero) when provider doesn't return them.
+      assertEquals(result.usage, {
+        inputTokens: 4,
+        outputTokens: 2,
+        totalTokens: 6,
+      });
+    });
+
+    it("surfaces OpenAI prompt_tokens_details.cached_tokens as cacheReadInputTokens", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "test-openai-key",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                choices: [{
+                  index: 0,
+                  message: { role: "assistant", content: "ok" },
+                  finish_reason: "stop",
+                }],
+                usage: {
+                  prompt_tokens: 100,
+                  completion_tokens: 40,
+                  total_tokens: 140,
+                  prompt_tokens_details: { cached_tokens: 80 },
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "gpt-4o-mini");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.usage, {
+        inputTokens: 100,
+        outputTokens: 40,
+        totalTokens: 140,
+        cacheReadInputTokens: 80,
+      });
+    });
+
+    it("leaves OpenAI cache field undefined when prompt_tokens_details is absent", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "test-openai-key",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                choices: [{
+                  index: 0,
+                  message: { role: "assistant", content: "ok" },
+                  finish_reason: "stop",
+                }],
+                usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "gpt-4o-mini");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.usage, {
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+      });
+    });
+
+    it("surfaces Google cachedContentTokenCount as cacheReadInputTokens", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "test-google-key",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                }],
+                usageMetadata: {
+                  promptTokenCount: 123,
+                  candidatesTokenCount: 45,
+                  totalTokenCount: 168,
+                  cachedContentTokenCount: 100,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "gemini-1.5-pro");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.usage, {
+        inputTokens: 123,
+        outputTokens: 45,
+        totalTokens: 168,
+        cacheReadInputTokens: 100,
+      });
+    });
+
+    it("leaves Google cache field undefined when cachedContentTokenCount is absent", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "test-google-key",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                }],
+                usageMetadata: {
+                  promptTokenCount: 8,
+                  candidatesTokenCount: 2,
+                  totalTokenCount: 10,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "gemini-1.5-pro");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.usage, {
+        inputTokens: 8,
+        outputTokens: 2,
+        totalTokens: 10,
+      });
     });
   });
 });

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -1857,4 +1857,199 @@ describe("provider/runtime-loader", () => {
       assertEquals((body as { max_tokens: number }).max_tokens, 64_000);
     });
   });
+
+  describe("Anthropic prompt caching (cache_control breakpoints)", () => {
+    // Captures the outbound body for a single Anthropic generate call with a
+    // caller-provided cacheControl option. Returns the parsed body so each test
+    // can assert what landed on the wire.
+    function createCachingCaptureRuntime() {
+      let capturedBody: Record<string, unknown> | null = null;
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          capturedBody = raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "claude-sonnet-4-20250514");
+      return {
+        runtime,
+        getBody: () => capturedBody,
+      };
+    }
+
+    const systemPrompt: RuntimePromptMessage = {
+      role: "system",
+      content: "You are a helpful assistant.",
+    };
+    const userPrompt: RuntimePromptMessage = {
+      role: "user",
+      content: [{ type: "text", text: "Hi" }],
+    };
+
+    const weatherTool = {
+      type: "function" as const,
+      name: "weather",
+      description: "Get weather",
+      inputSchema: {
+        type: "object",
+        properties: { city: { type: "string" } },
+        required: ["city"],
+        additionalProperties: false,
+      },
+    };
+    const searchTool = {
+      type: "function" as const,
+      name: "search",
+      description: "Search the web",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+        additionalProperties: false,
+      },
+    };
+
+    it("defaults system to string form when cacheControl is not set", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+      });
+      const body = getBody() as { system: unknown };
+      // Backward-compat path: without a breakpoint, system stays as a raw string.
+      assertEquals(body.system, "You are a helpful assistant.");
+    });
+
+    it("emits cache_control on the system block when cacheControl.system is true", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        cacheControl: { system: true },
+      });
+      const body = getBody() as { system: Array<Record<string, unknown>> };
+      assertEquals(body.system, [{
+        type: "text",
+        text: "You are a helpful assistant.",
+        cache_control: { type: "ephemeral" },
+      }]);
+    });
+
+    it('emits cache_control with 1h TTL when cacheControl.system is "1h"', async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        cacheControl: { system: "1h" },
+      });
+      const body = getBody() as { system: Array<Record<string, unknown>> };
+      assertEquals(body.system, [{
+        type: "text",
+        text: "You are a helpful assistant.",
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      }]);
+    });
+
+    it("emits cache_control on the LAST tool entry when cacheControl.tools is true", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        tools: [weatherTool, searchTool],
+        cacheControl: { tools: true },
+      });
+      const body = getBody() as { tools: Array<Record<string, unknown>> };
+      assertEquals(body.tools.length, 2);
+      // First tool is unmodified
+      assertEquals(body.tools[0], {
+        name: "weather",
+        description: "Get weather",
+        input_schema: weatherTool.inputSchema,
+      });
+      // Last tool carries the breakpoint
+      assertEquals(body.tools[1], {
+        name: "search",
+        description: "Search the web",
+        input_schema: searchTool.inputSchema,
+        cache_control: { type: "ephemeral" },
+      });
+    });
+
+    it("emits both system and tools breakpoints when both are set", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        tools: [weatherTool],
+        cacheControl: { system: true, tools: "1h" },
+      });
+      const body = getBody() as {
+        system: Array<Record<string, unknown>>;
+        tools: Array<Record<string, unknown>>;
+      };
+      assertEquals(body.system, [{
+        type: "text",
+        text: "You are a helpful assistant.",
+        cache_control: { type: "ephemeral" },
+      }]);
+      assertEquals(body.tools, [{
+        name: "weather",
+        description: "Get weather",
+        input_schema: weatherTool.inputSchema,
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      }]);
+    });
+
+    it("treats cacheControl.system === false as no-op (string form preserved)", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        cacheControl: { system: false },
+      });
+      const body = getBody() as { system: unknown };
+      assertEquals(body.system, "You are a helpful assistant.");
+    });
+
+    it("treats cacheControl.tools === false as no-op (no breakpoint attached)", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        tools: [weatherTool],
+        cacheControl: { tools: false },
+      });
+      const body = getBody() as { tools: Array<Record<string, unknown>> };
+      assertEquals(body.tools, [{
+        name: "weather",
+        description: "Get weather",
+        input_schema: weatherTool.inputSchema,
+      }]);
+    });
+
+    it("does not crash when cacheControl is set but there's no system prompt", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        cacheControl: { system: true },
+      });
+      const body = getBody() as Record<string, unknown>;
+      // No system field at all — nothing to attach the breakpoint to.
+      assertEquals("system" in body, false);
+    });
+
+    it("does not crash when cacheControl.tools is set but there's no tools array", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        cacheControl: { tools: true },
+      });
+      const body = getBody() as Record<string, unknown>;
+      assertEquals("tools" in body, false);
+    });
+  });
 });

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -94,6 +94,33 @@ type ProviderCacheControlOption = {
   tools?: ProviderCacheTtl;
 };
 
+/**
+ * Unified effort level for extended reasoning / thinking. Maps to
+ * per-provider knobs: Anthropic `thinking.budget_tokens`, OpenAI
+ * `reasoning_effort`, Gemini `thinkingConfig.thinkingBudget`.
+ */
+type ProviderReasoningEffort = "low" | "medium" | "high" | "max";
+
+/**
+ * Unified reasoning / thinking request option.
+ *
+ * Setting `enabled: true` turns on extended thinking on providers that
+ * support it (Anthropic Claude 4.x, OpenAI o-series, Gemini 2.5+). The
+ * `effort` field picks a coarse budget; when `budgetTokens` is set it
+ * wins for providers that take a numeric budget (Anthropic, Gemini).
+ *
+ * Providers that do not support reasoning treat this as a no-op. On
+ * Anthropic + OpenAI, enabling reasoning also disables sampling params
+ * that the providers reject in combination (`temperature`, `topP`,
+ * `topK`, `presencePenalty`, `frequencyPenalty`) — silently dropping
+ * them rather than failing the request.
+ */
+type ProviderReasoningOption = {
+  enabled?: boolean;
+  effort?: ProviderReasoningEffort;
+  budgetTokens?: number;
+};
+
 type OpenAICompatibleLanguageOptions = {
   prompt: RuntimePromptMessage[];
   maxOutputTokens?: number;
@@ -116,6 +143,12 @@ type OpenAICompatibleLanguageOptions = {
    * unchanged on every provider.
    */
   cacheControl?: ProviderCacheControlOption;
+  /**
+   * Enable extended reasoning / thinking on providers that support it.
+   * See {@link ProviderReasoningOption}. When unset, reasoning behaviour
+   * is unchanged on every provider.
+   */
+  reasoning?: ProviderReasoningOption;
 };
 type OpenAICompatibleChatMessage =
   | { role: "system"; content: string }
@@ -830,6 +863,35 @@ function resolveAnthropicMaxTokens(
   return requested;
 }
 
+/**
+ * Map a unified reasoning effort level to an Anthropic `thinking.budget_tokens`
+ * value. Anthropic's minimum accepted budget is 1024; higher tiers give Claude
+ * more headroom to explore. `max` maps to the upper bound documented for
+ * Claude 4.x family (32k tokens of thinking — caller can override via
+ * `budgetTokens` if they need more).
+ */
+function resolveAnthropicThinkingBudget(
+  option: ProviderReasoningOption | undefined,
+): number | undefined {
+  if (!option || option.enabled !== true) {
+    return undefined;
+  }
+  if (typeof option.budgetTokens === "number" && option.budgetTokens >= 1024) {
+    return option.budgetTokens;
+  }
+  switch (option.effort) {
+    case "low":
+      return 1024;
+    case "high":
+      return 16_384;
+    case "max":
+      return 32_768;
+    case "medium":
+    default:
+      return 4096;
+  }
+}
+
 function buildAnthropicMessagesRequest(
   modelId: string,
   providerName: string,
@@ -845,15 +907,35 @@ function buildAnthropicMessagesRequest(
 
   const { system, messages } = toAnthropicMessages(options.prompt, systemCacheControl);
   const anthropicTools = toAnthropicTools(options.tools, toolsCacheControl);
+  const thinkingBudget = resolveAnthropicThinkingBudget(options.reasoning);
+  const thinkingEnabled = thinkingBudget !== undefined;
+
+  // Anthropic requires max_tokens > budget_tokens when thinking is enabled.
+  // Growing max_tokens by the thinking budget preserves the caller's intended
+  // output budget, and we clamp the sum at the model's advertised maximum so
+  // the request never exceeds the API's hard cap.
+  const baseMaxTokens = resolveAnthropicMaxTokens(modelId, options.maxOutputTokens);
+  const maxTokens = thinkingEnabled
+    ? Math.min(
+      baseMaxTokens + (thinkingBudget ?? 0),
+      getAnthropicModelCapabilities(modelId).maxOutputTokens,
+    )
+    : baseMaxTokens;
 
   const body: AnthropicCompatibleRequest = {
     model: modelId,
     messages,
-    max_tokens: resolveAnthropicMaxTokens(modelId, options.maxOutputTokens),
+    max_tokens: maxTokens,
     ...(stream ? { stream: true } : {}),
     ...(system ? { system } : {}),
-    ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
-    ...(options.topP !== undefined ? { top_p: options.topP } : {}),
+    // Sampling params are mutually exclusive with thinking on Anthropic — the
+    // API rejects the combo outright. Drop them silently when thinking is on
+    // (callers see thinking's output instead of what they'd have gotten from
+    // custom sampling, which is the documented tradeoff).
+    ...(!thinkingEnabled && options.temperature !== undefined
+      ? { temperature: options.temperature }
+      : {}),
+    ...(!thinkingEnabled && options.topP !== undefined ? { top_p: options.topP } : {}),
     ...(options.stopSequences && options.stopSequences.length > 0
       ? { stop_sequences: options.stopSequences }
       : {}),
@@ -861,6 +943,7 @@ function buildAnthropicMessagesRequest(
     ...(options.toolChoice !== undefined
       ? { tool_choice: normalizeAnthropicToolChoice(options.toolChoice) }
       : {}),
+    ...(thinkingEnabled ? { thinking: { type: "enabled", budget_tokens: thinkingBudget } } : {}),
   };
 
   Object.assign(body, readProviderOptions(options.providerOptions, "anthropic", providerName));
@@ -1028,6 +1111,20 @@ async function* streamAnthropicCompatibleParts(
               delta: contentBlock.thinking,
             };
           }
+          continue;
+        }
+
+        // Redacted thinking blocks arrive as opaque encrypted payloads when
+        // Claude's safety classifier flags the reasoning trace. Surface them
+        // as a zero-length reasoning block so callers know thinking happened
+        // without leaking the (legitimately hidden) contents.
+        if (blockType === "redacted_thinking") {
+          const reasoningId = `thinking-${index}`;
+          reasoningBlocks.set(index, { id: reasoningId });
+          yield {
+            type: "reasoning-start",
+            id: reasoningId,
+          };
           continue;
         }
 
@@ -1288,19 +1385,59 @@ function extractOpenAIToolCalls(message: Record<string, unknown>): Array<{
   return normalized;
 }
 
+/**
+ * OpenAI reasoning models (o1 / o3 / o4 family) use the completion path but
+ * have different constraints than chat models: sampling params are rejected,
+ * and they accept a `reasoning_effort` field. We detect them by model id
+ * prefix so callers don't have to configure it per runtime.
+ */
+function isOpenAIReasoningModel(modelId: string): boolean {
+  return /^o[134](-|$)/.test(modelId);
+}
+
+/**
+ * Map the unified reasoning effort to OpenAI's `reasoning_effort` enum.
+ * OpenAI doesn't accept "max" — we collapse it to "high".
+ */
+function resolveOpenAIReasoningEffort(
+  option: ProviderReasoningOption | undefined,
+): "low" | "medium" | "high" | undefined {
+  if (!option || option.enabled !== true) {
+    return undefined;
+  }
+  switch (option.effort) {
+    case "low":
+      return "low";
+    case "high":
+    case "max":
+      return "high";
+    case "medium":
+    default:
+      return "medium";
+  }
+}
+
 function buildOpenAIChatRequest(
   modelId: string,
   providerName: string,
   options: OpenAICompatibleLanguageOptions,
   stream: boolean,
 ): OpenAICompatibleChatRequest {
+  const isReasoningModel = isOpenAIReasoningModel(modelId);
+  const reasoningEffort = resolveOpenAIReasoningEffort(options.reasoning);
+  const reasoningEnabled = isReasoningModel || reasoningEffort !== undefined;
+
   const body: OpenAICompatibleChatRequest = {
     model: modelId,
     messages: toOpenAICompatibleMessages(options.prompt),
     ...(stream ? { stream: true, stream_options: { include_usage: true } } : {}),
     ...(options.maxOutputTokens !== undefined ? { max_tokens: options.maxOutputTokens } : {}),
-    ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
-    ...(options.topP !== undefined ? { top_p: options.topP } : {}),
+    // OpenAI reasoning models reject temperature / top_p / frequency / presence.
+    // Drop them silently rather than letting the API bounce the request.
+    ...(!reasoningEnabled && options.temperature !== undefined
+      ? { temperature: options.temperature }
+      : {}),
+    ...(!reasoningEnabled && options.topP !== undefined ? { top_p: options.topP } : {}),
     ...(options.stopSequences && options.stopSequences.length > 0
       ? { stop: options.stopSequences }
       : {}),
@@ -1309,10 +1446,13 @@ function buildOpenAIChatRequest(
       : {}),
     ...(options.toolChoice !== undefined ? { tool_choice: options.toolChoice } : {}),
     ...(options.seed !== undefined ? { seed: options.seed } : {}),
-    ...(options.presencePenalty !== undefined ? { presence_penalty: options.presencePenalty } : {}),
-    ...(options.frequencyPenalty !== undefined
+    ...(!reasoningEnabled && options.presencePenalty !== undefined
+      ? { presence_penalty: options.presencePenalty }
+      : {}),
+    ...(!reasoningEnabled && options.frequencyPenalty !== undefined
       ? { frequency_penalty: options.frequencyPenalty }
       : {}),
+    ...(reasoningEffort !== undefined ? { reasoning_effort: reasoningEffort } : {}),
   };
 
   Object.assign(body, readProviderOptions(options.providerOptions, "openai", providerName));
@@ -1483,9 +1623,46 @@ function normalizeGoogleToolChoice(toolChoice: unknown):
   return undefined;
 }
 
+/**
+ * Map the unified reasoning option to Gemini's thinkingConfig. Gemini 2.5+
+ * accepts `includeThoughts: true` to stream back `thought` parts, and
+ * `thinkingBudget: N` to cap the thinking token count. The effort levels
+ * here follow Google's own guidance (low ~= 512, medium ~= 2048,
+ * high ~= 8192, max = -1 means "dynamic/no cap").
+ */
+function resolveGoogleThinkingConfig(
+  option: ProviderReasoningOption | undefined,
+): Record<string, unknown> | undefined {
+  if (!option || option.enabled !== true) {
+    return undefined;
+  }
+  const config: Record<string, unknown> = { includeThoughts: true };
+  if (typeof option.budgetTokens === "number") {
+    config.thinkingBudget = option.budgetTokens;
+    return config;
+  }
+  switch (option.effort) {
+    case "low":
+      config.thinkingBudget = 512;
+      break;
+    case "high":
+      config.thinkingBudget = 8192;
+      break;
+    case "max":
+      config.thinkingBudget = -1;
+      break;
+    case "medium":
+    default:
+      config.thinkingBudget = 2048;
+      break;
+  }
+  return config;
+}
+
 function buildGoogleGenerationConfig(
   options: OpenAICompatibleLanguageOptions,
 ): Record<string, unknown> | undefined {
+  const thinkingConfig = resolveGoogleThinkingConfig(options.reasoning);
   const config: Record<string, unknown> = {
     ...(options.maxOutputTokens !== undefined ? { maxOutputTokens: options.maxOutputTokens } : {}),
     ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
@@ -1495,6 +1672,7 @@ function buildGoogleGenerationConfig(
       ? { stopSequences: options.stopSequences }
       : {}),
     ...(options.seed !== undefined ? { seed: options.seed } : {}),
+    ...(thinkingConfig ? { thinkingConfig } : {}),
   };
 
   return Object.keys(config).length > 0 ? config : undefined;

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -518,9 +518,15 @@ function normalizeAnthropicFinishReason(
   }
 }
 
-function extractAnthropicUsage(payload: unknown):
-  | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
-  | undefined {
+type RuntimeUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+};
+
+function extractAnthropicUsage(payload: unknown): RuntimeUsage | undefined {
   const record = readRecord(payload);
   const usage = readRecord(record?.usage);
   if (!usage) {
@@ -529,6 +535,8 @@ function extractAnthropicUsage(payload: unknown):
 
   const inputTokens = usage.input_tokens;
   const outputTokens = usage.output_tokens;
+  const cacheCreationInputTokens = usage.cache_creation_input_tokens;
+  const cacheReadInputTokens = usage.cache_read_input_tokens;
 
   return {
     inputTokens: typeof inputTokens === "number" ? inputTokens : undefined,
@@ -537,17 +545,15 @@ function extractAnthropicUsage(payload: unknown):
       ? (typeof inputTokens === "number" ? inputTokens : 0) +
         (typeof outputTokens === "number" ? outputTokens : 0)
       : undefined,
+    ...(typeof cacheCreationInputTokens === "number" ? { cacheCreationInputTokens } : {}),
+    ...(typeof cacheReadInputTokens === "number" ? { cacheReadInputTokens } : {}),
   };
 }
 
 function mergeUsage(
-  current:
-    | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
-    | undefined,
-  next:
-    | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
-    | undefined,
-): { inputTokens?: number; outputTokens?: number; totalTokens?: number } | undefined {
+  current: RuntimeUsage | undefined,
+  next: RuntimeUsage | undefined,
+): RuntimeUsage | undefined {
   if (!current) {
     return next;
   }
@@ -558,11 +564,16 @@ function mergeUsage(
 
   const inputTokens = next.inputTokens ?? current.inputTokens;
   const outputTokens = next.outputTokens ?? current.outputTokens;
+  const cacheCreationInputTokens = next.cacheCreationInputTokens ??
+    current.cacheCreationInputTokens;
+  const cacheReadInputTokens = next.cacheReadInputTokens ?? current.cacheReadInputTokens;
 
   return {
     inputTokens,
     outputTokens,
     totalTokens: (inputTokens ?? 0) + (outputTokens ?? 0),
+    ...(cacheCreationInputTokens !== undefined ? { cacheCreationInputTokens } : {}),
+    ...(cacheReadInputTokens !== undefined ? { cacheReadInputTokens } : {}),
   };
 }
 
@@ -863,7 +874,7 @@ function buildAnthropicGenerateResult(payload: unknown): {
     | { type: "tool-result"; toolCallId: string; toolName: string; result: unknown }
   >;
   finishReason?: string | { unified: string; raw: string } | null;
-  usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+  usage?: RuntimeUsage;
 } {
   const record = readRecord(payload);
   const content = Array.isArray(record?.content) ? record.content : [];
@@ -968,7 +979,7 @@ async function* streamAnthropicCompatibleParts(
   const toolCalls = new Map<number, AnthropicStreamToolCallState>();
   const reasoningBlocks = new Map<number, AnthropicStreamReasoningState>();
   let finishReason: string | { unified: string; raw: string } | null = null;
-  let usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number } | undefined;
+  let usage: RuntimeUsage | undefined;
 
   for await (const chunk of stream) {
     buffer += decoder.decode(chunk, { stream: true });
@@ -1205,9 +1216,7 @@ function normalizeOpenAIFinishReason(
   return raw;
 }
 
-function extractOpenAIUsage(payload: unknown):
-  | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
-  | undefined {
+function extractOpenAIUsage(payload: unknown): RuntimeUsage | undefined {
   const record = readRecord(payload);
   const usage = readRecord(record?.usage);
   if (!usage) {
@@ -1217,11 +1226,14 @@ function extractOpenAIUsage(payload: unknown):
   const inputTokens = usage.prompt_tokens;
   const outputTokens = usage.completion_tokens;
   const totalTokens = usage.total_tokens;
+  const promptTokensDetails = readRecord(usage.prompt_tokens_details);
+  const cachedTokens = promptTokensDetails?.cached_tokens;
 
   return {
     inputTokens: typeof inputTokens === "number" ? inputTokens : undefined,
     outputTokens: typeof outputTokens === "number" ? outputTokens : undefined,
     totalTokens: typeof totalTokens === "number" ? totalTokens : undefined,
+    ...(typeof cachedTokens === "number" ? { cacheReadInputTokens: cachedTokens } : {}),
   };
 }
 
@@ -1327,9 +1339,7 @@ function normalizeGoogleFinishReason(
   }
 }
 
-function extractGoogleUsage(payload: unknown):
-  | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
-  | undefined {
+function extractGoogleUsage(payload: unknown): RuntimeUsage | undefined {
   const record = readRecord(payload);
   const usage = readRecord(record?.usageMetadata);
   if (!usage) {
@@ -1339,11 +1349,15 @@ function extractGoogleUsage(payload: unknown):
   const inputTokens = usage.promptTokenCount;
   const outputTokens = usage.candidatesTokenCount;
   const totalTokens = usage.totalTokenCount;
+  const cachedContentTokenCount = usage.cachedContentTokenCount;
 
   return {
     inputTokens: typeof inputTokens === "number" ? inputTokens : undefined,
     outputTokens: typeof outputTokens === "number" ? outputTokens : undefined,
     totalTokens: typeof totalTokens === "number" ? totalTokens : undefined,
+    ...(typeof cachedContentTokenCount === "number"
+      ? { cacheReadInputTokens: cachedContentTokenCount }
+      : {}),
   };
 }
 
@@ -1537,7 +1551,7 @@ function buildGoogleGenerateResult(payload: unknown): {
     | { type: "tool-call"; toolCallId: string; toolName: string; input: string }
   >;
   finishReason?: string | { unified: string; raw: string } | null;
-  usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+  usage?: RuntimeUsage;
 } {
   const parts = extractGoogleCandidateParts(payload);
   const content: Array<
@@ -1578,7 +1592,7 @@ async function* streamGoogleCompatibleParts(
   let reasoningId: string | null = null;
   let reasoningIndex = 0;
   let finishReason: string | { unified: string; raw: string } | null = null;
-  let usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number } | undefined;
+  let usage: RuntimeUsage | undefined;
 
   for await (const chunk of stream) {
     buffer += decoder.decode(chunk, { stream: true });
@@ -1710,7 +1724,7 @@ function buildOpenAIGenerateResult(payload: unknown): {
     }
   >;
   finishReason?: string | { unified: string; raw: string } | null;
-  usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+  usage?: RuntimeUsage;
 } {
   const choice = extractFirstChoice(payload);
   const message = readRecord(choice?.message);
@@ -1741,7 +1755,7 @@ async function* streamOpenAICompatibleParts(
   let reasoningId: string | null = null;
   let reasoningIndex = 0;
   let finishReason: string | { unified: string; raw: string } | null = null;
-  let usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number } | undefined;
+  let usage: RuntimeUsage | undefined;
 
   for await (const chunk of stream) {
     buffer += decoder.decode(chunk, { stream: true });

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -60,6 +60,40 @@ type RuntimeToolDefinition =
     id: `${string}.${string}`;
     args: Record<string, unknown>;
   };
+/**
+ * TTL for a single prompt-cache breakpoint.
+ *
+ * `true` and `"5m"` both map to Anthropic's default ephemeral (5-minute) cache.
+ * `"1h"` maps to the extended 1-hour cache at a 2x write cost. Callers can
+ * pick per breakpoint target.
+ */
+type ProviderCacheTtl = boolean | "5m" | "1h";
+
+/**
+ * Per-provider prompt / context caching controls.
+ *
+ * For Anthropic, flipping these on emits `cache_control: { type: "ephemeral" }`
+ * breakpoints on the assembled system prompt and/or the last tool definition
+ * sent to the Messages API, enabling Anthropic's explicit prompt cache.
+ *
+ * OpenAI's prompt cache is automatic on gpt-4o+ and has no request-side
+ * directive to emit, so this option is a no-op for the OpenAI runtime. Google
+ * uses a separate `cachedContent` resource model that is intentionally not
+ * covered by this option (it belongs on a dedicated Gemini-specific surface).
+ */
+type ProviderCacheControlOption = {
+  /**
+   * Attach a cache breakpoint to the final system-prompt text block.
+   * Use when the system prompt is large and reused across requests.
+   */
+  system?: ProviderCacheTtl;
+  /**
+   * Attach a cache breakpoint to the last tool definition in `tools`.
+   * Use when the tool schemas are large and identical across requests.
+   */
+  tools?: ProviderCacheTtl;
+};
+
 type OpenAICompatibleLanguageOptions = {
   prompt: RuntimePromptMessage[];
   maxOutputTokens?: number;
@@ -76,6 +110,12 @@ type OpenAICompatibleLanguageOptions = {
   providerOptions?: Record<string, unknown>;
   includeRawChunks?: boolean;
   abortSignal?: AbortSignal;
+  /**
+   * Per-provider prompt / context caching controls. See
+   * {@link ProviderCacheControlOption}. When unset, caching behaviour is
+   * unchanged on every provider.
+   */
+  cacheControl?: ProviderCacheControlOption;
 };
 type OpenAICompatibleChatMessage =
   | { role: "system"; content: string }
@@ -142,7 +182,12 @@ type AnthropicCompatibleRequest = {
   messages: AnthropicCompatibleMessage[];
   max_tokens: number;
   stream?: boolean;
-  system?: string;
+  /**
+   * String form is the classic shorthand. Array-of-blocks form is required
+   * when the system prompt carries a cache_control breakpoint, because
+   * cache_control lives on an individual content block, not on a raw string.
+   */
+  system?: string | Array<Record<string, unknown>>;
   temperature?: number;
   top_p?: number;
   stop_sequences?: string[];
@@ -558,9 +603,32 @@ function pushAnthropicUserContent(
   });
 }
 
+/**
+ * Resolves a {@link ProviderCacheTtl} into Anthropic's `cache_control` shape.
+ *
+ * Returns `undefined` when caching is not requested (`false` / `undefined`),
+ * `{ type: "ephemeral" }` for the 5-minute default (`true` / `"5m"`), or
+ * `{ type: "ephemeral", ttl: "1h" }` for the extended 1-hour cache.
+ */
+function resolveAnthropicCacheControlBlock(
+  ttl: ProviderCacheTtl | undefined,
+): { type: "ephemeral"; ttl?: "1h" } | undefined {
+  if (ttl === undefined || ttl === false) {
+    return undefined;
+  }
+  if (ttl === "1h") {
+    return { type: "ephemeral", ttl: "1h" };
+  }
+  return { type: "ephemeral" };
+}
+
 function toAnthropicMessages(
   prompt: RuntimePromptMessage[],
-): { system?: string; messages: AnthropicCompatibleMessage[] } {
+  systemCacheControl?: { type: "ephemeral"; ttl?: "1h" },
+): {
+  system?: string | Array<Record<string, unknown>>;
+  messages: AnthropicCompatibleMessage[];
+} {
   const systemParts: string[] = [];
   const messages: AnthropicCompatibleMessage[] = [];
 
@@ -603,14 +671,32 @@ function toAnthropicMessages(
     }
   }
 
-  return {
-    ...(systemParts.length > 0 ? { system: systemParts.join("\n\n") } : {}),
-    messages,
-  };
+  if (systemParts.length === 0) {
+    return { messages };
+  }
+
+  const joined = systemParts.join("\n\n");
+
+  // Cache-controlled system prompts must use the array-of-blocks form so the
+  // breakpoint lands on an individual content block. Callers that don't opt
+  // in keep the legacy raw-string form for backward compatibility.
+  if (systemCacheControl) {
+    return {
+      system: [{
+        type: "text",
+        text: joined,
+        cache_control: systemCacheControl,
+      }],
+      messages,
+    };
+  }
+
+  return { system: joined, messages };
 }
 
 function toAnthropicTools(
   tools: RuntimeToolDefinition[] | undefined,
+  toolsCacheControl?: { type: "ephemeral"; ttl?: "1h" },
 ): Array<Record<string, unknown>> | undefined {
   if (!tools) {
     return undefined;
@@ -644,7 +730,23 @@ function toAnthropicTools(
     });
   }
 
-  return normalized.length > 0 ? normalized : undefined;
+  if (normalized.length === 0) {
+    return undefined;
+  }
+
+  // Attach the cache breakpoint to the final tool entry so Anthropic caches
+  // the entire tools block up to and including that definition. Earlier tool
+  // entries are implicitly covered by the same breakpoint per Anthropic's
+  // walk-backward cache lookup behaviour.
+  if (toolsCacheControl) {
+    const lastIndex = normalized.length - 1;
+    normalized[lastIndex] = {
+      ...normalized[lastIndex],
+      cache_control: toolsCacheControl,
+    };
+  }
+
+  return normalized;
 }
 
 function createAnthropicRequestHeaders(options: {
@@ -723,7 +825,16 @@ function buildAnthropicMessagesRequest(
   options: OpenAICompatibleLanguageOptions,
   stream: boolean,
 ): AnthropicCompatibleRequest {
-  const { system, messages } = toAnthropicMessages(options.prompt);
+  const systemCacheControl = resolveAnthropicCacheControlBlock(
+    options.cacheControl?.system,
+  );
+  const toolsCacheControl = resolveAnthropicCacheControlBlock(
+    options.cacheControl?.tools,
+  );
+
+  const { system, messages } = toAnthropicMessages(options.prompt, systemCacheControl);
+  const anthropicTools = toAnthropicTools(options.tools, toolsCacheControl);
+
   const body: AnthropicCompatibleRequest = {
     model: modelId,
     messages,
@@ -735,7 +846,7 @@ function buildAnthropicMessagesRequest(
     ...(options.stopSequences && options.stopSequences.length > 0
       ? { stop_sequences: options.stopSequences }
       : {}),
-    ...(toAnthropicTools(options.tools) ? { tools: toAnthropicTools(options.tools) } : {}),
+    ...(anthropicTools ? { tools: anthropicTools } : {}),
     ...(options.toolChoice !== undefined
       ? { tool_choice: normalizeAnthropicToolChoice(options.toolChoice) }
       : {}),

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.208";
+export const VERSION = "0.1.209";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.207";
+export const VERSION = "0.1.208";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.206";
+export const VERSION = "0.1.207";


### PR DESCRIPTION
## Summary

Adds a unified `reasoning` option to `OpenAICompatibleLanguageOptions` that turns on extended reasoning / thinking across Anthropic Claude 4.x, OpenAI o1/o3/o4, and Gemini 2.5+ from a single effort enum. Refs #1047. Part of #1044. Stacked on #1058 (cache usage reporting).

## Motivation

Before this PR, the runtime parses thinking/reasoning content **on the response side** (Anthropic `thinking_delta`, OpenAI `reasoning_content`, Gemini `thought` parts all flow through to `reasoning-*` UI events) but never **requests** reasoning on any provider — so callers couldn't actually turn it on through this library. Opus 4.6's headline capability (adaptive thinking) was unreachable.

## Design

New option:

\`\`\`ts
reasoning?: {
  enabled?: boolean;
  effort?: \"low\" | \"medium\" | \"high\" | \"max\";
  budgetTokens?: number;
}
\`\`\`

Per-provider translation:

| Effort   | Anthropic `budget_tokens` | OpenAI `reasoning_effort` | Google `thinkingBudget` |
|----------|---------------------------|---------------------------|-------------------------|
| `low`    | 1024                      | \`low\`                     | 512                     |
| `medium` | 4096                      | \`medium\`                  | 2048                    |
| `high`   | 16384                     | \`high\`                    | 8192                    |
| `max`    | 32768                     | \`high\` (collapsed)        | -1 (dynamic)            |

When `reasoning.budgetTokens` is set, it overrides the effort mapping for providers that take a numeric budget (Anthropic, Google).

## Per-provider specifics

### Anthropic (https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking)

- Emits `thinking: { type: \"enabled\", budget_tokens: N }` on the Messages API.
- **Grows `max_tokens` by the thinking budget**, then clamps at the model's advertised cap from `getAnthropicModelCapabilities` (shared with #1043). Example: Opus 4.6 with `maxOutputTokens: 100_000` + `budgetTokens: 64_000` → request hits `max_tokens: 128_000` (the cap), not 164k.
- **Silently drops `temperature` and `top_p`** when thinking is enabled — the API rejects the combination outright, so dropping them is the only way to keep the request alive.

### OpenAI (https://platform.openai.com/docs/guides/reasoning)

- **Detects reasoning models by id prefix** (`/^o[134](-|$)/` — o1, o3, o4, plus dashed variants like `o3-mini`). On a detected reasoning model, the sanitization applies even without `reasoning.enabled`, because the API rejects sampling params on reasoning models regardless.
- Emits `reasoning_effort: \"low\" | \"medium\" | \"high\"` when `reasoning.enabled`. `\"max\"` collapses to `\"high\"` (OpenAI doesn't expose an above-high tier on Chat Completions).
- **Silently drops `temperature` / `top_p` / `presence_penalty` / `frequency_penalty`** on reasoning requests.

### Google (https://ai.google.dev/gemini-api/docs/thinking)

- Emits `generationConfig.thinkingConfig: { includeThoughts: true, thinkingBudget: N }` on Gemini 2.5+ requests.
- `thinkingBudget: -1` maps Google's \"dynamic / no cap\" mode (effort `max`).
- Thought summaries already stream through the existing Google response parser as `reasoning-*` UI events — enabling `includeThoughts` is the missing request-side half.

### Redacted thinking

Added a `redacted_thinking` case in the Anthropic stream parser. When Claude's safety classifier flags a thinking trace, the block type changes from `thinking` to `redacted_thinking` with an opaque encrypted `data` field. We surface it as a zero-length reasoning block (`reasoning-start` + `reasoning-end` with no deltas) so callers see that thinking happened without leaking the (legitimately hidden) contents.

## Scope notes

Closes the **request-side enable** half of #1047. Two acceptance criteria are deferred to a follow-up because they require extending `RuntimePromptMessage` (a public type change that warrants its own PR):

1. **Anthropic thinking signature round-trip on multi-turn** — requires an `assistant` message variant that carries opaque `thinking` parts with their `signature` field, plus replay logic in `toAnthropicMessages`. A follow-up issue will extend the prompt type.
2. **OpenAI Responses API reasoning summary parsing** — the current Chat Completions path already streams `reasoning_content` deltas; the Responses API has a richer `reasoning.summary` structure that's a follow-up.

This PR delivers the primary customer value: **Opus 4.6 adaptive thinking is now reachable through the veryfront-code runtime**.

## Testing

16 new test cases under `describe(\"reasoning / thinking request options\")`:

- Anthropic: default medium effort, effort→budget mapping, explicit `budgetTokens` override, `max_tokens` clamping at model cap, temperature/top_p drop when enabled, temperature/top_p preserved when disabled, `thinking` field omitted when `enabled: false`
- OpenAI: `reasoning_effort` emission, `max`→`high` collapse, auto-detection of o1/o3/o4 reasoning models, sampling param drop on reasoning models, sampling param preservation on non-reasoning models
- Google: `thinkingConfig` emission, effort mapping, `max`→`-1`, explicit `budgetTokens` override, `thinkingConfig` absent when reasoning disabled
- Anthropic stream: `redacted_thinking` blocks pass through as content-free reasoning events

All 1341 tests pass (16,341 steps in 22s). `deno fmt --check` + `deno check` clean.

## Version

Patch bump `0.1.208 → 0.1.209`.

## Test plan

- [x] \`deno test --no-check --allow-all src/provider/runtime-loader.test.ts\`
- [x] \`deno fmt --check\`
- [x] \`deno check src/provider/runtime-loader.ts src/provider/runtime-loader.test.ts\`
- [x] Full suite via pre-push hook (1341 tests)