### PR TITLE
Fix 6 broken documentation links in READMEs

### DIFF
--- a/src/build/README.md
+++ b/src/build/README.md
@@ -227,8 +227,8 @@ deno task test src/build/compiler/
 
 - [`server/`](../server/README.md) - Development server
 - [`rendering/`](../rendering/README.md) - SSR/RSC rendering
-- [`transforms/`](./transforms/README.md) - Code transforms
-- [`cli/`](../cli/README.md) - CLI commands
+- [`transforms/`](../transforms/README.md) - Code transforms
+- [`cli/`](../../cli/README.md) - CLI commands
 
 ## Troubleshooting
 

--- a/src/errors/README.md
+++ b/src/errors/README.md
@@ -286,8 +286,8 @@ export const MY_ERROR = defineError({
 
 ## Related Modules
 
-- [`observability/`](../../observability/README.md) - Error logging and tracing
-- [`server/`](../../server/README.md) - HTTP error responses
+- [`observability/`](../observability/README.md) - Error logging and tracing
+- [`server/`](../server/README.md) - HTTP error responses
 
 ## References
 

--- a/src/modules/README.md
+++ b/src/modules/README.md
@@ -298,7 +298,7 @@ deno task test src/modules/react-loader/
 - [`rendering/`](../rendering/README.md) - Uses modules for component loading
 - [`build/`](../build/README.md) - Bundles modules for production
 - [`platform/`](../platform/README.md) - File system access
-- [`core/config/`](../core/README.md) - Configuration management
+- [`config/`](../config/README.md) - Configuration management
 
 ## Troubleshooting
 

--- a/src/react/README.md
+++ b/src/react/README.md
@@ -338,7 +338,7 @@ deno task test src/react/compat/ssr-adapter/
 - [`components/`](./components/README.md) - Framework components details
 - [`html/`](../html/README.md) - HTML document generation
 - [`rendering/`](../rendering/README.md) - Page rendering engine
-- [`module-system/`](../module-system/README.md) - Component loading
+- [`modules/`](../modules/README.md) - Component loading
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Fix relative paths in `src/build/README.md`, `src/react/README.md`, `src/modules/README.md`, `src/errors/README.md`
- Issues were wrong directory depths and renamed directories (module-system→modules, core→config)

## Test plan
- [x] `deno task docs:check-links` — "All 39 doc links OK"