### PR TITLE
Share chunk-based conversation run mirroring

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.303",
+  "version": "0.1.304",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/conversation-run-chunk-mirror.test.ts
+++ b/src/agent/conversation-run-chunk-mirror.test.ts
@@ -1,0 +1,132 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ChatUiMessageChunk } from "../chat/protocol.ts";
+import type {
+  ConversationRunEventQueueController,
+  ConversationRunEventQueueFlushResult,
+  ConversationRunEventQueueSnapshot,
+} from "./durable.ts";
+import type { ConversationRunEvent } from "./conversation-run-events.ts";
+import { createConversationRunChunkMirror } from "./conversation-run-chunk-mirror.ts";
+
+function createQueueController(): ConversationRunEventQueueController & {
+  enqueued: unknown[];
+  disabled: boolean;
+} {
+  const enqueued: unknown[] = [];
+  return {
+    enqueued,
+    disabled: false,
+    enqueue(events: unknown[]) {
+      enqueued.push(...events);
+    },
+    async flush(): Promise<ConversationRunEventQueueFlushResult> {
+      enqueued.length = 0;
+      return { outcome: "flushed", latestEventId: 0, latestExternalEventSequence: 0 };
+    },
+    getSnapshot(): ConversationRunEventQueueSnapshot {
+      return {
+        latestEventId: 0,
+        latestExternalEventSequence: 0,
+        pendingEventCount: enqueued.length,
+        consecutiveFailures: 0,
+        disabled: this.disabled,
+      };
+    },
+  };
+}
+
+describe("agent/conversation-run-chunk-mirror", () => {
+  it("prepares UI chunks into durable events and enqueues them", async () => {
+    const queueController = createQueueController();
+    const preparedTypes: string[] = [];
+    const mirror = createConversationRunChunkMirror({
+      queueController,
+      immediateFlushEventCount: 99,
+      flushDelayMs: 10_000,
+      onChunkPrepared: ({ events }) => {
+        preparedTypes.push(...events.map((event) => event.type));
+      },
+    });
+
+    await mirror.handleChunk({ type: "text-delta", id: "m1", delta: "hello" });
+
+    assertEquals(preparedTypes, ["TEXT_MESSAGE_CONTENT"]);
+    assertEquals(queueController.enqueued, [
+      { type: "TEXT_MESSAGE_CONTENT", messageId: "m1", delta: "hello" },
+    ]);
+    mirror.dispose();
+  });
+
+  it("normalizes external events before enqueueing", async () => {
+    const queueController = createQueueController();
+    const prepared: ConversationRunEvent[][] = [];
+    const mirror = createConversationRunChunkMirror({
+      queueController,
+      immediateFlushEventCount: 99,
+      flushDelayMs: 10_000,
+      onExternalEventsPrepared: ({ events }) => {
+        prepared.push(events);
+      },
+    });
+
+    await mirror.appendEvents([
+      { type: "TEXT_MESSAGE_CONTENT", delta: "" },
+      { type: "TEXT_MESSAGE_CONTENT", delta: "persisted" },
+    ]);
+
+    assertEquals(prepared, [[
+      { type: "TEXT_MESSAGE_CONTENT", delta: "" },
+      { type: "TEXT_MESSAGE_CONTENT", delta: "persisted" },
+    ]]);
+    assertEquals(queueController.enqueued, [
+      { type: "TEXT_MESSAGE_CONTENT", delta: "" },
+      { type: "TEXT_MESSAGE_CONTENT", delta: "persisted" },
+    ]);
+    mirror.dispose();
+  });
+
+  it("allows hosts to wrap chunk and external event preparation", async () => {
+    const queueController = createQueueController();
+    const preparedMarkers: string[] = [];
+    const mirror = createConversationRunChunkMirror({
+      queueController,
+      immediateFlushEventCount: 99,
+      flushDelayMs: 10_000,
+      prepareChunkEvents: ({ defaultPrepare }) => {
+        preparedMarkers.push("chunk:start");
+        const events = defaultPrepare();
+        preparedMarkers.push(`chunk:${events.length}`);
+        return events;
+      },
+      prepareExternalEvents: async ({ defaultPrepare }) => {
+        preparedMarkers.push("external:start");
+        const events = defaultPrepare();
+        preparedMarkers.push(`external:${events.length}`);
+        return events;
+      },
+    });
+
+    await mirror.handleChunk({ type: "text-delta", id: "m1", delta: "hello" });
+    await mirror.appendEvents([{ type: "TEXT_MESSAGE_CONTENT", delta: "persisted" }]);
+
+    assertEquals(preparedMarkers, ["chunk:start", "chunk:1", "external:start", "external:1"]);
+    assertEquals(queueController.enqueued, [
+      { type: "TEXT_MESSAGE_CONTENT", messageId: "m1", delta: "hello" },
+      { type: "TEXT_MESSAGE_CONTENT", delta: "persisted" },
+    ]);
+    mirror.dispose();
+  });
+
+  it("does not enqueue when the underlying mirror is disabled", async () => {
+    const queueController = createQueueController();
+    queueController.disabled = true;
+    const mirror = createConversationRunChunkMirror({ queueController });
+
+    const chunk: ChatUiMessageChunk = { type: "text-delta", id: "m1", delta: "ignored" };
+    await mirror.handleChunk(chunk);
+    await mirror.appendEvents([{ type: "TEXT_MESSAGE_CONTENT", delta: "ignored" }]);
+
+    assertEquals(queueController.enqueued, []);
+  });
+});

