### PR TITLE
Fix isRemoteIntegrationTool to use __ separator

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.272",
+  "version": "0.1.273",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -210,14 +210,14 @@ describe("tool-helpers", () => {
       await assertRejects(
         () =>
           executeConfiguredTool(
-            "gmail:list-emails",
+            "gmail__list_emails",
             {},
             undefined,
             { toolCallId: "tool-3" },
-            ["gmail:get-email"],
+            ["gmail__get_email"],
           ),
         Error,
-        'Tool "gmail:list-emails" is not allowed for this run',
+        'Tool "gmail__list_emails" is not allowed for this run',
       );
     });
 
@@ -305,14 +305,14 @@ describe("tool-helpers", () => {
       toolRegistry.clearAll();
       try {
         const defs = await withMockRemoteIntegrationTools([
-          "gmail:list-emails",
-          "gmail:get-email",
+          "gmail__list_emails",
+          "gmail__get_email",
         ], () =>
           getAvailableTools(true, {
-            allowedRemoteToolNames: ["gmail:get-email"],
+            allowedRemoteToolNames: ["gmail__get_email"],
           }));
 
-        assertEquals(defs.map((def) => def.name), ["gmail:get-email"]);
+        assertEquals(defs.map((def) => def.name), ["gmail__get_email"]);
       } finally {
         toolRegistry.clearAll();
       }
@@ -324,15 +324,15 @@ describe("tool-helpers", () => {
       try {
         await assertRejects(
           () =>
-            withMockRemoteIntegrationTools(["gmail:list-emails"], () =>
+            withMockRemoteIntegrationTools(["gmail__list_emails"], () =>
               getAvailableTools(
                 {
-                  "gmail:get-email": true,
+                  "gmail__get_email": true,
                 },
-                { allowedRemoteToolNames: ["gmail:list-emails"] },
+                { allowedRemoteToolNames: ["gmail__list_emails"] },
               )),
           Error,
-          'Unknown tool reference: gmail:get-email. Tool names must exactly match tool({ id: "..." }). Available tools: gmail:list-emails',
+          'Unknown tool reference: gmail__get_email. Tool names must exactly match tool({ id: "..." }). Available tools: gmail__list_emails',
         );
       } finally {
         toolRegistry.clearAll();
@@ -344,17 +344,17 @@ describe("tool-helpers", () => {
 
       try {
         const defs = await withMockRemoteIntegrationTools([
-          "gmail:list-emails",
-          "gmail:get-email",
+          "gmail__list_emails",
+          "gmail__get_email",
         ], () =>
           getAvailableTools(
             {
-              "gmail:get-email": true,
+              "gmail__get_email": true,
             },
-            { allowedRemoteToolNames: ["gmail:list-emails", "gmail:get-email"] },
+            { allowedRemoteToolNames: ["gmail__list_emails", "gmail__get_email"] },
           ));
 
-        assertEquals(defs.map((def) => def.name), ["gmail:get-email"]);
+        assertEquals(defs.map((def) => def.name), ["gmail__get_email"]);
       } finally {
         toolRegistry.clearAll();
       }

--- a/src/integrations/remote-tools.test.ts
+++ b/src/integrations/remote-tools.test.ts
@@ -173,11 +173,11 @@ describe("integrations/remote-tools", () => {
       Response.json({
         content: [{ text: '{"ignored":true}' }],
         structuredContent: { repos: ["veryfront"] },
-      }), async () => await executeRemoteIntegrationTool("github:list-repos", {}));
+      }), async () => await executeRemoteIntegrationTool("github__list_repos", {}));
 
     assertEquals(result, { repos: ["veryfront"] });
-    assertStrictEquals(isRemoteIntegrationTool("github:list-repos"), true);
-    assertStrictEquals(isRemoteIntegrationTool("list-repos"), false);
+    assertStrictEquals(isRemoteIntegrationTool("github__list_repos"), true);
+    assertStrictEquals(isRemoteIntegrationTool("list_repos"), false);
   });
 
   it("posts integration config as a full replace payload", async () => {

--- a/src/integrations/remote-tools.ts
+++ b/src/integrations/remote-tools.ts
@@ -175,10 +175,10 @@ export async function getRemoteIntegrationToolDefinitions(): Promise<
 
 /**
  * Check if a tool name looks like a remote integration tool.
- * Integration tools use "integration:tool-id" format.
+ * Integration tools use "integration__tool_id" format (double underscore separator).
  */
 export function isRemoteIntegrationTool(toolName: string): boolean {
-  return toolName.includes(":");
+  return toolName.includes("__");
 }
 
 /**

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.272";
+export const VERSION = "0.1.273";


### PR DESCRIPTION
Was checking for colon, needs double underscore.