### PR TITLE
Share hosted child execution log entries

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.315",
+  "version": "0.1.316",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-execution-logging.test.ts
+++ b/src/agent/hosted-child-execution-logging.test.ts
@@ -1,0 +1,95 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import {
+  buildHostedChildCompletedLog,
+  buildHostedChildErrorLog,
+  buildHostedChildExhaustedStepBudgetLog,
+} from "./hosted-child-execution-logging.ts";
+import { HostedChildStreamIdleTimeoutError } from "./hosted-child-stream-watchdog.ts";
+
+Deno.test("buildHostedChildExhaustedStepBudgetLog builds warning context", () => {
+  assertEquals(
+    buildHostedChildExhaustedStepBudgetLog({
+      description: "Summarize docs",
+      kind: "invoke_agent",
+      stepCount: 10,
+      maxSteps: 10,
+      toolCallsLength: 3,
+    }),
+    {
+      level: "warn",
+      message: "Child fork exhausted step budget",
+      context: {
+        description: "Summarize docs",
+        kind: "invoke_agent",
+        stepCount: 10,
+        maxSteps: 10,
+        toolCalls: 3,
+      },
+    },
+  );
+});
+
+Deno.test("buildHostedChildCompletedLog includes result length and preview", () => {
+  const finalText = `${"a".repeat(210)}tail`;
+  const result = buildHostedChildCompletedLog({
+    description: "Summarize docs",
+    kind: "invoke_agent",
+    toolCallsLength: 2,
+    finalText,
+  });
+
+  assertEquals(result.level, "info");
+  assertEquals(result.message, "Child fork completed");
+  assertEquals(result.context.resultLength, 214);
+  assertEquals(result.context.resultPreview, "a".repeat(200));
+});
+
+Deno.test("buildHostedChildErrorLog returns stalled warning for idle timeout errors", () => {
+  const result = buildHostedChildErrorLog({
+    description: "Summarize docs",
+    kind: "invoke_agent",
+    error: new HostedChildStreamIdleTimeoutError({
+      phase: "generic_idle",
+      timeoutMs: 45_000,
+    }),
+    finalText: "partial",
+    toolCallsLength: 4,
+    toolResultsLength: 3,
+  });
+
+  assertEquals(result, {
+    level: "warn",
+    message: "Child fork stream stalled",
+    context: {
+      description: "Summarize docs",
+      kind: "invoke_agent",
+      phase: "generic_idle",
+      idleTimeoutMs: 45_000,
+      partialTextLength: 7,
+      toolCalls: 4,
+      toolResults: 3,
+    },
+  });
+});
+
+Deno.test("buildHostedChildErrorLog returns failure error for generic errors", () => {
+  const error = new Error("boom");
+  const result = buildHostedChildErrorLog({
+    description: "Summarize docs",
+    kind: "invoke_agent",
+    error,
+    finalText: "partial",
+    toolCallsLength: 4,
+    toolResultsLength: 3,
+  });
+
+  assertEquals(result, {
+    level: "error",
+    message: "Child fork failed",
+    context: {
+      description: "Summarize docs",
+      kind: "invoke_agent",
+      error,
+    },
+  });
+});

--- a/src/agent/hosted-child-execution-logging.ts
+++ b/src/agent/hosted-child-execution-logging.ts
@@ -1,0 +1,83 @@
+import { HostedChildStreamIdleTimeoutError } from "./hosted-child-stream-watchdog.ts";
+
+export type HostedChildExecutionLogLevel = "error" | "info" | "warn";
+
+export interface HostedChildExecutionLogEntry {
+  level: HostedChildExecutionLogLevel;
+  message: string;
+  context: Record<string, unknown>;
+}
+
+export function buildHostedChildExhaustedStepBudgetLog(input: {
+  description: string;
+  kind: string;
+  stepCount: number;
+  maxSteps: number;
+  toolCallsLength: number;
+}): HostedChildExecutionLogEntry {
+  return {
+    level: "warn",
+    message: "Child fork exhausted step budget",
+    context: {
+      description: input.description,
+      kind: input.kind,
+      stepCount: input.stepCount,
+      maxSteps: input.maxSteps,
+      toolCalls: input.toolCallsLength,
+    },
+  };
+}
+
+export function buildHostedChildCompletedLog(input: {
+  description: string;
+  kind: string;
+  toolCallsLength: number;
+  finalText: string;
+}): HostedChildExecutionLogEntry {
+  return {
+    level: "info",
+    message: "Child fork completed",
+    context: {
+      description: input.description,
+      kind: input.kind,
+      toolCalls: input.toolCallsLength,
+      resultLength: input.finalText.length,
+      resultPreview: input.finalText.substring(0, 200),
+    },
+  };
+}
+
+export function buildHostedChildErrorLog(input: {
+  description: string;
+  kind: string;
+  error: unknown;
+  finalText: string;
+  toolCallsLength: number;
+  toolResultsLength: number;
+}): HostedChildExecutionLogEntry {
+  if (input.error instanceof HostedChildStreamIdleTimeoutError) {
+    return {
+      level: "warn",
+      message: "Child fork stream stalled",
+      context: {
+        description: input.description,
+        kind: input.kind,
+        phase: input.error.phase,
+        idleTimeoutMs: input.error.timeoutMs,
+        partialTextLength: input.finalText.length,
+        toolCalls: input.toolCallsLength,
+        toolResults: input.toolResultsLength,
+      },
+    };
+  }
+
+  return {
+    level: "error",
+    message: "Child fork failed",
+    context: {
+      description: input.description,
+      kind: input.kind,
+      error: input.error,
+    },
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -355,6 +355,13 @@ export {
   shouldPruneSandboxToolsFromHostedChildRequest,
 } from "./hosted-child-requested-tools.ts";
 export {
+  buildHostedChildCompletedLog,
+  buildHostedChildErrorLog,
+  buildHostedChildExhaustedStepBudgetLog,
+  type HostedChildExecutionLogEntry,
+  type HostedChildExecutionLogLevel,
+} from "./hosted-child-execution-logging.ts";
+export {
   buildChildRunResultSummary,
   buildRootOwnedChildRunResultHint,
   buildRootOwnedChildRunResultText,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.315";
+export const VERSION = "0.1.316";


### PR DESCRIPTION
## Summary
- add pure hosted child execution log-entry builders
- keep concrete logger calls host-owned while sharing message/context semantics
- bump framework package version to 0.1.316

## Verification
- deno fmt --check src/agent/hosted-child-execution-logging.ts src/agent/hosted-child-execution-logging.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts
- deno test --no-check --allow-all src/agent/hosted-child-execution-logging.test.ts
- deno task lint
- deno task typecheck
- deno task build:npm
- pre-push checks: formatting, lint, typecheck, unit tests (1490 passed / 0 failed)