### PR TITLE
Add a host execution hook to detached AG-UI run start

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.219",
+  "version": "0.1.220",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent-runtime-ag-ui.md
+++ b/docs/reference/agent-runtime-ag-ui.md
@@ -109,6 +109,11 @@ export const POST = createAgUiDetachedStartHandler({
 });
 ```
 
+Hosts that need to keep their own detached execution pipeline can pass
+`startDetachedExecution` instead of `agent`. The package still owns request
+validation, duplicate detection, session-manager lifecycle, and the accepted
+response shape.
+
 ```ts
 import {
   createAgUiCancelHandler,

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -508,6 +508,13 @@ Response shape:
 - `202 { accepted: true, duplicate: false, runId, threadId }`
 - `202 { accepted: true, duplicate: true, runId, threadId }`
 
+Options may provide either:
+
+- `agent` to use the package runtime directly
+- `startDetachedExecution` to let the host run its own detached execution path
+  while the package still owns request validation, duplicate detection, and
+  session-manager lifecycle
+
 ### `createAgUiResumeHandler(options)`
 
 Create a generic POST handler for hosted resumable AG-UI runs.

--- a/src/agent/ag-ui-detached-start.test.ts
+++ b/src/agent/ag-ui-detached-start.test.ts
@@ -437,4 +437,67 @@ describe("agent/ag-ui-detached-start", () => {
     assertStringIncludes(String(capturedError), "background boom");
     assertEquals(sessionManager.getRunStatus("run_1"), null);
   });
+
+  it("supports a host-provided detached execution starter without a package agent", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    let acceptedRunId: string | null = null;
+    let finishedRunId: string | null = null;
+    let capturedAbortSignal: AbortSignal | null = null;
+    let capturedText: string | null = null;
+
+    const handler = createAgUiDetachedStartHandler({
+      sessionManager,
+      startDetachedExecution: async ({ request, abortSignal }) => {
+        capturedAbortSignal = abortSignal;
+        capturedText = typeof request.messages[0]?.parts[0] === "object" &&
+            request.messages[0]?.parts[0] !== null &&
+            "text" in request.messages[0].parts[0]
+          ? String(request.messages[0].parts[0].text)
+          : null;
+      },
+      onAccepted: ({ runId }) => {
+        acceptedRunId = runId;
+      },
+      onFinish: ({ runId }) => {
+        finishedRunId = runId;
+      },
+    });
+
+    const response = await handler(createDetachedRequest());
+
+    assertEquals(response.status, 202);
+    const payload = await response.json();
+    assertEquals(payload.accepted, true);
+    assertEquals(payload.duplicate, false);
+    assertEquals(acceptedRunId, "run_1");
+    await flushAsyncWork();
+    assertEquals(finishedRunId, "run_1");
+    assertEquals(capturedAbortSignal instanceof AbortSignal, true);
+    assertEquals(capturedText, "hello");
+    assertEquals(sessionManager.getRunStatus("run_1"), null);
+  });
+
+  it("fails fast when neither an agent nor a detached execution starter is configured", () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+
+    let thrown: unknown = null;
+    try {
+      createAgUiDetachedStartHandler({
+        sessionManager,
+      } as never);
+    } catch (error) {
+      thrown = error;
+    }
+
+    assertStringIncludes(
+      thrown instanceof Error ? thrown.message : String(thrown),
+      "Detached AG-UI start requires either an agent or startDetachedExecution handler.",
+    );
+  });
 });

