### PR TITLE
Preserve multi-agent service options before runtime adoption

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.283",
+  "version": "0.1.284",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/agent-service.test.ts
+++ b/src/agent/agent-service.test.ts
@@ -1,6 +1,12 @@
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { type AgentContract, defineAgentService, type DurableRunSink } from "./index.ts";
+import {
+  type AgentContract,
+  type AgentServiceRegistryContract,
+  type AgentServiceSingleAgentContract,
+  defineAgentService,
+  type DurableRunSink,
+} from "./index.ts";
 import { agent } from "./factory.ts";
 
 const assistant = agent({
@@ -31,17 +37,42 @@ describe("agent/agent-service", () => {
       { status: string }
     > = {
       serviceName: "veryfront-agent",
-      agent: assistant,
+      agents: { assistant },
+      defaultAgentId: "assistant",
       server: { port: 3001, basePath: "/api/ag-ui" },
       durableRunSink,
     };
 
     assertEquals(contract.serviceName, "veryfront-agent");
-    assertEquals(contract.agent.id, "phase-0-service-stub");
+    assertEquals(contract.agents.assistant.id, "phase-0-service-stub");
+    assertEquals(contract.defaultAgentId, "assistant");
     assertEquals(contract.server?.port, 3001);
     assertEquals(contract.durableRunSink?.startRun({ requestId: "run-123" }), {
       runId: "run-123",
     });
+  });
+
+  it("accepts single-agent convenience without replacing the multi-agent registry shape", () => {
+    const registryContract: AgentServiceRegistryContract = {
+      serviceName: "multi-agent-service",
+      agents: {
+        assistant,
+        reviewer: agent({
+          id: "reviewer",
+          system: "Review implementation plans.",
+        }),
+      },
+      defaultAgentId: "assistant",
+    };
+
+    const singleAgentContract: AgentServiceSingleAgentContract = {
+      serviceName: "single-agent-service",
+      agent: assistant,
+    };
+
+    assertEquals(registryContract.defaultAgentId, "assistant");
+    assertEquals(registryContract.agents.reviewer.id, "reviewer");
+    assertEquals(singleAgentContract.agent.id, "phase-0-service-stub");
   });
 
   it("throws until the hosted runtime service implementation lands", async () => {

--- a/src/agent/agent-service.ts
+++ b/src/agent/agent-service.ts
@@ -26,19 +26,68 @@ export interface AgentServiceServerConfig {
   cors?: boolean;
 }
 
-/**
- * Phase-0 contract draft for the future framework-owned hosted agent service.
- */
-export interface AgentContract<
+export type AgentRegistry = Record<string, Agent>;
+
+export interface AgentServiceContractBase<
   TStartInput = void,
   TRun = unknown,
   TEvent = unknown,
   TTerminalState = unknown,
 > {
   serviceName: string;
-  agent: Agent;
   server?: AgentServiceServerConfig;
   durableRunSink?: DurableRunSink<TStartInput, TRun, TEvent, TTerminalState>;
+}
+
+/**
+ * Multi-agent hosted-service contract. Framework services route to
+ * `defaultAgentId` unless the host chooses another registered agent.
+ */
+export interface AgentServiceRegistryContract<
+  TStartInput = void,
+  TRun = unknown,
+  TEvent = unknown,
+  TTerminalState = unknown,
+> extends AgentServiceContractBase<TStartInput, TRun, TEvent, TTerminalState> {
+  agents: AgentRegistry;
+  defaultAgentId: string;
+}
+
+/**
+ * Single-agent convenience accepted by `defineAgentService()`. Implementations
+ * must normalize this shape into the same registry path used by multi-agent
+ * services so framework users are not boxed into one-agent-per-process.
+ */
+export interface AgentServiceSingleAgentContract<
+  TStartInput = void,
+  TRun = unknown,
+  TEvent = unknown,
+  TTerminalState = unknown,
+> extends AgentServiceContractBase<TStartInput, TRun, TEvent, TTerminalState> {
+  agent: Agent;
+  defaultAgentId?: string;
+}
+
+/**
+ * Phase-0 contract draft for the future framework-owned hosted agent service.
+ */
+export type AgentContract<
+  TStartInput = void,
+  TRun = unknown,
+  TEvent = unknown,
+  TTerminalState = unknown,
+> =
+  | AgentServiceRegistryContract<TStartInput, TRun, TEvent, TTerminalState>
+  | AgentServiceSingleAgentContract<TStartInput, TRun, TEvent, TTerminalState>;
+
+export interface NormalizedAgentServiceContract<
+  TStartInput = void,
+  TRun = unknown,
+  TEvent = unknown,
+  TTerminalState = unknown,
+> extends AgentServiceContractBase<TStartInput, TRun, TEvent, TTerminalState> {
+  agents: AgentRegistry;
+  defaultAgentId: string;
 }
 
 /**
@@ -51,11 +100,46 @@ export interface AgentServiceDefinition<
   TEvent = unknown,
   TTerminalState = unknown,
 > {
-  contract: AgentContract<TStartInput, TRun, TEvent, TTerminalState>;
+  contract: NormalizedAgentServiceContract<TStartInput, TRun, TEvent, TTerminalState>;
 }
 
 const DEFINE_AGENT_SERVICE_STUB_ERROR =
   "defineAgentService() is a Phase 0 stub. The framework contract is reserved, but the hosted runtime implementation has not landed yet.";
+
+function getSingleAgentDefaultId(contract: {
+  agent: Agent;
+  defaultAgentId?: string;
+}): string {
+  return contract.defaultAgentId ?? contract.agent.id ?? "default";
+}
+
+function normalizeAgentServiceContract<
+  TStartInput = void,
+  TRun = unknown,
+  TEvent = unknown,
+  TTerminalState = unknown,
+>(
+  contract: AgentContract<TStartInput, TRun, TEvent, TTerminalState>,
+): NormalizedAgentServiceContract<TStartInput, TRun, TEvent, TTerminalState> {
+  if ("agents" in contract) {
+    return {
+      serviceName: contract.serviceName,
+      agents: contract.agents,
+      defaultAgentId: contract.defaultAgentId,
+      server: contract.server,
+      durableRunSink: contract.durableRunSink,
+    };
+  }
+
+  const defaultAgentId = getSingleAgentDefaultId(contract);
+  return {
+    serviceName: contract.serviceName,
+    agents: { [defaultAgentId]: contract.agent },
+    defaultAgentId,
+    server: contract.server,
+    durableRunSink: contract.durableRunSink,
+  };
+}
 
 /**
  * Reserve the public hosted agent-service signature before the runtime
@@ -69,6 +153,6 @@ export function defineAgentService<
 >(
   contract: AgentContract<TStartInput, TRun, TEvent, TTerminalState>,
 ): AgentServiceDefinition<TStartInput, TRun, TEvent, TTerminalState> {
-  void contract;
+  void normalizeAgentServiceContract(contract);
   throw new Error(DEFINE_AGENT_SERVICE_STUB_ERROR);
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -141,10 +141,14 @@ export {
 export { agent } from "./factory.ts";
 export {
   type AgentContract,
+  type AgentRegistry,
   type AgentServiceDefinition,
+  type AgentServiceRegistryContract,
   type AgentServiceServerConfig,
+  type AgentServiceSingleAgentContract,
   defineAgentService,
   type DurableRunSink,
+  type NormalizedAgentServiceContract,
 } from "./agent-service.ts";
 export {
   type AgUiRuntimeHandlerConfig,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.283";
+export const VERSION = "0.1.284";


### PR DESCRIPTION
## Summary\n- widen the Phase 0 hosted agent service contract to support an agent registry plus defaultAgentId\n- keep single-agent convenience while documenting that implementations normalize it into the registry path\n- bump framework version to 0.1.284 for the next agent reshape adoption slice\n\n## Verification\n- deno fmt --check deno.json src/agent/agent-service.ts src/agent/agent-service.test.ts src/agent/index.ts\n- deno task lint\n- deno task typecheck\n- deno test --no-check --allow-all src/agent/agent-service.test.ts\n- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/agent/agent-service.test.ts\n- pre-push checks: format, lint, typecheck, unit tests\n\nAgent reshape Phase 0 correction toward docs/plans/agent-reshape.md.