### PR TITLE
Share hosted child status monitoring across runtimes

### DIFF
--- a/src/agent/hosted-child-status.test.ts
+++ b/src/agent/hosted-child-status.test.ts
@@ -1,0 +1,57 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  HostedChildTerminalStateError,
+  monitorHostedChildRunStatus,
+  resolveHostedChildTerminalErrorCode,
+} from "./hosted-child-status.ts";
+
+describe("agent/hosted-child-status", () => {
+  it("maps terminal statuses to durable child error codes", () => {
+    assertEquals(resolveHostedChildTerminalErrorCode("cancelled"), "DURABLE_CHILD_CANCELLED");
+    assertEquals(resolveHostedChildTerminalErrorCode("failed"), "DURABLE_CHILD_FAILED");
+    assertEquals(
+      resolveHostedChildTerminalErrorCode("completed"),
+      "DURABLE_CHILD_COMPLETED_EXTERNALLY",
+    );
+  });
+
+  it("stores status and identifiers on HostedChildTerminalStateError", () => {
+    const error = new HostedChildTerminalStateError("failed", {
+      childConversationId: "11111111-1111-4111-a111-111111111111",
+      childRunId: "run_123",
+      childMessageId: "22222222-2222-4222-a222-222222222222",
+      latestEventId: 1,
+      latestExternalEventSequence: 0,
+    });
+
+    assertEquals(error.status, "failed");
+    assertEquals(error.name, "HostedChildTerminalStateError");
+    assertEquals(error.identifiers.childRunId, "run_123");
+  });
+
+  it("returns immediately when already aborted", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+    let calls = 0;
+
+    await monitorHostedChildRunStatus({
+      authToken: "token",
+      apiUrl: "https://api.example.com",
+      identifiers: {
+        childConversationId: "11111111-1111-4111-a111-111111111111",
+        childRunId: "run_123",
+        childMessageId: "22222222-2222-4222-a222-222222222222",
+        latestEventId: 1,
+        latestExternalEventSequence: 0,
+      },
+      abortSignal: abortController.signal,
+      pollIntervalMs: 1,
+      onTerminal: () => {
+        calls += 1;
+      },
+    });
+
+    assertEquals(calls, 0);
+  });
+});

--- a/src/agent/hosted-child-status.ts
+++ b/src/agent/hosted-child-status.ts
@@ -1,0 +1,107 @@
+import { type ConversationRunProjection, getConversationRun } from "./durable.ts";
+
+export interface HostedChildRunIdentifiers {
+  childConversationId: string;
+  childRunId: string;
+  childMessageId: string;
+  latestEventId: number;
+  latestExternalEventSequence: number;
+}
+
+type HostedConversationRunStatus = ConversationRunProjection["status"];
+
+export type HostedChildTerminalStatus = Extract<
+  HostedConversationRunStatus,
+  "completed" | "failed" | "cancelled"
+>;
+
+export class HostedChildTerminalStateError extends Error {
+  constructor(
+    readonly status: HostedChildTerminalStatus,
+    readonly identifiers: HostedChildRunIdentifiers,
+  ) {
+    super(
+      `Hosted child run ${identifiers.childRunId} became ${status} before local execution finished`,
+    );
+    this.name = "HostedChildTerminalStateError";
+  }
+}
+
+function isActiveHostedChildStatus(
+  status: HostedConversationRunStatus,
+): status is "pending" | "running" | "waiting_for_tool" {
+  return status === "pending" || status === "running" || status === "waiting_for_tool";
+}
+
+export function resolveHostedChildTerminalErrorCode(status: HostedChildTerminalStatus): string {
+  switch (status) {
+    case "cancelled":
+      return "DURABLE_CHILD_CANCELLED";
+    case "failed":
+      return "DURABLE_CHILD_FAILED";
+    case "completed":
+      return "DURABLE_CHILD_COMPLETED_EXTERNALLY";
+  }
+}
+
+async function waitForHostedChildStatusPoll(ms: number, abortSignal?: AbortSignal): Promise<void> {
+  if (ms <= 0 || abortSignal?.aborted) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    const timeoutId = setTimeout(() => {
+      abortSignal?.removeEventListener("abort", resolveOnAbort);
+      resolve();
+    }, ms);
+
+    const resolveOnAbort = () => {
+      clearTimeout(timeoutId);
+      abortSignal?.removeEventListener("abort", resolveOnAbort);
+      resolve();
+    };
+
+    abortSignal?.addEventListener("abort", resolveOnAbort, { once: true });
+  });
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+export async function monitorHostedChildRunStatus(input: {
+  authToken: string;
+  apiUrl: string;
+  identifiers: HostedChildRunIdentifiers;
+  abortSignal?: AbortSignal;
+  pollIntervalMs: number;
+  onTerminal: (error: HostedChildTerminalStateError) => void;
+}): Promise<void> {
+  while (!input.abortSignal?.aborted) {
+    await waitForHostedChildStatusPoll(input.pollIntervalMs, input.abortSignal);
+    if (input.abortSignal?.aborted) {
+      return;
+    }
+
+    try {
+      const run = await getConversationRun({
+        authToken: input.authToken,
+        apiUrl: input.apiUrl,
+        conversationId: input.identifiers.childConversationId,
+        runId: input.identifiers.childRunId,
+        abortSignal: input.abortSignal,
+      });
+
+      if (isActiveHostedChildStatus(run.status)) {
+        continue;
+      }
+
+      input.onTerminal(new HostedChildTerminalStateError(run.status, input.identifiers));
+      return;
+    } catch (error) {
+      if (input.abortSignal?.aborted || isAbortError(error)) {
+        return;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add shared hosted child-run status monitoring helpers in the agent surface
- export child identifiers, terminal error helpers, and durable-child polling helpers
- reduce duplicate durable child monitoring code across runtime hosts

## Verification
- deno fmt src/agent/hosted-child-status.ts src/agent/hosted-child-status.test.ts src/agent/index.ts
- deno lint src/agent/hosted-child-status.ts src/agent/hosted-child-status.test.ts src/agent/index.ts
- deno test -A src/agent/hosted-child-status.test.ts
- deno check src/agent/hosted-child-status.ts src/agent/index.ts