### PR TITLE
Preserve hosted chat runtime tool trace attribute types

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.448",
+  "version": "0.1.449",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted-chat-runtime-tool-assembly.ts
@@ -3,6 +3,7 @@ import {
   createRemoteMCPToolSource,
   createToolsFromHostDefinitions,
   type HostToolSet,
+  type HostToolTraceAttributes,
   listProjectScopedRemoteToolNames,
   type ProjectScopedRemoteToolOptions,
   type RemoteMCPToolSourceConfig,
@@ -48,7 +49,9 @@ export type HostedChatRuntimeToolAssemblyResult = {
   systemInstructions: string;
 };
 
-export type PrepareHostedChatRuntimeToolAssemblyInput = {
+export type PrepareHostedChatRuntimeToolAssemblyInput<
+  TTraceAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
+> = {
   taskContext: HostedChatRuntimeToolAssemblyContext;
   instructions: string | readonly ChatSystemMessage[];
   localTools: HostToolSet;
@@ -59,7 +62,7 @@ export type PrepareHostedChatRuntimeToolAssemblyInput = {
   allowedToolNames?: HostedChatRuntimeAllowedToolNames;
   projectScopedRemoteToolOptions?: ProjectScopedRemoteToolOptions;
   createRemoteToolSource?: (config: RemoteMCPToolSourceConfig) => RemoteToolSource;
-  traceLocalTools?: TraceHostToolsOptions;
+  traceLocalTools?: TraceHostToolsOptions<TTraceAttributes>;
   getProjectId?: () => string | null | undefined;
   getActiveBranchId?: () => string | null | undefined;
   prepareRemoteToolInput?: HostedProjectRemoteToolSourcePrepareToolInput;
@@ -99,8 +102,10 @@ export function filterHostedChatRuntimeLocalTools(input: {
   return Object.fromEntries(entries.sort(([left], [right]) => left.localeCompare(right)));
 }
 
-export async function prepareHostedChatRuntimeToolAssembly(
-  input: PrepareHostedChatRuntimeToolAssemblyInput,
+export async function prepareHostedChatRuntimeToolAssembly<
+  TTraceAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
+>(
+  input: PrepareHostedChatRuntimeToolAssemblyInput<TTraceAttributes>,
 ): Promise<HostedChatRuntimeToolAssemblyResult> {
   const allowedToolNames = normalizeAllowedToolNames(input.allowedToolNames);
   const sortedLocalTools = filterHostedChatRuntimeLocalTools({

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.448";
+export const VERSION = "0.1.449";


### PR DESCRIPTION
## Summary\n- preserve the hosted chat runtime tool assembly trace attribute generic\n- avoid forcing hosted runtime adapters to normalize trace attributes locally\n- bump package version to 0.1.449\n\n## Verification\n- deno check src/agent/hosted-chat-runtime-tool-assembly.ts src/agent/hosted-chat-runtime-tool-assembly.test.ts src/agent/index.ts src/index.ts\n- deno test --no-check --allow-all src/agent/hosted-chat-runtime-tool-assembly.test.ts\n- deno lint src/agent/hosted-chat-runtime-tool-assembly.ts src/agent/hosted-chat-runtime-tool-assembly.test.ts src/agent/index.ts\n- deno fmt --check src/agent/hosted-chat-runtime-tool-assembly.ts src/agent/hosted-chat-runtime-tool-assembly.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts\n- pre-push hook: ok | 1744 passed (17330 steps) | 0 failed