### PR TITLE
Share hosted child artifact helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.316",
+  "version": "0.1.317",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-artifact-support.test.ts
+++ b/src/agent/hosted-child-artifact-support.test.ts
@@ -1,0 +1,108 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import {
+  getHostedChildWrittenArtifactPath,
+  isHostedChildCreateFileAlreadyExistsResult,
+  isHostedChildTextProjectArtifactPrompt,
+  normalizeHostedChildArtifactPath,
+} from "./hosted-child-artifact-support.ts";
+
+Deno.test("isHostedChildTextProjectArtifactPrompt recognizes markdown artifact cues", () => {
+  assertEquals(isHostedChildTextProjectArtifactPrompt("Create a markdown research report"), true);
+  assertEquals(isHostedChildTextProjectArtifactPrompt("Write to docs/output.md"), true);
+  assertEquals(isHostedChildTextProjectArtifactPrompt("Build a React component"), false);
+});
+
+Deno.test("isHostedChildCreateFileAlreadyExistsResult recognizes direct and nested tool errors", () => {
+  assertEquals(
+    isHostedChildCreateFileAlreadyExistsResult({
+      isError: true,
+      content: [{ type: "text", text: "The file already exists at /docs/report.md" }],
+    }),
+    true,
+  );
+
+  assertEquals(
+    isHostedChildCreateFileAlreadyExistsResult({
+      error: "tool_error",
+      message: "File already exists: research/ai-coding-agents/sources.md",
+    }),
+    true,
+  );
+
+  assertEquals(
+    isHostedChildCreateFileAlreadyExistsResult({
+      output: {
+        error: "tool_error",
+        message: "File already exists: research/ai-coding-agents/sources.md",
+      },
+    }),
+    true,
+  );
+});
+
+Deno.test("isHostedChildCreateFileAlreadyExistsResult rejects successful or unknown results", () => {
+  assertEquals(
+    isHostedChildCreateFileAlreadyExistsResult({
+      content: [{ type: "text", text: "File created" }],
+    }),
+    false,
+  );
+  assertEquals(isHostedChildCreateFileAlreadyExistsResult(null), false);
+  assertEquals(isHostedChildCreateFileAlreadyExistsResult("string"), false);
+  assertEquals(isHostedChildCreateFileAlreadyExistsResult(42), false);
+});
+
+Deno.test("normalizeHostedChildArtifactPath normalizes project artifact paths", () => {
+  assertEquals(normalizeHostedChildArtifactPath("docs/report.md"), "/docs/report.md");
+  assertEquals(normalizeHostedChildArtifactPath("./plans/report.md"), "/plans/report.md");
+  assertEquals(normalizeHostedChildArtifactPath("'/plans/report.md,'"), "/plans/report.md");
+  assertEquals(normalizeHostedChildArtifactPath("https://example.com/report.md"), null);
+  assertEquals(normalizeHostedChildArtifactPath("/workspace/report.md"), null);
+});
+
+Deno.test("getHostedChildWrittenArtifactPath returns normalized paths for writing tools", () => {
+  assertEquals(
+    getHostedChildWrittenArtifactPath({
+      toolName: "create_file",
+      toolInput: { path: "docs/report.md", content: "hello" },
+      toolOutput: { content: [{ text: "created" }] },
+    }),
+    "/docs/report.md",
+  );
+
+  assertEquals(
+    getHostedChildWrittenArtifactPath({
+      toolName: "update_file",
+      toolInput: { path: "/plans/research.md", content: "updated" },
+      toolOutput: {},
+    }),
+    "/plans/research.md",
+  );
+});
+
+Deno.test("getHostedChildWrittenArtifactPath ignores non-writing tools, failed writes, and missing paths", () => {
+  assertEquals(
+    getHostedChildWrittenArtifactPath({
+      toolName: "bash",
+      toolInput: { path: "docs/report.md" },
+      toolOutput: {},
+    }),
+    null,
+  );
+  assertEquals(
+    getHostedChildWrittenArtifactPath({
+      toolName: "create_file",
+      toolInput: { path: "test.md" },
+      toolOutput: { isError: true, content: [{ text: "failed" }] },
+    }),
+    null,
+  );
+  assertEquals(
+    getHostedChildWrittenArtifactPath({
+      toolName: "create_file",
+      toolInput: { content: "no path" },
+      toolOutput: {},
+    }),
+    null,
+  );
+});

