### PR TITLE
Add hosted child fork step message preparation

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.397",
+  "version": "0.1.398",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-fork-step-message-preparation.test.ts
+++ b/src/agent/hosted-child-fork-step-message-preparation.test.ts
@@ -1,0 +1,76 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import type { AgentRuntimeMessage } from "./agent-runtime-message-adapter.ts";
+import {
+  convertCompactedProviderMessagesToChildForkRuntimeMessages,
+  prepareHostedChildForkRuntimeStepMessages,
+} from "./hosted-child-fork-step-message-preparation.ts";
+
+Deno.test("convertCompactedProviderMessagesToChildForkRuntimeMessages rewrites tool-call part types", () => {
+  const messages = convertCompactedProviderMessagesToChildForkRuntimeMessages([
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "tool-call-1",
+          toolName: "read_file",
+          input: { path: "README.md" },
+        },
+      ],
+    },
+  ]);
+
+  assertEquals(messages[0]?.parts[0], {
+    type: "tool-read_file",
+    toolCallId: "tool-call-1",
+    toolName: "read_file",
+    args: { path: "README.md" },
+  });
+});
+
+Deno.test("prepareHostedChildForkRuntimeStepMessages compacts messages and resolves system text", () => {
+  const messages: AgentRuntimeMessage[] = [
+    {
+      id: "message-1",
+      role: "user",
+      parts: [{ type: "text", text: "Create a report" }],
+      timestamp: 1,
+    },
+    {
+      id: "message-2",
+      role: "assistant",
+      parts: [{ type: "text", text: "Trailing assistant draft" }],
+      timestamp: 2,
+    },
+  ];
+
+  const prepared = prepareHostedChildForkRuntimeStepMessages({
+    messages,
+    buildInstructions: () => "Base instructions",
+    forkToolNames: ["read_file", "create_file"],
+    resolveSystem: ({ system, compactedMessages }) =>
+      compactedMessages.length === 1 ? `${system}\n\nContinuation reminder` : system,
+  });
+
+  assertEquals(prepared.system, "Base instructions\n\nContinuation reminder");
+  assertEquals(prepared.messages, [
+    {
+      id: "agent-runtime-user-1",
+      role: "user",
+      parts: [{ type: "text", text: "Create a report" }],
+      timestamp: 0,
+    },
+  ]);
+});
+
+Deno.test("prepareHostedChildForkRuntimeStepMessages falls back to current instructions", () => {
+  const prepared = prepareHostedChildForkRuntimeStepMessages({
+    messages: [],
+    buildInstructions: () => "Current instructions",
+    forkToolNames: [],
+    resolveSystem: () => null,
+  });
+
+  assertEquals(prepared.system, "Current instructions");
+  assertEquals(prepared.messages, []);
+});

--- a/src/agent/hosted-child-fork-step-message-preparation.ts
+++ b/src/agent/hosted-child-fork-step-message-preparation.ts
@@ -1,0 +1,61 @@
+import { compactForStep, estimateOverhead } from "../chat/message-prep.ts";
+import type { ProviderModelMessage } from "../chat/types.ts";
+import {
+  type AgentRuntimeMessage,
+  convertAgentRuntimeMessagesToProviderMessages,
+  convertProviderMessagesToAgentRuntimeMessages,
+} from "./agent-runtime-message-adapter.ts";
+
+export type HostedChildForkRuntimeStepSystemResolver = (input: {
+  system: string;
+  compactedMessages: readonly ProviderModelMessage[];
+}) => string | null | undefined;
+
+export type PrepareHostedChildForkRuntimeStepMessagesInput = {
+  messages: AgentRuntimeMessage[];
+  buildInstructions: () => string;
+  forkToolNames: readonly string[];
+  resolveSystem?: HostedChildForkRuntimeStepSystemResolver;
+};
+
+export type HostedChildForkRuntimeStepMessages = {
+  messages: AgentRuntimeMessage[];
+  system: string;
+};
+
+export function convertCompactedProviderMessagesToChildForkRuntimeMessages(
+  compactedMessages: readonly ProviderModelMessage[],
+): AgentRuntimeMessage[] {
+  return convertProviderMessagesToAgentRuntimeMessages(compactedMessages).map((message) => ({
+    ...message,
+    parts: message.parts.map((part) => {
+      if (part.type !== "tool-call") {
+        return part;
+      }
+
+      return {
+        ...part,
+        type: `tool-${part.toolName}`,
+      };
+    }),
+  }));
+}
+
+export function prepareHostedChildForkRuntimeStepMessages(
+  input: PrepareHostedChildForkRuntimeStepMessagesInput,
+): HostedChildForkRuntimeStepMessages {
+  const currentInstructions = input.buildInstructions();
+  const compactedMessages = compactForStep(
+    convertAgentRuntimeMessagesToProviderMessages(input.messages),
+    estimateOverhead(currentInstructions, input.forkToolNames.length),
+  );
+  const resolvedSystem = input.resolveSystem?.({
+    system: currentInstructions,
+    compactedMessages,
+  });
+
+  return {
+    messages: convertCompactedProviderMessagesToChildForkRuntimeMessages(compactedMessages),
+    system: typeof resolvedSystem === "string" ? resolvedSystem : currentInstructions,
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -834,6 +834,13 @@ export {
   toMirroredHostedStreamPart,
 } from "./hosted-child-mirror.ts";
 export {
+  convertCompactedProviderMessagesToChildForkRuntimeMessages,
+  type HostedChildForkRuntimeStepMessages,
+  type HostedChildForkRuntimeStepSystemResolver,
+  prepareHostedChildForkRuntimeStepMessages,
+  type PrepareHostedChildForkRuntimeStepMessagesInput,
+} from "./hosted-child-fork-step-message-preparation.ts";
+export {
   type HostedChildRunStatusMonitor,
   type StartedHostedChildForkRuntime,
   startHostedChildForkRuntimeWithHostTools,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.397";
+export const VERSION = "0.1.398";


### PR DESCRIPTION
## Summary\n- add a reusable hosted child fork step message preparation helper\n- centralize provider-message compaction and child fork runtime tool-call part normalization\n- bump package version to 0.1.398\n\n## Verification\n- deno check src/agent/hosted-child-fork-step-message-preparation.ts src/agent/hosted-child-fork-step-message-preparation.test.ts src/agent/index.ts\n- deno test --no-check --allow-all src/agent/hosted-child-fork-step-message-preparation.test.ts\n- deno task verify:quick\n- pre-push checks: 1690 passed, 0 failed