### PR TITLE
fix: emit truthful tool-call status during silent input gaps

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.213",
+  "version": "0.1.214",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/agent/ag-ui-browser-encoder.test.ts
+++ b/src/agent/ag-ui-browser-encoder.test.ts
@@ -123,6 +123,19 @@ describe("agent/ag-ui-browser-encoder", () => {
     );
     assertEquals(
       mapRuntimeStreamEventToAgUiBrowserEvents(state, {
+        type: "data-tool-call-status",
+        data: { toolCallId: "tool-1", status: "pending_input" },
+      }),
+      [{
+        event: "Custom",
+        payload: {
+          name: "tool-call-status",
+          value: { toolCallId: "tool-1", status: "pending_input" },
+        },
+      }],
+    );
+    assertEquals(
+      mapRuntimeStreamEventToAgUiBrowserEvents(state, {
         type: "tool-input-error",
         toolCallId: "tool-2",
         input: { url: "https://example.com" },

--- a/src/agent/ag-ui-browser-encoder.ts
+++ b/src/agent/ag-ui-browser-encoder.ts
@@ -461,6 +461,9 @@ export function mapRuntimeStreamEventToAgUiBrowserEvents(
       ];
 
     default:
+      if (typeof event.type === "string" && event.type.startsWith("data-")) {
+        return [createCustomDataEvent(event.type.slice(5), event.data)];
+      }
       return [];
   }
 }

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -81,6 +81,26 @@ describe("chat-stream-handler", () => {
       assertEquals(events[3], { type: "text-end", id: "text-1" });
     });
 
+    it("passes through data-tool-call-status events", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+
+      const result = createMockResult([
+        {
+          type: "data-tool-call-status",
+          data: { toolCallId: "tool-1", status: "pending_input" },
+        },
+        { type: "finish", finishReason: "stop", totalUsage: null },
+      ]);
+
+      await processStream(result, state, controller, encoder, "text-1", undefined);
+
+      assertEquals(events[0], {
+        type: "data-tool-call-status",
+        data: { toolCallId: "tool-1", status: "pending_input" },
+      });
+    });
+
     it("closes and reopens text segments when a tool interrupts assistant text", async () => {
       const { events, controller, encoder } = createSSECollector();
       const state = createStreamState();

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -301,6 +301,14 @@ export function processStream(
 
       const typedPart = part as RuntimeStreamPart;
 
+      if (typedPart.type.startsWith("data-")) {
+        sendSSE(controller, encoder, {
+          type: typedPart.type,
+          data: "data" in typedPart ? typedPart.data : undefined,
+        });
+        continue;
+      }
+
       switch (typedPart.type) {
         case "text-delta": {
           closeReasoningSegment();

--- a/src/agent/runtime/runtime-tool-types.ts
+++ b/src/agent/runtime/runtime-tool-types.ts
@@ -63,6 +63,10 @@ export type RuntimeStreamPart =
   | { type: "reasoning-delta"; id: string; delta: string }
   | { type: "reasoning-end"; id: string }
   | {
+    type: `data-${string}`;
+    data: unknown;
+  }
+  | {
     type: "tool-input-start";
     id: string;
     toolName: string;

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -6,6 +6,7 @@ import {
   ProviderQuotaError,
   ProviderRateLimitError,
   ProviderRequestError,
+  withToolInputStatusTransitions,
 } from "./runtime-loader.ts";
 import { createRuntimeJsonSchema } from "../agent/runtime/runtime-tool-builder.ts";
 import {
@@ -38,6 +39,80 @@ function readRequestHeader(init: RequestInit | undefined, name: string): string 
 }
 
 describe("provider/runtime-loader", () => {
+  it("emits pending_input and streaming_input transitions when tool input goes silent and resumes", async () => {
+    const events = await collectAsync(withToolInputStatusTransitions({
+      async *[Symbol.asyncIterator]() {
+        yield { type: "tool-input-start", id: "tool-1", toolName: "create_file" };
+        await new Promise((resolve) => setTimeout(resolve, 8));
+        yield { type: "tool-input-delta", id: "tool-1", delta: '{"path":"docs/report.md"' };
+        await new Promise((resolve) => setTimeout(resolve, 8));
+        yield {
+          type: "tool-call",
+          toolCallId: "tool-1",
+          toolName: "create_file",
+          input: { path: "docs/report.md" },
+        };
+        yield { type: "finish", finishReason: "tool-calls" };
+      },
+    }, 5));
+
+    assertEquals(events, [
+      { type: "tool-input-start", id: "tool-1", toolName: "create_file" },
+      {
+        type: "data-tool-call-status",
+        data: { toolCallId: "tool-1", status: "pending_input" },
+      },
+      {
+        type: "data-tool-call-status",
+        data: { toolCallId: "tool-1", status: "streaming_input" },
+      },
+      { type: "tool-input-delta", id: "tool-1", delta: '{"path":"docs/report.md"' },
+      {
+        type: "data-tool-call-status",
+        data: { toolCallId: "tool-1", status: "pending_input" },
+      },
+      {
+        type: "tool-call",
+        toolCallId: "tool-1",
+        toolName: "create_file",
+        input: { path: "docs/report.md" },
+      },
+      { type: "finish", finishReason: "tool-calls" },
+    ]);
+  });
+
+  it("does not fabricate pending_input for google-style immediate tool input", async () => {
+    const events = await collectAsync(withToolInputStatusTransitions({
+      async *[Symbol.asyncIterator]() {
+        yield { type: "tool-input-start", id: "tool-1", toolName: "search" };
+        yield { type: "tool-input-delta", id: "tool-1", delta: '{"query":"Veryfront"}' };
+        yield {
+          type: "tool-call",
+          toolCallId: "tool-1",
+          toolName: "search",
+          input: { query: "Veryfront" },
+        };
+        yield { type: "finish", finishReason: "tool-calls" };
+      },
+    }, 5));
+
+    assertEquals(events, [
+      { type: "tool-input-start", id: "tool-1", toolName: "search" },
+      {
+        type: "data-tool-call-status",
+        data: { toolCallId: "tool-1", status: "streaming_input" },
+      },
+      { type: "tool-input-delta", id: "tool-1", delta: '{"query":"Veryfront"}' },
+      {
+        type: "tool-call",
+        toolCallId: "tool-1",
+        toolName: "search",
+        input: { query: "Veryfront" },
+      },
+      { type: "finish", finishReason: "tool-calls" },
+    ]);
+  });
+
   it("creates an OpenAI-compatible language runtime without SDK helpers for generate", async () => {
     let requestedUrl = "";
     let requestedInit: RequestInit | undefined;
@@ -212,6 +287,13 @@ describe("provider/runtime-loader", () => {
         type: "tool-input-start",
         id: "call_weather",
         toolName: "weather",
+      },
+      {
+        type: "data-tool-call-status",
+        data: {
+          toolCallId: "call_weather",
+          status: "streaming_input",
+        },
       },
       {
         type: "tool-input-delta",
@@ -841,6 +923,13 @@ describe("provider/runtime-loader", () => {
         providerExecuted: true,
       },
       {
+        type: "data-tool-call-status",
+        data: {
+          toolCallId: "srvtool_web_1",
+          status: "streaming_input",
+        },
+      },
+      {
         type: "tool-input-delta",
         id: "srvtool_web_1",
         delta: '{"query":"Veryfront"}',
@@ -1067,7 +1156,7 @@ describe("provider/runtime-loader", () => {
     });
 
     const parts = await collectAsync(result.stream);
-    assertEquals(parts.length, 5);
+    assertEquals(parts.length, 6);
     assertEquals(parts[0], {
       type: "tool-input-start",
       id: "srvtool_fetch_2",
@@ -1075,18 +1164,25 @@ describe("provider/runtime-loader", () => {
       providerExecuted: true,
     });
     assertEquals(parts[1], {
+      type: "data-tool-call-status",
+      data: {
+        toolCallId: "srvtool_fetch_2",
+        status: "streaming_input",
+      },
+    });
+    assertEquals(parts[2], {
       type: "tool-input-delta",
       id: "srvtool_fetch_2",
       delta: '{"url":"https://veryfront.com/docs"}',
     });
-    assertEquals(parts[2], {
+    assertEquals(parts[3], {
       type: "tool-call",
       toolCallId: "srvtool_fetch_2",
       toolName: "web_fetch",
       input: '{"url":"https://veryfront.com/docs"}',
       providerExecuted: true,
     });
-    assertEquals(parts[3], {
+    assertEquals(parts[4], {
       type: "tool-result",
       toolCallId: "srvtool_fetch_2",
       toolName: "web_fetch",
@@ -1105,7 +1201,7 @@ describe("provider/runtime-loader", () => {
       },
       providerExecuted: true,
     });
-    assertEquals(parts[4], {
+    assertEquals(parts[5], {
       type: "finish",
       finishReason: { unified: "stop", raw: "end_turn" },
       usage: {
@@ -1590,6 +1686,13 @@ describe("provider/runtime-loader", () => {
         type: "tool-input-start",
         id: "tool_weather",
         toolName: "weather",
+      },
+      {
+        type: "data-tool-call-status",
+        data: {
+          toolCallId: "tool_weather",
+          status: "streaming_input",
+        },
       },
       {
         type: "tool-input-delta",
@@ -4445,6 +4548,7 @@ describe("provider/runtime-loader", () => {
         "reasoning-delta",
         "reasoning-end",
         "tool-input-start",
+        "data-tool-call-status",
         "tool-input-delta",
         "tool-call",
         "text-delta",

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -379,6 +379,206 @@ type GoogleCompatibleRequest = {
 const DEFAULT_ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1";
 const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 const DEFAULT_GOOGLE_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
+export const TOOL_INPUT_PENDING_THRESHOLD_MS = 5_000;
+type ToolInputActivityStatus = "pending_input" | "streaming_input";
+
+type ToolInputStatusState = {
+  dueAt: number | null;
+  lastStatus: ToolInputActivityStatus | null;
+};
+
+function getToolCallIdFromStreamPart(part: unknown): string | null {
+  if (!part || typeof part !== "object") {
+    return null;
+  }
+
+  const record = part as Record<string, unknown>;
+  if (typeof record.toolCallId === "string" && record.toolCallId.length > 0) {
+    return record.toolCallId;
+  }
+
+  if (typeof record.id === "string" && record.id.length > 0) {
+    return record.id;
+  }
+
+  return null;
+}
+
+function collectDueToolStatuses(
+  toolStates: Map<string, ToolInputStatusState>,
+  now: number,
+): Array<{ type: "data-tool-call-status"; data: { toolCallId: string; status: "pending_input" } }> {
+  const events: Array<
+    { type: "data-tool-call-status"; data: { toolCallId: string; status: "pending_input" } }
+  > = [];
+
+  for (const [toolCallId, state] of toolStates.entries()) {
+    if (state.dueAt === null || state.dueAt > now || state.lastStatus === "pending_input") {
+      continue;
+    }
+
+    state.dueAt = null;
+    state.lastStatus = "pending_input";
+    events.push({
+      type: "data-tool-call-status",
+      data: {
+        toolCallId,
+        status: "pending_input",
+      },
+    });
+  }
+
+  return events;
+}
+
+export async function* withToolInputStatusTransitions(
+  stream: AsyncIterable<unknown>,
+  thresholdMs = TOOL_INPUT_PENDING_THRESHOLD_MS,
+): AsyncIterable<unknown> {
+  const iterator = stream[Symbol.asyncIterator]();
+  const toolStates = new Map<string, ToolInputStatusState>();
+  const buffered: unknown[] = [];
+  let nextPartPromise: Promise<IteratorResult<unknown>> | null = null;
+
+  const closeTool = (toolCallId: string | null) => {
+    if (!toolCallId) {
+      return;
+    }
+
+    toolStates.delete(toolCallId);
+  };
+
+  const schedulePending = (toolCallId: string | null) => {
+    if (!toolCallId) {
+      return;
+    }
+
+    const state = toolStates.get(toolCallId) ?? {
+      dueAt: null,
+      lastStatus: null,
+    };
+    state.dueAt = Date.now() + thresholdMs;
+    toolStates.set(toolCallId, state);
+  };
+
+  const markStreaming = (toolCallId: string | null) => {
+    if (!toolCallId) {
+      return;
+    }
+
+    const state = toolStates.get(toolCallId) ?? {
+      dueAt: null,
+      lastStatus: null,
+    };
+
+    if (state.lastStatus !== "streaming_input") {
+      buffered.push({
+        type: "data-tool-call-status",
+        data: {
+          toolCallId,
+          status: "streaming_input",
+        },
+      });
+    }
+
+    state.lastStatus = "streaming_input";
+    state.dueAt = Date.now() + thresholdMs;
+    toolStates.set(toolCallId, state);
+  };
+
+  const processPart = (part: unknown) => {
+    if (!part || typeof part !== "object") {
+      buffered.push(part);
+      return;
+    }
+
+    const record = part as Record<string, unknown>;
+    const partType = typeof record.type === "string" ? record.type : null;
+    const toolCallId = getToolCallIdFromStreamPart(part);
+
+    switch (partType) {
+      case "tool-input-start":
+        schedulePending(toolCallId);
+        buffered.push(part);
+        return;
+      case "tool-input-delta":
+        markStreaming(toolCallId);
+        buffered.push(part);
+        return;
+      case "tool-call":
+      case "tool-result":
+      case "tool-error":
+        closeTool(toolCallId);
+        buffered.push(part);
+        return;
+      case "finish":
+      case "error":
+        toolStates.clear();
+        buffered.push(part);
+        return;
+      default:
+        buffered.push(part);
+        return;
+    }
+  };
+
+  while (true) {
+    if (buffered.length > 0) {
+      yield buffered.shift();
+      continue;
+    }
+
+    if (!nextPartPromise) {
+      nextPartPromise = iterator.next();
+    }
+
+    const nextDueAt = [...toolStates.values()]
+      .map((state) => state.dueAt)
+      .filter((value): value is number => value !== null)
+      .sort((left, right) => left - right)[0] ?? null;
+
+    if (nextDueAt !== null) {
+      let timeoutId: ReturnType<typeof setTimeout> | null = null;
+      const timeoutResult = await Promise.race([
+        nextPartPromise.then((result) => ({ kind: "part" as const, result })),
+        new Promise<{ kind: "timeout" }>((resolve) => {
+          timeoutId = setTimeout(
+            () => resolve({ kind: "timeout" }),
+            Math.max(0, nextDueAt - Date.now()),
+          );
+        }),
+      ]);
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+
+      if (timeoutResult.kind === "timeout") {
+        buffered.push(...collectDueToolStatuses(toolStates, Date.now()));
+        continue;
+      }
+
+      nextPartPromise = null;
+      if (timeoutResult.result.done) {
+        buffered.push(...collectDueToolStatuses(toolStates, Date.now()));
+        while (buffered.length > 0) {
+          yield buffered.shift();
+        }
+        return;
+      }
+
+      processPart(timeoutResult.result.value);
+      continue;
+    }
+
+    const result = await nextPartPromise;
+    nextPartPromise = null;
+    if (result.done) {
+      return;
+    }
+
+    processPart(result.value);
+  }
+}
 
 function joinUrl(base: string, path: string): string {
   return `${base.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
@@ -2901,7 +3101,9 @@ export function createOpenAIModelRuntime(
       }).then((responseStream) => {
         const drained = warnings.drain();
         return {
-          stream: ReadableStream.from(streamOpenAICompatibleParts(responseStream)),
+          stream: ReadableStream.from(
+            withToolInputStatusTransitions(streamOpenAICompatibleParts(responseStream)),
+          ),
           ...(drained.length > 0 ? { warnings: drained } : {}),
         };
       });
@@ -3552,7 +3754,9 @@ export function createOpenAIResponsesRuntime(
       }).then((responseStream) => {
         const drained = warnings.drain();
         return {
-          stream: ReadableStream.from(streamOpenAIResponsesParts(responseStream)),
+          stream: ReadableStream.from(
+            withToolInputStatusTransitions(streamOpenAIResponsesParts(responseStream)),
+          ),
           ...(drained.length > 0 ? { warnings: drained } : {}),
         };
       });
@@ -3633,7 +3837,9 @@ export function createAnthropicModelRuntime(
       }).then((responseStream) => {
         const drained = warnings.drain();
         return {
-          stream: ReadableStream.from(streamAnthropicCompatibleParts(responseStream)),
+          stream: ReadableStream.from(
+            withToolInputStatusTransitions(streamAnthropicCompatibleParts(responseStream)),
+          ),
           ...(drained.length > 0 ? { warnings: drained } : {}),
         };
       });
@@ -3710,7 +3916,9 @@ export function createGoogleModelRuntime(
       }).then((responseStream) => {
         const drained = warnings.drain();
         return {
-          stream: ReadableStream.from(streamGoogleCompatibleParts(responseStream)),
+          stream: ReadableStream.from(
+            withToolInputStatusTransitions(streamGoogleCompatibleParts(responseStream)),
+          ),
           ...(drained.length > 0 ? { warnings: drained } : {}),
         };
       });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.213";
+export const VERSION = "0.1.214";


### PR DESCRIPTION
## Summary
- emit transient `data-tool-call-status` events for silent tool-input gaps
- forward those status events through runtime SSE and AG-UI custom events
- cover Anthropic, OpenAI chat/completions, OpenAI Responses, and Google streams
- bump `deno.json` version to `0.1.214`

## Why
Fixes the upstream half of veryfront/veryfront-studio#1539 by surfacing truthful `pending_input` / `streaming_input` transitions instead of leaving long tool-input silences invisible.

## Testing
- `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/utils/logger/logger.test.ts src/utils/version.test.ts src/provider/runtime-loader.test.ts src/agent/ag-ui-browser-encoder.test.ts src/agent/runtime/chat-stream-handler.test.ts`
- pre-push suite (`deno task test:unit` via git push hook)
- `deno check src/provider/runtime-loader.ts src/agent/ag-ui-browser-encoder.ts src/agent/runtime/runtime-tool-types.ts src/agent/runtime/chat-stream-handler.ts`

Refs veryfront/veryfront-studio#1539
