### PR TITLE
feat(agent): add hosted runtime request config helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.380",
+  "version": "0.1.381",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-runtime-request-config.test.ts
+++ b/src/agent/hosted-runtime-request-config.test.ts
@@ -1,0 +1,133 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import {
+  getForwardedHostedModelId,
+  getForwardedHostedRuntimeOverrides,
+  resolveHostedRuntimeRequestConfig,
+  resolveHostedRuntimeThinkingOverride,
+} from "./hosted-runtime-request-config.ts";
+import type { RuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
+
+function createAgentConfig(
+  overrides: Partial<RuntimeAgentMarkdownDefinition> = {},
+): RuntimeAgentMarkdownDefinition {
+  return {
+    id: "veryfront",
+    name: "Veryfront",
+    description: "Veryfront agent",
+    instructions: "Help the user.",
+    model: "anthropic/claude-sonnet-4-6",
+    thinking: { enabled: true, budgetTokens: 5000 },
+    maxSteps: 12,
+    ...overrides,
+  };
+}
+
+Deno.test("getForwardedHostedModelId returns non-empty forwarded models", () => {
+  assertEquals(getForwardedHostedModelId({ model: "opus" }), "opus");
+  assertEquals(getForwardedHostedModelId({ model: "" }), undefined);
+  assertEquals(getForwardedHostedModelId({ model: "   " }), undefined);
+  assertEquals(getForwardedHostedModelId({ model: 42 }), undefined);
+  assertEquals(getForwardedHostedModelId(undefined), undefined);
+});
+
+Deno.test("getForwardedHostedRuntimeOverrides parses non-empty forwarded runtime overrides", () => {
+  assertEquals(getForwardedHostedRuntimeOverrides(undefined), undefined);
+  assertEquals(getForwardedHostedRuntimeOverrides({ runtimeOverrides: "bad" }), undefined);
+  assertEquals(getForwardedHostedRuntimeOverrides({ runtimeOverrides: null }), undefined);
+  assertEquals(getForwardedHostedRuntimeOverrides({ runtimeOverrides: {} }), undefined);
+  assertEquals(getForwardedHostedRuntimeOverrides({ runtimeOverrides: { thinking: 1000 } }), {
+    thinking: 1000,
+  });
+});
+
+Deno.test("resolveHostedRuntimeThinkingOverride applies optional thinking override", () => {
+  const configuredThinking = { enabled: true, budgetTokens: 5000 };
+  assertEquals(
+    resolveHostedRuntimeThinkingOverride({
+      configuredThinking,
+      requestedThinking: undefined,
+    }),
+    configuredThinking,
+  );
+  assertEquals(
+    resolveHostedRuntimeThinkingOverride({
+      configuredThinking,
+      requestedThinking: false,
+    }),
+    { enabled: false },
+  );
+  assertEquals(
+    resolveHostedRuntimeThinkingOverride({
+      configuredThinking: undefined,
+      requestedThinking: 2000,
+    }),
+    { enabled: true, budgetTokens: 2000 },
+  );
+});
+
+Deno.test("resolveHostedRuntimeRequestConfig prefers request model over forwarded and configured models", () => {
+  const result = resolveHostedRuntimeRequestConfig({
+    request: {
+      model: "openai/gpt-5.2",
+      forwardedProps: { model: "anthropic/claude-opus-4-6" },
+    },
+    agentConfig: createAgentConfig({ model: "anthropic/claude-haiku-4-5" }),
+    resolveModelId: (model) => model ? `veryfront-cloud/${model}` : undefined,
+  });
+
+  assertEquals(result.requestedModel, "veryfront-cloud/openai/gpt-5.2");
+});
+
+Deno.test("resolveHostedRuntimeRequestConfig resolves overrides, thinking, max steps, and client profile", () => {
+  const result = resolveHostedRuntimeRequestConfig({
+    request: {
+      model: "anthropic/claude-sonnet-4-6",
+      forwardedProps: {
+        veryfront: {
+          client: {
+            id: "veryfront-studio",
+          },
+        },
+        runtimeOverrides: {
+          allowedTools: ["read_file"],
+          maxSteps: 8,
+        },
+      },
+      runtimeOverrides: { thinking: false },
+    },
+    agentConfig: createAgentConfig({ maxSteps: 12 }),
+    resolveModelId: (model) => model ? `veryfront-cloud/${model}` : undefined,
+    resolveModelThinking: (model) =>
+      model === "veryfront-cloud/anthropic/claude-sonnet-4-6"
+        ? { enabled: true, budgetTokens: 2048 }
+        : undefined,
+  });
+
+  assertEquals(result.effectiveRuntimeOverrides, { thinking: false });
+  assertEquals(result.requestedMaxSteps, 12);
+  assertEquals(result.requestedThinking, { enabled: false });
+  assertEquals(result.clientProfile, {
+    id: "veryfront-studio",
+    type: "web",
+    trusted: true,
+    capabilities: ["ui_panels", "form_input", "media_display", "project_switching"],
+  });
+});
+
+Deno.test("resolveHostedRuntimeRequestConfig uses forwarded overrides when request overrides are absent", () => {
+  const result = resolveHostedRuntimeRequestConfig({
+    request: {
+      forwardedProps: {
+        runtimeOverrides: {
+          allowedTools: ["read_file"],
+          maxSteps: 8,
+        },
+      },
+    },
+    agentConfig: createAgentConfig({ maxSteps: 12 }),
+    resolveModelId: (model) => model ? `veryfront-cloud/${model}` : undefined,
+  });
+
+  assertEquals(result.effectiveRuntimeOverrides, { allowedTools: ["read_file"], maxSteps: 8 });
+  assertEquals(result.requestedMaxSteps, 8);
+});

--- a/src/agent/hosted-runtime-request-config.ts
+++ b/src/agent/hosted-runtime-request-config.ts
@@ -1,0 +1,112 @@
+import type { ChatRuntimeOverrides } from "../chat/types.ts";
+import { type HostedChatRequest, hostedChatRuntimeOverridesSchema } from "./hosted-chat-request.ts";
+import type {
+  RuntimeAgentMarkdownDefinition,
+  RuntimeAgentThinkingConfig,
+} from "./runtime-agent-definition.ts";
+import {
+  resolveRuntimeClientProfile,
+  type RuntimeClientProfile,
+} from "./runtime-client-profile.ts";
+
+export type HostedRuntimeRequestConfigRequest = Pick<
+  HostedChatRequest,
+  "model" | "forwardedProps" | "runtimeOverrides"
+>;
+
+export type HostedRuntimeRequestConfigAgent = Pick<
+  RuntimeAgentMarkdownDefinition,
+  "model" | "thinking" | "maxSteps"
+>;
+
+export type ResolveHostedRuntimeRequestConfigInput = {
+  request: HostedRuntimeRequestConfigRequest;
+  agentConfig: HostedRuntimeRequestConfigAgent;
+  resolveModelId: (modelId: string | undefined) => string | undefined;
+  resolveModelThinking?: (
+    modelId: string | undefined,
+  ) => RuntimeAgentThinkingConfig | undefined;
+};
+
+export type ResolvedHostedRuntimeRequestConfig = {
+  effectiveRuntimeOverrides: ChatRuntimeOverrides | undefined;
+  requestedModel: string | undefined;
+  clientProfile: RuntimeClientProfile | null;
+  requestedThinking: RuntimeAgentThinkingConfig | undefined;
+  requestedMaxSteps: number | undefined;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function getForwardedHostedModelId(
+  forwardedProps: Record<string, unknown> | undefined,
+): string | undefined {
+  return typeof forwardedProps?.model === "string" &&
+      forwardedProps.model.trim().length > 0
+    ? forwardedProps.model
+    : undefined;
+}
+
+export function getForwardedHostedRuntimeOverrides(
+  forwardedProps: Record<string, unknown> | undefined,
+): ChatRuntimeOverrides | undefined {
+  const runtimeOverrides = forwardedProps?.runtimeOverrides;
+  if (!isRecord(runtimeOverrides)) {
+    return undefined;
+  }
+
+  const parsedRuntimeOverrides = hostedChatRuntimeOverridesSchema.safeParse(
+    runtimeOverrides,
+  );
+  if (!parsedRuntimeOverrides.success) {
+    return undefined;
+  }
+
+  return Object.keys(parsedRuntimeOverrides.data).length > 0
+    ? parsedRuntimeOverrides.data
+    : undefined;
+}
+
+export function resolveHostedRuntimeThinkingOverride(input: {
+  configuredThinking: RuntimeAgentThinkingConfig | undefined;
+  requestedThinking: false | number | undefined;
+}): RuntimeAgentThinkingConfig | undefined {
+  if (input.requestedThinking === undefined) {
+    return input.configuredThinking;
+  }
+
+  if (input.requestedThinking === false) {
+    return { enabled: false };
+  }
+
+  return {
+    enabled: true,
+    budgetTokens: input.requestedThinking,
+  };
+}
+
+export function resolveHostedRuntimeRequestConfig(
+  input: ResolveHostedRuntimeRequestConfigInput,
+): ResolvedHostedRuntimeRequestConfig {
+  const effectiveRuntimeOverrides = input.request.runtimeOverrides ??
+    getForwardedHostedRuntimeOverrides(input.request.forwardedProps);
+  const requestedModel = input.resolveModelId(
+    input.request.model ?? getForwardedHostedModelId(input.request.forwardedProps) ??
+      input.agentConfig.model,
+  );
+
+  return {
+    effectiveRuntimeOverrides,
+    requestedModel,
+    clientProfile: resolveRuntimeClientProfile(input.request.forwardedProps),
+    requestedThinking: resolveHostedRuntimeThinkingOverride({
+      configuredThinking: input.resolveModelThinking?.(requestedModel) ??
+        input.agentConfig.thinking,
+      requestedThinking: effectiveRuntimeOverrides?.thinking,
+    }),
+    requestedMaxSteps: effectiveRuntimeOverrides?.maxSteps ??
+      input.agentConfig.maxSteps,
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -260,6 +260,16 @@ export {
   hostedDurableRootRunDescriptorSchema,
 } from "./hosted-chat-request.ts";
 export {
+  getForwardedHostedModelId,
+  getForwardedHostedRuntimeOverrides,
+  type HostedRuntimeRequestConfigAgent,
+  type HostedRuntimeRequestConfigRequest,
+  type ResolvedHostedRuntimeRequestConfig,
+  resolveHostedRuntimeRequestConfig,
+  type ResolveHostedRuntimeRequestConfigInput,
+  resolveHostedRuntimeThinkingOverride,
+} from "./hosted-runtime-request-config.ts";
+export {
   parseRuntimeAgentRunInvocation,
   parseRuntimeAgentRunInvocationOrError,
   type RuntimeAgentContextItem,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.380";
+export const VERSION = "0.1.381";


### PR DESCRIPTION
## Summary
- add shared hosted runtime request-config helpers for forwarded model/runtime overrides, thinking overrides, max steps, and client profile resolution
- export the helpers from the agent package surface
- bump package version to 0.1.381 for CI/CD publish

## Verification
- deno check src/agent/hosted-runtime-request-config.ts src/agent/hosted-runtime-request-config.test.ts
- deno test --no-check --allow-all src/agent/hosted-runtime-request-config.test.ts
- deno task verify:quick
- pre-push checks: fmt, lint, typecheck, unit tests (1615 passed, 0 failed)