### PR TITLE
feat(agent): add project context switch helpers

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -63,22 +63,37 @@ jobs:
 
   tests-e2e-rsc-browser:
     runs-on: veryfront-k8s-runners
-    timeout-minutes: 15
+    timeout-minutes: 25
     name: tests (rsc browser e2e)
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-deno
         with:
           warm-cache: "true"
-      - name: Force apt to IPv4
-        run: echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
+      - name: Configure apt retries
+        run: |
+          {
+            echo 'Acquire::ForceIPv4 "true";'
+            echo 'Acquire::Retries "5";'
+            echo 'Acquire::http::Timeout "30";'
+            echo 'Acquire::https::Timeout "30";'
+          } | sudo tee /etc/apt/apt.conf.d/99veryfront-ci-retries
       - name: Install Chromium
-        uses: nick-fields/retry@v4.0.0
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 20
-          command: deno run -A npm:playwright install --with-deps chromium
+        run: |
+          for attempt in 1 2 3; do
+            if deno run -A npm:playwright install --with-deps chromium; then
+              exit 0
+            fi
+
+            status=$?
+            if [ "$attempt" -eq 3 ]; then
+              exit "$status"
+            fi
+
+            sudo apt-get clean
+            sudo rm -rf /var/lib/apt/lists/*
+            sleep $((attempt * 20))
+          done
       - uses: nick-fields/retry@v4.0.0
         with:
           timeout_minutes: 10
@@ -92,22 +107,37 @@ jobs:
 
   tests-binary-e2e:
     runs-on: veryfront-k8s-runners
-    timeout-minutes: 20
+    timeout-minutes: 35
     name: tests (binary e2e)
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-deno
         with:
           warm-cache: "true"
-      - name: Force apt to IPv4
-        run: echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
+      - name: Configure apt retries
+        run: |
+          {
+            echo 'Acquire::ForceIPv4 "true";'
+            echo 'Acquire::Retries "5";'
+            echo 'Acquire::http::Timeout "30";'
+            echo 'Acquire::https::Timeout "30";'
+          } | sudo tee /etc/apt/apt.conf.d/99veryfront-ci-retries
       - name: Install Chromium
-        uses: nick-fields/retry@v4.0.0
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 20
-          command: deno run -A npm:playwright install --with-deps chromium
+        run: |
+          for attempt in 1 2 3; do
+            if deno run -A npm:playwright install --with-deps chromium; then
+              exit 0
+            fi
+
+            status=$?
+            if [ "$attempt" -eq 3 ]; then
+              exit "$status"
+            fi
+
+            sudo apt-get clean
+            sudo rm -rf /var/lib/apt/lists/*
+            sleep $((attempt * 20))
+          done
       - uses: nick-fields/retry@v4.0.0
         with:
           timeout_minutes: 15

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -72,6 +72,10 @@ jobs:
           warm-cache: "true"
       - name: Configure apt retries
         run: |
+          sudo sed -i \
+            -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+            -e 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+            /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
           {
             echo 'Acquire::ForceIPv4 "true";'
             echo 'Acquire::Retries "5";'
@@ -116,6 +120,10 @@ jobs:
           warm-cache: "true"
       - name: Configure apt retries
         run: |
+          sudo sed -i \
+            -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+            -e 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+            /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
           {
             echo 'Acquire::ForceIPv4 "true";'
             echo 'Acquire::Retries "5";'

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.372",
+  "version": "0.1.373",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -110,6 +110,11 @@ export type {
   ToolResultPart,
 } from "./types.ts";
 
+export {
+  applyAgentProjectContextChange,
+  getConfirmedProjectContextSwitchId,
+  type MutableAgentProjectContext,
+} from "./project-context.ts";
 export { getTextFromParts, getToolArguments, hasArgs, hasInput } from "./types.ts";
 
 export {

--- a/src/agent/project-context.test.ts
+++ b/src/agent/project-context.test.ts
@@ -1,0 +1,83 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import {
+  applyAgentProjectContextChange,
+  getConfirmedProjectContextSwitchId,
+  type MutableAgentProjectContext,
+} from "./project-context.ts";
+
+Deno.test("applyAgentProjectContextChange updates project and resets branch and skill context", () => {
+  const context: MutableAgentProjectContext & { steeringRevision: number } = {
+    projectId: "project-1",
+    branchId: "branch-1",
+    availableSkillIds: ["skill-a"],
+    steeringRevision: 3,
+  };
+
+  const changed = applyAgentProjectContextChange(context, "project-2");
+
+  assertEquals(changed, true);
+  assertEquals(context, {
+    projectId: "project-2",
+    branchId: null,
+    availableSkillIds: undefined,
+    steeringRevision: 3,
+  });
+});
+
+Deno.test("applyAgentProjectContextChange leaves context unchanged when project is already active", () => {
+  const context: MutableAgentProjectContext = {
+    projectId: "project-1",
+    branchId: "branch-1",
+    availableSkillIds: ["skill-a"],
+  };
+
+  const changed = applyAgentProjectContextChange(context, "project-1");
+
+  assertEquals(changed, false);
+  assertEquals(context, {
+    projectId: "project-1",
+    branchId: "branch-1",
+    availableSkillIds: ["skill-a"],
+  });
+});
+
+Deno.test("getConfirmedProjectContextSwitchId reads matching successful structured content", () => {
+  assertEquals(
+    getConfirmedProjectContextSwitchId(
+      {
+        structuredContent: {
+          success: true,
+          project_id: "project-2",
+        },
+      },
+      "project-2",
+    ),
+    "project-2",
+  );
+});
+
+Deno.test("getConfirmedProjectContextSwitchId reads matching successful direct content", () => {
+  assertEquals(
+    getConfirmedProjectContextSwitchId(
+      {
+        success: true,
+        project_id: "project-2",
+      },
+      "project-2",
+    ),
+    "project-2",
+  );
+});
+
+Deno.test("getConfirmedProjectContextSwitchId ignores failed, missing, or mismatched content", () => {
+  assertEquals(
+    getConfirmedProjectContextSwitchId({ success: false, project_id: "project-2" }, "project-2"),
+    null,
+  );
+  assertEquals(getConfirmedProjectContextSwitchId({ success: true }, "project-2"), null);
+  assertEquals(
+    getConfirmedProjectContextSwitchId({ success: true, project_id: "project-3" }, "project-2"),
+    null,
+  );
+  assertEquals(getConfirmedProjectContextSwitchId(null, "project-2"), null);
+});

--- a/src/agent/project-context.ts
+++ b/src/agent/project-context.ts
@@ -1,0 +1,63 @@
+export interface MutableAgentProjectContext {
+  projectId: string;
+  branchId?: string | null;
+  availableSkillIds?: string[];
+}
+
+export function applyAgentProjectContextChange(
+  context: MutableAgentProjectContext,
+  projectId: string,
+): boolean {
+  if (projectId === context.projectId) {
+    return false;
+  }
+
+  context.projectId = projectId;
+  context.branchId = null;
+  context.availableSkillIds = undefined;
+  return true;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isProjectContextSwitchContent(value: unknown): value is Record<string, unknown> {
+  return (
+    isRecord(value) &&
+    typeof Reflect.get(value, "success") === "boolean" &&
+    typeof Reflect.get(value, "project_id") === "string"
+  );
+}
+
+function getProjectContextSwitchContent(result: unknown): Record<string, unknown> | null {
+  if (isRecord(result)) {
+    const structuredContent = Reflect.get(result, "structuredContent");
+    if (isProjectContextSwitchContent(structuredContent)) {
+      return structuredContent;
+    }
+  }
+
+  if (isProjectContextSwitchContent(result)) {
+    return result;
+  }
+
+  return null;
+}
+
+export function getConfirmedProjectContextSwitchId(
+  result: unknown,
+  requestedProjectId: string,
+): string | null {
+  const content = getProjectContextSwitchContent(result);
+  if (!content || Reflect.get(content, "success") !== true) {
+    return null;
+  }
+
+  const projectId = Reflect.get(content, "project_id");
+  if (typeof projectId !== "string") {
+    return null;
+  }
+
+  return projectId === requestedProjectId ? projectId : null;
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.372";
+export const VERSION = "0.1.373";


### PR DESCRIPTION
## Summary
- add reusable hosted agent project-context switch helpers
- support direct and structuredContent tool-result shapes
- bump framework version to 0.1.373 for CI/CD publishing

## Verification
- deno test --no-check --allow-all src/agent/project-context.test.ts
- deno task verify:quick
- pre-push checks (format, lint, type check, unit tests)