### PR TITLE
Release veryfront 0.1.262

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.261",
+  "version": "0.1.262",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.261";
+export const VERSION = "0.1.262";


### PR DESCRIPTION
## Summary
- advance the stable release line to `0.1.262`
- publish the newly merged hosted message metadata helpers and shared hosted UI stream protocol support in the next stable release

## Testing
- version-only release-line update
- local pre-push checks passed during git push (format, lint, typecheck, full unit suite)
- upstream CI will validate the full release matrix