### PR TITLE
Share child-run execution cleanup helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.307",
+  "version": "0.1.308",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/child-run-execution-cleanup.test.ts
+++ b/src/agent/child-run-execution-cleanup.test.ts
@@ -1,0 +1,107 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  closeChildRunExecutionBuffers,
+  finalizeChildRunExecutionResources,
+} from "./child-run-execution-cleanup.ts";
+
+describe("child-run-execution-cleanup", () => {
+  it("closes reasoning before text buffers", async () => {
+    const calls: string[] = [];
+
+    await closeChildRunExecutionBuffers({
+      closeReasoningBuffer: () => {
+        calls.push("reasoning");
+        return Promise.resolve();
+      },
+      closeTextBuffer: () => {
+        calls.push("text");
+        return Promise.resolve();
+      },
+    });
+
+    assertEquals(calls, ["reasoning", "text"]);
+  });
+
+  it("appends the finish step only after durable work started", async () => {
+    const calls: string[] = [];
+
+    await finalizeChildRunExecutionResources({
+      durableStepStarted: true,
+      closeReasoningBuffer: () => {
+        calls.push("reasoning");
+        return Promise.resolve();
+      },
+      closeTextBuffer: () => {
+        calls.push("text");
+        return Promise.resolve();
+      },
+      appendFinishStepChunk: () => {
+        calls.push("finish-step");
+        return Promise.resolve();
+      },
+      flushMirror: () => {
+        calls.push("flush");
+        return Promise.resolve();
+      },
+    });
+
+    assertEquals(calls, ["reasoning", "text", "finish-step", "flush"]);
+  });
+
+  it("skips the finish step when durable work never started", async () => {
+    const calls: string[] = [];
+
+    await finalizeChildRunExecutionResources({
+      durableStepStarted: false,
+      closeReasoningBuffer: () => {
+        calls.push("reasoning");
+        return Promise.resolve();
+      },
+      closeTextBuffer: () => {
+        calls.push("text");
+        return Promise.resolve();
+      },
+      appendFinishStepChunk: () => {
+        calls.push("finish-step");
+        return Promise.resolve();
+      },
+      flushMirror: () => {
+        calls.push("flush");
+        return Promise.resolve();
+      },
+    });
+
+    assertEquals(calls, ["reasoning", "text", "flush"]);
+  });
+
+  it("settles tooling and runtime cleanup failures", async () => {
+    const calls: string[] = [];
+
+    await finalizeChildRunExecutionResources({
+      durableStepStarted: false,
+      closeReasoningBuffer: () => {
+        calls.push("reasoning");
+        return Promise.resolve();
+      },
+      closeTextBuffer: () => {
+        calls.push("text");
+        return Promise.resolve();
+      },
+      appendFinishStepChunk: () => {
+        calls.push("finish-step");
+        return Promise.resolve();
+      },
+      closeTooling: () => {
+        calls.push("tooling");
+        return Promise.reject(new Error("tooling failed"));
+      },
+      closeRuntime: () => {
+        calls.push("runtime");
+        return Promise.reject(new Error("runtime failed"));
+      },
+    });
+
+    assertEquals(calls, ["reasoning", "text", "tooling", "runtime"]);
+  });
+});

--- a/src/agent/child-run-execution-cleanup.ts
+++ b/src/agent/child-run-execution-cleanup.ts
@@ -1,0 +1,33 @@
+export interface ChildRunExecutionBufferCleanupInput {
+  closeReasoningBuffer: () => Promise<void>;
+  closeTextBuffer: () => Promise<void>;
+}
+
+export interface ChildRunExecutionResourceFinalizeInput
+  extends ChildRunExecutionBufferCleanupInput {
+  durableStepStarted: boolean;
+  appendFinishStepChunk: () => Promise<void>;
+  flushMirror?: () => Promise<void>;
+  closeTooling?: () => Promise<void>;
+  closeRuntime?: () => Promise<void>;
+}
+
+export async function closeChildRunExecutionBuffers(
+  input: ChildRunExecutionBufferCleanupInput,
+): Promise<void> {
+  await input.closeReasoningBuffer();
+  await input.closeTextBuffer();
+}
+
+export async function finalizeChildRunExecutionResources(
+  input: ChildRunExecutionResourceFinalizeInput,
+): Promise<void> {
+  await closeChildRunExecutionBuffers(input);
+
+  if (input.durableStepStarted) {
+    await input.appendFinishStepChunk();
+  }
+
+  await input.flushMirror?.();
+  await Promise.allSettled([input.closeTooling?.(), input.closeRuntime?.()]);
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -322,6 +322,12 @@ export {
   toChildRunToolInputRecord,
 } from "./child-run-execution-support.ts";
 export {
+  type ChildRunExecutionBufferCleanupInput,
+  type ChildRunExecutionResourceFinalizeInput,
+  closeChildRunExecutionBuffers,
+  finalizeChildRunExecutionResources,
+} from "./child-run-execution-cleanup.ts";
+export {
   buildChildRunExecutionSnapshot,
   buildChildRunFailureResult,
   buildChildRunFailureSnapshot,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.307";
+export const VERSION = "0.1.308";


### PR DESCRIPTION
## Summary
- add framework-owned child-run execution cleanup helpers for buffer closing and resource finalization
- export the cleanup contracts from the agent package surface
- bump the package version to 0.1.308 for publication

## Verification
- deno fmt --check src/agent/child-run-execution-cleanup.ts src/agent/child-run-execution-cleanup.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all src/agent/child-run-execution-cleanup.test.ts
- deno task lint
- deno task typecheck
- pre-push checks (format, lint, typecheck, unit tests)