### PR TITLE
Publish stream watchdog timer injection patch

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.294",
+  "version": "0.1.295",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.294";
+export const VERSION = "0.1.295";


### PR DESCRIPTION
## Summary
- publish the stream watchdog timer-injection patch as veryfront@0.1.295
- keep the already-merged watchdog API unchanged; this is a version-only release commit after the timer-options follow-up merged

## Verification
- pre-push: deno fmt --check
- pre-push: deno task lint
- pre-push: deno task typecheck
- pre-push: deno task test:unit (1453 passed, 0 failed)
- targeted rerun: VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all --unstable-worker-options --unstable-net src/routing/api/module-loader/loader.test.ts --filter 'symlink resistance'