### PR TITLE
Add hosted chat runtime tool assembly helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.447",
+  "version": "0.1.448",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-chat-runtime-tool-assembly.test.ts
+++ b/src/agent/hosted-chat-runtime-tool-assembly.test.ts
@@ -1,0 +1,151 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import type {
+  RemoteMCPToolSourceConfig,
+  RemoteToolSource,
+  ToolDefinition,
+  ToolExecutionContext,
+} from "#veryfront/tool";
+import { z } from "zod";
+import {
+  filterHostedChatRuntimeLocalTools,
+  type HostedChatRuntimeToolAssemblyContext,
+  prepareHostedChatRuntimeToolAssembly,
+} from "./hosted-chat-runtime-tool-assembly.ts";
+
+function localTool(description: string) {
+  return {
+    description,
+    inputSchema: z.object({}),
+    execute: () => ({ ok: true }),
+  };
+}
+
+function remoteTool(name: string, description: string): ToolDefinition {
+  return {
+    name,
+    description,
+    parameters: { type: "object", properties: {} },
+  };
+}
+
+function remoteSourceFromConfig(config: RemoteMCPToolSourceConfig): RemoteToolSource {
+  const sourceId = config.id ?? "source";
+  const tools = sourceId === "studio-mcp"
+    ? [remoteTool("studio_open_project", "Open a project")]
+    : [remoteTool("create_file", "Create a file")];
+
+  return {
+    id: sourceId,
+    listTools: () => Promise.resolve(tools),
+    executeTool: (_toolName: string, _args: unknown, _context?: ToolExecutionContext) =>
+      Promise.resolve({ ok: true }),
+  };
+}
+
+Deno.test("filterHostedChatRuntimeLocalTools filters and sorts local tools", () => {
+  const result = filterHostedChatRuntimeLocalTools({
+    tools: {
+      sleep: localTool("Sleep"),
+      form_input: localTool("Form input"),
+      invoke_agent: localTool("Invoke agent"),
+    },
+    allowedToolNames: new Set(["sleep", "invoke_agent"]),
+  });
+
+  assertEquals(Object.keys(result), ["invoke_agent", "sleep"]);
+});
+
+Deno.test("prepareHostedChatRuntimeToolAssembly builds provider-compatible runtime inventory", async () => {
+  const taskContext: HostedChatRuntimeToolAssemblyContext = {
+    authToken: "token",
+    projectId: "project-1",
+    branchId: "branch-1",
+    model: "openai/gpt-4.1",
+    clientProfile: {
+      id: "veryfront-studio",
+      type: "web",
+      trusted: true,
+      capabilities: ["ui_panels"],
+    },
+  };
+  const traceSpans: string[] = [];
+  const toolAssembly = await prepareHostedChatRuntimeToolAssembly({
+    taskContext,
+    instructions: "Base instructions",
+    localTools: {
+      sleep: localTool("Sleep"),
+      form_input: localTool("Form input"),
+      invoke_agent: localTool("Invoke agent"),
+    },
+    apiUrl: "https://api.example.com",
+    apiMcpUrl: "https://api.example.com/mcp",
+    studioMcpUrl: "https://studio.example.com/mcp",
+    conversationId: "conversation-1",
+    allowedToolNames: ["sleep", "create_file", "studio_open_project"],
+    projectScopedRemoteToolOptions: {
+      projectNavigationToolNames: ["studio_open_project"],
+    },
+    createRemoteToolSource: remoteSourceFromConfig,
+    traceLocalTools: {
+      trace: (spanName, operation) => {
+        traceSpans.push(spanName);
+        return operation();
+      },
+    },
+    preloadLatestConversationUserText: false,
+  });
+
+  assertEquals(toolAssembly.localToolNames, ["sleep"]);
+  assertEquals(toolAssembly.remoteToolNames, ["create_file", "studio_open_project"]);
+  assertEquals(toolAssembly.compatibleRemoteToolNames, ["create_file", "studio_open_project"]);
+  assertEquals(taskContext.availableToolNames, ["create_file", "sleep", "studio_open_project"]);
+  assertEquals(toolAssembly.systemInstructions.includes("Current run tool inventory:"), true);
+
+  const runtimeSleepTool = toolAssembly.runtimeTools.sleep;
+  assertExists(runtimeSleepTool);
+  await runtimeSleepTool.execute?.({});
+  assertEquals(traceSpans, ["tool.sleep"]);
+});
+
+Deno.test("prepareHostedChatRuntimeToolAssembly preloads default research artifacts", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = () =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: [{
+            role: "user",
+            parts: [{
+              type: "text",
+              text:
+                "/research Research reusable agent runtimes and save the report to the project.",
+            }],
+          }],
+        }),
+        { status: 200 },
+      ),
+    );
+
+  try {
+    const taskContext: HostedChatRuntimeToolAssemblyContext = {
+      authToken: "token",
+      parentRunId: "run-1",
+    };
+    await prepareHostedChatRuntimeToolAssembly({
+      taskContext,
+      instructions: "Base instructions",
+      localTools: {},
+      apiUrl: "https://api.example.com",
+      apiMcpUrl: "https://api.example.com/mcp",
+      createRemoteToolSource: remoteSourceFromConfig,
+      conversationId: "conversation-1",
+    });
+
+    assertEquals(
+      taskContext.defaultResearchArtifacts?.currentReportPath,
+      "/research/reusable-agent-runtimes/report.md",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/src/agent/hosted-chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted-chat-runtime-tool-assembly.ts
@@ -1,0 +1,175 @@
+import type { ChatSystemMessage } from "#veryfront/chat/types.ts";
+import {
+  createRemoteMCPToolSource,
+  createToolsFromHostDefinitions,
+  type HostToolSet,
+  listProjectScopedRemoteToolNames,
+  type ProjectScopedRemoteToolOptions,
+  type RemoteMCPToolSourceConfig,
+  type RemoteToolSource,
+  type ToolSet,
+  traceHostTools,
+  type TraceHostToolsOptions,
+} from "#veryfront/tool";
+import {
+  type DefaultResearchArtifactContext,
+  fetchLatestConversationUserText,
+  updateDefaultResearchArtifacts,
+} from "./default-research-artifact-support.ts";
+import {
+  createHostedProjectRemoteToolSources,
+  type HostedProjectRemoteToolSourceMutationHandler,
+  type HostedProjectRemoteToolSourcePrepareToolInput,
+  type HostedProjectRemoteToolSourceProjectSwitchHandler,
+  type HostedProjectRemoteToolSourceRetryPolicy,
+} from "./hosted-project-remote-tool-source.ts";
+import { type RuntimeClientProfile } from "./runtime-client-profile.ts";
+import { selectProviderCompatibleToolNames } from "./runtime/provider-tool-compat.ts";
+import { flattenSystemInstructions, withRuntimeToolInventory } from "./runtime-tool-inventory.ts";
+
+export type HostedChatRuntimeToolAssemblyContext = DefaultResearchArtifactContext & {
+  authToken: string;
+  projectId?: string | null;
+  branchId?: string | null;
+  model?: string;
+  clientProfile?: RuntimeClientProfile | null;
+  availableToolNames?: string[];
+};
+
+export type HostedChatRuntimeAllowedToolNames = readonly string[] | ReadonlySet<string> | null;
+
+export type HostedChatRuntimeToolAssemblyResult = {
+  runtimeTools: ToolSet;
+  remoteToolSources: RemoteToolSource[];
+  localToolNames: string[];
+  remoteToolNames: string[];
+  availableToolNames: string[];
+  compatibleRemoteToolNames: string[];
+  systemInstructions: string;
+};
+
+export type PrepareHostedChatRuntimeToolAssemblyInput = {
+  taskContext: HostedChatRuntimeToolAssemblyContext;
+  instructions: string | readonly ChatSystemMessage[];
+  localTools: HostToolSet;
+  apiUrl: string;
+  apiMcpUrl: string;
+  studioMcpUrl?: string | null;
+  conversationId?: string;
+  allowedToolNames?: HostedChatRuntimeAllowedToolNames;
+  projectScopedRemoteToolOptions?: ProjectScopedRemoteToolOptions;
+  createRemoteToolSource?: (config: RemoteMCPToolSourceConfig) => RemoteToolSource;
+  traceLocalTools?: TraceHostToolsOptions;
+  getProjectId?: () => string | null | undefined;
+  getActiveBranchId?: () => string | null | undefined;
+  prepareRemoteToolInput?: HostedProjectRemoteToolSourcePrepareToolInput;
+  shouldRetryWithRemoteTool?: HostedProjectRemoteToolSourceRetryPolicy;
+  onSteeringMutation?: HostedProjectRemoteToolSourceMutationHandler;
+  onStudioProjectSwitch?: HostedProjectRemoteToolSourceProjectSwitchHandler;
+  preloadLatestConversationUserText?: boolean;
+};
+
+function normalizeAllowedToolNames(
+  toolNames: HostedChatRuntimeAllowedToolNames | undefined,
+): ReadonlySet<string> | null {
+  if (!toolNames) {
+    return null;
+  }
+
+  return new Set(toolNames);
+}
+
+function activeProjectId(taskContext: HostedChatRuntimeToolAssemblyContext): string | null {
+  return taskContext.projectId || null;
+}
+
+function activeBranchId(taskContext: HostedChatRuntimeToolAssemblyContext): string | null {
+  return taskContext.branchId ?? null;
+}
+
+export function filterHostedChatRuntimeLocalTools(input: {
+  tools: HostToolSet;
+  allowedToolNames?: HostedChatRuntimeAllowedToolNames;
+}): HostToolSet {
+  const allowedToolNames = normalizeAllowedToolNames(input.allowedToolNames);
+  const entries = Object.entries(input.tools).filter(([toolName]) =>
+    allowedToolNames ? allowedToolNames.has(toolName) : true
+  );
+
+  return Object.fromEntries(entries.sort(([left], [right]) => left.localeCompare(right)));
+}
+
+export async function prepareHostedChatRuntimeToolAssembly(
+  input: PrepareHostedChatRuntimeToolAssemblyInput,
+): Promise<HostedChatRuntimeToolAssemblyResult> {
+  const allowedToolNames = normalizeAllowedToolNames(input.allowedToolNames);
+  const sortedLocalTools = filterHostedChatRuntimeLocalTools({
+    tools: input.localTools,
+    allowedToolNames,
+  });
+  const localHostTools = input.traceLocalTools
+    ? traceHostTools(sortedLocalTools, input.traceLocalTools)
+    : sortedLocalTools;
+
+  const remoteToolSources = createHostedProjectRemoteToolSources({
+    authToken: input.taskContext.authToken,
+    apiMcpUrl: input.apiMcpUrl,
+    studioMcpUrl: input.studioMcpUrl,
+    clientProfile: input.taskContext.clientProfile,
+    createRemoteToolSource: input.createRemoteToolSource ?? createRemoteMCPToolSource,
+    defaultProjectId: () => activeProjectId(input.taskContext),
+    getProjectId: input.getProjectId ?? (() => activeProjectId(input.taskContext)),
+    getActiveBranchId: input.getActiveBranchId ?? (() => activeBranchId(input.taskContext)),
+    conversationId: input.conversationId,
+    allowedToolNames,
+    projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions,
+    prepareToolInput: input.prepareRemoteToolInput,
+    shouldRetryWithTool: input.shouldRetryWithRemoteTool,
+    onSteeringMutation: input.onSteeringMutation,
+    onStudioProjectSwitch: input.onStudioProjectSwitch,
+  });
+  const remoteToolNames = await listProjectScopedRemoteToolNames(remoteToolSources, {
+    projectId: activeProjectId(input.taskContext),
+    projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions,
+  });
+  const localToolNames = Object.keys(localHostTools);
+  const availableToolNames = selectProviderCompatibleToolNames(
+    [...new Set([...localToolNames, ...remoteToolNames])].sort(),
+    {
+      model: input.taskContext.model,
+      requiredToolNames: localToolNames,
+    },
+  );
+  const compatibleToolNames = new Set(availableToolNames);
+  const compatibleRemoteToolNames = remoteToolNames.filter((toolName) =>
+    compatibleToolNames.has(toolName)
+  );
+
+  input.taskContext.availableToolNames = availableToolNames;
+  const systemInstructions = flattenSystemInstructions(
+    withRuntimeToolInventory(input.instructions, availableToolNames),
+  );
+
+  if (input.preloadLatestConversationUserText !== false) {
+    const latestUserText = await fetchLatestConversationUserText({
+      apiUrl: input.apiUrl,
+      authToken: input.taskContext.authToken,
+      conversationId: input.conversationId,
+    });
+    updateDefaultResearchArtifacts({
+      taskContext: input.taskContext,
+      latestUserText,
+      system: systemInstructions,
+    });
+  }
+
+  return {
+    runtimeTools: createToolsFromHostDefinitions(localHostTools),
+    remoteToolSources,
+    localToolNames,
+    remoteToolNames,
+    availableToolNames,
+    compatibleRemoteToolNames,
+    systemInstructions,
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -119,6 +119,14 @@ export {
   type WrapHostedChildSteeringMutationToolInput,
 } from "./hosted-child-steering-tools.ts";
 export {
+  filterHostedChatRuntimeLocalTools,
+  type HostedChatRuntimeAllowedToolNames,
+  type HostedChatRuntimeToolAssemblyContext,
+  type HostedChatRuntimeToolAssemblyResult,
+  prepareHostedChatRuntimeToolAssembly,
+  type PrepareHostedChatRuntimeToolAssemblyInput,
+} from "./hosted-chat-runtime-tool-assembly.ts";
+export {
   createHostedProjectRemoteToolSource,
   type CreateHostedProjectRemoteToolSourceInput,
   createHostedProjectRemoteToolSources,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.447";
+export const VERSION = "0.1.448";


### PR DESCRIPTION
## Summary\n- add a reusable hosted chat runtime tool assembly helper\n- centralize local tool filtering/tracing, hosted project MCP source assembly, provider-compatible tool inventory, and default research artifact preload\n- bump package version to 0.1.448\n\n## Verification\n- deno test --no-check --allow-all src/agent/hosted-chat-runtime-tool-assembly.test.ts\n- deno check src/agent/hosted-chat-runtime-tool-assembly.ts src/agent/hosted-chat-runtime-tool-assembly.test.ts src/agent/index.ts src/index.ts\n- deno lint src/agent/hosted-chat-runtime-tool-assembly.ts src/agent/hosted-chat-runtime-tool-assembly.test.ts src/agent/index.ts\n- deno fmt --check src/agent/hosted-chat-runtime-tool-assembly.ts src/agent/hosted-chat-runtime-tool-assembly.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts\n- pre-push hook: ok | 1744 passed (17330 steps) | 0 failed