### PR TITLE
Release veryfront 0.1.267

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.266",
+  "version": "0.1.267",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.266";
+export const VERSION = "0.1.267";


### PR DESCRIPTION
## Summary
- advance the stable release line from `0.1.266` to `0.1.267`
- publish the public hosted child status monitoring exports
- unblock downstream runtime adoption through the package entrypoint

## Verification
- release-line version bump only
- prior merged PR CI covered the export change