### PR TITLE
Share child-run result summary helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.308",
+  "version": "0.1.309",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/child-run-result-summary.test.ts
+++ b/src/agent/child-run-result-summary.test.ts
@@ -1,0 +1,143 @@
+import { assertEquals, assertObjectMatch } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  buildChildRunResultSummary,
+  buildRootOwnedChildRunResultHint,
+  buildRootOwnedChildRunResultText,
+  summarizeChildRunResultText,
+  summarizeChildRunResultValue,
+} from "./child-run-result-summary.ts";
+
+describe("child-run-result-summary", () => {
+  describe("summarizeChildRunResultText", () => {
+    it("returns short text unchanged", () => {
+      assertEquals(summarizeChildRunResultText("hello"), "hello");
+    });
+
+    it("truncates text exceeding the default limit", () => {
+      const longText = "a".repeat(5000);
+      const result = summarizeChildRunResultText(longText);
+
+      assertEquals(result.length < longText.length, true);
+      assertEquals(result.includes("… [truncated"), true);
+    });
+
+    it("respects custom maxLength", () => {
+      assertEquals(summarizeChildRunResultText("hello world", 5), "hello… [truncated 6 chars]");
+    });
+  });
+
+  describe("buildChildRunResultSummary", () => {
+    it("wraps text in a summary object", () => {
+      assertEquals(buildChildRunResultSummary("done"), { text: "done" });
+    });
+  });
+
+  describe("buildRootOwnedChildRunResultText", () => {
+    it("removes leading process narration from delegated results", () => {
+      assertEquals(
+        buildRootOwnedChildRunResultText(
+          "Let me check that for you.\n\nHere's the fallback summary",
+        ),
+        "Here's the fallback summary",
+      );
+    });
+
+    it("preserves substantive text when there is no process preamble", () => {
+      assertEquals(
+        buildRootOwnedChildRunResultText("Final report delivered."),
+        "Final report delivered.",
+      );
+    });
+  });
+
+  describe("buildRootOwnedChildRunResultHint", () => {
+    it("returns the provided root-owned continuation instruction with cleaned delegated text", () => {
+      assertEquals(
+        buildRootOwnedChildRunResultHint({
+          text: "I'll investigate this.\n\nFinal report delivered.",
+          instruction: "Root owns final response.",
+        }),
+        {
+          instruction: "Root owns final response.",
+          suggestedText: "Final report delivered.",
+        },
+      );
+    });
+  });
+
+  describe("summarizeChildRunResultValue", () => {
+    it("truncates long strings", () => {
+      const long = "x".repeat(1000);
+      const result = summarizeChildRunResultValue(long);
+
+      assertEquals(typeof result, "string");
+      assertEquals(typeof result === "string" && result.length < long.length, true);
+      assertEquals(typeof result === "string" && result.includes("… [truncated"), true);
+    });
+
+    it("preserves scalar values", () => {
+      assertEquals(summarizeChildRunResultValue("short"), "short");
+      assertEquals(summarizeChildRunResultValue(null), null);
+      assertEquals(summarizeChildRunResultValue(undefined), undefined);
+      assertEquals(summarizeChildRunResultValue(42), 42);
+      assertEquals(summarizeChildRunResultValue(true), true);
+    });
+
+    it("recursively summarizes arrays", () => {
+      const result = summarizeChildRunResultValue(["short", "x".repeat(1000)]);
+      assertEquals(Array.isArray(result), true);
+      if (!Array.isArray(result)) {
+        throw new Error("expected array result");
+      }
+      assertEquals(result[0], "short");
+      assertEquals(typeof result[1] === "string" && result[1].includes("… [truncated"), true);
+    });
+
+    it("strips long content fields from objects", () => {
+      const result = summarizeChildRunResultValue({ name: "file.txt", content: "x".repeat(500) });
+      assertObjectMatch(result, { name: "file.txt" });
+      assertEquals(isPlainTestRecord(result) && "content" in result, false);
+    });
+
+    it("preserves short content fields", () => {
+      assertObjectMatch(summarizeChildRunResultValue({ name: "file.txt", content: "short" }), {
+        content: "short",
+      });
+    });
+
+    it("strips content from files and chunks array entries", () => {
+      const result = summarizeChildRunResultValue({
+        files: [{ path: "/a.ts", content: "x".repeat(500) }],
+        chunks: [{ id: "c1", content: "x".repeat(500) }],
+      });
+
+      assertObjectMatch(result, {
+        files: [{ path: "/a.ts" }],
+        chunks: [{ id: "c1" }],
+      });
+    });
+
+    it("truncates at max depth", () => {
+      let nested: unknown = "leaf";
+      for (let i = 0; i < 10; i++) {
+        nested = { child: nested };
+      }
+
+      const result = summarizeChildRunResultValue(nested);
+      let current: unknown = result;
+      let depth = 0;
+      while (isPlainTestRecord(current) && "child" in current) {
+        current = current.child;
+        depth++;
+      }
+
+      assertEquals(current, "[truncated nested data]");
+      assertEquals(depth, 5);
+    });
+  });
+});
+
+function isPlainTestRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/agent/child-run-result-summary.ts
+++ b/src/agent/child-run-result-summary.ts
@@ -1,0 +1,135 @@
+const CHILD_RUN_RESULT_TEXT_LIMIT = 4_000;
+const CHILD_RUN_VALUE_STRING_LIMIT = 500;
+const CHILD_RUN_VALUE_SUMMARY_MAX_DEPTH = 5;
+const ROOT_RESPONSE_PROCESS_PREFIX_PATTERNS = [
+  /^let me [^.?!]+[.?!]\s*/i,
+  /^i(?:'|’)ll [^.?!]+[.?!]\s*/i,
+  /^i will [^.?!]+[.?!]\s*/i,
+  /^now i have [^.?!]+[.?!]\s*/i,
+  /^first,? [^.?!]+[.?!]\s*/i,
+];
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function summarizeChildRunResultText(
+  text: string,
+  maxLength = CHILD_RUN_RESULT_TEXT_LIMIT,
+): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  return `${text.slice(0, maxLength)}… [truncated ${text.length - maxLength} chars]`;
+}
+
+export function buildChildRunResultSummary(text: string): { text: string } {
+  return { text: summarizeChildRunResultText(text) };
+}
+
+export function buildRootOwnedChildRunResultText(text: string): string {
+  let normalized = text.trim();
+
+  for (const pattern of ROOT_RESPONSE_PROCESS_PREFIX_PATTERNS) {
+    normalized = normalized.replace(pattern, "").trimStart();
+  }
+
+  if (normalized.length === 0) {
+    return text.trim();
+  }
+
+  return normalized;
+}
+
+export function buildRootOwnedChildRunResultHint(
+  input: { text: string; instruction: string },
+): { instruction: string; suggestedText: string } {
+  return {
+    instruction: input.instruction,
+    suggestedText: summarizeChildRunResultText(buildRootOwnedChildRunResultText(input.text)),
+  };
+}
+
+export function summarizeChildRunResultValue(output: unknown, depth = 0): unknown {
+  if (typeof output === "string") {
+    return summarizeChildRunResultText(output, CHILD_RUN_VALUE_STRING_LIMIT);
+  }
+
+  if (output == null || typeof output !== "object") {
+    return output;
+  }
+
+  if (depth >= CHILD_RUN_VALUE_SUMMARY_MAX_DEPTH) {
+    return "[truncated nested data]";
+  }
+
+  if (Array.isArray(output)) {
+    return output.map((item) => summarizeChildRunResultValue(item, depth + 1));
+  }
+
+  if (!isPlainRecord(output)) {
+    return output;
+  }
+
+  if ("content" in output && typeof output.content === "string" && output.content.length > 200) {
+    const { content: _content, ...rest } = output;
+    return Object.fromEntries(
+      Object.entries(rest).map((
+        [key, value],
+      ) => [key, summarizeChildRunResultValue(value, depth + 1)]),
+    );
+  }
+
+  if ("files" in output && Array.isArray(output.files)) {
+    const files = output.files.map((file) => {
+      if (!isPlainRecord(file)) {
+        return summarizeChildRunResultValue(file, depth + 1);
+      }
+
+      return Object.fromEntries(
+        Object.entries(file)
+          .filter(([key]) => key !== "content")
+          .map(([key, value]) => [key, summarizeChildRunResultValue(value, depth + 1)]),
+      );
+    });
+
+    return {
+      ...Object.fromEntries(
+        Object.entries(output)
+          .filter(([key]) => key !== "files")
+          .map(([key, value]) => [key, summarizeChildRunResultValue(value, depth + 1)]),
+      ),
+      files,
+    };
+  }
+
+  if ("chunks" in output && Array.isArray(output.chunks)) {
+    const chunks = output.chunks.map((chunk) => {
+      if (!isPlainRecord(chunk)) {
+        return summarizeChildRunResultValue(chunk, depth + 1);
+      }
+
+      return Object.fromEntries(
+        Object.entries(chunk)
+          .filter(([key]) => key !== "content")
+          .map(([key, value]) => [key, summarizeChildRunResultValue(value, depth + 1)]),
+      );
+    });
+
+    return {
+      ...Object.fromEntries(
+        Object.entries(output)
+          .filter(([key]) => key !== "chunks")
+          .map(([key, value]) => [key, summarizeChildRunResultValue(value, depth + 1)]),
+      ),
+      chunks,
+    };
+  }
+
+  return Object.fromEntries(
+    Object.entries(output).map((
+      [key, value],
+    ) => [key, summarizeChildRunResultValue(value, depth + 1)]),
+  );
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -328,6 +328,13 @@ export {
   finalizeChildRunExecutionResources,
 } from "./child-run-execution-cleanup.ts";
 export {
+  buildChildRunResultSummary,
+  buildRootOwnedChildRunResultHint,
+  buildRootOwnedChildRunResultText,
+  summarizeChildRunResultText,
+  summarizeChildRunResultValue,
+} from "./child-run-result-summary.ts";
+export {
   buildChildRunExecutionSnapshot,
   buildChildRunFailureResult,
   buildChildRunFailureSnapshot,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.308";
+export const VERSION = "0.1.309";


### PR DESCRIPTION
## Summary
- add framework-owned child-run result text/value summary helpers
- expose a root-owned result hint helper that accepts the caller-provided instruction
- bump package version to 0.1.309 for publication

## Verification
- deno fmt --check src/agent/child-run-result-summary.ts src/agent/child-run-result-summary.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all src/agent/child-run-result-summary.test.ts
- deno task lint
- deno task typecheck
- pre-push checks (format, lint, typecheck, unit tests)