### PR TITLE
Normalize legacy project-agent model ids in runtime

### DIFF
--- a/src/agent/runtime/model-resolution.test.ts
+++ b/src/agent/runtime/model-resolution.test.ts
@@ -58,6 +58,21 @@ describe("agent/runtime/model-resolution", () => {
     );
   });
 
+  it("upgrades legacy bare model ids to provider/model strings", () => {
+    assertEquals(
+      resolveConfiguredAgentModel("claude-opus-4-6"),
+      "anthropic/claude-opus-4-6",
+    );
+    assertEquals(
+      resolveConfiguredAgentModel("opus"),
+      "anthropic/claude-opus-4-6",
+    );
+    assertEquals(
+      resolveConfiguredAgentModel("gpt-5.2"),
+      "openai/gpt-5.2",
+    );
+  });
+
   it("upgrades auto/local models to the default Veryfront cloud model when bootstrap is present", () => {
     setEnv("VERYFRONT_API_TOKEN", "vf_test_runtime");
     setEnv("VERYFRONT_PROJECT_SLUG", "demo-project");

--- a/src/agent/runtime/model-resolution.ts
+++ b/src/agent/runtime/model-resolution.ts
@@ -10,6 +10,22 @@ import { isVeryfrontCloudEnabled } from "#veryfront/platform/cloud/resolver.ts";
 export const AUTO_AGENT_MODEL = "auto";
 
 const HOSTED_PROVIDER_NAMES = new Set(["anthropic", "google", "openai"]);
+const LEGACY_MODEL_ALIASES: Record<string, string> = {
+  opus: "anthropic/claude-opus-4-6",
+  sonnet: "anthropic/claude-sonnet-4-6",
+  haiku: "anthropic/claude-haiku-4-5-20251001",
+  "claude-opus-4-6": "anthropic/claude-opus-4-6",
+  "claude-sonnet-4-6": "anthropic/claude-sonnet-4-6",
+  "claude-haiku-4-5-20251001": "anthropic/claude-haiku-4-5-20251001",
+  "gpt-5.2": "openai/gpt-5.2",
+  "gpt-5.4": "openai/gpt-5.2",
+  "gpt-5.4-mini": "openai/gpt-5.2",
+  "o3-pro": "openai/gpt-5.2",
+  "o4-mini": "openai/gpt-5.2",
+  "gemini-3.1-pro": "google-ai-studio/gemini-2.5-pro",
+  "gemini-2.5-pro": "google-ai-studio/gemini-2.5-pro",
+  "gemini-2.5-flash": "google-ai-studio/gemini-2.5-flash",
+};
 
 export function normalizeAgentModelConfig(model?: string): string {
   const normalized = model?.trim();
@@ -18,7 +34,15 @@ export function normalizeAgentModelConfig(model?: string): string {
 
 export function resolveConfiguredAgentModel(model?: string): string {
   const normalized = normalizeAgentModelConfig(model);
-  return normalized === AUTO_AGENT_MODEL ? `local/${DEFAULT_LOCAL_MODEL}` : normalized;
+  if (normalized === AUTO_AGENT_MODEL) {
+    return `local/${DEFAULT_LOCAL_MODEL}`;
+  }
+
+  if (normalized.includes("/")) {
+    return normalized;
+  }
+
+  return LEGACY_MODEL_ALIASES[normalized] ?? normalized;
 }
 
 function hasDirectProviderCredentials(provider: string): boolean {


### PR DESCRIPTION
## Summary
- normalize legacy bare model ids like `claude-opus-4-6` before runtime execution
- keep project-agent runtimes compatible with stored agent configs that still use old model ids
- add a regression test for legacy alias upgrade in runtime model resolution

## Verification
- `deno test --no-check --allow-all src/agent/runtime/model-resolution.test.ts`
