### PR TITLE
Add hosted durable child fork execution helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.399",
+  "version": "0.1.400",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-durable-child-fork-execution.test.ts
+++ b/src/agent/hosted-durable-child-fork-execution.test.ts
@@ -1,0 +1,276 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import type { ChildRunExecutionResult } from "./child-run-execution-snapshot.ts";
+import {
+  executeHostedDurableChildFork,
+  type HostedDurableChildSetupFailure,
+  type HostedDurableChildSuccess,
+} from "./hosted-durable-child-fork-execution.ts";
+import type { InvokeAgentChildRunProgressEvent } from "./invoke-agent-child-runs.ts";
+
+const API_URL = "https://api.example.com";
+const AUTH_TOKEN = "token-123";
+const PARENT_CONVERSATION_ID = "11111111-1111-4111-a111-111111111111";
+const CHILD_CONVERSATION_ID = "22222222-2222-4222-a222-222222222222";
+const PARENT_MESSAGE_ID = "33333333-3333-4333-a333-333333333333";
+const CHILD_MESSAGE_ID = "44444444-4444-4444-8444-444444444444";
+const PROJECT_ID = "55555555-5555-4555-8555-555555555555";
+const BRANCH_ID = "66666666-6666-4666-8666-666666666666";
+const originalFetch = globalThis.fetch;
+
+type DurableChildResult =
+  | { status: "missing_context"; message: string }
+  | { status: "setup_failed"; failure: HostedDurableChildSetupFailure }
+  | { status: "completed"; success: HostedDurableChildSuccess<ChildRunExecutionResult> };
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function acceptedRunResponse(run: unknown): Response {
+  return jsonResponse({ accepted: true, run }, 202);
+}
+
+function stubFetchWithRecorder(
+  handler: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> | Response,
+): { requests: { url: string; body: unknown }[] } {
+  const requests: { url: string; body: unknown }[] = [];
+  globalThis.fetch = async (input, init) => {
+    requests.push({
+      url: String(input),
+      body: getRequestBody(init),
+    });
+    return handler(input, init);
+  };
+  return { requests };
+}
+
+function getRequestBody(init: RequestInit | undefined): unknown {
+  if (!init || !("body" in init) || !init.body) {
+    return null;
+  }
+
+  return JSON.parse(String(init.body));
+}
+
+function getRecordedRequest(
+  requests: { url: string; body: unknown }[],
+  index: number,
+): { url: string; body: unknown } {
+  const request = requests[index];
+  if (!request) {
+    throw new Error(`Missing request at index ${index}`);
+  }
+  return request;
+}
+
+function getPublicId(value: unknown): string {
+  if (
+    !value || typeof value !== "object" || !("public_id" in value) ||
+    typeof value.public_id !== "string"
+  ) {
+    throw new Error("Missing string property public_id");
+  }
+
+  return value.public_id;
+}
+
+function baseSuccessResult(): ChildRunExecutionResult {
+  return {
+    success: true,
+    description: "Inspect logs",
+    summary: { text: "Found logs" },
+    steps: 2,
+    toolCalls: [],
+    toolResults: [],
+    usage: { inputTokens: 3, outputTokens: 4, totalTokens: 7 },
+    durationMs: 12,
+  };
+}
+
+describe("agent/hosted-durable-child-fork-execution", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns a host-shaped context-unavailable result without bootstrapping", async () => {
+    const result = await executeHostedDurableChildFork<DurableChildResult, ChildRunExecutionResult>(
+      {
+        authToken: AUTH_TOKEN,
+        apiUrl: API_URL,
+        forkInput: { description: "Inspect logs", prompt: "Find logs" },
+        executionOptions: { toolCallId: "tool-call-1" },
+        childAgentId: "invoke-agent-child",
+        getProjectId: () => PROJECT_ID,
+        defaultModel: "opus",
+        resolveModelId: (model) => `resolved-${model}`,
+        resolveProvider: () => "anthropic",
+        contextUnavailableMessage: "missing context",
+        setupFailedCode: "SETUP_FAILED",
+        executionFailedCode: "INVOKE_AGENT_FAILED",
+        executeLocal: () => baseSuccessResult(),
+        getExecutionSnapshot: () => null,
+        buildContextUnavailableResult: (message) => ({ status: "missing_context", message }),
+        buildSetupFailureResult: (failure) => ({ status: "setup_failed", failure }),
+        buildTerminalFailureResult: () => ({ status: "missing_context", message: "unexpected" }),
+        buildSuccessResult: (success) => ({ status: "completed", success }),
+      },
+    );
+
+    assertEquals(result, { status: "missing_context", message: "missing context" });
+  });
+
+  it("bootstraps, runs lifecycle progress, and returns host-shaped success", async () => {
+    let projectId = PROJECT_ID;
+    const lifecycleStatuses: string[] = [];
+    const bootstrapCalls: string[] = [];
+    const { requests } = stubFetchWithRecorder((_input, _init) => {
+      const requestCount = requests.length;
+      if (requestCount === 1) {
+        return jsonResponse({ id: PARENT_CONVERSATION_ID, project_id: projectId }, 200);
+      }
+      if (requestCount === 2) {
+        return jsonResponse({ id: CHILD_CONVERSATION_ID, project_id: projectId }, 200);
+      }
+      if (requestCount === 3) {
+        return jsonResponse({ id: CHILD_MESSAGE_ID }, 200);
+      }
+      if (requestCount === 4) {
+        return acceptedRunResponse({ run_id: "run_child_1" });
+      }
+      if (requestCount === 5) {
+        return jsonResponse(
+          {
+            run_id: "run_child_1",
+            conversation_id: CHILD_CONVERSATION_ID,
+            message_id: CHILD_MESSAGE_ID,
+            latest_event_id: 7,
+            latest_external_event_sequence: 3,
+            status: "running",
+          },
+          200,
+        );
+      }
+      if (requestCount === 6) {
+        return jsonResponse(
+          {
+            completed: true,
+            run: { run_id: "run_child_1", status: "completed" },
+          },
+          200,
+        );
+      }
+
+      throw new Error("Unexpected fetch call");
+    });
+
+    const result = await executeHostedDurableChildFork<DurableChildResult, ChildRunExecutionResult>(
+      {
+        authToken: AUTH_TOKEN,
+        apiUrl: API_URL,
+        forkInput: {
+          description: "Inspect logs",
+          prompt: "Find logs",
+          project_id: "77777777-7777-4777-8777-777777777777",
+        },
+        executionOptions: { toolCallId: "tool-call-1" },
+        childAgentId: "invoke-agent-child",
+        runProjectId: projectId,
+        parentConversationId: PARENT_CONVERSATION_ID,
+        parentRunId: "run_parent_1",
+        parentMessageId: PARENT_MESSAGE_ID,
+        getProjectId: () => projectId,
+        getBranchId: () => BRANCH_ID,
+        getContextModel: () => "sonnet",
+        defaultModel: "opus",
+        resolveModelId: (model) => `resolved-${model}`,
+        resolveProvider: (model) => `provider-${model}`,
+        onRequestedProjectId: (requestedProjectId) => {
+          projectId = requestedProjectId;
+        },
+        publishParentRunEvents: (events: InvokeAgentChildRunProgressEvent[]) => {
+          for (const event of events) {
+            if (event.type === "CUSTOM") {
+              lifecycleStatuses.push(event.value.status);
+            }
+          }
+        },
+        contextUnavailableMessage: "missing context",
+        setupFailedCode: "SETUP_FAILED",
+        executionFailedCode: "INVOKE_AGENT_FAILED",
+        executeLocal: () => baseSuccessResult(),
+        getExecutionSnapshot: () => null,
+        buildContextUnavailableResult: (message) => ({ status: "missing_context", message }),
+        buildSetupFailureResult: (failure) => ({ status: "setup_failed", failure }),
+        buildTerminalFailureResult: () => ({ status: "missing_context", message: "unexpected" }),
+        buildSuccessResult: (success) => ({ status: "completed", success }),
+        bootstrap: {
+          runBootstrap: async (operation) => {
+            bootstrapCalls.push("wrapped");
+            return operation();
+          },
+          onBootstrapStart: (bootstrapContext) => {
+            bootstrapCalls.push(`start:${bootstrapContext.resolvedModel}`);
+          },
+          onBootstrapComplete: (bootstrapContext) => {
+            bootstrapCalls.push(`complete:${bootstrapContext.identifiers.childRunId}`);
+          },
+        },
+      },
+    );
+
+    if (result.status !== "completed") {
+      throw new Error("Expected completed result");
+    }
+
+    assertEquals(projectId, "77777777-7777-4777-8777-777777777777");
+    assertEquals(bootstrapCalls, ["wrapped", "start:resolved-sonnet", "complete:run_child_1"]);
+    assertEquals(lifecycleStatuses, ["pending", "running", "completed"]);
+    assertEquals(result.success.identifiers, {
+      childConversationId: CHILD_CONVERSATION_ID,
+      childRunId: "run_child_1",
+      childMessageId: CHILD_MESSAGE_ID,
+      latestEventId: 7,
+      latestExternalEventSequence: 3,
+    });
+    assertEquals(result.success.targets, {
+      sourceTargetKind: "preview_branch",
+      runtimeTargetKind: "preview_branch",
+      targetBranchId: BRANCH_ID,
+    });
+    assertEquals(result.success.snapshot.success, true);
+    const createRunBody = getRecordedRequest(requests, 3).body;
+    assertEquals(createRunBody, {
+      kind: "agent",
+      owner: {
+        kind: "conversation",
+        id: CHILD_CONVERSATION_ID,
+      },
+      public_id: getPublicId(createRunBody),
+      request: {
+        mode: "default_chat",
+        agent_id: "invoke-agent-child",
+        initial_status: "running",
+        source_target_kind: "preview_branch",
+        runtime_target_kind: "preview_branch",
+        source_target_branch_id: BRANCH_ID,
+        runtime_target_branch_id: BRANCH_ID,
+      },
+    });
+    assertEquals(getRecordedRequest(requests, 5).body, {
+      status: "completed",
+      metadata: {
+        provider: "provider-resolved-sonnet",
+        model: "resolved-sonnet",
+        inputTokens: 3,
+        outputTokens: 4,
+        finishReason: "stop",
+      },
+      terminal_error_code: null,
+      terminal_error_message: null,
+    });
+  });
+});

