### PR TITLE
Add hosted child pending tool lifecycle logger

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.392",
+  "version": "0.1.393",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-pending-tool-lifecycle.test.ts
+++ b/src/agent/hosted-child-pending-tool-lifecycle.test.ts
@@ -1,6 +1,9 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import type { ChatMessageMetadata, ChatUiMessageChunk } from "../chat/protocol.ts";
-import { createHostedChildPendingToolLifecycle } from "./hosted-child-pending-tool-lifecycle.ts";
+import {
+  createHostedChildPendingToolLifecycle,
+  createHostedChildPendingToolLifecycleLogger,
+} from "./hosted-child-pending-tool-lifecycle.ts";
 
 Deno.test("createHostedChildPendingToolLifecycle closes incomplete streaming input", async () => {
   const chunks: ChatUiMessageChunk<ChatMessageMetadata>[] = [];
@@ -115,4 +118,58 @@ Deno.test("createHostedChildPendingToolLifecycle deletes settled pending tool ca
   await lifecycle.closePendingToolCalls({ kind: "ended" });
 
   assertEquals(chunks, []);
+});
+
+Deno.test("createHostedChildPendingToolLifecycleLogger writes host context for pending lifecycle warnings", () => {
+  const warnings: Array<{ message: string; context: Record<string, unknown> }> = [];
+  const logger = createHostedChildPendingToolLifecycleLogger(
+    {
+      conversationId: "conv-1",
+      parentRunId: "run-1",
+      description: "Summarize docs",
+    },
+    {
+      warn: (message: string, context: Record<string, unknown>) => {
+        warnings.push({ message, context });
+      },
+    },
+  );
+
+  logger.warnIncompleteToolLifecycles?.({
+    reason: "error",
+    toolCallIds: ["tool-1", "tool-2"],
+    errorMessage: "stream failed",
+  });
+  logger.warnUnknownToolIdentity?.({
+    toolCallId: "tool-1",
+    phase: "input_streaming",
+    reason: "error",
+    hasInputSnapshot: true,
+  });
+
+  assertEquals(warnings, [
+    {
+      message: "Closing incomplete child fork tool lifecycles",
+      context: {
+        conversationId: "conv-1",
+        runId: "run-1",
+        description: "Summarize docs",
+        reason: "error",
+        toolCallIds: ["tool-1", "tool-2"],
+        errorMessage: "stream failed",
+      },
+    },
+    {
+      message: "Closing child fork tool lifecycle without recoverable tool identity",
+      context: {
+        conversationId: "conv-1",
+        runId: "run-1",
+        description: "Summarize docs",
+        toolCallId: "tool-1",
+        phase: "input_streaming",
+        reason: "error",
+        hasInputSnapshot: true,
+      },
+    },
+  ]);
 });

--- a/src/agent/hosted-child-pending-tool-lifecycle.ts
+++ b/src/agent/hosted-child-pending-tool-lifecycle.ts
@@ -32,6 +32,45 @@ export interface HostedChildPendingToolLifecycleLogger {
   warnUnknownToolIdentity?: (input: HostedChildPendingToolLifecycleUnknownToolLog) => void;
 }
 
+export interface HostedChildPendingToolLifecycleLogContext {
+  conversationId?: string;
+  parentRunId?: string;
+  description: string;
+}
+
+export interface HostedChildPendingToolLifecycleLogWriter {
+  warn: (message: string, context: Record<string, unknown>) => void;
+}
+
+export function createHostedChildPendingToolLifecycleLogger(
+  context: HostedChildPendingToolLifecycleLogContext,
+  writer: HostedChildPendingToolLifecycleLogWriter,
+): HostedChildPendingToolLifecycleLogger {
+  return {
+    warnIncompleteToolLifecycles: (log) => {
+      writer.warn("Closing incomplete child fork tool lifecycles", {
+        conversationId: context.conversationId,
+        runId: context.parentRunId,
+        description: context.description,
+        reason: log.reason,
+        toolCallIds: log.toolCallIds,
+        errorMessage: log.errorMessage,
+      });
+    },
+    warnUnknownToolIdentity: (log) => {
+      writer.warn("Closing child fork tool lifecycle without recoverable tool identity", {
+        conversationId: context.conversationId,
+        runId: context.parentRunId,
+        description: context.description,
+        toolCallId: log.toolCallId,
+        phase: log.phase,
+        reason: log.reason,
+        hasInputSnapshot: log.hasInputSnapshot,
+      });
+    },
+  };
+}
+
 export interface HostedChildPendingToolLifecycleInput {
   appendMirrorChunk: (chunk: ChatUiMessageChunk<ChatMessageMetadata>) => Promise<void> | void;
   logger?: HostedChildPendingToolLifecycleLogger;

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -541,12 +541,15 @@ export {
 } from "./child-run-execution-cleanup.ts";
 export {
   createHostedChildPendingToolLifecycle,
+  createHostedChildPendingToolLifecycleLogger,
   type HostedChildPendingToolCallPhase,
   type HostedChildPendingToolCallState,
   type HostedChildPendingToolLifecycleCloseLog,
   type HostedChildPendingToolLifecycleCloseReason,
   type HostedChildPendingToolLifecycleInput,
+  type HostedChildPendingToolLifecycleLogContext,
   type HostedChildPendingToolLifecycleLogger,
+  type HostedChildPendingToolLifecycleLogWriter,
   type HostedChildPendingToolLifecycleUnknownToolLog,
 } from "./hosted-child-pending-tool-lifecycle.ts";
 export {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.392";
+export const VERSION = "0.1.393";


### PR DESCRIPTION
## Summary\n- add a reusable hosted child pending-tool lifecycle logger adapter\n- export pending-tool lifecycle log context and writer types from the agent package surface\n- bump package version to 0.1.393 for CI/CD publish\n\n## Verification\n- deno check src/agent/index.ts src/agent/hosted-child-pending-tool-lifecycle.ts src/agent/hosted-child-pending-tool-lifecycle.test.ts\n- deno test --no-check --allow-all src/agent/hosted-child-pending-tool-lifecycle.test.ts\n- deno task verify:quick