### PR TITLE
Align hosted child fork step message types

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.398",
+  "version": "0.1.399",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-fork-step-message-preparation.ts
+++ b/src/agent/hosted-child-fork-step-message-preparation.ts
@@ -1,10 +1,11 @@
 import { compactForStep, estimateOverhead } from "../chat/message-prep.ts";
 import type { ProviderModelMessage } from "../chat/types.ts";
 import {
-  type AgentRuntimeMessage,
+  type AgentRuntimeMessagePart,
   convertAgentRuntimeMessagesToProviderMessages,
   convertProviderMessagesToAgentRuntimeMessages,
 } from "./agent-runtime-message-adapter.ts";
+import type { Message as AgentMessage, MessagePart } from "./schemas/index.ts";
 
 export type HostedChildForkRuntimeStepSystemResolver = (input: {
   system: string;
@@ -12,32 +13,52 @@ export type HostedChildForkRuntimeStepSystemResolver = (input: {
 }) => string | null | undefined;
 
 export type PrepareHostedChildForkRuntimeStepMessagesInput = {
-  messages: AgentRuntimeMessage[];
+  messages: AgentMessage[];
   buildInstructions: () => string;
   forkToolNames: readonly string[];
   resolveSystem?: HostedChildForkRuntimeStepSystemResolver;
 };
 
 export type HostedChildForkRuntimeStepMessages = {
-  messages: AgentRuntimeMessage[];
+  messages: AgentMessage[];
   system: string;
 };
 
+function convertAgentRuntimePartToChildForkMessagePart(
+  part: AgentRuntimeMessagePart,
+): MessagePart {
+  if ("text" in part) {
+    return {
+      type: "text",
+      text: part.text,
+    };
+  }
+
+  if ("result" in part) {
+    return {
+      type: "tool-result",
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      result: part.result,
+    };
+  }
+
+  return {
+    type: `tool-${part.toolName}`,
+    toolCallId: part.toolCallId,
+    toolName: part.toolName,
+    args: part.args,
+  };
+}
+
 export function convertCompactedProviderMessagesToChildForkRuntimeMessages(
   compactedMessages: readonly ProviderModelMessage[],
-): AgentRuntimeMessage[] {
+): AgentMessage[] {
   return convertProviderMessagesToAgentRuntimeMessages(compactedMessages).map((message) => ({
-    ...message,
-    parts: message.parts.map((part) => {
-      if (part.type !== "tool-call") {
-        return part;
-      }
-
-      return {
-        ...part,
-        type: `tool-${part.toolName}`,
-      };
-    }),
+    id: message.id,
+    role: message.role,
+    parts: message.parts.map(convertAgentRuntimePartToChildForkMessagePart),
+    timestamp: message.timestamp,
   }));
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.398";
+export const VERSION = "0.1.399";


### PR DESCRIPTION
## Summary\n- align hosted child fork step message preparation with the public fork runtime message contract\n- keep provider compaction internal while returning public agent messages\n- bump package version to 0.1.399\n\n## Verification\n- deno check src/agent/hosted-child-fork-step-message-preparation.ts src/agent/hosted-child-fork-step-message-preparation.test.ts src/agent/index.ts\n- deno test --no-check --allow-all src/agent/hosted-child-fork-step-message-preparation.test.ts\n- deno task verify:quick\n- pre-push checks: 1690 passed, 0 failed