### PR TITLE
Add hosted child fork execution helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.450",
+  "version": "0.1.451",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-fork-execution-runner.test.ts
+++ b/src/agent/hosted-child-fork-execution-runner.test.ts
@@ -1,0 +1,159 @@
+import { assertEquals } from "@std/assert";
+import type { HostToolSet } from "#veryfront/tool";
+import {
+  DEFAULT_HOSTED_CHILD_FORK_STREAM_ACTIVE_TOOL_TIMEOUT_MS,
+  DEFAULT_HOSTED_CHILD_FORK_STREAM_FINALIZATION_TIMEOUT_MS,
+  DEFAULT_HOSTED_CHILD_FORK_STREAM_IDLE_TIMEOUT_MS,
+  DEFAULT_HOSTED_CHILD_FORK_STREAM_POST_TOOL_IDLE_TIMEOUT_MS,
+  DEFAULT_HOSTED_CHILD_STATUS_POLL_INTERVAL_MS,
+  executeHostedChildForkWithPreparedTools,
+} from "./hosted-child-fork-execution-runner.ts";
+import type { AgentResponse } from "./schemas/index.ts";
+
+function createRuntimeEventStream(
+  events: readonly Record<string, unknown>[],
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+      }
+      controller.close();
+    },
+  });
+}
+
+function createResponse(): AgentResponse {
+  return {
+    text: "Done.",
+    messages: [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        timestamp: 2,
+        parts: [{ type: "text", text: "Done." }],
+      },
+    ],
+    toolCalls: [],
+    status: "completed",
+    metadata: { finishReason: "stop" },
+  };
+}
+
+Deno.test("executeHostedChildForkWithPreparedTools returns a failure for unavailable tools", async () => {
+  const result = await executeHostedChildForkWithPreparedTools({
+    authToken: "token",
+    apiUrl: "https://api.example.com",
+    description: "Check the app",
+    kind: "invoke_agent",
+    provider: "anthropic",
+    forkModel: "anthropic/claude-sonnet-4",
+    maxSteps: 4,
+    effectivePrompt: "Do the work.",
+    toolAssembly: {
+      ok: false,
+      errorMessage: "Requested fork tools not available in runtime: bash",
+    },
+  });
+
+  assertEquals(result.success, false);
+  assertEquals(result.description, "Check the app");
+  if (!result.success) {
+    assertEquals(result.error, "Requested fork tools not available in runtime: bash");
+  }
+  assertEquals(result.steps, 0);
+  assertEquals(result.toolCalls, []);
+  assertEquals(result.toolResults, []);
+});
+
+Deno.test("executeHostedChildForkWithPreparedTools executes a prepared child fork and closes resources", async () => {
+  let closeToolingCalls = 0;
+  let closeRuntimeCalls = 0;
+  const toolTraceSpans: string[] = [];
+  const traceAttributes: Record<string, unknown>[] = [];
+  const partTypes: string[] = [];
+  const forkTools: HostToolSet = {
+    noop: {
+      description: "No-op tool",
+      inputSchema: {},
+      execute: () => "ok",
+    },
+  };
+
+  const result = await executeHostedChildForkWithPreparedTools({
+    authToken: "token",
+    apiUrl: "https://api.example.com",
+    projectId: "project-1",
+    description: "Check the app",
+    kind: "invoke_agent",
+    provider: "anthropic",
+    forkModel: "anthropic/claude-sonnet-4",
+    maxSteps: 4,
+    effectivePrompt: "Do the work.",
+    forkContext: {
+      projectId: "project-1",
+      branchId: "branch-1",
+      availableSkillIds: ["design"],
+    },
+    toolAssembly: {
+      ok: true,
+      forkTools,
+      availableToolNames: ["noop"],
+      closeTooling: () => {
+        closeToolingCalls += 1;
+        return Promise.resolve();
+      },
+      closeRuntime: () => {
+        closeRuntimeCalls += 1;
+        return Promise.resolve();
+      },
+    },
+    instrumentation: {
+      trace: (spanName, operation) => {
+        toolTraceSpans.push(spanName);
+        return operation();
+      },
+      buildToolTraceAttributes: ({ toolName, toolCallId }) => ({
+        toolName,
+        toolCallId: toolCallId ?? null,
+      }),
+      setTraceAttributes: (attributes) => {
+        traceAttributes.push(attributes);
+      },
+      tracePart: ({ partType }) => {
+        partTypes.push(partType);
+      },
+    },
+    runStep: async (input) => {
+      assertEquals(input.model, "anthropic/claude-sonnet-4");
+      assertEquals(input.forkToolNames, ["noop", "web_fetch", "web_search"]);
+      assertEquals(input.providerOptions, undefined);
+      assertEquals(input.system.includes('project_reference: "project-1"'), true);
+      assertEquals(input.system.includes("Available Skills"), true);
+      return {
+        stream: createRuntimeEventStream([{ type: "text-delta", delta: "Done." }]),
+        responsePromise: Promise.resolve(createResponse()),
+      };
+    },
+  });
+
+  assertEquals(result.success, true);
+  if (result.success) {
+    assertEquals(result.summary.text, "Done.");
+  }
+  assertEquals(partTypes, ["text-delta"]);
+  assertEquals(toolTraceSpans, []);
+  assertEquals(traceAttributes, []);
+  assertEquals(closeToolingCalls, 1);
+  assertEquals(closeRuntimeCalls, 1);
+});
+
+Deno.test("executeHostedChildForkWithPreparedTools exports stable default timeout constants", () => {
+  assertEquals(DEFAULT_HOSTED_CHILD_STATUS_POLL_INTERVAL_MS, 2_000);
+  assertEquals(DEFAULT_HOSTED_CHILD_FORK_STREAM_IDLE_TIMEOUT_MS, 45_000);
+  assertEquals(DEFAULT_HOSTED_CHILD_FORK_STREAM_ACTIVE_TOOL_TIMEOUT_MS, 5 * 60_000);
+  assertEquals(DEFAULT_HOSTED_CHILD_FORK_STREAM_POST_TOOL_IDLE_TIMEOUT_MS, 2 * 60_000);
+  assertEquals(DEFAULT_HOSTED_CHILD_FORK_STREAM_FINALIZATION_TIMEOUT_MS, 10_000);
+});

