### PR TITLE
Refactor provider finish reason normalization

### DIFF
--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -15,6 +15,12 @@ import {
   extractOpenAIUsageTokens,
 } from "./runtime-loader/provider-embedding-responses.ts";
 import {
+  normalizeAnthropicFinishReason,
+  normalizeGoogleFinishReason,
+  normalizeOpenAIFinishReason,
+  normalizeOpenAIResponsesFinishReason,
+} from "./runtime-loader/provider-finish-reasons.ts";
+import {
   createAnthropicRequestInit,
   createGoogleRequestInit,
   createOpenAIRequestInit,
@@ -577,26 +583,6 @@ function readProviderOptions(
   }
 
   return merged;
-}
-
-function normalizeAnthropicFinishReason(
-  raw: unknown,
-): string | { unified: string; raw: string } | null {
-  if (typeof raw !== "string") {
-    return null;
-  }
-
-  switch (raw) {
-    case "tool_use":
-      return { unified: "tool-calls", raw };
-    case "end_turn":
-    case "stop_sequence":
-      return { unified: "stop", raw };
-    case "max_tokens":
-      return { unified: "length", raw };
-    default:
-      return raw;
-  }
 }
 
 function normalizeAnthropicToolChoice(toolChoice: unknown): unknown {
@@ -1479,24 +1465,6 @@ async function* streamAnthropicCompatibleParts(
   };
 }
 
-function normalizeOpenAIFinishReason(
-  raw: unknown,
-): string | { unified: string; raw: string } | null {
-  if (typeof raw !== "string") {
-    return null;
-  }
-
-  if (raw === "tool_calls") {
-    return { unified: "tool-calls", raw };
-  }
-
-  if (raw === "content_filter") {
-    return { unified: "content-filter", raw };
-  }
-
-  return raw;
-}
-
 function extractOpenAIContentText(content: unknown): string {
   if (typeof content === "string") {
     return content;
@@ -1717,26 +1685,6 @@ function buildOpenAIChatRequest(
 
   Object.assign(body, providerOpts);
   return body;
-}
-
-function normalizeGoogleFinishReason(
-  raw: unknown,
-): string | { unified: string; raw: string } | null {
-  if (typeof raw !== "string") {
-    return null;
-  }
-
-  switch (raw) {
-    case "STOP":
-      return { unified: "stop", raw };
-    case "MAX_TOKENS":
-      return { unified: "length", raw };
-    case "SAFETY":
-    case "RECITATION":
-      return { unified: "content-filter", raw };
-    default:
-      return raw.toLowerCase();
-  }
 }
 
 function toGoogleContents(
@@ -2762,24 +2710,6 @@ function buildOpenAIResponsesRequest(
 
   Object.assign(body, readProviderOptions(options.providerOptions, "openai", providerName));
   return body;
-}
-
-function normalizeOpenAIResponsesFinishReason(
-  raw: unknown,
-): string | { unified: string; raw: string } | null {
-  if (typeof raw !== "string") return null;
-  switch (raw) {
-    case "completed":
-      return { unified: "stop", raw };
-    case "incomplete":
-      return { unified: "length", raw };
-    case "failed":
-      return { unified: "error", raw };
-    case "in_progress":
-      return null;
-    default:
-      return raw;
-  }
 }
 
 type OpenAIResponsesContentPart =

--- a/src/provider/runtime-loader/provider-finish-reasons.ts
+++ b/src/provider/runtime-loader/provider-finish-reasons.ts
@@ -1,0 +1,69 @@
+export type NormalizedFinishReason = string | { unified: string; raw: string } | null;
+
+export function normalizeAnthropicFinishReason(raw: unknown): NormalizedFinishReason {
+  if (typeof raw !== "string") {
+    return null;
+  }
+
+  switch (raw) {
+    case "tool_use":
+      return { unified: "tool-calls", raw };
+    case "end_turn":
+    case "stop_sequence":
+      return { unified: "stop", raw };
+    case "max_tokens":
+      return { unified: "length", raw };
+    default:
+      return raw;
+  }
+}
+
+export function normalizeGoogleFinishReason(raw: unknown): NormalizedFinishReason {
+  if (typeof raw !== "string") {
+    return null;
+  }
+
+  switch (raw) {
+    case "STOP":
+      return { unified: "stop", raw };
+    case "MAX_TOKENS":
+      return { unified: "length", raw };
+    case "SAFETY":
+    case "RECITATION":
+      return { unified: "content-filter", raw };
+    default:
+      return raw.toLowerCase();
+  }
+}
+
+export function normalizeOpenAIFinishReason(raw: unknown): NormalizedFinishReason {
+  if (typeof raw !== "string") {
+    return null;
+  }
+
+  if (raw === "tool_calls") {
+    return { unified: "tool-calls", raw };
+  }
+
+  if (raw === "content_filter") {
+    return { unified: "content-filter", raw };
+  }
+
+  return raw;
+}
+
+export function normalizeOpenAIResponsesFinishReason(raw: unknown): NormalizedFinishReason {
+  if (typeof raw !== "string") return null;
+  switch (raw) {
+    case "completed":
+      return { unified: "stop", raw };
+    case "incomplete":
+      return { unified: "length", raw };
+    case "failed":
+      return { unified: "error", raw };
+    case "in_progress":
+      return null;
+    default:
+      return raw;
+  }
+}


### PR DESCRIPTION
## Summary
- move provider-specific finish-reason normalization into `provider-finish-reasons.ts`
- preserve Anthropic, OpenAI Chat Completions, OpenAI Responses, and Google raw-to-unified mappings
- leave stream adapters and request/response builders unchanged

## Verification
- `VF_DISABLE_LRU_INTERVAL=1 deno test --no-check --allow-all src/provider/runtime-loader.test.ts src/provider/runtime-loader/provider-request-init.test.ts`
- `deno fmt --check src/provider/runtime-loader.ts src/provider/runtime-loader/provider-finish-reasons.ts`
- `DENO_NO_PACKAGE_JSON=1 deno lint src/provider/runtime-loader.ts src/provider/runtime-loader/provider-finish-reasons.ts`
- `deno check src/provider/runtime-loader.ts src/provider/runtime-loader/provider-finish-reasons.ts`
- `deno task typecheck`
- Pre-push hook: fmt, lint, typecheck, and full unit suite (`1431 passed (17182 steps) | 0 failed | 0 ignored (2 steps)`)

## Notes
- First pre-push attempt hit an unrelated timing-sensitive fs fallback test (`202ms` vs `<200ms`); retry passed without code changes.
- No provider finish-reason semantics changed.
