### PR TITLE
Preserve sandbox heartbeat and close failures in the framework client

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.276",
+  "version": "0.1.277",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -566,6 +566,21 @@ describe("Sandbox", () => {
       assertEquals(fetchCalls[1]!.init?.method, "POST");
       assertEquals(headerValue(fetchCalls, 1, "Authorization"), "Bearer token");
     });
+
+    it("should throw on heartbeat failure", async () => {
+      mockFetch([
+        jsonResponse({ id: "s6", endpoint: "https://sb.test", status: "running" }),
+        textResponse("upstream timeout", 503),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+
+      await assertRejects(
+        () => sandbox.heartbeat(),
+        Error,
+        "Sandbox heartbeat failed: 503 upstream timeout",
+      );
+    });
   });
 
   describe("close()", () => {
@@ -581,6 +596,21 @@ describe("Sandbox", () => {
       assertStringIncludes(fetchCalls[1]!.url, "/sandbox-sessions/s7");
       assertEquals(fetchCalls[1]!.init?.method, "DELETE");
       assertEquals(headerValue(fetchCalls, 1, "Authorization"), "Bearer token");
+    });
+
+    it("should throw on close failure", async () => {
+      mockFetch([
+        jsonResponse({ id: "s7", endpoint: "https://sb.test", status: "running" }),
+        textResponse("delete failed", 503),
+      ]);
+
+      const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
+
+      await assertRejects(
+        () => sandbox.close(),
+        Error,
+        "Close sandbox failed: 503 delete failed",
+      );
     });
   });
 

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -455,18 +455,30 @@ export class Sandbox {
 
   /** Send a heartbeat to prevent idle timeout. */
   async heartbeat(): Promise<void> {
-    await fetch(`${this.apiUrl}/sandbox-sessions/${this.sessionId}/heartbeat`, {
+    const res = await fetch(`${this.apiUrl}/sandbox-sessions/${this.sessionId}/heartbeat`, {
       method: "POST",
       headers: { Authorization: `Bearer ${this.authToken}` },
     });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({
+        detail: `Sandbox heartbeat failed: ${res.status} ${await res.text()}`,
+      });
+    }
   }
 
   /** Close the sandbox session and mark for deletion. */
   async close(): Promise<void> {
-    await fetch(`${this.apiUrl}/sandbox-sessions/${this.sessionId}`, {
+    const res = await fetch(`${this.apiUrl}/sandbox-sessions/${this.sessionId}`, {
       method: "DELETE",
       headers: { Authorization: `Bearer ${this.authToken}` },
     });
+
+    if (!res.ok) {
+      throw REQUEST_ERROR.create({
+        detail: `Close sandbox failed: ${res.status} ${await res.text()}`,
+      });
+    }
   }
 
   /** Get the session ID. */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.276";
+export const VERSION = "0.1.277";


### PR DESCRIPTION
## Summary
- make framework Sandbox.heartbeat() throw on non-2xx responses
- make framework Sandbox.close() throw on non-2xx responses
- add regression coverage for both failure paths
- bump framework release metadata for the next Phase 1 adoption step

## Testing
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/sandbox/sandbox.test.ts
- deno check src/sandbox/sandbox.ts src/sandbox/sandbox.test.ts src/utils/version-constant.ts

## Notes
- this follows the lazy sandbox lifecycle batch and preserves the failure signals the agent still relies on for local invalidation/logging policy