### PR TITLE
Add worker command to CLI help registry

### DIFF
--- a/cli/help/command-definitions.ts
+++ b/cli/help/command-definitions.ts
@@ -37,6 +37,7 @@ import { mcpHelp } from "../commands/mcp/command-help.ts";
 import { issuesHelp } from "../commands/issues/command-help.ts";
 import { startHelp } from "../commands/start/command-help.ts";
 import { taskHelp } from "../commands/task/command-help.ts";
+import { workerHelp } from "../commands/worker/command-help.ts";
 import { workflowHelp } from "../commands/workflow/command-help.ts";
 import { schemaHelp } from "../commands/schema/command-help.ts";
 import { testHelp } from "../commands/test/command-help.ts";
@@ -82,6 +83,7 @@ export const COMMANDS: CommandRegistry = {
   issues: issuesHelp,
   start: startHelp,
   task: taskHelp,
+  worker: workerHelp,
   workflow: workflowHelp,
   schema: schemaHelp,
   test: testHelp,


### PR DESCRIPTION
## Summary
- `veryfront worker --help` was showing "Unknown command: worker" because the worker command's help definition was never registered in `command-definitions.ts`
- Added the `workerHelp` import and registry entry — the handler and `command-help.ts` already existed

## Test plan
- [x] Run `veryfront worker --help` — should display worker options (redis-url, concurrency, poll-interval, etc.)
- [x] Run `veryfront --help` — worker should appear in the command list
- [x] Existing tests pass (verified via pre-push hook)