### PR TITLE
Add shared tool result error helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.360",
+  "version": "0.1.361",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -63,6 +63,7 @@ export type {
   SleepToolWait,
 } from "./sleep.ts";
 export { createRemoteMCPToolSource } from "./remote-mcp.ts";
+export { hasToolExecutionErrorMarker, isErroredToolExecutionResult } from "./result.ts";
 export type { RemoteMCPToolSourceConfig } from "./remote-mcp.ts";
 export { createContext7ToolSource } from "./context7.ts";
 export type { Context7ToolSourceConfig } from "./context7.ts";

--- a/src/tool/remote-mcp.test.ts
+++ b/src/tool/remote-mcp.test.ts
@@ -92,6 +92,30 @@ describe("tool/remote-mcp", () => {
     });
   });
 
+  it("normalizes remote MCP tool responses with generic error markers", async () => {
+    const source = createRemoteMCPToolSource({
+      id: "docs",
+      endpoint: "https://mcp.test",
+    });
+
+    const result = await withMockFetch(async () =>
+      Response.json({
+        jsonrpc: "2.0",
+        id: "docs:tools:call:search_docs",
+        result: {
+          error: "rate_limited",
+          content: [{
+            text: "Try again later",
+          }],
+        },
+      }), async () => await source.executeTool("search_docs", { query: "auth" }));
+
+    assertEquals(result, {
+      error: "tool_error",
+      message: "Try again later",
+    });
+  });
+
   it("preserves caller accept types while adding the MCP-required media types", async () => {
     let acceptHeader = "";
 

--- a/src/tool/remote-mcp.ts
+++ b/src/tool/remote-mcp.ts
@@ -1,5 +1,6 @@
 import type { ToolAnnotations } from "#veryfront/mcp/types.ts";
 import type { JsonSchema } from "./schema/json-schema.ts";
+import { hasToolExecutionErrorMarker } from "./result.ts";
 import type { RemoteToolSource, ToolDefinition, ToolExecutionContext } from "./types.ts";
 
 type ResolvableValue<T> = T | ((context?: ToolExecutionContext) => T | Promise<T>);
@@ -277,7 +278,7 @@ function normalizeCallToolResult(result: unknown): unknown {
       rawContent.filter((item): item is JsonRpcCallToolContentItem => isRecord(item)),
     );
 
-    if (result.isError === true) {
+    if (hasToolExecutionErrorMarker(result)) {
       return parseJsonText(text) ?? { error: "tool_error", message: text };
     }
 

--- a/src/tool/result.test.ts
+++ b/src/tool/result.test.ts
@@ -1,0 +1,22 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { hasToolExecutionErrorMarker, isErroredToolExecutionResult } from "./result.ts";
+
+describe("tool/result", () => {
+  it("detects standard error markers on tool result objects", () => {
+    assertEquals(hasToolExecutionErrorMarker({ error: "failed" }), true);
+    assertEquals(hasToolExecutionErrorMarker({ isError: true }), true);
+    assertEquals(hasToolExecutionErrorMarker({ isError: false }), false);
+    assertEquals(hasToolExecutionErrorMarker({ error: { message: "failed" } }), false);
+    assertEquals(hasToolExecutionErrorMarker("failed"), false);
+  });
+
+  it("detects errored execution results from direct or nested output markers", () => {
+    assertEquals(isErroredToolExecutionResult({ error: "failed" }), true);
+    assertEquals(isErroredToolExecutionResult({ isError: true }), true);
+    assertEquals(isErroredToolExecutionResult({ output: { error: "failed" } }), true);
+    assertEquals(isErroredToolExecutionResult({ output: { isError: true } }), true);
+    assertEquals(isErroredToolExecutionResult({ output: { ok: true } }), false);
+    assertEquals(isErroredToolExecutionResult({ ok: true }), false);
+  });
+});

--- a/src/tool/result.ts
+++ b/src/tool/result.ts
@@ -1,0 +1,23 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function hasToolExecutionErrorMarker(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return typeof value.error === "string" || value.isError === true;
+}
+
+export function isErroredToolExecutionResult(result: unknown): boolean {
+  if (hasToolExecutionErrorMarker(result)) {
+    return true;
+  }
+
+  if (!isRecord(result)) {
+    return false;
+  }
+
+  return hasToolExecutionErrorMarker(result.output);
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.360";
+export const VERSION = "0.1.361";


### PR DESCRIPTION
## Summary
- add shared tool result error marker helpers under `veryfront/tool`
- use the shared marker helper in remote MCP call result normalization
- add focused helper and remote MCP normalization coverage
- bump package version to `0.1.361` for CI/CD publishing

## Verification
- `deno test --no-check --allow-all src/tool/result.test.ts src/tool/remote-mcp.test.ts`
- `deno task lint && deno task typecheck && deno task verify:quick`
- `deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts`
- `deno task test:unit`
- pre-push checks