### PR TITLE
Harden AG-UI browser response stream disconnect handling

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.226",
+  "version": "0.1.227",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/ag-ui-browser-response-stream.test.ts
+++ b/src/agent/ag-ui-browser-response-stream.test.ts
@@ -138,4 +138,87 @@ describe("agent/ag-ui-browser-response-stream", () => {
     await collectStreamText(stream);
     assertEquals(finalSeen, ["a", "b"]);
   });
+
+  it("normalizes missing state to an empty snapshot object", async () => {
+    const stream = createAgUiBrowserResponseStream({
+      agUiInput: {
+        runId: "run-4",
+        threadId: "thread-4",
+        messages: [],
+      },
+      agentId: "assistant-1",
+      execution: {
+        agentUIStream: {
+          async *[Symbol.asyncIterator]() {
+            yield { type: "chunk", delta: "noop" };
+          },
+        },
+        fail: async () => {},
+        waitForFinish: async () => {},
+      },
+      encoder: {
+        encode: () => [],
+        finalize: () => [],
+      },
+      initialState: {},
+    });
+
+    const text = await collectStreamText(stream);
+    assertStringIncludes(text, "event: StateSnapshot");
+    assertStringIncludes(text, 'data: {"snapshot":{}}');
+  });
+
+  it("stops consuming chunks after the response stream is cancelled", async () => {
+    let releaseSecondChunk: (() => void) | undefined;
+    const secondChunkReady = new Promise<void>((resolve) => {
+      releaseSecondChunk = resolve;
+    });
+    let seenChunks = 0;
+    let waitForFinishCalls = 0;
+
+    const stream = createAgUiBrowserResponseStream({
+      agUiInput: {
+        runId: "run-5",
+        threadId: "thread-5",
+        messages: [],
+      },
+      agentId: "assistant-1",
+      execution: {
+        agentUIStream: {
+          async *[Symbol.asyncIterator]() {
+            yield { type: "chunk", delta: "a" };
+            await secondChunkReady;
+            yield { type: "chunk", delta: "b" };
+          },
+        },
+        fail: async () => {},
+        waitForFinish: async () => {
+          waitForFinishCalls += 1;
+        },
+      },
+      encoder: {
+        encode: (chunk): AgUiSseEvent[] => [{
+          event: "TextMessageContent",
+          payload: { delta: String((chunk as { delta: string }).delta) },
+        }],
+        finalize: () => [{ event: "RunFinished", payload: { metadata: {} } }],
+      },
+      initialState: {},
+      onChunk: () => {
+        seenChunks += 1;
+      },
+    });
+
+    const reader = stream.getReader();
+    for (let index = 0; index < 4; index += 1) {
+      const { done } = await reader.read();
+      assertEquals(done, false);
+    }
+    await reader.cancel();
+    releaseSecondChunk?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assertEquals(seenChunks, 1);
+    assertEquals(waitForFinishCalls, 0);
+  });
 });

--- a/src/agent/ag-ui-browser-response-stream.ts
+++ b/src/agent/ag-ui-browser-response-stream.ts
@@ -45,6 +45,14 @@ export interface CreateAgUiBrowserResponseStreamInput<TChunk, TState> {
   getFinalResponse?: (state: TState) => AgentResponse | null;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeSnapshot(snapshot: unknown): Record<string, unknown> {
+  return isRecord(snapshot) ? snapshot : {};
+}
+
 export function createAgUiBrowserResponseStream<TChunk, TState>(
   input: CreateAgUiBrowserResponseStreamInput<TChunk, TState>,
 ): ReadableStream<Uint8Array> {
@@ -86,40 +94,65 @@ export function createAgUiBrowserResponseStream<TChunk, TState>(
         const state = input.initialState;
 
         try {
-          writeEvent({
-            event: "RunStarted",
-            payload: {
-              runId: input.agUiInput.runId,
-              threadId: input.agUiInput.threadId,
-              agentId: input.agentId,
-            },
-          });
+          if (
+            !writeEvent({
+              event: "RunStarted",
+              payload: {
+                runId: input.agUiInput.runId,
+                threadId: input.agUiInput.threadId,
+                agentId: input.agentId,
+              },
+            })
+          ) {
+            return;
+          }
 
-          writeEvent({
-            event: "StateSnapshot",
-            payload: {
-              snapshot: input.agUiInput.state,
-            },
-          });
+          if (
+            !writeEvent({
+              event: "StateSnapshot",
+              payload: {
+                snapshot: normalizeSnapshot(input.agUiInput.state),
+              },
+            })
+          ) {
+            return;
+          }
 
-          writeEvent({
-            event: "MessagesSnapshot",
-            payload: {
-              messages: input.agUiInput.messages,
-            },
-          });
+          if (
+            !writeEvent({
+              event: "MessagesSnapshot",
+              payload: {
+                messages: input.agUiInput.messages,
+              },
+            })
+          ) {
+            return;
+          }
 
           for await (const chunk of input.execution.agentUIStream) {
+            if (streamClosed) {
+              return;
+            }
             input.onChunk?.(state, chunk);
             for (const event of input.encoder.encode(chunk)) {
-              writeEvent(event);
+              if (!writeEvent(event)) {
+                return;
+              }
             }
           }
 
+          if (streamClosed) {
+            return;
+          }
           await input.execution.waitForFinish();
 
+          if (streamClosed) {
+            return;
+          }
           for (const event of input.encoder.finalize(input.getFinalResponse?.(state) ?? null)) {
-            writeEvent(event);
+            if (!writeEvent(event)) {
+              return;
+            }
           }
         } catch (error) {
           await invokeFailWithoutLeaking(input.execution.fail, error);

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.226";
+export const VERSION = "0.1.227";


### PR DESCRIPTION
## Summary\n- stop consuming browser response-stream chunks once the SSE consumer disconnects\n- normalize missing AG-UI state snapshots to an empty object during bootstrap\n- bump the framework version to 0.1.227 with regression coverage for both cases\n\n## Testing\n- deno test --no-check --allow-all src/agent/ag-ui-browser-response-stream.test.ts\n- deno check src/agent/ag-ui-browser-response-stream.ts src/agent/index.ts\n- pre-push checks