### PR TITLE
Share hosted child stream watchdog timing helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.310",
+  "version": "0.1.311",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-stream-watchdog.test.ts
+++ b/src/agent/hosted-child-stream-watchdog.test.ts
@@ -1,0 +1,161 @@
+import { assert, assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import {
+  composeAbortSignals,
+  HOSTED_CHILD_STREAM_TIMEOUT_TOKEN,
+  HostedChildStreamIdleTimeoutError,
+  resolveHostedChildPromiseWithTimeout,
+  resolveHostedChildStreamWatchdogState,
+  withHostedChildStreamIdleTimeout,
+} from "./hosted-child-stream-watchdog.ts";
+
+const BASE_INPUT = {
+  activeToolCallId: null,
+  completedToolResults: 0,
+  idleTimeoutMs: 45_000,
+  activeToolTimeoutMs: 300_000,
+  postToolIdleTimeoutMs: 120_000,
+};
+
+Deno.test("resolveHostedChildStreamWatchdogState returns tool_running when a tool is active", () => {
+  const state = resolveHostedChildStreamWatchdogState({
+    ...BASE_INPUT,
+    activeToolCallId: "tc-1",
+  });
+  assertEquals(state, { phase: "tool_running", timeoutMs: 300_000 });
+});
+
+Deno.test("resolveHostedChildStreamWatchdogState returns post_tool_idle when tools completed", () => {
+  const state = resolveHostedChildStreamWatchdogState({
+    ...BASE_INPUT,
+    completedToolResults: 3,
+  });
+  assertEquals(state, { phase: "post_tool_idle", timeoutMs: 120_000 });
+});
+
+Deno.test("resolveHostedChildStreamWatchdogState returns generic_idle when no tools are running", () => {
+  const state = resolveHostedChildStreamWatchdogState(BASE_INPUT);
+  assertEquals(state, { phase: "generic_idle", timeoutMs: 45_000 });
+});
+
+Deno.test("HostedChildStreamIdleTimeoutError carries timeout state", () => {
+  const error = new HostedChildStreamIdleTimeoutError({
+    phase: "generic_idle",
+    timeoutMs: 45_000,
+  });
+  assertEquals(error.name, "HostedChildStreamIdleTimeoutError");
+  assert(error.message.includes("45s"));
+  assertEquals(error.phase, "generic_idle");
+  assertEquals(error.timeoutMs, 45_000);
+});
+
+Deno.test("composeAbortSignals returns undefined without active signals", () => {
+  assertEquals(composeAbortSignals([]), undefined);
+  assertEquals(composeAbortSignals([undefined, undefined]), undefined);
+});
+
+Deno.test("composeAbortSignals returns the single active signal", () => {
+  const controller = new AbortController();
+  assertEquals(composeAbortSignals([controller.signal]), controller.signal);
+  assertEquals(composeAbortSignals([undefined, controller.signal, undefined]), controller.signal);
+});
+
+Deno.test("composeAbortSignals composes multiple signals", () => {
+  const c1 = new AbortController();
+  const c2 = new AbortController();
+  const composed = composeAbortSignals([c1.signal, c2.signal]);
+  assert(composed);
+  assertEquals(composed.aborted, false);
+  c1.abort();
+  assertEquals(composed.aborted, true);
+});
+
+Deno.test("resolveHostedChildPromiseWithTimeout resolves before timeout", async () => {
+  const result = await resolveHostedChildPromiseWithTimeout(Promise.resolve("done"), 5_000);
+  assertEquals(result, "done");
+});
+
+Deno.test("resolveHostedChildPromiseWithTimeout resolves timeout token when promise stalls", async () => {
+  const neverResolve = new Promise<string>(() => {});
+  const result = await resolveHostedChildPromiseWithTimeout(neverResolve, 10);
+  assertEquals(result, HOSTED_CHILD_STREAM_TIMEOUT_TOKEN);
+});
+
+Deno.test("withHostedChildStreamIdleTimeout yields all values from a fast stream", async () => {
+  async function* fastStream() {
+    yield 1;
+    yield 2;
+    yield 3;
+  }
+
+  const values: number[] = [];
+  for await (
+    const value of withHostedChildStreamIdleTimeout({
+      stream: fastStream(),
+      getWatchdogState: () => ({
+        phase: "generic_idle",
+        timeoutMs: 5_000,
+      }),
+    })
+  ) {
+    values.push(value);
+  }
+
+  assertEquals(values, [1, 2, 3]);
+});
+
+Deno.test("withHostedChildStreamIdleTimeout throws when stream stalls", async () => {
+  async function* stallingStream() {
+    yield 1;
+    await new Promise(() => {});
+  }
+
+  const values: number[] = [];
+  await assertRejects(
+    async () => {
+      for await (
+        const value of withHostedChildStreamIdleTimeout({
+          stream: stallingStream(),
+          getWatchdogState: () => ({
+            phase: "generic_idle",
+            timeoutMs: 10,
+          }),
+        })
+      ) {
+        values.push(value);
+      }
+    },
+    HostedChildStreamIdleTimeoutError,
+  );
+
+  assertEquals(values, [1]);
+});
+
+Deno.test("withHostedChildStreamIdleTimeout continues when timeout callback asks to retry", async () => {
+  async function* stallingThenResumingStream() {
+    yield 1;
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    yield 2;
+  }
+
+  const values: number[] = [];
+  let idleTimeoutCalls = 0;
+
+  for await (
+    const value of withHostedChildStreamIdleTimeout({
+      stream: stallingThenResumingStream(),
+      getWatchdogState: () => ({
+        phase: "post_tool_idle",
+        timeoutMs: 5,
+      }),
+      onIdleTimeout: () => {
+        idleTimeoutCalls += 1;
+        return idleTimeoutCalls <= 3 ? "continue" : undefined;
+      },
+    })
+  ) {
+    values.push(value);
+  }
+
+  assertEquals(values, [1, 2]);
+  assert(idleTimeoutCalls >= 1);
+});

--- a/src/agent/hosted-child-stream-watchdog.ts
+++ b/src/agent/hosted-child-stream-watchdog.ts
@@ -1,0 +1,142 @@
+import { throwIfChildRunAborted } from "./child-run-execution-support.ts";
+
+export type HostedChildStreamWatchdogPhase = "tool_running" | "post_tool_idle" | "generic_idle";
+
+export interface HostedChildStreamWatchdogState {
+  phase: HostedChildStreamWatchdogPhase;
+  timeoutMs: number;
+}
+
+export class HostedChildStreamIdleTimeoutError extends Error {
+  readonly timeoutMs: number;
+  readonly phase: HostedChildStreamWatchdogPhase;
+
+  constructor(input: HostedChildStreamWatchdogState) {
+    super(
+      `Child fork stream stalled after ${
+        Math.round(input.timeoutMs / 1000)
+      }s without yielding a new event.`,
+    );
+    this.name = "HostedChildStreamIdleTimeoutError";
+    this.timeoutMs = input.timeoutMs;
+    this.phase = input.phase;
+  }
+}
+
+export const HOSTED_CHILD_STREAM_TIMEOUT_TOKEN = Symbol("hosted-child-stream-timeout");
+
+export function resolveHostedChildStreamWatchdogState(input: {
+  activeToolCallId: string | null;
+  completedToolResults: number;
+  idleTimeoutMs: number;
+  activeToolTimeoutMs: number;
+  postToolIdleTimeoutMs: number;
+}): HostedChildStreamWatchdogState {
+  if (input.activeToolCallId) {
+    return {
+      phase: "tool_running",
+      timeoutMs: input.activeToolTimeoutMs,
+    };
+  }
+
+  if (input.completedToolResults > 0) {
+    return {
+      phase: "post_tool_idle",
+      timeoutMs: input.postToolIdleTimeoutMs,
+    };
+  }
+
+  return {
+    phase: "generic_idle",
+    timeoutMs: input.idleTimeoutMs,
+  };
+}
+
+export function composeAbortSignals(
+  signals: Array<AbortSignal | undefined>,
+): AbortSignal | undefined {
+  const activeSignals = signals.filter((signal): signal is AbortSignal => signal != null);
+  if (activeSignals.length === 0) {
+    return undefined;
+  }
+  if (activeSignals.length === 1) {
+    return activeSignals[0];
+  }
+  return AbortSignal.any(activeSignals);
+}
+
+export async function* withHostedChildStreamIdleTimeout<T>(input: {
+  stream: AsyncIterable<T>;
+  getWatchdogState: () => HostedChildStreamWatchdogState;
+  abortSignal?: AbortSignal;
+  onIdleTimeout?: (
+    state: HostedChildStreamWatchdogState,
+  ) => undefined | "continue" | Promise<undefined | "continue">;
+}): AsyncGenerator<T, void, void> {
+  const iterator = input.stream[Symbol.asyncIterator]();
+  let pendingNext: Promise<IteratorResult<T>> | null = null;
+
+  while (true) {
+    throwIfChildRunAborted(input.abortSignal);
+
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const watchdogState = input.getWatchdogState();
+    if (!pendingNext) {
+      pendingNext = iterator.next();
+    }
+
+    try {
+      const result = await Promise.race<
+        IteratorResult<T> | typeof HOSTED_CHILD_STREAM_TIMEOUT_TOKEN
+      >([
+        pendingNext,
+        new Promise<typeof HOSTED_CHILD_STREAM_TIMEOUT_TOKEN>((resolve) => {
+          timeoutId = setTimeout(() => {
+            resolve(HOSTED_CHILD_STREAM_TIMEOUT_TOKEN);
+          }, watchdogState.timeoutMs);
+        }),
+      ]);
+
+      if (result === HOSTED_CHILD_STREAM_TIMEOUT_TOKEN) {
+        const action = await input.onIdleTimeout?.(watchdogState);
+        if (action === "continue") {
+          continue;
+        }
+
+        throw new HostedChildStreamIdleTimeoutError(watchdogState);
+      }
+
+      pendingNext = null;
+
+      if (result.done) {
+        return;
+      }
+
+      yield result.value;
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
+  }
+}
+
+export async function resolveHostedChildPromiseWithTimeout<T>(
+  promise: PromiseLike<T>,
+  timeoutMs: number,
+): Promise<T | typeof HOSTED_CHILD_STREAM_TIMEOUT_TOKEN> {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  try {
+    return await Promise.race([
+      Promise.resolve(promise),
+      new Promise<typeof HOSTED_CHILD_STREAM_TIMEOUT_TOKEN>((resolve) => {
+        timeoutId = setTimeout(() => resolve(HOSTED_CHILD_STREAM_TIMEOUT_TOKEN), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -338,6 +338,16 @@ export {
   type HostedChildPendingToolLifecycleUnknownToolLog,
 } from "./hosted-child-pending-tool-lifecycle.ts";
 export {
+  composeAbortSignals,
+  HOSTED_CHILD_STREAM_TIMEOUT_TOKEN,
+  HostedChildStreamIdleTimeoutError,
+  type HostedChildStreamWatchdogPhase,
+  type HostedChildStreamWatchdogState,
+  resolveHostedChildPromiseWithTimeout,
+  resolveHostedChildStreamWatchdogState,
+  withHostedChildStreamIdleTimeout,
+} from "./hosted-child-stream-watchdog.ts";
+export {
   buildChildRunResultSummary,
   buildRootOwnedChildRunResultHint,
   buildRootOwnedChildRunResultText,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.310";
+export const VERSION = "0.1.311";


### PR DESCRIPTION
## Summary
- add shared hosted child stream watchdog timeout helpers
- expose abort signal composition and promise timeout token from veryfront/agent
- keep runtime logging and timeout handling policy with callers

## Verification
- deno fmt --check targeted files
- deno test --no-check --allow-all src/agent/hosted-child-stream-watchdog.test.ts
- deno task lint
- deno task typecheck
- pre-push full checks