### PR TITLE
Add fork runtime allowlist helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.361",
+  "version": "0.1.362",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -715,6 +715,7 @@ export {
 } from "../chat/hosted-ui-chunk-mapping.ts";
 export {
   expandAllowedRemoteToolNames,
+  getForkRuntimeAllowedToolNames,
   getProviderNativeToolNames,
   type ProviderNativeToolInventoryOptions,
 } from "./provider-native-tool-inventory.ts";

--- a/src/agent/provider-native-tool-inventory.test.ts
+++ b/src/agent/provider-native-tool-inventory.test.ts
@@ -1,6 +1,11 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { expandAllowedRemoteToolNames, getProviderNativeToolNames } from "./index.ts";
+import type { HostToolSet } from "#veryfront/tool";
+import {
+  expandAllowedRemoteToolNames,
+  getForkRuntimeAllowedToolNames,
+  getProviderNativeToolNames,
+} from "./index.ts";
 
 describe("provider-native-tool-inventory", () => {
   it("returns anthropic provider-native tool names for an explicit provider", () => {
@@ -47,6 +52,22 @@ describe("provider-native-tool-inventory", () => {
         toolNames: ["create_file"],
       }),
       ["create_file"],
+    );
+  });
+
+  it("builds fork runtime allowed tool names from host tool definitions", () => {
+    const forkTools: HostToolSet = {
+      create_file: { description: "Create a file" },
+      web_search: { description: "Search the web" },
+    };
+
+    assertEquals(
+      getForkRuntimeAllowedToolNames({
+        provider: "anthropic",
+        forkModel: "claude-sonnet-4-6",
+        forkTools,
+      }),
+      ["create_file", "web_fetch", "web_search"],
     );
   });
 });

--- a/src/agent/provider-native-tool-inventory.ts
+++ b/src/agent/provider-native-tool-inventory.ts
@@ -1,3 +1,5 @@
+import type { HostToolSet } from "#veryfront/tool";
+
 const ANTHROPIC_PROVIDER_NATIVE_TOOL_NAMES = [
   "web_fetch",
   "web_search",
@@ -57,4 +59,16 @@ export function expandAllowedRemoteToolNames(
       ...getProviderNativeToolNames(options),
     ]),
   ].sort();
+}
+
+export function getForkRuntimeAllowedToolNames(input: {
+  provider: string;
+  forkModel?: string;
+  forkTools: HostToolSet;
+}): string[] {
+  return expandAllowedRemoteToolNames({
+    provider: input.provider,
+    model: input.forkModel,
+    toolNames: Object.keys(input.forkTools),
+  });
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.361";
+export const VERSION = "0.1.362";


### PR DESCRIPTION
## Summary
- add a shared fork runtime allowlist helper that derives allowed remote tool names from host tool definitions
- export the helper from the agent runtime API
- bump package version to 0.1.362 for CI/CD publishing

## Verification
- deno test --no-check --allow-all src/agent/provider-native-tool-inventory.test.ts src/utils/version.test.ts
- deno task lint && deno task typecheck && deno task verify:quick
- deno task test:unit
- pre-push checks