### PR TITLE
Add runtime message preparation helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.385",
+  "version": "0.1.386",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -514,6 +514,10 @@ export {
   type RuntimeFileUrlResolverInput,
 } from "./runtime-message-file-url-refresh.ts";
 export {
+  prepareAgentRuntimeMessagesFromUiMessages,
+  type PrepareAgentRuntimeMessagesFromUiMessagesOptions,
+} from "./runtime-message-preparation.ts";
+export {
   getRuntimeUploadUrl,
   type RuntimeUploadUrlClientOptions,
   type RuntimeUploadUrlFetch,

--- a/src/agent/runtime-message-preparation.test.ts
+++ b/src/agent/runtime-message-preparation.test.ts
@@ -1,0 +1,54 @@
+import { assertEquals } from "../testing/assert.ts";
+import type { ChatUiMessage } from "../chat/types.ts";
+import { prepareAgentRuntimeMessagesFromUiMessages } from "./runtime-message-preparation.ts";
+
+function userMessage(parts: ChatUiMessage["parts"]): ChatUiMessage {
+  return {
+    id: "message-1",
+    role: "user",
+    parts,
+  };
+}
+
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages returns an empty-conversation prompt", async () => {
+  const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+    messages: [],
+    emptyConversationPrompt: "Suggest next steps.",
+  });
+
+  assertEquals(messages[0]?.role, "user");
+  assertEquals(messages[0]?.parts, [{ type: "text", text: "Suggest next steps." }]);
+});
+
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages refreshes upload file URLs before conversion", async () => {
+  const resolvedUploadIds: string[] = [];
+  const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+    messages: [
+      userMessage([
+        { type: "text", text: "Use these files." },
+        {
+          type: "file",
+          mediaType: "text/plain",
+          filename: "notes.txt",
+          uploadId: "upload-1",
+          url: "https://files.example.com/original.txt",
+        },
+      ]),
+    ],
+    resolveFileUrl: async ({ uploadId }) => {
+      resolvedUploadIds.push(uploadId);
+      return "https://signed.example.com/file.txt";
+    },
+  });
+
+  assertEquals(resolvedUploadIds, ["upload-1"]);
+  assertEquals(messages[0]?.parts, [
+    { type: "text", text: "Use these files." },
+    {
+      type: "text",
+      text: "Attached files from earlier conversation context:\n\n<uploaded_files>\n" +
+        '<file name="notes.txt" upload_id="upload-1" url="https://signed.example.com/file.txt" type="text/plain" />\n' +
+        "</uploaded_files>",
+    },
+  ]);
+});

--- a/src/agent/runtime-message-preparation.ts
+++ b/src/agent/runtime-message-preparation.ts
@@ -1,0 +1,58 @@
+import { prepareProviderModelMessagesFromUiMessages } from "../chat/message-prep.ts";
+import type { ChatUiMessage } from "../chat/types.ts";
+import {
+  type AgentRuntimeMessage,
+  convertProviderMessagesToAgentRuntimeMessages,
+} from "./agent-runtime-message-adapter.ts";
+import {
+  resolveRuntimeMessageFileUrls,
+  type RuntimeFileUrlResolver,
+} from "./runtime-message-file-url-refresh.ts";
+
+const DEFAULT_EMPTY_CONVERSATION_PROMPT =
+  "Please provide 3-4 specific suggestions for what I could build or improve based on the current project context.";
+
+export type PrepareAgentRuntimeMessagesFromUiMessagesOptions = {
+  messages: readonly ChatUiMessage[];
+  emptyConversationPrompt?: string;
+  resolveFileUrl?: RuntimeFileUrlResolver;
+};
+
+export async function prepareAgentRuntimeMessagesFromUiMessages(
+  options: PrepareAgentRuntimeMessagesFromUiMessagesOptions,
+): Promise<AgentRuntimeMessage[]> {
+  if (isEmptyConversation(options.messages)) {
+    return convertProviderMessagesToAgentRuntimeMessages([
+      {
+        role: "user",
+        content: options.emptyConversationPrompt ?? DEFAULT_EMPTY_CONVERSATION_PROMPT,
+      },
+    ]);
+  }
+
+  const refreshedMessages = options.resolveFileUrl
+    ? await resolveRuntimeMessageFileUrls(options.messages, options.resolveFileUrl)
+    : [...options.messages];
+
+  return convertProviderMessagesToAgentRuntimeMessages(
+    prepareProviderModelMessagesFromUiMessages(refreshedMessages),
+  );
+}
+
+function isEmptyConversation(messages: readonly ChatUiMessage[]): boolean {
+  if (messages.length === 0) return true;
+
+  if (messages.length === 1 && messages[0]?.role === "user") {
+    const parts = messages[0].parts;
+    if (parts.length === 0) return true;
+
+    return parts.every((part) => {
+      if (part.type === "text") {
+        return !part.text || part.text.trim() === "";
+      }
+      return false;
+    });
+  }
+
+  return false;
+}

