### PR TITLE
Export chat message preparation helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.287",
+  "version": "0.1.288",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [
@@ -64,7 +64,8 @@
     "./extensions": "./src/extensions/index.ts",
     "./extensions/interfaces": "./src/extensions/interfaces/index.ts",
     "./cli": "./cli/main.ts",
-    "./chat/conversation": "./src/chat/conversation.ts"
+    "./chat/conversation": "./src/chat/conversation.ts",
+    "./chat/message-prep": "./src/chat/message-prep.ts"
   },
   "imports": {
     "veryfront/head": "./src/react/runtime/core.ts",
@@ -275,7 +276,8 @@
     "vfile": "npm:vfile@6.0.3",
     "class-variance-authority": "npm:class-variance-authority@0.7.1",
     "tailwind-merge": "npm:tailwind-merge@3.5.0",
-    "veryfront/chat/conversation": "./src/chat/conversation.ts"
+    "veryfront/chat/conversation": "./src/chat/conversation.ts",
+    "veryfront/chat/message-prep": "./src/chat/message-prep.ts"
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/scripts/build/browser-safe-exports.mjs
+++ b/scripts/build/browser-safe-exports.mjs
@@ -8,6 +8,7 @@ export const BROWSER_SAFE_EXPORTS = [
   "./chat/protocol",
   "./chat/types",
   "./chat/conversation",
+  "./chat/message-prep",
   "./markdown",
   "./mdx",
 ];

--- a/src/chat/message-prep.test.ts
+++ b/src/chat/message-prep.test.ts
@@ -1,0 +1,168 @@
+import { assertEquals, assertMatch, assertStringIncludes } from "#std/assert";
+import type { ChatModelMessage } from "./types.ts";
+import {
+  compressTurn,
+  enforceTokenBudget,
+  estimateTokens,
+  maskOldToolOutputs,
+  repairToolPairs,
+} from "./message-prep.ts";
+
+Deno.test("repairToolPairs moves a later tool result immediately after the matching tool call", () => {
+  const messages = [
+    {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "I want to build a bank" }],
+    },
+    {
+      role: "assistant" as const,
+      content: [
+        { type: "text" as const, text: "Let me gather one more detail first." },
+        {
+          type: "tool-call" as const,
+          toolCallId: "tool-form",
+          toolName: "form_input",
+          input: { title: "Bank builder intake" },
+        },
+      ],
+    },
+    {
+      role: "assistant" as const,
+      content: [{ type: "text" as const, text: "Waiting for your response." }],
+    },
+    {
+      role: "tool" as const,
+      content: [
+        {
+          type: "tool-result" as const,
+          toolCallId: "tool-form",
+          toolName: "form_input",
+          output: {
+            type: "json" as const,
+            value: {
+              submitted: true,
+              values: {
+                bank_type: "dashboard",
+              },
+            },
+          },
+        },
+      ],
+    },
+  ];
+
+  const repaired = repairToolPairs(messages);
+  const serialized = JSON.stringify(repaired);
+  const toolResultMatches = serialized.match(/"toolCallId":"tool-form"/g) ?? [];
+  const unavailableMatches = serialized.match(/\[tool result unavailable\]/g) ?? [];
+
+  assertEquals(toolResultMatches.length, 2);
+  assertEquals(unavailableMatches.length, 0);
+  assertEquals(repaired, [messages[0], messages[1], messages[3], messages[2]]);
+});
+
+Deno.test("maskOldToolOutputs masks large historical tool outputs and removes stale reasoning before the latest user turn", () => {
+  const messages = [
+    { role: "user", content: "run the check" },
+    {
+      role: "assistant",
+      content: [
+        { type: "reasoning", text: "old private chain" },
+        {
+          type: "tool-call",
+          toolCallId: "call-1",
+          toolName: "bash",
+          input: { command: "npm test" },
+        },
+      ],
+    },
+    {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "call-1",
+          toolName: "bash",
+          output: { type: "json", value: { exitCode: 0, stdout: "x".repeat(600) } },
+        },
+      ],
+    },
+    { role: "user", content: "now summarize it" },
+  ] satisfies ChatModelMessage[];
+
+  const masked = maskOldToolOutputs(messages);
+
+  assertEquals(masked[1], {
+    role: "assistant",
+    content: [{
+      type: "tool-call",
+      toolCallId: "call-1",
+      toolName: "bash",
+      input: { command: "npm test" },
+    }],
+  });
+  assertStringIncludes(JSON.stringify(masked[2]), "[Command: npm test — exit 0, output omitted");
+  assertEquals(masked[3], messages[3]);
+});
+
+Deno.test("enforceTokenBudget compresses the oldest turn before dropping later turns", () => {
+  const messages = [
+    { role: "user" as const, content: "old request ".repeat(100) },
+    { role: "assistant" as const, content: "old answer ".repeat(100) },
+    { role: "user" as const, content: "middle request ".repeat(5) },
+    { role: "assistant" as const, content: "middle answer ".repeat(5) },
+    { role: "user" as const, content: "latest request ".repeat(5) },
+    { role: "assistant" as const, content: "latest answer ".repeat(5) },
+  ];
+
+  const totalTokens = messages.reduce((sum, message) => sum + estimateTokens(message.content), 0);
+  const compacted = enforceTokenBudget(messages, totalTokens - 1);
+
+  assertMatch(String(compacted[0].content), /^\[Compressed:/);
+  assertEquals(compacted[1], {
+    role: "assistant",
+    content: "Acknowledged.",
+  });
+  assertEquals(compacted.slice(-2), messages.slice(-2));
+});
+
+Deno.test("enforceTokenBudget can still drop the oldest compressed turn when the budget remains too small", () => {
+  const messages = [
+    { role: "user" as const, content: "turn one ".repeat(120) },
+    { role: "assistant" as const, content: "answer one ".repeat(120) },
+    { role: "user" as const, content: "turn two ".repeat(120) },
+    { role: "assistant" as const, content: "answer two ".repeat(120) },
+    { role: "user" as const, content: "turn three ".repeat(120) },
+    { role: "assistant" as const, content: "answer three ".repeat(120) },
+    { role: "user" as const, content: "turn four ".repeat(120) },
+    { role: "assistant" as const, content: "answer four ".repeat(120) },
+  ];
+
+  const compacted = enforceTokenBudget(messages, 120);
+
+  assertEquals(compacted.length >= 4, true);
+  assertEquals(compacted[0], messages[4]);
+  assertEquals(compacted[1], messages[5]);
+  assertEquals(compacted[2], messages[6]);
+  assertEquals(compacted[3], messages[7]);
+});
+
+Deno.test("compressTurn emits a two-message summary shell", () => {
+  const messages = [
+    { role: "user" as const, content: "please do something important" },
+    {
+      role: "assistant" as const,
+      content: [
+        { type: "tool-call" as const, toolCallId: "tool-1", toolName: "web_search", input: {} },
+        { type: "text" as const, text: "Here is the final answer." },
+      ],
+    },
+  ];
+
+  const compressed = compressTurn(messages, 0, 1);
+  assertStringIncludes(String(compressed[0].content), "[Compressed: please do something important");
+  assertEquals(compressed[1], {
+    role: "assistant",
+    content: "Acknowledged.",
+  });
+});

--- a/src/chat/message-prep.ts
+++ b/src/chat/message-prep.ts
@@ -1,0 +1,616 @@
+import {
+  getStringField,
+  isReasoningPart,
+  isToolCallPart,
+  isToolResultPart,
+} from "./conversation.ts";
+import type { ChatModelMessage, ChatToolResultOutput, ChatToolResultPart } from "./types.ts";
+
+const CHARS_PER_TOKEN = 4;
+
+export function estimateTokens(value: unknown): number {
+  return Math.ceil(JSON.stringify(value ?? "").length / CHARS_PER_TOKEN);
+}
+
+function truncate(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return `${text.slice(0, maxLen)}…`;
+}
+
+export function compressTurn(
+  messages: ChatModelMessage[],
+  startIdx: number,
+  endIdx: number,
+): ChatModelMessage[] {
+  let userQuery = "";
+  const toolNames: string[] = [];
+  let assistantConclusion = "";
+
+  for (let i = startIdx; i <= endIdx; i++) {
+    const msg = messages[i];
+    if (msg.role === "user") {
+      const text = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
+      userQuery = truncate(text, 100);
+    } else if (msg.role === "assistant" && Array.isArray(msg.content)) {
+      for (const part of msg.content) {
+        if (part.type === "tool-call") {
+          toolNames.push(part.toolName);
+        } else if (part.type === "text") {
+          assistantConclusion = truncate(part.text, 150);
+        }
+      }
+    } else if (msg.role === "assistant" && typeof msg.content === "string") {
+      assistantConclusion = truncate(msg.content, 150);
+    }
+  }
+
+  const toolSummary = toolNames.length > 0 ? ` → used ${toolNames.join(", ")}` : "";
+  const conclusionSummary = assistantConclusion ? ` → ${assistantConclusion}` : "";
+  const summary = `[Compressed: ${userQuery}${toolSummary}${conclusionSummary}]`;
+
+  return [
+    { role: "user", content: summary },
+    { role: "assistant", content: "Acknowledged." },
+  ];
+}
+
+interface TurnWindow {
+  startIdx: number;
+  endIdx: number;
+  tokens: number;
+  compressed?: boolean;
+}
+
+function collectTurns(messages: ChatModelMessage[]): TurnWindow[] {
+  const turns: TurnWindow[] = [];
+  let currentTurn: TurnWindow | null = null;
+
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].role === "user") {
+      if (currentTurn) {
+        currentTurn.endIdx = i - 1;
+        turns.push(currentTurn);
+      }
+      currentTurn = { startIdx: i, endIdx: i, tokens: estimateTokens(messages[i].content) };
+    } else if (currentTurn) {
+      currentTurn.endIdx = i;
+      currentTurn.tokens += estimateTokens(messages[i].content);
+    }
+  }
+
+  if (currentTurn) {
+    currentTurn.endIdx = messages.length - 1;
+    turns.push(currentTurn);
+  }
+
+  return turns;
+}
+
+export function enforceTokenBudgetWithTurnCompression(
+  messages: ChatModelMessage[],
+  budget: number,
+  overhead: number,
+): ChatModelMessage[] {
+  const effectiveBudget = budget - overhead;
+  let totalTokens = messages.reduce((sum, message) => sum + estimateTokens(message.content), 0);
+  if (totalTokens <= effectiveBudget) return messages;
+
+  const turns = collectTurns(messages);
+  const minKeep = Math.min(2, turns.length);
+  const result = [...messages];
+
+  let compressCount = 0;
+  while (totalTokens > effectiveBudget && compressCount < turns.length - minKeep) {
+    const turn = turns[compressCount];
+    if (turn.compressed) {
+      compressCount++;
+      continue;
+    }
+
+    const compressed = compressTurn(messages, turn.startIdx, turn.endIdx);
+    const compressedTokens = compressed.reduce(
+      (sum, message) => sum + estimateTokens(message.content),
+      0,
+    );
+    const saved = turn.tokens - compressedTokens;
+    if (saved <= 0) {
+      compressCount++;
+      continue;
+    }
+
+    const turnLength = turn.endIdx - turn.startIdx + 1;
+    result.splice(turn.startIdx, turnLength, ...compressed);
+    const indexShift = compressed.length - turnLength;
+    for (let j = compressCount + 1; j < turns.length; j++) {
+      turns[j].startIdx += indexShift;
+      turns[j].endIdx += indexShift;
+    }
+    turn.endIdx = turn.startIdx + compressed.length - 1;
+    turn.tokens = compressedTokens;
+    turn.compressed = true;
+    totalTokens -= saved;
+    compressCount++;
+  }
+
+  if (totalTokens <= effectiveBudget) return result;
+
+  const finalTurns = collectTurns(result);
+  const finalMinKeep = Math.min(2, finalTurns.length);
+  let dropCount = 0;
+  while (totalTokens > effectiveBudget && dropCount < finalTurns.length - finalMinKeep) {
+    totalTokens -= finalTurns[dropCount].tokens;
+    dropCount++;
+  }
+
+  if (dropCount === 0) return result;
+
+  const firstKeepIdx = finalTurns[dropCount].startIdx;
+  return result.slice(firstKeepIdx);
+}
+
+const BUDGET_RATIO = 0.85;
+const DEFAULT_CONTEXT_WINDOW = 200_000;
+const DEFAULT_TOKEN_BUDGET = Math.floor(DEFAULT_CONTEXT_WINDOW * BUDGET_RATIO);
+const TOKENS_PER_TOOL = 250;
+
+const MASK_THRESHOLD = 500;
+
+function serializedLength(value: unknown): number {
+  return JSON.stringify(value ?? "").length;
+}
+
+function tryParseJson(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+interface ToolCallInfo {
+  toolName: string;
+  input: unknown;
+}
+
+function buildToolCallMap(messages: ChatModelMessage[]): Map<string, ToolCallInfo> {
+  const map = new Map<string, ToolCallInfo>();
+
+  for (const msg of messages) {
+    if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
+    for (const part of msg.content) {
+      if (isToolCallPart(part)) {
+        map.set(part.toolCallId, { toolName: part.toolName, input: part.input });
+      }
+    }
+  }
+
+  return map;
+}
+
+function maskReadFile(input: unknown, charCount: number): string {
+  const path = getStringField(input, "path", "unknown");
+  return `[File read: ${path} — content omitted (${charCount} chars)]`;
+}
+
+function maskBash(input: unknown, output: unknown, charCount: number): string {
+  const cmd = truncate(getStringField(input, "command", "unknown"), 80);
+  let exitCode = "?";
+  const parsed = tryParseJson(output);
+  if (isRecord(parsed) && "exitCode" in parsed) {
+    exitCode = String(parsed.exitCode);
+  }
+  return `[Command: ${cmd} — exit ${exitCode}, output omitted (${charCount} chars)]`;
+}
+
+function maskWebSearch(output: unknown): unknown {
+  const parsed = tryParseJson(output);
+  if (!Array.isArray(parsed)) return output;
+  return parsed.map((item: unknown) => {
+    if (!isRecord(item)) return item;
+    const { encryptedContent: _, ...rest } = item;
+    return rest;
+  });
+}
+
+function maskWebFetch(input: unknown, charCount: number): string {
+  const url = getStringField(input, "url", "unknown");
+  return `[Fetched: ${url} — content omitted (${charCount} chars)]`;
+}
+
+function maskTask(output: unknown, charCount: number): unknown {
+  const parsed = tryParseJson(output);
+  if (!isRecord(parsed)) {
+    return `[task output omitted (${charCount} chars)]`;
+  }
+
+  const masked: Record<string, unknown> = {};
+
+  if ("success" in parsed) masked.success = parsed.success;
+  if ("description" in parsed) masked.description = parsed.description;
+  if ("result" in parsed) {
+    masked.result = typeof parsed.result === "string"
+      ? truncate(parsed.result, 500)
+      : parsed.result;
+  }
+
+  return masked;
+}
+
+function maskGeneric(toolName: string, charCount: number): string {
+  return `[${toolName} output omitted (${charCount} chars)]`;
+}
+
+function getOutputValue(output: unknown): unknown {
+  if (!isRecord(output)) return output;
+  if ((output.type === "text" || output.type === "json") && "value" in output) {
+    return output.value;
+  }
+  return output;
+}
+
+function wrapToolResultOutput(
+  original: ChatToolResultOutput,
+  newValue: unknown,
+): ChatToolResultOutput {
+  const textValue = typeof newValue === "string" ? newValue : JSON.stringify(newValue);
+  if (original.type === "text") {
+    return { ...original, value: textValue };
+  }
+  if (original.type === "json") {
+    return { type: "text", value: textValue };
+  }
+  return original;
+}
+
+export function maskOldToolOutputs(messages: ChatModelMessage[]): ChatModelMessage[] {
+  let lastUserIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "user") {
+      lastUserIdx = i;
+      break;
+    }
+  }
+
+  if (lastUserIdx <= 0) return messages;
+
+  const toolCallMap = buildToolCallMap(messages);
+
+  return messages.map((msg, idx) => {
+    if (idx >= lastUserIdx) return msg;
+
+    if (msg.role === "assistant" && Array.isArray(msg.content)) {
+      const filtered = msg.content.filter((part) => !isReasoningPart(part));
+      if (filtered.length !== msg.content.length) {
+        return { ...msg, content: filtered };
+      }
+      return msg;
+    }
+
+    if (msg.role !== "tool" || !Array.isArray(msg.content)) return msg;
+
+    const newContent: ChatToolResultPart[] = msg.content.map((part) => {
+      if (part.type !== "tool-result") {
+        return part;
+      }
+
+      const rawValue = getOutputValue(part.output);
+      const charCount = serializedLength(rawValue);
+
+      if (charCount < MASK_THRESHOLD) return part;
+
+      const callInfo = toolCallMap.get(part.toolCallId);
+      const toolName = part.toolName || callInfo?.toolName || "unknown";
+      const input = callInfo?.input;
+
+      let masked: unknown;
+
+      switch (toolName) {
+        case "readFile":
+        case "get_file":
+          masked = maskReadFile(input, charCount);
+          break;
+        case "bash":
+          masked = maskBash(input, rawValue, charCount);
+          break;
+        case "web_search":
+          masked = maskWebSearch(rawValue);
+          break;
+        case "web_fetch":
+          masked = maskWebFetch(input, charCount);
+          break;
+        case "task":
+          masked = maskTask(rawValue, charCount);
+          break;
+        default:
+          masked = maskGeneric(toolName, charCount);
+          break;
+      }
+
+      return { ...part, output: wrapToolResultOutput(part.output, masked) };
+    });
+
+    return { ...msg, content: newContent };
+  });
+}
+
+function createSyntheticToolResult(toolCallId: string, toolName: string): ChatToolResultPart {
+  return {
+    type: "tool-result",
+    toolCallId,
+    toolName,
+    output: { type: "text", value: "[tool result unavailable]" },
+  };
+}
+
+export function repairToolPairs(messages: ChatModelMessage[]): ChatModelMessage[] {
+  const result = [...messages];
+  let mutated = false;
+
+  for (let index = 0; index < result.length; index++) {
+    const message = result[index];
+    if (message.role !== "assistant" || !Array.isArray(message.content)) {
+      continue;
+    }
+
+    const inlineResultIds = new Set<string>();
+    for (const part of message.content) {
+      if (isToolResultPart(part)) {
+        inlineResultIds.add(part.toolCallId);
+      }
+    }
+
+    const repairedContent: typeof message.content = [];
+    const regularToolCalls: Array<{ id: string; toolName: string }> = [];
+
+    for (const part of message.content) {
+      repairedContent.push(part);
+
+      if (!isToolCallPart(part)) {
+        continue;
+      }
+
+      const toolName = part.toolName ?? "unknown";
+
+      if (part.providerExecuted) {
+        if (!inlineResultIds.has(part.toolCallId)) {
+          repairedContent.push(createSyntheticToolResult(part.toolCallId, toolName));
+          mutated = true;
+        }
+        continue;
+      }
+
+      if (!inlineResultIds.has(part.toolCallId)) {
+        regularToolCalls.push({ id: part.toolCallId, toolName });
+      }
+    }
+
+    if (repairedContent.length !== message.content.length) {
+      result[index] = {
+        ...message,
+        content: repairedContent,
+      };
+    }
+
+    if (regularToolCalls.length === 0) {
+      continue;
+    }
+
+    const nextMessage = result[index + 1];
+    const immediateResultIds = new Set<string>();
+
+    if (nextMessage?.role === "tool" && Array.isArray(nextMessage.content)) {
+      for (const part of nextMessage.content) {
+        if (isToolResultPart(part)) {
+          immediateResultIds.add(part.toolCallId);
+        }
+      }
+    }
+
+    const unresolvedCalls = regularToolCalls.filter((toolCall) =>
+      !immediateResultIds.has(toolCall.id)
+    );
+    if (unresolvedCalls.length === 0) {
+      continue;
+    }
+
+    const movedResults = new Map<string, ChatToolResultPart>();
+
+    for (
+      let laterIndex = index + 2;
+      laterIndex < result.length && movedResults.size < unresolvedCalls.length;
+      laterIndex++
+    ) {
+      const laterMessage = result[laterIndex];
+      if (laterMessage?.role !== "tool" || !Array.isArray(laterMessage.content)) {
+        continue;
+      }
+
+      let removedFromLater = false;
+      const keptLaterContent = laterMessage.content.filter((part) => {
+        if (!isToolResultPart(part)) {
+          return true;
+        }
+
+        if (
+          !unresolvedCalls.some((toolCall) => toolCall.id === part.toolCallId) ||
+          movedResults.has(part.toolCallId)
+        ) {
+          return true;
+        }
+
+        movedResults.set(part.toolCallId, part);
+        removedFromLater = true;
+        return false;
+      });
+
+      if (!removedFromLater) {
+        continue;
+      }
+
+      mutated = true;
+      if (keptLaterContent.length === 0) {
+        result.splice(laterIndex, 1);
+        laterIndex--;
+        continue;
+      }
+
+      result[laterIndex] = {
+        ...laterMessage,
+        content: keptLaterContent,
+      };
+    }
+
+    const repairedResults = unresolvedCalls.map(
+      (toolCall) =>
+        movedResults.get(toolCall.id) ?? createSyntheticToolResult(toolCall.id, toolCall.toolName),
+    );
+
+    if (nextMessage?.role === "tool" && Array.isArray(nextMessage.content)) {
+      result[index + 1] = {
+        ...nextMessage,
+        content: [...repairedResults, ...nextMessage.content],
+      };
+    } else {
+      const toolMessage: ChatModelMessage = {
+        role: "tool",
+        content: repairedResults,
+      };
+      result.splice(index + 1, 0, toolMessage);
+    }
+    mutated = true;
+  }
+
+  return mutated ? result : messages;
+}
+
+export function estimateOverhead(instructions: unknown, toolCount: number): number {
+  const instructionTokens = estimateTokens(instructions);
+  return instructionTokens + toolCount * TOKENS_PER_TOOL;
+}
+
+export function ensureToolCallInputs(messages: ChatModelMessage[]): ChatModelMessage[] {
+  let mutated = false;
+
+  const result = messages.map((msg) => {
+    if (msg.role !== "assistant" || !Array.isArray(msg.content)) return msg;
+
+    let msgMutated = false;
+    const newContent = msg.content.map((part) => {
+      if (isToolCallPart(part)) {
+        const input = part.input;
+        if (
+          input === undefined || input === null || typeof input !== "object" || Array.isArray(input)
+        ) {
+          msgMutated = true;
+          return { ...part, input: {} };
+        }
+      }
+      return part;
+    });
+
+    if (msgMutated) {
+      mutated = true;
+      return { ...msg, content: newContent };
+    }
+    return msg;
+  });
+
+  return mutated ? result : messages;
+}
+
+export function compactForStep(
+  messages: ChatModelMessage[],
+  overhead: number = 0,
+): ChatModelMessage[] {
+  const compacted = enforceTokenBudget(
+    maskOldToolOutputs(messages),
+    DEFAULT_TOKEN_BUDGET,
+    overhead,
+  );
+
+  let end = compacted.length;
+  while (end > 1 && compacted[end - 1].role === "assistant") {
+    end--;
+  }
+
+  const trimmed = end < compacted.length ? compacted.slice(0, end) : compacted;
+
+  return ensureToolCallInputs(repairToolPairs(dedupeToolHistory(trimmed)));
+}
+
+export function dedupeToolHistory(messages: ChatModelMessage[]): ChatModelMessage[] {
+  const seenToolCallIds = new Set<string>();
+  const seenToolResultIds = new Set<string>();
+  let mutated = false;
+
+  const deduped: ChatModelMessage[] = [];
+
+  const filterParts = <T>(parts: T[]): { filtered: T[]; changed: boolean } => {
+    const filtered = parts.filter((part) => {
+      if (isToolCallPart(part)) {
+        if (seenToolCallIds.has(part.toolCallId)) {
+          mutated = true;
+          return false;
+        }
+        seenToolCallIds.add(part.toolCallId);
+        return true;
+      }
+      if (isToolResultPart(part)) {
+        if (seenToolResultIds.has(part.toolCallId)) {
+          mutated = true;
+          return false;
+        }
+        seenToolResultIds.add(part.toolCallId);
+        return true;
+      }
+      return true;
+    });
+    return { filtered, changed: filtered.length !== parts.length };
+  };
+
+  for (const message of messages) {
+    if (message.role === "user" && Array.isArray(message.content)) {
+      const { filtered, changed } = filterParts(message.content);
+      if (!changed) {
+        deduped.push(message);
+        continue;
+      }
+      if (filtered.length > 0) deduped.push({ ...message, content: filtered });
+    } else if (message.role === "assistant" && Array.isArray(message.content)) {
+      const { filtered, changed } = filterParts(message.content);
+      if (!changed) {
+        deduped.push(message);
+        continue;
+      }
+      if (filtered.length > 0) deduped.push({ ...message, content: filtered });
+    } else if (message.role === "tool") {
+      const { filtered, changed } = filterParts(message.content);
+      if (!changed) {
+        deduped.push(message);
+        continue;
+      }
+      if (filtered.length > 0) deduped.push({ ...message, content: filtered });
+    } else {
+      deduped.push(message);
+    }
+  }
+
+  return mutated ? deduped : messages;
+}
+
+export function enforceTokenBudget(
+  messages: ChatModelMessage[],
+  budget: number = DEFAULT_TOKEN_BUDGET,
+  overhead: number = 0,
+): ChatModelMessage[] {
+  if (messages.length === 0) {
+    return messages;
+  }
+
+  return enforceTokenBudgetWithTurnCompression(messages, budget, overhead);
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.287";
+export const VERSION = "0.1.288";


### PR DESCRIPTION
## Summary
- add a browser-safe veryfront/chat/message-prep export for shared chat preparation primitives
- include token-budget compression, historical tool-output masking, duplicate tool history removal, and tool-call/result repair helpers
- bump framework version to 0.1.288 for the next hosted adoption slice

## Verification
- deno fmt --check deno.json scripts/build/browser-safe-exports.mjs src/utils/version-constant.ts src/chat/message-prep.ts src/chat/message-prep.test.ts
- deno test --no-check --allow-all src/chat/message-prep.test.ts src/chat/conversation.test.ts src/chat/types.test.ts src/chat/index.test.ts
- deno task lint
- deno task typecheck
- deno task build:npm
- deno task docs:verify-npm
- pre-push format/lint/typecheck/unit tests

## Notes
- Product-specific upload signing and framework-message conversion stay outside this seam.