### PR TITLE
Expose reusable AG-UI host parsing helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.220",
+  "version": "0.1.221",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent-runtime-ag-ui.md
+++ b/docs/reference/agent-runtime-ag-ui.md
@@ -58,8 +58,54 @@ For resumable hosted runs, the package also exposes:
 - `createAgUiDetachedStartHandler()`
 - `createAgUiResumeHandler()`
 - `createAgUiCancelHandler()`
+- `parseAgUiRequest()`
+- `parseAgUiRequestOrError()`
+- `normalizeAgUiMessages()`
+- `createAgUiRunErrorEvent()`
+- `createAgUiSseErrorResponse()`
 - `AgUiResumeSignalSchema`
 - `waitForHumanInput()`
+
+## Host Parse / Normalize Helpers
+
+Hosts that keep auth, project-access, or runtime preparation local can still
+reuse the package AG-UI request plumbing directly:
+
+```ts
+import {
+  createAgUiRunErrorEvent,
+  createAgUiSseErrorResponse,
+  normalizeAgUiMessages,
+  parseAgUiRequestOrError,
+} from "veryfront/agent";
+
+export async function POST(request: Request) {
+  const parsed = await parseAgUiRequestOrError(request);
+  if (parsed instanceof Response) {
+    return parsed;
+  }
+
+  const normalizedMessages = normalizeAgUiMessages(parsed.messages);
+
+  try {
+    // host-local auth/project/runtime preparation here
+    return new Response(JSON.stringify({ ok: true, count: normalizedMessages.length }));
+  } catch (error) {
+    return createAgUiSseErrorResponse(
+      createAgUiRunErrorEvent(
+        error instanceof Error ? error.message : "Agent setup failed",
+        "SETUP_ERROR",
+      ),
+      500,
+    );
+  }
+}
+```
+
+This helper layer is intentionally narrower than `createAgUiHandler()`:
+
+- the package owns AG-UI request validation/normalization
+- the host still owns auth, project access, and runtime preparation
 
 ## Convenience Request Shape
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -26,11 +26,16 @@ import {
   createAgUiDetachedStartHandler,
   createAgUiHandler,
   createAgUiResumeHandler,
+  createAgUiRunErrorEvent,
+  createAgUiSseErrorResponse,
   createMemory,
   expandAllowedRemoteToolNames,
   getAgentsAsTools,
   getProviderNativeToolNames,
   HumanInputRequestSchema,
+  normalizeAgUiMessages,
+  parseAgUiRequest,
+  parseAgUiRequestOrError,
   registerAgent,
   RunResumeSessionManager,
   waitForHumanInput,
@@ -478,6 +483,30 @@ This schema accepts the higher-level host request format based on message
 `parts`. `createAgUiHandler()` normalizes it into the canonical
 `AgUiRuntimeRequestSchema` before invoking the runtime.
 
+### `parseAgUiRequest(request)`
+
+Parse and validate the convenience AG-UI wrapper request body into
+`AgUiRequestSchema`.
+
+### `parseAgUiRequestOrError(request)`
+
+Parse the convenience AG-UI wrapper request body and return either the parsed
+request or a `400` JSON `Response` when validation fails.
+
+### `normalizeAgUiMessages(messages)`
+
+Normalize convenience AG-UI `messages` into the runtime `Message[]` shape used
+by the agent runtime.
+
+### `createAgUiRunErrorEvent(message, code?)`
+
+Create a `RunError` AG-UI SSE event payload.
+
+### `createAgUiSseErrorResponse(event, status)`
+
+Create an AG-UI SSE `Response` from a prepared AG-UI event, preserving the
+existing `RunError` wire shape used by hosted routes.
+
 ### `AgUiRuntimeRequestSchema`
 
 Validate the canonical open-source AG-UI runtime request contract for hosted
@@ -586,6 +615,8 @@ Clear all stored messages from memory.
 | `createAgUiCancelHandler`        | Create a DELETE handler for hosted AG-UI run cancellation               |
 | `createAgUiDetachedStartHandler` | Create a POST handler for detached hosted AG-UI run kickoff             |
 | `createAgUiHandler`              | Create a POST handler for an AG-UI route                                |
+| `createAgUiRunErrorEvent`        | Create a `RunError` AG-UI SSE event                                     |
+| `createAgUiSseErrorResponse`     | Create an AG-UI SSE error `Response`                                    |
 | `createAgUiResumeHandler`        | Create a POST handler for hosted AG-UI run resume values                |
 | `createChatHandler`              | Create a POST handler for a chat API route.                             |
 | `createMemory`                   | Create memory (buffer, conversation, summary)                           |
@@ -648,6 +679,7 @@ Clear all stored messages from memory.
 | `AgUiCancelHandlerOptions`        | Options for `createAgUiCancelHandler`                                        |
 | `AgUiInjectedTool`                | AG-UI client-injected tool descriptor                                        |
 | `AgUiRequest`                     | Validated AG-UI runtime request body                                         |
+| `AgUiSseEvent`                    | AG-UI SSE event object used by host-facing AG-UI helpers                     |
 | `AgUiResumeHandlerOptions`        | Options for `createAgUiResumeHandler`                                        |
 | `AgUiResumeSignal`                | Validated hosted-run resume payload                                          |
 | `HumanInputField`                 | Canonical form/input field definition                                        |

--- a/src/agent/ag-ui-detached-start.ts
+++ b/src/agent/ag-ui-detached-start.ts
@@ -3,18 +3,20 @@ import { INVALID_ARGUMENT } from "#veryfront/errors";
 import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
 import { type Tool, toolRegistry } from "#veryfront/tool";
 import { streamDataStreamEvents } from "./data-stream.ts";
-import { type AgUiInjectedTool, type AgUiRequest, AgUiRequestSchema } from "./ag-ui-handler.ts";
+import {
+  type AgUiInjectedTool,
+  AgUiRequestSchema,
+  normalizeAgUiMessages,
+} from "./ag-ui-host-support.ts";
 import {
   AgentRuntime,
   RunAlreadyExistsError,
   type RunResumeSessionManager,
 } from "./runtime/index.ts";
-import type { Agent, Message } from "./types.ts";
+import type { Agent } from "./types.ts";
 
 const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const AG_UI_DETACHED_RUN_ID_SCHEMA = z.string().min(1).max(128).regex(AGENT_ID_PATTERN);
-const MAX_TEXT_PART_LENGTH = 10_000;
-
 type AgUiResumeValue = {
   result: unknown;
   isError: boolean;
@@ -25,94 +27,6 @@ type AgUiContextValue =
   | ((request: Request) => Record<string, unknown> | Promise<Record<string, unknown>>);
 
 type AgUiRuntimePart = Record<string, unknown> & { type: string };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function normalizeToolArgs(part: Record<string, unknown>): Record<string, unknown> {
-  if (isRecord(part.args)) return part.args;
-  if (isRecord(part.input)) return part.input;
-  return {};
-}
-
-function normalizeMessagePart(part: Record<string, unknown>): Message["parts"][number] | null {
-  if (
-    part.type === "text" && typeof part.text === "string" &&
-    part.text.length <= MAX_TEXT_PART_LENGTH
-  ) {
-    return { type: "text", text: part.text };
-  }
-
-  if (part.type === "tool_call" && typeof part.id === "string" && typeof part.name === "string") {
-    return {
-      type: "tool-call",
-      toolCallId: part.id,
-      toolName: part.name,
-      args: normalizeToolArgs(part),
-    };
-  }
-
-  if (
-    part.type === "tool-call" &&
-    typeof part.toolCallId === "string" &&
-    typeof part.toolName === "string"
-  ) {
-    return {
-      type: "tool-call",
-      toolCallId: part.toolCallId,
-      toolName: part.toolName,
-      args: normalizeToolArgs(part),
-    };
-  }
-
-  if (
-    typeof part.type === "string" &&
-    part.type.startsWith("tool-") &&
-    part.type !== "tool-result" &&
-    typeof part.toolCallId === "string" &&
-    typeof part.toolName === "string"
-  ) {
-    return {
-      type: part.type,
-      toolCallId: part.toolCallId,
-      toolName: part.toolName,
-      args: normalizeToolArgs(part),
-    };
-  }
-
-  if (part.type === "tool_result" && typeof part.tool_call_id === "string") {
-    return {
-      type: "tool-result",
-      toolCallId: part.tool_call_id,
-      toolName: typeof part.tool_name === "string" ? part.tool_name : "unknown",
-      result: "output" in part ? part.output : undefined,
-    };
-  }
-
-  if (part.type === "tool-result" && typeof part.toolCallId === "string") {
-    return {
-      type: "tool-result",
-      toolCallId: part.toolCallId,
-      toolName: typeof part.toolName === "string" ? part.toolName : "unknown",
-      result: "result" in part ? part.result : undefined,
-    };
-  }
-
-  return null;
-}
-
-function normalizeMessages(messages: AgUiRequest["messages"]): Message[] {
-  return messages.map((message) => ({
-    id: message.id,
-    role: message.role,
-    parts: message.parts
-      .map((part) => normalizeMessagePart(part))
-      .filter((part): part is Message["parts"][number] => part !== null),
-    ...(message.createdAt ? { timestamp: Date.parse(message.createdAt) || undefined } : {}),
-    ...(message.metadata ? { metadata: message.metadata } : {}),
-  }));
-}
 
 function isRequest(obj: unknown): obj is Request {
   return (
@@ -317,7 +231,7 @@ async function startDefaultDetachedExecution(input: {
   });
 
   const runtimeStream = await runtime.stream(
-    normalizeMessages(input.request.messages),
+    normalizeAgUiMessages(input.request.messages),
     buildStreamContext(input.request, input.context, input.request.threadId, input.request.runId),
     undefined,
     input.request.model,

--- a/src/agent/ag-ui-handler.ts
+++ b/src/agent/ag-ui-handler.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { getAgent } from "./composition/index.ts";
-import type { Agent, Message } from "./types.ts";
+import type { Agent } from "./types.ts";
 import {
   AgentRuntime,
   RunAlreadyExistsError,
@@ -16,16 +16,21 @@ import {
   mapRuntimeEventToAgUi,
 } from "#veryfront/internal-agents/ag-ui-sse.ts";
 import { streamDataStreamEvents } from "./data-stream.ts";
+import {
+  type AgUiInjectedTool,
+  type AgUiRequest,
+  normalizeAgUiMessages,
+  parseAgUiRequestOrError,
+} from "./ag-ui-host-support.ts";
 
-const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
-const MAX_TOOL_PARAMETERS_BYTES = 16_384;
-const MAX_CONTEXT_ITEM_BYTES = 16_384;
-const MAX_CONTEXT_TOTAL_BYTES = 65_536;
-const MAX_FORWARDED_PROPS_BYTES = 65_536;
-const MAX_TEXT_PART_LENGTH = 10_000;
-const MAX_MESSAGES_PER_REQUEST = 100;
-
-const encoder = new TextEncoder();
+export {
+  type AgUiContextItem,
+  AgUiContextItemSchema,
+  type AgUiInjectedTool,
+  AgUiInjectedToolSchema,
+  type AgUiRequest,
+  AgUiRequestSchema,
+} from "./ag-ui-host-support.ts";
 
 const AG_UI_HEADERS: Record<string, string> = {
   "Content-Type": "text/event-stream",
@@ -33,169 +38,8 @@ const AG_UI_HEADERS: Record<string, string> = {
   Connection: "keep-alive",
 };
 
-function isWithinJsonSizeLimit(value: unknown, maxBytes: number): boolean {
-  try {
-    return encoder.encode(JSON.stringify(value)).byteLength <= maxBytes;
-  } catch {
-    return false;
-  }
-}
-
-const AgUiRunIdSchema = z.string().min(1).max(128).regex(AGENT_ID_PATTERN);
-
-const AgUiInjectedToolSchema = z.object({
-  name: z.string().min(1).max(128),
-  description: z.string().max(1024).optional(),
-  parameters: z.record(z.string(), z.unknown()).optional().refine(
-    (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_TOOL_PARAMETERS_BYTES),
-    { message: "Tool parameters must be less than 16 KB" },
-  ),
-});
-
-const AgUiContextItemSchema = z.discriminatedUnion("type", [
-  z.object({
-    type: z.literal("text"),
-    title: z.string().max(256).optional(),
-    text: z.string().max(MAX_CONTEXT_ITEM_BYTES),
-  }),
-  z.object({
-    type: z.literal("json"),
-    title: z.string().max(256).optional(),
-    data: z.record(z.string(), z.unknown()).refine(
-      (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_ITEM_BYTES),
-      { message: "JSON context item must be less than 16 KB" },
-    ),
-  }),
-  z.object({
-    type: z.literal("resource"),
-    title: z.string().max(256).optional(),
-    uri: z.string().max(2048),
-    mimeType: z.string().max(256).optional(),
-    text: z.string().max(MAX_CONTEXT_ITEM_BYTES).optional(),
-  }),
-]);
-
-const AgUiMessagePartSchema = z.object({ type: z.string().min(1) }).passthrough();
-
-const AgUiMessageSchema = z.object({
-  id: z.string().min(1),
-  role: z.enum(["user", "assistant", "system", "tool"]),
-  parts: z.array(AgUiMessagePartSchema).default([]),
-  metadata: z.record(z.string(), z.unknown()).optional(),
-  createdAt: z.string().optional(),
-});
-
-export const AgUiRequestSchema = z.object({
-  threadId: z.string().uuid().optional(),
-  runId: AgUiRunIdSchema.optional(),
-  messages: z.array(AgUiMessageSchema).min(1).max(MAX_MESSAGES_PER_REQUEST),
-  tools: z.array(AgUiInjectedToolSchema).max(50).default([]),
-  context: z.array(AgUiContextItemSchema).max(10).default([]).refine(
-    (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_TOTAL_BYTES),
-    { message: "context must be less than 64 KB total" },
-  ),
-  forwardedProps: z.record(z.string(), z.unknown()).optional().refine(
-    (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_FORWARDED_PROPS_BYTES),
-    { message: "forwardedProps must be less than 64 KB" },
-  ),
-  model: z.string().optional(),
-  maxOutputTokens: z.number().int().positive().optional(),
-});
-
-export type AgUiInjectedTool = z.infer<typeof AgUiInjectedToolSchema>;
-export type AgUiContextItem = z.infer<typeof AgUiContextItemSchema>;
-export type AgUiRequest = z.infer<typeof AgUiRequestSchema>;
-
-type AgUiRuntimePart = Record<string, unknown> & { type: string };
 type AgUiResumeValue = { result: unknown; isError: boolean };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function normalizeToolArgs(part: Record<string, unknown>): Record<string, unknown> {
-  if (isRecord(part.args)) return part.args;
-  if (isRecord(part.input)) return part.input;
-  return {};
-}
-
-function normalizeMessagePart(part: Record<string, unknown>): Message["parts"][number] | null {
-  if (
-    part.type === "text" && typeof part.text === "string" &&
-    part.text.length <= MAX_TEXT_PART_LENGTH
-  ) {
-    return { type: "text", text: part.text };
-  }
-
-  if (part.type === "tool_call" && typeof part.id === "string" && typeof part.name === "string") {
-    return {
-      type: "tool-call",
-      toolCallId: part.id,
-      toolName: part.name,
-      args: normalizeToolArgs(part),
-    };
-  }
-
-  if (
-    part.type === "tool-call" &&
-    typeof part.toolCallId === "string" &&
-    typeof part.toolName === "string"
-  ) {
-    return {
-      type: "tool-call",
-      toolCallId: part.toolCallId,
-      toolName: part.toolName,
-      args: normalizeToolArgs(part),
-    };
-  }
-
-  if (
-    typeof part.type === "string" &&
-    part.type.startsWith("tool-") &&
-    part.type !== "tool-result" &&
-    typeof part.toolCallId === "string" &&
-    typeof part.toolName === "string"
-  ) {
-    return {
-      type: part.type,
-      toolCallId: part.toolCallId,
-      toolName: part.toolName,
-      args: normalizeToolArgs(part),
-    };
-  }
-
-  if (part.type === "tool_result" && typeof part.tool_call_id === "string") {
-    return {
-      type: "tool-result",
-      toolCallId: part.tool_call_id,
-      toolName: typeof part.tool_name === "string" ? part.tool_name : "unknown",
-      result: "output" in part ? part.output : undefined,
-    };
-  }
-
-  if (part.type === "tool-result" && typeof part.toolCallId === "string") {
-    return {
-      type: "tool-result",
-      toolCallId: part.toolCallId,
-      toolName: typeof part.toolName === "string" ? part.toolName : "unknown",
-      result: "result" in part ? part.result : undefined,
-    };
-  }
-
-  return null;
-}
-
-function normalizeMessages(messages: AgUiRequest["messages"]): Message[] {
-  return messages.map((message) => ({
-    id: message.id,
-    role: message.role,
-    parts: message.parts
-      .map((part) => normalizeMessagePart(part))
-      .filter((part): part is Message["parts"][number] => part !== null),
-    ...(message.createdAt ? { timestamp: Date.parse(message.createdAt) || undefined } : {}),
-    ...(message.metadata ? { metadata: message.metadata } : {}),
-  }));
-}
+type AgUiRuntimePart = Record<string, unknown> & { type: string };
 
 function isRequest(obj: unknown): obj is Request {
   return (
@@ -377,7 +221,7 @@ async function createAgUiDirectStreamResponse(
   await agent.clearMemory();
 
   const result = await agent.stream({
-    messages: normalizeMessages(request.messages),
+    messages: normalizeAgUiMessages(request.messages),
     context: buildStreamContext(request, baseContext, threadId, runId),
     ...(request.model ? { model: request.model } : {}),
     ...(request.maxOutputTokens ? { maxOutputTokens: request.maxOutputTokens } : {}),
@@ -470,7 +314,7 @@ async function createAgUiInjectedToolsStreamResponse(
   let upstreamBody: ReadableStream<Uint8Array>;
   try {
     upstreamBody = await runtime.stream(
-      normalizeMessages(request.messages),
+      normalizeAgUiMessages(request.messages),
       buildStreamContext(request, baseContext, threadId, runId),
       undefined,
       request.model,
@@ -558,7 +402,10 @@ export function createAgUiHandler(
     }
 
     try {
-      const parsed = AgUiRequestSchema.parse(await request.json());
+      const parsed = await parseAgUiRequestOrError(request);
+      if (parsed instanceof Response) {
+        return parsed;
+      }
 
       if (parsed.tools.length > 0) {
         if (!options?.sessionManager) {

--- a/src/agent/ag-ui-host-support.test.ts
+++ b/src/agent/ag-ui-host-support.test.ts
@@ -1,0 +1,127 @@
+import { assertEquals, assertInstanceOf, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  createAgUiRunErrorEvent,
+  createAgUiSseErrorResponse,
+  normalizeAgUiMessages,
+  parseAgUiRequest,
+  parseAgUiRequestOrError,
+} from "./ag-ui-host-support.ts";
+
+describe("agent/ag-ui-host-support", () => {
+  it("parses a valid AG-UI request body through the public helper", async () => {
+    const request = new Request("http://localhost/api/ag-ui", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        threadId: crypto.randomUUID(),
+        runId: "run_1",
+        messages: [{
+          id: "msg-1",
+          role: "user",
+          parts: [{ type: "text", text: "hello" }],
+        }],
+        tools: [],
+        context: [],
+      }),
+    });
+
+    const parsed = await parseAgUiRequest(request);
+
+    assertEquals(parsed.runId, "run_1");
+    assertEquals(parsed.messages.length, 1);
+    assertEquals(parsed.tools, []);
+  });
+
+  it("returns a 400 Response from parseAgUiRequestOrError for invalid AG-UI payloads", async () => {
+    const request = new Request("http://localhost/api/ag-ui", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: "not-an-array",
+      }),
+    });
+
+    const result = await parseAgUiRequestOrError(request);
+
+    assertInstanceOf(result, Response);
+    assertEquals(result.status, 400);
+    const body = await result.json();
+    assertEquals(body.error, "Invalid AG-UI request");
+    assertEquals(Array.isArray(body.details), true);
+  });
+
+  it("returns a 400 Response from parseAgUiRequestOrError for malformed JSON bodies", async () => {
+    const request = new Request("http://localhost/api/ag-ui", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not-valid-json",
+    });
+
+    const result = await parseAgUiRequestOrError(request);
+
+    assertInstanceOf(result, Response);
+    assertEquals(result.status, 400);
+    const body = await result.json();
+    assertEquals(body.error, "Invalid AG-UI request");
+    assertEquals(body.details, [{ path: [], message: "Malformed JSON request body" }]);
+  });
+
+  it("normalizes text, tool-call, and tool-result parts through the public helper", () => {
+    const messages = normalizeAgUiMessages([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "hello" },
+          {
+            type: "tool_call",
+            id: "tool-1",
+            name: "search_docs",
+            args: { query: "ag-ui" },
+          },
+          {
+            type: "tool_result",
+            tool_call_id: "tool-1",
+            tool_name: "search_docs",
+            output: { matches: 2 },
+          },
+        ],
+      },
+    ]);
+
+    assertEquals(messages, [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "hello" },
+          {
+            type: "tool-call",
+            toolCallId: "tool-1",
+            toolName: "search_docs",
+            args: { query: "ag-ui" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "tool-1",
+            toolName: "search_docs",
+            result: { matches: 2 },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("creates AG-UI SSE run-error responses with the existing wire shape", async () => {
+    const event = createAgUiRunErrorEvent("Overloaded right now", "OVERLOADED_ERROR");
+    const response = createAgUiSseErrorResponse(event, 503);
+
+    assertEquals(response.status, 503);
+    assertEquals(response.headers.get("content-type"), "text/event-stream; charset=utf-8");
+    const body = await response.text();
+    assertStringIncludes(body, "event: RunError");
+    assertStringIncludes(body, '"code":"OVERLOADED_ERROR"');
+    assertStringIncludes(body, "Overloaded right now");
+  });
+});

--- a/src/agent/ag-ui-host-support.ts
+++ b/src/agent/ag-ui-host-support.ts
@@ -1,0 +1,238 @@
+import { z } from "zod";
+import { formatAgUiEvent } from "#veryfront/internal-agents/ag-ui-sse.ts";
+import type { Message } from "./types.ts";
+
+const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const MAX_TOOL_PARAMETERS_BYTES = 16_384;
+const MAX_CONTEXT_ITEM_BYTES = 16_384;
+const MAX_CONTEXT_TOTAL_BYTES = 65_536;
+const MAX_FORWARDED_PROPS_BYTES = 65_536;
+const MAX_TEXT_PART_LENGTH = 10_000;
+const MAX_MESSAGES_PER_REQUEST = 100;
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export interface AgUiSseEvent {
+  event: string;
+  payload: Record<string, unknown>;
+}
+
+function isWithinJsonSizeLimit(value: unknown, maxBytes: number): boolean {
+  try {
+    return encoder.encode(JSON.stringify(value)).byteLength <= maxBytes;
+  } catch {
+    return false;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const AgUiRunIdSchema = z.string().min(1).max(128).regex(AGENT_ID_PATTERN);
+
+export const AgUiInjectedToolSchema = z.object({
+  name: z.string().min(1).max(128),
+  description: z.string().max(1024).optional(),
+  parameters: z.record(z.string(), z.unknown()).optional().refine(
+    (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_TOOL_PARAMETERS_BYTES),
+    { message: "Tool parameters must be less than 16 KB" },
+  ),
+});
+
+export const AgUiContextItemSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("text"),
+    title: z.string().max(256).optional(),
+    text: z.string().max(MAX_CONTEXT_ITEM_BYTES),
+  }),
+  z.object({
+    type: z.literal("json"),
+    title: z.string().max(256).optional(),
+    data: z.record(z.string(), z.unknown()).refine(
+      (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_ITEM_BYTES),
+      { message: "JSON context item must be less than 16 KB" },
+    ),
+  }),
+  z.object({
+    type: z.literal("resource"),
+    title: z.string().max(256).optional(),
+    uri: z.string().max(2048),
+    mimeType: z.string().max(256).optional(),
+    text: z.string().max(MAX_CONTEXT_ITEM_BYTES).optional(),
+  }),
+]);
+
+const AgUiMessagePartSchema = z.object({ type: z.string().min(1) }).passthrough();
+
+const AgUiMessageSchema = z.object({
+  id: z.string().min(1),
+  role: z.enum(["user", "assistant", "system", "tool"]),
+  parts: z.array(AgUiMessagePartSchema).default([]),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  createdAt: z.string().optional(),
+});
+
+export const AgUiRequestSchema = z.object({
+  threadId: z.string().uuid().optional(),
+  runId: AgUiRunIdSchema.optional(),
+  messages: z.array(AgUiMessageSchema).min(1).max(MAX_MESSAGES_PER_REQUEST),
+  tools: z.array(AgUiInjectedToolSchema).max(50).default([]),
+  context: z.array(AgUiContextItemSchema).max(10).default([]).refine(
+    (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_TOTAL_BYTES),
+    { message: "context must be less than 64 KB total" },
+  ),
+  forwardedProps: z.record(z.string(), z.unknown()).optional().refine(
+    (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_FORWARDED_PROPS_BYTES),
+    { message: "forwardedProps must be less than 64 KB" },
+  ),
+  model: z.string().optional(),
+  maxOutputTokens: z.number().int().positive().optional(),
+});
+
+export type AgUiInjectedTool = z.infer<typeof AgUiInjectedToolSchema>;
+export type AgUiContextItem = z.infer<typeof AgUiContextItemSchema>;
+export type AgUiRequest = z.infer<typeof AgUiRequestSchema>;
+
+function normalizeToolArgs(part: Record<string, unknown>): Record<string, unknown> {
+  if (isRecord(part.args)) return part.args;
+  if (isRecord(part.input)) return part.input;
+  return {};
+}
+
+function normalizeMessagePart(part: Record<string, unknown>): Message["parts"][number] | null {
+  if (
+    part.type === "text" && typeof part.text === "string" &&
+    part.text.length <= MAX_TEXT_PART_LENGTH
+  ) {
+    return { type: "text", text: part.text };
+  }
+
+  if (part.type === "tool_call" && typeof part.id === "string" && typeof part.name === "string") {
+    return {
+      type: "tool-call",
+      toolCallId: part.id,
+      toolName: part.name,
+      args: normalizeToolArgs(part),
+    };
+  }
+
+  if (
+    part.type === "tool-call" &&
+    typeof part.toolCallId === "string" &&
+    typeof part.toolName === "string"
+  ) {
+    return {
+      type: "tool-call",
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      args: normalizeToolArgs(part),
+    };
+  }
+
+  if (
+    typeof part.type === "string" &&
+    part.type.startsWith("tool-") &&
+    part.type !== "tool-result" &&
+    typeof part.toolCallId === "string" &&
+    typeof part.toolName === "string"
+  ) {
+    return {
+      type: part.type,
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      args: normalizeToolArgs(part),
+    };
+  }
+
+  if (part.type === "tool_result" && typeof part.tool_call_id === "string") {
+    return {
+      type: "tool-result",
+      toolCallId: part.tool_call_id,
+      toolName: typeof part.tool_name === "string" ? part.tool_name : "unknown",
+      result: "output" in part ? part.output : undefined,
+    };
+  }
+
+  if (part.type === "tool-result" && typeof part.toolCallId === "string") {
+    return {
+      type: "tool-result",
+      toolCallId: part.toolCallId,
+      toolName: typeof part.toolName === "string" ? part.toolName : "unknown",
+      result: "result" in part ? part.result : undefined,
+    };
+  }
+
+  return null;
+}
+
+export async function parseAgUiRequest(request: Request): Promise<AgUiRequest> {
+  return AgUiRequestSchema.parse(await request.json());
+}
+
+export async function parseAgUiRequestOrError(
+  request: Request,
+): Promise<AgUiRequest | Response> {
+  try {
+    return await parseAgUiRequest(request);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return Response.json(
+        {
+          error: "Invalid AG-UI request",
+          details: error.issues.map((issue) => ({
+            path: issue.path,
+            message: issue.message,
+          })),
+        },
+        { status: 400 },
+      );
+    }
+
+    if (error instanceof SyntaxError || error instanceof TypeError) {
+      return Response.json(
+        {
+          error: "Invalid AG-UI request",
+          details: [{ path: [], message: "Malformed JSON request body" }],
+        },
+        { status: 400 },
+      );
+    }
+
+    throw error;
+  }
+}
+
+export function normalizeAgUiMessages(messages: AgUiRequest["messages"]): Message[] {
+  return messages.map((message) => ({
+    id: message.id,
+    role: message.role,
+    parts: message.parts
+      .map((part) => normalizeMessagePart(part))
+      .filter((part): part is Message["parts"][number] => part !== null),
+    ...(message.createdAt ? { timestamp: Date.parse(message.createdAt) || undefined } : {}),
+    ...(message.metadata ? { metadata: message.metadata } : {}),
+  }));
+}
+
+export function createAgUiRunErrorEvent(message: string, code?: string): AgUiSseEvent {
+  return {
+    event: "RunError",
+    payload: {
+      message,
+      ...(code ? { code } : {}),
+    },
+  };
+}
+
+export function createAgUiSseErrorResponse(event: AgUiSseEvent, status: number): Response {
+  return new Response(decoder.decode(formatAgUiEvent(event.event, event.payload)), {
+    status,
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      "Connection": "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -188,6 +188,14 @@ export {
   createAgUiResumeHandler,
 } from "./ag-ui-run-control.ts";
 export {
+  type AgUiSseEvent,
+  createAgUiRunErrorEvent,
+  createAgUiSseErrorResponse,
+  normalizeAgUiMessages,
+  parseAgUiRequest,
+  parseAgUiRequestOrError,
+} from "./ag-ui-host-support.ts";
+export {
   type AgUiContextItem,
   type AgUiHandlerConfigWithAgent,
   type AgUiHandlerOptions,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.220";
+export const VERSION = "0.1.221";


### PR DESCRIPTION
## Summary
- add public AG-UI host-facing helpers for request parsing, message normalization, and SSE error shaping
- reuse the shared AG-UI helper surface from the direct handler and detached start paths
- document the new helper surface in the package AG-UI and agent references

## Verification
- deno test --no-check --allow-all src/agent/ag-ui-host-support.test.ts src/agent/ag-ui-handler.test.ts src/agent/ag-ui-detached-start.test.ts src/agent/ag-ui-run-control.test.ts src/agent/runtime-ag-ui-contract.test.ts
- deno check src/agent/index.ts
- deno fmt --check src/agent/ag-ui-host-support.ts src/agent/ag-ui-host-support.test.ts src/agent/ag-ui-handler.ts src/agent/ag-ui-detached-start.ts src/agent/index.ts docs/reference/agent-runtime-ag-ui.md docs/reference/agent.md