### PR TITLE
Add live Studio MCP tools helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.386",
+  "version": "0.1.387",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -130,6 +130,11 @@ export {
   type RuntimeClientType,
   runtimeClientTypeSchema,
 } from "./runtime-client-profile.ts";
+export {
+  buildStudioMcpHeaders,
+  createLiveStudioMcpTools,
+  type LiveStudioMcpToolsOptions,
+} from "./live-studio-mcp-tools.ts";
 
 export {
   parseRuntimeAgentMarkdownDefinition,

--- a/src/agent/live-studio-mcp-tools.test.ts
+++ b/src/agent/live-studio-mcp-tools.test.ts
@@ -1,0 +1,186 @@
+import { assertEquals } from "@std/assert";
+import type {
+  RemoteMCPToolSourceConfig,
+  RemoteToolSource,
+  ToolExecutionContext,
+} from "#veryfront/tool";
+import { buildStudioMcpHeaders, createLiveStudioMcpTools } from "./live-studio-mcp-tools.ts";
+import type { RuntimeClientProfile } from "./runtime-client-profile.ts";
+
+const trustedStudioProfile: RuntimeClientProfile = {
+  id: "veryfront-studio",
+  type: "web",
+  trusted: true,
+  capabilities: ["ui_panels", "form_input", "media_display", "project_switching"],
+};
+
+function createDeferredRemoteToolFixtures() {
+  const createdSources: RemoteMCPToolSourceConfig[] = [];
+  const executedCalls: Array<{
+    sourceIndex: number;
+    toolName: string;
+    args: Record<string, unknown>;
+    context?: ToolExecutionContext;
+  }> = [];
+  const listedContexts: Array<ToolExecutionContext | undefined> = [];
+
+  const createRemoteToolSource = (config: RemoteMCPToolSourceConfig): RemoteToolSource => {
+    const sourceIndex = createdSources.length;
+    createdSources.push(config);
+
+    return {
+      id: config.id ?? "studio-mcp-live-tools",
+      listTools: (context) => {
+        listedContexts.push(context);
+        return Promise.resolve([
+          {
+            name: "studio_suggestions",
+            description: "studio_suggestions",
+            parameters: { type: "object", properties: {} },
+          },
+        ]);
+      },
+      executeTool: (toolName, args, context) => {
+        executedCalls.push({ sourceIndex, toolName, args, context });
+        return Promise.resolve({ project: `project-${sourceIndex + 1}` });
+      },
+    };
+  };
+
+  return {
+    createdSources,
+    executedCalls,
+    listedContexts,
+    createRemoteToolSource,
+  };
+}
+
+Deno.test("buildStudioMcpHeaders includes auth and optional context headers", () => {
+  assertEquals(buildStudioMcpHeaders("token", "project-1", "conversation-1"), {
+    Authorization: "Bearer token",
+    "x-project-id": "project-1",
+    "x-conversation-id": "conversation-1",
+  });
+  assertEquals(buildStudioMcpHeaders("token", null), {
+    Authorization: "Bearer token",
+  });
+});
+
+Deno.test("createLiveStudioMcpTools reconnects studio tools when the active project changes", async () => {
+  const fixtures = createDeferredRemoteToolFixtures();
+  let projectId = "project-1";
+
+  const studioTools = await createLiveStudioMcpTools({
+    authToken: "auth-token",
+    clientProfile: trustedStudioProfile,
+    getProjectId: () => projectId,
+    studioMcpUrl: "https://studio.example.com/mcp",
+    conversationId: "conversation-1",
+    createRemoteToolSource: fixtures.createRemoteToolSource,
+  });
+
+  const resultProject1 = await studioTools.tools.studio_suggestions?.execute?.(
+    { field: "first" },
+    undefined,
+  );
+
+  projectId = "project-2";
+  const resultProject2 = await studioTools.tools.studio_suggestions?.execute?.(
+    { field: "second" },
+    undefined,
+  );
+
+  assertEquals(resultProject1, { project: "project-1" });
+  assertEquals(resultProject2, { project: "project-2" });
+  assertEquals(fixtures.createdSources, [
+    {
+      id: "studio-mcp-live-tools",
+      endpoint: "https://studio.example.com/mcp",
+      headers: {
+        Authorization: "Bearer auth-token",
+        "x-project-id": "project-1",
+        "x-conversation-id": "conversation-1",
+      },
+    },
+    {
+      id: "studio-mcp-live-tools",
+      endpoint: "https://studio.example.com/mcp",
+      headers: {
+        Authorization: "Bearer auth-token",
+        "x-project-id": "project-2",
+        "x-conversation-id": "conversation-1",
+      },
+    },
+  ]);
+  assertEquals(fixtures.listedContexts, [{ projectId: "project-1" }, { projectId: "project-2" }]);
+  assertEquals(fixtures.executedCalls, [
+    {
+      sourceIndex: 0,
+      toolName: "studio_suggestions",
+      args: { field: "first" },
+      context: undefined,
+    },
+    {
+      sourceIndex: 1,
+      toolName: "studio_suggestions",
+      args: { field: "second" },
+      context: undefined,
+    },
+  ]);
+
+  await studioTools.close();
+});
+
+Deno.test("createLiveStudioMcpTools reuses the existing client while the active project stays the same", async () => {
+  const fixtures = createDeferredRemoteToolFixtures();
+
+  const studioTools = await createLiveStudioMcpTools({
+    authToken: "auth-token",
+    clientProfile: trustedStudioProfile,
+    getProjectId: () => "project-1",
+    studioMcpUrl: "https://studio.example.com/mcp",
+    createRemoteToolSource: fixtures.createRemoteToolSource,
+  });
+
+  await studioTools.tools.studio_suggestions?.execute?.({ field: "first" }, undefined);
+  await studioTools.tools.studio_suggestions?.execute?.({ field: "second" }, undefined);
+
+  assertEquals(fixtures.createdSources.length, 1);
+  assertEquals(fixtures.listedContexts.length, 1);
+  assertEquals(fixtures.executedCalls.length, 2);
+});
+
+Deno.test("createLiveStudioMcpTools returns no tools without a trusted Studio-capable client", async () => {
+  const fixtures = createDeferredRemoteToolFixtures();
+
+  const studioTools = await createLiveStudioMcpTools({
+    authToken: "auth-token",
+    clientProfile: {
+      id: "veryfront-api",
+      type: "api",
+      trusted: true,
+      capabilities: [],
+    },
+    getProjectId: () => "project-1",
+    studioMcpUrl: "https://studio.example.com/mcp",
+    createRemoteToolSource: fixtures.createRemoteToolSource,
+  });
+
+  assertEquals(studioTools.tools, {});
+  assertEquals(fixtures.createdSources.length, 0);
+});
+
+Deno.test("createLiveStudioMcpTools returns no tools without a Studio MCP URL", async () => {
+  const fixtures = createDeferredRemoteToolFixtures();
+
+  const studioTools = await createLiveStudioMcpTools({
+    authToken: "auth-token",
+    clientProfile: trustedStudioProfile,
+    getProjectId: () => "project-1",
+    studioMcpUrl: null,
+    createRemoteToolSource: fixtures.createRemoteToolSource,
+  });
+
+  assertEquals(studioTools.tools, {});
+  assertEquals(fixtures.createdSources.length, 0);
+});

--- a/src/agent/live-studio-mcp-tools.ts
+++ b/src/agent/live-studio-mcp-tools.ts
@@ -1,0 +1,151 @@
+import {
+  createRemoteMCPToolSource,
+  type HostToolSet,
+  loadRemoteToolsFromSource,
+  type RemoteMCPToolSourceConfig,
+  type RemoteToolSource,
+  type ToolExecutionContext,
+} from "#veryfront/tool";
+import { clientAllowsStudioMcp, type RuntimeClientProfile } from "./runtime-client-profile.ts";
+
+export type LiveStudioMcpToolsOptions = {
+  authToken: string;
+  clientProfile?: RuntimeClientProfile | null;
+  getProjectId: () => string | null | undefined;
+  studioMcpUrl?: string | null;
+  conversationId?: string;
+  sourceId?: string;
+  createRemoteToolSource?: (config: RemoteMCPToolSourceConfig) => RemoteToolSource;
+  loadRemoteTools?: typeof loadRemoteToolsFromSource;
+};
+
+type StudioMcpState = {
+  projectId: string | null;
+  tools: HostToolSet;
+};
+
+export function buildStudioMcpHeaders(
+  authToken: string,
+  projectId: string | null,
+  conversationId?: string,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${authToken}`,
+  };
+  if (projectId) {
+    headers["x-project-id"] = projectId;
+  }
+  if (conversationId) {
+    headers["x-conversation-id"] = conversationId;
+  }
+  return headers;
+}
+
+async function loadStudioMcpState(input: {
+  authToken: string;
+  projectId: string | null;
+  conversationId?: string;
+  url: string;
+  sourceId: string;
+  createRemoteToolSource: (config: RemoteMCPToolSourceConfig) => RemoteToolSource;
+  loadRemoteTools: typeof loadRemoteToolsFromSource;
+}): Promise<StudioMcpState> {
+  const source = input.createRemoteToolSource({
+    id: input.sourceId,
+    endpoint: input.url,
+    headers: buildStudioMcpHeaders(input.authToken, input.projectId, input.conversationId),
+  });
+
+  return {
+    projectId: input.projectId,
+    tools: await input.loadRemoteTools(source, {
+      context: input.projectId ? { projectId: input.projectId } : undefined,
+    }),
+  };
+}
+
+export async function createLiveStudioMcpTools(input: LiveStudioMcpToolsOptions): Promise<{
+  tools: HostToolSet;
+  close: () => Promise<void>;
+}> {
+  const studioMcpUrl = input.studioMcpUrl;
+
+  if (!studioMcpUrl || !clientAllowsStudioMcp(input.clientProfile)) {
+    return {
+      tools: {},
+      close: async () => undefined,
+    };
+  }
+
+  const sourceId = input.sourceId ?? "studio-mcp-live-tools";
+  const createRemoteToolSource = input.createRemoteToolSource ?? createRemoteMCPToolSource;
+  const loadRemoteTools = input.loadRemoteTools ?? loadRemoteToolsFromSource;
+  let studioState: StudioMcpState | null = null;
+  let pendingState: Promise<StudioMcpState> | null = null;
+
+  const loadState = async (projectId: string | null): Promise<StudioMcpState> => {
+    if (studioState && studioState.projectId === projectId) {
+      return studioState;
+    }
+
+    if (pendingState) {
+      const loadedState = await pendingState;
+      if (loadedState.projectId === projectId) {
+        return loadedState;
+      }
+    }
+
+    const nextStatePromise = loadStudioMcpState({
+      authToken: input.authToken,
+      projectId,
+      conversationId: input.conversationId,
+      url: studioMcpUrl,
+      sourceId,
+      createRemoteToolSource,
+      loadRemoteTools,
+    });
+
+    pendingState = nextStatePromise;
+
+    try {
+      const nextState = await nextStatePromise;
+      studioState = nextState;
+      return nextState;
+    } finally {
+      if (pendingState === nextStatePromise) {
+        pendingState = null;
+      }
+    }
+  };
+
+  const initialState = await loadState(input.getProjectId() ?? null);
+  const wrappedTools: HostToolSet = {};
+
+  for (const [toolName, toolDefinition] of Object.entries(initialState.tools)) {
+    if (typeof toolDefinition.execute !== "function") {
+      wrappedTools[toolName] = toolDefinition;
+      continue;
+    }
+
+    wrappedTools[toolName] = {
+      ...toolDefinition,
+      execute: async (toolInput: unknown, execOptions?: ToolExecutionContext) => {
+        const liveState = await loadState(input.getProjectId() ?? null);
+        const liveTool = liveState.tools[toolName];
+
+        if (!liveTool || typeof liveTool.execute !== "function") {
+          throw new Error(`Studio MCP tool unavailable for current project: ${toolName}`);
+        }
+
+        return liveTool.execute(toolInput, execOptions);
+      },
+    };
+  }
+
+  return {
+    tools: wrappedTools,
+    close: async () => {
+      studioState = null;
+    },
+  };
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.386";
+export const VERSION = "0.1.387";


### PR DESCRIPTION
## Summary
- add a reusable live Studio MCP tool helper for hosted agent runtimes
- export Studio MCP header construction from the agent package
- bump package version to 0.1.387 for CI/CD publish

## Verification
- deno check src/agent/index.ts src/agent/live-studio-mcp-tools.ts src/agent/live-studio-mcp-tools.test.ts
- deno test --no-check --allow-all src/agent/live-studio-mcp-tools.test.ts
- deno task verify:quick
- pre-push checks