### PR TITLE
Expose fork runtime step helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.327",
+  "version": "0.1.328",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/fork-runtime-stream.test.ts
+++ b/src/agent/fork-runtime-stream.test.ts
@@ -1,13 +1,17 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
-import type { Message as AgentMessage } from "./schemas/index.ts";
+import type { AgentResponse, Message as AgentMessage } from "./schemas/index.ts";
 import {
+  buildForkRuntimeStepFromResponse,
   buildRecoveredStepParts,
   createFrameworkStreamState,
+  createInitialForkRuntimeMessages,
   createStreamedStepState,
   type ForkRuntimeStep,
   mapFrameworkEventToForkParts,
+  resolveForkRuntimeContinuationState,
   resolveForkStepResponse,
+  shouldContinueForkRuntimeStep,
 } from "./fork-runtime-stream.ts";
 
 describe("agent/fork-runtime-stream", () => {
@@ -154,5 +158,90 @@ describe("agent/fork-runtime-stream", () => {
     );
     assertEquals(response.status, "completed");
     assertExists(response.messages.find((message) => message.role === "assistant"));
+  });
+
+  it("builds fork runtime steps and continuation decisions from agent responses", () => {
+    const response: AgentResponse = {
+      text: "Saved.",
+      messages: [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          parts: [{
+            type: "tool-create_file",
+            toolCallId: "tool-1",
+            toolName: "create_file",
+            args: { path: "plans/a.md" },
+          }],
+        },
+      ],
+      toolCalls: [
+        {
+          id: "tool-1",
+          name: "create_file",
+          args: { path: "plans/a.md" },
+          status: "completed",
+          result: { path: "plans/a.md", success: true },
+        },
+      ],
+      status: "completed",
+      metadata: { finishReason: "tool-calls" },
+    };
+
+    const step = buildForkRuntimeStepFromResponse(response);
+
+    assertEquals(step, {
+      text: "Saved.",
+      messages: response.messages,
+      toolCalls: [{ toolCallId: "tool-1", toolName: "create_file", input: { path: "plans/a.md" } }],
+      toolResults: [{
+        toolCallId: "tool-1",
+        toolName: "create_file",
+        input: { path: "plans/a.md" },
+        output: { path: "plans/a.md", success: true },
+      }],
+      finishReason: "tool-calls",
+    });
+    assertEquals(shouldContinueForkRuntimeStep(step, response), true);
+  });
+
+  it("creates initial fork messages and resolves constrained continuation state", async () => {
+    const initialMessages: AgentMessage[] = [
+      {
+        id: "user-1",
+        role: "user",
+        timestamp: 1,
+        parts: [{ type: "text", text: "Existing context" }],
+      },
+    ];
+    const messages = createInitialForkRuntimeMessages({
+      initialMessages,
+      prompt: "Continue the task.",
+    });
+
+    assertEquals(messages.length, 2);
+    assertEquals(messages[0]?.parts, [{ type: "text", text: "Existing context" }]);
+    assertEquals(messages[1]?.role, "user");
+    assertEquals(messages[1]?.parts, [{ type: "text", text: "Continue the task." }]);
+
+    const continuation = await resolveForkRuntimeContinuationState({
+      continuationStepsRemaining: 1,
+      step: {
+        text: "Ready.",
+        messages: [],
+        toolCalls: [],
+        toolResults: [],
+        finishReason: "stop",
+      },
+      currentMessages: messages,
+      stepIndex: 0,
+      onBeforeStop: () => "Write the artifact now.",
+    });
+
+    assertExists(continuation);
+    assertEquals(continuation.continuationStepsRemaining, 0);
+    assertEquals(continuation.currentMessages.at(-1)?.parts, [
+      { type: "text", text: "Write the artifact now." },
+    ]);
   });
 });

--- a/src/agent/fork-runtime-stream.ts
+++ b/src/agent/fork-runtime-stream.ts
@@ -234,6 +234,112 @@ export async function runFrameworkForkStep(input: {
   };
 }
 
