### PR TITLE
Add hosted child fork tool input runner

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.455",
+  "version": "0.1.456",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-fork-execution-runner.test.ts
+++ b/src/agent/hosted-child-fork-execution-runner.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_HOSTED_CHILD_FORK_STREAM_IDLE_TIMEOUT_MS,
   DEFAULT_HOSTED_CHILD_FORK_STREAM_POST_TOOL_IDLE_TIMEOUT_MS,
   DEFAULT_HOSTED_CHILD_STATUS_POLL_INTERVAL_MS,
+  executeHostedChildForkToolInput,
   executeHostedChildForkWithPreparedTools,
 } from "./hosted-child-fork-execution-runner.ts";
 import { createHostedDurableChildForkRunContext } from "./hosted-child-fork-run-context.ts";
@@ -261,6 +262,97 @@ Deno.test("executeHostedChildForkWithPreparedTools allows injecting the run cont
   assertEquals(result.success, true);
   if (result.success) {
     assertEquals(result.summary.text, "Injected context.");
+  }
+});
+
+Deno.test("executeHostedChildForkToolInput resolves runtime config and prepares tools", async () => {
+  const callbacks: string[] = [];
+
+  const result = await executeHostedChildForkToolInput({
+    authToken: "token",
+    apiUrl: "https://api.example.com",
+    projectId: "project-1",
+    kind: "invoke_agent",
+    forkInput: {
+      description: "Review checkout",
+      prompt: "Review the checkout flow.",
+      project_id: "project-2",
+      tools: ["noop"],
+      model: "sonnet",
+      thinking: 256,
+      max_steps: 7,
+    },
+    toolCallId: "tool-call-1",
+    defaultModel: "haiku",
+    defaultMaxSteps: 80,
+    contextModel: "opus",
+    onRequestedProjectId: (projectId) => {
+      callbacks.push(`project:${projectId}`);
+    },
+    resolveModelId: (modelId) => `resolved-${modelId}`,
+    resolveProvider: (modelId) => `provider-${modelId}`,
+    resolveProviderOptions: (forkModel, thinkingConfig) => ({
+      forkModel,
+      thinkingConfig,
+    }),
+    onRuntimeConfig: (runtimeConfig) => {
+      callbacks.push(`runtime:${runtimeConfig.forkModel}`);
+    },
+    prepareToolAssembly: ({ runtimeConfig, requestedTools }) => {
+      callbacks.push(`tools:${requestedTools?.join(",") ?? "all"}`);
+      assertEquals(runtimeConfig.description, "Review checkout");
+      assertEquals(runtimeConfig.forkModel, "resolved-sonnet");
+      assertEquals(runtimeConfig.provider, "provider-resolved-sonnet");
+      assertEquals(runtimeConfig.maxSteps, 7);
+      assertEquals(runtimeConfig.thinkingConfig, { enabled: true, budgetTokens: 256 });
+      assertEquals(runtimeConfig.effectivePrompt.includes("Review the checkout flow."), true);
+      return {
+        ok: true,
+        forkTools: {},
+        availableToolNames: [],
+      };
+    },
+    startRuntime: (input) => {
+      callbacks.push(`start:${input.forkModel}`);
+      assertEquals(input.provider, "provider-resolved-sonnet");
+      assertEquals(input.maxSteps, 7);
+      assertEquals(input.providerOptions, {
+        forkModel: "resolved-sonnet",
+        thinkingConfig: { enabled: true, budgetTokens: 256 },
+      });
+      return {
+        forkStreamAbortController: new AbortController(),
+        childRunMonitorAbortController: null,
+        childRunMonitorPromise: Promise.resolve(),
+        forkToolNames: [],
+        streamResult: {
+          fullStream: (async function* () {
+            yield { type: "text-delta", text: "Resolved." } as const;
+          })(),
+          steps: Promise.resolve([
+            {
+              text: "Resolved.",
+              finishReason: "stop",
+              messages: [],
+              toolCalls: [],
+              toolResults: [],
+            },
+          ]),
+          totalUsage: Promise.resolve(undefined),
+        },
+      };
+    },
+  });
+
+  assertEquals(callbacks, [
+    "project:project-2",
+    "runtime:resolved-sonnet",
+    "tools:noop",
+    "start:resolved-sonnet",
+  ]);
+  assertEquals(result.success, true);
+  if (result.success) {
+    assertEquals(result.summary.text, "Resolved.");
   }
 });
 

