### PR TITLE
Add hosted conversation run mirror helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.412",
+  "version": "0.1.413",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/conversation-run-chunk-mirror.test.ts
+++ b/src/agent/conversation-run-chunk-mirror.test.ts
@@ -7,7 +7,11 @@ import type {
   ConversationRunEventQueueSnapshot,
 } from "./durable.ts";
 import type { ConversationRunEvent } from "./conversation-run-events.ts";
-import { createConversationRunChunkMirror } from "./conversation-run-chunk-mirror.ts";
+import {
+  createConversationRunChunkMirror,
+  createHostedConversationRunChunkMirror,
+  type HostedConversationRunChunkMirrorTraceAttributes,
+} from "./conversation-run-chunk-mirror.ts";
 
 function createQueueController(): ConversationRunEventQueueController & {
   enqueued: unknown[];
@@ -128,5 +132,71 @@ describe("agent/conversation-run-chunk-mirror", () => {
     await mirror.appendEvents([{ type: "TEXT_MESSAGE_CONTENT", delta: "ignored" }]);
 
     assertEquals(queueController.enqueued, []);
+  });
+
+  it("creates an API-backed hosted mirror with standard trace and debug instrumentation", async () => {
+    const traceOperations: string[] = [];
+    const traceAttributes: HostedConversationRunChunkMirrorTraceAttributes[] = [];
+    const debugMessages: Array<{ message: string; metadata: Record<string, unknown> }> = [];
+    const mirror = createHostedConversationRunChunkMirror({
+      authToken: "token",
+      apiUrl: "https://api.example.test",
+      conversationId: "conversation-1",
+      runId: "run-1",
+      latestEventId: 10,
+      latestExternalEventSequence: 20,
+      instrumentation: {
+        trace: async (operationName, operation) => {
+          traceOperations.push(operationName);
+          return await operation();
+        },
+        setTraceAttributes: (attributes) => {
+          traceAttributes.push(attributes);
+        },
+        debug: (message, metadata) => {
+          debugMessages.push({ message, metadata });
+        },
+      },
+    });
+
+    await mirror.handleChunk({ type: "text-delta", id: "m1", delta: "hello" });
+    await mirror.appendEvents([{ type: "TEXT_MESSAGE_CONTENT", delta: "persisted" }]);
+    mirror.dispose();
+
+    assertEquals(traceOperations, ["durable.mirrorChunk", "durable.mirrorAppendEvents"]);
+    assertEquals(traceAttributes, [
+      {
+        "conversation.id": "conversation-1",
+        "run.id": "run-1",
+        "stream.ui_chunk.type": "text-delta",
+        "durable.event_count": 1,
+      },
+      {
+        "conversation.id": "conversation-1",
+        "run.id": "run-1",
+        "durable.event_count": 1,
+      },
+    ]);
+    assertEquals(debugMessages, [
+      {
+        message: "Durable run mirror processed UI chunk",
+        metadata: {
+          conversationId: "conversation-1",
+          runId: "run-1",
+          chunkType: "text-delta",
+          durableEventTypes: ["TEXT_MESSAGE_CONTENT"],
+          durableEventCount: 1,
+        },
+      },
+      {
+        message: "Durable run mirror queued external events",
+        metadata: {
+          conversationId: "conversation-1",
+          runId: "run-1",
+          durableEventTypes: ["TEXT_MESSAGE_CONTENT"],
+          durableEventCount: 1,
+        },
+      },
+    ]);
   });
 });

