### PR TITLE
Preserve lazy exec startup policy in the framework

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "veryfront",
   "version": "0.1.277",
-  "version": "0.1.279",
+  "version": "0.1.280",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -30,6 +30,15 @@ You can also reconnect to an existing session:
 const sandbox = await Sandbox.get(sessionId);
 ```
 
+If you already know both the sandbox session ID and its runtime endpoint, attach without doing a reconnect lookup:
+
+```ts
+const sandbox = Sandbox.attach({
+  id: sessionId,
+  endpoint: sandboxEndpoint,
+});
+```
+
 If you want to defer session creation until the first command or file operation, use the lazy client:
 
 ```ts

--- a/docs/plans/phase-2-framework-attach.md
+++ b/docs/plans/phase-2-framework-attach.md
@@ -1,0 +1,12 @@
+# Phase 2 framework attach seam
+
+This framework slice exposes a public sandbox attach/reconnect seam so the hosted runtime can stop using a local private-constructor bridge.
+
+## Add now
+- a public `Sandbox.attach(...)` factory that accepts an already-known endpoint/session/auth/api tuple
+- coverage proving attached clients reuse the known endpoint/session without a lookup round-trip
+- reference docs for the new seam
+
+## Unlocks next
+- delete `src/tools/sandbox/frameworkSandboxBridge.ts` in veryfront-agent
+- remove one more local transport adapter file from the hosted runtime

--- a/docs/reference/sandbox.md
+++ b/docs/reference/sandbox.md
@@ -39,6 +39,12 @@ Reconnect to an existing sandbox session.
 
 **Returns:** <code>Promise&lt;Sandbox&gt;</code>
 
+### `Sandbox.attach(attachment)`
+
+Attach to an already-known sandbox session and endpoint without a reconnect lookup.
+
+**Returns:** <code>Sandbox</code>
+
 ### `Sandbox.createLazy(options?)`
 
 Create a lazily-provisioned sandbox client that only claims a session on first use, sends an initial heartbeat before marking the session ready, pauses background heartbeats while async command jobs are active, and keeps the session alive until `close()`.
@@ -135,6 +141,18 @@ Options for creating a sandbox session.
 | `authToken?` | `string` | Explicit Veryfront auth token or API key override. Defaults to request-scoped credentials or `VERYFRONT_API_TOKEN`. |
 | `projectId?` | `string` | Optional project context for project-scoped or project-billed sandbox sessions.                                     |
 
+### `SandboxAttachment`
+
+Known sandbox session details for `Sandbox.attach(...)`.
+
+| Property   | Type     | Description                                                                                                         |
+| ---------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
+| `id`       | `string` | Existing sandbox session ID.                                                                                        |
+| `endpoint` | `string` | Existing sandbox runtime endpoint URL.                                                                              |
+| `apiUrl?`  | `string` | Base URL of the Veryfront API. Defaults to VERYFRONT_API_URL env.                                                   |
+| `authToken?` | `string` | Explicit Veryfront auth token or API key override. Defaults to request-scoped credentials or `VERYFRONT_API_TOKEN`. |
+| `projectId?` | `string` | Optional project context metadata when the caller wants to preserve the same options shape as other sandbox factories. |
+
 ### `LazySandboxOptions`
 
 Options for a lazily-provisioned sandbox session.
@@ -217,6 +235,7 @@ Command job with captured stdout/stderr.
 | `ExecStreamEvent`    | Streaming event emitted during command execution.             |
 | `LazySandboxOptions` | Options for lazily-provisioned sandbox sessions.              |
 | `SandboxOptions`     | Options for creating a sandbox session.                       |
