### PR TITLE
fix(security): MCP server fails closed when auth is not explicitly configured (VULN-SRV-5)

### DIFF
--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -38,8 +38,6 @@ it is missing. Options:
 
 - `{ type: "bearer", validate }` (recommended for production) — validates a
   bearer token against your own logic.
-- `{ type: "api-key", validate }` — same as bearer but via a different header
-  convention.
 - `{ type: "none", allowUnauthenticated: true }` — **local development only**.
   Must be set explicitly; accepts every request without any check. Do not ship
   this to production.
@@ -122,11 +120,14 @@ import { registerTool } from "veryfront/mcp";
 import { tool } from "veryfront/tool";
 import { z } from "zod";
 
-registerTool("custom-tool", tool({
-  description: "A custom tool",
-  inputSchema: z.object({ input: z.string() }),
-  execute: async ({ input }) => ({ result: input.toUpperCase() }),
-}));
+registerTool(
+  "custom-tool",
+  tool({
+    description: "A custom tool",
+    inputSchema: z.object({ input: z.string() }),
+    execute: async ({ input }) => ({ result: input.toUpperCase() }),
+  }),
+);
 ```
 
 ## Transport note

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -15,7 +15,13 @@ This guide covers the application-facing MCP server exposed by `veryfront/mcp`. 
 ```ts
 import { createMCPServer } from "veryfront/mcp";
 
-const server = createMCPServer({ enabled: true });
+const server = createMCPServer({
+  enabled: true,
+  auth: {
+    type: "bearer",
+    validate: async (token) => token === Deno.env.get("MCP_TOKEN"),
+  },
+});
 const handler = server.createHTTPHandler();
 
 export const POST = handler;
@@ -24,6 +30,19 @@ export const OPTIONS = handler;
 ```
 
 Mount the handler on your application-owned MCP route. All auto-discovered tools, prompts, and resources are then exposed through the app-facing MCP transport.
+
+### Auth is required
+
+`auth` is a required field. The server fails closed at construction time if
+it is missing. Options:
+
+- `{ type: "bearer", validate }` (recommended for production) — validates a
+  bearer token against your own logic.
+- `{ type: "api-key", validate }` — same as bearer but via a different header
+  convention.
+- `{ type: "none", allowUnauthenticated: true }` — **local development only**.
+  Must be set explicitly; accepts every request without any check. Do not ship
+  this to production.
 
 The HTTP transport is session-based:
 

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -14,12 +14,12 @@ This is the application-facing MCP surface. It is separate from the internal AG-
 
 ```ts
 import {
+  clearMCPRegistry,
   createMCPServer,
-  registerTool,
+  getMCPRegistry,
   registerPrompt,
   registerResource,
-  clearMCPRegistry,
-  getMCPRegistry,
+  registerTool,
 } from "veryfront/mcp";
 ```
 
@@ -69,41 +69,41 @@ after `initialize`, and handles `POST`, `DELETE`, and `OPTIONS` requests.
 
 Current config shape:
 
-| Property | Type | Description |
-|------|-------------|-------------|
-| `enabled` | `boolean` | Enable the MCP server surface |
-| `port?` | `number` | Optional port for hosted/runtime wiring |
-| `auth` | `{ type: "bearer" \| "api-key"; validate?: Function } \| { type: "none"; allowUnauthenticated: true }` | **Required.** Request authentication. Use `{ type: "none", allowUnauthenticated: true }` only for local dev — the server fails closed when auth is unset. |
-| `cors?` | `{ enabled: boolean; origins?: string[] }` | Optional CORS configuration |
+| Property  | Type                                                                                      | Description                                                                                                                                               |
+| --------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled` | `boolean`                                                                                 | Enable the MCP server surface                                                                                                                             |
+| `port?`   | `number`                                                                                  | Optional port for hosted/runtime wiring                                                                                                                   |
+| `auth`    | `{ type: "bearer"; validate?: Function } \| { type: "none"; allowUnauthenticated: true }` | **Required.** Request authentication. Use `{ type: "none", allowUnauthenticated: true }` only for local dev — the server fails closed when auth is unset. |
+| `cors?`   | `{ enabled: boolean; origins?: string[] }`                                                | Optional CORS configuration                                                                                                                               |
 
 ## Exports
 
 ### Functions
 
-| Name | Description |
-|------|-------------|
-| `clearMCPRegistry` | Clear all registries |
-| `createMCPServer` | Create MCP server |
-| `getMCPRegistry` | Get tool/prompt/resource registry |
-| `getMCPStats` | Get registered capability stats |
-| `registerPrompt` | Register prompt with MCP |
-| `registerResource` | Register resource with MCP |
-| `registerTool` | Register tool with MCP |
+| Name               | Description                       |
+| ------------------ | --------------------------------- |
+| `clearMCPRegistry` | Clear all registries              |
+| `createMCPServer`  | Create MCP server                 |
+| `getMCPRegistry`   | Get tool/prompt/resource registry |
+| `getMCPStats`      | Get registered capability stats   |
+| `registerPrompt`   | Register prompt with MCP          |
+| `registerResource` | Register resource with MCP        |
+| `registerTool`     | Register tool with MCP            |
 
 ### Classes
 
-| Name | Description |
-|------|-------------|
+| Name        | Description         |
+| ----------- | ------------------- |
 | `MCPServer` | MCP server instance |
 
 ### Types
 
-| Name | Description |
-|------|-------------|
+| Name                      | Description                                          |
+| ------------------------- | ---------------------------------------------------- |
 | `IntegrationLoaderConfig` | Configuration for loading integration tools into MCP |
-| `MCPServerConfig` | `createMCPServer()` config |
-| `MCPStats` | Registry statistics |
-| `MCPTool` | Generic MCP tool definition |
+| `MCPServerConfig`         | `createMCPServer()` config                           |
+| `MCPStats`                | Registry statistics                                  |
+| `MCPTool`                 | Generic MCP tool definition                          |
 
 ## Related
 

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -38,8 +38,13 @@ tool({
   execute: async ({ query }) => ({ results: [] }),
 });
 
