### PR TITLE
Add detached AG-UI run start to the hosted agent surface

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.218",
+  "version": "0.1.219",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent-runtime-ag-ui-contract.md
+++ b/docs/reference/agent-runtime-ag-ui-contract.md
@@ -74,6 +74,7 @@ The package should standardize the runtime contract, not force one hardcoded rou
 Recommended default convention:
 
 - `POST /api/ag-ui`
+- `POST /api/ag-ui/runs`
 - `POST /api/ag-ui/runs/:runId/resume`
 - `DELETE /api/ag-ui/runs/:runId`
 

--- a/docs/reference/agent-runtime-ag-ui.md
+++ b/docs/reference/agent-runtime-ag-ui.md
@@ -16,6 +16,7 @@ This is the package-level AG-UI contract. Veryfront Studio's internal `/internal
 - canonical hosted runtime request contract: `AgUiRuntimeRequestSchema`
 - response body: AG-UI SSE
 - default endpoint convention: `/api/ag-ui`
+- default detached hosted start endpoint: `POST /api/ag-ui/runs`
 - default hosted resume endpoint: `POST /api/ag-ui/runs/:runId/resume`
 - default hosted cancel endpoint: `DELETE /api/ag-ui/runs/:runId`
 - host path: overrideable by the application
@@ -28,11 +29,7 @@ Use `createAgUiHandler()` as a convenience wrapper when you want a direct
 route handler:
 
 ```ts
-import {
-  agent,
-  createAgUiHandler,
-  RunResumeSessionManager,
-} from "veryfront/agent";
+import { agent, createAgUiHandler, RunResumeSessionManager } from "veryfront/agent";
 
 const assistant = agent({
   system: "You are a helpful assistant.",
@@ -58,6 +55,7 @@ accepts injected client tools in `tools`, pass the same public
 
 For resumable hosted runs, the package also exposes:
 
+- `createAgUiDetachedStartHandler()`
 - `createAgUiResumeHandler()`
 - `createAgUiCancelHandler()`
 - `AgUiResumeSignalSchema`
@@ -97,6 +95,21 @@ Package-hosted resumable runs can expose generic control endpoints using the
 same `RunResumeSessionManager` that the runtime uses internally:
 
 ```ts
