### PR TITLE
Add hosted durable chat run starter

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.439",
+  "version": "0.1.440",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-durable-chat-run-start.test.ts
+++ b/src/agent/hosted-durable-chat-run-start.test.ts
@@ -1,0 +1,185 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ChatUiMessage } from "#veryfront/chat/types.ts";
+import {
+  type AgUiResumeValue,
+  createDetachedRunTracker,
+  type ParsedHostedChatRequest,
+} from "./index.ts";
+import {
+  executeHostedDurableChatRun,
+  resolveHostedDurableRunSetupErrorResponse,
+} from "./hosted-durable-chat-run-start.ts";
+
+const userMessage: ChatUiMessage = {
+  id: "message-1",
+  role: "user",
+  parts: [{ type: "text", text: "Hello" }],
+};
+
+function createParsedRequest(
+  overrides: Partial<ParsedHostedChatRequest> = {},
+): ParsedHostedChatRequest {
+  const conversationId = crypto.randomUUID();
+  return {
+    userId: "user-1",
+    authToken: "token-1",
+    messages: [userMessage],
+    validatedContext: {
+      conversationId,
+      projectId: "project-1",
+      branchId: "branch-1",
+    },
+    projectId: "project-1",
+    conversationId,
+    parentRunId: "run-1",
+    upstreamParentConversationId: undefined,
+    upstreamParentRunId: undefined,
+    spawnedFromToolCallId: undefined,
+    model: "anthropic/claude-sonnet-4-6",
+    allowDelegation: true,
+    forwardedProps: { activeChatId: "chat-1" },
+    runtimeOverrides: undefined,
+    durableRootRun: {
+      runId: "run-1",
+      messageId: "message-1",
+    },
+    persistLatestUserMessageBeforeDurableRun: false,
+    ...overrides,
+  };
+}
+
+function createRequest(): Request {
+  return new Request("https://agent.example.com/api/ag-ui/runs", { method: "POST" });
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  return await response.json();
+}
+
+describe("agent/hosted-durable-chat-run-start", () => {
+  it("starts a detached durable chat run through the shared AG-UI start flow", async () => {
+    const tracker = createDetachedRunTracker<AgUiResumeValue>();
+    const preparedExecution = { id: "execution-1" };
+    let prepared = false;
+    let started = false;
+
+    const response = await executeHostedDurableChatRun({
+      req: createParsedRequest(),
+      rawRequest: createRequest(),
+      tracker,
+      prepareExecution: async () => {
+        prepared = true;
+        return preparedExecution;
+      },
+      startDetachedExecution: async ({ execution }) => {
+        assertEquals(execution, preparedExecution);
+        started = true;
+      },
+    });
+
+    assertEquals(response.status, 202);
+    assertEquals(await readJson(response), { accepted: true, duplicate: false });
+    assertEquals(prepared, true);
+    assertEquals(started, true);
+  });
+
+  it("short-circuits duplicate active runs before preparing execution", async () => {
+    const tracker = createDetachedRunTracker<AgUiResumeValue>();
+    const req = createParsedRequest();
+    if (!req.durableRootRun || !req.conversationId) {
+      throw new Error("Expected durable request");
+    }
+    tracker.sessionManager.startRun({
+      runId: req.durableRootRun.runId,
+      threadId: req.conversationId,
+    });
+    let prepared = false;
+
+    const response = await executeHostedDurableChatRun({
+      req,
+      rawRequest: createRequest(),
+      tracker,
+      prepareExecution: async () => {
+        prepared = true;
+        return {};
+      },
+      startDetachedExecution: async () => {},
+    });
+
+    assertEquals(response.status, 202);
+    assertEquals(await readJson(response), { accepted: true, duplicate: true });
+    assertEquals(prepared, false);
+  });
+
+  it("returns a stable error when durable conversation context is missing", async () => {
+    const tracker = createDetachedRunTracker<AgUiResumeValue>();
+
+    const response = await executeHostedDurableChatRun({
+      req: createParsedRequest({
+        conversationId: undefined,
+        durableRootRun: undefined,
+      }),
+      rawRequest: createRequest(),
+      tracker,
+      prepareExecution: async () => ({}),
+      startDetachedExecution: async () => {},
+    });
+
+    assertEquals(response.status, 400);
+    assertEquals(await readJson(response), {
+      errorCode: "DURABLE_CHAT_ROOT_REQUIRES_CONVERSATION",
+    });
+  });
+
+  it("maps auth setup failures with the supplied auth resolver", async () => {
+    const tracker = createDetachedRunTracker<AgUiResumeValue>();
+
+    const response = await executeHostedDurableChatRun({
+      req: createParsedRequest(),
+      rawRequest: createRequest(),
+      tracker,
+      prepareExecution: async () => {
+        throw new Error("denied");
+      },
+      startDetachedExecution: async () => {},
+      resolveAuthError: (error) =>
+        error instanceof Error && error.message === "denied"
+          ? { errorCode: "FORBIDDEN", statusCode: 403 }
+          : null,
+    });
+
+    assertEquals(response.status, 403);
+    assertEquals(await readJson(response), { errorCode: "FORBIDDEN" });
+  });
+
+  it("maps provider setup failures to durable setup responses", async () => {
+    const tracker = createDetachedRunTracker<AgUiResumeValue>();
+
+    const response = await executeHostedDurableChatRun({
+      req: createParsedRequest(),
+      rawRequest: createRequest(),
+      tracker,
+      prepareExecution: async () => {
+        throw new Error("prompt is too long");
+      },
+      startDetachedExecution: async () => {},
+    });
+
+    assertEquals(response.status, 413);
+    assertEquals(await readJson(response), { errorCode: "CONTEXT_LENGTH_EXCEEDED" });
+  });
+
+  it("resolves missing conversation setup errors to a bad request", () => {
+    assertEquals(
+      resolveHostedDurableRunSetupErrorResponse({
+        code: "UNKNOWN_ERROR",
+        originalError: new Error("DURABLE_CHAT_ROOT_REQUIRES_CONVERSATION"),
+      }),
+      {
+        errorCode: "DURABLE_CHAT_ROOT_REQUIRES_CONVERSATION",
+        statusCode: 400,
+      },
+    );
+  });
+});

