### PR TITLE
feat(agent): add runtime project files client

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.383",
+  "version": "0.1.384",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -597,6 +597,22 @@ export {
   type RuntimeBuiltinSkillEntriesResult,
 } from "./runtime-builtin-skill-files.ts";
 export {
+  createRuntimeProjectFilesClient,
+  getRuntimeProjectFile,
+  getRuntimeProjectFiles,
+  type RuntimeGetProjectFileOptions,
+  type RuntimeProjectFile,
+  type RuntimeProjectFileListItem,
+  runtimeProjectFileListItemSchema,
+  RuntimeProjectFilesApiAuthError,
+  type RuntimeProjectFilesApiOptions,
+  runtimeProjectFileSchema,
+  type RuntimeProjectFilesClient,
+  type RuntimeProjectFilesClientOptions,
+  type RuntimeProjectFilesFetch,
+  type RuntimeProjectFilesTrace,
+} from "./runtime-project-files-client.ts";
+export {
   buildRuntimeLoadedSkillResponse,
   buildRuntimeSkillDefinition,
   normalizeRuntimeSkillReferencePath,

--- a/src/agent/runtime-project-files-client.test.ts
+++ b/src/agent/runtime-project-files-client.test.ts
@@ -1,0 +1,256 @@
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
+import {
+  getRuntimeProjectFile,
+  getRuntimeProjectFiles,
+  RuntimeProjectFilesApiAuthError,
+  type RuntimeProjectFilesFetch,
+} from "./runtime-project-files-client.ts";
+
+const baseOptions = {
+  apiUrl: "https://api.test",
+  projectId: "project-1",
+  authToken: "token-1",
+};
+
+type FetchCall = {
+  url: string;
+  init: RequestInit;
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function textResponse(body: string, status: number): Response {
+  return new Response(body, { status });
+}
+
+function mockFetchResponses(
+  ...responses: Response[]
+): RuntimeProjectFilesFetch & { calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fetchMock = async (url: string, init: RequestInit): Promise<Response> => {
+    calls.push({ url, init });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error("Unexpected fetch call");
+    }
+    return response;
+  };
+
+  return Object.assign(fetchMock, { calls });
+}
+
+function getRequestedUrl(fetchSpy: ReturnType<typeof mockFetchResponses>, index = 0): URL {
+  return new URL(getFetchCall(fetchSpy, index).url);
+}
+
+function getFetchCall(fetchSpy: ReturnType<typeof mockFetchResponses>, index = 0): FetchCall {
+  const call = fetchSpy.calls[index];
+  if (!call) {
+    throw new Error(`Expected fetch call ${index}`);
+  }
+  return call;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  throw new Error("Expected Error");
+}
+
+Deno.test("getRuntimeProjectFile returns a project file from the API file route", async () => {
+  const fileData = { path: "src/index.ts", content: "hello" };
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({ ...fileData, type: "file", size: 5, checksum: null }),
+  );
+
+  const result = await getRuntimeProjectFile({
+    ...baseOptions,
+    fetch: fetchSpy,
+    path: "src/index.ts",
+  });
+
+  assertEquals(result, fileData);
+});
+
+Deno.test("getRuntimeProjectFile returns null when the API file route returns 404", async () => {
+  const fetchSpy = mockFetchResponses(textResponse("File not found", 404));
+
+  const result = await getRuntimeProjectFile({
+    ...baseOptions,
+    fetch: fetchSpy,
+    path: "missing.ts",
+  });
+
+  assertEquals(result, null);
+});
+
+Deno.test("getRuntimeProjectFile throws auth errors for API HTTP 401 and 403", async () => {
+  const unauthorizedFetch = mockFetchResponses(textResponse("Unauthorized", 401));
+  const unauthorizedError = await assertRejects(() =>
+    getRuntimeProjectFile({ ...baseOptions, fetch: unauthorizedFetch, path: "src/index.ts" })
+  );
+  assertInstanceOf(unauthorizedError, RuntimeProjectFilesApiAuthError);
+
+  const forbiddenFetch = mockFetchResponses(textResponse("Forbidden", 403));
+  const forbiddenError = await assertRejects(() =>
+    getRuntimeProjectFile({ ...baseOptions, fetch: forbiddenFetch, path: "src/index.ts" })
+  );
+  assertInstanceOf(forbiddenError, RuntimeProjectFilesApiAuthError);
+});
+
+Deno.test("getRuntimeProjectFile supports a custom access-denied error factory", async () => {
+  const fetchSpy = mockFetchResponses(textResponse("Forbidden", 403));
+
+  const error = await assertRejects(() =>
+    getRuntimeProjectFile({
+      ...baseOptions,
+      fetch: fetchSpy,
+      path: "src/index.ts",
+      createAccessDeniedError: (statusCode, message) => new Error(`${statusCode}: ${message}`),
+    })
+  );
+
+  assertEquals(getErrorMessage(error), "403: Access denied to project files API");
+});
+
+Deno.test("getRuntimeProjectFile reports upstream and network errors", async () => {
+  const upstreamFetch = mockFetchResponses(textResponse("Internal Server Error", 500));
+  const upstreamError = await assertRejects(() =>
+    getRuntimeProjectFile({ ...baseOptions, fetch: upstreamFetch, path: "src/index.ts" })
+  );
+  assertStringIncludes(
+    getErrorMessage(upstreamError),
+    "Failed to fetch file src/index.ts for project project-1: Internal Server Error",
+  );
+
+  const networkFetch: RuntimeProjectFilesFetch = async () => {
+    throw new Error("ECONNREFUSED");
+  };
+  const networkError = await assertRejects(() =>
+    getRuntimeProjectFile({ ...baseOptions, fetch: networkFetch, path: "src/index.ts" })
+  );
+  assertStringIncludes(getErrorMessage(networkError), "ECONNREFUSED");
+});
+
+Deno.test("getRuntimeProjectFile passes project, path, branch, fields, and auth through REST", async () => {
+  const fetchSpy = mockFetchResponses(jsonResponse({ path: "src/index.ts", content: "hello" }));
+
+  await getRuntimeProjectFile({
+    ...baseOptions,
+    fetch: fetchSpy,
+    path: "src/index.ts",
+    branchId: "branch-1",
+  });
+
+  const url = getRequestedUrl(fetchSpy);
+  assertEquals(url.origin, "https://api.test");
+  assertEquals(url.pathname, "/projects/project-1/files/src%2Findex.ts");
+  assertEquals(url.searchParams.get("branch"), "branch-1");
+  assertEquals(url.searchParams.get("fields"), "(path,content)");
+  assertEquals(
+    new Headers(getFetchCall(fetchSpy).init.headers).get("Authorization"),
+    "Bearer token-1",
+  );
+});
+
+Deno.test("getRuntimeProjectFiles returns project file paths from the API list route", async () => {
+  const files = [{ path: "src/index.ts" }];
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({
+      data: [{
+        ...files[0],
+        type: "file",
+        size: 1,
+        content: "ignored",
+        updated_at: "2026-01-01T00:00:00Z",
+      }],
+      page_info: { next: null },
+    }),
+  );
+
+  const result = await getRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy });
+
+  assertEquals(result, files);
+});
+
+Deno.test("getRuntimeProjectFiles follows API pagination until no next cursor remains", async () => {
+  const fetchSpy = mockFetchResponses(
+    jsonResponse({
+      data: [{ path: "a.ts" }],
+      page_info: { next: "cursor-2" },
+    }),
+    jsonResponse({
+      data: [{ path: "b.ts" }],
+      page_info: { next: null },
+    }),
+  );
+
+  const result = await getRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy });
+
+  assertEquals(result, [{ path: "a.ts" }, { path: "b.ts" }]);
+  assertEquals(getRequestedUrl(fetchSpy, 1).searchParams.get("cursor"), "cursor-2");
+});
+
+Deno.test("getRuntimeProjectFiles throws auth errors for API HTTP 401 and 403", async () => {
+  const unauthorizedFetch = mockFetchResponses(textResponse("Unauthorized", 401));
+  const unauthorizedError = await assertRejects(() =>
+    getRuntimeProjectFiles({ ...baseOptions, fetch: unauthorizedFetch })
+  );
+  assertInstanceOf(unauthorizedError, RuntimeProjectFilesApiAuthError);
+
+  const forbiddenFetch = mockFetchResponses(textResponse("Forbidden", 403));
+  const forbiddenError = await assertRejects(() =>
+    getRuntimeProjectFiles({ ...baseOptions, fetch: forbiddenFetch })
+  );
+  assertInstanceOf(forbiddenError, RuntimeProjectFilesApiAuthError);
+});
+
+Deno.test("getRuntimeProjectFiles reports upstream and network errors", async () => {
+  const notFoundFetch = mockFetchResponses(textResponse("Project not found", 404));
+  const notFoundError = await assertRejects(() =>
+    getRuntimeProjectFiles({ ...baseOptions, fetch: notFoundFetch })
+  );
+  assertStringIncludes(getErrorMessage(notFoundError), "Project not found");
+
+  const upstreamFetch = mockFetchResponses(textResponse("Internal Server Error", 500));
+  const upstreamError = await assertRejects(() =>
+    getRuntimeProjectFiles({ ...baseOptions, fetch: upstreamFetch })
+  );
+  assertStringIncludes(getErrorMessage(upstreamError), "Internal Server Error");
+
+  const networkFetch: RuntimeProjectFilesFetch = async () => {
+    throw new Error("ECONNREFUSED");
+  };
+  const networkError = await assertRejects(() =>
+    getRuntimeProjectFiles({ ...baseOptions, fetch: networkFetch })
+  );
+  assertStringIncludes(getErrorMessage(networkError), "ECONNREFUSED");
+});
+
+Deno.test("getRuntimeProjectFiles passes project, branch, fields, pagination limit, and auth through REST", async () => {
+  const fetchSpy = mockFetchResponses(jsonResponse({ data: [], page_info: { next: null } }));
+
+  await getRuntimeProjectFiles({ ...baseOptions, fetch: fetchSpy, branchId: "branch-1" });
+
+  const url = getRequestedUrl(fetchSpy);
+  assertEquals(url.origin, "https://api.test");
+  assertEquals(url.pathname, "/projects/project-1/files");
+  assertEquals(url.searchParams.get("branch"), "branch-1");
+  assertEquals(url.searchParams.get("fields"), "(path)");
+  assertEquals(url.searchParams.get("limit"), "100");
+  assertEquals(
+    new Headers(getFetchCall(fetchSpy).init.headers).get("Authorization"),
+    "Bearer token-1",
+  );
+});

