### PR TITLE
Add conversation root-run context helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.237",
+  "version": "0.1.240",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent-conversation-root-run-context.md
+++ b/docs/reference/agent-conversation-root-run-context.md
@@ -1,0 +1,30 @@
+---
+title: "Conversation root-run helpers"
+description: "Helpers for starting and carrying conversation-backed root-run lineage through host execution flows."
+order: 4
+---
+
+# Conversation root-run helpers
+
+Use these helpers when a host wants to:
+
+- start a canonical conversation-backed root run
+- reuse an existing provided root-run descriptor
+- derive one canonical context object that carries both durable run lineage and
+  effective parent lineage
+
+These helpers intentionally stay small. They package the repeated context and
+lineage wiring, but they do not own:
+
+- auth policy
+- transcript persistence rules
+- retry / cursor recovery policy
+- host-specific tracing or logging
+
+## Prepared context
+
+Use `prepareConversationRootRunContext()` when your host wants one call that:
+
+- starts or normalizes the root run
+- derives effective parent lineage
+- preserves an optional shared parent-run publisher

--- a/docs/reference/agent-conversation-run-context.md
+++ b/docs/reference/agent-conversation-run-context.md
@@ -1,0 +1,18 @@
+---
+title: "Conversation run context helpers"
+description: "Helpers for carrying conversation-backed run lineage and parent context through host execution flows."
+order: 3
+---
+
+# Conversation run context helpers
+
+Use `createConversationRunContext()` when your host wants one canonical object
+for:
+
+- the current conversation-backed run projection
+- the effective parent run id
+- the effective parent message id
+- an optional shared parent-run publisher
+
+This keeps parent lineage and durable run lineage aligned without re-deriving
+those values in multiple host modules.

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -224,6 +224,8 @@ For a conversations/control-plane host composition that combines
 `runHostedLifecycle()` with the public durable-run helpers, see
 [`Conversation-backed agent hosts`](./agent-conversation-control-plane.md).
 For higher-level root-run and child-run adapter factories over those same public exports, see [`Conversation-backed lifecycle adapters`](./agent-conversation-lifecycle.md).
+For a small helper that carries durable run lineage and effective parent lineage together, see [`Conversation run context helpers`](./agent-conversation-run-context.md).
+For helpers that start or normalize a conversation-backed root run before host execution begins, see [`Conversation root-run helpers`](./agent-conversation-root-run-context.md).
 
 ### Browser AG-UI encoder
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -20,6 +20,8 @@ npm install veryfront
 - [Agent runtime AG-UI contract](./agent-runtime-ag-ui-contract.md) - Canonical runtime-facing request contract, compatibility wrapper, and endpoint conventions for AG-UI execution.
 - [Conversation-backed agent hosts](./agent-conversation-control-plane.md) - Recommended composition of `veryfront/agent` public helpers for conversations/control-plane hosts.
 - [Conversation-backed lifecycle adapters](./agent-conversation-lifecycle.md) - Higher-level hosted lifecycle adapters for conversation-backed root runs and child runs.
+- [Conversation run context helpers](./agent-conversation-run-context.md) - Parent-lineage helpers for hosts that carry conversation-backed run context through execution.
+- [Conversation root-run helpers](./agent-conversation-root-run-context.md) - Root-run helpers for carrying durable run and parent lineage through conversation-backed host execution.
 
 ## Modules
 

