### PR TITLE
Add hosted form input tool

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.365",
+  "version": "0.1.366",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-form-input-tool.test.ts
+++ b/src/agent/hosted-form-input-tool.test.ts
@@ -1,0 +1,296 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import type { ToolExecutionContext } from "#veryfront/tool";
+import { createHostedFormInputTool } from "./index.ts";
+
+const API_URL = "https://api.example.com";
+const AUTH_TOKEN = "token-123";
+const INPUT_REQUEST_ID = "11111111-1111-4111-a111-111111111111";
+const CONVERSATION_ID = "22222222-2222-4222-a222-222222222222";
+const RUN_ID = "run_1";
+const TOOL_CALL_ID = "tool-call-1";
+const CREATED_AT = "2026-04-04T00:00:00.000Z";
+const EXPIRES_AT = "2026-04-04T00:05:00.000Z";
+const originalFetch = globalThis.fetch;
+
+type FetchCall = {
+  input: RequestInfo | URL;
+  init?: RequestInit;
+};
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function createLatestResponse(values: Record<string, unknown>) {
+  return {
+    id: "33333333-3333-4333-a333-333333333333",
+    input_request_id: INPUT_REQUEST_ID,
+    conversation_id: CONVERSATION_ID,
+    run_id: RUN_ID,
+    actor_type: "human",
+    actor_id: "user-1",
+    values,
+    created_at: CREATED_AT,
+  };
+}
+
+function createInputRequestRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: INPUT_REQUEST_ID,
+    conversation_id: CONVERSATION_ID,
+    run_id: RUN_ID,
+    tool_call_id: TOOL_CALL_ID,
+    kind: "form",
+    status: "open",
+    requested_responder_type: "human",
+    title: "Choose one",
+    description: "Pick",
+    fields: [
+      {
+        type: "confirm",
+        name: "confirmed",
+        label: "Confirm?",
+        required: false,
+        secret: false,
+        confirmLabel: "Yes",
+        denyLabel: "No",
+      },
+    ],
+    recommendations: null,
+    metadata: null,
+    created_at: CREATED_AT,
+    expires_at: EXPIRES_AT,
+    submitted_at: null,
+    cancelled_at: null,
+    expired_at: null,
+    latest_response: null,
+    ...overrides,
+  };
+}
+
+function createContext(overrides: Record<string, unknown> = {}) {
+  return {
+    authToken: AUTH_TOKEN,
+    conversationId: CONVERSATION_ID,
+    parentRunId: RUN_ID,
+    ...overrides,
+  };
+}
+
+function createExecuteInput(fields: Array<Record<string, unknown>>) {
+  return {
+    title: "Choose one",
+    description: "Pick",
+    fields,
+  };
+}
+
+function stubFetchSequence(responses: Response[]) {
+  const calls: FetchCall[] = [];
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ input, init });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error("Unexpected fetch call");
+    }
+    return response;
+  };
+  return calls;
+}
+
+describe("agent/hosted-form-input-tool", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("creates and polls a durable input request until it is submitted", async () => {
+    const calls = stubFetchSequence([
+      jsonResponse(createInputRequestRecord(), 201),
+      jsonResponse(
+        createInputRequestRecord({
+          status: "submitted",
+          submitted_at: "2026-04-04T00:00:30.000Z",
+          latest_response: createLatestResponse({ confirmed: true }),
+        }),
+        200,
+      ),
+    ]);
+
+    const formInputTool = createHostedFormInputTool(createContext(), API_URL);
+    const result = await formInputTool.execute(
+      createExecuteInput([{ type: "confirm", name: "confirmed", label: "Confirm?" }]),
+      { toolCallId: TOOL_CALL_ID },
+    );
+
+    assertEquals(result, {
+      submitted: true,
+      values: { confirmed: true },
+      inputRequestId: INPUT_REQUEST_ID,
+    });
+    assertEquals(
+      String(calls[0]?.input),
+      `${API_URL}/conversations/${CONVERSATION_ID}/input-requests`,
+    );
+    assertEquals(calls[0]?.init?.method, "POST");
+    assertEquals(JSON.parse(String(calls[0]?.init?.body)).run_id, RUN_ID);
+    assertEquals(JSON.parse(String(calls[0]?.init?.body)).tool_call_id, TOOL_CALL_ID);
+    assertEquals(
+      String(calls[1]?.input),
+      `${API_URL}/conversations/${CONVERSATION_ID}/input-requests/${INPUT_REQUEST_ID}`,
+    );
+    assertEquals(calls[1]?.init?.method, "GET");
+  });
+
+  it("publishes a lifecycle data event for the created durable input request", async () => {
+    const publishedEvents: unknown[] = [];
+    stubFetchSequence([
+      jsonResponse(
+        createInputRequestRecord({ status: "cancelled", cancelled_at: CREATED_AT }),
+        201,
+      ),
+      jsonResponse(
+        createInputRequestRecord({ status: "cancelled", cancelled_at: CREATED_AT }),
+        200,
+      ),
+    ]);
+
+    const formInputTool = createHostedFormInputTool(createContext(), API_URL);
+    const execContext: ToolExecutionContext = {
+      toolCallId: TOOL_CALL_ID,
+      publishDataEvent: (event) => {
+        publishedEvents.push(event);
+      },
+    };
+
+    await formInputTool.execute(
+      createExecuteInput([{ type: "confirm", name: "confirmed", label: "Confirm?" }]),
+      execContext,
+    );
+
+    assertEquals(publishedEvents, [
+      {
+        type: "veryfront.input_request.lifecycle",
+        data: {
+          action: "created",
+          inputRequest: {
+            id: INPUT_REQUEST_ID,
+            conversationId: CONVERSATION_ID,
+            runId: RUN_ID,
+            toolCallId: TOOL_CALL_ID,
+            kind: "form",
+            status: "cancelled",
+            requestedResponderType: "human",
+            title: "Choose one",
+            description: "Pick",
+            fields: [
+              {
+                type: "confirm",
+                name: "confirmed",
+                label: "Confirm?",
+                required: false,
+                secret: false,
+                confirmLabel: "Yes",
+                denyLabel: "No",
+              },
+            ],
+            recommendations: null,
+            metadata: null,
+            createdAt: CREATED_AT,
+            expiresAt: EXPIRES_AT,
+            submittedAt: null,
+            cancelledAt: CREATED_AT,
+            expiredAt: null,
+            latestResponse: null,
+          },
+        },
+        name: "veryfront.input_request.lifecycle",
+        value: {
+          action: "created",
+          inputRequest: {
+            id: INPUT_REQUEST_ID,
+            conversationId: CONVERSATION_ID,
+            runId: RUN_ID,
+            toolCallId: TOOL_CALL_ID,
+            kind: "form",
+            status: "cancelled",
+            requestedResponderType: "human",
+            title: "Choose one",
+            description: "Pick",
+            fields: [
+              {
+                type: "confirm",
+                name: "confirmed",
+                label: "Confirm?",
+                required: false,
+                secret: false,
+                confirmLabel: "Yes",
+                denyLabel: "No",
+              },
+            ],
+            recommendations: null,
+            metadata: null,
+            createdAt: CREATED_AT,
+            expiresAt: EXPIRES_AT,
+            submittedAt: null,
+            cancelledAt: CREATED_AT,
+            expiredAt: null,
+            latestResponse: null,
+          },
+        },
+      },
+    ]);
+  });
+
+  it("marks exact artifact path submissions as conversation-first", async () => {
+    stubFetchSequence([
+      jsonResponse(
+        createInputRequestRecord({ fields: [{ type: "textarea", name: "idea", label: "Idea" }] }),
+        201,
+      ),
+      jsonResponse(
+        createInputRequestRecord({
+          status: "submitted",
+          fields: [{ type: "textarea", name: "idea", label: "Idea" }],
+          submitted_at: "2026-04-04T00:00:30.000Z",
+          latest_response: createLatestResponse({
+            idea: "Write the final plan to /plans/budget-planning.md",
+          }),
+        }),
+        200,
+      ),
+    ]);
+
+    const context = createContext();
+    const formInputTool = createHostedFormInputTool(context, API_URL);
+
+    await formInputTool.execute(
+      createExecuteInput([{ type: "textarea", name: "idea", label: "Idea" }]),
+      { toolCallId: TOOL_CALL_ID },
+    );
+
+    assertEquals(context.slashCommandArtifactPathSeen, true);
+  });
+
+  it("surfaces durable input polling failures", async () => {
+    stubFetchSequence([
+      jsonResponse(createInputRequestRecord(), 201),
+      new Response("poll failed", { status: 500 }),
+    ]);
+
+    const formInputTool = createHostedFormInputTool(createContext(), API_URL);
+
+    await assertRejects(
+      () =>
+        formInputTool.execute(
+          createExecuteInput([{ type: "confirm", name: "confirmed", label: "Confirm?" }]),
+          { toolCallId: TOOL_CALL_ID },
+        ),
+      Error,
+      "poll failed",
+    );
+  });
+});

