### PR TITLE
Expose host tool set types

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.333",
+  "version": "0.1.334",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/tool/host-tools.test.ts
+++ b/src/tool/host-tools.test.ts
@@ -1,7 +1,8 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { z } from "zod";
-import { createToolsFromHostDefinitions } from "./host-tools.ts";
+import { createToolsFromHostDefinitions, type HostToolSet } from "./host-tools.ts";
+import type { ToolExecutionContext, ToolSet } from "./types.ts";
 
 const emptyJsonSchema = { type: "object" as const, properties: {} };
 
@@ -13,8 +14,8 @@ describe("tool/host-tools", () => {
       search: {
         description: "Search docs",
         inputSchema: z.object({ query: z.string() }),
-        execute: (input, context) => {
-          receivedContextToolCallId = String(context.toolCallId);
+        execute: (input: unknown, context?: ToolExecutionContext) => {
+          receivedContextToolCallId = String(context?.toolCallId);
           return input;
         },
       },
@@ -39,10 +40,10 @@ describe("tool/host-tools", () => {
       read_file: {
         description: "Read a file",
         inputSchema: z.object({ path: z.string() }),
-        execute: (_input, context) => {
-          receivedProjectId = String(context.projectId);
-          receivedToolCallId = String(context.toolCallId);
-          receivedAbortSignal = context.abortSignal;
+        execute: (_input: unknown, context?: ToolExecutionContext) => {
+          receivedProjectId = String(context?.projectId);
+          receivedToolCallId = String(context?.toolCallId);
+          receivedAbortSignal = context?.abortSignal;
           return { ok: true };
         },
       },
@@ -112,5 +113,19 @@ describe("tool/host-tools", () => {
     });
 
     assertEquals(Object.keys(tools), ["valid"]);
+  });
+
+  it("exposes host tool set and materialized tool set types for runtime hosts", () => {
+    const hostTools: HostToolSet = {
+      search: {
+        description: "Search docs",
+        inputSchema: z.object({ query: z.string() }),
+        execute: (input: unknown) => input,
+      },
+    };
+
+    const tools: ToolSet = createToolsFromHostDefinitions(hostTools);
+
+    assertEquals(Object.keys(tools), ["search"]);
   });
 });

--- a/src/tool/host-tools.ts
+++ b/src/tool/host-tools.ts
@@ -1,15 +1,32 @@
 import { z } from "zod";
 import { dynamicTool, tool } from "./factory.ts";
 import type { JsonSchema } from "./schema/json-schema.ts";
-import type { Tool, ToolConfig, ToolExecutionContext } from "./types.ts";
+import type { Tool, ToolConfig, ToolExecutionContext, ToolSet } from "./types.ts";
 
-export interface HostToolDefinition {
+type HostToolExecute = {
+  bivarianceHack: (input: unknown, options?: ToolExecutionContext) => Promise<unknown> | unknown;
+}["bivarianceHack"];
+
+export type HostToolDefinition = {
+  id?: string;
+  type?: Tool["type"];
+  title?: string;
+  description?: string;
+  inputSchema?: unknown;
+  inputSchemaJson?: JsonSchema;
+  parameters?: unknown;
+  providerOptions?: unknown;
+  execute?: Tool["execute"] | HostToolExecute;
+  mcp?: ToolConfig["mcp"];
+};
+
+export type HostToolSet = Record<string, HostToolDefinition>;
+
+type RunnableHostToolDefinition = HostToolDefinition & {
   description: string;
   inputSchema: z.ZodSchema<unknown>;
-  inputSchemaJson?: JsonSchema;
-  execute: (input: unknown, context: ToolExecutionContext) => Promise<unknown> | unknown;
-  mcp?: ToolConfig["mcp"];
-}
+  execute: HostToolExecute;
+};
 
 export interface HostToolMaterializationOptions {
   generateToolCallId?: (toolName: string) => string;
@@ -25,7 +42,7 @@ function isZodSchema(value: unknown): value is z.ZodSchema<unknown> {
   return typeof value._def.typeName === "string" || typeof value._def.type === "string";
 }
 
-function isHostToolDefinition(value: unknown): value is HostToolDefinition {
+function isHostToolDefinition(value: unknown): value is RunnableHostToolDefinition {
   return (
     isRecord(value) &&
     typeof value.description === "string" &&
@@ -54,10 +71,18 @@ function normalizeExecutionContext(
 }
 
 export function createToolsFromHostDefinitions(
+  definitions: HostToolSet,
+  options?: HostToolMaterializationOptions,
+): ToolSet;
+export function createToolsFromHostDefinitions(
+  definitions: Record<string, unknown>,
+  options?: HostToolMaterializationOptions,
+): ToolSet;
+export function createToolsFromHostDefinitions(
   definitions: Record<string, unknown>,
   options: HostToolMaterializationOptions = {},
-): Record<string, Tool<unknown, unknown>> {
-  const tools: Record<string, Tool<unknown, unknown>> = {};
+): ToolSet {
+  const tools: ToolSet = {};
 
   for (const [toolName, definition] of Object.entries(definitions)) {
     if (!isHostToolDefinition(definition)) continue;

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -50,6 +50,7 @@ export type {
   ToolDefinition,
   ToolExecutionContext,
   ToolExecutionDataEvent,
+  ToolSet,
 } from "./types.ts";
 
 export { dynamicTool, tool } from "./factory.ts";
@@ -59,7 +60,11 @@ export type { RemoteMCPToolSourceConfig } from "./remote-mcp.ts";
 export { createContext7ToolSource } from "./context7.ts";
 export type { Context7ToolSourceConfig } from "./context7.ts";
 export { createToolsFromHostDefinitions } from "./host-tools.ts";
-export type { HostToolDefinition, HostToolMaterializationOptions } from "./host-tools.ts";
+export type {
+  HostToolDefinition,
+  HostToolMaterializationOptions,
+  HostToolSet,
+} from "./host-tools.ts";
 export {
   createToolsFromRemoteDefinitions,
   loadRemoteToolsFromSource,

--- a/src/tool/types.ts
+++ b/src/tool/types.ts
@@ -136,6 +136,14 @@ export interface Tool<TInput = any, TOutput = any> {
 }
 
 /**
+ * Runtime tool map keyed by the tool name exposed to an agent.
+ *
+ * Hosts can use this for already-materialized framework tools, including
+ * tools loaded from remote sources.
+ */
+export type ToolSet = Record<string, Tool<unknown, unknown>>;
+
+/**
  * Provider-facing tool definition used for model/tool registration.
  */
 export interface ToolDefinition {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.333";
+export const VERSION = "0.1.334";


### PR DESCRIPTION
## Summary
- widen host tool definitions to cover runtime host tool maps
- expose HostToolSet and ToolSet public types
- return ToolSet from host tool materialization
- bump package version to 0.1.334 for CI/CD release

## Verification
- deno test --no-check --allow-all src/tool/host-tools.test.ts
- deno check src/tool/index.ts src/tool/host-tools.ts src/tool/host-tools.test.ts
- deno task verify:quick && deno task audit && deno task build:npm
- pre-push format/lint/typecheck/unit tests