### PR TITLE
Refactor AG-UI helpers and knowledge upload classification

### DIFF
--- a/cli/commands/knowledge/command.ts
+++ b/cli/commands/knowledge/command.ts
@@ -228,6 +228,31 @@ async function collectLocalFiles(
   return commandHelpers.collectLocalFiles(root, recursive);
 }
 
+function classifyListedUploadsForKnowledge(uploads: UploadItem[]): {
+  skipped: KnowledgeIngestSkippedFileResult[];
+  uploadTargets: string[];
+} {
+  const skipped: KnowledgeIngestSkippedFileResult[] = [];
+  const uploadTargets: string[] = [];
+
+  for (const item of uploads) {
+    if (item.type === "folder") {
+      continue;
+    }
+
+    const source = formatKnowledgeUploadSource(item.path);
+    const skippedUpload = classifySourceOrSkip({ source });
+    if (skippedUpload == null) {
+      uploadTargets.push(item.path);
+      continue;
+    }
+
+    skipped.push(skippedUpload);
+  }
+
+  return { skipped, uploadTargets };
+}
+
 function buildSourceReference(source: KnowledgeSource): string {
   return commandHelpers.buildSourceReference(source);
 }
@@ -488,41 +513,11 @@ export async function collectKnowledgeSources(
     });
 
   let uploads = await listUploadsForPrefix(uploadPrefix || undefined);
