### PR TITLE
Add hosted child fork tool source assembly

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.444",
+  "version": "0.1.445",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-fork-tool-sources.test.ts
+++ b/src/agent/hosted-child-fork-tool-sources.test.ts
@@ -1,0 +1,153 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import type {
+  RemoteMCPToolSourceConfig,
+  RemoteToolSource,
+  ToolDefinition,
+  ToolExecutionContext,
+} from "#veryfront/tool";
+import { prepareDefaultHostedChildForkToolSources } from "./hosted-child-fork-tool-sources.ts";
+import type { RuntimeClientProfile } from "./runtime-client-profile.ts";
+
+const trustedStudioProfile: RuntimeClientProfile = {
+  id: "veryfront-studio",
+  type: "web",
+  trusted: true,
+  capabilities: ["ui_panels"],
+};
+
+function remoteTool(name: string): ToolDefinition {
+  return {
+    name,
+    description: `${name} description`,
+    parameters: { type: "object", properties: {} },
+  };
+}
+
+function createRemoteSourceFixtures() {
+  const createdConfigs: RemoteMCPToolSourceConfig[] = [];
+  const executeCalls: Array<{
+    sourceId: string;
+    toolName: string;
+    args: Record<string, unknown>;
+    context?: ToolExecutionContext;
+  }> = [];
+
+  const createRemoteToolSource = (config: RemoteMCPToolSourceConfig): RemoteToolSource => {
+    createdConfigs.push(config);
+    const sourceId = config.id ?? "source";
+
+    return {
+      id: sourceId,
+      listTools: () =>
+        Promise.resolve(
+          sourceId === "studio-mcp-live-tools"
+            ? [remoteTool("studio_open_project")]
+            : [remoteTool("update_file"), remoteTool("studio_panel_control")],
+        ),
+      executeTool: (toolName, args, context) => {
+        executeCalls.push({ sourceId, toolName, args, context });
+        return Promise.resolve({ success: true, project_id: args.project_id });
+      },
+    };
+  };
+
+  return { createdConfigs, executeCalls, createRemoteToolSource };
+}
+
+Deno.test("prepareDefaultHostedChildForkToolSources loads API, live Studio, and global tools", async () => {
+  const fixtures = createRemoteSourceFixtures();
+  const switchedProjects: string[] = [];
+
+  const result = await prepareDefaultHostedChildForkToolSources({
+    authToken: "token-1",
+    apiMcpUrl: "https://api.example/mcp",
+    studioMcpUrl: "https://studio.example/mcp",
+    clientProfile: trustedStudioProfile,
+    getProjectId: () => "project-1",
+    conversationId: "conversation-1",
+    globalTools: {
+      sleep: {
+        description: "sleep",
+        execute: () => ({ ok: true }),
+      },
+    },
+    onConfirmedStudioProjectSwitch: (projectId) => {
+      switchedProjects.push(projectId);
+    },
+    createRemoteToolSource: fixtures.createRemoteToolSource,
+  });
+
+  assertEquals(result.ok, true);
+  if (!result.ok) {
+    return;
+  }
+
+  assertEquals(Object.keys(result.forkTools), ["sleep", "studio_open_project", "update_file"]);
+  assertEquals(
+    fixtures.createdConfigs.map((config) => [config.id, config.endpoint]),
+    [
+      ["studio-mcp-live-tools", "https://studio.example/mcp"],
+      ["veryfront-mcp-fork", "https://api.example/mcp"],
+    ],
+  );
+
+  await result.forkTools.studio_open_project?.execute?.({ project_id: "project-2" });
+
+  assertEquals(switchedProjects, ["project-2"]);
+  assertEquals(fixtures.executeCalls, [
+    {
+      sourceId: "studio-mcp-live-tools",
+      toolName: "studio_open_project",
+      args: { project_id: "project-2" },
+      context: undefined,
+    },
+  ]);
+
+  await result.closeStudioMcpTools?.();
+});
+
+Deno.test("prepareDefaultHostedChildForkToolSources reports Studio setup failures", async () => {
+  const logged: Array<{ message: string; metadata?: Record<string, unknown> }> = [];
+
+  const result = await prepareDefaultHostedChildForkToolSources({
+    authToken: "token-1",
+    apiMcpUrl: "https://api.example/mcp",
+    getProjectId: () => "project-1",
+    createLiveStudioTools: () => {
+      throw new Error("studio unavailable");
+    },
+    logger: {
+      error: (message, metadata) => {
+        logged.push({ message, metadata });
+      },
+    },
+  });
+
+  assertEquals(result, {
+    ok: false,
+    errorMessage: "MCP tool setup failed: studio unavailable",
+  });
+  assertEquals(logged.length, 1);
+});
+
+Deno.test("prepareDefaultHostedChildForkToolSources rethrows abort errors", async () => {
+  const abortController = new AbortController();
+  abortController.abort(new Error("fork aborted"));
+
+  await assertRejects(
+    () =>
+      prepareDefaultHostedChildForkToolSources({
+        authToken: "token-1",
+        apiMcpUrl: "https://api.example/mcp",
+        getProjectId: () => "project-1",
+        abortSignal: abortController.signal,
+        createLiveStudioTools: () =>
+          Promise.resolve({
+            tools: {},
+            close: () => Promise.resolve(),
+          }),
+      }),
+    Error,
+    "fork aborted",
+  );
+});

