### PR TITLE
fix: use max_completion_tokens for OpenAI Chat Completions

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.214",
+  "version": "0.1.215",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -196,7 +196,7 @@ describe("provider/runtime-loader", () => {
           role: "user",
           content: "Check weather",
         }],
-        max_tokens: 50,
+        max_completion_tokens: 50,
         temperature: 0.2,
         stop: ["END"],
         tools: [{

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -299,6 +299,7 @@ type OpenAICompatibleChatRequest = {
   stream_options?: {
     include_usage?: boolean;
   };
+  max_tokens?: number;
   max_completion_tokens?: number;
   temperature?: number;
   top_p?: number;
@@ -2171,6 +2172,16 @@ function isOpenAIReasoningModel(modelId: string): boolean {
 }
 
 /**
+ * Detect native OpenAI models (gpt-*, o-series, chatgpt-*) vs third-party
+ * OpenAI-compatible providers (Kimi, etc.). Native OpenAI models require
+ * `max_completion_tokens` (the old `max_tokens` is rejected by newer models
+ * like gpt-5.2), while third-party providers still expect `max_tokens`.
+ */
+function isNativeOpenAIModel(modelId: string): boolean {
+  return /^(gpt-|o[134](-|$)|chatgpt-)/.test(modelId);
+}
+
+/**
  * Map the unified reasoning effort to OpenAI's `reasoning_effort` enum.
  * OpenAI doesn't accept "max" — we collapse it to "high".
  */
@@ -2242,7 +2253,11 @@ function buildOpenAIChatRequest(
     model: modelId,
     messages: toOpenAICompatibleMessages(options.prompt),
     ...(stream ? { stream: true, stream_options: { include_usage: true } } : {}),
-    ...(options.maxOutputTokens !== undefined ? { max_completion_tokens: options.maxOutputTokens } : {}),
+    ...(options.maxOutputTokens !== undefined
+      ? isNativeOpenAIModel(modelId)
+        ? { max_completion_tokens: options.maxOutputTokens }
+        : { max_tokens: options.maxOutputTokens }
+      : {}),
     // OpenAI reasoning models reject temperature / top_p / frequency / presence.
     // Drop them silently rather than letting the API bounce the request.
     ...(!reasoningEnabled && options.temperature !== undefined

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -2182,6 +2182,15 @@ function isNativeOpenAIModel(modelId: string): boolean {
 }
 
 /**
+ * Kimi K2.5 fixes sampling parameters (temperature, top_p, presence_penalty,
+ * frequency_penalty) to predetermined values and rejects any other values.
+ * See https://platform.moonshot.cn/docs/guide/kimi-k2-5-quickstart
+ */
+function isFixedSamplingModel(modelId: string): boolean {
+  return /^kimi-k2\.5/.test(modelId);
+}
+
+/**
  * Map the unified reasoning effort to OpenAI's `reasoning_effort` enum.
  * OpenAI doesn't accept "max" — we collapse it to "high".
  */
@@ -2213,6 +2222,8 @@ function buildOpenAIChatRequest(
   const isReasoningModel = isOpenAIReasoningModel(modelId);
   const reasoningEffort = resolveOpenAIReasoningEffort(options.reasoning);
   const reasoningEnabled = isReasoningModel || reasoningEffort !== undefined;
+  const fixedSampling = isFixedSamplingModel(modelId);
+  const dropSamplingParams = reasoningEnabled || fixedSampling;
 
   // OpenAI Chat Completions has no top_k surface (it's exposed only on the
   // Responses API for some reasoning models). Quietly accepting it would
@@ -2226,10 +2237,10 @@ function buildOpenAIChatRequest(
     });
   }
 
-  // Reasoning models (o1 / o3 / o4) reject sampling params outright. Emit
-  // warnings at build time so callers see *why* the value didn't apply
-  // rather than a 400 from the API.
-  if (reasoningEnabled) {
+  // Reasoning models (o1 / o3 / o4) and models with fixed sampling params
+  // (Kimi K2.5) reject sampling params outright. Emit warnings at build time
+  // so callers see *why* the value didn't apply rather than a 400 from the API.
+  if (dropSamplingParams) {
     const dropped: Array<[keyof typeof options, string]> = [
       ["temperature", "temperature"],
       ["topP", "top_p"],
@@ -2242,8 +2253,9 @@ function buildOpenAIChatRequest(
           type: "unsupported-setting",
           provider: "openai",
           setting: key,
-          details:
-            `Dropped because OpenAI reasoning models reject ${openaiName}. Reasoning was active for this request.`,
+          details: fixedSampling
+            ? `Dropped because this model uses fixed sampling parameters.`
+            : `Dropped because OpenAI reasoning models reject ${openaiName}. Reasoning was active for this request.`,
         });
       }
     }
@@ -2258,12 +2270,12 @@ function buildOpenAIChatRequest(
         ? { max_completion_tokens: options.maxOutputTokens }
         : { max_tokens: options.maxOutputTokens }
       : {}),
-    // OpenAI reasoning models reject temperature / top_p / frequency / presence.
-    // Drop them silently rather than letting the API bounce the request.
-    ...(!reasoningEnabled && options.temperature !== undefined
+    // Reasoning models and fixed-sampling models reject temperature / top_p /
+    // frequency / presence. Drop them rather than letting the API bounce.
+    ...(!dropSamplingParams && options.temperature !== undefined
       ? { temperature: options.temperature }
       : {}),
-    ...(!reasoningEnabled && options.topP !== undefined ? { top_p: options.topP } : {}),
+    ...(!dropSamplingParams && options.topP !== undefined ? { top_p: options.topP } : {}),
     ...(options.stopSequences && options.stopSequences.length > 0
       ? { stop: options.stopSequences }
       : {}),
@@ -2272,10 +2284,10 @@ function buildOpenAIChatRequest(
       : {}),
     ...(options.toolChoice !== undefined ? { tool_choice: options.toolChoice } : {}),
     ...(options.seed !== undefined ? { seed: options.seed } : {}),
-    ...(!reasoningEnabled && options.presencePenalty !== undefined
+    ...(!dropSamplingParams && options.presencePenalty !== undefined
       ? { presence_penalty: options.presencePenalty }
       : {}),
-    ...(!reasoningEnabled && options.frequencyPenalty !== undefined
+    ...(!dropSamplingParams && options.frequencyPenalty !== undefined
       ? { frequency_penalty: options.frequencyPenalty }
       : {}),
     ...(reasoningEffort !== undefined ? { reasoning_effort: reasoningEffort } : {}),

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -2317,7 +2317,18 @@ function buildOpenAIChatRequest(
       : {}),
   };
 
-  Object.assign(body, readProviderOptions(options.providerOptions, "openai", providerName));
+  const providerOpts = readProviderOptions(options.providerOptions, "openai", providerName);
+
+  // Normalize max_tokens → max_completion_tokens for native OpenAI models.
+  // Provider options can re-introduce max_tokens which newer models reject.
+  if (isNativeOpenAIModel(modelId) && "max_tokens" in providerOpts) {
+    if (!("max_completion_tokens" in providerOpts)) {
+      providerOpts.max_completion_tokens = providerOpts.max_tokens;
+    }
+    delete providerOpts.max_tokens;
+  }
+
+  Object.assign(body, providerOpts);
   return body;
 }
 

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -299,7 +299,7 @@ type OpenAICompatibleChatRequest = {
   stream_options?: {
     include_usage?: boolean;
   };
-  max_tokens?: number;
+  max_completion_tokens?: number;
   temperature?: number;
   top_p?: number;
   stop?: string[];
@@ -2242,7 +2242,7 @@ function buildOpenAIChatRequest(
     model: modelId,
     messages: toOpenAICompatibleMessages(options.prompt),
     ...(stream ? { stream: true, stream_options: { include_usage: true } } : {}),
-    ...(options.maxOutputTokens !== undefined ? { max_tokens: options.maxOutputTokens } : {}),
+    ...(options.maxOutputTokens !== undefined ? { max_completion_tokens: options.maxOutputTokens } : {}),
     // OpenAI reasoning models reject temperature / top_p / frequency / presence.
     // Drop them silently rather than letting the API bounce the request.
     ...(!reasoningEnabled && options.temperature !== undefined


### PR DESCRIPTION
## Summary
- OpenAI deprecated `max_tokens` in favor of `max_completion_tokens` for newer models (gpt-4o, gpt-5.2, etc.)
- Users selecting OpenAI models via veryfront-cloud hit `STREAM_ERROR: Unsupported parameter: 'max_tokens' is not supported with this model`
- Updated the Chat Completions request builder to send `max_completion_tokens` instead

## Evidence

From the [OpenAI Chat Completions API reference](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create):

> - **maxCompletionTokens** (Long) - Optional - An upper bound for the number of tokens that can be generated.
> - **maxTokens** (Long) - **Deprecated** - The maximum number of tokens that can be generated. Deprecated in favor of `max_completion_tokens`.

The exact error from production:
```
Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
```

## Test plan
- [x] All 142 runtime-loader test steps pass
- [ ] Verify OpenAI gpt-5.2 conversation streaming works on staging