### PR TITLE
feat(mcp): add vf_trigger_deploy tool using existing deploy API

### DIFF
--- a/cli/mcp/advanced-tools.ts
+++ b/cli/mcp/advanced-tools.ts
@@ -22,6 +22,7 @@ import {
   vfListRoutes,
 } from "./tools/project-tools.ts";
 import { vfBuild } from "./tools/build-tool.ts";
+import { vfTriggerDeploy } from "./tools/deploy-tool.ts";
 import { vfRunLint } from "./tools/run-lint-tool.ts";
 import { vfRunTests } from "./tools/run-tests-tool.ts";
 import { vfGetConventions, vfScaffold } from "./tools/scaffold-tools.ts";
@@ -50,6 +51,7 @@ export const advancedTools: MCPTool[] = [
   vfGetDebugContext,
   vfGetComponentTree,
   vfBuild,
+  vfTriggerDeploy,
   vfHotReload,
   vfTriggerHmr,
   vfWaitForReady,

--- a/cli/mcp/standalone.ts
+++ b/cli/mcp/standalone.ts
@@ -507,6 +507,40 @@ export class StandaloneMCPServer {
           };
         },
       },
+      {
+        name: "vf_trigger_deploy",
+        description: "Deploy a project to an environment via the Veryfront API. " +
+          "Creates a release from the specified branch and deploys it to the target environment. " +
+          "Requires a valid API token (set VERYFRONT_API_TOKEN or run 'veryfront login'). " +
+          "Do not use for local builds — use vf_build instead. " +
+          "Do not use for running tests before deploy — use vf_run_tests instead.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            projectSlug: {
+              type: "string",
+              description: "The project slug to deploy. Example: 'my-app'.",
+            },
+            environment: {
+              type: "string",
+              description: "Target environment name. Defaults to 'production'.",
+            },
+            branch: {
+              type: "string",
+              description: "Git branch to create the release from. Defaults to 'main'.",
+            },
+          },
+          required: ["projectSlug"],
+        },
+        async execute(args) {
+          const { triggerDeploy } = await import("./tools/deploy-tool.ts");
+          return triggerDeploy({
+            projectSlug: args.projectSlug as string,
+            environment: (args.environment as string) ?? "production",
+            branch: (args.branch as string) ?? "main",
+          });
+        },
+      },
       ...this.createContext7Tools(),
     ];
   }