--- a/src/agent/hosted-child-artifact-support.test.ts
+++ b/src/agent/hosted-child-artifact-support.test.ts
@@ -58,6 +58,8 @@ Deno.test("normalizeHostedChildArtifactPath normalizes project artifact paths", 
   assertEquals(normalizeHostedChildArtifactPath("'/plans/report.md,'"), "/plans/report.md");
   assertEquals(normalizeHostedChildArtifactPath("https://example.com/report.md"), null);
   assertEquals(normalizeHostedChildArtifactPath("/workspace/report.md"), null);
+  assertEquals(normalizeHostedChildArtifactPath("../report.md"), null);
+  assertEquals(normalizeHostedChildArtifactPath("docs/../report.md"), null);
 });
 
 Deno.test("getHostedChildWrittenArtifactPath returns normalized paths for writing tools", () => {
@@ -94,6 +96,14 @@ Deno.test("getHostedChildWrittenArtifactPath ignores non-writing tools, failed w
       toolName: "create_file",
       toolInput: { path: "test.md" },
       toolOutput: { isError: true, content: [{ text: "failed" }] },
+    }),
+    null,
+  );
+  assertEquals(
+    getHostedChildWrittenArtifactPath({
+      toolName: "create_file",
+      toolInput: { path: "test.md" },
+      toolOutput: { error: "tool_error", message: "File already exists: test.md" },
     }),
     null,
   );

