### PR TITLE
Add hosted child fork run context injection

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.452",
+  "version": "0.1.453",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/extensions/ext-tailwind/_helpers/contract-init.ts
+++ b/extensions/ext-tailwind/_helpers/contract-init.ts
@@ -1,0 +1,15 @@
+/**
+ * Test-environment contract registration for the ext-tailwind workspace.
+ *
+ * Side-effect import: registers the default Bundler and ModuleLexer
+ * implementations so extension tests that exercise framework code can resolve
+ * those contracts when run from the workspace package.
+ *
+ * @module
+ */
+
+import { EsbuildBundler, EsModuleLexer } from "@veryfront/ext-esbuild";
+import { register, tryResolve } from "../../../src/extensions/contracts.ts";
+
+if (!tryResolve("Bundler")) register("Bundler", new EsbuildBundler());
+if (!tryResolve("ModuleLexer")) register("ModuleLexer", new EsModuleLexer());

--- a/src/agent/hosted-child-fork-execution-runner.test.ts
+++ b/src/agent/hosted-child-fork-execution-runner.test.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_HOSTED_CHILD_STATUS_POLL_INTERVAL_MS,
   executeHostedChildForkWithPreparedTools,
 } from "./hosted-child-fork-execution-runner.ts";
+import { createHostedDurableChildForkRunContext } from "./hosted-child-fork-run-context.ts";
 import type { AgentResponse } from "./schemas/index.ts";
 
 function createRuntimeEventStream(
@@ -197,6 +198,69 @@ Deno.test("executeHostedChildForkWithPreparedTools allows injecting the runtime 
   assertEquals(result.success, true);
   if (result.success) {
     assertEquals(result.summary.text, "Injected.");
+  }
+});
+
+Deno.test("executeHostedChildForkWithPreparedTools allows injecting the run context factory", async () => {
+  let createRunContextCalls = 0;
+  const result = await executeHostedChildForkWithPreparedTools({
+    authToken: "token",
+    apiUrl: "https://api.example.com",
+    description: "Check the app",
+    kind: "invoke_agent",
+    provider: "anthropic",
+    forkModel: "anthropic/claude-sonnet-4",
+    maxSteps: 4,
+    effectivePrompt: "Do the work.",
+    toolAssembly: {
+      ok: true,
+      forkTools: {},
+      availableToolNames: [],
+    },
+    createRunContext: (input) => {
+      createRunContextCalls += 1;
+      assertEquals(input.authToken, "token");
+      assertEquals(input.apiUrl, "https://api.example.com");
+      return createHostedDurableChildForkRunContext({
+        authToken: input.authToken,
+        apiUrl: input.apiUrl,
+        durableChildRun: input.durableChildRun,
+        instrumentation: input.instrumentation,
+        pendingToolLogContext: {
+          conversationId: input.conversationId,
+          parentRunId: input.parentRunId,
+          description: input.description,
+        },
+        pendingToolLogWriter: input.pendingToolLogWriter,
+      });
+    },
+    startRuntime: () => ({
+      forkStreamAbortController: new AbortController(),
+      childRunMonitorAbortController: null,
+      childRunMonitorPromise: Promise.resolve(),
+      forkToolNames: [],
+      streamResult: {
+        fullStream: (async function* () {
+          yield { type: "text-delta", text: "Injected context." } as const;
+        })(),
+        steps: Promise.resolve([
+          {
+            text: "Injected context.",
+            finishReason: "stop",
+            messages: [],
+            toolCalls: [],
+            toolResults: [],
+          },
+        ]),
+        totalUsage: Promise.resolve(undefined),
+      },
+    }),
+  });
+
+  assertEquals(createRunContextCalls, 1);
+  assertEquals(result.success, true);
+  if (result.success) {
+    assertEquals(result.summary.text, "Injected context.");
   }
 });
 

