### PR TITLE
Add conversation hosted terminal dispatch helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.402",
+  "version": "0.1.403",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/conversation-hosted-terminal.test.ts
+++ b/src/agent/conversation-hosted-terminal.test.ts
@@ -1,7 +1,13 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  type ConversationHostedTerminalRuntimeAdapter,
+  type ConversationHostedTerminalStateInput,
   createConversationHostedTerminalAdapter,
+  dispatchConversationHostedStreamErrorState,
+  dispatchConversationHostedTerminalState,
+  resolveConversationHostedStreamErrorState,
+  resolveConversationHostedTerminalState,
   toConversationHostedTerminalState,
 } from "./conversation-hosted-terminal.ts";
 
@@ -177,5 +183,129 @@ describe("agent/conversation-hosted-terminal", () => {
     } finally {
       restoreFetch();
     }
+  });
+
+  it("resolves reusable terminal states from stream conditions", () => {
+    assertEquals(
+      resolveConversationHostedTerminalState({
+        isAborted: true,
+        hasIncompleteToolParts: true,
+      }),
+      {
+        status: "cancelled",
+        terminalErrorCode: "ABORTED",
+        terminalErrorMessage: "Chat stream aborted",
+      },
+    );
+
+    assertEquals(
+      resolveConversationHostedTerminalState({
+        isAborted: false,
+        hasIncompleteToolParts: true,
+      }),
+      {
+        status: "failed",
+        terminalErrorCode: "INCOMPLETE_TOOL_CALLS",
+        terminalErrorMessage: "Assistant completed before tool execution completed",
+      },
+    );
+
+    assertEquals(
+      resolveConversationHostedTerminalState({
+        isAborted: false,
+        hasIncompleteToolParts: false,
+      }),
+      { status: "completed" },
+    );
+  });
+
+  it("resolves reusable stream error terminal states", () => {
+    assertEquals(resolveConversationHostedStreamErrorState(new Error("boom")), {
+      status: "failed",
+      terminalErrorCode: "STREAM_ERROR",
+      terminalErrorMessage: "boom",
+    });
+    assertEquals(resolveConversationHostedStreamErrorState("raw"), {
+      status: "failed",
+      terminalErrorCode: "STREAM_ERROR",
+      terminalErrorMessage: "raw",
+    });
+  });
+
+  it("dispatches reusable terminal runtime adapters", async () => {
+    const calls: string[] = [];
+    const adapter: ConversationHostedTerminalRuntimeAdapter = {
+      terminal: {
+        toTerminalState: (state: ConversationHostedTerminalStateInput) => ({
+          status: state.status,
+          ...(state.terminalErrorCode !== undefined
+            ? { terminalErrorCode: state.terminalErrorCode }
+            : {}),
+          ...(state.terminalErrorMessage !== undefined
+            ? { terminalErrorMessage: state.terminalErrorMessage }
+            : {}),
+        }),
+        finalizeRun: async (state) => {
+          calls.push(`finalize:${state.status}`);
+        },
+        cancelRun: async (state) => {
+          calls.push(`cancel:${state.status}`);
+        },
+        onTerminalState: async (state) => {
+          calls.push(`observed:${state.status}`);
+        },
+      },
+    };
+
+    await dispatchConversationHostedTerminalState(adapter, { status: "completed" });
+    await dispatchConversationHostedTerminalState(adapter, { status: "cancelled" });
+
+    assertEquals(calls, [
+      "finalize:completed",
+      "observed:completed",
+      "cancel:cancelled",
+      "observed:cancelled",
+    ]);
+  });
+
+  it("dispatches reusable stream error states", async () => {
+    const seen: unknown[] = [];
+    const adapter: ConversationHostedTerminalRuntimeAdapter = {
+      terminal: {
+        toTerminalState: (state: ConversationHostedTerminalStateInput) => ({
+          status: state.status,
+          ...(state.terminalErrorCode !== undefined
+            ? { terminalErrorCode: state.terminalErrorCode }
+            : {}),
+          ...(state.terminalErrorMessage !== undefined
+            ? { terminalErrorMessage: state.terminalErrorMessage }
+            : {}),
+        }),
+        finalizeRun: async (state) => {
+          seen.push(["finalize", state]);
+        },
+        cancelRun: async (state) => {
+          seen.push(["cancel", state]);
+        },
+        onTerminalState: async (state) => {
+          seen.push(["observed", state]);
+        },
+      },
+    };
+
+    const terminalState = await dispatchConversationHostedStreamErrorState(
+      adapter,
+      new Error("boom"),
+    );
+
+    assertEquals(terminalState, {
+      status: "failed",
+      terminalErrorCode: "STREAM_ERROR",
+      terminalErrorMessage: "boom",
+    });
+    assertEquals(seen, [
+      ["finalize", terminalState],
+      ["observed", terminalState],
+    ]);
   });
 });

--- a/src/agent/conversation-hosted-terminal.ts
+++ b/src/agent/conversation-hosted-terminal.ts
@@ -12,6 +12,92 @@ export interface ConversationHostedTerminalStateInput {
   terminalErrorMessage?: string | null;
 }
 
