### PR TITLE
Add hosted child execution log writer

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.391",
+  "version": "0.1.392",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-execution-logging.test.ts
+++ b/src/agent/hosted-child-execution-logging.test.ts
@@ -3,6 +3,8 @@ import {
   buildHostedChildCompletedLog,
   buildHostedChildErrorLog,
   buildHostedChildExhaustedStepBudgetLog,
+  createHostedChildExecutionLogWriter,
+  writeHostedChildExecutionLogEntry,
 } from "./hosted-child-execution-logging.ts";
 import { HostedChildStreamIdleTimeoutError } from "./hosted-child-stream-watchdog.ts";
 
@@ -92,4 +94,96 @@ Deno.test("buildHostedChildErrorLog returns failure error for generic errors", (
       error,
     },
   });
+});
+
+Deno.test("writeHostedChildExecutionLogEntry dispatches entries by level", () => {
+  const calls: Array<{
+    level: "error" | "info" | "warn";
+    message: string;
+    context: Record<string, unknown>;
+  }> = [];
+  const writer = {
+    error: (message: string, context: Record<string, unknown>) => {
+      calls.push({ level: "error", message, context });
+    },
+    info: (message: string, context: Record<string, unknown>) => {
+      calls.push({ level: "info", message, context });
+    },
+    warn: (message: string, context: Record<string, unknown>) => {
+      calls.push({ level: "warn", message, context });
+    },
+  };
+
+  const errorContext = { error: "boom" };
+  const infoContext = { resultLength: 7 };
+  const warnContext = { stepCount: 10 };
+
+  writeHostedChildExecutionLogEntry(
+    {
+      level: "error",
+      message: "Child fork failed",
+      context: errorContext,
+    },
+    writer,
+  );
+  writeHostedChildExecutionLogEntry(
+    {
+      level: "info",
+      message: "Child fork completed",
+      context: infoContext,
+    },
+    writer,
+  );
+  writeHostedChildExecutionLogEntry(
+    {
+      level: "warn",
+      message: "Child fork exhausted step budget",
+      context: warnContext,
+    },
+    writer,
+  );
+
+  assertEquals(calls, [
+    { level: "error", message: "Child fork failed", context: errorContext },
+    { level: "info", message: "Child fork completed", context: infoContext },
+    {
+      level: "warn",
+      message: "Child fork exhausted step budget",
+      context: warnContext,
+    },
+  ]);
+});
+
+Deno.test("createHostedChildExecutionLogWriter adapts a logger to an entry writer", () => {
+  const calls: Array<{
+    level: "error" | "info" | "warn";
+    message: string;
+    context: Record<string, unknown>;
+  }> = [];
+  const writeLog = createHostedChildExecutionLogWriter({
+    error: (message: string, context: Record<string, unknown>) => {
+      calls.push({ level: "error", message, context });
+    },
+    info: (message: string, context: Record<string, unknown>) => {
+      calls.push({ level: "info", message, context });
+    },
+    warn: (message: string, context: Record<string, unknown>) => {
+      calls.push({ level: "warn", message, context });
+    },
+  });
+  const context = { phase: "generic_idle" };
+
+  writeLog({
+    level: "warn",
+    message: "Child fork stream stalled",
+    context,
+  });
+
+  assertEquals(calls, [
+    {
+      level: "warn",
+      message: "Child fork stream stalled",
+      context,
+    },
+  ]);
 });

--- a/src/agent/hosted-child-execution-logging.ts
+++ b/src/agent/hosted-child-execution-logging.ts
@@ -8,6 +8,37 @@ export interface HostedChildExecutionLogEntry {
   context: Record<string, unknown>;
 }
 
+export interface HostedChildExecutionLogWriter {
+  error: (message: string, context: Record<string, unknown>) => void;
+  info: (message: string, context: Record<string, unknown>) => void;
+  warn: (message: string, context: Record<string, unknown>) => void;
+}
+
+export function writeHostedChildExecutionLogEntry(
+  entry: HostedChildExecutionLogEntry,
+  writer: HostedChildExecutionLogWriter,
+): void {
+  if (entry.level === "error") {
+    writer.error(entry.message, entry.context);
+    return;
+  }
+
+  if (entry.level === "info") {
+    writer.info(entry.message, entry.context);
+    return;
+  }
+
+  writer.warn(entry.message, entry.context);
+}
+
+export function createHostedChildExecutionLogWriter(
+  writer: HostedChildExecutionLogWriter,
+): (entry: HostedChildExecutionLogEntry) => void {
+  return (entry) => {
+    writeHostedChildExecutionLogEntry(entry, writer);
+  };
+}
+
 export function buildHostedChildExhaustedStepBudgetLog(input: {
   description: string;
   kind: string;

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -665,8 +665,11 @@ export {
   buildHostedChildCompletedLog,
   buildHostedChildErrorLog,
   buildHostedChildExhaustedStepBudgetLog,
+  createHostedChildExecutionLogWriter,
   type HostedChildExecutionLogEntry,
   type HostedChildExecutionLogLevel,
+  type HostedChildExecutionLogWriter,
+  writeHostedChildExecutionLogEntry,
 } from "./hosted-child-execution-logging.ts";
 export {
   buildChildRunResultSummary,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.391";
+export const VERSION = "0.1.392";


### PR DESCRIPTION
## Summary\n- add a reusable hosted child execution log writer adapter\n- export the writer helper from the agent package surface\n- bump package version to 0.1.392 for CI/CD publish\n\n## Verification\n- deno check src/agent/index.ts src/agent/hosted-child-execution-logging.ts src/agent/hosted-child-execution-logging.test.ts\n- deno test --no-check --allow-all src/agent/hosted-child-execution-logging.test.ts\n- deno task verify:quick