### PR TITLE
feat(providers): provider capability audit (#1044) — consolidated

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.207",
+  "version": "0.1.208",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -1,6 +1,12 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { createAnthropicModelRuntime } from "./runtime-loader.ts";
+import {
+  createAnthropicModelRuntime,
+  ProviderOverloadedError,
+  ProviderQuotaError,
+  ProviderRateLimitError,
+  ProviderRequestError,
+} from "./runtime-loader.ts";
 import { createRuntimeJsonSchema } from "../agent/runtime/runtime-tool-builder.ts";
 import {
   createGoogleEmbeddingRuntime,
@@ -1855,6 +1861,2316 @@ describe("provider/runtime-loader", () => {
     it("does not cap caller values for unknown models (no model intel to trust)", async () => {
       const body = await generateWith("some-future-model", 64_000);
       assertEquals((body as { max_tokens: number }).max_tokens, 64_000);
+    });
+  });
+
+  describe("Anthropic prompt caching (cache_control breakpoints)", () => {
+    // Captures the outbound body for a single Anthropic generate call with a
+    // caller-provided cacheControl option. Returns the parsed body so each test
+    // can assert what landed on the wire.
+    function createCachingCaptureRuntime() {
+      let capturedBody: Record<string, unknown> | null = null;
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          capturedBody = raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "claude-sonnet-4-20250514");
+      return {
+        runtime,
+        getBody: () => capturedBody,
+      };
+    }
+
+    const systemPrompt = {
+      role: "system",
+      content: "You are a helpful assistant.",
+    } as const;
+    const userPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Hi" }],
+    } as const;
+
+    const weatherTool = {
+      type: "function" as const,
+      name: "weather",
+      description: "Get weather",
+      inputSchema: {
+        type: "object",
+        properties: { city: { type: "string" } },
+        required: ["city"],
+        additionalProperties: false,
+      },
+    };
+    const searchTool = {
+      type: "function" as const,
+      name: "search",
+      description: "Search the web",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+        additionalProperties: false,
+      },
+    };
+
+    it("defaults system to string form when cacheControl is not set", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+      });
+      const body = getBody() as { system: unknown };
+      // Backward-compat path: without a breakpoint, system stays as a raw string.
+      assertEquals(body.system, "You are a helpful assistant.");
+    });
+
+    it("emits cache_control on the system block when cacheControl.system is true", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        cacheControl: { system: true },
+      });
+      const body = getBody() as { system: Array<Record<string, unknown>> };
+      assertEquals(body.system, [{
+        type: "text",
+        text: "You are a helpful assistant.",
+        cache_control: { type: "ephemeral" },
+      }]);
+    });
+
+    it('emits cache_control with 1h TTL when cacheControl.system is "1h"', async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        cacheControl: { system: "1h" },
+      });
+      const body = getBody() as { system: Array<Record<string, unknown>> };
+      assertEquals(body.system, [{
+        type: "text",
+        text: "You are a helpful assistant.",
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      }]);
+    });
+
+    it("emits cache_control on the LAST tool entry when cacheControl.tools is true", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        tools: [weatherTool, searchTool],
+        cacheControl: { tools: true },
+      });
+      const body = getBody() as { tools: Array<Record<string, unknown>> };
+      assertEquals(body.tools.length, 2);
+      // First tool is unmodified
+      assertEquals(body.tools[0], {
+        name: "weather",
+        description: "Get weather",
+        input_schema: weatherTool.inputSchema,
+      });
+      // Last tool carries the breakpoint
+      assertEquals(body.tools[1], {
+        name: "search",
+        description: "Search the web",
+        input_schema: searchTool.inputSchema,
+        cache_control: { type: "ephemeral" },
+      });
+    });
+
+    it("emits both system and tools breakpoints when both are set", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        tools: [weatherTool],
+        cacheControl: { system: true, tools: "1h" },
+      });
+      const body = getBody() as {
+        system: Array<Record<string, unknown>>;
+        tools: Array<Record<string, unknown>>;
+      };
+      assertEquals(body.system, [{
+        type: "text",
+        text: "You are a helpful assistant.",
+        cache_control: { type: "ephemeral" },
+      }]);
+      assertEquals(body.tools, [{
+        name: "weather",
+        description: "Get weather",
+        input_schema: weatherTool.inputSchema,
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      }]);
+    });
+
+    it("treats cacheControl.system === false as no-op (string form preserved)", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        cacheControl: { system: false },
+      });
+      const body = getBody() as { system: unknown };
+      assertEquals(body.system, "You are a helpful assistant.");
+    });
+
+    it("treats cacheControl.tools === false as no-op (no breakpoint attached)", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        tools: [weatherTool],
+        cacheControl: { tools: false },
+      });
+      const body = getBody() as { tools: Array<Record<string, unknown>> };
+      assertEquals(body.tools, [{
+        name: "weather",
+        description: "Get weather",
+        input_schema: weatherTool.inputSchema,
+      }]);
+    });
+
+    it("does not crash when cacheControl is set but there's no system prompt", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        cacheControl: { system: true },
+      });
+      const body = getBody() as Record<string, unknown>;
+      // No system field at all — nothing to attach the breakpoint to.
+      assertEquals("system" in body, false);
+    });
+
+    it("does not crash when cacheControl.tools is set but there's no tools array", async () => {
+      const { runtime, getBody } = createCachingCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [systemPrompt, userPrompt],
+        cacheControl: { tools: true },
+      });
+      const body = getBody() as Record<string, unknown>;
+      assertEquals("tools" in body, false);
+    });
+  });
+
+  describe("reasoning / thinking request options", () => {
+    const userPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Solve this" }],
+    } as const;
+
+    function createAnthropicCaptureRuntime(modelId = "claude-opus-4-6") {
+      let capturedBody: Record<string, unknown> | null = null;
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          capturedBody = raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, modelId);
+      return { runtime, getBody: () => capturedBody };
+    }
+
+    function createOpenAICaptureRuntime(modelId: string) {
+      let capturedBody: Record<string, unknown> | null = null;
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "test-openai-key",
+        baseURL: "https://example.openai.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          capturedBody = raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                choices: [{
+                  index: 0,
+                  message: { role: "assistant", content: "ok" },
+                  finish_reason: "stop",
+                }],
+                usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, modelId);
+      return { runtime, getBody: () => capturedBody };
+    }
+
+    function createGoogleCaptureRuntime(modelId = "gemini-2.5-pro") {
+      let capturedBody: Record<string, unknown> | null = null;
+      const runtime = createGoogleModelRuntime({
+        apiKey: "test-google-key",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          capturedBody = raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                }],
+                usageMetadata: {
+                  promptTokenCount: 1,
+                  candidatesTokenCount: 1,
+                  totalTokenCount: 2,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, modelId);
+      return { runtime, getBody: () => capturedBody };
+    }
+
+    it("emits Anthropic thinking block with medium effort budget by default", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        maxOutputTokens: 2048,
+        reasoning: { enabled: true },
+      });
+      const body = getBody() as {
+        thinking: { type: string; budget_tokens: number };
+        max_tokens: number;
+      };
+      assertEquals(body.thinking, { type: "enabled", budget_tokens: 4096 });
+      // max_tokens = baseMaxTokens(2048) + budget(4096) = 6144
+      assertEquals(body.max_tokens, 6144);
+    });
+
+    it("maps Anthropic effort levels to budget_tokens", async () => {
+      async function budgetFor(effort: "low" | "medium" | "high" | "max") {
+        const { runtime, getBody } = createAnthropicCaptureRuntime();
+        await runtime.doGenerate({
+          prompt: [userPrompt],
+          maxOutputTokens: 1024,
+          reasoning: { enabled: true, effort },
+        });
+        return (getBody() as { thinking: { budget_tokens: number } }).thinking.budget_tokens;
+      }
+      assertEquals(await budgetFor("low"), 1024);
+      assertEquals(await budgetFor("medium"), 4096);
+      assertEquals(await budgetFor("high"), 16_384);
+      assertEquals(await budgetFor("max"), 32_768);
+    });
+
+    it("honours Anthropic explicit budgetTokens over effort", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        maxOutputTokens: 1024,
+        reasoning: { enabled: true, effort: "low", budgetTokens: 12_345 },
+      });
+      const body = getBody() as { thinking: { budget_tokens: number } };
+      assertEquals(body.thinking.budget_tokens, 12_345);
+    });
+
+    it("clamps Anthropic max_tokens at the model cap when thinking is enabled", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime("claude-opus-4-6");
+      // Opus 4.6 caps at 128k. 100k base + 64k budget would be 164k — clamp to 128k.
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        maxOutputTokens: 100_000,
+        reasoning: { enabled: true, budgetTokens: 64_000 },
+      });
+      const body = getBody() as { max_tokens: number };
+      assertEquals(body.max_tokens, 128_000);
+    });
+
+    it("drops Anthropic temperature and top_p when thinking is enabled", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+        reasoning: { enabled: true },
+      });
+      const body = getBody() as Record<string, unknown>;
+      assertEquals("temperature" in body, false);
+      assertEquals("top_p" in body, false);
+    });
+
+    it("preserves Anthropic sampling params when reasoning is disabled", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+      });
+      const body = getBody() as { temperature: number; top_p: number };
+      assertEquals(body.temperature, 0.7);
+      assertEquals(body.top_p, 0.9);
+    });
+
+    it("omits Anthropic thinking field when reasoning.enabled is false", async () => {
+      const { runtime, getBody } = createAnthropicCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: false, effort: "high" },
+      });
+      const body = getBody() as Record<string, unknown>;
+      assertEquals("thinking" in body, false);
+    });
+
+    it("emits OpenAI reasoning_effort when reasoning is enabled", async () => {
+      const { runtime, getBody } = createOpenAICaptureRuntime("gpt-4o-mini");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: true, effort: "high" },
+      });
+      const body = getBody() as { reasoning_effort: string };
+      assertEquals(body.reasoning_effort, "high");
+    });
+
+    it("collapses OpenAI 'max' effort to 'high'", async () => {
+      const { runtime, getBody } = createOpenAICaptureRuntime("gpt-4o-mini");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: true, effort: "max" },
+      });
+      const body = getBody() as { reasoning_effort: string };
+      assertEquals(body.reasoning_effort, "high");
+    });
+
+    it("drops OpenAI sampling params on reasoning models (o1/o3/o4)", async () => {
+      const { runtime, getBody } = createOpenAICaptureRuntime("o3-mini");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+        presencePenalty: 0.1,
+        frequencyPenalty: 0.1,
+      });
+      const body = getBody() as Record<string, unknown>;
+      assertEquals("temperature" in body, false);
+      assertEquals("top_p" in body, false);
+      assertEquals("presence_penalty" in body, false);
+      assertEquals("frequency_penalty" in body, false);
+    });
+
+    it("preserves OpenAI sampling params on non-reasoning models", async () => {
+      const { runtime, getBody } = createOpenAICaptureRuntime("gpt-4o-mini");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+      });
+      const body = getBody() as { temperature: number; top_p: number };
+      assertEquals(body.temperature, 0.7);
+      assertEquals(body.top_p, 0.9);
+    });
+
+    it("emits Google thinkingConfig when reasoning is enabled", async () => {
+      const { runtime, getBody } = createGoogleCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: true, effort: "high" },
+      });
+      const body = getBody() as {
+        generationConfig: { thinkingConfig: { includeThoughts: boolean; thinkingBudget: number } };
+      };
+      assertEquals(body.generationConfig.thinkingConfig, {
+        includeThoughts: true,
+        thinkingBudget: 8192,
+      });
+    });
+
+    it("maps Google effort 'max' to thinkingBudget: -1 (dynamic)", async () => {
+      const { runtime, getBody } = createGoogleCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: true, effort: "max" },
+      });
+      const body = getBody() as {
+        generationConfig: { thinkingConfig: { thinkingBudget: number } };
+      };
+      assertEquals(body.generationConfig.thinkingConfig.thinkingBudget, -1);
+    });
+
+    it("honours Google explicit budgetTokens over effort", async () => {
+      const { runtime, getBody } = createGoogleCaptureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        reasoning: { enabled: true, effort: "low", budgetTokens: 4096 },
+      });
+      const body = getBody() as {
+        generationConfig: { thinkingConfig: { thinkingBudget: number } };
+      };
+      assertEquals(body.generationConfig.thinkingConfig.thinkingBudget, 4096);
+    });
+
+    it("omits Google thinkingConfig when reasoning is disabled", async () => {
+      const { runtime, getBody } = createGoogleCaptureRuntime();
+      await runtime.doGenerate({ prompt: [userPrompt] });
+      const body = getBody() as {
+        generationConfig?: { thinkingConfig?: unknown };
+      };
+      assertEquals(body.generationConfig?.thinkingConfig, undefined);
+    });
+
+    it("passes redacted_thinking blocks through as reasoning events without leaking content", async () => {
+      const encoder = new TextEncoder();
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              ReadableStream.from([
+                encoder.encode(
+                  'event: message_start\ndata: {"type":"message_start","message":{"id":"m1","type":"message","role":"assistant","content":[],"model":"claude-opus-4-6","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"redacted_thinking","data":"encrypted-opaque-blob"}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"ok"}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n',
+                ),
+                encoder.encode(
+                  'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n',
+                ),
+                encoder.encode(
+                  'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+                ),
+              ]),
+              { status: 200, headers: { "content-type": "text/event-stream" } },
+            ),
+          ),
+      }, "claude-opus-4-6");
+
+      const result = await runtime.doStream({ prompt: [userPrompt] });
+      const parts = await collectAsync(result.stream);
+      // Redacted thinking emits reasoning-start (block 0) + reasoning-end, but no delta.
+      const reasoningStarts = parts.filter((p) =>
+        (p as { type: string }).type === "reasoning-start"
+      );
+      const reasoningDeltas = parts.filter((p) =>
+        (p as { type: string }).type === "reasoning-delta"
+      );
+      const reasoningEnds = parts.filter((p) => (p as { type: string }).type === "reasoning-end");
+      assertEquals(reasoningStarts.length, 1);
+      assertEquals(reasoningDeltas.length, 0);
+      assertEquals(reasoningEnds.length, 1);
+    });
+  });
+
+  describe("cache usage reporting (cache_creation / cache_read / cached_tokens)", () => {
+    const userPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Hi" }],
+    } as const;
+
+    it("surfaces Anthropic cache_creation_input_tokens and cache_read_input_tokens on generate", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: {
+                  input_tokens: 12,
+                  output_tokens: 34,
+                  cache_creation_input_tokens: 2056,
+                  cache_read_input_tokens: 128,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "claude-sonnet-4-20250514");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.usage, {
+        inputTokens: 12,
+        outputTokens: 34,
+        totalTokens: 46,
+        cacheCreationInputTokens: 2056,
+        cacheReadInputTokens: 128,
+      });
+    });
+
+    it("propagates Anthropic cache fields through the stream usage accumulator", async () => {
+      const encoder = new TextEncoder();
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              ReadableStream.from([
+                // message_start carries input + cache token counts up front.
+                encoder.encode(
+                  'event: message_start\ndata: {"type":"message_start","message":{"id":"m1","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":12,"output_tokens":1,"cache_creation_input_tokens":2056,"cache_read_input_tokens":128}}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}\n\n',
+                ),
+                encoder.encode(
+                  'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+                ),
+                // message_delta only updates output_tokens; cache fields absent here.
+                encoder.encode(
+                  'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":34}}\n\n',
+                ),
+                encoder.encode(
+                  'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+                ),
+              ]),
+              { status: 200, headers: { "content-type": "text/event-stream" } },
+            ),
+          ),
+      }, "claude-sonnet-4-20250514");
+
+      const result = await runtime.doStream({ prompt: [userPrompt] });
+      const parts = await collectAsync(result.stream);
+      const finish = parts.find((p) => (p as { type: string }).type === "finish") as {
+        usage: {
+          inputTokens?: number;
+          outputTokens?: number;
+          cacheCreationInputTokens?: number;
+          cacheReadInputTokens?: number;
+        };
+      };
+      assertEquals(finish.usage.inputTokens, 12);
+      assertEquals(finish.usage.outputTokens, 34);
+      assertEquals(finish.usage.cacheCreationInputTokens, 2056);
+      assertEquals(finish.usage.cacheReadInputTokens, 128);
+    });
+
+    it("leaves Anthropic cache fields undefined when the provider omits them", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "test-anthropic-key",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 4, output_tokens: 2 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "claude-sonnet-4-20250514");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      // Cache fields should be absent (not zero) when provider doesn't return them.
+      assertEquals(result.usage, {
+        inputTokens: 4,
+        outputTokens: 2,
+        totalTokens: 6,
+      });
+    });
+
+    it("surfaces OpenAI prompt_tokens_details.cached_tokens as cacheReadInputTokens", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "test-openai-key",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                choices: [{
+                  index: 0,
+                  message: { role: "assistant", content: "ok" },
+                  finish_reason: "stop",
+                }],
+                usage: {
+                  prompt_tokens: 100,
+                  completion_tokens: 40,
+                  total_tokens: 140,
+                  prompt_tokens_details: { cached_tokens: 80 },
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "gpt-4o-mini");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.usage, {
+        inputTokens: 100,
+        outputTokens: 40,
+        totalTokens: 140,
+        cacheReadInputTokens: 80,
+      });
+    });
+
+    it("leaves OpenAI cache field undefined when prompt_tokens_details is absent", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "test-openai-key",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                choices: [{
+                  index: 0,
+                  message: { role: "assistant", content: "ok" },
+                  finish_reason: "stop",
+                }],
+                usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "gpt-4o-mini");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.usage, {
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+      });
+    });
+
+    it("surfaces Google cachedContentTokenCount as cacheReadInputTokens", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "test-google-key",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                }],
+                usageMetadata: {
+                  promptTokenCount: 123,
+                  candidatesTokenCount: 45,
+                  totalTokenCount: 168,
+                  cachedContentTokenCount: 100,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "gemini-1.5-pro");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.usage, {
+        inputTokens: 123,
+        outputTokens: 45,
+        totalTokens: 168,
+        cacheReadInputTokens: 100,
+      });
+    });
+
+    it("leaves Google cache field undefined when cachedContentTokenCount is absent", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "test-google-key",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                }],
+                usageMetadata: {
+                  promptTokenCount: 8,
+                  candidatesTokenCount: 2,
+                  totalTokenCount: 10,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "gemini-1.5-pro");
+
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.usage, {
+        inputTokens: 8,
+        outputTokens: 2,
+        totalTokens: 10,
+      });
+    });
+  });
+
+  describe("transient error classification (529 / 503 / 429 / Retry-After)", () => {
+    const userPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Hi" }],
+    } as const;
+
+    function errorResponse(status: number, body: unknown, headers?: Record<string, string>) {
+      return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json", ...headers },
+      });
+    }
+
+    async function expectError<E extends Error>(
+      promise: PromiseLike<unknown>,
+      errorClass: new (...args: never[]) => E,
+    ): Promise<E> {
+      try {
+        await promise;
+        throw new Error("Expected promise to reject, but it resolved");
+      } catch (err) {
+        if (!(err instanceof errorClass)) {
+          throw new Error(
+            `Expected ${errorClass.name}, got ${err instanceof Error ? err.name : typeof err}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+        return err;
+      }
+    }
+
+    it("classifies Anthropic 529 as ProviderOverloadedError (retryable)", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            errorResponse(529, { error: { type: "overloaded_error", message: "Overloaded" } }),
+          ),
+      }, "claude-opus-4-6");
+      const err = await expectError(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        ProviderOverloadedError,
+      );
+      assertEquals(err.provider, "anthropic");
+      assertEquals(err.status, 529);
+      assertEquals(err.retryable, true);
+    });
+
+    it("classifies OpenAI 503 as ProviderOverloadedError (retryable)", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () => Promise.resolve(errorResponse(503, { error: { message: "Service down" } })),
+      }, "gpt-4o-mini");
+      const err = await expectError(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        ProviderOverloadedError,
+      );
+      assertEquals(err.provider, "openai");
+      assertEquals(err.status, 503);
+      assertEquals(err.retryable, true);
+    });
+
+    it("classifies OpenAI 429 rate_limit_exceeded as ProviderRateLimitError with Retry-After", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            errorResponse(
+              429,
+              { error: { code: "rate_limit_exceeded", message: "Slow down" } },
+              { "retry-after": "12" },
+            ),
+          ),
+      }, "gpt-4o-mini");
+      const err = await expectError(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        ProviderRateLimitError,
+      );
+      assertEquals(err.provider, "openai");
+      assertEquals(err.status, 429);
+      assertEquals(err.retryable, true);
+      assertEquals(err.retryAfterMs, 12_000);
+    });
+
+    it("classifies OpenAI 429 insufficient_quota as ProviderQuotaError (non-retryable)", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            errorResponse(429, {
+              error: { code: "insufficient_quota", message: "Out of credits" },
+            }),
+          ),
+      }, "gpt-4o-mini");
+      const err = await expectError(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        ProviderQuotaError,
+      );
+      assertEquals(err.retryable, false);
+    });
+
+    it("classifies Google 503 as ProviderOverloadedError (retryable)", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: () =>
+          Promise.resolve(errorResponse(503, { error: { code: 503, message: "Unavailable" } })),
+      }, "gemini-1.5-pro");
+      const err = await expectError(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        ProviderOverloadedError,
+      );
+      assertEquals(err.provider, "google");
+      assertEquals(err.retryable, true);
+    });
+
+    it("classifies Google 429 RESOURCE_EXHAUSTED as ProviderQuotaError (non-retryable)", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: () =>
+          Promise.resolve(
+            errorResponse(429, {
+              error: { code: 429, status: "RESOURCE_EXHAUSTED", message: "Daily quota" },
+            }),
+          ),
+      }, "gemini-1.5-pro");
+      const err = await expectError(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        ProviderQuotaError,
+      );
+      assertEquals(err.retryable, false);
+    });
+
+    it("preserves non-retryable 4xx as ProviderRequestError", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () => Promise.resolve(errorResponse(400, { error: { message: "Bad request" } })),
+      }, "gpt-4o-mini");
+      const err = await expectError(
+        runtime.doGenerate({ prompt: [userPrompt] }),
+        ProviderRequestError,
+      );
+      assertEquals(err.retryable, false);
+      assertEquals(err.status, 400);
+    });
+
+    it("classifies stream-mode 529 the same as JSON-mode", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            errorResponse(529, { error: { type: "overloaded_error", message: "Overloaded" } }),
+          ),
+      }, "claude-opus-4-6");
+      const err = await expectError(
+        runtime.doStream({ prompt: [userPrompt] }),
+        ProviderOverloadedError,
+      );
+      assertEquals(err.retryable, true);
+    });
+  });
+
+  describe("provider warnings (unsupported-setting drops)", () => {
+    const userPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Hi" }],
+    } as const;
+
+    function okAnthropicResponse() {
+      return new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "ok" }],
+          stop_reason: "end_turn",
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    function okOpenAIResponse() {
+      return new Response(
+        JSON.stringify({
+          choices: [{
+            index: 0,
+            message: { role: "assistant", content: "ok" },
+            finish_reason: "stop",
+          }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    function okGoogleResponse() {
+      return new Response(
+        JSON.stringify({
+          candidates: [{
+            content: { role: "model", parts: [{ text: "ok" }] },
+            finishReason: "STOP",
+          }],
+          usageMetadata: {
+            promptTokenCount: 1,
+            candidatesTokenCount: 1,
+            totalTokenCount: 2,
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    function settings(result: { warnings?: unknown[] }): string[] {
+      return (result.warnings ?? []).flatMap((w) => {
+        const r = w as { setting?: string };
+        return r.setting ? [r.setting] : [];
+      });
+    }
+
+    it("warns on Anthropic presencePenalty / frequencyPenalty / seed / topK", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () => Promise.resolve(okAnthropicResponse()),
+      }, "claude-opus-4-6");
+      const result = await runtime.doGenerate({
+        prompt: [userPrompt],
+        presencePenalty: 0.1,
+        frequencyPenalty: 0.2,
+        seed: 42,
+        topK: 50,
+      });
+      const dropped = settings(result).sort();
+      assertEquals(dropped, ["frequencyPenalty", "presencePenalty", "seed", "topK"]);
+    });
+
+    it("warns when Anthropic stopSequences exceeds 4 entries (and truncates)", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(okAnthropicResponse());
+        },
+      }, "claude-opus-4-6");
+      const result = await runtime.doGenerate({
+        prompt: [userPrompt],
+        stopSequences: ["a", "b", "c", "d", "e", "f"],
+      });
+      const dropped = settings(result);
+      assertEquals(dropped.includes("stopSequences"), true);
+      const capturedBody = captured as { stop_sequences: string[] } | null;
+      assertEquals(capturedBody?.stop_sequences.length, 4);
+    });
+
+    it("warns when Anthropic temperature/topP are dropped due to extended thinking", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () => Promise.resolve(okAnthropicResponse()),
+      }, "claude-opus-4-6");
+      const result = await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+        reasoning: { enabled: true, effort: "low" },
+      });
+      const dropped = settings(result).sort();
+      assertEquals(dropped, ["temperature", "topP"]);
+    });
+
+    it("emits no warnings on a clean Anthropic request", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () => Promise.resolve(okAnthropicResponse()),
+      }, "claude-opus-4-6");
+      const result = await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+        stopSequences: ["END"],
+      }) as { warnings?: unknown[] };
+      assertEquals(result.warnings, undefined);
+    });
+
+    it("warns on OpenAI topK on Chat Completions", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () => Promise.resolve(okOpenAIResponse()),
+      }, "gpt-4o-mini");
+      const result = await runtime.doGenerate({
+        prompt: [userPrompt],
+        topK: 50,
+      });
+      assertEquals(settings(result), ["topK"]);
+    });
+
+    it("warns on OpenAI sampling params dropped for o3 reasoning model", async () => {
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () => Promise.resolve(okOpenAIResponse()),
+      }, "o3-mini");
+      const result = await runtime.doGenerate({
+        prompt: [userPrompt],
+        temperature: 0.7,
+        topP: 0.9,
+        presencePenalty: 0.1,
+        frequencyPenalty: 0.1,
+      });
+      const dropped = settings(result).sort();
+      assertEquals(dropped, [
+        "frequencyPenalty",
+        "presencePenalty",
+        "temperature",
+        "topP",
+      ]);
+    });
+
+    it("warns on Google presencePenalty / frequencyPenalty drops", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: () => Promise.resolve(okGoogleResponse()),
+      }, "gemini-1.5-pro");
+      const result = await runtime.doGenerate({
+        prompt: [userPrompt],
+        presencePenalty: 0.1,
+        frequencyPenalty: 0.2,
+      });
+      const dropped = settings(result).sort();
+      assertEquals(dropped, ["frequencyPenalty", "presencePenalty"]);
+    });
+
+    it("emits Anthropic metadata.user_id when userId is set", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(okAnthropicResponse());
+        },
+      }, "claude-opus-4-6");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        userId: "user_42",
+      });
+      const body = captured as { metadata: { user_id: string } } | null;
+      assertEquals(body?.metadata, { user_id: "user_42" });
+    });
+
+    it("emits OpenAI user field when userId is set", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(okOpenAIResponse());
+        },
+      }, "gpt-4o-mini");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        userId: "user_42",
+      });
+      const body = captured as { user: string } | null;
+      assertEquals(body?.user, "user_42");
+    });
+
+    it("emits Google labels.user_id from userId when requestLabels is unset", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(okGoogleResponse());
+        },
+      }, "gemini-1.5-pro");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        userId: "user_42",
+      });
+      const body = captured as { labels: Record<string, string> } | null;
+      assertEquals(body?.labels, { user_id: "user_42" });
+    });
+
+    it("Google requestLabels wins over userId-derived labels", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(okGoogleResponse());
+        },
+      }, "gemini-1.5-pro");
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        userId: "user_42",
+        requestLabels: { tenant: "acme", env: "prod" },
+      });
+      const body = captured as { labels: Record<string, string> } | null;
+      assertEquals(body?.labels, { tenant: "acme", env: "prod" });
+    });
+
+    it("omits provider metadata fields when userId is unset", async () => {
+      let anthropicBody: Record<string, unknown> | null = null;
+      let openaiBody: Record<string, unknown> | null = null;
+      let googleBody: Record<string, unknown> | null = null;
+
+      const anthropic = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          anthropicBody = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(okAnthropicResponse());
+        },
+      }, "claude-opus-4-6");
+      const openai = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          openaiBody = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(okOpenAIResponse());
+        },
+      }, "gpt-4o-mini");
+      const google = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          googleBody = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(okGoogleResponse());
+        },
+      }, "gemini-1.5-pro");
+
+      await anthropic.doGenerate({ prompt: [userPrompt] });
+      await openai.doGenerate({ prompt: [userPrompt] });
+      await google.doGenerate({ prompt: [userPrompt] });
+
+      assertEquals("metadata" in (anthropicBody ?? {}), false);
+      assertEquals("user" in (openaiBody ?? {}), false);
+      assertEquals("labels" in (googleBody ?? {}), false);
+    });
+
+    it("warnings are present on stream results too", async () => {
+      const encoder = new TextEncoder();
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              ReadableStream.from([
+                encoder.encode(
+                  'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n',
+                ),
+                encoder.encode(
+                  'data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}\n\n',
+                ),
+                encoder.encode("data: [DONE]\n\n"),
+              ]),
+              { status: 200, headers: { "content-type": "text/event-stream" } },
+            ),
+          ),
+      }, "o3-mini");
+      const result = await runtime.doStream({
+        prompt: [userPrompt],
+        temperature: 0.5,
+      });
+      assertEquals(settings(result), ["temperature"]);
+      // Drain the stream to keep Deno test runner happy.
+      await collectAsync(result.stream);
+    });
+  });
+
+  describe("Anthropic provider tool version aliasing", () => {
+    const userPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Run code" }],
+    } as const;
+
+    function captureBody() {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "claude-opus-4-6");
+      return { runtime, getBody: () => captured };
+    }
+
+    function toolType(body: Record<string, unknown> | null): string | undefined {
+      const tools = body?.tools as Array<{ type?: string }> | undefined;
+      return tools?.[0]?.type;
+    }
+
+    const cases: Array<[string, string]> = [
+      ["anthropic.code_execution", "code_execution_20260120"],
+      ["anthropic.computer_use", "computer_20250124"],
+      ["anthropic.computer", "computer_20250124"],
+      ["anthropic.text_editor", "text_editor_20250728"],
+      ["anthropic.bash", "bash_20250124"],
+      ["anthropic.memory", "memory_20250818"],
+      ["anthropic.web_search", "web_search_20250305"],
+      ["anthropic.web_fetch", "web_fetch_20250910"],
+    ];
+
+    for (const [shortId, expected] of cases) {
+      it(`maps ${shortId} -> ${expected}`, async () => {
+        const { runtime, getBody } = captureBody();
+        await runtime.doGenerate({
+          prompt: [userPrompt],
+          tools: [{
+            type: "provider",
+            name: "tool",
+            id: shortId as `${string}.${string}`,
+            args: {},
+          }],
+        });
+        assertEquals(toolType(getBody()), expected);
+      });
+    }
+
+    it("passes already-versioned types through verbatim", async () => {
+      const { runtime, getBody } = captureBody();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        tools: [{
+          type: "provider",
+          name: "tool",
+          id: "anthropic.code_execution_20250522",
+          args: {},
+        }],
+      });
+      assertEquals(toolType(getBody()), "code_execution_20250522");
+    });
+
+    it("leaves unknown short names unchanged", async () => {
+      const { runtime, getBody } = captureBody();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        tools: [{
+          type: "provider",
+          name: "tool",
+          id: "anthropic.future_tool",
+          args: {},
+        }],
+      });
+      assertEquals(toolType(getBody()), "future_tool");
+    });
+  });
+
+  describe("Anthropic native MCP server pass-through", () => {
+    const userPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Hi" }],
+    } as const;
+
+    function captureRuntime() {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "claude-opus-4-6");
+      return { runtime, getBody: () => captured };
+    }
+
+    it("emits mcp_servers on the body when set, with deep snake_case conversion", async () => {
+      const { runtime, getBody } = captureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        mcpServers: [{
+          type: "url",
+          url: "https://example.com/mcp",
+          name: "example",
+          authorizationToken: "Bearer abc",
+          toolConfiguration: {
+            enabled: true,
+            allowedTools: ["search", "fetch"],
+          },
+        }],
+      });
+      const body = getBody() as { mcp_servers: Array<Record<string, unknown>> } | null;
+      assertEquals(body?.mcp_servers, [{
+        type: "url",
+        url: "https://example.com/mcp",
+        name: "example",
+        authorization_token: "Bearer abc",
+        tool_configuration: {
+          enabled: true,
+          allowed_tools: ["search", "fetch"],
+        },
+      }]);
+    });
+
+    it("omits mcp_servers when the option is empty or unset", async () => {
+      const { runtime, getBody } = captureRuntime();
+      await runtime.doGenerate({ prompt: [userPrompt], mcpServers: [] });
+      assertEquals("mcp_servers" in (getBody() ?? {}), false);
+
+      const second = captureRuntime();
+      await second.runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals("mcp_servers" in (second.getBody() ?? {}), false);
+    });
+
+    it("emits container field verbatim when anthropicContainer is set", async () => {
+      const { runtime, getBody } = captureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        anthropicContainer: { id: "ctr_42", type: "computer-use" },
+      });
+      const body = getBody() as { container: unknown } | null;
+      assertEquals(body?.container, { id: "ctr_42", type: "computer-use" });
+    });
+
+    it("emits container as a bare string when anthropicContainer is a string", async () => {
+      const { runtime, getBody } = captureRuntime();
+      await runtime.doGenerate({
+        prompt: [userPrompt],
+        anthropicContainer: "ctr_42",
+      });
+      const body = getBody() as { container: string } | null;
+      assertEquals(body?.container, "ctr_42");
+    });
+
+    it("omits container when anthropicContainer is unset", async () => {
+      const { runtime, getBody } = captureRuntime();
+      await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals("container" in (getBody() ?? {}), false);
+    });
+  });
+
+  describe("Anthropic thinking signature multi-turn replay", () => {
+    const userPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "Hi" }],
+    } as const;
+
+    it("surfaces thinking blocks with text + signature on generate result", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [
+                  {
+                    type: "thinking",
+                    thinking: "Let me reason step by step...",
+                    signature: "sig_abc123",
+                  },
+                  { type: "text", text: "The answer is 42." },
+                ],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "claude-opus-4-6");
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.content, [
+        { type: "reasoning", text: "Let me reason step by step...", signature: "sig_abc123" },
+        { type: "text", text: "The answer is 42." },
+      ]);
+    });
+
+    it("surfaces redacted thinking blocks as opaque reasoning parts", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [
+                  { type: "redacted_thinking", data: "encrypted-blob" },
+                  { type: "text", text: "ok" },
+                ],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "claude-opus-4-6");
+      const result = await runtime.doGenerate({ prompt: [userPrompt] });
+      assertEquals(result.content, [
+        { type: "reasoning", redactedData: "encrypted-blob" },
+        { type: "text", text: "ok" },
+      ]);
+    });
+
+    it("replays reasoning content parts as thinking blocks on the next request", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "claude-opus-4-6");
+      await runtime.doGenerate({
+        prompt: [
+          userPrompt,
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "reasoning",
+                text: "Step by step thinking...",
+                signature: "sig_abc123",
+              },
+              { type: "text", text: "The answer is 42." },
+            ],
+          },
+          { role: "user", content: [{ type: "text", text: "Are you sure?" }] },
+        ],
+      });
+      const body = captured as {
+        messages: Array<{ role: string; content: Array<Record<string, unknown>> }>;
+      } | null;
+      assertEquals(body!.messages[1]!.role, "assistant");
+      assertEquals(body!.messages[1]!.content[0], {
+        type: "thinking",
+        thinking: "Step by step thinking...",
+        signature: "sig_abc123",
+      });
+      assertEquals(body!.messages[1]!.content[1], {
+        type: "text",
+        text: "The answer is 42.",
+      });
+    });
+
+    it("surfaces text-block citations on the generate result", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [
+                  {
+                    type: "text",
+                    text: "The capital of France is Paris.",
+                    citations: [
+                      {
+                        type: "web_search_result_location",
+                        cited_text: "Paris is the capital of France",
+                        url: "https://example.com/france",
+                        title: "France facts",
+                      },
+                    ],
+                  },
+                ],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "claude-opus-4-6");
+      const result = await runtime.doGenerate({
+        prompt: [{
+          role: "user",
+          content: [{ type: "text", text: "What is the capital of France?" }],
+        }],
+      });
+      const textPart = result.content![0] as {
+        type: "text";
+        text: string;
+        citations?: Array<Record<string, unknown>>;
+      };
+      assertEquals(textPart.text, "The capital of France is Paris.");
+      assertEquals(textPart.citations, [{
+        type: "web_search_result_location",
+        citedText: "Paris is the capital of France",
+        url: "https://example.com/france",
+        title: "France facts",
+      }]);
+    });
+
+    it("normalizes char_location and page_location citation kinds", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{
+                  type: "text",
+                  text: "ok",
+                  citations: [
+                    {
+                      type: "char_location",
+                      cited_text: "foo",
+                      document_index: 0,
+                      document_title: "Doc A",
+                      start_char_index: 12,
+                      end_char_index: 15,
+                    },
+                    {
+                      type: "page_location",
+                      cited_text: "bar",
+                      document_index: 1,
+                      start_page_number: 3,
+                      end_page_number: 4,
+                    },
+                  ],
+                }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "claude-opus-4-6");
+      const result = await runtime.doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "Cite" }] }],
+      });
+      const textPart = result.content![0] as {
+        citations?: Array<Record<string, unknown>>;
+      };
+      assertEquals(textPart.citations, [
+        {
+          type: "char_location",
+          citedText: "foo",
+          documentIndex: 0,
+          documentTitle: "Doc A",
+          startCharIndex: 12,
+          endCharIndex: 15,
+        },
+        {
+          type: "page_location",
+          citedText: "bar",
+          documentIndex: 1,
+          startPageNumber: 3,
+          endPageNumber: 4,
+        },
+      ]);
+    });
+
+    it("normalizes Google toolChoice 'tools' multi-name allowlist", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                }],
+                usageMetadata: {
+                  promptTokenCount: 1,
+                  candidatesTokenCount: 1,
+                  totalTokenCount: 2,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "gemini-1.5-pro");
+      await runtime.doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        toolChoice: { type: "tools", names: ["weather", "clock"] },
+      });
+      const body = captured as
+        | { toolConfig: { functionCallingConfig: Record<string, unknown> } }
+        | null;
+      assertEquals(body!.toolConfig.functionCallingConfig, {
+        mode: "ANY",
+        allowedFunctionNames: ["weather", "clock"],
+      });
+    });
+
+    it("normalizes Google toolChoice 'auto' / 'any' / 'none' explicit modes", async () => {
+      async function modeFor(toolChoice: { type: string }) {
+        let captured: Record<string, unknown> | null = null;
+        const runtime = createGoogleModelRuntime({
+          apiKey: "k",
+          baseURL: "https://example.google.test/v1beta",
+          fetch: (_input, init) => {
+            const raw = readRequestBody(init);
+            captured = raw ? JSON.parse(raw) : null;
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  candidates: [{
+                    content: { role: "model", parts: [{ text: "ok" }] },
+                    finishReason: "STOP",
+                  }],
+                  usageMetadata: {
+                    promptTokenCount: 1,
+                    candidatesTokenCount: 1,
+                    totalTokenCount: 2,
+                  },
+                }),
+                { status: 200, headers: { "content-type": "application/json" } },
+              ),
+            );
+          },
+        }, "gemini-1.5-pro");
+        await runtime.doGenerate({
+          prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+          toolChoice,
+        });
+        const body = captured as
+          | { toolConfig: { functionCallingConfig: { mode: string } } }
+          | null;
+        return body!.toolConfig.functionCallingConfig.mode;
+      }
+      assertEquals(await modeFor({ type: "auto" }), "AUTO");
+      assertEquals(await modeFor({ type: "any" }), "ANY");
+      assertEquals(await modeFor({ type: "none" }), "NONE");
+    });
+
+    it("surfaces Google groundingMetadata on the generate result when present", async () => {
+      const groundingMetadata = {
+        webSearchQueries: ["latest news"],
+        groundingChunks: [
+          {
+            web: {
+              uri: "https://example.com/article",
+              title: "Article title",
+            },
+          },
+        ],
+        groundingSupports: [{
+          segment: { startIndex: 0, endIndex: 10, text: "ok" },
+          groundingChunkIndices: [0],
+          confidenceScores: [0.95],
+        }],
+      };
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                  groundingMetadata,
+                }],
+                usageMetadata: {
+                  promptTokenCount: 1,
+                  candidatesTokenCount: 1,
+                  totalTokenCount: 2,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "gemini-2.5-pro");
+      const result = await runtime.doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      }) as { groundingMetadata?: Record<string, unknown> };
+      assertEquals(result.groundingMetadata, groundingMetadata);
+    });
+
+    it("omits groundingMetadata when the candidate doesn't have any", async () => {
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                }],
+                usageMetadata: {
+                  promptTokenCount: 1,
+                  candidatesTokenCount: 1,
+                  totalTokenCount: 2,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "gemini-2.5-pro");
+      const result = await runtime.doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      }) as { groundingMetadata?: unknown };
+      assertEquals("groundingMetadata" in result, false);
+    });
+
+    it("emits Google code_execution provider tool", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                }],
+                usageMetadata: {
+                  promptTokenCount: 1,
+                  candidatesTokenCount: 1,
+                  totalTokenCount: 2,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "gemini-2.5-pro");
+      await runtime.doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "Compute" }] }],
+        tools: [{
+          type: "provider",
+          name: "code_execution",
+          id: "google.code_execution",
+          args: {},
+        }],
+      });
+      const body = captured as { tools: Array<Record<string, unknown>> } | null;
+      assertEquals(body!.tools, [{ codeExecution: {} }]);
+    });
+
+    it("emits Google google_search provider tool alongside function declarations", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                }],
+                usageMetadata: {
+                  promptTokenCount: 1,
+                  candidatesTokenCount: 1,
+                  totalTokenCount: 2,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "gemini-2.5-pro");
+      await runtime.doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "Search" }] }],
+        tools: [
+          {
+            type: "function",
+            name: "weather",
+            inputSchema: { type: "object", properties: {} },
+          },
+          {
+            type: "provider",
+            name: "google_search",
+            id: "google.google_search",
+            args: {},
+          },
+        ],
+      });
+      const body = captured as { tools: Array<Record<string, unknown>> } | null;
+      assertEquals(body!.tools.length, 2);
+      assertEquals("functionDeclarations" in (body!.tools[0] as Record<string, unknown>), true);
+      assertEquals(body!.tools[1], { googleSearch: {} });
+    });
+
+    it("emits Google safetySettings when googleSafetySettings is set", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                }],
+                usageMetadata: {
+                  promptTokenCount: 1,
+                  candidatesTokenCount: 1,
+                  totalTokenCount: 2,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "gemini-1.5-pro");
+      await runtime.doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        googleSafetySettings: [
+          { category: "HARM_CATEGORY_HARASSMENT", threshold: "BLOCK_NONE" },
+          { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "BLOCK_ONLY_HIGH" },
+        ],
+      });
+      const body = captured as { safetySettings: unknown } | null;
+      assertEquals(body!.safetySettings, [
+        { category: "HARM_CATEGORY_HARASSMENT", threshold: "BLOCK_NONE" },
+        { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "BLOCK_ONLY_HIGH" },
+      ]);
+    });
+
+    it("omits safetySettings when googleSafetySettings is unset or empty", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                }],
+                usageMetadata: {
+                  promptTokenCount: 1,
+                  candidatesTokenCount: 1,
+                  totalTokenCount: 2,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "gemini-1.5-pro");
+      await runtime.doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        googleSafetySettings: [],
+      });
+      assertEquals("safetySettings" in (captured ?? {}), false);
+    });
+
+    it("emits Google cachedContent when googleCachedContent is set", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                }],
+                usageMetadata: {
+                  promptTokenCount: 1,
+                  candidatesTokenCount: 1,
+                  totalTokenCount: 2,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "gemini-1.5-pro");
+      await runtime.doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        googleCachedContent: "cachedContents/abc123",
+      });
+      const body = captured as { cachedContent: string } | null;
+      assertEquals(body!.cachedContent, "cachedContents/abc123");
+    });
+
+    it("omits cachedContent when googleCachedContent is unset", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createGoogleModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.google.test/v1beta",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [{
+                  content: { role: "model", parts: [{ text: "ok" }] },
+                  finishReason: "STOP",
+                }],
+                usageMetadata: {
+                  promptTokenCount: 1,
+                  candidatesTokenCount: 1,
+                  totalTokenCount: 2,
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "gemini-1.5-pro");
+      await runtime.doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      });
+      assertEquals("cachedContent" in (captured ?? {}), false);
+    });
+
+    it("emits OpenAI service_tier when serviceTier is set", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                choices: [{
+                  index: 0,
+                  message: { role: "assistant", content: "ok" },
+                  finish_reason: "stop",
+                }],
+                usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "gpt-4o-mini");
+      await runtime.doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        serviceTier: "flex",
+      });
+      const body = captured as { service_tier: string } | null;
+      assertEquals(body!.service_tier, "flex");
+    });
+
+    it("emits OpenAI parallel_tool_calls: false when parallelToolCalls is false", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                choices: [{
+                  index: 0,
+                  message: { role: "assistant", content: "ok" },
+                  finish_reason: "stop",
+                }],
+                usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "gpt-4o-mini");
+      await runtime.doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        parallelToolCalls: false,
+      });
+      const body = captured as { parallel_tool_calls: boolean } | null;
+      assertEquals(body!.parallel_tool_calls, false);
+    });
+
+    it("omits service_tier and parallel_tool_calls when unset", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                choices: [{
+                  index: 0,
+                  message: { role: "assistant", content: "ok" },
+                  finish_reason: "stop",
+                }],
+                usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "gpt-4o-mini");
+      await runtime.doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      });
+      assertEquals("service_tier" in (captured ?? {}), false);
+      assertEquals("parallel_tool_calls" in (captured ?? {}), false);
+    });
+
+    it("emits OpenAI response_format json_schema when responseFormat is structured", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                choices: [{
+                  index: 0,
+                  message: { role: "assistant", content: "{}" },
+                  finish_reason: "stop",
+                }],
+                usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "gpt-4o-2024-08-06");
+      const schema = {
+        type: "object",
+        properties: { name: { type: "string" } },
+        required: ["name"],
+        additionalProperties: false,
+      };
+      await runtime.doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        responseFormat: {
+          type: "json_schema",
+          name: "Person",
+          schema,
+          strict: true,
+        },
+      });
+      const body = captured as { response_format: Record<string, unknown> } | null;
+      assertEquals(body!.response_format, {
+        type: "json_schema",
+        json_schema: {
+          name: "Person",
+          schema,
+          strict: true,
+        },
+      });
+    });
+
+    it("emits OpenAI response_format json_object for type:json", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createOpenAIModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.openai.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                choices: [{
+                  index: 0,
+                  message: { role: "assistant", content: "{}" },
+                  finish_reason: "stop",
+                }],
+                usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "gpt-4o-mini");
+      await runtime.doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        responseFormat: { type: "json" },
+      });
+      const body = captured as { response_format: { type: string } } | null;
+      assertEquals(body!.response_format, { type: "json_object" });
+    });
+
+    it("warns and omits response_format on Anthropic when responseFormat is structured", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "claude-opus-4-6");
+      const result = await runtime.doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        responseFormat: { type: "json" },
+      }) as { warnings?: Array<{ setting?: string }> };
+      assertEquals("response_format" in (captured ?? {}), false);
+      const settingNames = (result.warnings ?? []).flatMap((w) => w.setting ? [w.setting] : []);
+      assertEquals(settingNames.includes("responseFormat"), true);
+    });
+
+    it("omits citations field on text blocks that don't have them", async () => {
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "no citations here" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          ),
+      }, "claude-opus-4-6");
+      const result = await runtime.doGenerate({
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      });
+      const textPart = result.content![0] as { citations?: unknown };
+      assertEquals("citations" in textPart, false);
+    });
+
+    it("replays redacted reasoning parts as redacted_thinking blocks", async () => {
+      let captured: Record<string, unknown> | null = null;
+      const runtime = createAnthropicModelRuntime({
+        apiKey: "k",
+        baseURL: "https://example.anthropic.test/v1",
+        fetch: (_input, init) => {
+          const raw = readRequestBody(init);
+          captured = raw ? JSON.parse(raw) : null;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                content: [{ type: "text", text: "ok" }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        },
+      }, "claude-opus-4-6");
+      await runtime.doGenerate({
+        prompt: [
+          userPrompt,
+          {
+            role: "assistant",
+            content: [
+              { type: "reasoning", redactedData: "encrypted-blob" },
+              { type: "text", text: "ok" },
+            ],
+          },
+          { role: "user", content: [{ type: "text", text: "go on" }] },
+        ],
+      });
+      const body = captured as {
+        messages: Array<{ role: string; content: Array<Record<string, unknown>> }>;
+      } | null;
+      assertEquals(body!.messages[1]!.content[0], {
+        type: "redacted_thinking",
+        data: "encrypted-blob",
+      });
     });
   });
 });

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -36,6 +36,18 @@ type RuntimePromptMessage =
         input: unknown;
         providerExecuted?: boolean;
       }
+      | {
+        // Anthropic thinking block replay. Carries the original signed
+        // thinking trace so that on the next turn Anthropic can verify
+        // the signature and let Claude continue reasoning from the same
+        // point. `text` + `signature` are the normal pair for an
+        // un-redacted thinking block; `redactedData` is set instead of
+        // both when Anthropic returned an encrypted opaque payload.
+        type: "reasoning";
+        text?: string;
+        signature?: string;
+        redactedData?: string;
+      }
     >;
   }
   | {
@@ -60,6 +72,67 @@ type RuntimeToolDefinition =
     id: `${string}.${string}`;
     args: Record<string, unknown>;
   };
+/**
+ * TTL for a single prompt-cache breakpoint.
+ *
+ * `true` and `"5m"` both map to Anthropic's default ephemeral (5-minute) cache.
+ * `"1h"` maps to the extended 1-hour cache at a 2x write cost. Callers can
+ * pick per breakpoint target.
+ */
+type ProviderCacheTtl = boolean | "5m" | "1h";
+
+/**
+ * Per-provider prompt / context caching controls.
+ *
+ * For Anthropic, flipping these on emits `cache_control: { type: "ephemeral" }`
+ * breakpoints on the assembled system prompt and/or the last tool definition
+ * sent to the Messages API, enabling Anthropic's explicit prompt cache.
+ *
+ * OpenAI's prompt cache is automatic on gpt-4o+ and has no request-side
+ * directive to emit, so this option is a no-op for the OpenAI runtime. Google
+ * uses a separate `cachedContent` resource model that is intentionally not
+ * covered by this option (it belongs on a dedicated Gemini-specific surface).
+ */
+type ProviderCacheControlOption = {
+  /**
+   * Attach a cache breakpoint to the final system-prompt text block.
+   * Use when the system prompt is large and reused across requests.
+   */
+  system?: ProviderCacheTtl;
+  /**
+   * Attach a cache breakpoint to the last tool definition in `tools`.
+   * Use when the tool schemas are large and identical across requests.
+   */
+  tools?: ProviderCacheTtl;
+};
+
+/**
+ * Unified effort level for extended reasoning / thinking. Maps to
+ * per-provider knobs: Anthropic `thinking.budget_tokens`, OpenAI
+ * `reasoning_effort`, Gemini `thinkingConfig.thinkingBudget`.
+ */
+type ProviderReasoningEffort = "low" | "medium" | "high" | "max";
+
+/**
+ * Unified reasoning / thinking request option.
+ *
+ * Setting `enabled: true` turns on extended thinking on providers that
+ * support it (Anthropic Claude 4.x, OpenAI o-series, Gemini 2.5+). The
+ * `effort` field picks a coarse budget; when `budgetTokens` is set it
+ * wins for providers that take a numeric budget (Anthropic, Gemini).
+ *
+ * Providers that do not support reasoning treat this as a no-op. On
+ * Anthropic + OpenAI, enabling reasoning also disables sampling params
+ * that the providers reject in combination (`temperature`, `topP`,
+ * `topK`, `presencePenalty`, `frequencyPenalty`) — silently dropping
+ * them rather than failing the request.
+ */
+type ProviderReasoningOption = {
+  enabled?: boolean;
+  effort?: ProviderReasoningEffort;
+  budgetTokens?: number;
+};
+
 type OpenAICompatibleLanguageOptions = {
   prompt: RuntimePromptMessage[];
   maxOutputTokens?: number;
@@ -76,6 +149,128 @@ type OpenAICompatibleLanguageOptions = {
   providerOptions?: Record<string, unknown>;
   includeRawChunks?: boolean;
   abortSignal?: AbortSignal;
+  /**
+   * Per-provider prompt / context caching controls. See
+   * {@link ProviderCacheControlOption}. When unset, caching behaviour is
+   * unchanged on every provider.
+   */
+  cacheControl?: ProviderCacheControlOption;
+  /**
+   * Enable extended reasoning / thinking on providers that support it.
+   * See {@link ProviderReasoningOption}. When unset, reasoning behaviour
+   * is unchanged on every provider.
+   */
+  reasoning?: ProviderReasoningOption;
+  /**
+   * Stable per-user identifier for rate-limiting, abuse detection, and
+   * billing attribution. Maps to:
+   *  - Anthropic: `metadata.user_id`
+   *  - OpenAI: `user`
+   *  - Google: `labels.user_id` (when {@link requestLabels} is unset)
+   */
+  userId?: string;
+  /**
+   * Provider-specific label map for Google Gemini's `labels` field.
+   * Anthropic and OpenAI don't have an arbitrary-label equivalent, so
+   * this is intentionally Google-only. When unset, no labels are sent.
+   */
+  requestLabels?: Record<string, string>;
+  /**
+   * OpenAI-specific. Maps to the `service_tier` field on Chat Completions
+   * which trades latency for cost. Documented values:
+   *
+   *  - `default` — standard processing (default if unset)
+   *  - `flex` — lower-priority queue, lower per-token cost, longer
+   *    expected latency. Useful for batchy or non-interactive workloads.
+   *  - `scale` — reserved-capacity tier with strict latency SLOs.
+   *  - `auto` — let OpenAI pick.
+   *
+   * Forwarded verbatim. Anthropic and Google have no equivalent and
+   * the field is silently omitted on those providers.
+   */
+  serviceTier?: "auto" | "default" | "flex" | "scale";
+  /**
+   * OpenAI-specific. When `false`, OpenAI runs tool calls sequentially
+   * instead of in parallel. Useful for ordered side effects where
+   * concurrent calls would race. Default behaviour (unset) is parallel.
+   */
+  parallelToolCalls?: boolean;
+  /**
+   * Structured-output response format. Maps to OpenAI's `response_format`
+   * field on Chat Completions (and Responses). Three variants:
+   *
+   *  - `{ type: "text" }` — the default (no constraint).
+   *  - `{ type: "json" }` — emits OpenAI's `response_format:
+   *    { type: "json_object" }` to force the model to return valid JSON.
+   *  - `{ type: "json_schema", name, schema, strict? }` — emits
+   *    OpenAI's `response_format: { type: "json_schema", json_schema: {
+   *    name, schema, strict } }` for fully constrained structured
+   *    outputs (gpt-4o-2024-08-06+).
+   *
+   * On Anthropic and Google this option emits an "unsupported-setting"
+   * warning when set to anything other than `text` (those providers
+   * have their own structured-output surfaces and need a dedicated
+   * follow-up to wire them in).
+   */
+  responseFormat?:
+    | { type: "text" }
+    | { type: "json" }
+    | {
+      type: "json_schema";
+      name: string;
+      schema: unknown;
+      description?: string;
+      strict?: boolean;
+    };
+  /**
+   * Anthropic-specific. `container` field for programmatic tool calling
+   * and agent skills. Anthropic uses this to scope a session to a
+   * sandboxed container (e.g. for Computer Use, code execution
+   * sandboxes, or skills loaded from a container). Forwarded verbatim.
+   *
+   * The shape varies — string container id or a structured object
+   * depending on the feature. Caller passes whatever Anthropic's docs
+   * specify for the target feature.
+   */
+  anthropicContainer?: unknown;
+  /**
+   * Google-specific. Reference to a previously-created Gemini cached
+   * content resource (created via the separate caches API) to attach
+   * to this request. Resource name format:
+   * `cachedContents/<id>`. See https://ai.google.dev/gemini-api/docs/caching.
+   *
+   * Cache creation itself is out of scope for the runtime — callers
+   * use the Gemini REST API or SDK to create the cache, then pass the
+   * resource name here on each subsequent generate call to attach the
+   * cached prefix and avoid re-paying for it.
+   */
+  googleCachedContent?: string;
+  /**
+   * Google-specific. Per-request safety filter configuration for
+   * Gemini. Each entry pairs a HARM_CATEGORY_* with a threshold
+   * (BLOCK_NONE / BLOCK_LOW_AND_ABOVE / BLOCK_MEDIUM_AND_ABOVE /
+   * BLOCK_ONLY_HIGH). Forwarded verbatim as the `safetySettings`
+   * field. See https://ai.google.dev/gemini-api/docs/safety-settings.
+   */
+  googleSafetySettings?: Array<{
+    category: string;
+    threshold: string;
+  }>;
+  /**
+   * Anthropic-specific. Native MCP server definitions to pass directly
+   * on the Messages API request body. Lets callers register MCP servers
+   * server-side instead of reloading them into local function tools.
+   *
+   * Caller must opt into the MCP beta by adding the matching header to
+   * `headers`, e.g. `{ "anthropic-beta": "mcp-client-2025-04-04" }`.
+   * Without that header Anthropic will reject the request.
+   *
+   * Each entry is forwarded with camelCase keys converted to snake_case
+   * so `authorizationToken` → `authorization_token`,
+   * `toolConfiguration.allowedTools` → `tool_configuration.allowed_tools`,
+   * etc.
+   */
+  mcpServers?: Array<Record<string, unknown>>;
 };
 type OpenAICompatibleChatMessage =
   | { role: "system"; content: string }
@@ -142,7 +337,12 @@ type AnthropicCompatibleRequest = {
   messages: AnthropicCompatibleMessage[];
   max_tokens: number;
   stream?: boolean;
-  system?: string;
+  /**
+   * String form is the classic shorthand. Array-of-blocks form is required
+   * when the system prompt carries a cache_control breakpoint, because
+   * cache_control lives on an individual content block, not on a raw string.
+   */
+  system?: string | Array<Record<string, unknown>>;
   temperature?: number;
   top_p?: number;
   stop_sequences?: string[];
@@ -168,9 +368,7 @@ type GoogleCompatibleRequest = {
   systemInstruction?: {
     parts: Array<{ text: string }>;
   };
-  tools?: Array<{
-    functionDeclarations: Array<Record<string, unknown>>;
-  }>;
+  tools?: Array<Record<string, unknown>>;
   toolConfig?: {
     functionCallingConfig: Record<string, unknown>;
   };
@@ -287,9 +485,203 @@ function extractGoogleUsageTokens(payload: unknown): number | undefined {
   return typeof promptTokenCount === "number" ? promptTokenCount : undefined;
 }
 
-async function readErrorMessage(response: Response): Promise<string> {
-  const text = await response.text();
-  return text.trim() || `${response.status} ${response.statusText}`.trim();
+type ProviderKind = "anthropic" | "openai" | "google";
+
+/**
+ * Structured warning emitted when a provider runtime drops or rewrites a
+ * caller-provided option. Mirrors the AI ecosystem convention (Vercel AI
+ * SDK, LangChain) of returning `unsupported-setting` warnings on the
+ * runtime result so callers can discover silently-dropped fields without
+ * having to read the source.
+ */
+export type ProviderWarning = {
+  type: "unsupported-setting" | "other";
+  setting?: string;
+  details?: string;
+  provider: ProviderKind;
+};
+
+/**
+ * Mutable warning collector handed to per-provider request builders so
+ * they can append entries during the build pass instead of plumbing a
+ * return-tuple shape through every helper.
+ */
+type WarningCollector = {
+  push(warning: ProviderWarning): void;
+  drain(): ProviderWarning[];
+};
+
+function createWarningCollector(): WarningCollector {
+  const list: ProviderWarning[] = [];
+  return {
+    push(warning) {
+      list.push(warning);
+    },
+    drain() {
+      return list.slice();
+    },
+  };
+}
+
+/**
+ * Base class for typed provider errors. The `retryable` flag is the
+ * primary signal for callers (or a retry wrapper) to decide whether to
+ * re-issue the request. `retryAfterMs` is set when the provider gave an
+ * explicit delay hint (Retry-After header, Retry-Info trailer).
+ */
+export class ProviderError extends Error {
+  readonly provider: ProviderKind;
+  readonly status: number;
+  readonly retryable: boolean;
+  readonly retryAfterMs?: number;
+
+  constructor(options: {
+    provider: ProviderKind;
+    status: number;
+    message: string;
+    retryable: boolean;
+    retryAfterMs?: number;
+  }) {
+    super(options.message);
+    this.name = new.target.name;
+    this.provider = options.provider;
+    this.status = options.status;
+    this.retryable = options.retryable;
+    if (options.retryAfterMs !== undefined) {
+      this.retryAfterMs = options.retryAfterMs;
+    }
+  }
+}
+
+/** Provider reports it is overloaded (Anthropic 529, OpenAI/Google 503). */
+export class ProviderOverloadedError extends ProviderError {}
+
+/** Provider is rate limiting this API key (OpenAI/Google 429 with Retry-After). */
+export class ProviderRateLimitError extends ProviderError {}
+
+/** Provider account quota is exhausted — non-retryable. */
+export class ProviderQuotaError extends ProviderError {}
+
+/** Non-retryable 4xx/5xx that doesn't fit another bucket. */
+export class ProviderRequestError extends ProviderError {}
+
+function parseRetryAfterMs(header: string | null): number | undefined {
+  if (!header) return undefined;
+  const asNumber = Number(header);
+  if (Number.isFinite(asNumber) && asNumber >= 0) {
+    return Math.round(asNumber * 1000);
+  }
+  // HTTP-date form (rare in practice for LLM providers).
+  const parsed = Date.parse(header);
+  if (!Number.isNaN(parsed)) {
+    return Math.max(0, parsed - Date.now());
+  }
+  return undefined;
+}
+
+/**
+ * Inspect a non-2xx response and build the most specific ProviderError
+ * subclass we can. Reads the response body as text (it's already dead
+ * on the wire by this point). Body classification handles the cases
+ * where HTTP status alone is ambiguous — notably OpenAI
+ * `insufficient_quota` vs `rate_limit_exceeded` both arriving as 429.
+ */
+async function buildProviderError(
+  provider: ProviderKind,
+  response: Response,
+): Promise<ProviderError> {
+  const rawBody = await response.text();
+  const message = rawBody.trim() || `${response.status} ${response.statusText}`.trim();
+  const status = response.status;
+  const retryAfterMs = parseRetryAfterMs(response.headers.get("retry-after"));
+
+  const parsedBody = (() => {
+    try {
+      return JSON.parse(rawBody) as Record<string, unknown>;
+    } catch {
+      return undefined;
+    }
+  })();
+  const errorRecord = readRecord(parsedBody?.error);
+  const errorCode = typeof errorRecord?.code === "string"
+    ? errorRecord.code
+    : typeof errorRecord?.type === "string"
+    ? errorRecord.type
+    : typeof errorRecord?.status === "string"
+    ? errorRecord.status
+    : undefined;
+
+  // Anthropic 529 = overloaded. Anthropic surfaces this with
+  // { error: { type: "overloaded_error" } } in the body.
+  if (provider === "anthropic" && status === 529) {
+    return new ProviderOverloadedError({
+      provider,
+      status,
+      message,
+      retryable: true,
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    });
+  }
+
+  // OpenAI / Google 503 = overloaded.
+  if ((provider === "openai" || provider === "google") && status === 503) {
+    return new ProviderOverloadedError({
+      provider,
+      status,
+      message,
+      retryable: true,
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    });
+  }
+
+  // OpenAI 429 splits based on the error code in the body:
+  //  - insufficient_quota → hard quota, non-retryable
+  //  - rate_limit_exceeded / tokens_per_min_exceeded → retry with Retry-After
+  if (provider === "openai" && status === 429) {
+    if (errorCode === "insufficient_quota") {
+      return new ProviderQuotaError({
+        provider,
+        status,
+        message,
+        retryable: false,
+      });
+    }
+    return new ProviderRateLimitError({
+      provider,
+      status,
+      message,
+      retryable: true,
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    });
+  }
+
+  // Google 429 RESOURCE_EXHAUSTED is almost always the daily free-tier
+  // quota — surface as a hard quota error so callers don't hot-loop on
+  // retries that can't possibly succeed until midnight UTC.
+  if (provider === "google" && status === 429) {
+    if (errorCode === "RESOURCE_EXHAUSTED") {
+      return new ProviderQuotaError({
+        provider,
+        status,
+        message,
+        retryable: false,
+      });
+    }
+    return new ProviderRateLimitError({
+      provider,
+      status,
+      message,
+      retryable: true,
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    });
+  }
+
+  return new ProviderRequestError({
+    provider,
+    status,
+    message,
+    retryable: false,
+  });
 }
 
 async function requestJson(options: {
@@ -297,11 +689,13 @@ async function requestJson(options: {
   fetchImpl: typeof globalThis.fetch;
   init: RequestInit;
   providerLabel: string;
+  providerKind: ProviderKind;
 }): Promise<unknown> {
   const response = await options.fetchImpl(options.url, options.init);
   if (!response.ok) {
-    const message = await readErrorMessage(response);
-    throw new Error(`${options.providerLabel} request failed: ${message}`);
+    const err = await buildProviderError(options.providerKind, response);
+    err.message = `${options.providerLabel} request failed: ${err.message}`;
+    throw err;
   }
 
   return response.json();
@@ -312,15 +706,22 @@ async function requestStream(options: {
   fetchImpl: typeof globalThis.fetch;
   init: RequestInit;
   providerLabel: string;
+  providerKind: ProviderKind;
 }): Promise<ReadableStream<Uint8Array>> {
   const response = await options.fetchImpl(options.url, options.init);
   if (!response.ok) {
-    const message = await readErrorMessage(response);
-    throw new Error(`${options.providerLabel} request failed: ${message}`);
+    const err = await buildProviderError(options.providerKind, response);
+    err.message = `${options.providerLabel} request failed: ${err.message}`;
+    throw err;
   }
 
   if (!response.body) {
-    throw new Error(`${options.providerLabel} request failed: stream body missing`);
+    throw new ProviderRequestError({
+      provider: options.providerKind,
+      status: response.status,
+      message: `${options.providerLabel} request failed: stream body missing`,
+      retryable: false,
+    });
   }
 
   return response.body;
@@ -364,6 +765,11 @@ function toOpenAICompatibleMessages(prompt: RuntimePromptMessage[]): OpenAICompa
         for (const part of message.content) {
           if (part.type === "text") {
             text += part.text;
+            continue;
+          }
+          // OpenAI Chat Completions has no roundtrip slot for Anthropic
+          // thinking blocks — they get dropped on replay. Anthropic-only.
+          if (part.type === "reasoning") {
             continue;
           }
 
@@ -473,9 +879,15 @@ function normalizeAnthropicFinishReason(
   }
 }
 
-function extractAnthropicUsage(payload: unknown):
-  | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
-  | undefined {
+type RuntimeUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+};
+
+function extractAnthropicUsage(payload: unknown): RuntimeUsage | undefined {
   const record = readRecord(payload);
   const usage = readRecord(record?.usage);
   if (!usage) {
@@ -484,6 +896,8 @@ function extractAnthropicUsage(payload: unknown):
 
   const inputTokens = usage.input_tokens;
   const outputTokens = usage.output_tokens;
+  const cacheCreationInputTokens = usage.cache_creation_input_tokens;
+  const cacheReadInputTokens = usage.cache_read_input_tokens;
 
   return {
     inputTokens: typeof inputTokens === "number" ? inputTokens : undefined,
@@ -492,17 +906,15 @@ function extractAnthropicUsage(payload: unknown):
       ? (typeof inputTokens === "number" ? inputTokens : 0) +
         (typeof outputTokens === "number" ? outputTokens : 0)
       : undefined,
+    ...(typeof cacheCreationInputTokens === "number" ? { cacheCreationInputTokens } : {}),
+    ...(typeof cacheReadInputTokens === "number" ? { cacheReadInputTokens } : {}),
   };
 }
 
 function mergeUsage(
-  current:
-    | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
-    | undefined,
-  next:
-    | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
-    | undefined,
-): { inputTokens?: number; outputTokens?: number; totalTokens?: number } | undefined {
+  current: RuntimeUsage | undefined,
+  next: RuntimeUsage | undefined,
+): RuntimeUsage | undefined {
   if (!current) {
     return next;
   }
@@ -513,11 +925,16 @@ function mergeUsage(
 
   const inputTokens = next.inputTokens ?? current.inputTokens;
   const outputTokens = next.outputTokens ?? current.outputTokens;
+  const cacheCreationInputTokens = next.cacheCreationInputTokens ??
+    current.cacheCreationInputTokens;
+  const cacheReadInputTokens = next.cacheReadInputTokens ?? current.cacheReadInputTokens;
 
   return {
     inputTokens,
     outputTokens,
     totalTokens: (inputTokens ?? 0) + (outputTokens ?? 0),
+    ...(cacheCreationInputTokens !== undefined ? { cacheCreationInputTokens } : {}),
+    ...(cacheReadInputTokens !== undefined ? { cacheReadInputTokens } : {}),
   };
 }
 
@@ -536,6 +953,26 @@ function toSnakeCaseRecord(record: Record<string, unknown>): Record<string, unkn
       value,
     ]),
   );
+}
+
+/**
+ * Recursive snake_case key converter for nested config objects (used for
+ * Anthropic mcp_servers, where authorizationToken / toolConfiguration /
+ * allowedTools all need conversion).
+ */
+function deepSnakeCase(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(deepSnakeCase);
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, v]) => [
+        key.replace(/[A-Z]/g, (match) => `_${match.toLowerCase()}`),
+        deepSnakeCase(v),
+      ]),
+    );
+  }
+  return value;
 }
 
 function pushAnthropicUserContent(
@@ -558,9 +995,32 @@ function pushAnthropicUserContent(
   });
 }
 
+/**
+ * Resolves a {@link ProviderCacheTtl} into Anthropic's `cache_control` shape.
+ *
+ * Returns `undefined` when caching is not requested (`false` / `undefined`),
+ * `{ type: "ephemeral" }` for the 5-minute default (`true` / `"5m"`), or
+ * `{ type: "ephemeral", ttl: "1h" }` for the extended 1-hour cache.
+ */
+function resolveAnthropicCacheControlBlock(
+  ttl: ProviderCacheTtl | undefined,
+): { type: "ephemeral"; ttl?: "1h" } | undefined {
+  if (ttl === undefined || ttl === false) {
+    return undefined;
+  }
+  if (ttl === "1h") {
+    return { type: "ephemeral", ttl: "1h" };
+  }
+  return { type: "ephemeral" };
+}
+
 function toAnthropicMessages(
   prompt: RuntimePromptMessage[],
-): { system?: string; messages: AnthropicCompatibleMessage[] } {
+  systemCacheControl?: { type: "ephemeral"; ttl?: "1h" },
+): {
+  system?: string | Array<Record<string, unknown>>;
+  messages: AnthropicCompatibleMessage[];
+} {
   const systemParts: string[] = [];
   const messages: AnthropicCompatibleMessage[] = [];
 
@@ -580,14 +1040,33 @@ function toAnthropicMessages(
       case "assistant":
         messages.push({
           role: "assistant",
-          content: message.content.map((part) =>
-            part.type === "text" ? { type: "text", text: part.text } : {
+          content: message.content.map((part) => {
+            if (part.type === "text") {
+              return { type: "text", text: part.text };
+            }
+            if (part.type === "reasoning") {
+              // Redacted thinking blocks roundtrip as the encrypted blob
+              // form Anthropic gave us. Plain thinking blocks need the
+              // signature to verify on the server.
+              if (typeof part.redactedData === "string") {
+                return {
+                  type: "redacted_thinking",
+                  data: part.redactedData,
+                };
+              }
+              return {
+                type: "thinking",
+                thinking: part.text ?? "",
+                ...(typeof part.signature === "string" ? { signature: part.signature } : {}),
+              };
+            }
+            return {
               type: "tool_use",
               id: part.toolCallId,
               name: part.toolName,
               input: part.input,
-            }
-          ),
+            };
+          }),
         });
         break;
       case "tool":
@@ -603,14 +1082,63 @@ function toAnthropicMessages(
     }
   }
 
-  return {
-    ...(systemParts.length > 0 ? { system: systemParts.join("\n\n") } : {}),
-    messages,
-  };
+  if (systemParts.length === 0) {
+    return { messages };
+  }
+
+  const joined = systemParts.join("\n\n");
+
+  // Cache-controlled system prompts must use the array-of-blocks form so the
+  // breakpoint lands on an individual content block. Callers that don't opt
+  // in keep the legacy raw-string form for backward compatibility.
+  if (systemCacheControl) {
+    return {
+      system: [{
+        type: "text",
+        text: joined,
+        cache_control: systemCacheControl,
+      }],
+      messages,
+    };
+  }
+
+  return { system: joined, messages };
+}
+
+/**
+ * Short-name → latest-versioned-type alias map for Anthropic provider tools.
+ *
+ * Anthropic tool types are date-stamped (e.g. `code_execution_20260120`) so
+ * callers either pin a version or get the latest. We accept both: a caller
+ * can pass `anthropic.code_execution` and we map to the latest known version,
+ * or pass `anthropic.code_execution_20250522` and we forward verbatim.
+ *
+ * Versions chosen here are the latest documented releases as of 2026-04-15
+ * — see https://docs.claude.com/en/docs/agents-and-tools/tool-use/overview.
+ * When Anthropic ships newer versions, update this map.
+ */
+const ANTHROPIC_TOOL_VERSION_ALIASES: Record<string, string> = {
+  code_execution: "code_execution_20260120",
+  computer_use: "computer_20250124",
+  computer: "computer_20250124",
+  text_editor: "text_editor_20250728",
+  bash: "bash_20250124",
+  memory: "memory_20250818",
+  web_search: "web_search_20250305",
+  web_fetch: "web_fetch_20250910",
+};
+
+function resolveAnthropicProviderType(rawType: string): string {
+  // Already-versioned types (contain a date stamp suffix) pass through verbatim.
+  if (/_\d{8}$/.test(rawType)) {
+    return rawType;
+  }
+  return ANTHROPIC_TOOL_VERSION_ALIASES[rawType] ?? rawType;
 }
 
 function toAnthropicTools(
   tools: RuntimeToolDefinition[] | undefined,
+  toolsCacheControl?: { type: "ephemeral"; ttl?: "1h" },
 ): Array<Record<string, unknown>> | undefined {
   if (!tools) {
     return undefined;
@@ -632,19 +1160,35 @@ function toAnthropicTools(
       continue;
     }
 
-    const providerType = tool.id.slice("anthropic.".length);
-    if (providerType.length === 0) {
+    const rawType = tool.id.slice("anthropic.".length);
+    if (rawType.length === 0) {
       continue;
     }
 
     normalized.push({
-      type: providerType,
+      type: resolveAnthropicProviderType(rawType),
       name: tool.name,
       ...toSnakeCaseRecord(tool.args),
     });
   }
 
-  return normalized.length > 0 ? normalized : undefined;
+  if (normalized.length === 0) {
+    return undefined;
+  }
+
+  // Attach the cache breakpoint to the final tool entry so Anthropic caches
+  // the entire tools block up to and including that definition. Earlier tool
+  // entries are implicitly covered by the same breakpoint per Anthropic's
+  // walk-backward cache lookup behaviour.
+  if (toolsCacheControl) {
+    const lastIndex = normalized.length - 1;
+    normalized[lastIndex] = {
+      ...normalized[lastIndex],
+      cache_control: toolsCacheControl,
+    };
+  }
+
+  return normalized;
 }
 
 function createAnthropicRequestHeaders(options: {
@@ -717,47 +1261,244 @@ function resolveAnthropicMaxTokens(
   return requested;
 }
 
+/**
+ * Map a unified reasoning effort level to an Anthropic `thinking.budget_tokens`
+ * value. Anthropic's minimum accepted budget is 1024; higher tiers give Claude
+ * more headroom to explore. `max` maps to the upper bound documented for
+ * Claude 4.x family (32k tokens of thinking — caller can override via
+ * `budgetTokens` if they need more).
+ */
+function resolveAnthropicThinkingBudget(
+  option: ProviderReasoningOption | undefined,
+): number | undefined {
+  if (!option || option.enabled !== true) {
+    return undefined;
+  }
+  if (typeof option.budgetTokens === "number" && option.budgetTokens >= 1024) {
+    return option.budgetTokens;
+  }
+  switch (option.effort) {
+    case "low":
+      return 1024;
+    case "high":
+      return 16_384;
+    case "max":
+      return 32_768;
+    case "medium":
+    default:
+      return 4096;
+  }
+}
+
 function buildAnthropicMessagesRequest(
   modelId: string,
   providerName: string,
   options: OpenAICompatibleLanguageOptions,
   stream: boolean,
+  warnings: WarningCollector,
 ): AnthropicCompatibleRequest {
-  const { system, messages } = toAnthropicMessages(options.prompt);
+  const systemCacheControl = resolveAnthropicCacheControlBlock(
+    options.cacheControl?.system,
+  );
+  const toolsCacheControl = resolveAnthropicCacheControlBlock(
+    options.cacheControl?.tools,
+  );
+
+  const { system, messages } = toAnthropicMessages(options.prompt, systemCacheControl);
+  const anthropicTools = toAnthropicTools(options.tools, toolsCacheControl);
+  const thinkingBudget = resolveAnthropicThinkingBudget(options.reasoning);
+  const thinkingEnabled = thinkingBudget !== undefined;
+
+  // Anthropic doesn't support these unified options at all — emit warnings
+  // so callers don't quietly pass values that have zero effect.
+  if (options.presencePenalty !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "anthropic",
+      setting: "presencePenalty",
+      details: "Anthropic Messages API has no equivalent and the value was dropped.",
+    });
+  }
+  if (options.frequencyPenalty !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "anthropic",
+      setting: "frequencyPenalty",
+      details: "Anthropic Messages API has no equivalent and the value was dropped.",
+    });
+  }
+  if (options.seed !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "anthropic",
+      setting: "seed",
+      details: "Anthropic Messages API does not support deterministic seeding.",
+    });
+  }
+  if (options.topK !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "anthropic",
+      setting: "topK",
+      details: "Anthropic Messages API does not expose top_k on this surface.",
+    });
+  }
+  if (
+    options.stopSequences && options.stopSequences.length > 4
+  ) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "anthropic",
+      setting: "stopSequences",
+      details:
+        `Anthropic accepts at most 4 stop sequences; ${options.stopSequences.length} were provided and the extras were truncated.`,
+    });
+  }
+  if (thinkingEnabled && options.temperature !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "anthropic",
+      setting: "temperature",
+      details:
+        "Dropped because Anthropic rejects sampling params when extended thinking is enabled.",
+    });
+  }
+  if (thinkingEnabled && options.topP !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "anthropic",
+      setting: "topP",
+      details:
+        "Dropped because Anthropic rejects sampling params when extended thinking is enabled.",
+    });
+  }
+  if (options.responseFormat && options.responseFormat.type !== "text") {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "anthropic",
+      setting: "responseFormat",
+      details:
+        "Anthropic Messages API does not have a structured-output response_format equivalent. Use a tool with the schema as input_schema instead.",
+    });
+  }
+
+  // Anthropic requires max_tokens > budget_tokens when thinking is enabled.
+  // Growing max_tokens by the thinking budget preserves the caller's intended
+  // output budget, and we clamp the sum at the model's advertised maximum so
+  // the request never exceeds the API's hard cap.
+  const baseMaxTokens = resolveAnthropicMaxTokens(modelId, options.maxOutputTokens);
+  const maxTokens = thinkingEnabled
+    ? Math.min(
+      baseMaxTokens + (thinkingBudget ?? 0),
+      getAnthropicModelCapabilities(modelId).maxOutputTokens,
+    )
+    : baseMaxTokens;
+
   const body: AnthropicCompatibleRequest = {
     model: modelId,
     messages,
-    max_tokens: resolveAnthropicMaxTokens(modelId, options.maxOutputTokens),
+    max_tokens: maxTokens,
     ...(stream ? { stream: true } : {}),
     ...(system ? { system } : {}),
-    ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
-    ...(options.topP !== undefined ? { top_p: options.topP } : {}),
-    ...(options.stopSequences && options.stopSequences.length > 0
-      ? { stop_sequences: options.stopSequences }
+    // Sampling params are mutually exclusive with thinking on Anthropic — the
+    // API rejects the combo outright. Drop them silently when thinking is on
+    // (callers see thinking's output instead of what they'd have gotten from
+    // custom sampling, which is the documented tradeoff).
+    ...(!thinkingEnabled && options.temperature !== undefined
+      ? { temperature: options.temperature }
       : {}),
-    ...(toAnthropicTools(options.tools) ? { tools: toAnthropicTools(options.tools) } : {}),
+    ...(!thinkingEnabled && options.topP !== undefined ? { top_p: options.topP } : {}),
+    ...(options.stopSequences && options.stopSequences.length > 0
+      ? { stop_sequences: options.stopSequences.slice(0, 4) }
+      : {}),
+    ...(anthropicTools ? { tools: anthropicTools } : {}),
     ...(options.toolChoice !== undefined
       ? { tool_choice: normalizeAnthropicToolChoice(options.toolChoice) }
       : {}),
+    ...(thinkingEnabled ? { thinking: { type: "enabled", budget_tokens: thinkingBudget } } : {}),
+    ...(typeof options.userId === "string" && options.userId.length > 0
+      ? { metadata: { user_id: options.userId } }
+      : {}),
+    ...(options.mcpServers && options.mcpServers.length > 0
+      ? { mcp_servers: deepSnakeCase(options.mcpServers) as unknown[] }
+      : {}),
+    ...(options.anthropicContainer !== undefined ? { container: options.anthropicContainer } : {}),
   };
 
   Object.assign(body, readProviderOptions(options.providerOptions, "anthropic", providerName));
   return body;
 }
 
+type AnthropicReasoningContent = {
+  type: "reasoning";
+  text?: string;
+  signature?: string;
+  redactedData?: string;
+};
+
+type AnthropicCitation = {
+  type: string;
+  citedText?: string;
+  url?: string;
+  title?: string;
+  startCharIndex?: number;
+  endCharIndex?: number;
+  startBlockIndex?: number;
+  endBlockIndex?: number;
+  startPageNumber?: number;
+  endPageNumber?: number;
+  documentIndex?: number;
+  documentTitle?: string;
+};
+
+type AnthropicTextContent = {
+  type: "text";
+  text: string;
+  citations?: AnthropicCitation[];
+};
+
+/**
+ * Best-effort camelCase normalization of a single Anthropic citation
+ * record. Handles the union of fields across web_search_result_location,
+ * web_fetch_result_location, char_location, page_location, and
+ * content_block_location citation kinds — see
+ * https://docs.claude.com/en/docs/build-with-claude/citations
+ */
+function normalizeAnthropicCitation(raw: unknown): AnthropicCitation | undefined {
+  const r = readRecord(raw);
+  if (!r) return undefined;
+  const typeStr = typeof r.type === "string" ? r.type : undefined;
+  if (!typeStr) return undefined;
+  const out: AnthropicCitation = { type: typeStr };
+  if (typeof r.cited_text === "string") out.citedText = r.cited_text;
+  if (typeof r.url === "string") out.url = r.url;
+  if (typeof r.title === "string") out.title = r.title;
+  if (typeof r.start_char_index === "number") out.startCharIndex = r.start_char_index;
+  if (typeof r.end_char_index === "number") out.endCharIndex = r.end_char_index;
+  if (typeof r.start_block_index === "number") out.startBlockIndex = r.start_block_index;
+  if (typeof r.end_block_index === "number") out.endBlockIndex = r.end_block_index;
+  if (typeof r.start_page_number === "number") out.startPageNumber = r.start_page_number;
+  if (typeof r.end_page_number === "number") out.endPageNumber = r.end_page_number;
+  if (typeof r.document_index === "number") out.documentIndex = r.document_index;
+  if (typeof r.document_title === "string") out.documentTitle = r.document_title;
+  return out;
+}
+
 function buildAnthropicGenerateResult(payload: unknown): {
   content: Array<
-    | { type: "text"; text: string }
+    | AnthropicTextContent
+    | AnthropicReasoningContent
     | { type: "tool-call"; toolCallId: string; toolName: string; input: string }
     | { type: "tool-result"; toolCallId: string; toolName: string; result: unknown }
   >;
   finishReason?: string | { unified: string; raw: string } | null;
-  usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+  usage?: RuntimeUsage;
 } {
   const record = readRecord(payload);
   const content = Array.isArray(record?.content) ? record.content : [];
   const normalized: Array<
-    | { type: "text"; text: string }
+    | AnthropicTextContent
+    | AnthropicReasoningContent
     | { type: "tool-call"; toolCallId: string; toolName: string; input: string }
     | { type: "tool-result"; toolCallId: string; toolName: string; result: unknown }
   > = [];
@@ -767,7 +1508,42 @@ function buildAnthropicGenerateResult(payload: unknown): {
     const blockType = typeof block?.type === "string" ? block.type : undefined;
 
     if (blockType === "text" && typeof block?.text === "string" && block.text.length > 0) {
-      normalized.push({ type: "text", text: block.text });
+      const citationsRaw = Array.isArray(block.citations) ? block.citations : undefined;
+      const citations = citationsRaw
+        ?.flatMap((c) => {
+          const normalizedCitation = normalizeAnthropicCitation(c);
+          return normalizedCitation ? [normalizedCitation] : [];
+        });
+      normalized.push({
+        type: "text",
+        text: block.text,
+        ...(citations && citations.length > 0 ? { citations } : {}),
+      });
+      continue;
+    }
+
+    // Thinking blocks carry the cleartext trace plus a signature that
+    // Anthropic uses to verify on subsequent turns. Surfacing both lets
+    // callers persist them as `reasoning` content parts and replay on
+    // the next turn so Claude can continue from the same thinking.
+    if (blockType === "thinking") {
+      normalized.push({
+        type: "reasoning",
+        ...(typeof block?.thinking === "string" ? { text: block.thinking } : {}),
+        ...(typeof block?.signature === "string" ? { signature: block.signature } : {}),
+      });
+      continue;
+    }
+
+    // Redacted thinking blocks arrive when Claude's safety classifier
+    // hides the trace. Pass the encrypted blob through opaquely so the
+    // caller can replay it on the next turn (Anthropic still needs the
+    // blob to verify continuity even though it can't read it).
+    if (blockType === "redacted_thinking" && typeof block?.data === "string") {
+      normalized.push({
+        type: "reasoning",
+        redactedData: block.data,
+      });
       continue;
     }
 
@@ -857,7 +1633,7 @@ async function* streamAnthropicCompatibleParts(
   const toolCalls = new Map<number, AnthropicStreamToolCallState>();
   const reasoningBlocks = new Map<number, AnthropicStreamReasoningState>();
   let finishReason: string | { unified: string; raw: string } | null = null;
-  let usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number } | undefined;
+  let usage: RuntimeUsage | undefined;
 
   for await (const chunk of stream) {
     buffer += decoder.decode(chunk, { stream: true });
@@ -906,6 +1682,20 @@ async function* streamAnthropicCompatibleParts(
               delta: contentBlock.thinking,
             };
           }
+          continue;
+        }
+
+        // Redacted thinking blocks arrive as opaque encrypted payloads when
+        // Claude's safety classifier flags the reasoning trace. Surface them
+        // as a zero-length reasoning block so callers know thinking happened
+        // without leaking the (legitimately hidden) contents.
+        if (blockType === "redacted_thinking") {
+          const reasoningId = `thinking-${index}`;
+          reasoningBlocks.set(index, { id: reasoningId });
+          yield {
+            type: "reasoning-start",
+            id: reasoningId,
+          };
           continue;
         }
 
@@ -1094,9 +1884,7 @@ function normalizeOpenAIFinishReason(
   return raw;
 }
 
-function extractOpenAIUsage(payload: unknown):
-  | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
-  | undefined {
+function extractOpenAIUsage(payload: unknown): RuntimeUsage | undefined {
   const record = readRecord(payload);
   const usage = readRecord(record?.usage);
   if (!usage) {
@@ -1106,11 +1894,14 @@ function extractOpenAIUsage(payload: unknown):
   const inputTokens = usage.prompt_tokens;
   const outputTokens = usage.completion_tokens;
   const totalTokens = usage.total_tokens;
+  const promptTokensDetails = readRecord(usage.prompt_tokens_details);
+  const cachedTokens = promptTokensDetails?.cached_tokens;
 
   return {
     inputTokens: typeof inputTokens === "number" ? inputTokens : undefined,
     outputTokens: typeof outputTokens === "number" ? outputTokens : undefined,
     totalTokens: typeof totalTokens === "number" ? totalTokens : undefined,
+    ...(typeof cachedTokens === "number" ? { cacheReadInputTokens: cachedTokens } : {}),
   };
 }
 
@@ -1165,19 +1956,95 @@ function extractOpenAIToolCalls(message: Record<string, unknown>): Array<{
   return normalized;
 }
 
+/**
+ * OpenAI reasoning models (o1 / o3 / o4 family) use the completion path but
+ * have different constraints than chat models: sampling params are rejected,
+ * and they accept a `reasoning_effort` field. We detect them by model id
+ * prefix so callers don't have to configure it per runtime.
+ */
+function isOpenAIReasoningModel(modelId: string): boolean {
+  return /^o[134](-|$)/.test(modelId);
+}
+
+/**
+ * Map the unified reasoning effort to OpenAI's `reasoning_effort` enum.
+ * OpenAI doesn't accept "max" — we collapse it to "high".
+ */
+function resolveOpenAIReasoningEffort(
+  option: ProviderReasoningOption | undefined,
+): "low" | "medium" | "high" | undefined {
+  if (!option || option.enabled !== true) {
+    return undefined;
+  }
+  switch (option.effort) {
+    case "low":
+      return "low";
+    case "high":
+    case "max":
+      return "high";
+    case "medium":
+    default:
+      return "medium";
+  }
+}
+
 function buildOpenAIChatRequest(
   modelId: string,
   providerName: string,
   options: OpenAICompatibleLanguageOptions,
   stream: boolean,
+  warnings: WarningCollector,
 ): OpenAICompatibleChatRequest {
+  const isReasoningModel = isOpenAIReasoningModel(modelId);
+  const reasoningEffort = resolveOpenAIReasoningEffort(options.reasoning);
+  const reasoningEnabled = isReasoningModel || reasoningEffort !== undefined;
+
+  // OpenAI Chat Completions has no top_k surface (it's exposed only on the
+  // Responses API for some reasoning models). Quietly accepting it would
+  // mislead callers into thinking it took effect.
+  if (options.topK !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "openai",
+      setting: "topK",
+      details: "OpenAI Chat Completions does not expose top_k; the value was dropped.",
+    });
+  }
+
+  // Reasoning models (o1 / o3 / o4) reject sampling params outright. Emit
+  // warnings at build time so callers see *why* the value didn't apply
+  // rather than a 400 from the API.
+  if (reasoningEnabled) {
+    const dropped: Array<[keyof typeof options, string]> = [
+      ["temperature", "temperature"],
+      ["topP", "top_p"],
+      ["presencePenalty", "presence_penalty"],
+      ["frequencyPenalty", "frequency_penalty"],
+    ];
+    for (const [key, openaiName] of dropped) {
+      if (options[key] !== undefined) {
+        warnings.push({
+          type: "unsupported-setting",
+          provider: "openai",
+          setting: key,
+          details:
+            `Dropped because OpenAI reasoning models reject ${openaiName}. Reasoning was active for this request.`,
+        });
+      }
+    }
+  }
+
   const body: OpenAICompatibleChatRequest = {
     model: modelId,
     messages: toOpenAICompatibleMessages(options.prompt),
     ...(stream ? { stream: true, stream_options: { include_usage: true } } : {}),
     ...(options.maxOutputTokens !== undefined ? { max_tokens: options.maxOutputTokens } : {}),
-    ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
-    ...(options.topP !== undefined ? { top_p: options.topP } : {}),
+    // OpenAI reasoning models reject temperature / top_p / frequency / presence.
+    // Drop them silently rather than letting the API bounce the request.
+    ...(!reasoningEnabled && options.temperature !== undefined
+      ? { temperature: options.temperature }
+      : {}),
+    ...(!reasoningEnabled && options.topP !== undefined ? { top_p: options.topP } : {}),
     ...(options.stopSequences && options.stopSequences.length > 0
       ? { stop: options.stopSequences }
       : {}),
@@ -1186,9 +2053,36 @@ function buildOpenAIChatRequest(
       : {}),
     ...(options.toolChoice !== undefined ? { tool_choice: options.toolChoice } : {}),
     ...(options.seed !== undefined ? { seed: options.seed } : {}),
-    ...(options.presencePenalty !== undefined ? { presence_penalty: options.presencePenalty } : {}),
-    ...(options.frequencyPenalty !== undefined
+    ...(!reasoningEnabled && options.presencePenalty !== undefined
+      ? { presence_penalty: options.presencePenalty }
+      : {}),
+    ...(!reasoningEnabled && options.frequencyPenalty !== undefined
       ? { frequency_penalty: options.frequencyPenalty }
+      : {}),
+    ...(reasoningEffort !== undefined ? { reasoning_effort: reasoningEffort } : {}),
+    ...(typeof options.userId === "string" && options.userId.length > 0
+      ? { user: options.userId }
+      : {}),
+    ...(options.serviceTier !== undefined ? { service_tier: options.serviceTier } : {}),
+    ...(options.parallelToolCalls !== undefined
+      ? { parallel_tool_calls: options.parallelToolCalls }
+      : {}),
+    ...(options.responseFormat && options.responseFormat.type !== "text"
+      ? {
+        response_format: options.responseFormat.type === "json" ? { type: "json_object" } : {
+          type: "json_schema",
+          json_schema: {
+            name: options.responseFormat.name,
+            ...(typeof options.responseFormat.description === "string"
+              ? { description: options.responseFormat.description }
+              : {}),
+            schema: unwrapToolInputSchema(options.responseFormat.schema),
+            ...(options.responseFormat.strict !== undefined
+              ? { strict: options.responseFormat.strict }
+              : {}),
+          },
+        },
+      }
       : {}),
   };
 
@@ -1216,9 +2110,7 @@ function normalizeGoogleFinishReason(
   }
 }
 
-function extractGoogleUsage(payload: unknown):
-  | { inputTokens?: number; outputTokens?: number; totalTokens?: number }
-  | undefined {
+function extractGoogleUsage(payload: unknown): RuntimeUsage | undefined {
   const record = readRecord(payload);
   const usage = readRecord(record?.usageMetadata);
   if (!usage) {
@@ -1228,11 +2120,15 @@ function extractGoogleUsage(payload: unknown):
   const inputTokens = usage.promptTokenCount;
   const outputTokens = usage.candidatesTokenCount;
   const totalTokens = usage.totalTokenCount;
+  const cachedContentTokenCount = usage.cachedContentTokenCount;
 
   return {
     inputTokens: typeof inputTokens === "number" ? inputTokens : undefined,
     outputTokens: typeof outputTokens === "number" ? outputTokens : undefined,
     totalTokens: typeof totalTokens === "number" ? totalTokens : undefined,
+    ...(typeof cachedContentTokenCount === "number"
+      ? { cacheReadInputTokens: cachedContentTokenCount }
+      : {}),
   };
 }
 
@@ -1258,20 +2154,29 @@ function toGoogleContents(
           parts: [{ text: readTextParts(message.content) }],
         });
         break;
-      case "assistant":
-        contents.push({
-          role: "model",
-          parts: message.content.map((part) =>
-            part.type === "text" ? { text: part.text } : {
-              functionCall: {
-                id: part.toolCallId,
-                name: part.toolName,
-                args: part.input,
-              },
-            }
-          ),
-        });
+      case "assistant": {
+        // Anthropic-only `reasoning` parts have no Gemini equivalent
+        // and are dropped on replay.
+        const parts: Array<Record<string, unknown>> = [];
+        for (const part of message.content) {
+          if (part.type === "text") {
+            parts.push({ text: part.text });
+            continue;
+          }
+          if (part.type === "reasoning") {
+            continue;
+          }
+          parts.push({
+            functionCall: {
+              id: part.toolCallId,
+              name: part.toolName,
+              args: part.input,
+            },
+          });
+        }
+        contents.push({ role: "model", parts });
         break;
+      }
       case "tool":
         contents.push({
           role: "user",
@@ -1299,22 +2204,45 @@ function toGoogleContents(
 
 function toGoogleTools(
   tools: RuntimeToolDefinition[] | undefined,
-): GoogleCompatibleRequest["tools"] | undefined {
+): Array<Record<string, unknown>> | undefined {
   if (!tools) {
     return undefined;
   }
 
-  const functionDeclarations = tools.flatMap((tool) =>
-    tool.type === "function"
-      ? [{
+  const functionDeclarations: Array<Record<string, unknown>> = [];
+  const providerEntries: Array<Record<string, unknown>> = [];
+
+  for (const tool of tools) {
+    if (tool.type === "function") {
+      functionDeclarations.push({
         name: tool.name,
         ...(typeof tool.description === "string" ? { description: tool.description } : {}),
         parameters: unwrapToolInputSchema(tool.inputSchema),
-      }]
-      : []
-  );
+      });
+      continue;
+    }
 
-  return functionDeclarations.length > 0 ? [{ functionDeclarations }] : undefined;
+    // Gemini provider tools — code_execution, google_search,
+    // google_search_retrieval — each lives in its own tools[] entry
+    // with a single key keyed by the camelCase tool name and an
+    // optional config payload (caller-provided tool.args).
+    if (!tool.id.startsWith("google.")) {
+      continue;
+    }
+    const providerType = tool.id.slice("google.".length);
+    if (providerType.length === 0) {
+      continue;
+    }
+    const camelKey = providerType.replace(/_([a-z])/g, (_, ch) => ch.toUpperCase());
+    providerEntries.push({ [camelKey]: tool.args ?? {} });
+  }
+
+  const result: Array<Record<string, unknown>> = [];
+  if (functionDeclarations.length > 0) {
+    result.push({ functionDeclarations });
+  }
+  result.push(...providerEntries);
+  return result.length > 0 ? result : undefined;
 }
 
 function unwrapToolInputSchema(inputSchema: unknown): unknown {
@@ -1346,7 +2274,11 @@ function normalizeGoogleToolChoice(toolChoice: unknown):
   }
 
   const record = readRecord(toolChoice);
-  if (record?.type === "tool" && typeof record.name === "string") {
+  if (!record) return undefined;
+
+  // Single-tool restriction: { type: "tool", name } — pin to one
+  // function via mode: ANY + allowedFunctionNames: [name].
+  if (record.type === "tool" && typeof record.name === "string") {
     return {
       functionCallingConfig: {
         mode: "ANY",
@@ -1355,12 +2287,74 @@ function normalizeGoogleToolChoice(toolChoice: unknown):
     };
   }
 
+  // Multi-tool restriction: { type: "tools", names: string[] } — pin
+  // to a subset via mode: ANY + the full allowedFunctionNames array.
+  if (record.type === "tools" && Array.isArray(record.names)) {
+    const names = record.names.filter((n): n is string => typeof n === "string");
+    if (names.length > 0) {
+      return {
+        functionCallingConfig: {
+          mode: "ANY",
+          allowedFunctionNames: names,
+        },
+      };
+    }
+  }
+
+  // Explicit mode forms: { type: "auto" | "none" | "any" }.
+  if (record.type === "auto") {
+    return { functionCallingConfig: { mode: "AUTO" } };
+  }
+  if (record.type === "none") {
+    return { functionCallingConfig: { mode: "NONE" } };
+  }
+  if (record.type === "any" || record.type === "required") {
+    return { functionCallingConfig: { mode: "ANY" } };
+  }
+
   return undefined;
+}
+
+/**
+ * Map the unified reasoning option to Gemini's thinkingConfig. Gemini 2.5+
+ * accepts `includeThoughts: true` to stream back `thought` parts, and
+ * `thinkingBudget: N` to cap the thinking token count. The effort levels
+ * here follow Google's own guidance (low ~= 512, medium ~= 2048,
+ * high ~= 8192, max = -1 means "dynamic/no cap").
+ */
+function resolveGoogleThinkingConfig(
+  option: ProviderReasoningOption | undefined,
+): Record<string, unknown> | undefined {
+  if (!option || option.enabled !== true) {
+    return undefined;
+  }
+  const config: Record<string, unknown> = { includeThoughts: true };
+  if (typeof option.budgetTokens === "number") {
+    config.thinkingBudget = option.budgetTokens;
+    return config;
+  }
+  switch (option.effort) {
+    case "low":
+      config.thinkingBudget = 512;
+      break;
+    case "high":
+      config.thinkingBudget = 8192;
+      break;
+    case "max":
+      config.thinkingBudget = -1;
+      break;
+    case "medium":
+    default:
+      config.thinkingBudget = 2048;
+      break;
+  }
+  return config;
 }
 
 function buildGoogleGenerationConfig(
   options: OpenAICompatibleLanguageOptions,
 ): Record<string, unknown> | undefined {
+  const thinkingConfig = resolveGoogleThinkingConfig(options.reasoning);
   const config: Record<string, unknown> = {
     ...(options.maxOutputTokens !== undefined ? { maxOutputTokens: options.maxOutputTokens } : {}),
     ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
@@ -1370,6 +2364,7 @@ function buildGoogleGenerationConfig(
       ? { stopSequences: options.stopSequences }
       : {}),
     ...(options.seed !== undefined ? { seed: options.seed } : {}),
+    ...(thinkingConfig ? { thinkingConfig } : {}),
   };
 
   return Object.keys(config).length > 0 ? config : undefined;
@@ -1378,8 +2373,47 @@ function buildGoogleGenerationConfig(
 function buildGoogleGenerateContentRequest(
   providerName: string,
   options: OpenAICompatibleLanguageOptions,
+  warnings: WarningCollector,
 ): GoogleCompatibleRequest {
+  // Google generate-content surface doesn't accept presence/frequency
+  // penalties on most current models. Emit warnings and let the request
+  // through without them.
+  if (options.presencePenalty !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "google",
+      setting: "presencePenalty",
+      details: "Gemini generateContent does not accept presencePenalty; the value was dropped.",
+    });
+  }
+  if (options.frequencyPenalty !== undefined) {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "google",
+      setting: "frequencyPenalty",
+      details: "Gemini generateContent does not accept frequencyPenalty; the value was dropped.",
+    });
+  }
+  if (options.responseFormat && options.responseFormat.type !== "text") {
+    warnings.push({
+      type: "unsupported-setting",
+      provider: "google",
+      setting: "responseFormat",
+      details:
+        "Gemini uses generationConfig.responseMimeType + responseSchema for structured outputs, which is a separate surface and not yet wired through this option.",
+    });
+  }
+
   const { systemInstruction, contents } = toGoogleContents(options.prompt);
+  const generationConfig = buildGoogleGenerationConfig(options);
+  // requestLabels wins over userId-derived labels: when callers explicitly
+  // provide a label map, that's the source of truth. Otherwise fall back
+  // to {user_id} derived from the unified userId option.
+  const labels = options.requestLabels && Object.keys(options.requestLabels).length > 0
+    ? options.requestLabels
+    : typeof options.userId === "string" && options.userId.length > 0
+    ? { user_id: options.userId }
+    : undefined;
   const body: GoogleCompatibleRequest = {
     contents,
     ...(systemInstruction ? { systemInstruction } : {}),
@@ -1387,8 +2421,13 @@ function buildGoogleGenerateContentRequest(
     ...(normalizeGoogleToolChoice(options.toolChoice)
       ? { toolConfig: normalizeGoogleToolChoice(options.toolChoice) }
       : {}),
-    ...(buildGoogleGenerationConfig(options)
-      ? { generationConfig: buildGoogleGenerationConfig(options) }
+    ...(generationConfig ? { generationConfig } : {}),
+    ...(labels ? { labels } : {}),
+    ...(typeof options.googleCachedContent === "string" && options.googleCachedContent.length > 0
+      ? { cachedContent: options.googleCachedContent }
+      : {}),
+    ...(options.googleSafetySettings && options.googleSafetySettings.length > 0
+      ? { safetySettings: options.googleSafetySettings }
       : {}),
   };
 
@@ -1426,7 +2465,8 @@ function buildGoogleGenerateResult(payload: unknown): {
     | { type: "tool-call"; toolCallId: string; toolName: string; input: string }
   >;
   finishReason?: string | { unified: string; raw: string } | null;
-  usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+  usage?: RuntimeUsage;
+  groundingMetadata?: Record<string, unknown>;
 } {
   const parts = extractGoogleCandidateParts(payload);
   const content: Array<
@@ -1451,10 +2491,19 @@ function buildGoogleGenerateResult(payload: unknown): {
     }
   }
 
+  // Gemini grounding (google_search / google_search_retrieval) returns
+  // a per-candidate groundingMetadata object with web search queries,
+  // grounding chunks, and citation indices into the response text.
+  // Pass it through opaquely so callers can render footnotes / source
+  // chips / "Search results" UI without parsing the wire shape.
+  const candidate = extractFirstGoogleCandidate(payload);
+  const groundingMetadata = readRecord(candidate?.groundingMetadata);
+
   return {
     content,
-    finishReason: normalizeGoogleFinishReason(extractFirstGoogleCandidate(payload)?.finishReason),
+    finishReason: normalizeGoogleFinishReason(candidate?.finishReason),
     usage: extractGoogleUsage(payload),
+    ...(groundingMetadata ? { groundingMetadata } : {}),
   };
 }
 
@@ -1467,7 +2516,7 @@ async function* streamGoogleCompatibleParts(
   let reasoningId: string | null = null;
   let reasoningIndex = 0;
   let finishReason: string | { unified: string; raw: string } | null = null;
-  let usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number } | undefined;
+  let usage: RuntimeUsage | undefined;
 
   for await (const chunk of stream) {
     buffer += decoder.decode(chunk, { stream: true });
@@ -1599,7 +2648,7 @@ function buildOpenAIGenerateResult(payload: unknown): {
     }
   >;
   finishReason?: string | { unified: string; raw: string } | null;
-  usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+  usage?: RuntimeUsage;
 } {
   const choice = extractFirstChoice(payload);
   const message = readRecord(choice?.message);
@@ -1630,7 +2679,7 @@ async function* streamOpenAICompatibleParts(
   let reasoningId: string | null = null;
   let reasoningIndex = 0;
   let finishReason: string | { unified: string; raw: string } | null = null;
-  let usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number } | undefined;
+  let usage: RuntimeUsage | undefined;
 
   for await (const chunk of stream) {
     buffer += decoder.decode(chunk, { stream: true });
@@ -1788,11 +2837,19 @@ export function createOpenAIModelRuntime(
     doGenerate(optionsForRuntime: unknown) {
       const options = optionsForRuntime as OpenAICompatibleLanguageOptions;
       const url = getOpenAIChatCompletionsUrl(config.baseURL);
-      const body = buildOpenAIChatRequest(modelId, config.name ?? "openai", options, false);
+      const warnings = createWarningCollector();
+      const body = buildOpenAIChatRequest(
+        modelId,
+        config.name ?? "openai",
+        options,
+        false,
+        warnings,
+      );
       return requestJson({
         url,
         fetchImpl,
         providerLabel: config.name ?? "openai",
+        providerKind: "openai",
         init: {
           method: "POST",
           headers: createRequestHeaders({
@@ -1803,16 +2860,30 @@ export function createOpenAIModelRuntime(
           body: JSON.stringify(body),
           signal: options.abortSignal,
         },
-      }).then(buildOpenAIGenerateResult);
+      }).then((payload) => {
+        const drained = warnings.drain();
+        return {
+          ...buildOpenAIGenerateResult(payload),
+          ...(drained.length > 0 ? { warnings: drained } : {}),
+        };
+      });
     },
     doStream(optionsForRuntime: unknown) {
       const options = optionsForRuntime as OpenAICompatibleLanguageOptions;
       const url = getOpenAIChatCompletionsUrl(config.baseURL);
-      const body = buildOpenAIChatRequest(modelId, config.name ?? "openai", options, true);
+      const warnings = createWarningCollector();
+      const body = buildOpenAIChatRequest(
+        modelId,
+        config.name ?? "openai",
+        options,
+        true,
+        warnings,
+      );
       return requestStream({
         url,
         fetchImpl,
         providerLabel: config.name ?? "openai",
+        providerKind: "openai",
         init: {
           method: "POST",
           headers: createRequestHeaders({
@@ -1823,9 +2894,13 @@ export function createOpenAIModelRuntime(
           body: JSON.stringify(body),
           signal: options.abortSignal,
         },
-      }).then((responseStream) => ({
-        stream: ReadableStream.from(streamOpenAICompatibleParts(responseStream)),
-      }));
+      }).then((responseStream) => {
+        const drained = warnings.drain();
+        return {
+          stream: ReadableStream.from(streamOpenAICompatibleParts(responseStream)),
+          ...(drained.length > 0 ? { warnings: drained } : {}),
+        };
+      });
     },
   };
 }
@@ -1843,16 +2918,19 @@ export function createAnthropicModelRuntime(
     doGenerate(optionsForRuntime: unknown) {
       const options = optionsForRuntime as OpenAICompatibleLanguageOptions;
       const url = getAnthropicMessagesUrl(config.baseURL);
+      const warnings = createWarningCollector();
       const body = buildAnthropicMessagesRequest(
         modelId,
         config.name ?? "anthropic",
         options,
         false,
+        warnings,
       );
       return requestJson({
         url,
         fetchImpl,
         providerLabel: config.name ?? "anthropic",
+        providerKind: "anthropic",
         init: {
           method: "POST",
           headers: createAnthropicRequestHeaders({
@@ -1863,21 +2941,30 @@ export function createAnthropicModelRuntime(
           body: JSON.stringify(body),
           signal: options.abortSignal,
         },
-      }).then(buildAnthropicGenerateResult);
+      }).then((payload) => {
+        const drained = warnings.drain();
+        return {
+          ...buildAnthropicGenerateResult(payload),
+          ...(drained.length > 0 ? { warnings: drained } : {}),
+        };
+      });
     },
     doStream(optionsForRuntime: unknown) {
       const options = optionsForRuntime as OpenAICompatibleLanguageOptions;
       const url = getAnthropicMessagesUrl(config.baseURL);
+      const warnings = createWarningCollector();
       const body = buildAnthropicMessagesRequest(
         modelId,
         config.name ?? "anthropic",
         options,
         true,
+        warnings,
       );
       return requestStream({
         url,
         fetchImpl,
         providerLabel: config.name ?? "anthropic",
+        providerKind: "anthropic",
         init: {
           method: "POST",
           headers: createAnthropicRequestHeaders({
@@ -1888,9 +2975,13 @@ export function createAnthropicModelRuntime(
           body: JSON.stringify(body),
           signal: options.abortSignal,
         },
-      }).then((responseStream) => ({
-        stream: ReadableStream.from(streamAnthropicCompatibleParts(responseStream)),
-      }));
+      }).then((responseStream) => {
+        const drained = warnings.drain();
+        return {
+          stream: ReadableStream.from(streamAnthropicCompatibleParts(responseStream)),
+          ...(drained.length > 0 ? { warnings: drained } : {}),
+        };
+      });
     },
   };
 }
@@ -1908,11 +2999,17 @@ export function createGoogleModelRuntime(
     doGenerate(optionsForRuntime: unknown) {
       const options = optionsForRuntime as OpenAICompatibleLanguageOptions;
       const url = getGoogleGenerateContentUrl(config.baseURL, modelId);
-      const body = buildGoogleGenerateContentRequest(config.name ?? "google", options);
+      const warnings = createWarningCollector();
+      const body = buildGoogleGenerateContentRequest(
+        config.name ?? "google",
+        options,
+        warnings,
+      );
       return requestJson({
         url,
         fetchImpl,
         providerLabel: config.name ?? "google",
+        providerKind: "google",
         init: {
           method: "POST",
           headers: createRequestHeaders({
@@ -1923,16 +3020,28 @@ export function createGoogleModelRuntime(
           body: JSON.stringify(body),
           signal: options.abortSignal,
         },
-      }).then(buildGoogleGenerateResult);
+      }).then((payload) => {
+        const drained = warnings.drain();
+        return {
+          ...buildGoogleGenerateResult(payload),
+          ...(drained.length > 0 ? { warnings: drained } : {}),
+        };
+      });
     },
     doStream(optionsForRuntime: unknown) {
       const options = optionsForRuntime as OpenAICompatibleLanguageOptions;
       const url = getGoogleStreamGenerateContentUrl(config.baseURL, modelId);
-      const body = buildGoogleGenerateContentRequest(config.name ?? "google", options);
+      const warnings = createWarningCollector();
+      const body = buildGoogleGenerateContentRequest(
+        config.name ?? "google",
+        options,
+        warnings,
+      );
       return requestStream({
         url,
         fetchImpl,
         providerLabel: config.name ?? "google",
+        providerKind: "google",
         init: {
           method: "POST",
           headers: createRequestHeaders({
@@ -1943,9 +3052,13 @@ export function createGoogleModelRuntime(
           body: JSON.stringify(body),
           signal: options.abortSignal,
         },
-      }).then((responseStream) => ({
-        stream: ReadableStream.from(streamGoogleCompatibleParts(responseStream)),
-      }));
+      }).then((responseStream) => {
+        const drained = warnings.drain();
+        return {
+          stream: ReadableStream.from(streamGoogleCompatibleParts(responseStream)),
+          ...(drained.length > 0 ? { warnings: drained } : {}),
+        };
+      });
     },
   };
 }
@@ -1973,6 +3086,7 @@ export function createOpenAIEmbeddingRuntime(
         url,
         fetchImpl,
         providerLabel: config.name ?? "openai",
+        providerKind: "openai",
         init: {
           method: "POST",
           headers: {
@@ -2021,6 +3135,7 @@ export function createGoogleEmbeddingRuntime(
           url,
           fetchImpl,
           providerLabel: config.name ?? "google",
+          providerKind: "google",
           init: {
             method: "POST",
             headers: {

--- a/src/provider/types.ts
+++ b/src/provider/types.ts
@@ -9,10 +9,12 @@ export interface ModelRuntimeGenerateResult {
   content?: unknown[];
   finishReason?: unknown;
   usage?: unknown;
+  warnings?: unknown[];
 }
 
 export interface ModelRuntimeStreamResult {
   stream: ReadableStream<unknown>;
+  warnings?: unknown[];
 }
 
 export interface ModelRuntime extends RuntimeMetadata {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.207";
+export const VERSION = "0.1.208";


### PR DESCRIPTION
## Summary

Implements the full provider capability audit (#1044) in a single patch release. Originally landed as 18 stacked PRs (#1057–#1075); consolidated here because the per-PR version bumps would have caused 17 cascading rebase conflicts on merge.

Closes #1045, #1046, #1047, #1048, #1049, #1050, #1051, #1053. Refs #1044, #1052 (C4 deferred — see below).

## Why one PR

The 18 stacked PRs each bumped the version sequentially (\`0.1.207 → 0.1.224\`). When PR #1062 landed on main bumping to 0.1.207 independently, every PR in the stack would have hit a version-file rebase conflict on merge — 17 manual conflicts in a row. The work is also tightly coupled (all touches \`runtime-loader.ts\` + \`types.ts\`), so consolidation costs nothing in review surface that the PR description below doesn't restore.

The 18 original PRs are linked by section so reviewers can read each piece in isolation.

## Cross-provider (PRs #1057–#1063)

### Prompt caching (closes #1045) — was #1057

- New \`cacheControl?: { system?, tools? }\` option on \`OpenAICompatibleLanguageOptions\`.
- Anthropic system prompts switch from string form to array-of-blocks form with \`cache_control: { type: \"ephemeral\" }\` when set. Last tool entry gets the breakpoint when \`cacheControl.tools\` is set, leveraging Anthropic's walk-backward cache lookup.
- Supports \`true\` / \`\"5m\"\` / \`\"1h\"\` TTL values.
- OpenAI: no-op (server-side automatic). Google: deferred to D1.

### Cache usage reporting (closes #1046) — was #1058

- New unified \`RuntimeUsage\` shape with \`cacheCreationInputTokens?\` and \`cacheReadInputTokens?\`.
- Anthropic parses \`cache_creation_input_tokens\` + \`cache_read_input_tokens\`. OpenAI parses \`prompt_tokens_details.cached_tokens\`. Google parses \`cachedContentTokenCount\`.
- Cache fields use conditional spread so backward-compat strict-equality assertions on usage objects still pass.

### Reasoning / thinking (closes #1047) — was #1059

- New unified \`reasoning?: { enabled?, effort?, budgetTokens? }\` option.
- Anthropic: emits \`thinking: { type: \"enabled\", budget_tokens }\`, grows \`max_tokens\` by the budget, clamps at the model cap, drops temperature/topP. Effort low/medium/high/max → 1024/4096/16384/32768 budget_tokens.
- OpenAI: detects o1/o3/o4 reasoning models by id prefix, emits \`reasoning_effort\`, drops sampling params (\`max\` collapses to \`high\`).
- Google: emits \`generationConfig.thinkingConfig: { includeThoughts, thinkingBudget }\` on Gemini 2.5+. Effort \`max\` → \`-1\` (dynamic).
- Anthropic stream parser handles \`redacted_thinking\` content blocks.

### Retry-on-transient errors (closes #1048) — was #1060

- New typed \`ProviderError\` hierarchy: \`ProviderOverloadedError\` (Anthropic 529, OpenAI/Google 503), \`ProviderRateLimitError\` (OpenAI 429 \`rate_limit_exceeded\` with \`Retry-After\` → \`retryAfterMs\`), \`ProviderQuotaError\` (OpenAI \`insufficient_quota\`, Google \`RESOURCE_EXHAUSTED\` — non-retryable), \`ProviderRequestError\` (catch-all).
- \`buildProviderError\` reads response body once, parses error.code/type/status, picks the most specific subclass.
- Disambiguates OpenAI 429 split (rate-limit vs quota) — prevents hot-loop on insufficient_quota.

### Provider warnings (closes #1049) — was #1061

- New \`ProviderWarning\` type and \`WarningCollector\` plumbed through every request builder.
- Anthropic warns on: presencePenalty, frequencyPenalty, seed, topK, stopSequences>4, temperature/topP-when-thinking, responseFormat.
- OpenAI warns on: topK on Chat Completions, sampling params on reasoning models.
- Google warns on: presencePenalty, frequencyPenalty, responseFormat.
- Warnings array omitted when empty (backward compat).

### User metadata (closes #1050) — was #1063

- New \`userId?: string\` (cross-provider) and \`requestLabels?: Record<string, string>\` (Google-only).
- Anthropic: \`metadata.user_id\`. OpenAI: \`user\`. Google: \`labels.user_id\` from \`userId\`, or full \`labels\` map from \`requestLabels\` (wins over userId-derived).

## Anthropic rollup #1051 (PRs #1064–#1068)

### B4 — Tool version aliases — was #1064

Short-name → versioned-type alias map: \`code_execution\` → \`code_execution_20260120\`, \`text_editor\` → \`text_editor_20250728\`, \`bash\` → \`bash_20250124\`, \`memory\` → \`memory_20250818\`, \`web_search\` → \`web_search_20250305\`, \`web_fetch\` → \`web_fetch_20250910\`, \`computer_use\`/\`computer\` → \`computer_20250124\`. Pinned versions and unknown names pass through verbatim.

### B5 — Native MCP server pass-through — was #1065

New \`mcpServers?: Array<Record<string, unknown>>\` option. Forwarded with deep camelCase → snake_case conversion (\`authorizationToken\` → \`authorization_token\`, \`toolConfiguration.allowedTools\` → \`tool_configuration.allowed_tools\`). Caller must set \`anthropic-beta: mcp-client-2025-04-04\` header explicitly.

### B6 — Container / agent skills — was #1066

New \`anthropicContainer?: unknown\` option, forwarded verbatim to the \`container\` field. Supports both string container ids and structured config objects.

### B2 — Thinking signature multi-turn replay — was #1067

New \`reasoning\` content part variant on \`RuntimePromptMessage\` assistant messages. \`buildAnthropicGenerateResult\` now parses \`thinking\` blocks (text + signature) and \`redacted_thinking\` blocks (encrypted blob) into reasoning content parts. \`toAnthropicMessages\` replays them as \`thinking\` / \`redacted_thinking\` blocks on the next request body so Claude can verify continuity. OpenAI/Google drop reasoning parts on replay (no equivalent slot).

### B7 — Citation metadata — was #1068

New \`citations?: AnthropicCitation[]\` field on text content parts. Normalizes all five citation kinds (\`web_search_result_location\`, \`web_fetch_result_location\`, \`char_location\`, \`page_location\`, \`content_block_location\`) into camelCase keys.

### B1, B3, B8 — covered by the cross-provider reasoning PR above

## OpenAI rollup #1052 (PRs #1069–#1070)

### C1 — Structured outputs — was #1069

New \`responseFormat?: { type: \"text\" | \"json\" | \"json_schema\", ... }\` option. \`json\` → \`{ type: \"json_object\" }\`. \`json_schema\` → \`{ type: \"json_schema\", json_schema: { name, schema, strict } }\` with schemas unwrapped via \`unwrapToolInputSchema\`. Anthropic and Google emit warnings and omit the field.

### C5 + C6 — service_tier and parallel_tool_calls — was #1070

Two thin pass-throughs: \`serviceTier?: \"auto\" | \"default\" | \"flex\" | \"scale\"\` and \`parallelToolCalls?: boolean\`.

### C2, C3 — covered by the cross-provider reasoning PR above

### C4 deferred

OpenAI Responses API reasoning summary streaming requires switching from \`/v1/chat/completions\` to \`/v1/responses\` — different endpoint, different streaming event grammar, different content block types. Adding it cleanly means a parallel runtime, not a patch to the existing one. Documented at #1052; needs its own design + review cycle as a follow-up.

## Google rollup #1053 (PRs #1071–#1075)

### D1 — cachedContent — was #1071

New \`googleCachedContent?: string\` option, forwarded as \`cachedContent\` field on the request body. Cache creation itself stays out of scope — callers use the Gemini caches REST API.

### D5 — safetySettings — was #1072

New \`googleSafetySettings?: Array<{ category, threshold }>\` option, forwarded verbatim.

### D3 — Native code execution + provider tools — was #1073

\`toGoogleTools\` generalized to accept \`google.code_execution\`, \`google.google_search\`, \`google.google_search_retrieval\` provider tools alongside function tools. Each native tool gets its own \`tools[]\` entry with snake_case → camelCase key conversion.

### D4 — groundingMetadata — was #1074

New \`groundingMetadata?: Record<string, unknown>\` field on the Google generate result. Forwarded opaquely so callers can render search-grounded UI without parsing the wire shape.

### D6 — Tool calling modes + multi-name allowlist — was #1075

\`normalizeGoogleToolChoice\` extended to handle \`{ type: \"tools\", names: [] }\`, \`{ type: \"auto\" }\`, \`{ type: \"any\" }\`, \`{ type: \"none\" }\` object forms in addition to the existing single-tool \`{ type: \"tool\", name }\` and string forms.

### D2 — covered by the cross-provider reasoning PR above

## Test coverage

The provider runtime-loader test file goes from ~21 cases to **129 cases (16,407 steps)**. New tests cover every drop site, every cache field, every reasoning effort mapping, every error classification, every metadata roundtrip, every provider tool alias, every grounding/citation/safety pathway, every replay shape.

Full pre-push hook (lint + format + typecheck + 1341-test suite) green:

\`\`\`
ok | 1341 passed (16407 steps) | 0 failed | 0 ignored (2 steps) (23s)
✅ All pre-push checks passed!
\`\`\`

## Version

Patch bump \`0.1.207 → 0.1.208\`.

## Test plan

- [x] \`deno test --no-check --allow-all src/provider/runtime-loader.test.ts\` — 129 cases pass
- [x] \`deno fmt --check\` clean
- [x] \`deno check src/provider/runtime-loader.ts src/provider/runtime-loader.test.ts src/provider/types.ts\` clean
- [x] Full suite via pre-push hook (1341 tests / 16,407 steps)

## Migration

No breaking changes. All new options default to off / unset. Existing request bodies are byte-identical when none of the new options are used. The \`RuntimeUsage\` shape gained two optional fields; the assistant content union gained one optional variant. Both are additive.