### PR TITLE
Allow hosted project steering builtin stores

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.463",
+  "version": "0.1.464",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-project-steering-adapter.test.ts
+++ b/src/agent/hosted-project-steering-adapter.test.ts
@@ -136,3 +136,49 @@ Use project instructions.`,
     assertEquals(result.instructions.includes("Use project instructions."), true);
   });
 });
+
+Deno.test("hosted project steering adapter accepts a custom builtin skill store", async () => {
+  await withSkillsDir(async (skillsDir) => {
+    const readSkillCalls: Array<{ skillsDir: string; skillId: string }> = [];
+    const referenceCalls: Array<{ skillsDir: string; skillId: string }> = [];
+    const adapter = createHostedProjectSteeringAdapter({
+      apiUrl: "https://api.example.test",
+      skillsDir,
+      projectFilesClient: createProjectFilesClient(),
+      builtinSkills: [
+        {
+          id: "custom",
+          name: "Custom",
+          description: "Custom builtin skill",
+          instructions: "",
+          allowedTools: [],
+        },
+      ],
+      builtinStore: {
+        readSkill: (storeSkillsDir, skillId) => {
+          readSkillCalls.push({ skillsDir: storeSkillsDir, skillId });
+          return skillId === "custom" ? "Use custom builtin instructions." : null;
+        },
+        readReferenceFile: () => null,
+        listReferences: (storeSkillsDir, skillId) => {
+          referenceCalls.push({ skillsDir: storeSkillsDir, skillId });
+          return ["references/custom.md"];
+        },
+      },
+    });
+
+    const loadSkillTool = adapter.createLoadSkillTool({
+      projectId: null,
+      authToken: "token-1",
+      branchId: null,
+      availableSkillIds: [],
+    });
+    const result = await loadSkillTool.execute({ skillId: "custom" });
+
+    assert("instructions" in result);
+    assertEquals(result.instructions, "Use custom builtin instructions.");
+    assertEquals(result.references, ["references/custom.md"]);
+    assertEquals(readSkillCalls, [{ skillsDir, skillId: "custom" }]);
+    assertEquals(referenceCalls, [{ skillsDir, skillId: "custom" }]);
+  });
+});

--- a/src/agent/hosted-project-steering-adapter.ts
+++ b/src/agent/hosted-project-steering-adapter.ts
@@ -7,6 +7,7 @@ import {
 } from "./runtime-builtin-skill-files.ts";
 import {
   createRuntimeLoadSkillTool,
+  type RuntimeLoadSkillBuiltinStore,
   type RuntimeLoadSkillToolContext,
   type RuntimeLoadSkillToolInput,
   type RuntimeLoadSkillToolOutput,
@@ -50,6 +51,7 @@ export type HostedProjectSteeringAdapterOptions = {
   projectFilesClient?: RuntimeProjectFilesClient;
   projectSkillLoader?: RuntimeProjectSkillLoader;
   builtinSkills?: readonly RuntimeSkillDefinition[];
+  builtinStore?: RuntimeLoadSkillBuiltinStore;
 };
 
 export type HostedProjectSkillIdsContext = MutableAgentProjectContext & {
@@ -112,6 +114,14 @@ function createDefaultProjectSkillLoader(
   });
 }
 
+function createDefaultBuiltinStore(): RuntimeLoadSkillBuiltinStore {
+  return {
+    readSkill: readRuntimeBuiltinSkill,
+    readReferenceFile: readRuntimeBuiltinSkillReferenceFile,
+    listReferences: listRuntimeBuiltinSkillReferences,
+  };
+}
+
 export function createHostedProjectSteeringAdapter(
   options: HostedProjectSteeringAdapterOptions,
 ): HostedProjectSteeringAdapter {
@@ -120,6 +130,7 @@ export function createHostedProjectSteeringAdapter(
     createDefaultProjectSkillLoader(options, projectFilesClient);
   const builtinSkills = options.builtinSkills ??
     loadRuntimeBuiltinSkillCatalog({ skillsDir: options.skillsDir, logger: options.logger });
+  const builtinStore = options.builtinStore ?? createDefaultBuiltinStore();
 
   async function getProjectInstructions(
     lookup: RuntimeProjectSteeringLookup,
@@ -157,11 +168,7 @@ export function createHostedProjectSteeringAdapter(
         skillsDir: options.skillsDir,
         projectSkillLoader,
         builtinSkillIds: builtinSkills.map((skill) => skill.id),
-        builtinStore: {
-          readSkill: readRuntimeBuiltinSkill,
-          readReferenceFile: readRuntimeBuiltinSkillReferenceFile,
-          listReferences: listRuntimeBuiltinSkillReferences,
-        },
+        builtinStore,
         logger: options.logger,
       }),
     refreshProjectSkillIds: async (context) => {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.463";
+export const VERSION = "0.1.464";


### PR DESCRIPTION
## Summary
- allow hosted project steering adapters to receive a custom builtin skill store
- keep default builtin skill file behavior unchanged
- bump package version for CI/CD release

## Verification
- deno test --no-check --allow-all src/agent/hosted-project-steering-adapter.test.ts
- deno task verify:quick
- pre-push checks: format, lint, typecheck, unit tests (1772 passed)