### PR TITLE
feat(agent): add runtime builtin skill file helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.382",
+  "version": "0.1.383",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -585,6 +585,18 @@ export {
   type SlashCommandArtifactPolicyInput,
 } from "./slash-command-artifact-policy.ts";
 export {
+  listRuntimeBuiltinSkillReferenceFiles,
+  listRuntimeBuiltinSkillReferences,
+  readRuntimeBuiltinDirectorySkill,
+  readRuntimeBuiltinFlatSkill,
+  readRuntimeBuiltinSkill,
+  readRuntimeBuiltinSkillEntries,
+  readRuntimeBuiltinSkillReferenceFile,
+  resolveRuntimeBuiltinSkillReferenceFilePath,
+  resolveRuntimeBuiltinSkillsDir,
+  type RuntimeBuiltinSkillEntriesResult,
+} from "./runtime-builtin-skill-files.ts";
+export {
   buildRuntimeLoadedSkillResponse,
   buildRuntimeSkillDefinition,
   normalizeRuntimeSkillReferencePath,

--- a/src/agent/runtime-builtin-skill-files.test.ts
+++ b/src/agent/runtime-builtin-skill-files.test.ts
@@ -1,0 +1,101 @@
+import { assertEquals } from "@std/assert";
+import { resolve } from "node:path";
+import {
+  listRuntimeBuiltinSkillReferenceFiles,
+  listRuntimeBuiltinSkillReferences,
+  readRuntimeBuiltinFlatSkill,
+  readRuntimeBuiltinSkill,
+  readRuntimeBuiltinSkillEntries,
+  readRuntimeBuiltinSkillReferenceFile,
+  resolveRuntimeBuiltinSkillReferenceFilePath,
+  resolveRuntimeBuiltinSkillsDir,
+} from "./runtime-builtin-skill-files.ts";
+
+function withTempDir(fn: (dir: string) => void): void {
+  const dir = Deno.makeTempDirSync();
+  try {
+    fn(dir);
+  } finally {
+    Deno.removeSync(dir, { recursive: true });
+  }
+}
+
+Deno.test("resolveRuntimeBuiltinSkillsDir resolves repo-root skills from dist-like paths", () => {
+  withTempDir((rootDir) => {
+    const baseDir = resolve(rootDir, "dist", "src", "skills");
+    const skillsDir = resolve(rootDir, "skills");
+    Deno.mkdirSync(resolve(skillsDir, "veryfront"), { recursive: true });
+    Deno.writeTextFileSync(resolve(skillsDir, "veryfront", "SKILL.md"), "body");
+
+    assertEquals(resolveRuntimeBuiltinSkillsDir(baseDir), skillsDir);
+  });
+});
+
+Deno.test("resolveRuntimeBuiltinSkillsDir falls back to the first candidate", () => {
+  withTempDir((rootDir) => {
+    const baseDir = resolve(rootDir, "app", "src", "skills");
+
+    assertEquals(resolveRuntimeBuiltinSkillsDir(baseDir), resolve(baseDir, "../../../skills"));
+  });
+});
+
+Deno.test("readRuntimeBuiltinSkillEntries reports entries and read errors", () => {
+  withTempDir((rootDir) => {
+    Deno.writeTextFileSync(resolve(rootDir, "build.md"), "body");
+
+    const result = readRuntimeBuiltinSkillEntries(rootDir);
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.entries.map((entry) => entry.name), ["build.md"]);
+    }
+
+    const missing = readRuntimeBuiltinSkillEntries(resolve(rootDir, "missing"));
+    assertEquals(missing.ok, false);
+  });
+});
+
+Deno.test("readRuntimeBuiltinSkill prefers directory skills over flat skills", () => {
+  withTempDir((rootDir) => {
+    Deno.mkdirSync(resolve(rootDir, "writer"), { recursive: true });
+    Deno.writeTextFileSync(resolve(rootDir, "writer", "SKILL.md"), "directory skill");
+    Deno.writeTextFileSync(resolve(rootDir, "writer.md"), "flat skill");
+
+    assertEquals(readRuntimeBuiltinSkill(rootDir, "writer"), "directory skill");
+    assertEquals(readRuntimeBuiltinFlatSkill(rootDir, "writer"), "flat skill");
+  });
+});
+
+Deno.test("runtime builtin skill reference helpers reject traversal and read valid files", () => {
+  withTempDir((rootDir) => {
+    const refsDir = resolve(rootDir, "writer", "references");
+    Deno.mkdirSync(refsDir, { recursive: true });
+    Deno.writeTextFileSync(resolve(refsDir, "guide.md"), "guide");
+    Deno.writeTextFileSync(resolve(refsDir, "notes.md"), "notes");
+    Deno.mkdirSync(resolve(refsDir, "nested"));
+
+    assertEquals(
+      resolveRuntimeBuiltinSkillReferenceFilePath(rootDir, "writer", "references/guide.md"),
+      resolve(refsDir, "guide.md"),
+    );
+    assertEquals(
+      resolveRuntimeBuiltinSkillReferenceFilePath(rootDir, "writer", "../escape.md"),
+      null,
+    );
+    assertEquals(
+      readRuntimeBuiltinSkillReferenceFile(rootDir, "writer", "references/guide.md"),
+      "guide",
+    );
+    assertEquals(
+      readRuntimeBuiltinSkillReferenceFile(rootDir, "writer", "references/missing.md"),
+      null,
+    );
+    assertEquals(listRuntimeBuiltinSkillReferenceFiles(rootDir, "writer"), [
+      "guide.md",
+      "notes.md",
+    ]);
+    assertEquals(listRuntimeBuiltinSkillReferences(rootDir, "writer"), [
+      "references/guide.md",
+      "references/notes.md",
+    ]);
+  });
+});

