### PR TITLE
Share hosted child mirror helpers across runtimes

### DIFF
--- a/src/agent/hosted-child-mirror.test.ts
+++ b/src/agent/hosted-child-mirror.test.ts
@@ -1,0 +1,88 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  appendHostedChildMirrorChunk,
+  closeHostedChildReasoningSegment,
+  closeHostedChildTextSegment,
+  isAlreadyMirroredHostedChunk,
+  toMirroredHostedStreamPart,
+} from "./hosted-child-mirror.ts";
+
+describe("agent/hosted-child-mirror", () => {
+  it("tracks mirrored chunk duplicates by part type", () => {
+    assertEquals(isAlreadyMirroredHostedChunk("reasoning-delta", "reasoning-delta"), true);
+    assertEquals(isAlreadyMirroredHostedChunk("tool-call", "tool-input-start"), true);
+    assertEquals(isAlreadyMirroredHostedChunk("tool-result", "tool-output-available"), true);
+    assertEquals(isAlreadyMirroredHostedChunk("error", "text-delta"), false);
+  });
+
+  it("maps hosted mirror parts onto hosted stream parts", () => {
+    assertEquals(
+      toMirroredHostedStreamPart({ type: "text-delta", text: "hello" }, {
+        messageId: "msg-1",
+        reasoningMessageId: "reason-1",
+      }),
+      {
+        type: "text-delta",
+        id: "msg-1",
+        text: "hello",
+      },
+    );
+
+    assertEquals(
+      toMirroredHostedStreamPart(
+        { type: "tool-input-start", toolCallId: "tc-1", toolName: "bash" },
+        {
+          messageId: "msg-1",
+          reasoningMessageId: "reason-1",
+        },
+      ),
+      {
+        type: "tool-input-start",
+        id: "tc-1",
+        toolName: "bash",
+      },
+    );
+  });
+
+  it("appends hosted child chunks when a mirror exists", async () => {
+    const handled: unknown[] = [];
+    const result = await appendHostedChildMirrorChunk({
+      mirror: {
+        handleChunk: (chunk) => {
+          handled.push(chunk);
+        },
+      },
+      chunk: { type: "text-delta", id: "msg-1", delta: "hi" },
+    });
+    assertEquals(result, true);
+    assertEquals(handled, [{ type: "text-delta", id: "msg-1", delta: "hi" }]);
+  });
+
+  it("closes reasoning and text segments when active", async () => {
+    const handled: unknown[] = [];
+    const state = { reasoningStarted: true, textStarted: true };
+    const mirror = {
+      handleChunk: (chunk: unknown) => {
+        handled.push(chunk);
+      },
+    };
+
+    await closeHostedChildReasoningSegment({
+      mirror,
+      reasoningMessageId: "r-1",
+      state,
+    });
+    await closeHostedChildTextSegment({
+      mirror,
+      messageId: "msg-1",
+      state,
+    });
+
+    assertEquals(handled, [
+      { type: "reasoning-end", id: "r-1" },
+      { type: "text-end", id: "msg-1" },
+    ]);
+    assertEquals(state, { reasoningStarted: false, textStarted: false });
+  });
+});

