### PR TITLE
Share hosted child run bootstrap helpers

### DIFF
--- a/src/agent/hosted-child-bootstrap.test.ts
+++ b/src/agent/hosted-child-bootstrap.test.ts
@@ -1,0 +1,167 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  bootstrapHostedChildRun,
+  buildHostedChildConversationBody,
+} from "./hosted-child-bootstrap.ts";
+
+const API_URL = "https://api.example.com";
+const AUTH_TOKEN = "token-123";
+const PARENT_CONVERSATION_ID = "11111111-1111-4111-a111-111111111111";
+const CHILD_CONVERSATION_ID = "22222222-2222-4222-a222-222222222222";
+const PARENT_MESSAGE_ID = "33333333-3333-4333-a333-333333333333";
+const CHILD_MESSAGE_ID = "44444444-4444-4444-8444-444444444444";
+const PROJECT_ID = "55555555-5555-4555-8555-555555555555";
+const BRANCH_ID = "66666666-6666-4666-8666-666666666666";
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function acceptedRunResponse(run: unknown): Response {
+  return jsonResponse({ accepted: true, run }, 202);
+}
+
+function stubFetchWithRecorder(
+  handler: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> | Response,
+) {
+  globalThis.fetch = (async (input, init) => handler(input, init)) as typeof fetch;
+}
+
+describe("agent/hosted-child-bootstrap", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("builds hidden child conversation metadata", () => {
+    assertEquals(
+      buildHostedChildConversationBody({
+        ensureProjectId: PROJECT_ID,
+        parentConversationId: PARENT_CONVERSATION_ID,
+        parentRunId: "parent-run-1",
+        parentMessageId: PARENT_MESSAGE_ID,
+        spawnedFromToolCallId: "tool-call-1",
+        description: "Inspect logs",
+      }),
+      {
+        project_id: PROJECT_ID,
+        type: "project_agent",
+        title: "Inspect logs",
+        metadata: {
+          hiddenFromChatList: true,
+          projectAgentChildRun: {
+            parentConversationId: PARENT_CONVERSATION_ID,
+            parentRunId: "parent-run-1",
+            spawnedFromMessageId: PARENT_MESSAGE_ID,
+            spawnedFromToolCallId: "tool-call-1",
+            description: "Inspect logs",
+          },
+        },
+      },
+    );
+  });
+
+  it("bootstraps a hosted child conversation, handoff message, and run", async () => {
+    const requests: { url: string; body: unknown }[] = [];
+    stubFetchWithRecorder(async (input, init) => {
+      requests.push({
+        url: String(input),
+        body: init?.body ? JSON.parse(String(init.body)) : null,
+      });
+
+      const requestCount = requests.length;
+      if (requestCount === 1) {
+        return jsonResponse({ id: PARENT_CONVERSATION_ID, project_id: PROJECT_ID }, 200);
+      }
+      if (requestCount === 2) {
+        return jsonResponse({ id: CHILD_CONVERSATION_ID, project_id: PROJECT_ID }, 200);
+      }
+      if (requestCount === 3) {
+        return jsonResponse({ id: CHILD_MESSAGE_ID }, 200);
+      }
+      if (requestCount === 4) {
+        return acceptedRunResponse({ run_id: "run_child_1" });
+      }
+      if (requestCount === 5) {
+        return jsonResponse(
+          {
+            run_id: "run_child_1",
+            conversation_id: CHILD_CONVERSATION_ID,
+            message_id: CHILD_MESSAGE_ID,
+            latest_event_id: 7,
+            latest_external_event_sequence: 3,
+            status: "running",
+          },
+          200,
+        );
+      }
+
+      throw new Error("Unexpected fetch call");
+    });
+
+    const result = await bootstrapHostedChildRun({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      ensureProjectId: PROJECT_ID,
+      runProjectId: PROJECT_ID,
+      parentConversationId: PARENT_CONVERSATION_ID,
+      parentRunId: "parent-run-1",
+      parentMessageId: PARENT_MESSAGE_ID,
+      spawnedFromToolCallId: "tool-call-1",
+      description: "Inspect logs",
+      prompt: "Find the latest logs.",
+      runId: "run_child_1",
+      agentId: "invoke-agent-child",
+      branchId: BRANCH_ID,
+    });
+
+    assertEquals(result, {
+      childConversationId: CHILD_CONVERSATION_ID,
+      childRunId: "run_child_1",
+      childMessageId: CHILD_MESSAGE_ID,
+      latestEventId: 7,
+      latestExternalEventSequence: 3,
+      status: "running",
+    });
+    assertEquals(requests[1].body, {
+      project_id: PROJECT_ID,
+      type: "project_agent",
+      title: "Inspect logs",
+      metadata: {
+        hiddenFromChatList: true,
+        projectAgentChildRun: {
+          parentConversationId: PARENT_CONVERSATION_ID,
+          parentRunId: "parent-run-1",
+          spawnedFromMessageId: PARENT_MESSAGE_ID,
+          spawnedFromToolCallId: "tool-call-1",
+          description: "Inspect logs",
+        },
+      },
+    });
+    assertEquals(requests[2].body, {
+      role: "user",
+      parts: [{ type: "text", text: "Find the latest logs." }],
+    });
+    assertEquals(requests[3].body, {
+      kind: "agent",
+      owner: {
+        kind: "conversation",
+        id: CHILD_CONVERSATION_ID,
+      },
+      public_id: "run_child_1",
+      request: {
+        mode: "default_chat",
+        agent_id: "invoke-agent-child",
+        initial_status: "running",
+        source_target_kind: "preview_branch",
+        runtime_target_kind: "preview_branch",
+        source_target_branch_id: BRANCH_ID,
+        runtime_target_branch_id: BRANCH_ID,
+      },
+    });
+  });
+});

