### PR TITLE
Share hosted child pending tool lifecycle recovery

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.309",
+  "version": "0.1.310",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-pending-tool-lifecycle.test.ts
+++ b/src/agent/hosted-child-pending-tool-lifecycle.test.ts
@@ -1,0 +1,118 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import type { ChatMessageMetadata, ChatUiMessageChunk } from "../chat/protocol.ts";
+import { createHostedChildPendingToolLifecycle } from "./hosted-child-pending-tool-lifecycle.ts";
+
+Deno.test("createHostedChildPendingToolLifecycle closes incomplete streaming input", async () => {
+  const chunks: ChatUiMessageChunk<ChatMessageMetadata>[] = [];
+  const logs: unknown[] = [];
+  const lifecycle = createHostedChildPendingToolLifecycle({
+    appendMirrorChunk: (chunk) => {
+      chunks.push(chunk);
+    },
+    logger: {
+      warnIncompleteToolLifecycles: (input) => logs.push(input),
+    },
+  });
+
+  lifecycle.upsertPendingToolCall("tool-1", {
+    phase: "input_streaming",
+    toolName: "lookup",
+    input: { query: "docs" },
+  });
+
+  await lifecycle.closePendingToolCalls({ kind: "ended" });
+
+  assertEquals(chunks, [
+    { type: "tool-input-start", toolCallId: "tool-1", toolName: "lookup" },
+    {
+      type: "tool-input-error",
+      toolCallId: "tool-1",
+      toolName: "lookup",
+      input: { query: "docs" },
+      errorText: "Child fork stream ended before tool input completed",
+    },
+  ]);
+  assertEquals(logs, [{ reason: "ended", toolCallIds: ["tool-1"], errorMessage: null }]);
+});
+
+Deno.test("createHostedChildPendingToolLifecycle closes awaiting result with output error", async () => {
+  const chunks: ChatUiMessageChunk<ChatMessageMetadata>[] = [];
+  const lifecycle = createHostedChildPendingToolLifecycle({
+    appendMirrorChunk: (chunk) => {
+      chunks.push(chunk);
+    },
+  });
+
+  await lifecycle.emitToolInputStartIfNeeded("tool-1", "lookup");
+  lifecycle.upsertPendingToolCall("tool-1", {
+    phase: "awaiting_result",
+    toolName: "lookup",
+    input: { query: "docs" },
+  });
+
+  await lifecycle.closePendingToolCalls({ kind: "aborted" });
+
+  assertEquals(chunks, [
+    { type: "tool-input-start", toolCallId: "tool-1", toolName: "lookup" },
+    {
+      type: "tool-output-error",
+      toolCallId: "tool-1",
+      errorText: "Child fork stream aborted before tool result completed",
+    },
+  ]);
+});
+
+Deno.test("createHostedChildPendingToolLifecycle logs unknown tool identity and recovers input", async () => {
+  const chunks: ChatUiMessageChunk<ChatMessageMetadata>[] = [];
+  const unknownLogs: unknown[] = [];
+  const lifecycle = createHostedChildPendingToolLifecycle({
+    appendMirrorChunk: (chunk) => {
+      chunks.push(chunk);
+    },
+    logger: {
+      warnUnknownToolIdentity: (input) => unknownLogs.push(input),
+    },
+  });
+
+  lifecycle.upsertPendingToolCall("tool-1", {
+    phase: "input_streaming",
+    input: "not-an-object",
+  });
+
+  await lifecycle.closePendingToolCalls({ kind: "error", error: new Error("stream failed") });
+
+  assertEquals(chunks, [
+    { type: "tool-input-start", toolCallId: "tool-1", toolName: "unknown" },
+    {
+      type: "tool-input-error",
+      toolCallId: "tool-1",
+      toolName: "unknown",
+      input: {},
+      errorText: "Child fork stream errored before tool input completed: stream failed",
+    },
+  ]);
+  assertEquals(unknownLogs, [
+    {
+      toolCallId: "tool-1",
+      phase: "input_streaming",
+      reason: "error",
+      hasInputSnapshot: true,
+    },
+  ]);
+});
+
+Deno.test("createHostedChildPendingToolLifecycle deletes settled pending tool calls", async () => {
+  const chunks: ChatUiMessageChunk<ChatMessageMetadata>[] = [];
+  const lifecycle = createHostedChildPendingToolLifecycle({
+    appendMirrorChunk: (chunk) => {
+      chunks.push(chunk);
+    },
+  });
+
+  lifecycle.upsertPendingToolCall("tool-1", { phase: "awaiting_result", toolName: "lookup" });
+  lifecycle.deletePendingToolCall("tool-1");
+
+  await lifecycle.closePendingToolCalls({ kind: "ended" });
+
+  assertEquals(chunks, []);
+});

