### PR TITLE
Share the hosted UI stream protocol across runtimes

### DIFF
--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -810,71 +810,77 @@ Clear all stored messages from memory.
 
 ### Types
 
-| Name                              | Description                                                                  |
-| --------------------------------- | ---------------------------------------------------------------------------- |
-| `AgUiDetachedStartAccepted`       | Accepted response shape for detached hosted AG-UI kickoff                    |
-| `AgUiDetachedStartHandlerOptions` | Options for `createAgUiDetachedStartHandler`                                 |
-| `AgUiDetachedStartRequest`        | Validated detached hosted AG-UI kickoff request                              |
-| `ExecuteAgUiDetachedStartInput`   | Input shape for `executeAgUiDetachedStart`                                   |
-| `Agent`                           | `agent()` return type                                                        |
-| `AgentConfig`                     | Agent configuration                                                          |
-| `AgentContext`                    | Agent handler context                                                        |
-| `AgentMiddleware`                 | Agent execution middleware                                                   |
-| `AgentResponse`                   | Agent execution response                                                     |
-| `AgentStatus`                     | Agent status (idle, running, etc.)                                           |
-| `AgentStreamResult`               | Streaming result (`.toDataStreamResponse()`)                                 |
-| `AgUiContextItem`                 | AG-UI runtime context item                                                   |
-| `AgUiHandlerConfigWithAgent`      | Direct-agent form for `createAgUiHandler`                                    |
-| `AgUiHandlerOptions`              | Options for `createAgUiHandler`                                              |
-| `AgUiCancelHandlerOptions`        | Options for `createAgUiCancelHandler`                                        |
-| `AgUiInjectedTool`                | AG-UI client-injected tool descriptor                                        |
-| `AgUiRequest`                     | Validated AG-UI runtime request body                                         |
-| `AgUiSseEvent`                    | AG-UI SSE event object used by host-facing AG-UI helpers                     |
-| `AgUiResumeHandlerOptions`        | Options for `createAgUiResumeHandler`                                        |
-| `AgUiResumeSignal`                | Validated hosted-run resume payload                                          |
-| `HumanInputField`                 | Canonical form/input field definition                                        |
-| `HumanInputFieldInput`            | Input shape accepted by `waitForHumanInput()` before defaults normalize      |
-| `HumanInputOption`                | Canonical select/radio option definition                                     |
-| `HumanInputPendingRequest`        | Pending human-input envelope passed to `onRequest`                           |
-| `HumanInputRequest`               | Normalized human-input request payload                                       |
-| `HumanInputRequestInput`          | Input shape accepted by `HumanInputRequestSchema`                            |
-| `HumanInputResult`                | Validated human-input resumed result                                         |
-| `RunResumeSessionManagerOptions`  | Options for `RunResumeSessionManager`                                        |
-| `RunSessionStatus`                | Status of a resumable run session                                            |
-| `SubmitResumeValueOutcome`        | Result of submitting an accepted or duplicate resume value                   |
-| `WaitForHumanInputOptions`        | Options for `waitForHumanInput()`                                            |
-| `ChatHandlerBeforeStream`         | Hook signature for `createChatHandler` customization before streaming.       |
-| `ChatHandlerBeforeStreamContext`  | Input passed to `beforeStream` hook.                                         |
-| `ChatHandlerBeforeStreamResult`   | Message/context mutations returned from `beforeStream`.                      |
-| `ChatHandlerMessageInput`         | Message shape for `prepend`/`append`/`replaceMessages` in `beforeStream`.    |
-| `ChatHandlerOptions`              | Options for `createChatHandler` — customize context and pre-stream behavior. |
-| `EdgeConfig`                      | Agent-to-agent edge config                                                   |
-| `Memory`                          | Memory interface                                                             |
-| `MemoryConfig`                    | Memory creation config                                                       |
-| `MemoryPersistence`               | Memory storage backend                                                       |
-| `MemoryStats`                     | Memory usage stats                                                           |
-| `Message`                         | Chat message (user, assistant, system, tool)                                 |
-| `MessagePart`                     | Multi-part message segment                                                   |
-| `ModelTransportRequest`           | Request-aware model transport hook input                                     |
-| `ModelTransportResolver`          | Hook that resolves request-aware model runtime/transport behavior            |
-| `ModelProvider`                   | Model provider interface                                                     |
-| `ModelString`                     | Model configuration string format: "provider/model-name"                     |
-| `RemoteToolSource`                | Runtime-discovered remote tool source                                        |
-| `RedisClient`                     | Redis client interface (compatible with ioredis and node-redis)              |
-| `RedisMemoryConfig`               | Redis memory configuration                                                   |
-| `ResolvedModelTransport`          | Request-aware model runtime / headers / providerOptions resolution           |
-| `ResolvedRuntimeState`            | Step-boundary system/context refresh result                                  |
-| `RuntimeStateRequest`             | Step-boundary runtime refresh hook input                                     |
-| `RuntimeStateResolver`            | Hook that refreshes system/context state during long-lived runs              |
-| `StreamToolCall`                  | Streaming tool call                                                          |
-| `ToolCall`                        | Completed tool call                                                          |
-| `ToolCallPart`                    | Tool call message segment                                                    |
-| `ToolCallPartWithArgs`            | Tool call with parsed args                                                   |
-| `ToolCallPartWithInput`           | Tool call with raw input                                                     |
-| `ToolResultPart`                  | Tool execution result segment                                                |
-| `WorkflowConfig`                  | `createWorkflow` config                                                      |
-| `WorkflowResult`                  | Completed workflow result                                                    |
-| `WorkflowStep`                    | Workflow step definition                                                     |
+| Name                              | Description                                                                                                                   |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `AgUiDetachedStartAccepted`       | Accepted response shape for detached hosted AG-UI kickoff                                                                     |
+| `AgUiDetachedStartHandlerOptions` | Options for `createAgUiDetachedStartHandler`                                                                                  |
+| `AgUiDetachedStartRequest`        | Validated detached hosted AG-UI kickoff request                                                                               |
+| `ExecuteAgUiDetachedStartInput`   | Input shape for `executeAgUiDetachedStart`                                                                                    |
+| `Agent`                           | `agent()` return type                                                                                                         |
+| `AgentConfig`                     | Agent configuration                                                                                                           |
+| `AgentContext`                    | Agent handler context                                                                                                         |
+| `AgentMiddleware`                 | Agent execution middleware                                                                                                    |
+| `AgentResponse`                   | Agent execution response                                                                                                      |
+| `AgentStatus`                     | Agent status (idle, running, etc.)                                                                                            |
+| `AgentStreamResult`               | Streaming result (`.toDataStreamResponse()`)                                                                                  |
+| `AgUiContextItem`                 | AG-UI runtime context item                                                                                                    |
+| `AgUiHandlerConfigWithAgent`      | Direct-agent form for `createAgUiHandler`                                                                                     |
+| `AgUiHandlerOptions`              | Options for `createAgUiHandler`                                                                                               |
+| `AgUiCancelHandlerOptions`        | Options for `createAgUiCancelHandler`                                                                                         |
+| `AgUiInjectedTool`                | AG-UI client-injected tool descriptor                                                                                         |
+| `AgUiRequest`                     | Validated AG-UI runtime request body                                                                                          |
+| `AgUiSseEvent`                    | AG-UI SSE event object used by host-facing AG-UI helpers                                                                      |
+| `AgUiResumeHandlerOptions`        | Options for `createAgUiResumeHandler`                                                                                         |
+| `AgUiResumeSignal`                | Validated hosted-run resume payload                                                                                           |
+| `HumanInputField`                 | Canonical form/input field definition                                                                                         |
+| `HumanInputFieldInput`            | Input shape accepted by `waitForHumanInput()` before defaults normalize                                                       |
+| `HumanInputOption`                | Canonical select/radio option definition                                                                                      |
+| `HumanInputPendingRequest`        | Pending human-input envelope passed to `onRequest`                                                                            |
+| `HumanInputRequest`               | Normalized human-input request payload                                                                                        |
+| `HumanInputRequestInput`          | Input shape accepted by `HumanInputRequestSchema`                                                                             |
+| `HumanInputResult`                | Validated human-input resumed result                                                                                          |
+| `RunResumeSessionManagerOptions`  | Options for `RunResumeSessionManager`                                                                                         |
+| `RunSessionStatus`                | Status of a resumable run session                                                                                             |
+| `SubmitResumeValueOutcome`        | Result of submitting an accepted or duplicate resume value                                                                    |
+| `WaitForHumanInputOptions`        | Options for `waitForHumanInput()`                                                                                             |
+| `ChatHandlerBeforeStream`         | Hook signature for `createChatHandler` customization before streaming.                                                        |
+| `ChatHandlerBeforeStreamContext`  | Input passed to `beforeStream` hook.                                                                                          |
+| `ChatHandlerBeforeStreamResult`   | Message/context mutations returned from `beforeStream`.                                                                       |
+| `ChatHandlerMessageInput`         | Message shape for `prepend`/`append`/`replaceMessages` in `beforeStream`.                                                     |
+| `ChatHandlerOptions`              | Options for `createChatHandler` — customize context and pre-stream behavior.                                                  |
+| `ChatMessageMetadata`             | Canonical hosted message metadata shape for streamed assistant messages.                                                      |
+| `ChatMessageMetadataUsage`        | Usage counters nested under `ChatMessageMetadata.usage`.                                                                      |
+| `EdgeConfig`                      | Agent-to-agent edge config                                                                                                    |
+| `Memory`                          | Memory interface                                                                                                              |
+| `MemoryConfig`                    | Memory creation config                                                                                                        |
+| `MemoryPersistence`               | Memory storage backend                                                                                                        |
+| `MemoryStats`                     | Memory usage stats                                                                                                            |
+| `Message`                         | Chat message (user, assistant, system, tool)                                                                                  |
+| `MessagePart`                     | Multi-part message segment                                                                                                    |
+| `ModelTransportRequest`           | Request-aware model transport hook input                                                                                      |
+| `ModelTransportResolver`          | Hook that resolves request-aware model runtime/transport behavior                                                             |
+| `ModelProvider`                   | Model provider interface                                                                                                      |
+| `ModelString`                     | Model configuration string format: "provider/model-name"                                                                      |
+| `RemoteToolSource`                | Runtime-discovered remote tool source                                                                                         |
+| `RedisClient`                     | Redis client interface (compatible with ioredis and node-redis)                                                               |
+| `RedisMemoryConfig`               | Redis memory configuration                                                                                                    |
+| `ResolvedModelTransport`          | Request-aware model runtime / headers / providerOptions resolution                                                            |
+| `ResolvedRuntimeState`            | Step-boundary system/context refresh result                                                                                   |
+| `RuntimeStateRequest`             | Step-boundary runtime refresh hook input                                                                                      |
+| `RuntimeStateResolver`            | Hook that refreshes system/context state during long-lived runs                                                               |
+| `StreamToolCall`                  | Streaming tool call                                                                                                           |
+| `ToolCall`                        | Completed tool call                                                                                                           |
+| `ToolCallPart`                    | Tool call message segment                                                                                                     |
+| `ToolCallPartWithArgs`            | Tool call with parsed args                                                                                                    |
+| `ToolCallPartWithInput`           | Tool call with raw input                                                                                                      |
+| `ToolResultPart`                  | Tool execution result segment                                                                                                 |
+| `ChatUiMessageChunk`              | Canonical hosted UI-stream chunk union for message lifecycle, text, reasoning, tool, file, source, approval, and data events. |
+| `ChildRunAudit`                   | Child-run audit summary nested inside hosted message metadata.                                                                |
+| `ChildRunAuditToolCall`           | Child-run audit tool-call entry.                                                                                              |
+| `ChildRunAuditToolResult`         | Child-run audit tool-result entry.                                                                                            |
+| `WorkflowConfig`                  | `createWorkflow` config                                                                                                       |
+| `WorkflowResult`                  | Completed workflow result                                                                                                     |
+| `WorkflowStep`                    | Workflow step definition                                                                                                      |
 
 ## Related
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -377,6 +377,14 @@ export {
   streamDataStreamEvents,
   stripLeadingEmptyObjectPlaceholder,
 } from "./data-stream.ts";
