### PR TITLE
Move lazy sandbox lifecycle into the framework before broader convergence

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.275",
+  "version": "0.1.276",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -30,6 +30,14 @@ You can also reconnect to an existing session:
 const sandbox = await Sandbox.get(sessionId);
 ```
 
+If you want to defer session creation until the first command or file operation, use the lazy client:
+
+```ts
+const sandbox = Sandbox.createLazy({
+  projectId: "proj_123",
+});
+```
+
 If you need to override the resolved credentials, pass `authToken`
 explicitly. This can be a JWT or a Studio-generated API key.
 
@@ -74,6 +82,7 @@ console.log(content);
 ## Lifecycle best practices
 
 - Always call `await sandbox.close()` in `finally` blocks.
+- Prefer `Sandbox.createLazy()` for agent-style workflows that may not need a session every run.
 - Use `sandbox.heartbeat()` during long-running sessions to avoid idle timeouts.
 - Persist `sandbox.id` only when you need reconnect semantics.
 - Keep auth tokens and API keys server-side only. Do not expose them to browsers.

--- a/docs/reference/sandbox.md
+++ b/docs/reference/sandbox.md
@@ -39,6 +39,12 @@ Reconnect to an existing sandbox session.
 
 **Returns:** <code>Promise&lt;Sandbox&gt;</code>
 
+### `Sandbox.createLazy(options?)`
+
+Create a lazily-provisioned sandbox client that only claims a session on first use, sends an initial heartbeat before marking the session ready, and keeps the session alive until `close()`.
+
+**Returns:** <code>LazySandbox</code>
+
 ### `sandbox.executeCommand(command)`
 
 Execute a bash command in the sandbox and return buffered result.
@@ -129,6 +135,21 @@ Options for creating a sandbox session.
 | `authToken?` | `string` | Explicit Veryfront auth token or API key override. Defaults to request-scoped credentials or `VERYFRONT_API_TOKEN`. |
 | `projectId?` | `string` | Optional project context for project-scoped or project-billed sandbox sessions.                                     |
 
+### `LazySandboxOptions`
+
+Options for a lazily-provisioned sandbox session.
+
+| Property               | Type                                | Description                                                                              |
+| ---------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------- |
+| `apiUrl?`              | `string`                            | Base URL of the Veryfront API.                                                           |
+| `authToken?`           | `string`                            | Explicit Veryfront auth token or API key override.                                       |
+| `projectId?`           | `string`                            | Initial project-scoped billing or isolation context.                                     |
+| `getProjectId?`        | `() => string \| null \| undefined` | Deferred resolver used at first provision time and on later project-context sync checks. |
+| `startupTimeoutMs?`    | `number`                            | Maximum time to wait for pending sessions to become ready. Defaults to 180000.           |
+| `pollIntervalMs?`      | `number`                            | Poll interval while waiting for readiness. Defaults to 2000.                             |
+| `heartbeatIntervalMs?` | `number`                            | Background heartbeat interval for active sessions. Defaults to 30000.                    |
+| `heartbeatGraceMs?`    | `number`                            | Minimum gap between non-forced heartbeats. Defaults to 5000.                             |
+
 ### `ExecResult`
 
 Result of a command execution: stdout, stderr, and exit code.
@@ -153,27 +174,27 @@ Streaming event emitted during command execution.
 
 Status of an async command job.
 
-| Property | Type | Description |
-| -------- | ---- | ----------- |
-| `id` | `string` | Job identifier. |
-| `status` | `"running" \| "completed" \| "failed" \| "canceled"` | Current job status. |
-| `exitCode` | `number \| null` | Exit code when available. |
-| `signal` | `string \| null` | Termination signal when present. |
-| `startedAt` | `string` | Job start timestamp. |
-| `finishedAt` | `string \| null` | Job completion timestamp. |
-| `heartbeatStatus` | `"disabled" \| "healthy" \| "degraded"` | Heartbeat health state. |
-| `lastHeartbeatAt` | `string \| null` | Last heartbeat timestamp. |
-| `lastHeartbeatError` | `string \| null` | Last heartbeat error, if any. |
-| `heartbeatFailureCount` | `number` | Number of heartbeat failures recorded. |
+| Property                | Type                                                 | Description                            |
+| ----------------------- | ---------------------------------------------------- | -------------------------------------- |
+| `id`                    | `string`                                             | Job identifier.                        |
+| `status`                | `"running" \| "completed" \| "failed" \| "canceled"` | Current job status.                    |
+| `exitCode`              | `number \| null`                                     | Exit code when available.              |
+| `signal`                | `string \| null`                                     | Termination signal when present.       |
+| `startedAt`             | `string`                                             | Job start timestamp.                   |
+| `finishedAt`            | `string \| null`                                     | Job completion timestamp.              |
+| `heartbeatStatus`       | `"disabled" \| "healthy" \| "degraded"`              | Heartbeat health state.                |
+| `lastHeartbeatAt`       | `string \| null`                                     | Last heartbeat timestamp.              |
+| `lastHeartbeatError`    | `string \| null`                                     | Last heartbeat error, if any.          |
+| `heartbeatFailureCount` | `number`                                             | Number of heartbeat failures recorded. |
 
 ### `CommandJobOutput`
 
 Command job with captured stdout/stderr.
 
-| Property | Type | Description |
-| -------- | ---- | ----------- |
-| `stdout` | `string` | Captured standard output. |
-| `stderr` | `string` | Captured standard error. |
+| Property          | Type      | Description                   |
+| ----------------- | --------- | ----------------------------- |
+| `stdout`          | `string`  | Captured standard output.     |
+| `stderr`          | `string`  | Captured standard error.      |
 | `stdoutTruncated` | `boolean` | Whether stdout was truncated. |
 | `stderrTruncated` | `boolean` | Whether stderr was truncated. |
 
@@ -181,19 +202,21 @@ Command job with captured stdout/stderr.
 
 ### Classes
 
-| Name      | Description                                                                             |
-| --------- | --------------------------------------------------------------------------------------- |
-| `Sandbox` | Client for isolated ephemeral compute environments with command execution and file I/O. |
+| Name          | Description                                                                             |
+| ------------- | --------------------------------------------------------------------------------------- |
+| `LazySandbox` | Lazily provisions sandbox sessions and keeps them heartbeating while active.            |
+| `Sandbox`     | Client for isolated ephemeral compute environments with command execution and file I/O. |
 
 ### Types
 
-| Name              | Description                                                   |
-| ----------------- | ------------------------------------------------------------- |
-| `CommandJob` | Status of an async command job. |
-| `CommandJobOutput` | Async command job with captured output. |
-| `ExecResult`      | Result of a command execution: stdout, stderr, and exit code. |
-| `ExecStreamEvent` | Streaming event emitted during command execution.             |
-| `SandboxOptions`  | Options for creating a sandbox session.                       |
+| Name                 | Description                                                   |
+| -------------------- | ------------------------------------------------------------- |
+| `CommandJob`         | Status of an async command job.                               |
+| `CommandJobOutput`   | Async command job with captured output.                       |
+| `ExecResult`         | Result of a command execution: stdout, stderr, and exit code. |
+| `ExecStreamEvent`    | Streaming event emitted during command execution.             |
+| `LazySandboxOptions` | Options for lazily-provisioned sandbox sessions.              |
+| `SandboxOptions`     | Options for creating a sandbox session.                       |
 
 ## Related
 

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -31,3 +31,4 @@ export {
   type SandboxOptions,
   type SandboxSession,
 } from "./sandbox.ts";
+export { LazySandbox, type LazySandboxOptions } from "./lazy-sandbox.ts";

--- a/src/sandbox/lazy-sandbox.ts
+++ b/src/sandbox/lazy-sandbox.ts
@@ -1,0 +1,503 @@
+import { REQUEST_ERROR } from "#veryfront/errors";
+import {
+  type CommandJob,
+  type CommandJobOutput,
+  type CommandJobStatus,
+  type ExecOptions,
+  type ExecResult,
+  type ExecStreamEvent,
+  resolveSandboxApiUrl,
+  resolveSandboxAuthToken,
+  type SandboxOptions,
+  waitForSandboxReady,
+} from "./sandbox.ts";
+
+export interface LazySandboxOptions extends SandboxOptions {
+  getProjectId?: () => string | null | undefined;
+  startupTimeoutMs?: number;
+  pollIntervalMs?: number;
+  heartbeatIntervalMs?: number;
+  heartbeatGraceMs?: number;
+}
+
+interface SandboxSessionRecord {
+  id: string;
+  endpoint: string;
+  status: string;
+}
+
+const DEFAULT_STARTUP_TIMEOUT_MS = 180_000;
+const DEFAULT_POLL_INTERVAL_MS = 2_000;
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+const DEFAULT_HEARTBEAT_GRACE_MS = 5_000;
+
+/** Lazily provisions sandbox sessions and keeps them alive while in use. */
+export class LazySandbox {
+  private readonly apiUrl: string;
+  private readonly authToken: string;
+  private readonly getProjectId: () => string | null | undefined;
+  private readonly startupTimeoutMs: number;
+  private readonly pollIntervalMs: number;
+  private readonly heartbeatIntervalMs: number;
+  private readonly heartbeatGraceMs: number;
+
+  private endpoint: string | null = null;
+  private sessionId: string | null = null;
+  private sessionProjectId: string | null = null;
+  private ensurePromise: Promise<void> | null = null;
+  private closePromise: Promise<void> | null = null;
+  private heartbeatPromise: Promise<void> | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private lastHeartbeatAt = 0;
+
+  constructor(options: LazySandboxOptions = {}) {
+    this.apiUrl = resolveSandboxApiUrl(options);
+    this.authToken = resolveSandboxAuthToken(options);
+    this.getProjectId = options.getProjectId ?? (() => options.projectId);
+    this.startupTimeoutMs = options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS;
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.heartbeatIntervalMs = options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+    this.heartbeatGraceMs = options.heartbeatGraceMs ?? DEFAULT_HEARTBEAT_GRACE_MS;
+  }
+
+  async ensure(): Promise<void> {
+    if (this.endpoint) return;
+    if (this.ensurePromise) {
+      await this.ensurePromise;
+      return;
+    }
+
+    const promise = this.bootstrapSession();
+    this.ensurePromise = promise;
+
+    try {
+      await promise;
+    } finally {
+      if (this.ensurePromise === promise) {
+        this.ensurePromise = null;
+      }
+    }
+  }
+
+  async executeCommand(command: string, options?: ExecOptions): Promise<ExecResult> {
+    let stdout = "";
+    let stderr = "";
+    let exitCode = 1;
+
+    for await (const event of this.executeStream(command, options)) {
+      switch (event.type) {
+        case "stdout":
+          stdout += event.data ?? "";
+          break;
+        case "stderr":
+          stderr += event.data ?? "";
+          break;
+        case "exit":
+          exitCode = event.exitCode ?? 1;
+          break;
+      }
+    }
+
+    return { stdout, stderr, exitCode };
+  }
+
+  async *executeStream(command: string, options?: ExecOptions): AsyncGenerator<ExecStreamEvent> {
+    await this.touchSession();
+
+    const res = await fetch(`${this.requireEndpoint()}/exec`, {
+      method: "POST",
+      headers: this.jsonHeaders(),
+      body: JSON.stringify({ command, ...options }),
+    });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({ detail: `Exec failed: ${res.status} ${await res.text()}` });
+    }
+
+    if (!res.body) {
+      throw new Error("Exec response has no body");
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        yield JSON.parse(line) as ExecStreamEvent;
+      }
+    }
+
+    if (buffer.trim()) {
+      yield JSON.parse(buffer) as ExecStreamEvent;
+    }
+  }
+
+  async readFile(path: string): Promise<string> {
+    await this.touchSession();
+
+    const res = await fetch(`${this.requireEndpoint()}/file?path=${encodeURIComponent(path)}`, {
+      headers: this.authHeaders(),
+    });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({ detail: `Read file failed: ${res.status} ${await res.text()}` });
+    }
+
+    return await res.text();
+  }
+
+  async writeFiles(files: Array<{ path: string; content: string }>): Promise<void> {
+    await this.touchSession();
+
+    const res = await fetch(`${this.requireEndpoint()}/files`, {
+      method: "POST",
+      headers: this.jsonHeaders(),
+      body: JSON.stringify({ files }),
+    });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({
+        detail: `Write files failed: ${res.status} ${await res.text()}`,
+      });
+    }
+  }
+
+  async startCommandJob(command: string, options?: ExecOptions): Promise<CommandJob> {
+    await this.touchSession();
+
+    const res = await fetch(`${this.requireEndpoint()}/exec/jobs`, {
+      method: "POST",
+      headers: this.jsonHeaders(),
+      body: JSON.stringify({ command, ...options }),
+    });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({
+        detail: `Start command job failed: ${res.status} ${await res.text()}`,
+      });
+    }
+
+    return mapCommandJob(await res.json());
+  }
+
+  async getCommandJob(jobId: string): Promise<CommandJob> {
+    await this.ensure();
+
+    const res = await fetch(`${this.requireEndpoint()}/exec/jobs/${jobId}`, {
+      headers: this.authHeaders(),
+    });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({
+        detail: `Get command job failed: ${res.status} ${await res.text()}`,
+      });
+    }
+
+    return mapCommandJob(await res.json());
+  }
+
+  async getCommandJobOutput(jobId: string): Promise<CommandJobOutput> {
+    await this.ensure();
+
+    const res = await fetch(`${this.requireEndpoint()}/exec/jobs/${jobId}/output`, {
+      headers: this.authHeaders(),
+    });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({
+        detail: `Get command job output failed: ${res.status} ${await res.text()}`,
+      });
+    }
+
+    const json = await res.json();
+    return {
+      ...mapCommandJob(json),
+      stdout: json.stdout,
+      stderr: json.stderr,
+      stdoutTruncated: json.stdout_truncated,
+      stderrTruncated: json.stderr_truncated,
+    };
+  }
+
+  async listCommandJobs(): Promise<CommandJob[]> {
+    await this.ensure();
+
+    const res = await fetch(`${this.requireEndpoint()}/exec/jobs`, {
+      headers: this.authHeaders(),
+    });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({
+        detail: `List command jobs failed: ${res.status} ${await res.text()}`,
+      });
+    }
+
+    const json = await res.json();
+    const jobs = Array.isArray(json) ? json : (json.jobs ?? []);
+    return jobs.map((job: Record<string, unknown>) => mapCommandJob(job));
+  }
+
+  async cancelCommandJob(jobId: string): Promise<CommandJob> {
+    await this.ensure();
+
+    const res = await fetch(`${this.requireEndpoint()}/exec/jobs/${jobId}/cancel`, {
+      method: "POST",
+      headers: this.authHeaders(),
+    });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({
+        detail: `Cancel command job failed: ${res.status} ${await res.text()}`,
+      });
+    }
+
+    return mapCommandJob(await res.json());
+  }
+
+  async heartbeat(force = false): Promise<void> {
+    const currentSessionId = this.sessionId;
+    if (!currentSessionId) return;
+
+    if (this.heartbeatPromise) {
+      await this.heartbeatPromise;
+      return;
+    }
+
+    if (
+      !force && this.lastHeartbeatAt > 0 &&
+      Date.now() - this.lastHeartbeatAt < this.heartbeatGraceMs
+    ) {
+      return;
+    }
+
+    const promise = (async () => {
+      const res = await fetch(`${this.apiUrl}/sandbox-sessions/${currentSessionId}/heartbeat`, {
+        method: "POST",
+        headers: this.authHeaders(),
+      });
+
+      if (!res.ok) {
+        if (this.sessionId === currentSessionId) {
+          await this.deleteSession(currentSessionId);
+          this.resetSessionState(currentSessionId);
+        }
+
+        throw new Error(`Sandbox heartbeat failed: ${res.status} ${await res.text()}`);
+      }
+
+      this.lastHeartbeatAt = Date.now();
+    })();
+
+    this.heartbeatPromise = promise;
+
+    try {
+      await promise;
+    } finally {
+      if (this.heartbeatPromise === promise) {
+        this.heartbeatPromise = null;
+      }
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.closePromise) {
+      await this.closePromise;
+      return;
+    }
+
+    const promise = (async () => {
+      if (this.ensurePromise) {
+        try {
+          await this.ensurePromise;
+        } catch {
+          // startup failure already handled by the caller path
+        }
+      }
+
+      const currentSessionId = this.sessionId;
+      if (!currentSessionId) {
+        this.resetSessionState();
+        return;
+      }
+
+      await this.deleteSession(currentSessionId);
+      this.resetSessionState(currentSessionId);
+    })();
+
+    this.closePromise = promise;
+
+    try {
+      await promise;
+    } finally {
+      if (this.closePromise === promise) {
+        this.closePromise = null;
+      }
+    }
+  }
+
+  get id(): string | null {
+    return this.sessionId;
+  }
+
+  get url(): string | null {
+    return this.endpoint;
+  }
+
+  get isActive(): boolean {
+    return this.endpoint !== null;
+  }
+
+  private async bootstrapSession(): Promise<void> {
+    const projectId = this.resolveProjectId();
+    const res = await fetch(`${this.apiUrl}/sandbox-sessions`, {
+      method: "POST",
+      headers: this.jsonHeaders(),
+      body: JSON.stringify(projectId ? { project_id: projectId } : {}),
+    });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({
+        detail: `Failed to create sandbox: ${res.status} ${await res.text()}`,
+      });
+    }
+
+    const session = await res.json();
+    this.sessionId = session.id;
+    this.sessionProjectId = projectId;
+
+    try {
+      const endpoint = await this.resolveReadyEndpoint(session);
+      this.endpoint = endpoint;
+      await this.heartbeat(true);
+      this.startHeartbeatLoop();
+    } catch (error) {
+      const currentSessionId = this.sessionId;
+      if (currentSessionId) {
+        await this.deleteSession(currentSessionId);
+      }
+      this.resetSessionState(currentSessionId ?? undefined);
+      throw error;
+    }
+  }
+
+  private async resolveReadyEndpoint(session: SandboxSessionRecord): Promise<string> {
+    if (session.status === "running") {
+      return session.endpoint;
+    }
+
+    await waitForSandboxReady({
+      apiUrl: this.apiUrl,
+      id: session.id,
+      authToken: this.authToken,
+      maxWaitMs: this.startupTimeoutMs,
+      pollIntervalMs: this.pollIntervalMs,
+    });
+
+    const res = await fetch(`${this.apiUrl}/sandbox-sessions/${session.id}`, {
+      headers: this.authHeaders(),
+    });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({
+        detail: `Failed to get sandbox: ${res.status} ${await res.text()}`,
+      });
+    }
+
+    const nextSession = await res.json();
+    return nextSession.endpoint;
+  }
+
+  private async touchSession(): Promise<void> {
+    const projectId = this.resolveProjectId();
+    if (this.endpoint && this.sessionProjectId !== projectId) {
+      const currentSessionId = this.sessionId;
+      if (currentSessionId) {
+        await this.deleteSession(currentSessionId);
+      }
+      this.resetSessionState(currentSessionId ?? undefined);
+    }
+
+    await this.ensure();
+    await this.heartbeat();
+  }
+
+  private startHeartbeatLoop(): void {
+    if (!this.sessionId || this.heartbeatTimer) return;
+
+    this.heartbeatTimer = setInterval(() => {
+      void this.heartbeat().catch(() => {
+        // next operation will reprovision
+      });
+    }, this.heartbeatIntervalMs);
+  }
+
+  private stopHeartbeatLoop(): void {
+    if (!this.heartbeatTimer) return;
+    clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = null;
+  }
+
+  private async deleteSession(sessionId: string): Promise<void> {
+    await fetch(`${this.apiUrl}/sandbox-sessions/${sessionId}`, {
+      method: "DELETE",
+      headers: this.authHeaders(),
+    });
+  }
+
+  private requireEndpoint(): string {
+    if (!this.endpoint) {
+      throw new Error("Sandbox endpoint unavailable");
+    }
+    return this.endpoint;
+  }
+
+  private resolveProjectId(): string | null {
+    return this.getProjectId() ?? null;
+  }
+
+  private resetSessionState(sessionId?: string): void {
+    if (!sessionId || this.sessionId === sessionId) {
+      this.stopHeartbeatLoop();
+      this.endpoint = null;
+      this.sessionId = null;
+      this.sessionProjectId = null;
+      this.heartbeatPromise = null;
+      this.lastHeartbeatAt = 0;
+    }
+  }
+
+  private authHeaders(): HeadersInit {
+    return { Authorization: `Bearer ${this.authToken}` };
+  }
+
+  private jsonHeaders(): HeadersInit {
+    return {
+      ...this.authHeaders(),
+      "Content-Type": "application/json",
+    };
+  }
+}
+
+function mapCommandJob(json: Record<string, unknown>): CommandJob {
+  return {
+    id: json.id as string,
+    status: json.status as CommandJobStatus,
+    exitCode: json.exit_code as number | null,
+    signal: json.signal as string | null,
+    startedAt: json.started_at as string,
+    finishedAt: json.finished_at as string | null,
+    heartbeatStatus: json.heartbeat_status as "disabled" | "healthy" | "degraded",
+    lastHeartbeatAt: json.last_heartbeat_at as string | null,
+    lastHeartbeatError: json.last_heartbeat_error as string | null,
+    heartbeatFailureCount: json.heartbeat_failure_count as number,
+  };
+}

--- a/src/sandbox/sandbox.test-helpers.ts
+++ b/src/sandbox/sandbox.test-helpers.ts
@@ -7,6 +7,7 @@ export const SANDBOX_ENV_KEYS = [
 ] as const;
 
 const originalSetTimeout = globalThis.setTimeout;
+const originalDateNow = Date.now;
 
 export function installMockFetch(
   state: { calls: FetchCall[]; responses: MockResponseEntry[] },
@@ -24,14 +25,21 @@ export function installMockFetch(
   }) as typeof fetch;
 }
 
-export function mockTimers(): void {
-  (globalThis as Record<string, unknown>).setTimeout = (fn: () => void, _ms?: number) => {
+export function mockTimers(options: { advanceTimeByMs?: boolean } = {}): void {
+  let fakeNow = 0;
+
+  Date.now = () => fakeNow;
+  (globalThis as Record<string, unknown>).setTimeout = (fn: () => void, ms?: number) => {
+    if (options.advanceTimeByMs) {
+      fakeNow += ms ?? 0;
+    }
     return originalSetTimeout(fn, 0);
   };
 }
 
 export function restoreTimers(): void {
   (globalThis as Record<string, unknown>).setTimeout = originalSetTimeout;
+  Date.now = originalDateNow;
 }
 
 export function jsonResponse(body: unknown, status = 200): Response {

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -584,6 +584,252 @@ describe("Sandbox", () => {
     });
   });
 
+  describe("createLazy()", () => {
+    it("waits long enough for pending sandbox sessions to survive operator reconcile lag", async () => {
+      mockTimers({ advanceTimeByMs: true });
+
+      let statusChecks = 0;
+      globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+        const url = typeof input === "string"
+          ? input
+          : input instanceof URL
+          ? input.toString()
+          : input.url;
+        fetchCalls.push({ url, init });
+
+        if (url === "https://api.test.com/sandbox-sessions" && init?.method === "POST") {
+          return Promise.resolve(jsonResponse({
+            id: "sandbox-1",
+            endpoint: "https://sandbox.example.com",
+            status: "pending",
+          }));
+        }
+
+        if (url === "https://api.test.com/sandbox-sessions/sandbox-1" && !init?.method) {
+          statusChecks += 1;
+          return Promise.resolve(jsonResponse({
+            endpoint: "https://sandbox.example.com",
+            status: statusChecks >= 85 ? "running" : "pending",
+          }));
+        }
+
+        if (
+          url === "https://api.test.com/sandbox-sessions/sandbox-1/heartbeat" &&
+          init?.method === "POST"
+        ) {
+          return Promise.resolve(jsonResponse({ ok: true }));
+        }
+
+        if (url === "https://sandbox.example.com/file?path=notes.txt" && !init?.method) {
+          return Promise.resolve(textResponse("file-body"));
+        }
+
+        if (
+          url === "https://api.test.com/sandbox-sessions/sandbox-1" && init?.method === "DELETE"
+        ) {
+          return Promise.resolve(jsonResponse({ ok: true }));
+        }
+
+        throw new Error(`Unexpected fetch call: ${url} ${init?.method ?? "GET"}`);
+      }) as typeof fetch;
+
+      const sandbox = Sandbox.createLazy({
+        authToken: "test-token",
+        apiUrl: "https://api.test.com",
+        heartbeatIntervalMs: 1_000_000,
+      });
+
+      const readPromise = sandbox.readFile("notes.txt");
+      await Promise.resolve();
+
+      assertEquals(await readPromise, "file-body");
+      assertEquals(statusChecks >= 85, true);
+      assertEquals(
+        fetchCalls.some((call) => call.url.endsWith("/sandbox-sessions/sandbox-1/heartbeat")),
+        true,
+      );
+      assertEquals(
+        fetchCalls.some((call) => call.url.endsWith("/file?path=notes.txt")),
+        true,
+      );
+      await sandbox.close();
+    });
+
+    it("cleans up failed startup heartbeats and reprovisions on the next attempt", async () => {
+      mockFetch([
+        jsonResponse({
+          id: "sandbox-1",
+          endpoint: "https://sandbox-1.example.com",
+          status: "running",
+        }),
+        textResponse("heartbeat failed", 503),
+        jsonResponse({ ok: true }),
+        jsonResponse({
+          id: "sandbox-2",
+          endpoint: "https://sandbox-2.example.com",
+          status: "running",
+        }),
+        jsonResponse({ ok: true }),
+        textResponse("file-body"),
+        jsonResponse({ ok: true }),
+      ]);
+
+      const sandbox = Sandbox.createLazy({
+        authToken: "test-token",
+        apiUrl: "https://api.test.com",
+      });
+
+      await assertRejects(
+        () => sandbox.readFile("notes.txt"),
+        Error,
+        "Sandbox heartbeat failed: 503 heartbeat failed",
+      );
+
+      assertEquals(sandbox.isActive, false);
+      assertEquals(await sandbox.readFile("notes.txt"), "file-body");
+      assertEquals(sandbox.isActive, true);
+      assertEquals(
+        fetchCalls.some((call) =>
+          call.url === "https://api.test.com/sandbox-sessions/sandbox-1" &&
+          call.init?.method === "DELETE"
+        ),
+        true,
+      );
+      assertEquals(
+        fetchCalls.some((call) => call.url === "https://sandbox-2.example.com/file?path=notes.txt"),
+        true,
+      );
+      await sandbox.close();
+    });
+
+    it("waits for an in-flight ensure before closing the sandbox session", async () => {
+      let resolveCreate!: (response: Response) => void;
+      let hasResolveCreate = false;
+
+      globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+        const url = typeof input === "string"
+          ? input
+          : input instanceof URL
+          ? input.toString()
+          : input.url;
+        fetchCalls.push({ url, init });
+
+        if (fetchCalls.length === 1) {
+          return new Promise<Response>((resolve) => {
+            resolveCreate = resolve;
+            hasResolveCreate = true;
+          });
+        }
+
+        if (fetchCalls.length === 2) {
+          return Promise.resolve(
+            jsonResponse({
+              ok: true,
+            }),
+          );
+        }
+
+        if (fetchCalls.length === 3) {
+          return Promise.resolve(jsonResponse({ ok: true }));
+        }
+
+        throw new Error(`Unexpected fetch call: ${url}`);
+      }) as typeof fetch;
+
+      const sandbox = Sandbox.createLazy({
+        authToken: "test-token",
+        apiUrl: "https://api.test.com",
+        heartbeatGraceMs: 0,
+      });
+
+      const ensurePromise = sandbox.ensure();
+      await Promise.resolve();
+
+      const closePromise = sandbox.close();
+
+      if (!hasResolveCreate) {
+        throw new Error("Expected create promise resolver to be captured");
+      }
+
+      resolveCreate(
+        jsonResponse({
+          id: "sandbox-1",
+          endpoint: "https://sandbox.example.com",
+          status: "running",
+        }),
+      );
+
+      await ensurePromise;
+      await closePromise;
+
+      assertStringIncludes(fetchCalls[2]!.url, "/sandbox-sessions/sandbox-1");
+      assertEquals(fetchCalls[2]!.init?.method, "DELETE");
+      assertEquals(sandbox.isActive, false);
+    });
+
+    it("keeps an active sandbox session heartbeating until close", async () => {
+      const originalSetInterval = globalThis.setInterval;
+      const originalClearInterval = globalThis.clearInterval;
+      const intervalCallbacks = new Map<number, () => void>();
+      let nextIntervalId = 1;
+
+      globalThis.setInterval = ((handler: TimerHandler) => {
+        const id = nextIntervalId;
+        nextIntervalId += 1;
+        if (typeof handler !== "function") {
+          throw new Error("Expected heartbeat interval handler to be a function");
+        }
+        intervalCallbacks.set(id, () => {
+          handler();
+        });
+        return id as ReturnType<typeof setInterval>;
+      }) as typeof setInterval;
+
+      globalThis.clearInterval = ((id: number) => {
+        intervalCallbacks.delete(id);
+      }) as typeof clearInterval;
+
+      mockFetch([
+        jsonResponse({
+          id: "sandbox-1",
+          endpoint: "https://sandbox.example.com",
+          status: "running",
+        }),
+        jsonResponse({ ok: true }),
+        jsonResponse({ ok: true }),
+        textResponse("file-body"),
+        jsonResponse({ ok: true }),
+        jsonResponse({ ok: true }),
+      ]);
+
+      const sandbox = Sandbox.createLazy({
+        authToken: "test-token",
+        apiUrl: "https://api.test.com",
+        heartbeatGraceMs: 0,
+      });
+
+      try {
+        assertEquals(await sandbox.readFile("notes.txt"), "file-body");
+        assertEquals(intervalCallbacks.size, 1);
+
+        await sandbox.heartbeat();
+        await sandbox.close();
+        const callsAfterClose = fetchCalls.length;
+
+        const heartbeatCalls = fetchCalls.filter((call) =>
+          call.url === "https://api.test.com/sandbox-sessions/sandbox-1/heartbeat"
+        );
+
+        assertEquals(heartbeatCalls.length, 3);
+        assertEquals(fetchCalls.length, callsAfterClose);
+        assertEquals(intervalCallbacks.size, 0);
+      } finally {
+        globalThis.setInterval = originalSetInterval;
+        globalThis.clearInterval = originalClearInterval;
+      }
+    });
+  });
+
   describe("list()", () => {
     it("should list sandbox sessions", async () => {
       mockFetch([

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -16,6 +16,7 @@ import {
 } from "#veryfront/errors";
 import { getVeryfrontCloudAuthToken } from "#veryfront/platform/cloud/resolver.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
+import { LazySandbox, type LazySandboxOptions } from "./lazy-sandbox.ts";
 
 /** Options for command execution: working directory, timeout, and environment variables. */
 export interface ExecOptions {
@@ -35,6 +36,25 @@ export interface SandboxOptions {
   authToken?: string;
   /** Optional project context for project-billed / project-scoped sandbox sessions. */
   projectId?: string;
+}
+
+export function resolveSandboxApiUrl(options: SandboxOptions = {}): string {
+  return options.apiUrl ||
+    getHostEnv("VERYFRONT_API_URL") ||
+    "https://api.veryfront.com";
+}
+
+export function resolveSandboxAuthToken(options: SandboxOptions = {}): string {
+  const authToken = options.authToken?.trim() || getVeryfrontCloudAuthToken();
+  if (authToken) return authToken;
+
+  throw toError(
+    createError({
+      type: "config",
+      message:
+        "Sandbox auth not configured. Set VERYFRONT_API_TOKEN, provide request-scoped Veryfront credentials, or pass authToken explicitly.",
+    }),
+  );
 }
 
 /** Result of a command execution: stdout, stderr, and exit code. */
@@ -115,22 +135,11 @@ export class Sandbox {
   ) {}
 
   private static resolveApiUrl(options: SandboxOptions = {}): string {
-    return options.apiUrl ||
-      getHostEnv("VERYFRONT_API_URL") ||
-      "https://api.veryfront.com";
+    return resolveSandboxApiUrl(options);
   }
 
   private static resolveAuthToken(options: SandboxOptions = {}): string {
-    const authToken = options.authToken?.trim() || getVeryfrontCloudAuthToken();
-    if (authToken) return authToken;
-
-    throw toError(
-      createError({
-        type: "config",
-        message:
-          "Sandbox auth not configured. Set VERYFRONT_API_TOKEN, provide request-scoped Veryfront credentials, or pass authToken explicitly.",
-      }),
-    );
+    return resolveSandboxAuthToken(options);
   }
 
   /** Create a new sandbox session. Claims a warm pod or creates a new one. */
@@ -230,26 +239,12 @@ export class Sandbox {
     maxWaitMs = 60_000,
     pollIntervalMs = 2_000,
   ): Promise<void> {
-    const start = Date.now();
-    while (Date.now() - start < maxWaitMs) {
-      // no cleanup needed: one-shot
-      await new Promise((r) => setTimeout(r, pollIntervalMs));
+    await waitForSandboxReady({ apiUrl, id, authToken, maxWaitMs, pollIntervalMs });
+  }
 
-      const res = await fetch(`${apiUrl}/sandbox-sessions/${id}`, {
-        headers: { Authorization: `Bearer ${authToken}` },
-      });
-
-      if (res.ok) {
-        const data = await res.json();
-        if (data.status === "running") return;
-        if (data.status === "error" || data.status === "deleting") {
-          throw INITIALIZATION_ERROR.create({
-            detail: `Sandbox failed to start: status=${data.status}`,
-          });
-        }
-      }
-    }
-    throw TIMEOUT_ERROR.create({ detail: "Sandbox did not become ready within timeout" });
+  /** Create a lazily-provisioned sandbox session with automatic heartbeats. */
+  static createLazy(options: LazySandboxOptions = {}): LazySandbox {
+    return new LazySandbox(options);
   }
 
   /** Execute a bash command in the sandbox and return buffered result. */
@@ -483,4 +478,38 @@ export class Sandbox {
   get url(): string {
     return this.endpoint;
   }
+}
+
+export async function waitForSandboxReady(input: {
+  apiUrl: string;
+  id: string;
+  authToken: string;
+  maxWaitMs?: number;
+  pollIntervalMs?: number;
+}): Promise<void> {
+  const maxWaitMs = input.maxWaitMs ?? 60_000;
+  const pollIntervalMs = input.pollIntervalMs ?? 2_000;
+  const start = Date.now();
+
+  while (Date.now() - start < maxWaitMs) {
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+
+    const res = await fetch(`${input.apiUrl}/sandbox-sessions/${input.id}`, {
+      headers: { Authorization: `Bearer ${input.authToken}` },
+    });
+
+    if (!res.ok) {
+      continue;
+    }
+
+    const data = await res.json();
+    if (data.status === "running") return;
+    if (data.status === "error" || data.status === "deleting") {
+      throw INITIALIZATION_ERROR.create({
+        detail: `Sandbox failed to start: status=${data.status}`,
+      });
+    }
+  }
+
+  throw TIMEOUT_ERROR.create({ detail: "Sandbox did not become ready within timeout" });
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.275";
+export const VERSION = "0.1.276";


### PR DESCRIPTION
## Summary
- add a framework-owned LazySandbox and Sandbox.createLazy() entrypoint
- document the new lazy sandbox lifecycle surface
- lock startup wait, startup-heartbeat recovery, close/ensure ordering, and steady-state heartbeats with regression tests
- bump the framework release metadata for the next publish

## Testing
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/sandbox/sandbox.test.ts
- deno check src/sandbox/index.ts src/sandbox/sandbox.ts src/sandbox/lazy-sandbox.ts src/sandbox/sandbox.test.ts src/sandbox/sandbox.test-helpers.ts
- deno task docs:validate

## Notes
- This is the first coherent Phase 1 sandbox batch
- exec retry/reprovision and command-job endpoint coordination stay local for later follow-ups