### PR TITLE
Add reusable runtime load skill tool

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.443",
+  "version": "0.1.444",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -837,6 +837,19 @@ export {
   type RuntimeSkillMetadataLogger,
 } from "./runtime-skill-metadata.ts";
 export {
+  createRuntimeLoadSkillTool,
+  RUNTIME_LOAD_SKILL_CONTINUATION_NOTE,
+  RUNTIME_LOAD_SKILL_DESCRIPTION,
+  type RuntimeLoadSkillBuiltinStore,
+  type RuntimeLoadSkillErrorOutput,
+  type RuntimeLoadSkillReferenceFileOutput,
+  type RuntimeLoadSkillToolContext,
+  type RuntimeLoadSkillToolInput,
+  type RuntimeLoadSkillToolMessages,
+  type RuntimeLoadSkillToolOptions,
+  type RuntimeLoadSkillToolOutput,
+} from "./runtime-load-skill-tool.ts";
+export {
   buildHostedChildCompletedLog,
   buildHostedChildErrorLog,
   buildHostedChildExhaustedStepBudgetLog,

--- a/src/agent/runtime-load-skill-tool.test.ts
+++ b/src/agent/runtime-load-skill-tool.test.ts
@@ -1,0 +1,193 @@
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import {
+  createRuntimeLoadSkillTool,
+  RUNTIME_LOAD_SKILL_CONTINUATION_NOTE,
+  type RuntimeLoadSkillBuiltinStore,
+} from "./runtime-load-skill-tool.ts";
+import type {
+  RuntimeLoadedProjectSkill,
+  RuntimeProjectSkillContext,
+  RuntimeProjectSkillLoader,
+} from "./runtime-project-skill-loader.ts";
+import type { RuntimeLoadedSkillResponse } from "./runtime-skill-metadata.ts";
+
+const PROJECT_CONTEXT: RuntimeProjectSkillContext = {
+  projectId: "project-1",
+  authToken: "auth-token",
+  branchId: "branch-1",
+};
+
+type ProjectSkillMap = Map<string, RuntimeLoadedProjectSkill>;
+type ProjectReferenceMap = Map<string, string>;
+
+function createProjectSkillLoader(input: {
+  skills?: ProjectSkillMap;
+  references?: ProjectReferenceMap;
+}): RuntimeProjectSkillLoader {
+  return {
+    listProjectSkillReferences: (_context, skillId) =>
+      Promise.resolve(input.skills?.get(skillId)?.references ?? []),
+    loadProjectSkill: (_context, skillId) => Promise.resolve(input.skills?.get(skillId) ?? null),
+    loadProjectSkillReference: (_context, skillId, normalizedFile) =>
+      Promise.resolve(input.references?.get(`${skillId}/${normalizedFile}`) ?? null),
+  };
+}
+
+function isRuntimeLoadedSkillResponse(result: unknown): result is RuntimeLoadedSkillResponse {
+  return !!result && typeof result === "object" && "skillId" in result &&
+    typeof result.skillId === "string" && "instructions" in result &&
+    typeof result.instructions === "string" && "nextStep" in result &&
+    typeof result.nextStep === "string";
+}
+
+function expectLoadedSkillResponse(result: unknown): RuntimeLoadedSkillResponse {
+  if (isRuntimeLoadedSkillResponse(result)) {
+    return result;
+  }
+
+  throw new Error("Expected loaded skill response");
+}
+
+function createBuiltinStore(input: {
+  skills?: Map<string, string>;
+  references?: Map<string, string>;
+  referenceLists?: Map<string, string[]>;
+}): RuntimeLoadSkillBuiltinStore {
+  return {
+    readSkill: (_skillsDir, skillId) => input.skills?.get(skillId) ?? null,
+    readReferenceFile: (_skillsDir, skillId, normalizedFile) =>
+      input.references?.get(`${skillId}/${normalizedFile}`) ?? null,
+    listReferences: (_skillsDir, skillId) => input.referenceLists?.get(skillId) ?? [],
+  };
+}
+
+Deno.test("createRuntimeLoadSkillTool loads project skills before builtin skills", async () => {
+  const tool = createRuntimeLoadSkillTool({
+    context: PROJECT_CONTEXT,
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({
+      skills: new Map([
+        ["plan", { instructions: "# Project plan", references: ["references/project.md"] }],
+      ]),
+    }),
+    builtinStore: createBuiltinStore({
+      skills: new Map([["plan", "# Builtin plan"]]),
+      referenceLists: new Map([["plan", ["references/builtin.md"]]]),
+    }),
+  });
+
+  const result = await tool.execute({ skillId: "plan" });
+
+  assertEquals(result, {
+    skillId: "plan",
+    instructions: "# Project plan",
+    nextStep: RUNTIME_LOAD_SKILL_CONTINUATION_NOTE,
+    references: ["references/project.md"],
+    referenceNote: "Use load_skill with the `file` parameter to load any of these reference files.",
+  });
+});
+
+Deno.test("createRuntimeLoadSkillTool falls back to builtin skills and filters allowed tools", async () => {
+  const tool = createRuntimeLoadSkillTool({
+    context: {
+      ...PROJECT_CONTEXT,
+      availableToolNames: ["read_file", "invoke_agent"],
+    },
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({}),
+    builtinStore: createBuiltinStore({
+      skills: new Map([
+        [
+          "write",
+          `---
+allowed-tools:
+  - read_file
+  - write_file
+model: sonnet
+max-steps: 8
+---
+Write carefully.`,
+        ],
+      ]),
+    }),
+  });
+
+  const result = expectLoadedSkillResponse(await tool.execute({ skillId: "write" }));
+
+  assertEquals(result.skillId, "write");
+  assertEquals(result.allowedTools, ["read_file"]);
+  assertEquals(result.delegationTools, ["read_file", "write_file"]);
+  assertEquals(result.unavailableCurrentRunTools, ["write_file"]);
+  assertEquals(result.model, "sonnet");
+  assertEquals(result.maxSteps, 8);
+});
+
+Deno.test("createRuntimeLoadSkillTool loads project and builtin reference files", async () => {
+  const tool = createRuntimeLoadSkillTool({
+    context: PROJECT_CONTEXT,
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({
+      references: new Map([["plan/references/project.md", "project reference"]]),
+    }),
+    builtinStore: createBuiltinStore({
+      references: new Map([["plan/references/builtin.md", "builtin reference"]]),
+    }),
+  });
+
+  assertEquals(await tool.execute({ skillId: "plan", file: "references/project.md" }), {
+    skillId: "plan",
+    file: "references/project.md",
+    content: "project reference",
+  });
+  assertEquals(await tool.execute({ skillId: "plan", file: "references/builtin.md" }), {
+    skillId: "plan",
+    file: "references/builtin.md",
+    content: "builtin reference",
+  });
+});
+
+Deno.test("createRuntimeLoadSkillTool rejects unsafe inputs and reports known skills", async () => {
+  const tool = createRuntimeLoadSkillTool({
+    context: {
+      ...PROJECT_CONTEXT,
+      availableSkillIds: ["project-only", "plan"],
+    },
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({}),
+    builtinSkillIds: ["build", "plan"],
+    builtinStore: createBuiltinStore({}),
+  });
+
+  assertEquals(await tool.execute({ skillId: "plan", file: "../secret.md" }), {
+    error: "Invalid reference file path: ../secret.md",
+  });
+  assertEquals(await tool.execute({ skillId: "missing" }), {
+    error: "Skill not found: missing. Available skills: build, plan, project-only",
+  });
+  await assertRejects(
+    () => tool.execute({ skillId: "bad/path" }),
+    Error,
+    "input validation failed",
+  );
+});
+
+Deno.test("createRuntimeLoadSkillTool allows host copy overrides", async () => {
+  const tool = createRuntimeLoadSkillTool({
+    context: PROJECT_CONTEXT,
+    skillsDir: "/skills",
+    projectSkillLoader: createProjectSkillLoader({}),
+    builtinStore: createBuiltinStore({
+      skills: new Map([["plan", "# Plan"]]),
+    }),
+    description: "Custom load skill description.",
+    nextStep: "Custom next step.",
+    messages: {
+      referenceNote: "Custom reference note.",
+    },
+  });
+
+  assertEquals(tool.description, "Custom load skill description.");
+  const result = expectLoadedSkillResponse(await tool.execute({ skillId: "plan" }));
+  assertEquals(result.nextStep, "Custom next step.");
+  assertStringIncludes(JSON.stringify(result), "Custom next step.");
+});

--- a/src/agent/runtime-load-skill-tool.ts
+++ b/src/agent/runtime-load-skill-tool.ts
@@ -1,0 +1,232 @@
+import { z } from "zod";
+import { tool } from "#veryfront/tool";
+import type { Tool } from "#veryfront/tool/types.ts";
+import {
+  LOAD_SKILL_CONTINUE_SAME_TURN,
+  LOAD_SKILL_DELEGATION_THRESHOLD,
+  LOAD_SKILL_OVERRIDE_FORWARDING,
+  LOAD_SKILL_ROOT_OWNERSHIP,
+  LOAD_SKILL_TOOL_INTERSECTION,
+  LOAD_SKILL_USE_ALLOWED_TOOLS,
+} from "./conversation-delegation-policy.ts";
+import {
+  listRuntimeBuiltinSkillReferences,
+  readRuntimeBuiltinSkill,
+  readRuntimeBuiltinSkillReferenceFile,
+} from "./runtime-builtin-skill-files.ts";
+import type {
+  RuntimeLoadedProjectSkill,
+  RuntimeProjectSkillContext,
+  RuntimeProjectSkillLoader,
+} from "./runtime-project-skill-loader.ts";
+import {
+  buildRuntimeLoadedSkillResponse,
+  normalizeRuntimeSkillReferencePath,
+  type RuntimeLoadedSkillResponse,
+  type RuntimeLoadedSkillResponseMessages,
+  type RuntimeSkillMetadataLogger,
+} from "./runtime-skill-metadata.ts";
+
+export const RUNTIME_LOAD_SKILL_CONTINUATION_NOTE =
+  `IMPORTANT: load_skill only loads instructions. It does not perform the task or finish the turn. ${LOAD_SKILL_CONTINUE_SAME_TURN} ${LOAD_SKILL_ROOT_OWNERSHIP} ${LOAD_SKILL_USE_ALLOWED_TOOLS} ${LOAD_SKILL_DELEGATION_THRESHOLD} ${LOAD_SKILL_OVERRIDE_FORWARDING} ${LOAD_SKILL_TOOL_INTERSECTION}`;
+
+export const RUNTIME_LOAD_SKILL_DESCRIPTION =
+  `Load the full instructions for a skill. Use this when you need detailed guidance for a specific task type. If the skill specifies allowed-tools, you MUST only use those tools while following this skill. load_skill does not perform the task by itself. ${LOAD_SKILL_CONTINUE_SAME_TURN} ${LOAD_SKILL_ROOT_OWNERSHIP} ${LOAD_SKILL_USE_ALLOWED_TOOLS} ${LOAD_SKILL_DELEGATION_THRESHOLD} Use the optional \`file\` parameter to load a specific reference file from the skill.`;
+
+const DEFAULT_RUNTIME_LOAD_SKILL_RESPONSE_MESSAGES: RuntimeLoadedSkillResponseMessages = {
+  allowedToolsNote:
+    "IMPORTANT: While following this skill, you MUST only use the tools listed in allowedTools.",
+  noCurrentRunToolsNote:
+    "IMPORTANT: While following this skill, no direct-execution tools from this skill are available in the current run. allowedTools is intentionally empty; do not attempt direct tool execution in this run.",
+  unavailableCurrentRunToolsDelegationNote:
+    "IMPORTANT: Some tools required by this skill are not available in the current run. Use invoke_agent for the isolated work and pass delegationTools as the child tools allowlist.",
+  overrideNote: LOAD_SKILL_OVERRIDE_FORWARDING,
+  referenceNote: "Use load_skill with the `file` parameter to load any of these reference files.",
+};
+
+export type RuntimeLoadSkillToolContext = RuntimeProjectSkillContext & {
+  availableSkillIds?: readonly string[];
+  availableToolNames?: readonly string[];
+};
+
+export type RuntimeLoadSkillBuiltinStore = {
+  readSkill: (skillsDir: string, skillId: string) => string | null;
+  readReferenceFile: (skillsDir: string, skillId: string, normalizedFile: string) => string | null;
+  listReferences: (skillsDir: string, skillId: string) => string[];
+};
+
+export type RuntimeLoadSkillToolMessages = Partial<RuntimeLoadedSkillResponseMessages>;
+
+export type RuntimeLoadSkillToolOptions = {
+  context: RuntimeLoadSkillToolContext;
+  skillsDir: string;
+  projectSkillLoader: RuntimeProjectSkillLoader;
+  builtinSkillIds?: readonly string[];
+  builtinStore?: RuntimeLoadSkillBuiltinStore;
+  description?: string;
+  nextStep?: string;
+  messages?: RuntimeLoadSkillToolMessages;
+  logger?: RuntimeSkillMetadataLogger;
+};
+
+const runtimeLoadSkillToolInputSchema = z.object({
+  skillId: z
+    .string()
+    .regex(/^[a-zA-Z0-9_-]+$/, 'skillId must contain only letters, numbers, "_" or "-"')
+    .describe('The skill ID to load (e.g., "react-components", "api-design")'),
+  file: z.string().optional().describe(
+    'Optional reference file to load (e.g. "references/quickstart.md")',
+  ),
+});
+
+export type RuntimeLoadSkillToolInput = z.infer<typeof runtimeLoadSkillToolInputSchema>;
+
+export type RuntimeLoadSkillReferenceFileOutput = {
+  skillId: string;
+  file: string;
+  content: string;
+};
+
+export type RuntimeLoadSkillErrorOutput = {
+  error: string;
+};
+
+export type RuntimeLoadSkillToolOutput =
+  | RuntimeLoadedSkillResponse
+  | RuntimeLoadSkillReferenceFileOutput
+  | RuntimeLoadSkillErrorOutput;
+
+function getBuiltinStore(options: RuntimeLoadSkillToolOptions): RuntimeLoadSkillBuiltinStore {
+  return {
+    readSkill: options.builtinStore?.readSkill ?? readRuntimeBuiltinSkill,
+    readReferenceFile: options.builtinStore?.readReferenceFile ??
+      readRuntimeBuiltinSkillReferenceFile,
+    listReferences: options.builtinStore?.listReferences ?? listRuntimeBuiltinSkillReferences,
+  };
+}
+
+function getResponseMessages(
+  options: RuntimeLoadSkillToolOptions,
+): RuntimeLoadedSkillResponseMessages {
+  return {
+    allowedToolsNote: options.messages?.allowedToolsNote ??
+      DEFAULT_RUNTIME_LOAD_SKILL_RESPONSE_MESSAGES.allowedToolsNote,
+    noCurrentRunToolsNote: options.messages?.noCurrentRunToolsNote ??
+      DEFAULT_RUNTIME_LOAD_SKILL_RESPONSE_MESSAGES.noCurrentRunToolsNote,
+    unavailableCurrentRunToolsDelegationNote:
+      options.messages?.unavailableCurrentRunToolsDelegationNote ??
+        DEFAULT_RUNTIME_LOAD_SKILL_RESPONSE_MESSAGES.unavailableCurrentRunToolsDelegationNote,
+    overrideNote: options.messages?.overrideNote ??
+      DEFAULT_RUNTIME_LOAD_SKILL_RESPONSE_MESSAGES.overrideNote,
+    referenceNote: options.messages?.referenceNote ??
+      DEFAULT_RUNTIME_LOAD_SKILL_RESPONSE_MESSAGES.referenceNote,
+  };
+}
+
+function buildLoadedSkillResponse(input: {
+  options: RuntimeLoadSkillToolOptions;
+  skillId: string;
+  instructions: string;
+  references?: readonly string[];
+}): RuntimeLoadedSkillResponse {
+  return buildRuntimeLoadedSkillResponse({
+    skillId: input.skillId,
+    instructions: input.instructions,
+    nextStep: input.options.nextStep ?? RUNTIME_LOAD_SKILL_CONTINUATION_NOTE,
+    messages: getResponseMessages(input.options),
+    references: input.references,
+    availableToolNames: input.options.context.availableToolNames,
+    logger: input.options.logger,
+  });
+}
+
+function buildMissingSkillError(
+  options: RuntimeLoadSkillToolOptions,
+  skillId: string,
+): RuntimeLoadSkillErrorOutput {
+  const knownIds = new Set([
+    ...(options.context.availableSkillIds ?? []),
+    ...(options.builtinSkillIds ?? []),
+  ]);
+  const available = [...knownIds].sort().join(", ");
+  return {
+    error: `Skill not found: ${skillId}. Available skills: ${available}`,
+  };
+}
+
+async function loadRuntimeSkillReferenceFile(
+  options: RuntimeLoadSkillToolOptions,
+  skillId: string,
+  file: string,
+): Promise<RuntimeLoadSkillReferenceFileOutput | RuntimeLoadSkillErrorOutput> {
+  const normalizedFile = normalizeRuntimeSkillReferencePath(file);
+  if (!normalizedFile) {
+    return { error: `Invalid reference file path: ${file}` };
+  }
+
+  const projectFileContent = await options.projectSkillLoader.loadProjectSkillReference(
+    options.context,
+    skillId,
+    normalizedFile,
+  );
+  if (projectFileContent) {
+    return { skillId, file: normalizedFile, content: projectFileContent };
+  }
+
+  const localContent = getBuiltinStore(options).readReferenceFile(
+    options.skillsDir,
+    skillId,
+    normalizedFile,
+  );
+  if (localContent) {
+    return { skillId, file: normalizedFile, content: localContent };
+  }
+
+  return { error: `Reference file not found: ${skillId}/${normalizedFile}` };
+}
+
+async function loadRuntimeSkillBody(
+  options: RuntimeLoadSkillToolOptions,
+  skillId: string,
+): Promise<RuntimeLoadedProjectSkill | null> {
+  return await options.projectSkillLoader.loadProjectSkill(options.context, skillId);
+}
+
+export function createRuntimeLoadSkillTool(
+  options: RuntimeLoadSkillToolOptions,
+): Tool<RuntimeLoadSkillToolInput, RuntimeLoadSkillToolOutput> {
+  const builtinStore = getBuiltinStore(options);
+
+  return tool({
+    id: "load_skill",
+    description: options.description ?? RUNTIME_LOAD_SKILL_DESCRIPTION,
+    inputSchema: runtimeLoadSkillToolInputSchema,
+    execute: async ({ skillId, file }) => {
+      if (file) {
+        return await loadRuntimeSkillReferenceFile(options, skillId, file);
+      }
+
+      const projectSkill = await loadRuntimeSkillBody(options, skillId);
+      if (projectSkill) {
+        return buildLoadedSkillResponse({
+          options,
+          skillId,
+          instructions: projectSkill.instructions,
+          references: projectSkill.references,
+        });
+      }
+
+      const localContent = builtinStore.readSkill(options.skillsDir, skillId);
+      if (localContent) {
+        return buildLoadedSkillResponse({
+          options,
+          skillId,
+          instructions: localContent,
+          references: builtinStore.listReferences(options.skillsDir, skillId),
+        });
+      }
+
+      return buildMissingSkillError(options, skillId);
+    },
+  });
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.443";
+export const VERSION = "0.1.444";


### PR DESCRIPTION
## Summary
- add a framework-hosted load_skill tool constructor for runtime skills
- keep project skill loading and builtin skill storage injectable for host services
- bump package version to 0.1.444 for publication

## Verification
- deno test --no-check --allow-all src/agent/runtime-load-skill-tool.test.ts
- deno check src/agent/runtime-load-skill-tool.ts src/agent/runtime-load-skill-tool.test.ts src/agent/index.ts
- deno lint src/agent/runtime-load-skill-tool.ts src/agent/runtime-load-skill-tool.test.ts src/agent/index.ts
- pre-push: format, lint, typecheck, unit tests (1736 passed)