### PR TITLE
Expose default research artifact support

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.337",
+  "version": "0.1.338",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/default-research-artifact-policy.test.ts
+++ b/src/agent/default-research-artifact-policy.test.ts
@@ -1,0 +1,166 @@
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  buildDefaultResearchArtifactPathReminder,
+  buildDefaultResearchArtifactPaths,
+  shouldInjectDefaultResearchArtifactPath,
+  withDefaultResearchArtifactPath,
+} from "./default-research-artifact-policy.ts";
+
+describe("default research artifact policy", () => {
+  it("injects default artifact path for research tasks with save-to-project cue", () => {
+    const result = withDefaultResearchArtifactPath({
+      description: "Research AI trends",
+      prompt: "Research the latest AI trends and save the results to the project",
+      runId: "run_123",
+    });
+
+    assertStringIncludes(result, "/research/ai-trends/runs/run_123.report.md");
+    assertStringIncludes(result, "/research/ai-trends/report.md");
+    assertStringIncludes(result, "/research/ai-trends/findings.md");
+    assertStringIncludes(result, "/research/ai-trends/sources.md");
+    assertStringIncludes(result, "CRITICAL");
+  });
+
+  it("does not inject when prompt lacks save-to-project cue", () => {
+    const prompt = "Research the latest AI trends and summarize findings";
+    const result = withDefaultResearchArtifactPath({
+      description: "Research AI trends",
+      prompt,
+    });
+
+    assertEquals(result, prompt);
+  });
+
+  it("does not inject when prompt already has artifact paths", () => {
+    const prompt = "Research AI trends and write the report to docs/ai-report.md";
+    const result = withDefaultResearchArtifactPath({
+      description: "Research AI trends",
+      prompt,
+    });
+
+    assertEquals(result, prompt);
+  });
+
+  it("does not inject for non-research tasks", () => {
+    const prompt = "Build a landing page and save to the project";
+    const result = withDefaultResearchArtifactPath({
+      description: "Build landing page",
+      prompt,
+    });
+
+    assertEquals(result, prompt);
+  });
+
+  it("uses slugified topic in path", () => {
+    const result = withDefaultResearchArtifactPath({
+      description: "Research quantum computing",
+      prompt: "Research quantum computing breakthroughs and save findings to the project",
+      runId: "run-live-123",
+    });
+
+    assertStringIncludes(result, "/research/quantum-computing/runs/run-live-123.report.md");
+  });
+
+  it("returns an exact run/current workspace reminder for implicit save-to-project research", () => {
+    const reminder = buildDefaultResearchArtifactPathReminder({
+      description: "Research durable run staging canary behavior",
+      prompt:
+        "/research Research durable run staging canary behavior and save the report to the project.",
+      runId: "run_123",
+    });
+
+    assertStringIncludes(
+      reminder ?? "",
+      "/research/durable-run-staging-canary-behavior/runs/run_123.report.md",
+    );
+  });
+
+  it("returns null when an exact artifact path already exists", () => {
+    assertEquals(
+      buildDefaultResearchArtifactPathReminder({
+        description: "Research durable run staging canary behavior",
+        prompt: "/research Write exactly /plans/canary.md in this run.",
+        runId: "run_123",
+      }),
+      null,
+    );
+  });
+
+  it("does not inject a default workspace when exact artifact paths are listed", () => {
+    assertEquals(
+      shouldInjectDefaultResearchArtifactPath({
+        description: "Research AI coding agents",
+        prompt:
+          "/research Research AI coding agents and save the report to the project.\n- research/ai-coding-agents/report.md\n- research/ai-coding-agents/sources.md",
+      }),
+      false,
+    );
+  });
+
+  it("recognizes implicit save-to-project research without an exact path", () => {
+    assertEquals(
+      shouldInjectDefaultResearchArtifactPath({
+        description: "Research durable run staging canary behavior",
+        prompt:
+          "/research Research durable run staging canary behavior and save the report to the project.",
+      }),
+      true,
+    );
+  });
+
+  it("builds topic-scoped current and run report paths", () => {
+    assertEquals(
+      buildDefaultResearchArtifactPaths({
+        description: "Research AI memory systems",
+        prompt: "Research AI memory systems deeply",
+        runId: "run_456",
+      }),
+      {
+        topicSlug: "ai-memory-systems",
+        topicRootPath: "/research/ai-memory-systems",
+        currentReportPath: "/research/ai-memory-systems/report.md",
+        runReportPath: "/research/ai-memory-systems/runs/run_456.report.md",
+        findingsPath: "/research/ai-memory-systems/findings.md",
+        sourcesPath: "/research/ai-memory-systems/sources.md",
+      },
+    );
+  });
+
+  it("falls back to a stable topic slug and run id when input is sparse", () => {
+    assertEquals(
+      buildDefaultResearchArtifactPaths({
+        description: "",
+        prompt: "Research this and save it to the project",
+      }),
+      {
+        topicSlug: "research-report",
+        topicRootPath: "/research/research-report",
+        currentReportPath: "/research/research-report/report.md",
+        runReportPath: "/research/research-report/runs/latest.report.md",
+        findingsPath: "/research/research-report/findings.md",
+        sourcesPath: "/research/research-report/sources.md",
+      },
+    );
+  });
+
+  it("derives a stable topic slug from root-thread research text with extra save instructions", () => {
+    assertEquals(
+      buildDefaultResearchArtifactPaths({
+        description:
+          "Research durable-run staging canary behavior and save the report to the project. Keep it short.",
+        prompt:
+          "/research Research durable-run staging canary behavior and save the report to the project. Keep it short.",
+        runId: "run_789",
+      }),
+      {
+        topicSlug: "durable-run-staging-canary-behavior",
+        topicRootPath: "/research/durable-run-staging-canary-behavior",
+        currentReportPath: "/research/durable-run-staging-canary-behavior/report.md",
+        runReportPath: "/research/durable-run-staging-canary-behavior/runs/run_789.report.md",
+        findingsPath: "/research/durable-run-staging-canary-behavior/findings.md",
+        sourcesPath: "/research/durable-run-staging-canary-behavior/sources.md",
+      },
+    );
+  });
+});

