### PR TITLE
Add runtime skill prompt helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.460",
+  "version": "0.1.461",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -871,6 +871,15 @@ export {
   type RuntimeProjectSteeringLookup,
 } from "./runtime-project-skill-catalog.ts";
 export {
+  createRuntimePromptBlock,
+  type RuntimePromptBlockOptions,
+} from "./runtime-prompt-block.ts";
+export {
+  buildRuntimeAvailableSkillsPromptBlock,
+  formatRuntimeSkillMetadata,
+  MAX_RUNTIME_SKILL_PROMPT_ENTRIES,
+} from "./runtime-skill-prompt.ts";
+export {
   buildRuntimeLoadedSkillResponse,
   buildRuntimeSkillDefinition,
   normalizeRuntimeSkillReferencePath,

--- a/src/agent/runtime-prompt-block.test.ts
+++ b/src/agent/runtime-prompt-block.test.ts
@@ -1,0 +1,31 @@
+import { assertEquals, assertMatch } from "#veryfront/testing/assert.ts";
+import { createRuntimePromptBlock } from "./runtime-prompt-block.ts";
+
+Deno.test("createRuntimePromptBlock wraps content in named tags", () => {
+  assertEquals(
+    createRuntimePromptBlock({ name: "context", content: "Hello world" }),
+    "<context>\nHello world\n</context>",
+  );
+});
+
+Deno.test("createRuntimePromptBlock trims boundary whitespace and preserves internal newlines", () => {
+  assertEquals(
+    createRuntimePromptBlock({ name: "note", content: "\nline1\nline2\n" }),
+    "<note>\nline1\nline2\n</note>",
+  );
+});
+
+Deno.test("createRuntimePromptBlock renders attrs as opening tag pairs", () => {
+  assertEquals(
+    createRuntimePromptBlock({ name: "tool", content: "body", attrs: { id: "1", type: "search" } }),
+    '<tool id="1" type="search">\nbody\n</tool>',
+  );
+});
+
+Deno.test("createRuntimePromptBlock omits attrs when none are provided", () => {
+  assertMatch(createRuntimePromptBlock({ name: "x", content: "y" }), /^<x>/);
+  assertEquals(
+    createRuntimePromptBlock({ name: "empty", content: "val", attrs: {} }),
+    "<empty>\nval\n</empty>",
+  );
+});

--- a/src/agent/runtime-prompt-block.ts
+++ b/src/agent/runtime-prompt-block.ts
@@ -1,0 +1,19 @@
+export type RuntimePromptBlockOptions = {
+  name: string;
+  content: string;
+  attrs?: Record<string, string>;
+};
+
+export function createRuntimePromptBlock({
+  name,
+  content,
+  attrs,
+}: RuntimePromptBlockOptions): string {
+  const attrString = attrs
+    ? Object.entries(attrs)
+      .map(([key, value]) => ` ${key}="${value}"`)
+      .join("")
+    : "";
+
+  return `<${name}${attrString}>\n${content.trim()}\n</${name}>`;
+}

--- a/src/agent/runtime-skill-prompt.test.ts
+++ b/src/agent/runtime-skill-prompt.test.ts
@@ -1,0 +1,101 @@
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  buildRuntimeAvailableSkillsPromptBlock,
+  formatRuntimeSkillMetadata,
+  MAX_RUNTIME_SKILL_PROMPT_ENTRIES,
+} from "./runtime-skill-prompt.ts";
+import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
+
+function createSkill(
+  input: Partial<RuntimeSkillDefinition> & Pick<RuntimeSkillDefinition, "id">,
+): RuntimeSkillDefinition {
+  return {
+    description: `Description for ${input.id}`,
+    instructions: `Instructions for ${input.id}`,
+    allowedTools: [],
+    name: input.id,
+    ...input,
+  };
+}
+
+Deno.test("formatRuntimeSkillMetadata renders structured skill defaults", () => {
+  assertEquals(
+    formatRuntimeSkillMetadata(
+      createSkill({
+        id: "knowledge",
+        allowedTools: ["knowledge_lookup", "read_file"],
+        model: "sonnet",
+        thinking: 4096,
+        maxSteps: 120,
+      }),
+    ),
+    " (tools: knowledge_lookup, read_file; model: sonnet; thinking: 4096; max-steps: 120)",
+  );
+});
+
+Deno.test("formatRuntimeSkillMetadata renders false thinking as off", () => {
+  assertEquals(
+    formatRuntimeSkillMetadata(createSkill({ id: "quick", thinking: false })),
+    " (thinking: off)",
+  );
+});
+
+Deno.test("formatRuntimeSkillMetadata returns an empty suffix without structured defaults", () => {
+  assertEquals(formatRuntimeSkillMetadata(createSkill({ id: "plain" })), "");
+});
+
+Deno.test("buildRuntimeAvailableSkillsPromptBlock renders skills and delegation policy", () => {
+  const block = buildRuntimeAvailableSkillsPromptBlock([
+    createSkill({
+      id: "build-ui",
+      description: "Build UI",
+      allowedTools: ["bash", "writeFile"],
+    }),
+  ]);
+
+  assertStringIncludes(block, "<available_skills>");
+  assertStringIncludes(block, "</available_skills>");
+  assertStringIncludes(block, "Use load_skill to load full instructions when needed.");
+  assertStringIncludes(block, "load_skill only loads instructions plus metadata.");
+  assertStringIncludes(block, "Continue the same turn after calling it");
+  assertStringIncludes(block, "Keep the root assistant visibly owning the work.");
+  assertStringIncludes(
+    block,
+    "When delegating, use the platform orchestration tool `invoke_agent`.",
+  );
+  assertStringIncludes(
+    block,
+    "Delegate only when isolation, parallelism, or a different tool/model budget materially helps.",
+  );
+  assertStringIncludes(block, "Pass through any returned model, thinking, or maxSteps overrides");
+  assertStringIncludes(block, "Do not mention child agents, delegation, or tool/process narration");
+  assertStringIncludes(block, "- build-ui: Build UI (tools: bash, writeFile)");
+});
+
+Deno.test("buildRuntimeAvailableSkillsPromptBlock truncates long skill lists", () => {
+  const skills = Array.from(
+    { length: MAX_RUNTIME_SKILL_PROMPT_ENTRIES + 2 },
+    (_unused, index) =>
+      createSkill({
+        id: `skill-${index + 1}`,
+        description: `Skill ${index + 1}`,
+      }),
+  );
+
+  const block = buildRuntimeAvailableSkillsPromptBlock(skills);
+
+  assertStringIncludes(block, "- skill-1: Skill 1");
+  assertStringIncludes(
+    block,
+    `- skill-${MAX_RUNTIME_SKILL_PROMPT_ENTRIES}: Skill ${MAX_RUNTIME_SKILL_PROMPT_ENTRIES}`,
+  );
+  assertEquals(
+    block.includes(
+      `- skill-${MAX_RUNTIME_SKILL_PROMPT_ENTRIES + 1}: Skill ${
+        MAX_RUNTIME_SKILL_PROMPT_ENTRIES + 1
+      }`,
+    ),
+    false,
+  );
+  assertStringIncludes(block, "(2 more skills available — use load_skill to discover)");
+});

