### PR TITLE
Share conversation persistence part mapping

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.292",
+  "version": "0.1.293",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/chat/conversation.test.ts
+++ b/src/chat/conversation.test.ts
@@ -8,13 +8,17 @@ import {
   convertUiMessagesToModelMessages,
   extractTextFromMessage,
   extractUploadId,
+  hasIncompleteToolParts,
   isRecord,
   isToolCallPart,
   mapToolState,
+  markIncompleteToolPartsAsErrored,
+  markIncompleteToolPartsAsStopped,
   messagePartSchema,
   messageStatusSchema,
   pushToolParts,
   stringifyUnknown,
+  toConversationPartsFromUiMessage,
 } from "veryfront/chat/conversation";
 
 describe("chat/conversation schemas", () => {
@@ -80,6 +84,126 @@ describe("chat/conversation helpers", () => {
       { type: "tool_call", id: "tc-1", name: "bash", input: { command: "ls" }, state: "completed" },
       { type: "tool_result", tool_call_id: "tc-1", output: "ok", is_error: false },
     ]);
+  });
+
+  it("maps UI messages into persistable conversation parts", () => {
+    const message: ChatUiMessage = {
+      id: "assistant-2",
+      role: "assistant",
+      parts: [
+        { type: "step-start" },
+        { type: "text", text: "Real content" },
+        { type: "reasoning", text: "Thinking…" },
+        { type: "source-url", sourceId: "src-1", url: "https://example.com", title: "Example" },
+        { type: "source-document", sourceId: "doc-1", title: "Design Doc" },
+        { type: "data-rollout", data: { approved: true } },
+        {
+          type: "file",
+          mediaType: "image/png",
+          url: "https://files.example.com/uploaded/11111111-1111-4111-a111-111111111111",
+        },
+        {
+          type: "file",
+          mediaType: "application/pdf",
+          filename: "brief.pdf",
+          url: "https://files.example.com/uploaded/22222222-2222-4222-a222-222222222222",
+        },
+        {
+          type: "tool-form_input",
+          toolCallId: "tool-1",
+          input: { title: "Continue?" },
+          state: "output-available",
+          output: { approved: true },
+        },
+      ],
+    };
+
+    assertEquals(toConversationPartsFromUiMessage(message), [
+      { type: "text", text: "Real content" },
+      { type: "reasoning", text: "Thinking…" },
+      { type: "citation", source_id: "src-1", title: "Example", url: "https://example.com" },
+      { type: "citation", source_id: "doc-1", title: "Design Doc" },
+      { type: "data", name: "rollout", value: { approved: true } },
+      {
+        type: "image",
+        upload_id: "11111111-1111-4111-a111-111111111111",
+        media_type: "image/png",
+        url: "https://files.example.com/uploaded/11111111-1111-4111-a111-111111111111",
+      },
+      {
+        type: "file",
+        upload_id: "22222222-2222-4222-a222-222222222222",
+        media_type: "application/pdf",
+        url: "https://files.example.com/uploaded/22222222-2222-4222-a222-222222222222",
+      },
+      {
+        type: "tool_call",
+        id: "tool-1",
+        name: "form_input",
+        input: { title: "Continue?" },
+        state: "completed",
+      },
+      {
+        type: "tool_result",
+        tool_call_id: "tool-1",
+        output: { approved: true },
+        is_error: false,
+      },
+    ]);
+  });
+
+  it("marks incomplete UI tool parts as stopped or errored", () => {
+    const message: ChatUiMessage = {
+      id: "assistant-3",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "update_file",
+          toolCallId: "tool-3",
+          input: {},
+          state: "pending",
+        },
+        {
+          type: "tool-form_input",
+          toolCallId: "tool-4",
+          input: { title: "Continue?" },
+          state: "approval-requested",
+          approval: { id: "approval-1" },
+        },
+      ],
+    };
+
+    assertEquals(hasIncompleteToolParts(message), true);
+    assertEquals(markIncompleteToolPartsAsErrored(message, "Assistant ended before completion"), {
+      id: "assistant-3",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "update_file",
+          toolCallId: "tool-3",
+          input: {},
+          state: "output-error",
+          errorText: "Assistant ended before completion",
+        },
+        {
+          type: "tool-form_input",
+          toolCallId: "tool-4",
+          input: { title: "Continue?" },
+          state: "output-error",
+          errorText: "Assistant ended before completion",
+        },
+      ],
+    });
+    assertEquals(markIncompleteToolPartsAsStopped(message).parts[0], {
+      type: "dynamic-tool",
+      toolName: "update_file",
+      toolCallId: "tool-3",
+      input: {},
+      state: "output-error",
+      errorText: "Stopped by user",
+    });
   });
 
   it("extracts upload ids and safely stringifies unknown values", () => {

--- a/src/chat/conversation.ts
+++ b/src/chat/conversation.ts
@@ -292,6 +292,157 @@ export function pushToolParts(
   });
 }
 
