### PR TITLE
Expose hosted child file write fallback

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.328",
+  "version": "0.1.329",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-artifact-support.test.ts
+++ b/src/agent/hosted-child-artifact-support.test.ts
@@ -4,6 +4,7 @@ import {
   isHostedChildCreateFileAlreadyExistsResult,
   isHostedChildTextProjectArtifactPrompt,
   normalizeHostedChildArtifactPath,
+  withHostedChildRerunnableFileWriteFallbacks,
 } from "./hosted-child-artifact-support.ts";
 
 Deno.test("isHostedChildTextProjectArtifactPrompt recognizes markdown artifact cues", () => {
@@ -115,4 +116,75 @@ Deno.test("getHostedChildWrittenArtifactPath ignores non-writing tools, failed w
     }),
     null,
   );
+});
+
+Deno.test("withHostedChildRerunnableFileWriteFallbacks retries existing create_file results through update_file", async () => {
+  const updateInputs: unknown[] = [];
+  const infoLogs: unknown[] = [];
+  const tools = withHostedChildRerunnableFileWriteFallbacks({
+    tools: {
+      create_file: {
+        execute: () => ({
+          isError: true,
+          content: [{ type: "text", text: "File already exists at /plans/report.md" }],
+        }),
+      },
+      update_file: {
+        execute: (input) => {
+          updateInputs.push(input);
+          return { success: true };
+        },
+      },
+    },
+    logger: {
+      info: (_message, metadata) => {
+        infoLogs.push(metadata);
+      },
+    },
+  });
+
+  const result = await tools.create_file?.execute?.({
+    project_reference: "project-1",
+    branch_id: "branch-1",
+    path: "/plans/report.md",
+    content: "# Report",
+  });
+
+  assertEquals(result, { success: true });
+  assertEquals(updateInputs, [{
+    project_reference: "project-1",
+    branch_id: "branch-1",
+    path: "/plans/report.md",
+    content: "# Report",
+  }]);
+  assertEquals(infoLogs, [{ path: "/plans/report.md" }]);
+});
+
+Deno.test("withHostedChildRerunnableFileWriteFallbacks keeps original result when fallback inputs are missing", async () => {
+  const originalResult = {
+    isError: true,
+    content: [{ type: "text", text: "File already exists at /plans/report.md" }],
+  };
+  let updateCallCount = 0;
+  const tools = withHostedChildRerunnableFileWriteFallbacks({
+    tools: {
+      create_file: {
+        execute: () => originalResult,
+      },
+      update_file: {
+        execute: () => {
+          updateCallCount += 1;
+          return { success: true };
+        },
+      },
+    },
+  });
+
+  const result = await tools.create_file?.execute?.({
+    path: "/plans/report.md",
+    content: "# Report",
+  });
+
+  assertEquals(result, originalResult);
+  assertEquals(updateCallCount, 0);
 });

--- a/src/agent/hosted-child-artifact-support.ts
+++ b/src/agent/hosted-child-artifact-support.ts
@@ -1,3 +1,6 @@
+import type { ToolExecutionContext } from "#veryfront/tool";
+import { toChildRunToolInputRecord } from "./child-run-execution-support.ts";
+
 const TEXT_PROJECT_ARTIFACT_CUE_PATTERN =
   /\b(markdown|reference document|research report|report|write-up|writeup|save it to the project|save everything to the project|save the results to the project|compile everything into a single well-structured markdown file)\b/i;
 const TEXT_PROJECT_ARTIFACT_PATH_PATTERN = /(?:^|[\s`"'(])(?:[\w./-]+\/)?[\w.-]+\.md\b/i;
@@ -12,6 +15,81 @@ export interface HostedChildWrittenArtifactPathInput {
   toolInput: unknown;
   toolOutput: unknown;
   writingToolNames?: readonly string[];
+}
+
+export type HostedChildFileWriteFallbackToolExecute = (
+  toolInput: unknown,
+  execOptions?: ToolExecutionContext,
+) => Promise<unknown> | unknown;
+
+export interface HostedChildFileWriteFallbackTool {
+  execute?: HostedChildFileWriteFallbackToolExecute;
+}
+
+export interface HostedChildFileWriteFallbackLogger {
+  info?: (message: string, metadata?: Record<string, unknown>) => void;
+}
+
+export function withHostedChildRerunnableFileWriteFallbacks(input: {
+  tools: Record<string, HostedChildFileWriteFallbackTool>;
+  createToolName?: string;
+  updateToolName?: string;
+  logger?: HostedChildFileWriteFallbackLogger;
+}): Record<string, HostedChildFileWriteFallbackTool> {
+  const createToolName = input.createToolName ?? "create_file";
+  const updateToolName = input.updateToolName ?? "update_file";
+  const createFileTool = input.tools[createToolName];
+  const updateFileTool = input.tools[updateToolName];
+
+  if (!createFileTool?.execute || !updateFileTool?.execute) {
+    return input.tools;
+  }
+
+  const createFileExecute = createFileTool.execute;
+  const updateFileExecute = updateFileTool.execute;
+
+  return {
+    ...input.tools,
+    [createToolName]: {
+      ...createFileTool,
+      execute: async (toolInput: unknown, execOptions?: ToolExecutionContext) => {
+        const normalizedToolInput = toChildRunToolInputRecord(toolInput);
+        const result = await createFileExecute(toolInput, execOptions);
+        if (!isHostedChildCreateFileAlreadyExistsResult(result)) {
+          return result;
+        }
+
+        const projectReference = normalizedToolInput.project_reference;
+        const branchId = normalizedToolInput.branch_id;
+        const path = normalizedToolInput.path;
+        const content = normalizedToolInput.content;
+
+        if (
+          typeof projectReference !== "string" || typeof path !== "string" ||
+          typeof content !== "string"
+        ) {
+          return result;
+        }
+
+        input.logger?.info?.(
+          "Falling back from create_file to update_file for existing project artifact",
+          {
+            path,
+          },
+        );
+
+        return updateFileExecute(
+          {
+            project_reference: projectReference,
+            ...(typeof branchId === "string" ? { branch_id: branchId } : {}),
+            path,
+            content,
+          },
+          execOptions,
+        );
+      },
+    },
+  };
 }
 
 export function isHostedChildTextProjectArtifactPrompt(prompt: string): boolean {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -395,10 +395,14 @@ export {
 } from "./hosted-child-requested-tools.ts";
 export {
   getHostedChildWrittenArtifactPath,
+  type HostedChildFileWriteFallbackLogger,
+  type HostedChildFileWriteFallbackTool,
+  type HostedChildFileWriteFallbackToolExecute,
   type HostedChildWrittenArtifactPathInput,
   isHostedChildCreateFileAlreadyExistsResult,
   isHostedChildTextProjectArtifactPrompt,
   normalizeHostedChildArtifactPath,
+  withHostedChildRerunnableFileWriteFallbacks,
 } from "./hosted-child-artifact-support.ts";
 export {
   buildHostedChildCompletedLog,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.328";
+export const VERSION = "0.1.329";


### PR DESCRIPTION
## Summary\n- expose a reusable hosted-child create_file→update_file fallback helper\n- add coverage for existing-file fallback and missing-input behavior\n- bump framework package version to 0.1.329 for CI/CD publishing\n\n## Verification\n- deno check src/agent/index.ts src/agent/hosted-child-artifact-support.ts src/agent/hosted-child-artifact-support.test.ts\n- deno test --no-check --allow-all src/agent/hosted-child-artifact-support.test.ts\n- deno task verify:quick\n- deno task audit\n- deno task build:npm\n- pre-push format/lint/typecheck/unit tests