### PR TITLE
feat(anthropic): short-name aliases for provider tool versions

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.209",
+  "version": "0.1.210",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.212",
+  "version": "0.1.213",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.206",
+  "version": "0.1.207",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.207",
+  "version": "0.1.208",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.210",
+  "version": "0.1.211",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.208",
+  "version": "0.1.209",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.211",
+  "version": "0.1.212",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -2970,6 +2970,125 @@ describe("provider/runtime-loader", () => {
       assertEquals(dropped, ["frequencyPenalty", "presencePenalty"]);
     });
 
+    it("emits Anthropic metadata.user_id when userId is set", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(okAnthropicResponse());
+        },
+      }, "claude-opus-4-6");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        userId: "user_42",
+      });
+      const body = captured as { metadata: { user_id: string } } | null;
+      assertEquals(body?.metadata, { user_id: "user_42" });
+    });
+
+    it("emits OpenAI user field when userId is set", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(okOpenAIResponse());
+        },
+      }, "gpt-4o-mini");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        userId: "user_42",
+      });
+      const body = captured as { user: string } | null;
+      assertEquals(body?.user, "user_42");
+    });
+
+    it("emits Google labels.user_id from userId when requestLabels is unset", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(okGoogleResponse());
+        },
+      }, "gemini-1.5-pro");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        userId: "user_42",
+      });
+      const body = captured as { labels: Record<string, string> } | null;
+      assertEquals(body?.labels, { user_id: "user_42" });
+    });
+
+    it("Google requestLabels wins over userId-derived labels", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(okGoogleResponse());
+        },
+      }, "gemini-1.5-pro");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        userId: "user_42",
+        requestLabels: { tenant: "acme", env: "prod" },
+      });
+      const body = captured as { labels: Record<string, string> } | null;
+      assertEquals(body?.labels, { tenant: "acme", env: "prod" });
+    });
+
+    it("omits provider metadata fields when userId is unset", async () => {
+      let anthropicBody: Record<string, unknown> | null = null;
+      let openaiBody: Record<string, unknown> | null = null;
+      let googleBody: Record<string, unknown> | null = null;
+
+      const anthropic = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          anthropicBody = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(okAnthropicResponse());
+        },
+      }, "claude-opus-4-6");
+      const openai = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          openaiBody = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(okOpenAIResponse());
+        },
+      }, "gpt-4o-mini");
+      const google = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          googleBody = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(okGoogleResponse());
+        },
+      }, "gemini-1.5-pro");
+
+      await anthropic.doGenerate({ prompt: [userPrompt] });
+      await openai.doGenerate({ prompt: [userPrompt] });
+      await google.doGenerate({ prompt: [userPrompt] });
+
+      assertEquals("metadata" in (anthropicBody ?? {}), false);
+      assertEquals("user" in (openaiBody ?? {}), false);
+      assertEquals("labels" in (googleBody ?? {}), false);
+    });
+
     it("warnings are present on stream results too", async () => {
       const encoder = new TextEncoder();
       const runtime = createOpenAIModelRuntime({

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -2795,4 +2795,209 @@ describe("provider/runtime-loader", () => {
       assertEquals(err.retryable, true);
     });
   });
+
+  describe("provider warnings (unsupported-setting drops)", () => {
+    const userPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Hi" }],
+    } as const;
+
+    function okAnthropicResponse() {
+      return new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "ok" }],
+          stop_reason: "end_turn",
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    function okOpenAIResponse() {
+      return new Response(
+        JSON.stringify({
+          choices: [{
+            index: 0,
+            message: { role: "assistant", content: "ok" },
+            finish_reason: "stop",
+          }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    function okGoogleResponse() {
+      return new Response(
+        JSON.stringify({
+          candidates: [{
+            content: { role: "model", parts: [{ text: "ok" }] },
+            finishReason: "STOP",
+          }],
+          usageMetadata: {
+            promptTokenCount: 1,
+            candidatesTokenCount: 1,
+            totalTokenCount: 2,
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    function settings(result: { warnings?: unknown[] }): string[] {
+      return (result.warnings ?? []).flatMap((w) => {
+        const r = w as { setting?: string };
+        return r.setting ? [r.setting] : [];
+      });
+    }
+
+    it("warns on Anthropic presencePenalty / frequencyPenalty / seed / topK", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () => Promise.resolve(okAnthropicResponse()),
+      }, "claude-opus-4-6");
+      const result = await runtime.doGenerate({
+        prompt: [userPrompt],
+        presencePenalty: 0.1,
+        frequencyPenalty: 0.2,
+        seed: 42,
+        topK: 50,
+      });
+      const dropped = settings(result).sort();
+      assertEquals(dropped, ["frequencyPenalty", "presencePenalty", "seed", "topK"]);
+    });
+
+    it("warns when Anthropic stopSequences exceeds 4 entries (and truncates)", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(okAnthropicResponse());
+        },
+      }, "claude-opus-4-6");
+      const result = await runtime.doGenerate({
+        prompt: [userPrompt],
+        stopSequences: ["a", "b", "c", "d", "e", "f"],
+      });
+      const dropped = settings(result);
+      assertEquals(dropped.includes("stopSequences"), true);
+      const capturedBody = captured as { stop_sequences: string[] } | null;
+      assertEquals(capturedBody?.stop_sequences.length, 4);
+    });
+
+    it("warns when Anthropic temperature/topP are dropped due to extended thinking", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () => Promise.resolve(okAnthropicResponse()),
+      }, "claude-opus-4-6");
+      const result = await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+        reasoning: { enabled: true, effort: "low" },
+      });
+      const dropped = settings(result).sort();
+      assertEquals(dropped, ["temperature", "topP"]);
+    });
+
+    it("emits no warnings on a clean Anthropic request", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () => Promise.resolve(okAnthropicResponse()),
+      }, "claude-opus-4-6");
+      const result = await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+        stopSequences: ["END"],
+      }) as { warnings?: unknown[] };
+      assertEquals(result.warnings, undefined);
+    });
+
+    it("warns on OpenAI topK on Chat Completions", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () => Promise.resolve(okOpenAIResponse()),
+      }, "gpt-4o-mini");
+      const result = await runtime.doGenerate({
+        prompt: [userPrompt],
+        topK: 50,
+      });
+      assertEquals(settings(result), ["topK"]);
+    });
+
+    it("warns on OpenAI sampling params dropped for o3 reasoning model", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () => Promise.resolve(okOpenAIResponse()),
+      }, "o3-mini");
+      const result = await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+        presencePenalty: 0.1,
+        frequencyPenalty: 0.1,
+      });
+      const dropped = settings(result).sort();
+      assertEquals(dropped, [
+        "frequencyPenalty",
+        "presencePenalty",
+        "temperature",
+        "topP",
+      ]);
+    });
+
+    it("warns on Google presencePenalty / frequencyPenalty drops", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: () => Promise.resolve(okGoogleResponse()),
+      }, "gemini-1.5-pro");
+      const result = await runtime.doGenerate({
+        prompt: [userPrompt],
+        presencePenalty: 0.1,
+        frequencyPenalty: 0.2,
+      });
+      const dropped = settings(result).sort();
+      assertEquals(dropped, ["frequencyPenalty", "presencePenalty"]);
+    });
+
+    it("warnings are present on stream results too", async () => {
+      const encoder = new TextEncoder();
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              ReadableStream.from([
+                encoder.encode(
+                  'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n',
+                ),
+                encoder.encode(
+                  'data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}\n\n',
+                ),
+                encoder.encode("data: [DONE]\n\n"),
+              ]),
+              { status: 200, headers: { "content-type": "text/event-stream" } },
+            ),
+          ),
+      }, "o3-mini");
+      const result = await runtime.doStream({
+        prompt: [userPrompt],
+        temperature: 0.5,
+      });
+      assertEquals(settings(result), ["temperature"]);
+      // Drain the stream to keep Deno test runner happy.
+      await collectAsync(result.stream);
+    });
+  });
 });

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -2053,6 +2053,331 @@ describe("provider/runtime-loader", () => {
     });
   });
 
