### PR TITLE
feat(logger): export request context utilities and add user_id/conversation_id fields

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -22,15 +22,17 @@ export {
 } from "./runtime-guards.ts";
 
 export {
+  __registerTraceContextGetter,
   agentLogger,
   bundlerLogger,
   createJobUserLogger,
   logger,
   refreshLoggerConfig,
   rendererLogger,
+  runWithRequestContextAsync,
   serverLogger,
 } from "./logger/index.ts";
-export type { Logger } from "./logger/index.ts";
+export type { Logger, RequestContext } from "./logger/index.ts";
 
 export {
   BREAKPOINT_LG,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -23,6 +23,7 @@ export {
 
 export {
   __registerTraceContextGetter,
+  __registerTraceContextGetter as registerTraceContextGetter,
   agentLogger,
   bundlerLogger,
   createJobUserLogger,

--- a/src/utils/logger/logger.test.ts
+++ b/src/utils/logger/logger.test.ts
@@ -637,6 +637,57 @@ describe("logger", () => {
       }
     });
 
+    it("should emit user_id alias for userId", () => {
+      const { getOutput, restore } = captureConsoleLog();
+
+      try {
+        withJsonLogFormat(() => {
+          const base = getBaseLogger("SERVER");
+          base.info("With user", { userId: "usr-123" });
+
+          const entry = JSON.parse(getOutput()) as LogEntry;
+          assertEquals(entry.userId, "usr-123");
+          assertEquals(entry.user_id, "usr-123");
+        });
+      } finally {
+        restore();
+      }
+    });
+
+    it("should emit conversation_id alias for conversationId", () => {
+      const { getOutput, restore } = captureConsoleLog();
+
+      try {
+        withJsonLogFormat(() => {
+          const base = getBaseLogger("SERVER");
+          base.info("With conversation", { conversationId: "conv-456" });
+
+          const entry = JSON.parse(getOutput()) as LogEntry;
+          assertEquals(entry.conversationId, "conv-456");
+          assertEquals(entry.conversation_id, "conv-456");
+        });
+      } finally {
+        restore();
+      }
+    });
+
+    it("should promote snake_case user_id and conversation_id directly", () => {
+      const { getOutput, restore } = captureConsoleLog();
+
+      try {
+        withJsonLogFormat(() => {
+          const base = getBaseLogger("SERVER");
+          base.info("Snake case", { user_id: "usr-789", conversation_id: "conv-012" });
+
+          const entry = JSON.parse(getOutput()) as LogEntry;
+          assertEquals(entry.user_id, "usr-789");
+          assertEquals(entry.conversation_id, "conv-012");
+        });
+      } finally {
+        restore();
+      }
+    });
+
     it("should not overwrite explicit snake_case with alias", () => {
       const { getOutput, restore } = captureConsoleLog();
 

--- a/src/utils/logger/logger.ts
+++ b/src/utils/logger/logger.ts
@@ -346,7 +346,9 @@ class ConsoleLogger implements Logger {
     if (entry.projectSlug && !entry.project_slug) entry.project_slug = entry.projectSlug;
     if (entry.durationMs != null && entry.duration_ms == null) entry.duration_ms = entry.durationMs;
     if (entry.userId && !entry.user_id) entry.user_id = entry.userId;
-    if (entry.conversationId && !entry.conversation_id) entry.conversation_id = entry.conversationId;
+    if (entry.conversationId && !entry.conversation_id) {
+      entry.conversation_id = entry.conversationId;
+    }
 
     if (Object.keys(mergedContext).length > 0) entry.context = mergedContext;
     if (error) entry.error = error;

--- a/src/utils/logger/logger.ts
+++ b/src/utils/logger/logger.ts
@@ -65,6 +65,8 @@ export interface LogEntry {
   task?: string;
   event_kind?: string;
   user_visible?: string;
+  user_id?: string;
+  conversation_id?: string;
   // Duration for timed operations
   /** @deprecated Use `duration_ms` instead. Kept for Grafana dashboard transition. Planned removal after Grafana dashboard migration is complete. */
   durationMs?: number;
@@ -326,6 +328,8 @@ class ConsoleLogger implements Logger {
     extractToEntryField(entry, mergedContext, "event_kind", (v) => String(v));
     extractToEntryField(entry, mergedContext, "user_visible", (v) => String(v));
     extractToEntryField(entry, mergedContext, "duration_ms", (v) => Number(v));
+    extractToEntryField(entry, mergedContext, "user_id", (v) => String(v));
+    extractToEntryField(entry, mergedContext, "conversation_id", (v) => String(v));
 
     // Emit snake_case aliases for camelCase fields (transition period)
     if (entry.requestId && !entry.request_id) entry.request_id = entry.requestId;

--- a/src/utils/logger/logger.ts
+++ b/src/utils/logger/logger.ts
@@ -67,6 +67,10 @@ export interface LogEntry {
   user_visible?: string;
   user_id?: string;
   conversation_id?: string;
+  /** @deprecated Use `user_id` instead. Kept for Grafana dashboard transition. */
+  userId?: string;
+  /** @deprecated Use `conversation_id` instead. Kept for Grafana dashboard transition. */
+  conversationId?: string;
   // Duration for timed operations
   /** @deprecated Use `duration_ms` instead. Kept for Grafana dashboard transition. Planned removal after Grafana dashboard migration is complete. */
   durationMs?: number;
@@ -331,12 +335,18 @@ class ConsoleLogger implements Logger {
     extractToEntryField(entry, mergedContext, "user_id", (v) => String(v));
     extractToEntryField(entry, mergedContext, "conversation_id", (v) => String(v));
 
+    // Also extract camelCase variants so callers can use either convention
+    extractToEntryField(entry, mergedContext, "userId", (v) => String(v));
+    extractToEntryField(entry, mergedContext, "conversationId", (v) => String(v));
+
     // Emit snake_case aliases for camelCase fields (transition period)
     if (entry.requestId && !entry.request_id) entry.request_id = entry.requestId;
     if (entry.traceId && !entry.trace_id) entry.trace_id = entry.traceId;
     if (entry.spanId && !entry.span_id) entry.span_id = entry.spanId;
     if (entry.projectSlug && !entry.project_slug) entry.project_slug = entry.projectSlug;
     if (entry.durationMs != null && entry.duration_ms == null) entry.duration_ms = entry.durationMs;
+    if (entry.userId && !entry.user_id) entry.user_id = entry.userId;
+    if (entry.conversationId && !entry.conversation_id) entry.conversation_id = entry.conversationId;
 
     if (Object.keys(mergedContext).length > 0) entry.context = mergedContext;
     if (error) entry.error = error;

--- a/src/utils/logger/request-context.ts
+++ b/src/utils/logger/request-context.ts
@@ -16,6 +16,8 @@ export interface RequestContext {
   projectSlug?: string;
   projectId?: string;
   domain?: string;
+  userId?: string;
+  conversationId?: string;
 }
 
 export const requestContextStore = new AsyncLocalStorage<RequestContext>();


### PR DESCRIPTION
## Summary
- Export `runWithRequestContextAsync`, `__registerTraceContextGetter`, and `RequestContext` type from `veryfront/utils` so downstream services can populate request-scoped logger context
- Add `userId` and `conversationId` optional fields to `RequestContext` interface
- Add `user_id` and `conversation_id` as top-level `LogEntry` fields, extracted to structured JSON output for Grafana/Loki filtering

## Context
Agent logs (e.g. "Failed to parse streamed tool arguments") lack project/user/trace context, making Grafana debugging impossible. This PR enables veryfront-agent to set up request context for the veryfront-code logger.

Companion PR: veryfront/veryfront-agent (feat/agent-log-context)

## Test plan
- [x] `deno task typecheck` passes
- [x] `deno test --allow-all src/utils/logger/logger.test.ts` passes (47 steps)
- [ ] After deploy: verify `user_id` and `conversation_id` appear in Grafana logs