### PR TITLE
Add hosted service auth helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.459",
+  "version": "0.1.460",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [
@@ -151,6 +151,7 @@
     "veryfront/extensions/bundler": "./src/extensions/bundler.ts",
     "veryfront/extensions/contracts": "./src/extensions/contracts.ts",
     "veryfront/extensions/interfaces": "./src/extensions/interfaces/index.ts",
+    "jose": "npm:jose@5.9.6",
     "#veryfront": "./src/index.ts",
     "#veryfront/agent": "./src/agent/index.ts",
     "#veryfront/agent/react": "./src/agent/react/index.ts",

--- a/src/agent/hosted-service-auth.test.ts
+++ b/src/agent/hosted-service-auth.test.ts
@@ -1,0 +1,375 @@
+import {
+  assert,
+  assertEquals,
+  assertInstanceOf,
+  assertStrictEquals,
+} from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { exportSPKI, generateKeyPair, SignJWT } from "jose";
+import {
+  createHostedServiceAuth,
+  getHostedServiceTokenFromRequest,
+  HostedServiceAuthError,
+  type HostedServiceAuthFetch,
+} from "./hosted-service-auth.ts";
+
+type JwtFixture = {
+  token: string;
+  publicKeyPem: string;
+};
+
+type FetchCall = {
+  input: string | URL | Request;
+  init: RequestInit | undefined;
+};
+
+function encodeBase64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return btoa(binary).replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+function createUnsignedJwt(payload: Record<string, unknown>): string {
+  return [
+    encodeBase64Url(JSON.stringify({ alg: "none", typ: "JWT" })),
+    encodeBase64Url(JSON.stringify(payload)),
+    "signature",
+  ].join(".");
+}
+
+async function createRs256JwtFixture(
+  payload: Record<string, unknown>,
+): Promise<JwtFixture> {
+  const { privateKey, publicKey } = await generateKeyPair("RS256");
+  const token = await new SignJWT(payload)
+    .setProtectedHeader({ alg: "RS256" })
+    .setIssuedAt()
+    .setExpirationTime("1h")
+    .sign(privateKey);
+
+  return {
+    token,
+    publicKeyPem: await exportSPKI(publicKey),
+  };
+}
+
+function createFetchMock(response: Response): {
+  calls: FetchCall[];
+  fetch: HostedServiceAuthFetch;
+} {
+  const calls: FetchCall[] = [];
+  const fetchMock: HostedServiceAuthFetch = (input, init) => {
+    calls.push({ input, init });
+    return Promise.resolve(response.clone());
+  };
+
+  return { calls, fetch: fetchMock };
+}
+
+function getAuthorizationHeader(call: FetchCall): string | null {
+  const headers = call.init?.headers;
+  if (headers instanceof Headers) return headers.get("authorization");
+  return null;
+}
+
+function getOnlyFetchCall(calls: FetchCall[]): FetchCall {
+  assertEquals(calls.length, 1);
+  const call = calls[0];
+  if (!call) throw new Error("Expected one fetch call");
+  return call;
+}
+
+describe("agent/hosted-service-auth", () => {
+  it("creates typed hosted service auth errors", () => {
+    const unauthenticated = new HostedServiceAuthError(401, "Token required");
+    assertEquals(unauthenticated.name, "HostedServiceAuthError");
+    assertEquals(unauthenticated.statusCode, 401);
+    assertEquals(unauthenticated.errorCode, "UNAUTHENTICATED");
+    assertEquals(unauthenticated.message, "Token required");
+
+    const forbidden = new HostedServiceAuthError(403, "No access");
+    assertEquals(forbidden.statusCode, 403);
+    assertEquals(forbidden.errorCode, "FORBIDDEN");
+  });
+
+  it("extracts auth tokens from cookies before bearer headers", () => {
+    const request = new Request("https://agent.test/run", {
+      headers: {
+        authorization: "Bearer bearer-token",
+        cookie: "theme=dark; authToken=cookie-token; other=value",
+      },
+    });
+
+    assertEquals(getHostedServiceTokenFromRequest(request), "cookie-token");
+  });
+
+  it("extracts bearer auth tokens when no auth cookie exists", () => {
+    const request = new Request("https://agent.test/run", {
+      headers: { authorization: "Bearer bearer-token" },
+    });
+
+    assertEquals(getHostedServiceTokenFromRequest(request), "bearer-token");
+  });
+
+  it("returns null when no auth token exists", () => {
+    const request = new Request("https://agent.test/run");
+    assertStrictEquals(getHostedServiceTokenFromRequest(request), null);
+  });
+
+  it("verifies RS256 JWTs with configured public key", async () => {
+    const fixture = await createRs256JwtFixture({
+      userId: "user-1",
+      email: "user@example.test",
+    });
+    const auth = createHostedServiceAuth({
+      getConfig: () => ({
+        OAUTH_PUBLIC_KEY: fixture.publicKeyPem,
+        NODE_ENV: "production",
+        VERYFRONT_API_URL: "https://api.example.test",
+      }),
+    });
+
+    const result = await auth.verifyJwt(fixture.token);
+
+    assertEquals(result.success, true);
+    if (!result.success) throw new Error("Expected JWT verification to succeed");
+    assertEquals(result.userId, "user-1");
+    assertEquals(result.email, "user@example.test");
+    assertEquals(result.token, fixture.token);
+  });
+
+  it("returns empty email when a valid JWT has no email claim", async () => {
+    const fixture = await createRs256JwtFixture({ userId: "user-1" });
+    const auth = createHostedServiceAuth({
+      getConfig: () => ({
+        OAUTH_PUBLIC_KEY: fixture.publicKeyPem,
+        NODE_ENV: "production",
+        VERYFRONT_API_URL: "https://api.example.test",
+      }),
+    });
+
+    const result = await auth.verifyJwt(fixture.token);
+
+    assertEquals(result.success, true);
+    if (!result.success) throw new Error("Expected JWT verification to succeed");
+    assertEquals(result.email, "");
+  });
+
+  it("rejects JWTs without a userId", async () => {
+    const fixture = await createRs256JwtFixture({ email: "user@example.test" });
+    const auth = createHostedServiceAuth({
+      getConfig: () => ({
+        OAUTH_PUBLIC_KEY: fixture.publicKeyPem,
+        NODE_ENV: "production",
+        VERYFRONT_API_URL: "https://api.example.test",
+      }),
+    });
+
+    const result = await auth.verifyJwt(fixture.token);
+
+    assertEquals(result.success, false);
+    if (result.success) throw new Error("Expected JWT verification to fail");
+    assertEquals(result.error.statusCode, 401);
+    assertEquals(result.error.errorCode, "UNAUTHENTICATED");
+    assertEquals(result.error.message, "Invalid token: missing userId");
+  });
+
+  it("requires a public key in production", async () => {
+    const auth = createHostedServiceAuth({
+      getConfig: () => ({
+        NODE_ENV: "production",
+        VERYFRONT_API_URL: "https://api.example.test",
+      }),
+    });
+
+    const result = await auth.verifyJwt("token");
+
+    assertEquals(result.success, false);
+    if (result.success) throw new Error("Expected JWT verification to fail");
+    assertEquals(result.error.statusCode, 500);
+    assertEquals(result.error.errorCode, "SERVER_ERROR");
+    assertEquals(result.error.message, "JWT public key not configured");
+  });
+
+  it("decodes unsigned JWTs outside production when no public key is configured", async () => {
+    const token = createUnsignedJwt({
+      userId: "user-åäö",
+      email: "åäö@example.test",
+    });
+    const auth = createHostedServiceAuth({
+      getConfig: () => ({
+        NODE_ENV: "development",
+        VERYFRONT_API_URL: "https://api.example.test",
+      }),
+    });
+
+    const result = await auth.verifyJwt(token);
+
+    assertEquals(result.success, true);
+    if (!result.success) throw new Error("Expected development JWT decode to succeed");
+    assertEquals(result.userId, "user-åäö");
+    assertEquals(result.email, "åäö@example.test");
+  });
+
+  it("rejects expired unsigned JWTs", async () => {
+    const token = createUnsignedJwt({ userId: "user-1", exp: 1 });
+    const auth = createHostedServiceAuth({
+      getConfig: () => ({
+        NODE_ENV: "development",
+        VERYFRONT_API_URL: "https://api.example.test",
+      }),
+    });
+
+    const result = await auth.verifyJwt(token);
+
+    assertEquals(result.success, false);
+    if (result.success) throw new Error("Expected development JWT decode to fail");
+    assertEquals(result.error.message, "Token expired");
+  });
+
+  it("rejects malformed unsigned JWTs", async () => {
+    const auth = createHostedServiceAuth({
+      getConfig: () => ({
+        NODE_ENV: "development",
+        VERYFRONT_API_URL: "https://api.example.test",
+      }),
+    });
+
+    const result = await auth.verifyJwt("not-a-token");
+
+    assertEquals(result.success, false);
+    if (result.success) throw new Error("Expected development JWT decode to fail");
+    assertEquals(result.error.message, "Invalid token format");
+  });
+
+  it("authenticates requests into hosted service auth context", async () => {
+    const fixture = await createRs256JwtFixture({ userId: "user-1" });
+    const request = new Request("https://agent.test/api/ag-ui", {
+      headers: { authorization: `Bearer ${fixture.token}` },
+    });
+    const auth = createHostedServiceAuth({
+      getConfig: () => ({
+        OAUTH_PUBLIC_KEY: fixture.publicKeyPem,
+        NODE_ENV: "production",
+        VERYFRONT_API_URL: "https://api.example.test",
+      }),
+    });
+
+    const result = await auth.authenticateRequest(request);
+
+    assert(!(result instanceof Response));
+    assertEquals(result, { authToken: fixture.token, userId: "user-1" });
+  });
+
+  it("returns 401 JSON responses for unauthenticated requests", async () => {
+    const auth = createHostedServiceAuth({
+      getConfig: () => ({
+        NODE_ENV: "production",
+        VERYFRONT_API_URL: "https://api.example.test",
+      }),
+    });
+
+    const result = await auth.authenticateRequest(
+      new Request("https://agent.test/api/ag-ui"),
+    );
+
+    assertInstanceOf(result, Response);
+    assertEquals(result.status, 401);
+    assertEquals(await result.json(), { errorCode: "UNAUTHENTICATED" });
+  });
+
+  it("checks project access against the configured API origin", async () => {
+    const fetchMock = createFetchMock(new Response("{}", { status: 200 }));
+    const auth = createHostedServiceAuth({
+      fetch: fetchMock.fetch,
+      projectAccessTimeoutMs: 1_000,
+      getConfig: () => ({
+        NODE_ENV: "production",
+        VERYFRONT_API_URL: "https://api.example.test/v1",
+      }),
+    });
+
+    const result = await auth.verifyProjectAccess("project-1", "token-1");
+
+    assertEquals(result.success, true);
+    if (!result.success) throw new Error("Expected project access to succeed");
+    assertEquals(result.projectId, "project-1");
+    const call = getOnlyFetchCall(fetchMock.calls);
+    assertEquals(String(call.input), "https://api.example.test/projects/project-1");
+    assertEquals(call.init?.method, "GET");
+    assertEquals(getAuthorizationHeader(call), "Bearer token-1");
+  });
+
+  it("omits authorization on project access checks without a token", async () => {
+    const fetchMock = createFetchMock(new Response("{}", { status: 200 }));
+    const auth = createHostedServiceAuth({
+      fetch: fetchMock.fetch,
+      getConfig: () => ({
+        NODE_ENV: "production",
+        VERYFRONT_API_URL: "https://api.example.test",
+      }),
+    });
+
+    await auth.verifyProjectAccess("project-1", "");
+
+    assertEquals(getAuthorizationHeader(getOnlyFetchCall(fetchMock.calls)), null);
+  });
+
+  it("maps missing projects to NOT_FOUND", async () => {
+    const fetchMock = createFetchMock(new Response("Not found", { status: 404 }));
+    const auth = createHostedServiceAuth({
+      fetch: fetchMock.fetch,
+      getConfig: () => ({
+        NODE_ENV: "production",
+        VERYFRONT_API_URL: "https://api.example.test",
+      }),
+    });
+
+    const result = await auth.verifyProjectAccess("project-1", "token-1");
+
+    assertEquals(result.success, false);
+    if (result.success) throw new Error("Expected project access to fail");
+    assertEquals(result.error.statusCode, 404);
+    assertEquals(result.error.errorCode, "NOT_FOUND");
+  });
+
+  it("maps unauthorized project responses to FORBIDDEN", async () => {
+    const fetchMock = createFetchMock(new Response("Forbidden", { status: 403 }));
+    const auth = createHostedServiceAuth({
+      fetch: fetchMock.fetch,
+      getConfig: () => ({
+        NODE_ENV: "production",
+        VERYFRONT_API_URL: "https://api.example.test",
+      }),
+    });
+
+    const result = await auth.verifyProjectAccess("project-1", "token-1");
+
+    assertEquals(result.success, false);
+    if (result.success) throw new Error("Expected project access to fail");
+    assertEquals(result.error.statusCode, 403);
+    assertEquals(result.error.errorCode, "FORBIDDEN");
+  });
+
+  it("maps failed project access fetches to FORBIDDEN", async () => {
+    const fetchMock: HostedServiceAuthFetch = () => Promise.reject(new Error("boom"));
+    const auth = createHostedServiceAuth({
+      fetch: fetchMock,
+      getConfig: () => ({
+        NODE_ENV: "production",
+        VERYFRONT_API_URL: "https://api.example.test",
+      }),
+    });
+
+    const result = await auth.verifyProjectAccess("project-1", "token-1");
+
+    assertEquals(result.success, false);
+    if (result.success) throw new Error("Expected project access to fail");
+    assertEquals(result.error.statusCode, 403);
+    assertEquals(result.error.errorCode, "FORBIDDEN");
+  });
+});

--- a/src/agent/hosted-service-auth.ts
+++ b/src/agent/hosted-service-auth.ts
@@ -1,0 +1,397 @@
+import { importSPKI, jwtVerify, type KeyLike } from "jose";
+
+export type HostedServiceAuthErrorCode =
+  | "UNAUTHENTICATED"
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "SERVER_ERROR";
+
+export class HostedServiceAuthError extends Error {
+  readonly statusCode: number;
+  readonly errorCode: HostedServiceAuthErrorCode;
+
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.name = "HostedServiceAuthError";
+    this.statusCode = statusCode;
+    this.errorCode = statusCode === 401 ? "UNAUTHENTICATED" : "FORBIDDEN";
+  }
+}
+
+export function isHostedServiceAuthError(
+  error: unknown,
+): error is HostedServiceAuthError {
+  return error instanceof HostedServiceAuthError;
+}
+
+export type HostedServiceAuthenticatedRequest = {
+  authToken: string;
+  userId: string;
+};
+
+export type HostedServiceJwtError = {
+  statusCode: number;
+  errorCode: HostedServiceAuthErrorCode;
+  message: string;
+};
+
+export type HostedServiceJwtResult =
+  | { success: true; userId: string; email: string; token: string }
+  | { success: false; error: HostedServiceJwtError };
+
+export type HostedServiceProjectAccessError = {
+  statusCode: number;
+  errorCode: HostedServiceAuthErrorCode;
+  message: string;
+};
+
+export type HostedServiceProjectAccessResult =
+  | { success: true; projectId: string }
+  | { success: false; error: HostedServiceProjectAccessError };
+
+export type HostedServiceAuthConfig = {
+  OAUTH_PUBLIC_KEY?: string | null;
+  NODE_ENV?: string | null;
+  VERYFRONT_API_URL: string;
+};
+
+export type HostedServiceAuthLogger = {
+  debug?: (message: string, metadata?: Record<string, unknown>) => void;
+  error?: (message: string, metadata?: Record<string, unknown>) => void;
+};
+
+export type HostedServiceAuthTrace = <TResult>(
+  operationName: string,
+  operation: () => Promise<TResult>,
+) => Promise<TResult>;
+
+export type HostedServiceAuthFetch = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export type HostedServiceAuthOptions = {
+  getConfig: () => HostedServiceAuthConfig;
+  logger?: HostedServiceAuthLogger;
+  trace?: HostedServiceAuthTrace;
+  fetch?: HostedServiceAuthFetch;
+  projectAccessTimeoutMs?: number;
+};
+
+export type HostedServiceAuth = {
+  authenticateRequest: (
+    request: Request,
+  ) => Promise<HostedServiceAuthenticatedRequest | Response>;
+  getTokenFromRequest: typeof getHostedServiceTokenFromRequest;
+  verifyJwt: (token: string) => Promise<HostedServiceJwtResult>;
+  verifyProjectAccess: (
+    projectId: string,
+    token: string,
+  ) => Promise<HostedServiceProjectAccessResult>;
+};
+
+let cachedPublicKeyInput: string | undefined;
+let cachedPublicKeyPromise: Promise<KeyLike> | undefined;
+
+function defaultTrace<TResult>(
+  _operationName: string,
+  operation: () => Promise<TResult>,
+): Promise<TResult> {
+  return operation();
+}
+
+function getFetch(options: HostedServiceAuthOptions): HostedServiceAuthFetch {
+  return options.fetch ?? fetch;
+}
+
+function getProjectAccessTimeoutMs(options: HostedServiceAuthOptions): number {
+  return options.projectAccessTimeoutMs ?? 15_000;
+}
+
+function getPublicKey(publicKeyInput: string): Promise<KeyLike> {
+  if (cachedPublicKeyInput !== publicKeyInput || !cachedPublicKeyPromise) {
+    cachedPublicKeyInput = publicKeyInput;
+    cachedPublicKeyPromise = importSPKI(publicKeyInput, "RS256");
+  }
+
+  return cachedPublicKeyPromise;
+}
+
+export function getHostedServiceTokenFromRequest(request: Request): string | null {
+  const cookies = request.headers.get("cookie") || "";
+  const cookieMatch = cookies.match(/(?:^|;\s*)authToken=([^;]+)/);
+  if (cookieMatch?.[1]) return cookieMatch[1];
+
+  const authHeader = request.headers.get("authorization");
+  if (authHeader?.startsWith("Bearer ")) return authHeader.slice(7);
+
+  return null;
+}
+
+function makeUnauthenticatedError(message: string): HostedServiceJwtError {
+  return {
+    statusCode: 401,
+    errorCode: "UNAUTHENTICATED",
+    message,
+  };
+}
+
+function decodeBase64Url(input: string): string {
+  const normalized = input.replace(/-/g, "+").replace(/_/g, "/");
+  const paddingLength = (4 - (normalized.length % 4)) % 4;
+  const padded = `${normalized}${"=".repeat(paddingLength)}`;
+
+  if (typeof atob !== "function") {
+    throw new Error("Base64URL decoding is not available in this runtime");
+  }
+
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+
+  return new TextDecoder().decode(bytes);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseJsonObject(json: string): Record<string, unknown> | null {
+  const parsed: unknown = JSON.parse(json);
+  return isRecord(parsed) ? parsed : null;
+}
+
+function decodeHostedServiceJwtWithoutVerify(
+  token: string,
+): HostedServiceJwtResult {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) {
+      return {
+        success: false,
+        error: makeUnauthenticatedError("Invalid token format"),
+      };
+    }
+
+    const payloadPart = parts[1];
+    if (!payloadPart) {
+      return {
+        success: false,
+        error: makeUnauthenticatedError("Invalid token format"),
+      };
+    }
+
+    const payload = parseJsonObject(decodeBase64Url(payloadPart));
+    if (!payload) {
+      return {
+        success: false,
+        error: makeUnauthenticatedError("Invalid token"),
+      };
+    }
+
+    if (typeof payload.exp === "number" && payload.exp * 1000 < Date.now()) {
+      return {
+        success: false,
+        error: makeUnauthenticatedError("Token expired"),
+      };
+    }
+
+    const userId = typeof payload.userId === "string" ? payload.userId : null;
+    if (!userId) {
+      return {
+        success: false,
+        error: makeUnauthenticatedError("Invalid token: missing userId"),
+      };
+    }
+
+    return {
+      success: true,
+      userId,
+      email: typeof payload.email === "string" ? payload.email : "",
+      token,
+    };
+  } catch {
+    return {
+      success: false,
+      error: makeUnauthenticatedError("Invalid token"),
+    };
+  }
+}
+
+export function createHostedServiceAuth(
+  options: HostedServiceAuthOptions,
+): HostedServiceAuth {
+  const trace = options.trace ?? defaultTrace;
+
+  async function verifyJwt(token: string): Promise<HostedServiceJwtResult> {
+    return await trace("auth.verifyJwt", async () => {
+      if (!token) {
+        return {
+          success: false,
+          error: makeUnauthenticatedError("Authentication token required"),
+        };
+      }
+
+      const config = options.getConfig();
+
+      if (!config.OAUTH_PUBLIC_KEY) {
+        if (config.NODE_ENV === "production") {
+          return {
+            success: false,
+            error: {
+              statusCode: 500,
+              errorCode: "SERVER_ERROR",
+              message: "JWT public key not configured",
+            },
+          };
+        }
+        return decodeHostedServiceJwtWithoutVerify(token);
+      }
+
+      try {
+        const publicKey = await getPublicKey(config.OAUTH_PUBLIC_KEY);
+        const { payload } = await jwtVerify(token, publicKey, {
+          algorithms: ["RS256"],
+        });
+
+        const userId = typeof payload.userId === "string" ? payload.userId : null;
+        if (!userId) {
+          return {
+            success: false,
+            error: makeUnauthenticatedError("Invalid token: missing userId"),
+          };
+        }
+
+        return {
+          success: true,
+          userId,
+          email: typeof payload.email === "string" ? payload.email : "",
+          token,
+        };
+      } catch (error) {
+        options.logger?.debug?.("JWT verification failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        if (errorMessage.includes("expired")) {
+          return {
+            success: false,
+            error: makeUnauthenticatedError("Token expired"),
+          };
+        }
+
+        return {
+          success: false,
+          error: makeUnauthenticatedError("Invalid token"),
+        };
+      }
+    });
+  }
+
+  async function authenticateRequest(
+    request: Request,
+  ): Promise<HostedServiceAuthenticatedRequest | Response> {
+    const token = getHostedServiceTokenFromRequest(request);
+    if (!token) {
+      return Response.json({ errorCode: "UNAUTHENTICATED" }, { status: 401 });
+    }
+
+    const auth = await verifyJwt(token);
+    if (!auth.success) {
+      return Response.json({ errorCode: auth.error.errorCode }, { status: 401 });
+    }
+
+    return {
+      authToken: auth.token,
+      userId: auth.userId,
+    };
+  }
+
+  async function verifyProjectAccess(
+    projectId: string,
+    token: string,
+  ): Promise<HostedServiceProjectAccessResult> {
+    return await trace("auth.verifyProjectAccess", async () => {
+      const config = options.getConfig();
+
+      try {
+        const apiUrl = new URL(config.VERYFRONT_API_URL);
+        const restUrl = new URL(`/projects/${projectId}`, apiUrl.origin);
+
+        const headers = new Headers({ "Content-Type": "application/json" });
+        if (token) {
+          headers.set("Authorization", `Bearer ${token}`);
+        }
+
+        const response = await getFetch(options)(restUrl.toString(), {
+          method: "GET",
+          headers,
+          signal: AbortSignal.timeout(getProjectAccessTimeoutMs(options)),
+        });
+
+        if (response.status === 404) {
+          return {
+            success: false,
+            error: {
+              statusCode: 404,
+              errorCode: "NOT_FOUND",
+              message: "Project not found",
+            },
+          };
+        }
+
+        if (response.status === 401 || response.status === 403) {
+          return {
+            success: false,
+            error: {
+              statusCode: 403,
+              errorCode: "FORBIDDEN",
+              message: "No access to project",
+            },
+          };
+        }
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          options.logger?.error?.("Project access check failed", {
+            error: errorText,
+            projectId,
+          });
+          return {
+            success: false,
+            error: {
+              statusCode: 403,
+              errorCode: "FORBIDDEN",
+              message: "No access to project",
+            },
+          };
+        }
+
+        return {
+          success: true,
+          projectId,
+        };
+      } catch (error) {
+        options.logger?.error?.("Project access check failed", { error, projectId });
+        return {
+          success: false,
+          error: {
+            statusCode: 403,
+            errorCode: "FORBIDDEN",
+            message: "No access to project",
+          },
+        };
+      }
+    });
+  }
+
+  return {
+    authenticateRequest,
+    getTokenFromRequest: getHostedServiceTokenFromRequest,
+    verifyJwt,
+    verifyProjectAccess,
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1296,3 +1296,22 @@ export {
   WaitConflictError,
   WaitNotPendingError,
 } from "./runtime/index.ts";
+
+export {
+  createHostedServiceAuth,
+  getHostedServiceTokenFromRequest,
+  type HostedServiceAuth,
+  type HostedServiceAuthConfig,
+  type HostedServiceAuthenticatedRequest,
+  HostedServiceAuthError,
+  type HostedServiceAuthErrorCode,
+  type HostedServiceAuthFetch,
+  type HostedServiceAuthLogger,
+  type HostedServiceAuthOptions,
+  type HostedServiceAuthTrace,
+  type HostedServiceJwtError,
+  type HostedServiceJwtResult,
+  type HostedServiceProjectAccessError,
+  type HostedServiceProjectAccessResult,
+  isHostedServiceAuthError,
+} from "./hosted-service-auth.ts";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.459";
+export const VERSION = "0.1.460";


### PR DESCRIPTION
## Summary\n- Add reusable hosted service auth helper for bearer/cookie auth, RS256 JWT verification, development JWT decode fallback, request auth, and project access checks.\n- Export the helper through veryfront/agent without exposing the unverified development decoder as public API.\n- Bump framework version to 0.1.460 for CI/CD publishing.\n\n## Verification\n- deno fmt --check src/agent/hosted-service-auth.ts src/agent/hosted-service-auth.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts\n- deno lint src/agent/hosted-service-auth.ts src/agent/hosted-service-auth.test.ts src/agent/index.ts\n- deno test --no-check --allow-all src/agent/hosted-service-auth.test.ts\n- deno check src/agent/hosted-service-auth.ts src/agent/hosted-service-auth.test.ts src/agent/index.ts\n- deno task verify:quick\n- pre-push checks: 1759 passed, 0 failed\n