### PR TITLE
Add conversation-backed hosted lifecycle adapters

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.236",
+  "version": "0.1.237",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent-conversation-lifecycle.md
+++ b/docs/reference/agent-conversation-lifecycle.md
@@ -1,0 +1,59 @@
+---
+title: "Conversation-backed lifecycle adapters"
+description: "Higher-level hosted lifecycle adapters for conversation-backed root runs and child runs."
+order: 2
+---
+
+# Conversation-backed lifecycle adapters
+
+These helpers package the most repetitive control-plane lifecycle composition
+for hosts that already use `veryfront/agent` public exports.
+
+## Root runs
+
+Use `createConversationHostedLifecycleAdapter()` when your host already knows
+how to:
+
+- start a conversation-owned run
+- encode runtime chunks into control-plane events
+- decide the final model/provider/usage payload
+
+The adapter then owns:
+
+- appending events through the canonical conversation-run events route
+- mutating the live run cursor after successful appends
+- finalizing or cancelling the canonical conversation run
+
+## Child runs
+
+Use `createConversationChildLifecycleAdapter()` when your host wants the
+framework to own the default child lifecycle progression:
+
+- pending
+- running
+- completed
+- failed
+- cancelled
+
+The adapter composes:
+
+- `publishInvokeAgentChildRunProgress()`
+- `finalizeConversationAgentRun()`
+
+and can either:
+
+- publish lifecycle events through a shared parent-run publisher, or
+- fall back to the canonical conversation-run events route.
+
+## Host-local responsibilities that remain
+
+Keep these concerns local to the host:
+
+- auth / project access policy
+- prompt and child-selection semantics
+- transcript persistence rules
+- retry / backoff / cursor-recovery policy
+- product-specific logging and tracing
+
+These helpers are meant to remove duplicated lifecycle plumbing, not to absorb
+product policy.

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -223,6 +223,7 @@ await runHostedLifecycle({
 For a conversations/control-plane host composition that combines
 `runHostedLifecycle()` with the public durable-run helpers, see
 [`Conversation-backed agent hosts`](./agent-conversation-control-plane.md).
+For higher-level root-run and child-run adapter factories over those same public exports, see [`Conversation-backed lifecycle adapters`](./agent-conversation-lifecycle.md).
 
 ### Browser AG-UI encoder
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -19,6 +19,7 @@ npm install veryfront
 
 - [Agent runtime AG-UI contract](./agent-runtime-ag-ui-contract.md) - Canonical runtime-facing request contract, compatibility wrapper, and endpoint conventions for AG-UI execution.
 - [Conversation-backed agent hosts](./agent-conversation-control-plane.md) - Recommended composition of `veryfront/agent` public helpers for conversations/control-plane hosts.
+- [Conversation-backed lifecycle adapters](./agent-conversation-lifecycle.md) - Higher-level hosted lifecycle adapters for conversation-backed root runs and child runs.
 
 ## Modules
 

--- a/src/agent/conversation-hosted-lifecycle.test.ts
+++ b/src/agent/conversation-hosted-lifecycle.test.ts
@@ -1,0 +1,277 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  createConversationChildLifecycleAdapter,
+  createConversationHostedLifecycleAdapter,
+} from "./conversation-hosted-lifecycle.ts";
+
+const API_URL = "https://api.example.com";
+const AUTH_TOKEN = "token-123";
+const CONVERSATION_ID = "11111111-1111-4111-a111-111111111111";
+const MESSAGE_ID = "22222222-2222-4222-a222-222222222222";
+const CHILD_CONVERSATION_ID = "33333333-3333-4333-a333-333333333333";
+const CHILD_MESSAGE_ID = "44444444-4444-4444-8444-444444444444";
+const BRANCH_ID = "55555555-5555-4555-8555-555555555555";
+const originalFetch = globalThis.fetch;
+
+type FetchCall = [RequestInfo | URL, RequestInit | undefined];
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function stubFetchSequence(...steps: Response[]): FetchCall[] {
+  const queue = [...steps];
+  const calls: FetchCall[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push([input, init]);
+    const next = queue.shift();
+    if (!next) {
+      throw new Error("Unexpected fetch call");
+    }
+    return next;
+  }) as typeof fetch;
+  return calls;
+}
+
+describe("agent/conversation-hosted-lifecycle", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("appends conversation events and mutates the run cursor", async () => {
+    const adapter = createConversationHostedLifecycleAdapter<string>({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      startRun: async () => ({
+        runId: "run_root_1",
+        conversationId: CONVERSATION_ID,
+        messageId: MESSAGE_ID,
+        latestEventId: 1,
+        latestExternalEventSequence: 2,
+        status: "running",
+      }),
+      mapChunkToEvents: (chunk) => [{ type: "STATE_DELTA", chunk }],
+      resolveFinalizeInput: () => ({ model: "gpt-5.4", provider: "openai" }),
+    });
+    const fetchCalls = stubFetchSequence(
+      jsonResponse({
+        latest_event_id: 3,
+        latest_external_event_sequence: 4,
+        appended_count: 1,
+        run: {
+          run_id: "run_root_1",
+          conversation_id: CONVERSATION_ID,
+          latest_event_id: 3,
+          latest_external_event_sequence: 4,
+        },
+      }),
+    );
+
+    const run = await adapter.startRun({ abortSignal: new AbortController().signal });
+    await adapter.appendEvents?.(run, "chunk-1");
+
+    assertEquals(run.latestEventId, 3);
+    assertEquals(run.latestExternalEventSequence, 4);
+    assertEquals(JSON.parse(String(fetchCalls[0]?.[1]?.body)), {
+      expected_previous_event_id: 1,
+      expected_previous_external_event_sequence: 2,
+      events: [{ type: "STATE_DELTA", chunk: "chunk-1" }],
+    });
+  });
+
+  it("finalizes and cancels conversation-backed root runs with host-supplied model metadata", async () => {
+    const run = {
+      runId: "run_root_2",
+      conversationId: CONVERSATION_ID,
+      messageId: MESSAGE_ID,
+      latestEventId: 0,
+      latestExternalEventSequence: 0,
+      status: "running" as const,
+    };
+    const adapter = createConversationHostedLifecycleAdapter<unknown>({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      startRun: async () => run,
+      resolveFinalizeInput: ({ terminalState }) => ({
+        model: terminalState.metadata?.modelId ?? "gpt-5.4",
+        provider: "openai",
+        usage: terminalState.metadata?.usage
+          ? {
+            inputTokens: terminalState.metadata.usage.inputTokens ?? 0,
+            outputTokens: terminalState.metadata.usage.outputTokens ?? 0,
+            totalTokens: (terminalState.metadata.usage.inputTokens ?? 0) +
+              (terminalState.metadata.usage.outputTokens ?? 0),
+          }
+          : undefined,
+        terminalErrorCode: terminalState.terminalErrorCode,
+        terminalErrorMessage: terminalState.terminalErrorMessage,
+      }),
+    });
+    const fetchCalls = stubFetchSequence(
+      jsonResponse({ completed: true, run: { run_id: "run_root_2", status: "completed" } }),
+      jsonResponse({ completed: true, run: { run_id: "run_root_2", status: "cancelled" } }),
+    );
+
+    await adapter.finalizeRun?.(run, {
+      status: "completed",
+      metadata: { modelId: "gpt-5.4", usage: { inputTokens: 2, outputTokens: 3 } },
+      terminalErrorCode: null,
+      terminalErrorMessage: null,
+    });
+    await adapter.cancelRun?.(run, {
+      status: "cancelled",
+      metadata: { modelId: "gpt-5.4-mini" },
+      terminalErrorCode: "ABORTED",
+      terminalErrorMessage: "Stopped",
+    });
+
+    assertEquals(JSON.parse(String(fetchCalls[0]?.[1]?.body)), {
+      status: "completed",
+      metadata: {
+        provider: "openai",
+        model: "gpt-5.4",
+        inputTokens: 2,
+        outputTokens: 3,
+        finishReason: "stop",
+      },
+      terminal_error_code: null,
+      terminal_error_message: null,
+    });
+    assertEquals(JSON.parse(String(fetchCalls[1]?.[1]?.body)), {
+      status: "cancelled",
+      metadata: null,
+      terminal_error_code: "ABORTED",
+      terminal_error_message: "Stopped",
+    });
+  });
+
+  it("publishes shared-parent child progress without falling back to HTTP append and finalizes child runs", async () => {
+    const published: unknown[][] = [];
+    const adapter = createConversationChildLifecycleAdapter({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      parentConversationId: CONVERSATION_ID,
+      parentRunId: "run_parent_1",
+      projectId: "project-1",
+      publishParentRunEvents: async (events) => {
+        published.push(events);
+      },
+      progress: {
+        toolCallId: "tool-1",
+        childAgentId: "researcher",
+        childConversationId: CHILD_CONVERSATION_ID,
+        childRunId: "run_child_1",
+        childMessageId: CHILD_MESSAGE_ID,
+        description: "Inspect logs",
+        sourceTargetKind: "project",
+        runtimeTargetKind: "production",
+        targetBranchId: null,
+      },
+      model: "gpt-5.4",
+      provider: "openai",
+    });
+    const fetchCalls = stubFetchSequence(
+      jsonResponse({ completed: true, run: { run_id: "run_child_1", status: "completed" } }),
+    );
+
+    await adapter.pending?.();
+    await adapter.running?.();
+    await adapter.completed?.({
+      status: "completed",
+      usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+    });
+
+    assertEquals(published.length, 3);
+    assertEquals(published[0]?.[0], {
+      type: "STATE_DELTA",
+      delta: [
+        {
+          op: "add",
+          path: "/invokeAgentChildRuns/tool-1",
+          value: {
+            toolCallId: "tool-1",
+            childConversationId: CHILD_CONVERSATION_ID,
+            childRunId: "run_child_1",
+            childMessageId: CHILD_MESSAGE_ID,
+            childAgentId: "researcher",
+            description: "Inspect logs",
+            status: "pending",
+            sourceTargetKind: "project",
+            runtimeTargetKind: "production",
+            targetBranchId: null,
+          },
+        },
+      ],
+    });
+    assertEquals(String(fetchCalls[0]?.[0]), `${API_URL}/runs/run_child_1/complete`);
+  });
+
+  it("falls back to canonical conversation-run event publishing when no shared parent publisher exists", async () => {
+    const adapter = createConversationChildLifecycleAdapter({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      parentConversationId: CONVERSATION_ID,
+      parentRunId: "run_parent_2",
+      projectId: "project-1",
+      progress: {
+        toolCallId: "tool-2",
+        childAgentId: "researcher",
+        childConversationId: CHILD_CONVERSATION_ID,
+        childRunId: "run_child_2",
+        childMessageId: CHILD_MESSAGE_ID,
+        description: "Inspect logs",
+        sourceTargetKind: "preview_branch",
+        runtimeTargetKind: "preview_branch",
+        targetBranchId: BRANCH_ID,
+      },
+      model: "gpt-5.4-mini",
+      provider: "openai",
+    });
+    const fetchCalls = stubFetchSequence(
+      jsonResponse({
+        latest_event_id: 7,
+        latest_external_event_sequence: 8,
+        appended_count: 2,
+        run: {
+          run_id: "run_parent_2",
+          conversation_id: CONVERSATION_ID,
+          latest_event_id: 7,
+          latest_external_event_sequence: 8,
+        },
+      }),
+      jsonResponse({ completed: true, run: { run_id: "run_child_2", status: "failed" } }),
+      jsonResponse({
+        latest_event_id: 9,
+        latest_external_event_sequence: 10,
+        appended_count: 2,
+        run: {
+          run_id: "run_parent_2",
+          conversation_id: CONVERSATION_ID,
+          latest_event_id: 9,
+          latest_external_event_sequence: 10,
+        },
+      }),
+    );
+
+    await adapter.pending?.();
+    await adapter.failed?.({
+      status: "failed",
+      terminalErrorCode: "FAILED",
+      terminalErrorMessage: "boom",
+    });
+
+    assertEquals(
+      String(fetchCalls[0]?.[0]),
+      `${API_URL}/conversations/${CONVERSATION_ID}/runs/run_parent_2/events`,
+    );
+    assertEquals(String(fetchCalls[1]?.[0]), `${API_URL}/runs/run_child_2/complete`);
+    assertEquals(
+      String(fetchCalls[2]?.[0]),
+      `${API_URL}/conversations/${CONVERSATION_ID}/runs/run_parent_2/events`,
+    );
+  });
+});

