### PR TITLE
Prevent fork stream side-channel rejection crashes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.414",
+  "version": "0.1.415",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/fork-runtime-stream.test.ts
+++ b/src/agent/fork-runtime-stream.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertExists } from "#veryfront/testing/assert";
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import { z } from "zod";
 import type { AgentResponse, Message as AgentMessage } from "./schemas/index.ts";
@@ -326,6 +326,56 @@ describe("agent/fork-runtime-stream", () => {
       inputTokens: 3,
       outputTokens: 4,
     });
+  });
+
+  it("does not leak unhandled rejections from side promises when the fork stream fails", async () => {
+    const unhandledRejections: unknown[] = [];
+    const handler = (event: PromiseRejectionEvent) => {
+      unhandledRejections.push(event.reason);
+      event.preventDefault();
+    };
+
+    globalThis.addEventListener("unhandledrejection", handler);
+    try {
+      const streamError = new Error("provider failed");
+      const streamResult = startAgentRuntimeFork({
+        apiUrl: "https://api.example.com",
+        authToken: "auth-token",
+        projectId: "project-1",
+        model: "model-1",
+        maxSteps: 1,
+        prompt: "Do the work.",
+        forkToolNames: [],
+        runtimeTools: {},
+        buildInstructions: () => "Base instructions.",
+        runStep: async () => ({
+          stream: new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.error(streamError);
+            },
+          }),
+          responsePromise: new Promise<AgentResponse>(() => {}),
+        }),
+      });
+
+      let thrown: unknown;
+      try {
+        for await (const _part of streamResult.fullStream) {
+          // The stream errors before yielding parts.
+        }
+      } catch (error) {
+        thrown = error;
+      }
+
+      assertEquals(thrown, streamError);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      assertEquals(unhandledRejections, []);
+      await assertRejects(() => Promise.resolve(streamResult.steps), Error, "provider failed");
+      await assertRejects(() => Promise.resolve(streamResult.totalUsage), Error, "provider failed");
+    } finally {
+      globalThis.removeEventListener("unhandledrejection", handler);
+    }
   });
 
   it("starts a high-level agent runtime fork from host tool definitions", async () => {

--- a/src/agent/fork-runtime-stream.ts
+++ b/src/agent/fork-runtime-stream.ts
@@ -276,6 +276,10 @@ function createForkRuntimeDeferred<T>(): {
     resolve = nextResolve;
     reject = nextReject;
   });
+  // These deferreds are side-channel results for consumers that need final
+  // steps/usage. The fork stream itself may fail before callers await them; keep
+  // their original rejection semantics while marking the rejection as observed.
+  promise.catch(() => {});
 
   return { promise, resolve, reject };
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.414";
+export const VERSION = "0.1.415";


### PR DESCRIPTION
## Summary
- mark fork runtime side-channel deferred promises as observed so caught `fullStream` failures do not leak unhandled rejections
- preserve rejection semantics for callers that await `steps` or `totalUsage`
- bump framework version to `0.1.415` for release

## Evidence
- Red/green regression: new `fork-runtime-stream` test failed before the fix with two unhandled rejections, then passed after the fix
- `deno test --allow-all src/agent/fork-runtime-stream.test.ts src/agent/hosted-child-fork-stream-execution.test.ts src/agent/hosted-child-lifecycle.test.ts`
- `deno task verify:quick`
- pre-push hook: formatting, lint, type check, and `deno task test:unit` -> 1699 passed, 0 failed

## Staging context
- latest durable canary retry is currently blocked by account credits: `/credits/balance` reports total 0
- transaction history shows +100 purchased credits at 2026-05-08 09:40:00Z, then AI inference spends exhausted them
- earlier agent pod restart matched this fix path: child fork provider failure rejected unawaited side-channel promises while the lifecycle had already caught the main stream error