+| `SandboxAttachment`  | Known sandbox session details used for `Sandbox.attach(...)`. |
 
 ## Related
 

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -18,6 +18,7 @@
  */
 
 export {
+  type SandboxAttachment,
   type CommandJob,
   type CommandJobHeartbeatStatus,
   type CommandJobOutput,

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -18,7 +18,6 @@
  */
 
 export {
-  type SandboxAttachment,
   type CommandJob,
   type CommandJobHeartbeatStatus,
   type CommandJobOutput,
@@ -27,6 +26,7 @@ export {
   type ExecResult,
   type ExecStreamEvent,
   Sandbox,
+  type SandboxAttachment,
   type SandboxListOptions,
   type SandboxListResult,
   type SandboxOptions,

--- a/src/sandbox/lazy-sandbox.ts
+++ b/src/sandbox/lazy-sandbox.ts
@@ -18,6 +18,10 @@ export interface LazySandboxOptions extends SandboxOptions {
   pollIntervalMs?: number;
   heartbeatIntervalMs?: number;
   heartbeatGraceMs?: number;
+  execStartTimeoutMs?: number;
+  execStartMaxAttempts?: number;
+  execStartRetryDelayMs?: number;
+  resolveRuntimeEndpoint?: (input: { endpoint: string; sessionId: string }) => string;
 }
 
 interface SandboxSessionRecord {
@@ -30,6 +34,15 @@ const DEFAULT_STARTUP_TIMEOUT_MS = 180_000;
 const DEFAULT_POLL_INTERVAL_MS = 2_000;
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_HEARTBEAT_GRACE_MS = 5_000;
+const DEFAULT_EXEC_START_TIMEOUT_MS = 30_000;
+const DEFAULT_EXEC_START_MAX_ATTEMPTS = 3;
+const DEFAULT_EXEC_START_RETRY_DELAY_MS = 1_000;
+const REPROVISIONABLE_EXEC_START_ERROR_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ENOTFOUND",
+  "EHOSTUNREACH",
+]);
 
 /** Lazily provisions sandbox sessions and keeps them alive while in use. */
 export class LazySandbox {
@@ -40,6 +53,15 @@ export class LazySandbox {
   private readonly pollIntervalMs: number;
   private readonly heartbeatIntervalMs: number;
   private readonly heartbeatGraceMs: number;
+  private readonly execStartTimeoutMs: number;
+  private readonly execStartMaxAttempts: number;
+  private readonly execStartRetryDelayMs: number;
+  private readonly resolveRuntimeEndpointOption:
+    | ((input: {
+      endpoint: string;
+      sessionId: string;
+    }) => string)
+    | undefined;
 
   private endpoint: string | null = null;
   private sessionId: string | null = null;
@@ -59,6 +81,11 @@ export class LazySandbox {
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
     this.heartbeatIntervalMs = options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
     this.heartbeatGraceMs = options.heartbeatGraceMs ?? DEFAULT_HEARTBEAT_GRACE_MS;
+    this.execStartTimeoutMs = options.execStartTimeoutMs ?? DEFAULT_EXEC_START_TIMEOUT_MS;
+    this.execStartMaxAttempts = options.execStartMaxAttempts ?? DEFAULT_EXEC_START_MAX_ATTEMPTS;
+    this.execStartRetryDelayMs = options.execStartRetryDelayMs ??
+      DEFAULT_EXEC_START_RETRY_DELAY_MS;
+    this.resolveRuntimeEndpointOption = options.resolveRuntimeEndpoint;
   }
 
   async ensure(): Promise<void> {
@@ -104,15 +131,17 @@ export class LazySandbox {
 
   async *executeStream(command: string, options?: ExecOptions): AsyncGenerator<ExecStreamEvent> {
     await this.touchSession();
+    let res: Response;
+    try {
+      res = await this.startExec(command, options);
+    } catch (error) {
+      if (!shouldReprovisionAfterExecStartFailure(error)) {
+        throw error;
+      }
 
-    const res = await fetch(`${this.requireEndpoint()}/exec`, {
-      method: "POST",
-      headers: this.jsonHeaders(),
-      body: JSON.stringify({ command, ...this.resolveExecOptions(options) }),
-    });
-
-    if (!res.ok) {
-      throw REQUEST_ERROR.create({ detail: `Exec failed: ${res.status} ${await res.text()}` });
+      await this.reprovisionAfterExecStartFailure();
+      await this.touchSession();
+      res = await this.startExec(command, options);
     }
 
     if (!res.body) {
@@ -174,7 +203,7 @@ export class LazySandbox {
 
   async startCommandJob(command: string, options?: ExecOptions): Promise<CommandJob> {
     await this.touchSession();
-    const endpoint = this.requireEndpoint();
+    const endpoint = this.resolveRuntimeEndpoint();
 
     const res = await fetch(`${endpoint}/exec/jobs`, {
       method: "POST",
@@ -500,7 +529,7 @@ export class LazySandbox {
     }
 
     await this.ensure();
-    return this.requireEndpoint();
+    return this.resolveRuntimeEndpoint();
   }
 
   private updateTrackedCommandJob(job: Pick<CommandJob, "id" | "status">, endpoint: string): void {
@@ -519,6 +548,77 @@ export class LazySandbox {
     }
   }
 
+  private async startExec(command: string, options?: ExecOptions): Promise<Response> {
+    const endpoint = this.resolveRuntimeEndpoint();
+    const body = JSON.stringify({ command, ...this.resolveExecOptions(options) });
+
+    for (let attempt = 1; attempt <= this.execStartMaxAttempts; attempt += 1) {
+      try {
+        const res = await this.fetchExecStart(`${endpoint}/exec`, {
+          method: "POST",
+          headers: this.jsonHeaders(),
+          body,
+        });
+
+        if (res.ok) {
+          return res;
+        }
+
+        if (isRetryableExecStartStatus(res.status) && attempt < this.execStartMaxAttempts) {
+          await this.waitForExecStartRetry();
+          continue;
+        }
+
+        throw REQUEST_ERROR.create({ detail: `Exec failed: ${res.status} ${await res.text()}` });
+      } catch (error) {
+        if (!isRetryableExecStartError(error) || attempt >= this.execStartMaxAttempts) {
+          throw error;
+        }
+
+        await this.waitForExecStartRetry();
+      }
+    }
+
+    throw new Error("Sandbox exec failed before a request was made");
+  }
+
+  private async fetchExecStart(url: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.execStartTimeoutMs);
+
+    try {
+      return await fetch(url, { ...init, signal: controller.signal });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private waitForExecStartRetry(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, this.execStartRetryDelayMs));
+  }
+
+  private async reprovisionAfterExecStartFailure(): Promise<void> {
+    const sessionId = this.sessionId;
+    if (!sessionId) return;
+
+    await this.deleteSession(sessionId);
+    this.resetSessionState(sessionId);
+  }
+
+  private resolveRuntimeEndpoint(): string {
+    const endpoint = this.requireEndpoint();
+    const sessionId = this.requireSessionId();
+    return this.resolveRuntimeEndpointOption?.({ endpoint, sessionId }) ?? endpoint;
+  }
+
+  private requireSessionId(): string {
+    if (!this.sessionId) {
+      throw new Error("Sandbox session unavailable");
+    }
+
+    return this.sessionId;
+  }
+
   private authHeaders(): HeadersInit {
     return { Authorization: `Bearer ${this.authToken}` };
   }
@@ -529,6 +629,28 @@ export class LazySandbox {
       "Content-Type": "application/json",
     };
   }
+}
+
+function isRetryableExecStartStatus(status: number): boolean {
+  return status === 502 || status === 503 || status === 504;
+}
+
+function isRetryableExecStartError(error: unknown): boolean {
+  return error instanceof Error && /fetch failed/i.test(error.message);
+}
+
+function shouldReprovisionAfterExecStartFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const cause = error.cause;
+  if (typeof cause !== "object" || cause === null || !("code" in cause)) {
+    return false;
+  }
+
+  return typeof cause.code === "string" &&
+    REPROVISIONABLE_EXEC_START_ERROR_CODES.has(cause.code);
 }
 
 function mapCommandJob(json: Record<string, unknown>): CommandJob {

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -978,6 +978,162 @@ describe("Sandbox", () => {
       }
     });
 
+    it("uses the lazy runtime endpoint resolver for exec and async jobs", async () => {
+      mockFetch([
+        jsonResponse({
+          id: "sandbox-1",
+          endpoint: "https://sandbox-1.example.com",
+          status: "running",
+        }),
+        jsonResponse({ ok: true }),
+        ndjsonResponse([
+          { type: "stdout", data: "ok\n" },
+          { type: "exit", exitCode: 0 },
+        ]),
+        jsonResponse({
+          id: "job-1",
+          status: "completed",
+          exit_code: 0,
+          signal: null,
+          started_at: "2026-01-01T00:00:00Z",
+          finished_at: "2026-01-01T00:00:01Z",
+          heartbeat_status: "disabled",
+          last_heartbeat_at: null,
+          last_heartbeat_error: null,
+          heartbeat_failure_count: 0,
+        }),
+        jsonResponse({ ok: true }),
+      ]);
+
+      const sandbox = Sandbox.createLazy({
+        authToken: "test-token",
+        apiUrl: "https://api.test.com",
+        resolveRuntimeEndpoint: ({ sessionId }) =>
+          `http://sandbox.veryfront-sandbox-${sessionId}.svc.cluster.local`,
+      });
+
+      try {
+        await sandbox.executeCommand("echo ok");
+        await sandbox.startCommandJob("npm test");
+
+        assertEquals(
+          fetchCalls[2]!.url,
+          "http://sandbox.veryfront-sandbox-sandbox-1.svc.cluster.local/exec",
+        );
+        assertEquals(
+          fetchCalls[3]!.url,
+          "http://sandbox.veryfront-sandbox-sandbox-1.svc.cluster.local/exec/jobs",
+        );
+      } finally {
+        await sandbox.close();
+      }
+    });
+
+    it("retries retryable lazy exec transport failures before streaming starts", async () => {
+      mockFetch([
+        jsonResponse({
+          id: "sandbox-1",
+          endpoint: "https://sandbox-1.example.com",
+          status: "running",
+        }),
+        jsonResponse({ ok: true }),
+        () => {
+          throw new TypeError("fetch failed");
+        },
+        ndjsonResponse([
+          { type: "stdout", data: "ok\n" },
+          { type: "exit", exitCode: 0 },
+        ]),
+        jsonResponse({ ok: true }),
+      ]);
+
+      const sandbox = Sandbox.createLazy({
+        authToken: "test-token",
+        apiUrl: "https://api.test.com",
+        execStartRetryDelayMs: 0,
+        execStartTimeoutMs: 15_000,
+      });
+
+      try {
+        const result = await sandbox.executeCommand("echo ok");
+        assertEquals(result.stdout, "ok\n");
+        assertEquals(fetchCalls[2]!.url, "https://sandbox-1.example.com/exec");
+        assertEquals(fetchCalls[3]!.url, "https://sandbox-1.example.com/exec");
+        assertEquals(fetchCalls[2]!.init?.signal instanceof AbortSignal, true);
+      } finally {
+        await sandbox.close();
+      }
+    });
+
+    it("reprovisions lazy exec after exhausted in-cluster transport failures", async () => {
+      const connectionRefusedError = () =>
+        new TypeError("fetch failed", { cause: { code: "ECONNREFUSED" } });
+
+      mockFetch([
+        jsonResponse({
+          id: "sandbox-1",
+          endpoint: "https://1111111111.sandbox.example.com",
+          status: "running",
+        }),
+        jsonResponse({ ok: true }),
+        () => {
+          throw connectionRefusedError();
+        },
+        () => {
+          throw connectionRefusedError();
+        },
+        () => {
+          throw connectionRefusedError();
+        },
+        jsonResponse({ ok: true }),
+        jsonResponse({
+          id: "sandbox-2",
+          endpoint: "https://2222222222.sandbox.example.com",
+          status: "running",
+        }),
+        jsonResponse({ ok: true }),
+        ndjsonResponse([
+          { type: "stdout", data: "ok\n" },
+          { type: "exit", exitCode: 0 },
+        ]),
+        jsonResponse({ ok: true }),
+      ]);
+
+      const sandbox = Sandbox.createLazy({
+        authToken: "test-token",
+        apiUrl: "https://api.test.com",
+        execStartRetryDelayMs: 0,
+        resolveRuntimeEndpoint: ({ sessionId }) =>
+          `http://sandbox.veryfront-sandbox-${sessionId}.svc.cluster.local`,
+      });
+
+      try {
+        const result = await sandbox.executeCommand("echo ok");
+        assertEquals(result.stdout, "ok\n");
+        assertEquals(
+          fetchCalls.filter((call) =>
+            call.url === "http://sandbox.veryfront-sandbox-sandbox-1.svc.cluster.local/exec"
+          ).length,
+          3,
+        );
+        assertEquals(
+          fetchCalls.some((call) =>
+            call.url === "https://api.test.com/sandbox-sessions/sandbox-1" &&
+            call.init?.method === "DELETE"
+          ),
+          true,
+        );
+        assertEquals(
+          fetchCalls.some((call) =>
+            call.url === "http://sandbox.veryfront-sandbox-sandbox-2.svc.cluster.local/exec"
+          ),
+          true,
+        );
+      } finally {
+        await sandbox.close();
+      }
+    });
+
     it("pauses heartbeats while async jobs are active and resumes them after the job completes", async () => {
       const originalSetInterval = globalThis.setInterval;
       const originalClearInterval = globalThis.clearInterval;

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -298,8 +298,14 @@ describe("Sandbox", () => {
       await sandbox.close();
 
       assertEquals(fetchCalls.length, 3);
-      assertEquals(fetchCalls[0]!.url, "https://attached.example.com/file?path=%2Fworkspace%2Fnote.txt");
-      assertEquals(fetchCalls[1]!.url, "https://api.test.com/sandbox-sessions/attached-1/heartbeat");
+      assertEquals(
+        fetchCalls[0]!.url,
+        "https://attached.example.com/file?path=%2Fworkspace%2Fnote.txt",
+      );
+      assertEquals(
+        fetchCalls[1]!.url,
+        "https://api.test.com/sandbox-sessions/attached-1/heartbeat",
+      );
       assertEquals(fetchCalls[2]!.url, "https://api.test.com/sandbox-sessions/attached-1");
       assertEquals(headerValue(fetchCalls, 0, "Authorization"), "Bearer attach-token");
     });
@@ -318,7 +324,10 @@ describe("Sandbox", () => {
       });
 
       assertEquals(await sandbox.readFile("/workspace/env.txt"), "env body");
-      assertEquals(fetchCalls[0]!.url, "https://attached-env.example.com/file?path=%2Fworkspace%2Fenv.txt");
+      assertEquals(
+        fetchCalls[0]!.url,
+        "https://attached-env.example.com/file?path=%2Fworkspace%2Fenv.txt",
+      );
       assertEquals(headerValue(fetchCalls, 0, "Authorization"), "Bearer vf_attach_env");
     });
   });

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -276,6 +276,53 @@ describe("Sandbox", () => {
     });
   });
 
+  describe("attach()", () => {
+    it("should attach to an already-known sandbox session without a reconnect lookup", async () => {
+      mockFetch([
+        textResponse("attached body"),
+        jsonResponse({ ok: true }),
+        jsonResponse({ ok: true }),
+      ]);
+
+      const sandbox = Sandbox.attach({
+        id: "attached-1",
+        endpoint: "https://attached.example.com",
+        authToken: "attach-token",
+        apiUrl: "https://api.test.com",
+      });
+
+      assertEquals(sandbox.id, "attached-1");
+      assertEquals(sandbox.url, "https://attached.example.com");
+      assertEquals(await sandbox.readFile("/workspace/note.txt"), "attached body");
+      await sandbox.heartbeat();
+      await sandbox.close();
+
+      assertEquals(fetchCalls.length, 3);
+      assertEquals(fetchCalls[0]!.url, "https://attached.example.com/file?path=%2Fworkspace%2Fnote.txt");
+      assertEquals(fetchCalls[1]!.url, "https://api.test.com/sandbox-sessions/attached-1/heartbeat");
+      assertEquals(fetchCalls[2]!.url, "https://api.test.com/sandbox-sessions/attached-1");
+      assertEquals(headerValue(fetchCalls, 0, "Authorization"), "Bearer attach-token");
+    });
+
+    it("should resolve authToken and apiUrl from environment when omitted", async () => {
+      setEnv("VERYFRONT_API_TOKEN", "vf_attach_env");
+      setEnv("VERYFRONT_API_URL", "https://attach.api.test");
+
+      mockFetch([
+        textResponse("env body"),
+      ]);
+
+      const sandbox = Sandbox.attach({
+        id: "attached-env",
+        endpoint: "https://attached-env.example.com",
+      });
+
+      assertEquals(await sandbox.readFile("/workspace/env.txt"), "env body");
+      assertEquals(fetchCalls[0]!.url, "https://attached-env.example.com/file?path=%2Fworkspace%2Fenv.txt");
+      assertEquals(headerValue(fetchCalls, 0, "Authorization"), "Bearer vf_attach_env");
+    });
+  });
+
   describe("executeCommand()", () => {
     it("should execute command and collect output", async () => {
       mockFetch([

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -127,6 +127,12 @@ export interface SandboxListResult {
   };
 }
 
+/** Known sandbox session connection details used to attach without a lookup round-trip. */
+export interface SandboxAttachment extends SandboxOptions {
+  id: string;
+  endpoint: string;
+}
+
 /** Client for isolated ephemeral compute environments with command execution and file I/O. */
 export class Sandbox {
   private constructor(
@@ -191,6 +197,13 @@ export class Sandbox {
 
     const { endpoint } = await res.json();
     return new Sandbox(endpoint, id, authToken, apiUrl);
+  }
+
+  /** Attach to an already-known sandbox session and endpoint without a reconnect lookup. */
+  static attach(attachment: SandboxAttachment): Sandbox {
+    const apiUrl = Sandbox.resolveApiUrl(attachment);
+    const authToken = Sandbox.resolveAuthToken(attachment);
+    return new Sandbox(attachment.endpoint, attachment.id, authToken, apiUrl);
   }
 
   /** List sandbox sessions with optional pagination. */

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.279";
+export const VERSION = "0.1.280";


### PR DESCRIPTION
## Summary\n- add lazy sandbox exec-start timeout/retry options\n- reprovision lazy sessions after exhausted in-cluster transport failures\n- route streaming exec and async jobs through a runtime endpoint resolver\n- cover retry, reprovision, and endpoint resolution in sandbox tests\n\n## Verification\n- deno test --no-check --allow-all src/sandbox/sandbox.test.ts\n- deno check src/sandbox/lazy-sandbox.ts src/sandbox/sandbox.test.ts\n- DENO_NO_PACKAGE_JSON=1 deno lint src/sandbox/lazy-sandbox.ts src/sandbox/sandbox.test.ts\n- deno task typecheck\n- deno task test:unit\n- git push pre-push checks passed\n\n## Notes\n- deno task verify:quick is currently blocked by existing no-default-export style violations in src/utils/clsx.ts and src/utils/mime-types.ts.