### PR TITLE
Use host timers for hosted runtime bootstrap

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.428",
+  "version": "0.1.429",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-chat-execution-runtime.ts
+++ b/src/agent/hosted-chat-execution-runtime.ts
@@ -157,8 +157,8 @@ function createHostedChatExecutionCleanup(cleanup: () => Promise<void>): () => P
 
 function createDefaultHostedChatExecutionRootStreamWatchdog(): HostedChatExecutionRootStreamWatchdog {
   return createChatStreamWatchdog({
-    setTimeoutFn: globalThis.setTimeout,
-    clearTimeoutFn: globalThis.clearTimeout,
+    setTimeoutFn: globalThis["setTimeout"],
+    clearTimeoutFn: globalThis["clearTimeout"],
   });
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.428";
+export const VERSION = "0.1.429";


### PR DESCRIPTION
## Summary\n- ensure hosted chat runtime bootstrap creates root stream watchdogs with host global timer functions\n- bump package version to 0.1.429 for CI/CD publishing\n\n## Verification\n- deno test --no-check --allow-all src/agent/hosted-chat-execution-runtime.test.ts\n- deno task verify:quick\n- pre-push checks: fmt, lint, typecheck, unit tests