### PR TITLE
Add latest conversation user message persistence helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.409",
+  "version": "0.1.410",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/conversation-bootstrap.test.ts
+++ b/src/agent/conversation-bootstrap.test.ts
@@ -6,7 +6,9 @@ import {
   createConversationRecord,
   ensureConversationProjectLink,
   fetchConversationRecord,
+  findLatestUserConversationMessageContext,
   persistConversationUserMessage,
+  persistLatestConversationUserMessage,
 } from "./conversation-bootstrap.ts";
 
 const API_URL = "https://api.example.com";
@@ -16,6 +18,7 @@ const CHILD_CONVERSATION_ID = "22222222-2222-4222-a222-222222222222";
 const MESSAGE_ID = "33333333-3333-4333-a333-333333333333";
 const USER_MESSAGE_ID = "33333333-3333-4333-a333-333333333334";
 const PARENT_MESSAGE_ID = "33333333-3333-4333-a333-333333333335";
+const SYSTEM_MESSAGE_ID = "33333333-3333-4333-a333-333333333336";
 const PROJECT_ID = "44444444-4444-4444-8444-444444444444";
 const BRANCH_ID = "55555555-5555-4555-8555-555555555555";
 const originalFetch = globalThis.fetch;
@@ -175,6 +178,88 @@ describe("agent/conversation-bootstrap", () => {
         }),
       Error,
       "CONVERSATION_USER_MESSAGE_REQUIRES_PERSISTABLE_PARTS",
+    );
+  });
+
+  it("finds the latest user message and visible non-system parent", () => {
+    const result = findLatestUserConversationMessageContext([
+      { id: SYSTEM_MESSAGE_ID, role: "system", parts: [{ type: "text", text: "system" }] },
+      { id: PARENT_MESSAGE_ID, role: "assistant", parts: [{ type: "text", text: "reply" }] },
+      { id: USER_MESSAGE_ID, role: "user", parts: [{ type: "text", text: "Hello" }] },
+    ]);
+
+    assertEquals(result.latestUserMessage?.id, USER_MESSAGE_ID);
+    assertEquals(result.visibleParentMessageId, PARENT_MESSAGE_ID);
+  });
+
+  it("does not use a system message as latest user message parent", () => {
+    const result = findLatestUserConversationMessageContext([
+      { id: SYSTEM_MESSAGE_ID, role: "system", parts: [{ type: "text", text: "system" }] },
+      { id: USER_MESSAGE_ID, role: "user", parts: [{ type: "text", text: "Hello" }] },
+    ]);
+
+    assertEquals(result.latestUserMessage?.id, USER_MESSAGE_ID);
+    assertEquals(result.visibleParentMessageId, undefined);
+  });
+
+  it("persists the latest conversation user message with a visible UUID parent", async () => {
+    let capturedInit: RequestInit | undefined;
+    stubFetchWithRecorder((_input, init) => {
+      capturedInit = init;
+      return jsonResponse({ id: MESSAGE_ID }, 201);
+    });
+
+    await persistLatestConversationUserMessage({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      enabled: true,
+      messages: [
+        { id: PARENT_MESSAGE_ID, role: "assistant", parts: [{ type: "text", text: "reply" }] },
+        { id: USER_MESSAGE_ID, role: "user", parts: [{ type: "text", text: "Hello" }] },
+      ],
+      operation: "Persist latest user message",
+    });
+
+    assertEquals(JSON.parse(String(capturedInit?.body)), {
+      role: "user",
+      parts: [{ type: "text", text: "Hello" }],
+      idempotency_key: USER_MESSAGE_ID,
+      parent_id: PARENT_MESSAGE_ID,
+    });
+  });
+
+  it("skips latest user message persistence when disabled", async () => {
+    globalThis.fetch = () => {
+      throw new Error("Unexpected fetch call");
+    };
+
+    await persistLatestConversationUserMessage({
+      authToken: AUTH_TOKEN,
+      apiUrl: API_URL,
+      conversationId: CONVERSATION_ID,
+      enabled: false,
+      messages: [{ id: USER_MESSAGE_ID, role: "user", parts: [{ type: "text", text: "Hello" }] }],
+    });
+  });
+
+  it("rejects latest user message persistence when no user message exists", async () => {
+    await assertRejects(
+      () =>
+        persistLatestConversationUserMessage({
+          authToken: AUTH_TOKEN,
+          apiUrl: API_URL,
+          conversationId: CONVERSATION_ID,
+          enabled: true,
+          messages: [{
+            id: SYSTEM_MESSAGE_ID,
+            role: "system",
+            parts: [{ type: "text", text: "system" }],
+          }],
+          missingUserMessageErrorMessage: "DURABLE_CHAT_ROOT_REQUIRES_USER_MESSAGE",
+        }),
+      Error,
+      "DURABLE_CHAT_ROOT_REQUIRES_USER_MESSAGE",
     );
   });
 