--- a/src/agent/runtime-project-files-client.ts
+++ b/src/agent/runtime-project-files-client.ts
@@ -1,0 +1,244 @@
+import { z } from "zod";
+
+const DEFAULT_PROJECT_FILES_TIMEOUT_MS = 15_000;
+const DEFAULT_PROJECT_FILES_PAGE_LIMIT = 100;
+
+export const runtimeProjectFileSchema = z.object({
+  path: z.string(),
+  content: z.string(),
+});
+
+export const runtimeProjectFileListItemSchema = z.object({
+  path: z.string(),
+});
+
+const runtimeProjectFileListRestResponseSchema = z.object({
+  data: z.array(runtimeProjectFileListItemSchema),
+  page_info: z.object({
+    next: z.string().nullable(),
+  }),
+});
+
+const apiErrorBodySchema = z
+  .object({
+    detail: z.string().optional(),
+    message: z.string().optional(),
+    error: z.string().optional(),
+  })
+  .passthrough();
+
+export type RuntimeProjectFile = z.infer<typeof runtimeProjectFileSchema>;
+export type RuntimeProjectFileListItem = z.infer<typeof runtimeProjectFileListItemSchema>;
+
+export type RuntimeProjectFilesApiOptions = {
+  projectId: string;
+  authToken: string;
+  branchId?: string | null;
+};
+
+export type RuntimeGetProjectFileOptions = RuntimeProjectFilesApiOptions & {
+  path: string;
+};
+
+export type RuntimeProjectFilesFetch = (url: string, init: RequestInit) => Promise<Response>;
+
+export type RuntimeProjectFilesTrace = <T>(name: string, fn: () => Promise<T>) => Promise<T>;
+
+export type RuntimeProjectFilesClientOptions = {
+  apiUrl: string | URL;
+  fetch?: RuntimeProjectFilesFetch;
+  timeoutMs?: number;
+  pageLimit?: number;
+  trace?: RuntimeProjectFilesTrace;
+  createAccessDeniedError?: (statusCode: number, message: string) => Error;
+};
+
+export type RuntimeProjectFilesClient = {
+  getProjectFile: (options: RuntimeGetProjectFileOptions) => Promise<RuntimeProjectFile | null>;
+  getProjectFiles: (
+    options: RuntimeProjectFilesApiOptions,
+  ) => Promise<RuntimeProjectFileListItem[]>;
+};
+
+export class RuntimeProjectFilesApiAuthError extends Error {
+  readonly statusCode: number;
+  readonly errorCode: string;
+
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.name = "RuntimeProjectFilesApiAuthError";
+    this.statusCode = statusCode;
+    this.errorCode = statusCode === 401 ? "UNAUTHENTICATED" : "FORBIDDEN";
+  }
+}
+
+export function createRuntimeProjectFilesClient(
+  options: RuntimeProjectFilesClientOptions,
+): RuntimeProjectFilesClient {
+  return {
+    getProjectFile: (input) => getRuntimeProjectFile({ ...options, ...input }),
+    getProjectFiles: (input) => getRuntimeProjectFiles({ ...options, ...input }),
+  };
+}
+
+export async function getRuntimeProjectFile(
+  options: RuntimeProjectFilesClientOptions & RuntimeGetProjectFileOptions,
+): Promise<RuntimeProjectFile | null> {
+  return traceProjectFilesRequest(options, "runtimeProjectFiles.getProjectFile", async () => {
+    const url = createRuntimeProjectFileUrl({
+      ...options,
+      fields: "(path,content)",
+    });
+    const response = await fetchRuntimeProjectFilesRestResponse(url, options);
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch file ${options.path} for project ${options.projectId}: ${await readApiErrorMessage(
+          response,
+        )}`,
+      );
+    }
+
+    const parsed = runtimeProjectFileSchema.safeParse(await response.json());
+    if (!parsed.success) {
+      throw new Error(
+        `Failed to fetch file ${options.path} for project ${options.projectId}: invalid API response`,
+      );
+    }
+
+    return parsed.data;
+  });
+}
+
+export async function getRuntimeProjectFiles(
+  options: RuntimeProjectFilesClientOptions & RuntimeProjectFilesApiOptions,
+): Promise<RuntimeProjectFileListItem[]> {
+  return traceProjectFilesRequest(options, "runtimeProjectFiles.getProjectFiles", async () => {
+    const files: RuntimeProjectFileListItem[] = [];
+    let cursor: string | null = null;
+
+    do {
+      const url = createRuntimeProjectFileUrl({
+        ...options,
+        fields: "(path)",
+        cursor,
+      });
+      const response = await fetchRuntimeProjectFilesRestResponse(url, options);
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch files for project ${options.projectId}: ${await readApiErrorMessage(
+            response,
+          )}`,
+        );
+      }
+
+      const parsed = runtimeProjectFileListRestResponseSchema.safeParse(await response.json());
+      if (!parsed.success) {
+        throw new Error(
+          `Failed to fetch files for project ${options.projectId}: invalid API response`,
+        );
+      }
+
+      files.push(...parsed.data.data);
+      cursor = parsed.data.page_info.next;
+    } while (cursor);
+
+    return files;
+  });
+}
+
+function createRuntimeProjectFileUrl(input: {
+  apiUrl: string | URL;
+  projectId: string;
+  path?: string;
+  branchId?: string | null;
+  fields: string;
+  cursor?: string | null;
+  pageLimit?: number;
+}): URL {
+  const apiUrl = new URL(input.apiUrl);
+  const encodedProjectId = encodeURIComponent(input.projectId);
+  const pathname = input.path
+    ? `/projects/${encodedProjectId}/files/${encodeURIComponent(input.path)}`
+    : `/projects/${encodedProjectId}/files`;
+  const url = new URL(pathname, apiUrl.origin);
+
+  url.searchParams.set("fields", input.fields);
+  if (input.branchId) {
+    url.searchParams.set("branch", input.branchId);
+  }
+  if (input.cursor) {
+    url.searchParams.set("cursor", input.cursor);
+  }
+  if (!input.path) {
+    url.searchParams.set("limit", String(input.pageLimit ?? DEFAULT_PROJECT_FILES_PAGE_LIMIT));
+  }
+
+  return url;
+}
+
+async function fetchRuntimeProjectFilesRestResponse(
+  url: URL,
+  options: RuntimeProjectFilesClientOptions & { authToken: string },
+): Promise<Response> {
+  const response = await (options.fetch ?? fetch)(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${options.authToken}`,
+    },
+    signal: AbortSignal.timeout(options.timeoutMs ?? DEFAULT_PROJECT_FILES_TIMEOUT_MS),
+  });
+
+  if (response.status === 401 || response.status === 403) {
+    throw createProjectFilesAccessDeniedError(options, response.status);
+  }
+
+  return response;
+}
+
+function createProjectFilesAccessDeniedError(
+  options: RuntimeProjectFilesClientOptions,
+  statusCode: number,
+): Error {
+  const message = "Access denied to project files API";
+  return options.createAccessDeniedError?.(statusCode, message) ??
+    new RuntimeProjectFilesApiAuthError(statusCode, message);
+}
+
+async function readApiErrorMessage(response: Response): Promise<string> {
+  const body = await response.text().catch(() => "");
+  if (!body.trim()) {
+    return response.statusText || `HTTP ${response.status}`;
+  }
+
+  const parsedJson = z
+    .string()
+    .transform((value, ctx) => {
+      try {
+        return JSON.parse(value);
+      } catch {
+        ctx.addIssue({ code: "custom", message: "Invalid JSON" });
+        return z.NEVER;
+      }
+    })
+    .pipe(apiErrorBodySchema)
+    .safeParse(body);
+
+  if (parsedJson.success) {
+    return parsedJson.data.detail ?? parsedJson.data.message ?? parsedJson.data.error ?? body;
+  }
+
+  return body;
+}
+
+function traceProjectFilesRequest<T>(
+  options: RuntimeProjectFilesClientOptions,
+  name: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return options.trace ? options.trace(name, fn) : fn();
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.383";
+export const VERSION = "0.1.384";


### PR DESCRIPTION
## Summary
- add a reusable runtime project files REST client for agent runtimes
- expose project file schemas, client helpers, and auth error type from veryfront/agent
- bump package version to 0.1.384 for CI/CD publishing

## Verification
- deno test --no-check --allow-all src/agent/runtime-project-files-client.test.ts
- deno check src/agent/index.ts src/agent/runtime-project-files-client.ts src/agent/runtime-project-files-client.test.ts
- deno task verify:quick
- pre-push checks: format, lint, typecheck, unit tests