### PR TITLE
Sanitize Google tool schemas for Gemini

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.436",
+  "version": "0.1.437",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/provider-tool-compat.test.ts
+++ b/src/agent/runtime/provider-tool-compat.test.ts
@@ -135,5 +135,4 @@ describe("provider-tool-compat", () => {
     assertEquals(containsKey(sanitized, "exclusiveMinimum"), false);
     assertEquals(containsKey(sanitized, "exclusiveMaximum"), false);
   });
-
 });

--- a/src/agent/runtime/provider-tool-compat.test.ts
+++ b/src/agent/runtime/provider-tool-compat.test.ts
@@ -108,4 +108,32 @@ describe("provider-tool-compat", () => {
     assertEquals(sanitized.enum, ["file", 1]);
     assertEquals(sanitized.type, undefined);
   });
+
+  it("normalizes Google schemas that use JSON Schema type arrays and numeric exclusive bounds", () => {
+    const sanitized = sanitizeProviderToolSchema(
+      {
+        type: "object",
+        properties: {
+          maybeText: {
+            type: ["string", "null"],
+          },
+          flexible: {
+            type: ["string", "number"],
+          },
+          count: {
+            type: "number",
+            exclusiveMinimum: 0,
+            exclusiveMaximum: 10,
+          },
+        },
+      } as never,
+      { model: "google-ai-studio/gemini-2.5-pro" },
+    );
+
+    assertEquals(sanitized.properties?.maybeText?.type, "string");
+    assertEquals(sanitized.properties?.flexible?.type, undefined);
+    assertEquals(containsKey(sanitized, "exclusiveMinimum"), false);
+    assertEquals(containsKey(sanitized, "exclusiveMaximum"), false);
+  });
+
 });

--- a/src/agent/runtime/provider-tool-compat.ts
+++ b/src/agent/runtime/provider-tool-compat.ts
@@ -27,6 +27,8 @@ const GOOGLE_UNSUPPORTED_SCHEMA_KEYS = new Set([
   "additionalProperties",
   "allOf",
   "default",
+  "exclusiveMaximum",
+  "exclusiveMinimum",
   "oneOf",
   "prefixItems",
 ]);
@@ -175,6 +177,13 @@ function getSharedLiteralType(values: readonly unknown[]): JsonSchema["type"] | 
   return firstType;
 }
 
+function getGoogleCompatibleSchemaType(type: unknown): unknown {
+  if (!Array.isArray(type)) return type;
+
+  const nonNullTypes = type.filter((value) => value !== "null");
+  return nonNullTypes.length === 1 ? nonNullTypes[0] : undefined;
+}
+
 function sanitizeGoogleSchemaValue(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map((item) => sanitizeGoogleSchemaValue(item));
@@ -190,6 +199,12 @@ function sanitizeGoogleSchemaValue(value: unknown): unknown {
 
   for (const [key, child] of Object.entries(value)) {
     if (key === "const" || key === "anyOf" || GOOGLE_UNSUPPORTED_SCHEMA_KEYS.has(key)) {
+      continue;
+    }
+
+    if (key === "type") {
+      const compatibleType = getGoogleCompatibleSchemaType(child);
+      if (compatibleType !== undefined) sanitized.type = compatibleType;
       continue;
     }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.436";
+export const VERSION = "0.1.437";


### PR DESCRIPTION
## Summary\n- normalize Google-bound JSON Schema type arrays before converting tool schemas\n- drop exclusiveMinimum/exclusiveMaximum for Google tool parameters\n- bump veryfront package version to 0.1.437\n\n## Evidence\n- RED: provider-tool-compat regression failed on array-valued type\n- GREEN: provider-tool-compat/model-tool-converter tests pass\n- deno lint passed\n- deno check passed\n\n## Follow-up\nAfter publish, bump veryfront-agent to veryfront@0.1.437 and rerun Gemini staging smoke.