--- a/src/agent/conversation-root-run-context.test.ts
+++ b/src/agent/conversation-root-run-context.test.ts
@@ -1,0 +1,195 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  createConversationRootRunContext,
+  createConversationRootRunStartAdapter,
+  prepareConversationRootRunContext,
+  startConversationRootRun,
+} from "./conversation-root-run-context.ts";
+
+const API_URL = "https://api.example.com";
+const AUTH_TOKEN = "token-123";
+const CONVERSATION_ID = "11111111-1111-4111-a111-111111111111";
+const MESSAGE_ID = "22222222-2222-4222-a222-222222222222";
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function stubFetchSequence(...steps: Response[]) {
+  const queue = [...steps];
+  const calls: [RequestInfo | URL, RequestInit | undefined][] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push([input, init]);
+    const next = queue.shift();
+    if (!next) {
+      throw new Error("Unexpected fetch call");
+    }
+    return next;
+  }) as typeof fetch;
+  return calls;
+}
+
+describe("agent/conversation-root-run-context", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("starts a canonical conversation root run when a conversation exists", async () => {
+    const calls = stubFetchSequence(
+      jsonResponse({ accepted: true, run: { run_id: "run_root_1" } }, 202),
+      jsonResponse({
+        run_id: "run_root_1",
+        conversation_id: CONVERSATION_ID,
+        message_id: MESSAGE_ID,
+        latest_event_id: 3,
+        latest_external_event_sequence: 7,
+        status: "running",
+      }),
+    );
+
+    const run = await startConversationRootRun({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      projectId: "project-1",
+      branchId: null,
+      agentId: "veryfront",
+    });
+
+    assertEquals(run?.runId, "run_root_1");
+    assertEquals(String(calls[0]?.[0]), `${API_URL}/runs`);
+  });
+
+  it("reuses a provided run descriptor without calling the API", async () => {
+    const run = await startConversationRootRun({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      agentId: "veryfront",
+      providedRun: {
+        runId: "existing-run",
+        messageId: MESSAGE_ID,
+        latestEventId: 4,
+        latestExternalEventSequence: 9,
+      },
+    });
+
+    assertEquals(run, {
+      runId: "existing-run",
+      conversationId: CONVERSATION_ID,
+      messageId: MESSAGE_ID,
+      latestEventId: 4,
+      latestExternalEventSequence: 9,
+      status: "running",
+    });
+  });
+
+  it("rejects provided runs without a conversation id", async () => {
+    await assertRejects(
+      () =>
+        startConversationRootRun({
+          authToken: AUTH_TOKEN,
+          apiUrl: API_URL,
+          agentId: "veryfront",
+          providedRun: {
+            runId: "existing-run",
+            messageId: MESSAGE_ID,
+          },
+        }),
+      Error,
+      "CONVERSATION_ROOT_RUN_REQUIRES_CONVERSATION",
+    );
+  });
+
+  it("creates one canonical root-run context object for durable and parent lineage", async () => {
+    const publishParentRunEvents = async (_events: unknown[]) => undefined;
+    const context = createConversationRootRunContext({
+      run: {
+        runId: "run_root_2",
+        conversationId: CONVERSATION_ID,
+        messageId: MESSAGE_ID,
+        latestEventId: 1,
+        latestExternalEventSequence: 2,
+        status: "running",
+      },
+      parentRunId: "parent-run",
+      parentMessageId: "parent-message",
+      appendParentRunEvents: publishParentRunEvents,
+    });
+
+    assertEquals(context.run, {
+      runId: "run_root_2",
+      conversationId: CONVERSATION_ID,
+      messageId: MESSAGE_ID,
+      latestEventId: 1,
+      latestExternalEventSequence: 2,
+      status: "running",
+    });
+    assertEquals(context.effectiveParentRunId, "run_root_2");
+    assertEquals(context.effectiveParentMessageId, MESSAGE_ID);
+    await context.publishParentRunEvents?.([{ type: "run-started" }]);
+  });
+
+  it("creates a reusable root-run start adapter over the canonical start helper", async () => {
+    stubFetchSequence(
+      jsonResponse({ accepted: true, run: { run_id: "run_root_adapter" } }, 202),
+      jsonResponse({
+        run_id: "run_root_adapter",
+        conversation_id: CONVERSATION_ID,
+        message_id: MESSAGE_ID,
+        latest_event_id: 8,
+        latest_external_event_sequence: 9,
+        status: "running",
+      }),
+    );
+
+    const startRun = createConversationRootRunStartAdapter({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      projectId: "project-1",
+      agentId: "veryfront",
+    });
+
+    const result = await startRun({ abortSignal: new AbortController().signal });
+
+    assertEquals(result.run?.runId, "run_root_adapter");
+    assertEquals(result.run?.latestEventId, 8);
+  });
+
+  it("prepares one conversation root-run context object from start + parent lineage", async () => {
+    const publishParentRunEvents = async (_events: unknown[]) => undefined;
+    stubFetchSequence(
+      jsonResponse({ accepted: true, run: { run_id: "run_root_prepare" } }, 202),
+      jsonResponse({
+        run_id: "run_root_prepare",
+        conversation_id: CONVERSATION_ID,
+        message_id: MESSAGE_ID,
+        latest_event_id: 3,
+        latest_external_event_sequence: 7,
+        status: "running",
+      }),
+    );
+
+    const context = await prepareConversationRootRunContext({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      projectId: "project-1",
+      agentId: "veryfront",
+      parentRunId: "parent-run",
+      parentMessageId: "parent-message",
+      appendParentRunEvents: publishParentRunEvents,
+    });
+
+    assertEquals(context.run?.runId, "run_root_prepare");
+    assertEquals(context.effectiveParentRunId, "run_root_prepare");
+    assertEquals(context.effectiveParentMessageId, MESSAGE_ID);
+    await context.publishParentRunEvents?.([{ type: "run-started" }]);
+  });
+});

