### PR TITLE
Add hosted runtime state resolver

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.465",
+  "version": "0.1.466",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-runtime-state-resolver.test.ts
+++ b/src/agent/hosted-runtime-state-resolver.test.ts
@@ -1,0 +1,96 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createHostedRuntimeStateResolver } from "./hosted-runtime-state-resolver.ts";
+import { FIRST_TURN_STARTER_INTENT_ROOT_OWNERSHIP_CONTEXT_KEY } from "./conversation-delegation-policy.ts";
+
+function createUserMessage(text: string) {
+  return {
+    role: "user",
+    content: text,
+  };
+}
+
+function createAssistantToolCall(toolName: string) {
+  return {
+    role: "assistant",
+    content: [{ type: "tool-call", toolCallId: `tool-${toolName}`, toolName }],
+  };
+}
+
+describe("agent/hosted-runtime-state-resolver", () => {
+  it("refreshes system instructions when the steering context changes", async () => {
+    const taskContext = {
+      projectId: "project-1",
+      branchId: null,
+      steeringRevision: 0,
+    };
+    let refreshCount = 0;
+    const resolver = createHostedRuntimeStateResolver({
+      taskContext,
+      refreshSystem: () => {
+        refreshCount += 1;
+        return `refreshed-${refreshCount}`;
+      },
+    });
+
+    assertEquals(await resolver({ system: "initial", messages: [], step: 0 }), {
+      system: "initial",
+      context: {},
+    });
+
+    taskContext.steeringRevision = 1;
+
+    assertEquals(await resolver({ system: "initial", messages: [], step: 1 }), {
+      system: "refreshed-1",
+      context: {},
+    });
+    assertEquals(refreshCount, 1);
+  });
+
+  it("applies starter-intent blocking context only while required", async () => {
+    const taskContext = {
+      projectId: null,
+      branchId: null,
+    };
+    const resolver = createHostedRuntimeStateResolver({ taskContext });
+
+    const first = await resolver({
+      system: "system",
+      messages: [createUserMessage("/plan create an app")],
+      step: 1,
+    });
+
+    assertEquals(first.context[FIRST_TURN_STARTER_INTENT_ROOT_OWNERSHIP_CONTEXT_KEY], true);
+
+    const second = await resolver({
+      context: first.context,
+      system: first.system,
+      messages: [createUserMessage("/plan create an app")],
+      step: 2,
+    });
+
+    assertEquals(
+      FIRST_TURN_STARTER_INTENT_ROOT_OWNERSHIP_CONTEXT_KEY in second.context,
+      false,
+    );
+  });
+
+  it("keeps slash-command artifact reminders until the host records the artifact path", async () => {
+    const taskContext = {
+      projectId: null,
+      branchId: null,
+      slashCommandArtifactPathSeen: false,
+    };
+    const resolver = createHostedRuntimeStateResolver({ taskContext });
+    const result = await resolver({
+      system: "system",
+      messages: [
+        createUserMessage("/plan build a dashboard in /plans/dashboard.md"),
+        createAssistantToolCall("load_skill"),
+      ],
+      step: 1,
+    });
+
+    assertEquals(result.system.includes("artifact"), true);
+  });
+});

