### PR TITLE
Keep silent tool-input streams alive during long create_file gaps

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.214",
+  "version": "0.1.215",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertGreaterOrEqual } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   createAnthropicModelRuntime,
@@ -111,6 +112,76 @@ describe("provider/runtime-loader", () => {
       },
       { type: "finish", finishReason: "tool-calls" },
     ]);
+  });
+
+  it("repeats pending_input heartbeats while create_file content stays silent after the path", async () => {
+    const events = await collectAsync(withToolInputStatusTransitions({
+      async *[Symbol.asyncIterator]() {
+        yield { type: "tool-input-start", id: "tool-1", toolName: "create_file" };
+        yield {
+          type: "tool-input-delta",
+          id: "tool-1",
+          delta: '{"path":"plans/ai-ontologies-research.md"',
+        };
+        await new Promise((resolve) => setTimeout(resolve, 18));
+        yield { type: "tool-input-delta", id: "tool-1", delta: ', "content":"# AI Ontologies"' };
+        yield {
+          type: "tool-call",
+          toolCallId: "tool-1",
+          toolName: "create_file",
+          input: {
+            path: "plans/ai-ontologies-research.md",
+            content: "# AI Ontologies",
+          },
+        };
+        yield { type: "finish", finishReason: "tool-calls" };
+      },
+    }, 5));
+
+    const firstDeltaIndex = events.findIndex((event) =>
+      event && typeof event === "object" && (event as { type?: string }).type === "tool-input-delta"
+    );
+    const secondDeltaIndex = events.findIndex((event, index) =>
+      index > firstDeltaIndex &&
+      event &&
+      typeof event === "object" &&
+      (event as { type?: string }).type === "tool-input-delta"
+    );
+
+    const pendingBetweenDeltas = events
+      .slice(firstDeltaIndex + 1, secondDeltaIndex)
+      .filter((event) =>
+        event &&
+        typeof event === "object" &&
+        (event as { type?: string }).type === "data-tool-call-status" &&
+        (event as { data?: { status?: string } }).data?.status === "pending_input"
+      );
+
+    assertGreaterOrEqual(
+      pendingBetweenDeltas.length,
+      2,
+      "expected repeated pending_input heartbeats while create_file content stayed silent",
+    );
+
+    assertEquals(events[0], { type: "tool-input-start", id: "tool-1", toolName: "create_file" });
+    assertEquals(events[1], {
+      type: "data-tool-call-status",
+      data: { toolCallId: "tool-1", status: "streaming_input" },
+    });
+    assertEquals(events[firstDeltaIndex], {
+      type: "tool-input-delta",
+      id: "tool-1",
+      delta: '{"path":"plans/ai-ontologies-research.md"',
+    });
+    assertEquals(events[secondDeltaIndex - 1], {
+      type: "data-tool-call-status",
+      data: { toolCallId: "tool-1", status: "streaming_input" },
+    });
+    assertEquals(events[secondDeltaIndex], {
+      type: "tool-input-delta",
+      id: "tool-1",
+      delta: ', "content":"# AI Ontologies"',
+    });
   });
 
   it("creates an OpenAI-compatible language runtime without SDK helpers for generate", async () => {

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -407,17 +407,18 @@ function getToolCallIdFromStreamPart(part: unknown): string | null {
 function collectDueToolStatuses(
   toolStates: Map<string, ToolInputStatusState>,
   now: number,
+  thresholdMs: number,
 ): Array<{ type: "data-tool-call-status"; data: { toolCallId: string; status: "pending_input" } }> {
   const events: Array<
     { type: "data-tool-call-status"; data: { toolCallId: string; status: "pending_input" } }
   > = [];
 
   for (const [toolCallId, state] of toolStates.entries()) {
-    if (state.dueAt === null || state.dueAt > now || state.lastStatus === "pending_input") {
+    if (state.dueAt === null || state.dueAt > now) {
       continue;
     }
 
-    state.dueAt = null;
+    state.dueAt = now + thresholdMs;
     state.lastStatus = "pending_input";
     events.push({
       type: "data-tool-call-status",
@@ -553,13 +554,13 @@ export async function* withToolInputStatusTransitions(
       }
 
       if (timeoutResult.kind === "timeout") {
-        buffered.push(...collectDueToolStatuses(toolStates, Date.now()));
+        buffered.push(...collectDueToolStatuses(toolStates, Date.now(), thresholdMs));
         continue;
       }
 
       nextPartPromise = null;
       if (timeoutResult.result.done) {
-        buffered.push(...collectDueToolStatuses(toolStates, Date.now()));
+        buffered.push(...collectDueToolStatuses(toolStates, Date.now(), thresholdMs));
         while (buffered.length > 0) {
           yield buffered.shift();
         }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.214";
+export const VERSION = "0.1.215";


### PR DESCRIPTION
## Summary
- repeat `pending_input` heartbeats while a tool input stays silent instead of emitting the status only once
- add a regression test for the exact `create_file` path-then-long-silence-then-content pattern from #1539
- bump the package version metadata to `0.1.215`

## Why
Staging evidence for veryfront-studio#1539 showed the remaining failure mode was a real provider/runtime silence window, not lost content:
- last `path` chunk at `18:00:07.347991 UTC`
- first `content` chunk at `18:02:34.580663 UTC`

Before this patch, the runtime would emit a single `pending_input` transition after 5 seconds and then go dark again for the rest of the silent window. That left the UI looking stuck and gave the stream no progress bytes during long tool-input stalls.

After this patch, the runtime keeps emitting status-only heartbeats every threshold interval until new tool bytes arrive, then resumes `streaming_input` on the next delta.

## Testing
- `deno fmt --check src/provider/runtime-loader.ts src/provider/runtime-loader.test.ts src/utils/version-constant.ts deno.json`
- `deno lint src/provider/runtime-loader.ts src/provider/runtime-loader.test.ts src/utils/version-constant.ts`
- `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/provider/runtime-loader.test.ts src/agent/runtime/chat-stream-handler.test.ts src/agent/ag-ui-browser-encoder.test.ts`

Related: veryfront/veryfront-studio#1539