--- a/src/agent/hosted-durable-child-fork-execution.ts
+++ b/src/agent/hosted-durable-child-fork-execution.ts
@@ -1,0 +1,331 @@
+import type {
+  ChildRunExecutionResult,
+  ChildRunExecutionSnapshot,
+} from "./child-run-execution-snapshot.ts";
+import { type ConversationRunTargets, resolveConversationRunTargets } from "./durable.ts";
+import { createConversationChildLifecycleAdapter } from "./conversation-hosted-lifecycle.ts";
+import type { InvokeAgentChildRunProgressEvent } from "./invoke-agent-child-runs.ts";
+import { bootstrapHostedChildRun } from "./hosted-child-bootstrap.ts";
+import {
+  runHostedChildExecutionLifecycle,
+  shouldSkipHostedChildTerminalPersistence,
+} from "./hosted-child-lifecycle.ts";
+import {
+  type HostedChildRunIdentifiers,
+  HostedChildTerminalStateError,
+  type HostedChildTerminalStatus,
+} from "./hosted-child-status.ts";
+import type { HostedChildForkToolInput } from "./hosted-child-tool-input.ts";
+import { throwIfChildRunAborted } from "./child-run-execution-support.ts";
+
+export type HostedDurableChildExecutionOptions = {
+  durableChildRun?: HostedChildRunIdentifiers;
+};
+
+export type HostedDurableChildSuccess<TLocalResult extends ChildRunExecutionResult> = {
+  result: TLocalResult;
+  snapshot: ChildRunExecutionSnapshot;
+  identifiers: HostedChildRunIdentifiers;
+  targets: ConversationRunTargets;
+};
+
+export type HostedDurableChildTerminalFailure = {
+  status: HostedChildTerminalStatus;
+  identifiers: HostedChildRunIdentifiers;
+  targets: ConversationRunTargets;
+  terminalErrorCode: string;
+  terminalErrorMessage: string;
+};
+
+export type HostedDurableChildSetupFailure = {
+  targets: ConversationRunTargets;
+  childConversationId: string | null;
+  childRunId: string | null;
+  childMessageId: string | null;
+  terminalErrorCode: string;
+  terminalErrorMessage: string;
+};
+
+export type HostedDurableChildBootstrapContext = {
+  parentConversationId: string;
+  parentRunId: string;
+  parentMessageId: string;
+  targets: ConversationRunTargets;
+  resolvedModel: string;
+  provider: string;
+};
+
+export type HostedDurableChildBootstrapCallbacks = {
+  runBootstrap?: <T>(operation: () => Promise<T>) => Promise<T>;
+  onBootstrapStart?: (input: HostedDurableChildBootstrapContext) => Promise<void> | void;
+  onBootstrapComplete?: (
+    input: HostedDurableChildBootstrapContext & { identifiers: HostedChildRunIdentifiers },
+  ) => Promise<void> | void;
+  onBootstrapError?: (input: {
+    error: unknown;
+    parentConversationId: string;
+    toolCallId: string;
+  }) => Promise<void> | void;
+};
+
+export type ExecuteHostedDurableChildForkInput<
+  TResult,
+  TLocalResult extends ChildRunExecutionResult,
+> = {
+  authToken: string;
+  apiUrl: string;
+  forkInput: HostedChildForkToolInput;
+  executionOptions: {
+    toolCallId: string;
+    abortSignal?: AbortSignal;
+  };
+  childAgentId: string;
+  runProjectId?: string | null;
+  parentConversationId?: string;
+  parentRunId?: string;
+  parentMessageId?: string;
+  getProjectId: () => string | null | undefined;
+  getBranchId?: () => string | null | undefined;
+  getContextModel?: () => string | undefined;
+  defaultModel: string;
+  resolveModelId: (model: string) => string;
+  resolveProvider: (modelId: string) => string;
+  onRequestedProjectId?: (projectId: string) => Promise<void> | void;
+  publishParentRunEvents?: (events: InvokeAgentChildRunProgressEvent[]) => Promise<void> | void;
+  contextUnavailableMessage: string;
+  setupFailedCode: string;
+  executionFailedCode: string;
+  executeLocal: (
+    options?: HostedDurableChildExecutionOptions,
+  ) => Promise<TLocalResult> | TLocalResult;
+  getExecutionSnapshot: () => ChildRunExecutionSnapshot | null;
+  buildContextUnavailableResult: (message: string) => TResult;
+  buildSetupFailureResult: (failure: HostedDurableChildSetupFailure) => TResult;
+  buildTerminalFailureResult: (failure: HostedDurableChildTerminalFailure) => TResult;
+  buildSuccessResult: (success: HostedDurableChildSuccess<TLocalResult>) => TResult;
+  onLifecycleError?: (error: unknown) => Promise<void> | void;
+  onLifecycleFinalized?: (input: {
+    identifiers: HostedChildRunIdentifiers;
+    status: "completed";
+  }) => Promise<void> | void;
+  bootstrap?: HostedDurableChildBootstrapCallbacks;
+};
+
+function getBranchId(input: {
+  getBranchId?: () => string | null | undefined;
+}): string | null | undefined {
+  return input.getBranchId?.();
+}
+
+function resolveContextModel(input: {
+  forkInput: HostedChildForkToolInput;
+  getContextModel?: () => string | undefined;
+  defaultModel: string;
+}): string {
+  return input.forkInput.model || input.getContextModel?.() || input.defaultModel;
+}
+
+async function defaultRunBootstrap<T>(operation: () => Promise<T>): Promise<T> {
+  return operation();
+}
+
+async function prepareHostedDurableChildBootstrapContext<
+  TResult,
+  TLocalResult extends ChildRunExecutionResult,
+>(
+  input: ExecuteHostedDurableChildForkInput<TResult, TLocalResult> & {
+    parentConversationId: string;
+    parentRunId: string;
+    parentMessageId: string;
+  },
+): Promise<HostedDurableChildBootstrapContext> {
+  if (input.forkInput.project_id) {
+    await input.onRequestedProjectId?.(input.forkInput.project_id);
+  }
+
+  const targets = resolveConversationRunTargets({
+    projectId: input.getProjectId() ?? null,
+    branchId: getBranchId(input) ?? null,
+  });
+  const resolvedModel = input.resolveModelId(resolveContextModel(input));
+
+  return {
+    parentConversationId: input.parentConversationId,
+    parentRunId: input.parentRunId,
+    parentMessageId: input.parentMessageId,
+    targets,
+    resolvedModel,
+    provider: input.resolveProvider(resolvedModel),
+  };
+}
+
+async function bootstrapHostedDurableChildFork<
+  TResult,
+  TLocalResult extends ChildRunExecutionResult,
+>(
+  input: ExecuteHostedDurableChildForkInput<TResult, TLocalResult> & {
+    bootstrapContext: HostedDurableChildBootstrapContext;
+  },
+): Promise<HostedChildRunIdentifiers> {
+  const runBootstrap = input.bootstrap?.runBootstrap ?? defaultRunBootstrap;
+
+  return runBootstrap(async () => {
+    await input.bootstrap?.onBootstrapStart?.(input.bootstrapContext);
+
+    const run = await bootstrapHostedChildRun({
+      authToken: input.authToken,
+      apiUrl: input.apiUrl,
+      ensureProjectId: input.getProjectId() ?? undefined,
+      runProjectId: input.runProjectId !== undefined ? input.runProjectId : undefined,
+      parentConversationId: input.bootstrapContext.parentConversationId,
+      parentRunId: input.bootstrapContext.parentRunId,
+      parentMessageId: input.bootstrapContext.parentMessageId,
+      spawnedFromToolCallId: input.executionOptions.toolCallId,
+      description: input.forkInput.description,
+      prompt: input.forkInput.prompt,
+      agentId: input.childAgentId,
+      branchId: getBranchId(input),
+    });
+    const identifiers: HostedChildRunIdentifiers = {
+      childConversationId: run.childConversationId,
+      childRunId: run.childRunId,
+      childMessageId: run.childMessageId,
+      latestEventId: run.latestEventId,
+      latestExternalEventSequence: run.latestExternalEventSequence,
+    };
+
+    await input.bootstrap?.onBootstrapComplete?.({
+      ...input.bootstrapContext,
+      identifiers,
+    });
+
+    return identifiers;
+  });
+}
+
+async function executeHostedDurableChildLifecycle<
+  TResult,
+  TLocalResult extends ChildRunExecutionResult,
+>(
+  input: ExecuteHostedDurableChildForkInput<TResult, TLocalResult> & {
+    bootstrapContext: HostedDurableChildBootstrapContext;
+    identifiers: HostedChildRunIdentifiers;
+  },
+): Promise<TResult> {
+  const { bootstrapContext, identifiers } = input;
+  const { targets } = bootstrapContext;
+  const lifecycleAdapter = createConversationChildLifecycleAdapter({
+    authToken: input.authToken,
+    apiUrl: input.apiUrl,
+    parentConversationId: bootstrapContext.parentConversationId,
+    parentRunId: bootstrapContext.parentRunId,
+    projectId: input.getProjectId(),
+    publishParentRunEvents: input.publishParentRunEvents,
+    progress: {
+      toolCallId: input.executionOptions.toolCallId,
+      childAgentId: input.childAgentId,
+      childConversationId: identifiers.childConversationId,
+      childRunId: identifiers.childRunId,
+      childMessageId: identifiers.childMessageId,
+      description: input.forkInput.description,
+      sourceTargetKind: targets.sourceTargetKind,
+      runtimeTargetKind: targets.runtimeTargetKind,
+      targetBranchId: targets.targetBranchId,
+    },
+    model: bootstrapContext.resolvedModel,
+    provider: bootstrapContext.provider,
+  });
+
+  const lifecycleResult = await runHostedChildExecutionLifecycle({
+    adapter: lifecycleAdapter,
+    executionFailedCode: input.executionFailedCode,
+    abortSignal: input.executionOptions.abortSignal,
+    execute: () =>
+      input.executeLocal({
+        durableChildRun: identifiers,
+      }),
+    getExecutionSnapshot: input.getExecutionSnapshot,
+    onLifecycleError: input.onLifecycleError,
+    skipTerminalPersistence: shouldSkipHostedChildTerminalPersistence,
+  });
+
+  if (lifecycleResult.status !== "completed") {
+    if (
+      lifecycleResult.status === "cancelled" &&
+      !(lifecycleResult.error instanceof HostedChildTerminalStateError)
+    ) {
+      throw lifecycleResult.error;
+    }
+
+    return input.buildTerminalFailureResult({
+      status: lifecycleResult.terminalState.status,
+      identifiers,
+      targets,
+      terminalErrorCode: lifecycleResult.terminalState.terminalErrorCode ??
+        input.executionFailedCode,
+      terminalErrorMessage: lifecycleResult.terminalState.terminalErrorMessage ?? "Unknown error",
+    });
+  }
+
+  await input.onLifecycleFinalized?.({
+    identifiers,
+    status: lifecycleResult.status,
+  });
+
+  return input.buildSuccessResult({
+    result: lifecycleResult.result,
+    snapshot: lifecycleResult.snapshot,
+    identifiers,
+    targets,
+  });
+}
+
+export async function executeHostedDurableChildFork<
+  TResult,
+  TLocalResult extends ChildRunExecutionResult,
+>(
+  input: ExecuteHostedDurableChildForkInput<TResult, TLocalResult>,
+): Promise<TResult> {
+  throwIfChildRunAborted(input.executionOptions.abortSignal);
+
+  if (!input.parentConversationId || !input.parentRunId || !input.parentMessageId) {
+    return input.buildContextUnavailableResult(input.contextUnavailableMessage);
+  }
+
+  const bootstrapContext = await prepareHostedDurableChildBootstrapContext({
+    ...input,
+    parentConversationId: input.parentConversationId,
+    parentRunId: input.parentRunId,
+    parentMessageId: input.parentMessageId,
+  });
+  const { targets } = bootstrapContext;
+  let identifiers: HostedChildRunIdentifiers;
+
+  try {
+    identifiers = await bootstrapHostedDurableChildFork({
+      ...input,
+      bootstrapContext,
+    });
+  } catch (error) {
+    await input.bootstrap?.onBootstrapError?.({
+      error,
+      parentConversationId: bootstrapContext.parentConversationId,
+      toolCallId: input.executionOptions.toolCallId,
+    });
+
+    return input.buildSetupFailureResult({
+      targets,
+      childConversationId: null,
+      childRunId: null,
+      childMessageId: null,
+      terminalErrorCode: input.setupFailedCode,
+      terminalErrorMessage: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  return executeHostedDurableChildLifecycle({
+    ...input,
+    bootstrapContext,
+    identifiers,
+  });
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -467,6 +467,16 @@ export {
   type PersistConversationUserMessageFailure,
 } from "./conversation-bootstrap.ts";
 export {
+  executeHostedDurableChildFork,
+  type ExecuteHostedDurableChildForkInput,
+  type HostedDurableChildBootstrapCallbacks,
+  type HostedDurableChildBootstrapContext,
+  type HostedDurableChildExecutionOptions,
+  type HostedDurableChildSetupFailure,
+  type HostedDurableChildSuccess,
+  type HostedDurableChildTerminalFailure,
+} from "./hosted-durable-child-fork-execution.ts";
+export {
   bootstrapHostedChildRun,
   type BootstrapHostedChildRunInput,
   type BootstrapHostedChildRunResult,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.399";
+export const VERSION = "0.1.400";


### PR DESCRIPTION
## Summary\n- add a reusable hosted durable child fork execution helper\n- expose host callbacks for bootstrap, lifecycle progress, and host-shaped result mapping\n- cover missing-context and successful lifecycle flows with Deno tests\n- bump package version to 0.1.400 for CI/CD publication\n\n## Verification\n- deno check src/agent/hosted-durable-child-fork-execution.ts src/agent/hosted-durable-child-fork-execution.test.ts src/agent/index.ts\n- deno test --no-check --allow-all src/agent/hosted-durable-child-fork-execution.test.ts\n- deno task verify:quick