### PR TITLE
Allow hosted durable child fork runtime overrides

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.400",
+  "version": "0.1.401",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-durable-child-fork-execution.ts
+++ b/src/agent/hosted-durable-child-fork-execution.ts
@@ -68,6 +68,13 @@ export type HostedDurableChildBootstrapCallbacks = {
   }) => Promise<void> | void;
 };
 
+export type HostedDurableChildRuntimeDependencies = {
+  bootstrapChildRun?: typeof bootstrapHostedChildRun;
+  createLifecycleAdapter?: typeof createConversationChildLifecycleAdapter;
+  runLifecycle?: typeof runHostedChildExecutionLifecycle;
+  shouldSkipTerminalPersistence?: typeof shouldSkipHostedChildTerminalPersistence;
+};
+
 export type ExecuteHostedDurableChildForkInput<
   TResult,
   TLocalResult extends ChildRunExecutionResult,
@@ -109,6 +116,7 @@ export type ExecuteHostedDurableChildForkInput<
     status: "completed";
   }) => Promise<void> | void;
   bootstrap?: HostedDurableChildBootstrapCallbacks;
+  runtime?: HostedDurableChildRuntimeDependencies;
 };
 
 function getBranchId(input: {
@@ -172,7 +180,8 @@ async function bootstrapHostedDurableChildFork<
   return runBootstrap(async () => {
     await input.bootstrap?.onBootstrapStart?.(input.bootstrapContext);
 
-    const run = await bootstrapHostedChildRun({
+    const bootstrapChildRun = input.runtime?.bootstrapChildRun ?? bootstrapHostedChildRun;
+    const run = await bootstrapChildRun({
       authToken: input.authToken,
       apiUrl: input.apiUrl,
       ensureProjectId: input.getProjectId() ?? undefined,
@@ -214,7 +223,9 @@ async function executeHostedDurableChildLifecycle<
 ): Promise<TResult> {
   const { bootstrapContext, identifiers } = input;
   const { targets } = bootstrapContext;
-  const lifecycleAdapter = createConversationChildLifecycleAdapter({
+  const createLifecycleAdapter = input.runtime?.createLifecycleAdapter ??
+    createConversationChildLifecycleAdapter;
+  const lifecycleAdapter = createLifecycleAdapter({
     authToken: input.authToken,
     apiUrl: input.apiUrl,
     parentConversationId: bootstrapContext.parentConversationId,
@@ -236,7 +247,10 @@ async function executeHostedDurableChildLifecycle<
     provider: bootstrapContext.provider,
   });
 
-  const lifecycleResult = await runHostedChildExecutionLifecycle({
+  const runLifecycle = input.runtime?.runLifecycle ?? runHostedChildExecutionLifecycle;
+  const skipTerminalPersistence = input.runtime?.shouldSkipTerminalPersistence ??
+    shouldSkipHostedChildTerminalPersistence;
+  const lifecycleResult = await runLifecycle({
     adapter: lifecycleAdapter,
     executionFailedCode: input.executionFailedCode,
     abortSignal: input.executionOptions.abortSignal,
@@ -246,7 +260,7 @@ async function executeHostedDurableChildLifecycle<
       }),
     getExecutionSnapshot: input.getExecutionSnapshot,
     onLifecycleError: input.onLifecycleError,
-    skipTerminalPersistence: shouldSkipHostedChildTerminalPersistence,
+    skipTerminalPersistence,
   });
 
   if (lifecycleResult.status !== "completed") {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -472,6 +472,7 @@ export {
   type HostedDurableChildBootstrapCallbacks,
   type HostedDurableChildBootstrapContext,
   type HostedDurableChildExecutionOptions,
+  type HostedDurableChildRuntimeDependencies,
   type HostedDurableChildSetupFailure,
   type HostedDurableChildSuccess,
   type HostedDurableChildTerminalFailure,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.400";
+export const VERSION = "0.1.401";


### PR DESCRIPTION
## Summary\n- allow hosted durable child fork execution to accept optional runtime dependency overrides\n- keep default hosted bootstrap, lifecycle adapter, lifecycle runner, and terminal persistence behavior unchanged\n- export the runtime dependency type for hosts that wire custom adapters\n- bump package version to 0.1.401 for CI/CD publication\n\n## Verification\n- deno check src/agent/hosted-durable-child-fork-execution.ts src/agent/hosted-durable-child-fork-execution.test.ts src/agent/index.ts\n- deno test --no-check --allow-all src/agent/hosted-durable-child-fork-execution.test.ts\n- deno task verify:quick