### PR TITLE
Add runtime agent invocation contract

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.355",
+  "version": "0.1.356",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent-runtime-ag-ui-contract.md
+++ b/docs/reference/agent-runtime-ag-ui-contract.md
@@ -1,10 +1,10 @@
-# Agent Runtime AG-UI Contract
+# Agent runtime AG-UI contract
 
 This document defines the canonical runtime-facing request contract for the `veryfront` package.
 
 The goal is to make downstream consumers target one explicit AG-UI-aligned input model instead of treating the current runtime transport as a custom side protocol.
 
-## Canonical Contract
+## Canonical contract
 
 The canonical runtime contract is defined in [`src/agent/runtime-ag-ui-contract.ts`](../../src/agent/runtime-ag-ui-contract.ts) by [`AgUiRuntimeRequestSchema`](../../src/agent/runtime-ag-ui-contract.ts).
 
@@ -21,7 +21,7 @@ It is based on the AG-UI `RunAgentInput` shape:
 
 The runtime response contract remains AG-UI SSE.
 
-## Supported AG-UI Subset
+## Supported AG-UI subset
 
 The package runtime currently accepts a text-first subset of AG-UI messages:
 
@@ -38,7 +38,7 @@ Current message support is intentionally narrower than the full AG-UI type catal
 
 The package runtime does not currently treat `developer`, `activity`, or `reasoning` messages as canonical input roles for this contract.
 
-## Package/Runtime Extensions
+## Package and runtime extensions
 
 The canonical runtime contract keeps a small number of package/runtime extensions:
 
@@ -54,20 +54,32 @@ Structured runtime context currently supports:
 
 These extensions are part of the package runtime contract, not AG-UI core.
 
-## Transitional Transport Wrapper
+## Control-plane runtime invocation wrapper
 
-The current internal transport route, `/internal/agents/stream`, is a compatibility wrapper, not the canonical package contract.
+`RuntimeAgentRunInvocationSchema` defines the service-to-service wrapper used
+when a trusted control plane invokes a separately deployed runtime agent
+service.
 
-That wrapper currently adds transport-only fields:
+The wrapper carries control-plane-owned metadata that does not belong in the
+public AG-UI runtime request body:
 
-- `agentId`
-- `agentSource`
+- runtime service and agent ids
+- conversation, run, message, and input-anchor ids
+- project and runtime-target context
+- optional parent-run and spawn lineage
+- optional validated claims
+- runtime tools, context, source metadata, and forwarded props
 
-It also accepts the legacy message shape based on `parts`.
+The wrapper does not replace `AgUiRuntimeRequestSchema`. Hosts should use
+`AgUiRuntimeRequestSchema` for public AG-UI runtime routes and use
+`RuntimeAgentRunInvocationSchema` only for signed control-plane routes where
+the control plane owns durable run identity and project context.
 
-The wrapper is defined by [`InternalAgentStreamRequestSchema`](../../src/internal-agents/schema.ts) and normalized into the canonical runtime input with [`toRuntimeRunAgentInput()`](../../src/internal-agents/schema.ts).
+Private routes such as `/internal/agents/stream` can use this wrapper as their
+host-specific service boundary, then normalize the message payload into the
+local agent runtime input model before execution.
 
-## Endpoint Convention
+## Endpoint convention
 
 The package should standardize the runtime contract, not force one hardcoded route.
 
@@ -87,12 +99,9 @@ Public control-plane wrapper convention:
 - `POST /api/control-plane/agents/runs/:runId/resume`
 - `DELETE /api/control-plane/agents/runs/:runId`
 
-Legacy internal compatibility route:
+Private signed control-plane wrappers:
 
 - `POST /internal/agents/stream`
-
-Legacy internal signed control-plane wrappers:
-
 - `POST /internal/agents/runs/:runId/resume`
 - `DELETE /internal/agents/runs/:runId`
 
@@ -105,9 +114,10 @@ helpers are available as public package exports:
 
 Those internal handlers are Veryfront-specific wrappers around the generic
 package-hosted run-control surface. Downstream package consumers should target
-the public `veryfront/agent` handlers instead of these internal routes.
+the public `veryfront/agent` handlers unless they are implementing a trusted
+control-plane runtime service.
 
-## What Downstream Consumers Should Target
+## What downstream consumers should target
 
 Downstream package/framework consumers should target:
 
