### PR TITLE
Add Veryfront Cloud model catalog

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.381",
+  "version": "0.1.382",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/provider.md
+++ b/docs/reference/provider.md
@@ -24,9 +24,12 @@ import {
   clearModelProviders,
   ensureModelReady,
   getRegisteredModelProviders,
+  groupVeryfrontCloudModelsByProvider,
   hasModelProvider,
   registerModelProvider,
+  resolveHostedVeryfrontCloudModelId,
   resolveModel,
+  resolveVeryfrontCloudModelId,
 } from "veryfront/provider";
 ```
 
@@ -76,24 +79,61 @@ Clear all registered model providers (for testing).
 
 **Returns:** `void`
 
+### Veryfront Cloud model catalog
+
+Use the hosted language model catalog when an agent service needs stable aliases, provider grouping, hosted model normalization, or Anthropic thinking provider options.
+
+```ts
+import {
+  groupVeryfrontCloudModelsByProvider,
+  resolveHostedVeryfrontCloudModelId,
+  resolveVeryfrontCloudModelId,
+} from "veryfront/provider";
+
+const modelId = resolveVeryfrontCloudModelId("opus");
+const hostedModelId = resolveHostedVeryfrontCloudModelId(modelId);
+const groupedModels = groupVeryfrontCloudModelsByProvider();
+```
+
 ## Exports
 
 ### Functions
 
-| Name                          | Description                                                                |
-| ----------------------------- | -------------------------------------------------------------------------- |
-| `clearModelProviders`         | Clear all registered model providers (for testing).                        |
-| `ensureModelReady`            | Eagerly verify that the resolved model's runtime is available.             |
-| `getRegisteredModelProviders` | Get list of registered model provider names (project-scoped + shared).     |
-| `hasModelProvider`            | Check if a model provider is registered (project-scoped or shared).        |
-| `registerModelProvider`       | Register a custom model provider factory for the current project.          |
-| `resolveModel`                | Resolve a "provider/model" string to a framework-compatible model runtime. |
+| Name                                           | Description                                                                |
+| ---------------------------------------------- | -------------------------------------------------------------------------- |
+| `clearModelProviders`                          | Clear all registered model providers (for testing).                        |
+| `ensureModelReady`                             | Eagerly verify that the resolved model's runtime is available.             |
+| `findVeryfrontCloudModel`                      | Find a hosted catalog model by alias.                                      |
+| `findVeryfrontCloudModelByModelId`             | Find a hosted catalog model by direct or hosted model ID.                  |
+| `getRegisteredModelProviders`                  | Get list of registered model provider names (project-scoped + shared).     |
+| `getVeryfrontCloudProviderFromModelId`         | Resolve the hosted language provider for a direct or hosted model ID.      |
+| `groupVeryfrontCloudModelsByProvider`          | Group hosted catalog models by provider in display order.                  |
+| `hasModelProvider`                             | Check if a model provider is registered (project-scoped or shared).        |
+| `normalizeVeryfrontCloudModelId`               | Remove the `veryfront-cloud/` prefix from a hosted model ID.               |
+| `registerModelProvider`                        | Register a custom model provider factory for the current project.          |
+| `resolveHostedVeryfrontCloudModelId`           | Prefix direct provider model IDs for the hosted gateway.                   |
+| `resolveModel`                                 | Resolve a "provider/model" string to a framework-compatible model runtime. |
+| `resolveVeryfrontCloudModelId`                 | Resolve a hosted catalog alias to a direct provider model ID.              |
+| `resolveVeryfrontCloudModelThinking`           | Resolve default thinking configuration for a hosted catalog model.         |
+| `resolveVeryfrontCloudThinkingProviderOptions` | Resolve Anthropic provider options for hosted thinking configuration.      |
+| `tryGetVeryfrontCloudProviderFromModelId`      | Resolve a hosted language provider without throwing on unknown prefixes.   |
+
+### Constants
+
+| Name                               | Description                                  |
+| ---------------------------------- | -------------------------------------------- |
+| `DEFAULT_VERYFRONT_CLOUD_MODEL_ID` | Default hosted catalog alias.                |
+| `VERYFRONT_CLOUD_CHAT_MODELS`      | Hosted language model catalog.               |
+| `VERYFRONT_CLOUD_MODEL_PREFIX`     | Prefix for hosted Veryfront Cloud model IDs. |
 
 ### Types
 
-| Name                   | Description                          |
-| ---------------------- | ------------------------------------ |
-| `ModelProviderFactory` | `(modelId: string) => model runtime` |
+| Name                                | Description                          |
+| ----------------------------------- | ------------------------------------ |
+| `ModelProviderFactory`              | `(modelId: string) => model runtime` |
+| `VeryfrontCloudChatModel`           | Hosted language model catalog entry. |
+| `VeryfrontCloudModelThinkingConfig` | Hosted model thinking configuration. |
+| `VeryfrontCloudProviderId`          | Hosted language provider identifier. |
 
 ## Related
 

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -30,3 +30,23 @@ export {
   runWithVeryfrontCloudContextAsync,
 } from "./veryfront-cloud/context.ts";
 export type { VeryfrontCloudContext } from "./veryfront-cloud/context.ts";
+export type { VeryfrontCloudProviderId } from "./veryfront-cloud/shared.ts";
+export {
+  DEFAULT_VERYFRONT_CLOUD_MODEL_ID,
+  findVeryfrontCloudModel,
+  findVeryfrontCloudModelByModelId,
+  getVeryfrontCloudProviderFromModelId,
+  groupVeryfrontCloudModelsByProvider,
+  normalizeVeryfrontCloudModelId,
+  resolveHostedVeryfrontCloudModelId,
+  resolveVeryfrontCloudModelId,
+  resolveVeryfrontCloudModelThinking,
+  resolveVeryfrontCloudThinkingProviderOptions,
+  tryGetVeryfrontCloudProviderFromModelId,
+  VERYFRONT_CLOUD_CHAT_MODELS,
+  VERYFRONT_CLOUD_MODEL_PREFIX,
+} from "./veryfront-cloud/model-catalog.ts";
+export type {
+  VeryfrontCloudChatModel,
+  VeryfrontCloudModelThinkingConfig,
+} from "./veryfront-cloud/model-catalog.ts";

--- a/src/provider/veryfront-cloud/model-catalog.test.ts
+++ b/src/provider/veryfront-cloud/model-catalog.test.ts
@@ -1,0 +1,151 @@
+import { assertEquals, assertExists, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  findVeryfrontCloudModel,
+  findVeryfrontCloudModelByModelId,
+  getVeryfrontCloudProviderFromModelId,
+  groupVeryfrontCloudModelsByProvider,
+  resolveHostedVeryfrontCloudModelId,
+  resolveVeryfrontCloudModelId,
+  resolveVeryfrontCloudModelThinking,
+  resolveVeryfrontCloudThinkingProviderOptions,
+  tryGetVeryfrontCloudProviderFromModelId,
+} from "./model-catalog.ts";
+
+describe("provider/veryfront-cloud/model-catalog", () => {
+  it("finds catalog models by alias", () => {
+    const opus = findVeryfrontCloudModel("opus");
+    assertExists(opus);
+    assertEquals(opus.provider, "anthropic");
+    assertEquals(findVeryfrontCloudModel("sonnet")?.provider, "anthropic");
+    assertEquals(findVeryfrontCloudModel("gpt-5.2")?.provider, "openai");
+    assertEquals(findVeryfrontCloudModel("gemini-2.5-pro")?.provider, "google");
+    assertEquals(findVeryfrontCloudModel("kimi-k2.5")?.provider, "moonshotai");
+    assertEquals(findVeryfrontCloudModel("nonexistent"), undefined);
+  });
+
+  it("extracts providers from direct and hosted model ids", () => {
+    assertEquals(getVeryfrontCloudProviderFromModelId("anthropic/claude-opus-4-6"), "anthropic");
+    assertEquals(getVeryfrontCloudProviderFromModelId("veryfront-cloud/openai/gpt-5.2"), "openai");
+    assertEquals(getVeryfrontCloudProviderFromModelId("google-ai-studio/gemini-2.5-pro"), "google");
+    assertEquals(getVeryfrontCloudProviderFromModelId("moonshotai/kimi-k2.5"), "moonshotai");
+    assertThrows(
+      () => getVeryfrontCloudProviderFromModelId("unknown/model"),
+      Error,
+      'Unknown model provider prefix "unknown"',
+    );
+  });
+
+  it("returns undefined for unknown provider prefixes in the try helper", () => {
+    assertEquals(
+      tryGetVeryfrontCloudProviderFromModelId("veryfront-cloud/anthropic/claude-opus-4-6"),
+      "anthropic",
+    );
+    assertEquals(tryGetVeryfrontCloudProviderFromModelId("unknown/model"), undefined);
+  });
+
+  it("finds catalog entries for direct and hosted model ids", () => {
+    assertEquals(findVeryfrontCloudModelByModelId("anthropic/claude-opus-4-6")?.id, "opus");
+    assertEquals(
+      findVeryfrontCloudModelByModelId("veryfront-cloud/anthropic/claude-opus-4-6")
+        ?.thinkingBudgetTokens,
+      2048,
+    );
+  });
+
+  it("groups models by provider in a stable order", () => {
+    const groups = groupVeryfrontCloudModelsByProvider();
+    assertEquals(groups.map((group) => group.provider), [
+      "anthropic",
+      "openai",
+      "google",
+      "moonshotai",
+    ]);
+    assertEquals(groups[0]?.label, "Anthropic");
+    assertEquals(groups[1]?.label, "OpenAI");
+    for (const group of groups) {
+      assertEquals(group.models.every((model) => model.provider === group.provider), true);
+    }
+  });
+
+  it("resolves aliases and preserves direct model ids", () => {
+    assertEquals(resolveVeryfrontCloudModelId("opus"), "anthropic/claude-opus-4-6");
+    assertEquals(resolveVeryfrontCloudModelId("gpt-5.2"), "openai/gpt-5.2");
+    assertEquals(resolveVeryfrontCloudModelId("openai/gpt-5.2"), "openai/gpt-5.2");
+    assertThrows(
+      () => resolveVeryfrontCloudModelId("not-a-real-model"),
+      Error,
+      'Unknown model alias "not-a-real-model"',
+    );
+  });
+
+  it("resolves default thinking budgets for catalog models", () => {
+    assertEquals(resolveVeryfrontCloudModelThinking("anthropic/claude-opus-4-6"), {
+      enabled: true,
+      budgetTokens: 2048,
+    });
+    assertEquals(resolveVeryfrontCloudModelThinking("veryfront-cloud/anthropic/claude-opus-4-6"), {
+      enabled: true,
+      budgetTokens: 2048,
+    });
+    assertEquals(resolveVeryfrontCloudModelThinking("openai/gpt-5.2"), undefined);
+    assertEquals(resolveVeryfrontCloudModelThinking("anthropic/claude-sonnet-4-6")?.enabled, true);
+    assertEquals(
+      resolveVeryfrontCloudModelThinking("anthropic/claude-haiku-4-5-20251001")?.enabled,
+      true,
+    );
+  });
+
+  it("prefixes direct provider model ids for the hosted gateway", () => {
+    assertEquals(
+      resolveHostedVeryfrontCloudModelId("anthropic/claude-opus-4-6"),
+      "veryfront-cloud/anthropic/claude-opus-4-6",
+    );
+    assertEquals(
+      resolveHostedVeryfrontCloudModelId("google-ai-studio/gemini-2.5-flash"),
+      "veryfront-cloud/google-ai-studio/gemini-2.5-flash",
+    );
+    assertEquals(
+      resolveHostedVeryfrontCloudModelId("veryfront-cloud/openai/gpt-5.2"),
+      "veryfront-cloud/openai/gpt-5.2",
+    );
+    assertEquals(resolveHostedVeryfrontCloudModelId("opus"), "opus");
+    assertEquals(resolveHostedVeryfrontCloudModelId(undefined), undefined);
+  });
+
+  it("maps enabled Anthropic thinking into provider options", () => {
+    assertEquals(
+      resolveVeryfrontCloudThinkingProviderOptions("veryfront-cloud/anthropic/claude-opus-4-6", {
+        enabled: true,
+        budgetTokens: 2048,
+      }),
+      {
+        anthropic: {
+          temperature: 1,
+          thinking: {
+            type: "enabled",
+            budget_tokens: 2048,
+          },
+        },
+      },
+    );
+  });
+
+  it("omits disabled, missing-budget, and non-Anthropic thinking options", () => {
+    assertEquals(
+      resolveVeryfrontCloudThinkingProviderOptions("anthropic/claude-opus-4-6", { enabled: false }),
+      undefined,
+    );
+    assertEquals(
+      resolveVeryfrontCloudThinkingProviderOptions("anthropic/claude-opus-4-6", { enabled: true }),
+      undefined,
+    );
+    assertEquals(
+      resolveVeryfrontCloudThinkingProviderOptions("openai/gpt-5.2", {
+        enabled: true,
+        budgetTokens: 2048,
+      }),
+      undefined,
+    );
+  });
+});

--- a/src/provider/veryfront-cloud/model-catalog.ts
+++ b/src/provider/veryfront-cloud/model-catalog.ts
@@ -1,0 +1,220 @@
+import type { VeryfrontCloudProviderId } from "./shared.ts";
+
+export type VeryfrontCloudModelThinkingConfig = {
+  enabled: boolean;
+  budgetTokens?: number;
+};
+
+export type VeryfrontCloudChatModel = {
+  id: string;
+  modelId: string;
+  provider: VeryfrontCloudProviderId;
+  name: string;
+  description: string;
+  thinkingBudgetTokens?: number;
+};
+
+export const DEFAULT_VERYFRONT_CLOUD_MODEL_ID = "opus";
+export const VERYFRONT_CLOUD_MODEL_PREFIX = "veryfront-cloud/";
+
+const HOSTED_MODEL_PROVIDER_PREFIXES = [
+  "anthropic/",
+  "openai/",
+  "google/",
+  "google-ai-studio/",
+  "moonshotai/",
+];
+
+export const VERYFRONT_CLOUD_CHAT_MODELS: VeryfrontCloudChatModel[] = [
+  {
+    id: "opus",
+    modelId: "anthropic/claude-opus-4-6",
+    provider: "anthropic",
+    name: "Claude Opus 4.6",
+    description: "Most capable for ambitious work",
+    thinkingBudgetTokens: 2048,
+  },
+  {
+    id: "sonnet",
+    modelId: "anthropic/claude-sonnet-4-6",
+    provider: "anthropic",
+    name: "Claude Sonnet 4.6",
+    description: "Most efficient for everyday tasks",
+    thinkingBudgetTokens: 2048,
+  },
+  {
+    id: "haiku",
+    modelId: "anthropic/claude-haiku-4-5-20251001",
+    provider: "anthropic",
+    name: "Claude Haiku 4.5",
+    description: "Fastest for quick answers",
+    thinkingBudgetTokens: 1024,
+  },
+  {
+    id: "gpt-5.2",
+    modelId: "openai/gpt-5.2",
+    provider: "openai",
+    name: "GPT-5.2",
+    description: "Most capable OpenAI model",
+  },
+  {
+    id: "gemini-2.5-pro",
+    modelId: "google-ai-studio/gemini-2.5-pro",
+    provider: "google",
+    name: "Gemini 2.5 Pro",
+    description: "Advanced reasoning and analysis",
+  },
+  {
+    id: "gemini-2.5-flash",
+    modelId: "google-ai-studio/gemini-2.5-flash",
+    provider: "google",
+    name: "Gemini 2.5 Flash",
+    description: "Fast and cost-efficient",
+  },
+  {
+    id: "kimi-k2.5",
+    modelId: "moonshotai/kimi-k2.5",
+    provider: "moonshotai",
+    name: "Kimi K2.5",
+    description: "Deep thinking and multimodal",
+  },
+];
+
+export function findVeryfrontCloudModel(id: string): VeryfrontCloudChatModel | undefined {
+  return VERYFRONT_CLOUD_CHAT_MODELS.find((model) => model.id === id);
+}
+
+export function normalizeVeryfrontCloudModelId(modelId: string): string {
+  return modelId.startsWith(VERYFRONT_CLOUD_MODEL_PREFIX)
+    ? modelId.slice(VERYFRONT_CLOUD_MODEL_PREFIX.length)
+    : modelId;
+}
+
+export function findVeryfrontCloudModelByModelId(
+  modelId: string,
+): VeryfrontCloudChatModel | undefined {
+  const normalizedModelId = normalizeVeryfrontCloudModelId(modelId);
+  return VERYFRONT_CLOUD_CHAT_MODELS.find((model) => model.modelId === normalizedModelId);
+}
+
+export function getVeryfrontCloudProviderFromModelId(
+  modelId: string,
+): VeryfrontCloudProviderId {
+  const normalizedModelId = normalizeVeryfrontCloudModelId(modelId);
+  const prefix = normalizedModelId.split("/")[0];
+  if (prefix === "google-ai-studio") return "google";
+  if (prefix === "openai" || prefix === "anthropic" || prefix === "moonshotai") return prefix;
+
+  throw new Error(`Unknown model provider prefix "${prefix}" in model ID "${modelId}"`);
+}
+
+export function tryGetVeryfrontCloudProviderFromModelId(
+  modelId: string,
+): VeryfrontCloudProviderId | undefined {
+  try {
+    return getVeryfrontCloudProviderFromModelId(modelId);
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveVeryfrontCloudModelId(alias?: string): string {
+  const requestedModel = alias || DEFAULT_VERYFRONT_CLOUD_MODEL_ID;
+  const catalogModel = VERYFRONT_CLOUD_CHAT_MODELS.find((model) =>
+    model.modelId === requestedModel
+  );
+  if (catalogModel) {
+    return catalogModel.modelId;
+  }
+
+  if (requestedModel.includes("/")) {
+    return requestedModel;
+  }
+
+  const model = findVeryfrontCloudModel(requestedModel);
+  if (!model) {
+    throw new Error(`Unknown model alias "${requestedModel}"`);
+  }
+  return model.modelId;
+}
+
+export function resolveHostedVeryfrontCloudModelId(
+  modelId: string | undefined,
+): string | undefined {
+  if (!modelId) {
+    return modelId;
+  }
+
+  if (modelId.startsWith(VERYFRONT_CLOUD_MODEL_PREFIX)) {
+    return modelId;
+  }
+
+  return HOSTED_MODEL_PROVIDER_PREFIXES.some((prefix) => modelId.startsWith(prefix))
+    ? `${VERYFRONT_CLOUD_MODEL_PREFIX}${modelId}`
+    : modelId;
+}
+
+export function resolveVeryfrontCloudModelThinking(
+  modelId: string | undefined,
+): VeryfrontCloudModelThinkingConfig | undefined {
+  if (!modelId) {
+    return undefined;
+  }
+
+  const model = findVeryfrontCloudModelByModelId(modelId) ?? findVeryfrontCloudModel(modelId);
+  if (typeof model?.thinkingBudgetTokens !== "number" || model.thinkingBudgetTokens <= 0) {
+    return undefined;
+  }
+
+  return {
+    enabled: true,
+    budgetTokens: model.thinkingBudgetTokens,
+  };
+}
+
+export function resolveVeryfrontCloudThinkingProviderOptions(
+  modelId: string,
+  thinking: VeryfrontCloudModelThinkingConfig | undefined,
+): Record<string, unknown> | undefined {
+  if (
+    !thinking?.enabled || typeof thinking.budgetTokens !== "number" || thinking.budgetTokens <= 0
+  ) {
+    return undefined;
+  }
+
+  const provider = getVeryfrontCloudProviderFromModelId(modelId);
+  if (provider !== "anthropic") {
+    return undefined;
+  }
+
+  return {
+    anthropic: {
+      temperature: 1,
+      thinking: {
+        type: "enabled",
+        budget_tokens: Math.floor(thinking.budgetTokens),
+      },
+    },
+  };
+}
+
+const PROVIDER_LABELS: Record<VeryfrontCloudProviderId, string> = {
+  anthropic: "Anthropic",
+  openai: "OpenAI",
+  google: "Google",
+  moonshotai: "Kimi",
+};
+
+const PROVIDER_ORDER: VeryfrontCloudProviderId[] = ["anthropic", "openai", "google", "moonshotai"];
+
+export function groupVeryfrontCloudModelsByProvider(): Array<{
+  provider: VeryfrontCloudProviderId;
+  label: string;
+  models: VeryfrontCloudChatModel[];
+}> {
+  return PROVIDER_ORDER.map((provider) => ({
+    provider,
+    label: PROVIDER_LABELS[provider],
+    models: VERYFRONT_CLOUD_CHAT_MODELS.filter((model) => model.provider === provider),
+  })).filter((group) => group.models.length > 0);
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.381";
+export const VERSION = "0.1.382";


### PR DESCRIPTION
## Summary\n- add a public Veryfront Cloud language model catalog under veryfront/provider\n- expose alias resolution, hosted model normalization, provider grouping, thinking defaults, and Anthropic thinking provider-option helpers\n- bump package version to 0.1.382 for CI publication\n\n## Verification\n- deno check src/provider/index.ts src/provider/veryfront-cloud/model-catalog.ts src/provider/veryfront-cloud/model-catalog.test.ts\n- deno test --no-check --allow-all src/provider/veryfront-cloud/model-catalog.test.ts\n- deno task verify:quick\n- pre-push checks: fmt, lint, typecheck, unit tests