### PR TITLE
Export hosted child retry block helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.404",
+  "version": "0.1.405",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-status.test.ts
+++ b/src/agent/hosted-child-status.test.ts
@@ -8,6 +8,7 @@ import {
   resolveHostedChildTerminalErrorCode,
   shouldBlockHostedChildSameTurnRetry,
 } from "./hosted-child-status.ts";
+import { shouldBlockHostedChildSameTurnRetry as shouldBlockHostedChildSameTurnRetryFromIndex } from "./index.ts";
 
 describe("agent/hosted-child-status", () => {
   it("maps terminal statuses to durable child error codes", () => {
@@ -103,5 +104,16 @@ describe("agent/hosted-child-status", () => {
     });
 
     assertEquals(calls, 0);
+  });
+});
+
+describe("agent/hosted-child-status public contract", () => {
+  it("exports same-turn retry block detection from veryfront/agent", () => {
+    assertEquals(
+      shouldBlockHostedChildSameTurnRetryFromIndex({
+        terminalErrorCode: hostedChildTerminalErrorCodes.cancelled,
+      }),
+      true,
+    );
   });
 });

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -869,6 +869,7 @@ export {
 } from "./hosted-child-fork-runtime-start.ts";
 export {
   type HostedChildRunIdentifiers,
+  type HostedChildSameTurnRetryBlockSignal,
   type HostedChildTerminalErrorCode,
   hostedChildTerminalErrorCodes,
   HostedChildTerminalStateError,
@@ -877,6 +878,7 @@ export {
   monitorHostedChildRunStatus,
   type MonitorHostedChildRunStatusInput,
   resolveHostedChildTerminalErrorCode,
+  shouldBlockHostedChildSameTurnRetry,
 } from "./hosted-child-status.ts";
 export {
   type HostedLifecycleAdapter,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.404";
+export const VERSION = "0.1.405";


### PR DESCRIPTION
## Summary
- export the hosted child same-turn retry block predicate from the public agent module
- cover the public contract through the hosted child status test
- bump the framework patch version for CI/CD publication

## Verification
- deno task verify:quick
- deno test --no-check --allow-all src/agent/hosted-child-status.test.ts src/utils/version.test.ts src/utils/logger/logger.test.ts
- pre-push: format/lint/typecheck + unit tests, 1693 passed

## Rejected alternatives
- Deep import from the hosted-child-status module: runtime hosts should use the stable veryfront/agent surface instead of relying on internal file layout.
- Keep the helper package-private: the predicate is explicitly reusable host-facing durable child-run behavior.

Co-authored-by: OmX <omx@oh-my-codex.dev>