### PR TITLE
Respect disabled AI discovery in hosted request discovery

### DIFF
--- a/src/server/handlers/request/api/project-discovery.test.ts
+++ b/src/server/handlers/request/api/project-discovery.test.ts
@@ -221,6 +221,44 @@ describe(
       assertExists(skillRegistry.get("writer-helper"));
     });
 
+    it("does not warn about zero agents and tools when AI primitive discovery is disabled", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+      skillRegistry.clearAll();
+
+      const ctx = createHandlerContext(
+        "/disabled-ai-discovery-project",
+        "disabled-ai-discovery-project",
+        "preview",
+      );
+      ctx.config = {
+        ai: {
+          tools: { discovery: { enabled: false } },
+          agents: { discovery: { enabled: false } },
+          skills: { discovery: { enabled: false } },
+        },
+      } as HandlerContext["config"];
+
+      const originalWarn = console.warn;
+      const warnings: string[] = [];
+      console.warn = (message?: unknown, ...args: unknown[]) => {
+        warnings.push([message, ...args].map(String).join(" "));
+      };
+
+      try {
+        await ensureProjectDiscovery(ctx);
+      } finally {
+        console.warn = originalWarn;
+      }
+
+      assertEquals(
+        warnings.some((warning) =>
+          warning.includes("Primitive discovery found 0 agents and 0 tools")
+        ),
+        false,
+      );
+    });
+
     it("keeps explicit tool ids available for request-time project-agent runs", async () => {
       agentRegistry.clearAll();
       toolRegistry.clearAll();

--- a/src/server/handlers/request/api/project-discovery.ts
+++ b/src/server/handlers/request/api/project-discovery.ts
@@ -16,17 +16,23 @@ const logger = serverLogger.component("api-wrapper");
  */
 const discoveredProjects = new Map<string, Promise<void>>();
 
+function isDiscoveryEnabled(
+  discovery: { enabled?: boolean } | undefined,
+): boolean {
+  return discovery?.enabled ?? true;
+}
+
 function buildDiscoveryConfig(ctx: HandlerContext) {
   const discoveryConfig = ctx.config?.ai;
-  const skillDiscoveryEnabled = discoveryConfig?.skills?.discovery?.enabled ?? true;
+  const toolDiscovery = discoveryConfig?.tools?.discovery;
+  const agentDiscovery = discoveryConfig?.agents?.discovery;
+  const skillDiscovery = discoveryConfig?.skills?.discovery;
 
   return {
     baseDir: ctx.projectDir,
-    toolDirs: discoveryConfig?.tools?.discovery?.paths ?? ["tools"],
-    agentDirs: discoveryConfig?.agents?.discovery?.paths ?? ["agents"],
-    skillDirs: skillDiscoveryEnabled
-      ? (discoveryConfig?.skills?.discovery?.paths ?? ["skills"])
-      : [],
+    toolDirs: isDiscoveryEnabled(toolDiscovery) ? (toolDiscovery?.paths ?? ["tools"]) : [],
+    agentDirs: isDiscoveryEnabled(agentDiscovery) ? (agentDiscovery?.paths ?? ["agents"]) : [],
+    skillDirs: isDiscoveryEnabled(skillDiscovery) ? (skillDiscovery?.paths ?? ["skills"]) : [],
     resourceDirs: ["resources"],
     promptDirs: ["prompts"],
     workflowDirs: ["workflows"],
@@ -93,7 +99,10 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<void>
     agentRegistry.clear();
     toolRegistry.clear();
 
-    const result = await discoverAll(buildDiscoveryConfig(ctx));
+    const discoveryOptions = buildDiscoveryConfig(ctx);
+    const result = await discoverAll(discoveryOptions);
+    const shouldWarnOnEmptyAiDiscovery = discoveryOptions.toolDirs.length > 0 ||
+      discoveryOptions.agentDirs.length > 0;
 
     const logData = {
       projectSlug: ctx.projectSlug,
@@ -103,7 +112,9 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<void>
       errors: result.errors.length,
     };
 
-    if (result.agents.size === 0 && result.tools.size === 0) {
+    if (
+      result.agents.size === 0 && result.tools.size === 0 && shouldWarnOnEmptyAiDiscovery
+    ) {
       logger.warn("Primitive discovery found 0 agents and 0 tools", {
         ...logData,
         errorMessages: result.errors.map((e) => e.error.message).slice(0, 5),


### PR DESCRIPTION
## Summary
- Respect `ai.tools.discovery.enabled`, `ai.agents.discovery.enabled`, and `ai.skills.discovery.enabled` in request-time project discovery.
- Suppress zero agents/tools warning when tool and agent discovery are explicitly disabled.
- Add regression coverage for disabled AI primitive discovery.

## Evidence / root cause
The server chart could render discovery-disabled config, but veryfront-code still scanned default tool/agent directories because request discovery only read custom paths and ignored `enabled=false` for tools/agents.

## Verification
- RED reproduced before fix: disabled discovery still emitted the zero-count warning
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/server/handlers/request/api/project-discovery.test.ts`
- `deno check src/server/handlers/request/api/project-discovery.ts src/server/handlers/request/api/project-discovery.test.ts`
- `deno lint src/server/handlers/request/api/project-discovery.ts src/server/handlers/request/api/project-discovery.test.ts`
- `deno fmt --check src/server/handlers/request/api/project-discovery.ts src/server/handlers/request/api/project-discovery.test.ts`
- LSP diagnostics clean for modified files

## Notes
- Existing local dirty proxy/generated files were preserved and not included in this PR.
- Live Loki follow-up requires deployment.