### PR TITLE
Add hosted child run-context stream executor

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.406",
+  "version": "0.1.407",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-fork-run-context.test.ts
+++ b/src/agent/hosted-child-fork-run-context.test.ts
@@ -1,6 +1,26 @@
 import { assertEquals } from "@std/assert";
 import type { ChatMessageMetadata, ChatUiMessageChunk } from "#veryfront/chat/protocol.ts";
-import { createHostedChildForkRunContext } from "./hosted-child-fork-run-context.ts";
+import {
+  createHostedChildForkRunContext,
+  executeHostedChildForkRunContextStream,
+} from "./hosted-child-fork-run-context.ts";
+import type { ForkPart, ForkRuntimeStep } from "./fork-runtime-stream.ts";
+
+async function* forkParts(parts: ForkPart[]): AsyncGenerator<ForkPart, void, void> {
+  for (const part of parts) {
+    yield part;
+  }
+}
+
+function createStep(text: string): ForkRuntimeStep {
+  return {
+    text,
+    finishReason: "stop",
+    messages: [],
+    toolCalls: [],
+    toolResults: [],
+  };
+}
 
 Deno.test("createHostedChildForkRunContext wires stream mirror state and buffers", async () => {
   const chunks: ChatUiMessageChunk<ChatMessageMetadata>[] = [];
@@ -75,4 +95,60 @@ Deno.test("createHostedChildForkRunContext closes pending tool calls with host l
     toolCallIds: ["tool-call-1"],
     errorMessage: null,
   });
+});
+
+Deno.test("executeHostedChildForkRunContextStream executes with run-context buffers", async () => {
+  const chunks: ChatUiMessageChunk<ChatMessageMetadata>[] = [];
+  const traces: string[] = [];
+  const context = createHostedChildForkRunContext({
+    mirror: {
+      handleChunk: (chunk) => {
+        chunks.push(chunk);
+      },
+    },
+    messageId: "message-1",
+    pendingToolLogContext: {
+      conversationId: "conversation-1",
+      parentRunId: "run-1",
+      description: "Check the app",
+    },
+  });
+
+  const result = await executeHostedChildForkRunContextStream({
+    runContext: context,
+    streamResult: {
+      fullStream: forkParts([
+        { type: "text-delta", text: "Done" },
+      ]),
+      steps: Promise.resolve([createStep("Done")]),
+      totalUsage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+    },
+    abortForkStream: () => undefined,
+    conversationId: "conversation-1",
+    parentRunId: "run-1",
+    description: "Check the app",
+    kind: "invoke_agent",
+    maxSteps: 10,
+    startTime: Date.now(),
+    finalizationTimeoutMs: 100,
+    idleTimeoutMs: 1_000,
+    activeToolTimeoutMs: 1_000,
+    postToolIdleTimeoutMs: 1_000,
+    tracePart: ({ partType }) => {
+      traces.push(partType);
+    },
+  });
+
+  assertEquals(result.success, true);
+  assertEquals(context.streamState.finalText, "Done");
+  assertEquals(context.toolCalls, []);
+  assertEquals(context.toolResults, []);
+  assertEquals(context.streamMirrorContext.hasStartedStep(), true);
+  assertEquals(chunks.map((chunk) => chunk.type), [
+    "start-step",
+    "text-start",
+    "text-delta",
+    "text-end",
+  ]);
+  assertEquals(traces, ["text-delta"]);
 });

--- a/src/agent/hosted-child-fork-run-context.ts
+++ b/src/agent/hosted-child-fork-run-context.ts
@@ -10,7 +10,11 @@ import {
   type HostedChildPendingToolLifecycleLogContext,
   type HostedChildPendingToolLifecycleLogWriter,
 } from "./hosted-child-pending-tool-lifecycle.ts";
