### PR TITLE
Refactor provider SSE stream parsing

### DIFF
--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -19,6 +19,7 @@ import {
   createGoogleRequestInit,
   createOpenAIRequestInit,
 } from "./runtime-loader/provider-request-init.ts";
+import { parseSseChunk } from "./runtime-loader/provider-sse.ts";
 import type { ProviderKind } from "./runtime-loader/provider-http.ts";
 import { requestJson, requestStream } from "./runtime-loader/provider-http.ts";
 import { readRecord } from "./runtime-loader/provider-records.ts";
@@ -1286,36 +1287,6 @@ function buildAnthropicGenerateResult(payload: unknown): {
     finishReason: normalizeAnthropicFinishReason(record?.stop_reason),
     usage: extractAnthropicUsage(payload),
   };
-}
-
-function parseSseChunk(chunk: string): {
-  events: Array<unknown | "[DONE]">;
-  remainder: string;
-} {
-  const blocks = chunk.split(/\r?\n\r?\n/);
-  const remainder = blocks.pop() ?? "";
-  const events = blocks.flatMap((block) => {
-    const dataLines = block.split(/\r?\n/)
-      .filter((line) => line.startsWith("data:"))
-      .map((line) => line.slice(5).trimStart());
-
-    if (!dataLines.length) {
-      return [];
-    }
-
-    const payload = dataLines.join("\n").trim();
-    if (payload === "[DONE]") {
-      return ["[DONE]" as const];
-    }
-
-    try {
-      return [JSON.parse(payload) as unknown];
-    } catch {
-      return [];
-    }
-  });
-
-  return { events, remainder };
 }
 
 async function* streamAnthropicCompatibleParts(

--- a/src/provider/runtime-loader/provider-sse.ts
+++ b/src/provider/runtime-loader/provider-sse.ts
@@ -1,0 +1,29 @@
+export function parseSseChunk(chunk: string): {
+  events: Array<unknown | "[DONE]">;
+  remainder: string;
+} {
+  const blocks = chunk.split(/\r?\n\r?\n/);
+  const remainder = blocks.pop() ?? "";
+  const events = blocks.flatMap((block) => {
+    const dataLines = block.split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trimStart());
+
+    if (!dataLines.length) {
+      return [];
+    }
+
+    const payload = dataLines.join("\n").trim();
+    if (payload === "[DONE]") {
+      return ["[DONE]" as const];
+    }
+
+    try {
+      return [JSON.parse(payload) as unknown];
+    } catch {
+      return [];
+    }
+  });
+
+  return { events, remainder };
+}


### PR DESCRIPTION
## Summary
- move shared provider SSE data-block parsing into `provider-sse.ts`
- keep provider stream adapters and event state machines unchanged
- preserve CRLF tolerance, `[DONE]` handling, and malformed JSON drop behavior

## Verification
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/provider/runtime-loader.test.ts src/provider/runtime-loader/provider-request-init.test.ts`
- `deno fmt --check src/provider/runtime-loader.ts src/provider/runtime-loader/provider-sse.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/provider/runtime-loader.ts src/provider/runtime-loader/provider-sse.ts`
- `deno check src/provider/runtime-loader.ts src/provider/runtime-loader/provider-sse.ts`
- `deno task typecheck`
- Pre-push hook: fmt, lint, typecheck, and full unit suite (`1431 passed (17182 steps) | 0 failed | 0 ignored (2 steps)`)

## Deferred
- full provider stream adapter splits remain out of scope
- no provider-specific stream state machine changes attempted
