### PR TITLE
Add a generic AG-UI browser response stream helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.225",
+  "version": "0.1.226",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent-runtime-ag-ui.md
+++ b/docs/reference/agent-runtime-ag-ui.md
@@ -107,6 +107,11 @@ This helper layer is intentionally narrower than `createAgUiHandler()`:
 - the package owns AG-UI request validation/normalization
 - the host still owns auth, project access, and runtime preparation
 
+Hosts that keep a custom execute path can also use
+`createAgUiBrowserResponseStream()` to emit the same bootstrap AG-UI SSE
+framing (`RunStarted`, `StateSnapshot`, `MessagesSnapshot`) while supplying a
+host-local encoder for their own chunk type.
+
 For canonical runtime AG-UI hosts using `createAgUiRuntimeHandler()`, the
 package can also invoke optional lifecycle callbacks when the default hosted
 stream path sees tool calls, finishes, or fails:

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -534,6 +534,12 @@ request or a `400` JSON `Response` when validation fails.
 Normalize canonical runtime AG-UI `messages` into the package `Message[]`
 shape used by `agent.stream()` and `AgentRuntime.stream()`.
 
+### `createAgUiBrowserResponseStream(input)`
+
+Create a host-facing AG-UI SSE stream for custom execution pipelines when the
+host already owns its own chunk type but wants to reuse package browser-event
+framing and bootstrap event conventions.
+
 ### `createAgUiRuntimeHandler(config)`
 
 Create a POST route handler for the canonical runtime AG-UI request contract.

--- a/src/agent/ag-ui-browser-response-stream.test.ts
+++ b/src/agent/ag-ui-browser-response-stream.test.ts
@@ -1,0 +1,141 @@
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createAgUiBrowserResponseStream } from "./ag-ui-browser-response-stream.ts";
+import type { AgUiSseEvent } from "./ag-ui-host-support.ts";
+
+async function collectStreamText(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalLength = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    totalLength += value.byteLength;
+  }
+
+  const merged = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return new TextDecoder().decode(merged);
+}
+
+describe("agent/ag-ui-browser-response-stream", () => {
+  it("writes bootstrap events, encoded chunk events, and finalize events", async () => {
+    const stream = createAgUiBrowserResponseStream({
+      agUiInput: {
+        runId: "run-1",
+        threadId: "thread-1",
+        state: { step: "draft" },
+        messages: [{ id: "user-1", role: "user" }],
+      },
+      agentId: "assistant-1",
+      execution: {
+        agentUIStream: {
+          async *[Symbol.asyncIterator]() {
+            yield { type: "chunk", delta: "hello" };
+          },
+        },
+        fail: async () => {},
+        waitForFinish: async () => {},
+      },
+      encoder: {
+        encode: (chunk): AgUiSseEvent[] => [{
+          event: "TextMessageContent",
+          payload: { delta: String((chunk as { delta: string }).delta) },
+        }],
+        finalize: () => [{ event: "RunFinished", payload: { metadata: {} } }],
+      },
+      initialState: { seenDeltas: [] as string[] },
+      onChunk: (state, chunk) => {
+        state.seenDeltas.push((chunk as { delta: string }).delta);
+      },
+      getFinalResponse: () => null,
+    });
+
+    const text = await collectStreamText(stream);
+    assertStringIncludes(text, "event: RunStarted");
+    assertStringIncludes(text, "event: StateSnapshot");
+    assertStringIncludes(text, "event: MessagesSnapshot");
+    assertStringIncludes(text, "event: TextMessageContent");
+    assertStringIncludes(text, "event: RunFinished");
+  });
+
+  it("emits RunError and swallows execution.fail rejections", async () => {
+    const stream = createAgUiBrowserResponseStream({
+      agUiInput: {
+        runId: "run-2",
+        threadId: "thread-2",
+        messages: [],
+      },
+      agentId: "assistant-1",
+      execution: {
+        agentUIStream: {
+          [Symbol.asyncIterator]() {
+            return {
+              next: async () => {
+                throw new Error("stream exploded");
+              },
+            };
+          },
+        },
+        fail: async () => {
+          throw new Error("fail exploded");
+        },
+        waitForFinish: async () => {},
+      },
+      encoder: {
+        encode: () => [],
+        finalize: () => [],
+      },
+      initialState: {},
+    });
+
+    const text = await collectStreamText(stream);
+    assertStringIncludes(text, "event: RunError");
+    assertStringIncludes(text, "stream exploded");
+  });
+
+  it("passes accumulated state into getFinalResponse", async () => {
+    let finalSeen: string[] | undefined;
+
+    const stream = createAgUiBrowserResponseStream({
+      agUiInput: {
+        runId: "run-3",
+        threadId: "thread-3",
+        messages: [],
+      },
+      agentId: "assistant-1",
+      execution: {
+        agentUIStream: {
+          async *[Symbol.asyncIterator]() {
+            yield { type: "chunk", delta: "a" };
+            yield { type: "chunk", delta: "b" };
+          },
+        },
+        fail: async () => {},
+        waitForFinish: async () => {},
+      },
+      encoder: {
+        encode: () => [],
+        finalize: () => [],
+      },
+      initialState: { seen: [] as string[] },
+      onChunk: (state, chunk) => {
+        state.seen.push((chunk as { delta: string }).delta);
+      },
+      getFinalResponse: (state) => {
+        finalSeen = [...state.seen];
+        return null;
+      },
+    });
+
+    await collectStreamText(stream);
+    assertEquals(finalSeen, ["a", "b"]);
+  });
+});

