### PR TITLE
feat(agent): add trace attribute builders

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.377",
+  "version": "0.1.378",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/agent-trace-attributes.test.ts
+++ b/src/agent/agent-trace-attributes.test.ts
@@ -1,0 +1,123 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  buildAgentRunTraceAttributes,
+  buildExecuteToolTraceAttributes,
+  buildFinalizedAgentRunTraceAttributes,
+  buildInvokeAgentTraceAttributes,
+} from "./index.ts";
+
+describe("agent/agent-trace-attributes", () => {
+  it("builds core agent run lineage attributes", () => {
+    assertEquals(
+      buildAgentRunTraceAttributes({
+        operationName: "chat",
+        conversationId: "conversation-1",
+        projectId: "project-1",
+        userId: "user-1",
+        agentId: "builder",
+        runId: "run-1",
+        parentRunId: "run-parent",
+        parentConversationId: "conversation-parent",
+        messageId: "message-1",
+        toolCallId: "tool-call-1",
+      }),
+      {
+        "conversation.id": "conversation-1",
+        "project.id": "project-1",
+        "user.id": "user-1",
+        "agent.id": "builder",
+        "run.id": "run-1",
+        "parent.run.id": "run-parent",
+        "parent.conversation.id": "conversation-parent",
+        "message.id": "message-1",
+        "tool.call.id": "tool-call-1",
+        "gen_ai.operation.name": "chat",
+        "gen_ai.conversation.id": "conversation-1",
+        "gen_ai.agent.id": "builder",
+      },
+    );
+  });
+
+  it("builds generic tool execution attributes", () => {
+    assertEquals(
+      buildExecuteToolTraceAttributes({
+        toolName: "bash",
+        toolCallId: "tool-call-1",
+      }),
+      {
+        "tool.name": "bash",
+        "tool.call.id": "tool-call-1",
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": "bash",
+        "gen_ai.tool.type": "function",
+        "gen_ai.tool.call.id": "tool-call-1",
+      },
+    );
+  });
+
+  it("builds invoke_agent child lineage and usage attributes", () => {
+    assertEquals(
+      buildInvokeAgentTraceAttributes({
+        conversationId: "conversation-1",
+        projectId: "project-1",
+        runId: "run-parent",
+        toolCallId: "tool-call-1",
+        childAgentId: "plan",
+        childConversationId: "conversation-child",
+        childRunId: "run-child",
+        childMessageId: "message-child",
+        sourceTargetKind: "project",
+        runtimeTargetKind: "production",
+        status: "completed",
+        usage: {
+          inputTokens: 10,
+          outputTokens: 5,
+        },
+      }),
+      {
+        "conversation.id": "conversation-1",
+        "project.id": "project-1",
+        "run.id": "run-parent",
+        "child.agent.id": "plan",
+        "child.conversation.id": "conversation-child",
+        "child.run.id": "run-child",
+        "child.message.id": "message-child",
+        "source.target.kind": "project",
+        "runtime.target.kind": "production",
+        "agent.run.final_status": "completed",
+        "tool.name": "invoke_agent",
+        "tool.call.id": "tool-call-1",
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": "invoke_agent",
+        "gen_ai.tool.type": "function",
+        "gen_ai.tool.call.id": "tool-call-1",
+        "gen_ai.usage.input_tokens": 10,
+        "gen_ai.usage.output_tokens": 5,
+      },
+    );
+  });
+
+  it("builds final run status attributes with provider and usage", () => {
+    assertEquals(
+      buildFinalizedAgentRunTraceAttributes({
+        status: "completed",
+        modelId: "anthropic/claude-opus-4-6",
+        usage: {
+          inputTokens: 11,
+          outputTokens: 7,
+          cachedInputTokens: 3,
+        },
+      }),
+      {
+        "agent.run.final_status": "completed",
+        "gen_ai.provider.name": "anthropic",
+        "gen_ai.response.model": "anthropic/claude-opus-4-6",
+        "gen_ai.response.finish_reasons": ["stop"],
+        "gen_ai.usage.input_tokens": 11,
+        "gen_ai.usage.output_tokens": 7,
+        "gen_ai.usage.cache_read.input_tokens": 3,
+      },
+    );
+  });
+});

