### PR TITLE
Add root-owned child result hint helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.467",
+  "version": "0.1.468",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/conversation-delegation-policy.test.ts
+++ b/src/agent/conversation-delegation-policy.test.ts
@@ -20,6 +20,7 @@ import {
   shouldReinforceLoadSkillContinuation,
   SLASH_COMMAND_ARTIFACT_REMINDER,
   SYNTHESIZE_DELEGATED_FINDINGS_IN_ROOT_VOICE,
+  withRootOwnedChildResultHint,
 } from "./conversation-delegation-policy.ts";
 
 const RESEARCH_REQUEST = "make a deep research on a2a protocol";
@@ -94,6 +95,51 @@ describe("conversation delegation policy", () => {
         suggestedText: "Final report delivered.",
       },
     );
+  });
+
+  it("adds root-owned hints to successful local child results", () => {
+    assertEquals(
+      withRootOwnedChildResultHint({
+        success: true,
+        summary: { text: "child result" },
+      }),
+      {
+        success: true,
+        summary: { text: "child result" },
+        rootResponseHint: {
+          instruction: ROOT_OWNED_CHILD_RESULT_INSTRUCTION,
+          suggestedText: "child result",
+        },
+      },
+    );
+  });
+
+  it("adds root-owned hints to completed durable child results", () => {
+    assertEquals(
+      withRootOwnedChildResultHint({
+        ok: true,
+        status: "completed",
+        text: "durable child result",
+      }),
+      {
+        ok: true,
+        status: "completed",
+        text: "durable child result",
+        rootResponseHint: {
+          instruction: ROOT_OWNED_CHILD_RESULT_INSTRUCTION,
+          suggestedText: "durable child result",
+        },
+      },
+    );
+  });
+
+  it("leaves failed child results unchanged", () => {
+    const failedResult = {
+      success: false,
+      error: "failed",
+    };
+
+    assertEquals(withRootOwnedChildResultHint(failedResult), failedResult);
   });
 
   it("builds invoke_agent follow-up guidance from the shared narration guard", () => {

--- a/src/agent/conversation-delegation-policy.ts
+++ b/src/agent/conversation-delegation-policy.ts
@@ -37,6 +37,51 @@ export function buildRootOwnedChildResultHint(
   });
 }
 
+export interface RootOwnedChildResultHint {
+  instruction: string;
+  suggestedText: string;
+}
+
+export interface RootOwnedChildResultHinted {
+  rootResponseHint?: RootOwnedChildResultHint;
+}
+
+function getRootOwnedChildResultText(result: unknown): string | null {
+  if (!isRecord(result)) {
+    return null;
+  }
+
+  if (
+    result.status === "completed" &&
+    typeof result.text === "string" &&
+    result.text.length > 0
+  ) {
+    return result.text;
+  }
+
+  if (!result.success || !isRecord(result.summary)) {
+    return null;
+  }
+
+  return typeof result.summary.text === "string" && result.summary.text.length > 0
+    ? result.summary.text
+    : null;
+}
+
+export function withRootOwnedChildResultHint<T extends object>(
+  result: T,
+): T & RootOwnedChildResultHinted {
+  const text = getRootOwnedChildResultText(result);
+  if (!text) {
+    return result;
+  }
+
+  return {
+    ...result,
+    rootResponseHint: buildRootOwnedChildResultHint(text),
+  };
+}
+
 export function buildInvokeAgentFollowupInstruction(): string {
   return `${SYNTHESIZE_DELEGATED_FINDINGS_IN_ROOT_VOICE} ${NO_DELEGATION_NARRATION_UNLESS_ASKED}`;
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -859,9 +859,12 @@ export {
   LOAD_SKILL_USE_ALLOWED_TOOLS,
   NO_DELEGATION_NARRATION_UNLESS_ASKED,
   ROOT_OWNED_CHILD_RESULT_INSTRUCTION,
+  type RootOwnedChildResultHint,
+  type RootOwnedChildResultHinted,
   shouldReinforceLoadSkillContinuation,
   SLASH_COMMAND_ARTIFACT_REMINDER,
   SYNTHESIZE_DELEGATED_FINDINGS_IN_ROOT_VOICE,
+  withRootOwnedChildResultHint,
 } from "./conversation-delegation-policy.ts";
 export {
   listRuntimeBuiltinSkillReferenceFiles,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.467";
+export const VERSION = "0.1.468";


### PR DESCRIPTION
## Summary
- add a reusable root-owned child result hint helper for local and durable child results
- export shared hint types for hosted child invoke wrappers
- bump package version to 0.1.468 for CI/CD publish

## Verification
- `deno test --no-check --allow-all src/agent/conversation-delegation-policy.test.ts`
- `deno check src/agent/index.ts`
- `deno task verify:quick`
- pre-push checks: format, lint, typecheck, unit tests (`1781 passed`, `0 failed`)
