### PR TITLE
Prevent cumulative tool-arg chunks from corrupting child calls

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.209",
+  "version": "0.1.210",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/data-stream.test.ts
+++ b/src/agent/data-stream.test.ts
@@ -98,4 +98,43 @@ describe("agent/data-stream", () => {
       { path: "/plans/report.md", content: "# Report" },
     );
   });
+
+  it("dedupes cumulative streamed tool argument buffers instead of concatenating them", () => {
+    const firstDelta = '{"path":"plans/report.md","content":"# Report';
+    const cumulativeSecondDelta =
+      '{"path":"plans/report.md","content":"# Report\\n\\nExecutive summary"}';
+
+    const merged = mergeToolInputDelta(firstDelta, cumulativeSecondDelta);
+
+    assertEquals(
+      merged,
+      '{"path":"plans/report.md","content":"# Report\\n\\nExecutive summary"}',
+    );
+    assertEquals(
+      parseToolInputObject(merged),
+      {
+        path: "plans/report.md",
+        content: "# Report\n\nExecutive summary",
+      },
+    );
+  });
+
+  it("merges overlapping tool argument deltas without duplicating the shared prefix", () => {
+    const firstDelta = '{"path":"plans/report.md","content":"# Report';
+    const overlappingSecondDelta = 'Report\\n\\nExecutive summary"}';
+
+    const merged = mergeToolInputDelta(firstDelta, overlappingSecondDelta);
+
+    assertEquals(
+      merged,
+      '{"path":"plans/report.md","content":"# Report\\n\\nExecutive summary"}',
+    );
+    assertEquals(
+      parseToolInputObject(merged),
+      {
+        path: "plans/report.md",
+        content: "# Report\n\nExecutive summary",
+      },
+    );
+  });
 });

--- a/src/agent/data-stream.ts
+++ b/src/agent/data-stream.ts
@@ -37,6 +37,29 @@ export function mergeToolInputDelta(currentArguments: string, nextDelta: string)
     }
   }
 
+  if (nextDelta.length === 0) {
+    return currentArguments;
+  }
+
+  if (currentArguments.length === 0) {
+    return nextDelta;
+  }
+
+  if (nextDelta === currentArguments || currentArguments.includes(nextDelta)) {
+    return currentArguments;
+  }
+
+  if (nextDelta.startsWith(currentArguments)) {
+    return nextDelta;
+  }
+
+  const maxOverlap = Math.min(currentArguments.length, nextDelta.length);
+  for (let overlap = maxOverlap; overlap > 0; overlap--) {
+    if (currentArguments.endsWith(nextDelta.slice(0, overlap))) {
+      return currentArguments + nextDelta.slice(overlap);
+    }
+  }
+
   return currentArguments + nextDelta;
 }
 

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -250,6 +250,45 @@ describe("chat-stream-handler", () => {
       });
     });
 
+    it("dedupes cumulative streamed tool argument buffers instead of corrupting the JSON payload", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        { type: "tool-input-start", id: "tc-cumulative", toolName: "create_file" },
+        {
+          type: "tool-input-delta",
+          id: "tc-cumulative",
+          delta: '{"path":"plans/report.md","content":"# Report',
+        },
+        {
+          type: "tool-input-delta",
+          id: "tc-cumulative",
+          delta: '{"path":"plans/report.md","content":"# Report\\n\\nExecutive summary"}',
+        },
+        { type: "finish", finishReason: "tool-calls", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      const tc = state.toolCalls.get("tc-cumulative")!;
+      assertEquals(
+        tc.arguments,
+        '{"path":"plans/report.md","content":"# Report\\n\\nExecutive summary"}',
+      );
+
+      assertEquals(events[1], {
+        type: "tool-input-delta",
+        toolCallId: "tc-cumulative",
+        inputTextDelta: '{"path":"plans/report.md","content":"# Report',
+      });
+      assertEquals(events[2], {
+        type: "tool-input-delta",
+        toolCallId: "tc-cumulative",
+        inputTextDelta: '{"path":"plans/report.md","content":"# Report\\n\\nExecutive summary"}',
+      });
+    });
+
     it("handles tool-call with full input object", async () => {
       const { events, controller, encoder } = createSSECollector();
       const state = createStreamState();

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.209";
+export const VERSION = "0.1.210";


### PR DESCRIPTION
## Summary
- normalize duplicate, cumulative, and overlapping streamed tool-argument chunks before parsing
- add targeted framework regressions for cumulative create_file buffers and overlapping deltas
- bump the framework version to `0.1.210`

## Testing
- deno test --no-check --allow-all src/agent/data-stream.test.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/tool-helpers.test.ts

## Why
Recent staging logs still show `Failed to parse streamed tool arguments` on `create_file` calls in `veryfront-agent rc.164`. The failure pattern is consistent with providers resending cumulative or overlapping arg buffers, which the shared runtime was previously concatenating verbatim.
