### PR TITLE
Share hosted UI chunk run-event preparation across runtimes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.261",
+  "version": "0.1.262",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/conversation-run-event-preparation.test.ts
+++ b/src/agent/conversation-run-event-preparation.test.ts
@@ -1,8 +1,10 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  prepareConversationRunChunkEvents,
   prepareConversationRunExternalEvents,
   prepareConversationRunStreamEvents,
+  toConversationRunStreamEvent,
 } from "./conversation-run-event-preparation.ts";
 
 describe("agent/conversation-run-event-preparation", () => {
@@ -23,5 +25,43 @@ describe("agent/conversation-run-event-preparation", () => {
 
     assertEquals(prepared.length > 1, true);
     assertEquals(prepared.every((event) => event.type === "TEXT_MESSAGE_CONTENT"), true);
+  });
+
+  it("maps hosted UI chunks to canonical stream events", () => {
+    assertEquals(
+      toConversationRunStreamEvent({
+        type: "start",
+        messageId: "msg-1",
+        messageMetadata: { modelId: "openai/gpt-5.4" },
+      }),
+      {
+        type: "start",
+        messageId: "msg-1",
+        messageMetadata: { modelId: "openai/gpt-5.4" },
+      },
+    );
+
+    assertEquals(
+      toConversationRunStreamEvent({
+        type: "finish",
+        finishReason: "stop",
+      }),
+      {
+        type: "finish",
+        finishReason: "stop",
+      },
+    );
+  });
+
+  it("encodes and normalizes hosted UI chunks in one step", () => {
+    const prepared = prepareConversationRunChunkEvents([
+      { type: "start", messageId: "msg-1" },
+      { type: "text-start", id: "msg-1" },
+      { type: "text-delta", id: "msg-1", delta: "hello" },
+      { type: "finish", finishReason: "stop" },
+    ]);
+
+    assertEquals(prepared[0]?.type, "TEXT_MESSAGE_START");
+    assertEquals(prepared.some((event) => event.type === "TEXT_MESSAGE_CONTENT"), true);
   });
 });

--- a/src/agent/conversation-run-event-preparation.ts
+++ b/src/agent/conversation-run-event-preparation.ts
@@ -1,4 +1,9 @@
-import { type ChatStreamEvent } from "../chat/protocol.ts";
+import {
+  type ChatFinishReason,
+  type ChatMessageMetadata,
+  type ChatStreamEvent,
+  type ChatUiMessageChunk,
+} from "../chat/protocol.ts";
 import {
   type ConversationRunEvent,
   ConversationRunEventEncoder,
@@ -6,11 +11,62 @@ import {
 } from "./conversation-run-events.ts";
 import { normalizeConversationRunEvents } from "./conversation-run-event-normalization.ts";
 
+function normalizeFinishReason(reason?: string): ChatFinishReason | undefined {
+  switch (reason) {
+    case "stop":
+    case "length":
+    case "tool-calls":
+    case "content-filter":
+    case "error":
+    case "other":
+      return reason;
+    default:
+      return undefined;
+  }
+}
+
+export function toConversationRunStreamEvent(
+  chunk: ChatUiMessageChunk<ChatMessageMetadata>,
+): ChatStreamEvent {
+  switch (chunk.type) {
+    case "start":
+      return {
+        type: "start",
+        ...(chunk.messageId !== undefined ? { messageId: chunk.messageId } : {}),
+        ...(chunk.messageMetadata !== undefined ? { messageMetadata: chunk.messageMetadata } : {}),
+      };
+    case "finish": {
+      const finishReason = normalizeFinishReason(chunk.finishReason);
+      return {
+        type: "finish",
+        ...(finishReason !== undefined ? { finishReason } : {}),
+      };
+    }
+    case "message-metadata":
+      return {
+        type: "message-metadata",
+        messageMetadata: chunk.messageMetadata,
+      };
+    default:
+      return chunk;
+  }
+}
+
 export function prepareConversationRunStreamEvents(
   events: ChatStreamEvent[],
   encoder = new ConversationRunEventEncoder(),
 ): ConversationRunEvent[] {
   return normalizeConversationRunEvents(encodeConversationRunEvents(events, encoder));
+}
+
+export function prepareConversationRunChunkEvents(
+  chunks: ChatUiMessageChunk<ChatMessageMetadata>[],
+  encoder = new ConversationRunEventEncoder(),
+): ConversationRunEvent[] {
+  return prepareConversationRunStreamEvents(
+    chunks.map((chunk) => toConversationRunStreamEvent(chunk)),
+    encoder,
+  );
 }
 
 export function prepareConversationRunExternalEvents(

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -271,8 +271,10 @@ export {
   normalizeEncodedConversationRunEvents,
 } from "./conversation-run-events.ts";
 export {
+  prepareConversationRunChunkEvents,
   prepareConversationRunExternalEvents,
   prepareConversationRunStreamEvents,
+  toConversationRunStreamEvent,
 } from "./conversation-run-event-preparation.ts";
 export {
   type ConversationRunMirror,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.261";
+export const VERSION = "0.1.262";


### PR DESCRIPTION
## Summary
- add a framework-owned helper that maps hosted UI chunks into canonical conversation-run stream events
- provide a one-step preparation helper for hosted UI chunks to durable conversation-run events
- export the new helper through the agent surface so hosts can delete local chunk-to-stream-event shims

## Testing
- deno test -A src/agent/conversation-run-event-preparation.test.ts src/agent/conversation-run-events.test.ts
- deno check src/agent/conversation-run-event-preparation.ts src/agent/index.ts
- local pre-push checks passed during git push (format, lint, typecheck, full unit suite)