### PR TITLE
Extend compiled binary e2e timeout

### DIFF
--- a/tests/integration/compiled-binary-e2e.test.ts
+++ b/tests/integration/compiled-binary-e2e.test.ts
@@ -52,7 +52,7 @@ try {
   // .env file doesn't exist - that's fine
 }
 
-describe("Compiled Binary E2E", { sanitizeOps: false, sanitizeResources: false }, () => {
+describe("Compiled Binary E2E", { sanitizeOps: false, sanitizeResources: false, timeout: 600_000 }, () => {
   beforeAll(async () => {
     await ensureBinaryCompiled();
   });


### PR DESCRIPTION
## Summary\n- extend the compiled binary e2e suite timeout to cover the full kitchen-sink run on CI runners\n- keep the job-level retry timeout unchanged\n\n## Verification\n- deno fmt tests/integration/compiled-binary-e2e.test.ts\n- pre-push checks