--- a/src/agent/hosted-child-fork-execution-runner.ts
+++ b/src/agent/hosted-child-fork-execution-runner.ts
@@ -60,6 +60,17 @@ export type HostedChildForkExecutionInstrumentation<
   error?: (message: string, metadata?: Record<string, unknown>) => void;
 };
 
+export type HostedChildForkExecutionRunContextFactoryInput = {
+  authToken: string;
+  apiUrl: string;
+  durableChildRun?: HostedChildRunIdentifiers;
+  conversationId?: string;
+  parentRunId?: string;
+  description: string;
+  instrumentation?: HostedChildForkExecutionInstrumentation;
+  pendingToolLogWriter?: { warn: (message: string, metadata?: Record<string, unknown>) => void };
+};
+
 export type ExecuteHostedChildForkWithPreparedToolsInput<
   TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
 > = {
@@ -87,6 +98,9 @@ export type ExecuteHostedChildForkWithPreparedToolsInput<
   buildInstructions?: () => string;
   onBeforeStop?: StartHostedChildForkRuntimeWithHostToolsInput<TAttributes>["onBeforeStop"];
   runStep?: AgentRuntimeForkStepRunner;
+  createRunContext?: (
+    input: HostedChildForkExecutionRunContextFactoryInput,
+  ) => HostedDurableChildForkRunContext;
   startRuntime?: (
     input: StartHostedChildForkRuntimeWithHostToolsInput<TAttributes>,
   ) => StartedHostedChildForkRuntime | Promise<StartedHostedChildForkRuntime>;
@@ -101,16 +115,9 @@ export type ExecuteHostedChildForkWithPreparedToolsInput<
   shouldRethrowError?: (error: unknown) => boolean;
 };
 
-function createForkRunContext(input: {
-  authToken: string;
-  apiUrl: string;
-  durableChildRun?: HostedChildRunIdentifiers;
-  conversationId?: string;
-  parentRunId?: string;
-  description: string;
-  instrumentation?: HostedChildForkExecutionInstrumentation;
-  pendingToolLogWriter?: { warn: (message: string, metadata?: Record<string, unknown>) => void };
-}): HostedDurableChildForkRunContext {
+function createForkRunContext(
+  input: HostedChildForkExecutionRunContextFactoryInput,
+): HostedDurableChildForkRunContext {
   const sourceInstrumentation = input.instrumentation;
   const sourceTrace = sourceInstrumentation?.trace;
   const instrumentation: HostedConversationRunChunkMirrorInstrumentation | undefined =
@@ -159,7 +166,8 @@ export async function executeHostedChildForkWithPreparedTools<
   input: ExecuteHostedChildForkWithPreparedToolsInput<TAttributes>,
 ): Promise<ChildRunExecutionResult> {
   const startTime = input.startTime ?? Date.now();
-  const runContext = createForkRunContext({
+  const createRunContext = input.createRunContext ?? createForkRunContext;
+  const runContext = createRunContext({
     authToken: input.authToken,
     apiUrl: input.apiUrl,
     durableChildRun: input.durableChildRun,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.452";
+export const VERSION = "0.1.453";


### PR DESCRIPTION
## Summary\n- Add a run-context factory injection point to the hosted child fork execution helper\n- Keep the default durable child fork run context behavior unchanged\n- Add focused coverage for the injected run-context seam\n- Restore the ext-tailwind workspace test helper needed by the repo-wide test task\n- Bump package version to 0.1.453\n\n## Verification\n- deno check src/agent/hosted-child-fork-execution-runner.ts src/agent/hosted-child-fork-execution-runner.test.ts src/agent/index.ts\n- deno test --no-check --allow-all src/agent/hosted-child-fork-execution-runner.test.ts\n- deno lint src/agent/hosted-child-fork-execution-runner.ts src/agent/hosted-child-fork-execution-runner.test.ts src/agent/index.ts\n- deno fmt --check deno.json src/utils/version-constant.ts src/agent/hosted-child-fork-execution-runner.ts src/agent/hosted-child-fork-execution-runner.test.ts\n- deno task verify\n- pre-push hook: 1751 passed (17330 steps)