### PR TITLE
Add hosted mirrored open tool closer

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.394",
+  "version": "0.1.395",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -876,8 +876,12 @@ export {
 } from "../chat/chat-ui-message-helpers.ts";
 export {
   cloneMirroredToolChunkState,
+  closeHostedMirroredOpenToolCalls,
+  type CloseHostedMirroredOpenToolCallsInput,
   computeOpenToolCalls,
   createMirroredToolChunkState,
+  getHostedMirroredAbortErrorText,
+  type HostedMirroredOpenToolCallLogger,
   isDurableMirroredOutputChunk,
   type MirroredToolChunkState,
   type OpenToolCalls,

--- a/src/agent/mirrored-tool-chunk-state.test.ts
+++ b/src/agent/mirrored-tool-chunk-state.test.ts
@@ -3,8 +3,10 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ChatMessageMetadata, ChatUiMessageChunk } from "../chat/protocol.ts";
 import {
   cloneMirroredToolChunkState,
+  closeHostedMirroredOpenToolCalls,
   computeOpenToolCalls,
   createMirroredToolChunkState,
+  getHostedMirroredAbortErrorText,
   isDurableMirroredOutputChunk,
   recordMirroredToolChunkState,
 } from "./mirrored-tool-chunk-state.ts";
@@ -150,5 +152,104 @@ describe("mirrored-tool-chunk-state", () => {
       needsInputClose: [],
       needsOutputClose: [{ toolCallId: "tc-1", toolName: "edit_file" }],
     });
+  });
+
+  it("builds stream abort error text from abort and non-abort errors", () => {
+    assertEquals(
+      getHostedMirroredAbortErrorText(new DOMException("cancelled", "AbortError")),
+      "Chat stream aborted before tool call completed",
+    );
+    assertEquals(
+      getHostedMirroredAbortErrorText(new Error("provider stopped")),
+      "Chat stream errored before tool call completed: provider stopped",
+    );
+  });
+
+  it("closes mirrored open tool calls with terminal error chunks", async () => {
+    const state = createMirroredToolChunkState();
+    recordMirroredToolChunkState(state, {
+      type: "tool-input-start",
+      toolCallId: "tc-1",
+      toolName: "bash",
+    });
+    recordMirroredToolChunkState(state, {
+      type: "tool-input-available",
+      toolCallId: "tc-2",
+      toolName: "edit_file",
+      input: { path: "AGENTS.md" },
+    });
+
+    const chunks: Chunk[] = [];
+    const warnings: Array<{ message: string; metadata?: Record<string, unknown> }> = [];
+
+    await closeHostedMirroredOpenToolCalls({
+      mirroredToolChunkState: state,
+      errorText: "stream stopped",
+      appendChunk: (chunk) => {
+        chunks.push(chunk);
+      },
+      logger: {
+        warn: (message, metadata) => {
+          warnings.push({ message, metadata });
+        },
+      },
+    });
+
+    assertEquals(chunks, [
+      {
+        type: "tool-input-error",
+        toolCallId: "tc-1",
+        toolName: "bash",
+        input: {},
+        errorText: "stream stopped",
+      },
+      {
+        type: "tool-output-error",
+        toolCallId: "tc-2",
+        errorText: "stream stopped",
+      },
+    ]);
+    assertEquals(warnings.length, 1);
+    assertEquals(warnings[0]?.message, "Closing open tool calls after stream abort");
+  });
+
+  it("does not append chunks when no mirrored tool calls are open", async () => {
+    const chunks: Chunk[] = [];
+
+    await closeHostedMirroredOpenToolCalls({
+      mirroredToolChunkState: createMirroredToolChunkState(),
+      errorText: "stream stopped",
+      appendChunk: (chunk) => {
+        chunks.push(chunk);
+      },
+    });
+
+    assertEquals(chunks, []);
+  });
+
+  it("logs tool calls without recoverable tool names", async () => {
+    const state = createMirroredToolChunkState();
+    state.startedToolCallIds.add("tc-1");
+
+    const warnings: Array<{ message: string; metadata?: Record<string, unknown> }> = [];
+
+    await closeHostedMirroredOpenToolCalls({
+      mirroredToolChunkState: state,
+      errorText: "stream stopped",
+      appendChunk: () => undefined,
+      logger: {
+        warn: (message, metadata) => {
+          warnings.push({ message, metadata });
+        },
+      },
+    });
+
+    assertEquals(
+      warnings.map(({ message }) => message),
+      [
+        "Closing open tool calls after stream abort",
+        "Closing aborted tool calls without recoverable tool names",
+      ],
+    );
   });
 });

