### PR TITLE
Add hosted chat runtime contract

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -85,11 +85,9 @@ jobs:
       - name: Install Chromium
         run: |
           for attempt in 1 2 3; do
-            if deno run -A npm:playwright install --with-deps chromium; then
-              exit 0
-            fi
-
+            deno run -A npm:playwright install --with-deps chromium && exit 0
             status=$?
+
             if [ "$attempt" -eq 3 ]; then
               exit "$status"
             fi
@@ -133,11 +131,9 @@ jobs:
       - name: Install Chromium
         run: |
           for attempt in 1 2 3; do
-            if deno run -A npm:playwright install --with-deps chromium; then
-              exit 0
-            fi
-
+            deno run -A npm:playwright install --with-deps chromium && exit 0
             status=$?
+
             if [ "$attempt" -eq 3 ]; then
               exit "$status"
             fi

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.379",
+  "version": "0.1.380",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-chat-runtime-contract.test.ts
+++ b/src/agent/hosted-chat-runtime-contract.test.ts
@@ -1,0 +1,81 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import type {
+  HostedChatRuntimeAgent,
+  HostedChatRuntimeFinishPart,
+  HostedChatRuntimeOnFinishEvent,
+  HostedChatRuntimeStreamInput,
+  HostedChatRuntimeStreamResult,
+  HostedChatRuntimeToUiMessageStreamOptions,
+} from "./hosted-chat-runtime-contract.ts";
+
+Deno.test("HostedChatRuntimeAgent describes a streamable hosted chat runtime", async () => {
+  let streamInput: HostedChatRuntimeStreamInput | undefined;
+  let streamOptions: HostedChatRuntimeToUiMessageStreamOptions | undefined;
+  const streamResult: HostedChatRuntimeStreamResult = {
+    steps: Promise.resolve([]),
+    toUIMessageStream: (options) => {
+      streamOptions = options;
+      return (async function* streamChunks() {})();
+    },
+  };
+  const agent: HostedChatRuntimeAgent = {
+    stream: (input) => {
+      streamInput = input;
+      return Promise.resolve(streamResult);
+    },
+  };
+  const abortController = new AbortController();
+
+  const result = await agent.stream({
+    messages: [
+      { id: "msg-1", role: "user", parts: [{ type: "text", text: "Hello" }], timestamp: 1 },
+    ],
+    abortSignal: abortController.signal,
+  });
+  const chunks = result.toUIMessageStream({ sendReasoning: true });
+
+  assertEquals(streamInput?.messages[0]?.id, "msg-1");
+  assertEquals(streamInput?.abortSignal, abortController.signal);
+  assertEquals(streamOptions?.sendReasoning, true);
+  const receivedChunks = [];
+  for await (const chunk of chunks) {
+    receivedChunks.push(chunk);
+  }
+  assertEquals(receivedChunks, []);
+});
+
+Deno.test("HostedChatRuntimeToUiMessageStreamOptions accepts finish metadata callbacks", () => {
+  const finishPart: HostedChatRuntimeFinishPart = {
+    type: "finish",
+    finishReason: "stop",
+    rawFinishReason: "provider-stop",
+    totalUsage: {
+      inputTokens: 3,
+      outputTokens: 5,
+      totalTokens: 8,
+      reasoningTokens: 1,
+      cachedInputTokens: 2,
+      inputTokenDetails: { cacheReadTokens: 2 },
+      outputTokenDetails: { reasoningTokens: 1 },
+    },
+  };
+  let finishEvent: HostedChatRuntimeOnFinishEvent<{ finishReason: string }> | undefined;
+  const options: HostedChatRuntimeToUiMessageStreamOptions<{ finishReason: string }> = {
+    messageMetadata: ({ part }) => ({ finishReason: part.finishReason }),
+    onFinish: (event) => {
+      finishEvent = event;
+    },
+  };
+
+  const metadata = options.messageMetadata?.({ part: finishPart });
+  options.onFinish?.({
+    messages: [],
+    isContinuation: false,
+    responseMessage: { id: "response", role: "assistant", parts: [] },
+    isAborted: false,
+    finishReason: "stop",
+  });
+
+  assertEquals(metadata, { finishReason: "stop" });
+  assertEquals(finishEvent?.responseMessage.id, "response");
+});

