### PR TITLE
Fix provider-compatible hosted tool payloads

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.435",
+  "version": "0.1.436",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -844,6 +844,8 @@ export {
 export {
   cleanupAfterHostedChatExecutionFinalization,
   createHostedChatExecutionRuntime,
+  createHostedChatExecutionRuntimeBootstrap,
+  type CreateHostedChatExecutionRuntimeBootstrapInput,
   type CreateHostedChatExecutionRuntimeInput,
   createHostedChatFinalizeDetachedBuildState,
   createHostedChatFinalizeResponseBuildState,

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -844,8 +844,6 @@ export {
 export {
   cleanupAfterHostedChatExecutionFinalization,
   createHostedChatExecutionRuntime,
-  createHostedChatExecutionRuntimeBootstrap,
-  type CreateHostedChatExecutionRuntimeBootstrapInput,
   type CreateHostedChatExecutionRuntimeInput,
   createHostedChatFinalizeDetachedBuildState,
   createHostedChatFinalizeResponseBuildState,
@@ -1159,12 +1157,19 @@ export {
 } from "./chat-handler.ts";
 export {
   AgentRuntime,
+  getProviderToolProfile,
+  type ProviderToolCompatOptions,
+  type ProviderToolCompatProvider,
+  type ProviderToolProfile,
   RunAlreadyExistsError,
   RunCancelledError,
   RunNotActiveError,
   RunResumeSessionManager,
   type RunResumeSessionManagerOptions,
   type RunSessionStatus,
+  sanitizeProviderToolSchema,
+  selectProviderCompatibleToolNames,
+  selectProviderCompatibleTools,
   type SubmitResumeValueOutcome,
   WaitConflictError,
   WaitNotPendingError,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -74,6 +74,15 @@ export {
   parseToolArgs,
 } from "./tool-helpers.ts";
 export type { ParsedToolArgs, ToolConfigEntry } from "./tool-helpers.ts";
+export {
+  getProviderToolProfile,
+  type ProviderToolCompatOptions,
+  type ProviderToolCompatProvider,
+  type ProviderToolProfile,
+  sanitizeProviderToolSchema,
+  selectProviderCompatibleToolNames,
+  selectProviderCompatibleTools,
+} from "./provider-tool-compat.ts";
 export { accumulateUsage, getMaxSteps, normalizeInput } from "./input-utils.ts";
 export { createStreamState, processStream } from "./chat-stream-handler.ts";
 export type {

--- a/src/agent/runtime/model-tool-converter.test.ts
+++ b/src/agent/runtime/model-tool-converter.test.ts
@@ -3,6 +3,24 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ToolDefinition } from "#veryfront/tool";
 import { convertToolsToRuntimeTools } from "./model-tool-converter.ts";
 
+function containsKey(value: unknown, key: string): boolean {
+  if (!value || typeof value !== "object") return false;
+  if (Object.hasOwn(value, key)) return true;
+  if (Array.isArray(value)) {
+    return value.some((item) => containsKey(item, key));
+  }
+  return Object.values(value).some((item) => containsKey(item, key));
+}
+
+function getRuntimeToolSchema(tool: unknown): unknown {
+  if (!tool || typeof tool !== "object" || !("inputSchema" in tool)) return undefined;
+  const inputSchema = (tool as { inputSchema?: unknown }).inputSchema;
+  if (!inputSchema || typeof inputSchema !== "object" || !("jsonSchema" in inputSchema)) {
+    return undefined;
+  }
+  return (inputSchema as { jsonSchema?: unknown }).jsonSchema;
+}
+
 describe("model-tool-converter", () => {
   it("returns undefined for empty tools array", () => {
     assertEquals(convertToolsToRuntimeTools([]), undefined);
@@ -167,5 +185,52 @@ describe("model-tool-converter", () => {
 
     assertEquals(result !== undefined, true);
     assertEquals(Object.keys(result!).filter((name) => name === "web_search").length, 1);
+  });
+
+  it("caps OpenAI-compatible runtime tools to the provider limit", () => {
+    const tools: ToolDefinition[] = Array.from({ length: 150 }, (_, index) => ({
+      name: `tool_${index}`,
+      description: `Tool ${index}`,
+      parameters: { type: "object", properties: {} },
+    }));
+
+    const result = convertToolsToRuntimeTools(tools, {
+      model: "veryfront-cloud/openai/gpt-5.2",
+    });
+
+    assertEquals(Object.keys(result ?? {}).length, 128);
+    assertEquals("tool_0" in result!, true);
+    assertEquals("tool_127" in result!, true);
+    assertEquals("tool_128" in result!, false);
+  });
+
+  it("sanitizes Google-compatible runtime tool schemas", () => {
+    const result = convertToolsToRuntimeTools([
+      {
+        name: "choose_kind",
+        description: "Choose a kind",
+        parameters: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            kind: { type: "string", const: "file", default: "file" },
+          },
+        },
+      },
+    ] as never, {
+      model: "veryfront-cloud/google-ai-studio/gemini-2.5-flash",
+    });
+
+    const schema = getRuntimeToolSchema(result?.choose_kind);
+
+    assertEquals(containsKey(schema, "const"), false);
+    assertEquals(containsKey(schema, "default"), false);
+    assertEquals(containsKey(schema, "additionalProperties"), false);
+    assertEquals(
+      (schema as { properties?: { kind?: { enum?: unknown[] } } }).properties?.kind?.enum,
+      [
+        "file",
+      ],
+    );
   });
 });

--- a/src/agent/runtime/model-tool-converter.ts
+++ b/src/agent/runtime/model-tool-converter.ts
@@ -18,6 +18,10 @@ import {
   createAnthropicWebFetchToolSet,
   createAnthropicWebSearchToolSet,
 } from "./provider-native-tools.ts";
+import {
+  sanitizeProviderToolSchema,
+  selectProviderCompatibleTools,
+} from "./provider-tool-compat.ts";
 
 export interface ConvertToolsToRuntimeToolsOptions {
   model?: string;
@@ -63,14 +67,19 @@ export function convertToolsToRuntimeTools(
   options?: ConvertToolsToRuntimeToolsOptions,
 ): RuntimeToolSet | undefined {
   const toolSet: RuntimeToolSet = {};
+  const compatibleTools = selectProviderCompatibleTools(tools, {
+    model: options?.model,
+  });
 
-  for (const def of tools) {
+  for (const def of compatibleTools) {
     addRuntimeTool(
       toolSet,
       def.name,
       createRuntimeTool({
         description: def.description,
-        inputSchema: createRuntimeJsonSchema(def.parameters),
+        inputSchema: createRuntimeJsonSchema(
+          sanitizeProviderToolSchema(def.parameters, { model: options?.model }),
+        ),
       }),
     );
   }

--- a/src/agent/runtime/provider-tool-compat.test.ts
+++ b/src/agent/runtime/provider-tool-compat.test.ts
@@ -93,4 +93,19 @@ describe("provider-tool-compat", () => {
     assertEquals(sanitized.properties?.kind?.enum, ["file"]);
     assertEquals(sanitized.properties?.nested?.enum, ["a", "b"]);
   });
+
+  it("does not assign a schema type when collapsed anyOf literals are mixed types", () => {
+    const sanitized = sanitizeProviderToolSchema(
+      {
+        anyOf: [
+          { const: "file" },
+          { const: 1 },
+        ],
+      } as never,
+      { model: "google-ai-studio/gemini-2.5-pro" },
+    );
+
+    assertEquals(sanitized.enum, ["file", 1]);
+    assertEquals(sanitized.type, undefined);
+  });
 });

--- a/src/agent/runtime/provider-tool-compat.test.ts
+++ b/src/agent/runtime/provider-tool-compat.test.ts
@@ -1,0 +1,96 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ToolDefinition } from "#veryfront/tool";
+import {
+  sanitizeProviderToolSchema,
+  selectProviderCompatibleToolNames,
+  selectProviderCompatibleTools,
+} from "./provider-tool-compat.ts";
+
+function dummyTool(name: string): ToolDefinition {
+  return {
+    name,
+    description: `Tool ${name}`,
+    parameters: { type: "object", properties: {} },
+  };
+}
+
+function containsKey(value: unknown, key: string): boolean {
+  if (!value || typeof value !== "object") return false;
+  if (Object.hasOwn(value, key)) return true;
+  if (Array.isArray(value)) {
+    return value.some((item) => containsKey(item, key));
+  }
+  return Object.values(value).some((item) => containsKey(item, key));
+}
+
+describe("provider-tool-compat", () => {
+  it("caps OpenAI-compatible tool names while preserving required tools first", () => {
+    const requiredToolNames = ["form_input", "invoke_agent", "load_skill", "sleep"];
+    const remoteToolNames = Array.from({ length: 150 }, (_, index) => `remote_${index}`);
+
+    const selected = selectProviderCompatibleToolNames(
+      [...requiredToolNames, ...remoteToolNames],
+      {
+        model: "veryfront-cloud/openai/gpt-5.2",
+        requiredToolNames,
+      },
+    );
+
+    assertEquals(selected.length, 128);
+    assertEquals(selected.slice(0, requiredToolNames.length), requiredToolNames);
+    assertEquals(selected.includes("remote_0"), true);
+    assertEquals(selected.includes("remote_123"), true);
+    assertEquals(selected.includes("remote_124"), false);
+  });
+
+  it("caps OpenAI-compatible tool definitions deterministically", () => {
+    const tools = Array.from({ length: 150 }, (_, index) => dummyTool(`tool_${index}`));
+
+    const selected = selectProviderCompatibleTools(tools, {
+      model: "openai/gpt-5.2",
+    });
+
+    assertEquals(selected.length, 128);
+    assertEquals(selected[0]?.name, "tool_0");
+    assertEquals(selected.at(-1)?.name, "tool_127");
+  });
+
+  it("sanitizes Google tool schemas to avoid unsupported JSON Schema keywords", () => {
+    const sanitized = sanitizeProviderToolSchema(
+      {
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+        $id: "tool-schema",
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          kind: {
+            type: "string",
+            const: "file",
+            default: "file",
+          },
+          nested: {
+            anyOf: [
+              { type: "string", const: "a" },
+              { type: "string", const: "b" },
+            ],
+          },
+          refValue: {
+            $ref: "#/$defs/refValue",
+          },
+        },
+      } as never,
+      { model: "veryfront-cloud/google-ai-studio/gemini-2.5-flash" },
+    );
+
+    assertEquals(containsKey(sanitized, "const"), false);
+    assertEquals(containsKey(sanitized, "default"), false);
+    assertEquals(containsKey(sanitized, "additionalProperties"), false);
+    assertEquals(containsKey(sanitized, "$schema"), false);
+    assertEquals(containsKey(sanitized, "$id"), false);
+    assertEquals(containsKey(sanitized, "$ref"), false);
+    assertEquals(containsKey(sanitized, "anyOf"), false);
+    assertEquals(sanitized.properties?.kind?.enum, ["file"]);
+    assertEquals(sanitized.properties?.nested?.enum, ["a", "b"]);
+  });
+});

--- a/src/agent/runtime/provider-tool-compat.ts
+++ b/src/agent/runtime/provider-tool-compat.ts
@@ -1,0 +1,228 @@
+import type { ToolDefinition } from "#veryfront/tool";
+import type { JsonSchema } from "#veryfront/tool/schema";
+
+export type ProviderToolCompatProvider =
+  | "anthropic"
+  | "google"
+  | "moonshot"
+  | "openai"
+  | "unknown";
+
+export interface ProviderToolProfile {
+  provider: ProviderToolCompatProvider;
+  maxTools?: number;
+  sanitizeSchema: boolean;
+}
+
+export interface ProviderToolCompatOptions {
+  model?: string;
+  requiredToolNames?: readonly string[];
+}
+
+const OPENAI_MAX_TOOLS = 128;
+const GOOGLE_UNSUPPORTED_SCHEMA_KEYS = new Set([
+  "$id",
+  "$ref",
+  "$schema",
+  "additionalProperties",
+  "allOf",
+  "default",
+  "oneOf",
+  "prefixItems",
+]);
+
+function normalizeModel(model?: string): string {
+  return model?.trim().toLowerCase() ?? "";
+}
+
+export function getProviderToolProfile(model?: string): ProviderToolProfile {
+  const normalized = normalizeModel(model);
+  const parts = normalized.split("/").filter(Boolean);
+  const provider = parts[0] === "veryfront-cloud" ? parts[1] : parts[0];
+
+  if (provider === "openai") {
+    return { provider: "openai", maxTools: OPENAI_MAX_TOOLS, sanitizeSchema: false };
+  }
+
+  if (provider === "google" || provider === "google-ai-studio") {
+    return { provider: "google", sanitizeSchema: true };
+  }
+
+  if (provider === "anthropic") {
+    return { provider: "anthropic", sanitizeSchema: false };
+  }
+
+  if (provider === "moonshot") {
+    return { provider: "moonshot", sanitizeSchema: false };
+  }
+
+  return { provider: "unknown", sanitizeSchema: false };
+}
+
+function uniqueInOrder(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    result.push(value);
+  }
+
+  return result;
+}
+
+export function selectProviderCompatibleToolNames(
+  toolNames: readonly string[],
+  options: ProviderToolCompatOptions = {},
+): string[] {
+  const profile = getProviderToolProfile(options.model);
+  const orderedToolNames = uniqueInOrder(toolNames);
+
+  if (profile.maxTools === undefined || orderedToolNames.length <= profile.maxTools) {
+    return orderedToolNames;
+  }
+
+  const available = new Set(orderedToolNames);
+  const requiredToolNames = uniqueInOrder(options.requiredToolNames ?? [])
+    .filter((toolName) => available.has(toolName));
+  const selected = [...requiredToolNames];
+  const selectedSet = new Set(selected);
+
+  for (const toolName of orderedToolNames) {
+    if (selected.length >= profile.maxTools) break;
+    if (selectedSet.has(toolName)) continue;
+    selected.push(toolName);
+    selectedSet.add(toolName);
+  }
+
+  return selected.slice(0, profile.maxTools);
+}
+
+export function selectProviderCompatibleTools(
+  tools: readonly ToolDefinition[],
+  options: ProviderToolCompatOptions = {},
+): ToolDefinition[] {
+  const toolsByName = new Map<string, ToolDefinition>();
+  for (const tool of tools) {
+    if (!toolsByName.has(tool.name)) toolsByName.set(tool.name, tool);
+  }
+
+  const selectedToolNames = selectProviderCompatibleToolNames(
+    [...toolsByName.keys()],
+    options,
+  );
+
+  return selectedToolNames
+    .map((toolName) => toolsByName.get(toolName))
+    .filter((tool): tool is ToolDefinition => tool !== undefined);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function getLiteralType(value: unknown): JsonSchema["type"] | undefined {
+  switch (typeof value) {
+    case "string":
+      return "string";
+    case "number":
+      return Number.isInteger(value) ? "integer" : "number";
+    case "boolean":
+      return "boolean";
+    default:
+      return value === null ? "null" : undefined;
+  }
+}
+
+function getEnumValuesFromAnyOf(anyOf: unknown): unknown[] | undefined {
+  if (!Array.isArray(anyOf)) return undefined;
+
+  const values: unknown[] = [];
+  for (const option of anyOf) {
+    if (!isPlainRecord(option)) return undefined;
+    if ("const" in option) {
+      values.push(option.const);
+      continue;
+    }
+    if (Array.isArray(option.enum) && option.enum.length > 0) {
+      values.push(...option.enum);
+      continue;
+    }
+    return undefined;
+  }
+
+  return values.length > 0 ? uniqueUnknownValues(values) : undefined;
+}
+
+function uniqueUnknownValues(values: unknown[]): unknown[] {
+  const result: unknown[] = [];
+  for (const value of values) {
+    if (result.some((existing) => Object.is(existing, value))) continue;
+    result.push(value);
+  }
+  return result;
+}
+
+function sanitizeGoogleSchemaValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeGoogleSchemaValue(item));
+  }
+
+  if (!isPlainRecord(value)) {
+    return value;
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  const enumFromAnyOf = getEnumValuesFromAnyOf(value.anyOf);
+  const constValue = value.const;
+
+  for (const [key, child] of Object.entries(value)) {
+    if (key === "const" || key === "anyOf" || GOOGLE_UNSUPPORTED_SCHEMA_KEYS.has(key)) {
+      continue;
+    }
+
+    if (key === "properties" && isPlainRecord(child)) {
+      sanitized.properties = Object.fromEntries(
+        Object.entries(child).map(([propertyName, propertySchema]) => [
+          propertyName,
+          sanitizeGoogleSchemaValue(propertySchema),
+        ]),
+      );
+      continue;
+    }
+
+    if (key === "items") {
+      sanitized.items = sanitizeGoogleSchemaValue(child);
+      continue;
+    }
+
+    sanitized[key] = sanitizeGoogleSchemaValue(child);
+  }
+
+  if (enumFromAnyOf) {
+    sanitized.enum = enumFromAnyOf;
+    if (!sanitized.type) {
+      const firstType = getLiteralType(enumFromAnyOf[0]);
+      if (firstType) sanitized.type = firstType;
+    }
+  } else if ("const" in value) {
+    sanitized.enum = [constValue];
+    if (!sanitized.type) {
+      const literalType = getLiteralType(constValue);
+      if (literalType) sanitized.type = literalType;
+    }
+  }
+
+  return sanitized;
+}
+
+export function sanitizeProviderToolSchema(
+  schema: JsonSchema,
+  options: Pick<ProviderToolCompatOptions, "model"> = {},
+): JsonSchema {
+  const profile = getProviderToolProfile(options.model);
+  if (!profile.sanitizeSchema) return schema;
+
+  return sanitizeGoogleSchemaValue(schema) as JsonSchema;
+}

--- a/src/agent/runtime/provider-tool-compat.ts
+++ b/src/agent/runtime/provider-tool-compat.ts
@@ -164,6 +164,17 @@ function uniqueUnknownValues(values: unknown[]): unknown[] {
   return result;
 }
 
+function getSharedLiteralType(values: readonly unknown[]): JsonSchema["type"] | undefined {
+  const literalTypes = values.map((value) => getLiteralType(value));
+  const firstType = literalTypes[0];
+
+  if (!firstType || literalTypes.some((literalType) => literalType !== firstType)) {
+    return undefined;
+  }
+
+  return firstType;
+}
+
 function sanitizeGoogleSchemaValue(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map((item) => sanitizeGoogleSchemaValue(item));
@@ -203,8 +214,8 @@ function sanitizeGoogleSchemaValue(value: unknown): unknown {
   if (enumFromAnyOf) {
     sanitized.enum = enumFromAnyOf;
     if (!sanitized.type) {
-      const firstType = getLiteralType(enumFromAnyOf[0]);
-      if (firstType) sanitized.type = firstType;
+      const sharedType = getSharedLiteralType(enumFromAnyOf);
+      if (sharedType) sanitized.type = sharedType;
     }
   } else if ("const" in value) {
     sanitized.enum = [constValue];

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.435";
+export const VERSION = "0.1.436";


### PR DESCRIPTION
## Summary
- Add provider-aware tool compatibility helpers for hosted runtime tool payloads.
- Cap OpenAI/Veryfront Cloud OpenAI tool definitions at 128.
- Sanitize Google/Gemini function schemas by removing unsupported JSON Schema keywords and normalizing simple literal unions.

## Why
Staging runs for veryfront-studio#3512/#3513/#3514 reached the selected models but failed at the provider boundary:
- OpenAI rejected 281 tools with a 128-tool limit.
- Google rejected function schemas containing `const`.

## Verification
- `DENO_NO_PACKAGE_JSON=1 deno lint src/agent/index.ts src/agent/runtime/index.ts src/agent/runtime/model-tool-converter.test.ts src/agent/runtime/model-tool-converter.ts src/agent/runtime/provider-tool-compat.test.ts src/agent/runtime/provider-tool-compat.ts`
- `deno check src/agent/runtime/provider-tool-compat.ts src/agent/runtime/provider-tool-compat.test.ts src/agent/runtime/model-tool-converter.ts src/agent/runtime/model-tool-converter.test.ts src/agent/runtime/index.ts src/agent/index.ts`
- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all src/agent/runtime/provider-tool-compat.test.ts src/agent/runtime/model-tool-converter.test.ts`
