### PR TITLE
fix: pass native image/file parts through AgentRuntimeMessage pipeline

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.407",
+  "version": "0.1.408",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/agent-runtime-message-adapter.test.ts
+++ b/src/agent/agent-runtime-message-adapter.test.ts
@@ -130,23 +130,43 @@ describe("agent runtime message adapter", () => {
     assertEquals(agentRuntimeMessages[0]?.parts, [agentRuntimeTextPart("Visible answer")]);
   });
 
-  it("converts multimodal parts into uploaded-file context annotations", () => {
+  it("passes image and file parts with URLs as native AgentRuntimeMessage parts", () => {
     const agentRuntimeMessages = convertProviderMessagesToAgentRuntimeMessages([
       providerMessage({
         role: "user",
         content: [
           {
             type: "image",
-            data: "ignored",
             mediaType: "image/png",
             filename: "diagram.png",
+            url: "https://uploads.example.com/diagram.png",
           },
           {
             type: "file",
-            data: "ignored",
             mediaType: "application/pdf",
             filename: "spec.pdf",
-            url: "https://example.com/spec.pdf",
+            url: "https://uploads.example.com/spec.pdf",
+          },
+        ],
+      }),
+    ]);
+
+    assertEquals(agentRuntimeMessages[0]?.parts, [
+      { type: "image", url: "https://uploads.example.com/diagram.png", mediaType: "image/png" },
+      { type: "file", url: "https://uploads.example.com/spec.pdf", mediaType: "application/pdf" },
+    ]);
+  });
+
+  it("falls back to annotation for multimodal parts without a URL", () => {
+    const agentRuntimeMessages = convertProviderMessagesToAgentRuntimeMessages([
+      providerMessage({
+        role: "user",
+        content: [
+          {
+            type: "image",
+            data: "base64data",
+            mediaType: "image/png",
+            filename: "diagram.png",
           },
         ],
       }),
@@ -158,7 +178,6 @@ describe("agent runtime message adapter", () => {
     if (firstPart && "text" in firstPart) {
       assertStringIncludes(firstPart.text, "<uploaded_files>");
       assertStringIncludes(firstPart.text, "diagram.png");
-      assertStringIncludes(firstPart.text, "spec.pdf");
     }
   });
 
@@ -188,6 +207,79 @@ describe("agent runtime message adapter", () => {
           providerToolResultPart(jsonOutput({ matches: 2 })),
         ],
       },
+    ]);
+  });
+
+  it("converts native image AgentRuntimeMessage part back to structured user content", () => {
+    const providerMessages = convertAgentRuntimeMessagesToProviderMessages([
+      agentRuntimeMessage(
+        "user",
+        [
+          agentRuntimeTextPart("What is in this image?"),
+          { type: "image", url: "https://uploads.example.com/photo.jpg", mediaType: "image/jpeg" },
+        ],
+        0,
+      ),
+    ]);
+
+    assertEquals(providerMessages, [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "What is in this image?" },
+          { type: "image", url: "https://uploads.example.com/photo.jpg", mediaType: "image/jpeg" },
+        ],
+      },
+    ]);
+  });
+
+  it("does not drop a file-only user message — emits structured content with the file part", () => {
+    const providerMessages = convertAgentRuntimeMessagesToProviderMessages([
+      agentRuntimeMessage(
+        "user",
+        [
+          {
+            type: "image",
+            url: "https://uploads.example.com/screenshot.png",
+            mediaType: "image/png",
+          },
+        ],
+        0,
+      ),
+    ]);
+
+    assertEquals(providerMessages, [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            url: "https://uploads.example.com/screenshot.png",
+            mediaType: "image/png",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("drops a data: URL image part when converting back to provider messages", () => {
+    const providerMessages = convertAgentRuntimeMessagesToProviderMessages([
+      agentRuntimeMessage(
+        "user",
+        [
+          agentRuntimeTextPart("Here is my image."),
+          {
+            type: "image",
+            url: "data:image/png;base64,abc123==",
+            mediaType: "image/png",
+          },
+        ],
+        0,
+      ),
+    ]);
+
+    assertEquals(providerMessages, [
+      { role: "user", content: "Here is my image." },
     ]);
   });
 

--- a/src/agent/agent-runtime-message-adapter.ts
+++ b/src/agent/agent-runtime-message-adapter.ts
@@ -1,7 +1,9 @@
 import { isRecord } from "#veryfront/chat/conversation.ts";
 import {
   buildDataFileAnnotation,
+  type ChatModelFilePart,
   type ChatToolResultPart,
+  type ChatUserContentPart,
   type ProviderModelMessage,
   type UploadedFileReference,
 } from "../chat/types.ts";
@@ -36,7 +38,9 @@ type AgentRuntimeMessageLikePart =
     toolCallId: string;
     toolName: string;
     output: unknown;
-  };
+  }
+  | { type: "image"; url: string; mediaType: string }
+  | { type: "file"; url: string; mediaType: string };
 
 export type AgentRuntimeMessagePart =
   | { type: "text"; text: string }
@@ -51,7 +55,9 @@ export type AgentRuntimeMessagePart =
     toolCallId: string;
     toolName: string;
     result: unknown;
-  };
+  }
+  | { type: "image"; url: string; mediaType: string }
+  | { type: "file"; url: string; mediaType: string };
 
 export interface AgentRuntimeMessage {
   id: string;
@@ -64,6 +70,7 @@ interface AgentRuntimeProviderContentParts {
   textParts: ProviderTextPart[];
   toolCallParts: ProviderToolCallPart[];
   toolResultParts: ChatToolResultPart[];
+  fileParts: ChatModelFilePart[];
 }
 
 type ProviderTextPart = { type: "text"; text: string };
@@ -103,6 +110,24 @@ function createTextAgentRuntimePart(text: string): AgentRuntimeMessagePart | nul
   return hasTextContent(text) ? { type: "text", text } : null;
 }
 
