### PR TITLE
Type hosted child fork execution trace attributes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.454",
+  "version": "0.1.455",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-fork-execution-runner.ts
+++ b/src/agent/hosted-child-fork-execution-runner.ts
@@ -30,7 +30,10 @@ import type {
   ChildRunExecutionResult,
   ChildRunExecutionSnapshot,
 } from "./child-run-execution-snapshot.ts";
-import type { HostedConversationRunChunkMirrorInstrumentation } from "./conversation-run-chunk-mirror.ts";
+import type {
+  HostedConversationRunChunkMirrorInstrumentation,
+  HostedConversationRunChunkMirrorTraceAttributes,
+} from "./conversation-run-chunk-mirror.ts";
 import type { HostedChildExecutionLogEntry } from "./hosted-child-execution-logging.ts";
 import type {
   HostedChildForkStreamLogger,
@@ -49,7 +52,9 @@ export type HostedChildForkExecutionInstrumentation<
   TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
 > = {
   trace?: <TResult>(operationName: string, operation: () => TResult) => TResult;
-  setTraceAttributes?: (attributes: Record<string, unknown>) => void;
+  setTraceAttributes?: (
+    attributes: TAttributes | HostedConversationRunChunkMirrorTraceAttributes,
+  ) => void;
   buildToolTraceAttributes?: (input: {
     toolName: string;
     toolCallId: string | undefined;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.454";
+export const VERSION = "0.1.455";


### PR DESCRIPTION
## Summary
- preserve the hosted child fork execution trace attribute type through the trace sink
- allow hosted child fork execution callers to use stricter trace attribute sinks while still supporting conversation mirror attributes
- bump the framework patch version to 0.1.455 for publication

## Verification
- deno check src/agent/hosted-child-fork-execution-runner.ts src/agent/index.ts
- deno test --no-check --allow-all src/agent/hosted-child-fork-execution-runner.test.ts
- deno lint src/agent/hosted-child-fork-execution-runner.ts src/agent/hosted-child-fork-execution-runner.test.ts src/agent/index.ts
- deno fmt --check deno.json src/utils/version-constant.ts src/agent/hosted-child-fork-execution-runner.ts src/agent/hosted-child-fork-execution-runner.test.ts
- pre-push checks

## Note
- Local deno task verify currently fails in unrelated repo-wide server/RSC tests because the harness treats existing EnvironmentConfig early-access warnings as fatal. This patch's focused checks and pre-push checks pass; PR CI is the full gate.