### PR TITLE
Let hosts reuse detached AG-UI start without synthetic requests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.223",
+  "version": "0.1.224",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -30,6 +30,7 @@ import {
   createAgUiRuntimeHandler,
   createAgUiSseErrorResponse,
   createMemory,
+  executeAgUiDetachedStart,
   expandAllowedRemoteToolNames,
   getAgentsAsTools,
   getProviderNativeToolNames,
@@ -575,6 +576,15 @@ Options may provide either:
   while the package still owns request validation, duplicate detection, and
   session-manager lifecycle
 
+### `executeAgUiDetachedStart(options, input)`
+
+Run the detached hosted-start lifecycle from a validated
+`AgUiDetachedStartRequest` object instead of an HTTP request.
+
+Use this when the host already owns outer request parsing/auth and wants the
+package to keep duplicate detection, session-manager lifecycle, and detached
+task orchestration without reserializing through a synthetic `Request`.
+
 ### `createAgUiResumeHandler(options)`
 
 Create a generic POST handler for hosted resumable AG-UI runs.
@@ -645,6 +655,7 @@ Clear all stored messages from memory.
 | `agentAsTool`                    | Wrap agent as callable tool                                             |
 | `createAgUiCancelHandler`        | Create a DELETE handler for hosted AG-UI run cancellation               |
 | `createAgUiDetachedStartHandler` | Create a POST handler for detached hosted AG-UI run kickoff             |
+| `executeAgUiDetachedStart`       | Run detached hosted-start lifecycle from a validated request object     |
 | `createAgUiHandler`              | Create a POST handler for an AG-UI route                                |
 | `createAgUiRuntimeHandler`       | Create a POST handler for the canonical runtime AG-UI request contract  |
 | `createAgUiRunErrorEvent`        | Create a `RunError` AG-UI SSE event                                     |
@@ -701,6 +712,7 @@ Clear all stored messages from memory.
 | `AgUiDetachedStartAccepted`       | Accepted response shape for detached hosted AG-UI kickoff                    |
 | `AgUiDetachedStartHandlerOptions` | Options for `createAgUiDetachedStartHandler`                                 |
 | `AgUiDetachedStartRequest`        | Validated detached hosted AG-UI kickoff request                              |
+| `ExecuteAgUiDetachedStartInput`   | Input shape for `executeAgUiDetachedStart`                                   |
 | `Agent`                           | `agent()` return type                                                        |
 | `AgentConfig`                     | Agent configuration                                                          |
 | `AgentContext`                    | Agent handler context                                                        |

--- a/src/agent/ag-ui-detached-start.test.ts
+++ b/src/agent/ag-ui-detached-start.test.ts
@@ -4,6 +4,7 @@ import {
   AgentRuntime,
   AgUiDetachedStartRequestSchema,
   createAgUiDetachedStartHandler,
+  executeAgUiDetachedStart,
   RunResumeSessionManager,
 } from "./index.ts";
 import type { Agent, Message } from "./types.ts";
@@ -195,6 +196,85 @@ describe("agent/ag-ui-detached-start", () => {
     const payload = await response.json();
     assertExists(payload);
     assertEquals(payload.error, "Invalid AG-UI detached start request");
+  });
+
+  it("starts a detached run from a validated request object", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    let acceptedRunId: string | null = null;
+    let finishedRunId: string | null = null;
+
+    const response = await executeAgUiDetachedStart(
+      {
+        sessionManager,
+        context: { tenant: "acme" },
+        startDetachedExecution: async ({ request, context }) => {
+          assertEquals(request.runId, "run_1");
+          assertEquals(context, { tenant: "acme" });
+        },
+        onAccepted: ({ runId }) => {
+          acceptedRunId = runId;
+        },
+        onFinish: ({ runId }) => {
+          finishedRunId = runId;
+        },
+      },
+      {
+        request: AgUiDetachedStartRequestSchema.parse({
+          runId: "run_1",
+          threadId: crypto.randomUUID(),
+          messages: [{
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          }],
+        }),
+      },
+    );
+
+    assertEquals(response.status, 202);
+    assertEquals(acceptedRunId, "run_1");
+    await flushAsyncWork();
+    assertEquals(finishedRunId, "run_1");
+    assertEquals(sessionManager.getRunStatus("run_1"), null);
+  });
+
+  it("returns duplicate=true from a validated request object when the run is already active", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    const threadId = crypto.randomUUID();
+    sessionManager.startRun({ runId: "run_1", threadId });
+
+    const response = await executeAgUiDetachedStart(
+      {
+        sessionManager,
+        startDetachedExecution: async () => {},
+      },
+      {
+        request: AgUiDetachedStartRequestSchema.parse({
+          runId: "run_1",
+          threadId,
+          messages: [{
+            id: "msg-1",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          }],
+        }),
+      },
+    );
+
+    assertEquals(response.status, 202);
+    assertEquals(await response.json(), {
+      accepted: true,
+      duplicate: true,
+      runId: "run_1",
+      threadId,
+    });
+    sessionManager.cancelRun("run_1");
   });
 
   it("supports injected client tools in detached runs", async () => {

--- a/src/agent/ag-ui-detached-start.test.ts
+++ b/src/agent/ag-ui-detached-start.test.ts
@@ -231,6 +231,10 @@ describe("agent/ag-ui-detached-start", () => {
             parts: [{ type: "text", text: "hello" }],
           }],
         }),
