### PR TITLE
Add hosted project steering adapter

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.462",
+  "version": "0.1.463",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-project-steering-adapter.test.ts
+++ b/src/agent/hosted-project-steering-adapter.test.ts
@@ -1,0 +1,138 @@
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { join } from "node:path";
+import { createHostedProjectSteeringAdapter } from "./hosted-project-steering-adapter.ts";
+import type {
+  RuntimeGetProjectFileOptions,
+  RuntimeProjectFile,
+  RuntimeProjectFileListItem,
+  RuntimeProjectFilesApiOptions,
+  RuntimeProjectFilesClient,
+} from "./runtime-project-files-client.ts";
+
+async function createSkillsDir(): Promise<string> {
+  const skillsDir = await Deno.makeTempDir();
+  const skillDir = join(skillsDir, "builtin");
+  await Deno.mkdir(skillDir, { recursive: true });
+  await Deno.writeTextFile(
+    join(skillDir, "SKILL.md"),
+    `---
+name: Builtin
+description: Builtin skill
+---
+Use builtin instructions.`,
+  );
+  return skillsDir;
+}
+
+async function withSkillsDir<T>(fn: (skillsDir: string) => Promise<T>): Promise<T> {
+  const skillsDir = await createSkillsDir();
+  try {
+    return await fn(skillsDir);
+  } finally {
+    await Deno.remove(skillsDir, { recursive: true });
+  }
+}
+
+function createProjectFilesClient(input: {
+  getProjectFile?: (options: RuntimeGetProjectFileOptions) => Promise<RuntimeProjectFile | null>;
+  getProjectFiles?: (
+    options: RuntimeProjectFilesApiOptions,
+  ) => Promise<RuntimeProjectFileListItem[]>;
+} = {}): RuntimeProjectFilesClient {
+  return {
+    getProjectFile: (options) => input.getProjectFile?.(options) ?? Promise.resolve(null),
+    getProjectFiles: (options) => input.getProjectFiles?.(options) ?? Promise.resolve([]),
+  };
+}
+
+Deno.test("hosted project steering adapter loads instructions and project skills", async () => {
+  await withSkillsDir(async (skillsDir) => {
+    const fileCalls: RuntimeGetProjectFileOptions[] = [];
+    const adapter = createHostedProjectSteeringAdapter({
+      apiUrl: "https://api.example.test",
+      skillsDir,
+      projectFilesClient: createProjectFilesClient({
+        getProjectFile: async (options) => {
+          fileCalls.push(options);
+          if (options.path === "AGENTS.md") {
+            return { path: options.path, content: "Project instructions" };
+          }
+          if (options.path === ".veryfront/skills/project/SKILL.md") {
+            return {
+              path: options.path,
+              content: `---
+name: Project Skill
+description: Project skill
+---
+Use project instructions.`,
+            };
+          }
+          return null;
+        },
+        getProjectFiles: async () => [
+          { path: ".veryfront/skills/project/SKILL.md" },
+          { path: ".veryfront/skills/project/references/guide.md" },
+        ],
+      }),
+    });
+
+    const lookup = {
+      projectId: "project-1",
+      authToken: "token-1",
+      branchId: "branch-1",
+    };
+
+    assertEquals(await adapter.getProjectInstructions(lookup), "Project instructions");
+    assertEquals((await adapter.getSkillsConfig(lookup)).map((skill) => skill.id), [
+      "builtin",
+      "project",
+    ]);
+    assertEquals(fileCalls.length, 2);
+    assertEquals(fileCalls[0], {
+      projectId: "project-1",
+      authToken: "token-1",
+      branchId: "branch-1",
+      path: "AGENTS.md",
+    });
+  });
+});
+
+Deno.test("hosted project steering adapter creates load_skill and refreshes project skill ids", async () => {
+  await withSkillsDir(async (skillsDir) => {
+    const adapter = createHostedProjectSteeringAdapter({
+      apiUrl: "https://api.example.test",
+      skillsDir,
+      projectFilesClient: createProjectFilesClient({
+        getProjectFile: async ({ path }) =>
+          path === ".veryfront/skills/project/SKILL.md"
+            ? {
+              path,
+              content: `---
+name: Project Skill
+description: Project skill
+---
+Use project instructions.`,
+            }
+            : null,
+        getProjectFiles: async () => [{ path: ".veryfront/skills/project/SKILL.md" }],
+      }),
+    });
+    const context = {
+      projectId: "project-1",
+      authToken: "token-1",
+      branchId: null,
+      availableSkillIds: [],
+    };
+
+    await adapter.refreshProjectSkillIds(context);
+    assertEquals(context.availableSkillIds, ["builtin", "project"]);
+
+    const loadSkillTool = adapter.createLoadSkillTool(context);
+    const result = await loadSkillTool.execute({ skillId: "project" });
+
+    assert("skillId" in result);
+    assertEquals(result.skillId, "project");
+    assert("instructions" in result);
+    assertEquals(result.instructions.includes("Use project instructions."), true);
+  });
+});