@@ -118,4 +128,11 @@ Downstream package/framework consumers should target:
 - AG-UI SSE responses
 - the default endpoint convention `/api/ag-ui` unless a host explicitly documents another route
 
-They should not treat `/internal/agents/stream` and its extra wrapper fields as the long-term package contract when the public `/api/control-plane/agents/*` route family is available.
+Control-plane runtime service implementers can also target:
+
+- `RuntimeAgentRunInvocationSchema`
+- `parseRuntimeAgentRunInvocation()`
+- `parseRuntimeAgentRunInvocationOrError()`
+
+They should not treat `/internal/agents/stream` as the public package AG-UI
+contract.

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -48,10 +48,13 @@ import {
   parseAgUiRequestOrError,
   parseAgUiRuntimeRequest,
   parseAgUiRuntimeRequestOrError,
+  parseRuntimeAgentRunInvocation,
+  parseRuntimeAgentRunInvocationOrError,
   registerAgent,
   runHostedChildLifecycle,
   runHostedLifecycle,
   RunResumeSessionManager,
+  RuntimeAgentRunInvocationSchema,
   shouldSkipHostedChildTerminalPersistence,
   waitForHumanInput,
 } from "veryfront/agent";
@@ -706,6 +709,31 @@ Parse and validate the canonical runtime AG-UI request body into
 Parse the canonical runtime AG-UI request body and return either the parsed
 request or a `400` JSON `Response` when validation fails.
 
+### `RuntimeAgentRunInvocationSchema`
+
+Validate the control-plane runtime agent invocation wrapper for separately
+deployed runtime services.
+
+Use this schema when a trusted control plane invokes a runtime agent service
+with run, project, target, lineage, tool, context, and forwarded-prop metadata.
+It wraps the message payload that a host can then normalize into the local
+agent runtime input model.
+
+This schema is not a replacement for `AgUiRuntimeRequestSchema`. Use
+`AgUiRuntimeRequestSchema` for public AG-UI runtime routes. Use
+`RuntimeAgentRunInvocationSchema` for signed service-to-service invocation
+routes where the control plane owns durable run identity and project context.
+
+### `parseRuntimeAgentRunInvocation(request)`
+
+Parse and validate the control-plane runtime agent invocation body into
+`RuntimeAgentRunInvocationSchema`.
+
+### `parseRuntimeAgentRunInvocationOrError(request)`
+
+Parse the control-plane runtime agent invocation body and return either the
+parsed request or a `400` JSON `Response` when validation fails.
+
 ### `normalizeAgUiRuntimeMessages(messages)`
 
 Normalize canonical runtime AG-UI `messages` into the package `Message[]`
@@ -834,34 +862,36 @@ Clear all stored messages from memory.
 
 ### Functions
 
