### PR TITLE
Share detached run tracking across hosts

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.302",
+  "version": "0.1.303",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/detached-run-tracker.test.ts
+++ b/src/agent/detached-run-tracker.test.ts
@@ -1,0 +1,71 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createDetachedRunTracker } from "./detached-run-tracker.ts";
+
+function deferred(): { promise: Promise<void>; resolve: () => Promise<void> } {
+  let resolvePromise: () => void = () => undefined;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    async resolve() {
+      resolvePromise();
+      await promise;
+    },
+  };
+}
+
+describe("agent/detached-run-tracker", () => {
+  it("tracks, cancels, and drains active run executions", async () => {
+    const tracker = createDetachedRunTracker<{ result: unknown; isError: boolean }>({
+      pollIntervalMs: 1,
+    });
+    const execution = deferred();
+
+    tracker.sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    void tracker.sessionManager.waitForSignal("run_1", "tool_1").catch(() => undefined);
+    tracker.registerExecution("run_1", execution.promise);
+
+    assertEquals(tracker.cancelAllRuns(), ["run_1"]);
+    const draining = tracker.waitForDrain({ timeoutMs: 50, pollIntervalMs: 1 });
+    const beforeResolve = await tracker.waitForDrain({ timeoutMs: 1, pollIntervalMs: 1 });
+    assertEquals(beforeResolve, { drained: false, pendingRunIds: ["run_1"] });
+
+    await execution.resolve();
+    assertEquals(await draining, { drained: true, pendingRunIds: [] });
+  });
+
+  it("keeps newer executions registered when an older execution settles", async () => {
+    const tracker = createDetachedRunTracker();
+    const oldExecution = deferred();
+    const newExecution = deferred();
+
+    tracker.registerExecution("run_1", oldExecution.promise);
+    tracker.registerExecution("run_1", newExecution.promise);
+    await oldExecution.resolve();
+
+    const pending = await tracker.waitForDrain({ timeoutMs: 1, pollIntervalMs: 1 });
+    assertEquals(pending, { drained: false, pendingRunIds: ["run_1"] });
+
+    await newExecution.resolve();
+    assertEquals(await tracker.waitForDrain({ timeoutMs: 50, pollIntervalMs: 1 }), {
+      drained: true,
+      pendingRunIds: [],
+    });
+  });
+
+  it("resets run status and active tracking", async () => {
+    const tracker = createDetachedRunTracker();
+    tracker.sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    tracker.trackRun("run_1");
+
+    tracker.reset();
+
+    assertEquals(tracker.sessionManager.getRunStatus("run_1"), null);
+    assertEquals(await tracker.waitForDrain({ timeoutMs: 1, pollIntervalMs: 1 }), {
+      drained: true,
+      pendingRunIds: [],
+    });
+  });
+});

--- a/src/agent/detached-run-tracker.ts
+++ b/src/agent/detached-run-tracker.ts
@@ -1,0 +1,112 @@
+import { RunResumeSessionManager } from "./runtime/resume-session.ts";
+
+export interface DetachedRunDrainResult {
+  drained: boolean;
+  pendingRunIds: string[];
+}
+
+export interface DetachedRunTrackerOptions<TResumeValue> {
+  sessionManager?: RunResumeSessionManager<TResumeValue>;
+  pollIntervalMs?: number;
+}
+
+export interface DetachedRunTracker<TResumeValue> {
+  readonly sessionManager: RunResumeSessionManager<TResumeValue>;
+  trackRun(runId: string): void;
+  untrackRun(runId: string): void;
+  cancelRun(runId: string): boolean;
+  registerExecution(runId: string, execution: Promise<void>): void;
+  cancelAllRuns(): string[];
+  waitForDrain(
+    input: { timeoutMs: number; pollIntervalMs?: number },
+  ): Promise<DetachedRunDrainResult>;
+  reset(): void;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export function createDetachedRunTracker<TResumeValue = unknown>(
+  options: DetachedRunTrackerOptions<TResumeValue> = {},
+): DetachedRunTracker<TResumeValue> {
+  const sessionManager = options.sessionManager ?? new RunResumeSessionManager<TResumeValue>();
+  const activeRunIds = new Set<string>();
+  const activeExecutions = new Map<string, Promise<void>>();
+  const defaultPollIntervalMs = options.pollIntervalMs ?? 50;
+
+  const collectPendingRunIds = (): string[] => [
+    ...new Set([...activeRunIds, ...activeExecutions.keys()]),
+  ];
+
+  const untrackRun = (runId: string): void => {
+    activeRunIds.delete(runId);
+  };
+
+  return {
+    sessionManager,
+    trackRun(runId) {
+      activeRunIds.add(runId);
+    },
+    untrackRun,
+    cancelRun(runId) {
+      const cancelled = sessionManager.cancelRun(runId);
+      if (cancelled) {
+        untrackRun(runId);
+      }
+      return cancelled;
+    },
+    registerExecution(runId, execution) {
+      activeRunIds.add(runId);
+
+      const trackedExecution = execution.finally(() => {
+        if (activeExecutions.get(runId) !== trackedExecution) {
+          return;
+        }
+
+        activeExecutions.delete(runId);
+        untrackRun(runId);
+      });
+
+      activeExecutions.set(runId, trackedExecution);
+    },
+    cancelAllRuns() {
+      const runIds = [...activeRunIds];
+      for (const runId of runIds) {
+        this.cancelRun(runId);
+      }
+      return runIds;
+    },
+    async waitForDrain(input) {
+      const pollIntervalMs = input.pollIntervalMs ?? defaultPollIntervalMs;
+      const deadline = Date.now() + input.timeoutMs;
+
+      while (Date.now() <= deadline) {
+        const pendingRunIds = collectPendingRunIds();
+        if (pendingRunIds.length === 0) {
+          return { drained: true, pendingRunIds: [] };
+        }
+
+        const executions = [...activeExecutions.values()];
+        if (executions.length > 0) {
+          await Promise.race([Promise.allSettled(executions), sleep(pollIntervalMs)]);
+          continue;
+        }
+
+        await sleep(pollIntervalMs);
+      }
+
+      return {
+        drained: false,
+        pendingRunIds: collectPendingRunIds(),
+      };
+    },
+    reset() {
+      sessionManager.reset();
+      activeRunIds.clear();
+      activeExecutions.clear();
+    },
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -461,6 +461,12 @@ export {
   type ExecuteAgUiDetachedStartInput,
 } from "./ag-ui-detached-start.ts";
 export {
+  createDetachedRunTracker,
+  type DetachedRunDrainResult,
+  type DetachedRunTracker,
+  type DetachedRunTrackerOptions,
+} from "./detached-run-tracker.ts";
+export {
   type AgUiCancelHandlerOptions,
   type AgUiResumeHandlerOptions,
   type AgUiResumeSignal,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.302";
+export const VERSION = "0.1.303";


### PR DESCRIPTION
## Summary\n- add a runtime-neutral detached run tracker built on RunResumeSessionManager\n- cover cancellation, drain waiting, replacement execution handling, and reset behavior\n- export the tracker from veryfront/agent and bump the package to 0.1.303\n\n## Verification\n- deno fmt --check src/agent/detached-run-tracker.ts src/agent/detached-run-tracker.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts\n- deno test --no-check --allow-all src/agent/detached-run-tracker.test.ts\n- deno task lint\n- deno task typecheck\n- pre-push checks: formatting, lint, typecheck, full unit suite (1455 passed)