### PR TITLE
Add AG-UI forwarded context helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.357",
+  "version": "0.1.358",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/ag-ui-forwarded-context.test.ts
+++ b/src/agent/ag-ui-forwarded-context.test.ts
@@ -1,0 +1,139 @@
+import { assertEquals } from "@std/assert";
+import { z } from "zod";
+import {
+  createAgUiRuntimeContextMap,
+  deriveAgUiForwardedConfig,
+  parseAgUiContextBoolean,
+  parseAgUiContextNullableString,
+  parseAgUiContextSchema,
+  parseAgUiContextString,
+} from "./ag-ui-forwarded-context.ts";
+import type { AgUiRuntimeRequest } from "./runtime-ag-ui-contract.ts";
+
+function createAgUiInput(overrides: Partial<AgUiRuntimeRequest> = {}): AgUiRuntimeRequest {
+  return {
+    threadId: "11111111-1111-4111-8111-111111111111",
+    runId: "run-1",
+    messages: [],
+    tools: [],
+    context: [],
+    ...overrides,
+  };
+}
+
+Deno.test("ag-ui-forwarded-context builds a description context map", () => {
+  const contextMap = createAgUiRuntimeContextMap(
+    createAgUiInput({
+      context: [
+        { description: "veryfront.projectId", value: '"project-1"' },
+        { type: "text", title: "Ignored", text: "not a legacy description item" },
+        { description: "veryfront.model", value: "openai/gpt-5.4" },
+      ],
+    }),
+  );
+
+  assertEquals(contextMap.get("veryfront.projectId"), '"project-1"');
+  assertEquals(contextMap.get("veryfront.model"), "openai/gpt-5.4");
+  assertEquals(contextMap.size, 2);
+});
+
+Deno.test("ag-ui-forwarded-context parses typed legacy context values", () => {
+  const overridesSchema = z.object({ maxSteps: z.number().int().positive().optional() }).strip();
+
+  assertEquals(parseAgUiContextString('"model-1"'), "model-1");
+  assertEquals(parseAgUiContextString("   "), undefined);
+  assertEquals(parseAgUiContextNullableString("null"), null);
+  assertEquals(parseAgUiContextNullableString('"branch-1"'), "branch-1");
+  assertEquals(parseAgUiContextBoolean("true"), true);
+  assertEquals(parseAgUiContextBoolean("yes"), undefined);
+  assertEquals(parseAgUiContextSchema('{"maxSteps":4}', overridesSchema), { maxSteps: 4 });
+  assertEquals(parseAgUiContextSchema('{"maxSteps":"many"}', overridesSchema), undefined);
+});
+
+Deno.test("ag-ui-forwarded-context prefers nested forwarded config before flat forwarded props", () => {
+  const configSchema = z
+    .object({
+      projectId: z.string().nullable().optional(),
+      model: z.string().optional(),
+      allowDelegation: z.boolean().optional(),
+    })
+    .strict();
+
+  const result = deriveAgUiForwardedConfig(
+    createAgUiInput({
+      forwardedProps: {
+        projectId: "project-flat",
+        model: "openai/gpt-5.4",
+        veryfront: {
+          projectId: "project-nested",
+          allowDelegation: false,
+        },
+      },
+    }),
+    {
+      schema: configSchema,
+      namespace: "veryfront",
+    },
+  );
+
+  assertEquals(result, {
+    projectId: "project-nested",
+    allowDelegation: false,
+  });
+});
+
+Deno.test("ag-ui-forwarded-context accepts flat forwarded config when no namespace payload exists", () => {
+  const configSchema = z
+    .object({
+      projectId: z.string().nullable().optional(),
+      model: z.string().optional(),
+      allowDelegation: z.boolean().optional(),
+    })
+    .strict();
+
+  const result = deriveAgUiForwardedConfig(
+    createAgUiInput({
+      forwardedProps: {
+        projectId: "project-flat",
+        model: "openai/gpt-5.4",
+      },
+    }),
+    {
+      schema: configSchema,
+      namespace: "veryfront",
+    },
+  );
+
+  assertEquals(result, {
+    projectId: "project-flat",
+    model: "openai/gpt-5.4",
+  });
+});
+
+Deno.test("ag-ui-forwarded-context rejects malformed namespaced forwarded config", () => {
+  const configSchema = z
+    .object({
+      projectId: z.string().nullable().optional(),
+      model: z.string().optional(),
+      allowDelegation: z.boolean().optional(),
+    })
+    .strict();
+
+  const result = deriveAgUiForwardedConfig(
+    createAgUiInput({
+      forwardedProps: {
+        projectId: "project-flat",
+        model: "openai/gpt-5.4",
+        veryfront: {
+          projectId: 123,
+        },
+      },
+    }),
+    {
+      schema: configSchema,
+      namespace: "veryfront",
+    },
+  );
+
+  assertEquals(result, undefined);
+});

