### PR TITLE
Expose runtime-native AG-UI parsing helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.221",
+  "version": "0.1.222",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent-runtime-ag-ui-contract.md
+++ b/docs/reference/agent-runtime-ag-ui-contract.md
@@ -98,6 +98,7 @@ the public `veryfront/agent` handlers instead of these internal routes.
 Downstream package/framework consumers should target:
 
 - the canonical `AgUiRuntimeRequestSchema`
+- the public `parseAgUiRuntimeRequest()` / `parseAgUiRuntimeRequestOrError()` helpers when they want framework-owned runtime-request parsing without using the higher-level `createAgUiHandler()` wrapper
 - AG-UI SSE responses
 - the default endpoint convention `/api/ag-ui` unless a host explicitly documents another route
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -36,6 +36,8 @@ import {
   normalizeAgUiMessages,
   parseAgUiRequest,
   parseAgUiRequestOrError,
+  parseAgUiRuntimeRequest,
+  parseAgUiRuntimeRequestOrError,
   registerAgent,
   RunResumeSessionManager,
   waitForHumanInput,
@@ -514,6 +516,16 @@ agent execution. This is the package-facing schema downstream runtimes should
 target; the older internal compatibility route remains a wrapper around this
 contract.
 
+### `parseAgUiRuntimeRequest(request)`
+
+Parse and validate the canonical runtime AG-UI request body into
+`AgUiRuntimeRequestSchema`.
+
+### `parseAgUiRuntimeRequestOrError(request)`
+
+Parse the canonical runtime AG-UI request body and return either the parsed
+request or a `400` JSON `Response` when validation fails.
+
 ### `AgUiResumeSignalSchema`
 
 Validate the canonical hosted-run resume payload for AG-UI tool-result
@@ -618,6 +630,8 @@ Clear all stored messages from memory.
 | `createAgUiRunErrorEvent`        | Create a `RunError` AG-UI SSE event                                     |
 | `createAgUiSseErrorResponse`     | Create an AG-UI SSE error `Response`                                    |
 | `createAgUiResumeHandler`        | Create a POST handler for hosted AG-UI run resume values                |
+| `parseAgUiRuntimeRequest`        | Parse and validate the canonical runtime AG-UI request body             |
+| `parseAgUiRuntimeRequestOrError` | Parse runtime AG-UI input or return a `400` validation `Response`       |
 | `createChatHandler`              | Create a POST handler for a chat API route.                             |
 | `createMemory`                   | Create memory (buffer, conversation, summary)                           |
 | `createRedisMemory`              | Create Redis-backed memory                                              |

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -148,6 +148,8 @@ export {
   AgUiRuntimeMessageSchema,
   type AgUiRuntimeRequest,
   AgUiRuntimeRequestSchema,
+  parseAgUiRuntimeRequest,
+  parseAgUiRuntimeRequestOrError,
 } from "./runtime-ag-ui-contract.ts";
 export {
   type AgUiBrowserEncodedEvent,

--- a/src/agent/runtime-ag-ui-contract.test.ts
+++ b/src/agent/runtime-ag-ui-contract.test.ts
@@ -1,6 +1,10 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertInstanceOf } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { AgUiRuntimeRequestSchema } from "./index.ts";
+import {
+  AgUiRuntimeRequestSchema,
+  parseAgUiRuntimeRequest,
+  parseAgUiRuntimeRequestOrError,
+} from "./index.ts";
 
 describe("agent/runtime-ag-ui-contract", () => {
   it("exports the canonical runtime AG-UI request schema from veryfront/agent", () => {
@@ -44,5 +48,66 @@ describe("agent/runtime-ag-ui-contract", () => {
     assertEquals(parsed.state, { phase: "draft" });
     assertEquals(parsed.tools, []);
     assertEquals(parsed.context, [{ description: "Current file", value: "src/main.ts" }]);
+  });
+
+  it("parses a valid runtime AG-UI request body through the public helper", async () => {
+    const parsed = await parseAgUiRuntimeRequest(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          threadId: crypto.randomUUID(),
+          runId: "run_1",
+          messages: [
+            {
+              id: "user_1",
+              role: "user",
+              content: "Hello",
+            },
+          ],
+          context: [],
+          tools: [],
+        }),
+      }),
+    );
+
+    assertEquals(parsed.runId, "run_1");
+    assertEquals(parsed.messages.length, 1);
+  });
+
+  it("returns a 400 response for malformed runtime AG-UI JSON bodies", async () => {
+    const result = await parseAgUiRuntimeRequestOrError(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not-json",
+      }),
+    );
+
+    assertInstanceOf(result, Response);
+    assertEquals(result.status, 400);
+    const body = await result.json();
+    assertEquals(body.error, "Invalid AG-UI runtime request");
+    assertEquals(body.details, [{ path: [], message: "Malformed JSON request body" }]);
+  });
+
+  it("returns a 400 response for invalid runtime AG-UI payloads", async () => {
+    const result = await parseAgUiRuntimeRequestOrError(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          threadId: "not-a-uuid",
+          runId: "run_1",
+          messages: [],
+        }),
+      }),
+    );
+
+    assertInstanceOf(result, Response);
+    assertEquals(result.status, 400);
+    const body = await result.json();
+    assertEquals(body.error, "Invalid AG-UI runtime request");
+    assertEquals(Array.isArray(body.details), true);
   });
 });

--- a/src/agent/runtime-ag-ui-contract.ts
+++ b/src/agent/runtime-ag-ui-contract.ts
@@ -142,3 +142,40 @@ export type AgUiRuntimeInjectedTool = z.infer<typeof AgUiRuntimeInjectedToolSche
 export type AgUiRuntimeContextItem = z.infer<typeof AgUiRuntimeContextItemSchema>;
 export type AgUiRuntimeMessage = z.infer<typeof AgUiRuntimeMessageSchema>;
 export type AgUiRuntimeRequest = z.infer<typeof AgUiRuntimeRequestSchema>;
+
+export async function parseAgUiRuntimeRequest(request: Request): Promise<AgUiRuntimeRequest> {
+  return AgUiRuntimeRequestSchema.parse(await request.json());
+}
+
+export async function parseAgUiRuntimeRequestOrError(
+  request: Request,
+): Promise<AgUiRuntimeRequest | Response> {
+  try {
+    return await parseAgUiRuntimeRequest(request);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return Response.json(
+        {
+          error: "Invalid AG-UI runtime request",
+          details: error.issues.map((issue) => ({
+            path: issue.path,
+            message: issue.message,
+          })),
+        },
+        { status: 400 },
+      );
+    }
+
+    if (error instanceof SyntaxError || error instanceof TypeError) {
+      return Response.json(
+        {
+          error: "Invalid AG-UI runtime request",
+          details: [{ path: [], message: "Malformed JSON request body" }],
+        },
+        { status: 400 },
+      );
+    }
+
+    throw error;
+  }
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.221";
+export const VERSION = "0.1.222";


### PR DESCRIPTION
## Summary
- add public helpers for parsing the canonical runtime AG-UI request contract
- return client-facing `400` responses for malformed JSON and invalid runtime AG-UI payloads
- document the runtime-native AG-UI helper surface alongside the existing AG-UI references

## Verification
- deno test --no-check --allow-all src/agent/runtime-ag-ui-contract.test.ts src/agent/ag-ui-host-support.test.ts
- deno check src/agent/index.ts
- deno fmt --check src/agent/runtime-ag-ui-contract.ts src/agent/runtime-ag-ui-contract.test.ts src/agent/index.ts docs/reference/agent-runtime-ag-ui-contract.md docs/reference/agent.md