### PR TITLE
Share hosted child requested-tool selection

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.314",
+  "version": "0.1.315",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-requested-tools.test.ts
+++ b/src/agent/hosted-child-requested-tools.test.ts
@@ -1,0 +1,91 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import {
+  buildHostedChildToolDescription,
+  expandHostedChildRequestedTools,
+  sanitizeHostedChildRequestedTools,
+  shouldPruneSandboxToolsFromHostedChildRequest,
+} from "./hosted-child-requested-tools.ts";
+
+const sandboxCuePattern = /\b(bash|shell|terminal|python|node|npm)\b/i;
+const textArtifactPrompt = (prompt: string) => /\b(markdown|report)\b/i.test(prompt);
+
+Deno.test("expandHostedChildRequestedTools returns undefined when tools are omitted", () => {
+  assertEquals(expandHostedChildRequestedTools({}), undefined);
+});
+
+Deno.test("expandHostedChildRequestedTools preserves empty requested tool arrays", () => {
+  assertEquals(expandHostedChildRequestedTools({ requestedTools: [] }), []);
+});
+
+Deno.test("expandHostedChildRequestedTools removes excluded tools and adds companions", () => {
+  const result = expandHostedChildRequestedTools({
+    requestedTools: ["shell", "panel", "create_file"],
+    excludedTools: new Set(["panel"]),
+    companionTools: { create_file: ["update_file"] },
+  });
+
+  assertEquals(result, ["shell", "create_file", "update_file"]);
+});
+
+Deno.test("expandHostedChildRequestedTools removes excluded companion tools", () => {
+  const result = expandHostedChildRequestedTools({
+    requestedTools: ["create_file"],
+    excludedTools: new Set(["update_file"]),
+    companionTools: { create_file: ["update_file"] },
+  });
+
+  assertEquals(result, ["create_file"]);
+});
+
+Deno.test("sanitizeHostedChildRequestedTools prunes sandbox tools for text artifact prompts without sandbox cues", () => {
+  const result = sanitizeHostedChildRequestedTools({
+    prompt: "Write a markdown report",
+    requestedTools: ["create_file", "bash", "readFile"],
+    sandboxRequiredCuePattern: sandboxCuePattern,
+    isTextArtifactPrompt: textArtifactPrompt,
+  });
+
+  assertEquals(result, ["create_file"]);
+});
+
+Deno.test("sanitizeHostedChildRequestedTools keeps sandbox tools when prompt contains sandbox cues", () => {
+  const result = sanitizeHostedChildRequestedTools({
+    prompt: "Write a markdown report using python",
+    requestedTools: ["create_file", "bash"],
+    sandboxRequiredCuePattern: sandboxCuePattern,
+    isTextArtifactPrompt: textArtifactPrompt,
+  });
+
+  assertEquals(result, ["create_file", "bash"]);
+});
+
+Deno.test("shouldPruneSandboxToolsFromHostedChildRequest is deterministic for stateful regex cues", () => {
+  const statefulSandboxCuePattern = /\bpython\b/gi;
+  const input = {
+    prompt: "Write a markdown report using python",
+    requestedTools: ["create_file", "bash"],
+    sandboxRequiredCuePattern: statefulSandboxCuePattern,
+    isTextArtifactPrompt: textArtifactPrompt,
+  };
+
+  assertEquals(shouldPruneSandboxToolsFromHostedChildRequest(input), false);
+  assertEquals(shouldPruneSandboxToolsFromHostedChildRequest(input), false);
+});
+
+Deno.test("shouldPruneSandboxToolsFromHostedChildRequest requires artifact tools", () => {
+  assertEquals(
+    shouldPruneSandboxToolsFromHostedChildRequest({
+      prompt: "Write a markdown report",
+      requestedTools: ["bash"],
+      sandboxRequiredCuePattern: sandboxCuePattern,
+      isTextArtifactPrompt: textArtifactPrompt,
+    }),
+    false,
+  );
+});
+
+Deno.test("buildHostedChildToolDescription describes child agent usage", () => {
+  const description = buildHostedChildToolDescription();
+  assertEquals(description.includes("child agent"), true);
+  assertEquals(description.includes("parallel"), true);
+});

