### PR TITLE
Add hosted chat execution runtime helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.419",
+  "version": "0.1.420",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-chat-execution-runtime.test.ts
+++ b/src/agent/hosted-chat-execution-runtime.test.ts
@@ -1,0 +1,489 @@
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ChatUiMessage, ChatUiMessageChunk, MessageMetadata } from "../chat/types.ts";
+import type { ConversationRunChunkMirror } from "./conversation-run-chunk-mirror.ts";
+import type { HostedChatRuntimeToUiMessageStreamOptions } from "./hosted-chat-runtime-contract.ts";
+import type { HostedLifecycleTerminalState } from "./hosted-lifecycle.ts";
+import { createMirroredToolChunkState } from "./mirrored-tool-chunk-state.ts";
+import {
+  cleanupAfterHostedChatExecutionFinalization,
+  createHostedChatExecutionRuntime,
+  createHostedChatFinalizeDetachedBuildState,
+  createHostedChatFinalizeResponseBuildState,
+  createHostedChatStreamFinalizationHooks,
+  type HostedChatExecutionLifecycleAdapter,
+  type HostedChatExecutionRootStreamWatchdog,
+  toHostedChatExecutionFinalState,
+} from "./hosted-chat-execution-runtime.ts";
+
+function createRootStreamWatchdog(input?: {
+  disposed?: () => void;
+}): HostedChatExecutionRootStreamWatchdog {
+  return {
+    signal: new AbortController().signal,
+    get lastTimeoutState() {
+      return null;
+    },
+    observe: () => {},
+    dispose: () => {
+      input?.disposed?.();
+    },
+  };
+}
+
+function createDurableRunMirror(input: {
+  chunks: ChatUiMessageChunk<MessageMetadata>[];
+  flushes: string[];
+}): ConversationRunChunkMirror {
+  return {
+    handleChunk: async (chunk) => {
+      input.chunks.push(chunk);
+    },
+    appendEvents: async () => {},
+    flush: async () => {
+      input.flushes.push("flush");
+    },
+    getSnapshot: () => ({
+      latestEventId: 0,
+      latestExternalEventSequence: 0,
+      pendingEventCount: 0,
+      consecutiveFailures: 0,
+      disabled: false,
+      hasFlushTimer: false,
+      hasRetryTimer: false,
+      inFlight: false,
+    }),
+    dispose: () => {},
+  };
+}
+
+function createLifecycleAdapter(input?: {
+  durableRunMirror?: ConversationRunChunkMirror | null;
+  messageId?: string | null;
+  terminalStates?: HostedLifecycleTerminalState[];
+}): HostedChatExecutionLifecycleAdapter {
+  const terminalStates = input?.terminalStates ?? [];
+  return {
+    durableRootRun: {
+      runId: "root-run-1",
+      messageId: input && "messageId" in input ? input.messageId : "stream-message-1",
+    },
+    durableRunMirror: input?.durableRunMirror ?? null,
+    terminal: {
+      toTerminalState: (state) => ({
+        status: state.status,
+        ...(state.metadata ? { metadata: state.metadata } : {}),
+        ...(state.terminalErrorCode !== undefined
+          ? { terminalErrorCode: state.terminalErrorCode }
+          : {}),
+        ...(state.terminalErrorMessage !== undefined
+          ? { terminalErrorMessage: state.terminalErrorMessage }
+          : {}),
+      }),
+      finalizeRun: async (state) => {
+        terminalStates.push(state);
+      },
+      cancelRun: async (state) => {
+        terminalStates.push(state);
+      },
+      onTerminalState: async () => {},
+    },
+  };
+}
+
+function createResponseMessage(input: {
+  parts: ChatUiMessage["parts"];
+  metadata?: MessageMetadata;
+}): ChatUiMessage {
+  return {
+    id: "assistant-message-1",
+    role: "assistant",
+    parts: input.parts,
+    ...(input.metadata ? { metadata: input.metadata } : {}),
+  };
+}
+
+function createStreamResult(input: {
+  finalStep: unknown;
+  captureOptions: (options?: HostedChatRuntimeToUiMessageStreamOptions) => void;
+}) {
+  return {
+    steps: Promise.resolve([input.finalStep]),
+    toUIMessageStream: (options?: HostedChatRuntimeToUiMessageStreamOptions) => {
+      input.captureOptions(options);
+      return emptyStream();
+    },
+  };
+}
+
+async function* emptyStream(): AsyncIterable<ChatUiMessageChunk<MessageMetadata>> {}
+
+function createLogger() {
+  const errors: Array<{ message: string; metadata?: Record<string, unknown> }> = [];
+  const warnings: Array<{ message: string; metadata?: Record<string, unknown> }> = [];
+  return {
+    errors,
+    warnings,
+    logger: {
+      error: (message: string, metadata?: Record<string, unknown>) => {
+        errors.push({ message, ...(metadata ? { metadata } : {}) });
+      },
+      warn: (message: string, metadata?: Record<string, unknown>) => {
+        warnings.push({ message, ...(metadata ? { metadata } : {}) });
+      },
+    },
+  };
+}
+
+describe("agent/hosted-chat-execution-runtime", () => {
+  it("does not inject fallback model metadata for finalization-only states", () => {
+    assertEquals(toHostedChatExecutionFinalState({ status: "completed" }), {
+      status: "completed",
+    });
+  });
+
+  it("keeps only present metadata and terminal error fields", () => {
+    assertEquals(
+      toHostedChatExecutionFinalState({
+        status: "failed",
+        metadata: {
+          modelId: "gpt-5.4",
+          usage: {
+            inputTokens: 10,
+            cachedInputTokens: 4,
+          },
+        },
+        terminalErrorCode: "STREAM_ERROR",
+      }),
+      {
+        status: "failed",
+        metadata: {
+          modelId: "gpt-5.4",
+          usage: {
+            inputTokens: 10,
+            cachedInputTokens: 4,
+          },
+        },
+        terminalErrorCode: "STREAM_ERROR",
+      },
+    );
+  });
+
+  it("logs cleanup failures during finalization without rethrowing", async () => {
+    const { logger, errors } = createLogger();
+
+    await cleanupAfterHostedChatExecutionFinalization({
+      cleanup: async () => {
+        throw new Error("cleanup failed");
+      },
+      logger,
+    });
+
+    assertEquals(errors, [
+      {
+        message: "Runtime cleanup failed during finalization",
+        metadata: { error: "cleanup failed" },
+      },
+    ]);
+  });
+
+  it("resolves aborted terminal state before incomplete tool state", () => {
+    const hooks = createHostedChatStreamFinalizationHooks({
+      lifecycleAdapter: createLifecycleAdapter(),
+      cleanup: async () => {},
+      streamError: null,
+    });
+
+    assertEquals(hooks.resolveTerminalState({ isAborted: true, hasIncompleteToolParts: true }), {
+      status: "cancelled",
+      terminalErrorCode: "ABORTED",
+      terminalErrorMessage: "Chat stream aborted",
+    });
+  });
+
+  it("appends fallback chunks and flushes through the mirror", async () => {
+    const chunks: ChatUiMessageChunk<MessageMetadata>[] = [];
+    const flushes: string[] = [];
+    const hooks = createHostedChatStreamFinalizationHooks({
+      lifecycleAdapter: createLifecycleAdapter({
+        durableRunMirror: createDurableRunMirror({ chunks, flushes }),
+      }),
+      cleanup: async () => {},
+      streamError: null,
+    });
+    const chunk: ChatUiMessageChunk<MessageMetadata> = {
+      type: "text-delta",
+      id: "assistant-message-1",
+      delta: "hello",
+    };
+
+    await hooks.appendFallbackChunk(chunk);
+    await hooks.flushMirror();
+
+    assertEquals(chunks, [chunk]);
+    assertEquals(flushes, ["flush"]);
+  });
+
+  it("builds finalized response state and metadata without mirror fallback chunks", async () => {
+    const buildState = createHostedChatFinalizeResponseBuildState({
+      responseMessage: createResponseMessage({
+        parts: [],
+        metadata: {
+          modelId: "gpt-test",
+          usage: { inputTokens: 2, outputTokens: 3 },
+        },
+      }),
+      isAborted: false,
+      lifecycleAdapter: createLifecycleAdapter(),
+      mirroredToolChunkState: createMirroredToolChunkState(),
+      capturedMessageId: "assistant-message-1",
+      incompleteToolCallsPartErrorText: "Tool call did not complete",
+    });
+
+    const state = await buildState({ text: "fallback text" });
+
+    assertEquals(state.persistedMessage.parts, []);
+    assertEquals(state.finalizedMessage.parts, [{ type: "text", text: "fallback text" }]);
+    assertEquals(state.fallbackChunks, []);
+    assertEquals(state.hasIncompleteToolParts, false);
+    assertEquals(state.metadata, {
+      modelId: "gpt-test",
+      usage: { inputTokens: 2, outputTokens: 3 },
+    });
+  });
+
+  it("builds detached fallback chunks only with content, mirror, and captured message id", async () => {
+    const chunks: ChatUiMessageChunk<MessageMetadata>[] = [];
+    const flushes: string[] = [];
+    const buildState = createHostedChatFinalizeDetachedBuildState({
+      capturedMessageId: "assistant-message-1",
+      isAborted: false,
+      lifecycleAdapter: createLifecycleAdapter({
+        durableRunMirror: createDurableRunMirror({ chunks, flushes }),
+      }),
+      mirroredToolChunkState: createMirroredToolChunkState(),
+      mirroredDurableOutput: false,
+      incompleteToolCallsPartErrorText: "Tool call did not complete",
+    });
+
+    const state = await buildState({ text: "detached fallback" });
+
+    assertEquals(state, {
+      hasContent: true,
+      fallbackChunks: [
+        { type: "text-start", id: "assistant-message-1" },
+        { type: "text-delta", id: "assistant-message-1", delta: "detached fallback" },
+        { type: "text-end", id: "assistant-message-1" },
+      ],
+      hasIncompleteToolParts: false,
+    });
+  });
+
+  it("requires a durable stream message id when a conversation id is present", async () => {
+    await assertRejects(
+      async () => {
+        const streamResult = createStreamResult({
+          finalStep: {},
+          captureOptions: () => {},
+        });
+        createHostedChatExecutionRuntime({
+          agentId: "agent-1",
+          modelId: "openai/gpt-5.4",
+          originalMessages: [],
+          runContext: { withContext: (fn) => fn() },
+          abortSignal: new AbortController().signal,
+          bootstrap: {
+            cleanup: async () => {},
+            lifecycleAdapter: createLifecycleAdapter({ messageId: null }),
+            rootStreamWatchdog: createRootStreamWatchdog(),
+            streamResult,
+            streamingMessageId: null,
+            capturedMessageId: null,
+            capturedConversationId: "conversation-1",
+            mirroredToolChunkState: createMirroredToolChunkState(),
+          },
+        });
+      },
+      Error,
+      "DURABLE_CHAT_ROOT_REQUIRES_CONVERSATION",
+    );
+  });
+
+  it("wires stream metadata and response message ids into runtime stream options", () => {
+    let streamOptions: HostedChatRuntimeToUiMessageStreamOptions | undefined;
+    const messageIds: string[] = [];
+    const runtime = createHostedChatExecutionRuntime({
+      agentId: "agent-1",
+      modelId: "openai/gpt-5.4",
+      originalMessages: [],
+      responseMessageId: "response-message-1",
+      runContext: {
+        withContext: (fn) => fn(),
+        setMessageId: (messageId) => {
+          messageIds.push(messageId);
+        },
+      },
+      abortSignal: new AbortController().signal,
+      bootstrap: {
+        cleanup: async () => {},
+        lifecycleAdapter: createLifecycleAdapter(),
+        rootStreamWatchdog: createRootStreamWatchdog(),
+        streamResult: createStreamResult({
+          finalStep: {},
+          captureOptions: (options) => {
+            streamOptions = options;
+          },
+        }),
+        streamingMessageId: "stream-message-1",
+        capturedMessageId: "stream-message-1",
+        capturedConversationId: "conversation-1",
+        mirroredToolChunkState: createMirroredToolChunkState(),
+      },
+    });
+
+    assertEquals(runtime.agentUIStream !== undefined, true);
+    assertEquals(messageIds, ["stream-message-1"]);
+    if (!streamOptions) {
+      throw new Error("stream options were not captured");
+    }
+    assertEquals(streamOptions.generateMessageId?.(), "response-message-1");
+    assertEquals(
+      streamOptions.messageMetadata?.({
+        part: {
+          type: "finish",
+          finishReason: "stop",
+          totalUsage: {
+            inputTokens: 5,
+            outputTokens: 7,
+          },
+        },
+      }),
+      {
+        agentId: "agent-1",
+        modelId: "openai/gpt-5.4",
+        runId: "root-run-1",
+        streamingMessageId: "stream-message-1",
+        usage: {
+          inputTokens: 5,
+          outputTokens: 7,
+        },
+      },
+    );
+  });
+
+  it("finalizes detached streams when the finish handler never runs", async () => {
+    let disposed = 0;
+    const terminalStates: HostedLifecycleTerminalState[] = [];
+    const runtime = createHostedChatExecutionRuntime({
+      agentId: "agent-1",
+      modelId: "openai/gpt-5.4",
+      originalMessages: [],
+      runContext: { withContext: (fn) => fn() },
+      abortSignal: new AbortController().signal,
+      bootstrap: {
+        cleanup: async () => {},
+        lifecycleAdapter: createLifecycleAdapter({ terminalStates }),
+        rootStreamWatchdog: createRootStreamWatchdog({
+          disposed: () => {
+            disposed += 1;
+          },
+        }),
+        streamResult: createStreamResult({
+          finalStep: { text: "detached fallback" },
+          captureOptions: () => {},
+        }),
+        streamingMessageId: "stream-message-1",
+        capturedMessageId: "stream-message-1",
+        capturedConversationId: "conversation-1",
+        mirroredToolChunkState: createMirroredToolChunkState(),
+      },
+    });
+
+    await runtime.waitForFinish();
+
+    assertEquals(terminalStates, [{ status: "completed" }]);
+    assertEquals(disposed, 1);
+  });
+
+  it("uses response finish events instead of detached fallback when present", async () => {
+    let streamOptions: HostedChatRuntimeToUiMessageStreamOptions | undefined;
+    const terminalStates: HostedLifecycleTerminalState[] = [];
+    const runtime = createHostedChatExecutionRuntime({
+      agentId: "agent-1",
+      modelId: "openai/gpt-5.4",
+      originalMessages: [],
+      runContext: { withContext: (fn) => fn() },
+      abortSignal: new AbortController().signal,
+      bootstrap: {
+        cleanup: async () => {},
+        lifecycleAdapter: createLifecycleAdapter({ terminalStates }),
+        rootStreamWatchdog: createRootStreamWatchdog(),
+        streamResult: createStreamResult({
+          finalStep: {},
+          captureOptions: (options) => {
+            streamOptions = options;
+          },
+        }),
+        streamingMessageId: "stream-message-1",
+        capturedMessageId: "stream-message-1",
+        capturedConversationId: "conversation-1",
+        mirroredToolChunkState: createMirroredToolChunkState(),
+      },
+    });
+    if (!streamOptions) {
+      throw new Error("stream options were not captured");
+    }
+
+    await streamOptions.onFinish?.({
+      messages: [],
+      isContinuation: false,
+      responseMessage: createResponseMessage({ parts: [{ type: "text", text: "done" }] }),
+      isAborted: false,
+      finishReason: "stop",
+    });
+    await runtime.waitForFinish();
+
+    assertEquals(terminalStates, [{ status: "completed" }]);
+  });
+
+  it("records stream errors before detached finalization fallback", async () => {
+    let streamOptions: HostedChatRuntimeToUiMessageStreamOptions | undefined;
+    const terminalStates: HostedLifecycleTerminalState[] = [];
+    const runtime = createHostedChatExecutionRuntime({
+      agentId: "agent-1",
+      modelId: "openai/gpt-5.4",
+      originalMessages: [],
+      runContext: { withContext: (fn) => fn() },
+      abortSignal: new AbortController().signal,
+      bootstrap: {
+        cleanup: async () => {},
+        lifecycleAdapter: createLifecycleAdapter({ terminalStates }),
+        rootStreamWatchdog: createRootStreamWatchdog(),
+        streamResult: createStreamResult({
+          finalStep: { text: "detached fallback" },
+          captureOptions: (options) => {
+            streamOptions = options;
+          },
+        }),
+        streamingMessageId: "stream-message-1",
+        capturedMessageId: "stream-message-1",
+        capturedConversationId: "conversation-1",
+        mirroredToolChunkState: createMirroredToolChunkState(),
+      },
+    });
+    if (!streamOptions) {
+      throw new Error("stream options were not captured");
+    }
+
+    assertEquals(streamOptions.onError?.(new Error("stream failed")), "stream failed");
+    await runtime.waitForFinish();
+
+    assertEquals(terminalStates, [
+      {
+        status: "failed",
+        terminalErrorCode: "STREAM_ERROR",
+        terminalErrorMessage: "stream failed",
+      },
+    ]);
+  });
+});

