### PR TITLE
Expose hosted child execution lifecycle

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.335",
+  "version": "0.1.336",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-lifecycle.test.ts
+++ b/src/agent/hosted-child-lifecycle.test.ts
@@ -1,17 +1,26 @@
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ChildRunExecutionResult } from "./child-run-execution-snapshot.ts";
 import {
   type HostedChildLifecycleAdapter,
+  runHostedChildExecutionLifecycle,
   runHostedChildLifecycle,
 } from "./hosted-child-lifecycle.ts";
+import { HostedChildTerminalStateError } from "./hosted-child-status.ts";
 
 describe("agent/hosted-child-lifecycle", () => {
   it("runs pending, running, and completed around successful execution", async () => {
     const calls: string[] = [];
     const adapter: HostedChildLifecycleAdapter = {
-      pending: () => calls.push("pending"),
-      running: () => calls.push("running"),
-      completed: () => calls.push("completed"),
+      pending: () => {
+        calls.push("pending");
+      },
+      running: () => {
+        calls.push("running");
+      },
+      completed: () => {
+        calls.push("completed");
+      },
     };
 
     const result = await runHostedChildLifecycle({
@@ -43,9 +52,15 @@ describe("agent/hosted-child-lifecycle", () => {
     const calls: string[] = [];
     const error = new Error("boom");
     const adapter: HostedChildLifecycleAdapter = {
-      pending: () => calls.push("pending"),
-      running: () => calls.push("running"),
-      failed: (terminalState) => calls.push(`failed:${terminalState.terminalErrorCode}`),
+      pending: () => {
+        calls.push("pending");
+      },
+      running: () => {
+        calls.push("running");
+      },
+      failed: (terminalState) => {
+        calls.push(`failed:${terminalState.terminalErrorCode}`);
+      },
     };
 
     const result = await runHostedChildLifecycle({
@@ -62,7 +77,9 @@ describe("agent/hosted-child-lifecycle", () => {
 
     assertEquals(calls, ["pending", "running", "failed:STREAM_ERROR"]);
     assertEquals(result.status, "failed");
-    assertEquals(result.error, error);
+    if (result.status !== "completed") {
+      assertEquals(result.error, error);
+    }
     assertEquals(result.terminalState.terminalErrorMessage, "boom");
   });
 
@@ -70,9 +87,15 @@ describe("agent/hosted-child-lifecycle", () => {
     const calls: string[] = [];
     const error = new Error("aborted");
     const adapter: HostedChildLifecycleAdapter = {
-      pending: () => calls.push("pending"),
-      running: () => calls.push("running"),
-      cancelled: (terminalState) => calls.push(`cancelled:${terminalState.terminalErrorCode}`),
+      pending: () => {
+        calls.push("pending");
+      },
+      running: () => {
+        calls.push("running");
+      },
+      cancelled: (terminalState) => {
+        calls.push(`cancelled:${terminalState.terminalErrorCode}`);
+      },
     };
 
     const result = await runHostedChildLifecycle({
@@ -89,7 +112,9 @@ describe("agent/hosted-child-lifecycle", () => {
 
     assertEquals(calls, ["pending", "running", "cancelled:CANCELLED"]);
     assertEquals(result.status, "cancelled");
-    assertEquals(result.error, error);
+    if (result.status !== "completed") {
+      assertEquals(result.error, error);
+    }
   });
 
   it("reports terminal hook errors through onLifecycleError for failure states", async () => {
@@ -144,5 +169,141 @@ describe("agent/hosted-child-lifecycle", () => {
       Error,
       "persist failed",
     );
+  });
+
+  it("runs child execution lifecycle and snapshots successful local results", async () => {
+    const calls: string[] = [];
+    const adapter: HostedChildLifecycleAdapter = {
+      pending: () => {
+        calls.push("pending");
+      },
+      running: () => {
+        calls.push("running");
+      },
+      completed: (terminalState) => {
+        calls.push(`completed:${terminalState.usage?.totalTokens ?? 0}`);
+      },
+    };
+    const localResult: ChildRunExecutionResult = {
+      success: true,
+      description: "Search docs",
+      summary: { text: "Found docs" },
+      steps: 2,
+      toolCalls: [],
+      toolResults: [],
+      usage: { inputTokens: 3, outputTokens: 4, totalTokens: 7 },
+      durationMs: 12,
+    };
+
+    const result = await runHostedChildExecutionLifecycle({
+      adapter,
+      executionFailedCode: "INVOKE_AGENT_FAILED",
+      execute: () => localResult,
+      getExecutionSnapshot: () => null,
+    });
+
+    assertEquals(calls, ["pending", "running", "completed:7"]);
+    assertEquals(result.status, "completed");
+    if (result.status === "completed") {
+      assertEquals(result.result, localResult);
+      assertEquals(result.snapshot.fullResultText, "Found docs");
+    }
+  });
+
+  it("maps failed child execution snapshots to terminal failed states", async () => {
+    const calls: string[] = [];
+    const adapter: HostedChildLifecycleAdapter = {
+      failed: (terminalState) => {
+        calls.push(`failed:${terminalState.terminalErrorCode}`);
+      },
+    };
+    const localResult: ChildRunExecutionResult = {
+      success: false,
+      description: "Search docs",
+      error: "search failed",
+      steps: 1,
+      toolCalls: [],
+      toolResults: [],
+      usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+      durationMs: 4,
+    };
+
+    const result = await runHostedChildExecutionLifecycle({
+      adapter,
+      executionFailedCode: "INVOKE_AGENT_FAILED",
+      execute: () => localResult,
+      getExecutionSnapshot: () => null,
+    });
+
+    assertEquals(calls, ["failed:INVOKE_AGENT_FAILED"]);
+    assertEquals(result.status, "failed");
+    assertEquals(result.terminalState.terminalErrorMessage, "search failed");
+    assertEquals(result.terminalState.usage?.totalTokens, 3);
+  });
+
+  it("skips selected terminal persistence while preserving failure state", async () => {
+    const calls: string[] = [];
+    const adapter: HostedChildLifecycleAdapter = {
+      failed: () => {
+        calls.push("failed");
+      },
+    };
+    const localResult: ChildRunExecutionResult = {
+      success: false,
+      description: "Search docs",
+      error: "already persisted",
+      steps: 1,
+      toolCalls: [],
+      toolResults: [],
+      durationMs: 4,
+    };
+
+    const result = await runHostedChildExecutionLifecycle({
+      adapter,
+      executionFailedCode: "DURABLE_CHILD_FAILED",
+      execute: () => localResult,
+      getExecutionSnapshot: () => null,
+      skipTerminalPersistence: (terminalState) =>
+        terminalState.terminalErrorCode === "DURABLE_CHILD_FAILED",
+    });
+
+    assertEquals(calls, []);
+    assertEquals(result.status, "failed");
+    assertEquals(result.terminalState.terminalErrorCode, "DURABLE_CHILD_FAILED");
+  });
+
+  it("preserves external terminal status without re-persisting it", async () => {
+    const calls: string[] = [];
+    const adapter: HostedChildLifecycleAdapter = {
+      completed: () => {
+        calls.push("completed");
+      },
+      failed: () => {
+        calls.push("failed");
+      },
+      cancelled: () => {
+        calls.push("cancelled");
+      },
+    };
+
+    const result = await runHostedChildExecutionLifecycle({
+      adapter,
+      executionFailedCode: "INVOKE_AGENT_FAILED",
+      execute: () => {
+        throw new HostedChildTerminalStateError("completed", {
+          childConversationId: "conversation-1",
+          childRunId: "run-1",
+          childMessageId: "message-1",
+          latestEventId: 1,
+          latestExternalEventSequence: 1,
+        });
+      },
+      getExecutionSnapshot: () => null,
+    });
+
+    assertEquals(calls, []);
+    assertEquals(result.status, "failed");
+    assertEquals(result.terminalState.status, "completed");
+    assertEquals(result.terminalState.terminalErrorCode, "DURABLE_CHILD_COMPLETED_EXTERNALLY");
   });
 });

--- a/src/agent/hosted-child-lifecycle.ts
+++ b/src/agent/hosted-child-lifecycle.ts
@@ -1,3 +1,15 @@
+import {
+  buildChildRunExecutionSnapshot,
+  type ChildRunExecutionResult,
+  type ChildRunExecutionSnapshot,
+  getChildRunSnapshotUsage,
+} from "./child-run-execution-snapshot.ts";
+import { isChildRunAbortError } from "./child-run-execution-support.ts";
+import {
+  HostedChildTerminalStateError,
+  resolveHostedChildTerminalErrorCode,
+} from "./hosted-child-status.ts";
+
 export interface HostedChildLifecycleTerminalState {
   status: "completed" | "failed" | "cancelled";
   usage?: {
@@ -61,6 +73,47 @@ export type HostedChildLifecycleRunResult<TResult> =
     terminalState: HostedChildLifecycleTerminalState;
   };
 
+export type HostedChildExecutionLifecycleResult<
+  TLocalResult extends ChildRunExecutionResult,
+> =
+  | {
+    status: "completed";
+    result: TLocalResult;
+    snapshot: ChildRunExecutionSnapshot;
+    terminalState: HostedChildLifecycleTerminalState;
+  }
+  | {
+    status: "failed" | "cancelled";
+    error: unknown;
+    terminalState: HostedChildLifecycleTerminalState;
+  };
+
+export interface HostedChildExecutionLifecycleOptions<
+  TLocalResult extends ChildRunExecutionResult,
+> {
+  adapter: HostedChildLifecycleAdapter;
+  executionFailedCode: string;
+  abortSignal?: AbortSignal | undefined;
+  execute: () => Promise<TLocalResult> | TLocalResult;
+  getExecutionSnapshot: () => ChildRunExecutionSnapshot | null;
+  onLifecycleError?: (error: unknown) => Promise<void> | void;
+  skipTerminalPersistence?: (terminalState: HostedChildLifecycleTerminalState) => boolean;
+}
+
+class HostedChildExecutionFailure extends Error {
+  constructor(
+    message: string,
+    readonly usage?: {
+      inputTokens: number;
+      outputTokens: number;
+      totalTokens: number;
+    },
+  ) {
+    super(message);
+    this.name = "HostedChildExecutionFailure";
+  }
+}
+
 async function dispatchTerminalState(
   adapter: HostedChildLifecycleAdapter,
   terminalState: HostedChildLifecycleTerminalState,
@@ -118,4 +171,175 @@ export async function runHostedChildLifecycle<TResult>(
     result,
     terminalState,
   };
+}
+
+function toHostedChildLifecycleUsage(
+  usage: ChildRunExecutionSnapshot["usage"] | undefined,
+): HostedChildLifecycleTerminalState["usage"] {
+  if (!usage) {
+    return undefined;
+  }
+
+  return {
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    totalTokens: usage.totalTokens,
+  };
+}
+
+function wrapSkippableTerminalPersistence(
+  adapter: HostedChildLifecycleAdapter,
+  skipTerminalPersistence: HostedChildExecutionLifecycleOptions<
+    ChildRunExecutionResult
+  >["skipTerminalPersistence"],
+): HostedChildLifecycleAdapter {
+  if (!skipTerminalPersistence) {
+    return adapter;
+  }
+
+  return {
+    ...adapter,
+    failed: async (terminalState) => {
+      if (skipTerminalPersistence(terminalState)) {
+        return;
+      }
+
+      await adapter.failed?.(terminalState);
+    },
+    cancelled: async (terminalState) => {
+      if (skipTerminalPersistence(terminalState)) {
+        return;
+      }
+
+      await adapter.cancelled?.(terminalState);
+    },
+  };
+}
+
+function resolveHostedChildExecutionErrorState(
+  error: unknown,
+  input: {
+    executionFailedCode: string;
+    abortSignal?: AbortSignal | undefined;
+    getExecutionSnapshot: () => ChildRunExecutionSnapshot | null;
+  },
+): HostedChildLifecycleErrorState {
+  if (error instanceof HostedChildTerminalStateError) {
+    if (error.status === "completed") {
+      throw error;
+    }
+
+    return {
+      status: error.status,
+      terminalErrorCode: resolveHostedChildTerminalErrorCode(error.status),
+      terminalErrorMessage: error.message,
+    };
+  }
+
+  if (error instanceof HostedChildExecutionFailure) {
+    return {
+      status: "failed",
+      terminalErrorCode: input.executionFailedCode,
+      terminalErrorMessage: error.message,
+      usage: toHostedChildLifecycleUsage(error.usage),
+    };
+  }
+
+  if (isChildRunAbortError(error) || input.abortSignal?.aborted) {
+    return {
+      status: "cancelled",
+      terminalErrorCode: "CANCELLED",
+      terminalErrorMessage: "Child run cancelled",
+      usage: toHostedChildLifecycleUsage(getChildRunSnapshotUsage(input.getExecutionSnapshot())),
+    };
+  }
+
+  return {
+    status: "failed",
+    terminalErrorCode: input.executionFailedCode,
+    terminalErrorMessage: error instanceof Error ? error.message : String(error),
+    usage: toHostedChildLifecycleUsage(getChildRunSnapshotUsage(input.getExecutionSnapshot())),
+  };
+}
+
+export async function runHostedChildExecutionLifecycle<
+  TLocalResult extends ChildRunExecutionResult,
+>(
+  options: HostedChildExecutionLifecycleOptions<TLocalResult>,
+): Promise<HostedChildExecutionLifecycleResult<TLocalResult>> {
+  const adapter = wrapSkippableTerminalPersistence(
+    options.adapter,
+    options.skipTerminalPersistence,
+  );
+
+  try {
+    const lifecycleResult = await runHostedChildLifecycle({
+      adapter,
+      execute: async () => {
+        const result = await options.execute();
+        const snapshot = options.getExecutionSnapshot() ?? buildChildRunExecutionSnapshot(result);
+
+        if (!snapshot.success) {
+          throw new HostedChildExecutionFailure(snapshot.error ?? "Unknown error", snapshot.usage);
+        }
+
+        return {
+          result,
+          snapshot,
+        };
+      },
+      resolveCompletedState: ({ snapshot }) => ({
+        status: "completed",
+        usage: toHostedChildLifecycleUsage(snapshot.usage),
+      }),
+      resolveErrorState: (error) =>
+        resolveHostedChildExecutionErrorState(error, {
+          executionFailedCode: options.executionFailedCode,
+          abortSignal: options.abortSignal,
+          getExecutionSnapshot: options.getExecutionSnapshot,
+        }),
+      onLifecycleError: options.onLifecycleError,
+    });
+
+    if (lifecycleResult.status !== "completed") {
+      return lifecycleResult;
+    }
+
+    return {
+      status: "completed",
+      result: lifecycleResult.result.result,
+      snapshot: lifecycleResult.result.snapshot,
+      terminalState: lifecycleResult.terminalState,
+    };
+  } catch (error) {
+    if (error instanceof HostedChildTerminalStateError) {
+      return {
+        status: error.status === "cancelled" ? "cancelled" : "failed",
+        error,
+        terminalState: {
+          status: error.status,
+          terminalErrorCode: resolveHostedChildTerminalErrorCode(error.status),
+          terminalErrorMessage: error.message,
+        },
+      };
+    }
+
+    const terminalState = resolveHostedChildExecutionErrorState(error, {
+      executionFailedCode: options.executionFailedCode,
+      abortSignal: options.abortSignal,
+      getExecutionSnapshot: options.getExecutionSnapshot,
+    });
+
+    try {
+      await dispatchTerminalState(adapter, terminalState);
+    } catch (lifecycleError) {
+      await options.onLifecycleError?.(lifecycleError);
+    }
+
+    return {
+      status: terminalState.status,
+      error,
+      terminalState,
+    };
+  }
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -525,10 +525,13 @@ export {
   publishInvokeAgentChildRunProgress,
 } from "./invoke-agent-child-runs.ts";
 export {
+  type HostedChildExecutionLifecycleOptions,
+  type HostedChildExecutionLifecycleResult,
   type HostedChildLifecycleAdapter,
   type HostedChildLifecycleRunnerOptions,
   type HostedChildLifecycleRunResult,
   type HostedChildLifecycleTerminalState,
+  runHostedChildExecutionLifecycle,
   runHostedChildLifecycle,
 } from "./hosted-child-lifecycle.ts";
 export {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.335";
+export const VERSION = "0.1.336";


### PR DESCRIPTION
## Summary
- add a reusable hosted child execution lifecycle helper for child run hosts
- normalize child execution snapshots, aborts, terminal status errors, and terminal persistence skipping in veryfront/agent
- bump package version to 0.1.336 for CI/CD publishing

## Verification
- deno check src/agent/index.ts src/agent/hosted-child-lifecycle.ts src/agent/hosted-child-lifecycle.test.ts
- deno test --no-check --allow-all src/agent/hosted-child-lifecycle.test.ts
- deno task verify:quick && deno task audit && deno task build:npm
- pre-push format, lint, typecheck, unit tests