### PR TITLE
Add a generic hosted child lifecycle runner

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.229",
+  "version": "0.1.230",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent-runtime-ag-ui.md
+++ b/docs/reference/agent-runtime-ag-ui.md
@@ -120,6 +120,12 @@ For durable control-plane integration, `runHostedLifecycle()` provides a
 framework-owned orchestration loop while the host keeps ownership of auth, run
 creation, append/mirror policy, finalize/cancel calls, and transcript policy.
 
+For child-run or delegated durable progress flows,
+`runHostedChildLifecycle()` provides the same kind of framework-owned
+orchestration around pending/running/completed/failed/cancelled transitions
+while the host keeps the actual control-plane transport and progress payload
+policy.
+
 For canonical runtime AG-UI hosts using `createAgUiRuntimeHandler()`, the
 package can also invoke optional lifecycle callbacks when the default hosted
 stream path sees tool calls, finishes, or fails:

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -44,6 +44,7 @@ import {
   parseAgUiRuntimeRequest,
   parseAgUiRuntimeRequestOrError,
   registerAgent,
+  runHostedChildLifecycle,
   runHostedLifecycle,
   RunResumeSessionManager,
   waitForHumanInput,
@@ -260,6 +261,7 @@ const allowedRemoteToolNames = expandAllowedRemoteToolNames({
 ```ts
 import {
   HostedLifecycleTerminalState,
+  runHostedChildLifecycle,
   HumanInputRequestSchema,
   runHostedLifecycle,
   RunResumeSessionManager,
@@ -351,6 +353,7 @@ modules.
 | `createAgUiBrowserEncoderState()`                        | `() => AgUiBrowserEncoderState`                  | Create mutable encoder state for one browser AG-UI stream.                     |
 | `buildAgUiBrowserFinalizeResponse()`                     | `(metadata) => AgentResponse \| null`            | Convert browser-finished metadata into the canonical final AgentResponse.      |
 | `runHostedLifecycle()`                                   | `(options) => Promise<HostedLifecycleRunResult>` | Orchestrate start/observe/finalize/cancel sequencing with host-owned adapters. |
+| `runHostedChildLifecycle()`                              | `(options) => Promise<HostedChildLifecycleRunResult>` | Orchestrate pending/running/completed/failed/cancelled child lifecycle sequencing with host-owned adapters. |
 | `mapRuntimeStreamEventToAgUiBrowserEvents(state, event)` | `(state, event) => AgUiBrowserEncodedEvent[]`    | Map one runtime stream event into zero or more browser/public AG-UI events.    |
 | `finalizeAgUiBrowserEvents(state, response)`             | `(state, response) => AgUiBrowserEncodedEvent[]` | Emit terminal browser/public AG-UI events after the runtime stream finishes.   |
 

--- a/src/agent/hosted-child-lifecycle.test.ts
+++ b/src/agent/hosted-child-lifecycle.test.ts
@@ -1,0 +1,148 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  type HostedChildLifecycleAdapter,
+  runHostedChildLifecycle,
+} from "./hosted-child-lifecycle.ts";
+
+describe("agent/hosted-child-lifecycle", () => {
+  it("runs pending, running, and completed around successful execution", async () => {
+    const calls: string[] = [];
+    const adapter: HostedChildLifecycleAdapter = {
+      pending: () => calls.push("pending"),
+      running: () => calls.push("running"),
+      completed: () => calls.push("completed"),
+    };
+
+    const result = await runHostedChildLifecycle({
+      adapter,
+      execute: async () => "ok",
+      resolveCompletedState: () => ({
+        status: "completed",
+        usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+      }),
+      resolveErrorState: () => ({
+        status: "failed",
+        terminalErrorCode: "FAILED",
+        terminalErrorMessage: "failed",
+      }),
+    });
+
+    assertEquals(calls, ["pending", "running", "completed"]);
+    assertEquals(result, {
+      status: "completed",
+      result: "ok",
+      terminalState: {
+        status: "completed",
+        usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+      },
+    });
+  });
+
+  it("dispatches failed state and returns the original error", async () => {
+    const calls: string[] = [];
+    const error = new Error("boom");
+    const adapter: HostedChildLifecycleAdapter = {
+      pending: () => calls.push("pending"),
+      running: () => calls.push("running"),
+      failed: (terminalState) => calls.push(`failed:${terminalState.terminalErrorCode}`),
+    };
+
+    const result = await runHostedChildLifecycle({
+      adapter,
+      execute: async () => {
+        throw error;
+      },
+      resolveErrorState: (caught) => ({
+        status: "failed",
+        terminalErrorCode: "STREAM_ERROR",
+        terminalErrorMessage: caught instanceof Error ? caught.message : String(caught),
+      }),
+    });
+
+    assertEquals(calls, ["pending", "running", "failed:STREAM_ERROR"]);
+    assertEquals(result.status, "failed");
+    assertEquals(result.error, error);
+    assertEquals(result.terminalState.terminalErrorMessage, "boom");
+  });
+
+  it("dispatches cancelled state and returns the original error", async () => {
+    const calls: string[] = [];
+    const error = new Error("aborted");
+    const adapter: HostedChildLifecycleAdapter = {
+      pending: () => calls.push("pending"),
+      running: () => calls.push("running"),
+      cancelled: (terminalState) => calls.push(`cancelled:${terminalState.terminalErrorCode}`),
+    };
+
+    const result = await runHostedChildLifecycle({
+      adapter,
+      execute: async () => {
+        throw error;
+      },
+      resolveErrorState: () => ({
+        status: "cancelled",
+        terminalErrorCode: "CANCELLED",
+        terminalErrorMessage: "Child run cancelled",
+      }),
+    });
+
+    assertEquals(calls, ["pending", "running", "cancelled:CANCELLED"]);
+    assertEquals(result.status, "cancelled");
+    assertEquals(result.error, error);
+  });
+
+  it("reports terminal hook errors through onLifecycleError for failure states", async () => {
+    const lifecycleErrors: unknown[] = [];
+    const adapter: HostedChildLifecycleAdapter = {
+      failed: () => {
+        throw new Error("persist failed");
+      },
+    };
+
+    const result = await runHostedChildLifecycle({
+      adapter,
+      execute: async () => {
+        throw new Error("boom");
+      },
+      resolveErrorState: () => ({
+        status: "failed",
+        terminalErrorCode: "STREAM_ERROR",
+        terminalErrorMessage: "boom",
+      }),
+      onLifecycleError: (error) => {
+        lifecycleErrors.push(error);
+      },
+    });
+
+    assertEquals(result.status, "failed");
+    assertEquals(lifecycleErrors.length, 1);
+    assertEquals(
+      lifecycleErrors[0] instanceof Error ? lifecycleErrors[0].message : String(lifecycleErrors[0]),
+      "persist failed",
+    );
+  });
+
+  it("still throws lifecycle hook errors on successful completion", async () => {
+    const adapter: HostedChildLifecycleAdapter = {
+      completed: () => {
+        throw new Error("persist failed");
+      },
+    };
+
+    await assertRejects(
+      () =>
+        runHostedChildLifecycle({
+          adapter,
+          execute: async () => "ok",
+          resolveErrorState: () => ({
+            status: "failed",
+            terminalErrorCode: "STREAM_ERROR",
+            terminalErrorMessage: "boom",
+          }),
+        }),
+      Error,
+      "persist failed",
+    );
+  });
+});

--- a/src/agent/hosted-child-lifecycle.ts
+++ b/src/agent/hosted-child-lifecycle.ts
@@ -1,0 +1,121 @@
+export interface HostedChildLifecycleTerminalState {
+  status: "completed" | "failed" | "cancelled";
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  };
+  terminalErrorCode?: string | null;
+  terminalErrorMessage?: string | null;
+}
+
+export interface HostedChildLifecycleCompletedState
+  extends Omit<HostedChildLifecycleTerminalState, "status"> {
+  status: "completed";
+}
+
+export interface HostedChildLifecycleAdapter {
+  pending?: () => Promise<void> | void;
+  running?: () => Promise<void> | void;
+  completed?: (
+    terminalState: HostedChildLifecycleTerminalState,
+  ) => Promise<void> | void;
+  failed?: (
+    terminalState: HostedChildLifecycleTerminalState,
+  ) => Promise<void> | void;
+  cancelled?: (
+    terminalState: HostedChildLifecycleTerminalState,
+  ) => Promise<void> | void;
+}
+
+export interface HostedChildLifecycleErrorState
+  extends Omit<HostedChildLifecycleTerminalState, "status"> {
+  status: "failed" | "cancelled";
+}
+
+export interface HostedChildLifecycleRunnerOptions<TResult> {
+  adapter: HostedChildLifecycleAdapter;
+  execute: () => Promise<TResult> | TResult;
+  resolveCompletedState?: (
+    result: TResult,
+  ) =>
+    | Promise<HostedChildLifecycleCompletedState>
+    | HostedChildLifecycleCompletedState;
+  resolveErrorState: (
+    error: unknown,
+  ) =>
+    | Promise<HostedChildLifecycleErrorState>
+    | HostedChildLifecycleErrorState;
+  onLifecycleError?: (error: unknown) => Promise<void> | void;
+}
+
+export type HostedChildLifecycleRunResult<TResult> =
+  | {
+    status: "completed";
+    result: TResult;
+    terminalState: HostedChildLifecycleTerminalState;
+  }
+  | {
+    status: "failed" | "cancelled";
+    error: unknown;
+    terminalState: HostedChildLifecycleTerminalState;
+  };
+
+async function dispatchTerminalState(
+  adapter: HostedChildLifecycleAdapter,
+  terminalState: HostedChildLifecycleTerminalState,
+): Promise<void> {
+  if (terminalState.status === "cancelled") {
+    await adapter.cancelled?.(terminalState);
+    return;
+  }
+
+  if (terminalState.status === "failed") {
+    await adapter.failed?.(terminalState);
+    return;
+  }
+
+  await adapter.completed?.(terminalState);
+}
+
+export async function runHostedChildLifecycle<TResult>(
+  options: HostedChildLifecycleRunnerOptions<TResult>,
+): Promise<HostedChildLifecycleRunResult<TResult>> {
+  await options.adapter.pending?.();
+  await options.adapter.running?.();
+
+  let result: TResult;
+  try {
+    result = await options.execute();
+  } catch (error) {
+    const terminalState = await options.resolveErrorState(error);
+
+    try {
+      await dispatchTerminalState(options.adapter, terminalState);
+    } catch (lifecycleError) {
+      if (options.onLifecycleError) {
+        await options.onLifecycleError(lifecycleError);
+      } else {
+        throw lifecycleError;
+      }
+    }
+
+    return {
+      status: terminalState.status,
+      error,
+      terminalState,
+    };
+  }
+
+  const terminalState = options.resolveCompletedState
+    ? await options.resolveCompletedState(result)
+    : { status: "completed" as const };
+
+  await dispatchTerminalState(options.adapter, terminalState);
+
+  return {
+    status: "completed",
+    result,
+    terminalState,
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -179,6 +179,13 @@ export {
   type CreateAgUiBrowserResponseStreamInput,
 } from "./ag-ui-browser-response-stream.ts";
 export {
+  type HostedChildLifecycleAdapter,
+  type HostedChildLifecycleRunnerOptions,
+  type HostedChildLifecycleRunResult,
+  type HostedChildLifecycleTerminalState,
+  runHostedChildLifecycle,
+} from "./hosted-child-lifecycle.ts";
+export {
   type HostedLifecycleAdapter,
   type HostedLifecycleExecution,
   type HostedLifecycleRunnerOptions,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.229";
+export const VERSION = "0.1.230";


### PR DESCRIPTION
## Summary
- add a transport-agnostic hosted child lifecycle runner for pending/running/completed/failed/cancelled sequencing
- export the new helper from `veryfront/agent` and document it alongside the hosted lifecycle runner
- bump the package version to `0.1.230`

## Testing
- deno test --no-check --allow-all src/agent/hosted-child-lifecycle.test.ts
- deno check src/agent/hosted-child-lifecycle.ts src/agent/index.ts