### PR TITLE
Add hosted chat runtime agent adapter

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.408",
+  "version": "0.1.409",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-chat-runtime-agent-adapter.test.ts
+++ b/src/agent/hosted-chat-runtime-agent-adapter.test.ts
@@ -1,0 +1,214 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ChatUiMessageChunk } from "../chat/types.ts";
+import type { ToolExecutionDataEvent } from "../tool/types.ts";
+import {
+  createHostedChatRuntimeAgentAdapter,
+  type HostedChatRuntimeAgentAdapterInput,
+} from "./hosted-chat-runtime-agent-adapter.ts";
+
+const encoder = new TextEncoder();
+
+async function collectChunks(
+  stream: AsyncIterable<ChatUiMessageChunk>,
+): Promise<ChatUiMessageChunk[]> {
+  const chunks: ChatUiMessageChunk[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+function createSseResponse(events: Array<Record<string, unknown>>): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const event of events) {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+        }
+        controller.close();
+      },
+    }),
+  );
+}
+
+function publishDataEventFrom(
+  input: Parameters<HostedChatRuntimeAgentAdapterInput["runtimeAgent"]["stream"]>[0] | undefined,
+  event: ToolExecutionDataEvent,
+): void {
+  const publishDataEvent = input?.context?.publishDataEvent;
+  if (typeof publishDataEvent !== "function") {
+    throw new Error("Runtime context did not receive a publishDataEvent callback");
+  }
+
+  publishDataEvent(event);
+}
+
+describe("createHostedChatRuntimeAgentAdapter", () => {
+  it("runs a framework runtime agent under the host runner and maps its data stream", async () => {
+    let capturedInput:
+      | Parameters<HostedChatRuntimeAgentAdapterInput["runtimeAgent"]["stream"]>[0]
+      | undefined;
+    let runnerCalled = false;
+    const abortController = new AbortController();
+    const runtimeAgent: HostedChatRuntimeAgentAdapterInput["runtimeAgent"] = {
+      stream(input) {
+        capturedInput = input;
+        return Promise.resolve({
+          toDataStreamResponse: () =>
+            createSseResponse([
+              { type: "message-start", messageId: "framework-message" },
+              { type: "step-start" },
+              { type: "text-start", id: "text-1" },
+              { type: "text-delta", id: "text-1", delta: "Hello from adapter" },
+              { type: "step-end" },
+              { type: "text-end", id: "text-1" },
+              { type: "message-finish" },
+            ]),
+        });
+      },
+    };
+    const adapter = createHostedChatRuntimeAgentAdapter({
+      runtimeAgent,
+      runStream: async (operation) => {
+        runnerCalled = true;
+        return await operation();
+      },
+    });
+
+    const result = await adapter.stream({
+      messages: [
+        {
+          id: "user-message",
+          role: "user",
+          parts: [{ type: "text", text: "Hello" }],
+          timestamp: 1,
+        },
+      ],
+      abortSignal: abortController.signal,
+    });
+    const chunks = await collectChunks(
+      result.toUIMessageStream({ generateMessageId: () => "assistant-message" }),
+    );
+
+    assertEquals(runnerCalled, true);
+    assertEquals(capturedInput?.messages?.[0]?.id, "user-message");
+    assertEquals(capturedInput?.context?.abortSignal, abortController.signal);
+    assertEquals(chunks, [
+      { type: "start", messageId: "assistant-message" },
+      { type: "start-step" },
+      { type: "text-start", id: "assistant-message" },
+      { type: "text-delta", id: "assistant-message", delta: "Hello from adapter" },
+      { type: "finish-step" },
+      { type: "text-end", id: "assistant-message" },
+      { type: "finish", finishReason: "stop" },
+    ]);
+  });
+
+  it("bridges host-published tool data events into the UI message stream", async () => {
+    let capturedInput:
+      | Parameters<HostedChatRuntimeAgentAdapterInput["runtimeAgent"]["stream"]>[0]
+      | undefined;
+    let baseController: ReadableStreamDefaultController<Uint8Array> | null = null;
+    let resolveBaseReadStarted = () => {};
+    const baseReadStarted = new Promise<void>((resolve) => {
+      resolveBaseReadStarted = resolve;
+    });
+    const runtimeAgent: HostedChatRuntimeAgentAdapterInput["runtimeAgent"] = {
+      stream(input) {
+        capturedInput = input;
+        return Promise.resolve({
+          toDataStreamResponse: () =>
+            new Response(
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  baseController = controller;
+                },
+                pull() {
+                  resolveBaseReadStarted();
+                },
+              }),
+            ),
+        });
+      },
+    };
+    const adapter = createHostedChatRuntimeAgentAdapter({ runtimeAgent });
+
+    const result = await adapter.stream({
+      messages: [
+        {
+          id: "user-message",
+          role: "user",
+          parts: [{ type: "text", text: "Hello" }],
+          timestamp: 1,
+        },
+      ],
+      abortSignal: new AbortController().signal,
+    });
+    const chunksPromise = collectChunks(
+      result.toUIMessageStream({ generateMessageId: () => "assistant-message" }),
+    );
+    await baseReadStarted;
+
+    publishDataEventFrom(capturedInput, {
+      type: "tool-progress",
+      data: { step: 1 },
+      name: "tool-progress",
+      value: { step: 1 },
+    });
+    baseController?.enqueue(encoder.encode('data: {"type":"message-finish"}\n\n'));
+    baseController?.close();
+
+    assertEquals(await chunksPromise, [
+      { type: "start", messageId: "assistant-message" },
+      { type: "data-tool-progress", data: { step: 1 } },
+      { type: "finish", finishReason: "stop" },
+    ]);
+  });
+
+  it("reports orphaned tool input warnings with a bounded preview", async () => {
+    const warnings: Array<
+      { message: string; metadata: { toolCallId: string; inputPreview: string } }
+    > = [];
+    const runtimeAgent: HostedChatRuntimeAgentAdapterInput["runtimeAgent"] = {
+      stream() {
+        return Promise.resolve({
+          toDataStreamResponse: () =>
+            createSseResponse([
+              { type: "step-start" },
+              {
+                type: "tool-input-delta",
+                toolCallId: "tool-orphan",
+                inputTextDelta: "x".repeat(510),
+              },
+              { type: "message-finish" },
+            ]),
+        });
+      },
+    };
+    const adapter = createHostedChatRuntimeAgentAdapter({
+      runtimeAgent,
+      warnOrphanedToolInput: (message, metadata) => warnings.push({ message, metadata }),
+    });
+
+    await collectChunks(
+      (
+        await adapter.stream({
+          messages: [],
+          abortSignal: new AbortController().signal,
+        })
+      ).toUIMessageStream({ generateMessageId: () => "assistant-message" }),
+    );
+
+    assertEquals(warnings, [
+      {
+        message:
+          "Dropping orphan AG-UI runtime tool-input-delta stream without a matching lifecycle",
+        metadata: {
+          toolCallId: "tool-orphan",
+          inputPreview: `${"x".repeat(500)}...`,
+        },
+      },
+    ]);
+  });
+});

