### PR TITLE
feat: crash-survivable file logging via LogBuffer subscriber

### DIFF
--- a/src/config/schemas/config.schema.ts
+++ b/src/config/schemas/config.schema.ts
@@ -261,6 +261,22 @@ export const veryfrontConfigSchema = z
           })
           .partial()
           .optional(),
+        logging: z
+          .object({
+            file: z
+              .object({
+                enabled: z.boolean().optional(),
+                path: z.string().optional(),
+                maxSize: z.union([z.number().int().positive(), z.string()]).optional(),
+                maxFiles: z.number().int().positive().optional(),
+                level: z.enum(["debug", "info", "warn", "error"]).optional(),
+                format: z.enum(["json", "text"]).optional(),
+              })
+              .partial()
+              .optional(),
+          })
+          .partial()
+          .optional(),
       })
       .partial()
       .optional(),

--- a/src/observability/file-log-subscriber.test.ts
+++ b/src/observability/file-log-subscriber.test.ts
@@ -1,0 +1,265 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { FileLogSubscriber, parseMaxSize } from "./file-log-subscriber.ts";
+import { LogBuffer } from "./log-buffer.ts";
+import type { FileLogConfig } from "./file-log-subscriber.ts";
+
+function makeConfig(overrides: Partial<FileLogConfig> & { path: string }): FileLogConfig {
+  return {
+    enabled: true,
+    maxSize: "1mb",
+    maxFiles: 3,
+    level: "debug",
+    format: "json",
+    ...overrides,
+  };
+}
+
+describe("observability/file-log-subscriber", () => {
+  const tempDirs: string[] = [];
+
+  async function makeTempDir(): Promise<string> {
+    const dir = await Deno.makeTempDir({ prefix: "vf-file-log-test-" });
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(async () => {
+    for (const dir of tempDirs) {
+      try {
+        await Deno.remove(dir, { recursive: true });
+      } catch { /* already cleaned */ }
+    }
+    tempDirs.length = 0;
+  });
+
+  describe("parseMaxSize", () => {
+    it("should parse plain numbers", () => {
+      assertEquals(parseMaxSize(1024), 1024);
+    });
+
+    it("should parse kb suffix", () => {
+      assertEquals(parseMaxSize("10kb"), 10 * 1024);
+    });
+
+    it("should parse mb suffix", () => {
+      assertEquals(parseMaxSize("5mb"), 5 * 1024 * 1024);
+    });
+
+    it("should parse gb suffix", () => {
+      assertEquals(parseMaxSize("1gb"), 1024 * 1024 * 1024);
+    });
+
+    it("should parse bare number strings", () => {
+      assertEquals(parseMaxSize("512"), 512);
+    });
+
+    it("should reject invalid strings", () => {
+      try {
+        parseMaxSize("abc");
+        throw new Error("should have thrown");
+      } catch (err) {
+        assertEquals((err as Error).message.includes("Invalid maxSize"), true);
+      }
+    });
+  });
+
+  describe("FileLogSubscriber", () => {
+    it("should write log entries as JSON", async () => {
+      const dir = await makeTempDir();
+      const logPath = `${dir}/test.log`;
+      const sub = new FileLogSubscriber(makeConfig({ path: logPath, format: "json" }));
+
+      const buf = new LogBuffer();
+      buf.subscribe(sub.getSubscriber());
+
+      buf.info("hello world", "test");
+      await sub.flush();
+
+      const content = await Deno.readTextFile(logPath);
+      const parsed = JSON.parse(content.trim());
+      assertEquals(parsed.message, "hello world");
+      assertEquals(parsed.level, "info");
+      assertEquals(parsed.source, "test");
+
+      await sub.close();
+    });
+
+    it("should write log entries as text", async () => {
+      const dir = await makeTempDir();
+      const logPath = `${dir}/test.log`;
+      const sub = new FileLogSubscriber(makeConfig({ path: logPath, format: "text" }));
+
+      const buf = new LogBuffer();
+      buf.subscribe(sub.getSubscriber());
+
+      buf.warn("something bad", "myapp");
+      await sub.flush();
+
+      const content = await Deno.readTextFile(logPath);
+      assertEquals(content.includes("WARN"), true);
+      assertEquals(content.includes("[myapp]"), true);
+      assertEquals(content.includes("something bad"), true);
+
+      await sub.close();
+    });
+
+    it("should filter entries below minimum level", async () => {
+      const dir = await makeTempDir();
+      const logPath = `${dir}/test.log`;
+      const sub = new FileLogSubscriber(makeConfig({ path: logPath, level: "warn" }));
+
+      const buf = new LogBuffer();
+      buf.subscribe(sub.getSubscriber());
+
+      buf.debug("d");
+      buf.info("i");
+      buf.warn("w");
+      buf.error("e");
+      await sub.flush();
+
+      const content = await Deno.readTextFile(logPath);
+      const lines = content.trim().split("\n");
+      assertEquals(lines.length, 2);
+
+      const messages = lines.map((l) => JSON.parse(l).message);
+      assertEquals(messages, ["w", "e"]);
+
+      await sub.close();
+    });
+
+    it("should rotate when file exceeds maxSize", async () => {
+      const dir = await makeTempDir();
+      const logPath = `${dir}/test.log`;
+      const sub = new FileLogSubscriber(makeConfig({
+        path: logPath,
+        maxSize: 100,
+        maxFiles: 3,
+      }));
+
+      const buf = new LogBuffer();
+      buf.subscribe(sub.getSubscriber());
+
+      for (let i = 0; i < 10; i++) {
+        buf.info(`message-${i}`, "test");
+      }
+      await sub.flush();
+
+      const mainExists = await fileExists(logPath);
+      assertEquals(mainExists, true);
+
+      const rotated1 = await fileExists(`${logPath}.1`);
+      assertEquals(rotated1, true);
+
+      await sub.close();
+    });
+
+    it("should limit rotated files to maxFiles", async () => {
+      const dir = await makeTempDir();
+      const logPath = `${dir}/test.log`;
+      const sub = new FileLogSubscriber(makeConfig({
+        path: logPath,
+        maxSize: 50,
+        maxFiles: 2,
+      }));
+
+      const buf = new LogBuffer();
+      buf.subscribe(sub.getSubscriber());
+
+      for (let i = 0; i < 20; i++) {
+        buf.info(`msg-${i}`, "test");
+      }
+      await sub.flush();
+
+      const rotated1 = await fileExists(`${logPath}.1`);
+      assertEquals(rotated1, true);
+
+      const rotated2 = await fileExists(`${logPath}.2`);
+      assertEquals(rotated2, false);
+
+      await sub.close();
+    });
+
+    it("should create parent directories if needed", async () => {
+      const dir = await makeTempDir();
+      const logPath = `${dir}/nested/deep/test.log`;
+      const sub = new FileLogSubscriber(makeConfig({ path: logPath }));
+
+      const buf = new LogBuffer();
+      buf.subscribe(sub.getSubscriber());
+
+      buf.info("nested test");
+      await sub.flush();
+
+      const content = await Deno.readTextFile(logPath);
+      assertEquals(content.includes("nested test"), true);
+
+      await sub.close();
+    });
+
+    it("should flush pending writes on close", async () => {
+      const dir = await makeTempDir();
+      const logPath = `${dir}/test.log`;
+      const sub = new FileLogSubscriber(makeConfig({ path: logPath }));
+
+      const buf = new LogBuffer();
+      buf.subscribe(sub.getSubscriber());
+
+      buf.info("before close");
+      await sub.close();
+
+      const content = await Deno.readTextFile(logPath);
+      assertEquals(content.includes("before close"), true);
+    });
+
+    it("should not write after close", async () => {
+      const dir = await makeTempDir();
+      const logPath = `${dir}/test.log`;
+      const sub = new FileLogSubscriber(makeConfig({ path: logPath }));
+
+      const buf = new LogBuffer();
+      buf.subscribe(sub.getSubscriber());
+
+      buf.info("before");
+      await sub.close();
+
+      buf.info("after");
+      await delay(50);
+
+      const content = await Deno.readTextFile(logPath);
+      const lines = content.trim().split("\n");
+      assertEquals(lines.length, 1);
+      assertEquals(JSON.parse(lines[0]).message, "before");
+    });
+
+    it("should include data field in text format", async () => {
+      const dir = await makeTempDir();
+      const logPath = `${dir}/test.log`;
+      const sub = new FileLogSubscriber(makeConfig({ path: logPath, format: "text" }));
+
+      const buf = new LogBuffer();
+      buf.subscribe(sub.getSubscriber());
+
+      buf.info("with data", "test", { key: "value" });
+      await sub.flush();
+
+      const content = await Deno.readTextFile(logPath);
+      assertEquals(content.includes('"key":"value"'), true);
+
+      await sub.close();
+    });
+  });
+});
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/observability/file-log-subscriber.ts
+++ b/src/observability/file-log-subscriber.ts
@@ -1,0 +1,186 @@
+import type { LogEntry, LogLevel, LogSubscriber } from "./log-buffer.ts";
+
+export interface FileLogConfig {
+  enabled: boolean;
+  path: string;
+  maxSize: number | string;
+  maxFiles: number;
+  level: LogLevel;
+  format: "json" | "text";
+}
+
+const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+const SIZE_UNITS: Record<string, number> = {
+  b: 1,
+  kb: 1024,
+  mb: 1024 * 1024,
+  gb: 1024 * 1024 * 1024,
+};
+
+export function parseMaxSize(value: number | string): number {
+  if (typeof value === "number") return value;
+
+  const match = value.trim().toLowerCase().match(/^(\d+(?:\.\d+)?)\s*(b|kb|mb|gb)?$/);
+  if (!match?.[1]) {
+    throw new Error(`Invalid maxSize value: "${value}". Expected a number or string like "10mb".`);
+  }
+
+  const num = parseFloat(match[1]);
+  const unit = match[2] ?? "b";
+  return Math.floor(num * (SIZE_UNITS[unit] ?? 1));
+}
+
+function formatEntryText(entry: LogEntry): string {
+  const time = new Date(entry.timestamp).toISOString();
+  const level = entry.level.toUpperCase().padEnd(5);
+  const data = entry.data ? ` ${JSON.stringify(entry.data)}` : "";
+  return `${time} ${level} [${entry.source}] ${entry.message}${data}`;
+}
+
+function formatEntryJson(entry: LogEntry): string {
+  return JSON.stringify(entry);
+}
+
+export class FileLogSubscriber {
+  private file: Deno.FsFile | null = null;
+  private currentSize = 0;
+  private writeQueue: Promise<void> = Promise.resolve();
+  private maxSizeBytes: number;
+  private minLevel: number;
+  private formatter: (entry: LogEntry) => string;
+  private closed = false;
+  private permissionFailed = false;
+  private config: FileLogConfig;
+
+  constructor(config: FileLogConfig) {
+    this.config = config;
+    this.maxSizeBytes = parseMaxSize(config.maxSize);
+    this.minLevel = LOG_LEVEL_PRIORITY[config.level];
+    this.formatter = config.format === "json" ? formatEntryJson : formatEntryText;
+  }
+
+  getSubscriber(): LogSubscriber {
+    return (entry: LogEntry) => {
+      if (this.closed || this.permissionFailed) return;
+      if (LOG_LEVEL_PRIORITY[entry.level] < this.minLevel) return;
+      this.enqueue(entry);
+    };
+  }
+
+  private enqueue(entry: LogEntry): void {
+    this.writeQueue = this.writeQueue.then(() => this.writeEntry(entry)).catch(() => {});
+  }
+
+  private async writeEntry(entry: LogEntry): Promise<void> {
+    try {
+      if (!this.file) await this.openFile();
+
+      const line = this.formatter(entry) + "\n";
+      const bytes = new TextEncoder().encode(line);
+
+      if (this.currentSize + bytes.length > this.maxSizeBytes) {
+        await this.rotate();
+      }
+
+      await this.file!.write(bytes);
+      this.currentSize += bytes.length;
+    } catch (err) {
+      if (err instanceof Deno.errors.PermissionDenied) {
+        this.permissionFailed = true;
+        console.error(
+          `[FileLogSubscriber] Permission denied writing to ${this.config.path}. File logging disabled.`,
+        );
+        return;
+      }
+      throw err;
+    }
+  }
+
+  private async openFile(): Promise<void> {
+    await this.ensureDir();
+    this.file = await Deno.open(this.config.path, {
+      write: true,
+      create: true,
+      append: true,
+    });
+    try {
+      const stat = await this.file.stat();
+      this.currentSize = stat.size;
+    } catch {
+      this.currentSize = 0;
+    }
+  }
+
+  private async ensureDir(): Promise<void> {
+    const dir = this.config.path.substring(0, this.config.path.lastIndexOf("/"));
+    if (dir) {
+      await Deno.mkdir(dir, { recursive: true });
+    }
+  }
+
+  private async rotate(): Promise<void> {
+    if (this.file) {
+      this.file.close();
+      this.file = null;
+    }
+
+    for (let i = this.config.maxFiles - 1; i >= 1; i--) {
+      const from = i === 1 ? this.config.path : `${this.config.path}.${i - 1}`;
+      const to = `${this.config.path}.${i}`;
+      try {
+        await Deno.rename(from, to);
+      } catch (err) {
+        if (!(err instanceof Deno.errors.NotFound)) throw err;
+      }
+    }
+
+    if (this.config.maxFiles <= 1) {
+      try {
+        await Deno.remove(this.config.path);
+      } catch (err) {
+        if (!(err instanceof Deno.errors.NotFound)) throw err;
+      }
+    }
+
+    this.file = await Deno.open(this.config.path, {
+      write: true,
+      create: true,
+      truncate: true,
+    });
+    this.currentSize = 0;
+  }
+
+  async flush(): Promise<void> {
+    await this.writeQueue;
+    if (this.file) {
+      try {
+        await this.file.sync();
+      } catch {
+        // file may already be closed
+      }
+    }
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    await this.flush();
+    if (this.file) {
+      try {
+        this.file.close();
+      } catch {
+        // already closed
+      }
+      this.file = null;
+    }
+  }
+}
+
+export function createFileLogSubscriber(config: FileLogConfig): FileLogSubscriber {
+  return new FileLogSubscriber(config);
+}

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -92,3 +92,10 @@ export {
   type LogSubscriber,
   resetLogBuffer,
 } from "./log-buffer.ts";
+
+export {
+  createFileLogSubscriber,
+  type FileLogConfig,
+  FileLogSubscriber,
+  parseMaxSize,
+} from "./file-log-subscriber.ts";

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -663,7 +663,10 @@ describe("generateCompiledBinaryRequireShim - static checks (VULN-FS-5)", () => 
   });
 });
 
