### PR TITLE
Add hosted agent run lifecycle helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.461",
+  "version": "0.1.462",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-agent-run-lifecycle.test.ts
+++ b/src/agent/hosted-agent-run-lifecycle.test.ts
@@ -1,0 +1,173 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  createHostedAgentRunSpanController,
+  createHostedRootRunLifecycleRuntimeAdapter,
+  type HostedAgentRunSpan,
+} from "./hosted-agent-run-lifecycle.ts";
+import { createConversationHostedTerminalAdapter } from "./conversation-hosted-terminal.ts";
+import type { ConversationHostedTerminalAdapter } from "./conversation-hosted-terminal.ts";
+import type { HostedLifecycleTerminalState } from "./hosted-lifecycle.ts";
+
+type TerminalAdapterOptions = Parameters<
+  typeof createConversationHostedTerminalAdapter
+>[0];
+
+class RecordingSpan implements HostedAgentRunSpan {
+  attributes: Record<string, unknown> = {};
+  finished = 0;
+  withContextCalls = 0;
+
+  setAttributes(attributes: Record<string, unknown>): void {
+    this.attributes = { ...this.attributes, ...attributes };
+  }
+
+  finish(): void {
+    this.finished += 1;
+  }
+
+  withContext<T>(fn: () => T): T {
+    this.withContextCalls += 1;
+    return fn();
+  }
+}
+
+function createRecordingTerminalAdapter(
+  input: TerminalAdapterOptions,
+): ConversationHostedTerminalAdapter {
+  const toTerminalState = (state: {
+    status: HostedLifecycleTerminalState["status"];
+    metadata?: HostedLifecycleTerminalState["metadata"];
+    terminalErrorCode?: string | null;
+    terminalErrorMessage?: string | null;
+  }): HostedLifecycleTerminalState => ({
+    status: state.status,
+    ...(state.metadata ? { metadata: state.metadata } : {}),
+    ...(state.terminalErrorCode !== undefined
+      ? { terminalErrorCode: state.terminalErrorCode }
+      : {}),
+    ...(state.terminalErrorMessage !== undefined
+      ? { terminalErrorMessage: state.terminalErrorMessage }
+      : {}),
+  });
+
+  return {
+    toTerminalState,
+    finalizeRun: async () => {},
+    cancelRun: async () => {},
+    onTerminalState: async (terminalState) => {
+      await input.onTerminalState?.(terminalState);
+    },
+    dispatch: async (state) => {
+      const terminalState = toTerminalState(state);
+      await input.onTerminalState?.(terminalState);
+      return terminalState;
+    },
+  };
+}
+
+describe("hosted-agent-run-lifecycle", () => {
+  it("records start and final span attributes once", () => {
+    const span = new RecordingSpan();
+    const controller = createHostedAgentRunSpanController({
+      tracer: { startSpan: () => span },
+      operationName: "chat",
+      conversationId: "conversation-1",
+      projectId: "project-1",
+      userId: "user-1",
+      agentId: "agent-1",
+      rootRun: { runId: "run-1", messageId: "message-1" },
+      upstreamParentConversationId: "parent-conversation-1",
+      upstreamParentRunId: "parent-run-1",
+      spawnedFromToolCallId: "tool-call-1",
+    });
+
+    assertEquals(span.attributes["conversation.id"], "conversation-1");
+    assertEquals(span.attributes["project.id"], "project-1");
+    assertEquals(span.attributes["run.id"], "run-1");
+    assertEquals(span.attributes["message.id"], "message-1");
+    assertEquals(span.attributes["parent.conversation.id"], "parent-conversation-1");
+    assertEquals(span.attributes["parent.run.id"], "parent-run-1");
+    assertEquals(span.attributes["tool.call.id"], "tool-call-1");
+    assertEquals(span.attributes["gen_ai.operation.name"], "chat");
+
+    const value = controller.withContext(() => "ok");
+    assertEquals(value, "ok");
+    assertEquals(span.withContextCalls, 1);
+
+    controller.setMessageId("message-2");
+    controller.finalize({
+      status: "completed",
+      modelId: "veryfront-cloud/anthropic/claude-sonnet-4-6",
+      usage: { inputTokens: 10, outputTokens: 5, cachedInputTokens: 2 },
+    });
+    controller.finalize({ status: "failed", terminalErrorCode: "LATE" });
+
+    assertEquals(span.finished, 1);
+    assertEquals(span.attributes["message.id"], "message-2");
+    assertEquals(span.attributes["agent.run.final_status"], "completed");
+    assertEquals(span.attributes["gen_ai.provider.name"], "anthropic");
+    assertEquals(
+      span.attributes["gen_ai.response.model"],
+      "veryfront-cloud/anthropic/claude-sonnet-4-6",
+    );
+    assertEquals(span.attributes["gen_ai.usage.input_tokens"], 10);
+    assertEquals(span.attributes["gen_ai.usage.output_tokens"], 5);
+    assertEquals(span.attributes["gen_ai.usage.cache_read.input_tokens"], 2);
+  });
+
+  it("creates a terminal adapter and finalizes the span", async () => {
+    const finalized: unknown[] = [];
+    let terminalOptions: TerminalAdapterOptions | undefined;
+
+    const adapter = createHostedRootRunLifecycleRuntimeAdapter({
+      authToken: "token",
+      apiUrl: "https://api.example.com",
+      modelId: "veryfront-cloud/openai/gpt-5.1",
+      durableRootRun: {
+        runId: "run-1",
+        conversationId: "conversation-1",
+        messageId: "message-1",
+        latestEventId: 7,
+        latestExternalEventSequence: 3,
+      },
+      durableRunMirror: null,
+      resolveProvider: (modelId) => modelId.split("/")[1] ?? "unknown",
+      agentRunSpan: {
+        finalize: (state) => {
+          finalized.push(state);
+        },
+      },
+      createTerminalAdapter: (input) => {
+        terminalOptions = input;
+        return createRecordingTerminalAdapter(input);
+      },
+    });
+
+    await adapter.terminal.onTerminalState({
+      status: "failed",
+      metadata: {
+        modelId: "veryfront-cloud/openai/gpt-5.2",
+        usage: { inputTokens: 3, outputTokens: 4 },
+      },
+      terminalErrorCode: "STREAM_ERROR",
+      terminalErrorMessage: "stream broke",
+    });
+
+    assertEquals(adapter.durableRootRun?.runId, "run-1");
+    assertEquals(terminalOptions?.authToken, "token");
+    assertEquals(terminalOptions?.apiUrl, "https://api.example.com");
+    assertEquals(terminalOptions?.fallbackModelId, "veryfront-cloud/openai/gpt-5.1");
+    assertEquals(terminalOptions?.run?.status, "running");
+    assertEquals(terminalOptions?.run?.waitingToolCallId, null);
+    assertEquals(finalized, [
+      {
+        status: "failed",
+        modelId: "veryfront-cloud/openai/gpt-5.2",
+        usage: { inputTokens: 3, outputTokens: 4 },
+        terminalErrorCode: "STREAM_ERROR",
+        terminalErrorMessage: "stream broke",
+      },
+    ]);
+  });
+});

