### PR TITLE
Add hosted child sandbox tool source helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.449",
+  "version": "0.1.450",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-fork-tool-sources.test.ts
+++ b/src/agent/hosted-child-fork-tool-sources.test.ts
@@ -1,11 +1,21 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import type {
+  CommandJob,
+  CommandJobOutput,
+  CreateSandboxBashTool,
+  HostedSandboxToolsOptions,
+  HostedSandboxToolsResult,
+} from "#veryfront/sandbox";
+import type {
   RemoteMCPToolSourceConfig,
   RemoteToolSource,
   ToolDefinition,
   ToolExecutionContext,
 } from "#veryfront/tool";
-import { prepareDefaultHostedChildForkToolSources } from "./hosted-child-fork-tool-sources.ts";
+import {
+  prepareDefaultHostedChildForkSandboxToolSources,
+  prepareDefaultHostedChildForkToolSources,
+} from "./hosted-child-fork-tool-sources.ts";
 import type { RuntimeClientProfile } from "./runtime-client-profile.ts";
 
 const trustedStudioProfile: RuntimeClientProfile = {
@@ -52,6 +62,55 @@ function createRemoteSourceFixtures() {
   };
 
   return { createdConfigs, executeCalls, createRemoteToolSource };
+}
+
+function commandJob(status: CommandJob["status"]): CommandJob {
+  return {
+    id: "job-1",
+    status,
+    exitCode: null,
+    signal: null,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    finishedAt: null,
+    heartbeatStatus: "healthy",
+    lastHeartbeatAt: null,
+    lastHeartbeatError: null,
+    heartbeatFailureCount: 0,
+  };
+}
+
+function commandJobOutput(): CommandJobOutput {
+  return {
+    ...commandJob("completed"),
+    exitCode: 0,
+    finishedAt: "2026-01-01T00:00:01.000Z",
+    stdout: "",
+    stderr: "",
+    stdoutTruncated: false,
+    stderrTruncated: false,
+  };
+}
+
+function createSandboxToolsResult(input: {
+  tools?: HostedSandboxToolsResult["tools"];
+  closeSandbox: () => Promise<void>;
+}): HostedSandboxToolsResult {
+  return {
+    tools: input.tools ?? {},
+    sandbox: {
+      ensure: () => Promise.resolve(),
+      close: () => Promise.resolve(),
+      executeCommand: () => Promise.resolve({ stdout: "", stderr: "", exitCode: 0 }),
+      startCommandJob: () => Promise.resolve(commandJob("running")),
+      getCommandJob: () => Promise.resolve(commandJob("completed")),
+      getCommandJobOutput: () => Promise.resolve(commandJobOutput()),
+      cancelCommandJob: () => Promise.resolve(commandJob("canceled")),
+      isActive: true,
+      id: "sandbox-1",
+      url: "https://sandbox.example",
+    },
+    closeSandbox: input.closeSandbox,
+  };
 }
 
 Deno.test("prepareDefaultHostedChildForkToolSources loads API, live Studio, and global tools", async () => {
@@ -150,4 +209,96 @@ Deno.test("prepareDefaultHostedChildForkToolSources rethrows abort errors", asyn
     Error,
     "fork aborted",
   );
+});
+
+Deno.test("prepareDefaultHostedChildForkSandboxToolSources merges sandbox tools and returns runtime cleanup", async () => {
+  const fixtures = createRemoteSourceFixtures();
+  const sandboxToolInputs: HostedSandboxToolsOptions[] = [];
+  let sandboxClosed = false;
+  const createBashTool: CreateSandboxBashTool = () => Promise.resolve({ tools: {} });
+
+  const result = await prepareDefaultHostedChildForkSandboxToolSources({
+    authToken: "token-1",
+    apiUrl: "https://api.example",
+    apiMcpUrl: "https://api.example/mcp",
+    studioMcpUrl: "https://studio.example/mcp",
+    clientProfile: trustedStudioProfile,
+    getProjectId: () => "project-1",
+    conversationId: "conversation-1",
+    globalTools: {
+      sleep: {
+        description: "sleep",
+        execute: () => ({ ok: true }),
+      },
+    },
+    createBashTool,
+    createRemoteToolSource: fixtures.createRemoteToolSource,
+    createHostedSandboxTools: (sandboxInput) => {
+      sandboxToolInputs.push(sandboxInput);
+      return Promise.resolve(
+        createSandboxToolsResult({
+          tools: {
+            bash: {
+              description: "bash",
+              execute: () => ({ ok: true }),
+            },
+          },
+          closeSandbox: () => {
+            sandboxClosed = true;
+            return Promise.resolve();
+          },
+        }),
+      );
+    },
+  });
+
+  assertEquals(result.ok, true);
+  if (!result.ok) {
+    return;
+  }
+
+  assertEquals(Object.keys(result.forkTools), [
+    "bash",
+    "sleep",
+    "studio_open_project",
+    "update_file",
+  ]);
+  assertEquals(sandboxToolInputs.map((input) => [input.apiUrl, input.getProjectId?.()]), [
+    ["https://api.example", "project-1"],
+  ]);
+
+  await result.closeRuntime?.();
+  assertEquals(sandboxClosed, true);
+  await result.closeTooling?.();
+});
+
+Deno.test("prepareDefaultHostedChildForkSandboxToolSources closes sandbox when source setup fails", async () => {
+  let sandboxClosed = false;
+  const createBashTool: CreateSandboxBashTool = () => Promise.resolve({ tools: {} });
+
+  const result = await prepareDefaultHostedChildForkSandboxToolSources({
+    authToken: "token-1",
+    apiUrl: "https://api.example",
+    apiMcpUrl: "https://api.example/mcp",
+    getProjectId: () => "project-1",
+    createBashTool,
+    createLiveStudioTools: () => {
+      throw new Error("studio unavailable");
+    },
+    createHostedSandboxTools: () =>
+      Promise.resolve(
+        createSandboxToolsResult({
+          closeSandbox: () => {
+            sandboxClosed = true;
+            return Promise.resolve();
+          },
+        }),
+      ),
+  });
+
+  assertEquals(result, {
+    ok: false,
+    errorMessage: "MCP tool setup failed: studio unavailable",
+  });
+  assertEquals(sandboxClosed, true);
 });