--- a/src/agent/conversation-root-run-context.ts
+++ b/src/agent/conversation-root-run-context.ts
@@ -1,0 +1,135 @@
+import { type ConversationRunProjection, createConversationAgentRun } from "./durable.ts";
+
+export interface ConversationRootRunDescriptor {
+  runId: string;
+  messageId: string;
+  latestEventId?: number;
+  latestExternalEventSequence?: number;
+}
+
+export interface ConversationRootRunContext {
+  run: ConversationRunProjection | null;
+  effectiveParentRunId?: string;
+  effectiveParentMessageId?: string;
+  publishParentRunEvents?: (events: unknown[]) => Promise<void> | void;
+}
+
+function normalizeProvidedRun(input: {
+  conversationId: string;
+  providedRun: ConversationRootRunDescriptor;
+}): ConversationRunProjection {
+  return {
+    runId: input.providedRun.runId,
+    conversationId: input.conversationId,
+    messageId: input.providedRun.messageId,
+    latestEventId: input.providedRun.latestEventId ?? 0,
+    latestExternalEventSequence: input.providedRun.latestExternalEventSequence ?? 0,
+    status: "running",
+  };
+}
+
+function createMirrorPublisher(
+  appendEvents: ((events: unknown[]) => Promise<void> | void) | undefined,
+): ConversationRootRunContext["publishParentRunEvents"] {
+  return appendEvents ? (events) => appendEvents(events) : undefined;
+}
+
+export function createConversationRootRunContext(input: {
+  run: ConversationRunProjection | null;
+  parentRunId?: string;
+  parentMessageId?: string;
+  appendParentRunEvents?: ((events: unknown[]) => Promise<void> | void) | undefined;
+}): ConversationRootRunContext {
+  return {
+    run: input.run,
+    effectiveParentRunId: input.run?.runId ?? input.parentRunId,
+    effectiveParentMessageId: input.run?.messageId ?? input.parentMessageId,
+    publishParentRunEvents: createMirrorPublisher(input.appendParentRunEvents),
+  };
+}
+
+export async function startConversationRootRun(input: {
+  authToken: string;
+  apiUrl: string;
+  conversationId?: string;
+  projectId?: string | null;
+  branchId?: string | null;
+  agentId: string;
+  providedRun?: ConversationRootRunDescriptor;
+}): Promise<ConversationRunProjection | null> {
+  if (input.providedRun) {
+    if (!input.conversationId) {
+      throw new Error("CONVERSATION_ROOT_RUN_REQUIRES_CONVERSATION");
+    }
+
+    return normalizeProvidedRun({
+      conversationId: input.conversationId,
+      providedRun: input.providedRun,
+    });
+  }
+
+  if (!input.conversationId) {
+    return null;
+  }
+
+  return createConversationAgentRun({
+    authToken: input.authToken,
+    apiUrl: input.apiUrl,
+    conversationId: input.conversationId,
+    projectId: input.projectId ?? null,
+    branchId: input.branchId,
+    agentId: input.agentId,
+  });
+}
+
+export function createConversationRootRunStartAdapter(input: {
+  authToken: string;
+  apiUrl: string;
+  conversationId?: string;
+  projectId?: string | null;
+  branchId?: string | null;
+  agentId: string;
+  providedRun?: ConversationRootRunDescriptor;
+}): (input: { abortSignal: AbortSignal }) => Promise<{ run: ConversationRunProjection | null }> {
+  return async () => ({
+    run: await startConversationRootRun({
+      authToken: input.authToken,
+      apiUrl: input.apiUrl,
+      conversationId: input.conversationId,
+      projectId: input.projectId,
+      branchId: input.branchId,
+      agentId: input.agentId,
+      providedRun: input.providedRun,
+    }),
+  });
+}
+
+export async function prepareConversationRootRunContext(input: {
+  authToken: string;
+  apiUrl: string;
+  conversationId?: string;
+  projectId?: string | null;
+  branchId?: string | null;
+  agentId: string;
+  providedRun?: ConversationRootRunDescriptor;
+  parentRunId?: string;
+  parentMessageId?: string;
+  appendParentRunEvents?: ((events: unknown[]) => Promise<void> | void) | undefined;
+}): Promise<ConversationRootRunContext> {
+  const { run } = await createConversationRootRunStartAdapter({
+    authToken: input.authToken,
+    apiUrl: input.apiUrl,
+    conversationId: input.conversationId,
+    projectId: input.projectId,
+    branchId: input.branchId,
+    agentId: input.agentId,
+    providedRun: input.providedRun,
+  })({ abortSignal: new AbortController().signal });
+
+  return createConversationRootRunContext({
+    run,
+    parentRunId: input.parentRunId,
+    parentMessageId: input.parentMessageId,
+    appendParentRunEvents: input.appendParentRunEvents,
+  });
+}

