### PR TITLE
Add durable input request protocol helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.364",
+  "version": "0.1.365",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -766,6 +766,22 @@ export {
   createAgUiHandler,
 } from "./ag-ui-handler.ts";
 export {
+  buildInputRequestLifecycleDataEvent,
+  createInputRequest,
+  createInputRequestRequestSchema,
+  createInputRequestResponseSchema,
+  type FormInputToolInput,
+  formInputToolInputSchema,
+  getInputRequest,
+  getInputRequestResponseSchema,
+  inputRequestLifecycleDataEventSchema,
+  type InputRequestOutput,
+  inputRequestOutputSchema,
+  inputRequestRestSchema,
+  inputResponseRestSchema,
+  inputResponseValuesSchema,
+} from "./input-request-protocol.ts";
+export {
   type DurableHumanInputFlowResult,
   executeDurableHumanInputFlow,
   type ExecuteDurableHumanInputFlowOptions,

--- a/src/agent/input-request-protocol.test.ts
+++ b/src/agent/input-request-protocol.test.ts
@@ -1,0 +1,193 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  buildInputRequestLifecycleDataEvent,
+  createInputRequest,
+  createInputRequestResponseSchema,
+  getInputRequest,
+} from "./index.ts";
+
+const API_URL = "https://api.example.com";
+const AUTH_TOKEN = "token-123";
+const CONVERSATION_ID = "22222222-2222-4222-a222-222222222222";
+const RUN_ID = "run_1";
+const TOOL_CALL_ID = "tool-call-1";
+const INPUT_REQUEST_ID = "11111111-1111-4111-a111-111111111111";
+const CREATED_AT = "2026-04-04T00:00:00.000Z";
+const EXPIRES_AT = "2026-04-04T00:05:00.000Z";
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function createLatestResponse(values: Record<string, unknown>) {
+  return {
+    id: "33333333-3333-4333-a333-333333333333",
+    input_request_id: INPUT_REQUEST_ID,
+    conversation_id: CONVERSATION_ID,
+    run_id: RUN_ID,
+    actor_type: "human",
+    actor_id: "user-1",
+    values,
+    created_at: CREATED_AT,
+  };
+}
+
+function createInputRequestRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: INPUT_REQUEST_ID,
+    conversation_id: CONVERSATION_ID,
+    run_id: RUN_ID,
+    tool_call_id: TOOL_CALL_ID,
+    kind: "form",
+    status: "open",
+    requested_responder_type: "human",
+    title: "Choose one",
+    description: "Pick",
+    fields: [
+      {
+        type: "confirm",
+        name: "confirmed",
+        label: "Confirm?",
+        required: false,
+        secret: false,
+        confirmLabel: "Yes",
+        denyLabel: "No",
+      },
+    ],
+    recommendations: null,
+    metadata: null,
+    created_at: CREATED_AT,
+    expires_at: EXPIRES_AT,
+    submitted_at: null,
+    cancelled_at: null,
+    expired_at: null,
+    latest_response: null,
+    ...overrides,
+  };
+}
+
+function stubFetchWithRecorder(
+  handler: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> | Response,
+) {
+  globalThis.fetch = async (input, init) => handler(input, init);
+}
+
+describe("agent/input-request-protocol", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("creates durable form input requests through the conversation endpoint", async () => {
+    let capturedUrl = "";
+    let capturedInit: RequestInit | undefined;
+    stubFetchWithRecorder((input, init) => {
+      capturedUrl = String(input);
+      capturedInit = init;
+      return jsonResponse(createInputRequestRecord({ metadata: { submitLabel: "Send" } }), 201);
+    });
+
+    const result = await createInputRequest({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      runId: RUN_ID,
+      toolCallId: TOOL_CALL_ID,
+      form: {
+        title: "Choose one",
+        description: "Pick",
+        submitLabel: "Send",
+        fields: [{ type: "confirm", name: "confirmed", label: "Confirm?" }],
+      },
+      expiresAt: EXPIRES_AT,
+    });
+
+    assertEquals(result.id, INPUT_REQUEST_ID);
+    assertEquals(result.toolCallId, TOOL_CALL_ID);
+    assertEquals(capturedUrl, `${API_URL}/conversations/${CONVERSATION_ID}/input-requests`);
+    assertEquals(capturedInit?.method, "POST");
+    assertEquals(capturedInit?.headers, {
+      Authorization: `Bearer ${AUTH_TOKEN}`,
+      "Content-Type": "application/json",
+    });
+    assertEquals(JSON.parse(String(capturedInit?.body)), {
+      run_id: RUN_ID,
+      tool_call_id: TOOL_CALL_ID,
+      kind: "form",
+      requested_responder_type: "human",
+      title: "Choose one",
+      description: "Pick",
+      fields: [
+        {
+          type: "confirm",
+          name: "confirmed",
+          label: "Confirm?",
+          required: false,
+          secret: false,
+          confirmLabel: "Yes",
+          denyLabel: "No",
+        },
+      ],
+      expires_at: EXPIRES_AT,
+      metadata: { submitLabel: "Send" },
+    });
+  });
+
+  it("fetches and normalizes durable input request snapshots", async () => {
+    stubFetchWithRecorder((input, init) => {
+      assertEquals(
+        String(input),
+        `${API_URL}/conversations/${CONVERSATION_ID}/input-requests/${INPUT_REQUEST_ID}`,
+      );
+      assertEquals(init?.method, "GET");
+      return jsonResponse(
+        createInputRequestRecord({
+          status: "submitted",
+          latest_response: createLatestResponse({ confirmed: true }),
+        }),
+        200,
+      );
+    });
+
+    const result = await getInputRequest({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      inputRequestId: INPUT_REQUEST_ID,
+    });
+
+    assertEquals(result.status, "submitted");
+    assertEquals(result.latestResponse?.values, { confirmed: true });
+  });
+
+  it("builds input request lifecycle data events", () => {
+    const inputRequest = createInputRequestResponseSchema.parse(createInputRequestRecord());
+
+    assertEquals(buildInputRequestLifecycleDataEvent({ action: "created", inputRequest }), {
+      type: "veryfront.input_request.lifecycle",
+      data: { action: "created", inputRequest },
+      name: "veryfront.input_request.lifecycle",
+      value: { action: "created", inputRequest },
+    });
+  });
+
+  it("surfaces API failures with response text", async () => {
+    stubFetchWithRecorder(() => new Response("poll failed", { status: 500 }));
+
+    await assertRejects(
+      () =>
+        getInputRequest({
+          authToken: AUTH_TOKEN,
+          apiUrl: API_URL,
+          conversationId: CONVERSATION_ID,
+          inputRequestId: INPUT_REQUEST_ID,
+        }),
+      Error,
+      "poll failed",
+    );
+  });
+});