--- a/src/agent/hosted-child-fork-tool-sources.ts
+++ b/src/agent/hosted-child-fork-tool-sources.ts
@@ -6,6 +6,11 @@ import {
   type RemoteToolSource,
 } from "#veryfront/tool";
 import {
+  createHostedSandboxTools,
+  type HostedSandboxToolsOptions,
+  type HostedSandboxToolsResult,
+} from "#veryfront/sandbox";
+import {
   createLiveStudioMcpTools,
   type LiveStudioMcpToolsOptions,
 } from "./live-studio-mcp-tools.ts";
@@ -14,7 +19,10 @@ import {
   type HostedChildProjectSwitchHandler,
   wrapHostedChildProjectSwitchTool,
 } from "./hosted-child-steering-tools.ts";
-import { buildDefaultHostedChildForkToolSet } from "./hosted-child-requested-tools.ts";
+import {
+  buildDefaultHostedChildForkToolSet,
+  type DefaultHostedChildForkToolAssemblySourceResult,
+} from "./hosted-child-requested-tools.ts";
 
 export type HostedChildForkToolSourcesLogger = {
   error: (message: string, metadata?: Record<string, unknown>) => void;
@@ -50,6 +58,16 @@ export type DefaultHostedChildForkToolSourcesResult =
   | {
     ok: false;
     errorMessage: string;
+  };
+
+export type PrepareDefaultHostedChildForkSandboxToolSourcesInput =
+  & PrepareDefaultHostedChildForkToolSourcesInput
+  & {
+    apiUrl: string;
+    createBashTool: HostedSandboxToolsOptions["createBashTool"];
+    createHostedSandboxTools?: (
+      input: HostedSandboxToolsOptions,
+    ) => Promise<HostedSandboxToolsResult>;
   };
 
 export async function prepareDefaultHostedChildForkToolSources(
@@ -121,6 +139,50 @@ export async function prepareDefaultHostedChildForkToolSources(
     ),
     closeStudioMcpTools,
   };
+}
+
+export async function prepareDefaultHostedChildForkSandboxToolSources(
+  input: PrepareDefaultHostedChildForkSandboxToolSourcesInput,
+): Promise<DefaultHostedChildForkToolAssemblySourceResult> {
+  const {
+    apiUrl,
+    createBashTool,
+    createHostedSandboxTools: createHostedSandboxToolsOverride,
+    globalTools,
+    ...toolSourceInput
+  } = input;
+  const createSandboxTools = createHostedSandboxToolsOverride ?? createHostedSandboxTools;
+  const sandboxResult = await createSandboxTools({
+    authToken: input.authToken,
+    apiUrl,
+    getProjectId: input.getProjectId,
+    createBashTool,
+  });
+  const mergedGlobalTools = {
+    ...(globalTools ?? {}),
+    ...sandboxResult.tools,
+  };
+
+  try {
+    const toolSources = await prepareDefaultHostedChildForkToolSources({
+      ...toolSourceInput,
+      globalTools: mergedGlobalTools,
+    });
+    if (!toolSources.ok) {
+      await sandboxResult.closeSandbox();
+      return toolSources;
+    }
+
+    return {
+      ok: true,
+      forkTools: toolSources.forkTools,
+      closeRuntime: sandboxResult.closeSandbox,
+      closeTooling: toolSources.closeStudioMcpTools,
+    };
+  } catch (error) {
+    await sandboxResult.closeSandbox();
+    throw error;
+  }
 }
 
 function throwIfAborted(abortSignal: AbortSignal | undefined): void {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -165,6 +165,8 @@ export {
 export {
   type DefaultHostedChildForkToolSourcesResult,
   type HostedChildForkToolSourcesLogger,
+  prepareDefaultHostedChildForkSandboxToolSources,
+  type PrepareDefaultHostedChildForkSandboxToolSourcesInput,
   prepareDefaultHostedChildForkToolSources,
   type PrepareDefaultHostedChildForkToolSourcesInput,
 } from "./hosted-child-fork-tool-sources.ts";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.449";
+export const VERSION = "0.1.450";


### PR DESCRIPTION
## Summary
- add a reusable hosted child fork helper that combines sandbox tools with API/Studio MCP tool sources
- preserve sandbox cleanup on source setup failures and expose runtime/tooling cleanup handles on success
- bump framework version to 0.1.450 for CI/CD publication

## Verification
- deno check src/agent/hosted-child-fork-tool-sources.ts src/agent/hosted-child-fork-tool-sources.test.ts src/agent/index.ts
- deno test --no-check --allow-all src/agent/hosted-child-fork-tool-sources.test.ts
- deno lint src/agent/hosted-child-fork-tool-sources.ts src/agent/hosted-child-fork-tool-sources.test.ts src/agent/index.ts
- deno fmt --check src/agent/hosted-child-fork-tool-sources.ts src/agent/hosted-child-fork-tool-sources.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts
- git push pre-push checks: ok | 1746 passed (17330 steps) | 0 failed