### PR TITLE
Keep release checks portable and leak-free

### DIFF
--- a/.github/actions/setup-deno/action.yml
+++ b/.github/actions/setup-deno/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Pre-warm the esm.sh cache for tests
     required: false
     default: "false"
+  warm-redis-cache:
+    description: Pre-warm the deno.land Redis cache for unit and integration tests
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -18,10 +22,15 @@ runs:
         version="2.7.7"
         os="$(uname -s)"
         arch="$(uname -m)"
+        deno_exe="deno"
 
         case "${os}" in
           Linux) os_target="unknown-linux-gnu" ;;
           Darwin) os_target="apple-darwin" ;;
+          MINGW*|MSYS*|CYGWIN*)
+            os_target="pc-windows-msvc"
+            deno_exe="deno.exe"
+            ;;
           *) echo "Unsupported Deno install OS: ${os}" >&2; exit 1 ;;
         esac
 
@@ -32,7 +41,7 @@ runs:
         esac
 
         deno_dir="${RUNNER_TEMP}/deno-${version}-${arch_target}-${os_target}"
-        deno_bin="${deno_dir}/deno"
+        deno_bin="${deno_dir}/${deno_exe}"
         if [ ! -x "${deno_bin}" ]; then
           mkdir -p "${deno_dir}"
           zip_path="${deno_dir}/deno.zip"
@@ -50,10 +59,11 @@ runs:
       shell: bash
       run: deno run -A scripts/build/generate-templates-manifest.ts && deno fmt cli/templates/manifest.json
 
-    - name: Warm Deno module cache
+    - name: Warm Redis module cache
+      if: inputs.warm-redis-cache == 'true'
       shell: bash
       run: |
-        deno cache --reload=https://deno.land/x/redis https://deno.land/x/redis@v0.32.1/mod.ts
+        deno cache --reload=https://deno.land/x/redis https://deno.land/x/redis@v0.32.1/mod.ts || true
 
     - name: Warm esm.sh cache
       if: inputs.warm-cache == 'true'

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -48,6 +48,7 @@ jobs:
       - uses: ./.github/actions/setup-deno
         with:
           warm-cache: "true"
+          warm-redis-cache: "true"
       - uses: nick-fields/retry@v4.0.0
         with:
           timeout_minutes: ${{ matrix.suite == 'integration' && 10 || 5 }}

--- a/cli/mcp/tools/run-lint-tool.ts
+++ b/cli/mcp/tools/run-lint-tool.ts
@@ -17,6 +17,25 @@ const runLintInput = z.object({
 
 type RunLintInput = z.infer<typeof runLintInput>;
 
+const PROCESS_CLEANUP_TIMEOUT_MS = 1000;
+
+async function waitForProcessCleanup(outputSettled: Promise<void>): Promise<void> {
+  let cleanupTimeout: number | undefined;
+  try {
+    await Promise.race([
+      outputSettled,
+      new Promise<void>((resolve) => {
+        cleanupTimeout = setTimeout(resolve, PROCESS_CLEANUP_TIMEOUT_MS);
+        Deno.unrefTimer(cleanupTimeout);
+      }),
+    ]);
+  } finally {
+    if (cleanupTimeout !== undefined) {
+      clearTimeout(cleanupTimeout);
+    }
+  }
+}
+
 /** Spawn deno lint and return structured results. Exported for standalone reuse. */
 export async function executeLint(
   input: { timeout?: number } = {},
@@ -29,24 +48,41 @@ export async function executeLint(
 
   const child = cmd.spawn();
   const timeoutMs = input.timeout ?? 120000;
+  const outputPromise = child.output();
+  const outputSettled = outputPromise.then(
+    () => undefined,
+    () => undefined,
+  );
+  let timeout: number | undefined;
 
-  const result = await Promise.race([
-    child.output(),
-    new Promise<never>((_, reject) => {
-      const timer = setTimeout(() => {
-        try {
-          child.kill();
-        } catch {
-          // Process may have already exited
-        }
-        reject(new Error(`Lint execution timed out after ${timeoutMs}ms`));
-      }, timeoutMs);
-      Deno.unrefTimer(timer);
-    }),
-  ]);
+  try {
+    const result = await Promise.race([
+      outputPromise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          try {
+            child.kill();
+          } catch {
+            // Process may have already exited
+          }
+          reject(new Error(`Lint execution timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+        Deno.unrefTimer(timeout);
+      }),
+    ]);
 
-  const stdout = new TextDecoder().decode(result.stdout);
-  return parseLintJsonOutput(stdout, result.code);
+    const stdout = new TextDecoder().decode(result.stdout);
+    return parseLintJsonOutput(stdout, result.code);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("timed out")) {
+      await waitForProcessCleanup(outputSettled);
+    }
+    throw error;
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
 }
 
 export const vfRunLint: MCPTool<RunLintInput, LintResult> = {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.313",
+  "version": "0.1.314",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.313";
+export const VERSION = "0.1.314";


### PR DESCRIPTION
## Summary
- install the pinned Deno binary directly on Windows runners as well as Linux/macOS
- wait for killed lint subprocesses after timeout so Deno leak detection can close resources
- bump framework package metadata to 0.1.314 for the next release

## Verification
- deno fmt --check .github/actions/setup-deno/action.yml cli/mcp/tools/run-lint-tool.ts deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all cli/mcp/tools/run-lint-tool.test.ts src/routing/api/module-loader/loader.test.ts
- deno task lint
- deno task typecheck
- deno task build:npm and generated hosted-child-stream-watchdog uses globalThis timers
- pre-push checks: 1477 passed (17270 steps), 0 failed