### PR TITLE
Pre-register Anthropic and Google as built-in providers (Option C)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.299",
+  "version": "0.1.300",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/extensions/registries/ai-provider-registry.test.ts
+++ b/src/extensions/registries/ai-provider-registry.test.ts
@@ -13,12 +13,26 @@ function fakeProvider(id: string): AIProvider {
 }
 
 describe("AIProviderRegistry", () => {
+  it("ships with built-in anthropic and google providers", () => {
+    const reg = createAIProviderRegistry();
+    assert(reg.has("anthropic"));
+    assert(reg.has("google"));
+    assertEquals(reg.has("openai"), false);
+  });
+
   it("register + get returns the same instance", () => {
     const reg = createAIProviderRegistry();
     const p = fakeProvider("openai");
     reg.register(p);
     assertEquals(reg.get("openai"), p);
     assert(reg.has("openai"));
+  });
+
+  it("register overrides a built-in provider silently", () => {
+    const reg = createAIProviderRegistry();
+    const custom = fakeProvider("anthropic");
+    reg.register(custom);
+    assertEquals(reg.get("anthropic"), custom);
   });
 
   it("get returns undefined for unknown id", () => {
@@ -30,20 +44,14 @@ describe("AIProviderRegistry", () => {
   it("require throws with a helpful message listing known providers", () => {
     const reg = createAIProviderRegistry();
     reg.register(fakeProvider("openai"));
-    reg.register(fakeProvider("anthropic"));
     assertThrows(
-      () => reg.require("google"),
+      () => reg.require("nope"),
       Error,
-      "google",
-    );
-    assertThrows(
-      () => reg.require("google"),
-      Error,
-      "openai, anthropic",
+      "nope",
     );
   });
 
-  it("register throws on duplicate id (no silent overwrite)", () => {
+  it("register throws on duplicate id for non-builtin providers", () => {
     const reg = createAIProviderRegistry();
     reg.register(fakeProvider("openai"));
     assertThrows(
@@ -66,8 +74,7 @@ describe("AIProviderRegistry", () => {
   it("list returns providers in insertion order", () => {
     const reg = createAIProviderRegistry();
     reg.register(fakeProvider("openai"));
-    reg.register(fakeProvider("anthropic"));
-    reg.register(fakeProvider("google"));
-    assertEquals(reg.list().map((p) => p.id), ["openai", "anthropic", "google"]);
+    const ids = reg.list().map((p) => p.id);
+    assertEquals(ids, ["anthropic", "google", "openai"]);
   });
 });

--- a/src/extensions/registries/ai-provider-registry.ts
+++ b/src/extensions/registries/ai-provider-registry.ts
@@ -1,29 +1,69 @@
 /**
  * Default Map-backed implementation of the AIProviderRegistry contract.
  *
- * Preserves insertion order via Map (used by `list()`). Throws on
- * duplicate id to surface silent collisions between extensions.
+ * Pre-registers built-in providers (Anthropic, Google) so every consumer
+ * works out of the box.  Extensions can override a built-in by calling
+ * `register()` with the same id — built-ins are silently replaced while
+ * collisions between two extensions still throw.
  *
  * @module extensions/registries/ai-provider-registry
  */
 
 import type { AIProvider, AIProviderRegistry } from "../interfaces/ai-provider.ts";
+import { createAnthropicModelRuntime, createGoogleModelRuntime } from "#veryfront/provider/runtime-loader.ts";
+import type { AIProviderConfig } from "../interfaces/ai-provider.ts";
+import type { ModelRuntime } from "#veryfront/provider/types.ts";
+
+class BuiltinAnthropicProvider implements AIProvider {
+  readonly id = "anthropic";
+
+  createModel(modelId: string, config: AIProviderConfig): ModelRuntime {
+    return createAnthropicModelRuntime({
+      apiKey: config.credential,
+      authToken: typeof config.authToken === "string" ? config.authToken : undefined,
+      baseURL: config.baseURL,
+      name: config.name ?? "anthropic",
+      fetch: config.fetch,
+    }, modelId);
+  }
+}
+
+class BuiltinGoogleProvider implements AIProvider {
+  readonly id = "google";
+
+  createModel(modelId: string, config: AIProviderConfig): ModelRuntime {
+    return createGoogleModelRuntime({
+      apiKey: config.credential,
+      baseURL: config.baseURL,
+      name: config.name ?? "google",
+      fetch: config.fetch,
+    }, modelId);
+  }
+}
 
 class AIProviderRegistryImpl implements AIProviderRegistry {
   private readonly providers = new Map<string, AIProvider>();
+  private readonly builtins = new Set<string>();
 
   register(provider: AIProvider): void {
-    if (this.providers.has(provider.id)) {
+    if (this.providers.has(provider.id) && !this.builtins.has(provider.id)) {
       throw new Error(
         `AIProvider "${provider.id}" is already registered. ` +
           `Call unregister("${provider.id}") first if you intend to replace it.`,
       );
     }
+    this.builtins.delete(provider.id);
     this.providers.set(provider.id, provider);
+  }
+
+  registerBuiltin(provider: AIProvider): void {
+    this.providers.set(provider.id, provider);
+    this.builtins.add(provider.id);
   }
 
   unregister(id: string): void {
     this.providers.delete(id);
+    this.builtins.delete(id);
   }
 
   get(id: string): AIProvider | undefined {
@@ -49,5 +89,8 @@ class AIProviderRegistryImpl implements AIProviderRegistry {
 }
 
 export function createAIProviderRegistry(): AIProviderRegistry {
-  return new AIProviderRegistryImpl();
+  const registry = new AIProviderRegistryImpl();
+  registry.registerBuiltin(new BuiltinAnthropicProvider());
+  registry.registerBuiltin(new BuiltinGoogleProvider());
+  return registry;
 }

--- a/src/provider/veryfront-cloud/provider.test.ts
+++ b/src/provider/veryfront-cloud/provider.test.ts
@@ -1,8 +1,11 @@
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
-import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { deleteEnv, setEnv } from "#veryfront/compat/process.ts";
 import { clearEmbeddingProviders, resolveEmbeddingModel } from "#veryfront/embedding/index.ts";
 import { clearModelProviders, findAvailableCloudModel, resolveModel } from "#veryfront/provider";
+import { register, reset } from "#veryfront/extensions/contracts.ts";
+import { AIProviderRegistryName } from "#veryfront/extensions/interfaces/index.ts";
+import { createAIProviderRegistry } from "#veryfront/extensions/registries/ai-provider-registry.ts";
 
 const CLOUD_ENV_KEYS = [
   "VERYFRONT_API_TOKEN",
@@ -27,42 +30,52 @@ function setCloudBootstrap(): void {
 }
 
 describe("provider/veryfront-cloud", () => {
+  beforeEach(() => {
+    register(AIProviderRegistryName, createAIProviderRegistry());
+  });
+
   afterEach(() => {
     clearCloudEnv();
     clearModelProviders();
     clearEmbeddingProviders();
+    reset();
+  });
+
+  it("resolves veryfront-cloud anthropic models via the built-in provider", () => {
+    setCloudBootstrap();
+
+    const model = resolveModel("veryfront-cloud/anthropic/claude-sonnet-4-6") as Record<string, unknown>;
+    assertEquals(typeof model.doGenerate, "function");
+    assertEquals(typeof model.doStream, "function");
   });
 
   it("throws when resolving veryfront-cloud openai models without ext-openai installed", () => {
     setCloudBootstrap();
 
-    // ext-openai is not registered in this test — expect the install hint.
     assertThrows(
       () => resolveModel("veryfront-cloud/openai/gpt-5.2"),
       Error,
-      "OpenAI provider not installed",
+      "openai",
     );
   });
 
   it("throws when resolving veryfront-cloud moonshotai models without ext-openai installed", () => {
     setCloudBootstrap();
 
-    // moonshotai routes through the openai provider, which requires ext-openai.
     assertThrows(
       () => resolveModel("veryfront-cloud/moonshotai/kimi-k2"),
       Error,
-      "OpenAI provider not installed",
+      "openai",
     );
   });
 
   it("throws when resolving veryfront-cloud openai embedding models without ext-openai installed", () => {
     setCloudBootstrap();
 
-    // OpenAI embedding requires ext-openai.
     assertThrows(
       () => resolveEmbeddingModel("veryfront-cloud/openai/text-embedding-3-small"),
       Error,
-      "OpenAI provider not installed",
+      "openai",
     );
   });
 

--- a/src/provider/veryfront-cloud/provider.ts
+++ b/src/provider/veryfront-cloud/provider.ts
@@ -1,6 +1,5 @@
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
-import { createAnthropicModelRuntime, createGoogleModelRuntime } from "../runtime-loader.ts";
-import { tryResolve } from "#veryfront/extensions/contracts.ts";
+import { resolve } from "#veryfront/extensions/contracts.ts";
 import type { AIProviderRegistry } from "#veryfront/extensions/interfaces/index.ts";
 import { AIProviderRegistryName } from "#veryfront/extensions/interfaces/index.ts";
 import type { ModelRuntime } from "../types.ts";
@@ -17,53 +16,30 @@ export function createVeryfrontCloudModel(modelId: string): ModelRuntime {
   const baseURL = getVeryfrontCloudGatewayBaseUrl(apiBaseUrl, provider);
   const fetch = createVeryfrontCloudFetch(apiToken, projectSlug);
 
+  const registry = resolve<AIProviderRegistry>(AIProviderRegistryName);
+
   switch (provider) {
-    case "anthropic": {
-      const registry = tryResolve<AIProviderRegistry>(AIProviderRegistryName);
-      const anthropic = registry?.get("anthropic");
-      if (anthropic) {
-        return anthropic.createModel(upstreamModelId, {
-          credential: apiToken,
-          authToken: apiToken,
-          baseURL,
-          name: "veryfront-cloud",
-          fetch,
-        });
-      }
-      // Fall back to the built-in runtime-loader when the extension is not
-      // registered.  Keeps Anthropic working until @veryfront/ext-anthropic is
-      // published to npm and adopted by all consumers.
-      return createAnthropicModelRuntime({
+    case "anthropic":
+    case "google": {
+      const p = registry.require(provider);
+      return p.createModel(upstreamModelId, {
+        credential: apiToken,
         authToken: apiToken,
         baseURL,
         name: "veryfront-cloud",
         fetch,
-      }, upstreamModelId);
+      });
     }
-
-    case "google":
-      return createGoogleModelRuntime({
-        apiKey: apiToken,
-        baseURL,
-        name: "veryfront-cloud",
-        fetch,
-      }, upstreamModelId);
 
     case "openai":
     case "moonshotai": {
-      const registry = tryResolve<AIProviderRegistry>(AIProviderRegistryName);
-      const openai = registry?.get("openai");
-      if (openai) {
-        return openai.createModel(upstreamModelId, {
-          credential: apiToken,
-          baseURL,
-          name: "veryfront-cloud",
-          fetch,
-        });
-      }
-      throw new Error(
-        "OpenAI provider not installed. Add @veryfront/ext-openai to use openai/moonshotai models via veryfront-cloud.",
-      );
+      const p = registry.require("openai");
+      return p.createModel(upstreamModelId, {
+        credential: apiToken,
+        baseURL,
+        name: "veryfront-cloud",
+        fetch,
+      });
     }
 
     default: {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.299";
+export const VERSION = "0.1.300";


### PR DESCRIPTION
## Summary

Single execution flow for AI model resolution. All providers go through the `AIProviderRegistry` — no fallbacks, no per-callsite branching.

**What changed:**
- `createAIProviderRegistry()` pre-registers Anthropic and Google as built-in providers
- `veryfront-cloud/provider.ts` uses `resolve()` + `registry.require()` uniformly for all providers
- Built-ins can be silently overridden by extensions calling `register()` with the same id
- Non-builtin duplicates still throw to catch collisions

**Replaces:** The per-callsite fallback from #1319

## Why

The extension architecture moved Anthropic behind `@veryfront/ext-anthropic` which isn't published. This crashed every consumer that doesn't run `orchestrateExtensions()` (like veryfront-agent). Instead of per-callsite fallbacks, built-in providers in the registry give every consumer a working default while extensions can override when adopted.

## Test plan

- [x] Typecheck passes
- [x] Registry tests pass (8/8) — includes new tests for built-in override behavior
- [x] Provider tests pass (8/8) — includes new test for built-in Anthropic resolution