### PR TITLE
feat(agent): add hosted child fork tool selection helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.371",
+  "version": "0.1.372",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-fork-tool-selection.test.ts
+++ b/src/agent/hosted-child-fork-tool-selection.test.ts
@@ -1,0 +1,82 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import type { HostToolDefinition, HostToolSet } from "#veryfront/tool";
+import { selectHostedChildForkRuntimeTools } from "./hosted-child-requested-tools.ts";
+
+const createFileTool: HostToolDefinition = {
+  description: "Create a file",
+  parameters: { type: "object", properties: {} },
+};
+const updateFileTool: HostToolDefinition = {
+  description: "Update a file",
+  parameters: { type: "object", properties: {} },
+};
+const bashTool: HostToolDefinition = {
+  description: "Run shell",
+  parameters: { type: "object", properties: {} },
+};
+const forkTools: HostToolSet = {
+  create_file: createFileTool,
+  update_file: updateFileTool,
+  bash: bashTool,
+};
+
+Deno.test("selectHostedChildForkRuntimeTools returns all fork tools when no requested tools are provided", () => {
+  const result = selectHostedChildForkRuntimeTools({
+    provider: "openai",
+    forkModel: "openai/gpt-5.4",
+    forkTools,
+  });
+
+  assertEquals(result, {
+    ok: true,
+    forkTools,
+  });
+});
+
+Deno.test("selectHostedChildForkRuntimeTools narrows fork tools to requested runtime tools", () => {
+  const result = selectHostedChildForkRuntimeTools({
+    provider: "openai",
+    forkModel: "openai/gpt-5.4",
+    forkTools,
+    requestedTools: ["update_file", "bash"],
+  });
+
+  assertEquals(result, {
+    ok: true,
+    forkTools: {
+      update_file: updateFileTool,
+      bash: bashTool,
+    },
+  });
+});
+
+Deno.test("selectHostedChildForkRuntimeTools accepts provider-native requested tool names", () => {
+  const result = selectHostedChildForkRuntimeTools({
+    provider: "anthropic",
+    forkModel: "anthropic/claude-sonnet-4.5",
+    forkTools,
+    requestedTools: ["web_search", "create_file"],
+  });
+
+  assertEquals(result, {
+    ok: true,
+    forkTools: {
+      create_file: createFileTool,
+    },
+  });
+});
+
+Deno.test("selectHostedChildForkRuntimeTools reports requested tools unavailable to the runtime", () => {
+  const result = selectHostedChildForkRuntimeTools({
+    provider: "openai",
+    forkModel: "openai/gpt-5.4",
+    forkTools,
+    requestedTools: ["missing_tool"],
+  });
+
+  assertEquals(result, {
+    ok: false,
+    errorMessage:
+      "Requested fork tools not available in runtime: missing_tool. Available: bash, create_file, update_file.",
+  });
+});

--- a/src/agent/hosted-child-requested-tools.ts
+++ b/src/agent/hosted-child-requested-tools.ts
@@ -1,3 +1,7 @@
+import type { HostToolSet } from "#veryfront/tool";
+
+import { getForkRuntimeAllowedToolNames } from "./provider-native-tool-inventory.ts";
+
 export interface HostedChildRequestedToolsInput {
   prompt: string;
   requestedTools?: readonly string[];
@@ -107,6 +111,62 @@ export function shouldPruneSandboxToolsFromHostedChildRequest(input: {
   }
 
   return !matchesSandboxRequiredCue(input.sandboxRequiredCuePattern, input.prompt);
+}
+
+export type HostedChildForkRuntimeToolSelectionResult =
+  | {
+    ok: true;
+    forkTools: HostToolSet;
+  }
+  | {
+    ok: false;
+    errorMessage: string;
+  };
+
+export function selectHostedChildForkRuntimeTools(input: {
+  provider: string;
+  forkModel?: string;
+  forkTools: HostToolSet;
+  requestedTools?: readonly string[];
+}): HostedChildForkRuntimeToolSelectionResult {
+  if (!input.requestedTools?.length) {
+    return {
+      ok: true,
+      forkTools: input.forkTools,
+    };
+  }
+
+  const availableNames = new Set(
+    getForkRuntimeAllowedToolNames({
+      provider: input.provider,
+      forkModel: input.forkModel,
+      forkTools: input.forkTools,
+    }),
+  );
+  const unavailableRequested = input.requestedTools.filter((toolName) =>
+    !availableNames.has(toolName)
+  );
+  if (unavailableRequested.length > 0) {
+    return {
+      ok: false,
+      errorMessage: `Requested fork tools not available in runtime: ${
+        unavailableRequested.join(", ")
+      }. Available: ${[...availableNames].sort().join(", ")}.`,
+    };
+  }
+
+  const allowedSet = new Set(input.requestedTools);
+  const forkTools: HostToolSet = {};
+  for (const [toolName, toolDefinition] of Object.entries(input.forkTools)) {
+    if (allowedSet.has(toolName)) {
+      forkTools[toolName] = toolDefinition;
+    }
+  }
+
+  return {
+    ok: true,
+    forkTools,
+  };
 }
 
 export function buildHostedChildToolDescription(): string {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -460,8 +460,10 @@ export {
 export {
   buildHostedChildToolDescription,
   expandHostedChildRequestedTools,
+  type HostedChildForkRuntimeToolSelectionResult,
   type HostedChildRequestedToolsInput,
   sanitizeHostedChildRequestedTools,
+  selectHostedChildForkRuntimeTools,
   shouldPruneSandboxToolsFromHostedChildRequest,
 } from "./hosted-child-requested-tools.ts";
 export {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.371";
+export const VERSION = "0.1.372";


### PR DESCRIPTION
## Summary
- add a framework helper for selecting requested hosted child fork runtime tools
- keep provider-native tool names in the runtime availability check
- bump package version to `0.1.372` for CI/CD release

## Verification
- `deno test --no-check --allow-all src/agent/hosted-child-fork-tool-selection.test.ts src/agent/hosted-child-requested-tools.test.ts src/agent/provider-native-tool-inventory.test.ts`
- `deno task verify:quick`
- pre-push checks: fmt, lint, typecheck, `deno task test:unit`