-| Name                             | Description                                                             |
-| -------------------------------- | ----------------------------------------------------------------------- |
-| `agent`                          | Create an agent                                                         |
-| `agentAsTool`                    | Wrap agent as callable tool                                             |
-| `createAgUiCancelHandler`        | Create a DELETE handler for hosted AG-UI run cancellation               |
-| `createAgUiDetachedStartHandler` | Create a POST handler for detached hosted AG-UI run kickoff             |
-| `executeAgUiDetachedStart`       | Run detached hosted-start lifecycle from a validated request object     |
-| `createAgUiHandler`              | Create a POST handler for an AG-UI route                                |
-| `createAgUiRuntimeHandler`       | Create a POST handler for the canonical runtime AG-UI request contract  |
-| `createAgUiRunErrorEvent`        | Create a `RunError` AG-UI SSE event                                     |
-| `createAgUiSseErrorResponse`     | Create an AG-UI SSE error `Response`                                    |
-| `createAgUiResumeHandler`        | Create a POST handler for hosted AG-UI run resume values                |
-| `normalizeAgUiRuntimeMessages`   | Normalize runtime AG-UI messages into package `Message[]`               |
-| `parseAgUiRuntimeRequest`        | Parse and validate the canonical runtime AG-UI request body             |
-| `parseAgUiRuntimeRequestOrError` | Parse runtime AG-UI input or return a `400` validation `Response`       |
-| `createChatHandler`              | Create a POST handler for a chat API route.                             |
-| `createMemory`                   | Create memory (buffer, conversation, summary)                           |
-| `createRedisMemory`              | Create Redis-backed memory                                              |
-| `createWorkflow`                 | Create sequential agent workflow                                        |
-| `getAgent`                       | Get agent by ID                                                         |
-| `getAgentsAsTools`               | Get agents as tools (multi-agent)                                       |
-| `getAllAgentIds`                 | List registered agent IDs                                               |
-| `getTextFromParts`               | Extract text from multi-part message                                    |
-| `getToolArguments`               | Extract parsed tool call args                                           |
-| `hasArgs`                        | Check for parsed args on tool call                                      |
-| `hasInput`                       | Check for raw input on tool call                                        |
-| `registerAgent`                  | Register agent for discovery                                            |
-| `waitForHumanInput`              | Wait for a canonical human-input response over hosted AG-UI run control |
+| Name                                    | Description                                                              |
+| --------------------------------------- | ------------------------------------------------------------------------ |
+| `agent`                                 | Create an agent                                                          |
+| `agentAsTool`                           | Wrap agent as callable tool                                              |
+| `createAgUiCancelHandler`               | Create a DELETE handler for hosted AG-UI run cancellation                |
+| `createAgUiDetachedStartHandler`        | Create a POST handler for detached hosted AG-UI run kickoff              |
+| `executeAgUiDetachedStart`              | Run detached hosted-start lifecycle from a validated request object      |
+| `createAgUiHandler`                     | Create a POST handler for an AG-UI route                                 |
+| `createAgUiRuntimeHandler`              | Create a POST handler for the canonical runtime AG-UI request contract   |
+| `createAgUiRunErrorEvent`               | Create a `RunError` AG-UI SSE event                                      |
+| `createAgUiSseErrorResponse`            | Create an AG-UI SSE error `Response`                                     |
+| `createAgUiResumeHandler`               | Create a POST handler for hosted AG-UI run resume values                 |
+| `normalizeAgUiRuntimeMessages`          | Normalize runtime AG-UI messages into package `Message[]`                |
+| `parseAgUiRuntimeRequest`               | Parse and validate the canonical runtime AG-UI request body              |
+| `parseAgUiRuntimeRequestOrError`        | Parse runtime AG-UI input or return a `400` validation `Response`        |
+| `parseRuntimeAgentRunInvocation`        | Parse and validate a control-plane runtime agent invocation body         |
+| `parseRuntimeAgentRunInvocationOrError` | Parse a runtime agent invocation or return a `400` validation `Response` |
+| `createChatHandler`                     | Create a POST handler for a chat API route.                              |
+| `createMemory`                          | Create memory (buffer, conversation, summary)                            |
+| `createRedisMemory`                     | Create Redis-backed memory                                               |
+| `createWorkflow`                        | Create sequential agent workflow                                         |
+| `getAgent`                              | Get agent by ID                                                          |
+| `getAgentsAsTools`                      | Get agents as tools (multi-agent)                                        |
+| `getAllAgentIds`                        | List registered agent IDs                                                |
+| `getTextFromParts`                      | Extract text from multi-part message                                     |
+| `getToolArguments`                      | Extract parsed tool call args                                            |
+| `hasArgs`                               | Check for parsed args on tool call                                       |
+| `hasInput`                              | Check for raw input on tool call                                         |
+| `registerAgent`                         | Register agent for discovery                                             |
+| `waitForHumanInput`                     | Wait for a canonical human-input response over hosted AG-UI run control  |
 
 ### Classes
 
@@ -878,17 +908,30 @@ Clear all stored messages from memory.
 
 ### Schemas
 