--- a/src/agent/hosted-form-input-tool.ts
+++ b/src/agent/hosted-form-input-tool.ts
@@ -1,0 +1,117 @@
+import { tool, type ToolExecutionContext } from "#veryfront/tool";
+import { containsExactArtifactPathValue } from "./slash-command-artifact-policy.ts";
+import {
+  buildInputRequestLifecycleDataEvent,
+  createInputRequest,
+  type FormInputToolInput,
+  formInputToolInputSchema,
+  getInputRequest,
+  type InputRequestOutput,
+} from "./input-request-protocol.ts";
+import { executeDurableHumanInputFlow, type HumanInputResult } from "./human-input.ts";
+
+const INPUT_REQUEST_TIMEOUT_MS = 5 * 60_000;
+const INPUT_REQUEST_POLL_INTERVAL_MS = 500;
+
+export interface HostedFormInputToolContext {
+  authToken: string;
+  conversationId?: string;
+  parentRunId?: string;
+  slashCommandArtifactPathSeen?: boolean;
+}
+
+export function createHostedFormInputTool(context: HostedFormInputToolContext, apiUrl: string) {
+  return tool({
+    description:
+      "Display a durable structured form to collect user input. Use this when you need a concrete choice or structured values before continuing. The request is persisted as an input_request and the tool waits until the user submits or the request expires.",
+    inputSchema: formInputToolInputSchema,
+    execute: async (input, execOptions) =>
+      executeDurableFormInputFlow(context, apiUrl, input, execOptions),
+  });
+}
+
+async function executeDurableFormInputFlow(
+  context: HostedFormInputToolContext,
+  apiUrl: string,
+  input: FormInputToolInput,
+  execContext?: ToolExecutionContext,
+) {
+  if (!context.conversationId) {
+    throw new Error("form_input requires a durable conversation context");
+  }
+  if (!context.parentRunId) {
+    throw new Error("form_input requires a durable run context");
+  }
+
+  const conversationId = context.conversationId;
+  const parentRunId = context.parentRunId;
+  const toolCallId =
+    typeof execContext?.toolCallId === "string" && execContext.toolCallId.length > 0
+      ? execContext.toolCallId
+      : `form_input-${crypto.randomUUID()}`;
+
+  const { result, createdRequest } = await executeDurableHumanInputFlow({
+    runId: parentRunId,
+    threadId: conversationId,
+    toolCallId,
+    request: input,
+    timeoutMs: INPUT_REQUEST_TIMEOUT_MS + 5_000,
+    pollIntervalMs: INPUT_REQUEST_POLL_INTERVAL_MS,
+    onRequest: async (pendingRequest) => {
+      const created = await createInputRequest({
+        authToken: context.authToken,
+        apiUrl,
+        conversationId,
+        runId: parentRunId,
+        toolCallId,
+        form: pendingRequest.request,
+        expiresAt: new Date(Date.now() + INPUT_REQUEST_TIMEOUT_MS).toISOString(),
+      });
+      await execContext?.publishDataEvent?.(buildInputRequestLifecycleDataEvent({
+        action: "created",
+        inputRequest: created,
+      }));
+      return created;
+    },
+    getSnapshot: (created) =>
+      getInputRequest({
+        authToken: context.authToken,
+        apiUrl,
+        conversationId,
+        inputRequestId: created.id,
+      }),
+    resolveSnapshot: (current) => resolveDurableInputRequestResult(context, current),
+  });
+
+  return {
+    ...result,
+    inputRequestId: createdRequest.id,
+  };
+}
+
+function resolveDurableInputRequestResult(
+  context: HostedFormInputToolContext,
+  snapshot: InputRequestOutput,
+): HumanInputResult | undefined {
+  if (snapshot.status === "submitted") {
+    const values = snapshot.latestResponse?.values ?? {};
+
+    if (containsExactArtifactPathValue(values)) {
+      context.slashCommandArtifactPathSeen = true;
+    }
+
+    return {
+      submitted: true,
+      values,
+    };
+  }
+
+  if (snapshot.status === "cancelled" || snapshot.status === "expired") {
+    return {
+      submitted: false,
+      values: {},
+    };
+  }
+
+  return undefined;
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -766,6 +766,10 @@ export {
   createAgUiHandler,
 } from "./ag-ui-handler.ts";
 export {
+  createHostedFormInputTool,
+  type HostedFormInputToolContext,
+} from "./hosted-form-input-tool.ts";
+export {
   buildInputRequestLifecycleDataEvent,
   createInputRequest,
   createInputRequestRequestSchema,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.365";
+export const VERSION = "0.1.366";


### PR DESCRIPTION
## Summary
- add a reusable hosted form_input tool built on the durable human-input and input-request protocol helpers
- export the tool from the public agent surface
- bump the framework patch version for CI/CD release

## Verification
- deno test --no-check --allow-all src/agent/hosted-form-input-tool.test.ts src/agent/input-request-protocol.test.ts src/agent/human-input.test.ts
- deno task verify:quick
- pre-push checks passed: format, lint, typecheck, unit tests

## Failure follow-up
- pre-push initially failed because deno.json was bumped without updating src/utils/version-constant.ts; updated the version constant and reran the failing version/logger tests successfully before amending.