### PR TITLE
Release veryfront 0.1.260

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.259",
+  "version": "0.1.260",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.259";
+export const VERSION = "0.1.260";


### PR DESCRIPTION
## Summary
- advance the stable release line to 0.1.260 so recently merged AG-UI seams can publish
- keep the source version constant in sync with deno.json

## Testing
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- release workflow on merge