--- a/src/agent/hosted-chat-execution-runtime.ts
+++ b/src/agent/hosted-chat-execution-runtime.ts
@@ -1,0 +1,501 @@
+import {
+  buildChatStreamChunkMessageMetadata,
+  extractChatMessageMetadata,
+} from "../chat/chat-ui-message-helpers.ts";
+import { getLastStreamStep } from "../chat/final-step-fallback.ts";
+import type { ChatUiMessage, ChatUiMessageChunk, MessageMetadata } from "../chat/types.ts";
+import {
+  buildDetachedFallbackChunks,
+  buildDetachedFallbackMessageState,
+  buildFinalizedMessageFallbackChunks,
+  buildFinalizedMessageState,
+} from "./hosted-finalized-message.ts";
+import type {
+  HostedChatRuntimeStreamResult,
+  HostedChatRuntimeToUiMessageStreamOptions,
+} from "./hosted-chat-runtime-contract.ts";
+import type { HostedLifecycleTerminalState } from "./hosted-lifecycle.ts";
+import {
+  type ConversationHostedTerminalRuntimeAdapter,
+  type ConversationHostedTerminalStateInput,
+  dispatchConversationHostedStreamErrorState,
+  dispatchConversationHostedTerminalState,
+  resolveConversationHostedTerminalState,
+  toConversationHostedTerminalState,
+} from "./conversation-hosted-terminal.ts";
+import {
+  createHostedMirroredUiStream,
+  type MirroredToolChunkState,
+} from "./mirrored-tool-chunk-state.ts";
+import {
+  finalizeHostedDetached,
+  finalizeHostedResponse,
+  type FinalizeHostedResponseOptions,
+  type HostedDetachedFinalizationState,
+  type HostedResponseFinalizationState,
+} from "./hosted-stream-finalization.ts";
+import {
+  getEmptyHostedFinalizedMessageTerminalError,
+  getHostedStreamErrorText,
+  shouldFailEmptyHostedFinalizedMessage,
+} from "./hosted-stream-terminal-error.ts";
+import type { ConversationRunChunkMirror } from "./conversation-run-chunk-mirror.ts";
+import type { BuildChatStreamChunkMessageMetadataInput } from "../chat/chat-ui-message-helpers.ts";
+import type { createChatStreamWatchdog } from "../chat/stream-watchdog.ts";
+
+const INCOMPLETE_TOOL_CALLS_PART_ERROR_TEXT = "Assistant ended before tool execution completed";
+
+const FINALIZATION_TERMINAL_STATE_FALLBACK_MODEL_ID = "";
+
+export interface HostedChatExecutionRuntime {
+  agentUIStream: AsyncIterable<ChatUiMessageChunk<MessageMetadata>>;
+  fail: (error: unknown) => Promise<void>;
+  waitForFinish: () => Promise<void>;
+}
+
+export interface HostedChatExecutionRuntimeLogger {
+  error: (message: string, metadata?: Record<string, unknown>) => void;
+  warn: (message: string, metadata?: Record<string, unknown>) => void;
+}
+
+export interface HostedChatExecutionRunContext {
+  withContext: <T>(fn: () => T) => T;
+  setMessageId?: (messageId: string) => void;
+}
+
+export interface HostedChatExecutionLifecycleAdapter
+  extends ConversationHostedTerminalRuntimeAdapter {
+  durableRootRun: {
+    runId: string;
+    messageId?: string | null;
+  } | null;
+  durableRunMirror: ConversationRunChunkMirror | null;
+}
+
+export type HostedChatExecutionRootStreamWatchdog = ReturnType<typeof createChatStreamWatchdog>;
+
+export interface HostedChatExecutionRuntimeBootstrap {
+  cleanup: () => Promise<void>;
+  lifecycleAdapter: HostedChatExecutionLifecycleAdapter;
+  rootStreamWatchdog: HostedChatExecutionRootStreamWatchdog;
+  streamResult: HostedChatRuntimeStreamResult;
+  streamingMessageId: string | null;
+  capturedMessageId: string | null;
+  capturedConversationId?: string;
+  mirroredToolChunkState: MirroredToolChunkState;
+}
+
+export interface CreateHostedChatExecutionRuntimeInput {
+  agentId: string;
+  modelId: string;
+  originalMessages: ChatUiMessage[];
+  responseMessageId?: string;
+  runContext: HostedChatExecutionRunContext;
+  abortSignal: AbortSignal;
+  bootstrap: HostedChatExecutionRuntimeBootstrap;
+  logger?: HostedChatExecutionRuntimeLogger;
+  incompleteToolCallsPartErrorText?: string;
+}
+
+type SharedFinalizationHooks = Pick<
+  FinalizeHostedResponseOptions<ChatUiMessage, ChatUiMessageChunk<MessageMetadata>>,
+  | "resolveEmptyTerminalError"
+  | "appendFallbackChunk"
+  | "flushMirror"
+  | "dispatchTerminalState"
+  | "resolveTerminalState"
+  | "cleanup"
+  | "streamError"
+>;
+
+export function toHostedChatExecutionFinalState(
+  input: ConversationHostedTerminalStateInput,
+): HostedLifecycleTerminalState {
+  return toConversationHostedTerminalState({
+    state: input,
+    fallbackModelId: FINALIZATION_TERMINAL_STATE_FALLBACK_MODEL_ID,
+  });
+}
+
+export async function cleanupAfterHostedChatExecutionFinalization(input: {
+  cleanup: () => Promise<void>;
+  logger?: HostedChatExecutionRuntimeLogger;
+}): Promise<void> {
+  await input.cleanup().catch((cleanupError: unknown) => {
+    input.logger?.error("Runtime cleanup failed during finalization", {
+      error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+    });
+  });
+}
+
+export function createHostedChatStreamFinalizationHooks(input: {
+  lifecycleAdapter: HostedChatExecutionLifecycleAdapter;
+  cleanup: () => Promise<void>;
+  streamError: unknown;
+  logger?: HostedChatExecutionRuntimeLogger;
+}): SharedFinalizationHooks {
+  return {
+    resolveEmptyTerminalError: (
+      { finalStep, streamError }: { finalStep: unknown; streamError?: unknown | null },
+    ) => getEmptyHostedFinalizedMessageTerminalError({ finalStep, streamError }),
+    appendFallbackChunk: (chunk: ChatUiMessageChunk<MessageMetadata>) =>
+      input.lifecycleAdapter.durableRunMirror?.handleChunk(chunk),
+    flushMirror: () => input.lifecycleAdapter.durableRunMirror?.flush(),
+    dispatchTerminalState: async (terminalState) => {
+      await dispatchConversationHostedTerminalState(input.lifecycleAdapter, terminalState);
+    },
+    resolveTerminalState: ({ isAborted, hasIncompleteToolParts }: {
+      isAborted: boolean;
+      hasIncompleteToolParts: boolean;
+    }) =>
+      toHostedChatExecutionFinalState(
+        resolveConversationHostedTerminalState({ isAborted, hasIncompleteToolParts }),
+      ),
+    cleanup: () =>
+      cleanupAfterHostedChatExecutionFinalization({
+        cleanup: input.cleanup,
+        logger: input.logger,
+      }),
+    streamError: input.streamError,
+  };
+}
+
+export function createHostedChatFinalizeResponseBuildState(input: {
+  responseMessage: ChatUiMessage;
+  isAborted: boolean;
+  lifecycleAdapter: HostedChatExecutionLifecycleAdapter;
+  mirroredToolChunkState: MirroredToolChunkState;
+  capturedMessageId: string | null;
+  incompleteToolCallsPartErrorText: string;
+}): (
+  finalStep: unknown,
+) => Promise<HostedResponseFinalizationState<ChatUiMessage, ChatUiMessageChunk<MessageMetadata>>> {
+  return async (finalStep) => {
+    const { persistedMessage, sanitizedFinalizedMessage, hasIncompleteFinalizedToolParts } =
+      buildFinalizedMessageState({
+        responseMessage: input.responseMessage,
+        isAborted: input.isAborted,
+        finalStep,
+        incompleteToolCallsPartErrorText: input.incompleteToolCallsPartErrorText,
+      });
+
+    return {
+      persistedMessage,
+      finalizedMessage: sanitizedFinalizedMessage,
+      fallbackChunks:
+        sanitizedFinalizedMessage.parts.length > 0 && input.lifecycleAdapter.durableRunMirror
+          ? buildFinalizedMessageFallbackChunks({
+            persistedMessage,
+            sanitizedFinalizedMessage,
+            finalStep,
+            mirroredToolChunkState: input.mirroredToolChunkState,
+            capturedMessageId: input.capturedMessageId,
+            hasIncompleteFinalizedToolParts,
+          })
+          : [],
+      hasIncompleteToolParts: hasIncompleteFinalizedToolParts,
+      metadata: extractChatMessageMetadata(sanitizedFinalizedMessage.metadata),
+    };
+  };
+}
+
+export function createHostedChatFinalizeDetachedBuildState(input: {
+  capturedMessageId: string | null;
+  isAborted: boolean;
+  lifecycleAdapter: HostedChatExecutionLifecycleAdapter;
+  mirroredToolChunkState: MirroredToolChunkState;
+  mirroredDurableOutput: boolean;
+  incompleteToolCallsPartErrorText: string;
+}): (
+  finalStep: unknown,
+) => Promise<HostedDetachedFinalizationState<ChatUiMessageChunk<MessageMetadata>>> {
+  return async (finalStep) => {
+    const { finalizedFallbackMessage, hasIncompleteFallbackToolParts } =
+      buildDetachedFallbackMessageState({
+        capturedMessageId: input.capturedMessageId,
+        finalStep,
+        isAborted: input.isAborted,
+        incompleteToolCallsPartErrorText: input.incompleteToolCallsPartErrorText,
+      });
+    const fallbackParts = finalizedFallbackMessage.parts;
+
+    return {
+      hasContent: fallbackParts.length > 0,
+      fallbackChunks: fallbackParts.length > 0 && input.lifecycleAdapter.durableRunMirror &&
+          input.capturedMessageId
+        ? buildDetachedFallbackChunks({
+          fallbackParts,
+          finalStep,
+          mirroredToolChunkState: input.mirroredToolChunkState,
+          mirroredDurableOutput: input.mirroredDurableOutput,
+          capturedMessageId: input.capturedMessageId,
+          hasIncompleteFallbackToolParts,
+        })
+        : [],
+      hasIncompleteToolParts: hasIncompleteFallbackToolParts,
+    };
+  };
+}
+
+async function finalizeExecutionFailure(input: {
+  lifecycleAdapter: HostedChatExecutionLifecycleAdapter;
+  error: unknown;
+  conversationId?: string;
+  runId?: string;
+  logMessage: string;
+  logger?: HostedChatExecutionRuntimeLogger;
+}): Promise<void> {
+  await dispatchConversationHostedStreamErrorState(input.lifecycleAdapter, input.error).catch(
+    (finalizeError) => {
+      input.logger?.error(input.logMessage, {
+        conversationId: input.conversationId,
+        runId: input.runId,
+        error: finalizeError instanceof Error ? finalizeError.message : String(finalizeError),
+      });
+    },
+  );
+}
+
+function createStreamMessageMetadataBuilder(input: {
+  agentId: string;
+  modelId: string;
+  lifecycleAdapter: HostedChatExecutionLifecycleAdapter;
+  streamingMessageId: string | null;
+}): HostedChatRuntimeToUiMessageStreamOptions["messageMetadata"] {
+  return ({ part }) =>
+    buildChatStreamChunkMessageMetadata(
+      {
+        agentId: input.agentId,
+        modelId: input.modelId,
+        ...(input.lifecycleAdapter.durableRootRun
+          ? { runId: input.lifecycleAdapter.durableRootRun.runId }
+          : {}),
+        ...(input.streamingMessageId ? { streamingMessageId: input.streamingMessageId } : {}),
+        part: {
+          type: part.type,
+          ...("totalUsage" in part ? { totalUsage: part.totalUsage } : {}),
+        },
+      } satisfies BuildChatStreamChunkMessageMetadataInput,
+    );
+}
+
+function logCleanupError(input: {
+  error: unknown;
+  logger?: HostedChatExecutionRuntimeLogger;
+}): void {
+  input.logger?.error("Runtime cleanup failed", {
+    error: input.error instanceof Error ? input.error.message : String(input.error),
+  });
+}
+
+async function finalizeResponseFinish(input: {
+  responseMessage: ChatUiMessage;
+  isAborted: boolean;
+  streamResult: { steps: PromiseLike<readonly unknown[]> };
+  lastStreamError: unknown;
+  lifecycleAdapter: HostedChatExecutionLifecycleAdapter;
+  mirroredToolChunkState: MirroredToolChunkState;
+  capturedMessageId: string | null;
+  incompleteToolCallsPartErrorText: string;
+  cleanup: () => Promise<void>;
+  logger?: HostedChatExecutionRuntimeLogger;
+}): Promise<void> {
+  const hooks = createHostedChatStreamFinalizationHooks({
+    lifecycleAdapter: input.lifecycleAdapter,
+    cleanup: input.cleanup,
+    streamError: input.lastStreamError,
+    logger: input.logger,
+  });
+  const buildState = createHostedChatFinalizeResponseBuildState({
+    responseMessage: input.responseMessage,
+    isAborted: input.isAborted,
+    lifecycleAdapter: input.lifecycleAdapter,
+    mirroredToolChunkState: input.mirroredToolChunkState,
+    capturedMessageId: input.capturedMessageId,
+    incompleteToolCallsPartErrorText: input.incompleteToolCallsPartErrorText,
+  });
+
+  await finalizeHostedResponse({
+    isAborted: input.isAborted,
+    getFinalStep: () => getLastStreamStep(input.streamResult),
+    buildState,
+    shouldFailEmptyMessage: ({ isAborted, message }) =>
+      shouldFailEmptyHostedFinalizedMessage({ isAborted, message }),
+    ...hooks,
+  });
+}
+
+async function finalizeDetachedStreamEnd(input: {
+  capturedMessageId: string | null;
+  streamResult: { steps: PromiseLike<readonly unknown[]> };
+  isAborted: boolean;
+  lastStreamError: unknown;
+  lifecycleAdapter: HostedChatExecutionLifecycleAdapter;
+  mirroredToolChunkState: MirroredToolChunkState;
+  mirroredDurableOutput: boolean;
+  incompleteToolCallsPartErrorText: string;
+  cleanup: () => Promise<void>;
+  logger?: HostedChatExecutionRuntimeLogger;
+}): Promise<void> {
+  const hooks = createHostedChatStreamFinalizationHooks({
+    lifecycleAdapter: input.lifecycleAdapter,
+    cleanup: input.cleanup,
+    streamError: input.lastStreamError,
+    logger: input.logger,
+  });
+  const buildState = createHostedChatFinalizeDetachedBuildState({
+    capturedMessageId: input.capturedMessageId,
+    isAborted: input.isAborted,
+    lifecycleAdapter: input.lifecycleAdapter,
+    mirroredToolChunkState: input.mirroredToolChunkState,
+    mirroredDurableOutput: input.mirroredDurableOutput,
+    incompleteToolCallsPartErrorText: input.incompleteToolCallsPartErrorText,
+  });
+
+  await finalizeHostedDetached({
+    isAborted: input.isAborted,
+    mirroredDurableOutput: input.mirroredDurableOutput,
+    getFinalStep: () => getLastStreamStep(input.streamResult),
+    buildState,
+    ...hooks,
+  });
+}
+
+function resolveStreamingMessageId(input: {
+  conversationId?: string;
+  lifecycleAdapter: HostedChatExecutionLifecycleAdapter;
+  runContext: HostedChatExecutionRunContext;
+}): string | null {
+  const streamingMessageId = input.lifecycleAdapter.durableRootRun?.messageId ?? null;
+  if (input.conversationId && !streamingMessageId) {
+    throw new Error("DURABLE_CHAT_ROOT_REQUIRES_CONVERSATION");
+  }
+
+  if (streamingMessageId) {
+    input.runContext.setMessageId?.(streamingMessageId);
+  }
+
+  return streamingMessageId;
+}
+
+export function createHostedChatExecutionRuntime(
+  input: CreateHostedChatExecutionRuntimeInput,
+): HostedChatExecutionRuntime {
+  let finishPromise: Promise<void> = Promise.resolve();
+  let lastStreamError: unknown = null;
+  let finishHandlerStarted = false;
+  let mirroredDurableOutput = false;
+  const incompleteToolCallsPartErrorText = input.incompleteToolCallsPartErrorText ??
+    INCOMPLETE_TOOL_CALLS_PART_ERROR_TEXT;
+  const streamingMessageId = resolveStreamingMessageId({
+    conversationId: input.bootstrap.capturedConversationId,
+    lifecycleAdapter: input.bootstrap.lifecycleAdapter,
+    runContext: input.runContext,
+  });
+
+  const finalizeDetachedStreamEndIfNeeded = async () => {
+    if (finishHandlerStarted) {
+      return;
+    }
+
+    finishHandlerStarted = true;
+    await finalizeDetachedStreamEnd({
+      capturedMessageId: input.bootstrap.capturedMessageId,
+      streamResult: input.bootstrap.streamResult,
+      isAborted: input.abortSignal.aborted,
+      lastStreamError,
+      lifecycleAdapter: input.bootstrap.lifecycleAdapter,
+      mirroredToolChunkState: input.bootstrap.mirroredToolChunkState,
+      mirroredDurableOutput,
+      incompleteToolCallsPartErrorText,
+      cleanup: input.bootstrap.cleanup,
+      logger: input.logger,
+    });
+  };
+
+  const fail = async (error: unknown) => {
+    await input.runContext.withContext(async () => {
+      input.bootstrap.rootStreamWatchdog.dispose();
+      await input.bootstrap.cleanup().catch((cleanupError: unknown) => {
+        logCleanupError({ error: cleanupError, logger: input.logger });
+      });
+      await finalizeExecutionFailure({
+        lifecycleAdapter: input.bootstrap.lifecycleAdapter,
+        error,
+        conversationId: input.bootstrap.capturedConversationId,
+        runId: input.bootstrap.lifecycleAdapter.durableRootRun?.runId,
+        logMessage: "Failed to mark durable chat root run as failed",
+        logger: input.logger,
+      });
+    });
+  };
+
+  const streamOptions: HostedChatRuntimeToUiMessageStreamOptions = {
+    sendReasoning: true,
+    originalMessages: input.originalMessages,
+    onError: (error) => {
+      lastStreamError = error;
+      return input.runContext.withContext(() => getHostedStreamErrorText(error));
+    },
+    onFinish: ({ responseMessage, isAborted }) => {
+      finishHandlerStarted = true;
+      finishPromise = input.runContext.withContext(() =>
+        finalizeResponseFinish({
+          responseMessage,
+          isAborted,
+          streamResult: input.bootstrap.streamResult,
+          lastStreamError,
+          lifecycleAdapter: input.bootstrap.lifecycleAdapter,
+          mirroredToolChunkState: input.bootstrap.mirroredToolChunkState,
+          capturedMessageId: input.bootstrap.capturedMessageId,
+          incompleteToolCallsPartErrorText,
+          cleanup: input.bootstrap.cleanup,
+          logger: input.logger,
+        }).catch((error) =>
+          finalizeExecutionFailure({
+            lifecycleAdapter: input.bootstrap.lifecycleAdapter,
+            error,
+            conversationId: input.bootstrap.capturedConversationId,
+            runId: input.bootstrap.lifecycleAdapter.durableRootRun?.runId,
+            logMessage: "Failed to finalize durable chat root run",
+            logger: input.logger,
+          })
+        )
+      );
+    },
+    messageMetadata: createStreamMessageMetadataBuilder({
+      agentId: input.agentId,
+      modelId: input.modelId,
+      lifecycleAdapter: input.bootstrap.lifecycleAdapter,
+      streamingMessageId,
+    }),
+  };
+
+  if (input.responseMessageId) {
+    const responseMessageId = input.responseMessageId;
+    streamOptions.generateMessageId = () => responseMessageId;
+  }
+  const agentUIStream = input.bootstrap.streamResult.toUIMessageStream(streamOptions);
+
+  return {
+    agentUIStream: createHostedMirroredUiStream({
+      sourceStream: agentUIStream,
+      rootStreamWatchdog: input.bootstrap.rootStreamWatchdog,
+      mirroredToolChunkState: input.bootstrap.mirroredToolChunkState,
+      appendChunk: (chunk) => input.bootstrap.lifecycleAdapter.durableRunMirror?.handleChunk(chunk),
+      setMirroredOutput: (value) => {
+        mirroredDurableOutput = value;
+      },
+      logger: input.logger,
+    }),
+    fail,
+    waitForFinish: async () => {
+      try {
+        await finalizeDetachedStreamEndIfNeeded();
+        await finishPromise;
+      } finally {
+        input.bootstrap.rootStreamWatchdog.dispose();
+      }
+    },
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -798,6 +798,21 @@ export {
   type FinalizedMessageState,
 } from "./hosted-finalized-message.ts";
 export {
+  cleanupAfterHostedChatExecutionFinalization,
+  createHostedChatExecutionRuntime,
+  type CreateHostedChatExecutionRuntimeInput,
+  createHostedChatFinalizeDetachedBuildState,
+  createHostedChatFinalizeResponseBuildState,
+  createHostedChatStreamFinalizationHooks,
+  type HostedChatExecutionLifecycleAdapter,
+  type HostedChatExecutionRootStreamWatchdog,
+  type HostedChatExecutionRunContext,
+  type HostedChatExecutionRuntime,
+  type HostedChatExecutionRuntimeBootstrap,
+  type HostedChatExecutionRuntimeLogger,
+  toHostedChatExecutionFinalState,
+} from "./hosted-chat-execution-runtime.ts";
+export {
   finalizeHostedDetached,
   type FinalizeHostedDetachedOptions,
   finalizeHostedResponse,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.419";
+export const VERSION = "0.1.420";


### PR DESCRIPTION
## Summary\n- Add a reusable hosted chat execution runtime helper for root chat stream coordination and finalization.\n- Export the helper from the agent package surface.\n- Bump the package patch version to 0.1.420 for CI/CD publication.\n\n## Verification\n- deno test --allow-all src/agent/hosted-chat-execution-runtime.test.ts\n- deno task verify:quick\n- pre-push checks passed: fmt, lint, typecheck, unit tests (1700 passed / 0 failed)