### PR TITLE
Expose runtime AG-UI handlers for host-controlled execution

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.222",
+  "version": "0.1.223",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent-runtime-ag-ui-contract.md
+++ b/docs/reference/agent-runtime-ag-ui-contract.md
@@ -99,6 +99,8 @@ Downstream package/framework consumers should target:
 
 - the canonical `AgUiRuntimeRequestSchema`
 - the public `parseAgUiRuntimeRequest()` / `parseAgUiRuntimeRequestOrError()` helpers when they want framework-owned runtime-request parsing without using the higher-level `createAgUiHandler()` wrapper
+- `createAgUiRuntimeHandler()` when they want package-owned runtime-request parsing plus either direct package streaming or a host-provided execution handoff
+- `normalizeAgUiRuntimeMessages()` when they need the canonical runtime-message to package-message conversion outside the default handler path
 - AG-UI SSE responses
 - the default endpoint convention `/api/ag-ui` unless a host explicitly documents another route
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -27,6 +27,7 @@ import {
   createAgUiHandler,
   createAgUiResumeHandler,
   createAgUiRunErrorEvent,
+  createAgUiRuntimeHandler,
   createAgUiSseErrorResponse,
   createMemory,
   expandAllowedRemoteToolNames,
@@ -34,6 +35,7 @@ import {
   getProviderNativeToolNames,
   HumanInputRequestSchema,
   normalizeAgUiMessages,
+  normalizeAgUiRuntimeMessages,
   parseAgUiRequest,
   parseAgUiRequestOrError,
   parseAgUiRuntimeRequest,
@@ -526,6 +528,23 @@ Parse and validate the canonical runtime AG-UI request body into
 Parse the canonical runtime AG-UI request body and return either the parsed
 request or a `400` JSON `Response` when validation fails.
 
+### `normalizeAgUiRuntimeMessages(messages)`
+
+Normalize canonical runtime AG-UI `messages` into the package `Message[]`
+shape used by `agent.stream()` and `AgentRuntime.stream()`.
+
+### `createAgUiRuntimeHandler(config)`
+
+Create a POST route handler for the canonical runtime AG-UI request contract.
+
+This handler:
+
+- validates `AgUiRuntimeRequestSchema`
+- optionally resolves extra host context
+- can stream directly through a package `agent`
+- can hand off to a host-provided `execute` callback for custom auth,
+  preparation, or execution while keeping package-owned runtime-request parsing
+
 ### `AgUiResumeSignalSchema`
 
 Validate the canonical hosted-run resume payload for AG-UI tool-result
@@ -627,9 +646,11 @@ Clear all stored messages from memory.
 | `createAgUiCancelHandler`        | Create a DELETE handler for hosted AG-UI run cancellation               |
 | `createAgUiDetachedStartHandler` | Create a POST handler for detached hosted AG-UI run kickoff             |
 | `createAgUiHandler`              | Create a POST handler for an AG-UI route                                |
+| `createAgUiRuntimeHandler`       | Create a POST handler for the canonical runtime AG-UI request contract  |
 | `createAgUiRunErrorEvent`        | Create a `RunError` AG-UI SSE event                                     |
 | `createAgUiSseErrorResponse`     | Create an AG-UI SSE error `Response`                                    |
 | `createAgUiResumeHandler`        | Create a POST handler for hosted AG-UI run resume values                |
+| `normalizeAgUiRuntimeMessages`   | Normalize runtime AG-UI messages into package `Message[]`               |
 | `parseAgUiRuntimeRequest`        | Parse and validate the canonical runtime AG-UI request body             |
 | `parseAgUiRuntimeRequestOrError` | Parse runtime AG-UI input or return a `400` validation `Response`       |
 | `createChatHandler`              | Create a POST handler for a chat API route.                             |

--- a/src/agent/ag-ui-runtime-handler.test.ts
+++ b/src/agent/ag-ui-runtime-handler.test.ts
@@ -1,0 +1,222 @@
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createAgUiRuntimeHandler } from "./ag-ui-runtime-handler.ts";
+import type { Agent, Message } from "./types.ts";
+
+const encoder = new TextEncoder();
+
+function encodeDataStreamEvent(payload: Record<string, unknown>): Uint8Array {
+  return encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+function createTestAgent() {
+  let clearMemoryCalls = 0;
+  let capturedMessages: Message[] = [];
+  let capturedContext: Record<string, unknown> | undefined;
+
+  const agent: Agent = {
+    id: "assistant-1",
+    config: {
+      id: "assistant-1",
+      system: "You are helpful.",
+      model: "anthropic/claude-sonnet-4-6",
+    } as Agent["config"],
+    generate: async () => {
+      throw new Error("not used");
+    },
+    stream: async (input) => {
+      capturedMessages = input.messages ?? [];
+      capturedContext = input.context;
+
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            encodeDataStreamEvent({ type: "message-start", messageId: "assistant-msg-1" }),
+          );
+          controller.enqueue(
+            encodeDataStreamEvent({
+              type: "data",
+              data: {
+                model: "anthropic/claude-sonnet-4-6",
+                inferenceMode: "cloud",
+              },
+            }),
+          );
+          controller.enqueue(encodeDataStreamEvent({ type: "text-start", id: "text-1" }));
+          controller.enqueue(
+            encodeDataStreamEvent({
+              type: "text-delta",
+              id: "text-1",
+              delta: "hello from runtime",
+            }),
+          );
+          controller.enqueue(encodeDataStreamEvent({ type: "text-end", id: "text-1" }));
+          controller.close();
+        },
+      });
+
+      return {
+        toDataStreamResponse: () =>
+          new Response(stream, {
+            headers: { "Content-Type": "text/event-stream" },
+          }),
+      };
+    },
+    respond: async () => new Response("not used"),
+    getMemory: () => {
+      throw new Error("not used");
+    },
+    getMemoryStats: async () => ({
+      totalMessages: 0,
+      estimatedTokens: 0,
+      type: "conversation",
+    }),
+    clearMemory: async () => {
+      clearMemoryCalls += 1;
+    },
+  };
+
+  return {
+    agent,
+    get clearMemoryCalls() {
+      return clearMemoryCalls;
+    },
+    get capturedMessages() {
+      return capturedMessages;
+    },
+    get capturedContext() {
+      return capturedContext;
+    },
+  };
+}
+
+describe("agent/ag-ui-runtime-handler", () => {
+  it("streams AG-UI events from the canonical runtime request contract", async () => {
+    const testAgent = createTestAgent();
+    const threadId = crypto.randomUUID();
+    const handler = createAgUiRuntimeHandler({
+      agent: testAgent.agent,
+      context: { tenant: "acme" },
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          threadId,
+          runId: "run_runtime_1",
+          messages: [
+            { id: "sys-1", role: "system", content: "Behave." },
+            { id: "user-1", role: "user", content: "Hello" },
+          ],
+          context: [{ type: "text", text: "Current file: app.tsx" }],
+          state: { step: "draft" },
+          forwardedProps: { traceId: "trace-1" },
+        }),
+      }),
+    );
+
+    assertEquals(response.status, 200);
+    assertEquals(response.headers.get("content-type"), "text/event-stream");
+    assertEquals(testAgent.clearMemoryCalls, 1);
+    assertEquals(testAgent.capturedMessages.length, 2);
+    assertEquals(testAgent.capturedMessages[0]?.parts[0]?.type, "text");
+    assertEquals(testAgent.capturedMessages[1]?.parts[0]?.type, "text");
+    assertEquals(testAgent.capturedContext?.tenant, "acme");
+    assertEquals(testAgent.capturedContext?.runId, "run_runtime_1");
+    assertEquals(testAgent.capturedContext?.threadId, threadId);
+    assertEquals(
+      testAgent.capturedContext?.agUi,
+      {
+        context: [{ type: "text", text: "Current file: app.tsx" }],
+        forwardedProps: { traceId: "trace-1" },
+      },
+    );
+
+    const body = await response.text();
+    assertStringIncludes(body, "event: RunStarted");
+    assertStringIncludes(body, '"runId":"run_runtime_1"');
+    assertStringIncludes(body, "event: StateSnapshot");
+    assertStringIncludes(body, '"snapshot":{"step":"draft"}');
+    assertStringIncludes(body, "event: MessagesSnapshot");
+    assertStringIncludes(body, '"role":"user","parts":[{"type":"text","text":"Hello"}]');
+    assertStringIncludes(body, "event: TextMessageContent");
+  });
+
+  it("hands parsed runtime requests to a custom execute hook", async () => {
+    const threadId = crypto.randomUUID();
+    const handler = createAgUiRuntimeHandler({
+      execute: async ({ agUiInput, context, createDefaultResponse }) => {
+        assertEquals(createDefaultResponse, undefined);
+        assertEquals(context.hook, "present");
+        return Response.json({
+          threadId: agUiInput.threadId,
+          runId: agUiInput.runId,
+          messageCount: agUiInput.messages.length,
+        });
+      },
+      context: { hook: "present" },
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          threadId,
+          runId: "run_runtime_2",
+          messages: [{ id: "user-1", role: "user", content: "Hello" }],
+        }),
+      }),
+    );
+
+    assertEquals(response.status, 200);
+    assertEquals(await response.json(), {
+      threadId,
+      runId: "run_runtime_2",
+      messageCount: 1,
+    });
+  });
+
+  it("requires a session manager when injected runtime tools are present and the default path is used", async () => {
+    const testAgent = createTestAgent();
+    const threadId = crypto.randomUUID();
+    const handler = createAgUiRuntimeHandler({ agent: testAgent.agent });
+
+    const response = await handler(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          threadId,
+          runId: "run_runtime_3",
+          messages: [{ id: "user-1", role: "user", content: "Hello" }],
+          tools: [{ name: "ui_search" }],
+        }),
+      }),
+    );
+
+    assertEquals(response.status, 501);
+    assertEquals(await response.json(), {
+      error:
+        "Injected AG-UI tools require a public RunResumeSessionManager on createAgUiRuntimeHandler().",
+    });
+  });
+
+  it("rejects invalid runtime request bodies", async () => {
+    const testAgent = createTestAgent();
+    const handler = createAgUiRuntimeHandler({ agent: testAgent.agent });
+
+    const response = await handler(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: [] }),
+      }),
+    );
+
+    assertEquals(response.status, 400);
+    assertStringIncludes(await response.text(), "Invalid AG-UI runtime request");
+  });
+});

