### PR TITLE
Add hosted child steering tool wrappers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.393",
+  "version": "0.1.394",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-steering-tools.test.ts
+++ b/src/agent/hosted-child-steering-tools.test.ts
@@ -1,0 +1,125 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import type { HostToolDefinition, HostToolSet } from "#veryfront/tool";
+import {
+  wrapHostedChildProjectSwitchTool,
+  wrapHostedChildSteeringMutationTool,
+} from "./hosted-child-steering-tools.ts";
+
+Deno.test("wrapHostedChildSteeringMutationTool leaves tools without execute unchanged", () => {
+  const toolDefinition: HostToolDefinition = { description: "no execute" };
+
+  const wrapped = wrapHostedChildSteeringMutationTool({
+    toolName: "create_file",
+    toolDefinition,
+    activeProjectId: "project-1",
+  });
+
+  assertEquals(wrapped, toolDefinition);
+});
+
+Deno.test("wrapHostedChildSteeringMutationTool reports successful steering mutations", async () => {
+  const mutations: unknown[] = [];
+  const wrapped = wrapHostedChildSteeringMutationTool({
+    toolName: "create_file",
+    toolDefinition: {
+      execute: () => ({ structuredContent: { success: true } }),
+    },
+    activeProjectId: "project-1",
+    activeBranchId: "branch-1",
+    onMutation: (mutation) => {
+      mutations.push(mutation);
+    },
+  });
+
+  const result = await wrapped.execute?.({
+    project_reference: "project-1",
+    branch_id: "branch-1",
+    path: "AGENTS.md",
+  });
+
+  assertEquals(result, { structuredContent: { success: true } });
+  assertEquals(mutations, [{ instructionsChanged: true, skillsChanged: false }]);
+});
+
+Deno.test("wrapHostedChildSteeringMutationTool ignores failed or irrelevant mutations", async () => {
+  let mutationCount = 0;
+  const failedTool = wrapHostedChildSteeringMutationTool({
+    toolName: "update_file",
+    toolDefinition: {
+      execute: () => ({ structuredContent: { success: false } }),
+    },
+    activeProjectId: "project-1",
+    onMutation: () => {
+      mutationCount += 1;
+    },
+  });
+  const unrelatedTool = wrapHostedChildSteeringMutationTool({
+    toolName: "update_file",
+    toolDefinition: {
+      execute: () => ({ structuredContent: { success: true } }),
+    },
+    activeProjectId: "project-1",
+    onMutation: () => {
+      mutationCount += 1;
+    },
+  });
+
+  await failedTool.execute?.({ project_reference: "project-1", path: "AGENTS.md" });
+  await unrelatedTool.execute?.({ project_reference: "project-2", path: "AGENTS.md" });
+
+  assertEquals(mutationCount, 0);
+});
+
+Deno.test("wrapHostedChildProjectSwitchTool leaves missing switch tools unchanged", () => {
+  const tools: HostToolSet = {};
+
+  wrapHostedChildProjectSwitchTool({
+    tools,
+    onConfirmedProjectSwitch: () => {
+      throw new Error("unexpected project switch");
+    },
+  });
+
+  assertEquals(tools, {});
+});
+
+Deno.test("wrapHostedChildProjectSwitchTool reports confirmed project switches", async () => {
+  const switchedProjectIds: string[] = [];
+  const tools: HostToolSet = {
+    studio_open_project: {
+      execute: () => ({ structuredContent: { success: true, project_id: "project-2" } }),
+    },
+  };
+
+  wrapHostedChildProjectSwitchTool({
+    tools,
+    onConfirmedProjectSwitch: (projectId) => {
+      switchedProjectIds.push(projectId);
+    },
+  });
+
+  const result = await tools.studio_open_project?.execute?.({ project_id: "project-2" });
+
+  assertEquals(result, { structuredContent: { success: true, project_id: "project-2" } });
+  assertEquals(switchedProjectIds, ["project-2"]);
+});
+
+Deno.test("wrapHostedChildProjectSwitchTool ignores mismatched or failed project switches", async () => {
+  const switchedProjectIds: string[] = [];
+  const tools: HostToolSet = {
+    studio_open_project: {
+      execute: () => ({ structuredContent: { success: true, project_id: "project-3" } }),
+    },
+  };
+
+  wrapHostedChildProjectSwitchTool({
+    tools,
+    onConfirmedProjectSwitch: (projectId) => {
+      switchedProjectIds.push(projectId);
+    },
+  });
+
+  await tools.studio_open_project?.execute?.({ project_id: "project-2" });
+
+  assertEquals(switchedProjectIds, []);
+});

