### PR TITLE
Expose project scoped remote tool helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.341",
+  "version": "0.1.342",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -70,6 +70,12 @@ export {
   loadRemoteToolsFromSource,
 } from "./remote-source-tools.ts";
 export type { RemoteToolMaterializationOptions } from "./remote-source-tools.ts";
+export {
+  filterProjectScopedRemoteToolDefinitions,
+  hydrateProjectScopedRemoteToolInput,
+  isProjectNavigationRemoteTool,
+} from "./project-scoped-remote-tools.ts";
+export type { ProjectScopedRemoteToolOptions } from "./project-scoped-remote-tools.ts";
 
 export { toolRegistry } from "./registry.ts";
 

--- a/src/tool/project-scoped-remote-tools.test.ts
+++ b/src/tool/project-scoped-remote-tools.test.ts
@@ -1,0 +1,137 @@
+import { assertEquals, assertStrictEquals } from "@std/assert";
+import {
+  filterProjectScopedRemoteToolDefinitions,
+  hydrateProjectScopedRemoteToolInput,
+  isProjectNavigationRemoteTool,
+} from "./project-scoped-remote-tools.ts";
+import type { ToolDefinition } from "./types.ts";
+
+function toolDefinition(input: {
+  name: string;
+  required?: string[];
+}): ToolDefinition {
+  return {
+    name: input.name,
+    description: input.name,
+    parameters: {
+      type: "object",
+      properties: {},
+      ...(input.required ? { required: input.required } : {}),
+    },
+  };
+}
+
+Deno.test("filterProjectScopedRemoteToolDefinitions hides project-bound tools when no active project exists", () => {
+  const tools = [
+    toolDefinition({ name: "list_projects" }),
+    toolDefinition({ name: "list_files", required: ["project_reference"] }),
+    toolDefinition({ name: "get_project", required: ["project_id"] }),
+  ];
+
+  assertEquals(
+    filterProjectScopedRemoteToolDefinitions(tools, null).map((tool) => tool.name),
+    ["list_projects"],
+  );
+});
+
+Deno.test("filterProjectScopedRemoteToolDefinitions preserves project-bound tools when an active project exists", () => {
+  const tools = [
+    toolDefinition({ name: "list_projects" }),
+    toolDefinition({ name: "list_files", required: ["project_reference"] }),
+  ];
+
+  assertEquals(
+    filterProjectScopedRemoteToolDefinitions(tools, "project-1").map((tool) => tool.name),
+    ["list_projects", "list_files"],
+  );
+});
+
+Deno.test("filterProjectScopedRemoteToolDefinitions does not infer project scope without required fields", () => {
+  const tools = [
+    toolDefinition({ name: "list_agents" }),
+    toolDefinition({ name: "list_workflows" }),
+  ];
+
+  assertEquals(
+    filterProjectScopedRemoteToolDefinitions(tools, null).map((tool) => tool.name),
+    ["list_agents", "list_workflows"],
+  );
+});
+
+Deno.test("filterProjectScopedRemoteToolDefinitions allows configured navigation tools without an active project", () => {
+  const tools = [
+    toolDefinition({ name: "open_project", required: ["project_id"] }),
+    toolDefinition({ name: "delete_project", required: ["project_id"] }),
+  ];
+
+  assertEquals(
+    filterProjectScopedRemoteToolDefinitions(tools, null, {
+      projectNavigationToolNames: ["open_project"],
+    }).map((tool) => tool.name),
+    ["open_project"],
+  );
+});
+
+Deno.test("isProjectNavigationRemoteTool checks configured navigation tools", () => {
+  assertEquals(
+    isProjectNavigationRemoteTool("open_project", { projectNavigationToolNames: ["open_project"] }),
+    true,
+  );
+  assertEquals(
+    isProjectNavigationRemoteTool("delete_project", {
+      projectNavigationToolNames: ["open_project"],
+    }),
+    false,
+  );
+  assertEquals(isProjectNavigationRemoteTool("", { projectNavigationToolNames: [""] }), false);
+});
+
+Deno.test("hydrateProjectScopedRemoteToolInput injects project_reference when required", () => {
+  assertEquals(
+    hydrateProjectScopedRemoteToolInput({
+      toolDefinition: toolDefinition({ name: "list_files", required: ["project_reference"] }),
+      activeProjectId: "project-1",
+      toolInput: { pattern: "src" },
+    }),
+    { pattern: "src", project_reference: "project-1" },
+  );
+});
+
+Deno.test("hydrateProjectScopedRemoteToolInput preserves explicit project_reference", () => {
+  const toolInput = { project_reference: "explicit-project", pattern: "src" };
+
+  assertStrictEquals(
+    hydrateProjectScopedRemoteToolInput({
+      toolDefinition: toolDefinition({ name: "list_files", required: ["project_reference"] }),
+      activeProjectId: "project-1",
+      toolInput,
+    }),
+    toolInput,
+  );
+});
+
+Deno.test("hydrateProjectScopedRemoteToolInput leaves non-project-reference tools unchanged", () => {
+  const toolInput = { limit: 5 };
+
+  assertStrictEquals(
+    hydrateProjectScopedRemoteToolInput({
+      toolDefinition: toolDefinition({ name: "list_agents" }),
+      activeProjectId: "project-1",
+      toolInput,
+    }),
+    toolInput,
+  );
+});
+
+Deno.test("hydrateProjectScopedRemoteToolInput leaves inputs unchanged without active project", () => {
+  const toolInput = { pattern: "src" };
+
+  assertStrictEquals(
+    hydrateProjectScopedRemoteToolInput({
+      toolDefinition: toolDefinition({ name: "list_files", required: ["project_reference"] }),
+      activeProjectId: null,
+      toolInput,
+    }),
+    toolInput,
+  );
+});

