### PR TITLE
Add hosted child runtime config helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.390",
+  "version": "0.1.391",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-tool-input.test.ts
+++ b/src/agent/hosted-child-tool-input.test.ts
@@ -2,6 +2,8 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import {
   DEFAULT_HOSTED_CHILD_AGENT_ID,
   hostedChildForkToolInputSchema,
+  resolveHostedChildForkRuntimeConfig,
+  resolveHostedChildForkThinkingOverride,
 } from "./hosted-child-tool-input.ts";
 
 Deno.test("hostedChildForkToolInputSchema accepts the hosted child fork fields", () => {
@@ -50,4 +52,64 @@ Deno.test("hostedChildForkToolInputSchema rejects negative thinking budgets", ()
 
 Deno.test("DEFAULT_HOSTED_CHILD_AGENT_ID names the hosted child runtime agent", () => {
   assertEquals(DEFAULT_HOSTED_CHILD_AGENT_ID, "invoke-agent-child");
+});
+
+Deno.test("resolveHostedChildForkThinkingOverride maps child fork thinking values", () => {
+  assertEquals(resolveHostedChildForkThinkingOverride(undefined), undefined);
+  assertEquals(resolveHostedChildForkThinkingOverride(0), { enabled: false });
+  assertEquals(resolveHostedChildForkThinkingOverride(2048), {
+    enabled: true,
+    budgetTokens: 2048,
+  });
+});
+
+Deno.test("resolveHostedChildForkRuntimeConfig resolves reusable child fork runtime options", () => {
+  const result = resolveHostedChildForkRuntimeConfig({
+    forkInput: {
+      description: "research solar panels",
+      prompt: "Research solar panels and save the report to the project.",
+      tools: ["readFile"],
+      model: "sonnet",
+      thinking: 1024,
+      max_steps: 12,
+    },
+    contextModel: "opus",
+    defaultModel: "haiku",
+    defaultMaxSteps: 80,
+    runId: "run-1",
+    resolveModelId: (modelId) => `resolved-${modelId}`,
+    resolveProvider: (modelId) => `provider-for-${modelId}`,
+  });
+
+  assertEquals(result.description, "research solar panels");
+  assertEquals(result.requestedTools, ["readFile"]);
+  assertEquals(result.forkModel, "resolved-sonnet");
+  assertEquals(result.provider, "provider-for-resolved-sonnet");
+  assertEquals(result.maxSteps, 12);
+  assertEquals(result.thinkingConfig, { enabled: true, budgetTokens: 1024 });
+  assertEquals(
+    result.effectivePrompt.includes("/research/solar-panels/runs/run-1.report.md"),
+    true,
+  );
+});
+
+Deno.test("resolveHostedChildForkRuntimeConfig falls back to context model and default max steps", () => {
+  const result = resolveHostedChildForkRuntimeConfig({
+    forkInput: {
+      description: "write tests",
+      prompt: "Write focused tests.",
+    },
+    contextModel: "opus",
+    defaultModel: "haiku",
+    defaultMaxSteps: 80,
+    runId: "tool-call-1",
+    resolveModelId: (modelId) => `resolved-${modelId}`,
+    resolveProvider: (modelId) => `provider-for-${modelId}`,
+  });
+
+  assertEquals(result.forkModel, "resolved-opus");
+  assertEquals(result.provider, "provider-for-resolved-opus");
+  assertEquals(result.maxSteps, 80);
+  assertEquals(result.thinkingConfig, undefined);
+  assertEquals(result.effectivePrompt, "Write focused tests.");
 });

--- a/src/agent/hosted-child-tool-input.ts
+++ b/src/agent/hosted-child-tool-input.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import { withDefaultResearchArtifactPath } from "./default-research-artifact-policy.ts";
+import type { RuntimeAgentThinkingConfig } from "./runtime-agent-definition.ts";
 
 export const DEFAULT_HOSTED_CHILD_AGENT_ID = "invoke-agent-child";
 
@@ -21,3 +23,61 @@ export const hostedChildForkToolInputSchema = z.object({
 });
 
 export type HostedChildForkToolInput = z.infer<typeof hostedChildForkToolInputSchema>;
+
+export type HostedChildForkRuntimeConfig = {
+  description: string;
+  effectivePrompt: string;
+  requestedTools: string[] | undefined;
+  forkModel: string;
+  provider: string;
+  maxSteps: number;
+  thinkingConfig: RuntimeAgentThinkingConfig | undefined;
+};
+
+export type ResolveHostedChildForkRuntimeConfigInput = {
+  forkInput: Pick<
+    HostedChildForkToolInput,
+    "description" | "prompt" | "tools" | "model" | "thinking" | "max_steps"
+  >;
+  contextModel?: string;
+  defaultModel: string;
+  defaultMaxSteps: number;
+  runId: string;
+  resolveModelId: (modelId: string) => string;
+  resolveProvider: (modelId: string) => string;
+};
+
+export function resolveHostedChildForkThinkingOverride(
+  thinking: HostedChildForkToolInput["thinking"],
+): RuntimeAgentThinkingConfig | undefined {
+  if (thinking === 0) {
+    return { enabled: false };
+  }
+
+  if (typeof thinking === "number") {
+    return { enabled: true, budgetTokens: thinking };
+  }
+
+  return undefined;
+}
+
+export function resolveHostedChildForkRuntimeConfig(
+  input: ResolveHostedChildForkRuntimeConfigInput,
+): HostedChildForkRuntimeConfig {
+  const { description, prompt, tools, model, thinking, max_steps } = input.forkInput;
+  const forkModel = input.resolveModelId(model || input.contextModel || input.defaultModel);
+
+  return {
+    description,
+    effectivePrompt: withDefaultResearchArtifactPath({
+      description,
+      prompt,
+      runId: input.runId,
+    }),
+    requestedTools: tools,
+    forkModel,
+    provider: input.resolveProvider(forkModel),
+    maxSteps: max_steps || input.defaultMaxSteps,
+    thinkingConfig: resolveHostedChildForkThinkingOverride(thinking),
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -561,8 +561,12 @@ export {
 } from "./hosted-child-stream-watchdog.ts";
 export {
   DEFAULT_HOSTED_CHILD_AGENT_ID,
+  type HostedChildForkRuntimeConfig,
   type HostedChildForkToolInput,
   hostedChildForkToolInputSchema,
+  resolveHostedChildForkRuntimeConfig,
+  type ResolveHostedChildForkRuntimeConfigInput,
+  resolveHostedChildForkThinkingOverride,
 } from "./hosted-child-tool-input.ts";
 
 export {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.390";
+export const VERSION = "0.1.391";


### PR DESCRIPTION
## Summary\n- add a hosted child fork runtime config helper for prompt, model, provider, max-step, and thinking option normalization\n- export the helper from the agent public surface\n- bump package version to 0.1.391\n\n## Verification\n- deno test --no-check --allow-all src/agent/hosted-child-tool-input.test.ts\n- deno check src/agent/index.ts src/agent/hosted-child-tool-input.ts src/agent/hosted-child-tool-input.test.ts\n- deno task verify:quick\n- pre-push checks