### PR TITLE
feat(agent): add project steering mutation helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.373",
+  "version": "0.1.374",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -111,6 +111,16 @@ export type {
 } from "./types.ts";
 
 export {
+  DEFAULT_PROJECT_STEERING_PATHS,
+  getProjectSteeringMutation,
+  isSuccessfulProjectSteeringMutationResult,
+  PROJECT_STEERING_FILE_MUTATION_TOOL_NAMES,
+  type ProjectSteeringMutationInput,
+  type ProjectSteeringMutationResult,
+  type ProjectSteeringPaths,
+} from "./project-steering-mutation.ts";
+
+export {
   applyAgentProjectContextChange,
   getConfirmedProjectContextSwitchId,
   type MutableAgentProjectContext,

--- a/src/agent/project-steering-mutation.test.ts
+++ b/src/agent/project-steering-mutation.test.ts
@@ -1,0 +1,75 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import {
+  getProjectSteeringMutation,
+  isSuccessfulProjectSteeringMutationResult,
+  PROJECT_STEERING_FILE_MUTATION_TOOL_NAMES,
+} from "./project-steering-mutation.ts";
+
+Deno.test("PROJECT_STEERING_FILE_MUTATION_TOOL_NAMES contains canonical file mutation tools", () => {
+  assertEquals(PROJECT_STEERING_FILE_MUTATION_TOOL_NAMES, [
+    "create_file",
+    "update_file",
+    "delete_file",
+    "move_file",
+  ]);
+});
+
+Deno.test("getProjectSteeringMutation detects instruction file writes for the active project", () => {
+  assertEquals(
+    getProjectSteeringMutation({
+      toolName: "update_file",
+      toolInput: {
+        project_reference: "project-1",
+        path: "AGENTS.md",
+      },
+      activeProjectId: "project-1",
+      activeBranchId: null,
+    }),
+    { instructionsChanged: true, skillsChanged: false },
+  );
+});
+
+Deno.test("getProjectSteeringMutation detects skill directory moves", () => {
+  assertEquals(
+    getProjectSteeringMutation({
+      toolName: "move_file",
+      toolInput: {
+        project_reference: "project-1",
+        branch_id: "branch-1",
+        source_path: "src/old.ts",
+        destination_path: ".veryfront/skills/react/SKILL.md",
+      },
+      activeProjectId: "project-1",
+      activeBranchId: "branch-1",
+    }),
+    { instructionsChanged: false, skillsChanged: true },
+  );
+});
+
+Deno.test("getProjectSteeringMutation ignores mutations for other projects", () => {
+  assertEquals(
+    getProjectSteeringMutation({
+      toolName: "update_file",
+      toolInput: {
+        project_reference: "project-2",
+        path: "AGENTS.md",
+      },
+      activeProjectId: "project-1",
+      activeBranchId: null,
+    }),
+    { instructionsChanged: false, skillsChanged: false },
+  );
+});
+
+Deno.test("isSuccessfulProjectSteeringMutationResult rejects errored tool results", () => {
+  assertEquals(isSuccessfulProjectSteeringMutationResult({ isError: true }), false);
+  assertEquals(
+    isSuccessfulProjectSteeringMutationResult({ structuredContent: { success: false } }),
+    false,
+  );
+  assertEquals(
+    isSuccessfulProjectSteeringMutationResult({ structuredContent: { success: true } }),
+    true,
+  );
+  assertEquals(isSuccessfulProjectSteeringMutationResult("plain result"), true);
+});

--- a/src/agent/project-steering-mutation.ts
+++ b/src/agent/project-steering-mutation.ts
@@ -1,0 +1,126 @@
+export const DEFAULT_PROJECT_STEERING_PATHS = {
+  instructions: ["AGENTS.md"],
+  skills: [".veryfront/skills"],
+} as const;
+
+export const PROJECT_STEERING_FILE_MUTATION_TOOL_NAMES = [
+  "create_file",
+  "update_file",
+  "delete_file",
+  "move_file",
+] as const;
+
+export type ProjectSteeringPaths = {
+  instructions: readonly string[];
+  skills: readonly string[];
+};
+
+export type ProjectSteeringMutationInput = {
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  activeProjectId?: string | null;
+  activeBranchId?: string | null;
+  steeringPaths?: ProjectSteeringPaths;
+};
+
+export type ProjectSteeringMutationResult = {
+  instructionsChanged: boolean;
+  skillsChanged: boolean;
+};
+
+const NO_MUTATION: ProjectSteeringMutationResult = {
+  instructionsChanged: false,
+  skillsChanged: false,
+};
+
+function getPathMutationFlags(
+  path: string,
+  steeringPaths: ProjectSteeringPaths,
+): ProjectSteeringMutationResult {
+  return {
+    instructionsChanged: steeringPaths.instructions.includes(path),
+    skillsChanged: steeringPaths.skills.some((prefix) =>
+      path === prefix || path.startsWith(`${prefix}/`)
+    ),
+  };
+}
+
+function mergeMutationFlags(
+  flags: readonly ProjectSteeringMutationResult[],
+): ProjectSteeringMutationResult {
+  return {
+    instructionsChanged: flags.some((flag) => flag.instructionsChanged),
+    skillsChanged: flags.some((flag) => flag.skillsChanged),
+  };
+}
+
+function matchesActiveProjectTarget(input: {
+  toolInput: Record<string, unknown>;
+  activeProjectId?: string | null;
+  activeBranchId?: string | null;
+}): boolean {
+  if (!input.activeProjectId) {
+    return false;
+  }
+
+  const projectReference = input.toolInput.project_reference;
+  if (typeof projectReference !== "string" || projectReference !== input.activeProjectId) {
+    return false;
+  }
+
+  const targetBranchId = typeof input.toolInput.branch_id === "string"
+    ? input.toolInput.branch_id
+    : null;
+  return targetBranchId === (input.activeBranchId ?? null);
+}
+
+export function getProjectSteeringMutation(
+  input: ProjectSteeringMutationInput,
+): ProjectSteeringMutationResult {
+  if (
+    !matchesActiveProjectTarget({
+      toolInput: input.toolInput,
+      activeProjectId: input.activeProjectId,
+      activeBranchId: input.activeBranchId,
+    })
+  ) {
+    return NO_MUTATION;
+  }
+
+  const steeringPaths = input.steeringPaths ?? DEFAULT_PROJECT_STEERING_PATHS;
+
+  if (
+    input.toolName === "create_file" || input.toolName === "update_file" ||
+    input.toolName === "delete_file"
+  ) {
+    const path = input.toolInput.path;
+    return typeof path === "string" ? getPathMutationFlags(path, steeringPaths) : NO_MUTATION;
+  }
+
+  if (input.toolName === "move_file") {
+    const paths = [input.toolInput.source_path, input.toolInput.destination_path].filter((
+      path,
+    ): path is string => typeof path === "string");
+
+    return mergeMutationFlags(paths.map((path) => getPathMutationFlags(path, steeringPaths)));
+  }
+
+  return NO_MUTATION;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isSuccessfulProjectSteeringMutationResult(result: unknown): boolean {
+  if (!isRecord(result)) {
+    return true;
+  }
+
+  if (result.isError === true) {
+    return false;
+  }
+
+  const structuredContent = result.structuredContent;
+  return !(isRecord(structuredContent) && structuredContent.success === false);
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.373";
+export const VERSION = "0.1.374";


### PR DESCRIPTION
## Summary
- add reusable project steering mutation helpers for hosted agents
- expose default steering paths, file mutation tool names, and result success detection
- bump framework version to 0.1.374 for CI/CD publishing

## Verification
- deno test --no-check --allow-all src/agent/project-steering-mutation.test.ts
- deno lint src/agent/project-steering-mutation.ts src/agent/project-steering-mutation.test.ts src/agent/index.ts
- deno check src/agent/project-steering-mutation.test.ts
- deno task verify:quick
- pre-push checks