### PR TITLE
Add hosted child fork tool set helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.389",
+  "version": "0.1.390",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-requested-tools.test.ts
+++ b/src/agent/hosted-child-requested-tools.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import {
+  buildDefaultHostedChildForkToolSet,
   buildHostedChildToolDescription,
   DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES,
   expandHostedChildRequestedTools,
@@ -159,5 +160,32 @@ Deno.test("selectDefaultHostedChildForkRuntimeTools filters requested tools afte
       create_file: forkTools.create_file,
       update_file: forkTools.update_file,
     },
+  });
+});
+
+Deno.test("buildDefaultHostedChildForkToolSet merges tool sets deterministically and removes default exclusions", () => {
+  const bashTool = { description: "Run shell commands" };
+  const createFileTool = { description: "Create a file" };
+  const updateFileTool = { description: "Update a file" };
+  const replacementCreateFileTool = { description: "Create a replacement file" };
+
+  const result = buildDefaultHostedChildForkToolSet(
+    {
+      studio_suggestions: { description: "Suggest UI actions" },
+      update_file: updateFileTool,
+      create_file: createFileTool,
+    },
+    {
+      studio_panel_control: { description: "Control panels" },
+      bash: bashTool,
+      create_file: replacementCreateFileTool,
+    },
+  );
+
+  assertEquals(Object.keys(result), ["bash", "create_file", "update_file"]);
+  assertEquals(result, {
+    bash: bashTool,
+    create_file: replacementCreateFileTool,
+    update_file: updateFileTool,
   });
 });

--- a/src/agent/hosted-child-requested-tools.ts
+++ b/src/agent/hosted-child-requested-tools.ts
@@ -220,6 +220,30 @@ export function selectDefaultHostedChildForkRuntimeTools(input: {
   });
 }
 
+export function buildDefaultHostedChildForkToolSet(
+  ...toolSets: readonly HostToolSet[]
+): HostToolSet {
+  const allTools: HostToolSet = {};
+  for (const toolSet of toolSets) {
+    Object.assign(allTools, toolSet);
+  }
+
+  const forkTools: HostToolSet = {};
+  for (
+    const [toolName, toolDefinition] of Object.entries(allTools).sort(([left], [right]) =>
+      left.localeCompare(right)
+    )
+  ) {
+    if (DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES.has(toolName)) {
+      continue;
+    }
+
+    forkTools[toolName] = toolDefinition;
+  }
+
+  return forkTools;
+}
+
 export function buildHostedChildToolDescription(): string {
   return `Invoke a focused child agent on an isolated subtask.
 Call multiple times in one response to run child agents in parallel.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -566,6 +566,7 @@ export {
 } from "./hosted-child-tool-input.ts";
 
 export {
+  buildDefaultHostedChildForkToolSet,
   buildHostedChildToolDescription,
   DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES,
   DEFAULT_HOSTED_CHILD_REQUESTED_TOOL_COMPANIONS,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.389";
+export const VERSION = "0.1.390";


### PR DESCRIPTION
## Summary
- add a helper for deterministic hosted child fork tool-set assembly
- apply the default hosted child UI-only tool exclusions in the framework
- bump the framework patch version to 0.1.390 for CI/CD publication

## Verification
- deno check src/agent/index.ts src/agent/hosted-child-requested-tools.ts src/agent/hosted-child-requested-tools.test.ts
- deno test --no-check --allow-all src/agent/hosted-child-requested-tools.test.ts
- deno task verify:quick
- pre-push checks passed: 1660 passed (17205 steps), 0 failed