### PR TITLE
Expose durable human input flow helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.334",
+  "version": "0.1.335",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/human-input.test.ts
+++ b/src/agent/human-input.test.ts
@@ -2,10 +2,12 @@ import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { RunCancelledError, RunResumeSessionManager } from "./index.ts";
 import {
+  executeDurableHumanInputFlow,
   HumanInputPendingRequestSchema,
   HumanInputResultSchema,
   HumanInputResumeError,
   InvalidHumanInputResultError,
+  waitForDurableHumanInputResolution,
   waitForHumanInput,
 } from "./human-input.ts";
 
@@ -162,5 +164,102 @@ describe("agent/human-input", () => {
     sessionManager.cancelRun("run_1");
 
     await assertRejects(() => pending, RunCancelledError);
+  });
+
+  it("bridges a durable request snapshot into the local human input wait", async () => {
+    const result = await executeDurableHumanInputFlow({
+      runId: "run_1",
+      threadId: crypto.randomUUID(),
+      toolCallId: "tool_1",
+      request: {
+        title: "Repository details",
+        fields: [{ type: "text", name: "repo", label: "Repository" }],
+      },
+      timeoutMs: 100,
+      pollIntervalMs: 1,
+      onRequest: (request) => ({
+        id: "input_request_1",
+        request,
+      }),
+      getSnapshot: (createdRequest) => ({
+        id: createdRequest.id,
+        status: "submitted",
+        values: {
+          repo: createdRequest.request.request.title,
+        },
+      }),
+      resolveSnapshot: (snapshot) =>
+        snapshot.status === "submitted"
+          ? {
+            submitted: true,
+            values: snapshot.values,
+          }
+          : undefined,
+    });
+
+    assertEquals(result.createdRequest.id, "input_request_1");
+    assertEquals(result.result, {
+      submitted: true,
+      values: {
+        repo: "Repository details",
+      },
+    });
+  });
+
+  it("surfaces durable request timeout as a human input resume error", async () => {
+    await assertRejects(
+      () =>
+        executeDurableHumanInputFlow({
+          runId: "run_1",
+          threadId: crypto.randomUUID(),
+          toolCallId: "tool_1",
+          request: {
+            title: "Repository details",
+            fields: [{ type: "text", name: "repo", label: "Repository" }],
+          },
+          timeoutMs: 0,
+          pollIntervalMs: 1,
+          onRequest: () => ({
+            id: "input_request_1",
+          }),
+          getSnapshot: (createdRequest) => ({
+            id: createdRequest.id,
+            status: "open",
+          }),
+          resolveSnapshot: () => undefined,
+        }),
+      HumanInputResumeError,
+      "Timed out while waiting for durable human input resolution",
+    );
+  });
+
+  it("polls durable human input snapshots until a resolution is available", async () => {
+    const snapshots: Array<{
+      status: "open" | "submitted" | "expired";
+      values: Record<string, string | number | boolean | null>;
+    }> = [
+      { status: "open", values: {} },
+      { status: "submitted", values: { repo: "veryfront" } },
+    ];
+
+    const result = await waitForDurableHumanInputResolution({
+      deadline: Date.now() + 100,
+      pollIntervalMs: 1,
+      getSnapshot: () => snapshots.shift() ?? { status: "expired", values: {} },
+      resolveSnapshot: (snapshot) =>
+        snapshot.status === "submitted"
+          ? {
+            submitted: true,
+            values: snapshot.values,
+          }
+          : undefined,
+    });
+
+    assertEquals(result, {
+      submitted: true,
+      values: {
+        repo: "veryfront",
+      },
+    });
   });
 });

--- a/src/agent/human-input.ts
+++ b/src/agent/human-input.ts
@@ -98,10 +98,41 @@ export type HumanInputRequestInput = z.input<typeof HumanInputRequestSchema>;
 export type HumanInputResult = z.infer<typeof HumanInputResultSchema>;
 export type HumanInputPendingRequest = z.infer<typeof HumanInputPendingRequestSchema>;
 
