### PR TITLE
Add hosted child invoke tool wrapper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.466",
+  "version": "0.1.467",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-child-invoke-tool.test.ts
+++ b/src/agent/hosted-child-invoke-tool.test.ts
@@ -1,0 +1,93 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { z } from "zod";
+import {
+  FIRST_TURN_STARTER_INTENT_ROOT_OWNERSHIP_BLOCK_MESSAGE,
+  FIRST_TURN_STARTER_INTENT_ROOT_OWNERSHIP_CONTEXT_KEY,
+} from "./conversation-delegation-policy.ts";
+import { createHostedChildInvokeTool } from "./hosted-child-invoke-tool.ts";
+
+const inputSchema = z.object({
+  description: z.string(),
+});
+
+type TestInput = z.infer<typeof inputSchema>;
+
+type TestResult = {
+  success: boolean;
+  description?: string;
+  terminalErrorCode?: string;
+  terminalErrorMessage?: string;
+  decorated?: boolean;
+};
+
+function buildFailureResult(failure: {
+  terminalErrorCode: string;
+  terminalErrorMessage: string;
+}): TestResult {
+  return {
+    success: false,
+    terminalErrorCode: failure.terminalErrorCode,
+    terminalErrorMessage: failure.terminalErrorMessage,
+  };
+}
+
+Deno.test("createHostedChildInvokeTool builds the shared child invoke description and executes", async () => {
+  const invokeTool = createHostedChildInvokeTool<TestInput, TestResult>({
+    inputSchema,
+    additionalDescriptionParts: ["Use agent_id to target a specific child agent."],
+    buildFailureResult,
+    execute: (input) => ({ success: true, description: input.description }),
+    decorateResult: (result) => ({ ...result, decorated: true }),
+  });
+
+  assertStringIncludes(invokeTool.description, "Invoke a focused child agent");
+  assertStringIncludes(invokeTool.description, "Use agent_id to target");
+  assertEquals(await invokeTool.execute({ description: "inspect auth" }), {
+    success: true,
+    description: "inspect auth",
+    decorated: true,
+  });
+});
+
+Deno.test("createHostedChildInvokeTool blocks first-turn starter intent delegation", async () => {
+  const invokeTool = createHostedChildInvokeTool<TestInput, TestResult>({
+    inputSchema,
+    buildFailureResult,
+    execute: (input) => ({ success: true, description: input.description }),
+  });
+
+  const result = await invokeTool.execute(
+    { description: "delegate immediately" },
+    { [FIRST_TURN_STARTER_INTENT_ROOT_OWNERSHIP_CONTEXT_KEY]: true },
+  );
+
+  assertEquals(result, {
+    success: false,
+    terminalErrorCode: "STARTER_INTENT_ROOT_OWNERSHIP_REQUIRED",
+    terminalErrorMessage: FIRST_TURN_STARTER_INTENT_ROOT_OWNERSHIP_BLOCK_MESSAGE,
+  });
+});
+
+Deno.test("createHostedChildInvokeTool blocks same-turn retry after a cancellation result", async () => {
+  const invokeTool = createHostedChildInvokeTool<TestInput, TestResult>({
+    inputSchema,
+    buildFailureResult,
+    execute: () => ({
+      success: false,
+      terminalErrorCode: "DURABLE_CHILD_CANCELLED",
+      terminalErrorMessage: "Child run cancelled",
+    }),
+  });
+
+  assertEquals(await invokeTool.execute({ description: "first attempt" }), {
+    success: false,
+    terminalErrorCode: "DURABLE_CHILD_CANCELLED",
+    terminalErrorMessage: "Child run cancelled",
+  });
+  assertEquals(await invokeTool.execute({ description: "retry" }), {
+    success: false,
+    terminalErrorCode: "INVOKE_AGENT_RETRY_BLOCKED",
+    terminalErrorMessage:
+      "A delegated child run was cancelled in this response. Start a fresh turn instead of retrying invoke_agent again in the same run.",
+  });
+});

