### PR TITLE
Preserve host timer control for hosted child stream watchdogs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.311",
+  "version": "0.1.312",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-stream-watchdog.ts
+++ b/src/agent/hosted-child-stream-watchdog.ts
@@ -79,7 +79,7 @@ export async function* withHostedChildStreamIdleTimeout<T>(input: {
   while (true) {
     throwIfChildRunAborted(input.abortSignal);
 
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
     const watchdogState = input.getWatchdogState();
     if (!pendingNext) {
       pendingNext = iterator.next();
@@ -91,7 +91,7 @@ export async function* withHostedChildStreamIdleTimeout<T>(input: {
       >([
         pendingNext,
         new Promise<typeof HOSTED_CHILD_STREAM_TIMEOUT_TOKEN>((resolve) => {
-          timeoutId = setTimeout(() => {
+          timeoutId = globalThis.setTimeout(() => {
             resolve(HOSTED_CHILD_STREAM_TIMEOUT_TOKEN);
           }, watchdogState.timeoutMs);
         }),
@@ -115,7 +115,7 @@ export async function* withHostedChildStreamIdleTimeout<T>(input: {
       yield result.value;
     } finally {
       if (timeoutId) {
-        clearTimeout(timeoutId);
+        globalThis.clearTimeout(timeoutId);
       }
     }
   }
@@ -125,18 +125,21 @@ export async function resolveHostedChildPromiseWithTimeout<T>(
   promise: PromiseLike<T>,
   timeoutMs: number,
 ): Promise<T | typeof HOSTED_CHILD_STREAM_TIMEOUT_TOKEN> {
-  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
 
   try {
     return await Promise.race([
       Promise.resolve(promise),
       new Promise<typeof HOSTED_CHILD_STREAM_TIMEOUT_TOKEN>((resolve) => {
-        timeoutId = setTimeout(() => resolve(HOSTED_CHILD_STREAM_TIMEOUT_TOKEN), timeoutMs);
+        timeoutId = globalThis.setTimeout(
+          () => resolve(HOSTED_CHILD_STREAM_TIMEOUT_TOKEN),
+          timeoutMs,
+        );
       }),
     ]);
   } finally {
     if (timeoutId) {
-      clearTimeout(timeoutId);
+      globalThis.clearTimeout(timeoutId);
     }
   }
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.311";
+export const VERSION = "0.1.312";


### PR DESCRIPTION
## Summary
- use globalThis timers inside hosted child stream watchdog helpers
- preserve Node/Vitest fake-timer control for npm consumers
- bump framework package to 0.1.312

## Verification
- deno fmt --check targeted files
- deno test --no-check --allow-all src/agent/hosted-child-stream-watchdog.test.ts
- deno task lint
- deno task typecheck
- pre-push full checks