### PR TITLE
fix(agent): treat file-only messages as empty conversation to prevent EMPTY_COMPLETION

### DIFF
--- a/src/agent/runtime-message-preparation.test.ts
+++ b/src/agent/runtime-message-preparation.test.ts
@@ -20,6 +20,47 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages returns an empty-conversati
   assertEquals(messages[0]?.parts, [{ type: "text", text: "Suggest next steps." }]);
 });
 
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages treats file-only message as empty conversation", async () => {
+  const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+    messages: [
+      userMessage([
+        {
+          type: "file",
+          mediaType: "image/png",
+          filename: "screenshot.png",
+          uploadId: "upload-1",
+          url: "https://files.example.com/screenshot.png",
+        },
+      ]),
+    ],
+    emptyConversationPrompt: "Suggest next steps.",
+  });
+
+  assertEquals(messages[0]?.role, "user");
+  assertEquals(messages[0]?.parts, [{ type: "text", text: "Suggest next steps." }]);
+});
+
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages treats text-empty-plus-file message as empty conversation", async () => {
+  const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+    messages: [
+      userMessage([
+        { type: "text", text: "   " },
+        {
+          type: "file",
+          mediaType: "image/png",
+          filename: "screenshot.png",
+          uploadId: "upload-1",
+          url: "https://files.example.com/screenshot.png",
+        },
+      ]),
+    ],
+    emptyConversationPrompt: "Suggest next steps.",
+  });
+
+  assertEquals(messages[0]?.role, "user");
+  assertEquals(messages[0]?.parts, [{ type: "text", text: "Suggest next steps." }]);
+});
+
 Deno.test("prepareAgentRuntimeMessagesFromUiMessages refreshes upload file URLs before conversion", async () => {
   const resolvedUploadIds: string[] = [];
   const messages = await prepareAgentRuntimeMessagesFromUiMessages({

--- a/src/agent/runtime-message-preparation.ts
+++ b/src/agent/runtime-message-preparation.ts
@@ -50,7 +50,7 @@ function isEmptyConversation(messages: readonly ChatUiMessage[]): boolean {
       if (part.type === "text") {
         return !part.text || part.text.trim() === "";
       }
-      return false;
+      return true;
     });
   }
 


### PR DESCRIPTION
## Problem

When a user sends a chat message with only file attachments and no text, `isEmptyConversation` returned `false` because non-text parts short-circuited the `every()` check. After conversion via `agent-runtime-message-adapter`, the LLM received only a file annotation text with no user intent:

```
Attached files from earlier conversation context:

<uploaded_files>
<file name="screenshot.png" ... />
</uploaded_files>
```

With no actionable request, some LLMs return an empty response. This triggers `shouldFailEmptyFinalizedMessage` in the agent runtime, producing an `EMPTY_COMPLETION` error — which is the root cause of [veryfront/veryfront-studio#3499](https://github.com/veryfront/veryfront-studio/issues/3499).

## Fix

Change the non-text part check in `isEmptyConversation` from `return false` to `return true`.

A message composed entirely of file parts has no text intent — it should be treated the same as an empty text message. The configured `emptyConversationPrompt` (or `DEFAULT_EMPTY_CONVERSATION_PROMPT`) is used instead, so the LLM always receives actionable text.

**Mixed messages (text + files) are unaffected**: a non-empty text part still returns `false` from `parts.every()`, leaving the existing conversion path untouched.

## Evidence

TDD cycle in `src/agent/runtime-message-preparation.test.ts`:

- Two new tests added: file-only and whitespace-text-plus-file cases
- Both tests **failed** against the old `return false` code
- Both tests **pass** after the one-line fix

```
ok | 4 passed | 0 failed (11ms)
```

## Related

- Studio fix (error panel now shows for EMPTY_COMPLETION): veryfront/veryfront-studio#3504
- Agent fix (propagate URL resolution errors): veryfront/veryfront-agent (separate PR)