### PR TITLE
Preserve lazy sandbox job continuity before the hosted cleanup

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "veryfront",
   "version": "0.1.277",
-  "version": "0.1.278",
+  "version": "0.1.279",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -38,6 +38,14 @@ const sandbox = Sandbox.createLazy({
 });
 ```
 
+If your project context can change over time, prefer `getProjectId()` so lazy exec and async job calls inherit the latest project reference automatically:
+
+```ts
+const sandbox = Sandbox.createLazy({
+  getProjectId: () => currentProjectId,
+});
+```
+
 If you need to override the resolved credentials, pass `authToken`
 explicitly. This can be a JWT or a Studio-generated API key.
 

--- a/docs/plans/phase-2-lazy-sandbox-job-continuity.md
+++ b/docs/plans/phase-2-lazy-sandbox-job-continuity.md
@@ -1,0 +1,17 @@
+# Phase 2 lazy sandbox job continuity
+
+This batch closes the next framework gap that blocks a larger hosted-agent sandbox cleanup.
+
+## Add now
+- command-job endpoint tracking inside framework `LazySandbox`
+- heartbeat preservation while async command jobs are active
+- lazy default `projectReference` propagation from `getProjectId()` when callers do not supply one explicitly
+
+## Lock now
+- active command jobs keep their original endpoint reachable even if the current session heartbeat fails
+- lazy heartbeats pause while async jobs are active and resume when the tracked set returns to zero
+- `executeStream()` and `startCommandJob()` forward `projectReference` from lazy project context by default
+
+## Keep for later
+- full hosted-agent replacement of the local `LazySandbox` owner
+- hosted-agent-specific knowledge-ingest routing and runtime endpoint rewrite policy

--- a/docs/reference/sandbox.md
+++ b/docs/reference/sandbox.md
@@ -41,7 +41,7 @@ Reconnect to an existing sandbox session.
 
 ### `Sandbox.createLazy(options?)`
 
-Create a lazily-provisioned sandbox client that only claims a session on first use, sends an initial heartbeat before marking the session ready, and keeps the session alive until `close()`.
+Create a lazily-provisioned sandbox client that only claims a session on first use, sends an initial heartbeat before marking the session ready, pauses background heartbeats while async command jobs are active, and keeps the session alive until `close()`.
 
 **Returns:** <code>LazySandbox</code>
 
@@ -144,7 +144,7 @@ Options for a lazily-provisioned sandbox session.
 | `apiUrl?`              | `string`                            | Base URL of the Veryfront API.                                                           |
 | `authToken?`           | `string`                            | Explicit Veryfront auth token or API key override.                                       |
 | `projectId?`           | `string`                            | Initial project-scoped billing or isolation context.                                     |
-| `getProjectId?`        | `() => string \| null \| undefined` | Deferred resolver used at first provision time and on later project-context sync checks. |
+| `getProjectId?`        | `() => string \| null \| undefined` | Deferred resolver used at first provision time, on later project-context sync checks, and as the default `projectReference` for lazy exec/job calls when callers do not override it. |
 | `startupTimeoutMs?`    | `number`                            | Maximum time to wait for pending sessions to become ready. Defaults to 180000.           |
 | `pollIntervalMs?`      | `number`                            | Poll interval while waiting for readiness. Defaults to 2000.                             |
 | `heartbeatIntervalMs?` | `number`                            | Background heartbeat interval for active sessions. Defaults to 30000.                    |

--- a/src/sandbox/lazy-sandbox.ts
+++ b/src/sandbox/lazy-sandbox.ts
@@ -49,6 +49,7 @@ export class LazySandbox {
   private heartbeatPromise: Promise<void> | null = null;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private lastHeartbeatAt = 0;
+  private readonly activeCommandJobEndpoints = new Map<string, string>();
 
   constructor(options: LazySandboxOptions = {}) {
     this.apiUrl = resolveSandboxApiUrl(options);
@@ -107,7 +108,7 @@ export class LazySandbox {
     const res = await fetch(`${this.requireEndpoint()}/exec`, {
       method: "POST",
       headers: this.jsonHeaders(),
-      body: JSON.stringify({ command, ...options }),
+      body: JSON.stringify({ command, ...this.resolveExecOptions(options) }),
     });
 
     if (!res.ok) {
@@ -173,11 +174,12 @@ export class LazySandbox {
 
   async startCommandJob(command: string, options?: ExecOptions): Promise<CommandJob> {
     await this.touchSession();
+    const endpoint = this.requireEndpoint();
 
-    const res = await fetch(`${this.requireEndpoint()}/exec/jobs`, {
+    const res = await fetch(`${endpoint}/exec/jobs`, {
       method: "POST",
       headers: this.jsonHeaders(),
-      body: JSON.stringify({ command, ...options }),
+      body: JSON.stringify({ command, ...this.resolveExecOptions(options) }),
     });
 
     if (!res.ok) {
@@ -186,13 +188,15 @@ export class LazySandbox {
       });
     }
 
-    return mapCommandJob(await res.json());
+    const job = mapCommandJob(await res.json());
+    this.updateTrackedCommandJob(job, endpoint);
+    return job;
   }
 
   async getCommandJob(jobId: string): Promise<CommandJob> {
-    await this.ensure();
+    const endpoint = await this.resolveCommandJobEndpoint(jobId);
 
-    const res = await fetch(`${this.requireEndpoint()}/exec/jobs/${jobId}`, {
+    const res = await fetch(`${endpoint}/exec/jobs/${jobId}`, {
       headers: this.authHeaders(),
     });
 
@@ -202,13 +206,15 @@ export class LazySandbox {
       });
     }
 
-    return mapCommandJob(await res.json());
+    const job = mapCommandJob(await res.json());
+    this.updateTrackedCommandJob(job, endpoint);
+    return job;
   }
 
   async getCommandJobOutput(jobId: string): Promise<CommandJobOutput> {
-    await this.ensure();
+    const endpoint = await this.resolveCommandJobEndpoint(jobId);
 
-    const res = await fetch(`${this.requireEndpoint()}/exec/jobs/${jobId}/output`, {
+    const res = await fetch(`${endpoint}/exec/jobs/${jobId}/output`, {
       headers: this.authHeaders(),
     });
 
@@ -219,13 +225,15 @@ export class LazySandbox {
     }
 
     const json = await res.json();
-    return {
+    const output = {
       ...mapCommandJob(json),
       stdout: json.stdout,
       stderr: json.stderr,
       stdoutTruncated: json.stdout_truncated,
       stderrTruncated: json.stderr_truncated,
     };
+    this.updateTrackedCommandJob(output, endpoint);
+    return output;
   }
 
   async listCommandJobs(): Promise<CommandJob[]> {
@@ -247,9 +255,9 @@ export class LazySandbox {
   }
 
   async cancelCommandJob(jobId: string): Promise<CommandJob> {
-    await this.ensure();
+    const endpoint = await this.resolveCommandJobEndpoint(jobId);
 
-    const res = await fetch(`${this.requireEndpoint()}/exec/jobs/${jobId}/cancel`, {
+    const res = await fetch(`${endpoint}/exec/jobs/${jobId}/cancel`, {
       method: "POST",
       headers: this.authHeaders(),
     });
@@ -260,7 +268,9 @@ export class LazySandbox {
       });
     }
 
-    return mapCommandJob(await res.json());
+    const job = mapCommandJob(await res.json());
+    this.updateTrackedCommandJob(job, endpoint);
+    return job;
   }
 
   async heartbeat(force = false): Promise<void> {
@@ -287,8 +297,10 @@ export class LazySandbox {
 
       if (!res.ok) {
         if (this.sessionId === currentSessionId) {
-          await this.deleteSession(currentSessionId);
-          this.resetSessionState(currentSessionId);
+          if (this.activeCommandJobEndpoints.size === 0) {
+            await this.deleteSession(currentSessionId);
+            this.resetSessionState(currentSessionId);
+          }
         }
 
         throw new Error(`Sandbox heartbeat failed: ${res.status} ${await res.text()}`);
@@ -431,7 +443,7 @@ export class LazySandbox {
   }
 
   private startHeartbeatLoop(): void {
-    if (!this.sessionId || this.heartbeatTimer) return;
+    if (!this.sessionId || this.heartbeatTimer || this.activeCommandJobEndpoints.size > 0) return;
 
     this.heartbeatTimer = setInterval(() => {
       void this.heartbeat().catch(() => {
@@ -467,11 +479,43 @@ export class LazySandbox {
   private resetSessionState(sessionId?: string): void {
     if (!sessionId || this.sessionId === sessionId) {
       this.stopHeartbeatLoop();
+      this.activeCommandJobEndpoints.clear();
       this.endpoint = null;
       this.sessionId = null;
       this.sessionProjectId = null;
       this.heartbeatPromise = null;
       this.lastHeartbeatAt = 0;
+    }
+  }
+
+  private resolveExecOptions(options?: ExecOptions): ExecOptions | undefined {
+    const projectReference = options?.projectReference ?? this.resolveProjectId() ?? undefined;
+    return projectReference ? { ...options, projectReference } : options;
+  }
+
+  private async resolveCommandJobEndpoint(jobId: string): Promise<string> {
+    const trackedEndpoint = this.activeCommandJobEndpoints.get(jobId);
+    if (trackedEndpoint) {
+      return trackedEndpoint;
+    }
+
+    await this.ensure();
+    return this.requireEndpoint();
+  }
+
+  private updateTrackedCommandJob(job: Pick<CommandJob, "id" | "status">, endpoint: string): void {
+    if (job.status === "running") {
+      this.activeCommandJobEndpoints.set(job.id, endpoint);
+      this.stopHeartbeatLoop();
+      return;
+    }
+
+    if (!this.activeCommandJobEndpoints.delete(job.id)) {
+      return;
+    }
+
+    if (this.activeCommandJobEndpoints.size === 0 && this.endpoint) {
+      this.startHeartbeatLoop();
     }
   }
 

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -871,6 +871,211 @@ describe("Sandbox", () => {
         globalThis.clearInterval = originalClearInterval;
       }
     });
+
+    it("forwards projectReference from lazy project context for exec and async jobs", async () => {
+      mockFetch([
+        jsonResponse({
+          id: "sandbox-1",
+          endpoint: "https://sandbox.example.com",
+          status: "running",
+        }),
+        jsonResponse({ ok: true }),
+        ndjsonResponse([
+          { type: "stdout", data: "ok\n" },
+          { type: "exit", exitCode: 0 },
+        ]),
+        jsonResponse({
+          id: "job-1",
+          status: "completed",
+          exit_code: 0,
+          signal: null,
+          started_at: "2026-01-01T00:00:00Z",
+          finished_at: "2026-01-01T00:00:01Z",
+          heartbeat_status: "disabled",
+          last_heartbeat_at: null,
+          last_heartbeat_error: null,
+          heartbeat_failure_count: 0,
+        }),
+        jsonResponse({ ok: true }),
+      ]);
+
+      const sandbox = Sandbox.createLazy({
+        authToken: "test-token",
+        apiUrl: "https://api.test.com",
+        getProjectId: () => "project-123",
+      });
+
+      try {
+        await sandbox.executeCommand("echo ok");
+        await sandbox.startCommandJob("npm test");
+
+        assertEquals(jsonBody(fetchCalls, 2), {
+          command: "echo ok",
+          projectReference: "project-123",
+        });
+        assertEquals(jsonBody(fetchCalls, 3), {
+          command: "npm test",
+          projectReference: "project-123",
+        });
+      } finally {
+        await sandbox.close();
+      }
+    });
+
+    it("pauses heartbeats while async jobs are active and resumes them after the job completes", async () => {
+      const originalSetInterval = globalThis.setInterval;
+      const originalClearInterval = globalThis.clearInterval;
+      const intervalCallbacks = new Map<number, () => void>();
+      let nextIntervalId = 1;
+
+      globalThis.setInterval = ((handler: TimerHandler) => {
+        const id = nextIntervalId;
+        nextIntervalId += 1;
+        if (typeof handler !== "function") {
+          throw new Error("Expected heartbeat interval handler to be a function");
+        }
+        intervalCallbacks.set(id, () => {
+          handler();
+        });
+        return id as ReturnType<typeof setInterval>;
+      }) as typeof setInterval;
+
+      globalThis.clearInterval = ((id: number) => {
+        intervalCallbacks.delete(id);
+      }) as typeof clearInterval;
+
+      mockFetch([
+        jsonResponse({
+          id: "sandbox-1",
+          endpoint: "https://sandbox-1.example.com",
+          status: "running",
+        }),
+        jsonResponse({ ok: true }),
+        jsonResponse({
+          id: "job-1",
+          status: "running",
+          exit_code: null,
+          signal: null,
+          started_at: "2026-01-01T00:00:00Z",
+          finished_at: null,
+          heartbeat_status: "disabled",
+          last_heartbeat_at: null,
+          last_heartbeat_error: null,
+          heartbeat_failure_count: 0,
+        }),
+        jsonResponse({
+          id: "job-1",
+          status: "completed",
+          exit_code: 0,
+          signal: null,
+          started_at: "2026-01-01T00:00:00Z",
+          finished_at: "2026-01-01T00:01:00Z",
+          heartbeat_status: "healthy",
+          last_heartbeat_at: "2026-01-01T00:00:30Z",
+          last_heartbeat_error: null,
+          heartbeat_failure_count: 0,
+          stdout: "done\n",
+          stderr: "",
+          stdout_truncated: false,
+          stderr_truncated: false,
+        }),
+        jsonResponse({ ok: true }),
+      ]);
+
+      const sandbox = Sandbox.createLazy({
+        authToken: "test-token",
+        apiUrl: "https://api.test.com",
+      });
+
+      try {
+        const job = await sandbox.startCommandJob("npm test");
+        assertEquals(job.status, "running");
+        assertEquals(intervalCallbacks.size, 0);
+
+        const output = await sandbox.getCommandJobOutput("job-1");
+        assertEquals(output.status, "completed");
+        assertEquals(output.stdout, "done\n");
+        assertEquals(intervalCallbacks.size, 1);
+        assertEquals(
+          fetchCalls.some((call) =>
+            call.url === "https://sandbox-1.example.com/exec/jobs/job-1/output"
+          ),
+          true,
+        );
+      } finally {
+        await sandbox.close();
+        globalThis.setInterval = originalSetInterval;
+        globalThis.clearInterval = originalClearInterval;
+      }
+    });
+
+    it("preserves the current session when a heartbeat fails while async jobs are active", async () => {
+      mockFetch([
+        jsonResponse({
+          id: "sandbox-1",
+          endpoint: "https://sandbox-1.example.com",
+          status: "running",
+        }),
+        jsonResponse({ ok: true }),
+        jsonResponse({
+          id: "job-1",
+          status: "running",
+          exit_code: null,
+          signal: null,
+          started_at: "2026-01-01T00:00:00Z",
+          finished_at: null,
+          heartbeat_status: "disabled",
+          last_heartbeat_at: null,
+          last_heartbeat_error: null,
+          heartbeat_failure_count: 0,
+        }),
+        textResponse("upstream timeout", 503),
+        jsonResponse({
+          id: "job-1",
+          status: "completed",
+          exit_code: 0,
+          signal: null,
+          started_at: "2026-01-01T00:00:00Z",
+          finished_at: "2026-01-01T00:01:00Z",
+          heartbeat_status: "healthy",
+          last_heartbeat_at: "2026-01-01T00:00:30Z",
+          last_heartbeat_error: null,
+          heartbeat_failure_count: 0,
+          stdout: "done\n",
+          stderr: "",
+          stdout_truncated: false,
+          stderr_truncated: false,
+        }),
+        jsonResponse({ ok: true }),
+      ]);
+
+      const sandbox = Sandbox.createLazy({
+        authToken: "test-token",
+        apiUrl: "https://api.test.com",
+      });
+
+      try {
+        await sandbox.startCommandJob("npm test");
+
+        await assertRejects(
+          () => sandbox.heartbeat(true),
+          Error,
+          "Sandbox heartbeat failed: 503 upstream timeout",
+        );
+
+        assertEquals(sandbox.isActive, true);
+        const output = await sandbox.getCommandJobOutput("job-1");
+        assertEquals(output.status, "completed");
+        assertEquals(
+          fetchCalls.some((call) =>
+            call.url === "https://sandbox-1.example.com/exec/jobs/job-1/output"
+          ),
+          true,
+        );
+      } finally {
+        await sandbox.close();
+      }
+    });
   });
 
   describe("list()", () => {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.278";
+export const VERSION = "0.1.279";


### PR DESCRIPTION
## Summary
- track async job endpoints inside framework LazySandbox so job polling/output/cancel stay reachable without the hosted runtime owning that map
- pause lazy heartbeats while async jobs are active and preserve the current session if a heartbeat fails during a running job
- default lazy exec/job projectReference from getProjectId() and document the new behavior

## Verification
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/sandbox/sandbox.test.ts
- deno check src/sandbox/lazy-sandbox.ts src/sandbox/sandbox.ts src/sandbox/sandbox.test.ts
- deno task docs:validate
- deno task typecheck

## Notes
- deno task verify:quick still stops on existing repo-wide no-default-export style violations in src/utils/clsx.ts and src/utils/mime-types.ts, outside this diff