### PR TITLE
Add AG-UI chat chunk browser encoder

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.396",
+  "version": "0.1.397",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/ag-ui-chat-ui-chunk-browser-encoder.test.ts
+++ b/src/agent/ag-ui-chat-ui-chunk-browser-encoder.test.ts
@@ -1,0 +1,179 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ChatUiMessageChunk } from "#veryfront/chat/protocol.ts";
+import {
+  createAgUiChatUiChunkBrowserEncoder,
+  getAgUiChatUiMessageChunkMetadata,
+  getAgUiChatUiMessageUsageMetadata,
+  normalizeChatUiMessageChunkToAgUiRuntimeEvent,
+} from "./ag-ui-chat-ui-chunk-browser-encoder.ts";
+
+describe("agent/ag-ui-chat-ui-chunk-browser-encoder", () => {
+  it("extracts usage and total token metadata", () => {
+    assertEquals(
+      getAgUiChatUiMessageUsageMetadata({
+        usage: {
+          inputTokens: 12,
+          outputTokens: 8,
+        },
+      }),
+      {
+        inputTokens: 12,
+        outputTokens: 8,
+        totalTokens: 20,
+      },
+    );
+
+    assertEquals(
+      getAgUiChatUiMessageUsageMetadata({
+        usage: {
+          outputTokens: 8,
+        },
+      }),
+      {
+        inputTokens: undefined,
+        outputTokens: 8,
+        totalTokens: 8,
+      },
+    );
+
+    assertEquals(getAgUiChatUiMessageUsageMetadata(undefined), {
+      inputTokens: undefined,
+      outputTokens: undefined,
+      totalTokens: undefined,
+    });
+  });
+
+  it("extracts model, provider, usage, and finish reason from chat chunks", () => {
+    const finishChunk: ChatUiMessageChunk = {
+      type: "finish",
+      finishReason: "stop",
+      messageMetadata: {
+        modelId: "custom/model",
+        usage: {
+          inputTokens: 2,
+          outputTokens: 3,
+        },
+      },
+    };
+
+    assertEquals(
+      getAgUiChatUiMessageChunkMetadata(finishChunk, {
+        resolveProvider: (modelId) => modelId === "custom/model" ? "custom-provider" : undefined,
+      }),
+      {
+        provider: "custom-provider",
+        model: "custom/model",
+        inputTokens: 2,
+        outputTokens: 3,
+        totalTokens: 5,
+        finishReason: "stop",
+      },
+    );
+  });
+
+  it("returns null when a non-finish chunk has no metadata", () => {
+    assertEquals(
+      getAgUiChatUiMessageChunkMetadata({ type: "text-delta", id: "msg-1", delta: "hello" }),
+      null,
+    );
+  });
+
+  it("normalizes chat chunks into AG-UI runtime events", () => {
+    assertEquals(
+      normalizeChatUiMessageChunkToAgUiRuntimeEvent({
+        type: "start",
+        messageId: "msg-1",
+        messageMetadata: { modelId: "model-a" },
+      }),
+      {
+        type: "message-start",
+        messageId: "msg-1",
+        messageMetadata: { modelId: "model-a" },
+      },
+    );
+
+    assertEquals(normalizeChatUiMessageChunkToAgUiRuntimeEvent({ type: "start-step" }), {
+      type: "step-start",
+    });
+    assertEquals(normalizeChatUiMessageChunkToAgUiRuntimeEvent({ type: "finish-step" }), {
+      type: "step-end",
+    });
+    assertEquals(
+      normalizeChatUiMessageChunkToAgUiRuntimeEvent({ type: "error", errorText: "boom" }),
+      {
+        type: "error",
+        error: "boom",
+      },
+    );
+  });
+
+  it("creates a browser encoder for chat UI chunks", () => {
+    const encoder = createAgUiChatUiChunkBrowserEncoder({
+      modelId: "custom/model",
+      resolveProvider: (modelId) => modelId === "custom/model" ? "custom-provider" : undefined,
+    });
+
+    const encodedStart = encoder.encode({
+      type: "start",
+      messageId: "msg-1",
+      messageMetadata: {
+        modelId: "custom/model",
+        usage: {
+          inputTokens: 1,
+        },
+      },
+    });
+
+    assertEquals(encodedStart, []);
+
+    assertEquals(encoder.encode({ type: "text-delta", id: "msg-1", delta: "hello" }), [
+      {
+        event: "TextMessageStart",
+        payload: {
+          messageId: "msg-1",
+          role: "assistant",
+        },
+      },
+      {
+        event: "TextMessageContent",
+        payload: {
+          messageId: "msg-1",
+          delta: "hello",
+        },
+      },
+    ]);
+
+    assertEquals(
+      encoder.finalize({
+        text: "hello",
+        messages: [{
+          id: "msg-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "hello" }],
+        }],
+        toolCalls: [],
+        status: "completed",
+      }),
+      [
+        {
+          event: "TextMessageEnd",
+          payload: {
+            messageId: "msg-1",
+          },
+        },
+        {
+          event: "RunFinished",
+          payload: {
+            metadata: {
+              provider: "custom-provider",
+              model: "custom/model",
+              inputTokens: 1,
+              totalTokens: 1,
+            },
+          },
+        },
+      ],
+    );
+  });
+});

