### PR TITLE
fix: return 404 for unknown custom-domain token mint failures

### DIFF
--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -184,6 +184,46 @@ describe("Proxy Handler", () => {
       await handler.close();
     });
 
+    // Regression test for the ai-chatbot.veryfront.com incident (#1054): bare
+    // {slug}.veryfront.com is intentionally unsupported, so the handler treats it as a
+    // custom domain, the token mint returns "Project not found for domain", and the
+    // user previously saw a misleading 502. Must resolve to a clean 404.
+    it("returns 404 when custom domain token mint reports no project for domain", async () => {
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") {
+          return new Response('{"error":"Project not found for domain"}', {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+
+        const req = new Request("http://ai-chatbot.veryfront.com/robots.txt", {
+          headers: { host: "ai-chatbot.veryfront.com" },
+        });
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.projectSlug, undefined);
+        assertEquals(ctx.error?.status, 404);
+        assertEquals(
+          ctx.error?.message,
+          "No project configured for domain: ai-chatbot.veryfront.com",
+        );
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
     it("strips port from custom domain host before token fetch", async () => {
       const tokenRequests: string[] = [];
       const { server, port } = createMockServer((req: Request) => {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -215,6 +215,15 @@ function parseStatusFromError(error: unknown): number | null {
   return match ? Number(match[1]) : null;
 }
 
+// Brittle on purpose: we string-match the API's OAuth error body. Source of truth is
+// veryfront-api/src/api/http/rest/auth/routes.ts — `oauthError(c, 'Project not found
+// for domain', ...)`. If that string is renamed, this regex silently regresses to 502.
+// Durable fix is a typed error code from the token-mint helper; tracked separately.
+function isMissingCustomDomainProjectError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /project not found for domain/i.test(message);
+}
+
 async function extractUserIdFromToken(
   token: string,
   apiBaseUrl: string,
@@ -635,6 +644,13 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
       if (isCustomDomain && !projectSlug) {
         if (!token) {
+          if (isMissingCustomDomainProjectError(tokenFetchError)) {
+            logger?.info("Custom domain project not found during token fetch", {
+              domain: host,
+            });
+            return makeErrorContext(base, 404, `No project configured for domain: ${host}`);
+          }
+
           logger?.error("Cannot process custom domain without token", undefined, { domain: host });
           return makeErrorContext(base, 502, `Failed to authenticate for domain: ${host}`, token);
         }

--- a/src/server/utils/domain-parser.ts
+++ b/src/server/utils/domain-parser.ts
@@ -171,6 +171,10 @@ export function parseProjectDomain(host: string): ParsedDomain {
     return createParsedDomain(null, null, env, true, env === "preview");
   }
 
+  // Intentionally NOT supported: bare {slug}.veryfront.{com,org}. Projects must use the
+  // explicit {slug}.production.veryfront.com form. Do not re-add — this has been tried
+  // and reverted (PR #1055). It collides with infra subdomains (api/studio/docs/www)
+  // and erases the environment from the URL, which the product decision requires.
   return createParsedDomain(null, null, null, false, false);
 }
 


### PR DESCRIPTION
## Summary
- return 404 instead of 502 when custom-domain token minting reports `Project not found for domain`
- cover the regression with a proxy handler test
- preserve existing 502 behavior when there is truly no token source available

## Evidence
Production logs at 2026-04-15 21:52 UTC showed repeated errors like:
- `502 GET /wsa.php`
- `Cannot process custom domain without token`
- `OAuth token request failed: 400 - {"error":"Project not found for domain"}`

Those requests targeted `react.veryfront.com`, which is not configured to a project. That should be a clean 404, not a proxy auth failure.

## Validation
- `deno test --no-check --allow-all src/proxy/handler.test.ts src/proxy/token-priority.test.ts`
- `deno task test --headless` currently fails immediately on this toolchain because the underlying `deno test` task does not accept `--headless`; I also started `deno task test` to validate the wider suite, but stopped it after the relevant proxy regression coverage had passed.
