### PR TITLE
Preserve streamed inputText in internal AG-UI snapshots

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.212",
+  "version": "0.1.213",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/internal-agents/schema.test.ts
+++ b/src/internal-agents/schema.test.ts
@@ -173,6 +173,92 @@ describe("internal-agents/schema", () => {
     });
   });
 
+  it("prefers streamed inputText over empty fallback args when normalizing legacy assistant tool calls", () => {
+    const internalRequest = InternalAgentStreamRequestSchema.parse({
+      agentId: "agent_1",
+      threadId: "10000000-1000-4000-8000-100000000001",
+      runId: "run_1",
+      messages: [
+        {
+          id: "assistant_1",
+          role: "assistant",
+          parts: [
+            { type: "text", text: "Writing report" },
+            {
+              type: "tool-call",
+              toolCallId: "tool_1",
+              toolName: "create_file",
+              args: {},
+              inputText: '{"path":"plans/report.md","content":"# Report"}',
+            },
+          ],
+        },
+      ],
+      context: [],
+    });
+
+    assertEquals(toRuntimeRunAgentInput(internalRequest).messages, [
+      {
+        id: "assistant_1",
+        role: "assistant",
+        content: "Writing report",
+        toolCalls: [{
+          id: "tool_1",
+          type: "function",
+          function: {
+            name: "create_file",
+            arguments: JSON.stringify({
+              path: "plans/report.md",
+              content: "# Report",
+            }),
+          },
+        }],
+      },
+    ]);
+  });
+
+  it("repairs leading-quote streamed inputText before serializing legacy assistant tool calls", () => {
+    const internalRequest = InternalAgentStreamRequestSchema.parse({
+      agentId: "agent_1",
+      threadId: "10000000-1000-4000-8000-100000000001",
+      runId: "run_1",
+      messages: [
+        {
+          id: "assistant_1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-call",
+              toolCallId: "tool_1",
+              toolName: "create_file",
+              args: {},
+              inputText: '"path":"plans/report.md","content":"# Report"}',
+            },
+          ],
+        },
+      ],
+      context: [],
+    });
+
+    assertEquals(toRuntimeRunAgentInput(internalRequest).messages, [
+      {
+        id: "assistant_1",
+        role: "assistant",
+        toolCalls: [{
+          id: "tool_1",
+          type: "function",
+          function: {
+            name: "create_file",
+            arguments: JSON.stringify({
+              path: "plans/report.md",
+              content: "# Report",
+            }),
+          },
+        }],
+      },
+    ]);
+  });
+
   it("preserves canonical runtime messages on the compatibility route", () => {
     const internalRequest = InternalAgentStreamRequestSchema.parse({
       agentId: "agent_1",

--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -10,6 +10,7 @@ import {
   AgUiRuntimeRunIdSchema,
   AgUiRuntimeToolCallSchema,
 } from "#veryfront/agent/runtime-ag-ui-contract.ts";
+import { stripLeadingEmptyObjectPlaceholder } from "#veryfront/agent/data-stream.ts";
 
 const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const MAX_FORWARDED_PROPS_BYTES = 65_536;
@@ -88,11 +89,37 @@ function extractToolArgs(
   part: Record<string, unknown>,
 ): Record<string, unknown> {
   const args = part.args;
-  if (args && typeof args === "object" && !Array.isArray(args)) {
+  if (args && typeof args === "object" && !Array.isArray(args) && Object.keys(args).length > 0) {
     return args as Record<string, unknown>;
   }
 
   const input = part.input;
+  if (
+    input && typeof input === "object" && !Array.isArray(input) && Object.keys(input).length > 0
+  ) {
+    return input as Record<string, unknown>;
+  }
+
+  const inputText = part.inputText;
+  if (typeof inputText === "string" && inputText.length > 0) {
+    try {
+      const normalizedInputText = (() => {
+        const stripped = stripLeadingEmptyObjectPlaceholder(inputText);
+        return stripped.trimStart().startsWith('"') ? `{${stripped}` : stripped;
+      })();
+      const parsed = JSON.parse(normalizedInputText);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return {};
+    }
+  }
+
+  if (args && typeof args === "object" && !Array.isArray(args)) {
+    return args as Record<string, unknown>;
+  }
+
   if (input && typeof input === "object" && !Array.isArray(input)) {
     return input as Record<string, unknown>;
   }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.212";
+export const VERSION = "0.1.213";


### PR DESCRIPTION
## Summary
- prefer `inputText` over empty fallback args when serializing legacy assistant tool calls
- repair leading-quote streamed inputText before snapshot/public-message serialization
- keep deep-research child snapshots aligned with the actual streamed tool input

## Testing
- deno test --no-check --allow-all src/internal-agents/schema.test.ts src/agent/data-stream.test.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/runtime/tool-helpers.test.ts

## Why
Staging rc.167 removed the old parse-error noise, but deep-research child snapshots still showed `create_file.arguments = {}`. The remaining data loss happens in the internal AG-UI compatibility serializer, which ignored `inputText` when `args` was the fallback empty object. This patch preserves the real streamed tool input so snapshots, replay, and the browser reflect what the model actually emitted.
