### PR TITLE
Expose hosted AG-UI lifecycle callbacks

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.224",
+  "version": "0.1.225",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent-runtime-ag-ui.md
+++ b/docs/reference/agent-runtime-ag-ui.md
@@ -107,6 +107,14 @@ This helper layer is intentionally narrower than `createAgUiHandler()`:
 - the package owns AG-UI request validation/normalization
 - the host still owns auth, project access, and runtime preparation
 
+For canonical runtime AG-UI hosts using `createAgUiRuntimeHandler()`, the
+package can also invoke optional lifecycle callbacks when the default hosted
+stream path sees tool calls, finishes, or fails:
+
+- `onToolCallSeen`
+- `onFinish`
+- `onError`
+
 ## Convenience Request Shape
 
 `AgUiRequestSchema` accepts:

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -545,6 +545,8 @@ This handler:
 - can stream directly through a package `agent`
 - can hand off to a host-provided `execute` callback for custom auth,
   preparation, or execution while keeping package-owned runtime-request parsing
+- can notify host lifecycle callbacks (`onToolCallSeen`, `onFinish`, `onError`)
+  while the package still owns the default AG-UI stream path
 
 ### `AgUiResumeSignalSchema`
 

--- a/src/agent/ag-ui-runtime-handler.test.ts
+++ b/src/agent/ag-ui-runtime-handler.test.ts
@@ -1,6 +1,8 @@
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { RunResumeSessionManager } from "./index.ts";
 import { createAgUiRuntimeHandler } from "./ag-ui-runtime-handler.ts";
+import { AgentRuntime } from "./runtime/index.ts";
 import type { Agent, Message } from "./types.ts";
 
 const encoder = new TextEncoder();
@@ -177,6 +179,315 @@ describe("agent/ag-ui-runtime-handler", () => {
       runId: "run_runtime_2",
       messageCount: 1,
     });
