### PR TITLE
Prevent closed SSE streams from crashing agent responses

### DIFF
--- a/src/agent/runtime/sse-utils.test.ts
+++ b/src/agent/runtime/sse-utils.test.ts
@@ -36,6 +36,37 @@ describe("sse-utils", () => {
       assertEquals(parsed.type, "complex");
       assertEquals(parsed.data.nested, true);
     });
+
+    it("ignores closed stream controller enqueue errors", () => {
+      const controller = {
+        enqueue() {
+          throw new TypeError("The stream controller cannot close or enqueue");
+        },
+      } as unknown as ReadableStreamDefaultController;
+      const encoder = new TextEncoder();
+
+      sendSSE(controller, encoder, { type: "test" });
+    });
+
+    it("rethrows unrelated enqueue errors", () => {
+      const expected = new TypeError("boom");
+      const controller = {
+        enqueue() {
+          throw expected;
+        },
+      } as unknown as ReadableStreamDefaultController;
+      const encoder = new TextEncoder();
+
+      let actual: unknown;
+
+      try {
+        sendSSE(controller, encoder, { type: "test" });
+      } catch (error) {
+        actual = error;
+      }
+
+      assertEquals(actual, expected);
+    });
   });
 
   describe("closeSSEStream", () => {

--- a/src/agent/runtime/sse-utils.ts
+++ b/src/agent/runtime/sse-utils.ts
@@ -20,7 +20,15 @@ export function sendSSE(
   encoder: TextEncoder,
   event: Record<string, unknown>,
 ): void {
-  controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+  try {
+    controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+  } catch (error) {
+    if (isClosedStreamControllerError(error)) {
+      return;
+    }
+
+    throw error;
+  }
 }
 
 export function closeSSEStream(controller: ReadableStreamDefaultController): void {


### PR DESCRIPTION
## Summary
Production conversation pages can return a blank Vike fallback page when the SSE response stream closes before the agent runtime finishes emitting step/tool events.

This PR aligns `sendSSE()` with `closeSSEStream()` by treating Deno's closed-stream controller error as terminal transport state instead of rethrowing it, while still surfacing unrelated enqueue failures.

## Repro
1. Open `https://veryfront.org/?conversation_id=be170f07-866c-4d5a-97bf-bbd5ce09c9ed`
2. Observe `HTTP/2 500` and a plain `An error occurred.` page
3. Inspect `veryfront-server` production logs for the same failure shape:
   - `TypeError: The stream controller cannot close or enqueue`
   - stack includes `src/agent/runtime/sse-utils.ts:23`

## Fix
- swallow only the known closed-stream enqueue error in `sendSSE()`
- keep rethrowing any other enqueue failure
- add regression tests for both paths

## Verification
- `deno test --no-check --allow-all src/agent/runtime/*.test.ts`
- `deno fmt --check src/agent/runtime/sse-utils.ts src/agent/runtime/sse-utils.test.ts`
- `deno check src/agent/runtime/sse-utils.ts src/agent/runtime/sse-utils.test.ts`

## Evidence
- Browser screenshot: `<local-path>`
- Browser console showed Vike could not render the error page after the server returned `500`
- `curl -I https://veryfront.org/?conversation_id=be170f07-866c-4d5a-97bf-bbd5ce09c9ed` returned `HTTP/2 500` with request id `4a15b379-cfc7-453e-8ea6-a5a4bfcf01a8`