+function toNativeFilePart(
+  type: "image" | "file",
+  part: unknown,
+): { type: "image"; url: string; mediaType: string } | {
+  type: "file";
+  url: string;
+  mediaType: string;
+} | null {
+  const url = getOptionalStringField(part, "url");
+  const mediaType = getOptionalStringField(part, "mediaType");
+  if (!url || url.startsWith("data:") || !mediaType) {
+    return null;
+  }
+  return type === "file"
+    ? { type: "file" as const, url, mediaType }
+    : { type: "image" as const, url, mediaType };
+}
+
 function convertStructuredPart(part: StructuredProviderPart): AgentRuntimeMessagePart | null {
   switch (part.type) {
     case "text":
@@ -129,7 +154,7 @@ function convertStructuredPart(part: StructuredProviderPart): AgentRuntimeMessag
 
     case "image":
     case "file":
-      return null;
+      return toNativeFilePart(part.type, part);
 
     default: {
       const exhaustiveCheck: never = part;
@@ -189,17 +214,18 @@ function convertContentToAgentRuntimeParts(
   const attachmentReferences: UploadedFileReference[] = [];
 
   for (const part of message.content) {
+    const convertedPart = convertStructuredPart(part);
+    if (convertedPart) {
+      parts.push(convertedPart);
+      continue;
+    }
+
     if (part.type === "image" || part.type === "file") {
       const attachmentReference = createAttachmentReference(part);
       if (attachmentReference) {
         attachmentReferences.push(attachmentReference);
       }
       continue;
-    }
-
-    const convertedPart = convertStructuredPart(part);
-    if (convertedPart) {
-      parts.push(convertedPart);
     }
   }
 
@@ -313,12 +339,21 @@ function collectAgentRuntimeProviderContentParts(
   const textParts: ProviderTextPart[] = [];
   const toolCallParts: ProviderToolCallPart[] = [];
   const toolResultParts: ChatToolResultPart[] = [];
+  const fileParts: ChatModelFilePart[] = [];
 
   for (const part of parts) {
     const textPart = getAgentRuntimeTextPart(part);
     if (textPart) {
       textParts.push(textPart);
       continue;
+    }
+
+    if (part.type === "image" || part.type === "file") {
+      const nativePart = toNativeFilePart(part.type, part);
+      if (nativePart) {
+        fileParts.push(nativePart);
+        continue;
+      }
     }
 
     const toolResultPart = getAgentRuntimeToolResultPart(part);
@@ -338,7 +373,7 @@ function collectAgentRuntimeProviderContentParts(
     }
   }
 
-  return { textParts, toolCallParts, toolResultParts };
+  return { textParts, toolCallParts, toolResultParts, fileParts };
 }
 
 function createProviderMessageFromAgentRuntimeMessage(
@@ -346,9 +381,8 @@ function createProviderMessageFromAgentRuntimeMessage(
     parts: ReadonlyArray<AgentRuntimeMessageLikePart>;
   },
 ): ProviderModelMessage | null {
-  const { textParts, toolCallParts, toolResultParts } = collectAgentRuntimeProviderContentParts(
-    message.parts,
-  );
+  const { textParts, toolCallParts, toolResultParts, fileParts } =
+    collectAgentRuntimeProviderContentParts(message.parts);
 
   switch (message.role) {
     case "assistant":
@@ -372,13 +406,21 @@ function createProviderMessageFromAgentRuntimeMessage(
       };
 
     case "user": {
-      if (textParts.length === 0) {
+      if (textParts.length === 0 && fileParts.length === 0) {
         return null;
       }
 
+      if (fileParts.length === 0) {
+        return {
+          role: "user",
+          content: joinTextParts(textParts),
+        };
+      }
+
+      const content: ChatUserContentPart[] = [...textParts, ...fileParts];
       return {
         role: "user",
-        content: joinTextParts(textParts),
+        content,
       };
     }
 

--- a/src/agent/hosted-child-fork-step-message-preparation.ts
+++ b/src/agent/hosted-child-fork-step-message-preparation.ts
@@ -43,12 +43,24 @@ function convertAgentRuntimePartToChildForkMessagePart(
     };
   }
 
-  return {
-    type: `tool-${part.toolName}`,
-    toolCallId: part.toolCallId,
-    toolName: part.toolName,
-    args: part.args,
-  };
+  if ("toolCallId" in part) {
+    return {
+      type: `tool-${part.toolName}`,
+      toolCallId: part.toolCallId,
+      toolName: part.toolName,
+      args: part.args,
+    };
+  }
+
+  // image/file parts have no equivalent in the child-fork AgentMessage schema — render as a placeholder
+  if (part.type === "image" || part.type === "file") {
+    return { type: "text", text: `[file: ${part.mediaType}]` };
+  }
+
+  const _exhaustive: never = part;
+  throw new Error(
+    `Unhandled AgentRuntimeMessagePart type: ${String((_exhaustive as { type: unknown }).type)}`,
+  );
 }
 
 export function convertCompactedProviderMessagesToChildForkRuntimeMessages(

--- a/src/agent/runtime-message-preparation.test.ts
+++ b/src/agent/runtime-message-preparation.test.ts
@@ -44,11 +44,29 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages refreshes upload file URLs 
   assertEquals(resolvedUploadIds, ["upload-1"]);
   assertEquals(messages[0]?.parts, [
     { type: "text", text: "Use these files." },
-    {
-      type: "text",
-      text: "Attached files from earlier conversation context:\n\n<uploaded_files>\n" +
-        '<file name="notes.txt" upload_id="upload-1" url="https://signed.example.com/file.txt" type="text/plain" />\n' +
-        "</uploaded_files>",
-    },
+    { type: "file", url: "https://signed.example.com/file.txt", mediaType: "text/plain" },
+  ]);
+});
+
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages keeps original URL when resolver returns undefined", async () => {
+  const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+    messages: [
+      userMessage([
+        { type: "text", text: "Check this image." },
+        {
+          type: "file",
+          mediaType: "image/png",
+          filename: "photo.png",
+          uploadId: "upload-2",
+          url: "https://files.example.com/photo.png",
+        },
+      ]),
+    ],
+    resolveFileUrl: async () => undefined,
+  });
+
+  assertEquals(messages[0]?.parts, [
+    { type: "text", text: "Check this image." },
+    { type: "file", url: "https://files.example.com/photo.png", mediaType: "image/png" },
   ]);
 });

