### PR TITLE
fix(security): stop honoring x-environment header to gate dev surface (VULN-SRV-1/2)

### DIFF
--- a/cli/shared/server-startup.ts
+++ b/cli/shared/server-startup.ts
@@ -99,13 +99,14 @@ export async function startCliProductionServer(
     signal: options.signal,
     defaultProjectSlug: options.defaultProjectSlug,
     defaultProjectId: options.defaultProjectId,
-    // Register the cwd project as a local project so filesystem-backed dev
-    // surfaces (error overlay, RSC `fs` client-module strategy, `/_veryfront/fs/`
-    // module loader) continue to work for single-project standalone deployments
-    // like `vf serve` and the compiled binary. This is a server-trusted mapping
-    // — it comes from CLI startup options, not request headers — so it is a
-    // legitimate source of `isLocalProject: true` under VULN-SRV-1/2.
-    localProjects: { [options.defaultProjectSlug]: options.projectDir },
+    // Do NOT register a `localProjects` mapping here. `vf serve` and the
+    // compiled binary are production deployments, and `isLocalProject: true`
+    // flips `isDev` on in security headers (suppressing CSP) and in the SSR
+    // error overlay (exposing absolute paths and stack traces) — the exact
+    // dev-surface leak VULN-SRV-1 / VULN-SRV-2 was closing. The strategy
+    // narrowing in `client-module-strategy.ts` already routes hydration
+    // through `/_veryfront/rsc/module?` for non-local deployments, so no
+    // `localProjects` entry is required for the compiled binary to work.
   };
   return await startProductionServer(serverOptions);
 }

--- a/cli/shared/server-startup.ts
+++ b/cli/shared/server-startup.ts
@@ -99,6 +99,13 @@ export async function startCliProductionServer(
     signal: options.signal,
     defaultProjectSlug: options.defaultProjectSlug,
     defaultProjectId: options.defaultProjectId,
+    // Register the cwd project as a local project so filesystem-backed dev
+    // surfaces (error overlay, RSC `fs` client-module strategy, `/_veryfront/fs/`
+    // module loader) continue to work for single-project standalone deployments
+    // like `vf serve` and the compiled binary. This is a server-trusted mapping
+    // — it comes from CLI startup options, not request headers — so it is a
+    // legitimate source of `isLocalProject: true` under VULN-SRV-1/2.
+    localProjects: { [options.defaultProjectSlug]: options.projectDir },
   };
   return await startProductionServer(serverOptions);
 }

--- a/src/html/hydration-script-builder/hydration-data-generator.test.ts
+++ b/src/html/hydration-script-builder/hydration-data-generator.test.ts
@@ -128,15 +128,32 @@ describe("hydration-data-generator", () => {
       assertEquals(parsed.pageType, "tsx");
     });
 
