### PR TITLE
Let hosted runtimes construct request probes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.301",
+  "version": "0.1.302",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/agent-service.test.ts
+++ b/src/agent/agent-service.test.ts
@@ -127,6 +127,33 @@ describe("agent/agent-service", () => {
     assertEquals(await shuttingDown.text(), "Shutting down");
   });
 
+  it("provides a host request helper for relative runtime checks", async () => {
+    const runtime = defineAgentService({
+      serviceName: "veryfront-agent",
+      agent: assistant,
+    }).createRuntime({
+      routes: [
+        {
+          method: "POST",
+          path: "/echo",
+          handler: async (request) =>
+            Response.json({
+              method: request.method,
+              body: await request.text(),
+            }),
+        },
+      ],
+    });
+
+    const ready = await runtime.request("/readiness");
+    assertEquals(ready.status, 200);
+    assertEquals(await ready.text(), "OK");
+
+    const echo = await runtime.request("/echo", { method: "POST", body: "hello" });
+    assertEquals(echo.status, 200);
+    assertEquals(await echo.json(), { method: "POST", body: "hello" });
+  });
+
   it("dispatches host-owned routes without taking over product policy", async () => {
     const runtime = defineAgentService({
       serviceName: "veryfront-agent",

--- a/src/agent/agent-service.ts
+++ b/src/agent/agent-service.ts
@@ -50,6 +50,7 @@ export interface AgentServiceRuntime<
 > {
   readonly contract: NormalizedAgentServiceContract<TStartInput, TRun, TEvent, TTerminalState>;
   fetch(request: Request): Promise<Response>;
+  request(input: string | URL | Request, init?: RequestInit): Promise<Response>;
   setShuttingDown(shuttingDown?: boolean): void;
 }
 
@@ -295,6 +296,15 @@ function withCorsHeaders(
   });
 }
 
+function toRuntimeRequest(input: string | URL | Request, init?: RequestInit): Request {
+  if (input instanceof Request) {
+    return init === undefined ? input : new Request(input, init);
+  }
+
+  const requestUrl = typeof input === "string" ? new URL(input, "http://localhost") : input;
+  return new Request(requestUrl, init);
+}
+
 function createAgentServiceRuntime<
   TStartInput = void,
   TRun = unknown,
@@ -308,7 +318,7 @@ function createAgentServiceRuntime<
   const routes = options.routes ?? [];
   const corsConfig = normalizeCorsConfig(contract.server);
 
-  return {
+  const runtime: AgentServiceRuntime<TStartInput, TRun, TEvent, TTerminalState> = {
     contract,
     async fetch(request) {
       if (
@@ -342,10 +352,15 @@ function createAgentServiceRuntime<
       response = new Response("Not Found", { status: 404 });
       return withCorsHeaders(response, corsConfig, request);
     },
+    request(input, init) {
+      return runtime.fetch(toRuntimeRequest(input, init));
+    },
     setShuttingDown(next = true) {
       shuttingDown = next;
     },
   };
+
+  return runtime;
 }
 
 /**

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.301";
+export const VERSION = "0.1.302";


### PR DESCRIPTION
## Summary\n- add an AgentServiceRuntime.request helper for relative-path runtime probes\n- keep fetch as the canonical dispatch path while removing the need for host-local request wrappers\n- bump the package version to 0.1.302 for the next adoption slice\n\n## Verification\n- deno fmt --check src/agent/agent-service.ts src/agent/agent-service.test.ts deno.json src/utils/version-constant.ts\n- deno test --no-check --allow-all src/agent/agent-service.test.ts\n- deno task lint\n- deno task typecheck\n- pre-push checks: formatting, lint, typecheck, full unit suite (1454 passed)