-// Create the app-facing MCP server and mount its HTTP handler
-const server = createMCPServer({ enabled: true });
+// Create the app-facing MCP server and mount its HTTP handler.
+// `auth` is required — pick a real auth strategy for production, or use the
+// explicit `{ type: "none", allowUnauthenticated: true }` opt-in for local dev.
+const server = createMCPServer({
+  enabled: true,
+  auth: { type: "none", allowUnauthenticated: true },
+});
 const handler = server.createHTTPHandler();
 ```
 
@@ -68,7 +73,7 @@ Current config shape:
 |------|-------------|-------------|
 | `enabled` | `boolean` | Enable the MCP server surface |
 | `port?` | `number` | Optional port for hosted/runtime wiring |
-| `auth?` | `{ type: "bearer" \| "api-key" \| "none"; validate?: Function }` | Optional request authentication |
+| `auth` | `{ type: "bearer" \| "api-key"; validate?: Function } \| { type: "none"; allowUnauthenticated: true }` | **Required.** Request authentication. Use `{ type: "none", allowUnauthenticated: true }` only for local dev — the server fails closed when auth is unset. |
 | `cors?` | `{ enabled: boolean; origins?: string[] }` | Optional CORS configuration |
 
 ## Exports

--- a/src/mcp/acceptance.test.ts
+++ b/src/mcp/acceptance.test.ts
@@ -43,7 +43,10 @@ async function initSession(
 
 describe("Acceptance Criteria — Streamable HTTP Transport (#839)", () => {
   it("POST with request returns application/json", async () => {
-    const handler = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } }).createHTTPHandler();
+    const handler = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    }).createHTTPHandler();
     const res = await post(handler, MCP_INIT);
     assertEquals(res.status, 200);
     assertEquals(res.headers.get("Content-Type"), "application/json");
@@ -52,7 +55,10 @@ describe("Acceptance Criteria — Streamable HTTP Transport (#839)", () => {
   });
 
   it("Server assigns MCP-Session-Id in initialize response", async () => {
-    const handler = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } }).createHTTPHandler();
+    const handler = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    }).createHTTPHandler();
     const res = await post(handler, MCP_INIT);
     const sessionId = res.headers.get("MCP-Session-Id");
     assertExists(sessionId);
@@ -60,7 +66,10 @@ describe("Acceptance Criteria — Streamable HTTP Transport (#839)", () => {
   });
 
   it("POST with notification returns 202 Accepted with no body", async () => {
-    const handler = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } }).createHTTPHandler();
+    const handler = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    }).createHTTPHandler();
     const sid = await initSession(handler);
     const res = await post(
       handler,
@@ -73,14 +82,20 @@ describe("Acceptance Criteria — Streamable HTTP Transport (#839)", () => {
   });
 
   it("Missing session ID on post-init requests returns 400 Bad Request", async () => {
-    const handler = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } }).createHTTPHandler();
+    const handler = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    }).createHTTPHandler();
     await initSession(handler);
     const res = await post(handler, { jsonrpc: "2.0", id: 2, method: "tools/list" });
     assertEquals(res.status, 400);
   });
 
   it("Unknown session IDs return 404 Not Found", async () => {
-    const handler = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } }).createHTTPHandler();
+    const handler = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    }).createHTTPHandler();
     await initSession(handler);
     const res = await post(
       handler,
@@ -91,7 +106,10 @@ describe("Acceptance Criteria — Streamable HTTP Transport (#839)", () => {
   });
 
   it("DELETE with session ID terminates the session", async () => {
-    const handler = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } }).createHTTPHandler();
+    const handler = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    }).createHTTPHandler();
     const sidA = await initSession(handler);
     await initSession(handler); // sidB keeps session check active
 
@@ -113,7 +131,10 @@ describe("Acceptance Criteria — Streamable HTTP Transport (#839)", () => {
   });
 
   it("OPTIONS returns 204", async () => {
-    const handler = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } }).createHTTPHandler();
+    const handler = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    }).createHTTPHandler();
     const res = await handler(
       new Request("http://localhost/mcp", { method: "OPTIONS" }),
     );
@@ -141,7 +162,10 @@ describe("Acceptance Criteria — Streamable HTTP Transport (#839)", () => {
   });
 
   it("Unsupported HTTP method returns 405", async () => {
-    const handler = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } }).createHTTPHandler();
+    const handler = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    }).createHTTPHandler();
     const res = await handler(
       new Request("http://localhost/mcp", { method: "PUT" }),
     );
@@ -155,7 +179,10 @@ describe("Acceptance Criteria — Streamable HTTP Transport (#839)", () => {
   });
 
   it("Existing stdio transport unchanged (handleRequest works directly)", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     const res = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,

--- a/src/mcp/acceptance.test.ts
+++ b/src/mcp/acceptance.test.ts
@@ -43,7 +43,7 @@ async function initSession(
 
 describe("Acceptance Criteria — Streamable HTTP Transport (#839)", () => {
   it("POST with request returns application/json", async () => {
-    const handler = createMCPServer({ enabled: true }).createHTTPHandler();
+    const handler = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } }).createHTTPHandler();
     const res = await post(handler, MCP_INIT);
     assertEquals(res.status, 200);
     assertEquals(res.headers.get("Content-Type"), "application/json");
@@ -52,7 +52,7 @@ describe("Acceptance Criteria — Streamable HTTP Transport (#839)", () => {
   });
 
   it("Server assigns MCP-Session-Id in initialize response", async () => {
-    const handler = createMCPServer({ enabled: true }).createHTTPHandler();
+    const handler = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } }).createHTTPHandler();
     const res = await post(handler, MCP_INIT);
     const sessionId = res.headers.get("MCP-Session-Id");
     assertExists(sessionId);
@@ -60,7 +60,7 @@ describe("Acceptance Criteria — Streamable HTTP Transport (#839)", () => {
   });
 
   it("POST with notification returns 202 Accepted with no body", async () => {
-    const handler = createMCPServer({ enabled: true }).createHTTPHandler();
+    const handler = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } }).createHTTPHandler();
     const sid = await initSession(handler);
     const res = await post(
       handler,
@@ -73,14 +73,14 @@ describe("Acceptance Criteria — Streamable HTTP Transport (#839)", () => {
   });
 
   it("Missing session ID on post-init requests returns 400 Bad Request", async () => {
-    const handler = createMCPServer({ enabled: true }).createHTTPHandler();
+    const handler = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } }).createHTTPHandler();
     await initSession(handler);
     const res = await post(handler, { jsonrpc: "2.0", id: 2, method: "tools/list" });
     assertEquals(res.status, 400);
   });
 
   it("Unknown session IDs return 404 Not Found", async () => {
-    const handler = createMCPServer({ enabled: true }).createHTTPHandler();
+    const handler = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } }).createHTTPHandler();
     await initSession(handler);
     const res = await post(
       handler,
@@ -91,7 +91,7 @@ describe("Acceptance Criteria — Streamable HTTP Transport (#839)", () => {
   });
 
   it("DELETE with session ID terminates the session", async () => {
-    const handler = createMCPServer({ enabled: true }).createHTTPHandler();
+    const handler = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } }).createHTTPHandler();
     const sidA = await initSession(handler);
     await initSession(handler); // sidB keeps session check active
 
@@ -113,7 +113,7 @@ describe("Acceptance Criteria — Streamable HTTP Transport (#839)", () => {
   });
 
   it("OPTIONS returns 204", async () => {
-    const handler = createMCPServer({ enabled: true }).createHTTPHandler();
+    const handler = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } }).createHTTPHandler();
     const res = await handler(
       new Request("http://localhost/mcp", { method: "OPTIONS" }),
     );
@@ -123,6 +123,7 @@ describe("Acceptance Criteria — Streamable HTTP Transport (#839)", () => {
   it("Origin validation returns 403 Forbidden if present and invalid", async () => {
     const handler = createMCPServer({
       enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
       cors: { enabled: true, origins: ["https://allowed.com"] },
     }).createHTTPHandler();
 
@@ -140,7 +141,7 @@ describe("Acceptance Criteria — Streamable HTTP Transport (#839)", () => {
   });
 
   it("Unsupported HTTP method returns 405", async () => {
-    const handler = createMCPServer({ enabled: true }).createHTTPHandler();
+    const handler = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } }).createHTTPHandler();
     const res = await handler(
       new Request("http://localhost/mcp", { method: "PUT" }),
     );
@@ -154,7 +155,7 @@ describe("Acceptance Criteria — Streamable HTTP Transport (#839)", () => {
   });
 
   it("Existing stdio transport unchanged (handleRequest works directly)", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     const res = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -18,7 +18,7 @@
  * });
  *
  * // Start MCP server — registered tools are exposed automatically.
- * // `auth` is required: use bearer/api-key for production, or the explicit
+ * // `auth` is required: use bearer for production, or the explicit
  * // `{ type: "none", allowUnauthenticated: true }` opt-in for local dev only.
  * const server = createMCPServer({
  *   enabled: true,

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -17,8 +17,13 @@
  *   execute: async ({ query }) => ({ results: [] }),
  * });
  *
- * // Start MCP server — registered tools are exposed automatically
- * const server = createMCPServer();
+ * // Start MCP server — registered tools are exposed automatically.
+ * // `auth` is required: use bearer/api-key for production, or the explicit
+ * // `{ type: "none", allowUnauthenticated: true }` opt-in for local dev only.
+ * const server = createMCPServer({
+ *   enabled: true,
+ *   auth: { type: "none", allowUnauthenticated: true },
+ * });
  * ```
  */
 

