### PR TITLE
Resolve preview alias in CLI help lookup

### DIFF
--- a/cli/help/command-help.ts
+++ b/cli/help/command-help.ts
@@ -11,8 +11,14 @@ import { getCommandTips } from "./tips.ts";
 import { showMainHelp } from "./main-help.ts";
 import { error, muted } from "../ui/colors.ts";
 
+const COMMAND_ALIASES: Record<string, string> = {
+  preview: "serve",
+  g: "generate",
+};
+
 export function showCommandHelp(command: string): void {
-  const cmd = COMMANDS[command];
+  const resolved = COMMAND_ALIASES[command] ?? command;
+  const cmd = COMMANDS[resolved];
 
   if (!cmd) {
     console.log();


### PR DESCRIPTION
## Summary
- `veryfront preview --help` was showing "Unknown command: preview" because `showCommandHelp()` did a direct lookup without resolving aliases
- Added a `COMMAND_ALIASES` map that resolves `preview` → `serve` (and `g` → `generate`) before the COMMANDS registry lookup

## Test plan
- [x] Run `veryfront preview --help` — should display serve command help
- [x] Run `veryfront serve --help` — should still work as before
- [x] Existing tests pass (verified via pre-push hook)