### PR TITLE
Expose hosted child status monitoring on the agent surface

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -368,6 +368,13 @@ export {
   toMirroredHostedStreamPart,
 } from "./hosted-child-mirror.ts";
 export {
+  type HostedChildRunIdentifiers,
+  HostedChildTerminalStateError,
+  type HostedChildTerminalStatus,
+  monitorHostedChildRunStatus,
+  resolveHostedChildTerminalErrorCode,
+} from "./hosted-child-status.ts";
+export {
   type HostedLifecycleAdapter,
   type HostedLifecycleExecution,
   type HostedLifecycleRunnerOptions,


### PR DESCRIPTION
## Summary
- export hosted child status monitoring helpers from the public agent surface
- keep the existing helper module unchanged
- unblock downstream runtime adoption through the package entrypoint

## Verification
- deno lint src/agent/index.ts src/agent/hosted-child-status.ts src/agent/hosted-child-status.test.ts
- deno test -A src/agent/hosted-child-status.test.ts
- deno check src/agent/index.ts src/agent/hosted-child-status.ts