### PR TITLE
Add traced host tool wrapper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.346",
+  "version": "0.1.347",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -77,6 +77,13 @@ export {
   loadRemoteToolsFromSource,
 } from "./remote-source-tools.ts";
 export type { RemoteToolMaterializationOptions } from "./remote-source-tools.ts";
+export { traceHostTools } from "./tracing.ts";
+export type {
+  HostToolTraceAttributeInput,
+  HostToolTraceAttributes,
+  HostToolTraceRunner,
+  TraceHostToolsOptions,
+} from "./tracing.ts";
 export {
   filterProjectScopedRemoteToolDefinitions,
   hydrateProjectScopedRemoteToolInput,

--- a/src/tool/tracing.test.ts
+++ b/src/tool/tracing.test.ts
@@ -1,0 +1,128 @@
+import { assertEquals, assertRejects, assertStrictEquals } from "@std/assert";
+import type { HostToolSet } from "./host-tools.ts";
+import { traceHostTools } from "./tracing.ts";
+
+function requireTool(tools: HostToolSet, toolName: string) {
+  const definition = tools[toolName];
+  if (!definition) {
+    throw new Error(`Missing tool ${toolName}`);
+  }
+  return definition;
+}
+
+Deno.test("traceHostTools passes through tools without execute unchanged", () => {
+  const providerTool = { description: "A provider tool" };
+  const toolset: HostToolSet = { web_search: providerTool };
+
+  const traced = traceHostTools(toolset, {
+    trace: (_spanName, operation) => operation(),
+  });
+
+  assertStrictEquals(traced.web_search, providerTool);
+});
+
+Deno.test("traceHostTools wraps executable tools with a trace span", async () => {
+  const spans: string[] = [];
+  const calls: unknown[] = [];
+  const toolset: HostToolSet = {
+    my_tool: {
+      description: "does something",
+      execute: (input: unknown) => {
+        calls.push(input);
+        return { result: "ok" };
+      },
+    },
+  };
+
+  const traced = traceHostTools(toolset, {
+    trace: (spanName, operation) => {
+      spans.push(spanName);
+      return operation();
+    },
+  });
+
+  const result = await requireTool(traced, "my_tool").execute?.({ input: "val" });
+
+  assertEquals(result, { result: "ok" });
+  assertEquals(spans, ["tool.my_tool"]);
+  assertEquals(calls, [{ input: "val" }]);
+});
+
+Deno.test("traceHostTools publishes attributes with tool name and tool call id", async () => {
+  const attributes: Record<string, unknown>[] = [];
+  const toolset: HostToolSet = {
+    bash: {
+      execute: () => null,
+    },
+  };
+
+  const traced = traceHostTools(toolset, {
+    trace: (_spanName, operation) => operation(),
+    buildAttributes: ({ toolName, toolCallId, context }) => ({
+      "tool.name": toolName,
+      "tool.call.id": toolCallId,
+      "context.seen": Boolean(context),
+    }),
+    setAttributes: (nextAttributes) => {
+      attributes.push(nextAttributes);
+    },
+  });
+
+  await requireTool(traced, "bash").execute?.({}, { toolCallId: "call-abc" });
+
+  assertEquals(attributes, [
+    {
+      "tool.name": "bash",
+      "tool.call.id": "call-abc",
+      "context.seen": true,
+    },
+  ]);
+});
+
+Deno.test("traceHostTools preserves non-execute properties on wrapped tools", () => {
+  const providerOptions = { anthropic: { cacheControl: { type: "ephemeral" } } };
+  const toolset: HostToolSet = {
+    my_tool: {
+      description: "original desc",
+      providerOptions,
+      execute: () => undefined,
+    },
+  };
+
+  const traced = traceHostTools(toolset, {
+    trace: (_spanName, operation) => operation(),
+  });
+
+  const tracedTool = requireTool(traced, "my_tool");
+  assertEquals(tracedTool.description, "original desc");
+  assertStrictEquals(tracedTool.providerOptions, providerOptions);
+});
+
+Deno.test("traceHostTools propagates errors from the original execute function", async () => {
+  const toolset: HostToolSet = {
+    fail: {
+      execute: () => {
+        throw new Error("tool failed");
+      },
+    },
+  };
+
+  const traced = traceHostTools(toolset, {
+    trace: (_spanName, operation) => operation(),
+  });
+
+  await assertRejects(
+    async () => {
+      await requireTool(traced, "fail").execute?.({});
+    },
+    Error,
+    "tool failed",
+  );
+});
+
+Deno.test("traceHostTools returns an empty toolset for empty input", () => {
+  const traced = traceHostTools({}, {
+    trace: (_spanName, operation) => operation(),
+  });
+  assertEquals(traced, {});
+});

--- a/src/tool/tracing.ts
+++ b/src/tool/tracing.ts
@@ -1,0 +1,66 @@
+import type { HostToolSet } from "./host-tools.ts";
+import type { ToolExecutionContext } from "./types.ts";
+
+export type HostToolTraceRunner = <TResult>(
+  spanName: string,
+  operation: () => TResult,
+) => TResult;
+
+export type HostToolTraceAttributes = Record<string, unknown>;
+
+export type HostToolTraceAttributeInput = {
+  toolName: string;
+  toolCallId: string | undefined;
+  context: ToolExecutionContext | undefined;
+};
+
+export type TraceHostToolsOptions = {
+  trace: HostToolTraceRunner;
+  buildAttributes?: (
+    input: HostToolTraceAttributeInput,
+  ) => HostToolTraceAttributes | undefined;
+  setAttributes?: (attributes: HostToolTraceAttributes) => void;
+  getSpanName?: (toolName: string) => string;
+};
+
+function defaultSpanName(toolName: string): string {
+  return `tool.${toolName}`;
+}
+
+function getToolCallId(context: ToolExecutionContext | undefined): string | undefined {
+  return typeof context?.toolCallId === "string" ? context.toolCallId : undefined;
+}
+
+export function traceHostTools(
+  tools: HostToolSet,
+  options: TraceHostToolsOptions,
+): HostToolSet {
+  const traced: HostToolSet = {};
+  const getSpanName = options.getSpanName ?? defaultSpanName;
+
+  for (const [toolName, definition] of Object.entries(tools)) {
+    if (!definition.execute) {
+      traced[toolName] = definition;
+      continue;
+    }
+
+    const originalExecute = definition.execute;
+    traced[toolName] = {
+      ...definition,
+      execute: (input: unknown, context: ToolExecutionContext | undefined) =>
+        options.trace(getSpanName(toolName), () => {
+          const attributes = options.buildAttributes?.({
+            toolName,
+            toolCallId: getToolCallId(context),
+            context,
+          });
+          if (attributes) {
+            options.setAttributes?.(attributes);
+          }
+          return originalExecute(input, context);
+        }),
+    };
+  }
+
+  return traced;
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.346";
+export const VERSION = "0.1.347";


### PR DESCRIPTION
## Summary
- expose a reusable host-tool tracing decorator from veryfront/tool
- let host runtimes bind span and attribute callbacks without duplicating wrapper behavior
- bump patch version to 0.1.347

## Verification
- deno check src/tool/index.ts src/tool/tracing.ts src/tool/tracing.test.ts
- deno test --no-check --allow-all src/tool/tracing.test.ts
- deno task verify:quick && deno task audit && deno task build:npm
- git push pre-push checks (format, lint, typecheck, unit tests)