--- a/src/agent/hosted-child-bootstrap.ts
+++ b/src/agent/hosted-child-bootstrap.ts
@@ -1,0 +1,72 @@
+import { bootstrapConversationAgentRun } from "./conversation-bootstrap.ts";
+import { type HostedChildRunIdentifiers } from "./hosted-child-status.ts";
+
+export interface HostedChildConversationBodyInput {
+  ensureProjectId?: string | null;
+  parentConversationId: string;
+  parentRunId: string;
+  parentMessageId: string;
+  spawnedFromToolCallId: string;
+  description: string;
+}
+
+export interface BootstrapHostedChildRunInput extends HostedChildConversationBodyInput {
+  authToken: string;
+  apiUrl: string;
+  runProjectId?: string | null;
+  prompt: string;
+  runId?: string;
+  agentId: string;
+  branchId?: string | null;
+}
+
+export interface BootstrapHostedChildRunResult extends HostedChildRunIdentifiers {
+  status: "running";
+}
+
+export function buildHostedChildConversationBody(input: HostedChildConversationBodyInput) {
+  return {
+    ...(input.ensureProjectId ? { project_id: input.ensureProjectId } : {}),
+    type: "project_agent" as const,
+    title: input.description,
+    metadata: {
+      hiddenFromChatList: true,
+      projectAgentChildRun: {
+        parentConversationId: input.parentConversationId,
+        parentRunId: input.parentRunId,
+        spawnedFromMessageId: input.parentMessageId,
+        spawnedFromToolCallId: input.spawnedFromToolCallId,
+        description: input.description,
+      },
+    },
+  };
+}
+
+export async function bootstrapHostedChildRun(
+  input: BootstrapHostedChildRunInput,
+): Promise<BootstrapHostedChildRunResult> {
+  const result = await bootstrapConversationAgentRun({
+    authToken: input.authToken,
+    apiUrl: input.apiUrl,
+    parentConversationId: input.parentConversationId,
+    ensureProjectId: input.ensureProjectId ?? undefined,
+    conversationBody: buildHostedChildConversationBody(input),
+    handoffMessageBody: {
+      role: "user",
+      parts: [{ type: "text", text: input.prompt }],
+    },
+    runId: input.runId,
+    agentId: input.agentId,
+    projectId: input.runProjectId ?? null,
+    branchId: input.branchId,
+  });
+
+  return {
+    childConversationId: result.conversation.id,
+    childRunId: result.run.runId,
+    childMessageId: result.run.messageId,
+    latestEventId: result.run.latestEventId,
+    latestExternalEventSequence: result.run.latestExternalEventSequence,
+    status: "running",
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -243,6 +243,13 @@ export {
   fetchConversationRecord,
 } from "./conversation-bootstrap.ts";
 export {
+  bootstrapHostedChildRun,
+  type BootstrapHostedChildRunInput,
+  type BootstrapHostedChildRunResult,
+  buildHostedChildConversationBody,
+  type HostedChildConversationBodyInput,
+} from "./hosted-child-bootstrap.ts";
+export {
   type ConversationChildLifecycleContext,
   type ConversationHostedLifecycleFinalizeInput,
   createConversationChildLifecycleAdapter,


### PR DESCRIPTION
## Summary\n- add a hosted child bootstrap helper for hidden child conversations, handoff messages, and run starts\n- expose hosted child conversation-body construction and canonical child run identifiers on the public agent surface\n- cover child metadata, handoff body, target propagation, and bootstrap result mapping with unit tests\n\n## Verification\n- deno test --no-check --allow-all src/agent/hosted-child-bootstrap.test.ts src/agent/conversation-bootstrap.test.ts\n- deno fmt --check src/ cli/\n- DENO_NO_PACKAGE_JSON=1 deno lint src/ cli/\n- deno task typecheck\n- pre-push checks: formatting, lint, typecheck, unit tests\n\n## Risk\n- Narrow: this composes existing conversation bootstrap and durable run creation helpers without changing their behavior.\n