### PR TITLE
Keep Gemini array tool schemas valid

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.437",
+  "version": "0.1.438",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime/provider-tool-compat.test.ts
+++ b/src/agent/runtime/provider-tool-compat.test.ts
@@ -135,4 +135,22 @@ describe("provider-tool-compat", () => {
     assertEquals(containsKey(sanitized, "exclusiveMinimum"), false);
     assertEquals(containsKey(sanitized, "exclusiveMaximum"), false);
   });
+
+  it("keeps Google array schemas valid when upstream tools omit item schemas", () => {
+    const sanitized = sanitizeProviderToolSchema(
+      {
+        type: "object",
+        properties: {
+          labelIds: {
+            type: "array",
+            description: "Label IDs to apply.",
+          },
+        },
+      } as never,
+      { model: "google-ai-studio/gemini-2.5-pro" },
+    );
+
+    assertEquals(sanitized.properties?.labelIds?.type, "array");
+    assertEquals(sanitized.properties?.labelIds?.items, {});
+  });
 });

--- a/src/agent/runtime/provider-tool-compat.ts
+++ b/src/agent/runtime/provider-tool-compat.ts
@@ -240,6 +240,10 @@ function sanitizeGoogleSchemaValue(value: unknown): unknown {
     }
   }
 
+  if (sanitized.type === "array" && !Object.hasOwn(sanitized, "items")) {
+    sanitized.items = {};
+  }
+
   return sanitized;
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.437";
+export const VERSION = "0.1.438";


### PR DESCRIPTION
## Summary\n- Adds a Google/Gemini sanitizer fallback for array schemas from upstream tools that omit `items`.\n- Bumps `veryfront` to `0.1.438`.\n- This addresses the follow-up staging error after `0.1.437`: Gemini rejected label/id array parameters with `items: missing field`.\n\n## TDD evidence\n- RED: `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all src/agent/runtime/provider-tool-compat.test.ts` failed with `labelIds.items` undefined.\n- GREEN: same focused suite plus model converter tests now pass.\n\n## Verification\n- `DENO_NO_PACKAGE_JSON=1 deno fmt --check src/agent/runtime/provider-tool-compat.ts src/agent/runtime/provider-tool-compat.test.ts deno.json src/utils/version-constant.ts`\n- `DENO_NO_PACKAGE_JSON=1 deno lint src/agent/runtime/provider-tool-compat.ts src/agent/runtime/provider-tool-compat.test.ts src/agent/runtime/model-tool-converter.ts src/agent/runtime/model-tool-converter.test.ts`\n- `deno check src/agent/runtime/provider-tool-compat.ts src/agent/runtime/provider-tool-compat.test.ts src/agent/runtime/model-tool-converter.ts src/agent/runtime/model-tool-converter.test.ts`\n- `VF_DISABLE_LRU_INTERVAL=1 SSR_TRANSFORM_PER_PROJECT_LIMIT=0 REVALIDATION_PER_PROJECT_LIMIT=0 NODE_ENV=production LOG_FORMAT=text deno test --no-check --allow-all src/agent/runtime/provider-tool-compat.test.ts src/agent/runtime/model-tool-converter.test.ts`\n- Live minimal Gemini 2.5 Flash validation: `type: array` without `items` is rejected; `items: {}` is accepted.\n\n## Follow-up\nAfter this publishes, bump veryfront-agent to `veryfront@0.1.438` and rerun staging Gemini Pro/Flash browser smoke.\n