+  });
+
+  it("calls runtime lifecycle hooks for direct hosted AG-UI streams", async () => {
+    const testAgent = createTestAgent();
+    const threadId = crypto.randomUUID();
+    let finishedRunId: string | undefined;
+    let seenToolCallId: string | undefined;
+
+    testAgent.agent.stream = async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            encodeDataStreamEvent({ type: "message-start", messageId: "assistant-msg-1" }),
+          );
+          controller.enqueue(
+            encodeDataStreamEvent({
+              type: "tool-input-start",
+              toolCallId: "tool-call-42",
+              toolName: "client_confirm",
+            }),
+          );
+          controller.enqueue(
+            encodeDataStreamEvent({
+              type: "tool-input-delta",
+              toolCallId: "tool-call-42",
+              inputTextDelta: '{"approved":true}',
+            }),
+          );
+          controller.enqueue(
+            encodeDataStreamEvent({
+              type: "tool-input-available",
+              toolCallId: "tool-call-42",
+            }),
+          );
+          controller.close();
+        },
+      });
+
+      return {
+        toDataStreamResponse: () =>
+          new Response(stream, {
+            headers: { "Content-Type": "text/event-stream" },
+          }),
+      };
+    };
+
+    const handler = createAgUiRuntimeHandler({
+      agent: testAgent.agent,
+      onToolCallSeen: ({ request, toolCallId }) => {
+        finishedRunId = request.runId;
+        seenToolCallId = toolCallId;
+      },
+      onFinish: ({ request }) => {
+        finishedRunId = request.runId;
+      },
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          threadId,
+          runId: "run_runtime_hooks_1",
+          messages: [{ id: "user-1", role: "user", content: "Hello" }],
+        }),
+      }),
+    );
+
+    assertEquals(response.status, 200);
+    await response.text();
+    assertEquals(finishedRunId, "run_runtime_hooks_1");
+    assertEquals(seenToolCallId, "tool-call-42");
+  });
+
+  it("calls onError when the runtime AG-UI stream fails", async () => {
+    const testAgent = createTestAgent();
+    const threadId = crypto.randomUUID();
+    let seenRunId: string | undefined;
+    let seenError: string | undefined;
+
+    testAgent.agent.stream = async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            encodeDataStreamEvent({ type: "message-start", messageId: "assistant-msg-1" }),
+          );
+          controller.error(new Error("runtime stream exploded"));
+        },
+      });
+
+      return {
+        toDataStreamResponse: () =>
+          new Response(stream, {
+            headers: { "Content-Type": "text/event-stream" },
+          }),
+      };
+    };
+
+    const handler = createAgUiRuntimeHandler({
+      agent: testAgent.agent,
+      onError: ({ request, error }) => {
+        seenRunId = request.runId;
+        seenError = error instanceof Error ? error.message : String(error);
+      },
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          threadId,
+          runId: "run_runtime_hooks_2",
+          messages: [{ id: "user-1", role: "user", content: "Hello" }],
+        }),
+      }),
+    );
+
+    assertEquals(response.status, 200);
+    const body = await response.text();
+    assertStringIncludes(body, "event: RunError");
+    assertEquals(seenRunId, "run_runtime_hooks_2");
+    assertEquals(seenError, "runtime stream exploded");
+  });
+
+  it("swallows rejected lifecycle callback promises during normal streaming", async () => {
+    const testAgent = createTestAgent();
+    const threadId = crypto.randomUUID();
+    const handler = createAgUiRuntimeHandler({
+      agent: testAgent.agent,
+      onFinish: async () => {
+        throw new Error("telemetry exploded");
+      },
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          threadId,
+          runId: "run_runtime_hooks_3",
+          messages: [{ id: "user-1", role: "user", content: "Hello" }],
+        }),
+      }),
+    );
+
+    assertEquals(response.status, 200);
+    const body = await response.text();
+    assertStringIncludes(body, "event: RunFinished");
+  });
+
+  it("calls onError when direct hosted stream setup fails before a stream exists", async () => {
+    const testAgent = createTestAgent();
+    const threadId = crypto.randomUUID();
+    let seenRunId: string | undefined;
+    let seenError: string | undefined;
+
+    testAgent.agent.clearMemory = async () => {
+      throw new Error("clearMemory exploded");
+    };
+
+    const handler = createAgUiRuntimeHandler({
+      agent: testAgent.agent,
+      onError: ({ request, error }) => {
+        seenRunId = request.runId;
+        seenError = error instanceof Error ? error.message : String(error);
+      },
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          threadId,
+          runId: "run_runtime_hooks_4",
+          messages: [{ id: "user-1", role: "user", content: "Hello" }],
+        }),
+      }),
+    );
+
+    assertEquals(response.status, 500);
+    assertEquals(await response.json(), { error: "clearMemory exploded" });
+    assertEquals(seenRunId, "run_runtime_hooks_4");
+    assertEquals(seenError, "clearMemory exploded");
+  });
+
+  it("forwards lifecycle callbacks through the injected-tools runtime path", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    const originalStream = AgentRuntime.prototype.stream;
+    let seenToolCallId: string | undefined;
+    let finishedRunId: string | undefined;
+
+    AgentRuntime.prototype.stream = async function (
+      messages,
+      context,
+    ): Promise<ReadableStream<Uint8Array>> {
+      const runtimeConfig = this as unknown as {
+        config: {
+          tools?: Record<string, {
+            execute: (
+              input: Record<string, unknown>,
+              context?: { toolCallId?: string },
+            ) => Promise<unknown>;
+          }>;
+        };
+      };
+
+      const injectedTool = runtimeConfig.config.tools?.client_confirm;
+      if (!injectedTool) {
+        throw new Error("Expected injected tool to be merged into the runtime config");
+      }
+
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          void (async () => {
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "message-start",
+                messageId: "assistant-msg-1",
+              }),
+            );
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "tool-input-start",
+                toolCallId: "tool-call-1",
+                toolName: "client_confirm",
+              }),
+            );
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "tool-input-delta",
+                toolCallId: "tool-call-1",
+                inputTextDelta: '{"approved":true}',
+              }),
+            );
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "tool-input-available",
+                toolCallId: "tool-call-1",
+              }),
+            );
+
+            const result = await injectedTool.execute(
+              { approved: true },
+              { toolCallId: "tool-call-1" },
+            );
+
+            controller.enqueue(
+              encodeDataStreamEvent({
+                type: "tool-output-available",
+                toolCallId: "tool-call-1",
+                output: result,
+              }),
+            );
+            controller.close();
+          })();
+        },
+      });
+
+      assertEquals(messages[0]?.role, "user");
+      assertEquals(context?.runId, "run_runtime_4");
+      return stream;
+    };
+
+    try {
+      const handler = createAgUiRuntimeHandler({
+        agent: createTestAgent().agent,
+        sessionManager,
+        onToolCallSeen: ({ toolCallId }) => {
+          seenToolCallId = toolCallId;
+        },
+        onFinish: ({ request }) => {
+          finishedRunId = request.runId;
+        },
+      });
+
+      const response = await handler(
+        new Request("http://localhost/api/ag-ui", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            threadId: crypto.randomUUID(),
+            runId: "run_runtime_4",
+            messages: [{ id: "msg-1", role: "user", content: "hello" }],
+            tools: [{ name: "client_confirm" }],
+          }),
+        }),
+      );
+
+      const bodyPromise = response.text();
+      const submitOutcome = sessionManager.submitSignal("run_runtime_4", {
+        waitKey: "tool-call-1",
+        value: { result: { approved: true }, isError: false },
+      });
+      assertEquals(submitOutcome, { accepted: true });
+
+      const body = await bodyPromise;
+      assertStringIncludes(body, "event: ToolCallStart");
+      assertEquals(seenToolCallId, "tool-call-1");
+      assertEquals(finishedRunId, "run_runtime_4");
+    } finally {
+      AgentRuntime.prototype.stream = originalStream;
+    }
   });
 
   it("requires a session manager when injected runtime tools are present and the default path is used", async () => {

--- a/src/agent/ag-ui-runtime-handler.ts
+++ b/src/agent/ag-ui-runtime-handler.ts
@@ -31,6 +31,39 @@ const AG_UI_HEADERS: Record<string, string> = {
 type AgUiResumeValue = { result: unknown; isError: boolean };
 type AgUiRuntimePart = Record<string, unknown> & { type: string };
 
+export interface AgUiRuntimeLifecycleContext {
+  request: AgUiRuntimeRequest;
+  toolCallId?: string;
+  error?: unknown;
+}
+
+function invokeLifecycleCallback(
+  callback: ((context: AgUiRuntimeLifecycleContext) => Promise<void> | void) | undefined,
+  context: AgUiRuntimeLifecycleContext,
+): void {
+  if (!callback) return;
+
+  try {
+    const result = callback(context);
+    void Promise.resolve(result).catch(() => undefined);
+  } catch {
+    return;
+  }
+}
+
+async function invokeLifecycleCallbackAndWait(
+  callback: ((context: AgUiRuntimeLifecycleContext) => Promise<void> | void) | undefined,
+  context: AgUiRuntimeLifecycleContext,
+): Promise<void> {
+  if (!callback) return;
+
+  try {
+    await callback(context);
+  } catch {
+    return;
+  }
+}
+
 function isRequest(obj: unknown): obj is Request {
   return (
     typeof obj === "object" &&
@@ -212,6 +245,11 @@ async function createAgUiRuntimeDirectStreamResponse(
   agent: Agent,
   request: AgUiRuntimeRequest,
   baseContext: Record<string, unknown>,
+  lifecycle?: {
+    onFinish?: () => Promise<void> | void;
+    onError?: (error: unknown) => Promise<void> | void;
+    onToolCallSeen?: (toolCallId: string) => Promise<void> | void;
+  },
 ): Promise<Response> {
   await agent.clearMemory();
 
@@ -227,6 +265,9 @@ async function createAgUiRuntimeDirectStreamResponse(
     upstreamBody: upstream.body,
     upstreamStatus: upstream.status,
     upstreamStatusText: upstream.statusText,
+    onFinish: lifecycle?.onFinish,
+    onError: lifecycle?.onError,
+    onToolCallSeen: lifecycle?.onToolCallSeen,
   });
 }
 
@@ -297,6 +338,11 @@ async function createAgUiRuntimeInjectedToolsStreamResponse(
   request: AgUiRuntimeRequest,
   baseContext: Record<string, unknown>,
   sessionManager: RunResumeSessionManager<AgUiResumeValue>,
+  lifecycle?: {
+    onFinish?: () => Promise<void> | void;
+    onError?: (error: unknown) => Promise<void> | void;
+    onToolCallSeen?: (toolCallId: string) => Promise<void> | void;
+  },
 ): Promise<Response> {
   try {
     sessionManager.startRun({ runId: request.runId, threadId: request.threadId });
@@ -333,12 +379,15 @@ async function createAgUiRuntimeInjectedToolsStreamResponse(
     upstreamStatus: 200,
     onFinish: () => {
       sessionManager.completeRun(request.runId);
+      void lifecycle?.onFinish?.();
     },
-    onError: () => {
+    onError: (error) => {
       sessionManager.failRun(request.runId);
+      void lifecycle?.onError?.(error);
     },
     onToolCallSeen: (toolCallId) => {
       sessionManager.prepareForSignal(request.runId, toolCallId);
+      void lifecycle?.onToolCallSeen?.(toolCallId);
     },
   });
 }
@@ -360,6 +409,9 @@ export interface AgUiRuntimeHandlerOptions {
     | ((request: Request) => Record<string, unknown> | Promise<Record<string, unknown>>);
   sessionManager?: RunResumeSessionManager<AgUiResumeValue>;
   execute?: AgUiRuntimeHandlerExecute;
+  onToolCallSeen?: (context: AgUiRuntimeLifecycleContext) => Promise<void> | void;
+  onFinish?: (context: AgUiRuntimeLifecycleContext) => Promise<void> | void;
+  onError?: (context: AgUiRuntimeLifecycleContext) => Promise<void> | void;
 }
 
 export interface AgUiRuntimeHandlerConfigWithAgent extends AgUiRuntimeHandlerOptions {
@@ -414,17 +466,72 @@ export function createAgUiRuntimeHandler(
             : createAgUiRuntimeDirectStreamResponse(config.agent, parsed, context)
         : undefined;
 
+      const invokeLifecycle = (
+        type: "onFinish" | "onError" | "onToolCallSeen",
+        extra: Partial<AgUiRuntimeLifecycleContext> = {},
+      ): void => {
+        invokeLifecycleCallback(config[type], {
+          request: parsed,
+          ...extra,
+        });
+      };
+
+      const createDefaultResponseWithLifecycle = createDefaultResponse
+        ? async () => {
+          try {
+            if (!config.agent) {
+              return await createDefaultResponse();
+            }
+
+            if (parsed.tools.length > 0) {
+              if (!config.sessionManager) {
+                return await createDefaultResponse();
+              }
+
+              return await createAgUiRuntimeInjectedToolsStreamResponse(
+                config.agent,
+                parsed,
+                context,
+                config.sessionManager,
+                {
+                  onFinish: () => invokeLifecycle("onFinish"),
+                  onError: (error) => invokeLifecycle("onError", { error }),
+                  onToolCallSeen: (toolCallId) => invokeLifecycle("onToolCallSeen", { toolCallId }),
+                },
+              );
+            }
+
+            return await createAgUiRuntimeDirectStreamResponse(
+              config.agent,
+              parsed,
+              context,
+              {
+                onFinish: () => invokeLifecycle("onFinish"),
+                onError: (error) => invokeLifecycle("onError", { error }),
+                onToolCallSeen: (toolCallId) => invokeLifecycle("onToolCallSeen", { toolCallId }),
+              },
+            );
+          } catch (error) {
+            await invokeLifecycleCallbackAndWait(config.onError, {
+              request: parsed,
+              error,
+            });
+            throw error;
+          }
+        }
+        : undefined;
+
       if (config.execute) {
         return await config.execute({
           request,
           agUiInput: parsed,
           context,
-          createDefaultResponse,
+          createDefaultResponse: createDefaultResponseWithLifecycle,
         });
       }
 
-      if (createDefaultResponse) {
-        return await createDefaultResponse();
+      if (createDefaultResponseWithLifecycle) {
+        return await createDefaultResponseWithLifecycle();
       }
 
       throw new Error("createAgUiRuntimeHandler configuration became invalid during execution.");

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -145,6 +145,7 @@ export {
   type AgUiRuntimeHandlerExecute,
   type AgUiRuntimeHandlerExecuteInput,
   type AgUiRuntimeHandlerOptions,
+  type AgUiRuntimeLifecycleContext,
   createAgUiRuntimeHandler,
 } from "./ag-ui-runtime-handler.ts";
 export {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.224";
+export const VERSION = "0.1.225";


### PR DESCRIPTION
## Summary
- add hosted runtime-handler lifecycle callbacks for tool-call, finish, and error observation
- keep the default AG-UI runtime stream path package-owned while letting hosts observe lifecycle milestones
- document the new callbacks and bump the package version to 0.1.225

## Testing
- deno test --no-check --allow-all src/agent/ag-ui-runtime-handler.test.ts
- deno check src/agent/ag-ui-runtime-handler.ts src/agent/index.ts
