### PR TITLE
Release veryfront-code 0.1.368

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.367",
+  "version": "0.1.368",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.367";
+export const VERSION = "0.1.368";


### PR DESCRIPTION
## Summary
- Bump veryfront-code to 0.1.368 for the unified agent worker contract release.
- Keep the static version constant in sync with `deno.json`.

## Verification
- `deno fmt --check deno.json src/utils/version-constant.ts src/utils/version.test.ts src/utils/logger/logger.test.ts`
- `deno test -A src/utils/version.test.ts src/utils/logger/logger.test.ts`
- pre-push hook runs full format, lint, typecheck, and test suite

Constraint: Downstream repos need a published veryfront-code version that includes the agent worker contract changes.
Confidence: high
Scope-risk: narrow
Tested: Focused version/logger checks locally; pre-push full checks on push
