### PR TITLE
Share AG-UI runtime message mapping

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.290",
+  "version": "0.1.291",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/chat/ag-ui.test.ts
+++ b/src/chat/ag-ui.test.ts
@@ -4,6 +4,7 @@ import {
   createAgUiChatEventDecoderState,
   decodeAgUiSseChunk,
   flushAgUiSseChunk,
+  mapAgUiRuntimeMessagesToChatUiMessages,
   parseSseEvent,
 } from "./ag-ui.ts";
 
@@ -340,5 +341,138 @@ describe("chat/ag-ui", () => {
       type: "data-state-delta",
       data: { phase: "planning" },
     }]);
+  });
+
+  it("maps runtime-native messages into chat UI messages with tool results", () => {
+    const result = mapAgUiRuntimeMessagesToChatUiMessages([
+      {
+        id: "system-1",
+        role: "system",
+        content: "Follow the project instructions",
+      },
+      {
+        id: "user-1",
+        role: "user",
+        content: "Inspect the project first",
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: "Trying a search",
+        toolCalls: [
+          {
+            id: "tool-call-1",
+            type: "function",
+            function: {
+              name: "search_files",
+              arguments: '{"query":"auth"}',
+            },
+          },
+        ],
+      },
+      {
+        id: "tool-1",
+        role: "tool",
+        toolCallId: "tool-call-1",
+        content: '{"matches":2}',
+      },
+    ]);
+
+    assertEquals(result, [
+      {
+        id: "system-1",
+        role: "system",
+        parts: [{ type: "text", text: "Follow the project instructions" }],
+      },
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Inspect the project first" }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "Trying a search" },
+          {
+            type: "dynamic-tool",
+            toolName: "search_files",
+            toolCallId: "tool-call-1",
+            input: { query: "auth" },
+            state: "output-available",
+            output: { matches: 2 },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("maps runtime tool errors and orphan tool results into assistant tool parts", () => {
+    const result = mapAgUiRuntimeMessagesToChatUiMessages([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: "Working",
+        toolCalls: [
+          {
+            id: "tool-call-1",
+            type: "function",
+            function: {
+              name: "search_files",
+              arguments: "not-json",
+            },
+          },
+        ],
+      },
+      {
+        id: "tool-1",
+        role: "tool",
+        toolCallId: "tool-call-1",
+        content: "ignored on error",
+        error: "search failed",
+      },
+      {
+        id: "tool-orphan",
+        role: "tool",
+        toolCallId: "missing-tool-call",
+        content: '{"matches":2}',
+      },
+      {
+        id: "assistant-empty",
+        role: "assistant",
+      },
+    ]);
+
+    assertEquals(result, [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "Working" },
+          {
+            type: "dynamic-tool",
+            toolName: "search_files",
+            toolCallId: "tool-call-1",
+            input: { raw: "not-json" },
+            state: "output-error",
+            errorText: "search failed",
+          },
+        ],
+      },
+      {
+        id: "tool-orphan",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolName: "unknown",
+            toolCallId: "missing-tool-call",
+            input: {},
+            state: "output-available",
+            output: { matches: 2 },
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/src/chat/ag-ui.ts
+++ b/src/chat/ag-ui.ts
@@ -10,6 +10,7 @@ import {
   toRenderableCustomChunk,
 } from "./ag-ui-helpers.ts";
 import type { ChatStreamEvent } from "./protocol.ts";
+import type { ChatUiMessage, ChatUiMessagePart } from "./types.ts";
 import { z } from "zod";
 
 type JsonPatchOperation = {
@@ -23,6 +24,40 @@ type ToolCallState = {
   toolName: string;
   argsText: string;
 };
+
+export type AgUiRuntimeToolCall = {
+  id: string;
+  type: "function";
+  function: {
+    name: string;
+    arguments: string;
+  };
+};
+
+export type AgUiRuntimeMessage =
+  | {
+    id: string;
+    role: "system";
+    content: string;
+  }
+  | {
+    id: string;
+    role: "user";
+    content: string;
+  }
+  | {
+    id: string;
+    role: "assistant";
+    content?: string;
+    toolCalls?: AgUiRuntimeToolCall[];
+  }
+  | {
+    id: string;
+    role: "tool";
+    toolCallId: string;
+    content: string;
+    error?: string;
+  };
 
 export type ParsedSseEvent = {
   id: number | null;
@@ -143,6 +178,195 @@ export const AgUiWireEventNameSchema = z.enum([
   "RunFinished",
   "RunError",
 ]);
+
+function parseRuntimeToolInput(rawArguments: string): unknown {
+  try {
+    return JSON.parse(rawArguments);
+  } catch {
+    return { raw: rawArguments };
+  }
+}
+
+function parseRuntimeToolOutput(rawContent: string): unknown {
+  try {
+    return JSON.parse(rawContent);
+  } catch {
+    return rawContent;
+  }
+}
+
+function createRuntimeSystemMessage(
+  message: Extract<AgUiRuntimeMessage, { role: "system" }>,
+): ChatUiMessage {
+  return {
+    id: message.id,
+    role: "system",
+    parts: [{ type: "text", text: message.content }],
+  };
+}
+
+function createRuntimeUserMessage(
+  message: Extract<AgUiRuntimeMessage, { role: "user" }>,
+): ChatUiMessage {
+  return {
+    id: message.id,
+    role: "user",
+    parts: [{ type: "text", text: message.content }],
+  };
+}
+
+function createRuntimeAssistantMessage(
+  message: Extract<AgUiRuntimeMessage, { role: "assistant" }>,
+): ChatUiMessage | null {
+  const parts: ChatUiMessagePart[] = [];
+
+  if (typeof message.content === "string" && message.content.trim().length > 0) {
+    parts.push({ type: "text", text: message.content });
+  }
+
+  for (const toolCall of message.toolCalls ?? []) {
+    parts.push({
+      type: "dynamic-tool",
+      toolName: toolCall.function.name,
+      toolCallId: toolCall.id,
+      input: parseRuntimeToolInput(toolCall.function.arguments),
+      state: "input-available",
+    });
+  }
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return {
+    id: message.id,
+    role: "assistant",
+    parts,
+  };
+}
+
+function buildResolvedRuntimeToolPart(input: {
+  toolName: string;
+  toolCallId: string;
+  toolInput: unknown;
+  title?: string;
+  providerExecuted?: boolean;
+  error?: string;
+  content: string;
+}): ChatUiMessagePart {
+  if (typeof input.error === "string" && input.error.length > 0) {
+    return {
+      type: "dynamic-tool",
+      toolName: input.toolName,
+      toolCallId: input.toolCallId,
+      ...(input.title ? { title: input.title } : {}),
+      ...(input.providerExecuted !== undefined ? { providerExecuted: input.providerExecuted } : {}),
+      input: input.toolInput,
+      state: "output-error",
+      errorText: input.error,
+    };
+  }
+
+  return {
+    type: "dynamic-tool",
+    toolName: input.toolName,
+    toolCallId: input.toolCallId,
+    ...(input.title ? { title: input.title } : {}),
+    ...(input.providerExecuted !== undefined ? { providerExecuted: input.providerExecuted } : {}),
+    input: input.toolInput,
+    state: "output-available",
+    output: parseRuntimeToolOutput(input.content),
+  };
+}
+
+function applyRuntimeToolResultMessage(
+  messages: ChatUiMessage[],
+  message: Extract<AgUiRuntimeMessage, { role: "tool" }>,
+): void {
+  for (let messageIndex = messages.length - 1; messageIndex >= 0; messageIndex -= 1) {
+    const currentMessage = messages[messageIndex];
+    if (currentMessage.role !== "assistant") {
+      continue;
+    }
+
+    const partIndex = currentMessage.parts.findIndex(
+      (part) =>
+        part.type === "dynamic-tool" &&
+        part.toolCallId === message.toolCallId &&
+        (part.state === "input-available" || part.state === "input-streaming"),
+    );
+
+    if (partIndex === -1) {
+      continue;
+    }
+
+    const part = currentMessage.parts[partIndex];
+    if (part.type !== "dynamic-tool") {
+      continue;
+    }
+
+    currentMessage.parts.splice(
+      partIndex,
+      1,
+      buildResolvedRuntimeToolPart({
+        toolName: part.toolName,
+        toolCallId: part.toolCallId,
+        ...(part.title ? { title: part.title } : {}),
+        ...(part.providerExecuted !== undefined ? { providerExecuted: part.providerExecuted } : {}),
+        toolInput: part.input,
+        error: message.error,
+        content: message.content,
+      }),
+    );
+    return;
+  }
+
+  messages.push({
+    id: message.id,
+    role: "assistant",
+    parts: [
+      buildResolvedRuntimeToolPart({
+        toolName: "unknown",
+        toolCallId: message.toolCallId,
+        toolInput: {},
+        error: message.error,
+        content: message.content,
+      }),
+    ],
+  });
+}
+
+export function mapAgUiRuntimeMessagesToChatUiMessages(
+  messages: AgUiRuntimeMessage[],
+): ChatUiMessage[] {
+  const mappedMessages: ChatUiMessage[] = [];
+
+  for (const message of messages) {
+    switch (message.role) {
+      case "system":
+        mappedMessages.push(createRuntimeSystemMessage(message));
+        break;
+
+      case "user":
+        mappedMessages.push(createRuntimeUserMessage(message));
+        break;
+
+      case "assistant": {
+        const assistantMessage = createRuntimeAssistantMessage(message);
+        if (assistantMessage) {
+          mappedMessages.push(assistantMessage);
+        }
+        break;
+      }
+
+      case "tool":
+        applyRuntimeToolResultMessage(mappedMessages, message);
+        break;
+    }
+  }
+
+  return mappedMessages;
+}
 
 export const AgUiWireEventSchema = z.discriminatedUnion("eventName", [
   z.object({

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.290";
+export const VERSION = "0.1.291";


### PR DESCRIPTION
## Summary
- add a browser-safe AG-UI runtime-message to chat UI message mapper
- cover tool-call/tool-result merging, tool errors, orphan tool results, and invalid tool args
- bump the package to 0.1.291 for downstream adoption

## Verification
- deno test --no-check --allow-all src/chat/ag-ui.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts src/chat/ag-ui.ts src/chat/ag-ui.test.ts
- deno task lint
- deno task typecheck
- deno task build:npm
- deno task docs:verify-npm
- pre-push checks: format, lint, typecheck, unit tests (1449 passed, 0 failed)