--- a/src/agent/hosted-child-steering-tools.ts
+++ b/src/agent/hosted-child-steering-tools.ts
@@ -1,0 +1,92 @@
+import type { HostToolDefinition, HostToolSet, ToolExecutionContext } from "#veryfront/tool";
+import { toChildRunToolInputRecord } from "./child-run-execution-support.ts";
+import { getConfirmedProjectContextSwitchId } from "./project-context.ts";
+import {
+  getProjectSteeringMutation,
+  isSuccessfulProjectSteeringMutationResult,
+  type ProjectSteeringMutationResult,
+  type ProjectSteeringPaths,
+} from "./project-steering-mutation.ts";
+
+export type HostedChildSteeringMutationHandler = (
+  mutation: ProjectSteeringMutationResult,
+) => Promise<void> | void;
+
+export type HostedChildProjectSwitchHandler = (projectId: string) => Promise<void> | void;
+
+export type WrapHostedChildSteeringMutationToolInput = {
+  toolName: string;
+  toolDefinition: HostToolDefinition;
+  activeProjectId?: string | null;
+  activeBranchId?: string | null;
+  steeringPaths?: ProjectSteeringPaths;
+  onMutation?: HostedChildSteeringMutationHandler;
+};
+
+export type WrapHostedChildProjectSwitchToolInput = {
+  tools: HostToolSet;
+  toolName?: string;
+  onConfirmedProjectSwitch: HostedChildProjectSwitchHandler;
+};
+
+export function wrapHostedChildSteeringMutationTool(
+  input: WrapHostedChildSteeringMutationToolInput,
+): HostToolDefinition {
+  if (!input.toolDefinition.execute) {
+    return input.toolDefinition;
+  }
+
+  const originalExecute = input.toolDefinition.execute;
+
+  return {
+    ...input.toolDefinition,
+    execute: async (toolInput: unknown, execOptions?: ToolExecutionContext) => {
+      const normalizedToolInput = toChildRunToolInputRecord(toolInput);
+      const result = await originalExecute(toolInput, execOptions);
+      if (!isSuccessfulProjectSteeringMutationResult(result)) {
+        return result;
+      }
+
+      const mutation = getProjectSteeringMutation({
+        toolName: input.toolName,
+        toolInput: normalizedToolInput,
+        activeProjectId: input.activeProjectId,
+        activeBranchId: input.activeBranchId,
+        steeringPaths: input.steeringPaths,
+      });
+
+      if (mutation.instructionsChanged || mutation.skillsChanged) {
+        await input.onMutation?.(mutation);
+      }
+
+      return result;
+    },
+  };
+}
+
+export function wrapHostedChildProjectSwitchTool(
+  input: WrapHostedChildProjectSwitchToolInput,
+): void {
+  const toolName = input.toolName ?? "studio_open_project";
+  const toolDefinition = input.tools[toolName];
+  if (!toolDefinition?.execute) {
+    return;
+  }
+
+  const originalExecute = toolDefinition.execute;
+  input.tools[toolName] = {
+    ...toolDefinition,
+    execute: async (toolInput: unknown, execOptions?: ToolExecutionContext) => {
+      const normalizedToolInput = toChildRunToolInputRecord(toolInput);
+      const result = await originalExecute(toolInput, execOptions);
+      const projectId = normalizedToolInput.project_id;
+      const confirmedProjectId = typeof projectId === "string"
+        ? getConfirmedProjectContextSwitchId(result, projectId)
+        : null;
+      if (confirmedProjectId) {
+        await input.onConfirmedProjectSwitch(confirmedProjectId);
+      }
+      return result;
+    },
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -111,6 +111,15 @@ export type {
 } from "./types.ts";
 
 export {
+  type HostedChildProjectSwitchHandler,
+  type HostedChildSteeringMutationHandler,
+  wrapHostedChildProjectSwitchTool,
+  type WrapHostedChildProjectSwitchToolInput,
+  wrapHostedChildSteeringMutationTool,
+  type WrapHostedChildSteeringMutationToolInput,
+} from "./hosted-child-steering-tools.ts";
+
+export {
   DEFAULT_PROJECT_STEERING_PATHS,
   getProjectSteeringMutation,
   isSuccessfulProjectSteeringMutationResult,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.393";
+export const VERSION = "0.1.394";


### PR DESCRIPTION
## Summary\n- Add reusable hosted child wrappers for steering file mutation tools\n- Add a reusable hosted child project switch wrapper for confirmed Studio project switches\n- Export the new hosted child wrapper helpers and bump package version to 0.1.394\n\n## Validation\n- deno check src/agent/index.ts src/agent/hosted-child-steering-tools.ts src/agent/hosted-child-steering-tools.test.ts\n- deno test --no-check --allow-all src/agent/hosted-child-steering-tools.test.ts\n- deno task verify:quick\n- pre-push checks\n