--- a/src/tool/project-scoped-remote-tools.ts
+++ b/src/tool/project-scoped-remote-tools.ts
@@ -1,0 +1,86 @@
+import type { ToolDefinition } from "./types.ts";
+
+export type ProjectScopedRemoteToolOptions = {
+  projectNavigationToolNames?: readonly string[];
+};
+
+function getProjectNavigationToolNames(
+  options: ProjectScopedRemoteToolOptions,
+): ReadonlySet<string> {
+  return new Set(options.projectNavigationToolNames ?? []);
+}
+
+function getRequiredToolProperties(toolDefinition: ToolDefinition): string[] {
+  if (typeof toolDefinition.parameters !== "object" || toolDefinition.parameters === null) {
+    return [];
+  }
+
+  const required = Reflect.get(toolDefinition.parameters, "required");
+  return Array.isArray(required)
+    ? required.filter((property): property is string => typeof property === "string")
+    : [];
+}
+
+function requiresActiveProject(
+  toolDefinition: ToolDefinition,
+  options: ProjectScopedRemoteToolOptions,
+): boolean {
+  if (isProjectNavigationRemoteTool(toolDefinition.name, options)) {
+    return false;
+  }
+
+  return getRequiredToolProperties(toolDefinition).some(
+    (property) => property === "project_reference" || property === "project_id",
+  );
+}
+
+function requiresProjectReference(toolDefinition: ToolDefinition): boolean {
+  return getRequiredToolProperties(toolDefinition).includes("project_reference");
+}
+
+export function isProjectNavigationRemoteTool(
+  toolName: string,
+  options: ProjectScopedRemoteToolOptions = {},
+): boolean {
+  if (toolName.length === 0) {
+    return false;
+  }
+
+  return getProjectNavigationToolNames(options).has(toolName);
+}
+
+export function filterProjectScopedRemoteToolDefinitions(
+  toolDefinitions: readonly ToolDefinition[],
+  projectId: string | null,
+  options: ProjectScopedRemoteToolOptions = {},
+): ToolDefinition[] {
+  if (projectId) {
+    return [...toolDefinitions];
+  }
+
+  return toolDefinitions.filter((toolDefinition) =>
+    !requiresActiveProject(toolDefinition, options)
+  );
+}
+
+export function hydrateProjectScopedRemoteToolInput(input: {
+  toolDefinition: ToolDefinition | undefined;
+  activeProjectId: string | null;
+  toolInput: Record<string, unknown>;
+}): Record<string, unknown> {
+  if (
+    !input.toolDefinition || !input.activeProjectId ||
+    !requiresProjectReference(input.toolDefinition)
+  ) {
+    return input.toolInput;
+  }
+
+  if (input.toolInput.project_reference) {
+    return input.toolInput;
+  }
+
+  return {
+    ...input.toolInput,
+    project_reference: input.activeProjectId,
+  };
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.341";
+export const VERSION = "0.1.342";


### PR DESCRIPTION
## Summary\n- add reusable project-scoped remote tool filtering and input hydration helpers\n- support configurable project navigation tools rather than hard-coding a host-specific tool name\n- export helpers from veryfront/tool\n- bump package version to 0.1.342\n\n## Verification\n- deno check src/tool/project-scoped-remote-tools.ts src/tool/project-scoped-remote-tools.test.ts src/tool/index.ts\n- deno test --no-check --allow-all src/tool/project-scoped-remote-tools.test.ts\n- deno task verify:quick && deno task audit && deno task build:npm\n- pre-push: format, lint, typecheck, unit tests (1553 passed / 17340 steps)