--- a/src/agent/conversation-run-chunk-mirror.ts
+++ b/src/agent/conversation-run-chunk-mirror.ts
@@ -20,6 +20,7 @@ import {
 
 const DEFAULT_IMMEDIATE_FLUSH_EVENT_COUNT = 24;
 const DEFAULT_MAX_CURSOR_RESYNCS_PER_FLUSH = 3;
+const DEFAULT_HOSTED_CHUNK_MIRROR_BATCH_SIZE = 24;
 
 export interface ConversationRunChunkMirror {
   handleChunk(chunk: ChatUiMessageChunk<ChatMessageMetadata>): Promise<void>;
@@ -87,6 +88,30 @@ export interface ConversationRunChunkMirrorApiOptions
 export type ConversationRunChunkMirrorOptions =
   | ConversationRunChunkMirrorQueueOptions
   | ConversationRunChunkMirrorApiOptions;
+
+export type HostedConversationRunChunkMirrorTraceAttributes = Record<
+  string,
+  string | number | boolean | null | undefined
+>;
+
+export interface HostedConversationRunChunkMirrorInstrumentation {
+  trace?: <T>(operationName: string, operation: () => Promise<T>) => Promise<T>;
+  setTraceAttributes?: (attributes: HostedConversationRunChunkMirrorTraceAttributes) => void;
+  debug?: (message: string, metadata: Record<string, unknown>) => void;
+  warn?: (message: string, metadata: Record<string, unknown>) => void;
+  error?: (message: string, metadata: Record<string, unknown>) => void;
+}
+
+export interface HostedConversationRunChunkMirrorOptions {
+  authToken: string;
+  apiUrl: string;
+  conversationId: string;
+  runId: string;
+  latestEventId: number;
+  latestExternalEventSequence?: number;
+  batchSize?: number;
+  instrumentation?: HostedConversationRunChunkMirrorInstrumentation;
+}
 
 function resolveQueueController(
   input: ConversationRunChunkMirrorOptions,
@@ -167,4 +192,162 @@ export function createConversationRunChunkMirror(
       mirror.dispose();
     },
   };
+}
+
+function createHostedChunkMirrorRetryMetadata(input: {
+  conversationId: string;
+  runId: string;
+  errorMessage: string;
+  retryDelayMs: number;
+  pendingEventCount: number;
+  consecutiveFailures: number;
+}): Record<string, unknown> {
+  return {
+    conversationId: input.conversationId,
+    runId: input.runId,
+    error: input.errorMessage,
+    retryDelayMs: input.retryDelayMs,
+    pendingEventCount: input.pendingEventCount,
+    consecutiveFailures: input.consecutiveFailures,
+  };
+}
+
+async function runHostedChunkMirrorTrace<T>(
+  instrumentation: HostedConversationRunChunkMirrorInstrumentation | undefined,
+  operationName: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (instrumentation?.trace) {
+    return await instrumentation.trace(operationName, operation);
+  }
+
+  return await operation();
+}
+
+function recordHostedChunkMirrorRetryScheduled(input: {
+  instrumentation: HostedConversationRunChunkMirrorInstrumentation | undefined;
+  conversationId: string;
+  runId: string;
+  flushAttempt: ConversationRunMirrorRetryScheduledState;
+}): void {
+  input.instrumentation?.error?.(
+    "Durable run mirror flush failed; queued for retry",
+    createHostedChunkMirrorRetryMetadata({
+      conversationId: input.conversationId,
+      runId: input.runId,
+      errorMessage: input.flushAttempt.errorMessage ?? "Conversation run append failed",
+      retryDelayMs: input.flushAttempt.retryDelayMs,
+      pendingEventCount: input.flushAttempt.pendingEventCount,
+      consecutiveFailures: input.flushAttempt.consecutiveFailures,
+    }),
+  );
+}
+
+function recordHostedChunkMirrorStopped(input: {
+  instrumentation: HostedConversationRunChunkMirrorInstrumentation | undefined;
+  conversationId: string;
+  runId: string;
+  flushAttempt: ConversationRunMirrorStoppedState;
+}): void {
+  if (input.flushAttempt.disableReason === "cursor_resyncs_exhausted") {
+    input.instrumentation?.error?.(
+      "Disabling durable run mirroring after repeated cursor resync failures",
+      {
+        conversationId: input.conversationId,
+        runId: input.runId,
+      },
+    );
+    return;
+  }
+
+  if (input.flushAttempt.disableReason === "ignorable_append_rejection") {
+    input.instrumentation?.warn?.(
+      "Disabling durable run mirroring after external append rejection",
+      {
+        conversationId: input.conversationId,
+        runId: input.runId,
+      },
+    );
+    return;
+  }
+
+  if (input.flushAttempt.disableReason === "non_appendable") {
+    input.instrumentation?.warn?.(
+      "Disabling durable run mirroring after cursor mismatch reached a non-appendable run state",
+      {
+        conversationId: input.conversationId,
+        runId: input.runId,
+        latestEventId: input.flushAttempt.latestEventId,
+        latestExternalEventSequence: input.flushAttempt.latestExternalEventSequence,
+      },
+    );
+  }
+}
+
+export function createHostedConversationRunChunkMirror(
+  input: HostedConversationRunChunkMirrorOptions,
+): ConversationRunChunkMirror {
+  const batchSize = input.batchSize ?? DEFAULT_HOSTED_CHUNK_MIRROR_BATCH_SIZE;
+
+  return createConversationRunChunkMirror({
+    authToken: input.authToken,
+    apiUrl: input.apiUrl,
+    conversationId: input.conversationId,
+    runId: input.runId,
+    latestEventId: input.latestEventId,
+    latestExternalEventSequence: input.latestExternalEventSequence,
+    maxEventsPerBatch: batchSize,
+    maxCursorResyncsPerFlush: DEFAULT_MAX_CURSOR_RESYNCS_PER_FLUSH,
+    immediateFlushEventCount: batchSize,
+    prepareChunkEvents: ({ chunk, defaultPrepare }) =>
+      runHostedChunkMirrorTrace(input.instrumentation, "durable.mirrorChunk", async () => {
+        const events = defaultPrepare();
+        input.instrumentation?.setTraceAttributes?.({
+          "conversation.id": input.conversationId,
+          "run.id": input.runId,
+          "stream.ui_chunk.type": chunk.type,
+          "durable.event_count": events.length,
+        });
+        input.instrumentation?.debug?.("Durable run mirror processed UI chunk", {
+          conversationId: input.conversationId,
+          runId: input.runId,
+          chunkType: chunk.type,
+          durableEventTypes: events.map((event) => event.type),
+          durableEventCount: events.length,
+        });
+        return events;
+      }),
+    prepareExternalEvents: ({ defaultPrepare }) =>
+      runHostedChunkMirrorTrace(input.instrumentation, "durable.mirrorAppendEvents", async () => {
+        const events = defaultPrepare();
+        input.instrumentation?.setTraceAttributes?.({
+          "conversation.id": input.conversationId,
+          "run.id": input.runId,
+          "durable.event_count": events.length,
+        });
+        input.instrumentation?.debug?.("Durable run mirror queued external events", {
+          conversationId: input.conversationId,
+          runId: input.runId,
+          durableEventTypes: events.map((event) => event.type),
+          durableEventCount: events.length,
+        });
+        return events;
+      }),
+    onRetryScheduled: (flushAttempt) => {
+      recordHostedChunkMirrorRetryScheduled({
+        instrumentation: input.instrumentation,
+        conversationId: input.conversationId,
+        runId: input.runId,
+        flushAttempt,
+      });
+    },
+    onStopped: (flushAttempt) => {
+      recordHostedChunkMirrorStopped({
+        instrumentation: input.instrumentation,
+        conversationId: input.conversationId,
+        runId: input.runId,
+        flushAttempt,
+      });
+    },
+  });
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -772,6 +772,10 @@ export {
   type ConversationRunChunkMirrorPrepareExternalEventsInput,
   type ConversationRunChunkMirrorQueueOptions,
   createConversationRunChunkMirror,
+  createHostedConversationRunChunkMirror,
+  type HostedConversationRunChunkMirrorInstrumentation,
+  type HostedConversationRunChunkMirrorOptions,
+  type HostedConversationRunChunkMirrorTraceAttributes,
 } from "./conversation-run-chunk-mirror.ts";
 export {
   type ConversationRunStreamMirror,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.412";
+export const VERSION = "0.1.413";


### PR DESCRIPTION
## Summary
- add a reusable API-backed conversation run chunk mirror helper with standard hosted tracing/logging hooks
- export hosted mirror instrumentation/input types from the agent package
- bump package version to 0.1.413 for CI/CD release

## Verification
- deno test --no-check --allow-all src/agent/conversation-run-chunk-mirror.test.ts
- deno check src/agent/index.ts
- deno task verify:quick
- pre-push checks passed: 1699 passed, 0 failed