+function pushFileConversationPart(
+  parts: MessagePart[],
+  part: Extract<ChatUiMessagePart, { type: "file" }>,
+): void {
+  const uploadId = part.uploadId ?? extractUploadId(part.url);
+  if (!uploadId) return;
+
+  if (part.mediaType.startsWith("image/")) {
+    parts.push({
+      type: "image",
+      upload_id: uploadId,
+      media_type: part.mediaType,
+      ...(part.url ? { url: part.url } : {}),
+    });
+    return;
+  }
+
+  parts.push({
+    type: "file",
+    upload_id: uploadId,
+    media_type: part.mediaType,
+    ...(part.url ? { url: part.url } : {}),
+  });
+}
+
+export function toConversationPartsFromUiMessage(message: ChatUiMessage): MessagePart[] {
+  const parts: MessagePart[] = [];
+
+  for (const part of message.parts) {
+    if (part.type === "text") {
+      parts.push({ type: "text", text: part.text });
+      continue;
+    }
+
+    if (part.type === "reasoning") {
+      parts.push({ type: "reasoning", text: part.text });
+      continue;
+    }
+
+    if (part.type === "step-start") {
+      continue;
+    }
+
+    if (part.type === "source-url") {
+      parts.push({
+        type: "citation",
+        source_id: part.sourceId,
+        title: part.title,
+        url: part.url,
+      });
+      continue;
+    }
+
+    if (part.type === "source-document") {
+      parts.push({
+        type: "citation",
+        source_id: part.sourceId,
+        title: part.title,
+      });
+      continue;
+    }
+
+    if (part.type === "file") {
+      pushFileConversationPart(parts, part);
+      continue;
+    }
+
+    if (isDataUiPart(part)) {
+      const name = part.type.replace(/^data-/, "");
+      if (name.length > 0) {
+        parts.push({
+          type: "data",
+          name,
+          value: part.data,
+        });
+      }
+      continue;
+    }
+
+    if (isToolUiPart(part)) {
+      const toolName = getUiToolName(part);
+      if (!toolName) {
+        continue;
+      }
+
+      pushToolParts(parts, toolName, part.toolCallId, part.state, part);
+    }
+  }
+
+  return parts.filter((part) => messagePartSchema.safeParse(part).success);
+}
+
+function isToolComplete(part: ToolUiPart): boolean {
+  return part.state === "output-available" || part.state === "output-error" ||
+    part.state === "output-denied";
+}
+
+export function hasIncompleteToolParts(message: ChatUiMessage): boolean {
+  return message.parts.some((part) => isToolUiPart(part) && !isToolComplete(part));
+}
+
+export function markIncompleteToolPartsAsStopped(message: ChatUiMessage): ChatUiMessage {
+  return markIncompleteToolPartsAsErrored(message, "Stopped by user");
+}
+
+export function markIncompleteToolPartsAsErrored(
+  message: ChatUiMessage,
+  errorText: string,
+): ChatUiMessage {
+  let mutated = false;
+
+  const parts = message.parts.map((part) => {
+    if (!isToolUiPart(part) || isToolComplete(part)) {
+      return part;
+    }
+
+    mutated = true;
+    return markToolPartAsErrored(part, errorText);
+  });
+
+  return mutated ? { ...message, parts } : message;
+}
+
+function markToolPartAsErrored(part: ToolUiPart, errorText: string): ChatUiMessagePart {
+  if (part.type === "dynamic-tool") {
+    return {
+      type: "dynamic-tool",
+      toolName: part.toolName,
+      toolCallId: part.toolCallId,
+      ...(part.title ? { title: part.title } : {}),
+      ...(part.providerExecuted !== undefined ? { providerExecuted: part.providerExecuted } : {}),
+      ...(part.callProviderMetadata ? { callProviderMetadata: part.callProviderMetadata } : {}),
+      input: part.input,
+      state: "output-error",
+      errorText,
+    };
+  }
+
+  return {
+    type: part.type,
+    toolCallId: part.toolCallId,
+    ...(part.toolName ? { toolName: part.toolName } : {}),
+    ...(part.title ? { title: part.title } : {}),
+    ...(part.providerExecuted !== undefined ? { providerExecuted: part.providerExecuted } : {}),
+    ...(part.callProviderMetadata ? { callProviderMetadata: part.callProviderMetadata } : {}),
+    input: part.input,
+    state: "output-error",
+    errorText,
+  };
+}
+
 export function isToolCallPart(value: unknown): value is ToolCallLike {
   return (
     isRecord(value) &&

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.292";
+export const VERSION = "0.1.293";


### PR DESCRIPTION
## Summary
- add generic UI-to-conversation part mapping helpers to veryfront/chat/conversation
- add helpers for marking incomplete tool UI parts as stopped or errored
- bump the package to 0.1.293 for downstream adoption

## Verification
- deno test --no-check --allow-all src/chat/conversation.test.ts
- deno fmt --check deno.json src/utils/version-constant.ts src/chat/conversation.ts src/chat/conversation.test.ts
- deno task lint
- deno task typecheck
- deno task build:npm
- deno task docs:verify-npm
- pre-push checks: format, lint, typecheck, unit tests (1452 passed, 0 failed)