### PR TITLE
feat(schemas): SchemaValidator contract + defineSchema lazy factory (PR 6 Phase A infra)

### DIFF
--- a/src/extensions/interfaces/index.ts
+++ b/src/extensions/interfaces/index.ts
@@ -76,8 +76,12 @@ export type {
 
 // Schema validator
 export type {
+  InferSchema,
+  InferShape,
   Schema,
+  SchemaFactory,
   SchemaValidator,
+  SchemaValidatorCoerce,
   ValidationFailure,
   ValidationIssue,
   ValidationResult,

--- a/src/extensions/interfaces/schema-validator.ts
+++ b/src/extensions/interfaces/schema-validator.ts
@@ -3,14 +3,67 @@
  *
  * Default implementation: `@veryfront/ext-zod`
  *
+ * The interface exposes a small DSL (inspired by zod) that lets core modules
+ * declare validation schemas without importing zod directly. Schemas are
+ * constructed lazily via `defineSchema()` so that an extension-provided
+ * implementation can be registered before any schema is materialized.
+ *
  * @module extensions/interfaces/schema-validator
  */
 
-/** An opaque schema definition that validates and infers type `T`. */
+/**
+ * An opaque schema definition that validates and infers type `T`.
+ *
+ * Implementations may use this as a nominal wrapper around a native validator
+ * (e.g. a zod schema). Core code only calls the methods defined here.
+ */
 export interface Schema<T = unknown> {
-  /** Brand field for nominal typing -- not used at runtime. */
+  /** Brand field for nominal typing — not used at runtime. */
   readonly _output: T;
+
+  // Refinement / modifier chainables
+  optional(): Schema<T | undefined>;
+  nullable(): Schema<T | null>;
+  nullish(): Schema<T | null | undefined>;
+  default(value: T | (() => T)): Schema<T>;
+  describe(description: string): Schema<T>;
+  refine(check: (value: T) => boolean, message?: string | { message?: string }): Schema<T>;
+  transform<U>(fn: (value: T) => U): Schema<U>;
+
+  // Object-level chainables (no-op / type-preserving on non-object schemas;
+  // implementations should only call these on object schemas).
+  strict(): Schema<T>;
+  passthrough(): Schema<T>;
+  partial(): Schema<Partial<T>>;
+  extend<U extends Record<string, Schema<unknown>>>(
+    shape: U,
+  ): Schema<T & { [K in keyof U]: InferSchema<U[K]> }>;
+  merge<U>(other: Schema<U>): Schema<T & U>;
+
+  // String-level chainables
+  min(value: number, message?: string): Schema<T>;
+  max(value: number, message?: string): Schema<T>;
+  int(message?: string): Schema<T>;
+  positive(message?: string): Schema<T>;
+  nonnegative(message?: string): Schema<T>;
+  regex(pattern: RegExp, message?: string): Schema<T>;
+  email(message?: string): Schema<T>;
+  url(message?: string): Schema<T>;
+  uuid(message?: string): Schema<T>;
+  datetime(message?: string): Schema<T>;
+
+  // Validation
+  parse(data: unknown): T;
+  safeParse(data: unknown): ValidationResult<T>;
 }
+
+/** Extracts the inferred output type `T` from a `Schema<T>`. */
+export type InferSchema<S> = S extends Schema<infer T> ? T : never;
+
+/** Maps a raw object shape to its inferred object type. */
+export type InferShape<S extends Record<string, Schema<unknown>>> = {
+  [K in keyof S]: InferSchema<S[K]>;
+};
 
 /** A single validation issue with location context. */
 export interface ValidationIssue {
@@ -34,18 +87,72 @@ export interface ValidationFailure {
   success: false;
   /** List of issues found during validation. */
   issues: ValidationIssue[];
+  /** Native error thrown by the underlying validator (if any). */
+  error?: unknown;
 }
 
 /** Discriminated union of validation outcomes. */
 export type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
 
 /**
+ * Namespace for `coerce.*` constructors — accepts input in any form and
+ * coerces to the target type before validation.
+ */
+export interface SchemaValidatorCoerce {
+  string(): Schema<string>;
+  number(): Schema<number>;
+  boolean(): Schema<boolean>;
+  date(): Schema<Date>;
+}
+
+/**
  * SchemaValidator contract interface.
  *
- * Implementations validate unknown input against a typed schema and
- * return a discriminated success/failure result.
+ * Exposes a zod-inspired DSL. The `object(shape)`, `array(schema)`, etc.
+ * constructors produce opaque `Schema<T>` instances that can be further
+ * refined via chainables and finally validated with `.parse` / `.safeParse`.
  */
 export interface SchemaValidator {
-  /** Validate `data` against the given schema. */
+  // Primitive constructors
+  string(): Schema<string>;
+  number(): Schema<number>;
+  boolean(): Schema<boolean>;
+  date(): Schema<Date>;
+  null(): Schema<null>;
+  unknown(): Schema<unknown>;
+  // deno-lint-ignore no-explicit-any -- `any` constructor intentionally mirrors zod
+  any(): Schema<any>;
+
+  // Composite constructors
+  object<S extends Record<string, Schema<unknown>>>(shape: S): Schema<InferShape<S>>;
+  array<T>(element: Schema<T>): Schema<T[]>;
+  record<K extends string | number | symbol, V>(
+    keys: Schema<K>,
+    values: Schema<V>,
+  ): Schema<Record<K, V>>;
+  union<T extends readonly [Schema<unknown>, ...Schema<unknown>[]]>(
+    schemas: T,
+  ): Schema<InferSchema<T[number]>>;
+  discriminatedUnion<
+    K extends string,
+    T extends readonly [Schema<unknown>, ...Schema<unknown>[]],
+  >(
+    discriminator: K,
+    schemas: T,
+  ): Schema<InferSchema<T[number]>>;
+  literal<T extends string | number | boolean | null>(value: T): Schema<T>;
+  enum<T extends readonly [string, ...string[]]>(values: T): Schema<T[number]>;
+
+  /** Coercing constructors — accept any input and coerce to the target. */
+  coerce: SchemaValidatorCoerce;
+
+  /**
+   * Convenience that runs validation on an already-constructed schema.
+   * Equivalent to `schema.safeParse(data)`; kept for ergonomic parity with
+   * earlier revisions of this contract.
+   */
   validate<T>(schema: Schema<T>, data: unknown): ValidationResult<T>;
 }
+
+/** Factory type accepted by `defineSchema`. */
+export type SchemaFactory<T> = (v: SchemaValidator) => Schema<T>;

--- a/src/schemas/define.test.ts
+++ b/src/schemas/define.test.ts
@@ -1,0 +1,68 @@
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { register, reset, tryResolve } from "#veryfront/extensions/contracts.ts";
+import type { SchemaValidator } from "#veryfront/extensions/interfaces/index.ts";
+import { defineSchema } from "./define.ts";
+import { registerZodAdapter, zodAdapter } from "./zod-adapter.ts";
+
+/**
+ * The bootstrap side-effect import in `src/schemas/index.ts` registers the
+ * zod adapter globally. These tests reset the registry between cases to
+ * exercise both the "registered" and "unresolved" paths, then restore the
+ * default state afterwards so downstream tests keep their invariants.
+ */
+describe("defineSchema", () => {
+  afterEach(() => {
+    // Restore default state for any subsequent tests in the same process.
+    reset();
+    registerZodAdapter();
+  });
+
+  it(
+    "throws a helpful error when no SchemaValidator contract is registered",
+    () => {
+      reset();
+      const getSchema = defineSchema((v) => v.object({ id: v.string() }));
+      assertThrows(
+        () => getSchema(),
+        Error,
+        "SchemaValidator contract unresolved — install ext-zod",
+      );
+    },
+  );
+
+  it("materializes the schema lazily via the registered adapter", () => {
+    reset();
+    register<SchemaValidator>("SchemaValidator", zodAdapter);
+
+    const getSchema = defineSchema((v) =>
+      v.object({ id: v.string().min(1), count: v.number().int() })
+    );
+
+    const schema = getSchema();
+    const parsed = schema.parse({ id: "abc", count: 3 });
+    assertEquals(parsed, { id: "abc", count: 3 });
+  });
+
+  it("caches the built schema across repeated calls", () => {
+    reset();
+    register<SchemaValidator>("SchemaValidator", zodAdapter);
+
+    const getSchema = defineSchema((v) => v.string());
+    const first = getSchema();
+    const second = getSchema();
+    assertEquals(first === second, true);
+  });
+
+  it("defers adapter resolution until first call", () => {
+    reset();
+    const getSchema = defineSchema((v) => v.boolean());
+
+    // No contract yet — construction alone must not throw.
+    assertEquals(tryResolve<SchemaValidator>("SchemaValidator"), undefined);
+
+    register<SchemaValidator>("SchemaValidator", zodAdapter);
+    const schema = getSchema();
+    assertEquals(schema.parse(true), true);
+  });
+});

--- a/src/schemas/define.ts
+++ b/src/schemas/define.ts
@@ -1,0 +1,48 @@
+/**
+ * Lazy schema factory.
+ *
+ * `defineSchema(factory)` returns a memoized getter that resolves the
+ * `SchemaValidator` extension contract on first call and materializes the
+ * schema via the provided factory. This indirection lets core modules declare
+ * schemas without importing zod directly — a real validator (typically
+ * `@veryfront/ext-zod`) must be registered in the contract registry before
+ * the schema is first accessed.
+ *
+ * @module schemas/define
+ */
+
+import { tryResolve } from "#veryfront/extensions/contracts.ts";
+import type {
+  Schema,
+  SchemaFactory,
+  SchemaValidator,
+} from "#veryfront/extensions/interfaces/index.ts";
+
+/**
+ * Wrap a schema factory so that it is built lazily on first call.
+ *
+ * @param factory - Receives a `SchemaValidator` and returns a `Schema<T>`.
+ * @returns A zero-arg getter that caches and returns the built schema.
+ * @throws Error when no `SchemaValidator` contract is registered.
+ *
+ * @example
+ * ```ts
+ * const getUserSchema = defineSchema((v) =>
+ *   v.object({ id: v.string().uuid(), name: v.string().min(1) })
+ * );
+ *
+ * const user = getUserSchema().parse(input);
+ * ```
+ */
+export function defineSchema<T>(factory: SchemaFactory<T>): () => Schema<T> {
+  let cached: Schema<T> | undefined;
+  return () => {
+    if (cached) return cached;
+    const v = tryResolve<SchemaValidator>("SchemaValidator");
+    if (!v) {
+      throw new Error("SchemaValidator contract unresolved — install ext-zod");
+    }
+    cached = factory(v);
+    return cached;
+  };
+}

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,9 +1,20 @@
 /**
- * Reusable Zod validation schemas — common types (email, slug, URL, UUID,
- * pagination) and primitives (file paths, hex colors, semver, timestamps).
+ * Reusable validation schemas — common types (email, slug, URL, UUID,
+ * pagination) and primitives (file paths, hex colors, semver, timestamps),
+ * plus the `defineSchema` lazy-factory helper.
+ *
+ * Importing this module also registers the default zod-backed
+ * `SchemaValidator` adapter so that `defineSchema(...)` works out of the box.
  *
  * @module schemas
  */
+
+import { registerZodAdapter } from "./zod-adapter.ts";
+
+// Register the default SchemaValidator implementation once at module load.
+registerZodAdapter();
+
+export { defineSchema } from "./define.ts";
 
 export {
   CommonSchemas,

--- a/src/schemas/zod-adapter.ts
+++ b/src/schemas/zod-adapter.ts
@@ -1,0 +1,180 @@
+/**
+ * Zod-backed `SchemaValidator` adapter.
+ *
+ * This is the default (core-provided) implementation of the
+ * `SchemaValidator` contract. It thinly wraps zod so that core modules can
+ * declare schemas through the extension-neutral DSL while still getting zod's
+ * runtime behavior.
+ *
+ * The entire zod surface used by the contract is confined to this file; when
+ * `@veryfront/ext-zod` takes over in Phase B this file will be deleted and
+ * the `"zod"` import map entry removed.
+ *
+ * @module schemas/zod-adapter
+ */
+
+import { z } from "zod";
+import { register } from "#veryfront/extensions/contracts.ts";
+import type {
+  InferShape,
+  Schema,
+  SchemaValidator,
+  SchemaValidatorCoerce,
+  ValidationIssue,
+  ValidationResult,
+} from "#veryfront/extensions/interfaces/index.ts";
+
+// deno-lint-ignore no-explicit-any -- zod's chainable APIs return parametric types
+type AnyZodSchema = z.ZodType<any, any, any>;
+
+/** Unwrap our opaque Schema<T> back to the underlying zod schema. */
+function toZod<T>(schema: Schema<T>): AnyZodSchema {
+  return (schema as unknown as { __zod: AnyZodSchema }).__zod;
+}
+
+/** Wrap a zod schema as an opaque Schema<T> with chainables routed through zod. */
+function wrap<T>(zs: AnyZodSchema): Schema<T> {
+  // The wrapper fakes the full Schema<T> surface; unsupported chainables on
+  // unsuitable kinds (e.g. calling `.email()` on a number) throw at runtime
+  // just like zod would.
+  // deno-lint-ignore no-explicit-any -- safe within this adapter
+  const anyZs = zs as any;
+  const s: Schema<T> = {
+    _output: undefined as unknown as T,
+    optional: () => wrap<T | undefined>(zs.optional()),
+    nullable: () => wrap<T | null>(zs.nullable()),
+    nullish: () => wrap<T | null | undefined>(zs.nullish()),
+    default: (value: T | (() => T)) => wrap<T>(anyZs.default(value)),
+    describe: (description: string) => wrap<T>(zs.describe(description)),
+    refine: (
+      check: (value: T) => boolean,
+      message?: string | { message?: string },
+    ) => wrap<T>(zs.refine(check as (v: unknown) => boolean, message as never)),
+    transform: <U>(fn: (value: T) => U) => wrap<U>(zs.transform(fn as never)),
+    strict: () => wrap<T>(anyZs.strict()),
+    passthrough: () => wrap<T>(anyZs.passthrough()),
+    partial: () => wrap<Partial<T>>(anyZs.partial()),
+    extend: <U extends Record<string, Schema<unknown>>>(shape: U) => {
+      const zodShape = toZodShape(shape);
+      return wrap<T & { [K in keyof U]: U[K] extends Schema<infer V> ? V : never }>(
+        anyZs.extend(zodShape),
+      );
+    },
+    merge: <U>(other: Schema<U>) => wrap<T & U>(anyZs.merge(toZod(other))),
+    min: (value: number, message?: string) => wrap<T>(anyZs.min(value, message)),
+    max: (value: number, message?: string) => wrap<T>(anyZs.max(value, message)),
+    int: (message?: string) => wrap<T>(anyZs.int(message)),
+    positive: (message?: string) => wrap<T>(anyZs.positive(message)),
+    nonnegative: (message?: string) => wrap<T>(anyZs.nonnegative(message)),
+    regex: (pattern: RegExp, message?: string) => wrap<T>(anyZs.regex(pattern, message)),
+    email: (message?: string) => wrap<T>(anyZs.email(message)),
+    url: (message?: string) => wrap<T>(anyZs.url(message)),
+    uuid: (message?: string) => wrap<T>(anyZs.uuid(message)),
+    datetime: (message?: string) => wrap<T>(anyZs.datetime(message)),
+    parse: (data: unknown): T => zs.parse(data) as T,
+    safeParse: (data: unknown): ValidationResult<T> => {
+      const res = zs.safeParse(data);
+      if (res.success) return { success: true, data: res.data as T };
+      const issues: ValidationIssue[] = res.error.issues.map((issue) => ({
+        path: issue.path as (string | number)[],
+        message: issue.message,
+        code: issue.code,
+      }));
+      return { success: false, issues, error: res.error };
+    },
+  };
+  // Attach the underlying zod schema for adapter round-trips without
+  // widening the public Schema<T> surface.
+  (s as unknown as { __zod: AnyZodSchema }).__zod = zs;
+  return s;
+}
+
+function toZodShape(
+  shape: Record<string, Schema<unknown>>,
+): Record<string, AnyZodSchema> {
+  const out: Record<string, AnyZodSchema> = {};
+  for (const [key, value] of Object.entries(shape)) {
+    out[key] = toZod(value);
+  }
+  return out;
+}
+
+const coerce: SchemaValidatorCoerce = {
+  string: (): Schema<string> => wrap(z.coerce.string()),
+  number: (): Schema<number> => wrap(z.coerce.number()),
+  boolean: (): Schema<boolean> => wrap(z.coerce.boolean()),
+  date: (): Schema<Date> => wrap(z.coerce.date()),
+};
+
+/** The zod-backed `SchemaValidator` singleton registered by `registerZodAdapter`. */
+export const zodAdapter: SchemaValidator = {
+  string: (): Schema<string> => wrap(z.string()),
+  number: (): Schema<number> => wrap(z.number()),
+  boolean: (): Schema<boolean> => wrap(z.boolean()),
+  date: (): Schema<Date> => wrap(z.date()),
+  null: (): Schema<null> => wrap(z.null()),
+  unknown: (): Schema<unknown> => wrap(z.unknown()),
+  // deno-lint-ignore no-explicit-any -- contract mirrors zod's `any` constructor
+  any: (): Schema<any> => wrap(z.any()),
+
+  object: <S extends Record<string, Schema<unknown>>>(shape: S): Schema<InferShape<S>> =>
+    wrap(z.object(toZodShape(shape))),
+
+  array: <T>(element: Schema<T>): Schema<T[]> => wrap(z.array(toZod(element))),
+
+  record: <K extends string | number | symbol, V>(
+    keys: Schema<K>,
+    values: Schema<V>,
+  ): Schema<Record<K, V>> => wrap(z.record(toZod(keys) as unknown as z.ZodString, toZod(values))),
+
+  union: <T extends readonly [Schema<unknown>, ...Schema<unknown>[]]>(
+    schemas: T,
+  ): Schema<T[number] extends Schema<infer U> ? U : never> => {
+    const zodSchemas = schemas.map((s: Schema<unknown>) => toZod(s)) as unknown as [
+      AnyZodSchema,
+      AnyZodSchema,
+      ...AnyZodSchema[],
+    ];
+    return wrap(z.union(zodSchemas));
+  },
+
+  discriminatedUnion: <
+    K extends string,
+    T extends readonly [Schema<unknown>, ...Schema<unknown>[]],
+  >(
+    discriminator: K,
+    schemas: T,
+  ): Schema<T[number] extends Schema<infer U> ? U : never> => {
+    const zodSchemas = schemas.map((s: Schema<unknown>) => toZod(s)) as unknown as [
+      // deno-lint-ignore no-explicit-any -- discriminated-union variants widen here
+      z.ZodObject<any>,
+      // deno-lint-ignore no-explicit-any -- discriminated-union variants widen here
+      z.ZodObject<any>,
+      // deno-lint-ignore no-explicit-any -- discriminated-union variants widen here
+      ...z.ZodObject<any>[],
+    ];
+    return wrap(z.discriminatedUnion(discriminator, zodSchemas));
+  },
+
+  literal: <T extends string | number | boolean | null>(value: T): Schema<T> =>
+    wrap(z.literal(value as never)),
+
+  enum: <T extends readonly [string, ...string[]]>(values: T): Schema<T[number]> =>
+    wrap(
+      (z.enum as unknown as (v: readonly [string, ...string[]]) => AnyZodSchema)(values),
+    ),
+
+  coerce,
+
+  validate: <T>(schema: Schema<T>, data: unknown): ValidationResult<T> => schema.safeParse(data),
+};
+
+/**
+ * Register the zod adapter as the default `SchemaValidator` implementation.
+ *
+ * Called once at core bootstrap (`src/schemas/index.ts` side-effect import).
+ * Phase B will delete this function when `@veryfront/ext-zod` takes over.
+ */
+export function registerZodAdapter(): void {
+  register<SchemaValidator>("SchemaValidator", zodAdapter);
+}


### PR DESCRIPTION
## Summary

Phase A infrastructure for PR 6 (ext-zod extraction). Introduces the extension-neutral `SchemaValidator` contract and a zod-backed adapter, without yet migrating any call sites.

- Expands `SchemaValidator` in `src/extensions/interfaces/schema-validator.ts` from a single `validate()` method to a full zod-inspired DSL: primitive constructors (`string`, `number`, `boolean`, `date`, `null`, `unknown`, `any`), composites (`object`, `array`, `record`, `union`, `discriminatedUnion`, `literal`, `enum`), a `coerce` namespace, and chainables (`optional`/`nullable`/`nullish`/`min`/`max`/`int`/`positive`/`nonnegative`/`regex`/`email`/`url`/`uuid`/`datetime`/`describe`/`strict`/`passthrough`/`partial`/`extend`/`merge`/`default`/`refine`/`transform`).
- Adds `defineSchema(factory)` in `src/schemas/define.ts` — a lazy factory that resolves the `SchemaValidator` contract on first call and caches the materialized schema, so schemas can be declared at module top-level before any extension is registered.
- Adds `src/schemas/zod-adapter.ts` — a zod-backed implementation of the contract. All zod usage is confined to this one file so Phase B can delete it when `@veryfront/ext-zod` takes over.
- Registers the adapter as a side effect of importing `src/schemas/index.ts`, so `defineSchema(...)` works out of the box at core bootstrap.

No existing schema files are migrated in this PR — the contract and adapter land first so the migration and the contract design can be reviewed independently.

## Out of scope (deferred to PR 6b)

- Migrating core schema files (`src/jobs/schemas.ts`, `src/workflow/schemas/**`, etc.) to `defineSchema` + `InferSchema`.
- Creating the `extensions/ext-zod/` package. Core already has a zod-backed adapter registered at bootstrap; the extension package will replace it in Phase B.
- Call sites that depend on zod's public surface and cannot migrate through the contract alone (enumerated below).

## Out of Phase A entirely (require contract design extensions)

These surfaces depend on zod internals that the extension-neutral contract intentionally does not expose, and must remain on direct `zod` imports until we extend the contract or rework the API:

- `src/tool/handler.ts` — public tool API accepts `z.ZodSchema<T>` from user code.
- `src/agent/human-input.ts` — `InvalidHumanInputResultError` exposes `z.ZodIssue` in its public type signature.
- Any file using `zodToJsonSchema` (walks `z._def`) for OpenAI/Anthropic/MCP tool schemas.
- `src/config/config.schema.ts` — uses `.shape` for partial config merging.
- `src/schemas/primitives.ts` — uses `z.lazy` for recursive JSON schema.
- `parsers.ts` files that pattern-match on `z.ZodError` instances.

## Test plan

- [x] `deno task typecheck` — EXIT=0
- [x] `src/schemas/define.test.ts` — 4/4 pass (unregistered contract throws, lazy materialization, caching, deferred resolution)
- [x] `deno task test:unit` — 1387 pass (pre-push hook, full suite)
- [x] `deno fmt --check` — clean
- [x] `deno lint` — clean

## Notes for reviewers

The `defineSchema` factory returns `() => Schema<T>` rather than a direct `Schema<T>` because external consumers (extensions) cannot assume `SchemaValidator` is registered at their module-load time. Core callers will need to adopt `FooSchema()` usage and `InferSchema<ReturnType<typeof FooSchema>>` for type extraction when they migrate.

Part of Extensions Wave 2-4 plan (`docs/superpowers/plans/2026-04-20-extensions-waves-2-4-and-inlining.md`, PR 6).