### PR TITLE
Align the hosted agent-service stub with the approved Phase 0 contract

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.274",
+  "version": "0.1.275",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -242,6 +242,7 @@ const durableRunSink: DurableRunSink = {
 // Phase 0 reserves the public signature only. This currently throws until the
 // hosted runtime implementation lands in a later migration phase.
 defineAgentService({
+  serviceName: "veryfront-agent",
   agent: assistant,
   durableRunSink,
 });

--- a/src/agent/agent-service.test.ts
+++ b/src/agent/agent-service.test.ts
@@ -30,11 +30,15 @@ describe("agent/agent-service", () => {
       { type: string },
       { status: string }
     > = {
+      serviceName: "veryfront-agent",
       agent: assistant,
+      server: { port: 3001, basePath: "/api/ag-ui" },
       durableRunSink,
     };
 
+    assertEquals(contract.serviceName, "veryfront-agent");
     assertEquals(contract.agent.id, "phase-0-service-stub");
+    assertEquals(contract.server?.port, 3001);
     assertEquals(contract.durableRunSink?.startRun({ requestId: "run-123" }), {
       runId: "run-123",
     });
@@ -43,7 +47,7 @@ describe("agent/agent-service", () => {
   it("throws until the hosted runtime service implementation lands", async () => {
     await assertRejects(
       async () => {
-        defineAgentService({ agent: assistant });
+        defineAgentService({ serviceName: "veryfront-agent", agent: assistant });
       },
       Error,
       "Phase 0 stub",

--- a/src/agent/agent-service.ts
+++ b/src/agent/agent-service.ts
@@ -17,6 +17,16 @@ export interface DurableRunSink<
 }
 
 /**
+ * Placeholder host-facing server config reserved for the future hosted service
+ * implementation.
+ */
+export interface AgentServiceServerConfig {
+  port?: number;
+  basePath?: string;
+  cors?: boolean;
+}
+
+/**
  * Phase-0 contract draft for the future framework-owned hosted agent service.
  */
 export interface AgentContract<
@@ -25,7 +35,9 @@ export interface AgentContract<
   TEvent = unknown,
   TTerminalState = unknown,
 > {
+  serviceName: string;
   agent: Agent;
+  server?: AgentServiceServerConfig;
   durableRunSink?: DurableRunSink<TStartInput, TRun, TEvent, TTerminalState>;
 }
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -142,6 +142,7 @@ export { agent } from "./factory.ts";
 export {
   type AgentContract,
   type AgentServiceDefinition,
+  type AgentServiceServerConfig,
   defineAgentService,
   type DurableRunSink,
 } from "./agent-service.ts";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.274";
+export const VERSION = "0.1.275";


### PR DESCRIPTION
## Summary
- align the Phase 0 defineAgentService stub with the approved serviceName/agent/server/durableRunSink contract
- keep the stub type-only and throwing while correcting the adoption surface
- bump framework release metadata for the corrective follow-up release

## Testing
- deno check src/agent/agent-service.ts src/agent/agent-service.test.ts src/agent/index.ts
- deno test --no-check --allow-all src/agent/agent-service.test.ts
- deno task docs:validate
- deno task typecheck

## Notes
- This follows the already-merged #1290 to match the approved reshape plan before agent adoption flips from prep to positive usage coverage.