### PR TITLE
Add hosted chat execution preparation helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.458",
+  "version": "0.1.459",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-chat-preparation.test.ts
+++ b/src/agent/hosted-chat-preparation.test.ts
@@ -3,6 +3,7 @@ import type { ChatUiMessage } from "#veryfront/chat/types.ts";
 import type { ParsedHostedChatRequest } from "./hosted-chat-request-parser.ts";
 import {
   normalizeParsedHostedChatRequest,
+  prepareHostedChatExecution,
   prepareHostedChatRuntimeCreationOptions,
   prepareHostedChatRuntimeMessages,
 } from "./hosted-chat-preparation.ts";
@@ -216,6 +217,74 @@ Deno.test("prepareHostedChatRuntimeCreationOptions builds runtime options from r
 
   await result.creationOptions.publishParentRunEvents?.([{ type: "state_delta" }]);
   assertEquals(parentEvents, [{ type: "state_delta" }]);
+});
+
+Deno.test("prepareHostedChatExecution prepares root run, runtime, and final messages", async () => {
+  const result = await prepareHostedChatExecution({
+    request: createParsedHostedChatRequest({
+      conversationId: "conversation-1",
+      projectId: "project-1",
+      durableRootRun: {
+        runId: "run-1",
+        messageId: "message-1",
+        latestEventId: 3,
+        latestExternalEventSequence: 2,
+      },
+      parentRunId: "parent-run-1",
+    }),
+    agentConfig: {
+      id: "agent-1",
+      model: "configured-model",
+      maxSteps: 25,
+    },
+    apiUrl: "https://api.example.com",
+    abortSignal: new AbortController().signal,
+    resolveModelId: (modelId) => modelId ? `resolved:${modelId}` : undefined,
+    fetchSteering: () =>
+      Promise.resolve({
+        instructions: "Project instructions",
+        skills: [],
+      }),
+    buildInstructions: (input) => [
+      {
+        role: "system",
+        content: `${input.agentConfig.id}:${input.instructions}`,
+      },
+    ],
+    createRuntime: (options) =>
+      Promise.resolve({
+        runtimeKind: "framework",
+        modelId: options.model ?? "resolved:configured-model",
+        cleanup: () => Promise.resolve(),
+        agent: {
+          stream: () =>
+            Promise.resolve({
+              steps: Promise.resolve([]),
+              toUIMessageStream: async function* () {},
+            }),
+        },
+      }),
+  });
+
+  assertEquals(result.parentMessageId, "user-message-1");
+  assertEquals(result.rootRunContext.durableRootRun, {
+    runId: "run-1",
+    conversationId: "conversation-1",
+    messageId: "message-1",
+    latestEventId: 3,
+    latestExternalEventSequence: 2,
+  });
+  assertEquals(result.rootRunContext.effectiveParentRunId, "run-1");
+  assertEquals(result.rootRunContext.effectiveParentMessageId, "message-1");
+  assertEquals(result.runtime.runtimeKind, "framework");
+  assertEquals(result.runtime.modelId, "resolved:configured-model");
+  assertEquals(result.finalMessages.length, 1);
+  assertEquals(result.steering.agentInstructions, [
+    {
+      role: "system",
+      content: "agent-1:Project instructions",
+    },
+  ]);
 });
 
 Deno.test("prepareHostedChatRuntimeMessages refreshes uploaded file URLs through the hosted API", async () => {

--- a/src/agent/hosted-chat-preparation.ts
+++ b/src/agent/hosted-chat-preparation.ts
@@ -7,9 +7,15 @@ import type { AgentRuntimeMessage } from "./agent-runtime-message-adapter.ts";
 import type { ConversationRunEvent } from "./conversation-run-events.ts";
 import type {
   HostedChatRuntimeCreationOptions,
+  HostedChatRuntimeCreationResult,
   HostedChatRuntimeProjectSteering,
 } from "./hosted-chat-runtime-contract.ts";
 import type { ParsedHostedChatRequest } from "./hosted-chat-request-parser.ts";
+import {
+  type HostedConversationRootRunContext,
+  prepareHostedConversationRootRunContext,
+  type PrepareHostedConversationRootRunContextInput,
+} from "./conversation-root-run-lifecycle.ts";
 import {
   prepareAgentRuntimeMessagesFromUiMessages,
   type PrepareAgentRuntimeMessagesFromUiMessagesOptions,
@@ -94,6 +100,62 @@ export type HostedChatRuntimeCreationPreparationResult<TRuntimeAgentDefinition> 
   steering: HostedChatRuntimePreparationSteering & {
     agentInstructions: string | ChatSystemMessage[];
   };
+  runtimeConfig: ResolvedHostedRuntimeRequestConfig;
+};
+
+export type HostedChatExecutionPreparationRootRunOptions = Pick<
+  PrepareHostedConversationRootRunContextInput,
+  | "implementationKind"
+  | "persistLatestUserMessageOperation"
+  | "missingUserMessageErrorMessage"
+  | "onPersistLatestUserMessageFailure"
+  | "instrumentation"
+>;
+
+export type HostedChatExecutionPreparationInput<
+  TRuntimeAgentDefinition extends {
+    id: string;
+    model?: string;
+    thinking?: RuntimeAgentThinkingConfig;
+    maxSteps?: number;
+  },
+  TRuntimeResult extends HostedChatRuntimeCreationResult,
+> = {
+  request: ParsedHostedChatRequest;
+  agentConfig: TRuntimeAgentDefinition;
+  apiUrl: string | URL;
+  abortSignal: AbortSignal;
+  rootRun?: HostedChatExecutionPreparationRootRunOptions;
+  resolveModelId: (modelId: string | undefined) => string | undefined;
+  resolveModelThinking?: (
+    modelId: string | undefined,
+  ) => RuntimeAgentThinkingConfig | undefined;
+  fetchSteering: (input: {
+    projectId: string | null;
+    authToken: string;
+    branchId?: string | null;
+  }) => Promise<HostedChatRuntimePreparationSteering>;
+  buildInstructions: (
+    input: HostedChatRuntimeInstructionsInput<TRuntimeAgentDefinition>,
+  ) => string | ChatSystemMessage[];
+  createRuntime: (
+    options: HostedChatRuntimeCreationOptions<
+      TRuntimeAgentDefinition,
+      RuntimeAgentThinkingConfig
+    >,
+  ) => Promise<TRuntimeResult>;
+};
+
+export type HostedChatExecutionPreparationResult<
+  TRuntimeAgentDefinition,
+  TRuntimeResult extends HostedChatRuntimeCreationResult,
+> = NormalizedHostedChatRequest & {
+  rootRunContext: HostedConversationRootRunContext;
+  runtime: TRuntimeResult;
+  finalMessages: AgentRuntimeMessage[];
+  steering: HostedChatRuntimeCreationPreparationResult<
+    TRuntimeAgentDefinition
+  >["steering"];
   runtimeConfig: ResolvedHostedRuntimeRequestConfig;
 };
 
@@ -197,6 +259,74 @@ export async function prepareHostedChatRuntimeCreationOptions<
       agentInstructions,
     },
     runtimeConfig,
+  };
+}
+
+export async function prepareHostedChatExecution<
+  TRuntimeAgentDefinition extends {
+    id: string;
+    model?: string;
+    thinking?: RuntimeAgentThinkingConfig;
+    maxSteps?: number;
+  },
+  TRuntimeResult extends HostedChatRuntimeCreationResult,
+>(
+  input: HostedChatExecutionPreparationInput<
+    TRuntimeAgentDefinition,
+    TRuntimeResult
+  >,
+): Promise<
+  HostedChatExecutionPreparationResult<TRuntimeAgentDefinition, TRuntimeResult>
+> {
+  const normalized = normalizeParsedHostedChatRequest(input.request);
+  const rootRunContext = await prepareHostedConversationRootRunContext(
+    {
+      authToken: input.request.authToken,
+      apiUrl: input.apiUrl.toString(),
+      conversationId: input.request.conversationId,
+      projectId: input.request.projectId,
+      branchId: normalized.effectiveValidatedContext.branchId,
+      agentId: input.agentConfig.id,
+      messages: normalized.effectiveMessages,
+      parentRunId: input.request.parentRunId,
+      parentMessageId: normalized.parentMessageId,
+      providedRun: input.request.durableRootRun,
+      persistLatestUserMessageBeforeRun: input.request.persistLatestUserMessageBeforeDurableRun,
+      ...input.rootRun,
+    },
+    { abortSignal: input.abortSignal },
+  );
+  const runtimePreparation = await prepareHostedChatRuntimeCreationOptions({
+    request: input.request,
+    agentConfig: input.agentConfig,
+    projectId: input.request.projectId,
+    authToken: input.request.authToken,
+    conversationId: input.request.conversationId,
+    branchId: normalized.effectiveValidatedContext.branchId,
+    environmentContext: normalized.effectiveValidatedContext.environmentContext,
+    rootRunContext,
+    resolveModelId: input.resolveModelId,
+    resolveModelThinking: input.resolveModelThinking,
+    fetchSteering: input.fetchSteering,
+    buildInstructions: input.buildInstructions,
+  });
+  const runtime = await input.createRuntime(runtimePreparation.creationOptions);
+  const finalMessages = await prepareHostedChatRuntimeMessages(
+    normalized.effectiveMessages,
+    {
+      authToken: input.request.authToken,
+      apiUrl: input.apiUrl,
+      projectId: input.request.projectId,
+    },
+  );
+
+  return {
+    ...normalized,
+    rootRunContext,
+    runtime,
+    finalMessages,
+    steering: runtimePreparation.steering,
+    runtimeConfig: runtimePreparation.runtimeConfig,
   };
 }
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -679,6 +679,9 @@ export {
   type PrepareAgentRuntimeMessagesFromUiMessagesOptions,
 } from "./runtime-message-preparation.ts";
 export {
+  type HostedChatExecutionPreparationInput,
+  type HostedChatExecutionPreparationResult,
+  type HostedChatExecutionPreparationRootRunOptions,
   type HostedChatRuntimeCreationPreparationInput,
   type HostedChatRuntimeCreationPreparationResult,
   type HostedChatRuntimeInstructionsInput,
@@ -686,6 +689,7 @@ export {
   type HostedChatRuntimePreparationSteering,
   type NormalizedHostedChatRequest,
   normalizeParsedHostedChatRequest,
+  prepareHostedChatExecution,
   prepareHostedChatRuntimeCreationOptions,
   prepareHostedChatRuntimeMessages,
   type PrepareHostedChatRuntimeMessagesOptions,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.458";
+export const VERSION = "0.1.459";


### PR DESCRIPTION
## Summary\n- add a framework helper that prepares hosted chat execution across request normalization, root-run context, runtime creation, and final message preparation\n- export the helper and types from the agent public surface\n- bump the package patch version to 0.1.459\n\n## Verification\n- deno check src/agent/hosted-chat-preparation.ts src/agent/index.ts\n- deno test --no-check --allow-all src/agent/hosted-chat-preparation.test.ts\n- deno task verify\n- pre-push checks