### PR TITLE
Reserve the hosted agent-service seam before the agent reshape lands

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.273",
+  "version": "0.1.274",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -16,6 +16,7 @@ Route examples below use the default app router. The hosted AG-UI path is owned 
 import {
   agent,
   agentAsTool,
+  AgentContract,
   AgentRuntime,
   AgUiDetachedStartRequestSchema,
   AgUiRequestSchema,
@@ -31,6 +32,8 @@ import {
   createAgUiRuntimeHandler,
   createAgUiSseErrorResponse,
   createMemory,
+  defineAgentService,
+  DurableRunSink,
   executeAgUiDetachedStart,
   expandAllowedRemoteToolNames,
   getAgentsAsTools,
@@ -217,6 +220,30 @@ await runHostedLifecycle({
   },
   adapter,
   resolveTerminalState: () => ({ status: "completed" }),
+});
+```
+
+### Phase-0 hosted service contract stub
+
+```ts
+import { agent, defineAgentService, type DurableRunSink } from "veryfront/agent";
+
+const assistant = agent({
+  system: "You are a hosted assistant.",
+});
+
+const durableRunSink: DurableRunSink = {
+  startRun: () => ({ runId: "run_123" }),
+  appendEvents: async () => {},
+  finalizeRun: async () => {},
+  cancelRun: async () => {},
+};
+
+// Phase 0 reserves the public signature only. This currently throws until the
+// hosted runtime implementation lands in a later migration phase.
+defineAgentService({
+  agent: assistant,
+  durableRunSink,
 });
 ```
 

--- a/src/agent/agent-service.test.ts
+++ b/src/agent/agent-service.test.ts
@@ -1,0 +1,52 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { type AgentContract, defineAgentService, type DurableRunSink } from "./index.ts";
+import { agent } from "./factory.ts";
+
+const assistant = agent({
+  id: "phase-0-service-stub",
+  system: "You are a hosted service stub test agent.",
+});
+
+describe("agent/agent-service", () => {
+  it("exports a typed contract surface for future hosted service adoption", () => {
+    const durableRunSink: DurableRunSink<
+      { requestId: string },
+      { runId: string },
+      { type: string },
+      { status: string }
+    > = {
+      startRun(input) {
+        return { runId: input.requestId };
+      },
+      appendEvents() {},
+      finalizeRun() {},
+      cancelRun() {},
+    };
+
+    const contract: AgentContract<
+      { requestId: string },
+      { runId: string },
+      { type: string },
+      { status: string }
+    > = {
+      agent: assistant,
+      durableRunSink,
+    };
+
+    assertEquals(contract.agent.id, "phase-0-service-stub");
+    assertEquals(contract.durableRunSink?.startRun({ requestId: "run-123" }), {
+      runId: "run-123",
+    });
+  });
+
+  it("throws until the hosted runtime service implementation lands", async () => {
+    await assertRejects(
+      async () => {
+        defineAgentService({ agent: assistant });
+      },
+      Error,
+      "Phase 0 stub",
+    );
+  });
+});

--- a/src/agent/agent-service.ts
+++ b/src/agent/agent-service.ts
@@ -1,0 +1,62 @@
+import type { Agent } from "./types.ts";
+
+/**
+ * Transport-neutral durable run lifecycle sink reserved for hosted agent-service
+ * adoption work.
+ */
+export interface DurableRunSink<
+  TStartInput = void,
+  TRun = unknown,
+  TEvent = unknown,
+  TTerminalState = unknown,
+> {
+  startRun(input: TStartInput): Promise<TRun> | TRun;
+  appendEvents(run: TRun, events: TEvent[]): Promise<void> | void;
+  finalizeRun(run: TRun, terminalState: TTerminalState): Promise<void> | void;
+  cancelRun(run: TRun, terminalState: TTerminalState): Promise<void> | void;
+}
+
+/**
+ * Phase-0 contract draft for the future framework-owned hosted agent service.
+ */
+export interface AgentContract<
+  TStartInput = void,
+  TRun = unknown,
+  TEvent = unknown,
+  TTerminalState = unknown,
+> {
+  agent: Agent;
+  durableRunSink?: DurableRunSink<TStartInput, TRun, TEvent, TTerminalState>;
+}
+
+/**
+ * Type-preserving service definition reserved ahead of the runtime
+ * implementation landing in a later migration phase.
+ */
+export interface AgentServiceDefinition<
+  TStartInput = void,
+  TRun = unknown,
+  TEvent = unknown,
+  TTerminalState = unknown,
+> {
+  contract: AgentContract<TStartInput, TRun, TEvent, TTerminalState>;
+}
+
+const DEFINE_AGENT_SERVICE_STUB_ERROR =
+  "defineAgentService() is a Phase 0 stub. The framework contract is reserved, but the hosted runtime implementation has not landed yet.";
+
+/**
+ * Reserve the public hosted agent-service signature before the runtime
+ * implementation lands.
+ */
+export function defineAgentService<
+  TStartInput = void,
+  TRun = unknown,
+  TEvent = unknown,
+  TTerminalState = unknown,
+>(
+  contract: AgentContract<TStartInput, TRun, TEvent, TTerminalState>,
+): AgentServiceDefinition<TStartInput, TRun, TEvent, TTerminalState> {
+  void contract;
+  throw new Error(DEFINE_AGENT_SERVICE_STUB_ERROR);
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -140,6 +140,12 @@ export {
 
 export { agent } from "./factory.ts";
 export {
+  type AgentContract,
+  type AgentServiceDefinition,
+  defineAgentService,
+  type DurableRunSink,
+} from "./agent-service.ts";
+export {
   type AgUiRuntimeHandlerConfig,
   type AgUiRuntimeHandlerConfigWithAgent,
   type AgUiRuntimeHandlerExecute,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.273";
+export const VERSION = "0.1.274";


### PR DESCRIPTION
## Summary
- add the Phase 0 hosted agent-service contract and throwing defineAgentService stub
- export and document the new agent-service surface
- bump the framework version metadata for the next release cut

## Testing
- deno test --no-check --allow-all src/agent/agent-service.test.ts
- deno check src/agent/agent-service.ts src/agent/index.ts src/utils/version-constant.ts
- deno task docs:validate
- deno task typecheck

## Notes
- defineAgentService still throws by design in Phase 0
- verify:quick is currently blocked by pre-existing repo issues outside this diff