### PR TITLE
Fix deep import violation in prompt/factory.ts

### DIFF
--- a/src/prompt/factory.ts
+++ b/src/prompt/factory.ts
@@ -1,6 +1,6 @@
 import type { Prompt, PromptConfig } from "./types.ts";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
-import { COMMON_BLOCKED_PATTERNS } from "../agent/middleware/security/validator.ts";
+import { COMMON_BLOCKED_PATTERNS } from "#veryfront/agent/middleware/index.ts";
 
 type PromptGenerateFn = (variables: Record<string, unknown>) => string | Promise<string>;
 


### PR DESCRIPTION
## Summary
- Change `src/prompt/factory.ts` to import `COMMON_BLOCKED_PATTERNS` from barrel `#veryfront/agent/middleware/index.ts` instead of deep relative path `../agent/middleware/security/validator.ts`
- The symbol was already exported from the barrel file

## Test plan
- [x] `deno task lint:ban-deep-imports` — 0 violations
- [x] `deno task typecheck` — passes