--- a/src/agent/hosted-child-fork-tool-sources.ts
+++ b/src/agent/hosted-child-fork-tool-sources.ts
@@ -1,0 +1,137 @@
+import {
+  createRemoteMCPToolSource,
+  createToolsFromRemoteDefinitions,
+  type HostToolSet,
+  type RemoteMCPToolSourceConfig,
+  type RemoteToolSource,
+} from "#veryfront/tool";
+import {
+  createLiveStudioMcpTools,
+  type LiveStudioMcpToolsOptions,
+} from "./live-studio-mcp-tools.ts";
+import type { RuntimeClientProfile } from "./runtime-client-profile.ts";
+import {
+  type HostedChildProjectSwitchHandler,
+  wrapHostedChildProjectSwitchTool,
+} from "./hosted-child-steering-tools.ts";
+import { buildDefaultHostedChildForkToolSet } from "./hosted-child-requested-tools.ts";
+
+export type HostedChildForkToolSourcesLogger = {
+  error: (message: string, metadata?: Record<string, unknown>) => void;
+};
+
+export type PrepareDefaultHostedChildForkToolSourcesInput = {
+  authToken: string;
+  apiMcpUrl: string;
+  getProjectId: () => string | null | undefined;
+  studioMcpUrl?: string | null;
+  clientProfile?: RuntimeClientProfile | null;
+  conversationId?: string;
+  globalTools?: HostToolSet;
+  abortSignal?: AbortSignal;
+  apiSourceId?: string;
+  onConfirmedStudioProjectSwitch?: HostedChildProjectSwitchHandler;
+  createRemoteToolSource?: (config: RemoteMCPToolSourceConfig) => RemoteToolSource;
+  createToolsFromRemoteDefinitions?: typeof createToolsFromRemoteDefinitions;
+  createLiveStudioTools?: (input: LiveStudioMcpToolsOptions) => Promise<{
+    tools: HostToolSet;
+    close: () => Promise<void>;
+  }>;
+  isAbortError?: (error: unknown) => boolean;
+  logger?: HostedChildForkToolSourcesLogger;
+};
+
+export type DefaultHostedChildForkToolSourcesResult =
+  | {
+    ok: true;
+    forkTools: HostToolSet;
+    closeStudioMcpTools?: () => Promise<void>;
+  }
+  | {
+    ok: false;
+    errorMessage: string;
+  };
+
+export async function prepareDefaultHostedChildForkToolSources(
+  input: PrepareDefaultHostedChildForkToolSourcesInput,
+): Promise<DefaultHostedChildForkToolSourcesResult> {
+  let closeStudioMcpTools: (() => Promise<void>) | undefined;
+  let studioMcpTools: HostToolSet = {};
+  const createLiveStudioTools = input.createLiveStudioTools ?? createLiveStudioMcpTools;
+
+  try {
+    const studioTools = await createLiveStudioTools({
+      authToken: input.authToken,
+      clientProfile: input.clientProfile,
+      getProjectId: input.getProjectId,
+      studioMcpUrl: input.studioMcpUrl,
+      ...(input.conversationId ? { conversationId: input.conversationId } : {}),
+      ...(input.createRemoteToolSource
+        ? { createRemoteToolSource: input.createRemoteToolSource }
+        : {}),
+    });
+    studioMcpTools = studioTools.tools;
+    closeStudioMcpTools = studioTools.close;
+  } catch (error) {
+    if (input.abortSignal?.aborted || input.isAbortError?.(error)) {
+      throw error;
+    }
+
+    input.logger?.error("Failed to initialize MCP tool sources for child fork", {
+      mcpError: error,
+    });
+    return {
+      ok: false,
+      errorMessage: `MCP tool setup failed: ${
+        error instanceof Error ? error.message : "Unknown error"
+      }`,
+    };
+  }
+
+  throwIfAborted(input.abortSignal);
+
+  const createRemoteToolSource = input.createRemoteToolSource ?? createRemoteMCPToolSource;
+  const materializeRemoteTools = input.createToolsFromRemoteDefinitions ??
+    createToolsFromRemoteDefinitions;
+  const apiMcpSource = createRemoteToolSource({
+    id: input.apiSourceId ?? "veryfront-mcp-fork",
+    endpoint: input.apiMcpUrl,
+    headers: {
+      Authorization: `Bearer ${input.authToken}`,
+    },
+  });
+  const apiMcpDefinitions = await apiMcpSource.listTools();
+  const apiMcpTools = materializeRemoteTools(apiMcpSource, apiMcpDefinitions);
+
+  if (input.onConfirmedStudioProjectSwitch) {
+    wrapHostedChildProjectSwitchTool({
+      tools: studioMcpTools,
+      onConfirmedProjectSwitch: input.onConfirmedStudioProjectSwitch,
+    });
+  }
+
+  throwIfAborted(input.abortSignal);
+
+  return {
+    ok: true,
+    forkTools: buildDefaultHostedChildForkToolSet(
+      apiMcpTools,
+      studioMcpTools,
+      input.globalTools ?? {},
+    ),
+    closeStudioMcpTools,
+  };
+}
+
+function throwIfAborted(abortSignal: AbortSignal | undefined): void {
+  if (!abortSignal?.aborted) {
+    return;
+  }
+
+  const reason = abortSignal.reason;
+  if (reason instanceof Error) {
+    throw reason;
+  }
+
+  throw new Error("Child fork aborted");
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -154,6 +154,12 @@ export {
   createLiveStudioMcpTools,
   type LiveStudioMcpToolsOptions,
 } from "./live-studio-mcp-tools.ts";
+export {
+  type DefaultHostedChildForkToolSourcesResult,
+  type HostedChildForkToolSourcesLogger,
+  prepareDefaultHostedChildForkToolSources,
+  type PrepareDefaultHostedChildForkToolSourcesInput,
+} from "./hosted-child-fork-tool-sources.ts";
 
 export {
   parseRuntimeAgentMarkdownDefinition,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.444";
+export const VERSION = "0.1.445";


### PR DESCRIPTION
## Summary\n- add a reusable hosted child fork tool-source assembly helper\n- wire API MCP, live Studio MCP, project-switch callbacks, global tools, and default child fork filtering behind one framework entrypoint\n- bump package version to 0.1.445 for CI/CD publication\n\n## Verification\n- deno test --no-check --allow-all src/agent/hosted-child-fork-tool-sources.test.ts\n- deno check src/agent/hosted-child-fork-tool-sources.ts src/agent/hosted-child-fork-tool-sources.test.ts src/agent/index.ts\n- deno lint src/agent/hosted-child-fork-tool-sources.ts src/agent/hosted-child-fork-tool-sources.test.ts src/agent/index.ts\n- deno fmt --check src/agent/hosted-child-fork-tool-sources.ts src/agent/hosted-child-fork-tool-sources.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts\n- deno check src/index.ts\n- deno task verify:quick