### PR TITLE
Add AG-UI chat response helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.425",
+  "version": "0.1.426",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/ag-ui-chat-ui-chunk-browser-encoder.test.ts
+++ b/src/agent/ag-ui-chat-ui-chunk-browser-encoder.test.ts
@@ -1,8 +1,9 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ChatUiMessageChunk } from "#veryfront/chat/protocol.ts";
 import {
   createAgUiChatUiChunkBrowserEncoder,
+  createAgUiChatUiTrackedBrowserResponse,
   getAgUiChatUiMessageChunkMetadata,
   getAgUiChatUiMessageUsageMetadata,
   normalizeChatUiMessageChunkToAgUiRuntimeEvent,
@@ -175,5 +176,59 @@ describe("agent/ag-ui-chat-ui-chunk-browser-encoder", () => {
         },
       ],
     );
+  });
+
+  it("creates a tracked browser response for chat UI chunks", async () => {
+    const response = createAgUiChatUiTrackedBrowserResponse({
+      agUiInput: {
+        threadId: crypto.randomUUID(),
+        runId: "run_1",
+        messages: [],
+        tools: [],
+        context: [],
+      },
+      agentId: "agent-1",
+      modelId: "custom/model",
+      resolveProvider: (modelId) => modelId === "custom/model" ? "custom-provider" : undefined,
+      execution: {
+        agentUIStream: {
+          async *[Symbol.asyncIterator]() {
+            yield {
+              type: "start",
+              messageId: "msg-1",
+              messageMetadata: { modelId: "custom/model" },
+            };
+            yield {
+              type: "text-delta",
+              id: "msg-1",
+              delta: "hello",
+            };
+            yield {
+              type: "finish",
+              finishReason: "stop",
+              messageMetadata: {
+                modelId: "custom/model",
+                usage: {
+                  inputTokens: 2,
+                  outputTokens: 3,
+                },
+              },
+            };
+          },
+        },
+        fail: async () => {},
+        waitForFinish: async () => {},
+      },
+    });
+
+    const text = await response.text();
+    assertStringIncludes(text, "event: RunStarted");
+    assertStringIncludes(text, "event: TextMessageContent");
+    assertStringIncludes(text, '"model":"custom/model"');
+    assertStringIncludes(text, '"provider":"custom-provider"');
+    assertStringIncludes(text, '"inputTokens":2');
+    assertStringIncludes(text, '"outputTokens":3');
+    assertStringIncludes(text, '"totalTokens":5');
+    assertStringIncludes(text, '"finishReason":"stop"');
   });
 });

--- a/src/agent/ag-ui-chat-ui-chunk-browser-encoder.ts
+++ b/src/agent/ag-ui-chat-ui-chunk-browser-encoder.ts
@@ -1,11 +1,16 @@
 import { tryGetVeryfrontCloudProviderFromModelId } from "#veryfront/provider";
 import type { ChatMessageMetadata, ChatUiMessageChunk } from "#veryfront/chat/protocol.ts";
 import type { AgUiBrowserChunkEncoder } from "./ag-ui-browser-chunk-encoder.ts";
+import { createAgUiBrowserFinalizeTracker } from "./ag-ui-browser-finalize-tracker.ts";
 import {
   type AgUiBrowserRunFinishedMetadata,
   type AgUiRuntimeStreamEvent,
 } from "./ag-ui-browser-encoder.ts";
 import { createAgUiBrowserChunkEncoder } from "./ag-ui-browser-chunk-encoder.ts";
+import {
+  createAgUiTrackedBrowserResponse,
+  type CreateAgUiTrackedBrowserResponseInput,
+} from "./ag-ui-tracked-browser-response.ts";
 
 export type AgUiChatUiChunkBrowserEncoder = Pick<
   AgUiBrowserChunkEncoder<ChatUiMessageChunk<ChatMessageMetadata>>,
@@ -15,6 +20,15 @@ export type AgUiChatUiChunkBrowserEncoder = Pick<
 export interface CreateAgUiChatUiChunkBrowserEncoderOptions {
   modelId?: string;
   resolveProvider?: (modelId: string) => string | undefined;
+}
+
+export interface CreateAgUiChatUiTrackedBrowserResponseInput extends
+  Omit<
+    CreateAgUiTrackedBrowserResponseInput<ChatUiMessageChunk<ChatMessageMetadata>>,
+    "chunkEncoder" | "finalizeTracker"
+  > {
+  modelId: string;
+  resolveProvider?: CreateAgUiChatUiChunkBrowserEncoderOptions["resolveProvider"];
 }
 
 export function getAgUiChatUiMessageMetadataFromChunk(
@@ -132,5 +146,27 @@ export function createAgUiChatUiChunkBrowserEncoder(
     },
     getMetadataFromChunk: (chunk) => getAgUiChatUiMessageChunkMetadata(chunk, options),
     getRuntimeEvents: (chunk) => [normalizeChatUiMessageChunkToAgUiRuntimeEvent(chunk)],
+  });
+}
+
+export function createAgUiChatUiTrackedBrowserResponse(
+  input: CreateAgUiChatUiTrackedBrowserResponseInput,
+): Response {
+  const finalizeTracker = createAgUiBrowserFinalizeTracker<
+    ChatUiMessageChunk<ChatMessageMetadata>
+  >({
+    getMetadataFromChunk: (chunk) =>
+      getAgUiChatUiMessageChunkMetadata(chunk, {
+        resolveProvider: input.resolveProvider,
+      }),
+  });
+
+  return createAgUiTrackedBrowserResponse({
+    ...input,
+    chunkEncoder: createAgUiChatUiChunkBrowserEncoder({
+      modelId: input.modelId,
+      resolveProvider: input.resolveProvider,
+    }),
+    finalizeTracker,
   });
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -344,6 +344,8 @@ export {
   type AgUiChatUiChunkBrowserEncoder,
   createAgUiChatUiChunkBrowserEncoder,
   type CreateAgUiChatUiChunkBrowserEncoderOptions,
+  createAgUiChatUiTrackedBrowserResponse,
+  type CreateAgUiChatUiTrackedBrowserResponseInput,
   getAgUiChatUiMessageChunkMetadata,
   getAgUiChatUiMessageMetadataFromChunk,
   getAgUiChatUiMessageUsageMetadata,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.425";
+export const VERSION = "0.1.426";


### PR DESCRIPTION
## Summary
- add a framework helper that creates tracked AG-UI browser responses for Chat UI chunks
- export the helper from veryfront/agent
- bump the framework patch version to 0.1.426 for CI/CD publishing

## Verification
- deno test --no-check --allow-all src/agent/ag-ui-chat-ui-chunk-browser-encoder.test.ts
- deno task verify:quick
- pre-push checks passed: format, lint, typecheck, unit tests