### PR TITLE
Expose slash command artifact policy

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.338",
+  "version": "0.1.339",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -436,6 +436,12 @@ export {
   updateDefaultResearchArtifacts,
 } from "./default-research-artifact-support.ts";
 export {
+  containsExactArtifactPathValue,
+  evaluateSlashCommandArtifactPolicy,
+  type SlashCommandArtifactPolicy,
+  type SlashCommandArtifactPolicyInput,
+} from "./slash-command-artifact-policy.ts";
+export {
   buildHostedChildCompletedLog,
   buildHostedChildErrorLog,
   buildHostedChildExhaustedStepBudgetLog,

--- a/src/agent/slash-command-artifact-policy.test.ts
+++ b/src/agent/slash-command-artifact-policy.test.ts
@@ -1,0 +1,224 @@
+import { assertEquals } from "@std/assert";
+import {
+  containsExactArtifactPathValue,
+  evaluateSlashCommandArtifactPolicy,
+} from "./slash-command-artifact-policy.ts";
+
+const EXACT_PLAN_COMMAND =
+  '<span data-command="plan">/plan</span> Create or update exactly /plans/budget-planning.md in this run.';
+const FORM_INPUT_PLAN_COMMAND =
+  '<span data-command="plan">/plan</span> Create a concrete implementation plan for this idea. Ask clarifying questions first, then produce markdown that matches the existing /plans conventions in this repository.';
+const FORM_INPUT_IDEA =
+  "Write a consolidated budget-planning plan to /plans/budget-planning.md that supersedes the existing plan.";
+const PLAN_SKILL_RESULT = { skillId: "plan", instructions: "Plan instructions" };
+
+function userMessage(content: string) {
+  return { role: "user", content };
+}
+
+function assistantMessage(content: unknown[]) {
+  return { role: "assistant", content };
+}
+
+function toolMessage(content: unknown[]) {
+  return { role: "tool", content };
+}
+
+function toolRoleJsonStringMessage(toolCallId: string, content: string) {
+  return { role: "tool", toolCallId, content };
+}
+
+function loadSkillCall(toolCallId = "tool-call-1") {
+  return toolCall(toolCallId, "load_skill", { skillId: "plan" });
+}
+
+function formInputCall(toolCallId = "tool-call-2") {
+  return toolCall(toolCallId, "form_input", { title: "What should the plan cover?" });
+}
+
+function invokeAgentCall(toolCallId = "tool-call-2") {
+  return toolCall(toolCallId, "invoke_agent", { task: "Write the plan" });
+}
+
+function toolCall(toolCallId: string, toolName: string, input: Record<string, unknown>) {
+  return {
+    type: "tool-call",
+    toolCallId,
+    toolName,
+    input,
+  };
+}
+
+function loadSkillResult(toolCallId = "tool-call-1") {
+  return toolResult(toolCallId, "load_skill", PLAN_SKILL_RESULT);
+}
+
+function formInputResult(toolCallId = "tool-call-2") {
+  return toolResult(toolCallId, "form_input", formInputSubmission());
+}
+
+function formInputResultWithoutToolName(toolCallId = "tool-call-2") {
+  return {
+    type: "tool-result",
+    toolCallId,
+    output: formInputSubmission(),
+  };
+}
+
+function toolResult(toolCallId: string, toolName: string, output: unknown) {
+  return {
+    type: "tool-result",
+    toolCallId,
+    toolName,
+    output,
+  };
+}
+
+function formInputSubmission() {
+  return {
+    submitted: true,
+    values: {
+      idea: FORM_INPUT_IDEA,
+    },
+  };
+}
+
+Deno.test("slash-command artifact policy detects exact artifact paths inside submitted values", () => {
+  assertEquals(
+    containsExactArtifactPathValue({
+      submitted: true,
+      values: { idea: FORM_INPUT_IDEA },
+    }),
+    true,
+  );
+});
+
+Deno.test("slash-command artifact policy keeps the artifact reminder after load_skill", () => {
+  assertEquals(
+    evaluateSlashCommandArtifactPolicy({
+      messages: [
+        userMessage(EXACT_PLAN_COMMAND),
+        assistantMessage([loadSkillCall()]),
+        toolMessage([loadSkillResult()]),
+      ],
+    }),
+    {
+      hasSlashCommand: true,
+      hasExactArtifactPath: true,
+      hasLoadSkill: true,
+      hasInvokeAgent: false,
+      shouldKeepReminder: true,
+    },
+  );
+});
+
+Deno.test("slash-command artifact policy keeps the artifact reminder for form_input results", () => {
+  assertEquals(
+    evaluateSlashCommandArtifactPolicy({
+      messages: [
+        userMessage(FORM_INPUT_PLAN_COMMAND),
+        assistantMessage([loadSkillCall(), formInputCall()]),
+        toolMessage([loadSkillResult(), formInputResult()]),
+      ],
+    }),
+    {
+      hasSlashCommand: true,
+      hasExactArtifactPath: true,
+      hasLoadSkill: true,
+      hasInvokeAgent: false,
+      shouldKeepReminder: true,
+    },
+  );
+});
+
+Deno.test("slash-command artifact policy resolves resumed form_input results without toolName", () => {
+  assertEquals(
+    evaluateSlashCommandArtifactPolicy({
+      messages: [
+        userMessage(FORM_INPUT_PLAN_COMMAND),
+        assistantMessage([loadSkillCall(), formInputCall()]),
+        assistantMessage([formInputResultWithoutToolName()]),
+      ],
+    }),
+    {
+      hasSlashCommand: true,
+      hasExactArtifactPath: true,
+      hasLoadSkill: true,
+      hasInvokeAgent: false,
+      shouldKeepReminder: true,
+    },
+  );
+});
+
+Deno.test("slash-command artifact policy resolves resumed form_input tool-role JSON strings", () => {
+  assertEquals(
+    evaluateSlashCommandArtifactPolicy({
+      messages: [
+        userMessage(FORM_INPUT_PLAN_COMMAND),
+        assistantMessage([loadSkillCall(), formInputCall()]),
+        toolRoleJsonStringMessage("tool-call-2", JSON.stringify(formInputSubmission())),
+      ],
+    }),
+    {
+      hasSlashCommand: true,
+      hasExactArtifactPath: true,
+      hasLoadSkill: true,
+      hasInvokeAgent: false,
+      shouldKeepReminder: true,
+    },
+  );
+});
+
+Deno.test("slash-command artifact policy drops the reminder after invoke_agent starts", () => {
+  assertEquals(
+    evaluateSlashCommandArtifactPolicy({
+      messages: [
+        userMessage(EXACT_PLAN_COMMAND),
+        assistantMessage([loadSkillCall(), invokeAgentCall()]),
+        toolMessage([loadSkillResult()]),
+      ],
+    }),
+    {
+      hasSlashCommand: true,
+      hasExactArtifactPath: true,
+      hasLoadSkill: true,
+      hasInvokeAgent: true,
+      shouldKeepReminder: false,
+    },
+  );
+});
+
+Deno.test("slash-command artifact policy preserves persisted exact-path state before invoke_agent", () => {
+  assertEquals(
+    evaluateSlashCommandArtifactPolicy({
+      messages: [userMessage(FORM_INPUT_PLAN_COMMAND), assistantMessage([loadSkillCall()])],
+      slashCommandArtifactPathSeen: true,
+    }),
+    {
+      hasSlashCommand: true,
+      hasExactArtifactPath: true,
+      hasLoadSkill: true,
+      hasInvokeAgent: false,
+      shouldKeepReminder: true,
+    },
+  );
+});
+
+Deno.test("slash-command artifact policy drops persisted exact-path state after invoke_agent starts", () => {
+  assertEquals(
+    evaluateSlashCommandArtifactPolicy({
+      messages: [
+        userMessage(EXACT_PLAN_COMMAND),
+        assistantMessage([loadSkillCall(), invokeAgentCall()]),
+      ],
+      slashCommandArtifactPathSeen: true,
+    }),
+    {
+      hasSlashCommand: true,
+      hasExactArtifactPath: true,
+      hasLoadSkill: true,
+      hasInvokeAgent: true,
+      shouldKeepReminder: false,
+    },
+  );
+});

--- a/src/agent/slash-command-artifact-policy.ts
+++ b/src/agent/slash-command-artifact-policy.ts
@@ -1,0 +1,212 @@
+import { isRecord } from "../chat/conversation.ts";
+
+const SLASH_COMMAND_PATTERN = /(?:^|<span\s+data-command="[^"]+">)\s*\/[a-z0-9_-]+/i;
+const EXACT_ARTIFACT_PATH_PATTERN = /(?:^|[\s`"'(])\/?[\w./-]+\.(?:md|mdx|txt|json|ya?ml)\b/i;
+
+export interface SlashCommandArtifactPolicyInput {
+  messages: readonly unknown[];
+  slashCommandArtifactPathSeen?: boolean;
+}
+
+export interface SlashCommandArtifactPolicy {
+  hasSlashCommand: boolean;
+  hasExactArtifactPath: boolean;
+  hasLoadSkill: boolean;
+  hasInvokeAgent: boolean;
+  shouldKeepReminder: boolean;
+}
+
+function isToolCallPart(
+  part: unknown,
+): part is { type: "tool-call"; toolCallId: string; toolName: string } {
+  return (
+    isRecord(part) &&
+    part.type === "tool-call" &&
+    typeof part.toolCallId === "string" &&
+    typeof part.toolName === "string"
+  );
+}
+
+function isToolResultPart(part: unknown): part is {
+  type: "tool-result";
+  toolCallId: string;
+  toolName?: string;
+  output?: unknown;
+  result?: unknown;
+} {
+  return isRecord(part) && part.type === "tool-result" && typeof part.toolCallId === "string";
+}
+
+function isToolRoleMessage(message: unknown): message is {
+  role: "tool";
+  toolCallId?: string;
+  toolName?: string;
+  content: unknown;
+} {
+  return isRecord(message) && message.role === "tool" && "content" in message;
+}
+
+function parseJsonString(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function extractArtifactPathsFromUnknown(value: unknown): string[] {
+  if (typeof value === "string") {
+    return EXACT_ARTIFACT_PATH_PATTERN.test(value) ? [value] : [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => extractArtifactPathsFromUnknown(item));
+  }
+
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  return Object.values(value).flatMap((nestedValue) =>
+    extractArtifactPathsFromUnknown(nestedValue)
+  );
+}
+
+function extractMessageTexts(content: unknown): string[] {
+  if (typeof content === "string" && content.trim().length > 0) {
+    return [content];
+  }
+
+  if (!Array.isArray(content)) {
+    return [];
+  }
+
+  return content.flatMap((part) =>
+    isRecord(part) && part.type === "text" && typeof part.text === "string" &&
+      part.text.trim().length > 0
+      ? [part.text]
+      : []
+  );
+}
+
+function resolveToolName(
+  toolCallNamesById: ReadonlyMap<string, string>,
+  value: { toolName?: string; toolCallId?: string },
+): string | undefined {
+  if (typeof value.toolName === "string" && value.toolName.length > 0) {
+    return value.toolName;
+  }
+
+  return typeof value.toolCallId === "string" ? toolCallNamesById.get(value.toolCallId) : undefined;
+}
+
+function hasToolCallOrResult(messages: readonly unknown[], toolName: string): boolean {
+  return messages.some((message) => {
+    if (!isRecord(message) || !Array.isArray(message.content)) {
+      return false;
+    }
+
+    return message.content.some((part) => {
+      if (!isRecord(part) || typeof part.toolName !== "string") {
+        return false;
+      }
+
+      return (part.type === "tool-call" || part.type === "tool-result") &&
+        part.toolName === toolName;
+    });
+  });
+}
+
+function containsSlashCommand(messages: readonly unknown[]): boolean {
+  return messages.some((message) => {
+    if (!isRecord(message) || message.role !== "user") {
+      return false;
+    }
+
+    return extractMessageTexts(message.content).some((text) => SLASH_COMMAND_PATTERN.test(text));
+  });
+}
+
+function containsExactArtifactPath(messages: readonly unknown[]): boolean {
+  const toolCallNamesById = new Map<string, string>();
+
+  for (const message of messages) {
+    if (!isRecord(message) || !Array.isArray(message.content)) {
+      continue;
+    }
+
+    for (const part of message.content) {
+      if (!isToolCallPart(part)) {
+        continue;
+      }
+
+      toolCallNamesById.set(part.toolCallId, part.toolName);
+    }
+  }
+
+  return messages.some((message) => {
+    if (!isRecord(message)) {
+      return false;
+    }
+
+    if (message.role === "user") {
+      return extractMessageTexts(message.content).some((text) =>
+        EXACT_ARTIFACT_PATH_PATTERN.test(text)
+      );
+    }
+
+    if (isToolRoleMessage(message) && !Array.isArray(message.content)) {
+      const resolvedToolName = resolveToolName(toolCallNamesById, message);
+
+      if (resolvedToolName !== "form_input") {
+        return false;
+      }
+
+      const parsedContent = typeof message.content === "string"
+        ? parseJsonString(message.content)
+        : message.content;
+      return containsExactArtifactPathValue(parsedContent);
+    }
+
+    if (!Array.isArray(message.content)) {
+      return false;
+    }
+
+    return message.content.some((part) => {
+      if (!isToolResultPart(part) || !isRecord(part)) {
+        return false;
+      }
+
+      const resolvedToolName = resolveToolName(toolCallNamesById, part);
+
+      if (resolvedToolName !== "form_input") {
+        return false;
+      }
+
+      return containsExactArtifactPathValue(part.output) ||
+        containsExactArtifactPathValue(part.result);
+    });
+  });
+}
+
+export function containsExactArtifactPathValue(value: unknown): boolean {
+  return extractArtifactPathsFromUnknown(value).length > 0;
+}
+
+export function evaluateSlashCommandArtifactPolicy(
+  input: SlashCommandArtifactPolicyInput,
+): SlashCommandArtifactPolicy {
+  const hasSlashCommand = containsSlashCommand(input.messages);
+  const hasExactArtifactPath = containsExactArtifactPath(input.messages) ||
+    input.slashCommandArtifactPathSeen === true;
+  const hasLoadSkill = hasToolCallOrResult(input.messages, "load_skill");
+  const hasInvokeAgent = hasToolCallOrResult(input.messages, "invoke_agent");
+
+  return {
+    hasSlashCommand,
+    hasExactArtifactPath,
+    hasLoadSkill,
+    hasInvokeAgent,
+    shouldKeepReminder: hasSlashCommand && hasExactArtifactPath && hasLoadSkill && !hasInvokeAgent,
+  };
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.338";
+export const VERSION = "0.1.339";


### PR DESCRIPTION
## Summary\n- add a reusable slash-command artifact reminder policy helper\n- export exact artifact path detection from the agent package\n- bump package version to 0.1.339\n\n## Verification\n- deno check src/agent/slash-command-artifact-policy.ts src/agent/slash-command-artifact-policy.test.ts\n- deno test --no-check --allow-all src/agent/slash-command-artifact-policy.test.ts\n- deno task verify:quick && deno task audit && deno task build:npm\n- pre-push checks