### PR TITLE
Expose conversation-run monitoring for hosted control-plane adapters

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.235",
+  "version": "0.1.236",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/durable.test.ts
+++ b/src/agent/durable.test.ts
@@ -493,4 +493,45 @@ describe("agent/durable", () => {
     assertEquals(pollErrors, ["temporary"]);
     assertEquals(seen, ["cancelled"]);
   });
+
+  it("rethrows terminal callback errors instead of swallowing them as poll errors", async () => {
+    let callCount = 0;
+    stubFetchImplementation(async () => {
+      callCount += 1;
+      return jsonResponse(
+        {
+          run_id: "run_terminal_3",
+          conversation_id: CONVERSATION_ID,
+          message_id: MESSAGE_ID,
+          latest_event_id: 5,
+          latest_external_event_sequence: 6,
+          status: "failed",
+        },
+        200,
+      );
+    });
+    const pollErrors: string[] = [];
+
+    await assertRejects(
+      () =>
+        monitorConversationRunStatus({
+          authToken: AUTH_TOKEN,
+          apiUrl: API_URL,
+          conversationId: CONVERSATION_ID,
+          runId: "run_terminal_3",
+          pollIntervalMs: 0,
+          onPollError: (error) => {
+            pollErrors.push(error instanceof Error ? error.message : String(error));
+          },
+          onTerminal: () => {
+            throw new Error("stop upstream");
+          },
+        }),
+      Error,
+      "stop upstream",
+    );
+
+    assertEquals(callCount, 1);
+    assertEquals(pollErrors, []);
+  });
 });

--- a/src/agent/durable.ts
+++ b/src/agent/durable.ts
@@ -425,27 +425,15 @@ export async function monitorConversationRunStatus(input: {
       return;
     }
 
+    let run: ConversationRunProjection;
     try {
-      const run = await getConversationRun({
+      run = await getConversationRun({
         authToken: input.authToken,
         apiUrl: input.apiUrl,
         conversationId: input.conversationId,
         runId: input.runId,
         abortSignal: input.abortSignal,
       });
-
-      if (isActiveConversationRunStatus(run.status)) {
-        continue;
-      }
-
-      if (
-        run.status === "completed" ||
-        run.status === "failed" ||
-        run.status === "cancelled"
-      ) {
-        await input.onTerminal(new ConversationRunTerminalStateError(run, run.status));
-      }
-      return;
     } catch (error) {
       if (input.abortSignal?.aborted) {
         return;
@@ -456,7 +444,21 @@ export async function monitorConversationRunStatus(input: {
       }
 
       await input.onPollError?.(error);
+      continue;
     }
+
+    if (isActiveConversationRunStatus(run.status)) {
+      continue;
+    }
+
+    if (
+      run.status === "completed" ||
+      run.status === "failed" ||
+      run.status === "cancelled"
+    ) {
+      await input.onTerminal(new ConversationRunTerminalStateError(run, run.status));
+    }
+    return;
   }
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.235";
+export const VERSION = "0.1.236";


### PR DESCRIPTION
## Summary
- add a typed conversation-run monitoring helper on top of the public durable run APIs
- document how to compose the public agent helpers into conversation-backed hosts
- bump the package to `0.1.235`

## Verification
- deno test --no-check --allow-all src/agent/durable.test.ts src/agent/invoke-agent-child-runs.test.ts
- deno check src/agent/durable.ts src/agent/index.ts
