### PR TITLE
fix(security): require proxy trust before honoring forwarded headers (VULN-SRV-3/4)

### DIFF
--- a/src/channels/control-plane.ts
+++ b/src/channels/control-plane.ts
@@ -332,6 +332,8 @@ export async function verifyDispatchJwsSignature(
     const verified = await crypto.subtle.verify("Ed25519", publicKey, signature, signingInput);
     if (!verified) return false;
 
+    if (claims.iss !== "veryfront-api") return false;
+
     const now = Math.floor(Date.now() / 1000);
     if (claims.exp <= now) return false;
     if (claims.iat > now + SIGNATURE_SKEW_SECONDS) return false;

--- a/src/channels/control-plane.ts
+++ b/src/channels/control-plane.ts
@@ -293,6 +293,56 @@ export async function listRuntimeAgents(
   return RuntimeAgentListResponseSchema.parse({ agents });
 }
 
+/**
+ * Verify the Ed25519 signature of a dispatch JWS and the recency of its
+ * timestamps, without binding to a particular request body or audience.
+ *
+ * This is intentionally weaker than {@link verifyDispatchJws}: it answers
+ * "was this JWS minted by a holder of the control-plane private key and is it
+ * still fresh?" and is used as a trust signal in code paths (proxy-trust,
+ * adapter selection) that don't yet have access to the authoritative request
+ * body or project audience. Callers that consume request payloads MUST still
+ * call {@link verifyDispatchJws} / {@link verifyControlPlaneJws} to bind the
+ * signature to the body and project.
+ *
+ * Returns true iff the signature verifies and `iat`/`exp` are within the
+ * allowed skew and max-age window. All other failures (including parsing
+ * errors) resolve to false so callers can treat the signal as present-but-not-
+ * proven without raising.
+ */
+export async function verifyDispatchJwsSignature(
+  jws: string,
+  options: {
+    publicKeyPem: string;
+    maxAgeSeconds: number;
+  },
+): Promise<boolean> {
+  try {
+    const parts = jws.split(".");
+    if (parts.length !== 3) return false;
+    const [encodedHeader, encodedPayload, encodedSignature] = parts;
+    if (!encodedHeader || !encodedPayload || !encodedSignature) return false;
+
+    compactJwsHeaderSchema.parse(parseCompactJwsPart(encodedHeader));
+    const claims = dispatchClaimsSchema.parse(parseCompactJwsPart(encodedPayload));
+
+    const signingInput = new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`);
+    const signature = base64urlDecodeToBytes(encodedSignature);
+    const publicKey = await importEd25519PublicKey(options.publicKeyPem);
+    const verified = await crypto.subtle.verify("Ed25519", publicKey, signature, signingInput);
+    if (!verified) return false;
+
+    const now = Math.floor(Date.now() / 1000);
+    if (claims.exp <= now) return false;
+    if (claims.iat > now + SIGNATURE_SKEW_SECONDS) return false;
+    if (now - claims.iat > options.maxAgeSeconds) return false;
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function verifyDispatchJws(
   jws: string,
   body: string,

--- a/src/channels/invoke.ts
+++ b/src/channels/invoke.ts
@@ -153,7 +153,7 @@ export async function listChannelAssistants(
 
   return ChannelAssistantsResponseSchema.parse({ assistants });
 }
-export { verifyDispatchJws } from "./control-plane.ts";
+export { verifyDispatchJws, verifyDispatchJwsSignature } from "./control-plane.ts";
 
 function normalizeConversationPart(
   part: z.infer<typeof rawHistoryPartSchema>,

--- a/src/server/handlers/preview/hmr.handler.test.ts
+++ b/src/server/handlers/preview/hmr.handler.test.ts
@@ -173,12 +173,13 @@ describe("server/handlers/preview/hmr.handler", () => {
       assertEquals(result.continue, false);
     });
 
-    it("proceeds when x-forwarded-host is a local preview host", async () => {
+    it("proceeds when x-forwarded-host is a local preview host AND request is proxy-trusted", async () => {
       const handler = new HMRHandler();
       const req = new Request("http://example.com/_ws", {
         headers: {
           host: "internal.proxy:3000",
           "x-forwarded-host": "preview.veryfront.me:3000",
+          "x-veryfront-dispatch-jws": "test-jws",
         },
       });
       const ctx = makeCtx({
@@ -195,7 +196,89 @@ describe("server/handlers/preview/hmr.handler", () => {
         headers: {
           host: "localhost:3000",
           "x-forwarded-host": "evil.example.com",
+          "x-veryfront-dispatch-jws": "test-jws",
         },
+      });
+      const ctx = makeCtx({
+        isLocalProject: false,
+        requestContext: { mode: "production" } as any,
+      });
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, true);
+    });
+
+    it("IGNORES x-forwarded-host: localhost when request is NOT proxy-trusted (VULN-SRV-4)", async () => {
+      // Without proxy trust, the forwarded host must not be allowed to unlock the
+      // localhost short-circuit that enables HMR. Otherwise any remote client could
+      // claim to be localhost and open a WebSocket against the dev runtime.
+      const handler = new HMRHandler();
+      const req = new Request("http://evil.example.com/_ws", {
+        headers: {
+          host: "evil.example.com",
+          "x-forwarded-host": "localhost",
+        },
+      });
+      const ctx = makeCtx({
+        isLocalProject: false,
+        requestContext: { mode: "production" } as any,
+      });
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, true);
+    });
+
+    it("IGNORES x-forwarded-host: 127.0.0.1 when request is NOT proxy-trusted", async () => {
+      const handler = new HMRHandler();
+      const req = new Request("http://evil.example.com/_ws", {
+        headers: {
+          host: "evil.example.com",
+          "x-forwarded-host": "127.0.0.1",
+        },
+      });
+      const ctx = makeCtx({
+        isLocalProject: false,
+        requestContext: { mode: "production" } as any,
+      });
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, true);
+    });
+
+    it("HONOURS x-forwarded-host: localhost when request IS proxy-trusted", async () => {
+      const handler = new HMRHandler();
+      const req = new Request("http://internal.proxy/_ws", {
+        headers: {
+          host: "internal.proxy:3000",
+          "x-forwarded-host": "localhost",
+          "x-veryfront-dispatch-jws": "test-jws",
+        },
+      });
+      const ctx = makeCtx({
+        isLocalProject: false,
+        adapter: createMockAdapter({ upgradeWebSocket: undefined }),
+      });
+      const result = await handler.handle(req, ctx);
+      // Handler path entered — not short-circuited.
+      assertEquals(result.continue, false);
+    });
+
+    it("HONOURS raw Host: localhost even without proxy trust (bare-metal local dev)", async () => {
+      const handler = new HMRHandler();
+      const req = new Request("http://localhost:3000/_ws", {
+        headers: { host: "localhost:3000" },
+      });
+      const ctx = makeCtx({
+        isLocalProject: false,
+        adapter: createMockAdapter({ upgradeWebSocket: undefined }),
+      });
+      const result = await handler.handle(req, ctx);
+      assertEquals(result.continue, false);
+    });
+
+    it('treats "localhost.evil.com" as non-local (must not match by prefix)', async () => {
+      // Regression: any substring-match on "localhost" would be dangerous; isLocalDevHost
+      // uses precise matching, and this test locks that behaviour in.
+      const handler = new HMRHandler();
+      const req = new Request("http://localhost.evil.com/_ws", {
+        headers: { host: "localhost.evil.com" },
       });
       const ctx = makeCtx({
         isLocalProject: false,

--- a/src/server/handlers/preview/hmr.handler.test.ts
+++ b/src/server/handlers/preview/hmr.handler.test.ts
@@ -1,8 +1,52 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
 import type { HandlerContext } from "../types.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { HMRHandler } from "./hmr.handler.ts";
+
+const encoder = new TextEncoder();
+
+function encodePem(label: string, der: ArrayBuffer): string {
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = base64.match(/.{1,64}/g) ?? [base64];
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
+}
+
+let signingKeyPair: CryptoKeyPair | undefined;
+let trustedPublicKeyPem: string | undefined;
+
+async function ensureKeyMaterial(): Promise<void> {
+  if (signingKeyPair && trustedPublicKeyPem) return;
+  signingKeyPair = (await crypto.subtle.generateKey(
+    "Ed25519",
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const der = await crypto.subtle.exportKey("spki", signingKeyPair.publicKey);
+  trustedPublicKeyPem = encodePem("PUBLIC KEY", der);
+}
+
+async function mintTrustedDispatchJws(): Promise<string> {
+  await ensureKeyMaterial();
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "EdDSA", typ: "JWT" };
+  const claims = {
+    iss: "veryfront-api",
+    aud: "demo-project",
+    sub: "dispatch-hmr-test",
+    project_id: "proj_123",
+    platform: "slack",
+    body_sha256: "n/a",
+    iat: now,
+    exp: now + 60,
+  };
+  const encodedHeader = base64urlEncode(JSON.stringify(header));
+  const encodedPayload = base64urlEncode(JSON.stringify(claims));
+  const signingInput = encoder.encode(`${encodedHeader}.${encodedPayload}`);
+  const signature = await crypto.subtle.sign("Ed25519", signingKeyPair!.privateKey, signingInput);
+  return `${encodedHeader}.${encodedPayload}.${base64urlEncodeBytes(new Uint8Array(signature))}`;
+}
 
 function createMockAdapter(
   serverOverrides: Record<string, unknown> = {},
@@ -21,7 +65,8 @@ function createMockAdapter(
       stat: () => Promise.resolve({ isFile: false, isDirectory: false, size: 0, mtime: null }),
     },
     env: {
-      get: () => undefined,
+      get: (key: string) =>
+        key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? trustedPublicKeyPem : undefined,
       set: () => {},
       delete: () => {},
       toObject: () => ({}),
@@ -179,7 +224,7 @@ describe("server/handlers/preview/hmr.handler", () => {
         headers: {
           host: "internal.proxy:3000",
           "x-forwarded-host": "preview.veryfront.me:3000",
-          "x-veryfront-dispatch-jws": "test-jws",
+          "x-veryfront-dispatch-jws": await mintTrustedDispatchJws(),
         },
       });
       const ctx = makeCtx({
@@ -196,7 +241,7 @@ describe("server/handlers/preview/hmr.handler", () => {
         headers: {
           host: "localhost:3000",
           "x-forwarded-host": "evil.example.com",
-          "x-veryfront-dispatch-jws": "test-jws",
+          "x-veryfront-dispatch-jws": await mintTrustedDispatchJws(),
         },
       });
       const ctx = makeCtx({
@@ -248,7 +293,7 @@ describe("server/handlers/preview/hmr.handler", () => {
         headers: {
           host: "internal.proxy:3000",
           "x-forwarded-host": "localhost",
-          "x-veryfront-dispatch-jws": "test-jws",
+          "x-veryfront-dispatch-jws": await mintTrustedDispatchJws(),
         },
       });
       const ctx = makeCtx({
@@ -259,6 +304,32 @@ describe("server/handlers/preview/hmr.handler", () => {
       // Handler path entered — not short-circuited.
       assertEquals(result.continue, false);
     });
+
+    it(
+      "IGNORES x-forwarded-host: localhost when dispatch-JWS is present but unverifiable (Codex P1 regression)",
+      async () => {
+        // A direct-access attacker can attach any value to x-veryfront-dispatch-jws
+        // because the proxy does not strip that header on ingress. Prior to the
+        // fix, mere presence unlocked forwarded-header trust and re-opened the
+        // localhost short-circuit. The handler must now cryptographically verify
+        // the JWS before promoting the request to proxy-trusted.
+        const handler = new HMRHandler();
+        const req = new Request("http://evil.example.com/_ws", {
+          headers: {
+            host: "evil.example.com",
+            "x-forwarded-host": "localhost",
+            "x-veryfront-dispatch-jws": "eyJhbGciOi.fake.value",
+          },
+        });
+        const ctx = makeCtx({
+          isLocalProject: false,
+          requestContext: { mode: "production" } as any,
+        });
+        const result = await handler.handle(req, ctx);
+        // The bogus JWS must NOT unlock the localhost short-circuit.
+        assertEquals(result.continue, true);
+      },
+    );
 
     it("HONOURS raw Host: localhost even without proxy trust (bare-metal local dev)", async () => {
       const handler = new HMRHandler();

--- a/src/server/handlers/preview/hmr.handler.ts
+++ b/src/server/handlers/preview/hmr.handler.ts
@@ -28,6 +28,7 @@ import {
 import { getPingIntervalMs, startPingInterval, stopPingInterval } from "./hmr-ping-keepalive.ts";
 import { broadcastUpdate, getMetrics } from "./hmr-message-router.ts";
 import { getEffectiveRequestHost } from "../../utils/request-host.ts";
+import { isProxyTrusted } from "../../utils/proxy-trust.ts";
 
 const logger = serverLogger.component("hmr-handler");
 
@@ -95,7 +96,13 @@ export class HMRHandler extends BaseHandler {
     const queryEnv = url.searchParams.get("x-environment");
     const isPreviewMode = ctx.requestContext?.mode === "preview" || queryEnv === "preview";
     const isLocal = !!ctx.isLocalProject;
-    const host = getEffectiveRequestHost(req, url);
+    // SECURITY: x-forwarded-host is client-controlled unless we trust the upstream proxy.
+    // Honouring it unconditionally lets any remote client present `x-forwarded-host: localhost`
+    // and unlock the localhost short-circuit that opens HMR (VULN-SRV-4). Only consult
+    // forwarded headers when the request is proxy-trusted; otherwise use Host / url.host.
+    const host = isProxyTrusted(req)
+      ? getEffectiveRequestHost(req, url)
+      : (req.headers.get("host") ?? url.host);
     const isLocalhost = isLocalDevHost(host);
 
     if (!isPreviewMode && !isLocal && !isLocalhost) {

--- a/src/server/handlers/preview/hmr.handler.ts
+++ b/src/server/handlers/preview/hmr.handler.ts
@@ -29,6 +29,7 @@ import { getPingIntervalMs, startPingInterval, stopPingInterval } from "./hmr-pi
 import { broadcastUpdate, getMetrics } from "./hmr-message-router.ts";
 import { getEffectiveRequestHost } from "../../utils/request-host.ts";
 import { isProxyTrusted } from "../../utils/proxy-trust.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 const logger = serverLogger.component("hmr-handler");
 
@@ -89,8 +90,8 @@ export class HMRHandler extends BaseHandler {
     });
   }
 
-  handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
-    if (!this.shouldHandle(req, ctx)) return Promise.resolve(this.continue());
+  async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
+    if (!this.shouldHandle(req, ctx)) return this.continue();
 
     const url = new URL(req.url);
     const queryEnv = url.searchParams.get("x-environment");
@@ -100,7 +101,11 @@ export class HMRHandler extends BaseHandler {
     // Honouring it unconditionally lets any remote client present `x-forwarded-host: localhost`
     // and unlock the localhost short-circuit that opens HMR (VULN-SRV-4). Only consult
     // forwarded headers when the request is proxy-trusted; otherwise use Host / url.host.
-    const host = isProxyTrusted(req)
+    // Proxy trust requires a verifiable dispatch JWS (or operator opt-in) — mere header
+    // presence is not enough, since `x-veryfront-dispatch-jws` is not stripped on ingress.
+    const publicKeyPem = ctx.adapter?.env?.get("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY") ??
+      getHostEnv("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
+    const host = (await isProxyTrusted(req, { publicKeyPem }))
       ? getEffectiveRequestHost(req, url)
       : (req.headers.get("host") ?? url.host);
     const isLocalhost = isLocalDevHost(host);
@@ -115,7 +120,7 @@ export class HMRHandler extends BaseHandler {
         isLocal,
         isLocalhost,
       });
-      return Promise.resolve(this.continue());
+      return this.continue();
     }
 
     HMRHandler.initialize();
@@ -133,29 +138,25 @@ export class HMRHandler extends BaseHandler {
     }
 
     if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
-      return Promise.resolve(
-        this.respond(
-          new Response(
-            JSON.stringify({
-              status: "ok",
-              clients: getClientCount(),
-              clientDetails: getClientDetails(),
-              metrics: {
-                ...getMetrics(),
-                reloadNotifierMetrics: ReloadNotifier.getMetrics(),
-              },
-              message: "HMR WebSocket endpoint - connect via WebSocket",
-            }),
-            { headers: { "content-type": "application/json" } },
-          ),
+      return this.respond(
+        new Response(
+          JSON.stringify({
+            status: "ok",
+            clients: getClientCount(),
+            clientDetails: getClientDetails(),
+            metrics: {
+              ...getMetrics(),
+              reloadNotifierMetrics: ReloadNotifier.getMetrics(),
+            },
+            message: "HMR WebSocket endpoint - connect via WebSocket",
+          }),
+          { headers: { "content-type": "application/json" } },
         ),
       );
     }
 
     if (!ctx.adapter?.server) {
-      return Promise.resolve(
-        this.respond(new Response("WebSocket not supported", { status: 501 })),
-      );
+      return this.respond(new Response("WebSocket not supported", { status: 501 }));
     }
 
     try {
@@ -240,12 +241,10 @@ export class HMRHandler extends BaseHandler {
         totalClients: getClientCount(),
       });
 
-      return Promise.resolve(this.respond(response));
+      return this.respond(response);
     } catch (error) {
       logger.error("WebSocket upgrade failed", { error });
-      return Promise.resolve(
-        this.respond(new Response("WebSocket upgrade failed", { status: 500 })),
-      );
+      return this.respond(new Response("WebSocket upgrade failed", { status: 500 }));
     }
   }
 

--- a/src/server/runtime-handler/adapter-factory.test.ts
+++ b/src/server/runtime-handler/adapter-factory.test.ts
@@ -8,6 +8,27 @@ import {
   ProjectDiscoveryCache,
 } from "./local-project-discovery.ts";
 
+/**
+ * Build a Request suitable for resolveAdapter tests.
+ *
+ * @param options.projectPath Value for the `x-project-path` header (if provided)
+ * @param options.trusted     When true, attaches a dispatch-JWS header so
+ *                            isProxyTrusted() returns true. Omit/false to
+ *                            simulate an untrusted client.
+ */
+function makeReq(
+  options: { projectPath?: string; trusted?: boolean } = {},
+): Request {
+  const headers = new Headers();
+  if (options.projectPath !== undefined) {
+    headers.set("x-project-path", options.projectPath);
+  }
+  if (options.trusted) {
+    headers.set("x-veryfront-dispatch-jws", "test-jws");
+  }
+  return new Request("http://example.com/", { headers });
+}
+
 function createMockAdapter(
   files: Record<string, { isDirectory: boolean; isFile?: boolean }>,
 ): RuntimeAdapter {
@@ -76,6 +97,7 @@ describe("adapter-factory", () => {
     });
 
     const result = await resolveAdapter({
+      req: makeReq({ projectPath: "/trusted/project", trusted: true }),
       projectDir: "/base/project",
       adapter,
       config: undefined,
@@ -94,7 +116,6 @@ describe("adapter-factory", () => {
         isDraft: false,
         allowIframeEmbed: false,
       },
-      headerProjectPath: "/trusted/project",
       isProxyMode: false,
     });
 
@@ -103,7 +124,7 @@ describe("adapter-factory", () => {
     assertEquals(localProjectCache.has("myproject"), false);
   });
 
-  it("accepts validated x-project-path override in proxy mode", async () => {
+  it("accepts validated x-project-path override in proxy mode when proxy trusted", async () => {
     const adapter = createMockAdapter({
       "/trusted/project": { isDirectory: true },
       "/trusted/project/app": { isDirectory: true },
@@ -113,6 +134,7 @@ describe("adapter-factory", () => {
     localAdapterCache.set("/trusted/project", adapter);
 
     const result = await resolveAdapter({
+      req: makeReq({ projectPath: "/trusted/project", trusted: true }),
       projectDir: "/base/project",
       adapter,
       config: undefined,
@@ -131,13 +153,83 @@ describe("adapter-factory", () => {
         isDraft: false,
         allowIframeEmbed: false,
       },
-      headerProjectPath: "/trusted/project",
       isProxyMode: true,
     });
 
     assertEquals(result.isLocalProject, true);
     assertEquals(result.projectDir, "/trusted/project");
     assertEquals(localProjectCache.get("myproject"), "/trusted/project");
+  });
+
+  it("ignores x-project-path in proxy mode when request is NOT proxy-trusted (VULN-SRV-3)", async () => {
+    // An attacker reaching the runtime directly (no dispatch-JWS, env not set)
+    // must not be able to steer project discovery at arbitrary filesystem paths.
+    const adapter = createMockAdapter({
+      "/attacker/chosen/path": { isDirectory: true },
+      "/attacker/chosen/path/app": { isDirectory: true },
+    });
+
+    const result = await resolveAdapter({
+      req: makeReq({ projectPath: "/attacker/chosen/path", trusted: false }),
+      projectDir: "/base/project",
+      adapter,
+      config: undefined,
+      projectSlug: "myproject",
+      projectId: "proj_123",
+      proxyToken: undefined,
+      releaseId: undefined,
+      proxyEnv: "preview",
+      branch: null,
+      environmentName: undefined,
+      parsedDomain: {
+        slug: null,
+        branch: null,
+        environment: null,
+        isVeryfrontDomain: false,
+        isDraft: false,
+        allowIframeEmbed: false,
+      },
+      isProxyMode: true,
+    });
+
+    // The attacker-supplied path must not be adopted as the project root.
+    assertEquals(result.isLocalProject, false);
+    assertEquals(result.projectDir, "/base/project");
+    assertEquals(localProjectCache.has("myproject"), false);
+  });
+
+  it("honours x-project-path in proxy mode when dispatch-JWS header is present", async () => {
+    const adapter = createMockAdapter({
+      "/trusted/project": { isDirectory: true },
+      "/trusted/project/app": { isDirectory: true },
+    });
+    localAdapterCache.set("/trusted/project", adapter);
+
+    const result = await resolveAdapter({
+      req: makeReq({ projectPath: "/trusted/project", trusted: true }),
+      projectDir: "/base/project",
+      adapter,
+      config: undefined,
+      projectSlug: "myproject",
+      projectId: "proj_123",
+      proxyToken: undefined,
+      releaseId: undefined,
+      proxyEnv: "preview",
+      branch: null,
+      environmentName: undefined,
+      parsedDomain: {
+        slug: null,
+        branch: null,
+        environment: null,
+        isVeryfrontDomain: false,
+        isDraft: false,
+        allowIframeEmbed: false,
+      },
+      isProxyMode: true,
+    });
+
+    assertEquals(result.isLocalProject, true);
+    assertEquals(result.projectDir, "/trusted/project");
   });
 
   it("returns original adapter when no local project found and not proxy mode", async () => {
@@ -161,7 +253,7 @@ describe("adapter-factory", () => {
         isDraft: false,
         allowIframeEmbed: false,
       },
-      headerProjectPath: undefined,
+      req: makeReq(),
       isProxyMode: false,
     });
 
@@ -171,7 +263,7 @@ describe("adapter-factory", () => {
     assertEquals(result.config, undefined);
   });
 
-  it("skips local discovery in proxy mode without headerProjectPath", async () => {
+  it("skips local discovery in proxy mode when no x-project-path header is supplied", async () => {
     const adapter = createMockAdapter({
       "data/projects/myproject": { isDirectory: true },
       "data/projects/myproject/app": { isDirectory: true },
@@ -196,7 +288,7 @@ describe("adapter-factory", () => {
         isDraft: false,
         allowIframeEmbed: false,
       },
-      headerProjectPath: undefined,
+      req: makeReq(),
       isProxyMode: true,
     });
 
@@ -230,7 +322,7 @@ describe("adapter-factory", () => {
         isDraft: false,
         allowIframeEmbed: false,
       },
-      headerProjectPath: undefined,
+      req: makeReq(),
       isProxyMode: false,
     });
 
@@ -260,7 +352,7 @@ describe("adapter-factory", () => {
         isDraft: false,
         allowIframeEmbed: false,
       },
-      headerProjectPath: undefined,
+      req: makeReq(),
       isProxyMode: false,
     });
 
@@ -289,7 +381,7 @@ describe("adapter-factory", () => {
         isDraft: false,
         allowIframeEmbed: false,
       },
-      headerProjectPath: undefined,
+      req: makeReq(),
       isProxyMode: false,
     });
 
@@ -310,6 +402,7 @@ describe("adapter-factory", () => {
     cache.adapters.set("/trusted/project", adapter);
 
     const result = await resolveAdapter({
+      req: makeReq({ projectPath: "/trusted/project", trusted: true }),
       projectDir: "/base/project",
       adapter,
       config: undefined,
@@ -328,7 +421,6 @@ describe("adapter-factory", () => {
         isDraft: false,
         allowIframeEmbed: false,
       },
-      headerProjectPath: "/trusted/project",
       isProxyMode: true,
       cache,
     });
@@ -371,7 +463,7 @@ describe("adapter-factory", () => {
         isDraft: false,
         allowIframeEmbed: false,
       },
-      headerProjectPath: undefined,
+      req: makeReq(),
       isProxyMode: false,
       cache,
     });
@@ -436,7 +528,7 @@ describe("adapter-factory", () => {
             isDraft: false,
             allowIframeEmbed: false,
           },
-          headerProjectPath: undefined,
+          req: makeReq(),
           isProxyMode: true,
         });
       } catch {
@@ -482,7 +574,7 @@ describe("adapter-factory", () => {
               isDraft: false,
               allowIframeEmbed: false,
             },
-            headerProjectPath: undefined,
+            req: makeReq(),
             isProxyMode: true,
           }),
         Error,
@@ -512,7 +604,7 @@ describe("adapter-factory", () => {
           isDraft: false,
           allowIframeEmbed: false,
         },
-        headerProjectPath: undefined,
+        req: makeReq(),
         isProxyMode: true,
       });
 
@@ -548,7 +640,7 @@ describe("adapter-factory", () => {
             isDraft: false,
             allowIframeEmbed: false,
           },
-          headerProjectPath: undefined,
+          req: makeReq(),
           isProxyMode: true,
         });
         succeeded = true;

--- a/src/server/runtime-handler/adapter-factory.test.ts
+++ b/src/server/runtime-handler/adapter-factory.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
 import { resolveAdapter } from "./adapter-factory.ts";
 import {
   localAdapterCache,
@@ -8,23 +9,73 @@ import {
   ProjectDiscoveryCache,
 } from "./local-project-discovery.ts";
 
+const encoder = new TextEncoder();
+
+function encodePem(label: string, der: ArrayBuffer): string {
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = base64.match(/.{1,64}/g) ?? [base64];
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
+}
+
+// Shared Ed25519 key pair and PEM-encoded public half. Lazily generated on the
+// first makeReq({ trusted: true }) call so tests that don't need a valid JWS
+// pay nothing for the key material.
+let signingKeyPair: CryptoKeyPair | undefined;
+let trustedPublicKeyPem: string | undefined;
+
+async function ensureKeyMaterial(): Promise<void> {
+  if (signingKeyPair && trustedPublicKeyPem) return;
+  signingKeyPair = (await crypto.subtle.generateKey(
+    "Ed25519",
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const der = await crypto.subtle.exportKey("spki", signingKeyPair.publicKey);
+  trustedPublicKeyPem = encodePem("PUBLIC KEY", der);
+}
+
+async function mintTrustedDispatchJws(): Promise<string> {
+  await ensureKeyMaterial();
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "EdDSA", typ: "JWT" };
+  const claims = {
+    iss: "veryfront-api",
+    aud: "demo-project",
+    sub: "dispatch-adapter-test",
+    project_id: "proj_123",
+    platform: "slack",
+    body_sha256: "n/a",
+    iat: now,
+    exp: now + 60,
+  };
+  const encodedHeader = base64urlEncode(JSON.stringify(header));
+  const encodedPayload = base64urlEncode(JSON.stringify(claims));
+  const signingInput = encoder.encode(`${encodedHeader}.${encodedPayload}`);
+  const signature = await crypto.subtle.sign("Ed25519", signingKeyPair!.privateKey, signingInput);
+  return `${encodedHeader}.${encodedPayload}.${base64urlEncodeBytes(new Uint8Array(signature))}`;
+}
+
 /**
  * Build a Request suitable for resolveAdapter tests.
  *
  * @param options.projectPath Value for the `x-project-path` header (if provided)
- * @param options.trusted     When true, attaches a dispatch-JWS header so
- *                            isProxyTrusted() returns true. Omit/false to
- *                            simulate an untrusted client.
+ * @param options.trusted     When true, attaches a valid freshly-signed dispatch
+ *                            JWS so isProxyTrusted() verifies. When "bogus",
+ *                            attaches an unverifiable header value to simulate
+ *                            the direct-access spoofing attack. Omit/false for
+ *                            an untrusted client.
  */
-function makeReq(
-  options: { projectPath?: string; trusted?: boolean } = {},
-): Request {
+async function makeReq(
+  options: { projectPath?: string; trusted?: boolean | "bogus" } = {},
+): Promise<Request> {
   const headers = new Headers();
   if (options.projectPath !== undefined) {
     headers.set("x-project-path", options.projectPath);
   }
-  if (options.trusted) {
-    headers.set("x-veryfront-dispatch-jws", "test-jws");
+  if (options.trusted === true) {
+    headers.set("x-veryfront-dispatch-jws", await mintTrustedDispatchJws());
+  } else if (options.trusted === "bogus") {
+    headers.set("x-veryfront-dispatch-jws", "eyJhbGciOi.fake.value");
   }
   return new Request("http://example.com/", { headers });
 }
@@ -68,7 +119,8 @@ function createMockAdapter(
       watch: () => ({ close: () => {}, [Symbol.asyncIterator]: async function* () {} }),
     },
     env: {
-      get: () => undefined,
+      get: (key: string) =>
+        key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY" ? trustedPublicKeyPem : undefined,
       set: () => {},
       toObject: () => ({}),
     },
@@ -97,7 +149,7 @@ describe("adapter-factory", () => {
     });
 
     const result = await resolveAdapter({
-      req: makeReq({ projectPath: "/trusted/project", trusted: true }),
+      req: await makeReq({ projectPath: "/trusted/project", trusted: true }),
       projectDir: "/base/project",
       adapter,
       config: undefined,
@@ -134,7 +186,7 @@ describe("adapter-factory", () => {
     localAdapterCache.set("/trusted/project", adapter);
 
     const result = await resolveAdapter({
-      req: makeReq({ projectPath: "/trusted/project", trusted: true }),
+      req: await makeReq({ projectPath: "/trusted/project", trusted: true }),
       projectDir: "/base/project",
       adapter,
       config: undefined,
@@ -170,7 +222,7 @@ describe("adapter-factory", () => {
     });
 
     const result = await resolveAdapter({
-      req: makeReq({ projectPath: "/attacker/chosen/path", trusted: false }),
+      req: await makeReq({ projectPath: "/attacker/chosen/path", trusted: false }),
       projectDir: "/base/project",
       adapter,
       config: undefined,
@@ -198,6 +250,50 @@ describe("adapter-factory", () => {
     assertEquals(localProjectCache.has("myproject"), false);
   });
 
+  it(
+    "ignores x-project-path in proxy mode when dispatch-JWS is present but unverifiable (Codex P1 regression)",
+    async () => {
+      // Historically `isProxyTrusted` trusted any request that merely carried an
+      // `x-veryfront-dispatch-jws` header. The proxy does not strip that header
+      // on ingress (it has to pass through to channel handlers), so a direct-
+      // access attacker could attach any value — including gibberish — and
+      // re-enable `x-project-path` spoofing. This test pins the fix: a bogus
+      // (unsigned / unverifiable) dispatch JWS must NOT promote the request
+      // into proxy-trusted territory.
+      const adapter = createMockAdapter({
+        "/attacker/chosen/path": { isDirectory: true },
+        "/attacker/chosen/path/app": { isDirectory: true },
+      });
+
+      const result = await resolveAdapter({
+        req: await makeReq({ projectPath: "/attacker/chosen/path", trusted: "bogus" }),
+        projectDir: "/base/project",
+        adapter,
+        config: undefined,
+        projectSlug: "myproject",
+        projectId: "proj_123",
+        proxyToken: undefined,
+        releaseId: undefined,
+        proxyEnv: "preview",
+        branch: null,
+        environmentName: undefined,
+        parsedDomain: {
+          slug: null,
+          branch: null,
+          environment: null,
+          isVeryfrontDomain: false,
+          isDraft: false,
+          allowIframeEmbed: false,
+        },
+        isProxyMode: true,
+      });
+
+      assertEquals(result.isLocalProject, false);
+      assertEquals(result.projectDir, "/base/project");
+      assertEquals(localProjectCache.has("myproject"), false);
+    },
+  );
+
   it("honours x-project-path in proxy mode when dispatch-JWS header is present", async () => {
     const adapter = createMockAdapter({
       "/trusted/project": { isDirectory: true },
@@ -206,7 +302,7 @@ describe("adapter-factory", () => {
     localAdapterCache.set("/trusted/project", adapter);
 
     const result = await resolveAdapter({
-      req: makeReq({ projectPath: "/trusted/project", trusted: true }),
+      req: await makeReq({ projectPath: "/trusted/project", trusted: true }),
       projectDir: "/base/project",
       adapter,
       config: undefined,
@@ -253,7 +349,7 @@ describe("adapter-factory", () => {
         isDraft: false,
         allowIframeEmbed: false,
       },
-      req: makeReq(),
+      req: await makeReq(),
       isProxyMode: false,
     });
 
@@ -288,7 +384,7 @@ describe("adapter-factory", () => {
         isDraft: false,
         allowIframeEmbed: false,
       },
-      req: makeReq(),
+      req: await makeReq(),
       isProxyMode: true,
     });
 
@@ -322,7 +418,7 @@ describe("adapter-factory", () => {
         isDraft: false,
         allowIframeEmbed: false,
       },
-      req: makeReq(),
+      req: await makeReq(),
       isProxyMode: false,
     });
 
@@ -352,7 +448,7 @@ describe("adapter-factory", () => {
         isDraft: false,
         allowIframeEmbed: false,
       },
-      req: makeReq(),
+      req: await makeReq(),
       isProxyMode: false,
     });
 
@@ -381,7 +477,7 @@ describe("adapter-factory", () => {
         isDraft: false,
         allowIframeEmbed: false,
       },
-      req: makeReq(),
+      req: await makeReq(),
       isProxyMode: false,
     });
 
@@ -402,7 +498,7 @@ describe("adapter-factory", () => {
     cache.adapters.set("/trusted/project", adapter);
 
     const result = await resolveAdapter({
-      req: makeReq({ projectPath: "/trusted/project", trusted: true }),
+      req: await makeReq({ projectPath: "/trusted/project", trusted: true }),
       projectDir: "/base/project",
       adapter,
       config: undefined,
@@ -463,7 +559,7 @@ describe("adapter-factory", () => {
         isDraft: false,
         allowIframeEmbed: false,
       },
-      req: makeReq(),
+      req: await makeReq(),
       isProxyMode: false,
       cache,
     });
@@ -528,7 +624,7 @@ describe("adapter-factory", () => {
             isDraft: false,
             allowIframeEmbed: false,
           },
-          req: makeReq(),
+          req: await makeReq(),
           isProxyMode: true,
         });
       } catch {
@@ -574,7 +670,7 @@ describe("adapter-factory", () => {
               isDraft: false,
               allowIframeEmbed: false,
             },
-            req: makeReq(),
+            req: await makeReq(),
             isProxyMode: true,
           }),
         Error,
@@ -604,7 +700,7 @@ describe("adapter-factory", () => {
           isDraft: false,
           allowIframeEmbed: false,
         },
-        req: makeReq(),
+        req: await makeReq(),
         isProxyMode: true,
       });
 
@@ -640,7 +736,7 @@ describe("adapter-factory", () => {
             isDraft: false,
             allowIframeEmbed: false,
           },
-          req: makeReq(),
+          req: await makeReq(),
           isProxyMode: true,
         });
         succeeded = true;

--- a/src/server/runtime-handler/adapter-factory.test.ts
+++ b/src/server/runtime-handler/adapter-factory.test.ts
@@ -648,6 +648,7 @@ describe("adapter-factory", () => {
         },
       };
       const adapter = { ...base, fs: extendedFs } as unknown as RuntimeAdapter;
+      const req = await makeReq();
 
       await assertRejects(
         () =>
@@ -670,7 +671,7 @@ describe("adapter-factory", () => {
               isDraft: false,
               allowIframeEmbed: false,
             },
-            req: await makeReq(),
+            req,
             isProxyMode: true,
           }),
         Error,

--- a/src/server/runtime-handler/adapter-factory.ts
+++ b/src/server/runtime-handler/adapter-factory.ts
@@ -22,6 +22,7 @@ import {
 } from "./local-project-discovery.ts";
 import type { ParsedDomain } from "../utils/domain-parser.ts";
 import { isProxyTrusted } from "../utils/proxy-trust.ts";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 
 const baseLogger = getBaseLogger("SERVER");
 
@@ -94,9 +95,16 @@ export async function resolveAdapter(
   // SECURITY: `x-project-path` is a client-controlled header. Honouring it from any
   // request would let an attacker reaching the runtime directly aim project discovery
   // (and therefore `/_veryfront/fs/...`) at arbitrary filesystem paths (VULN-SRV-3).
-  // Only read it when the request is proxy-trusted (control-plane JWS header present
-  // or the operator has explicitly opted in via VERYFRONT_TRUST_FORWARDED_HEADERS=1).
-  const trustedHeaderProjectPath = opts.isProxyMode && isProxyTrusted(opts.req)
+  // Only read it when the request is proxy-trusted: either the operator opted in via
+  // VERYFRONT_TRUST_FORWARDED_HEADERS=1, or the request carries a dispatch JWS that
+  // verifies against CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY. Mere header presence is
+  // NOT sufficient — a direct-access attacker could otherwise spoof `x-project-path`
+  // by attaching any value in `x-veryfront-dispatch-jws`.
+  const publicKeyPem = opts.adapter.env.get("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY") ??
+    getHostEnv("CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY");
+  const proxyTrusted = opts.isProxyMode &&
+    (await isProxyTrusted(opts.req, { publicKeyPem }));
+  const trustedHeaderProjectPath = proxyTrusted
     ? opts.req.headers.get("x-project-path")?.trim() || undefined
     : undefined;
   const shouldCheckLocalPath = opts.projectSlug && (!opts.isProxyMode || trustedHeaderProjectPath);

--- a/src/server/runtime-handler/adapter-factory.ts
+++ b/src/server/runtime-handler/adapter-factory.ts
@@ -21,6 +21,7 @@ import {
   type ProjectDiscoveryCache,
 } from "./local-project-discovery.ts";
 import type { ParsedDomain } from "../utils/domain-parser.ts";
+import { isProxyTrusted } from "../utils/proxy-trust.ts";
 
 const baseLogger = getBaseLogger("SERVER");
 
@@ -38,6 +39,11 @@ interface AdapterResolutionResult {
 }
 
 interface AdapterResolutionOptions {
+  /**
+   * Inbound request. Used to determine whether forwarded headers such as
+   * `x-project-path` can be trusted (see {@link isProxyTrusted}).
+   */
+  req: Request;
   /** Base project directory */
   projectDir: string;
   /** Base adapter */
@@ -60,8 +66,6 @@ interface AdapterResolutionOptions {
   environmentName: string | undefined;
   /** Parsed domain info */
   parsedDomain: ParsedDomain;
-  /** Project path from header */
-  headerProjectPath: string | undefined;
   /** Whether running in proxy mode */
   isProxyMode: boolean;
   /** Optional injectable cache (defaults to module-level singleton) */
@@ -86,7 +90,15 @@ export async function resolveAdapter(
   // Check if this is a local project.
   // In proxy mode, skip local discovery unless there's an explicit header path override —
   // the standard directories (data/projects/, projects/) don't exist in k8s.
-  const trustedHeaderProjectPath = opts.isProxyMode ? opts.headerProjectPath : undefined;
+  //
+  // SECURITY: `x-project-path` is a client-controlled header. Honouring it from any
+  // request would let an attacker reaching the runtime directly aim project discovery
+  // (and therefore `/_veryfront/fs/...`) at arbitrary filesystem paths (VULN-SRV-3).
+  // Only read it when the request is proxy-trusted (control-plane JWS header present
+  // or the operator has explicitly opted in via VERYFRONT_TRUST_FORWARDED_HEADERS=1).
+  const trustedHeaderProjectPath = opts.isProxyMode && isProxyTrusted(opts.req)
+    ? opts.req.headers.get("x-project-path")?.trim() || undefined
+    : undefined;
   const shouldCheckLocalPath = opts.projectSlug && (!opts.isProxyMode || trustedHeaderProjectPath);
   const localProjectPath = shouldCheckLocalPath
     ? await findLocalProjectPath(opts.projectSlug!, opts.adapter, trustedHeaderProjectPath, cache)

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -520,8 +520,12 @@ export function createVeryfrontHandler(
             if (response) return response;
           }
 
-          // Resolve adapter and config for project
+          // Resolve adapter and config for project.
+          // Note: `x-project-path` is NOT forwarded via `headers.projectPath` anymore;
+          // `resolveAdapter` reads it directly from `req` and only honours it when the
+          // request is proxy-trusted (see isProxyTrusted).
           const adapterRes = await resolveAdapter({
+            req,
             projectDir,
             adapter,
             config,
@@ -533,7 +537,6 @@ export function createVeryfrontHandler(
             branch: reqCtx.branch,
             environmentName: projectRes.environmentName,
             parsedDomain: projectRes.parsedDomain,
-            headerProjectPath: headers.projectPath,
             isProxyMode,
           });
 

--- a/src/server/utils/proxy-trust.test.ts
+++ b/src/server/utils/proxy-trust.test.ts
@@ -1,0 +1,96 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { isProxyTrusted } from "./proxy-trust.ts";
+
+const ENV_KEY = "VERYFRONT_TRUST_FORWARDED_HEADERS";
+
+describe("server/utils/proxy-trust", () => {
+  let previousEnv: string | undefined;
+
+  beforeEach(() => {
+    previousEnv = Deno.env.get(ENV_KEY);
+    Deno.env.delete(ENV_KEY);
+  });
+
+  afterEach(() => {
+    if (previousEnv === undefined) {
+      Deno.env.delete(ENV_KEY);
+    } else {
+      Deno.env.set(ENV_KEY, previousEnv);
+    }
+  });
+
+  describe("isProxyTrusted", () => {
+    it("returns false when no trust signals are present", () => {
+      const req = new Request("http://example.com/");
+      assertEquals(isProxyTrusted(req), false);
+    });
+
+    it("returns true when x-veryfront-dispatch-jws header is present", () => {
+      const req = new Request("http://example.com/", {
+        headers: { "x-veryfront-dispatch-jws": "eyJhbGciOi.fake.value" },
+      });
+      assertEquals(isProxyTrusted(req), true);
+    });
+
+    it("returns true when x-veryfront-dispatch-jws header is present with empty string value", () => {
+      // Header presence is sufficient — the JWS is validated elsewhere.
+      const req = new Request("http://example.com/", {
+        headers: { "x-veryfront-dispatch-jws": "" },
+      });
+      assertEquals(isProxyTrusted(req), true);
+    });
+
+    it("is case-insensitive on the dispatch JWS header name", () => {
+      const req = new Request("http://example.com/", {
+        headers: { "X-Veryfront-Dispatch-JWS": "value" },
+      });
+      assertEquals(isProxyTrusted(req), true);
+    });
+
+    it('returns true when VERYFRONT_TRUST_FORWARDED_HEADERS === "1"', () => {
+      Deno.env.set(ENV_KEY, "1");
+      const req = new Request("http://example.com/");
+      assertEquals(isProxyTrusted(req), true);
+    });
+
+    it('returns false when env value is "true" (strict === "1" only)', () => {
+      Deno.env.set(ENV_KEY, "true");
+      const req = new Request("http://example.com/");
+      assertEquals(isProxyTrusted(req), false);
+    });
+
+    it('returns false when env value is "0"', () => {
+      Deno.env.set(ENV_KEY, "0");
+      const req = new Request("http://example.com/");
+      assertEquals(isProxyTrusted(req), false);
+    });
+
+    it("returns false when env value is an empty string", () => {
+      Deno.env.set(ENV_KEY, "");
+      const req = new Request("http://example.com/");
+      assertEquals(isProxyTrusted(req), false);
+    });
+
+    it('returns false when env value has whitespace around "1" (strict match)', () => {
+      // Fail-closed: misconfiguration should not accidentally enable trust.
+      Deno.env.set(ENV_KEY, " 1 ");
+      const req = new Request("http://example.com/");
+      assertEquals(isProxyTrusted(req), false);
+    });
+
+    it("returns false when env var is unset", () => {
+      // beforeEach already deleted it; this documents the default posture.
+      const req = new Request("http://example.com/");
+      assertEquals(isProxyTrusted(req), false);
+    });
+
+    it("returns true when both env opt-in and dispatch header are present", () => {
+      Deno.env.set(ENV_KEY, "1");
+      const req = new Request("http://example.com/", {
+        headers: { "x-veryfront-dispatch-jws": "anything" },
+      });
+      assertEquals(isProxyTrusted(req), true);
+    });
+  });
+});

--- a/src/server/utils/proxy-trust.test.ts
+++ b/src/server/utils/proxy-trust.test.ts
@@ -1,8 +1,60 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
 import { isProxyTrusted } from "./proxy-trust.ts";
 
 const ENV_KEY = "VERYFRONT_TRUST_FORWARDED_HEADERS";
+const encoder = new TextEncoder();
+
+function encodePem(label: string, der: ArrayBuffer): string {
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = base64.match(/.{1,64}/g) ?? [base64];
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
+}
+
+async function mintDispatchJws(
+  overrides: Partial<{
+    iat: number;
+    exp: number;
+    audience: string;
+    projectId: string;
+    signingKeyPair: CryptoKeyPair;
+    advertisedPublicKeyPair: CryptoKeyPair;
+  }> = {},
+): Promise<{ jws: string; publicKeyPem: string }> {
+  const signingKeyPair = overrides.signingKeyPair ?? (await crypto.subtle.generateKey(
+    "Ed25519",
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const advertisedKeyPair = overrides.advertisedPublicKeyPair ?? signingKeyPair;
+
+  const advertisedDer = await crypto.subtle.exportKey("spki", advertisedKeyPair.publicKey);
+  const publicKeyPem = encodePem("PUBLIC KEY", advertisedDer);
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "EdDSA", typ: "JWT" };
+  const claims = {
+    iss: "veryfront-api",
+    aud: overrides.audience ?? "demo-project",
+    sub: "dispatch-proxy-trust",
+    project_id: overrides.projectId ?? "proj-1",
+    platform: "slack",
+    body_sha256: "n/a",
+    iat: overrides.iat ?? now,
+    exp: overrides.exp ?? now + 60,
+  };
+
+  const encodedHeader = base64urlEncode(JSON.stringify(header));
+  const encodedPayload = base64urlEncode(JSON.stringify(claims));
+  const signingInput = encoder.encode(`${encodedHeader}.${encodedPayload}`);
+  const signature = await crypto.subtle.sign("Ed25519", signingKeyPair.privateKey, signingInput);
+
+  return {
+    publicKeyPem,
+    jws: `${encodedHeader}.${encodedPayload}.${base64urlEncodeBytes(new Uint8Array(signature))}`,
+  };
+}
 
 describe("server/utils/proxy-trust", () => {
   let previousEnv: string | undefined;
@@ -21,76 +73,149 @@ describe("server/utils/proxy-trust", () => {
   });
 
   describe("isProxyTrusted", () => {
-    it("returns false when no trust signals are present", () => {
+    it("returns false when no trust signals are present", async () => {
       const req = new Request("http://example.com/");
-      assertEquals(isProxyTrusted(req), false);
+      assertEquals(await isProxyTrusted(req), false);
     });
 
-    it("returns true when x-veryfront-dispatch-jws header is present", () => {
+    it("returns true for a validly signed, fresh dispatch JWS", async () => {
+      const { jws, publicKeyPem } = await mintDispatchJws();
+      const req = new Request("http://example.com/", {
+        headers: { "x-veryfront-dispatch-jws": jws },
+      });
+      assertEquals(await isProxyTrusted(req, { publicKeyPem }), true);
+    });
+
+    it("returns false when a dispatch JWS is present but no public key is configured", async () => {
+      // Fails closed if the operator hasn't configured the verification key — we
+      // refuse to trust an unverified header even when it looks well-formed.
+      const { jws } = await mintDispatchJws();
+      const req = new Request("http://example.com/", {
+        headers: { "x-veryfront-dispatch-jws": jws },
+      });
+      assertEquals(await isProxyTrusted(req), false);
+    });
+
+    it("rejects a bogus dispatch JWS even when the header is present (VULN-SRV-3/4 regression)", async () => {
+      // An attacker reaching the runtime directly could attach any value here;
+      // we must not promote it to "proxy-trusted" without crypto verification.
+      const { publicKeyPem } = await mintDispatchJws();
       const req = new Request("http://example.com/", {
         headers: { "x-veryfront-dispatch-jws": "eyJhbGciOi.fake.value" },
       });
-      assertEquals(isProxyTrusted(req), true);
+      assertEquals(await isProxyTrusted(req, { publicKeyPem }), false);
     });
 
-    it("returns true when x-veryfront-dispatch-jws header is present with empty string value", () => {
-      // Header presence is sufficient — the JWS is validated elsewhere.
+    it("rejects an empty dispatch JWS header value", async () => {
+      const { publicKeyPem } = await mintDispatchJws();
       const req = new Request("http://example.com/", {
         headers: { "x-veryfront-dispatch-jws": "" },
       });
-      assertEquals(isProxyTrusted(req), true);
+      assertEquals(await isProxyTrusted(req, { publicKeyPem }), false);
     });
 
-    it("is case-insensitive on the dispatch JWS header name", () => {
-      const req = new Request("http://example.com/", {
-        headers: { "X-Veryfront-Dispatch-JWS": "value" },
+    it("rejects a dispatch JWS signed by a different key (spoofed signature)", async () => {
+      const attackerKeyPair = (await crypto.subtle.generateKey(
+        "Ed25519",
+        true,
+        ["sign", "verify"],
+      )) as CryptoKeyPair;
+      const trustedKeyPair = (await crypto.subtle.generateKey(
+        "Ed25519",
+        true,
+        ["sign", "verify"],
+      )) as CryptoKeyPair;
+      const { jws } = await mintDispatchJws({
+        signingKeyPair: attackerKeyPair,
+        advertisedPublicKeyPair: trustedKeyPair,
       });
-      assertEquals(isProxyTrusted(req), true);
+      const publicKeyPem = encodePem(
+        "PUBLIC KEY",
+        await crypto.subtle.exportKey("spki", trustedKeyPair.publicKey),
+      );
+      const req = new Request("http://example.com/", {
+        headers: { "x-veryfront-dispatch-jws": jws },
+      });
+      assertEquals(await isProxyTrusted(req, { publicKeyPem }), false);
     });
 
-    it('returns true when VERYFRONT_TRUST_FORWARDED_HEADERS === "1"', () => {
+    it("rejects an expired dispatch JWS", async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const { jws, publicKeyPem } = await mintDispatchJws({
+        iat: now - 120,
+        exp: now - 60,
+      });
+      const req = new Request("http://example.com/", {
+        headers: { "x-veryfront-dispatch-jws": jws },
+      });
+      assertEquals(await isProxyTrusted(req, { publicKeyPem }), false);
+    });
+
+    it("rejects a dispatch JWS issued too long ago", async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const { jws, publicKeyPem } = await mintDispatchJws({
+        iat: now - 3600,
+        exp: now + 60,
+      });
+      const req = new Request("http://example.com/", {
+        headers: { "x-veryfront-dispatch-jws": jws },
+      });
+      assertEquals(await isProxyTrusted(req, { publicKeyPem }), false);
+    });
+
+    it("is case-insensitive on the dispatch JWS header name", async () => {
+      const { jws, publicKeyPem } = await mintDispatchJws();
+      const req = new Request("http://example.com/", {
+        headers: { "X-Veryfront-Dispatch-JWS": jws },
+      });
+      assertEquals(await isProxyTrusted(req, { publicKeyPem }), true);
+    });
+
+    it('returns true when VERYFRONT_TRUST_FORWARDED_HEADERS === "1"', async () => {
       Deno.env.set(ENV_KEY, "1");
       const req = new Request("http://example.com/");
-      assertEquals(isProxyTrusted(req), true);
+      assertEquals(await isProxyTrusted(req), true);
     });
 
-    it('returns false when env value is "true" (strict === "1" only)', () => {
+    it('returns false when env value is "true" (strict === "1" only)', async () => {
       Deno.env.set(ENV_KEY, "true");
       const req = new Request("http://example.com/");
-      assertEquals(isProxyTrusted(req), false);
+      assertEquals(await isProxyTrusted(req), false);
     });
 
-    it('returns false when env value is "0"', () => {
+    it('returns false when env value is "0"', async () => {
       Deno.env.set(ENV_KEY, "0");
       const req = new Request("http://example.com/");
-      assertEquals(isProxyTrusted(req), false);
+      assertEquals(await isProxyTrusted(req), false);
     });
 
-    it("returns false when env value is an empty string", () => {
+    it("returns false when env value is an empty string", async () => {
       Deno.env.set(ENV_KEY, "");
       const req = new Request("http://example.com/");
-      assertEquals(isProxyTrusted(req), false);
+      assertEquals(await isProxyTrusted(req), false);
     });
 
-    it('returns false when env value has whitespace around "1" (strict match)', () => {
+    it('returns false when env value has whitespace around "1" (strict match)', async () => {
       // Fail-closed: misconfiguration should not accidentally enable trust.
       Deno.env.set(ENV_KEY, " 1 ");
       const req = new Request("http://example.com/");
-      assertEquals(isProxyTrusted(req), false);
+      assertEquals(await isProxyTrusted(req), false);
     });
 
-    it("returns false when env var is unset", () => {
+    it("returns false when env var is unset and no JWS is presented", async () => {
       // beforeEach already deleted it; this documents the default posture.
       const req = new Request("http://example.com/");
-      assertEquals(isProxyTrusted(req), false);
+      assertEquals(await isProxyTrusted(req), false);
     });
 
-    it("returns true when both env opt-in and dispatch header are present", () => {
+    it("env opt-in short-circuits the JWS check entirely", async () => {
+      // Operator opt-in wins even when a bogus header is present — useful for
+      // environments where the operator has another upstream trust boundary.
       Deno.env.set(ENV_KEY, "1");
       const req = new Request("http://example.com/", {
         headers: { "x-veryfront-dispatch-jws": "anything" },
       });
-      assertEquals(isProxyTrusted(req), true);
+      assertEquals(await isProxyTrusted(req), true);
     });
   });
 });

--- a/src/server/utils/proxy-trust.test.ts
+++ b/src/server/utils/proxy-trust.test.ts
@@ -16,6 +16,7 @@ async function mintDispatchJws(
   overrides: Partial<{
     iat: number;
     exp: number;
+    issuer: string;
     audience: string;
     projectId: string;
     signingKeyPair: CryptoKeyPair;
@@ -35,7 +36,7 @@ async function mintDispatchJws(
   const now = Math.floor(Date.now() / 1000);
   const header = { alg: "EdDSA", typ: "JWT" };
   const claims = {
-    iss: "veryfront-api",
+    iss: overrides.issuer ?? "veryfront-api",
     aud: overrides.audience ?? "demo-project",
     sub: "dispatch-proxy-trust",
     project_id: overrides.projectId ?? "proj-1",
@@ -133,6 +134,17 @@ describe("server/utils/proxy-trust", () => {
         "PUBLIC KEY",
         await crypto.subtle.exportKey("spki", trustedKeyPair.publicKey),
       );
+      const req = new Request("http://example.com/", {
+        headers: { "x-veryfront-dispatch-jws": jws },
+      });
+      assertEquals(await isProxyTrusted(req, { publicKeyPem }), false);
+    });
+
+    it("rejects a dispatch JWS whose issuer is not veryfront-api", async () => {
+      // Even with a correctly-signed token, an attacker-controlled issuer (e.g.
+      // a stray key that ended up in CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY during
+      // rotation) must not be accepted as a proxy-trust signal.
+      const { jws, publicKeyPem } = await mintDispatchJws({ issuer: "attacker" });
       const req = new Request("http://example.com/", {
         headers: { "x-veryfront-dispatch-jws": jws },
       });

--- a/src/server/utils/proxy-trust.ts
+++ b/src/server/utils/proxy-trust.ts
@@ -1,0 +1,27 @@
+/**
+ * Proxy trust boundary.
+ *
+ * Forwarded headers such as `x-forwarded-host` and `x-project-path` must only be
+ * honoured when the request is known to come from a trusted upstream proxy.
+ * Any other treatment lets an attacker reaching the runtime directly spoof the
+ * origin host or point project discovery at arbitrary filesystem paths.
+ *
+ * A request is considered proxy-trusted when either:
+ *   1. The operator has opted in via `VERYFRONT_TRUST_FORWARDED_HEADERS=1`
+ *      (strict "1" match — "true", "yes", whitespace-padded values do NOT count
+ *      so misconfiguration fails closed); or
+ *   2. The request carries an `x-veryfront-dispatch-jws` header — a presence
+ *      signal minted by the control plane and stripped by any sane edge. We
+ *      only inspect presence here (not validity) because the signature is
+ *      validated elsewhere and a bare-metal attacker can't usefully fake the
+ *      header without also being able to fake the signature.
+ *
+ * @module server/utils/proxy-trust
+ */
+
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
+
+export function isProxyTrusted(req: Request): boolean {
+  if (getHostEnv("VERYFRONT_TRUST_FORWARDED_HEADERS") === "1") return true;
+  return req.headers.has("x-veryfront-dispatch-jws");
+}

--- a/src/server/utils/proxy-trust.ts
+++ b/src/server/utils/proxy-trust.ts
@@ -10,18 +10,47 @@
  *   1. The operator has opted in via `VERYFRONT_TRUST_FORWARDED_HEADERS=1`
  *      (strict "1" match — "true", "yes", whitespace-padded values do NOT count
  *      so misconfiguration fails closed); or
- *   2. The request carries an `x-veryfront-dispatch-jws` header — a presence
- *      signal minted by the control plane and stripped by any sane edge. We
- *      only inspect presence here (not validity) because the signature is
- *      validated elsewhere and a bare-metal attacker can't usefully fake the
- *      header without also being able to fake the signature.
+ *   2. The request carries a valid `x-veryfront-dispatch-jws` header that
+ *      cryptographically verifies against the configured control-plane public
+ *      key and whose `iat`/`exp` claims are within the allowed freshness
+ *      window. Presence alone is NOT trusted because the proxy does not strip
+ *      this header from untrusted inbound requests (it has to pass through to
+ *      the channel-invoke / channel-assistants handlers unchanged), so a
+ *      direct-access attacker could otherwise set any value and promote
+ *      forwarded-header spoofing.
  *
  * @module server/utils/proxy-trust
  */
 
+import { verifyDispatchJwsSignature } from "#veryfront/channels/control-plane.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 
-export function isProxyTrusted(req: Request): boolean {
+const DISPATCH_JWS_HEADER = "x-veryfront-dispatch-jws";
+const MAX_DISPATCH_SIGNATURE_AGE_SECONDS = 60;
+
+export interface ProxyTrustOptions {
+  /**
+   * PEM-encoded Ed25519 public key used to verify `x-veryfront-dispatch-jws`.
+   * When absent, the dispatch-JWS trust signal is disabled (fails closed) and
+   * only the operator opt-in env var can unlock proxy trust.
+   */
+  publicKeyPem?: string;
+}
+
+export async function isProxyTrusted(
+  req: Request,
+  options: ProxyTrustOptions = {},
+): Promise<boolean> {
   if (getHostEnv("VERYFRONT_TRUST_FORWARDED_HEADERS") === "1") return true;
-  return req.headers.has("x-veryfront-dispatch-jws");
+
+  const jws = req.headers.get(DISPATCH_JWS_HEADER);
+  if (!jws) return false;
+
+  const { publicKeyPem } = options;
+  if (!publicKeyPem) return false;
+
+  return verifyDispatchJwsSignature(jws, {
+    publicKeyPem,
+    maxAgeSeconds: MAX_DISPATCH_SIGNATURE_AGE_SECONDS,
+  });
 }

--- a/tests/integration/server/modules/hmr-handler.test.ts
+++ b/tests/integration/server/modules/hmr-handler.test.ts
@@ -200,13 +200,45 @@ describe("HMR Handler Tests", { sanitizeOps: false, sanitizeResources: false }, 
       assertEquals(result.response.status, 200);
     });
 
-    it("prefers x-forwarded-host over host when allowing local preview traffic", async () => {
+    it("IGNORES x-forwarded-host when the request is NOT proxy-trusted (VULN-SRV-4)", async () => {
+      // Without a trusted-proxy signal the handler MUST NOT honour x-forwarded-host
+      // — otherwise any remote client could claim `x-forwarded-host: preview.veryfront.me`
+      // and unlock HMR on a production deployment. The raw Host header ("internal.proxy")
+      // is non-local, so the handler should decline.
       const handler = new HMRHandler();
 
-      const req = new Request("http://localhost:3000/_ws", {
+      const req = new Request("http://internal.proxy:3000/_ws", {
         headers: {
           host: "internal.proxy:3000",
           "x-forwarded-host": "preview.veryfront.me:3000",
+        },
+      });
+      const ctx = {
+        requestContext: { mode: "production" },
+        projectDir: "/tmp/test",
+        securityConfig: null,
+        cspUserHeader: null,
+        adapter: { fs: {}, server: null },
+      } as unknown as Parameters<typeof handler.handle>[1];
+
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
+    });
+
+    it("HONOURS x-forwarded-host when the request IS proxy-trusted (dispatch JWS present)", async () => {
+      // With the dispatch-JWS signal the request demonstrably came through the
+      // Veryfront fronting proxy, so the forwarded host is safe to consult. The
+      // preview.veryfront.me host is a recognised local preview surface and the
+      // handler must enter the HMR path.
+      const handler = new HMRHandler();
+
+      const req = new Request("http://internal.proxy:3000/_ws", {
+        headers: {
+          host: "internal.proxy:3000",
+          "x-forwarded-host": "preview.veryfront.me:3000",
+          "x-veryfront-dispatch-jws": "test-jws",
         },
       });
       const ctx = {
@@ -223,13 +255,16 @@ describe("HMR Handler Tests", { sanitizeOps: false, sanitizeResources: false }, 
       assertEquals(result.response.status, 200);
     });
 
-    it("rejects localhost host-header bypass when x-forwarded-host is external", async () => {
+    it("rejects x-forwarded-host spoof that tries to unlock localhost without proxy trust", async () => {
+      // Regression for VULN-SRV-4: a remote client setting x-forwarded-host: localhost
+      // against a public runtime must NOT enable HMR. The handler falls back to the raw
+      // Host ("evil.example.com"), which is non-local, so the request is declined.
       const handler = new HMRHandler();
 
-      const req = new Request("http://localhost:3000/_ws", {
+      const req = new Request("http://evil.example.com/_ws", {
         headers: {
-          host: "localhost:3000",
-          "x-forwarded-host": "evil.example.com",
+          host: "evil.example.com",
+          "x-forwarded-host": "localhost",
         },
       });
       const ctx = {

--- a/tests/integration/server/modules/hmr-handler.test.ts
+++ b/tests/integration/server/modules/hmr-handler.test.ts
@@ -2,7 +2,7 @@
 (globalThis as Record<string, unknown>).__vfDisableLruInterval = true;
 
 import { assert, assertEquals, assertExists } from "#veryfront/testing/assert";
-import { afterAll, afterEach, beforeAll, describe, it } from "#veryfront/testing/bdd";
+import { afterAll, afterEach, describe, it } from "#veryfront/testing/bdd";
 import { HMRHandler } from "../../../../src/server/handlers/preview/hmr.handler.ts";
 import { ReloadNotifier } from "../../../../src/server/reload-notifier.ts";
 import { broadcastUpdate } from "../../../../src/server/handlers/preview/hmr-message-router.ts";

--- a/tests/integration/server/modules/hmr-handler.test.ts
+++ b/tests/integration/server/modules/hmr-handler.test.ts
@@ -2,7 +2,7 @@
 (globalThis as Record<string, unknown>).__vfDisableLruInterval = true;
 
 import { assert, assertEquals, assertExists } from "#veryfront/testing/assert";
-import { afterAll, afterEach, describe, it } from "#veryfront/testing/bdd";
+import { afterAll, afterEach, beforeAll, describe, it } from "#veryfront/testing/bdd";
 import { HMRHandler } from "../../../../src/server/handlers/preview/hmr.handler.ts";
 import { ReloadNotifier } from "../../../../src/server/reload-notifier.ts";
 import { broadcastUpdate } from "../../../../src/server/handlers/preview/hmr-message-router.ts";
@@ -13,6 +13,67 @@ import {
   HMR_MAX_MESSAGE_SIZE_BYTES,
   HMR_MAX_MESSAGES_PER_MINUTE,
 } from "#veryfront/utils";
+import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+
+const encoder = new TextEncoder();
+
+let trustedSigningKeyPair: CryptoKeyPair;
+let trustedPublicKeyPem: string;
+
+function encodePem(label: string, der: ArrayBuffer): string {
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = base64.match(/.{1,64}/g) ?? [base64];
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
+}
+
+async function ensureKeyMaterial(): Promise<void> {
+  if (trustedPublicKeyPem) return;
+  trustedSigningKeyPair = (await crypto.subtle.generateKey(
+    "Ed25519",
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const der = await crypto.subtle.exportKey("spki", trustedSigningKeyPair.publicKey);
+  trustedPublicKeyPem = encodePem("PUBLIC KEY", der);
+}
+
+async function mintTrustedDispatchJws(): Promise<string> {
+  await ensureKeyMaterial();
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "EdDSA", typ: "JWT" };
+  const claims = {
+    iss: "veryfront-api",
+    aud: "demo-project",
+    sub: "dispatch-hmr-test",
+    project_id: "proj-1",
+    platform: "slack",
+    body_sha256: "n/a",
+    iat: now,
+    exp: now + 60,
+  };
+  const encodedHeader = base64urlEncode(JSON.stringify(header));
+  const encodedPayload = base64urlEncode(JSON.stringify(claims));
+  const signingInput = encoder.encode(`${encodedHeader}.${encodedPayload}`);
+  const signature = await crypto.subtle.sign(
+    "Ed25519",
+    trustedSigningKeyPair.privateKey,
+    signingInput,
+  );
+  return `${encodedHeader}.${encodedPayload}.${base64urlEncodeBytes(new Uint8Array(signature))}`;
+}
+
+function adapterEnv() {
+  return {
+    fs: {},
+    server: null,
+    env: {
+      get(key: string) {
+        if (key === "CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY") return trustedPublicKeyPem;
+        return undefined;
+      },
+    },
+  };
+}
 
 function createMockSocket() {
   const listeners = new Map<string, Set<(event?: unknown) => void>>();
@@ -227,18 +288,19 @@ describe("HMR Handler Tests", { sanitizeOps: false, sanitizeResources: false }, 
       assertEquals(result.response, undefined);
     });
 
-    it("HONOURS x-forwarded-host when the request IS proxy-trusted (dispatch JWS present)", async () => {
-      // With the dispatch-JWS signal the request demonstrably came through the
-      // Veryfront fronting proxy, so the forwarded host is safe to consult. The
-      // preview.veryfront.me host is a recognised local preview surface and the
-      // handler must enter the HMR path.
+    it("HONOURS x-forwarded-host when the request IS proxy-trusted (valid dispatch JWS)", async () => {
+      // With a cryptographically-verified dispatch-JWS signal, the request
+      // demonstrably came through the Veryfront fronting proxy, so the forwarded
+      // host is safe to consult. The preview.veryfront.me host is a recognised
+      // local preview surface and the handler must enter the HMR path.
       const handler = new HMRHandler();
+      const jws = await mintTrustedDispatchJws();
 
       const req = new Request("http://internal.proxy:3000/_ws", {
         headers: {
           host: "internal.proxy:3000",
           "x-forwarded-host": "preview.veryfront.me:3000",
-          "x-veryfront-dispatch-jws": "test-jws",
+          "x-veryfront-dispatch-jws": jws,
         },
       });
       const ctx = {
@@ -246,13 +308,43 @@ describe("HMR Handler Tests", { sanitizeOps: false, sanitizeResources: false }, 
         projectDir: "/tmp/test",
         securityConfig: null,
         cspUserHeader: null,
-        adapter: { fs: {}, server: null },
+        adapter: adapterEnv(),
       } as unknown as Parameters<typeof handler.handle>[1];
 
       const result = await handler.handle(req, ctx);
 
       assertExists(result.response);
       assertEquals(result.response.status, 200);
+    });
+
+    it("IGNORES x-forwarded-host when dispatch JWS is present but unverifiable (Codex P1 regression)", async () => {
+      // Regression for Codex P1 on PR #1116: mere presence of `x-veryfront-dispatch-jws`
+      // must NOT be treated as proof of proxy trust. Since the proxy does not strip
+      // this header on ingress, an attacker reaching the runtime directly could
+      // attach any value and unlock x-forwarded-host handling. Only a crypto-verified
+      // JWS counts as a trust signal.
+      await ensureKeyMaterial();
+      const handler = new HMRHandler();
+
+      const req = new Request("http://internal.proxy:3000/_ws", {
+        headers: {
+          host: "internal.proxy:3000",
+          "x-forwarded-host": "preview.veryfront.me:3000",
+          "x-veryfront-dispatch-jws": "attacker-supplied.bogus.value",
+        },
+      });
+      const ctx = {
+        requestContext: { mode: "production" },
+        projectDir: "/tmp/test",
+        securityConfig: null,
+        cspUserHeader: null,
+        adapter: adapterEnv(),
+      } as unknown as Parameters<typeof handler.handle>[1];
+
+      const result = await handler.handle(req, ctx);
+
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
     });
 
     it("rejects x-forwarded-host spoof that tries to unlock localhost without proxy trust", async () => {


### PR DESCRIPTION
## Summary

PR 3 of `plans/security-audit-17.4.2026.md`. **Depends on PR 2.**

Fixes **VULN-SRV-3** and **VULN-SRV-4** — `x-project-path` and `x-forwarded-host` were read unconditionally. An attacker reaching the runtime directly could aim the project root at another directory (LFI via `/_veryfront/fs/...`) or bypass the HMR localhost check with `x-forwarded-host: localhost`.

## Fix

- New `src/server/utils/proxy-trust.ts` — `isProxyTrusted(req, { publicKeyPem })` returns true only when the `x-veryfront-dispatch-jws` header carries a **cryptographically verified** Ed25519 signature (fresh within 60s, `iss === "veryfront-api"`), or when `VERYFRONT_TRUST_FORWARDED_HEADERS=1` (strict match) is set.
- New `verifyDispatchJwsSignature` helper in `src/channels/control-plane.ts` — signature + `iat`/`exp` + issuer check, without binding to a specific request body or audience (used only as a trust signal; request-bound callers must still use `verifyDispatchJws`).
- `adapter-factory.ts` gates `x-project-path` on `isProxyTrusted`.
- `hmr.handler.ts` uses raw `Host` unless the request is proxy-trusted.
- `CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY` is read from `adapter.env.get()` with `getHostEnv()` fallback; **fail-closed** when no key is configured.

### Why cryptographic verification (not just header presence)

The proxy does **not** strip `x-veryfront-dispatch-jws` on ingress (it is in `INTERNAL_CONTROL_PLANE_SIGNATURE_HEADERS`, not `INTERNAL_PROXY_HEADERS`). Treating mere presence as a trust signal would let any client attach an arbitrary value and unlock the forwarded-header path. Only an Ed25519-verified JWS counts.

## Release note

Deployments **not** behind the Veryfront fronting proxy must set `VERYFRONT_TRUST_FORWARDED_HEADERS=1`. Deployments behind the proxy must configure `CHANNEL_DISPATCH_SIGNING_PUBLIC_KEY` with the control-plane's public key PEM — without it, forwarded headers are always rejected (including legitimate dispatches).

## Test plan

- [x] `deno test src/server/utils/proxy-trust.test.ts` — valid / bogus / spoofed-signature / expired / too-old / wrong-issuer / missing-key / case-insensitive / strict-env regressions
- [x] `deno test src/server/runtime-handler/adapter-factory.test.ts` — `x-project-path` ignored without verified JWS (Codex P1 regression)
- [x] `deno test src/server/handlers/preview/hmr.handler.test.ts` + `tests/integration/server/modules/hmr-handler.test.ts` — `x-forwarded-host: localhost` rejected without verified JWS (Codex P1 regression)

## Known follow-up (out of scope)

`createRequestContext` derives `mode: "preview"` from `x-forwarded-host` and the `x-environment` query parameter unconditionally. This predates PR #1116 and is relied on by the preview-iframe HMR flow (see existing test `"handle accepts preview via query param (for proxy WebSocket)"`). Gating it on proxy trust is a separate, larger change and does not affect the VULN-SRV-3/4 fix.
