### PR TITLE
Turn agent service stubs into a route runtime shell

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.297",
+  "version": "0.1.298",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/agent-service.test.ts
+++ b/src/agent/agent-service.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   type AgentContract,
@@ -44,7 +44,7 @@ describe("agent/agent-service", () => {
     };
 
     assertEquals(contract.serviceName, "veryfront-agent");
-    assertEquals(contract.agents.assistant.id, "phase-0-service-stub");
+    assertEquals(contract.agents.assistant?.id, "phase-0-service-stub");
     assertEquals(contract.defaultAgentId, "assistant");
     assertEquals(contract.server?.port, 3001);
     assertEquals(contract.durableRunSink?.startRun({ requestId: "run-123" }), {
@@ -71,17 +71,64 @@ describe("agent/agent-service", () => {
     };
 
     assertEquals(registryContract.defaultAgentId, "assistant");
-    assertEquals(registryContract.agents.reviewer.id, "reviewer");
+    assertEquals(registryContract.agents.reviewer?.id, "reviewer");
     assertEquals(singleAgentContract.agent.id, "phase-0-service-stub");
   });
 
-  it("throws until the hosted runtime service implementation lands", async () => {
-    await assertRejects(
-      async () => {
-        defineAgentService({ serviceName: "veryfront-agent", agent: assistant });
-      },
-      Error,
-      "Phase 0 stub",
+  it("normalizes single-agent convenience into the registry contract", () => {
+    const service = defineAgentService({
+      serviceName: "veryfront-agent",
+      agent: assistant,
+    });
+
+    assertEquals(service.contract.serviceName, "veryfront-agent");
+    assertEquals(service.contract.defaultAgentId, assistant.id);
+    assertEquals(service.contract.agents[assistant.id], assistant);
+  });
+
+  it("creates a runtime with readiness and liveness routes", async () => {
+    const runtime = defineAgentService({
+      serviceName: "veryfront-agent",
+      agent: assistant,
+    }).createRuntime();
+
+    const ready = await runtime.fetch(new Request("https://agent.test/readiness"));
+    assertEquals(ready.status, 200);
+    assertEquals(await ready.text(), "OK");
+
+    const live = await runtime.fetch(new Request("https://agent.test/liveness"));
+    assertEquals(live.status, 200);
+    assertEquals(await live.text(), "OK");
+
+    runtime.setShuttingDown();
+    const shuttingDown = await runtime.fetch(new Request("https://agent.test/readiness"));
+    assertEquals(shuttingDown.status, 503);
+    assertEquals(await shuttingDown.text(), "Shutting down");
+  });
+
+  it("dispatches host-owned routes without taking over product policy", async () => {
+    const runtime = defineAgentService({
+      serviceName: "veryfront-agent",
+      agents: { assistant },
+      defaultAgentId: "assistant",
+    }).createRuntime({
+      routes: [
+        {
+          method: "DELETE",
+          path: "/api/ag-ui/runs/:runId",
+          handler: (_request, params) => Response.json({ runId: params.runId }),
+        },
+      ],
+    });
+
+    const response = await runtime.fetch(
+      new Request("https://agent.test/api/ag-ui/runs/run-123", { method: "DELETE" }),
     );
+
+    assertEquals(response.status, 200);
+    assertEquals(await response.json(), { runId: "run-123" });
+
+    const missing = await runtime.fetch(new Request("https://agent.test/not-found"));
+    assertEquals(missing.status, 404);
   });
 });

--- a/src/agent/agent-service.ts
+++ b/src/agent/agent-service.ts
@@ -26,6 +26,23 @@ export interface AgentServiceServerConfig {
   cors?: boolean;
 }
 
+export interface AgentServiceRoute {
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS";
+  path: string;
+  handler: (request: Request, params: Record<string, string>) => Promise<Response> | Response;
+}
+
+export interface AgentServiceRuntime<
+  TStartInput = void,
+  TRun = unknown,
+  TEvent = unknown,
+  TTerminalState = unknown,
+> {
+  readonly contract: NormalizedAgentServiceContract<TStartInput, TRun, TEvent, TTerminalState>;
+  fetch(request: Request): Promise<Response>;
+  setShuttingDown(shuttingDown?: boolean): void;
+}
+
 export type AgentRegistry = Record<string, Agent>;
 
 export interface AgentServiceContractBase<
@@ -101,10 +118,13 @@ export interface AgentServiceDefinition<
   TTerminalState = unknown,
 > {
   contract: NormalizedAgentServiceContract<TStartInput, TRun, TEvent, TTerminalState>;
+  createRuntime(options?: { routes?: AgentServiceRoute[] }): AgentServiceRuntime<
+    TStartInput,
+    TRun,
+    TEvent,
+    TTerminalState
+  >;
 }
-
-const DEFINE_AGENT_SERVICE_STUB_ERROR =
-  "defineAgentService() is a Phase 0 stub. The framework contract is reserved, but the hosted runtime implementation has not landed yet.";
 
 function getSingleAgentDefaultId(contract: {
   agent: Agent;
@@ -141,9 +161,96 @@ function normalizeAgentServiceContract<
   };
 }
 
+function normalizePath(path: string): string {
+  if (path === "") return "/";
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+function splitPath(path: string): string[] {
+  const normalized = normalizePath(path);
+  if (normalized === "/") return [];
+  return normalized.split("/").filter(Boolean);
+}
+
+function matchRoute(
+  route: AgentServiceRoute,
+  request: Request,
+): Record<string, string> | undefined {
+  if (request.method.toUpperCase() !== route.method) {
+    return undefined;
+  }
+
+  const routeParts = splitPath(route.path);
+  const requestParts = splitPath(new URL(request.url).pathname);
+  if (routeParts.length !== requestParts.length) {
+    return undefined;
+  }
+
+  const params: Record<string, string> = {};
+  for (const [index, routePart] of routeParts.entries()) {
+    const requestPart = requestParts[index];
+    if (requestPart === undefined) {
+      return undefined;
+    }
+
+    if (routePart.startsWith(":")) {
+      params[routePart.slice(1)] = decodeURIComponent(requestPart);
+      continue;
+    }
+
+    if (routePart !== requestPart) {
+      return undefined;
+    }
+  }
+
+  return params;
+}
+
+function createAgentServiceRuntime<
+  TStartInput = void,
+  TRun = unknown,
+  TEvent = unknown,
+  TTerminalState = unknown,
+>(
+  contract: NormalizedAgentServiceContract<TStartInput, TRun, TEvent, TTerminalState>,
+  options: { routes?: AgentServiceRoute[] } = {},
+): AgentServiceRuntime<TStartInput, TRun, TEvent, TTerminalState> {
+  let shuttingDown = false;
+  const routes = options.routes ?? [];
+
+  return {
+    contract,
+    async fetch(request) {
+      const path = new URL(request.url).pathname;
+      if (request.method === "GET" && path === "/readiness") {
+        return shuttingDown ? new Response("Shutting down", { status: 503 }) : new Response("OK");
+      }
+      if (request.method === "GET" && path === "/liveness") {
+        return new Response("OK");
+      }
+
+      for (const route of routes) {
+        const params = matchRoute(route, request);
+        if (params) {
+          return await route.handler(request, params);
+        }
+      }
+
+      return new Response("Not Found", { status: 404 });
+    },
+    setShuttingDown(next = true) {
+      shuttingDown = next;
+    },
+  };
+}
+
 /**
- * Reserve the public hosted agent-service signature before the runtime
- * implementation lands.
+ * Define a hosted agent service and expose a policy-neutral runtime shell.
+ *
+ * The first implementation slice owns contract normalization plus standard
+ * health/readiness behavior. Hosts pass product-specific routes explicitly so
+ * auth, observability, durable sinks, and AG-UI execution policy can keep
+ * migrating in smaller additive seams.
  */
 export function defineAgentService<
   TStartInput = void,
@@ -153,6 +260,11 @@ export function defineAgentService<
 >(
   contract: AgentContract<TStartInput, TRun, TEvent, TTerminalState>,
 ): AgentServiceDefinition<TStartInput, TRun, TEvent, TTerminalState> {
-  void normalizeAgentServiceContract(contract);
-  throw new Error(DEFINE_AGENT_SERVICE_STUB_ERROR);
+  const normalized = normalizeAgentServiceContract(contract);
+  return {
+    contract: normalized,
+    createRuntime(options) {
+      return createAgentServiceRuntime(normalized, options);
+    },
+  };
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.297";
+export const VERSION = "0.1.298";


### PR DESCRIPTION
## Summary
- make defineAgentService return a normalized service definition instead of throwing
- add a transport-neutral runtime shell with framework-owned readiness/liveness behavior
- support explicit host-owned route dispatch for gradual hosted-service adoption
- bump package version to 0.1.298

## Verification
- deno fmt --check src/agent/agent-service.ts src/agent/agent-service.test.ts deno.json src/utils/version-constant.ts
- deno lint src/agent/agent-service.ts src/agent/agent-service.test.ts
- deno test --allow-all src/agent/agent-service.test.ts
- deno task typecheck
- deno task docs:verify-npm
- deno task build:npm
- deno task lint
- pre-push checks: format, lint, typecheck, unit