### PR TITLE
Release veryfront 0.1.265

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.264",
+  "version": "0.1.265",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.264";
+export const VERSION = "0.1.265";


### PR DESCRIPTION
## Summary
- advance the stable release line from `0.1.264` to `0.1.265`
- publish the newly merged hosted child mirror helpers
- unblock downstream runtime adoption

## Verification
- release-line version bump only
- prior merged PR CI on main covered the shipped framework changes