### PR TITLE
refactor(agent): add hosted child fork runtime starter

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.370",
+  "version": "0.1.371",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-fork-runtime-start.test.ts
+++ b/src/agent/hosted-child-fork-runtime-start.test.ts
@@ -1,0 +1,108 @@
+import { assertEquals, assertInstanceOf } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { AgentResponse } from "./schemas/index.ts";
+import {
+  startHostedChildForkRuntimeWithHostTools,
+  type StartHostedChildForkRuntimeWithHostToolsInput,
+} from "./hosted-child-fork-runtime-start.ts";
+import {
+  HostedChildTerminalStateError,
+  type MonitorHostedChildRunStatusInput,
+} from "./hosted-child-status.ts";
+
+function createRuntimeEventStream(
+  events: readonly Record<string, unknown>[],
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+      }
+      controller.close();
+    },
+  });
+}
+
+function createResponse(): AgentResponse {
+  return {
+    text: "Done.",
+    messages: [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        timestamp: 2,
+        parts: [{ type: "text", text: "Done." }],
+      },
+    ],
+    toolCalls: [],
+    status: "completed",
+    metadata: { finishReason: "stop" },
+  };
+}
+
+function createStartInput(
+  overrides: Partial<StartHostedChildForkRuntimeWithHostToolsInput> = {},
+): StartHostedChildForkRuntimeWithHostToolsInput {
+  return {
+    apiUrl: "https://api.example.com",
+    authToken: "auth-token",
+    projectId: "project-1",
+    provider: "anthropic",
+    forkModel: "anthropic/claude-sonnet-4",
+    maxSteps: 1,
+    prompt: "Do the work.",
+    forkTools: {},
+    buildInstructions: () => "Base instructions.",
+    runStep: async () => ({
+      stream: createRuntimeEventStream([{ type: "text-delta", delta: "Done." }]),
+      responsePromise: Promise.resolve(createResponse()),
+    }),
+    ...overrides,
+  };
+}
+
+describe("agent/hosted-child-fork-runtime-start", () => {
+  it("starts a fork runtime without a durable child monitor", async () => {
+    const started = startHostedChildForkRuntimeWithHostTools(createStartInput());
+
+    assertEquals(started.childRunMonitorAbortController, null);
+    await started.childRunMonitorPromise;
+
+    const parts = [];
+    for await (const part of started.streamResult.fullStream) {
+      parts.push(part);
+    }
+
+    assertEquals(parts, [{ type: "text-delta", text: "Done." }]);
+  });
+
+  it("starts a durable child monitor that aborts the fork stream on terminal child state", async () => {
+    const monitorCalls: MonitorHostedChildRunStatusInput[] = [];
+    const started = startHostedChildForkRuntimeWithHostTools(
+      createStartInput({
+        durableChildRun: {
+          childConversationId: "conversation-child",
+          childRunId: "run-child",
+          childMessageId: "message-child",
+          latestEventId: 1,
+          latestExternalEventSequence: 2,
+        },
+        childRunMonitorPollIntervalMs: 25,
+        monitorChildRunStatus: async (input) => {
+          monitorCalls.push(input);
+          input.onTerminal(new HostedChildTerminalStateError("cancelled", input.identifiers));
+        },
+      }),
+    );
+
+    await started.childRunMonitorPromise;
+
+    assertInstanceOf(started.childRunMonitorAbortController, AbortController);
+    assertEquals(monitorCalls.length, 1);
+    assertEquals(monitorCalls[0]?.abortSignal?.aborted, false);
+    assertEquals(started.forkStreamAbortController.signal.aborted, true);
+    assertEquals(started.forkStreamAbortController.signal.reason instanceof Error, true);
+  });
+});

