### PR TITLE
Add hosted project remote tool source

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.424",
+  "version": "0.1.425",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-project-remote-tool-source.test.ts
+++ b/src/agent/hosted-project-remote-tool-source.test.ts
@@ -1,0 +1,223 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import type { RemoteToolSource, ToolDefinition, ToolExecutionContext } from "#veryfront/tool";
+import { createHostedProjectRemoteToolSource } from "./hosted-project-remote-tool-source.ts";
+
+function projectFileTool(name: string): ToolDefinition {
+  return {
+    name,
+    description: `${name} description`,
+    parameters: {
+      type: "object",
+      properties: {
+        project_reference: { type: "string" },
+        path: { type: "string" },
+      },
+      required: ["project_reference", "path"],
+    },
+  };
+}
+
+function navigationTool(name: string): ToolDefinition {
+  return {
+    name,
+    description: `${name} description`,
+    parameters: {
+      type: "object",
+      properties: {
+        project_id: { type: "string" },
+      },
+      required: ["project_id"],
+    },
+  };
+}
+
+function createRemoteSource(input: {
+  tools: ToolDefinition[];
+  execute?: (
+    toolName: string,
+    args: unknown,
+    context?: ToolExecutionContext,
+  ) => Promise<unknown> | unknown;
+}): RemoteToolSource {
+  return {
+    id: "source-1",
+    listTools: () => Promise.resolve(input.tools),
+    executeTool: (toolName, args, context) =>
+      input.execute?.(toolName, args, context) ?? { ok: true },
+  };
+}
+
+Deno.test("createHostedProjectRemoteToolSource scopes tool listings and hydrates project inputs", async () => {
+  const executeCalls: Array<{ toolName: string; args: unknown; context?: ToolExecutionContext }> =
+    [];
+  const source = createHostedProjectRemoteToolSource({
+    source: createRemoteSource({
+      tools: [projectFileTool("update_file"), navigationTool("studio_open_project")],
+      execute: (toolName, args, context) => {
+        executeCalls.push({ toolName, args, context });
+        return { ok: true };
+      },
+    }),
+    defaultProjectId: () => "project-1",
+    projectScopedRemoteToolOptions: {
+      projectNavigationToolNames: ["studio_open_project"],
+    },
+  });
+
+  assertEquals(
+    (await source.listTools()).map((tool) => tool.name),
+    ["update_file", "studio_open_project"],
+  );
+
+  await source.executeTool("update_file", { path: "AGENTS.md" });
+
+  assertEquals(executeCalls, [
+    {
+      toolName: "update_file",
+      args: { path: "AGENTS.md", project_reference: "project-1" },
+      context: { projectId: "project-1" },
+    },
+  ]);
+});
+
+Deno.test("createHostedProjectRemoteToolSource applies local input preparation before execution", async () => {
+  let executedArgs: unknown;
+  const source = createHostedProjectRemoteToolSource({
+    source: createRemoteSource({
+      tools: [projectFileTool("create_file")],
+      execute: (_toolName, args) => {
+        executedArgs = args;
+        return { ok: true };
+      },
+    }),
+    defaultProjectId: "project-1",
+    prepareToolInput: ({ toolInput }) => ({
+      ...toolInput,
+      path: "research/report.md",
+    }),
+  });
+
+  await source.executeTool("create_file", { content: "hello" });
+
+  assertEquals(executedArgs, {
+    content: "hello",
+    path: "research/report.md",
+    project_reference: "project-1",
+  });
+});
+
+Deno.test("createHostedProjectRemoteToolSource retries configured write collisions with the fallback tool", async () => {
+  const executeCalls: string[] = [];
+  const source = createHostedProjectRemoteToolSource({
+    source: createRemoteSource({
+      tools: [projectFileTool("create_file"), projectFileTool("update_file")],
+      execute: (toolName) => {
+        executeCalls.push(toolName);
+        return toolName === "create_file"
+          ? { isError: true, message: "file already exists" }
+          : { ok: true };
+      },
+    }),
+    defaultProjectId: "project-1",
+    shouldRetryWithTool: ({ error }) => {
+      if (typeof error !== "object" || error === null) {
+        return false;
+      }
+      return Reflect.get(error, "message") === "file already exists";
+    },
+  });
+
+  assertEquals(await source.executeTool("create_file", { path: "report.md" }), { ok: true });
+  assertEquals(executeCalls, ["create_file", "update_file"]);
+});
+
+Deno.test("createHostedProjectRemoteToolSource retries thrown errors and rethrows non-retry errors", async () => {
+  const executeCalls: string[] = [];
+  const source = createHostedProjectRemoteToolSource({
+    source: createRemoteSource({
+      tools: [projectFileTool("create_file"), projectFileTool("update_file")],
+      execute: (toolName) => {
+        executeCalls.push(toolName);
+        if (toolName === "create_file") {
+          throw new Error("file already exists");
+        }
+        return { ok: true };
+      },
+    }),
+    defaultProjectId: "project-1",
+    shouldRetryWithTool: ({ error }) =>
+      error instanceof Error && error.message === "file already exists",
+  });
+
+  assertEquals(await source.executeTool("create_file", { path: "report.md" }), { ok: true });
+  assertEquals(executeCalls, ["create_file", "update_file"]);
+
+  const failingSource = createHostedProjectRemoteToolSource({
+    source: createRemoteSource({
+      tools: [projectFileTool("create_file")],
+      execute: () => {
+        throw new Error("permission denied");
+      },
+    }),
+    defaultProjectId: "project-1",
+    shouldRetryWithTool: () => false,
+  });
+
+  await assertRejects(
+    () => failingSource.executeTool("create_file", { path: "report.md" }),
+    Error,
+    "permission denied",
+  );
+});
+
+Deno.test("createHostedProjectRemoteToolSource reports project navigation and steering mutations", async () => {
+  const switchedProjects: string[] = [];
+  const mutations: Array<{ instructionsChanged: boolean; skillsChanged: boolean }> = [];
+  const source = createHostedProjectRemoteToolSource({
+    source: createRemoteSource({
+      tools: [navigationTool("studio_open_project"), projectFileTool("update_file")],
+      execute: (toolName) => {
+        if (toolName === "studio_open_project") {
+          return { success: true, project_id: "project-2" };
+        }
+        return { success: true };
+      },
+    }),
+    defaultProjectId: () => "project-1",
+    projectScopedRemoteToolOptions: {
+      projectNavigationToolNames: ["studio_open_project"],
+    },
+    onProjectSwitch: (projectId) => {
+      switchedProjects.push(projectId);
+    },
+    onSteeringMutation: (mutation) => {
+      mutations.push({
+        instructionsChanged: mutation.instructionsChanged,
+        skillsChanged: mutation.skillsChanged,
+      });
+    },
+  });
+
+  await source.executeTool("studio_open_project", { project_id: "project-2" });
+  await source.executeTool("update_file", { path: "AGENTS.md" });
+
+  assertEquals(switchedProjects, ["project-2"]);
+  assertEquals(mutations, [{ instructionsChanged: true, skillsChanged: false }]);
+});
+
+Deno.test("createHostedProjectRemoteToolSource skips mutation callbacks for failed results", async () => {
+  let mutationCount = 0;
+  const source = createHostedProjectRemoteToolSource({
+    source: createRemoteSource({
+      tools: [projectFileTool("update_file")],
+      execute: () => ({ isError: true }),
+    }),
+    defaultProjectId: "project-1",
+    onSteeringMutation: () => {
+      mutationCount += 1;
+    },
+  });
+
+  assertEquals(await source.executeTool("update_file", { path: "AGENTS.md" }), { isError: true });
+  assertEquals(mutationCount, 0);
+});