+        rawRequest: new Request("http://localhost/api/ag-ui/runs", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        }),
       },
     );
 
@@ -264,6 +268,10 @@ describe("agent/ag-ui-detached-start", () => {
             parts: [{ type: "text", text: "hello" }],
           }],
         }),
+        rawRequest: new Request("http://localhost/api/ag-ui/runs", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        }),
       },
     );
 
@@ -275,6 +283,40 @@ describe("agent/ag-ui-detached-start", () => {
       threadId,
     });
     sessionManager.cancelRun("run_1");
+  });
+
+  it("fails fast when a host starter is used without a rawRequest", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+
+    try {
+      await executeAgUiDetachedStart(
+        {
+          sessionManager,
+          startDetachedExecution: async () => {},
+        },
+        {
+          request: AgUiDetachedStartRequestSchema.parse({
+            runId: "run_1",
+            threadId: crypto.randomUUID(),
+            messages: [{
+              id: "msg-1",
+              role: "user",
+              parts: [{ type: "text", text: "hello" }],
+            }],
+          }),
+        },
+      );
+      throw new Error("Expected executeAgUiDetachedStart to require rawRequest");
+    } catch (error) {
+      assertStringIncludes(
+        error instanceof Error ? error.message : String(error),
+        "executeAgUiDetachedStart requires rawRequest when options.startDetachedExecution is used.",
+      );
+    }
+    assertEquals(sessionManager.getRunStatus("run_1"), null);
   });
 
   it("supports injected client tools in detached runs", async () => {

--- a/src/agent/ag-ui-detached-start.ts
+++ b/src/agent/ag-ui-detached-start.ts
@@ -263,10 +263,29 @@ async function resolveDetachedStartContext(
   return options.context;
 }
 
+function assertDetachedStartRawRequest(
+  options: AgUiDetachedStartHandlerOptions,
+  input: ExecuteAgUiDetachedStartInput,
+): Request | undefined {
+  if (!options.startDetachedExecution) {
+    return input.rawRequest;
+  }
+
+  if (input.rawRequest) {
+    return input.rawRequest;
+  }
+
+  throw INVALID_ARGUMENT.create({
+    detail:
+      "executeAgUiDetachedStart requires rawRequest when options.startDetachedExecution is used.",
+  });
+}
+
 export async function executeAgUiDetachedStart(
   options: AgUiDetachedStartHandlerOptions,
   input: ExecuteAgUiDetachedStartInput,
 ): Promise<Response> {
+  const rawRequest = assertDetachedStartRawRequest(options, input);
   const context = await resolveDetachedStartContext(options, input);
 
   try {
@@ -287,12 +306,7 @@ export async function executeAgUiDetachedStart(
           await options.startDetachedExecution({
             request: input.request,
             requestOrCtx: input.requestOrCtx,
-            rawRequest: input.rawRequest ??
-              new Request("http://localhost/api/ag-ui/runs", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(input.request),
-              }),
+            rawRequest: rawRequest!,
             context,
             abortSignal,
           });

--- a/src/agent/ag-ui-detached-start.ts
+++ b/src/agent/ag-ui-detached-start.ts
@@ -133,17 +133,6 @@ function buildMergedTools(
   return { ...agent.config.tools, ...injectedTools };
 }
 
-async function resolveContextValue(
-  value: AgUiContextValue | undefined,
-  request: Request,
-): Promise<Record<string, unknown>> {
-  if (typeof value === "function") {
-    return await value(request);
-  }
-
-  return value ?? {};
-}
-
 function scheduleDetachedTask(requestOrCtx: unknown, task: Promise<void>): void {
   if (
     typeof requestOrCtx === "object" &&
@@ -180,6 +169,13 @@ export const AgUiDetachedStartAcceptedSchema = z.object({
 
 export type AgUiDetachedStartRequest = z.infer<typeof AgUiDetachedStartRequestSchema>;
 export type AgUiDetachedStartAccepted = z.infer<typeof AgUiDetachedStartAcceptedSchema>;
+
+export interface ExecuteAgUiDetachedStartInput {
+  request: AgUiDetachedStartRequest;
+  rawRequest?: Request;
+  requestOrCtx?: unknown;
+  context?: Record<string, unknown>;
+}
 
 interface AgUiDetachedStartExecutionInput {
   request: AgUiDetachedStartRequest;
@@ -242,6 +238,128 @@ async function startDefaultDetachedExecution(input: {
   await drainRuntimeStream(runtimeStream);
 }
 
+async function resolveDetachedStartContext(
+  options: AgUiDetachedStartHandlerOptions,
+  input: ExecuteAgUiDetachedStartInput,
+): Promise<Record<string, unknown>> {
+  if (input.context) {
+    return input.context;
+  }
+
+  if (!options.context) {
+    return {};
+  }
+
+  if (typeof options.context === "function") {
+    if (!input.rawRequest) {
+      throw INVALID_ARGUMENT.create({
+        detail: "executeAgUiDetachedStart requires rawRequest when options.context is a function.",
+      });
+    }
+
+    return await options.context(input.rawRequest);
+  }
+
+  return options.context;
+}
+
+export async function executeAgUiDetachedStart(
+  options: AgUiDetachedStartHandlerOptions,
+  input: ExecuteAgUiDetachedStartInput,
+): Promise<Response> {
+  const context = await resolveDetachedStartContext(options, input);
+
+  try {
+    const abortSignal = options.sessionManager.startRun({
+      runId: input.request.runId,
+      threadId: input.request.threadId,
+    });
+
+    await options.onAccepted?.({
+      request: input.request,
+      runId: input.request.runId,
+      threadId: input.request.threadId,
+    });
+
+    const detachedTask = (async () => {
+      try {
+        if (options.startDetachedExecution) {
+          await options.startDetachedExecution({
+            request: input.request,
+            requestOrCtx: input.requestOrCtx,
+            rawRequest: input.rawRequest ??
+              new Request("http://localhost/api/ag-ui/runs", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(input.request),
+              }),
+            context,
+            abortSignal,
+          });
+        } else if (options.agent) {
+          await startDefaultDetachedExecution({
+            agent: options.agent,
+            request: input.request,
+            context,
+            abortSignal,
+            sessionManager: options.sessionManager,
+          });
+        } else {
+          throw new Error(
+            "Detached AG-UI start configuration became invalid during execution.",
+          );
+        }
+
+        options.sessionManager.completeRun(input.request.runId);
+        await options.onFinish?.({
+          runId: input.request.runId,
+          threadId: input.request.threadId,
+        });
+      } catch (error) {
+        options.sessionManager.failRun(input.request.runId);
+        await options.onError?.({
+          runId: input.request.runId,
+          threadId: input.request.threadId,
+          error,
+        });
+      }
+    })().catch(() => undefined);
+
+    scheduleDetachedTask(input.requestOrCtx, detachedTask);
+
+    return Response.json(
+      {
+        accepted: true,
+        duplicate: false,
+        runId: input.request.runId,
+        threadId: input.request.threadId,
+      } satisfies AgUiDetachedStartAccepted,
+      { status: 202 },
+    );
+  } catch (error) {
+    if (error instanceof RunAlreadyExistsError) {
+      await options.onDuplicate?.({
+        request: input.request,
+        runId: input.request.runId,
+        threadId: input.request.threadId,
+      });
+
+      return Response.json(
+        {
+          accepted: true,
+          duplicate: true,
+          runId: input.request.runId,
+          threadId: input.request.threadId,
+        } satisfies AgUiDetachedStartAccepted,
+        { status: 202 },
+      );
+    }
+
+    options.sessionManager.failRun(input.request.runId);
+    throw error;
+  }
+}
+
 export function createAgUiDetachedStartHandler(
   options: AgUiDetachedStartHandlerOptions,
 ): (requestOrCtx: unknown) => Promise<Response> {
@@ -256,92 +374,11 @@ export function createAgUiDetachedStartHandler(
 
     try {
       const parsed = AgUiDetachedStartRequestSchema.parse(await request.json());
-      const context = await resolveContextValue(options.context, request);
-
-      try {
-        const abortSignal = options.sessionManager.startRun({
-          runId: parsed.runId,
-          threadId: parsed.threadId,
-        });
-
-        await options.onAccepted?.({
-          request: parsed,
-          runId: parsed.runId,
-          threadId: parsed.threadId,
-        });
-
-        const detachedTask = (async () => {
-          try {
-            if (options.startDetachedExecution) {
-              await options.startDetachedExecution({
-                request: parsed,
-                requestOrCtx,
-                rawRequest: request,
-                context,
-                abortSignal,
-              });
-            } else if (options.agent) {
-              await startDefaultDetachedExecution({
-                agent: options.agent,
-                request: parsed,
-                context,
-                abortSignal,
-                sessionManager: options.sessionManager,
-              });
-            } else {
-              throw new Error(
-                "Detached AG-UI start configuration became invalid during execution.",
-              );
-            }
-
-            options.sessionManager.completeRun(parsed.runId);
-            await options.onFinish?.({
-              runId: parsed.runId,
-              threadId: parsed.threadId,
-            });
-          } catch (error) {
-            options.sessionManager.failRun(parsed.runId);
-            await options.onError?.({
-              runId: parsed.runId,
-              threadId: parsed.threadId,
-              error,
-            });
-          }
-        })().catch(() => undefined);
-
-        scheduleDetachedTask(requestOrCtx, detachedTask);
-
-        return Response.json(
-          {
-            accepted: true,
-            duplicate: false,
-            runId: parsed.runId,
-            threadId: parsed.threadId,
-          } satisfies AgUiDetachedStartAccepted,
-          { status: 202 },
-        );
-      } catch (error) {
-        if (error instanceof RunAlreadyExistsError) {
-          await options.onDuplicate?.({
-            request: parsed,
-            runId: parsed.runId,
-            threadId: parsed.threadId,
-          });
-
-          return Response.json(
-            {
-              accepted: true,
-              duplicate: true,
-              runId: parsed.runId,
-              threadId: parsed.threadId,
-            } satisfies AgUiDetachedStartAccepted,
-            { status: 202 },
-          );
-        }
-
-        options.sessionManager.failRun(parsed.runId);
-        throw error;
-      }
+      return await executeAgUiDetachedStart(options, {
+        request: parsed,
+        rawRequest: request,
+        requestOrCtx,
+      });
     } catch (error) {
       if (error instanceof z.ZodError) {
         return Response.json(

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -189,6 +189,8 @@ export {
   type AgUiDetachedStartRequest,
   AgUiDetachedStartRequestSchema,
   createAgUiDetachedStartHandler,
+  executeAgUiDetachedStart,
+  type ExecuteAgUiDetachedStartInput,
 } from "./ag-ui-detached-start.ts";
 export {
   type AgUiCancelHandlerOptions,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.223";
+export const VERSION = "0.1.224";


### PR DESCRIPTION
## Summary
- add a typed detached-start executor for validated AG-UI kickoff payloads
- keep the handler path and direct object path on the same detached lifecycle implementation
- bump the package version to 0.1.224 and document the new helper

## Testing
- deno test --no-check --allow-all src/agent/ag-ui-detached-start.test.ts src/agent/ag-ui-handler.test.ts src/internal-agents/schema.test.ts
- deno check src/agent/index.ts src/agent/ag-ui-detached-start.ts
- git push -u origin feat/ag-ui-detached-start-executor (pre-push checks passed)