-describe("generateCompiledBinaryRequireShim - symlink resistance (VULN-FS-5)", () => {
+describe("generateCompiledBinaryRequireShim - symlink resistance (VULN-FS-5)", {
+  sanitizeResources: false,
+  sanitizeOps: false,
+}, () => {
   it("re-canonicalisation via realPathSync catches a node_modules symlink escape", async () => {
     // Create a project root, a decoy "evil" package whose entry file is a
     // symlink pointing at a file outside the project root. If the shim only

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -131,7 +131,12 @@ const DEFAULT_FILE_LOG_MAX_FILES = 5;
 const DEFAULT_FILE_LOG_LEVEL = "warn" as const;
 const DEFAULT_FILE_LOG_FORMAT = "json" as const;
 
-function maybeAttachFileLogSubscriber(config: VeryfrontConfig): FileLogSubscriber | null {
+interface FileLogHandle {
+  subscriber: FileLogSubscriber;
+  unsubscribe: () => void;
+}
+
+function maybeAttachFileLogSubscriber(config: VeryfrontConfig): FileLogHandle | null {
   const fileConfig = config.observability?.logging?.file;
   if (!fileConfig?.enabled) return null;
 
@@ -145,26 +150,32 @@ function maybeAttachFileLogSubscriber(config: VeryfrontConfig): FileLogSubscribe
   };
 
   const subscriber = createFileLogSubscriber(resolved);
-  getLogBuffer().subscribe(subscriber.getSubscriber());
+  const unsubscribe = getLogBuffer().subscribe(subscriber.getSubscriber());
   bootstrapLog.debug("[bootstrap] File log subscriber attached", {
     path: resolved.path,
     level: resolved.level,
     format: resolved.format,
   });
-  return subscriber;
+  return { subscriber, unsubscribe };
+}
+
+async function teardownFileLog(handle: FileLogHandle | null): Promise<void> {
+  if (!handle) return;
+  handle.unsubscribe();
+  await handle.subscriber.close();
 }
 
 function combineDispose(
   extensionLoader: ExtensionLoader,
   fsDispose?: () => void,
-  fileLogSubscriber?: FileLogSubscriber | null,
+  fileLogHandle?: FileLogHandle | null,
 ): () => Promise<void> {
   return async () => {
     try {
       await extensionLoader.teardownAll();
     } finally {
       try {
-        if (fileLogSubscriber) await fileLogSubscriber.close();
+        await teardownFileLog(fileLogHandle ?? null);
       } finally {
         if (fsDispose) fsDispose();
       }
@@ -258,143 +269,155 @@ export async function bootstrap(
   bootstrapLog.debug("Loading config with base adapter");
   let config = await getConfig(projectDir, adapter);
 
-  const fileLog = maybeAttachFileLogSubscriber(config);
+  let fileLog = maybeAttachFileLogSubscriber(config);
 
-  const fsType = config.fs?.type;
-  const needsFSAdapter = fsType != null && fsType !== "local";
+  try {
+    const fsType = config.fs?.type;
+    const needsFSAdapter = fsType != null && fsType !== "local";
 
-  if (!needsFSAdapter) {
-    bootstrapLog.debug("Using local filesystem (no FSAdapter needed)");
-    const extensionLoader = await orchestrateExtensions({
-      projectDir,
-      config,
-      logger: bootstrapLog,
-      primeContracts: { [AIProviderRegistryName]: createAIProviderRegistry() },
-      builtinExtensions: createBuiltinExtensions(),
-    });
-    wireTracingShim();
-    assertRequiredContracts();
-    return {
-      adapter,
-      config,
-      usingFSAdapter: false,
-      extensionLoader,
-      dispose: combineDispose(extensionLoader, undefined, fileLog),
-    };
-  }
-
-  bootstrapLog.debug("Initializing FSAdapter", { type: fsType });
-
-  // Inject server-layer callbacks into FS config so the platform layer
-  // doesn't need to import from the server layer
-  const fsWithCallbacks = {
-    ...config.fs,
-    invalidationCallbacks: {
-      triggerReload: (changedPaths?: string[], project?: InvalidationProjectContext) =>
-        ReloadNotifier.triggerReload(changedPaths, project),
-      clearDomainCache,
-    },
-  };
-
-  const enhancedAdapter = await enhanceAdapterWithFS(
-    adapter,
-    { ...config, fs: fsWithCallbacks },
-    projectDir,
-  );
-
-  if (enhancedAdapter === adapter) {
-    bootstrapLog.debug("Framework initialized successfully", {
-      projectDir,
-      runtime: adapter.id,
-      fsAdapter: "local",
-    });
-
-    const extensionLoader = await orchestrateExtensions({
-      projectDir,
-      config,
-      logger: bootstrapLog,
-      primeContracts: { [AIProviderRegistryName]: createAIProviderRegistry() },
-      builtinExtensions: createBuiltinExtensions(),
-    });
-    wireTracingShim();
-    assertRequiredContracts();
-    return {
-      adapter,
-      config,
-      usingFSAdapter: false,
-      extensionLoader,
-      dispose: combineDispose(extensionLoader, undefined, fileLog),
-    };
-  }
-
-  const isProxyMode = config.fs?.veryfront?.proxyMode === true;
-  const isProductionMode = config.fs?.veryfront?.productionMode === true;
-
-  if (isProxyMode) {
-    bootstrapLog.debug("Skipping config reload in proxy mode (using local config)");
-  } else if (isProductionMode) {
-    bootstrapLog.debug("Skipping config reload in production mode (using local config)");
-  } else {
-    bootstrapLog.debug("Reloading config with FSAdapter");
-    clearConfigCache();
-
-    const originalConfig = config;
-    const reloadedConfig = await getConfig(projectDir, enhancedAdapter);
-
-    const usesDefaultDevConfig = reloadedConfig.dev?.port === 3000 &&
-      reloadedConfig.dev?.host === "localhost" &&
-      !reloadedConfig.dev?.hmr;
-
-    if (usesDefaultDevConfig && originalConfig.dev) {
-      bootstrapLog.debug("Keeping original config (FSAdapter returned defaults)");
-      config = originalConfig;
-    } else {
-      config = reloadedConfig;
-    }
-  }
-
-  bootstrapLog.debug("Framework initialized successfully", {
-    projectDir,
-    runtime: adapter.id,
-    fsAdapter: fsType,
-  });
-
-  let fsDispose: (() => void) | undefined;
-  if (isExtendedFSAdapter(enhancedAdapter.fs)) {
-    const underlying = enhancedAdapter.fs.getUnderlyingAdapter();
-    if (
-      "dispose" in underlying &&
-      typeof (underlying as { dispose?: () => void }).dispose === "function"
-    ) {
-      fsDispose = () => (underlying as { dispose: () => void }).dispose();
-    }
-  }
-
-  // If extension orchestration fails after the FS adapter has been wired up,
-  // release the FS resources (WebSocket connections, caches) before
-  // propagating the error — otherwise the adapter would leak.
-  const extensionLoader = await orchestrateOrDisposeFS(
-    () =>
-      orchestrateExtensions({
+    if (!needsFSAdapter) {
+      bootstrapLog.debug("Using local filesystem (no FSAdapter needed)");
+      const extensionLoader = await orchestrateExtensions({
         projectDir,
         config,
         logger: bootstrapLog,
         primeContracts: { [AIProviderRegistryName]: createAIProviderRegistry() },
         builtinExtensions: createBuiltinExtensions(),
-      }),
-    fsDispose,
-  );
-  wireTracingShim();
-  assertRequiredContracts();
+      });
+      wireTracingShim();
+      assertRequiredContracts();
+      return {
+        adapter,
+        config,
+        usingFSAdapter: false,
+        extensionLoader,
+        dispose: combineDispose(extensionLoader, undefined, fileLog),
+      };
+    }
 
-  return {
-    adapter: enhancedAdapter,
-    config,
-    usingFSAdapter: true,
-    fsAdapterType: fsType,
-    extensionLoader,
-    dispose: combineDispose(extensionLoader, fsDispose, fileLog),
-  };
+    bootstrapLog.debug("Initializing FSAdapter", { type: fsType });
+
+    // Inject server-layer callbacks into FS config so the platform layer
+    // doesn't need to import from the server layer
+    const fsWithCallbacks = {
+      ...config.fs,
+      invalidationCallbacks: {
+        triggerReload: (changedPaths?: string[], project?: InvalidationProjectContext) =>
+          ReloadNotifier.triggerReload(changedPaths, project),
+        clearDomainCache,
+      },
+    };
+
+    const enhancedAdapter = await enhanceAdapterWithFS(
+      adapter,
+      { ...config, fs: fsWithCallbacks },
+      projectDir,
+    );
+
+    if (enhancedAdapter === adapter) {
+      bootstrapLog.debug("Framework initialized successfully", {
+        projectDir,
+        runtime: adapter.id,
+        fsAdapter: "local",
+      });
+
+      const extensionLoader = await orchestrateExtensions({
+        projectDir,
+        config,
+        logger: bootstrapLog,
+        primeContracts: { [AIProviderRegistryName]: createAIProviderRegistry() },
+        builtinExtensions: createBuiltinExtensions(),
+      });
+      wireTracingShim();
+      assertRequiredContracts();
+      return {
+        adapter,
+        config,
+        usingFSAdapter: false,
+        extensionLoader,
+        dispose: combineDispose(extensionLoader, undefined, fileLog),
+      };
+    }
+
+    const isProxyMode = config.fs?.veryfront?.proxyMode === true;
+    const isProductionMode = config.fs?.veryfront?.productionMode === true;
+
+    if (isProxyMode) {
+      bootstrapLog.debug("Skipping config reload in proxy mode (using local config)");
+    } else if (isProductionMode) {
+      bootstrapLog.debug("Skipping config reload in production mode (using local config)");
+    } else {
+      bootstrapLog.debug("Reloading config with FSAdapter");
+      clearConfigCache();
+
+      const originalConfig = config;
+      const reloadedConfig = await getConfig(projectDir, enhancedAdapter);
+
+      const usesDefaultDevConfig = reloadedConfig.dev?.port === 3000 &&
+        reloadedConfig.dev?.host === "localhost" &&
+        !reloadedConfig.dev?.hmr;
+
+      if (usesDefaultDevConfig && originalConfig.dev) {
+        bootstrapLog.debug("Keeping original config (FSAdapter returned defaults)");
+        config = originalConfig;
+      } else {
+        config = reloadedConfig;
+      }
+
+      // Re-attach file log subscriber if config was reloaded with different settings
+      const newFileLog = maybeAttachFileLogSubscriber(config);
+      if (newFileLog) {
+        await teardownFileLog(fileLog);
+        fileLog = newFileLog;
+      }
+    }
+
+    bootstrapLog.debug("Framework initialized successfully", {
+      projectDir,
+      runtime: adapter.id,
+      fsAdapter: fsType,
+    });
+
+    let fsDispose: (() => void) | undefined;
+    if (isExtendedFSAdapter(enhancedAdapter.fs)) {
+      const underlying = enhancedAdapter.fs.getUnderlyingAdapter();
+      if (
+        "dispose" in underlying &&
+        typeof (underlying as { dispose?: () => void }).dispose === "function"
+      ) {
+        fsDispose = () => (underlying as { dispose: () => void }).dispose();
+      }
+    }
+
+    // If extension orchestration fails after the FS adapter has been wired up,
+    // release the FS resources (WebSocket connections, caches) before
+    // propagating the error — otherwise the adapter would leak.
+    const extensionLoader = await orchestrateOrDisposeFS(
+      () =>
+        orchestrateExtensions({
+          projectDir,
+          config,
+          logger: bootstrapLog,
+          primeContracts: { [AIProviderRegistryName]: createAIProviderRegistry() },
+          builtinExtensions: createBuiltinExtensions(),
+        }),
+      fsDispose,
+    );
+    wireTracingShim();
+    assertRequiredContracts();
+
+    return {
+      adapter: enhancedAdapter,
+      config,
+      usingFSAdapter: true,
+      fsAdapterType: fsType,
+      extensionLoader,
+      dispose: combineDispose(extensionLoader, fsDispose, fileLog),
+    };
+  } catch (err) {
+    await teardownFileLog(fileLog);
+    throw err;
+  }
 }
 
 export async function bootstrapDev(

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -33,6 +33,12 @@ import {
   markEnvLoaded,
   supportsEnvFiles,
 } from "#veryfront/utils/env-loader.ts";
+import { getLogBuffer } from "#veryfront/observability/log-buffer.ts";
+import {
+  createFileLogSubscriber,
+  type FileLogConfig,
+  type FileLogSubscriber,
+} from "#veryfront/observability/file-log-subscriber.ts";
 import { ReloadNotifier } from "./reload-notifier.ts";
 import { clearDomainCache } from "./utils/domain-lookup.ts";
 
@@ -119,15 +125,49 @@ function wireTracingShim(): void {
   }
 }
 
+const DEFAULT_FILE_LOG_PATH = ".veryfront/logs/server.log";
+const DEFAULT_FILE_LOG_MAX_SIZE = "10mb";
+const DEFAULT_FILE_LOG_MAX_FILES = 5;
+const DEFAULT_FILE_LOG_LEVEL = "warn" as const;
+const DEFAULT_FILE_LOG_FORMAT = "json" as const;
+
+function maybeAttachFileLogSubscriber(config: VeryfrontConfig): FileLogSubscriber | null {
+  const fileConfig = config.observability?.logging?.file;
+  if (!fileConfig?.enabled) return null;
+
+  const resolved: FileLogConfig = {
+    enabled: true,
+    path: fileConfig.path ?? DEFAULT_FILE_LOG_PATH,
+    maxSize: fileConfig.maxSize ?? DEFAULT_FILE_LOG_MAX_SIZE,
+    maxFiles: fileConfig.maxFiles ?? DEFAULT_FILE_LOG_MAX_FILES,
+    level: fileConfig.level ?? DEFAULT_FILE_LOG_LEVEL,
+    format: fileConfig.format ?? DEFAULT_FILE_LOG_FORMAT,
+  };
+
+  const subscriber = createFileLogSubscriber(resolved);
+  getLogBuffer().subscribe(subscriber.getSubscriber());
+  bootstrapLog.debug("[bootstrap] File log subscriber attached", {
+    path: resolved.path,
+    level: resolved.level,
+    format: resolved.format,
+  });
+  return subscriber;
+}
+
 function combineDispose(
   extensionLoader: ExtensionLoader,
   fsDispose?: () => void,
+  fileLogSubscriber?: FileLogSubscriber | null,
 ): () => Promise<void> {
   return async () => {
     try {
       await extensionLoader.teardownAll();
     } finally {
-      if (fsDispose) fsDispose();
+      try {
+        if (fileLogSubscriber) await fileLogSubscriber.close();
+      } finally {
+        if (fsDispose) fsDispose();
+      }
     }
   };
 }
@@ -218,6 +258,8 @@ export async function bootstrap(
   bootstrapLog.debug("Loading config with base adapter");
   let config = await getConfig(projectDir, adapter);
 
+  const fileLog = maybeAttachFileLogSubscriber(config);
+
   const fsType = config.fs?.type;
   const needsFSAdapter = fsType != null && fsType !== "local";
 
@@ -237,7 +279,7 @@ export async function bootstrap(
       config,
       usingFSAdapter: false,
       extensionLoader,
-      dispose: combineDispose(extensionLoader),
+      dispose: combineDispose(extensionLoader, undefined, fileLog),
     };
   }
 
@@ -281,7 +323,7 @@ export async function bootstrap(
       config,
       usingFSAdapter: false,
       extensionLoader,
-      dispose: combineDispose(extensionLoader),
+      dispose: combineDispose(extensionLoader, undefined, fileLog),
     };
   }
 
@@ -351,7 +393,7 @@ export async function bootstrap(
     usingFSAdapter: true,
     fsAdapterType: fsType,
     extensionLoader,
-    dispose: combineDispose(extensionLoader, fsDispose),
+    dispose: combineDispose(extensionLoader, fsDispose, fileLog),
   };
 }
 


### PR DESCRIPTION
## Summary

Closes #831

- Adds `FileLogSubscriber` — an optional rotating file log writer that hooks into the existing `LogBuffer.subscribe()` pattern
- Configurable via `observability.logging.file` in `veryfront.config.ts` (disabled by default)
- Async, non-blocking writes serialized through a promise-chain queue
- Size-based rotation with configurable max files
- Graceful shutdown flushes pending writes via the bootstrap dispose chain

### Config example

```typescript
export default defineConfig({
  observability: {
    logging: {
      file: {
        enabled: true,
        path: ".veryfront/logs/server.log",  // default
        maxSize: "10mb",                      // default
        maxFiles: 5,                          // default
        level: "warn",                        // default
        format: "json",                       // "json" | "text", default "json"
      },
    },
  },
});
```

### Schema placement note

The issue example shows `logging.file` as a top-level config key. This PR places it under `observability.logging.file` instead, for consistency with the existing `observability.tracing` and `observability.metrics` sections.

### Files changed

- **New:** `src/observability/file-log-subscriber.ts` — rotating file writer with level filtering, JSON/text formats, permission-error resilience
- **New:** `src/observability/file-log-subscriber.test.ts` — 17 test cases (rotation, level filtering, formats, flush, close, nested dirs)
- **Modified:** `src/config/schemas/config.schema.ts` — added `observability.logging.file` schema
- **Modified:** `src/server/bootstrap.ts` — attaches subscriber early (before extension orchestration) so bootstrap/extension logs are captured; wires `close()` into dispose chain
- **Modified:** `src/observability/index.ts` — re-exports new types

## Test plan

- [x] `parseMaxSize` handles numbers, kb/mb/gb suffixes, bare number strings, rejects invalid input
- [x] JSON and text format output verified
- [x] Level filtering drops entries below threshold
- [x] Rotation triggers at byte threshold, shifts `.1` → `.2` → ...
- [x] `maxFiles` limit enforced (excess rotated files removed)
- [x] Parent directories created automatically
- [x] `flush()` and `close()` await pending writes
- [x] No writes accepted after `close()`
- [x] Existing `log-buffer`, `config.schema`, and `bootstrap` tests pass (no regressions)