### PR TITLE
fix(proxy): return 404 for unmapped custom domains

### DIFF
--- a/src/proxy/cache/redis-cache.test.ts
+++ b/src/proxy/cache/redis-cache.test.ts
@@ -1,0 +1,90 @@
+import { assertEquals } from "#veryfront/testing/assert";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd";
+import { RedisCache } from "./redis-cache.ts";
+import type { RedisClientType } from "redis";
+
+type RedisErrorHandler = (error: Error) => void;
+
+class FakeRedisClient {
+  private errorHandler: RedisErrorHandler | null = null;
+
+  on(event: string, handler: RedisErrorHandler): this {
+    if (event === "error") this.errorHandler = handler;
+    return this;
+  }
+
+  async connect(): Promise<void> {}
+  async close(): Promise<void> {}
+  async get(): Promise<string | null> {
+    return null;
+  }
+
+  emitError(error: Error): void {
+    this.errorHandler?.(error);
+  }
+}
+
+class TestRedisCache extends RedisCache {
+  constructor(private readonly fakeClient: FakeRedisClient) {
+    super({ url: "redis://localhost:6379" });
+  }
+
+  protected override createRedisClient(): RedisClientType {
+    return this.fakeClient as unknown as RedisClientType;
+  }
+}
+
+describe("RedisCache", () => {
+  const originalConsoleLog = console.log;
+  let logLines: string[] = [];
+
+  beforeEach(() => {
+    logLines = [];
+    console.log = ((...args: unknown[]) => {
+      logLines.push(args.map((arg) => String(arg)).join(" "));
+    }) as typeof console.log;
+  });
+
+  afterEach(async () => {
+    console.log = originalConsoleLog;
+  });
+
+  it("logs transient socket closures as warnings instead of errors", async () => {
+    const client = new FakeRedisClient();
+    const cache = new TestRedisCache(client);
+
+    await cache.get("missing");
+    client.emitError(new Error("Socket closed unexpectedly"));
+
+    assertEquals(
+      logLines.some((line: string) =>
+        line.includes("[RedisCache] Client connection dropped; reconnecting")
+      ),
+      true,
+    );
+    assertEquals(
+      logLines.some((line: string) => line.includes("[RedisCache] Client error")),
+      false,
+    );
+
+    await cache.close();
+  });
+
+  it("keeps non-transient client errors at error level", async () => {
+    const client = new FakeRedisClient();
+    const cache = new TestRedisCache(client);
+
+    await cache.get("missing");
+    client.emitError(new Error("AUTH failed"));
+
+    assertEquals(logLines.some((line: string) => line.includes("[RedisCache] Client error")), true);
+    assertEquals(
+      logLines.some((line: string) =>
+        line.includes("[RedisCache] Client connection dropped; reconnecting")
+      ),
+      false,
+    );
+
+    await cache.close();
+  });
+});

--- a/src/proxy/cache/redis-cache.ts
+++ b/src/proxy/cache/redis-cache.ts
@@ -36,6 +36,11 @@ export class RedisCache implements TokenCache {
     return `${this.prefix}${k}`;
   }
 
+  private isTransientClientError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    return error.message === "Socket closed unexpectedly";
+  }
+
   async get(key: string): Promise<TokenCacheEntry | null> {
     return withSpan(
       "cache.redis.get",
@@ -220,36 +225,47 @@ export class RedisCache implements TokenCache {
     return withSpan("cache.redis.connect", async () => {
       if (this.connected && this.client) return;
 
-      // deno-lint-ignore no-explicit-any
-      const clientOpts: Record<string, any> = {
-        url: this.url,
-        socket: {
-          connectTimeout: this.connectTimeout,
-          tls: this.tls || undefined,
-          reconnectStrategy: (retries: number) => {
-            if (retries > MAX_RECONNECT_RETRIES) {
-              return new Error("Max reconnection attempts reached");
-            }
-            return Math.min(retries * RECONNECT_BACKOFF_BASE_MS, RECONNECT_BACKOFF_MAX_MS);
-          },
-        },
-      };
-      if (this.password) clientOpts.password = this.password;
-      if (this.username) clientOpts.username = this.username;
-
-      const client = createClient(clientOpts);
+      const client = this.createRedisClient();
 
       client.on("error", (err) => {
-        logger.error("[RedisCache] Client error", {
+        const context = {
           error: err instanceof Error ? err.message : String(err),
-        });
+        };
+
+        if (this.isTransientClientError(err)) {
+          logger.warn("[RedisCache] Client connection dropped; reconnecting", context);
+        } else {
+          logger.error("[RedisCache] Client error", context);
+        }
+
         this.connected = false;
       });
 
-      this.client = client as RedisClientType;
+      this.client = client;
       await client.connect();
       this.connected = true;
       logger.info("[RedisCache] Connected");
     });
+  }
+
+  protected createRedisClient(): RedisClientType {
+    // deno-lint-ignore no-explicit-any
+    const clientOpts: Record<string, any> = {
+      url: this.url,
+      socket: {
+        connectTimeout: this.connectTimeout,
+        tls: this.tls || undefined,
+        reconnectStrategy: (retries: number) => {
+          if (retries > MAX_RECONNECT_RETRIES) {
+            return new Error("Max reconnection attempts reached");
+          }
+          return Math.min(retries * RECONNECT_BACKOFF_BASE_MS, RECONNECT_BACKOFF_MAX_MS);
+        },
+      },
+    };
+    if (this.password) clientOpts.password = this.password;
+    if (this.username) clientOpts.username = this.username;
+
+    return createClient(clientOpts) as RedisClientType;
   }
 }

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -69,7 +69,11 @@ async function createRs256Jwt(userId: string): Promise<{
   };
 }
 
