### PR TITLE
Add a reusable AG-UI browser finalize-response helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.227",
+  "version": "0.1.228",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent-runtime-ag-ui.md
+++ b/docs/reference/agent-runtime-ag-ui.md
@@ -112,6 +112,10 @@ Hosts that keep a custom execute path can also use
 framing (`RunStarted`, `StateSnapshot`, `MessagesSnapshot`) while supplying a
 host-local encoder for their own chunk type.
 
+When a host accumulates browser-finished metadata separately,
+`buildAgUiBrowserFinalizeResponse()` converts that metadata into the canonical
+final `AgentResponse` consumed by the browser encoder finalization path.
+
 For canonical runtime AG-UI hosts using `createAgUiRuntimeHandler()`, the
 package can also invoke optional lifecycle callbacks when the default hosted
 stream path sees tool calls, finishes, or fails:

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -21,6 +21,7 @@ import {
   AgUiRequestSchema,
   AgUiResumeSignalSchema,
   AgUiRuntimeRequestSchema,
+  buildAgUiBrowserFinalizeResponse,
   createAgUiBrowserEncoderState,
   createAgUiCancelHandler,
   createAgUiDetachedStartHandler,
@@ -204,6 +205,7 @@ const events = mapRuntimeStreamEventToAgUiBrowserEvents(state, {
 });
 
 const finalEvents = finalizeAgUiBrowserEvents(state, null);
+const finalResponse = buildAgUiBrowserFinalizeResponse(state.metadata);
 ```
 
 ### Provider-native tool inventory
@@ -313,6 +315,7 @@ modules.
 | Export                                                   | Type                                             | Description                                                                  |
 | -------------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------- |
 | `createAgUiBrowserEncoderState()`                        | `() => AgUiBrowserEncoderState`                  | Create mutable encoder state for one browser AG-UI stream.                   |
+| `buildAgUiBrowserFinalizeResponse()`                     | `(metadata) => AgentResponse \| null`            | Convert browser-finished metadata into the canonical final AgentResponse.    |
 | `mapRuntimeStreamEventToAgUiBrowserEvents(state, event)` | `(state, event) => AgUiBrowserEncodedEvent[]`    | Map one runtime stream event into zero or more browser/public AG-UI events.  |
 | `finalizeAgUiBrowserEvents(state, response)`             | `(state, response) => AgUiBrowserEncodedEvent[]` | Emit terminal browser/public AG-UI events after the runtime stream finishes. |
 

--- a/src/agent/ag-ui-browser-encoder.test.ts
+++ b/src/agent/ag-ui-browser-encoder.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  buildAgUiBrowserFinalizeResponse,
   createAgUiBrowserEncoderState,
   finalizeAgUiBrowserEvents,
   mapRuntimeStreamEventToAgUiBrowserEvents,
@@ -431,6 +432,55 @@ describe("agent/ag-ui-browser-encoder", () => {
           message: "Agent run produced no assistant-visible output",
         },
       }],
+    );
+  });
+});
+
+describe("buildAgUiBrowserFinalizeResponse", () => {
+  it("returns null when metadata is empty", () => {
+    assertEquals(buildAgUiBrowserFinalizeResponse({}), null);
+  });
+
+  it("maps finishReason and usage into an AgentResponse", () => {
+    assertEquals(
+      buildAgUiBrowserFinalizeResponse({
+        finishReason: "stop",
+        inputTokens: 10,
+        outputTokens: 5,
+      }),
+      {
+        text: "",
+        messages: [],
+        toolCalls: [],
+        status: "completed",
+        usage: {
+          promptTokens: 10,
+          completionTokens: 5,
+          totalTokens: 15,
+        },
+        metadata: { finishReason: "stop" },
+      },
+    );
+  });
+
+  it("respects an explicit total token count when provided", () => {
+    assertEquals(
+      buildAgUiBrowserFinalizeResponse({
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 99,
+      }),
+      {
+        text: "",
+        messages: [],
+        toolCalls: [],
+        status: "completed",
+        usage: {
+          promptTokens: 10,
+          completionTokens: 5,
+          totalTokens: 99,
+        },
+      },
     );
   });
 });

--- a/src/agent/ag-ui-browser-encoder.ts
+++ b/src/agent/ag-ui-browser-encoder.ts
@@ -133,6 +133,39 @@ function applyResponseMetadata(
   }
 }
 
+export function buildAgUiBrowserFinalizeResponse(
+  metadata: AgUiBrowserRunFinishedMetadata,
+): AgentResponse | null {
+  const responseMetadata: Record<string, unknown> = {};
+  if (typeof metadata.finishReason === "string" && metadata.finishReason.length > 0) {
+    responseMetadata.finishReason = metadata.finishReason;
+  }
+
+  const usage = typeof metadata.inputTokens === "number" ||
+      typeof metadata.outputTokens === "number" ||
+      typeof metadata.totalTokens === "number"
+    ? {
+      promptTokens: metadata.inputTokens ?? 0,
+      completionTokens: metadata.outputTokens ?? 0,
+      totalTokens: metadata.totalTokens ??
+        ((metadata.inputTokens ?? 0) + (metadata.outputTokens ?? 0)),
+    }
+    : undefined;
+
+  if (!usage && Object.keys(responseMetadata).length === 0) {
+    return null;
+  }
+
+  return {
+    text: "",
+    messages: [],
+    toolCalls: [],
+    status: "completed",
+    ...(usage ? { usage } : {}),
+    ...(Object.keys(responseMetadata).length > 0 ? { metadata: responseMetadata } : {}),
+  };
+}
+
 function completeToolInput(
   state: AgUiBrowserEncoderState,
   event: AgUiRuntimeStreamEvent,

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -166,6 +166,7 @@ export {
   type AgUiBrowserEncoderState,
   type AgUiBrowserRunFinishedMetadata,
   type AgUiRuntimeStreamEvent,
+  buildAgUiBrowserFinalizeResponse,
   createAgUiBrowserEncoderState,
   finalizeAgUiBrowserEvents,
   mapRuntimeStreamEventToAgUiBrowserEvents,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.227";
+export const VERSION = "0.1.228";


### PR DESCRIPTION
## Summary\n- add a public helper that turns browser-finished metadata into the canonical final AgentResponse shape\n- export and document the helper alongside the browser AG-UI encoder APIs\n- bump the framework version to 0.1.228 with regression coverage\n\n## Testing\n- deno test --no-check --allow-all src/agent/ag-ui-browser-encoder.test.ts\n- deno check src/agent/ag-ui-browser-encoder.ts src/agent/index.ts\n- pre-push checks