### PR TITLE
Share request-scoped auth caching

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.295",
+  "version": "0.1.296",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [
@@ -68,7 +68,8 @@
     "./chat/message-prep": "./src/chat/message-prep.ts",
     "./chat/final-step-fallback": "./src/chat/final-step-fallback.ts",
     "./chat/provider-errors": "./src/chat/provider-errors.ts",
-    "./chat/stream-watchdog": "./src/chat/stream-watchdog.ts"
+    "./chat/stream-watchdog": "./src/chat/stream-watchdog.ts",
+    "./agent/request-auth-cache": "./src/agent/request-auth-cache.ts"
   },
   "imports": {
     "veryfront/head": "./src/react/runtime/core.ts",

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -151,6 +151,12 @@ export {
   type NormalizedAgentServiceContract,
 } from "./agent-service.ts";
 export {
+  type CachedRequestAuthResult,
+  createRequestAuthCache,
+  type CreateRequestAuthCacheOptions,
+  type RequestAuthCache,
+} from "./request-auth-cache.ts";
+export {
   type AgUiRuntimeHandlerConfig,
   type AgUiRuntimeHandlerConfigWithAgent,
   type AgUiRuntimeHandlerExecute,

--- a/src/agent/request-auth-cache.test.ts
+++ b/src/agent/request-auth-cache.test.ts
@@ -1,0 +1,62 @@
+import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createRequestAuthCache } from "./request-auth-cache.ts";
+
+describe("agent/request-auth-cache", () => {
+  it("caches successful auth results by Request identity", async () => {
+    let calls = 0;
+    const request = new Request("https://agent.test/api/ag-ui");
+    const cache = createRequestAuthCache({
+      authenticate: () => {
+        calls += 1;
+        return { authToken: "token-1", userId: "user-1" };
+      },
+    });
+
+    const first = await cache.authenticate(request);
+    const second = await cache.authenticate(request);
+
+    assertStrictEquals(first, second);
+    assertEquals(calls, 1);
+    assertEquals(first, { authToken: "token-1", userId: "user-1" });
+  });
+
+  it("does not cache Response failures by default", async () => {
+    let calls = 0;
+    const request = new Request("https://agent.test/api/ag-ui");
+    const cache = createRequestAuthCache({
+      authenticate: () => {
+        calls += 1;
+        return Response.json({ errorCode: "UNAUTHENTICATED" }, { status: 401 });
+      },
+    });
+
+    const first = await cache.authenticate(request);
+    const second = await cache.authenticate(request);
+
+    assertEquals(first instanceof Response ? first.status : 0, 401);
+    assertEquals(second instanceof Response ? second.status : 0, 401);
+    assertEquals(calls, 2);
+  });
+
+  it("caches only results accepted by the host predicate", async () => {
+    let calls = 0;
+    const request = new Request("https://agent.test/api/ag-ui");
+    const cache = createRequestAuthCache({
+      authenticate: () => {
+        calls += 1;
+        return { authToken: `token-${calls}`, userId: "user-1" };
+      },
+      shouldCache: (result) => !(result instanceof Response) && result.authToken === "token-2",
+    });
+
+    const first = await cache.authenticate(request);
+    const second = await cache.authenticate(request);
+    const third = await cache.authenticate(request);
+
+    assertEquals(first, { authToken: "token-1", userId: "user-1" });
+    assertStrictEquals(second, third);
+    assertEquals(second, { authToken: "token-2", userId: "user-1" });
+    assertEquals(calls, 2);
+  });
+});

--- a/src/agent/request-auth-cache.ts
+++ b/src/agent/request-auth-cache.ts
@@ -1,0 +1,34 @@
+export type CachedRequestAuthResult<TAuth> = TAuth | Response;
+
+export interface CreateRequestAuthCacheOptions<TAuth> {
+  authenticate: (
+    request: Request,
+  ) => Promise<CachedRequestAuthResult<TAuth>> | CachedRequestAuthResult<TAuth>;
+  shouldCache?: (result: CachedRequestAuthResult<TAuth>) => boolean;
+}
+
+export interface RequestAuthCache<TAuth> {
+  authenticate: (request: Request) => Promise<CachedRequestAuthResult<TAuth>>;
+}
+
+export function createRequestAuthCache<TAuth>(
+  options: CreateRequestAuthCacheOptions<TAuth>,
+): RequestAuthCache<TAuth> {
+  const cache = new WeakMap<Request, TAuth>();
+  const shouldCache = options.shouldCache ?? ((result) => !(result instanceof Response));
+
+  return {
+    async authenticate(request) {
+      if (cache.has(request)) {
+        const cached = cache.get(request);
+        if (cached !== undefined) return cached;
+      }
+
+      const result = await options.authenticate(request);
+      if (shouldCache(result) && !(result instanceof Response)) {
+        cache.set(request, result);
+      }
+      return result;
+    },
+  };
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.295";
+export const VERSION = "0.1.296";


### PR DESCRIPTION
## Summary
- add a small request-scoped auth cache seam for hosted AG-UI/run-control handlers
- export the seam from `veryfront/agent` and as `veryfront/agent/request-auth-cache`
- bump package version to 0.1.296 for downstream adoption

## Verification
- deno fmt --check src/agent/request-auth-cache.ts src/agent/request-auth-cache.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts
- deno lint src/agent/request-auth-cache.ts src/agent/request-auth-cache.test.ts src/agent/index.ts
- deno test --allow-all src/agent/request-auth-cache.test.ts
- deno task typecheck
- deno task docs:verify-npm