### PR TITLE
fix(agent): preserve host-tool trace attribute types

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.369",
+  "version": "0.1.370",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/fork-runtime-stream.test.ts
+++ b/src/agent/fork-runtime-stream.test.ts
@@ -17,6 +17,7 @@ import {
   shouldContinueForkRuntimeStep,
   startAgentRuntimeFork,
   startAgentRuntimeForkWithHostTools,
+  type StartAgentRuntimeForkWithHostToolsInput,
 } from "./fork-runtime-stream.ts";
 
 const encoder = new TextEncoder();
@@ -402,6 +403,35 @@ describe("agent/fork-runtime-stream", () => {
     assertEquals(traceCalls, ["tool.create_file"]);
     assertEquals(attributes, [{ toolName: "create_file", toolCallId: "tool-call-1" }]);
     assertEquals(parts, [{ type: "text-delta", text: "Done." }]);
+  });
+
+  it("preserves typed trace attributes for high-level host-tool forks", () => {
+    type NarrowTraceAttributes = {
+      toolName: string;
+      toolCallId: string | undefined;
+    };
+    const attributeNames: string[] = [];
+    const input: StartAgentRuntimeForkWithHostToolsInput<NarrowTraceAttributes> = {
+      apiUrl: "https://api.example.com",
+      authToken: "auth-token",
+      projectId: "project-1",
+      provider: "anthropic",
+      forkModel: "anthropic/claude-sonnet-4",
+      maxSteps: 1,
+      forkTools: {},
+      buildInstructions: () => "Base instructions.",
+      traceTools: {
+        trace: (_spanName, operation) => operation(),
+        buildAttributes: ({ toolName, toolCallId }) => ({ toolName, toolCallId }),
+        setAttributes: (attributes) => {
+          attributeNames.push(attributes.toolName);
+        },
+      },
+    };
+
+    input.traceTools?.setAttributes?.({ toolName: "create_file", toolCallId: undefined });
+
+    assertEquals(attributeNames, ["create_file"]);
   });
 
   it("continues a high-level agent runtime fork when the continuation resolver returns a prompt", async () => {

--- a/src/agent/fork-runtime-stream.ts
+++ b/src/agent/fork-runtime-stream.ts
@@ -1,6 +1,7 @@
 import {
   createToolsFromHostDefinitions,
   type HostToolSet,
+  type HostToolTraceAttributes,
   type Tool,
   traceHostTools,
   type TraceHostToolsOptions,
@@ -207,7 +208,9 @@ export type StartAgentRuntimeForkInput = {
   runStep?: AgentRuntimeForkStepRunner;
 };
 
-export type StartAgentRuntimeForkWithHostToolsInput =
+export type StartAgentRuntimeForkWithHostToolsInput<
+  TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
+> =
   & Omit<
     StartAgentRuntimeForkInput,
     "forkToolNames" | "model" | "runtimeTools"
@@ -216,11 +219,13 @@ export type StartAgentRuntimeForkWithHostToolsInput =
     provider: string;
     forkModel: string;
     forkTools: HostToolSet;
-    traceTools?: TraceHostToolsOptions;
+    traceTools?: TraceHostToolsOptions<TAttributes>;
   };
 
-export function startAgentRuntimeForkWithHostTools(
-  input: StartAgentRuntimeForkWithHostToolsInput,
+export function startAgentRuntimeForkWithHostTools<
+  TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
+>(
+  input: StartAgentRuntimeForkWithHostToolsInput<TAttributes>,
 ): {
   streamResult: ForkRuntimeStreamResult;
   forkToolNames: string[];

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.369";
+export const VERSION = "0.1.370";


### PR DESCRIPTION
## Summary
- Make `StartAgentRuntimeForkWithHostToolsInput` generic over host-tool trace attributes
- Preserve typed `traceTools` callbacks when callers provide narrower attribute records
- Bump package version to `0.1.370` for CI/CD publication

## Verification
- RED: `deno check src/agent/fork-runtime-stream.test.ts` failed because `StartAgentRuntimeForkWithHostToolsInput` was not generic
- `deno fmt --check src/agent/fork-runtime-stream.ts src/agent/fork-runtime-stream.test.ts deno.json src/utils/version-constant.ts`
- `deno lint src/agent/fork-runtime-stream.ts src/agent/fork-runtime-stream.test.ts`
- `deno check src/agent/fork-runtime-stream.ts src/agent/fork-runtime-stream.test.ts`
- `deno test --no-check --allow-all src/agent/fork-runtime-stream.test.ts src/agent/provider-native-tool-inventory.test.ts`
- `deno test --no-check --allow-all --unstable-worker-options --parallel --ignore=tests,src/workflow/__tests__,cli/commands/*.integration.test.ts,extensions`
- pre-push checks passed: format, lint, typecheck, unit tests

## Note
- `deno task verify` still fails while collecting `extensions/ext-tailwind/src/dynamic-esm-import.integration.test.ts` because `extensions/ext-tailwind/_helpers/contract-init.ts` is missing in this checkout. The scoped non-extension verification above is green.