### PR TITLE
Add runtime tool inventory helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.349",
+  "version": "0.1.350",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -377,6 +377,16 @@ when bootstrap credentials are present.
 
 **Returns:** `Agent`
 
+### Runtime instruction helpers
+
+Use these helpers when a host needs to add the current tool surface to runtime
+system instructions without copying prompt bookkeeping.
+
+| Export                        | Type                                               | Description                                                                                               |
+| ----------------------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `withRuntimeToolInventory()`  | `(instructions, toolNames) => ChatSystemMessage[]` | Append the canonical current-run tool inventory system message, replacing any previous inventory message. |
+| `flattenSystemInstructions()` | `(instructions) => string`                         | Flatten system messages into the string form consumed by model runtimes.                                  |
+
 ### Browser AG-UI stream encoder
 
 Use these helpers when a host needs to turn the framework runtime stream event

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -240,6 +240,7 @@ export {
   type ToolExecutionDataEventBridgeStreamInput,
   type ToolExecutionDataEventPublisher,
 } from "./tool-execution-data-event-bridge.ts";
+export { flattenSystemInstructions, withRuntimeToolInventory } from "./runtime-tool-inventory.ts";
 export {
   createAgUiTrackedBrowserResponse,
   type CreateAgUiTrackedBrowserResponseInput,

--- a/src/agent/runtime-tool-inventory.test.ts
+++ b/src/agent/runtime-tool-inventory.test.ts
@@ -1,0 +1,55 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ChatSystemMessage } from "../chat/types.ts";
+import { flattenSystemInstructions, withRuntimeToolInventory } from "./runtime-tool-inventory.ts";
+
+describe("runtime tool inventory instructions", () => {
+  it("appends visible tool inventory to string instructions", () => {
+    assertEquals(withRuntimeToolInventory("Base system", ["write_file", "read_file"]), [
+      { role: "system", content: "Base system" },
+      {
+        role: "system",
+        content: `Current run tool inventory:
+
+- write_file
+- read_file
+
+Only treat the tools listed above as actually available in this run.
+If the list is "- none", say plainly that no tools are available.
+Do NOT infer tool availability from examples, skills, or the base prompt.`,
+      },
+    ]);
+  });
+
+  it("replaces stale inventory messages when instructions are already materialized", () => {
+    const instructions: ChatSystemMessage[] = [
+      { role: "system", content: "Base system" },
+      { role: "system", content: "Current run tool inventory:\n\n- stale" },
+    ];
+
+    assertEquals(withRuntimeToolInventory(instructions, []), [
+      { role: "system", content: "Base system" },
+      {
+        role: "system",
+        content: `Current run tool inventory:
+
+- none
+
+Only treat the tools listed above as actually available in this run.
+If the list is "- none", say plainly that no tools are available.
+Do NOT infer tool availability from examples, skills, or the base prompt.`,
+      },
+    ]);
+  });
+
+  it("flattens non-empty system text with blank-line separation", () => {
+    assertEquals(
+      flattenSystemInstructions([
+        { role: "system", content: "  first  " },
+        { role: "system", content: "" },
+        { role: "system", content: "second" },
+      ]),
+      "first\n\nsecond",
+    );
+  });
+});

--- a/src/agent/runtime-tool-inventory.ts
+++ b/src/agent/runtime-tool-inventory.ts
@@ -1,0 +1,46 @@
+import type { ChatSystemMessage } from "../chat/types.ts";
+
+const RUNTIME_TOOL_INVENTORY_HEADER = "Current run tool inventory:";
+
+function createRuntimeToolInventoryMessage(toolNames: readonly string[]): ChatSystemMessage {
+  const toolList = toolNames.length > 0
+    ? toolNames.map((toolName) => `- ${toolName}`).join("\n")
+    : "- none";
+
+  return {
+    role: "system",
+    content: `${RUNTIME_TOOL_INVENTORY_HEADER}
+
+${toolList}
+
+Only treat the tools listed above as actually available in this run.
+If the list is "- none", say plainly that no tools are available.
+Do NOT infer tool availability from examples, skills, or the base prompt.`,
+  };
+}
+
+function isRuntimeToolInventoryMessage(message: ChatSystemMessage): boolean {
+  return message.content.includes(RUNTIME_TOOL_INVENTORY_HEADER);
+}
+
+export function withRuntimeToolInventory(
+  instructions: string | readonly ChatSystemMessage[],
+  toolNames: readonly string[],
+): ChatSystemMessage[] {
+  const inventoryMessage = createRuntimeToolInventoryMessage(toolNames);
+  if (typeof instructions === "string") {
+    return [{ role: "system", content: instructions }, inventoryMessage];
+  }
+
+  return [
+    ...instructions.filter((message) => !isRuntimeToolInventoryMessage(message)),
+    inventoryMessage,
+  ];
+}
+
+export function flattenSystemInstructions(instructions: readonly ChatSystemMessage[]): string {
+  return instructions
+    .map((message) => message.content.trim())
+    .filter((content) => content.length > 0)
+    .join("\n\n");
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.349";
+export const VERSION = "0.1.350";


### PR DESCRIPTION
## Summary
- add framework-owned runtime instruction helpers for current-run tool inventory
- export the helpers from veryfront/agent and document them
- bump package version to 0.1.350 for CI/CD publish

## Verification
- deno test --no-check --allow-all src/agent/runtime-tool-inventory.test.ts src/utils/version.test.ts
- deno task verify:quick
- pre-push checks: fmt, lint, typecheck, test:unit