### PR TITLE
fix: register ext-jwt in proxy for AuthProvider contract

### DIFF
--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -23,6 +23,8 @@
 import { createProxyHandler, INTERNAL_PROXY_HEADERS, type ProxyConfig } from "./handler.ts";
 import { createCacheFromEnv } from "./cache/index.ts";
 import { isRetryableConnectionError } from "./retry.ts";
+import { register } from "../extensions/contracts.ts";
+import { createAuthProvider } from "../../extensions/ext-jwt/src/index.ts";
 import {
   endSpan,
   extractContext,
@@ -109,6 +111,8 @@ const VERYFRONT_SERVER_RETRY_COUNT = parseInt(
 const VERYFRONT_SERVER_RETRY_DELAY_MS = parseInt(
   getEnv("VERYFRONT_SERVER_RETRY_DELAY_MS") || String(DEFAULT_SERVER_RETRY_DELAY_MS),
 );
+
+register("AuthProvider", createAuthProvider({}));
 
 // Initialize cache and proxy handler
 const cache = await createCacheFromEnv();

--- a/src/proxy/proxy-auth-provider.test.ts
+++ b/src/proxy/proxy-auth-provider.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
+import { register, reset, resolve, tryResolve } from "../extensions/contracts.ts";
+import { createAuthProvider } from "../../extensions/ext-jwt/src/index.ts";
+import type { AuthProvider } from "../extensions/interfaces/auth-provider.ts";
+
+describe("Proxy AuthProvider contract registration", {
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, () => {
+  it("ext-jwt registers a valid AuthProvider", () => {
+    reset();
+    const provider = createAuthProvider({});
+    register("AuthProvider", provider);
+
+    const resolved = tryResolve<AuthProvider>("AuthProvider");
+    assertNotEquals(resolved, undefined);
+    assertEquals(typeof resolved!.verify, "function");
+    assertEquals(typeof resolved!.sign, "function");
+    assertEquals(typeof resolved!.decode, "function");
+    assertEquals(typeof resolved!.verifyWithJwks, "function");
+    reset();
+  });
+
+  it("resolve throws when AuthProvider is not registered", () => {
+    reset();
+    let threw = false;
+    try {
+      resolve<AuthProvider>("AuthProvider");
+    } catch {
+      threw = true;
+    }
+    assertEquals(threw, true);
+    reset();
+  });
+});


### PR DESCRIPTION
## Summary

- The proxy server (split mode) does not run `orchestrateExtensions()`, so the `AuthProvider` contract was never registered after ext-jwt was extracted in #1184
- This caused `{"error":"Internal Proxy Error","message":"Missing extension for contract \"AuthProvider\""}` on protected preview environments
- Registers `ext-jwt` explicitly in `proxy/main.ts` before handling requests
- Adds a regression test verifying contract resolution

## Context

Production incident on 2026-04-29: accidental deployment jumped from v0.1.9 to v0.1.321, exposing this latent regression. The bug has existed since v0.1.218 but only affects protected preview environments.

## Test plan

- [x] `deno test src/proxy/` — all 14 test files (153 steps) pass
- [x] `deno check src/proxy/main.ts` — typecheck passes
- [ ] Deploy and verify `test-f859276d.preview.veryfront.com` no longer returns JSON error