### PR TITLE
Add default research artifact mirror handler

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.446",
+  "version": "0.1.447",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/default-research-artifact-support.test.ts
+++ b/src/agent/default-research-artifact-support.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  createDefaultResearchRunArtifactMirrorHandler,
   type DefaultResearchArtifactContext,
   extractLatestUserText,
   mirrorDefaultResearchRunArtifact,
@@ -291,5 +292,79 @@ describe("default research artifact support", () => {
         context: { projectId: "project-1" },
       },
     ]);
+  });
+
+  it("creates a mirror handler from the API remote tool source", async () => {
+    const calls: Array<
+      {
+        toolName: string;
+        args: Record<string, unknown>;
+        context: Record<string, unknown> | undefined;
+      }
+    > = [];
+    const handler = createDefaultResearchRunArtifactMirrorHandler({
+      taskContext: {
+        projectId: "fallback-project",
+        defaultResearchArtifacts: defaultArtifacts(),
+      },
+      remoteToolSource: {
+        executeTool: (toolName, args, context) => {
+          calls.push({ toolName, args, context });
+          return Promise.resolve({
+            path: "research/ai-coding-agents/runs/run-1.report.md",
+          });
+        },
+      },
+    });
+
+    await handler({
+      toolName: "create_file",
+      input: {
+        path: "research/ai-coding-agents/report.md",
+        content: "# report",
+      },
+      result: {
+        path: "research/ai-coding-agents/report.md",
+      },
+      context: {},
+    });
+
+    assertEquals(calls, [
+      {
+        toolName: "create_file",
+        args: {
+          path: "research/ai-coding-agents/runs/run-1.report.md",
+          content: "# report",
+          project_reference: "fallback-project",
+        },
+        context: {},
+      },
+    ]);
+  });
+
+  it("skips mirror handler writes for errored tool results", async () => {
+    const calls: string[] = [];
+    const handler = createDefaultResearchRunArtifactMirrorHandler({
+      taskContext: {
+        defaultResearchArtifacts: defaultArtifacts(),
+      },
+      remoteToolSource: {
+        executeTool: (toolName) => {
+          calls.push(toolName);
+          return Promise.resolve(undefined);
+        },
+      },
+    });
+
+    await handler({
+      toolName: "create_file",
+      input: {
+        path: "research/ai-coding-agents/report.md",
+        content: "# report",
+      },
+      result: { isError: true },
+    });
+
+    assertEquals(calls, []);
   });
 });

--- a/src/agent/default-research-artifact-support.ts
+++ b/src/agent/default-research-artifact-support.ts
@@ -1,4 +1,6 @@
 import type { ChatSystemMessage } from "#veryfront/chat/types.ts";
+import { isErroredToolExecutionResult, type RemoteToolSource } from "#veryfront/tool";
+import { toChildRunToolInputRecord } from "./child-run-execution-support.ts";
 import { isHostedChildCreateFileAlreadyExistsResult } from "./hosted-child-artifact-support.ts";
 import {
   buildDefaultResearchArtifactPathReminder,
@@ -11,6 +13,7 @@ export type DefaultResearchArtifacts = DefaultResearchArtifactPaths;
 
 export interface DefaultResearchArtifactContext {
   availableToolNames?: string[];
+  projectId?: string | null;
   parentRunId?: string;
   defaultResearchArtifacts?: DefaultResearchArtifacts | null;
 }
@@ -336,4 +339,36 @@ export async function mirrorDefaultResearchRunArtifact(input: {
     }
     throw error;
   }
+}
+
+export function createDefaultResearchRunArtifactMirrorHandler(input: {
+  taskContext: DefaultResearchArtifactContext;
+  remoteToolSource?: Pick<RemoteToolSource, "executeTool"> | null;
+}) {
+  return async (request: {
+    toolName: string;
+    input: Record<string, unknown>;
+    result: unknown;
+    context?: Record<string, unknown>;
+  }): Promise<void> => {
+    const remoteToolSource = input.remoteToolSource;
+    if (!remoteToolSource || isErroredToolExecutionResult(request.result)) {
+      return;
+    }
+
+    const activeProjectId = typeof request.context?.projectId === "string"
+      ? request.context.projectId
+      : input.taskContext.projectId || null;
+
+    await mirrorDefaultResearchRunArtifact({
+      toolName: request.toolName,
+      toolInput: toChildRunToolInputRecord(request.input),
+      taskContext: input.taskContext,
+      activeProjectId,
+      executeContext: request.context,
+      toolResult: request.result,
+      executeTool: (nextToolName, nextArgs, nextContext) =>
+        remoteToolSource.executeTool(nextToolName, nextArgs, nextContext),
+    });
+  };
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -741,6 +741,7 @@ export {
 } from "./default-research-artifact-policy.ts";
 export {
   applyDefaultResearchArtifactPath,
+  createDefaultResearchRunArtifactMirrorHandler,
   type DefaultResearchArtifactContext,
   type DefaultResearchArtifactLogger,
   type DefaultResearchArtifacts,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.446";
+export const VERSION = "0.1.447";


### PR DESCRIPTION
## Summary\n- add a shared default research artifact mirror handler\n- expose the handler from the agent framework exports\n- bump package version to 0.1.447 for CI/CD publishing\n\n## Verification\n- deno test --no-check --allow-all src/agent/default-research-artifact-support.test.ts\n- deno check src/agent/default-research-artifact-support.ts src/agent/default-research-artifact-support.test.ts src/agent/index.ts\n- deno lint src/agent/default-research-artifact-support.ts src/agent/default-research-artifact-support.test.ts src/agent/index.ts\n- deno fmt --check src/agent/default-research-artifact-support.ts src/agent/default-research-artifact-support.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts\n- deno check src/index.ts\n- pre-push hook: ok | 1741 passed (17330 steps) | 0 failed