--- a/src/mcp/schemas/index.ts
+++ b/src/mcp/schemas/index.ts
@@ -5,6 +5,7 @@
  */
 
 export {
+  MCPAuthConfigSchema,
   type MCPServerConfig,
   MCPServerConfigSchema,
   type MCPStats,

--- a/src/mcp/schemas/mcp.schema.ts
+++ b/src/mcp/schemas/mcp.schema.ts
@@ -1,15 +1,29 @@
 import { z } from "zod";
 
+/**
+ * MCP auth configuration. One of:
+ * - `{ type: "bearer", validate?: (token) => Promise<boolean> }` — bearer-token auth.
+ * - `{ type: "api-key", validate?: ... }` — api-key auth.
+ * - `{ type: "none", allowUnauthenticated: true }` — explicit opt-in to an
+ *   unauthenticated server. Required for local dev/testing; prevents accidental
+ *   exposure of the JSON-RPC surface in production (VULN-SRV-5).
+ */
+const AuthValidatedSchema = z.object({
+  type: z.enum(["bearer", "api-key"]),
+  validate: z.function().optional(),
+});
+
+const AuthNoneSchema = z.object({
+  type: z.literal("none"),
+  allowUnauthenticated: z.literal(true),
+});
+
+export const MCPAuthConfigSchema = z.union([AuthValidatedSchema, AuthNoneSchema]);
+
 export const MCPServerConfigSchema = z.object({
   enabled: z.boolean(),
   port: z.number().int().positive().optional(),
-  auth: z
-    .object({
-      type: z.enum(["bearer", "api-key", "none"]),
-      validate: z.function()
-        .optional(),
-    })
-    .optional(),
+  auth: MCPAuthConfigSchema,
   cors: z
     .object({
       enabled: z.boolean(),

--- a/src/mcp/schemas/mcp.schema.ts
+++ b/src/mcp/schemas/mcp.schema.ts
@@ -3,13 +3,12 @@ import { z } from "zod";
 /**
  * MCP auth configuration. One of:
  * - `{ type: "bearer", validate?: (token) => Promise<boolean> }` — bearer-token auth.
- * - `{ type: "api-key", validate?: ... }` — api-key auth.
  * - `{ type: "none", allowUnauthenticated: true }` — explicit opt-in to an
  *   unauthenticated server. Required for local dev/testing; prevents accidental
  *   exposure of the JSON-RPC surface in production (VULN-SRV-5).
  */
 const AuthValidatedSchema = z.object({
-  type: z.enum(["bearer", "api-key"]),
+  type: z.literal("bearer"),
   validate: z.function().optional(),
 });
 

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1,4 +1,9 @@
-import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertStringIncludes,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { dynamicTool } from "#veryfront/tool";
 import { z } from "zod";
@@ -49,7 +54,7 @@ describe("mcp/server", () => {
   });
 
   it("extracts end-user and project IDs from HTTP headers into tool context", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     let capturedContext: { endUserId?: string; projectId?: string } | undefined;
 
     registerTool(
@@ -89,7 +94,7 @@ describe("mcp/server", () => {
   });
 
   it("ignores invalid identity headers when building tool context", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     let capturedContext: { endUserId?: string; projectId?: string } | undefined;
 
     registerTool(
@@ -130,6 +135,7 @@ describe("mcp/server", () => {
   it("includes integration context headers in CORS preflight response", async () => {
     const server = createMCPServer({
       enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
       cors: { enabled: true, origins: ["https://example.com"] },
     });
 
@@ -233,7 +239,7 @@ describe("mcp/server", () => {
 
   describe("request body size limit", () => {
     it("rejects requests with Content-Length exceeding 1MB", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const handler = server.createHTTPHandler();
 
       const response = await handler(
@@ -253,7 +259,7 @@ describe("mcp/server", () => {
     });
 
     it("rejects requests with body exceeding 1MB even without Content-Length", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const handler = server.createHTTPHandler();
 
       const largeBody = "x".repeat(1_048_577);
@@ -271,7 +277,7 @@ describe("mcp/server", () => {
     });
 
     it("accepts requests within the 1MB limit", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const handler = server.createHTTPHandler();
 
       const response = await handler(
@@ -288,7 +294,7 @@ describe("mcp/server", () => {
 
   describe("request validation", () => {
     it("rejects requests with invalid content type", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const handler = server.createHTTPHandler();
 
       const response = await handler(
@@ -305,7 +311,7 @@ describe("mcp/server", () => {
     });
 
     it("rejects malformed JSON request bodies", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const handler = server.createHTTPHandler();
 
       const response = await handler(
@@ -326,6 +332,7 @@ describe("mcp/server", () => {
     it("returns CORS headers when request Origin matches configured origins", async () => {
       const server = createMCPServer({
         enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
         cors: { enabled: true, origins: ["https://a.com", "https://b.com"] },
       });
 
@@ -345,6 +352,7 @@ describe("mcp/server", () => {
     it("returns no CORS headers when request Origin does not match", async () => {
       const server = createMCPServer({
         enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
         cors: { enabled: true, origins: ["https://allowed.com"] },
       });
 
@@ -363,6 +371,7 @@ describe("mcp/server", () => {
     it("returns no CORS headers when no origins configured", async () => {
       const server = createMCPServer({
         enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
         cors: { enabled: true },
       });
 
@@ -379,7 +388,7 @@ describe("mcp/server", () => {
     });
 
     it("returns no CORS headers when CORS is disabled", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
 
       const handler = server.createHTTPHandler();
       const response = await handler(
@@ -396,6 +405,7 @@ describe("mcp/server", () => {
     it("includes CORS headers on POST responses when Origin matches", async () => {
       const server = createMCPServer({
         enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
         cors: { enabled: true, origins: ["https://example.com"] },
       });
 
@@ -418,7 +428,7 @@ describe("mcp/server", () => {
 
   describe("initialize version negotiation", () => {
     it("echoes 2025-11-25 when client requests it", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -430,7 +440,7 @@ describe("mcp/server", () => {
     });
 
     it("echoes 2024-11-05 when client requests it", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -442,7 +452,7 @@ describe("mcp/server", () => {
     });
 
     it("returns 2025-11-25 for unknown version", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -454,7 +464,7 @@ describe("mcp/server", () => {
     });
 
     it("returns 2025-11-25 when no version is provided", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -465,7 +475,7 @@ describe("mcp/server", () => {
     });
 
     it("serverInfo includes title and description", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -480,7 +490,7 @@ describe("mcp/server", () => {
     });
 
     it("includes instructions field", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -492,7 +502,7 @@ describe("mcp/server", () => {
     });
 
     it("capabilities include listChanged", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -511,6 +521,7 @@ describe("mcp/server", () => {
     it("returns 403 when Origin is not in allowed list", async () => {
       const server = createMCPServer({
         enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
         cors: { enabled: true, origins: ["https://allowed.com"] },
       });
 
@@ -534,6 +545,7 @@ describe("mcp/server", () => {
     it("returns 200 when Origin is in allowed list", async () => {
       const server = createMCPServer({
         enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
         cors: { enabled: true, origins: ["https://allowed.com"] },
       });
 
@@ -555,6 +567,7 @@ describe("mcp/server", () => {
     it("returns 200 when no Origin header is present", async () => {
       const server = createMCPServer({
         enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
         cors: { enabled: true, origins: ["https://allowed.com"] },
       });
 
@@ -573,7 +586,7 @@ describe("mcp/server", () => {
 
   describe("notifications/initialized", () => {
     it("handles notifications/initialized with id", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -585,7 +598,7 @@ describe("mcp/server", () => {
     });
 
     it("handles notifications/initialized without id (proper notification)", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         method: "notifications/initialized",
@@ -597,7 +610,7 @@ describe("mcp/server", () => {
   });
 
   it("includes title and annotations in tools/list when configured", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
 
     registerTool(
       "test:annotated",
@@ -638,7 +651,7 @@ describe("mcp/server", () => {
   });
 
   it("omits title and annotations from tools/list when not configured", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
 
     registerTool(
       "test:plain",
@@ -664,7 +677,7 @@ describe("mcp/server", () => {
   });
 
   it("only includes valid annotation keys in tools/list", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
 
     registerTool(
       "test:partial-annotations",
@@ -695,7 +708,7 @@ describe("mcp/server", () => {
 
   describe("callTool error handling", () => {
     it("returns isError false on successful tool execution", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
 
       registerTool(
         "test:echo",
@@ -725,7 +738,7 @@ describe("mcp/server", () => {
     });
 
     it("returns isError true when tool execution throws", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
 
       registerTool(
         "test:fail",
@@ -756,7 +769,7 @@ describe("mcp/server", () => {
     });
 
     it("returns JSON-RPC error with code -32602 for unknown tool", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
 
       const response = await server.handleRequest({
         jsonrpc: "2.0",
@@ -771,7 +784,7 @@ describe("mcp/server", () => {
     });
 
     it("returns JSON-RPC error with code -32602 for invalid arguments", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
 
       registerTool(
         "test:strict",
@@ -799,7 +812,7 @@ describe("mcp/server", () => {
 
   describe("list endpoint pagination", () => {
     it("tools/list accepts cursor param without erroring", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const response = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -812,7 +825,7 @@ describe("mcp/server", () => {
     });
 
     it("tools/list does not include nextCursor when all results fit", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
 
       registerTool(
         "test:pagination",
@@ -836,7 +849,7 @@ describe("mcp/server", () => {
     });
 
     it("resources/list accepts cursor param without erroring", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const response = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -849,7 +862,7 @@ describe("mcp/server", () => {
     });
 
     it("prompts/list accepts cursor param without erroring", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const response = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -864,7 +877,7 @@ describe("mcp/server", () => {
 
   describe("resources/templates/list", () => {
     it("returns array without error", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const response = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -879,7 +892,7 @@ describe("mcp/server", () => {
     });
 
     it("includes parameterized resources as templates", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       registerResource("test:users", {
         id: "test:users",
         pattern: "/users/:id",
@@ -904,7 +917,7 @@ describe("mcp/server", () => {
     });
 
     it("excludes scheme-only colons like openapi://spec", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       registerResource("test:openapi", {
         id: "test:openapi",
         pattern: "openapi://spec",
@@ -927,7 +940,7 @@ describe("mcp/server", () => {
     });
 
     it("includes title when set on resource", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       registerResource("test:posts", {
         id: "test:posts",
         pattern: "/posts/:slug",
@@ -954,7 +967,7 @@ describe("mcp/server", () => {
   });
 
   it("declares completions capability in initialize", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -971,7 +984,7 @@ describe("mcp/server", () => {
   });
 
   it("completion/complete returns empty values for unknown ref", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -990,7 +1003,7 @@ describe("mcp/server", () => {
   });
 
   it("completion/complete returns empty values when argument is missing", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1008,7 +1021,7 @@ describe("mcp/server", () => {
   });
 
   it("completion/complete returns empty values when ref is missing", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1026,7 +1039,7 @@ describe("mcp/server", () => {
   });
 
   it("stores client capabilities from initialize request", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1042,7 +1055,7 @@ describe("mcp/server", () => {
   });
 
   it("reports no elicitation support when client does not declare it", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1058,7 +1071,7 @@ describe("mcp/server", () => {
   });
 
   it("treats empty elicitation capability as form-only support", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1074,7 +1087,7 @@ describe("mcp/server", () => {
   });
 
   it("handles malformed elicitation capability without crashing", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1090,7 +1103,7 @@ describe("mcp/server", () => {
   });
 
   it("keeps elicitation capabilities isolated per HTTP session", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     const handler = server.createHTTPHandler();
 
     const sessionA = await initSessionWithCapabilities(handler, { elicitation: { form: {} } });
@@ -1103,7 +1116,7 @@ describe("mcp/server", () => {
   });
 
   it("syncs integration config to API on first tools/list call", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     server.setIntegrationLoader({
       integrations: { github: {} },
       apiBaseUrl: "https://api.example.com",
@@ -1127,7 +1140,7 @@ describe("mcp/server", () => {
   });
 
   it("syncs integration config only once", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     server.setIntegrationLoader({
       integrations: { github: {} },
       apiBaseUrl: "https://api.example.com",
@@ -1154,7 +1167,7 @@ describe("mcp/server", () => {
 
   describe("Streamable HTTP session management", () => {
     it("returns MCP-Session-Id header on initialize response", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const handler = server.createHTTPHandler();
       const response = await handler(
         new Request("http://localhost/mcp", {
@@ -1188,7 +1201,7 @@ describe("mcp/server", () => {
     });
 
     it("returns 400 when MCP-Session-Id is missing on post-init request", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const handler = server.createHTTPHandler();
 
       // First, initialize to create a session
@@ -1206,7 +1219,7 @@ describe("mcp/server", () => {
     });
 
     it("returns 404 for expired/unknown session ID", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const handler = server.createHTTPHandler();
 
       // Initialize to set the initialized flag
@@ -1226,7 +1239,7 @@ describe("mcp/server", () => {
     });
 
     it("accepts DELETE to terminate session", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const handler = server.createHTTPHandler();
 
       // Initialize two sessions so one remains active after DELETE
@@ -1270,7 +1283,7 @@ describe("mcp/server", () => {
     });
 
     it("clears session-scoped elicitation capabilities after DELETE", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const handler = server.createHTTPHandler();
 
       const sessionId = await initSessionWithCapabilities(handler, { elicitation: { form: {} } });
@@ -1287,7 +1300,7 @@ describe("mcp/server", () => {
     });
 
     it("returns 202 for JSON-RPC notifications", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const handler = server.createHTTPHandler();
 
       // Initialize
@@ -1308,7 +1321,7 @@ describe("mcp/server", () => {
     });
 
     it("returns 200 with JSON-RPC response for request with id: 0", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const handler = server.createHTTPHandler();
       const sessionId = await initSession(handler);
 
@@ -1348,7 +1361,7 @@ describe("mcp/server", () => {
     });
 
     it("returns 405 for unsupported HTTP methods", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const handler = server.createHTTPHandler();
       const response = await handler(
         new Request("http://localhost/mcp", { method: "PUT" }),
@@ -1359,6 +1372,7 @@ describe("mcp/server", () => {
     it("includes MCP-Session-Id in CORS allowed headers", async () => {
       const server = createMCPServer({
         enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
         cors: { enabled: true, origins: ["https://example.com"] },
       });
 
@@ -1379,6 +1393,7 @@ describe("mcp/server", () => {
     it("includes DELETE in CORS allowed methods", async () => {
       const server = createMCPServer({
         enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
         cors: { enabled: true, origins: ["https://example.com"] },
       });
 
@@ -1396,7 +1411,7 @@ describe("mcp/server", () => {
     });
 
     it("resets session requirement after all sessions are terminated", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const handler = server.createHTTPHandler();
 
       // Client initializes, creating a session
@@ -1423,7 +1438,7 @@ describe("mcp/server", () => {
     });
 
     it("isolates concurrent sessions independently", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const handler = server.createHTTPHandler();
 
       // Two clients initialize
@@ -1483,7 +1498,7 @@ describe("mcp/server", () => {
     });
 
     it("accepts valid session ID on post-init requests", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       const handler = server.createHTTPHandler();
 
       const sessionId = await initSession(handler);
@@ -1503,7 +1518,7 @@ describe("mcp/server", () => {
   });
 
   it("declares tasks capability in initialize", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1521,7 +1536,7 @@ describe("mcp/server", () => {
   });
 
   it("logging/setLevel stores the level and returns empty result", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1533,7 +1548,7 @@ describe("mcp/server", () => {
   });
 
   it("extracts progressToken from _meta and passes to tool context", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     let capturedContext: Record<string, unknown> | undefined;
 
     registerTool(
@@ -1561,7 +1576,7 @@ describe("mcp/server", () => {
   });
 
   it("accepts notifications/cancelled without error", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       method: "notifications/cancelled",
@@ -1572,7 +1587,7 @@ describe("mcp/server", () => {
   });
 
   it("logging/setLevel rejects invalid level", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1584,7 +1599,7 @@ describe("mcp/server", () => {
   });
 
   it("tools/call with task field returns CreateTaskResult immediately", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     registerTool(
       "test:slow",
       dynamicTool({
@@ -1610,7 +1625,7 @@ describe("mcp/server", () => {
   });
 
   it("tasks/get returns task status", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     registerTool(
       "test:slow2",
       dynamicTool({
@@ -1643,7 +1658,7 @@ describe("mcp/server", () => {
   });
 
   it("tasks/cancel cancels a working task", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     registerTool(
       "test:slow3",
       dynamicTool({
@@ -1677,7 +1692,7 @@ describe("mcp/server", () => {
   });
 
   it("tasks/result returns completed task result", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     registerTool(
       "test:fast",
       dynamicTool({
@@ -1707,7 +1722,7 @@ describe("mcp/server", () => {
   });
 
   it("tasks/result returns error when task is still working", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     registerTool(
       "test:slow4",
       dynamicTool({
@@ -1739,7 +1754,7 @@ describe("mcp/server", () => {
   });
 
   it("async tool failure sets task status to failed", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     registerTool(
       "test:fail",
       dynamicTool({
@@ -1771,7 +1786,7 @@ describe("mcp/server", () => {
   });
 
   it("tasks/get returns error for unknown taskId", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1783,7 +1798,7 @@ describe("mcp/server", () => {
   });
 
   it("tasks/cancel returns error for unknown taskId", async () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1796,7 +1811,7 @@ describe("mcp/server", () => {
   describe("listChanged notifications", () => {
     it("calls onNotification when tools list changes", () => {
       const notifications: Array<{ method: string }> = [];
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       server.onNotification = (notification) => {
         notifications.push(notification as { method: string });
       };
@@ -1807,7 +1822,7 @@ describe("mcp/server", () => {
 
     it("calls onNotification for resources list changes", () => {
       const notifications: Array<{ method: string }> = [];
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       server.onNotification = (notification) => {
         notifications.push(notification as { method: string });
       };
@@ -1818,7 +1833,7 @@ describe("mcp/server", () => {
 
     it("calls onNotification for prompts list changes", () => {
       const notifications: Array<{ method: string }> = [];
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       server.onNotification = (notification) => {
         notifications.push(notification as { method: string });
       };
@@ -1828,12 +1843,12 @@ describe("mcp/server", () => {
     });
 
     it("does not throw when onNotification is not set", () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       server.notifyToolsChanged(); // should not throw
     });
 
     it("emits tools/list_changed when loadRemoteIntegrationTools succeeds", async () => {
-      const server = createMCPServer({ enabled: true });
+      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
       server.setIntegrationLoader({
         integrations: { github: {} },
         apiBaseUrl: "https://api.example.com",
@@ -1861,6 +1876,147 @@ describe("mcp/server", () => {
         (n) => n.method === "notifications/tools/list_changed",
       );
       assertExists(toolsChanged);
+    });
+  });
+
+  describe("auth fail-closed (VULN-SRV-5)", () => {
+    it("throws when no auth is configured (unset auth)", () => {
+      assertThrows(
+        () => {
+          // deno-lint-ignore no-explicit-any -- testing runtime guard against missing auth
+          createMCPServer({ enabled: true } as any);
+        },
+        Error,
+        "MCP auth must be configured",
+      );
+    });
+
+    it("error for unset auth mentions allowUnauthenticated for dev opt-in", () => {
+      assertThrows(
+        () => {
+          // deno-lint-ignore no-explicit-any -- testing runtime guard against missing auth
+          createMCPServer({ enabled: true } as any);
+        },
+        Error,
+        "allowUnauthenticated: true",
+      );
+    });
+
+    it("throws when auth.type is 'none' without allowUnauthenticated (undefined)", () => {
+      assertThrows(
+        () => {
+          // deno-lint-ignore no-explicit-any -- testing runtime guard against {type:"none"} shorthand
+          createMCPServer({ enabled: true, auth: { type: "none" } } as any);
+        },
+        Error,
+        "allowUnauthenticated: true",
+      );
+    });
+
+    it("throws when auth.type is 'none' with allowUnauthenticated: false", () => {
+      assertThrows(
+        () => {
+          createMCPServer({
+            enabled: true,
+            // deno-lint-ignore no-explicit-any -- deliberately invalid: allow=false must reject
+            auth: { type: "none", allowUnauthenticated: false } as any,
+          });
+        },
+        Error,
+        "allowUnauthenticated: true",
+      );
+    });
+
+    it("throws when auth.type is 'none' with non-boolean allowUnauthenticated", () => {
+      assertThrows(
+        () => {
+          createMCPServer({
+            enabled: true,
+            // deno-lint-ignore no-explicit-any -- deliberately invalid non-bool flag
+            auth: { type: "none", allowUnauthenticated: "yes" } as any,
+          });
+        },
+        Error,
+        "allowUnauthenticated: true",
+      );
+    });
+
+    it("throws when auth.type is unknown", () => {
+      assertThrows(
+        () => {
+          createMCPServer({
+            enabled: true,
+            // deno-lint-ignore no-explicit-any -- deliberately invalid auth type
+            auth: { type: "oauth" } as any,
+          });
+        },
+        Error,
+        "not supported",
+      );
+    });
+
+    it("succeeds with explicit allowUnauthenticated: true", () => {
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
+      assertExists(server);
+    });
+
+    it("succeeds with bearer auth", () => {
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "bearer", validate: async (t: string) => t === "ok" },
+      });
+      assertExists(server);
+    });
+
+    it("http-transport: bearer rejects missing token", async () => {
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "bearer", validate: async (t: string) => t === "ok" },
+      });
+      const handler = server.createHTTPHandler();
+      const res = await handler(
+        new Request("http://localhost/mcp", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+        }),
+      );
+      assertEquals(res.status, 401);
+    });
+
+    it("http-transport: bearer rejects bad token", async () => {
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "bearer", validate: async (t: string) => t === "ok" },
+      });
+      const handler = server.createHTTPHandler();
+      const res = await handler(
+        new Request("http://localhost/mcp", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "Authorization": "Bearer nope" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+        }),
+      );
+      assertEquals(res.status, 401);
+    });
+
+    it("http-transport: none + allowUnauthenticated accepts requests", async () => {
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
+      const handler = server.createHTTPHandler();
+      const res = await handler(
+        new Request("http://localhost/mcp", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+        }),
+      );
+      assertEquals(res.status, 200);
     });
   });
 });

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -54,7 +54,10 @@ describe("mcp/server", () => {
   });
 
   it("extracts end-user and project IDs from HTTP headers into tool context", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     let capturedContext: { endUserId?: string; projectId?: string } | undefined;
 
     registerTool(
@@ -94,7 +97,10 @@ describe("mcp/server", () => {
   });
 
   it("ignores invalid identity headers when building tool context", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     let capturedContext: { endUserId?: string; projectId?: string } | undefined;
 
     registerTool(
@@ -239,7 +245,10 @@ describe("mcp/server", () => {
 
   describe("request body size limit", () => {
     it("rejects requests with Content-Length exceeding 1MB", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const handler = server.createHTTPHandler();
 
       const response = await handler(
@@ -259,7 +268,10 @@ describe("mcp/server", () => {
     });
 
     it("rejects requests with body exceeding 1MB even without Content-Length", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const handler = server.createHTTPHandler();
 
       const largeBody = "x".repeat(1_048_577);
@@ -277,7 +289,10 @@ describe("mcp/server", () => {
     });
 
     it("accepts requests within the 1MB limit", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const handler = server.createHTTPHandler();
 
       const response = await handler(
@@ -294,7 +309,10 @@ describe("mcp/server", () => {
 
   describe("request validation", () => {
     it("rejects requests with invalid content type", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const handler = server.createHTTPHandler();
 
       const response = await handler(
@@ -311,7 +329,10 @@ describe("mcp/server", () => {
     });
 
     it("rejects malformed JSON request bodies", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const handler = server.createHTTPHandler();
 
       const response = await handler(
@@ -388,7 +409,10 @@ describe("mcp/server", () => {
     });
 
     it("returns no CORS headers when CORS is disabled", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
 
       const handler = server.createHTTPHandler();
       const response = await handler(
@@ -428,7 +452,10 @@ describe("mcp/server", () => {
 
   describe("initialize version negotiation", () => {
     it("echoes 2025-11-25 when client requests it", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -440,7 +467,10 @@ describe("mcp/server", () => {
     });
 
     it("echoes 2024-11-05 when client requests it", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -452,7 +482,10 @@ describe("mcp/server", () => {
     });
 
     it("returns 2025-11-25 for unknown version", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -464,7 +497,10 @@ describe("mcp/server", () => {
     });
 
     it("returns 2025-11-25 when no version is provided", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -475,7 +511,10 @@ describe("mcp/server", () => {
     });
 
     it("serverInfo includes title and description", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -490,7 +529,10 @@ describe("mcp/server", () => {
     });
 
     it("includes instructions field", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -502,7 +544,10 @@ describe("mcp/server", () => {
     });
 
     it("capabilities include listChanged", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -586,7 +631,10 @@ describe("mcp/server", () => {
 
   describe("notifications/initialized", () => {
     it("handles notifications/initialized with id", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -598,7 +646,10 @@ describe("mcp/server", () => {
     });
 
     it("handles notifications/initialized without id (proper notification)", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const res = await server.handleRequest({
         jsonrpc: "2.0",
         method: "notifications/initialized",
@@ -610,7 +661,10 @@ describe("mcp/server", () => {
   });
 
   it("includes title and annotations in tools/list when configured", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
 
     registerTool(
       "test:annotated",
@@ -651,7 +705,10 @@ describe("mcp/server", () => {
   });
 
   it("omits title and annotations from tools/list when not configured", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
 
     registerTool(
       "test:plain",
@@ -677,7 +734,10 @@ describe("mcp/server", () => {
   });
 
   it("only includes valid annotation keys in tools/list", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
 
     registerTool(
       "test:partial-annotations",
@@ -708,7 +768,10 @@ describe("mcp/server", () => {
 
   describe("callTool error handling", () => {
     it("returns isError false on successful tool execution", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
 
       registerTool(
         "test:echo",
@@ -738,7 +801,10 @@ describe("mcp/server", () => {
     });
 
     it("returns isError true when tool execution throws", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
 
       registerTool(
         "test:fail",
@@ -769,7 +835,10 @@ describe("mcp/server", () => {
     });
 
     it("returns JSON-RPC error with code -32602 for unknown tool", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
 
       const response = await server.handleRequest({
         jsonrpc: "2.0",
@@ -784,7 +853,10 @@ describe("mcp/server", () => {
     });
 
     it("returns JSON-RPC error with code -32602 for invalid arguments", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
 
       registerTool(
         "test:strict",
@@ -812,7 +884,10 @@ describe("mcp/server", () => {
 
   describe("list endpoint pagination", () => {
     it("tools/list accepts cursor param without erroring", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const response = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -825,7 +900,10 @@ describe("mcp/server", () => {
     });
 
     it("tools/list does not include nextCursor when all results fit", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
 
       registerTool(
         "test:pagination",
@@ -849,7 +927,10 @@ describe("mcp/server", () => {
     });
 
     it("resources/list accepts cursor param without erroring", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const response = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -862,7 +943,10 @@ describe("mcp/server", () => {
     });
 
     it("prompts/list accepts cursor param without erroring", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const response = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -877,7 +961,10 @@ describe("mcp/server", () => {
 
   describe("resources/templates/list", () => {
     it("returns array without error", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const response = await server.handleRequest({
         jsonrpc: "2.0",
         id: 1,
@@ -892,7 +979,10 @@ describe("mcp/server", () => {
     });
 
     it("includes parameterized resources as templates", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       registerResource("test:users", {
         id: "test:users",
         pattern: "/users/:id",
@@ -917,7 +1007,10 @@ describe("mcp/server", () => {
     });
 
     it("excludes scheme-only colons like openapi://spec", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       registerResource("test:openapi", {
         id: "test:openapi",
         pattern: "openapi://spec",
@@ -940,7 +1033,10 @@ describe("mcp/server", () => {
     });
 
     it("includes title when set on resource", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       registerResource("test:posts", {
         id: "test:posts",
         pattern: "/posts/:slug",
@@ -967,7 +1063,10 @@ describe("mcp/server", () => {
   });
 
   it("declares completions capability in initialize", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -984,7 +1083,10 @@ describe("mcp/server", () => {
   });
 
   it("completion/complete returns empty values for unknown ref", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1003,7 +1105,10 @@ describe("mcp/server", () => {
   });
 
   it("completion/complete returns empty values when argument is missing", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1021,7 +1126,10 @@ describe("mcp/server", () => {
   });
 
   it("completion/complete returns empty values when ref is missing", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1039,7 +1147,10 @@ describe("mcp/server", () => {
   });
 
   it("stores client capabilities from initialize request", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1055,7 +1166,10 @@ describe("mcp/server", () => {
   });
 
   it("reports no elicitation support when client does not declare it", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1071,7 +1185,10 @@ describe("mcp/server", () => {
   });
 
   it("treats empty elicitation capability as form-only support", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1087,7 +1204,10 @@ describe("mcp/server", () => {
   });
 
   it("handles malformed elicitation capability without crashing", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1103,7 +1223,10 @@ describe("mcp/server", () => {
   });
 
   it("keeps elicitation capabilities isolated per HTTP session", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     const handler = server.createHTTPHandler();
 
     const sessionA = await initSessionWithCapabilities(handler, { elicitation: { form: {} } });
@@ -1116,7 +1239,10 @@ describe("mcp/server", () => {
   });
 
   it("syncs integration config to API on first tools/list call", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     server.setIntegrationLoader({
       integrations: { github: {} },
       apiBaseUrl: "https://api.example.com",
@@ -1140,7 +1266,10 @@ describe("mcp/server", () => {
   });
 
   it("syncs integration config only once", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     server.setIntegrationLoader({
       integrations: { github: {} },
       apiBaseUrl: "https://api.example.com",
@@ -1167,7 +1296,10 @@ describe("mcp/server", () => {
 
   describe("Streamable HTTP session management", () => {
     it("returns MCP-Session-Id header on initialize response", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const handler = server.createHTTPHandler();
       const response = await handler(
         new Request("http://localhost/mcp", {
@@ -1201,7 +1333,10 @@ describe("mcp/server", () => {
     });
 
     it("returns 400 when MCP-Session-Id is missing on post-init request", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const handler = server.createHTTPHandler();
 
       // First, initialize to create a session
@@ -1219,7 +1354,10 @@ describe("mcp/server", () => {
     });
 
     it("returns 404 for expired/unknown session ID", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const handler = server.createHTTPHandler();
 
       // Initialize to set the initialized flag
@@ -1239,7 +1377,10 @@ describe("mcp/server", () => {
     });
 
     it("accepts DELETE to terminate session", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const handler = server.createHTTPHandler();
 
       // Initialize two sessions so one remains active after DELETE
@@ -1283,7 +1424,10 @@ describe("mcp/server", () => {
     });
 
     it("clears session-scoped elicitation capabilities after DELETE", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const handler = server.createHTTPHandler();
 
       const sessionId = await initSessionWithCapabilities(handler, { elicitation: { form: {} } });
@@ -1300,7 +1444,10 @@ describe("mcp/server", () => {
     });
 
     it("returns 202 for JSON-RPC notifications", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const handler = server.createHTTPHandler();
 
       // Initialize
@@ -1321,7 +1468,10 @@ describe("mcp/server", () => {
     });
 
     it("returns 200 with JSON-RPC response for request with id: 0", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const handler = server.createHTTPHandler();
       const sessionId = await initSession(handler);
 
@@ -1361,7 +1511,10 @@ describe("mcp/server", () => {
     });
 
     it("returns 405 for unsupported HTTP methods", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const handler = server.createHTTPHandler();
       const response = await handler(
         new Request("http://localhost/mcp", { method: "PUT" }),
@@ -1411,7 +1564,10 @@ describe("mcp/server", () => {
     });
 
     it("resets session requirement after all sessions are terminated", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const handler = server.createHTTPHandler();
 
       // Client initializes, creating a session
@@ -1438,7 +1594,10 @@ describe("mcp/server", () => {
     });
 
     it("isolates concurrent sessions independently", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const handler = server.createHTTPHandler();
 
       // Two clients initialize
@@ -1498,7 +1657,10 @@ describe("mcp/server", () => {
     });
 
     it("accepts valid session ID on post-init requests", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       const handler = server.createHTTPHandler();
 
       const sessionId = await initSession(handler);
@@ -1518,7 +1680,10 @@ describe("mcp/server", () => {
   });
 
   it("declares tasks capability in initialize", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1536,7 +1701,10 @@ describe("mcp/server", () => {
   });
 
   it("logging/setLevel stores the level and returns empty result", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1548,7 +1716,10 @@ describe("mcp/server", () => {
   });
 
   it("extracts progressToken from _meta and passes to tool context", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     let capturedContext: Record<string, unknown> | undefined;
 
     registerTool(
@@ -1576,7 +1747,10 @@ describe("mcp/server", () => {
   });
 
   it("accepts notifications/cancelled without error", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       method: "notifications/cancelled",
@@ -1587,7 +1761,10 @@ describe("mcp/server", () => {
   });
 
   it("logging/setLevel rejects invalid level", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1599,7 +1776,10 @@ describe("mcp/server", () => {
   });
 
   it("tools/call with task field returns CreateTaskResult immediately", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     registerTool(
       "test:slow",
       dynamicTool({
@@ -1625,7 +1805,10 @@ describe("mcp/server", () => {
   });
 
   it("tasks/get returns task status", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     registerTool(
       "test:slow2",
       dynamicTool({
@@ -1658,7 +1841,10 @@ describe("mcp/server", () => {
   });
 
   it("tasks/cancel cancels a working task", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     registerTool(
       "test:slow3",
       dynamicTool({
@@ -1692,7 +1878,10 @@ describe("mcp/server", () => {
   });
 
   it("tasks/result returns completed task result", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     registerTool(
       "test:fast",
       dynamicTool({
@@ -1722,7 +1911,10 @@ describe("mcp/server", () => {
   });
 
   it("tasks/result returns error when task is still working", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     registerTool(
       "test:slow4",
       dynamicTool({
@@ -1754,7 +1946,10 @@ describe("mcp/server", () => {
   });
 
   it("async tool failure sets task status to failed", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     registerTool(
       "test:fail",
       dynamicTool({
@@ -1786,7 +1981,10 @@ describe("mcp/server", () => {
   });
 
   it("tasks/get returns error for unknown taskId", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1798,7 +1996,10 @@ describe("mcp/server", () => {
   });
 
   it("tasks/cancel returns error for unknown taskId", async () => {
-    const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     const result = await server.handleRequest({
       jsonrpc: "2.0",
       id: 1,
@@ -1811,7 +2012,10 @@ describe("mcp/server", () => {
   describe("listChanged notifications", () => {
     it("calls onNotification when tools list changes", () => {
       const notifications: Array<{ method: string }> = [];
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       server.onNotification = (notification) => {
         notifications.push(notification as { method: string });
       };
@@ -1822,7 +2026,10 @@ describe("mcp/server", () => {
 
     it("calls onNotification for resources list changes", () => {
       const notifications: Array<{ method: string }> = [];
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       server.onNotification = (notification) => {
         notifications.push(notification as { method: string });
       };
@@ -1833,7 +2040,10 @@ describe("mcp/server", () => {
 
     it("calls onNotification for prompts list changes", () => {
       const notifications: Array<{ method: string }> = [];
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       server.onNotification = (notification) => {
         notifications.push(notification as { method: string });
       };
@@ -1843,12 +2053,18 @@ describe("mcp/server", () => {
     });
 
     it("does not throw when onNotification is not set", () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       server.notifyToolsChanged(); // should not throw
     });
 
     it("emits tools/list_changed when loadRemoteIntegrationTools succeeds", async () => {
-      const server = createMCPServer({ enabled: true, auth: { type: "none", allowUnauthenticated: true } });
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
       server.setIntegrationLoader({
         integrations: { github: {} },
         apiBaseUrl: "https://api.example.com",

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -2171,6 +2171,20 @@ describe("mcp/server", () => {
       );
     });
 
+    it("throws when auth.type is 'api-key' (no validator wiring yet)", () => {
+      assertThrows(
+        () => {
+          createMCPServer({
+            enabled: true,
+            // deno-lint-ignore no-explicit-any -- api-key is not yet supported; must fail closed
+            auth: { type: "api-key" } as any,
+          });
+        },
+        Error,
+        "not supported",
+      );
+    });
+
     it("succeeds with explicit allowUnauthenticated: true", () => {
       const server = createMCPServer({
         enabled: true,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -165,12 +165,12 @@ export class MCPServer {
       return;
     }
 
-    if (type === "bearer" || type === "api-key") {
+    if (type === "bearer") {
       return;
     }
 
     throw new Error(
-      `MCP auth type '${String(type)}' is not supported. Use 'bearer', 'api-key', ` +
+      `MCP auth type '${String(type)}' is not supported. Use 'bearer' ` +
         "or { type: 'none', allowUnauthenticated: true } for explicit opt-in to " +
         "unauthenticated traffic.",
     );
@@ -700,8 +700,6 @@ export class MCPServer {
 
     const authHeader = request.headers.get("Authorization");
     if (!authHeader) return false;
-
-    if (auth.type !== "bearer") return false;
 
     const token = authHeader.replace("Bearer ", "");
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -113,11 +113,67 @@ export class MCPServer {
   onNotification?: (notification: { jsonrpc: "2.0"; method: string; params?: unknown }) => void;
 
   constructor(config: MCPServerConfig) {
+    MCPServer.validateAuthConfig(config);
     this.config = config;
 
-    if (!config.auth || config.auth.type === "none") {
-      logger.warn("MCP server has no authentication configured — all requests will be accepted");
+    if (config.auth.type === "none") {
+      logger.warn(
+        "MCP server started with auth.type='none' (allowUnauthenticated) — all requests will be accepted",
+      );
     }
+  }
+
+  /**
+   * Fail-closed validation of the auth configuration (VULN-SRV-5).
+   *
+   * Historically, an unset `auth` field — or `{ type: "none" }` — silently
+   * accepted every request with only a warning log. That meant an operator who
+   * forgot to configure auth shipped an unauthenticated JSON-RPC surface.
+   *
+   * The new contract: `auth` is required, and the only way to accept
+   * unauthenticated traffic is to explicitly set
+   * `{ type: "none", allowUnauthenticated: true }`. Any other shape is
+   * rejected at construction time.
+   */
+  private static validateAuthConfig(config: MCPServerConfig): void {
+    const auth = (config as { auth?: unknown }).auth;
+
+    if (auth === undefined || auth === null) {
+      throw new Error(
+        "MCP auth must be configured. For local dev, pass " +
+          "{ auth: { type: 'none', allowUnauthenticated: true } } explicitly.",
+      );
+    }
+
+    if (typeof auth !== "object") {
+      throw new Error(
+        "MCP auth must be an object. For local dev, pass " +
+          "{ auth: { type: 'none', allowUnauthenticated: true } } explicitly.",
+      );
+    }
+
+    const type = (auth as { type?: unknown }).type;
+
+    if (type === "none") {
+      const allow = (auth as { allowUnauthenticated?: unknown }).allowUnauthenticated;
+      if (allow !== true) {
+        throw new Error(
+          "MCP auth type 'none' requires allowUnauthenticated: true to acknowledge " +
+            "the server will accept all requests.",
+        );
+      }
+      return;
+    }
+
+    if (type === "bearer" || type === "api-key") {
+      return;
+    }
+
+    throw new Error(
+      `MCP auth type '${String(type)}' is not supported. Use 'bearer', 'api-key', ` +
+        "or { type: 'none', allowUnauthenticated: true } for explicit opt-in to " +
+        "unauthenticated traffic.",
+    );
   }
 
   notifyToolsChanged(): void {
@@ -607,7 +663,7 @@ export class MCPServer {
 
   createHTTPHandler(): (request: Request) => Promise<Response> {
     return createMCPHTTPHandler({
-      authEnabled: Boolean(this.config.auth?.type && this.config.auth.type !== "none"),
+      authEnabled: this.config.auth.type !== "none",
       getCORSHeaders: (requestOrigin) => this.getCORSHeaders(requestOrigin),
       validateAuth: (request) => this.validateAuth(request),
       handleRequest: (request, context) => this.handleRequest(request, context),
@@ -640,7 +696,7 @@ export class MCPServer {
 
   private async validateAuth(request: Request): Promise<boolean> {
     const auth = this.config.auth;
-    if (!auth || auth.type === "none") return true;
+    if (auth.type === "none") return true;
 
     const authHeader = request.headers.get("Authorization");
     if (!authHeader) return false;

--- a/tests/docs/guide-examples.test.ts
+++ b/tests/docs/guide-examples.test.ts
@@ -728,7 +728,10 @@ import {
 
 describe("Guide: mcp-server.mdx", () => {
   it("should create an MCP server", () => {
-    const server = createMCPServer({ enabled: true });
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
     assertExists(server);
     assertExists(server.handleRequest);
   });


### PR DESCRIPTION
## Summary

PR 9 of `plans/security-audit-17.4.2026.md`. **Breaking config change.**

Fixes **VULN-SRV-5** — `McpServer` treated "auth unset" and "auth explicitly none" identically (log warning, accept all requests). Operators who forget to configure auth ship an unauthenticated JSON-RPC surface.

## Fix

- Constructor throws when `config.auth` is undefined.
- `auth.type === "none"` requires `allowUnauthenticated: true` as an explicit acknowledgement.
- `MCPAuthConfig` union updated to make the opt-in compile-time visible.
- `api-key` type removed from the accepted auth union (was advertised but never validated — every request returned 401). Fails fast at construction until a real validator is wired up.

## Release note

Before upgrading, add to your MCP config:

    { auth: { type: "bearer", token: "..." } }

or (local dev only):

    { auth: { type: "none", allowUnauthenticated: true } }

The previously-advertised `{ type: "api-key" }` option is removed; it never had a corresponding request validator.

## Test plan

- [x] `deno test src/mcp/` — 6 files, 149 steps, 0 failed
- [x] Server without auth throws at construction (`throws when no auth is configured (unset auth)`)
- [x] `auth: { type: "none" }` (no opt-in) throws (`throws when auth.type is 'none' without allowUnauthenticated`)
- [x] `auth: { type: "api-key" }` throws at construction (`throws when auth.type is 'api-key' (no validator wiring yet)`)