### PR TITLE
Handle repeated placeholder tool-arg streams without losing errors

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.210",
+  "version": "0.1.211",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/data-stream.test.ts
+++ b/src/agent/data-stream.test.ts
@@ -137,4 +137,30 @@ describe("agent/data-stream", () => {
       },
     );
   });
+
+  it("dedupes repeated placeholder-style cumulative chunks that omit the opening brace", () => {
+    const firstDelta = mergeToolInputDelta(
+      "{}",
+      '"path":"plans/report.md","content":"# Report',
+    );
+
+    assertEquals(firstDelta, '{"path":"plans/report.md","content":"# Report');
+
+    const secondDelta = mergeToolInputDelta(
+      firstDelta,
+      '"path":"plans/report.md","content":"# Report\\n\\nExecutive summary"}',
+    );
+
+    assertEquals(
+      secondDelta,
+      '{"path":"plans/report.md","content":"# Report\\n\\nExecutive summary"}',
+    );
+    assertEquals(
+      parseToolInputObject(secondDelta),
+      {
+        path: "plans/report.md",
+        content: "# Report\n\nExecutive summary",
+      },
+    );
+  });
 });

--- a/src/agent/data-stream.ts
+++ b/src/agent/data-stream.ts
@@ -26,14 +26,16 @@ export function stripLeadingEmptyObjectPlaceholder(rawArgs: string): string {
 }
 
 export function mergeToolInputDelta(currentArguments: string, nextDelta: string): string {
-  if (currentArguments === "{}") {
-    const normalizedDelta = nextDelta.trimStart();
-    if (normalizedDelta.startsWith("{")) {
-      return normalizedDelta;
-    }
+  const normalizedDelta = nextDelta.trimStart();
+  const candidateDeltas = normalizedDelta.startsWith('"')
+    ? [normalizedDelta, `{${normalizedDelta}`]
+    : [normalizedDelta];
 
-    if (normalizedDelta.startsWith('"')) {
-      return `{${normalizedDelta}`;
+  if (currentArguments === "{}") {
+    for (const candidate of candidateDeltas) {
+      if (candidate.startsWith("{")) {
+        return candidate;
+      }
     }
   }
 
@@ -45,18 +47,20 @@ export function mergeToolInputDelta(currentArguments: string, nextDelta: string)
     return nextDelta;
   }
 
-  if (nextDelta === currentArguments || currentArguments.includes(nextDelta)) {
-    return currentArguments;
-  }
+  for (const candidate of candidateDeltas) {
+    if (candidate === currentArguments || currentArguments.includes(candidate)) {
+      return currentArguments;
+    }
 
-  if (nextDelta.startsWith(currentArguments)) {
-    return nextDelta;
-  }
+    if (candidate.startsWith(currentArguments)) {
+      return candidate;
+    }
 
-  const maxOverlap = Math.min(currentArguments.length, nextDelta.length);
-  for (let overlap = maxOverlap; overlap > 0; overlap--) {
-    if (currentArguments.endsWith(nextDelta.slice(0, overlap))) {
-      return currentArguments + nextDelta.slice(overlap);
+    const maxOverlap = Math.min(currentArguments.length, candidate.length);
+    for (let overlap = maxOverlap; overlap > 0; overlap--) {
+      if (currentArguments.endsWith(candidate.slice(0, overlap))) {
+        return currentArguments + candidate.slice(overlap);
+      }
     }
   }
 

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -289,6 +289,55 @@ describe("chat-stream-handler", () => {
       });
     });
 
+    it("dedupes repeated placeholder-style cumulative tool deltas without swallowing parse errors", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        { type: "tool-input-start", id: "tc-repeat-placeholder", toolName: "create_file" },
+        {
+          type: "tool-input-delta",
+          id: "tc-repeat-placeholder",
+          delta: "{}",
+        },
+        {
+          type: "tool-input-delta",
+          id: "tc-repeat-placeholder",
+          delta: '"path":"plans/report.md","content":"# Report',
+        },
+        {
+          type: "tool-input-delta",
+          id: "tc-repeat-placeholder",
+          delta: '"path":"plans/report.md","content":"# Report\\n\\nExecutive summary"}',
+        },
+        { type: "finish", finishReason: "tool-calls", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      const tc = state.toolCalls.get("tc-repeat-placeholder")!;
+      assertEquals(
+        tc.arguments,
+        '{"path":"plans/report.md","content":"# Report\\n\\nExecutive summary"}',
+      );
+
+      assertEquals(events[1], {
+        type: "tool-input-delta",
+        toolCallId: "tc-repeat-placeholder",
+        inputTextDelta: "{}",
+      });
+      assertEquals(events[2], {
+        type: "tool-input-delta",
+        toolCallId: "tc-repeat-placeholder",
+        inputTextDelta: '"path":"plans/report.md","content":"# Report',
+      });
+      assertEquals(events[3], {
+        type: "tool-input-delta",
+        toolCallId: "tc-repeat-placeholder",
+        inputTextDelta: '"path":"plans/report.md","content":"# Report\\n\\nExecutive summary"}',
+      });
+    });
+
     it("handles tool-call with full input object", async () => {
       const { events, controller, encoder } = createSSECollector();
       const state = createStreamState();

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.210";
+export const VERSION = "0.1.211";


### PR DESCRIPTION
## Summary
- normalize repeated placeholder-style cumulative tool-argument chunks on every merge step
- add regressions covering quote-prefixed cumulative create_file buffers in both the low-level merge helper and runtime stream handler
- bump the framework version to `0.1.211`

## Testing
- deno test --no-check --allow-all src/agent/data-stream.test.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/tool-helpers.test.ts

## Why
Fresh staging evidence on `veryfront-agent rc.165` still showed malformed `create_file` tool calls with parse errors at the point where providers resent cumulative object bodies starting at the first property without an opening brace. The prior overlap fix improved some cases but did not repair repeated placeholder-style chunks after the first delta.