--- a/src/agent/hosted-child-invoke-tool.ts
+++ b/src/agent/hosted-child-invoke-tool.ts
@@ -1,0 +1,90 @@
+import { tool } from "#veryfront/tool";
+import type { Tool, ToolConfig, ToolExecutionContext } from "#veryfront/tool";
+import {
+  buildInvokeAgentFollowupInstruction,
+  FIRST_TURN_STARTER_INTENT_ROOT_OWNERSHIP_BLOCK_MESSAGE,
+  FIRST_TURN_STARTER_INTENT_ROOT_OWNERSHIP_CONTEXT_KEY,
+  isStarterIntentRootOwnershipRequired,
+} from "./conversation-delegation-policy.ts";
+import { buildHostedChildToolDescription } from "./hosted-child-requested-tools.ts";
+import { shouldBlockHostedChildSameTurnRetry } from "./hosted-child-status.ts";
+
+export interface HostedChildInvokeFailure {
+  terminalErrorCode: string;
+  terminalErrorMessage: string;
+}
+
+export interface CreateHostedChildInvokeToolOptions<TInput, TResult> {
+  id?: string;
+  inputSchema: ToolConfig<TInput, TResult>["inputSchema"];
+  additionalDescriptionParts?: readonly string[];
+  execute: (input: TInput, context?: ToolExecutionContext) => Promise<TResult> | TResult;
+  buildFailureResult: (failure: HostedChildInvokeFailure) => TResult;
+  decorateResult?: (result: TResult) => TResult;
+  shouldBlockSameTurnRetry?: (result: TResult) => boolean;
+  retryBlockedErrorCode?: string;
+  retryBlockedMessage?: string;
+  starterIntentRootOwnershipErrorCode?: string;
+  starterIntentRootOwnershipMessage?: string;
+}
+
+const DEFAULT_RETRY_BLOCKED_ERROR_CODE = "INVOKE_AGENT_RETRY_BLOCKED";
+const DEFAULT_STARTER_INTENT_ROOT_OWNERSHIP_ERROR_CODE = "STARTER_INTENT_ROOT_OWNERSHIP_REQUIRED";
+const DEFAULT_RETRY_BLOCKED_MESSAGE =
+  "A delegated child run was cancelled in this response. Start a fresh turn instead of retrying invoke_agent again in the same run.";
+
+function shouldBlockForStarterIntentRootOwnership(context?: ToolExecutionContext): boolean {
+  return isStarterIntentRootOwnershipRequired(
+    context?.[FIRST_TURN_STARTER_INTENT_ROOT_OWNERSHIP_CONTEXT_KEY],
+  );
+}
+
+function buildHostedChildInvokeToolDescription(
+  additionalDescriptionParts?: readonly string[],
+): string {
+  return [
+    buildHostedChildToolDescription(),
+    buildInvokeAgentFollowupInstruction(),
+    ...(additionalDescriptionParts ?? []),
+  ].join("\n\n");
+}
+
+export function createHostedChildInvokeTool<TInput, TResult>(
+  options: CreateHostedChildInvokeToolOptions<TInput, TResult>,
+): Tool<TInput, TResult> {
+  let blockedRetryMessage: string | null = null;
+
+  return tool({
+    ...(options.id ? { id: options.id } : {}),
+    description: buildHostedChildInvokeToolDescription(options.additionalDescriptionParts),
+    inputSchema: options.inputSchema,
+    execute: async (input, executionOptions) => {
+      if (blockedRetryMessage) {
+        return options.buildFailureResult({
+          terminalErrorCode: options.retryBlockedErrorCode ?? DEFAULT_RETRY_BLOCKED_ERROR_CODE,
+          terminalErrorMessage: blockedRetryMessage,
+        });
+      }
+
+      if (shouldBlockForStarterIntentRootOwnership(executionOptions)) {
+        return options.buildFailureResult({
+          terminalErrorCode: options.starterIntentRootOwnershipErrorCode ??
+            DEFAULT_STARTER_INTENT_ROOT_OWNERSHIP_ERROR_CODE,
+          terminalErrorMessage: options.starterIntentRootOwnershipMessage ??
+            FIRST_TURN_STARTER_INTENT_ROOT_OWNERSHIP_BLOCK_MESSAGE,
+        });
+      }
+
+      const rawResult = await options.execute(input, executionOptions);
+      const result = options.decorateResult ? options.decorateResult(rawResult) : rawResult;
+      const shouldBlockRetry = options.shouldBlockSameTurnRetry ??
+        shouldBlockHostedChildSameTurnRetry;
+
+      if (shouldBlockRetry(result)) {
+        blockedRetryMessage = options.retryBlockedMessage ?? DEFAULT_RETRY_BLOCKED_MESSAGE;
+      }
+
+      return result;
+    },
+  });
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -772,6 +772,11 @@ export {
 } from "./hosted-child-tool-input.ts";
 
 export {
+  createHostedChildInvokeTool,
+  type CreateHostedChildInvokeToolOptions,
+  type HostedChildInvokeFailure,
+} from "./hosted-child-invoke-tool.ts";
+export {
   buildDefaultHostedChildForkToolSet,
   buildHostedChildToolDescription,
   DEFAULT_HOSTED_CHILD_EXCLUDED_TOOL_NAMES,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.466";
+export const VERSION = "0.1.467";


### PR DESCRIPTION
## Summary
- add a reusable hosted child invoke tool wrapper for separately deployed agent services
- centralize starter-intent delegation blocking and same-turn cancelled-child retry blocking
- bump package version to 0.1.467 for CI/CD publish

## Verification
- `deno test --no-check --allow-all src/agent/hosted-child-invoke-tool.test.ts`
- `deno check src/agent/index.ts`
- `deno task verify:quick`
- pre-push checks: format, lint, typecheck, unit tests (`1781 passed`, `0 failed`)
