### PR TITLE
fix(agent): preserve attachment context in text-generation prompts

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.426",
+  "version": "0.1.427",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/agent-runtime-message-adapter.test.ts
+++ b/src/agent/agent-runtime-message-adapter.test.ts
@@ -151,10 +151,88 @@ describe("agent runtime message adapter", () => {
       }),
     ]);
 
-    assertEquals(agentRuntimeMessages[0]?.parts, [
-      { type: "image", url: "https://uploads.example.com/diagram.png", mediaType: "image/png" },
-      { type: "file", url: "https://uploads.example.com/spec.pdf", mediaType: "application/pdf" },
+    const parts = agentRuntimeMessages[0]?.parts ?? [];
+    assertEquals(
+      parts.some((part) =>
+        part.type === "image" &&
+        "url" in part &&
+        part.url === "https://uploads.example.com/diagram.png" &&
+        part.mediaType === "image/png"
+      ),
+      true,
+    );
+    assertEquals(
+      parts.some((part) =>
+        part.type === "file" &&
+        "url" in part &&
+        part.url === "https://uploads.example.com/spec.pdf" &&
+        part.mediaType === "application/pdf"
+      ),
+      true,
+    );
+  });
+
+  it("keeps user attachments visible as text context when native file parts are emitted", () => {
+    const agentRuntimeMessages = convertProviderMessagesToAgentRuntimeMessages([
+      providerMessage({
+        role: "user",
+        content: [
+          { type: "text", text: "Sent with attachments" },
+          {
+            type: "file",
+            data: "https://signed.example.com/invoice.pdf",
+            url: "https://signed.example.com/invoice.pdf",
+            mediaType: "application/pdf",
+            filename: "sample-attachment.pdf",
+            uploadId: "test-upload-id",
+            uploadPath: "_chat/test-user-id/test-upload-sample-attachment.pdf",
+          },
+        ],
+      }),
     ]);
+
+    const parts = agentRuntimeMessages[0]?.parts ?? [];
+    assertEquals(parts.some((part) => part.type === "file"), true);
+
+    const text = parts
+      .flatMap((part) => part.type === "text" && "text" in part ? [part.text] : [])
+      .join("\n");
+
+    assertStringIncludes(text, "Sent with attachments");
+    assertStringIncludes(text, "<uploaded_files>");
+    assertStringIncludes(text, "sample-attachment.pdf");
+    assertStringIncludes(text, "test-upload-id");
+    assertStringIncludes(text, "application/pdf");
+  });
+
+  it("does not append a second uploaded files annotation during provider round trips", () => {
+    const agentRuntimeMessages = convertProviderMessagesToAgentRuntimeMessages([
+      providerMessage({
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text:
+              'Sent with attachments\n<uploaded_files>[{"name":"sample-attachment.pdf","mediaType":"application/pdf","uploadId":"test-upload-id"}]</uploaded_files>',
+          },
+          {
+            type: "file",
+            data: "https://signed.example.com/invoice.pdf",
+            url: "https://signed.example.com/invoice.pdf",
+            mediaType: "application/pdf",
+            filename: "sample-attachment.pdf",
+            uploadId: "test-upload-id",
+            uploadPath: "_chat/test-user-id/test-upload-sample-attachment.pdf",
+          },
+        ],
+      }),
+    ]);
+
+    const textParts = (agentRuntimeMessages[0]?.parts ?? [])
+      .flatMap((part) => part.type === "text" && "text" in part ? [part.text] : []);
+
+    assertEquals(textParts.length, 1);
+    assertEquals(textParts.join("\n").split("<uploaded_files>").length - 1, 1);
   });
 
   it("falls back to annotation for multimodal parts without a URL", () => {

--- a/src/agent/agent-runtime-message-adapter.ts
+++ b/src/agent/agent-runtime-message-adapter.ts
@@ -202,6 +202,10 @@ function buildAttachmentContextPart(
   };
 }
 
+function hasUploadedFilesAnnotation(parts: StructuredProviderPart[]): boolean {
+  return parts.some((part) => part.type === "text" && part.text.includes("<uploaded_files>"));
+}
+
 function convertContentToAgentRuntimeParts(
   message: ProviderModelMessage,
 ): AgentRuntimeMessage["parts"] {
@@ -217,7 +221,6 @@ function convertContentToAgentRuntimeParts(
     const convertedPart = convertStructuredPart(part);
     if (convertedPart) {
       parts.push(convertedPart);
-      continue;
     }
 
     if (part.type === "image" || part.type === "file") {
@@ -229,7 +232,9 @@ function convertContentToAgentRuntimeParts(
     }
   }
 
-  const attachmentContextPart = buildAttachmentContextPart(attachmentReferences);
+  const attachmentContextPart = hasUploadedFilesAnnotation(message.content)
+    ? null
+    : buildAttachmentContextPart(attachmentReferences);
   if (attachmentContextPart) {
     parts.push(attachmentContextPart);
   }

--- a/src/agent/runtime-message-preparation.test.ts
+++ b/src/agent/runtime-message-preparation.test.ts
@@ -1,6 +1,13 @@
-import { assertEquals } from "../testing/assert.ts";
+import { assertEquals, assertStringIncludes } from "../testing/assert.ts";
 import type { ChatUiMessage } from "../chat/types.ts";
+import { generateText } from "../runtime/runtime-bridge.ts";
+import { createGenerateModel } from "../runtime/runtime-bridge.test-helpers.ts";
+import { convertToTextGenerationRuntimeMessages } from "./runtime/text-generation-runtime-message-converter.ts";
 import { prepareAgentRuntimeMessagesFromUiMessages } from "./runtime-message-preparation.ts";
+
+function countOccurrences(value: string, pattern: string): number {
+  return value.split(pattern).length - 1;
+}
 
 function userMessage(parts: ChatUiMessage["parts"]): ChatUiMessage {
   return {
@@ -42,10 +49,24 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages refreshes upload file URLs 
   });
 
   assertEquals(resolvedUploadIds, ["upload-1"]);
-  assertEquals(messages[0]?.parts, [
-    { type: "text", text: "Use these files." },
-    { type: "file", url: "https://signed.example.com/file.txt", mediaType: "text/plain" },
-  ]);
+  const parts = messages[0]?.parts ?? [];
+  assertEquals(
+    parts.some((part) =>
+      part.type === "file" &&
+      "url" in part &&
+      part.url === "https://signed.example.com/file.txt" &&
+      part.mediaType === "text/plain"
+    ),
+    true,
+  );
+
+  const text = parts.flatMap((part) => part.type === "text" && "text" in part ? [part.text] : [])
+    .join("\n");
+  assertStringIncludes(text, "Use these files.");
+  assertStringIncludes(text, "<uploaded_files>");
+  assertStringIncludes(text, "notes.txt");
+  assertStringIncludes(text, "upload-1");
+  assertStringIncludes(text, "https://signed.example.com/file.txt");
 });
 
 Deno.test("prepareAgentRuntimeMessagesFromUiMessages keeps original URL when resolver returns undefined", async () => {
@@ -65,8 +86,119 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages keeps original URL when res
     resolveFileUrl: async () => undefined,
   });
 
-  assertEquals(messages[0]?.parts, [
-    { type: "text", text: "Check this image." },
-    { type: "file", url: "https://files.example.com/photo.png", mediaType: "image/png" },
-  ]);
+  const parts = messages[0]?.parts ?? [];
+  assertEquals(
+    parts.some((part) =>
+      part.type === "file" &&
+      "url" in part &&
+      part.url === "https://files.example.com/photo.png" &&
+      part.mediaType === "image/png"
+    ),
+    true,
+  );
+
+  const text = parts.flatMap((part) => part.type === "text" && "text" in part ? [part.text] : [])
+    .join("\n");
+  assertStringIncludes(text, "Check this image.");
+  assertStringIncludes(text, "<uploaded_files>");
+  assertStringIncludes(text, "photo.png");
+  assertStringIncludes(text, "upload-2");
+});
+
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages keeps a synthetic PDF visible through text-generation conversion", async () => {
+  const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+    messages: [
+      userMessage([
+        { type: "text", text: "Sent with attachments" },
+        {
+          type: "file",
+          mediaType: "application/pdf",
+          filename: "sample-attachment.pdf",
+          uploadId: "test-upload-id",
+          uploadPath: "_chat/test-user-id/test-upload-sample-attachment.pdf",
+          url: "/api/projects/test-project-id/uploads/test-upload-id",
+        },
+      ]),
+    ],
+    resolveFileUrl: async () => "https://signed.example.com/invoice.pdf",
+  });
+
+  const runtimeMessages = convertToTextGenerationRuntimeMessages(messages);
+
+  assertEquals(runtimeMessages[0]?.role, "user");
+  const content = runtimeMessages[0]?.content;
+  if (typeof content !== "string") {
+    throw new Error("Expected text-generation runtime user content to be a string");
+  }
+
+  assertStringIncludes(content, "Sent with attachments");
+  assertStringIncludes(content, "<uploaded_files>");
+  assertStringIncludes(content, "sample-attachment.pdf");
+  assertStringIncludes(content, "test-upload-id");
+  assertStringIncludes(content, "application/pdf");
+  assertStringIncludes(content, "https://signed.example.com/invoice.pdf");
+  assertEquals(countOccurrences(content, "<uploaded_files>"), 1);
+});
+
+Deno.test("chat attachment preparation keeps a synthetic PDF visible in the model prompt", async () => {
+  const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+    messages: [
+      userMessage([
+        { type: "text", text: "Sent with attachments" },
+        {
+          type: "file",
+          mediaType: "application/pdf",
+          filename: "sample-attachment.pdf",
+          uploadId: "test-upload-id",
+          uploadPath: "_chat/test-user-id/test-upload-sample-attachment.pdf",
+          url: "/api/projects/test-project-id/uploads/test-upload-id",
+        },
+      ]),
+    ],
+    resolveFileUrl: async () => "https://signed.example.com/invoice.pdf",
+  });
+  const runtimeMessages = convertToTextGenerationRuntimeMessages(messages);
+  let sawPrompt = false;
+  const model = createGenerateModel("test", "test/attachment-e2e", async (options) => {
+    sawPrompt = true;
+    const prompt = options.prompt;
+    assertEquals(prompt.length, 1);
+    const firstMessage = prompt[0];
+    if (
+      !firstMessage ||
+      typeof firstMessage !== "object" ||
+      !("role" in firstMessage) ||
+      firstMessage.role !== "user" ||
+      !("content" in firstMessage) ||
+      !Array.isArray(firstMessage.content)
+    ) {
+      throw new Error("Expected a user prompt with text content parts");
+    }
+
+    const text = firstMessage.content
+      .flatMap((part) =>
+        part && typeof part === "object" && "type" in part && part.type === "text" &&
+          "text" in part && typeof part.text === "string"
+          ? [part.text]
+          : []
+      )
+      .join("\n");
+
+    assertStringIncludes(text, "Sent with attachments");
+    assertStringIncludes(text, "<uploaded_files>");
+    assertStringIncludes(text, "sample-attachment.pdf");
+    assertStringIncludes(text, "test-upload-id");
+    assertStringIncludes(text, "https://signed.example.com/invoice.pdf");
+    assertEquals(countOccurrences(text, "<uploaded_files>"), 1);
+
+    return {
+      content: [{ type: "text", text: "I can see sample-attachment.pdf." }],
+      finishReason: { unified: "stop", raw: "stop" },
+    };
+  });
+
+  const result = await generateText({ model, messages: runtimeMessages });
+
+  assertEquals(sawPrompt, true);
+  assertEquals(result.text, "I can see sample-attachment.pdf.");
 });

