### PR TITLE
Share external agent worker client

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.422",
+  "version": "0.1.423",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/external-agent-worker-client.test.ts
+++ b/src/agent/external-agent-worker-client.test.ts
@@ -1,0 +1,200 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  createExternalAgentWorkerClient,
+  type ExternalAgentWorker,
+} from "./external-agent-worker-client.ts";
+
+const API_URL = "https://api.example.com";
+const API_TOKEN = "api-token";
+const WORKER_TOKEN = "worker-token";
+const PROJECT_REFERENCE = "testing-project";
+const WORKER_ID = "11111111-1111-4111-8111-111111111111";
+const PROJECT_ID = "22222222-2222-4222-8222-222222222222";
+const RUN_ID = "run_123";
+const CONVERSATION_ID = "33333333-3333-4333-8333-333333333333";
+
+type FetchCall = [RequestInfo | URL, RequestInit | undefined];
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function worker(overrides: Partial<ExternalAgentWorker> = {}): ExternalAgentWorker {
+  return {
+    id: WORKER_ID,
+    project_id: PROJECT_ID,
+    implementation_kind: "veryfront-codex",
+    worker_key: "local-codex",
+    display_name: "Local Codex",
+    status: "online",
+    metadata: null,
+    last_heartbeat_at: null,
+    ...overrides,
+  };
+}
+
+function fetchSequence(...responses: Response[]): {
+  calls: FetchCall[];
+  fetchImpl: typeof fetch;
+} {
+  const calls: FetchCall[] = [];
+  const queue = [...responses];
+  return {
+    calls,
+    fetchImpl: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push([input, init]);
+      const next = queue.shift();
+      if (!next) {
+        throw new Error("Unexpected fetch call");
+      }
+      return next;
+    }) as typeof fetch,
+  };
+}
+
+function authorization(call: FetchCall): string | null {
+  return new Headers(call[1]?.headers).get("Authorization");
+}
+
+function requestBody(call: FetchCall): unknown {
+  return JSON.parse(String(call[1]?.body));
+}
+
+describe("external agent worker client", () => {
+  it("registers a worker and uses its scoped worker token for worker-owned requests", async () => {
+    const { calls, fetchImpl } = fetchSequence(
+      jsonResponse({ worker: worker(), token: WORKER_TOKEN }, 201),
+      jsonResponse({ worker: worker({ status: "online" }) }),
+    );
+    const client = createExternalAgentWorkerClient({
+      apiUrl: `${API_URL}/`,
+      authToken: API_TOKEN,
+      fetch: fetchImpl,
+    });
+
+    const registeredWorker = await client.registerWorker({
+      projectReference: PROJECT_REFERENCE,
+      implementationKind: "veryfront-codex",
+      implementationDisplayName: "Veryfront Codex",
+      workerKey: "local-codex",
+      displayName: "Local Codex",
+      metadata: { workspaceIsolation: "project-conversation" },
+    });
+    await client.heartbeatWorker(registeredWorker.id);
+
+    assertEquals(
+      String(calls[0]?.[0]),
+      `${API_URL}/agent-workers/projects/${PROJECT_REFERENCE}/workers`,
+    );
+    assertEquals(authorization(calls[0]!), `Bearer ${API_TOKEN}`);
+    assertEquals(requestBody(calls[0]!), {
+      implementation_kind: "veryfront-codex",
+      implementation_display_name: "Veryfront Codex",
+      worker_key: "local-codex",
+      display_name: "Local Codex",
+      metadata: { workspaceIsolation: "project-conversation" },
+    });
+    assertEquals(
+      String(calls[1]?.[0]),
+      `${API_URL}/agent-workers/workers/${WORKER_ID}/heartbeat`,
+    );
+    assertEquals(authorization(calls[1]!), `Bearer ${WORKER_TOKEN}`);
+  });
+
+  it("claims runs, records sessions, appends events, and completes runs through the external worker contract", async () => {
+    const { calls, fetchImpl } = fetchSequence(
+      jsonResponse({ worker: worker(), token: WORKER_TOKEN }, 201),
+      jsonResponse({
+        run: {
+          run_id: RUN_ID,
+          conversation_id: CONVERSATION_ID,
+          message_id: "44444444-4444-4444-8444-444444444444",
+          project_id: PROJECT_ID,
+          agent_id: "veryfront-agent",
+          status: "running",
+          request_snapshot: { messages: [], tools: [], context: [] },
+          latest_event_id: 0,
+          latest_external_event_sequence: 4,
+          lease_owner: WORKER_ID,
+          lease_expires_at: "2026-05-08T12:00:00.000Z",
+          worker_session: null,
+        },
+      }),
+      jsonResponse({
+        session: {
+          id: "55555555-5555-4555-8555-555555555555",
+          run_id: RUN_ID,
+          implementation_kind: "veryfront-codex",
+          worker_id: WORKER_ID,
+          session_key: "codex-session-1",
+          status: "active",
+        },
+      }),
+      jsonResponse({ appended: true, latest_external_event_sequence: 6 }),
+      jsonResponse({ completed: true }),
+    );
+    const client = createExternalAgentWorkerClient({
+      apiUrl: API_URL,
+      authToken: API_TOKEN,
+      fetch: fetchImpl,
+    });
+
+    const registeredWorker = await client.registerWorker({
+      projectReference: PROJECT_REFERENCE,
+      implementationKind: "veryfront-codex",
+      implementationDisplayName: "Veryfront Codex",
+      workerKey: "local-codex",
+    });
+    const run = await client.claimRun({
+      workerId: registeredWorker.id,
+      leaseDurationSeconds: 30,
+    });
+    await client.recordSession({
+      workerId: registeredWorker.id,
+      runId: RUN_ID,
+      sessionKey: "codex-session-1",
+      status: "active",
+      metadata: { workspacePath: "/workspace" },
+    });
+    await client.appendRunEvents({
+      conversationId: CONVERSATION_ID,
+      runId: RUN_ID,
+      events: [{ type: "TEXT_MESSAGE_CHUNK", payload: { delta: "hello" } }],
+      expectedPreviousExternalEventSequence: run?.latest_external_event_sequence,
+    });
+    await client.completeRun({
+      runId: RUN_ID,
+      status: "completed",
+    });
+
+    assertEquals(
+      String(calls[1]?.[0]),
+      `${API_URL}/agent-workers/workers/${WORKER_ID}/claim`,
+    );
+    assertEquals(authorization(calls[1]!), `Bearer ${WORKER_TOKEN}`);
+    assertEquals(requestBody(calls[1]!), { lease_duration_seconds: 30 });
+    assertEquals(
+      String(calls[2]?.[0]),
+      `${API_URL}/agent-workers/workers/${WORKER_ID}/runs/${RUN_ID}/session`,
+    );
+    assertEquals(authorization(calls[2]!), `Bearer ${WORKER_TOKEN}`);
+    assertEquals(requestBody(calls[2]!), {
+      session_key: "codex-session-1",
+      status: "active",
+      metadata: { workspacePath: "/workspace" },
+    });
+    assertEquals(
+      String(calls[3]?.[0]),
+      `${API_URL}/conversations/${CONVERSATION_ID}/runs/${RUN_ID}/events`,
+    );
+    assertEquals(requestBody(calls[3]!), {
+      events: [{ type: "TEXT_MESSAGE_CHUNK", payload: { delta: "hello" } }],
+      expected_previous_external_event_sequence: 4,
+    });
+    assertEquals(String(calls[4]?.[0]), `${API_URL}/runs/${RUN_ID}/complete`);
+  });
+});

