### PR TITLE
Move sandbox in-cluster endpoint routing into the framework

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.284",
+  "version": "0.1.285",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -32,4 +32,8 @@ export {
   type SandboxOptions,
   type SandboxSession,
 } from "./sandbox.ts";
-export { LazySandbox, type LazySandboxOptions } from "./lazy-sandbox.ts";
+export {
+  LazySandbox,
+  type LazySandboxOptions,
+  resolveDefaultSandboxRuntimeEndpoint,
+} from "./lazy-sandbox.ts";

--- a/src/sandbox/lazy-sandbox.ts
+++ b/src/sandbox/lazy-sandbox.ts
@@ -1,4 +1,5 @@
 import { REQUEST_ERROR } from "#veryfront/errors";
+import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import {
   type CommandJob,
   type CommandJobOutput,
@@ -44,6 +45,28 @@ const REPROVISIONABLE_EXEC_START_ERROR_CODES = new Set([
   "ENOTFOUND",
   "EHOSTUNREACH",
 ]);
+const VERYFRONT_SANDBOX_PUBLIC_HOST_PATTERN = /^([a-z0-9-]+)\.sandbox\.veryfront\.[a-z0-9.-]+$/i;
+
+export function resolveDefaultSandboxRuntimeEndpoint(input: { endpoint: string }): string {
+  if (!getHostEnv("KUBERNETES_SERVICE_HOST")) {
+    return input.endpoint;
+  }
+
+  let hostname: string;
+  try {
+    hostname = new URL(input.endpoint).hostname;
+  } catch {
+    return input.endpoint;
+  }
+
+  const match = hostname.match(VERYFRONT_SANDBOX_PUBLIC_HOST_PATTERN);
+  const shortId = match?.[1];
+  if (!shortId) {
+    return input.endpoint;
+  }
+
+  return `http://sandbox.veryfront-sandbox-${shortId}.svc.cluster.local`;
+}
 
 /** Lazily provisions sandbox sessions and keeps them alive while in use. */
 export class LazySandbox {
@@ -624,7 +647,8 @@ export class LazySandbox {
   private resolveRuntimeEndpoint(): string {
     const endpoint = this.requireEndpoint();
     const sessionId = this.requireSessionId();
-    return this.resolveRuntimeEndpointOption?.({ endpoint, sessionId }) ?? endpoint;
+    return this.resolveRuntimeEndpointOption?.({ endpoint, sessionId }) ??
+      resolveDefaultSandboxRuntimeEndpoint({ endpoint });
   }
 
   private requireSessionId(): string {

--- a/src/sandbox/sandbox.test-helpers.ts
+++ b/src/sandbox/sandbox.test-helpers.ts
@@ -6,6 +6,7 @@ export type MockResponseEntry =
 export const SANDBOX_ENV_KEYS = [
   "VERYFRONT_API_TOKEN",
   "VERYFRONT_API_URL",
+  "KUBERNETES_SERVICE_HOST",
 ] as const;
 
 const originalSetTimeout = globalThis.setTimeout;

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -18,6 +18,7 @@ import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront
 import { runWithProjectEnv } from "../server/project-env/storage.ts";
 import type { ExecStreamEvent } from "./sandbox.ts";
 import { Sandbox } from "./sandbox.ts";
+import { resolveDefaultSandboxRuntimeEndpoint } from "./lazy-sandbox.ts";
 
 // Mock fetch for testing
 const originalFetch = globalThis.fetch;
@@ -679,6 +680,33 @@ describe("Sandbox", () => {
         () => sandbox.close(),
         Error,
         "Close sandbox failed: 503 delete failed",
+      );
+    });
+  });
+
+  describe("resolveDefaultSandboxRuntimeEndpoint()", () => {
+    it("keeps public sandbox endpoints outside Kubernetes", () => {
+      assertEquals(
+        resolveDefaultSandboxRuntimeEndpoint({ endpoint: "https://abc123.sandbox.veryfront.com" }),
+        "https://abc123.sandbox.veryfront.com",
+      );
+    });
+
+    it("routes public sandbox endpoints to their in-cluster service in Kubernetes", () => {
+      setEnv("KUBERNETES_SERVICE_HOST", "10.0.0.1");
+
+      assertEquals(
+        resolveDefaultSandboxRuntimeEndpoint({ endpoint: "https://abc123.sandbox.veryfront.com" }),
+        "http://sandbox.veryfront-sandbox-abc123.svc.cluster.local",
+      );
+    });
+
+    it("keeps non-matching sandbox endpoints unchanged in Kubernetes", () => {
+      setEnv("KUBERNETES_SERVICE_HOST", "10.0.0.1");
+
+      assertEquals(
+        resolveDefaultSandboxRuntimeEndpoint({ endpoint: "https://sandbox.example.com" }),
+        "https://sandbox.example.com",
       );
     });
   });

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.284";
+export const VERSION = "0.1.285";


### PR DESCRIPTION
## Summary
- adds a default LazySandbox runtime endpoint resolver for Kubernetes-hosted Veryfront sandbox endpoints
- keeps non-Kubernetes and non-matching endpoints unchanged
- preserves the custom resolver hook for non-default runtimes
- bumps veryfront to 0.1.285 for the next agent adoption slice

## Verification
- deno fmt --check deno.json src/sandbox/lazy-sandbox.ts src/sandbox/index.ts src/sandbox/sandbox.test.ts src/utils/version-constant.ts
- deno task lint
- deno task typecheck
- deno test --no-check --allow-all src/utils/version.test.ts src/sandbox/sandbox.test.ts

Related to agent reshape Phase 1/2 sandbox lifecycle shrink.