### PR TITLE
Share child-run final-step safeguards

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.304",
+  "version": "0.1.305",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/child-run-final-step-support.test.ts
+++ b/src/agent/child-run-final-step-support.test.ts
@@ -1,0 +1,55 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  appendMissingChildRunToolCalls,
+  appendMissingChildRunToolResults,
+  buildChildRunExhaustedStepBudgetErrorMessage,
+} from "./child-run-final-step-support.ts";
+
+describe("agent/child-run-final-step-support", () => {
+  it("appends tool calls that are not already present", () => {
+    const existing = [{ toolCallId: "tc-1", toolName: "bash" }];
+    appendMissingChildRunToolCalls(existing, [
+      { toolCallId: "tc-1", toolName: "bash" },
+      { toolCallId: "tc-2", toolName: "readFile" },
+    ]);
+
+    assertEquals(existing, [
+      { toolCallId: "tc-1", toolName: "bash" },
+      { toolCallId: "tc-2", toolName: "readFile" },
+    ]);
+  });
+
+  it("appends tool results that are not already present", () => {
+    const existing = [{ toolCallId: "tc-1", toolName: "bash", input: {}, output: "ok" }];
+    appendMissingChildRunToolResults(existing, [
+      { toolCallId: "tc-1", toolName: "bash", input: {}, output: "changed" },
+      { toolCallId: "tc-2", toolName: "readFile", input: { path: "/a" }, output: "contents" },
+    ]);
+
+    assertEquals(existing, [
+      { toolCallId: "tc-1", toolName: "bash", input: {}, output: "ok" },
+      { toolCallId: "tc-2", toolName: "readFile", input: { path: "/a" }, output: "contents" },
+    ]);
+  });
+
+  it("builds exhausted step budget messages with deduplicated tool names", () => {
+    const message = buildChildRunExhaustedStepBudgetErrorMessage(50, [
+      { toolName: "bash" },
+      { toolName: "readFile" },
+      { toolName: "bash" },
+    ]);
+
+    assertEquals(
+      message,
+      "Child agent exhausted its step budget (50 steps) without completing the task. Tools called: bash, readFile. Increase max_steps or simplify the task.",
+    );
+  });
+
+  it("uses a none placeholder when no tools were called", () => {
+    assertEquals(
+      buildChildRunExhaustedStepBudgetErrorMessage(10, []),
+      "Child agent exhausted its step budget (10 steps) without completing the task. Tools called: (none). Increase max_steps or simplify the task.",
+    );
+  });
+});

--- a/src/agent/child-run-final-step-support.ts
+++ b/src/agent/child-run-final-step-support.ts
@@ -1,0 +1,51 @@
+interface ToolCallLike {
+  toolCallId: string;
+  toolName: string;
+  input?: unknown;
+}
+
+interface ToolResultLike {
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+  output: unknown;
+}
+
+export function appendMissingChildRunToolCalls(
+  toolCalls: ToolCallLike[],
+  fallbackToolCalls: ToolCallLike[],
+): void {
+  const existingToolCallIds = new Set(toolCalls.map((toolCall) => toolCall.toolCallId));
+  for (const toolCall of fallbackToolCalls) {
+    if (existingToolCallIds.has(toolCall.toolCallId)) {
+      continue;
+    }
+
+    toolCalls.push(toolCall);
+    existingToolCallIds.add(toolCall.toolCallId);
+  }
+}
+
+export function appendMissingChildRunToolResults(
+  toolResults: ToolResultLike[],
+  fallbackToolResults: ToolResultLike[],
+): void {
+  const existingToolResultIds = new Set(toolResults.map((toolResult) => toolResult.toolCallId));
+  for (const toolResult of fallbackToolResults) {
+    if (existingToolResultIds.has(toolResult.toolCallId)) {
+      continue;
+    }
+
+    toolResults.push(toolResult);
+    existingToolResultIds.add(toolResult.toolCallId);
+  }
+}
+
+export function buildChildRunExhaustedStepBudgetErrorMessage(
+  stepCount: number,
+  toolCalls: Array<{ toolName: string }>,
+): string {
+  const calledToolNames = [...new Set(toolCalls.map((toolCall) => toolCall.toolName))];
+  const toolList = calledToolNames.join(", ") || "(none)";
+  return `Child agent exhausted its step budget (${stepCount} steps) without completing the task. Tools called: ${toolList}. Increase max_steps or simplify the task.`;
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -311,6 +311,11 @@ export {
   createConversationRunMirror,
 } from "./conversation-run-mirror.ts";
 export {
+  appendMissingChildRunToolCalls,
+  appendMissingChildRunToolResults,
+  buildChildRunExhaustedStepBudgetErrorMessage,
+} from "./child-run-final-step-support.ts";
+export {
   type ConversationRunChunkMirror,
   type ConversationRunChunkMirrorApiOptions,
   type ConversationRunChunkMirrorOptions,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.304";
+export const VERSION = "0.1.305";


### PR DESCRIPTION
## Summary
- add reusable child-run final-step fallback helpers for missing tool calls/results
- add the shared exhausted-step-budget diagnostic builder
- bump package version to 0.1.305

## Verification
- deno fmt --check src/agent/child-run-final-step-support.ts src/agent/child-run-final-step-support.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all src/agent/child-run-final-step-support.test.ts
- deno task lint
- deno task typecheck
- git push pre-push checks: fmt, lint, typecheck, unit tests (1457 passed / 0 failed)
