### PR TITLE
Add hosted child invoke result builders

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.411",
+  "version": "0.1.412",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-durable-child-fork-execution.test.ts
+++ b/src/agent/hosted-durable-child-fork-execution.test.ts
@@ -1,7 +1,14 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
-import type { ChildRunExecutionResult } from "./child-run-execution-snapshot.ts";
 import {
+  buildChildRunExecutionSnapshot,
+  type ChildRunExecutionResult,
+} from "./child-run-execution-snapshot.ts";
+import type { ConversationRunTargets } from "./durable.ts";
+import {
+  buildHostedDurableChildInvokeFailureResult,
+  buildHostedDurableChildInvokeSuccessResult,
+  buildHostedDurableChildInvokeTerminalFailureResult,
   executeHostedDurableChildFork,
   type HostedDurableChildSetupFailure,
   type HostedDurableChildSuccess,
@@ -94,6 +101,87 @@ function baseSuccessResult(): ChildRunExecutionResult {
 describe("agent/hosted-durable-child-fork-execution", () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
+  });
+
+  it("builds standard hosted invoke failure, terminal failure, and success results", () => {
+    const identifiers = {
+      childConversationId: CHILD_CONVERSATION_ID,
+      childRunId: "run_child_1",
+      childMessageId: CHILD_MESSAGE_ID,
+      latestEventId: 7,
+      latestExternalEventSequence: 3,
+    };
+    const targets = {
+      sourceTargetKind: "preview_branch",
+      runtimeTargetKind: "preview_branch",
+      targetBranchId: BRANCH_ID,
+    } satisfies ConversationRunTargets;
+
+    assertEquals(
+      buildHostedDurableChildInvokeFailureResult({
+        terminalErrorCode: "SETUP_FAILED",
+        terminalErrorMessage: "setup failed",
+        targets,
+        childConversationId: CHILD_CONVERSATION_ID,
+      }),
+      {
+        ok: false,
+        status: "failed",
+        childConversationId: CHILD_CONVERSATION_ID,
+        sourceTargetKind: "preview_branch",
+        runtimeTargetKind: "preview_branch",
+        terminalErrorCode: "SETUP_FAILED",
+        terminalErrorMessage: "setup failed",
+      },
+    );
+
+    assertEquals(
+      buildHostedDurableChildInvokeTerminalFailureResult({
+        status: "failed",
+        identifiers,
+        targets,
+        terminalErrorCode: "INVOKE_AGENT_FAILED",
+        terminalErrorMessage: "child failed",
+      }),
+      {
+        ok: false,
+        status: "failed",
+        childConversationId: CHILD_CONVERSATION_ID,
+        childRunId: "run_child_1",
+        childMessageId: CHILD_MESSAGE_ID,
+        sourceTargetKind: "preview_branch",
+        runtimeTargetKind: "preview_branch",
+        terminalErrorCode: "INVOKE_AGENT_FAILED",
+        terminalErrorMessage: "child failed",
+      },
+    );
+
+    assertEquals(
+      buildHostedDurableChildInvokeSuccessResult({
+        result: baseSuccessResult(),
+        snapshot: buildChildRunExecutionSnapshot(baseSuccessResult()),
+        identifiers,
+        targets,
+      }),
+      {
+        ok: true,
+        status: "completed",
+        text: "Found logs",
+        summary: { text: "Found logs" },
+        steps: 2,
+        toolCalls: [],
+        toolResults: [],
+        usage: { inputTokens: 3, outputTokens: 4, totalTokens: 7 },
+        durationMs: 12,
+        childConversationId: CHILD_CONVERSATION_ID,
+        childRunId: "run_child_1",
+        childMessageId: CHILD_MESSAGE_ID,
+        sourceTargetKind: "preview_branch",
+        runtimeTargetKind: "preview_branch",
+        terminalErrorCode: null,
+        terminalErrorMessage: null,
+      },
+    );
   });
 
   it("returns a host-shaped context-unavailable result without bootstrapping", async () => {

--- a/src/agent/hosted-durable-child-fork-execution.ts
+++ b/src/agent/hosted-durable-child-fork-execution.ts
@@ -2,6 +2,7 @@ import type {
   ChildRunExecutionResult,
   ChildRunExecutionSnapshot,
 } from "./child-run-execution-snapshot.ts";
+import { buildChildRunResultSummary } from "./child-run-result-summary.ts";
 import { type ConversationRunTargets, resolveConversationRunTargets } from "./durable.ts";
 import { createConversationChildLifecycleAdapter } from "./conversation-hosted-lifecycle.ts";
 import type { InvokeAgentChildRunProgressEvent } from "./invoke-agent-child-runs.ts";
@@ -20,6 +21,35 @@ import { throwIfChildRunAborted } from "./child-run-execution-support.ts";
 
 export type HostedDurableChildExecutionOptions = {
   durableChildRun?: HostedChildRunIdentifiers;
+};
+
+export type HostedDurableChildInvokeResult = {
+  ok: boolean;
+  status: "completed" | "failed";
+  text?: string;
+  error?: string;
+  summary?: { text: string };
+  steps?: number;
+  toolCalls?: ChildRunExecutionSnapshot["toolCalls"];
+  toolResults?: ChildRunExecutionSnapshot["toolResults"];
+  usage?: ChildRunExecutionSnapshot["usage"];
+  durationMs?: ChildRunExecutionSnapshot["durationMs"];
+  childConversationId?: string | null;
+  childRunId?: string | null;
+  childMessageId?: string | null;
+  sourceTargetKind?: ConversationRunTargets["sourceTargetKind"];
+  runtimeTargetKind?: ConversationRunTargets["runtimeTargetKind"];
+  terminalErrorCode: string | null;
+  terminalErrorMessage: string | null;
+};
+
+export type BuildHostedDurableChildInvokeFailureResultInput = {
+  terminalErrorCode: string;
+  terminalErrorMessage: string;
+  targets?: ConversationRunTargets;
+  childConversationId?: string | null;
+  childRunId?: string | null;
+  childMessageId?: string | null;
 };
 
 export type HostedDurableChildSuccess<TLocalResult extends ChildRunExecutionResult> = {
@@ -45,6 +75,70 @@ export type HostedDurableChildSetupFailure = {
   terminalErrorCode: string;
   terminalErrorMessage: string;
 };
+
+export function buildHostedDurableChildInvokeFailureResult(
+  input: BuildHostedDurableChildInvokeFailureResultInput,
+): HostedDurableChildInvokeResult {
+  return {
+    ok: false,
+    status: "failed",
+    ...(input.childConversationId ? { childConversationId: input.childConversationId } : {}),
+    ...(input.childRunId ? { childRunId: input.childRunId } : {}),
+    ...(input.childMessageId ? { childMessageId: input.childMessageId } : {}),
+    ...(input.targets
+      ? {
+        sourceTargetKind: input.targets.sourceTargetKind,
+        runtimeTargetKind: input.targets.runtimeTargetKind,
+      }
+      : {}),
+    terminalErrorCode: input.terminalErrorCode,
+    terminalErrorMessage: input.terminalErrorMessage,
+  };
+}
+
+export function buildHostedDurableChildInvokeTerminalFailureResult(
+  input: HostedDurableChildTerminalFailure,
+): HostedDurableChildInvokeResult {
+  return buildHostedDurableChildInvokeFailureResult({
+    terminalErrorCode: input.terminalErrorCode,
+    terminalErrorMessage: input.terminalErrorMessage,
+    targets: input.targets,
+    childConversationId: input.identifiers.childConversationId,
+    childRunId: input.identifiers.childRunId,
+    childMessageId: input.identifiers.childMessageId,
+  });
+}
+
+export function buildHostedDurableChildInvokeSuccessResult<
+  TLocalResult extends ChildRunExecutionResult,
+>(input: HostedDurableChildSuccess<TLocalResult>): HostedDurableChildInvokeResult {
+  const summaryText = input.snapshot.fullResultText ??
+    (input.result.success ? input.result.summary.text : input.result.error);
+
+  return {
+    ok: input.snapshot.success,
+    status: input.snapshot.success ? "completed" : "failed",
+    ...(summaryText
+      ? {
+        text: summaryText,
+        summary: buildChildRunResultSummary(summaryText),
+      }
+      : {}),
+    ...(input.snapshot.success ? {} : { error: input.snapshot.error ?? "invoke_agent failed" }),
+    steps: input.snapshot.steps,
+    toolCalls: input.snapshot.toolCalls,
+    toolResults: input.snapshot.toolResults,
+    usage: input.snapshot.usage,
+    durationMs: input.snapshot.durationMs,
+    childConversationId: input.identifiers.childConversationId,
+    childRunId: input.identifiers.childRunId,
+    childMessageId: input.identifiers.childMessageId,
+    sourceTargetKind: input.targets.sourceTargetKind,
+    runtimeTargetKind: input.targets.runtimeTargetKind,
+    terminalErrorCode: input.snapshot.success ? null : "INVOKE_AGENT_FAILED",
+    terminalErrorMessage: input.snapshot.success ? null : input.snapshot.error,
+  };
+}
 
 export type HostedDurableChildBootstrapContext = {
   parentConversationId: string;

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -487,11 +487,16 @@ export {
   persistLatestConversationUserMessage,
 } from "./conversation-bootstrap.ts";
 export {
+  buildHostedDurableChildInvokeFailureResult,
+  type BuildHostedDurableChildInvokeFailureResultInput,
+  buildHostedDurableChildInvokeSuccessResult,
+  buildHostedDurableChildInvokeTerminalFailureResult,
   executeHostedDurableChildFork,
   type ExecuteHostedDurableChildForkInput,
   type HostedDurableChildBootstrapCallbacks,
   type HostedDurableChildBootstrapContext,
   type HostedDurableChildExecutionOptions,
+  type HostedDurableChildInvokeResult,
   type HostedDurableChildRuntimeDependencies,
   type HostedDurableChildSetupFailure,
   type HostedDurableChildSuccess,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.411";
+export const VERSION = "0.1.412";


### PR DESCRIPTION
## Summary\n- add standard hosted child invoke result builders for context/setup/terminal/success mappings\n- export the reusable result type and builder helpers from the agent package\n- bump package version to 0.1.412 for CI/CD publication\n\n## Verification\n- deno test --no-check --allow-all src/agent/hosted-durable-child-fork-execution.test.ts\n- deno check src/agent/index.ts\n- deno task verify:quick