### PR TITLE
Expose the hosted route contract for service shells

### DIFF
--- a/src/agent/agent-service.test.ts
+++ b/src/agent/agent-service.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   type AgentContract,
   type AgentServiceRegistryContract,
+  type AgentServiceRoute,
   type AgentServiceSingleAgentContract,
   defineAgentService,
   type DurableRunSink,
@@ -84,6 +85,26 @@ describe("agent/agent-service", () => {
     assertEquals(service.contract.serviceName, "veryfront-agent");
     assertEquals(service.contract.defaultAgentId, assistant.id);
     assertEquals(service.contract.agents[assistant.id], assistant);
+  });
+
+  it("exports the host route type accepted by service runtimes", async () => {
+    const routes: AgentServiceRoute[] = [
+      {
+        method: "GET",
+        path: "/custom/:id",
+        handler: (_request, params) => Response.json({ id: params.id }),
+      },
+    ];
+
+    const runtime = defineAgentService({
+      serviceName: "route-type-service",
+      agent: assistant,
+    }).createRuntime({ routes });
+
+    const response = await runtime.fetch(new Request("https://agent.test/custom/route-1"));
+
+    assertEquals(response.status, 200);
+    assertEquals(await response.json(), { id: "route-1" });
   });
 
   it("creates a runtime with readiness and liveness routes", async () => {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -144,6 +144,7 @@ export {
   type AgentRegistry,
   type AgentServiceDefinition,
   type AgentServiceRegistryContract,
+  type AgentServiceRoute,
   type AgentServiceServerConfig,
   type AgentServiceSingleAgentContract,
   defineAgentService,


### PR DESCRIPTION
## Summary
- export AgentServiceRoute from veryfront/agent
- add coverage proving downstream hosts can type the route array passed to createRuntime
- keep runtime behavior unchanged

## Verification
- deno fmt --check src/agent/index.ts src/agent/agent-service.test.ts
- deno test --no-check --allow-all src/agent/agent-service.test.ts
- deno task lint
- deno task typecheck
- pre-push checks passed