--- a/src/agent/input-request-protocol.ts
+++ b/src/agent/input-request-protocol.ts
@@ -1,0 +1,210 @@
+import { z } from "zod";
+import type { ToolExecutionDataEvent } from "../tool/types.ts";
+import { HumanInputFieldSchema, HumanInputRequestSchema } from "./human-input.ts";
+
+export const formInputToolInputSchema = HumanInputRequestSchema.omit({ metadata: true });
+export const inputResponseValuesSchema = z.record(
+  z.string(),
+  z.union([z.string(), z.boolean(), z.number(), z.null()]),
+);
+
+export const createInputRequestRequestSchema = z.object({
+  run_id: z.string().min(1),
+  tool_call_id: z.string().min(1),
+  kind: z.literal("form"),
+  requested_responder_type: z.literal("human"),
+  title: z.string(),
+  description: z.string().optional(),
+  fields: z.array(HumanInputFieldSchema).min(1),
+  expires_at: z.string().datetime({ offset: true }),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const inputResponseRestSchema = z
+  .object({
+    id: z.string().uuid(),
+    input_request_id: z.string().uuid(),
+    conversation_id: z.string().uuid(),
+    run_id: z.string().min(1),
+    actor_type: z.string(),
+    actor_id: z.string(),
+    values: inputResponseValuesSchema,
+    created_at: z.string(),
+  })
+  .passthrough()
+  .transform((value) => ({
+    id: value.id,
+    inputRequestId: value.input_request_id,
+    conversationId: value.conversation_id,
+    runId: value.run_id,
+    actorType: value.actor_type,
+    actorId: value.actor_id,
+    values: value.values,
+    createdAt: value.created_at,
+  }));
+
+export const inputRequestRestSchema = z
+  .object({
+    id: z.string().uuid(),
+    conversation_id: z.string().uuid(),
+    run_id: z.string().min(1),
+    tool_call_id: z.string().min(1),
+    kind: z.literal("form"),
+    status: z.enum(["open", "submitted", "cancelled", "expired"]),
+    requested_responder_type: z.enum(["human", "agent", "system"]),
+    title: z.string(),
+    description: z.string().nullable(),
+    fields: z.array(HumanInputFieldSchema),
+    recommendations: z.record(z.string(), z.unknown()).nullable().optional(),
+    metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+    created_at: z.string(),
+    expires_at: z.string().nullable(),
+    submitted_at: z.string().nullable().optional(),
+    cancelled_at: z.string().nullable().optional(),
+    expired_at: z.string().nullable().optional(),
+    latest_response: inputResponseRestSchema.nullable().optional(),
+  })
+  .passthrough()
+  .transform((value) => ({
+    id: value.id,
+    conversationId: value.conversation_id,
+    runId: value.run_id,
+    toolCallId: value.tool_call_id,
+    kind: value.kind,
+    status: value.status,
+    requestedResponderType: value.requested_responder_type,
+    title: value.title,
+    description: value.description,
+    fields: value.fields,
+    recommendations: value.recommendations ?? null,
+    metadata: value.metadata ?? null,
+    createdAt: value.created_at,
+    expiresAt: value.expires_at,
+    submittedAt: value.submitted_at ?? null,
+    cancelledAt: value.cancelled_at ?? null,
+    expiredAt: value.expired_at ?? null,
+    latestResponse: value.latest_response ?? null,
+  }));
+
+export const createInputRequestResponseSchema = inputRequestRestSchema;
+export const getInputRequestResponseSchema = inputRequestRestSchema;
+export const inputRequestOutputSchema = z.object({
+  id: z.string().uuid(),
+  conversationId: z.string().uuid(),
+  runId: z.string().min(1),
+  toolCallId: z.string().min(1),
+  kind: z.literal("form"),
+  status: z.enum(["open", "submitted", "cancelled", "expired"]),
+  requestedResponderType: z.enum(["human", "agent", "system"]),
+  title: z.string(),
+  description: z.string().nullable(),
+  fields: z.array(HumanInputFieldSchema),
+  recommendations: z.record(z.string(), z.unknown()).nullable(),
+  metadata: z.record(z.string(), z.unknown()).nullable(),
+  createdAt: z.string(),
+  expiresAt: z.string().nullable(),
+  submittedAt: z.string().nullable(),
+  cancelledAt: z.string().nullable(),
+  expiredAt: z.string().nullable(),
+  latestResponse: inputResponseRestSchema.nullable(),
+});
+
+export const inputRequestLifecycleDataEventSchema = z.object({
+  type: z.literal("veryfront.input_request.lifecycle"),
+  data: z.object({
+    action: z.enum(["created", "updated"]),
+    inputRequest: inputRequestOutputSchema,
+  }),
+  name: z.literal("veryfront.input_request.lifecycle"),
+  value: z.object({
+    action: z.enum(["created", "updated"]),
+    inputRequest: inputRequestOutputSchema,
+  }),
+});
+
+export type FormInputToolInput = z.infer<typeof formInputToolInputSchema>;
+export type InputRequestOutput = z.infer<typeof inputRequestOutputSchema>;
+
+export async function createInputRequest(input: {
+  authToken: string;
+  apiUrl: string;
+  conversationId: string;
+  runId: string;
+  toolCallId: string;
+  form: FormInputToolInput;
+  expiresAt: string;
+}): Promise<InputRequestOutput> {
+  const requestBody = createInputRequestRequestSchema.parse({
+    run_id: input.runId,
+    tool_call_id: input.toolCallId,
+    kind: "form",
+    requested_responder_type: "human",
+    title: input.form.title,
+    ...(input.form.description ? { description: input.form.description } : {}),
+    fields: input.form.fields,
+    expires_at: input.expiresAt,
+    ...(input.form.submitLabel ? { metadata: { submitLabel: input.form.submitLabel } } : {}),
+  });
+  const response = await fetch(
+    `${input.apiUrl}/conversations/${input.conversationId}/input-requests`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${input.authToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+      signal: AbortSignal.timeout(15_000),
+    },
+  );
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(detail || `Failed to create durable input request (HTTP ${response.status})`);
+  }
+
+  return createInputRequestResponseSchema.parse(await response.json());
+}
+
+export async function getInputRequest(input: {
+  authToken: string;
+  apiUrl: string;
+  conversationId: string;
+  inputRequestId: string;
+}): Promise<InputRequestOutput> {
+  const response = await fetch(
+    `${input.apiUrl}/conversations/${input.conversationId}/input-requests/${input.inputRequestId}`,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${input.authToken}`,
+      },
+      signal: AbortSignal.timeout(15_000),
+    },
+  );
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(detail || `Failed to fetch durable input request (HTTP ${response.status})`);
+  }
+
+  return getInputRequestResponseSchema.parse(await response.json());
+}
+
+export function buildInputRequestLifecycleDataEvent(input: {
+  action: "created" | "updated";
+  inputRequest: InputRequestOutput;
+}): ToolExecutionDataEvent {
+  return inputRequestLifecycleDataEventSchema.parse({
+    type: "veryfront.input_request.lifecycle",
+    data: {
+      action: input.action,
+      inputRequest: input.inputRequest,
+    },
+    name: "veryfront.input_request.lifecycle",
+    value: {
+      action: input.action,
+      inputRequest: input.inputRequest,
+    },
+  });
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.364";
+export const VERSION = "0.1.365";


### PR DESCRIPTION
## Summary\n- add reusable durable form input request REST schemas and API helpers\n- add a lifecycle data event builder for input request tool events\n- bump framework version to 0.1.365 for CI/CD publishing\n\n## Verification\n- deno test --no-check --allow-all src/agent/input-request-protocol.test.ts src/utils/version.test.ts\n- deno task lint && deno task typecheck && deno task verify:quick\n- deno task test:unit\n- pre-push checks