### PR TITLE
Release veryfront-code 0.1.393

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.392",
+  "version": "0.1.393",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.392";
+export const VERSION = "0.1.393";


### PR DESCRIPTION
## Summary
- bump veryfront-code from 0.1.392 to 0.1.393
- publish the provider follow-up fix from #1443, which landed after v0.1.392 was already tagged

## Verification
- deno fmt --check deno.json src/utils/version-constant.ts
- DENO_NO_PACKAGE_JSON=1 deno lint src/utils/version-constant.ts
- pre-push hook: format checked 3305 files
- pre-push hook: lint checked 3274 files
- pre-push hook: typecheck passed
- pre-push hook: unit tests passed, 1665 passed / 0 failed / 0 ignored (2 steps)

## Notes
- This is intentionally a narrow release-only PR so downstream agents can consume the fix through the normal versioned dependency path.