--- a/src/agent/ag-ui-forwarded-context.ts
+++ b/src/agent/ag-ui-forwarded-context.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+import type { AgUiRuntimeRequest } from "./runtime-ag-ui-contract.ts";
+
+export type AgUiForwardedConfigOptions<TConfig> = {
+  schema: z.ZodType<TConfig>;
+  namespace?: string;
+};
+
+export function createAgUiRuntimeContextMap(
+  input: Pick<AgUiRuntimeRequest, "context">,
+): Map<string, string> {
+  const contextMap = new Map<string, string>();
+
+  for (const entry of input.context) {
+    if ("description" in entry) {
+      contextMap.set(entry.description, entry.value);
+    }
+  }
+
+  return contextMap;
+}
+
+export function parseAgUiContextJsonValue(raw: string | undefined): unknown {
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+export function parseAgUiContextString(raw: string | undefined): string | undefined {
+  const parsed = parseAgUiContextJsonValue(raw);
+  return typeof parsed === "string" && parsed.trim().length > 0 ? parsed : undefined;
+}
+
+export function parseAgUiContextNullableString(raw: string | undefined): string | null | undefined {
+  const parsed = parseAgUiContextJsonValue(raw);
+  if (parsed === null) {
+    return null;
+  }
+
+  return typeof parsed === "string" && parsed.trim().length > 0 ? parsed : undefined;
+}
+
+export function parseAgUiContextBoolean(raw: string | undefined): boolean | undefined {
+  const parsed = parseAgUiContextJsonValue(raw);
+  return typeof parsed === "boolean" ? parsed : undefined;
+}
+
+export function parseAgUiContextSchema<TValue>(
+  raw: string | undefined,
+  schema: z.ZodType<TValue>,
+): TValue | undefined {
+  const parsed = parseAgUiContextJsonValue(raw);
+  const result = schema.safeParse(parsed);
+  return result.success ? result.data : undefined;
+}
+
+export function deriveAgUiForwardedConfig<TConfig>(
+  input: Pick<AgUiRuntimeRequest, "forwardedProps">,
+  options: AgUiForwardedConfigOptions<TConfig>,
+): TConfig | undefined {
+  const forwardedProps = z.record(z.string(), z.unknown()).safeParse(input.forwardedProps);
+  if (!forwardedProps.success) {
+    return undefined;
+  }
+
+  if (options.namespace) {
+    const nestedConfig = options.schema.safeParse(forwardedProps.data[options.namespace]);
+    if (nestedConfig.success) {
+      return nestedConfig.data;
+    }
+  }
+
+  const rootConfig = options.schema.safeParse(forwardedProps.data);
+  return rootConfig.success ? rootConfig.data : undefined;
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -170,6 +170,16 @@ export {
   createAgUiRuntimeHandler,
 } from "./ag-ui-runtime-handler.ts";
 export {
+  type AgUiForwardedConfigOptions,
+  createAgUiRuntimeContextMap,
+  deriveAgUiForwardedConfig,
+  parseAgUiContextBoolean,
+  parseAgUiContextJsonValue,
+  parseAgUiContextNullableString,
+  parseAgUiContextSchema,
+  parseAgUiContextString,
+} from "./ag-ui-forwarded-context.ts";
+export {
   type AgUiRuntimeContextItem,
   AgUiRuntimeContextItemSchema,
   type AgUiRuntimeInjectedTool,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.357";
+export const VERSION = "0.1.358";


### PR DESCRIPTION
## Summary\n- add reusable AG-UI forwarded/context parsing helpers under the agent runtime API\n- export the helpers from veryfront/agent\n- bump package version to 0.1.358 for CI/CD publish\n\n## Verification\n- deno test --no-check --allow-all src/agent/ag-ui-forwarded-context.test.ts\n- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts\n- deno task lint && deno task typecheck\n- deno task verify:quick\n- pre-push checks passed: fmt, lint, typecheck, unit tests