--- a/src/agent/hosted-child-fork-runtime-start.ts
+++ b/src/agent/hosted-child-fork-runtime-start.ts
@@ -1,0 +1,84 @@
+import type { HostToolTraceAttributes } from "#veryfront/tool";
+import {
+  type ForkRuntimeStreamResult,
+  startAgentRuntimeForkWithHostTools,
+  type StartAgentRuntimeForkWithHostToolsInput,
+} from "./fork-runtime-stream.ts";
+import {
+  type HostedChildRunIdentifiers,
+  monitorHostedChildRunStatus,
+  type MonitorHostedChildRunStatusInput,
+} from "./hosted-child-status.ts";
+import { composeAbortSignals } from "./hosted-child-stream-watchdog.ts";
+
+export type HostedChildRunStatusMonitor = (
+  input: MonitorHostedChildRunStatusInput,
+) => Promise<void>;
+
+export type StartHostedChildForkRuntimeWithHostToolsInput<
+  TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
+> = StartAgentRuntimeForkWithHostToolsInput<TAttributes> & {
+  durableChildRun?: HostedChildRunIdentifiers;
+  childRunMonitorPollIntervalMs?: number;
+  monitorChildRunStatus?: HostedChildRunStatusMonitor;
+};
+
+export interface StartedHostedChildForkRuntime {
+  forkStreamAbortController: AbortController;
+  childRunMonitorAbortController: AbortController | null;
+  childRunMonitorPromise: Promise<void>;
+  streamResult: ForkRuntimeStreamResult;
+  forkToolNames: string[];
+}
+
+export function startHostedChildForkRuntimeWithHostTools<
+  TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
+>(
+  input: StartHostedChildForkRuntimeWithHostToolsInput<TAttributes>,
+): StartedHostedChildForkRuntime {
+  const {
+    durableChildRun,
+    childRunMonitorPollIntervalMs,
+    monitorChildRunStatus,
+    abortSignal,
+    ...runtimeInput
+  } = input;
+  const forkStreamAbortController = new AbortController();
+  const forkStreamAbortSignal = composeAbortSignals([
+    abortSignal,
+    forkStreamAbortController.signal,
+  ]);
+
+  const childRunMonitorAbortController = durableChildRun ? new AbortController() : null;
+  const childRunMonitorSignal = childRunMonitorAbortController
+    ? composeAbortSignals([abortSignal, childRunMonitorAbortController.signal])
+    : undefined;
+  const monitor = monitorChildRunStatus ?? monitorHostedChildRunStatus;
+  const childRunMonitorPromise = durableChildRun
+    ? monitor({
+      authToken: runtimeInput.authToken,
+      apiUrl: runtimeInput.apiUrl,
+      identifiers: durableChildRun,
+      abortSignal: childRunMonitorSignal,
+      pollIntervalMs: childRunMonitorPollIntervalMs ?? 2_000,
+      onTerminal: (error) => {
+        if (!forkStreamAbortController.signal.aborted) {
+          forkStreamAbortController.abort(error);
+        }
+      },
+    })
+    : Promise.resolve();
+
+  const { streamResult, forkToolNames } = startAgentRuntimeForkWithHostTools({
+    ...runtimeInput,
+    abortSignal: forkStreamAbortSignal,
+  });
+
+  return {
+    forkStreamAbortController,
+    childRunMonitorAbortController,
+    childRunMonitorPromise,
+    streamResult,
+    forkToolNames,
+  };
+}

--- a/src/agent/hosted-child-status.ts
+++ b/src/agent/hosted-child-status.ts
@@ -90,14 +90,18 @@ function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
 }
 
-export async function monitorHostedChildRunStatus(input: {
+export interface MonitorHostedChildRunStatusInput {
   authToken: string;
   apiUrl: string;
   identifiers: HostedChildRunIdentifiers;
   abortSignal?: AbortSignal;
   pollIntervalMs: number;
   onTerminal: (error: HostedChildTerminalStateError) => void;
-}): Promise<void> {
+}
+
+export async function monitorHostedChildRunStatus(
+  input: MonitorHostedChildRunStatusInput,
+): Promise<void> {
   while (!input.abortSignal?.aborted) {
     await waitForHostedChildStatusPoll(input.pollIntervalMs, input.abortSignal);
     if (input.abortSignal?.aborted) {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -656,6 +656,12 @@ export {
   toMirroredHostedStreamPart,
 } from "./hosted-child-mirror.ts";
 export {
+  type HostedChildRunStatusMonitor,
+  type StartedHostedChildForkRuntime,
+  startHostedChildForkRuntimeWithHostTools,
+  type StartHostedChildForkRuntimeWithHostToolsInput,
+} from "./hosted-child-fork-runtime-start.ts";
+export {
   type HostedChildRunIdentifiers,
   type HostedChildTerminalErrorCode,
   hostedChildTerminalErrorCodes,
@@ -663,6 +669,7 @@ export {
   type HostedChildTerminalStatus,
   isHostedChildTerminalErrorCode,
   monitorHostedChildRunStatus,
+  type MonitorHostedChildRunStatusInput,
   resolveHostedChildTerminalErrorCode,
 } from "./hosted-child-status.ts";
 export {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.370";
+export const VERSION = "0.1.371";


### PR DESCRIPTION
## Summary
- add a reusable hosted child fork runtime starter that composes fork cancellation, optional durable child status monitoring, and host-tool fork startup
- export the child status monitor input type for injectable monitors and tests
- bump framework package version to 0.1.371

## Verification
- deno fmt --check src/agent/hosted-child-fork-runtime-start.ts src/agent/hosted-child-fork-runtime-start.test.ts src/agent/hosted-child-status.ts src/agent/index.ts deno.json src/utils/version-constant.ts
- deno lint src/agent/hosted-child-fork-runtime-start.ts src/agent/hosted-child-fork-runtime-start.test.ts src/agent/hosted-child-status.ts src/agent/index.ts
- deno check src/agent/hosted-child-fork-runtime-start.ts src/agent/hosted-child-fork-runtime-start.test.ts src/agent/index.ts
- deno test --no-check --allow-all src/agent/hosted-child-fork-runtime-start.test.ts src/agent/fork-runtime-stream.test.ts src/agent/hosted-child-status.test.ts
- deno task verify:quick
- deno task test:unit
