### PR TITLE
Add host-tool fork runtime starter

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.368",
+  "version": "0.1.369",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/fork-runtime-stream.test.ts
+++ b/src/agent/fork-runtime-stream.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertExists } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
+import { z } from "zod";
 import type { AgentResponse, Message as AgentMessage } from "./schemas/index.ts";
 import {
   buildForkRuntimeStepFromResponse,
@@ -7,6 +8,7 @@ import {
   createForkRuntimeStreamMappingState,
   createInitialForkRuntimeMessages,
   createStreamedStepState,
+  type ForkPart,
   type ForkRuntimeStep,
   mapAgUiRuntimeEventToForkParts,
   resolveForkRuntimeContinuationState,
@@ -14,6 +16,7 @@ import {
   type RunAgentRuntimeForkStepInput,
   shouldContinueForkRuntimeStep,
   startAgentRuntimeFork,
+  startAgentRuntimeForkWithHostTools,
 } from "./fork-runtime-stream.ts";
 
 const encoder = new TextEncoder();
@@ -322,6 +325,83 @@ describe("agent/fork-runtime-stream", () => {
       inputTokens: 3,
       outputTokens: 4,
     });
+  });
+
+  it("starts a high-level agent runtime fork from host tool definitions", async () => {
+    const capturedInputs: RunAgentRuntimeForkStepInput[] = [];
+    const traceCalls: string[] = [];
+    const attributes: Record<string, unknown>[] = [];
+    const response: AgentResponse = {
+      text: "Done.",
+      messages: [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          timestamp: 2,
+          parts: [{ type: "text", text: "Done." }],
+        },
+      ],
+      toolCalls: [],
+      status: "completed",
+      usage: {
+        promptTokens: 1,
+        completionTokens: 2,
+        totalTokens: 3,
+      },
+      metadata: { finishReason: "stop" },
+    };
+
+    const { streamResult, forkToolNames } = startAgentRuntimeForkWithHostTools({
+      apiUrl: "https://api.example.com",
+      authToken: "auth-token",
+      projectId: "project-1",
+      provider: "anthropic",
+      forkModel: "anthropic/claude-sonnet-4",
+      maxSteps: 1,
+      prompt: "Do the work.",
+      forkTools: {
+        create_file: {
+          description: "Create a file.",
+          inputSchema: z.object({ path: z.string() }),
+          execute: () => ({ ok: true }),
+        },
+      },
+      traceTools: {
+        trace: (spanName, operation) => {
+          traceCalls.push(spanName);
+          return operation();
+        },
+        buildAttributes: ({ toolName, toolCallId }) => ({ toolName, toolCallId }),
+        setAttributes: (nextAttributes) => {
+          attributes.push(nextAttributes);
+        },
+      },
+      runStep: async (input) => {
+        capturedInputs.push(input);
+        const createFileTool = input.runtimeTools.create_file;
+        if (createFileTool && typeof createFileTool !== "boolean") {
+          await createFileTool.execute({ path: "artifact.md" }, { toolCallId: "tool-call-1" });
+        }
+
+        return {
+          stream: createRuntimeEventStream([{ type: "text-delta", delta: "Done." }]),
+          responsePromise: Promise.resolve(response),
+        };
+      },
+      buildInstructions: () => "Base instructions.",
+    });
+
+    const parts: ForkPart[] = [];
+    for await (const part of streamResult.fullStream) {
+      parts.push(part);
+    }
+
+    assertEquals(forkToolNames, ["create_file", "web_fetch", "web_search"]);
+    assertEquals(capturedInputs[0]?.forkToolNames, forkToolNames);
+    assertEquals(Object.keys(capturedInputs[0]?.runtimeTools ?? {}), ["create_file"]);
+    assertEquals(traceCalls, ["tool.create_file"]);
+    assertEquals(attributes, [{ toolName: "create_file", toolCallId: "tool-call-1" }]);
+    assertEquals(parts, [{ type: "text-delta", text: "Done." }]);
   });
 
   it("continues a high-level agent runtime fork when the continuation resolver returns a prompt", async () => {

--- a/src/agent/fork-runtime-stream.ts
+++ b/src/agent/fork-runtime-stream.ts
@@ -1,4 +1,10 @@
-import type { Tool } from "#veryfront/tool";
+import {
+  createToolsFromHostDefinitions,
+  type HostToolSet,
+  type Tool,
+  traceHostTools,
+  type TraceHostToolsOptions,
+} from "#veryfront/tool";
 import { isRecord } from "../chat/conversation.ts";
 import { safeJsonParse } from "../chat/provider-errors.ts";
 import { runWithVeryfrontCloudContextAsync } from "../provider/veryfront-cloud/context.ts";
@@ -13,6 +19,7 @@ import {
   HOSTED_CHILD_STREAM_TIMEOUT_TOKEN,
   resolveHostedChildPromiseWithTimeout,
 } from "./hosted-child-stream-watchdog.ts";
+import { getForkRuntimeAllowedToolNames } from "./provider-native-tool-inventory.ts";
 import { AgentRuntime } from "./runtime/index.ts";
 import type { AgentResponse, Message as AgentMessage } from "./schemas/index.ts";
 
@@ -199,6 +206,59 @@ export type StartAgentRuntimeForkInput = {
   prepareStep?: ForkRuntimeStepPreparer;
   runStep?: AgentRuntimeForkStepRunner;
 };
+
+export type StartAgentRuntimeForkWithHostToolsInput =
+  & Omit<
+    StartAgentRuntimeForkInput,
+    "forkToolNames" | "model" | "runtimeTools"
+  >
+  & {
+    provider: string;
+    forkModel: string;
+    forkTools: HostToolSet;
+    traceTools?: TraceHostToolsOptions;
+  };
+
+export function startAgentRuntimeForkWithHostTools(
+  input: StartAgentRuntimeForkWithHostToolsInput,
+): {
+  streamResult: ForkRuntimeStreamResult;
+  forkToolNames: string[];
+} {
+  const forkTools = input.traceTools
+    ? traceHostTools(input.forkTools, input.traceTools)
+    : input.forkTools;
+  const runtimeTools = createToolsFromHostDefinitions(forkTools);
+  const forkToolNames = getForkRuntimeAllowedToolNames({
+    provider: input.provider,
+    forkModel: input.forkModel,
+    forkTools: input.forkTools,
+  });
+
+  return {
+    streamResult: startAgentRuntimeFork({
+      apiUrl: input.apiUrl,
+      authToken: input.authToken,
+      projectId: input.projectId,
+      model: input.forkModel,
+      maxSteps: input.maxSteps,
+      prompt: input.prompt,
+      maxContinuationSteps: input.maxContinuationSteps,
+      abortSignal: input.abortSignal,
+      forkToolNames,
+      runtimeTools,
+      providerOptions: input.providerOptions,
+      buildInstructions: input.buildInstructions,
+      onBeforeStop: input.onBeforeStop,
+      initialMessages: input.initialMessages,
+      responseTimeoutMs: input.responseTimeoutMs,
+      logger: input.logger,
+      prepareStep: input.prepareStep,
+      runStep: input.runStep,
+    }),
+    forkToolNames,
+  };
+}
 
 function createForkRuntimeDeferred<T>(): {
   promise: Promise<T>;

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -314,6 +314,8 @@ export {
   shouldContinueForkRuntimeStep,
   startAgentRuntimeFork,
   type StartAgentRuntimeForkInput,
+  startAgentRuntimeForkWithHostTools,
+  type StartAgentRuntimeForkWithHostToolsInput,
 } from "./fork-runtime-stream.ts";
 export {
   executeHostedChildForkStream,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.368";
+export const VERSION = "0.1.369";


### PR DESCRIPTION
## Summary\n- adds a framework-owned helper for starting agent runtime forks from host tool definitions\n- centralizes host-tool tracing, materialization, and provider-native fork tool allowlist expansion\n- patch-bumps the package to 0.1.369 for CI/CD publication\n\n## Verification\n- deno test --no-check --allow-all src/agent/fork-runtime-stream.test.ts src/agent/provider-native-tool-inventory.test.ts\n- deno check src/agent/fork-runtime-stream.ts src/agent/index.ts\n- deno test --no-check --allow-all --unstable-worker-options --parallel '--ignore=tests,src/workflow/__tests__,cli/commands/*.integration.test.ts,extensions'\n\nNote: the broader documented unit command without excluding extensions currently discovers extensions/ext-tailwind/src/dynamic-esm-import.integration.test.ts, which imports a missing extensions/ext-tailwind/_helpers/contract-init.ts. This PR's broadened run excludes extensions/ to avoid that unrelated workspace test discovery issue.\n