### PR TITLE
Release veryfront 0.1.259

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.258",
+  "version": "0.1.259",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.258";
+export const VERSION = "0.1.259";


### PR DESCRIPTION
## Summary
- advance the stable release line to 0.1.259 so the recently merged AG-UI seams can actually publish
- keep the package version in sync with the source version constant tests

## Testing
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- release workflow on merge
