### PR TITLE
Advance veryfront-code to 0.1.269 for runtime fix rollout

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.268",
+  "version": "0.1.269",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.268";
+export const VERSION = "0.1.269";


### PR DESCRIPTION
## Summary
- bump `veryfront-code` from `0.1.268` to `0.1.269`
- unblock publishing and deployment of the already-merged project-agent runtime normalization fix
- ensure downstream deploys pick up a new package version instead of the stale `0.1.268` release

## Verification
- `deno test --no-check --allow-all src/agent/runtime/model-resolution.test.ts`
