### PR TITLE
Publish lazy sandbox exec start policy

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.277",
-  "version": "0.1.280",
+  "version": "0.1.281",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.280";
+export const VERSION = "0.1.281";


### PR DESCRIPTION
## Summary
- advance the stable framework version to 0.1.281 so the merged lazy sandbox exec start policy can publish
- keep the runtime VERSION constant aligned with deno.json
- remove the stale duplicate deno.json version key while setting the active release version

## Verification
- deno check src/utils/version.ts src/utils/version-constant.ts
- DENO_NO_PACKAGE_JSON=1 deno lint deno.json src/utils/version.ts src/utils/version-constant.ts
- deno task typecheck
- pre-push: format, lint, typecheck, unit tests (1436 passed / 17211 steps)
