### PR TITLE
Expose mirrored tool chunk state

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.336",
+  "version": "0.1.337",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -593,6 +593,15 @@ export {
   normalizeChatUiMessageStream,
 } from "../chat/chat-ui-message-helpers.ts";
 export {
+  cloneMirroredToolChunkState,
+  computeOpenToolCalls,
+  createMirroredToolChunkState,
+  isDurableMirroredOutputChunk,
+  type MirroredToolChunkState,
+  type OpenToolCalls,
+  recordMirroredToolChunkState,
+} from "./mirrored-tool-chunk-state.ts";
+export {
   type HostedStreamPartForUiChunkMapping,
   type HostedUiChunkMappingOptions,
   mapHostedStreamPartToChatUiChunks,

--- a/src/agent/mirrored-tool-chunk-state.test.ts
+++ b/src/agent/mirrored-tool-chunk-state.test.ts
@@ -1,0 +1,154 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ChatMessageMetadata, ChatUiMessageChunk } from "../chat/protocol.ts";
+import {
+  cloneMirroredToolChunkState,
+  computeOpenToolCalls,
+  createMirroredToolChunkState,
+  isDurableMirroredOutputChunk,
+  recordMirroredToolChunkState,
+} from "./mirrored-tool-chunk-state.ts";
+
+type Chunk = ChatUiMessageChunk<ChatMessageMetadata>;
+
+function createStateAfterRecording(chunk: Chunk): ReturnType<typeof createMirroredToolChunkState> {
+  const state = createMirroredToolChunkState();
+  recordMirroredToolChunkState(state, chunk);
+  return state;
+}
+
+function expectMirrored(chunk: Chunk): void {
+  assertEquals(isDurableMirroredOutputChunk(chunk), true);
+}
+
+function expectNotMirrored(chunk: Chunk): void {
+  assertEquals(isDurableMirroredOutputChunk(chunk), false);
+}
+
+describe("mirrored-tool-chunk-state", () => {
+  it("identifies durable mirrored output chunk types", () => {
+    expectMirrored({ type: "text-start", id: "msg-1" });
+    expectMirrored({ type: "text-delta", id: "msg-1", delta: "" });
+    expectMirrored({ type: "text-end", id: "msg-1" });
+    expectMirrored({ type: "reasoning-start", id: "msg-1" });
+    expectMirrored({ type: "reasoning-delta", id: "msg-1", delta: "" });
+    expectMirrored({ type: "reasoning-end", id: "msg-1" });
+    expectMirrored({ type: "tool-input-start", toolCallId: "tc-1", toolName: "bash" });
+    expectMirrored({ type: "tool-input-delta", toolCallId: "tc-1", inputTextDelta: "" });
+    expectMirrored({
+      type: "tool-input-available",
+      toolCallId: "tc-1",
+      toolName: "bash",
+      input: {},
+    });
+    expectMirrored({
+      type: "tool-input-error",
+      toolCallId: "tc-1",
+      toolName: "bash",
+      input: {},
+      errorText: "err",
+    });
+    expectMirrored({ type: "tool-output-available", toolCallId: "tc-1", output: "ok" });
+    expectMirrored({ type: "tool-output-error", toolCallId: "tc-1", errorText: "fail" });
+    expectMirrored({ type: "tool-output-denied", toolCallId: "tc-1" });
+
+    expectNotMirrored({ type: "start" });
+    expectNotMirrored({ type: "finish" });
+    expectNotMirrored({ type: "message-metadata", messageMetadata: {} });
+  });
+
+  it("creates empty state", () => {
+    const state = createMirroredToolChunkState();
+
+    assertEquals(state.startedToolCallIds.size, 0);
+    assertEquals(state.inputAvailableToolCallIds.size, 0);
+    assertEquals(state.outputAvailableToolCallIds.size, 0);
+    assertEquals(state.outputErrorToolCallIds.size, 0);
+    assertEquals(state.outputDeniedToolCallIds.size, 0);
+  });
+
+  it("clones state as an independent copy", () => {
+    const state = createMirroredToolChunkState();
+    state.startedToolCallIds.add("tc-1");
+
+    const clone = cloneMirroredToolChunkState(state);
+    clone.startedToolCallIds.add("tc-2");
+
+    assertEquals(state.startedToolCallIds.has("tc-2"), false);
+    assertEquals(clone.startedToolCallIds.has("tc-1"), true);
+  });
+
+  it("records tool lifecycle chunks", () => {
+    const inputStarted = createStateAfterRecording({
+      type: "tool-input-start",
+      toolCallId: "tc-1",
+      toolName: "bash",
+    });
+    assertEquals(inputStarted.startedToolCallIds.has("tc-1"), true);
+
+    const inputAvailable = createStateAfterRecording({
+      type: "tool-input-available",
+      toolCallId: "tc-1",
+      toolName: "bash",
+      input: {},
+    });
+    assertEquals(inputAvailable.startedToolCallIds.has("tc-1"), true);
+    assertEquals(inputAvailable.inputAvailableToolCallIds.has("tc-1"), true);
+
+    const outputAvailable = createStateAfterRecording({
+      type: "tool-output-available",
+      toolCallId: "tc-1",
+      output: "ok",
+    });
+    assertEquals(outputAvailable.outputAvailableToolCallIds.has("tc-1"), true);
+
+    const outputError = createStateAfterRecording({
+      type: "tool-output-error",
+      toolCallId: "tc-1",
+      errorText: "fail",
+    });
+    assertEquals(outputError.outputErrorToolCallIds.has("tc-1"), true);
+
+    const outputDenied = createStateAfterRecording({
+      type: "tool-output-denied",
+      toolCallId: "tc-1",
+    });
+    assertEquals(outputDenied.outputDeniedToolCallIds.has("tc-1"), true);
+  });
+
+  it("treats tool-input-error as a terminal error result", () => {
+    const state = createStateAfterRecording({
+      type: "tool-input-error",
+      toolCallId: "tc-1",
+      toolName: "edit_file",
+      input: { path: "x.md" },
+      errorText: "bad args",
+    });
+
+    assertEquals(state.outputErrorToolCallIds.has("tc-1"), true);
+    assertEquals(computeOpenToolCalls(state), {
+      needsInputClose: [],
+      needsOutputClose: [],
+    });
+  });
+
+  it("ignores non-tool chunks while recording state", () => {
+    const state = createStateAfterRecording({ type: "text-delta", id: "msg-1", delta: "hi" });
+
+    assertEquals(state.startedToolCallIds.size, 0);
+  });
+
+  it("returns output closes for accepted but unresolved tool calls", () => {
+    const state = createStateAfterRecording({
+      type: "tool-input-available",
+      toolCallId: "tc-1",
+      toolName: "edit_file",
+      input: { path: "x.md" },
+    });
+
+    assertEquals(computeOpenToolCalls(state), {
+      needsInputClose: [],
+      needsOutputClose: [{ toolCallId: "tc-1", toolName: "edit_file" }],
+    });
+  });
+});

