### PR TITLE
Add project-scoped remote tool catalog helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.358",
+  "version": "0.1.359",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -85,11 +85,23 @@ export type {
   TraceHostToolsOptions,
 } from "./tracing.ts";
 export {
+  createProjectScopedRemoteToolCatalog,
   filterProjectScopedRemoteToolDefinitions,
   hydrateProjectScopedRemoteToolInput,
   isProjectNavigationRemoteTool,
+  isRemoteToolNameAllowed,
+  listProjectScopedRemoteToolNames,
+  resolveProjectScopedRemoteToolProjectId,
 } from "./project-scoped-remote-tools.ts";
-export type { ProjectScopedRemoteToolOptions } from "./project-scoped-remote-tools.ts";
+export type {
+  ListProjectScopedRemoteToolNameOptions,
+  ProjectScopedRemoteToolCatalog,
+  ProjectScopedRemoteToolCatalogOptions,
+  ProjectScopedRemoteToolDefinitions,
+  ProjectScopedRemoteToolExecution,
+  ProjectScopedRemoteToolExecutionInput,
+  ProjectScopedRemoteToolOptions,
+} from "./project-scoped-remote-tools.ts";
 
 export { toolRegistry } from "./registry.ts";
 

--- a/src/tool/project-scoped-remote-tools.test.ts
+++ b/src/tool/project-scoped-remote-tools.test.ts
@@ -1,10 +1,14 @@
 import { assertEquals, assertStrictEquals } from "@std/assert";
 import {
+  createProjectScopedRemoteToolCatalog,
   filterProjectScopedRemoteToolDefinitions,
   hydrateProjectScopedRemoteToolInput,
   isProjectNavigationRemoteTool,
+  isRemoteToolNameAllowed,
+  listProjectScopedRemoteToolNames,
+  resolveProjectScopedRemoteToolProjectId,
 } from "./project-scoped-remote-tools.ts";
-import type { ToolDefinition } from "./types.ts";
+import type { RemoteToolSource, ToolDefinition, ToolExecutionContext } from "./types.ts";
 
 function toolDefinition(input: {
   name: string;
@@ -135,3 +139,140 @@ Deno.test("hydrateProjectScopedRemoteToolInput leaves inputs unchanged without a
     toolInput,
   );
 });
+
+Deno.test("resolveProjectScopedRemoteToolProjectId prefers context project ids", () => {
+  assertEquals(
+    resolveProjectScopedRemoteToolProjectId({ projectId: "context-project" }, "default-project"),
+    "context-project",
+  );
+  assertEquals(resolveProjectScopedRemoteToolProjectId({}, "default-project"), "default-project");
+  assertEquals(resolveProjectScopedRemoteToolProjectId(undefined, null), null);
+});
+
+Deno.test("isRemoteToolNameAllowed applies optional allowlists", () => {
+  assertEquals(isRemoteToolNameAllowed("list_files", null), true);
+  assertEquals(isRemoteToolNameAllowed("list_files", new Set(["list_files"])), true);
+  assertEquals(isRemoteToolNameAllowed("delete_file", new Set(["list_files"])), false);
+});
+
+Deno.test("createProjectScopedRemoteToolCatalog filters, caches, and hydrates project tools", async () => {
+  const listContexts: (ToolExecutionContext | undefined)[] = [];
+  const source: RemoteToolSource = {
+    id: "api",
+    async listTools(context) {
+      listContexts.push(context);
+      return [
+        toolDefinition({ name: "list_projects" }),
+        toolDefinition({ name: "list_files", required: ["project_reference"] }),
+        toolDefinition({ name: "delete_file", required: ["project_reference"] }),
+      ];
+    },
+    async executeTool() {
+      return { ok: true };
+    },
+  };
+  const catalog = createProjectScopedRemoteToolCatalog({
+    source,
+    defaultProjectId: "project-1",
+    allowedToolNames: new Set(["list_files", "list_projects"]),
+  });
+
+  assertEquals((await catalog.listTools()).map((tool) => tool.name), [
+    "list_projects",
+    "list_files",
+  ]);
+  assertEquals(listContexts, [{ projectId: "project-1" }]);
+
+  const prepared = await catalog.prepareExecution({
+    toolName: "list_files",
+    toolInput: { pattern: "src" },
+    context: {},
+  });
+
+  assertEquals(prepared.activeProjectId, "project-1");
+  assertEquals(prepared.toolInput, {
+    pattern: "src",
+    project_reference: "project-1",
+  });
+  assertEquals(prepared.executeContext, { projectId: "project-1" });
+  assertEquals(listContexts, [{ projectId: "project-1" }]);
+});
+
+Deno.test("createProjectScopedRemoteToolCatalog rejects disallowed execution", async () => {
+  const source: RemoteToolSource = {
+    id: "api",
+    async listTools() {
+      return [toolDefinition({ name: "list_files", required: ["project_reference"] })];
+    },
+    async executeTool() {
+      return { ok: true };
+    },
+  };
+  const catalog = createProjectScopedRemoteToolCatalog({
+    source,
+    defaultProjectId: "project-1",
+    allowedToolNames: new Set(["list_projects"]),
+  });
+
+  await assertRejectsWithMessage(
+    () =>
+      catalog.prepareExecution({
+        toolName: "list_files",
+        toolInput: {},
+      }),
+    'Tool "list_files" is not allowed for this run',
+  );
+});
+
+Deno.test("listProjectScopedRemoteToolNames returns sorted unique visible names", async () => {
+  const sourceA: RemoteToolSource = {
+    id: "api",
+    async listTools(context) {
+      assertEquals(context, { projectId: "project-1" });
+      return [
+        toolDefinition({ name: "list_files", required: ["project_reference"] }),
+        toolDefinition({ name: "list_projects" }),
+      ];
+    },
+    async executeTool() {
+      return { ok: true };
+    },
+  };
+  const sourceB: RemoteToolSource = {
+    id: "studio",
+    async listTools(context) {
+      assertEquals(context, { projectId: "project-1" });
+      return [
+        toolDefinition({ name: "list_files", required: ["project_reference"] }),
+        toolDefinition({ name: "studio_open_project", required: ["project_id"] }),
+      ];
+    },
+    async executeTool() {
+      return { ok: true };
+    },
+  };
+
+  assertEquals(
+    await listProjectScopedRemoteToolNames([sourceA, sourceB], {
+      projectId: "project-1",
+      projectScopedRemoteToolOptions: {
+        projectNavigationToolNames: ["studio_open_project"],
+      },
+    }),
+    ["list_files", "list_projects", "studio_open_project"],
+  );
+});
+
+async function assertRejectsWithMessage(
+  action: () => Promise<unknown>,
+  message: string,
+): Promise<void> {
+  try {
+    await action();
+  } catch (error) {
+    assertEquals(error instanceof Error ? error.message : String(error), message);
+    return;
+  }
+
+  throw new Error("Expected action to reject");
+}

