### PR TITLE
Add runtime project skill catalog helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.435",
+  "version": "0.1.436",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -765,6 +765,14 @@ export {
   type RuntimeProjectSkillLoaderOptions,
 } from "./runtime-project-skill-loader.ts";
 export {
+  getRuntimeProjectInstructions,
+  getRuntimeProjectSkillCatalog,
+  loadRuntimeBuiltinSkillCatalog,
+  type RuntimeProjectInstructionsOptions,
+  type RuntimeProjectSkillCatalogOptions,
+  type RuntimeProjectSteeringLookup,
+} from "./runtime-project-skill-catalog.ts";
+export {
   buildRuntimeLoadedSkillResponse,
   buildRuntimeSkillDefinition,
   normalizeRuntimeSkillReferencePath,

--- a/src/agent/runtime-project-skill-catalog.test.ts
+++ b/src/agent/runtime-project-skill-catalog.test.ts
@@ -1,0 +1,183 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { resolve } from "node:path";
+import {
+  getRuntimeProjectInstructions,
+  getRuntimeProjectSkillCatalog,
+  loadRuntimeBuiltinSkillCatalog,
+} from "./runtime-project-skill-catalog.ts";
+import type {
+  RuntimeGetProjectFileOptions,
+  RuntimeProjectFilesApiOptions,
+} from "./runtime-project-files-client.ts";
+import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
+
+const PROJECT_CONTEXT = {
+  projectId: "project-1",
+  authToken: "auth-token",
+  branchId: "branch-1",
+};
+
+function withTempDir(fn: (dir: string) => void): void {
+  const dir = Deno.makeTempDirSync();
+  try {
+    fn(dir);
+  } finally {
+    Deno.removeSync(dir, { recursive: true });
+  }
+}
+
+function createSkillCatalog(input: {
+  builtinSkills?: readonly RuntimeSkillDefinition[];
+  paths?: readonly string[] | null;
+  contentsByPath?: Record<string, string>;
+}) {
+  const fileCalls: RuntimeGetProjectFileOptions[] = [];
+  const filesCalls: RuntimeProjectFilesApiOptions[] = [];
+  const contentsByPath = input.contentsByPath ?? {};
+
+  return {
+    catalog: () =>
+      getRuntimeProjectSkillCatalog({
+        ...PROJECT_CONTEXT,
+        builtinSkills: input.builtinSkills ?? [],
+        getProjectFiles: async (options) => {
+          filesCalls.push(options);
+          return input.paths === null ? null : (input.paths ?? []).map((path) => ({ path }));
+        },
+        getProjectFile: async (options) => {
+          fileCalls.push(options);
+          const content = contentsByPath[options.path];
+          return content ? { path: options.path, content } : null;
+        },
+      }),
+    fileCalls,
+    filesCalls,
+  };
+}
+
+Deno.test("loadRuntimeBuiltinSkillCatalog loads flat and directory skills with references", () => {
+  withTempDir((rootDir) => {
+    Deno.writeTextFileSync(
+      resolve(rootDir, "plan.md"),
+      "---\ndescription: Plan work\nallowed-tools: bash, edit\n---\n\n# Plan",
+    );
+    Deno.mkdirSync(resolve(rootDir, "research", "references"), { recursive: true });
+    Deno.writeTextFileSync(
+      resolve(rootDir, "research", "SKILL.md"),
+      "---\ndescription: Research\nmodel: sonnet\n---\n\n# Research",
+    );
+    Deno.writeTextFileSync(resolve(rootDir, "research", "references", "guide.md"), "# Guide");
+
+    const catalog = loadRuntimeBuiltinSkillCatalog({ skillsDir: rootDir });
+
+    assertEquals(catalog.map((skill) => skill.id), ["plan", "research"]);
+    assertEquals(catalog[0]?.allowedTools, ["bash", "edit"]);
+    assertEquals(catalog[1]?.references, ["references/guide.md"]);
+  });
+});
+
+Deno.test("getRuntimeProjectInstructions returns the first available instruction file", async () => {
+  const fileCalls: RuntimeGetProjectFileOptions[] = [];
+
+  const instructions = await getRuntimeProjectInstructions({
+    ...PROJECT_CONTEXT,
+    getProjectFile: async (options) => {
+      fileCalls.push(options);
+      return options.path === "AGENTS.md" ? { path: options.path, content: "# Agent" } : null;
+    },
+  });
+
+  assertEquals(instructions, "# Agent");
+  assertEquals(fileCalls, [
+    {
+      ...PROJECT_CONTEXT,
+      path: "AGENTS.md",
+    },
+  ]);
+});
+
+Deno.test("getRuntimeProjectSkillCatalog returns builtin skills when project files are unavailable", async () => {
+  const builtinSkills = [
+    {
+      id: "plan",
+      name: "plan",
+      description: "Plan",
+      instructions: "# Plan",
+      allowedTools: [],
+    },
+  ];
+  const { catalog } = createSkillCatalog({ builtinSkills, paths: null });
+
+  assertEquals(await catalog(), builtinSkills);
+});
+
+Deno.test("getRuntimeProjectSkillCatalog parses project directory skills and references", async () => {
+  const { catalog, filesCalls, fileCalls } = createSkillCatalog({
+    paths: [
+      ".veryfront/skills/research/SKILL.md",
+      ".veryfront/skills/research/references/checklists/checklist.md",
+    ],
+    contentsByPath: {
+      ".veryfront/skills/research/SKILL.md":
+        "---\ndescription: Research deeply\nmodel: sonnet\nthinking: false\nmax-steps: 7\nallowed-tools:\n  - bash\n---\n\n# Research",
+    },
+  });
+
+  const skills = await catalog();
+  const research = skills.find((skill) => skill.id === "research");
+
+  assertExists(research);
+  assertEquals(research.description, "Research deeply");
+  assertEquals(research.model, "sonnet");
+  assertEquals(research.thinking, false);
+  assertEquals(research.maxSteps, 7);
+  assertEquals(research.allowedTools, ["bash"]);
+  assertEquals(research.references, ["references/checklists/checklist.md"]);
+  assertEquals(filesCalls, [PROJECT_CONTEXT]);
+  assertEquals(fileCalls, [
+    {
+      ...PROJECT_CONTEXT,
+      path: ".veryfront/skills/research/SKILL.md",
+    },
+  ]);
+});
+
+Deno.test("getRuntimeProjectSkillCatalog prefers directory skills and lets project skills override builtins", async () => {
+  const builtinSkills = [
+    {
+      id: "alpha",
+      name: "alpha",
+      description: "Builtin alpha",
+      instructions: "# Builtin alpha",
+      allowedTools: [],
+    },
+    {
+      id: "shared",
+      name: "shared",
+      description: "Builtin shared",
+      instructions: "# Builtin shared",
+      allowedTools: [],
+    },
+  ];
+  const { catalog } = createSkillCatalog({
+    builtinSkills,
+    paths: [
+      ".veryfront/skills/shared.md",
+      ".veryfront/skills/shared/SKILL.md",
+      ".veryfront/skills/zeta.md",
+    ],
+    contentsByPath: {
+      ".veryfront/skills/shared.md": "---\ndescription: Flat shared\n---\n\n# Shared flat",
+      ".veryfront/skills/shared/SKILL.md":
+        "---\ndescription: Directory shared\n---\n\n# Shared directory",
+      ".veryfront/skills/zeta.md": "---\ndescription: Zeta\n---\n\n# Zeta",
+    },
+  });
+
+  const skills = await catalog();
+  const shared = skills.find((skill) => skill.id === "shared");
+
+  assertExists(shared);
+  assertEquals(shared.description, "Directory shared");
+  assertEquals(skills.map((skill) => skill.id), ["alpha", "shared", "zeta"]);
+});

--- a/src/agent/runtime-project-skill-catalog.ts
+++ b/src/agent/runtime-project-skill-catalog.ts
@@ -1,0 +1,238 @@
+import { basename } from "node:path";
+import {
+  DEFAULT_PROJECT_STEERING_PATHS,
+  type ProjectSteeringPaths,
+} from "./project-steering-mutation.ts";
+import type {
+  RuntimeGetProjectFileOptions,
+  RuntimeProjectFile,
+  RuntimeProjectFileListItem,
+  RuntimeProjectFilesApiOptions,
+} from "./runtime-project-files-client.ts";
+import {
+  listRuntimeBuiltinSkillReferences,
+  readRuntimeBuiltinDirectorySkill,
+  readRuntimeBuiltinFlatSkill,
+  readRuntimeBuiltinSkillEntries,
+} from "./runtime-builtin-skill-files.ts";
+import {
+  buildRuntimeSkillDefinition,
+  type RuntimeSkillDefinition,
+  type RuntimeSkillMetadataLogger,
+} from "./runtime-skill-metadata.ts";
+
+export type RuntimeProjectSteeringLookup = {
+  projectId: string;
+  authToken: string;
+  branchId?: string | null;
+};
+
+export type RuntimeProjectSkillCatalogOptions = {
+  getProjectFile: (options: RuntimeGetProjectFileOptions) => Promise<RuntimeProjectFile | null>;
+  getProjectFiles: (
+    options: RuntimeProjectFilesApiOptions,
+  ) => Promise<readonly RuntimeProjectFileListItem[] | null>;
+  builtinSkills: readonly RuntimeSkillDefinition[];
+  steeringPaths?: Pick<ProjectSteeringPaths, "skills">;
+  logger?: RuntimeSkillMetadataLogger;
+};
+
+export type RuntimeProjectInstructionsOptions = {
+  getProjectFile: (options: RuntimeGetProjectFileOptions) => Promise<RuntimeProjectFile | null>;
+  steeringPaths?: Pick<ProjectSteeringPaths, "instructions">;
+};
+
+function sortSkillsById(skills: Iterable<RuntimeSkillDefinition>): RuntimeSkillDefinition[] {
+  return [...skills].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function getSkillPaths(options: Pick<RuntimeProjectSkillCatalogOptions, "steeringPaths">) {
+  return options.steeringPaths?.skills ?? DEFAULT_PROJECT_STEERING_PATHS.skills;
+}
+
+function getInstructionPaths(options: RuntimeProjectInstructionsOptions) {
+  return options.steeringPaths?.instructions ?? DEFAULT_PROJECT_STEERING_PATHS.instructions;
+}
+
+export function loadRuntimeBuiltinSkillCatalog(input: {
+  skillsDir: string;
+  logger?: RuntimeSkillMetadataLogger;
+}): RuntimeSkillDefinition[] {
+  const entriesResult = readRuntimeBuiltinSkillEntries(input.skillsDir);
+  if (!entriesResult.ok) {
+    input.logger?.error?.("Failed to load built-in skills", {
+      error: entriesResult.errorMessage,
+      skillsDir: input.skillsDir,
+    });
+    return [];
+  }
+
+  return sortSkillsById(
+    entriesResult.entries.flatMap((entry) => {
+      if (entry.isFile() && entry.name.endsWith(".md")) {
+        const id = basename(entry.name, ".md");
+        const content = readRuntimeBuiltinFlatSkill(input.skillsDir, id);
+        if (content === null) {
+          return [];
+        }
+
+        const definition = buildRuntimeSkillDefinition({
+          id,
+          content,
+          logger: input.logger,
+        });
+
+        return definition ? [definition] : [];
+      }
+
+      if (entry.isDirectory()) {
+        const content = readRuntimeBuiltinDirectorySkill(input.skillsDir, entry.name);
+        if (content === null) {
+          return [];
+        }
+
+        const definition = buildRuntimeSkillDefinition({
+          id: entry.name,
+          content,
+          references: listRuntimeBuiltinSkillReferences(input.skillsDir, entry.name),
+          logger: input.logger,
+        });
+
+        return definition ? [definition] : [];
+      }
+
+      return [];
+    }),
+  );
+}
+
+export async function getRuntimeProjectInstructions(
+  input: RuntimeProjectSteeringLookup & RuntimeProjectInstructionsOptions,
+): Promise<string> {
+  for (const filePath of getInstructionPaths(input)) {
+    const file = await input.getProjectFile({
+      projectId: input.projectId,
+      authToken: input.authToken,
+      branchId: input.branchId,
+      path: filePath,
+    });
+
+    if (file?.content) {
+      return file.content;
+    }
+  }
+
+  return "";
+}
+
+export async function getRuntimeProjectSkillCatalog(
+  input: RuntimeProjectSteeringLookup & RuntimeProjectSkillCatalogOptions,
+): Promise<RuntimeSkillDefinition[]> {
+  const allFiles = await input.getProjectFiles({
+    projectId: input.projectId,
+    authToken: input.authToken,
+    branchId: input.branchId,
+  });
+  if (!allFiles || allFiles.length === 0) {
+    return [...input.builtinSkills];
+  }
+
+  const projectSkillsById = new Map<string, RuntimeSkillDefinition>();
+
+  for (const prefix of getSkillPaths(input)) {
+    const prefixWithSlash = `${prefix}/`;
+
+    const flatPaths = allFiles
+      .filter((file) => {
+        if (!file.path.startsWith(prefixWithSlash) || !file.path.endsWith(".md")) {
+          return false;
+        }
+
+        const relative = file.path.slice(prefixWithSlash.length);
+        return !relative.includes("/");
+      })
+      .map((file) => file.path);
+
+    const dirPaths = allFiles
+      .filter((file) => file.path.startsWith(prefixWithSlash) && file.path.endsWith("/SKILL.md"))
+      .map((file) => file.path);
+
+    const skillPaths = [...dirPaths.sort(), ...flatPaths.sort()];
+    if (skillPaths.length === 0) {
+      continue;
+    }
+
+    const skillFiles = await Promise.all(
+      skillPaths.map((path) =>
+        input.getProjectFile({
+          projectId: input.projectId,
+          authToken: input.authToken,
+          branchId: input.branchId,
+          path,
+        })
+      ),
+    );
+
+    for (const file of skillFiles) {
+      if (!file?.content) {
+        continue;
+      }
+
+      const isFlat = file.path.endsWith(".md") && !file.path.endsWith("/SKILL.md");
+      const id = getProjectSkillId(file.path, isFlat);
+      if (!id) {
+        continue;
+      }
+
+      const definition = buildRuntimeSkillDefinition({
+        id,
+        content: file.content,
+        references: getProjectSkillReferences({ allFiles, file, isFlat }),
+        logger: input.logger,
+      });
+
+      if (definition && !projectSkillsById.has(definition.id)) {
+        projectSkillsById.set(definition.id, definition);
+      }
+    }
+  }
+
+  if (projectSkillsById.size === 0) {
+    return [...input.builtinSkills];
+  }
+
+  const mergedSkillsById = new Map(input.builtinSkills.map((skill) => [skill.id, skill]));
+  for (const skill of projectSkillsById.values()) {
+    mergedSkillsById.set(skill.id, skill);
+  }
+
+  return sortSkillsById(mergedSkillsById.values());
+}
+
+function getProjectSkillId(path: string, isFlat: boolean): string | null {
+  const pathParts = path.split("/");
+  const fileName = pathParts.at(-1);
+  if (isFlat) {
+    return fileName ? basename(fileName, ".md") : null;
+  }
+
+  return pathParts.at(-2) ?? null;
+}
+
+function getProjectSkillReferences(input: {
+  allFiles: readonly RuntimeProjectFileListItem[];
+  file: RuntimeProjectFile;
+  isFlat: boolean;
+}): string[] {
+  if (input.isFlat) {
+    return [];
+  }
+
+  const skillRootPrefix = input.file.path.replace(/SKILL\.md$/, "");
+  const refsPrefix = `${skillRootPrefix}references/`;
+
+  return input.allFiles
+    .filter((file) => file.path.startsWith(refsPrefix))
+    .map((file) => file.path.slice(skillRootPrefix.length))
+    .sort();
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.435";
+export const VERSION = "0.1.436";


### PR DESCRIPTION
## Summary\n- add reusable runtime helpers for builtin skill catalog loading\n- add project skill catalog and instruction lookup helpers over host-provided project file readers\n- bump package version to 0.1.436 for CI/CD publish\n\n## Verification\n- deno test --no-check --allow-all src/agent/runtime-project-skill-catalog.test.ts src/agent/runtime-project-skill-loader.test.ts src/agent/runtime-builtin-skill-files.test.ts\n- deno task verify:quick\n- pre-push checks