### PR TITLE
fix(security): JSON-encode pathname in RSC page handler to block reflected XSS (VULN-INJ-1)

### DIFF
--- a/src/server/services/rsc/orchestrators/page-handler.test.ts
+++ b/src/server/services/rsc/orchestrators/page-handler.test.ts
@@ -89,4 +89,287 @@ describe("server/services/rsc/orchestrators/page-handler", () => {
       assertEquals(html.includes("</html>"), true);
     });
   });
+
+  describe("reflected XSS hardening (VULN-INJ-1)", () => {
+    it("should not allow single-quote pathname to break out of the JS string literal", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/x';alert(1);//", new URLSearchParams());
+      const html = await response.text();
+      // The known-bad pattern: the original code emitted
+      //   const renderUrl = '/_veryfront/rsc/renderx';alert(1);//';
+      // which closes the single-quoted JS string literal and executes alert(1).
+      assertEquals(
+        html.includes("'/_veryfront/rsc/renderx';alert(1);//'"),
+        false,
+        "unescaped single quote leaked into inline script",
+      );
+      // The exploit payload `;alert(1);//` must only appear as inert characters
+      // *inside* the JSON string, never as JS tokens after a closing quote.
+      assertEquals(
+        /=\s*'[^']*';alert\(1\)/.test(html),
+        false,
+        "alert(1) payload escaped the JSON string literal",
+      );
+      assertEquals(
+        /=\s*"[^"]*";\s*alert\(1\)/.test(html),
+        false,
+        "alert(1) payload escaped the JSON string literal (double-quoted)",
+      );
+    });
+
+    it("should not allow </script> injection to break out of the inline <script> block", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle(
+        "/a</script><script>alert(2)</script>",
+        new URLSearchParams(),
+      );
+      const html = await response.text();
+      // The injected `</script>` (literal lowercase with no leading backslash)
+      // must not appear on the renderUrl assignment line - the `<` must be
+      // encoded as \u003c inside the JSON string.
+      const renderUrlLine = html
+        .split("\n")
+        .find((line) => line.includes("const renderUrl ="));
+      assertEquals(renderUrlLine !== undefined, true);
+      assertEquals(
+        renderUrlLine!.includes("</script>"),
+        false,
+        "</script> must not appear on the renderUrl line",
+      );
+      assertEquals(
+        renderUrlLine!.includes("<script>"),
+        false,
+        "<script> must not appear on the renderUrl line",
+      );
+    });
+
+    it("should defeat </SCRIPT > case/space variants used by browser parsers", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle(
+        "/a</SCRIPT ><script>alert('case')</script>",
+        new URLSearchParams(),
+      );
+      const html = await response.text();
+      const renderUrlLine = html
+        .split("\n")
+        .find((line) => line.includes("const renderUrl ="));
+      assertEquals(renderUrlLine !== undefined, true);
+      // Case-insensitive check: no `</script...` variant may appear on the
+      // renderUrl line since `<` is `\u003c`.
+      assertEquals(
+        /<\/script/i.test(renderUrlLine!),
+        false,
+        "case-variant </SCRIPT must not appear on the renderUrl line",
+      );
+    });
+
+    it("should defeat <ScRiPt> mixed-case breakout attempts", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle(
+        "/a<ScRiPt>alert('mixed')</ScRiPt>",
+        new URLSearchParams(),
+      );
+      const html = await response.text();
+      const renderUrlLine = html
+        .split("\n")
+        .find((line) => line.includes("const renderUrl ="));
+      assertEquals(renderUrlLine !== undefined, true);
+      // No additional `<script...` opening tags (any case) on the renderUrl line.
+      assertEquals(
+        /<script/i.test(renderUrlLine!),
+        false,
+        "mixed-case <ScRiPt> must not appear on the renderUrl line",
+      );
+    });
+
+    it("should block <!--<script> HTML comment breakout attempts", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle(
+        "/a<!--<script>alert('comment')</script>",
+        new URLSearchParams(),
+      );
+      const html = await response.text();
+      // The only `<!--` tokens allowed are inside our own comments (we emit none
+      // in this template). Inside the JSON-encoded renderUrl string, `<` must
+      // be encoded as \u003c so `<!--` cannot appear literally.
+      assertEquals(
+        html.includes("<!--"),
+        false,
+        "raw <!-- HTML comment must not appear in output",
+      );
+      // And the injected `<script>` opener must not appear on the renderUrl line.
+      const renderUrlLine = html
+        .split("\n")
+        .find((line) => line.includes("const renderUrl ="));
+      assertEquals(renderUrlLine !== undefined, true);
+      assertEquals(
+        /<script/i.test(renderUrlLine!),
+        false,
+        "<script breakout must not appear on the renderUrl line",
+      );
+    });
+
+    it("should escape U+2028 as \\u2028 (JS line terminator in older browsers)", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/a\u2028b", new URLSearchParams());
+      const html = await response.text();
+      assertEquals(
+        html.includes("\u2028"),
+        false,
+        "raw U+2028 must be escaped in inline <script>",
+      );
+      assertEquals(html.includes("\\u2028"), true, "U+2028 should render as \\u2028");
+    });
+
+    it("should escape U+2029 as \\u2029 (JS line terminator in older browsers)", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/a\u2029b", new URLSearchParams());
+      const html = await response.text();
+      assertEquals(
+        html.includes("\u2029"),
+        false,
+        "raw U+2029 must be escaped in inline <script>",
+      );
+      assertEquals(html.includes("\\u2029"), true, "U+2029 should render as \\u2029");
+    });
+
+    it("should encode & as \\u0026 in the inline script (defense-in-depth)", async () => {
+      const handler = new PageHandler();
+      const params = new URLSearchParams({ a: "1&evil" });
+      const response = handler.handle("/p&q", params);
+      const html = await response.text();
+      // Extract the inline <script type="module"> body (best-effort).
+      const scriptStart = html.indexOf('<script type="module"');
+      const scriptBody = html.slice(scriptStart);
+      const endIdx = scriptBody.indexOf("</script>");
+      const inlineBody = scriptBody.slice(0, endIdx);
+      assertEquals(
+        inlineBody.includes("&"),
+        false,
+        "raw & must not appear inside inline script",
+      );
+      assertEquals(
+        inlineBody.includes("\\u0026"),
+        true,
+        "& should be JSON-encoded as \\u0026",
+      );
+    });
+
+    it("should JSON-encode null bytes without terminating the string", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/a\x00b", new URLSearchParams());
+      const html = await response.text();
+      // JSON encodes NUL as \u0000; no raw NUL in the body.
+      assertEquals(html.includes("\x00"), false, "raw NUL byte leaked into HTML");
+      assertEquals(html.includes("\\u0000"), true, "NUL should render as \\u0000");
+    });
+
+    it("should keep backslashes inside the JSON string literal", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/a\\b'c", new URLSearchParams());
+      const html = await response.text();
+      // Backslash must be doubled so the JS literal is still valid.
+      assertEquals(
+        html.includes("\\\\"),
+        true,
+        "backslash should be escaped as \\\\ inside the JSON literal",
+      );
+      // The renderUrl must be enclosed in a double-quoted JSON string (JSON
+      // never uses single quotes), preventing the lone `'` from breaking out.
+      const renderUrlLine = html
+        .split("\n")
+        .find((line) => line.includes("const renderUrl ="));
+      assertEquals(renderUrlLine !== undefined, true);
+      assertEquals(
+        renderUrlLine!.includes("\""),
+        true,
+        "renderUrl line must use double quotes (JSON literal)",
+      );
+    });
+
+    it("should escape newline and carriage return in the pathname", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/a\r\nalert(4)", new URLSearchParams());
+      const html = await response.text();
+      const scriptStart = html.indexOf('<script type="module"');
+      const scriptBody = html.slice(scriptStart);
+      const endIdx = scriptBody.indexOf("</script>");
+      const inlineBody = scriptBody.slice(0, endIdx);
+      // Raw CR/LF would terminate a JS string literal.
+      assertEquals(inlineBody.includes("\r"), false, "raw CR leaked into inline script");
+      // The JSON-encoded URL must contain the escapes.
+      assertEquals(inlineBody.includes("\\r"), true, "CR should be escaped as \\r");
+      assertEquals(inlineBody.includes("\\n"), true, "LF should be escaped as \\n");
+    });
+
+    it("should render unicode/emoji pathnames without corruption", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/hello-\u{1F600}", new URLSearchParams());
+      const html = await response.text();
+      // The emoji should round-trip (either literal or JSON \uXXXX surrogate pair).
+      const hasLiteral = html.includes("\u{1F600}");
+      const hasEscaped = html.includes("\\ud83d\\ude00") || html.includes("\\uD83D\\uDE00");
+      assertEquals(
+        hasLiteral || hasEscaped,
+        true,
+        "emoji pathname should round-trip (literal or JSON-escaped)",
+      );
+      // And the document must still be valid.
+      assertEquals(html.startsWith("<!DOCTYPE html>"), true);
+    });
+
+    it("should render an empty pathname without producing broken script", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle("", new URLSearchParams());
+      const html = await response.text();
+      assertEquals(html.startsWith("<!DOCTYPE html>"), true);
+      // The URL should be the JSON-encoded empty-path variant.
+      assertEquals(
+        html.includes('"/_veryfront/rsc/render"'),
+        true,
+        "empty pathname should produce a bare render URL",
+      );
+    });
+
+    it("should JSON-encode a malicious query string", async () => {
+      const handler = new PageHandler();
+      // URLSearchParams percent-encodes most things, but let's stress the
+      // pipeline end-to-end: the rendered string must not contain raw '.
+      const params = new URLSearchParams();
+      params.set("q", "';alert(5);//");
+      const response = handler.handle("/page", params);
+      const html = await response.text();
+      const scriptStart = html.indexOf('<script type="module"');
+      const scriptBody = html.slice(scriptStart);
+      const endIdx = scriptBody.indexOf("</script>");
+      const inlineBody = scriptBody.slice(0, endIdx);
+      assertEquals(
+        inlineBody.includes("alert(5)"),
+        false,
+        "query-string payload executed outside of JSON-encoded string",
+      );
+      // Whatever URLSearchParams produced, it must live inside a quoted JSON string.
+      assertEquals(
+        /renderUrl\s*=\s*"/.test(inlineBody),
+        true,
+        "renderUrl must be assigned from a double-quoted JSON string literal",
+      );
+    });
+
+    it("should assign renderUrl from a JSON string (double quotes), not a single-quoted literal", async () => {
+      const handler = new PageHandler();
+      const response = handler.handle("/ok", new URLSearchParams());
+      const html = await response.text();
+      assertEquals(
+        /const\s+renderUrl\s*=\s*'/.test(html),
+        false,
+        "single-quoted renderUrl literal is the known-bad pattern",
+      );
+      assertEquals(
+        /const\s+renderUrl\s*=\s*"[^"]*";/.test(html),
+        true,
+        "renderUrl should be a double-quoted JSON string",
+      );
+    });
+  });
 });

