### PR TITLE
Preserve hosted child fork run context instrumentation type

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.453",
+  "version": "0.1.454",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-fork-execution-runner.ts
+++ b/src/agent/hosted-child-fork-execution-runner.ts
@@ -60,14 +60,16 @@ export type HostedChildForkExecutionInstrumentation<
   error?: (message: string, metadata?: Record<string, unknown>) => void;
 };
 
-export type HostedChildForkExecutionRunContextFactoryInput = {
+export type HostedChildForkExecutionRunContextFactoryInput<
+  TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
+> = {
   authToken: string;
   apiUrl: string;
   durableChildRun?: HostedChildRunIdentifiers;
   conversationId?: string;
   parentRunId?: string;
   description: string;
-  instrumentation?: HostedChildForkExecutionInstrumentation;
+  instrumentation?: HostedChildForkExecutionInstrumentation<TAttributes>;
   pendingToolLogWriter?: { warn: (message: string, metadata?: Record<string, unknown>) => void };
 };
 
@@ -99,7 +101,7 @@ export type ExecuteHostedChildForkWithPreparedToolsInput<
   onBeforeStop?: StartHostedChildForkRuntimeWithHostToolsInput<TAttributes>["onBeforeStop"];
   runStep?: AgentRuntimeForkStepRunner;
   createRunContext?: (
-    input: HostedChildForkExecutionRunContextFactoryInput,
+    input: HostedChildForkExecutionRunContextFactoryInput<TAttributes>,
   ) => HostedDurableChildForkRunContext;
   startRuntime?: (
     input: StartHostedChildForkRuntimeWithHostToolsInput<TAttributes>,
@@ -115,8 +117,10 @@ export type ExecuteHostedChildForkWithPreparedToolsInput<
   shouldRethrowError?: (error: unknown) => boolean;
 };
 
-function createForkRunContext(
-  input: HostedChildForkExecutionRunContextFactoryInput,
+function createForkRunContext<
+  TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
+>(
+  input: HostedChildForkExecutionRunContextFactoryInput<TAttributes>,
 ): HostedDurableChildForkRunContext {
   const sourceInstrumentation = input.instrumentation;
   const sourceTrace = sourceInstrumentation?.trace;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.453";
+export const VERSION = "0.1.454";


### PR DESCRIPTION
## Summary
- preserve the hosted child fork run context factory instrumentation generic
- keep custom run-context factories aligned with the hosted child fork execution helper's trace attribute type
- bump the framework patch version to 0.1.454 for publication

## Verification
- deno check src/agent/hosted-child-fork-execution-runner.ts src/agent/hosted-child-fork-execution-runner.test.ts src/agent/index.ts
- deno test --no-check --allow-all src/agent/hosted-child-fork-execution-runner.test.ts
- deno lint src/agent/hosted-child-fork-execution-runner.ts src/agent/hosted-child-fork-execution-runner.test.ts src/agent/index.ts
- deno fmt --check deno.json src/utils/version-constant.ts src/agent/hosted-child-fork-execution-runner.ts src/agent/hosted-child-fork-execution-runner.test.ts
- git diff --check
- deno task verify
- pre-push checks