### PR TITLE
Keep native npm dependencies optional for agent clients

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.423",
+  "version": "0.1.424",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -17,6 +17,7 @@ import {
 	BROWSER_SAFE_DNT_TIMER_MODULES,
 	BROWSER_SAFE_EXPORTS,
 } from "./browser-safe-exports.mjs";
+import { normalizeNpmPackageMetadata } from "./npm-package-metadata.ts";
 
 const denoJson = JSON.parse(await Deno.readTextFile("./deno.json"));
 const version = denoJson.version;
@@ -168,6 +169,11 @@ await build({
 
 	// Post-build steps
 	async postBuild() {
+		const pkgPath = "./npm/package.json";
+		const initialPkg = JSON.parse(await Deno.readTextFile(pkgPath));
+		normalizeNpmPackageMetadata(initialPkg);
+		await Deno.writeTextFile(pkgPath, JSON.stringify(initialPkg, null, 2));
+
 		// Run npm install with --legacy-peer-deps to avoid peer dep conflicts
 		// (e.g., @ai-sdk/react requires react ~19.1.2 but framework uses 19.1.1)
 		const npmInstall = new Deno.Command("npm", {
@@ -258,8 +264,8 @@ await build({
 		}, null, 2));
 
 		// Update package.json with bin entry and type
-		const pkgPath = "./npm/package.json";
 		const pkg = JSON.parse(await Deno.readTextFile(pkgPath));
+		normalizeNpmPackageMetadata(pkg);
 		pkg.type = "module"; // Required for ESM imports without warnings
 		pkg.types = "./esm/src/index.d.ts";
 		pkg.bin = { veryfront: "bin/veryfront.js" };

--- a/scripts/build/npm-package-metadata.ts
+++ b/scripts/build/npm-package-metadata.ts
@@ -1,0 +1,24 @@
+type PackageJson = {
+	dependencies?: Record<string, string>;
+	optionalDependencies?: Record<string, string>;
+	peerDependencies?: Record<string, string>;
+	peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+};
+
+const OPTIONAL_NATIVE_PEERS = {
+	"better-sqlite3": ">=9.0.0",
+} as const;
+
+export function normalizeNpmPackageMetadata(pkg: PackageJson): PackageJson {
+	for (const [name, range] of Object.entries(OPTIONAL_NATIVE_PEERS)) {
+		delete pkg.dependencies?.[name];
+
+		pkg.peerDependencies ??= {};
+		pkg.peerDependencies[name] = range;
+
+		pkg.peerDependenciesMeta ??= {};
+		pkg.peerDependenciesMeta[name] = { optional: true };
+	}
+
+	return pkg;
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.423";
+export const VERSION = "0.1.424";

--- a/tests/build/npm-package-metadata.test.ts
+++ b/tests/build/npm-package-metadata.test.ts
@@ -1,0 +1,23 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { normalizeNpmPackageMetadata } from "../../scripts/build/npm-package-metadata.ts";
+
+Deno.test("keeps native sqlite support optional for npm consumers", () => {
+  const pkg = normalizeNpmPackageMetadata({
+    dependencies: {
+      "better-sqlite3": "9.6.0",
+      "@kreuzberg/node": "^4.4.2",
+    },
+    peerDependencies: {},
+    peerDependenciesMeta: {},
+  });
+
+  assertEquals(pkg.dependencies, {
+    "@kreuzberg/node": "^4.4.2",
+  });
+  assertEquals(pkg.peerDependencies, {
+    "better-sqlite3": ">=9.0.0",
+  });
+  assertEquals(pkg.peerDependenciesMeta, {
+    "better-sqlite3": { optional: true },
+  });
+});


### PR DESCRIPTION
## Summary
- normalize generated npm metadata before release-time install and before publish
- keep better-sqlite3 as an optional peer, not a required dependency
- bump veryfront to 0.1.424 for release

## Verification
- deno test --allow-all tests/build/npm-package-metadata.test.ts
- deno lint scripts/build/npm-package-metadata.ts tests/build/npm-package-metadata.test.ts
- deno fmt --check scripts/build/build-npm-dnt.ts scripts/build/npm-package-metadata.ts tests/build/npm-package-metadata.test.ts deno.json src/utils/version-constant.ts
- deno run -A scripts/build/build-npm-dnt.ts
- generated npm/package.json check: dependencies.better-sqlite3 is absent, peerDependencies.better-sqlite3 is >=9.0.0, peerDependenciesMeta.better-sqlite3.optional is true
- generated npm/node_modules check: better-sqlite3 not installed
- deno task typecheck
- pre-push hook: 1703 passed, 0 failed
- git diff --check