### PR TITLE
Share UI-to-model message preparation

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.291",
+  "version": "0.1.292",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/chat/message-prep.test.ts
+++ b/src/chat/message-prep.test.ts
@@ -5,7 +5,10 @@ import {
   enforceTokenBudget,
   estimateTokens,
   maskOldToolOutputs,
+  prepareModelMessagesFromUiMessages,
   repairToolPairs,
+  rewriteUnsupportedFilePartsAsAnnotations,
+  stripPendingToolParts,
 } from "./message-prep.ts";
 
 Deno.test("repairToolPairs moves a later tool result immediately after the matching tool call", () => {
@@ -165,4 +168,117 @@ Deno.test("compressTurn emits a two-message summary shell", () => {
     role: "assistant",
     content: "Acknowledged.",
   });
+});
+
+Deno.test("stripPendingToolParts removes stale assistant tool calls before model conversion", () => {
+  const messages = [
+    {
+      id: "assistant-1",
+      role: "assistant" as const,
+      parts: [
+        { type: "text" as const, text: "Let me ask one thing." },
+        {
+          type: "dynamic-tool" as const,
+          toolName: "form_input",
+          toolCallId: "tool-form",
+          state: "input-available" as const,
+          input: { title: "Intake" },
+        },
+      ],
+    },
+  ];
+
+  assertEquals(stripPendingToolParts(messages), [
+    {
+      id: "assistant-1",
+      role: "assistant",
+      parts: [{ type: "text", text: "Let me ask one thing." }],
+    },
+  ]);
+});
+
+Deno.test("rewriteUnsupportedFilePartsAsAnnotations converts non-model-native files into text annotations", () => {
+  const messages = [
+    {
+      id: "user-1",
+      role: "user" as const,
+      parts: [
+        { type: "text" as const, text: "Read this data." },
+        {
+          type: "file" as const,
+          mediaType: "application/zip",
+          filename: "archive.zip",
+          uploadId: "upload-zip",
+          uploadPath: "uploads/archive.zip",
+          url: "https://files.example.com/archive.zip",
+        },
+      ],
+    },
+  ];
+
+  assertEquals(rewriteUnsupportedFilePartsAsAnnotations(messages)[0].parts, [
+    {
+      type: "text",
+      text: "Read this data.\n\n<uploaded_files>\n" +
+        '<file name="archive.zip" upload_id="upload-zip" path="uploads/archive.zip" ' +
+        'url="https://files.example.com/archive.zip" type="application/zip" />\n' +
+        "</uploaded_files>",
+    },
+  ]);
+});
+
+Deno.test("prepareModelMessagesFromUiMessages normalizes UI history into model-safe tool order", () => {
+  const prepared = prepareModelMessagesFromUiMessages([
+    {
+      id: "user-1",
+      role: "user",
+      parts: [{ type: "text", text: "Inspect rollout state." }],
+    },
+    {
+      id: "assistant-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "search_files",
+          toolCallId: "tool-1",
+          state: "output-available",
+          input: { query: "rollout" },
+          output: { matches: 2 },
+        },
+      ],
+    },
+  ]);
+
+  assertEquals(prepared, [
+    {
+      role: "user",
+      content: [{ type: "text", text: "Inspect rollout state." }],
+    },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "tool-1",
+          toolName: "search_files",
+          input: { query: "rollout" },
+        },
+      ],
+    },
+    {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "tool-1",
+          toolName: "search_files",
+          output: {
+            type: "json",
+            value: { matches: 2 },
+          },
+        },
+      ],
+    },
+  ]);
 });

--- a/src/chat/message-prep.ts
+++ b/src/chat/message-prep.ts
@@ -1,10 +1,20 @@
 import {
+  convertUiMessagesToModelMessages,
   getStringField,
   isReasoningPart,
   isToolCallPart,
   isToolResultPart,
 } from "./conversation.ts";
-import type { ChatModelMessage, ChatToolResultOutput, ChatToolResultPart } from "./types.ts";
+import {
+  buildDataFileAnnotation,
+  type ChatModelMessage,
+  type ChatToolResultOutput,
+  type ChatToolResultPart,
+  type ChatUiMessage,
+  type ChatUiMessagePart,
+  normalizeInlineAttachmentMediaType,
+  type UploadedFileReference,
+} from "./types.ts";
 
 const CHARS_PER_TOKEN = 4;
 
