### PR TITLE
Prefer canonical research outputs for run mirrors

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.418",
+  "version": "0.1.419",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/default-research-artifact-support.test.ts
+++ b/src/agent/default-research-artifact-support.test.ts
@@ -245,4 +245,51 @@ describe("default research artifact support", () => {
       },
     ]);
   });
+
+  it("prefers the returned canonical report path over stale injected defaults", async () => {
+    const calls: Array<
+      {
+        toolName: string;
+        args: Record<string, unknown>;
+        context: Record<string, unknown> | undefined;
+      }
+    > = [];
+
+    await mirrorDefaultResearchRunArtifact({
+      toolName: "create_file",
+      toolInput: {
+        path: "research/durable-run-staging-canary/report.md",
+        content: "# report",
+      },
+      toolResult: {
+        path: "research/durable-run-staging-canary-behavior/report.md",
+      },
+      taskContext: {
+        parentRunId: "run_4fee8a83-cb68-4075-bef8-ca16eca50770",
+        defaultResearchArtifacts: defaultArtifacts(),
+      },
+      activeProjectId: "project-1",
+      executeContext: { projectId: "project-1" },
+      executeTool: (toolName, args, context) => {
+        calls.push({ toolName, args, context });
+        return Promise.resolve({
+          path:
+            "research/durable-run-staging-canary-behavior/runs/run_4fee8a83-cb68-4075-bef8-ca16eca50770.report.md",
+        });
+      },
+    });
+
+    assertEquals(calls, [
+      {
+        toolName: "create_file",
+        args: {
+          path:
+            "research/durable-run-staging-canary-behavior/runs/run_4fee8a83-cb68-4075-bef8-ca16eca50770.report.md",
+          content: "# report",
+          project_reference: "project-1",
+        },
+        context: { projectId: "project-1" },
+      },
+    ]);
+  });
 });

--- a/src/agent/default-research-artifact-support.ts
+++ b/src/agent/default-research-artifact-support.ts
@@ -31,6 +31,33 @@ function extractToolResultPath(result: unknown): string | null {
   return result.path.replace(/^\/+/, "");
 }
 
+function isReportPath(path: string | null): path is string {
+  return path !== null && (path === "report.md" || path.endsWith("/report.md"));
+}
+
+function currentReportPathMatches(
+  artifacts: DefaultResearchArtifacts | null | undefined,
+  path: string | null,
+): boolean {
+  if (!artifacts || !path) {
+    return false;
+  }
+
+  return artifacts.currentReportPath.replace(/^\/+/, "") === path;
+}
+
+function buildDefaultArtifactsFromResultPath(input: {
+  resultPath: string | null;
+  parentRunId?: string;
+}): DefaultResearchArtifacts | null {
+  return input.resultPath && isReportPath(input.resultPath)
+    ? buildDefaultResearchArtifactPathsFromCurrentReportPath({
+      currentReportPath: input.resultPath,
+      runId: input.parentRunId,
+    })
+    : null;
+}
+
 export function extractLatestUserText(messages: readonly unknown[]): string | null {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
@@ -271,13 +298,15 @@ export async function mirrorDefaultResearchRunArtifact(input: {
     ? input.toolInput.path.replace(/^\/+/, "")
     : null;
   const resultPath = extractToolResultPath(input.toolResult);
-  const defaultArtifacts = input.taskContext.defaultResearchArtifacts ??
-    (resultPath
-      ? buildDefaultResearchArtifactPathsFromCurrentReportPath({
-        currentReportPath: resultPath,
-        runId: input.taskContext.parentRunId,
-      })
-      : null);
+  const contextArtifacts = input.taskContext.defaultResearchArtifacts;
+  const resultArtifacts = buildDefaultArtifactsFromResultPath({
+    resultPath,
+    parentRunId: input.taskContext.parentRunId,
+  });
+  const defaultArtifacts = resultArtifacts &&
+      !currentReportPathMatches(contextArtifacts, resultPath)
+    ? resultArtifacts
+    : contextArtifacts ?? resultArtifacts;
   if (!defaultArtifacts) {
     return;
   }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.418";
+export const VERSION = "0.1.419";


### PR DESCRIPTION
Default research artifact state can be missing or stale when a file tool normalizes the effective report path. The mirror helper now treats a returned canonical report path as the authoritative current report when it disagrees with injected defaults, then derives the run-scoped mirror from that path.

Constraint: Staging canary writes can receive a tool result path that differs from the model-requested path.

Rejected: Agent-side duplicate mirroring | would keep the framework helper inconsistent for future runtimes.

Confidence: high

Scope-risk: narrow

Directive: Keep result-path derivation authoritative when the file tool returns a canonical research report path.

Tested: deno test --no-check --allow-all --parallel src/agent/default-research-artifact-support.test.ts

Tested: deno fmt --check src/agent/default-research-artifact-support.ts src/agent/default-research-artifact-support.test.ts deno.json src/utils/version-constant.ts

Tested: deno task typecheck

Tested: git diff --check

