### PR TITLE
Publish child-run support helpers as 0.1.307

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.306",
+  "version": "0.1.307",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.306";
+export const VERSION = "0.1.307";


### PR DESCRIPTION
## Summary
- bump framework package metadata to `0.1.307`
- keep the generated runtime version constant in sync
- enables the already-merged child-run execution support helpers to publish as an exact package version

## Verification
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `deno task typecheck`
- pre-push full checks (`1459 passed / 0 failed`)
