### PR TITLE
Add reusable sleep tool

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.344",
+  "version": "0.1.345",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -55,6 +55,13 @@ export type {
 
 export { dynamicTool, tool } from "./factory.ts";
 export type { DynamicToolConfig } from "./factory.ts";
+export { createSleepTool, DEFAULT_SLEEP_TOOL_MAX_SECONDS, sleepTool } from "./sleep.ts";
+export type {
+  CreateSleepToolOptions,
+  SleepToolInput,
+  SleepToolOutput,
+  SleepToolWait,
+} from "./sleep.ts";
 export { createRemoteMCPToolSource } from "./remote-mcp.ts";
 export type { RemoteMCPToolSourceConfig } from "./remote-mcp.ts";
 export { createContext7ToolSource } from "./context7.ts";

--- a/src/tool/sleep.test.ts
+++ b/src/tool/sleep.test.ts
@@ -1,0 +1,51 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createSleepTool, DEFAULT_SLEEP_TOOL_MAX_SECONDS, sleepTool } from "./sleep.ts";
+
+describe("tool/sleep", () => {
+  it("waits for the requested number of seconds and returns a concise result", async () => {
+    const waits: number[] = [];
+    const testSleepTool = createSleepTool({
+      wait: (milliseconds) => {
+        waits.push(milliseconds);
+      },
+    });
+
+    const result = await testSleepTool.execute({ seconds: 5 });
+
+    assertEquals(waits, [5000]);
+    assertEquals(result, {
+      sleptFor: 5,
+      message: "Waited for 5 seconds",
+    });
+  });
+
+  it("uses singular second copy for one second", async () => {
+    const testSleepTool = createSleepTool({ wait: () => undefined });
+
+    assertEquals(await testSleepTool.execute({ seconds: 1 }), {
+      sleptFor: 1,
+      message: "Waited for 1 second",
+    });
+  });
+
+  it("supports custom maximum seconds", async () => {
+    const testSleepTool = createSleepTool({ maxSeconds: 10, wait: () => undefined });
+
+    assertEquals(testSleepTool.inputSchema.safeParse({ seconds: 10 }).success, true);
+    assertEquals(testSleepTool.inputSchema.safeParse({ seconds: 11 }).success, false);
+  });
+
+  it("rejects values outside the configured public schema bounds", async () => {
+    await assertRejects(
+      () => sleepTool.execute({ seconds: 0 }),
+      Error,
+      'Tool "sleep" input validation failed',
+    );
+    await assertRejects(
+      () => sleepTool.execute({ seconds: DEFAULT_SLEEP_TOOL_MAX_SECONDS + 1 }),
+      Error,
+      'Tool "sleep" input validation failed',
+    );
+  });
+});

--- a/src/tool/sleep.ts
+++ b/src/tool/sleep.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import { tool } from "./factory.ts";
+
+export const DEFAULT_SLEEP_TOOL_MAX_SECONDS = 60;
+
+export type SleepToolWait = (milliseconds: number) => Promise<void> | void;
+
+export type CreateSleepToolOptions = {
+  maxSeconds?: number;
+  wait?: SleepToolWait;
+};
+
+const defaultSleepToolWait: SleepToolWait = (milliseconds) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+
+function createSleepToolInputSchema(maxSeconds: number) {
+  return z.object({
+    seconds: z.number().min(1).max(maxSeconds).describe(
+      `Number of seconds to wait (1-${maxSeconds})`,
+    ),
+  });
+}
+
+export type SleepToolInput = z.infer<ReturnType<typeof createSleepToolInputSchema>>;
+
+export type SleepToolOutput = {
+  sleptFor: number;
+  message: string;
+};
+
+export function createSleepTool(options: CreateSleepToolOptions = {}) {
+  const maxSeconds = options.maxSeconds ?? DEFAULT_SLEEP_TOOL_MAX_SECONDS;
+  const wait = options.wait ?? defaultSleepToolWait;
+
+  return tool<SleepToolInput, SleepToolOutput>({
+    id: "sleep",
+    description:
+      `Wait for a specified number of seconds before continuing. Use this when a task needs to pause execution, such as waiting for an external process to complete or adding a delay between operations. Maximum sleep time is ${maxSeconds} seconds.`,
+    inputSchema: createSleepToolInputSchema(maxSeconds),
+    execute: async ({ seconds }) => {
+      const clampedSeconds = Math.min(Math.max(1, seconds), maxSeconds);
+      await wait(clampedSeconds * 1000);
+      return {
+        sleptFor: clampedSeconds,
+        message: `Waited for ${clampedSeconds} second${clampedSeconds === 1 ? "" : "s"}`,
+      };
+    },
+  });
+}
+
+export const sleepTool = createSleepTool();

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.344";
+export const VERSION = "0.1.345";


### PR DESCRIPTION
Expose a framework-native sleep tool with injectable wait behavior and focused coverage.\n\nVerification:\n- deno check src/tool/index.ts src/tool/sleep.ts src/tool/sleep.test.ts\n- deno test --no-check --allow-all src/tool/sleep.test.ts\n- deno task verify:quick && deno task audit && deno task build:npm\n- pre-push checks: 1554 tests / 17344 steps