### PR TITLE
feat(extensions): extract jose into ext-jwt

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -12,7 +12,8 @@
     "data/",
     ".deno_cache/",
     "cli/templates/files/",
-    "cli/templates/integrations/"
+    "cli/templates/integrations/",
+    "extensions/"
   ],
   "exports": {
     ".": "./src/index.ts",
@@ -262,7 +263,6 @@
     "tailwindcss/colors": "https://esm.sh/tailwindcss@4.2.2/colors",
     "redis": "npm:redis@5.11.0",
     "pg": "npm:pg@8.13.1",
-    "jose": "npm:jose@5.9.6",
     "@opentelemetry/api": "npm:@opentelemetry/api@1.9.0",
     "@opentelemetry/core": "npm:@opentelemetry/core@2.6.0",
     "@opentelemetry/context-async-hooks": "npm:@opentelemetry/context-async-hooks@2.6.0",

--- a/extensions/ext-jwt/deno.json
+++ b/extensions/ext-jwt/deno.json
@@ -1,0 +1,20 @@
+{
+  "name": "ext-jwt",
+  "version": "0.1.0",
+  "exports": "./src/index.ts",
+  "veryfront": {
+    "extension": true,
+    "capabilities": [
+      { "type": "contract", "name": "AuthProvider" },
+      { "type": "network", "host": "*" }
+    ]
+  },
+  "imports": {
+    "jose": "npm:jose@5.9.6",
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/testing/bdd": "jsr:@std/testing@1/bdd"
+  },
+  "tasks": {
+    "test": "deno test --no-check --allow-all src/"
+  }
+}

--- a/extensions/ext-jwt/src/index.test.ts
+++ b/extensions/ext-jwt/src/index.test.ts
@@ -1,0 +1,155 @@
+/**
+ * ext-jwt extension tests.
+ *
+ * @module extensions/ext-jwt/test
+ */
+
+import { assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+
+import {
+  createLocalJWKSet,
+  exportJWK,
+  generateKeyPair,
+  type JSONWebKeySet,
+  SignJWT,
+} from "jose";
+
+import factory, { type JwksResolver } from "./index.ts";
+
+const TEST_SECRET = "test-secret-for-ext-jwt-tests";
+
+describe("ext-jwt factory", () => {
+  it("produces an Extension with name ext-jwt and an AuthProvider in provides", () => {
+    const ext = factory({ secret: TEST_SECRET });
+    assertEquals(ext.name, "ext-jwt");
+    assertEquals(typeof ext.version, "string");
+    assertEquals(Array.isArray(ext.capabilities), true);
+
+    const provides = ext.provides;
+    if (!provides) throw new Error("Expected provides to be defined");
+    const auth = provides.AuthProvider as Record<string, unknown>;
+
+    assertEquals(typeof auth.sign, "function");
+    assertEquals(typeof auth.verify, "function");
+    assertEquals(typeof auth.verifyWithJwks, "function");
+    assertEquals(typeof auth.decode, "function");
+  });
+});
+
+describe("ext-jwt AuthProvider", () => {
+  it("sign → verify round-trip returns the original subject", async () => {
+    const ext = factory({ secret: TEST_SECRET });
+    const auth = ext.provides!.AuthProvider as {
+      sign: (payload: { sub: string; [k: string]: unknown }) => Promise<string>;
+      verify: (token: string) => Promise<{ sub: string; [k: string]: unknown }>;
+    };
+
+    const token = await auth.sign({ sub: "user-42", role: "admin" }, {
+      expiresIn: "1h",
+    });
+    assertEquals(typeof token, "string");
+
+    const payload = await auth.verify(token);
+    assertEquals(payload.sub, "user-42");
+    assertEquals(payload.role, "admin");
+  });
+
+  it("verify throws on tokens signed with a different secret", async () => {
+    const ext = factory({ secret: TEST_SECRET });
+    const auth = ext.provides!.AuthProvider as {
+      verify: (token: string) => Promise<unknown>;
+    };
+
+    const foreign = await new SignJWT({ sub: "x" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setExpirationTime("1h")
+      .sign(new TextEncoder().encode("some-other-secret"));
+
+    let threw = false;
+    try {
+      await auth.verify(foreign);
+    } catch {
+      threw = true;
+    }
+    assertEquals(threw, true);
+  });
+
+  it("verifyWithJwks verifies an RS256 token against an injected JWKS resolver", async () => {
+    const kid = "test-rs256-key";
+    const { privateKey, publicKey } = await generateKeyPair("RS256");
+    const token = await new SignJWT({ sub: "user-jwks", userId: "user-123" })
+      .setProtectedHeader({ alg: "RS256", kid })
+      .setExpirationTime("1h")
+      .sign(privateKey);
+
+    const jwk = await exportJWK(publicKey);
+    const jwks: JSONWebKeySet = {
+      keys: [{ ...jwk, kid, alg: "RS256", use: "sig" }],
+    };
+
+    let factoryCalls = 0;
+    const resolverFactory = (url: string): JwksResolver => {
+      factoryCalls += 1;
+      assertEquals(url, "https://example.test/.well-known/jwks.json");
+      return createLocalJWKSet(jwks) as unknown as JwksResolver;
+    };
+
+    const ext = factory({
+      secret: TEST_SECRET,
+      jwksResolverFactory: resolverFactory,
+    });
+    const auth = ext.provides!.AuthProvider as {
+      verifyWithJwks: (
+        token: string,
+        url: string,
+        opts?: { algorithms?: string[] },
+      ) => Promise<{ sub: string; userId?: string }>;
+    };
+
+    const payload = await auth.verifyWithJwks(
+      token,
+      "https://example.test/.well-known/jwks.json",
+      { algorithms: ["RS256"] },
+    );
+    assertEquals(payload.sub, "user-jwks");
+    assertEquals(payload.userId, "user-123");
+
+    // Second verify against the same URL must reuse the cached resolver.
+    const payload2 = await auth.verifyWithJwks(
+      token,
+      "https://example.test/.well-known/jwks.json",
+      { algorithms: ["RS256"] },
+    );
+    assertEquals(payload2.sub, "user-jwks");
+    assertEquals(factoryCalls, 1);
+  });
+
+  it("decode returns the protected header for a well-formed token", async () => {
+    const token = await new SignJWT({ sub: "x" })
+      .setProtectedHeader({ alg: "HS256", kid: "abc" })
+      .setExpirationTime("1h")
+      .sign(new TextEncoder().encode(TEST_SECRET));
+
+    const ext = factory({ secret: TEST_SECRET });
+    const auth = ext.provides!.AuthProvider as {
+      decode: (t: string) => { alg?: string; kid?: string } | undefined;
+    };
+
+    const header = auth.decode(token);
+    if (!header) throw new Error("Expected header to be defined");
+    assertEquals(header.alg, "HS256");
+    assertEquals(header.kid, "abc");
+  });
+
+  it("decode returns undefined for malformed input", () => {
+    const ext = factory({ secret: TEST_SECRET });
+    const auth = ext.provides!.AuthProvider as {
+      decode: (t: string) => unknown;
+    };
+
+    assertEquals(auth.decode("not-a-jwt"), undefined);
+    assertEquals(auth.decode(""), undefined);
+    assertEquals(auth.decode("a.b"), undefined);
+  });
+});

--- a/extensions/ext-jwt/src/index.ts
+++ b/extensions/ext-jwt/src/index.ts
@@ -1,0 +1,173 @@
+/**
+ * ext-jwt — AuthProvider implementation backed by `jose`.
+ *
+ * Provides the `AuthProvider` contract: sign / verify (HS256 by default),
+ * verify-with-remote-JWKS, and decode-header.
+ *
+ * @module extensions/ext-jwt
+ */
+
+import {
+  createRemoteJWKSet,
+  decodeProtectedHeader,
+  type JWTPayload,
+  jwtVerify,
+  type KeyLike,
+  SignJWT,
+} from "jose";
+
+import type { ExtensionFactory } from "veryfront/extensions";
+import type {
+  AuthProvider,
+  SignOptions,
+  TokenHeader,
+  TokenPayload,
+  VerifyOptions,
+} from "veryfront/extensions/interfaces";
+
+/**
+ * Signature used by jose's verify step to resolve a key for a given header.
+ *
+ * Matches the shape returned by `createRemoteJWKSet` / `createLocalJWKSet`
+ * and lets tests inject an in-memory key set without reaching the network.
+ */
+export type JwksResolver = Parameters<typeof jwtVerify>[1] & object;
+
+/**
+ * Factory for building a JWKS resolver from a URL.
+ *
+ * The default uses `createRemoteJWKSet`; tests can inject a stub that returns
+ * a local resolver bound to an in-memory key set.
+ */
+export type JwksResolverFactory = (jwksUrl: string) => JwksResolver;
+
+/**
+ * Optional configuration for the ext-jwt factory.
+ *
+ * - `secret`: HMAC secret for `sign`/`verify`. Falls back to the `JWT_SECRET`
+ *   environment variable. Without one, `sign`/`verify` throw.
+ * - `jwksResolverFactory`: test seam that overrides JWKS resolution.
+ */
+export interface ExtJwtConfig {
+  secret?: string | Uint8Array;
+  jwksResolverFactory?: JwksResolverFactory;
+}
+
+function defaultJwksResolverFactory(jwksUrl: string): JwksResolver {
+  return createRemoteJWKSet(new URL(jwksUrl)) as unknown as JwksResolver;
+}
+
+function toUint8Array(secret: string | Uint8Array): Uint8Array {
+  return typeof secret === "string" ? new TextEncoder().encode(secret) : secret;
+}
+
+function getSecret(configSecret?: string | Uint8Array): Uint8Array {
+  if (configSecret !== undefined) return toUint8Array(configSecret);
+  const env = typeof Deno !== "undefined"
+    ? Deno.env.get("JWT_SECRET")
+    : undefined;
+  if (!env) {
+    throw new Error(
+      "ext-jwt: no HMAC secret configured. Pass `secret` to the extension " +
+        "factory or set the JWT_SECRET environment variable.",
+    );
+  }
+  return new TextEncoder().encode(env);
+}
+
+function createAuthProvider(config: ExtJwtConfig): AuthProvider {
+  const jwksResolverFactory = config.jwksResolverFactory ??
+    defaultJwksResolverFactory;
+
+  // Cache one resolver per JWKS URL; `createRemoteJWKSet` maintains its own
+  // internal key cache with cooldown/rotation semantics, so reusing the
+  // same resolver is required for the cache to be effective.
+  const jwksResolvers = new Map<string, JwksResolver>();
+
+  function getJwksResolver(jwksUrl: string): JwksResolver {
+    const existing = jwksResolvers.get(jwksUrl);
+    if (existing) return existing;
+    const created = jwksResolverFactory(jwksUrl);
+    jwksResolvers.set(jwksUrl, created);
+    return created;
+  }
+
+  return {
+    async sign(payload: TokenPayload, options?: SignOptions): Promise<string> {
+      const secret = getSecret(config.secret);
+      const algorithm = options?.algorithm ?? "HS256";
+      const { sub, ...rest } = payload;
+      const builder = new SignJWT(rest as JWTPayload)
+        .setProtectedHeader({ alg: algorithm })
+        .setSubject(sub);
+      if (options?.expiresIn !== undefined) {
+        // jose's setExpirationTime accepts `string | number | Date`.
+        builder.setExpirationTime(
+          options.expiresIn as string | number,
+        );
+      }
+      return await builder.sign(secret);
+    },
+
+    async verify(
+      token: string,
+      options?: VerifyOptions,
+    ): Promise<TokenPayload> {
+      const secret = getSecret(config.secret);
+      const algorithms = options?.algorithms ?? ["HS256"];
+      const { payload } = await jwtVerify(token, secret, { algorithms });
+      return payload as TokenPayload;
+    },
+
+    async verifyWithJwks(
+      token: string,
+      jwksUrl: string,
+      options?: VerifyOptions,
+    ): Promise<TokenPayload> {
+      const resolver = getJwksResolver(jwksUrl);
+      const { algorithms, ...rest } = options ?? {};
+      const verifyOpts: Record<string, unknown> = { ...rest };
+      if (algorithms) verifyOpts.algorithms = algorithms;
+      const { payload } = await jwtVerify(
+        token,
+        resolver as unknown as KeyLike,
+        verifyOpts,
+      );
+      return payload as TokenPayload;
+    },
+
+    decode(token: string): TokenHeader | undefined {
+      try {
+        return decodeProtectedHeader(token) as TokenHeader;
+      } catch {
+        return undefined;
+      }
+    },
+  };
+}
+
+/**
+ * Default export — the ext-jwt extension factory.
+ *
+ * Produces an extension that registers an `AuthProvider` contract
+ * implementation backed by `jose`.
+ */
+const extJwt: ExtensionFactory = (config?: unknown) => {
+  const cfg = (config ?? {}) as ExtJwtConfig;
+  const provider = createAuthProvider(cfg);
+
+  return {
+    name: "ext-jwt",
+    version: "0.1.0",
+    capabilities: [
+      { type: "contract", name: "AuthProvider" },
+      { type: "network", host: "*" },
+    ],
+    provides: {
+      AuthProvider: provider,
+    },
+  };
+};
+
+export default extJwt;
+export { createAuthProvider };

--- a/src/extensions/interfaces/auth-provider.ts
+++ b/src/extensions/interfaces/auth-provider.ts
@@ -37,16 +37,48 @@ export interface VerifyOptions {
 }
 
 /**
+ * The parsed, unverified header of a JWT.
+ *
+ * Returned by {@link AuthProvider.decode}. `alg` is the signing algorithm
+ * advertised by the token (e.g. `"HS256"`, `"RS256"`); additional fields
+ * such as `kid` or `typ` may be present.
+ */
+export interface TokenHeader {
+  /** Signing algorithm advertised by the token header. */
+  alg?: string;
+  /** Additional header fields. */
+  [key: string]: unknown;
+}
+
+/**
  * AuthProvider contract interface.
  *
  * Implementations sign, verify, and decode authentication tokens
- * (e.g. JWTs) for request authentication.
+ * (e.g. JWTs) for request authentication, and verify third-party tokens
+ * against a remote JWKS.
  */
 export interface AuthProvider {
   /** Sign a payload into a token string. */
   sign(payload: TokenPayload, options?: SignOptions): Promise<string>;
   /** Verify a token and return its decoded payload. Throws on invalid tokens. */
   verify(token: string, options?: VerifyOptions): Promise<TokenPayload>;
-  /** Decode a token without verifying its signature. */
-  decode(token: string): TokenPayload | undefined;
+  /**
+   * Verify a token against a remote JSON Web Key Set.
+   *
+   * Fetches (and caches) the JWKS at `jwksUrl`, then verifies the token's
+   * signature and claims. Throws on invalid tokens, unreachable JWKS, or
+   * `kid`/algorithm mismatch.
+   */
+  verifyWithJwks(
+    token: string,
+    jwksUrl: string,
+    options?: VerifyOptions,
+  ): Promise<TokenPayload>;
+  /**
+   * Decode a token's protected header without verifying its signature.
+   *
+   * Returns `undefined` on malformed input. Useful for inspecting `alg`
+   * before choosing a verification strategy.
+   */
+  decode(token: string): TokenHeader | undefined;
 }

--- a/src/extensions/interfaces/index.ts
+++ b/src/extensions/interfaces/index.ts
@@ -35,7 +35,13 @@ export type {
 export type { DatabaseClient, QueryResult } from "./database-client.ts";
 
 // Auth provider
-export type { AuthProvider, SignOptions, TokenPayload, VerifyOptions } from "./auth-provider.ts";
+export type {
+  AuthProvider,
+  SignOptions,
+  TokenHeader,
+  TokenPayload,
+  VerifyOptions,
+} from "./auth-provider.ts";
 
 // Tracing exporter
 export type { SpanData, TracingExporter } from "./tracing-exporter.ts";

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -1,13 +1,136 @@
 import { assertEquals } from "#veryfront/testing/assert";
-import { describe, it } from "#veryfront/testing/bdd";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd";
 import { createMockServer } from "../../tests/_helpers/utils.ts";
-import { createProxyHandler, injectContextHeaders, type ProxyContext } from "./handler.ts";
-import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import {
+  __resetCachedAuthProviderForTests,
+  createProxyHandler,
+  injectContextHeaders,
+  type ProxyContext,
+} from "./handler.ts";
+import { register, reset } from "../extensions/contracts.ts";
+import type {
+  AuthProvider,
+  TokenHeader,
+  TokenPayload,
+} from "../extensions/interfaces/auth-provider.ts";
 
 const TEST_JWT_SECRET = "test-jwt-secret-for-proxy-handler-tests";
 
 // Set JWT_SECRET so extractUserIdFromToken can verify tokens
 Deno.env.set("JWT_SECRET", TEST_JWT_SECRET);
+
+/**
+ * In-memory AuthProvider used by the proxy tests.
+ *
+ * Implements a minimum surface: HS256 sign/verify via a registered secret,
+ * `verifyWithJwks` that dispatches to an in-memory JWKS-URL -> payload map,
+ * and a tolerant `decode` that returns `undefined` on malformed input.
+ *
+ * The fakeness of the tokens is deliberate: they're base64url-encoded JSON
+ * with a trivial HMAC stand-in, which keeps the tests fast and independent
+ * of `jose`.
+ */
+interface MockAuthOptions {
+  /** Map from jwksUrl -> (token -> payload) for verifyWithJwks. */
+  jwksVerifiers?: Map<string, Map<string, TokenPayload>>;
+  /** Override the expected HMAC secret for HS256 verify. */
+  secret?: string;
+}
+
+function base64url(data: string): string {
+  return btoa(data).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64urlDecode(str: string): string {
+  const padded = str.replace(/-/g, "+").replace(/_/g, "/") +
+    "=".repeat((4 - (str.length % 4)) % 4);
+  return atob(padded);
+}
+
+async function hmacSha(alg: "HS256" | "HS384", secret: string, data: string): Promise<string> {
+  const hashName = alg === "HS256" ? "SHA-256" : "SHA-384";
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: hashName },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(data));
+  return base64url(String.fromCharCode(...new Uint8Array(sig)));
+}
+
+/**
+ * Sign a minimal JWT using HS256/HS384 for tests. Matches the shape produced
+ * by `jose` closely enough that the mock AuthProvider's `verify` can round-trip.
+ */
+export async function signTestJwt(
+  payload: Record<string, unknown>,
+  alg: "HS256" | "HS384" = "HS256",
+  secret: string = TEST_JWT_SECRET,
+  kid?: string,
+): Promise<string> {
+  const header: Record<string, unknown> = { alg, typ: "JWT" };
+  if (kid) header.kid = kid;
+  const now = Math.floor(Date.now() / 1000);
+  const body = { iat: now, exp: now + 3600, ...payload };
+  const h = base64url(JSON.stringify(header));
+  const b = base64url(JSON.stringify(body));
+  const sig = await hmacSha(alg, secret, `${h}.${b}`);
+  return `${h}.${b}.${sig}`;
+}
+
+function createMockAuthProvider(options: MockAuthOptions = {}): AuthProvider {
+  const secret = options.secret ?? TEST_JWT_SECRET;
+  const jwksVerifiers = options.jwksVerifiers ?? new Map();
+
+  return {
+    sign(payload: TokenPayload): Promise<string> {
+      return signTestJwt(payload as Record<string, unknown>, "HS256", secret);
+    },
+    async verify(token: string, opts): Promise<TokenPayload> {
+      const parts = token.split(".");
+      if (parts.length !== 3) throw new Error("Malformed token");
+      const header = JSON.parse(base64urlDecode(parts[0])) as { alg?: string };
+      const body = JSON.parse(base64urlDecode(parts[1])) as TokenPayload;
+      const alg = header.alg ?? "";
+      const allowed = opts?.algorithms ?? ["HS256"];
+      if (!allowed.includes(alg)) throw new Error(`Unexpected alg: ${alg}`);
+
+      // Attempt to verify against the env secret as well as the configured
+      // one. When the handler calls verify() during tests that deleted
+      // JWT_SECRET, we must still reject on mismatch.
+      const envSecret = Deno.env.get("JWT_SECRET");
+      const expected = await hmacSha(
+        alg as "HS256" | "HS384",
+        envSecret ?? secret,
+        `${parts[0]}.${parts[1]}`,
+      );
+      if (parts[2] !== expected) throw new Error("Invalid signature");
+
+      if (typeof body.exp === "number" && body.exp < Math.floor(Date.now() / 1000)) {
+        throw new Error("Token expired");
+      }
+      return body;
+    },
+    async verifyWithJwks(token, jwksUrl): Promise<TokenPayload> {
+      const forUrl = jwksVerifiers.get(jwksUrl);
+      if (!forUrl) throw new Error(`No JWKS registered for ${jwksUrl}`);
+      const payload = forUrl.get(token);
+      if (!payload) throw new Error("Token not recognized by JWKS");
+      return payload;
+    },
+    decode(token: string): TokenHeader | undefined {
+      const parts = token.split(".");
+      if (parts.length !== 3) return undefined;
+      try {
+        return JSON.parse(base64urlDecode(parts[0])) as TokenHeader;
+      } catch {
+        return undefined;
+      }
+    },
+  };
+}
 
 function createTokenResponse(): Response {
   return Response.json({
@@ -21,54 +144,6 @@ function createNotFoundResponse(): Response {
   return new Response("Not found", { status: 404 });
 }
 
-async function createFakeJwt(userId: string): Promise<string> {
-  const secret = new TextEncoder().encode(TEST_JWT_SECRET);
-  return new SignJWT({ userId })
-    .setProtectedHeader({ alg: "HS256" })
-    .setExpirationTime("1h")
-    .sign(secret);
-}
-
-async function createRs256Jwt(userId: string): Promise<{
-  token: string;
-  jwks: {
-    keys: Array<{
-      alg: "RS256";
-      e: string;
-      kid: string;
-      kty: "RSA";
-      n: string;
-      use: "sig";
-    }>;
-  };
-}> {
-  const kid = "test-rs256-key";
-  const { privateKey, publicKey } = await generateKeyPair("RS256");
-  const token = await new SignJWT({ userId })
-    .setProtectedHeader({ alg: "RS256", kid })
-    .setExpirationTime("1h")
-    .sign(privateKey);
-  const exported = await exportJWK(publicKey);
-
-  if (exported.kty !== "RSA" || !exported.n || !exported.e) {
-    throw new Error("Expected RSA public JWK");
-  }
-
-  return {
-    token,
-    jwks: {
-      keys: [{
-        alg: "RS256",
-        e: exported.e,
-        kid,
-        kty: "RSA",
-        n: exported.n,
-        use: "sig",
-      }],
-    },
-  };
-}
-
 function createHandler(port: number, apiBasePath = "") {
   return createProxyHandler({
     config: {
@@ -80,6 +155,43 @@ function createHandler(port: number, apiBasePath = "") {
     },
   });
 }
+
+/** Per-test JWKS store so tests can register RS256 tokens by URL. */
+const jwksVerifiers = new Map<string, Map<string, TokenPayload>>();
+
+function registerRs256Token(jwksUrl: string, token: string, payload: TokenPayload): void {
+  let byToken = jwksVerifiers.get(jwksUrl);
+  if (!byToken) {
+    byToken = new Map();
+    jwksVerifiers.set(jwksUrl, byToken);
+  }
+  byToken.set(token, payload);
+}
+
+function forgeRs256Token(kid: string, userId: string): string {
+  const header = base64url(JSON.stringify({ alg: "RS256", kid, typ: "JWT" }));
+  const body = base64url(JSON.stringify({
+    userId,
+    sub: userId,
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  }));
+  // Signature intentionally opaque — the mock verifier looks up (url, token)
+  // pairs, so the bytes here just need to be unique per token.
+  const sig = base64url(`sig-${kid}-${userId}-${Math.random()}`);
+  return `${header}.${body}.${sig}`;
+}
+
+beforeEach(() => {
+  reset();
+  __resetCachedAuthProviderForTests();
+  jwksVerifiers.clear();
+  register<AuthProvider>("AuthProvider", createMockAuthProvider({ jwksVerifiers }));
+});
+
+afterEach(() => {
+  reset();
+  __resetCachedAuthProviderForTests();
+});
 
 describe("Proxy Handler", () => {
   describe("processRequest with custom domains", () => {
@@ -400,7 +512,7 @@ describe("Proxy Handler", () => {
     });
 
     it("allows access to protected custom domain with auth token for project member", async () => {
-      const memberToken = await createFakeJwt("user-123");
+      const memberToken = await signTestJwt({ userId: "user-123", sub: "user-123" });
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);
 
@@ -448,7 +560,7 @@ describe("Proxy Handler", () => {
     });
 
     it("returns 403 for protected custom domain when authenticated user is not a member", async () => {
-      const nonMemberToken = await createFakeJwt("other-user");
+      const nonMemberToken = await signTestJwt({ userId: "other-user", sub: "other-user" });
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);
 
@@ -543,7 +655,7 @@ describe("Proxy Handler", () => {
     });
 
     it("allows access to protected veryfront domain with auth token for project member", async () => {
-      const memberToken = await createFakeJwt("user-123");
+      const memberToken = await signTestJwt({ userId: "user-123", sub: "user-123" });
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);
 
@@ -593,7 +705,7 @@ describe("Proxy Handler", () => {
     });
 
     it("returns 403 for protected veryfront domain when authenticated user is not a member", async () => {
-      const nonMemberToken = await createFakeJwt("other-user");
+      const nonMemberToken = await signTestJwt({ userId: "other-user", sub: "other-user" });
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);
 
@@ -856,7 +968,7 @@ describe("Proxy Handler", () => {
     });
 
     it("allows access to protected preview domain with auth token for project member", async () => {
-      const memberToken = await createFakeJwt("user-123");
+      const memberToken = await signTestJwt({ userId: "user-123", sub: "user-123" });
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);
 
@@ -961,7 +1073,7 @@ describe("Proxy Handler", () => {
     });
 
     it("returns 404 for missing preview project with auth token", async () => {
-      const memberToken = await createFakeJwt("user-123");
+      const memberToken = await signTestJwt({ userId: "user-123", sub: "user-123" });
       const { server, port } = createMockServer((_req: Request) => {
         return createNotFoundResponse();
       });
@@ -1047,17 +1159,14 @@ describe("Proxy Handler", () => {
     });
 
     it("allows access to protected preview domain with RS256 auth token verified via JWKS", async () => {
-      const { token: memberToken, jwks } = await createRs256Jwt("user-123");
-      let jwksRequestCount = 0;
+      const kid = "test-rs256-key";
+      const memberToken = forgeRs256Token(kid, "user-123");
+      const jwksUrl = (port: number) => `http://127.0.0.1:${port}/.well-known/jwks.json`;
+
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);
 
         if (pathname === "/auth/token") return createTokenResponse();
-
-        if (pathname === "/.well-known/jwks.json") {
-          jwksRequestCount += 1;
-          return Response.json(jwks);
-        }
 
         if (pathname.startsWith("/projects/")) {
           return Response.json({
@@ -1078,6 +1187,12 @@ describe("Proxy Handler", () => {
       });
 
       try {
+        // Register the token with the URL the proxy will compute for this port.
+        registerRs256Token(jwksUrl(port), memberToken, {
+          sub: "user-123",
+          userId: "user-123",
+        });
+
         const handler = createHandler(port);
 
         const req = new Request(
@@ -1095,7 +1210,6 @@ describe("Proxy Handler", () => {
         assertEquals(ctx.error, undefined);
         assertEquals(ctx.projectSlug, "protected-project");
         assertEquals(ctx.environmentId, "env-1");
-        assertEquals(jwksRequestCount, 1);
 
         await handler.close();
       } finally {
@@ -1104,23 +1218,15 @@ describe("Proxy Handler", () => {
     });
 
     it("preserves a path-prefixed API base when resolving JWKS", async () => {
-      const { token: memberToken, jwks } = await createRs256Jwt("user-123");
-      let prefixedJwksRequestCount = 0;
-      let rootJwksRequestCount = 0;
+      const kid = "test-rs256-key";
+      const memberToken = forgeRs256Token(kid, "user-123");
+      const prefixedJwksUrl = (port: number) =>
+        `http://127.0.0.1:${port}/api/.well-known/jwks.json`;
+
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);
 
         if (pathname === "/api/auth/token") return createTokenResponse();
-
-        if (pathname === "/api/.well-known/jwks.json") {
-          prefixedJwksRequestCount += 1;
-          return Response.json(jwks);
-        }
-
-        if (pathname === "/.well-known/jwks.json") {
-          rootJwksRequestCount += 1;
-          return createNotFoundResponse();
-        }
 
         if (pathname.startsWith("/api/projects/")) {
           return Response.json({
@@ -1141,6 +1247,11 @@ describe("Proxy Handler", () => {
       });
 
       try {
+        registerRs256Token(prefixedJwksUrl(port), memberToken, {
+          sub: "user-123",
+          userId: "user-123",
+        });
+
         const handler = createHandler(port, "/api");
 
         const req = new Request(
@@ -1158,8 +1269,6 @@ describe("Proxy Handler", () => {
         assertEquals(ctx.error, undefined);
         assertEquals(ctx.projectSlug, "protected-project");
         assertEquals(ctx.environmentId, "env-1");
-        assertEquals(prefixedJwksRequestCount, 1);
-        assertEquals(rootJwksRequestCount, 0);
 
         await handler.close();
       } finally {
@@ -1168,7 +1277,7 @@ describe("Proxy Handler", () => {
     });
 
     it("returns 403 for protected preview domain when authenticated user is not a member", async () => {
-      const nonMemberToken = await createFakeJwt("other-user");
+      const nonMemberToken = await signTestJwt({ userId: "other-user", sub: "other-user" });
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);
 
@@ -1273,10 +1382,11 @@ describe("Proxy Handler", () => {
       Deno.env.delete("JWT_SECRET");
 
       try {
-        const memberToken = await new SignJWT({ userId: "user-123" })
-          .setProtectedHeader({ alg: "HS256" })
-          .setExpirationTime("1h")
-          .sign(new TextEncoder().encode("some-other-secret"));
+        const memberToken = await signTestJwt(
+          { userId: "user-123", sub: "user-123" },
+          "HS256",
+          "some-other-secret",
+        );
 
         const { server, port } = createMockServer((req: Request) => {
           const { pathname } = new URL(req.url);
@@ -1332,10 +1442,10 @@ describe("Proxy Handler", () => {
 
     it("rejects JWT signed with a different algorithm", async () => {
       // Sign with HS384 instead of the expected HS256
-      const wrongAlgToken = await new SignJWT({ userId: "user-123" })
-        .setProtectedHeader({ alg: "HS384" })
-        .setExpirationTime("1h")
-        .sign(new TextEncoder().encode(TEST_JWT_SECRET));
+      const wrongAlgToken = await signTestJwt(
+        { userId: "user-123", sub: "user-123" },
+        "HS384",
+      );
 
       const { server, port } = createMockServer((req: Request) => {
         const { pathname } = new URL(req.url);

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -6,7 +6,48 @@ import { cwd, getEnv } from "#veryfront/platform/compat/process.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { injectContext, ProxySpanNames, withSpan } from "./tracing.ts";
 import { computeContentSourceId } from "#veryfront/cache/keys.ts";
-import { createRemoteJWKSet, decodeProtectedHeader, jwtVerify } from "jose";
+import { resolve as resolveContract } from "../extensions/contracts.ts";
+import type { AuthProvider } from "../extensions/interfaces/auth-provider.ts";
+
+/**
+ * Cache the resolved AuthProvider at module scope so the proxy does not pay
+ * the registry lookup on every request. The cache is cleared implicitly when
+ * `ExtensionLoader.teardownAll()` clears the registry — the next call
+ * re-resolves (or surfaces the "install ext-jwt" hint if the extension was
+ * removed).
+ */
+let cachedAuthProvider: AuthProvider | undefined;
+
+function getAuthProvider(): AuthProvider {
+  if (cachedAuthProvider) return cachedAuthProvider;
+
+  try {
+    cachedAuthProvider = resolveContract<AuthProvider>("AuthProvider");
+    return cachedAuthProvider;
+  } catch (err) {
+    // resolve() already throws with a helpful "Recommended: @veryfront/ext-jwt"
+    // message, but the proxy is a load-bearing code path — append a concrete
+    // remediation hint that names the project-root extension directory so
+    // the user knows exactly what's missing.
+    const base = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `${base}\nTo enable JWT verification in the proxy, install ext-jwt ` +
+        `(scaffold with \`deno task cli extension init ext-jwt\` or add the ` +
+        `npm package @veryfront/ext-jwt).`,
+      { cause: err },
+    );
+  }
+}
+
+/**
+ * Reset the cached AuthProvider. Intended for tests that `register()` a mock
+ * after the handler module has been imported.
+ *
+ * @internal
+ */
+export function __resetCachedAuthProviderForTests(): void {
+  cachedAuthProvider = undefined;
+}
 
 export const INTERNAL_PROXY_HEADERS = [
   "x-token",
@@ -64,24 +105,10 @@ interface DomainLookupResult {
   }>;
 }
 
-const remoteJwksByUrl = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
-
-function getApiJwks(apiBaseUrl: string, logger?: ProxyLogger) {
+function resolveApiJwksUrl(apiBaseUrl: string, logger?: ProxyLogger): string | undefined {
   try {
     const normalizedBaseUrl = apiBaseUrl.endsWith("/") ? apiBaseUrl : `${apiBaseUrl}/`;
-    const jwksUrl = new URL(".well-known/jwks.json", normalizedBaseUrl);
-    const cacheKey = jwksUrl.toString();
-
-    // Lazily initialize and cache JWKS in a single, idempotent step to avoid
-    // unsynchronized read/then-write on the shared Map across concurrent calls.
-    let jwks = remoteJwksByUrl.get(cacheKey);
-    if (!jwks) {
-      const created = createRemoteJWKSet(jwksUrl);
-      remoteJwksByUrl.set(cacheKey, created);
-      jwks = created;
-    }
-
-    return jwks;
+    return new URL(".well-known/jwks.json", normalizedBaseUrl).toString();
   } catch (error) {
     logger?.error("Invalid API base URL for JWKS lookup", error as Error, {
       apiBaseUrl,
@@ -229,23 +256,22 @@ async function extractUserIdFromToken(
   apiBaseUrl: string,
   log?: ProxyLogger,
 ): Promise<string | undefined> {
-  let algorithm: string | undefined;
+  const auth = getAuthProvider();
 
-  try {
-    algorithm = decodeProtectedHeader(token).alg;
-  } catch (error) {
-    log?.debug("Failed to decode JWT header", {
-      error: error instanceof Error ? error.message : String(error),
-    });
+  const header = auth.decode(token);
+  if (!header) {
+    log?.debug("Failed to decode JWT header");
     return undefined;
   }
 
+  const algorithm = header.alg;
+
   if (algorithm === "RS256") {
-    const jwks = getApiJwks(apiBaseUrl, log);
-    if (!jwks) return undefined;
+    const jwksUrl = resolveApiJwksUrl(apiBaseUrl, log);
+    if (!jwksUrl) return undefined;
 
     try {
-      const { payload } = await jwtVerify(token, jwks, {
+      const payload = await auth.verifyWithJwks(token, jwksUrl, {
         algorithms: ["RS256"],
       });
       return (payload as { userId?: string }).userId;
@@ -270,10 +296,10 @@ async function extractUserIdFromToken(
   }
 
   try {
-    const secret = new TextEncoder().encode(jwtSecret);
-    const { payload } = await jwtVerify(token, secret, {
-      algorithms: ["HS256"],
-    });
+    // ext-jwt reads JWT_SECRET from the environment when no `secret` was
+    // passed to the extension factory; the explicit env check above is kept
+    // so callers can warn once before we attempt verification.
+    const payload = await auth.verify(token, { algorithms: ["HS256"] });
     return (payload as { userId?: string }).userId;
   } catch (error) {
     log?.debug("JWT verification failed", {


### PR DESCRIPTION
Closes #1125

## Summary

- Widen the `AuthProvider` contract with `verifyWithJwks(token, jwksUrl, opts?)` and a dedicated `TokenHeader` type returned by `decode`.
- New project-root extension `extensions/ext-jwt/` (name `ext-jwt`, version `0.1.0`) implements the `AuthProvider` contract on top of `jose`. The factory accepts an optional `jwksResolverFactory` test seam and caches one resolver per JWKS URL.
- `src/proxy/handler.ts` no longer imports `jose` directly; it lazily resolves `AuthProvider` through the contract registry via a module-scope cache, and emits an install hint that mentions `ext-jwt` when no implementation is registered.
- `src/proxy/handler.test.ts` rewritten to register a Web-Crypto-backed mock `AuthProvider` — no `jose` imports anywhere in `src/` or `cli/`.
- Root `deno.json` drops `"jose"` from the import map and excludes `extensions/` from the root test runner (so nested import maps stay authoritative for extension tests).

Plan: see `plans/mcp_server_implementation.md` / tracking issue #1125.

Parallel note: PR 4 (the token-recommendations follow-up) also touches `src/proxy/handler.ts` in a different region (`recommendations.ts` calls); a trivial 2-line merge is expected.

## Test plan

- [x] `deno task test` on `extensions/ext-jwt/` (6 steps)
- [x] `src/proxy/handler.test.ts` suite (36 steps, all using `register`/`reset`)
- [x] Full proxy suite (142 steps)
- [x] Extensions suite (125 steps)
- [x] Pre-push hook: fmt, lint, typecheck, full unit test suite (1378 tests / 16830 steps)
- [x] `grep -R "from \"jose\"" src cli` returns no matches