--- a/src/server/services/rsc/orchestrators/page-handler.test.ts
+++ b/src/server/services/rsc/orchestrators/page-handler.test.ts
@@ -281,7 +281,7 @@ describe("server/services/rsc/orchestrators/page-handler", () => {
         .find((line) => line.includes("const renderUrl ="));
       assertEquals(renderUrlLine !== undefined, true);
       assertEquals(
-        renderUrlLine!.includes("\""),
+        renderUrlLine!.includes('"'),
         true,
         "renderUrl line must use double quotes (JSON literal)",
       );

--- a/src/server/services/rsc/orchestrators/page-handler.ts
+++ b/src/server/services/rsc/orchestrators/page-handler.ts
@@ -1,5 +1,26 @@
 import { buildNonceAttribute } from "#veryfront/html/html-escape.ts";
 
+/**
+ * Serialize a value as a JSON string literal that is safe to embed inside an
+ * inline HTML <script>. JSON already escapes quotes, backslashes, and control
+ * characters; we additionally escape:
+ *   - `<` / `>` so `</script>`, `<!--`, and `<script` cannot appear literally,
+ *   - `&` as defense-in-depth against reparsing contexts (e.g. HTML entity
+ *     re-decoding in some legacy paths),
+ *   - U+2028 / U+2029 which are valid JSON but terminate JS string literals
+ *     in older browsers.
+ *
+ * See VULN-INJ-1 in the security audit.
+ */
+function jsonForScript(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
 export class PageHandler {
   handle(pathname: string, searchParams: URLSearchParams, nonce?: string): Response {
     const html = this.buildHtml(pathname, searchParams, nonce);
@@ -13,6 +34,7 @@ export class PageHandler {
     const queryString = searchParams.toString();
     const renderUrl = `/_veryfront/rsc/render${pathname}${queryString ? `?${queryString}` : ""}`;
     const nonceAttr = buildNonceAttribute(nonce);
+    const renderUrlJs = jsonForScript(renderUrl);
 
     return `<!DOCTYPE html>
 <html lang="en">
@@ -61,7 +83,7 @@ export class PageHandler {
     }
 
     (async () => {
-      const renderUrl = '${renderUrl}';
+      const renderUrl = ${renderUrlJs};
       const payload =
         (await fetchPayload(renderUrl)) ??
         (await fetchPayload('/_veryfront/rsc/payload')) ??


### PR DESCRIPTION
## Summary

PR 4 of `plans/security-audit-17.4.2026.md`.

Fixes **VULN-INJ-1** — reflected XSS in `PageHandler`. The inline `<script>` template uses `const renderUrl = '\${renderUrl}';` with the pathname interpolated unescaped. Single-quote/newline/`</script>` terminates the JS string literal; the nonce-carrying inline script executes attacker JS.

## Fix

- Replaces raw interpolation with a `jsonForScript()` helper that JSON-encodes and escapes `<`, `>`, `&`, `U+2028`, `U+2029`.
- Template emits `const renderUrl = <jsonForScript(renderUrl)>;`.
- Adds tests for single-quote and `</script>` in pathname.

## Test plan

- [x] `deno test src/server/services/rsc/orchestrators/page-handler.test.ts`
- [x] Manually hit `/_veryfront/rsc/page/x';alert(1);//` and verify no execution