### PR TITLE
Add default hosted child tool request helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.388",
+  "version": "0.1.389",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-requested-tools.test.ts
+++ b/src/agent/hosted-child-requested-tools.test.ts
@@ -1,8 +1,11 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import {
   buildHostedChildToolDescription,
+  DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES,
   expandHostedChildRequestedTools,
+  sanitizeDefaultHostedChildRequestedTools,
   sanitizeHostedChildRequestedTools,
+  selectDefaultHostedChildForkRuntimeTools,
   shouldPruneSandboxToolsFromHostedChildRequest,
 } from "./hosted-child-requested-tools.ts";
 
@@ -88,4 +91,73 @@ Deno.test("buildHostedChildToolDescription describes child agent usage", () => {
   const description = buildHostedChildToolDescription();
   assertEquals(description.includes("child agent"), true);
   assertEquals(description.includes("parallel"), true);
+});
+
+Deno.test("DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES excludes UI-only tools", () => {
+  assertEquals(DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES.has("studio_panel_control"), true);
+  assertEquals(DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES.has("studio_suggestions"), true);
+  assertEquals(DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES.has("form_input"), true);
+  assertEquals(DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES.has("bash"), false);
+  assertEquals(DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES.has("create_file"), false);
+});
+
+Deno.test("sanitizeDefaultHostedChildRequestedTools applies default exclusions and companions", () => {
+  const result = sanitizeDefaultHostedChildRequestedTools({
+    prompt: "hello",
+    requestedTools: ["bash", "studio_panel_control", "form_input", "create_file"],
+  });
+
+  assertEquals(result, ["bash", "create_file", "update_file"]);
+});
+
+Deno.test("sanitizeDefaultHostedChildRequestedTools adds reverse file-writing companions", () => {
+  const result = sanitizeDefaultHostedChildRequestedTools({
+    prompt: "hello",
+    requestedTools: ["update_file"],
+  });
+
+  assertEquals(result, ["update_file", "create_file"]);
+});
+
+Deno.test("sanitizeDefaultHostedChildRequestedTools prunes sandbox tools for text artifact prompts", () => {
+  const result = sanitizeDefaultHostedChildRequestedTools({
+    prompt: "Write a markdown research report",
+    requestedTools: ["create_file", "bash"],
+  });
+
+  assertEquals(result, ["create_file", "update_file"]);
+});
+
+Deno.test("sanitizeDefaultHostedChildRequestedTools keeps sandbox tools for prompts with sandbox cues", () => {
+  const result = sanitizeDefaultHostedChildRequestedTools({
+    prompt: "Write a markdown report using python to parse data",
+    requestedTools: ["create_file", "bash"],
+  });
+
+  assertEquals(result, ["create_file", "update_file", "bash"]);
+});
+
+Deno.test("selectDefaultHostedChildForkRuntimeTools filters requested tools after defaults", () => {
+  const forkTools = {
+    bash: { description: "Run shell commands" },
+    create_file: { description: "Create a file" },
+    update_file: { description: "Update a file" },
+    knowledge_lookup: { description: "Lookup knowledge" },
+  };
+
+  const result = selectDefaultHostedChildForkRuntimeTools({
+    provider: "anthropic",
+    forkModel: "claude-sonnet-4-5-20250929",
+    forkTools,
+    effectivePrompt: "Create the requested project artifact",
+    requestedTools: ["create_file"],
+  });
+
+  assertEquals(result, {
+    ok: true,
+    forkTools: {
+      create_file: forkTools.create_file,
+      update_file: forkTools.update_file,
+    },
+  });
 });

--- a/src/agent/hosted-child-requested-tools.ts
+++ b/src/agent/hosted-child-requested-tools.ts
@@ -1,5 +1,6 @@
 import type { HostToolSet } from "#veryfront/tool";
 
