### PR TITLE
Mirror research reports from effective output paths

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.416",
+  "version": "0.1.417",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/default-research-artifact-support.test.ts
+++ b/src/agent/default-research-artifact-support.test.ts
@@ -157,4 +157,46 @@ describe("default research artifact support", () => {
       },
     ]);
   });
+
+  it("mirrors when the tool result reports the canonical current report path", async () => {
+    const calls: Array<
+      {
+        toolName: string;
+        args: Record<string, unknown>;
+        context: Record<string, unknown> | undefined;
+      }
+    > = [];
+
+    await mirrorDefaultResearchRunArtifact({
+      toolName: "create_file",
+      toolInput: {
+        path: "research/ai-coding-agents-draft/report.md",
+        content: "# report",
+      },
+      toolResult: {
+        path: "research/ai-coding-agents/report.md",
+      },
+      taskContext: {
+        defaultResearchArtifacts: defaultArtifacts(),
+      },
+      activeProjectId: "project-1",
+      executeContext: { projectId: "project-1" },
+      executeTool: (toolName, args, context) => {
+        calls.push({ toolName, args, context });
+        return Promise.resolve({ path: "research/ai-coding-agents/runs/run-1.report.md" });
+      },
+    });
+
+    assertEquals(calls, [
+      {
+        toolName: "create_file",
+        args: {
+          path: "research/ai-coding-agents/runs/run-1.report.md",
+          content: "# report",
+          project_reference: "project-1",
+        },
+        context: { projectId: "project-1" },
+      },
+    ]);
+  });
 });

--- a/src/agent/default-research-artifact-support.ts
+++ b/src/agent/default-research-artifact-support.ts
@@ -22,6 +22,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function extractToolResultPath(result: unknown): string | null {
+  if (!isRecord(result) || typeof result.path !== "string") {
+    return null;
+  }
+
+  return result.path.replace(/^\/+/, "");
+}
+
 export function extractLatestUserText(messages: readonly unknown[]): string | null {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
@@ -243,6 +251,7 @@ export function shouldRetryCreateResearchArtifactAsUpdate(input: {
 export async function mirrorDefaultResearchRunArtifact(input: {
   toolName: string;
   toolInput: Record<string, unknown>;
+  toolResult?: unknown;
   taskContext: DefaultResearchArtifactContext;
   activeProjectId: string | null;
   executeContext: Record<string, unknown> | undefined;
@@ -261,10 +270,11 @@ export async function mirrorDefaultResearchRunArtifact(input: {
   const path = typeof input.toolInput.path === "string"
     ? input.toolInput.path.replace(/^\/+/, "")
     : null;
+  const resultPath = extractToolResultPath(input.toolResult);
   const canonicalCurrentPath = defaultArtifacts.currentReportPath.replace(/^\/+/, "");
   const canonicalRunPath = defaultArtifacts.runReportPath.replace(/^\/+/, "");
 
-  if (!content || path !== canonicalCurrentPath) {
+  if (!content || (path !== canonicalCurrentPath && resultPath !== canonicalCurrentPath)) {
     return;
   }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.416";
+export const VERSION = "0.1.417";


### PR DESCRIPTION
## Summary
- let default research artifact mirroring consider the successful tool result path as the effective current report path
- keep current report and run-scoped report pairing intact when downstream MCP tooling normalizes paths
- bump package version to `0.1.417`

## Verification
- `deno test --no-check --allow-all --parallel src/agent/default-research-artifact-support.test.ts`
- `deno fmt --check src/agent/default-research-artifact-support.ts src/agent/default-research-artifact-support.test.ts deno.json src/utils/version-constant.ts`
- `git diff --check`
- pre-push checks: formatting, lint, typecheck, unit tests: 1699 passed / 0 failed