### PR TITLE
Release veryfront 0.1.268

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.267",
+  "version": "0.1.268",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.267";
+export const VERSION = "0.1.268";


### PR DESCRIPTION
## Summary\n- advance the stable version to 0.1.268\n- publish the hosted child bootstrap helper and public agent surface export\n\n## Verification\n- deno fmt --check deno.json src/utils/version-constant.ts\n- DENO_NO_PACKAGE_JSON=1 deno lint src/utils/version-constant.ts\n- deno check src/agent/index.ts src/utils/index.ts\n- pre-push checks: formatting, lint, typecheck, unit tests\n