+  describe("reasoning / thinking request options", () => {
+    const userPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Solve this" }],
+    } as const;
+
+    function createAnthropicCaptureRuntime(modelId = "claude-opus-4-6") {
+      let capturedBody: Record<string, unknown> | null = null;
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          capturedBody = raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, modelId);
+      return { runtime, getBody: () => capturedBody };
+    }
+
+    function createOpenAICaptureRuntime(modelId: string) {
+      let capturedBody: Record<string, unknown> | null = null;
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "test-openai-key",
+        baseURL: "https://example.openai.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          capturedBody = raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                choices: [{
+                  index: 0,
+                  message: { role: "assistant", content: "ok" },
+                  finish_reason: "stop",
+                }],
+                usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, modelId);
+      return { runtime, getBody: () => capturedBody };
+    }
+
+    function createGoogleCaptureRuntime(modelId = "gemini-2.5-pro") {
+      let capturedBody: Record<string, unknown> | null = null;
+      const runtime = createGoogleModelRuntime({
+        apiKey: "test-google-key",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          capturedBody = raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                }],
+                usageMetadata: {
+                  promptTokenCount: 1,
+                  candidatesTokenCount: 1,
+                  totalTokenCount: 2,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, modelId);
+      return { runtime, getBody: () => capturedBody };
+    }
+
+    it("emits Anthropic thinking block with medium effort budget by default", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        maxOutputTokens: 2048,
+        reasoning: { enabled: true },
+      });
+      const body = getBody() as {
+        thinking: { type: string; budget_tokens: number };
+        max_tokens: number;
+      };
+      assertEquals(body.thinking, { type: "enabled", budget_tokens: 4096 });
+      // max_tokens = baseMaxTokens(2048) + budget(4096) = 6144
+      assertEquals(body.max_tokens, 6144);
+    });
+
+    it("maps Anthropic effort levels to budget_tokens", async () => {
+      async function budgetFor(effort: "low" | "medium" | "high" | "max") {
+        const { runtime, getBody } = createAnthropicCaptureRuntime();
+        await runtime.doGenerate({
+          prompt: [userPrompt],
+          maxOutputTokens: 1024,
+          reasoning: { enabled: true, effort },
+        });
+        return (getBody() as { thinking: { budget_tokens: number } }).thinking.budget_tokens;
+      }
+      assertEquals(await budgetFor("low"), 1024);
+      assertEquals(await budgetFor("medium"), 4096);
+      assertEquals(await budgetFor("high"), 16_384);
+      assertEquals(await budgetFor("max"), 32_768);
+    });
+
+    it("honours Anthropic explicit budgetTokens over effort", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        maxOutputTokens: 1024,
+        reasoning: { enabled: true, effort: "low", budgetTokens: 12_345 },
+      });
+      const body = getBody() as { thinking: { budget_tokens: number } };
+      assertEquals(body.thinking.budget_tokens, 12_345);
+    });
+
+    it("clamps Anthropic max_tokens at the model cap when thinking is enabled", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime("claude-opus-4-6");
+      // Opus 4.6 caps at 128k. 100k base + 64k budget would be 164k — clamp to 128k.
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        maxOutputTokens: 100_000,
+        reasoning: { enabled: true, budgetTokens: 64_000 },
+      });
+      const body = getBody() as { max_tokens: number };
+      assertEquals(body.max_tokens, 128_000);
+    });
+
+    it("drops Anthropic temperature and top_p when thinking is enabled", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+        reasoning: { enabled: true },
+      });
+      const body = getBody() as Record<string, unknown>;
+      assertEquals("temperature" in body, false);
+      assertEquals("top_p" in body, false);
+    });
+
+    it("preserves Anthropic sampling params when reasoning is disabled", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+      });
+      const body = getBody() as { temperature: number; top_p: number };
+      assertEquals(body.temperature, 0.7);
+      assertEquals(body.top_p, 0.9);
+    });
+
+    it("omits Anthropic thinking field when reasoning.enabled is false", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: false, effort: "high" },
+      });
+      const body = getBody() as Record<string, unknown>;
+      assertEquals("thinking" in body, false);
+    });
+
+    it("emits OpenAI reasoning_effort when reasoning is enabled", async () => {
+      const { runtime, getBody } = createOpenAICaptureRuntime("gpt-4o-mini");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: true, effort: "high" },
+      });
+      const body = getBody() as { reasoning_effort: string };
+      assertEquals(body.reasoning_effort, "high");
+    });
+
+    it("collapses OpenAI 'max' effort to 'high'", async () => {
+      const { runtime, getBody } = createOpenAICaptureRuntime("gpt-4o-mini");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: true, effort: "max" },
+      });
+      const body = getBody() as { reasoning_effort: string };
+      assertEquals(body.reasoning_effort, "high");
+    });
+
+    it("drops OpenAI sampling params on reasoning models (o1/o3/o4)", async () => {
+      const { runtime, getBody } = createOpenAICaptureRuntime("o3-mini");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+        presencePenalty: 0.1,
+        frequencyPenalty: 0.1,
+      });
+      const body = getBody() as Record<string, unknown>;
+      assertEquals("temperature" in body, false);
+      assertEquals("top_p" in body, false);
+      assertEquals("presence_penalty" in body, false);
+      assertEquals("frequency_penalty" in body, false);
+    });
+
+    it("preserves OpenAI sampling params on non-reasoning models", async () => {
+      const { runtime, getBody } = createOpenAICaptureRuntime("gpt-4o-mini");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+      });
+      const body = getBody() as { temperature: number; top_p: number };
+      assertEquals(body.temperature, 0.7);
+      assertEquals(body.top_p, 0.9);
+    });
+
+    it("emits Google thinkingConfig when reasoning is enabled", async () => {
+      const { runtime, getBody } = createGoogleCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: true, effort: "high" },
+      });
+      const body = getBody() as {
+        generationConfig: { thinkingConfig: { includeThoughts: boolean; thinkingBudget: number } };
+      };
+      assertEquals(body.generationConfig.thinkingConfig, {
+        includeThoughts: true,
+        thinkingBudget: 8192,
+      });
+    });
+
+    it("maps Google effort 'max' to thinkingBudget: -1 (dynamic)", async () => {
+      const { runtime, getBody } = createGoogleCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: true, effort: "max" },
+      });
+      const body = getBody() as {
+        generationConfig: { thinkingConfig: { thinkingBudget: number } };
+      };
+      assertEquals(body.generationConfig.thinkingConfig.thinkingBudget, -1);
+    });
+
+    it("honours Google explicit budgetTokens over effort", async () => {
+      const { runtime, getBody } = createGoogleCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: true, effort: "low", budgetTokens: 4096 },
+      });
+      const body = getBody() as {
+        generationConfig: { thinkingConfig: { thinkingBudget: number } };
+      };
+      assertEquals(body.generationConfig.thinkingConfig.thinkingBudget, 4096);
+    });
+
+    it("omits Google thinkingConfig when reasoning is disabled", async () => {
+      const { runtime, getBody } = createGoogleCaptureRuntime();
+      await runtime.doGenerate({ prompt: [userPrompt] });
+      const body = getBody() as {
+        generationConfig?: { thinkingConfig?: unknown };
+      };
+      assertEquals(body.generationConfig?.thinkingConfig, undefined);
+    });
+
+    it("passes redacted_thinking blocks through as reasoning events without leaking content", async () => {
+      const encoder = new TextEncoder();
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              ReadableStream.from([
+                encoder.encode(
+                  'event: message_start\ndata: {"type":"message_start","message":{"id":"m1","type":"message","role":"assistant","content":[],"model":"claude-opus-4-6","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"redacted_thinking","data":"encrypted-opaque-blob"}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"ok"}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n',
+                ),
+                encoder.encode(
+                  'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n',
+                ),
+                encoder.encode(
+                  'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+                ),
+              ]),
+              { status: 200, headers: { "content-type": "text/event-stream" } },
+            ),
+          ),
+      }, "claude-opus-4-6");
+
+      const result = await runtime.doStream({ prompt: [userPrompt] });
+      const parts = await collectAsync(result.stream);
+      // Redacted thinking emits reasoning-start (block 0) + reasoning-end, but no delta.
+      const reasoningStarts = parts.filter((p) =>
+        (p as { type: string }).type === "reasoning-start"
+      );
+      const reasoningDeltas = parts.filter((p) =>
+        (p as { type: string }).type === "reasoning-delta"
+      );
+      const reasoningEnds = parts.filter((p) => (p as { type: string }).type === "reasoning-end");
+      assertEquals(reasoningStarts.length, 1);
+      assertEquals(reasoningDeltas.length, 0);
+      assertEquals(reasoningEnds.length, 1);
+    });
+  });
+
   describe("cache usage reporting (cache_creation / cache_read / cached_tokens)", () => {
     const userPrompt = {
       role: "user",

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -1888,14 +1888,14 @@ describe("provider/runtime-loader", () => {
       };
     }
 
-    const systemPrompt: RuntimePromptMessage = {
+    const systemPrompt = {
       role: "system",
       content: "You are a helpful assistant.",
-    };
-    const userPrompt: RuntimePromptMessage = {
+    } as const;
+    const userPrompt = {
       role: "user",
       content: [{ type: "text", text: "Hi" }],
-    };
+    } as const;
 
     const weatherTool = {
       type: "function" as const,
@@ -2050,6 +2050,248 @@ describe("provider/runtime-loader", () => {
       });
       const body = getBody() as Record<string, unknown>;
       assertEquals("tools" in body, false);
+    });
+  });
+
+  describe("cache usage reporting (cache_creation / cache_read / cached_tokens)", () => {
+    const userPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Hi" }],
+    } as const;
+
+    it("surfaces Anthropic cache_creation_input_tokens and cache_read_input_tokens on generate", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: {
+                  input_tokens: 12,
+                  output_tokens: 34,
+                  cache_creation_input_tokens: 2056,
+                  cache_read_input_tokens: 128,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "claude-sonnet-4-20250514");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.usage, {
+        inputTokens: 12,
+        outputTokens: 34,
+        totalTokens: 46,
+        cacheCreationInputTokens: 2056,
+        cacheReadInputTokens: 128,
+      });
+    });
+
+    it("propagates Anthropic cache fields through the stream usage accumulator", async () => {
+      const encoder = new TextEncoder();
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              ReadableStream.from([
+                // message_start carries input + cache token counts up front.
+                encoder.encode(
+                  'event: message_start\ndata: {"type":"message_start","message":{"id":"m1","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":12,"output_tokens":1,"cache_creation_input_tokens":2056,"cache_read_input_tokens":128}}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+                ),
+                // message_delta only updates output_tokens; cache fields absent here.
+                encoder.encode(
+                  'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":34}}\n\n',
+                ),
+                encoder.encode(
+                  'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+                ),
+              ]),
+              { status: 200, headers: { "content-type": "text/event-stream" } },
+            ),
+          ),
+      }, "claude-sonnet-4-20250514");
+
+      const result = await runtime.doStream({ prompt: [userPrompt] });
+      const parts = await collectAsync(result.stream);
+      const finish = parts.find((p) => (p as { type: string }).type === "finish") as {
+        usage: {
+          inputTokens?: number;
+          outputTokens?: number;
+          cacheCreationInputTokens?: number;
+          cacheReadInputTokens?: number;
+        };
+      };
+      assertEquals(finish.usage.inputTokens, 12);
+      assertEquals(finish.usage.outputTokens, 34);
+      assertEquals(finish.usage.cacheCreationInputTokens, 2056);
+      assertEquals(finish.usage.cacheReadInputTokens, 128);
+    });
+
+    it("leaves Anthropic cache fields undefined when the provider omits them", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 4, output_tokens: 2 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "claude-sonnet-4-20250514");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      // Cache fields should be absent (not zero) when provider doesn't return them.
+      assertEquals(result.usage, {
+        inputTokens: 4,
+        outputTokens: 2,
+        totalTokens: 6,
+      });
+    });
+
+    it("surfaces OpenAI prompt_tokens_details.cached_tokens as cacheReadInputTokens", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "test-openai-key",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                choices: [{
+                  index: 0,
+                  message: { role: "assistant", content: "ok" },
+                  finish_reason: "stop",
+                }],
+                usage: {
+                  prompt_tokens: 100,
+                  completion_tokens: 40,
+                  total_tokens: 140,
+                  prompt_tokens_details: { cached_tokens: 80 },
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "gpt-4o-mini");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.usage, {
+        inputTokens: 100,
+        outputTokens: 40,
+        totalTokens: 140,
+        cacheReadInputTokens: 80,
+      });
+    });
+
+    it("leaves OpenAI cache field undefined when prompt_tokens_details is absent", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "test-openai-key",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                choices: [{
+                  index: 0,
+                  message: { role: "assistant", content: "ok" },
+                  finish_reason: "stop",
+                }],
+                usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "gpt-4o-mini");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.usage, {
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+      });
+    });
+
+    it("surfaces Google cachedContentTokenCount as cacheReadInputTokens", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "test-google-key",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                }],
+                usageMetadata: {
+                  promptTokenCount: 123,
+                  candidatesTokenCount: 45,
+                  totalTokenCount: 168,
+                  cachedContentTokenCount: 100,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "gemini-1.5-pro");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.usage, {
+        inputTokens: 123,
+        outputTokens: 45,
+        totalTokens: 168,
+        cacheReadInputTokens: 100,
+      });
+    });
+
+    it("leaves Google cache field undefined when cachedContentTokenCount is absent", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "test-google-key",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                }],
+                usageMetadata: {
+                  promptTokenCount: 8,
+                  candidatesTokenCount: 2,
+                  totalTokenCount: 10,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "gemini-1.5-pro");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.usage, {
+        inputTokens: 8,
+        outputTokens: 2,
+        totalTokens: 10,
+      });
     });
   });
 });

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -1,6 +1,12 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { createAnthropicModelRuntime } from "./runtime-loader.ts";
+import {
+  createAnthropicModelRuntime,
+  ProviderOverloadedError,
+  ProviderQuotaError,
+  ProviderRateLimitError,
+  ProviderRequestError,
+} from "./runtime-loader.ts";
 import { createRuntimeJsonSchema } from "../agent/runtime/runtime-tool-builder.ts";
 import {
   createGoogleEmbeddingRuntime,
@@ -2617,6 +2623,176 @@ describe("provider/runtime-loader", () => {
         outputTokens: 2,
         totalTokens: 10,
       });
+    });
+  });
+
+  describe("transient error classification (529 / 503 / 429 / Retry-After)", () => {
+    const userPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Hi" }],
+    } as const;
+
+    function errorResponse(status: number, body: unknown, headers?: Record<string, string>) {
+      return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json", ...headers },
+      });
+    }
+
+    async function expectError<E extends Error>(
+      promise: PromiseLike<unknown>,
+      errorClass: new (...args: never[]) => E,
+    ): Promise<E> {
+      try {
+        await promise;
+        throw new Error("Expected promise to reject, but it resolved");
+      } catch (err) {
+        if (!(err instanceof errorClass)) {
+          throw new Error(
+            `Expected ${errorClass.name}, got ${err instanceof Error ? err.name : typeof err}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+        return err;
+      }
+    }
+
+    it("classifies Anthropic 529 as ProviderOverloadedError (retryable)", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            errorResponse(529, { error: { type: "overloaded_error", message: "Overloaded" } }),
+          ),
+      }, "claude-opus-4-6");
+      const err = await expectError(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        ProviderOverloadedError,
+      );
+      assertEquals(err.provider, "anthropic");
+      assertEquals(err.status, 529);
+      assertEquals(err.retryable, true);
+    });
+
+    it("classifies OpenAI 503 as ProviderOverloadedError (retryable)", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () => Promise.resolve(errorResponse(503, { error: { message: "Service down" } })),
+      }, "gpt-4o-mini");
+      const err = await expectError(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        ProviderOverloadedError,
+      );
+      assertEquals(err.provider, "openai");
+      assertEquals(err.status, 503);
+      assertEquals(err.retryable, true);
+    });
+
+    it("classifies OpenAI 429 rate_limit_exceeded as ProviderRateLimitError with Retry-After", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            errorResponse(
+              429,
+              { error: { code: "rate_limit_exceeded", message: "Slow down" } },
+              { "retry-after": "12" },
+            ),
+          ),
+      }, "gpt-4o-mini");
+      const err = await expectError(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        ProviderRateLimitError,
+      );
+      assertEquals(err.provider, "openai");
+      assertEquals(err.status, 429);
+      assertEquals(err.retryable, true);
+      assertEquals(err.retryAfterMs, 12_000);
+    });
+
+    it("classifies OpenAI 429 insufficient_quota as ProviderQuotaError (non-retryable)", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            errorResponse(429, {
+              error: { code: "insufficient_quota", message: "Out of credits" },
+            }),
+          ),
+      }, "gpt-4o-mini");
+      const err = await expectError(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        ProviderQuotaError,
+      );
+      assertEquals(err.retryable, false);
+    });
+
+    it("classifies Google 503 as ProviderOverloadedError (retryable)", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: () =>
+          Promise.resolve(errorResponse(503, { error: { code: 503, message: "Unavailable" } })),
+      }, "gemini-1.5-pro");
+      const err = await expectError(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        ProviderOverloadedError,
+      );
+      assertEquals(err.provider, "google");
+      assertEquals(err.retryable, true);
+    });
+
+    it("classifies Google 429 RESOURCE_EXHAUSTED as ProviderQuotaError (non-retryable)", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: () =>
+          Promise.resolve(
+            errorResponse(429, {
+              error: { code: 429, status: "RESOURCE_EXHAUSTED", message: "Daily quota" },
+            }),
+          ),
+      }, "gemini-1.5-pro");
+      const err = await expectError(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        ProviderQuotaError,
+      );
+      assertEquals(err.retryable, false);
+    });
+
+    it("preserves non-retryable 4xx as ProviderRequestError", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () => Promise.resolve(errorResponse(400, { error: { message: "Bad request" } })),
+      }, "gpt-4o-mini");
+      const err = await expectError(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        ProviderRequestError,
+      );
+      assertEquals(err.retryable, false);
+      assertEquals(err.status, 400);
+    });
+
+    it("classifies stream-mode 529 the same as JSON-mode", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            errorResponse(529, { error: { type: "overloaded_error", message: "Overloaded" } }),
+          ),
+      }, "claude-opus-4-6");
+      const err = await expectError(
+        runtime.doStream({ prompt: [userPrompt] }),
+        ProviderOverloadedError,
+      );
+      assertEquals(err.retryable, true);
     });
   });
 });

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -1857,4 +1857,199 @@ describe("provider/runtime-loader", () => {
       assertEquals((body as { max_tokens: number }).max_tokens, 64_000);
     });
   });
+
+  describe("Anthropic prompt caching (cache_control breakpoints)", () => {
+    // Captures the outbound body for a single Anthropic generate call with a
+    // caller-provided cacheControl option. Returns the parsed body so each test
+    // can assert what landed on the wire.
+    function createCachingCaptureRuntime() {
+      let capturedBody: Record<string, unknown> | null = null;
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          capturedBody = raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "claude-sonnet-4-20250514");
+      return {
+        runtime,
+        getBody: () => capturedBody,
+      };
+    }
+
+    const systemPrompt: RuntimePromptMessage = {
+      role: "system",
+      content: "You are a helpful assistant.",
+    };
+    const userPrompt: RuntimePromptMessage = {
+      role: "user",
+      content: [{ type: "text", text: "Hi" }],
+    };
+
+    const weatherTool = {
+      type: "function" as const,
+      name: "weather",
+      description: "Get weather",
+      inputSchema: {
+        type: "object",
+        properties: { city: { type: "string" } },
+        required: ["city"],
+        additionalProperties: false,
+      },
+    };
+    const searchTool = {
+      type: "function" as const,
+      name: "search",
+      description: "Search the web",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+        additionalProperties: false,
+      },
+    };
+
+    it("defaults system to string form when cacheControl is not set", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+      });
+      const body = getBody() as { system: unknown };
+      // Backward-compat path: without a breakpoint, system stays as a raw string.
+      assertEquals(body.system, "You are a helpful assistant.");
+    });
+
+    it("emits cache_control on the system block when cacheControl.system is true", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        cacheControl: { system: true },
+      });
+      const body = getBody() as { system: Array<Record<string, unknown>> };
+      assertEquals(body.system, [{
+        type: "text",
+        text: "You are a helpful assistant.",
+        cache_control: { type: "ephemeral" },
+      }]);
+    });
+
+    it('emits cache_control with 1h TTL when cacheControl.system is "1h"', async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        cacheControl: { system: "1h" },
+      });
+      const body = getBody() as { system: Array<Record<string, unknown>> };
+      assertEquals(body.system, [{
+        type: "text",
+        text: "You are a helpful assistant.",
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      }]);
+    });
+
+    it("emits cache_control on the LAST tool entry when cacheControl.tools is true", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        tools: [weatherTool, searchTool],
+        cacheControl: { tools: true },
+      });
+      const body = getBody() as { tools: Array<Record<string, unknown>> };
+      assertEquals(body.tools.length, 2);
+      // First tool is unmodified
+      assertEquals(body.tools[0], {
+        name: "weather",
+        description: "Get weather",
+        input_schema: weatherTool.inputSchema,
+      });
+      // Last tool carries the breakpoint
+      assertEquals(body.tools[1], {
+        name: "search",
+        description: "Search the web",
+        input_schema: searchTool.inputSchema,
+        cache_control: { type: "ephemeral" },
+      });
+    });
+
+    it("emits both system and tools breakpoints when both are set", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        tools: [weatherTool],
+        cacheControl: { system: true, tools: "1h" },
+      });
+      const body = getBody() as {
+        system: Array<Record<string, unknown>>;
+        tools: Array<Record<string, unknown>>;
+      };
+      assertEquals(body.system, [{
+        type: "text",
+        text: "You are a helpful assistant.",
+        cache_control: { type: "ephemeral" },
+      }]);
+      assertEquals(body.tools, [{
+        name: "weather",
+        description: "Get weather",
+        input_schema: weatherTool.inputSchema,
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      }]);
+    });
+
+    it("treats cacheControl.system === false as no-op (string form preserved)", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        cacheControl: { system: false },
+      });
+      const body = getBody() as { system: unknown };
+      assertEquals(body.system, "You are a helpful assistant.");
+    });
+
+    it("treats cacheControl.tools === false as no-op (no breakpoint attached)", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        tools: [weatherTool],
+        cacheControl: { tools: false },
+      });
+      const body = getBody() as { tools: Array<Record<string, unknown>> };
+      assertEquals(body.tools, [{
+        name: "weather",
+        description: "Get weather",
+        input_schema: weatherTool.inputSchema,
+      }]);
+    });
+
+    it("does not crash when cacheControl is set but there's no system prompt", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        cacheControl: { system: true },
+      });
+      const body = getBody() as Record<string, unknown>;
+      // No system field at all — nothing to attach the breakpoint to.
+      assertEquals("system" in body, false);
+    });
+
+    it("does not crash when cacheControl.tools is set but there's no tools array", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        cacheControl: { tools: true },
+      });
+      const body = getBody() as Record<string, unknown>;
+      assertEquals("tools" in body, false);
+    });
+  });
 });

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -3119,4 +3119,94 @@ describe("provider/runtime-loader", () => {
       await collectAsync(result.stream);
     });
   });
+
+  describe("Anthropic provider tool version aliasing", () => {
+    const userPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Run code" }],
+    } as const;
+
+    function captureBody() {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "claude-opus-4-6");
+      return { runtime, getBody: () => captured };
+    }
+
+    function toolType(body: Record<string, unknown> | null): string | undefined {
+      const tools = body?.tools as Array<{ type?: string }> | undefined;
+      return tools?.[0]?.type;
+    }
+
+    const cases: Array<[string, string]> = [
+      ["anthropic.code_execution", "code_execution_20260120"],
+      ["anthropic.computer_use", "computer_20250124"],
+      ["anthropic.computer", "computer_20250124"],
+      ["anthropic.text_editor", "text_editor_20250728"],
+      ["anthropic.bash", "bash_20250124"],
+      ["anthropic.memory", "memory_20250818"],
+      ["anthropic.web_search", "web_search_20250305"],
+      ["anthropic.web_fetch", "web_fetch_20250910"],
+    ];
+
+    for (const [shortId, expected] of cases) {
+      it(`maps ${shortId} -> ${expected}`, async () => {
+        const { runtime, getBody } = captureBody();
+        await runtime.doGenerate({
+          prompt: [userPrompt],
+          tools: [{
+            type: "provider",
+            name: "tool",
+            id: shortId as `${string}.${string}`,
+            args: {},
+          }],
+        });
+        assertEquals(toolType(getBody()), expected);
+      });
+    }
+
+    it("passes already-versioned types through verbatim", async () => {
+      const { runtime, getBody } = captureBody();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        tools: [{
+          type: "provider",
+          name: "tool",
+          id: "anthropic.code_execution_20250522",
+          args: {},
+        }],
+      });
+      assertEquals(toolType(getBody()), "code_execution_20250522");
+    });
+
+    it("leaves unknown short names unchanged", async () => {
+      const { runtime, getBody } = captureBody();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        tools: [{
+          type: "provider",
+          name: "tool",
+          id: "anthropic.future_tool",
+          args: {},
+        }],
+      });
+      assertEquals(toolType(getBody()), "future_tool");
+    });
+  });
 });

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -149,6 +149,20 @@ type OpenAICompatibleLanguageOptions = {
    * is unchanged on every provider.
    */
   reasoning?: ProviderReasoningOption;
+  /**
+   * Stable per-user identifier for rate-limiting, abuse detection, and
+   * billing attribution. Maps to:
+   *  - Anthropic: `metadata.user_id`
+   *  - OpenAI: `user`
+   *  - Google: `labels.user_id` (when {@link requestLabels} is unset)
+   */
+  userId?: string;
+  /**
+   * Provider-specific label map for Google Gemini's `labels` field.
+   * Anthropic and OpenAI don't have an arbitrary-label equivalent, so
+   * this is intentionally Google-only. When unset, no labels are sent.
+   */
+  requestLabels?: Record<string, string>;
 };
 type OpenAICompatibleChatMessage =
   | { role: "system"; content: string }
@@ -1212,6 +1226,9 @@ function buildAnthropicMessagesRequest(
       ? { tool_choice: normalizeAnthropicToolChoice(options.toolChoice) }
       : {}),
     ...(thinkingEnabled ? { thinking: { type: "enabled", budget_tokens: thinkingBudget } } : {}),
+    ...(typeof options.userId === "string" && options.userId.length > 0
+      ? { metadata: { user_id: options.userId } }
+      : {}),
   };
 
   Object.assign(body, readProviderOptions(options.providerOptions, "anthropic", providerName));
@@ -1757,6 +1774,9 @@ function buildOpenAIChatRequest(
       ? { frequency_penalty: options.frequencyPenalty }
       : {}),
     ...(reasoningEffort !== undefined ? { reasoning_effort: reasoningEffort } : {}),
+    ...(typeof options.userId === "string" && options.userId.length > 0
+      ? { user: options.userId }
+      : {}),
   };
 
   Object.assign(body, readProviderOptions(options.providerOptions, "openai", providerName));
@@ -2009,6 +2029,14 @@ function buildGoogleGenerateContentRequest(
 
   const { systemInstruction, contents } = toGoogleContents(options.prompt);
   const generationConfig = buildGoogleGenerationConfig(options);
+  // requestLabels wins over userId-derived labels: when callers explicitly
+  // provide a label map, that's the source of truth. Otherwise fall back
+  // to {user_id} derived from the unified userId option.
+  const labels = options.requestLabels && Object.keys(options.requestLabels).length > 0
+    ? options.requestLabels
+    : typeof options.userId === "string" && options.userId.length > 0
+    ? { user_id: options.userId }
+    : undefined;
   const body: GoogleCompatibleRequest = {
     contents,
     ...(systemInstruction ? { systemInstruction } : {}),
@@ -2017,6 +2045,7 @@ function buildGoogleGenerateContentRequest(
       ? { toolConfig: normalizeGoogleToolChoice(options.toolChoice) }
       : {}),
     ...(generationConfig ? { generationConfig } : {}),
+    ...(labels ? { labels } : {}),
   };
 
   Object.assign(body, readProviderOptions(options.providerOptions, "google", providerName));

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -94,6 +94,33 @@ type ProviderCacheControlOption = {
   tools?: ProviderCacheTtl;
 };
 
+/**
+ * Unified effort level for extended reasoning / thinking. Maps to
+ * per-provider knobs: Anthropic `thinking.budget_tokens`, OpenAI
+ * `reasoning_effort`, Gemini `thinkingConfig.thinkingBudget`.
+ */
+type ProviderReasoningEffort = "low" | "medium" | "high" | "max";
+
+/**
+ * Unified reasoning / thinking request option.
+ *
+ * Setting `enabled: true` turns on extended thinking on providers that
+ * support it (Anthropic Claude 4.x, OpenAI o-series, Gemini 2.5+). The
+ * `effort` field picks a coarse budget; when `budgetTokens` is set it
+ * wins for providers that take a numeric budget (Anthropic, Gemini).
+ *
+ * Providers that do not support reasoning treat this as a no-op. On
+ * Anthropic + OpenAI, enabling reasoning also disables sampling params
+ * that the providers reject in combination (`temperature`, `topP`,
+ * `topK`, `presencePenalty`, `frequencyPenalty`) — silently dropping
+ * them rather than failing the request.
+ */
+type ProviderReasoningOption = {
+  enabled?: boolean;
+  effort?: ProviderReasoningEffort;
+  budgetTokens?: number;
+};
+
 type OpenAICompatibleLanguageOptions = {
   prompt: RuntimePromptMessage[];
   maxOutputTokens?: number;
@@ -116,6 +143,12 @@ type OpenAICompatibleLanguageOptions = {
    * unchanged on every provider.
    */
   cacheControl?: ProviderCacheControlOption;
+  /**
+   * Enable extended reasoning / thinking on providers that support it.
+   * See {@link ProviderReasoningOption}. When unset, reasoning behaviour
+   * is unchanged on every provider.
+   */
+  reasoning?: ProviderReasoningOption;
 };
 type OpenAICompatibleChatMessage =
   | { role: "system"; content: string }
@@ -830,6 +863,35 @@ function resolveAnthropicMaxTokens(
   return requested;
 }
 
+/**
+ * Map a unified reasoning effort level to an Anthropic `thinking.budget_tokens`
+ * value. Anthropic's minimum accepted budget is 1024; higher tiers give Claude
+ * more headroom to explore. `max` maps to the upper bound documented for
+ * Claude 4.x family (32k tokens of thinking — caller can override via
+ * `budgetTokens` if they need more).
+ */
+function resolveAnthropicThinkingBudget(
+  option: ProviderReasoningOption | undefined,
+): number | undefined {
+  if (!option || option.enabled !== true) {
+    return undefined;
+  }
+  if (typeof option.budgetTokens === "number" && option.budgetTokens >= 1024) {
+    return option.budgetTokens;
+  }
+  switch (option.effort) {
+    case "low":
+      return 1024;
+    case "high":
+      return 16_384;
+    case "max":
+      return 32_768;
+    case "medium":
+    default:
+      return 4096;
+  }
+}
+
 function buildAnthropicMessagesRequest(
   modelId: string,
   providerName: string,
@@ -845,15 +907,35 @@ function buildAnthropicMessagesRequest(
 
   const { system, messages } = toAnthropicMessages(options.prompt, systemCacheControl);
   const anthropicTools = toAnthropicTools(options.tools, toolsCacheControl);
+  const thinkingBudget = resolveAnthropicThinkingBudget(options.reasoning);
+  const thinkingEnabled = thinkingBudget !== undefined;
+
+  // Anthropic requires max_tokens > budget_tokens when thinking is enabled.
+  // Growing max_tokens by the thinking budget preserves the caller's intended
+  // output budget, and we clamp the sum at the model's advertised maximum so
+  // the request never exceeds the API's hard cap.
+  const baseMaxTokens = resolveAnthropicMaxTokens(modelId, options.maxOutputTokens);
+  const maxTokens = thinkingEnabled
+    ? Math.min(
+      baseMaxTokens + (thinkingBudget ?? 0),
+      getAnthropicModelCapabilities(modelId).maxOutputTokens,
+    )
+    : baseMaxTokens;
 
   const body: AnthropicCompatibleRequest = {
     model: modelId,
     messages,
-    max_tokens: resolveAnthropicMaxTokens(modelId, options.maxOutputTokens),
+    max_tokens: maxTokens,
     ...(stream ? { stream: true } : {}),
     ...(system ? { system } : {}),
-    ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
-    ...(options.topP !== undefined ? { top_p: options.topP } : {}),
+    // Sampling params are mutually exclusive with thinking on Anthropic — the
+    // API rejects the combo outright. Drop them silently when thinking is on
+    // (callers see thinking's output instead of what they'd have gotten from
+    // custom sampling, which is the documented tradeoff).
+    ...(!thinkingEnabled && options.temperature !== undefined
+      ? { temperature: options.temperature }
+      : {}),
+    ...(!thinkingEnabled && options.topP !== undefined ? { top_p: options.topP } : {}),
     ...(options.stopSequences && options.stopSequences.length > 0
       ? { stop_sequences: options.stopSequences }
       : {}),
@@ -861,6 +943,7 @@ function buildAnthropicMessagesRequest(
     ...(options.toolChoice !== undefined
       ? { tool_choice: normalizeAnthropicToolChoice(options.toolChoice) }
       : {}),
+    ...(thinkingEnabled ? { thinking: { type: "enabled", budget_tokens: thinkingBudget } } : {}),
   };
 
   Object.assign(body, readProviderOptions(options.providerOptions, "anthropic", providerName));
@@ -1028,6 +1111,20 @@ async function* streamAnthropicCompatibleParts(
               delta: contentBlock.thinking,
             };
           }
+          continue;
+        }
+
+        // Redacted thinking blocks arrive as opaque encrypted payloads when
+        // Claude's safety classifier flags the reasoning trace. Surface them
+        // as a zero-length reasoning block so callers know thinking happened
+        // without leaking the (legitimately hidden) contents.
+        if (blockType === "redacted_thinking") {
+          const reasoningId = `thinking-${index}`;
+          reasoningBlocks.set(index, { id: reasoningId });
+          yield {
+            type: "reasoning-start",
+            id: reasoningId,
+          };
           continue;
         }
 
@@ -1288,19 +1385,59 @@ function extractOpenAIToolCalls(message: Record<string, unknown>): Array<{
   return normalized;
 }
 
+/**
+ * OpenAI reasoning models (o1 / o3 / o4 family) use the completion path but
+ * have different constraints than chat models: sampling params are rejected,
+ * and they accept a `reasoning_effort` field. We detect them by model id
+ * prefix so callers don't have to configure it per runtime.
+ */
+function isOpenAIReasoningModel(modelId: string): boolean {
+  return /^o[134](-|$)/.test(modelId);
+}
+
+/**
+ * Map the unified reasoning effort to OpenAI's `reasoning_effort` enum.
+ * OpenAI doesn't accept "max" — we collapse it to "high".
+ */
+function resolveOpenAIReasoningEffort(
+  option: ProviderReasoningOption | undefined,
+): "low" | "medium" | "high" | undefined {
+  if (!option || option.enabled !== true) {
+    return undefined;
+  }
+  switch (option.effort) {
+    case "low":
+      return "low";
+    case "high":
+    case "max":
+      return "high";
+    case "medium":
+    default:
+      return "medium";
+  }
+}
+
 function buildOpenAIChatRequest(
   modelId: string,
   providerName: string,
   options: OpenAICompatibleLanguageOptions,
   stream: boolean,
 ): OpenAICompatibleChatRequest {
+  const isReasoningModel = isOpenAIReasoningModel(modelId);
+  const reasoningEffort = resolveOpenAIReasoningEffort(options.reasoning);
+  const reasoningEnabled = isReasoningModel || reasoningEffort !== undefined;
+
   const body: OpenAICompatibleChatRequest = {
     model: modelId,
     messages: toOpenAICompatibleMessages(options.prompt),
     ...(stream ? { stream: true, stream_options: { include_usage: true } } : {}),
     ...(options.maxOutputTokens !== undefined ? { max_tokens: options.maxOutputTokens } : {}),
-    ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
-    ...(options.topP !== undefined ? { top_p: options.topP } : {}),
+    // OpenAI reasoning models reject temperature / top_p / frequency / presence.
+    // Drop them silently rather than letting the API bounce the request.
+    ...(!reasoningEnabled && options.temperature !== undefined
+      ? { temperature: options.temperature }
+      : {}),
+    ...(!reasoningEnabled && options.topP !== undefined ? { top_p: options.topP } : {}),
     ...(options.stopSequences && options.stopSequences.length > 0
       ? { stop: options.stopSequences }
       : {}),
@@ -1309,10 +1446,13 @@ function buildOpenAIChatRequest(
       : {}),
     ...(options.toolChoice !== undefined ? { tool_choice: options.toolChoice } : {}),
     ...(options.seed !== undefined ? { seed: options.seed } : {}),
-    ...(options.presencePenalty !== undefined ? { presence_penalty: options.presencePenalty } : {}),
-    ...(options.frequencyPenalty !== undefined
+    ...(!reasoningEnabled && options.presencePenalty !== undefined
+      ? { presence_penalty: options.presencePenalty }
+      : {}),
+    ...(!reasoningEnabled && options.frequencyPenalty !== undefined
       ? { frequency_penalty: options.frequencyPenalty }
       : {}),
+    ...(reasoningEffort !== undefined ? { reasoning_effort: reasoningEffort } : {}),
   };
 
   Object.assign(body, readProviderOptions(options.providerOptions, "openai", providerName));
@@ -1483,9 +1623,46 @@ function normalizeGoogleToolChoice(toolChoice: unknown):
   return undefined;
 }
 
+/**
+ * Map the unified reasoning option to Gemini's thinkingConfig. Gemini 2.5+
+ * accepts `includeThoughts: true` to stream back `thought` parts, and
+ * `thinkingBudget: N` to cap the thinking token count. The effort levels
+ * here follow Google's own guidance (low ~= 512, medium ~= 2048,
+ * high ~= 8192, max = -1 means "dynamic/no cap").
+ */
+function resolveGoogleThinkingConfig(
+  option: ProviderReasoningOption | undefined,
+): Record<string, unknown> | undefined {
+  if (!option || option.enabled !== true) {
+    return undefined;
+  }
+  const config: Record<string, unknown> = { includeThoughts: true };
+  if (typeof option.budgetTokens === "number") {
+    config.thinkingBudget = option.budgetTokens;
+    return config;
+  }
+  switch (option.effort) {
+    case "low":
+      config.thinkingBudget = 512;
+      break;
+    case "high":
+      config.thinkingBudget = 8192;
+      break;
+    case "max":
+      config.thinkingBudget = -1;
+      break;
+    case "medium":
+    default:
+      config.thinkingBudget = 2048;
+      break;
+  }
+  return config;
+}
+
 function buildGoogleGenerationConfig(
   options: OpenAICompatibleLanguageOptions,
 ): Record<string, unknown> | undefined {
+  const thinkingConfig = resolveGoogleThinkingConfig(options.reasoning);
   const config: Record<string, unknown> = {
     ...(options.maxOutputTokens !== undefined ? { maxOutputTokens: options.maxOutputTokens } : {}),
     ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
@@ -1495,6 +1672,7 @@ function buildGoogleGenerationConfig(
       ? { stopSequences: options.stopSequences }
       : {}),
     ...(options.seed !== undefined ? { seed: options.seed } : {}),
+    ...(thinkingConfig ? { thinkingConfig } : {}),
   };
 
   return Object.keys(config).length > 0 ? config : undefined;

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -955,6 +955,37 @@ function toAnthropicMessages(
   return { system: joined, messages };
 }
 
+/**
+ * Short-name → latest-versioned-type alias map for Anthropic provider tools.
+ *
+ * Anthropic tool types are date-stamped (e.g. `code_execution_20260120`) so
+ * callers either pin a version or get the latest. We accept both: a caller
+ * can pass `anthropic.code_execution` and we map to the latest known version,
+ * or pass `anthropic.code_execution_20250522` and we forward verbatim.
+ *
+ * Versions chosen here are the latest documented releases as of 2026-04-15
+ * — see https://docs.claude.com/en/docs/agents-and-tools/tool-use/overview.
+ * When Anthropic ships newer versions, update this map.
+ */
+const ANTHROPIC_TOOL_VERSION_ALIASES: Record<string, string> = {
+  code_execution: "code_execution_20260120",
+  computer_use: "computer_20250124",
+  computer: "computer_20250124",
+  text_editor: "text_editor_20250728",
+  bash: "bash_20250124",
+  memory: "memory_20250818",
+  web_search: "web_search_20250305",
+  web_fetch: "web_fetch_20250910",
+};
+
+function resolveAnthropicProviderType(rawType: string): string {
+  // Already-versioned types (contain a date stamp suffix) pass through verbatim.
+  if (/_\d{8}$/.test(rawType)) {
+    return rawType;
+  }
+  return ANTHROPIC_TOOL_VERSION_ALIASES[rawType] ?? rawType;
+}
+
 function toAnthropicTools(
   tools: RuntimeToolDefinition[] | undefined,
   toolsCacheControl?: { type: "ephemeral"; ttl?: "1h" },
@@ -979,13 +1010,13 @@ function toAnthropicTools(
       continue;
     }
 
-    const providerType = tool.id.slice("anthropic.".length);
-    if (providerType.length === 0) {
+    const rawType = tool.id.slice("anthropic.".length);
+    if (rawType.length === 0) {
       continue;
     }
 
     normalized.push({
-      type: providerType,
+      type: resolveAnthropicProviderType(rawType),
       name: tool.name,
       ...toSnakeCaseRecord(tool.args),
     });

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -365,9 +365,167 @@ function extractGoogleUsageTokens(payload: unknown): number | undefined {
   return typeof promptTokenCount === "number" ? promptTokenCount : undefined;
 }
 
-async function readErrorMessage(response: Response): Promise<string> {
-  const text = await response.text();
-  return text.trim() || `${response.status} ${response.statusText}`.trim();
+type ProviderKind = "anthropic" | "openai" | "google";
+
+/**
+ * Base class for typed provider errors. The `retryable` flag is the
+ * primary signal for callers (or a retry wrapper) to decide whether to
+ * re-issue the request. `retryAfterMs` is set when the provider gave an
+ * explicit delay hint (Retry-After header, Retry-Info trailer).
+ */
+export class ProviderError extends Error {
+  readonly provider: ProviderKind;
+  readonly status: number;
+  readonly retryable: boolean;
+  readonly retryAfterMs?: number;
+
+  constructor(options: {
+    provider: ProviderKind;
+    status: number;
+    message: string;
+    retryable: boolean;
+    retryAfterMs?: number;
+  }) {
+    super(options.message);
+    this.name = new.target.name;
+    this.provider = options.provider;
+    this.status = options.status;
+    this.retryable = options.retryable;
+    if (options.retryAfterMs !== undefined) {
+      this.retryAfterMs = options.retryAfterMs;
+    }
+  }
+}
+
+/** Provider reports it is overloaded (Anthropic 529, OpenAI/Google 503). */
+export class ProviderOverloadedError extends ProviderError {}
+
+/** Provider is rate limiting this API key (OpenAI/Google 429 with Retry-After). */
+export class ProviderRateLimitError extends ProviderError {}
+
+/** Provider account quota is exhausted — non-retryable. */
+export class ProviderQuotaError extends ProviderError {}
+
+/** Non-retryable 4xx/5xx that doesn't fit another bucket. */
+export class ProviderRequestError extends ProviderError {}
+
+function parseRetryAfterMs(header: string | null): number | undefined {
+  if (!header) return undefined;
+  const asNumber = Number(header);
+  if (Number.isFinite(asNumber) && asNumber >= 0) {
+    return Math.round(asNumber * 1000);
+  }
+  // HTTP-date form (rare in practice for LLM providers).
+  const parsed = Date.parse(header);
+  if (!Number.isNaN(parsed)) {
+    return Math.max(0, parsed - Date.now());
+  }
+  return undefined;
+}
+
+/**
+ * Inspect a non-2xx response and build the most specific ProviderError
+ * subclass we can. Reads the response body as text (it's already dead
+ * on the wire by this point). Body classification handles the cases
+ * where HTTP status alone is ambiguous — notably OpenAI
+ * `insufficient_quota` vs `rate_limit_exceeded` both arriving as 429.
+ */
+async function buildProviderError(
+  provider: ProviderKind,
+  response: Response,
+): Promise<ProviderError> {
+  const rawBody = await response.text();
+  const message = rawBody.trim() || `${response.status} ${response.statusText}`.trim();
+  const status = response.status;
+  const retryAfterMs = parseRetryAfterMs(response.headers.get("retry-after"));
+
+  const parsedBody = (() => {
+    try {
+      return JSON.parse(rawBody) as Record<string, unknown>;
+    } catch {
+      return undefined;
+    }
+  })();
+  const errorRecord = readRecord(parsedBody?.error);
+  const errorCode = typeof errorRecord?.code === "string"
+    ? errorRecord.code
+    : typeof errorRecord?.type === "string"
+    ? errorRecord.type
+    : typeof errorRecord?.status === "string"
+    ? errorRecord.status
+    : undefined;
+
+  // Anthropic 529 = overloaded. Anthropic surfaces this with
+  // { error: { type: "overloaded_error" } } in the body.
+  if (provider === "anthropic" && status === 529) {
+    return new ProviderOverloadedError({
+      provider,
+      status,
+      message,
+      retryable: true,
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    });
+  }
+
+  // OpenAI / Google 503 = overloaded.
+  if ((provider === "openai" || provider === "google") && status === 503) {
+    return new ProviderOverloadedError({
+      provider,
+      status,
+      message,
+      retryable: true,
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    });
+  }
+
+  // OpenAI 429 splits based on the error code in the body:
+  //  - insufficient_quota → hard quota, non-retryable
+  //  - rate_limit_exceeded / tokens_per_min_exceeded → retry with Retry-After
+  if (provider === "openai" && status === 429) {
+    if (errorCode === "insufficient_quota") {
+      return new ProviderQuotaError({
+        provider,
+        status,
+        message,
+        retryable: false,
+      });
+    }
+    return new ProviderRateLimitError({
+      provider,
+      status,
+      message,
+      retryable: true,
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    });
+  }
+
+  // Google 429 RESOURCE_EXHAUSTED is almost always the daily free-tier
+  // quota — surface as a hard quota error so callers don't hot-loop on
+  // retries that can't possibly succeed until midnight UTC.
+  if (provider === "google" && status === 429) {
+    if (errorCode === "RESOURCE_EXHAUSTED") {
+      return new ProviderQuotaError({
+        provider,
+        status,
+        message,
+        retryable: false,
+      });
+    }
+    return new ProviderRateLimitError({
+      provider,
+      status,
+      message,
+      retryable: true,
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    });
+  }
+
+  return new ProviderRequestError({
+    provider,
+    status,
+    message,
+    retryable: false,
+  });
 }
 
 async function requestJson(options: {
@@ -375,11 +533,13 @@ async function requestJson(options: {
   fetchImpl: typeof globalThis.fetch;
   init: RequestInit;
   providerLabel: string;
+  providerKind: ProviderKind;
 }): Promise<unknown> {
   const response = await options.fetchImpl(options.url, options.init);
   if (!response.ok) {
-    const message = await readErrorMessage(response);
-    throw new Error(`${options.providerLabel} request failed: ${message}`);
+    const err = await buildProviderError(options.providerKind, response);
+    err.message = `${options.providerLabel} request failed: ${err.message}`;
+    throw err;
   }
 
   return response.json();
@@ -390,15 +550,22 @@ async function requestStream(options: {
   fetchImpl: typeof globalThis.fetch;
   init: RequestInit;
   providerLabel: string;
+  providerKind: ProviderKind;
 }): Promise<ReadableStream<Uint8Array>> {
   const response = await options.fetchImpl(options.url, options.init);
   if (!response.ok) {
-    const message = await readErrorMessage(response);
-    throw new Error(`${options.providerLabel} request failed: ${message}`);
+    const err = await buildProviderError(options.providerKind, response);
+    err.message = `${options.providerLabel} request failed: ${err.message}`;
+    throw err;
   }
 
   if (!response.body) {
-    throw new Error(`${options.providerLabel} request failed: stream body missing`);
+    throw new ProviderRequestError({
+      provider: options.providerKind,
+      status: response.status,
+      message: `${options.providerLabel} request failed: stream body missing`,
+      retryable: false,
+    });
   }
 
   return response.body;
@@ -2096,6 +2263,7 @@ export function createOpenAIModelRuntime(
         url,
         fetchImpl,
         providerLabel: config.name ?? "openai",
+        providerKind: "openai",
         init: {
           method: "POST",
           headers: createRequestHeaders({
@@ -2116,6 +2284,7 @@ export function createOpenAIModelRuntime(
         url,
         fetchImpl,
         providerLabel: config.name ?? "openai",
+        providerKind: "openai",
         init: {
           method: "POST",
           headers: createRequestHeaders({
@@ -2156,6 +2325,7 @@ export function createAnthropicModelRuntime(
         url,
         fetchImpl,
         providerLabel: config.name ?? "anthropic",
+        providerKind: "anthropic",
         init: {
           method: "POST",
           headers: createAnthropicRequestHeaders({
@@ -2181,6 +2351,7 @@ export function createAnthropicModelRuntime(
         url,
         fetchImpl,
         providerLabel: config.name ?? "anthropic",
+        providerKind: "anthropic",
         init: {
           method: "POST",
           headers: createAnthropicRequestHeaders({
@@ -2216,6 +2387,7 @@ export function createGoogleModelRuntime(
         url,
         fetchImpl,
         providerLabel: config.name ?? "google",
+        providerKind: "google",
         init: {
           method: "POST",
           headers: createRequestHeaders({
@@ -2236,6 +2408,7 @@ export function createGoogleModelRuntime(
         url,
         fetchImpl,
         providerLabel: config.name ?? "google",
+        providerKind: "google",
         init: {
           method: "POST",
           headers: createRequestHeaders({
@@ -2276,6 +2449,7 @@ export function createOpenAIEmbeddingRuntime(
         url,
         fetchImpl,
         providerLabel: config.name ?? "openai",
+        providerKind: "openai",
         init: {
           method: "POST",
           headers: {
@@ -2324,6 +2498,7 @@ export function createGoogleEmbeddingRuntime(
           url,
           fetchImpl,
           providerLabel: config.name ?? "google",
+          providerKind: "google",
           init: {
             method: "POST",
             headers: {

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -518,9 +518,15 @@ function normalizeAnthropicFinishReason(
   }
 }
 
-function extractAnthropicUsage(payload: unknown):
-  | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
-  | undefined {
+type RuntimeUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+};
+
+function extractAnthropicUsage(payload: unknown): RuntimeUsage | undefined {
   const record = readRecord(payload);
   const usage = readRecord(record?.usage);
   if (!usage) {
@@ -529,6 +535,8 @@ function extractAnthropicUsage(payload: unknown):
 
   const inputTokens = usage.input_tokens;
   const outputTokens = usage.output_tokens;
+  const cacheCreationInputTokens = usage.cache_creation_input_tokens;
+  const cacheReadInputTokens = usage.cache_read_input_tokens;
 
   return {
     inputTokens: typeof inputTokens === "number" ? inputTokens : undefined,
@@ -537,17 +545,15 @@ function extractAnthropicUsage(payload: unknown):
       ? (typeof inputTokens === "number" ? inputTokens : 0) +
         (typeof outputTokens === "number" ? outputTokens : 0)
       : undefined,
+    ...(typeof cacheCreationInputTokens === "number" ? { cacheCreationInputTokens } : {}),
+    ...(typeof cacheReadInputTokens === "number" ? { cacheReadInputTokens } : {}),
   };
 }
 
 function mergeUsage(
-  current:
-    | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
-    | undefined,
-  next:
-    | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
-    | undefined,
-): { inputTokens?: number; outputTokens?: number; totalTokens?: number } | undefined {
+  current: RuntimeUsage | undefined,
+  next: RuntimeUsage | undefined,
+): RuntimeUsage | undefined {
   if (!current) {
     return next;
   }
@@ -558,11 +564,16 @@ function mergeUsage(
 
   const inputTokens = next.inputTokens ?? current.inputTokens;
   const outputTokens = next.outputTokens ?? current.outputTokens;
+  const cacheCreationInputTokens = next.cacheCreationInputTokens ??
+    current.cacheCreationInputTokens;
+  const cacheReadInputTokens = next.cacheReadInputTokens ?? current.cacheReadInputTokens;
 
   return {
     inputTokens,
     outputTokens,
     totalTokens: (inputTokens ?? 0) + (outputTokens ?? 0),
+    ...(cacheCreationInputTokens !== undefined ? { cacheCreationInputTokens } : {}),
+    ...(cacheReadInputTokens !== undefined ? { cacheReadInputTokens } : {}),
   };
 }
 
@@ -863,7 +874,7 @@ function buildAnthropicGenerateResult(payload: unknown): {
     | { type: "tool-result"; toolCallId: string; toolName: string; result: unknown }
   >;
   finishReason?: string | { unified: string; raw: string } | null;
-  usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+  usage?: RuntimeUsage;
 } {
   const record = readRecord(payload);
   const content = Array.isArray(record?.content) ? record.content : [];
@@ -968,7 +979,7 @@ async function* streamAnthropicCompatibleParts(
   const toolCalls = new Map<number, AnthropicStreamToolCallState>();
   const reasoningBlocks = new Map<number, AnthropicStreamReasoningState>();
   let finishReason: string | { unified: string; raw: string } | null = null;
-  let usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number } | undefined;
+  let usage: RuntimeUsage | undefined;
 
   for await (const chunk of stream) {
     buffer += decoder.decode(chunk, { stream: true });
@@ -1205,9 +1216,7 @@ function normalizeOpenAIFinishReason(
   return raw;
 }
 
-function extractOpenAIUsage(payload: unknown):
-  | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
-  | undefined {
+function extractOpenAIUsage(payload: unknown): RuntimeUsage | undefined {
   const record = readRecord(payload);
   const usage = readRecord(record?.usage);
   if (!usage) {
@@ -1217,11 +1226,14 @@ function extractOpenAIUsage(payload: unknown):
   const inputTokens = usage.prompt_tokens;
   const outputTokens = usage.completion_tokens;
   const totalTokens = usage.total_tokens;
+  const promptTokensDetails = readRecord(usage.prompt_tokens_details);
+  const cachedTokens = promptTokensDetails?.cached_tokens;
 
   return {
     inputTokens: typeof inputTokens === "number" ? inputTokens : undefined,
     outputTokens: typeof outputTokens === "number" ? outputTokens : undefined,
     totalTokens: typeof totalTokens === "number" ? totalTokens : undefined,
+    ...(typeof cachedTokens === "number" ? { cacheReadInputTokens: cachedTokens } : {}),
   };
 }
 
@@ -1327,9 +1339,7 @@ function normalizeGoogleFinishReason(
   }
 }
 
-function extractGoogleUsage(payload: unknown):
-  | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
-  | undefined {
+function extractGoogleUsage(payload: unknown): RuntimeUsage | undefined {
   const record = readRecord(payload);
   const usage = readRecord(record?.usageMetadata);
   if (!usage) {
@@ -1339,11 +1349,15 @@ function extractGoogleUsage(payload: unknown):
   const inputTokens = usage.promptTokenCount;
   const outputTokens = usage.candidatesTokenCount;
   const totalTokens = usage.totalTokenCount;
+  const cachedContentTokenCount = usage.cachedContentTokenCount;
 
   return {
     inputTokens: typeof inputTokens === "number" ? inputTokens : undefined,
     outputTokens: typeof outputTokens === "number" ? outputTokens : undefined,
     totalTokens: typeof totalTokens === "number" ? totalTokens : undefined,
+    ...(typeof cachedContentTokenCount === "number"
+      ? { cacheReadInputTokens: cachedContentTokenCount }
+      : {}),
   };
 }
 
@@ -1537,7 +1551,7 @@ function buildGoogleGenerateResult(payload: unknown): {
     | { type: "tool-call"; toolCallId: string; toolName: string; input: string }
   >;
   finishReason?: string | { unified: string; raw: string } | null;
-  usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+  usage?: RuntimeUsage;
 } {
   const parts = extractGoogleCandidateParts(payload);
   const content: Array<
@@ -1578,7 +1592,7 @@ async function* streamGoogleCompatibleParts(
   let reasoningId: string | null = null;
   let reasoningIndex = 0;
   let finishReason: string | { unified: string; raw: string } | null = null;
-  let usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number } | undefined;
+  let usage: RuntimeUsage | undefined;
 
   for await (const chunk of stream) {
     buffer += decoder.decode(chunk, { stream: true });
@@ -1710,7 +1724,7 @@ function buildOpenAIGenerateResult(payload: unknown): {
     }
   >;
   finishReason?: string | { unified: string; raw: string } | null;
-  usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+  usage?: RuntimeUsage;
 } {
   const choice = extractFirstChoice(payload);
   const message = readRecord(choice?.message);
@@ -1741,7 +1755,7 @@ async function* streamOpenAICompatibleParts(
   let reasoningId: string | null = null;
   let reasoningIndex = 0;
   let finishReason: string | { unified: string; raw: string } | null = null;
-  let usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number } | undefined;
+  let usage: RuntimeUsage | undefined;
 
   for await (const chunk of stream) {
     buffer += decoder.decode(chunk, { stream: true });

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -60,6 +60,40 @@ type RuntimeToolDefinition =
     id: `${string}.${string}`;
     args: Record<string, unknown>;
   };
+/**
+ * TTL for a single prompt-cache breakpoint.
+ *
+ * `true` and `"5m"` both map to Anthropic's default ephemeral (5-minute) cache.
+ * `"1h"` maps to the extended 1-hour cache at a 2x write cost. Callers can
+ * pick per breakpoint target.
+ */
+type ProviderCacheTtl = boolean | "5m" | "1h";
+
+/**
+ * Per-provider prompt / context caching controls.
+ *
+ * For Anthropic, flipping these on emits `cache_control: { type: "ephemeral" }`
+ * breakpoints on the assembled system prompt and/or the last tool definition
+ * sent to the Messages API, enabling Anthropic's explicit prompt cache.
+ *
+ * OpenAI's prompt cache is automatic on gpt-4o+ and has no request-side
+ * directive to emit, so this option is a no-op for the OpenAI runtime. Google
+ * uses a separate `cachedContent` resource model that is intentionally not
+ * covered by this option (it belongs on a dedicated Gemini-specific surface).
+ */
+type ProviderCacheControlOption = {
+  /**
+   * Attach a cache breakpoint to the final system-prompt text block.
+   * Use when the system prompt is large and reused across requests.
+   */
+  system?: ProviderCacheTtl;
+  /**
+   * Attach a cache breakpoint to the last tool definition in `tools`.
+   * Use when the tool schemas are large and identical across requests.
+   */
+  tools?: ProviderCacheTtl;
+};
+
 type OpenAICompatibleLanguageOptions = {
   prompt: RuntimePromptMessage[];
   maxOutputTokens?: number;
@@ -76,6 +110,12 @@ type OpenAICompatibleLanguageOptions = {
   providerOptions?: Record<string, unknown>;
   includeRawChunks?: boolean;
   abortSignal?: AbortSignal;
+  /**
+   * Per-provider prompt / context caching controls. See
+   * {@link ProviderCacheControlOption}. When unset, caching behaviour is
+   * unchanged on every provider.
+   */
+  cacheControl?: ProviderCacheControlOption;
 };
 type OpenAICompatibleChatMessage =
   | { role: "system"; content: string }
@@ -142,7 +182,12 @@ type AnthropicCompatibleRequest = {
   messages: AnthropicCompatibleMessage[];
   max_tokens: number;
   stream?: boolean;
-  system?: string;
+  /**
+   * String form is the classic shorthand. Array-of-blocks form is required
+   * when the system prompt carries a cache_control breakpoint, because
+   * cache_control lives on an individual content block, not on a raw string.
+   */
+  system?: string | Array<Record<string, unknown>>;
   temperature?: number;
   top_p?: number;
   stop_sequences?: string[];
@@ -558,9 +603,32 @@ function pushAnthropicUserContent(
   });
 }
 
+/**
+ * Resolves a {@link ProviderCacheTtl} into Anthropic's `cache_control` shape.
+ *
+ * Returns `undefined` when caching is not requested (`false` / `undefined`),
+ * `{ type: "ephemeral" }` for the 5-minute default (`true` / `"5m"`), or
+ * `{ type: "ephemeral", ttl: "1h" }` for the extended 1-hour cache.
+ */
+function resolveAnthropicCacheControlBlock(
+  ttl: ProviderCacheTtl | undefined,
+): { type: "ephemeral"; ttl?: "1h" } | undefined {
+  if (ttl === undefined || ttl === false) {
+    return undefined;
+  }
+  if (ttl === "1h") {
+    return { type: "ephemeral", ttl: "1h" };
+  }
+  return { type: "ephemeral" };
+}
+
 function toAnthropicMessages(
   prompt: RuntimePromptMessage[],
-): { system?: string; messages: AnthropicCompatibleMessage[] } {
+  systemCacheControl?: { type: "ephemeral"; ttl?: "1h" },
+): {
+  system?: string | Array<Record<string, unknown>>;
+  messages: AnthropicCompatibleMessage[];
+} {
   const systemParts: string[] = [];
   const messages: AnthropicCompatibleMessage[] = [];
 
@@ -603,14 +671,32 @@ function toAnthropicMessages(
     }
   }
 
-  return {
-    ...(systemParts.length > 0 ? { system: systemParts.join("\n\n") } : {}),
-    messages,
-  };
+  if (systemParts.length === 0) {
+    return { messages };
+  }
+
+  const joined = systemParts.join("\n\n");
+
+  // Cache-controlled system prompts must use the array-of-blocks form so the
+  // breakpoint lands on an individual content block. Callers that don't opt
+  // in keep the legacy raw-string form for backward compatibility.
+  if (systemCacheControl) {
+    return {
+      system: [{
+        type: "text",
+        text: joined,
+        cache_control: systemCacheControl,
+      }],
+      messages,
+    };
+  }
+
+  return { system: joined, messages };
 }
 
 function toAnthropicTools(
   tools: RuntimeToolDefinition[] | undefined,
+  toolsCacheControl?: { type: "ephemeral"; ttl?: "1h" },
 ): Array<Record<string, unknown>> | undefined {
   if (!tools) {
     return undefined;
@@ -644,7 +730,23 @@ function toAnthropicTools(
     });
   }
 
-  return normalized.length > 0 ? normalized : undefined;
+  if (normalized.length === 0) {
+    return undefined;
+  }
+
+  // Attach the cache breakpoint to the final tool entry so Anthropic caches
+  // the entire tools block up to and including that definition. Earlier tool
+  // entries are implicitly covered by the same breakpoint per Anthropic's
+  // walk-backward cache lookup behaviour.
+  if (toolsCacheControl) {
+    const lastIndex = normalized.length - 1;
+    normalized[lastIndex] = {
+      ...normalized[lastIndex],
+      cache_control: toolsCacheControl,
+    };
+  }
+
+  return normalized;
 }
 
 function createAnthropicRequestHeaders(options: {
@@ -723,7 +825,16 @@ function buildAnthropicMessagesRequest(
   options: OpenAICompatibleLanguageOptions,
   stream: boolean,
 ): AnthropicCompatibleRequest {
-  const { system, messages } = toAnthropicMessages(options.prompt);
+  const systemCacheControl = resolveAnthropicCacheControlBlock(
+    options.cacheControl?.system,
+  );
+  const toolsCacheControl = resolveAnthropicCacheControlBlock(
+    options.cacheControl?.tools,
+  );
+
+  const { system, messages } = toAnthropicMessages(options.prompt, systemCacheControl);
+  const anthropicTools = toAnthropicTools(options.tools, toolsCacheControl);
+
   const body: AnthropicCompatibleRequest = {
     model: modelId,
     messages,
@@ -735,7 +846,7 @@ function buildAnthropicMessagesRequest(
     ...(options.stopSequences && options.stopSequences.length > 0
       ? { stop_sequences: options.stopSequences }
       : {}),
-    ...(toAnthropicTools(options.tools) ? { tools: toAnthropicTools(options.tools) } : {}),
+    ...(anthropicTools ? { tools: anthropicTools } : {}),
     ...(options.toolChoice !== undefined
       ? { tool_choice: normalizeAnthropicToolChoice(options.toolChoice) }
       : {}),

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -368,6 +368,42 @@ function extractGoogleUsageTokens(payload: unknown): number | undefined {
 type ProviderKind = "anthropic" | "openai" | "google";
 
 /**
+ * Structured warning emitted when a provider runtime drops or rewrites a
+ * caller-provided option. Mirrors the AI ecosystem convention (Vercel AI
+ * SDK, LangChain) of returning `unsupported-setting` warnings on the
+ * runtime result so callers can discover silently-dropped fields without
+ * having to read the source.
+ */
+export type ProviderWarning = {
+  type: "unsupported-setting" | "other";
+  setting?: string;
+  details?: string;
+  provider: ProviderKind;
+};
+
+/**
+ * Mutable warning collector handed to per-provider request builders so
+ * they can append entries during the build pass instead of plumbing a
+ * return-tuple shape through every helper.
+ */
+type WarningCollector = {
+  push(warning: ProviderWarning): void;
+  drain(): ProviderWarning[];
+};
+
+function createWarningCollector(): WarningCollector {
+  const list: ProviderWarning[] = [];
+  return {
+    push(warning) {
+      list.push(warning);
+    },
+    drain() {
+      return list.slice();
+    },
+  };
+}
+
+/**
  * Base class for typed provider errors. The `retryable` flag is the
  * primary signal for callers (or a retry wrapper) to decide whether to
  * re-issue the request. `retryAfterMs` is set when the provider gave an
@@ -1064,6 +1100,7 @@ function buildAnthropicMessagesRequest(
   providerName: string,
   options: OpenAICompatibleLanguageOptions,
   stream: boolean,
+  warnings: WarningCollector,
 ): AnthropicCompatibleRequest {
   const systemCacheControl = resolveAnthropicCacheControlBlock(
     options.cacheControl?.system,
@@ -1076,6 +1113,70 @@ function buildAnthropicMessagesRequest(
   const anthropicTools = toAnthropicTools(options.tools, toolsCacheControl);
   const thinkingBudget = resolveAnthropicThinkingBudget(options.reasoning);
   const thinkingEnabled = thinkingBudget !== undefined;
+
+  // Anthropic doesn't support these unified options at all — emit warnings
+  // so callers don't quietly pass values that have zero effect.
+  if (options.presencePenalty !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "anthropic",
+      setting: "presencePenalty",
+      details: "Anthropic Messages API has no equivalent and the value was dropped.",
+    });
+  }
+  if (options.frequencyPenalty !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "anthropic",
+      setting: "frequencyPenalty",
+      details: "Anthropic Messages API has no equivalent and the value was dropped.",
+    });
+  }
+  if (options.seed !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "anthropic",
+      setting: "seed",
+      details: "Anthropic Messages API does not support deterministic seeding.",
+    });
+  }
+  if (options.topK !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "anthropic",
+      setting: "topK",
+      details: "Anthropic Messages API does not expose top_k on this surface.",
+    });
+  }
+  if (
+    options.stopSequences && options.stopSequences.length > 4
+  ) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "anthropic",
+      setting: "stopSequences",
+      details:
+        `Anthropic accepts at most 4 stop sequences; ${options.stopSequences.length} were provided and the extras were truncated.`,
+    });
+  }
+  if (thinkingEnabled && options.temperature !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "anthropic",
+      setting: "temperature",
+      details:
+        "Dropped because Anthropic rejects sampling params when extended thinking is enabled.",
+    });
+  }
+  if (thinkingEnabled && options.topP !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "anthropic",
+      setting: "topP",
+      details:
+        "Dropped because Anthropic rejects sampling params when extended thinking is enabled.",
+    });
+  }
 
   // Anthropic requires max_tokens > budget_tokens when thinking is enabled.
   // Growing max_tokens by the thinking budget preserves the caller's intended
@@ -1104,7 +1205,7 @@ function buildAnthropicMessagesRequest(
       : {}),
     ...(!thinkingEnabled && options.topP !== undefined ? { top_p: options.topP } : {}),
     ...(options.stopSequences && options.stopSequences.length > 0
-      ? { stop_sequences: options.stopSequences }
+      ? { stop_sequences: options.stopSequences.slice(0, 4) }
       : {}),
     ...(anthropicTools ? { tools: anthropicTools } : {}),
     ...(options.toolChoice !== undefined
@@ -1589,10 +1690,46 @@ function buildOpenAIChatRequest(
   providerName: string,
   options: OpenAICompatibleLanguageOptions,
   stream: boolean,
+  warnings: WarningCollector,
 ): OpenAICompatibleChatRequest {
   const isReasoningModel = isOpenAIReasoningModel(modelId);
   const reasoningEffort = resolveOpenAIReasoningEffort(options.reasoning);
   const reasoningEnabled = isReasoningModel || reasoningEffort !== undefined;
+
+  // OpenAI Chat Completions has no top_k surface (it's exposed only on the
+  // Responses API for some reasoning models). Quietly accepting it would
+  // mislead callers into thinking it took effect.
+  if (options.topK !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "openai",
+      setting: "topK",
+      details: "OpenAI Chat Completions does not expose top_k; the value was dropped.",
+    });
+  }
+
+  // Reasoning models (o1 / o3 / o4) reject sampling params outright. Emit
+  // warnings at build time so callers see *why* the value didn't apply
+  // rather than a 400 from the API.
+  if (reasoningEnabled) {
+    const dropped: Array<[keyof typeof options, string]> = [
+      ["temperature", "temperature"],
+      ["topP", "top_p"],
+      ["presencePenalty", "presence_penalty"],
+      ["frequencyPenalty", "frequency_penalty"],
+    ];
+    for (const [key, openaiName] of dropped) {
+      if (options[key] !== undefined) {
+        warnings.push({
+          type: "unsupported-setting",
+          provider: "openai",
+          setting: key,
+          details:
+            `Dropped because OpenAI reasoning models reject ${openaiName}. Reasoning was active for this request.`,
+        });
+      }
+    }
+  }
 
   const body: OpenAICompatibleChatRequest = {
     model: modelId,
@@ -1848,8 +1985,30 @@ function buildGoogleGenerationConfig(
 function buildGoogleGenerateContentRequest(
   providerName: string,
   options: OpenAICompatibleLanguageOptions,
+  warnings: WarningCollector,
 ): GoogleCompatibleRequest {
+  // Google generate-content surface doesn't accept presence/frequency
+  // penalties on most current models. Emit warnings and let the request
+  // through without them.
+  if (options.presencePenalty !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "google",
+      setting: "presencePenalty",
+      details: "Gemini generateContent does not accept presencePenalty; the value was dropped.",
+    });
+  }
+  if (options.frequencyPenalty !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "google",
+      setting: "frequencyPenalty",
+      details: "Gemini generateContent does not accept frequencyPenalty; the value was dropped.",
+    });
+  }
+
   const { systemInstruction, contents } = toGoogleContents(options.prompt);
+  const generationConfig = buildGoogleGenerationConfig(options);
   const body: GoogleCompatibleRequest = {
     contents,
     ...(systemInstruction ? { systemInstruction } : {}),
@@ -1857,9 +2016,7 @@ function buildGoogleGenerateContentRequest(
     ...(normalizeGoogleToolChoice(options.toolChoice)
       ? { toolConfig: normalizeGoogleToolChoice(options.toolChoice) }
       : {}),
-    ...(buildGoogleGenerationConfig(options)
-      ? { generationConfig: buildGoogleGenerationConfig(options) }
-      : {}),
+    ...(generationConfig ? { generationConfig } : {}),
   };
 
   Object.assign(body, readProviderOptions(options.providerOptions, "google", providerName));
@@ -2258,7 +2415,14 @@ export function createOpenAIModelRuntime(
     doGenerate(optionsForRuntime: unknown) {
       const options = optionsForRuntime as OpenAICompatibleLanguageOptions;
       const url = getOpenAIChatCompletionsUrl(config.baseURL);
-      const body = buildOpenAIChatRequest(modelId, config.name ?? "openai", options, false);
+      const warnings = createWarningCollector();
+      const body = buildOpenAIChatRequest(
+        modelId,
+        config.name ?? "openai",
+        options,
+        false,
+        warnings,
+      );
       return requestJson({
         url,
         fetchImpl,
@@ -2274,12 +2438,25 @@ export function createOpenAIModelRuntime(
           body: JSON.stringify(body),
           signal: options.abortSignal,
         },
-      }).then(buildOpenAIGenerateResult);
+      }).then((payload) => {
+        const drained = warnings.drain();
+        return {
+          ...buildOpenAIGenerateResult(payload),
+          ...(drained.length > 0 ? { warnings: drained } : {}),
+        };
+      });
     },
     doStream(optionsForRuntime: unknown) {
       const options = optionsForRuntime as OpenAICompatibleLanguageOptions;
       const url = getOpenAIChatCompletionsUrl(config.baseURL);
-      const body = buildOpenAIChatRequest(modelId, config.name ?? "openai", options, true);
+      const warnings = createWarningCollector();
+      const body = buildOpenAIChatRequest(
+        modelId,
+        config.name ?? "openai",
+        options,
+        true,
+        warnings,
+      );
       return requestStream({
         url,
         fetchImpl,
@@ -2295,9 +2472,13 @@ export function createOpenAIModelRuntime(
           body: JSON.stringify(body),
           signal: options.abortSignal,
         },
-      }).then((responseStream) => ({
-        stream: ReadableStream.from(streamOpenAICompatibleParts(responseStream)),
-      }));
+      }).then((responseStream) => {
+        const drained = warnings.drain();
+        return {
+          stream: ReadableStream.from(streamOpenAICompatibleParts(responseStream)),
+          ...(drained.length > 0 ? { warnings: drained } : {}),
+        };
+      });
     },
   };
 }
@@ -2315,11 +2496,13 @@ export function createAnthropicModelRuntime(
     doGenerate(optionsForRuntime: unknown) {
       const options = optionsForRuntime as OpenAICompatibleLanguageOptions;
       const url = getAnthropicMessagesUrl(config.baseURL);
+      const warnings = createWarningCollector();
       const body = buildAnthropicMessagesRequest(
         modelId,
         config.name ?? "anthropic",
         options,
         false,
+        warnings,
       );
       return requestJson({
         url,
@@ -2336,16 +2519,24 @@ export function createAnthropicModelRuntime(
           body: JSON.stringify(body),
           signal: options.abortSignal,
         },
-      }).then(buildAnthropicGenerateResult);
+      }).then((payload) => {
+        const drained = warnings.drain();
+        return {
+          ...buildAnthropicGenerateResult(payload),
+          ...(drained.length > 0 ? { warnings: drained } : {}),
+        };
+      });
     },
     doStream(optionsForRuntime: unknown) {
       const options = optionsForRuntime as OpenAICompatibleLanguageOptions;
       const url = getAnthropicMessagesUrl(config.baseURL);
+      const warnings = createWarningCollector();
       const body = buildAnthropicMessagesRequest(
         modelId,
         config.name ?? "anthropic",
         options,
         true,
+        warnings,
       );
       return requestStream({
         url,
@@ -2362,9 +2553,13 @@ export function createAnthropicModelRuntime(
           body: JSON.stringify(body),
           signal: options.abortSignal,
         },
-      }).then((responseStream) => ({
-        stream: ReadableStream.from(streamAnthropicCompatibleParts(responseStream)),
-      }));
+      }).then((responseStream) => {
+        const drained = warnings.drain();
+        return {
+          stream: ReadableStream.from(streamAnthropicCompatibleParts(responseStream)),
+          ...(drained.length > 0 ? { warnings: drained } : {}),
+        };
+      });
     },
   };
 }
@@ -2382,7 +2577,12 @@ export function createGoogleModelRuntime(
     doGenerate(optionsForRuntime: unknown) {
       const options = optionsForRuntime as OpenAICompatibleLanguageOptions;
       const url = getGoogleGenerateContentUrl(config.baseURL, modelId);
-      const body = buildGoogleGenerateContentRequest(config.name ?? "google", options);
+      const warnings = createWarningCollector();
+      const body = buildGoogleGenerateContentRequest(
+        config.name ?? "google",
+        options,
+        warnings,
+      );
       return requestJson({
         url,
         fetchImpl,
@@ -2398,12 +2598,23 @@ export function createGoogleModelRuntime(
           body: JSON.stringify(body),
           signal: options.abortSignal,
         },
-      }).then(buildGoogleGenerateResult);
+      }).then((payload) => {
+        const drained = warnings.drain();
+        return {
+          ...buildGoogleGenerateResult(payload),
+          ...(drained.length > 0 ? { warnings: drained } : {}),
+        };
+      });
     },
     doStream(optionsForRuntime: unknown) {
       const options = optionsForRuntime as OpenAICompatibleLanguageOptions;
       const url = getGoogleStreamGenerateContentUrl(config.baseURL, modelId);
-      const body = buildGoogleGenerateContentRequest(config.name ?? "google", options);
+      const warnings = createWarningCollector();
+      const body = buildGoogleGenerateContentRequest(
+        config.name ?? "google",
+        options,
+        warnings,
+      );
       return requestStream({
         url,
         fetchImpl,
@@ -2419,9 +2630,13 @@ export function createGoogleModelRuntime(
           body: JSON.stringify(body),
           signal: options.abortSignal,
         },
-      }).then((responseStream) => ({
-        stream: ReadableStream.from(streamGoogleCompatibleParts(responseStream)),
-      }));
+      }).then((responseStream) => {
+        const drained = warnings.drain();
+        return {
+          stream: ReadableStream.from(streamGoogleCompatibleParts(responseStream)),
+          ...(drained.length > 0 ? { warnings: drained } : {}),
+        };
+      });
     },
   };
 }

--- a/src/provider/types.ts
+++ b/src/provider/types.ts
@@ -9,10 +9,12 @@ export interface ModelRuntimeGenerateResult {
   content?: unknown[];
   finishReason?: unknown;
   usage?: unknown;
+  warnings?: unknown[];
 }
 
 export interface ModelRuntimeStreamResult {
   stream: ReadableStream<unknown>;
+  warnings?: unknown[];
 }
 
 export interface ModelRuntime extends RuntimeMetadata {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.211";
+export const VERSION = "0.1.212";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.208";
+export const VERSION = "0.1.209";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.210";
+export const VERSION = "0.1.211";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.207";
+export const VERSION = "0.1.208";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.212";
+export const VERSION = "0.1.213";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.206";
+export const VERSION = "0.1.207";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.209";
+export const VERSION = "0.1.210";


### PR DESCRIPTION
## Summary

Adds an alias map so callers can pass un-versioned Anthropic provider tool ids (\`anthropic.code_execution\`, \`anthropic.text_editor\`, etc.) and have the runtime forward the latest documented versioned type to the Messages API. Refs **B4** in #1051. Part of #1044. Stacked on #1063.

## Motivation

Anthropic provider tools are versioned with date stamps (e.g. \`code_execution_20260120\`, \`text_editor_20250728\`). Callers using veryfront-code today have to either pin the exact versioned id when registering provider tools or read the Anthropic docs every time a new version drops. \`@ai-sdk/anthropic\` papers over this with a short-name → versioned-name map. This PR ports the same convention.

## Aliases

| Short name | Latest versioned type |
|------------|----------------------|
| \`code_execution\` | \`code_execution_20260120\` |
| \`computer_use\` / \`computer\` | \`computer_20250124\` |
| \`text_editor\` | \`text_editor_20250728\` |
| \`bash\` | \`bash_20250124\` |
| \`memory\` | \`memory_20250818\` |
| \`web_search\` | \`web_search_20250305\` |
| \`web_fetch\` | \`web_fetch_20250910\` |

Versions chosen here are the latest documented as of 2026-04-15 — see https://docs.claude.com/en/docs/agents-and-tools/tool-use/overview.

## Backward compat

- **Already-versioned ids pass through verbatim.** \`anthropic.code_execution_20250522\` (an older but still-valid version) still produces \`type: \"code_execution_20250522\"\`. Detection is via \`/_\\d{8}\$/\` regex on the type string.
- **Unknown short names pass through unchanged.** \`anthropic.future_tool\` still produces \`type: \"future_tool\"\` so future tool releases work without code changes here.

## Testing

11 new test cases under \`describe(\"Anthropic provider tool version aliasing\")\`:

- 8 short-name → versioned-type mappings (one per alias entry)
- Pinned version pass-through (\`code_execution_20250522\`)
- Unknown short name pass-through (\`future_tool\`)
- Type extraction from outbound request body

All 1341 tests pass (16,375 steps in 23s). \`deno fmt --check\` + \`deno check\` clean.

## Version

Patch bump \`0.1.212 → 0.1.213\`.

## Test plan

- [x] \`deno test --no-check --allow-all src/provider/runtime-loader.test.ts\` — 99 steps pass
- [x] \`deno fmt --check\`
- [x] \`deno check src/provider/runtime-loader.ts src/provider/runtime-loader.test.ts\`
- [x] Full suite via pre-push hook (1341 tests / 16,375 steps)