### PR TITLE
Fix integration tools resolution for project agents

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.282",
+  "version": "0.1.283",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -110,6 +110,7 @@ const LOAD_SKILL_TOOL_ID = "load-skill";
 
 type RuntimeToolFilterConfig = AgentConfig & {
   __vfAllowedRemoteTools?: string[];
+  __vfForwardedIntegrationToolDefs?: Array<{ name: string; description: string; parameters: Record<string, unknown> }>;
 };
 
 function isAbortError(error: unknown, abortSignal?: AbortSignal): boolean {
@@ -418,6 +419,27 @@ function getRuntimeAllowedRemoteTools(config: AgentConfig): string[] | undefined
   return raw.every((toolName) => typeof toolName === "string") ? raw : [];
 }
 
+function getRuntimeForwardedIntegrationToolDefs(
+  config: AgentConfig,
+): ToolDefinition[] | undefined {
+  const configWithFilters = config as RuntimeToolFilterConfig;
+  const raw = configWithFilters.__vfForwardedIntegrationToolDefs;
+  if (!Array.isArray(raw) || raw.length === 0) return undefined;
+  return raw
+    .filter(
+      (def): def is { name: string; description: string; parameters: Record<string, unknown> } =>
+        typeof def === "object" &&
+        def !== null &&
+        typeof def.name === "string" &&
+        typeof def.description === "string",
+    )
+    .map((def) => ({
+      name: def.name,
+      description: def.description,
+      parameters: def.parameters ?? { type: "object", properties: {} },
+    }));
+}
+
 type ResolvedModelTransport = {
   requestedModel: string;
   resolvedModelString: string;
@@ -722,6 +744,7 @@ export class AgentRuntime {
       // Request-scoped skill policy (not class-level mutable state)
       let activeSkillPolicy: string[] | undefined;
       const allowedRemoteToolNames = getRuntimeAllowedRemoteTools(this.config);
+      const forwardedRemoteToolDefinitions = getRuntimeForwardedIntegrationToolDefs(this.config);
       let currentSystemPrompt = systemPrompt;
       let currentRuntimeContext = runtimeContext;
 
@@ -743,6 +766,7 @@ export class AgentRuntime {
         let tools = isLocal ? [] : await getAvailableTools(this.config.tools, {
           includeSkillTools: Boolean(this.config.skills),
           allowedRemoteToolNames,
+          forwardedRemoteToolDefinitions,
           remoteToolSources: this.config.remoteTools,
           remoteToolContext: toolContext,
         });
@@ -1004,6 +1028,7 @@ export class AgentRuntime {
     let finalFinishReason: string | undefined;
     let latestAssistantText = "";
     const allowedRemoteToolNames = getRuntimeAllowedRemoteTools(this.config);
+    const forwardedRemoteToolDefinitions = getRuntimeForwardedIntegrationToolDefs(this.config);
     let currentSystemPrompt = systemPrompt;
     let currentRuntimeContext = runtimeContext;
 
@@ -1026,6 +1051,7 @@ export class AgentRuntime {
       let tools = isLocalStreaming ? [] : await getAvailableTools(this.config.tools, {
         includeSkillTools: Boolean(this.config.skills),
         allowedRemoteToolNames,
+        forwardedRemoteToolDefinitions,
         remoteToolSources: this.config.remoteTools,
         remoteToolContext: toolContext,
       });

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -436,7 +436,10 @@ function getRuntimeForwardedIntegrationToolDefs(
     .map((def) => ({
       name: def.name,
       description: def.description,
-      parameters: def.parameters ?? { type: "object", properties: {} },
+      parameters:
+        typeof def.parameters === "object" && def.parameters !== null && !Array.isArray(def.parameters)
+          ? def.parameters
+          : { type: "object", properties: {} },
     }));
 }
 

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -47,7 +47,7 @@ import { repairToolCall } from "./repair-tool-call.ts";
 import { MiddlewareChain } from "../middleware/chain.ts";
 import { AGENT_DEFAULTS } from "../defaults.ts";
 import { tryGetCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
-import type { ToolExecutionContext } from "#veryfront/tool";
+import type { ToolDefinition, ToolExecutionContext } from "#veryfront/tool";
 import { isLocalModelRuntime } from "#veryfront/provider/runtime-inspection.ts";
 import { generateText, streamText } from "#veryfront/runtime/runtime-bridge.ts";
 
@@ -110,7 +110,9 @@ const LOAD_SKILL_TOOL_ID = "load-skill";
 
 type RuntimeToolFilterConfig = AgentConfig & {
   __vfAllowedRemoteTools?: string[];
-  __vfForwardedIntegrationToolDefs?: Array<{ name: string; description: string; parameters: Record<string, unknown> }>;
+  __vfForwardedIntegrationToolDefs?: Array<
+    { name: string; description: string; parameters: Record<string, unknown> }
+  >;
 };
 
 function isAbortError(error: unknown, abortSignal?: AbortSignal): boolean {
@@ -436,10 +438,10 @@ function getRuntimeForwardedIntegrationToolDefs(
     .map((def) => ({
       name: def.name,
       description: def.description,
-      parameters:
-        typeof def.parameters === "object" && def.parameters !== null && !Array.isArray(def.parameters)
-          ? def.parameters
-          : { type: "object", properties: {} },
+      parameters: typeof def.parameters === "object" && def.parameters !== null &&
+          !Array.isArray(def.parameters)
+        ? def.parameters
+        : { type: "object", properties: {} },
     }));
 }
 

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -396,7 +396,10 @@ describe("tool-helpers", () => {
           "gmail__get_email",
           "gmail__list_emails",
         ]);
-        assertEquals(defs.find((d) => d.name === "gmail__get_email")?.description, "Get a specific email by ID");
+        assertEquals(
+          defs.find((d) => d.name === "gmail__get_email")?.description,
+          "Get a specific email by ID",
+        );
       } finally {
         toolRegistry.clearAll();
       }

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -360,6 +360,75 @@ describe("tool-helpers", () => {
       }
     });
 
+    it("resolves explicit integration tools from forwarded definitions when remote fetch is unavailable", async () => {
+      toolRegistry.clearAll();
+
+      try {
+        // Simulates production: remote integration tool fetch fails (no API token),
+        // but the API forwarded definitions via forwardedProps.
+        const defs = await getAvailableTools(
+          {
+            "gmail__list_emails": true,
+            "gmail__get_email": true,
+          },
+          {
+            includeIntegrationTools: false,
+            allowedRemoteToolNames: ["gmail__list_emails", "gmail__get_email"],
+            forwardedRemoteToolDefinitions: [
+              {
+                name: "gmail__list_emails",
+                description: "List emails from Gmail inbox",
+                parameters: { type: "object", properties: {} },
+              },
+              {
+                name: "gmail__get_email",
+                description: "Get a specific email by ID",
+                parameters: {
+                  type: "object",
+                  properties: { id: { type: "string" } },
+                },
+              },
+            ],
+          },
+        );
+
+        assertEquals(defs.map((def) => def.name).sort(), [
+          "gmail__get_email",
+          "gmail__list_emails",
+        ]);
+        assertEquals(defs.find((d) => d.name === "gmail__get_email")?.description, "Get a specific email by ID");
+      } finally {
+        toolRegistry.clearAll();
+      }
+    });
+
+    it("forwarded definitions are filtered by allowedRemoteToolNames", async () => {
+      toolRegistry.clearAll();
+
+      try {
+        const defs = await getAvailableTools(true, {
+          includeIntegrationTools: false,
+          allowedRemoteToolNames: ["gmail__list_emails"],
+          forwardedRemoteToolDefinitions: [
+            {
+              name: "gmail__list_emails",
+              description: "List emails",
+              parameters: { type: "object", properties: {} },
+            },
+            {
+              name: "gmail__send_email",
+              description: "Send an email",
+              parameters: { type: "object", properties: {} },
+            },
+          ],
+        });
+
+        assertEquals(defs.map((def) => def.name), ["gmail__list_emails"]);
+      } finally {
+        toolRegistry.clearAll();
+      }
+    });
+
     it("merges generic remote MCP tool sources into available tools", async () => {
       toolRegistry.clearAll();
 

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -298,6 +298,27 @@ function addToolDefinition(
 }
 
 /**
+ * Merge forwarded integration tool definitions into the remote defs array.
+ * Forwarded definitions are provided by the API when the runtime cannot
+ * fetch them directly (e.g., the runtime token lacks user auth).
+ * Only appends definitions not already present in the array.
+ */
+function appendForwardedToolDefinitions(
+  remoteDefs: ToolDefinition[],
+  forwarded: ToolDefinition[] | undefined,
+  allowedNames: string[] | undefined,
+): void {
+  if (!forwarded?.length) return;
+  const existing = new Set(remoteDefs.map((def) => def.name));
+  for (const def of forwarded) {
+    if (existing.has(def.name)) continue;
+    if (allowedNames && !allowedNames.includes(def.name)) continue;
+    remoteDefs.push(def);
+    existing.add(def.name);
+  }
+}
+
+/**
  * Get available tools based on agent configuration.
  * When tools === true, loads all tools from registry.
  * Otherwise loads specific tools from config.
@@ -311,6 +332,7 @@ export async function getAvailableTools(
     includeSkillTools?: boolean;
     includeIntegrationTools?: boolean;
     allowedRemoteToolNames?: string[];
+    forwardedRemoteToolDefinitions?: ToolDefinition[];
     remoteToolSources?: RemoteToolSource[];
     remoteToolContext?: ToolExecutionContext;
   },
@@ -333,6 +355,7 @@ export async function getAvailableTools(
 
     // Append remote integration tools (per-request, project-scoped)
     const remoteDefs = await getRemoteToolDefinitions(options);
+    appendForwardedToolDefinitions(remoteDefs, options?.forwardedRemoteToolDefinitions, options?.allowedRemoteToolNames);
     for (const def of remoteDefs) {
       logToolDefinition(def.name, def);
     }
@@ -343,6 +366,7 @@ export async function getAvailableTools(
 
   const tools: ToolDefinition[] = [];
   const remoteDefs = await getRemoteToolDefinitions(options);
+  appendForwardedToolDefinitions(remoteDefs, options?.forwardedRemoteToolDefinitions, options?.allowedRemoteToolNames);
   const remoteToolNames = new Set(remoteDefs.map((def) => def.name));
   const explicitlyRequestedRemoteToolNames = new Set<string>();
   const unresolvedConfiguredToolNames: string[] = [];

--- a/src/agent/runtime/tool-helpers.ts
+++ b/src/agent/runtime/tool-helpers.ts
@@ -355,7 +355,11 @@ export async function getAvailableTools(
 
     // Append remote integration tools (per-request, project-scoped)
     const remoteDefs = await getRemoteToolDefinitions(options);
-    appendForwardedToolDefinitions(remoteDefs, options?.forwardedRemoteToolDefinitions, options?.allowedRemoteToolNames);
+    appendForwardedToolDefinitions(
+      remoteDefs,
+      options?.forwardedRemoteToolDefinitions,
+      options?.allowedRemoteToolNames,
+    );
     for (const def of remoteDefs) {
       logToolDefinition(def.name, def);
     }
@@ -366,7 +370,11 @@ export async function getAvailableTools(
 
   const tools: ToolDefinition[] = [];
   const remoteDefs = await getRemoteToolDefinitions(options);
-  appendForwardedToolDefinitions(remoteDefs, options?.forwardedRemoteToolDefinitions, options?.allowedRemoteToolNames);
+  appendForwardedToolDefinitions(
+    remoteDefs,
+    options?.forwardedRemoteToolDefinitions,
+    options?.allowedRemoteToolNames,
+  );
   const remoteToolNames = new Set(remoteDefs.map((def) => def.name));
   const explicitlyRequestedRemoteToolNames = new Set<string>();
   const unresolvedConfiguredToolNames: string[] = [];

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -25,6 +25,7 @@ const logger = serverLogger.component("internal-agent-run-stream");
 type RuntimeFilteredAgent = Agent & {
   config: Agent["config"] & {
     __vfAllowedRemoteTools?: string[];
+    __vfForwardedIntegrationToolDefs?: ForwardedToolDef[];
   };
 };
 
@@ -137,6 +138,35 @@ function getAllowedRemoteToolNames(
   return allowedTools.every((toolName) => typeof toolName === "string") ? allowedTools : [];
 }
 
+interface ForwardedToolDef {
+  name: string;
+  description: string;
+  inputSchema?: Record<string, unknown>;
+  parameters?: Record<string, unknown>;
+}
+
+function getForwardedIntegrationToolDefinitions(
+  forwardedProps: RuntimeRunAgentInput["forwardedProps"],
+): ForwardedToolDef[] | undefined {
+  const runtimeOverrides = isRecord(forwardedProps?.runtimeOverrides)
+    ? forwardedProps.runtimeOverrides
+    : null;
+  if (!runtimeOverrides) return undefined;
+  const defs = runtimeOverrides.integrationToolDefinitions;
+  if (!Array.isArray(defs) || defs.length === 0) return undefined;
+  return defs.filter(
+    (def): def is ForwardedToolDef =>
+      typeof def === "object" &&
+      def !== null &&
+      typeof def.name === "string" &&
+      typeof def.description === "string",
+  ).map((def) => ({
+    name: def.name,
+    description: def.description,
+    parameters: def.inputSchema ?? def.parameters ?? { type: "object", properties: {} },
+  }));
+}
+
 export async function createRuntimeAgentStreamResponse(
   input: RuntimeRunAgentInput,
   agent: Agent,
@@ -157,6 +187,7 @@ export async function createRuntimeAgentStreamResponse(
 
   const mergedTools = buildMergedTools(agent, input, deps.sessionManager);
   const allowedRemoteToolNames = getAllowedRemoteToolNames(input.forwardedProps);
+  const forwardedIntegrationToolDefs = getForwardedIntegrationToolDefinitions(input.forwardedProps);
   const runtimeAgent: RuntimeFilteredAgent = {
     ...agent,
     config: {
@@ -164,6 +195,9 @@ export async function createRuntimeAgentStreamResponse(
       tools: mergedTools,
       ...(allowedRemoteToolNames !== undefined
         ? { __vfAllowedRemoteTools: allowedRemoteToolNames }
+        : {}),
+      ...(forwardedIntegrationToolDefs !== undefined
+        ? { __vfForwardedIntegrationToolDefs: forwardedIntegrationToolDefs }
         : {}),
     },
   };

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.282";
+export const VERSION = "0.1.283";


### PR DESCRIPTION
## Summary

- Fixes runtime crash when project agents reference integration tools (e.g. `gmail__list_emails`) in explicit `tools: { ... }` config
- Root cause: the runtime calls back to `/integrations/tools/list` to get tool definitions, but the project-scoped service token lacks `userId` → API returns 401 → tools resolve as empty → `Unknown tool references ... Available tools: (none)`
- Fix: accept `forwardedRemoteToolDefinitions` in `getAvailableTools` so definitions forwarded from the API (which has user context at enqueue time) are used as a fallback when the HTTP callback fails

## Changes

- `tool-helpers.ts`: Add `forwardedRemoteToolDefinitions` option to `getAvailableTools`, merge them into remote defs with `allowedRemoteToolNames` filtering
- `index.ts`: Read `__vfForwardedIntegrationToolDefs` from agent config and pass to both generate/stream paths
- `run-stream.ts`: Extract `integrationToolDefinitions` from `forwardedProps.runtimeOverrides` and set on agent config

## Test plan

- [x] New test: explicit integration tools resolve from forwarded definitions when remote fetch unavailable
- [x] New test: forwarded definitions are filtered by `allowedRemoteToolNames`
- [x] All existing `tool-helpers.test.ts` tests pass
- [ ] Companion PR in veryfront-api forwards definitions via `forwardedProps`