### PR TITLE
Resolve g alias in CLI help lookup

### DIFF
--- a/cli/help/command-help.ts
+++ b/cli/help/command-help.ts
@@ -11,8 +11,14 @@ import { getCommandTips } from "./tips.ts";
 import { showMainHelp } from "./main-help.ts";
 import { error, muted } from "../ui/colors.ts";
 
+const COMMAND_ALIASES: Record<string, string> = {
+  preview: "serve",
+  g: "generate",
+};
+
 export function showCommandHelp(command: string): void {
-  const cmd = COMMANDS[command];
+  const resolved = COMMAND_ALIASES[command] ?? command;
+  const cmd = COMMANDS[resolved];
 
   if (!cmd) {
     console.log();


### PR DESCRIPTION
## Summary
- `veryfront g --help` was showing "Unknown command: g" because `showCommandHelp()` did a direct lookup without resolving aliases
- Added a `COMMAND_ALIASES` map that resolves `g` → `generate` (and `preview` → `serve`) before the COMMANDS registry lookup

## Test plan
- [x] Run `veryfront g --help` — should display generate command help
- [x] Run `veryfront generate --help` — should still work as before
- [x] Existing tests pass (verified via pre-push hook)