### PR TITLE
Expose project references through the framework sandbox command surface

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "veryfront",
   "version": "0.1.277",
+  "version": "0.1.278",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/sandbox.md
+++ b/docs/reference/sandbox.md
@@ -45,13 +45,13 @@ Create a lazily-provisioned sandbox client that only claims a session on first u
 
 **Returns:** <code>LazySandbox</code>
 
-### `sandbox.executeCommand(command)`
+### `sandbox.executeCommand(command, options?)`
 
 Execute a bash command in the sandbox and return buffered result.
 
 **Returns:** <code>Promise&lt;ExecResult&gt;</code>
 
-### `sandbox.executeStream(command)`
+### `sandbox.executeStream(command, options?)`
 
 Execute a bash command with streaming output (NDJSON).
 

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -413,6 +413,7 @@ describe("Sandbox", () => {
         cwd: "/workspace/app",
         timeout_seconds: 30,
         env: { NODE_ENV: "test" },
+        projectReference: "project-123",
       });
 
       assertEquals(result.stdout, "ok\n");
@@ -422,6 +423,7 @@ describe("Sandbox", () => {
         cwd: "/workspace/app",
         timeout_seconds: 30,
         env: { NODE_ENV: "test" },
+        projectReference: "project-123",
       });
     });
 
@@ -452,12 +454,21 @@ describe("Sandbox", () => {
 
       const sandbox = await Sandbox.create({ authToken: "token", apiUrl: "https://api.test.com" });
       const events: ExecStreamEvent[] = [];
-      for await (const event of sandbox.executeStream("cmd", { cwd: "/tmp" })) {
+      for await (
+        const event of sandbox.executeStream("cmd", {
+          cwd: "/tmp",
+          projectReference: "project-456",
+        })
+      ) {
         events.push(event);
       }
 
       assertEquals(events.length, 2);
-      assertEquals(jsonBody(fetchCalls, 1), { command: "cmd", cwd: "/tmp" });
+      assertEquals(jsonBody(fetchCalls, 1), {
+        command: "cmd",
+        cwd: "/tmp",
+        projectReference: "project-456",
+      });
     });
   });
 
@@ -484,6 +495,7 @@ describe("Sandbox", () => {
         cwd: "/workspace",
         timeout_seconds: 120,
         env: { CI: "true" },
+        projectReference: "project-789",
       });
 
       assertEquals(job.id, "job-opts");
@@ -492,6 +504,7 @@ describe("Sandbox", () => {
         cwd: "/workspace",
         timeout_seconds: 120,
         env: { CI: "true" },
+        projectReference: "project-789",
       });
     });
   });

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -18,7 +18,7 @@ import { getVeryfrontCloudAuthToken } from "#veryfront/platform/cloud/resolver.t
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { LazySandbox, type LazySandboxOptions } from "./lazy-sandbox.ts";
 
-/** Options for command execution: working directory, timeout, and environment variables. */
+/** Options for command execution: working directory, timeout, environment variables, and optional project reference. */
 export interface ExecOptions {
   /** Working directory for the command. */
   cwd?: string;
@@ -26,6 +26,8 @@ export interface ExecOptions {
   timeout_seconds?: number;
   /** Additional environment variables for the command. */
   env?: Record<string, string>;
+  /** Optional project reference forwarded to sandbox command surfaces that support project-scoped execution. */
+  projectReference?: string;
 }
 
 /** Options for creating a sandbox session. */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.277";
+export const VERSION = "0.1.278";


### PR DESCRIPTION
## Summary
- add optional `projectReference` to framework sandbox command options
- forward it through execute, stream, and async command-job payloads
- document and regression-test the new additive option
- bump framework release metadata for the next publish

## Testing
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/sandbox/sandbox.test.ts
- deno check src/sandbox/sandbox.ts src/sandbox/sandbox.test.ts docs/reference/sandbox.md src/utils/version-constant.ts

## Notes
- additive only: existing consumers continue to work unchanged
- this unblocks a larger agent-side cleanup batch that can stop encoding project scope into raw command strings