--- a/src/agent/schemas/agent.schema.ts
+++ b/src/agent/schemas/agent.schema.ts
@@ -65,6 +65,16 @@ export const MessagePartSchema = z.union([
     args: z.record(z.string(), z.unknown()),
   }),
   ToolResultPartSchema,
+  z.object({
+    type: z.literal("image"),
+    url: z.string(),
+    mediaType: z.string(),
+  }),
+  z.object({
+    type: z.literal("file"),
+    url: z.string(),
+    mediaType: z.string(),
+  }),
 ]);
 
 export const MessageSchema = z.object({

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.407";
+export const VERSION = "0.1.408";


### PR DESCRIPTION
## Problem

When a user sends a file attachment (image or PDF), two things break:

1. **File-only messages cause `EMPTY_COMPLETION`** — the LLM receives only an XML annotation with no user intent, produces a minimal/empty response, and the error panel is shown.
2. **The LLM never sees actual file content** — even with text + file, the image pixels or PDF text are stripped and replaced with an annotation.

**Root cause:** `convertContentToAgentRuntimeParts` in `agent-runtime-message-adapter.ts` stripped all `image`/`file` parts from `ProviderModelMessage → AgentRuntimeMessage` conversion, replacing them with an XML annotation: `"Attached files from earlier conversation context: ..."`. When converting back (`AgentRuntimeMessage → ProviderModelMessage`), user messages only received string content, so the LLM never got multimodal input.

## Fix

- Add `{ type: "image"; url: string; mediaType: string }` and `{ type: "file"; url: string; mediaType: string }` variants to `AgentRuntimeMessagePart` and `AgentRuntimeMessageLikePart`
- In `convertStructuredPart`: return native image/file parts for URL-based attachments (signed URLs from veryfront-agent)
- In `convertContentToAgentRuntimeParts`: try native conversion first; fall back to XML annotation only when URL is missing or is a `data:` base64 URL
- In `collectAgentRuntimeProviderContentParts` + `createProviderMessageFromAgentRuntimeMessage`: collect file parts and emit structured `ChatUserContentPart[]` content for user messages
- Add image/file variants to `MessagePartSchema` in agent.schema.ts
- Guard `hosted-child-fork-step-message-preparation.ts` against image/file parts (convert to text annotation for child fork messages)

## What's preserved

The XML annotation fallback is kept for:
- Base64 `data:` URLs (can't pass as URL to provider)
- Parts with no URL (e.g. uploadId-only references before URL resolution)
- Unsupported media types (e.g. DOCX) — rewritten to annotation by upstream `rewriteUnsupportedFilePartsAsAnnotations`

## Providers

All three supported providers (Anthropic, OpenAI, Google) support native URL-based multimodal input. No provider-specific handling required.

## Reproduction script

```
deno run --no-check --allow-all scripts/repro-3499-file-attachment.ts
```

## Evidence

```
Scenario 1: Text + PDF attachment — file passes natively (not as annotation)
  → resolveFileUrl("upload-pdf") → signed URL
  ✓ Text part preserved
  ✓ File part is native (not annotation text)
  ✓ Signed URL forwarded to provider
  ✓ mediaType preserved

Scenario 2: Image-only message — not dropped (was causing EMPTY_COMPLETION)
  ProviderModelMessages:
  [{ "role": "user", "content": [{ "type": "file", "mediaType": "image/png", "url": "https://signed.example.com/screenshot.png" }] }]
  ✓ Message not dropped (EMPTY_COMPLETION fix)
  ✓ Content is structured array (not empty string)
  ✓ File part present in provider message

Scenario 3: Round-trip ProviderModelMessage → AgentRuntime → ProviderModelMessage
  ✓ Image survives round-trip
  ✓ File survives round-trip
  ✓ Image URL preserved
  ✓ File URL preserved

Scenario 4: Unsupported media type (DOCX) → annotation text (expected fallback)
  ✓ DOCX becomes annotation text (appended to message text)

All checks passed.
```

## Related

- Companion fix (URL error propagation): veryfront/veryfront-agent#1210
- Issue: veryfront/veryfront-studio#3499

## Test plan

- [x] `agent-runtime-message-adapter.test.ts` — 8 tests: native passthrough, annotation fallback, round-trip, file-only not dropped
- [x] `runtime-message-preparation.test.ts` — updated to expect native file part after URL resolution
- [x] `hosted-child-fork-step-message-preparation.test.ts` — 3 existing tests pass
- [x] Full `src/agent/` suite: 280 passed, 0 failed
- [x] `scripts/repro-3499-file-attachment.ts` — 4 end-to-end scenarios all pass