### PR TITLE
Add hosted chat preparation helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.456",
+  "version": "0.1.457",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-chat-preparation.test.ts
+++ b/src/agent/hosted-chat-preparation.test.ts
@@ -1,0 +1,154 @@
+import { assertEquals } from "../testing/assert.ts";
+import type { ChatUiMessage } from "#veryfront/chat/types.ts";
+import type { ParsedHostedChatRequest } from "./hosted-chat-request-parser.ts";
+import {
+  normalizeParsedHostedChatRequest,
+  prepareHostedChatRuntimeMessages,
+} from "./hosted-chat-preparation.ts";
+
+const userMessage: ChatUiMessage = {
+  id: "user-message-1",
+  role: "user",
+  parts: [{ type: "text", text: "Hello" }],
+};
+
+const assistantMessage: ChatUiMessage = {
+  id: "assistant-message-1",
+  role: "assistant",
+  parts: [{ type: "text", text: "Hi" }],
+};
+
+function createParsedHostedChatRequest(
+  overrides: Partial<ParsedHostedChatRequest> = {},
+): ParsedHostedChatRequest {
+  return {
+    userId: "user-1",
+    authToken: "auth-token",
+    messages: [userMessage],
+    validatedContext: {
+      conversationId: "conversation-from-context",
+      projectId: "project-from-context",
+      branchId: "branch-from-context",
+    },
+    projectId: "project-from-context",
+    conversationId: "conversation-from-context",
+    parentRunId: undefined,
+    upstreamParentConversationId: undefined,
+    upstreamParentRunId: undefined,
+    spawnedFromToolCallId: undefined,
+    model: undefined,
+    allowDelegation: undefined,
+    forwardedProps: undefined,
+    runtimeOverrides: undefined,
+    durableRootRun: undefined,
+    persistLatestUserMessageBeforeDurableRun: false,
+    ...overrides,
+  };
+}
+
+Deno.test("normalizeParsedHostedChatRequest uses the latest user message as parent message id", () => {
+  const secondUserMessage: ChatUiMessage = {
+    id: "user-message-2",
+    role: "user",
+    parts: [{ type: "text", text: "Continue" }],
+  };
+  const messages = [userMessage, assistantMessage, secondUserMessage];
+
+  const normalized = normalizeParsedHostedChatRequest(
+    createParsedHostedChatRequest({ messages }),
+  );
+
+  assertEquals(normalized.effectiveMessages, messages);
+  assertEquals(normalized.parentMessageId, "user-message-2");
+});
+
+Deno.test("normalizeParsedHostedChatRequest keeps validated context ahead of top-level values", () => {
+  const normalized = normalizeParsedHostedChatRequest(
+    createParsedHostedChatRequest({
+      projectId: "project-top-level",
+      conversationId: "conversation-top-level",
+      validatedContext: {
+        projectId: "project-context",
+        conversationId: "conversation-context",
+        branchId: "branch-context",
+        environmentContext: "runtime env",
+      },
+    }),
+  );
+
+  assertEquals(normalized.effectiveValidatedContext, {
+    projectId: "project-context",
+    conversationId: "conversation-context",
+    branchId: "branch-context",
+    environmentContext: "runtime env",
+  });
+});
+
+Deno.test("normalizeParsedHostedChatRequest falls back to top-level context values", () => {
+  const normalized = normalizeParsedHostedChatRequest(
+    createParsedHostedChatRequest({
+      projectId: "project-top-level",
+      conversationId: "conversation-top-level",
+      validatedContext: {
+        projectId: null,
+        branchId: null,
+      },
+    }),
+  );
+
+  assertEquals(normalized.effectiveValidatedContext, {
+    projectId: "project-top-level",
+    conversationId: "conversation-top-level",
+    branchId: null,
+  });
+});
+
+Deno.test("prepareHostedChatRuntimeMessages refreshes uploaded file URLs through the hosted API", async () => {
+  const requestedUrls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input, _init): Promise<Response> => {
+    requestedUrls.push(input.toString());
+    return Promise.resolve(
+      new Response(JSON.stringify({ signed_url: "https://signed.example.com/notes.txt" }), {
+        status: 200,
+      }),
+    );
+  };
+
+  try {
+    const messages = await prepareHostedChatRuntimeMessages([
+      {
+        id: "message-1",
+        role: "user",
+        parts: [
+          { type: "text", text: "Use this file." },
+          {
+            type: "file",
+            mediaType: "text/plain",
+            filename: "notes.txt",
+            uploadId: "upload-1",
+            url: "https://files.example.com/original.txt",
+          },
+        ],
+      },
+    ], {
+      apiUrl: "https://api.example.com",
+      authToken: "token-1",
+      projectId: "project-1",
+    });
+
+    assertEquals(requestedUrls, [
+      "https://api.example.com/projects/project-1/uploads/upload-1/url",
+    ]);
+    assertEquals(
+      messages[0]?.parts.some((part) =>
+        part.type === "file" &&
+        part.url === "https://signed.example.com/notes.txt" &&
+        part.mediaType === "text/plain"
+      ),
+      true,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/src/agent/hosted-chat-preparation.ts
+++ b/src/agent/hosted-chat-preparation.ts
@@ -1,0 +1,71 @@
+import type { ChatRequestContext, ChatUiMessage } from "#veryfront/chat/types.ts";
+import type { AgentRuntimeMessage } from "./agent-runtime-message-adapter.ts";
+import type { ParsedHostedChatRequest } from "./hosted-chat-request-parser.ts";
+import {
+  prepareAgentRuntimeMessagesFromUiMessages,
+  type PrepareAgentRuntimeMessagesFromUiMessagesOptions,
+} from "./runtime-message-preparation.ts";
+import { getRuntimeUploadUrl } from "./runtime-upload-url-client.ts";
+
+export type NormalizedHostedChatRequest = {
+  effectiveMessages: ChatUiMessage[];
+  effectiveValidatedContext: ChatRequestContext;
+  parentMessageId: string | undefined;
+};
+
+export type PrepareHostedChatRuntimeMessagesOptions =
+  & Pick<
+    PrepareAgentRuntimeMessagesFromUiMessagesOptions,
+    "emptyConversationPrompt"
+  >
+  & {
+    authToken?: string;
+    apiUrl?: string | URL;
+    projectId?: string | null;
+  };
+
+export function normalizeParsedHostedChatRequest(
+  request: ParsedHostedChatRequest,
+): NormalizedHostedChatRequest {
+  const effectiveMessages = request.messages;
+  const validatedContext = request.validatedContext;
+  const conversationId = validatedContext.conversationId ?? request.conversationId;
+  const effectiveValidatedContext: ChatRequestContext = {
+    ...validatedContext,
+    projectId: validatedContext.projectId ?? request.projectId,
+    branchId: validatedContext.branchId ?? null,
+    ...(conversationId ? { conversationId } : {}),
+  };
+
+  return {
+    effectiveMessages,
+    effectiveValidatedContext,
+    parentMessageId: effectiveMessages.findLast((message) => message.role === "user")?.id,
+  };
+}
+
+export async function prepareHostedChatRuntimeMessages(
+  messages: readonly ChatUiMessage[],
+  options: PrepareHostedChatRuntimeMessagesOptions = {},
+): Promise<AgentRuntimeMessage[]> {
+  if (!options.authToken || !options.apiUrl) {
+    return await prepareAgentRuntimeMessagesFromUiMessages({
+      messages,
+      emptyConversationPrompt: options.emptyConversationPrompt,
+    });
+  }
+  const authToken = options.authToken;
+  const apiUrl = options.apiUrl;
+
+  return await prepareAgentRuntimeMessagesFromUiMessages({
+    messages,
+    emptyConversationPrompt: options.emptyConversationPrompt,
+    resolveFileUrl: ({ uploadId }) =>
+      getRuntimeUploadUrl({
+        apiUrl,
+        authToken,
+        uploadId,
+        projectId: options.projectId,
+      }),
+  });
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -679,6 +679,12 @@ export {
   type PrepareAgentRuntimeMessagesFromUiMessagesOptions,
 } from "./runtime-message-preparation.ts";
 export {
+  type NormalizedHostedChatRequest,
+  normalizeParsedHostedChatRequest,
+  prepareHostedChatRuntimeMessages,
+  type PrepareHostedChatRuntimeMessagesOptions,
+} from "./hosted-chat-preparation.ts";
+export {
   getRuntimeUploadUrl,
   type RuntimeUploadUrlClientOptions,
   type RuntimeUploadUrlFetch,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.456";
+export const VERSION = "0.1.457";


### PR DESCRIPTION
## Summary
- add shared hosted chat request normalization for separately deployed agent services
- add shared hosted chat runtime message preparation with signed upload URL refresh
- bump package version to 0.1.457 for CI/CD publication

## Verification
- deno check src/agent/hosted-chat-preparation.ts src/agent/index.ts
- deno test --no-check --allow-all src/agent/hosted-chat-preparation.test.ts src/agent/runtime-message-preparation.test.ts src/agent/runtime-upload-url-client.test.ts
- deno task verify
- pre-push checks