--- a/src/agent/runtime/text-generation-runtime-message-converter.test.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   convertToTextGenerationRuntimeMessage,
@@ -43,6 +43,81 @@ describe("text-generation-runtime-message-converter", () => {
       };
       const result = convertToTextGenerationRuntimeMessage(msg);
       assertEquals(result, { role: "user", content: "Hello world" });
+    });
+
+    it("preserves user file parts as provider-visible attachment context", () => {
+      const msg = {
+        id: "u-file",
+        role: "user",
+        parts: [
+          { type: "text", text: "Sent with attachments" },
+          {
+            type: "file",
+            url: "https://signed.example.com/invoice.pdf",
+            mediaType: "application/pdf",
+            filename: "sample-attachment.pdf",
+            uploadId: "test-upload-id",
+            uploadPath: "_chat/test-user-id/test-upload-sample-attachment.pdf",
+          },
+        ],
+      } as unknown as Message;
+
+      const result = convertToTextGenerationRuntimeMessage(msg);
+
+      assertEquals(result.role, "user");
+      if (typeof result.content !== "string") {
+        throw new Error("Expected user content to be text fallback for current runtime");
+      }
+      assertStringIncludes(result.content, "Sent with attachments");
+      assertStringIncludes(result.content, "<uploaded_files>");
+      assertStringIncludes(result.content, "sample-attachment.pdf");
+      assertStringIncludes(result.content, "test-upload-id");
+      assertStringIncludes(result.content, "application/pdf");
+    });
+
+    it("separates user text from attachment context with a readable blank line", () => {
+      const msg = {
+        id: "u-file-spacing",
+        role: "user",
+        parts: [
+          { type: "text", text: "Sent with attachments" },
+          {
+            type: "file",
+            url: "https://signed.example.com/invoice.pdf",
+            mediaType: "application/pdf",
+            filename: "sample-attachment.pdf",
+          },
+        ],
+      } as unknown as Message;
+
+      const result = convertToTextGenerationRuntimeMessage(msg);
+
+      if (typeof result.content !== "string") {
+        throw new Error("Expected user content to be text fallback for current runtime");
+      }
+      assertStringIncludes(result.content, "Sent with attachments\n\n<uploaded_files>");
+    });
+
+    it("does not start file-only user attachment context with blank lines", () => {
+      const msg = {
+        id: "u-file-only",
+        role: "user",
+        parts: [
+          {
+            type: "file",
+            url: "https://signed.example.com/invoice.pdf",
+            mediaType: "application/pdf",
+            filename: "sample-attachment.pdf",
+          },
+        ],
+      } as unknown as Message;
+
+      const result = convertToTextGenerationRuntimeMessage(msg);
+
+      if (typeof result.content !== "string") {
+        throw new Error("Expected user content to be text fallback for current runtime");
+      }
+      assertEquals(result.content.startsWith("<uploaded_files>"), true);
     });
 
     it("converts an assistant message with text", () => {

--- a/src/agent/runtime/text-generation-runtime-message-converter.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.ts
@@ -14,6 +14,7 @@ import type {
   TextGenerationRuntimeToolCallPart,
   TextGenerationRuntimeToolMessage,
 } from "./text-generation-runtime-message-types.ts";
+import { buildDataFileAnnotation } from "#veryfront/chat/types.ts";
 import {
   getTextFromParts,
   getToolArguments,
@@ -21,6 +22,58 @@ import {
   type ToolCallPart,
   type ToolResultPart,
 } from "../types.ts";
+
+function getStringPartField(part: unknown, key: string): string | undefined {
+  if (!part || typeof part !== "object" || Array.isArray(part)) return undefined;
+
+  const value = (part as Record<string, unknown>)[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function buildAttachmentContextFromParts(parts: Message["parts"]): string {
+  const refs = parts.flatMap((part) => {
+    const type = getStringPartField(part, "type");
+    if (type !== "file" && type !== "image") return [];
+
+    const mediaType = getStringPartField(part, "mediaType");
+    if (!mediaType) return [];
+
+    const uploadId = getStringPartField(part, "uploadId");
+    const uploadPath = getStringPartField(part, "uploadPath");
+    const url = getStringPartField(part, "url");
+
+    return [{
+      name: getStringPartField(part, "filename") ?? (type === "image" ? "image" : "file"),
+      mediaType,
+      ...(uploadId ? { uploadId } : {}),
+      ...(uploadPath ? { path: uploadPath } : {}),
+      ...(url ? { url } : {}),
+    }];
+  });
+
+  return refs.length > 0 ? buildDataFileAnnotation(refs) : "";
+}
+
+function appendReadableAttachmentContext(text: string, attachmentContext: string): string {
+  const normalizedContext = attachmentContext.trimStart();
+  if (!normalizedContext) {
+    return text;
+  }
+
+  if (text.length === 0) {
+    return normalizedContext;
+  }
+
+  const separator = text.endsWith("\n\n") ? "" : text.endsWith("\n") ? "\n" : "\n\n";
+  return `${text}${separator}${normalizedContext}`;
+}
+
+function getUserTextWithAttachmentContext(parts: Message["parts"]): string {
+  const text = getTextFromParts(parts);
+  return text.includes("<uploaded_files>")
+    ? text
+    : appendReadableAttachmentContext(text, buildAttachmentContextFromParts(parts));
+}
 
 /**
  * Convert a veryfront Message to the current text-generation runtime message format.
@@ -33,7 +86,7 @@ export function convertToTextGenerationRuntimeMessage(msg: Message): TextGenerat
     }
 
     case "user": {
-      const text = getTextFromParts(msg.parts);
+      const text = getUserTextWithAttachmentContext(msg.parts);
       return { role: "user", content: text };
     }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.426";
+export const VERSION = "0.1.427";


### PR DESCRIPTION
## Summary

- Preserve native user `image`/`file` parts while also adding provider-visible uploaded-file text context.
- Ensure text-generation conversion includes `<uploaded_files>` metadata for native attachments instead of dropping them.
- Avoid duplicate `<uploaded_files>` annotations during provider round trips.
- Keep attachment annotations readable: separated from user text by a blank line, without leading blank lines for file-only prompts.
- Add regression coverage for the synthetic PDF path through message preparation, text-generation conversion, and a fake model prompt.
- Bump package version from `0.1.426` to `0.1.427` in `deno.json` and `src/utils/version-constant.ts`.

Addresses https://github.com/veryfront/veryfront-studio/issues/3510 and the upstream attachment-context portion of https://github.com/veryfront/veryfront-studio/issues/3499.

## Why this is needed

#1469 preserved native file/image parts through the AgentRuntimeMessage pipeline, but the text-generation runtime path still needed provider-visible attachment context. Without that context, the model can respond as if no attachment was present even though the persisted chat message contains a file part.

## Regression coverage

- Runtime message preparation keeps signed PDF metadata visible.
- Text-generation conversion includes one readable `<uploaded_files>` annotation.
- File-only prompts do not start with leading blank lines.
- Provider round trips do not duplicate existing attachment annotations.
- Fake model prompt test proves the final model-facing prompt contains the uploaded PDF metadata.

## Test plan

- [x] `deno fmt --check deno.json src/utils/version-constant.ts src/agent/agent-runtime-message-adapter.ts src/agent/agent-runtime-message-adapter.test.ts src/agent/runtime-message-preparation.test.ts src/agent/runtime/text-generation-runtime-message-converter.ts src/agent/runtime/text-generation-runtime-message-converter.test.ts`
- [x] `DENO_NO_PACKAGE_JSON=1 deno lint src/utils/version-constant.ts src/agent/agent-runtime-message-adapter.ts src/agent/agent-runtime-message-adapter.test.ts src/agent/runtime-message-preparation.test.ts src/agent/runtime/text-generation-runtime-message-converter.ts src/agent/runtime/text-generation-runtime-message-converter.test.ts`
- [x] `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/agent/agent-runtime-message-adapter.test.ts src/agent/runtime-message-preparation.test.ts src/agent/runtime/text-generation-runtime-message-converter.test.ts` — 7 passed / 31 steps / 0 failed
- [x] `deno check src/agent/agent-runtime-message-adapter.ts src/agent/runtime-message-preparation.ts src/agent/runtime/text-generation-runtime-message-converter.ts`

## Follow-up required after merge

After this package version is published, `veryfront-agent` needs a dependency-only PR bumping `veryfront` to the published version containing this change, followed by staging rollout and end-to-end attachment retest.