--- a/src/agent/conversation-hosted-lifecycle.ts
+++ b/src/agent/conversation-hosted-lifecycle.ts
@@ -1,0 +1,199 @@
+import {
+  appendConversationRunEvents,
+  type ConversationAgentRunUsage,
+  type ConversationRunProjection,
+  finalizeConversationAgentRun,
+} from "./durable.ts";
+import {
+  type InvokeAgentChildRunProgressEvent,
+  type InvokeAgentChildRunProgressInput,
+  publishInvokeAgentChildRunProgress,
+} from "./invoke-agent-child-runs.ts";
+import type {
+  HostedChildLifecycleAdapter,
+  HostedChildLifecycleTerminalState,
+} from "./hosted-child-lifecycle.ts";
+import type { HostedLifecycleAdapter, HostedLifecycleTerminalState } from "./hosted-lifecycle.ts";
+
+export interface ConversationHostedLifecycleFinalizeInput {
+  model: string;
+  provider: string;
+  usage?: ConversationAgentRunUsage;
+  terminalErrorCode?: string | null;
+  terminalErrorMessage?: string | null;
+}
+
+export interface CreateConversationHostedLifecycleAdapterOptions<TChunk> {
+  authToken: string;
+  apiUrl: string;
+  startRun: (
+    input: { abortSignal: AbortSignal },
+  ) => Promise<ConversationRunProjection> | ConversationRunProjection;
+  mapChunkToEvents?: (
+    chunk: TChunk,
+    run: ConversationRunProjection,
+  ) => Promise<readonly unknown[] | unknown[]> | readonly unknown[] | unknown[];
+  resolveFinalizeInput: (input: {
+    run: ConversationRunProjection;
+    terminalState: HostedLifecycleTerminalState;
+  }) =>
+    | Promise<ConversationHostedLifecycleFinalizeInput>
+    | ConversationHostedLifecycleFinalizeInput;
+}
+
+export function createConversationHostedLifecycleAdapter<TChunk>(
+  options: CreateConversationHostedLifecycleAdapterOptions<TChunk>,
+): HostedLifecycleAdapter<ConversationRunProjection, TChunk> {
+  return {
+    startRun: options.startRun,
+    appendEvents: options.mapChunkToEvents
+      ? async (run, chunk) => {
+        const events = [...await options.mapChunkToEvents!(chunk, run)];
+        if (events.length === 0) {
+          return;
+        }
+
+        const appended = await appendConversationRunEvents({
+          authToken: options.authToken,
+          apiUrl: options.apiUrl,
+          conversationId: run.conversationId,
+          runId: run.runId,
+          expectedPreviousEventId: run.latestEventId,
+          expectedPreviousExternalEventSequence: run.latestExternalEventSequence,
+          events,
+        });
+
+        run.latestEventId = appended.latestEventId;
+        run.latestExternalEventSequence = appended.latestExternalEventSequence;
+      }
+      : undefined,
+    finalizeRun: async (run, terminalState) => {
+      const finalizeInput = await options.resolveFinalizeInput({ run, terminalState });
+      await finalizeConversationAgentRun({
+        authToken: options.authToken,
+        apiUrl: options.apiUrl,
+        conversationId: run.conversationId,
+        runId: run.runId,
+        status: terminalState.status,
+        model: finalizeInput.model,
+        provider: finalizeInput.provider,
+        usage: finalizeInput.usage,
+        terminalErrorCode: finalizeInput.terminalErrorCode,
+        terminalErrorMessage: finalizeInput.terminalErrorMessage,
+      });
+    },
+    cancelRun: async (run, terminalState) => {
+      const finalizeInput = await options.resolveFinalizeInput({ run, terminalState });
+      await finalizeConversationAgentRun({
+        authToken: options.authToken,
+        apiUrl: options.apiUrl,
+        conversationId: run.conversationId,
+        runId: run.runId,
+        status: "cancelled",
+        model: finalizeInput.model,
+        provider: finalizeInput.provider,
+        usage: finalizeInput.usage,
+        terminalErrorCode: finalizeInput.terminalErrorCode,
+        terminalErrorMessage: finalizeInput.terminalErrorMessage,
+      });
+    },
+  };
+}
+
+export interface ConversationChildLifecycleContext {
+  authToken: string;
+  apiUrl: string;
+  parentConversationId: string;
+  parentRunId: string;
+  projectId?: string | null;
+  publishParentRunEvents?: (events: InvokeAgentChildRunProgressEvent[]) => Promise<void> | void;
+  progress: Omit<InvokeAgentChildRunProgressInput, "status">;
+  model: string;
+  provider: string;
+}
+
+function toConversationChildUsage(
+  usage: HostedChildLifecycleTerminalState["usage"],
+): ConversationAgentRunUsage | undefined {
+  if (!usage) {
+    return undefined;
+  }
+
+  const inputTokens = usage.inputTokens ?? 0;
+  const outputTokens = usage.outputTokens ?? 0;
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: usage.totalTokens ?? inputTokens + outputTokens,
+  };
+}
+
+async function publishConversationChildProgress(
+  ctx: ConversationChildLifecycleContext,
+  status: InvokeAgentChildRunProgressInput["status"],
+): Promise<void> {
+  await publishInvokeAgentChildRunProgress({
+    authToken: ctx.authToken,
+    apiUrl: ctx.apiUrl,
+    conversationId: ctx.parentConversationId,
+    runId: ctx.parentRunId,
+    ...(ctx.projectId !== undefined ? { projectId: ctx.projectId } : {}),
+    ...ctx.progress,
+    status,
+    ...(ctx.publishParentRunEvents ? { publishParentRunEvents: ctx.publishParentRunEvents } : {}),
+  });
+}
+
+export function createConversationChildLifecycleAdapter(
+  ctx: ConversationChildLifecycleContext,
+): HostedChildLifecycleAdapter {
+  return {
+    pending: () => publishConversationChildProgress(ctx, "pending"),
+    running: () => publishConversationChildProgress(ctx, "running"),
+    completed: async (terminalState) => {
+      await finalizeConversationAgentRun({
+        authToken: ctx.authToken,
+        apiUrl: ctx.apiUrl,
+        conversationId: ctx.progress.childConversationId,
+        runId: ctx.progress.childRunId,
+        status: "completed",
+        model: ctx.model,
+        provider: ctx.provider,
+        usage: toConversationChildUsage(terminalState.usage),
+        terminalErrorCode: null,
+        terminalErrorMessage: null,
+      });
+      await publishConversationChildProgress(ctx, "completed");
+    },
+    failed: async (terminalState) => {
+      await finalizeConversationAgentRun({
+        authToken: ctx.authToken,
+        apiUrl: ctx.apiUrl,
+        conversationId: ctx.progress.childConversationId,
+        runId: ctx.progress.childRunId,
+        status: "failed",
+        model: ctx.model,
+        provider: ctx.provider,
+        usage: toConversationChildUsage(terminalState.usage),
+        terminalErrorCode: terminalState.terminalErrorCode ?? "FAILED",
+        terminalErrorMessage: terminalState.terminalErrorMessage ?? "Unknown error",
+      });
+      await publishConversationChildProgress(ctx, "failed");
+    },
+    cancelled: async (terminalState) => {
+      await finalizeConversationAgentRun({
+        authToken: ctx.authToken,
+        apiUrl: ctx.apiUrl,
+        conversationId: ctx.progress.childConversationId,
+        runId: ctx.progress.childRunId,
+        status: "cancelled",
+        model: ctx.model,
+        provider: ctx.provider,
+        usage: toConversationChildUsage(terminalState.usage),
+        terminalErrorCode: terminalState.terminalErrorCode ?? "CANCELLED",
+        terminalErrorMessage: terminalState.terminalErrorMessage ?? "Child run cancelled",
+      });
+      await publishConversationChildProgress(ctx, "cancelled");
+    },
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -191,6 +191,13 @@ export {
   fetchConversationRecord,
 } from "./conversation-bootstrap.ts";
 export {
+  type ConversationChildLifecycleContext,
+  type ConversationHostedLifecycleFinalizeInput,
+  createConversationChildLifecycleAdapter,
+  createConversationHostedLifecycleAdapter,
+  type CreateConversationHostedLifecycleAdapterOptions,
+} from "./conversation-hosted-lifecycle.ts";
+export {
   type ActiveConversationRunStatus,
   appendConversationRunEvents,
   AppendConversationRunEventsError,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.236";
+export const VERSION = "0.1.237";


### PR DESCRIPTION
## Summary
- add higher-level conversation-backed hosted lifecycle adapter factories for root runs and child runs
- document the public lifecycle composition path for conversations/control-plane hosts
- bump the package to `0.1.237`

## Verification
- deno test --no-check --allow-all src/agent/conversation-hosted-lifecycle.test.ts src/agent/durable.test.ts src/agent/invoke-agent-child-runs.test.ts
- deno check src/agent/conversation-hosted-lifecycle.ts src/agent/index.ts
