### PR TITLE
Add studio.veryfront.com regression test for unmapped domain 404 (#1110)

### DIFF
--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -379,8 +379,9 @@ describe("Proxy Handler", () => {
         return createNotFoundResponse();
       });
 
+      let handler: ReturnType<typeof createHandler> | undefined;
       try {
-        const handler = createHandler(port);
+        handler = createHandler(port);
 
         const req = new Request("http://studio.veryfront.com/", {
           headers: { host: "studio.veryfront.com" },
@@ -394,9 +395,8 @@ describe("Proxy Handler", () => {
           ctx.error?.message,
           "No project configured for domain: studio.veryfront.com",
         );
-
-        await handler.close();
       } finally {
+        await handler?.close();
         await server.shutdown();
       }
     });

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -362,6 +362,45 @@ describe("Proxy Handler", () => {
       }
     });
 
+    // Regression: studio.veryfront.com is an infra subdomain that doesn't map to a
+    // project. The token mint returns 400 "Project not found for domain" — the proxy
+    // must return a clean 404, not a misleading 502. (#1110)
+    it("returns 404 for studio.veryfront.com when token mint rejects the domain", async () => {
+      const { server, port } = createMockServer((req: Request) => {
+        const { pathname } = new URL(req.url);
+
+        if (pathname === "/auth/token") {
+          return new Response('{"error":"Project not found for domain"}', {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        return createNotFoundResponse();
+      });
+
+      try {
+        const handler = createHandler(port);
+
+        const req = new Request("http://studio.veryfront.com/", {
+          headers: { host: "studio.veryfront.com" },
+        });
+
+        const ctx = await handler.processRequest(req);
+
+        assertEquals(ctx.projectSlug, undefined);
+        assertEquals(ctx.error?.status, 404);
+        assertEquals(
+          ctx.error?.message,
+          "No project configured for domain: studio.veryfront.com",
+        );
+
+        await handler.close();
+      } finally {
+        await server.shutdown();
+      }
+    });
+
     it("logs expected custom domain token-mint misses below error level", async () => {
       const { entries, logger } = createRecordingLogger();
       const { server, port } = createMockServer((req: Request) => {


### PR DESCRIPTION
## Summary
- Adds regression test verifying `studio.veryfront.com` returns 404 (not 502) when the token mint rejects it with "Project not found for domain"
- The core fix (mapping token-mint 400 → proxy 404 for unmapped custom domains) already existed from #1054; this closes the gap by adding the specific `studio.veryfront.com` test case requested in #1110

Closes #1110

## Test plan
- [x] New test `returns 404 for studio.veryfront.com when token mint rejects the domain` passes
- [x] All 1690 existing unit tests continue to pass
- [x] Pre-push hooks (format, lint, typecheck, tests) all green