### PR TITLE
Expose npm type declarations through public export maps

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.217",
+  "version": "0.1.218",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -254,12 +254,30 @@ await build({
 		const pkgPath = "./npm/package.json";
 		const pkg = JSON.parse(await Deno.readTextFile(pkgPath));
 		pkg.type = "module"; // Required for ESM imports without warnings
+		pkg.types = "./esm/src/index.d.ts";
 		pkg.bin = { veryfront: "bin/veryfront.js" };
 		pkg.files = ["esm", "script", "src", "bin", "tsconfig.json", "LICENSE", "README.md"];
 		pkg.exports["./tsconfig.json"] = "./tsconfig.json";
+		addTypesExportEntries(pkg.exports);
 		await Deno.writeTextFile(pkgPath, JSON.stringify(pkg, null, 2));
 	},
 });
+
+function addTypesExportEntries(
+	exportsMap: Record<string, string | { import?: string; types?: string }>,
+): void {
+	for (const [exportKey, exportValue] of Object.entries(exportsMap)) {
+		if (exportKey === "./tsconfig.json" || typeof exportValue === "string") {
+			continue;
+		}
+
+		if (!exportValue.import || !exportValue.import.endsWith(".js")) {
+			continue;
+		}
+
+		exportValue.types = exportValue.import.replace(/\.js$/, ".d.ts");
+	}
+}
 
 /** Patch a generated file with string or regex replacement. Throws if pattern not found. */
 function patchFile(

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.217";
+export const VERSION = "0.1.218";


### PR DESCRIPTION
## Summary
- add `types` entries to generated npm export-map records
- set the root npm `types` field during the dnt post-build step
- bump the release version to `0.1.218`

