### PR TITLE
Add hosted stream terminal error helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.395",
+  "version": "0.1.396",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-stream-terminal-error.test.ts
+++ b/src/agent/hosted-stream-terminal-error.test.ts
@@ -1,0 +1,140 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  getEmptyHostedFinalizedMessageTerminalError,
+  getHostedStreamErrorText,
+  shouldFailEmptyHostedFinalizedMessage,
+} from "./hosted-stream-terminal-error.ts";
+
+Deno.test("getHostedStreamErrorText extracts message from Error", () => {
+  assertEquals(getHostedStreamErrorText(new Error("boom")), "boom");
+});
+
+Deno.test("getHostedStreamErrorText returns string errors as-is", () => {
+  assertEquals(getHostedStreamErrorText("raw error"), "raw error");
+});
+
+Deno.test("getHostedStreamErrorText extracts message from record with message field", () => {
+  assertEquals(getHostedStreamErrorText({ message: "from record" }), "from record");
+});
+
+Deno.test("getHostedStreamErrorText recognizes credit limit errors", () => {
+  assertStringIncludes(getHostedStreamErrorText(new Error("AI credit limit exceeded")), "credit");
+});
+
+Deno.test("getEmptyHostedFinalizedMessageTerminalError returns default empty response error", () => {
+  const result = getEmptyHostedFinalizedMessageTerminalError({ finalStep: null });
+  assertEquals(result.code, "EMPTY_RESPONSE");
+  assertStringIncludes(result.message, "without producing a response");
+});
+
+Deno.test("getEmptyHostedFinalizedMessageTerminalError returns stream error when present", () => {
+  assertEquals(
+    getEmptyHostedFinalizedMessageTerminalError({
+      finalStep: null,
+      streamError: new Error("connection lost"),
+    }),
+    { code: "STREAM_ERROR", message: "connection lost" },
+  );
+});
+
+Deno.test("getEmptyHostedFinalizedMessageTerminalError returns credit error from stream error", () => {
+  const result = getEmptyHostedFinalizedMessageTerminalError({
+    finalStep: null,
+    streamError: JSON.stringify({ slug: "insufficient-credits", suggestion: "Buy credits" }),
+  });
+  assertEquals(result.code, "INSUFFICIENT_CREDITS");
+});
+
+Deno.test("getEmptyHostedFinalizedMessageTerminalError extracts terminal error from final step response body", () => {
+  const result = getEmptyHostedFinalizedMessageTerminalError({
+    finalStep: {
+      response: {
+        body: JSON.stringify({ slug: "insufficient-credits", suggestion: "Upgrade plan" }),
+      },
+    },
+  });
+  assertEquals(result.code, "INSUFFICIENT_CREDITS");
+});
+
+Deno.test("shouldFailEmptyHostedFinalizedMessage fails non-aborted empty assistant responses", () => {
+  assertEquals(
+    shouldFailEmptyHostedFinalizedMessage({
+      isAborted: false,
+      message: { parts: [] },
+    }),
+    true,
+  );
+});
+
+Deno.test("shouldFailEmptyHostedFinalizedMessage keeps aborted empty assistant responses cancellable", () => {
+  assertEquals(
+    shouldFailEmptyHostedFinalizedMessage({
+      isAborted: true,
+      message: { parts: [] },
+    }),
+    false,
+  );
+});
+
+Deno.test("shouldFailEmptyHostedFinalizedMessage keeps non-empty assistant responses successful", () => {
+  assertEquals(
+    shouldFailEmptyHostedFinalizedMessage({
+      isAborted: false,
+      message: { parts: [{ type: "text", text: "Done" }] },
+    }),
+    false,
+  );
+});
+
+Deno.test("getEmptyHostedFinalizedMessageTerminalError prefers a real terminal error from final step response body", () => {
+  assertEquals(
+    getEmptyHostedFinalizedMessageTerminalError({
+      finalStep: {
+        response: {
+          body: {
+            slug: "insufficient-credits",
+            error: "AI credit limit exceeded",
+            suggestion: "Purchase additional credits or upgrade your subscription plan.",
+          },
+        },
+      },
+    }),
+    {
+      code: "INSUFFICIENT_CREDITS",
+      message: "Purchase additional credits or upgrade your subscription plan.",
+    },
+  );
+});
+
+Deno.test("getEmptyHostedFinalizedMessageTerminalError prefers a streamed provider error over final step fallback", () => {
+  assertEquals(
+    getEmptyHostedFinalizedMessageTerminalError({
+      streamError: "AI credit limit exceeded",
+      finalStep: {
+        response: {
+          body: {
+            slug: "resource-limit-exceeded",
+            suggestion: "Reduce the request size.",
+          },
+        },
+      },
+    }),
+    {
+      code: "INSUFFICIENT_CREDITS",
+      message: "Insufficient AI credits",
+    },
+  );
+});
+
+Deno.test("getEmptyHostedFinalizedMessageTerminalError keeps unknown streamed errors as stream failures", () => {
+  assertEquals(
+    getEmptyHostedFinalizedMessageTerminalError({
+      streamError: "Provider stream closed unexpectedly",
+      finalStep: null,
+    }),
+    {
+      code: "STREAM_ERROR",
+      message: "Provider stream closed unexpectedly",
+    },
+  );
+});

