### PR TITLE
Reduce recoverable render warning noise

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.318",
+  "version": "0.1.319",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/observability/production-log-noise.test.ts
+++ b/src/observability/production-log-noise.test.ts
@@ -1,0 +1,36 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+
+const recoverableWarnSites = [
+  {
+    path: "src/transforms/esm/http-cache.ts",
+    snippet: 'httpCacheLog.warn("Local cache has missing deps, will re-fetch"',
+  },
+  {
+    path: "src/transforms/esm/http-cache.ts",
+    snippet: 'httpCacheLog.warn("Cached code has missing bundle deps, will re-fetch"',
+  },
+  {
+    path: "src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts",
+    snippet:
+      "log.warn(\n          `${LOG_PREFIX_MDX_LOADER} Cached code has ${unresolvedDeps.length} missing file dependencies, invalidating`,",
+  },
+  {
+    path: "src/transforms/pipeline/stages/ssr-vf-modules/index.ts",
+    snippet: "logger.warn(`${LOG_PREFIX} Initialized`",
+  },
+  {
+    path: "src/server/handlers/request/api/project-discovery.ts",
+    snippet: 'logger.warn("Primitive discovery found 0 agents and 0 tools"',
+  },
+];
+
+Deno.test("recoverable render cache events do not emit production warning logs", async () => {
+  for (const site of recoverableWarnSites) {
+    const source = await Deno.readTextFile(site.path);
+    assertEquals(
+      source.includes(site.snippet),
+      false,
+      `${site.path} should not warn for recoverable/no-op production events`,
+    );
+  }
+});

--- a/src/server/handlers/request/api/project-discovery.ts
+++ b/src/server/handlers/request/api/project-discovery.ts
@@ -115,7 +115,7 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<void>
     if (
       result.agents.size === 0 && result.tools.size === 0 && shouldWarnOnEmptyAiDiscovery
     ) {
-      logger.warn("Primitive discovery found 0 agents and 0 tools", {
+      logger.info("Primitive discovery found 0 agents and 0 tools", {
         ...logData,
         errorMessages: result.errors.map((e) => e.error.message).slice(0, 5),
         baseDir: ctx.projectDir,

--- a/src/transforms/esm/http-cache.ts
+++ b/src/transforms/esm/http-cache.ts
@@ -108,7 +108,7 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
     if (deps.length > 0) {
       const depsValid = await validateBundleDepsExist(deps, cacheDir);
       if (!depsValid) {
-        httpCacheLog.warn("Local cache has missing deps, will re-fetch", {
+        httpCacheLog.debug("Local cache has missing deps, will re-fetch", {
           url: normalizedUrl,
           hash,
           missingDeps: deps.length,
@@ -170,7 +170,7 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
       if (deps.length > 0) {
         const depsExist = await validateBundleDepsExist(deps, cacheDir);
         if (!depsExist) {
-          httpCacheLog.warn("Cached code has missing bundle deps, will re-fetch", {
+          httpCacheLog.debug("Cached code has missing bundle deps, will re-fetch", {
             url: normalizedUrl,
             hash,
             missingDeps: deps.length,

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts
@@ -151,7 +151,7 @@ export async function readDistributedCache(
 
       const unresolvedDeps = await findMissingFileDependenciesInCode(moduleCode, log);
       if (unresolvedDeps.length > 0) {
-        log.warn(
+        log.debug(
           `${LOG_PREFIX_MDX_LOADER} Cached code has ${unresolvedDeps.length} missing file dependencies, invalidating`,
           { normalizedPath, missingDeps: unresolvedDeps.slice(0, 5) },
         );

--- a/src/transforms/pipeline/stages/ssr-vf-modules/index.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/index.ts
@@ -71,7 +71,7 @@ let _initLogged = false;
 function logInitOnce(): void {
   if (_initLogged) return;
   _initLogged = true;
-  logger.warn(`${LOG_PREFIX} Initialized`, {
+  logger.debug(`${LOG_PREFIX} Initialized`, {
     importMetaUrl: import.meta.url,
     frameworkRoot: FRAMEWORK_ROOT,
     embeddedSrcDir: EMBEDDED_SRC_DIR,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.318";
+export const VERSION = "0.1.319";


### PR DESCRIPTION
## Summary
- Downgrade recoverable render cache self-healing logs from warn to debug.
- Log SSR VF module init at debug instead of warn.
- Log empty AI primitive discovery at info instead of warn when discovery completed without errors.
- Add a production log-noise regression test and publish this as framework v0.1.319.

## Verification
- `deno fmt --check deno.json src/utils/version-constant.ts src/observability/production-log-noise.test.ts src/server/handlers/request/api/project-discovery.ts src/transforms/esm/http-cache.ts src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts src/transforms/pipeline/stages/ssr-vf-modules/index.ts`
- `deno task lint`
- `deno check src/server/handlers/request/api/project-discovery.ts src/transforms/esm/http-cache.ts src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts src/transforms/pipeline/stages/ssr-vf-modules/index.ts src/observability/production-log-noise.test.ts src/utils/version-constant.ts`
- `deno test --no-check --allow-all src/observability/production-log-noise.test.ts src/server/handlers/request/api/project-discovery.test.ts src/transforms/esm/http-cache.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/framework-validator.test.ts src/transforms/mdx/esm-module-loader/module-fetcher/dependency-recovery.test.ts src/transforms/pipeline/stages/ssr-vf-modules/import-finder.test.ts src/utils/version.test.ts`