-function createHandler(port: number, apiBasePath = "") {
+function createHandler(
+  port: number,
+  apiBasePath = "",
+  logger?: Parameters<typeof createProxyHandler>[0]["logger"],
+) {
   return createProxyHandler({
     config: {
       apiBaseUrl: `http://127.0.0.1:${port}${apiBasePath}`,
@@ -78,6 +82,7 @@ function createHandler(port: number, apiBasePath = "") {
       previewApiClientId: "test-client",
       previewApiClientSecret: "test-secret",
     },
+    logger,
   });
 }
 
@@ -168,8 +173,16 @@ describe("Proxy Handler", () => {
         return createNotFoundResponse();
       });
 
+      const infoLogs: Array<{ msg: string; extra?: Record<string, unknown> }> = [];
+      const errorLogs: Array<{ msg: string; error?: Error; extra?: Record<string, unknown> }> = [];
+
       try {
-        const handler = createHandler(port);
+        const handler = createHandler(port, "", {
+          debug: () => {},
+          info: (msg, extra) => infoLogs.push({ msg, extra }),
+          warn: () => {},
+          error: (msg, error, extra) => errorLogs.push({ msg, error, extra }),
+        });
 
         const req = new Request("http://studio.veryfront.com/page", {
           headers: { host: "studio.veryfront.com" },
@@ -183,6 +196,111 @@ describe("Proxy Handler", () => {
           ctx.error?.message,
           "No project configured for domain: studio.veryfront.com",
         );
+        assertEquals(
+          infoLogs.some((entry) => entry.msg === "Custom domain token lookup returned no project"),
+          true,
+        );
+        assertEquals(errorLogs.some((entry) => entry.msg === "Token fetch failed"), false);
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
+    it("keeps missing custom-domain token lookups at info level after negative caching", async () => {
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") {
+          return new Response('{"error":"Project not found for domain"}', { status: 400 });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      const infoLogs: Array<{ msg: string; extra?: Record<string, unknown> }> = [];
+      const errorLogs: Array<{ msg: string; error?: Error; extra?: Record<string, unknown> }> = [];
+
+      try {
+        const handler = createHandler(port, "", {
+          debug: () => {},
+          info: (msg, extra) => infoLogs.push({ msg, extra }),
+          warn: () => {},
+          error: (msg, error, extra) => errorLogs.push({ msg, error, extra }),
+        });
+
+        const req = new Request("http://builder.veryfront.com/page", {
+          headers: { host: "builder.veryfront.com" },
+        });
+
+        const first = await handler.processRequest(req);
+        const second = await handler.processRequest(req);
+
+        assertEquals(first.error?.status, 404);
+        assertEquals(second.error?.status, 404);
+        assertEquals(
+          errorLogs.some((entry) =>
+            entry.msg === "Token fetch failed" ||
+            entry.msg === "Cannot process custom domain without token"
+          ),
+          false,
+        );
+        assertEquals(
+          infoLogs.filter((entry) => entry.msg === "Custom domain token lookup returned no project")
+            .length,
+          2,
+        );
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
+    it("keeps missing custom-domain API lookups at info level", async () => {
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") {
+          return createTokenResponse();
+        }
+
+        if (pathname.startsWith("/projects/")) {
+          return createNotFoundResponse();
+        }
+
+        return createNotFoundResponse();
+      });
+
+      const infoLogs: Array<{ msg: string; extra?: Record<string, unknown> }> = [];
+      const errorLogs: Array<{ msg: string; error?: Error; extra?: Record<string, unknown> }> = [];
+
+      try {
+        const handler = createHandler(port, "", {
+          debug: () => {},
+          info: (msg, extra) => infoLogs.push({ msg, extra }),
+          warn: () => {},
+          error: (msg, error, extra) => errorLogs.push({ msg, error, extra }),
+        });
+
+        const req = new Request("http://studio.veryfront.com/page", {
+          headers: { host: "studio.veryfront.com" },
+        });
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.projectSlug, undefined);
+        assertEquals(ctx.error?.status, 404);
+        assertEquals(
+          ctx.error?.message,
+          "No project configured for domain: studio.veryfront.com",
+        );
+        assertEquals(
+          infoLogs.some((entry) => entry.msg === "Custom domain lookup returned no project"),
+          true,
+        );
+        assertEquals(errorLogs.some((entry) => entry.msg === "Custom domain not found"), false);
 
         await handler.close();
       } finally {

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -157,6 +157,39 @@ describe("Proxy Handler", () => {
       }
     });
 
+    it("returns 404 when token fetch says custom domain is not configured", async () => {
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") {
+          return new Response('{"error":"Project not found for domain"}', { status: 400 });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+
+        const req = new Request("http://studio.veryfront.com/page", {
+          headers: { host: "studio.veryfront.com" },
+        });
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.projectSlug, undefined);
+        assertEquals(ctx.error?.status, 404);
+        assertEquals(
+          ctx.error?.message,
+          "No project configured for domain: studio.veryfront.com",
+        );
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
     it("returns 502 error when no token available for custom domain", async () => {
       const handler = createProxyHandler({
         config: {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -635,6 +635,12 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
       if (isCustomDomain && !projectSlug) {
         if (!token) {
+          const status = parseStatusFromError(tokenFetchError);
+          if (status === 400 || status === 404) {
+            logger?.info("Custom domain not found during token fetch", { domain: host, status });
+            return makeErrorContext(base, 404, `No project configured for domain: ${host}`, token);
+          }
+
           logger?.error("Cannot process custom domain without token", undefined, { domain: host });
           return makeErrorContext(base, 502, `Failed to authenticate for domain: ${host}`, token);
         }

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -210,8 +210,27 @@ function extractUserToken(cookieHeader: string): string | undefined {
 }
 
 function parseStatusFromError(error: unknown): number | null {
+  if (error && typeof error === "object") {
+    const detail = (error as { detail?: unknown }).detail;
+    if (typeof detail === "string") {
+      const detailMatch = detail.match(/failed: (\d+)/i);
+      if (detailMatch) return Number(detailMatch[1]);
+    }
+
+    const cause = (error as { cause?: unknown }).cause;
+    if (cause && cause !== error) {
+      const causeStatus = parseStatusFromError(cause);
+      if (causeStatus !== null) return causeStatus;
+    }
+
+    const directStatus = (error as { status?: unknown }).status;
+    if (typeof directStatus === "number" && Number.isFinite(directStatus) && directStatus >= 400) {
+      return directStatus;
+    }
+  }
+
   const message = error instanceof Error ? error.message : String(error);
-  const match = message.match(/failed: (\d+)/);
+  const match = message.match(/failed: (\d+)/i);
   return match ? Number(match[1]) : null;
 }
 
@@ -445,10 +464,22 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
           token = await tokenManager.getToken(scope, projectSlug, customDomain);
         } catch (error) {
           tokenFetchError = error;
-          logger?.error(options.tokenFetchErrorMessage, error as Error, {
-            projectSlug,
-            customDomain,
-          });
+          const status = parseStatusFromError(error);
+          const isExpectedMissingCustomDomain = !!customDomain &&
+            (status === 400 || status === 404);
+
+          if (isExpectedMissingCustomDomain) {
+            logger?.info("Custom domain token lookup returned no project", {
+              projectSlug,
+              customDomain,
+              status,
+            });
+          } else {
+            logger?.error(options.tokenFetchErrorMessage, error as Error, {
+              projectSlug,
+              customDomain,
+            });
+          }
         }
       }
     }
@@ -647,7 +678,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
 
         const lookupResult = await lookupProjectByDomain(host, config.apiBaseUrl, token, logger);
         if (!lookupResult) {
-          logger?.error("Custom domain not found", undefined, { domain: host });
+          logger?.info("Custom domain lookup returned no project", { domain: host });
           return makeErrorContext(base, 404, `No project configured for domain: ${host}`, token);
         }
 

--- a/src/server/handlers/request/api/project-discovery.test.ts
+++ b/src/server/handlers/request/api/project-discovery.test.ts
@@ -221,6 +221,44 @@ describe(
       assertExists(skillRegistry.get("writer-helper"));
     });
 
+    it("does not warn about zero agents and tools when AI primitive discovery is disabled", async () => {
+      agentRegistry.clearAll();
+      toolRegistry.clearAll();
+      skillRegistry.clearAll();
+
+      const ctx = createHandlerContext(
+        "/disabled-ai-discovery-project",
+        "disabled-ai-discovery-project",
+        "preview",
+      );
+      ctx.config = {
+        ai: {
+          tools: { discovery: { enabled: false } },
+          agents: { discovery: { enabled: false } },
+          skills: { discovery: { enabled: false } },
+        },
+      } as HandlerContext["config"];
+
+      const originalWarn = console.warn;
+      const warnings: string[] = [];
+      console.warn = (message?: unknown, ...args: unknown[]) => {
+        warnings.push([message, ...args].map(String).join(" "));
+      };
+
+      try {
+        await ensureProjectDiscovery(ctx);
+      } finally {
+        console.warn = originalWarn;
+      }
+
+      assertEquals(
+        warnings.some((warning) =>
+          warning.includes("Primitive discovery found 0 agents and 0 tools")
+        ),
+        false,
+      );
+    });
+
     it("keeps explicit tool ids available for request-time project-agent runs", async () => {
       agentRegistry.clearAll();
       toolRegistry.clearAll();

--- a/src/server/handlers/request/api/project-discovery.ts
+++ b/src/server/handlers/request/api/project-discovery.ts
@@ -16,17 +16,23 @@ const logger = serverLogger.component("api-wrapper");
  */
 const discoveredProjects = new Map<string, Promise<void>>();
 
+function isDiscoveryEnabled(
+  discovery: { enabled?: boolean } | undefined,
+): boolean {
+  return discovery?.enabled ?? true;
+}
+
 function buildDiscoveryConfig(ctx: HandlerContext) {
   const discoveryConfig = ctx.config?.ai;
-  const skillDiscoveryEnabled = discoveryConfig?.skills?.discovery?.enabled ?? true;
+  const toolDiscovery = discoveryConfig?.tools?.discovery;
+  const agentDiscovery = discoveryConfig?.agents?.discovery;
+  const skillDiscovery = discoveryConfig?.skills?.discovery;
 
   return {
     baseDir: ctx.projectDir,
-    toolDirs: discoveryConfig?.tools?.discovery?.paths ?? ["tools"],
-    agentDirs: discoveryConfig?.agents?.discovery?.paths ?? ["agents"],
-    skillDirs: skillDiscoveryEnabled
-      ? (discoveryConfig?.skills?.discovery?.paths ?? ["skills"])
-      : [],
+    toolDirs: isDiscoveryEnabled(toolDiscovery) ? (toolDiscovery?.paths ?? ["tools"]) : [],
+    agentDirs: isDiscoveryEnabled(agentDiscovery) ? (agentDiscovery?.paths ?? ["agents"]) : [],
+    skillDirs: isDiscoveryEnabled(skillDiscovery) ? (skillDiscovery?.paths ?? ["skills"]) : [],
     resourceDirs: ["resources"],
     promptDirs: ["prompts"],
     workflowDirs: ["workflows"],
@@ -93,7 +99,10 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<void>
     agentRegistry.clear();
     toolRegistry.clear();
 
-    const result = await discoverAll(buildDiscoveryConfig(ctx));
+    const discoveryOptions = buildDiscoveryConfig(ctx);
+    const result = await discoverAll(discoveryOptions);
+    const shouldWarnOnEmptyAiDiscovery = discoveryOptions.toolDirs.length > 0 ||
+      discoveryOptions.agentDirs.length > 0;
 
     const logData = {
       projectSlug: ctx.projectSlug,
@@ -103,7 +112,9 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<void>
       errors: result.errors.length,
     };
 
-    if (result.agents.size === 0 && result.tools.size === 0) {
+    if (
+      result.agents.size === 0 && result.tools.size === 0 && shouldWarnOnEmptyAiDiscovery
+    ) {
       logger.warn("Primitive discovery found 0 agents and 0 tools", {
         ...logData,
         errorMessages: result.errors.map((e) => e.error.message).slice(0, 5),


### PR DESCRIPTION
Closes #1110

## Summary
- return 404 instead of auth failures for unmapped custom domains
- keep missing custom-domain token/API lookups at info level to avoid noisy error logs
- add coverage for the custom-domain 404 and negative-cache paths

## Verification
- targeted proxy tests passed locally:
  - `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/proxy/handler.test.ts src/proxy/token-priority.test.ts`
- `deno task test --headless` currently fails before proxy tests due an unrelated missing module under `.worktrees/refactor-150/.../src/extensions/validation.ts`