--- a/src/agent/hosted-child-pending-tool-lifecycle.ts
+++ b/src/agent/hosted-child-pending-tool-lifecycle.ts
@@ -1,0 +1,152 @@
+import type { ChatMessageMetadata, ChatUiMessageChunk } from "../chat/protocol.ts";
+import { toChildRunToolInputRecord } from "./child-run-execution-support.ts";
+
+export type HostedChildPendingToolCallPhase = "input_streaming" | "awaiting_result";
+
+export interface HostedChildPendingToolCallState {
+  phase: HostedChildPendingToolCallPhase;
+  toolName?: string;
+  input?: unknown;
+}
+
+export type HostedChildPendingToolLifecycleCloseReason =
+  | { kind: "ended" }
+  | { kind: "aborted" }
+  | { kind: "error"; error: unknown };
+
+export interface HostedChildPendingToolLifecycleCloseLog {
+  reason: HostedChildPendingToolLifecycleCloseReason["kind"];
+  toolCallIds: string[];
+  errorMessage: string | null;
+}
+
+export interface HostedChildPendingToolLifecycleUnknownToolLog {
+  toolCallId: string;
+  phase: HostedChildPendingToolCallPhase;
+  reason: HostedChildPendingToolLifecycleCloseReason["kind"];
+  hasInputSnapshot: boolean;
+}
+
+export interface HostedChildPendingToolLifecycleLogger {
+  warnIncompleteToolLifecycles?: (input: HostedChildPendingToolLifecycleCloseLog) => void;
+  warnUnknownToolIdentity?: (input: HostedChildPendingToolLifecycleUnknownToolLog) => void;
+}
+
+export interface HostedChildPendingToolLifecycleInput {
+  appendMirrorChunk: (chunk: ChatUiMessageChunk<ChatMessageMetadata>) => Promise<void> | void;
+  logger?: HostedChildPendingToolLifecycleLogger;
+}
+
+export function createHostedChildPendingToolLifecycle(input: HostedChildPendingToolLifecycleInput) {
+  const startedToolCallIds = new Set<string>();
+  const pendingToolCalls = new Map<string, HostedChildPendingToolCallState>();
+
+  const emitToolInputStartIfNeeded = async (toolCallId: string, toolName: string) => {
+    if (startedToolCallIds.has(toolCallId)) {
+      return;
+    }
+
+    startedToolCallIds.add(toolCallId);
+    await input.appendMirrorChunk({
+      type: "tool-input-start",
+      toolCallId,
+      toolName,
+    });
+  };
+
+  const upsertPendingToolCall = (toolCallId: string, state: HostedChildPendingToolCallState) => {
+    const existing = pendingToolCalls.get(toolCallId);
+    pendingToolCalls.set(toolCallId, {
+      phase: state.phase,
+      toolName: state.toolName ?? existing?.toolName,
+      input: state.input ?? existing?.input,
+    });
+  };
+
+  const closePendingToolCalls = async (reason: HostedChildPendingToolLifecycleCloseReason) => {
+    if (pendingToolCalls.size === 0) {
+      return;
+    }
+
+    const errorMessage = reason.kind === "error"
+      ? (reason.error instanceof Error ? reason.error.message : String(reason.error))
+      : null;
+    const toolCallIds = [...pendingToolCalls.keys()];
+
+    input.logger?.warnIncompleteToolLifecycles?.({
+      reason: reason.kind,
+      toolCallIds,
+      errorMessage,
+    });
+
+    for (const [toolCallId, state] of pendingToolCalls) {
+      const toolName = state.toolName ?? "unknown";
+      if (toolName === "unknown") {
+        input.logger?.warnUnknownToolIdentity?.({
+          toolCallId,
+          phase: state.phase,
+          reason: reason.kind,
+          hasInputSnapshot: typeof state.input !== "undefined",
+        });
+      }
+
+      await emitToolInputStartIfNeeded(toolCallId, toolName);
+
+      if (state.phase === "awaiting_result") {
+        await input.appendMirrorChunk({
+          type: "tool-output-error",
+          toolCallId,
+          errorText: buildPendingToolOutputErrorText(reason, errorMessage),
+        });
+        continue;
+      }
+
+      await input.appendMirrorChunk({
+        type: "tool-input-error",
+        toolCallId,
+        toolName,
+        input: toChildRunToolInputRecord(state.input),
+        errorText: buildPendingToolInputErrorText(reason, errorMessage),
+      });
+    }
+
+    pendingToolCalls.clear();
+  };
+
+  return {
+    upsertPendingToolCall,
+    emitToolInputStartIfNeeded,
+    deletePendingToolCall: (toolCallId: string) => {
+      pendingToolCalls.delete(toolCallId);
+    },
+    closePendingToolCalls,
+  };
+}
+
+function buildPendingToolInputErrorText(
+  reason: HostedChildPendingToolLifecycleCloseReason,
+  errorMessage: string | null,
+): string {
+  switch (reason.kind) {
+    case "error":
+      return `Child fork stream errored before tool input completed: ${errorMessage}`;
+    case "aborted":
+      return "Child fork stream aborted before tool input completed";
+    case "ended":
+      return "Child fork stream ended before tool input completed";
+  }
+}
+
+function buildPendingToolOutputErrorText(
+  reason: HostedChildPendingToolLifecycleCloseReason,
+  errorMessage: string | null,
+): string {
+  switch (reason.kind) {
+    case "error":
+      return `Child fork stream errored before tool result completed: ${errorMessage}`;
+    case "aborted":
+      return "Child fork stream aborted before tool result completed";
+    case "ended":
+      return "Child fork stream ended before tool result completed";
+  }
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -328,6 +328,16 @@ export {
   finalizeChildRunExecutionResources,
 } from "./child-run-execution-cleanup.ts";
 export {
+  createHostedChildPendingToolLifecycle,
+  type HostedChildPendingToolCallPhase,
+  type HostedChildPendingToolCallState,
+  type HostedChildPendingToolLifecycleCloseLog,
+  type HostedChildPendingToolLifecycleCloseReason,
+  type HostedChildPendingToolLifecycleInput,
+  type HostedChildPendingToolLifecycleLogger,
+  type HostedChildPendingToolLifecycleUnknownToolLog,
+} from "./hosted-child-pending-tool-lifecycle.ts";
+export {
   buildChildRunResultSummary,
   buildRootOwnedChildRunResultHint,
   buildRootOwnedChildRunResultText,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.309";
+export const VERSION = "0.1.310";


### PR DESCRIPTION
## Summary
- add a framework helper for closing incomplete hosted child tool lifecycles
- emit protocol-level tool input/output error chunks for ended, aborted, and errored streams
- keep logging caller-injected so runtime observability policy remains outside the shared helper

## Verification
- deno fmt --check src/agent/hosted-child-pending-tool-lifecycle.ts src/agent/hosted-child-pending-tool-lifecycle.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all src/agent/hosted-child-pending-tool-lifecycle.test.ts
- deno task lint
- deno task typecheck
- pre-push checks