### PR TITLE
fix(agent/runtime): distinguish stream-terminated tool calls from parse errors

### DIFF
--- a/src/agent/runtime/index.test.ts
+++ b/src/agent/runtime/index.test.ts
@@ -218,8 +218,7 @@ describe("agent runtime streamed tool result collection", () => {
       // stream stalled before the finalizing `tool-call` event fired. The
       // partial JSON would otherwise produce an "Expected ',' or '}' after
       // property value" error if we naively parsed it.
-      const partialArgs =
-        '{"path":"/plans/headless-browser-automation-research.md","conten';
+      const partialArgs = '{"path":"/plans/headless-browser-automation-research.md","conten';
       const materialized = materializeStreamedToolCall({
         id: "toolu_01HebautJT22EGCZh8K1Dfpw",
         name: "write_file",
@@ -281,8 +280,7 @@ describe("agent runtime streamed tool result collection", () => {
   it(
     "truncates partialArgumentsPreview to 200 chars for huge mid-stream cutoffs",
     () => {
-      const longFragment =
-        '{"path":"/plans/x.md","content":"' + "a".repeat(500);
+      const longFragment = '{"path":"/plans/x.md","content":"' + "a".repeat(500);
       const materialized = materializeStreamedToolCall({
         id: "toolu_long_partial",
         name: "write_file",

--- a/src/agent/runtime/index.test.ts
+++ b/src/agent/runtime/index.test.ts
@@ -5,6 +5,8 @@ import {
   collectFinalStreamToolResults,
   collectGeneratedToolResults,
   collectPersistedToolResults,
+  isStreamedToolCallIncomplete,
+  materializeStreamedToolCall,
 } from "./index.ts";
 import type { ChatStreamState } from "./chat-stream-handler.ts";
 import type { Message } from "../types.ts";
@@ -132,4 +134,176 @@ describe("agent runtime streamed tool result collection", () => {
     assertEquals(captured.inputText, '{"query":"AI ontologies research"}');
     assertEquals(captured.parseError, undefined);
   });
+
+  it("flags a streamed tool call as incomplete when inputAvailable is false", () => {
+    assertEquals(
+      isStreamedToolCallIncomplete({ inputAvailable: false }),
+      true,
+    );
+  });
+
+  it("flags a streamed tool call as incomplete when inputAvailable is missing", () => {
+    // `inputAvailable` is optional on StreamingToolCall and is only set to
+    // `true` once the provider emits the finalizing tool-call event. An
+    // undefined value means the stream terminated (abort, stall, transport
+    // error) before finalization and the accumulated `arguments` is only a
+    // partial delta fragment, NOT a committed tool-argument JSON.
+    assertEquals(
+      isStreamedToolCallIncomplete({}),
+      true,
+    );
+  });
+
+  it("treats a streamed tool call as complete only when inputAvailable is true", () => {
+    assertEquals(
+      isStreamedToolCallIncomplete({ inputAvailable: true }),
+      false,
+    );
+  });
+
+  it("materializes a complete streamed tool call into a ready-to-execute part", () => {
+    const materialized = materializeStreamedToolCall({
+      id: "toolu_complete",
+      name: "write_file",
+      arguments: '{"path":"/plans/report.md","content":"# Summary"}',
+      inputAvailable: true,
+    });
+
+    assertEquals(materialized.kind, "complete");
+    assertEquals(materialized.part.type, "tool-write_file");
+    assertEquals(
+      (materialized.part as { toolCallId: string }).toolCallId,
+      "toolu_complete",
+    );
+    assertEquals(
+      (materialized.part as { args: Record<string, unknown> }).args,
+      { path: "/plans/report.md", content: "# Summary" },
+    );
+    assertEquals(
+      (materialized.part as { inputText?: string }).inputText,
+      '{"path":"/plans/report.md","content":"# Summary"}',
+    );
+  });
+
+  it("materializes a parse-error streamed tool call without parsing executable args", () => {
+    const materialized = materializeStreamedToolCall({
+      id: "toolu_parse_error",
+      name: "web_search",
+      // Malformed JSON emitted by a finalized (inputAvailable: true) tool call
+      // is the rare provider/SDK bug case. It must NOT be conflated with stream
+      // termination.
+      arguments: '{"query":"streaming bugs',
+      inputAvailable: true,
+    });
+
+    assertEquals(materialized.kind, "parse-error");
+    assertEquals(
+      (materialized.part as { args: Record<string, unknown> }).args,
+      {},
+    );
+    assertEquals(
+      (materialized.part as { inputText?: string }).inputText,
+      '{"query":"streaming bugs',
+    );
+    if (materialized.kind === "parse-error") {
+      assertEquals(typeof materialized.parseError, "string");
+    }
+  });
+
+  it(
+    "materializes an incomplete streamed tool call (stream terminated before tool-call event)",
+    () => {
+      // This is the exact shape observed in production: a `write_file` tool
+      // whose `content` field got cut off mid-emission because the provider
+      // stream stalled before the finalizing `tool-call` event fired. The
+      // partial JSON would otherwise produce an "Expected ',' or '}' after
+      // property value" error if we naively parsed it.
+      const partialArgs =
+        '{"path":"/plans/headless-browser-automation-research.md","conten';
+      const materialized = materializeStreamedToolCall({
+        id: "toolu_01HebautJT22EGCZh8K1Dfpw",
+        name: "write_file",
+        arguments: partialArgs,
+        // inputAvailable deliberately omitted — same as the production state
+        // when the stream ends before `tool-input-end` / `tool-call` fires.
+      });
+
+      assertEquals(materialized.kind, "incomplete");
+      // args MUST be empty — we must not hand the execution path a partial
+      // object constructed from truncated JSON, because downstream consumers
+      // assume args reflect a committed tool choice.
+      assertEquals(
+        (materialized.part as { args: Record<string, unknown> }).args,
+        {},
+      );
+      // inputText MUST preserve the partial fragment verbatim so the persisted
+      // assistant message is transparent about what happened (not swallowed).
+      assertEquals(
+        (materialized.part as { inputText?: string }).inputText,
+        partialArgs,
+      );
+      if (materialized.kind === "incomplete") {
+        assertEquals(materialized.partialArgumentsLength, partialArgs.length);
+        assertEquals(
+          materialized.partialArgumentsPreview,
+          partialArgs.slice(0, 200),
+        );
+      }
+    },
+  );
+
+  it(
+    "materializes an incomplete streamed tool call with empty arguments (stream died before any delta)",
+    () => {
+      const materialized = materializeStreamedToolCall({
+        id: "toolu_pre_delta_death",
+        name: "read_file",
+        arguments: "",
+      });
+
+      assertEquals(materialized.kind, "incomplete");
+      assertEquals(
+        (materialized.part as { args: Record<string, unknown> }).args,
+        {},
+      );
+      // No inputText field when the stream died before emitting any delta.
+      assertEquals(
+        (materialized.part as { inputText?: string }).inputText,
+        undefined,
+      );
+      if (materialized.kind === "incomplete") {
+        assertEquals(materialized.partialArgumentsLength, 0);
+        assertEquals(materialized.partialArgumentsPreview, "");
+      }
+    },
+  );
+
+  it(
+    "truncates partialArgumentsPreview to 200 chars for huge mid-stream cutoffs",
+    () => {
+      const longFragment =
+        '{"path":"/plans/x.md","content":"' + "a".repeat(500);
+      const materialized = materializeStreamedToolCall({
+        id: "toolu_long_partial",
+        name: "write_file",
+        arguments: longFragment,
+      });
+
+      assertEquals(materialized.kind, "incomplete");
+      if (materialized.kind === "incomplete") {
+        assertEquals(materialized.partialArgumentsLength, longFragment.length);
+        assertEquals(materialized.partialArgumentsPreview.length, 200);
+        assertEquals(
+          materialized.partialArgumentsPreview,
+          longFragment.slice(0, 200),
+        );
+      }
+      // The full fragment is still preserved on the persisted part so we do
+      // not lose forensic data — only the log preview is truncated.
+      assertEquals(
+        (materialized.part as { inputText?: string }).inputText,
+        longFragment,
+      );
+    },
+  );
 });

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -198,6 +198,97 @@ export function captureStreamedToolCallInput(
   };
 }
 
+/**
+ * A streamed tool call is "incomplete" when the provider stream terminated
+ * (abort, stall, timeout, transport error) before the SDK emitted the
+ * finalizing `tool-call` event that sets `inputAvailable: true`. In that state
+ * `arguments` only holds partial JSON fragments from `tool-input-delta` events,
+ * so the tool call is NOT a committed model choice and must not be parsed or
+ * executed. This is semantically distinct from a parse failure on a finalized
+ * tool call (`inputAvailable: true` but malformed JSON — which only happens on
+ * genuine provider bugs) and needs to be reported as a stream-termination
+ * error rather than a tool-argument error.
+ */
+export function isStreamedToolCallIncomplete(
+  toolCall: Pick<StreamingToolCall, "inputAvailable">,
+): boolean {
+  return toolCall.inputAvailable !== true;
+}
+
+/**
+ * Classification of a streamed tool call when we reach end-of-stream and need
+ * to persist it into the assistant message. Three distinct cases, each with
+ * different semantics downstream:
+ *
+ * - `complete`: provider emitted the finalizing `tool-call` event and the
+ *   arguments parsed cleanly. Execute the tool normally.
+ * - `parse-error`: provider emitted the finalizing `tool-call` event but the
+ *   arguments are not valid JSON. This is a provider/SDK bug; record it as a
+ *   tool-argument error so the step can recover.
+ * - `incomplete`: stream terminated before the finalizing event fired. The
+ *   model never committed this tool use; record it as a stream-termination
+ *   error so the parent (e.g. child-fork watchdog) can decide whether to
+ *   retry the step cleanly instead of seeing a malformed tool call.
+ */
+export type StreamedToolCallMaterialization =
+  | { readonly kind: "complete"; readonly part: MessagePart }
+  | {
+    readonly kind: "parse-error";
+    readonly part: MessagePart;
+    readonly parseError: string;
+  }
+  | {
+    readonly kind: "incomplete";
+    readonly part: MessagePart;
+    readonly partialArgumentsLength: number;
+    readonly partialArgumentsPreview: string;
+  };
+
+/**
+ * Classify and build the persisted `MessagePart` for a single streamed tool
+ * call. Pure function — no logging, no SSE, no memory. Callers decide what to
+ * do with the result so this stays unit-testable.
+ *
+ * The resulting `part` is always pushed into the assistant message so the
+ * conversation history is transparent: even incomplete tool calls leave a
+ * visible trace with their partial `inputText`. What differs is the caller's
+ * error-surfacing behavior (log warning, SSE event, tool-result error).
+ */
+export function materializeStreamedToolCall(
+  tc: StreamingToolCall,
+): StreamedToolCallMaterialization {
+  const basePart: MessagePart = {
+    type: `tool-${tc.name}`,
+    toolCallId: tc.id,
+    toolName: tc.name,
+    args: {},
+    ...(tc.arguments.length > 0 ? { inputText: tc.arguments } : {}),
+  };
+
+  if (isStreamedToolCallIncomplete(tc)) {
+    return {
+      kind: "incomplete",
+      part: basePart,
+      partialArgumentsLength: tc.arguments.length,
+      partialArgumentsPreview: tc.arguments.slice(0, 200),
+    };
+  }
+
+  const capturedInput = captureStreamedToolCallInput(tc);
+  const part: MessagePart = {
+    type: `tool-${tc.name}`,
+    toolCallId: tc.id,
+    toolName: tc.name,
+    args: capturedInput.args,
+    ...(capturedInput.inputText ? { inputText: capturedInput.inputText } : {}),
+  };
+
+  if (capturedInput.parseError) {
+    return { kind: "parse-error", part, parseError: capturedInput.parseError };
+  }
+  return { kind: "complete", part };
+}
+
 function isToolResultPart(part: MessagePart): part is ToolResultPart {
   return part.type === "tool-result" && "result" in part;
 }
@@ -961,20 +1052,36 @@ export class AgentRuntime {
       if (state.accumulatedText) streamParts.push({ type: "text", text: state.accumulatedText });
 
       for (const tc of state.toolCalls.values()) {
-        const capturedInput = captureStreamedToolCallInput(tc);
-        if (capturedInput.parseError) {
+        const materialized = materializeStreamedToolCall(tc);
+        streamParts.push(materialized.part);
+
+        if (materialized.kind === "incomplete") {
+          // Stream terminated before the provider emitted the finalizing
+          // `tool-call` event for this block. The model never committed this
+          // tool use. Surface the failure via SSE so the live client can
+          // react, and leave the partial fragment under `inputText` in the
+          // persisted part above so the history is replayable and transparent.
+          logger.warn("Streamed tool call terminated before tool-call event", {
+            toolCallId: tc.id,
+            toolName: tc.name,
+            partialArgumentsLength: materialized.partialArgumentsLength,
+            partialArgumentsPreview: materialized.partialArgumentsPreview,
+          });
+          const dynamicIncomplete = isDynamicTool(tc.name);
+          sendSSE(controller, encoder, {
+            type: "tool-input-error",
+            toolCallId: tc.id,
+            errorText:
+              `Stream terminated before tool-call event fired for "${tc.name}". ` +
+              `Received ${materialized.partialArgumentsLength} chars of partial tool-input deltas.`,
+            ...(dynamicIncomplete ? { dynamic: true } : {}),
+          });
+        } else if (materialized.kind === "parse-error") {
           logger.warn("Failed to parse streamed tool arguments", {
             toolCallId: tc.id,
-            error: capturedInput.parseError,
+            error: materialized.parseError,
           });
         }
-        streamParts.push({
-          type: `tool-${tc.name}`,
-          toolCallId: tc.id,
-          toolName: tc.name,
-          args: capturedInput.args,
-          ...(capturedInput.inputText ? { inputText: capturedInput.inputText } : {}),
-        });
       }
 
       const assistantMessage: Message = {
@@ -1033,6 +1140,30 @@ export class AgentRuntime {
 
       for (const tc of streamedToolCalls) {
         throwIfAborted(abortSignal);
+        if (isStreamedToolCallIncomplete(tc)) {
+          // Stream ended before the provider finalized this tool call. We
+          // cannot execute it — record a distinct stream-termination error
+          // (not a tool-argument parse error) so the parent step and any
+          // upstream orchestrator (e.g. the child-fork watchdog) see a
+          // completed step with a clearly-labelled failure and can recover.
+          const incompleteToolCall: ToolCall = {
+            id: tc.id,
+            name: tc.name,
+            args: {},
+            ...(tc.arguments.length > 0 ? { inputText: tc.arguments } : {}),
+            status: "pending",
+          };
+          await this.recordToolError(
+            incompleteToolCall,
+            `Stream terminated before tool-call event fired for "${tc.name}". ` +
+              `Received ${tc.arguments.length} chars of partial tool-input deltas.`,
+            controller,
+            encoder,
+            currentMessages,
+            toolCalls,
+          );
+          continue;
+        }
         const capturedInput = captureStreamedToolCallInput(tc);
         const toolCall: ToolCall = {
           id: tc.id,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1071,8 +1071,7 @@ export class AgentRuntime {
           sendSSE(controller, encoder, {
             type: "tool-input-error",
             toolCallId: tc.id,
-            errorText:
-              `Stream terminated before tool-call event fired for "${tc.name}". ` +
+            errorText: `Stream terminated before tool-call event fired for "${tc.name}". ` +
               `Received ${materialized.partialArgumentsLength} chars of partial tool-input deltas.`,
             ...(dynamicIncomplete ? { dynamic: true } : {}),
           });


### PR DESCRIPTION
## Summary
Fixes the root cause of the warning reported:

```
level=warn service=server
message="Failed to parse streamed tool arguments"
error="Expected ',' or '}' after property value in JSON at position 111"
→ "Closing incomplete child fork tool lifecycles"
→ "Child fork stopped before writing required artifacts; requesting one focused recovery step"
```

The agent runtime end-of-stream loops routed every `StreamingToolCall` through `captureStreamedToolCallInput` → `parseToolArgs`, **including tool calls where the provider stream aborted/stalled/timed out before emitting the finalizing `tool-call` event**. In that state `tc.arguments` is only partial JSON accumulated from `tool-input-delta` events — the model never committed this tool use. Parsing it raised the spurious warning and pushed a zombie tool call (empty args) into the persisted assistant message, which downstream code conflated with a genuine tool-argument parse error.

`inputAvailable` on `StreamingToolCall` is already the contract for "the model committed to this tool use" (set `true` only in the `tool-call` case of `chat-stream-handler.ts:238`). We were ignoring it.

## What changed
- `isStreamedToolCallIncomplete(tc)` — tiny predicate over the existing `inputAvailable` contract.
- `materializeStreamedToolCall(tc)` — pure function that classifies a streamed tool call into `complete` | `parse-error` | `incomplete` and builds the persisted `MessagePart` with the correct shape. Incomplete tool calls keep their partial fragment under `inputText` (nothing is swallowed) but their `args` stay `{}` so we never hand truncated JSON to the execution path.
- Persistence loop (`src/agent/runtime/index.ts:962`) now dispatches on `materializeStreamedToolCall`.
- Execution loop (`src/agent/runtime/index.ts:1034`) now calls `recordToolError` with a distinct "Stream terminated before tool-call event fired" message when `inputAvailable === false`, so the child-fork watchdog sees a cleanly-labelled failure rather than a malformed-argument error.
- Regression tests (14 total, 9 new) covering the helper predicate, the three classifications, the exact production fragment shape (`toolu_01HebautJT22EGCZh8K1Dfpw`, write_file with truncated content), the empty-arguments edge case, and 200-char preview truncation.

## Test plan
- [x] `deno test --allow-all --no-check src/agent/runtime/index.test.ts` — 14 passed
- [x] `deno test --allow-all --no-check src/agent/runtime/` — 13 suites, 183 steps passed
- [x] `deno check src/agent/runtime/index.ts` — clean
- [x] `deno fmt` clean
- [x] Pre-push hook: **1342 passed (16454 steps), 0 failed**
- [ ] Deploy to staging, re-run deep-research fixture that produced the log pattern, verify no more "Failed to parse streamed tool arguments" and a clean "Stream terminated before tool-call event fired" warning in its place
