### PR TITLE
Restore Anthropic tool-argument streaming for file writes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.215",
+  "version": "0.1.216",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "exclude": [

--- a/src/provider/runtime-loader.test.ts
+++ b/src/provider/runtime-loader.test.ts
@@ -967,6 +967,10 @@ describe("provider/runtime-loader", () => {
 
     assertEquals(requestedUrl, "https://example.anthropic.test/v1/messages");
     assertEquals(requestedInit?.method, "POST");
+    assertEquals(
+      readRequestHeader(requestedInit, "anthropic-beta"),
+      "fine-grained-tool-streaming-2025-05-14",
+    );
     const requestBody = typeof requestedInit?.body === "string"
       ? JSON.parse(requestedInit.body)
       : undefined;

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -3789,6 +3789,7 @@ export function createAnthropicModelRuntime(
           apiKey: config.apiKey,
           authToken: config.authToken,
           extraHeaders: options.headers,
+          enableFineGrainedToolStreaming: true,
           body: JSON.stringify(body),
           signal: options.abortSignal,
         }),

--- a/src/provider/runtime-loader/provider-request-init.test.ts
+++ b/src/provider/runtime-loader/provider-request-init.test.ts
@@ -1,0 +1,46 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createAnthropicRequestHeaders } from "./provider-request-init.ts";
+
+describe("provider/runtime-loader/provider-request-init", () => {
+  it("enables Anthropic fine-grained tool streaming on streaming requests", () => {
+    const headers = createAnthropicRequestHeaders({
+      apiKey: "test-anthropic-key",
+      enableFineGrainedToolStreaming: true,
+    });
+
+    assertEquals(headers.get("anthropic-beta"), "fine-grained-tool-streaming-2025-05-14");
+    assertEquals(headers.get("x-api-key"), "test-anthropic-key");
+    assertEquals(headers.get("anthropic-version"), "2023-06-01");
+  });
+
+  it("merges the fine-grained tool streaming beta with caller-supplied Anthropic betas", () => {
+    const headers = createAnthropicRequestHeaders({
+      apiKey: "test-anthropic-key",
+      enableFineGrainedToolStreaming: true,
+      extraHeaders: {
+        "anthropic-beta": "mcp-client-2025-04-04, context-management-2025-06-27",
+      },
+    });
+
+    assertEquals(
+      headers.get("anthropic-beta"),
+      "mcp-client-2025-04-04,context-management-2025-06-27,fine-grained-tool-streaming-2025-05-14",
+    );
+  });
+
+  it("does not duplicate the fine-grained tool streaming beta when callers already provide it", () => {
+    const headers = createAnthropicRequestHeaders({
+      apiKey: "test-anthropic-key",
+      enableFineGrainedToolStreaming: true,
+      extraHeaders: {
+        "anthropic-beta": "fine-grained-tool-streaming-2025-05-14, mcp-client-2025-04-04",
+      },
+    });
+
+    assertEquals(
+      headers.get("anthropic-beta"),
+      "fine-grained-tool-streaming-2025-05-14,mcp-client-2025-04-04",
+    );
+  });
+});

--- a/src/provider/runtime-loader/provider-request-init.ts
+++ b/src/provider/runtime-loader/provider-request-init.ts
@@ -1,3 +1,5 @@
+const ANTHROPIC_FINE_GRAINED_TOOL_STREAMING_BETA = "fine-grained-tool-streaming-2025-05-14";
+
 export function createRequestHeaders(options: {
   apiKeyHeaderName: string;
   apiKey: string;
@@ -13,10 +15,24 @@ export function createAnthropicRequestHeaders(options: {
   apiKey?: string;
   authToken?: string;
   extraHeaders?: HeadersInit;
+  enableFineGrainedToolStreaming?: boolean;
 }): Headers {
   const headers = new Headers(options.extraHeaders);
   headers.set("content-type", "application/json");
   headers.set("anthropic-version", headers.get("anthropic-version") ?? "2023-06-01");
+
+  if (options.enableFineGrainedToolStreaming) {
+    const existingBetaHeader = headers.get("anthropic-beta");
+    if (!existingBetaHeader) {
+      headers.set("anthropic-beta", ANTHROPIC_FINE_GRAINED_TOOL_STREAMING_BETA);
+    } else {
+      const betas = new Set(
+        existingBetaHeader.split(",").map((beta) => beta.trim()).filter((beta) => beta.length > 0),
+      );
+      betas.add(ANTHROPIC_FINE_GRAINED_TOOL_STREAMING_BETA);
+      headers.set("anthropic-beta", Array.from(betas).join(","));
+    }
+  }
 
   if (options.authToken) {
     headers.set("authorization", `Bearer ${options.authToken}`);
@@ -49,6 +65,7 @@ export function createAnthropicRequestInit(options: {
   apiKey?: string;
   authToken?: string;
   extraHeaders?: HeadersInit;
+  enableFineGrainedToolStreaming?: boolean;
   body: string;
   signal?: AbortSignal;
 }): RequestInit {
@@ -58,6 +75,7 @@ export function createAnthropicRequestInit(options: {
       apiKey: options.apiKey,
       authToken: options.authToken,
       extraHeaders: options.extraHeaders,
+      enableFineGrainedToolStreaming: options.enableFineGrainedToolStreaming,
     }),
     body: options.body,
     signal: options.signal,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.215";
+export const VERSION = "0.1.216";


### PR DESCRIPTION
## Summary\n- enable Anthropic fine-grained tool streaming on the streaming runtime path\n- preserve caller-supplied  headers while adding the file-write streaming beta\n- bump Veryfront version to 0.1.216 and cover the header behavior with tests\n\n## Verification\n- deno test --no-check --allow-all src/provider/runtime-loader.test.ts src/provider/runtime-loader/provider-request-init.test.ts\n- direct Anthropic runtime stream proof with first  delta at ~2.95s