### PR TITLE
Add public remote tool allowlist

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.352",
+  "version": "0.1.353",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -291,6 +291,22 @@ const allowedRemoteToolNames = expandAllowedRemoteToolNames({
 });
 ```
 
+### Remote tool allowlists
+
+Use `allowedRemoteTools` when a host discovers a remote tool inventory but only
+wants a subset exposed to the model and executable at runtime. Omit it to expose
+all tools returned by `remoteTools`. Use an empty array to expose none.
+
+```ts
+import { agent } from "veryfront/agent";
+
+const assistant = agent({
+  system: "Use only the selected remote tools.",
+  remoteTools: [docsTools],
+  allowedRemoteTools: ["docs_search"],
+});
+```
+
 ### Human input over hosted AG-UI runs
 
 ```ts
@@ -364,6 +380,7 @@ when bootstrap credentials are present.
 | `system`                 | <code>string &#124; (() =&gt; string) &#124; (() =&gt; Promise&lt;string&gt;)</code>                                                                | System prompt — string, function, or async function                                  |
 | `tools?`                 | <code>true &#124; Record&lt;string, Tool &#124; boolean&gt;</code>                                                                                  | Tools available to the agent                                                         |
 | `remoteTools?`           | `RemoteToolSource[]`                                                                                                                                | Remote tool sources queried per request (for example remote MCP)                     |
+| `allowedRemoteTools?`    | `string[]`                                                                                                                                          | Restrict `remoteTools` exposure and execution to these tool names.                   |
 | `maxSteps?`              | `number`                                                                                                                                            | Max tool-call iterations per request                                                 |
 | `streaming?`             | `boolean`                                                                                                                                           | Enable streaming responses                                                           |
 | `memory?`                | `MemoryConfig`                                                                                                                                      | Conversation memory settings                                                         |

--- a/src/agent/fork-runtime-stream.ts
+++ b/src/agent/fork-runtime-stream.ts
@@ -211,7 +211,7 @@ export async function runAgentRuntimeForkStep(input: RunAgentRuntimeForkStepInpu
     ...(input.providerOptions
       ? { resolveModelTransport: () => ({ providerOptions: input.providerOptions }) }
       : {}),
-    __vfAllowedRemoteTools: input.forkToolNames,
+    allowedRemoteTools: input.forkToolNames,
   };
   const runtime = new AgentRuntime("invoke-agent-child-runtime", runtimeConfig);
 

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -410,6 +410,14 @@ export function enforceSkillPolicy(
 }
 
 function getRuntimeAllowedRemoteTools(config: AgentConfig): string[] | undefined {
+  if (Object.hasOwn(config, "allowedRemoteTools")) {
+    const raw = config.allowedRemoteTools;
+    if (!Array.isArray(raw)) {
+      return [];
+    }
+    return raw.every((toolName) => typeof toolName === "string") ? raw : [];
+  }
+
   const configWithRuntimeFilters = config as RuntimeToolFilterConfig;
   if (!Object.hasOwn(configWithRuntimeFilters, "__vfAllowedRemoteTools")) {
     return undefined;

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -79,6 +79,11 @@ export interface AgentConfig {
   system: string | (() => string) | (() => Promise<string>);
   tools?: true | Record<string, Tool | boolean>;
   remoteTools?: RemoteToolSource[];
+  /**
+   * Optional remote tool name allowlist. When set, only matching tools from
+   * `remoteTools` are exposed to the model and executable at runtime.
+   */
+  allowedRemoteTools?: string[];
   maxSteps?: number;
   streaming?: boolean;
   memory?: MemoryConfig;

--- a/src/internal-agents/run-stream.ts
+++ b/src/internal-agents/run-stream.ts
@@ -24,7 +24,6 @@ const logger = serverLogger.component("internal-agent-run-stream");
 
 type RuntimeFilteredAgent = Agent & {
   config: Agent["config"] & {
-    __vfAllowedRemoteTools?: string[];
     __vfForwardedIntegrationToolDefs?: ForwardedToolDef[];
   };
 };
@@ -194,7 +193,7 @@ export async function createRuntimeAgentStreamResponse(
       ...agent.config,
       tools: mergedTools,
       ...(allowedRemoteToolNames !== undefined
-        ? { __vfAllowedRemoteTools: allowedRemoteToolNames }
+        ? { allowedRemoteTools: allowedRemoteToolNames }
         : {}),
       ...(forwardedIntegrationToolDefs !== undefined
         ? { __vfForwardedIntegrationToolDefs: forwardedIntegrationToolDefs }

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -1,4 +1,3 @@
-import type { Agent } from "#veryfront/agent";
 import { AgentRunSessionManager } from "#veryfront/internal-agents/session-manager.ts";
 import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
@@ -284,8 +283,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
       getAllAgentIds: () => ["assistant-1"],
       sessionManager: new AgentRunSessionManager(),
       createRuntime: (agent) => {
-        const config = agent.config as Agent["config"] & { __vfAllowedRemoteTools?: string[] };
-        capturedAllowedTools = config.__vfAllowedRemoteTools;
+        capturedAllowedTools = agent.config.allowedRemoteTools;
 
         return {
           stream: async (_messages, _context, callbacks) => {
@@ -346,8 +344,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
       getAllAgentIds: () => ["assistant-1"],
       sessionManager: new AgentRunSessionManager(),
       createRuntime: (agent) => {
-        const config = agent.config as Agent["config"] & { __vfAllowedRemoteTools?: string[] };
-        capturedAllowedTools = config.__vfAllowedRemoteTools;
+        capturedAllowedTools = agent.config.allowedRemoteTools;
 
         return {
           stream: async (_messages, _context, callbacks) => {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.352";
+export const VERSION = "0.1.353";


### PR DESCRIPTION
## Summary
- expose allowedRemoteTools on the public agent runtime config
- use the public field for internal runtime remote tool filters and fork runtime filters
- keep the private runtime filter fallback for compatibility
- document the remote tool allowlist API and bump the package patch version to 0.1.353

## Verification
- deno test --no-check --allow-all src/server/handlers/request/agent-stream.handler.test.ts src/agent/runtime/tool-helpers.test.ts src/agent/runtime/index.test.ts
- deno task verify:quick
- pre-push checks: fmt, lint, type check, unit tests