### PR TITLE
Publish proxy log fixes as v0.1.318

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.317",
+  "version": "0.1.318",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.317";
+export const VERSION = "0.1.318";


### PR DESCRIPTION
## Summary\n- Bump deno.json to 0.1.318 so the merged proxy log-noise fixes publish as a new immutable framework release.\n\n## Evidence\n- Production re-query after server deployment showed veryfrontVersion 0.1.317 still emitting the old custom-domain token errors.\n- v0.1.317 existed before PR #1343, so server artifacts rebuilt with 0.1.317 did not include the source fix.\n\n## Verification\n- deno fmt --check deno.json\n- confirmed v0.1.318 is not present in veryfront/veryfront-code or veryfront/veryfront releases\n\n## Not tested\n- Release workflow until merged to main.