-  let skipped = uploads.flatMap((item: UploadItem) => {
-    if (item.type === "folder") {
-      return [];
-    }
-
-    const skippedUpload = classifySourceOrSkip({
-      source: formatKnowledgeUploadSource(item.path),
-    });
-    return skippedUpload == null ? [] : [skippedUpload];
-  });
-  let uploadTargets = uploads
-    .filter((item: UploadItem) => item.type !== "folder")
-    .map((item: UploadItem) => item.path)
-    .filter((uploadPath) =>
-      classifySourceOrSkip({ source: formatKnowledgeUploadSource(uploadPath) }) == null
-    );
+  let { skipped, uploadTargets } = classifyListedUploadsForKnowledge(uploads);
 
   if (!uploadTargets.length && uploadPrefix && !uploadPrefix.endsWith("/")) {
     uploads = await listUploadsForPrefix(`${uploadPrefix}/`);
-    skipped = uploads.flatMap((item: UploadItem) => {
-      if (item.type === "folder") {
-        return [];
-      }
-
-      const skippedUpload = classifySourceOrSkip({
-        source: formatKnowledgeUploadSource(item.path),
-      });
-      return skippedUpload == null ? [] : [skippedUpload];
-    });
-    uploadTargets = uploads
-      .filter((item: UploadItem) => item.type !== "folder")
-      .map((item: UploadItem) => item.path)
-      .filter((uploadPath) =>
-        classifySourceOrSkip({ source: formatKnowledgeUploadSource(uploadPath) }) == null
-      );
+    ({ skipped, uploadTargets } = classifyListedUploadsForKnowledge(uploads));
   }
 
   if (!uploadTargets.length && skipped.length === 0) {

--- a/src/agent/ag-ui-detached-start.ts
+++ b/src/agent/ag-ui-detached-start.ts
@@ -1,13 +1,9 @@
 import { z } from "zod";
 import { INVALID_ARGUMENT } from "#veryfront/errors";
-import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
-import { type Tool, toolRegistry } from "#veryfront/tool";
 import { streamDataStreamEvents } from "./data-stream.ts";
-import {
-  type AgUiInjectedTool,
-  AgUiRequestSchema,
-  normalizeAgUiMessages,
-} from "./ag-ui-host-support.ts";
+import { AgUiRequestSchema, normalizeAgUiMessages } from "./ag-ui-host-support.ts";
+import { extractRequest } from "./ag-ui-request-shared.ts";
+import { type AgUiResumeValue, buildMergedAgUiTools } from "./ag-ui-tool-shared.ts";
 import {
   AgentRuntime,
   RunAlreadyExistsError,
@@ -17,42 +13,12 @@ import type { Agent } from "./types.ts";
 
 const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const AG_UI_DETACHED_RUN_ID_SCHEMA = z.string().min(1).max(128).regex(AGENT_ID_PATTERN);
-type AgUiResumeValue = {
-  result: unknown;
-  isError: boolean;
-};
 
 type AgUiContextValue =
   | Record<string, unknown>
   | ((request: Request) => Record<string, unknown> | Promise<Record<string, unknown>>);
 
 type AgUiRuntimePart = Record<string, unknown> & { type: string };
-
-function isRequest(obj: unknown): obj is Request {
-  return (
-    typeof obj === "object" &&
-    obj !== null &&
-    "json" in obj &&
-    typeof obj.json === "function" &&
-    "url" in obj &&
-    typeof obj.url === "string" &&
-    "method" in obj &&
-    typeof obj.method === "string"
-  );
-}
-
-function extractRequest(requestOrCtx: unknown): Request {
-  if (isRequest(requestOrCtx)) return requestOrCtx;
-
-  if (typeof requestOrCtx === "object" && requestOrCtx !== null && "request" in requestOrCtx) {
-    const candidate = (requestOrCtx as Record<string, unknown>).request;
-    if (isRequest(candidate)) return candidate;
-  }
-
-  throw INVALID_ARGUMENT.create({
-    detail: "Invalid handler argument: expected Request or APIContext",
-  });
-}
 
 function buildStreamContext(
   request: AgUiDetachedStartRequest,
@@ -71,66 +37,12 @@ function buildStreamContext(
   };
 }
 
-function createInjectedAgUiTool(
-  runId: string,
-  tool: AgUiInjectedTool,
-  sessionManager: RunResumeSessionManager<AgUiResumeValue>,
-): Tool {
-  return {
-    id: tool.name,
-    type: "function",
-    description: tool.description ?? tool.name,
-    inputSchema: z.record(z.string(), z.unknown()),
-    inputSchemaJson: (tool.parameters ??
-      { type: "object", properties: {}, additionalProperties: true }) as Tool["inputSchemaJson"],
-    execute: async (_input, context) => {
-      const toolCallId = typeof context?.toolCallId === "string" ? context.toolCallId : null;
-      if (!toolCallId) {
-        throw new Error(`Missing toolCallId for injected tool "${tool.name}"`);
-      }
-
-      sessionManager.prepareForSignal(runId, toolCallId);
-      const submitted = await sessionManager.waitForSignal(runId, toolCallId);
-      if (submitted.isError) {
-        throw new Error(
-          typeof submitted.result === "string"
-            ? submitted.result
-            : JSON.stringify(submitted.result),
-        );
-      }
-      return submitted.result;
-    },
-  };
-}
-
 function buildMergedTools(
   agent: Agent,
   request: AgUiDetachedStartRequest,
   sessionManager: RunResumeSessionManager<AgUiResumeValue>,
 ): Agent["config"]["tools"] {
-  const injectedTools = Object.fromEntries(
-    request.tools.map((tool) => [
-      tool.name,
-      createInjectedAgUiTool(request.runId, tool, sessionManager),
-    ]),
-  );
-
-  if (!agent.config.tools) {
-    return Object.keys(injectedTools).length > 0 ? injectedTools : undefined;
-  }
-
-  if (agent.config.tools === true) {
-    const merged: Record<string, Tool | boolean> = {};
-    for (const [toolId] of toolRegistry.getAll()) {
-      if (!agent.config.skills && SKILL_TOOL_IDS.has(toolId)) {
-        continue;
-      }
-      merged[toolId] = true;
-    }
-    return { ...merged, ...injectedTools };
-  }
-
-  return { ...agent.config.tools, ...injectedTools };
+  return buildMergedAgUiTools(agent, request.runId, request.tools, sessionManager);
 }
 
 function scheduleDetachedTask(requestOrCtx: unknown, task: Promise<void>): void {

--- a/src/agent/ag-ui-handler.ts
+++ b/src/agent/ag-ui-handler.ts
@@ -6,9 +6,6 @@ import {
   RunAlreadyExistsError,
   type RunResumeSessionManager,
 } from "./runtime/index.ts";
-import { INVALID_ARGUMENT } from "#veryfront/errors";
-import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
-import { type Tool, toolRegistry } from "#veryfront/tool";
 import {
   createStreamTransformState,
   finalizeRunEvents,
@@ -17,11 +14,12 @@ import {
 } from "#veryfront/internal-agents/ag-ui-sse.ts";
 import { streamDataStreamEvents } from "./data-stream.ts";
 import {
-  type AgUiInjectedTool,
   type AgUiRequest,
   normalizeAgUiMessages,
   parseAgUiRequestOrError,
 } from "./ag-ui-host-support.ts";
+import { extractRequest } from "./ag-ui-request-shared.ts";
+import { type AgUiResumeValue, buildMergedAgUiTools } from "./ag-ui-tool-shared.ts";
 
 export {
   type AgUiContextItem,
@@ -38,34 +36,7 @@ const AG_UI_HEADERS: Record<string, string> = {
   Connection: "keep-alive",
 };
 
-type AgUiResumeValue = { result: unknown; isError: boolean };
 type AgUiRuntimePart = Record<string, unknown> & { type: string };
-
-function isRequest(obj: unknown): obj is Request {
-  return (
-    typeof obj === "object" &&
-    obj !== null &&
-    "json" in obj &&
-    typeof obj.json === "function" &&
-    "url" in obj &&
-    typeof obj.url === "string" &&
-    "method" in obj &&
-    typeof obj.method === "string"
-  );
-}
-
-function extractRequest(requestOrCtx: unknown): Request {
-  if (isRequest(requestOrCtx)) return requestOrCtx;
-
-  if (typeof requestOrCtx === "object" && requestOrCtx !== null && "request" in requestOrCtx) {
-    const candidate = (requestOrCtx as Record<string, unknown>).request;
-    if (isRequest(candidate)) return candidate;
-  }
-
-  throw INVALID_ARGUMENT.create({
-    detail: "Invalid handler argument: expected Request or APIContext",
-  });
-}
 
 function generateRunId(): string {
   return `run_${crypto.randomUUID().replaceAll("-", "")}`;
@@ -239,38 +210,6 @@ async function createAgUiDirectStreamResponse(
   });
 }
 
-function createInjectedAgUiTool(
-  runId: string,
-  tool: AgUiInjectedTool,
-  sessionManager: RunResumeSessionManager<AgUiResumeValue>,
-): Tool {
-  return {
-    id: tool.name,
-    type: "function",
-    description: tool.description ?? tool.name,
-    inputSchema: z.record(z.string(), z.unknown()),
-    inputSchemaJson: (tool.parameters ??
-      { type: "object", properties: {}, additionalProperties: true }) as Tool["inputSchemaJson"],
-    execute: async (_input, context) => {
-      const toolCallId = typeof context?.toolCallId === "string" ? context.toolCallId : null;
-      if (!toolCallId) {
-        throw new Error(`Missing toolCallId for injected tool "${tool.name}"`);
-      }
-
-      sessionManager.prepareForSignal(runId, toolCallId);
-      const submitted = await sessionManager.waitForSignal(runId, toolCallId);
-      if (submitted.isError) {
-        throw new Error(
-          typeof submitted.result === "string"
-            ? submitted.result
-            : JSON.stringify(submitted.result),
-        );
-      }
-      return submitted.result;
-    },
-  };
-}
-
 async function createAgUiInjectedToolsStreamResponse(
   agent: Agent,
   request: AgUiRequest,
@@ -289,26 +228,9 @@ async function createAgUiInjectedToolsStreamResponse(
     throw error;
   }
 
-  const injectedTools = Object.fromEntries(
-    request.tools.map((tool) => [tool.name, createInjectedAgUiTool(runId, tool, sessionManager)]),
-  );
-
-  const mergedTools: Agent["config"]["tools"] = !agent.config.tools
-    ? injectedTools
-    : agent.config.tools === true
-    ? {
-      ...Object.fromEntries(
-        [...toolRegistry.getAll()]
-          .filter(([toolId]) => agent.config.skills || !SKILL_TOOL_IDS.has(toolId))
-          .map(([toolId]) => [toolId, true]),
-      ),
-      ...injectedTools,
-    }
-    : { ...agent.config.tools, ...injectedTools };
-
   const runtime = new AgentRuntime(agent.id, {
     ...agent.config,
-    tools: mergedTools,
+    tools: buildMergedAgUiTools(agent, runId, request.tools, sessionManager),
   });
 
   let upstreamBody: ReadableStream<Uint8Array>;

--- a/src/agent/ag-ui-host-support.ts
+++ b/src/agent/ag-ui-host-support.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { formatAgUiEvent } from "#veryfront/internal-agents/ag-ui-sse.ts";
 import type { Message } from "./types.ts";
+import { parseAgUiJsonRequestOrError } from "./ag-ui-request-shared.ts";
 
 const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const MAX_TOOL_PARAMETERS_BYTES = 16_384;
@@ -173,34 +174,10 @@ export async function parseAgUiRequest(request: Request): Promise<AgUiRequest> {
 export async function parseAgUiRequestOrError(
   request: Request,
 ): Promise<AgUiRequest | Response> {
-  try {
-    return await parseAgUiRequest(request);
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return Response.json(
-        {
-          error: "Invalid AG-UI request",
-          details: error.issues.map((issue) => ({
-            path: issue.path,
-            message: issue.message,
-          })),
-        },
-        { status: 400 },
-      );
-    }
-
-    if (error instanceof SyntaxError || error instanceof TypeError) {
-      return Response.json(
-        {
-          error: "Invalid AG-UI request",
-          details: [{ path: [], message: "Malformed JSON request body" }],
-        },
-        { status: 400 },
-      );
-    }
-
-    throw error;
-  }
+  return await parseAgUiJsonRequestOrError(
+    () => parseAgUiRequest(request),
+    "Invalid AG-UI request",
+  );
 }
 
 export function normalizeAgUiMessages(messages: AgUiRequest["messages"]): Message[] {

--- a/src/agent/ag-ui-request-shared.ts
+++ b/src/agent/ag-ui-request-shared.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import { INVALID_ARGUMENT } from "#veryfront/errors";
+
+export function isRequest(value: unknown): value is Request {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "json" in value &&
+    typeof value.json === "function" &&
+    "url" in value &&
+    typeof value.url === "string" &&
+    "method" in value &&
+    typeof value.method === "string"
+  );
+}
+
+export function extractRequest(requestOrCtx: unknown): Request {
+  if (isRequest(requestOrCtx)) return requestOrCtx;
+
+  if (typeof requestOrCtx === "object" && requestOrCtx !== null && "request" in requestOrCtx) {
+    const candidate = (requestOrCtx as Record<string, unknown>).request;
+    if (isRequest(candidate)) return candidate;
+  }
+
+  throw INVALID_ARGUMENT.create({
+    detail: "Invalid handler argument: expected Request or APIContext",
+  });
+}
+
+export async function parseAgUiJsonRequestOrError<T>(
+  parseRequest: () => Promise<T>,
+  errorLabel: string,
+): Promise<T | Response> {
+  try {
+    return await parseRequest();
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return Response.json(
+        {
+          error: errorLabel,
+          details: error.issues.map((issue) => ({
+            path: issue.path,
+            message: issue.message,
+          })),
+        },
+        { status: 400 },
+      );
+    }
+
+    if (error instanceof SyntaxError || error instanceof TypeError) {
+      return Response.json(
+        {
+          error: errorLabel,
+          details: [{ path: [], message: "Malformed JSON request body" }],
+        },
+        { status: 400 },
+      );
+    }
+
+    throw error;
+  }
+}

--- a/src/agent/ag-ui-run-control.ts
+++ b/src/agent/ag-ui-run-control.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { INVALID_ARGUMENT } from "#veryfront/errors";
+import { extractRequest } from "./ag-ui-request-shared.ts";
 import {
   RunNotActiveError,
   RunResumeSessionManager,
@@ -25,32 +25,6 @@ type ResumeValue = {
   result: unknown;
   isError: boolean;
 };
-
-function isRequest(value: unknown): value is Request {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "json" in value &&
-    typeof value.json === "function" &&
-    "url" in value &&
-    typeof value.url === "string" &&
-    "method" in value &&
-    typeof value.method === "string"
-  );
-}
-
-function extractRequest(requestOrCtx: unknown): Request {
-  if (isRequest(requestOrCtx)) return requestOrCtx;
-
-  if (typeof requestOrCtx === "object" && requestOrCtx !== null && "request" in requestOrCtx) {
-    const candidate = (requestOrCtx as Record<string, unknown>).request;
-    if (isRequest(candidate)) return candidate;
-  }
-
-  throw INVALID_ARGUMENT.create({
-    detail: "Invalid handler argument: expected Request or APIContext",
-  });
-}
 
 function getRunId(pathname: string, regex: RegExp): string | null {
   return regex.exec(pathname)?.[1] ?? null;

--- a/src/agent/ag-ui-runtime-handler.ts
+++ b/src/agent/ag-ui-runtime-handler.ts
@@ -1,7 +1,4 @@
 import { z } from "zod";
-import { INVALID_ARGUMENT } from "#veryfront/errors";
-import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
-import { type Tool, toolRegistry } from "#veryfront/tool";
 import {
   AgentRuntime,
   RunAlreadyExistsError,
@@ -9,10 +6,11 @@ import {
 } from "./runtime/index.ts";
 import type { Agent } from "./types.ts";
 import {
-  type AgUiRuntimeInjectedTool,
   type AgUiRuntimeRequest,
   parseAgUiRuntimeRequestOrError,
 } from "./runtime-ag-ui-contract.ts";
+import { extractRequest } from "./ag-ui-request-shared.ts";
+import { type AgUiResumeValue, buildMergedAgUiTools } from "./ag-ui-tool-shared.ts";
 import { normalizeAgUiRuntimeMessages } from "./ag-ui-runtime-support.ts";
 import {
   createStreamTransformState,
@@ -28,7 +26,6 @@ const AG_UI_HEADERS: Record<string, string> = {
   Connection: "keep-alive",
 };
 
-type AgUiResumeValue = { result: unknown; isError: boolean };
 type AgUiRuntimePart = Record<string, unknown> & { type: string };
 
 export interface AgUiRuntimeLifecycleContext {
@@ -64,34 +61,8 @@ async function invokeLifecycleCallbackAndWait(
   }
 }
 
-function isRequest(obj: unknown): obj is Request {
-  return (
-    typeof obj === "object" &&
-    obj !== null &&
-    "json" in obj &&
-    typeof obj.json === "function" &&
-    "url" in obj &&
-    typeof obj.url === "string" &&
-    "method" in obj &&
-    typeof obj.method === "string"
-  );
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function extractRequest(requestOrCtx: unknown): Request {
-  if (isRequest(requestOrCtx)) return requestOrCtx;
-
-  if (typeof requestOrCtx === "object" && requestOrCtx !== null && "request" in requestOrCtx) {
-    const candidate = (requestOrCtx as Record<string, unknown>).request;
-    if (isRequest(candidate)) return candidate;
-  }
-
-  throw INVALID_ARGUMENT.create({
-    detail: "Invalid handler argument: expected Request or APIContext",
-  });
 }
 
 function buildStreamContext(
@@ -271,66 +242,12 @@ async function createAgUiRuntimeDirectStreamResponse(
   });
 }
 
-function createInjectedAgUiTool(
-  runId: string,
-  tool: AgUiRuntimeInjectedTool,
-  sessionManager: RunResumeSessionManager<AgUiResumeValue>,
-): Tool {
-  return {
-    id: tool.name,
-    type: "function",
-    description: tool.description ?? tool.name,
-    inputSchema: z.record(z.string(), z.unknown()),
-    inputSchemaJson: (tool.parameters ??
-      { type: "object", properties: {}, additionalProperties: true }) as Tool["inputSchemaJson"],
-    execute: async (_input, context) => {
-      const toolCallId = typeof context?.toolCallId === "string" ? context.toolCallId : null;
-      if (!toolCallId) {
-        throw new Error(`Missing toolCallId for injected tool "${tool.name}"`);
-      }
-
-      sessionManager.prepareForSignal(runId, toolCallId);
-      const submitted = await sessionManager.waitForSignal(runId, toolCallId);
-      if (submitted.isError) {
-        throw new Error(
-          typeof submitted.result === "string"
-            ? submitted.result
-            : JSON.stringify(submitted.result),
-        );
-      }
-      return submitted.result;
-    },
-  };
-}
-
 function buildMergedTools(
   agent: Agent,
   request: AgUiRuntimeRequest,
   sessionManager: RunResumeSessionManager<AgUiResumeValue>,
 ): Agent["config"]["tools"] {
-  const injectedTools = Object.fromEntries(
-    request.tools.map((tool) => [
-      tool.name,
-      createInjectedAgUiTool(request.runId, tool, sessionManager),
-    ]),
-  );
-
-  if (!agent.config.tools) {
-    return Object.keys(injectedTools).length > 0 ? injectedTools : undefined;
-  }
-
-  if (agent.config.tools === true) {
-    const merged: Record<string, Tool | boolean> = {};
-    for (const [toolId] of toolRegistry.getAll()) {
-      if (!agent.config.skills && SKILL_TOOL_IDS.has(toolId)) {
-        continue;
-      }
-      merged[toolId] = true;
-    }
-    return { ...merged, ...injectedTools };
-  }
-
-  return { ...agent.config.tools, ...injectedTools };
+  return buildMergedAgUiTools(agent, request.runId, request.tools, sessionManager);
 }
 
 async function createAgUiRuntimeInjectedToolsStreamResponse(

--- a/src/agent/ag-ui-tool-shared.ts
+++ b/src/agent/ag-ui-tool-shared.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+import { SKILL_TOOL_IDS } from "#veryfront/skill/types.ts";
+import { toolRegistry } from "#veryfront/tool/registry.ts";
+import type { Tool } from "#veryfront/tool/types.ts";
+import type { RunResumeSessionManager } from "./runtime/index.ts";
+import type { Agent } from "./types.ts";
+
+export type AgUiResumeValue = { result: unknown; isError: boolean };
+
+export interface AgUiInjectedToolLike {
+  name: string;
+  description?: string;
+  parameters?: unknown;
+}
+
+export function createInjectedAgUiTool(
+  runId: string,
+  tool: AgUiInjectedToolLike,
+  sessionManager: RunResumeSessionManager<AgUiResumeValue>,
+): Tool {
+  return {
+    id: tool.name,
+    type: "function",
+    description: tool.description ?? tool.name,
+    inputSchema: z.record(z.string(), z.unknown()),
+    inputSchemaJson: (tool.parameters ??
+      { type: "object", properties: {}, additionalProperties: true }) as Tool["inputSchemaJson"],
+    execute: async (_input, context) => {
+      const toolCallId = typeof context?.toolCallId === "string" ? context.toolCallId : null;
+      if (!toolCallId) {
+        throw new Error(`Missing toolCallId for injected tool "${tool.name}"`);
+      }
+
+      sessionManager.prepareForSignal(runId, toolCallId);
+      const submitted = await sessionManager.waitForSignal(runId, toolCallId);
+      if (submitted.isError) {
+        throw new Error(
+          typeof submitted.result === "string"
+            ? submitted.result
+            : JSON.stringify(submitted.result),
+        );
+      }
+      return submitted.result;
+    },
+  };
+}
+
+export function buildMergedAgUiTools(
+  agent: Agent,
+  runId: string,
+  tools: AgUiInjectedToolLike[],
+  sessionManager: RunResumeSessionManager<AgUiResumeValue>,
+): Agent["config"]["tools"] {
+  const injectedTools = Object.fromEntries(
+    tools.map((tool) => [
+      tool.name,
+      createInjectedAgUiTool(runId, tool, sessionManager),
+    ]),
+  );
+
+  if (!agent.config.tools) {
+    return Object.keys(injectedTools).length > 0 ? injectedTools : undefined;
+  }
+
+  if (agent.config.tools === true) {
+    const merged: Record<string, Tool | boolean> = {};
+    for (const [toolId] of toolRegistry.getAll()) {
+      if (!agent.config.skills && SKILL_TOOL_IDS.has(toolId)) {
+        continue;
+      }
+      merged[toolId] = true;
+    }
+    return { ...merged, ...injectedTools };
+  }
+
+  return { ...agent.config.tools, ...injectedTools };
+}

--- a/src/agent/runtime-ag-ui-contract.ts
+++ b/src/agent/runtime-ag-ui-contract.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { parseAgUiJsonRequestOrError } from "./ag-ui-request-shared.ts";
 
 const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const MAX_TOOL_PARAMETERS_BYTES = 16_384;
@@ -172,32 +173,8 @@ export async function parseAgUiRuntimeRequest(request: Request): Promise<AgUiRun
 export async function parseAgUiRuntimeRequestOrError(
   request: Request,
 ): Promise<AgUiRuntimeRequest | Response> {
-  try {
-    return await parseAgUiRuntimeRequest(request);
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return Response.json(
-        {
-          error: "Invalid AG-UI runtime request",
-          details: error.issues.map((issue) => ({
-            path: issue.path,
-            message: issue.message,
-          })),
-        },
-        { status: 400 },
-      );
-    }
-
-    if (error instanceof SyntaxError || error instanceof TypeError) {
-      return Response.json(
-        {
-          error: "Invalid AG-UI runtime request",
-          details: [{ path: [], message: "Malformed JSON request body" }],
-        },
-        { status: 400 },
-      );
-    }
-
-    throw error;
-  }
+  return await parseAgUiJsonRequestOrError(
+    () => parseAgUiRuntimeRequest(request),
+    "Invalid AG-UI runtime request",
+  );
 }


### PR DESCRIPTION
## Summary
- Split shared AG-UI request/parse helpers from injected-tool merge helpers to preserve module boundaries while removing duplication
- Reused the AG-UI helpers across direct, runtime, detached, run-control, and contract/support paths without changing behavior
- Deduplicated knowledge ingest upload listing classification while preserving skip/target partitioning and prefix retry behavior

## Verification
- `deno fmt --check src/agent/ag-ui-request-shared.ts src/agent/ag-ui-tool-shared.ts src/agent/ag-ui-detached-start.ts src/agent/ag-ui-handler.ts src/agent/ag-ui-run-control.ts src/agent/ag-ui-runtime-handler.ts src/agent/ag-ui-host-support.ts src/agent/runtime-ag-ui-contract.ts cli/commands/knowledge/command.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/agent/ag-ui-request-shared.ts src/agent/ag-ui-tool-shared.ts src/agent/ag-ui-detached-start.ts src/agent/ag-ui-handler.ts src/agent/ag-ui-run-control.ts src/agent/ag-ui-runtime-handler.ts src/agent/ag-ui-host-support.ts src/agent/runtime-ag-ui-contract.ts cli/commands/knowledge/command.ts`
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --unstable-net src/agent/ag-ui-handler.test.ts src/agent/ag-ui-runtime-handler.test.ts src/agent/ag-ui-detached-start.test.ts src/agent/ag-ui-run-control.test.ts src/agent/ag-ui-host-support.test.ts src/agent/runtime-ag-ui-contract.test.ts`
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all cli/commands/knowledge/command.test.ts cli/commands/knowledge/handler.test.ts`
- `deno task typecheck`
- Pre-push hook: fmt, lint, typecheck, and unit suite passed (`1429 passed`, `17170 steps`, `0 failed`)
- Architect review approved the final split-helper diff

## Deferred
- API module-loader/provider runtime-loader cleanup left for a later, narrower PR
- AgentRuntime/proxy/render/WebSocket cleanup intentionally out of scope