+export type {
+  ChatMessageMetadata,
+  ChatMessageMetadataUsage,
+  ChatUiMessageChunk,
+  ChildRunAudit,
+  ChildRunAuditToolCall,
+  ChildRunAuditToolResult,
+} from "../chat/protocol.ts";
 export {
   expandAllowedRemoteToolNames,
   getProviderNativeToolNames,

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -210,6 +210,15 @@ export {
   type UseChatResult,
 } from "#veryfront/agent/react/use-chat/index.ts";
 
+export type {
+  ChatMessageMetadata,
+  ChatMessageMetadataUsage,
+  ChatUiMessageChunk,
+  ChildRunAudit,
+  ChildRunAuditToolCall,
+  ChildRunAuditToolResult,
+} from "./protocol.ts";
+
 export {
   useAgent,
   type UseAgentOptions,

--- a/src/chat/protocol.ts
+++ b/src/chat/protocol.ts
@@ -75,6 +75,52 @@ export interface ChatMessage {
   createdAt?: Date | string;
 }
 
+export interface ChatMessageMetadataUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  reasoningTokens?: number;
+  cachedInputTokens?: number;
+}
+
+export interface ChildRunAuditToolCall {
+  toolName: string;
+  toolCallId: string;
+  input?: unknown;
+}
+
+export interface ChildRunAuditToolResult {
+  toolName: string;
+  toolCallId: string;
+  input: unknown;
+  output: unknown;
+}
+
+export interface ChildRunAudit {
+  status: "completed" | "failed" | "cancelled" | "stopped";
+  description?: string;
+  steps?: number;
+  durationMs?: number;
+  toolCalls?: ChildRunAuditToolCall[];
+  toolResults?: ChildRunAuditToolResult[];
+  terminalErrorCode?: string | null;
+  terminalErrorMessage?: string | null;
+}
+
+export interface ChatMessageMetadata {
+  createdAt?: string;
+  isStopped?: boolean;
+  isCompleted?: boolean;
+  completedAt?: string;
+  agentId?: string;
+  agentName?: string;
+  conversationId?: string;
+  modelId?: string;
+  runId?: string;
+  streamingMessageId?: string;
+  childRunAudit?: ChildRunAudit;
+  usage?: ChatMessageMetadataUsage;
+}
+
 export type ChatFinishReason =
   | "stop"
   | "length"
@@ -205,4 +251,106 @@ export type ChatStreamEvent =
   | {
     type: "error";
     errorText: string;
+  };
+
+type MessageLifecycleChunk<TMessageMetadata> =
+  | {
+    type: "start";
+    messageId?: string;
+    messageMetadata?: TMessageMetadata;
+  }
+  | {
+    type: "finish";
+    finishReason?: string;
+    messageMetadata?: TMessageMetadata;
+  }
+  | {
+    type: "message-metadata";
+    messageMetadata: TMessageMetadata;
+  };
+
+type IdChunk<TType extends string> = {
+  type: TType;
+  id: string;
+};
+
+type IdDeltaChunk<TType extends string> = IdChunk<TType> & {
+  delta: string;
+};
+
+type ToolCallChunk<TType extends string> = {
+  type: TType;
+  toolCallId: string;
+};
+
+type NamedToolCallChunk<TType extends string> = ToolCallChunk<TType> & {
+  toolName: string;
+};
+
+type ToolInputChunk<TType extends string> = NamedToolCallChunk<TType> & {
+  input: unknown;
+};
+
+type ToolErrorChunk<TType extends string> = ToolCallChunk<TType> & {
+  errorText: string;
+};
+
+export type ChatUiMessageChunk<TMessageMetadata = ChatMessageMetadata> =
+  | MessageLifecycleChunk<TMessageMetadata>
+  | {
+    type: "start-step";
+  }
+  | {
+    type: "finish-step";
+  }
+  | {
+    type: "abort";
+  }
+  | IdChunk<"reasoning-start">
+  | IdDeltaChunk<"reasoning-delta">
+  | IdChunk<"reasoning-end">
+  | IdChunk<"text-start">
+  | IdDeltaChunk<"text-delta">
+  | IdChunk<"text-end">
+  | {
+    type: "source-url";
+    sourceId: string;
+    url: string;
+    title?: string;
+  }
+  | {
+    type: "source-document";
+    sourceId: string;
+    mediaType: string;
+    title: string;
+    filename?: string;
+  }
+  | {
+    type: "file";
+    mediaType: string;
+    url: string;
+  }
+  | NamedToolCallChunk<"tool-input-start">
+  | (ToolCallChunk<"tool-input-delta"> & {
+    inputTextDelta: string;
+  })
+  | ToolInputChunk<"tool-input-available">
+  | (ToolInputChunk<"tool-input-error"> & {
+    errorText: string;
+  })
+  | (ToolCallChunk<"tool-output-available"> & {
+    output: unknown;
+  })
+  | ToolErrorChunk<"tool-output-error">
+  | ToolCallChunk<"tool-output-denied">
+  | (ToolCallChunk<"tool-approval-request"> & {
+    approvalId: string;
+  })
+  | {
+    type: "error";
+    errorText: string;
+  }
+  | {
+    type: `data-${string}`;
+    data: unknown;
   };


### PR DESCRIPTION
## Summary
- promote the hosted UI chunk and message metadata contract into `veryfront-code`
- export `ChatUiMessageChunk` and `ChatMessageMetadata` through the framework chat and agent surfaces
- document the shared protocol so hosts stop duplicating these types locally

## Testing
- deno check src/chat/protocol.ts src/chat/index.ts src/agent/index.ts
- local pre-push checks passed during git push (format, lint, typecheck, full unit suite)