-import type { HostedChildForkPendingToolLifecycle } from "./hosted-child-fork-stream-execution.ts";
+import {
+  executeHostedChildForkStream,
+  type ExecuteHostedChildForkStreamInput,
+  type HostedChildForkPendingToolLifecycle,
+} from "./hosted-child-fork-stream-execution.ts";
 
 export interface HostedChildForkToolCallSnapshot {
   toolName: string;
@@ -96,4 +100,71 @@ export function createHostedChildForkRunContext(
     toolResults: [],
     streamState: { finalText: "" },
   };
+}
+
+export type ExecuteHostedChildForkRunContextStreamInput =
+  & Pick<
+    ExecuteHostedChildForkStreamInput,
+    | "streamResult"
+    | "abortSignal"
+    | "abortForkStream"
+    | "conversationId"
+    | "parentRunId"
+    | "description"
+    | "kind"
+    | "usage"
+    | "maxSteps"
+    | "startTime"
+    | "finalizationTimeoutMs"
+    | "onSettled"
+    | "idleTimeoutMs"
+    | "activeToolTimeoutMs"
+    | "postToolIdleTimeoutMs"
+    | "logger"
+    | "writeLog"
+    | "tracePart"
+  >
+  & {
+    runContext: HostedChildForkRunContext;
+  };
+
+export function executeHostedChildForkRunContextStream(
+  input: ExecuteHostedChildForkRunContextStreamInput,
+) {
+  const { streamMirrorContext, pendingToolLifecycle, toolCalls, toolResults, streamState } =
+    input.runContext;
+
+  return executeHostedChildForkStream({
+    streamResult: input.streamResult,
+    abortSignal: input.abortSignal,
+    abortForkStream: input.abortForkStream,
+    conversationId: input.conversationId,
+    parentRunId: input.parentRunId,
+    description: input.description,
+    kind: input.kind,
+    durableRunMirror: streamMirrorContext.durableRunMirror,
+    durableMessageId: streamMirrorContext.durableMessageId,
+    durableReasoningMessageId: streamMirrorContext.durableReasoningMessageId,
+    durableMirrorState: streamMirrorContext.durableMirrorState,
+    appendDurableMirrorChunk: streamMirrorContext.appendDurableMirrorChunk,
+    closeDurableMirrorReasoning: streamMirrorContext.closeDurableMirrorReasoning,
+    closeDurableMirrorText: streamMirrorContext.closeDurableMirrorText,
+    markDurableStepStarted: streamMirrorContext.markDurableStepStarted,
+    durableMirrorHasEmittedProgress: streamMirrorContext.hasEmittedProgress,
+    pendingToolLifecycle,
+    toolCalls,
+    toolResults,
+    streamState,
+    usage: input.usage,
+    maxSteps: input.maxSteps,
+    startTime: input.startTime,
+    finalizationTimeoutMs: input.finalizationTimeoutMs,
+    onSettled: input.onSettled,
+    idleTimeoutMs: input.idleTimeoutMs,
+    activeToolTimeoutMs: input.activeToolTimeoutMs,
+    postToolIdleTimeoutMs: input.postToolIdleTimeoutMs,
+    logger: input.logger,
+    writeLog: input.writeLog,
+    tracePart: input.tracePart,
+  });
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -424,6 +424,8 @@ export {
 } from "./hosted-child-fork-instructions.ts";
 export {
   createHostedChildForkRunContext,
+  executeHostedChildForkRunContextStream,
+  type ExecuteHostedChildForkRunContextStreamInput,
   type HostedChildForkRunContext,
   type HostedChildForkRunContextInput,
   type HostedChildForkStreamMirrorContext,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.406";
+export const VERSION = "0.1.407";


### PR DESCRIPTION
## Summary
- add a framework helper that executes hosted child fork streams from the reusable run context
- export the helper from the public agent surface
- bump package version to 0.1.407 for CI/CD publication

## Verification
- deno test --no-check --allow-all src/agent/hosted-child-fork-run-context.test.ts src/agent/hosted-child-fork-stream-execution.test.ts
- deno check src/agent/index.ts
- deno task verify:quick
- pre-push checks: format, lint, typecheck, unit tests