### PR TITLE
Add hosted child fork run context helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.441",
+  "version": "0.1.442",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-fork-run-context.test.ts
+++ b/src/agent/hosted-child-fork-run-context.test.ts
@@ -2,6 +2,7 @@ import { assertEquals } from "@std/assert";
 import type { ChatMessageMetadata, ChatUiMessageChunk } from "#veryfront/chat/protocol.ts";
 import {
   createHostedChildForkRunContext,
+  createHostedDurableChildForkRunContext,
   executeHostedChildForkRunContextStream,
   finalizeHostedChildForkRunContextResources,
   handleHostedChildForkRunContextError,
@@ -55,6 +56,50 @@ Deno.test("createHostedChildForkRunContext wires stream mirror state and buffers
   assertEquals(context.streamMirrorContext.hasStartedStep(), true);
   assertEquals(context.streamMirrorContext.hasEmittedProgress(), true);
   assertEquals(chunks, [{ type: "start-step" }]);
+});
+
+Deno.test("createHostedDurableChildForkRunContext wires conversation mirror and child identifiers", () => {
+  const traces: string[] = [];
+  const context = createHostedDurableChildForkRunContext({
+    authToken: "token",
+    apiUrl: "https://api.example.com",
+    durableChildRun: {
+      childConversationId: "child-conversation-1",
+      childRunId: "child-run-1",
+      childMessageId: "child-message-1",
+      latestEventId: 5,
+      latestExternalEventSequence: 7,
+    },
+    instrumentation: {
+      trace: (operationName, operation) => {
+        traces.push(operationName);
+        return operation();
+      },
+    },
+    pendingToolLogContext: {
+      conversationId: "conversation-1",
+      parentRunId: "run-1",
+      description: "Check the app",
+    },
+  });
+
+  assertEquals(context.durableRunMirror?.getSnapshot(), {
+    latestEventId: 5,
+    latestExternalEventSequence: 7,
+    consecutiveFailures: 0,
+    disabled: false,
+    pendingEventCount: 0,
+    inFlight: false,
+    hasFlushTimer: false,
+    hasRetryTimer: false,
+  });
+  assertEquals(context.streamMirrorContext.durableRunMirror, true);
+  assertEquals(context.streamMirrorContext.durableMessageId, "child-message-1");
+  assertEquals(
+    context.streamMirrorContext.durableReasoningMessageId,
+    "child-message-1:reasoning",
+  );
+  assertEquals(traces, []);
 });
 
 Deno.test("createHostedChildForkRunContext closes pending tool calls with host logger", async () => {

--- a/src/agent/hosted-child-fork-run-context.ts
+++ b/src/agent/hosted-child-fork-run-context.ts
@@ -5,6 +5,11 @@ import {
   type HostedChildMirrorContext,
 } from "./hosted-child-mirror.ts";
 import {
+  type ConversationRunChunkMirror,
+  createHostedConversationRunChunkMirror,
+  type HostedConversationRunChunkMirrorInstrumentation,
+} from "./conversation-run-chunk-mirror.ts";
+import {
   createHostedChildPendingToolLifecycle,
   createHostedChildPendingToolLifecycleLogger,
   type HostedChildPendingToolLifecycleLogContext,
@@ -26,7 +31,10 @@ import type {
   ChildRunExecutionSnapshot,
 } from "./child-run-execution-snapshot.ts";
 import { isChildRunAbortError } from "./child-run-execution-support.ts";
-import { HostedChildTerminalStateError } from "./hosted-child-status.ts";
+import {
+  type HostedChildRunIdentifiers,
+  HostedChildTerminalStateError,
+} from "./hosted-child-status.ts";
 
 export interface HostedChildForkToolCallSnapshot {
   toolName: string;
@@ -67,10 +75,23 @@ export interface HostedChildForkRunContext {
   streamState: HostedChildForkStreamState;
 }
 
+export type HostedDurableChildForkRunContext = HostedChildForkRunContext & {
+  durableRunMirror: ConversationRunChunkMirror | null;
+};
+
 export interface HostedChildForkRunContextInput {
   mirror: HostedChildChunkMirror | null;
   messageId?: string | null;
   reasoningMessageId?: string | null;
+  pendingToolLogContext: HostedChildPendingToolLifecycleLogContext;
+  pendingToolLogWriter?: HostedChildPendingToolLifecycleLogWriter;
+}
+
+export interface HostedDurableChildForkRunContextInput {
+  authToken: string;
+  apiUrl: string;
+  durableChildRun?: HostedChildRunIdentifiers;
+  instrumentation?: HostedConversationRunChunkMirrorInstrumentation;
   pendingToolLogContext: HostedChildPendingToolLifecycleLogContext;
   pendingToolLogWriter?: HostedChildPendingToolLifecycleLogWriter;
 }
@@ -133,6 +154,32 @@ export function createHostedChildForkRunContext(
     toolCalls: [],
     toolResults: [],
     streamState: { finalText: "" },
+  };
+}
+
+export function createHostedDurableChildForkRunContext(
+  input: HostedDurableChildForkRunContextInput,
+): HostedDurableChildForkRunContext {
+  const durableRunMirror = input.durableChildRun
+    ? createHostedConversationRunChunkMirror({
+      authToken: input.authToken,
+      apiUrl: input.apiUrl,
+      conversationId: input.durableChildRun.childConversationId,
+      runId: input.durableChildRun.childRunId,
+      latestEventId: input.durableChildRun.latestEventId,
+      latestExternalEventSequence: input.durableChildRun.latestExternalEventSequence,
+      instrumentation: input.instrumentation,
+    })
+    : null;
+
+  return {
+    durableRunMirror,
+    ...createHostedChildForkRunContext({
+      mirror: durableRunMirror,
+      messageId: input.durableChildRun?.childMessageId ?? null,
+      pendingToolLogContext: input.pendingToolLogContext,
+      pendingToolLogWriter: input.pendingToolLogWriter,
+    }),
   };
 }
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -474,6 +474,7 @@ export {
 } from "./hosted-child-fork-instructions.ts";
 export {
   createHostedChildForkRunContext,
+  createHostedDurableChildForkRunContext,
   executeHostedChildForkRunContextStream,
   type ExecuteHostedChildForkRunContextStreamInput,
   finalizeHostedChildForkRunContextResources,
@@ -486,6 +487,8 @@ export {
   type HostedChildForkStreamState,
   type HostedChildForkToolCallSnapshot,
   type HostedChildForkToolResultSnapshot,
+  type HostedDurableChildForkRunContext,
+  type HostedDurableChildForkRunContextInput,
 } from "./hosted-child-fork-run-context.ts";
 export {
   executeHostedChildForkStream,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.441";
+export const VERSION = "0.1.442";


### PR DESCRIPTION
## Summary\n- add a reusable hosted durable child fork run-context helper\n- wire durable child run identifiers into the hosted conversation mirror in the framework\n- bump package version to 0.1.442\n\n## Verification\n- deno test --no-check --allow-all src/agent/hosted-child-fork-run-context.test.ts\n- deno check src/agent/hosted-child-fork-run-context.ts src/agent/hosted-child-fork-run-context.test.ts src/agent/index.ts\n- deno lint src/agent/hosted-child-fork-run-context.ts src/agent/hosted-child-fork-run-context.test.ts src/agent/index.ts\n- deno fmt --check src/agent/hosted-child-fork-run-context.ts src/agent/hosted-child-fork-run-context.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts\n- deno test --no-check --allow-all src/agent/hosted-child-fork-run-context.test.ts src/agent/conversation-run-chunk-mirror.test.ts src/agent/hosted-child-fork-stream-execution.test.ts\n- pre-push hook: format, lint, typecheck, unit tests (1728 passed)