--- a/src/agent/conversation-run-chunk-mirror.ts
+++ b/src/agent/conversation-run-chunk-mirror.ts
@@ -1,0 +1,170 @@
+import type { ChatMessageMetadata, ChatUiMessageChunk } from "../chat/protocol.ts";
+import {
+  type ConversationRunEvent,
+  ConversationRunEventEncoder,
+} from "./conversation-run-events.ts";
+import {
+  type ConversationRunMirror,
+  type ConversationRunMirrorRetryScheduledState,
+  type ConversationRunMirrorStoppedState,
+  createConversationRunMirror,
+} from "./conversation-run-mirror.ts";
+import {
+  prepareConversationRunChunkEvents,
+  prepareConversationRunExternalEvents,
+} from "./conversation-run-event-preparation.ts";
+import {
+  type ConversationRunEventQueueController,
+  createConversationRunEventQueueController,
+} from "./durable.ts";
+
+const DEFAULT_IMMEDIATE_FLUSH_EVENT_COUNT = 24;
+const DEFAULT_MAX_CURSOR_RESYNCS_PER_FLUSH = 3;
+
+export interface ConversationRunChunkMirror {
+  handleChunk(chunk: ChatUiMessageChunk<ChatMessageMetadata>): Promise<void>;
+  appendEvents(events: ConversationRunEvent[]): Promise<void>;
+  flush(): Promise<void>;
+  getSnapshot(): ReturnType<ConversationRunMirror["getSnapshot"]>;
+  dispose(): void;
+}
+
+export interface ConversationRunChunkMirrorPreparedChunk {
+  chunk: ChatUiMessageChunk<ChatMessageMetadata>;
+  events: ConversationRunEvent[];
+}
+
+export interface ConversationRunChunkMirrorPreparedEvents {
+  events: ConversationRunEvent[];
+}
+
+export interface ConversationRunChunkMirrorPrepareChunkEventsInput {
+  chunk: ChatUiMessageChunk<ChatMessageMetadata>;
+  defaultPrepare: () => ConversationRunEvent[];
+}
+
+export interface ConversationRunChunkMirrorPrepareExternalEventsInput {
+  events: ConversationRunEvent[];
+  defaultPrepare: () => ConversationRunEvent[];
+}
+
+interface ConversationRunChunkMirrorSharedOptions {
+  immediateFlushEventCount?: number;
+  encoder?: ConversationRunEventEncoder;
+  flushDelayMs?: number;
+  getRetryDelayMs?: (consecutiveFailures: number) => number;
+  onRetryScheduled?: (state: ConversationRunMirrorRetryScheduledState) => Promise<void> | void;
+  onStopped?: (state: ConversationRunMirrorStoppedState) => Promise<void> | void;
+  prepareChunkEvents?: (
+    input: ConversationRunChunkMirrorPrepareChunkEventsInput,
+  ) => Promise<ConversationRunEvent[]> | ConversationRunEvent[];
+  prepareExternalEvents?: (
+    input: ConversationRunChunkMirrorPrepareExternalEventsInput,
+  ) => Promise<ConversationRunEvent[]> | ConversationRunEvent[];
+  onChunkPrepared?: (input: ConversationRunChunkMirrorPreparedChunk) => Promise<void> | void;
+  onExternalEventsPrepared?: (
+    input: ConversationRunChunkMirrorPreparedEvents,
+  ) => Promise<void> | void;
+}
+
+export interface ConversationRunChunkMirrorQueueOptions
+  extends ConversationRunChunkMirrorSharedOptions {
+  queueController: ConversationRunEventQueueController;
+}
+
+export interface ConversationRunChunkMirrorApiOptions
+  extends ConversationRunChunkMirrorSharedOptions {
+  authToken: string;
+  apiUrl: string;
+  conversationId: string;
+  runId: string;
+  latestEventId: number;
+  latestExternalEventSequence?: number;
+  maxEventsPerBatch?: number;
+  maxCursorResyncsPerFlush?: number;
+}
+
+export type ConversationRunChunkMirrorOptions =
+  | ConversationRunChunkMirrorQueueOptions
+  | ConversationRunChunkMirrorApiOptions;
+
+function resolveQueueController(
+  input: ConversationRunChunkMirrorOptions,
+): ConversationRunEventQueueController {
+  if ("queueController" in input) {
+    return input.queueController;
+  }
+
+  const maxEventsPerBatch = input.maxEventsPerBatch ?? DEFAULT_IMMEDIATE_FLUSH_EVENT_COUNT;
+  return createConversationRunEventQueueController({
+    authToken: input.authToken,
+    apiUrl: input.apiUrl,
+    conversationId: input.conversationId,
+    runId: input.runId,
+    latestEventId: input.latestEventId,
+    latestExternalEventSequence: input.latestExternalEventSequence ?? 0,
+    maxEventsPerBatch,
+    maxCursorResyncsPerFlush: input.maxCursorResyncsPerFlush ??
+      DEFAULT_MAX_CURSOR_RESYNCS_PER_FLUSH,
+  });
+}
+
+export function createConversationRunChunkMirror(
+  input: ConversationRunChunkMirrorOptions,
+): ConversationRunChunkMirror {
+  const encoder = input.encoder ?? new ConversationRunEventEncoder();
+  const immediateFlushEventCount = input.immediateFlushEventCount ??
+    DEFAULT_IMMEDIATE_FLUSH_EVENT_COUNT;
+  const mirror = createConversationRunMirror({
+    queueController: resolveQueueController(input),
+    immediateFlushEventCount,
+    ...(input.flushDelayMs !== undefined ? { flushDelayMs: input.flushDelayMs } : {}),
+    ...(input.getRetryDelayMs ? { getRetryDelayMs: input.getRetryDelayMs } : {}),
+    ...(input.onRetryScheduled ? { onRetryScheduled: input.onRetryScheduled } : {}),
+    ...(input.onStopped ? { onStopped: input.onStopped } : {}),
+  });
+
+  return {
+    async handleChunk(chunk) {
+      if (mirror.getSnapshot().disabled) {
+        return;
+      }
+
+      const events = await (input.prepareChunkEvents?.({
+        chunk,
+        defaultPrepare: () => prepareConversationRunChunkEvents([chunk], encoder),
+      }) ?? prepareConversationRunChunkEvents([chunk], encoder));
+      await input.onChunkPrepared?.({ chunk, events });
+      if (events.length === 0) {
+        return;
+      }
+
+      mirror.enqueue(events);
+    },
+    async appendEvents(events) {
+      if (mirror.getSnapshot().disabled || events.length === 0) {
+        return;
+      }
+
+      const normalizedEvents = await (input.prepareExternalEvents?.({
+        events,
+        defaultPrepare: () => prepareConversationRunExternalEvents(events),
+      }) ?? prepareConversationRunExternalEvents(events));
+      await input.onExternalEventsPrepared?.({ events: normalizedEvents });
+      if (normalizedEvents.length === 0) {
+        return;
+      }
+
+      mirror.enqueue(normalizedEvents);
+    },
+    flush() {
+      return mirror.flush();
+    },
+    getSnapshot() {
+      return mirror.getSnapshot();
+    },
+    dispose() {
+      mirror.dispose();
+    },
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -311,6 +311,17 @@ export {
   createConversationRunMirror,
 } from "./conversation-run-mirror.ts";
 export {
+  type ConversationRunChunkMirror,
+  type ConversationRunChunkMirrorApiOptions,
+  type ConversationRunChunkMirrorOptions,
+  type ConversationRunChunkMirrorPrepareChunkEventsInput,
+  type ConversationRunChunkMirrorPreparedChunk,
+  type ConversationRunChunkMirrorPreparedEvents,
+  type ConversationRunChunkMirrorPrepareExternalEventsInput,
+  type ConversationRunChunkMirrorQueueOptions,
+  createConversationRunChunkMirror,
+} from "./conversation-run-chunk-mirror.ts";
+export {
   type ConversationRunStreamMirror,
   createConversationRunStreamMirror,
 } from "./conversation-run-stream-mirror.ts";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.303";
+export const VERSION = "0.1.304";


### PR DESCRIPTION
## Summary
- add a reusable conversation run chunk mirror that prepares chat UI chunks and externally supplied run events before queueing
- expose host-owned preparation hooks so tracing/logging wrappers stay outside framework core
- bump package version to 0.1.304

## Verification
- deno fmt --check src/agent/conversation-run-chunk-mirror.ts src/agent/conversation-run-chunk-mirror.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all src/agent/conversation-run-chunk-mirror.test.ts
- deno task lint
- deno task typecheck
- git push pre-push checks: fmt, lint, typecheck, unit tests (1456 passed / 0 failed)