--- a/src/agent/hosted-child-artifact-support.ts
+++ b/src/agent/hosted-child-artifact-support.ts
@@ -4,6 +4,7 @@ const TEXT_PROJECT_ARTIFACT_PATH_PATTERN = /(?:^|[\s`"'(])(?:[\w./-]+\/)?[\w.-]+
 
 const DEFAULT_WRITING_TOOL_NAMES = ["create_file", "update_file"];
 const CREATE_FILE_ALREADY_EXISTS_PATTERN = /file already exists/i;
+const TOOL_ERROR_VALUES = new Set(["error", "tool_error"]);
 const MAX_NESTED_TOOL_RESULT_DEPTH = 8;
 
 export interface HostedChildWrittenArtifactPathInput {
@@ -55,9 +56,16 @@ export function normalizeHostedChildArtifactPath(path: string): string | null {
   }
 
   const prefixedPath = trimmedPath.replace(/^\.\//, "/");
-  const normalizedPath = prefixedPath.startsWith("/") ? prefixedPath : `/${prefixedPath}`;
+  const normalizedPath = (prefixedPath.startsWith("/") ? prefixedPath : `/${prefixedPath}`).replace(
+    /\/{2,}/g,
+    "/",
+  );
 
-  return normalizedPath.replace(/\/{2,}/g, "/");
+  if (normalizedPath.split("/").includes("..")) {
+    return null;
+  }
+
+  return normalizedPath;
 }
 
 function isHostedChildCreateFileAlreadyExistsResultAtDepth(
@@ -99,7 +107,15 @@ function hasAlreadyExistsContentPart(content: unknown): boolean {
 }
 
 function isErrorToolOutput(output: unknown): boolean {
-  return isRecord(output) && output.isError === true;
+  if (!isRecord(output)) {
+    return false;
+  }
+
+  if (output.isError === true) {
+    return true;
+  }
+
+  return typeof output.error === "string" && TOOL_ERROR_VALUES.has(output.error);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/agent/hosted-child-artifact-support.ts
+++ b/src/agent/hosted-child-artifact-support.ts
@@ -1,0 +1,107 @@
+const TEXT_PROJECT_ARTIFACT_CUE_PATTERN =
+  /\b(markdown|reference document|research report|report|write-up|writeup|save it to the project|save everything to the project|save the results to the project|compile everything into a single well-structured markdown file)\b/i;
+const TEXT_PROJECT_ARTIFACT_PATH_PATTERN = /(?:^|[\s`"'(])(?:[\w./-]+\/)?[\w.-]+\.md\b/i;
+
+const DEFAULT_WRITING_TOOL_NAMES = ["create_file", "update_file"];
+const CREATE_FILE_ALREADY_EXISTS_PATTERN = /file already exists/i;
+const MAX_NESTED_TOOL_RESULT_DEPTH = 8;
+
+export interface HostedChildWrittenArtifactPathInput {
+  toolName: string;
+  toolInput: unknown;
+  toolOutput: unknown;
+  writingToolNames?: readonly string[];
+}
+
+export function isHostedChildTextProjectArtifactPrompt(prompt: string): boolean {
+  return TEXT_PROJECT_ARTIFACT_CUE_PATTERN.test(prompt) ||
+    TEXT_PROJECT_ARTIFACT_PATH_PATTERN.test(prompt);
+}
+
+export function isHostedChildCreateFileAlreadyExistsResult(result: unknown): boolean {
+  return isHostedChildCreateFileAlreadyExistsResultAtDepth(result, 0);
+}
+
+export function getHostedChildWrittenArtifactPath(
+  input: HostedChildWrittenArtifactPathInput,
+): string | null {
+  const writingToolNames = input.writingToolNames ?? DEFAULT_WRITING_TOOL_NAMES;
+  if (!writingToolNames.includes(input.toolName)) {
+    return null;
+  }
+
+  if (isErrorToolOutput(input.toolOutput)) {
+    return null;
+  }
+
+  if (!isRecord(input.toolInput)) {
+    return null;
+  }
+
+  const path = input.toolInput.path;
+  return typeof path === "string" ? normalizeHostedChildArtifactPath(path) : null;
+}
+
+export function normalizeHostedChildArtifactPath(path: string): string | null {
+  const trimmedPath = path.trim().replace(/^[`"'(]+|[`"'),.;:!?]+$/g, "");
+  if (trimmedPath.length === 0) {
+    return null;
+  }
+  if (
+    trimmedPath.includes("://") || trimmedPath === "/workspace" ||
+    trimmedPath.startsWith("/workspace/")
+  ) {
+    return null;
+  }
+
+  const prefixedPath = trimmedPath.replace(/^\.\//, "/");
+  const normalizedPath = prefixedPath.startsWith("/") ? prefixedPath : `/${prefixedPath}`;
+
+  return normalizedPath.replace(/\/{2,}/g, "/");
+}
+
+function isHostedChildCreateFileAlreadyExistsResultAtDepth(
+  result: unknown,
+  depth: number,
+): boolean {
+  if (depth > MAX_NESTED_TOOL_RESULT_DEPTH || !isRecord(result)) {
+    return false;
+  }
+
+  if (
+    typeof result.message === "string" && CREATE_FILE_ALREADY_EXISTS_PATTERN.test(result.message)
+  ) {
+    return true;
+  }
+
+  if (
+    result.output !== undefined &&
+    isHostedChildCreateFileAlreadyExistsResultAtDepth(result.output, depth + 1)
+  ) {
+    return true;
+  }
+
+  return hasAlreadyExistsContentPart(result.content);
+}
+
+function hasAlreadyExistsContentPart(content: unknown): boolean {
+  if (!Array.isArray(content)) {
+    return false;
+  }
+
+  return content.some((part) => {
+    if (!isRecord(part)) {
+      return false;
+    }
+
+    return typeof part.text === "string" && CREATE_FILE_ALREADY_EXISTS_PATTERN.test(part.text);
+  });
+}
+
+function isErrorToolOutput(output: unknown): boolean {
+  return isRecord(output) && output.isError === true;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -355,6 +355,13 @@ export {
   shouldPruneSandboxToolsFromHostedChildRequest,
 } from "./hosted-child-requested-tools.ts";
 export {
+  getHostedChildWrittenArtifactPath,
+  type HostedChildWrittenArtifactPathInput,
+  isHostedChildCreateFileAlreadyExistsResult,
+  isHostedChildTextProjectArtifactPrompt,
+  normalizeHostedChildArtifactPath,
+} from "./hosted-child-artifact-support.ts";
+export {
   buildHostedChildCompletedLog,
   buildHostedChildErrorLog,
   buildHostedChildExhaustedStepBudgetLog,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.316";
+export const VERSION = "0.1.317";


### PR DESCRIPTION
## Summary\n- add reusable hosted child artifact prompt/write-path/already-exists helpers to the agent surface\n- cover generic artifact behavior with focused Deno tests\n- bump framework package version to 0.1.317\n\n## Verification\n- deno fmt --check src/agent/hosted-child-artifact-support.ts src/agent/hosted-child-artifact-support.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts\n- deno test --no-check --allow-all src/agent/hosted-child-artifact-support.test.ts\n- deno task lint\n- deno task typecheck\n- deno task build:npm\n- pre-push checks: formatting, lint, typecheck, unit tests (1496 passed / 0 failed)