### PR TITLE
fix(veryfront-cloud): send x-veryfront-project-slug header on gateway calls

### DIFF
--- a/src/provider/veryfront-cloud/provider.ts
+++ b/src/provider/veryfront-cloud/provider.ts
@@ -14,9 +14,9 @@ import {
 
 export function createVeryfrontCloudModel(modelId: string): ModelRuntime {
   const { provider, modelId: upstreamModelId } = parseVeryfrontCloudModelId(modelId, "language");
-  const { apiBaseUrl, apiToken } = requireVeryfrontCloudBootstrap();
+  const { apiBaseUrl, apiToken, projectSlug } = requireVeryfrontCloudBootstrap();
   const baseURL = getVeryfrontCloudGatewayBaseUrl(apiBaseUrl, provider);
-  const fetch = createVeryfrontCloudFetch(apiToken);
+  const fetch = createVeryfrontCloudFetch(apiToken, projectSlug);
 
   switch (provider) {
     case "anthropic":

--- a/src/provider/veryfront-cloud/shared.ts
+++ b/src/provider/veryfront-cloud/shared.ts
@@ -118,7 +118,10 @@ export function getVeryfrontCloudGatewayBaseUrl(
  * The gateway expects only Bearer auth, so we strip all provider-specific
  * headers to prevent credential leakage to the wrong auth path.
  */
-export function createVeryfrontCloudFetch(apiToken: string): typeof fetch {
+export function createVeryfrontCloudFetch(
+  apiToken: string,
+  projectSlug?: string,
+): typeof fetch {
   return (input, init) => {
     const request = new Request(input, init);
     const headers = new Headers(request.headers);
@@ -126,6 +129,10 @@ export function createVeryfrontCloudFetch(apiToken: string): typeof fetch {
     headers.delete("x-api-key");
     headers.delete("x-goog-api-key");
     headers.set("Authorization", `Bearer ${apiToken}`);
+
+    if (projectSlug) {
+      headers.set("x-veryfront-project-slug", projectSlug);
+    }
 
     return fetch(new Request(request, { headers }));
   };


### PR DESCRIPTION
## Summary

The veryfront-cloud provider creates model runtimes via `createVeryfrontCloudFetch`, which sets `Authorization` but never identifies the project. The API gateway then falls back to user-scoped credit checks, logging `AI gateway request without projectId` (~3×/30min on staging, all from the agent with `userAgent: "node"`).

The bootstrap already has `projectSlug` available via `requireVeryfrontCloudBootstrap()` but the destructure in `provider.ts` was ignoring it:

```diff
- const { apiBaseUrl, apiToken } = requireVeryfrontCloudBootstrap();
- const fetch = createVeryfrontCloudFetch(apiToken);
+ const { apiBaseUrl, apiToken, projectSlug } = requireVeryfrontCloudBootstrap();
+ const fetch = createVeryfrontCloudFetch(apiToken, projectSlug);
```

Now `createVeryfrontCloudFetch` sets `x-veryfront-project-slug` on every gateway call when the slug is known. The companion PR in veryfront-api resolves the slug to a UUID and scopes credit checks to the correct project.

## Companion PR
- **veryfront-api**: `fix/gateway-accept-project-slug-header` — adds slug→UUID resolution fallback in `resolveGatewayProjectId`

## Test plan
- [x] `deno check` clean
- [x] Pre-push hook: **1346 passed (16517 steps), 0 failed**
- [ ] Deploy both PRs to staging, verify `AI gateway request without projectId` warnings stop for agent-originated calls