### PR TITLE
Add runtime file URL helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.384",
+  "version": "0.1.385",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -509,6 +509,17 @@ export {
   getAgentRuntimeToolResultPart,
 } from "./agent-runtime-message-adapter.ts";
 export {
+  resolveRuntimeMessageFileUrls,
+  type RuntimeFileUrlResolver,
+  type RuntimeFileUrlResolverInput,
+} from "./runtime-message-file-url-refresh.ts";
+export {
+  getRuntimeUploadUrl,
+  type RuntimeUploadUrlClientOptions,
+  type RuntimeUploadUrlFetch,
+  type RuntimeUploadUrlOptions,
+} from "./runtime-upload-url-client.ts";
+export {
   type ChildRunExecutionBufferCleanupInput,
   type ChildRunExecutionResourceFinalizeInput,
   closeChildRunExecutionBuffers,

--- a/src/agent/runtime-message-file-url-refresh.test.ts
+++ b/src/agent/runtime-message-file-url-refresh.test.ts
@@ -1,0 +1,78 @@
+import { assertEquals } from "../testing/assert.ts";
+import type { ChatUiMessage } from "../chat/types.ts";
+import { resolveRuntimeMessageFileUrls } from "./runtime-message-file-url-refresh.ts";
+
+function userMessage(parts: ChatUiMessage["parts"]): ChatUiMessage {
+  return {
+    id: "message-1",
+    role: "user",
+    parts,
+  };
+}
+
+Deno.test("resolveRuntimeMessageFileUrls refreshes upload file URLs once", async () => {
+  const resolvedUploadIds: string[] = [];
+  const messages = await resolveRuntimeMessageFileUrls(
+    [
+      userMessage([
+        { type: "text", text: "Use these files." },
+        {
+          type: "file",
+          mediaType: "text/plain",
+          filename: "notes.txt",
+          uploadId: "upload-1",
+          url: "https://files.example.com/original.txt",
+        },
+        {
+          type: "file",
+          mediaType: "text/plain",
+          filename: "copy.txt",
+          uploadId: "upload-1",
+          url: "https://files.example.com/copy.txt",
+        },
+      ]),
+    ],
+    async ({ uploadId }) => {
+      resolvedUploadIds.push(uploadId);
+      return "https://signed.example.com/file.txt";
+    },
+  );
+
+  assertEquals(resolvedUploadIds, ["upload-1"]);
+  assertEquals(messages[0]?.parts, [
+    { type: "text", text: "Use these files." },
+    {
+      type: "file",
+      mediaType: "text/plain",
+      filename: "notes.txt",
+      uploadId: "upload-1",
+      url: "https://signed.example.com/file.txt",
+    },
+    {
+      type: "file",
+      mediaType: "text/plain",
+      filename: "copy.txt",
+      uploadId: "upload-1",
+      url: "https://signed.example.com/file.txt",
+    },
+  ]);
+});
+
+Deno.test("resolveRuntimeMessageFileUrls keeps existing parts when resolver returns no URL", async () => {
+  const messages = [
+    userMessage([
+      {
+        type: "file",
+        mediaType: "text/plain",
+        filename: "notes.txt",
+        uploadId: "upload-1",
+        url: "https://files.example.com/original.txt",
+      },
+    ]),
+  ];
+
+  assertEquals(
+    await resolveRuntimeMessageFileUrls(messages, () => Promise.resolve(undefined)),
+    messages,
+  );
+});

--- a/src/agent/runtime-message-file-url-refresh.ts
+++ b/src/agent/runtime-message-file-url-refresh.ts
@@ -1,0 +1,54 @@
+import type { ChatFileUiPart, ChatUiMessage, FileUIPartWithUpload } from "../chat/types.ts";
+
+export type RuntimeFileUrlResolverInput = {
+  uploadId: string;
+  part: FileUIPartWithUpload;
+  message: ChatUiMessage;
+};
+
+export type RuntimeFileUrlResolver = (
+  input: RuntimeFileUrlResolverInput,
+) => Promise<string | undefined>;
+
+export async function resolveRuntimeMessageFileUrls(
+  messages: readonly ChatUiMessage[],
+  resolveFileUrl: RuntimeFileUrlResolver,
+): Promise<ChatUiMessage[]> {
+  const urlByUploadId = new Map<string, Promise<string | undefined>>();
+
+  return Promise.all(
+    messages.map(async (message) => {
+      if (!message.parts.some((part) => part.type === "file" && part.uploadId)) {
+        return message;
+      }
+
+      const parts = await Promise.all(
+        message.parts.map(async (part) => {
+          if (!isFilePartWithUpload(part)) return part;
+
+          let urlPromise = urlByUploadId.get(part.uploadId);
+          if (!urlPromise) {
+            urlPromise = resolveFileUrl({ uploadId: part.uploadId, part, message });
+            urlByUploadId.set(part.uploadId, urlPromise);
+          }
+
+          const signedUrl = await urlPromise;
+          if (!signedUrl || signedUrl === part.url) return part;
+
+          return {
+            ...part,
+            url: signedUrl,
+          };
+        }),
+      );
+
+      return { ...message, parts };
+    }),
+  );
+}
+
+function isFilePartWithUpload(part: ChatUiMessage["parts"][number]): part is ChatFileUiPart & {
+  uploadId: string;
+} {
+  return part.type === "file" && typeof part.uploadId === "string" && part.uploadId.length > 0;
+}

--- a/src/agent/runtime-upload-url-client.test.ts
+++ b/src/agent/runtime-upload-url-client.test.ts
@@ -1,0 +1,91 @@
+import { assertEquals, assertRejects } from "../testing/assert.ts";
+import { getRuntimeUploadUrl } from "./runtime-upload-url-client.ts";
+
+Deno.test("getRuntimeUploadUrl fetches project-scoped signed upload URLs", async () => {
+  const requestedUrls: string[] = [];
+  const fetchUploadUrl = (url: string, _init: RequestInit): Promise<Response> => {
+    requestedUrls.push(url);
+    return Promise.resolve(
+      new Response(JSON.stringify({ signed_url: "https://signed.example.com/file.txt" }), {
+        status: 200,
+      }),
+    );
+  };
+
+  const signedUrl = await getRuntimeUploadUrl({
+    apiUrl: "https://api.example.com/base",
+    authToken: "token-1",
+    projectId: "project-1",
+    uploadId: "uploads/notes.txt",
+    fetch: fetchUploadUrl,
+  });
+
+  assertEquals(signedUrl, "https://signed.example.com/file.txt");
+  assertEquals(requestedUrls, [
+    "https://api.example.com/projects/project-1/uploads/uploads%2Fnotes.txt/url",
+  ]);
+});
+
+Deno.test("getRuntimeUploadUrl fetches global signed upload URLs", async () => {
+  const requestedUrls: string[] = [];
+  const fetchUploadUrl = (url: string, _init: RequestInit): Promise<Response> => {
+    requestedUrls.push(url);
+    return Promise.resolve(
+      new Response(JSON.stringify({ signed_url: "https://signed.example.com/global.txt" }), {
+        status: 200,
+      }),
+    );
+  };
+
+  const signedUrl = await getRuntimeUploadUrl({
+    apiUrl: "https://api.example.com",
+    authToken: "token-1",
+    uploadId: "upload-1",
+    fetch: fetchUploadUrl,
+  });
+
+  assertEquals(signedUrl, "https://signed.example.com/global.txt");
+  assertEquals(requestedUrls, ["https://api.example.com/uploads/upload-1/url"]);
+});
+
+Deno.test("getRuntimeUploadUrl reports API errors", async () => {
+  const fetchUploadUrl = (_url: string, _init: RequestInit): Promise<Response> =>
+    Promise.resolve(
+      new Response(JSON.stringify({ detail: "not allowed" }), {
+        status: 403,
+      }),
+    );
+
+  await assertRejects(
+    () =>
+      getRuntimeUploadUrl({
+        apiUrl: "https://api.example.com",
+        authToken: "token-1",
+        uploadId: "upload-1",
+        fetch: fetchUploadUrl,
+      }),
+    Error,
+    "not allowed",
+  );
+});
+
+Deno.test("getRuntimeUploadUrl rejects invalid responses", async () => {
+  const fetchUploadUrl = (_url: string, _init: RequestInit): Promise<Response> =>
+    Promise.resolve(
+      new Response(JSON.stringify({ url: "https://signed.example.com/file.txt" }), {
+        status: 200,
+      }),
+    );
+
+  await assertRejects(
+    () =>
+      getRuntimeUploadUrl({
+        apiUrl: "https://api.example.com",
+        authToken: "token-1",
+        uploadId: "upload-1",
+        fetch: fetchUploadUrl,
+      }),
+    Error,
+    "invalid API response",
+  );
+});

--- a/src/agent/runtime-upload-url-client.ts
+++ b/src/agent/runtime-upload-url-client.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+
+const DEFAULT_RUNTIME_UPLOAD_URL_TIMEOUT_MS = 15_000;
+
+const runtimeUploadUrlResponseSchema = z.object({
+  signed_url: z.string(),
+});
+
+const apiErrorBodySchema = z
+  .object({
+    detail: z.string().optional(),
+    message: z.string().optional(),
+    error: z.string().optional(),
+  })
+  .passthrough();
+
+export type RuntimeUploadUrlFetch = (url: string, init: RequestInit) => Promise<Response>;
+
+export type RuntimeUploadUrlClientOptions = {
+  apiUrl: string | URL;
+  fetch?: RuntimeUploadUrlFetch;
+  timeoutMs?: number;
+};
+
+export type RuntimeUploadUrlOptions = RuntimeUploadUrlClientOptions & {
+  authToken: string;
+  uploadId: string;
+  projectId?: string | null;
+};
+
+export async function getRuntimeUploadUrl(options: RuntimeUploadUrlOptions): Promise<string> {
+  const url = createRuntimeUploadUrl(options);
+  const response = await (options.fetch ?? fetch)(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${options.authToken}`,
+    },
+    signal: AbortSignal.timeout(options.timeoutMs ?? DEFAULT_RUNTIME_UPLOAD_URL_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch signed upload URL for ${options.uploadId}: ${await readApiErrorMessage(
+        response,
+      )}`,
+    );
+  }
+
+  const parsed = runtimeUploadUrlResponseSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new Error(
+      `Failed to fetch signed upload URL for ${options.uploadId}: invalid API response`,
+    );
+  }
+
+  return parsed.data.signed_url;
+}
+
+function createRuntimeUploadUrl(input: {
+  apiUrl: string | URL;
+  uploadId: string;
+  projectId?: string | null;
+}): URL {
+  const apiUrl = new URL(input.apiUrl);
+  const encodedUploadId = encodeURIComponent(input.uploadId);
+  const pathname = input.projectId
+    ? `/projects/${encodeURIComponent(input.projectId)}/uploads/${encodedUploadId}/url`
+    : `/uploads/${encodedUploadId}/url`;
+  return new URL(pathname, apiUrl.origin);
+}
+
+async function readApiErrorMessage(response: Response): Promise<string> {
+  const body = await response.text().catch(() => "");
+  if (!body.trim()) {
+    return response.statusText || `HTTP ${response.status}`;
+  }
+
+  const parsedJson = z
+    .string()
+    .transform((value, ctx) => {
+      try {
+        return JSON.parse(value);
+      } catch {
+        ctx.addIssue({ code: "custom", message: "Invalid JSON" });
+        return z.NEVER;
+      }
+    })
+    .pipe(apiErrorBodySchema)
+    .safeParse(body);
+
+  if (parsedJson.success) {
+    return parsedJson.data.detail ?? parsedJson.data.message ?? parsedJson.data.error ?? body;
+  }
+
+  return body;
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.384";
+export const VERSION = "0.1.385";


### PR DESCRIPTION
## Summary\n- Add host-neutral runtime message file URL refresh helper with per-upload caching\n- Add runtime upload signed URL client for reusable agent hosts\n- Bump framework package version to 0.1.385 for CI/CD publishing\n\n## Verification\n- deno test --no-check --allow-all src/agent/runtime-message-file-url-refresh.test.ts src/agent/runtime-upload-url-client.test.ts\n- deno check src/agent/index.ts src/agent/runtime-message-file-url-refresh.ts src/agent/runtime-message-file-url-refresh.test.ts src/agent/runtime-upload-url-client.ts src/agent/runtime-upload-url-client.test.ts\n- deno task verify:quick\n- pre-push checks: format, lint, typecheck, unit tests (1638 passed, 0 failed)