--- a/src/agent/default-research-artifact-policy.ts
+++ b/src/agent/default-research-artifact-policy.ts
@@ -1,0 +1,146 @@
+const RESEARCH_TASK_CUE_PATTERN = /\b(research|report|findings|sources|authoritative sources)\b/i;
+const RESEARCH_PROJECT_SAVE_CUE_PATTERN =
+  /\b(?:save|write|persist|store|compile)\b[^\n]{0,120}\b(?:to|into)\b[^\n]{0,40}\b(?:the\s+)?project\b/i;
+
+const PROJECT_ARTIFACT_PATH_PATTERN = /(?:\/|\.{1,2}\/)?(?:[\w.-]+\/)+[\w.-]+\.[\w.-]+/g;
+
+function slugifyArtifactSegment(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/['"]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function slugifyRunArtifactSegment(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function hasAnyArtifactPath(prompt: string): boolean {
+  PROJECT_ARTIFACT_PATH_PATTERN.lastIndex = 0;
+  return PROJECT_ARTIFACT_PATH_PATTERN.test(prompt);
+}
+
+function isGenericResearchTopic(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  return normalized.length === 0 ||
+    normalized === "this" ||
+    normalized === "that" ||
+    normalized === "it" ||
+    normalized === "the project" ||
+    normalized === "the topic";
+}
+
+function extractResearchTopic(input: { description: string; prompt: string }): string | null {
+  const quotedPromptTopic = input.prompt.match(/\bresearch(?:\s+on|\s+about)?\s+["“]([^"”]+)["”]/i)
+    ?.[1];
+  if (quotedPromptTopic?.trim() && !isGenericResearchTopic(quotedPromptTopic)) {
+    return quotedPromptTopic.trim();
+  }
+
+  const cleanedDescription = input.description
+    .replace(/^research\s+/i, "")
+    .replace(/\.\s+.*$/s, "")
+    .replace(/\s+and\s+(?:save|write|persist|store|compile)\b.*$/i, "")
+    .replace(/\s+across\b.*$/i, "")
+    .trim();
+  if (cleanedDescription.length > 0) {
+    return cleanedDescription;
+  }
+
+  const promptTopic = input.prompt
+    .match(/\bresearch(?:\s+on|\s+about)?\s+([^\n.,:]+)/i)?.[1]
+    ?.replace(/\s+and\s+save\b.*$/i, "")
+    ?.replace(/\s+and\s+write\b.*$/i, "")
+    ?.trim();
+  if (!promptTopic || isGenericResearchTopic(promptTopic)) {
+    return null;
+  }
+
+  return promptTopic;
+}
+
+export interface DefaultResearchArtifactPaths {
+  topicSlug: string;
+  topicRootPath: string;
+  currentReportPath: string;
+  runReportPath: string;
+  findingsPath: string;
+  sourcesPath: string;
+}
+
+export function shouldInjectDefaultResearchArtifactPath(input: {
+  description: string;
+  prompt: string;
+}): boolean {
+  if (
+    !RESEARCH_TASK_CUE_PATTERN.test(input.description) &&
+    !RESEARCH_TASK_CUE_PATTERN.test(input.prompt)
+  ) {
+    return false;
+  }
+
+  if (!RESEARCH_PROJECT_SAVE_CUE_PATTERN.test(input.prompt)) {
+    return false;
+  }
+
+  return !hasAnyArtifactPath(input.prompt);
+}
+
+export function buildDefaultResearchArtifactPathReminder(input: {
+  description: string;
+  prompt: string;
+  runId?: string;
+}): string | null {
+  if (!shouldInjectDefaultResearchArtifactPath(input)) {
+    return null;
+  }
+
+  const artifactPaths = buildDefaultResearchArtifactPaths(input);
+
+  return [
+    "Default research workspace (because no exact artifact path was provided):",
+    `- Write the run-scoped report to exactly ${artifactPaths.runReportPath}.`,
+    `- Then create or update the current topic report at exactly ${artifactPaths.currentReportPath}.`,
+    `- Supporting artifacts can live at ${artifactPaths.findingsPath} and ${artifactPaths.sourcesPath} when useful.`,
+    `CRITICAL: The task is incomplete until ${artifactPaths.runReportPath} and ${artifactPaths.currentReportPath} both exist with the final report content.`,
+    "Use create_file or update_file yourself before finishing.",
+  ].join("\n");
+}
+
+export function buildDefaultResearchArtifactPaths(input: {
+  description: string;
+  prompt: string;
+  runId?: string;
+}): DefaultResearchArtifactPaths {
+  const topic = extractResearchTopic(input);
+  const topicSlug = topic ? slugifyArtifactSegment(topic) : "research-report";
+  const sanitizedRunId = slugifyRunArtifactSegment(input.runId ?? "");
+  const effectiveRunId = sanitizedRunId.length > 0 ? sanitizedRunId : "latest";
+  const topicRootPath = `/research/${topicSlug}`;
+
+  return {
+    topicSlug,
+    topicRootPath,
+    currentReportPath: `${topicRootPath}/report.md`,
+    runReportPath: `${topicRootPath}/runs/${effectiveRunId}.report.md`,
+    findingsPath: `${topicRootPath}/findings.md`,
+    sourcesPath: `${topicRootPath}/sources.md`,
+  };
+}
+
+export function withDefaultResearchArtifactPath(input: {
+  description: string;
+  prompt: string;
+  runId?: string;
+}): string {
+  const reminder = buildDefaultResearchArtifactPathReminder(input);
+  if (!reminder) {
+    return input.prompt;
+  }
+
+  return [input.prompt, "", reminder].join("\n");
+}

--- a/src/agent/default-research-artifact-support.test.ts
+++ b/src/agent/default-research-artifact-support.test.ts
@@ -1,0 +1,160 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  type DefaultResearchArtifactContext,
+  extractLatestUserText,
+  mirrorDefaultResearchRunArtifact,
+  shouldRetryCreateResearchArtifactAsUpdate,
+  updateDefaultResearchArtifacts,
+} from "./default-research-artifact-support.ts";
+
+function defaultArtifacts() {
+  return {
+    topicSlug: "ai-coding-agents",
+    topicRootPath: "/research/ai-coding-agents",
+    currentReportPath: "/research/ai-coding-agents/report.md",
+    runReportPath: "/research/ai-coding-agents/runs/run-1.report.md",
+    findingsPath: "/research/ai-coding-agents/findings.md",
+    sourcesPath: "/research/ai-coding-agents/sources.md",
+  };
+}
+
+describe("default research artifact support", () => {
+  it("extracts the latest user text from string and part-array messages", () => {
+    assertEquals(
+      extractLatestUserText([
+        { role: "user", content: "old" },
+        { role: "assistant", content: "ignore" },
+        { role: "user", content: [{ type: "text", text: "latest" }] },
+      ]),
+      "latest",
+    );
+  });
+
+  it("updates task context and appends a system reminder", () => {
+    const taskContext: DefaultResearchArtifactContext = { parentRunId: "run-1" };
+    const system = updateDefaultResearchArtifacts({
+      taskContext,
+      latestUserText: "/research Research AI coding agents and save the report to the project.",
+      system: "base",
+    });
+
+    assertEquals(typeof system, "string");
+    assertEquals(
+      taskContext.defaultResearchArtifacts?.currentReportPath,
+      "/research/ai-coding-agents/report.md",
+    );
+  });
+
+  it("retries existing-file collisions for explicit research markdown paths without injected defaults", () => {
+    assertEquals(
+      shouldRetryCreateResearchArtifactAsUpdate({
+        toolName: "create_file",
+        toolInput: {
+          path: "research/ai-coding-agents/sources.md",
+          content: "# sources",
+        },
+        taskContext: {},
+        error: {
+          output: {
+            error: "tool_error",
+            message: "File already exists: research/ai-coding-agents/sources.md",
+          },
+        },
+      }),
+      true,
+    );
+  });
+
+  it("retries MCP isError content collisions for explicit research markdown paths", () => {
+    assertEquals(
+      shouldRetryCreateResearchArtifactAsUpdate({
+        toolName: "create_file",
+        toolInput: {
+          path: "research/ai-coding-agents/sources.md",
+          content: "# sources",
+        },
+        taskContext: {},
+        error: {
+          isError: true,
+          content: [{
+            type: "text",
+            text: "File already exists: research/ai-coding-agents/sources.md",
+          }],
+        },
+      }),
+      true,
+    );
+  });
+
+  it("does not retry non-research create_file collisions without injected defaults", () => {
+    assertEquals(
+      shouldRetryCreateResearchArtifactAsUpdate({
+        toolName: "create_file",
+        toolInput: {
+          path: "src/app.ts",
+          content: "export {}",
+        },
+        taskContext: {},
+        error: { message: "File already exists: src/app.ts" },
+      }),
+      false,
+    );
+  });
+
+  it("falls back to update_file when create_file throws a nested existing-file tool result", async () => {
+    const calls: Array<
+      {
+        toolName: string;
+        args: Record<string, unknown>;
+        context: Record<string, unknown> | undefined;
+      }
+    > = [];
+
+    await mirrorDefaultResearchRunArtifact({
+      toolName: "create_file",
+      toolInput: {
+        path: "research/ai-coding-agents/report.md",
+        content: "# report",
+      },
+      taskContext: {
+        defaultResearchArtifacts: defaultArtifacts(),
+      },
+      activeProjectId: "project-1",
+      executeContext: { projectId: "project-1" },
+      executeTool: (toolName, args, context) => {
+        calls.push({ toolName, args, context });
+        if (calls.length === 1) {
+          throw {
+            output: {
+              error: "tool_error",
+              message: "File already exists: research/ai-coding-agents/runs/run-1.report.md",
+            },
+          };
+        }
+        return Promise.resolve({ path: "research/ai-coding-agents/runs/run-1.report.md" });
+      },
+    });
+
+    assertEquals(calls, [
+      {
+        toolName: "create_file",
+        args: {
+          path: "research/ai-coding-agents/runs/run-1.report.md",
+          content: "# report",
+          project_reference: "project-1",
+        },
+        context: { projectId: "project-1" },
+      },
+      {
+        toolName: "update_file",
+        args: {
+          path: "research/ai-coding-agents/runs/run-1.report.md",
+          content: "# report",
+          project_reference: "project-1",
+        },
+        context: { projectId: "project-1" },
+      },
+    ]);
+  });
+});

--- a/src/agent/default-research-artifact-support.ts
+++ b/src/agent/default-research-artifact-support.ts
@@ -1,0 +1,289 @@
+import type { ChatSystemMessage } from "../chat/types.ts";
+import { isHostedChildCreateFileAlreadyExistsResult } from "./hosted-child-artifact-support.ts";
+import {
+  buildDefaultResearchArtifactPathReminder,
+  buildDefaultResearchArtifactPaths,
+  type DefaultResearchArtifactPaths,
+} from "./default-research-artifact-policy.ts";
+
+export type DefaultResearchArtifacts = DefaultResearchArtifactPaths;
+
+export interface DefaultResearchArtifactContext {
+  availableToolNames?: string[];
+  parentRunId?: string;
+  defaultResearchArtifacts?: DefaultResearchArtifacts | null;
+}
+
+export interface DefaultResearchArtifactLogger {
+  debug?: (message: string, metadata?: Record<string, unknown>) => void;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function extractLatestUserText(messages: readonly unknown[]): string | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!isRecord(message) || message.role !== "user") {
+      continue;
+    }
+
+    const content = message.content;
+    if (typeof content === "string" && content.trim().length > 0) {
+      return content;
+    }
+
+    if (!Array.isArray(content)) {
+      continue;
+    }
+
+    const text = content
+      .flatMap((part) =>
+        isRecord(part) && part.type === "text" && typeof part.text === "string"
+          ? [part.text.trim()]
+          : []
+      )
+      .filter((value) => value.length > 0)
+      .join("\n");
+
+    if (text.length > 0) {
+      return text;
+    }
+  }
+
+  return null;
+}
+
+function extractLatestUserDescription(text: string): string {
+  const withoutCommandSpan = text.replace(
+    /<span\s+data-command="[^"]+">\s*(\/[a-z0-9_-]+)\s*<\/span>/gi,
+    "$1",
+  );
+  const withoutLeadingSlashCommand = withoutCommandSpan.replace(/^\s*\/[a-z0-9_-]+\s*/i, "");
+
+  return withoutLeadingSlashCommand.trim();
+}
+
+export async function fetchLatestConversationUserText(input: {
+  apiUrl: string;
+  authToken: string;
+  conversationId?: string;
+  logger?: DefaultResearchArtifactLogger;
+}): Promise<string | null> {
+  if (!input.conversationId) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(
+      `${input.apiUrl}/conversations/${input.conversationId}/messages?limit=20`,
+      {
+        headers: {
+          Authorization: `Bearer ${input.authToken}`,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      input.logger?.debug?.(
+        "Could not preload conversation messages for research workspace detection",
+        {
+          conversationId: input.conversationId,
+          status: response.status,
+        },
+      );
+      return null;
+    }
+
+    const payload = await response.json();
+    const data = isRecord(payload) ? payload.data : undefined;
+    const messages = Array.isArray(data)
+      ? data.map((message) => ({
+        role: isRecord(message) ? message.role : undefined,
+        content: isRecord(message) && Array.isArray(message.parts) ? message.parts : [],
+      }))
+      : [];
+
+    return extractLatestUserText(messages);
+  } catch (error) {
+    input.logger?.debug?.(
+      "Failed to preload conversation messages for research workspace detection",
+      {
+        conversationId: input.conversationId,
+        error,
+      },
+    );
+    return null;
+  }
+}
+
+export function updateDefaultResearchArtifacts(input: {
+  taskContext: DefaultResearchArtifactContext;
+  latestUserText: string | null;
+  system: string | ChatSystemMessage[];
+}): string | ChatSystemMessage[] {
+  if (!input.latestUserText) {
+    return input.system;
+  }
+
+  const latestUserDescription = extractLatestUserDescription(input.latestUserText);
+  const defaultResearchWorkspaceReminder = buildDefaultResearchArtifactPathReminder({
+    description: latestUserDescription,
+    prompt: input.latestUserText,
+    runId: input.taskContext.parentRunId,
+  });
+
+  if (!defaultResearchWorkspaceReminder) {
+    input.taskContext.defaultResearchArtifacts = null;
+    return input.system;
+  }
+
+  input.taskContext.defaultResearchArtifacts = buildDefaultResearchArtifactPaths({
+    description: latestUserDescription,
+    prompt: input.latestUserText,
+    runId: input.taskContext.parentRunId,
+  });
+
+  return appendSystemReminder(input.system, defaultResearchWorkspaceReminder);
+}
+
+function appendSystemReminder(
+  instructions: string | ChatSystemMessage[],
+  reminder: string,
+): string | ChatSystemMessage[] {
+  if (typeof instructions === "string") {
+    return instructions.includes(reminder) ? instructions : `${instructions}\n\n${reminder}`;
+  }
+
+  if (instructions.some((message) => message.content.includes(reminder))) {
+    return instructions;
+  }
+
+  return [
+    ...instructions,
+    {
+      role: "system",
+      content: reminder,
+    },
+  ];
+}
+
+export function applyDefaultResearchArtifactPath(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  taskContext: DefaultResearchArtifactContext,
+): Record<string, unknown> {
+  const defaultArtifacts = taskContext.defaultResearchArtifacts;
+  if (!defaultArtifacts || (toolName !== "create_file" && toolName !== "update_file")) {
+    return toolInput;
+  }
+
+  const path = typeof toolInput.path === "string" ? toolInput.path.replace(/^\/+/, "") : null;
+  if (!path) {
+    return toolInput;
+  }
+
+  const canonicalCurrentPath = defaultArtifacts.currentReportPath.replace(/^\/+/, "");
+  const canonicalRunPath = defaultArtifacts.runReportPath.replace(/^\/+/, "");
+  const canonicalFindingsPath = defaultArtifacts.findingsPath.replace(/^\/+/, "");
+  const canonicalSourcesPath = defaultArtifacts.sourcesPath.replace(/^\/+/, "");
+
+  if (
+    path === canonicalCurrentPath || path === canonicalRunPath || path === canonicalFindingsPath ||
+    path === canonicalSourcesPath
+  ) {
+    return toolInput;
+  }
+
+  if (!path.endsWith("/report.md") && path !== "report.md") {
+    return toolInput;
+  }
+
+  return {
+    ...toolInput,
+    path: canonicalCurrentPath,
+  };
+}
+
+export function shouldRetryCreateResearchArtifactAsUpdate(input: {
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  taskContext: DefaultResearchArtifactContext;
+  error: unknown;
+}): boolean {
+  if (input.toolName !== "create_file") {
+    return false;
+  }
+
+  const defaultArtifacts = input.taskContext.defaultResearchArtifacts;
+  if (!isHostedChildCreateFileAlreadyExistsResult(input.error)) {
+    return false;
+  }
+
+  const path = typeof input.toolInput.path === "string"
+    ? input.toolInput.path.replace(/^\/+/, "")
+    : null;
+  const content = typeof input.toolInput.content === "string" ? input.toolInput.content : null;
+  if (!path || !content) {
+    return false;
+  }
+
+  if (!defaultArtifacts) {
+    return path.startsWith("research/") && path.endsWith(".md");
+  }
+
+  const topicRootPath = defaultArtifacts.currentReportPath.replace(/^\/+/, "").replace(
+    /\/report\.md$/,
+    "",
+  );
+  return path === topicRootPath || path.startsWith(`${topicRootPath}/`);
+}
+
+export async function mirrorDefaultResearchRunArtifact(input: {
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  taskContext: DefaultResearchArtifactContext;
+  activeProjectId: string | null;
+  executeContext: Record<string, unknown> | undefined;
+  executeTool: (
+    toolName: string,
+    args: Record<string, unknown>,
+    context: Record<string, unknown> | undefined,
+  ) => Promise<unknown>;
+}): Promise<void> {
+  const defaultArtifacts = input.taskContext.defaultResearchArtifacts;
+  if (!defaultArtifacts || (input.toolName !== "create_file" && input.toolName !== "update_file")) {
+    return;
+  }
+
+  const content = typeof input.toolInput.content === "string" ? input.toolInput.content : null;
+  const path = typeof input.toolInput.path === "string"
+    ? input.toolInput.path.replace(/^\/+/, "")
+    : null;
+  const canonicalCurrentPath = defaultArtifacts.currentReportPath.replace(/^\/+/, "");
+  const canonicalRunPath = defaultArtifacts.runReportPath.replace(/^\/+/, "");
+
+  if (!content || path !== canonicalCurrentPath) {
+    return;
+  }
+
+  const mirroredInput: Record<string, unknown> = {
+    ...input.toolInput,
+    path: canonicalRunPath,
+  };
+
+  if (input.activeProjectId) {
+    mirroredInput.project_reference = input.activeProjectId;
+  }
+
+  try {
+    await input.executeTool(input.toolName, mirroredInput, input.executeContext);
+  } catch (error) {
+    if (input.toolName === "create_file" && isHostedChildCreateFileAlreadyExistsResult(error)) {
+      await input.executeTool("update_file", mirroredInput, input.executeContext);
+      return;
+    }
+    throw error;
+  }
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -418,6 +418,24 @@ export {
   withHostedChildRerunnableFileWriteFallbacks,
 } from "./hosted-child-artifact-support.ts";
 export {
+  buildDefaultResearchArtifactPathReminder,
+  buildDefaultResearchArtifactPaths,
+  type DefaultResearchArtifactPaths,
+  shouldInjectDefaultResearchArtifactPath,
+  withDefaultResearchArtifactPath,
+} from "./default-research-artifact-policy.ts";
+export {
+  applyDefaultResearchArtifactPath,
+  type DefaultResearchArtifactContext,
+  type DefaultResearchArtifactLogger,
+  type DefaultResearchArtifacts,
+  extractLatestUserText,
+  fetchLatestConversationUserText,
+  mirrorDefaultResearchRunArtifact,
+  shouldRetryCreateResearchArtifactAsUpdate,
+  updateDefaultResearchArtifacts,
+} from "./default-research-artifact-support.ts";
+export {
   buildHostedChildCompletedLog,
   buildHostedChildErrorLog,
   buildHostedChildExhaustedStepBudgetLog,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.337";
+export const VERSION = "0.1.338";


### PR DESCRIPTION
## Summary
- add reusable default research artifact path policy helpers
- add reusable research artifact runtime support for system reminders, path normalization, create/update retry, and run-artifact mirroring
- bump package version to 0.1.338 for CI/CD publishing

## Verification
- deno check src/agent/index.ts src/agent/default-research-artifact-policy.ts src/agent/default-research-artifact-policy.test.ts src/agent/default-research-artifact-support.ts src/agent/default-research-artifact-support.test.ts
- deno test --no-check --allow-all src/agent/default-research-artifact-policy.test.ts src/agent/default-research-artifact-support.test.ts
- deno task verify:quick && deno task audit && deno task build:npm
- pre-push format, lint, typecheck, unit tests