### PR TITLE
Keep cursor-resync recovery from classifying blocked runs as appendable

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.243",
+  "version": "0.1.244",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/durable.test.ts
+++ b/src/agent/durable.test.ts
@@ -468,6 +468,16 @@ describe("agent/durable", () => {
         }),
         200,
       ),
+      jsonResponse(
+        camelCaseDurableRunProjection({
+          runId: "run_resync_4",
+          latestExternalEventSequence: 6,
+          status: "waiting_for_tool",
+          waitingToolCallId: "tool-call-2",
+          waitingToolName: "form_input",
+        }),
+        200,
+      ),
     );
 
     assertEquals(
@@ -533,6 +543,29 @@ describe("agent/durable", () => {
           latestEventId: 0,
           latestExternalEventSequence: 4,
           waitingToolCallId: "tool-call-1",
+          waitingToolName: "form_input",
+          status: "waiting_for_tool",
+        },
+      },
+    );
+
+    assertEquals(
+      await resyncConversationRunAppendCursor({
+        authToken: AUTH_TOKEN,
+        apiUrl: API_URL,
+        conversationId: CONVERSATION_ID,
+        runId: "run_resync_4",
+        previousLatestExternalEventSequence: 4,
+      }),
+      {
+        result: "non_appendable",
+        run: {
+          runId: "run_resync_4",
+          conversationId: CONVERSATION_ID,
+          messageId: MESSAGE_ID,
+          latestEventId: 0,
+          latestExternalEventSequence: 6,
+          waitingToolCallId: "tool-call-2",
           waitingToolName: "form_input",
           status: "waiting_for_tool",
         },

--- a/src/agent/durable.ts
+++ b/src/agent/durable.ts
@@ -360,16 +360,16 @@ export async function resyncConversationRunAppendCursor(input: {
     abortSignal: input.abortSignal,
   });
 
-  if (run.latestExternalEventSequence > input.previousLatestExternalEventSequence) {
+  if (!isAppendableConversationRunProjection(run)) {
     return {
-      result: "advanced",
+      result: "non_appendable",
       run,
     };
   }
 
-  if (!isAppendableConversationRunProjection(run)) {
+  if (run.latestExternalEventSequence > input.previousLatestExternalEventSequence) {
     return {
-      result: "non_appendable",
+      result: "advanced",
       run,
     };
   }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.243";
+export const VERSION = "0.1.244";


### PR DESCRIPTION
## Summary
- fix `resyncConversationRunAppendCursor()` to prioritize non-appendable run states over cursor advancement
- add regression coverage for runs that advance the cursor and become waiting-for-tool in the same transition
- bump the package version to `0.1.244`

## Testing
- deno test --no-check --allow-all src/agent/durable.test.ts
- deno check src/agent/durable.ts src/agent/index.ts
- full pre-push suite