### PR TITLE
Add hosted child tool input contract

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.378",
+  "version": "0.1.379",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-tool-input.test.ts
+++ b/src/agent/hosted-child-tool-input.test.ts
@@ -1,0 +1,53 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import {
+  DEFAULT_HOSTED_CHILD_AGENT_ID,
+  hostedChildForkToolInputSchema,
+} from "./hosted-child-tool-input.ts";
+
+Deno.test("hostedChildForkToolInputSchema accepts the hosted child fork fields", () => {
+  const parsed = hostedChildForkToolInputSchema.parse({
+    description: "review auth flow",
+    prompt: "Review the authentication flow and report issues.",
+    project_id: "project-123",
+    tools: ["readFile", "bash"],
+    model: "sonnet",
+    thinking: 1024,
+    max_steps: 12,
+  });
+
+  assertEquals(parsed, {
+    description: "review auth flow",
+    prompt: "Review the authentication flow and report issues.",
+    project_id: "project-123",
+    tools: ["readFile", "bash"],
+    model: "sonnet",
+    thinking: 1024,
+    max_steps: 12,
+  });
+});
+
+Deno.test("hostedChildForkToolInputSchema preserves omitted optional fork controls", () => {
+  const parsed = hostedChildForkToolInputSchema.parse({
+    description: "write tests",
+    prompt: "Add focused tests for the changed helper.",
+  });
+
+  assertEquals(parsed, {
+    description: "write tests",
+    prompt: "Add focused tests for the changed helper.",
+  });
+});
+
+Deno.test("hostedChildForkToolInputSchema rejects negative thinking budgets", () => {
+  const result = hostedChildForkToolInputSchema.safeParse({
+    description: "bad budget",
+    prompt: "Try an invalid budget.",
+    thinking: -1,
+  });
+
+  assertEquals(result.success, false);
+});
+
+Deno.test("DEFAULT_HOSTED_CHILD_AGENT_ID names the hosted child runtime agent", () => {
+  assertEquals(DEFAULT_HOSTED_CHILD_AGENT_ID, "invoke-agent-child");
+});

--- a/src/agent/hosted-child-tool-input.ts
+++ b/src/agent/hosted-child-tool-input.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const DEFAULT_HOSTED_CHILD_AGENT_ID = "invoke-agent-child";
+
+export const hostedChildForkToolInputSchema = z.object({
+  description: z.string().describe("3-5 word task summary"),
+  prompt: z.string().describe("Detailed instructions for the task"),
+  project_id: z.string().optional().describe(
+    "Override project context. Use after studio_open_project.",
+  ),
+  tools: z.array(z.string()).optional().describe(
+    "Tool subset for this fork. Omit = inherit all parent tools.",
+  ),
+  model: z.string().optional().describe('Model override (e.g. "sonnet" for cheaper work).'),
+  thinking: z
+    .number()
+    .nonnegative()
+    .optional()
+    .describe("Thinking override in budget tokens. Use 0 to disable thinking."),
+  max_steps: z.number().optional().describe("Max steps override."),
+});
+
+export type HostedChildForkToolInput = z.infer<typeof hostedChildForkToolInputSchema>;

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -513,6 +513,12 @@ export {
   withHostedChildStreamIdleTimeout,
 } from "./hosted-child-stream-watchdog.ts";
 export {
+  DEFAULT_HOSTED_CHILD_AGENT_ID,
+  type HostedChildForkToolInput,
+  hostedChildForkToolInputSchema,
+} from "./hosted-child-tool-input.ts";
+
+export {
   buildHostedChildToolDescription,
   expandHostedChildRequestedTools,
   type HostedChildForkRuntimeToolSelectionResult,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.378";
+export const VERSION = "0.1.379";


### PR DESCRIPTION
## Summary\n- Add a reusable hosted child fork tool input schema and default child agent id\n- Export the contract from veryfront/agent\n- Bump the package patch version for CI/CD publication\n\n## Verification\n- deno test --no-check --allow-all src/agent/hosted-child-tool-input.test.ts\n- deno check src/agent/hosted-child-tool-input.ts src/agent/hosted-child-tool-input.test.ts\n- deno lint src/agent/hosted-child-tool-input.ts src/agent/hosted-child-tool-input.test.ts src/agent/index.ts\n- deno task verify:quick\n- pre-push checks: fmt, lint, typecheck, unit tests