--- a/src/agent/ag-ui-browser-response-stream.ts
+++ b/src/agent/ag-ui-browser-response-stream.ts
@@ -1,0 +1,142 @@
+import type { AgentResponse } from "./types.ts";
+import type { AgUiSseEvent } from "./ag-ui-host-support.ts";
+
+const encoder = new TextEncoder();
+
+function formatAgUiSseEventWithId(event: AgUiSseEvent, eventId: number | null): Uint8Array {
+  const idLine = eventId === null ? "" : `id: ${eventId}\n`;
+  return encoder.encode(
+    `${idLine}event: ${event.event}\ndata: ${JSON.stringify(event.payload)}\n\n`,
+  );
+}
+
+function invokeFailWithoutLeaking(
+  fail: (error: unknown) => Promise<void>,
+  error: unknown,
+): Promise<void> {
+  return fail(error).catch(() => undefined);
+}
+
+export interface AgUiBrowserResponseRequestState {
+  runId?: string;
+  threadId?: string;
+  state?: unknown;
+  messages: unknown[];
+}
+
+export interface AgUiBrowserResponseExecution<TChunk> {
+  agentUIStream: AsyncIterable<TChunk>;
+  fail: (error: unknown) => Promise<void>;
+  waitForFinish: () => Promise<void>;
+}
+
+export interface AgUiBrowserResponseEncoder<TChunk> {
+  encode: (chunk: TChunk) => AgUiSseEvent[];
+  finalize: (response: AgentResponse | null) => AgUiSseEvent[];
+}
+
+export interface CreateAgUiBrowserResponseStreamInput<TChunk, TState> {
+  agUiInput: AgUiBrowserResponseRequestState;
+  agentId: string;
+  execution: AgUiBrowserResponseExecution<TChunk>;
+  encoder: AgUiBrowserResponseEncoder<TChunk>;
+  initialState: TState;
+  onChunk?: (state: TState, chunk: TChunk) => void;
+  getFinalResponse?: (state: TState) => AgentResponse | null;
+}
+
+export function createAgUiBrowserResponseStream<TChunk, TState>(
+  input: CreateAgUiBrowserResponseStreamInput<TChunk, TState>,
+): ReadableStream<Uint8Array> {
+  let streamClosed = false;
+  let nextEventId = 1;
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      const writeEvent = (event: AgUiSseEvent) => {
+        if (streamClosed) {
+          return false;
+        }
+
+        try {
+          controller.enqueue(formatAgUiSseEventWithId(event, nextEventId));
+          nextEventId += 1;
+          return true;
+        } catch {
+          streamClosed = true;
+          return false;
+        }
+      };
+
+      const closeStream = () => {
+        if (streamClosed) {
+          return;
+        }
+
+        if (controller.desiredSize === null) {
+          streamClosed = true;
+          return;
+        }
+
+        controller.close();
+        streamClosed = true;
+      };
+
+      void (async () => {
+        const state = input.initialState;
+
+        try {
+          writeEvent({
+            event: "RunStarted",
+            payload: {
+              runId: input.agUiInput.runId,
+              threadId: input.agUiInput.threadId,
+              agentId: input.agentId,
+            },
+          });
+
+          writeEvent({
+            event: "StateSnapshot",
+            payload: {
+              snapshot: input.agUiInput.state,
+            },
+          });
+
+          writeEvent({
+            event: "MessagesSnapshot",
+            payload: {
+              messages: input.agUiInput.messages,
+            },
+          });
+
+          for await (const chunk of input.execution.agentUIStream) {
+            input.onChunk?.(state, chunk);
+            for (const event of input.encoder.encode(chunk)) {
+              writeEvent(event);
+            }
+          }
+
+          await input.execution.waitForFinish();
+
+          for (const event of input.encoder.finalize(input.getFinalResponse?.(state) ?? null)) {
+            writeEvent(event);
+          }
+        } catch (error) {
+          await invokeFailWithoutLeaking(input.execution.fail, error);
+          writeEvent({
+            event: "RunError",
+            payload: {
+              code: "STREAM_ERROR",
+              message: error instanceof Error ? error.message : String(error),
+            },
+          });
+        } finally {
+          closeStream();
+        }
+      })();
+    },
+    cancel() {
+      streamClosed = true;
+    },
+  });
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -171,6 +171,13 @@ export {
   mapRuntimeStreamEventToAgUiBrowserEvents,
 } from "./ag-ui-browser-encoder.ts";
 export {
+  type AgUiBrowserResponseEncoder,
+  type AgUiBrowserResponseExecution,
+  type AgUiBrowserResponseRequestState,
+  createAgUiBrowserResponseStream,
+  type CreateAgUiBrowserResponseStreamInput,
+} from "./ag-ui-browser-response-stream.ts";
+export {
   mergeToolCallInput,
   mergeToolInputDelta,
   parseDataStreamSseEvents,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.225";
+export const VERSION = "0.1.226";


### PR DESCRIPTION
## Summary
- add a generic AG-UI browser response stream helper for custom execution paths
- keep package-owned bootstrap events, SSE framing, and terminal error handling while hosts supply their own encoder/final-state callback
- document the helper and bump the package version to 0.1.226

## Testing
- deno test --no-check --allow-all src/agent/ag-ui-browser-response-stream.test.ts src/agent/ag-ui-runtime-handler.test.ts
- deno check src/agent/ag-ui-browser-response-stream.ts src/agent/ag-ui-runtime-handler.ts src/agent/index.ts
