### PR TITLE
Refactor provider embedding response helpers

### DIFF
--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -9,6 +9,12 @@ import {
   getOpenAIResponsesUrl,
 } from "./runtime-loader/provider-endpoints.ts";
 import {
+  extractGoogleEmbedding,
+  extractGoogleUsageTokens,
+  extractOpenAIEmbeddings,
+  extractOpenAIUsageTokens,
+} from "./runtime-loader/provider-embedding-responses.ts";
+import {
   createAnthropicRequestInit,
   createGoogleRequestInit,
   createOpenAIRequestInit,
@@ -406,66 +412,6 @@ type GoogleCompatibleRequest = {
   generationConfig?: Record<string, unknown>;
   [key: string]: unknown;
 };
-
-function isNumberArray(value: unknown): value is number[] {
-  return Array.isArray(value) && value.every((entry) => typeof entry === "number");
-}
-
-function extractOpenAIEmbeddings(payload: unknown): number[][] {
-  const record = readRecord(payload);
-  const data = record?.data;
-  if (!Array.isArray(data)) {
-    throw new Error("Invalid OpenAI embedding response: data array missing");
-  }
-
-  const embeddings: number[][] = [];
-
-  for (const item of data) {
-    const itemRecord = readRecord(item);
-    const embedding = itemRecord?.embedding;
-    if (!isNumberArray(embedding)) {
-      throw new Error("Invalid OpenAI embedding response: embedding vector missing");
-    }
-    embeddings.push(embedding);
-  }
-
-  return embeddings;
-}
-
-function extractOpenAIUsageTokens(payload: unknown): number | undefined {
-  const record = readRecord(payload);
-  const usage = readRecord(record?.usage);
-  const totalTokens = usage?.total_tokens;
-  return typeof totalTokens === "number" ? totalTokens : undefined;
-}
-
-function extractGoogleEmbedding(payload: unknown): number[] {
-  const record = readRecord(payload);
-  const embeddings = record?.embeddings;
-
-  if (Array.isArray(embeddings) && embeddings.length > 0) {
-    const firstEmbedding = readRecord(embeddings[0]);
-    const values = firstEmbedding?.values;
-    if (isNumberArray(values)) {
-      return values;
-    }
-  }
-
-  const embedding = readRecord(record?.embedding);
-  const values = embedding?.values;
-  if (isNumberArray(values)) {
-    return values;
-  }
-
-  throw new Error("Invalid Google embedding response: embedding vector missing");
-}
-
-function extractGoogleUsageTokens(payload: unknown): number | undefined {
-  const record = readRecord(payload);
-  const usageMetadata = readRecord(record?.usageMetadata);
-  const promptTokenCount = usageMetadata?.promptTokenCount;
-  return typeof promptTokenCount === "number" ? promptTokenCount : undefined;
-}
 
 /**
  * Structured warning emitted when a provider runtime drops or rewrites a

--- a/src/provider/runtime-loader/provider-embedding-responses.ts
+++ b/src/provider/runtime-loader/provider-embedding-responses.ts
@@ -1,0 +1,61 @@
+import { readRecord } from "./provider-records.ts";
+
+function isNumberArray(value: unknown): value is number[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "number");
+}
+
+export function extractOpenAIEmbeddings(payload: unknown): number[][] {
+  const record = readRecord(payload);
+  const data = record?.data;
+  if (!Array.isArray(data)) {
+    throw new Error("Invalid OpenAI embedding response: data array missing");
+  }
+
+  const embeddings: number[][] = [];
+
+  for (const item of data) {
+    const itemRecord = readRecord(item);
+    const embedding = itemRecord?.embedding;
+    if (!isNumberArray(embedding)) {
+      throw new Error("Invalid OpenAI embedding response: embedding vector missing");
+    }
+    embeddings.push(embedding);
+  }
+
+  return embeddings;
+}
+
+export function extractOpenAIUsageTokens(payload: unknown): number | undefined {
+  const record = readRecord(payload);
+  const usage = readRecord(record?.usage);
+  const totalTokens = usage?.total_tokens;
+  return typeof totalTokens === "number" ? totalTokens : undefined;
+}
+
+export function extractGoogleEmbedding(payload: unknown): number[] {
+  const record = readRecord(payload);
+  const embeddings = record?.embeddings;
+
+  if (Array.isArray(embeddings) && embeddings.length > 0) {
+    const firstEmbedding = readRecord(embeddings[0]);
+    const values = firstEmbedding?.values;
+    if (isNumberArray(values)) {
+      return values;
+    }
+  }
+
+  const embedding = readRecord(record?.embedding);
+  const values = embedding?.values;
+  if (isNumberArray(values)) {
+    return values;
+  }
+
+  throw new Error("Invalid Google embedding response: embedding vector missing");
+}
+
+export function extractGoogleUsageTokens(payload: unknown): number | undefined {
+  const record = readRecord(payload);
+  const usageMetadata = readRecord(record?.usageMetadata);
+  const promptTokenCount = usageMetadata?.promptTokenCount;
+  return typeof promptTokenCount === "number" ? promptTokenCount : undefined;
+}


### PR DESCRIPTION
## Summary
- move OpenAI/Google embedding response parsing helpers into `provider-embedding-responses.ts`
- keep embedding runtime factory behavior unchanged while shrinking `runtime-loader.ts`
- preserve existing embedding response validation errors and usage-token extraction

## Verification
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/provider/runtime-loader.test.ts src/provider/runtime-loader/provider-request-init.test.ts`
- `deno fmt --check src/provider/runtime-loader.ts src/provider/runtime-loader/provider-embedding-responses.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/provider/runtime-loader.ts src/provider/runtime-loader/provider-embedding-responses.ts`
- `deno check src/provider/runtime-loader.ts src/provider/runtime-loader/provider-embedding-responses.ts`
- `deno task typecheck`
- Pre-push hook: fmt, lint, typecheck, and full unit suite (`1431 passed (17182 steps) | 0 failed`)

## Deferred
- moving embedding runtime factories is left out to keep this PR helper-extraction only
- larger per-provider runtime splits remain separate, higher-risk slices