--- a/src/agent/hosted-stream-terminal-error.ts
+++ b/src/agent/hosted-stream-terminal-error.ts
@@ -1,0 +1,81 @@
+import { isRecord } from "../chat/conversation.ts";
+import { extractFinalStepTerminalError } from "../chat/final-step-fallback.ts";
+import { parseProviderError } from "../chat/provider-errors.ts";
+
+const EMPTY_RESPONSE_TERMINAL_ERROR_CODE = "EMPTY_RESPONSE";
+const EMPTY_RESPONSE_TERMINAL_ERROR_MESSAGE = "Assistant completed without producing a response";
+const EXTERNAL_SERVICE_ERROR_CODE = "EXTERNAL_SERVICE_ERROR";
+const EXTERNAL_SERVICE_ERROR_MESSAGE = "AI provider service error";
+const STREAM_ERROR_TERMINAL_ERROR_CODE = "STREAM_ERROR";
+
+export type HostedStreamTerminalError = {
+  code: string;
+  message: string;
+};
+
+function getUnknownErrorMessage(error: unknown): string {
+  if (typeof error === "string") {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (isRecord(error) && typeof error.message === "string") {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+function getHostedStreamTerminalError(streamError: unknown): HostedStreamTerminalError | null {
+  if (streamError == null) {
+    return null;
+  }
+
+  const parsedError = parseProviderError(streamError);
+  if (
+    parsedError.code !== EXTERNAL_SERVICE_ERROR_CODE ||
+    parsedError.message !== EXTERNAL_SERVICE_ERROR_MESSAGE
+  ) {
+    return {
+      code: parsedError.code,
+      message: parsedError.message,
+    };
+  }
+
+  const message = getUnknownErrorMessage(streamError).trim();
+  if (message.length === 0) {
+    return null;
+  }
+
+  return {
+    code: STREAM_ERROR_TERMINAL_ERROR_CODE,
+    message,
+  };
+}
+
+export function getHostedStreamErrorText(streamError: unknown): string {
+  return getHostedStreamTerminalError(streamError)?.message ?? getUnknownErrorMessage(streamError);
+}
+
+export function getEmptyHostedFinalizedMessageTerminalError(input: {
+  finalStep: unknown;
+  streamError?: unknown | null;
+}): HostedStreamTerminalError {
+  return (
+    getHostedStreamTerminalError(input.streamError) ??
+      extractFinalStepTerminalError(input.finalStep) ?? {
+      code: EMPTY_RESPONSE_TERMINAL_ERROR_CODE,
+      message: EMPTY_RESPONSE_TERMINAL_ERROR_MESSAGE,
+    }
+  );
+}
+
+export function shouldFailEmptyHostedFinalizedMessage(input: {
+  isAborted: boolean;
+  message: { parts: ReadonlyArray<unknown> };
+}): boolean {
+  return !input.isAborted && input.message.parts.length === 0;
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -742,6 +742,12 @@ export {
   type HostedTerminalError,
 } from "./hosted-stream-finalization.ts";
 export {
+  getEmptyHostedFinalizedMessageTerminalError,
+  getHostedStreamErrorText,
+  type HostedStreamTerminalError,
+  shouldFailEmptyHostedFinalizedMessage,
+} from "./hosted-stream-terminal-error.ts";
+export {
   type ActiveConversationRunStatus,
   appendConversationRunEvents,
   AppendConversationRunEventsError,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.395";
+export const VERSION = "0.1.396";


### PR DESCRIPTION
## Summary
- add reusable hosted stream terminal-error helpers for stream error text, empty finalized-message terminal errors, and empty-message failure decisions
- export the helpers from the agent package surface
- bump package version to 0.1.396 for CI/CD publishing

## Verification
- deno fmt src/agent/hosted-stream-terminal-error.ts src/agent/hosted-stream-terminal-error.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts
- deno check src/agent/index.ts src/agent/hosted-stream-terminal-error.ts src/agent/hosted-stream-terminal-error.test.ts
- deno test --no-check --allow-all src/agent/hosted-stream-terminal-error.test.ts
- deno task verify:quick
- pre-push checks: 1686 passed (17214 steps), 0 failed