### PR TITLE
Add a public control-plane route family for agent runs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.230",
+  "version": "0.1.231",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [
@@ -30,6 +30,8 @@
     "./markdown": "./src/markdown/index.ts",
     "./mdx": "./src/mdx/index.ts",
     "./agent": "./src/agent/index.ts",
+    "./channels/control-plane": "./src/channels/control-plane.ts",
+    "./channels/invoke": "./src/channels/invoke.ts",
     "./tool": "./src/tool/index.ts",
     "./workflow": "./src/workflow/index.ts",
     "./workflow/worker": "./src/workflow/worker/index.ts",

--- a/docs/reference/agent-runtime-ag-ui-contract.md
+++ b/docs/reference/agent-runtime-ag-ui-contract.md
@@ -80,11 +80,18 @@ Recommended default convention:
 
 Hosts may override the route when needed.
 
-Current internal compatibility route:
+Public control-plane wrapper convention:
+
+- `POST /api/control-plane/agents/list`
+- `POST /api/control-plane/agents/stream`
+- `POST /api/control-plane/agents/runs/:runId/resume`
+- `DELETE /api/control-plane/agents/runs/:runId`
+
+Legacy internal compatibility route:
 
 - `POST /internal/agents/stream`
 
-Current internal signed control-plane wrappers:
+Legacy internal signed control-plane wrappers:
 
 - `POST /internal/agents/runs/:runId/resume`
 - `DELETE /internal/agents/runs/:runId`
@@ -111,4 +118,4 @@ Downstream package/framework consumers should target:
 - AG-UI SSE responses
 - the default endpoint convention `/api/ag-ui` unless a host explicitly documents another route
 
-They should not treat `/internal/agents/stream` and its extra wrapper fields as the long-term package contract.
+They should not treat `/internal/agents/stream` and its extra wrapper fields as the long-term package contract when the public `/api/control-plane/agents/*` route family is available.

--- a/docs/reference/agent-runtime-ag-ui-contract.md
+++ b/docs/reference/agent-runtime-ag-ui-contract.md
@@ -89,6 +89,13 @@ Current internal signed control-plane wrappers:
 - `POST /internal/agents/runs/:runId/resume`
 - `DELETE /internal/agents/runs/:runId`
 
+When a host needs to interoperate with the signed control-plane wrapper shape
+directly, the current request/response schemas and signature verification
+helpers are available as public package exports:
+
+- `veryfront/channels/control-plane`
+- `veryfront/channels/invoke`
+
 Those internal handlers are Veryfront-specific wrappers around the generic
 package-hosted run-control surface. Downstream package consumers should target
 the public `veryfront/agent` handlers instead of these internal routes.

--- a/docs/reference/agent-runtime-ag-ui.md
+++ b/docs/reference/agent-runtime-ag-ui.md
@@ -9,7 +9,7 @@ order: 10
 The `veryfront/agent` package supports a generic AG-UI transport for hosted
 agent runtimes.
 
-This is the package-level AG-UI contract. Veryfront Studio's internal `/internal/agents/*` routes are compatibility/control-plane wrappers, not the canonical public package surface.
+This is the package-level AG-UI contract. The public control-plane wrapper convention is `/api/control-plane/agents/*`; Veryfront Studio's legacy `/internal/agents/*` routes remain compatibility aliases, not the canonical public package surface.
 
 ## Contract
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -32,6 +32,8 @@ npm install veryfront
 | [`veryfront/markdown`](./markdown.md)         | Markdown rendering with syntax highlighting and diagrams.                                                                                                             |
 | [`veryfront/mdx`](./mdx.md)                   | Component overrides for `.mdx` page rendering.                                                                                                                        |
 | [`veryfront/agent`](./agent.md)               | AI agents with memory, tools, and multi-agent composition.                                                                                                            |
+| `veryfront/channels/control-plane`            | Public schemas and signature verification helpers for the signed control-plane agent discovery surface.                                                                |
+| `veryfront/channels/invoke`                   | Public schemas and helpers for channel/assistant invocation payloads built on the control-plane contracts.                                                             |
 | [`veryfront/tool`](./tool.md)                 | Define tools with Zod schemas for agents and MCP.                                                                                                                     |
 | [`veryfront/workflow`](./workflow.md)         | DAG-based agentic workflows with human-in-the-loop support.                                                                                                           |
 | [`veryfront/prompt`](./prompt.md)             | Declare and register prompts exposable over MCP.                                                                                                                      |

--- a/src/channels/control-plane.ts
+++ b/src/channels/control-plane.ts
@@ -6,6 +6,13 @@ import { z } from "zod";
 
 const SIGNATURE_SKEW_SECONDS = 5;
 
+export const CONTROL_PLANE_AGENTS_LIST_PATH = "/api/control-plane/agents/list";
+export const CONTROL_PLANE_AGENT_STREAM_PATH = "/api/control-plane/agents/stream";
+export const CONTROL_PLANE_AGENT_RUNS_PATH_PREFIX = "/api/control-plane/agents/runs/";
+export const LEGACY_INTERNAL_AGENTS_LIST_PATH = "/internal/agents/list";
+export const LEGACY_INTERNAL_AGENT_STREAM_PATH = "/internal/agents/stream";
+export const LEGACY_INTERNAL_AGENT_RUNS_PATH_PREFIX = "/internal/agents/runs/";
+
 const compactJwsHeaderSchema = z.object({
   alg: z.literal("EdDSA"),
   typ: z.string().optional(),

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -70,6 +70,7 @@ const INTERNAL_CONTROL_PLANE_SIGNATURE_HEADERS = [
 
 function isInternalControlPlanePath(pathname: string): boolean {
   return pathname === "/channels/invoke" ||
+    pathname.startsWith("/api/control-plane/agents/") ||
     pathname.startsWith("/internal/agents/") ||
     pathname.startsWith("/internal/tasks/") ||
     pathname.startsWith("/internal/workflows/");

--- a/src/server/handlers/request/agent-run-cancel.handler.test.ts
+++ b/src/server/handlers/request/agent-run-cancel.handler.test.ts
@@ -31,6 +31,31 @@ describe("server/handlers/request/agent-run-cancel.handler", () => {
     assertEquals(sessionManager.getRunStatus("run_1"), null);
   });
 
+  it("accepts the public control-plane cancel route", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    const handler = new AgentRunCancelHandler(sessionManager);
+    const body = JSON.stringify({ runId: "run_1" });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/api/control-plane/agents/runs/run_1", {
+        method: "DELETE",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 202);
+    assertEquals(sessionManager.getRunStatus("run_1"), null);
+  });
+
   it("returns 204 when the run is already inactive", async () => {
     const handler = new AgentRunCancelHandler(new AgentRunSessionManager());
     const body = JSON.stringify({ runId: "run_1" });

--- a/src/server/handlers/request/agent-run-cancel.handler.ts
+++ b/src/server/handlers/request/agent-run-cancel.handler.ts
@@ -1,4 +1,8 @@
 import {
+  CONTROL_PLANE_AGENT_RUNS_PATH_PREFIX,
+  LEGACY_INTERNAL_AGENT_RUNS_PATH_PREFIX,
+} from "#veryfront/channels/control-plane.ts";
+import {
   ControlPlaneRequestError,
   verifyControlPlaneRequest,
 } from "#veryfront/internal-agents/control-plane-auth.ts";
@@ -15,7 +19,7 @@ import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 
-const CANCEL_PATH_REGEX = /^\/internal\/agents\/runs\/([^/]+)$/;
+const CANCEL_PATH_REGEX = /^\/(?:api\/control-plane\/agents|internal\/agents)\/runs\/([^/]+)$/;
 
 function getRunId(pathname: string): string | null {
   return CANCEL_PATH_REGEX.exec(pathname)?.[1] ?? null;
@@ -25,7 +29,10 @@ export class AgentRunCancelHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "AgentRunCancelHandler",
     priority: PRIORITY_MEDIUM_API as HandlerPriority,
-    patterns: [{ pattern: "/internal/agents/runs/", prefix: true, method: "DELETE" }],
+    patterns: [
+      { pattern: CONTROL_PLANE_AGENT_RUNS_PATH_PREFIX, prefix: true, method: "DELETE" },
+      { pattern: LEGACY_INTERNAL_AGENT_RUNS_PATH_PREFIX, prefix: true, method: "DELETE" },
+    ],
   };
 
   constructor(private readonly sessionManager: AgentRunSessionManager = agentRunSessionManager) {

--- a/src/server/handlers/request/agent-run-resume.handler.test.ts
+++ b/src/server/handlers/request/agent-run-resume.handler.test.ts
@@ -37,6 +37,36 @@ describe("server/handlers/request/agent-run-resume.handler", () => {
     assertEquals(await pending, { result: { ok: true }, isError: false });
   });
 
+  it("accepts the public control-plane resume route", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    const pending = sessionManager.waitForToolResult("run_1", "tool_1");
+
+    const handler = new AgentRunResumeHandler(sessionManager);
+    const body = JSON.stringify({
+      type: "tool_result",
+      toolCallId: "tool_1",
+      result: { ok: true },
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/api/control-plane/agents/runs/run_1/resume", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals(await pending, { result: { ok: true }, isError: false });
+  });
+
   it("returns duplicate=true for a repeated identical tool result", async () => {
     const sessionManager = new AgentRunSessionManager();
     sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });

--- a/src/server/handlers/request/agent-run-resume.handler.ts
+++ b/src/server/handlers/request/agent-run-resume.handler.ts
@@ -1,4 +1,8 @@
 import {
+  CONTROL_PLANE_AGENT_RUNS_PATH_PREFIX,
+  LEGACY_INTERNAL_AGENT_RUNS_PATH_PREFIX,
+} from "#veryfront/channels/control-plane.ts";
+import {
   ControlPlaneRequestError,
   verifyControlPlaneRequest,
 } from "#veryfront/internal-agents/control-plane-auth.ts";
@@ -19,7 +23,8 @@ import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 
-const RESUME_PATH_REGEX = /^\/internal\/agents\/runs\/([^/]+)\/resume$/;
+const RESUME_PATH_REGEX =
+  /^\/(?:api\/control-plane\/agents|internal\/agents)\/runs\/([^/]+)\/resume$/;
 
 function getRunId(pathname: string): string | null {
   return RESUME_PATH_REGEX.exec(pathname)?.[1] ?? null;
@@ -29,7 +34,10 @@ export class AgentRunResumeHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "AgentRunResumeHandler",
     priority: PRIORITY_MEDIUM_API as HandlerPriority,
-    patterns: [{ pattern: "/internal/agents/runs/", prefix: true, method: "POST" }],
+    patterns: [
+      { pattern: CONTROL_PLANE_AGENT_RUNS_PATH_PREFIX, prefix: true, method: "POST" },
+      { pattern: LEGACY_INTERNAL_AGENT_RUNS_PATH_PREFIX, prefix: true, method: "POST" },
+    ],
   };
 
   constructor(private readonly sessionManager: AgentRunSessionManager = agentRunSessionManager) {

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -131,6 +131,51 @@ describe("server/handlers/request/agent-stream.handler", () => {
     assertStringIncludes(text, "event: ReasoningMessageEnd");
   });
 
+  it("accepts the public control-plane stream route", async () => {
+    const handler = new AgentStreamHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: (id) => id === "assistant-1" ? createAgent("assistant-1") : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+      sessionManager: new AgentRunSessionManager(),
+      createRuntime: () => ({
+        stream: async (_messages, _context, callbacks) => {
+          callbacks?.onFinish?.({
+            text: "hello from runtime",
+            messages: [],
+            toolCalls: [],
+            status: "completed",
+            usage: undefined,
+            metadata: { finishReason: "stop" },
+          });
+
+          return new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.close();
+            },
+          });
+        },
+      }),
+    });
+
+    const body = createAgentStreamRequestBody();
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, { requestId: "run_1" });
+
+    const result = await handler.handle(
+      new Request("https://example.com/api/control-plane/agents/stream", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+  });
+
   it("accepts the canonical runtime AG-UI request shape on the existing internal stream route", async () => {
     let streamContext: Record<string, unknown> | undefined;
 

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -1,6 +1,10 @@
 import type { Agent } from "#veryfront/agent";
 import { defaultChannelInvokeDeps } from "#veryfront/channels/invoke.ts";
-import { type RuntimeAgentDiscoveryDeps } from "#veryfront/channels/control-plane.ts";
+import {
+  CONTROL_PLANE_AGENT_STREAM_PATH,
+  LEGACY_INTERNAL_AGENT_STREAM_PATH,
+  type RuntimeAgentDiscoveryDeps,
+} from "#veryfront/channels/control-plane.ts";
 import {
   createRuntimeAgentStreamResponse,
   type RuntimeAgentStreamExecutionDeps,
@@ -116,7 +120,10 @@ export class AgentStreamHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "AgentStreamHandler",
     priority: PRIORITY_MEDIUM_API as HandlerPriority,
-    patterns: [{ pattern: "/internal/agents/stream", exact: true, method: "POST" }],
+    patterns: [
+      { pattern: CONTROL_PLANE_AGENT_STREAM_PATH, exact: true, method: "POST" },
+      { pattern: LEGACY_INTERNAL_AGENT_STREAM_PATH, exact: true, method: "POST" },
+    ],
   };
 
   constructor(private readonly deps: AgentStreamHandlerDeps = defaultDeps) {

--- a/src/server/handlers/request/internal-agents-list.handler.test.ts
+++ b/src/server/handlers/request/internal-agents-list.handler.test.ts
@@ -66,6 +66,38 @@ describe("server/handlers/request/internal-agents-list.handler", () => {
     });
   });
 
+  it("accepts the public control-plane agents list route", async () => {
+    const handler = new InternalAgentsListHandler({
+      ensureProjectDiscovery: async () => {},
+      getAgent: (id) => id === "assistant-1" ? createAgentWithConfig("assistant-1") : undefined,
+      getAllAgentIds: () => ["assistant-1"],
+    });
+
+    const body = JSON.stringify({
+      requestId: "agents-1",
+      projectId: "proj-1",
+      surface: "studio",
+    });
+    const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+      requestId: "agents-1",
+    });
+
+    const result = await handler.handle(
+      new Request("https://example.com/api/control-plane/agents/list", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-veryfront-control-plane-jws": jws,
+        },
+        body,
+      }),
+      createCtx(publicKeyPem),
+    );
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+  });
+
   it("returns 401 when the control-plane signature is missing", async () => {
     const handler = new InternalAgentsListHandler({
       ensureProjectDiscovery: async () => {},

--- a/src/server/handlers/request/internal-agents-list.handler.ts
+++ b/src/server/handlers/request/internal-agents-list.handler.ts
@@ -1,8 +1,10 @@
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import {
+  CONTROL_PLANE_AGENTS_LIST_PATH,
   type ControlPlaneAgentsListRequest,
   ControlPlaneAgentsListRequestSchema,
+  LEGACY_INTERNAL_AGENTS_LIST_PATH,
   listRuntimeAgents,
   type RuntimeAgentDiscoveryDeps,
 } from "../../../channels/control-plane.ts";
@@ -23,7 +25,10 @@ export class InternalAgentsListHandler extends BaseHandler {
   metadata: HandlerMetadata = {
     name: "InternalAgentsListHandler",
     priority: PRIORITY_MEDIUM_API as HandlerPriority,
-    patterns: [{ pattern: "/internal/agents/list", exact: true, method: "POST" }],
+    patterns: [
+      { pattern: CONTROL_PLANE_AGENTS_LIST_PATH, exact: true, method: "POST" },
+      { pattern: LEGACY_INTERNAL_AGENTS_LIST_PATH, exact: true, method: "POST" },
+    ],
   };
 
   constructor(private readonly deps: RuntimeAgentDiscoveryDeps = defaultChannelInvokeDeps) {

--- a/src/server/runtime-handler/environment-resolution.test.ts
+++ b/src/server/runtime-handler/environment-resolution.test.ts
@@ -66,6 +66,26 @@ describe("environment-resolution", () => {
     assertEquals(result.releaseId, undefined);
   });
 
+  it("allows public control-plane agent paths without releaseId in proxy production", () => {
+    const result = resolveEnvironment({
+      proxyEnv: "production",
+      reqCtxMode: "production",
+      releaseId: undefined,
+      projectSlug: "my-project",
+      projectId: "proj_123",
+      environmentName: undefined,
+      host: "10.192.2.245:20000",
+      isLocalProject: false,
+      isProxyMode: true,
+      pathname: "/api/control-plane/agents/runs/run_1",
+      defaultEnvironment: undefined,
+    });
+
+    assertEquals(result.errorResponse, undefined);
+    assertEquals(result.resolvedEnvironment, "production");
+    assertEquals(result.releaseId, undefined);
+  });
+
   it("still requires releaseId for non-control-plane proxy production paths", () => {
     const result = resolveEnvironment({
       proxyEnv: "production",

--- a/src/server/runtime-handler/environment-resolution.ts
+++ b/src/server/runtime-handler/environment-resolution.ts
@@ -64,7 +64,8 @@ export function resolveEnvironment(
 
   // Some internal framework surfaces are routed directly to a runtime owner pod and
   // rely on signed control-plane auth instead of a user-facing release address.
-  const isInternalAgentControlPlanePath = opts.pathname.startsWith("/internal/agents/");
+  const isInternalAgentControlPlanePath = opts.pathname.startsWith("/internal/agents/") ||
+    opts.pathname.startsWith("/api/control-plane/agents/");
 
   // Skip releaseId validation for development assets and signed internal control-plane
   // requests because they do not require a user-facing release context.

--- a/src/server/runtime-handler/request-utils.test.ts
+++ b/src/server/runtime-handler/request-utils.test.ts
@@ -141,6 +141,11 @@ describe("request-utils", () => {
       assertEquals(shouldSkipEnrichedContext("/internal/agents/list"), true);
     });
 
+    it("returns true for public control-plane agent routes", () => {
+      assertEquals(shouldSkipEnrichedContext("/api/control-plane/agents/list"), true);
+      assertEquals(shouldSkipEnrichedContext("/api/control-plane/agents/runs/run_1"), true);
+    });
+
     it("returns false for render routes", () => {
       assertEquals(shouldSkipEnrichedContext("/"), false);
       assertEquals(shouldSkipEnrichedContext("/bench/interactive"), false);

--- a/src/server/runtime-handler/request-utils.ts
+++ b/src/server/runtime-handler/request-utils.ts
@@ -84,5 +84,6 @@ export function isWebSocketPath(pathname: string): boolean {
  * render cache prefix/content-source derivation and the enriched render payload.
  */
 export function shouldSkipEnrichedContext(pathname: string): boolean {
-  return pathname.startsWith("/api/") || pathname.startsWith("/internal/agents/");
+  return pathname.startsWith("/api/") || pathname.startsWith("/internal/agents/") ||
+    pathname.startsWith("/api/control-plane/agents/");
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.230";
+export const VERSION = "0.1.231";


### PR DESCRIPTION
## Summary
- add a stable `/api/control-plane/agents/*` route family for agent list/stream/run-control endpoints
- keep `/internal/agents/*` as compatibility aliases while the public route becomes the production-grade contract
- update runtime utilities and docs so both route families are treated consistently during the transition

## Testing
- deno test --no-check --allow-all src/server/runtime-handler/request-utils.test.ts src/server/runtime-handler/environment-resolution.test.ts src/server/handlers/request/internal-agents-list.handler.test.ts src/server/handlers/request/agent-run-resume.handler.test.ts src/server/handlers/request/agent-run-cancel.handler.test.ts src/server/handlers/request/agent-stream.handler.test.ts
- deno eval --config deno.json "import { ControlPlaneAgentsListRequestSchema, CONTROL_PLANE_AGENT_STREAM_PATH } from "veryfront/channels/control-plane"; import { ChannelInvokeRequestSchema } from "veryfront/channels/invoke"; console.log(ControlPlaneAgentsListRequestSchema.shape.requestId !== undefined && CONTROL_PLANE_AGENT_STREAM_PATH === "/api/control-plane/agents/stream" && !!ChannelInvokeRequestSchema);"