### PR TITLE
Add hosted project remote source helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.430",
+  "version": "0.1.431",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-project-remote-tool-source.test.ts
+++ b/src/agent/hosted-project-remote-tool-source.test.ts
@@ -1,6 +1,14 @@
 import { assertEquals, assertRejects } from "@std/assert";
-import type { RemoteToolSource, ToolDefinition, ToolExecutionContext } from "#veryfront/tool";
-import { createHostedProjectRemoteToolSource } from "./hosted-project-remote-tool-source.ts";
+import type {
+  RemoteMCPToolSourceConfig,
+  RemoteToolSource,
+  ToolDefinition,
+  ToolExecutionContext,
+} from "#veryfront/tool";
+import {
+  createHostedProjectRemoteToolSource,
+  createHostedProjectRemoteToolSources,
+} from "./hosted-project-remote-tool-source.ts";
 
 function projectFileTool(name: string): ToolDefinition {
   return {
@@ -32,6 +40,7 @@ function navigationTool(name: string): ToolDefinition {
 }
 
 function createRemoteSource(input: {
+  id?: string;
   tools: ToolDefinition[];
   execute?: (
     toolName: string,
@@ -40,11 +49,17 @@ function createRemoteSource(input: {
   ) => Promise<unknown> | unknown;
 }): RemoteToolSource {
   return {
-    id: "source-1",
+    id: input.id ?? "source-1",
     listTools: () => Promise.resolve(input.tools),
     executeTool: (toolName, args, context) =>
       input.execute?.(toolName, args, context) ?? { ok: true },
   };
+}
+
+async function resolveTestHeaders(
+  headers: RemoteMCPToolSourceConfig["headers"],
+): Promise<HeadersInit | undefined> {
+  return typeof headers === "function" ? await headers() : headers;
 }
 
 Deno.test("createHostedProjectRemoteToolSource scopes tool listings and hydrates project inputs", async () => {
@@ -220,4 +235,122 @@ Deno.test("createHostedProjectRemoteToolSource skips mutation callbacks for fail
 
   assertEquals(await source.executeTool("update_file", { path: "AGENTS.md" }), { isError: true });
   assertEquals(mutationCount, 0);
+});
+
+Deno.test("createHostedProjectRemoteToolSources builds API and gated Studio MCP sources", async () => {
+  const configs: RemoteMCPToolSourceConfig[] = [];
+  let activeProjectId = "project-1";
+  const sources = createHostedProjectRemoteToolSources({
+    authToken: "token-1",
+    apiMcpUrl: "https://api.example/mcp",
+    studioMcpUrl: "https://studio.example/mcp",
+    clientProfile: {
+      id: "veryfront-studio",
+      type: "web",
+      trusted: true,
+      capabilities: ["ui_panels"],
+    },
+    getProjectId: () => activeProjectId,
+    conversationId: "conversation-1",
+    createRemoteToolSource: (config) => {
+      configs.push(config);
+      return createRemoteSource({ id: config.id, tools: [projectFileTool("update_file")] });
+    },
+  });
+
+  assertEquals(sources.map((source) => source.id), ["veryfront-mcp", "studio-mcp"]);
+  assertEquals(configs.map((config) => config.endpoint), [
+    "https://api.example/mcp",
+    "https://studio.example/mcp",
+  ]);
+  assertEquals(configs[0]?.headers, { Authorization: "Bearer token-1" });
+
+  activeProjectId = "project-2";
+  assertEquals(await resolveTestHeaders(configs[1]?.headers), {
+    Authorization: "Bearer token-1",
+    "x-conversation-id": "conversation-1",
+    "x-project-id": "project-2",
+  });
+
+  const blockedSources = createHostedProjectRemoteToolSources({
+    authToken: "token-1",
+    apiMcpUrl: "https://api.example/mcp",
+    studioMcpUrl: "https://studio.example/mcp",
+    clientProfile: {
+      id: "veryfront-cli",
+      type: "cli",
+      trusted: true,
+      capabilities: [],
+    },
+    getProjectId: () => "project-1",
+    createRemoteToolSource: (config) =>
+      createRemoteSource({ id: config.id, tools: [projectFileTool(config.id ?? "tool")] }),
+  });
+
+  assertEquals(blockedSources.map((source) => source.id), ["veryfront-mcp"]);
+});
+
+Deno.test("createHostedProjectRemoteToolSources applies project wrapper policy to created sources", async () => {
+  const executed: Array<{ toolName: string; args: unknown; context?: ToolExecutionContext }> = [];
+  const switchedProjects: string[] = [];
+  const mutations: Array<{ instructionsChanged: boolean; skillsChanged: boolean }> = [];
+  const sources = createHostedProjectRemoteToolSources({
+    authToken: "token-1",
+    apiMcpUrl: "https://api.example/mcp",
+    studioMcpUrl: "https://studio.example/mcp",
+    clientProfile: {
+      id: "veryfront-studio",
+      type: "web",
+      trusted: true,
+      capabilities: ["ui_panels"],
+    },
+    defaultProjectId: () => "project-1",
+    getProjectId: () => "project-1",
+    projectScopedRemoteToolOptions: {
+      projectNavigationToolNames: ["studio_open_project"],
+    },
+    prepareToolInput: ({ toolInput }) => ({
+      ...toolInput,
+      prepared: true,
+    }),
+    onSteeringMutation: (mutation) => {
+      mutations.push({
+        instructionsChanged: mutation.instructionsChanged,
+        skillsChanged: mutation.skillsChanged,
+      });
+    },
+    onStudioProjectSwitch: (projectId) => {
+      switchedProjects.push(projectId);
+    },
+    createRemoteToolSource: (config) =>
+      createRemoteSource({
+        id: config.id,
+        tools: [projectFileTool("update_file"), navigationTool("studio_open_project")],
+        execute: (toolName, args, context) => {
+          executed.push({ toolName, args, context });
+          if (config.id === "studio-mcp" && toolName === "studio_open_project") {
+            return { success: true, project_id: "project-2" };
+          }
+          return { success: true };
+        },
+      }),
+  });
+
+  await sources[0]?.executeTool("update_file", { path: "AGENTS.md" });
+  await sources[1]?.executeTool("studio_open_project", { project_id: "project-2" });
+
+  assertEquals(executed, [
+    {
+      toolName: "update_file",
+      args: { path: "AGENTS.md", prepared: true, project_reference: "project-1" },
+      context: { projectId: "project-1" },
+    },
+    {
+      toolName: "studio_open_project",
+      args: { prepared: true, project_id: "project-2" },
+      context: { projectId: "project-1" },
+    },
+  ]);
+  assertEquals(mutations, [{ instructionsChanged: true, skillsChanged: false }]);
+  assertEquals(switchedProjects, ["project-2"]);
 });

--- a/src/agent/hosted-project-remote-tool-source.ts
+++ b/src/agent/hosted-project-remote-tool-source.ts
@@ -1,12 +1,16 @@
 import {
   createProjectScopedRemoteToolCatalog,
+  createRemoteMCPToolSource,
   isProjectNavigationRemoteTool,
   type ProjectScopedRemoteToolDefaultProjectId,
   type ProjectScopedRemoteToolOptions,
+  type RemoteMCPToolSourceConfig,
   type RemoteToolSource,
   type ToolExecutionContext,
 } from "#veryfront/tool";
 import { toChildRunToolInputRecord } from "./child-run-execution-support.ts";
+import { buildStudioMcpHeaders } from "./live-studio-mcp-tools.ts";
+import { clientAllowsStudioMcp, type RuntimeClientProfile } from "./runtime-client-profile.ts";
 import { getConfirmedProjectContextSwitchId } from "./project-context.ts";
 import {
   getProjectSteeringMutation,
@@ -173,4 +177,91 @@ export function createHostedProjectRemoteToolSource(
       return result;
     },
   };
+}
+
+export type CreateHostedProjectRemoteToolSourcesInput =
+  & Omit<
+    CreateHostedProjectRemoteToolSourceInput,
+    "source" | "onProjectSwitch"
+  >
+  & {
+    authToken: string;
+    apiMcpUrl: string;
+    studioMcpUrl?: string | null;
+    clientProfile?: RuntimeClientProfile | null;
+    getProjectId: () => string | null | undefined;
+    conversationId?: string;
+    apiSourceId?: string;
+    studioSourceId?: string;
+    createRemoteToolSource?: (config: RemoteMCPToolSourceConfig) => RemoteToolSource;
+    onStudioProjectSwitch?: HostedProjectRemoteToolSourceProjectSwitchHandler;
+  };
+
+function createHostedProjectRemoteToolSourceFromConfig(
+  input: CreateHostedProjectRemoteToolSourcesInput,
+  source: RemoteToolSource,
+  onProjectSwitch?: HostedProjectRemoteToolSourceProjectSwitchHandler,
+): RemoteToolSource {
+  return createHostedProjectRemoteToolSource({
+    source,
+    ...(input.defaultProjectId !== undefined ? { defaultProjectId: input.defaultProjectId } : {}),
+    ...(input.getActiveBranchId !== undefined
+      ? { getActiveBranchId: input.getActiveBranchId }
+      : {}),
+    ...(input.allowedToolNames !== undefined ? { allowedToolNames: input.allowedToolNames } : {}),
+    ...(input.projectScopedRemoteToolOptions !== undefined
+      ? { projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions }
+      : {}),
+    ...(input.prepareToolInput !== undefined ? { prepareToolInput: input.prepareToolInput } : {}),
+    ...(input.retryToolName !== undefined ? { retryToolName: input.retryToolName } : {}),
+    ...(input.shouldRetryWithTool !== undefined
+      ? { shouldRetryWithTool: input.shouldRetryWithTool }
+      : {}),
+    ...(input.steeringPaths !== undefined ? { steeringPaths: input.steeringPaths } : {}),
+    ...(input.onSteeringMutation !== undefined
+      ? { onSteeringMutation: input.onSteeringMutation }
+      : {}),
+    ...(onProjectSwitch !== undefined ? { onProjectSwitch } : {}),
+  });
+}
+
+export function createHostedProjectRemoteToolSources(
+  input: CreateHostedProjectRemoteToolSourcesInput,
+): RemoteToolSource[] {
+  const createRemoteToolSource = input.createRemoteToolSource ?? createRemoteMCPToolSource;
+  const sources = [
+    createHostedProjectRemoteToolSourceFromConfig(
+      input,
+      createRemoteToolSource({
+        id: input.apiSourceId ?? "veryfront-mcp",
+        endpoint: input.apiMcpUrl,
+        headers: {
+          Authorization: `Bearer ${input.authToken}`,
+        },
+      }),
+    ),
+  ];
+
+  if (!input.studioMcpUrl || !clientAllowsStudioMcp(input.clientProfile)) {
+    return sources;
+  }
+
+  sources.push(
+    createHostedProjectRemoteToolSourceFromConfig(
+      input,
+      createRemoteToolSource({
+        id: input.studioSourceId ?? "studio-mcp",
+        endpoint: input.studioMcpUrl,
+        headers: () =>
+          buildStudioMcpHeaders(
+            input.authToken,
+            input.getProjectId() ?? null,
+            input.conversationId,
+          ),
+      }),
+      input.onStudioProjectSwitch,
+    ),
+  );
+
+  return sources;
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -121,6 +121,8 @@ export {
 export {
   createHostedProjectRemoteToolSource,
   type CreateHostedProjectRemoteToolSourceInput,
+  createHostedProjectRemoteToolSources,
+  type CreateHostedProjectRemoteToolSourcesInput,
   type HostedProjectRemoteToolSourceMutationHandler,
   type HostedProjectRemoteToolSourcePrepareToolInput,
   type HostedProjectRemoteToolSourceProjectSwitchHandler,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.430";
+export const VERSION = "0.1.431";


### PR DESCRIPTION
## Summary\n- add a reusable hosted project remote tool source list helper for API MCP and gated Studio MCP sources\n- preserve project-scoped execution, steering mutation, retry, and project-switch callbacks through the existing source wrapper\n- bump package version to 0.1.431 for CI/CD publication\n\n## Verification\n- deno test --no-check --allow-all src/agent/hosted-project-remote-tool-source.test.ts\n- deno task verify:quick\n- deno task build:npm\n- pre-push checks