### PR TITLE
Add hosted child terminal code helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.354",
+  "version": "0.1.355",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -38,8 +38,10 @@ import {
   expandAllowedRemoteToolNames,
   getAgentsAsTools,
   getProviderNativeToolNames,
+  hostedChildTerminalErrorCodes,
   HostedLifecycleTerminalState,
   HumanInputRequestSchema,
+  isHostedChildTerminalErrorCode,
   normalizeAgUiMessages,
   normalizeAgUiRuntimeMessages,
   parseAgUiRequest,
@@ -50,6 +52,7 @@ import {
   runHostedChildLifecycle,
   runHostedLifecycle,
   RunResumeSessionManager,
+  shouldSkipHostedChildTerminalPersistence,
   waitForHumanInput,
 } from "veryfront/agent";
 ```
@@ -427,6 +430,10 @@ modules.
 | `runHostedLifecycle()`                                   | `(options) => Promise<HostedLifecycleRunResult>`                                                   | Orchestrate start/observe/finalize/cancel sequencing with host-owned adapters.                                                                                                                                               |
 | `runHostedResponseStreamWithHeartbeat()`                 | `(options) => Promise<void>`                                                                       | Stream hosted execution chunks through one writer while the package owns heartbeat timing plus the generic hosted lifecycle loop and the host keeps heartbeat chunk and logging policy local.                                |
 | `runHostedChildLifecycle()`                              | `(options) => Promise<HostedChildLifecycleRunResult>`                                              | Orchestrate pending/running/completed/failed/cancelled child lifecycle sequencing with host-owned adapters.                                                                                                                  |
+| `runHostedChildExecutionLifecycle()`                     | `(options) => Promise<HostedChildExecutionLifecycleResult>`                                        | Wrap hosted child lifecycle sequencing around local child execution snapshots and normalize terminal child-run errors.                                                                                                       |
+| `hostedChildTerminalErrorCodes`                          | `{ cancelled, failed, completedExternally }`                                                       | Canonical durable child terminal error codes emitted when an externally controlled child run reaches a terminal state before local execution completes.                                                                      |
+| `isHostedChildTerminalErrorCode()`                       | `(value) => value is HostedChildTerminalErrorCode`                                                 | Check whether an unknown value is one of the canonical hosted child terminal error codes.                                                                                                                                    |
+| `shouldSkipHostedChildTerminalPersistence()`             | `(terminalState) => boolean`                                                                       | Determine whether a hosted child terminal state already reflects external durable child persistence and should not be finalized again by lifecycle adapters.                                                                 |
 | `createConversationHostedStreamLifecycleAdapter()`       | `(options) => HostedLifecycleAdapter<ConversationRunProjection, ChatStreamEvent>`                  | Create a conversation-backed hosted lifecycle adapter that appends canonical conversation-run events directly from public chat stream events.                                                                                |
 | `createConversationAgentRun()`                           | `(input) => Promise<ConversationRunProjection>`                                                    | Create a conversation-owned durable agent run and read back its canonical projection.                                                                                                                                        |
 | `getConversationRun()`                                   | `(input) => Promise<ConversationRunProjection>`                                                    | Read the canonical projection for an existing conversation-owned durable run.                                                                                                                                                |

--- a/src/agent/hosted-child-lifecycle.test.ts
+++ b/src/agent/hosted-child-lifecycle.test.ts
@@ -5,10 +5,30 @@ import {
   type HostedChildLifecycleAdapter,
   runHostedChildExecutionLifecycle,
   runHostedChildLifecycle,
+  shouldSkipHostedChildTerminalPersistence,
 } from "./hosted-child-lifecycle.ts";
 import { HostedChildTerminalStateError } from "./hosted-child-status.ts";
 
 describe("agent/hosted-child-lifecycle", () => {
+  it("identifies externally persisted terminal states", () => {
+    assertEquals(
+      shouldSkipHostedChildTerminalPersistence({ terminalErrorCode: "DURABLE_CHILD_CANCELLED" }),
+      true,
+    );
+    assertEquals(
+      shouldSkipHostedChildTerminalPersistence({ terminalErrorCode: "DURABLE_CHILD_FAILED" }),
+      true,
+    );
+    assertEquals(
+      shouldSkipHostedChildTerminalPersistence({
+        terminalErrorCode: "DURABLE_CHILD_COMPLETED_EXTERNALLY",
+      }),
+      true,
+    );
+    assertEquals(shouldSkipHostedChildTerminalPersistence({ terminalErrorCode: "OTHER" }), false);
+    assertEquals(shouldSkipHostedChildTerminalPersistence({ terminalErrorCode: null }), false);
+  });
+
   it("runs pending, running, and completed around successful execution", async () => {
     const calls: string[] = [];
     const adapter: HostedChildLifecycleAdapter = {

--- a/src/agent/hosted-child-lifecycle.ts
+++ b/src/agent/hosted-child-lifecycle.ts
@@ -7,6 +7,7 @@ import {
 import { isChildRunAbortError } from "./child-run-execution-support.ts";
 import {
   HostedChildTerminalStateError,
+  isHostedChildTerminalErrorCode,
   resolveHostedChildTerminalErrorCode,
 } from "./hosted-child-status.ts";
 
@@ -87,6 +88,12 @@ export type HostedChildExecutionLifecycleResult<
     error: unknown;
     terminalState: HostedChildLifecycleTerminalState;
   };
+
+export function shouldSkipHostedChildTerminalPersistence(
+  terminalState: Pick<HostedChildLifecycleTerminalState, "terminalErrorCode">,
+): boolean {
+  return isHostedChildTerminalErrorCode(terminalState.terminalErrorCode);
+}
 
 export interface HostedChildExecutionLifecycleOptions<
   TLocalResult extends ChildRunExecutionResult,

--- a/src/agent/hosted-child-status.test.ts
+++ b/src/agent/hosted-child-status.test.ts
@@ -1,19 +1,38 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  hostedChildTerminalErrorCodes,
   HostedChildTerminalStateError,
+  isHostedChildTerminalErrorCode,
   monitorHostedChildRunStatus,
   resolveHostedChildTerminalErrorCode,
 } from "./hosted-child-status.ts";
 
 describe("agent/hosted-child-status", () => {
   it("maps terminal statuses to durable child error codes", () => {
-    assertEquals(resolveHostedChildTerminalErrorCode("cancelled"), "DURABLE_CHILD_CANCELLED");
-    assertEquals(resolveHostedChildTerminalErrorCode("failed"), "DURABLE_CHILD_FAILED");
+    assertEquals(
+      resolveHostedChildTerminalErrorCode("cancelled"),
+      hostedChildTerminalErrorCodes.cancelled,
+    );
+    assertEquals(
+      resolveHostedChildTerminalErrorCode("failed"),
+      hostedChildTerminalErrorCodes.failed,
+    );
     assertEquals(
       resolveHostedChildTerminalErrorCode("completed"),
-      "DURABLE_CHILD_COMPLETED_EXTERNALLY",
+      hostedChildTerminalErrorCodes.completedExternally,
     );
+  });
+
+  it("recognizes hosted child terminal error codes", () => {
+    assertEquals(isHostedChildTerminalErrorCode(hostedChildTerminalErrorCodes.cancelled), true);
+    assertEquals(isHostedChildTerminalErrorCode(hostedChildTerminalErrorCodes.failed), true);
+    assertEquals(
+      isHostedChildTerminalErrorCode(hostedChildTerminalErrorCodes.completedExternally),
+      true,
+    );
+    assertEquals(isHostedChildTerminalErrorCode("OTHER"), false);
+    assertEquals(isHostedChildTerminalErrorCode(null), false);
   });
 
   it("stores status and identifiers on HostedChildTerminalStateError", () => {

--- a/src/agent/hosted-child-status.ts
+++ b/src/agent/hosted-child-status.ts
@@ -10,6 +10,25 @@ export interface HostedChildRunIdentifiers {
 
 type HostedConversationRunStatus = ConversationRunProjection["status"];
 
+export const hostedChildTerminalErrorCodes = Object.freeze({
+  cancelled: "DURABLE_CHILD_CANCELLED",
+  failed: "DURABLE_CHILD_FAILED",
+  completedExternally: "DURABLE_CHILD_COMPLETED_EXTERNALLY",
+});
+
+export type HostedChildTerminalErrorCode =
+  (typeof hostedChildTerminalErrorCodes)[keyof typeof hostedChildTerminalErrorCodes];
+
+export function isHostedChildTerminalErrorCode(
+  value: unknown,
+): value is HostedChildTerminalErrorCode {
+  return (
+    value === hostedChildTerminalErrorCodes.cancelled ||
+    value === hostedChildTerminalErrorCodes.failed ||
+    value === hostedChildTerminalErrorCodes.completedExternally
+  );
+}
+
 export type HostedChildTerminalStatus = Extract<
   HostedConversationRunStatus,
   "completed" | "failed" | "cancelled"
@@ -33,14 +52,16 @@ function isActiveHostedChildStatus(
   return status === "pending" || status === "running" || status === "waiting_for_tool";
 }
 
-export function resolveHostedChildTerminalErrorCode(status: HostedChildTerminalStatus): string {
+export function resolveHostedChildTerminalErrorCode(
+  status: HostedChildTerminalStatus,
+): HostedChildTerminalErrorCode {
   switch (status) {
     case "cancelled":
-      return "DURABLE_CHILD_CANCELLED";
+      return hostedChildTerminalErrorCodes.cancelled;
     case "failed":
-      return "DURABLE_CHILD_FAILED";
+      return hostedChildTerminalErrorCodes.failed;
     case "completed":
-      return "DURABLE_CHILD_COMPLETED_EXTERNALLY";
+      return hostedChildTerminalErrorCodes.completedExternally;
   }
 }
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -596,6 +596,7 @@ export {
   type HostedChildLifecycleTerminalState,
   runHostedChildExecutionLifecycle,
   runHostedChildLifecycle,
+  shouldSkipHostedChildTerminalPersistence,
 } from "./hosted-child-lifecycle.ts";
 export {
   appendHostedChildMirrorChunk,
@@ -611,8 +612,11 @@ export {
 } from "./hosted-child-mirror.ts";
 export {
   type HostedChildRunIdentifiers,
+  type HostedChildTerminalErrorCode,
+  hostedChildTerminalErrorCodes,
   HostedChildTerminalStateError,
   type HostedChildTerminalStatus,
+  isHostedChildTerminalErrorCode,
   monitorHostedChildRunStatus,
   resolveHostedChildTerminalErrorCode,
 } from "./hosted-child-status.ts";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.354";
+export const VERSION = "0.1.355";


### PR DESCRIPTION
## Summary
- add canonical hosted child terminal error code constants and predicate
- add a lifecycle helper for skipping terminal persistence already reflected by durable child state
- document the hosted child terminal helper exports

## Verification
- deno test --no-check --allow-all src/agent/hosted-child-status.test.ts src/agent/hosted-child-lifecycle.test.ts
- deno task verify:quick
- pre-push checks: fmt, lint, type check, unit tests