--- a/src/agent/hosted-chat-runtime-contract.ts
+++ b/src/agent/hosted-chat-runtime-contract.ts
@@ -1,0 +1,101 @@
+import type { ChatFinishReason } from "../chat/protocol.ts";
+import type {
+  ChatSystemMessage,
+  ChatUiMessage,
+  ChatUiMessageChunk,
+  MessageMetadata,
+} from "../chat/types.ts";
+import type { AgentRuntimeMessage } from "./agent-runtime-message-adapter.ts";
+import type { ConversationRunEvent } from "./conversation-run-events.ts";
+import type { RuntimeClientProfile } from "./runtime-client-profile.ts";
+import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
+
+export type HostedChatRuntimeFinishPart = {
+  type: "finish";
+  finishReason: ChatFinishReason;
+  rawFinishReason?: string;
+  totalUsage: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    reasoningTokens?: number;
+    cachedInputTokens?: number;
+    inputTokenDetails?: {
+      noCacheTokens?: number;
+      cacheReadTokens?: number;
+      cacheWriteTokens?: number;
+    };
+    outputTokenDetails?: {
+      textTokens?: number;
+      reasoningTokens?: number;
+    };
+  };
+};
+
+export type HostedChatRuntimeOnFinishEvent<TMessageMetadata = MessageMetadata> = {
+  messages: Array<ChatUiMessage<TMessageMetadata>>;
+  isContinuation: boolean;
+  responseMessage: ChatUiMessage<TMessageMetadata>;
+  isAborted: boolean;
+  finishReason: ChatFinishReason;
+};
+
+export type HostedChatRuntimeToUiMessageStreamOptions<TMessageMetadata = MessageMetadata> = {
+  sendReasoning?: boolean;
+  originalMessages?: Array<ChatUiMessage<TMessageMetadata>>;
+  generateMessageId?: () => string;
+  onError?: (error: unknown) => string;
+  onFinish?: (event: HostedChatRuntimeOnFinishEvent<TMessageMetadata>) => void | Promise<void>;
+  messageMetadata?: (input: { part: HostedChatRuntimeFinishPart }) => TMessageMetadata | undefined;
+};
+
+export type HostedChatRuntimeStreamInput = {
+  messages: AgentRuntimeMessage[];
+  abortSignal: AbortSignal;
+};
+
+export type HostedChatRuntimeStreamResult<TMessageMetadata = MessageMetadata> = {
+  steps: PromiseLike<readonly unknown[]>;
+  toUIMessageStream: (
+    options?: HostedChatRuntimeToUiMessageStreamOptions<TMessageMetadata>,
+  ) => AsyncIterable<ChatUiMessageChunk<TMessageMetadata>>;
+};
+
+export type HostedChatRuntimeAgent<TMessageMetadata = MessageMetadata> = {
+  stream: (
+    input: HostedChatRuntimeStreamInput,
+  ) => Promise<HostedChatRuntimeStreamResult<TMessageMetadata>>;
+};
+
+export type HostedChatRuntimeCreationResult<TMessageMetadata = MessageMetadata> = {
+  runtimeKind: "framework";
+  agent: HostedChatRuntimeAgent<TMessageMetadata>;
+  modelId: string;
+  cleanup: () => Promise<void>;
+};
+
+export type HostedChatRuntimeProjectSteering<TRuntimeAgentDefinition> = {
+  agent: TRuntimeAgentDefinition;
+  environmentContext?: string;
+  initialProjectInstructions?: string;
+  initialSkills?: RuntimeSkillDefinition[];
+};
+
+export type HostedChatRuntimeCreationOptions<TRuntimeAgentDefinition, TThinkingConfig> = {
+  projectId: string | null;
+  branchId?: string | null;
+  authToken: string;
+  instructions: string | ChatSystemMessage[];
+  model?: string;
+  maxSteps?: number;
+  allowedTools?: string[];
+  allowDelegation?: boolean;
+  thinking?: TThinkingConfig;
+  conversationId?: string;
+  parentRunId?: string;
+  parentMessageId?: string;
+  availableSkillIds?: string[];
+  publishParentRunEvents?: (events: ConversationRunEvent[]) => Promise<void>;
+  clientProfile?: RuntimeClientProfile | null;
+  liveProjectSteering?: HostedChatRuntimeProjectSteering<TRuntimeAgentDefinition>;
+};

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -237,6 +237,18 @@ export {
   buildFinalizedAgentRunTraceAttributes,
   buildInvokeAgentTraceAttributes,
 } from "./agent-trace-attributes.ts";
+export type {
+  HostedChatRuntimeAgent,
+  HostedChatRuntimeCreationOptions,
+  HostedChatRuntimeCreationResult,
+  HostedChatRuntimeFinishPart,
+  HostedChatRuntimeOnFinishEvent,
+  HostedChatRuntimeProjectSteering,
+  HostedChatRuntimeStreamInput,
+  HostedChatRuntimeStreamResult,
+  HostedChatRuntimeToUiMessageStreamOptions,
+} from "./hosted-chat-runtime-contract.ts";
+
 export {
   buildHostedChatRequestForwardedPropsFromRuntimeAgentInvocation,
   buildHostedChatRequestFromRuntimeAgentInvocation,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.379";
+export const VERSION = "0.1.380";


### PR DESCRIPTION
## Summary\n- Add reusable hosted chat runtime contract types\n- Export the contract from veryfront/agent\n- Bump the package patch version for CI/CD publication\n\n## Verification\n- deno check src/agent/hosted-chat-runtime-contract.ts src/agent/hosted-chat-runtime-contract.test.ts\n- deno test --no-check --allow-all src/agent/hosted-chat-runtime-contract.test.ts\n- deno lint src/agent/hosted-chat-runtime-contract.ts src/agent/hosted-chat-runtime-contract.test.ts src/agent/index.ts\n- deno task verify:quick\n- pre-push checks: fmt, lint, typecheck, unit tests