-type HumanInputResumeValue = {
+export type HumanInputResumeValue = {
   result: unknown;
   isError: boolean;
 };
+
+export type DurableHumanInputFlowResult<TCreatedRequest> = {
+  result: HumanInputResult;
+  createdRequest: TCreatedRequest;
+};
+
+export interface ExecuteDurableHumanInputFlowOptions<
+  TCreatedRequest,
+  TSnapshot,
+> {
+  sessionManager?: RunResumeSessionManager<HumanInputResumeValue> | undefined;
+  runId: string;
+  threadId: string;
+  toolCallId: string;
+  request: HumanInputRequestInput;
+  timeoutMs: number;
+  pollIntervalMs: number;
+  onRequest: (
+    request: HumanInputPendingRequest,
+  ) => TCreatedRequest | Promise<TCreatedRequest>;
+  onCreatedRequest?: ((request: TCreatedRequest) => void | Promise<void>) | undefined;
+  getSnapshot: (request: TCreatedRequest) => TSnapshot | Promise<TSnapshot>;
+  resolveSnapshot: (snapshot: TSnapshot) => HumanInputResult | undefined;
+}
+
+export interface WaitForDurableHumanInputResolutionOptions<TSnapshot> {
+  deadline: number;
+  pollIntervalMs: number;
+  getSnapshot: () => TSnapshot | Promise<TSnapshot>;
+  resolveSnapshot: (snapshot: TSnapshot) => HumanInputResult | undefined;
+}
 
 export interface WaitForHumanInputOptions {
   sessionManager: RunResumeSessionManager<HumanInputResumeValue>;
@@ -124,6 +155,64 @@ export class InvalidHumanInputResultError extends Error {
   constructor(readonly detail: z.ZodIssue[]) {
     super("Invalid human input resume payload");
     this.name = "InvalidHumanInputResultError";
+  }
+}
+
+export async function executeDurableHumanInputFlow<
+  TCreatedRequest,
+  TSnapshot,
+>(
+  options: ExecuteDurableHumanInputFlowOptions<TCreatedRequest, TSnapshot>,
+): Promise<DurableHumanInputFlowResult<TCreatedRequest>> {
+  const sessionManager = options.sessionManager ??
+    new RunResumeSessionManager<HumanInputResumeValue>();
+  sessionManager.startRun({
+    runId: options.runId,
+    threadId: options.threadId,
+  });
+
+  let resolveCreatedRequest: ((request: TCreatedRequest) => void) | null = null;
+  const createdRequestPromise = new Promise<TCreatedRequest>((resolve) => {
+    resolveCreatedRequest = resolve;
+  });
+
+  try {
+    const result = await waitForHumanInput({
+      sessionManager,
+      runId: options.runId,
+      toolCallId: options.toolCallId,
+      request: options.request,
+      onRequest: async (pendingRequest) => {
+        const currentRequest = await options.onRequest(pendingRequest);
+        if (!resolveCreatedRequest) {
+          throw new Error("Durable human input flow could not track the created request");
+        }
+        resolveCreatedRequest(currentRequest);
+        await options.onCreatedRequest?.(currentRequest);
+
+        void bridgeDurableHumanInputRequest({
+          sessionManager,
+          runId: options.runId,
+          toolCallId: options.toolCallId,
+          createdRequest: currentRequest,
+          timeoutMs: options.timeoutMs,
+          pollIntervalMs: options.pollIntervalMs,
+          getSnapshot: options.getSnapshot,
+          resolveSnapshot: options.resolveSnapshot,
+        });
+      },
+    });
+
+    const createdRequest = await createdRequestPromise;
+
+    sessionManager.completeRun(options.runId);
+    return {
+      result,
+      createdRequest,
+    };
+  } catch (error) {
+    sessionManager.failRun(options.runId);
+    throw error;
   }
 }
 
@@ -150,4 +239,77 @@ export async function waitForHumanInput(
   }
 
   return parsed.data;
+}
+
+export async function waitForDurableHumanInputResolution<TSnapshot>(
+  options: WaitForDurableHumanInputResolutionOptions<TSnapshot>,
+): Promise<HumanInputResult> {
+  while (Date.now() < options.deadline) {
+    const snapshot = await options.getSnapshot();
+    const result = options.resolveSnapshot(snapshot);
+
+    if (result) {
+      return result;
+    }
+
+    await delay(options.pollIntervalMs);
+  }
+
+  throw new Error("Timed out while waiting for durable human input resolution");
+}
+
+async function bridgeDurableHumanInputRequest<
+  TCreatedRequest,
+  TSnapshot,
+>(input: {
+  sessionManager: RunResumeSessionManager<HumanInputResumeValue>;
+  runId: string;
+  toolCallId: string;
+  createdRequest: TCreatedRequest;
+  timeoutMs: number;
+  pollIntervalMs: number;
+  getSnapshot: (request: TCreatedRequest) => TSnapshot | Promise<TSnapshot>;
+  resolveSnapshot: (snapshot: TSnapshot) => HumanInputResult | undefined;
+}): Promise<void> {
+  try {
+    const resolved = await waitForDurableHumanInputResolution({
+      deadline: Date.now() + input.timeoutMs,
+      pollIntervalMs: input.pollIntervalMs,
+      getSnapshot: () => input.getSnapshot(input.createdRequest),
+      resolveSnapshot: input.resolveSnapshot,
+    });
+
+    submitHumanInputResumeValue(input.sessionManager, input.runId, input.toolCallId, {
+      result: resolved,
+      isError: false,
+    });
+  } catch (error) {
+    submitHumanInputResumeValue(input.sessionManager, input.runId, input.toolCallId, {
+      result: error instanceof Error ? error.message : String(error),
+      isError: true,
+    });
+  }
+}
+
+function submitHumanInputResumeValue(
+  sessionManager: RunResumeSessionManager<HumanInputResumeValue>,
+  runId: string,
+  toolCallId: string,
+  value: HumanInputResumeValue,
+) {
+  try {
+    sessionManager.submitSignal(runId, {
+      waitKey: toolCallId,
+      value,
+    });
+  } catch {
+    // Ignore late resume submissions once the local wait has already completed
+    // or the ephemeral session has been finalized.
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -642,6 +642,9 @@ export {
   createAgUiHandler,
 } from "./ag-ui-handler.ts";
 export {
+  type DurableHumanInputFlowResult,
+  executeDurableHumanInputFlow,
+  type ExecuteDurableHumanInputFlowOptions,
   type HumanInputField,
   type HumanInputFieldInput,
   HumanInputFieldSchema,
@@ -655,7 +658,10 @@ export {
   type HumanInputResult,
   HumanInputResultSchema,
   HumanInputResumeError,
+  type HumanInputResumeValue,
   InvalidHumanInputResultError,
+  waitForDurableHumanInputResolution,
+  type WaitForDurableHumanInputResolutionOptions,
   waitForHumanInput,
   type WaitForHumanInputOptions,
 } from "./human-input.ts";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.334";
+export const VERSION = "0.1.335";


### PR DESCRIPTION
## Summary\n- add a reusable durable human input flow helper for host-backed requests\n- export durable human input polling and resume value types from veryfront/agent\n- bump package version to 0.1.335 for CI/CD publishing\n\n## Verification\n- deno check src/agent/index.ts src/agent/human-input.ts src/agent/human-input.test.ts\n- deno test --no-check --allow-all src/agent/human-input.test.ts\n- deno task verify:quick && deno task audit && deno task build:npm\n- pre-push format, lint, typecheck, unit tests