### PR TITLE
Add hosted sandbox tool suite

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.351",
+  "version": "0.1.352",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/sandbox.md
+++ b/docs/reference/sandbox.md
@@ -51,6 +51,18 @@ Create a lazily-provisioned sandbox client that only claims a session on first u
 
 **Returns:** <code>LazySandbox</code>
 
+### `createHostedSandboxClient(options?)`
+
+Create a lazily-provisioned sandbox client for hosted agent runtimes. The client applies the current project as the default `projectReference` for command execution and async command jobs.
+
+**Returns:** <code>HostedSandboxClient</code>
+
+### `createHostedSandboxTools(options)`
+
+Create sandbox shell tools plus async command job tools for hosted agent runtimes. Pass an injected `createBashTool` factory to keep the framework independent of a concrete bash-tool package.
+
+**Returns:** <code>Promise&lt;HostedSandboxToolsResult&gt;</code>
+
 ### `sandbox.executeCommand(command, options?)`
 
 Execute a bash command in the sandbox and return buffered result.
@@ -145,28 +157,40 @@ Options for creating a sandbox session.
 
 Known sandbox session details for `Sandbox.attach(...)`.
 
-| Property   | Type     | Description                                                                                                         |
-| ---------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
-| `id`       | `string` | Existing sandbox session ID.                                                                                        |
-| `endpoint` | `string` | Existing sandbox runtime endpoint URL.                                                                              |
-| `apiUrl?`  | `string` | Base URL of the Veryfront API. Defaults to VERYFRONT_API_URL env.                                                   |
-| `authToken?` | `string` | Explicit Veryfront auth token or API key override. Defaults to request-scoped credentials or `VERYFRONT_API_TOKEN`. |
+| Property     | Type     | Description                                                                                                            |
+| ------------ | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `id`         | `string` | Existing sandbox session ID.                                                                                           |
+| `endpoint`   | `string` | Existing sandbox runtime endpoint URL.                                                                                 |
+| `apiUrl?`    | `string` | Base URL of the Veryfront API. Defaults to VERYFRONT_API_URL env.                                                      |
+| `authToken?` | `string` | Explicit Veryfront auth token or API key override. Defaults to request-scoped credentials or `VERYFRONT_API_TOKEN`.    |
 | `projectId?` | `string` | Optional project context metadata when the caller wants to preserve the same options shape as other sandbox factories. |
 
 ### `LazySandboxOptions`
 
 Options for a lazily-provisioned sandbox session.
 
-| Property               | Type                                | Description                                                                              |
-| ---------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------- |
-| `apiUrl?`              | `string`                            | Base URL of the Veryfront API.                                                           |
-| `authToken?`           | `string`                            | Explicit Veryfront auth token or API key override.                                       |
-| `projectId?`           | `string`                            | Initial project-scoped billing or isolation context.                                     |
+| Property               | Type                                | Description                                                                                                                                                                          |
+| ---------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `apiUrl?`              | `string`                            | Base URL of the Veryfront API.                                                                                                                                                       |
+| `authToken?`           | `string`                            | Explicit Veryfront auth token or API key override.                                                                                                                                   |
+| `projectId?`           | `string`                            | Initial project-scoped billing or isolation context.                                                                                                                                 |
 | `getProjectId?`        | `() => string \| null \| undefined` | Deferred resolver used at first provision time, on later project-context sync checks, and as the default `projectReference` for lazy exec/job calls when callers do not override it. |
