### PR TITLE
Support dynamic project-scoped remote tool defaults

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.359",
+  "version": "0.1.360",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -97,6 +97,7 @@ export type {
   ListProjectScopedRemoteToolNameOptions,
   ProjectScopedRemoteToolCatalog,
   ProjectScopedRemoteToolCatalogOptions,
+  ProjectScopedRemoteToolDefaultProjectId,
   ProjectScopedRemoteToolDefinitions,
   ProjectScopedRemoteToolExecution,
   ProjectScopedRemoteToolExecutionInput,

--- a/src/tool/project-scoped-remote-tools.test.ts
+++ b/src/tool/project-scoped-remote-tools.test.ts
@@ -198,6 +198,45 @@ Deno.test("createProjectScopedRemoteToolCatalog filters, caches, and hydrates pr
   assertEquals(listContexts, [{ projectId: "project-1" }]);
 });
 
+Deno.test("createProjectScopedRemoteToolCatalog resolves dynamic default project ids", async () => {
+  const listContexts: (ToolExecutionContext | undefined)[] = [];
+  let defaultProjectId: string | null = null;
+  const source: RemoteToolSource = {
+    id: "api",
+    async listTools(context) {
+      listContexts.push(context);
+      return [
+        toolDefinition({ name: "list_projects" }),
+        toolDefinition({ name: "list_files", required: ["project_reference"] }),
+      ];
+    },
+    async executeTool() {
+      return { ok: true };
+    },
+  };
+  const catalog = createProjectScopedRemoteToolCatalog({
+    source,
+    defaultProjectId: () => defaultProjectId,
+  });
+
+  assertEquals((await catalog.listTools()).map((tool) => tool.name), ["list_projects"]);
+  defaultProjectId = "project-2";
+
+  const prepared = await catalog.prepareExecution({
+    toolName: "list_files",
+    toolInput: { pattern: "src" },
+    context: {},
+  });
+
+  assertEquals(prepared.activeProjectId, "project-2");
+  assertEquals(prepared.toolInput, {
+    pattern: "src",
+    project_reference: "project-2",
+  });
+  assertEquals(prepared.executeContext, { projectId: "project-2" });
+  assertEquals(listContexts, [undefined, { projectId: "project-2" }]);
+});
+
 Deno.test("createProjectScopedRemoteToolCatalog rejects disallowed execution", async () => {
   const source: RemoteToolSource = {
     id: "api",

--- a/src/tool/project-scoped-remote-tools.ts
+++ b/src/tool/project-scoped-remote-tools.ts
@@ -4,9 +4,15 @@ export type ProjectScopedRemoteToolOptions = {
   projectNavigationToolNames?: readonly string[];
 };
 
+export type ProjectScopedRemoteToolDefaultProjectId =
+  | string
+  | null
+  | undefined
+  | (() => string | null | undefined);
+
 export type ProjectScopedRemoteToolCatalogOptions = {
   source: RemoteToolSource;
-  defaultProjectId?: string | null;
+  defaultProjectId?: ProjectScopedRemoteToolDefaultProjectId;
   allowedToolNames?: ReadonlySet<string> | null;
   projectScopedRemoteToolOptions?: ProjectScopedRemoteToolOptions;
 };
@@ -144,6 +150,15 @@ export function resolveProjectScopedRemoteToolProjectId(
   return defaultProjectId || null;
 }
 
+function resolveDefaultProjectId(
+  defaultProjectId: ProjectScopedRemoteToolDefaultProjectId,
+): string | null {
+  const resolvedProjectId = typeof defaultProjectId === "function"
+    ? defaultProjectId()
+    : defaultProjectId;
+  return resolvedProjectId || null;
+}
+
 function withActiveProjectContext(
   context: ToolExecutionContext | undefined,
   activeProjectId: string | null,
@@ -173,7 +188,7 @@ export function createProjectScopedRemoteToolCatalog(
   ): Promise<ProjectScopedRemoteToolDefinitions> {
     const activeProjectId = resolveProjectScopedRemoteToolProjectId(
       context,
-      input.defaultProjectId,
+      resolveDefaultProjectId(input.defaultProjectId),
     );
 
     if (cachedToolDefinitions && cachedProjectId === activeProjectId) {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.359";
+export const VERSION = "0.1.360";


### PR DESCRIPTION
## Summary
- allow project-scoped remote tool catalogs to resolve default project ids dynamically
- cover project-switch-style catalog reuse with a regression test
- bump package version to 0.1.360 for CI release

## Verification
- deno test --no-check --allow-all src/tool/project-scoped-remote-tools.test.ts
- deno task lint && deno task typecheck
- deno task verify:quick
- deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts
- pre-push checks passed: fmt, lint, typecheck, unit tests