### PR TITLE
feat(init): merge per-integration npmDependencies into generated package.json

### DIFF
--- a/cli/commands/init/config-generator.test.ts
+++ b/cli/commands/init/config-generator.test.ts
@@ -27,5 +27,67 @@ describe("config-generator", () => {
         await Deno.remove(tmpDir, { recursive: true });
       }
     });
+
+    it("merges npmDependencies from selected integrations", async () => {
+      const tmpDir = await Deno.makeTempDir();
+      try {
+        await createPackageJson(tmpDir, "demo", {
+          integrations: [
+            {
+              name: "neon",
+              npmDependencies: { pg: "^8.13.1" },
+            },
+            {
+              name: "stripe",
+              npmDependencies: { stripe: "^17.0.0" },
+            },
+          ],
+        });
+
+        const pkg = JSON.parse(await Deno.readTextFile(join(tmpDir, "package.json")));
+        assertEquals(pkg.dependencies.pg, "^8.13.1");
+        assertEquals(pkg.dependencies.stripe, "^17.0.0");
+        // existing defaults still present
+        assertEquals(pkg.dependencies.veryfront !== undefined, true);
+        assertEquals(pkg.dependencies.react !== undefined, true);
+      } finally {
+        await Deno.remove(tmpDir, { recursive: true });
+      }
+    });
+
+    it("is a no-op for integrations without npmDependencies", async () => {
+      const tmpDir = await Deno.makeTempDir();
+      try {
+        await createPackageJson(tmpDir, "demo", {
+          integrations: [{ name: "slack" }], // no npmDependencies
+        });
+        const pkg = JSON.parse(await Deno.readTextFile(join(tmpDir, "package.json")));
+        assertEquals(Object.keys(pkg.dependencies).sort(), [
+          "react",
+          "react-dom",
+          "veryfront",
+          "zod",
+        ]);
+      } finally {
+        await Deno.remove(tmpDir, { recursive: true });
+      }
+    });
+
+    it("later integrations do not clobber earlier ones on version collision", async () => {
+      const tmpDir = await Deno.makeTempDir();
+      try {
+        await createPackageJson(tmpDir, "demo", {
+          integrations: [
+            { name: "a", npmDependencies: { shared: "^1.0.0" } },
+            { name: "b", npmDependencies: { shared: "^2.0.0" } },
+          ],
+        });
+        const pkg = JSON.parse(await Deno.readTextFile(join(tmpDir, "package.json")));
+        // First declaration wins; second is skipped with a warning logged by the impl.
+        assertEquals(pkg.dependencies.shared, "^1.0.0");
+      } finally {
+        await Deno.remove(tmpDir, { recursive: true });
+      }
+    });
   });
 });

--- a/cli/commands/init/config-generator.ts
+++ b/cli/commands/init/config-generator.ts
@@ -5,9 +5,23 @@ import { createFileSystem } from "veryfront/platform";
 // Keep init scaffold aligned with current framework default React major/minor.
 const DEFAULT_INIT_REACT_VERSION = "19.1.1";
 