-| `startupTimeoutMs?`    | `number`                            | Maximum time to wait for pending sessions to become ready. Defaults to 180000.           |
-| `pollIntervalMs?`      | `number`                            | Poll interval while waiting for readiness. Defaults to 2000.                             |
-| `heartbeatIntervalMs?` | `number`                            | Background heartbeat interval for active sessions. Defaults to 30000.                    |
-| `heartbeatGraceMs?`    | `number`                            | Minimum gap between non-forced heartbeats. Defaults to 5000.                             |
+| `startupTimeoutMs?`    | `number`                            | Maximum time to wait for pending sessions to become ready. Defaults to 180000.                                                                                                       |
+| `pollIntervalMs?`      | `number`                            | Poll interval while waiting for readiness. Defaults to 2000.                                                                                                                         |
+| `heartbeatIntervalMs?` | `number`                            | Background heartbeat interval for active sessions. Defaults to 30000.                                                                                                                |
+| `heartbeatGraceMs?`    | `number`                            | Minimum gap between non-forced heartbeats. Defaults to 5000.                                                                                                                         |
+
+### `HostedSandboxToolsOptions`
+
+Options for creating hosted sandbox tools.
+
+| Property         | Type                                | Description                                                               |
+| ---------------- | ----------------------------------- | ------------------------------------------------------------------------- |
+| `createBashTool` | `CreateSandboxBashTool`             | Bash-tool factory used to create shell, read-file, and write-file tools.  |
+| `apiUrl?`        | `string`                            | Base URL of the Veryfront API.                                            |
+| `authToken?`     | `string`                            | Explicit Veryfront auth token or API key override.                        |
+| `projectId?`     | `string`                            | Initial project context for project-scoped sandbox sessions and commands. |
+| `getProjectId?`  | `() => string \| null \| undefined` | Deferred resolver for the active project context.                         |
 
 ### `ExecResult`
 
@@ -227,15 +251,18 @@ Command job with captured stdout/stderr.
 
 ### Types
 
-| Name                 | Description                                                   |
-| -------------------- | ------------------------------------------------------------- |
-| `CommandJob`         | Status of an async command job.                               |
-| `CommandJobOutput`   | Async command job with captured output.                       |
-| `ExecResult`         | Result of a command execution: stdout, stderr, and exit code. |
-| `ExecStreamEvent`    | Streaming event emitted during command execution.             |
-| `LazySandboxOptions` | Options for lazily-provisioned sandbox sessions.              |
-| `SandboxOptions`     | Options for creating a sandbox session.                       |
-| `SandboxAttachment`  | Known sandbox session details used for `Sandbox.attach(...)`. |
+| Name                        | Description                                                     |
+| --------------------------- | --------------------------------------------------------------- |
+| `CommandJob`                | Status of an async command job.                                 |
+| `CommandJobOutput`          | Async command job with captured output.                         |
+| `ExecResult`                | Result of a command execution: stdout, stderr, and exit code.   |
+| `ExecStreamEvent`           | Streaming event emitted during command execution.               |
+| `HostedSandboxClient`       | Hosted sandbox client with shell and async command job methods. |
+| `HostedSandboxToolsOptions` | Options for creating hosted sandbox tools.                      |
+| `HostedSandboxToolsResult`  | Hosted sandbox tool set plus close helper.                      |
+| `LazySandboxOptions`        | Options for lazily-provisioned sandbox sessions.                |
+| `SandboxOptions`            | Options for creating a sandbox session.                         |
+| `SandboxAttachment`         | Known sandbox session details used for `Sandbox.attach(...)`.   |
 
 ## Related
 

