### PR TITLE
Add hosted project skill loader

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.434",
+  "version": "0.1.435",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -757,6 +757,14 @@ export {
   type RuntimeProjectFilesTrace,
 } from "./runtime-project-files-client.ts";
 export {
+  createRuntimeProjectSkillLoader,
+  type RuntimeLoadedProjectSkill,
+  type RuntimeProjectSkillContext,
+  type RuntimeProjectSkillLoader,
+  type RuntimeProjectSkillLoaderLogger,
+  type RuntimeProjectSkillLoaderOptions,
+} from "./runtime-project-skill-loader.ts";
+export {
   buildRuntimeLoadedSkillResponse,
   buildRuntimeSkillDefinition,
   normalizeRuntimeSkillReferencePath,

--- a/src/agent/runtime-project-skill-loader.test.ts
+++ b/src/agent/runtime-project-skill-loader.test.ts
@@ -1,0 +1,146 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { createRuntimeProjectSkillLoader } from "./runtime-project-skill-loader.ts";
+import type {
+  RuntimeGetProjectFileOptions,
+  RuntimeProjectFile,
+  RuntimeProjectFileListItem,
+  RuntimeProjectFilesApiOptions,
+} from "./runtime-project-files-client.ts";
+
+class AccessDeniedError extends Error {}
+
+const PROJECT_CONTEXT = {
+  projectId: "project-1",
+  authToken: "auth-token",
+  branchId: "branch-1",
+};
+
+type FileCall = RuntimeGetProjectFileOptions;
+type FilesCall = RuntimeProjectFilesApiOptions;
+
+function createLoader(input: {
+  getProjectFile?: (options: RuntimeGetProjectFileOptions) => Promise<RuntimeProjectFile | null>;
+  getProjectFiles?: (
+    options: RuntimeProjectFilesApiOptions,
+  ) => Promise<RuntimeProjectFileListItem[]>;
+  warnings?: Array<{ message: string; metadata?: Record<string, unknown> }>;
+} = {}) {
+  const fileCalls: FileCall[] = [];
+  const filesCalls: FilesCall[] = [];
+  const warnings = input.warnings ?? [];
+
+  return {
+    loader: createRuntimeProjectSkillLoader({
+      getProjectFile: async (options) => {
+        fileCalls.push(options);
+        return input.getProjectFile ? await input.getProjectFile(options) : null;
+      },
+      getProjectFiles: async (options) => {
+        filesCalls.push(options);
+        return input.getProjectFiles ? await input.getProjectFiles(options) : [];
+      },
+      isAccessDeniedError: (error) => error instanceof AccessDeniedError,
+      logger: {
+        warn: (message, metadata) => warnings.push({ message, metadata }),
+      },
+    }),
+    fileCalls,
+    filesCalls,
+    warnings,
+  };
+}
+
+Deno.test("runtime project skill loader returns empty results without project context", async () => {
+  const { loader, fileCalls, filesCalls } = createLoader();
+  const context = { authToken: "auth-token", projectId: null, branchId: null };
+
+  assertEquals(await loader.listProjectSkillReferences(context, "research"), []);
+  assertEquals(await loader.loadProjectSkill(context, "research"), null);
+  assertEquals(
+    await loader.loadProjectSkillReference(context, "research", "references/guide.md"),
+    null,
+  );
+  assertEquals(fileCalls, []);
+  assertEquals(filesCalls, []);
+});
+
+Deno.test("runtime project skill loader loads directory skills with normalized sorted references", async () => {
+  const { loader } = createLoader({
+    getProjectFile: async ({ path }) =>
+      path === ".veryfront/skills/research/SKILL.md" ? { path, content: "# Research" } : null,
+    getProjectFiles: async () => [
+      { path: ".veryfront/skills/research/references/zeta.md" },
+      { path: ".veryfront/skills/research/references/checklists/checklist.md" },
+      { path: ".veryfront/skills/other/references/skip.md" },
+      { path: ".veryfront/skills/research/references//invalid.md" },
+    ],
+  });
+
+  assertEquals(await loader.loadProjectSkill(PROJECT_CONTEXT, "research"), {
+    instructions: "# Research",
+    references: ["references/checklists/checklist.md", "references/zeta.md"],
+  });
+});
+
+Deno.test("runtime project skill loader falls back to flat project skills without references", async () => {
+  const { loader, fileCalls } = createLoader({
+    getProjectFile: async ({ path }) =>
+      path === ".veryfront/skills/custom.md" ? { path, content: "# Custom" } : null,
+  });
+
+  assertEquals(await loader.loadProjectSkill(PROJECT_CONTEXT, "custom"), {
+    instructions: "# Custom",
+    references: [],
+  });
+  assertEquals(fileCalls.map((call) => call.path), [
+    ".veryfront/skills/custom/SKILL.md",
+    ".veryfront/skills/custom.md",
+  ]);
+});
+
+Deno.test("runtime project skill loader loads project skill reference content", async () => {
+  const { loader } = createLoader({
+    getProjectFile: async ({ path }) =>
+      path === ".veryfront/skills/research/references/guide.md"
+        ? { path, content: "# Guide" }
+        : null,
+  });
+
+  assertEquals(
+    await loader.loadProjectSkillReference(PROJECT_CONTEXT, "research", "references/guide.md"),
+    "# Guide",
+  );
+});
+
+Deno.test("runtime project skill loader returns null and logs when lookup is denied", async () => {
+  const { loader, warnings } = createLoader({
+    getProjectFile: async () => {
+      throw new AccessDeniedError("Access denied");
+    },
+  });
+
+  assertEquals(await loader.loadProjectSkill(PROJECT_CONTEXT, "research"), null);
+  assertEquals(
+    await loader.loadProjectSkillReference(PROJECT_CONTEXT, "research", "references/guide.md"),
+    null,
+  );
+  assertEquals(warnings, [
+    {
+      message: "Falling back to builtin skill after project skill lookup was denied",
+      metadata: {
+        projectId: "project-1",
+        branchId: "branch-1",
+        skillId: "research",
+      },
+    },
+    {
+      message: "Falling back to builtin skill reference after project skill lookup was denied",
+      metadata: {
+        projectId: "project-1",
+        branchId: "branch-1",
+        skillId: "research",
+        file: "references/guide.md",
+      },
+    },
+  ]);
+});

--- a/src/agent/runtime-project-skill-loader.ts
+++ b/src/agent/runtime-project-skill-loader.ts
@@ -1,0 +1,217 @@
+import {
+  DEFAULT_PROJECT_STEERING_PATHS,
+  type ProjectSteeringPaths,
+} from "./project-steering-mutation.ts";
+import type {
+  RuntimeGetProjectFileOptions,
+  RuntimeProjectFile,
+  RuntimeProjectFileListItem,
+  RuntimeProjectFilesApiOptions,
+} from "./runtime-project-files-client.ts";
+import { normalizeRuntimeSkillReferencePath } from "./runtime-skill-metadata.ts";
+
+export type RuntimeProjectSkillContext = {
+  projectId?: string | null;
+  authToken: string;
+  branchId?: string | null;
+};
+
+export type RuntimeLoadedProjectSkill = {
+  instructions: string;
+  references: string[];
+};
+
+export type RuntimeProjectSkillLoaderLogger = {
+  warn?: (message: string, metadata?: Record<string, unknown>) => void;
+};
+
+export type RuntimeProjectSkillLoaderOptions = {
+  getProjectFile: (options: RuntimeGetProjectFileOptions) => Promise<RuntimeProjectFile | null>;
+  getProjectFiles: (
+    options: RuntimeProjectFilesApiOptions,
+  ) => Promise<RuntimeProjectFileListItem[]>;
+  steeringPaths?: Pick<ProjectSteeringPaths, "skills">;
+  isAccessDeniedError?: (error: unknown) => boolean;
+  logger?: RuntimeProjectSkillLoaderLogger;
+};
+
+export type RuntimeProjectSkillLoader = {
+  listProjectSkillReferences: (
+    context: RuntimeProjectSkillContext,
+    skillId: string,
+  ) => Promise<string[]>;
+  loadProjectSkill: (
+    context: RuntimeProjectSkillContext,
+    skillId: string,
+  ) => Promise<RuntimeLoadedProjectSkill | null>;
+  loadProjectSkillReference: (
+    context: RuntimeProjectSkillContext,
+    skillId: string,
+    normalizedFile: string,
+  ) => Promise<string | null>;
+};
+
+function getSkillPaths(options: RuntimeProjectSkillLoaderOptions): readonly string[] {
+  return options.steeringPaths?.skills ?? DEFAULT_PROJECT_STEERING_PATHS.skills;
+}
+
+function isAccessDeniedError(
+  error: unknown,
+  options: RuntimeProjectSkillLoaderOptions,
+): boolean {
+  return options.isAccessDeniedError?.(error) ?? false;
+}
+
+async function listProjectSkillReferences(input: {
+  options: RuntimeProjectSkillLoaderOptions;
+  context: RuntimeProjectSkillContext;
+  skillId: string;
+}): Promise<string[]> {
+  const projectId = input.context.projectId;
+  if (!projectId) {
+    return [];
+  }
+
+  const allFiles = await input.options.getProjectFiles({
+    projectId,
+    authToken: input.context.authToken,
+    branchId: input.context.branchId,
+  });
+  const references = new Set<string>();
+
+  for (const skillsPath of getSkillPaths(input.options)) {
+    const skillPrefix = `${skillsPath}/${input.skillId}/`;
+    const refsPrefix = `${skillPrefix}references/`;
+
+    for (const file of allFiles) {
+      if (!file.path.startsWith(refsPrefix)) {
+        continue;
+      }
+
+      const relativePath = file.path.slice(skillPrefix.length);
+      if (!relativePath.includes("/")) {
+        continue;
+      }
+
+      const normalizedReference = normalizeRuntimeSkillReferencePath(relativePath);
+      if (normalizedReference) {
+        references.add(normalizedReference);
+      }
+    }
+  }
+
+  return [...references].sort();
+}
+
+async function loadProjectSkill(input: {
+  options: RuntimeProjectSkillLoaderOptions;
+  context: RuntimeProjectSkillContext;
+  skillId: string;
+}): Promise<RuntimeLoadedProjectSkill | null> {
+  const projectId = input.context.projectId;
+  if (!projectId) {
+    return null;
+  }
+
+  try {
+    for (const skillsPath of getSkillPaths(input.options)) {
+      const directorySkill = await input.options.getProjectFile({
+        projectId,
+        authToken: input.context.authToken,
+        branchId: input.context.branchId,
+        path: `${skillsPath}/${input.skillId}/SKILL.md`,
+      });
+
+      if (directorySkill?.content) {
+        return {
+          instructions: directorySkill.content,
+          references: await listProjectSkillReferences(input),
+        };
+      }
+
+      const flatSkill = await input.options.getProjectFile({
+        projectId,
+        authToken: input.context.authToken,
+        branchId: input.context.branchId,
+        path: `${skillsPath}/${input.skillId}.md`,
+      });
+
+      if (flatSkill?.content) {
+        return {
+          instructions: flatSkill.content,
+          references: [],
+        };
+      }
+    }
+  } catch (error) {
+    if (isAccessDeniedError(error, input.options)) {
+      input.options.logger?.warn?.(
+        "Falling back to builtin skill after project skill lookup was denied",
+        {
+          projectId,
+          branchId: input.context.branchId ?? null,
+          skillId: input.skillId,
+        },
+      );
+      return null;
+    }
+
+    throw error;
+  }
+
+  return null;
+}
+
+async function loadProjectSkillReference(input: {
+  options: RuntimeProjectSkillLoaderOptions;
+  context: RuntimeProjectSkillContext;
+  skillId: string;
+  normalizedFile: string;
+}): Promise<string | null> {
+  const projectId = input.context.projectId;
+  if (!projectId) {
+    return null;
+  }
+
+  try {
+    for (const skillsPath of getSkillPaths(input.options)) {
+      const projectFile = await input.options.getProjectFile({
+        projectId,
+        authToken: input.context.authToken,
+        branchId: input.context.branchId,
+        path: `${skillsPath}/${input.skillId}/${input.normalizedFile}`,
+      });
+      if (projectFile?.content) {
+        return projectFile.content;
+      }
+    }
+  } catch (error) {
+    if (!isAccessDeniedError(error, input.options)) {
+      throw error;
+    }
+
+    input.options.logger?.warn?.(
+      "Falling back to builtin skill reference after project skill lookup was denied",
+      {
+        projectId,
+        branchId: input.context.branchId ?? null,
+        skillId: input.skillId,
+        file: input.normalizedFile,
+      },
+    );
+  }
+
+  return null;
+}
+
+export function createRuntimeProjectSkillLoader(
+  options: RuntimeProjectSkillLoaderOptions,
+): RuntimeProjectSkillLoader {
+  return {
+    listProjectSkillReferences: (context, skillId) =>
+      listProjectSkillReferences({ options, context, skillId }),
+    loadProjectSkill: (context, skillId) => loadProjectSkill({ options, context, skillId }),
+    loadProjectSkillReference: (context, skillId, normalizedFile) =>
+      loadProjectSkillReference({ options, context, skillId, normalizedFile }),
+  };
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.434";
+export const VERSION = "0.1.435";


### PR DESCRIPTION
## Summary\n- add a reusable hosted project skill loader for project-first skill lookup\n- support directory skills, flat skill files, normalized references, and access-denied fallback logging\n- bump package version to 0.1.435 for CI release\n\n## Verification\n- deno test --no-check --allow-all src/agent/runtime-project-skill-loader.test.ts\n- deno task verify:quick\n- pre-push: format, lint, typecheck, unit tests