--- a/src/agent/agent-trace-attributes.ts
+++ b/src/agent/agent-trace-attributes.ts
@@ -1,0 +1,170 @@
+type TracePrimitive = string | number | boolean;
+export type AgentTraceAttributeValue =
+  | TracePrimitive
+  | readonly TracePrimitive[]
+  | null
+  | undefined;
+export type AgentTraceAttributes = Record<string, AgentTraceAttributeValue>;
+
+export type AgentTraceUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+  cachedInputTokens?: number;
+};
+
+function compactTraceAttributes(attributes: AgentTraceAttributes): AgentTraceAttributes {
+  return Object.fromEntries(
+    Object.entries(attributes).filter(([, value]) => value !== null && value !== undefined),
+  );
+}
+
+function resolveGenAiProviderName(modelId: string | null | undefined): string | null {
+  const normalizedModelId = modelId?.startsWith("veryfront-cloud/")
+    ? modelId.slice("veryfront-cloud/".length)
+    : modelId;
+  const provider = normalizedModelId?.split("/")[0]?.trim().toLowerCase();
+
+  switch (provider) {
+    case "anthropic":
+      return "anthropic";
+    case "openai":
+      return "openai";
+    case "google":
+    case "google-ai-studio":
+      return "gcp.gen_ai";
+    case "moonshotai":
+      return "moonshotai";
+    default:
+      return null;
+  }
+}
+
+function buildUsageTraceAttributes(usage?: AgentTraceUsage): AgentTraceAttributes {
+  return compactTraceAttributes({
+    ...(typeof usage?.inputTokens === "number"
+      ? { "gen_ai.usage.input_tokens": usage.inputTokens }
+      : {}),
+    ...(typeof usage?.outputTokens === "number"
+      ? { "gen_ai.usage.output_tokens": usage.outputTokens }
+      : {}),
+    ...(typeof usage?.cachedInputTokens === "number"
+      ? { "gen_ai.usage.cache_read.input_tokens": usage.cachedInputTokens }
+      : {}),
+  });
+}
+
+export function buildAgentRunTraceAttributes(input: {
+  operationName: "chat" | "invoke_agent";
+  conversationId?: string;
+  projectId?: string | null;
+  userId: string;
+  agentId: string;
+  runId?: string | null;
+  parentRunId?: string | null;
+  parentConversationId?: string | null;
+  messageId?: string | null;
+  toolCallId?: string | null;
+}): AgentTraceAttributes {
+  return compactTraceAttributes({
+    "conversation.id": input.conversationId,
+    "project.id": input.projectId,
+    "user.id": input.userId,
+    "agent.id": input.agentId,
+    "run.id": input.runId,
+    "parent.run.id": input.parentRunId,
+    "parent.conversation.id": input.parentConversationId,
+    "message.id": input.messageId,
+    "tool.call.id": input.toolCallId,
+    "gen_ai.operation.name": input.operationName,
+    "gen_ai.conversation.id": input.conversationId,
+    "gen_ai.agent.id": input.agentId,
+  });
+}
+
+export function buildExecuteToolTraceAttributes(input: {
+  toolName: string;
+  toolCallId?: string | null;
+}): AgentTraceAttributes {
+  return compactTraceAttributes({
+    "tool.name": input.toolName,
+    "tool.call.id": input.toolCallId,
+    "gen_ai.operation.name": "execute_tool",
+    "gen_ai.tool.name": input.toolName,
+    "gen_ai.tool.type": "function",
+    "gen_ai.tool.call.id": input.toolCallId,
+  });
+}
+
+export function buildInvokeAgentTraceAttributes(input: {
+  conversationId?: string;
+  projectId?: string | null;
+  runId?: string | null;
+  toolCallId: string;
+  childAgentId: string;
+  childConversationId?: string | null;
+  childRunId?: string | null;
+  childMessageId?: string | null;
+  sourceTargetKind?: string | null;
+  runtimeTargetKind?: string | null;
+  targetEnvironmentId?: string | null;
+  targetBranchId?: string | null;
+  status?: "completed" | "failed";
+  usage?: AgentTraceUsage;
+  terminalErrorCode?: string | null;
+  terminalErrorMessage?: string | null;
+}): AgentTraceAttributes {
+  return compactTraceAttributes({
+    "conversation.id": input.conversationId,
+    "project.id": input.projectId,
+    "run.id": input.runId,
+    "child.agent.id": input.childAgentId,
+    "child.conversation.id": input.childConversationId,
+    "child.run.id": input.childRunId,
+    "child.message.id": input.childMessageId,
+    "source.target.kind": input.sourceTargetKind,
+    "runtime.target.kind": input.runtimeTargetKind,
+    "target.environment.id": input.targetEnvironmentId,
+    "target.branch.id": input.targetBranchId,
+    ...(input.status ? { "agent.run.final_status": input.status } : {}),
+    ...(input.status === "failed"
+      ? {
+        "error.type": input.terminalErrorCode ?? "INVOKE_AGENT_FAILED",
+        "error.message": input.terminalErrorMessage,
+      }
+      : {}),
+    ...buildExecuteToolTraceAttributes({
+      toolName: "invoke_agent",
+      toolCallId: input.toolCallId,
+    }),
+    ...buildUsageTraceAttributes(input.usage),
+  });
+}
+
+export function buildFinalizedAgentRunTraceAttributes(input: {
+  status: "completed" | "failed" | "cancelled";
+  modelId?: string | null;
+  usage?: AgentTraceUsage;
+  terminalErrorCode?: string | null;
+  terminalErrorMessage?: string | null;
+}): AgentTraceAttributes {
+  const providerName = resolveGenAiProviderName(input.modelId);
+  const finishReason = input.status === "cancelled"
+    ? "cancelled"
+    : input.status === "completed"
+    ? "stop"
+    : null;
+
+  return compactTraceAttributes({
+    "agent.run.final_status": input.status,
+    ...(providerName ? { "gen_ai.provider.name": providerName } : {}),
+    ...(input.modelId ? { "gen_ai.response.model": input.modelId } : {}),
+    ...(finishReason ? { "gen_ai.response.finish_reasons": [finishReason] } : {}),
+    ...(input.status === "failed"
+      ? {
+        "error.type": input.terminalErrorCode ?? "STREAM_ERROR",
+        "error.message": input.terminalErrorMessage,
+      }
+      : {}),
+    ...buildUsageTraceAttributes(input.usage),
+  });
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -229,6 +229,15 @@ export {
   parseAgUiRuntimeRequestOrError,
 } from "./runtime-ag-ui-contract.ts";
 export {
+  type AgentTraceAttributes,
+  type AgentTraceAttributeValue,
+  type AgentTraceUsage,
+  buildAgentRunTraceAttributes,
+  buildExecuteToolTraceAttributes,
+  buildFinalizedAgentRunTraceAttributes,
+  buildInvokeAgentTraceAttributes,
+} from "./agent-trace-attributes.ts";
+export {
   buildHostedChatRequestForwardedPropsFromRuntimeAgentInvocation,
   buildHostedChatRequestFromRuntimeAgentInvocation,
   buildHostedChatRequestInputFromRuntimeAgentInvocation,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.377";
+export const VERSION = "0.1.378";


### PR DESCRIPTION
## Summary
- Add reusable agent trace attribute builders for run, tool, child-agent, and final-status spans.
- Export trace attribute types and helpers from veryfront/agent.
- Bump package version to 0.1.378 for CI/CD release.

## Verification
- deno test --no-check --allow-all src/agent/agent-trace-attributes.test.ts
- deno check src/agent/agent-trace-attributes.ts src/agent/agent-trace-attributes.test.ts
- deno lint src/agent/agent-trace-attributes.ts src/agent/agent-trace-attributes.test.ts src/agent/index.ts
- deno task verify:quick
- pre-push checks: format, lint, typecheck, unit tests (1603 passed)