### PR TITLE
Refactor provider runtime-loader transport helpers

### DIFF
--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -13,11 +13,21 @@ import {
   createGoogleRequestInit,
   createOpenAIRequestInit,
 } from "./runtime-loader/provider-request-init.ts";
+import type { ProviderKind } from "./runtime-loader/provider-http.ts";
+import { requestJson, requestStream } from "./runtime-loader/provider-http.ts";
+import { readRecord } from "./runtime-loader/provider-records.ts";
 import {
   TOOL_INPUT_PENDING_THRESHOLD_MS,
   withToolInputStatusTransitions,
 } from "./runtime-loader/tool-input-status.ts";
 
+export {
+  ProviderError,
+  ProviderOverloadedError,
+  ProviderQuotaError,
+  ProviderRateLimitError,
+  ProviderRequestError,
+} from "./runtime-loader/provider-http.ts";
 export { TOOL_INPUT_PENDING_THRESHOLD_MS, withToolInputStatusTransitions };
 
 export interface OpenAIRuntimeConfig {
@@ -401,14 +411,6 @@ function isNumberArray(value: unknown): value is number[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === "number");
 }
 
-function readRecord(value: unknown): Record<string, unknown> | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return undefined;
-  }
-
-  return Object.fromEntries(Object.entries(value));
-}
-
 function extractOpenAIEmbeddings(payload: unknown): number[][] {
   const record = readRecord(payload);
   const data = record?.data;
@@ -465,8 +467,6 @@ function extractGoogleUsageTokens(payload: unknown): number | undefined {
   return typeof promptTokenCount === "number" ? promptTokenCount : undefined;
 }
 
-type ProviderKind = "anthropic" | "openai" | "google";
-
 /**
  * Structured warning emitted when a provider runtime drops or rewrites a
  * caller-provided option. Mirrors the AI ecosystem convention (Vercel AI
@@ -501,210 +501,6 @@ function createWarningCollector(): WarningCollector {
       return list.slice();
     },
   };
-}
-
-/**
- * Base class for typed provider errors. The `retryable` flag is the
- * primary signal for callers (or a retry wrapper) to decide whether to
- * re-issue the request. `retryAfterMs` is set when the provider gave an
- * explicit delay hint (Retry-After header, Retry-Info trailer).
- */
-export class ProviderError extends Error {
-  readonly provider: ProviderKind;
-  readonly status: number;
-  readonly retryable: boolean;
-  readonly retryAfterMs?: number;
-
-  constructor(options: {
-    provider: ProviderKind;
-    status: number;
-    message: string;
-    retryable: boolean;
-    retryAfterMs?: number;
-  }) {
-    super(options.message);
-    this.name = new.target.name;
-    this.provider = options.provider;
-    this.status = options.status;
-    this.retryable = options.retryable;
-    if (options.retryAfterMs !== undefined) {
-      this.retryAfterMs = options.retryAfterMs;
-    }
-  }
-}
-
-/** Provider reports it is overloaded (Anthropic 529, OpenAI/Google 503). */
-export class ProviderOverloadedError extends ProviderError {}
-
-/** Provider is rate limiting this API key (OpenAI/Google 429 with Retry-After). */
-export class ProviderRateLimitError extends ProviderError {}
-
-/** Provider account quota is exhausted — non-retryable. */
-export class ProviderQuotaError extends ProviderError {}
-
-/** Non-retryable 4xx/5xx that doesn't fit another bucket. */
-export class ProviderRequestError extends ProviderError {}
-
-function parseRetryAfterMs(header: string | null): number | undefined {
-  if (!header) return undefined;
-  const asNumber = Number(header);
-  if (Number.isFinite(asNumber) && asNumber >= 0) {
-    return Math.round(asNumber * 1000);
-  }
-  // HTTP-date form (rare in practice for LLM providers).
-  const parsed = Date.parse(header);
-  if (!Number.isNaN(parsed)) {
-    return Math.max(0, parsed - Date.now());
-  }
-  return undefined;
-}
-
-/**
- * Inspect a non-2xx response and build the most specific ProviderError
- * subclass we can. Reads the response body as text (it's already dead
- * on the wire by this point). Body classification handles the cases
- * where HTTP status alone is ambiguous — notably OpenAI
- * `insufficient_quota` vs `rate_limit_exceeded` both arriving as 429.
- */
-async function buildProviderError(
-  provider: ProviderKind,
-  response: Response,
-): Promise<ProviderError> {
-  const rawBody = await response.text();
-  const message = rawBody.trim() || `${response.status} ${response.statusText}`.trim();
-  const status = response.status;
-  const retryAfterMs = parseRetryAfterMs(response.headers.get("retry-after"));
-
-  const parsedBody = (() => {
-    try {
-      return JSON.parse(rawBody) as Record<string, unknown>;
-    } catch {
-      return undefined;
-    }
-  })();
-  const errorRecord = readRecord(parsedBody?.error);
-  const errorCode = typeof errorRecord?.code === "string"
-    ? errorRecord.code
-    : typeof errorRecord?.type === "string"
-    ? errorRecord.type
-    : typeof errorRecord?.status === "string"
-    ? errorRecord.status
-    : undefined;
-
-  // Anthropic 529 = overloaded. Anthropic surfaces this with
-  // { error: { type: "overloaded_error" } } in the body.
-  if (provider === "anthropic" && status === 529) {
-    return new ProviderOverloadedError({
-      provider,
-      status,
-      message,
-      retryable: true,
-      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
-    });
-  }
-
-  // OpenAI / Google 503 = overloaded.
-  if ((provider === "openai" || provider === "google") && status === 503) {
-    return new ProviderOverloadedError({
-      provider,
-      status,
-      message,
-      retryable: true,
-      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
-    });
-  }
-
-  // OpenAI 429 splits based on the error code in the body:
-  //  - insufficient_quota → hard quota, non-retryable
-  //  - rate_limit_exceeded / tokens_per_min_exceeded → retry with Retry-After
-  if (provider === "openai" && status === 429) {
-    if (errorCode === "insufficient_quota") {
-      return new ProviderQuotaError({
-        provider,
-        status,
-        message,
-        retryable: false,
-      });
-    }
-    return new ProviderRateLimitError({
-      provider,
-      status,
-      message,
-      retryable: true,
-      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
-    });
-  }
-
-  // Google 429 RESOURCE_EXHAUSTED is almost always the daily free-tier
-  // quota — surface as a hard quota error so callers don't hot-loop on
-  // retries that can't possibly succeed until midnight UTC.
-  if (provider === "google" && status === 429) {
-    if (errorCode === "RESOURCE_EXHAUSTED") {
-      return new ProviderQuotaError({
-        provider,
-        status,
-        message,
-        retryable: false,
-      });
-    }
-    return new ProviderRateLimitError({
-      provider,
-      status,
-      message,
-      retryable: true,
-      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
-    });
-  }
-
-  return new ProviderRequestError({
-    provider,
-    status,
-    message,
-    retryable: false,
-  });
-}
-
-async function requestJson(options: {
-  url: string;
-  fetchImpl: typeof globalThis.fetch;
-  init: RequestInit;
-  providerLabel: string;
-  providerKind: ProviderKind;
-}): Promise<unknown> {
-  const response = await options.fetchImpl(options.url, options.init);
-  if (!response.ok) {
-    const err = await buildProviderError(options.providerKind, response);
-    err.message = `${options.providerLabel} request failed: ${err.message}`;
-    throw err;
-  }
-
-  return response.json();
-}
-
-async function requestStream(options: {
-  url: string;
-  fetchImpl: typeof globalThis.fetch;
-  init: RequestInit;
-  providerLabel: string;
-  providerKind: ProviderKind;
-}): Promise<ReadableStream<Uint8Array>> {
-  const response = await options.fetchImpl(options.url, options.init);
-  if (!response.ok) {
-    const err = await buildProviderError(options.providerKind, response);
-    err.message = `${options.providerLabel} request failed: ${err.message}`;
-    throw err;
-  }
-
-  if (!response.body) {
-    throw new ProviderRequestError({
-      provider: options.providerKind,
-      status: response.status,
-      message: `${options.providerLabel} request failed: stream body missing`,
-      retryable: false,
-    });
-  }
-
-  return response.body;
 }
 
 function stringifyJsonValue(value: unknown): string {

--- a/src/provider/runtime-loader/provider-http.ts
+++ b/src/provider/runtime-loader/provider-http.ts
@@ -1,0 +1,207 @@
+import { readRecord } from "./provider-records.ts";
+
+export type ProviderKind = "anthropic" | "openai" | "google";
+
+/**
+ * Base class for typed provider errors. The `retryable` flag is the
+ * primary signal for callers (or a retry wrapper) to decide whether to
+ * re-issue the request. `retryAfterMs` is set when the provider gave an
+ * explicit delay hint (Retry-After header, Retry-Info trailer).
+ */
+export class ProviderError extends Error {
+  readonly provider: ProviderKind;
+  readonly status: number;
+  readonly retryable: boolean;
+  readonly retryAfterMs?: number;
+
+  constructor(options: {
+    provider: ProviderKind;
+    status: number;
+    message: string;
+    retryable: boolean;
+    retryAfterMs?: number;
+  }) {
+    super(options.message);
+    this.name = new.target.name;
+    this.provider = options.provider;
+    this.status = options.status;
+    this.retryable = options.retryable;
+    if (options.retryAfterMs !== undefined) {
+      this.retryAfterMs = options.retryAfterMs;
+    }
+  }
+}
+
+/** Provider reports it is overloaded (Anthropic 529, OpenAI/Google 503). */
+export class ProviderOverloadedError extends ProviderError {}
+
+/** Provider is rate limiting this API key (OpenAI/Google 429 with Retry-After). */
+export class ProviderRateLimitError extends ProviderError {}
+
+/** Provider account quota is exhausted — non-retryable. */
+export class ProviderQuotaError extends ProviderError {}
+
+/** Non-retryable 4xx/5xx that doesn't fit another bucket. */
+export class ProviderRequestError extends ProviderError {}
+
+function parseRetryAfterMs(header: string | null): number | undefined {
+  if (!header) return undefined;
+  const asNumber = Number(header);
+  if (Number.isFinite(asNumber) && asNumber >= 0) {
+    return Math.round(asNumber * 1000);
+  }
+  // HTTP-date form (rare in practice for LLM providers).
+  const parsed = Date.parse(header);
+  if (!Number.isNaN(parsed)) {
+    return Math.max(0, parsed - Date.now());
+  }
+  return undefined;
+}
+
+/**
+ * Inspect a non-2xx response and build the most specific ProviderError
+ * subclass we can. Reads the response body as text (it's already dead
+ * on the wire by this point). Body classification handles the cases
+ * where HTTP status alone is ambiguous — notably OpenAI
+ * `insufficient_quota` vs `rate_limit_exceeded` both arriving as 429.
+ */
+async function buildProviderError(
+  provider: ProviderKind,
+  response: Response,
+): Promise<ProviderError> {
+  const rawBody = await response.text();
+  const message = rawBody.trim() || `${response.status} ${response.statusText}`.trim();
+  const status = response.status;
+  const retryAfterMs = parseRetryAfterMs(response.headers.get("retry-after"));
+
+  const parsedBody = (() => {
+    try {
+      return JSON.parse(rawBody) as Record<string, unknown>;
+    } catch {
+      return undefined;
+    }
+  })();
+  const errorRecord = readRecord(parsedBody?.error);
+  const errorCode = typeof errorRecord?.code === "string"
+    ? errorRecord.code
+    : typeof errorRecord?.type === "string"
+    ? errorRecord.type
+    : typeof errorRecord?.status === "string"
+    ? errorRecord.status
+    : undefined;
+
+  // Anthropic 529 = overloaded. Anthropic surfaces this with
+  // { error: { type: "overloaded_error" } } in the body.
+  if (provider === "anthropic" && status === 529) {
+    return new ProviderOverloadedError({
+      provider,
+      status,
+      message,
+      retryable: true,
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    });
+  }
+
+  // OpenAI / Google 503 = overloaded.
+  if ((provider === "openai" || provider === "google") && status === 503) {
+    return new ProviderOverloadedError({
+      provider,
+      status,
+      message,
+      retryable: true,
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    });
+  }
+
+  // OpenAI 429 splits based on the error code in the body:
+  //  - insufficient_quota → hard quota, non-retryable
+  //  - rate_limit_exceeded / tokens_per_min_exceeded → retry with Retry-After
+  if (provider === "openai" && status === 429) {
+    if (errorCode === "insufficient_quota") {
+      return new ProviderQuotaError({
+        provider,
+        status,
+        message,
+        retryable: false,
+      });
+    }
+    return new ProviderRateLimitError({
+      provider,
+      status,
+      message,
+      retryable: true,
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    });
+  }
+
+  // Google 429 RESOURCE_EXHAUSTED is almost always the daily free-tier
+  // quota — surface as a hard quota error so callers don't hot-loop on
+  // retries that can't possibly succeed until midnight UTC.
+  if (provider === "google" && status === 429) {
+    if (errorCode === "RESOURCE_EXHAUSTED") {
+      return new ProviderQuotaError({
+        provider,
+        status,
+        message,
+        retryable: false,
+      });
+    }
+    return new ProviderRateLimitError({
+      provider,
+      status,
+      message,
+      retryable: true,
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    });
+  }
+
+  return new ProviderRequestError({
+    provider,
+    status,
+    message,
+    retryable: false,
+  });
+}
+
+export async function requestJson(options: {
+  url: string;
+  fetchImpl: typeof globalThis.fetch;
+  init: RequestInit;
+  providerLabel: string;
+  providerKind: ProviderKind;
+}): Promise<unknown> {
+  const response = await options.fetchImpl(options.url, options.init);
+  if (!response.ok) {
+    const err = await buildProviderError(options.providerKind, response);
+    err.message = `${options.providerLabel} request failed: ${err.message}`;
+    throw err;
+  }
+
+  return response.json();
+}
+
+export async function requestStream(options: {
+  url: string;
+  fetchImpl: typeof globalThis.fetch;
+  init: RequestInit;
+  providerLabel: string;
+  providerKind: ProviderKind;
+}): Promise<ReadableStream<Uint8Array>> {
+  const response = await options.fetchImpl(options.url, options.init);
+  if (!response.ok) {
+    const err = await buildProviderError(options.providerKind, response);
+    err.message = `${options.providerLabel} request failed: ${err.message}`;
+    throw err;
+  }
+
+  if (!response.body) {
+    throw new ProviderRequestError({
+      provider: options.providerKind,
+      status: response.status,
+      message: `${options.providerLabel} request failed: stream body missing`,
+      retryable: false,
+    });
+  }
+
+  return response.body;
+}

--- a/src/provider/runtime-loader/provider-records.ts
+++ b/src/provider/runtime-loader/provider-records.ts
@@ -1,0 +1,7 @@
+export function readRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  return Object.fromEntries(Object.entries(value));
+}


### PR DESCRIPTION
## Summary
- move provider runtime-loader transport/error classification into `provider-http.ts`
- move shared unknown-to-record conversion into `provider-records.ts`
- keep `runtime-loader.ts` focused on request shaping, response parsing, and runtime factory exports while preserving the existing public error exports

## Verification
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/provider/runtime-loader.test.ts src/provider/runtime-loader/provider-request-init.test.ts`
- `deno fmt --check src/provider/runtime-loader.ts src/provider/runtime-loader/provider-http.ts src/provider/runtime-loader/provider-records.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/provider/runtime-loader.ts src/provider/runtime-loader/provider-http.ts src/provider/runtime-loader/provider-records.ts`
- `deno check src/provider/runtime-loader.ts src/provider/runtime-loader/provider-http.ts src/provider/runtime-loader/provider-records.ts`
- `deno task typecheck`
- Pre-push hook: fmt, lint, typecheck, and full unit suite (`1431 passed (17180 steps) | 0 failed`)

## Deferred
- per-provider request/response builder splits remain out of scope for this PR
- no AgentRuntime/proxy/render/WebSocket refactors attempted here
