### PR TITLE
Normalize leading-quote tool deltas before fallback tool calls

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.211",
+  "version": "0.1.212",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/data-stream.test.ts
+++ b/src/agent/data-stream.test.ts
@@ -163,4 +163,32 @@ describe("agent/data-stream", () => {
       },
     );
   });
+
+  it("normalizes a first streamed delta that starts at the first property without an opening brace", () => {
+    const merged = mergeToolInputDelta(
+      "",
+      '"path":"plans/report.md","content":"# Report"}',
+    );
+
+    assertEquals(
+      merged,
+      '{"path":"plans/report.md","content":"# Report"}',
+    );
+    assertEquals(
+      parseToolInputObject(merged),
+      { path: "plans/report.md", content: "# Report" },
+    );
+  });
+
+  it("preserves normalized partial streamed arguments when the later tool-call payload is only an empty object", () => {
+    const normalizedPartial = mergeToolInputDelta(
+      "",
+      '"path":"plans/report.md","content":"# Report',
+    );
+
+    assertEquals(
+      mergeToolCallInput(normalizedPartial, "{}"),
+      '{"path":"plans/report.md","content":"# Report',
+    );
+  });
 });

--- a/src/agent/data-stream.ts
+++ b/src/agent/data-stream.ts
@@ -31,7 +31,7 @@ export function mergeToolInputDelta(currentArguments: string, nextDelta: string)
     ? [normalizedDelta, `{${normalizedDelta}`]
     : [normalizedDelta];
 
-  if (currentArguments === "{}") {
+  if (currentArguments === "{}" || currentArguments.length === 0) {
     for (const candidate of candidateDeltas) {
       if (candidate.startsWith("{")) {
         return candidate;
@@ -72,8 +72,14 @@ export function mergeToolCallInput(currentArguments: string, nextInput: string):
     return nextInput;
   }
 
+  const normalizedCurrent = stripLeadingEmptyObjectPlaceholder(currentArguments);
+
   if (nextInput.trim() === "{}" && currentArguments.trim().startsWith("{")) {
     return currentArguments;
+  }
+
+  if (nextInput.trim() === "{}" && normalizedCurrent.trim().startsWith("{")) {
+    return normalizedCurrent;
   }
 
   if (currentArguments.trim() === "{}" && nextInput.trim().startsWith("{")) {

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -367,6 +367,47 @@ describe("chat-stream-handler", () => {
       });
     });
 
+    it("normalizes quote-prefixed first tool-input deltas before a fallback empty tool-call payload arrives", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        { type: "tool-input-start", id: "tc-leading-quote", toolName: "create_file" },
+        {
+          type: "tool-input-delta",
+          id: "tc-leading-quote",
+          delta: '"path":"plans/report.md","content":"# Report',
+        },
+        {
+          type: "tool-call",
+          toolCallId: "tc-leading-quote",
+          toolName: "create_file",
+          input: {},
+        },
+        { type: "finish", finishReason: "tool-calls", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "t", undefined);
+
+      const tc = state.toolCalls.get("tc-leading-quote")!;
+      assertEquals(
+        tc.arguments,
+        '{"path":"plans/report.md","content":"# Report',
+      );
+
+      assertEquals(events[1], {
+        type: "tool-input-delta",
+        toolCallId: "tc-leading-quote",
+        inputTextDelta: '"path":"plans/report.md","content":"# Report',
+      });
+      assertEquals(events[2], {
+        type: "tool-input-available",
+        toolCallId: "tc-leading-quote",
+        toolName: "create_file",
+        input: {},
+      });
+    });
+
     it("preserves tool-call input when the provider already emits a JSON string", async () => {
       const { events, controller, encoder } = createSSECollector();
       const state = createStreamState();

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.211";
+export const VERSION = "0.1.212";


### PR DESCRIPTION
## Summary
- normalize quote-prefixed first tool-input deltas into object form immediately
- preserve normalized partial tool input when a later fallback `{}` tool-call payload arrives
- bump the framework version to `0.1.212`

## Testing
- deno test --no-check --allow-all src/agent/data-stream.test.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/tool-helpers.test.ts

## Why
Fresh staging retest on `veryfront-agent rc.166` still showed child `create_file` tool calls recorded as `{}` even though parse warnings were gone. The remaining transport shape starts the first tool-input delta at the first property without an opening brace, then later emits an empty-object tool-call payload. This patch preserves the real partial tool input across that sequence instead of letting the fallback `{}` win.
