### PR TITLE
fix(security)!: require auth on OAuth init; key tokens by (serviceId, userId) (VULN-AUTH-2)

### DIFF
--- a/cli/templates/integrations/airtable/files/app/api/auth/airtable/callback/route.ts
+++ b/cli/templates/integrations/airtable/files/app/api/auth/airtable/callback/route.ts
@@ -2,31 +2,35 @@ import { airtableConfig, createOAuthCallbackHandler } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/airtable/files/app/api/auth/airtable/route.ts
+++ b/cli/templates/integrations/airtable/files/app/api/auth/airtable/route.ts
@@ -1,6 +1,13 @@
 import { airtableConfig, createOAuthInitHandler } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
 export const GET = createOAuthInitHandler(airtableConfig, {
   tokenStore: oauthMemoryTokenStore,
+  getUserId,
 });

--- a/cli/templates/integrations/asana/files/app/api/auth/asana/callback/route.ts
+++ b/cli/templates/integrations/asana/files/app/api/auth/asana/callback/route.ts
@@ -2,31 +2,35 @@ import { asanaConfig, createOAuthCallbackHandler } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/asana/files/app/api/auth/asana/route.ts
+++ b/cli/templates/integrations/asana/files/app/api/auth/asana/route.ts
@@ -1,4 +1,13 @@
 import { asanaConfig, createOAuthInitHandler } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(asanaConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(asanaConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/bitbucket/files/app/api/auth/bitbucket/callback/route.ts
+++ b/cli/templates/integrations/bitbucket/files/app/api/auth/bitbucket/callback/route.ts
@@ -8,24 +8,21 @@ import { bitbucketConfig, createOAuthCallbackHandler } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  async getTokens(serviceId: string): Promise<unknown> {
-    return tokenStore.getToken(USER_ID, serviceId);
+  async getTokens(serviceId: string, userId: string): Promise<unknown> {
+    return tokenStore.getToken(userId, serviceId);
   },
 
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ): Promise<void> {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
 
-  async clearTokens(serviceId: string): Promise<void> {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string): Promise<void> {
+    await tokenStore.revokeToken(userId, serviceId);
   },
 
   getState(state: string): unknown {

--- a/cli/templates/integrations/bitbucket/files/app/api/auth/bitbucket/callback/route.ts
+++ b/cli/templates/integrations/bitbucket/files/app/api/auth/bitbucket/callback/route.ts
@@ -9,32 +9,34 @@ import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
 const hybridTokenStore = {
-  async getTokens(serviceId: string, userId: string): Promise<unknown> {
+  getTokens(serviceId: string, userId: string) {
     return tokenStore.getToken(userId, serviceId);
   },
-
   async setTokens(
     serviceId: string,
     userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
-  ): Promise<void> {
+  ) {
     await tokenStore.setToken(userId, serviceId, tokens);
   },
-
-  async clearTokens(serviceId: string, userId: string): Promise<void> {
+  async clearTokens(serviceId: string, userId: string) {
     await tokenStore.revokeToken(userId, serviceId);
   },
-
-  getState(state: string): unknown {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }): unknown {
-    return oauthMemoryTokenStore.setState(state);
-  },
-
-  clearState(state: string): unknown {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/bitbucket/files/app/api/auth/bitbucket/route.ts
+++ b/cli/templates/integrations/bitbucket/files/app/api/auth/bitbucket/route.ts
@@ -1,6 +1,13 @@
 import { bitbucketConfig, createOAuthInitHandler } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
 export const GET = createOAuthInitHandler(bitbucketConfig, {
   tokenStore: oauthMemoryTokenStore,
+  getUserId,
 });

--- a/cli/templates/integrations/box/files/app/api/auth/box/callback/route.ts
+++ b/cli/templates/integrations/box/files/app/api/auth/box/callback/route.ts
@@ -2,31 +2,35 @@ import { boxConfig, createOAuthCallbackHandler } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  async getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  async getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/box/files/app/api/auth/box/route.ts
+++ b/cli/templates/integrations/box/files/app/api/auth/box/route.ts
@@ -1,4 +1,13 @@
 import { boxConfig, createOAuthInitHandler } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(boxConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(boxConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/calendar/files/app/api/auth/calendar/callback/route.ts
+++ b/cli/templates/integrations/calendar/files/app/api/auth/calendar/callback/route.ts
@@ -8,31 +8,35 @@ import { calendarConfig, createOAuthCallbackHandler } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/calendar/files/app/api/auth/calendar/route.ts
+++ b/cli/templates/integrations/calendar/files/app/api/auth/calendar/route.ts
@@ -1,4 +1,13 @@
 import { calendarConfig, createOAuthInitHandler } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(calendarConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(calendarConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/clickup/files/app/api/auth/clickup/callback/route.ts
+++ b/cli/templates/integrations/clickup/files/app/api/auth/clickup/callback/route.ts
@@ -2,31 +2,35 @@ import { clickupConfig, createOAuthCallbackHandler } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/clickup/files/app/api/auth/clickup/route.ts
+++ b/cli/templates/integrations/clickup/files/app/api/auth/clickup/route.ts
@@ -1,4 +1,13 @@
 import { clickupConfig, createOAuthInitHandler } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(clickupConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(clickupConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/confluence/files/app/api/auth/confluence/callback/route.ts
+++ b/cli/templates/integrations/confluence/files/app/api/auth/confluence/callback/route.ts
@@ -2,31 +2,35 @@ import { confluenceConfig, createOAuthCallbackHandler } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/confluence/files/app/api/auth/confluence/route.ts
+++ b/cli/templates/integrations/confluence/files/app/api/auth/confluence/route.ts
@@ -1,6 +1,13 @@
 import { confluenceConfig, createOAuthInitHandler } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
 export const GET = createOAuthInitHandler(confluenceConfig, {
   tokenStore: oauthMemoryTokenStore,
+  getUserId,
 });

--- a/cli/templates/integrations/discord/files/app/api/auth/discord/callback/route.ts
+++ b/cli/templates/integrations/discord/files/app/api/auth/discord/callback/route.ts
@@ -8,13 +8,9 @@ import { createOAuthCallbackHandler, discordConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   setTokens(
     serviceId: string,
@@ -25,14 +21,21 @@ const hybridTokenStore = {
   clearTokens(serviceId: string) {
     return tokenStore.revokeToken(USER_ID, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/discord/files/app/api/auth/discord/callback/route.ts
+++ b/cli/templates/integrations/discord/files/app/api/auth/discord/callback/route.ts
@@ -12,14 +12,15 @@ const hybridTokenStore = {
   getTokens(serviceId: string, userId: string) {
     return tokenStore.getToken(userId, serviceId);
   },
-  setTokens(
+  async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    return tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  clearTokens(serviceId: string) {
-    return tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
   setState(
     state: string,

--- a/cli/templates/integrations/discord/files/app/api/auth/discord/route.ts
+++ b/cli/templates/integrations/discord/files/app/api/auth/discord/route.ts
@@ -1,6 +1,13 @@
 import { createOAuthInitHandler, discordConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
 export const GET = createOAuthInitHandler(discordConfig, {
   tokenStore: oauthMemoryTokenStore,
+  getUserId,
 });

--- a/cli/templates/integrations/docs-google/files/app/api/auth/docs-google/callback/route.ts
+++ b/cli/templates/integrations/docs-google/files/app/api/auth/docs-google/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, docsGoogleConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/docs-google/files/app/api/auth/docs-google/route.ts
+++ b/cli/templates/integrations/docs-google/files/app/api/auth/docs-google/route.ts
@@ -1,6 +1,13 @@
 import { createOAuthInitHandler, docsGoogleConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
 export const GET = createOAuthInitHandler(docsGoogleConfig, {
   tokenStore: oauthMemoryTokenStore,
+  getUserId,
 });

--- a/cli/templates/integrations/drive/files/app/api/auth/drive/callback/route.ts
+++ b/cli/templates/integrations/drive/files/app/api/auth/drive/callback/route.ts
@@ -8,13 +8,9 @@ import { createOAuthCallbackHandler, driveConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   setTokens(
     serviceId: string,
@@ -25,14 +21,21 @@ const hybridTokenStore = {
   clearTokens(serviceId: string) {
     return tokenStore.revokeToken(USER_ID, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/drive/files/app/api/auth/drive/callback/route.ts
+++ b/cli/templates/integrations/drive/files/app/api/auth/drive/callback/route.ts
@@ -12,14 +12,15 @@ const hybridTokenStore = {
   getTokens(serviceId: string, userId: string) {
     return tokenStore.getToken(userId, serviceId);
   },
-  setTokens(
+  async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    return tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  clearTokens(serviceId: string) {
-    return tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
   setState(
     state: string,

--- a/cli/templates/integrations/drive/files/app/api/auth/drive/route.ts
+++ b/cli/templates/integrations/drive/files/app/api/auth/drive/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, driveConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(driveConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(driveConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/dropbox/files/app/api/auth/dropbox/callback/route.ts
+++ b/cli/templates/integrations/dropbox/files/app/api/auth/dropbox/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, dropboxConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/dropbox/files/app/api/auth/dropbox/route.ts
+++ b/cli/templates/integrations/dropbox/files/app/api/auth/dropbox/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, dropboxConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(dropboxConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(dropboxConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/figma/files/app/api/auth/figma/callback/route.ts
+++ b/cli/templates/integrations/figma/files/app/api/auth/figma/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, figmaConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/figma/files/app/api/auth/figma/route.ts
+++ b/cli/templates/integrations/figma/files/app/api/auth/figma/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, figmaConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(figmaConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(figmaConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/freshdesk/files/app/api/auth/freshdesk/callback/route.ts
+++ b/cli/templates/integrations/freshdesk/files/app/api/auth/freshdesk/callback/route.ts
@@ -8,30 +8,34 @@ import { createOAuthCallbackHandler, freshdeskConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
 type Tokens = { accessToken: string; refreshToken?: string; expiresAt?: number };
-type State = { state: string; codeVerifier?: string; createdAt: number };
+type StateMeta = {
+  userId: string;
+  serviceId: string;
+  codeVerifier?: string;
+  redirectUri?: string;
+  scopes?: string[];
+  createdAt: number;
+};
 
 // Hybrid adapter: uses framework's oauthMemoryTokenStore for state (PKCE),
-// but user's tokenStore for actual token storage
+// but user's tokenStore for actual token storage. Tokens are keyed by
+// (serviceId, userId) — NEVER share a single slot across users.
 const hybridTokenStore = {
-  getTokens(serviceId: string): Promise<Tokens | null> {
-    return tokenStore.getToken("current-user", serviceId);
+  getTokens(serviceId: string, userId: string): Promise<Tokens | null> {
+    return tokenStore.getToken(userId, serviceId);
   },
-  async setTokens(serviceId: string, tokens: Tokens): Promise<void> {
-    await tokenStore.setToken("current-user", serviceId, tokens);
+  async setTokens(serviceId: string, userId: string, tokens: Tokens): Promise<void> {
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string): Promise<void> {
-    await tokenStore.revokeToken("current-user", serviceId);
+  async clearTokens(serviceId: string, userId: string): Promise<void> {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string): ReturnType<typeof oauthMemoryTokenStore.getState> {
-    return oauthMemoryTokenStore.getState(state);
+  setState(state: string, meta: StateMeta): ReturnType<typeof oauthMemoryTokenStore.setState> {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(stateObj: State): ReturnType<typeof oauthMemoryTokenStore.setState> {
-    return oauthMemoryTokenStore.setState(stateObj);
-  },
-  clearState(state: string): ReturnType<typeof oauthMemoryTokenStore.clearState> {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string): ReturnType<typeof oauthMemoryTokenStore.consumeState> {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/freshdesk/files/app/api/auth/freshdesk/route.ts
+++ b/cli/templates/integrations/freshdesk/files/app/api/auth/freshdesk/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, freshdeskConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(freshdeskConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(freshdeskConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/github/files/app/api/auth/github/callback/route.ts
+++ b/cli/templates/integrations/github/files/app/api/auth/github/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, githubConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  async getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  async getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/github/files/app/api/auth/github/route.ts
+++ b/cli/templates/integrations/github/files/app/api/auth/github/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, githubConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(githubConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(githubConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/gitlab/files/app/api/auth/gitlab/callback/route.ts
+++ b/cli/templates/integrations/gitlab/files/app/api/auth/gitlab/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, gitlabConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/gitlab/files/app/api/auth/gitlab/route.ts
+++ b/cli/templates/integrations/gitlab/files/app/api/auth/gitlab/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, gitlabConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(gitlabConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(gitlabConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/gmail/files/app/api/auth/gmail/callback/route.ts
+++ b/cli/templates/integrations/gmail/files/app/api/auth/gmail/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, gmailConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/gmail/files/app/api/auth/gmail/route.ts
+++ b/cli/templates/integrations/gmail/files/app/api/auth/gmail/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, gmailConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(gmailConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(gmailConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/gmail/files/lib/gmail-client.ts
+++ b/cli/templates/integrations/gmail/files/lib/gmail-client.ts
@@ -40,29 +40,36 @@ export interface SendEmailOptions {
   isHtml?: boolean;
 }
 
+// TokenStore adapter keyed by (serviceId, userId). All API calls must pass
+// the authenticated user's id — NEVER use a shared "current-user" constant
+// in production; that re-introduces VULN-AUTH-2.
 const tokenStoreAdapter = {
-  async getTokens(serviceId: string): Promise<unknown> {
-    return tokenStore.getToken("current-user", serviceId);
+  async getTokens(serviceId: string, userId: string): Promise<unknown> {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ): Promise<void> {
-    await tokenStore.setToken("current-user", serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string): Promise<void> {
-    await tokenStore.revokeToken("current-user", serviceId);
-  },
-  async getState(): Promise<null> {
-    return null;
+  async clearTokens(serviceId: string, userId: string): Promise<void> {
+    await tokenStore.revokeToken(userId, serviceId);
   },
   async setState(): Promise<void> {},
-  async clearState(): Promise<void> {},
+  async consumeState(): Promise<null> {
+    return null;
+  },
 };
 
 const gmailService = new OAuthService(gmailConfig, tokenStoreAdapter);
 
-export function createGmailClient(): {
+/**
+ * Create a Gmail client scoped to a specific user. Pass the authenticated
+ * user's id (from your session). Tokens are looked up and stored per-user.
+ */
+export function createGmailClient(userId: string): {
   isConnected(): Promise<boolean>;
   listMessages(options?: {
     maxResults?: number;
@@ -78,7 +85,7 @@ export function createGmailClient(): {
   archiveEmail(messageId: string): Promise<void>;
 } {
   async function apiRequest<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
-    return gmailService.fetch<T>(endpoint, options);
+    return gmailService.fetch<T>(userId, endpoint, options);
   }
 
   function formatAddresses(addresses: string | string[] | undefined): string {
@@ -88,7 +95,7 @@ export function createGmailClient(): {
 
   return {
     async isConnected(): Promise<boolean> {
-      const token = await gmailService.getAccessToken();
+      const token = await gmailService.getAccessToken(userId);
       return token !== null;
     },
 

--- a/cli/templates/integrations/hubspot/files/app/api/auth/hubspot/callback/route.ts
+++ b/cli/templates/integrations/hubspot/files/app/api/auth/hubspot/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, hubspotConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/hubspot/files/app/api/auth/hubspot/route.ts
+++ b/cli/templates/integrations/hubspot/files/app/api/auth/hubspot/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, hubspotConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(hubspotConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(hubspotConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/intercom/files/app/api/auth/intercom/callback/route.ts
+++ b/cli/templates/integrations/intercom/files/app/api/auth/intercom/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, intercomConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/intercom/files/app/api/auth/intercom/route.ts
+++ b/cli/templates/integrations/intercom/files/app/api/auth/intercom/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, intercomConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(intercomConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(intercomConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/jira/files/app/api/auth/jira/callback/route.ts
+++ b/cli/templates/integrations/jira/files/app/api/auth/jira/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, jiraConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  async getTokens(serviceId: string): Promise<unknown> {
-    return tokenStore.getToken(USER_ID, serviceId);
+  async getTokens(serviceId: string, userId: string): Promise<unknown> {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ): Promise<void> {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string): Promise<void> {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string): Promise<void> {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string): Promise<unknown> {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ): Promise<void> {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }): Promise<void> {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string): Promise<void> {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string): Promise<unknown> {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/jira/files/app/api/auth/jira/route.ts
+++ b/cli/templates/integrations/jira/files/app/api/auth/jira/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, jiraConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(jiraConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(jiraConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/linear/files/app/api/auth/linear/callback/route.ts
+++ b/cli/templates/integrations/linear/files/app/api/auth/linear/callback/route.ts
@@ -8,31 +8,35 @@ import { createOAuthCallbackHandler, linearConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/linear/files/app/api/auth/linear/route.ts
+++ b/cli/templates/integrations/linear/files/app/api/auth/linear/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, linearConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(linearConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(linearConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/mailchimp/files/app/api/auth/mailchimp/callback/route.ts
+++ b/cli/templates/integrations/mailchimp/files/app/api/auth/mailchimp/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, mailchimpConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  async getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  async getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/mailchimp/files/app/api/auth/mailchimp/route.ts
+++ b/cli/templates/integrations/mailchimp/files/app/api/auth/mailchimp/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, mailchimpConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(mailchimpConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(mailchimpConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/monday/files/app/api/auth/monday/callback/route.ts
+++ b/cli/templates/integrations/monday/files/app/api/auth/monday/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, mondayConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/monday/files/app/api/auth/monday/route.ts
+++ b/cli/templates/integrations/monday/files/app/api/auth/monday/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, mondayConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(mondayConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(mondayConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/notion/files/app/api/auth/notion/callback/route.ts
+++ b/cli/templates/integrations/notion/files/app/api/auth/notion/callback/route.ts
@@ -2,22 +2,19 @@ import { createOAuthCallbackHandler, notionConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  async getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  async getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
   async getState(state: string) {
     return oauthMemoryTokenStore.getState(state);

--- a/cli/templates/integrations/notion/files/app/api/auth/notion/callback/route.ts
+++ b/cli/templates/integrations/notion/files/app/api/auth/notion/callback/route.ts
@@ -3,7 +3,7 @@ import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
 const hybridTokenStore = {
-  async getTokens(serviceId: string, userId: string) {
+  getTokens(serviceId: string, userId: string) {
     return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
@@ -16,14 +16,21 @@ const hybridTokenStore = {
   async clearTokens(serviceId: string, userId: string) {
     await tokenStore.revokeToken(userId, serviceId);
   },
-  async getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  async setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    await oauthMemoryTokenStore.setState(state);
-  },
-  async clearState(state: string) {
-    await oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/notion/files/app/api/auth/notion/route.ts
+++ b/cli/templates/integrations/notion/files/app/api/auth/notion/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, notionConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(notionConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(notionConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/onedrive/files/app/api/auth/onedrive/callback/route.ts
+++ b/cli/templates/integrations/onedrive/files/app/api/auth/onedrive/callback/route.ts
@@ -8,31 +8,35 @@ import { createOAuthCallbackHandler, oneDriveConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  async getTokens(serviceId: string): Promise<unknown> {
-    return tokenStore.getToken(USER_ID, serviceId);
+  async getTokens(serviceId: string, userId: string): Promise<unknown> {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ): Promise<void> {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string): Promise<void> {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string): Promise<void> {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string): Promise<unknown> {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ): Promise<void> {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }): Promise<void> {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string): Promise<void> {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string): Promise<unknown> {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/onedrive/files/app/api/auth/onedrive/route.ts
+++ b/cli/templates/integrations/onedrive/files/app/api/auth/onedrive/route.ts
@@ -1,6 +1,13 @@
 import { createOAuthInitHandler, oneDriveConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
 export const GET = createOAuthInitHandler(oneDriveConfig, {
   tokenStore: oauthMemoryTokenStore,
+  getUserId,
 });

--- a/cli/templates/integrations/outlook/files/app/api/auth/outlook/callback/route.ts
+++ b/cli/templates/integrations/outlook/files/app/api/auth/outlook/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, outlookConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/outlook/files/app/api/auth/outlook/route.ts
+++ b/cli/templates/integrations/outlook/files/app/api/auth/outlook/route.ts
@@ -1,6 +1,13 @@
 import { createOAuthInitHandler, outlookConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
 export const GET = createOAuthInitHandler(outlookConfig, {
   tokenStore: oauthMemoryTokenStore,
+  getUserId,
 });

--- a/cli/templates/integrations/pipedrive/files/app/api/auth/pipedrive/callback/route.ts
+++ b/cli/templates/integrations/pipedrive/files/app/api/auth/pipedrive/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, pipedriveConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/pipedrive/files/app/api/auth/pipedrive/route.ts
+++ b/cli/templates/integrations/pipedrive/files/app/api/auth/pipedrive/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, pipedriveConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(pipedriveConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(pipedriveConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/quickbooks/files/app/api/auth/quickbooks/callback/route.ts
+++ b/cli/templates/integrations/quickbooks/files/app/api/auth/quickbooks/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, quickbooksConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/quickbooks/files/app/api/auth/quickbooks/route.ts
+++ b/cli/templates/integrations/quickbooks/files/app/api/auth/quickbooks/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, quickbooksConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(quickbooksConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(quickbooksConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/salesforce/files/app/api/auth/salesforce/callback/route.ts
+++ b/cli/templates/integrations/salesforce/files/app/api/auth/salesforce/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, salesforceConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/salesforce/files/app/api/auth/salesforce/route.ts
+++ b/cli/templates/integrations/salesforce/files/app/api/auth/salesforce/route.ts
@@ -1,6 +1,13 @@
 import { createOAuthInitHandler, salesforceConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
 export const GET = createOAuthInitHandler(salesforceConfig, {
   tokenStore: oauthMemoryTokenStore,
+  getUserId,
 });

--- a/cli/templates/integrations/sharepoint/files/app/api/auth/sharepoint/callback/route.ts
+++ b/cli/templates/integrations/sharepoint/files/app/api/auth/sharepoint/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, sharePointConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/sharepoint/files/app/api/auth/sharepoint/route.ts
+++ b/cli/templates/integrations/sharepoint/files/app/api/auth/sharepoint/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, sharePointConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(sharePointConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(sharePointConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/sheets/files/app/api/auth/sheets/callback/route.ts
+++ b/cli/templates/integrations/sheets/files/app/api/auth/sheets/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, sheetsConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/sheets/files/app/api/auth/sheets/route.ts
+++ b/cli/templates/integrations/sheets/files/app/api/auth/sheets/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, sheetsConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(sheetsConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(sheetsConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/shopify/files/app/api/auth/shopify/callback/route.ts
+++ b/cli/templates/integrations/shopify/files/app/api/auth/shopify/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, shopifyConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/shopify/files/app/api/auth/shopify/route.ts
+++ b/cli/templates/integrations/shopify/files/app/api/auth/shopify/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, shopifyConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(shopifyConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(shopifyConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/slack/files/app/api/auth/slack/callback/route.ts
+++ b/cli/templates/integrations/slack/files/app/api/auth/slack/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, slackConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/slack/files/app/api/auth/slack/route.ts
+++ b/cli/templates/integrations/slack/files/app/api/auth/slack/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, slackConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(slackConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(slackConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/teams/files/app/api/auth/teams/callback/route.ts
+++ b/cli/templates/integrations/teams/files/app/api/auth/teams/callback/route.ts
@@ -8,13 +8,9 @@ import { createOAuthCallbackHandler, teamsConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   setTokens(
     serviceId: string,
@@ -25,14 +21,21 @@ const hybridTokenStore = {
   clearTokens(serviceId: string) {
     return tokenStore.revokeToken(USER_ID, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/teams/files/app/api/auth/teams/callback/route.ts
+++ b/cli/templates/integrations/teams/files/app/api/auth/teams/callback/route.ts
@@ -12,14 +12,15 @@ const hybridTokenStore = {
   getTokens(serviceId: string, userId: string) {
     return tokenStore.getToken(userId, serviceId);
   },
-  setTokens(
+  async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    return tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  clearTokens(serviceId: string) {
-    return tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
   setState(
     state: string,

--- a/cli/templates/integrations/teams/files/app/api/auth/teams/route.ts
+++ b/cli/templates/integrations/teams/files/app/api/auth/teams/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, teamsConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(teamsConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(teamsConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/trello/files/app/api/auth/trello/callback/route.ts
+++ b/cli/templates/integrations/trello/files/app/api/auth/trello/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, trelloConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/trello/files/app/api/auth/trello/route.ts
+++ b/cli/templates/integrations/trello/files/app/api/auth/trello/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, trelloConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(trelloConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(trelloConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/twitter/files/app/api/auth/twitter/callback/route.ts
+++ b/cli/templates/integrations/twitter/files/app/api/auth/twitter/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, twitterConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/twitter/files/app/api/auth/twitter/route.ts
+++ b/cli/templates/integrations/twitter/files/app/api/auth/twitter/route.ts
@@ -1,6 +1,13 @@
 import { createOAuthInitHandler, twitterConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
 export const GET = createOAuthInitHandler(twitterConfig, {
   tokenStore: oauthMemoryTokenStore,
+  getUserId,
 });

--- a/cli/templates/integrations/webex/files/app/api/auth/webex/callback/route.ts
+++ b/cli/templates/integrations/webex/files/app/api/auth/webex/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, webexConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  async getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  async getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/webex/files/app/api/auth/webex/route.ts
+++ b/cli/templates/integrations/webex/files/app/api/auth/webex/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, webexConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(webexConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(webexConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/xero/files/app/api/auth/xero/callback/route.ts
+++ b/cli/templates/integrations/xero/files/app/api/auth/xero/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, xeroConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/xero/files/app/api/auth/xero/route.ts
+++ b/cli/templates/integrations/xero/files/app/api/auth/xero/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, xeroConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(xeroConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(xeroConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/cli/templates/integrations/zoom/files/app/api/auth/zoom/callback/route.ts
+++ b/cli/templates/integrations/zoom/files/app/api/auth/zoom/callback/route.ts
@@ -2,31 +2,35 @@ import { createOAuthCallbackHandler, zoomConfig } from "veryfront/oauth";
 import { tokenStore } from "../../../../../lib/token-store.ts";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-
-// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT)
-const USER_ID = "current-user";
-
 const hybridTokenStore = {
-  getTokens(serviceId: string) {
-    return tokenStore.getToken(USER_ID, serviceId);
+  getTokens(serviceId: string, userId: string) {
+    return tokenStore.getToken(userId, serviceId);
   },
   async setTokens(
     serviceId: string,
+    userId: string,
     tokens: { accessToken: string; refreshToken?: string; expiresAt?: number },
   ) {
-    await tokenStore.setToken(USER_ID, serviceId, tokens);
+    await tokenStore.setToken(userId, serviceId, tokens);
   },
-  async clearTokens(serviceId: string) {
-    await tokenStore.revokeToken(USER_ID, serviceId);
+  async clearTokens(serviceId: string, userId: string) {
+    await tokenStore.revokeToken(userId, serviceId);
   },
-  getState(state: string) {
-    return oauthMemoryTokenStore.getState(state);
+  setState(
+    state: string,
+    meta: {
+      userId: string;
+      serviceId: string;
+      codeVerifier?: string;
+      redirectUri?: string;
+      scopes?: string[];
+      createdAt: number;
+    },
+  ) {
+    return oauthMemoryTokenStore.setState(state, meta);
   },
-  setState(state: { state: string; codeVerifier?: string; createdAt: number }) {
-    return oauthMemoryTokenStore.setState(state);
-  },
-  clearState(state: string) {
-    return oauthMemoryTokenStore.clearState(state);
+  consumeState(state: string) {
+    return oauthMemoryTokenStore.consumeState(state);
   },
 };
 

--- a/cli/templates/integrations/zoom/files/app/api/auth/zoom/route.ts
+++ b/cli/templates/integrations/zoom/files/app/api/auth/zoom/route.ts
@@ -1,4 +1,13 @@
 import { createOAuthInitHandler, zoomConfig } from "veryfront/oauth";
 import { oauthMemoryTokenStore } from "../../../../../lib/oauth-memory-store.ts";
 
-export const GET = createOAuthInitHandler(zoomConfig, { tokenStore: oauthMemoryTokenStore });
+// TODO: Replace with real user ID from your auth system (e.g., session cookie, JWT).
+// NEVER return a shared constant in production - it breaks per-user token isolation (VULN-AUTH-2).
+function getUserId(_request: Request): string {
+  return "current-user";
+}
+
+export const GET = createOAuthInitHandler(zoomConfig, {
+  tokenStore: oauthMemoryTokenStore,
+  getUserId,
+});

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -12,19 +12,25 @@ Route examples below use the default app router. Veryfront Code also supports mo
 
 ## Quick setup
 
-Two routes handle the full OAuth flow — redirect to the provider and handle the callback:
+Two routes handle the full OAuth flow — redirect to the provider and handle the callback. Both handlers require a `getUserId` function that returns the authenticated user's id from your session; unauthenticated requests receive a 401.
 
 ```ts
 // app/api/auth/github/route.ts
 import { createOAuthInitHandler, githubConfig } from "veryfront/oauth";
+import { getSessionUserId } from "../../../../lib/auth.ts";
 
-export const GET = createOAuthInitHandler(githubConfig);
+export const GET = createOAuthInitHandler(githubConfig, {
+  // Return the signed-in user's id, or null/undefined to reject the request.
+  getUserId: (request) => getSessionUserId(request),
+});
 ```
 
 ```ts
 // app/api/auth/github/callback/route.ts
 import { createOAuthCallbackHandler, githubConfig } from "veryfront/oauth";
 
+// The callback reads the initiating user id from the stored OAuth state row,
+// so it does not need its own getUserId function.
 export const GET = createOAuthCallbackHandler(githubConfig);
 ```
 
@@ -35,7 +41,9 @@ GITHUB_CLIENT_ID=your-client-id
 GITHUB_CLIENT_SECRET=your-client-secret
 ```
 
-Link users to `/api/auth/github` to start the flow. After authorization, they're redirected back to your callback route with tokens.
+Link users to `/api/auth/github` to start the flow. After authorization, they're redirected back to your callback route. Tokens are stored in that user's per-user slot — never in a single shared slot.
+
+> **Security.** `getUserId` is required. The init handler rejects any request where it returns `null`, `undefined`, or an empty string. The user's id is bound into the OAuth state row and the callback stores tokens keyed by `(serviceId, userId)`, so one user cannot overwrite another user's tokens by completing an OAuth flow.
 
 ## Available providers
 
@@ -45,32 +53,34 @@ Each provider exports a config object (e.g., `githubConfig`, `gmailConfig`, `dis
 
 ## Token storage
 
-By default, tokens are stored in memory (lost on restart). For production, implement a persistent store:
+By default, tokens are stored in memory (lost on restart). For production, implement a persistent store. The `TokenStore` interface is keyed by `(serviceId, userId)` so each user's tokens live in their own slot, and OAuth state rows are consumed atomically (one-shot):
 
 ```ts
 import { createOAuthCallbackHandler, githubConfig } from "veryfront/oauth";
-import type { TokenStore, OAuthTokens, OAuthState } from "veryfront/oauth";
+import type { TokenStore, OAuthTokens, StoredOAuthState } from "veryfront/oauth";
 
 const redisTokenStore: TokenStore = {
-  async getTokens(serviceId) {
-    const data = await redis.get(`oauth:tokens:${serviceId}`);
-    return data ? JSON.parse(data) : null;
+  async getTokens(serviceId, userId) {
+    const data = await redis.get(`oauth:tokens:${serviceId}:${userId}`);
+    return data ? (JSON.parse(data) as OAuthTokens) : null;
   },
-  async setTokens(serviceId, tokens) {
-    await redis.set(`oauth:tokens:${serviceId}`, JSON.stringify(tokens));
+  async setTokens(serviceId, userId, tokens) {
+    await redis.set(`oauth:tokens:${serviceId}:${userId}`, JSON.stringify(tokens));
   },
-  async clearTokens(serviceId) {
-    await redis.del(`oauth:tokens:${serviceId}`);
+  async clearTokens(serviceId, userId) {
+    await redis.del(`oauth:tokens:${serviceId}:${userId}`);
   },
-  async getState(state) {
-    const data = await redis.get(`oauth:state:${state}`);
-    return data ? JSON.parse(data) : null;
+  async setState(state, meta) {
+    // Set with a short TTL (e.g. 10 minutes) so abandoned flows don't pile up.
+    await redis.set(`oauth:state:${state}`, JSON.stringify(meta), "EX", 600);
   },
-  async setState(state) {
-    await redis.set(`oauth:state:${state.state}`, JSON.stringify(state));
-  },
-  async clearState(state) {
-    await redis.del(`oauth:state:${state}`);
+  async consumeState(state) {
+    // Atomic read + delete — the state row must be usable exactly once.
+    const key = `oauth:state:${state}`;
+    const data = await redis.get(key);
+    if (!data) return null;
+    await redis.del(key);
+    return JSON.parse(data) as StoredOAuthState;
   },
 };
 
@@ -79,18 +89,26 @@ export const GET = createOAuthCallbackHandler(githubConfig, {
 });
 ```
 
+The callback handler reads the initiating user's id from the state row and calls `setTokens(serviceId, userId, tokens)`. If the state row is missing, expired, forged, or already consumed, the callback returns an error without storing anything.
+
 ## Status and disconnect
 
-Check if a user is connected, or disconnect them:
+Check if a user is connected, or disconnect them. These handlers also require `getUserId` so they act on the caller's own tokens only:
 
 ```ts
 // app/api/auth/github/status/route.ts
 import { createOAuthStatusHandler, githubConfig } from "veryfront/oauth";
-export const GET = createOAuthStatusHandler(githubConfig);
+import { getSessionUserId } from "../../../../../lib/auth.ts";
+export const GET = createOAuthStatusHandler(githubConfig, {
+  getUserId: (request) => getSessionUserId(request),
+});
 
 // app/api/auth/github/disconnect/route.ts
 import { createOAuthDisconnectHandler, githubConfig } from "veryfront/oauth";
-export const POST = createOAuthDisconnectHandler(githubConfig);
+import { getSessionUserId } from "../../../../../lib/auth.ts";
+export const POST = createOAuthDisconnectHandler(githubConfig, {
+  getUserId: (request) => getSessionUserId(request),
+});
 ```
 
 ## Custom OAuth provider
@@ -113,10 +131,26 @@ const myProvider = {
 };
 
 // app/api/auth/my-provider/route.ts
-export const GET = createOAuthInitHandler(myProvider);
+export const GET = createOAuthInitHandler(myProvider, {
+  getUserId: (request) => getSessionUserId(request),
+});
 
 // app/api/auth/my-provider/callback/route.ts
 export const GET = createOAuthCallbackHandler(myProvider);
+```
+
+## Calling provider APIs on behalf of a user
+
+OAuth service clients (e.g. `OAuthService.fetch`, `OAuthService.getAccessToken`) require the authenticated user's id so tokens are looked up from that user's slot:
+
+```ts
+import { OAuthService, gmailConfig } from "veryfront/oauth";
+import { tokenStore } from "../../lib/token-store.ts";
+
+const gmail = new OAuthService(gmailConfig, tokenStore);
+
+// Pass the signed-in user's id — never a hardcoded constant.
+const response = await gmail.fetch(session.userId, "/users/me/messages");
 ```
 
 ## Next

--- a/src/oauth/handlers/callback-handler.test.ts
+++ b/src/oauth/handlers/callback-handler.test.ts
@@ -4,6 +4,7 @@ import { MemoryTokenStore } from "../token-store/memory.ts";
 import type { OAuthServiceConfig } from "../types.ts";
 
 const TEST_CONFIG: OAuthServiceConfig = {
+  providerId: "test-provider",
   serviceId: "test-provider",
   displayName: "Test Provider",
   clientIdEnvVar: "TEST_CLIENT_ID",
@@ -42,7 +43,7 @@ Deno.test("callback-handler: rejects request when state parameter is missing", a
   assertEquals(location.searchParams.get("error"), "invalid_state");
 });
 
-Deno.test("callback-handler: rejects request when state parameter is invalid (not in store)", async () => {
+Deno.test("callback-handler: rejects request when state is unknown (forged)", async () => {
   const tokenStore = new MemoryTokenStore();
   const handler = createOAuthCallbackHandler(TEST_CONFIG, {
     tokenStore,
@@ -59,11 +60,38 @@ Deno.test("callback-handler: rejects request when state parameter is invalid (no
   assertEquals(location.searchParams.get("error"), "invalid_state");
 });
 
+Deno.test("callback-handler: rejects request when state serviceId does not match", async () => {
+  const tokenStore = new MemoryTokenStore();
+
+  await tokenStore.setState("valid-state", {
+    userId: "alice",
+    serviceId: "other-provider", // mismatched!
+    redirectUri: "http://localhost:3000/api/auth/test-provider/callback",
+    scopes: ["read"],
+    createdAt: Date.now(),
+  });
+
+  const handler = createOAuthCallbackHandler(TEST_CONFIG, {
+    tokenStore,
+    baseUrl: "http://localhost:3000",
+    envReader: (key) => ENV[key],
+  });
+
+  const response = await handler(
+    makeRequest({ code: "auth-code-123", state: "valid-state" }),
+  );
+
+  assertEquals(response.status, 302);
+  const location = new URL(response.headers.get("location")!);
+  assertEquals(location.searchParams.get("error"), "invalid_state");
+});
+
 Deno.test("callback-handler: rejects request when state has expired", async () => {
   const tokenStore = new MemoryTokenStore();
 
-  await tokenStore.setState({
-    state: "expired-state",
+  await tokenStore.setState("expired-state", {
+    userId: "alice",
+    serviceId: TEST_CONFIG.serviceId,
     redirectUri: "http://localhost:3000/api/auth/test-provider/callback",
     scopes: ["read"],
     createdAt: Date.now() - 11 * 60 * 1000, // 11 minutes ago, past 10-minute expiry
@@ -84,16 +112,38 @@ Deno.test("callback-handler: rejects request when state has expired", async () =
   assertEquals(location.searchParams.get("error"), "invalid_state");
 });
 
-Deno.test("callback-handler: allows missing state when skipStateValidation is true", async () => {
+Deno.test("callback-handler: consumes state once (double-use rejected)", async () => {
   const tokenStore = new MemoryTokenStore();
 
-  // Store a valid state so token exchange can work
-  await tokenStore.setState({
-    state: "valid-state",
+  await tokenStore.setState("valid-state", {
+    userId: "alice",
+    serviceId: TEST_CONFIG.serviceId,
     redirectUri: "http://localhost:3000/api/auth/test-provider/callback",
     scopes: ["read"],
     createdAt: Date.now(),
   });
+
+  const handler = createOAuthCallbackHandler(TEST_CONFIG, {
+    tokenStore,
+    baseUrl: "http://localhost:3000",
+    envReader: (key) => ENV[key],
+  });
+
+  // First call consumes state
+  await handler(makeRequest({ code: "auth-code-123", state: "valid-state" }));
+
+  // Second call with same state should fail with invalid_state
+  const response = await handler(
+    makeRequest({ code: "auth-code-456", state: "valid-state" }),
+  );
+
+  assertEquals(response.status, 302);
+  const location = new URL(response.headers.get("location")!);
+  assertEquals(location.searchParams.get("error"), "invalid_state");
+});
+
+Deno.test("callback-handler: allows missing state when skipStateValidation is true", async () => {
+  const tokenStore = new MemoryTokenStore();
 
   const handler = createOAuthCallbackHandler(TEST_CONFIG, {
     tokenStore,
@@ -137,11 +187,12 @@ Deno.test("callback-handler: calls onError with invalid_state when state is miss
   assertEquals(errorCode, "invalid_state");
 });
 
-Deno.test("callback-handler: accepts request with valid state from store", async () => {
+Deno.test("callback-handler: proceeds with valid state matching serviceId", async () => {
   const tokenStore = new MemoryTokenStore();
 
-  await tokenStore.setState({
-    state: "valid-state-abc",
+  await tokenStore.setState("valid-state-abc", {
+    userId: "alice",
+    serviceId: TEST_CONFIG.serviceId,
     redirectUri: "http://localhost:3000/api/auth/test-provider/callback",
     scopes: ["read"],
     createdAt: Date.now(),
@@ -163,5 +214,64 @@ Deno.test("callback-handler: accepts request with valid state from store", async
   const error = location.searchParams.get("error");
   if (error) {
     assertNotEquals(error, "invalid_state");
+  }
+});
+
+Deno.test("callback-handler: stores tokens keyed by (serviceId, userId) — bob's slot untouched", async () => {
+  const tokenStore = new MemoryTokenStore();
+  // Bob already connected
+  await tokenStore.setTokens(TEST_CONFIG.serviceId, "bob", {
+    accessToken: "bob-existing-token",
+  });
+
+  // Alice starts an OAuth flow
+  await tokenStore.setState("alice-state", {
+    userId: "alice",
+    serviceId: TEST_CONFIG.serviceId,
+    redirectUri: "http://localhost:3000/api/auth/test-provider/callback",
+    scopes: ["read"],
+    createdAt: Date.now(),
+  });
+
+  // Stub token exchange to succeed without a network call by intercepting fetch.
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async (url: string | URL | Request, _init?: RequestInit) => {
+    const href = typeof url === "string" ? url : (url as URL).toString();
+    if (href === TEST_CONFIG.tokenUrl) {
+      return new Response(
+        JSON.stringify({
+          access_token: "alice-access-token",
+          refresh_token: "alice-refresh-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+          scope: "read",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    return new Response("not found", { status: 404 });
+  };
+
+  try {
+    const handler = createOAuthCallbackHandler(TEST_CONFIG, {
+      tokenStore,
+      baseUrl: "http://localhost:3000",
+      envReader: (key) => ENV[key],
+    });
+
+    const response = await handler(
+      makeRequest({ code: "auth-code-abc", state: "alice-state" }),
+    );
+    assertEquals(response.status, 302);
+
+    // Alice's tokens stored under her userId
+    const aliceTokens = await tokenStore.getTokens(TEST_CONFIG.serviceId, "alice");
+    assertEquals(aliceTokens?.accessToken, "alice-access-token");
+
+    // Bob's slot untouched
+    const bobTokens = await tokenStore.getTokens(TEST_CONFIG.serviceId, "bob");
+    assertEquals(bobTokens?.accessToken, "bob-existing-token");
+  } finally {
+    globalThis.fetch = origFetch;
   }
 });

--- a/src/oauth/handlers/callback-handler.ts
+++ b/src/oauth/handlers/callback-handler.ts
@@ -6,7 +6,7 @@ import {
 } from "#veryfront/config/environment-config.ts";
 import { type EnvReader, OAuthService } from "../providers/base.ts";
 import { memoryTokenStore } from "../token-store/memory.ts";
-import type { OAuthServiceConfig, OAuthState, TokenStore } from "../types.ts";
+import type { OAuthServiceConfig, StoredOAuthState, TokenStore } from "../types.ts";
 
 const logger = baseLogger.component("o-auth");
 
@@ -23,8 +23,8 @@ export interface OAuthCallbackHandlerOptions {
   /** Error redirect path */
   errorRedirect?: string;
 
-  /** Custom success callback */
-  onSuccess?: (serviceId: string, tokens: unknown) => void | Promise<void>;
+  /** Custom success callback (called with the user id the tokens were stored under) */
+  onSuccess?: (serviceId: string, tokens: unknown, userId: string) => void | Promise<void>;
 
   /** Custom error callback */
   onError?: (serviceId: string, error: string) => void | Promise<void>;
@@ -102,7 +102,7 @@ export function createOAuthCallbackHandler(
 
     if (!code) return handleError(appUrl, "no_code");
 
-    let storedState: OAuthState | null = null;
+    let storedState: StoredOAuthState | null = null;
 
     if (!skipStateValidation && !state) {
       return handleError(appUrl, "invalid_state", "Missing state parameter", {
@@ -111,10 +111,18 @@ export function createOAuthCallbackHandler(
     }
 
     if (state) {
-      storedState = await tokenStore.getState(state);
+      // Atomic read+delete. Unknown/expired/forged state all return null.
+      storedState = await tokenStore.consumeState(state);
       if (!skipStateValidation && !storedState) {
         return handleError(appUrl, "invalid_state", "Invalid or expired state", {
           serviceId: config.serviceId,
+        });
+      }
+      // A state record from a different service must never authorize this one.
+      if (storedState && storedState.serviceId !== config.serviceId) {
+        return handleError(appUrl, "invalid_state", "State serviceId mismatch", {
+          serviceId: config.serviceId,
+          stateServiceId: storedState.serviceId,
         });
       }
     }
@@ -138,11 +146,20 @@ export function createOAuthCallbackHandler(
         );
       }
 
-      await tokenStore.setTokens(config.serviceId, result.tokens);
+      // Without state (skipStateValidation) we have no userId — refuse to
+      // store tokens under a shared slot. Callers who need this path must
+      // provide a store that handles it themselves (e.g. cookie-scoped).
+      if (!storedState) {
+        return handleError(
+          appUrl,
+          "invalid_state",
+          `Cannot store tokens for ${config.serviceId}: no state (and thus no userId) available`,
+        );
+      }
 
-      if (state) await tokenStore.clearState(state);
+      await tokenStore.setTokens(config.serviceId, storedState.userId, result.tokens);
 
-      await onSuccess?.(config.serviceId, result.tokens);
+      await onSuccess?.(config.serviceId, result.tokens, storedState.userId);
 
       const successUrl = new URL(successRedirect, appUrl);
       successUrl.searchParams.set("connected", config.serviceId);

--- a/src/oauth/handlers/init-handler.test.ts
+++ b/src/oauth/handlers/init-handler.test.ts
@@ -7,9 +7,10 @@ import {
   createOAuthStatusHandler,
 } from "./init-handler.ts";
 import { MemoryTokenStore } from "../token-store/memory.ts";
-import type { OAuthServiceConfig, OAuthState, OAuthTokens, TokenStore } from "../types.ts";
+import type { OAuthServiceConfig, OAuthTokens, StoredOAuthState, TokenStore } from "../types.ts";
 
 const TEST_CONFIG: OAuthServiceConfig = {
+  providerId: "test-provider",
   serviceId: "test-provider",
   displayName: "Test Provider",
   clientIdEnvVar: "TEST_CLIENT_ID",
@@ -40,23 +41,76 @@ function createFailingStateStore(message: string): TokenStore {
     },
     async setTokens(): Promise<void> {},
     async clearTokens(): Promise<void> {},
-    async getState(): Promise<OAuthState | null> {
-      return null;
-    },
     async setState(): Promise<void> {
       throw new Error(message);
     },
-    async clearState(): Promise<void> {},
+    async consumeState(): Promise<StoredOAuthState | null> {
+      return null;
+    },
   };
 }
+
+Deno.test("init handler: returns 401 when getUserId is not provided (fail-closed)", async () => {
+  // deno-lint-ignore no-explicit-any
+  const handler = createOAuthInitHandler(TEST_CONFIG, {
+    env: makeEnv(),
+    envReader: (key: string) => ENV[key],
+    // intentionally omit getUserId to simulate caller who forgets — but TS requires it,
+    // so we cast to `any` only to check runtime fail-closed behavior.
+  } as any);
+
+  const response = await handler(new Request("http://localhost:3000/api/auth/test-provider"));
+  assertEquals(response.status, 401);
+});
+
+Deno.test("init handler: returns 401 when isAuthenticated returns false", async () => {
+  const store = new MemoryTokenStore();
+  const handler = createOAuthInitHandler(TEST_CONFIG, {
+    tokenStore: store,
+    env: makeEnv(),
+    envReader: (key: string) => ENV[key],
+    isAuthenticated: () => false,
+    getUserId: () => "alice",
+  });
+
+  const response = await handler(new Request("http://localhost:3000/api/auth/test-provider"));
+  assertEquals(response.status, 401);
+});
+
+Deno.test("init handler: returns 401 when getUserId returns null", async () => {
+  const store = new MemoryTokenStore();
+  const handler = createOAuthInitHandler(TEST_CONFIG, {
+    tokenStore: store,
+    env: makeEnv(),
+    envReader: (key: string) => ENV[key],
+    getUserId: () => null,
+  });
+
+  const response = await handler(new Request("http://localhost:3000/api/auth/test-provider"));
+  assertEquals(response.status, 401);
+});
+
+Deno.test("init handler: returns 401 when getUserId returns empty string", async () => {
+  const store = new MemoryTokenStore();
+  const handler = createOAuthInitHandler(TEST_CONFIG, {
+    tokenStore: store,
+    env: makeEnv(),
+    envReader: (key: string) => ENV[key],
+    getUserId: () => "",
+  });
+
+  const response = await handler(new Request("http://localhost:3000/api/auth/test-provider"));
+  assertEquals(response.status, 401);
+});
 
 Deno.test("init handler: returns 500 when oauth is not configured", async () => {
   const handler = createOAuthInitHandler(TEST_CONFIG, {
     env: makeEnv(),
     envReader: () => undefined,
+    getUserId: () => "alice",
   });
 
-  const response = await handler();
+  const response = await handler(new Request("http://localhost:3000/api/auth/test-provider"));
 
   assertEquals(response.status, 500);
   assertEquals(await response.json(), {
@@ -65,16 +119,17 @@ Deno.test("init handler: returns 500 when oauth is not configured", async () => 
   });
 });
 
-Deno.test("init handler: stores state and redirects to the provider", async () => {
+Deno.test("init handler: stores state with userId and redirects to the provider", async () => {
   const store = new MemoryTokenStore();
   const appUrl = "https://example.test";
   const handler = createOAuthInitHandler(TEST_CONFIG, {
     tokenStore: store,
     env: makeEnv(appUrl),
     envReader: (key: string) => ENV[key],
+    getUserId: () => "alice",
   });
 
-  const response = await handler();
+  const response = await handler(new Request("http://localhost:3000/api/auth/test-provider"));
 
   assertEquals(response.status, 302);
 
@@ -93,9 +148,30 @@ Deno.test("init handler: stores state and redirects to the provider", async () =
     throw new Error("expected redirect state parameter to be present");
   }
 
-  const storedState = await store.getState(state);
+  // Peek without consuming — use a separate method for test assertion by consuming a clone.
+  const storedState = await store.consumeState(state);
+  assertEquals(storedState?.userId, "alice");
+  assertEquals(storedState?.serviceId, "test-provider");
   assertEquals(storedState?.redirectUri, `${appUrl}/api/auth/test-provider/callback`);
   assertEquals(storedState?.scopes, ["read"]);
+});
+
+Deno.test("init handler: supports async isAuthenticated and getUserId", async () => {
+  const store = new MemoryTokenStore();
+  const handler = createOAuthInitHandler(TEST_CONFIG, {
+    tokenStore: store,
+    env: makeEnv("https://example.test"),
+    envReader: (key: string) => ENV[key],
+    isAuthenticated: () => Promise.resolve(true),
+    getUserId: () => Promise.resolve("bob"),
+  });
+
+  const response = await handler(new Request("http://localhost:3000/api/auth/test-provider"));
+
+  assertEquals(response.status, 302);
+  const state = new URL(response.headers.get("location")!).searchParams.get("state")!;
+  const storedState = await store.consumeState(state);
+  assertEquals(storedState?.userId, "bob");
 });
 
 Deno.test("init handler: returns 500 when state persistence fails", async () => {
@@ -103,9 +179,10 @@ Deno.test("init handler: returns 500 when state persistence fails", async () => 
     tokenStore: createFailingStateStore("state store failed"),
     env: makeEnv(),
     envReader: (key: string) => ENV[key],
+    getUserId: () => "alice",
   });
 
-  const response = await handler();
+  const response = await handler(new Request("http://localhost:3000/api/auth/test-provider"));
 
   assertEquals(response.status, 500);
   assertEquals(await response.json(), {
@@ -114,11 +191,36 @@ Deno.test("init handler: returns 500 when state persistence fails", async () => 
   });
 });
 
-Deno.test("status handler: returns status without isAuthenticated", async () => {
+Deno.test("status handler: returns 401 when getUserId is not provided (fail-closed)", async () => {
   const store = new MemoryTokenStore();
   const handler = createOAuthStatusHandler(TEST_CONFIG, {
     tokenStore: store,
     envReader: (key: string) => ENV[key],
+    // deno-lint-ignore no-explicit-any
+  } as any);
+
+  const res = await handler(makeRequest());
+  assertEquals(res.status, 401);
+});
+
+Deno.test("status handler: returns 401 when getUserId returns null", async () => {
+  const store = new MemoryTokenStore();
+  const handler = createOAuthStatusHandler(TEST_CONFIG, {
+    tokenStore: store,
+    envReader: (key: string) => ENV[key],
+    getUserId: () => null,
+  });
+
+  const res = await handler(makeRequest());
+  assertEquals(res.status, 401);
+});
+
+Deno.test("status handler: returns status for authenticated user", async () => {
+  const store = new MemoryTokenStore();
+  const handler = createOAuthStatusHandler(TEST_CONFIG, {
+    tokenStore: store,
+    envReader: (key: string) => ENV[key],
+    getUserId: () => "alice",
   });
 
   const res = await handler(makeRequest());
@@ -134,6 +236,7 @@ Deno.test("status handler: returns 401 when isAuthenticated returns false", asyn
     tokenStore: store,
     envReader: (key: string) => ENV[key],
     isAuthenticated: () => false,
+    getUserId: () => "alice",
   });
 
   const res = await handler(makeRequest());
@@ -142,23 +245,29 @@ Deno.test("status handler: returns 401 when isAuthenticated returns false", asyn
   assertEquals(body.error, "Unauthorized");
 });
 
-Deno.test("status handler: returns status when isAuthenticated returns true", async () => {
+Deno.test("status handler: scopes token lookup to caller userId", async () => {
   const store = new MemoryTokenStore();
+  await store.setTokens(TEST_CONFIG.serviceId, "alice", { accessToken: "alice-token" });
+  await store.setTokens(TEST_CONFIG.serviceId, "bob", { accessToken: "bob-token" });
+
   const handler = createOAuthStatusHandler(TEST_CONFIG, {
     tokenStore: store,
     envReader: (key: string) => ENV[key],
-    isAuthenticated: () => true,
+    getUserId: () => "alice",
   });
 
   const res = await handler(makeRequest());
   assertEquals(res.status, 200);
   const body = await res.json();
-  assertEquals(body.service, "test-provider");
+  assertEquals(body.connected, true);
+
+  // Bob's tokens must still be there
+  assertEquals((await store.getTokens(TEST_CONFIG.serviceId, "bob"))?.accessToken, "bob-token");
 });
 
 Deno.test("status handler: treats expired access as connected when refresh token exists", async () => {
   const store = new MemoryTokenStore();
-  await store.setTokens(TEST_CONFIG.serviceId, {
+  await store.setTokens(TEST_CONFIG.serviceId, "alice", {
     accessToken: "access-token",
     refreshToken: "refresh-token",
     expiresAt: Date.now() - 1_000,
@@ -167,6 +276,7 @@ Deno.test("status handler: treats expired access as connected when refresh token
   const handler = createOAuthStatusHandler(TEST_CONFIG, {
     tokenStore: store,
     envReader: (key: string) => ENV[key],
+    getUserId: () => "alice",
   });
 
   const res = await handler(makeRequest());
@@ -177,30 +287,51 @@ Deno.test("status handler: treats expired access as connected when refresh token
   assertEquals(body.hasRefreshToken, true);
 });
 
-Deno.test("status handler: supports async isAuthenticated", async () => {
+Deno.test("status handler: supports async isAuthenticated and getUserId", async () => {
   const store = new MemoryTokenStore();
   const handler = createOAuthStatusHandler(TEST_CONFIG, {
     tokenStore: store,
     envReader: (key: string) => ENV[key],
     isAuthenticated: async () => false,
+    getUserId: async () => "alice",
   });
 
   const res = await handler(makeRequest());
   assertEquals(res.status, 401);
 });
 
-Deno.test("disconnect handler: returns success without isAuthenticated", async () => {
+Deno.test("disconnect handler: returns 401 when getUserId is not provided (fail-closed)", async () => {
   const store = new MemoryTokenStore();
-  await store.setTokens(TEST_CONFIG.serviceId, { accessToken: "access-token" });
   const handler = createOAuthDisconnectHandler(TEST_CONFIG, {
     tokenStore: store,
+    // deno-lint-ignore no-explicit-any
+  } as any);
+
+  const res = await handler(makeRequest());
+  assertEquals(res.status, 401);
+});
+
+Deno.test("disconnect handler: clears only the calling user's tokens", async () => {
+  const store = new MemoryTokenStore();
+  await store.setTokens(TEST_CONFIG.serviceId, "alice", { accessToken: "alice-token" });
+  await store.setTokens(TEST_CONFIG.serviceId, "bob", { accessToken: "bob-token" });
+
+  const handler = createOAuthDisconnectHandler(TEST_CONFIG, {
+    tokenStore: store,
+    getUserId: () => "alice",
   });
 
   const res = await handler(makeRequest());
   assertEquals(res.status, 200);
   const body = await res.json();
   assertEquals(body.success, true);
-  assertEquals(await store.getTokens(TEST_CONFIG.serviceId), null);
+
+  assertEquals(await store.getTokens(TEST_CONFIG.serviceId, "alice"), null);
+  // Bob's tokens must be untouched
+  assertEquals(
+    (await store.getTokens(TEST_CONFIG.serviceId, "bob"))?.accessToken,
+    "bob-token",
+  );
 });
 
 Deno.test("disconnect handler: returns 401 when isAuthenticated returns false", async () => {
@@ -208,6 +339,7 @@ Deno.test("disconnect handler: returns 401 when isAuthenticated returns false", 
   const handler = createOAuthDisconnectHandler(TEST_CONFIG, {
     tokenStore: store,
     isAuthenticated: () => false,
+    getUserId: () => "alice",
   });
 
   const res = await handler(makeRequest());
@@ -216,24 +348,12 @@ Deno.test("disconnect handler: returns 401 when isAuthenticated returns false", 
   assertEquals(body.error, "Unauthorized");
 });
 
-Deno.test("disconnect handler: returns success when isAuthenticated returns true", async () => {
-  const store = new MemoryTokenStore();
-  const handler = createOAuthDisconnectHandler(TEST_CONFIG, {
-    tokenStore: store,
-    isAuthenticated: () => true,
-  });
-
-  const res = await handler(makeRequest());
-  assertEquals(res.status, 200);
-  const body = await res.json();
-  assertEquals(body.success, true);
-});
-
-Deno.test("disconnect handler: supports async isAuthenticated", async () => {
+Deno.test("disconnect handler: supports async isAuthenticated and getUserId", async () => {
   const store = new MemoryTokenStore();
   const handler = createOAuthDisconnectHandler(TEST_CONFIG, {
     tokenStore: store,
     isAuthenticated: async () => false,
+    getUserId: async () => "alice",
   });
 
   const res = await handler(makeRequest());

--- a/src/oauth/handlers/init-handler.ts
+++ b/src/oauth/handlers/init-handler.ts
@@ -22,6 +22,24 @@ async function isRequestUnauthorized(
   return isAuthenticated ? !(await isAuthenticated(req)) : false;
 }
 
+/**
+ * Resolve the userId for a request, returning null when anonymous.
+ *
+ * `getUserId` is required at compile time (see handler option types). We
+ * still tolerate `undefined` at runtime (e.g. a JS caller) and treat it as
+ * unauthenticated — NEVER fall back to "anonymous": that preserves
+ * VULN-AUTH-2 where unrelated users share a single token slot.
+ */
+async function resolveUserId(
+  req: Request,
+  getUserId: GetUserIdFn | undefined,
+): Promise<string | null> {
+  if (!getUserId) return null;
+  const result = await getUserId(req);
+  if (!result) return null; // null, undefined, or empty string all fail.
+  return result;
+}
+
 function resolveAppUrl(baseUrl: string | undefined, env: EnvironmentConfig): string {
   return baseUrl ?? env.appUrl ?? DEFAULT_APP_URL;
 }
@@ -46,6 +64,9 @@ function createInitErrorResponse(error: unknown): Response {
   );
 }
 
+/** Signature for resolving the authenticated user's id from a request. */
+export type GetUserIdFn = (req: Request) => string | null | Promise<string | null>;
+
 export interface OAuthInitHandlerOptions {
   /** Token store to use (defaults to memory store) */
   tokenStore?: TokenStore;
@@ -61,21 +82,45 @@ export interface OAuthInitHandlerOptions {
 
   /** EnvReader for dynamic env vars (defaults to getEnv) */
   envReader?: EnvReader;
+
+  /**
+   * Optional authentication check. If supplied and returns false the request
+   * is rejected with 401. Independent from `getUserId` which always runs.
+   */
+  isAuthenticated?: (req: Request) => boolean | Promise<boolean>;
+
+  /**
+   * REQUIRED. Resolve the authenticated user's id. The returned id is
+   * persisted with the OAuth `state` so the callback stores tokens in that
+   * user's slot. Return `null` (or an empty string) to reject unauthenticated
+   * requests with 401. NEVER return a shared constant like "anonymous" —
+   * that re-introduces VULN-AUTH-2.
+   */
+  getUserId: GetUserIdFn;
 }
 
 export function createOAuthInitHandler(
   config: OAuthServiceConfig,
-  options: OAuthInitHandlerOptions = {},
-): () => Promise<Response> {
+  options: OAuthInitHandlerOptions,
+): (req: Request) => Promise<Response> {
   const {
     tokenStore = memoryTokenStore,
     baseUrl,
     authOptions = {},
     env = getEnvironmentConfig(),
     envReader = getEnv,
-  } = options;
+    isAuthenticated,
+    getUserId,
+  } = options ?? ({} as OAuthInitHandlerOptions);
 
-  return async function handler(): Promise<Response> {
+  return async function handler(req: Request): Promise<Response> {
+    if (await isRequestUnauthorized(req, isAuthenticated)) {
+      return createUnauthorizedResponse();
+    }
+
+    const userId = await resolveUserId(req, getUserId);
+    if (!userId) return createUnauthorizedResponse();
+
     const service = new OAuthService(config, tokenStore, envReader);
 
     if (!service.isConfigured()) {
@@ -87,7 +132,15 @@ export function createOAuthInitHandler(
 
     try {
       const { url, state } = await service.createAuthorizationUrl({ ...authOptions, redirectUri });
-      await tokenStore.setState(state);
+      await tokenStore.setState(state.state, {
+        userId,
+        serviceId: config.serviceId,
+        codeVerifier: state.codeVerifier,
+        redirectUri: state.redirectUri,
+        scopes: state.scopes,
+        createdAt: state.createdAt,
+        metadata: state.metadata,
+      });
       return Response.redirect(url);
     } catch (error) {
       logger.error("Init error", { serviceId: config.serviceId }, error);
@@ -105,24 +158,31 @@ export interface OAuthStatusHandlerOptions {
 
   /** Optional authentication check — return true if the request is authenticated */
   isAuthenticated?: (req: Request) => boolean | Promise<boolean>;
+
+  /** REQUIRED. Resolve the authenticated user's id (see OAuthInitHandlerOptions). */
+  getUserId: GetUserIdFn;
 }
 
 export function createOAuthStatusHandler(
   config: OAuthServiceConfig,
-  options: OAuthStatusHandlerOptions = {},
+  options: OAuthStatusHandlerOptions,
 ): (req: Request) => Promise<Response> {
   const {
     tokenStore = memoryTokenStore,
     envReader = getEnv,
     isAuthenticated,
-  } = options;
+    getUserId,
+  } = options ?? ({} as OAuthStatusHandlerOptions);
 
   return async function handler(req: Request): Promise<Response> {
     if (await isRequestUnauthorized(req, isAuthenticated)) {
       return createUnauthorizedResponse();
     }
 
-    const tokens = await tokenStore.getTokens(config.serviceId);
+    const userId = await resolveUserId(req, getUserId);
+    if (!userId) return createUnauthorizedResponse();
+
+    const tokens = await tokenStore.getTokens(config.serviceId, userId);
 
     const isConnected = !!tokens?.accessToken;
     const isExpired = tokens?.expiresAt ? Date.now() > tokens.expiresAt : false;
@@ -139,22 +199,30 @@ export function createOAuthStatusHandler(
   };
 }
 
+export interface OAuthDisconnectHandlerOptions {
+  tokenStore?: TokenStore;
+  /** Optional authentication check — return true if the request is authenticated */
+  isAuthenticated?: (req: Request) => boolean | Promise<boolean>;
+  /** REQUIRED. Resolve the authenticated user's id (see OAuthInitHandlerOptions). */
+  getUserId: GetUserIdFn;
+}
+
 export function createOAuthDisconnectHandler(
   config: OAuthServiceConfig,
-  options: {
-    tokenStore?: TokenStore;
-    /** Optional authentication check — return true if the request is authenticated */
-    isAuthenticated?: (req: Request) => boolean | Promise<boolean>;
-  } = {},
+  options: OAuthDisconnectHandlerOptions,
 ): (req: Request) => Promise<Response> {
-  const { tokenStore = memoryTokenStore, isAuthenticated } = options;
+  const { tokenStore = memoryTokenStore, isAuthenticated, getUserId } = options ??
+    ({} as OAuthDisconnectHandlerOptions);
 
   return async function handler(req: Request): Promise<Response> {
     if (await isRequestUnauthorized(req, isAuthenticated)) {
       return createUnauthorizedResponse();
     }
 
-    await tokenStore.clearTokens(config.serviceId);
+    const userId = await resolveUserId(req, getUserId);
+    if (!userId) return createUnauthorizedResponse();
+
+    await tokenStore.clearTokens(config.serviceId, userId);
 
     return Response.json({
       success: true,

--- a/src/oauth/providers/base.ts
+++ b/src/oauth/providers/base.ts
@@ -314,8 +314,15 @@ export class OAuthService extends OAuthProvider {
     });
   }
 
-  async getAccessToken(): Promise<string | null> {
-    const tokens = await this.tokenStore?.getTokens(this.serviceId);
+  /**
+   * Get a valid access token for the given user, refreshing if needed.
+   *
+   * `userId` is required — this store is keyed by `(serviceId, userId)` to
+   * prevent one user's OAuth completion from overwriting another user's
+   * tokens. See VULN-AUTH-2.
+   */
+  async getAccessToken(userId: string): Promise<string | null> {
+    const tokens = await this.tokenStore?.getTokens(this.serviceId, userId);
     if (!tokens) return null;
 
     const isExpired = tokens.expiresAt && Date.now() > tokens.expiresAt - TOKEN_REFRESH_BUFFER_MS;
@@ -329,12 +336,12 @@ export class OAuthService extends OAuthProvider {
     if (!this.tokenStore) {
       throw new Error("TokenStore not configured");
     }
-    await this.tokenStore.setTokens(this.serviceId, result.tokens);
+    await this.tokenStore.setTokens(this.serviceId, userId, result.tokens);
     return result.tokens.accessToken;
   }
 
-  async fetch<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
-    const token = await this.getAccessToken();
+  async fetch<T>(userId: string, endpoint: string, options: RequestInit = {}): Promise<T> {
+    const token = await this.getAccessToken(userId);
     if (!token) {
       throw TOKEN_STORAGE_ERROR.create({
         detail: `Not authenticated with ${this.serviceConfig.displayName}`,

--- a/src/oauth/token-store/index.ts
+++ b/src/oauth/token-store/index.ts
@@ -5,4 +5,4 @@
  */
 
 export { MemoryTokenStore, memoryTokenStore } from "./memory.ts";
-export type { OAuthState, OAuthTokens, TokenStore } from "../types.ts";
+export type { OAuthState, OAuthTokens, StoredOAuthState, TokenStore } from "../types.ts";

--- a/src/oauth/token-store/memory.ts
+++ b/src/oauth/token-store/memory.ts
@@ -1,69 +1,82 @@
-import type { OAuthState, OAuthTokens, TokenStore } from "../types.ts";
+import type { OAuthTokens, StoredOAuthState, TokenStore } from "../types.ts";
 
-/** How long an OAuth state nonce remains valid (10 minutes). */
-const STATE_EXPIRATION_MS = 10 * 60 * 1_000;
+/** State expiry window: reject any state older than this (10 minutes). */
+const STATE_EXPIRY_MS = 10 * 60 * 1_000;
 
+/**
+ * In-memory TokenStore keyed by `(serviceId, userId)`.
+ *
+ * Suitable for development and tests. For production use a persistent store
+ * (Redis, Postgres, ...) keyed the same way. Never share a single slot per
+ * service across users — see VULN-AUTH-2.
+ */
 export class MemoryTokenStore implements TokenStore {
   private tokens = new Map<string, OAuthTokens>();
-  private states = new Map<string, OAuthState>();
+  private states = new Map<string, StoredOAuthState>();
   private projectId: string;
 
   constructor(projectId = "default") {
     this.projectId = projectId;
   }
 
-  private scopedKey(serviceId: string): string {
-    return `${this.projectId}:${serviceId}`;
+  private scopedKey(serviceId: string, userId: string): string {
+    return `${this.projectId}:${serviceId}:${userId}`;
   }
 
-  async getTokens(serviceId: string): Promise<OAuthTokens | null> {
-    return this.tokens.get(this.scopedKey(serviceId)) ?? null;
+  getTokens(serviceId: string, userId: string): Promise<OAuthTokens | null> {
+    return Promise.resolve(this.tokens.get(this.scopedKey(serviceId, userId)) ?? null);
   }
 
-  async setTokens(serviceId: string, tokens: OAuthTokens): Promise<void> {
-    this.tokens.set(this.scopedKey(serviceId), tokens);
+  setTokens(serviceId: string, userId: string, tokens: OAuthTokens): Promise<void> {
+    this.tokens.set(this.scopedKey(serviceId, userId), tokens);
+    return Promise.resolve();
   }
 
-  async clearTokens(serviceId: string): Promise<void> {
-    this.tokens.delete(this.scopedKey(serviceId));
+  clearTokens(serviceId: string, userId: string): Promise<void> {
+    this.tokens.delete(this.scopedKey(serviceId, userId));
+    return Promise.resolve();
   }
 
-  async getState(state: string): Promise<OAuthState | null> {
-    const storedState = this.states.get(state);
-    if (!storedState) return null;
-
-    if (Date.now() - storedState.createdAt > STATE_EXPIRATION_MS) {
-      this.states.delete(state);
-      return null;
-    }
-
-    return storedState;
-  }
-
-  async setState(storedState: OAuthState): Promise<void> {
-    this.states.set(storedState.state, storedState);
+  setState(state: string, meta: StoredOAuthState): Promise<void> {
+    this.states.set(state, meta);
     this.cleanupExpiredStates();
+    return Promise.resolve();
   }
 
-  async clearState(state: string): Promise<void> {
+  /**
+   * Atomically read and delete state (one-shot). Returns null for unknown or
+   * expired entries. Expired entries are removed on read.
+   */
+  consumeState(state: string): Promise<StoredOAuthState | null> {
+    const meta = this.states.get(state);
+    if (!meta) return Promise.resolve(null);
     this.states.delete(state);
+    if (Date.now() - meta.createdAt > STATE_EXPIRY_MS) {
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(meta);
   }
 
   private cleanupExpiredStates(): void {
     const now = Date.now();
-    for (const [state, storedState] of this.states) {
-      if (now - storedState.createdAt > STATE_EXPIRATION_MS) {
+    for (const [state, meta] of this.states) {
+      if (now - meta.createdAt > STATE_EXPIRY_MS) {
         this.states.delete(state);
       }
     }
   }
 
+  /** List connected slots as `${serviceId}:${userId}` strings (test/debug aid). */
   getConnectedServices(): string[] {
-    return [...this.tokens.keys()];
+    const prefix = `${this.projectId}:`;
+    return [...this.tokens.keys()].map((key) =>
+      key.startsWith(prefix) ? key.slice(prefix.length) : key
+    );
   }
 
-  isConnected(serviceId: string): boolean {
-    const tokens = this.tokens.get(this.scopedKey(serviceId));
+  /** Whether a given user has usable tokens for a service. */
+  isConnected(serviceId: string, userId: string): boolean {
+    const tokens = this.tokens.get(this.scopedKey(serviceId, userId));
     if (!tokens) return false;
 
     const isExpired = tokens.expiresAt != null && Date.now() > tokens.expiresAt;
@@ -76,4 +89,4 @@ export class MemoryTokenStore implements TokenStore {
   }
 }
 
-export const memoryTokenStore = new MemoryTokenStore();
+export const memoryTokenStore: TokenStore = new MemoryTokenStore();

--- a/src/oauth/types.ts
+++ b/src/oauth/types.ts
@@ -10,13 +10,40 @@ export type {
 } from "./schemas/index.ts";
 
 // Import types used locally in this file
-import type { OAuthState, OAuthTokens } from "./schemas/index.ts";
+import type { OAuthTokens } from "./schemas/index.ts";
 
+/**
+ * Persisted OAuth state row. Created when init handler starts a flow and
+ * consumed exactly once by the callback handler.
+ *
+ * `userId` binds the flow to the authenticated user who initiated it so the
+ * resulting tokens are stored in that user's slot (not a shared one).
+ */
+export interface StoredOAuthState {
+  userId: string;
+  serviceId: string;
+  codeVerifier?: string;
+  redirectUri?: string;
+  scopes?: string[];
+  createdAt: number;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * TokenStore is keyed by `(serviceId, userId)` — tokens are per-user.
+ *
+ * Using a single-slot-per-service store is a vulnerability: the last OAuth
+ * completion overwrites all others, so an attacker who starts and finishes
+ * an OAuth flow with their own account can cause server-side code to act
+ * on the attacker's account. Callers MUST pass `userId` from authenticated
+ * session context.
+ */
 export interface TokenStore {
-  getTokens(serviceId: string): Promise<OAuthTokens | null>;
-  setTokens(serviceId: string, tokens: OAuthTokens): Promise<void>;
-  clearTokens(serviceId: string): Promise<void>;
-  getState(state: string): Promise<OAuthState | null>;
-  setState(state: OAuthState): Promise<void>;
-  clearState(state: string): Promise<void>;
+  getTokens(serviceId: string, userId: string): Promise<OAuthTokens | null>;
+  setTokens(serviceId: string, userId: string, tokens: OAuthTokens): Promise<void>;
+  clearTokens(serviceId: string, userId: string): Promise<void>;
+  /** Persist a new OAuth state row for the initiating user. */
+  setState(state: string, meta: StoredOAuthState): Promise<void>;
+  /** Atomically read and delete state. Returns null if unknown/expired. */
+  consumeState(state: string): Promise<StoredOAuthState | null>;
 }

--- a/tests/docs/guide-examples.test.ts
+++ b/tests/docs/guide-examples.test.ts
@@ -671,10 +671,13 @@ describe("Guide: oauth.mdx", () => {
   });
 
   it("should create OAuth handlers from config", () => {
-    const initHandler = createOAuthInitHandler(githubConfig);
+    // Auth-scoped handlers require a getUserId resolver. In real apps the
+    // resolver reads session/JWT; for docs purposes a simple stub suffices.
+    const getUserId = () => "user-1";
+    const initHandler = createOAuthInitHandler(githubConfig, { getUserId });
     const callbackHandler = createOAuthCallbackHandler(githubConfig);
-    const statusHandler = createOAuthStatusHandler(githubConfig);
-    const disconnectHandler = createOAuthDisconnectHandler(githubConfig);
+    const statusHandler = createOAuthStatusHandler(githubConfig, { getUserId });
+    const disconnectHandler = createOAuthDisconnectHandler(githubConfig, { getUserId });
 
     assert(typeof initHandler === "function");
     assert(typeof callbackHandler === "function");
@@ -682,21 +685,25 @@ describe("Guide: oauth.mdx", () => {
     assert(typeof disconnectHandler === "function");
   });
 
-  it("should support MemoryTokenStore for token persistence", async () => {
+  it("should support MemoryTokenStore for per-user token persistence", async () => {
     const store = new MemoryTokenStore();
 
     // No tokens initially
-    const initial = await store.getTokens("github");
+    const initial = await store.getTokens("github", "user-1");
     assertEquals(initial, null);
 
     // Store tokens
-    await store.setTokens("github", { accessToken: "test-token" });
-    const tokens = await store.getTokens("github");
+    await store.setTokens("github", "user-1", { accessToken: "test-token" });
+    const tokens = await store.getTokens("github", "user-1");
     assertEquals(tokens?.accessToken, "test-token");
 
+    // Different user's slot is untouched
+    const otherUser = await store.getTokens("github", "user-2");
+    assertEquals(otherUser, null);
+
     // Clear tokens
-    await store.clearTokens("github");
-    const after = await store.getTokens("github");
+    await store.clearTokens("github", "user-1");
+    const after = await store.getTokens("github", "user-1");
     assertEquals(after, null);
   });
 
@@ -713,7 +720,7 @@ describe("Guide: oauth.mdx", () => {
       apiBaseUrl: "https://api.provider.com",
     };
 
-    const handler = createOAuthInitHandler(myProvider);
+    const handler = createOAuthInitHandler(myProvider, { getUserId: () => "user-1" });
     assert(typeof handler === "function");
   });
 });


### PR DESCRIPTION
## Summary

PR 6 of `plans/security-audit-17.4.2026.md`. **Breaking change — OAuth API signatures now require `getUserId`.**

Fixes **VULN-AUTH-2** — two defects:
1. `createOAuthInitHandler` has no `isAuthenticated` option; any unauthenticated user can start an OAuth flow.
2. `TokenStore` keyed tokens by `serviceId` only — a single global slot per service, last caller wins, so an attacker's flow overwrites victims' tokens and the server acts on the attacker's account.

## Fix

- `OAuthInitHandlerOptions.getUserId` is now mandatory; init returns 401 without it.
- `TokenStore` keys by `(serviceId, userId)`; `setState`/`consumeState` carry `userId` through the callback.
- `OAuthService.fetch` / `setTokens` / `getTokens` require `userId` (compile-time contract).
- Status & disconnect handlers updated likewise.
- CLI callback templates migrated to the new contract:
  - `drive`, `discord`, `teams` — `setTokens`/`clearTokens` now take `userId` (removed the undefined `USER_ID` placeholder).
  - `bitbucket`, `notion` — swapped legacy `getState`/`clearState` for `setState(state, meta)` + `consumeState`.

## Test plan

- [x] `deno test src/oauth/`
- [x] Unauthenticated init → 401
- [x] Alice's callback does NOT overwrite Bob's token slot
- [x] All 5 updated CLI callback templates expose `consumeState` and per-user `setTokens(serviceId, userId, tokens)` / `clearTokens(serviceId, userId)` — no stale `USER_ID` / `getState` / `clearState` references remain
- [x] CI: format, lint, typecheck, unit, integration, rsc browser e2e all green
