### PR TITLE
fix(security): reject symlink traversal in workspace-sync (VULN-FS-4)

### DIFF
--- a/src/workflow/claude-code/workspace-sync.test.ts
+++ b/src/workflow/claude-code/workspace-sync.test.ts
@@ -174,6 +174,15 @@ describe("WorkspaceSync symlink hardening (VULN-FS-4)", () => {
     assertEquals(await Deno.readTextFile(join(workspaceDir, "a", "b", "c.txt")), "deep");
   });
 
+  it("rejects empty path and bare '/' that would resolve to the workspace root", async () => {
+    const { workspace, workspaceDir } = await makeWorkspace(baseDir);
+    await assertRejects(() => workspace.writeFile("", "x"), Error);
+    await assertRejects(() => workspace.writeFile("/", "x"), Error);
+    // Workspace dir must remain a directory, not be clobbered into a file.
+    const info = await Deno.stat(workspaceDir);
+    assertEquals(info.isDirectory, true);
+  });
+
   it("rejects paths containing a NUL byte", async () => {
     const { workspace } = await makeWorkspace(baseDir);
     await assertRejects(

--- a/src/workflow/claude-code/workspace-sync.test.ts
+++ b/src/workflow/claude-code/workspace-sync.test.ts
@@ -271,4 +271,30 @@ describe("WorkspaceSync symlink hardening (VULN-FS-4)", () => {
     const { workspaceDir } = await makeWorkspace(baseDir);
     assertEquals(dirname(join(workspaceDir, "a", "b.txt")), join(workspaceDir, "a"));
   });
+
+  it("detectChanges does NOT descend into symlinked directories (VULN-FS-4)", async () => {
+    const { workspace, workspaceDir } = await makeWorkspace(baseDir);
+    // Seed a legitimate file so initialize()-free harness still has something
+    // under the workspace to contrast with.
+    await workspace.writeFile("real.txt", "real");
+
+    // Put a secret file in the outside dir — it must NOT end up in changes.
+    const secret = join(escapeDir, "secret.txt");
+    await Deno.writeTextFile(secret, "this-must-not-leak");
+
+    // Plant an attacker symlink pointing to the escape directory.
+    await Deno.symlink(escapeDir, join(workspaceDir, "outside"));
+
+    // detectChanges requires initialized=true. Flip it via a tiny cast to
+    // bypass the API-dependent initialize() path for this unit test.
+    (workspace as unknown as { initialized: boolean }).initialized = true;
+
+    const changes = await workspace.detectChanges();
+
+    // Must see real.txt as created, and NOTHING whose path resolves under
+    // the escape directory.
+    const leakedPaths = changes.filter((c) => c.path.includes("outside/"));
+    assertEquals(leakedPaths, []);
+    assertEquals(changes.some((c) => c.path === "/real.txt"), true);
+  });
 });

--- a/src/workflow/claude-code/workspace-sync.test.ts
+++ b/src/workflow/claude-code/workspace-sync.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for WorkspaceSync symlink hardening (VULN-FS-4).
+ *
+ * These tests exercise resolveSafePath indirectly via the public file methods
+ * (writeFile / readFile / deleteFile / fileExists) to verify that:
+ *
+ *   - Symlinks in the workspace are rejected — even when they point inside
+ *     the workspace — to avoid race-susceptible traversal.
+ *   - Symlinks at any intermediate path segment are caught.
+ *   - Dangling symlinks do not cause the target file to be created.
+ *   - Relative symlinks that escape the workspace are rejected.
+ *   - Absolute paths and NUL bytes are rejected as bad input.
+ *   - Normal deep-nested writes with no symlinks still succeed.
+ *   - Unicode paths with combining characters still succeed.
+ */
+
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { dirname, join } from "@std/path";
+import { WorkspaceSync } from "./workspace-sync.ts";
+import type { CapturedTenantContext } from "../types.ts";
+
+function stubTenant(): CapturedTenantContext {
+  return {
+    projectSlug: "test-project",
+    token: "test-token",
+    productionMode: false,
+  };
+}
+
+/**
+ * Create a WorkspaceSync whose workspaceDir is an already-prepared temp dir
+ * (without going through initialize(), which requires live API calls).
+ */
+async function makeWorkspace(baseDir: string): Promise<{
+  workspace: WorkspaceSync;
+  workspaceDir: string;
+}> {
+  const runId = "runtest";
+  const workspace = new WorkspaceSync({
+    baseDir,
+    runId,
+    tenant: stubTenant(),
+  });
+  const workspaceDir = workspace.workspaceDir;
+  await Deno.mkdir(workspaceDir, { recursive: true });
+  return { workspace, workspaceDir };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await Deno.lstat(path);
+    return true;
+  } catch (e) {
+    if (e instanceof Deno.errors.NotFound) return false;
+    throw e;
+  }
+}
+
+describe("WorkspaceSync symlink hardening (VULN-FS-4)", () => {
+  let baseDir: string;
+  let escapeDir: string;
+  let escapeFile: string;
+
+  beforeEach(async () => {
+    baseDir = await Deno.makeTempDir({ prefix: "vf-ws-sync-base-" });
+    escapeDir = await Deno.makeTempDir({ prefix: "vf-ws-sync-outside-" });
+    escapeFile = join(escapeDir, "victim.txt");
+    await Deno.writeTextFile(escapeFile, "original outside content");
+  });
+
+  afterEach(async () => {
+    for (const dir of [baseDir, escapeDir]) {
+      try {
+        await Deno.remove(dir, { recursive: true });
+      } catch (e) {
+        if (!(e instanceof Deno.errors.NotFound)) throw e;
+      }
+    }
+  });
+
+  it("rejects write through a direct symlink pointing outside the workspace", async () => {
+    const { workspace, workspaceDir } = await makeWorkspace(baseDir);
+    // Pre-existing malicious symlink from a prior run.
+    await Deno.symlink(escapeFile, join(workspaceDir, "a.txt"));
+
+    await assertRejects(
+      () => workspace.writeFile("a.txt", "PWNED"),
+      Error,
+    );
+
+    // Victim file is untouched.
+    const victimContent = await Deno.readTextFile(escapeFile);
+    assertEquals(victimContent, "original outside content");
+  });
+
+  it("rejects write when an intermediate directory segment is a symlink", async () => {
+    const { workspace, workspaceDir } = await makeWorkspace(baseDir);
+    // workspace/sub -> /tmp/<escape>
+    await Deno.symlink(escapeDir, join(workspaceDir, "sub"));
+
+    await assertRejects(
+      () => workspace.writeFile("sub/x.txt", "PWNED"),
+      Error,
+    );
+
+    // No file created inside the escape directory.
+    assertEquals(await exists(join(escapeDir, "x.txt")), false);
+  });
+
+  it("rejects write through a dangling symlink and does NOT create the target", async () => {
+    const { workspace, workspaceDir } = await makeWorkspace(baseDir);
+    const missingTarget = join(escapeDir, "does-not-exist-yet.txt");
+    await Deno.symlink(missingTarget, join(workspaceDir, "dangle.txt"));
+
+    await assertRejects(
+      () => workspace.writeFile("dangle.txt", "PWNED"),
+      Error,
+    );
+
+    // The dangling target must not have been materialised.
+    assertEquals(await exists(missingTarget), false);
+  });
+
+  it("rejects relative symlinks that resolve outside the workspace", async () => {
+    const { workspace, workspaceDir } = await makeWorkspace(baseDir);
+    // workspace/a -> ../../etc/hostname (relative escape)
+    await Deno.symlink("../../etc/hostname", join(workspaceDir, "a"));
+    assertEquals((await Deno.lstat(join(workspaceDir, "a"))).isSymlink, true);
+
+    await assertRejects(
+      () => workspace.writeFile("a", "PWNED"),
+      Error,
+    );
+  });
+
+  it("rejects a symlink even when its target is INSIDE the workspace (safer treatment)", async () => {
+    const { workspace, workspaceDir } = await makeWorkspace(baseDir);
+    const realFile = join(workspaceDir, "real.txt");
+    await Deno.writeTextFile(realFile, "original");
+    // workspace/alias -> workspace/real.txt
+    await Deno.symlink(realFile, join(workspaceDir, "alias"));
+
+    await assertRejects(
+      () => workspace.writeFile("alias", "overwritten"),
+      Error,
+    );
+
+    // Target still has its original content.
+    assertEquals(await Deno.readTextFile(realFile), "original");
+  });
+
+  it("pre-existing symlink is still caught on the single writeFile call", async () => {
+    const { workspace, workspaceDir } = await makeWorkspace(baseDir);
+    // Simulate attacker-placed symlink before a single write call.
+    await Deno.symlink(escapeFile, join(workspaceDir, "race.txt"));
+
+    await assertRejects(
+      () => workspace.writeFile("race.txt", "PWNED"),
+      Error,
+    );
+    assertEquals(await Deno.readTextFile(escapeFile), "original outside content");
+  });
+
+  it("allows a normal write with no symlinks present", async () => {
+    const { workspace, workspaceDir } = await makeWorkspace(baseDir);
+    await workspace.writeFile("hello.txt", "world");
+    assertEquals(await Deno.readTextFile(join(workspaceDir, "hello.txt")), "world");
+  });
+
+  it("supports nested path creation where intermediate dirs do not yet exist", async () => {
+    const { workspace, workspaceDir } = await makeWorkspace(baseDir);
+    await workspace.writeFile("a/b/c.txt", "deep");
+    assertEquals(await Deno.readTextFile(join(workspaceDir, "a", "b", "c.txt")), "deep");
+  });
+
+  it("rejects paths containing a NUL byte", async () => {
+    const { workspace } = await makeWorkspace(baseDir);
+    await assertRejects(
+      () => workspace.writeFile("bad\0name.txt", "x"),
+      Error,
+    );
+  });
+
+  it("accepts Unicode paths with combining characters", async () => {
+    const { workspace, workspaceDir } = await makeWorkspace(baseDir);
+    // "café" with a combining acute accent (e + U+0301).
+    const weird = "cafe\u0301/re\u0301sume\u0301.txt";
+    await workspace.writeFile(weird, "unicode ok");
+    const expected = join(workspaceDir, "cafe\u0301", "re\u0301sume\u0301.txt");
+    assertEquals(await Deno.readTextFile(expected), "unicode ok");
+  });
+
+  it("rejects Windows-style drive-letter absolute paths", async () => {
+    const { workspace } = await makeWorkspace(baseDir);
+    await assertRejects(
+      () => workspace.writeFile("C:\\Windows\\pwn.txt", "x"),
+      Error,
+    );
+  });
+
+  it("rejects UNC-style double-slash paths", async () => {
+    const { workspace } = await makeWorkspace(baseDir);
+    await assertRejects(
+      () => workspace.writeFile("//evil-host/share/pwn.txt", "x"),
+      Error,
+    );
+  });
+
+  it("an absolute-looking Unix path does NOT escape the workspace", async () => {
+    // The one-leading-slash API convention treats this as workspace-relative;
+    // the critical property is that the write must not land outside.
+    const { workspace, workspaceDir } = await makeWorkspace(baseDir);
+    const outsidePath = join(escapeDir, "pwned.txt");
+    await workspace.writeFile(outsidePath, "x");
+    assertEquals(await exists(outsidePath), false);
+    // It ends up safely inside the workspace instead.
+    assertEquals(
+      await exists(join(workspaceDir, outsidePath.replace(/^\/+/, ""))),
+      true,
+    );
+  });
+
+  it("rejects readFile through a symlink", async () => {
+    const { workspace, workspaceDir } = await makeWorkspace(baseDir);
+    await Deno.symlink(escapeFile, join(workspaceDir, "read.txt"));
+    await assertRejects(
+      () => workspace.readFile("read.txt"),
+      Error,
+    );
+  });
+
+  it("rejects deleteFile through a symlink and leaves target intact", async () => {
+    const { workspace, workspaceDir } = await makeWorkspace(baseDir);
+    await Deno.symlink(escapeFile, join(workspaceDir, "del.txt"));
+    await assertRejects(
+      () => workspace.deleteFile("del.txt"),
+      Error,
+    );
+    assertEquals(await exists(escapeFile), true);
+  });
+
+  it("fileExists returns false (does not throw) when a symlink is present", async () => {
+    const { workspace, workspaceDir } = await makeWorkspace(baseDir);
+    await Deno.symlink(escapeFile, join(workspaceDir, "probe.txt"));
+    // fileExists swallows errors by design; it should report "no such safe file"
+    // rather than following the symlink.
+    const result = await workspace.fileExists("probe.txt");
+    assertEquals(result, false);
+  });
+
+  it("symlink planted between writes on same workspace is caught on next write", async () => {
+    const { workspace, workspaceDir } = await makeWorkspace(baseDir);
+    // First write: clean.
+    await workspace.writeFile("file.txt", "first");
+    assertEquals(await Deno.readTextFile(join(workspaceDir, "file.txt")), "first");
+
+    // Attacker replaces the file with a symlink mid-session.
+    await Deno.remove(join(workspaceDir, "file.txt"));
+    await Deno.symlink(escapeFile, join(workspaceDir, "file.txt"));
+
+    await assertRejects(
+      () => workspace.writeFile("file.txt", "PWNED"),
+      Error,
+    );
+    assertEquals(await Deno.readTextFile(escapeFile), "original outside content");
+  });
+
+  // Sanity: dirname helper is exercised elsewhere too.
+  it("dirname of a nested safe path matches the workspace", async () => {
+    const { workspaceDir } = await makeWorkspace(baseDir);
+    assertEquals(dirname(join(workspaceDir, "a", "b.txt")), join(workspaceDir, "a"));
+  });
+});

