### PR TITLE
Keep protected redirects out of warning logs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.319",
+  "version": "0.1.320",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/proxy/log-noise.test.ts
+++ b/src/proxy/log-noise.test.ts
@@ -33,6 +33,11 @@ describe("proxy log noise classification", () => {
     }
   });
 
+  it("classifies redirects below warning severity", () => {
+    assertEquals(getProxyFailureLogLevel(302, "GET", "/"), "info");
+    assertEquals(getProxyFailureLogLevel(304, "GET", "/asset.js"), "info");
+  });
+
   it("downgrades scanner-probe 502s while preserving normal 5xx errors", () => {
     assertEquals(getProxyFailureLogLevel(502, "GET", "/wp.php"), "warn");
     assertEquals(getProxyFailureLogLevel(502, "HEAD", "//autoload_classmap.php"), "warn");

--- a/src/proxy/log-noise.ts
+++ b/src/proxy/log-noise.ts
@@ -22,7 +22,7 @@ export function isLikelyScannerProbePath(pathname: string): boolean {
     .some((segment) => SCANNER_PROBE_SEGMENTS.has(segment));
 }
 
-export type ProxyFailureLogLevel = "warn" | "error";
+export type ProxyFailureLogLevel = "info" | "warn" | "error";
 
 export function getProxyFailureLogLevel(
   status: number,
@@ -37,5 +37,6 @@ export function getProxyFailureLogLevel(
     return "warn";
   }
 
+  if (status < 400) return "info";
   return status < 500 ? "warn" : "error";
 }

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -300,7 +300,7 @@ function forwardToServer(req: Request): Promise<Response> {
         async () => {
           if (ctx.error) {
             const ms = Math.round(performance.now() - startTime);
-            const logLevel = ctx.error.status < 500 ? "warn" : "error";
+            const logLevel = getProxyFailureLogLevel(ctx.error.status, req.method, url.pathname);
             proxyLogger[logLevel](`${ctx.error.status} ${req.method} ${url.pathname}`, { ms });
             endSpan(spanInfo?.span, ctx.error.status);
             return createProxyErrorResponse(ctx.error);

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.319";
+export const VERSION = "0.1.320";


### PR DESCRIPTION
## Summary\n- classify proxy 3xx responses as info instead of warn\n- route protected-project redirect errors through the shared proxy log-level classifier\n- publish as v0.1.320 for production rollout\n\n## Verification\n- deno fmt --check deno.json src/utils/version-constant.ts src/proxy/log-noise.ts src/proxy/log-noise.test.ts src/proxy/main.ts\n- deno check src/proxy/log-noise.ts src/proxy/main.ts src/utils/version-constant.ts\n- deno test --no-check --allow-all src/proxy/log-noise.test.ts src/proxy/handler.test.ts src/proxy/error-response.test.ts src/utils/version.test.ts\n\n## Grafana evidence\n- after v0.1.319 production deploy, protected redirects still appeared as warn-level \; this keeps expected redirects visible at info while preserving warn/error classification for 4xx/5xx.\n