### PR TITLE
Fall back to built-in Anthropic runtime when ext-anthropic is not registered

### DIFF
--- a/src/provider/veryfront-cloud/provider.ts
+++ b/src/provider/veryfront-cloud/provider.ts
@@ -1,5 +1,5 @@
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
-import { createGoogleModelRuntime } from "../runtime-loader.ts";
+import { createAnthropicModelRuntime, createGoogleModelRuntime } from "../runtime-loader.ts";
 import { tryResolve } from "#veryfront/extensions/contracts.ts";
 import type { AIProviderRegistry } from "#veryfront/extensions/interfaces/index.ts";
 import { AIProviderRegistryName } from "#veryfront/extensions/interfaces/index.ts";
@@ -30,9 +30,15 @@ export function createVeryfrontCloudModel(modelId: string): ModelRuntime {
           fetch,
         });
       }
-      throw new Error(
-        "Anthropic provider not installed. Add @veryfront/ext-anthropic to use anthropic/* models via veryfront-cloud.",
-      );
+      // Fall back to the built-in runtime-loader when the extension is not
+      // registered.  Keeps Anthropic working until @veryfront/ext-anthropic is
+      // published to npm and adopted by all consumers.
+      return createAnthropicModelRuntime({
+        authToken: apiToken,
+        baseURL,
+        name: "veryfront-cloud",
+        fetch,
+      }, upstreamModelId);
     }
 
     case "google":


### PR DESCRIPTION
## Summary

- The extension-based Anthropic provider (added in the SDK's extension architecture) requires `@veryfront/ext-anthropic` which is not yet published to npm
- This crashes veryfront-agent on every Anthropic model request with `"Anthropic provider not installed"`
- Fix: fall back to the built-in `createAnthropicModelRuntime` from `runtime-loader.ts` when no extension is registered
- The extension path is still preferred when available — this just adds a fallback

## Context

This is the root cause of the veryfront-agent crash on staging that blocks the E2E health suite. The agent pods crash-loop because every "Create deep research" request tries to resolve an Anthropic model.

Related fixes:
- veryfront/veryfront-api#1980 (allowedTools restriction)
- veryfront/veryfront-studio#2819 (sourceTargetKind revert)
- veryfront/veryfront-e2e#87 (timeout increase)

## Test plan

- [x] Typecheck passes (`deno task typecheck`)
- [x] Provider tests pass (all 7 provider/veryfront-cloud tests ok)
- [ ] Publish new SDK version, bump in veryfront-agent, verify E2E green