--- a/src/agent/hosted-chat-runtime-agent-adapter.ts
+++ b/src/agent/hosted-chat-runtime-agent-adapter.ts
@@ -1,0 +1,88 @@
+import type { ToolExecutionDataEvent } from "#veryfront/tool/types.ts";
+import { createChatUiMessageStreamFromDataStream } from "./chat-ui-message-stream.ts";
+import type {
+  HostedChatRuntimeAgent,
+  HostedChatRuntimeStreamResult,
+} from "./hosted-chat-runtime-contract.ts";
+import { createToolExecutionDataEventBridgeStream } from "./tool-execution-data-event-bridge.ts";
+import type { Agent } from "./types.ts";
+
+export type HostedChatRuntimeAgentAdapterRunner = <TResult>(
+  operation: () => Promise<TResult>,
+) => Promise<TResult>;
+
+export type HostedChatRuntimeAgentAdapterWarning = {
+  toolCallId: string;
+  inputPreview: string;
+};
+
+export type HostedChatRuntimeAgentAdapterInput = {
+  runtimeAgent: Pick<Agent, "stream">;
+  runStream?: HostedChatRuntimeAgentAdapterRunner;
+  warnOrphanedToolInput?: (
+    message: string,
+    metadata: HostedChatRuntimeAgentAdapterWarning,
+  ) => void;
+};
+
+function previewToolInput(inputText: string): string {
+  return inputText.length > 500 ? `${inputText.slice(0, 500)}...` : inputText;
+}
+
+export function createHostedChatRuntimeAgentAdapter(
+  input: HostedChatRuntimeAgentAdapterInput,
+): HostedChatRuntimeAgent {
+  const runStream = input.runStream ?? ((operation) => operation());
+
+  return {
+    stream: async (streamInput): Promise<HostedChatRuntimeStreamResult> => {
+      let publishDataEvent = (_event: ToolExecutionDataEvent) => {};
+      const response = await runStream(() =>
+        input.runtimeAgent.stream({
+          messages: streamInput.messages,
+          context: {
+            abortSignal: streamInput.abortSignal,
+            publishDataEvent: (event: ToolExecutionDataEvent) => publishDataEvent(event),
+          },
+        })
+      );
+
+      const streamResponse = response.toDataStreamResponse();
+      if (!streamResponse.body) {
+        throw new Error("Agent runtime returned an empty stream body");
+      }
+
+      const stream = createToolExecutionDataEventBridgeStream({
+        baseStream: streamResponse.body,
+        installPublisher: (nextPublishDataEvent) => {
+          publishDataEvent = nextPublishDataEvent;
+        },
+      });
+
+      return {
+        steps: Promise.resolve([]),
+        toUIMessageStream(options = {}) {
+          return createChatUiMessageStreamFromDataStream(
+            { stream },
+            {
+              generateMessageId: options.generateMessageId,
+              sendReasoning: options.sendReasoning,
+              onError: options.onError,
+              messageMetadata: options.messageMetadata,
+              onFinish: options.onFinish,
+              onOrphanedToolInput: ({ toolCallId, inputText }) => {
+                input.warnOrphanedToolInput?.(
+                  "Dropping orphan AG-UI runtime tool-input-delta stream without a matching lifecycle",
+                  {
+                    toolCallId,
+                    inputPreview: previewToolInput(inputText),
+                  },
+                );
+              },
+            },
+          );
+        },
+      };
+    },
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -251,6 +251,13 @@ export {
   buildFinalizedAgentRunTraceAttributes,
   buildInvokeAgentTraceAttributes,
 } from "./agent-trace-attributes.ts";
+export {
+  createHostedChatRuntimeAgentAdapter,
+  type HostedChatRuntimeAgentAdapterInput,
+  type HostedChatRuntimeAgentAdapterRunner,
+  type HostedChatRuntimeAgentAdapterWarning,
+} from "./hosted-chat-runtime-agent-adapter.ts";
+
 export type {
   HostedChatRuntimeAgent,
   HostedChatRuntimeCreationOptions,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.408";
+export const VERSION = "0.1.409";


### PR DESCRIPTION
## Summary
- add a reusable hosted chat runtime adapter for runtime agent data streams
- expose the adapter from the public agent surface
- bump package version to 0.1.409 for CI/CD publication

## Verification
- deno test --no-check --allow-all src/agent/hosted-chat-runtime-agent-adapter.test.ts
- deno check src/agent/index.ts
- deno task verify:quick
- pre-push checks: format, lint, typecheck, unit tests