### PR TITLE
Share hosted UI chunk mapping helpers across runtimes

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -397,6 +397,11 @@ export {
   normalizeChatUiMessageStream,
 } from "../chat/chat-ui-message-helpers.ts";
 export {
+  type HostedStreamPartForUiChunkMapping,
+  type HostedUiChunkMappingOptions,
+  mapHostedStreamPartToChatUiChunks,
+} from "../chat/hosted-ui-chunk-mapping.ts";
+export {
   expandAllowedRemoteToolNames,
   getProviderNativeToolNames,
   type ProviderNativeToolInventoryOptions,

--- a/src/chat/hosted-ui-chunk-mapping.test.ts
+++ b/src/chat/hosted-ui-chunk-mapping.test.ts
@@ -1,0 +1,54 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { mapHostedStreamPartToChatUiChunks } from "./hosted-ui-chunk-mapping.ts";
+
+describe("chat/hosted-ui-chunk-mapping", () => {
+  it("maps hosted stream parts into chat UI chunks", () => {
+    assertEquals(mapHostedStreamPartToChatUiChunks({ type: "start" }, { messageId: "msg-1" }), [
+      { type: "start", messageId: "msg-1" },
+    ]);
+
+    assertEquals(
+      mapHostedStreamPartToChatUiChunks({
+        type: "source",
+        sourceType: "url",
+        id: "src-1",
+        url: "https://example.com",
+        title: "Example",
+      }),
+      [{ type: "source-url", sourceId: "src-1", url: "https://example.com", title: "Example" }],
+    );
+
+    assertEquals(
+      mapHostedStreamPartToChatUiChunks({
+        type: "tool-input-delta",
+        id: "tool-1",
+        delta: '{"q":"voice"}',
+      }),
+      [{ type: "tool-input-delta", toolCallId: "tool-1", inputTextDelta: '{"q":"voice"}' }],
+    );
+
+    assertEquals(
+      mapHostedStreamPartToChatUiChunks({
+        type: "tool-error",
+        toolCallId: "tool-1",
+        toolName: "web_search",
+        input: { q: "voice ai" },
+        error: new Error("provider timeout"),
+      }),
+      [
+        { type: "tool-input-start", toolCallId: "tool-1", toolName: "web_search" },
+        {
+          type: "tool-input-error",
+          toolCallId: "tool-1",
+          toolName: "web_search",
+          input: { q: "voice ai" },
+          errorText: "provider timeout",
+        },
+      ],
+    );
+
+    assertEquals(mapHostedStreamPartToChatUiChunks({ type: "abort" }), [{ type: "abort" }]);
+    assertEquals(mapHostedStreamPartToChatUiChunks({ type: "finish" }), [{ type: "finish" }]);
+  });
+});

--- a/src/chat/hosted-ui-chunk-mapping.ts
+++ b/src/chat/hosted-ui-chunk-mapping.ts
@@ -1,0 +1,303 @@
+import type { ChatMessageMetadata, ChatUiMessageChunk } from "./protocol.ts";
+
+export type HostedUiChunkMappingOptions = {
+  messageId?: string | null;
+  reasoningMessageId?: string | null;
+  sendReasoning?: boolean;
+  sendSources?: boolean;
+  onError?: (error: unknown) => string;
+};
+
+export type HostedStreamSourcePart =
+  | {
+    type: "source";
+    id: string;
+    sourceType: "url";
+    url: string;
+    title?: string;
+  }
+  | {
+    type: "source";
+    id: string;
+    sourceType: "document";
+    mediaType: string;
+    title?: string;
+    filename?: string;
+  };
+
+export type HostedStreamPartForUiChunkMapping =
+  | {
+    type: "start";
+  }
+  | {
+    type: "start-step";
+  }
+  | {
+    type: "finish-step";
+  }
+  | {
+    type: "finish";
+    finishReason?: string;
+  }
+  | {
+    type: "abort";
+  }
+  | {
+    type: "reasoning-start";
+    id: string;
+  }
+  | {
+    type: "reasoning-delta";
+    id: string;
+    text: string;
+  }
+  | {
+    type: "reasoning-end";
+    id: string;
+  }
+  | {
+    type: "text-start";
+    id: string;
+  }
+  | {
+    type: "text-delta";
+    id: string;
+    text: string;
+  }
+  | {
+    type: "text-end";
+    id: string;
+  }
+  | HostedStreamSourcePart
+  | {
+    type: "file";
+    file: {
+      mediaType: string;
+      base64: string;
+    };
+  }
+  | {
+    type: "tool-input-start";
+    id: string;
+    toolName: string;
+  }
+  | {
+    type: "tool-input-delta";
+    id: string;
+    delta: string;
+  }
+  | {
+    type: "tool-call";
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+    invalid: true;
+    error: unknown;
+  }
+  | {
+    type: "tool-call";
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+    invalid?: false;
+  }
+  | {
+    type: "tool-approval-request";
+    approvalId: string;
+    toolCall: {
+      toolCallId: string;
+    };
+  }
+  | {
+    type: "tool-result";
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+    output: unknown;
+  }
+  | {
+    type: "tool-error";
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+    error: unknown;
+  }
+  | {
+    type: "tool-output-denied";
+    toolCallId: string;
+  }
+  | {
+    type: "error";
+    error: unknown;
+  }
+  | {
+    type: "tool-input-end";
+  }
+  | {
+    type: "raw";
+  };
+
+function defaultOnError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function mapHostedStreamSourceToUiChunks(
+  part: HostedStreamSourcePart,
+  sendSources: boolean,
+): ChatUiMessageChunk<ChatMessageMetadata>[] {
+  if (!sendSources) {
+    return [];
+  }
+
+  if (part.sourceType === "url") {
+    return [{
+      type: "source-url",
+      sourceId: part.id,
+      url: part.url,
+      ...(part.title ? { title: part.title } : {}),
+    }];
+  }
+
+  return [
+    {
+      type: "source-document",
+      sourceId: part.id,
+      mediaType: part.mediaType,
+      title: part.title ?? part.filename ?? part.id,
+      ...(part.filename ? { filename: part.filename } : {}),
+    },
+  ];
+}
+
+function mapToolCallPartToUiChunks(
+  part: Extract<HostedStreamPartForUiChunkMapping, { type: "tool-call" }>,
+  onError: (error: unknown) => string,
+): ChatUiMessageChunk<ChatMessageMetadata>[] {
+  if (part.invalid) {
+    return [{
+      type: "tool-input-error",
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      input: part.input,
+      errorText: onError(part.error),
+    }];
+  }
+
+  return [{
+    type: "tool-input-available",
+    toolCallId: part.toolCallId,
+    toolName: part.toolName,
+    input: part.input,
+  }];
+}
+
+function mapToolErrorPartToUiChunks(
+  part: Extract<HostedStreamPartForUiChunkMapping, { type: "tool-error" }>,
+  onError: (error: unknown) => string,
+): ChatUiMessageChunk<ChatMessageMetadata>[] {
+  return [
+    {
+      type: "tool-input-start",
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+    },
+    {
+      type: "tool-input-error",
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      input: part.input,
+      errorText: onError(part.error),
+    },
+  ];
+}
+
+export function mapHostedStreamPartToChatUiChunks(
+  part: HostedStreamPartForUiChunkMapping,
+  options: HostedUiChunkMappingOptions = {},
+): ChatUiMessageChunk<ChatMessageMetadata>[] {
+  const onError = options.onError ?? defaultOnError;
+  const sendReasoning = options.sendReasoning ?? true;
+  const sendSources = options.sendSources ?? true;
+
+  switch (part.type) {
+    case "start":
+      return [{ type: "start", ...(options.messageId ? { messageId: options.messageId } : {}) }];
+
+    case "start-step":
+      return [{ type: "start-step" }];
+
+    case "finish-step":
+      return [{ type: "finish-step" }];
+
+    case "finish":
+      return [{
+        type: "finish",
+        ...(part.finishReason ? { finishReason: part.finishReason } : {}),
+      }];
+
+    case "abort":
+      return [{ type: "abort" }];
+
+    case "reasoning-start":
+      return [{ type: "reasoning-start", id: options.reasoningMessageId ?? part.id }];
+
+    case "reasoning-delta":
+      return sendReasoning
+        ? [{ type: "reasoning-delta", id: options.reasoningMessageId ?? part.id, delta: part.text }]
+        : [];
+
+    case "reasoning-end":
+      return [{ type: "reasoning-end", id: options.reasoningMessageId ?? part.id }];
+
+    case "text-start":
+      return [{ type: "text-start", id: options.messageId ?? part.id }];
+
+    case "text-delta":
+      return [{ type: "text-delta", id: options.messageId ?? part.id, delta: part.text }];
+
+    case "text-end":
+      return [{ type: "text-end", id: options.messageId ?? part.id }];
+
+    case "source":
+      return mapHostedStreamSourceToUiChunks(part, sendSources);
+
+    case "file":
+      return [{
+        type: "file",
+        mediaType: part.file.mediaType,
+        url: `data:${part.file.mediaType};base64,${part.file.base64}`,
+      }];
+
+    case "tool-input-start":
+      return [{ type: "tool-input-start", toolCallId: part.id, toolName: part.toolName }];
+
+    case "tool-input-delta":
+      return [{ type: "tool-input-delta", toolCallId: part.id, inputTextDelta: part.delta }];
+
+    case "tool-call":
+      return mapToolCallPartToUiChunks(part, onError);
+
+    case "tool-approval-request":
+      return [{
+        type: "tool-approval-request",
+        approvalId: part.approvalId,
+        toolCallId: part.toolCall.toolCallId,
+      }];
+
+    case "tool-result":
+      return [{ type: "tool-output-available", toolCallId: part.toolCallId, output: part.output }];
+
+    case "tool-error":
+      return mapToolErrorPartToUiChunks(part, onError);
+
+    case "tool-output-denied":
+      return [{ type: "tool-output-denied", toolCallId: part.toolCallId }];
+
+    case "error":
+      return [{ type: "error", errorText: onError(part.error) }];
+
+    case "tool-input-end":
+    case "raw":
+      return [];
+  }
+}

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -64,6 +64,7 @@ const expectedRuntimeExports = [
   "downloadMarkdown",
   "exportAsMarkdown",
   "extractChatMessageMetadata",
+  "mapHostedStreamPartToChatUiChunks",
   "extractSourcesFromParts",
   "getTextContent",
   "groupPartsInOrder",

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -234,6 +234,11 @@ export {
   normalizeChatUiMessageChunk,
   normalizeChatUiMessageStream,
 } from "./chat-ui-message-helpers.ts";
+export {
+  type HostedStreamPartForUiChunkMapping,
+  type HostedUiChunkMappingOptions,
+  mapHostedStreamPartToChatUiChunks,
+} from "./hosted-ui-chunk-mapping.ts";
 
 export {
   useCompletion,


### PR DESCRIPTION
## Summary
- add shared hosted stream-part to `ChatUiMessageChunk` mapping helpers in the chat surface
- export the helper through both `veryfront/chat` and `veryfront/agent`
- lock the shared runtime export surface with a focused helper test and barrel snapshot update

## Verification
- deno fmt --check src/chat/hosted-ui-chunk-mapping.ts src/chat/hosted-ui-chunk-mapping.test.ts src/chat/index.ts src/chat/index.test.ts src/agent/index.ts
- deno lint src/chat/hosted-ui-chunk-mapping.ts src/chat/hosted-ui-chunk-mapping.test.ts src/chat/index.ts src/chat/index.test.ts src/agent/index.ts
- deno test -A src/chat/hosted-ui-chunk-mapping.test.ts src/chat/index.test.ts
- deno check src/chat/hosted-ui-chunk-mapping.ts src/chat/index.ts src/agent/index.ts