-| Name                             | Description                                                            |
-| -------------------------------- | ---------------------------------------------------------------------- |
-| `AgUiDetachedStartRequestSchema` | Canonical detached hosted-run kickoff request schema                   |
-| `AgUiRequestSchema`              | Convenience request schema for `createAgUiHandler()`                   |
-| `AgUiRuntimeRequestSchema`       | Canonical open-source AG-UI runtime request contract for hosted runs   |
-| `AgUiResumeSignalSchema`         | Canonical hosted-run resume payload for AG-UI tool-result continuation |
-| `HumanInputFieldSchema`          | Canonical human-input field schema                                     |
-| `HumanInputOptionSchema`         | Canonical human-input option schema                                    |
-| `HumanInputPendingRequestSchema` | Canonical pending human-input request envelope for hosts               |
-| `HumanInputRequestSchema`        | Canonical human-input request payload                                  |
-| `HumanInputResultSchema`         | Canonical human-input resumed result payload                           |
+| Name                                | Description                                                            |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| `AgUiDetachedStartRequestSchema`    | Canonical detached hosted-run kickoff request schema                   |
+| `AgUiRequestSchema`                 | Convenience request schema for `createAgUiHandler()`                   |
+| `AgUiRuntimeRequestSchema`          | Canonical open-source AG-UI runtime request contract for hosted runs   |
+| `AgUiResumeSignalSchema`            | Canonical hosted-run resume payload for AG-UI tool-result continuation |
+| `HumanInputFieldSchema`             | Canonical human-input field schema                                     |
+| `HumanInputOptionSchema`            | Canonical human-input option schema                                    |
+| `HumanInputPendingRequestSchema`    | Canonical pending human-input request envelope for hosts               |
+| `HumanInputRequestSchema`           | Canonical human-input request payload                                  |
+| `HumanInputResultSchema`            | Canonical human-input resumed result payload                           |
+| `RuntimeAgentContextItemSchema`     | Control-plane runtime agent invocation context item schema             |
+| `RuntimeAgentIdSchema`              | Control-plane runtime agent id schema                                  |
+| `RuntimeAgentProjectContextSchema`  | Control-plane runtime agent project and target context schema          |
+| `RuntimeAgentRunContextSchema`      | Control-plane runtime agent run identity and lineage context schema    |
+| `RuntimeAgentRunIdSchema`           | Control-plane runtime agent run id schema                              |
+| `RuntimeAgentRunInvocationSchema`   | Control-plane runtime agent invocation wrapper schema                  |
+| `RuntimeAgentServiceIdSchema`       | Control-plane runtime agent service id schema                          |
+| `RuntimeAgentSourceContextSchema`   | Control-plane runtime agent source context schema                      |
+| `RuntimeAgentTargetKindSchema`      | Control-plane runtime target kind schema                               |
+| `RuntimeAgentToolCallIdSchema`      | Control-plane runtime tool call id schema                              |
+| `RuntimeAgentToolNameSchema`        | Control-plane runtime tool name schema                                 |
+| `RuntimeAgentToolSchema`            | Control-plane runtime tool descriptor schema                           |
+| `RuntimeAgentValidatedClaimsSchema` | Control-plane runtime validated claims schema                          |
 
 ### Types
 
@@ -951,6 +994,14 @@ Clear all stored messages from memory.
 | `ResolvedRuntimeState`                     | Step-boundary system/context refresh result                                                                                   |
 | `RuntimeStateRequest`                      | Step-boundary runtime refresh hook input                                                                                      |
 | `RuntimeStateResolver`                     | Hook that refreshes system/context state during long-lived runs                                                               |
+| `RuntimeAgentContextItem`                  | Validated control-plane runtime agent invocation context item                                                                 |
+| `RuntimeAgentProjectContext`               | Validated control-plane runtime agent project and target context                                                              |
+| `RuntimeAgentRunContext`                   | Validated control-plane runtime agent run identity and lineage context                                                        |
+| `RuntimeAgentRunInvocation`                | Validated control-plane runtime agent invocation wrapper                                                                      |
+| `RuntimeAgentSourceContext`                | Validated control-plane runtime agent source context                                                                          |
+| `RuntimeAgentTargetKind`                   | Runtime target kind for a control-plane runtime agent invocation                                                              |
+| `RuntimeAgentTool`                         | Validated control-plane runtime agent tool descriptor                                                                         |
+| `RuntimeAgentValidatedClaims`              | Validated claims attached to a control-plane runtime agent invocation                                                         |
 | `StreamToolCall`                           | Streaming tool call                                                                                                           |
 | `ToolCall`                                 | Completed tool call                                                                                                           |
 | `ToolCallPart`                             | Tool call message segment                                                                                                     |

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -182,6 +182,32 @@ export {
   parseAgUiRuntimeRequest,
   parseAgUiRuntimeRequestOrError,
 } from "./runtime-ag-ui-contract.ts";
