### PR TITLE
Expose sandbox attachment before the hosted bridge cleanup

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "veryfront",
   "version": "0.1.277",
-  "version": "0.1.279",
+  "version": "0.1.280",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -30,6 +30,15 @@ You can also reconnect to an existing session:
 const sandbox = await Sandbox.get(sessionId);
 ```
 
+If you already know both the sandbox session ID and its runtime endpoint, attach without doing a reconnect lookup:
+
+```ts
+const sandbox = Sandbox.attach({
+  id: sessionId,
+  endpoint: sandboxEndpoint,
+});
+```
+
 If you want to defer session creation until the first command or file operation, use the lazy client:
 
 ```ts

--- a/docs/plans/phase-2-framework-attach.md
+++ b/docs/plans/phase-2-framework-attach.md
@@ -1,0 +1,12 @@
+# Phase 2 framework attach seam
+
+This framework slice exposes a public sandbox attach/reconnect seam so the hosted runtime can stop using a local private-constructor bridge.
+
+## Add now
+- a public `Sandbox.attach(...)` factory that accepts an already-known endpoint/session/auth/api tuple
+- coverage proving attached clients reuse the known endpoint/session without a lookup round-trip
+- reference docs for the new seam
+
+## Unlocks next
+- delete `src/tools/sandbox/frameworkSandboxBridge.ts` in veryfront-agent
+- remove one more local transport adapter file from the hosted runtime

--- a/docs/reference/sandbox.md
+++ b/docs/reference/sandbox.md
@@ -39,6 +39,12 @@ Reconnect to an existing sandbox session.
 
 **Returns:** <code>Promise&lt;Sandbox&gt;</code>
 
+### `Sandbox.attach(attachment)`
+
+Attach to an already-known sandbox session and endpoint without a reconnect lookup.
+
+**Returns:** <code>Sandbox</code>
+
 ### `Sandbox.createLazy(options?)`
 
 Create a lazily-provisioned sandbox client that only claims a session on first use, sends an initial heartbeat before marking the session ready, pauses background heartbeats while async command jobs are active, and keeps the session alive until `close()`.
@@ -135,6 +141,18 @@ Options for creating a sandbox session.
 | `authToken?` | `string` | Explicit Veryfront auth token or API key override. Defaults to request-scoped credentials or `VERYFRONT_API_TOKEN`. |
 | `projectId?` | `string` | Optional project context for project-scoped or project-billed sandbox sessions.                                     |
 
+### `SandboxAttachment`
+
+Known sandbox session details for `Sandbox.attach(...)`.
+
+| Property   | Type     | Description                                                                                                         |
+| ---------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
+| `id`       | `string` | Existing sandbox session ID.                                                                                        |
+| `endpoint` | `string` | Existing sandbox runtime endpoint URL.                                                                              |
+| `apiUrl?`  | `string` | Base URL of the Veryfront API. Defaults to VERYFRONT_API_URL env.                                                   |
+| `authToken?` | `string` | Explicit Veryfront auth token or API key override. Defaults to request-scoped credentials or `VERYFRONT_API_TOKEN`. |
+| `projectId?` | `string` | Optional project context metadata when the caller wants to preserve the same options shape as other sandbox factories. |
+
 ### `LazySandboxOptions`
 
 Options for a lazily-provisioned sandbox session.
@@ -217,6 +235,7 @@ Command job with captured stdout/stderr.
 | `ExecStreamEvent`    | Streaming event emitted during command execution.             |
 | `LazySandboxOptions` | Options for lazily-provisioned sandbox sessions.              |
 | `SandboxOptions`     | Options for creating a sandbox session.                       |
+| `SandboxAttachment`  | Known sandbox session details used for `Sandbox.attach(...)`. |
 
 ## Related
 

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -18,6 +18,7 @@
  */
 
 export {
+  type SandboxAttachment,
   type CommandJob,
   type CommandJobHeartbeatStatus,
   type CommandJobOutput,

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -18,7 +18,6 @@
  */
 
 export {
-  type SandboxAttachment,
   type CommandJob,
   type CommandJobHeartbeatStatus,
   type CommandJobOutput,
@@ -27,6 +26,7 @@ export {
   type ExecResult,
   type ExecStreamEvent,
   Sandbox,
+  type SandboxAttachment,
   type SandboxListOptions,
   type SandboxListResult,
   type SandboxOptions,

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -298,8 +298,14 @@ describe("Sandbox", () => {
       await sandbox.close();
 
       assertEquals(fetchCalls.length, 3);
-      assertEquals(fetchCalls[0]!.url, "https://attached.example.com/file?path=%2Fworkspace%2Fnote.txt");
-      assertEquals(fetchCalls[1]!.url, "https://api.test.com/sandbox-sessions/attached-1/heartbeat");
+      assertEquals(
+        fetchCalls[0]!.url,
+        "https://attached.example.com/file?path=%2Fworkspace%2Fnote.txt",
+      );
+      assertEquals(
+        fetchCalls[1]!.url,
+        "https://api.test.com/sandbox-sessions/attached-1/heartbeat",
+      );
       assertEquals(fetchCalls[2]!.url, "https://api.test.com/sandbox-sessions/attached-1");
       assertEquals(headerValue(fetchCalls, 0, "Authorization"), "Bearer attach-token");
     });
@@ -318,7 +324,10 @@ describe("Sandbox", () => {
       });
 
       assertEquals(await sandbox.readFile("/workspace/env.txt"), "env body");
-      assertEquals(fetchCalls[0]!.url, "https://attached-env.example.com/file?path=%2Fworkspace%2Fenv.txt");
+      assertEquals(
+        fetchCalls[0]!.url,
+        "https://attached-env.example.com/file?path=%2Fworkspace%2Fenv.txt",
+      );
       assertEquals(headerValue(fetchCalls, 0, "Authorization"), "Bearer vf_attach_env");
     });
   });

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -276,6 +276,53 @@ describe("Sandbox", () => {
     });
   });
 
