### PR TITLE
Let framework runs target generic agents

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.366",
+  "version": "0.1.367",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/conversation-bootstrap.ts
+++ b/src/agent/conversation-bootstrap.ts
@@ -214,6 +214,7 @@ export async function bootstrapConversationAgentRun(input: {
   handoffMessageBody: unknown;
   runId?: string;
   agentId: string;
+  runtimeProviderId?: string | null;
   projectId?: string | null;
   branchId?: string | null;
 }): Promise<BootstrapConversationAgentRunResult> {
@@ -244,6 +245,7 @@ export async function bootstrapConversationAgentRun(input: {
     conversationId: conversation.id,
     runId: input.runId,
     agentId: input.agentId,
+    runtimeProviderId: input.runtimeProviderId,
     projectId: effectiveProjectId,
     branchId: input.branchId,
   });

--- a/src/agent/conversation-root-run-context.ts
+++ b/src/agent/conversation-root-run-context.ts
@@ -57,6 +57,7 @@ export async function startConversationRootRun(input: {
   projectId?: string | null;
   branchId?: string | null;
   agentId: string;
+  runtimeProviderId?: string | null;
   providedRun?: ConversationRootRunDescriptor;
 }): Promise<ConversationRunProjection | null> {
   if (input.providedRun) {
@@ -81,6 +82,7 @@ export async function startConversationRootRun(input: {
     projectId: input.projectId ?? null,
     branchId: input.branchId,
     agentId: input.agentId,
+    runtimeProviderId: input.runtimeProviderId,
   });
 }
 
@@ -91,6 +93,7 @@ export function createConversationRootRunStartAdapter(input: {
   projectId?: string | null;
   branchId?: string | null;
   agentId: string;
+  runtimeProviderId?: string | null;
   providedRun?: ConversationRootRunDescriptor;
 }): (input: { abortSignal: AbortSignal }) => Promise<{ run: ConversationRunProjection | null }> {
   return async () => ({
@@ -101,6 +104,7 @@ export function createConversationRootRunStartAdapter(input: {
       projectId: input.projectId,
       branchId: input.branchId,
       agentId: input.agentId,
+      runtimeProviderId: input.runtimeProviderId,
       providedRun: input.providedRun,
     }),
   });
@@ -113,6 +117,7 @@ export async function prepareConversationRootRunContext(input: {
   projectId?: string | null;
   branchId?: string | null;
   agentId: string;
+  runtimeProviderId?: string | null;
   providedRun?: ConversationRootRunDescriptor;
   parentRunId?: string;
   parentMessageId?: string;
@@ -125,6 +130,7 @@ export async function prepareConversationRootRunContext(input: {
     projectId: input.projectId,
     branchId: input.branchId,
     agentId: input.agentId,
+    runtimeProviderId: input.runtimeProviderId,
     providedRun: input.providedRun,
   })({ abortSignal: new AbortController().signal });
 

--- a/src/agent/durable.test.ts
+++ b/src/agent/durable.test.ts
@@ -201,6 +201,42 @@ describe("agent/durable", () => {
     );
   });
 
+  it("creates queued generic runtime agent runs when runtimeProviderId is provided", async () => {
+    const fetchCalls = stubFetchSequence(
+      acceptedRunResponse({ run_id: "run_codex_1" }),
+      jsonResponse(durableRunProjection({ run_id: "run_codex_1" }), 200),
+    );
+
+    await createConversationAgentRun({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      runId: "run_codex_1",
+      agentId: "codex",
+      runtimeProviderId: "codex",
+      projectId: null,
+      branchId: null,
+    });
+
+    assertEquals(
+      JSON.parse(String(fetchCalls[0]?.[1]?.body)),
+      {
+        kind: "agent",
+        owner: {
+          kind: "conversation",
+          id: CONVERSATION_ID,
+        },
+        public_id: "run_codex_1",
+        request: {
+          mode: "agent",
+          agent_id: "codex",
+          runtime_provider_id: "codex",
+          initial_status: "pending",
+        },
+      },
+    );
+  });
+
   it("accepts camelCase durable run responses for backward compatibility", async () => {
     stubFetchSequence(
       acceptedRunResponse({ runId: "run_child_2" }),

--- a/src/agent/durable.ts
+++ b/src/agent/durable.ts
@@ -292,6 +292,7 @@ export interface CreateConversationAgentRunInput {
   conversationId: string;
   runId?: string;
   agentId: string;
+  runtimeProviderId?: string | null;
   projectId?: string | null;
   branchId?: string | null;
 }
@@ -1254,6 +1255,35 @@ export async function createConversationAgentRun(
   });
   const runId = input.runId ?? `run_${crypto.randomUUID()}`;
 
+  const request = input.runtimeProviderId
+    ? {
+      mode: "agent" as const,
+      agent_id: input.agentId,
+      runtime_provider_id: input.runtimeProviderId,
+      initial_status: "pending" as const,
+      ...(targets.sourceTargetKind ? { source_target_kind: targets.sourceTargetKind } : {}),
+      ...(targets.runtimeTargetKind ? { runtime_target_kind: targets.runtimeTargetKind } : {}),
+      ...(targets.targetBranchId
+        ? {
+          source_target_branch_id: targets.targetBranchId,
+          runtime_target_branch_id: targets.targetBranchId,
+        }
+        : {}),
+    }
+    : {
+      mode: "default_chat" as const,
+      agent_id: input.agentId,
+      initial_status: "running" as const,
+      ...(targets.sourceTargetKind ? { source_target_kind: targets.sourceTargetKind } : {}),
+      ...(targets.runtimeTargetKind ? { runtime_target_kind: targets.runtimeTargetKind } : {}),
+      ...(targets.targetBranchId
+        ? {
+          source_target_branch_id: targets.targetBranchId,
+          runtime_target_branch_id: targets.targetBranchId,
+        }
+        : {}),
+    };
+
   await controlPlaneJson({
     authToken: input.authToken,
     url: `${input.apiUrl}/runs`,
@@ -1265,19 +1295,7 @@ export async function createConversationAgentRun(
         id: input.conversationId,
       },
       public_id: runId,
-      request: {
-        mode: "default_chat",
-        agent_id: input.agentId,
-        initial_status: "running",
-        ...(targets.sourceTargetKind ? { source_target_kind: targets.sourceTargetKind } : {}),
-        ...(targets.runtimeTargetKind ? { runtime_target_kind: targets.runtimeTargetKind } : {}),
-        ...(targets.targetBranchId
-          ? {
-            source_target_branch_id: targets.targetBranchId,
-            runtime_target_branch_id: targets.targetBranchId,
-          }
-          : {}),
-      },
+      request,
     },
     responseSchema: CreateConversationRunAcceptedSchema,
     operation: "Create canonical durable run",

--- a/src/agent/hosted-child-bootstrap.test.ts
+++ b/src/agent/hosted-child-bootstrap.test.ts
@@ -164,4 +164,80 @@ describe("agent/hosted-child-bootstrap", () => {
       },
     });
   });
+
+  it("returns the queued child run status for external runtime providers", async () => {
+    const requests: { url: string; body: unknown }[] = [];
+    stubFetchWithRecorder(async (input, init) => {
+      requests.push({
+        url: String(input),
+        body: init?.body ? JSON.parse(String(init.body)) : null,
+      });
+
+      const requestCount = requests.length;
+      if (requestCount === 1) {
+        return jsonResponse({ id: PARENT_CONVERSATION_ID, project_id: PROJECT_ID }, 200);
+      }
+      if (requestCount === 2) {
+        return jsonResponse({ id: CHILD_CONVERSATION_ID, project_id: PROJECT_ID }, 200);
+      }
+      if (requestCount === 3) {
+        return jsonResponse({ id: CHILD_MESSAGE_ID }, 200);
+      }
+      if (requestCount === 4) {
+        return acceptedRunResponse({ run_id: "run_child_queued" });
+      }
+      if (requestCount === 5) {
+        return jsonResponse(
+          {
+            run_id: "run_child_queued",
+            conversation_id: CHILD_CONVERSATION_ID,
+            message_id: CHILD_MESSAGE_ID,
+            latest_event_id: 0,
+            latest_external_event_sequence: 0,
+            status: "pending",
+          },
+          200,
+        );
+      }
+
+      throw new Error("Unexpected fetch call");
+    });
+
+    const result = await bootstrapHostedChildRun({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      ensureProjectId: PROJECT_ID,
+      runProjectId: PROJECT_ID,
+      parentConversationId: PARENT_CONVERSATION_ID,
+      parentRunId: "parent-run-1",
+      parentMessageId: PARENT_MESSAGE_ID,
+      spawnedFromToolCallId: "tool-call-1",
+      description: "Inspect logs",
+      prompt: "Find the latest logs.",
+      runId: "run_child_queued",
+      agentId: "invoke-agent-child",
+      runtimeProviderId: "codex",
+      branchId: BRANCH_ID,
+    });
+
+    assertEquals(result.status, "pending");
+    assertEquals(requests[3].body, {
+      kind: "agent",
+      owner: {
+        kind: "conversation",
+        id: CHILD_CONVERSATION_ID,
+      },
+      public_id: "run_child_queued",
+      request: {
+        mode: "agent",
+        agent_id: "invoke-agent-child",
+        runtime_provider_id: "codex",
+        initial_status: "pending",
+        source_target_kind: "preview_branch",
+        runtime_target_kind: "preview_branch",
+        source_target_branch_id: BRANCH_ID,
+        runtime_target_branch_id: BRANCH_ID,
+      },
+    });
+  });
 });

--- a/src/agent/hosted-child-bootstrap.ts
+++ b/src/agent/hosted-child-bootstrap.ts
@@ -1,4 +1,5 @@
 import { bootstrapConversationAgentRun } from "./conversation-bootstrap.ts";
+import { type ConversationRunProjection } from "./durable.ts";
 import { type HostedChildRunIdentifiers } from "./hosted-child-status.ts";
 
 export interface HostedChildConversationBodyInput {
@@ -17,11 +18,12 @@ export interface BootstrapHostedChildRunInput extends HostedChildConversationBod
   prompt: string;
   runId?: string;
   agentId: string;
+  runtimeProviderId?: string | null;
   branchId?: string | null;
 }
 
 export interface BootstrapHostedChildRunResult extends HostedChildRunIdentifiers {
-  status: "running";
+  status: ConversationRunProjection["status"];
 }
 
 export function buildHostedChildConversationBody(input: HostedChildConversationBodyInput) {
@@ -57,6 +59,7 @@ export async function bootstrapHostedChildRun(
     },
     runId: input.runId,
     agentId: input.agentId,
+    runtimeProviderId: input.runtimeProviderId,
     projectId: input.runProjectId ?? null,
     branchId: input.branchId,
   });
@@ -67,6 +70,6 @@ export async function bootstrapHostedChildRun(
     childMessageId: result.run.messageId,
     latestEventId: result.run.latestEventId,
     latestExternalEventSequence: result.run.latestExternalEventSequence,
-    status: "running",
+    status: result.run.status,
   };
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.366";
+export const VERSION = "0.1.367";


### PR DESCRIPTION
## Summary
- Thread runtimeProviderId through conversation bootstrap/root-run helpers
- Let framework-created conversation agent runs enqueue generic agent runtime runs with mode: agent
- Bump veryfront-code to 0.1.346 because PR #1375 owns the 0.1.345 release line

## Tests
- deno check src/agent/durable.ts src/agent/conversation-root-run-context.ts src/agent/hosted-child-bootstrap.ts src/agent/conversation-bootstrap.ts
- deno test --no-check --allow-env --allow-read --allow-net src/agent/durable.test.ts
- deno test --no-check --allow-env --allow-read src/utils/version.test.ts src/utils/logger/logger.test.ts

## Notes
- Full pre-push unit suite was attempted. It passed the relevant framework tests but failed on existing sandbox worker/leak tests, plus the previous 0.1.345 version mismatch that is now fixed by moving this branch to 0.1.346.
- After this PR is merged and 0.1.346 is released, bump the veryfront dependency in veryfront-agent, veryfront-api, and veryfront-studio.