### PR TITLE
Expose runtime loaded skill response helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.340",
+  "version": "0.1.341",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -442,11 +442,14 @@ export {
   type SlashCommandArtifactPolicyInput,
 } from "./slash-command-artifact-policy.ts";
 export {
+  buildRuntimeLoadedSkillResponse,
   buildRuntimeSkillDefinition,
   normalizeRuntimeSkillReferencePath,
   type ParsedRuntimeSkillDocument,
   parseRuntimeSkillDocument,
   parseRuntimeSkillMetadata,
+  type RuntimeLoadedSkillResponse,
+  type RuntimeLoadedSkillResponseMessages,
   type RuntimeSkillDefinition,
   type RuntimeSkillFrontmatter,
   RuntimeSkillFrontmatterSchema,

--- a/src/agent/runtime-skill-metadata.test.ts
+++ b/src/agent/runtime-skill-metadata.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertExists } from "@std/assert";
 import {
+  buildRuntimeLoadedSkillResponse,
   buildRuntimeSkillDefinition,
   normalizeRuntimeSkillReferencePath,
   parseRuntimeSkillMetadata,
@@ -185,4 +186,113 @@ Deno.test("normalizeRuntimeSkillReferencePath rejects empty paths", () => {
 
 Deno.test("normalizeRuntimeSkillReferencePath rejects empty segments", () => {
   assertEquals(normalizeRuntimeSkillReferencePath("docs//guide.md"), null);
+});
+
+const loadedSkillMessages = {
+  allowedToolsNote: "Use only allowed tools.",
+  noCurrentRunToolsNote: "No direct tools are available.",
+  unavailableCurrentRunToolsDelegationNote: "Delegate unavailable tools.",
+  overrideNote: "Forward overrides.",
+  referenceNote: "Load references separately.",
+};
+
+Deno.test("buildRuntimeLoadedSkillResponse includes basic response fields", () => {
+  const response = buildRuntimeLoadedSkillResponse({
+    skillId: "plan",
+    instructions: "Plan carefully.",
+    nextStep: "Continue after loading.",
+    messages: loadedSkillMessages,
+  });
+
+  assertEquals(response, {
+    skillId: "plan",
+    instructions: "Plan carefully.",
+    nextStep: "Continue after loading.",
+  });
+});
+
+Deno.test("buildRuntimeLoadedSkillResponse filters allowed tools to current run surface", () => {
+  const response = buildRuntimeLoadedSkillResponse({
+    skillId: "write",
+    instructions: `---
+allowed-tools: read_file, write_file, shell
+---
+Write carefully.`,
+    nextStep: "Continue after loading.",
+    messages: loadedSkillMessages,
+    availableToolNames: ["read_file", "write_file"],
+  });
+
+  assertEquals(response.allowedTools, ["read_file", "write_file"]);
+  assertEquals(response.delegationTools, ["read_file", "write_file", "shell"]);
+  assertEquals(response.unavailableCurrentRunTools, ["shell"]);
+  assertEquals(response.note, "Use only allowed tools.");
+  assertEquals(response.delegationNote, "Delegate unavailable tools.");
+});
+
+Deno.test("buildRuntimeLoadedSkillResponse returns empty allowedTools when declared tools have no current run overlap", () => {
+  const response = buildRuntimeLoadedSkillResponse({
+    skillId: "write",
+    instructions: `---
+allowed-tools:
+  - shell
+---
+Write carefully.`,
+    nextStep: "Continue after loading.",
+    messages: loadedSkillMessages,
+    availableToolNames: ["read_file"],
+  });
+
+  assertEquals(response.allowedTools, []);
+  assertEquals(response.delegationTools, ["shell"]);
+  assertEquals(response.unavailableCurrentRunTools, ["shell"]);
+  assertEquals(response.note, "No direct tools are available.");
+});
+
+Deno.test("buildRuntimeLoadedSkillResponse preserves runtime overrides and references", () => {
+  const response = buildRuntimeLoadedSkillResponse({
+    skillId: "research",
+    instructions: `---
+model: sonnet
+thinking: 2000
+max-steps: 8
+---
+Research carefully.`,
+    nextStep: "Continue after loading.",
+    messages: loadedSkillMessages,
+    references: ["references/guide.md"],
+  });
+
+  assertEquals(response.model, "sonnet");
+  assertEquals(response.thinking, 2000);
+  assertEquals(response.maxSteps, 8);
+  assertEquals(response.overrideNote, "Forward overrides.");
+  assertEquals(response.references, ["references/guide.md"]);
+  assertEquals(response.referenceNote, "Load references separately.");
+});
+
+Deno.test("buildRuntimeLoadedSkillResponse logs invalid metadata and returns a base response", () => {
+  const instructions = `---
+allowed-tools:
+  - shell
+  - 123
+---
+Body`;
+  const errors: Array<Record<string, unknown> | undefined> = [];
+  const response = buildRuntimeLoadedSkillResponse({
+    skillId: "invalid",
+    instructions,
+    nextStep: "Continue after loading.",
+    messages: loadedSkillMessages,
+    logger: {
+      error: (_message, metadata) => errors.push(metadata),
+    },
+  });
+
+  assertEquals(response, {
+    skillId: "invalid",
+    instructions,
+    nextStep: "Continue after loading.",
+  });
+  assertEquals(errors.length, 1);
 });

--- a/src/agent/runtime-skill-metadata.ts
+++ b/src/agent/runtime-skill-metadata.ts
@@ -49,6 +49,31 @@ export type RuntimeSkillDefinition = {
   references?: string[];
 };
 
+export type RuntimeLoadedSkillResponseMessages = {
+  allowedToolsNote: string;
+  noCurrentRunToolsNote: string;
+  unavailableCurrentRunToolsDelegationNote: string;
+  overrideNote: string;
+  referenceNote: string;
+};
+
+export type RuntimeLoadedSkillResponse = {
+  skillId: string;
+  instructions: string;
+  nextStep: string;
+  allowedTools?: string[];
+  note?: string;
+  delegationTools?: string[];
+  unavailableCurrentRunTools?: string[];
+  delegationNote?: string;
+  model?: string;
+  thinking?: false | number;
+  maxSteps?: number;
+  overrideNote?: string;
+  references?: string[];
+  referenceNote?: string;
+};
+
 export type RuntimeSkillMetadataLogger = {
   error?: (message: string, metadata?: Record<string, unknown>) => void;
 };
@@ -155,4 +180,64 @@ export function normalizeRuntimeSkillReferencePath(path: string): string | null 
   }
 
   return segments.join("/");
+}
+
+export function buildRuntimeLoadedSkillResponse(input: {
+  skillId: string;
+  instructions: string;
+  nextStep: string;
+  messages: RuntimeLoadedSkillResponseMessages;
+  references?: readonly string[];
+  availableToolNames?: readonly string[];
+  logger?: RuntimeSkillMetadataLogger;
+}): RuntimeLoadedSkillResponse {
+  const metadata = parseRuntimeSkillMetadata(input.instructions, { logger: input.logger });
+  const declaredAllowedTools = metadata?.allowedTools ?? [];
+  const availableToolNameSet = input.availableToolNames && input.availableToolNames.length > 0
+    ? new Set(input.availableToolNames)
+    : null;
+  const currentRunAllowedTools = availableToolNameSet
+    ? declaredAllowedTools.filter((toolName) => availableToolNameSet.has(toolName))
+    : declaredAllowedTools;
+  const unavailableCurrentRunTools = availableToolNameSet && declaredAllowedTools.length > 0
+    ? declaredAllowedTools.filter((toolName) => !availableToolNameSet.has(toolName))
+    : [];
+  const hasOverrides = metadata?.model !== undefined || metadata?.thinking !== undefined ||
+    metadata?.maxSteps !== undefined;
+  const hasDeclaredAllowedTools = declaredAllowedTools.length > 0;
+
+  return {
+    skillId: input.skillId,
+    instructions: input.instructions,
+    nextStep: input.nextStep,
+    ...(hasDeclaredAllowedTools
+      ? {
+        allowedTools: currentRunAllowedTools,
+        note: currentRunAllowedTools.length > 0
+          ? input.messages.allowedToolsNote
+          : input.messages.noCurrentRunToolsNote,
+      }
+      : {}),
+    ...(hasDeclaredAllowedTools ? { delegationTools: declaredAllowedTools } : {}),
+    ...(unavailableCurrentRunTools.length > 0
+      ? {
+        unavailableCurrentRunTools,
+        delegationNote: input.messages.unavailableCurrentRunToolsDelegationNote,
+      }
+      : {}),
+    ...(metadata?.model ? { model: metadata.model } : {}),
+    ...(metadata?.thinking !== undefined ? { thinking: metadata.thinking } : {}),
+    ...(metadata?.maxSteps !== undefined ? { maxSteps: metadata.maxSteps } : {}),
+    ...(hasOverrides
+      ? {
+        overrideNote: input.messages.overrideNote,
+      }
+      : {}),
+    ...(input.references && input.references.length > 0
+      ? {
+        references: [...input.references],
+        referenceNote: input.messages.referenceNote,
+      }
+      : {}),
+  };
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.340";
+export const VERSION = "0.1.341";


### PR DESCRIPTION
## Summary\n- add a reusable runtime loaded-skill response builder for skill metadata, allowed tool filtering, runtime overrides, and reference metadata\n- export the helper and response types from veryfront/agent\n- bump package version to 0.1.341\n\n## Verification\n- deno check src/agent/runtime-skill-metadata.ts src/agent/runtime-skill-metadata.test.ts src/agent/index.ts\n- deno test --no-check --allow-all src/agent/runtime-skill-metadata.test.ts\n- deno task verify:quick && deno task audit && deno task build:npm\n- pre-push: format, lint, typecheck, unit tests (1544 passed / 17340 steps)