### PR TITLE
Add a reusable conversation-backed durable agent run client

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.231",
+  "version": "0.1.232",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [
@@ -30,6 +30,7 @@
     "./markdown": "./src/markdown/index.ts",
     "./mdx": "./src/mdx/index.ts",
     "./agent": "./src/agent/index.ts",
+    "./agent/durable": "./src/agent/durable.ts",
     "./channels/control-plane": "./src/channels/control-plane.ts",
     "./channels/invoke": "./src/channels/invoke.ts",
     "./tool": "./src/tool/index.ts",

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -354,6 +354,9 @@ modules.
 | `buildAgUiBrowserFinalizeResponse()`                     | `(metadata) => AgentResponse \| null`            | Convert browser-finished metadata into the canonical final AgentResponse.      |
 | `runHostedLifecycle()`                                   | `(options) => Promise<HostedLifecycleRunResult>` | Orchestrate start/observe/finalize/cancel sequencing with host-owned adapters. |
 | `runHostedChildLifecycle()`                              | `(options) => Promise<HostedChildLifecycleRunResult>` | Orchestrate pending/running/completed/failed/cancelled child lifecycle sequencing with host-owned adapters. |
+| `createConversationAgentRun()`                           | `(input) => Promise<ConversationRunProjection>`  | Create a conversation-owned durable agent run and read back its canonical projection. |
+| `finalizeConversationAgentRun()`                         | `(input) => Promise<void>`                       | Finalize a conversation-owned durable agent run through the canonical complete route. |
+| `resolveConversationRunTargets()`                        | `({ projectId?, branchId? }) => ConversationRunTargets` | Resolve project/branch target metadata for durable conversation-backed runs. |
 | `mapRuntimeStreamEventToAgUiBrowserEvents(state, event)` | `(state, event) => AgUiBrowserEncodedEvent[]`    | Map one runtime stream event into zero or more browser/public AG-UI events.    |
 | `finalizeAgUiBrowserEvents(state, response)`             | `(state, response) => AgUiBrowserEncodedEvent[]` | Emit terminal browser/public AG-UI events after the runtime stream finishes.   |
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -32,6 +32,7 @@ npm install veryfront
 | [`veryfront/markdown`](./markdown.md)         | Markdown rendering with syntax highlighting and diagrams.                                                                                                             |
 | [`veryfront/mdx`](./mdx.md)                   | Component overrides for `.mdx` page rendering.                                                                                                                        |
 | [`veryfront/agent`](./agent.md)               | AI agents with memory, tools, and multi-agent composition.                                                                                                            |
+| `veryfront/agent/durable`                     | Conversation-backed durable run helpers for hosts that integrate agent runs with a control-plane conversations API.                                                   |
 | `veryfront/channels/control-plane`            | Public schemas and signature verification helpers for the signed control-plane agent discovery surface.                                                                |
 | `veryfront/channels/invoke`                   | Public schemas and helpers for channel/assistant invocation payloads built on the control-plane contracts.                                                             |
 | [`veryfront/tool`](./tool.md)                 | Define tools with Zod schemas for agents and MCP.                                                                                                                     |

--- a/src/agent/durable.test.ts
+++ b/src/agent/durable.test.ts
@@ -1,0 +1,278 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  createConversationAgentRun,
+  finalizeConversationAgentRun,
+  resolveConversationRunTargets,
+} from "./durable.ts";
+
+const API_URL = "https://api.example.com";
+const AUTH_TOKEN = "token-123";
+const CONVERSATION_ID = "11111111-1111-4111-a111-111111111111";
+const MESSAGE_ID = "22222222-2222-4222-a222-222222222222";
+const PROJECT_ID = "33333333-3333-4333-a333-333333333333";
+const BRANCH_ID = "44444444-4444-4444-8444-444444444444";
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function acceptedRunResponse(run: unknown): Response {
+  return jsonResponse(
+    {
+      accepted: true,
+      run,
+    },
+    202,
+  );
+}
+
+function durableRunProjection(overrides: Record<string, unknown> = {}) {
+  return {
+    run_id: "run_root_1",
+    conversation_id: CONVERSATION_ID,
+    message_id: MESSAGE_ID,
+    latest_event_id: 1,
+    latest_external_event_sequence: 1,
+    status: "running",
+    project_id: null,
+    ...overrides,
+  };
+}
+
+function camelCaseDurableRunProjection(overrides: Record<string, unknown> = {}) {
+  return {
+    runId: "run_child_2",
+    conversationId: CONVERSATION_ID,
+    messageId: MESSAGE_ID,
+    latestEventId: 0,
+    latestExternalEventSequence: 0,
+    status: "running",
+    projectId: null,
+    ...overrides,
+  };
+}
+
+type FetchCall = [RequestInfo | URL, RequestInit | undefined];
+
+function stubFetchSequence(...steps: Response[]): FetchCall[] {
+  const queue = [...steps];
+  const calls: FetchCall[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push([input, init]);
+    const next = queue.shift();
+    if (!next) {
+      throw new Error("Unexpected fetch call");
+    }
+
+    return next;
+  }) as typeof fetch;
+  return calls;
+}
+
+describe("agent/durable", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("resolves non-project run targets to nulls", () => {
+    assertEquals(resolveConversationRunTargets({ projectId: null, branchId: null }), {
+      sourceTargetKind: null,
+      runtimeTargetKind: null,
+      targetBranchId: null,
+    });
+  });
+
+  it("resolves project preview targets when a branch is present", () => {
+    assertEquals(resolveConversationRunTargets({ projectId: PROJECT_ID, branchId: BRANCH_ID }), {
+      sourceTargetKind: "preview_branch",
+      runtimeTargetKind: "preview_branch",
+      targetBranchId: BRANCH_ID,
+    });
+  });
+
+  it("creates a conversation-owned durable run without target metadata for non-project runs", async () => {
+    const fetchCalls = stubFetchSequence(
+      acceptedRunResponse({ run_id: "run_root_1" }),
+      jsonResponse(durableRunProjection(), 200),
+    );
+
+    await createConversationAgentRun({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      runId: "run_root_1",
+      agentId: "default-chat",
+      projectId: null,
+      branchId: null,
+    });
+
+    assertEquals(
+      JSON.parse(String(fetchCalls[0]?.[1]?.body)),
+      {
+        kind: "agent",
+        owner: {
+          kind: "conversation",
+          id: CONVERSATION_ID,
+        },
+        public_id: "run_root_1",
+        request: {
+          mode: "default_chat",
+          agent_id: "default-chat",
+          initial_status: "running",
+        },
+      },
+    );
+  });
+
+  it("preserves preview target metadata for project-backed runs", async () => {
+    const fetchCalls = stubFetchSequence(
+      acceptedRunResponse({ run_id: "run_child_1" }),
+      jsonResponse(
+        durableRunProjection({
+          run_id: "run_child_1",
+          project_id: PROJECT_ID,
+          source_target_kind: "preview_branch",
+        }),
+        200,
+      ),
+    );
+
+    await createConversationAgentRun({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      runId: "run_child_1",
+      agentId: "invoke-agent-child",
+      projectId: PROJECT_ID,
+      branchId: BRANCH_ID,
+    });
+
+    assertEquals(
+      JSON.parse(String(fetchCalls[0]?.[1]?.body)),
+      {
+        kind: "agent",
+        owner: {
+          kind: "conversation",
+          id: CONVERSATION_ID,
+        },
+        public_id: "run_child_1",
+        request: {
+          mode: "default_chat",
+          agent_id: "invoke-agent-child",
+          initial_status: "running",
+          source_target_kind: "preview_branch",
+          runtime_target_kind: "preview_branch",
+          source_target_branch_id: BRANCH_ID,
+          runtime_target_branch_id: BRANCH_ID,
+        },
+      },
+    );
+  });
+
+  it("accepts camelCase durable run responses for backward compatibility", async () => {
+    stubFetchSequence(
+      acceptedRunResponse({ runId: "run_child_2" }),
+      jsonResponse(camelCaseDurableRunProjection(), 200),
+    );
+
+    const result = await createConversationAgentRun({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      runId: "run_child_2",
+      agentId: "invoke-agent-child",
+    });
+
+    assertEquals(result, {
+      runId: "run_child_2",
+      conversationId: CONVERSATION_ID,
+      messageId: MESSAGE_ID,
+      latestEventId: 0,
+      latestExternalEventSequence: 0,
+      status: "running",
+    });
+  });
+
+  it("rejects durable run projections that omit latestExternalEventSequence", async () => {
+    stubFetchSequence(
+      acceptedRunResponse({ runId: "run_child_3" }),
+      jsonResponse(
+        {
+          runId: "run_child_3",
+          conversationId: CONVERSATION_ID,
+          messageId: MESSAGE_ID,
+          latestEventId: 0,
+          status: "running",
+        },
+        200,
+      ),
+    );
+
+    await assertRejects(
+      () =>
+        createConversationAgentRun({
+          authToken: AUTH_TOKEN,
+          apiUrl: API_URL,
+          conversationId: CONVERSATION_ID,
+          runId: "run_child_3",
+          agentId: "invoke-agent-child",
+        }),
+      Error,
+      "Missing latestExternalEventSequence in durable run response",
+    );
+  });
+
+  it("finalizes durable runs through the canonical complete route", async () => {
+    const fetchCalls = stubFetchSequence(
+      jsonResponse(
+        {
+          completed: true,
+          run: {
+            runId: "run_root_1",
+            status: "completed",
+          },
+        },
+        200,
+      ),
+    );
+
+    await finalizeConversationAgentRun({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      runId: "run_root_1",
+      status: "completed",
+      model: "gpt-5.4",
+      provider: "openai",
+      usage: {
+        inputTokens: 10,
+        outputTokens: 20,
+        totalTokens: 30,
+      },
+      terminalErrorCode: null,
+      terminalErrorMessage: null,
+    });
+
+    assertEquals(
+      JSON.parse(String(fetchCalls[0]?.[1]?.body)),
+      {
+        status: "completed",
+        metadata: {
+          provider: "openai",
+          model: "gpt-5.4",
+          inputTokens: 10,
+          outputTokens: 20,
+          finishReason: "stop",
+        },
+        terminal_error_code: null,
+        terminal_error_message: null,
+      },
+    );
+  });
+});