--- a/src/agent/mirrored-tool-chunk-state.ts
+++ b/src/agent/mirrored-tool-chunk-state.ts
@@ -1,0 +1,135 @@
+import type { ChatMessageMetadata, ChatUiMessageChunk } from "../chat/protocol.ts";
+
+export function isDurableMirroredOutputChunk(
+  chunk: ChatUiMessageChunk<ChatMessageMetadata>,
+): boolean {
+  switch (chunk.type) {
+    case "text-start":
+    case "text-delta":
+    case "text-end":
+    case "reasoning-start":
+    case "reasoning-delta":
+    case "reasoning-end":
+    case "tool-input-start":
+    case "tool-input-delta":
+    case "tool-input-available":
+    case "tool-input-error":
+    case "tool-output-available":
+    case "tool-output-error":
+    case "tool-output-denied":
+      return true;
+
+    default:
+      return false;
+  }
+}
+
+export interface MirroredToolChunkState {
+  startedToolCallIds: Set<string>;
+  inputAvailableToolCallIds: Set<string>;
+  outputAvailableToolCallIds: Set<string>;
+  outputErrorToolCallIds: Set<string>;
+  outputDeniedToolCallIds: Set<string>;
+  toolCallNames: Map<string, string>;
+}
+
+export function createMirroredToolChunkState(): MirroredToolChunkState {
+  return {
+    startedToolCallIds: new Set<string>(),
+    inputAvailableToolCallIds: new Set<string>(),
+    outputAvailableToolCallIds: new Set<string>(),
+    outputErrorToolCallIds: new Set<string>(),
+    outputDeniedToolCallIds: new Set<string>(),
+    toolCallNames: new Map<string, string>(),
+  };
+}
+
+export function cloneMirroredToolChunkState(
+  state: MirroredToolChunkState,
+): MirroredToolChunkState {
+  return {
+    startedToolCallIds: new Set(state.startedToolCallIds),
+    inputAvailableToolCallIds: new Set(state.inputAvailableToolCallIds),
+    outputAvailableToolCallIds: new Set(state.outputAvailableToolCallIds),
+    outputErrorToolCallIds: new Set(state.outputErrorToolCallIds),
+    outputDeniedToolCallIds: new Set(state.outputDeniedToolCallIds),
+    toolCallNames: new Map(state.toolCallNames),
+  };
+}
+
+export function recordMirroredToolChunkState(
+  state: MirroredToolChunkState,
+  chunk: ChatUiMessageChunk<ChatMessageMetadata>,
+): void {
+  switch (chunk.type) {
+    case "tool-input-start":
+      state.startedToolCallIds.add(chunk.toolCallId);
+      if (chunk.toolName.length > 0) {
+        state.toolCallNames.set(chunk.toolCallId, chunk.toolName);
+      }
+      break;
+
+    case "tool-input-available":
+      state.startedToolCallIds.add(chunk.toolCallId);
+      state.inputAvailableToolCallIds.add(chunk.toolCallId);
+      if (chunk.toolName.length > 0) {
+        state.toolCallNames.set(chunk.toolCallId, chunk.toolName);
+      }
+      break;
+
+    case "tool-input-error":
+      state.startedToolCallIds.add(chunk.toolCallId);
+      state.inputAvailableToolCallIds.add(chunk.toolCallId);
+      state.outputErrorToolCallIds.add(chunk.toolCallId);
+      if (chunk.toolName.length > 0) {
+        state.toolCallNames.set(chunk.toolCallId, chunk.toolName);
+      }
+      break;
+
+    case "tool-output-available":
+      state.outputAvailableToolCallIds.add(chunk.toolCallId);
+      break;
+
+    case "tool-output-error":
+      state.outputErrorToolCallIds.add(chunk.toolCallId);
+      break;
+
+    case "tool-output-denied":
+      state.outputDeniedToolCallIds.add(chunk.toolCallId);
+      break;
+  }
+}
+
+export interface OpenToolCalls {
+  needsInputClose: Array<{ toolCallId: string; toolName: string }>;
+  needsOutputClose: Array<{ toolCallId: string; toolName: string }>;
+}
+
+export function computeOpenToolCalls(
+  state: MirroredToolChunkState,
+): OpenToolCalls {
+  const needsInputClose: Array<{ toolCallId: string; toolName: string }> = [];
+  const needsOutputClose: Array<{ toolCallId: string; toolName: string }> = [];
+
+  for (const toolCallId of state.startedToolCallIds) {
+    const toolName = state.toolCallNames.get(toolCallId) ?? "unknown";
+
+    if (!state.inputAvailableToolCallIds.has(toolCallId)) {
+      needsInputClose.push({ toolCallId, toolName });
+      continue;
+    }
+
+    if (
+      !state.outputAvailableToolCallIds.has(toolCallId) &&
+      !state.outputErrorToolCallIds.has(toolCallId) &&
+      !state.outputDeniedToolCallIds.has(toolCallId)
+    ) {
+      needsOutputClose.push({ toolCallId, toolName });
+    }
+  }
+
+  return {
+    needsInputClose,
+    needsOutputClose,
+  };
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.336";
+export const VERSION = "0.1.337";


### PR DESCRIPTION
## Summary
- add reusable mirrored UI tool chunk state helpers for hosted stream finalization
- export tool lifecycle recording and open tool-call close computation from veryfront/agent
- bump package version to 0.1.337 for CI/CD publishing

## Verification
- deno check src/agent/index.ts src/agent/mirrored-tool-chunk-state.ts src/agent/mirrored-tool-chunk-state.test.ts
- deno test --no-check --allow-all src/agent/mirrored-tool-chunk-state.test.ts
- deno task verify:quick && deno task audit && deno task build:npm
- pre-push format, lint, typecheck, unit tests