### PR TITLE
Add conversation user message persistence

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.362",
+  "version": "0.1.363",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/conversation-bootstrap.test.ts
+++ b/src/agent/conversation-bootstrap.test.ts
@@ -6,6 +6,7 @@ import {
   createConversationRecord,
   ensureConversationProjectLink,
   fetchConversationRecord,
+  persistConversationUserMessage,
 } from "./conversation-bootstrap.ts";
 
 const API_URL = "https://api.example.com";
@@ -13,6 +14,8 @@ const AUTH_TOKEN = "token-123";
 const CONVERSATION_ID = "11111111-1111-4111-a111-111111111111";
 const CHILD_CONVERSATION_ID = "22222222-2222-4222-a222-222222222222";
 const MESSAGE_ID = "33333333-3333-4333-a333-333333333333";
+const USER_MESSAGE_ID = "33333333-3333-4333-a333-333333333334";
+const PARENT_MESSAGE_ID = "33333333-3333-4333-a333-333333333335";
 const PROJECT_ID = "44444444-4444-4444-8444-444444444444";
 const BRANCH_ID = "55555555-5555-4555-8555-555555555555";
 const originalFetch = globalThis.fetch;
@@ -117,6 +120,62 @@ describe("agent/conversation-bootstrap", () => {
     });
     assertEquals(conversation, { id: CHILD_CONVERSATION_ID, projectId: PROJECT_ID });
     assertEquals(message, { id: MESSAGE_ID });
