### PR TITLE
Add detached AG-UI start request builder

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.363",
+  "version": "0.1.364",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/ag-ui-detached-start.test.ts
+++ b/src/agent/ag-ui-detached-start.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   AgentRuntime,
   AgUiDetachedStartRequestSchema,
+  buildDetachedAgUiStartRequest,
   createAgUiDetachedStartHandler,
   executeAgUiDetachedStart,
   RunResumeSessionManager,
@@ -67,6 +68,77 @@ async function flushAsyncWork(): Promise<void> {
 }
 
 describe("agent/ag-ui-detached-start", () => {
+  it("builds a detached start request from chat UI messages", () => {
+    const request = buildDetachedAgUiStartRequest({
+      runId: "run_1",
+      threadId: "b2b4620f-7058-4407-a8df-1d88b860bc1d",
+      messages: [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "Done" }],
+          metadata: {
+            modelId: "anthropic/claude-sonnet-4-6",
+            usage: {
+              inputTokens: 12,
+              outputTokens: 34,
+              cachedInputTokens: 5,
+            },
+          },
+        },
+      ],
+      model: "anthropic/claude-sonnet-4-6",
+      forwardedProps: { projectId: "project-1" },
+    });
+
+    assertEquals(request, {
+      runId: "run_1",
+      threadId: "b2b4620f-7058-4407-a8df-1d88b860bc1d",
+      messages: [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "Done" }],
+          metadata: {
+            modelId: "anthropic/claude-sonnet-4-6",
+            usage: {
+              inputTokens: 12,
+              outputTokens: 34,
+              cachedInputTokens: 5,
+            },
+          },
+        },
+      ],
+      tools: [],
+      context: [],
+      model: "anthropic/claude-sonnet-4-6",
+      forwardedProps: { projectId: "project-1" },
+    });
+  });
+
+  it("builds detached start fallback ids and placeholder messages", () => {
+    const request = buildDetachedAgUiStartRequest({
+      runId: "run_2",
+      threadId: "not-a-uuid",
+      messages: [],
+      createThreadId: () => "generated-thread-id",
+    });
+
+    assertEquals(request, {
+      runId: "run_2",
+      threadId: "generated-thread-id",
+      messages: [
+        {
+          id: "run_2:placeholder",
+          role: "user",
+          parts: [{ type: "text", text: "" }],
+        },
+      ],
+      tools: [],
+      context: [],
+    });
+  });
+
   it("requires explicit run and thread ids", () => {
     const parsed = AgUiDetachedStartRequestSchema.parse({
       runId: "run_1",

--- a/src/agent/ag-ui-detached-start.ts
+++ b/src/agent/ag-ui-detached-start.ts
@@ -10,6 +10,7 @@ import {
   type RunResumeSessionManager,
 } from "./runtime/index.ts";
 import type { Agent } from "./types.ts";
+import type { ChatUiMessage, MessageMetadata } from "../chat/types.ts";
 
 const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const AG_UI_DETACHED_RUN_ID_SCHEMA = z.string().min(1).max(128).regex(AGENT_ID_PATTERN);
@@ -81,6 +82,76 @@ export const AgUiDetachedStartAcceptedSchema = z.object({
 
 export type AgUiDetachedStartRequest = z.infer<typeof AgUiDetachedStartRequestSchema>;
 export type AgUiDetachedStartAccepted = z.infer<typeof AgUiDetachedStartAcceptedSchema>;
+
+function toDetachedAgUiMessageMetadata(
+  metadata: MessageMetadata | undefined,
+): Record<string, unknown> | undefined {
+  if (!metadata) {
+    return undefined;
+  }
+
+  const normalizedMetadata: Record<string, unknown> = {
+    ...(metadata.modelId ? { modelId: metadata.modelId } : {}),
+    ...(metadata.usage
+      ? {
+        usage: {
+          ...(metadata.usage.inputTokens !== undefined
+            ? { inputTokens: metadata.usage.inputTokens }
+            : {}),
+          ...(metadata.usage.outputTokens !== undefined
+            ? { outputTokens: metadata.usage.outputTokens }
+            : {}),
+          ...(metadata.usage.cachedInputTokens !== undefined
+            ? { cachedInputTokens: metadata.usage.cachedInputTokens }
+            : {}),
+        },
+      }
+      : {}),
+  };
+
+  return Object.keys(normalizedMetadata).length > 0 ? normalizedMetadata : undefined;
+}
+
+export function buildDetachedAgUiStartRequest(input: {
+  runId: string;
+  threadId: string;
+  messages: ChatUiMessage[];
+  model?: string;
+  forwardedProps?: Record<string, unknown>;
+  createThreadId?: () => string;
+}): AgUiDetachedStartRequest {
+  const effectiveThreadId = z.string().uuid().safeParse(input.threadId).success
+    ? input.threadId
+    : (input.createThreadId?.() ?? crypto.randomUUID());
+  const effectiveMessages: AgUiDetachedStartRequest["messages"] = input.messages.length > 0
+    ? input.messages.map((message) => {
+      const metadata = toDetachedAgUiMessageMetadata(message.metadata);
+
+      return {
+        id: message.id,
+        role: message.role,
+        parts: message.parts,
+        ...(metadata ? { metadata } : {}),
+      };
+    })
+    : [
+      {
+        id: `${input.runId}:placeholder`,
+        role: "user",
+        parts: [{ type: "text", text: "" }],
+      },
+    ];
+
+  return {
+    runId: input.runId,
+    threadId: effectiveThreadId,
+    messages: effectiveMessages,
+    tools: [],
+    context: [],
+    ...(input.model ? { model: input.model } : {}),
+    ...(input.forwardedProps ? { forwardedProps: input.forwardedProps } : {}),
+  };
+}
 
 export interface ExecuteAgUiDetachedStartInput {
   request: AgUiDetachedStartRequest;

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -728,6 +728,7 @@ export {
   type AgUiDetachedStartHandlerOptions,
   type AgUiDetachedStartRequest,
   AgUiDetachedStartRequestSchema,
+  buildDetachedAgUiStartRequest,
   createAgUiDetachedStartHandler,
   executeAgUiDetachedStart,
   type ExecuteAgUiDetachedStartInput,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.363";
+export const VERSION = "0.1.364";


### PR DESCRIPTION
## Summary
- Add a framework helper for building detached AG-UI start requests from chat UI messages
- Preserve model, forwarded props, selected message metadata, UUID fallback, and placeholder message behavior
- Bump the package version to 0.1.364 for release

## Verification
- deno test --no-check --allow-all src/agent/ag-ui-detached-start.test.ts src/utils/version.test.ts
- deno task lint && deno task typecheck && deno task verify:quick
- deno task test:unit
- pre-push checks