### PR TITLE
Let hosted service runtimes own CORS policy

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.300",
+  "version": "0.1.301",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/agent-service.test.ts
+++ b/src/agent/agent-service.test.ts
@@ -152,4 +152,87 @@ describe("agent/agent-service", () => {
     const missing = await runtime.fetch(new Request("https://agent.test/not-found"));
     assertEquals(missing.status, 404);
   });
+
+  it("handles CORS preflight through the runtime shell", async () => {
+    const runtime = defineAgentService({
+      serviceName: "veryfront-agent",
+      agent: assistant,
+      server: {
+        cors: {
+          origins: ["http://localhost:3000"],
+          credentials: true,
+        },
+      },
+    }).createRuntime();
+
+    const response = await runtime.fetch(
+      new Request("https://agent.test/api/ag-ui/runs", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "http://localhost:3000",
+          "Access-Control-Request-Method": "POST",
+          "Access-Control-Request-Headers": "Content-Type,Authorization",
+        },
+      }),
+    );
+
+    assertEquals(response.status, 204);
+    assertEquals(response.headers.get("Access-Control-Allow-Origin"), "http://localhost:3000");
+    assertEquals(response.headers.get("Access-Control-Allow-Credentials"), "true");
+    assertEquals(
+      response.headers.get("Access-Control-Allow-Headers"),
+      "Content-Type,Authorization",
+    );
+  });
+
+  it("does not allow disallowed CORS origins", async () => {
+    const runtime = defineAgentService({
+      serviceName: "veryfront-agent",
+      agent: assistant,
+      server: {
+        cors: {
+          origins: ["http://localhost:3000"],
+          credentials: true,
+        },
+      },
+    }).createRuntime();
+
+    const response = await runtime.fetch(
+      new Request("https://agent.test/api/ag-ui/runs", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://evil.example",
+          "Access-Control-Request-Method": "POST",
+        },
+      }),
+    );
+
+    assertEquals(response.status, 204);
+    assertEquals(response.headers.get("Access-Control-Allow-Origin"), null);
+  });
+
+  it("adds CORS headers to runtime responses for allowed origins", async () => {
+    const runtime = defineAgentService({
+      serviceName: "veryfront-agent",
+      agent: assistant,
+      server: {
+        cors: {
+          origins: ["http://localhost:3000"],
+          credentials: true,
+        },
+      },
+    }).createRuntime();
+
+    const response = await runtime.fetch(
+      new Request("https://agent.test/readiness", {
+        headers: {
+          Origin: "http://localhost:3000",
+        },
+      }),
+    );
+
+    assertEquals(response.status, 200);
+    assertEquals(response.headers.get("Access-Control-Allow-Origin"), "http://localhost:3000");
+    assertEquals(response.headers.get("Access-Control-Allow-Credentials"), "true");
+  });
 });

--- a/src/agent/agent-service.ts
+++ b/src/agent/agent-service.ts
@@ -20,14 +20,24 @@ export interface DurableRunSink<
  * Placeholder host-facing server config reserved for the future hosted service
  * implementation.
  */
+export type AgentServiceRouteMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS";
+
+export interface AgentServiceCorsConfig {
+  origins?: string[];
+  credentials?: boolean;
+  allowMethods?: AgentServiceRouteMethod[];
+  allowHeaders?: string[];
+  maxAgeSeconds?: number;
+}
+
 export interface AgentServiceServerConfig {
   port?: number;
   basePath?: string;
-  cors?: boolean;
+  cors?: boolean | AgentServiceCorsConfig;
 }
 
 export interface AgentServiceRoute {
-  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS";
+  method: AgentServiceRouteMethod;
   path: string;
   handler: (request: Request, params: Record<string, string>) => Promise<Response> | Response;
 }
@@ -206,6 +216,85 @@ function matchRoute(
   return params;
 }
 