+export {
+  parseRuntimeAgentRunInvocation,
+  parseRuntimeAgentRunInvocationOrError,
+  type RuntimeAgentContextItem,
+  RuntimeAgentContextItemSchema,
+  RuntimeAgentIdSchema,
+  type RuntimeAgentProjectContext,
+  RuntimeAgentProjectContextSchema,
+  type RuntimeAgentRunContext,
+  RuntimeAgentRunContextSchema,
+  RuntimeAgentRunIdSchema,
+  type RuntimeAgentRunInvocation,
+  RuntimeAgentRunInvocationSchema,
+  RuntimeAgentServiceIdSchema,
+  type RuntimeAgentSourceContext,
+  RuntimeAgentSourceContextSchema,
+  type RuntimeAgentTargetKind,
+  RuntimeAgentTargetKindSchema,
+  type RuntimeAgentTool,
+  RuntimeAgentToolCallIdSchema,
+  RuntimeAgentToolNameSchema,
+  RuntimeAgentToolSchema,
+  type RuntimeAgentValidatedClaims,
+  RuntimeAgentValidatedClaimsSchema,
+  validateRuntimeAgentTargetSelection,
+} from "./runtime-agent-invocation-contract.ts";
 export { normalizeAgUiRuntimeMessages } from "./ag-ui-runtime-support.ts";
 export {
   type AgUiBrowserEncodedEvent,

--- a/src/agent/runtime-agent-invocation-contract.test.ts
+++ b/src/agent/runtime-agent-invocation-contract.test.ts
@@ -1,0 +1,187 @@
+import { assertEquals, assertInstanceOf, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  parseRuntimeAgentRunInvocation,
+  parseRuntimeAgentRunInvocationOrError,
+  RuntimeAgentRunInvocationSchema,
+} from "./index.ts";
+
+const conversationId = "10000000-1000-4000-8000-100000000001";
+const messageId = "10000000-1000-4000-8000-100000000002";
+const inputAnchorMessageId = "10000000-1000-4000-8000-100000000003";
+const userId = "10000000-1000-4000-8000-100000000004";
+const projectId = "10000000-1000-4000-8000-100000000005";
+const branchId = "10000000-1000-4000-8000-100000000006";
+
+function createInvocation(overrides: Record<string, unknown> = {}) {
+  return {
+    run: {
+      agentServiceId: "1-runtime-provider",
+      agentId: "builder",
+      conversationId,
+      runId: "run_root_1",
+      messageId,
+      inputAnchorMessageId,
+      requestedByUserId: userId,
+      project: {
+        projectId,
+        projectSlug: "demo-project",
+        runtimeTargetKind: "preview_branch",
+        runtimeTargetBranchId: branchId,
+      },
+      validatedClaims: {
+        subject: userId,
+        projectId,
+        projectSlug: "demo-project",
+        scopes: ["agent:run"],
+      },
+    },
+    messages: [
+      { id: "user-message-1", role: "user", parts: [{ type: "text", text: "Hello" }] },
+      {
+        id: "tool-message-1",
+        role: "tool",
+        parts: [{ type: "tool_result", output: { ok: true } }],
+      },
+    ],
+    tools: [{
+      name: "studio_focus_component",
+      description: "Focus the selected component",
+      inputSchema: {
+        type: "object",
+        properties: {
+          componentId: { type: "string" },
+        },
+      },
+    }],
+    context: [{ type: "text", text: "Current file: app.tsx" }],
+    agentSource: { type: "branch", branch: "main" },
+    forwardedProps: { activeChatId: "chat_123" },
+    ...overrides,
+  };
+}
+
+describe("agent/runtime-agent-invocation-contract", () => {
+  it("exports the control-plane runtime agent invocation schema from veryfront/agent", () => {
+    const parsed = RuntimeAgentRunInvocationSchema.parse(createInvocation());
+
+    assertEquals(parsed.run.agentServiceId, "1-runtime-provider");
+    assertEquals(parsed.run.project.runtimeTargetKind, "preview_branch");
+    assertEquals(parsed.run.validatedClaims?.scopes, ["agent:run"]);
+    assertEquals(parsed.messages.length, 2);
+    assertEquals(parsed.tools[0]?.name, "studio_focus_component");
+  });
+
+  it("enforces child-run lineage before invoking a runtime agent service", () => {
+    const parsed = RuntimeAgentRunInvocationSchema.parse(createInvocation({
+      run: {
+        agentServiceId: "veryfront-platform-agent",
+        agentId: "builder",
+        conversationId,
+        runId: "run_child_1",
+        messageId,
+        inputAnchorMessageId,
+        requestedByUserId: userId,
+        project: {
+          projectId,
+          projectSlug: "demo-project",
+        },
+        parentRunId: "run_root_1",
+        spawnedFromToolCallId: "tool_1",
+      },
+    }));
+
+    assertEquals(parsed.run.parentRunId, "run_root_1");
+
+    assertThrows(() =>
+      RuntimeAgentRunInvocationSchema.parse(createInvocation({
+        run: {
+          agentServiceId: "veryfront-platform-agent",
+          agentId: "builder",
+          conversationId,
+          runId: "run_root_1",
+          messageId,
+          inputAnchorMessageId,
+          requestedByUserId: userId,
+          project: {
+            projectId,
+            projectSlug: "demo-project",
+          },
+          parentRunId: "run_root_1",
+        },
+      }))
+    );
+
+    assertThrows(() =>
+      RuntimeAgentRunInvocationSchema.parse(createInvocation({
+        run: {
+          agentServiceId: "veryfront-platform-agent",
+          agentId: "builder",
+          conversationId,
+          runId: "run_child_1",
+          messageId,
+          inputAnchorMessageId,
+          requestedByUserId: userId,
+          project: {
+            projectId,
+            projectSlug: "demo-project",
+          },
+          spawnedFromToolCallId: "tool_1",
+        },
+      }))
+    );
+  });
+
+  it("rejects project claims that do not match the selected project context", () => {
+    assertThrows(() =>
+      RuntimeAgentRunInvocationSchema.parse(createInvocation({
+        run: {
+          agentServiceId: "veryfront-platform-agent",
+          agentId: "builder",
+          conversationId,
+          runId: "run_root_1",
+          messageId,
+          inputAnchorMessageId,
+          requestedByUserId: userId,
+          project: {
+            projectId,
+            projectSlug: "demo-project",
+          },
+          validatedClaims: {
+            subject: userId,
+            projectId: "10000000-1000-4000-8000-100000000007",
+          },
+        },
+      }))
+    );
+  });
+
+  it("parses runtime agent invocation request bodies through the public helper", async () => {
+    const parsed = await parseRuntimeAgentRunInvocation(
+      new Request("http://localhost/internal/agents/stream", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(createInvocation()),
+      }),
+    );
+
+    assertEquals(parsed.run.runId, "run_root_1");
+    assertEquals(parsed.context.length, 1);
+  });
+
+  it("returns a 400 response for malformed runtime agent invocation payloads", async () => {
+    const result = await parseRuntimeAgentRunInvocationOrError(
+      new Request("http://localhost/internal/agents/stream", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ run: { runId: "run_1" } }),
+      }),
+    );
+
+    assertInstanceOf(result, Response);
+    assertEquals(result.status, 400);
+    const body = await result.json();
+    assertEquals(body.error, "Invalid runtime agent invocation");
+    assertEquals(Array.isArray(body.details), true);
+  });
+});

