### PR TITLE
Narrow traced host tool attribute callbacks

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.347",
+  "version": "0.1.348",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/tool/tracing.test.ts
+++ b/src/tool/tracing.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, assertRejects, assertStrictEquals } from "@std/assert";
 import type { HostToolSet } from "./host-tools.ts";
-import { traceHostTools } from "./tracing.ts";
+import { traceHostTools, type TraceHostToolsOptions } from "./tracing.ts";
 
 function requireTool(tools: HostToolSet, toolName: string) {
   const definition = tools[toolName];
@@ -77,6 +77,29 @@ Deno.test("traceHostTools publishes attributes with tool name and tool call id",
       "context.seen": true,
     },
   ]);
+});
+
+Deno.test("traceHostTools keeps build/set attribute callbacks on the same narrowed type", async () => {
+  type NarrowAttributes = Record<string, string | number>;
+  const seen: NarrowAttributes[] = [];
+  const options: TraceHostToolsOptions<NarrowAttributes> = {
+    trace: (_spanName, operation) => operation(),
+    buildAttributes: ({ toolName }) => ({
+      "tool.name": toolName,
+      count: 1,
+    }),
+    setAttributes: (attributes) => {
+      const toolName: string | number | undefined = attributes["tool.name"];
+      if (toolName) {
+        seen.push(attributes);
+      }
+    },
+  };
+  const traced = traceHostTools({ typed: { execute: () => "ok" } }, options);
+
+  await requireTool(traced, "typed").execute?.({});
+
+  assertEquals(seen, [{ "tool.name": "typed", count: 1 }]);
 });
 
 Deno.test("traceHostTools preserves non-execute properties on wrapped tools", () => {

--- a/src/tool/tracing.ts
+++ b/src/tool/tracing.ts
@@ -14,12 +14,14 @@ export type HostToolTraceAttributeInput = {
   context: ToolExecutionContext | undefined;
 };
 
-export type TraceHostToolsOptions = {
+export type TraceHostToolsOptions<
+  TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
+> = {
   trace: HostToolTraceRunner;
   buildAttributes?: (
     input: HostToolTraceAttributeInput,
-  ) => HostToolTraceAttributes | undefined;
-  setAttributes?: (attributes: HostToolTraceAttributes) => void;
+  ) => TAttributes | undefined;
+  setAttributes?: (attributes: TAttributes) => void;
   getSpanName?: (toolName: string) => string;
 };
 
@@ -31,9 +33,11 @@ function getToolCallId(context: ToolExecutionContext | undefined): string | unde
   return typeof context?.toolCallId === "string" ? context.toolCallId : undefined;
 }
 
-export function traceHostTools(
+export function traceHostTools<
+  TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
+>(
   tools: HostToolSet,
-  options: TraceHostToolsOptions,
+  options: TraceHostToolsOptions<TAttributes>,
 ): HostToolSet {
   const traced: HostToolSet = {};
   const getSpanName = options.getSpanName ?? defaultSpanName;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.347";
+export const VERSION = "0.1.348";


### PR DESCRIPTION
## Summary
- make traceHostTools generic over host telemetry attribute records
- keep buildAttributes and setAttributes on the same narrowed attribute type
- add type coverage for host runtimes with stricter telemetry contracts
- bump patch version to 0.1.348

## Verification
- deno check src/tool/index.ts src/tool/tracing.ts src/tool/tracing.test.ts
- deno test --no-check --allow-all src/tool/tracing.test.ts
- deno task verify:quick && deno task audit && deno task build:npm
- git push pre-push checks (format, lint, typecheck, unit tests)