### PR TITLE
Share child-run execution support helpers

### DIFF
--- a/src/agent/child-run-execution-support.test.ts
+++ b/src/agent/child-run-execution-support.test.ts
@@ -1,0 +1,79 @@
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  formatChildRunStreamPartError,
+  isChildRunAbortError,
+  throwIfChildRunAborted,
+  toChildRunToolInputRecord,
+} from "./child-run-execution-support.ts";
+
+describe("child-run-execution-support", () => {
+  describe("toChildRunToolInputRecord", () => {
+    it("converts plain objects to records", () => {
+      assertEquals(toChildRunToolInputRecord({ a: 1, b: "two" }), { a: 1, b: "two" });
+    });
+
+    it("returns an empty record for nullish, array, and primitive inputs", () => {
+      assertEquals(toChildRunToolInputRecord(null), {});
+      assertEquals(toChildRunToolInputRecord(undefined), {});
+      assertEquals(toChildRunToolInputRecord([1, 2, 3]), {});
+      assertEquals(toChildRunToolInputRecord("string"), {});
+      assertEquals(toChildRunToolInputRecord(42), {});
+      assertEquals(toChildRunToolInputRecord(true), {});
+    });
+  });
+
+  describe("throwIfChildRunAborted", () => {
+    it("does nothing when the signal is absent or not aborted", () => {
+      const controller = new AbortController();
+
+      assertEquals(throwIfChildRunAborted(undefined), undefined);
+      assertEquals(throwIfChildRunAborted(controller.signal), undefined);
+    });
+
+    it("throws an AbortError when the signal is aborted without a custom Error reason", () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      let thrownName = "";
+      try {
+        throwIfChildRunAborted(controller.signal);
+      } catch (error) {
+        if (error instanceof Error) {
+          thrownName = error.name;
+        }
+      }
+
+      assertEquals(thrownName, "AbortError");
+    });
+
+    it("throws the signal Error reason when present", () => {
+      const controller = new AbortController();
+      controller.abort(new Error("custom reason"));
+
+      assertThrows(() => throwIfChildRunAborted(controller.signal), Error, "custom reason");
+    });
+  });
+
+  describe("isChildRunAbortError", () => {
+    it("recognizes AbortError instances", () => {
+      assertEquals(isChildRunAbortError(new DOMException("aborted", "AbortError")), true);
+    });
+
+    it("rejects regular errors and non-error values", () => {
+      assertEquals(isChildRunAbortError(new Error("not abort")), false);
+      assertEquals(isChildRunAbortError(null), false);
+      assertEquals(isChildRunAbortError("string"), false);
+      assertEquals(isChildRunAbortError(undefined), false);
+    });
+  });
+
+  describe("formatChildRunStreamPartError", () => {
+    it("extracts Error messages and stringifies other values", () => {
+      assertEquals(formatChildRunStreamPartError(new Error("oops")), "oops");
+      assertEquals(formatChildRunStreamPartError("raw"), "raw");
+      assertEquals(formatChildRunStreamPartError(42), "42");
+      assertEquals(formatChildRunStreamPartError(null), "null");
+    });
+  });
+});

--- a/src/agent/child-run-execution-support.ts
+++ b/src/agent/child-run-execution-support.ts
@@ -1,0 +1,29 @@
+export function toChildRunToolInputRecord(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {};
+  }
+
+  return Object.fromEntries(Object.entries(value));
+}
+
+function createChildRunAbortError(abortSignal?: AbortSignal): Error {
+  if (abortSignal?.reason instanceof Error) {
+    return abortSignal.reason;
+  }
+
+  return new DOMException("The operation was aborted.", "AbortError");
+}
+
+export function throwIfChildRunAborted(abortSignal?: AbortSignal): void {
+  if (abortSignal?.aborted) {
+    throw createChildRunAbortError(abortSignal);
+  }
+}
+
+export function isChildRunAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+export function formatChildRunStreamPartError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -316,6 +316,12 @@ export {
   buildChildRunExhaustedStepBudgetErrorMessage,
 } from "./child-run-final-step-support.ts";
 export {
+  formatChildRunStreamPartError,
+  isChildRunAbortError,
+  throwIfChildRunAborted,
+  toChildRunToolInputRecord,
+} from "./child-run-execution-support.ts";
+export {
   buildChildRunExecutionSnapshot,
   buildChildRunFailureResult,
   buildChildRunFailureSnapshot,


### PR DESCRIPTION
## Summary
- add framework-owned child-run execution support helpers for abort checks, abort-error detection, stream-part error formatting, and tool-input normalization
- export the helpers from `veryfront/agent`
- cover the helper behavior with focused tests

## Verification
- `deno fmt --check src/agent/child-run-execution-support.ts src/agent/child-run-execution-support.test.ts src/agent/index.ts`
- `deno test --no-check --allow-all src/agent/child-run-execution-support.test.ts`
- `deno task lint`
- `deno task typecheck`
- pre-push full checks (`1459 passed / 0 failed`)