+export type ForkRuntimeContinuationPromptResolver = (input: {
+  step: ForkRuntimeStep;
+  stepIndex: number;
+}) => Promise<string | null> | string | null;
+
+export function buildForkRuntimeStepFromResponse(response: AgentResponse): ForkRuntimeStep {
+  const toolCalls = response.toolCalls.map((toolCall) => ({
+    toolCallId: toolCall.id,
+    toolName: toolCall.name,
+    input: toolCall.args,
+  }));
+  const toolResults = response.toolCalls.flatMap((toolCall) =>
+    toolCall.status === "completed"
+      ? [
+        {
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+          input: toolCall.args,
+          output: toolCall.result,
+        },
+      ]
+      : []
+  );
+  const finishReasonValue = response.metadata?.finishReason;
+
+  return {
+    text: response.text,
+    messages: structuredClone(response.messages),
+    toolCalls,
+    toolResults,
+    finishReason: typeof finishReasonValue === "string" ? finishReasonValue : null,
+  };
+}
+
+export function shouldContinueForkRuntimeStep(
+  step: ForkRuntimeStep,
+  response: AgentResponse,
+): boolean {
+  return step.finishReason === "tool-calls" &&
+    response.toolCalls.some((toolCall) => toolCall.status !== "error");
+}
+
+export function createForkRuntimeUserMessage(input: {
+  text: string;
+  id?: string;
+  timestamp?: number;
+}): AgentMessage {
+  return {
+    id: input.id ?? crypto.randomUUID(),
+    role: "user",
+    parts: [{ type: "text", text: input.text }],
+    timestamp: input.timestamp ?? Date.now(),
+  };
+}
+
+export function createInitialForkRuntimeMessages(input: {
+  initialMessages?: readonly AgentMessage[];
+  prompt?: string;
+}): AgentMessage[] {
+  const currentMessages = input.initialMessages?.map((message) => ({
+    ...message,
+    parts: [...message.parts],
+  })) ?? [];
+
+  if (typeof input.prompt !== "string") {
+    return currentMessages;
+  }
+
+  return [...currentMessages, createForkRuntimeUserMessage({ text: input.prompt })];
+}
+
+export function getMaxForkRuntimeStepCount(input: {
+  maxSteps: number;
+  maxContinuationSteps?: number;
+}): number {
+  return input.maxSteps + (input.maxContinuationSteps ?? 0);
+}
+
+export async function resolveForkRuntimeContinuationState(input: {
+  continuationStepsRemaining: number;
+  onBeforeStop?: ForkRuntimeContinuationPromptResolver;
+  step: ForkRuntimeStep;
+  currentMessages: AgentMessage[];
+  stepIndex: number;
+}): Promise<{ continuationStepsRemaining: number; currentMessages: AgentMessage[] } | null> {
+  if (input.continuationStepsRemaining <= 0 || !input.onBeforeStop) {
+    return null;
+  }
+
+  const continuationPrompt = await input.onBeforeStop({
+    step: input.step,
+    stepIndex: input.stepIndex,
+  });
+  if (typeof continuationPrompt !== "string" || continuationPrompt.trim().length === 0) {
+    return null;
+  }
+
+  return {
+    continuationStepsRemaining: input.continuationStepsRemaining - 1,
+    currentMessages: [
+      ...input.currentMessages,
+      createForkRuntimeUserMessage({ text: continuationPrompt }),
+    ],
+  };
+}
+
 export function createStreamedStepState(): StreamedStepState {
   return {
     text: "",

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -241,19 +241,26 @@ export {
 } from "./ag-ui-tracked-browser-response.ts";
 export {
   applyPartToStreamedStepState,
+  buildForkRuntimeStepFromResponse,
   buildRecoveredStepParts,
+  createForkRuntimeUserMessage,
   createFrameworkStreamState,
+  createInitialForkRuntimeMessages,
   createStreamedStepState,
   DEFAULT_FORK_RESPONSE_PROMISE_TIMEOUT_MS,
   type ForkPart,
   type ForkRecoveredPartsState,
+  type ForkRuntimeContinuationPromptResolver,
   type ForkRuntimeStep,
   type ForkRuntimeStreamLogger,
   type ForkRuntimeStreamResult,
   type FrameworkStreamState,
+  getMaxForkRuntimeStepCount,
   mapFrameworkEventToForkParts,
+  resolveForkRuntimeContinuationState,
   resolveForkStepResponse,
   runFrameworkForkStep,
+  shouldContinueForkRuntimeStep,
 } from "./fork-runtime-stream.ts";
 export {
   executeHostedChildForkStream,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.327";
+export const VERSION = "0.1.328";


### PR DESCRIPTION
## Summary\n- expose reusable fork runtime response-to-step helpers\n- expose initial-message and constrained-continuation helpers\n- bump framework package version to 0.1.328 for CI/CD publishing\n\n## Verification\n- deno test --no-check --allow-all src/agent/fork-runtime-stream.test.ts\n- deno check src/agent/index.ts src/agent/fork-runtime-stream.ts src/agent/fork-runtime-stream.test.ts\n- deno task verify:quick\n- deno task audit\n- deno task build:npm\n- pre-push format/lint/typecheck/unit tests