--- a/src/sandbox/hosted-tools.test.ts
+++ b/src/sandbox/hosted-tools.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd";
+import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert";
+import type { CreateSandboxBashTool, SandboxShellToolSet } from "./shell-tools.ts";
+import {
+  createHostedSandboxClient,
+  createHostedSandboxTools,
+  createProjectScopedExecOptions,
+  unwrapSandboxWorkingDirectoryCommand,
+} from "./hosted-tools.ts";
+import {
+  clearSandboxEnv,
+  type FetchCall,
+  installMockFetch,
+  jsonBody,
+  jsonResponse,
+  type MockResponseEntry,
+  ndjsonResponse,
+} from "./sandbox.test-helpers.ts";
+
+const originalFetch = globalThis.fetch;
+let fetchCalls: FetchCall[] = [];
+let fetchResponses: MockResponseEntry[] = [];
+
+const createBashTool: CreateSandboxBashTool = async (input) => {
+  assertEquals(input.destination, "/workspace");
+  assertStringIncludes(input.promptOptions.toolPrompt, "agent-browser");
+  return {
+    tools: {
+      bash: {
+        description: "Run commands",
+        execute: async (toolInput: unknown) => toolInput,
+      },
+      readFile: { description: "Read file" },
+      writeFile: { description: "Write file" },
+    },
+  };
+};
+
+function mockFetch(responses: MockResponseEntry[]) {
+  fetchResponses = [...responses];
+  fetchCalls = [];
+  globalThis.fetch = installMockFetch({ calls: fetchCalls, responses: fetchResponses });
+}
+
+function createSandboxSessionResponse(
+  overrides: Partial<{ id: string; endpoint: string; status: string }> = {},
+): Response {
+  return jsonResponse({
+    id: "sandbox-1",
+    endpoint: "https://sandbox.example.com",
+    status: "running",
+    ...overrides,
+  });
+}
+
+function createOkResponse(): Response {
+  return jsonResponse({ ok: true });
+}
+
+function createJobPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "job-1",
+    status: "running",
+    exit_code: null,
+    signal: null,
+    started_at: "2026-03-19T10:00:00.000Z",
+    finished_at: null,
+    heartbeat_status: "healthy",
+    last_heartbeat_at: "2026-03-19T10:00:05.000Z",
+    last_heartbeat_error: null,
+    heartbeat_failure_count: 0,
+    ...overrides,
+  };
+}
+
+async function executeStartCommandJob(
+  tools: SandboxShellToolSet,
+  command: string,
+): Promise<unknown> {
+  const execute = tools.start_command_job?.execute;
+  assertExists(execute);
+  return await execute({ command });
+}
+
+describe("sandbox/hosted-tools", () => {
+  beforeEach(() => {
+    fetchCalls = [];
+    fetchResponses = [];
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    clearSandboxEnv();
+  });
+
+  it("creates shell tools and async command job tools", async () => {
+    mockFetch([]);
+
+    const { tools } = await createHostedSandboxTools({
+      authToken: "test-token",
+      apiUrl: "https://api.example.com",
+      projectId: "project-123",
+      createBashTool,
+    });
+
+    assertExists(tools.bash);
+    assertExists(tools.sandbox_read_file);
+    assertExists(tools.sandbox_write_file);
+    assertExists(tools.start_command_job);
+    assertExists(tools.get_command_job);
+    assertExists(tools.get_command_job_output);
+    assertExists(tools.cancel_command_job);
+    assertEquals(tools.readFile, undefined);
+    assertEquals(tools.writeFile, undefined);
+  });
+
+  it("passes the latest project reference through exec and command-job requests", async () => {
+    mockFetch([
+      createSandboxSessionResponse(),
+      createOkResponse(),
+      ndjsonResponse([{ type: "stdout", data: "ok" }, { type: "exit", exitCode: 0 }]),
+      jsonResponse(createJobPayload()),
+    ]);
+
+    let projectId = "project-1";
+    const sandbox = createHostedSandboxClient({
+      authToken: "test-token",
+      apiUrl: "https://api.example.com",
+      getProjectId: () => projectId,
+    });
+
+    projectId = "project-2";
+
+    assertEquals(await sandbox.executeCommand("echo ok"), {
+      stdout: "ok",
+      stderr: "",
+      exitCode: 0,
+    });
+    assertEquals(await sandbox.startCommandJob("npm test"), {
+      id: "job-1",
+      status: "running",
+      exitCode: null,
+      signal: null,
+      startedAt: "2026-03-19T10:00:00.000Z",
+      finishedAt: null,
+      heartbeatStatus: "healthy",
+      lastHeartbeatAt: "2026-03-19T10:00:05.000Z",
+      lastHeartbeatError: null,
+      heartbeatFailureCount: 0,
+    });
+
+    assertEquals(jsonBody(fetchCalls, 0), { project_id: "project-2" });
+    assertEquals(jsonBody(fetchCalls, 2), {
+      command: "echo ok",
+      projectReference: "project-2",
+    });
+    assertEquals(jsonBody(fetchCalls, 3), {
+      command: "npm test",
+      cwd: "/workspace",
+      projectReference: "project-2",
+    });
+  });
+
+  it("strips bash-tool workspace prefixes from async command job tool commands", async () => {
+    mockFetch([
+      createSandboxSessionResponse(),
+      createOkResponse(),
+      jsonResponse(createJobPayload()),
+    ]);
+
+    const { tools } = await createHostedSandboxTools({
+      authToken: "test-token",
+      apiUrl: "https://api.example.com",
+      projectId: "project-123",
+      createBashTool,
+    });
+
+    await executeStartCommandJob(
+      tools,
+      'mkdir -p /tmp/bash-tool && cd "/workspace" && python3 process_pdf.py',
+    );
+
+    assertEquals(jsonBody(fetchCalls, 2), {
+      command: "python3 process_pdf.py",
+      cwd: "/workspace",
+      projectReference: "project-123",
+    });
+  });
+
+  it("normalizes command and project helper outputs", () => {
+    assertEquals(
+      unwrapSandboxWorkingDirectoryCommand('mkdir -p /tmp/bash-tool && cd "/workspace" && echo ok'),
+      "echo ok",
+    );
+    assertEquals(unwrapSandboxWorkingDirectoryCommand("  echo ok  "), "echo ok");
+    assertEquals(createProjectScopedExecOptions("project-123"), {
+      projectReference: "project-123",
+    });
+    assertEquals(createProjectScopedExecOptions(null), {});
+  });
+});