--- a/src/agent/conversation-run-context.test.ts
+++ b/src/agent/conversation-run-context.test.ts
@@ -1,0 +1,48 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createConversationRunContext } from "./conversation-run-context.ts";
+
+const RUN = {
+  runId: "run_1",
+  conversationId: "11111111-1111-4111-a111-111111111111",
+  messageId: "22222222-2222-4222-a222-222222222222",
+  latestEventId: 1,
+  latestExternalEventSequence: 2,
+  status: "running" as const,
+};
+
+describe("agent/conversation-run-context", () => {
+  it("prefers durable run lineage when a run exists", () => {
+    const publishParentRunEvents = async (_events: unknown[]) => undefined;
+    assertEquals(
+      createConversationRunContext({
+        run: RUN,
+        parentRunId: "parent-run",
+        parentMessageId: "parent-message",
+        publishParentRunEvents,
+      }),
+      {
+        run: RUN,
+        effectiveParentRunId: "run_1",
+        effectiveParentMessageId: "22222222-2222-4222-a222-222222222222",
+        publishParentRunEvents,
+      },
+    );
+  });
+
+  it("falls back to provided parent lineage when no run exists", () => {
+    assertEquals(
+      createConversationRunContext({
+        run: null,
+        parentRunId: "parent-run",
+        parentMessageId: "parent-message",
+      }),
+      {
+        run: null,
+        effectiveParentRunId: "parent-run",
+        effectiveParentMessageId: "parent-message",
+        publishParentRunEvents: undefined,
+      },
+    );
+  });
+});

--- a/src/agent/conversation-run-context.ts
+++ b/src/agent/conversation-run-context.ts
@@ -1,0 +1,22 @@
+import type { ConversationRunProjection } from "./durable.ts";
+
+export interface ConversationRunContext {
+  run: ConversationRunProjection | null;
+  effectiveParentRunId?: string;
+  effectiveParentMessageId?: string;
+  publishParentRunEvents?: (events: unknown[]) => Promise<void> | void;
+}
+
+export function createConversationRunContext(input: {
+  run: ConversationRunProjection | null;
+  parentRunId?: string;
+  parentMessageId?: string;
+  publishParentRunEvents?: ((events: unknown[]) => Promise<void> | void) | undefined;
+}) {
+  return {
+    run: input.run,
+    effectiveParentRunId: input.run?.runId ?? input.parentRunId,
+    effectiveParentMessageId: input.run?.messageId ?? input.parentMessageId,
+    publishParentRunEvents: input.publishParentRunEvents,
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -179,6 +179,10 @@ export {
   type CreateAgUiBrowserResponseStreamInput,
 } from "./ag-ui-browser-response-stream.ts";
 export {
+  type ConversationRunContext,
+  createConversationRunContext,
+} from "./conversation-run-context.ts";
+export {
   bootstrapConversationAgentRun,
   type BootstrapConversationAgentRunResult,
   type ConversationMessageRecord,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.237";
+export const VERSION = "0.1.240";


### PR DESCRIPTION
## Summary
- add reusable root-run helpers for starting or normalizing conversation-backed runs
- add a small context helper for carrying durable run lineage with effective parent lineage
- bump the package to `0.1.239`

## Verification
- deno test --no-check --allow-all src/agent/conversation-root-run-context.test.ts
- deno check src/agent/conversation-root-run-context.ts src/agent/index.ts
