### PR TITLE
Release veryfront-code 0.1.394

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.393",
+  "version": "0.1.394",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.393";
+export const VERSION = "0.1.394";


### PR DESCRIPTION
## Summary
- bump veryfront-code from 0.1.393 to 0.1.394
- publish the provider status follow-up fix that landed after the existing v0.1.393 tag
- keep v0.1.393 immutable because it already points at an earlier main commit

## Verification
- deno fmt --check deno.json src/utils/version-constant.ts
- DENO_NO_PACKAGE_JSON=1 deno lint src/utils/version-constant.ts
- pre-push hook: format checked 3305 files
- pre-push hook: lint checked 3274 files
- pre-push hook: typecheck passed
- pre-push hook: unit tests passed, 1666 passed / 0 failed / 0 ignored (2 steps)

## Release note
- v0.1.393 already exists at commit 84ecfbb, before the provider follow-up fix. This PR creates the next clean release version for downstream consumers.