### PR TITLE
Derive research run mirrors from effective report outputs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.417",
+  "version": "0.1.418",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/default-research-artifact-policy.ts
+++ b/src/agent/default-research-artifact-policy.ts
@@ -132,6 +132,31 @@ export function buildDefaultResearchArtifactPaths(input: {
   };
 }
 
+export function buildDefaultResearchArtifactPathsFromCurrentReportPath(input: {
+  currentReportPath: string;
+  runId?: string;
+}): DefaultResearchArtifactPaths | null {
+  const currentReportPath = input.currentReportPath.replace(/^\/+/, "");
+  const reportPathMatch = currentReportPath.match(/^research\/(.+)\/report\.md$/);
+  if (!reportPathMatch?.[1]) {
+    return null;
+  }
+
+  const topicSlug = reportPathMatch[1];
+  const sanitizedRunId = slugifyRunArtifactSegment(input.runId ?? "");
+  const effectiveRunId = sanitizedRunId.length > 0 ? sanitizedRunId : "latest";
+  const topicRootPath = `/research/${topicSlug}`;
+
+  return {
+    topicSlug,
+    topicRootPath,
+    currentReportPath: `/${currentReportPath}`,
+    runReportPath: `${topicRootPath}/runs/${effectiveRunId}.report.md`,
+    findingsPath: `${topicRootPath}/findings.md`,
+    sourcesPath: `${topicRootPath}/sources.md`,
+  };
+}
+
 export function withDefaultResearchArtifactPath(input: {
   description: string;
   prompt: string;

--- a/src/agent/default-research-artifact-support.test.ts
+++ b/src/agent/default-research-artifact-support.test.ts
@@ -199,4 +199,50 @@ describe("default research artifact support", () => {
       },
     ]);
   });
+
+  it("derives the run-scoped mirror path from an effective research report result", async () => {
+    const calls: Array<
+      {
+        toolName: string;
+        args: Record<string, unknown>;
+        context: Record<string, unknown> | undefined;
+      }
+    > = [];
+
+    await mirrorDefaultResearchRunArtifact({
+      toolName: "create_file",
+      toolInput: {
+        path: "research/durable-run-staging-canary/report.md",
+        content: "# report",
+      },
+      toolResult: {
+        path: "research/durable-run-staging-canary-behavior/report.md",
+      },
+      taskContext: {
+        parentRunId: "run_192c702c-9070-4aad-acac-db7f3158af3e",
+      },
+      activeProjectId: "project-1",
+      executeContext: { projectId: "project-1" },
+      executeTool: (toolName, args, context) => {
+        calls.push({ toolName, args, context });
+        return Promise.resolve({
+          path:
+            "research/durable-run-staging-canary-behavior/runs/run_192c702c-9070-4aad-acac-db7f3158af3e.report.md",
+        });
+      },
+    });
+
+    assertEquals(calls, [
+      {
+        toolName: "create_file",
+        args: {
+          path:
+            "research/durable-run-staging-canary-behavior/runs/run_192c702c-9070-4aad-acac-db7f3158af3e.report.md",
+          content: "# report",
+          project_reference: "project-1",
+        },
+        context: { projectId: "project-1" },
+      },
+    ]);
+  });
 });

--- a/src/agent/default-research-artifact-support.ts
+++ b/src/agent/default-research-artifact-support.ts
@@ -3,6 +3,7 @@ import { isHostedChildCreateFileAlreadyExistsResult } from "./hosted-child-artif
 import {
   buildDefaultResearchArtifactPathReminder,
   buildDefaultResearchArtifactPaths,
+  buildDefaultResearchArtifactPathsFromCurrentReportPath,
   type DefaultResearchArtifactPaths,
 } from "./default-research-artifact-policy.ts";
 
@@ -261,8 +262,7 @@ export async function mirrorDefaultResearchRunArtifact(input: {
     context: Record<string, unknown> | undefined,
   ) => Promise<unknown>;
 }): Promise<void> {
-  const defaultArtifacts = input.taskContext.defaultResearchArtifacts;
-  if (!defaultArtifacts || (input.toolName !== "create_file" && input.toolName !== "update_file")) {
+  if (input.toolName !== "create_file" && input.toolName !== "update_file") {
     return;
   }
 
@@ -271,6 +271,17 @@ export async function mirrorDefaultResearchRunArtifact(input: {
     ? input.toolInput.path.replace(/^\/+/, "")
     : null;
   const resultPath = extractToolResultPath(input.toolResult);
+  const defaultArtifacts = input.taskContext.defaultResearchArtifacts ??
+    (resultPath
+      ? buildDefaultResearchArtifactPathsFromCurrentReportPath({
+        currentReportPath: resultPath,
+        runId: input.taskContext.parentRunId,
+      })
+      : null);
+  if (!defaultArtifacts) {
+    return;
+  }
+
   const canonicalCurrentPath = defaultArtifacts.currentReportPath.replace(/^\/+/, "");
   const canonicalRunPath = defaultArtifacts.runReportPath.replace(/^\/+/, "");
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.417";
+export const VERSION = "0.1.418";


### PR DESCRIPTION
## Summary
- derive run-scoped research mirror paths from effective `research/<topic>/report.md` tool results when prompt-derived default artifact state is unavailable
- keep the mirror rule in `veryfront-code` so all runtime adapters share it
- bump package version to `0.1.418`

## Test evidence
- `deno test --no-check --allow-all --parallel src/agent/default-research-artifact-support.test.ts`
- `deno fmt --check src/agent/default-research-artifact-policy.ts src/agent/default-research-artifact-support.ts src/agent/default-research-artifact-support.test.ts deno.json src/utils/version-constant.ts`
- `deno task typecheck`
- `git diff --check`
- pre-push hook: format, lint, typecheck, unit tests (`1699 passed / 0 failed`)

## Context
Staging durable canary still produced the current report but missed the run-scoped mirror. The live tool result had the canonical current report path, so the generic framework helper can derive the run mirror from that effective output instead of requiring adapter-local default artifact state.

Co-authored-by: OmX <omx@oh-my-codex.dev>