### PR TITLE
Preserve release source targets for external workers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.431",
+  "version": "0.1.432",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/external-agent-worker-client.test.ts
+++ b/src/agent/external-agent-worker-client.test.ts
@@ -117,6 +117,8 @@ describe("external agent worker client", () => {
           agent_id: "veryfront-agent",
           status: "running",
           request_snapshot: { messages: [], tools: [], context: [] },
+          source_target_kind: "release",
+          source_target_release_version: "2026.05.08",
           latest_event_id: 0,
           latest_external_event_sequence: 4,
           lease_owner: WORKER_ID,
@@ -153,6 +155,8 @@ describe("external agent worker client", () => {
       workerId: registeredWorker.id,
       leaseDurationSeconds: 30,
     });
+    assertEquals(run?.source_target_kind, "release");
+    assertEquals(run?.source_target_release_version, "2026.05.08");
     await client.recordSession({
       workerId: registeredWorker.id,
       runId: RUN_ID,

--- a/src/agent/external-agent-worker-client.ts
+++ b/src/agent/external-agent-worker-client.ts
@@ -53,6 +53,7 @@ export const ExternalAgentWorkerRunSchema = z.object({
   source_target_kind: z.string().nullable().optional(),
   source_target_environment_id: z.string().uuid().nullable().optional(),
   source_target_branch_id: z.string().uuid().nullable().optional(),
+  source_target_release_version: z.string().nullable().optional(),
   runtime_target_kind: z.string().nullable().optional(),
   runtime_target_environment_id: z.string().uuid().nullable().optional(),
   runtime_target_branch_id: z.string().uuid().nullable().optional(),

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.431";
+export const VERSION = "0.1.432";


### PR DESCRIPTION
## Summary
- Preserve `source_target_release_version` when external agent workers claim runs.
- Add regression coverage for release-backed worker runs.
- Bump framework version to `0.1.432` for the follow-up release.

## Why
`veryfront-api` now returns release-backed source targets for agent worker runs, but the framework client schema stripped `source_target_release_version`. Adapters such as `veryfront-agent-codex` could see `source_target_kind: "release"` without the release version needed to load the release source.

## Verification
- `deno test --no-check --allow-all src/agent/external-agent-worker-client.test.ts src/utils/version.test.ts src/utils/logger/logger.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts src/agent/external-agent-worker-client.ts src/agent/external-agent-worker-client.test.ts`
- `deno check src/agent/external-agent-worker-client.ts src/agent/index.ts src/utils/version.ts`
- `git diff --check`
- Pre-push hook passed: formatting, lint, typecheck, generated manifests, and unit tests: `1713 passed (17292 steps), 0 failed`.