--- a/src/agent/durable.ts
+++ b/src/agent/durable.ts
@@ -1,0 +1,257 @@
+import { z } from "zod";
+
+const AGENT_RUN_API_TIMEOUT_MS = 15_000;
+
+export const ConversationRunTargetsSchema = z.object({
+  sourceTargetKind: z.enum(["project", "preview_branch"]).nullable(),
+  runtimeTargetKind: z.enum(["production", "preview_branch"]).nullable(),
+  targetBranchId: z.string().uuid().nullable(),
+});
+
+export type ConversationRunTargets = z.infer<typeof ConversationRunTargetsSchema>;
+
+export function resolveConversationRunTargets(input: {
+  projectId?: string | null;
+  branchId?: string | null;
+}): ConversationRunTargets {
+  return ConversationRunTargetsSchema.parse(
+    !input.projectId
+      ? {
+        sourceTargetKind: null,
+        runtimeTargetKind: null,
+        targetBranchId: null,
+      }
+      : input.branchId
+      ? {
+        sourceTargetKind: "preview_branch",
+        runtimeTargetKind: "preview_branch",
+        targetBranchId: input.branchId,
+      }
+      : {
+        sourceTargetKind: "project",
+        runtimeTargetKind: "production",
+        targetBranchId: null,
+      },
+  );
+}
+
+export const ConversationRunProjectionSchema = z
+  .object({
+    runId: z.string().min(1).optional(),
+    run_id: z.string().min(1).optional(),
+    conversationId: z.string().uuid().optional(),
+    conversation_id: z.string().uuid().optional(),
+    messageId: z.string().uuid().optional(),
+    message_id: z.string().uuid().optional(),
+    latestEventId: z.number().int().nonnegative().optional(),
+    latest_event_id: z.number().int().nonnegative().optional(),
+    latestExternalEventSequence: z.number().int().nonnegative().optional(),
+    latest_external_event_sequence: z.number().int().nonnegative().optional(),
+    status: z.enum(["pending", "running", "waiting_for_tool", "completed", "failed", "cancelled"]),
+  })
+  .passthrough()
+  .transform((data) => {
+    const runId = data.runId ?? data.run_id;
+    const conversationId = data.conversationId ?? data.conversation_id;
+    const messageId = data.messageId ?? data.message_id;
+    const latestEventId = data.latestEventId ?? data.latest_event_id ?? 0;
+    const latestExternalEventSequence = data.latestExternalEventSequence ??
+      data.latest_external_event_sequence;
+
+    if (!runId || !conversationId || !messageId) {
+      throw new Error("Missing run identifiers in durable run response");
+    }
+
+    if (latestExternalEventSequence === undefined) {
+      throw new Error("Missing latestExternalEventSequence in durable run response");
+    }
+
+    return {
+      runId,
+      conversationId,
+      messageId,
+      latestEventId,
+      latestExternalEventSequence,
+      status: data.status,
+    };
+  });
+
+export type ConversationRunProjection = z.infer<typeof ConversationRunProjectionSchema>;
+
+export const CreateConversationRunAcceptedSchema = z
+  .object({
+    run: z
+      .object({
+        runId: z.string().min(1).optional(),
+        run_id: z.string().min(1).optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough()
+  .transform((data) => {
+    const runId = data.run.runId ?? data.run.run_id;
+    if (!runId) {
+      throw new Error("Missing run id in canonical create run response");
+    }
+
+    return { runId };
+  });
+
+export const CompleteConversationRunResponseSchema = z
+  .object({
+    completed: z.boolean(),
+    run: z
+      .object({
+        runId: z.string().min(1).optional(),
+        run_id: z.string().min(1).optional(),
+        status: z.enum(["pending", "running", "waiting", "completed", "failed", "cancelled"]),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+export interface ConversationAgentRunUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+export interface CreateConversationAgentRunInput {
+  authToken: string;
+  apiUrl: string;
+  conversationId: string;
+  runId?: string;
+  agentId: string;
+  projectId?: string | null;
+  branchId?: string | null;
+}
+
+export interface FinalizeConversationAgentRunInput {
+  authToken: string;
+  apiUrl: string;
+  conversationId: string;
+  runId: string;
+  status: "completed" | "failed" | "cancelled";
+  model: string;
+  provider: string;
+  usage?: ConversationAgentRunUsage;
+  terminalErrorCode?: string | null;
+  terminalErrorMessage?: string | null;
+}
+
+async function controlPlaneJson<T>(input: {
+  authToken: string;
+  url: string;
+  method?: "GET" | "POST";
+  body?: unknown;
+  responseSchema: z.ZodSchema<T>;
+  operation: string;
+}): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, AGENT_RUN_API_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(input.url, {
+      method: input.method ?? "GET",
+      headers: {
+        Authorization: `Bearer ${input.authToken}`,
+        "Content-Type": "application/json",
+      },
+      ...(input.body !== undefined ? { body: JSON.stringify(input.body) } : {}),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new Error(`${input.operation} timed out after ${AGENT_RUN_API_TIMEOUT_MS}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `${input.operation} failed (${response.status}): ${body || response.statusText}`,
+    );
+  }
+
+  return input.responseSchema.parse(await response.json());
+}
+
+export async function createConversationAgentRun(
+  input: CreateConversationAgentRunInput,
+): Promise<ConversationRunProjection> {
+  const targets = resolveConversationRunTargets({
+    projectId: input.projectId ?? null,
+    branchId: input.branchId ?? null,
+  });
+  const runId = input.runId ?? `run_${crypto.randomUUID()}`;
+
+  await controlPlaneJson({
+    authToken: input.authToken,
+    url: `${input.apiUrl}/runs`,
+    method: "POST",
+    body: {
+      kind: "agent",
+      owner: {
+        kind: "conversation",
+        id: input.conversationId,
+      },
+      public_id: runId,
+      request: {
+        mode: "default_chat",
+        agent_id: input.agentId,
+        initial_status: "running",
+        ...(targets.sourceTargetKind ? { source_target_kind: targets.sourceTargetKind } : {}),
+        ...(targets.runtimeTargetKind ? { runtime_target_kind: targets.runtimeTargetKind } : {}),
+        ...(targets.targetBranchId
+          ? {
+            source_target_branch_id: targets.targetBranchId,
+            runtime_target_branch_id: targets.targetBranchId,
+          }
+          : {}),
+      },
+    },
+    responseSchema: CreateConversationRunAcceptedSchema,
+    operation: "Create canonical durable run",
+  });
+
+  return controlPlaneJson({
+    authToken: input.authToken,
+    url: `${input.apiUrl}/conversations/${input.conversationId}/runs/${runId}`,
+    responseSchema: ConversationRunProjectionSchema,
+    operation: "Read conversation durable run projection",
+  });
+}
+
+export async function finalizeConversationAgentRun(
+  input: FinalizeConversationAgentRunInput,
+): Promise<void> {
+  const metadata = input.status === "completed"
+    ? {
+      provider: input.provider,
+      model: input.model,
+      inputTokens: input.usage?.inputTokens ?? 0,
+      outputTokens: input.usage?.outputTokens ?? 0,
+      finishReason: "stop",
+    }
+    : null;
+
+  await controlPlaneJson({
+    authToken: input.authToken,
+    url: `${input.apiUrl}/runs/${input.runId}/complete`,
+    method: "POST",
+    body: {
+      status: input.status,
+      metadata,
+      terminal_error_code: input.terminalErrorCode ?? null,
+      terminal_error_message: input.terminalErrorMessage ?? null,
+    },
+    responseSchema: CompleteConversationRunResponseSchema,
+    operation: "Complete canonical durable run",
+  });
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -179,6 +179,17 @@ export {
   type CreateAgUiBrowserResponseStreamInput,
 } from "./ag-ui-browser-response-stream.ts";
 export {
+  CompleteConversationRunResponseSchema,
+  type ConversationAgentRunUsage,
+  type ConversationRunProjection,
+  ConversationRunProjectionSchema,
+  type ConversationRunTargets,
+  ConversationRunTargetsSchema,
+  createConversationAgentRun,
+  finalizeConversationAgentRun,
+  resolveConversationRunTargets,
+} from "./durable.ts";
+export {
   type HostedChildLifecycleAdapter,
   type HostedChildLifecycleRunnerOptions,
   type HostedChildLifecycleRunResult,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.231";
+export const VERSION = "0.1.232";


### PR DESCRIPTION
## Summary
- add a public `veryfront/agent/durable` submodule for creating and finalizing conversation-backed agent runs
- export the durable run schemas and target-resolution helpers through `veryfront/agent`
- bump the package version to `0.1.232`

## Testing
- deno test --no-check --allow-all src/agent/durable.test.ts
- deno check src/agent/durable.ts src/agent/index.ts