### PR TITLE
ci: retry chromium dependency install

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -73,7 +73,12 @@ jobs:
       - name: Force apt to IPv4
         run: echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
       - name: Install Chromium
-        run: deno run -A npm:playwright install --with-deps chromium
+        uses: nick-fields/retry@v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 20
+          command: deno run -A npm:playwright install --with-deps chromium
       - uses: nick-fields/retry@v4.0.0
         with:
           timeout_minutes: 10
@@ -97,7 +102,12 @@ jobs:
       - name: Force apt to IPv4
         run: echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
       - name: Install Chromium
-        run: deno run -A npm:playwright install --with-deps chromium
+        uses: nick-fields/retry@v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 20
+          command: deno run -A npm:playwright install --with-deps chromium
       - uses: nick-fields/retry@v4.0.0
         with:
           timeout_minutes: 15


### PR DESCRIPTION
## Summary
- wrap Chromium dependency installation in the existing retry action for both browser e2e jobs
- keep the IPv4 apt configuration and test retry behavior unchanged

## Root cause
The failing main run died before tests executed, during `playwright install --with-deps chromium`, because Ubuntu package indexes/dependencies intermittently timed out or had mirror sync errors. The install step itself had no retry wrapper while the test commands already did.

## Verification
- git diff --check
- ruby -e 'require "psych"; Psych.load_file(".github/workflows/cicd.yml"); puts "workflow yaml ok"'
- pre-push checks: format, lint, typecheck, unit tests
