### PR TITLE
Add hosted chat runtime bootstrap helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.426",
+  "version": "0.1.427",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-chat-execution-runtime.test.ts
+++ b/src/agent/hosted-chat-execution-runtime.test.ts
@@ -2,12 +2,17 @@ import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ChatUiMessage, ChatUiMessageChunk, MessageMetadata } from "../chat/types.ts";
 import type { ConversationRunChunkMirror } from "./conversation-run-chunk-mirror.ts";
-import type { HostedChatRuntimeToUiMessageStreamOptions } from "./hosted-chat-runtime-contract.ts";
+import type {
+  HostedChatRuntimeAgent,
+  HostedChatRuntimeStreamInput,
+  HostedChatRuntimeToUiMessageStreamOptions,
+} from "./hosted-chat-runtime-contract.ts";
 import type { HostedLifecycleTerminalState } from "./hosted-lifecycle.ts";
 import { createMirroredToolChunkState } from "./mirrored-tool-chunk-state.ts";
 import {
   cleanupAfterHostedChatExecutionFinalization,
   createHostedChatExecutionRuntime,
+  createHostedChatExecutionRuntimeBootstrap,
   createHostedChatFinalizeDetachedBuildState,
   createHostedChatFinalizeResponseBuildState,
   createHostedChatStreamFinalizationHooks,
@@ -18,9 +23,10 @@ import {
 
 function createRootStreamWatchdog(input?: {
   disposed?: () => void;
+  signal?: AbortSignal;
 }): HostedChatExecutionRootStreamWatchdog {
   return {
-    signal: new AbortController().signal,
+    signal: input?.signal ?? new AbortController().signal,
     get lastTimeoutState() {
       return null;
     },
@@ -199,6 +205,92 @@ describe("agent/hosted-chat-execution-runtime", () => {
       terminalErrorCode: "ABORTED",
       terminalErrorMessage: "Chat stream aborted",
     });
+  });
+
+  it("creates a traced runtime bootstrap with merged abort signal and idempotent cleanup", async () => {
+    const requestAbortController = new AbortController();
+    const watchdogAbortController = new AbortController();
+    const finalMessages: HostedChatRuntimeStreamInput["messages"] = [];
+    let cleanupCount = 0;
+    let traceCount = 0;
+    let capturedMessages: HostedChatRuntimeStreamInput["messages"] | undefined;
+    let capturedAbortSignal: AbortSignal | undefined;
+    const agent: HostedChatRuntimeAgent = {
+      stream: async (input) => {
+        capturedMessages = input.messages;
+        capturedAbortSignal = input.abortSignal;
+        return createStreamResult({
+          finalStep: {},
+          captureOptions: () => {},
+        });
+      },
+    };
+
+    const bootstrap = await createHostedChatExecutionRuntimeBootstrap({
+      agent,
+      cleanup: async () => {
+        cleanupCount += 1;
+      },
+      lifecycleAdapter: createLifecycleAdapter(),
+      finalMessages,
+      conversationId: "conversation-1",
+      abortSignal: requestAbortController.signal,
+      traceStream: async (operation) => {
+        traceCount += 1;
+        return await operation();
+      },
+      createRootStreamWatchdog: () =>
+        createRootStreamWatchdog({
+          signal: watchdogAbortController.signal,
+        }),
+    });
+
+    assertEquals(traceCount, 1);
+    assertEquals(capturedMessages, finalMessages);
+    if (!capturedAbortSignal) {
+      throw new Error("stream abort signal was not captured");
+    }
+    assertEquals(capturedAbortSignal.aborted, false);
+    watchdogAbortController.abort();
+    assertEquals(capturedAbortSignal.aborted, true);
+    assertEquals(bootstrap.streamingMessageId, "stream-message-1");
+    assertEquals(bootstrap.capturedMessageId, "stream-message-1");
+    assertEquals(bootstrap.capturedConversationId, "conversation-1");
+
+    await bootstrap.cleanup();
+    await bootstrap.cleanup();
+
+    assertEquals(cleanupCount, 1);
+  });
+
+  it("rejects a conversation runtime bootstrap without a durable stream message id", async () => {
+    let streamCalls = 0;
+    const agent: HostedChatRuntimeAgent = {
+      stream: async () => {
+        streamCalls += 1;
+        return createStreamResult({
+          finalStep: {},
+          captureOptions: () => {},
+        });
+      },
+    };
+
+    await assertRejects(
+      async () => {
+        await createHostedChatExecutionRuntimeBootstrap({
+          agent,
+          cleanup: async () => {},
+          lifecycleAdapter: createLifecycleAdapter({ messageId: null }),
+          finalMessages: [],
+          conversationId: "conversation-1",
+          abortSignal: new AbortController().signal,
+          createRootStreamWatchdog,
+        });
+      },
+      Error,
+      "DURABLE_CHAT_ROOT_REQUIRES_CONVERSATION",
+    );
+    assertEquals(streamCalls, 0);
   });
 
   it("appends fallback chunks and flushes through the mirror", async () => {

--- a/src/agent/hosted-chat-execution-runtime.ts
+++ b/src/agent/hosted-chat-execution-runtime.ts
@@ -11,6 +11,8 @@ import {
   buildFinalizedMessageState,
 } from "./hosted-finalized-message.ts";
 import type {
+  HostedChatRuntimeAgent,
+  HostedChatRuntimeStreamInput,
   HostedChatRuntimeStreamResult,
   HostedChatRuntimeToUiMessageStreamOptions,
 } from "./hosted-chat-runtime-contract.ts";
@@ -25,6 +27,7 @@ import {
 } from "./conversation-hosted-terminal.ts";
 import {
   createHostedMirroredUiStream,
+  createMirroredToolChunkState,
   type MirroredToolChunkState,
 } from "./mirrored-tool-chunk-state.ts";
 import {
@@ -41,7 +44,7 @@ import {
 } from "./hosted-stream-terminal-error.ts";
 import type { ConversationRunChunkMirror } from "./conversation-run-chunk-mirror.ts";
 import type { BuildChatStreamChunkMessageMetadataInput } from "../chat/chat-ui-message-helpers.ts";
-import type { createChatStreamWatchdog } from "../chat/stream-watchdog.ts";
+import { createChatStreamWatchdog } from "../chat/stream-watchdog.ts";
 
 const INCOMPLETE_TOOL_CALLS_PART_ERROR_TEXT = "Assistant ended before tool execution completed";
 
@@ -85,6 +88,17 @@ export interface HostedChatExecutionRuntimeBootstrap {
   mirroredToolChunkState: MirroredToolChunkState;
 }
 
+export interface CreateHostedChatExecutionRuntimeBootstrapInput {
+  agent: HostedChatRuntimeAgent;
+  cleanup: () => Promise<void>;
+  lifecycleAdapter: HostedChatExecutionLifecycleAdapter;
+  finalMessages: HostedChatRuntimeStreamInput["messages"];
+  conversationId?: string;
+  abortSignal: AbortSignal;
+  traceStream?: <T>(operation: () => Promise<T>) => Promise<T>;
+  createRootStreamWatchdog?: () => HostedChatExecutionRootStreamWatchdog;
+}
+
 export interface CreateHostedChatExecutionRuntimeInput {
   agentId: string;
   modelId: string;
@@ -126,6 +140,72 @@ export async function cleanupAfterHostedChatExecutionFinalization(input: {
       error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
     });
   });
+}
+
+function createHostedChatExecutionCleanup(cleanup: () => Promise<void>): () => Promise<void> {
+  let cleanedUp = false;
+
+  return async () => {
+    if (cleanedUp) {
+      return;
+    }
+
+    cleanedUp = true;
+    await cleanup();
+  };
+}
+
+function createDefaultHostedChatExecutionRootStreamWatchdog(): HostedChatExecutionRootStreamWatchdog {
+  return createChatStreamWatchdog({
+    setTimeoutFn: globalThis.setTimeout,
+    clearTimeoutFn: globalThis.clearTimeout,
+  });
+}
+
+function traceHostedChatRuntimeStream<T>(
+  traceStream: CreateHostedChatExecutionRuntimeBootstrapInput["traceStream"],
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (!traceStream) {
+    return operation();
+  }
+
+  return traceStream(operation);
+}
+
+export async function createHostedChatExecutionRuntimeBootstrap(
+  input: CreateHostedChatExecutionRuntimeBootstrapInput,
+): Promise<HostedChatExecutionRuntimeBootstrap> {
+  const cleanup = createHostedChatExecutionCleanup(input.cleanup);
+  const streamingMessageId = input.lifecycleAdapter.durableRootRun?.messageId ?? null;
+  if (input.conversationId && !streamingMessageId) {
+    throw new Error("DURABLE_CHAT_ROOT_REQUIRES_CONVERSATION");
+  }
+
+  const rootStreamWatchdog = input.createRootStreamWatchdog
+    ? input.createRootStreamWatchdog()
+    : createDefaultHostedChatExecutionRootStreamWatchdog();
+  const streamAbortSignal = AbortSignal.any([input.abortSignal, rootStreamWatchdog.signal]);
+
+  const streamResult = await traceHostedChatRuntimeStream(
+    input.traceStream,
+    () =>
+      input.agent.stream({
+        messages: input.finalMessages,
+        abortSignal: streamAbortSignal,
+      }),
+  );
+
+  return {
+    cleanup,
+    lifecycleAdapter: input.lifecycleAdapter,
+    rootStreamWatchdog,
+    streamResult,
+    streamingMessageId,
+    capturedMessageId: streamingMessageId,
+    ...(input.conversationId ? { capturedConversationId: input.conversationId } : {}),
+    mirroredToolChunkState: createMirroredToolChunkState(),
+  };
 }
 
 export function createHostedChatStreamFinalizationHooks(input: {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -814,6 +814,8 @@ export {
 export {
   cleanupAfterHostedChatExecutionFinalization,
   createHostedChatExecutionRuntime,
+  createHostedChatExecutionRuntimeBootstrap,
+  type CreateHostedChatExecutionRuntimeBootstrapInput,
   type CreateHostedChatExecutionRuntimeInput,
   createHostedChatFinalizeDetachedBuildState,
   createHostedChatFinalizeResponseBuildState,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.426";
+export const VERSION = "0.1.427";


### PR DESCRIPTION
## Summary\n- add a reusable hosted chat execution runtime bootstrap helper\n- centralize root stream watchdog setup, merged abort signals, stream tracing, durable message capture, and one-shot cleanup\n- bump package version to 0.1.427 for CI/CD publishing\n\n## Verification\n- deno test --no-check --allow-all src/agent/hosted-chat-execution-runtime.test.ts\n- deno task verify:quick\n- pre-push checks: fmt, lint, typecheck, unit tests