--- a/src/sandbox/hosted-tools.ts
+++ b/src/sandbox/hosted-tools.ts
@@ -1,0 +1,169 @@
+import { z } from "zod";
+import { tool } from "#veryfront/tool";
+import type { CommandJob, CommandJobOutput, ExecOptions } from "./sandbox.ts";
+import { LazySandbox, type LazySandboxOptions } from "./lazy-sandbox.ts";
+import {
+  type BashToolSandboxLike,
+  type CreateSandboxBashTool,
+  createSandboxShellTools,
+  type SandboxShellToolSet,
+} from "./shell-tools.ts";
+
+const SANDBOX_WORKING_DIRECTORY = "/workspace";
+const SANDBOX_WORKING_DIRECTORY_PREFIX_PATTERN =
+  /^\s*(?:mkdir -p \/tmp\/bash-tool\s*&&\s*)?cd\s+"\/workspace"\s*&&\s*/i;
+
+export interface HostedSandboxJobClient {
+  startCommandJob(command: string): Promise<CommandJob>;
+  getCommandJob(jobId: string): Promise<CommandJob>;
+  getCommandJobOutput(jobId: string): Promise<CommandJobOutput>;
+  cancelCommandJob(jobId: string): Promise<CommandJob>;
+}
+
+export interface HostedSandboxClient extends BashToolSandboxLike, HostedSandboxJobClient {
+  ensure(): Promise<void>;
+  close(): Promise<void>;
+  readonly isActive: boolean;
+  readonly id: string | null;
+  readonly url: string | null;
+}
+
+export interface HostedSandboxClientOptions extends LazySandboxOptions {}
+
+export interface HostedSandboxToolsOptions extends HostedSandboxClientOptions {
+  createBashTool: CreateSandboxBashTool;
+}
+
+export interface HostedSandboxToolsResult {
+  tools: SandboxShellToolSet;
+  sandbox: HostedSandboxClient;
+  closeSandbox: () => Promise<void>;
+}
+
+export function unwrapSandboxWorkingDirectoryCommand(command: string): string {
+  const trimmedCommand = command.trim();
+  if (!SANDBOX_WORKING_DIRECTORY_PREFIX_PATTERN.test(trimmedCommand)) {
+    return trimmedCommand;
+  }
+
+  return trimmedCommand.replace(SANDBOX_WORKING_DIRECTORY_PREFIX_PATTERN, "").trim();
+}
+
+export function createProjectScopedExecOptions(
+  projectReference: string | null | undefined,
+): ExecOptions {
+  return projectReference ? { projectReference } : {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toSandboxFileContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (content instanceof Uint8Array) {
+    return new TextDecoder().decode(content);
+  }
+  return String(content ?? "");
+}
+
+function normalizeSandboxWriteFile(file: unknown): { path: string; content: string } {
+  if (!isRecord(file) || typeof file.path !== "string") {
+    throw new Error("Sandbox writeFiles entries must include a string path");
+  }
+
+  return {
+    path: file.path,
+    content: toSandboxFileContent(file.content),
+  };
+}
+
+export function createHostedSandboxClient(
+  input: HostedSandboxClientOptions = {},
+): HostedSandboxClient {
+  const getProjectId = input.getProjectId ?? (() => input.projectId);
+  const sandbox = new LazySandbox({ ...input, getProjectId });
+
+  const getExecOptions = () => createProjectScopedExecOptions(getProjectId());
+  const getCommandJobExecOptions = () => ({
+    ...getExecOptions(),
+    cwd: SANDBOX_WORKING_DIRECTORY,
+  });
+
+  return {
+    ensure: () => sandbox.ensure(),
+    async executeCommand(command) {
+      return await sandbox.executeCommand(command, getExecOptions());
+    },
+    readFile: (path) => sandbox.readFile(path),
+    writeFiles: (files) => sandbox.writeFiles(files.map((file) => normalizeSandboxWriteFile(file))),
+    startCommandJob: (command) =>
+      sandbox.startCommandJob(
+        unwrapSandboxWorkingDirectoryCommand(command),
+        getCommandJobExecOptions(),
+      ),
+    getCommandJob: (jobId) => sandbox.getCommandJob(jobId),
+    getCommandJobOutput: (jobId) => sandbox.getCommandJobOutput(jobId),
+    cancelCommandJob: (jobId) => sandbox.cancelCommandJob(jobId),
+    close: () => sandbox.close(),
+    get isActive() {
+      return sandbox.isActive;
+    },
+    get id() {
+      return sandbox.id;
+    },
+    get url() {
+      return sandbox.url;
+    },
+  };
+}
+
+export async function createHostedSandboxTools(
+  input: HostedSandboxToolsOptions,
+): Promise<HostedSandboxToolsResult> {
+  const sandbox = createHostedSandboxClient(input);
+  const shellTools = await createSandboxShellTools(sandbox, input.createBashTool);
+
+  const tools: SandboxShellToolSet = {
+    ...shellTools,
+    start_command_job: tool({
+      description:
+        "Start a long-running sandbox command as an async job. Use this instead of bash for durable shell operations.",
+      inputSchema: z.object({
+        command: z.string().describe("Single shell command to run asynchronously in the sandbox"),
+      }),
+      execute: async ({ command }) => await sandbox.startCommandJob(command),
+    }),
+    get_command_job: tool({
+      description:
+        "Get the current status for an async sandbox command job. Use this for polling while a long-running job is still running.",
+      inputSchema: z.object({
+        jobId: z.string().describe("Sandbox command job ID"),
+      }),
+      execute: async ({ jobId }) => await sandbox.getCommandJob(jobId),
+    }),
+    get_command_job_output: tool({
+      description:
+        "Get the captured stdout/stderr and terminal metadata for an async sandbox command job. Prefer calling this after the job reaches a terminal state.",
+      inputSchema: z.object({
+        jobId: z.string().describe("Sandbox command job ID"),
+      }),
+      execute: async ({ jobId }) => await sandbox.getCommandJobOutput(jobId),
+    }),
+    cancel_command_job: tool({
+      description: "Cancel a running async sandbox command job.",
+      inputSchema: z.object({
+        jobId: z.string().describe("Sandbox command job ID"),
+      }),
+      execute: async ({ jobId }) => await sandbox.cancelCommandJob(jobId),
+    }),
+  };
+
+  return {
+    tools,
+    sandbox,
+    closeSandbox: () => sandbox.close(),
+  };
+}

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -46,3 +46,14 @@ export {
   type SandboxShellToolDefinition,
   type SandboxShellToolSet,
 } from "./shell-tools.ts";
+export {
+  createHostedSandboxClient,
+  createHostedSandboxTools,
+  createProjectScopedExecOptions,
+  type HostedSandboxClient,
+  type HostedSandboxClientOptions,
+  type HostedSandboxJobClient,
+  type HostedSandboxToolsOptions,
+  type HostedSandboxToolsResult,
+  unwrapSandboxWorkingDirectoryCommand,
+} from "./hosted-tools.ts";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.351";
+export const VERSION = "0.1.352";


### PR DESCRIPTION
## Summary
- add hosted sandbox client and tool helpers for agent runtimes
- apply active project references to sandbox exec and async command-job requests
- expose the helpers from veryfront/sandbox and document the public API
- bump package version to 0.1.352 for CI/CD release

## Verification
- deno test --no-check --allow-all src/sandbox/hosted-tools.test.ts src/sandbox/shell-tools.test.ts
- deno task verify:quick
- pre-push checks: fmt, lint, type check, unit tests