### PR TITLE
Add hosted AG-UI chat request helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.433",
+  "version": "0.1.434",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-ag-ui-chat-request.test.ts
+++ b/src/agent/hosted-ag-ui-chat-request.test.ts
@@ -1,0 +1,239 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { AgUiRuntimeRequest } from "./runtime-ag-ui-contract.ts";
+import {
+  buildParsedHostedAgUiRequest,
+  createHostedAgUiValidationErrorResponse,
+  deriveHostedAgUiChatContext,
+} from "./hosted-ag-ui-chat-request.ts";
+
+function createAgUiInput(overrides: Partial<AgUiRuntimeRequest> = {}): AgUiRuntimeRequest {
+  return {
+    threadId: "11111111-1111-4111-8111-111111111111",
+    runId: "run-1",
+    messages: [],
+    tools: [],
+    context: [],
+    ...overrides,
+  };
+}
+
+function createToolConversationMessages(userContent: string): AgUiRuntimeRequest["messages"] {
+  return [
+    {
+      id: "system-1",
+      role: "system",
+      content: "You are helpful.",
+    },
+    {
+      id: "user-1",
+      role: "user",
+      content: userContent,
+    },
+    {
+      id: "assistant-1",
+      role: "assistant",
+      content: "Working on it",
+      toolCalls: [
+        {
+          id: "tool-call-1",
+          type: "function",
+          function: {
+            name: "search_files",
+            arguments: '{"query":"auth"}',
+          },
+        },
+      ],
+    },
+    {
+      id: "tool-1",
+      role: "tool",
+      toolCallId: "tool-call-1",
+      content: '{"matches":2}',
+    },
+  ];
+}
+
+describe("agent/hosted-ag-ui-chat-request", () => {
+  it("derives hosted chat context from AG-UI context entries", () => {
+    const result = deriveHostedAgUiChatContext(
+      createAgUiInput({
+        context: [
+          { description: "veryfront.projectId", value: '"project-1"' },
+          { description: "veryfront.branchId", value: '"branch-1"' },
+          { description: "veryfront.conversationId", value: '"conversation-1"' },
+          { description: "veryfront.environmentContext", value: "Editor: local" },
+          { description: "veryfront.model", value: "openai/gpt-5.4" },
+          { description: "veryfront.allowDelegation", value: "true" },
+          { description: "veryfront.runtimeOverrides", value: '{"maxSteps":4}' },
+        ],
+      }),
+    );
+
+    assertEquals(result, {
+      validatedContext: {
+        projectId: "project-1",
+        branchId: "branch-1",
+        conversationId: "conversation-1",
+        environmentContext: "Editor: local",
+      },
+      projectId: "project-1",
+      conversationId: "conversation-1",
+      model: "openai/gpt-5.4",
+      allowDelegation: true,
+      runtimeOverrides: { maxSteps: 4 },
+    });
+  });
+
+  it("prefers forwarded config over AG-UI context entries", () => {
+    const result = deriveHostedAgUiChatContext(
+      createAgUiInput({
+        context: [
+          { description: "veryfront.projectId", value: '"project-from-context"' },
+          { description: "veryfront.model", value: "openai/gpt-5.4" },
+        ],
+        forwardedProps: {
+          veryfront: {
+            projectId: "project-from-forwarded",
+            branchId: "branch-from-forwarded",
+            conversationId: "conversation-from-forwarded",
+            environmentContext: "Forwarded environment",
+            model: "anthropic/claude-sonnet-4-5",
+            allowDelegation: false,
+            runtimeOverrides: { maxSteps: 8 },
+          },
+        },
+      }),
+      { forwardedConfigNamespace: "veryfront" },
+    );
+
+    assertEquals(result, {
+      validatedContext: {
+        projectId: "project-from-forwarded",
+        branchId: "branch-from-forwarded",
+        conversationId: "conversation-from-forwarded",
+        environmentContext: "Forwarded environment",
+      },
+      projectId: "project-from-forwarded",
+      conversationId: "conversation-from-forwarded",
+      model: "anthropic/claude-sonnet-4-5",
+      allowDelegation: false,
+      runtimeOverrides: { maxSteps: 8 },
+    });
+  });
+
+  it("builds parsed hosted AG-UI requests and verifies project access", async () => {
+    let verifiedProjectId: string | undefined;
+    let verifiedAuthToken: string | undefined;
+    const parsed = await buildParsedHostedAgUiRequest({
+      agUiInput: createAgUiInput({
+        parentRunId: "run-parent-1",
+        messages: createToolConversationMessages("Hello"),
+        context: [
+          { description: "veryfront.projectId", value: '"project-1"' },
+          { description: "veryfront.model", value: "openai/gpt-5.4" },
+          { description: "veryfront.allowDelegation", value: "true" },
+        ],
+        forwardedProps: {
+          unrelated: "ok",
+        },
+      }),
+      authToken: "auth-token",
+      userId: "user-1",
+      verifyProjectAccess: ({ projectId, authToken }) => {
+        verifiedProjectId = projectId;
+        verifiedAuthToken = authToken;
+        return Promise.resolve({ success: true });
+      },
+    });
+
+    if (parsed instanceof Response) {
+      throw new Error("Expected parsed request");
+    }
+
+    assertEquals(verifiedProjectId, "project-1");
+    assertEquals(verifiedAuthToken, "auth-token");
+    assertEquals(parsed.userId, "user-1");
+    assertEquals(parsed.authToken, "auth-token");
+    assertEquals(parsed.projectId, "project-1");
+    assertEquals(parsed.parentRunId, "run-parent-1");
+    assertEquals(parsed.model, "openai/gpt-5.4");
+    assertEquals(parsed.allowDelegation, true);
+    assertEquals(parsed.forwardedProps, { unrelated: "ok" });
+    assertEquals(parsed.persistLatestUserMessageBeforeDurableRun, true);
+    assertEquals(parsed.messages, [
+      {
+        id: "system-1",
+        role: "system",
+        parts: [{ type: "text", text: "You are helpful." }],
+      },
+      {
+        id: "user-1",
+        role: "user",
+        parts: [{ type: "text", text: "Hello" }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "Working on it" },
+          {
+            type: "dynamic-tool",
+            toolName: "search_files",
+            toolCallId: "tool-call-1",
+            input: { query: "auth" },
+            state: "output-available",
+            output: { matches: 2 },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("returns stable project-access error responses", async () => {
+    const response = await buildParsedHostedAgUiRequest({
+      agUiInput: createAgUiInput({
+        context: [{ description: "veryfront.projectId", value: '"project-1"' }],
+      }),
+      authToken: "auth-token",
+      userId: "user-1",
+      verifyProjectAccess: () =>
+        Promise.resolve({
+          success: false,
+          error: {
+            errorCode: "FORBIDDEN",
+            message: "denied",
+            statusCode: 401,
+          },
+        }),
+    });
+
+    if (!(response instanceof Response)) {
+      throw new Error("Expected project-access response");
+    }
+
+    assertEquals(response.status, 403);
+    assertEquals(await response.json(), {
+      errorCode: "FORBIDDEN",
+      message: "denied",
+    });
+  });
+
+  it("preserves hosted validation error envelopes", async () => {
+    const response = await createHostedAgUiValidationErrorResponse(
+      Response.json(
+        {
+          error: "Invalid AG-UI runtime request",
+          details: [{ message: "Expected array, received string" }],
+        },
+        { status: 400 },
+      ),
+    );
+
+    assertEquals(response.status, 400);
+    assertEquals(await response.json(), {
+      errorCode: "VALIDATION_ERROR",
+      message: "Invalid AG-UI request: Expected array, received string",
+    });
+  });
+});

--- a/src/agent/hosted-ag-ui-chat-request.ts
+++ b/src/agent/hosted-ag-ui-chat-request.ts
@@ -1,0 +1,186 @@
+import { mapAgUiRuntimeMessagesToChatUiMessages } from "#veryfront/chat/ag-ui.ts";
+import type { ChatRequestContext, ChatRuntimeOverrides } from "#veryfront/chat/types.ts";
+import { z } from "zod";
+import {
+  createAgUiRuntimeContextMap,
+  deriveAgUiForwardedConfig,
+  parseAgUiContextBoolean,
+  parseAgUiContextNullableString,
+  parseAgUiContextSchema,
+  parseAgUiContextString,
+} from "./ag-ui-forwarded-context.ts";
+import type { AgUiRuntimeRequest } from "./runtime-ag-ui-contract.ts";
+import { hostedChatRuntimeOverridesSchema } from "./hosted-chat-request.ts";
+import type {
+  HostedChatProjectAccessResult,
+  ParsedHostedChatRequest,
+  ParseHostedChatRequestOptions,
+} from "./hosted-chat-request-parser.ts";
+
+export const hostedAgUiChatForwardedConfigSchema = z
+  .object({
+    projectId: z.string().nullable().optional(),
+    branchId: z.string().nullable().optional(),
+    conversationId: z.string().optional(),
+    environmentContext: z.string().optional(),
+    model: z.string().optional(),
+    allowDelegation: z.boolean().optional(),
+    runtimeOverrides: hostedChatRuntimeOverridesSchema.optional(),
+  })
+  .strict();
+
+export type HostedAgUiChatForwardedConfig = z.infer<typeof hostedAgUiChatForwardedConfigSchema>;
+
+export type DerivedHostedAgUiChatContext = {
+  validatedContext: ChatRequestContext;
+  projectId: string | null;
+  conversationId: string | undefined;
+  model: string | undefined;
+  allowDelegation: boolean | undefined;
+  runtimeOverrides: ChatRuntimeOverrides | undefined;
+};
+
+export type ParsedHostedAgUiRequest = ParsedHostedChatRequest & {
+  agUiInput: AgUiRuntimeRequest;
+};
+
+export type BuildParsedHostedAgUiRequestOptions = {
+  agUiInput: AgUiRuntimeRequest;
+  authToken: string;
+  userId: string;
+  forwardedConfigNamespace?: string;
+  verifyProjectAccess?: ParseHostedChatRequestOptions["verifyProjectAccess"];
+};
+
+const hostedValidationErrorBodySchema = z
+  .object({
+    error: z.string().optional(),
+    details: z.array(z.object({ message: z.string().optional() }).passthrough()).optional(),
+  })
+  .passthrough();
+
+async function verifyHostedAgUiProjectAccess(input: {
+  projectId: string | null;
+  authToken: string;
+  verifyProjectAccess?: (
+    input: { projectId: string; authToken: string },
+  ) => Promise<HostedChatProjectAccessResult>;
+}): Promise<Response | undefined> {
+  if (!input.projectId || !input.verifyProjectAccess) {
+    return undefined;
+  }
+
+  const access = await input.verifyProjectAccess({
+    projectId: input.projectId,
+    authToken: input.authToken,
+  });
+  if (access.success) {
+    return undefined;
+  }
+
+  return Response.json(
+    { errorCode: access.error.errorCode, message: access.error.message },
+    { status: access.error.statusCode === 404 ? 404 : 403 },
+  );
+}
+
+export function deriveHostedAgUiChatContext(
+  agUiInput: AgUiRuntimeRequest,
+  options: { forwardedConfigNamespace?: string } = {},
+): DerivedHostedAgUiChatContext {
+  const contextMap = createAgUiRuntimeContextMap(agUiInput);
+  const contextNamespace = options.forwardedConfigNamespace ?? "veryfront";
+  const forwardedConfig = deriveAgUiForwardedConfig(agUiInput, {
+    schema: hostedAgUiChatForwardedConfigSchema,
+    namespace: options.forwardedConfigNamespace,
+  });
+
+  const projectId = forwardedConfig?.projectId ??
+    parseAgUiContextNullableString(contextMap.get(`${contextNamespace}.projectId`)) ?? null;
+  const branchId = forwardedConfig?.branchId ??
+    parseAgUiContextNullableString(contextMap.get(`${contextNamespace}.branchId`)) ?? null;
+  const environmentContext = forwardedConfig?.environmentContext ??
+    parseAgUiContextString(contextMap.get(`${contextNamespace}.environmentContext`));
+  const conversationId = forwardedConfig?.conversationId ??
+    parseAgUiContextString(contextMap.get(`${contextNamespace}.conversationId`));
+
+  const validatedContext: ChatRequestContext = {
+    projectId,
+    branchId,
+    ...(conversationId ? { conversationId } : {}),
+    ...(environmentContext ? { environmentContext } : {}),
+  };
+
+  return {
+    validatedContext,
+    projectId,
+    conversationId,
+    model: forwardedConfig?.model ??
+      parseAgUiContextString(contextMap.get(`${contextNamespace}.model`)),
+    allowDelegation: forwardedConfig?.allowDelegation ??
+      parseAgUiContextBoolean(contextMap.get(`${contextNamespace}.allowDelegation`)),
+    runtimeOverrides: forwardedConfig?.runtimeOverrides ??
+      parseAgUiContextSchema(
+        contextMap.get(`${contextNamespace}.runtimeOverrides`),
+        hostedChatRuntimeOverridesSchema,
+      ),
+  };
+}
+
+export async function createHostedAgUiValidationErrorResponse(
+  response: Response,
+): Promise<Response> {
+  const bodyResult = hostedValidationErrorBodySchema.safeParse(
+    await response.json().catch((): null => null),
+  );
+  const body = bodyResult.success ? bodyResult.data : null;
+
+  const detailMessage = body?.details
+    ?.map((detail) => detail.message)
+    .filter((message): message is string => typeof message === "string")
+    .join(", ") ||
+    body?.error ||
+    "Invalid AG-UI request";
+
+  return Response.json(
+    { errorCode: "VALIDATION_ERROR", message: `Invalid AG-UI request: ${detailMessage}` },
+    { status: 400 },
+  );
+}
+
+export async function buildParsedHostedAgUiRequest(
+  input: BuildParsedHostedAgUiRequestOptions,
+): Promise<ParsedHostedAgUiRequest | Response> {
+  const chatContext = deriveHostedAgUiChatContext(input.agUiInput, {
+    forwardedConfigNamespace: input.forwardedConfigNamespace,
+  });
+
+  const accessError = await verifyHostedAgUiProjectAccess({
+    projectId: chatContext.projectId,
+    authToken: input.authToken,
+    verifyProjectAccess: input.verifyProjectAccess,
+  });
+  if (accessError) {
+    return accessError;
+  }
+
+  return {
+    agUiInput: input.agUiInput,
+    userId: input.userId,
+    authToken: input.authToken,
+    messages: mapAgUiRuntimeMessagesToChatUiMessages(input.agUiInput.messages),
+    validatedContext: chatContext.validatedContext,
+    projectId: chatContext.projectId,
+    conversationId: chatContext.conversationId,
+    parentRunId: input.agUiInput.parentRunId,
+    upstreamParentConversationId: undefined,
+    upstreamParentRunId: undefined,
+    spawnedFromToolCallId: undefined,
+    model: chatContext.model,
+    allowDelegation: chatContext.allowDelegation,
+    forwardedProps: input.agUiInput.forwardedProps,
+    runtimeOverrides: chatContext.runtimeOverrides,
+    durableRootRun: undefined,
+    persistLatestUserMessageBeforeDurableRun: true,
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -291,6 +291,16 @@ export {
   parseRuntimeAgentRunInvocationHostedChatRequestFromRequest,
 } from "./hosted-chat-request-parser.ts";
 export {
+  buildParsedHostedAgUiRequest,
+  type BuildParsedHostedAgUiRequestOptions,
+  createHostedAgUiValidationErrorResponse,
+  type DerivedHostedAgUiChatContext,
+  deriveHostedAgUiChatContext,
+  type HostedAgUiChatForwardedConfig,
+  hostedAgUiChatForwardedConfigSchema,
+  type ParsedHostedAgUiRequest,
+} from "./hosted-ag-ui-chat-request.ts";
+export {
   buildHostedChatRequestForwardedPropsFromRuntimeAgentInvocation,
   buildHostedChatRequestFromRuntimeAgentInvocation,
   buildHostedChatRequestInputFromRuntimeAgentInvocation,

--- a/src/chat/ag-ui.ts
+++ b/src/chat/ag-ui.ts
@@ -285,7 +285,7 @@ function applyRuntimeToolResultMessage(
 ): void {
   for (let messageIndex = messages.length - 1; messageIndex >= 0; messageIndex -= 1) {
     const currentMessage = messages[messageIndex];
-    if (currentMessage.role !== "assistant") {
+    if (!currentMessage || currentMessage.role !== "assistant") {
       continue;
     }
 
@@ -301,7 +301,7 @@ function applyRuntimeToolResultMessage(
     }
 
     const part = currentMessage.parts[partIndex];
-    if (part.type !== "dynamic-tool") {
+    if (!part || part.type !== "dynamic-tool") {
       continue;
     }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.433";
+export const VERSION = "0.1.434";


### PR DESCRIPTION
## Summary\n- add a reusable hosted AG-UI chat request/context helper for separately deployed agent services\n- preserve hosted validation and project-access response envelopes\n- fix AG-UI tool-result narrowing under strict indexed access\n- bump package version to 0.1.434 for CI/CD publishing\n\n## Verification\n- deno test --no-check --allow-all src/agent/hosted-ag-ui-chat-request.test.ts src/chat/ag-ui.test.ts\n- deno task verify:quick\n- pre-push checks: format, lint, typecheck, unit tests (1714 passed)