### PR TITLE
Add hosted agent service route set

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.464",
+  "version": "0.1.465",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-agent-service-routes.test.ts
+++ b/src/agent/hosted-agent-service-routes.test.ts
@@ -1,0 +1,129 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { createDetachedRunTracker } from "./detached-run-tracker.ts";
+import { createHostedAgentServiceRouteSet } from "./hosted-agent-service-routes.ts";
+import type { HostedServiceAuthenticatedRequest } from "./hosted-service-auth.ts";
+import type { ParsedHostedChatRequest } from "./hosted-chat-request-parser.ts";
+
+function createDevToken(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: "none", typ: "JWT" }));
+  const body = btoa(JSON.stringify(payload));
+  return `${header}.${body}.unsigned`;
+}
+
+function createAuthenticatedRequest(path: string, body: unknown, method = "POST"): Request {
+  return new Request(`https://agent.example.test${path}`, {
+    method,
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${createDevToken({ userId: "user-1" })}`,
+    },
+    body: method === "DELETE" ? undefined : JSON.stringify(body),
+  });
+}
+
+function createAgUiBody(): Record<string, unknown> {
+  return {
+    threadId: "00000000-0000-4000-8000-000000000001",
+    runId: "run-1",
+    state: {},
+    messages: [],
+    tools: [],
+    context: [],
+  };
+}
+
+function createRouteSet(input: {
+  prepareExecution?: (req: ParsedHostedChatRequest) => Promise<{ executionId: string }>;
+  streamResponse?: Response;
+} = {}) {
+  const tracker = createDetachedRunTracker();
+  const preparedRequests: ParsedHostedChatRequest[] = [];
+  const streamInputs: Array<{ executionId: string; agUiRunId: string }> = [];
+
+  const routeSet = createHostedAgentServiceRouteSet({
+    tracker,
+    authenticateRequest: async (request): Promise<HostedServiceAuthenticatedRequest | Response> => {
+      const authorization = request.headers.get("authorization");
+      if (!authorization?.startsWith("Bearer ")) {
+        return Response.json({ errorCode: "UNAUTHENTICATED" }, { status: 401 });
+      }
+      return { authToken: authorization.slice(7), userId: "user-1" };
+    },
+    verifyProjectAccess: async () => ({ success: true }),
+    prepareExecution: async (req) => {
+      preparedRequests.push(req);
+      return input.prepareExecution?.(req) ?? { executionId: "exec-1" };
+    },
+    streamExecutionToAgUiResponse: (streamInput) => {
+      streamInputs.push({
+        executionId: streamInput.executionId,
+        agUiRunId: streamInput.agUiInput.runId,
+      });
+      return input.streamResponse ?? new Response("streamed");
+    },
+    startDetachedExecution: async () => {},
+  });
+
+  return { routeSet, tracker, preparedRequests, streamInputs };
+}
+
+Deno.test("hosted agent service routes expose the default hosted paths", () => {
+  const { routeSet } = createRouteSet();
+
+  assertEquals(routeSet.routes.map((route) => `${route.method} ${route.path}`), [
+    "POST /api/ag-ui/messages/stream",
+    "POST /api/ag-ui",
+    "DELETE /api/ag-ui/runs/:runId",
+    "POST /api/ag-ui/runs",
+    "POST /internal/agents/stream",
+  ]);
+});
+
+Deno.test("hosted agent service routes require auth for AG-UI streams", async () => {
+  const { routeSet } = createRouteSet();
+  const response = await routeSet.handleAgUiRequest(
+    new Request("https://agent.example.test/api/ag-ui", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(createAgUiBody()),
+    }),
+  );
+
+  assertEquals(response.status, 401);
+  assertEquals(await response.json(), { errorCode: "UNAUTHENTICATED" });
+});
+
+Deno.test("hosted agent service routes stream prepared AG-UI execution", async () => {
+  const streamResponse = new Response("ok", { status: 201 });
+  const { routeSet, preparedRequests, streamInputs } = createRouteSet({ streamResponse });
+  const response = await routeSet.handleAgUiRequest(
+    createAuthenticatedRequest("/api/ag-ui", createAgUiBody()),
+  );
+
+  assertEquals(response, streamResponse);
+  assertEquals(preparedRequests.length, 1);
+  assertEquals(streamInputs, [{ executionId: "exec-1", agUiRunId: "run-1" }]);
+});
+
+Deno.test("hosted agent service routes enforce durable root lineage", async () => {
+  const { routeSet } = createRouteSet();
+  const response = await routeSet.handleDurableChatRunExecuteRequest({
+    request: createAuthenticatedRequest("/api/ag-ui/runs", {
+      messages: [],
+      context: { projectId: null, branchId: null },
+    }),
+  });
+
+  assertEquals(response.status, 400);
+  assertEquals(await response.json(), { errorCode: "DURABLE_CHAT_ROOT_REQUIRES_CONVERSATION" });
+});
+
+Deno.test("hosted agent service routes cancel AG-UI runs", async () => {
+  const { routeSet } = createRouteSet();
+  const response = await routeSet.handleDurableChatRunCancelRequest({
+    request: createAuthenticatedRequest("/api/ag-ui/runs/run-1", {}, "DELETE"),
+    runId: "run-1",
+  });
+
+  assertEquals(response.status, 204);
+});

--- a/src/agent/hosted-agent-service-routes.ts
+++ b/src/agent/hosted-agent-service-routes.ts
@@ -1,0 +1,364 @@
+import { parseProviderError } from "../chat/provider-errors.ts";
+import type { AgentServiceRoute } from "./agent-service.ts";
+import { createAgUiRunErrorEvent, createAgUiSseErrorResponse } from "./ag-ui-host-support.ts";
+import { createAgUiRuntimeHandler } from "./ag-ui-runtime-handler.ts";
+import { createAgUiCancelHandler } from "./ag-ui-run-control.ts";
+import type { AgUiResumeValue } from "./ag-ui-tool-shared.ts";
+import type { DetachedRunTracker } from "./detached-run-tracker.ts";
+import {
+  buildParsedHostedAgUiRequest,
+  createHostedAgUiValidationErrorResponse,
+  type ParsedHostedAgUiRequest,
+} from "./hosted-ag-ui-chat-request.ts";
+import {
+  type ParsedHostedChatRequest,
+  parseHostedChatRequestFromRequest,
+  parseRuntimeAgentRunInvocationHostedChatRequestFromRequest,
+} from "./hosted-chat-request-parser.ts";
+import { executeHostedDurableChatRun } from "./hosted-durable-chat-run-start.ts";
+import {
+  type HostedServiceAuthenticatedRequest,
+  HostedServiceAuthError,
+} from "./hosted-service-auth.ts";
+import { createRequestAuthCache } from "./request-auth-cache.ts";
+import { isResponseLike } from "./response-like.ts";
+import type { AgUiRuntimeRequest } from "./runtime-ag-ui-contract.ts";
+
+export type HostedAgentServiceRoutesLogger = {
+  error(message: string, metadata?: Record<string, unknown>): void;
+};
+
+export type HostedAgentServiceRoutesTrace = <TResult>(
+  operationName: string,
+  operation: () => Promise<TResult>,
+) => Promise<TResult>;
+
+export type HostedAgentServiceActiveSpanAttributes = Record<
+  string,
+  string | number | boolean | readonly (string | number | boolean)[] | null | undefined
+>;
+
+export type HostedAgentServiceStreamExecutionInput<TExecution extends object> = TExecution & {
+  requestAbortSignal: AbortSignal;
+  agUiInput: AgUiRuntimeRequest;
+};
+
+export type HostedAgentServiceDetachedExecutionInput<TExecution extends object> = {
+  execution: TExecution;
+  abortSignal: AbortSignal;
+};
+
+export type HostedAgentServiceDetachedCleanupInput<TExecution extends object> = {
+  execution: TExecution;
+  runId: string;
+  conversationId: string;
+};
+
+export type HostedAgentServiceRouteSetOptions<TExecution extends object> = {
+  forwardedConfigNamespace?: string;
+  authenticateRequest: (
+    request: Request,
+  ) => Promise<HostedServiceAuthenticatedRequest | Response>;
+  verifyProjectAccess: (projectId: string, authToken: string) => Promise<
+    {
+      success: true;
+    } | {
+      success: false;
+      error: { errorCode: string; message: string; statusCode: number };
+    }
+  >;
+  tracker: DetachedRunTracker<AgUiResumeValue>;
+  prepareExecution: (req: ParsedHostedChatRequest) => Promise<TExecution>;
+  streamExecutionToAgUiResponse: (
+    input: HostedAgentServiceStreamExecutionInput<TExecution>,
+  ) => Promise<Response> | Response;
+  startDetachedExecution: (
+    input: HostedAgentServiceDetachedExecutionInput<TExecution>,
+  ) => Promise<void>;
+  cleanupExecution?: (
+    input: HostedAgentServiceDetachedCleanupInput<TExecution>,
+  ) => Promise<void>;
+  setActiveSpanAttributes?: (attributes: HostedAgentServiceActiveSpanAttributes) => void;
+  trace?: HostedAgentServiceRoutesTrace;
+  logger?: HostedAgentServiceRoutesLogger;
+};
+
+export type HostedAgentServiceRouteSet<TExecution extends object> = {
+  routes: AgentServiceRoute[];
+  authenticateAgUiRequest: (
+    request: Request,
+  ) => Promise<HostedServiceAuthenticatedRequest | Response>;
+  createAgUiValidationErrorResponse: (response: Response) => Promise<Response>;
+  buildParsedAgUiRequest: (input: {
+    agUiInput: AgUiRuntimeRequest;
+    authToken: string;
+    userId: string;
+  }) => Promise<ParsedHostedAgUiRequest | Response>;
+  handleAgUiRequest: (request: Request) => Promise<Response>;
+  handleDurableChatRunExecuteRequest: (input: {
+    request: Request;
+    requestOrCtx?: unknown;
+  }) => Promise<Response>;
+  handleRuntimeAgentRunInvocationExecuteRequest: (input: {
+    request: Request;
+    requestOrCtx?: unknown;
+  }) => Promise<Response>;
+  handleDurableChatRunCancelRequest: (input: {
+    request: Request;
+    runId: string | undefined;
+  }) => Promise<Response>;
+};
+
+function defaultTrace<TResult>(
+  _operationName: string,
+  operation: () => Promise<TResult>,
+): Promise<TResult> {
+  return operation();
+}
+
+function createAgUiSetupErrorResponse(input: {
+  error: unknown;
+  projectId: string | null;
+  userId: string;
+  runId: string | undefined;
+  logger?: HostedAgentServiceRoutesLogger;
+}): Response {
+  if (input.error instanceof HostedServiceAuthError) {
+    input.logger?.error("AG-UI auth error from API", {
+      errorCode: input.error.errorCode,
+      statusCode: input.error.statusCode,
+      projectId: input.projectId,
+      userId: input.userId,
+      runId: input.runId,
+    });
+    return createAgUiSseErrorResponse(
+      createAgUiRunErrorEvent(input.error.errorCode, input.error.errorCode),
+      input.error.statusCode,
+    );
+  }
+
+  const { code, status, message } = parseProviderError(input.error);
+  input.logger?.error("AG-UI request failed during setup", {
+    errorCode: code,
+    originalError: input.error instanceof Error ? input.error.message : String(input.error),
+    projectId: input.projectId,
+    userId: input.userId,
+    runId: input.runId,
+  });
+
+  const statusCode = status ||
+    (code === "OVERLOADED_ERROR" ? 503 : code === "CONTEXT_LENGTH_EXCEEDED" ? 413 : 500);
+  return createAgUiSseErrorResponse(createAgUiRunErrorEvent(message, code), statusCode);
+}
+
+export function createHostedAgentServiceRouteSet<TExecution extends object>(
+  options: HostedAgentServiceRouteSetOptions<TExecution>,
+): HostedAgentServiceRouteSet<TExecution> {
+  const trace = options.trace ?? defaultTrace;
+  const forwardedConfigNamespace = options.forwardedConfigNamespace ?? "veryfront";
+  const requestAuthCache = createRequestAuthCache<HostedServiceAuthenticatedRequest>({
+    authenticate: (request) => trace("agui.verifyJwt", () => options.authenticateRequest(request)),
+  });
+
+  async function authenticateAgUiRequest(
+    request: Request,
+  ): Promise<HostedServiceAuthenticatedRequest | Response> {
+    return requestAuthCache.authenticate(request);
+  }
+
+  async function buildParsedAgUiRequest(input: {
+    agUiInput: AgUiRuntimeRequest;
+    authToken: string;
+    userId: string;
+  }): Promise<ParsedHostedAgUiRequest | Response> {
+    return buildParsedHostedAgUiRequest({
+      ...input,
+      forwardedConfigNamespace,
+      verifyProjectAccess: ({ projectId, authToken }) =>
+        options.verifyProjectAccess(projectId, authToken),
+    });
+  }
+
+  async function executeAgUiRuntimeRequest(input: {
+    request: Request;
+    agUiInput: AgUiRuntimeRequest;
+  }): Promise<Response> {
+    const authenticatedRequest = await authenticateAgUiRequest(input.request);
+    if (isResponseLike(authenticatedRequest)) {
+      return authenticatedRequest;
+    }
+
+    const parsedRequest = await buildParsedAgUiRequest({
+      agUiInput: input.agUiInput,
+      authToken: authenticatedRequest.authToken,
+      userId: authenticatedRequest.userId,
+    });
+    if (isResponseLike(parsedRequest)) {
+      return parsedRequest;
+    }
+    const runId = parsedRequest.agUiInput?.runId;
+
+    try {
+      const execution = await options.prepareExecution(parsedRequest);
+      return await options.streamExecutionToAgUiResponse({
+        ...execution,
+        requestAbortSignal: input.request.signal,
+        agUiInput: parsedRequest.agUiInput,
+      });
+    } catch (error) {
+      return createAgUiSetupErrorResponse({
+        error,
+        projectId: parsedRequest.projectId,
+        userId: parsedRequest.userId,
+        runId,
+        logger: options.logger,
+      });
+    }
+  }
+
+  const hostedAgUiRuntimeHandler = createAgUiRuntimeHandler({
+    beforeParse: async ({ request }) => {
+      const result = await authenticateAgUiRequest(request);
+      return isResponseLike(result) ? result : undefined;
+    },
+    validationErrorResponse: ({ response }) => createHostedAgUiValidationErrorResponse(response),
+    execute: ({ request, agUiInput }) => executeAgUiRuntimeRequest({ request, agUiInput }),
+  });
+
+  async function handleAgUiRequest(request: Request): Promise<Response> {
+    return hostedAgUiRuntimeHandler(request);
+  }
+
+  async function executeParsedDurableChatRun(input: {
+    req: ParsedHostedChatRequest;
+    request: Request;
+    requestOrCtx?: unknown;
+  }): Promise<Response> {
+    return executeHostedDurableChatRun({
+      req: input.req,
+      rawRequest: input.request,
+      requestOrCtx: input.requestOrCtx,
+      tracker: options.tracker,
+      prepareExecution: options.prepareExecution,
+      startDetachedExecution: options.startDetachedExecution,
+      cleanupExecution: options.cleanupExecution,
+      resolveAuthError: (error) =>
+        error instanceof HostedServiceAuthError
+          ? {
+            errorCode: error.errorCode,
+            statusCode: error.statusCode,
+          }
+          : null,
+      logger: options.logger,
+    });
+  }
+
+  async function handleDurableChatRunExecuteRequest(input: {
+    request: Request;
+    requestOrCtx?: unknown;
+  }): Promise<Response> {
+    return trace("handler.durableChatRunExecute", async () => {
+      const req = await parseHostedChatRequestFromRequest(input.request, {
+        authenticate: options.authenticateRequest,
+        verifyProjectAccess: ({ projectId, authToken }) =>
+          options.verifyProjectAccess(projectId, authToken),
+      });
+      if (req instanceof Response) {
+        return req;
+      }
+
+      return executeParsedDurableChatRun({
+        req,
+        request: input.request,
+        requestOrCtx: input.requestOrCtx,
+      });
+    });
+  }
+
+  async function handleRuntimeAgentRunInvocationExecuteRequest(input: {
+    request: Request;
+    requestOrCtx?: unknown;
+  }): Promise<Response> {
+    return trace("handler.runtimeAgentRunInvocationExecute", async () => {
+      const req = await parseRuntimeAgentRunInvocationHostedChatRequestFromRequest(input.request, {
+        authenticate: options.authenticateRequest,
+        verifyProjectAccess: ({ projectId, authToken }) =>
+          options.verifyProjectAccess(projectId, authToken),
+      });
+      if (req instanceof Response) {
+        return req;
+      }
+
+      return executeParsedDurableChatRun({
+        req,
+        request: input.request,
+        requestOrCtx: input.requestOrCtx,
+      });
+    });
+  }
+
+  async function handleDurableChatRunCancelRequest(input: {
+    request: Request;
+    runId: string | undefined;
+  }): Promise<Response> {
+    return trace("handler.durableChatRunCancel", async () => {
+      const authenticatedRequest = await authenticateAgUiRequest(input.request);
+      if (authenticatedRequest instanceof Response) {
+        return authenticatedRequest;
+      }
+
+      if (!input.runId) {
+        return Response.json({ errorCode: "VALIDATION_ERROR" }, { status: 400 });
+      }
+
+      options.setActiveSpanAttributes?.({ "run.id": input.runId });
+      const hostedAgUiCancelHandler = createAgUiCancelHandler({
+        sessionManager: options.tracker.sessionManager,
+      });
+      return hostedAgUiCancelHandler(input.request);
+    });
+  }
+
+  const routes: AgentServiceRoute[] = [
+    {
+      method: "POST",
+      path: "/api/ag-ui/messages/stream",
+      handler: (request: Request) => handleAgUiRequest(request),
+    },
+    {
+      method: "POST",
+      path: "/api/ag-ui",
+      handler: (request: Request) => handleAgUiRequest(request),
+    },
+    {
+      method: "DELETE",
+      path: "/api/ag-ui/runs/:runId",
+      handler: (request: Request, params: Record<string, string>) =>
+        handleDurableChatRunCancelRequest({
+          request,
+          runId: params.runId,
+        }),
+    },
+    {
+      method: "POST",
+      path: "/api/ag-ui/runs",
+      handler: (request: Request) => handleDurableChatRunExecuteRequest({ request }),
+    },
+    {
+      method: "POST",
+      path: "/internal/agents/stream",
+      handler: (request: Request) => handleRuntimeAgentRunInvocationExecuteRequest({ request }),
+    },
+  ];
+
+  return {
+    routes,
+    authenticateAgUiRequest,
+    createAgUiValidationErrorResponse: createHostedAgUiValidationErrorResponse,
+    buildParsedAgUiRequest,
+    handleAgUiRequest,
+    handleDurableChatRunExecuteRequest,
+    handleRuntimeAgentRunInvocationExecuteRequest,
+    handleDurableChatRunCancelRequest,
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -309,6 +309,17 @@ export type {
 } from "./hosted-chat-runtime-contract.ts";
 
 export {
+  createHostedAgentServiceRouteSet,
+  type HostedAgentServiceActiveSpanAttributes,
+  type HostedAgentServiceDetachedCleanupInput,
+  type HostedAgentServiceDetachedExecutionInput,
+  type HostedAgentServiceRouteSet,
+  type HostedAgentServiceRouteSetOptions,
+  type HostedAgentServiceRoutesLogger,
+  type HostedAgentServiceRoutesTrace,
+  type HostedAgentServiceStreamExecutionInput,
+} from "./hosted-agent-service-routes.ts";
+export {
   executeHostedDurableChatRun,
   type ExecuteHostedDurableChatRunInput,
   type HostedDurableRunAccepted,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.464";
+export const VERSION = "0.1.465";


### PR DESCRIPTION
## Summary
- add a reusable hosted agent service route set for AG-UI stream, durable run start/cancel, and runtime-agent invocation routes
- keep host callbacks responsible for auth, project access, execution prep, streaming, detached execution, and tracing
- bump package version for CI/CD release

## Verification
- deno test --no-check --allow-all src/agent/hosted-agent-service-routes.test.ts
- deno check src/agent/index.ts
- deno task verify:quick
- pre-push checks: format, lint, typecheck, unit tests (1777 passed)