### PR TITLE
Patch hosted runtime npm timer output

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.429",
+  "version": "0.1.430",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/scripts/build/browser-safe-exports.mjs
+++ b/scripts/build/browser-safe-exports.mjs
@@ -16,6 +16,7 @@ export const BROWSER_SAFE_EXPORTS = [
 ];
 
 export const BROWSER_SAFE_DNT_TIMER_MODULES = [
+  "src/agent/hosted-chat-execution-runtime.js",
   "src/agent/hosted-child-stream-watchdog.js",
   "src/chat/final-step-fallback.js",
 ];

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.429";
+export const VERSION = "0.1.430";


### PR DESCRIPTION
## Summary\n- include hosted chat execution runtime in the npm timer-shim normalization list\n- bump package version to 0.1.430 for CI/CD publication\n\n## Verification\n- deno task build:npm\n- deno test --no-check --allow-all src/agent/hosted-chat-execution-runtime.test.ts\n- deno task verify:quick\n- pre-push checks