### PR TITLE
Add hosted chat request parser helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.431",
+  "version": "0.1.432",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-chat-request-parser.ts
+++ b/src/agent/hosted-chat-request-parser.ts
@@ -1,0 +1,201 @@
+import type {
+  ChatRequestContext,
+  ChatRuntimeOverrides,
+  ChatUiMessage,
+  DurableRootRunDescriptor,
+} from "#veryfront/chat/types.ts";
+import {
+  buildHostedChatRequestInputFromRuntimeAgentInvocation,
+  type HostedChatRequest,
+  hostedChatRequestSchema,
+} from "./hosted-chat-request.ts";
+import { RuntimeAgentRunInvocationSchema } from "./runtime-agent-invocation-contract.ts";
+
+export type HostedChatRequestPrincipal = {
+  userId: string;
+  authToken: string;
+};
+
+export type HostedChatProjectAccessError = {
+  errorCode: string;
+  message: string;
+  statusCode: number;
+};
+
+export type HostedChatProjectAccessResult =
+  | { success: true }
+  | { success: false; error: HostedChatProjectAccessError };
+
+export type ParsedHostedChatRequest = {
+  userId: string;
+  authToken: string;
+  messages: ChatUiMessage[];
+  validatedContext: ChatRequestContext;
+  projectId: string | null;
+  conversationId: string | undefined;
+  parentRunId: string | undefined;
+  upstreamParentConversationId: string | undefined;
+  upstreamParentRunId: string | undefined;
+  spawnedFromToolCallId: string | undefined;
+  model: string | undefined;
+  allowDelegation: boolean | undefined;
+  forwardedProps: HostedChatRequest["forwardedProps"];
+  runtimeOverrides: ChatRuntimeOverrides | undefined;
+  durableRootRun: DurableRootRunDescriptor | undefined;
+  persistLatestUserMessageBeforeDurableRun: boolean;
+};
+
+export type ParseHostedChatRequestOptions = {
+  authenticate: (request: Request) => Promise<HostedChatRequestPrincipal | Response>;
+  verifyProjectAccess?: (input: {
+    projectId: string;
+    authToken: string;
+  }) => Promise<HostedChatProjectAccessResult>;
+};
+
+async function parseRequestJson(request: Request): Promise<unknown> {
+  return await request.json().catch((): null => null);
+}
+
+function createValidationErrorResponse(input: {
+  messagePrefix: string;
+  validationMessage: string;
+}): Response {
+  return Response.json(
+    {
+      errorCode: "VALIDATION_ERROR",
+      message: `${input.messagePrefix}: ${input.validationMessage}`,
+    },
+    { status: 400 },
+  );
+}
+
+async function verifyHostedChatProjectAccess(input: {
+  projectId: string | null;
+  authToken: string;
+  verifyProjectAccess?: ParseHostedChatRequestOptions["verifyProjectAccess"];
+}): Promise<Response | undefined> {
+  if (!input.projectId || !input.verifyProjectAccess) {
+    return undefined;
+  }
+
+  const access = await input.verifyProjectAccess({
+    projectId: input.projectId,
+    authToken: input.authToken,
+  });
+  if (access.success) {
+    return undefined;
+  }
+
+  return Response.json(
+    { errorCode: access.error.errorCode, message: access.error.message },
+    { status: access.error.statusCode === 404 ? 404 : 403 },
+  );
+}
+
+export async function buildParsedHostedChatRequest(input: {
+  chatRequest: HostedChatRequest;
+  authToken: string;
+  userId: string;
+  verifyProjectAccess?: ParseHostedChatRequestOptions["verifyProjectAccess"];
+}): Promise<ParsedHostedChatRequest | Response> {
+  const {
+    messages,
+    context: chatContext,
+    model,
+    allowDelegation,
+    forwardedProps,
+    runtimeOverrides,
+    durableRootRun,
+  } = input.chatRequest;
+  const projectId = chatContext.projectId;
+  const conversationId = chatContext.conversationId;
+
+  const accessError = await verifyHostedChatProjectAccess({
+    projectId,
+    authToken: input.authToken,
+    verifyProjectAccess: input.verifyProjectAccess,
+  });
+  if (accessError) {
+    return accessError;
+  }
+
+  return {
+    userId: input.userId,
+    authToken: input.authToken,
+    messages,
+    validatedContext: chatContext,
+    projectId,
+    conversationId,
+    parentRunId: durableRootRun?.runId,
+    upstreamParentConversationId: durableRootRun?.parentConversationId,
+    upstreamParentRunId: durableRootRun?.parentRunId,
+    spawnedFromToolCallId: durableRootRun?.spawnedFromToolCallId,
+    model,
+    allowDelegation,
+    forwardedProps,
+    runtimeOverrides,
+    durableRootRun,
+    persistLatestUserMessageBeforeDurableRun: false,
+  };
+}
+
+export async function parseHostedChatRequestFromRequest(
+  request: Request,
+  options: ParseHostedChatRequestOptions,
+): Promise<ParsedHostedChatRequest | Response> {
+  const authenticatedRequest = await options.authenticate(request);
+  if (authenticatedRequest instanceof Response) {
+    return authenticatedRequest;
+  }
+
+  const parsed = hostedChatRequestSchema.safeParse(await parseRequestJson(request));
+  if (!parsed.success) {
+    return createValidationErrorResponse({
+      messagePrefix: "Invalid request",
+      validationMessage: parsed.error.message,
+    });
+  }
+
+  return await buildParsedHostedChatRequest({
+    authToken: authenticatedRequest.authToken,
+    userId: authenticatedRequest.userId,
+    chatRequest: parsed.data,
+    verifyProjectAccess: options.verifyProjectAccess,
+  });
+}
+
+export async function parseRuntimeAgentRunInvocationHostedChatRequestFromRequest(
+  request: Request,
+  options: ParseHostedChatRequestOptions,
+): Promise<ParsedHostedChatRequest | Response> {
+  const authenticatedRequest = await options.authenticate(request);
+  if (authenticatedRequest instanceof Response) {
+    return authenticatedRequest;
+  }
+
+  const invocation = RuntimeAgentRunInvocationSchema.safeParse(await parseRequestJson(request));
+  if (!invocation.success) {
+    return createValidationErrorResponse({
+      messagePrefix: "Invalid runtime agent invocation",
+      validationMessage: invocation.error.message,
+    });
+  }
+
+  const chatRequest = hostedChatRequestSchema.safeParse(
+    buildHostedChatRequestInputFromRuntimeAgentInvocation(invocation.data),
+  );
+  if (!chatRequest.success) {
+    return createValidationErrorResponse({
+      messagePrefix: "Invalid runtime agent invocation",
+      validationMessage: chatRequest.error.message,
+    });
+  }
+
+  return await buildParsedHostedChatRequest({
+    authToken: authenticatedRequest.authToken,
+    userId: authenticatedRequest.userId,
+    chatRequest: chatRequest.data,
+    verifyProjectAccess: options.verifyProjectAccess,
+  });
+}