--- a/src/agent/hosted-child-fork-execution-runner.ts
+++ b/src/agent/hosted-child-fork-execution-runner.ts
@@ -41,6 +41,12 @@ import type {
 } from "./hosted-child-fork-stream-execution.ts";
 import type { HostedChildRunIdentifiers } from "./hosted-child-status.ts";
 import { throwIfChildRunAborted } from "./child-run-execution-support.ts";
+import {
+  type HostedChildForkRuntimeConfig,
+  type HostedChildForkToolInput,
+  resolveHostedChildForkRuntimeConfig,
+  type ResolveHostedChildForkRuntimeConfigInput,
+} from "./hosted-child-tool-input.ts";
 
 export const DEFAULT_HOSTED_CHILD_FORK_STREAM_IDLE_TIMEOUT_MS = 45_000;
 export const DEFAULT_HOSTED_CHILD_FORK_STREAM_ACTIVE_TOOL_TIMEOUT_MS = 5 * 60_000;
@@ -167,6 +173,84 @@ function defaultResolveSystem(input: {
 
   const remindedSystem = addLoadSkillContinuationReminder(input.system);
   return typeof remindedSystem === "string" ? remindedSystem : input.system;
+}
+
+export type ExecuteHostedChildForkToolInputOptions<
+  TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
+> =
+  & Omit<
+    ExecuteHostedChildForkWithPreparedToolsInput<TAttributes>,
+    | "description"
+    | "provider"
+    | "forkModel"
+    | "maxSteps"
+    | "effectivePrompt"
+    | "toolAssembly"
+    | "providerOptions"
+  >
+  & {
+    forkInput: HostedChildForkToolInput;
+    toolCallId: string;
+    defaultModel: string;
+    defaultMaxSteps: number;
+    contextModel?: string;
+    onRequestedProjectId?: (projectId: string) => void | Promise<void>;
+    prepareToolAssembly: (input: {
+      runtimeConfig: HostedChildForkRuntimeConfig;
+      requestedTools?: HostedChildForkToolInput["tools"];
+      abortSignal?: AbortSignal;
+    }) =>
+      | DefaultHostedChildForkToolAssemblyResult
+      | Promise<DefaultHostedChildForkToolAssemblyResult>;
+    resolveModelId: ResolveHostedChildForkRuntimeConfigInput["resolveModelId"];
+    resolveProvider: ResolveHostedChildForkRuntimeConfigInput["resolveProvider"];
+    resolveProviderOptions?: (
+      forkModel: string,
+      thinkingConfig: HostedChildForkRuntimeConfig["thinkingConfig"],
+    ) => Record<string, unknown> | undefined;
+    onRuntimeConfig?: (runtimeConfig: HostedChildForkRuntimeConfig) => void | Promise<void>;
+  };
+
+export async function executeHostedChildForkToolInput<
+  TAttributes extends HostToolTraceAttributes = HostToolTraceAttributes,
+>(
+  input: ExecuteHostedChildForkToolInputOptions<TAttributes>,
+): Promise<ChildRunExecutionResult> {
+  if (input.forkInput.project_id) {
+    await input.onRequestedProjectId?.(input.forkInput.project_id);
+  }
+
+  const runtimeConfig = resolveHostedChildForkRuntimeConfig({
+    forkInput: input.forkInput,
+    contextModel: input.contextModel,
+    defaultModel: input.defaultModel,
+    defaultMaxSteps: input.defaultMaxSteps,
+    runId: input.durableChildRun?.childRunId ?? input.toolCallId,
+    resolveModelId: input.resolveModelId,
+    resolveProvider: input.resolveProvider,
+  });
+
+  await input.onRuntimeConfig?.(runtimeConfig);
+
+  const toolAssembly = await input.prepareToolAssembly({
+    runtimeConfig,
+    requestedTools: runtimeConfig.requestedTools,
+    abortSignal: input.abortSignal,
+  });
+
+  return executeHostedChildForkWithPreparedTools({
+    ...input,
+    description: runtimeConfig.description,
+    provider: runtimeConfig.provider,
+    forkModel: runtimeConfig.forkModel,
+    maxSteps: runtimeConfig.maxSteps,
+    effectivePrompt: runtimeConfig.effectivePrompt,
+    toolAssembly,
+    providerOptions: input.resolveProviderOptions?.(
+      runtimeConfig.forkModel,
+      runtimeConfig.thinkingConfig,
+    ),
+  });
 }
 
 export async function executeHostedChildForkWithPreparedTools<

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -494,6 +494,8 @@ export {
   DEFAULT_HOSTED_CHILD_FORK_STREAM_IDLE_TIMEOUT_MS,
   DEFAULT_HOSTED_CHILD_FORK_STREAM_POST_TOOL_IDLE_TIMEOUT_MS,
   DEFAULT_HOSTED_CHILD_STATUS_POLL_INTERVAL_MS,
+  executeHostedChildForkToolInput,
+  type ExecuteHostedChildForkToolInputOptions,
   executeHostedChildForkWithPreparedTools,
   type ExecuteHostedChildForkWithPreparedToolsInput,
   type HostedChildForkExecutionInstrumentation,

--- a/src/observability/tracing/otlp-setup.ts
+++ b/src/observability/tracing/otlp-setup.ts
@@ -12,7 +12,8 @@
  * - OTEL_EXPORTER_OTLP_HEADERS: Auth headers
  **************************/
 
-import { getOtelTracingConfig } from "#veryfront/config/env.ts";
+import { getEnv } from "#veryfront/platform/compat/process.ts";
+import { isTruthyEnvValue } from "#veryfront/utils/constants/env.ts";
 import { serverLogger } from "#veryfront/utils";
 import {
   type Context,
@@ -55,13 +56,15 @@ function parseHeaders(headerString: string | undefined): Record<string, string> 
 }
 
 function getConfig(): OTLPConfig {
-  const tracingConfig = getOtelTracingConfig();
-
+  // Span helpers can run during module initialization and test setup, before
+  // bootstrap has loaded .env files. Read tracing env directly here so no-op
+  // spans do not force early EnvironmentConfig initialization.
   return {
-    enabled: tracingConfig.enabledFlag === "true",
-    serviceName: tracingConfig.serviceName || "veryfront",
-    endpoint: tracingConfig.endpoint || "",
-    headers: parseHeaders(tracingConfig.headers),
+    enabled: isTruthyEnvValue(getEnv("VERYFRONT_OTEL")) ||
+      isTruthyEnvValue(getEnv("OTEL_TRACES_ENABLED")),
+    serviceName: getEnv("OTEL_SERVICE_NAME") || "veryfront",
+    endpoint: getEnv("OTEL_EXPORTER_OTLP_ENDPOINT") || "",
+    headers: parseHeaders(getEnv("OTEL_EXPORTER_OTLP_HEADERS")),
   };
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.455";
+export const VERSION = "0.1.456";


### PR DESCRIPTION
## Summary
- add a hosted child fork helper that resolves tool input runtime config, prepares host-provided tools, and delegates to the existing prepared-tools executor
- export the helper and options type from the agent package surface
- avoid early EnvironmentConfig access from OTLP span helpers by reading tracing env directly before bootstrap
- bump package version to 0.1.456

## Verification
- deno check src/observability/tracing/otlp-setup.ts src/agent/hosted-child-fork-execution-runner.ts src/agent/index.ts
- deno test --no-check --allow-all src/agent/hosted-child-fork-execution-runner.test.ts tests/integration/server/start-veryfront-server.test.ts tests/integration/server/rsc/streaming-dom.test.ts
- deno lint src/observability/tracing/otlp-setup.ts src/agent/hosted-child-fork-execution-runner.ts src/agent/hosted-child-fork-execution-runner.test.ts src/agent/index.ts
- deno fmt --check src/observability/tracing/otlp-setup.ts src/agent/hosted-child-fork-execution-runner.ts src/agent/hosted-child-fork-execution-runner.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts
- deno task verify
- pre-push checks