--- a/src/agent/hosted-agent-run-lifecycle.ts
+++ b/src/agent/hosted-agent-run-lifecycle.ts
@@ -1,0 +1,161 @@
+import type { ConversationRunChunkMirror } from "./conversation-run-chunk-mirror.ts";
+import {
+  type ConversationHostedTerminalAdapter,
+  createConversationHostedTerminalAdapter,
+} from "./conversation-hosted-terminal.ts";
+import type { HostedChatExecutionLifecycleAdapter } from "./hosted-chat-execution-runtime.ts";
+import type { HostedLifecycleTerminalState } from "./hosted-lifecycle.ts";
+import type { HostedConversationRootRunState } from "./conversation-root-run-lifecycle.ts";
+import {
+  type AgentTraceAttributes,
+  buildAgentRunTraceAttributes,
+  buildFinalizedAgentRunTraceAttributes,
+} from "./agent-trace-attributes.ts";
+
+export interface HostedAgentRunSpan {
+  setAttributes: (attributes: AgentTraceAttributes) => void;
+  finish: () => void;
+  withContext: <T>(fn: () => T) => T;
+}
+
+export interface HostedAgentRunTracer {
+  startSpan: (name: string) => HostedAgentRunSpan;
+}
+
+export interface HostedAgentRunSpanFinalState {
+  status: "completed" | "failed" | "cancelled";
+  modelId?: string | null;
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cachedInputTokens?: number;
+  };
+  terminalErrorCode?: string | null;
+  terminalErrorMessage?: string | null;
+}
+
+export interface HostedAgentRunSpanController {
+  withContext: <T>(fn: () => T) => T;
+  setAttributes: (attributes: AgentTraceAttributes) => void;
+  setMessageId: (messageId: string) => void;
+  finalize: (finalState: HostedAgentRunSpanFinalState) => void;
+}
+
+export interface CreateHostedAgentRunSpanControllerInput {
+  tracer: HostedAgentRunTracer;
+  spanName?: string;
+  operationName: "chat" | "invoke_agent";
+  conversationId?: string;
+  projectId: string | null;
+  userId: string;
+  agentId: string;
+  rootRun?: Pick<HostedConversationRootRunState, "runId" | "messageId"> | null;
+  upstreamParentConversationId?: string;
+  upstreamParentRunId?: string;
+  spawnedFromToolCallId?: string;
+}
+
+export function createHostedAgentRunSpanController(
+  input: CreateHostedAgentRunSpanControllerInput,
+): HostedAgentRunSpanController {
+  const span = input.tracer.startSpan(input.spanName ?? "agent.run");
+  let finalized = false;
+
+  span.setAttributes(
+    buildAgentRunTraceAttributes({
+      operationName: input.operationName,
+      conversationId: input.conversationId,
+      projectId: input.projectId,
+      userId: input.userId,
+      agentId: input.agentId,
+      runId: input.rootRun?.runId,
+      parentConversationId: input.upstreamParentConversationId,
+      parentRunId: input.upstreamParentRunId,
+      messageId: input.rootRun?.messageId,
+      toolCallId: input.spawnedFromToolCallId,
+    }),
+  );
+
+  return {
+    withContext: (fn) => span.withContext(fn),
+    setAttributes: (attributes) => {
+      span.setAttributes(attributes);
+    },
+    setMessageId: (messageId) => {
+      span.setAttributes({ "message.id": messageId });
+    },
+    finalize: (finalState) => {
+      if (finalized) {
+        return;
+      }
+
+      finalized = true;
+      span.setAttributes(buildFinalizedAgentRunTraceAttributes(finalState));
+      span.finish();
+    },
+  };
+}
+
+export interface HostedRootRunLifecycleRuntimeAdapter extends HostedChatExecutionLifecycleAdapter {
+  durableRootRun: HostedConversationRootRunState | null;
+  durableRunMirror: ConversationRunChunkMirror | null;
+}
+
+export interface CreateHostedRootRunLifecycleRuntimeAdapterInput {
+  authToken: string;
+  apiUrl: string;
+  modelId: string;
+  durableRootRun: HostedConversationRootRunState | null;
+  durableRunMirror: ConversationRunChunkMirror | null;
+  agentRunSpan: Pick<HostedAgentRunSpanController, "finalize">;
+  resolveProvider: (modelId: string) => string;
+  createTerminalAdapter?: (
+    input: Parameters<typeof createConversationHostedTerminalAdapter>[0],
+  ) => ConversationHostedTerminalAdapter;
+}
+
+function finalizeHostedAgentRunSpan(input: {
+  agentRunSpan: Pick<HostedAgentRunSpanController, "finalize">;
+  modelId: string;
+  terminalState: HostedLifecycleTerminalState;
+}): void {
+  input.agentRunSpan.finalize({
+    status: input.terminalState.status,
+    modelId: input.terminalState.metadata?.modelId ?? input.modelId,
+    usage: input.terminalState.metadata?.usage,
+    terminalErrorCode: input.terminalState.terminalErrorCode,
+    terminalErrorMessage: input.terminalState.terminalErrorMessage,
+  });
+}
+
+export function createHostedRootRunLifecycleRuntimeAdapter(
+  input: CreateHostedRootRunLifecycleRuntimeAdapterInput,
+): HostedRootRunLifecycleRuntimeAdapter {
+  const createTerminal = input.createTerminalAdapter ?? createConversationHostedTerminalAdapter;
+
+  return {
+    durableRootRun: input.durableRootRun,
+    durableRunMirror: input.durableRunMirror,
+    terminal: createTerminal({
+      authToken: input.authToken,
+      apiUrl: input.apiUrl,
+      run: input.durableRootRun
+        ? {
+          ...input.durableRootRun,
+          waitingToolCallId: null,
+          waitingToolName: null,
+          status: "running",
+        }
+        : null,
+      fallbackModelId: input.modelId,
+      resolveProvider: input.resolveProvider,
+      onTerminalState: (terminalState) => {
+        finalizeHostedAgentRunSpan({
+          agentRunSpan: input.agentRunSpan,
+          modelId: input.modelId,
+          terminalState,
+        });
+      },
+    }),
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -284,6 +284,18 @@ export {
   type HostedChatRuntimeAgentAdapterWarning,
 } from "./hosted-chat-runtime-agent-adapter.ts";
 
+export {
+  createHostedAgentRunSpanController,
+  type CreateHostedAgentRunSpanControllerInput,
+  createHostedRootRunLifecycleRuntimeAdapter,
+  type CreateHostedRootRunLifecycleRuntimeAdapterInput,
+  type HostedAgentRunSpan,
+  type HostedAgentRunSpanController,
+  type HostedAgentRunSpanFinalState,
+  type HostedAgentRunTracer,
+  type HostedRootRunLifecycleRuntimeAdapter,
+} from "./hosted-agent-run-lifecycle.ts";
+
 export type {
   HostedChatRuntimeAgent,
   HostedChatRuntimeCreationOptions,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.461";
+export const VERSION = "0.1.462";


### PR DESCRIPTION
## Summary\n- add reusable hosted agent run span controller\n- add hosted root-run lifecycle adapter that composes terminal finalization with span finalization\n- bump framework version to 0.1.462\n\n## Verification\n- deno test --no-check --allow-all src/agent/hosted-agent-run-lifecycle.test.ts src/agent/agent-service-route-export.check.ts\n- deno task verify:quick\n- architect review: APPROVED