--- a/src/agent/conversation-bootstrap.ts
+++ b/src/agent/conversation-bootstrap.ts
@@ -199,6 +199,64 @@ export async function persistConversationUserMessage(input: {
   });
 }
 
+export function findLatestUserConversationMessageContext(messages: ChatUiMessage[]): {
+  latestUserMessage: ChatUiMessage | undefined;
+  visibleParentMessageId?: string;
+} {
+  const latestUserMessageIndex = messages.findLastIndex((message) => message.role === "user");
+  const latestUserMessage = latestUserMessageIndex >= 0
+    ? messages[latestUserMessageIndex]
+    : undefined;
+
+  if (latestUserMessageIndex >= 0) {
+    for (let index = latestUserMessageIndex - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (message && message.role !== "system") {
+        return {
+          latestUserMessage,
+          visibleParentMessageId: message.id,
+        };
+      }
+    }
+  }
+
+  return {
+    latestUserMessage,
+  };
+}
+
+export async function persistLatestConversationUserMessage(input: {
+  authToken: string;
+  apiUrl: string;
+  conversationId?: string;
+  messages: ChatUiMessage[];
+  enabled: boolean;
+  operation?: string;
+  missingUserMessageErrorMessage?: string;
+  onFailure?: (failure: PersistConversationUserMessageFailure) => void;
+}): Promise<void> {
+  if (!input.enabled || !input.conversationId) {
+    return;
+  }
+
+  const { latestUserMessage, visibleParentMessageId } = findLatestUserConversationMessageContext(
+    input.messages,
+  );
+  if (!latestUserMessage) {
+    throw new Error(input.missingUserMessageErrorMessage ?? "CONVERSATION_REQUIRES_USER_MESSAGE");
+  }
+
+  await persistConversationUserMessage({
+    authToken: input.authToken,
+    apiUrl: input.apiUrl,
+    conversationId: input.conversationId,
+    message: latestUserMessage,
+    operation: input.operation,
+    ...(isUuid(visibleParentMessageId) ? { parentMessageId: visibleParentMessageId } : {}),
+    ...(input.onFailure ? { onFailure: input.onFailure } : {}),
+  });
+}
+
 export interface BootstrapConversationAgentRunResult {
   conversation: ConversationRecord;
   message: ConversationMessageRecord;

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -481,8 +481,10 @@ export {
   createConversationRecord,
   ensureConversationProjectLink,
   fetchConversationRecord,
+  findLatestUserConversationMessageContext,
   persistConversationUserMessage,
   type PersistConversationUserMessageFailure,
+  persistLatestConversationUserMessage,
 } from "./conversation-bootstrap.ts";
 export {
   executeHostedDurableChildFork,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.409";
+export const VERSION = "0.1.410";


### PR DESCRIPTION
## Summary\n- add a reusable helper for resolving and persisting the latest conversation user message\n- keep system messages out of visible parent resolution\n- bump package version for CI/CD publish\n\n## Verification\n- deno test --no-check --allow-all src/agent/conversation-bootstrap.test.ts\n- deno check src/agent/index.ts\n- deno task verify:quick