+export const CONVERSATION_HOSTED_STREAM_ERROR_TERMINAL_ERROR_CODE = "STREAM_ERROR";
+export const CONVERSATION_HOSTED_ABORTED_TERMINAL_ERROR_CODE = "ABORTED";
+export const CONVERSATION_HOSTED_INCOMPLETE_TOOL_CALLS_TERMINAL_ERROR_CODE =
+  "INCOMPLETE_TOOL_CALLS";
+
+const DEFAULT_CONVERSATION_HOSTED_ABORTED_TERMINAL_ERROR_MESSAGE = "Chat stream aborted";
+const DEFAULT_CONVERSATION_HOSTED_INCOMPLETE_TOOL_CALLS_TERMINAL_ERROR_MESSAGE =
+  "Assistant completed before tool execution completed";
+
+export interface ResolveConversationHostedTerminalStateInput {
+  isAborted: boolean;
+  hasIncompleteToolParts: boolean;
+  abortedTerminalErrorMessage?: string;
+  incompleteToolCallsTerminalErrorMessage?: string;
+}
+
+export type ConversationHostedTerminalStateResolution = Pick<
+  ConversationHostedTerminalStateInput,
+  "status" | "terminalErrorCode" | "terminalErrorMessage"
+>;
+
+export function resolveConversationHostedTerminalState(
+  input: ResolveConversationHostedTerminalStateInput,
+): ConversationHostedTerminalStateResolution {
+  if (input.isAborted) {
+    return {
+      status: "cancelled",
+      terminalErrorCode: CONVERSATION_HOSTED_ABORTED_TERMINAL_ERROR_CODE,
+      terminalErrorMessage: input.abortedTerminalErrorMessage ??
+        DEFAULT_CONVERSATION_HOSTED_ABORTED_TERMINAL_ERROR_MESSAGE,
+    };
+  }
+
+  if (input.hasIncompleteToolParts) {
+    return {
+      status: "failed",
+      terminalErrorCode: CONVERSATION_HOSTED_INCOMPLETE_TOOL_CALLS_TERMINAL_ERROR_CODE,
+      terminalErrorMessage: input.incompleteToolCallsTerminalErrorMessage ??
+        DEFAULT_CONVERSATION_HOSTED_INCOMPLETE_TOOL_CALLS_TERMINAL_ERROR_MESSAGE,
+    };
+  }
+
+  return { status: "completed" };
+}
+
+export function resolveConversationHostedStreamErrorState(
+  error: unknown,
+): ConversationHostedTerminalStateResolution {
+  return {
+    status: "failed",
+    terminalErrorCode: CONVERSATION_HOSTED_STREAM_ERROR_TERMINAL_ERROR_CODE,
+    terminalErrorMessage: error instanceof Error ? error.message : String(error),
+  };
+}
+
+export interface ConversationHostedTerminalRuntimeAdapter {
+  terminal: Pick<
+    ConversationHostedTerminalAdapter,
+    "toTerminalState" | "finalizeRun" | "cancelRun" | "onTerminalState"
+  >;
+}
+
+export async function dispatchConversationHostedTerminalState(
+  adapter: ConversationHostedTerminalRuntimeAdapter,
+  state: ConversationHostedTerminalStateInput,
+): Promise<HostedLifecycleTerminalState> {
+  const terminalState = adapter.terminal.toTerminalState(state);
+  if (terminalState.status === "cancelled") {
+    await adapter.terminal.cancelRun(terminalState);
+  } else {
+    await adapter.terminal.finalizeRun(terminalState);
+  }
+  await adapter.terminal.onTerminalState(terminalState);
+  return terminalState;
+}
+
+export async function dispatchConversationHostedStreamErrorState(
+  adapter: ConversationHostedTerminalRuntimeAdapter,
+  error: unknown,
+): Promise<HostedLifecycleTerminalState> {
+  return dispatchConversationHostedTerminalState(
+    adapter,
+    resolveConversationHostedStreamErrorState(error),
+  );
+}
+
 export interface CreateConversationHostedTerminalAdapterOptions {
   authToken: string;
   apiUrl: string;

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -493,10 +493,20 @@ export {
   createConversationHostedStreamLifecycleAdapter,
 } from "./conversation-hosted-lifecycle.ts";
 export {
+  CONVERSATION_HOSTED_ABORTED_TERMINAL_ERROR_CODE,
+  CONVERSATION_HOSTED_INCOMPLETE_TOOL_CALLS_TERMINAL_ERROR_CODE,
+  CONVERSATION_HOSTED_STREAM_ERROR_TERMINAL_ERROR_CODE,
   type ConversationHostedTerminalAdapter,
+  type ConversationHostedTerminalRuntimeAdapter,
   type ConversationHostedTerminalStateInput,
+  type ConversationHostedTerminalStateResolution,
   createConversationHostedTerminalAdapter,
   type CreateConversationHostedTerminalAdapterOptions,
+  dispatchConversationHostedStreamErrorState,
+  dispatchConversationHostedTerminalState,
+  resolveConversationHostedStreamErrorState,
+  resolveConversationHostedTerminalState,
+  type ResolveConversationHostedTerminalStateInput,
   toConversationHostedTerminalState,
 } from "./conversation-hosted-terminal.ts";
 export {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.402";
+export const VERSION = "0.1.403";


### PR DESCRIPTION
## Summary
- add reusable hosted terminal state resolution helpers for aborted, incomplete-tool, and stream-error terminal states
- add reusable terminal dispatch helpers for host runtime adapters
- bump package version to 0.1.403

## Verification
- deno check src/agent/conversation-hosted-terminal.ts src/agent/conversation-hosted-terminal.test.ts src/agent/index.ts
- deno test --no-check --allow-all src/utils/version.test.ts src/agent/conversation-hosted-terminal.test.ts
- deno task verify:quick
- pre-push checks passed