--- a/src/agent/runtime-agent-invocation-contract.ts
+++ b/src/agent/runtime-agent-invocation-contract.ts
@@ -1,0 +1,260 @@
+import { z } from "zod";
+import { parseAgUiJsonRequestOrError } from "./ag-ui-request-shared.ts";
+
+const MAX_TOOL_PARAMETERS_BYTES = 16_384;
+const MAX_CONTEXT_ITEM_BYTES = 16_384;
+const MAX_CONTEXT_TOTAL_BYTES = 65_536;
+const MAX_FORWARDED_PROPS_BYTES = 65_536;
+const encoder = new TextEncoder();
+
+function isWithinJsonSizeLimit(value: unknown, maxBytes: number): boolean {
+  try {
+    return encoder.encode(JSON.stringify(value)).byteLength <= maxBytes;
+  } catch {
+    return false;
+  }
+}
+
+export const RuntimeAgentRunIdSchema = z.string().min(1).max(128).regex(/^[a-zA-Z0-9_-]+$/);
+
+export const RuntimeAgentToolCallIdSchema = z.string().min(1).max(128);
+
+export const RuntimeAgentServiceIdSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(
+    /^[a-zA-Z0-9][a-zA-Z0-9._:-]*$/,
+    "Agent service ids must start with an alphanumeric character and use a valid service-id format",
+  );
+
+export const RuntimeAgentIdSchema = z.string().min(1).max(128);
+
+export const RuntimeAgentToolNameSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9._:-]*$/,
+    "Tool names must start with a letter and use a valid client-tool format",
+  );
+
+const RuntimeAgentToolJsonSchemaDocumentSchema = z.record(z.string(), z.unknown()).refine(
+  (value) => isWithinJsonSizeLimit(value, MAX_TOOL_PARAMETERS_BYTES),
+  { message: "Tool schema metadata must be less than 16 KB" },
+);
+
+export const RuntimeAgentToolSchema = z.object({
+  name: RuntimeAgentToolNameSchema,
+  description: z.string().max(1024).optional(),
+  parameters: z.record(z.string(), z.unknown()).optional().refine(
+    (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_TOOL_PARAMETERS_BYTES),
+    { message: "Tool parameters must be less than 16 KB" },
+  ),
+  inputSchema: RuntimeAgentToolJsonSchemaDocumentSchema.optional(),
+  outputSchema: RuntimeAgentToolJsonSchemaDocumentSchema.optional(),
+});
+
+export const RuntimeAgentContextItemSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("text"),
+    title: z.string().max(256).optional(),
+    text: z.string().max(MAX_CONTEXT_ITEM_BYTES),
+  }),
+  z.object({
+    type: z.literal("json"),
+    title: z.string().max(256).optional(),
+    data: z.record(z.string(), z.unknown()).refine(
+      (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_ITEM_BYTES),
+      { message: "JSON context item must be less than 16 KB" },
+    ),
+  }),
+  z.object({
+    type: z.literal("resource"),
+    title: z.string().max(256).optional(),
+    uri: z.string().max(2048),
+    mimeType: z.string().max(256).optional(),
+    text: z.string().max(MAX_CONTEXT_ITEM_BYTES).optional(),
+  }),
+]);
+
+export const RuntimeAgentSourceContextSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("branch"),
+    branch: z.string().min(1).max(255),
+  }),
+  z.object({
+    type: z.literal("environment"),
+    environmentName: z.string().min(1).max(255),
+    releaseId: z.string().min(1).max(255).optional(),
+  }),
+  z.object({
+    type: z.literal("release"),
+    releaseId: z.string().min(1).max(255),
+  }),
+]);
+
+export const RuntimeAgentTargetKindSchema = z.enum([
+  "production",
+  "environment",
+  "preview_branch",
+]);
+
+type RuntimeAgentTargetSelectionInput = {
+  runtimeTargetKind?: z.infer<typeof RuntimeAgentTargetKindSchema> | null;
+  runtimeTargetEnvironmentId?: string | null;
+  runtimeTargetBranchId?: string | null;
+};
+
+export function validateRuntimeAgentTargetSelection(
+  input: RuntimeAgentTargetSelectionInput,
+  ctx: z.RefinementCtx,
+) {
+  const kind = input.runtimeTargetKind;
+  if (!kind || kind === "production") {
+    if (input.runtimeTargetEnvironmentId || input.runtimeTargetBranchId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "production target does not accept environment or branch identifiers",
+        path: ["runtimeTargetKind"],
+      });
+    }
+    return;
+  }
+
+  if (kind === "environment") {
+    if (!input.runtimeTargetEnvironmentId || input.runtimeTargetBranchId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "environment target requires runtimeTargetEnvironmentId and no runtimeTargetBranchId",
+        path: ["runtimeTargetKind"],
+      });
+    }
+    return;
+  }
+
+  if (!input.runtimeTargetBranchId || input.runtimeTargetEnvironmentId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        "preview_branch target requires runtimeTargetBranchId and no runtimeTargetEnvironmentId",
+      path: ["runtimeTargetKind"],
+    });
+  }
+}
+
+export const RuntimeAgentProjectContextSchema = z.object({
+  projectId: z.string().uuid(),
+  projectSlug: z.string().min(1).max(255),
+  runtimeTargetKind: RuntimeAgentTargetKindSchema.nullable().optional(),
+  runtimeTargetEnvironmentId: z.string().uuid().nullable().optional(),
+  runtimeTargetBranchId: z.string().uuid().nullable().optional(),
+}).superRefine(validateRuntimeAgentTargetSelection);
+
+export const RuntimeAgentValidatedClaimsSchema = z.object({
+  subject: z.string().min(1).max(256),
+  projectId: z.string().uuid().optional(),
+  projectSlug: z.string().min(1).max(255).optional(),
+  scopes: z.array(z.string().min(1).max(128)).max(50).default([]),
+});
+
+export const RuntimeAgentRunContextSchema = z.object({
+  agentServiceId: RuntimeAgentServiceIdSchema,
+  agentId: RuntimeAgentIdSchema,
+  conversationId: z.string().uuid(),
+  runId: RuntimeAgentRunIdSchema,
+  messageId: z.string().uuid(),
+  inputAnchorMessageId: z.string().uuid(),
+  requestedByUserId: z.string().uuid(),
+  project: RuntimeAgentProjectContextSchema,
+  parentConversationId: z.string().uuid().nullable().optional(),
+  parentRunId: RuntimeAgentRunIdSchema.nullable().optional(),
+  spawnedFromMessageId: z.string().uuid().nullable().optional(),
+  spawnedFromToolCallId: RuntimeAgentToolCallIdSchema.nullable().optional(),
+  validatedClaims: RuntimeAgentValidatedClaimsSchema.optional(),
+}).superRefine((input, ctx) => {
+  if (input.parentRunId && input.parentRunId === input.runId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "parentRunId cannot match runId",
+      path: ["parentRunId"],
+    });
+  }
+
+  if (!input.parentRunId && input.spawnedFromMessageId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "spawnedFromMessageId requires parentRunId",
+      path: ["spawnedFromMessageId"],
+    });
+  }
+
+  if (!input.parentRunId && input.spawnedFromToolCallId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "spawnedFromToolCallId requires parentRunId",
+      path: ["spawnedFromToolCallId"],
+    });
+  }
+
+  if (
+    input.validatedClaims?.projectId && input.validatedClaims.projectId !== input.project.projectId
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "validatedClaims.projectId must match project.projectId",
+      path: ["validatedClaims", "projectId"],
+    });
+  }
+
+  if (
+    input.validatedClaims?.projectSlug &&
+    input.validatedClaims.projectSlug !== input.project.projectSlug
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "validatedClaims.projectSlug must match project.projectSlug",
+      path: ["validatedClaims", "projectSlug"],
+    });
+  }
+});
+
+export const RuntimeAgentRunInvocationSchema = z.object({
+  run: RuntimeAgentRunContextSchema,
+  messages: z.array(z.unknown()).default([]),
+  tools: z.array(RuntimeAgentToolSchema).max(50).default([]),
+  context: z.array(RuntimeAgentContextItemSchema).max(10).default([]).refine(
+    (value) => isWithinJsonSizeLimit(value, MAX_CONTEXT_TOTAL_BYTES),
+    { message: "context must be less than 64 KB total" },
+  ),
+  agentSource: RuntimeAgentSourceContextSchema.optional(),
+  forwardedProps: z.record(z.string(), z.unknown()).optional().refine(
+    (value) => value === undefined || isWithinJsonSizeLimit(value, MAX_FORWARDED_PROPS_BYTES),
+    { message: "forwardedProps must be less than 64 KB" },
+  ),
+});
+
+export type RuntimeAgentTool = z.infer<typeof RuntimeAgentToolSchema>;
+export type RuntimeAgentContextItem = z.infer<typeof RuntimeAgentContextItemSchema>;
+export type RuntimeAgentSourceContext = z.infer<typeof RuntimeAgentSourceContextSchema>;
+export type RuntimeAgentTargetKind = z.infer<typeof RuntimeAgentTargetKindSchema>;
+export type RuntimeAgentProjectContext = z.infer<typeof RuntimeAgentProjectContextSchema>;
+export type RuntimeAgentValidatedClaims = z.infer<typeof RuntimeAgentValidatedClaimsSchema>;
+export type RuntimeAgentRunContext = z.infer<typeof RuntimeAgentRunContextSchema>;
+export type RuntimeAgentRunInvocation = z.infer<typeof RuntimeAgentRunInvocationSchema>;
+
+export async function parseRuntimeAgentRunInvocation(
+  request: Request,
+): Promise<RuntimeAgentRunInvocation> {
+  return RuntimeAgentRunInvocationSchema.parse(await request.json());
+}
+
+export async function parseRuntimeAgentRunInvocationOrError(
+  request: Request,
+): Promise<RuntimeAgentRunInvocation | Response> {
+  return await parseAgUiJsonRequestOrError(
+    () => parseRuntimeAgentRunInvocation(request),
+    "Invalid runtime agent invocation",
+  );
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.355";
+export const VERSION = "0.1.356";


### PR DESCRIPTION
## Summary
- expose a shared `RuntimeAgentRunInvocationSchema` from `veryfront/agent`
- add parse helpers for trusted control-plane runtime service invocations
- document the boundary between public AG-UI runtime input and service-to-service runtime invocation wrappers
- bump package version to `0.1.356` for CI/CD publishing

## Verification
- `deno test --no-check --allow-all src/agent/runtime-agent-invocation-contract.test.ts --unstable-worker-options --unstable-net`
- `deno task verify:quick`
- pre-push checks: format, lint, type check, unit tests