### PR TITLE
Preserve uploaded images through provider runtime

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.438",
+  "version": "0.1.439",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/extensions/ext-anthropic/src/anthropic-provider.test.ts
+++ b/extensions/ext-anthropic/src/anthropic-provider.test.ts
@@ -129,6 +129,55 @@ describe("anthropic-provider", () => {
     });
   });
 
+  it("sends image URL user parts as Anthropic vision content", async () => {
+    let requestedInit: RequestInit | undefined;
+
+    const runtime = createAnthropicModelRuntime({
+      apiKey: "test-anthropic-key",
+      baseURL: "https://example.anthropic.test/v1",
+      fetch: (_input, init) => {
+        requestedInit = init;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              content: [{ type: "text", text: "web app screenshot" }],
+              stop_reason: "end_turn",
+              usage: { input_tokens: 8, output_tokens: 2 },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        );
+      },
+    }, "claude-sonnet-4-20250514");
+
+    await runtime.doGenerate({
+      prompt: [{
+        role: "user",
+        content: [
+          { type: "text", text: "What is this?" },
+          {
+            type: "image",
+            mediaType: "image/jpeg",
+            url: "https://signed.example.com/web-app-screenshot.jpg",
+          },
+        ],
+      }],
+      maxOutputTokens: 64,
+    });
+
+    const requestBody = JSON.parse(readRequestBody(requestedInit) ?? "{}");
+    assertEquals(requestBody.messages[0].content, [
+      { type: "text", text: "What is this?" },
+      {
+        type: "image",
+        source: {
+          type: "url",
+          url: "https://signed.example.com/web-app-screenshot.jpg",
+        },
+      },
+    ]);
+  });
+
   it("unwraps runtime tool schemas before sending Anthropic tool definitions", async () => {
     let requestedInit: RequestInit | undefined;
 

--- a/extensions/ext-anthropic/src/anthropic-provider.ts
+++ b/extensions/ext-anthropic/src/anthropic-provider.ts
@@ -26,7 +26,6 @@ import {
   ProviderRequestError,
   readProviderOptions,
   readRecord,
-  readTextParts,
   requestJson,
   requestStream,
   stringifyJsonValue,
@@ -283,6 +282,33 @@ function pushAnthropicUserContent(
   });
 }
 
+function toAnthropicUserContent(
+  parts: Extract<RuntimePromptMessage, { role: "user" }>["content"],
+): Array<Record<string, unknown>> {
+  const content: Array<Record<string, unknown>> = [];
+
+  for (const part of parts) {
+    if (part.type === "text") {
+      if (part.text.length > 0) {
+        content.push({ type: "text", text: part.text });
+      }
+      continue;
+    }
+
+    if (part.type === "image" || part.mediaType.startsWith("image/")) {
+      content.push({
+        type: "image",
+        source: {
+          type: "url",
+          url: part.url,
+        },
+      });
+    }
+  }
+
+  return content;
+}
+
 /**
  * Resolves a {@link ProviderCacheTtl} into Anthropic's `cache_control` shape.
  *
@@ -320,10 +346,7 @@ function toAnthropicMessages(
         }
         break;
       case "user":
-        pushAnthropicUserContent(messages, [{
-          type: "text",
-          text: readTextParts(message.content),
-        }]);
+        pushAnthropicUserContent(messages, toAnthropicUserContent(message.content));
         break;
       case "assistant":
         messages.push({

--- a/extensions/ext-google/src/google-provider.test.ts
+++ b/extensions/ext-google/src/google-provider.test.ts
@@ -147,6 +147,59 @@ describe("ext-google/google-provider", () => {
     });
   });
 
+  it("sends image URL user parts as Google fileData content", async () => {
+    let requestedInit: RequestInit | undefined;
+
+    const runtime = createGoogleModelRuntime({
+      apiKey: "test-google-key",
+      baseURL: "https://example.google.test/v1beta",
+      fetch: (_input, init) => {
+        requestedInit = init;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              candidates: [{
+                content: { role: "model", parts: [{ text: "web app screenshot" }] },
+                finishReason: "STOP",
+              }],
+              usageMetadata: {
+                promptTokenCount: 8,
+                candidatesTokenCount: 2,
+                totalTokenCount: 10,
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        );
+      },
+    }, "gemini-2.0-flash");
+
+    await runtime.doGenerate({
+      prompt: [{
+        role: "user",
+        content: [
+          { type: "text", text: "What is this?" },
+          {
+            type: "image",
+            mediaType: "image/jpeg",
+            url: "https://signed.example.com/web-app-screenshot.jpg",
+          },
+        ],
+      }],
+    });
+
+    const requestBody = JSON.parse(readRequestBody(requestedInit) ?? "{}");
+    assertEquals(requestBody.contents[0].parts, [
+      { text: "What is this?" },
+      {
+        fileData: {
+          mimeType: "image/jpeg",
+          fileUri: "https://signed.example.com/web-app-screenshot.jpg",
+        },
+      },
+    ]);
+  });
+
   it("creates a Google-compatible language runtime without SDK helpers for stream", async () => {
     let requestedUrl = "";
     let requestedInit: RequestInit | undefined;

--- a/extensions/ext-google/src/google-provider.ts
+++ b/extensions/ext-google/src/google-provider.ts
@@ -27,7 +27,6 @@ import {
   ProviderRequestError,
   readProviderOptions,
   readRecord,
-  readTextParts,
   requestJson,
   requestStream,
   stringifyJsonValue,
@@ -249,7 +248,7 @@ function toGoogleContents(
       case "user":
         contents.push({
           role: "user",
-          parts: [{ text: readTextParts(message.content) }],
+          parts: toGoogleUserParts(message.content),
         });
         break;
       case "assistant": {
@@ -298,6 +297,32 @@ function toGoogleContents(
       : {}),
     contents,
   };
+}
+
+function toGoogleUserParts(
+  parts: Extract<RuntimePromptMessage, { role: "user" }>["content"],
+): Array<Record<string, unknown>> {
+  const content: Array<Record<string, unknown>> = [];
+
+  for (const part of parts) {
+    if (part.type === "text") {
+      if (part.text.length > 0) {
+        content.push({ text: part.text });
+      }
+      continue;
+    }
+
+    if (part.type === "image" || part.mediaType.startsWith("image/")) {
+      content.push({
+        fileData: {
+          mimeType: part.mediaType,
+          fileUri: part.url,
+        },
+      });
+    }
+  }
+
+  return content;
 }
 
 function toGoogleTools(

--- a/extensions/ext-openai/src/openai-provider.test.ts
+++ b/extensions/ext-openai/src/openai-provider.test.ts
@@ -165,6 +165,53 @@ describe("openai-provider", () => {
     });
   });
 
+  it("sends image URL user parts as OpenAI Chat Completions image_url content", async () => {
+    let requestedInit: RequestInit | undefined;
+
+    const runtime = createOpenAIModelRuntime({
+      apiKey: "test-openai-key",
+      baseURL: "https://example.openai.test/v1",
+      fetch: (_input, init) => {
+        requestedInit = init;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              choices: [{
+                finish_reason: "stop",
+                message: { role: "assistant", content: "web app screenshot" },
+              }],
+              usage: { prompt_tokens: 8, completion_tokens: 2, total_tokens: 10 },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        );
+      },
+    }, "gpt-4o-mini");
+
+    await runtime.doGenerate({
+      prompt: [{
+        role: "user",
+        content: [
+          { type: "text", text: "What is this?" },
+          {
+            type: "image",
+            mediaType: "image/jpeg",
+            url: "https://signed.example.com/web-app-screenshot.jpg",
+          },
+        ],
+      }],
+    });
+
+    const requestBody = JSON.parse(readRequestBody(requestedInit) ?? "{}");
+    assertEquals(requestBody.messages[0].content, [
+      { type: "text", text: "What is this?" },
+      {
+        type: "image_url",
+        image_url: { url: "https://signed.example.com/web-app-screenshot.jpg" },
+      },
+    ]);
+  });
+
   it("creates an OpenAI-compatible language runtime without SDK helpers for stream", async () => {
     const encoder = new TextEncoder();
     const runtime = createOpenAIModelRuntime({
@@ -1149,6 +1196,35 @@ describe("openai-provider", () => {
       assertEquals(body!.input, [{
         role: "user",
         content: [{ type: "input_text", text: "Hi" }],
+      }]);
+    });
+
+    it("converts image URL user parts to Responses input_image content", async () => {
+      const { runtime, getBody } = captureResponsesRuntime();
+      await runtime.doGenerate({
+        prompt: [{
+          role: "user",
+          content: [
+            { type: "text", text: "What is this?" },
+            {
+              type: "image",
+              mediaType: "image/jpeg",
+              url: "https://signed.example.com/web-app-screenshot.jpg",
+            },
+          ],
+        }],
+      });
+      const body = getBody() as { input: Array<Record<string, unknown>> } | null;
+      assertEquals(body!.input, [{
+        role: "user",
+        content: [
+          { type: "input_text", text: "What is this?" },
+          {
+            type: "input_image",
+            image_url: "https://signed.example.com/web-app-screenshot.jpg",
+            detail: "auto",
+          },
+        ],
       }]);
     });
 

--- a/extensions/ext-openai/src/openai-provider.ts
+++ b/extensions/ext-openai/src/openai-provider.ts
@@ -27,7 +27,6 @@ import {
   ProviderRequestError,
   readProviderOptions,
   readRecord,
-  readTextParts,
   requestJson,
   requestStream,
   stringifyJsonValue,
@@ -751,7 +750,7 @@ function toOpenAIResponsesInput(
       case "user":
         input.push({
           role: "user",
-          content: [{ type: "input_text", text: readTextParts(message.content) }],
+          content: toOpenAIResponsesUserContent(message.content),
         });
         break;
       case "assistant": {
@@ -814,6 +813,34 @@ function toOpenAIResponsesInput(
     ...(instructionsParts.length > 0 ? { instructions: instructionsParts.join("\n\n") } : {}),
     input,
   };
+}
+
+function toOpenAIResponsesUserContent(
+  parts: Extract<RuntimePromptMessage, { role: "user" }>["content"],
+): Array<Record<string, unknown>> {
+  const content: Array<Record<string, unknown>> = [];
+
+  for (const part of parts) {
+    if (part.type === "text") {
+      if (part.text.length > 0) {
+        content.push({ type: "input_text", text: part.text });
+      }
+      continue;
+    }
+
+    if (part.type === "image" || part.mediaType.startsWith("image/")) {
+      content.push({ type: "input_image", image_url: part.url, detail: "auto" });
+      continue;
+    }
+
+    content.push({
+      type: "input_file",
+      file_url: part.url,
+      ...(part.filename ? { filename: part.filename } : {}),
+    });
+  }
+
+  return content;
 }
 
 /**

--- a/src/agent/runtime-message-file-url-refresh.ts
+++ b/src/agent/runtime-message-file-url-refresh.ts
@@ -1,4 +1,4 @@
-import type { ChatFileUiPart, ChatUiMessage, FileUIPartWithUpload } from "../chat/types.ts";
+import type { ChatUiMessage, FileUIPartWithUpload } from "../chat/types.ts";
 
 export type RuntimeFileUrlResolverInput = {
   uploadId: string;
@@ -18,25 +18,30 @@ export async function resolveRuntimeMessageFileUrls(
 
   return Promise.all(
     messages.map(async (message) => {
-      if (!message.parts.some((part) => part.type === "file" && part.uploadId)) {
+      if (!message.parts.some((part) => getUploadId(part))) {
         return message;
       }
 
       const parts = await Promise.all(
         message.parts.map(async (part) => {
-          if (!isFilePartWithUpload(part)) return part;
+          const uploadId = getUploadId(part);
+          if (!uploadId) return part;
 
-          let urlPromise = urlByUploadId.get(part.uploadId);
+          let urlPromise = urlByUploadId.get(uploadId);
           if (!urlPromise) {
-            urlPromise = resolveFileUrl({ uploadId: part.uploadId, part, message });
-            urlByUploadId.set(part.uploadId, urlPromise);
+            urlPromise = resolveFileUrl({
+              uploadId,
+              part: toResolverPart(part, uploadId),
+              message,
+            });
+            urlByUploadId.set(uploadId, urlPromise);
           }
 
           const signedUrl = await urlPromise;
-          if (!signedUrl || signedUrl === part.url) return part;
+          if (!signedUrl) return normalizeUploadedFilePart(part, uploadId);
 
           return {
-            ...part,
+            ...normalizeUploadedFilePart(part, uploadId),
             url: signedUrl,
           };
         }),
@@ -47,8 +52,69 @@ export async function resolveRuntimeMessageFileUrls(
   );
 }
 
-function isFilePartWithUpload(part: ChatUiMessage["parts"][number]): part is ChatFileUiPart & {
-  uploadId: string;
-} {
-  return part.type === "file" && typeof part.uploadId === "string" && part.uploadId.length > 0;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getStringField(part: unknown, key: string): string | undefined {
+  if (!isRecord(part)) return undefined;
+
+  const value = part[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function getUploadId(part: unknown): string | undefined {
+  if (!isRecord(part) || (part.type !== "file" && part.type !== "image")) {
+    return undefined;
+  }
+
+  return getStringField(part, "uploadId") ?? getStringField(part, "upload_id");
+}
+
+function getMediaType(part: unknown): string | undefined {
+  return getStringField(part, "mediaType") ?? getStringField(part, "media_type");
+}
+
+function normalizeUploadedFilePart(
+  part: ChatUiMessage["parts"][number],
+  uploadId: string,
+): ChatUiMessage["parts"][number] {
+  if (!isRecord(part)) return part;
+
+  const partRecord: Record<string, unknown> = part;
+  const partType = partRecord.type;
+  if (partType !== "file" && partType !== "image") return part;
+
+  const mediaType = getMediaType(part);
+  const url = getStringField(part, "url");
+  if (!mediaType || !url) return part;
+
+  const filename = getStringField(part, "filename");
+  const uploadPath = getStringField(part, "uploadPath") ?? getStringField(part, "upload_path");
+
+  return {
+    type: partType === "image" ? "image" : "file",
+    mediaType,
+    url,
+    ...(filename ? { filename } : {}),
+    uploadId,
+    ...(uploadPath ? { uploadPath } : {}),
+  } as ChatUiMessage["parts"][number];
+}
+
+function toResolverPart(
+  part: ChatUiMessage["parts"][number],
+  uploadId: string,
+): FileUIPartWithUpload {
+  const normalized = normalizeUploadedFilePart(part, uploadId);
+  if (isRecord(normalized) && normalized.type === "file") {
+    return normalized as FileUIPartWithUpload;
+  }
+
+  return {
+    type: "file",
+    mediaType: getMediaType(part) ?? "application/octet-stream",
+    url: getStringField(part, "url") ?? "",
+    uploadId,
+  };
 }

--- a/src/agent/runtime-message-preparation.test.ts
+++ b/src/agent/runtime-message-preparation.test.ts
@@ -69,6 +69,63 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages refreshes upload file URLs 
   assertStringIncludes(text, "https://signed.example.com/file.txt");
 });
 
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages preserves persisted uploaded image parts for vision models", async () => {
+  const resolvedUploadIds: string[] = [];
+  const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+    messages: [
+      userMessage(
+        [
+          { type: "text", text: "What is this?" },
+          {
+            type: "image",
+            upload_id: "upload-image-1",
+            media_type: "image/jpeg",
+            url: "/api/projects/project-1/uploads/upload-image-1",
+          },
+        ] as unknown as ChatUiMessage["parts"],
+      ),
+    ],
+    resolveFileUrl: async ({ uploadId }) => {
+      resolvedUploadIds.push(uploadId);
+      return "https://signed.example.com/web-app-screenshot.jpg";
+    },
+  });
+
+  assertEquals(resolvedUploadIds, ["upload-image-1"]);
+  assertEquals(messages[0]?.parts, [
+    { type: "text", text: "What is this?" },
+    {
+      type: "image",
+      url: "https://signed.example.com/web-app-screenshot.jpg",
+      mediaType: "image/jpeg",
+    },
+    {
+      type: "text",
+      text: "Attached files from earlier conversation context:\n\n<uploaded_files>\n" +
+        '<file name="image" upload_id="upload-image-1" url="https://signed.example.com/web-app-screenshot.jpg" type="image/jpeg" />\n' +
+        "</uploaded_files>",
+    },
+  ]);
+
+  const runtimeMessages = convertToTextGenerationRuntimeMessages(messages);
+  const content = runtimeMessages[0]?.role === "user" ? runtimeMessages[0].content : null;
+  if (!Array.isArray(content)) {
+    throw new Error("Expected text-generation runtime to keep multimodal user content");
+  }
+
+  const text = content.flatMap((part) => part.type === "text" ? [part.text] : []).join("\n");
+  assertStringIncludes(text, "What is this?");
+  assertStringIncludes(text, "<uploaded_files>");
+  assertEquals(
+    content.some((part) =>
+      part.type === "image" &&
+      part.url === "https://signed.example.com/web-app-screenshot.jpg" &&
+      part.mediaType === "image/jpeg"
+    ),
+    true,
+  );
+});
+
 Deno.test("prepareAgentRuntimeMessagesFromUiMessages keeps original URL when resolver returns undefined", async () => {
   const messages = await prepareAgentRuntimeMessagesFromUiMessages({
     messages: [
@@ -127,17 +184,24 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages keeps a synthetic PDF visib
 
   assertEquals(runtimeMessages[0]?.role, "user");
   const content = runtimeMessages[0]?.content;
-  if (typeof content !== "string") {
-    throw new Error("Expected text-generation runtime user content to be a string");
+  if (!Array.isArray(content)) {
+    throw new Error("Expected text-generation runtime user content to preserve native file parts");
   }
 
-  assertStringIncludes(content, "Sent with attachments");
-  assertStringIncludes(content, "<uploaded_files>");
-  assertStringIncludes(content, "sample-attachment.pdf");
-  assertStringIncludes(content, "test-upload-id");
-  assertStringIncludes(content, "application/pdf");
-  assertStringIncludes(content, "https://signed.example.com/invoice.pdf");
-  assertEquals(countOccurrences(content, "<uploaded_files>"), 1);
+  const text = content.flatMap((part) => part.type === "text" ? [part.text] : []).join("\n");
+  assertStringIncludes(text, "Sent with attachments");
+  assertStringIncludes(text, "<uploaded_files>");
+  assertStringIncludes(text, "sample-attachment.pdf");
+  assertStringIncludes(text, "test-upload-id");
+  assertStringIncludes(text, "application/pdf");
+  assertStringIncludes(text, "https://signed.example.com/invoice.pdf");
+  assertEquals(countOccurrences(text, "<uploaded_files>"), 1);
+  assertEquals(
+    content.some((part) =>
+      part.type === "file" && part.url === "https://signed.example.com/invoice.pdf"
+    ),
+    true,
+  );
 });
 
 Deno.test("chat attachment preparation keeps a synthetic PDF visible in the model prompt", async () => {

--- a/src/agent/runtime/text-generation-runtime-message-converter.test.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.test.ts
@@ -7,6 +7,7 @@ import {
 import type {
   TextGenerationRuntimeAssistantMessage,
   TextGenerationRuntimeToolMessage,
+  TextGenerationRuntimeUserMessage,
 } from "./text-generation-runtime-message-types.ts";
 import type { Message } from "../types.ts";
 
@@ -65,14 +66,22 @@ describe("text-generation-runtime-message-converter", () => {
       const result = convertToTextGenerationRuntimeMessage(msg);
 
       assertEquals(result.role, "user");
-      if (typeof result.content !== "string") {
-        throw new Error("Expected user content to be text fallback for current runtime");
+      const content = (result as TextGenerationRuntimeUserMessage).content;
+      if (!Array.isArray(content)) {
+        throw new Error("Expected user content to preserve native file parts");
       }
-      assertStringIncludes(result.content, "Sent with attachments");
-      assertStringIncludes(result.content, "<uploaded_files>");
-      assertStringIncludes(result.content, "sample-attachment.pdf");
-      assertStringIncludes(result.content, "test-upload-id");
-      assertStringIncludes(result.content, "application/pdf");
+      assertEquals(content[0], { type: "text", text: "Sent with attachments" });
+      assertEquals(content[1], {
+        type: "file",
+        mediaType: "application/pdf",
+        url: "https://signed.example.com/invoice.pdf",
+        filename: "sample-attachment.pdf",
+      });
+      const text = content.flatMap((part) => part.type === "text" ? [part.text] : []).join("\n");
+      assertStringIncludes(text, "<uploaded_files>");
+      assertStringIncludes(text, "sample-attachment.pdf");
+      assertStringIncludes(text, "test-upload-id");
+      assertStringIncludes(text, "application/pdf");
     });
 
     it("separates user text from attachment context with a readable blank line", () => {
@@ -92,10 +101,12 @@ describe("text-generation-runtime-message-converter", () => {
 
       const result = convertToTextGenerationRuntimeMessage(msg);
 
-      if (typeof result.content !== "string") {
-        throw new Error("Expected user content to be text fallback for current runtime");
+      const content = (result as TextGenerationRuntimeUserMessage).content;
+      if (!Array.isArray(content)) {
+        throw new Error("Expected user content to preserve native file parts");
       }
-      assertStringIncludes(result.content, "Sent with attachments\n\n<uploaded_files>");
+      const text = content.flatMap((part) => part.type === "text" ? [part.text] : []).join("\n\n");
+      assertStringIncludes(text, "Sent with attachments\n\n<uploaded_files>");
     });
 
     it("does not start file-only user attachment context with blank lines", () => {
@@ -114,10 +125,12 @@ describe("text-generation-runtime-message-converter", () => {
 
       const result = convertToTextGenerationRuntimeMessage(msg);
 
-      if (typeof result.content !== "string") {
-        throw new Error("Expected user content to be text fallback for current runtime");
+      const content = (result as TextGenerationRuntimeUserMessage).content;
+      if (!Array.isArray(content)) {
+        throw new Error("Expected user content to preserve native file parts");
       }
-      assertEquals(result.content.startsWith("<uploaded_files>"), true);
+      const text = content.flatMap((part) => part.type === "text" ? [part.text] : []).join("\n");
+      assertEquals(text.startsWith("<uploaded_files>"), true);
     });
 
     it("converts an assistant message with text", () => {

--- a/src/agent/runtime/text-generation-runtime-message-converter.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.ts
@@ -9,6 +9,7 @@
 
 import type {
   TextGenerationRuntimeAssistantMessage,
+  TextGenerationRuntimeFilePart,
   TextGenerationRuntimeMessage,
   TextGenerationRuntimeTextPart,
   TextGenerationRuntimeToolCallPart,
@@ -75,6 +76,26 @@ function getUserTextWithAttachmentContext(parts: Message["parts"]): string {
     : appendReadableAttachmentContext(text, buildAttachmentContextFromParts(parts));
 }
 
+function getUserFileParts(parts: Message["parts"]): TextGenerationRuntimeFilePart[] {
+  return parts.flatMap((part) => {
+    const type = getStringPartField(part, "type");
+    if (type !== "file" && type !== "image") return [];
+
+    const mediaType = getStringPartField(part, "mediaType");
+    const url = getStringPartField(part, "url");
+    if (!mediaType || !url || url.startsWith("data:")) return [];
+
+    return [{
+      type,
+      mediaType,
+      url,
+      ...(getStringPartField(part, "filename")
+        ? { filename: getStringPartField(part, "filename") }
+        : {}),
+    }];
+  });
+}
+
 /**
  * Convert a veryfront Message to the current text-generation runtime message format.
  */
@@ -86,8 +107,26 @@ export function convertToTextGenerationRuntimeMessage(msg: Message): TextGenerat
     }
 
     case "user": {
-      const text = getUserTextWithAttachmentContext(msg.parts);
-      return { role: "user", content: text };
+      const fileParts = getUserFileParts(msg.parts);
+      if (fileParts.length === 0) {
+        const text = getUserTextWithAttachmentContext(msg.parts);
+        return { role: "user", content: text };
+      }
+
+      const text = getTextFromParts(msg.parts);
+      const attachmentContext = text.includes("<uploaded_files>")
+        ? ""
+        : buildAttachmentContextFromParts(msg.parts);
+      return {
+        role: "user",
+        content: [
+          ...(text.length > 0 ? [{ type: "text" as const, text }] : []),
+          ...fileParts,
+          ...(attachmentContext.length > 0
+            ? [{ type: "text" as const, text: attachmentContext.trimStart() }]
+            : []),
+        ],
+      };
     }
 
     case "assistant": {

--- a/src/agent/runtime/text-generation-runtime-message-types.ts
+++ b/src/agent/runtime/text-generation-runtime-message-types.ts
@@ -11,6 +11,13 @@ export interface TextGenerationRuntimeTextPart {
   text: string;
 }
 
+export interface TextGenerationRuntimeFilePart {
+  type: "file" | "image";
+  mediaType: string;
+  url: string;
+  filename?: string;
+}
+
 export interface TextGenerationRuntimeToolCallPart {
   type: "tool-call";
   toolCallId: string;
@@ -35,7 +42,7 @@ export interface TextGenerationRuntimeSystemMessage {
 
 export interface TextGenerationRuntimeUserMessage {
   role: "user";
-  content: string;
+  content: string | Array<TextGenerationRuntimeTextPart | TextGenerationRuntimeFilePart>;
 }
 
 export interface TextGenerationRuntimeAssistantMessage {

--- a/src/chat/conversation.ts
+++ b/src/chat/conversation.ts
@@ -514,7 +514,7 @@ function toJsonValue(value: unknown): JsonValue {
 }
 
 function getFilePart(part: unknown): {
-  type: "file";
+  type: "file" | "image";
   mediaType: string;
   data: string;
   url: string;
@@ -522,22 +522,25 @@ function getFilePart(part: unknown): {
   uploadId?: string;
   uploadPath?: string;
 } | null {
-  if (!isRecord(part) || part.type !== "file") {
+  if (!isRecord(part) || (part.type !== "file" && part.type !== "image")) {
     return null;
   }
 
-  const mediaType = getNonEmptyStringField(part, "mediaType");
+  const mediaType = getNonEmptyStringField(part, "mediaType") ??
+    getNonEmptyStringField(part, "media_type");
   const data = getNonEmptyStringField(part, "url");
   if (!mediaType || !data) {
     return null;
   }
 
   const filename = getNonEmptyStringField(part, "filename");
-  const uploadId = getNonEmptyStringField(part, "uploadId");
-  const uploadPath = getNonEmptyStringField(part, "uploadPath");
+  const uploadId = getNonEmptyStringField(part, "uploadId") ??
+    getNonEmptyStringField(part, "upload_id");
+  const uploadPath = getNonEmptyStringField(part, "uploadPath") ??
+    getNonEmptyStringField(part, "upload_path");
 
   return {
-    type: "file",
+    type: part.type === "image" ? "image" : "file",
     mediaType,
     data,
     url: data,
@@ -720,10 +723,13 @@ function convertSystemMessage(message: ChatUiMessage): ProviderModelMessage[] {
 function convertUserMessage(message: ChatUiMessage): ProviderModelMessage[] {
   const content: Array<
     { type: "text"; text: string } | {
-      type: "file";
+      type: "file" | "image";
       mediaType: string;
       data: string;
+      url: string;
       filename?: string;
+      uploadId?: string;
+      uploadPath?: string;
     }
   > = [];
 
@@ -756,7 +762,7 @@ function convertAssistantMessage(message: ChatUiMessage): ProviderModelMessage[]
   const assistantContent: Array<
     | { type: "text"; text: string }
     | { type: "reasoning"; text: string }
-    | { type: "file"; mediaType: string; data: string; filename?: string }
+    | { type: "file" | "image"; mediaType: string; data: string; filename?: string }
     | { type: "tool-call"; toolCallId: string; toolName: string; input: Record<string, unknown> }
   > = [];
   const deferredAssistantContent: typeof assistantContent = [];
@@ -805,7 +811,7 @@ function convertAssistantMessage(message: ChatUiMessage): ProviderModelMessage[]
     part:
       | { type: "text"; text: string }
       | { type: "reasoning"; text: string }
-      | { type: "file"; mediaType: string; data: string; filename?: string }
+      | { type: "file" | "image"; mediaType: string; data: string; filename?: string }
       | { type: "tool-call"; toolCallId: string; toolName: string; input: Record<string, unknown> },
   ) => {
     if (toolResults.length > 0) {

--- a/src/provider/runtime-loader.ts
+++ b/src/provider/runtime-loader.ts
@@ -34,7 +34,13 @@ export type { RuntimeUsage };
 
 export type RuntimePromptMessage =
   | { role: "system"; content: string }
-  | { role: "user"; content: Array<{ type: "text"; text: string }> }
+  | {
+    role: "user";
+    content: Array<
+      | { type: "text"; text: string }
+      | { type: "image" | "file"; mediaType: string; url: string; filename?: string }
+    >;
+  }
   | {
     role: "assistant";
     content: Array<
@@ -261,7 +267,15 @@ type OpenAICompatibleLanguageOptions = {
 };
 export type OpenAICompatibleChatMessage =
   | { role: "system"; content: string }
-  | { role: "user"; content: string }
+  | {
+    role: "user";
+    content:
+      | string
+      | Array<
+        | { type: "text"; text: string }
+        | { type: "image_url"; image_url: { url: string } }
+      >;
+  }
   | {
     role: "assistant";
     content: string | null;
@@ -279,6 +293,11 @@ export type OpenAICompatibleChatMessage =
     tool_call_id: string;
     content: string;
   };
+type RuntimePromptUserContent = Extract<RuntimePromptMessage, { role: "user" }>["content"];
+type OpenAICompatibleUserContent = Extract<
+  OpenAICompatibleChatMessage,
+  { role: "user" }
+>["content"];
 export type OpenAICompatibleChatRequest = {
   model: string;
   messages: OpenAICompatibleChatMessage[];
@@ -359,6 +378,30 @@ export function readTextParts(parts: Array<{ type: string; text?: string }>): st
   return text;
 }
 
+function toOpenAICompatibleUserContent(
+  parts: RuntimePromptUserContent,
+): OpenAICompatibleUserContent {
+  if (!parts.some((part) => part.type !== "text" && part.mediaType.startsWith("image/"))) {
+    return readTextParts(parts);
+  }
+
+  const content: Exclude<OpenAICompatibleUserContent, string> = [];
+
+  for (const part of parts) {
+    if (part.type === "text") {
+      if (part.text.length > 0) {
+        content.push({ type: "text", text: part.text });
+      }
+      continue;
+    }
+    if (part.type === "image" || part.mediaType.startsWith("image/")) {
+      content.push({ type: "image_url", image_url: { url: part.url } });
+    }
+  }
+
+  return content.length > 0 ? content : readTextParts(parts);
+}
+
 export function toOpenAICompatibleMessages(
   prompt: RuntimePromptMessage[],
 ): OpenAICompatibleChatMessage[] {
@@ -370,7 +413,7 @@ export function toOpenAICompatibleMessages(
         messages.push({ role: "system", content: message.content });
         break;
       case "user":
-        messages.push({ role: "user", content: readTextParts(message.content) });
+        messages.push({ role: "user", content: toOpenAICompatibleUserContent(message.content) });
         break;
       case "assistant": {
         let text = "";

--- a/src/runtime/runtime-bridge.ts
+++ b/src/runtime/runtime-bridge.ts
@@ -73,7 +73,13 @@ type EmbedManyOptions = {
 
 type RuntimePromptMessage =
   | { role: "system"; content: string }
-  | { role: "user"; content: Array<{ type: "text"; text: string }> }
+  | {
+    role: "user";
+    content: Array<
+      | { type: "text"; text: string }
+      | { type: "image" | "file"; mediaType: string; url: string; filename?: string }
+    >;
+  }
   | {
     role: "assistant";
     content: Array<
@@ -181,7 +187,9 @@ function toRuntimePrompt(
       case "user":
         prompt.push({
           role: "user",
-          content: [{ type: "text", text: message.content }],
+          content: typeof message.content === "string"
+            ? [{ type: "text", text: message.content }]
+            : message.content,
         });
         break;
       case "assistant":

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.438";
+export const VERSION = "0.1.439";


### PR DESCRIPTION
## Summary
- refresh persisted snake_case `image` upload parts into signed camelCase runtime parts
- keep uploaded image/file parts through text-generation runtime and provider prompts
- emit provider-native image payloads for Anthropic, Google, OpenAI Chat Completions, and OpenAI Responses
- bump `veryfront` package version to `0.1.439`

## Evidence
- Staging conversation `835c40af-01f0-4841-94f6-f0710e6fd571` stores a user `image` part with `upload_id=f511afb2-9c79-4d11-9555-f588a1f4661a`, `media_type=image/jpeg`; the UI displays a web-app screenshot, while the assistant answered as if it had not received the image.
- Red test first failed because persisted `image` parts were not resolved/preserved.
- Focused verification passes locally:
  - `deno check src/agent/runtime-message-preparation.test.ts src/agent/runtime-message-file-url-refresh.ts src/chat/conversation.ts src/agent/runtime/text-generation-runtime-message-converter.ts src/runtime/runtime-bridge.ts src/provider/runtime-loader.ts src/agent/runtime/text-generation-runtime-message-converter.test.ts`
  - `deno test --no-check --allow-all src/agent/runtime-message-preparation.test.ts src/agent/runtime-message-file-url-refresh.test.ts src/chat/conversation.test.ts src/agent/runtime/text-generation-runtime-message-converter.test.ts src/runtime/runtime-bridge.test.ts extensions/ext-anthropic/src/anthropic-provider.test.ts extensions/ext-google/src/google-provider.test.ts extensions/ext-openai/src/openai-provider.test.ts`
  - typed extension tests: `(cd extensions/ext-openai && deno test --allow-all src/openai-provider.test.ts)`, `(cd extensions/ext-anthropic && deno test --allow-all src/anthropic-provider.test.ts)`, `(cd extensions/ext-google && deno test --allow-all src/google-provider.test.ts)`

## Notes
- This is the framework-side fix. After merge/publish, `veryfront-agent` needs a dependency bump to `veryfront@0.1.439`, then staging browser verification on the affected upload flow.
- Official API docs support the provider payload shapes used here: Anthropic URL image source, OpenAI image URL inputs, Gemini `fileData.fileUri` media parts.
