### PR TITLE
Release external worker source target fix

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.432",
+  "version": "0.1.433",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.432";
+export const VERSION = "0.1.433";


### PR DESCRIPTION
## Summary
- Bump Veryfront framework release version to `0.1.433`.
- Keep `deno.json` and runtime `VERSION` synchronized.

## Why
`0.1.432` was already published before PR #1499 reached main, so the npm package at `0.1.432` does not include the external worker `source_target_release_version` schema fix. This creates a fresh immutable package version for the already-merged source fix.

## Verification
- `deno test --no-check --allow-all src/utils/version.test.ts src/utils/logger/logger.test.ts src/agent/external-agent-worker-client.test.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts`
- `git diff --check`
- Pre-push hook passed: formatting, lint, typecheck, generated manifests, and unit tests: `1713 passed (17295 steps), 0 failed`.