--- a/src/tool/project-scoped-remote-tools.ts
+++ b/src/tool/project-scoped-remote-tools.ts
@@ -1,7 +1,48 @@
-import type { ToolDefinition } from "./types.ts";
+import type { RemoteToolSource, ToolDefinition, ToolExecutionContext } from "./types.ts";
 
 export type ProjectScopedRemoteToolOptions = {
   projectNavigationToolNames?: readonly string[];
+};
+
+export type ProjectScopedRemoteToolCatalogOptions = {
+  source: RemoteToolSource;
+  defaultProjectId?: string | null;
+  allowedToolNames?: ReadonlySet<string> | null;
+  projectScopedRemoteToolOptions?: ProjectScopedRemoteToolOptions;
+};
+
+export type ProjectScopedRemoteToolDefinitions = {
+  activeProjectId: string | null;
+  toolDefinitions: ToolDefinition[];
+};
+
+export type ProjectScopedRemoteToolExecutionInput = {
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  context?: ToolExecutionContext;
+};
+
+export type ProjectScopedRemoteToolExecution = ProjectScopedRemoteToolDefinitions & {
+  toolDefinition: ToolDefinition | undefined;
+  toolInput: Record<string, unknown>;
+  executeContext: ToolExecutionContext | undefined;
+};
+
+export type ProjectScopedRemoteToolCatalog = {
+  id: string;
+  listActiveToolDefinitions(
+    context?: ToolExecutionContext,
+  ): Promise<ProjectScopedRemoteToolDefinitions>;
+  listTools(context?: ToolExecutionContext): Promise<ToolDefinition[]>;
+  prepareExecution(
+    input: ProjectScopedRemoteToolExecutionInput,
+  ): Promise<ProjectScopedRemoteToolExecution>;
+};
+
+export type ListProjectScopedRemoteToolNameOptions = {
+  projectId: string | null;
+  context?: ToolExecutionContext;
+  projectScopedRemoteToolOptions?: ProjectScopedRemoteToolOptions;
 };
 
 function getProjectNavigationToolNames(
@@ -49,6 +90,13 @@ export function isProjectNavigationRemoteTool(
   return getProjectNavigationToolNames(options).has(toolName);
 }
 
+export function isRemoteToolNameAllowed(
+  toolName: string,
+  allowedToolNames: ReadonlySet<string> | null | undefined,
+): boolean {
+  return !allowedToolNames || allowedToolNames.has(toolName);
+}
+
 export function filterProjectScopedRemoteToolDefinitions(
   toolDefinitions: readonly ToolDefinition[],
   projectId: string | null,
@@ -83,4 +131,128 @@ export function hydrateProjectScopedRemoteToolInput(input: {
     ...input.toolInput,
     project_reference: input.activeProjectId,
   };
+}
+
+export function resolveProjectScopedRemoteToolProjectId(
+  context: ToolExecutionContext | undefined,
+  defaultProjectId: string | null | undefined,
+): string | null {
+  if (typeof context?.projectId === "string" && context.projectId.length > 0) {
+    return context.projectId;
+  }
+
+  return defaultProjectId || null;
+}
+
+function withActiveProjectContext(
+  context: ToolExecutionContext | undefined,
+  activeProjectId: string | null,
+): ToolExecutionContext | undefined {
+  if (!activeProjectId) {
+    return context;
+  }
+
+  if (context?.projectId === activeProjectId) {
+    return context;
+  }
+
+  return {
+    ...(context ?? {}),
+    projectId: activeProjectId,
+  };
+}
+
+export function createProjectScopedRemoteToolCatalog(
+  input: ProjectScopedRemoteToolCatalogOptions,
+): ProjectScopedRemoteToolCatalog {
+  let cachedProjectId: string | null | undefined;
+  let cachedToolDefinitions: ToolDefinition[] | null = null;
+
+  async function listActiveToolDefinitions(
+    context?: ToolExecutionContext,
+  ): Promise<ProjectScopedRemoteToolDefinitions> {
+    const activeProjectId = resolveProjectScopedRemoteToolProjectId(
+      context,
+      input.defaultProjectId,
+    );
+
+    if (cachedToolDefinitions && cachedProjectId === activeProjectId) {
+      return {
+        activeProjectId,
+        toolDefinitions: cachedToolDefinitions,
+      };
+    }
+
+    const sourceContext = withActiveProjectContext(context, activeProjectId);
+    const toolDefinitions = filterProjectScopedRemoteToolDefinitions(
+      await input.source.listTools(sourceContext),
+      activeProjectId,
+      input.projectScopedRemoteToolOptions,
+    );
+
+    cachedProjectId = activeProjectId;
+    cachedToolDefinitions = toolDefinitions;
+
+    return {
+      activeProjectId,
+      toolDefinitions,
+    };
+  }
+
+  return {
+    id: input.source.id,
+    listActiveToolDefinitions,
+    async listTools(context) {
+      const { toolDefinitions } = await listActiveToolDefinitions(context);
+      return toolDefinitions.filter((toolDefinition) =>
+        isRemoteToolNameAllowed(toolDefinition.name, input.allowedToolNames)
+      );
+    },
+    async prepareExecution(executionInput) {
+      if (!isRemoteToolNameAllowed(executionInput.toolName, input.allowedToolNames)) {
+        throw new Error(`Tool "${executionInput.toolName}" is not allowed for this run`);
+      }
+
+      const { activeProjectId, toolDefinitions } = await listActiveToolDefinitions(
+        executionInput.context,
+      );
+      const toolDefinition = toolDefinitions.find((definition) =>
+        definition.name === executionInput.toolName
+      );
+      const toolInput = hydrateProjectScopedRemoteToolInput({
+        toolDefinition,
+        activeProjectId,
+        toolInput: executionInput.toolInput,
+      });
+
+      return {
+        activeProjectId,
+        toolDefinitions,
+        toolDefinition,
+        toolInput,
+        executeContext: withActiveProjectContext(executionInput.context, activeProjectId),
+      };
+    },
+  };
+}
+
+export async function listProjectScopedRemoteToolNames(
+  remoteSources: readonly RemoteToolSource[],
+  options: ListProjectScopedRemoteToolNameOptions,
+): Promise<string[]> {
+  const remoteToolNames = new Set<string>();
+  const sourceContext = withActiveProjectContext(options.context, options.projectId);
+
+  for (const source of remoteSources) {
+    const toolDefinitions = filterProjectScopedRemoteToolDefinitions(
+      await source.listTools(sourceContext),
+      options.projectId,
+      options.projectScopedRemoteToolOptions,
+    );
+    for (const toolDefinition of toolDefinitions) {
+      remoteToolNames.add(toolDefinition.name);
+    }
+  }
+
+  return [...remoteToolNames].sort();
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.358";
+export const VERSION = "0.1.359";


### PR DESCRIPTION
## Summary
- add reusable project-scoped remote tool catalog helpers
- add sorted remote tool name collection helper
- bump package version to 0.1.359 for CI release

## Verification
- deno test --no-check --allow-all src/tool/project-scoped-remote-tools.test.ts
- deno task lint && deno task typecheck
- deno task verify:quick
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- pre-push checks passed: fmt, lint, typecheck, unit tests