--- a/src/agent/external-agent-worker-client.ts
+++ b/src/agent/external-agent-worker-client.ts
@@ -1,0 +1,295 @@
+import { z } from "zod";
+
+export const ExternalAgentWorkerSchema = z.object({
+  id: z.string().uuid(),
+  project_id: z.string().uuid(),
+  implementation_kind: z.string(),
+  worker_key: z.string(),
+  display_name: z.string().nullable().optional(),
+  status: z.string().optional(),
+  metadata: z.unknown().nullable().optional(),
+  last_heartbeat_at: z.string().nullable().optional(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+});
+
+const ExternalAgentWorkerRequestMessageSchema = z.object({
+  id: z.string(),
+  role: z.string(),
+  parts: z.array(z.object({ type: z.string() }).passthrough()).default([]),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  createdAt: z.string().optional(),
+});
+
+export const ExternalAgentWorkerRequestSnapshotSchema = z.object({
+  messages: z.array(ExternalAgentWorkerRequestMessageSchema),
+  tools: z.array(z.unknown()).default([]),
+  context: z.array(z.unknown()).default([]),
+  forwardedProps: z.record(z.string(), z.unknown()).optional(),
+  traceContext: z.unknown().optional(),
+});
+
+export const ExternalAgentWorkerSessionSchema = z.object({
+  id: z.string().uuid(),
+  run_id: z.string(),
+  implementation_kind: z.string(),
+  worker_id: z.string().uuid().nullable(),
+  session_key: z.string(),
+  status: z.string(),
+  metadata: z.unknown().nullable().optional(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+  ended_at: z.string().nullable().optional(),
+});
+
+export const ExternalAgentWorkerRunSchema = z.object({
+  run_id: z.string(),
+  conversation_id: z.string().uuid(),
+  message_id: z.string().uuid(),
+  project_id: z.string().uuid().nullable(),
+  agent_id: z.string(),
+  status: z.string(),
+  request_snapshot: ExternalAgentWorkerRequestSnapshotSchema.nullable(),
+  source_target_kind: z.string().nullable().optional(),
+  source_target_environment_id: z.string().uuid().nullable().optional(),
+  source_target_branch_id: z.string().uuid().nullable().optional(),
+  runtime_target_kind: z.string().nullable().optional(),
+  runtime_target_environment_id: z.string().uuid().nullable().optional(),
+  runtime_target_branch_id: z.string().uuid().nullable().optional(),
+  latest_event_id: z.number(),
+  latest_external_event_sequence: z.number(),
+  lease_owner: z.string().nullable(),
+  lease_expires_at: z.string().nullable(),
+  worker_session: ExternalAgentWorkerSessionSchema.nullable().default(null),
+});
+
+const RegisterExternalAgentWorkerResponseSchema = z.object({
+  worker: ExternalAgentWorkerSchema,
+  token: z.string().min(1),
+});
+
+export type ExternalAgentWorker = z.infer<typeof ExternalAgentWorkerSchema>;
+export type ExternalAgentWorkerRequestSnapshot = z.infer<
+  typeof ExternalAgentWorkerRequestSnapshotSchema
+>;
+export type ExternalAgentWorkerRun = z.infer<typeof ExternalAgentWorkerRunSchema>;
+export type ExternalAgentWorkerSession = z.infer<
+  typeof ExternalAgentWorkerSessionSchema
+>;
+
+export interface ExternalAgentWorkerClientOptions {
+  apiUrl: string;
+  authToken: string;
+  fetch?: typeof fetch;
+}
+
+export interface RegisterExternalAgentWorkerInput {
+  projectReference: string;
+  implementationKind: string;
+  implementationDisplayName: string;
+  workerKey: string;
+  displayName?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ClaimExternalAgentWorkerRunInput {
+  workerId: string;
+  leaseDurationSeconds: number;
+}
+
+export interface RecordExternalAgentWorkerSessionInput {
+  workerId: string;
+  runId: string;
+  sessionKey: string;
+  status?: "active" | "completed" | "failed" | "cancelled";
+  metadata?: Record<string, unknown>;
+}
+
+export interface CompleteExternalAgentWorkerRunInput {
+  runId: string;
+  status: "completed" | "failed" | "cancelled";
+  terminalErrorCode?: string;
+  terminalErrorMessage?: string;
+}
+
+export interface AppendExternalAgentWorkerRunEventsInput {
+  conversationId: string;
+  runId: string;
+  events: unknown[];
+  expectedPreviousExternalEventSequence?: number;
+}
+
+export interface ExternalAgentWorkerClient {
+  registerWorker(input: RegisterExternalAgentWorkerInput): Promise<ExternalAgentWorker>;
+  heartbeatWorker(workerId: string): Promise<ExternalAgentWorker>;
+  claimRun(input: ClaimExternalAgentWorkerRunInput): Promise<ExternalAgentWorkerRun | null>;
+  renewLease(input: ClaimExternalAgentWorkerRunInput & { runId: string }): Promise<
+    ExternalAgentWorkerRun | null
+  >;
+  recordSession(input: RecordExternalAgentWorkerSessionInput): Promise<
+    ExternalAgentWorkerSession
+  >;
+  appendRunEvents(input: AppendExternalAgentWorkerRunEventsInput): Promise<void>;
+  completeRun(input: CompleteExternalAgentWorkerRunInput): Promise<void>;
+}
+
+class DefaultExternalAgentWorkerClient implements ExternalAgentWorkerClient {
+  readonly #apiUrl: string;
+  readonly #authToken: string;
+  readonly #fetch: typeof fetch;
+  readonly #workerTokensByWorkerId = new Map<string, string>();
+
+  constructor(options: ExternalAgentWorkerClientOptions) {
+    this.#apiUrl = options.apiUrl.replace(/\/$/, "");
+    this.#authToken = options.authToken;
+    this.#fetch = options.fetch ?? fetch;
+  }
+
+  async #request<S extends z.ZodTypeAny>(
+    path: string,
+    schema: S,
+    init: RequestInit = {},
+    options: { workerId?: string } = {},
+  ): Promise<z.output<S>> {
+    const token = options.workerId
+      ? this.#workerTokensByWorkerId.get(options.workerId) ?? this.#authToken
+      : this.#authToken;
+    const response = await this.#fetch(`${this.#apiUrl}${path}`, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        ...init.headers,
+      },
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(body || `Veryfront API returned HTTP ${response.status}`);
+    }
+
+    return schema.parse(await response.json());
+  }
+
+  async registerWorker(
+    input: RegisterExternalAgentWorkerInput,
+  ): Promise<ExternalAgentWorker> {
+    const response = await this.#request(
+      `/agent-workers/projects/${encodeURIComponent(input.projectReference)}/workers`,
+      RegisterExternalAgentWorkerResponseSchema,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          implementation_kind: input.implementationKind,
+          implementation_display_name: input.implementationDisplayName,
+          worker_key: input.workerKey,
+          display_name: input.displayName,
+          metadata: input.metadata,
+        }),
+      },
+    );
+
+    this.#workerTokensByWorkerId.set(response.worker.id, response.token);
+    return response.worker;
+  }
+
+  async heartbeatWorker(workerId: string): Promise<ExternalAgentWorker> {
+    const response = await this.#request(
+      `/agent-workers/workers/${encodeURIComponent(workerId)}/heartbeat`,
+      z.object({ worker: ExternalAgentWorkerSchema }),
+      { method: "POST" },
+      { workerId },
+    );
+    return response.worker;
+  }
+
+  async claimRun(
+    input: ClaimExternalAgentWorkerRunInput,
+  ): Promise<ExternalAgentWorkerRun | null> {
+    const response = await this.#request(
+      `/agent-workers/workers/${encodeURIComponent(input.workerId)}/claim`,
+      z.object({ run: ExternalAgentWorkerRunSchema.nullable() }),
+      {
+        method: "POST",
+        body: JSON.stringify({ lease_duration_seconds: input.leaseDurationSeconds }),
+      },
+      { workerId: input.workerId },
+    );
+    return response.run;
+  }
+
+  async renewLease(
+    input: ClaimExternalAgentWorkerRunInput & { runId: string },
+  ): Promise<ExternalAgentWorkerRun | null> {
+    const response = await this.#request(
+      `/agent-workers/workers/${encodeURIComponent(input.workerId)}/runs/${
+        encodeURIComponent(input.runId)
+      }/lease`,
+      z.object({ run: ExternalAgentWorkerRunSchema.nullable() }),
+      {
+        method: "POST",
+        body: JSON.stringify({ lease_duration_seconds: input.leaseDurationSeconds }),
+      },
+      { workerId: input.workerId },
+    );
+    return response.run;
+  }
+
+  async recordSession(
+    input: RecordExternalAgentWorkerSessionInput,
+  ): Promise<ExternalAgentWorkerSession> {
+    const response = await this.#request(
+      `/agent-workers/workers/${encodeURIComponent(input.workerId)}/runs/${
+        encodeURIComponent(input.runId)
+      }/session`,
+      z.object({ session: ExternalAgentWorkerSessionSchema }),
+      {
+        method: "PUT",
+        body: JSON.stringify({
+          session_key: input.sessionKey,
+          status: input.status,
+          metadata: input.metadata,
+        }),
+      },
+      { workerId: input.workerId },
+    );
+    return response.session;
+  }
+
+  async appendRunEvents(input: AppendExternalAgentWorkerRunEventsInput): Promise<void> {
+    await this.#request(
+      `/conversations/${encodeURIComponent(input.conversationId)}/runs/${
+        encodeURIComponent(input.runId)
+      }/events`,
+      z.unknown(),
+      {
+        method: "POST",
+        body: JSON.stringify({
+          events: input.events,
+          expected_previous_external_event_sequence: input.expectedPreviousExternalEventSequence,
+        }),
+      },
+    );
+  }
+
+  async completeRun(input: CompleteExternalAgentWorkerRunInput): Promise<void> {
+    await this.#request(
+      `/runs/${encodeURIComponent(input.runId)}/complete`,
+      z.unknown(),
+      {
+        method: "POST",
+        body: JSON.stringify({
+          status: input.status,
+          terminal_error_code: input.terminalErrorCode,
+          terminal_error_message: input.terminalErrorMessage,
+        }),
+      },
+    );
+  }
+}
+
+export function createExternalAgentWorkerClient(
+  options: ExternalAgentWorkerClientOptions,
+): ExternalAgentWorkerClient {
+  return new DefaultExternalAgentWorkerClient(options);
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -872,6 +872,24 @@ export {
   type TerminalConversationRunStatus,
 } from "./durable.ts";
 export {
+  type AppendExternalAgentWorkerRunEventsInput,
+  type ClaimExternalAgentWorkerRunInput,
+  type CompleteExternalAgentWorkerRunInput,
+  createExternalAgentWorkerClient,
+  type ExternalAgentWorker,
+  type ExternalAgentWorkerClient,
+  type ExternalAgentWorkerClientOptions,
+  type ExternalAgentWorkerRequestSnapshot,
+  ExternalAgentWorkerRequestSnapshotSchema,
+  type ExternalAgentWorkerRun,
+  ExternalAgentWorkerRunSchema,
+  ExternalAgentWorkerSchema,
+  type ExternalAgentWorkerSession,
+  ExternalAgentWorkerSessionSchema,
+  type RecordExternalAgentWorkerSessionInput,
+  type RegisterExternalAgentWorkerInput,
+} from "./external-agent-worker-client.ts";
+export {
   buildInvokeAgentChildRunLifecycleCustomEvent,
   buildInvokeAgentChildRunProgressEvents,
   buildInvokeAgentChildRunStateDelta,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.422";
+export const VERSION = "0.1.423";


### PR DESCRIPTION
## Summary
- add a shared `veryfront/agent` external-agent worker client for registration, heartbeat, claim, lease renewal, session recording, event append, and run completion
- preserve scoped worker-token auth and injectable fetch for adapter testability
- bump package version to `0.1.423` so adapters can consume the released helper

## Verification
- `deno test --allow-all src/agent/external-agent-worker-client.test.ts`
- `deno test --no-check --allow-all --parallel src/agent/external-agent-worker-client.test.ts src/agent/durable.test.ts`
- `deno task typecheck`
- `deno check src/agent/index.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts src/agent/external-agent-worker-client.ts src/agent/external-agent-worker-client.test.ts src/agent/index.ts`
- `deno lint src/agent/external-agent-worker-client.ts src/agent/external-agent-worker-client.test.ts src/agent/index.ts`
- `git diff --check`
- pre-push hook: full unit suite passed (`1703 passed`, `0 failed`)

## Follow-up
After this releases, `veryfront-agent-codex` can replace its duplicated worker registration/claim/session/event client with this public helper.