### PR TITLE
feat(agent): add runtime client profile helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.375",
+  "version": "0.1.376",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -121,6 +121,17 @@ export {
 } from "./project-steering-mutation.ts";
 
 export {
+  clientAllowsStudioMcp,
+  resolveRuntimeClientProfile,
+  type RuntimeClientCapability,
+  runtimeClientCapabilitySchema,
+  type RuntimeClientProfile,
+  runtimeClientProfileSchema,
+  type RuntimeClientType,
+  runtimeClientTypeSchema,
+} from "./runtime-client-profile.ts";
+
+export {
   parseRuntimeAgentMarkdownDefinition,
   type ParseRuntimeAgentMarkdownDefinitionInput,
   parseRuntimeAgentMarkdownDefinitionInputSchema,

--- a/src/agent/runtime-client-profile.test.ts
+++ b/src/agent/runtime-client-profile.test.ts
@@ -1,0 +1,69 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { clientAllowsStudioMcp, resolveRuntimeClientProfile } from "./runtime-client-profile.ts";
+
+Deno.test("resolveRuntimeClientProfile normalizes nested Veryfront client metadata", () => {
+  assertEquals(
+    resolveRuntimeClientProfile({
+      veryfront: {
+        client: {
+          id: "veryfront-studio",
+          type: "web",
+          platform: "browser",
+          version: "1.0.0",
+        },
+      },
+    }),
+    {
+      id: "veryfront-studio",
+      type: "web",
+      trusted: true,
+      capabilities: ["ui_panels", "form_input", "media_display", "project_switching"],
+    },
+  );
+});
+
+Deno.test("resolveRuntimeClientProfile ignores legacy flat client ids", () => {
+  assertEquals(resolveRuntimeClientProfile({ clientId: "veryfront-studio" }), null);
+});
+
+Deno.test("resolveRuntimeClientProfile does not grant capabilities to unknown clients", () => {
+  const profile = resolveRuntimeClientProfile({
+    veryfront: {
+      client: {
+        id: "third-party-api",
+        type: "api",
+      },
+    },
+  });
+
+  assertEquals(profile, {
+    id: "third-party-api",
+    type: "api",
+    trusted: false,
+    capabilities: [],
+  });
+  assertEquals(clientAllowsStudioMcp(profile), false);
+});
+
+Deno.test("clientAllowsStudioMcp allows trusted studio-capable clients", () => {
+  const profile = resolveRuntimeClientProfile({
+    clientId: "veryfront-studio",
+    veryfront: {
+      client: {
+        id: "veryfront-studio",
+        type: "web",
+        platform: "browser",
+      },
+    },
+    model: "anthropic/claude-sonnet-4",
+    activeChatId: "chat-123",
+  });
+
+  assertEquals(profile, {
+    id: "veryfront-studio",
+    type: "web",
+    trusted: true,
+    capabilities: ["ui_panels", "form_input", "media_display", "project_switching"],
+  });
+  assertEquals(clientAllowsStudioMcp(profile), true);
+});

--- a/src/agent/runtime-client-profile.ts
+++ b/src/agent/runtime-client-profile.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+
+export const runtimeClientTypeSchema = z.enum(["web", "cli", "api", "internal"]);
+export const runtimeClientCapabilitySchema = z.enum([
+  "ui_panels",
+  "form_input",
+  "media_display",
+  "project_switching",
+]);
+
+export const runtimeClientProfileSchema = z.object({
+  id: z.string().min(1).max(128),
+  type: runtimeClientTypeSchema,
+  trusted: z.boolean(),
+  capabilities: z.array(runtimeClientCapabilitySchema),
+});
+
+export type RuntimeClientType = z.infer<typeof runtimeClientTypeSchema>;
+export type RuntimeClientCapability = z.infer<typeof runtimeClientCapabilitySchema>;
+export type RuntimeClientProfile = z.infer<typeof runtimeClientProfileSchema>;
+
+const clientMetadataSchema = z
+  .object({
+    id: z.string().min(1).max(128),
+    type: runtimeClientTypeSchema.optional(),
+    platform: z.string().min(1).max(128).optional(),
+    version: z.string().min(1).max(64).optional(),
+  })
+  .strict();
+
+const clientEnvelopeSchema = z
+  .object({
+    veryfront: z
+      .object({
+        client: clientMetadataSchema.optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+type FirstPartyClientProfile = {
+  type: RuntimeClientType;
+  capabilities: RuntimeClientCapability[];
+};
+
+const FIRST_PARTY_CLIENTS: Readonly<Record<string, FirstPartyClientProfile>> = {
+  "veryfront-studio": {
+    type: "web",
+    capabilities: ["ui_panels", "form_input", "media_display", "project_switching"],
+  },
+  "veryfront-cli": {
+    type: "cli",
+    capabilities: [],
+  },
+  "veryfront-api": {
+    type: "api",
+    capabilities: [],
+  },
+};
+
+export function resolveRuntimeClientProfile(
+  forwardedProps: Record<string, unknown> | undefined,
+): RuntimeClientProfile | null {
+  const parsed = clientEnvelopeSchema.safeParse(forwardedProps);
+  if (!parsed.success) {
+    return null;
+  }
+
+  const metadata = parsed.data.veryfront?.client;
+  const clientId = metadata?.id.trim();
+  if (!clientId) {
+    return null;
+  }
+
+  const knownClient = FIRST_PARTY_CLIENTS[clientId];
+  if (knownClient) {
+    return runtimeClientProfileSchema.parse({
+      id: clientId,
+      type: metadata?.type ?? knownClient.type,
+      trusted: true,
+      capabilities: knownClient.capabilities,
+    });
+  }
+
+  return runtimeClientProfileSchema.parse({
+    id: clientId,
+    type: metadata?.type ?? "api",
+    trusted: false,
+    capabilities: [],
+  });
+}
+
+export function clientAllowsStudioMcp(
+  clientProfile: RuntimeClientProfile | null | undefined,
+): boolean {
+  if (!clientProfile?.trusted) {
+    return false;
+  }
+
+  return (
+    clientProfile.capabilities.includes("ui_panels") ||
+    clientProfile.capabilities.includes("form_input") ||
+    clientProfile.capabilities.includes("media_display")
+  );
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.375";
+export const VERSION = "0.1.376";


### PR DESCRIPTION
## Summary
- add framework-owned runtime client profile schemas and resolution helpers
- expose studio-capability gating for hosted agent services
- bump package version to `0.1.376` for CI/CD publish

## Verification
- `deno test --no-check --allow-all src/agent/runtime-client-profile.test.ts`
- `deno lint src/agent/runtime-client-profile.ts src/agent/runtime-client-profile.test.ts src/agent/index.ts`
- `deno check src/agent/runtime-client-profile.test.ts`
- `deno task verify:quick`
- pre-push checks: format, lint, typecheck, unit tests (1601 passed)