### PR TITLE
Publish control-plane channel contracts through the package

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.230",
+  "version": "0.1.231",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [
@@ -30,6 +30,8 @@
     "./markdown": "./src/markdown/index.ts",
     "./mdx": "./src/mdx/index.ts",
     "./agent": "./src/agent/index.ts",
+    "./channels/control-plane": "./src/channels/control-plane.ts",
+    "./channels/invoke": "./src/channels/invoke.ts",
     "./tool": "./src/tool/index.ts",
     "./workflow": "./src/workflow/index.ts",
     "./workflow/worker": "./src/workflow/worker/index.ts",

--- a/docs/reference/agent-runtime-ag-ui-contract.md
+++ b/docs/reference/agent-runtime-ag-ui-contract.md
@@ -89,6 +89,13 @@ Current internal signed control-plane wrappers:
 - `POST /internal/agents/runs/:runId/resume`
 - `DELETE /internal/agents/runs/:runId`
 
+When a host needs to interoperate with the signed control-plane wrapper shape
+directly, the current request/response schemas and signature verification
+helpers are available as public package exports:
+
+- `veryfront/channels/control-plane`
+- `veryfront/channels/invoke`
+
 Those internal handlers are Veryfront-specific wrappers around the generic
 package-hosted run-control surface. Downstream package consumers should target
 the public `veryfront/agent` handlers instead of these internal routes.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -32,6 +32,8 @@ npm install veryfront
 | [`veryfront/markdown`](./markdown.md)         | Markdown rendering with syntax highlighting and diagrams.                                                                                                             |
 | [`veryfront/mdx`](./mdx.md)                   | Component overrides for `.mdx` page rendering.                                                                                                                        |
 | [`veryfront/agent`](./agent.md)               | AI agents with memory, tools, and multi-agent composition.                                                                                                            |
+| `veryfront/channels/control-plane`            | Public schemas and signature verification helpers for the signed control-plane agent discovery surface.                                                                |
+| `veryfront/channels/invoke`                   | Public schemas and helpers for channel/assistant invocation payloads built on the control-plane contracts.                                                             |
 | [`veryfront/tool`](./tool.md)                 | Define tools with Zod schemas for agents and MCP.                                                                                                                     |
 | [`veryfront/workflow`](./workflow.md)         | DAG-based agentic workflows with human-in-the-loop support.                                                                                                           |
 | [`veryfront/prompt`](./prompt.md)             | Declare and register prompts exposable over MCP.                                                                                                                      |

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.230";
+export const VERSION = "0.1.231";


### PR DESCRIPTION
## Summary
- export the existing control-plane and channel invoke contract modules through the public package map
- bump the package version to `0.1.231`
- document the new imports alongside the AG-UI/control-plane compatibility guidance

## Testing
- deno eval --config deno.json "import { ControlPlaneAgentsListRequestSchema, verifyControlPlaneJws } from "veryfront/channels/control-plane"; import { ChannelInvokeRequestSchema, executeChannelInvoke } from "veryfront/channels/invoke"; console.log(Boolean(ControlPlaneAgentsListRequestSchema && verifyControlPlaneJws && ChannelInvokeRequestSchema && executeChannelInvoke));"