### PR TITLE
Expose runtime tool result hooks

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.420",
+  "version": "0.1.421",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime-refresh.test.ts
+++ b/src/agent/runtime-refresh.test.ts
@@ -4,7 +4,7 @@ import { type ModelRuntime } from "#veryfront/provider";
 import { tool } from "#veryfront/tool";
 import { z } from "zod";
 import { agent } from "./index.ts";
-import type { RuntimeStateRequest } from "./types.ts";
+import type { RuntimeStateRequest, ToolExecutionResultRequest } from "./types.ts";
 
 function createRuntimeStream(parts: unknown[]) {
   return new ReadableStream<unknown>({
@@ -30,6 +30,146 @@ function extractSystemPrompt(options: unknown): string {
 }
 
 describe("agent runtime refresh hooks", () => {
+  it("notifies configured hooks after generate() executes a tool", async () => {
+    const toolResults: ToolExecutionResultRequest[] = [];
+    const model: ModelRuntime = {
+      provider: "hosted",
+      modelId: "hosted/tool-result-generate",
+      async doGenerate() {
+        return {
+          content: [{
+            type: "tool-call",
+            toolCallId: "write-1",
+            toolName: "write_report",
+            input: '{"path":"research/report.md"}',
+          }],
+          finishReason: "tool-calls",
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        };
+      },
+      async doStream() {
+        return { stream: createRuntimeStream([{ type: "finish", finishReason: "stop" }]) };
+      },
+    };
+
+    const writeReport = tool({
+      id: "write_report",
+      description: "Write a report",
+      inputSchema: z.object({ path: z.string() }),
+      execute: async ({ path }, context) => ({
+        path: `canonical/${path}`,
+        projectId: context?.projectId,
+      }),
+    });
+
+    const assistant = agent({
+      model: "hosted/tool-result-generate",
+      system: "Generate tool result hook test",
+      tools: { write_report: writeReport },
+      maxSteps: 1,
+      resolveModelTransport: async () => ({ model }),
+      onToolResult: (request) => {
+        toolResults.push(request);
+      },
+    });
+
+    await assistant.generate({
+      input: "Write a report",
+      context: { projectId: "project-generate" },
+    });
+
+    assertEquals(toolResults.length, 1);
+    assertEquals(toolResults[0]?.toolName, "write_report");
+    assertEquals(toolResults[0]?.toolCallId, "write-1");
+    assertEquals(toolResults[0]?.input, { path: "research/report.md" });
+    assertEquals(toolResults[0]?.result, {
+      path: "canonical/research/report.md",
+      projectId: "project-generate",
+    });
+    assertEquals(toolResults[0]?.context?.projectId, "project-generate");
+  });
+
+  it("notifies configured hooks after stream() executes a tool", async () => {
+    const toolResults: ToolExecutionResultRequest[] = [];
+    let callCount = 0;
+    const model: ModelRuntime = {
+      provider: "hosted",
+      modelId: "hosted/tool-result-stream",
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "unused" }],
+          finishReason: "stop",
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        };
+      },
+      async doStream() {
+        callCount++;
+
+        if (callCount === 1) {
+          return {
+            stream: createRuntimeStream([
+              {
+                type: "tool-call",
+                toolCallId: "write-stream-1",
+                toolName: "write_report",
+                input: '{"path":"research/stream-report.md"}',
+              },
+              {
+                type: "finish",
+                finishReason: "tool-calls",
+                usage: { inputTokens: 1, outputTokens: 1 },
+              },
+            ]),
+          };
+        }
+
+        return {
+          stream: createRuntimeStream([
+            { type: "text-delta", text: "stream complete" },
+            { type: "finish", finishReason: "stop", usage: { inputTokens: 1, outputTokens: 1 } },
+          ]),
+        };
+      },
+    };
+
+    const writeReport = tool({
+      id: "write_report",
+      description: "Write a report",
+      inputSchema: z.object({ path: z.string() }),
+      execute: async ({ path }, context) => ({
+        path: `canonical/${path}`,
+        projectId: context?.projectId,
+      }),
+    });
+
+    const assistant = agent({
+      model: "hosted/tool-result-stream",
+      system: "Stream tool result hook test",
+      tools: { write_report: writeReport },
+      resolveModelTransport: async () => ({ model }),
+      onToolResult: (request) => {
+        toolResults.push(request);
+      },
+    });
+
+    const response = (await assistant.stream({
+      input: "Write a report",
+      context: { projectId: "project-stream" },
+    })).toDataStreamResponse();
+
+    await response.text();
+
+    assertEquals(toolResults.length, 1);
+    assertEquals(toolResults[0]?.toolName, "write_report");
+    assertEquals(toolResults[0]?.toolCallId, "write-stream-1");
+    assertEquals(toolResults[0]?.input, { path: "research/stream-report.md" });
+    assertEquals(toolResults[0]?.result, {
+      path: "canonical/research/stream-report.md",
+      projectId: "project-stream",
+    });
+    assertEquals(toolResults[0]?.context?.projectId, "project-stream");
+  });
+
   it("refreshes system and context at step boundaries for generate()", async () => {
     const runtimeRequests: RuntimeStateRequest[] = [];
     const observedSystems: string[] = [];

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -21,6 +21,7 @@ import {
   type MessagePart,
   type ResolvedRuntimeState,
   type ToolCall,
+  type ToolExecutionResultRequest,
   type ToolResultPart,
 } from "../types.ts";
 import { ensureModelReady, type ModelRuntime, resolveModel } from "#veryfront/provider";
@@ -530,6 +531,15 @@ export class AgentRuntime {
     };
   }
 
+  private async notifyToolResult(
+    request: Omit<ToolExecutionResultRequest, "agentId">,
+  ): Promise<void> {
+    await this.config.onToolResult?.({
+      agentId: this.id,
+      ...request,
+    });
+  }
+
   /**
    * Generate a response (non-streaming)
    */
@@ -932,18 +942,27 @@ export class AgentRuntime {
               const startTime = Date.now();
 
               const cacheCtx = tryGetCacheKeyContext();
+              const executionContext = {
+                toolCallId: tc.toolCallId,
+                ...toolContext,
+                projectId: cacheCtx?.projectId ?? toolContext?.projectId,
+              };
               const result = await executeConfiguredTool(
                 tc.toolName,
                 toolCall.args,
                 this.config.tools,
-                {
-                  toolCallId: tc.toolCallId,
-                  ...toolContext,
-                  projectId: cacheCtx?.projectId ?? toolContext?.projectId,
-                },
+                executionContext,
                 allowedRemoteToolNames,
                 this.config.remoteTools,
               );
+              await this.notifyToolResult({
+                mode: "generate",
+                toolName: tc.toolName,
+                toolCallId: tc.toolCallId,
+                input: toolCall.args,
+                result,
+                context: executionContext,
+              });
 
               toolCall.status = "completed";
               toolCall.result = result;
@@ -1280,18 +1299,27 @@ export class AgentRuntime {
 
           callbacks?.onToolCall?.(toolCall);
 
+          const executionContext = {
+            toolCallId: tc.id,
+            ...toolContext,
+          };
           const result = await executeConfiguredTool(
             tc.name,
             toolCall.args,
             this.config.tools,
-            {
-              toolCallId: tc.id,
-              ...toolContext,
-            },
+            executionContext,
             allowedRemoteToolNames,
             this.config.remoteTools,
           );
           throwIfAborted(abortSignal);
+          await this.notifyToolResult({
+            mode: "stream",
+            toolName: tc.name,
+            toolCallId: tc.id,
+            input: toolCall.args,
+            result,
+            context: executionContext,
+          });
 
           toolCall.status = "completed";
           toolCall.result = result;

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -3,7 +3,7 @@
  **************************/
 
 import type { ModelRuntime } from "#veryfront/provider/types.ts";
-import type { RemoteToolSource, Tool } from "#veryfront/tool";
+import type { RemoteToolSource, Tool, ToolExecutionContext } from "#veryfront/tool";
 import { INVALID_ARGUMENT } from "#veryfront/errors/error-registry.ts";
 import type { Memory } from "./memory/memory-interface.ts";
 
@@ -106,6 +106,12 @@ export interface AgentConfig {
    */
   resolveRuntimeState?: RuntimeStateResolver;
   /**
+   * Optional hook invoked after the runtime executes a configured local,
+   * registry, integration, or remote tool and before the tool result is
+   * persisted or streamed back to callers.
+   */
+  onToolResult?: ToolExecutionResultHandler;
+  /**
    * Enable skills for this agent.
    * - true: include all discovered skills from skills/ directory
    * - string[]: include only specific skill IDs
@@ -157,6 +163,20 @@ export interface ResolvedRuntimeState {
 export type RuntimeStateResolver = (
   request: RuntimeStateRequest,
 ) => ResolvedRuntimeState | undefined | Promise<ResolvedRuntimeState | undefined>;
+
+export interface ToolExecutionResultRequest {
+  agentId: string;
+  mode: "generate" | "stream";
+  toolName: string;
+  toolCallId: string;
+  input: Record<string, unknown>;
+  result: unknown;
+  context?: ToolExecutionContext;
+}
+
+export type ToolExecutionResultHandler = (
+  request: ToolExecutionResultRequest,
+) => void | Promise<void>;
 
 // Import for use in AgentMiddleware
 import type { AgentContext, AgentResponse } from "./schemas/index.ts";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.420";
+export const VERSION = "0.1.421";


### PR DESCRIPTION
## Summary\n- add an AgentConfig onToolResult hook at the runtime tool execution boundary\n- invoke it for both generate() and stream() after configured tool execution succeeds\n- add regression coverage proving the hook sees tool name, call id, input, result, and execution context\n- bump veryfront to 0.1.421 for release\n\n## Root cause\nStaging proved the durable research mirror helper and API MCP create_file work when invoked directly in the deployed pod, but live agent runs still missed the hidden mirror. The wrapper around the remote tool source was therefore the wrong interception boundary. The runtime itself is the stable place that observes every configured tool result before persistence/streaming.\n\n## Test evidence\n- deno test --allow-all src/agent/runtime-refresh.test.ts\n- deno task typecheck\n- DENO_NO_PACKAGE_JSON=1 deno lint src/agent/types.ts src/agent/runtime/index.ts src/agent/runtime-refresh.test.ts src/utils/version-constant.ts\n- deno fmt --check deno.json src/utils/version-constant.ts src/agent/types.ts src/agent/runtime/index.ts src/agent/runtime-refresh.test.ts\n- deno check src/agent/index.ts src/agent/runtime/index.ts src/agent/runtime-refresh.test.ts\n- git diff --check\n- pre-push checks: fmt, lint, typecheck, unit tests: 1700 passed / 0 failed\n