### PR TITLE
Add hosted chat runtime creation preparation

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.457",
+  "version": "0.1.458",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-chat-preparation.test.ts
+++ b/src/agent/hosted-chat-preparation.test.ts
@@ -3,6 +3,7 @@ import type { ChatUiMessage } from "#veryfront/chat/types.ts";
 import type { ParsedHostedChatRequest } from "./hosted-chat-request-parser.ts";
 import {
   normalizeParsedHostedChatRequest,
+  prepareHostedChatRuntimeCreationOptions,
   prepareHostedChatRuntimeMessages,
 } from "./hosted-chat-preparation.ts";
 
@@ -101,6 +102,120 @@ Deno.test("normalizeParsedHostedChatRequest falls back to top-level context valu
     conversationId: "conversation-top-level",
     branchId: null,
   });
+});
+
+Deno.test("prepareHostedChatRuntimeCreationOptions builds runtime options from request, steering, and root context", async () => {
+  const skill = {
+    id: "debug",
+    name: "Debug",
+    description: "Debug failures",
+    instructions: "Use a systematic debugging workflow.",
+    allowedTools: ["bash"],
+  };
+  const fetchInputs: Array<{
+    projectId: string | null;
+    authToken: string;
+    branchId?: string | null;
+  }> = [];
+  const parentEvents: unknown[] = [];
+
+  const result = await prepareHostedChatRuntimeCreationOptions({
+    request: createParsedHostedChatRequest({
+      allowDelegation: false,
+      model: "requested-model",
+      runtimeOverrides: {
+        allowedTools: ["load_skill"],
+        thinking: false,
+        maxSteps: 7,
+      },
+    }),
+    agentConfig: {
+      id: "agent-1",
+      model: "configured-model",
+      thinking: { enabled: true, budgetTokens: 1000 },
+      maxSteps: 50,
+    },
+    projectId: "project-1",
+    authToken: "token-1",
+    conversationId: "conversation-1",
+    branchId: "branch-1",
+    environmentContext: "Browser workspace",
+    rootRunContext: {
+      effectiveParentRunId: "run-1",
+      effectiveParentMessageId: "message-1",
+      publishParentRunEvents: (events) => {
+        parentEvents.push(...events);
+        return Promise.resolve();
+      },
+    },
+    resolveModelId: (modelId) => modelId ? `resolved:${modelId}` : undefined,
+    resolveModelThinking: (modelId) => modelId ? { enabled: true, budgetTokens: 1234 } : undefined,
+    fetchSteering: (input) => {
+      fetchInputs.push(input);
+      return Promise.resolve({
+        instructions: "Project instructions",
+        skills: [skill],
+      });
+    },
+    buildInstructions: (input) => [
+      {
+        role: "system",
+        content: [
+          input.agentConfig.id,
+          input.instructions,
+          input.skills.map((entry) => entry.id).join(","),
+          input.projectId,
+          input.branchId,
+          input.environmentContext,
+        ].filter((value): value is string => typeof value === "string").join("|"),
+      },
+    ],
+  });
+
+  assertEquals(fetchInputs, [
+    {
+      projectId: "project-1",
+      authToken: "token-1",
+      branchId: "branch-1",
+    },
+  ]);
+  assertEquals(result.runtimeConfig.requestedModel, "resolved:requested-model");
+  assertEquals(result.creationOptions, {
+    projectId: "project-1",
+    authToken: "token-1",
+    instructions: [
+      {
+        role: "system",
+        content: "agent-1|Project instructions|debug|project-1|branch-1|Browser workspace",
+      },
+    ],
+    branchId: "branch-1",
+    model: "resolved:requested-model",
+    thinking: { enabled: false },
+    maxSteps: 7,
+    allowedTools: ["load_skill"],
+    allowDelegation: false,
+    conversationId: "conversation-1",
+    parentRunId: "run-1",
+    parentMessageId: "message-1",
+    availableSkillIds: ["debug"],
+    publishParentRunEvents: result.creationOptions.publishParentRunEvents,
+    clientProfile: null,
+    liveProjectSteering: {
+      agent: {
+        id: "agent-1",
+        model: "configured-model",
+        thinking: { enabled: true, budgetTokens: 1000 },
+        maxSteps: 50,
+      },
+      environmentContext: "Browser workspace",
+      initialProjectInstructions: "Project instructions",
+      initialSkills: [skill],
+    },
+  });
+
+  await result.creationOptions.publishParentRunEvents?.([{ type: "state_delta" }]);
+  assertEquals(parentEvents, [{ type: "state_delta" }]);
 });
 
 Deno.test("prepareHostedChatRuntimeMessages refreshes uploaded file URLs through the hosted API", async () => {

--- a/src/agent/hosted-chat-preparation.ts
+++ b/src/agent/hosted-chat-preparation.ts
@@ -1,11 +1,26 @@
-import type { ChatRequestContext, ChatUiMessage } from "#veryfront/chat/types.ts";
+import type {
+  ChatRequestContext,
+  ChatSystemMessage,
+  ChatUiMessage,
+} from "#veryfront/chat/types.ts";
 import type { AgentRuntimeMessage } from "./agent-runtime-message-adapter.ts";
+import type { ConversationRunEvent } from "./conversation-run-events.ts";
+import type {
+  HostedChatRuntimeCreationOptions,
+  HostedChatRuntimeProjectSteering,
+} from "./hosted-chat-runtime-contract.ts";
 import type { ParsedHostedChatRequest } from "./hosted-chat-request-parser.ts";
 import {
   prepareAgentRuntimeMessagesFromUiMessages,
   type PrepareAgentRuntimeMessagesFromUiMessagesOptions,
 } from "./runtime-message-preparation.ts";
+import type { RuntimeAgentThinkingConfig } from "./runtime-agent-definition.ts";
+import {
+  type ResolvedHostedRuntimeRequestConfig,
+  resolveHostedRuntimeRequestConfig,
+} from "./hosted-runtime-request-config.ts";
 import { getRuntimeUploadUrl } from "./runtime-upload-url-client.ts";
+import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
 
 export type NormalizedHostedChatRequest = {
   effectiveMessages: ChatUiMessage[];
@@ -24,6 +39,64 @@ export type PrepareHostedChatRuntimeMessagesOptions =
     projectId?: string | null;
   };
 
+export type HostedChatRuntimePreparationRootRunContext = {
+  effectiveParentRunId?: string;
+  effectiveParentMessageId?: string;
+  publishParentRunEvents?: (events: ConversationRunEvent[]) => Promise<void>;
+};
+
+export type HostedChatRuntimePreparationSteering = {
+  instructions: string;
+  skills: RuntimeSkillDefinition[];
+};
+
+export type HostedChatRuntimeInstructionsInput<TRuntimeAgentDefinition> = {
+  agentConfig: TRuntimeAgentDefinition;
+  projectId: string | null;
+  branchId?: string | null;
+  environmentContext?: string;
+  instructions: string;
+  skills: RuntimeSkillDefinition[];
+};
+
+export type HostedChatRuntimeCreationPreparationInput<TRuntimeAgentDefinition> = {
+  request: ParsedHostedChatRequest;
+  agentConfig: TRuntimeAgentDefinition & {
+    model?: string;
+    thinking?: RuntimeAgentThinkingConfig;
+    maxSteps?: number;
+  };
+  projectId: string | null;
+  authToken: string;
+  conversationId?: string;
+  branchId?: string | null;
+  environmentContext?: string;
+  rootRunContext?: HostedChatRuntimePreparationRootRunContext;
+  resolveModelId: (modelId: string | undefined) => string | undefined;
+  resolveModelThinking?: (
+    modelId: string | undefined,
+  ) => RuntimeAgentThinkingConfig | undefined;
+  fetchSteering: (input: {
+    projectId: string | null;
+    authToken: string;
+    branchId?: string | null;
+  }) => Promise<HostedChatRuntimePreparationSteering>;
+  buildInstructions: (
+    input: HostedChatRuntimeInstructionsInput<TRuntimeAgentDefinition>,
+  ) => string | ChatSystemMessage[];
+};
+
+export type HostedChatRuntimeCreationPreparationResult<TRuntimeAgentDefinition> = {
+  creationOptions: HostedChatRuntimeCreationOptions<
+    TRuntimeAgentDefinition,
+    RuntimeAgentThinkingConfig
+  >;
+  steering: HostedChatRuntimePreparationSteering & {
+    agentInstructions: string | ChatSystemMessage[];
+  };
+  runtimeConfig: ResolvedHostedRuntimeRequestConfig;
+};
+
 export function normalizeParsedHostedChatRequest(
   request: ParsedHostedChatRequest,
 ): NormalizedHostedChatRequest {
@@ -41,6 +114,89 @@ export function normalizeParsedHostedChatRequest(
     effectiveMessages,
     effectiveValidatedContext,
     parentMessageId: effectiveMessages.findLast((message) => message.role === "user")?.id,
+  };
+}
+
+function buildHostedChatRuntimeProjectSteering<TRuntimeAgentDefinition>(input: {
+  agentConfig: TRuntimeAgentDefinition;
+  environmentContext?: string;
+  instructions: string;
+  skills: RuntimeSkillDefinition[];
+}): HostedChatRuntimeProjectSteering<TRuntimeAgentDefinition> {
+  return {
+    agent: input.agentConfig,
+    ...(input.environmentContext ? { environmentContext: input.environmentContext } : {}),
+    ...(input.instructions ? { initialProjectInstructions: input.instructions } : {}),
+    ...(input.skills.length > 0 ? { initialSkills: input.skills } : {}),
+  };
+}
+
+export async function prepareHostedChatRuntimeCreationOptions<
+  TRuntimeAgentDefinition,
+>(
+  input: HostedChatRuntimeCreationPreparationInput<TRuntimeAgentDefinition>,
+): Promise<HostedChatRuntimeCreationPreparationResult<TRuntimeAgentDefinition>> {
+  const steering = await input.fetchSteering({
+    projectId: input.projectId,
+    authToken: input.authToken,
+    branchId: input.branchId,
+  });
+  const agentInstructions = input.buildInstructions({
+    agentConfig: input.agentConfig,
+    projectId: input.projectId,
+    branchId: input.branchId,
+    environmentContext: input.environmentContext,
+    instructions: steering.instructions,
+    skills: steering.skills,
+  });
+  const runtimeConfig = resolveHostedRuntimeRequestConfig({
+    request: input.request,
+    agentConfig: input.agentConfig,
+    resolveModelId: input.resolveModelId,
+    resolveModelThinking: input.resolveModelThinking,
+  });
+
+  return {
+    creationOptions: {
+      projectId: input.projectId,
+      authToken: input.authToken,
+      instructions: agentInstructions,
+      ...(input.branchId !== undefined ? { branchId: input.branchId } : {}),
+      ...(runtimeConfig.requestedModel ? { model: runtimeConfig.requestedModel } : {}),
+      ...(runtimeConfig.requestedThinking ? { thinking: runtimeConfig.requestedThinking } : {}),
+      ...(runtimeConfig.requestedMaxSteps !== undefined
+        ? { maxSteps: runtimeConfig.requestedMaxSteps }
+        : {}),
+      ...(runtimeConfig.effectiveRuntimeOverrides?.allowedTools
+        ? { allowedTools: runtimeConfig.effectiveRuntimeOverrides.allowedTools }
+        : {}),
+      ...(input.request.allowDelegation !== undefined
+        ? { allowDelegation: input.request.allowDelegation }
+        : {}),
+      ...(input.conversationId ? { conversationId: input.conversationId } : {}),
+      ...(input.rootRunContext?.effectiveParentRunId
+        ? { parentRunId: input.rootRunContext.effectiveParentRunId }
+        : {}),
+      ...(input.rootRunContext?.effectiveParentMessageId
+        ? { parentMessageId: input.rootRunContext.effectiveParentMessageId }
+        : {}),
+      availableSkillIds: steering.skills.map((skill) => skill.id),
+      ...(input.rootRunContext?.publishParentRunEvents
+        ? { publishParentRunEvents: input.rootRunContext.publishParentRunEvents }
+        : {}),
+      clientProfile: runtimeConfig.clientProfile,
+      liveProjectSteering: buildHostedChatRuntimeProjectSteering({
+        agentConfig: input.agentConfig,
+        environmentContext: input.environmentContext,
+        instructions: steering.instructions,
+        skills: steering.skills,
+      }),
+    },
+    steering: {
+      ...steering,
+      agentInstructions,
+    },
+    runtimeConfig,
   };
 }
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -679,8 +679,14 @@ export {
   type PrepareAgentRuntimeMessagesFromUiMessagesOptions,
 } from "./runtime-message-preparation.ts";
 export {
+  type HostedChatRuntimeCreationPreparationInput,
+  type HostedChatRuntimeCreationPreparationResult,
+  type HostedChatRuntimeInstructionsInput,
+  type HostedChatRuntimePreparationRootRunContext,
+  type HostedChatRuntimePreparationSteering,
   type NormalizedHostedChatRequest,
   normalizeParsedHostedChatRequest,
+  prepareHostedChatRuntimeCreationOptions,
   prepareHostedChatRuntimeMessages,
   type PrepareHostedChatRuntimeMessagesOptions,
 } from "./hosted-chat-preparation.ts";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.457";
+export const VERSION = "0.1.458";


### PR DESCRIPTION
## Summary\n- add a reusable hosted chat runtime creation preparation helper\n- return resolved request runtime config, steering, and framework runtime creation options\n- bump package version to 0.1.458 for CI/CD release\n\n## Verification\n- deno check src/agent/hosted-chat-preparation.ts src/agent/index.ts\n- deno test --no-check --allow-all src/agent/hosted-chat-preparation.test.ts\n- deno task verify\n- pre-push checks