### PR TITLE
Share child-run execution snapshots

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.305",
+  "version": "0.1.306",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/child-run-execution-snapshot.test.ts
+++ b/src/agent/child-run-execution-snapshot.test.ts
@@ -1,0 +1,100 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  buildChildRunExecutionSnapshot,
+  buildChildRunFailureResult,
+  buildChildRunFailureSnapshot,
+  buildChildRunResultCommon,
+  buildChildRunSuccessResult,
+  buildChildRunSuccessSnapshot,
+  getChildRunSnapshotUsage,
+} from "./child-run-execution-snapshot.ts";
+
+const COMMON = {
+  description: "Test task",
+  steps: 3,
+  toolCalls: [{ toolName: "bash", toolCallId: "tc-1" }],
+  toolResults: [{ toolName: "bash", toolCallId: "tc-1", input: {}, output: "ok" }],
+  usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+  durationMs: 5000,
+};
+
+describe("agent/child-run-execution-snapshot", () => {
+  it("builds success results with common execution metadata", () => {
+    const result = buildChildRunSuccessResult(COMMON, { text: "Done!" });
+
+    assertEquals(result, {
+      success: true,
+      description: "Test task",
+      summary: { text: "Done!" },
+      steps: 3,
+      toolCalls: [{ toolName: "bash", toolCallId: "tc-1" }],
+      toolResults: [{ toolName: "bash", toolCallId: "tc-1", input: {}, output: "ok" }],
+      usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+      durationMs: 5000,
+    });
+  });
+
+  it("builds failure results with common execution metadata", () => {
+    const result = buildChildRunFailureResult(COMMON, "Something broke");
+
+    assertEquals(result, {
+      success: false,
+      description: "Test task",
+      error: "Something broke",
+      steps: 3,
+      toolCalls: [{ toolName: "bash", toolCallId: "tc-1" }],
+      toolResults: [{ toolName: "bash", toolCallId: "tc-1", input: {}, output: "ok" }],
+      usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+      durationMs: 5000,
+    });
+  });
+
+  it("converts success and failure results to snapshots", () => {
+    const success = buildChildRunExecutionSnapshot(
+      buildChildRunSuccessResult(COMMON, { text: "full text" }),
+    );
+    const failure = buildChildRunExecutionSnapshot(buildChildRunFailureResult(COMMON, "error"));
+
+    assertEquals(success.fullResultText, "full text");
+    assertEquals(success.error, null);
+    assertEquals(failure.fullResultText, null);
+    assertEquals(failure.error, "error");
+  });
+
+  it("builds explicit success and failure snapshots", () => {
+    assertEquals(buildChildRunFailureSnapshot(COMMON, "error", "partial text"), {
+      success: false,
+      description: "Test task",
+      fullResultText: "partial text",
+      error: "error",
+      steps: 3,
+      toolCalls: [{ toolName: "bash", toolCallId: "tc-1" }],
+      toolResults: [{ toolName: "bash", toolCallId: "tc-1", input: {}, output: "ok" }],
+      usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+      durationMs: 5000,
+    });
+
+    assertEquals(buildChildRunSuccessSnapshot(COMMON, "full text"), {
+      success: true,
+      description: "Test task",
+      fullResultText: "full text",
+      error: null,
+      steps: 3,
+      toolCalls: [{ toolName: "bash", toolCallId: "tc-1" }],
+      toolResults: [{ toolName: "bash", toolCallId: "tc-1", input: {}, output: "ok" }],
+      usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+      durationMs: 5000,
+    });
+  });
+
+  it("returns common input unchanged and reads optional snapshot usage", () => {
+    const common = buildChildRunResultCommon(COMMON);
+    assertEquals(common, COMMON);
+    assertEquals(
+      getChildRunSnapshotUsage(buildChildRunSuccessSnapshot(COMMON, "full text")),
+      COMMON.usage,
+    );
+    assertEquals(getChildRunSnapshotUsage(null), undefined);
+  });
+});