--- a/src/agent/hosted-durable-chat-run-start.ts
+++ b/src/agent/hosted-durable-chat-run-start.ts
@@ -1,0 +1,246 @@
+import { parseProviderError } from "../chat/provider-errors.ts";
+import {
+  AgUiDetachedStartAcceptedSchema,
+  buildDetachedAgUiStartRequest,
+  executeAgUiDetachedStart,
+} from "./ag-ui-detached-start.ts";
+import type { AgUiResumeValue } from "./ag-ui-tool-shared.ts";
+import type { DetachedRunTracker } from "./detached-run-tracker.ts";
+import type { ParsedHostedChatRequest } from "./hosted-chat-request-parser.ts";
+
+export type HostedDurableRunSetupErrorStatusCode = 400 | 402 | 413 | 429 | 500 | 503;
+
+export type HostedDurableRunAccepted = {
+  accepted: boolean;
+  duplicate: boolean;
+};
+
+export type HostedDurableRunAuthErrorResponse = {
+  errorCode: string;
+  statusCode: number;
+  metadata?: Record<string, unknown>;
+};
+
+export type HostedDurableRunLogger = {
+  error(message: string, metadata?: Record<string, unknown>): void;
+};
+
+export type HostedDurableRunStartExecutionInput<TExecution> = {
+  execution: TExecution;
+  abortSignal: AbortSignal;
+};
+
+export type HostedDurableRunStartCleanupInput<TExecution> = {
+  execution: TExecution;
+  runId: string;
+  conversationId: string;
+};
+
+export type ExecuteHostedDurableChatRunInput<TExecution> = {
+  req: ParsedHostedChatRequest;
+  rawRequest: Request;
+  requestOrCtx?: unknown;
+  tracker: DetachedRunTracker<AgUiResumeValue>;
+  prepareExecution: (req: ParsedHostedChatRequest) => Promise<TExecution>;
+  startDetachedExecution: (
+    input: HostedDurableRunStartExecutionInput<TExecution>,
+  ) => Promise<void>;
+  cleanupExecution?: (input: HostedDurableRunStartCleanupInput<TExecution>) => Promise<void>;
+  resolveAuthError?: (error: unknown) => HostedDurableRunAuthErrorResponse | null | undefined;
+  logger?: HostedDurableRunLogger;
+};
+
+function readBooleanProperty(input: object | null, propertyName: string): boolean {
+  if (!input) {
+    return false;
+  }
+
+  return Object.getOwnPropertyDescriptor(input, propertyName)?.value === true;
+}
+
+function isDurableRunSetupErrorStatusCode(
+  status: number | undefined,
+): status is HostedDurableRunSetupErrorStatusCode {
+  return status === 400 || status === 402 || status === 413 || status === 429 ||
+    status === 500 || status === 503;
+}
+
+function fallbackDurableRunSetupErrorStatusCode(
+  code: string,
+): HostedDurableRunSetupErrorStatusCode {
+  if (code === "OVERLOADED_ERROR") return 503;
+  if (code === "CONTEXT_LENGTH_EXCEEDED") return 413;
+
+  return 500;
+}
+
+export function resolveHostedDurableRunSetupErrorResponse(input: {
+  code: string;
+  status?: number;
+  originalError: unknown;
+}): {
+  errorCode: string;
+  statusCode: HostedDurableRunSetupErrorStatusCode;
+} {
+  if (
+    input.originalError instanceof Error &&
+    input.originalError.message === "DURABLE_CHAT_ROOT_REQUIRES_CONVERSATION"
+  ) {
+    return {
+      errorCode: "DURABLE_CHAT_ROOT_REQUIRES_CONVERSATION",
+      statusCode: 400,
+    };
+  }
+
+  return {
+    errorCode: input.code,
+    statusCode: isDurableRunSetupErrorStatusCode(input.status)
+      ? input.status
+      : fallbackDurableRunSetupErrorStatusCode(input.code),
+  };
+}
+
+async function parseAcceptedDetachedStartResponse(
+  response: Response,
+): Promise<HostedDurableRunAccepted> {
+  if (response.status !== 202) {
+    return { accepted: false, duplicate: false };
+  }
+
+  const payload = await response.json().catch((): null => null);
+  const parsed = AgUiDetachedStartAcceptedSchema.safeParse(payload);
+  if (parsed.success) {
+    return {
+      accepted: parsed.data.accepted,
+      duplicate: parsed.data.duplicate,
+    };
+  }
+
+  const payloadObject = typeof payload === "object" ? payload : null;
+  return {
+    accepted: readBooleanProperty(payloadObject, "accepted"),
+    duplicate: readBooleanProperty(payloadObject, "duplicate"),
+  };
+}
+
+async function executeHostedDurableChatRunStart<TExecution>(
+  input: ExecuteHostedDurableChatRunInput<TExecution>,
+): Promise<Response | HostedDurableRunAccepted> {
+  const { durableRootRun, conversationId } = input.req;
+  if (!durableRootRun || !conversationId) {
+    throw new Error("DURABLE_CHAT_ROOT_REQUIRES_CONVERSATION");
+  }
+
+  const execution = await input.prepareExecution(input.req);
+  const detachedStartRequest = buildDetachedAgUiStartRequest({
+    runId: durableRootRun.runId,
+    threadId: conversationId,
+    messages: input.req.messages,
+    model: input.req.model,
+    forwardedProps: input.req.forwardedProps,
+  });
+  const detachedStartResponse = await executeAgUiDetachedStart(
+    {
+      sessionManager: input.tracker.sessionManager,
+      startDetachedExecution: async ({ abortSignal }) => {
+        const detachedExecution = input.startDetachedExecution({
+          execution,
+          abortSignal,
+        });
+        input.tracker.registerExecution(durableRootRun.runId, detachedExecution);
+        await detachedExecution;
+      },
+      onDuplicate: async () => {
+        await input.cleanupExecution?.({
+          execution,
+          runId: durableRootRun.runId,
+          conversationId,
+        });
+      },
+      onAccepted: async () => {
+        input.tracker.trackRun(durableRootRun.runId);
+      },
+      onError: async ({ error }) => {
+        input.tracker.untrackRun(durableRootRun.runId);
+        input.logger?.error("Detached durable run execution failed", {
+          runId: durableRootRun.runId,
+          conversationId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      },
+    },
+    {
+      request: detachedStartRequest,
+      rawRequest: input.rawRequest,
+      requestOrCtx: input.requestOrCtx ?? input.rawRequest,
+    },
+  );
+
+  if (detachedStartResponse.status !== 202) {
+    return detachedStartResponse;
+  }
+
+  return await parseAcceptedDetachedStartResponse(detachedStartResponse);
+}
+
+export async function executeHostedDurableChatRun<TExecution>(
+  input: ExecuteHostedDurableChatRunInput<TExecution>,
+): Promise<Response> {
+  const { durableRootRun, conversationId, projectId, userId } = input.req;
+  if (!durableRootRun || !conversationId) {
+    return Response.json(
+      { errorCode: "DURABLE_CHAT_ROOT_REQUIRES_CONVERSATION" },
+      { status: 400 },
+    );
+  }
+
+  const existingRunStatus = input.tracker.sessionManager.getRunStatus(durableRootRun.runId);
+  if (existingRunStatus === "running" || existingRunStatus === "waiting") {
+    return Response.json({ accepted: true, duplicate: true }, { status: 202 });
+  }
+
+  try {
+    const startResult = await executeHostedDurableChatRunStart(input);
+
+    if (startResult instanceof Response) {
+      return startResult;
+    }
+
+    return Response.json(startResult, { status: 202 });
+  } catch (error) {
+    const authError = input.resolveAuthError?.(error);
+    if (authError) {
+      input.logger?.error("Durable chat auth error from API", {
+        errorCode: authError.errorCode,
+        statusCode: authError.statusCode,
+        projectId,
+        userId,
+        runId: durableRootRun.runId,
+        ...authError.metadata,
+      });
+      return Response.json(
+        { errorCode: authError.errorCode },
+        { status: authError.statusCode },
+      );
+    }
+
+    const { code, status } = parseProviderError(error);
+    const response = resolveHostedDurableRunSetupErrorResponse({
+      code,
+      status,
+      originalError: error,
+    });
+    input.logger?.error("Durable chat execute failed during setup", {
+      errorCode: code,
+      originalError: error instanceof Error ? error.message : String(error),
+      projectId,
+      userId,
+      runId: durableRootRun.runId,
+    });
+
+    return Response.json(
+      { errorCode: response.errorCode },
+      { status: response.statusCode },
+    );
+  }
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -281,6 +281,17 @@ export type {
 } from "./hosted-chat-runtime-contract.ts";
 
 export {
+  executeHostedDurableChatRun,
+  type ExecuteHostedDurableChatRunInput,
+  type HostedDurableRunAccepted,
+  type HostedDurableRunAuthErrorResponse,
+  type HostedDurableRunLogger,
+  type HostedDurableRunSetupErrorStatusCode,
+  type HostedDurableRunStartCleanupInput,
+  type HostedDurableRunStartExecutionInput,
+  resolveHostedDurableRunSetupErrorResponse,
+} from "./hosted-durable-chat-run-start.ts";
+export {
   buildParsedHostedChatRequest,
   type HostedChatProjectAccessError,
   type HostedChatProjectAccessResult,
@@ -1080,6 +1091,7 @@ export {
   executeAgUiDetachedStart,
   type ExecuteAgUiDetachedStartInput,
 } from "./ag-ui-detached-start.ts";
+export type { AgUiResumeValue } from "./ag-ui-tool-shared.ts";
 export {
   createDetachedRunTracker,
   type DetachedRunDrainResult,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.439";
+export const VERSION = "0.1.440";


### PR DESCRIPTION
## Summary
- add a reusable hosted durable chat run start helper around detached AG-UI execution
- expose durable setup error mapping and resume value types for hosted runtimes
- bump package version to 0.1.440

## Verification
- deno test --no-check --allow-all src/agent/hosted-durable-chat-run-start.test.ts
- deno test --no-check --allow-all src/agent/hosted-durable-chat-run-start.test.ts src/agent/ag-ui-detached-start.test.ts src/agent/hosted-chat-request.test.ts
- deno lint src/agent/hosted-durable-chat-run-start.ts src/agent/hosted-durable-chat-run-start.test.ts src/agent/index.ts
- deno check src/agent/hosted-durable-chat-run-start.ts src/agent/hosted-durable-chat-run-start.test.ts src/agent/index.ts
- pre-push hook: format, lint, type check, unit tests: 1727 passed, 0 failed

## Notes
Repository-wide exploratory commands currently reach unrelated existing blockers outside this change:
- extensions/ext-tailwind/src/dynamic-esm-import.integration.test.ts imports missing ../_helpers/contract-init.ts.
- after excluding that, broad parallel execution reported cli/auth/auth.integration.test.ts token persistence; the isolated CLI auth integration file passes.