### PR TITLE
Fail hosted runs on stream errors after partial output

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.412",
+  "version": "0.1.413",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-stream-finalization.test.ts
+++ b/src/agent/hosted-stream-finalization.test.ts
@@ -75,6 +75,50 @@ describe("agent/hosted-stream-finalization", () => {
     assertEquals(calls, ["flush", "dispatch:failed:EMPTY_RESPONSE", "cleanup"]);
   });
 
+  it("fails hosted responses with content when the stream recorded an error", async () => {
+    const calls: string[] = [];
+
+    await finalizeHostedResponse({
+      isAborted: false,
+      streamError: new Error("insufficient credits"),
+      getFinalStep: async () => ({ step: 1 }),
+      buildState: async () => ({
+        persistedMessage: { id: "msg-1" },
+        finalizedMessage: { id: "msg-1", parts: ["tool-result"] },
+        fallbackChunks: ["chunk-1"],
+        hasIncompleteToolParts: false,
+        metadata: { modelId: "openai/gpt-5.4" },
+      }),
+      shouldFailEmptyMessage: () => false,
+      resolveEmptyTerminalError: ({ streamError }) => ({
+        code: "STREAM_ERROR",
+        message: streamError instanceof Error ? streamError.message : String(streamError),
+      }),
+      appendFallbackChunk: async (chunk) => {
+        calls.push(`append:${chunk}`);
+      },
+      flushMirror: async () => {
+        calls.push("flush");
+      },
+      dispatchTerminalState: async (state) => {
+        calls.push(
+          `dispatch:${state.status}:${state.terminalErrorCode}:${state.metadata?.modelId}`,
+        );
+      },
+      resolveTerminalState: () => ({ status: "completed" }),
+      cleanup: async () => {
+        calls.push("cleanup");
+      },
+    });
+
+    assertEquals(calls, [
+      "append:chunk-1",
+      "flush",
+      "dispatch:failed:STREAM_ERROR:openai/gpt-5.4",
+      "cleanup",
+    ]);
+  });
+
   it("finalizes hosted detached streams through detached fallback state", async () => {
     const calls: string[] = [];
 
@@ -106,6 +150,48 @@ describe("agent/hosted-stream-finalization", () => {
     });
 
     assertEquals(calls, ["append:tool-1", "flush", "dispatch:failed", "cleanup"]);
+  });
+
+  it("fails hosted detached streams with content when the stream recorded an error", async () => {
+    const calls: string[] = [];
+
+    await finalizeHostedDetached({
+      isAborted: false,
+      mirroredDurableOutput: true,
+      streamError: new Error("insufficient credits"),
+      getFinalStep: async () => ({ step: 1 }),
+      buildState: async () => ({
+        hasContent: true,
+        fallbackChunks: ["tool-1"],
+        hasIncompleteToolParts: false,
+      }),
+      resolveEmptyTerminalError: ({ streamError }) => ({
+        code: "STREAM_ERROR",
+        message: streamError instanceof Error ? streamError.message : String(streamError),
+      }),
+      appendFallbackChunk: async (chunk) => {
+        calls.push(`append:${chunk}`);
+      },
+      flushMirror: async () => {
+        calls.push("flush");
+      },
+      dispatchTerminalState: async (state) => {
+        calls.push(
+          `dispatch:${state.status}:${state.terminalErrorCode}:${state.terminalErrorMessage}`,
+        );
+      },
+      resolveTerminalState: () => ({ status: "completed" }),
+      cleanup: async () => {
+        calls.push("cleanup");
+      },
+    });
+
+    assertEquals(calls, [
+      "append:tool-1",
+      "flush",
+      "dispatch:failed:STREAM_ERROR:insufficient credits",
+      "cleanup",
+    ]);
   });
 
   it("propagates cleanup errors after dispatching terminal state", async () => {

--- a/src/agent/hosted-stream-finalization.ts
+++ b/src/agent/hosted-stream-finalization.ts
@@ -76,6 +76,12 @@ async function cleanupAfterFinalization(cleanup: () => Promise<void> | void): Pr
   await cleanup();
 }
 
+function shouldFailStreamError(
+  input: { isAborted: boolean; streamError?: unknown | null },
+): boolean {
+  return !input.isAborted && input.streamError != null;
+}
+
 export async function finalizeHostedResponse<TMessage, TChunk>(
   options: FinalizeHostedResponseOptions<TMessage, TChunk>,
 ): Promise<void> {
@@ -106,6 +112,22 @@ export async function finalizeHostedResponse<TMessage, TChunk>(
 
   await appendFallbackChunks(state.fallbackChunks, options.appendFallbackChunk);
   await options.flushMirror();
+  if (shouldFailStreamError({ isAborted: options.isAborted, streamError: options.streamError })) {
+    const terminalError = await options.resolveEmptyTerminalError({
+      finalStep,
+      streamError: options.streamError,
+    });
+
+    await options.dispatchTerminalState({
+      status: "failed",
+      metadata: state.metadata,
+      terminalErrorCode: terminalError.code,
+      terminalErrorMessage: terminalError.message,
+    });
+    await cleanupAfterFinalization(options.cleanup);
+    return;
+  }
+
   const terminalState = options.resolveTerminalState({
     isAborted: options.isAborted,
     hasIncompleteToolParts: state.hasIncompleteToolParts,
@@ -141,6 +163,21 @@ export async function finalizeHostedDetached<TChunk>(
 
   await appendFallbackChunks(state.fallbackChunks, options.appendFallbackChunk);
   await options.flushMirror();
+  if (shouldFailStreamError({ isAborted: options.isAborted, streamError: options.streamError })) {
+    const terminalError = await options.resolveEmptyTerminalError({
+      finalStep,
+      streamError: options.streamError,
+    });
+
+    await options.dispatchTerminalState({
+      status: "failed",
+      terminalErrorCode: terminalError.code,
+      terminalErrorMessage: terminalError.message,
+    });
+    await cleanupAfterFinalization(options.cleanup);
+    return;
+  }
+
   await options.dispatchTerminalState(
     options.resolveTerminalState({
       isAborted: options.isAborted,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.412";
+export const VERSION = "0.1.413";


### PR DESCRIPTION
## Summary
- make hosted response and detached finalization fail when a non-aborted stream error is recorded, even after fallback chunks or tool results were mirrored
- add regression coverage for stream errors that arrive after content exists
- bump veryfront to 0.1.413 for release

## Why
The staging /plan canary produced partial assistant content (reasoning + load_skill tool result) and then stopped without a final answer. Because the finalizer treated non-empty mirrored content as completed, the run was persisted as completed instead of failed. This change makes stream errors terminally authoritative while preserving fallback chunk mirroring before the terminal state is dispatched.

## Test evidence
- deno fmt --check deno.json src/utils/version-constant.ts src/agent/hosted-stream-finalization.ts src/agent/hosted-stream-finalization.test.ts
- deno lint src/agent/hosted-stream-finalization.ts src/agent/hosted-stream-finalization.test.ts
- deno test --no-check --allow-all --parallel src/agent/hosted-stream-finalization.test.ts
- deno test --no-check --allow-all --parallel src/agent/hosted-stream-finalization.test.ts src/agent/hosted-lifecycle.test.ts src/agent/hosted-child-lifecycle.test.ts
- deno test --no-check --allow-all --parallel src/agent
- deno test --no-check --allow-all --parallel src/utils/version.test.ts src/utils/logger/logger.test.ts src/agent/hosted-stream-finalization.test.ts
- deno task test:unit --no-lock
- pre-push hook: format, lint, typecheck, unit tests

## Staging note
A full post-release staging canary is still blocked by insufficient staging AI credits. Once this release is consumed by veryfront-agent and staging has credits, rerun the durable canary.