### PR TITLE
feat(agent): add hosted chat request contract

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.376",
+  "version": "0.1.377",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-chat-request.test.ts
+++ b/src/agent/hosted-chat-request.test.ts
@@ -1,0 +1,129 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  buildHostedChatRequestForwardedPropsFromRuntimeAgentInvocation,
+  buildHostedChatRequestFromRuntimeAgentInvocation,
+  hostedChatRequestSchema,
+  hostedChatRuntimeOverridesSchema,
+  RuntimeAgentRunInvocationSchema,
+} from "./index.ts";
+
+const conversationId = "10000000-1000-4000-8000-100000000001";
+const messageId = "10000000-1000-4000-8000-100000000002";
+const inputAnchorMessageId = "10000000-1000-4000-8000-100000000003";
+const userId = "10000000-1000-4000-8000-100000000004";
+const projectId = "10000000-1000-4000-8000-100000000005";
+const branchId = "10000000-1000-4000-8000-100000000006";
+
+function createRuntimeInvocation() {
+  return RuntimeAgentRunInvocationSchema.parse({
+    run: {
+      agentServiceId: "runtime-provider",
+      agentId: "builder",
+      conversationId,
+      runId: "run_root_1",
+      messageId,
+      inputAnchorMessageId,
+      requestedByUserId: userId,
+      project: {
+        projectId,
+        projectSlug: "demo-project",
+        runtimeTargetKind: "preview_branch",
+        runtimeTargetBranchId: branchId,
+      },
+      parentConversationId: "10000000-1000-4000-8000-100000000007",
+      parentRunId: "run_parent_1",
+      spawnedFromToolCallId: "tool_1",
+    },
+    messages: [{ id: "user-message-1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
+    tools: [{
+      name: "studio_focus_component",
+      inputSchema: {
+        type: "object",
+        properties: {
+          componentId: { type: "string" },
+        },
+      },
+    }],
+    context: [{ type: "text", text: "Current file: app.tsx" }],
+    forwardedProps: { activeChatId: "chat_123" },
+  });
+}
+
+describe("agent/hosted-chat-request", () => {
+  it("validates hosted chat request runtime overrides", () => {
+    const parsed = hostedChatRuntimeOverridesSchema.parse({
+      allowedTools: ["read_file"],
+      thinking: 2048,
+      maxSteps: 10,
+      ignored: true,
+    });
+
+    assertEquals(parsed, {
+      allowedTools: ["read_file"],
+      thinking: 2048,
+      maxSteps: 10,
+    });
+    assertEquals(hostedChatRuntimeOverridesSchema.safeParse({ thinking: 0 }).success, false);
+  });
+
+  it("validates hosted chat requests with durable root run descriptors", () => {
+    const parsed = hostedChatRequestSchema.parse({
+      messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
+      context: {
+        conversationId,
+        projectId,
+        branchId,
+      },
+      model: "opus",
+      allowDelegation: true,
+      runtimeOverrides: {
+        thinking: false,
+      },
+      durableRootRun: {
+        runId: "run_root_1",
+        messageId,
+        latestEventId: 2,
+        latestExternalEventSequence: 3,
+        parentConversationId: "10000000-1000-4000-8000-100000000007",
+        parentRunId: "run_parent_1",
+        spawnedFromToolCallId: "tool_1",
+      },
+    });
+
+    assertEquals(parsed.durableRootRun?.runId, "run_root_1");
+    assertEquals(parsed.context.branchId, branchId);
+    assertEquals(
+      hostedChatRequestSchema.safeParse({
+        messages: [],
+        context: { projectId: null, branchId: null },
+        durableRootRun: { runId: "run 1", messageId },
+      }).success,
+      false,
+    );
+  });
+
+  it("builds a hosted chat request from a runtime agent invocation", () => {
+    const invocation = createRuntimeInvocation();
+    const forwardedProps = buildHostedChatRequestForwardedPropsFromRuntimeAgentInvocation(
+      invocation,
+    );
+    const request = buildHostedChatRequestFromRuntimeAgentInvocation(invocation);
+
+    assertEquals(forwardedProps?.activeChatId, "chat_123");
+    assertEquals(forwardedProps?.runtimeContext, invocation.context);
+    assertEquals(forwardedProps?.runtimeTools, invocation.tools);
+    assertEquals(request.context, {
+      conversationId,
+      projectId,
+      branchId,
+    });
+    assertEquals(request.durableRootRun, {
+      runId: "run_root_1",
+      messageId,
+      parentConversationId: "10000000-1000-4000-8000-100000000007",
+      parentRunId: "run_parent_1",
+      spawnedFromToolCallId: "tool_1",
+    });
+  });
+});

--- a/src/agent/hosted-chat-request.ts
+++ b/src/agent/hosted-chat-request.ts
@@ -1,0 +1,98 @@
+import type { ChatRuntimeOverrides, DurableRootRunDescriptor } from "../chat/types.ts";
+import { chatRequestContextSchema, chatUiMessagesSchema } from "../chat/types.ts";
+import { z } from "zod";
+import type { RuntimeAgentRunInvocation } from "./runtime-agent-invocation-contract.ts";
+
+const durableRootRunIdSchema = z.string().min(1).max(128).regex(/^[a-zA-Z0-9_-]+$/);
+
+export const hostedDurableRootRunDescriptorSchema: z.ZodType<DurableRootRunDescriptor> = z
+  .object({
+    runId: durableRootRunIdSchema,
+    messageId: z.string().uuid(),
+    latestEventId: z.number().int().nonnegative().optional(),
+    latestExternalEventSequence: z.number().int().nonnegative().optional(),
+    parentConversationId: z.string().uuid().optional(),
+    parentRunId: durableRootRunIdSchema.optional(),
+    spawnedFromToolCallId: z.string().min(1).max(256).optional(),
+  })
+  .strict();
+
+export const hostedChatRuntimeOverridesSchema: z.ZodType<ChatRuntimeOverrides> = z
+  .object({
+    allowedTools: z.array(z.string().min(1)).max(100).optional(),
+    thinking: z.union([z.literal(false), z.number().int().positive()]).optional(),
+    maxSteps: z.number().int().positive().optional(),
+  })
+  .strip();
+
+export const hostedChatRequestSchema = z.object({
+  messages: chatUiMessagesSchema,
+  context: chatRequestContextSchema,
+  model: z.string().optional(),
+  allowDelegation: z.boolean().optional(),
+  forwardedProps: z.record(z.string(), z.unknown()).optional(),
+  runtimeOverrides: hostedChatRuntimeOverridesSchema.optional(),
+  durableRootRun: hostedDurableRootRunDescriptorSchema.optional(),
+});
+
+export type HostedChatRequest = z.infer<typeof hostedChatRequestSchema>;
+export type HostedChatRequestInput = {
+  messages: RuntimeAgentRunInvocation["messages"];
+  context: z.infer<typeof chatRequestContextSchema>;
+  model?: string;
+  allowDelegation?: boolean;
+  forwardedProps?: Record<string, unknown>;
+  runtimeOverrides?: ChatRuntimeOverrides;
+  durableRootRun?: DurableRootRunDescriptor;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function buildHostedChatRequestForwardedPropsFromRuntimeAgentInvocation(
+  input: RuntimeAgentRunInvocation,
+): HostedChatRequest["forwardedProps"] {
+  const forwardedProps: Record<string, unknown> = isRecord(input.forwardedProps)
+    ? { ...input.forwardedProps }
+    : {};
+
+  if (input.context.length > 0) {
+    forwardedProps.runtimeContext = input.context;
+  }
+
+  if (input.tools.length > 0) {
+    forwardedProps.runtimeTools = input.tools;
+  }
+
+  return Object.keys(forwardedProps).length > 0 ? forwardedProps : undefined;
+}
+
+export function buildHostedChatRequestInputFromRuntimeAgentInvocation(
+  input: RuntimeAgentRunInvocation,
+): HostedChatRequestInput {
+  return {
+    messages: input.messages,
+    context: {
+      conversationId: input.run.conversationId,
+      projectId: input.run.project.projectId,
+      branchId: input.run.project.runtimeTargetBranchId ?? null,
+    },
+    forwardedProps: buildHostedChatRequestForwardedPropsFromRuntimeAgentInvocation(input),
+    durableRootRun: {
+      runId: input.run.runId,
+      messageId: input.run.messageId,
+      parentConversationId: input.run.parentConversationId ?? undefined,
+      parentRunId: input.run.parentRunId ?? undefined,
+      spawnedFromToolCallId: input.run.spawnedFromToolCallId ?? undefined,
+    },
+  };
+}
+
+export function buildHostedChatRequestFromRuntimeAgentInvocation(
+  input: RuntimeAgentRunInvocation,
+): HostedChatRequest {
+  return hostedChatRequestSchema.parse(
+    buildHostedChatRequestInputFromRuntimeAgentInvocation(input),
+  );
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -229,6 +229,16 @@ export {
   parseAgUiRuntimeRequestOrError,
 } from "./runtime-ag-ui-contract.ts";
 export {
+  buildHostedChatRequestForwardedPropsFromRuntimeAgentInvocation,
+  buildHostedChatRequestFromRuntimeAgentInvocation,
+  buildHostedChatRequestInputFromRuntimeAgentInvocation,
+  type HostedChatRequest,
+  type HostedChatRequestInput,
+  hostedChatRequestSchema,
+  hostedChatRuntimeOverridesSchema,
+  hostedDurableRootRunDescriptorSchema,
+} from "./hosted-chat-request.ts";
+export {
   parseRuntimeAgentRunInvocation,
   parseRuntimeAgentRunInvocationOrError,
   type RuntimeAgentContextItem,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.376";
+export const VERSION = "0.1.377";


### PR DESCRIPTION
## Summary\n- Add hosted chat request schemas for runtime-hosted agent services.\n- Add helpers to bridge runtime agent invocations into hosted chat request inputs.\n- Bump package version to 0.1.377 for CI/CD release.\n\n## Verification\n- deno test --no-check --allow-all src/agent/hosted-chat-request.test.ts\n- deno check src/agent/hosted-chat-request.ts src/agent/hosted-chat-request.test.ts\n- deno task verify:quick\n- pre-push checks: format, lint, typecheck, unit tests (1602 passed)