### PR TITLE
Expose framework message conversion helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.331",
+  "version": "0.1.332",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/framework-message-adapter.test.ts
+++ b/src/agent/framework-message-adapter.test.ts
@@ -1,0 +1,198 @@
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
+import type { ChatModelMessage, ChatToolResultOutput, ChatToolResultPart } from "../chat/types.ts";
+import {
+  convertFrameworkMessagesToModelMessages,
+  convertModelMessagesToFrameworkMessages,
+  type FrameworkMessage,
+  type FrameworkMessagePart,
+} from "./framework-message-adapter.ts";
+
+type ModelStructuredPart = Exclude<ChatModelMessage["content"], string>[number];
+
+const TOOL_CALL_ID = "tool-1";
+const TOOL_NAME = "search_files";
+
+function modelMessage(message: ChatModelMessage): ChatModelMessage {
+  return message;
+}
+
+function modelTextPart(text: string): ModelStructuredPart {
+  return { type: "text", text };
+}
+
+function modelToolCallPart(input: Record<string, unknown>): ModelStructuredPart {
+  return {
+    type: "tool-call",
+    toolCallId: TOOL_CALL_ID,
+    toolName: TOOL_NAME,
+    input,
+  };
+}
+
+function jsonOutput(value: ChatToolResultOutput["value"]): ChatToolResultOutput {
+  return {
+    type: "json",
+    value,
+  };
+}
+
+function modelToolResultPart(output: ChatToolResultOutput): ChatToolResultPart {
+  return {
+    type: "tool-result",
+    toolCallId: TOOL_CALL_ID,
+    toolName: TOOL_NAME,
+    output,
+  };
+}
+
+function frameworkMessage(
+  role: FrameworkMessage["role"],
+  parts: FrameworkMessagePart[],
+  timestamp: number,
+): FrameworkMessage {
+  return {
+    id: `framework-${role}-${timestamp + 1}`,
+    role,
+    parts,
+    timestamp,
+  };
+}
+
+function frameworkTextPart(text: string): FrameworkMessagePart {
+  return { type: "text", text };
+}
+
+function frameworkToolCallPart(
+  args: Record<string, unknown>,
+  type = "tool-call",
+): FrameworkMessagePart {
+  return {
+    type,
+    toolCallId: TOOL_CALL_ID,
+    toolName: TOOL_NAME,
+    args,
+  };
+}
+
+function frameworkToolResultPart(result: unknown): FrameworkMessagePart {
+  return {
+    type: "tool-result",
+    toolCallId: TOOL_CALL_ID,
+    toolName: TOOL_NAME,
+    result,
+  };
+}
+
+describe("framework message adapter", () => {
+  it("converts text, tool-call, and tool-result model messages into framework messages", () => {
+    const frameworkMessages = convertModelMessagesToFrameworkMessages([
+      modelMessage({ role: "system", content: "System instructions" }),
+      modelMessage({
+        role: "assistant",
+        content: [modelTextPart("Searching…"), modelToolCallPart({ query: "chat runtime" })],
+      }),
+      modelMessage({
+        role: "tool",
+        content: [modelToolResultPart(jsonOutput({ matches: 2 }))],
+      }),
+    ]);
+
+    assertEquals(frameworkMessages, [
+      frameworkMessage("system", [frameworkTextPart("System instructions")], 0),
+      frameworkMessage(
+        "assistant",
+        [frameworkTextPart("Searching…"), frameworkToolCallPart({ query: "chat runtime" })],
+        1,
+      ),
+      frameworkMessage("tool", [frameworkToolResultPart(jsonOutput({ matches: 2 }))], 2),
+    ]);
+  });
+
+  it("ignores reasoning-only parts when converting framework messages", () => {
+    const frameworkMessages = convertModelMessagesToFrameworkMessages([
+      modelMessage({
+        role: "assistant",
+        content: [
+          {
+            type: "reasoning",
+            text: "Hidden thinking",
+          },
+          modelTextPart("Visible answer"),
+        ],
+      }),
+    ]);
+
+    assertEquals(frameworkMessages[0]?.parts, [frameworkTextPart("Visible answer")]);
+  });
+
+  it("converts multimodal parts into uploaded-file context annotations", () => {
+    const frameworkMessages = convertModelMessagesToFrameworkMessages([
+      modelMessage({
+        role: "user",
+        content: [
+          {
+            type: "image",
+            data: "ignored",
+            mediaType: "image/png",
+            filename: "diagram.png",
+          },
+          {
+            type: "file",
+            data: "ignored",
+            mediaType: "application/pdf",
+            filename: "spec.pdf",
+            url: "https://example.com/spec.pdf",
+          },
+        ],
+      }),
+    ]);
+
+    assertEquals(frameworkMessages[0]?.parts.length, 1);
+    const firstPart = frameworkMessages[0]?.parts[0];
+    assertEquals(firstPart?.type, "text");
+    if (firstPart && "text" in firstPart) {
+      assertStringIncludes(firstPart.text, "<uploaded_files>");
+      assertStringIncludes(firstPart.text, "diagram.png");
+      assertStringIncludes(firstPart.text, "spec.pdf");
+    }
+  });
+
+  it("converts framework tool-prefixed parts back into model messages", () => {
+    const modelMessages = convertFrameworkMessagesToModelMessages([
+      frameworkMessage("user", [frameworkTextPart("Inspect the rollout state.")], 0),
+      frameworkMessage(
+        "assistant",
+        [
+          frameworkTextPart("Looking now."),
+          frameworkToolCallPart({ query: "rollout" }, "tool-search_files"),
+        ],
+        1,
+      ),
+      frameworkMessage("tool", [frameworkToolResultPart({ matches: 2 })], 2),
+    ]);
+
+    assertEquals(modelMessages, [
+      { role: "user", content: "Inspect the rollout state." },
+      {
+        role: "assistant",
+        content: [modelTextPart("Looking now."), modelToolCallPart({ query: "rollout" })],
+      },
+      {
+        role: "tool",
+        content: [
+          modelToolResultPart(jsonOutput({ matches: 2 })),
+        ],
+      },
+    ]);
+  });
+
+  it("skips empty framework messages that do not contribute model content", () => {
+    const modelMessages = convertFrameworkMessagesToModelMessages([
+      frameworkMessage("assistant", [], 0),
+      frameworkMessage("tool", [], 1),
+    ]);
+
+    assertEquals(modelMessages, []);
+  });
+});

