### PR TITLE
Let hosts gate AG-UI runtime request parsing

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.296",
+  "version": "0.1.297",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/ag-ui-runtime-handler.test.ts
+++ b/src/agent/ag-ui-runtime-handler.test.ts
@@ -181,6 +181,73 @@ describe("agent/ag-ui-runtime-handler", () => {
     });
   });
 
+  it("lets hosts short-circuit before parsing the runtime request body", async () => {
+    let beforeParseCalls = 0;
+    let executeCalls = 0;
+    const handler = createAgUiRuntimeHandler({
+      beforeParse: ({ request }) => {
+        beforeParseCalls += 1;
+        assertEquals(request.url, "http://localhost/api/ag-ui");
+        return Response.json({ errorCode: "UNAUTHENTICATED" }, { status: 401 });
+      },
+      execute: () => {
+        executeCalls += 1;
+        return Response.json({ ok: true });
+      },
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not-json",
+      }),
+    );
+
+    assertEquals(response.status, 401);
+    assertEquals(await response.json(), { errorCode: "UNAUTHENTICATED" });
+    assertEquals(beforeParseCalls, 1);
+    assertEquals(executeCalls, 0);
+  });
+
+  it("lets hosts preserve their validation-error response shape", async () => {
+    let executeCalls = 0;
+    const handler = createAgUiRuntimeHandler({
+      validationErrorResponse: async ({ response }) => {
+        const body = await response.json();
+        return Response.json(
+          {
+            errorCode: "VALIDATION_ERROR",
+            source: body,
+          },
+          { status: response.status },
+        );
+      },
+      execute: () => {
+        executeCalls += 1;
+        return Response.json({ ok: true });
+      },
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          threadId: crypto.randomUUID(),
+          runId: "run_invalid_runtime_request",
+          messages: "not-an-array",
+        }),
+      }),
+    );
+
+    assertEquals(response.status, 400);
+    assertEquals(executeCalls, 0);
+    const body = await response.json();
+    assertEquals(body.errorCode, "VALIDATION_ERROR");
+    assertEquals(body.source.error, "Invalid AG-UI runtime request");
+  });
+
   it("calls runtime lifecycle hooks for direct hosted AG-UI streams", async () => {
     const testAgent = createTestAgent();
     const threadId = crypto.randomUUID();

--- a/src/agent/ag-ui-runtime-handler.ts
+++ b/src/agent/ag-ui-runtime-handler.ts
@@ -320,10 +320,29 @@ export type AgUiRuntimeHandlerExecute = (
   input: AgUiRuntimeHandlerExecuteInput,
 ) => Promise<Response> | Response;
 
+export interface AgUiRuntimeRequestGateInput {
+  request: Request;
+}
+
+export type AgUiRuntimeRequestGate = (
+  input: AgUiRuntimeRequestGateInput,
+) => Promise<Response | undefined | void> | Response | undefined | void;
+
+export interface AgUiRuntimeValidationErrorInput {
+  request: Request;
+  response: Response;
+}
+
+export type AgUiRuntimeValidationErrorResponse = (
+  input: AgUiRuntimeValidationErrorInput,
+) => Promise<Response> | Response;
+
 export interface AgUiRuntimeHandlerOptions {
   context?:
     | Record<string, unknown>
     | ((request: Request) => Record<string, unknown> | Promise<Record<string, unknown>>);
+  beforeParse?: AgUiRuntimeRequestGate;
+  validationErrorResponse?: AgUiRuntimeValidationErrorResponse;
   sessionManager?: RunResumeSessionManager<AgUiResumeValue>;
   execute?: AgUiRuntimeHandlerExecute;
   onToolCallSeen?: (context: AgUiRuntimeLifecycleContext) => Promise<void> | void;
@@ -352,8 +371,17 @@ export function createAgUiRuntimeHandler(
     const request = extractRequest(requestOrCtx);
 
     try {
+      const gateResult = await config.beforeParse?.({ request });
+      if (gateResult instanceof Response) {
+        return gateResult;
+      }
+
       const parsed = await parseAgUiRuntimeRequestOrError(request);
       if (parsed instanceof Response) {
+        if (config.validationErrorResponse) {
+          return await config.validationErrorResponse({ request, response: parsed });
+        }
+
         return parsed;
       }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.296";
+export const VERSION = "0.1.297";


### PR DESCRIPTION
## Summary
- add policy-neutral before-parse and validation-error hooks to the AG-UI runtime handler
- preserve host auth-before-body and custom validation envelope migrations without moving product policy into framework core
- bump package version to 0.1.297

## Verification
- deno fmt --check src/agent/ag-ui-runtime-handler.ts src/agent/ag-ui-runtime-handler.test.ts deno.json src/utils/version-constant.ts
- deno lint src/agent/ag-ui-runtime-handler.ts src/agent/ag-ui-runtime-handler.test.ts
- deno test --allow-all src/agent/ag-ui-runtime-handler.test.ts
- deno task typecheck
- deno task lint
- deno task docs:verify-npm
- deno task build:npm
- pre-push checks: format, lint, typecheck, unit