### PR TITLE
feat(agent): add runtime agent definition parser

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.374",
+  "version": "0.1.375",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -121,6 +121,16 @@ export {
 } from "./project-steering-mutation.ts";
 
 export {
+  parseRuntimeAgentMarkdownDefinition,
+  type ParseRuntimeAgentMarkdownDefinitionInput,
+  parseRuntimeAgentMarkdownDefinitionInputSchema,
+  type RuntimeAgentMarkdownDefinition,
+  runtimeAgentMarkdownDefinitionSchema,
+  type RuntimeAgentThinkingConfig,
+  runtimeAgentThinkingConfigSchema,
+} from "./runtime-agent-definition.ts";
+
+export {
   applyAgentProjectContextChange,
   getConfirmedProjectContextSwitchId,
   type MutableAgentProjectContext,

--- a/src/agent/runtime-agent-definition.test.ts
+++ b/src/agent/runtime-agent-definition.test.ts
@@ -1,0 +1,60 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { parseRuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
+
+Deno.test("parseRuntimeAgentMarkdownDefinition normalizes frontmatter and instructions", () => {
+  const result = parseRuntimeAgentMarkdownDefinition({
+    id: "support-agent",
+    content: `---
+name: Support Agent
+description: Helps users resolve issues
+model: gpt-5.4
+thinking: 1200
+max-steps: 8
+---
+
+Follow the support runbook.
+`,
+  });
+
+  assertEquals(result, {
+    id: "support-agent",
+    name: "Support Agent",
+    description: "Helps users resolve issues",
+    model: "gpt-5.4",
+    thinking: { enabled: true, budgetTokens: 1200 },
+    maxSteps: 8,
+    instructions: "Follow the support runbook.",
+  });
+});
+
+Deno.test("parseRuntimeAgentMarkdownDefinition falls back to id and handles boolean thinking", () => {
+  assertEquals(
+    parseRuntimeAgentMarkdownDefinition({
+      id: "writer",
+      content: `---
+thinking: false
+---
+Draft concise copy.
+`,
+    }),
+    {
+      id: "writer",
+      name: "writer",
+      description: "",
+      thinking: { enabled: false },
+      instructions: "Draft concise copy.",
+    },
+  );
+
+  assertEquals(
+    parseRuntimeAgentMarkdownDefinition({
+      id: "planner",
+      content: `---
+thinking: true
+---
+Create a plan.
+`,
+    }).thinking,
+    { enabled: true },
+  );
+});

--- a/src/agent/runtime-agent-definition.ts
+++ b/src/agent/runtime-agent-definition.ts
@@ -1,0 +1,65 @@
+import { extract } from "#std/front-matter/yaml.ts";
+import { z } from "zod";
+
+export const runtimeAgentThinkingConfigSchema = z.object({
+  enabled: z.boolean(),
+  budgetTokens: z.number().positive().optional(),
+});
+
+export type RuntimeAgentThinkingConfig = z.infer<typeof runtimeAgentThinkingConfigSchema>;
+
+export const runtimeAgentMarkdownDefinitionSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string(),
+  instructions: z.string(),
+  thinking: runtimeAgentThinkingConfigSchema.optional(),
+  model: z.string().min(1).optional(),
+  maxSteps: z.number().optional(),
+});
+
+export type RuntimeAgentMarkdownDefinition = z.infer<typeof runtimeAgentMarkdownDefinitionSchema>;
+
+export const parseRuntimeAgentMarkdownDefinitionInputSchema = z.object({
+  id: z.string().min(1),
+  content: z.string(),
+});
+
+export type ParseRuntimeAgentMarkdownDefinitionInput = z.infer<
+  typeof parseRuntimeAgentMarkdownDefinitionInputSchema
+>;
+
+function parseThinking(value: unknown): RuntimeAgentThinkingConfig | undefined {
+  if (typeof value === "number" && value > 0) {
+    return { enabled: true, budgetTokens: value };
+  }
+  if (value === false) {
+    return { enabled: false };
+  }
+  if (value === true) {
+    return { enabled: true };
+  }
+  return undefined;
+}
+
+export function parseRuntimeAgentMarkdownDefinition(
+  input: ParseRuntimeAgentMarkdownDefinitionInput,
+): RuntimeAgentMarkdownDefinition {
+  const parsedInput = parseRuntimeAgentMarkdownDefinitionInputSchema.parse(input);
+  const { attrs, body } = extract<Record<string, unknown>>(parsedInput.content);
+  const name = typeof attrs.name === "string" && attrs.name.trim() ? attrs.name : parsedInput.id;
+  const description = typeof attrs.description === "string" ? attrs.description : "";
+  const model = typeof attrs.model === "string" && attrs.model.trim() ? attrs.model : undefined;
+  const thinking = parseThinking(attrs.thinking);
+  const maxSteps = typeof attrs["max-steps"] === "number" ? attrs["max-steps"] : undefined;
+
+  return runtimeAgentMarkdownDefinitionSchema.parse({
+    id: parsedInput.id,
+    name,
+    description,
+    instructions: body.trim(),
+    ...(model ? { model } : {}),
+    ...(thinking ? { thinking } : {}),
+    ...(maxSteps === undefined ? {} : { maxSteps }),
+  });
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.374";
+export const VERSION = "0.1.375";


### PR DESCRIPTION
## Summary
- add framework-owned runtime agent markdown definition schemas and parser
- export parser and inferred types from `veryfront/agent`
- bump package version to `0.1.375` for CI/CD publish

## Verification
- `deno test --no-check --allow-all src/agent/runtime-agent-definition.test.ts`
- `deno task verify:quick`
- pre-push checks: format, lint, typecheck, unit tests (1597 passed)