--- a/src/agent/ag-ui-chat-ui-chunk-browser-encoder.ts
+++ b/src/agent/ag-ui-chat-ui-chunk-browser-encoder.ts
@@ -1,0 +1,136 @@
+import { tryGetVeryfrontCloudProviderFromModelId } from "#veryfront/provider";
+import type { ChatMessageMetadata, ChatUiMessageChunk } from "#veryfront/chat/protocol.ts";
+import type { AgUiBrowserChunkEncoder } from "./ag-ui-browser-chunk-encoder.ts";
+import {
+  type AgUiBrowserRunFinishedMetadata,
+  type AgUiRuntimeStreamEvent,
+} from "./ag-ui-browser-encoder.ts";
+import { createAgUiBrowserChunkEncoder } from "./ag-ui-browser-chunk-encoder.ts";
+
+export type AgUiChatUiChunkBrowserEncoder = Pick<
+  AgUiBrowserChunkEncoder<ChatUiMessageChunk<ChatMessageMetadata>>,
+  "encode" | "finalize"
+>;
+
+export interface CreateAgUiChatUiChunkBrowserEncoderOptions {
+  modelId?: string;
+  resolveProvider?: (modelId: string) => string | undefined;
+}
+
+export function getAgUiChatUiMessageMetadataFromChunk(
+  chunk: ChatUiMessageChunk<ChatMessageMetadata>,
+): ChatMessageMetadata | undefined {
+  if (chunk.type === "start" || chunk.type === "finish") {
+    return chunk.messageMetadata;
+  }
+
+  if (chunk.type === "message-metadata") {
+    return chunk.messageMetadata;
+  }
+
+  return undefined;
+}
+
+export function getAgUiChatUiMessageUsageMetadata(
+  messageMetadata: ChatMessageMetadata | undefined,
+): Pick<AgUiBrowserRunFinishedMetadata, "inputTokens" | "outputTokens" | "totalTokens"> {
+  const inputTokens = messageMetadata?.usage?.inputTokens;
+  const outputTokens = messageMetadata?.usage?.outputTokens;
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: typeof inputTokens === "number" || typeof outputTokens === "number"
+      ? (inputTokens ?? 0) + (outputTokens ?? 0)
+      : undefined,
+  };
+}
+
+export function getAgUiChatUiMessageChunkMetadata(
+  chunk: ChatUiMessageChunk<ChatMessageMetadata>,
+  options: Pick<CreateAgUiChatUiChunkBrowserEncoderOptions, "resolveProvider"> = {},
+): Partial<AgUiBrowserRunFinishedMetadata> | null {
+  const messageMetadata = getAgUiChatUiMessageMetadataFromChunk(chunk);
+  const modelId = messageMetadata?.modelId;
+  const provider = modelId
+    ? (options.resolveProvider ?? tryGetVeryfrontCloudProviderFromModelId)(modelId)
+    : undefined;
+  const usageMetadata = getAgUiChatUiMessageUsageMetadata(messageMetadata);
+
+  if (
+    !provider &&
+    !modelId &&
+    typeof usageMetadata.inputTokens !== "number" &&
+    typeof usageMetadata.outputTokens !== "number" &&
+    chunk.type !== "finish"
+  ) {
+    return null;
+  }
+
+  return {
+    ...(provider ? { provider } : {}),
+    ...(modelId ? { model: modelId } : {}),
+    ...(typeof usageMetadata.inputTokens === "number"
+      ? { inputTokens: usageMetadata.inputTokens }
+      : {}),
+    ...(typeof usageMetadata.outputTokens === "number"
+      ? { outputTokens: usageMetadata.outputTokens }
+      : {}),
+    ...(typeof usageMetadata.totalTokens === "number"
+      ? { totalTokens: usageMetadata.totalTokens }
+      : {}),
+    ...(chunk.type === "finish" && chunk.finishReason ? { finishReason: chunk.finishReason } : {}),
+  };
+}
+
+export function normalizeChatUiMessageChunkToAgUiRuntimeEvent(
+  chunk: ChatUiMessageChunk<ChatMessageMetadata>,
+): AgUiRuntimeStreamEvent {
+  switch (chunk.type) {
+    case "start":
+      return {
+        ...chunk,
+        type: "message-start",
+      };
+
+    case "finish":
+      return {
+        ...chunk,
+        type: "message-finish",
+      };
+
+    case "start-step":
+      return { type: "step-start" };
+
+    case "finish-step":
+      return { type: "step-end" };
+
+    case "error":
+      return {
+        type: "error",
+        error: chunk.errorText,
+      };
+
+    default:
+      return {
+        ...chunk,
+      };
+  }
+}
+
+export function createAgUiChatUiChunkBrowserEncoder(
+  options: CreateAgUiChatUiChunkBrowserEncoderOptions = {},
+): AgUiChatUiChunkBrowserEncoder {
+  const provider = options.modelId
+    ? (options.resolveProvider ?? tryGetVeryfrontCloudProviderFromModelId)(options.modelId)
+    : undefined;
+
+  return createAgUiBrowserChunkEncoder({
+    initialMetadata: {
+      ...(provider ? { provider } : {}),
+      ...(options.modelId ? { model: options.modelId } : {}),
+    },
+    getMetadataFromChunk: (chunk) => getAgUiChatUiMessageChunkMetadata(chunk, options),
+    getRuntimeEvents: (chunk) => [normalizeChatUiMessageChunkToAgUiRuntimeEvent(chunk)],
+  });
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -326,6 +326,15 @@ export {
   type CreateAgUiBrowserChunkEncoderOptions,
 } from "./ag-ui-browser-chunk-encoder.ts";
 export {
+  type AgUiChatUiChunkBrowserEncoder,
+  createAgUiChatUiChunkBrowserEncoder,
+  type CreateAgUiChatUiChunkBrowserEncoderOptions,
+  getAgUiChatUiMessageChunkMetadata,
+  getAgUiChatUiMessageMetadataFromChunk,
+  getAgUiChatUiMessageUsageMetadata,
+  normalizeChatUiMessageChunkToAgUiRuntimeEvent,
+} from "./ag-ui-chat-ui-chunk-browser-encoder.ts";
+export {
   type AgUiRuntimeEventEncoder,
   createAgUiRuntimeEventEncoder,
   type CreateAgUiRuntimeEventEncoderOptions,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.396";
+export const VERSION = "0.1.397";


### PR DESCRIPTION
## Summary\n- add a reusable AG-UI browser encoder for chat UI chunks\n- expose metadata extraction and runtime-event normalization helpers\n- bump the framework patch version to 0.1.397 for CI/CD release\n\n## Verification\n- deno check src/agent/ag-ui-chat-ui-chunk-browser-encoder.ts src/agent/ag-ui-chat-ui-chunk-browser-encoder.test.ts src/agent/index.ts\n- deno test --no-check --allow-all src/agent/ag-ui-chat-ui-chunk-browser-encoder.test.ts\n- deno task verify:quick\n- pre-push checks: 1687 passed (17219 steps), 0 failed