--- a/src/agent/runtime-skill-prompt.ts
+++ b/src/agent/runtime-skill-prompt.ts
@@ -1,0 +1,61 @@
+import {
+  KEEP_ROOT_ASSISTANT_VISIBLE_OWNER,
+  LOAD_SKILL_CONTINUE_SAME_TURN,
+  LOAD_SKILL_DELEGATION_THRESHOLD,
+  LOAD_SKILL_OVERRIDE_FORWARDING,
+  NO_DELEGATION_NARRATION_UNLESS_ASKED,
+} from "./conversation-delegation-policy.ts";
+import { createRuntimePromptBlock } from "./runtime-prompt-block.ts";
+import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
+
+export const MAX_RUNTIME_SKILL_PROMPT_ENTRIES = 30;
+
+export function formatRuntimeSkillMetadata(skill: RuntimeSkillDefinition): string {
+  const details: string[] = [];
+  const allowedTools = skill.allowedTools ?? [];
+
+  if (allowedTools.length > 0) {
+    details.push(`tools: ${allowedTools.join(", ")}`);
+  }
+
+  if (skill.model) {
+    details.push(`model: ${skill.model}`);
+  }
+
+  if (skill.thinking === false) {
+    details.push("thinking: off");
+  } else if (typeof skill.thinking === "number") {
+    details.push(`thinking: ${skill.thinking}`);
+  }
+
+  if (skill.maxSteps !== undefined) {
+    details.push(`max-steps: ${skill.maxSteps}`);
+  }
+
+  return details.length > 0 ? ` (${details.join("; ")})` : "";
+}
+
+export function buildRuntimeAvailableSkillsPromptBlock(
+  skills: readonly RuntimeSkillDefinition[],
+): string {
+  const displaySkills = skills.slice(0, MAX_RUNTIME_SKILL_PROMPT_ENTRIES);
+  const skillsList = displaySkills
+    .map((skill) => `- ${skill.id}: ${skill.description}${formatRuntimeSkillMetadata(skill)}`)
+    .join("\n");
+
+  const truncationNote = skills.length > MAX_RUNTIME_SKILL_PROMPT_ENTRIES
+    ? `\n\n(${
+      skills.length - MAX_RUNTIME_SKILL_PROMPT_ENTRIES
+    } more skills available — use load_skill to discover)`
+    : "";
+
+  return createRuntimePromptBlock({
+    name: "available_skills",
+    content:
+      `You have access to these skills. Use load_skill to load full instructions when needed. load_skill only loads instructions plus metadata. ${LOAD_SKILL_CONTINUE_SAME_TURN} ${KEEP_ROOT_ASSISTANT_VISIBLE_OWNER} If a skill specifies allowed tools, you MUST stay within the current-run intersection of those tools. When delegating, use the platform orchestration tool \`invoke_agent\`. ${LOAD_SKILL_DELEGATION_THRESHOLD} ${LOAD_SKILL_OVERRIDE_FORWARDING} ${NO_DELEGATION_NARRATION_UNLESS_ASKED}
+
+Do NOT attempt tools that are absent from the current run just because they appear in loaded skill instructions.
+
+${skillsList}${truncationNote}`,
+  });
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.460";
+export const VERSION = "0.1.461";


### PR DESCRIPTION
## Summary\n- add reusable runtime prompt block and skill prompt helpers\n- export the helpers from the agent runtime surface\n- bump package version to 0.1.461 for CI/CD publishing\n\n## Verification\n- deno test --no-check --allow-all src/agent/runtime-prompt-block.test.ts src/agent/runtime-skill-prompt.test.ts src/agent/agent-service-route-export.check.ts\n- deno task verify:quick