+  describe("attach()", () => {
+    it("should attach to an already-known sandbox session without a reconnect lookup", async () => {
+      mockFetch([
+        textResponse("attached body"),
+        jsonResponse({ ok: true }),
+        jsonResponse({ ok: true }),
+      ]);
+
+      const sandbox = Sandbox.attach({
+        id: "attached-1",
+        endpoint: "https://attached.example.com",
+        authToken: "attach-token",
+        apiUrl: "https://api.test.com",
+      });
+
+      assertEquals(sandbox.id, "attached-1");
+      assertEquals(sandbox.url, "https://attached.example.com");
+      assertEquals(await sandbox.readFile("/workspace/note.txt"), "attached body");
+      await sandbox.heartbeat();
+      await sandbox.close();
+
+      assertEquals(fetchCalls.length, 3);
+      assertEquals(fetchCalls[0]!.url, "https://attached.example.com/file?path=%2Fworkspace%2Fnote.txt");
+      assertEquals(fetchCalls[1]!.url, "https://api.test.com/sandbox-sessions/attached-1/heartbeat");
+      assertEquals(fetchCalls[2]!.url, "https://api.test.com/sandbox-sessions/attached-1");
+      assertEquals(headerValue(fetchCalls, 0, "Authorization"), "Bearer attach-token");
+    });
+
+    it("should resolve authToken and apiUrl from environment when omitted", async () => {
+      setEnv("VERYFRONT_API_TOKEN", "vf_attach_env");
+      setEnv("VERYFRONT_API_URL", "https://attach.api.test");
+
+      mockFetch([
+        textResponse("env body"),
+      ]);
+
+      const sandbox = Sandbox.attach({
+        id: "attached-env",
+        endpoint: "https://attached-env.example.com",
+      });
+
+      assertEquals(await sandbox.readFile("/workspace/env.txt"), "env body");
+      assertEquals(fetchCalls[0]!.url, "https://attached-env.example.com/file?path=%2Fworkspace%2Fenv.txt");
+      assertEquals(headerValue(fetchCalls, 0, "Authorization"), "Bearer vf_attach_env");
+    });
+  });
+
   describe("executeCommand()", () => {
     it("should execute command and collect output", async () => {
       mockFetch([

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -127,6 +127,12 @@ export interface SandboxListResult {
   };
 }
 
+/** Known sandbox session connection details used to attach without a lookup round-trip. */
+export interface SandboxAttachment extends SandboxOptions {
+  id: string;
+  endpoint: string;
+}
+
 /** Client for isolated ephemeral compute environments with command execution and file I/O. */
 export class Sandbox {
   private constructor(
@@ -191,6 +197,13 @@ export class Sandbox {
 
     const { endpoint } = await res.json();
     return new Sandbox(endpoint, id, authToken, apiUrl);
+  }
+
+  /** Attach to an already-known sandbox session and endpoint without a reconnect lookup. */
+  static attach(attachment: SandboxAttachment): Sandbox {
+    const apiUrl = Sandbox.resolveApiUrl(attachment);
+    const authToken = Sandbox.resolveAuthToken(attachment);
+    return new Sandbox(attachment.endpoint, attachment.id, authToken, apiUrl);
   }
 
   /** List sandbox sessions with optional pagination. */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.279";
+export const VERSION = "0.1.280";


### PR DESCRIPTION
## Summary
- add  for already-known session + endpoint attachment without a reconnect lookup
- document the new attach seam and bump the framework release metadata
- lock the attach behavior with sandbox regression coverage

## Verification
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/sandbox/sandbox.test.ts
- deno check src/sandbox/index.ts src/sandbox/sandbox.ts src/sandbox/sandbox.test.ts
- deno task docs:validate