### PR TITLE
Add hosted conversation root-run context helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.415",
+  "version": "0.1.416",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/conversation-root-run-lifecycle.test.ts
+++ b/src/agent/conversation-root-run-lifecycle.test.ts
@@ -1,6 +1,9 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { prepareConversationRootRunLifecycle } from "./conversation-root-run-lifecycle.ts";
+import {
+  prepareConversationRootRunLifecycle,
+  prepareHostedConversationRootRunContext,
+} from "./conversation-root-run-lifecycle.ts";
 
 describe("agent/conversation-root-run-lifecycle", () => {
   it("starts a run and derives root-run lineage plus a mirror in one helper", async () => {
@@ -80,5 +83,61 @@ describe("agent/conversation-root-run-lifecycle", () => {
 
     await lifecycle.publishParentRunEvents?.([{ type: "child-started" }]);
     assertEquals(recorded, [[{ type: "child-started" }]]);
+  });
+
+  it("prepares a hosted root-run context with durable mirroring", async () => {
+    const debugMessages: string[] = [];
+    const context = await prepareHostedConversationRootRunContext(
+      {
+        authToken: "token",
+        apiUrl: "https://api.example.test",
+        conversationId: "conv-1",
+        projectId: "project-1",
+        branchId: "branch-1",
+        agentId: "agent-1",
+        messages: [],
+        providedRun: {
+          runId: "run-1",
+          messageId: "msg-1",
+          latestEventId: 5,
+          latestExternalEventSequence: 6,
+        },
+        persistLatestUserMessageBeforeRun: true,
+        parentRunId: "parent-run",
+        parentMessageId: "parent-message",
+        instrumentation: {
+          debug: (message) => {
+            debugMessages.push(message);
+          },
+        },
+      },
+      { abortSignal: new AbortController().signal },
+    );
+
+    try {
+      assertEquals(context.durableRootRun, {
+        runId: "run-1",
+        conversationId: "conv-1",
+        messageId: "msg-1",
+        latestEventId: 5,
+        latestExternalEventSequence: 6,
+      });
+      assertEquals(context.effectiveParentRunId, "run-1");
+      assertEquals(context.effectiveParentMessageId, "msg-1");
+
+      await context.publishParentRunEvents?.([{
+        type: "CUSTOM",
+        name: "child-run",
+        value: { runId: "child-run-1" },
+      }]);
+
+      assertEquals(
+        debugMessages.includes("Durable run mirror queued external events"),
+        true,
+      );
+      assertEquals(context.durableRunMirror?.getSnapshot().pendingEventCount, 1);
+    } finally {
+      context.durableRunMirror?.dispose();
+    }
   });
 });

--- a/src/agent/conversation-root-run-lifecycle.ts
+++ b/src/agent/conversation-root-run-lifecycle.ts
@@ -1,8 +1,18 @@
 import {
   type ConversationRootRunContext,
+  type ConversationRootRunDescriptor,
   createConversationRootRunContext,
+  createConversationRootRunStartAdapter,
 } from "./conversation-root-run-context.ts";
+import { persistLatestConversationUserMessage } from "./conversation-bootstrap.ts";
+import {
+  type ConversationRunChunkMirror,
+  createHostedConversationRunChunkMirror,
+  type HostedConversationRunChunkMirrorInstrumentation,
+} from "./conversation-run-chunk-mirror.ts";
+import { type ConversationRunEvent } from "./conversation-run-events.ts";
 import type { ConversationRunProjection } from "./durable.ts";
+import type { ChatUiMessage } from "#veryfront/chat/types.ts";
 
 export interface ConversationRootRunLifecycle<TMirror> extends ConversationRootRunContext {
   mirror: TMirror | null;
@@ -37,5 +47,138 @@ export async function prepareConversationRootRunLifecycle<TMirror>(
   return {
     ...context,
     mirror: run && input.createMirror ? await input.createMirror(run) : null,
+  };
+}
+
+export interface HostedConversationRootRunState {
+  runId: string;
+  conversationId: string;
+  messageId: string;
+  latestEventId: number;
+  latestExternalEventSequence: number;
+}
+
+export interface HostedConversationRootRunContext {
+  durableRootRun: HostedConversationRootRunState | null;
+  durableRunMirror: ConversationRunChunkMirror | null;
+  effectiveParentRunId?: string;
+  effectiveParentMessageId?: string;
+  publishParentRunEvents?: (events: ConversationRunEvent[]) => Promise<void>;
+}
+
+export interface PrepareHostedConversationRootRunContextInput {
+  authToken: string;
+  apiUrl: string;
+  conversationId?: string;
+  projectId?: string | null;
+  branchId?: string | null;
+  agentId: string;
+  implementationKind?: string | null;
+  messages: ChatUiMessage[];
+  parentRunId?: string;
+  parentMessageId?: string;
+  providedRun?: ConversationRootRunDescriptor;
+  persistLatestUserMessageBeforeRun: boolean;
+  persistLatestUserMessageOperation?: string;
+  missingUserMessageErrorMessage?: string;
+  onPersistLatestUserMessageFailure?: Parameters<
+    typeof persistLatestConversationUserMessage
+  >[0]["onFailure"];
+  instrumentation?: HostedConversationRunChunkMirrorInstrumentation;
+}
+
+function isConversationRunEvent(value: unknown): value is ConversationRunEvent {
+  return typeof value === "object" && value !== null && "type" in value &&
+    typeof value.type === "string";
+}
+
+function toHostedConversationRootRunState(
+  run: ConversationRunProjection | null,
+): HostedConversationRootRunState | null {
+  if (!run) {
+    return null;
+  }
+
+  return {
+    runId: run.runId,
+    conversationId: run.conversationId,
+    messageId: run.messageId,
+    latestEventId: run.latestEventId,
+    latestExternalEventSequence: run.latestExternalEventSequence,
+  };
+}
+
+export async function prepareHostedConversationRootRunContext(
+  input: PrepareHostedConversationRootRunContextInput,
+  options: { abortSignal: AbortSignal },
+): Promise<HostedConversationRootRunContext> {
+  let durableRunMirror: ConversationRunChunkMirror | null = null;
+  const startConversationRootRun = createConversationRootRunStartAdapter({
+    authToken: input.authToken,
+    apiUrl: input.apiUrl,
+    conversationId: input.conversationId,
+    projectId: input.projectId,
+    branchId: input.branchId,
+    agentId: input.agentId,
+    implementationKind: input.implementationKind,
+    providedRun: input.providedRun,
+  });
+
+  const rootRunLifecycle = await prepareConversationRootRunLifecycle(
+    {
+      startRun: async ({ abortSignal }) => {
+        if (!input.providedRun) {
+          await persistLatestConversationUserMessage({
+            authToken: input.authToken,
+            apiUrl: input.apiUrl,
+            conversationId: input.conversationId,
+            messages: input.messages,
+            enabled: input.persistLatestUserMessageBeforeRun,
+            operation: input.persistLatestUserMessageOperation,
+            missingUserMessageErrorMessage: input.missingUserMessageErrorMessage,
+            onFailure: input.onPersistLatestUserMessageFailure,
+          });
+        }
+
+        return await startConversationRootRun({ abortSignal });
+      },
+      parentRunId: input.parentRunId,
+      parentMessageId: input.parentMessageId,
+      appendParentRunEvents: async (events) => {
+        if (!durableRunMirror || !events.every(isConversationRunEvent)) {
+          return;
+        }
+
+        await durableRunMirror.appendEvents(events);
+      },
+      createMirror: (run) => {
+        durableRunMirror = createHostedConversationRunChunkMirror({
+          authToken: input.authToken,
+          apiUrl: input.apiUrl,
+          conversationId: run.conversationId,
+          runId: run.runId,
+          latestEventId: run.latestEventId,
+          latestExternalEventSequence: run.latestExternalEventSequence,
+          instrumentation: input.instrumentation,
+        });
+
+        return durableRunMirror;
+      },
+    },
+    options,
+  );
+
+  durableRunMirror = rootRunLifecycle.mirror;
+
+  return {
+    durableRootRun: toHostedConversationRootRunState(rootRunLifecycle.run),
+    durableRunMirror,
+    effectiveParentRunId: rootRunLifecycle.effectiveParentRunId,
+    effectiveParentMessageId: rootRunLifecycle.effectiveParentMessageId,
+    publishParentRunEvents: rootRunLifecycle.publishParentRunEvents
+      ? async (events) => {
+        await rootRunLifecycle.publishParentRunEvents?.(events);
+      }
+      : undefined,
   };
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -466,8 +466,12 @@ export {
 } from "./conversation-root-run-context.ts";
 export {
   type ConversationRootRunLifecycle,
+  type HostedConversationRootRunContext,
+  type HostedConversationRootRunState,
   prepareConversationRootRunLifecycle,
   type PrepareConversationRootRunLifecycleOptions,
+  prepareHostedConversationRootRunContext,
+  type PrepareHostedConversationRootRunContextInput,
 } from "./conversation-root-run-lifecycle.ts";
 export {
   bootstrapConversationAgentRun,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.415";
+export const VERSION = "0.1.416";


### PR DESCRIPTION
## Summary
- add a hosted conversation root-run context helper that persists the latest user message, starts or adopts a root run, and creates the hosted durable chunk mirror in one reusable framework path
- export the helper and related context/input types from veryfront/agent
- bump framework package version to 0.1.416 for CI/CD publishing

## Verification
- deno test --allow-all src/agent/conversation-root-run-lifecycle.test.ts
- deno task verify:quick
- pre-push checks passed: fmt, lint, typecheck, unit tests (1699 passed / 0 failed)