--- a/src/agent/runtime-builtin-skill-files.ts
+++ b/src/agent/runtime-builtin-skill-files.ts
@@ -1,0 +1,121 @@
+import { type Dirent, existsSync, readdirSync, readFileSync } from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
+import { normalizeRuntimeSkillReferencePath } from "./runtime-skill-metadata.ts";
+
+export type RuntimeBuiltinSkillEntriesResult = { ok: true; entries: Dirent[] } | {
+  ok: false;
+  errorMessage: string;
+};
+
+function hasRuntimeBuiltinSkillFiles(path: string): boolean {
+  return existsSync(resolve(path, "build.md")) ||
+    existsSync(resolve(path, "veryfront", "SKILL.md"));
+}
+
+export function resolveRuntimeBuiltinSkillsDir(baseDir: string): string {
+  const firstCandidate = resolve(baseDir, "../../../skills");
+  const candidates = [
+    firstCandidate,
+    resolve(baseDir, "../../skills"),
+    resolve(baseDir, "../skills"),
+  ];
+
+  return candidates.find((candidate) => hasRuntimeBuiltinSkillFiles(candidate)) ?? firstCandidate;
+}
+
+export function readRuntimeBuiltinSkillEntries(
+  skillsDir: string,
+): RuntimeBuiltinSkillEntriesResult {
+  try {
+    return {
+      ok: true,
+      entries: readdirSync(skillsDir, { withFileTypes: true }),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function resolveRuntimeBuiltinSkillReferenceFilePath(
+  skillsDir: string,
+  skillId: string,
+  file: string,
+): string | null {
+  const normalizedFile = normalizeRuntimeSkillReferencePath(file);
+  if (!normalizedFile) {
+    return null;
+  }
+
+  const skillDir = resolve(skillsDir, skillId);
+  const filePath = resolve(skillDir, normalizedFile);
+  const relativePath = relative(skillDir, filePath);
+
+  if (relativePath.length === 0 || isAbsolute(relativePath) || relativePath.startsWith("..")) {
+    return null;
+  }
+
+  return filePath;
+}
+
+export function readRuntimeBuiltinSkillReferenceFile(
+  skillsDir: string,
+  skillId: string,
+  file: string,
+): string | null {
+  const filePath = resolveRuntimeBuiltinSkillReferenceFilePath(skillsDir, skillId, file);
+  if (!filePath || !existsSync(filePath)) {
+    return null;
+  }
+
+  return readFileSync(filePath, "utf-8");
+}
+
+export function readRuntimeBuiltinDirectorySkill(
+  skillsDir: string,
+  skillId: string,
+): string | null {
+  const directorySkillPath = resolve(skillsDir, skillId, "SKILL.md");
+  if (!existsSync(directorySkillPath)) {
+    return null;
+  }
+
+  return readFileSync(directorySkillPath, "utf-8");
+}
+
+export function readRuntimeBuiltinFlatSkill(skillsDir: string, skillId: string): string | null {
+  const flatSkillPath = resolve(skillsDir, `${skillId}.md`);
+  if (!existsSync(flatSkillPath)) {
+    return null;
+  }
+
+  return readFileSync(flatSkillPath, "utf-8");
+}
+
+export function readRuntimeBuiltinSkill(skillsDir: string, skillId: string): string | null {
+  return readRuntimeBuiltinDirectorySkill(skillsDir, skillId) ??
+    readRuntimeBuiltinFlatSkill(skillsDir, skillId);
+}
+
+export function listRuntimeBuiltinSkillReferenceFiles(
+  skillsDir: string,
+  skillId: string,
+): string[] {
+  const refsDir = resolve(skillsDir, skillId, "references");
+  if (!existsSync(refsDir)) {
+    return [];
+  }
+
+  return readdirSync(refsDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+export function listRuntimeBuiltinSkillReferences(skillsDir: string, skillId: string): string[] {
+  return listRuntimeBuiltinSkillReferenceFiles(skillsDir, skillId).map((file) =>
+    `references/${file}`
+  );
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.382";
+export const VERSION = "0.1.383";


### PR DESCRIPTION
## Summary\n- add reusable runtime builtin skill file helpers for agent services\n- export helpers from the public agent runtime surface\n- bump package version to 0.1.383 for CI/CD publishing\n\n## Verification\n- deno check src/agent/index.ts src/agent/runtime-builtin-skill-files.ts src/agent/runtime-builtin-skill-files.test.ts\n- deno test --no-check --allow-all src/agent/runtime-builtin-skill-files.test.ts\n- deno task verify:quick