+import { createAgUiDetachedStartHandler, RunResumeSessionManager } from "veryfront/agent";
+
+const sessionManager = new RunResumeSessionManager<{
+  result: unknown;
+  isError: boolean;
+}>();
+
+// app/api/ag-ui/runs/route.ts
+export const POST = createAgUiDetachedStartHandler({
+  agent: assistant,
+  sessionManager,
+});
+```
+
+```ts
 import {
   createAgUiCancelHandler,
   createAgUiResumeHandler,
@@ -113,10 +126,7 @@ export const POST = createAgUiResumeHandler({ sessionManager });
 ```
 
 ```ts
-import {
-  createAgUiCancelHandler,
-  RunResumeSessionManager,
-} from "veryfront/agent";
+import { createAgUiCancelHandler, RunResumeSessionManager } from "veryfront/agent";
 
 const sessionManager = new RunResumeSessionManager<{
   result: unknown;

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -17,11 +17,13 @@ import {
   agent,
   agentAsTool,
   AgentRuntime,
+  AgUiDetachedStartRequestSchema,
   AgUiRequestSchema,
   AgUiResumeSignalSchema,
   AgUiRuntimeRequestSchema,
   createAgUiBrowserEncoderState,
   createAgUiCancelHandler,
+  createAgUiDetachedStartHandler,
   createAgUiHandler,
   createAgUiResumeHandler,
   createMemory,
@@ -136,11 +138,23 @@ export const POST = createAgUiHandler({
 ### AG-UI run control routes
 
 ```ts
+// app/api/ag-ui/runs/route.ts
+import { createAgUiDetachedStartHandler, RunResumeSessionManager } from "veryfront/agent";
+
+const sessionManager = new RunResumeSessionManager<{
+  result: unknown;
+  isError: boolean;
+}>();
+
+export const POST = createAgUiDetachedStartHandler({
+  agent: assistant,
+  sessionManager,
+});
+```
+
+```ts
 // app/api/ag-ui/runs/[runId]/resume/route.ts
-import {
-  createAgUiResumeHandler,
-  RunResumeSessionManager,
-} from "veryfront/agent";
+import { createAgUiResumeHandler, RunResumeSessionManager } from "veryfront/agent";
 
 const sessionManager = new RunResumeSessionManager<{
   result: unknown;
@@ -152,10 +166,7 @@ export const POST = createAgUiResumeHandler({ sessionManager });
 
 ```ts
 // app/api/ag-ui/runs/[runId]/route.ts
-import {
-  createAgUiCancelHandler,
-  RunResumeSessionManager,
-} from "veryfront/agent";
+import { createAgUiCancelHandler, RunResumeSessionManager } from "veryfront/agent";
 
 const sessionManager = new RunResumeSessionManager<{
   result: unknown;
@@ -479,6 +490,24 @@ contract.
 Validate the canonical hosted-run resume payload for AG-UI tool-result
 continuations.
 
+### `AgUiDetachedStartRequestSchema`
+
+Validate the canonical detached hosted-run kickoff payload for AG-UI routes.
+This schema requires explicit `runId` and `threadId`.
+
+### `createAgUiDetachedStartHandler(options)`
+
+Create a generic POST handler for detached hosted AG-UI run kickoff.
+
+Default route convention:
+
+- `POST /api/ag-ui/runs`
+
+Response shape:
+
+- `202 { accepted: true, duplicate: false, runId, threadId }`
+- `202 { accepted: true, duplicate: true, runId, threadId }`
+
 ### `createAgUiResumeHandler(options)`
 
 Create a generic POST handler for hosted resumable AG-UI runs.
@@ -543,26 +572,27 @@ Clear all stored messages from memory.
 
 ### Functions
 
-| Name                      | Description                                                             |
-| ------------------------- | ----------------------------------------------------------------------- |
-| `agent`                   | Create an agent                                                         |
-| `agentAsTool`             | Wrap agent as callable tool                                             |
-| `createAgUiCancelHandler` | Create a DELETE handler for hosted AG-UI run cancellation               |
-| `createAgUiHandler`       | Create a POST handler for an AG-UI route                                |
-| `createAgUiResumeHandler` | Create a POST handler for hosted AG-UI run resume values                |
-| `createChatHandler`       | Create a POST handler for a chat API route.                             |
-| `createMemory`            | Create memory (buffer, conversation, summary)                           |
-| `createRedisMemory`       | Create Redis-backed memory                                              |
-| `createWorkflow`          | Create sequential agent workflow                                        |
-| `getAgent`                | Get agent by ID                                                         |
-| `getAgentsAsTools`        | Get agents as tools (multi-agent)                                       |
-| `getAllAgentIds`          | List registered agent IDs                                               |
-| `getTextFromParts`        | Extract text from multi-part message                                    |
-| `getToolArguments`        | Extract parsed tool call args                                           |
-| `hasArgs`                 | Check for parsed args on tool call                                      |
-| `hasInput`                | Check for raw input on tool call                                        |
-| `registerAgent`           | Register agent for discovery                                            |
-| `waitForHumanInput`       | Wait for a canonical human-input response over hosted AG-UI run control |
+| Name                             | Description                                                             |
+| -------------------------------- | ----------------------------------------------------------------------- |
+| `agent`                          | Create an agent                                                         |
+| `agentAsTool`                    | Wrap agent as callable tool                                             |
+| `createAgUiCancelHandler`        | Create a DELETE handler for hosted AG-UI run cancellation               |
+| `createAgUiDetachedStartHandler` | Create a POST handler for detached hosted AG-UI run kickoff             |
+| `createAgUiHandler`              | Create a POST handler for an AG-UI route                                |
+| `createAgUiResumeHandler`        | Create a POST handler for hosted AG-UI run resume values                |
+| `createChatHandler`              | Create a POST handler for a chat API route.                             |
+| `createMemory`                   | Create memory (buffer, conversation, summary)                           |
+| `createRedisMemory`              | Create Redis-backed memory                                              |
+| `createWorkflow`                 | Create sequential agent workflow                                        |
+| `getAgent`                       | Get agent by ID                                                         |
+| `getAgentsAsTools`               | Get agents as tools (multi-agent)                                       |
+| `getAllAgentIds`                 | List registered agent IDs                                               |
+| `getTextFromParts`               | Extract text from multi-part message                                    |
+| `getToolArguments`               | Extract parsed tool call args                                           |
+| `hasArgs`                        | Check for parsed args on tool call                                      |
+| `hasInput`                       | Check for raw input on tool call                                        |
+| `registerAgent`                  | Register agent for discovery                                            |
+| `waitForHumanInput`              | Wait for a canonical human-input response over hosted AG-UI run control |
 
 ### Classes
 
@@ -581,6 +611,7 @@ Clear all stored messages from memory.
 
 | Name                             | Description                                                            |
 | -------------------------------- | ---------------------------------------------------------------------- |
+| `AgUiDetachedStartRequestSchema` | Canonical detached hosted-run kickoff request schema                   |
 | `AgUiRequestSchema`              | Convenience request schema for `createAgUiHandler()`                   |
 | `AgUiRuntimeRequestSchema`       | Canonical open-source AG-UI runtime request contract for hosted runs   |
 | `AgUiResumeSignalSchema`         | Canonical hosted-run resume payload for AG-UI tool-result continuation |
@@ -592,66 +623,69 @@ Clear all stored messages from memory.
 
 ### Types
 
-| Name                             | Description                                                                  |
-| -------------------------------- | ---------------------------------------------------------------------------- |
-| `Agent`                          | `agent()` return type                                                        |
-| `AgentConfig`                    | Agent configuration                                                          |
-| `AgentContext`                   | Agent handler context                                                        |
-| `AgentMiddleware`                | Agent execution middleware                                                   |
-| `AgentResponse`                  | Agent execution response                                                     |
-| `AgentStatus`                    | Agent status (idle, running, etc.)                                           |
-| `AgentStreamResult`              | Streaming result (`.toDataStreamResponse()`)                                 |
-| `AgUiContextItem`                | AG-UI runtime context item                                                   |
-| `AgUiHandlerConfigWithAgent`     | Direct-agent form for `createAgUiHandler`                                    |
-| `AgUiHandlerOptions`             | Options for `createAgUiHandler`                                              |
-| `AgUiCancelHandlerOptions`       | Options for `createAgUiCancelHandler`                                        |
-| `AgUiInjectedTool`               | AG-UI client-injected tool descriptor                                        |
-| `AgUiRequest`                    | Validated AG-UI runtime request body                                         |
-| `AgUiResumeHandlerOptions`       | Options for `createAgUiResumeHandler`                                        |
-| `AgUiResumeSignal`               | Validated hosted-run resume payload                                          |
-| `HumanInputField`                | Canonical form/input field definition                                        |
-| `HumanInputFieldInput`           | Input shape accepted by `waitForHumanInput()` before defaults normalize      |
-| `HumanInputOption`               | Canonical select/radio option definition                                     |
-| `HumanInputPendingRequest`       | Pending human-input envelope passed to `onRequest`                           |
-| `HumanInputRequest`              | Normalized human-input request payload                                       |
-| `HumanInputRequestInput`         | Input shape accepted by `HumanInputRequestSchema`                            |
-| `HumanInputResult`               | Validated human-input resumed result                                         |
-| `RunResumeSessionManagerOptions` | Options for `RunResumeSessionManager`                                        |
-| `RunSessionStatus`               | Status of a resumable run session                                            |
-| `SubmitResumeValueOutcome`       | Result of submitting an accepted or duplicate resume value                   |
-| `WaitForHumanInputOptions`       | Options for `waitForHumanInput()`                                            |
-| `ChatHandlerBeforeStream`        | Hook signature for `createChatHandler` customization before streaming.       |
-| `ChatHandlerBeforeStreamContext` | Input passed to `beforeStream` hook.                                         |
-| `ChatHandlerBeforeStreamResult`  | Message/context mutations returned from `beforeStream`.                      |
-| `ChatHandlerMessageInput`        | Message shape for `prepend`/`append`/`replaceMessages` in `beforeStream`.    |
-| `ChatHandlerOptions`             | Options for `createChatHandler` — customize context and pre-stream behavior. |
-| `EdgeConfig`                     | Agent-to-agent edge config                                                   |
-| `Memory`                         | Memory interface                                                             |
-| `MemoryConfig`                   | Memory creation config                                                       |
-| `MemoryPersistence`              | Memory storage backend                                                       |
-| `MemoryStats`                    | Memory usage stats                                                           |
-| `Message`                        | Chat message (user, assistant, system, tool)                                 |
-| `MessagePart`                    | Multi-part message segment                                                   |
-| `ModelTransportRequest`          | Request-aware model transport hook input                                     |
-| `ModelTransportResolver`         | Hook that resolves request-aware model runtime/transport behavior            |
-| `ModelProvider`                  | Model provider interface                                                     |
-| `ModelString`                    | Model configuration string format: "provider/model-name"                     |
-| `RemoteToolSource`               | Runtime-discovered remote tool source                                        |
-| `RedisClient`                    | Redis client interface (compatible with ioredis and node-redis)              |
-| `RedisMemoryConfig`              | Redis memory configuration                                                   |
-| `ResolvedModelTransport`         | Request-aware model runtime / headers / providerOptions resolution           |
-| `ResolvedRuntimeState`           | Step-boundary system/context refresh result                                  |
-| `RuntimeStateRequest`            | Step-boundary runtime refresh hook input                                     |
-| `RuntimeStateResolver`           | Hook that refreshes system/context state during long-lived runs              |
-| `StreamToolCall`                 | Streaming tool call                                                          |
-| `ToolCall`                       | Completed tool call                                                          |
-| `ToolCallPart`                   | Tool call message segment                                                    |
-| `ToolCallPartWithArgs`           | Tool call with parsed args                                                   |
-| `ToolCallPartWithInput`          | Tool call with raw input                                                     |
-| `ToolResultPart`                 | Tool execution result segment                                                |
-| `WorkflowConfig`                 | `createWorkflow` config                                                      |
-| `WorkflowResult`                 | Completed workflow result                                                    |
-| `WorkflowStep`                   | Workflow step definition                                                     |
+| Name                              | Description                                                                  |
+| --------------------------------- | ---------------------------------------------------------------------------- |
+| `AgUiDetachedStartAccepted`       | Accepted response shape for detached hosted AG-UI kickoff                    |
+| `AgUiDetachedStartHandlerOptions` | Options for `createAgUiDetachedStartHandler`                                 |
+| `AgUiDetachedStartRequest`        | Validated detached hosted AG-UI kickoff request                              |
+| `Agent`                           | `agent()` return type                                                        |
+| `AgentConfig`                     | Agent configuration                                                          |
+| `AgentContext`                    | Agent handler context                                                        |
+| `AgentMiddleware`                 | Agent execution middleware                                                   |
+| `AgentResponse`                   | Agent execution response                                                     |
+| `AgentStatus`                     | Agent status (idle, running, etc.)                                           |
+| `AgentStreamResult`               | Streaming result (`.toDataStreamResponse()`)                                 |
+| `AgUiContextItem`                 | AG-UI runtime context item                                                   |
+| `AgUiHandlerConfigWithAgent`      | Direct-agent form for `createAgUiHandler`                                    |
+| `AgUiHandlerOptions`              | Options for `createAgUiHandler`                                              |
+| `AgUiCancelHandlerOptions`        | Options for `createAgUiCancelHandler`                                        |
+| `AgUiInjectedTool`                | AG-UI client-injected tool descriptor                                        |
+| `AgUiRequest`                     | Validated AG-UI runtime request body                                         |
+| `AgUiResumeHandlerOptions`        | Options for `createAgUiResumeHandler`                                        |
+| `AgUiResumeSignal`                | Validated hosted-run resume payload                                          |
+| `HumanInputField`                 | Canonical form/input field definition                                        |
+| `HumanInputFieldInput`            | Input shape accepted by `waitForHumanInput()` before defaults normalize      |
+| `HumanInputOption`                | Canonical select/radio option definition                                     |
+| `HumanInputPendingRequest`        | Pending human-input envelope passed to `onRequest`                           |
+| `HumanInputRequest`               | Normalized human-input request payload                                       |
+| `HumanInputRequestInput`          | Input shape accepted by `HumanInputRequestSchema`                            |
+| `HumanInputResult`                | Validated human-input resumed result                                         |
+| `RunResumeSessionManagerOptions`  | Options for `RunResumeSessionManager`                                        |
+| `RunSessionStatus`                | Status of a resumable run session                                            |
+| `SubmitResumeValueOutcome`        | Result of submitting an accepted or duplicate resume value                   |
+| `WaitForHumanInputOptions`        | Options for `waitForHumanInput()`                                            |
+| `ChatHandlerBeforeStream`         | Hook signature for `createChatHandler` customization before streaming.       |
+| `ChatHandlerBeforeStreamContext`  | Input passed to `beforeStream` hook.                                         |
+| `ChatHandlerBeforeStreamResult`   | Message/context mutations returned from `beforeStream`.                      |
+| `ChatHandlerMessageInput`         | Message shape for `prepend`/`append`/`replaceMessages` in `beforeStream`.    |
+| `ChatHandlerOptions`              | Options for `createChatHandler` — customize context and pre-stream behavior. |
+| `EdgeConfig`                      | Agent-to-agent edge config                                                   |
+| `Memory`                          | Memory interface                                                             |
+| `MemoryConfig`                    | Memory creation config                                                       |
+| `MemoryPersistence`               | Memory storage backend                                                       |
+| `MemoryStats`                     | Memory usage stats                                                           |
+| `Message`                         | Chat message (user, assistant, system, tool)                                 |
+| `MessagePart`                     | Multi-part message segment                                                   |
+| `ModelTransportRequest`           | Request-aware model transport hook input                                     |
+| `ModelTransportResolver`          | Hook that resolves request-aware model runtime/transport behavior            |
+| `ModelProvider`                   | Model provider interface                                                     |
+| `ModelString`                     | Model configuration string format: "provider/model-name"                     |
+| `RemoteToolSource`                | Runtime-discovered remote tool source                                        |
+| `RedisClient`                     | Redis client interface (compatible with ioredis and node-redis)              |
+| `RedisMemoryConfig`               | Redis memory configuration                                                   |
+| `ResolvedModelTransport`          | Request-aware model runtime / headers / providerOptions resolution           |
+| `ResolvedRuntimeState`            | Step-boundary system/context refresh result                                  |
+| `RuntimeStateRequest`             | Step-boundary runtime refresh hook input                                     |
+| `RuntimeStateResolver`            | Hook that refreshes system/context state during long-lived runs              |
+| `StreamToolCall`                  | Streaming tool call                                                          |
+| `ToolCall`                        | Completed tool call                                                          |
+| `ToolCallPart`                    | Tool call message segment                                                    |
+| `ToolCallPartWithArgs`            | Tool call with parsed args                                                   |
+| `ToolCallPartWithInput`           | Tool call with raw input                                                     |
+| `ToolResultPart`                  | Tool execution result segment                                                |
+| `WorkflowConfig`                  | `createWorkflow` config                                                      |
+| `WorkflowResult`                  | Completed workflow result                                                    |
+| `WorkflowStep`                    | Workflow step definition                                                     |
 
 ## Related
 

--- a/src/agent/ag-ui-detached-start.test.ts
+++ b/src/agent/ag-ui-detached-start.test.ts
@@ -1,0 +1,440 @@
+import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  AgentRuntime,
+  AgUiDetachedStartRequestSchema,
+  createAgUiDetachedStartHandler,
+  RunResumeSessionManager,
+} from "./index.ts";
+import type { Agent, Message } from "./types.ts";
+
+const encoder = new TextEncoder();
+
+function encodeDataStreamEvent(payload: Record<string, unknown>): Uint8Array {
+  return encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+function createTestAgent(): Agent {
+  return {
+    id: "assistant-1",
+    config: {
+      id: "assistant-1",
+      system: "You are helpful.",
+      model: "anthropic/claude-sonnet-4-6",
+    } as Agent["config"],
+    generate: async () => {
+      throw new Error("not used");
+    },
+    stream: async () => {
+      throw new Error("not used");
+    },
+    respond: async () => new Response("not used"),
+    getMemory: () => {
+      throw new Error("not used");
+    },
+    getMemoryStats: async () => ({
+      totalMessages: 0,
+      estimatedTokens: 0,
+      type: "conversation",
+    }),
+    clearMemory: async () => {},
+  };
+}
+
+function createDetachedRequest(
+  overrides: Record<string, unknown> = {},
+): Request {
+  return new Request("http://localhost/api/ag-ui/runs", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      runId: "run_1",
+      threadId: crypto.randomUUID(),
+      messages: [{
+        id: "msg-1",
+        role: "user",
+        parts: [{ type: "text", text: "hello" }],
+      }],
+      ...overrides,
+    }),
+  });
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await Promise.resolve();
+}
+
+describe("agent/ag-ui-detached-start", () => {
+  it("requires explicit run and thread ids", () => {
+    const parsed = AgUiDetachedStartRequestSchema.parse({
+      runId: "run_1",
+      threadId: crypto.randomUUID(),
+      messages: [{
+        id: "msg-1",
+        role: "user",
+        parts: [{ type: "text", text: "hello" }],
+      }],
+    });
+
+    assertEquals(parsed.runId, "run_1");
+    assertExists(parsed.threadId);
+  });
+
+  it("starts a detached run and returns accepted duplicate false", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    const originalStream = AgentRuntime.prototype.stream;
+    let acceptedRunId: string | null = null;
+    let finishedRunId: string | null = null;
+
+    AgentRuntime.prototype.stream = async function (
+      messages: Message[],
+      context,
+    ): Promise<ReadableStream<Uint8Array>> {
+      assertEquals(messages[0]?.role, "user");
+      assertEquals(context?.runId, "run_1");
+
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            encodeDataStreamEvent({ type: "message-start", messageId: "assistant-1" }),
+          );
+          controller.enqueue(encodeDataStreamEvent({ type: "text-start", id: "text-1" }));
+          controller.enqueue(
+            encodeDataStreamEvent({ type: "text-delta", id: "text-1", delta: "hello" }),
+          );
+          controller.enqueue(encodeDataStreamEvent({ type: "text-end", id: "text-1" }));
+          controller.close();
+        },
+      });
+    };
+
+    try {
+      const request = createDetachedRequest();
+      const requestPayload = await request.clone().json() as { threadId: string };
+      const handler = createAgUiDetachedStartHandler({
+        agent: createTestAgent(),
+        sessionManager,
+        onAccepted: ({ runId }) => {
+          acceptedRunId = runId;
+        },
+        onFinish: ({ runId }) => {
+          finishedRunId = runId;
+        },
+      });
+
+      const response = await handler(request);
+
+      assertEquals(response.status, 202);
+      assertEquals(await response.json(), {
+        accepted: true,
+        duplicate: false,
+        runId: "run_1",
+        threadId: requestPayload.threadId,
+      });
+    } finally {
+      AgentRuntime.prototype.stream = originalStream;
+    }
+
+    assertEquals(acceptedRunId, "run_1");
+    await flushAsyncWork();
+    assertEquals(finishedRunId, "run_1");
+    assertEquals(sessionManager.getRunStatus("run_1"), null);
+  });
+
+  it("returns accepted duplicate true for an already active run", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    const threadId = crypto.randomUUID();
+    sessionManager.startRun({ runId: "run_1", threadId });
+    let duplicateRunId: string | null = null;
+
+    const handler = createAgUiDetachedStartHandler({
+      agent: createTestAgent(),
+      sessionManager,
+      onDuplicate: ({ runId }) => {
+        duplicateRunId = runId;
+      },
+    });
+
+    const response = await handler(createDetachedRequest({ threadId }));
+
+    assertEquals(response.status, 202);
+    assertEquals(await response.json(), {
+      accepted: true,
+      duplicate: true,
+      runId: "run_1",
+      threadId,
+    });
+    assertEquals(duplicateRunId, "run_1");
+    sessionManager.cancelRun("run_1");
+  });
+
+  it("returns 400 for malformed detached start payloads", async () => {
+    const handler = createAgUiDetachedStartHandler({
+      agent: createTestAgent(),
+      sessionManager: new RunResumeSessionManager<{ result: unknown; isError: boolean }>(),
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ag-ui/runs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [],
+        }),
+      }),
+    );
+
+    assertEquals(response.status, 400);
+    const payload = await response.json();
+    assertExists(payload);
+    assertEquals(payload.error, "Invalid AG-UI detached start request");
+  });
+
+  it("supports injected client tools in detached runs", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    const originalStream = AgentRuntime.prototype.stream;
+    let finishedRunId: string | null = null;
+
+    AgentRuntime.prototype.stream = async function (
+      _messages,
+      context,
+    ): Promise<ReadableStream<Uint8Array>> {
+      const runtimeConfig = this as unknown as {
+        config: {
+          tools?: Record<string, {
+            execute: (
+              input: Record<string, unknown>,
+              context?: { toolCallId?: string },
+            ) => Promise<unknown>;
+          }>;
+        };
+      };
+
+      const injectedTool = runtimeConfig.config.tools?.client_confirm;
+      if (!injectedTool) {
+        throw new Error("Expected injected tool to be merged into the runtime config");
+      }
+
+      assertEquals(context?.runId, "run_1");
+
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          void (async () => {
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "tool-input-start",
+                toolCallId: "tool-call-1",
+                toolName: "client_confirm",
+              }),
+            );
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "tool-input-delta",
+                toolCallId: "tool-call-1",
+                inputTextDelta: '{"approved":true}',
+              }),
+            );
+
+            const result = await injectedTool.execute(
+              { approved: true },
+              { toolCallId: "tool-call-1" },
+            );
+
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "tool-output-available",
+                toolCallId: "tool-call-1",
+                output: result,
+              }),
+            );
+            controller.close();
+          })();
+        },
+      });
+    };
+
+    try {
+      const handler = createAgUiDetachedStartHandler({
+        agent: createTestAgent(),
+        sessionManager,
+        onFinish: ({ runId }) => {
+          finishedRunId = runId;
+        },
+      });
+
+      const threadId = crypto.randomUUID();
+      const response = await handler(createDetachedRequest({
+        threadId,
+        tools: [{ name: "client_confirm" }],
+      }));
+
+      assertEquals(response.status, 202);
+      assertEquals(await response.json(), {
+        accepted: true,
+        duplicate: false,
+        runId: "run_1",
+        threadId,
+      });
+
+      const submitOutcome = sessionManager.submitSignal("run_1", {
+        waitKey: "tool-call-1",
+        value: { result: { approved: true }, isError: false },
+      });
+      assertEquals(submitOutcome, { accepted: true });
+    } finally {
+      AgentRuntime.prototype.stream = originalStream;
+    }
+
+    await flushAsyncWork();
+    assertEquals(finishedRunId, "run_1");
+  });
+
+  it("preserves tool-* call variants during detached request normalization", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    const originalStream = AgentRuntime.prototype.stream;
+
+    AgentRuntime.prototype.stream = async function (
+      messages: Message[],
+    ): Promise<ReadableStream<Uint8Array>> {
+      assertEquals(messages[0]?.parts[0], {
+        type: "tool-input-available",
+        toolCallId: "tool-call-1",
+        toolName: "client_confirm",
+        args: { approved: true },
+      });
+
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close();
+        },
+      });
+    };
+
+    try {
+      const handler = createAgUiDetachedStartHandler({
+        agent: createTestAgent(),
+        sessionManager,
+      });
+
+      const response = await handler(createDetachedRequest({
+        messages: [{
+          id: "assistant-1",
+          role: "assistant",
+          parts: [{
+            type: "tool-input-available",
+            toolCallId: "tool-call-1",
+            toolName: "client_confirm",
+            input: { approved: true },
+          }],
+        }],
+      }));
+
+      assertEquals(response.status, 202);
+      const payload = await response.json();
+      assertEquals(payload.accepted, true);
+      assertEquals(payload.duplicate, false);
+    } finally {
+      AgentRuntime.prototype.stream = originalStream;
+    }
+  });
+
+  it("drops oversize detached text parts the same way as the direct AG-UI handler", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    const originalStream = AgentRuntime.prototype.stream;
+
+    AgentRuntime.prototype.stream = async function (
+      messages: Message[],
+    ): Promise<ReadableStream<Uint8Array>> {
+      assertEquals(messages[0]?.parts.length, 0);
+
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close();
+        },
+      });
+    };
+
+    try {
+      const handler = createAgUiDetachedStartHandler({
+        agent: createTestAgent(),
+        sessionManager,
+      });
+
+      const response = await handler(createDetachedRequest({
+        messages: [{
+          id: "msg-1",
+          role: "user",
+          parts: [{ type: "text", text: "x".repeat(10_001) }],
+        }],
+      }));
+
+      assertEquals(response.status, 202);
+      const payload = await response.json();
+      assertEquals(payload.accepted, true);
+      assertEquals(payload.duplicate, false);
+    } finally {
+      AgentRuntime.prototype.stream = originalStream;
+    }
+  });
+
+  it("calls onError when background execution fails after acceptance", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    const originalStream = AgentRuntime.prototype.stream;
+    let acceptedRunId: string | null = null;
+    let capturedError: string | null = null;
+
+    AgentRuntime.prototype.stream = async function (): Promise<ReadableStream<Uint8Array>> {
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.error(new Error("background boom"));
+        },
+      });
+    };
+
+    try {
+      const handler = createAgUiDetachedStartHandler({
+        agent: createTestAgent(),
+        sessionManager,
+        onAccepted: ({ runId }) => {
+          acceptedRunId = runId;
+        },
+        onError: ({ error }) => {
+          capturedError = error instanceof Error ? error.message : String(error);
+        },
+      });
+
+      const response = await handler(createDetachedRequest());
+
+      assertEquals(response.status, 202);
+      const payload = await response.json();
+      assertEquals(payload.accepted, true);
+      assertEquals(payload.duplicate, false);
+    } finally {
+      AgentRuntime.prototype.stream = originalStream;
+    }
+
+    assertEquals(acceptedRunId, "run_1");
+    await flushAsyncWork();
+    assertStringIncludes(String(capturedError), "background boom");
+    assertEquals(sessionManager.getRunStatus("run_1"), null);
+  });
+});

