### PR TITLE
Publish host tool materialization for adapters

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.322",
+  "version": "0.1.323",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.322";
+export const VERSION = "0.1.323";


### PR DESCRIPTION
## Summary\n- bump framework package version to 0.1.323 so the merged host-tool materializer is publishable\n- keep the hard-coded runtime version in sync with deno.json\n- unblock downstream hosts from deleting local tool compatibility glue and using the shared veryfront/tool path\n\n## Verification\n- deno fmt --check deno.json src/utils/version-constant.ts\n- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts\n- pre-push checks: formatting, lint, typecheck, unit tests