--- a/src/agent/hosted-project-steering-adapter.ts
+++ b/src/agent/hosted-project-steering-adapter.ts
@@ -1,0 +1,177 @@
+import type { Tool } from "#veryfront/tool";
+import { HostedServiceAuthError, isHostedServiceAuthError } from "./hosted-service-auth.ts";
+import {
+  listRuntimeBuiltinSkillReferences,
+  readRuntimeBuiltinSkill,
+  readRuntimeBuiltinSkillReferenceFile,
+} from "./runtime-builtin-skill-files.ts";
+import {
+  createRuntimeLoadSkillTool,
+  type RuntimeLoadSkillToolContext,
+  type RuntimeLoadSkillToolInput,
+  type RuntimeLoadSkillToolOutput,
+} from "./runtime-load-skill-tool.ts";
+import type { MutableAgentProjectContext } from "./project-context.ts";
+import {
+  createRuntimeProjectFilesClient,
+  type RuntimeProjectFilesClient,
+  type RuntimeProjectFilesClientOptions,
+  type RuntimeProjectFilesFetch,
+  type RuntimeProjectFilesTrace,
+} from "./runtime-project-files-client.ts";
+import {
+  getRuntimeProjectInstructions,
+  getRuntimeProjectSkillCatalog,
+  loadRuntimeBuiltinSkillCatalog,
+  type RuntimeProjectSteeringLookup,
+} from "./runtime-project-skill-catalog.ts";
+import {
+  createRuntimeProjectSkillLoader,
+  type RuntimeLoadedProjectSkill,
+  type RuntimeProjectSkillContext,
+  type RuntimeProjectSkillLoader,
+  type RuntimeProjectSkillLoaderLogger,
+} from "./runtime-project-skill-loader.ts";
+import type {
+  RuntimeSkillDefinition,
+  RuntimeSkillMetadataLogger,
+} from "./runtime-skill-metadata.ts";
+
+export type HostedProjectSteeringLogger =
+  & RuntimeSkillMetadataLogger
+  & RuntimeProjectSkillLoaderLogger;
+
+export type HostedProjectSteeringAdapterOptions = {
+  apiUrl: string | URL;
+  skillsDir: string;
+  logger?: HostedProjectSteeringLogger;
+  trace?: RuntimeProjectFilesTrace;
+  fetch?: RuntimeProjectFilesFetch;
+  projectFilesClient?: RuntimeProjectFilesClient;
+  projectSkillLoader?: RuntimeProjectSkillLoader;
+  builtinSkills?: readonly RuntimeSkillDefinition[];
+};
+
+export type HostedProjectSkillIdsContext = MutableAgentProjectContext & {
+  authToken: string;
+};
+
+export type HostedProjectSteeringAdapter = {
+  listBuiltinSkillIds: () => string[];
+  getProjectInstructions: (lookup: RuntimeProjectSteeringLookup) => Promise<string>;
+  getSkillsConfig: (lookup: RuntimeProjectSteeringLookup) => Promise<RuntimeSkillDefinition[]>;
+  listProjectSkillReferences: (
+    context: RuntimeProjectSkillContext,
+    skillId: string,
+  ) => Promise<string[]>;
+  loadProjectSkill: (
+    context: RuntimeProjectSkillContext,
+    skillId: string,
+  ) => Promise<RuntimeLoadedProjectSkill | null>;
+  loadProjectSkillReference: (
+    context: RuntimeProjectSkillContext,
+    skillId: string,
+    normalizedFile: string,
+  ) => Promise<string | null>;
+  createLoadSkillTool: (
+    context: RuntimeLoadSkillToolContext,
+  ) => Tool<RuntimeLoadSkillToolInput, RuntimeLoadSkillToolOutput>;
+  refreshProjectSkillIds: (context: HostedProjectSkillIdsContext) => Promise<void>;
+};
+
+function createProjectFilesAccessDeniedError(statusCode: number, message: string): Error {
+  return new HostedServiceAuthError(statusCode, message);
+}
+
+function createProjectFilesClientOptions(
+  options: HostedProjectSteeringAdapterOptions,
+): RuntimeProjectFilesClientOptions {
+  return {
+    apiUrl: options.apiUrl,
+    fetch: options.fetch,
+    trace: options.trace,
+    createAccessDeniedError: createProjectFilesAccessDeniedError,
+  };
+}
+
+function createDefaultProjectFilesClient(
+  options: HostedProjectSteeringAdapterOptions,
+): RuntimeProjectFilesClient {
+  return createRuntimeProjectFilesClient(createProjectFilesClientOptions(options));
+}
+
+function createDefaultProjectSkillLoader(
+  options: HostedProjectSteeringAdapterOptions,
+  projectFilesClient: RuntimeProjectFilesClient,
+): RuntimeProjectSkillLoader {
+  return createRuntimeProjectSkillLoader({
+    getProjectFile: projectFilesClient.getProjectFile,
+    getProjectFiles: projectFilesClient.getProjectFiles,
+    isAccessDeniedError: isHostedServiceAuthError,
+    logger: options.logger,
+  });
+}
+
+export function createHostedProjectSteeringAdapter(
+  options: HostedProjectSteeringAdapterOptions,
+): HostedProjectSteeringAdapter {
+  const projectFilesClient = options.projectFilesClient ?? createDefaultProjectFilesClient(options);
+  const projectSkillLoader = options.projectSkillLoader ??
+    createDefaultProjectSkillLoader(options, projectFilesClient);
+  const builtinSkills = options.builtinSkills ??
+    loadRuntimeBuiltinSkillCatalog({ skillsDir: options.skillsDir, logger: options.logger });
+
+  async function getProjectInstructions(
+    lookup: RuntimeProjectSteeringLookup,
+  ): Promise<string> {
+    return getRuntimeProjectInstructions({
+      ...lookup,
+      getProjectFile: projectFilesClient.getProjectFile,
+    });
+  }
+
+  async function getSkillsConfig(
+    lookup: RuntimeProjectSteeringLookup,
+  ): Promise<RuntimeSkillDefinition[]> {
+    return getRuntimeProjectSkillCatalog({
+      ...lookup,
+      builtinSkills,
+      logger: options.logger,
+      getProjectFile: projectFilesClient.getProjectFile,
+      getProjectFiles: projectFilesClient.getProjectFiles,
+    });
+  }
+
+  return {
+    listBuiltinSkillIds: () => builtinSkills.map((skill) => skill.id),
+    getProjectInstructions,
+    getSkillsConfig,
+    listProjectSkillReferences: (context, skillId) =>
+      projectSkillLoader.listProjectSkillReferences(context, skillId),
+    loadProjectSkill: (context, skillId) => projectSkillLoader.loadProjectSkill(context, skillId),
+    loadProjectSkillReference: (context, skillId, normalizedFile) =>
+      projectSkillLoader.loadProjectSkillReference(context, skillId, normalizedFile),
+    createLoadSkillTool: (context) =>
+      createRuntimeLoadSkillTool({
+        context,
+        skillsDir: options.skillsDir,
+        projectSkillLoader,
+        builtinSkillIds: builtinSkills.map((skill) => skill.id),
+        builtinStore: {
+          readSkill: readRuntimeBuiltinSkill,
+          readReferenceFile: readRuntimeBuiltinSkillReferenceFile,
+          listReferences: listRuntimeBuiltinSkillReferences,
+        },
+        logger: options.logger,
+      }),
+    refreshProjectSkillIds: async (context) => {
+      const skills = await getSkillsConfig({
+        projectId: context.projectId,
+        authToken: context.authToken,
+        branchId: context.branchId,
+      });
+
+      context.availableSkillIds = skills.map((skill) => skill.id);
+    },
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -867,6 +867,13 @@ export {
   type RuntimeProjectFilesTrace,
 } from "./runtime-project-files-client.ts";
 export {
+  createHostedProjectSteeringAdapter,
+  type HostedProjectSkillIdsContext,
+  type HostedProjectSteeringAdapter,
+  type HostedProjectSteeringAdapterOptions,
+  type HostedProjectSteeringLogger,
+} from "./hosted-project-steering-adapter.ts";
+export {
   createRuntimeProjectSkillLoader,
   type RuntimeLoadedProjectSkill,
   type RuntimeProjectSkillContext,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.462";
+export const VERSION = "0.1.463";


### PR DESCRIPTION
## Summary
- add a hosted project steering adapter for project instructions, skill catalog lookup, load_skill creation, and skill id refresh
- expose the adapter through veryfront/agent
- bump framework package version to 0.1.463 for CI/CD release

## Verification
- deno task verify:quick
- deno test --no-check --allow-all src/agent/hosted-project-steering-adapter.test.ts
- pre-push checks: format, lint, typecheck, unit tests
- architect review: APPROVED