--- a/src/agent/ag-ui-runtime-handler.ts
+++ b/src/agent/ag-ui-runtime-handler.ts
@@ -1,0 +1,453 @@
+import { z } from "zod";
+import { INVALID_ARGUMENT } from "#veryfront/errors";
+import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
+import { type Tool, toolRegistry } from "#veryfront/tool";
+import {
+  AgentRuntime,
+  RunAlreadyExistsError,
+  type RunResumeSessionManager,
+} from "./runtime/index.ts";
+import type { Agent } from "./types.ts";
+import {
+  type AgUiRuntimeInjectedTool,
+  type AgUiRuntimeRequest,
+  parseAgUiRuntimeRequestOrError,
+} from "./runtime-ag-ui-contract.ts";
+import { normalizeAgUiRuntimeMessages } from "./ag-ui-runtime-support.ts";
+import {
+  createStreamTransformState,
+  finalizeRunEvents,
+  formatAgUiEvent,
+  mapRuntimeEventToAgUi,
+} from "#veryfront/internal-agents/ag-ui-sse.ts";
+import { streamDataStreamEvents } from "./data-stream.ts";
+
+const AG_UI_HEADERS: Record<string, string> = {
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache",
+  Connection: "keep-alive",
+};
+
+type AgUiResumeValue = { result: unknown; isError: boolean };
+type AgUiRuntimePart = Record<string, unknown> & { type: string };
+
+function isRequest(obj: unknown): obj is Request {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "json" in obj &&
+    typeof obj.json === "function" &&
+    "url" in obj &&
+    typeof obj.url === "string" &&
+    "method" in obj &&
+    typeof obj.method === "string"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function extractRequest(requestOrCtx: unknown): Request {
+  if (isRequest(requestOrCtx)) return requestOrCtx;
+
+  if (typeof requestOrCtx === "object" && requestOrCtx !== null && "request" in requestOrCtx) {
+    const candidate = (requestOrCtx as Record<string, unknown>).request;
+    if (isRequest(candidate)) return candidate;
+  }
+
+  throw INVALID_ARGUMENT.create({
+    detail: "Invalid handler argument: expected Request or APIContext",
+  });
+}
+
+function buildStreamContext(
+  request: AgUiRuntimeRequest,
+  baseContext: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ...baseContext,
+    threadId: request.threadId,
+    runId: request.runId,
+    agUi: {
+      context: request.context,
+      forwardedProps: request.forwardedProps,
+    },
+  };
+}
+
+function closeController(controller: ReadableStreamDefaultController<Uint8Array>): void {
+  try {
+    controller.close();
+  } catch {
+    return;
+  }
+}
+
+function enqueueEvent(
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  event: string,
+  payload: Record<string, unknown>,
+): boolean {
+  try {
+    controller.enqueue(formatAgUiEvent(event, payload));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function createAgUiRuntimeStreamResponse(
+  options: {
+    agentId: string;
+    request: AgUiRuntimeRequest;
+    upstreamBody: ReadableStream<Uint8Array> | null;
+    upstreamStatus: number;
+    upstreamStatusText?: string;
+    onFinish?: () => void;
+    onError?: (error: unknown) => void;
+    onToolCallSeen?: (toolCallId: string) => void;
+  },
+): Promise<Response> {
+  const {
+    agentId,
+    request,
+    upstreamBody,
+    upstreamStatus,
+    upstreamStatusText,
+    onFinish,
+    onError,
+    onToolCallSeen,
+  } = options;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start: async (controller) => {
+      const state = createStreamTransformState();
+      const prepareToolResultIfNeeded = (event: string, payload: Record<string, unknown>) => {
+        if (
+          event !== "ToolCallStart" && event !== "ToolCallArgs" &&
+          event !== "ToolCallEnd"
+        ) {
+          return;
+        }
+
+        const toolCallId = typeof payload.toolCallId === "string" ? payload.toolCallId : null;
+        if (toolCallId) {
+          onToolCallSeen?.(toolCallId);
+        }
+      };
+
+      if (
+        !enqueueEvent(controller, "RunStarted", {
+          runId: request.runId,
+          threadId: request.threadId,
+          agentId,
+        })
+      ) {
+        return;
+      }
+      if (
+        !enqueueEvent(controller, "StateSnapshot", {
+          snapshot: isRecord(request.state) ? request.state : {},
+        })
+      ) {
+        return;
+      }
+      if (
+        !enqueueEvent(controller, "MessagesSnapshot", {
+          messages: normalizeAgUiRuntimeMessages(request.messages),
+        })
+      ) {
+        return;
+      }
+
+      try {
+        if (!upstreamBody) {
+          for (const event of finalizeRunEvents(state, null)) {
+            if (!enqueueEvent(controller, event.event, event.payload)) {
+              return;
+            }
+          }
+          onFinish?.();
+          closeController(controller);
+          return;
+        }
+
+        for await (
+          const event of streamDataStreamEvents(upstreamBody) as AsyncIterable<AgUiRuntimePart>
+        ) {
+          for (const mapped of mapRuntimeEventToAgUi(state, event)) {
+            prepareToolResultIfNeeded(mapped.event, mapped.payload);
+            if (!enqueueEvent(controller, mapped.event, mapped.payload)) {
+              return;
+            }
+          }
+        }
+
+        for (const event of finalizeRunEvents(state, null)) {
+          if (!enqueueEvent(controller, event.event, event.payload)) {
+            return;
+          }
+        }
+        onFinish?.();
+      } catch (error) {
+        onError?.(error);
+        enqueueEvent(controller, "RunError", {
+          message: error instanceof Error ? error.message : "Agent run failed",
+        });
+      } finally {
+        closeController(controller);
+      }
+    },
+  });
+
+  return new Response(stream, {
+    status: upstreamStatus,
+    statusText: upstreamStatusText,
+    headers: { ...AG_UI_HEADERS },
+  });
+}
+
+async function createAgUiRuntimeDirectStreamResponse(
+  agent: Agent,
+  request: AgUiRuntimeRequest,
+  baseContext: Record<string, unknown>,
+): Promise<Response> {
+  await agent.clearMemory();
+
+  const result = await agent.stream({
+    messages: normalizeAgUiRuntimeMessages(request.messages),
+    context: buildStreamContext(request, baseContext),
+  });
+
+  const upstream = result.toDataStreamResponse();
+  return await createAgUiRuntimeStreamResponse({
+    agentId: agent.id,
+    request,
+    upstreamBody: upstream.body,
+    upstreamStatus: upstream.status,
+    upstreamStatusText: upstream.statusText,
+  });
+}
+
+function createInjectedAgUiTool(
+  runId: string,
+  tool: AgUiRuntimeInjectedTool,
+  sessionManager: RunResumeSessionManager<AgUiResumeValue>,
+): Tool {
+  return {
+    id: tool.name,
+    type: "function",
+    description: tool.description ?? tool.name,
+    inputSchema: z.record(z.string(), z.unknown()),
+    inputSchemaJson: (tool.parameters ??
+      { type: "object", properties: {}, additionalProperties: true }) as Tool["inputSchemaJson"],
+    execute: async (_input, context) => {
+      const toolCallId = typeof context?.toolCallId === "string" ? context.toolCallId : null;
+      if (!toolCallId) {
+        throw new Error(`Missing toolCallId for injected tool "${tool.name}"`);
+      }
+
+      sessionManager.prepareForSignal(runId, toolCallId);
+      const submitted = await sessionManager.waitForSignal(runId, toolCallId);
+      if (submitted.isError) {
+        throw new Error(
+          typeof submitted.result === "string"
+            ? submitted.result
+            : JSON.stringify(submitted.result),
+        );
+      }
+      return submitted.result;
+    },
+  };
+}
+
+function buildMergedTools(
+  agent: Agent,
+  request: AgUiRuntimeRequest,
+  sessionManager: RunResumeSessionManager<AgUiResumeValue>,
+): Agent["config"]["tools"] {
+  const injectedTools = Object.fromEntries(
+    request.tools.map((tool) => [
+      tool.name,
+      createInjectedAgUiTool(request.runId, tool, sessionManager),
+    ]),
+  );
+
+  if (!agent.config.tools) {
+    return Object.keys(injectedTools).length > 0 ? injectedTools : undefined;
+  }
+
+  if (agent.config.tools === true) {
+    const merged: Record<string, Tool | boolean> = {};
+    for (const [toolId] of toolRegistry.getAll()) {
+      if (!agent.config.skills && SKILL_TOOL_IDS.has(toolId)) {
+        continue;
+      }
+      merged[toolId] = true;
+    }
+    return { ...merged, ...injectedTools };
+  }
+
+  return { ...agent.config.tools, ...injectedTools };
+}
+
+async function createAgUiRuntimeInjectedToolsStreamResponse(
+  agent: Agent,
+  request: AgUiRuntimeRequest,
+  baseContext: Record<string, unknown>,
+  sessionManager: RunResumeSessionManager<AgUiResumeValue>,
+): Promise<Response> {
+  try {
+    sessionManager.startRun({ runId: request.runId, threadId: request.threadId });
+  } catch (error) {
+    if (error instanceof RunAlreadyExistsError) {
+      return Response.json({ error: "Run already active" }, { status: 409 });
+    }
+    throw error;
+  }
+
+  const runtime = new AgentRuntime(agent.id, {
+    ...agent.config,
+    tools: buildMergedTools(agent, request, sessionManager),
+  });
+
+  let upstreamBody: ReadableStream<Uint8Array>;
+  try {
+    upstreamBody = await runtime.stream(
+      normalizeAgUiRuntimeMessages(request.messages),
+      buildStreamContext(request, baseContext),
+      undefined,
+      undefined,
+      undefined,
+    );
+  } catch (error) {
+    sessionManager.failRun(request.runId);
+    throw error;
+  }
+
+  return await createAgUiRuntimeStreamResponse({
+    agentId: agent.id,
+    request,
+    upstreamBody,
+    upstreamStatus: 200,
+    onFinish: () => {
+      sessionManager.completeRun(request.runId);
+    },
+    onError: () => {
+      sessionManager.failRun(request.runId);
+    },
+    onToolCallSeen: (toolCallId) => {
+      sessionManager.prepareForSignal(request.runId, toolCallId);
+    },
+  });
+}
+
+export interface AgUiRuntimeHandlerExecuteInput {
+  request: Request;
+  agUiInput: AgUiRuntimeRequest;
+  context: Record<string, unknown>;
+  createDefaultResponse?: () => Promise<Response>;
+}
+
+export type AgUiRuntimeHandlerExecute = (
+  input: AgUiRuntimeHandlerExecuteInput,
+) => Promise<Response> | Response;
+
+export interface AgUiRuntimeHandlerOptions {
+  context?:
+    | Record<string, unknown>
+    | ((request: Request) => Record<string, unknown> | Promise<Record<string, unknown>>);
+  sessionManager?: RunResumeSessionManager<AgUiResumeValue>;
+  execute?: AgUiRuntimeHandlerExecute;
+}
+
+export interface AgUiRuntimeHandlerConfigWithAgent extends AgUiRuntimeHandlerOptions {
+  agent: Agent;
+}
+
+export type AgUiRuntimeHandlerConfig =
+  | AgUiRuntimeHandlerConfigWithAgent
+  | (AgUiRuntimeHandlerOptions & { agent?: undefined; execute: AgUiRuntimeHandlerExecute });
+
+export function createAgUiRuntimeHandler(
+  config: AgUiRuntimeHandlerConfig,
+): (requestOrCtx: unknown) => Promise<Response> {
+  if (!config.agent && !config.execute) {
+    throw new Error(
+      "createAgUiRuntimeHandler requires either an agent or an execute handler.",
+    );
+  }
+
+  return async function POST(requestOrCtx: unknown): Promise<Response> {
+    const request = extractRequest(requestOrCtx);
+
+    try {
+      const parsed = await parseAgUiRuntimeRequestOrError(request);
+      if (parsed instanceof Response) {
+        return parsed;
+      }
+
+      const context = typeof config.context === "function"
+        ? await config.context(request)
+        : config.context ?? {};
+
+      const createDefaultResponse = config.agent
+        ? () =>
+          parsed.tools.length > 0
+            ? config.sessionManager
+              ? createAgUiRuntimeInjectedToolsStreamResponse(
+                config.agent,
+                parsed,
+                context,
+                config.sessionManager,
+              )
+              : Promise.resolve(
+                Response.json(
+                  {
+                    error:
+                      "Injected AG-UI tools require a public RunResumeSessionManager on createAgUiRuntimeHandler().",
+                  },
+                  { status: 501 },
+                ),
+              )
+            : createAgUiRuntimeDirectStreamResponse(config.agent, parsed, context)
+        : undefined;
+
+      if (config.execute) {
+        return await config.execute({
+          request,
+          agUiInput: parsed,
+          context,
+          createDefaultResponse,
+        });
+      }
+
+      if (createDefaultResponse) {
+        return await createDefaultResponse();
+      }
+
+      throw new Error("createAgUiRuntimeHandler configuration became invalid during execution.");
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return Response.json(
+          {
+            error: "Invalid AG-UI runtime request",
+            details: error.issues.map((issue) => ({
+              path: issue.path,
+              message: issue.message,
+            })),
+          },
+          { status: 400 },
+        );
+      }
+
+      return Response.json(
+        {
+          error: error instanceof Error ? error.message : "Internal server error",
+        },
+        { status: 500 },
+      );
+    }
+  };
+}