--- a/src/agent/hosted-chat-request.test.ts
+++ b/src/agent/hosted-chat-request.test.ts
@@ -5,6 +5,8 @@ import {
   buildHostedChatRequestFromRuntimeAgentInvocation,
   hostedChatRequestSchema,
   hostedChatRuntimeOverridesSchema,
+  parseHostedChatRequestFromRequest,
+  parseRuntimeAgentRunInvocationHostedChatRequestFromRequest,
   RuntimeAgentRunInvocationSchema,
 } from "./index.ts";
 
@@ -125,5 +127,115 @@ describe("agent/hosted-chat-request", () => {
       parentRunId: "run_parent_1",
       spawnedFromToolCallId: "tool_1",
     });
+  });
+
+  it("parses hosted chat requests with auth and project-access callbacks", async () => {
+    const parsed = await parseHostedChatRequestFromRequest(
+      new Request("https://agent.example.com/api/ag-ui/runs", {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
+          context: {
+            conversationId,
+            projectId,
+            branchId,
+          },
+          model: "opus",
+          allowDelegation: true,
+          forwardedProps: { activeChatId: "chat_123" },
+          durableRootRun: {
+            runId: "run_root_1",
+            messageId,
+            parentConversationId: "10000000-1000-4000-8000-100000000007",
+            parentRunId: "run_parent_1",
+            spawnedFromToolCallId: "tool_1",
+          },
+        }),
+      }),
+      {
+        authenticate: () => Promise.resolve({ userId, authToken: "token_1" }),
+        verifyProjectAccess: ({ projectId: checkedProjectId, authToken }) => {
+          assertEquals(checkedProjectId, projectId);
+          assertEquals(authToken, "token_1");
+          return Promise.resolve({ success: true });
+        },
+      },
+    );
+
+    if (parsed instanceof Response) {
+      throw new Error("Expected parsed request");
+    }
+
+    assertEquals(parsed.userId, userId);
+    assertEquals(parsed.authToken, "token_1");
+    assertEquals(parsed.projectId, projectId);
+    assertEquals(parsed.conversationId, conversationId);
+    assertEquals(parsed.parentRunId, "run_root_1");
+    assertEquals(parsed.upstreamParentConversationId, "10000000-1000-4000-8000-100000000007");
+    assertEquals(parsed.upstreamParentRunId, "run_parent_1");
+    assertEquals(parsed.spawnedFromToolCallId, "tool_1");
+    assertEquals(parsed.persistLatestUserMessageBeforeDurableRun, false);
+  });
+
+  it("returns hosted chat project-access errors as stable JSON responses", async () => {
+    const response = await parseHostedChatRequestFromRequest(
+      new Request("https://agent.example.com/api/ag-ui/runs", {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
+          context: {
+            projectId,
+            branchId,
+          },
+        }),
+      }),
+      {
+        authenticate: () => Promise.resolve({ userId, authToken: "token_1" }),
+        verifyProjectAccess: () =>
+          Promise.resolve({
+            success: false,
+            error: {
+              errorCode: "PROJECT_ACCESS_DENIED",
+              message: "Project access denied",
+              statusCode: 401,
+            },
+          }),
+      },
+    );
+
+    if (!(response instanceof Response)) {
+      throw new Error("Expected error response");
+    }
+
+    assertEquals(response.status, 403);
+    assertEquals(await response.json(), {
+      errorCode: "PROJECT_ACCESS_DENIED",
+      message: "Project access denied",
+    });
+  });
+
+  it("parses runtime agent invocations into hosted chat requests", async () => {
+    const invocation = createRuntimeInvocation();
+    const parsed = await parseRuntimeAgentRunInvocationHostedChatRequestFromRequest(
+      new Request("https://agent.example.com/internal/agents/stream", {
+        method: "POST",
+        body: JSON.stringify(invocation),
+      }),
+      {
+        authenticate: () => Promise.resolve({ userId, authToken: "token_1" }),
+        verifyProjectAccess: () => Promise.resolve({ success: true }),
+      },
+    );
+
+    if (parsed instanceof Response) {
+      throw new Error("Expected parsed runtime invocation");
+    }
+
+    assertEquals(parsed.messages, invocation.messages);
+    assertEquals(parsed.projectId, projectId);
+    assertEquals(parsed.conversationId, conversationId);
+    assertEquals(parsed.forwardedProps?.runtimeContext, invocation.context);
+    assertEquals(parsed.forwardedProps?.runtimeTools, invocation.tools);
+    assertEquals(parsed.durableRootRun?.runId, "run_root_1");
   });
 });

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -281,6 +281,16 @@ export type {
 } from "./hosted-chat-runtime-contract.ts";
 
 export {
+  buildParsedHostedChatRequest,
+  type HostedChatProjectAccessError,
+  type HostedChatProjectAccessResult,
+  type HostedChatRequestPrincipal,
+  type ParsedHostedChatRequest,
+  parseHostedChatRequestFromRequest,
+  type ParseHostedChatRequestOptions,
+  parseRuntimeAgentRunInvocationHostedChatRequestFromRequest,
+} from "./hosted-chat-request-parser.ts";
+export {
   buildHostedChatRequestForwardedPropsFromRuntimeAgentInvocation,
   buildHostedChatRequestFromRuntimeAgentInvocation,
   buildHostedChatRequestInputFromRuntimeAgentInvocation,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.431";
+export const VERSION = "0.1.432";


### PR DESCRIPTION
## Summary\n- add a reusable hosted chat request parser that binds host auth and project-access callbacks\n- support runtime agent invocation request conversion through the same parsed request shape\n- bump package version to 0.1.432 for CI publishing\n\n## Verification\n- deno test --no-check --allow-all src/agent/hosted-chat-request.test.ts\n- deno task verify:quick\n- pre-push checks: format, lint, typecheck, unit tests