--- a/src/agent/ag-ui-detached-start.ts
+++ b/src/agent/ag-ui-detached-start.ts
@@ -1,0 +1,397 @@
+import { z } from "zod";
+import { INVALID_ARGUMENT } from "#veryfront/errors";
+import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
+import { type Tool, toolRegistry } from "#veryfront/tool";
+import { streamDataStreamEvents } from "./data-stream.ts";
+import { type AgUiInjectedTool, type AgUiRequest, AgUiRequestSchema } from "./ag-ui-handler.ts";
+import {
+  AgentRuntime,
+  RunAlreadyExistsError,
+  type RunResumeSessionManager,
+} from "./runtime/index.ts";
+import type { Agent, Message } from "./types.ts";
+
+const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const AG_UI_DETACHED_RUN_ID_SCHEMA = z.string().min(1).max(128).regex(AGENT_ID_PATTERN);
+const MAX_TEXT_PART_LENGTH = 10_000;
+
+type AgUiResumeValue = {
+  result: unknown;
+  isError: boolean;
+};
+
+type AgUiContextValue =
+  | Record<string, unknown>
+  | ((request: Request) => Record<string, unknown> | Promise<Record<string, unknown>>);
+
+type AgUiRuntimePart = Record<string, unknown> & { type: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeToolArgs(part: Record<string, unknown>): Record<string, unknown> {
+  if (isRecord(part.args)) return part.args;
+  if (isRecord(part.input)) return part.input;
+  return {};
+}
+
+function normalizeMessagePart(part: Record<string, unknown>): Message["parts"][number] | null {
+  if (
+    part.type === "text" && typeof part.text === "string" &&
+    part.text.length <= MAX_TEXT_PART_LENGTH
+  ) {
+    return { type: "text", text: part.text };
+  }
+
+  if (part.type === "tool_call" && typeof part.id === "string" && typeof part.name === "string") {
+    return {
+      type: "tool-call",
+      toolCallId: part.id,
+      toolName: part.name,
+      args: normalizeToolArgs(part),
+    };
+  }
+
+  if (
+    part.type === "tool-call" &&
+    typeof part.toolCallId === "string" &&
+    typeof part.toolName === "string"
+  ) {
+    return {
+      type: "tool-call",
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      args: normalizeToolArgs(part),
+    };
+  }
+
+  if (
+    typeof part.type === "string" &&
+    part.type.startsWith("tool-") &&
+    part.type !== "tool-result" &&
+    typeof part.toolCallId === "string" &&
+    typeof part.toolName === "string"
+  ) {
+    return {
+      type: part.type,
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      args: normalizeToolArgs(part),
+    };
+  }
+
+  if (part.type === "tool_result" && typeof part.tool_call_id === "string") {
+    return {
+      type: "tool-result",
+      toolCallId: part.tool_call_id,
+      toolName: typeof part.tool_name === "string" ? part.tool_name : "unknown",
+      result: "output" in part ? part.output : undefined,
+    };
+  }
+
+  if (part.type === "tool-result" && typeof part.toolCallId === "string") {
+    return {
+      type: "tool-result",
+      toolCallId: part.toolCallId,
+      toolName: typeof part.toolName === "string" ? part.toolName : "unknown",
+      result: "result" in part ? part.result : undefined,
+    };
+  }
+
+  return null;
+}
+
+function normalizeMessages(messages: AgUiRequest["messages"]): Message[] {
+  return messages.map((message) => ({
+    id: message.id,
+    role: message.role,
+    parts: message.parts
+      .map((part) => normalizeMessagePart(part))
+      .filter((part): part is Message["parts"][number] => part !== null),
+    ...(message.createdAt ? { timestamp: Date.parse(message.createdAt) || undefined } : {}),
+    ...(message.metadata ? { metadata: message.metadata } : {}),
+  }));
+}
+
+function isRequest(obj: unknown): obj is Request {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "json" in obj &&
+    typeof obj.json === "function" &&
+    "url" in obj &&
+    typeof obj.url === "string" &&
+    "method" in obj &&
+    typeof obj.method === "string"
+  );
+}
+
+function extractRequest(requestOrCtx: unknown): Request {
+  if (isRequest(requestOrCtx)) return requestOrCtx;
+
+  if (typeof requestOrCtx === "object" && requestOrCtx !== null && "request" in requestOrCtx) {
+    const candidate = (requestOrCtx as Record<string, unknown>).request;
+    if (isRequest(candidate)) return candidate;
+  }
+
+  throw INVALID_ARGUMENT.create({
+    detail: "Invalid handler argument: expected Request or APIContext",
+  });
+}
+
+function buildStreamContext(
+  request: AgUiDetachedStartRequest,
+  baseContext: Record<string, unknown>,
+  threadId: string,
+  runId: string,
+): Record<string, unknown> {
+  return {
+    ...baseContext,
+    threadId,
+    runId,
+    agUi: {
+      context: request.context,
+      forwardedProps: request.forwardedProps,
+    },
+  };
+}
+
+function createInjectedAgUiTool(
+  runId: string,
+  tool: AgUiInjectedTool,
+  sessionManager: RunResumeSessionManager<AgUiResumeValue>,
+): Tool {
+  return {
+    id: tool.name,
+    type: "function",
+    description: tool.description ?? tool.name,
+    inputSchema: z.record(z.string(), z.unknown()),
+    inputSchemaJson: (tool.parameters ??
+      { type: "object", properties: {}, additionalProperties: true }) as Tool["inputSchemaJson"],
+    execute: async (_input, context) => {
+      const toolCallId = typeof context?.toolCallId === "string" ? context.toolCallId : null;
+      if (!toolCallId) {
+        throw new Error(`Missing toolCallId for injected tool "${tool.name}"`);
+      }
+
+      sessionManager.prepareForSignal(runId, toolCallId);
+      const submitted = await sessionManager.waitForSignal(runId, toolCallId);
+      if (submitted.isError) {
+        throw new Error(
+          typeof submitted.result === "string"
+            ? submitted.result
+            : JSON.stringify(submitted.result),
+        );
+      }
+      return submitted.result;
+    },
+  };
+}
+
+function buildMergedTools(
+  agent: Agent,
+  request: AgUiDetachedStartRequest,
+  sessionManager: RunResumeSessionManager<AgUiResumeValue>,
+): Agent["config"]["tools"] {
+  const injectedTools = Object.fromEntries(
+    request.tools.map((tool) => [
+      tool.name,
+      createInjectedAgUiTool(request.runId, tool, sessionManager),
+    ]),
+  );
+
+  if (!agent.config.tools) {
+    return Object.keys(injectedTools).length > 0 ? injectedTools : undefined;
+  }
+
+  if (agent.config.tools === true) {
+    const merged: Record<string, Tool | boolean> = {};
+    for (const [toolId] of toolRegistry.getAll()) {
+      if (!agent.config.skills && SKILL_TOOL_IDS.has(toolId)) {
+        continue;
+      }
+      merged[toolId] = true;
+    }
+    return { ...merged, ...injectedTools };
+  }
+
+  return { ...agent.config.tools, ...injectedTools };
+}
+
+async function resolveContextValue(
+  value: AgUiContextValue | undefined,
+  request: Request,
+): Promise<Record<string, unknown>> {
+  if (typeof value === "function") {
+    return await value(request);
+  }
+
+  return value ?? {};
+}
+
+function scheduleDetachedTask(requestOrCtx: unknown, task: Promise<void>): void {
+  if (
+    typeof requestOrCtx === "object" &&
+    requestOrCtx !== null &&
+    "waitUntil" in requestOrCtx &&
+    typeof (requestOrCtx as Record<string, unknown>).waitUntil === "function"
+  ) {
+    ((requestOrCtx as { waitUntil: (promise: Promise<void>) => void }).waitUntil)(task);
+    return;
+  }
+
+  void task;
+}
+
+async function drainRuntimeStream(
+  stream: ReadableStream<Uint8Array>,
+): Promise<void> {
+  for await (const _event of streamDataStreamEvents(stream) as AsyncIterable<AgUiRuntimePart>) {
+    continue;
+  }
+}
+
+export const AgUiDetachedStartRequestSchema = AgUiRequestSchema.extend({
+  threadId: z.string().uuid(),
+  runId: AG_UI_DETACHED_RUN_ID_SCHEMA,
+});
+
+export const AgUiDetachedStartAcceptedSchema = z.object({
+  accepted: z.literal(true),
+  duplicate: z.boolean(),
+  runId: AG_UI_DETACHED_RUN_ID_SCHEMA,
+  threadId: z.string().uuid(),
+});
+
+export type AgUiDetachedStartRequest = z.infer<typeof AgUiDetachedStartRequestSchema>;
+export type AgUiDetachedStartAccepted = z.infer<typeof AgUiDetachedStartAcceptedSchema>;
+
+export interface AgUiDetachedStartHandlerOptions {
+  agent: Agent;
+  sessionManager: RunResumeSessionManager<AgUiResumeValue>;
+  context?: AgUiContextValue;
+  onAccepted?: (input: {
+    request: AgUiDetachedStartRequest;
+    runId: string;
+    threadId: string;
+  }) => Promise<void> | void;
+  onDuplicate?: (input: {
+    request: AgUiDetachedStartRequest;
+    runId: string;
+    threadId: string;
+  }) => Promise<void> | void;
+  onFinish?: (input: { runId: string; threadId: string }) => Promise<void> | void;
+  onError?: (input: { runId: string; threadId: string; error: unknown }) => Promise<void> | void;
+}
+
+export function createAgUiDetachedStartHandler(
+  options: AgUiDetachedStartHandlerOptions,
+): (requestOrCtx: unknown) => Promise<Response> {
+  return async function POST(requestOrCtx: unknown): Promise<Response> {
+    const request = extractRequest(requestOrCtx);
+
+    try {
+      const parsed = AgUiDetachedStartRequestSchema.parse(await request.json());
+      const context = await resolveContextValue(options.context, request);
+
+      try {
+        const abortSignal = options.sessionManager.startRun({
+          runId: parsed.runId,
+          threadId: parsed.threadId,
+        });
+
+        const runtime = new AgentRuntime(options.agent.id, {
+          ...options.agent.config,
+          tools: buildMergedTools(options.agent, parsed, options.sessionManager),
+        });
+
+        const runtimeStream = await runtime.stream(
+          normalizeMessages(parsed.messages),
+          buildStreamContext(parsed, context, parsed.threadId, parsed.runId),
+          undefined,
+          parsed.model,
+          parsed.maxOutputTokens,
+          abortSignal,
+        );
+
+        await options.onAccepted?.({
+          request: parsed,
+          runId: parsed.runId,
+          threadId: parsed.threadId,
+        });
+
+        const detachedTask = (async () => {
+          try {
+            await drainRuntimeStream(runtimeStream);
+            options.sessionManager.completeRun(parsed.runId);
+            await options.onFinish?.({
+              runId: parsed.runId,
+              threadId: parsed.threadId,
+            });
+          } catch (error) {
+            options.sessionManager.failRun(parsed.runId);
+            await options.onError?.({
+              runId: parsed.runId,
+              threadId: parsed.threadId,
+              error,
+            });
+          }
+        })().catch(() => undefined);
+
+        scheduleDetachedTask(requestOrCtx, detachedTask);
+
+        return Response.json(
+          {
+            accepted: true,
+            duplicate: false,
+            runId: parsed.runId,
+            threadId: parsed.threadId,
+          } satisfies AgUiDetachedStartAccepted,
+          { status: 202 },
+        );
+      } catch (error) {
+        if (error instanceof RunAlreadyExistsError) {
+          await options.onDuplicate?.({
+            request: parsed,
+            runId: parsed.runId,
+            threadId: parsed.threadId,
+          });
+
+          return Response.json(
+            {
+              accepted: true,
+              duplicate: true,
+              runId: parsed.runId,
+              threadId: parsed.threadId,
+            } satisfies AgUiDetachedStartAccepted,
+            { status: 202 },
+          );
+        }
+
+        options.sessionManager.failRun(parsed.runId);
+        throw error;
+      }
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return Response.json(
+          {
+            error: "Invalid AG-UI detached start request",
+            details: error.issues.map((issue) => ({
+              path: issue.path,
+              message: issue.message,
+            })),
+          },
+          { status: 400 },
+        );
+      }
+
+      return Response.json(
+        {
+          error: error instanceof Error ? error.message : "Internal detached start failed",
+        },
+        { status: 500 },
+      );
+    }
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -172,6 +172,14 @@ export {
   type ProviderNativeToolInventoryOptions,
 } from "./provider-native-tool-inventory.ts";
 export {
+  type AgUiDetachedStartAccepted,
+  AgUiDetachedStartAcceptedSchema,
+  type AgUiDetachedStartHandlerOptions,
+  type AgUiDetachedStartRequest,
+  AgUiDetachedStartRequestSchema,
+  createAgUiDetachedStartHandler,
+} from "./ag-ui-detached-start.ts";
+export {
   type AgUiCancelHandlerOptions,
   type AgUiResumeHandlerOptions,
   type AgUiResumeSignal,

--- a/src/server/runtime-handler/request-tracker.test.ts
+++ b/src/server/runtime-handler/request-tracker.test.ts
@@ -115,6 +115,11 @@ describe("server/runtime-handler/request-tracker", () => {
       requestTracker.complete("req-mod", 200);
     });
 
+    it("should treat lightweight stylesheet requests as internal assets", () => {
+      requestTracker.start("req-style", "proj", "/_vf_styles/styles.css", "GET");
+      requestTracker.complete("req-style", 200);
+    });
+
     it("should handle _veryfront module path completion without error", () => {
       requestTracker.start("req-vf", "proj", "/_veryfront/bar.js", "GET");
       requestTracker.complete("req-vf", 200);

--- a/src/server/runtime-handler/request-tracker.ts
+++ b/src/server/runtime-handler/request-tracker.ts
@@ -7,7 +7,7 @@
 
 import { serverLogger } from "#veryfront/utils";
 import { unrefTimer } from "#veryfront/compat/process.ts";
-import { isWebSocketPath } from "./request-utils.ts";
+import { isLightweightPath, isWebSocketPath } from "./request-utils.ts";
 
 const logger = serverLogger.component("request-tracker");
 
@@ -98,8 +98,9 @@ class RequestTracker {
       releaseId,
     };
 
-    // WebSocket connections are long-lived by design — don't flag them as stuck.
-    if (!isWebSocketPath(path)) {
+    // WebSocket connections are long-lived by design and lightweight internal
+    // asset/module requests can be noisy under CI jitter — don't flag them as stuck.
+    if (!isWebSocketPath(path) && !isLightweightPath(path)) {
       tracked.slowTimer = setTimeout(() => {
         const elapsedMs = Math.round(performance.now() - startTime);
         logger.warn("Slow request detected", {
@@ -152,10 +153,7 @@ class RequestTracker {
     if (timedOut) this.totalTimedOut++;
     else this.totalCompleted++;
 
-    const isModuleRequest = tracked.path.startsWith("/_vf_modules/") ||
-      tracked.path.startsWith("/_veryfront/");
-
-    if (isModuleRequest) {
+    if (isLightweightPath(tracked.path)) {
       if (durationMs > MODULE_REQUEST_LOG_THRESHOLD_MS) {
         logger.debug(`${tracked.method} ${tracked.path} ${statusCode} ${durationMs}ms`);
       }

--- a/src/server/runtime-handler/request-utils.test.ts
+++ b/src/server/runtime-handler/request-utils.test.ts
@@ -31,6 +31,7 @@ describe("request-utils", () => {
 
     it("LIGHTWEIGHT_PATH_PREFIXES includes module paths", () => {
       assertEquals(LIGHTWEIGHT_PATH_PREFIXES.includes("/_vf_modules/"), true);
+      assertEquals(LIGHTWEIGHT_PATH_PREFIXES.includes("/_vf_styles/"), true);
       assertEquals(LIGHTWEIGHT_PATH_PREFIXES.includes("/_veryfront/modules/"), true);
       assertEquals(LIGHTWEIGHT_PATH_PREFIXES.includes("/_veryfront/hydration-runtime.js"), true);
     });
@@ -104,6 +105,7 @@ describe("request-utils", () => {
 
     it("returns true for CSS paths", () => {
       assertEquals(isLightweightPath("/_vf/css/styles.css"), true);
+      assertEquals(isLightweightPath("/_vf_styles/styles.css"), true);
     });
 
     it("returns true for lib module paths", () => {

--- a/src/server/runtime-handler/request-utils.ts
+++ b/src/server/runtime-handler/request-utils.ts
@@ -58,6 +58,7 @@ export function isMonitoringPath(pathname: string): boolean {
 /** Lightweight paths that should skip concurrency limiting (modules, static assets) */
 export const LIGHTWEIGHT_PATH_PREFIXES = [
   "/_vf_modules/",
+  "/_vf_styles/",
   "/_veryfront/modules/",
   "/_veryfront/hydration-runtime.js",
   "/_veryfront/preview-hmr.js",

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.218";
+export const VERSION = "0.1.219";


### PR DESCRIPTION
## Summary
- add a public detached AG-UI run start handler under the existing hosted AG-UI family
- export the new detached start request/response types from `veryfront/agent`
- document `POST /api/ag-ui/runs` alongside the existing AG-UI stream/resume/cancel surfaces
- bump the package version to `0.1.219`

## Verification
- `deno test --no-check --allow-all src/agent/ag-ui-detached-start.test.ts src/agent/ag-ui-run-control.test.ts`
- `deno check src/agent/index.ts`
- repo pre-push checks passed during branch push