@@ -175,6 +185,221 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 interface ToolCallInfo {
   toolName: string;
   input: unknown;
+}
+
+export function isModelSupportedFileMediaType(mediaType: string): boolean {
+  return mediaType.startsWith("image/") || mediaType === "application/pdf" ||
+    mediaType === "text/plain";
+}
+
+export function normalizeMessageFilePartMediaTypes(messages: ChatUiMessage[]): ChatUiMessage[] {
+  return messages.map((message) => {
+    if (!message.parts.some((part) => part.type === "file")) {
+      return message;
+    }
+
+    const parts = message.parts.map((part) => {
+      if (part.type !== "file") {
+        return part;
+      }
+
+      const mediaType = normalizeInlineAttachmentMediaType(part.filename, part.mediaType);
+      if (mediaType === part.mediaType) {
+        return part;
+      }
+
+      return {
+        ...part,
+        mediaType,
+      };
+    });
+
+    return { ...message, parts };
+  });
+}
+
+export function rewriteUnsupportedFilePartsAsAnnotations(
+  messages: ChatUiMessage[],
+): ChatUiMessage[] {
+  return messages.map((message) => {
+    if (message.parts.length === 0) {
+      return message;
+    }
+
+    const kept: ChatUiMessagePart[] = [];
+    const dataFiles: UploadedFileReference[] = [];
+
+    for (const part of message.parts) {
+      if (part.type !== "file") {
+        kept.push(part);
+        continue;
+      }
+
+      const normalizedMediaType = normalizeInlineAttachmentMediaType(part.filename, part.mediaType);
+      if (isModelSupportedFileMediaType(normalizedMediaType)) {
+        kept.push({
+          ...part,
+          mediaType: normalizedMediaType,
+        });
+        continue;
+      }
+
+      dataFiles.push({
+        name: part.filename || "file",
+        mediaType: normalizedMediaType,
+        ...(part.url ? { url: part.url } : {}),
+        ...(part.uploadId ? { uploadId: part.uploadId } : {}),
+        ...(part.uploadPath ? { path: part.uploadPath } : {}),
+      });
+    }
+
+    if (dataFiles.length === 0) {
+      return message;
+    }
+
+    const annotation = buildDataFileAnnotation(dataFiles);
+    const lastTextIndex = kept.findLastIndex((part) => part.type === "text");
+
+    if (lastTextIndex >= 0) {
+      const textPart = kept[lastTextIndex];
+      if (textPart.type === "text") {
+        kept[lastTextIndex] = { type: "text", text: textPart.text + annotation };
+      }
+    } else {
+      kept.push({ type: "text", text: annotation.trimStart() });
+    }
+
+    return { ...message, parts: kept };
+  });
+}
+
+function isPendingToolPart(part: unknown): boolean {
+  if (!isRecord(part) || typeof part.type !== "string") {
+    return false;
+  }
+
+  const state = typeof part.state === "string" ? part.state : null;
+  const isPendingState = state === "pending" || state === "input-available" ||
+    state === "input-streaming";
+  if (!isPendingState) {
+    return false;
+  }
+
+  return part.type === "dynamic-tool" || part.type === "tool_call" || part.type.startsWith("tool-");
+}
+
+export function stripPendingToolParts(messages: ChatUiMessage[]): ChatUiMessage[] {
+  return messages.flatMap((message) => {
+    if (message.role !== "assistant" || message.parts.length === 0) {
+      return [message];
+    }
+
+    const parts = message.parts.filter((part) => !isPendingToolPart(part));
+    if (parts.length === message.parts.length) {
+      return [message];
+    }
+
+    if (parts.length === 0) {
+      return [];
+    }
+
+    return [{ ...message, parts }];
+  });
+}
+
+function isKeepableModelPart(part: unknown, includeReasoning: boolean): boolean {
+  if (!isRecord(part) || typeof part.type !== "string") return false;
+
+  switch (part.type) {
+    case "text":
+      return typeof part.text === "string" && part.text.trim().length > 0;
+    case "reasoning":
+      return includeReasoning;
+    case "tool-call":
+    case "tool-result":
+    case "image":
+      return true;
+    case "file": {
+      const hasMediaType = typeof part.mediaType === "string" && part.mediaType.length > 0;
+      if (!hasMediaType) {
+        return false;
+      }
+
+      const url = typeof part.url === "string" ? part.url : "";
+      if (url.startsWith("data:image/") && part.filename === "preview-screenshot.png") {
+        return false;
+      }
+      return true;
+    }
+    default:
+      return true;
+  }
+}
+
+function hasValidContent(message: ChatModelMessage): boolean {
+  const content = message.content;
+
+  if (content === undefined || content === null) return false;
+  if (typeof content === "string") return content.trim().length > 0;
+  if (Array.isArray(content)) return content.some((part) => isKeepableModelPart(part, false));
+  return true;
+}
+
+function cleanContent<T>(content: T[]): T[] {
+  const hasSubstantiveContent = content.some((part) => isKeepableModelPart(part, false));
+  return content.filter((part) => isKeepableModelPart(part, hasSubstantiveContent));
+}
+
+export function sanitizeModelMessages(messages: ChatModelMessage[]): ChatModelMessage[] {
+  const result: ChatModelMessage[] = [];
+
+  for (const message of messages) {
+    if (Array.isArray(message.content)) {
+      if (message.role === "user") {
+        const cleaned = cleanContent(message.content);
+        if (cleaned.length > 0) result.push({ ...message, content: cleaned });
+      } else if (message.role === "assistant") {
+        const cleaned = cleanContent(message.content);
+        if (cleaned.length > 0) result.push({ ...message, content: cleaned });
+      } else if (message.role === "tool") {
+        const cleaned = cleanContent(message.content);
+        if (cleaned.length > 0) result.push({ ...message, content: cleaned });
+      }
+      continue;
+    }
+
+    if (hasValidContent(message)) {
+      result.push(message);
+    }
+  }
+
+  return result;
+}
+
+function filterValidMessages(messages: ChatModelMessage[]): ChatModelMessage[] {
+  return messages.filter((message) => {
+    const content = message.content;
+    if (content === undefined || content === null) return false;
+    if (typeof content === "string") return content.trim().length > 0;
+    if (Array.isArray(content)) return content.length > 0;
+    return true;
+  });
+}
+
+export function prepareModelMessagesFromUiMessages(messages: ChatUiMessage[]): ChatModelMessage[] {
+  const validMessages = messages.filter((message) =>
+    message && typeof message === "object" && "role" in message
+  );
+  const normalizedMessages = normalizeMessageFilePartMediaTypes(validMessages);
+  const strippedPendingToolMessages = stripPendingToolParts(normalizedMessages);
+  const rewrittenMessages = rewriteUnsupportedFilePartsAsAnnotations(strippedPendingToolMessages);
+  const modelMessages = convertUiMessagesToModelMessages(rewrittenMessages);
+  const patchedMessages = ensureToolCallInputs(dedupeToolHistory(modelMessages));
+  const sanitized = sanitizeModelMessages(patchedMessages);
+  const masked = maskOldToolOutputs(sanitized);
+  const compacted = enforceTokenBudget(masked);
+  const filtered = filterValidMessages(compacted);
+  return repairToolPairs(filtered);
 }
 
 function buildToolCallMap(messages: ChatModelMessage[]): Map<string, ToolCallInfo> {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.291";
+export const VERSION = "0.1.292";


### PR DESCRIPTION
## Summary
- add generic chat UI to model-message preparation helpers in veryfront/chat/message-prep
- cover pending tool stripping, unsupported file annotation rewriting, and model-safe tool ordering
- bump the package to 0.1.292 for downstream adoption

## Verification
- deno test --no-check --allow-all src/chat/message-prep.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts src/chat/message-prep.ts src/chat/message-prep.test.ts
- deno task lint
- deno task typecheck
- deno task build:npm
- deno task docs:verify-npm
- pre-push checks: format, lint, typecheck, unit tests (1452 passed, 0 failed)