--- a/src/agent/hosted-runtime-state-resolver.ts
+++ b/src/agent/hosted-runtime-state-resolver.ts
@@ -1,0 +1,133 @@
+import {
+  type DefaultResearchArtifactContext,
+  extractLatestUserText,
+  updateDefaultResearchArtifacts,
+} from "./default-research-artifact-support.ts";
+import {
+  addFirstTurnStarterIntentRootOwnershipReminder,
+  addSlashCommandArtifactReminder,
+  evaluateStarterIntentTurnPolicy,
+  FIRST_TURN_STARTER_INTENT_ROOT_OWNERSHIP_CONTEXT_KEY,
+} from "./conversation-delegation-policy.ts";
+import { evaluateSlashCommandArtifactPolicy } from "./slash-command-artifact-policy.ts";
+import { flattenSystemInstructions } from "./runtime-tool-inventory.ts";
+
+export type HostedRuntimeStateResolverContext = DefaultResearchArtifactContext & {
+  projectId?: string | null;
+  branchId?: string | null;
+  steeringRevision?: number;
+  slashCommandArtifactPathSeen?: boolean;
+};
+
+export type HostedRuntimeStateResolverInput = {
+  context?: Record<string, unknown>;
+  system: string;
+  messages: readonly unknown[];
+  step: number;
+};
+
+export type HostedRuntimeStateResolverResult = {
+  system: string;
+  context: Record<string, unknown>;
+};
+
+export type HostedRuntimeSystemRefreshInput<TContext extends HostedRuntimeStateResolverContext> = {
+  taskContext: TContext;
+  system: string;
+};
+
+export type HostedRuntimeSystemRefresh<TContext extends HostedRuntimeStateResolverContext> = (
+  input: HostedRuntimeSystemRefreshInput<TContext>,
+) => Promise<string> | string;
+
+export type CreateHostedRuntimeStateResolverOptions<
+  TContext extends HostedRuntimeStateResolverContext,
+> = {
+  taskContext: TContext;
+  refreshSystem?: HostedRuntimeSystemRefresh<TContext>;
+};
+
+function activeProjectId(context: HostedRuntimeStateResolverContext): string | null {
+  return context.projectId || null;
+}
+
+function activeBranchId(context: HostedRuntimeStateResolverContext): string | null {
+  return context.branchId ?? null;
+}
+
+function steeringRevision(context: HostedRuntimeStateResolverContext): number {
+  return context.steeringRevision ?? 0;
+}
+
+export function createHostedRuntimeStateResolver<
+  TContext extends HostedRuntimeStateResolverContext,
+>(
+  options: CreateHostedRuntimeStateResolverOptions<TContext>,
+): (input: HostedRuntimeStateResolverInput) => Promise<HostedRuntimeStateResolverResult> {
+  let lastAppliedSteeringRevision = steeringRevision(options.taskContext);
+  let lastAppliedProjectId = activeProjectId(options.taskContext);
+  let lastAppliedBranchId = activeBranchId(options.taskContext);
+
+  return async ({ context, system, messages, step }) => {
+    const currentSteeringRevision = steeringRevision(options.taskContext);
+    const currentProjectId = activeProjectId(options.taskContext);
+    const currentBranchId = activeBranchId(options.taskContext);
+    const steeringChanged = currentSteeringRevision !== lastAppliedSteeringRevision ||
+      currentProjectId !== lastAppliedProjectId ||
+      currentBranchId !== lastAppliedBranchId;
+
+    let nextSystem = system;
+    const nextContextRecord = { ...(context ?? {}) };
+
+    if (steeringChanged && options.refreshSystem) {
+      nextSystem = await options.refreshSystem({
+        taskContext: options.taskContext,
+        system,
+      });
+
+      lastAppliedSteeringRevision = currentSteeringRevision;
+      lastAppliedProjectId = currentProjectId;
+      lastAppliedBranchId = currentBranchId;
+    }
+
+    const latestUserText = extractLatestUserText(messages);
+    if (latestUserText) {
+      const reminded = updateDefaultResearchArtifacts({
+        taskContext: options.taskContext,
+        latestUserText,
+        system: nextSystem,
+      });
+      nextSystem = typeof reminded === "string" ? reminded : flattenSystemInstructions(reminded);
+    }
+
+    const starterIntentPolicy = evaluateStarterIntentTurnPolicy({
+      messages,
+      step,
+    });
+
+    if (starterIntentPolicy.shouldAddRootOwnershipReminder) {
+      nextSystem = addFirstTurnStarterIntentRootOwnershipReminder(nextSystem);
+    }
+
+    if (starterIntentPolicy.shouldBlockImmediateDelegation) {
+      nextContextRecord[FIRST_TURN_STARTER_INTENT_ROOT_OWNERSHIP_CONTEXT_KEY] = true;
+    } else {
+      delete nextContextRecord[FIRST_TURN_STARTER_INTENT_ROOT_OWNERSHIP_CONTEXT_KEY];
+    }
+
+    const slashCommandArtifactPolicy = evaluateSlashCommandArtifactPolicy({
+      messages,
+      slashCommandArtifactPathSeen: options.taskContext.slashCommandArtifactPathSeen,
+    });
+
+    if (slashCommandArtifactPolicy.shouldKeepReminder) {
+      const reminded = addSlashCommandArtifactReminder(nextSystem);
+      nextSystem = typeof reminded === "string" ? reminded : flattenSystemInstructions(reminded);
+    }
+
+    return {
+      system: nextSystem,
+      context: nextContextRecord,
+    };
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -320,6 +320,15 @@ export {
   type HostedAgentServiceStreamExecutionInput,
 } from "./hosted-agent-service-routes.ts";
 export {
+  createHostedRuntimeStateResolver,
+  type CreateHostedRuntimeStateResolverOptions,
+  type HostedRuntimeStateResolverContext,
+  type HostedRuntimeStateResolverInput,
+  type HostedRuntimeStateResolverResult,
+  type HostedRuntimeSystemRefresh,
+  type HostedRuntimeSystemRefreshInput,
+} from "./hosted-runtime-state-resolver.ts";
+export {
   executeHostedDurableChatRun,
   type ExecuteHostedDurableChatRunInput,
   type HostedDurableRunAccepted,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.465";
+export const VERSION = "0.1.466";


### PR DESCRIPTION
## Summary\n- add a reusable hosted runtime state resolver for per-step system/context policy updates\n- cover steering refresh, starter-intent delegation blocking, slash-command artifact reminders, and default research artifact updates\n- bump stable package version to 0.1.466 for CI/CD publish\n\n## Verification\n- deno test --no-check --allow-all src/agent/hosted-runtime-state-resolver.test.ts\n- deno check src/agent/index.ts\n- deno task verify:quick