--- a/src/agent/mirrored-tool-chunk-state.ts
+++ b/src/agent/mirrored-tool-chunk-state.ts
@@ -105,6 +105,37 @@ export interface OpenToolCalls {
   needsOutputClose: Array<{ toolCallId: string; toolName: string }>;
 }
 
+export interface HostedMirroredOpenToolCallLogger {
+  warn: (message: string, metadata?: Record<string, unknown>) => void;
+}
+
+export interface CloseHostedMirroredOpenToolCallsInput {
+  mirroredToolChunkState: MirroredToolChunkState;
+  errorText: string;
+  appendChunk: (
+    chunk: ChatUiMessageChunk<ChatMessageMetadata>,
+  ) => Promise<void> | void;
+  logger?: HostedMirroredOpenToolCallLogger;
+}
+
+function isAbortErrorLike(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return true;
+  }
+
+  return error instanceof Error && error.name === "AbortError";
+}
+
+export function getHostedMirroredAbortErrorText(streamError: unknown): string {
+  if (isAbortErrorLike(streamError)) {
+    return "Chat stream aborted before tool call completed";
+  }
+
+  return `Chat stream errored before tool call completed: ${
+    streamError instanceof Error ? streamError.message : String(streamError)
+  }`;
+}
+
 export function computeOpenToolCalls(
   state: MirroredToolChunkState,
 ): OpenToolCalls {
@@ -132,4 +163,50 @@ export function computeOpenToolCalls(
     needsInputClose,
     needsOutputClose,
   };
+}
+
+export async function closeHostedMirroredOpenToolCalls(
+  input: CloseHostedMirroredOpenToolCallsInput,
+): Promise<void> {
+  const openToolCalls = computeOpenToolCalls(input.mirroredToolChunkState);
+  if (
+    openToolCalls.needsInputClose.length === 0 &&
+    openToolCalls.needsOutputClose.length === 0
+  ) {
+    return;
+  }
+
+  input.logger?.warn("Closing open tool calls after stream abort", {
+    needsInputClose: openToolCalls.needsInputClose.map(({ toolCallId }) => toolCallId),
+    needsOutputClose: openToolCalls.needsOutputClose.map(({ toolCallId }) => toolCallId),
+    errorText: input.errorText,
+  });
+
+  const unknownToolNames = openToolCalls.needsInputClose.filter(
+    ({ toolName }) => toolName === "unknown",
+  );
+  if (unknownToolNames.length > 0) {
+    input.logger?.warn("Closing aborted tool calls without recoverable tool names", {
+      toolCallIds: unknownToolNames.map(({ toolCallId }) => toolCallId),
+      errorText: input.errorText,
+    });
+  }
+
+  for (const { toolCallId, toolName } of openToolCalls.needsInputClose) {
+    await input.appendChunk({
+      type: "tool-input-error",
+      toolCallId,
+      toolName,
+      input: {},
+      errorText: input.errorText,
+    });
+  }
+
+  for (const { toolCallId } of openToolCalls.needsOutputClose) {
+    await input.appendChunk({
+      type: "tool-output-error",
+      toolCallId,
+      errorText: input.errorText,
+    });
+  }
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.394";
+export const VERSION = "0.1.395";


### PR DESCRIPTION
## Summary
- add framework helper for closing mirrored open tool calls after stream aborts
- add hosted stream abort error text helper
- bump package version to 0.1.395 for CI release

## Verification
- deno check src/agent/index.ts src/agent/mirrored-tool-chunk-state.ts src/agent/mirrored-tool-chunk-state.test.ts
- deno test --no-check --allow-all src/agent/mirrored-tool-chunk-state.test.ts
- deno task verify:quick
- pre-push checks: 1672 passed (17214 steps), 0 failed