### PR TITLE
Add hosted child retry block helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.403",
+  "version": "0.1.404",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-status.test.ts
+++ b/src/agent/hosted-child-status.test.ts
@@ -6,6 +6,7 @@ import {
   isHostedChildTerminalErrorCode,
   monitorHostedChildRunStatus,
   resolveHostedChildTerminalErrorCode,
+  shouldBlockHostedChildSameTurnRetry,
 } from "./hosted-child-status.ts";
 
 describe("agent/hosted-child-status", () => {
@@ -33,6 +34,36 @@ describe("agent/hosted-child-status", () => {
     );
     assertEquals(isHostedChildTerminalErrorCode("OTHER"), false);
     assertEquals(isHostedChildTerminalErrorCode(null), false);
+  });
+
+  it("detects child cancellation results that should block same-turn retries", () => {
+    assertEquals(
+      shouldBlockHostedChildSameTurnRetry({
+        terminalErrorCode: "CANCELLED",
+        terminalErrorMessage: "Run cancelled by host",
+      }),
+      true,
+    );
+    assertEquals(
+      shouldBlockHostedChildSameTurnRetry({
+        terminalErrorCode: hostedChildTerminalErrorCodes.cancelled,
+      }),
+      true,
+    );
+    assertEquals(
+      shouldBlockHostedChildSameTurnRetry({
+        terminalErrorMessage: "Child run cancelled",
+      }),
+      true,
+    );
+    assertEquals(
+      shouldBlockHostedChildSameTurnRetry({
+        terminalErrorCode: "INVOKE_AGENT_FAILED",
+        terminalErrorMessage: "Child run failed",
+      }),
+      false,
+    );
+    assertEquals(shouldBlockHostedChildSameTurnRetry(null), false);
   });
 
   it("stores status and identifiers on HostedChildTerminalStateError", () => {

--- a/src/agent/hosted-child-status.ts
+++ b/src/agent/hosted-child-status.ts
@@ -29,6 +29,33 @@ export function isHostedChildTerminalErrorCode(
   );
 }
 
+export interface HostedChildSameTurnRetryBlockSignal {
+  terminalErrorCode?: string | null;
+  terminalErrorMessage?: string | null;
+}
+
+function getOptionalStringProperty(value: object, property: string): string | null {
+  const descriptor = Object.getOwnPropertyDescriptor(value, property);
+  return typeof descriptor?.value === "string" ? descriptor.value : null;
+}
+
+export function shouldBlockHostedChildSameTurnRetry(
+  result: unknown,
+): result is HostedChildSameTurnRetryBlockSignal {
+  if (typeof result !== "object" || result === null) {
+    return false;
+  }
+
+  const terminalErrorCode = getOptionalStringProperty(result, "terminalErrorCode");
+  const terminalErrorMessage = getOptionalStringProperty(result, "terminalErrorMessage");
+
+  return (
+    terminalErrorCode === "CANCELLED" ||
+    terminalErrorCode === hostedChildTerminalErrorCodes.cancelled ||
+    terminalErrorMessage === "Child run cancelled"
+  );
+}
+
 export type HostedChildTerminalStatus = Extract<
   HostedConversationRunStatus,
   "completed" | "failed" | "cancelled"

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.403";
+export const VERSION = "0.1.404";


### PR DESCRIPTION
## Summary
- add a framework helper for detecting durable child cancellation results that should block same-turn retries
- cover the helper in hosted child status tests
- bump `deno.json` and the runtime version constant to `0.1.404` for CI/CD publishing

## Verification
- deno task verify:quick
- deno test --no-check --allow-all src/agent/hosted-child-status.test.ts src/agent/hosted-durable-child-fork-execution.test.ts
- pre-push checks: format/lint/typecheck + unit tests, 1691 passed

Rejected: Keep the predicate in one service | retry blocking follows framework durable child terminal codes and should be reusable.
Rejected: Move product retry policy into the framework | the helper only detects the terminal signal; hosts still decide how to message or enforce it.