### PR TITLE
Allow hosted child fork runtime injection

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.451",
+  "version": "0.1.452",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-fork-execution-runner.test.ts
+++ b/src/agent/hosted-child-fork-execution-runner.test.ts
@@ -150,6 +150,56 @@ Deno.test("executeHostedChildForkWithPreparedTools executes a prepared child for
   assertEquals(closeRuntimeCalls, 1);
 });
 
+Deno.test("executeHostedChildForkWithPreparedTools allows injecting the runtime starter", async () => {
+  let startRuntimeCalls = 0;
+  const result = await executeHostedChildForkWithPreparedTools({
+    authToken: "token",
+    apiUrl: "https://api.example.com",
+    description: "Check the app",
+    kind: "invoke_agent",
+    provider: "anthropic",
+    forkModel: "anthropic/claude-sonnet-4",
+    maxSteps: 4,
+    effectivePrompt: "Do the work.",
+    toolAssembly: {
+      ok: true,
+      forkTools: {},
+      availableToolNames: [],
+    },
+    startRuntime: (input) => {
+      startRuntimeCalls += 1;
+      assertEquals(input.forkModel, "anthropic/claude-sonnet-4");
+      return {
+        forkStreamAbortController: new AbortController(),
+        childRunMonitorAbortController: null,
+        childRunMonitorPromise: Promise.resolve(),
+        forkToolNames: [],
+        streamResult: {
+          fullStream: (async function* () {
+            yield { type: "text-delta", text: "Injected." } as const;
+          })(),
+          steps: Promise.resolve([
+            {
+              text: "Injected.",
+              finishReason: "stop",
+              messages: [],
+              toolCalls: [],
+              toolResults: [],
+            },
+          ]),
+          totalUsage: Promise.resolve(undefined),
+        },
+      };
+    },
+  });
+
+  assertEquals(startRuntimeCalls, 1);
+  assertEquals(result.success, true);
+  if (result.success) {
+    assertEquals(result.summary.text, "Injected.");
+  }
+});
+
 Deno.test("executeHostedChildForkWithPreparedTools exports stable default timeout constants", () => {
   assertEquals(DEFAULT_HOSTED_CHILD_STATUS_POLL_INTERVAL_MS, 2_000);
   assertEquals(DEFAULT_HOSTED_CHILD_FORK_STREAM_IDLE_TIMEOUT_MS, 45_000);

--- a/src/agent/hosted-child-fork-execution-runner.ts
+++ b/src/agent/hosted-child-fork-execution-runner.ts
@@ -21,6 +21,7 @@ import {
   prepareHostedChildForkRuntimeStepMessages,
 } from "./hosted-child-fork-step-message-preparation.ts";
 import {
+  type StartedHostedChildForkRuntime,
   startHostedChildForkRuntimeWithHostTools,
   type StartHostedChildForkRuntimeWithHostToolsInput,
 } from "./hosted-child-fork-runtime-start.ts";
@@ -86,6 +87,9 @@ export type ExecuteHostedChildForkWithPreparedToolsInput<
   buildInstructions?: () => string;
   onBeforeStop?: StartHostedChildForkRuntimeWithHostToolsInput<TAttributes>["onBeforeStop"];
   runStep?: AgentRuntimeForkStepRunner;
+  startRuntime?: (
+    input: StartHostedChildForkRuntimeWithHostToolsInput<TAttributes>,
+  ) => StartedHostedChildForkRuntime | Promise<StartedHostedChildForkRuntime>;
   childRunMonitorPollIntervalMs?: number;
   idleTimeoutMs?: number;
   activeToolTimeoutMs?: number;
@@ -200,7 +204,8 @@ export async function executeHostedChildForkWithPreparedTools<
         setAttributes: sourceInstrumentation.setTraceAttributes,
       }
       : undefined;
-    const started = await startHostedChildForkRuntimeWithHostTools({
+    const startRuntime = input.startRuntime ?? startHostedChildForkRuntimeWithHostTools;
+    const started = await startRuntime({
       apiUrl: input.apiUrl,
       authToken: input.authToken,
       projectId: input.projectId ?? null,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.451";
+export const VERSION = "0.1.452";


### PR DESCRIPTION
## Summary
- add dependency injection for the hosted child fork runtime starter
- cover the injected runtime path in the hosted child fork execution helper tests
- bump the package version to 0.1.452

## Verification
- `deno check src/agent/hosted-child-fork-execution-runner.ts src/agent/hosted-child-fork-execution-runner.test.ts src/agent/index.ts`
- `deno test --no-check --allow-all src/agent/hosted-child-fork-execution-runner.test.ts`
- `deno lint src/agent/hosted-child-fork-execution-runner.ts src/agent/hosted-child-fork-execution-runner.test.ts src/agent/index.ts`
- `deno fmt --check deno.json src/utils/version-constant.ts src/agent/hosted-child-fork-execution-runner.ts src/agent/hosted-child-fork-execution-runner.test.ts src/agent/index.ts`
- pre-push unit suite: `1750 passed (17330 steps)`
