### PR TITLE
Send implementation kinds for external agent runs

### DIFF
--- a/src/agent/conversation-bootstrap.ts
+++ b/src/agent/conversation-bootstrap.ts
@@ -214,7 +214,7 @@ export async function bootstrapConversationAgentRun(input: {
   handoffMessageBody: unknown;
   runId?: string;
   agentId: string;
-  runtimeProviderId?: string | null;
+  implementationKind?: string | null;
   projectId?: string | null;
   branchId?: string | null;
 }): Promise<BootstrapConversationAgentRunResult> {
@@ -245,7 +245,7 @@ export async function bootstrapConversationAgentRun(input: {
     conversationId: conversation.id,
     runId: input.runId,
     agentId: input.agentId,
-    runtimeProviderId: input.runtimeProviderId,
+    implementationKind: input.implementationKind,
     projectId: effectiveProjectId,
     branchId: input.branchId,
   });

--- a/src/agent/conversation-root-run-context.ts
+++ b/src/agent/conversation-root-run-context.ts
@@ -57,7 +57,7 @@ export async function startConversationRootRun(input: {
   projectId?: string | null;
   branchId?: string | null;
   agentId: string;
-  runtimeProviderId?: string | null;
+  implementationKind?: string | null;
   providedRun?: ConversationRootRunDescriptor;
 }): Promise<ConversationRunProjection | null> {
   if (input.providedRun) {
@@ -82,7 +82,7 @@ export async function startConversationRootRun(input: {
     projectId: input.projectId ?? null,
     branchId: input.branchId,
     agentId: input.agentId,
-    runtimeProviderId: input.runtimeProviderId,
+    implementationKind: input.implementationKind,
   });
 }
 
@@ -93,7 +93,7 @@ export function createConversationRootRunStartAdapter(input: {
   projectId?: string | null;
   branchId?: string | null;
   agentId: string;
-  runtimeProviderId?: string | null;
+  implementationKind?: string | null;
   providedRun?: ConversationRootRunDescriptor;
 }): (input: { abortSignal: AbortSignal }) => Promise<{ run: ConversationRunProjection | null }> {
   return async () => ({
@@ -104,7 +104,7 @@ export function createConversationRootRunStartAdapter(input: {
       projectId: input.projectId,
       branchId: input.branchId,
       agentId: input.agentId,
-      runtimeProviderId: input.runtimeProviderId,
+      implementationKind: input.implementationKind,
       providedRun: input.providedRun,
     }),
   });
@@ -117,7 +117,7 @@ export async function prepareConversationRootRunContext(input: {
   projectId?: string | null;
   branchId?: string | null;
   agentId: string;
-  runtimeProviderId?: string | null;
+  implementationKind?: string | null;
   providedRun?: ConversationRootRunDescriptor;
   parentRunId?: string;
   parentMessageId?: string;
@@ -130,7 +130,7 @@ export async function prepareConversationRootRunContext(input: {
     projectId: input.projectId,
     branchId: input.branchId,
     agentId: input.agentId,
-    runtimeProviderId: input.runtimeProviderId,
+    implementationKind: input.implementationKind,
     providedRun: input.providedRun,
   })({ abortSignal: new AbortController().signal });
 

--- a/src/agent/durable.test.ts
+++ b/src/agent/durable.test.ts
@@ -201,7 +201,7 @@ describe("agent/durable", () => {
     );
   });
 
-  it("creates queued generic runtime agent runs when runtimeProviderId is provided", async () => {
+  it("creates queued generic agent runs when implementationKind is provided", async () => {
     const fetchCalls = stubFetchSequence(
       acceptedRunResponse({ run_id: "run_codex_1" }),
       jsonResponse(durableRunProjection({ run_id: "run_codex_1" }), 200),
@@ -213,7 +213,7 @@ describe("agent/durable", () => {
       conversationId: CONVERSATION_ID,
       runId: "run_codex_1",
       agentId: "codex",
-      runtimeProviderId: "codex",
+      implementationKind: "codex",
       projectId: null,
       branchId: null,
     });
@@ -230,7 +230,7 @@ describe("agent/durable", () => {
         request: {
           mode: "agent",
           agent_id: "codex",
-          runtime_provider_id: "codex",
+          implementation_kind: "codex",
           initial_status: "pending",
         },
       },

--- a/src/agent/durable.ts
+++ b/src/agent/durable.ts
@@ -292,7 +292,7 @@ export interface CreateConversationAgentRunInput {
   conversationId: string;
   runId?: string;
   agentId: string;
-  runtimeProviderId?: string | null;
+  implementationKind?: string | null;
   projectId?: string | null;
   branchId?: string | null;
 }
@@ -1255,11 +1255,11 @@ export async function createConversationAgentRun(
   });
   const runId = input.runId ?? `run_${crypto.randomUUID()}`;
 
-  const request = input.runtimeProviderId
+  const request = input.implementationKind
     ? {
       mode: "agent" as const,
       agent_id: input.agentId,
-      runtime_provider_id: input.runtimeProviderId,
+      implementation_kind: input.implementationKind,
       initial_status: "pending" as const,
       ...(targets.sourceTargetKind ? { source_target_kind: targets.sourceTargetKind } : {}),
       ...(targets.runtimeTargetKind ? { runtime_target_kind: targets.runtimeTargetKind } : {}),

--- a/src/agent/hosted-child-bootstrap.test.ts
+++ b/src/agent/hosted-child-bootstrap.test.ts
@@ -165,7 +165,7 @@ describe("agent/hosted-child-bootstrap", () => {
     });
   });
 
-  it("returns the queued child run status for external runtime providers", async () => {
+  it("returns the queued child run status for external agent implementations", async () => {
     const requests: { url: string; body: unknown }[] = [];
     stubFetchWithRecorder(async (input, init) => {
       requests.push({
@@ -216,7 +216,7 @@ describe("agent/hosted-child-bootstrap", () => {
       prompt: "Find the latest logs.",
       runId: "run_child_queued",
       agentId: "invoke-agent-child",
-      runtimeProviderId: "codex",
+      implementationKind: "codex",
       branchId: BRANCH_ID,
     });
 
@@ -231,7 +231,7 @@ describe("agent/hosted-child-bootstrap", () => {
       request: {
         mode: "agent",
         agent_id: "invoke-agent-child",
-        runtime_provider_id: "codex",
+        implementation_kind: "codex",
         initial_status: "pending",
         source_target_kind: "preview_branch",
         runtime_target_kind: "preview_branch",

--- a/src/agent/hosted-child-bootstrap.ts
+++ b/src/agent/hosted-child-bootstrap.ts
@@ -18,7 +18,7 @@ export interface BootstrapHostedChildRunInput extends HostedChildConversationBod
   prompt: string;
   runId?: string;
   agentId: string;
-  runtimeProviderId?: string | null;
+  implementationKind?: string | null;
   branchId?: string | null;
 }
 
@@ -59,7 +59,7 @@ export async function bootstrapHostedChildRun(
     },
     runId: input.runId,
     agentId: input.agentId,
-    runtimeProviderId: input.runtimeProviderId,
+    implementationKind: input.implementationKind,
     projectId: input.runProjectId ?? null,
     branchId: input.branchId,
   });


### PR DESCRIPTION
## Summary
- update veryfront-code agent run creation helpers to send `implementationKind`
- preserve existing runtime target terminology where it refers to project hosting/runtime targets, not connected-agent implementation selection
- update durable and hosted child bootstrap tests

## Verification
- `deno fmt --check` on touched agent files
- focused Deno tests: `deno test --no-check --allow-all --parallel src/agent/durable.test.ts src/agent/hosted-child-bootstrap.test.ts` passed 31 steps
- pre-push checks passed: formatting, lint, typecheck, and full unit suite `1584 passed (17384 steps)`
- `git diff --check`

## Notes
- This is the framework-side contract update needed by downstream agents once the API migration lands.
