### PR TITLE
Preserve queue-controller events across in-flight flushes

### DIFF
--- a/src/agent/durable.test.ts
+++ b/src/agent/durable.test.ts
@@ -772,6 +772,91 @@ describe("agent/durable", () => {
     });
   });
 
+  it("merges events enqueued during an in-flight retry flush", async () => {
+    let resolveAppend: ((response: Response) => void) | null = null;
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      if (String(input).endsWith("/events")) {
+        return new Promise<Response>((resolve) => {
+          resolveAppend = resolve;
+        });
+      }
+
+      return Promise.resolve(jsonResponse(camelCaseDurableRunProjection(), 200));
+    }) as typeof fetch;
+
+    const controller = createConversationRunEventQueueController({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      runId: "run_queue_controller_merge",
+      latestEventId: 2,
+      latestExternalEventSequence: 4,
+      maxEventsPerBatch: 2,
+    });
+
+    controller.enqueue([{ type: "STATE_DELTA", id: 1 }]);
+
+    const flushPromise = controller.flush();
+    controller.enqueue([{ type: "CUSTOM", id: 2 }]);
+    resolveAppend?.(jsonResponse({ detail: "internal failure" }, 500));
+
+    assertEquals(await flushPromise, {
+      outcome: "retry_scheduled",
+      latestEventId: 2,
+      latestExternalEventSequence: 4,
+      pendingEventCount: 2,
+      consecutiveFailures: 1,
+      disabled: false,
+      errorMessage: "Append conversation run events failed (500): internal failure",
+    });
+    assertEquals(controller.getSnapshot(), {
+      latestEventId: 2,
+      latestExternalEventSequence: 4,
+      pendingEventCount: 2,
+      consecutiveFailures: 1,
+      disabled: false,
+    });
+  });
+
+  it("requeues buffered events when queue flushing throws before classification completes", async () => {
+    let appendRequestCount = 0;
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      if (String(input).endsWith("/events")) {
+        appendRequestCount += 1;
+        return Promise.resolve(jsonResponse({ detail: "External run event cursor mismatch" }, 400));
+      }
+
+      return Promise.reject(new Error("run lookup failed"));
+    }) as typeof fetch;
+
+    const controller = createConversationRunEventQueueController({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      runId: "run_queue_controller_throw",
+      latestEventId: 2,
+      latestExternalEventSequence: 4,
+      maxEventsPerBatch: 2,
+    });
+
+    controller.enqueue([{ type: "STATE_DELTA", id: 1 }, { type: "CUSTOM", id: 2 }]);
+
+    await assertRejects(
+      () => controller.flush(),
+      Error,
+      "run lookup failed",
+    );
+
+    assertEquals(appendRequestCount, 1);
+    assertEquals(controller.getSnapshot(), {
+      latestEventId: 2,
+      latestExternalEventSequence: 4,
+      pendingEventCount: 2,
+      consecutiveFailures: 0,
+      disabled: false,
+    });
+  });
+
   it("parses append errors and exposes ignore/cursor helpers", () => {
     assertEquals(
       parseAppendConversationRunEventsErrorBody(

--- a/src/agent/durable.ts
+++ b/src/agent/durable.ts
@@ -962,19 +962,25 @@ export function createConversationRunEventQueueController(input: {
       const queuedEvents = pendingEvents;
       pendingEvents = [];
 
-      const flushed = await flushConversationRunEventQueue({
-        authToken: input.authToken,
-        apiUrl: input.apiUrl,
-        conversationId: input.conversationId,
-        runId: input.runId,
-        latestEventId,
-        latestExternalEventSequence,
-        events: queuedEvents,
-        maxEventsPerBatch: input.maxEventsPerBatch,
-        maxBatchPayloadBytes: input.maxBatchPayloadBytes,
-        maxCursorResyncsPerFlush: input.maxCursorResyncsPerFlush ?? 3,
-        consecutiveFailures,
-      });
+      let flushed;
+      try {
+        flushed = await flushConversationRunEventQueue({
+          authToken: input.authToken,
+          apiUrl: input.apiUrl,
+          conversationId: input.conversationId,
+          runId: input.runId,
+          latestEventId,
+          latestExternalEventSequence,
+          events: queuedEvents,
+          maxEventsPerBatch: input.maxEventsPerBatch,
+          maxBatchPayloadBytes: input.maxBatchPayloadBytes,
+          maxCursorResyncsPerFlush: input.maxCursorResyncsPerFlush ?? 3,
+          consecutiveFailures,
+        });
+      } catch (error) {
+        pendingEvents = [...queuedEvents, ...pendingEvents];
+        throw error;
+      }
 
       latestEventId = flushed.latestEventId;
       latestExternalEventSequence = flushed.latestExternalEventSequence;
@@ -1005,7 +1011,7 @@ export function createConversationRunEventQueueController(input: {
         };
       }
 
-      pendingEvents = flushed.pendingEvents;
+      pendingEvents = [...flushed.pendingEvents, ...pendingEvents];
       consecutiveFailures = flushed.consecutiveFailures;
       return {
         outcome: "retry_scheduled" as const,


### PR DESCRIPTION
## Summary
- merge concurrently enqueued events back into the controller queue on retry scheduling
- restore buffered events when queue flushing throws before recovery classification completes
- add regression coverage for both loss cases

## Verification
- `deno test --no-check --allow-all src/agent/durable.test.ts`
- `deno check src/agent/durable.ts src/agent/index.ts`