### PR TITLE
Add hosted local child invoke helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.468",
+  "version": "0.1.469",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-durable-child-fork-execution.test.ts
+++ b/src/agent/hosted-durable-child-fork-execution.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   buildChildRunExecutionSnapshot,
@@ -11,6 +11,7 @@ import {
   buildHostedDurableChildInvokeTerminalFailureResult,
   createHostedDurableChildInvokeTraceRecorder,
   executeHostedDurableChildFork,
+  executeHostedLocalChildInvoke,
   type HostedDurableChildSetupFailure,
   type HostedDurableChildSuccess,
 } from "./hosted-durable-child-fork-execution.ts";
@@ -332,6 +333,83 @@ describe("agent/hosted-durable-child-fork-execution", () => {
       "gen_ai.usage.input_tokens": 3,
       "gen_ai.usage.output_tokens": 4,
     });
+  });
+
+  it("records successful local child invoke results", async () => {
+    const localResult: ChildRunExecutionResult = {
+      success: true,
+      description: "Inspect logs",
+      summary: { text: "done" },
+      steps: 1,
+      toolCalls: [],
+      toolResults: [],
+      durationMs: 10,
+    };
+    const recordedFailures: string[] = [];
+    const result = await executeHostedLocalChildInvoke({
+      forkInput: { description: "Inspect logs" },
+      traceRecorder: {
+        recordLocalResult: (recordedResult) => recordedResult,
+        recordLocalFailure: (errorMessage) => {
+          recordedFailures.push(errorMessage);
+        },
+      },
+      execute: () => localResult,
+    });
+
+    assertEquals(result, localResult);
+    assertEquals(recordedFailures, []);
+  });
+
+  it("normalizes non-abort local child invoke failures", async () => {
+    const recordedFailures: string[] = [];
+    const result = await executeHostedLocalChildInvoke({
+      forkInput: { description: "Inspect logs" },
+      traceRecorder: {
+        recordLocalResult: (recordedResult) => recordedResult,
+        recordLocalFailure: (errorMessage) => {
+          recordedFailures.push(errorMessage);
+        },
+      },
+      execute: () => {
+        throw new Error("provider failed");
+      },
+    });
+
+    assertEquals(recordedFailures, ["provider failed"]);
+    assertEquals(result, {
+      success: false,
+      description: "Inspect logs",
+      error: "provider failed",
+      steps: 0,
+      toolCalls: [],
+      toolResults: [],
+      durationMs: 0,
+    });
+  });
+
+  it("rethrows user-requested local child invoke aborts", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+    const abortError = new Error("Aborted");
+
+    await assertRejects(
+      () =>
+        executeHostedLocalChildInvoke({
+          forkInput: { description: "Inspect logs" },
+          abortSignal: abortController.signal,
+          traceRecorder: {
+            recordLocalResult: (recordedResult) => recordedResult,
+            recordLocalFailure: () => {},
+          },
+          execute: () => {
+            throw abortError;
+          },
+          isAbortError: (error) => error === abortError,
+        }),
+      Error,
+      "Aborted",
+    );
   });
 
   it("returns a host-shaped context-unavailable result without bootstrapping", async () => {

--- a/src/agent/hosted-durable-child-fork-execution.ts
+++ b/src/agent/hosted-durable-child-fork-execution.ts
@@ -21,7 +21,7 @@ import {
   type HostedChildTerminalStatus,
 } from "./hosted-child-status.ts";
 import type { HostedChildForkToolInput } from "./hosted-child-tool-input.ts";
-import { throwIfChildRunAborted } from "./child-run-execution-support.ts";
+import { isChildRunAbortError, throwIfChildRunAborted } from "./child-run-execution-support.ts";
 
 export type HostedDurableChildExecutionOptions = {
   durableChildRun?: HostedChildRunIdentifiers;
@@ -96,6 +96,21 @@ export type HostedDurableChildInvokeTraceOverrides = Partial<
 export type HostedDurableChildInvokeTraceRecorder = ReturnType<
   typeof createHostedDurableChildInvokeTraceRecorder
 >;
+
+export type HostedLocalChildInvokeTraceRecorder = {
+  recordLocalResult<TLocalResult extends ChildRunExecutionResult>(
+    result: TLocalResult,
+  ): TLocalResult;
+  recordLocalFailure(errorMessage: string): void;
+};
+
+export type ExecuteHostedLocalChildInvokeInput = {
+  forkInput: Pick<HostedChildForkToolInput, "description">;
+  abortSignal?: AbortSignal;
+  traceRecorder: HostedLocalChildInvokeTraceRecorder;
+  execute: () => Promise<ChildRunExecutionResult> | ChildRunExecutionResult;
+  isAbortError?: (error: unknown) => boolean;
+};
 
 export function buildHostedDurableChildInvokeFailureResult(
   input: BuildHostedDurableChildInvokeFailureResultInput,
@@ -253,6 +268,34 @@ export function createHostedDurableChildInvokeTraceRecorder(input: {
       return buildHostedDurableChildInvokeSuccessResult(success);
     },
   };
+}
+
+export async function executeHostedLocalChildInvoke(
+  input: ExecuteHostedLocalChildInvokeInput,
+): Promise<ChildRunExecutionResult> {
+  try {
+    const result = await input.execute();
+    return input.traceRecorder.recordLocalResult(result);
+  } catch (error) {
+    const isAbortError = input.isAbortError ?? isChildRunAbortError;
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    if (isAbortError(error) && (input.abortSignal?.aborted || errorMessage === "Aborted")) {
+      throw error;
+    }
+
+    input.traceRecorder.recordLocalFailure(errorMessage);
+
+    return {
+      success: false,
+      description: input.forkInput.description,
+      error: errorMessage,
+      steps: 0,
+      toolCalls: [],
+      toolResults: [],
+      durationMs: 0,
+    };
+  }
 }
 
 export type HostedDurableChildBootstrapContext = {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -608,6 +608,8 @@ export {
   createHostedDurableChildInvokeTraceRecorder,
   executeHostedDurableChildFork,
   type ExecuteHostedDurableChildForkInput,
+  executeHostedLocalChildInvoke,
+  type ExecuteHostedLocalChildInvokeInput,
   type HostedDurableChildBootstrapCallbacks,
   type HostedDurableChildBootstrapContext,
   type HostedDurableChildExecutionOptions,
@@ -620,6 +622,7 @@ export {
   type HostedDurableChildSetupFailure,
   type HostedDurableChildSuccess,
   type HostedDurableChildTerminalFailure,
+  type HostedLocalChildInvokeTraceRecorder,
 } from "./hosted-durable-child-fork-execution.ts";
 export {
   bootstrapHostedChildRun,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.468";
+export const VERSION = "0.1.469";


### PR DESCRIPTION
## Summary
- add a reusable hosted local child-invoke fallback helper
- normalize local child execution failures through the shared result shape and trace recorder
- bump package version to 0.1.469 for CI/CD publish

## Verification
- `deno test --no-check --allow-all src/agent/hosted-durable-child-fork-execution.test.ts`
- `deno check src/agent/index.ts`
- `deno task verify:quick`
- pre-push checks: format, lint, typecheck, unit tests (`1781 passed`, `0 failed`)