-    it("should choose fs client modules for preview pages", () => {
+    it("should choose fs client modules for local projects", () => {
       const options: HTMLGenerationOptions = {
         ...baseOptions,
-        environment: "preview",
+        isLocalProject: true,
       };
       const parsed = parseHydrationData("page", {}, {}, options) as {
         clientModuleStrategy?: unknown;
       };
       assertEquals(parsed.clientModuleStrategy, "fs");
+    });
+
+    it("should choose rsc module client loading for remote preview pages", () => {
+      // Preview pods (accessed via trusted proxy with environment=preview) do
+      // not expose the dev-only `/_veryfront/fs/` handler — that surface is
+      // gated on `isLocalProject` under VULN-SRV-1/2. Preview clients load
+      // compiled modules via the RSC module endpoint, the same as production.
+      const options: HTMLGenerationOptions = {
+        ...baseOptions,
+        mode: "production",
+        environment: "preview",
+        isLocalProject: false,
+      };
+      const parsed = parseHydrationData("page", {}, {}, options) as {
+        clientModuleStrategy?: unknown;
+      };
+      assertEquals(parsed.clientModuleStrategy, "rsc-module");
     });
 
     it("should choose rsc module client loading for remote production pages", () => {

--- a/src/rendering/rsc/client-module-strategy.test.ts
+++ b/src/rendering/rsc/client-module-strategy.test.ts
@@ -8,13 +8,25 @@ import {
 } from "./client-module-strategy.ts";
 
 describe("rendering/rsc/client-module-strategy", () => {
-  it("uses the fs strategy for local or preview environments", () => {
+  it("uses the fs strategy only for local projects", () => {
+    // Only the server-trusted `isLocalProject` signal unlocks the dev-only
+    // `/_veryfront/fs/` handler. Preview mode (which can be reached via
+    // trusted proxy headers) no longer implies dev-file availability — the
+    // fs handler was narrowed to local projects under VULN-SRV-1/2.
     assertEquals(determineClientModuleStrategy({ isLocalProject: true }), "fs");
-    assertEquals(determineClientModuleStrategy({ environment: "preview" }), "fs");
+    assertEquals(
+      determineClientModuleStrategy({ isLocalProject: true, environment: "production" }),
+      "fs",
+    );
   });
 
-  it("uses the rsc module strategy for remote production environments", () => {
+  it("uses the rsc module strategy for remote environments", () => {
     assertEquals(determineClientModuleStrategy({ environment: "production" }), "rsc-module");
+    assertEquals(determineClientModuleStrategy({ environment: "preview" }), "rsc-module");
+    assertEquals(
+      determineClientModuleStrategy({ isLocalProject: false, environment: "preview" }),
+      "rsc-module",
+    );
   });
 
   it("resolves strategy from hydration data without probing endpoints", () => {

--- a/src/rendering/rsc/client-module-strategy.ts
+++ b/src/rendering/rsc/client-module-strategy.ts
@@ -33,7 +33,15 @@ export interface ClientModuleUrlOptions {
 export function determineClientModuleStrategy(
   options: ClientModuleStrategyOptions,
 ): ClientModuleStrategy {
-  return options.isLocalProject || options.environment === "preview" ? "fs" : "rsc-module";
+  // Only emit the `fs` strategy when the server is backed by a real on-disk
+  // project (server-trusted `isLocalProject` signal). The `/_veryfront/fs/`
+  // handler that serves those modules was narrowed to local projects only
+  // under VULN-SRV-1/2: honoring a client-reachable `environment === "preview"`
+  // here would advertise a dev-only endpoint that returns 404 in preview pods
+  // and — more importantly — mixes the preview-mode signal (environment) with
+  // the local-filesystem signal (isLocalProject). Preview pods serve the same
+  // compiled client modules as production, via the RSC module endpoint.
+  return options.isLocalProject ? "fs" : "rsc-module";
 }
 
 export function readHydrationData(

--- a/src/server/context/request-context.test.ts
+++ b/src/server/context/request-context.test.ts
@@ -51,13 +51,13 @@ describe("createRequestContext", () => {
       assertEquals(ctx.mode, "preview");
     });
 
-    it("returns preview mode when x-environment header is preview", () => {
+    it("does NOT honor x-environment: preview header on a production host (VULN-SRV-1/2)", () => {
       const req = makeRequest("https://127.0.0.1/page", {
         host: "example.com",
         "x-environment": "preview",
       });
       const ctx = createRequestContext(req);
-      assertEquals(ctx.mode, "preview");
+      assertEquals(ctx.mode, "production");
     });
 
     it("returns preview mode via .preview. in veryfront.org domain", () => {
@@ -75,6 +75,87 @@ describe("createRequestContext", () => {
       });
       const ctx = createRequestContext(req);
       assertEquals(ctx.mode, "production");
+    });
+
+    it("ignores unknown x-environment header values on a production host", () => {
+      const req = makeRequest("https://127.0.0.1/page", {
+        host: "example.com",
+        "x-environment": "staging",
+      });
+      const ctx = createRequestContext(req);
+      assertEquals(ctx.mode, "production");
+    });
+
+    it("ignores empty x-environment header values on a production host", () => {
+      const req = makeRequest("https://127.0.0.1/page", {
+        host: "example.com",
+        "x-environment": "",
+      });
+      const ctx = createRequestContext(req);
+      assertEquals(ctx.mode, "production");
+    });
+
+    it("does NOT flip mode on upper-case x-environment: PREVIEW", () => {
+      const req = makeRequest("https://127.0.0.1/page", {
+        host: "example.com",
+        "x-environment": "PREVIEW",
+      });
+      const ctx = createRequestContext(req);
+      assertEquals(ctx.mode, "production");
+    });
+
+    it("does NOT flip mode on mixed-case x-environment: Preview", () => {
+      const req = makeRequest("https://127.0.0.1/page", {
+        host: "example.com",
+        "x-environment": "Preview",
+      });
+      const ctx = createRequestContext(req);
+      assertEquals(ctx.mode, "production");
+    });
+
+    it("does NOT flip mode on URL-encoded x-environment header (documents Request behavior)", () => {
+      // Deno's Request does not auto-decode header values; we never decode either.
+      const req = makeRequest("https://127.0.0.1/page", {
+        host: "example.com",
+        "x-environment": "%70review",
+      });
+      const ctx = createRequestContext(req);
+      assertEquals(ctx.mode, "production");
+    });
+
+    it("hostname wins: .preview. host + x-environment: production still yields preview", () => {
+      const req = makeRequest("https://127.0.0.1/page", {
+        host: "my-app.preview.veryfront.com",
+        "x-environment": "production",
+      });
+      const ctx = createRequestContext(req);
+      assertEquals(ctx.mode, "preview");
+    });
+
+    it("hostname wins: .preview. host + x-environment: preview stays preview", () => {
+      const req = makeRequest("https://127.0.0.1/page", {
+        host: "my-app.preview.veryfront.com",
+        "x-environment": "preview",
+      });
+      const ctx = createRequestContext(req);
+      assertEquals(ctx.mode, "preview");
+    });
+
+    it("IPv4 host without .preview. stays production even with x-environment: preview", () => {
+      const req = makeRequest("https://127.0.0.1/page", {
+        host: "127.0.0.1",
+        "x-environment": "preview",
+      });
+      const ctx = createRequestContext(req);
+      assertEquals(ctx.mode, "production");
+    });
+
+    it("custom domain containing '.preview.' substring is treated as preview (host-derived)", () => {
+      const req = makeRequest("https://127.0.0.1/page", {
+        host: ".preview.example.local",
+      });
+      const ctx = createRequestContext(req);
+      assertEquals(ctx.mode, "preview");
     });
   });
 

--- a/src/server/context/request-context.ts
+++ b/src/server/context/request-context.ts
@@ -14,13 +14,16 @@ export function createRequestContext(req: Request): RequestContext {
   const parsed = parseProjectDomain(effectiveHost);
   const headerProjectSlug = req.headers.get("x-project-slug")?.trim() || undefined;
 
-  const xEnvironment = req.headers.get("x-environment");
-
-  const mode: "preview" | "production" = parsed.environment === "preview" ||
-      effectiveHost.includes(".preview.") ||
-      xEnvironment === "preview"
-    ? "preview"
-    : "production";
+  // Mode derives from server-trusted signals only. The `x-environment` header
+  // is client-controlled and must NOT be able to flip a production request
+  // into preview mode (VULN-SRV-1 / VULN-SRV-2). Preview is determined by the
+  // HTTP Host / X-Forwarded-Host — those are terminated at the edge proxy and
+  // are the same signal used for routing, so they're the correct source of
+  // truth.
+  const mode: "preview" | "production" =
+    parsed.environment === "preview" || effectiveHost.includes(".preview.")
+      ? "preview"
+      : "production";
 
   return {
     // Framework-owned token: bypass project env overlay so proxy mode works

--- a/src/server/handlers/dev/files/dev-file.handler.test.ts
+++ b/src/server/handlers/dev/files/dev-file.handler.test.ts
@@ -162,6 +162,5 @@ describe(
 
       assertEquals(result.continue, true);
     });
-
   },
 );

--- a/src/server/handlers/dev/files/dev-file.handler.test.ts
+++ b/src/server/handlers/dev/files/dev-file.handler.test.ts
@@ -21,63 +21,6 @@ function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
   } as HandlerContext;
 }
 
-function createProxyPreviewAdapter() {
-  const base = createMockAdapter();
-  const calls: string[] = [];
-  let inContext = false;
-
-  const fs = {
-    ...base.fs,
-    stat: async (path: string) => {
-      calls.push(`stat:${path}`);
-      if (!inContext) throw new Error("missing proxy context");
-      return await base.fs.stat(path);
-    },
-    readFile: async (path: string) => {
-      calls.push(`readFile:${path}`);
-      if (!inContext) throw new Error("missing proxy context");
-      return await base.fs.readFile(path);
-    },
-    isVeryfrontAdapter: () => true,
-    getUnderlyingAdapter: () => ({}),
-    getAdapterType: () => "VeryfrontFSAdapter",
-    isMultiProjectMode: () => true,
-    isContextualMode: () => true,
-    runWithContext: async (
-      _slug: string,
-      _token: string,
-      fn: () => Promise<unknown>,
-      _projectId?: string,
-      _options?: Record<string, unknown>,
-    ) => {
-      calls.push("runWithContext");
-      inContext = true;
-      try {
-        return await fn();
-      } finally {
-        inContext = false;
-      }
-    },
-    setRequestToken: (_token: string) => {
-      calls.push("setRequestToken");
-    },
-    setRequestBranch: (_branch: string | null) => {
-      calls.push("setRequestBranch");
-    },
-    setProductionMode: (_enabled: boolean, _releaseId?: string | null) => {
-      calls.push("setProductionMode");
-    },
-  };
-
-  return {
-    adapter: {
-      ...base,
-      fs,
-    },
-    calls,
-  };
-}
-
 describe(
   "server/handlers/dev/files/dev-file.handler",
   {
@@ -90,21 +33,20 @@ describe(
       esbuild.stop();
     });
 
-    it("serves preview file modules for remote preview mode", async () => {
+    it("serves file modules for local projects", async () => {
       const handler = new DevFileHandler();
       const adapter = createMockAdapter();
       const modulePath = "/project/app/page.tsx";
       adapter.fs.files.set(
         modulePath,
-        "export default function Page() { return 'preview'; }",
+        "export default function Page() { return 'local'; }",
       );
 
       const encodedPath = base64urlEncode("app/page.tsx");
       const req = new Request(`http://localhost/_veryfront/fs/${encodedPath}.js`);
       const ctx = makeCtx({
         adapter,
-        isLocalProject: false,
-        requestContext: { mode: "preview" } as HandlerContext["requestContext"],
+        isLocalProject: true,
       });
 
       const result = await handler.handle(req, ctx);
@@ -112,42 +54,10 @@ describe(
       assertEquals(result.continue, false);
       assertEquals(result.response?.status, 200);
       const body = await result.response!.text();
-      assertEquals(body.includes("preview"), true);
+      assertEquals(body.includes("local"), true);
     });
 
-    it("uses proxy fs context for remote preview modules", async () => {
-      const handler = new DevFileHandler();
-      const { adapter, calls } = createProxyPreviewAdapter();
-      const modulePath = "/project/app/page.tsx";
-      adapter.fs.files.set(
-        modulePath,
-        "export default function Page() { return 'preview-proxy'; }",
-      );
-
-      const encodedPath = base64urlEncode("app/page.tsx");
-      const req = new Request(`http://localhost/_veryfront/fs/${encodedPath}.js`);
-      const ctx = makeCtx({
-        adapter: adapter as HandlerContext["adapter"],
-        isLocalProject: false,
-        projectSlug: "test-project",
-        projectId: "proj-123",
-        proxyToken: "test-token",
-        releaseId: "rel-1",
-        environmentName: "staging",
-        parsedDomain: { branch: "feature-x" } as HandlerContext["parsedDomain"],
-        requestContext: { mode: "preview" } as HandlerContext["requestContext"],
-      });
-
-      const result = await handler.handle(req, ctx);
-
-      assertEquals(result.continue, false);
-      assertEquals(result.response?.status, 200);
-      assertEquals(calls.includes("runWithContext"), true);
-      const body = await result.response!.text();
-      assertEquals(body.includes("preview-proxy"), true);
-    });
-
-    it("keeps browser import-map exact specifiers in preview bundles", async () => {
+    it("keeps browser import-map exact specifiers in local bundles", async () => {
       const handler = new DevFileHandler();
       const adapter = createMockAdapter();
       const modulePath = "/project/app/page.tsx";
@@ -157,7 +67,7 @@ describe(
           '"use client";',
           'import { Chat } from "veryfront/chat";',
           "export default function Page() {",
-          '  return Chat ? "preview-chat" : "missing";',
+          '  return Chat ? "local-chat" : "missing";',
           "}",
         ].join("\n"),
       );
@@ -166,8 +76,7 @@ describe(
       const req = new Request(`http://localhost/_veryfront/fs/${encodedPath}.js`);
       const ctx = makeCtx({
         adapter,
-        isLocalProject: false,
-        requestContext: { mode: "preview" } as HandlerContext["requestContext"],
+        isLocalProject: true,
       });
 
       const result = await handler.handle(req, ctx);
@@ -180,7 +89,7 @@ describe(
       assertEquals(specifiers.some((specifier) => specifier.includes("esm.sh")), false);
     });
 
-    it("keeps browser import-map prefix specifiers in preview bundles", async () => {
+    it("keeps browser import-map prefix specifiers in local bundles", async () => {
       const handler = new DevFileHandler();
       const adapter = createMockAdapter();
       const modulePath = "/project/app/page.tsx";
@@ -199,8 +108,7 @@ describe(
       const req = new Request(`http://localhost/_veryfront/fs/${encodedPath}.js`);
       const ctx = makeCtx({
         adapter,
-        isLocalProject: false,
-        requestContext: { mode: "preview" } as HandlerContext["requestContext"],
+        isLocalProject: true,
       });
 
       const result = await handler.handle(req, ctx);
@@ -211,6 +119,34 @@ describe(
       const specifiers = getImportSpecifiers(body);
       assertEquals(specifiers.includes("@/components/Button"), true);
       assertEquals(specifiers.some((specifier) => specifier.includes("esm.sh")), false);
+    });
+
+    it("does NOT serve when only preview mode is set (VULN-SRV-1/2)", async () => {
+      // Remote preview (isLocalProject=false) must never expose project source
+      // via /_veryfront/fs/, even if requestContext.mode is somehow "preview".
+      const handler = new DevFileHandler();
+      const adapter = createMockAdapter();
+      const modulePath = "/project/app/page.tsx";
+      adapter.fs.files.set(
+        modulePath,
+        "export default function Page() { return 'leak'; }",
+      );
+
+      const encodedPath = base64urlEncode("app/page.tsx");
+      const req = new Request(`http://localhost/_veryfront/fs/${encodedPath}.js`);
+      const ctx = makeCtx({
+        adapter,
+        isLocalProject: false,
+        requestContext: { mode: "preview" } as HandlerContext["requestContext"],
+      });
+
+      // Enabled gate must be false in preview-only (non-local) context.
+      const enabled = handler.metadata.enabled?.(ctx) ?? true;
+      assertEquals(enabled, false);
+
+      // Even if called directly, handler must continue (not serve).
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, true);
     });
 
     it("continues for non-local production requests", async () => {
@@ -226,5 +162,6 @@ describe(
 
       assertEquals(result.continue, true);
     });
+
   },
 );

--- a/src/server/handlers/dev/files/dev-file.handler.ts
+++ b/src/server/handlers/dev/files/dev-file.handler.ts
@@ -13,21 +13,21 @@ import {
   PRIORITY_MEDIUM_DEV_FILES,
 } from "#veryfront/utils/constants/index.ts";
 import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
-import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 export class DevFileHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "DevFileHandler",
     priority: PRIORITY_MEDIUM_DEV_FILES as HandlerPriority,
     patterns: [{ pattern: "/_veryfront/fs/", prefix: true, method: "GET" }],
-    enabled: (ctx) => !!ctx.isLocalProject || ctx.requestContext?.mode === "preview",
+    // Strictly local-only: exposes project source tree (VULN-SRV-1 / VULN-SRV-2).
+    // Preview mode (even host-derived) must not unlock this surface.
+    enabled: (ctx) => !!ctx.isLocalProject,
   };
 
   async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
     const { pathname } = new URL(req.url);
 
-    const isPreviewMode = ctx.requestContext?.mode === "preview";
-    if (!ctx.isLocalProject && !isPreviewMode) return this.continue();
+    if (!ctx.isLocalProject) return this.continue();
 
     if (req.method !== "GET" || !pathname.startsWith("/_veryfront/fs/")) {
       return this.continue();
@@ -35,24 +35,6 @@ export class DevFileHandler extends BaseHandler {
 
     const fsAdapter = ctx.adapter.fs;
     const isExtended = isExtendedFSAdapter(fsAdapter);
-
-    if (!ctx.isLocalProject && ctx.projectSlug && isExtended && fsAdapter.isMultiProjectMode()) {
-      const effectiveToken = ctx.proxyToken || getHostEnv("VERYFRONT_API_TOKEN") || "";
-      const branch = ctx.parsedDomain?.branch ?? null;
-
-      return await fsAdapter.runWithContext(
-        ctx.projectSlug,
-        effectiveToken,
-        () => this.handleWithContext(req, pathname, ctx),
-        ctx.projectId,
-        {
-          productionMode: false,
-          releaseId: ctx.releaseId,
-          branch,
-          environmentName: ctx.environmentName,
-        },
-      );
-    }
 
     if (isExtended && fsAdapter.isContextualMode()) {
       try {

--- a/src/server/handlers/preview/markdown-preview.handler.test.ts
+++ b/src/server/handlers/preview/markdown-preview.handler.test.ts
@@ -1,0 +1,46 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { MarkdownPreviewHandler } from "./markdown-preview.handler.ts";
+import type { HandlerContext } from "../types.ts";
+
+function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    projectDir: "/project",
+    ...overrides,
+  } as HandlerContext;
+}
+
+describe("MarkdownPreviewHandler.metadata.enabled", () => {
+  it("is enabled for a local project", () => {
+    const handler = new MarkdownPreviewHandler();
+    const ctx = makeCtx({ isLocalProject: true });
+    assertEquals(handler.metadata.enabled?.(ctx), true);
+  });
+
+  it("is enabled for host-derived preview (mode: preview)", () => {
+    // After VULN-SRV-1/2 fix, requestContext.mode === 'preview' only happens
+    // when the Host / X-Forwarded-Host is server-trusted preview. The
+    // x-environment client header is ignored — see request-context.test.ts.
+    const handler = new MarkdownPreviewHandler();
+    const ctx = makeCtx({
+      isLocalProject: false,
+      requestContext: { mode: "preview" } as HandlerContext["requestContext"],
+    });
+    assertEquals(handler.metadata.enabled?.(ctx), true);
+  });
+
+  it("is NOT enabled for a non-local production request", () => {
+    const handler = new MarkdownPreviewHandler();
+    const ctx = makeCtx({
+      isLocalProject: false,
+      requestContext: { mode: "production" } as HandlerContext["requestContext"],
+    });
+    assertEquals(handler.metadata.enabled?.(ctx), false);
+  });
+
+  it("is NOT enabled when no request context and not a local project", () => {
+    const handler = new MarkdownPreviewHandler();
+    const ctx = makeCtx({ isLocalProject: false });
+    assertEquals(handler.metadata.enabled?.(ctx), false);
+  });
+});

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -250,7 +250,10 @@ export class SSRService implements SSRServiceLike {
     nonce?: string,
   ): SSRRenderResult {
     const errorObj = error instanceof Error ? error : new Error(String(error));
-    const isDev = ctx.isLocalProject || ctx.requestContext?.mode === "preview";
+    // Dev-only overlay (full stack, absolute paths, line numbers) must never
+    // be exposed outside a local project — including remote preview, which is
+    // internet-reachable. See VULN-SRV-1 / VULN-SRV-2.
+    const isDev = Boolean(ctx.isLocalProject);
 
     if (error instanceof VeryfrontError && error.slug === "file-not-found") {
       logger.debug("Page not found", { slug, error: errorObj.message });

--- a/tests/e2e/regressions/rsc-proxy-hydration.test.ts
+++ b/tests/e2e/regressions/rsc-proxy-hydration.test.ts
@@ -292,13 +292,33 @@ describe(
             LOCAL_RSC_CONFIG_SOURCE,
           );
 
-          const server = await context.createProductionServer({ hostname: "127.0.0.1" });
+          // Explicitly register the test project as local so the `fs`
+          // client-module strategy and the `/_veryfront/fs/` module loader
+          // are unlocked. Post-VULN-SRV-1/2 these strictly gate on
+          // `isLocalProject`, and the test context writes its sources
+          // outside of the `standardProjectDirs` (`data/projects/`,
+          // `projects/`) discovery roots.
+          const port = await context.allocatePort();
+          const controller = new AbortController();
+          const server = await startProductionServer({
+            projectDir: context.projectDir,
+            port,
+            bindAddress: "127.0.0.1",
+            signal: controller.signal,
+            defaultProjectSlug: context.projectId,
+            defaultProjectId: context.projectId,
+            localProjects: { [context.projectId]: context.projectDir },
+          });
+          context.trackResource(server);
+          await server.ready;
+          await waitForReady(port);
+
           const browserContext = await browser.newContext();
           const page = await browserContext.newPage();
           const diagnostics = captureBrowserDiagnostics(page);
 
           try {
-            const response = await page.goto(`http://127.0.0.1:${server.port}/`);
+            const response = await page.goto(`http://127.0.0.1:${port}/`);
             assertEquals(response?.status(), 200);
 
             await assertCounterHydration(page, {
@@ -368,9 +388,14 @@ describe(
             context,
             getProxyHeaders("preview"),
             async (page, diagnostics) => {
+              // Preview pods hydrate via the RSC module endpoint, same as
+              // production. The `fs` strategy + `/_veryfront/fs/` module
+              // loader are dev-only surfaces gated on `isLocalProject` under
+              // VULN-SRV-1/2 — a trusted `x-environment: preview` header
+              // cannot unlock them because they serve raw project source.
               await assertCounterHydration(page, {
-                expectedStrategy: "fs",
-                expectedModulePath: "/_veryfront/fs/",
+                expectedStrategy: "rsc-module",
+                expectedModulePath: "/_veryfront/rsc/module?",
               });
 
               const hydrationErrors = findHydrationOrCspFailures(

--- a/tests/integration/compiled-binary-e2e.test.ts
+++ b/tests/integration/compiled-binary-e2e.test.ts
@@ -1940,9 +1940,9 @@ export default function ClientPage() {
     await withServer(projectDir, async (server) => {
       await withBrowserPageAgainstServer(server, async ({ page, diagnostics }) => {
         await assertCounterHydration(page, {
-          expectedStrategy: "fs",
+          expectedStrategy: "rsc-module",
           expectedPagePath: "app/page.tsx",
-          expectedModulePath: "/_veryfront/fs/",
+          expectedModulePath: "/_veryfront/rsc/module",
         });
 
         assertNoBrowserHydrationErrors(diagnostics, "Unexpected hydration errors");

--- a/tests/integration/server/production/server.test.ts
+++ b/tests/integration/server/production/server.test.ts
@@ -368,7 +368,19 @@ describe(
 
         const port = await context.allocatePort();
         const controller = new AbortController();
-        const server = await startServer(context, port, controller.signal);
+        // Start the server with the project registered as local so the SSR
+        // error overlay path is active (post-VULN-SRV-1/2, the overlay gates
+        // strictly on `isLocalProject`).
+        const server = await startProductionServer({
+          projectDir: context.projectDir,
+          port,
+          bindAddress: "127.0.0.1",
+          signal: controller.signal,
+          defaultProjectSlug: context.projectId,
+          defaultProjectId: context.projectId,
+          localProjects: { [context.projectId]: context.projectDir },
+        });
+        await server.ready;
 
         const res = await fetch(`http://127.0.0.1:${port}/a/b`);
         assertEquals(res.status, 500);

--- a/tests/integration/server/production/ssr.test.ts
+++ b/tests/integration/server/production/ssr.test.ts
@@ -148,6 +148,9 @@ describe(
           bindAddress: "127.0.0.1",
           defaultProjectSlug: context.projectId,
           defaultProjectId: context.projectId,
+          // Mark this project as local so the SSR error overlay path is active
+          // (post-VULN-SRV-1/2, the overlay gates strictly on `isLocalProject`).
+          localProjects: { [context.projectId]: context.projectDir },
         });
         context.trackResource(server);
         await server.ready;

--- a/tests/integration/server/rsc/client-modules.test.ts
+++ b/tests/integration/server/rsc/client-modules.test.ts
@@ -124,8 +124,25 @@ describe("RSC Client Modules Tests", { sanitizeOps: false, sanitizeResources: fa
           ].join("\n"),
         );
 
-        const server = await context.createProductionServer({ hostname: "127.0.0.1" });
-        const baseUrl = `http://127.0.0.1:${server.port}`;
+        // Start the server with the project registered as local so the RSC
+        // `fs` client-module strategy and the `/_veryfront/fs/` module loader
+        // are active. Post-VULN-SRV-1/2 these gate strictly on `isLocalProject`.
+        const { startProductionServer } = await import(
+          "../../../../src/server/production-server.ts"
+        );
+        const port = await context.allocatePort();
+        const server = await startProductionServer({
+          projectDir: context.projectDir,
+          port,
+          bindAddress: "127.0.0.1",
+          defaultProjectSlug: context.projectId,
+          defaultProjectId: context.projectId,
+          localProjects: { [context.projectId]: context.projectDir },
+        });
+        context.trackResource(server);
+        await server.ready;
+
+        const baseUrl = `http://127.0.0.1:${port}`;
 
         const pageRes = await fetch(`${baseUrl}/`);
         assertEquals(pageRes.status, 200);

--- a/tests/server/context/request-context.test.ts
+++ b/tests/server/context/request-context.test.ts
@@ -115,14 +115,17 @@ describe("request-context", () => {
       assertEquals(ctx.mode, "preview");
     });
 
-    it("uses x-environment header for custom domains", () => {
+    it("ignores x-environment header on custom domains (VULN-SRV-1/2)", () => {
+      // The x-environment header is client-controlled and must NOT be able to
+      // flip a production request into preview mode. Mode is derived from the
+      // proxy-terminated Host / X-Forwarded-Host signal only.
       const ctx = createRequestContext(
         new Request("https://custom-domain.com/page", {
           headers: { "x-environment": "preview" },
         }),
       );
 
-      assertEquals(ctx.mode, "preview");
+      assertEquals(ctx.mode, "production");
     });
 
     it("defaults to production for custom domains without header", () => {


### PR DESCRIPTION
## Summary

PR 2 of `plans/security-audit-17.4.2026.md`.

Fixes **VULN-SRV-1** and **VULN-SRV-2** — the untrusted `x-environment: preview` header flips production into preview mode, unlocking `DevFileHandler` (project source at `/_veryfront/fs/...`), markdown preview reads, and the SSR error overlay (stack traces, absolute paths).

## Fix

- `createRequestContext` no longer reads `x-environment`; mode is derived from server-trusted signals only (`parseProjectDomain` / `.preview.` hostname).
- `ssr.service.ts` error overlay gates on `ctx.isLocalProject` only — preview mode never ships stack traces.
- `dev-file.handler.ts` gate tightened to `isLocalProject` only.
- Follow-up: `determineClientModuleStrategy` narrowed — `"fs"` strategy only when `isLocalProject` (preview pods now route hydration through `/_veryfront/rsc/module?`).
- Follow-up: `startCliProductionServer` no longer registers the compiled binary as a local project, so `vf serve` runs with `isLocalProject: false` / `isDev: false` (restores CSP, suppresses SSR overlay).

## Test plan

- [x] `deno test src/server/context/ src/server/handlers/dev/ src/server/handlers/preview/ src/server/services/rendering/` — **23 passed (234 steps) | 0 failed**
- [x] Untrusted `x-environment: preview` on a production host does NOT flip mode — covered by `src/server/context/request-context.test.ts` (production host + header variants: `preview`, `PREVIEW`, `Preview`, `%70review`, empty, unknown values). Dev surfaces gate on `isLocalProject` / host-derived mode, so this header can no longer reach the dev-file surface.
- [x] Preview hostnames (`*.preview.veryfront.com`, `*.preview.veryfront.org`, any `.preview.` host) still resolve to preview mode — covered by `request-context.test.ts` "returns preview mode when parseProjectDomain returns preview environment" + ".preview. in host triggers preview" + "hostname wins" cases.
- [x] CI green — all required checks pass on the tip commit (binary e2e, rsc browser e2e, integration, unit, typecheck, lint, format, CodeQL).