### PR TITLE
Keep hosted OpenAI models available without project extensions

### DIFF
--- a/src/embedding/veryfront-cloud/provider.ts
+++ b/src/embedding/veryfront-cloud/provider.ts
@@ -7,6 +7,7 @@ import {
   parseVeryfrontCloudModelId,
   requireVeryfrontCloudBootstrap,
 } from "#veryfront/provider/veryfront-cloud/shared.ts";
+import { createVeryfrontCloudOpenAIEmbeddingModel } from "#veryfront/provider/veryfront-cloud/openai.ts";
 
 export function createVeryfrontCloudEmbeddingModel(modelId: string): EmbeddingRuntime {
   const { provider, modelId: upstreamModelId } = parseVeryfrontCloudModelId(modelId, "embedding");
@@ -16,9 +17,11 @@ export function createVeryfrontCloudEmbeddingModel(modelId: string): EmbeddingRu
 
   switch (provider) {
     case "openai":
-      throw new Error(
-        "OpenAI provider not installed. Add @veryfront/ext-openai to use openai embedding models via veryfront-cloud.",
-      );
+      return createVeryfrontCloudOpenAIEmbeddingModel(upstreamModelId, {
+        apiToken,
+        baseURL,
+        fetch,
+      });
 
     case "google":
       return createGoogleEmbeddingRuntime({

--- a/src/provider/veryfront-cloud/openai.ts
+++ b/src/provider/veryfront-cloud/openai.ts
@@ -1,0 +1,34 @@
+import type { EmbeddingRuntime, ModelRuntime } from "#veryfront/provider/types.ts";
+import { OpenAIProvider } from "../../../extensions/ext-openai/src/openai-provider.ts";
+
+const openAIProvider = new OpenAIProvider();
+
+interface VeryfrontCloudOpenAIConfig {
+  apiToken: string;
+  baseURL: string;
+  fetch: typeof globalThis.fetch;
+}
+
+export function createVeryfrontCloudOpenAIModel(
+  modelId: string,
+  config: VeryfrontCloudOpenAIConfig,
+): ModelRuntime {
+  return openAIProvider.createModel(modelId, {
+    credential: config.apiToken,
+    baseURL: config.baseURL,
+    name: "veryfront-cloud",
+    fetch: config.fetch,
+  });
+}
+
+export function createVeryfrontCloudOpenAIEmbeddingModel(
+  modelId: string,
+  config: VeryfrontCloudOpenAIConfig,
+): EmbeddingRuntime {
+  return openAIProvider.createEmbedding(modelId, {
+    credential: config.apiToken,
+    baseURL: config.baseURL,
+    name: "veryfront-cloud",
+    fetch: config.fetch,
+  });
+}

--- a/src/provider/veryfront-cloud/provider.test.ts
+++ b/src/provider/veryfront-cloud/provider.test.ts
@@ -33,37 +33,33 @@ describe("provider/veryfront-cloud", () => {
     clearEmbeddingProviders();
   });
 
-  it("throws when resolving veryfront-cloud openai models without ext-openai installed", () => {
+  it("resolves veryfront-cloud openai models without project ext-openai installed", () => {
     setCloudBootstrap();
 
-    // ext-openai is not registered in this test — expect the install hint.
-    assertThrows(
-      () => resolveModel("veryfront-cloud/openai/gpt-5.2"),
-      Error,
-      "OpenAI provider not installed",
-    );
+    const model = resolveModel("veryfront-cloud/openai/gpt-5.2") as Record<string, unknown>;
+
+    assertEquals(typeof model.doGenerate, "function");
+    assertEquals(typeof model.doStream, "function");
   });
 
-  it("throws when resolving veryfront-cloud moonshotai models without ext-openai installed", () => {
+  it("resolves veryfront-cloud moonshotai models without project ext-openai installed", () => {
     setCloudBootstrap();
 
-    // moonshotai routes through the openai provider, which requires ext-openai.
-    assertThrows(
-      () => resolveModel("veryfront-cloud/moonshotai/kimi-k2"),
-      Error,
-      "OpenAI provider not installed",
-    );
+    const model = resolveModel("veryfront-cloud/moonshotai/kimi-k2") as Record<string, unknown>;
+
+    assertEquals(typeof model.doGenerate, "function");
+    assertEquals(typeof model.doStream, "function");
   });
 
-  it("throws when resolving veryfront-cloud openai embedding models without ext-openai installed", () => {
+  it("resolves veryfront-cloud openai embedding models without project ext-openai installed", () => {
     setCloudBootstrap();
 
-    // OpenAI embedding requires ext-openai.
-    assertThrows(
-      () => resolveEmbeddingModel("veryfront-cloud/openai/text-embedding-3-small"),
-      Error,
-      "OpenAI provider not installed",
-    );
+    const model = resolveEmbeddingModel("veryfront-cloud/openai/text-embedding-3-small") as Record<
+      string,
+      unknown
+    >;
+
+    assertEquals(typeof model.doEmbed, "function");
   });
 
   it("prefers the default veryfront-cloud model when cloud bootstrap is active", () => {

--- a/src/provider/veryfront-cloud/provider.ts
+++ b/src/provider/veryfront-cloud/provider.ts
@@ -10,6 +10,7 @@ import {
   parseVeryfrontCloudModelId,
   requireVeryfrontCloudBootstrap,
 } from "./shared.ts";
+import { createVeryfrontCloudOpenAIModel } from "./openai.ts";
 
 export function createVeryfrontCloudModel(modelId: string): ModelRuntime {
   const { provider, modelId: upstreamModelId } = parseVeryfrontCloudModelId(modelId, "language");
@@ -61,9 +62,11 @@ export function createVeryfrontCloudModel(modelId: string): ModelRuntime {
           fetch,
         });
       }
-      throw new Error(
-        "OpenAI provider not installed. Add @veryfront/ext-openai to use openai/moonshotai models via veryfront-cloud.",
-      );
+      return createVeryfrontCloudOpenAIModel(upstreamModelId, {
+        apiToken,
+        baseURL,
+        fetch,
+      });
     }
 
     default: {


### PR DESCRIPTION
## Summary
- route veryfront-cloud OpenAI/Moonshot language models through the bundled ext-openai provider when no project extension is registered
- route veryfront-cloud OpenAI embeddings through the same bundled provider
- update provider tests from expected install-hint failures to runnable hosted model/embedding runtime creation

## Verification
- PASS: red test first: provider test failed on OpenAI/Moonshot language and OpenAI embedding missing provider errors
- PASS: deno test --allow-env --allow-net=api.openai.com,api.anthropic.com,generativelanguage.googleapis.com,api.veryfront.com src/provider/veryfront-cloud/provider.test.ts src/embedding/model-resolution.test.ts
- PASS: DENO_NO_PACKAGE_JSON=1 deno lint src/provider/veryfront-cloud/provider.ts src/provider/veryfront-cloud/openai.ts src/embedding/veryfront-cloud/provider.ts src/provider/veryfront-cloud/provider.test.ts
- PASS: deno fmt --check src/ cli/
- PASS: deno task typecheck
- PASS: lsp_diagnostics on changed TS files returned 0 errors

## Production evidence
Grafana showed recurring veryfront-server internal agent stream failures for veryfront-cloud/openai setup because ext-openai was not registered. This fixes the source routing failure rather than downgrading logs.

## Notes
Full deno task test was not run; focused provider/embedding tests and full typecheck were run.