--- a/src/agent/hosted-project-remote-tool-source.ts
+++ b/src/agent/hosted-project-remote-tool-source.ts
@@ -1,0 +1,176 @@
+import {
+  createProjectScopedRemoteToolCatalog,
+  isProjectNavigationRemoteTool,
+  type ProjectScopedRemoteToolDefaultProjectId,
+  type ProjectScopedRemoteToolOptions,
+  type RemoteToolSource,
+  type ToolExecutionContext,
+} from "#veryfront/tool";
+import { toChildRunToolInputRecord } from "./child-run-execution-support.ts";
+import { getConfirmedProjectContextSwitchId } from "./project-context.ts";
+import {
+  getProjectSteeringMutation,
+  isSuccessfulProjectSteeringMutationResult,
+  type ProjectSteeringMutationResult,
+  type ProjectSteeringPaths,
+} from "./project-steering-mutation.ts";
+
+export type HostedProjectRemoteToolSourceMutationHandler = (
+  mutation: ProjectSteeringMutationResult,
+) => Promise<void> | void;
+
+export type HostedProjectRemoteToolSourceProjectSwitchHandler = (
+  projectId: string,
+) => Promise<void> | void;
+
+export type HostedProjectRemoteToolSourcePrepareToolInput = (input: {
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  context?: ToolExecutionContext;
+}) => Record<string, unknown>;
+
+export type HostedProjectRemoteToolSourceRetryPolicy = (input: {
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  activeProjectId: string | null;
+  activeBranchId: string | null;
+  error: unknown;
+}) => boolean;
+
+export type CreateHostedProjectRemoteToolSourceInput = {
+  source: RemoteToolSource;
+  defaultProjectId?: ProjectScopedRemoteToolDefaultProjectId;
+  getActiveBranchId?: () => string | null | undefined;
+  allowedToolNames?: ReadonlySet<string> | null;
+  projectScopedRemoteToolOptions?: ProjectScopedRemoteToolOptions;
+  prepareToolInput?: HostedProjectRemoteToolSourcePrepareToolInput;
+  retryToolName?: string;
+  shouldRetryWithTool?: HostedProjectRemoteToolSourceRetryPolicy;
+  steeringPaths?: ProjectSteeringPaths;
+  onProjectSwitch?: HostedProjectRemoteToolSourceProjectSwitchHandler;
+  onSteeringMutation?: HostedProjectRemoteToolSourceMutationHandler;
+};
+
+function resolveActiveBranchId(
+  getActiveBranchId: (() => string | null | undefined) | undefined,
+): string | null {
+  return getActiveBranchId?.() ?? null;
+}
+
+export function createHostedProjectRemoteToolSource(
+  input: CreateHostedProjectRemoteToolSourceInput,
+): RemoteToolSource {
+  const toolCatalog = createProjectScopedRemoteToolCatalog({
+    source: input.source,
+    defaultProjectId: input.defaultProjectId,
+    allowedToolNames: input.allowedToolNames,
+    projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions,
+  });
+  const retryToolName = input.retryToolName ?? "update_file";
+
+  async function executeWithRetry(inputExecution: {
+    toolName: string;
+    toolInput: Record<string, unknown>;
+    executeContext?: ToolExecutionContext;
+    activeProjectId: string | null;
+    activeBranchId: string | null;
+  }): Promise<unknown> {
+    try {
+      return await input.source.executeTool(
+        inputExecution.toolName,
+        inputExecution.toolInput,
+        inputExecution.executeContext,
+      );
+    } catch (error) {
+      if (
+        input.shouldRetryWithTool?.({
+          toolName: inputExecution.toolName,
+          toolInput: inputExecution.toolInput,
+          activeProjectId: inputExecution.activeProjectId,
+          activeBranchId: inputExecution.activeBranchId,
+          error,
+        })
+      ) {
+        return input.source.executeTool(
+          retryToolName,
+          inputExecution.toolInput,
+          inputExecution.executeContext,
+        );
+      }
+
+      throw error;
+    }
+  }
+
+  return {
+    id: input.source.id,
+    listTools: (context) => toolCatalog.listTools(context),
+    async executeTool(toolName, args, context) {
+      const normalizedToolInput = input.prepareToolInput?.({
+        toolName,
+        toolInput: toChildRunToolInputRecord(args),
+        context,
+      }) ?? toChildRunToolInputRecord(args);
+      const {
+        activeProjectId,
+        toolInput: hydratedToolInput,
+        executeContext,
+      } = await toolCatalog.prepareExecution({
+        toolName,
+        toolInput: normalizedToolInput,
+        context,
+      });
+      const activeBranchId = resolveActiveBranchId(input.getActiveBranchId);
+      let result = await executeWithRetry({
+        toolName,
+        toolInput: hydratedToolInput,
+        executeContext,
+        activeProjectId,
+        activeBranchId,
+      });
+
+      if (
+        input.shouldRetryWithTool?.({
+          toolName,
+          toolInput: hydratedToolInput,
+          activeProjectId,
+          activeBranchId,
+          error: result,
+        })
+      ) {
+        result = await input.source.executeTool(retryToolName, hydratedToolInput, executeContext);
+      }
+
+      if (!isSuccessfulProjectSteeringMutationResult(result)) {
+        return result;
+      }
+
+      if (isProjectNavigationRemoteTool(toolName, input.projectScopedRemoteToolOptions)) {
+        const requestedProjectId = normalizedToolInput.project_id;
+        const confirmedProjectId = typeof requestedProjectId === "string"
+          ? getConfirmedProjectContextSwitchId(result, requestedProjectId)
+          : null;
+
+        if (confirmedProjectId) {
+          await input.onProjectSwitch?.(confirmedProjectId);
+        }
+
+        return result;
+      }
+
+      const mutation = getProjectSteeringMutation({
+        toolName,
+        toolInput: hydratedToolInput,
+        activeProjectId,
+        activeBranchId,
+        steeringPaths: input.steeringPaths,
+      });
+
+      if (mutation.instructionsChanged || mutation.skillsChanged) {
+        await input.onSteeringMutation?.(mutation);
+      }
+
+      return result;
+    },
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -118,6 +118,14 @@ export {
   wrapHostedChildSteeringMutationTool,
   type WrapHostedChildSteeringMutationToolInput,
 } from "./hosted-child-steering-tools.ts";
+export {
+  createHostedProjectRemoteToolSource,
+  type CreateHostedProjectRemoteToolSourceInput,
+  type HostedProjectRemoteToolSourceMutationHandler,
+  type HostedProjectRemoteToolSourcePrepareToolInput,
+  type HostedProjectRemoteToolSourceProjectSwitchHandler,
+  type HostedProjectRemoteToolSourceRetryPolicy,
+} from "./hosted-project-remote-tool-source.ts";
 
 export {
   DEFAULT_PROJECT_STEERING_PATHS,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.424";
+export const VERSION = "0.1.425";


### PR DESCRIPTION
## Summary
- add a hosted project-aware remote tool source wrapper
- centralize project-scoped listing, input hydration, fallback retries, project navigation callbacks, and steering mutation callbacks
- export the helper from veryfront/agent and bump package version to 0.1.425

## Verification
- deno test --no-check --allow-all src/agent/hosted-project-remote-tool-source.test.ts
- deno task verify:quick
- pre-push checks passed: format, lint, typecheck, unit tests