+  });
+
+  it("persists a UI user message through the conversation messages endpoint", async () => {
+    let capturedUrl = "";
+    let capturedInit: RequestInit | undefined;
+    stubFetchWithRecorder((input, init) => {
+      capturedUrl = String(input);
+      capturedInit = init;
+      return jsonResponse({ id: MESSAGE_ID }, 201);
+    });
+
+    const result = await persistConversationUserMessage({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      parentMessageId: PARENT_MESSAGE_ID,
+      message: {
+        id: USER_MESSAGE_ID,
+        role: "user",
+        parts: [{ type: "text", text: "Hello" }],
+        metadata: { source: "test" },
+      },
+    });
+
+    assertEquals(result, { id: MESSAGE_ID });
+    assertEquals(capturedUrl, `${API_URL}/conversations/${CONVERSATION_ID}/messages`);
+    assertEquals(capturedInit?.method, "POST");
+    assertEquals(capturedInit?.headers, {
+      Authorization: `Bearer ${AUTH_TOKEN}`,
+      "Content-Type": "application/json",
+    });
+    assertEquals(JSON.parse(String(capturedInit?.body)), {
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }],
+      idempotency_key: USER_MESSAGE_ID,
+      parent_id: PARENT_MESSAGE_ID,
+      metadata: { source: "test" },
+    });
+  });
+
+  it("rejects UI user messages without persistable parts", async () => {
+    await assertRejects(
+      () =>
+        persistConversationUserMessage({
+          authToken: AUTH_TOKEN,
+          apiUrl: API_URL,
+          conversationId: CONVERSATION_ID,
+          message: {
+            id: USER_MESSAGE_ID,
+            role: "user",
+            parts: [],
+          },
+        }),
+      Error,
+      "CONVERSATION_USER_MESSAGE_REQUIRES_PERSISTABLE_PARTS",
+    );
   });
 
   it("bootstraps a conversation-backed agent run", async () => {

--- a/src/agent/conversation-bootstrap.ts
+++ b/src/agent/conversation-bootstrap.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import { isUuid, toConversationPartsFromUiMessage } from "../chat/conversation.ts";
+import type { ChatUiMessage } from "../chat/types.ts";
 import { type ConversationRunProjection, createConversationAgentRun } from "./durable.ts";
 
 const CONVERSATION_API_TIMEOUT_MS = 15_000;
@@ -22,6 +24,18 @@ export const ConversationMessageRecordSchema = z.object({
 export type ConversationRecord = z.infer<typeof ConversationRecordSchema>;
 export type ConversationMessageRecord = z.infer<typeof ConversationMessageRecordSchema>;
 
+export interface ConversationControlPlaneResponseError {
+  status: number;
+  statusText: string;
+  body: string;
+}
+
+export interface PersistConversationUserMessageFailure
+  extends ConversationControlPlaneResponseError {
+  conversationId: string;
+  messageId: string;
+}
+
 async function controlPlaneJson<T>(input: {
   authToken: string;
   url: string;
@@ -29,6 +43,7 @@ async function controlPlaneJson<T>(input: {
   body?: unknown;
   responseSchema: z.ZodSchema<T>;
   operation: string;
+  onResponseError?: (error: ConversationControlPlaneResponseError) => void;
 }): Promise<T> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), CONVERSATION_API_TIMEOUT_MS);
@@ -55,6 +70,11 @@ async function controlPlaneJson<T>(input: {
 
   if (!response.ok) {
     const body = await response.text().catch(() => "");
+    input.onResponseError?.({
+      status: response.status,
+      statusText: response.statusText,
+      body,
+    });
     throw new Error(
       `${input.operation} failed (${response.status}): ${body || response.statusText}`,
     );
@@ -129,6 +149,8 @@ export async function createConversationMessage(input: {
   apiUrl: string;
   conversationId: string;
   body: unknown;
+  operation?: string;
+  onResponseError?: (error: ConversationControlPlaneResponseError) => void;
 }): Promise<ConversationMessageRecord> {
   return controlPlaneJson({
     authToken: input.authToken,
@@ -136,7 +158,44 @@ export async function createConversationMessage(input: {
     method: "POST",
     body: input.body,
     responseSchema: ConversationMessageRecordSchema,
-    operation: "Create conversation message",
+    operation: input.operation ?? "Create conversation message",
+    onResponseError: input.onResponseError,
+  });
+}
+
+export async function persistConversationUserMessage(input: {
+  authToken: string;
+  apiUrl: string;
+  conversationId: string;
+  message: ChatUiMessage;
+  parentMessageId?: string;
+  operation?: string;
+  onFailure?: (failure: PersistConversationUserMessageFailure) => void;
+}): Promise<ConversationMessageRecord> {
+  const parts = toConversationPartsFromUiMessage(input.message);
+  if (parts.length === 0) {
+    throw new Error("CONVERSATION_USER_MESSAGE_REQUIRES_PERSISTABLE_PARTS");
+  }
+
+  return createConversationMessage({
+    authToken: input.authToken,
+    apiUrl: input.apiUrl,
+    conversationId: input.conversationId,
+    operation: input.operation ?? "Persist conversation user message",
+    body: {
+      role: "user",
+      parts,
+      idempotency_key: input.message.id,
+      ...(isUuid(input.parentMessageId) ? { parent_id: input.parentMessageId } : {}),
+      ...(input.message.metadata ? { metadata: input.message.metadata } : {}),
+    },
+    onResponseError: (error) => {
+      input.onFailure?.({
+        conversationId: input.conversationId,
+        messageId: input.message.id,
+        ...error,
+      });
+    },
   });
 }
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -347,6 +347,7 @@ export {
 export {
   bootstrapConversationAgentRun,
   type BootstrapConversationAgentRunResult,
+  type ConversationControlPlaneResponseError,
   type ConversationMessageRecord,
   ConversationMessageRecordSchema,
   type ConversationRecord,
@@ -355,6 +356,8 @@ export {
   createConversationRecord,
   ensureConversationProjectLink,
   fetchConversationRecord,
+  persistConversationUserMessage,
+  type PersistConversationUserMessageFailure,
 } from "./conversation-bootstrap.ts";
 export {
   bootstrapHostedChildRun,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.362";
+export const VERSION = "0.1.363";


### PR DESCRIPTION
## Summary\n- add a reusable helper for persisting UI user messages through the conversation messages endpoint\n- expose response-error callback metadata for control-plane message persistence failures\n- bump package version to 0.1.363\n\n## Verification\n- deno test --no-check --allow-all src/agent/conversation-bootstrap.test.ts src/utils/version.test.ts\n- deno task lint && deno task typecheck && deno task verify:quick\n- deno task test:unit\n- pre-push checks