+import { isHostedChildTextProjectArtifactPrompt } from "./hosted-child-artifact-support.ts";
 import { getForkRuntimeAllowedToolNames } from "./provider-native-tool-inventory.ts";
 
 export interface HostedChildRequestedToolsInput {
@@ -15,6 +16,22 @@ export interface HostedChildRequestedToolsInput {
 
 const DEFAULT_SANDBOX_TOOL_NAMES = ["bash", "readFile", "writeFile"];
 const DEFAULT_ARTIFACT_TOOL_NAMES = ["create_file", "update_file"];
+
+export const DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "studio_panel_control",
+  "studio_suggestions",
+  "form_input",
+]);
+
+export const DEFAULT_HOSTED_CHILD_REQUESTED_TOOL_COMPANIONS: Readonly<
+  Record<string, readonly string[]>
+> = {
+  create_file: ["update_file"],
+  update_file: ["create_file"],
+};
+
+export const DEFAULT_HOSTED_CHILD_SANDBOX_REQUIRED_CUE_PATTERN =
+  /\b(bash|shell|terminal|command line|cli|\/workspace|workspace\/|python|node|npm|pnpm|yarn|curl|jq|csv|json|pdf|zip|unzip|archive|repo|git|test|build|script)\b/i;
 
 export function sanitizeHostedChildRequestedTools(
   input: HostedChildRequestedToolsInput,
@@ -167,6 +184,40 @@ export function selectHostedChildForkRuntimeTools(input: {
     ok: true,
     forkTools,
   };
+}
+
+export function sanitizeDefaultHostedChildRequestedTools(input: {
+  prompt: string;
+  requestedTools?: readonly string[];
+}): string[] | undefined {
+  return sanitizeHostedChildRequestedTools({
+    prompt: input.prompt,
+    requestedTools: input.requestedTools,
+    excludedTools: DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES,
+    companionTools: DEFAULT_HOSTED_CHILD_REQUESTED_TOOL_COMPANIONS,
+    sandboxRequiredCuePattern: DEFAULT_HOSTED_CHILD_SANDBOX_REQUIRED_CUE_PATTERN,
+    isTextArtifactPrompt: isHostedChildTextProjectArtifactPrompt,
+  });
+}
+
+export function selectDefaultHostedChildForkRuntimeTools(input: {
+  provider: string;
+  forkModel?: string;
+  forkTools: HostToolSet;
+  effectivePrompt: string;
+  requestedTools?: readonly string[];
+}): HostedChildForkRuntimeToolSelectionResult {
+  const effectiveRequestedTools = sanitizeDefaultHostedChildRequestedTools({
+    prompt: input.effectivePrompt,
+    requestedTools: input.requestedTools,
+  });
+
+  return selectHostedChildForkRuntimeTools({
+    provider: input.provider,
+    forkModel: input.forkModel,
+    forkTools: input.forkTools,
+    requestedTools: effectiveRequestedTools,
+  });
 }
 
 export function buildHostedChildToolDescription(): string {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -567,10 +567,15 @@ export {
 
 export {
   buildHostedChildToolDescription,
+  DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES,
+  DEFAULT_HOSTED_CHILD_REQUESTED_TOOL_COMPANIONS,
+  DEFAULT_HOSTED_CHILD_SANDBOX_REQUIRED_CUE_PATTERN,
   expandHostedChildRequestedTools,
   type HostedChildForkRuntimeToolSelectionResult,
   type HostedChildRequestedToolsInput,
+  sanitizeDefaultHostedChildRequestedTools,
   sanitizeHostedChildRequestedTools,
+  selectDefaultHostedChildForkRuntimeTools,
   selectHostedChildForkRuntimeTools,
   shouldPruneSandboxToolsFromHostedChildRequest,
 } from "./hosted-child-requested-tools.ts";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.388";
+export const VERSION = "0.1.389";


### PR DESCRIPTION
## Summary
- add default hosted child requested-tool sanitization policy
- add a helper that sanitizes and selects hosted child fork runtime tools
- bump the framework patch version to 0.1.389 for CI/CD publication

## Verification
- deno check src/agent/index.ts src/agent/hosted-child-requested-tools.ts src/agent/hosted-child-requested-tools.test.ts
- deno test --no-check --allow-all src/agent/hosted-child-requested-tools.test.ts src/agent/hosted-child-fork-tool-selection.test.ts
- deno task verify:quick
- pre-push checks passed: 1659 passed (17205 steps), 0 failed