### PR TITLE
Keep chat fallback timers test-controllable

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.289",
+  "version": "0.1.290",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/scripts/build/browser-safe-exports.mjs
+++ b/scripts/build/browser-safe-exports.mjs
@@ -15,6 +15,10 @@ export const BROWSER_SAFE_EXPORTS = [
   "./mdx",
 ];
 
+export const BROWSER_SAFE_DNT_TIMER_MODULES = [
+  "src/chat/final-step-fallback.js",
+];
+
 export const BROWSER_SAFE_CLIENT_MODULES = [
   "src/agent/react/use-voice-input.js",
   "src/react/components/chat/chat/components/code-block.js",

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -12,7 +12,11 @@
  */
 
 import { build, emptyDir } from "jsr:@deno/dnt";
-import { BROWSER_SAFE_CLIENT_MODULES, BROWSER_SAFE_EXPORTS } from "./browser-safe-exports.mjs";
+import {
+	BROWSER_SAFE_CLIENT_MODULES,
+	BROWSER_SAFE_DNT_TIMER_MODULES,
+	BROWSER_SAFE_EXPORTS,
+} from "./browser-safe-exports.mjs";
 
 const denoJson = JSON.parse(await Deno.readTextFile("./deno.json"));
 const version = denoJson.version;
@@ -217,7 +221,10 @@ await build({
 			}
 		}
 
-		for (const path of BROWSER_SAFE_CLIENT_MODULES) {
+		for (const path of [
+			...BROWSER_SAFE_CLIENT_MODULES,
+			...BROWSER_SAFE_DNT_TIMER_MODULES,
+		]) {
 			normalizeBrowserTimerShim(
 				`./npm/esm/${path}`,
 				`${path} browser-safe dnt shim removal`,

--- a/src/chat/final-step-fallback.ts
+++ b/src/chat/final-step-fallback.ts
@@ -728,13 +728,13 @@ async function resolveStreamPromiseWithTimeout<T>(
   timeoutMs: number,
   fallback: T,
 ): Promise<T> {
-  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
 
   try {
     const resolved = await Promise.race([
       Promise.resolve(promise),
       new Promise<typeof STREAM_PROMISE_TIMEOUT_TOKEN>((resolve) => {
-        timeoutId = setTimeout(() => resolve(STREAM_PROMISE_TIMEOUT_TOKEN), timeoutMs);
+        timeoutId = globalThis.setTimeout(() => resolve(STREAM_PROMISE_TIMEOUT_TOKEN), timeoutMs);
       }),
     ]);
 
@@ -747,7 +747,7 @@ async function resolveStreamPromiseWithTimeout<T>(
     return fallback;
   } finally {
     if (timeoutId) {
-      clearTimeout(timeoutId);
+      globalThis.clearTimeout(timeoutId);
     }
   }
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.289";
+export const VERSION = "0.1.290";


### PR DESCRIPTION
## Summary
- keep the final-step fallback timeout helper on runtime global timers
- strip dnt timer shims from the browser-safe final-step fallback npm module
- bump the framework package to 0.1.290 for the downstream adoption fix

## Verification
- deno fmt --check deno.json src/utils/version-constant.ts src/chat/final-step-fallback.ts scripts/build/build-npm-dnt.ts
- deno test --no-check --allow-all src/chat/final-step-fallback.test.ts src/chat/provider-errors.test.ts src/chat/conversation.test.ts src/chat/message-prep.test.ts
- deno task lint
- deno task typecheck
- deno task build:npm
- deno task docs:verify-npm
- pre-push checks: format, lint, typecheck, unit tests (1449 passed, 0 failed)