### PR TITLE
Expose runtime skill metadata helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.339",
+  "version": "0.1.340",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -442,6 +442,17 @@ export {
   type SlashCommandArtifactPolicyInput,
 } from "./slash-command-artifact-policy.ts";
 export {
+  buildRuntimeSkillDefinition,
+  normalizeRuntimeSkillReferencePath,
+  type ParsedRuntimeSkillDocument,
+  parseRuntimeSkillDocument,
+  parseRuntimeSkillMetadata,
+  type RuntimeSkillDefinition,
+  type RuntimeSkillFrontmatter,
+  RuntimeSkillFrontmatterSchema,
+  type RuntimeSkillMetadataLogger,
+} from "./runtime-skill-metadata.ts";
+export {
   buildHostedChildCompletedLog,
   buildHostedChildErrorLog,
   buildHostedChildExhaustedStepBudgetLog,

--- a/src/agent/runtime-skill-metadata.test.ts
+++ b/src/agent/runtime-skill-metadata.test.ts
@@ -1,0 +1,188 @@
+import { assertEquals, assertExists } from "@std/assert";
+import {
+  buildRuntimeSkillDefinition,
+  normalizeRuntimeSkillReferencePath,
+  parseRuntimeSkillMetadata,
+} from "./runtime-skill-metadata.ts";
+
+Deno.test("parseRuntimeSkillMetadata parses valid frontmatter", () => {
+  const content = `---
+name: My Skill
+description: A useful skill
+---
+Body content here`;
+  const metadata = parseRuntimeSkillMetadata(content);
+  assertExists(metadata);
+  assertEquals(metadata.name, "My Skill");
+  assertEquals(metadata.description, "A useful skill");
+});
+
+Deno.test("parseRuntimeSkillMetadata returns empty metadata for content without frontmatter", () => {
+  const metadata = parseRuntimeSkillMetadata("no frontmatter here");
+  assertExists(metadata);
+  assertEquals(metadata.name, undefined);
+  assertEquals(metadata.description, undefined);
+});
+
+Deno.test("parseRuntimeSkillMetadata returns empty metadata for empty content", () => {
+  const metadata = parseRuntimeSkillMetadata("");
+  assertExists(metadata);
+  assertEquals(metadata.name, undefined);
+});
+
+Deno.test("buildRuntimeSkillDefinition builds a skill definition from valid content", () => {
+  const content = `---
+name: Code Review
+description: Reviews code quality
+---
+# Code Review Skill
+Review the code for quality issues.`;
+
+  const skill = buildRuntimeSkillDefinition({ id: "code-review", content });
+  assertExists(skill);
+  assertEquals(skill.id, "code-review");
+  assertEquals(skill.name, "Code Review");
+  assertEquals(skill.description, "Reviews code quality");
+  assertEquals(skill.instructions, content);
+});
+
+Deno.test("buildRuntimeSkillDefinition uses id as fallback name", () => {
+  const content = `---
+description: A skill
+---
+Body`;
+  const skill = buildRuntimeSkillDefinition({ id: "my-skill", content });
+  assertEquals(skill?.name, "my-skill");
+});
+
+Deno.test("buildRuntimeSkillDefinition extracts description from markdown body", () => {
+  const content = `---
+name: Test
+---
+# This is the heading
+Some body text`;
+  const skill = buildRuntimeSkillDefinition({ id: "test", content });
+  assertEquals(skill?.description, "This is the heading");
+});
+
+Deno.test("buildRuntimeSkillDefinition builds a bare skill", () => {
+  const skill = buildRuntimeSkillDefinition({ id: "bare", content: "Just a body" });
+  assertExists(skill);
+  assertEquals(skill.id, "bare");
+  assertEquals(skill.name, "bare");
+});
+
+Deno.test("buildRuntimeSkillDefinition includes optional runtime fields", () => {
+  const content = `---
+name: Skill
+description: Desc
+model: sonnet
+thinking: 5000
+max-steps: 20
+allowed-tools:
+  - bash
+  - readFile
+---
+Body`;
+  const skill = buildRuntimeSkillDefinition({ id: "s1", content });
+  assertEquals(skill?.model, "sonnet");
+  assertEquals(skill?.thinking, 5000);
+  assertEquals(skill?.maxSteps, 20);
+  assertEquals(skill?.allowedTools, ["bash", "readFile"]);
+});
+
+Deno.test("buildRuntimeSkillDefinition parses comma and whitespace allowed-tools strings", () => {
+  const commaSkill = buildRuntimeSkillDefinition({
+    id: "comma",
+    content: `---
+allowed-tools: bash, readFile
+---
+Body`,
+  });
+  const whitespaceSkill = buildRuntimeSkillDefinition({
+    id: "space",
+    content: `---
+allowed-tools: bash readFile
+---
+Body`,
+  });
+
+  assertEquals(commaSkill?.allowedTools, ["bash", "readFile"]);
+  assertEquals(whitespaceSkill?.allowedTools, ["bash", "readFile"]);
+});
+
+Deno.test("buildRuntimeSkillDefinition includes references when provided", () => {
+  const content = `---
+name: Skill
+description: Desc
+---
+Body`;
+  const skill = buildRuntimeSkillDefinition({
+    id: "s1",
+    content,
+    references: ["ref1.md", "ref2.md"],
+  });
+  assertEquals(skill?.references, ["ref1.md", "ref2.md"]);
+});
+
+Deno.test("buildRuntimeSkillDefinition omits references when empty", () => {
+  const content = `---
+name: Skill
+description: Desc
+---
+Body`;
+  const skill = buildRuntimeSkillDefinition({ id: "s1", content, references: [] });
+  assertEquals(skill?.references, undefined);
+});
+
+Deno.test("buildRuntimeSkillDefinition returns null and logs invalid metadata", () => {
+  const errors: Array<Record<string, unknown> | undefined> = [];
+  const skill = buildRuntimeSkillDefinition({
+    id: "invalid",
+    content: `---
+allowed-tools:
+  - bash
+  - 123
+---
+Body`,
+    logger: {
+      error: (_message, metadata) => errors.push(metadata),
+    },
+  });
+
+  assertEquals(skill, null);
+  assertEquals(errors.length, 1);
+});
+
+Deno.test("normalizeRuntimeSkillReferencePath normalizes a simple path", () => {
+  assertEquals(normalizeRuntimeSkillReferencePath("docs/guide.md"), "docs/guide.md");
+});
+
+Deno.test("normalizeRuntimeSkillReferencePath converts backslashes", () => {
+  assertEquals(normalizeRuntimeSkillReferencePath("docs\\guide.md"), "docs/guide.md");
+});
+
+Deno.test("normalizeRuntimeSkillReferencePath trims whitespace", () => {
+  assertEquals(normalizeRuntimeSkillReferencePath("  docs/guide.md  "), "docs/guide.md");
+});
+
+Deno.test("normalizeRuntimeSkillReferencePath rejects absolute paths", () => {
+  assertEquals(normalizeRuntimeSkillReferencePath("/etc/passwd"), null);
+});
+
+Deno.test("normalizeRuntimeSkillReferencePath rejects parent traversal", () => {
+  assertEquals(normalizeRuntimeSkillReferencePath("../escape/attempt"), null);
+});
+
+Deno.test("normalizeRuntimeSkillReferencePath rejects dot segments", () => {
+  assertEquals(normalizeRuntimeSkillReferencePath("./relative"), null);
+});
+
+Deno.test("normalizeRuntimeSkillReferencePath rejects empty paths", () => {
+  assertEquals(normalizeRuntimeSkillReferencePath(""), null);
+  assertEquals(normalizeRuntimeSkillReferencePath("   "), null);
+});
+
+Deno.test("normalizeRuntimeSkillReferencePath rejects empty segments", () => {
+  assertEquals(normalizeRuntimeSkillReferencePath("docs//guide.md"), null);
+});

--- a/src/agent/runtime-skill-metadata.ts
+++ b/src/agent/runtime-skill-metadata.ts
@@ -1,0 +1,158 @@
+import { extract } from "#std/front-matter/yaml.ts";
+import { z } from "zod";
+
+function normalizeAllowedTools(value: string | string[] | undefined): string[] {
+  if (value === undefined) {
+    return [];
+  }
+
+  const values = Array.isArray(value)
+    ? value
+    : value.includes(",")
+    ? value.split(",")
+    : value.split(/\s+/);
+
+  return values.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
+}
+
+const rawRuntimeSkillFrontmatterSchema = z
+  .object({
+    name: z.string().optional(),
+    description: z.string().optional(),
+    "allowed-tools": z.union([z.string(), z.array(z.string())]).optional(),
+    model: z.string().optional(),
+    thinking: z.union([z.literal(false), z.coerce.number().int().positive()]).optional(),
+    "max-steps": z.coerce.number().int().positive().optional(),
+  })
+  .passthrough();
+
+export const RuntimeSkillFrontmatterSchema = rawRuntimeSkillFrontmatterSchema.transform((data) => ({
+  name: data.name?.trim() || undefined,
+  description: data.description?.trim() || undefined,
+  allowedTools: normalizeAllowedTools(data["allowed-tools"]),
+  model: data.model?.trim() || undefined,
+  thinking: data.thinking,
+  maxSteps: data["max-steps"],
+}));
+
+export type RuntimeSkillFrontmatter = z.infer<typeof RuntimeSkillFrontmatterSchema>;
+
+export type RuntimeSkillDefinition = {
+  id: string;
+  name: string;
+  description: string;
+  instructions: string;
+  allowedTools: string[];
+  model?: string;
+  thinking?: false | number;
+  maxSteps?: number;
+  references?: string[];
+};
+
+export type RuntimeSkillMetadataLogger = {
+  error?: (message: string, metadata?: Record<string, unknown>) => void;
+};
+
+export type ParsedRuntimeSkillDocument = {
+  metadata: RuntimeSkillFrontmatter;
+  body: string;
+};
+
+function extractDescriptionFromMarkdown(content: string, fallback: string): string {
+  const lines = content.split("\n");
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+
+    const headerMatch = /^#+\s+(.+)$/.exec(trimmed);
+    const description = (headerMatch?.[1] ?? trimmed).trim();
+
+    if (description.length <= 100) {
+      return description;
+    }
+
+    return `${description.slice(0, 97)}...`;
+  }
+
+  return fallback;
+}
+
+export function parseRuntimeSkillDocument(
+  content: string,
+  options: { logger?: RuntimeSkillMetadataLogger } = {},
+): ParsedRuntimeSkillDocument | null {
+  try {
+    const parsed = extract<Record<string, unknown>>(content);
+    const result = RuntimeSkillFrontmatterSchema.safeParse(parsed.attrs);
+
+    if (!result.success) {
+      options.logger?.error?.("Invalid skill frontmatter; skipping skill", {
+        error: result.error.message,
+      });
+      return null;
+    }
+
+    return {
+      metadata: result.data,
+      body: parsed.body,
+    };
+  } catch (error) {
+    options.logger?.error?.("Invalid skill frontmatter; skipping skill", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+export function parseRuntimeSkillMetadata(
+  content: string,
+  options: { logger?: RuntimeSkillMetadataLogger } = {},
+): RuntimeSkillFrontmatter | null {
+  return parseRuntimeSkillDocument(content, options)?.metadata ?? null;
+}
+
+export function buildRuntimeSkillDefinition(input: {
+  id: string;
+  content: string;
+  references?: readonly string[];
+  logger?: RuntimeSkillMetadataLogger;
+}): RuntimeSkillDefinition | null {
+  const document = parseRuntimeSkillDocument(input.content, { logger: input.logger });
+  if (!document) {
+    return null;
+  }
+
+  const { metadata, body } = document;
+
+  return {
+    id: input.id,
+    name: metadata.name ?? input.id,
+    description: metadata.description ?? extractDescriptionFromMarkdown(body, input.id),
+    instructions: input.content,
+    allowedTools: metadata.allowedTools,
+    ...(metadata.model ? { model: metadata.model } : {}),
+    ...(metadata.thinking !== undefined ? { thinking: metadata.thinking } : {}),
+    ...(metadata.maxSteps !== undefined ? { maxSteps: metadata.maxSteps } : {}),
+    ...(input.references && input.references.length > 0
+      ? { references: [...input.references] }
+      : {}),
+  };
+}
+
+export function normalizeRuntimeSkillReferencePath(path: string): string | null {
+  const normalized = path.trim().replaceAll("\\", "/");
+
+  if (normalized.length === 0 || normalized.startsWith("/")) {
+    return null;
+  }
+
+  const segments = normalized.split("/");
+  if (segments.some((segment) => segment.length === 0 || segment === "." || segment === "..")) {
+    return null;
+  }
+
+  return segments.join("/");
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.339";
+export const VERSION = "0.1.340";


### PR DESCRIPTION
## Summary\n- add reusable runtime skill frontmatter parsing and definition helpers\n- add safe runtime skill reference path normalization\n- bump package version to 0.1.340\n\n## Verification\n- deno check src/agent/runtime-skill-metadata.ts src/agent/runtime-skill-metadata.test.ts src/agent/index.ts\n- deno test --no-check --allow-all src/agent/runtime-skill-metadata.test.ts\n- deno task verify:quick && deno task audit && deno task build:npm\n- pre-push checks