--- a/src/agent/child-run-execution-snapshot.ts
+++ b/src/agent/child-run-execution-snapshot.ts
@@ -1,0 +1,154 @@
+export interface ChildRunExecutionUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+export interface ChildRunToolCallSnapshot {
+  toolName: string;
+  toolCallId: string;
+  input?: unknown;
+}
+
+export interface ChildRunToolResultSnapshot {
+  toolName: string;
+  toolCallId: string;
+  input: unknown;
+  output: unknown;
+}
+
+export interface ChildRunExecutionSnapshot {
+  success: boolean;
+  description: string;
+  fullResultText: string | null;
+  error: string | null;
+  steps: number;
+  toolCalls: ChildRunToolCallSnapshot[];
+  toolResults: ChildRunToolResultSnapshot[];
+  usage?: ChildRunExecutionUsage;
+  durationMs: number;
+}
+
+export type ChildRunExecutionResult =
+  | {
+    success: true;
+    description: string;
+    summary: { text: string };
+    steps: number;
+    toolCalls: ChildRunToolCallSnapshot[];
+    toolResults: ChildRunToolResultSnapshot[];
+    usage?: ChildRunExecutionUsage;
+    durationMs: number;
+  }
+  | {
+    success: false;
+    description: string;
+    error: string;
+    steps: number;
+    toolCalls: ChildRunToolCallSnapshot[];
+    toolResults: ChildRunToolResultSnapshot[];
+    usage?: ChildRunExecutionUsage;
+    durationMs: number;
+  };
+
+export interface ChildRunResultCommon {
+  description: string;
+  steps: number;
+  toolCalls: ChildRunToolCallSnapshot[];
+  toolResults: ChildRunToolResultSnapshot[];
+  usage?: ChildRunExecutionUsage;
+  durationMs: number;
+}
+
+export function getChildRunSnapshotUsage(
+  snapshot: ChildRunExecutionSnapshot | null,
+): ChildRunExecutionSnapshot["usage"] | undefined {
+  return snapshot?.usage;
+}
+
+export function buildChildRunExecutionSnapshot(
+  result: ChildRunExecutionResult,
+): ChildRunExecutionSnapshot {
+  return {
+    success: result.success,
+    description: result.description,
+    fullResultText: result.success ? result.summary.text : null,
+    error: result.success ? null : result.error,
+    steps: result.steps,
+    toolCalls: result.toolCalls ?? [],
+    toolResults: result.toolResults ?? [],
+    usage: result.usage,
+    durationMs: result.durationMs ?? 0,
+  };
+}
+
+export function buildChildRunResultCommon(input: ChildRunResultCommon): ChildRunResultCommon {
+  return input;
+}
+
+export function buildChildRunSuccessResult(
+  common: ChildRunResultCommon,
+  summary: { text: string },
+): ChildRunExecutionResult & { success: true } {
+  return {
+    success: true,
+    description: common.description,
+    summary,
+    steps: common.steps,
+    toolCalls: common.toolCalls,
+    toolResults: common.toolResults,
+    usage: common.usage,
+    durationMs: common.durationMs,
+  };
+}
+
+export function buildChildRunFailureResult(
+  common: ChildRunResultCommon,
+  error: string,
+): ChildRunExecutionResult & { success: false } {
+  return {
+    success: false,
+    description: common.description,
+    error,
+    steps: common.steps,
+    toolCalls: common.toolCalls,
+    toolResults: common.toolResults,
+    usage: common.usage,
+    durationMs: common.durationMs,
+  };
+}
+
+export function buildChildRunFailureSnapshot(
+  common: ChildRunResultCommon,
+  error: string,
+  fullResultText: string | null,
+): ChildRunExecutionSnapshot {
+  return {
+    success: false,
+    description: common.description,
+    fullResultText,
+    error,
+    steps: common.steps,
+    toolCalls: common.toolCalls,
+    toolResults: common.toolResults,
+    usage: common.usage,
+    durationMs: common.durationMs,
+  };
+}
+
+export function buildChildRunSuccessSnapshot(
+  common: ChildRunResultCommon,
+  fullResultText: string,
+): ChildRunExecutionSnapshot {
+  return {
+    success: true,
+    description: common.description,
+    fullResultText,
+    error: null,
+    steps: common.steps,
+    toolCalls: common.toolCalls,
+    toolResults: common.toolResults,
+    usage: common.usage,
+    durationMs: common.durationMs,
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -316,6 +316,21 @@ export {
   buildChildRunExhaustedStepBudgetErrorMessage,
 } from "./child-run-final-step-support.ts";
 export {
+  buildChildRunExecutionSnapshot,
+  buildChildRunFailureResult,
+  buildChildRunFailureSnapshot,
+  buildChildRunResultCommon,
+  buildChildRunSuccessResult,
+  buildChildRunSuccessSnapshot,
+  type ChildRunExecutionResult,
+  type ChildRunExecutionSnapshot,
+  type ChildRunExecutionUsage,
+  type ChildRunResultCommon,
+  type ChildRunToolCallSnapshot,
+  type ChildRunToolResultSnapshot,
+  getChildRunSnapshotUsage,
+} from "./child-run-execution-snapshot.ts";
+export {
   type ConversationRunChunkMirror,
   type ConversationRunChunkMirrorApiOptions,
   type ConversationRunChunkMirrorOptions,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.305";
+export const VERSION = "0.1.306";


### PR DESCRIPTION
## Summary
- add shared child-run execution result/snapshot types and builders
- export the pure snapshot seam from `veryfront/agent`
- bump package version to `0.1.306`

## Verification
- `deno fmt --check src/agent/child-run-execution-snapshot.ts src/agent/child-run-execution-snapshot.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts`
- `deno test --no-check --allow-all src/agent/child-run-execution-snapshot.test.ts`
- `deno task lint`
- `deno task typecheck`
- pre-push checks: format, lint, typecheck, unit (`1458 passed / 0 failed`)
