### PR TITLE
Bump framework version to 0.1.422

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.421",
+  "version": "0.1.422",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.421";
+export const VERSION = "0.1.422";


### PR DESCRIPTION
## Summary\n- bump framework package version to 0.1.422 so the latest exported agent helpers publish through CI/CD\n\n## Verification\n- deno task verify:quick\n- pre-push checks: format, lint, typecheck, unit tests (1702 passed, 0 failed)