### PR TITLE
Add a hosted lifecycle runner for durable control-plane adapters

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.228",
+  "version": "0.1.229",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent-runtime-ag-ui.md
+++ b/docs/reference/agent-runtime-ag-ui.md
@@ -116,6 +116,10 @@ When a host accumulates browser-finished metadata separately,
 `buildAgUiBrowserFinalizeResponse()` converts that metadata into the canonical
 final `AgentResponse` consumed by the browser encoder finalization path.
 
+For durable control-plane integration, `runHostedLifecycle()` provides a
+framework-owned orchestration loop while the host keeps ownership of auth, run
+creation, append/mirror policy, finalize/cancel calls, and transcript policy.
+
 For canonical runtime AG-UI hosts using `createAgUiRuntimeHandler()`, the
 package can also invoke optional lifecycle callbacks when the default hosted
 stream path sees tool calls, finishes, or fails:

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -35,6 +35,7 @@ import {
   expandAllowedRemoteToolNames,
   getAgentsAsTools,
   getProviderNativeToolNames,
+  HostedLifecycleTerminalState,
   HumanInputRequestSchema,
   normalizeAgUiMessages,
   normalizeAgUiRuntimeMessages,
@@ -43,6 +44,7 @@ import {
   parseAgUiRuntimeRequest,
   parseAgUiRuntimeRequestOrError,
   registerAgent,
+  runHostedLifecycle,
   RunResumeSessionManager,
   waitForHumanInput,
 } from "veryfront/agent";
@@ -187,6 +189,36 @@ const sessionManager = new RunResumeSessionManager<{
 export const DELETE = createAgUiCancelHandler({ sessionManager });
 ```
 
+### Hosted durable lifecycle runner
+
+```ts
+import { type HostedLifecycleAdapter, runHostedLifecycle } from "veryfront/agent";
+
+type DurableChunk = { type: string; payload: unknown };
+type DurableRunContext = { runId: string; latestCursor: number };
+
+const adapter: HostedLifecycleAdapter<DurableRunContext, DurableChunk> = {
+  startRun: async () => ({ runId: "run_123", latestCursor: 0 }),
+  appendEvents: async (_run, _chunk) => {},
+  finalizeRun: async (_run, _terminalState) => {},
+  cancelRun: async (_run, _terminalState) => {},
+};
+
+await runHostedLifecycle({
+  abortSignal: new AbortController().signal,
+  execution: {
+    stream: {
+      async *[Symbol.asyncIterator]() {
+        yield { type: "text-delta", payload: "hello" } satisfies DurableChunk;
+      },
+    },
+    waitForFinish: async () => {},
+  },
+  adapter,
+  resolveTerminalState: () => ({ status: "completed" }),
+});
+```
+
 ### Browser AG-UI encoder
 
 ```ts
@@ -227,7 +259,9 @@ const allowedRemoteToolNames = expandAllowedRemoteToolNames({
 
 ```ts
 import {
+  HostedLifecycleTerminalState,
   HumanInputRequestSchema,
+  runHostedLifecycle,
   RunResumeSessionManager,
   waitForHumanInput,
 } from "veryfront/agent";
@@ -312,12 +346,13 @@ Use these helpers when a host needs to turn the framework runtime stream event
 family into browser/public AG-UI events without importing internal transport
 modules.
 
-| Export                                                   | Type                                             | Description                                                                  |
-| -------------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------- |
-| `createAgUiBrowserEncoderState()`                        | `() => AgUiBrowserEncoderState`                  | Create mutable encoder state for one browser AG-UI stream.                   |
-| `buildAgUiBrowserFinalizeResponse()`                     | `(metadata) => AgentResponse \| null`            | Convert browser-finished metadata into the canonical final AgentResponse.    |
-| `mapRuntimeStreamEventToAgUiBrowserEvents(state, event)` | `(state, event) => AgUiBrowserEncodedEvent[]`    | Map one runtime stream event into zero or more browser/public AG-UI events.  |
-| `finalizeAgUiBrowserEvents(state, response)`             | `(state, response) => AgUiBrowserEncodedEvent[]` | Emit terminal browser/public AG-UI events after the runtime stream finishes. |
+| Export                                                   | Type                                             | Description                                                                    |
+| -------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------ |
+| `createAgUiBrowserEncoderState()`                        | `() => AgUiBrowserEncoderState`                  | Create mutable encoder state for one browser AG-UI stream.                     |
+| `buildAgUiBrowserFinalizeResponse()`                     | `(metadata) => AgentResponse \| null`            | Convert browser-finished metadata into the canonical final AgentResponse.      |
+| `runHostedLifecycle()`                                   | `(options) => Promise<HostedLifecycleRunResult>` | Orchestrate start/observe/finalize/cancel sequencing with host-owned adapters. |
+| `mapRuntimeStreamEventToAgUiBrowserEvents(state, event)` | `(state, event) => AgUiBrowserEncodedEvent[]`    | Map one runtime stream event into zero or more browser/public AG-UI events.    |
+| `finalizeAgUiBrowserEvents(state, response)`             | `(state, response) => AgUiBrowserEncodedEvent[]` | Emit terminal browser/public AG-UI events after the runtime stream finishes.   |
 
 ### Provider-native tool inventory
 

--- a/examples/hosted-lifecycle-reference/README.md
+++ b/examples/hosted-lifecycle-reference/README.md
@@ -1,0 +1,16 @@
+# Hosted lifecycle reference
+
+This example shows the intended Phase 1 integration shape for a host that wants
+to connect a framework agent run to an external conversations/control-plane API.
+
+The framework owns the orchestration loop through `runHostedLifecycle(...)`.
+The host still owns:
+
+- auth and project access
+- external run creation / lookup / append / finalize / cancel
+- mirroring policy and retry behavior
+- transcript persistence policy
+- forwarded config extraction
+- runtime-native message bridging
+
+See `index.ts` for a minimal adapter composition sketch.

--- a/examples/hosted-lifecycle-reference/index.ts
+++ b/examples/hosted-lifecycle-reference/index.ts
@@ -1,0 +1,38 @@
+import {
+  runHostedLifecycle,
+  type HostedLifecycleAdapter,
+  type HostedLifecycleTerminalState,
+} from "veryfront/agent";
+
+type DurableChunk = { type: string; payload: unknown };
+type DurableRunContext = {
+  runId: string;
+  latestCursor: number;
+};
+
+const adapter: HostedLifecycleAdapter<DurableRunContext, DurableChunk> = {
+  startRun: async () => ({ runId: "run_123", latestCursor: 0 }),
+  appendEvents: async (_run, _chunk) => {
+    // Host-owned durable mirror append/retry policy.
+  },
+  finalizeRun: async (_run, _terminalState: HostedLifecycleTerminalState) => {
+    // Host-owned complete/finalize call against the control plane.
+  },
+  cancelRun: async (_run, _terminalState: HostedLifecycleTerminalState) => {
+    // Host-owned cancel call against the control plane.
+  },
+};
+
+await runHostedLifecycle({
+  abortSignal: new AbortController().signal,
+  execution: {
+    stream: {
+      async *[Symbol.asyncIterator]() {
+        yield { type: "text-delta", payload: "hello" } satisfies DurableChunk;
+      },
+    },
+    waitForFinish: async () => {},
+  },
+  adapter,
+  resolveTerminalState: () => ({ status: "completed" }),
+});

--- a/src/agent/hosted-lifecycle.test.ts
+++ b/src/agent/hosted-lifecycle.test.ts
@@ -1,0 +1,261 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  type HostedLifecycleAdapter,
+  type HostedLifecycleTerminalState,
+  runHostedLifecycle,
+} from "./hosted-lifecycle.ts";
+
+function createAbortSignal(): AbortSignal {
+  return new AbortController().signal;
+}
+
+describe("agent/hosted-lifecycle", () => {
+  it("runs start, chunk append/transcript hooks, then terminal hooks on success", async () => {
+    const calls: string[] = [];
+    const adapter: HostedLifecycleAdapter<{ runId: string }, string> = {
+      startRun: () => {
+        calls.push("startRun");
+        return { runId: "run-1" };
+      },
+      appendEvents: (_run, chunk) => {
+        calls.push(`append:${chunk}`);
+      },
+      persistTranscriptChunk: (_run, chunk) => {
+        calls.push(`persistChunk:${chunk}`);
+      },
+      persistTranscriptTerminalState: (_run, state) => {
+        calls.push(`persistTerminal:${state.status}`);
+      },
+      onTerminalState: (_run, state) => {
+        calls.push(`onTerminal:${state.status}`);
+      },
+      finalizeRun: (_run, state) => {
+        calls.push(`finalize:${state.status}`);
+      },
+    };
+
+    const result = await runHostedLifecycle({
+      abortSignal: createAbortSignal(),
+      execution: {
+        stream: {
+          async *[Symbol.asyncIterator]() {
+            yield "a";
+            yield "b";
+          },
+        },
+        waitForFinish: async () => {
+          calls.push("waitForFinish");
+        },
+      },
+      adapter,
+      resolveTerminalState: (): HostedLifecycleTerminalState => ({
+        status: "completed",
+        metadata: {
+          modelId: "openai/gpt-5.4",
+        },
+      }),
+    });
+
+    assertEquals(result.run, { runId: "run-1" });
+    assertEquals(result.terminalState.status, "completed");
+    assertEquals(calls, [
+      "startRun",
+      "append:a",
+      "persistChunk:a",
+      "append:b",
+      "persistChunk:b",
+      "waitForFinish",
+      "persistTerminal:completed",
+      "onTerminal:completed",
+      "finalize:completed",
+    ]);
+  });
+
+  it("dispatches cancelRun for cancelled terminal states", async () => {
+    const calls: string[] = [];
+
+    await runHostedLifecycle({
+      abortSignal: createAbortSignal(),
+      execution: {
+        stream: {
+          async *[Symbol.asyncIterator]() {
+            yield "chunk";
+          },
+        },
+        waitForFinish: async () => {
+          calls.push("waitForFinish");
+        },
+      },
+      adapter: {
+        startRun: () => ({ runId: "run-1" }),
+        cancelRun: (_run, state) => {
+          calls.push(`cancel:${state.status}`);
+        },
+        onTerminalState: (_run, state) => {
+          calls.push(`terminal:${state.status}`);
+        },
+      },
+      resolveTerminalState: () => ({ status: "cancelled", terminalErrorCode: "ABORTED" }),
+    });
+
+    assertEquals(calls, ["waitForFinish", "terminal:cancelled", "cancel:cancelled"]);
+  });
+
+  it("maps thrown execution errors through the default failed terminal state and rethrows", async () => {
+    const calls: string[] = [];
+    const error = new Error("stream exploded");
+
+    await assertRejects(
+      () =>
+        runHostedLifecycle({
+          abortSignal: createAbortSignal(),
+          execution: {
+            stream: {
+              [Symbol.asyncIterator]() {
+                return {
+                  next: async () => {
+                    throw error;
+                  },
+                };
+              },
+            },
+            waitForFinish: async () => {},
+          },
+          adapter: {
+            startRun: () => ({ runId: "run-1" }),
+            onTerminalState: (_run, state) => {
+              calls.push(
+                `${state.status}:${state.terminalErrorCode}:${state.terminalErrorMessage}`,
+              );
+            },
+            finalizeRun: (_run, state) => {
+              calls.push(`finalize:${state.status}`);
+            },
+          },
+          resolveTerminalState: () => ({ status: "completed" }),
+        }),
+      Error,
+      "stream exploded",
+    );
+
+    assertEquals(calls, ["failed:STREAM_ERROR:stream exploded", "finalize:failed"]);
+  });
+
+  it("supports custom error terminal state mapping", async () => {
+    const calls: string[] = [];
+
+    await assertRejects(
+      () =>
+        runHostedLifecycle({
+          abortSignal: createAbortSignal(),
+          execution: {
+            stream: {
+              [Symbol.asyncIterator]() {
+                return {
+                  next: async () => {
+                    throw new Error("cancelled by host");
+                  },
+                };
+              },
+            },
+            waitForFinish: async () => {},
+          },
+          adapter: {
+            startRun: () => ({ runId: "run-1" }),
+            cancelRun: (_run, state) => {
+              calls.push(`cancel:${state.terminalErrorCode}`);
+            },
+          },
+          resolveTerminalState: () => ({ status: "completed" }),
+          resolveErrorTerminalState: () => ({
+            status: "cancelled",
+            terminalErrorCode: "HOST_CANCELLED",
+            terminalErrorMessage: "cancelled by host",
+          }),
+        }),
+      Error,
+      "cancelled by host",
+    );
+
+    assertEquals(calls, ["cancel:HOST_CANCELLED"]);
+  });
+
+  it("still finalizes when transcript hooks fail on success", async () => {
+    const calls: string[] = [];
+
+    await assertRejects(
+      () =>
+        runHostedLifecycle({
+          abortSignal: createAbortSignal(),
+          execution: {
+            stream: {
+              async *[Symbol.asyncIterator]() {
+                yield "chunk";
+              },
+            },
+            waitForFinish: async () => {
+              calls.push("waitForFinish");
+            },
+          },
+          adapter: {
+            startRun: () => ({ runId: "run-1" }),
+            persistTranscriptTerminalState: () => {
+              calls.push("persistTerminal");
+              throw new Error("persist failed");
+            },
+            onTerminalState: () => {
+              calls.push("onTerminal");
+            },
+            finalizeRun: () => {
+              calls.push("finalize");
+            },
+          },
+          resolveTerminalState: () => ({ status: "completed" }),
+        }),
+      Error,
+      "persist failed",
+    );
+
+    assertEquals(calls, ["waitForFinish", "persistTerminal", "onTerminal", "finalize"]);
+  });
+
+  it("rethrows the original execution error even when terminal hooks fail", async () => {
+    const calls: string[] = [];
+    const executionError = new Error("stream exploded");
+
+    await assertRejects(
+      () =>
+        runHostedLifecycle({
+          abortSignal: createAbortSignal(),
+          execution: {
+            stream: {
+              [Symbol.asyncIterator]() {
+                return {
+                  next: async () => {
+                    throw executionError;
+                  },
+                };
+              },
+            },
+            waitForFinish: async () => {},
+          },
+          adapter: {
+            startRun: () => ({ runId: "run-1" }),
+            onTerminalState: () => {
+              calls.push("onTerminal");
+              throw new Error("observer failed");
+            },
+            finalizeRun: () => {
+              calls.push("finalize");
+            },
+          },
+          resolveTerminalState: () => ({ status: "completed" }),
+        }),
+      Error,
+      "stream exploded",
+    );
+
+    assertEquals(calls, ["onTerminal", "finalize"]);
+  });
+});

--- a/src/agent/hosted-lifecycle.ts
+++ b/src/agent/hosted-lifecycle.ts
@@ -1,0 +1,159 @@
+export interface HostedLifecycleTerminalState {
+  status: "completed" | "failed" | "cancelled";
+  metadata?: {
+    modelId?: string;
+    usage?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cachedInputTokens?: number;
+    };
+  };
+  terminalErrorCode?: string | null;
+  terminalErrorMessage?: string | null;
+}
+
+export interface HostedLifecycleExecution<TChunk> {
+  stream: AsyncIterable<TChunk>;
+  waitForFinish: () => Promise<void>;
+}
+
+export interface HostedLifecycleAdapter<TRun, TChunk> {
+  startRun: (input: { abortSignal: AbortSignal }) => Promise<TRun> | TRun;
+  appendEvents?: (run: TRun, chunk: TChunk) => Promise<void> | void;
+  persistTranscriptChunk?: (run: TRun, chunk: TChunk) => Promise<void> | void;
+  persistTranscriptTerminalState?: (
+    run: TRun,
+    terminalState: HostedLifecycleTerminalState,
+  ) => Promise<void> | void;
+  onTerminalState?: (
+    run: TRun,
+    terminalState: HostedLifecycleTerminalState,
+  ) => Promise<void> | void;
+  finalizeRun?: (run: TRun, terminalState: HostedLifecycleTerminalState) => Promise<void> | void;
+  cancelRun?: (run: TRun, terminalState: HostedLifecycleTerminalState) => Promise<void> | void;
+}
+
+export interface HostedLifecycleRunnerOptions<TRun, TChunk> {
+  abortSignal: AbortSignal;
+  execution: HostedLifecycleExecution<TChunk>;
+  adapter: HostedLifecycleAdapter<TRun, TChunk>;
+  resolveTerminalState: () => Promise<HostedLifecycleTerminalState> | HostedLifecycleTerminalState;
+  resolveErrorTerminalState?: (
+    error: unknown,
+  ) => Promise<HostedLifecycleTerminalState> | HostedLifecycleTerminalState;
+}
+
+export interface HostedLifecycleRunResult<TRun> {
+  run: TRun;
+  terminalState: HostedLifecycleTerminalState;
+}
+
+function getTerminalErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function defaultErrorTerminalState(
+  abortSignal: AbortSignal,
+  error: unknown,
+): HostedLifecycleTerminalState {
+  if (abortSignal.aborted) {
+    return {
+      status: "cancelled",
+      terminalErrorCode: "ABORTED",
+      terminalErrorMessage: getTerminalErrorMessage(error),
+    };
+  }
+
+  return {
+    status: "failed",
+    terminalErrorCode: "STREAM_ERROR",
+    terminalErrorMessage: getTerminalErrorMessage(error),
+  };
+}
+
+async function captureHookError(
+  callback: (() => Promise<void> | void) | undefined,
+): Promise<unknown | null> {
+  if (!callback) {
+    return null;
+  }
+
+  try {
+    await callback();
+    return null;
+  } catch (error) {
+    return error;
+  }
+}
+
+async function runTerminalHooks<TRun, TChunk>(input: {
+  run: TRun;
+  terminalState: HostedLifecycleTerminalState;
+  adapter: HostedLifecycleAdapter<TRun, TChunk>;
+}): Promise<void> {
+  let firstHookError: unknown | null = null;
+
+  const persistError = await captureHookError(() =>
+    input.adapter.persistTranscriptTerminalState?.(input.run, input.terminalState)
+  );
+  if (persistError) {
+    firstHookError = persistError;
+  }
+
+  const terminalObserverError = await captureHookError(() =>
+    input.adapter.onTerminalState?.(input.run, input.terminalState)
+  );
+  if (!firstHookError && terminalObserverError) {
+    firstHookError = terminalObserverError;
+  }
+
+  const terminalControlError = await captureHookError(() =>
+    input.terminalState.status === "cancelled"
+      ? input.adapter.cancelRun?.(input.run, input.terminalState)
+      : input.adapter.finalizeRun?.(input.run, input.terminalState)
+  );
+
+  if (firstHookError) {
+    throw firstHookError;
+  }
+
+  if (terminalControlError) {
+    throw terminalControlError;
+  }
+}
+
+export async function runHostedLifecycle<TRun, TChunk>(
+  options: HostedLifecycleRunnerOptions<TRun, TChunk>,
+): Promise<HostedLifecycleRunResult<TRun>> {
+  const run = await options.adapter.startRun({ abortSignal: options.abortSignal });
+
+  try {
+    for await (const chunk of options.execution.stream) {
+      await options.adapter.appendEvents?.(run, chunk);
+      await options.adapter.persistTranscriptChunk?.(run, chunk);
+    }
+
+    await options.execution.waitForFinish();
+  } catch (error) {
+    const terminalState = options.resolveErrorTerminalState
+      ? await options.resolveErrorTerminalState(error)
+      : defaultErrorTerminalState(options.abortSignal, error);
+
+    await runTerminalHooks({
+      run,
+      terminalState,
+      adapter: options.adapter,
+    }).catch(() => undefined);
+
+    throw error;
+  }
+
+  const terminalState = await options.resolveTerminalState();
+  await runTerminalHooks({
+    run,
+    terminalState,
+    adapter: options.adapter,
+  });
+
+  return { run, terminalState };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -179,6 +179,14 @@ export {
   type CreateAgUiBrowserResponseStreamInput,
 } from "./ag-ui-browser-response-stream.ts";
 export {
+  type HostedLifecycleAdapter,
+  type HostedLifecycleExecution,
+  type HostedLifecycleRunnerOptions,
+  type HostedLifecycleRunResult,
+  type HostedLifecycleTerminalState,
+  runHostedLifecycle,
+} from "./hosted-lifecycle.ts";
+export {
   mergeToolCallInput,
   mergeToolInputDelta,
   parseDataStreamSseEvents,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.228";
+export const VERSION = "0.1.229";


### PR DESCRIPTION
## Summary\n- add a framework-owned hosted lifecycle runner and public callback contracts for start/observe/finalize/cancel sequencing\n- document the new seam and ship a minimal hosted lifecycle reference integration example\n- bump the framework version to 0.1.229\n\n## Testing\n- deno test --no-check --allow-all src/agent/hosted-lifecycle.test.ts\n- deno check src/agent/hosted-lifecycle.ts src/agent/index.ts\n- pre-push checks