### PR TITLE
Add public response-like guard

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.353",
+  "version": "0.1.354",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -471,6 +471,21 @@ modules.
 | `mapRuntimeStreamEventToAgUiBrowserEvents(state, event)` | `(state, event) => AgUiBrowserEncodedEvent[]`                                                      | Map one runtime stream event into zero or more browser/public AG-UI events.                                                                                                                                                  |
 | `finalizeAgUiBrowserEvents(state, response)`             | `(state, response) => AgUiBrowserEncodedEvent[]`                                                   | Emit terminal browser/public AG-UI events after the runtime stream finishes.                                                                                                                                                 |
 
+### Response-like guards
+
+Use `isResponseLike` when host hooks can return a `Response` created by a
+different JavaScript runtime realm. It avoids fragile `instanceof Response`
+checks at route boundaries.
+
+```ts
+import { isResponseLike } from "veryfront/agent";
+
+const result = await beforeParse(request);
+if (isResponseLike(result)) {
+  return result;
+}
+```
+
 ### Provider-native tool inventory
 
 Use these helpers when a host needs to derive provider-native remote-tool

--- a/src/agent/ag-ui-handler.ts
+++ b/src/agent/ag-ui-handler.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isResponseLike } from "./response-like.ts";
 import { getAgent } from "./composition/index.ts";
 import type { Agent } from "./types.ts";
 import {
@@ -325,7 +326,7 @@ export function createAgUiHandler(
 
     try {
       const parsed = await parseAgUiRequestOrError(request);
-      if (parsed instanceof Response) {
+      if (isResponseLike(parsed)) {
         return parsed;
       }
 

--- a/src/agent/ag-ui-runtime-handler.ts
+++ b/src/agent/ag-ui-runtime-handler.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isResponseLike } from "./response-like.ts";
 import {
   AgentRuntime,
   RunAlreadyExistsError,
@@ -372,12 +373,12 @@ export function createAgUiRuntimeHandler(
 
     try {
       const gateResult = await config.beforeParse?.({ request });
-      if (gateResult instanceof Response) {
+      if (isResponseLike(gateResult)) {
         return gateResult;
       }
 
       const parsed = await parseAgUiRuntimeRequestOrError(request);
-      if (parsed instanceof Response) {
+      if (isResponseLike(parsed)) {
         if (config.validationErrorResponse) {
           return await config.validationErrorResponse({ request, response: parsed });
         }

--- a/src/agent/chat-handler.ts
+++ b/src/agent/chat-handler.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isResponseLike } from "./response-like.ts";
 import { getAgent } from "./composition/index.ts";
 import type { Message } from "./types.ts";
 import { fromError } from "#veryfront/errors/veryfront-error.ts";
@@ -155,19 +156,6 @@ function extractLastUserText(messages: ParsedMessage[]): string {
   }
 
   return "";
-}
-
-function isResponseLike(value: unknown): value is Response {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "status" in value &&
-    typeof value.status === "number" &&
-    "headers" in value &&
-    typeof value.headers === "object" &&
-    "bodyUsed" in value &&
-    typeof value.bodyUsed === "boolean"
-  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -139,6 +139,7 @@ export {
 } from "./composition/index.ts";
 
 export { agent } from "./factory.ts";
+export { isResponseLike } from "./response-like.ts";
 export {
   type AgentContract,
   type AgentRegistry,

--- a/src/agent/request-auth-cache.ts
+++ b/src/agent/request-auth-cache.ts
@@ -1,3 +1,4 @@
+import { isResponseLike } from "./response-like.ts";
 export type CachedRequestAuthResult<TAuth> = TAuth | Response;
 
 export interface CreateRequestAuthCacheOptions<TAuth> {
@@ -15,7 +16,7 @@ export function createRequestAuthCache<TAuth>(
   options: CreateRequestAuthCacheOptions<TAuth>,
 ): RequestAuthCache<TAuth> {
   const cache = new WeakMap<Request, TAuth>();
-  const shouldCache = options.shouldCache ?? ((result) => !(result instanceof Response));
+  const shouldCache = options.shouldCache ?? ((result) => !isResponseLike(result));
 
   return {
     async authenticate(request) {
@@ -25,7 +26,7 @@ export function createRequestAuthCache<TAuth>(
       }
 
       const result = await options.authenticate(request);
-      if (shouldCache(result) && !(result instanceof Response)) {
+      if (shouldCache(result) && !isResponseLike(result)) {
         cache.set(request, result);
       }
       return result;

--- a/src/agent/response-like.test.ts
+++ b/src/agent/response-like.test.ts
@@ -1,0 +1,38 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { isResponseLike } from "./response-like.ts";
+
+describe("isResponseLike", () => {
+  it("accepts native responses", () => {
+    assertEquals(isResponseLike(new Response("ok", { status: 201 })), true);
+  });
+
+  it("accepts response-shaped values from another runtime realm", () => {
+    assertEquals(
+      isResponseLike({
+        status: 401,
+        headers: new Headers(),
+        bodyUsed: false,
+        text: async () => "unauthorized",
+        json: async () => ({ error: "unauthorized" }),
+      }),
+      true,
+    );
+  });
+
+  it("accepts minimal response-shaped test doubles", () => {
+    assertEquals(
+      isResponseLike({
+        status: 400,
+        headers: new Headers(),
+        text: async () => "bad request",
+        json: async () => ({ error: "bad request" }),
+      }),
+      true,
+    );
+  });
+
+  it("rejects ordinary objects with only a status", () => {
+    assertEquals(isResponseLike({ status: 200 }), false);
+  });
+});

--- a/src/agent/response-like.ts
+++ b/src/agent/response-like.ts
@@ -1,0 +1,28 @@
+export function isResponseLike(value: unknown): value is Response {
+  if (value instanceof Response) {
+    return true;
+  }
+
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  if (!("status" in value) || typeof value.status !== "number") {
+    return false;
+  }
+
+  if (!("headers" in value) || typeof value.headers !== "object" || value.headers === null) {
+    return false;
+  }
+
+  if ("bodyUsed" in value && typeof value.bodyUsed === "boolean") {
+    return true;
+  }
+
+  return (
+    "text" in value &&
+    typeof value.text === "function" &&
+    "json" in value &&
+    typeof value.json === "function"
+  );
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.353";
+export const VERSION = "0.1.354";


### PR DESCRIPTION
## Summary
- expose isResponseLike from veryfront/agent for host route boundaries
- use the guard in AG-UI, chat, and request-auth flows instead of relying on Response realm identity
- document the helper and bump the package patch version to 0.1.354

## Verification
- deno test --no-check --allow-all src/agent/response-like.test.ts src/agent/ag-ui-runtime-handler.test.ts src/agent/ag-ui-handler.test.ts src/agent/request-auth-cache.test.ts src/agent/chat-handler.test.ts
- deno task verify:quick
- pre-push checks: fmt, lint, type check, unit tests