--- a/src/agent/hosted-child-requested-tools.ts
+++ b/src/agent/hosted-child-requested-tools.ts
@@ -1,0 +1,131 @@
+export interface HostedChildRequestedToolsInput {
+  prompt: string;
+  requestedTools?: readonly string[];
+  excludedTools?: ReadonlySet<string>;
+  companionTools?: Readonly<Record<string, readonly string[]>>;
+  sandboxToolNames?: readonly string[];
+  artifactToolNames?: readonly string[];
+  sandboxRequiredCuePattern?: RegExp;
+  isTextArtifactPrompt?: (prompt: string) => boolean;
+}
+
+const DEFAULT_SANDBOX_TOOL_NAMES = ["bash", "readFile", "writeFile"];
+const DEFAULT_ARTIFACT_TOOL_NAMES = ["create_file", "update_file"];
+
+export function sanitizeHostedChildRequestedTools(
+  input: HostedChildRequestedToolsInput,
+): string[] | undefined {
+  const expandedTools = expandHostedChildRequestedTools({
+    requestedTools: input.requestedTools,
+    excludedTools: input.excludedTools,
+    companionTools: input.companionTools,
+  });
+  if (!expandedTools) {
+    return expandedTools;
+  }
+
+  if (
+    !shouldPruneSandboxToolsFromHostedChildRequest({
+      prompt: input.prompt,
+      requestedTools: expandedTools,
+      sandboxToolNames: input.sandboxToolNames ?? DEFAULT_SANDBOX_TOOL_NAMES,
+      artifactToolNames: input.artifactToolNames ?? DEFAULT_ARTIFACT_TOOL_NAMES,
+      sandboxRequiredCuePattern: input.sandboxRequiredCuePattern,
+      isTextArtifactPrompt: input.isTextArtifactPrompt,
+    })
+  ) {
+    return expandedTools;
+  }
+
+  const sandboxToolNames = new Set(input.sandboxToolNames ?? DEFAULT_SANDBOX_TOOL_NAMES);
+  return expandedTools.filter((toolName) => !sandboxToolNames.has(toolName));
+}
+
+export function expandHostedChildRequestedTools(input: {
+  requestedTools?: readonly string[];
+  excludedTools?: ReadonlySet<string>;
+  companionTools?: Readonly<Record<string, readonly string[]>>;
+}): string[] | undefined {
+  if (!input.requestedTools) {
+    return undefined;
+  }
+
+  if (input.requestedTools.length === 0) {
+    return [];
+  }
+
+  const expandedTools = new Set<string>();
+
+  for (const toolName of input.requestedTools) {
+    if (input.excludedTools?.has(toolName)) {
+      continue;
+    }
+
+    expandedTools.add(toolName);
+
+    for (const companionTool of input.companionTools?.[toolName] ?? []) {
+      if (input.excludedTools?.has(companionTool)) {
+        continue;
+      }
+
+      expandedTools.add(companionTool);
+    }
+  }
+
+  return [...expandedTools];
+}
+
+export function shouldPruneSandboxToolsFromHostedChildRequest(input: {
+  prompt: string;
+  requestedTools?: readonly string[];
+  sandboxToolNames?: readonly string[];
+  artifactToolNames?: readonly string[];
+  sandboxRequiredCuePattern?: RegExp;
+  isTextArtifactPrompt?: (prompt: string) => boolean;
+}): boolean {
+  const requestedTools = input.requestedTools;
+  if (!requestedTools?.length) {
+    return false;
+  }
+
+  const sandboxToolNames = input.sandboxToolNames ?? DEFAULT_SANDBOX_TOOL_NAMES;
+  if (!sandboxToolNames.some((toolName) => requestedTools.includes(toolName))) {
+    return false;
+  }
+
+  const artifactToolNames = input.artifactToolNames ?? DEFAULT_ARTIFACT_TOOL_NAMES;
+  if (!artifactToolNames.some((toolName) => requestedTools.includes(toolName))) {
+    return false;
+  }
+
+  if (!input.isTextArtifactPrompt?.(input.prompt)) {
+    return false;
+  }
+
+  if (!input.sandboxRequiredCuePattern) {
+    return true;
+  }
+
+  return !matchesSandboxRequiredCue(input.sandboxRequiredCuePattern, input.prompt);
+}
+
+export function buildHostedChildToolDescription(): string {
+  return `Invoke a focused child agent on an isolated subtask.
+Call multiple times in one response to run child agents in parallel.
+
+Use when:
+- Work can be isolated from the main conversation
+- You need focused context without polluting the main thread
+- A subtask benefits from different tools, model, or step limits
+- You want the child result returned back to the main thread
+
+This uses the shared child-run execution engine. Prefer this as the long-term child-work primitive.`;
+}
+
+function matchesSandboxRequiredCue(pattern: RegExp, prompt: string): boolean {
+  const deterministicFlags = [...pattern.flags]
+    .filter((flag) => flag !== "g" && flag !== "y")
+    .join("");
+
+  return new RegExp(pattern.source, deterministicFlags).test(prompt);
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -348,6 +348,13 @@ export {
   withHostedChildStreamIdleTimeout,
 } from "./hosted-child-stream-watchdog.ts";
 export {
+  buildHostedChildToolDescription,
+  expandHostedChildRequestedTools,
+  type HostedChildRequestedToolsInput,
+  sanitizeHostedChildRequestedTools,
+  shouldPruneSandboxToolsFromHostedChildRequest,
+} from "./hosted-child-requested-tools.ts";
+export {
   buildChildRunResultSummary,
   buildRootOwnedChildRunResultHint,
   buildRootOwnedChildRunResultText,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.314";
+export const VERSION = "0.1.315";


### PR DESCRIPTION
## Summary
- add reusable hosted child requested-tool expansion and sanitization helpers
- keep host/product exclusions and artifact policy injectable at the edge
- bump framework package version to 0.1.315

## Verification
- deno fmt --check src/agent/hosted-child-requested-tools.ts src/agent/hosted-child-requested-tools.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all src/agent/hosted-child-requested-tools.test.ts
- deno task lint
- deno task typecheck
- deno task build:npm
- pre-push checks: formatting, lint, typecheck, unit tests (1485 passed / 0 failed)