+function normalizeCorsConfig(
+  server: AgentServiceServerConfig | undefined,
+): AgentServiceCorsConfig | undefined {
+  const cors = server?.cors;
+  if (!cors) return undefined;
+  if (cors === true) return { origins: ["*"] };
+  return cors;
+}
+
+function getAllowedCorsOrigin(
+  config: AgentServiceCorsConfig,
+  request: Request,
+): string | undefined {
+  const origin = request.headers.get("Origin");
+  if (!origin) return undefined;
+
+  const origins = config.origins ?? ["*"];
+  if (origins.includes("*")) {
+    return config.credentials ? origin : "*";
+  }
+
+  return origins.includes(origin) ? origin : undefined;
+}
+
+function appendCorsHeaders(
+  headers: Headers,
+  config: AgentServiceCorsConfig,
+  request: Request,
+): void {
+  const allowedOrigin = getAllowedCorsOrigin(config, request);
+  if (!allowedOrigin) return;
+
+  headers.set("Access-Control-Allow-Origin", allowedOrigin);
+  headers.append("Vary", "Origin");
+
+  if (config.credentials) {
+    headers.set("Access-Control-Allow-Credentials", "true");
+  }
+}
+
+function createCorsPreflightResponse(
+  request: Request,
+  config: AgentServiceCorsConfig,
+): Response {
+  const headers = new Headers();
+  appendCorsHeaders(headers, config, request);
+
+  const allowMethods = config.allowMethods ?? ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"];
+  headers.set("Access-Control-Allow-Methods", allowMethods.join(", "));
+
+  const requestedHeaders = request.headers.get("Access-Control-Request-Headers");
+  const allowHeaders = config.allowHeaders?.join(", ") ?? requestedHeaders;
+  if (allowHeaders) {
+    headers.set("Access-Control-Allow-Headers", allowHeaders);
+  }
+
+  if (config.maxAgeSeconds !== undefined) {
+    headers.set("Access-Control-Max-Age", String(config.maxAgeSeconds));
+  }
+
+  return new Response(null, { status: 204, headers });
+}
+
+function withCorsHeaders(
+  response: Response,
+  config: AgentServiceCorsConfig | undefined,
+  request: Request,
+): Response {
+  if (!config) return response;
+
+  const headers = new Headers(response.headers);
+  appendCorsHeaders(headers, config, request);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 function createAgentServiceRuntime<
   TStartInput = void,
   TRun = unknown,
@@ -217,26 +306,41 @@ function createAgentServiceRuntime<
 ): AgentServiceRuntime<TStartInput, TRun, TEvent, TTerminalState> {
   let shuttingDown = false;
   const routes = options.routes ?? [];
+  const corsConfig = normalizeCorsConfig(contract.server);
 
   return {
     contract,
     async fetch(request) {
+      if (
+        corsConfig && request.method === "OPTIONS" &&
+        request.headers.has("Access-Control-Request-Method")
+      ) {
+        return createCorsPreflightResponse(request, corsConfig);
+      }
+
       const path = new URL(request.url).pathname;
+      let response: Response;
       if (request.method === "GET" && path === "/readiness") {
-        return shuttingDown ? new Response("Shutting down", { status: 503 }) : new Response("OK");
+        response = shuttingDown
+          ? new Response("Shutting down", { status: 503 })
+          : new Response("OK");
+        return withCorsHeaders(response, corsConfig, request);
       }
       if (request.method === "GET" && path === "/liveness") {
-        return new Response("OK");
+        response = new Response("OK");
+        return withCorsHeaders(response, corsConfig, request);
       }
 
       for (const route of routes) {
         const params = matchRoute(route, request);
         if (params) {
-          return await route.handler(request, params);
+          response = await route.handler(request, params);
+          return withCorsHeaders(response, corsConfig, request);
         }
       }
 
-      return new Response("Not Found", { status: 404 });
+      response = new Response("Not Found", { status: 404 });
+      return withCorsHeaders(response, corsConfig, request);
     },
     setShuttingDown(next = true) {
       shuttingDown = next;

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -142,9 +142,11 @@ export { agent } from "./factory.ts";
 export {
   type AgentContract,
   type AgentRegistry,
+  type AgentServiceCorsConfig,
   type AgentServiceDefinition,
   type AgentServiceRegistryContract,
   type AgentServiceRoute,
+  type AgentServiceRouteMethod,
   type AgentServiceServerConfig,
   type AgentServiceSingleAgentContract,
   defineAgentService,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.300";
+export const VERSION = "0.1.301";


### PR DESCRIPTION
## Summary
- add runtime-agnostic hosted service CORS config for preflight and response headers
- keep product routes and auth host-owned while allowing service runtimes to own transport CORS policy
- bump package version to 0.1.301 for publication after merge

## Verification
- deno fmt --check src/agent/agent-service.ts src/agent/agent-service.test.ts deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all src/agent/agent-service.test.ts
- deno check src/agent/agent-service-route-export.check.ts
- deno task lint
- deno task typecheck
- pre-push checks: format, lint, typecheck, unit tests (1454 passed, 17218 steps, 0 failed)