### PR TITLE
Expose hosted child failure handling

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.330",
+  "version": "0.1.331",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-fork-stream-execution.test.ts
+++ b/src/agent/hosted-child-fork-stream-execution.test.ts
@@ -1,7 +1,8 @@
-import { assertEquals, assertExists } from "#veryfront/testing/assert";
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import {
   executeHostedChildForkStream,
+  handleHostedChildForkFailure,
   type HostedChildForkPendingToolLifecycle,
 } from "./hosted-child-fork-stream-execution.ts";
 import type { ForkPart, ForkRuntimeStep } from "./fork-runtime-stream.ts";
@@ -126,5 +127,55 @@ describe("hosted child fork stream execution", () => {
       chunks.find((chunk) => typeof chunk === "object" && chunk !== null && "type" in chunk),
     );
     assertEquals(writeLogs.length, 1);
+  });
+
+  it("builds failure result and snapshot for child fork errors", async () => {
+    const writeLogs: unknown[] = [];
+    const snapshots: unknown[] = [];
+
+    const result = await handleHostedChildForkFailure({
+      error: new Error("Model failed"),
+      description: "Inspect repo",
+      kind: "invoke_agent",
+      finalText: "partial",
+      toolCalls: [{ toolName: "read_file", toolCallId: "tool-1", input: { path: "README.md" } }],
+      toolResults: [{ toolName: "read_file", toolCallId: "tool-1", input: {}, output: {} }],
+      usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+      startTime: Date.now(),
+      onSettled: (snapshot) => {
+        snapshots.push(snapshot);
+      },
+      writeLog: (entry) => {
+        writeLogs.push(entry);
+      },
+    });
+
+    assertEquals(result.success, false);
+    if (!result.success) {
+      assertEquals(result.error, "Model failed");
+    }
+    assertEquals(result.steps, 1);
+    assertEquals(result.toolCalls.length, 1);
+    assertEquals(result.toolResults.length, 1);
+    assertEquals(snapshots.length, 1);
+    assertEquals(writeLogs.length, 1);
+  });
+
+  it("rethrows child fork errors when host policy requires it", async () => {
+    await assertRejects(
+      () =>
+        handleHostedChildForkFailure({
+          error: new Error("Insufficient credits"),
+          description: "Inspect repo",
+          kind: "invoke_agent",
+          finalText: "",
+          toolCalls: [],
+          toolResults: [],
+          startTime: Date.now(),
+          shouldRethrowError: () => true,
+        }),
+      Error,
+      "Insufficient credits",
+    );
   });
 });

--- a/src/agent/hosted-child-fork-stream-execution.ts
+++ b/src/agent/hosted-child-fork-stream-execution.ts
@@ -34,6 +34,7 @@ import {
 } from "./child-run-result-summary.ts";
 import {
   buildHostedChildCompletedLog,
+  buildHostedChildErrorLog,
   buildHostedChildExhaustedStepBudgetLog,
   type HostedChildExecutionLogEntry,
 } from "./hosted-child-execution-logging.ts";
@@ -113,6 +114,20 @@ export interface ExecuteHostedChildForkStreamInput {
   logger?: HostedChildForkStreamLogger;
   writeLog?: (entry: HostedChildExecutionLogEntry) => void;
   tracePart?: (input: HostedChildForkStreamTraceInput) => void | Promise<void>;
+}
+
+export interface HandleHostedChildForkFailureInput {
+  error: unknown;
+  description: string;
+  kind: string;
+  finalText: string;
+  toolCalls: Array<{ toolName: string; toolCallId: string; input?: unknown }>;
+  toolResults: Array<{ toolName: string; toolCallId: string; input: unknown; output: unknown }>;
+  usage?: ChildRunExecutionUsage;
+  startTime: number;
+  onSettled?: (snapshot: ChildRunExecutionSnapshot) => void | Promise<void>;
+  shouldRethrowError?: (error: unknown) => boolean;
+  writeLog?: (entry: HostedChildExecutionLogEntry) => void;
 }
 
 function isSoftIdleHeartbeatPhase(phase: HostedChildStreamWatchdogState["phase"]): boolean {
@@ -246,6 +261,38 @@ export async function finalizeHostedChildForkCompletion(input: {
   const snapshot = buildChildRunSuccessSnapshot(common, finalText);
   await input.onSettled?.(snapshot);
   return buildChildRunSuccessResult(common, buildChildRunResultSummary(finalText));
+}
+
+export async function handleHostedChildForkFailure(
+  input: HandleHostedChildForkFailureInput,
+): Promise<ChildRunExecutionResult> {
+  input.writeLog?.(
+    buildHostedChildErrorLog({
+      description: input.description,
+      kind: input.kind,
+      error: input.error,
+      finalText: input.finalText,
+      toolCallsLength: input.toolCalls.length,
+      toolResultsLength: input.toolResults.length,
+    }),
+  );
+
+  if (input.shouldRethrowError?.(input.error)) {
+    throw input.error;
+  }
+
+  const errorText = input.error instanceof Error ? input.error.message : "Unknown error";
+  const common = buildChildRunResultCommon({
+    description: input.description,
+    steps: input.toolCalls.length,
+    toolCalls: input.toolCalls,
+    toolResults: input.toolResults,
+    usage: input.usage,
+    durationMs: Date.now() - input.startTime,
+  });
+  const snapshot = buildChildRunFailureSnapshot(common, errorText, input.finalText || null);
+  await input.onSettled?.(snapshot);
+  return buildChildRunFailureResult(common, errorText);
 }
 
 export async function handleHostedChildForkStreamPart(input: {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -266,6 +266,8 @@ export {
   executeHostedChildForkStream,
   type ExecuteHostedChildForkStreamInput,
   finalizeHostedChildForkCompletion,
+  handleHostedChildForkFailure,
+  type HandleHostedChildForkFailureInput,
   handleHostedChildForkStreamPart,
   type HostedChildForkPendingToolLifecycle,
   type HostedChildForkStreamHandlingState,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.330";
+export const VERSION = "0.1.331";


### PR DESCRIPTION
Expose a reusable hosted child fork failure helper and bump package version to 0.1.331.\n\nVerification:\n- deno test --no-check --allow-all src/agent/hosted-child-fork-stream-execution.test.ts\n- deno check src/agent/index.ts src/agent/hosted-child-fork-stream-execution.ts src/agent/hosted-child-fork-stream-execution.test.ts\n- deno task verify:quick\n- deno task audit\n- deno task build:npm\n- pre-push format/lint/typecheck/unit tests