--- a/src/agent/framework-message-adapter.ts
+++ b/src/agent/framework-message-adapter.ts
@@ -1,0 +1,429 @@
+import { isRecord } from "../chat/conversation.ts";
+import {
+  buildDataFileAnnotation,
+  type ChatModelMessage,
+  type ChatToolResultPart,
+  type UploadedFileReference,
+} from "../chat/types.ts";
+import { toChildRunToolInputRecord } from "./child-run-execution-support.ts";
+
+type StructuredModelPart = Exclude<ChatModelMessage["content"], string>[number];
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+type FrameworkMessageLikePart =
+  | { type: "text"; text: string }
+  | {
+    type: string;
+    toolCallId: string;
+    toolName: string;
+    args: Record<string, unknown>;
+  }
+  | {
+    type: string;
+    toolCallId: string;
+    toolName: string;
+    input: Record<string, unknown>;
+  }
+  | {
+    type: "tool-result";
+    toolCallId: string;
+    toolName: string;
+    result: unknown;
+  }
+  | {
+    type: "tool-result";
+    toolCallId: string;
+    toolName: string;
+    output: unknown;
+  };
+
+export type FrameworkMessagePart =
+  | { type: "text"; text: string }
+  | {
+    type: string;
+    toolCallId: string;
+    toolName: string;
+    args: Record<string, unknown>;
+  }
+  | {
+    type: "tool-result";
+    toolCallId: string;
+    toolName: string;
+    result: unknown;
+  };
+
+export interface FrameworkMessage {
+  id: string;
+  role: ChatModelMessage["role"];
+  parts: FrameworkMessagePart[];
+  timestamp: number;
+}
+
+interface FrameworkModelContentParts {
+  textParts: FrameworkModelTextPart[];
+  toolCallParts: FrameworkModelToolCallPart[];
+  toolResultParts: ChatToolResultPart[];
+}
+
+type FrameworkModelTextPart = { type: "text"; text: string };
+
+type FrameworkModelToolCallPart = {
+  type: "tool-call";
+  toolCallId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+};
+
+export class FrameworkMessageConversionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FrameworkMessageConversionError";
+  }
+}
+
+function hasTextContent(text: string): boolean {
+  return text.trim().length > 0;
+}
+
+function getOptionalStringField(part: unknown, key: string): string | undefined {
+  if (!isRecord(part)) {
+    return undefined;
+  }
+
+  const value = part[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function createFrameworkMessageId(message: ChatModelMessage, index: number): string {
+  return `framework-${message.role}-${index + 1}`;
+}
+
+function createTextFrameworkPart(text: string): FrameworkMessagePart | null {
+  return hasTextContent(text) ? { type: "text", text } : null;
+}
+
+function convertStructuredPart(part: StructuredModelPart): FrameworkMessagePart | null {
+  switch (part.type) {
+    case "text":
+      return createTextFrameworkPart(part.text);
+
+    case "reasoning":
+      return null;
+
+    case "tool-call":
+      return {
+        type: "tool-call",
+        toolCallId: part.toolCallId,
+        toolName: part.toolName,
+        args: "input" in part ? toChildRunToolInputRecord(part.input) : {},
+      };
+
+    case "tool-result":
+      return {
+        type: "tool-result",
+        toolCallId: part.toolCallId,
+        toolName: part.toolName,
+        result: "output" in part ? part.output : null,
+      };
+
+    case "image":
+    case "file":
+      return null;
+
+    default: {
+      const exhaustiveCheck: never = part;
+      throw new FrameworkMessageConversionError(
+        `Unsupported framework message part: ${String(exhaustiveCheck)}`,
+      );
+    }
+  }
+}
+
+function createAttachmentReference(part: StructuredModelPart): UploadedFileReference | null {
+  const filename = getOptionalStringField(part, "filename");
+  const mediaType = getOptionalStringField(part, "mediaType");
+  const uploadId = getOptionalStringField(part, "uploadId");
+  const uploadPath = getOptionalStringField(part, "uploadPath");
+  const url = getOptionalStringField(part, "url");
+
+  if (!mediaType) {
+    return null;
+  }
+
+  const normalizedUrl = url?.startsWith("data:") ? undefined : url;
+
+  return {
+    name: filename ?? (part.type === "image" ? "image" : "file"),
+    mediaType,
+    ...(uploadId ? { uploadId } : {}),
+    ...(uploadPath ? { path: uploadPath } : {}),
+    ...(normalizedUrl ? { url: normalizedUrl } : {}),
+  };
+}
+
+function buildAttachmentContextPart(
+  attachmentReferences: UploadedFileReference[],
+): FrameworkMessagePart | null {
+  if (attachmentReferences.length === 0) {
+    return null;
+  }
+
+  return {
+    type: "text",
+    text: `Attached files from earlier conversation context:${
+      buildDataFileAnnotation(attachmentReferences)
+    }`,
+  };
+}
+
+function convertContentToFrameworkParts(message: ChatModelMessage): FrameworkMessage["parts"] {
+  if (typeof message.content === "string") {
+    const textPart = createTextFrameworkPart(message.content);
+    return textPart ? [textPart] : [];
+  }
+
+  const parts: FrameworkMessage["parts"] = [];
+  const attachmentReferences: UploadedFileReference[] = [];
+
+  for (const part of message.content) {
+    if (part.type === "image" || part.type === "file") {
+      const attachmentReference = createAttachmentReference(part);
+      if (attachmentReference) {
+        attachmentReferences.push(attachmentReference);
+      }
+      continue;
+    }
+
+    const convertedPart = convertStructuredPart(part);
+    if (convertedPart) {
+      parts.push(convertedPart);
+    }
+  }
+
+  const attachmentContextPart = buildAttachmentContextPart(attachmentReferences);
+  if (attachmentContextPart) {
+    parts.push(attachmentContextPart);
+  }
+
+  return parts;
+}
+
+function toJsonValue(value: unknown): JsonValue {
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => toJsonValue(item));
+  }
+
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, toJsonValue(entry)]),
+    );
+  }
+
+  return JSON.stringify(value);
+}
+
+function toToolResultOutput(value: unknown): { type: "json"; value: JsonValue } {
+  return {
+    type: "json",
+    value: toJsonValue(value),
+  };
+}
+
+export function getFrameworkTextPart(part: unknown): { type: "text"; text: string } | null {
+  return isRecord(part) && part.type === "text" && typeof part.text === "string"
+    ? { type: "text", text: part.text }
+    : null;
+}
+
+export function getFrameworkToolCallPart(
+  part: unknown,
+): { toolCallId: string; toolName: string; input: Record<string, unknown> } | null {
+  if (!isRecord(part) || typeof part.type !== "string") {
+    return null;
+  }
+
+  if (part.type !== "tool-call" && !part.type.startsWith("tool-")) {
+    return null;
+  }
+
+  const toolCallId = getOptionalStringField(part, "toolCallId");
+  const toolName = getOptionalStringField(part, "toolName") ?? part.type.replace(/^tool-/, "");
+  if (!toolCallId || toolName.length === 0) {
+    return null;
+  }
+
+  return {
+    toolCallId,
+    toolName,
+    input: toChildRunToolInputRecord(part.args ?? part.input),
+  };
+}
+
+export function getFrameworkToolResultPart(
+  part: unknown,
+): { toolCallId: string; toolName: string; output: unknown } | null {
+  if (!isRecord(part) || part.type !== "tool-result") {
+    return null;
+  }
+
+  const toolCallId = getOptionalStringField(part, "toolCallId");
+  const toolName = getOptionalStringField(part, "toolName");
+  if (!toolCallId || !toolName) {
+    return null;
+  }
+
+  return {
+    toolCallId,
+    toolName,
+    output: Object.hasOwn(part, "result") ? part.result : null,
+  };
+}
+
+export function createToolResultPart(part: {
+  toolCallId: string;
+  toolName: string;
+  output: unknown;
+}): ChatToolResultPart {
+  return {
+    type: "tool-result",
+    toolCallId: part.toolCallId,
+    toolName: part.toolName,
+    output: toToolResultOutput(part.output),
+  };
+}
+
+function joinTextParts(textParts: readonly FrameworkModelTextPart[]): string {
+  return textParts.map((part) => part.text).join("\n\n");
+}
+
+function collectFrameworkModelContentParts(
+  parts: ReadonlyArray<FrameworkMessageLikePart>,
+): FrameworkModelContentParts {
+  const textParts: FrameworkModelTextPart[] = [];
+  const toolCallParts: FrameworkModelToolCallPart[] = [];
+  const toolResultParts: ChatToolResultPart[] = [];
+
+  for (const part of parts) {
+    const textPart = getFrameworkTextPart(part);
+    if (textPart) {
+      textParts.push(textPart);
+      continue;
+    }
+
+    const toolResultPart = getFrameworkToolResultPart(part);
+    if (toolResultPart) {
+      toolResultParts.push(createToolResultPart(toolResultPart));
+      continue;
+    }
+
+    const toolCallPart = getFrameworkToolCallPart(part);
+    if (toolCallPart) {
+      toolCallParts.push({
+        type: "tool-call",
+        toolCallId: toolCallPart.toolCallId,
+        toolName: toolCallPart.toolName,
+        input: toolCallPart.input,
+      });
+    }
+  }
+
+  return { textParts, toolCallParts, toolResultParts };
+}
+
+function createModelMessageFromFrameworkMessage(
+  message: Pick<FrameworkMessage, "role"> & { parts: ReadonlyArray<FrameworkMessageLikePart> },
+): ChatModelMessage | null {
+  const { textParts, toolCallParts, toolResultParts } = collectFrameworkModelContentParts(
+    message.parts,
+  );
+
+  switch (message.role) {
+    case "assistant":
+      if (textParts.length === 0 && toolCallParts.length === 0) {
+        return null;
+      }
+
+      return {
+        role: "assistant",
+        content: [...textParts, ...toolCallParts],
+      };
+
+    case "tool":
+      if (toolResultParts.length === 0) {
+        return null;
+      }
+
+      return {
+        role: "tool",
+        content: toolResultParts,
+      };
+
+    case "user": {
+      if (textParts.length === 0) {
+        return null;
+      }
+
+      return {
+        role: "user",
+        content: joinTextParts(textParts),
+      };
+    }
+
+    case "system": {
+      if (textParts.length === 0) {
+        return null;
+      }
+
+      return {
+        role: "system",
+        content: joinTextParts(textParts),
+      };
+    }
+
+    default: {
+      const exhaustiveCheck: never = message.role;
+      throw new FrameworkMessageConversionError(
+        `Unsupported framework message role when converting to model message: ${
+          String(exhaustiveCheck)
+        }`,
+      );
+    }
+  }
+}
+
+export function convertModelMessagesToFrameworkMessages(
+  messages: readonly ChatModelMessage[],
+): FrameworkMessage[] {
+  return messages.map((message, index) => ({
+    id: createFrameworkMessageId(message, index),
+    role: message.role,
+    parts: convertContentToFrameworkParts(message),
+    timestamp: index,
+  }));
+}
+
+export function convertFrameworkMessagesToModelMessages(
+  messages: ReadonlyArray<
+    Pick<FrameworkMessage, "role"> & { parts: ReadonlyArray<FrameworkMessageLikePart> }
+  >,
+): ChatModelMessage[] {
+  const converted: ChatModelMessage[] = [];
+
+  for (const message of messages) {
+    const convertedMessage = createModelMessageFromFrameworkMessage(message);
+    if (convertedMessage) {
+      converted.push(convertedMessage);
+    }
+  }
+
+  return converted;
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -363,6 +363,17 @@ export {
   toChildRunToolInputRecord,
 } from "./child-run-execution-support.ts";
 export {
+  convertFrameworkMessagesToModelMessages,
+  convertModelMessagesToFrameworkMessages,
+  createToolResultPart,
+  type FrameworkMessage,
+  FrameworkMessageConversionError,
+  type FrameworkMessagePart,
+  getFrameworkTextPart,
+  getFrameworkToolCallPart,
+  getFrameworkToolResultPart,
+} from "./framework-message-adapter.ts";
+export {
   type ChildRunExecutionBufferCleanupInput,
   type ChildRunExecutionResourceFinalizeInput,
   closeChildRunExecutionBuffers,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.331";
+export const VERSION = "0.1.332";


### PR DESCRIPTION
## Summary\n- add reusable framework/model message conversion helpers under veryfront/agent\n- cover text, tool, reasoning, and attachment conversion behavior\n- bump package version to 0.1.332 for CI/CD release\n\n## Verification\n- deno test --no-check --allow-all src/agent/framework-message-adapter.test.ts\n- deno check src/agent/index.ts src/agent/framework-message-adapter.ts src/agent/framework-message-adapter.test.ts\n- deno task verify:quick && deno task audit && deno task build:npm\n- pre-push format/lint/typecheck/unit tests