+export interface CreatePackageJsonOptions {
+  /**
+   * Selected integrations whose `connector.json#npmDependencies` should be
+   * merged into the generated project's `package.json#dependencies`.
+   * First declaration wins on version collisions; framework pins
+   * (react, react-dom, veryfront, zod) always take precedence.
+   */
+  integrations?: Array<{
+    name: string;
+    npmDependencies?: Record<string, string>;
+  }>;
+}
+
 export async function createPackageJson(
   projectDir: string,
   projectName?: string,
+  options: CreatePackageJsonOptions = {},
 ): Promise<void> {
   const fs = createFileSystem();
 
@@ -17,6 +31,24 @@ export async function createPackageJson(
   if (await fs.exists(pkgPath)) {
     const existing = JSON.parse(await fs.readTextFile(pkgPath));
     templateDeps = existing.dependencies ?? {};
+  }
+
+  // Merge per-integration deps. First declaration wins; collisions are logged.
+  const integrationDeps: Record<string, string> = {};
+  for (const integration of options.integrations ?? []) {
+    for (const [pkg, range] of Object.entries(integration.npmDependencies ?? {})) {
+      if (pkg in integrationDeps) {
+        if (integrationDeps[pkg] !== range) {
+          logger.warn(
+            `[init] ${integration.name} requested ${pkg}@${range} but ${pkg}@${
+              integrationDeps[pkg]
+            } is already pinned by an earlier integration - keeping the earlier pin`,
+          );
+        }
+        continue;
+      }
+      integrationDeps[pkg] = range;
+    }
   }
 
   const dirName = projectDir.split(/[/\\]/).pop();
@@ -34,6 +66,7 @@ export async function createPackageJson(
     },
     dependencies: {
       ...templateDeps,
+      ...integrationDeps,
       react: `^${DEFAULT_INIT_REACT_VERSION}`,
       "react-dom": `^${DEFAULT_INIT_REACT_VERSION}`,
       veryfront: `^${VERSION}`,

--- a/cli/commands/init/init-command.ts
+++ b/cli/commands/init/init-command.ts
@@ -269,6 +269,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
 
   const allEnvVars: EnvVarConfig[] = templateConfig?.envVars ? [...templateConfig.envVars] : [];
   const featureTips: string[] = [];
+  let loadedIntegrations: ResolvedIntegration[] = [];
 
   if (features.length) {
     const { ordered, errors } = await resolveFeatures(features);
@@ -309,10 +310,11 @@ export async function initCommand(options: InitOptions): Promise<void> {
     if (baseConfig?.envVars) allEnvVars.push(...baseConfig.envVars);
 
     const {
-      integrations: loadedIntegrations,
+      integrations: resolvedIntegrations,
       files: integrationFiles,
       errors: integrationErrors,
     } = await loadIntegrations(integrations);
+    loadedIntegrations = resolvedIntegrations;
 
     if (integrationErrors.length) {
       for (const error of integrationErrors) logger.warn(error);
@@ -359,7 +361,12 @@ export async function initCommand(options: InitOptions): Promise<void> {
 
     // Skip in quiet/TUI mode since local dev uses CDN and package.json can cause hydration issues
     if (!options.quiet) {
-      await createPackageJson(projectDir, projectName);
+      await createPackageJson(projectDir, projectName, {
+        integrations: loadedIntegrations.map((integration) => ({
+          name: integration.config.name,
+          npmDependencies: integration.config.npmDependencies,
+        })),
+      });
     }
 
     if (allEnvVars.length) {

--- a/cli/commands/init/init.integration.test.ts
+++ b/cli/commands/init/init.integration.test.ts
@@ -171,6 +171,23 @@ describe("init command integration", () => {
       const packageJson = await readTextFile(join(projectDir, "package.json"));
       assertExists(packageJson.includes("veryfront"));
     });
+
+    it("merges npm dependencies from selected integrations into package.json", async () => {
+      const result = await runInitCommand([
+        projectName,
+        "-t",
+        "minimal",
+        "--integrations",
+        "neon",
+        "--skip-install",
+        "--skip-env-prompt",
+      ]);
+
+      assertEquals(result.code, 0);
+
+      const pkg = JSON.parse(await readTextFile(join(projectDir, "package.json")));
+      assertEquals(pkg.dependencies.pg, "^8.13.1");
+    });
   });
 
   describe("wizard behavior in non-TTY", () => {

--- a/cli/templates/integrations/neon/connector.json
+++ b/cli/templates/integrations/neon/connector.json
@@ -30,6 +30,9 @@
       "docsUrl": "https://neon.tech/docs/connect/connect-from-any-app"
     }
   ],
+  "npmDependencies": {
+    "pg": "^8.13.1"
+  },
   "tools": [
     {
       "id": "list-projects",

--- a/src/integrations/schema.ts
+++ b/src/integrations/schema.ts
@@ -151,6 +151,14 @@ export const IntegrationConfigSchema = z.object({
   description: z.string(),
   auth: OAuthConfigSchema,
   envVars: z.array(EnvVarSchema).optional(),
+  /**
+   * Optional map of npm packages to semver ranges. When this integration is
+   * selected during `veryfront init`, these deps are merged into the
+   * generated project's `package.json#dependencies`. Use this for templates
+   * that import packages beyond the init scaffold's defaults (react,
+   * react-dom, veryfront, zod).
+   */
+  npmDependencies: z.record(z.string(), z.string()).optional(),
   tools: z.array(IntegrationToolSchema),
   prompts: z.array(IntegrationPromptSchema).optional(),
   suggestedWith: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

- Adds optional `npmDependencies` field to `connector.json` (schema in `src/integrations/schema.ts`).
- `cli/commands/init/config-generator.ts` merges those deps into the generated `package.json#dependencies`.
- Seeds the neon template with `pg ^8.13.1` so `veryfront init --integrations neon` now produces a working project.

Merge order: `templateDeps → integrationDeps → framework pins`. Framework pins (react/react-dom/veryfront/zod) always win. First declaration wins on cross-integration collisions; a warning is logged when a later integration requests a different version of the same package.

From plan: **PR 2** of `docs/superpowers/plans/2026-04-20-extensions-waves-2-4-and-inlining.md`. Unblocks PR 1 (drop dead `pg` import-map entry) and cleanly supports the wave 3+ extensions that will want to pin peer deps via integration templates.

## Test plan

- [x] `deno task test:unit` — full suite green locally (1379 existing + 3 new config-generator specs)
- [x] New integration test: `veryfront init --integrations neon` → assert `pkg.dependencies.pg === "^8.13.1"`
- [ ] CI green