--- a/src/agent/ag-ui-runtime-support.ts
+++ b/src/agent/ag-ui-runtime-support.ts
@@ -1,0 +1,64 @@
+import type { Message } from "./types.ts";
+import type { AgUiRuntimeRequest } from "./runtime-ag-ui-contract.ts";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseToolArguments(serializedArguments: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(serializedArguments);
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function normalizeAgUiRuntimeMessages(
+  messages: AgUiRuntimeRequest["messages"],
+): Message[] {
+  return messages.map((message) => {
+    const parts: Message["parts"] = [];
+
+    switch (message.role) {
+      case "system":
+      case "user":
+        parts.push({ type: "text", text: message.content });
+        break;
+      case "assistant":
+        if (typeof message.content === "string" && message.content.length > 0) {
+          parts.push({ type: "text", text: message.content });
+        }
+        for (const toolCall of message.toolCalls ?? []) {
+          parts.push({
+            type: "tool-call",
+            toolCallId: toolCall.id,
+            toolName: toolCall.function.name,
+            args: parseToolArguments(toolCall.function.arguments),
+          });
+        }
+        break;
+      case "tool":
+        parts.push({
+          type: "tool-result",
+          toolCallId: message.toolCallId,
+          toolName: "unknown",
+          result: message.error
+            ? {
+              content: message.content,
+              error: message.error,
+            }
+            : message.content,
+        });
+        break;
+    }
+
+    return {
+      id: message.id,
+      role: message.role,
+      parts,
+      ...(message.createdAt ? { timestamp: Date.parse(message.createdAt) || undefined } : {}),
+      ...(message.metadata ? { metadata: message.metadata } : {}),
+    };
+  });
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -140,6 +140,14 @@ export {
 
 export { agent } from "./factory.ts";
 export {
+  type AgUiRuntimeHandlerConfig,
+  type AgUiRuntimeHandlerConfigWithAgent,
+  type AgUiRuntimeHandlerExecute,
+  type AgUiRuntimeHandlerExecuteInput,
+  type AgUiRuntimeHandlerOptions,
+  createAgUiRuntimeHandler,
+} from "./ag-ui-runtime-handler.ts";
+export {
   type AgUiRuntimeContextItem,
   AgUiRuntimeContextItemSchema,
   type AgUiRuntimeInjectedTool,
@@ -151,6 +159,7 @@ export {
   parseAgUiRuntimeRequest,
   parseAgUiRuntimeRequestOrError,
 } from "./runtime-ag-ui-contract.ts";
+export { normalizeAgUiRuntimeMessages } from "./ag-ui-runtime-support.ts";
 export {
   type AgUiBrowserEncodedEvent,
   type AgUiBrowserEncoderState,

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -4,6 +4,7 @@ import {
   type AgentResponse,
   AgentRuntime,
 } from "#veryfront/agent";
+import { normalizeAgUiRuntimeMessages } from "#veryfront/agent/ag-ui-runtime-support.ts";
 import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
 import { type Tool, toolRegistry } from "#veryfront/tool";
 import { z } from "zod";
@@ -120,62 +121,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseToolArguments(serializedArguments: string): Record<string, unknown> {
-  try {
-    const parsed = JSON.parse(serializedArguments);
-    return isRecord(parsed) ? parsed : {};
-  } catch {
-    return {};
-  }
-}
-
-function normalizeRuntimeMessages(messages: RuntimeRunAgentInput["messages"]): Message[] {
-  return messages.map((message) => {
-    const parts: Message["parts"] = [];
-
-    switch (message.role) {
-      case "system":
-      case "user":
-        parts.push({ type: "text", text: message.content });
-        break;
-      case "assistant":
-        if (typeof message.content === "string" && message.content.length > 0) {
-          parts.push({ type: "text", text: message.content });
-        }
-        for (const toolCall of message.toolCalls ?? []) {
-          parts.push({
-            type: "tool-call",
-            toolCallId: toolCall.id,
-            toolName: toolCall.function.name,
-            args: parseToolArguments(toolCall.function.arguments),
-          });
-        }
-        break;
-      case "tool":
-        parts.push({
-          type: "tool-result",
-          toolCallId: message.toolCallId,
-          toolName: "unknown",
-          result: message.error
-            ? {
-              content: message.content,
-              error: message.error,
-            }
-            : message.content,
-        });
-        break;
-    }
-
-    return {
-      id: message.id,
-      role: message.role,
-      parts,
-      ...(message.createdAt ? { timestamp: Date.parse(message.createdAt) || undefined } : {}),
-      ...(message.metadata ? { metadata: message.metadata } : {}),
-    };
-  });
-}
-
 function getAllowedRemoteToolNames(
   forwardedProps: RuntimeRunAgentInput["forwardedProps"],
 ): string[] | undefined {
@@ -226,7 +171,7 @@ export async function createRuntimeAgentStreamResponse(
     new AgentRuntime(runtimeAgent.id, runtimeAgent.config);
 
   let completedResponse: AgentResponse | null = null;
-  const runtimeMessages = normalizeRuntimeMessages(input.messages);
+  const runtimeMessages = normalizeAgUiRuntimeMessages(input.messages);
   let runtimeStream: ReadableStream<Uint8Array>;
   let clientAttached = true;
   try {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.222";
+export const VERSION = "0.1.223";


### PR DESCRIPTION
## Summary
- add a public runtime AG-UI handler for canonical runtime-shaped requests
- add a shared runtime-message normalization helper and reuse it in internal agent streaming
- document the new runtime handler surface and bump the package version to 0.1.223

## Testing
- deno test --no-check --allow-all src/agent/ag-ui-runtime-handler.test.ts src/agent/ag-ui-handler.test.ts src/internal-agents/schema.test.ts
- deno check src/internal-agents/run-stream.ts src/server/handlers/request/agent-stream.handler.ts src/agent/index.ts
- git push -u origin feat/ag-ui-runtime-handler-hooks (pre-push checks passed)