### PR TITLE
Reduce expected custom-domain proxy log noise

### DIFF
--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -156,6 +156,32 @@ function createHandler(port: number, apiBasePath = "") {
   });
 }
 
+function createRecordingLogger() {
+  const entries: Array<{
+    level: "debug" | "info" | "warn" | "error";
+    message: string;
+    extra?: Record<string, unknown>;
+  }> = [];
+
+  return {
+    entries,
+    logger: {
+      debug(message: string, extra?: Record<string, unknown>) {
+        entries.push({ level: "debug", message, extra });
+      },
+      info(message: string, extra?: Record<string, unknown>) {
+        entries.push({ level: "info", message, extra });
+      },
+      warn(message: string, extra?: Record<string, unknown>) {
+        entries.push({ level: "warn", message, extra });
+      },
+      error(message: string, _error?: Error, extra?: Record<string, unknown>) {
+        entries.push({ level: "error", message, extra });
+      },
+    },
+  };
+}
+
 /** Per-test JWKS store so tests can register RS256 tokens by URL. */
 const jwksVerifiers = new Map<string, Map<string, TokenPayload>>();
 
@@ -328,6 +354,105 @@ describe("Proxy Handler", () => {
         assertEquals(
           ctx.error?.message,
           "No project configured for domain: ai-chatbot.veryfront.com",
+        );
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
+    it("logs expected custom domain token-mint misses below error level", async () => {
+      const { entries, logger } = createRecordingLogger();
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") {
+          return new Response('{"error":"Project not found for domain"}', {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createProxyHandler({
+          config: {
+            apiBaseUrl: `http://127.0.0.1:${port}`,
+            apiClientId: "test-client",
+            apiClientSecret: "test-secret",
+            previewApiClientId: "test-client",
+            previewApiClientSecret: "test-secret",
+          },
+          logger,
+        });
+
+        const req = new Request("http://unknown-domain.com/page", {
+          headers: { host: "unknown-domain.com" },
+        });
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error?.status, 404);
+        assertEquals(
+          entries.filter((entry) => entry.level === "error").map((entry) => entry.message),
+          [],
+        );
+        assertEquals(
+          entries.some((entry) =>
+            entry.level === "info" &&
+            entry.message === "Custom domain project not found during token fetch"
+          ),
+          true,
+        );
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
+    it("logs custom domains missing after lookup below error level", async () => {
+      const { entries, logger } = createRecordingLogger();
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") return createTokenResponse();
+        if (pathname.startsWith("/projects/")) return createNotFoundResponse();
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createProxyHandler({
+          config: {
+            apiBaseUrl: `http://127.0.0.1:${port}`,
+            apiClientId: "test-client",
+            apiClientSecret: "test-secret",
+            previewApiClientId: "test-client",
+            previewApiClientSecret: "test-secret",
+          },
+          logger,
+        });
+
+        const req = new Request("http://unknown-domain.com/page", {
+          headers: { host: "unknown-domain.com" },
+        });
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.error?.status, 404);
+        assertEquals(
+          entries.filter((entry) => entry.level === "error").map((entry) => entry.message),
+          [],
+        );
+        assertEquals(
+          entries.some((entry) =>
+            entry.level === "info" && entry.message === "Custom domain not found"
+          ),
+          true,
         );
 
         await handler.close();

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -481,10 +481,12 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
           token = await tokenManager.getToken(scope, projectSlug, customDomain);
         } catch (error) {
           tokenFetchError = error;
-          logger?.error(options.tokenFetchErrorMessage, error as Error, {
-            projectSlug,
-            customDomain,
-          });
+          if (!(customDomain && isMissingCustomDomainProjectError(error))) {
+            logger?.error(options.tokenFetchErrorMessage, error as Error, {
+              projectSlug,
+              customDomain,
+            });
+          }
         }
       }
     }
@@ -684,7 +686,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
         const lookupResult = await lookupProjectByDomain(host, config.apiBaseUrl, token, logger);
         if (!lookupResult) {
-          logger?.error("Custom domain not found", undefined, { domain: host });
+          logger?.info("Custom domain not found", { domain: host });
           return makeErrorContext(base, 404, `No project configured for domain: ${host}`, token);
         }
 

--- a/src/proxy/log-noise.test.ts
+++ b/src/proxy/log-noise.test.ts
@@ -1,0 +1,44 @@
+import { assertEquals } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
+import { getProxyFailureLogLevel, isLikelyScannerProbePath } from "./log-noise.ts";
+
+describe("proxy log noise classification", () => {
+  it("classifies common scanner probe paths as noisy", () => {
+    for (
+      const path of [
+        "/031.php",
+        "//autoload_classmap.php",
+        "/wp.php",
+        "/shell20211028.php",
+        "/about25.php",
+        "/wp-admin/setup-config.php",
+      ]
+    ) {
+      assertEquals(isLikelyScannerProbePath(path), true);
+    }
+  });
+
+  it("does not classify normal app and framework paths as scanner probes", () => {
+    for (
+      const path of [
+        "/",
+        "/about",
+        "/api/health",
+        "/_veryfront/assets/app.js",
+        "/blog/post.php-not-a-probe",
+        "/api/render",
+      ]
+    ) {
+      assertEquals(isLikelyScannerProbePath(path), false);
+    }
+  });
+
+  it("downgrades scanner-probe 502s while preserving normal 5xx errors", () => {
+    assertEquals(getProxyFailureLogLevel(502, "GET", "/wp.php"), "warn");
+    assertEquals(getProxyFailureLogLevel(502, "HEAD", "//autoload_classmap.php"), "warn");
+    assertEquals(getProxyFailureLogLevel(502, "POST", "/wp.php"), "error");
+    assertEquals(getProxyFailureLogLevel(500, "GET", "/wp.php"), "error");
+    assertEquals(getProxyFailureLogLevel(502, "GET", "/api/render"), "error");
+    assertEquals(getProxyFailureLogLevel(404, "GET", "/wp.php"), "warn");
+  });
+});

--- a/src/proxy/log-noise.ts
+++ b/src/proxy/log-noise.ts
@@ -1,0 +1,41 @@
+const PHP_PROBE_PATTERN = /(?:^|\/)[^/?#]*\.php$/i;
+
+const SCANNER_PROBE_SEGMENTS = new Set([
+  "autoload_classmap.php",
+  "dropdown.php",
+  "edit.php",
+  "h.php",
+  "shell20211028.php",
+  "wp-admin",
+  "wp.php",
+  "x.php",
+  "zwso.php",
+]);
+
+export function isLikelyScannerProbePath(pathname: string): boolean {
+  const normalized = pathname.replace(/^\/+/, "/").toLowerCase();
+  if (PHP_PROBE_PATTERN.test(normalized)) return true;
+
+  return normalized
+    .split("/")
+    .filter(Boolean)
+    .some((segment) => SCANNER_PROBE_SEGMENTS.has(segment));
+}
+
+export type ProxyFailureLogLevel = "warn" | "error";
+
+export function getProxyFailureLogLevel(
+  status: number,
+  method: string,
+  pathname: string,
+): ProxyFailureLogLevel {
+  if (
+    status === 502 &&
+    ["GET", "HEAD"].includes(method.toUpperCase()) &&
+    isLikelyScannerProbePath(pathname)
+  ) {
+    return "warn";
+  }
+
+  return status < 500 ? "warn" : "error";
+}

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -35,6 +35,7 @@ import {
   withSpan,
 } from "./tracing.ts";
 import { proxyLogger, runWithProxyRequestContext } from "./logger.ts";
+import { getProxyFailureLogLevel } from "./log-noise.ts";
 import { RendererRouter } from "./renderer-router.ts";
 import { ServerResolver } from "./server-resolver.ts";
 import { parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
@@ -454,7 +455,8 @@ function forwardToServer(req: Request): Promise<Response> {
 
           // All retries exhausted or non-retryable error
           const ms = Math.round(performance.now() - startTime);
-          proxyLogger.error(`502 ${req.method} ${url.pathname}`, { ms }, lastError as Error);
+          const logLevel = getProxyFailureLogLevel(502, req.method, url.pathname);
+          proxyLogger[logLevel](`502 ${req.method} ${url.pathname}`, { ms }, lastError as Error);
           endSpan(spanInfo?.span, 502, lastError as Error);
           return jsonErrorResponse(502, {
             error: "Proxy Error",


### PR DESCRIPTION
## Summary\n- Downgrade expected missing custom-domain token-mint misses out of error-level logging\n- Log custom-domain lookup misses at info instead of error while preserving 404 behavior\n- Downgrade scanner/probe-shaped GET/HEAD 502 proxy failures to warning while preserving normal 5xx error visibility\n- Add regression coverage for custom-domain log severity and scanner/probe 502 classification\n\n## Context\nGrafana CSV export showed repeated veryfront-proxy noise: `Token fetch failed`, `Cannot process custom domain without token`, `Custom domain not found`, and `502 GET <php/probe path>`. This PR addresses the source-code proxy seams without blanket-suppressing genuine proxy/auth failures.\n\n## Verification\n- RED first: new handler tests failed before the implementation with error-level `Token fetch failed` and `Custom domain not found` entries.\n- RED first: new log-noise test failed before implementation because `log-noise.ts` / `getProxyFailureLogLevel` did not exist.\n- `deno test --no-check --allow-all src/proxy/log-noise.test.ts src/proxy/handler.test.ts src/proxy/token-priority.test.ts`\n- `deno fmt --check src/proxy/main.ts src/proxy/log-noise.ts src/proxy/log-noise.test.ts`\n- `DENO_NO_PACKAGE_JSON=1 deno lint src/proxy/main.ts src/proxy/log-noise.ts src/proxy/log-noise.test.ts`\n- `deno check src/proxy/main.ts src/proxy/log-noise.ts src/proxy/log-noise.test.ts`\n- `deno fmt --check src/proxy/handler.ts src/proxy/handler.test.ts`\n- `DENO_NO_PACKAGE_JSON=1 deno lint src/proxy/handler.ts src/proxy/handler.test.ts`\n- `deno check src/proxy/handler.ts`\n\n## Not tested\n- Full `deno task verify` was not run for this focused PR.\n- `deno check src/proxy/handler.test.ts` still reports pre-existing strict indexed-access errors in the existing test helper at lines 94, 95, and 127.\n- Live Grafana post-deploy query.\n\nConstraint: Keep genuine proxy/auth failures visible at error level.\nRejected: Blanket suppression of custom-domain or 502 proxy errors | would hide real token, lookup, or upstream failures.\nConfidence: medium\nScope-risk: narrow\nDirective: Do not downgrade unexpected token fetch failures without a specific expected-error predicate; keep scanner classification conservative.