### PR TITLE
fix(security): restrict Tailwind plugin loader to allowlist (VULN-FS-1)

### DIFF
--- a/src/html/styles-builder/plugin-loader.test.ts
+++ b/src/html/styles-builder/plugin-loader.test.ts
@@ -1,7 +1,17 @@
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { VeryfrontError } from "#veryfront/errors";
 import { loadModuleFromEsmSh, loadPlugin } from "./plugin-loader.ts";
+import {
+  bareName,
+  PACKAGE_SPEC_RE,
+  TAILWIND_PLUGIN_ALLOWLIST,
+} from "./tailwind-plugin-allowlist.ts";
 
 describe("styles-builder/plugin-loader", () => {
   it("throws when esm.sh stub request fails", async () => {
@@ -11,7 +21,7 @@ describe("styles-builder/plugin-loader", () => {
 
     try {
       await assertRejects(
-        () => loadModuleFromEsmSh("missing-plugin@1.0.0"),
+        () => loadModuleFromEsmSh("@tailwindcss/typography@0.5.19"),
         Error,
         "Failed to fetch stub: 503",
       );
@@ -28,7 +38,7 @@ describe("styles-builder/plugin-loader", () => {
 
     try {
       await assertRejects(
-        () => loadModuleFromEsmSh("broken-package@1.0.0"),
+        () => loadModuleFromEsmSh("@tailwindcss/forms@0.5.11"),
         Error,
         "Could not find bundle path in esm.sh response",
       );
@@ -52,7 +62,7 @@ describe("styles-builder/plugin-loader", () => {
 
     try {
       await assertRejects(
-        () => loadModuleFromEsmSh("bad-package@1.0.0"),
+        () => loadModuleFromEsmSh("tailwindcss-animate@1.0.7"),
         Error,
         "Failed to fetch bundle: 500",
       );
@@ -76,7 +86,7 @@ describe("styles-builder/plugin-loader", () => {
 
     try {
       await assertRejects(
-        () => loadModuleFromEsmSh("html-package@1.0.0"),
+        () => loadModuleFromEsmSh("@tailwindcss/aspect-ratio@0.4.2"),
         Error,
         "returned HTML instead of JavaScript",
       );
@@ -97,7 +107,7 @@ describe("styles-builder/plugin-loader", () => {
       const pluginCache = new Map<string, unknown>();
       const pluginErrors = new Map<string, Error>();
       pluginErrors.set(
-        "cached-bad-plugin",
+        "@tailwindcss/typography",
         new VeryfrontError("cached plugin load failure", {
           slug: "network-error",
           category: "SERVER",
@@ -108,7 +118,7 @@ describe("styles-builder/plugin-loader", () => {
       );
 
       await assertRejects(
-        () => loadPlugin("cached-bad-plugin", pluginCache, pluginErrors),
+        () => loadPlugin("@tailwindcss/typography", pluginCache, pluginErrors),
         Error,
         "cached plugin load failure",
       );
@@ -125,7 +135,7 @@ describe("styles-builder/plugin-loader", () => {
 
     try {
       try {
-        await loadPlugin("broken-plugin@1.0.0", new Map(), new Map());
+        await loadPlugin("@tailwindcss/typography@0.5.19", new Map(), new Map());
         throw new Error("Expected loadPlugin to throw");
       } catch (error) {
         assertEquals(error instanceof VeryfrontError, true);
@@ -134,7 +144,7 @@ describe("styles-builder/plugin-loader", () => {
         assertEquals(error.slug, "network-error");
         assertEquals(error.status, 502);
         assertEquals(
-          error.message.includes('Failed to load plugin "broken-plugin@1.0.0"'),
+          error.message.includes('Failed to load plugin "@tailwindcss/typography@0.5.19"'),
           true,
         );
       }
@@ -162,8 +172,16 @@ describe("styles-builder/plugin-loader", () => {
       const pluginCache = new Map<string, unknown>();
       const pluginErrors = new Map<string, Error>();
 
-      const first = await loadPlugin("good-plugin@1.0.0", pluginCache, pluginErrors);
-      const second = await loadPlugin("good-plugin@1.0.0", pluginCache, pluginErrors);
+      const first = await loadPlugin(
+        "@tailwindcss/typography@0.5.19",
+        pluginCache,
+        pluginErrors,
+      );
+      const second = await loadPlugin(
+        "@tailwindcss/typography@0.5.19",
+        pluginCache,
+        pluginErrors,
+      );
 
       assertEquals(typeof first, "object");
       assertEquals(second === first, true);
@@ -172,4 +190,205 @@ describe("styles-builder/plugin-loader", () => {
       globalThis.fetch = originalFetch;
     }
   });
+});
+
+describe("styles-builder/plugin-loader allowlist enforcement (VULN-FS-1)", () => {
+  // All tests in this block must reject BEFORE any fetch happens. Install a
+  // fetch stub that fails the test if called.
+  function withFailFastFetch(run: () => Promise<void>): Promise<void> {
+    const originalFetch = globalThis.fetch;
+    let called = false;
+    globalThis.fetch = ((..._args: Parameters<typeof fetch>) => {
+      called = true;
+      return Promise.reject(new Error("fetch must not be called for rejected specs"));
+    }) as typeof fetch;
+    return run().finally(() => {
+      globalThis.fetch = originalFetch;
+      if (called) {
+        throw new Error(
+          "Allowlist enforcement leaked a fetch: rejection must happen before network I/O",
+        );
+      }
+    });
+  }
+
+  const rejectionCases: Array<[string, string]> = [
+    ["non-allowlisted package", "evil-package@1.0.0"],
+    ["path-traversal specifier", "../../etc/passwd"],
+    ["URL-like specifier", "https://evil.com/x"],
+    ["shell-injection specifier", "pkg;evil"],
+    ["NUL-byte specifier", "pkg\0"],
+    ["empty string", ""],
+    ["unicode homoglyph (fullwidth @)", "\uFF20tailwindcss/typography"],
+    ["allowlisted-name with extra suffix", "@tailwindcss/typography-evil"],
+    ["leading whitespace", " @tailwindcss/typography"],
+    ["trailing whitespace", "@tailwindcss/typography "],
+    ["uppercase variant of allowlisted scope", "@TAILWINDCSS/typography"],
+    ["parent-directory jump in bare name", "foo/../bar"],
+    ["absolute path", "/etc/passwd"],
+    ["backslash path", "evil\\pkg"],
+  ];
+
+  for (const [label, spec] of rejectionCases) {
+    it(`loadModuleFromEsmSh rejects ${label}`, () => {
+      return withFailFastFetch(async () => {
+        await assertRejects(
+          () => loadModuleFromEsmSh(spec),
+          Error,
+        );
+      });
+    });
+
+    it(`loadPlugin rejects ${label}`, () => {
+      return withFailFastFetch(async () => {
+        await assertRejects(
+          () => loadPlugin(spec, new Map(), new Map()),
+          Error,
+        );
+      });
+    });
+  }
+
+  it("loadModuleFromEsmSh error mentions invalid specifier or allowlist", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (() => {
+      throw new Error("must not fetch");
+    }) as typeof fetch;
+    try {
+      const err = await assertRejects(
+        () => loadModuleFromEsmSh("evil-package@1.0.0"),
+        Error,
+      );
+      const combined = err.message;
+      const mentionsAllowlist = combined.includes("allowlist") ||
+        combined.includes("Invalid Tailwind plugin specifier");
+      assert(
+        mentionsAllowlist,
+        `Expected error to mention allowlist or invalid specifier, got: ${combined}`,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("loadPlugin rejects an unknown package id (not on allowlist)", async () => {
+    await assertRejects(
+      () => loadPlugin("definitely-not-an-allowed-plugin", new Map(), new Map()),
+      Error,
+    );
+  });
+});
+
+describe("styles-builder/plugin-loader allowlist positive cases", () => {
+  // Verify each allowlisted package is accepted past the guard by letting the
+  // fetch fail downstream. The acceptance is proven by the *specific* error
+  // message: if the guard rejected, we would never see a fetch error.
+  for (const pkg of TAILWIND_PLUGIN_ALLOWLIST) {
+    it(`accepts ${pkg} bare name (passes allowlist guard)`, async () => {
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (() =>
+        Promise.resolve(
+          new Response("downstream failure", { status: 503 }),
+        )) as typeof fetch;
+      try {
+        const err = await assertRejects(
+          () => loadModuleFromEsmSh(pkg),
+          Error,
+        );
+        assertStringIncludes(err.message, "Failed to fetch stub: 503");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it(`accepts ${pkg}@1.2.3 versioned spec (passes allowlist guard)`, async () => {
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (() =>
+        Promise.resolve(
+          new Response("downstream failure", { status: 503 }),
+        )) as typeof fetch;
+      try {
+        const err = await assertRejects(
+          () => loadModuleFromEsmSh(`${pkg}@1.2.3`),
+          Error,
+        );
+        assertStringIncludes(err.message, "Failed to fetch stub: 503");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  }
+});
+
+describe("styles-builder/plugin-loader bareName", () => {
+  it("returns an unscoped name unchanged", () => {
+    assertEquals(bareName("pkg"), "pkg");
+  });
+
+  it("strips @version from an unscoped name", () => {
+    assertEquals(bareName("pkg@1"), "pkg");
+    assertEquals(bareName("pkg@1.2.3-rc.4"), "pkg");
+  });
+
+  it("returns a scoped name unchanged", () => {
+    assertEquals(bareName("@scope/pkg"), "@scope/pkg");
+  });
+
+  it("strips @version from a scoped name", () => {
+    assertEquals(bareName("@scope/pkg@1.0.0"), "@scope/pkg");
+    assertEquals(bareName("@tailwindcss/typography@0.5.19"), "@tailwindcss/typography");
+  });
+});
+
+describe("styles-builder/plugin-loader PACKAGE_SPEC_RE", () => {
+  const rejects = [
+    ["empty string", ""],
+    ["URL-like", "https://evil.com/x"],
+    ["path traversal", "../../etc/passwd"],
+    ["shell-injection", "pkg;evil"],
+    ["NUL byte", "pkg\0"],
+    ["fullwidth @ homoglyph", "\uFF20tailwindcss/typography"],
+    ["leading whitespace", " pkg"],
+    ["trailing whitespace", "pkg "],
+    ["internal whitespace", "pk g"],
+    ["absolute path", "/etc/passwd"],
+    ["backslash", "evil\\pkg"],
+    ["scope without name", "@scope/"],
+    ["name starting with dot", ".hidden"],
+    ["name starting with dash", "-pkg"],
+  ];
+
+  for (const [label, spec] of rejects) {
+    it(`rejects ${label}`, () => {
+      assertEquals(
+        PACKAGE_SPEC_RE.test(spec),
+        false,
+        `expected rejection for ${JSON.stringify(spec)}`,
+      );
+    });
+  }
+
+  const accepts = [
+    "pkg",
+    "pkg@1",
+    "pkg@1.2.3",
+    "pkg@1.2.3-rc.4",
+    "pkg@1.2.3+build.5",
+    "@scope/pkg",
+    "@scope/pkg@1.0.0",
+    "@tailwindcss/typography",
+    "@tailwindcss/typography@0.5.19",
+    "tailwindcss-animate",
+    "tailwindcss-animate@1.0.7",
+  ];
+
+  for (const spec of accepts) {
+    it(`accepts ${spec}`, () => {
+      assertEquals(
+        PACKAGE_SPEC_RE.test(spec),
+        true,
+        `expected acceptance for ${JSON.stringify(spec)}`,
+      );
+    });
+  }
 });

--- a/src/html/styles-builder/plugin-loader.test.ts
+++ b/src/html/styles-builder/plugin-loader.test.ts
@@ -258,7 +258,7 @@ describe("styles-builder/plugin-loader allowlist enforcement (VULN-FS-1)", () =>
       const err = await assertRejects(
         () => loadModuleFromEsmSh("evil-package@1.0.0"),
         Error,
-      );
+      ) as Error;
       const combined = err.message;
       const mentionsAllowlist = combined.includes("allowlist") ||
         combined.includes("Invalid Tailwind plugin specifier");
@@ -294,7 +294,7 @@ describe("styles-builder/plugin-loader allowlist positive cases", () => {
         const err = await assertRejects(
           () => loadModuleFromEsmSh(pkg),
           Error,
-        );
+        ) as Error;
         assertStringIncludes(err.message, "Failed to fetch stub: 503");
       } finally {
         globalThis.fetch = originalFetch;
@@ -311,7 +311,7 @@ describe("styles-builder/plugin-loader allowlist positive cases", () => {
         const err = await assertRejects(
           () => loadModuleFromEsmSh(`${pkg}@1.2.3`),
           Error,
-        );
+        ) as Error;
         assertStringIncludes(err.message, "Failed to fetch stub: 503");
       } finally {
         globalThis.fetch = originalFetch;
@@ -341,7 +341,7 @@ describe("styles-builder/plugin-loader bareName", () => {
 });
 
 describe("styles-builder/plugin-loader PACKAGE_SPEC_RE", () => {
-  const rejects = [
+  const rejects: Array<[string, string]> = [
     ["empty string", ""],
     ["URL-like", "https://evil.com/x"],
     ["path traversal", "../../etc/passwd"],

--- a/src/html/styles-builder/plugin-loader.ts
+++ b/src/html/styles-builder/plugin-loader.ts
@@ -19,8 +19,33 @@ import {
   VeryfrontError,
 } from "#veryfront/errors";
 import { getTailwindPluginBundleUrl } from "#veryfront/build/binary-plugin-includes.ts";
+import {
+  bareName,
+  PACKAGE_SPEC_RE,
+  TAILWIND_PLUGIN_ALLOWLIST,
+} from "./tailwind-plugin-allowlist.ts";
 
 const logger = serverLogger.component("tailwind");
+
+/**
+ * Enforce the Tailwind plugin allowlist (VULN-FS-1).
+ *
+ * Called at the top of every entry point that can load third-party plugin
+ * code. Rejects anything that is not a syntactically valid npm package
+ * specifier, and anything whose bare name is not on the allowlist.
+ */
+function assertPluginAllowed(spec: string): void {
+  if (!PACKAGE_SPEC_RE.test(spec)) {
+    throw new Error(`Invalid Tailwind plugin specifier: ${spec}`);
+  }
+  const name = bareName(spec);
+  if (!TAILWIND_PLUGIN_ALLOWLIST.has(name)) {
+    throw new Error(
+      `Package "${name}" is not on the Tailwind plugin allowlist. ` +
+        `See src/html/styles-builder/tailwind-plugin-allowlist.ts.`,
+    );
+  }
+}
 
 // Provide localStorage shim for plugins that use util-deprecate (which checks localStorage)
 // This prevents "LocalStorage is not supported in this context" errors in Deno.
@@ -107,6 +132,8 @@ async function importBundledModule(code: string): Promise<unknown> {
  * dynamic imports from URLs. Fetches bundled code, rewrites imports, loads via temp file.
  */
 export async function loadModuleFromEsmSh(packageName: string): Promise<unknown> {
+  assertPluginAllowed(packageName);
+
   const stubUrl = getTailwindPluginBundleUrl(packageName);
   logger.debug("Fetching esm.sh stub", { url: stubUrl });
 
@@ -177,6 +204,8 @@ export async function loadPlugin(
   if (pluginCache.has(id)) {
     return pluginCache.get(id);
   }
+
+  assertPluginAllowed(id);
 
   const { isDeno } = await import("#veryfront/platform/compat/runtime.ts");
 

--- a/src/html/styles-builder/plugin-loader.ts
+++ b/src/html/styles-builder/plugin-loader.ts
@@ -198,14 +198,17 @@ export async function loadPlugin(
   pluginCache: Map<string, unknown>,
   pluginErrors: Map<string, Error>,
 ): Promise<unknown> {
+  // Enforce the allowlist before consulting any caches so a disallowed id can
+  // never be served from a pre-seeded or stale cache entry — defence-in-depth
+  // against future changes that might pre-populate these maps.
+  assertPluginAllowed(id);
+
   const cachedError = pluginErrors.get(id);
   if (cachedError) throw cachedError;
 
   if (pluginCache.has(id)) {
     return pluginCache.get(id);
   }
-
-  assertPluginAllowed(id);
 
   const { isDeno } = await import("#veryfront/platform/compat/runtime.ts");
 

--- a/src/html/styles-builder/tailwind-compiler.test.ts
+++ b/src/html/styles-builder/tailwind-compiler.test.ts
@@ -379,43 +379,20 @@ describe("styles-builder/tailwind-compiler", () => {
       }
     });
 
-    it("should dynamically load a simple package without tailwindcss dependency", async () => {
+    it("should reject a non-allowlisted package before any network call (VULN-FS-1)", async () => {
       const originalFetch = globalThis.fetch;
       let fetchCallCount = 0;
-      globalThis.fetch = ((input: URL | Request | string) => {
-        const url = typeof input === "string"
-          ? input
-          : input instanceof URL
-          ? input.toString()
-          : input.url;
-
+      globalThis.fetch = (() => {
         fetchCallCount++;
-        if (fetchCallCount === 1) {
-          assertEquals(url.includes("is-odd@3.0.1?bundle"), true);
-          return Promise.resolve(
-            new Response(`export * from "/v1/is-odd.bundle.mjs";`, { status: 200 }),
-          );
-        }
-
-        assertEquals(url.includes("/v1/is-odd.bundle.mjs"), true);
-        return Promise.resolve(
-          new Response(`export default (n) => n % 2 === 1;`, { status: 200 }),
-        );
+        return Promise.reject(new Error("fetch must not be called"));
       }) as typeof fetch;
 
       try {
-        const mod = await loadModuleFromEsmSh("is-odd@3.0.1");
-
-        assertEquals(typeof mod, "object");
-        assertEquals(mod !== null, true);
-        const modObj = mod as { default?: unknown };
-        assertEquals("default" in modObj, true);
-
-        const isOdd = modObj.default as (n: number) => boolean;
-        assertEquals(typeof isOdd, "function");
-        assertEquals(isOdd(3), true);
-        assertEquals(isOdd(4), false);
-        assertEquals(fetchCallCount, 2);
+        await assertRejects(
+          () => loadModuleFromEsmSh("is-odd@3.0.1"),
+          Error,
+        );
+        assertEquals(fetchCallCount, 0);
       } finally {
         globalThis.fetch = originalFetch;
       }

--- a/src/html/styles-builder/tailwind-plugin-allowlist.test.ts
+++ b/src/html/styles-builder/tailwind-plugin-allowlist.test.ts
@@ -1,0 +1,21 @@
+import { assert } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { BINARY_TAILWIND_PLUGIN_PACKAGES } from "#veryfront/build/binary-plugin-includes.ts";
+import { bareName, TAILWIND_PLUGIN_ALLOWLIST } from "./tailwind-plugin-allowlist.ts";
+
+describe("styles-builder/tailwind-plugin-allowlist drift", () => {
+  it("every bundled binary plugin is on the allowlist", () => {
+    const missing: string[] = [];
+    for (const spec of BINARY_TAILWIND_PLUGIN_PACKAGES) {
+      const name = bareName(spec);
+      if (!TAILWIND_PLUGIN_ALLOWLIST.has(name)) missing.push(name);
+    }
+    assert(
+      missing.length === 0,
+      `BINARY_TAILWIND_PLUGIN_PACKAGES includes package(s) not on the ` +
+        `Tailwind plugin allowlist: ${missing.join(", ")}. Bundling a plugin ` +
+        `without allowlisting it makes it unloadable at runtime. Add the ` +
+        `missing name(s) to TAILWIND_PLUGIN_ALLOWLIST after review.`,
+    );
+  });
+});

--- a/src/html/styles-builder/tailwind-plugin-allowlist.ts
+++ b/src/html/styles-builder/tailwind-plugin-allowlist.ts
@@ -11,11 +11,18 @@
  */
 
 export const TAILWIND_PLUGIN_ALLOWLIST: ReadonlySet<string> = new Set([
+  // Bundled into the compiled binary (see src/build/binary-plugin-includes.ts).
+  // Must stay in sync with BINARY_TAILWIND_PLUGIN_PACKAGES — an invariant
+  // enforced by tailwind-plugin-allowlist.test.ts.
   "@tailwindcss/typography",
   "@tailwindcss/forms",
+  "tailwindcss-animate",
+  "tailwind-scrollbar-hide",
+  "daisyui",
+  // Allowlisted but NOT bundled: loaded from esm.sh on first use. Adding an
+  // entry here is arbitrary-code-exec surface; review each one explicitly.
   "@tailwindcss/aspect-ratio",
   "@tailwindcss/container-queries",
-  "tailwindcss-animate",
 ]);
 
 /**

--- a/src/html/styles-builder/tailwind-plugin-allowlist.ts
+++ b/src/html/styles-builder/tailwind-plugin-allowlist.ts
@@ -1,0 +1,44 @@
+/**
+ * Allowlist of Tailwind CSS plugin package names that may be dynamically loaded
+ * via `loadPlugin` / `loadModuleFromEsmSh`.
+ *
+ * Tailwind v4 stylesheets can request plugins through the `@plugin "..."`
+ * directive. Without restriction, this turns arbitrary project CSS into a
+ * remote-code-execution vector because the loader fetches and imports code
+ * from https://esm.sh. Only the packages listed here may be loaded.
+ *
+ * @module html/styles-builder/tailwind-plugin-allowlist
+ */
+
+export const TAILWIND_PLUGIN_ALLOWLIST: ReadonlySet<string> = new Set([
+  "@tailwindcss/typography",
+  "@tailwindcss/forms",
+  "@tailwindcss/aspect-ratio",
+  "@tailwindcss/container-queries",
+  "tailwindcss-animate",
+]);
+
+/**
+ * Matches npm package specifiers, optionally scoped and optionally suffixed
+ * with an `@version` range. Deliberately restrictive: ASCII only, no path
+ * separators, no whitespace, no control characters.
+ */
+export const PACKAGE_SPEC_RE = /^(?:@[a-z0-9][\w.-]*\/)?[a-z0-9][\w.-]*(?:@[\w.+-]+)?$/i;
+
+/**
+ * Return the bare package name (without any `@version` suffix) for a spec.
+ *
+ * Examples:
+ *   bareName("pkg")            -> "pkg"
+ *   bareName("pkg@1.0.0")      -> "pkg"
+ *   bareName("@scope/pkg")     -> "@scope/pkg"
+ *   bareName("@scope/pkg@1.0") -> "@scope/pkg"
+ */
+export function bareName(spec: string): string {
+  if (spec.startsWith("@")) {
+    const idx = spec.indexOf("@", 1);
+    return idx === -1 ? spec : spec.slice(0, idx);
+  }
+  const idx = spec.indexOf("@");
+  return idx === -1 ? spec : spec.slice(0, idx);
+}


### PR DESCRIPTION
## Summary

PR 1 of `plans/security-audit-17.4.2026.md`. **CRITICAL hotfix.**

Fixes **VULN-FS-1** — arbitrary npm package fetched from esm.sh and dynamically imported inside the main server process via `@plugin "..."` in project CSS, yielding RCE on the host.

## Fix

- Adds `src/html/styles-builder/tailwind-plugin-allowlist.ts` with strict package-spec regex and `TAILWIND_PLUGIN_ALLOWLIST`.
- Calls `assertPluginAllowed()` at the top of `loadModuleFromEsmSh` and `loadPlugin` before any cache lookup or network call.
- Adds rejection tests for unknown packages and malformed specifiers.

## Test plan

- [x] `deno test src/html/styles-builder/`
- [x] Confirm project using only allowlisted plugins still builds
- [x] Confirm unlisted `@plugin "evil"` produces a clear error (not RCE)