--- a/src/chat/message-prep.ts
+++ b/src/chat/message-prep.ts
@@ -7,6 +7,7 @@ import {
 } from "./conversation.ts";
 import {
   buildDataFileAnnotation,
+  type ChatAssistantContentPart,
   type ChatToolResultOutput,
   type ChatToolResultPart,
   type ChatUiMessage,
@@ -38,6 +39,8 @@ export function compressTurn(
 
   for (let i = startIdx; i <= endIdx; i++) {
     const msg = messages[i];
+    if (!msg) continue;
+
     if (msg.role === "user") {
       const text = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
       userQuery = truncate(text, 100);
@@ -76,15 +79,18 @@ function collectTurns(messages: ProviderModelMessage[]): TurnWindow[] {
   let currentTurn: TurnWindow | null = null;
 
   for (let i = 0; i < messages.length; i++) {
-    if (messages[i].role === "user") {
+    const message = messages[i];
+    if (!message) continue;
+
+    if (message.role === "user") {
       if (currentTurn) {
         currentTurn.endIdx = i - 1;
         turns.push(currentTurn);
       }
-      currentTurn = { startIdx: i, endIdx: i, tokens: estimateTokens(messages[i].content) };
+      currentTurn = { startIdx: i, endIdx: i, tokens: estimateTokens(message.content) };
     } else if (currentTurn) {
       currentTurn.endIdx = i;
-      currentTurn.tokens += estimateTokens(messages[i].content);
+      currentTurn.tokens += estimateTokens(message.content);
     }
   }
 
@@ -112,6 +118,8 @@ export function enforceTokenBudgetWithTurnCompression(
   let compressCount = 0;
   while (totalTokens > effectiveBudget && compressCount < turns.length - minKeep) {
     const turn = turns[compressCount];
+    if (!turn) break;
+
     if (turn.compressed) {
       compressCount++;
       continue;
@@ -132,8 +140,10 @@ export function enforceTokenBudgetWithTurnCompression(
     result.splice(turn.startIdx, turnLength, ...compressed);
     const indexShift = compressed.length - turnLength;
     for (let j = compressCount + 1; j < turns.length; j++) {
-      turns[j].startIdx += indexShift;
-      turns[j].endIdx += indexShift;
+      const laterTurn = turns[j];
+      if (!laterTurn) continue;
+      laterTurn.startIdx += indexShift;
+      laterTurn.endIdx += indexShift;
     }
     turn.endIdx = turn.startIdx + compressed.length - 1;
     turn.tokens = compressedTokens;
@@ -148,13 +158,18 @@ export function enforceTokenBudgetWithTurnCompression(
   const finalMinKeep = Math.min(2, finalTurns.length);
   let dropCount = 0;
   while (totalTokens > effectiveBudget && dropCount < finalTurns.length - finalMinKeep) {
-    totalTokens -= finalTurns[dropCount].tokens;
+    const turn = finalTurns[dropCount];
+    if (!turn) break;
+    totalTokens -= turn.tokens;
     dropCount++;
   }
 
   if (dropCount === 0) return result;
 
-  const firstKeepIdx = finalTurns[dropCount].startIdx;
+  const firstKeptTurn = finalTurns[dropCount];
+  if (!firstKeptTurn) return result;
+
+  const firstKeepIdx = firstKeptTurn.startIdx;
   return result.slice(firstKeepIdx);
 }
 
@@ -262,7 +277,7 @@ export function rewriteUnsupportedFilePartsAsAnnotations(
 
     if (lastTextIndex >= 0) {
       const textPart = kept[lastTextIndex];
-      if (textPart.type === "text") {
+      if (textPart?.type === "text") {
         kept[lastTextIndex] = { type: "text", text: textPart.text + annotation };
       }
     } else {
@@ -504,7 +519,8 @@ function wrapToolResultOutput(
 export function maskOldToolOutputs(messages: ProviderModelMessage[]): ProviderModelMessage[] {
   let lastUserIdx = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i].role === "user") {
+    const message = messages[i];
+    if (message?.role === "user") {
       lastUserIdx = i;
       break;
     }
@@ -587,6 +603,8 @@ export function repairToolPairs(messages: ProviderModelMessage[]): ProviderModel
 
   for (let index = 0; index < result.length; index++) {
     const message = result[index];
+    if (!message) continue;
+
     if (message.role !== "assistant" || !Array.isArray(message.content)) {
       continue;
     }
@@ -598,7 +616,7 @@ export function repairToolPairs(messages: ProviderModelMessage[]): ProviderModel
       }
     }
 
-    const repairedContent: typeof message.content = [];
+    const repairedContent: ChatAssistantContentPart[] = [];
     const regularToolCalls: Array<{ id: string; toolName: string }> = [];
 
     for (const part of message.content) {
@@ -768,7 +786,7 @@ export function compactForStep(
   );
 
   let end = compacted.length;
-  while (end > 1 && compacted[end - 1].role === "assistant") {
+  while (end > 1 && compacted[end - 1]?.role === "assistant") {
     end--;
   }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.385";
+export const VERSION = "0.1.386";


### PR DESCRIPTION
## Summary\n- Add a reusable runtime message preparation helper for agent hosts\n- Reuse the runtime file URL refresh helper before provider message conversion\n- Tighten message-prep indexed access guards so the helper is type-checkable through the agent export path\n- Bump framework package version to 0.1.386 for CI/CD publishing\n\n## Verification\n- deno check src/chat/message-prep.ts src/agent/index.ts src/agent/runtime-message-preparation.ts src/agent/runtime-message-preparation.test.ts\n- deno test --no-check --allow-all src/agent/runtime-message-preparation.test.ts src/agent/runtime-message-file-url-refresh.test.ts src/agent/runtime-upload-url-client.test.ts\n- deno task verify:quick\n- pre-push checks: format, lint, typecheck, unit tests (1640 passed, 0 failed)