### PR TITLE
Allow host timer injection for stream watchdog

### DIFF
--- a/src/chat/stream-watchdog.test.ts
+++ b/src/chat/stream-watchdog.test.ts
@@ -101,6 +101,26 @@ describe("chat/stream-watchdog", () => {
     );
   });
 
+  it("accepts injected timer functions for host test instrumentation", () => {
+    using time = new FakeTime();
+    const watchdog = createChatStreamWatchdog({
+      ...watchdogOptions,
+      setTimeoutFn: globalThis.setTimeout,
+      clearTimeoutFn: globalThis.clearTimeout,
+    });
+    watchdog.observe({
+      type: "tool-input-available",
+      toolCallId: "tool-3",
+      toolName: "bash",
+      input: {},
+    });
+
+    time.tick(301);
+
+    assertEquals(watchdog.signal.aborted, true);
+    watchdog.dispose();
+  });
+
   it("aborts with AbortError and records timeout state", () => {
     using time = new FakeTime();
     const watchdog = createChatStreamWatchdog(watchdogOptions);

--- a/src/chat/stream-watchdog.ts
+++ b/src/chat/stream-watchdog.ts
@@ -20,6 +20,8 @@ export type ChatStreamWatchdogOptions = {
   idleTimeoutMs?: number;
   toolRunningTimeoutMs?: number;
   longRunningToolNames?: Iterable<string>;
+  setTimeoutFn?: typeof globalThis.setTimeout;
+  clearTimeoutFn?: typeof globalThis.clearTimeout;
 };
 
 export class ChatStreamIdleTimeoutError extends Error {
@@ -149,7 +151,7 @@ export function createChatStreamWatchdog(options?: ChatStreamWatchdogOptions) {
 
   const clearTimer = () => {
     if (timer !== null) {
-      clearTimeout(timer);
+      resolvedOptions.clearTimeoutFn(timer);
       timer = null;
     }
   };
@@ -165,7 +167,7 @@ export function createChatStreamWatchdog(options?: ChatStreamWatchdogOptions) {
       return;
     }
 
-    timer = setTimeout(() => {
+    timer = resolvedOptions.setTimeoutFn(() => {
       lastTimeoutState = state;
       controller.abort(
         new DOMException(new ChatStreamIdleTimeoutError(state).message, "AbortError"),
@@ -205,6 +207,8 @@ function resolveChatStreamWatchdogOptions(options?: ChatStreamWatchdogOptions) {
     toolRunningTimeoutMs: options?.toolRunningTimeoutMs ??
       DEFAULT_CHAT_STREAM_TOOL_RUNNING_TIMEOUT_MS,
     longRunningToolNames: new Set(options?.longRunningToolNames ?? ["invoke_agent"]),
+    setTimeoutFn: options?.setTimeoutFn ?? globalThis.setTimeout,
+    clearTimeoutFn: options?.clearTimeoutFn ?? globalThis.clearTimeout,
   };
 }
 


### PR DESCRIPTION
## Summary
- add optional timer-function injection to veryfront/chat/stream-watchdog
- keep default runtime behavior on globalThis timers
- cover host fake-timer instrumentation with a regression test

## Verification
- deno test --no-check --allow-all src/chat/stream-watchdog.test.ts
- deno fmt --check src/chat/stream-watchdog.ts src/chat/stream-watchdog.test.ts
- deno task lint
- deno task typecheck