--- a/src/agent/hosted-child-mirror.ts
+++ b/src/agent/hosted-child-mirror.ts
@@ -1,0 +1,208 @@
+import type { ChatMessageMetadata, ChatUiMessageChunk } from "../chat/protocol.ts";
+import type { HostedStreamPartForUiChunkMapping } from "../chat/hosted-ui-chunk-mapping.ts";
+
+export interface HostedChildChunkMirror {
+  handleChunk(chunk: ChatUiMessageChunk<ChatMessageMetadata>): Promise<void> | void;
+}
+
+export interface HostedChildMirrorState {
+  reasoningStarted: boolean;
+  textStarted: boolean;
+}
+
+type CoreMirroredPartType =
+  | "reasoning-delta"
+  | "text-delta"
+  | "tool-input-start"
+  | "tool-input-delta"
+  | "tool-call"
+  | "tool-result";
+
+type MirroredPartType = CoreMirroredPartType | "tool-error" | "error";
+
+type DurableMirrorChunkType = ChatUiMessageChunk<ChatMessageMetadata>["type"];
+
+const ALREADY_MIRRORED_CHUNK_TYPES_BY_PART_TYPE: Readonly<
+  Partial<Record<MirroredPartType, readonly DurableMirrorChunkType[]>>
+> = {
+  "reasoning-delta": ["reasoning-delta"],
+  "text-delta": ["text-delta"],
+  "tool-input-start": ["tool-input-start"],
+  "tool-call": ["tool-input-start", "tool-input-available", "tool-input-error"],
+  "tool-result": ["tool-output-available"],
+  "tool-error": ["tool-input-start", "tool-input-error"],
+};
+
+export function isAlreadyMirroredHostedChunk(
+  partType: MirroredPartType,
+  mirroredChunkType: DurableMirrorChunkType,
+): boolean {
+  return ALREADY_MIRRORED_CHUNK_TYPES_BY_PART_TYPE[partType]?.includes(mirroredChunkType) ?? false;
+}
+
+type MirroredHostedStreamPart = Extract<
+  HostedStreamPartForUiChunkMapping,
+  | { type: "reasoning-delta" }
+  | { type: "text-delta" }
+  | { type: "source" }
+  | { type: "tool-input-start" }
+  | { type: "tool-call" }
+  | { type: "tool-input-delta" }
+  | { type: "tool-result" }
+  | { type: "tool-error" }
+  | { type: "error" }
+>;
+
+type HostedMirrorBasePart =
+  | { type: "reasoning-delta"; text: string }
+  | { type: "text-delta"; text: string }
+  | { type: "tool-input-start"; toolCallId: string; toolName: string }
+  | { type: "tool-input-delta"; toolCallId: string; delta: string }
+  | { type: "tool-call"; toolCallId: string; toolName: string; input: unknown }
+  | { type: "tool-result"; toolCallId: string; toolName: string; input: unknown; output: unknown }
+  | { type: "tool-error"; toolCallId: string; toolName: string; input: unknown; error: Error }
+  | { type: "error"; error: Error };
+
+type ExtraMirroredHostedStreamPart = Extract<HostedStreamPartForUiChunkMapping, { type: "source" }>;
+
+export type HostedChildMirrorPart = HostedMirrorBasePart | ExtraMirroredHostedStreamPart;
+
+export function toMirroredHostedStreamPart(
+  part: HostedChildMirrorPart,
+  ids: {
+    messageId: string | null;
+    reasoningMessageId: string | null;
+  },
+): MirroredHostedStreamPart {
+  switch (part.type) {
+    case "reasoning-delta":
+      return {
+        type: "reasoning-delta",
+        id: ids.reasoningMessageId ?? "fork-reasoning",
+        text: part.text,
+      };
+
+    case "text-delta":
+      return {
+        type: "text-delta",
+        id: ids.messageId ?? "fork-message",
+        text: part.text,
+      };
+
+    case "tool-input-start":
+      return {
+        type: "tool-input-start",
+        id: part.toolCallId,
+        toolName: part.toolName,
+      };
+
+    case "source":
+      if (part.sourceType === "url") {
+        return {
+          type: "source",
+          id: part.id,
+          sourceType: "url",
+          url: part.url,
+          ...(part.title ? { title: part.title } : {}),
+        };
+      }
+
+      return {
+        type: "source",
+        id: part.id,
+        sourceType: "document",
+        mediaType: part.mediaType,
+        title: part.title ?? part.filename ?? part.id,
+        ...(part.filename ? { filename: part.filename } : {}),
+      };
+
+    case "tool-call":
+      return {
+        type: "tool-call",
+        toolCallId: part.toolCallId,
+        toolName: part.toolName,
+        input: part.input,
+      };
+
+    case "tool-input-delta":
+      return {
+        type: "tool-input-delta",
+        id: part.toolCallId,
+        delta: part.delta,
+      };
+
+    case "tool-result":
+      return {
+        type: "tool-result",
+        toolCallId: part.toolCallId,
+        toolName: part.toolName,
+        input: part.input,
+        output: part.output,
+      };
+
+    case "tool-error":
+      return {
+        type: "tool-error",
+        toolCallId: part.toolCallId,
+        toolName: part.toolName,
+        input: part.input,
+        error: part.error,
+      };
+
+    case "error":
+      return {
+        type: "error",
+        error: part.error,
+      };
+  }
+}
+
+export async function appendHostedChildMirrorChunk(input: {
+  mirror: HostedChildChunkMirror | null;
+  chunk: ChatUiMessageChunk<ChatMessageMetadata>;
+}): Promise<boolean> {
+  if (!input.mirror) {
+    return false;
+  }
+
+  await input.mirror.handleChunk(input.chunk);
+  return true;
+}
+
+export async function closeHostedChildReasoningSegment(input: {
+  mirror: HostedChildChunkMirror | null;
+  reasoningMessageId: string | null;
+  state: HostedChildMirrorState;
+}): Promise<void> {
+  if (!input.state.reasoningStarted || !input.reasoningMessageId) {
+    return;
+  }
+
+  input.state.reasoningStarted = false;
+  await appendHostedChildMirrorChunk({
+    mirror: input.mirror,
+    chunk: {
+      type: "reasoning-end",
+      id: input.reasoningMessageId,
+    },
+  });
+}
+
+export async function closeHostedChildTextSegment(input: {
+  mirror: HostedChildChunkMirror | null;
+  messageId: string | null;
+  state: HostedChildMirrorState;
+}): Promise<void> {
+  if (!input.state.textStarted || !input.messageId) {
+    return;
+  }
+
+  input.state.textStarted = false;
+  await appendHostedChildMirrorChunk({
+    mirror: input.mirror,
+    chunk: {
+      type: "text-end",
+      id: input.messageId,
+    },
+  });
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -358,6 +358,16 @@ export {
   runHostedChildLifecycle,
 } from "./hosted-child-lifecycle.ts";
 export {
+  appendHostedChildMirrorChunk,
+  closeHostedChildReasoningSegment,
+  closeHostedChildTextSegment,
+  type HostedChildChunkMirror,
+  type HostedChildMirrorPart,
+  type HostedChildMirrorState,
+  isAlreadyMirroredHostedChunk,
+  toMirroredHostedStreamPart,
+} from "./hosted-child-mirror.ts";
+export {
   type HostedLifecycleAdapter,
   type HostedLifecycleExecution,
   type HostedLifecycleRunnerOptions,


### PR DESCRIPTION
## Summary
- add shared hosted child-run mirror helpers in the agent surface
- export mirrored-part translation, duplicate-chunk detection, and segment-closing helpers
- reduce duplicate child-run mirror code across runtime hosts

## Verification
- deno fmt src/agent/hosted-child-mirror.test.ts
- deno lint src/agent/hosted-child-mirror.ts src/agent/hosted-child-mirror.test.ts src/agent/index.ts
- deno test -A src/agent/hosted-child-mirror.test.ts
- deno check src/agent/hosted-child-mirror.ts src/agent/index.ts