### PR TITLE
Repair streamed child-tool args before file writes fail

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.206",
+  "version": "0.1.207",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/data-stream.test.ts
+++ b/src/agent/data-stream.test.ts
@@ -83,4 +83,19 @@ describe("agent/data-stream", () => {
       { query: "Veryfront" },
     );
   });
+
+  it("repairs placeholder deltas when the provider streams the object body without a leading brace", () => {
+    assertEquals(
+      stripLeadingEmptyObjectPlaceholder('{}"path":"/plans/report.md","content":"# Report"}'),
+      '{"path":"/plans/report.md","content":"# Report"}',
+    );
+    assertEquals(
+      mergeToolInputDelta("{}", '"path":"/plans/report.md","content":"# Report"}'),
+      '{"path":"/plans/report.md","content":"# Report"}',
+    );
+    assertEquals(
+      parseToolInputObject('{}"path":"/plans/report.md","content":"# Report"}'),
+      { path: "/plans/report.md", content: "# Report" },
+    );
+  });
 });

--- a/src/agent/data-stream.ts
+++ b/src/agent/data-stream.ts
@@ -7,16 +7,34 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 export function stripLeadingEmptyObjectPlaceholder(rawArgs: string): string {
   let normalized = rawArgs.trim();
 
-  while (normalized.startsWith("{}") && normalized.slice(2).trimStart().startsWith("{")) {
-    normalized = normalized.slice(2).trimStart();
+  while (normalized.startsWith("{}")) {
+    const remainder = normalized.slice(2).trimStart();
+    if (remainder.startsWith("{")) {
+      normalized = remainder;
+      continue;
+    }
+
+    if (remainder.startsWith('"')) {
+      normalized = `{${remainder}`;
+      continue;
+    }
+
+    break;
   }
 
   return normalized;
 }
 
 export function mergeToolInputDelta(currentArguments: string, nextDelta: string): string {
-  if (currentArguments === "{}" && nextDelta.trimStart().startsWith("{")) {
-    return nextDelta;
+  if (currentArguments === "{}") {
+    const normalizedDelta = nextDelta.trimStart();
+    if (normalizedDelta.startsWith("{")) {
+      return normalizedDelta;
+    }
+
+    if (normalizedDelta.startsWith('"')) {
+      return `{${normalizedDelta}`;
+    }
   }
 
   return currentArguments + nextDelta;

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -96,6 +96,12 @@ describe("tool-helpers", () => {
       assertEquals(result.error, undefined);
     });
 
+    it("repairs placeholder-prefixed streamed object bodies that omit the opening brace", () => {
+      const result = parseToolArgs('{}"path":"/plans/report.md","content":"# Report"}');
+      assertEquals(result.args, { path: "/plans/report.md", content: "# Report" });
+      assertEquals(result.error, undefined);
+    });
+
     it("handles empty object passed directly", () => {
       const result = parseToolArgs({});
       assertEquals(result.args, {});

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -30,8 +30,19 @@ export interface ParsedToolArgs {
 function stripLeadingEmptyObjectPlaceholder(rawArgs: string): string {
   let normalized = rawArgs.trim();
 
-  while (normalized.startsWith("{}") && normalized.slice(2).trimStart().startsWith("{")) {
-    normalized = normalized.slice(2).trimStart();
+  while (normalized.startsWith("{}")) {
+    const remainder = normalized.slice(2).trimStart();
+    if (remainder.startsWith("{")) {
+      normalized = remainder;
+      continue;
+    }
+
+    if (remainder.startsWith('"')) {
+      normalized = `{${remainder}`;
+      continue;
+    }
+
+    break;
   }
 
   return normalized;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.206";
+export const VERSION = "0.1.207";


### PR DESCRIPTION
## Summary
- repair placeholder-prefixed streamed tool-input chunks when the object body arrives without its leading brace
- add regression coverage for the helper-layer parsing/merge behavior
- bump the framework release version to `0.1.207` in `deno.json` and `src/utils/version-constant.ts`

## Why
Hosted deep-research child runs were reaching the `create_file` phase with malformed streamed tool arguments, producing parse warnings and missing the required artifact write. This patch fixes the shared framework helper path instead of relying on app-specific recovery.

## Tested
- `deno test --no-check --allow-all src/agent/data-stream.test.ts src/agent/runtime/tool-helpers.test.ts`
- repo pre-push checks passed during `git push` (format, lint, typecheck, unit tests)

## Not tested
- hosted authenticated UI smoke after rollout to staging/production