--- a/src/agent/ag-ui-detached-start.ts
+++ b/src/agent/ag-ui-detached-start.ts
@@ -267,10 +267,22 @@ export const AgUiDetachedStartAcceptedSchema = z.object({
 export type AgUiDetachedStartRequest = z.infer<typeof AgUiDetachedStartRequestSchema>;
 export type AgUiDetachedStartAccepted = z.infer<typeof AgUiDetachedStartAcceptedSchema>;
 
-export interface AgUiDetachedStartHandlerOptions {
-  agent: Agent;
+interface AgUiDetachedStartExecutionInput {
+  request: AgUiDetachedStartRequest;
+  requestOrCtx: unknown;
+  rawRequest: Request;
+  context: Record<string, unknown>;
+  abortSignal: AbortSignal;
+}
+
+type AgUiDetachedExecutionStarter = (
+  input: AgUiDetachedStartExecutionInput,
+) => Promise<void> | void;
+
+interface AgUiDetachedStartHandlerOptionsBase {
   sessionManager: RunResumeSessionManager<AgUiResumeValue>;
   context?: AgUiContextValue;
+  startDetachedExecution?: AgUiDetachedExecutionStarter;
   onAccepted?: (input: {
     request: AgUiDetachedStartRequest;
     runId: string;
@@ -285,9 +297,46 @@ export interface AgUiDetachedStartHandlerOptions {
   onError?: (input: { runId: string; threadId: string; error: unknown }) => Promise<void> | void;
 }
 
+export type AgUiDetachedStartHandlerOptions =
+  | (AgUiDetachedStartHandlerOptionsBase & { agent: Agent })
+  | (AgUiDetachedStartHandlerOptionsBase & {
+    agent?: undefined;
+    startDetachedExecution: AgUiDetachedExecutionStarter;
+  });
+
+async function startDefaultDetachedExecution(input: {
+  agent: Agent;
+  request: AgUiDetachedStartRequest;
+  context: Record<string, unknown>;
+  abortSignal: AbortSignal;
+  sessionManager: RunResumeSessionManager<AgUiResumeValue>;
+}): Promise<void> {
+  const runtime = new AgentRuntime(input.agent.id, {
+    ...input.agent.config,
+    tools: buildMergedTools(input.agent, input.request, input.sessionManager),
+  });
+
+  const runtimeStream = await runtime.stream(
+    normalizeMessages(input.request.messages),
+    buildStreamContext(input.request, input.context, input.request.threadId, input.request.runId),
+    undefined,
+    input.request.model,
+    input.request.maxOutputTokens,
+    input.abortSignal,
+  );
+
+  await drainRuntimeStream(runtimeStream);
+}
+
 export function createAgUiDetachedStartHandler(
   options: AgUiDetachedStartHandlerOptions,
 ): (requestOrCtx: unknown) => Promise<Response> {
+  if (!options.agent && !options.startDetachedExecution) {
+    throw new Error(
+      "Detached AG-UI start requires either an agent or startDetachedExecution handler.",
+    );
+  }
+
   return async function POST(requestOrCtx: unknown): Promise<Response> {
     const request = extractRequest(requestOrCtx);
 
@@ -301,20 +350,6 @@ export function createAgUiDetachedStartHandler(
           threadId: parsed.threadId,
         });
 
-        const runtime = new AgentRuntime(options.agent.id, {
-          ...options.agent.config,
-          tools: buildMergedTools(options.agent, parsed, options.sessionManager),
-        });
-
-        const runtimeStream = await runtime.stream(
-          normalizeMessages(parsed.messages),
-          buildStreamContext(parsed, context, parsed.threadId, parsed.runId),
-          undefined,
-          parsed.model,
-          parsed.maxOutputTokens,
-          abortSignal,
-        );
-
         await options.onAccepted?.({
           request: parsed,
           runId: parsed.runId,
@@ -323,7 +358,28 @@ export function createAgUiDetachedStartHandler(
 
         const detachedTask = (async () => {
           try {
-            await drainRuntimeStream(runtimeStream);
+            if (options.startDetachedExecution) {
+              await options.startDetachedExecution({
+                request: parsed,
+                requestOrCtx,
+                rawRequest: request,
+                context,
+                abortSignal,
+              });
+            } else if (options.agent) {
+              await startDefaultDetachedExecution({
+                agent: options.agent,
+                request: parsed,
+                context,
+                abortSignal,
+                sessionManager: options.sessionManager,
+              });
+            } else {
+              throw new Error(
+                "Detached AG-UI start configuration became invalid during execution.",
+              );
+            }
+
             options.sessionManager.completeRun(parsed.runId);
             await options.onFinish?.({
               runId: parsed.runId,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.219";
+export const VERSION = "0.1.220";


### PR DESCRIPTION
## Summary
- add a host-provided detached execution hook to `createAgUiDetachedStartHandler()`
- keep package-owned request validation, duplicate handling, and session-manager lifecycle intact
- document the host hook and bump the package version to `0.1.220`

## Verification
- `deno test --no-check --allow-all src/agent/ag-ui-detached-start.test.ts src/agent/ag-ui-run-control.test.ts`
- `deno check src/agent/index.ts`
- repo pre-push checks passed during branch push