--- a/cli/mcp/tools/deploy-tool.test.ts
+++ b/cli/mcp/tools/deploy-tool.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Tests for MCP deploy tool
+ */
+
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
+import { triggerDeploy, vfTriggerDeploy } from "./deploy-tool.ts";
+
+// ---------------------------------------------------------------------------
+// Tool definition (shape)
+// ---------------------------------------------------------------------------
+
+describe("mcp/tools/deploy-tool", () => {
+  describe("vfTriggerDeploy tool definition", () => {
+    it("has correct tool name", () => {
+      assertEquals(vfTriggerDeploy.name, "vf_trigger_deploy");
+    });
+
+    it("has title", () => {
+      assertEquals(vfTriggerDeploy.title, "Trigger Deploy");
+    });
+
+    it("has description mentioning deploy", () => {
+      assertExists(vfTriggerDeploy.description);
+      assertEquals(vfTriggerDeploy.description.includes("deploy"), true);
+    });
+
+    it("has description cross-referencing vf_build", () => {
+      assertEquals(vfTriggerDeploy.description.includes("vf_build"), true);
+    });
+
+    it("has description cross-referencing vf_run_tests", () => {
+      assertEquals(vfTriggerDeploy.description.includes("vf_run_tests"), true);
+    });
+
+    it("has execute function", () => {
+      assertEquals(typeof vfTriggerDeploy.execute, "function");
+    });
+
+    it("has correct annotations — not read-only, not destructive, not idempotent, open-world", () => {
+      assertEquals(vfTriggerDeploy.annotations?.readOnlyHint, false);
+      assertEquals(vfTriggerDeploy.annotations?.destructiveHint, false);
+      assertEquals(vfTriggerDeploy.annotations?.idempotentHint, false);
+      assertEquals(vfTriggerDeploy.annotations?.openWorldHint, true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Input schema validation
+  // ---------------------------------------------------------------------------
+
+  describe("input schema", () => {
+    const schema = vfTriggerDeploy.inputSchema;
+
+    it("requires projectSlug", () => {
+      const result = schema.safeParse({});
+      assertEquals(result.success, false);
+    });
+
+    it("accepts valid input with only projectSlug", () => {
+      const result = schema.safeParse({ projectSlug: "my-app" });
+      assertEquals(result.success, true);
+      if (result.success) {
+        assertEquals(result.data.projectSlug, "my-app");
+        assertEquals(result.data.environment, "production");
+        assertEquals(result.data.branch, "main");
+      }
+    });
+
+    it("applies default environment when not provided", () => {
+      const result = schema.safeParse({ projectSlug: "my-app" });
+      assertEquals(result.success, true);
+      if (result.success) {
+        assertEquals(result.data.environment, "production");
+      }
+    });
+
+    it("applies default branch when not provided", () => {
+      const result = schema.safeParse({ projectSlug: "my-app" });
+      assertEquals(result.success, true);
+      if (result.success) {
+        assertEquals(result.data.branch, "main");
+      }
+    });
+
+    it("accepts custom environment and branch", () => {
+      const result = schema.safeParse({
+        projectSlug: "my-app",
+        environment: "staging",
+        branch: "develop",
+      });
+      assertEquals(result.success, true);
+      if (result.success) {
+        assertEquals(result.data.environment, "staging");
+        assertEquals(result.data.branch, "develop");
+      }
+    });
+
+    it("rejects non-string projectSlug", () => {
+      const result = schema.safeParse({ projectSlug: 123 });
+      assertEquals(result.success, false);
+    });
+
+    it("rejects non-string environment", () => {
+      const result = schema.safeParse({
+        projectSlug: "my-app",
+        environment: 42,
+      });
+      assertEquals(result.success, false);
+    });
+
+    it("rejects non-string branch", () => {
+      const result = schema.safeParse({
+        projectSlug: "my-app",
+        branch: true,
+      });
+      assertEquals(result.success, false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Auth error handling
+  // ---------------------------------------------------------------------------
+
+  describe("triggerDeploy auth error", () => {
+    it("returns structured error when VERYFRONT_API_TOKEN is not set", async () => {
+      const originalToken = Deno.env.get("VERYFRONT_API_TOKEN");
+      try {
+        Deno.env.delete("VERYFRONT_API_TOKEN");
+
+        const result = await triggerDeploy({
+          projectSlug: "my-app",
+          environment: "production",
+          branch: "main",
+        });
+
+        assertEquals(result.success, false);
+        assertEquals(
+          result.error,
+          "Not authenticated. Run 'veryfront login' first.",
+        );
+      } finally {
+        if (originalToken !== undefined) {
+          Deno.env.set("VERYFRONT_API_TOKEN", originalToken);
+        } else {
+          Deno.env.delete("VERYFRONT_API_TOKEN");
+        }
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Happy path with mock fetch
+  // ---------------------------------------------------------------------------
+
+  describe("triggerDeploy happy path", () => {
+    it("creates release and deployment, returns structured result", async () => {
+      const originalToken = Deno.env.get("VERYFRONT_API_TOKEN");
+      try {
+        Deno.env.set("VERYFRONT_API_TOKEN", "test-token-abc");
+
+        const capturedRequests: { method: string; url: string }[] = [];
+
+        const result = await withMockFetch(
+          async (input: string | URL | Request, init?: RequestInit) => {
+            const request = input instanceof Request ? input : new Request(input, init);
+            const url = request.url;
+            const method = request.method;
+            capturedRequests.push({ method, url });
+
+            // GET /projects/my-app/environments
+            if (method === "GET" && url.includes("/environments")) {
+              return Response.json({
+                data: [
+                  { id: "env-1", name: "production", protected: true },
+                  { id: "env-2", name: "staging", protected: false },
+                ],
+              });
+            }
+
+            // POST /projects/my-app/releases
+            if (method === "POST" && url.includes("/releases")) {
+              return Response.json({
+                id: "rel-42",
+                name: "Release 42",
+                version: "v1.0.42",
+                export_status: "completed",
+                build_status: "completed",
+                deploy_status: "pending",
+              });
+            }
+
+            // POST /projects/my-app/deployments
+            if (method === "POST" && url.includes("/deployments")) {
+              return Response.json({
+                id: "deploy-99",
+                release: "rel-42",
+                environment: "env-1",
+              });
+            }
+
+            return new Response("Not Found", { status: 404 });
+          },
+          async () =>
+            await triggerDeploy({
+              projectSlug: "my-app",
+              environment: "production",
+              branch: "main",
+            }),
+        );
+
+        assertEquals(result.success, true);
+        assertEquals(result.deploymentId, "deploy-99");
+        assertEquals(result.release, {
+          id: "rel-42",
+          name: "Release 42",
+          version: "v1.0.42",
+        });
+        assertEquals(result.environment, {
+          id: "env-1",
+          name: "production",
+        });
+
+        // Verify correct API calls were made
+        assertEquals(capturedRequests.length, 3);
+        assertEquals(capturedRequests[0].method, "GET");
+        assertEquals(capturedRequests[0].url.includes("/environments"), true);
+        assertEquals(capturedRequests[1].method, "POST");
+        assertEquals(capturedRequests[1].url.includes("/releases"), true);
+        assertEquals(capturedRequests[2].method, "POST");
+        assertEquals(capturedRequests[2].url.includes("/deployments"), true);
+      } finally {
+        if (originalToken !== undefined) {
+          Deno.env.set("VERYFRONT_API_TOKEN", originalToken);
+        } else {
+          Deno.env.delete("VERYFRONT_API_TOKEN");
+        }
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Environment not found
+  // ---------------------------------------------------------------------------
+
+  describe("triggerDeploy environment not found", () => {
+    it("returns structured error when environment does not exist", async () => {
+      const originalToken = Deno.env.get("VERYFRONT_API_TOKEN");
+      try {
+        Deno.env.set("VERYFRONT_API_TOKEN", "test-token-abc");
+
+        const result = await withMockFetch(
+          async (input: string | URL | Request, init?: RequestInit) => {
+            const request = input instanceof Request ? input : new Request(input, init);
+
+            if (request.method === "GET" && request.url.includes("/environments")) {
+              return Response.json({ data: [] });
+            }
+
+            return new Response("Not Found", { status: 404 });
+          },
+          async () =>
+            await triggerDeploy({
+              projectSlug: "my-app",
+              environment: "nonexistent",
+              branch: "main",
+            }),
+        );
+
+        assertEquals(result.success, false);
+        assertEquals(result.error, 'Environment "nonexistent" not found.');
+      } finally {
+        if (originalToken !== undefined) {
+          Deno.env.set("VERYFRONT_API_TOKEN", originalToken);
+        } else {
+          Deno.env.delete("VERYFRONT_API_TOKEN");
+        }
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // API error handling
+  // ---------------------------------------------------------------------------
+
+  describe("triggerDeploy API error", () => {
+    it("returns structured error on API failure", async () => {
+      const originalToken = Deno.env.get("VERYFRONT_API_TOKEN");
+      try {
+        Deno.env.set("VERYFRONT_API_TOKEN", "test-token-abc");
+
+        const result = await withMockFetch(
+          async () =>
+            Response.json(
+              { error: "forbidden", message: "Access denied" },
+              { status: 403 },
+            ),
+          async () =>
+            await triggerDeploy({
+              projectSlug: "my-app",
+              environment: "production",
+              branch: "main",
+            }),
+        );
+
+        assertEquals(result.success, false);
+        assertExists(result.error);
+      } finally {
+        if (originalToken !== undefined) {
+          Deno.env.set("VERYFRONT_API_TOKEN", originalToken);
+        } else {
+          Deno.env.delete("VERYFRONT_API_TOKEN");
+        }
+      }
+    });
+
+    it("returns auth error on 401 response", async () => {
+      const originalToken = Deno.env.get("VERYFRONT_API_TOKEN");
+      try {
+        Deno.env.set("VERYFRONT_API_TOKEN", "invalid-token");
+
+        const result = await withMockFetch(
+          async () =>
+            Response.json(
+              {
+                error: "unauthorized",
+                message: "API request failed: 401 Unauthorized",
+              },
+              { status: 401 },
+            ),
+          async () =>
+            await triggerDeploy({
+              projectSlug: "my-app",
+              environment: "production",
+              branch: "main",
+            }),
+        );
+
+        assertEquals(result.success, false);
+        assertEquals(
+          result.error,
+          "Not authenticated. Run 'veryfront login' first.",
+        );
+      } finally {
+        if (originalToken !== undefined) {
+          Deno.env.set("VERYFRONT_API_TOKEN", originalToken);
+        } else {
+          Deno.env.delete("VERYFRONT_API_TOKEN");
+        }
+      }
+    });
+  });
+});

--- a/cli/mcp/tools/deploy-tool.ts
+++ b/cli/mcp/tools/deploy-tool.ts
@@ -1,0 +1,132 @@
+/**
+ * MCP tool: vf_trigger_deploy
+ *
+ * Creates a release from a branch and deploys it to an environment.
+ * Wraps the same API calls used by the `vf deploy` CLI command.
+ */
+
+import { z } from "zod";
+import type { MCPTool } from "veryfront/mcp";
+import { getEnvironmentConfig } from "veryfront/config";
+import { createApiClient, resolveConfig } from "#cli/shared/config";
+import {
+  createDeployment,
+  createRelease,
+  getEnvironmentByName,
+} from "../../commands/deploy/command.ts";
+
+const triggerDeployInput = z.object({
+  projectSlug: z.string().describe(
+    "The project slug to deploy. Example: 'my-app'.",
+  ),
+  environment: z.string().optional().default("production").describe(
+    "Target environment name. Defaults to 'production'.",
+  ),
+  branch: z.string().optional().default("main").describe(
+    "Git branch to create the release from. Defaults to 'main'.",
+  ),
+});
+
+export type TriggerDeployInput = z.infer<typeof triggerDeployInput>;
+
+export interface TriggerDeployResult {
+  success: boolean;
+  deploymentId?: string;
+  release?: { id: string; name: string; version: string };
+  environment?: { id: string; name: string };
+  error?: string;
+}
+
+/**
+ * Trigger a deploy via the Veryfront API.
+ *
+ * Exported for standalone MCP server reuse.
+ */
+export async function triggerDeploy(
+  input: TriggerDeployInput,
+): Promise<TriggerDeployResult> {
+  try {
+    const env = getEnvironmentConfig();
+    const apiToken = env.apiToken;
+
+    if (!apiToken) {
+      return {
+        success: false,
+        error: "Not authenticated. Run 'veryfront login' first.",
+      };
+    }
+
+    const config = await resolveConfig(undefined, {
+      ...env,
+      apiToken,
+      projectSlug: input.projectSlug,
+    });
+
+    const client = createApiClient(config);
+
+    const environment = await getEnvironmentByName(
+      client,
+      input.projectSlug,
+      input.environment,
+    );
+    if (!environment) {
+      return {
+        success: false,
+        error: `Environment "${input.environment}" not found.`,
+      };
+    }
+
+    const release = await createRelease(client, input.projectSlug, {
+      branch: input.branch,
+    });
+
+    const deployment = await createDeployment(
+      client,
+      input.projectSlug,
+      release.id,
+      environment.id,
+    );
+
+    return {
+      success: true,
+      deploymentId: deployment.id,
+      release: { id: release.id, name: release.name, version: release.version },
+      environment: { id: environment.id, name: environment.name },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (
+      message.includes("Missing API token") ||
+      message.includes("Authentication required") ||
+      message.includes("401")
+    ) {
+      return {
+        success: false,
+        error: "Not authenticated. Run 'veryfront login' first.",
+      };
+    }
+
+    return { success: false, error: message };
+  }
+}
+
+export const vfTriggerDeploy: MCPTool<TriggerDeployInput, TriggerDeployResult> = {
+  name: "vf_trigger_deploy",
+  title: "Trigger Deploy",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  description:
+    "Use this when you need to deploy a project to an environment via the Veryfront API. " +
+    "Creates a release from the specified branch and deploys it to the target environment. " +
+    "Returns the deployment ID, release info, and environment info on success. " +
+    "Requires a valid API token (set VERYFRONT_API_TOKEN or run 'veryfront login'). " +
+    "Do not use for local builds — use vf_build instead. " +
+    "Do not use for running tests before deploy — use vf_run_tests instead.",
+  inputSchema: triggerDeployInput,
+  execute: (input) => triggerDeploy(input),
+};


### PR DESCRIPTION
## Summary

- Add `vf_trigger_deploy` MCP tool that creates a release and deploys it via the existing Veryfront API
- Wraps the same API calls used by `vf deploy` CLI command (environments, releases, deployments)
- Register in both connected mode (`advanced-tools.ts`) and standalone mode (`standalone.ts`)
- Shared `triggerDeploy()` export for standalone reuse

Closes #1088

## Changes

**New files:**
- `cli/mcp/tools/deploy-tool.ts` — Tool definition with `triggerDeploy()` shared helper
- `cli/mcp/tools/deploy-tool.test.ts` — 26 test steps with `withMockFetch` integration tests

**Modified files (additive only):**
- `cli/mcp/advanced-tools.ts` — Import + array entry
- `cli/mcp/standalone.ts` — Standalone tool entry

## Tool specification

| Field | Value |
|-------|-------|
| Name | `vf_trigger_deploy` |
| Title | `Trigger Deploy` |
| Annotations | `readOnlyHint: false`, `destructiveHint: false`, `idempotentHint: false`, `openWorldHint: true` |
| Input | `projectSlug` (required string), `environment` (optional, default "production"), `branch` (optional, default "main") |
| Output | `{ success, deploymentId?, release?, environment?, error? }` |

## Design decisions

- **`idempotentHint: false`** — Each call creates a new release + deployment
- **`openWorldHint: true`** — Makes network calls to Veryfront API
- **Structured error returns** — Auth errors, env-not-found, API failures all return `{ success: false, error }` instead of throwing
- **401 detection** — Catches 401 responses and maps to auth error message
- **Reuses existing deploy command imports** — `createRelease`, `createDeployment`, `getEnvironmentByName` from `cli/commands/deploy/command.ts`

## Test plan

- [x] `deno test --no-check --allow-all cli/mcp/tools/deploy-tool.test.ts` — 26 steps pass
- [x] `deno test --no-check --allow-all --parallel cli/mcp/` — 22 suites, 461 steps, 0 failed
- [x] `deno task build` — full build succeeds
- [x] Tool shape: name, title, description, annotations, execute (7 tests)
- [x] Description cross-references vf_build and vf_run_tests
- [x] Input schema: required projectSlug, defaults, type rejection (8 tests)
- [x] Auth error: returns structured error when no API token (1 test)
- [x] Happy path: mocks 3 API calls, verifies structured result (1 test with withMockFetch)
- [x] Environment not found: returns structured error (1 test)
- [x] API error: 403 returns error, 401 maps to auth error (2 tests)