### PR TITLE
Publish conversation root-run context helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.240",
+  "version": "0.1.241",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -183,6 +183,14 @@ export {
   createConversationRunContext,
 } from "./conversation-run-context.ts";
 export {
+  type ConversationRootRunContext,
+  type ConversationRootRunDescriptor,
+  createConversationRootRunContext,
+  createConversationRootRunStartAdapter,
+  prepareConversationRootRunContext,
+  startConversationRootRun,
+} from "./conversation-root-run-context.ts";
+export {
   bootstrapConversationAgentRun,
   type BootstrapConversationAgentRunResult,
   type ConversationMessageRecord,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.240";
+export const VERSION = "0.1.241";


### PR DESCRIPTION
## Summary
- export the conversation root-run context helpers from the public `veryfront/agent` entrypoint
- bump the package version to `0.1.241`
- keep the documented control-plane root-run helpers reachable from the shipped package surface

## Testing
- deno test --no-check --allow-all src/agent/conversation-run-context.test.ts src/agent/conversation-root-run-context.test.ts
- deno check src/agent/index.ts src/agent/conversation-root-run-context.ts src/agent/conversation-run-context.ts
- deno eval --config deno.json 'import { createConversationRootRunContext, createConversationRootRunStartAdapter, prepareConversationRootRunContext, startConversationRootRun } from "./src/agent/index.ts"; console.log(typeof createConversationRootRunContext, typeof createConversationRootRunStartAdapter, typeof prepareConversationRootRunContext, typeof startConversationRootRun)'
- full pre-push suite