### PR TITLE
Release veryfront 0.1.264

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.263",
+  "version": "0.1.264",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.263";
+export const VERSION = "0.1.264";


### PR DESCRIPTION
## Summary
- advance the stable release line from `0.1.263` to `0.1.264`
- publish the newly merged hosted UI chunk mapping helpers and provider runtime refactors
- unblock downstream adoption in runtime hosts

## Verification
- release-line version bump only
- prior merged PR CI on main covered the shipped framework changes