--- a/src/agent/hosted-child-fork-execution-runner.ts
+++ b/src/agent/hosted-child-fork-execution-runner.ts
@@ -1,0 +1,287 @@
+import type { HostToolTraceAttributes } from "#veryfront/tool";
+import { buildChildRunFailureResult } from "./child-run-execution-snapshot.ts";
+import {
+  createHostedDurableChildForkRunContext,
+  executeHostedChildForkRunContextStream,
+  finalizeHostedChildForkRunContextResources,
+  handleHostedChildForkRunContextError,
+  type HostedDurableChildForkRunContext,
+} from "./hosted-child-fork-run-context.ts";
+import { type DefaultHostedChildForkToolAssemblyResult } from "./hosted-child-requested-tools.ts";
+import {
+  addLoadSkillContinuationReminder,
+  shouldReinforceLoadSkillContinuation,
+} from "./conversation-delegation-policy.ts";
+import {
+  buildHostedChildForkInstructions,
+  type HostedChildForkInstructionsContext,
+} from "./hosted-child-fork-instructions.ts";
+import {
+  type HostedChildForkRuntimeStepSystemResolver,
+  prepareHostedChildForkRuntimeStepMessages,
+} from "./hosted-child-fork-step-message-preparation.ts";
+import {
+  startHostedChildForkRuntimeWithHostTools,
+  type StartHostedChildForkRuntimeWithHostToolsInput,
+} from "./hosted-child-fork-runtime-start.ts";
+import { type AgentRuntimeForkStepRunner, runAgentRuntimeForkStep } from "./fork-runtime-stream.ts";
+import type {
+  ChildRunExecutionResult,
+  ChildRunExecutionSnapshot,
+} from "./child-run-execution-snapshot.ts";
+import type { HostedConversationRunChunkMirrorInstrumentation } from "./conversation-run-chunk-mirror.ts";
+import type { HostedChildExecutionLogEntry } from "./hosted-child-execution-logging.ts";
+import type {
+  HostedChildForkStreamLogger,
+  HostedChildForkStreamTraceInput,
+} from "./hosted-child-fork-stream-execution.ts";
+import type { HostedChildRunIdentifiers } from "./hosted-child-status.ts";
+import { throwIfChildRunAborted } from "./child-run-execution-support.ts";
+
+export const DEFAULT_HOSTED_CHILD_FORK_STREAM_IDLE_TIMEOUT_MS = 45_000;
+export const DEFAULT_HOSTED_CHILD_FORK_STREAM_ACTIVE_TOOL_TIMEOUT_MS = 5 * 60_000;
+export const DEFAULT_HOSTED_CHILD_FORK_STREAM_POST_TOOL_IDLE_TIMEOUT_MS = 2 * 60_000;
+export const DEFAULT_HOSTED_CHILD_FORK_STREAM_FINALIZATION_TIMEOUT_MS = 10_000;
+export const DEFAULT_HOSTED_CHILD_STATUS_POLL_INTERVAL_MS = 2_000;
+
+export type HostedChildForkExecutionInstrumentation<
+  TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
+> = {
+  trace?: <TResult>(operationName: string, operation: () => TResult) => TResult;
+  setTraceAttributes?: (attributes: Record<string, unknown>) => void;
+  buildToolTraceAttributes?: (input: {
+    toolName: string;
+    toolCallId: string | undefined;
+  }) => TAttributes | undefined;
+  tracePart?: (input: HostedChildForkStreamTraceInput) => void | Promise<void>;
+  debug?: (message: string, metadata?: Record<string, unknown>) => void;
+  warn?: (message: string, metadata?: Record<string, unknown>) => void;
+  error?: (message: string, metadata?: Record<string, unknown>) => void;
+};
+
+export type ExecuteHostedChildForkWithPreparedToolsInput<
+  TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
+> = {
+  authToken: string;
+  apiUrl: string;
+  projectId?: string | null;
+  description: string;
+  kind: string;
+  provider: string;
+  forkModel: string;
+  maxSteps: number;
+  effectivePrompt: string;
+  forkContext?: HostedChildForkInstructionsContext;
+  toolAssembly: DefaultHostedChildForkToolAssemblyResult;
+  abortSignal?: AbortSignal;
+  durableChildRun?: HostedChildRunIdentifiers;
+  conversationId?: string;
+  parentRunId?: string;
+  pendingToolLogWriter?: { warn: (message: string, metadata?: Record<string, unknown>) => void };
+  logger?: HostedChildForkStreamLogger;
+  instrumentation?: HostedChildForkExecutionInstrumentation<TAttributes>;
+  providerOptions?: Record<string, unknown>;
+  maxContinuationSteps?: number;
+  resolveSystem?: HostedChildForkRuntimeStepSystemResolver;
+  buildInstructions?: () => string;
+  onBeforeStop?: StartHostedChildForkRuntimeWithHostToolsInput<TAttributes>["onBeforeStop"];
+  runStep?: AgentRuntimeForkStepRunner;
+  childRunMonitorPollIntervalMs?: number;
+  idleTimeoutMs?: number;
+  activeToolTimeoutMs?: number;
+  postToolIdleTimeoutMs?: number;
+  finalizationTimeoutMs?: number;
+  startTime?: number;
+  onSettled?: (snapshot: ChildRunExecutionSnapshot) => void | Promise<void>;
+  writeLog?: (entry: HostedChildExecutionLogEntry) => void;
+  shouldRethrowError?: (error: unknown) => boolean;
+};
+
+function createForkRunContext(input: {
+  authToken: string;
+  apiUrl: string;
+  durableChildRun?: HostedChildRunIdentifiers;
+  conversationId?: string;
+  parentRunId?: string;
+  description: string;
+  instrumentation?: HostedChildForkExecutionInstrumentation;
+  pendingToolLogWriter?: { warn: (message: string, metadata?: Record<string, unknown>) => void };
+}): HostedDurableChildForkRunContext {
+  const sourceInstrumentation = input.instrumentation;
+  const sourceTrace = sourceInstrumentation?.trace;
+  const instrumentation: HostedConversationRunChunkMirrorInstrumentation | undefined =
+    sourceInstrumentation
+      ? {
+        trace: sourceTrace
+          ? <TResult>(operationName: string, operation: () => Promise<TResult>) =>
+            sourceTrace(operationName, operation)
+          : undefined,
+        setTraceAttributes: sourceInstrumentation.setTraceAttributes,
+        debug: sourceInstrumentation.debug,
+        warn: sourceInstrumentation.warn,
+        error: sourceInstrumentation.error,
+      }
+      : undefined;
+
+  return createHostedDurableChildForkRunContext({
+    authToken: input.authToken,
+    apiUrl: input.apiUrl,
+    durableChildRun: input.durableChildRun,
+    instrumentation,
+    pendingToolLogContext: {
+      conversationId: input.conversationId,
+      parentRunId: input.parentRunId,
+      description: input.description,
+    },
+    pendingToolLogWriter: input.pendingToolLogWriter,
+  });
+}
+
+function defaultResolveSystem(input: {
+  system: string;
+  compactedMessages: Parameters<HostedChildForkRuntimeStepSystemResolver>[0]["compactedMessages"];
+}): string {
+  if (!shouldReinforceLoadSkillContinuation([...input.compactedMessages])) {
+    return input.system;
+  }
+
+  const remindedSystem = addLoadSkillContinuationReminder(input.system);
+  return typeof remindedSystem === "string" ? remindedSystem : input.system;
+}
+
+export async function executeHostedChildForkWithPreparedTools<
+  TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
+>(
+  input: ExecuteHostedChildForkWithPreparedToolsInput<TAttributes>,
+): Promise<ChildRunExecutionResult> {
+  const startTime = input.startTime ?? Date.now();
+  const runContext = createForkRunContext({
+    authToken: input.authToken,
+    apiUrl: input.apiUrl,
+    durableChildRun: input.durableChildRun,
+    conversationId: input.conversationId,
+    parentRunId: input.parentRunId,
+    description: input.description,
+    instrumentation: input.instrumentation,
+    pendingToolLogWriter: input.pendingToolLogWriter,
+  });
+
+  let closeTooling: (() => Promise<void>) | undefined;
+  let closeRuntime: (() => Promise<void>) | undefined;
+  let childRunMonitorAbortController: AbortController | null = null;
+  let childRunMonitorPromise: Promise<void> = Promise.resolve();
+
+  try {
+    throwIfChildRunAborted(input.abortSignal);
+    if (!input.toolAssembly.ok) {
+      return buildChildRunFailureResult(
+        {
+          description: input.description,
+          steps: 0,
+          toolCalls: [],
+          toolResults: [],
+          durationMs: Date.now() - startTime,
+        },
+        input.toolAssembly.errorMessage,
+      );
+    }
+
+    closeTooling = input.toolAssembly.closeTooling;
+    closeRuntime = input.toolAssembly.closeRuntime;
+    const buildInstructions = input.buildInstructions ??
+      (() => buildHostedChildForkInstructions(input.forkContext));
+    const sourceInstrumentation = input.instrumentation;
+    const sourceTrace = sourceInstrumentation?.trace;
+    const traceTools = sourceTrace
+      ? {
+        trace: <TResult>(spanName: string, operation: () => TResult): TResult =>
+          sourceTrace(spanName, operation),
+        buildAttributes: sourceInstrumentation.buildToolTraceAttributes,
+        setAttributes: sourceInstrumentation.setTraceAttributes,
+      }
+      : undefined;
+    const started = await startHostedChildForkRuntimeWithHostTools({
+      apiUrl: input.apiUrl,
+      authToken: input.authToken,
+      projectId: input.projectId ?? null,
+      provider: input.provider,
+      forkModel: input.forkModel,
+      maxSteps: input.maxSteps,
+      prompt: input.effectivePrompt,
+      maxContinuationSteps: input.maxContinuationSteps ?? 0,
+      abortSignal: input.abortSignal,
+      forkTools: input.toolAssembly.forkTools,
+      providerOptions: input.providerOptions,
+      buildInstructions,
+      onBeforeStop: input.onBeforeStop ?? (() => null),
+      durableChildRun: input.durableChildRun,
+      childRunMonitorPollIntervalMs: input.childRunMonitorPollIntervalMs ??
+        DEFAULT_HOSTED_CHILD_STATUS_POLL_INTERVAL_MS,
+      logger: input.logger?.warn ? { warn: input.logger.warn } : undefined,
+      prepareStep: ({ messages, buildInstructions: prepareBuildInstructions, forkToolNames }) =>
+        prepareHostedChildForkRuntimeStepMessages({
+          messages,
+          buildInstructions: prepareBuildInstructions,
+          forkToolNames,
+          resolveSystem: input.resolveSystem ?? defaultResolveSystem,
+        }),
+      runStep: input.runStep ?? runAgentRuntimeForkStep,
+      traceTools,
+    });
+    childRunMonitorAbortController = started.childRunMonitorAbortController;
+    childRunMonitorPromise = started.childRunMonitorPromise;
+
+    return await executeHostedChildForkRunContextStream({
+      runContext,
+      streamResult: started.streamResult,
+      abortSignal: input.abortSignal,
+      abortForkStream: (error) => {
+        if (!started.forkStreamAbortController.signal.aborted) {
+          started.forkStreamAbortController.abort(error);
+        }
+      },
+      conversationId: input.conversationId,
+      parentRunId: input.parentRunId,
+      description: input.description,
+      kind: input.kind,
+      usage: undefined,
+      maxSteps: input.maxSteps,
+      startTime,
+      finalizationTimeoutMs: input.finalizationTimeoutMs ??
+        DEFAULT_HOSTED_CHILD_FORK_STREAM_FINALIZATION_TIMEOUT_MS,
+      onSettled: input.onSettled,
+      idleTimeoutMs: input.idleTimeoutMs ?? DEFAULT_HOSTED_CHILD_FORK_STREAM_IDLE_TIMEOUT_MS,
+      activeToolTimeoutMs: input.activeToolTimeoutMs ??
+        DEFAULT_HOSTED_CHILD_FORK_STREAM_ACTIVE_TOOL_TIMEOUT_MS,
+      postToolIdleTimeoutMs: input.postToolIdleTimeoutMs ??
+        DEFAULT_HOSTED_CHILD_FORK_STREAM_POST_TOOL_IDLE_TIMEOUT_MS,
+      logger: input.logger,
+      writeLog: input.writeLog,
+      tracePart: input.instrumentation?.tracePart,
+    });
+  } catch (error) {
+    return handleHostedChildForkRunContextError({
+      error,
+      abortSignal: input.abortSignal,
+      description: input.description,
+      kind: input.kind,
+      runContext,
+      usage: undefined,
+      startTime,
+      onSettled: input.onSettled,
+      shouldRethrowError: input.shouldRethrowError,
+      writeLog: input.writeLog,
+    });
+  } finally {
+    await finalizeHostedChildForkRunContextResources({
+      runContext,
+      monitorAbortController: childRunMonitorAbortController,
+      monitorPromise: childRunMonitorPromise,
+      flushMirror: () => runContext.durableRunMirror?.flush() ?? Promise.resolve(),
+      closeTooling,
+      closeRuntime,
+    });
+    closeTooling = undefined;
+    closeRuntime = undefined;
+  }
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -489,6 +489,16 @@ export {
   type HostedChildForkInstructionsContext,
 } from "./hosted-child-fork-instructions.ts";
 export {
+  DEFAULT_HOSTED_CHILD_FORK_STREAM_ACTIVE_TOOL_TIMEOUT_MS,
+  DEFAULT_HOSTED_CHILD_FORK_STREAM_FINALIZATION_TIMEOUT_MS,
+  DEFAULT_HOSTED_CHILD_FORK_STREAM_IDLE_TIMEOUT_MS,
+  DEFAULT_HOSTED_CHILD_FORK_STREAM_POST_TOOL_IDLE_TIMEOUT_MS,
+  DEFAULT_HOSTED_CHILD_STATUS_POLL_INTERVAL_MS,
+  executeHostedChildForkWithPreparedTools,
+  type ExecuteHostedChildForkWithPreparedToolsInput,
+  type HostedChildForkExecutionInstrumentation,
+} from "./hosted-child-fork-execution-runner.ts";
+export {
   createHostedChildForkRunContext,
   createHostedDurableChildForkRunContext,
   executeHostedChildForkRunContextStream,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.450";
+export const VERSION = "0.1.451";


### PR DESCRIPTION
## Summary
- add a reusable hosted child fork execution helper for prepared tool assemblies
- centralize child fork run-context setup, runtime start, stream execution, error handling, and cleanup defaults
- export stable timeout defaults and bump the package version to 0.1.451

## Verification
- `deno check src/agent/hosted-child-fork-execution-runner.ts src/agent/hosted-child-fork-execution-runner.test.ts src/agent/index.ts`
- `deno test --no-check --allow-all src/agent/hosted-child-fork-execution-runner.test.ts`
- `deno lint src/agent/hosted-child-fork-execution-runner.ts src/agent/hosted-child-fork-execution-runner.test.ts src/agent/index.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts src/agent/hosted-child-fork-execution-runner.ts src/agent/hosted-child-fork-execution-runner.test.ts src/agent/index.ts`
- pre-push unit suite: `1749 passed (17330 steps)`
