### PR TITLE
Use bundled Tailwind processor when no project extension is registered

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.320",
+  "version": "0.1.321",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/html/styles-builder/tailwind-compiler-cache.ts
+++ b/src/html/styles-builder/tailwind-compiler-cache.ts
@@ -14,7 +14,10 @@
  * @module html/styles-builder/tailwind-compiler-cache
  */
 
-import { tryResolve as tryResolveContract } from "#veryfront/extensions/contracts.ts";
+import {
+  register as registerContract,
+  tryResolve as tryResolveContract,
+} from "#veryfront/extensions/contracts.ts";
 import type { CSSCompiler, CSSProcessor } from "#veryfront/extensions/interfaces/index.ts";
 import { serverLogger } from "#veryfront/utils";
 import { DEPENDENCY_MISSING, NETWORK_ERROR } from "#veryfront/errors";
@@ -71,6 +74,37 @@ async function getTailwindBaseCSS(): Promise<string> {
   return tailwindBaseCSS;
 }
 
+async function resolveCSSProcessor(): Promise<CSSProcessor | undefined> {
+  const registeredProcessor = tryResolveContract<CSSProcessor>("CSSProcessor");
+  if (registeredProcessor) return registeredProcessor;
+
+  try {
+    const { default: createTailwindExtension } = await import(
+      "../../../extensions/ext-tailwind/src/index.ts"
+    );
+    const extension = createTailwindExtension();
+    await extension.setup?.({
+      config: {},
+      logger,
+      provide: (name: string, impl: unknown) => registerContract(name, impl),
+      get: () => undefined,
+      require: <T>(name: string): T => {
+        const contract = tryResolveContract<T>(name);
+        if (contract === undefined) {
+          throw new Error(`Missing required extension contract: ${name}`);
+        }
+        return contract;
+      },
+    });
+  } catch (error) {
+    logger.warn("Failed to register built-in CSSProcessor extension", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  return tryResolveContract<CSSProcessor>("CSSProcessor");
+}
+
 function evictOldestCompiler(): void {
   if (compilerCache.size < MAX_CACHED_COMPILERS) return;
 
@@ -108,7 +142,7 @@ export async function getCompiler(
 
   logger.debug("Creating new compiler", { hash, projectSlug });
 
-  const processor = tryResolveContract<CSSProcessor>("CSSProcessor");
+  const processor = await resolveCSSProcessor();
   if (!processor) {
     logger.warn(
       "No CSSProcessor extension registered — CSS output will be empty. Install it with: deno add @veryfront/ext-tailwind",

--- a/src/html/styles-builder/tailwind-default-processor.test.ts
+++ b/src/html/styles-builder/tailwind-default-processor.test.ts
@@ -1,0 +1,59 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  reset as resetContracts,
+  tryResolve as tryResolveContract,
+} from "#veryfront/extensions/contracts.ts";
+import type { CSSProcessor } from "#veryfront/extensions/interfaces/index.ts";
+import { generateTailwindCSS, invalidateCompiler } from "./tailwind-compiler.ts";
+
+const MOCK_TAILWIND_BASE_CSS = "@layer theme, base, components, utilities;";
+
+function mockTailwindFetch(): () => void {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((input: URL | Request | string) => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.toString()
+      : input.url;
+
+    if (!url.includes("tailwindcss")) {
+      return Promise.reject(new Error(`Unexpected fetch URL during test: ${url}`));
+    }
+
+    return Promise.resolve(new Response(MOCK_TAILWIND_BASE_CSS, { status: 200 }));
+  }) as typeof fetch;
+
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}
+
+describe("styles-builder/tailwind default CSSProcessor", () => {
+  let restoreFetch: (() => void) | undefined;
+
+  beforeEach(() => {
+    resetContracts();
+    invalidateCompiler();
+    restoreFetch = mockTailwindFetch();
+  });
+
+  afterEach(() => {
+    restoreFetch?.();
+    restoreFetch = undefined;
+    resetContracts();
+    invalidateCompiler();
+  });
+
+  it("uses the built-in Tailwind processor when no project extension registered one", async () => {
+    const result = await generateTailwindCSS(
+      '@import "tailwindcss";/*vf-default-css-processor*/',
+      ["text-red-500"],
+      { minify: true, projectSlug: "vf-default-css-processor" },
+    );
+
+    assertEquals(result.error, undefined);
+    assertEquals(tryResolveContract<CSSProcessor>("CSSProcessor") !== undefined, true);
+  });
+});

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.320";
+export const VERSION = "0.1.321";


### PR DESCRIPTION
## Summary
- lazily registers the bundled ext-tailwind CSSProcessor when the extension registry is empty
- keeps project/bootstrapped CSSProcessor implementations ahead of the built-in fallback
- bumps veryfront to v0.1.321 for release

## Verification
- RED: `deno test --no-check --allow-all src/html/styles-builder/tailwind-default-processor.test.ts` failed before the source fix because no CSSProcessor was registered and the empty-CSS warning path ran
- GREEN: `deno test --no-check --allow-all src/html/styles-builder/tailwind-default-processor.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts src/html/styles-builder/tailwind-compiler-cache.ts src/html/styles-builder/tailwind-default-processor.test.ts`
- `deno check src/html/styles-builder/tailwind-compiler-cache.ts src/html/styles-builder/tailwind-default-processor.test.ts src/utils/version-constant.ts`
- `deno test --no-check --allow-all src/html/styles-builder/tailwind-default-processor.test.ts src/html/styles-builder/tailwind-compiler-regression.test.ts src/utils/version.test.ts`
- `deno lint src/html/styles-builder/tailwind-compiler-cache.ts src/html/styles-builder/tailwind-default-processor.test.ts src/utils/version-constant.ts`