--- a/src/workflow/claude-code/workspace-sync.ts
+++ b/src/workflow/claude-code/workspace-sync.ts
@@ -314,14 +314,26 @@ export class WorkspaceSync {
   }
 
   /**
-   * Recursively walk directory and detect changes
+   * Recursively walk directory and detect changes.
+   *
+   * SECURITY: Uses lstat (not stat) and skips any symlink it finds, so a
+   * symlink planted inside the workspace cannot cause us to descend into —
+   * or read the contents of — files outside the workspace (VULN-FS-4).
    */
   private async walkAndDetect(
     localPath: string,
     relativePath: string,
     changes: FileChange[],
   ): Promise<void> {
-    const stat = await Deno.stat(localPath);
+    const stat = await Deno.lstat(localPath);
+
+    // Ignore symlinks outright — we never treat them as real files here.
+    if (stat.isSymlink) {
+      if (this.config.debug) {
+        logger.info("Skipping symlink during change detection", { localPath });
+      }
+      return;
+    }
 
     if (stat.isDirectory) {
       for await (const entry of Deno.readDir(localPath)) {
@@ -334,7 +346,7 @@ export class WorkspaceSync {
       return;
     }
 
-    // It's a file - check for changes
+    // It's a regular file - check for changes
     const content = await Deno.readTextFile(localPath);
     const newHash = await checksum(content);
     const originalHash = this.fileChecksums.get(relativePath);

--- a/src/workflow/claude-code/workspace-sync.ts
+++ b/src/workflow/claude-code/workspace-sync.ts
@@ -470,10 +470,16 @@ export class WorkspaceSync {
     // Normalize the input path (treat leading "/" as workspace-relative).
     const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
 
+    // Empty path resolves to the workspace dir itself — writing to it would
+    // clobber the workspace as a regular file. Reject explicitly.
+    if (normalizedPath === "") {
+      throw SECURITY_VIOLATION.create({ detail: `Empty path not allowed` });
+    }
+
     // Resolve the full path lexically first (catches literal "..").
     const fullPath = resolve(join(this.workspaceDir, normalizedPath));
     const relativePath = relative(this.workspaceDir, fullPath);
-    if (relativePath.startsWith("..") || relativePath === "..") {
+    if (!relativePath || relativePath.startsWith("..") || relativePath === "..") {
       throw SECURITY_VIOLATION.create({ detail: `Path traversal detected: ${path}` });
     }
 

--- a/src/workflow/claude-code/workspace-sync.ts
+++ b/src/workflow/claude-code/workspace-sync.ts
@@ -13,8 +13,9 @@
 import { logger as baseLogger } from "#veryfront/utils";
 import { api } from "../api.ts";
 import type { CapturedTenantContext } from "../types.ts";
-import { join, relative, resolve } from "@std/path";
+import { dirname, join, relative, resolve } from "@std/path";
 import { INITIALIZATION_ERROR, INVALID_ARGUMENT, SECURITY_VIOLATION } from "#veryfront/errors";
+import { isWithinDirectory } from "#veryfront/utils/path-utils.ts";
 
 const logger = baseLogger.component("workspace-sync");
 
@@ -228,8 +229,8 @@ export class WorkspaceSync {
         this.fileChecksums.set(path, hash);
 
         // Write to local filesystem (use safe path resolution)
-        const localPath = this.resolveSafePath(path);
-        const dir = localPath.substring(0, localPath.lastIndexOf("/"));
+        const localPath = await this.resolveSafePath(path);
+        const dir = dirname(localPath);
         await Deno.mkdir(dir, { recursive: true });
         await Deno.writeTextFile(localPath, content);
 
@@ -293,7 +294,7 @@ export class WorkspaceSync {
     // Check for deleted files
     for (const [path, originalHash] of this.fileChecksums) {
       try {
-        const localPath = this.resolveSafePath(path);
+        const localPath = await this.resolveSafePath(path);
         await Deno.stat(localPath);
       } catch (_) {
         // File was deleted
@@ -388,7 +389,7 @@ export class WorkspaceSync {
       }
 
       try {
-        const localPath = this.resolveSafePath(change.path);
+        const localPath = await this.resolveSafePath(change.path);
         const content = await Deno.readTextFile(localPath);
 
         if (options.onUpload) {
@@ -418,19 +419,89 @@ export class WorkspaceSync {
   }
 
   /**
-   * Safely resolve a path within the workspace, preventing path traversal attacks
+   * Safely resolve a path within the workspace, preventing path traversal
+   * and symlink-based escapes (VULN-FS-4).
+   *
+   * - Rejects NUL bytes outright.
+   * - Rejects any intermediate path segment that is a symlink.
+   * - Re-checks containment by realpath-ing the parent directory after the
+   *   segment walk, so a symlink that resolves through a non-symlink directory
+   *   chain still cannot escape the workspace.
+   *
+   * Note: this deliberately rejects ALL symlinks inside the workspace — even
+   * those whose targets remain within it — because the race window between
+   * resolution and use is not worth the complexity for our use-case.
    */
-  private resolveSafePath(path: string): string {
-    // Normalize the input path
+  private async resolveSafePath(path: string): Promise<string> {
+    // Reject NUL bytes — they confuse filesystem APIs and are never legitimate.
+    if (path.includes("\0")) {
+      throw SECURITY_VIOLATION.create({ detail: `NUL byte in path` });
+    }
+
+    // Workspace-relative paths only. A single leading "/" is the canonical
+    // API form for "the project root" (e.g. "/src/foo.ts") and is accepted;
+    // anything that syntactically looks like a system-absolute path beyond
+    // that one-slash convention is rejected.
+    //
+    // - Windows drive letters (C:\...) — rejected.
+    // - UNC paths (//host/share) — rejected.
+    // - Unix absolute paths with a leading slash are treated as
+    //   workspace-relative, but any component that tries to escape the
+    //   workspace is still caught by the traversal / realpath checks below.
+    if (/^[A-Za-z]:[\\/]/.test(path)) {
+      throw SECURITY_VIOLATION.create({ detail: `Absolute path not allowed: ${path}` });
+    }
+    if (path.startsWith("//")) {
+      throw SECURITY_VIOLATION.create({ detail: `Absolute path not allowed: ${path}` });
+    }
+
+    // Normalize the input path (treat leading "/" as workspace-relative).
     const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
 
-    // Resolve the full path
+    // Resolve the full path lexically first (catches literal "..").
     const fullPath = resolve(join(this.workspaceDir, normalizedPath));
-
-    // Verify the resolved path is within the workspace
     const relativePath = relative(this.workspaceDir, fullPath);
-    if (relativePath.startsWith("..") || !relativePath || relativePath === "..") {
+    if (relativePath.startsWith("..") || relativePath === "..") {
       throw SECURITY_VIOLATION.create({ detail: `Path traversal detected: ${path}` });
+    }
+
+    // Walk each segment and reject any existing symlink along the way.
+    // A segment that does not yet exist is fine — it will be created later.
+    const relSegments = relativePath === "" ? [] : relativePath.split(/[\\/]/).filter(Boolean);
+    let cursor = this.workspaceDir;
+    for (const seg of relSegments) {
+      cursor = join(cursor, seg);
+      try {
+        const info = await Deno.lstat(cursor);
+        if (info.isSymlink) {
+          throw SECURITY_VIOLATION.create({
+            detail: `Refusing to traverse symlink: ${cursor}`,
+          });
+        }
+      } catch (e) {
+        if (e instanceof Deno.errors.NotFound) {
+          // Segment doesn't exist yet — the rest of the chain will be
+          // created under a verified-non-symlink parent, so stop walking.
+          break;
+        }
+        throw e;
+      }
+    }
+
+    // Final containment check against the realpath of the parent directory,
+    // to defeat any symlink-in-parent we might have missed (e.g. one that
+    // appeared mid-walk). If the parent doesn't exist yet, that's fine —
+    // the segment walk above already proved every existing ancestor is real.
+    try {
+      const parentReal = await Deno.realPath(dirname(fullPath));
+      const workspaceReal = await Deno.realPath(this.workspaceDir);
+      if (!isWithinDirectory(workspaceReal, parentReal)) {
+        throw SECURITY_VIOLATION.create({
+          detail: `Resolved parent outside workspace: ${parentReal}`,
+        });
+      }
+    } catch (e) {
+      if (!(e instanceof Deno.errors.NotFound)) throw e;
     }
 
     return fullPath;
@@ -440,7 +511,7 @@ export class WorkspaceSync {
    * Read a file from the workspace
    */
   async readFile(path: string): Promise<string> {
-    const localPath = this.resolveSafePath(path);
+    const localPath = await this.resolveSafePath(path);
     return await Deno.readTextFile(localPath);
   }
 
@@ -448,10 +519,10 @@ export class WorkspaceSync {
    * Write a file to the workspace
    */
   async writeFile(path: string, content: string): Promise<void> {
-    const localPath = this.resolveSafePath(path);
+    const localPath = await this.resolveSafePath(path);
 
     // Ensure directory exists
-    const dir = localPath.substring(0, localPath.lastIndexOf("/"));
+    const dir = dirname(localPath);
     await Deno.mkdir(dir, { recursive: true });
 
     await Deno.writeTextFile(localPath, content);
@@ -461,7 +532,7 @@ export class WorkspaceSync {
    * Delete a file from the workspace
    */
   async deleteFile(path: string): Promise<void> {
-    const localPath = this.resolveSafePath(path);
+    const localPath = await this.resolveSafePath(path);
     await Deno.remove(localPath);
   }
 
@@ -470,7 +541,7 @@ export class WorkspaceSync {
    */
   async fileExists(path: string): Promise<boolean> {
     try {
-      const localPath = this.resolveSafePath(path);
+      const localPath = await this.resolveSafePath(path);
       await Deno.stat(localPath);
       return true;
     } catch (_) {


### PR DESCRIPTION
## Summary

PR 8 of `plans/security-audit-17.4.2026.md`.

Fixes **VULN-FS-4** — `resolveSafePath` in `workspace-sync.ts` blocks literal `../` but does not call `realpath`/`lstat`. A prior run's symlink at `workspaceDir/<name>` pointing outside the workspace makes subsequent `writeFile` calls follow it.

## Fix

- Walks each intermediate segment and throws if any is a symlink (`Deno.lstat`).
- Final containment check against `Deno.realPath(dirname(fullPath))` vs the workspace root.
- Missing segments (not-yet-created) are allowed so we can still write new files.
- Rejects empty normalized paths (`""`, `"/"`) so writes cannot clobber the workspace dir itself (Codex review fix).

## Test plan

- [x] `deno test src/workflow/claude-code/workspace-sync.test.ts` — 20/20 passing
- [x] Symlink pointing to `/tmp/evil` → `writeFile` throws and target is untouched (covered by `rejects write through a direct symlink pointing outside the workspace`)