### PR TITLE
Add bootstrapped hosted chat execution runtime helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.469",
+  "version": "0.1.470",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-chat-execution-runtime.test.ts
+++ b/src/agent/hosted-chat-execution-runtime.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ChatUiMessage, ChatUiMessageChunk, MessageMetadata } from "../chat/types.ts";
+import type { HostedAgentRunSpan, HostedAgentRunTracer } from "./hosted-agent-run-lifecycle.ts";
 import type { ConversationRunChunkMirror } from "./conversation-run-chunk-mirror.ts";
 import type {
   HostedChatRuntimeAgent,
@@ -11,6 +12,7 @@ import type { HostedLifecycleTerminalState } from "./hosted-lifecycle.ts";
 import { createMirroredToolChunkState } from "./mirrored-tool-chunk-state.ts";
 import {
   cleanupAfterHostedChatExecutionFinalization,
+  createBootstrappedHostedChatExecutionRuntime,
   createHostedChatExecutionRuntime,
   createHostedChatExecutionRuntimeBootstrap,
   createHostedChatFinalizeDetachedBuildState,
@@ -137,6 +139,38 @@ function createLogger() {
       warn: (message: string, metadata?: Record<string, unknown>) => {
         warnings.push({ message, ...(metadata ? { metadata } : {}) });
       },
+    },
+  };
+}
+
+function createTracer() {
+  const attributes: Array<Parameters<HostedAgentRunSpan["setAttributes"]>[0]> = [];
+  let finishCount = 0;
+  let contextCount = 0;
+  const span: HostedAgentRunSpan = {
+    setAttributes: (nextAttributes) => {
+      attributes.push(nextAttributes);
+    },
+    finish: () => {
+      finishCount += 1;
+    },
+    withContext: (fn) => {
+      contextCount += 1;
+      return fn();
+    },
+  };
+  const tracer: HostedAgentRunTracer = {
+    startSpan: () => span,
+  };
+
+  return {
+    attributes,
+    tracer,
+    get finishCount() {
+      return finishCount;
+    },
+    get contextCount() {
+      return contextCount;
     },
   };
 }
@@ -291,6 +325,119 @@ describe("agent/hosted-chat-execution-runtime", () => {
       "DURABLE_CHAT_ROOT_REQUIRES_CONVERSATION",
     );
     assertEquals(streamCalls, 0);
+  });
+
+  it("creates a bootstrapped hosted chat execution runtime", async () => {
+    const tracer = createTracer();
+    const finalMessages: HostedChatRuntimeStreamInput["messages"] = [];
+    let traceStreamCount = 0;
+    let capturedMessages: HostedChatRuntimeStreamInput["messages"] | undefined;
+    let streamOptions: HostedChatRuntimeToUiMessageStreamOptions | undefined;
+    const agent: HostedChatRuntimeAgent = {
+      stream: async (input) => {
+        capturedMessages = input.messages;
+        return createStreamResult({
+          finalStep: {},
+          captureOptions: (options) => {
+            streamOptions = options;
+          },
+        });
+      },
+    };
+
+    const bootstrapped = await createBootstrappedHostedChatExecutionRuntime({
+      authToken: "token",
+      apiUrl: "https://api.example.test",
+      agent,
+      agentId: "agent-1",
+      modelId: "openai/gpt-5.4",
+      cleanup: async () => {},
+      messages: [],
+      finalMessages,
+      conversationId: "conversation-1",
+      projectId: "project-1",
+      userId: "user-1",
+      rootRunContext: {
+        durableRootRun: {
+          runId: "root-run-1",
+          conversationId: "conversation-1",
+          messageId: "stream-message-1",
+          latestEventId: 0,
+          latestExternalEventSequence: 0,
+        },
+        durableRunMirror: null,
+      },
+      abortSignal: new AbortController().signal,
+      responseMessageId: "response-message-1",
+      tracer: tracer.tracer,
+      resolveProvider: () => "openai",
+      traceStream: async (operation) => {
+        traceStreamCount += 1;
+        return await operation();
+      },
+      createRootStreamWatchdog,
+    });
+
+    assertEquals(traceStreamCount, 1);
+    assertEquals(tracer.contextCount, 1);
+    assertEquals(capturedMessages, finalMessages);
+    assertEquals(bootstrapped.execution.agentUIStream !== undefined, true);
+    assertEquals(streamOptions?.generateMessageId?.(), "response-message-1");
+    assertEquals(tracer.attributes[0], {
+      "conversation.id": "conversation-1",
+      "project.id": "project-1",
+      "user.id": "user-1",
+      "agent.id": "agent-1",
+      "run.id": "root-run-1",
+      "message.id": "stream-message-1",
+      "gen_ai.operation.name": "chat",
+      "gen_ai.conversation.id": "conversation-1",
+      "gen_ai.agent.id": "agent-1",
+    });
+  });
+
+  it("finalizes the agent run span when bootstrapping hosted chat execution fails", async () => {
+    const tracer = createTracer();
+    const agent: HostedChatRuntimeAgent = {
+      stream: async () => {
+        throw new Error("stream startup failed");
+      },
+    };
+
+    await assertRejects(
+      async () => {
+        await createBootstrappedHostedChatExecutionRuntime({
+          authToken: "token",
+          apiUrl: "https://api.example.test",
+          agent,
+          agentId: "agent-1",
+          modelId: "openai/gpt-5.4",
+          cleanup: async () => {},
+          messages: [],
+          finalMessages: [],
+          projectId: null,
+          userId: "user-1",
+          rootRunContext: {
+            durableRootRun: null,
+            durableRunMirror: null,
+          },
+          abortSignal: new AbortController().signal,
+          tracer: tracer.tracer,
+          resolveProvider: () => "openai",
+        });
+      },
+      Error,
+      "stream startup failed",
+    );
+
+    assertEquals(tracer.finishCount, 1);
+    assertEquals(tracer.attributes.at(-1), {
+      "agent.run.final_status": "failed",
+      "gen_ai.provider.name": "openai",
+      "gen_ai.response.model": "openai/gpt-5.4",
+      "error.type": "STREAM_ERROR",
+      "error.message": "stream startup failed",
+    });
   });
 
   it("appends fallback chunks and flushes through the mirror", async () => {

--- a/src/agent/hosted-chat-execution-runtime.ts
+++ b/src/agent/hosted-chat-execution-runtime.ts
@@ -4,6 +4,14 @@ import {
 } from "../chat/chat-ui-message-helpers.ts";
 import { getLastStreamStep } from "../chat/final-step-fallback.ts";
 import type { ChatUiMessage, ChatUiMessageChunk, MessageMetadata } from "../chat/types.ts";
+import type { HostedConversationRootRunContext } from "./conversation-root-run-lifecycle.ts";
+import {
+  createHostedAgentRunSpanController,
+  createHostedRootRunLifecycleRuntimeAdapter,
+  type CreateHostedRootRunLifecycleRuntimeAdapterInput,
+  type HostedAgentRunSpanController,
+  type HostedAgentRunTracer,
+} from "./hosted-agent-run-lifecycle.ts";
 import {
   buildDetachedFallbackChunks,
   buildDetachedFallbackMessageState,
@@ -111,6 +119,44 @@ export interface CreateHostedChatExecutionRuntimeInput {
   incompleteToolCallsPartErrorText?: string;
 }
 
+export interface CreateBootstrappedHostedChatExecutionRuntimeInput {
+  authToken: string;
+  apiUrl: string;
+  agent: HostedChatRuntimeAgent;
+  agentId: string;
+  modelId: string;
+  cleanup: () => Promise<void>;
+  messages: ChatUiMessage[];
+  finalMessages: HostedChatRuntimeStreamInput["messages"];
+  conversationId?: string;
+  projectId: string | null;
+  userId: string;
+  rootRunContext: HostedConversationRootRunContext;
+  abortSignal: AbortSignal;
+  responseMessageId?: string;
+  upstreamParentConversationId?: string;
+  upstreamParentRunId?: string;
+  spawnedFromToolCallId?: string;
+  tracer: HostedAgentRunTracer;
+  resolveProvider: (modelId: string) => string;
+  traceStream?: CreateHostedChatExecutionRuntimeBootstrapInput["traceStream"];
+  logger?: HostedChatExecutionRuntimeLogger;
+  spanName?: string;
+  terminalErrorCode?: string;
+  incompleteToolCallsPartErrorText?: string;
+  createRootStreamWatchdog?: CreateHostedChatExecutionRuntimeBootstrapInput[
+    "createRootStreamWatchdog"
+  ];
+  createTerminalAdapter?: CreateHostedRootRunLifecycleRuntimeAdapterInput[
+    "createTerminalAdapter"
+  ];
+}
+
+export interface BootstrappedHostedChatExecutionRuntime {
+  agentRunSpan: HostedAgentRunSpanController;
+  execution: HostedChatExecutionRuntime;
+}
+
 type SharedFinalizationHooks = Pick<
   FinalizeHostedResponseOptions<ChatUiMessage, ChatUiMessageChunk<MessageMetadata>>,
   | "resolveEmptyTerminalError"
@@ -156,10 +202,7 @@ function createHostedChatExecutionCleanup(cleanup: () => Promise<void>): () => P
 }
 
 function createDefaultHostedChatExecutionRootStreamWatchdog(): HostedChatExecutionRootStreamWatchdog {
-  return createChatStreamWatchdog({
-    setTimeoutFn: globalThis["setTimeout"],
-    clearTimeoutFn: globalThis["clearTimeout"],
-  });
+  return createChatStreamWatchdog();
 }
 
 function traceHostedChatRuntimeStream<T>(
@@ -187,14 +230,20 @@ export async function createHostedChatExecutionRuntimeBootstrap(
     : createDefaultHostedChatExecutionRootStreamWatchdog();
   const streamAbortSignal = AbortSignal.any([input.abortSignal, rootStreamWatchdog.signal]);
 
-  const streamResult = await traceHostedChatRuntimeStream(
-    input.traceStream,
-    () =>
-      input.agent.stream({
-        messages: input.finalMessages,
-        abortSignal: streamAbortSignal,
-      }),
-  );
+  let streamResult: HostedChatRuntimeStreamResult;
+  try {
+    streamResult = await traceHostedChatRuntimeStream(
+      input.traceStream,
+      () =>
+        input.agent.stream({
+          messages: input.finalMessages,
+          abortSignal: streamAbortSignal,
+        }),
+    );
+  } catch (error) {
+    rootStreamWatchdog.dispose();
+    throw error;
+  }
 
   return {
     cleanup,
@@ -206,6 +255,79 @@ export async function createHostedChatExecutionRuntimeBootstrap(
     ...(input.conversationId ? { capturedConversationId: input.conversationId } : {}),
     mirroredToolChunkState: createMirroredToolChunkState(),
   };
+}
+
+async function createBootstrappedHostedChatRuntime(
+  input: CreateBootstrappedHostedChatExecutionRuntimeInput,
+  agentRunSpan: HostedAgentRunSpanController,
+): Promise<HostedChatExecutionRuntime> {
+  const lifecycleAdapter = createHostedRootRunLifecycleRuntimeAdapter({
+    authToken: input.authToken,
+    apiUrl: input.apiUrl,
+    modelId: input.modelId,
+    durableRootRun: input.rootRunContext.durableRootRun,
+    durableRunMirror: input.rootRunContext.durableRunMirror,
+    agentRunSpan,
+    resolveProvider: input.resolveProvider,
+    ...(input.createTerminalAdapter ? { createTerminalAdapter: input.createTerminalAdapter } : {}),
+  });
+  const bootstrap = await createHostedChatExecutionRuntimeBootstrap({
+    agent: input.agent,
+    cleanup: input.cleanup,
+    lifecycleAdapter,
+    finalMessages: input.finalMessages,
+    conversationId: input.conversationId,
+    abortSignal: input.abortSignal,
+    traceStream: input.traceStream,
+    ...(input.createRootStreamWatchdog
+      ? { createRootStreamWatchdog: input.createRootStreamWatchdog }
+      : {}),
+  });
+
+  return createHostedChatExecutionRuntime({
+    agentId: input.agentId,
+    modelId: input.modelId,
+    originalMessages: input.messages,
+    responseMessageId: input.responseMessageId,
+    runContext: agentRunSpan,
+    abortSignal: input.abortSignal,
+    bootstrap,
+    logger: input.logger,
+    incompleteToolCallsPartErrorText: input.incompleteToolCallsPartErrorText,
+  });
+}
+
+export async function createBootstrappedHostedChatExecutionRuntime(
+  input: CreateBootstrappedHostedChatExecutionRuntimeInput,
+): Promise<BootstrappedHostedChatExecutionRuntime> {
+  const agentRunSpan = createHostedAgentRunSpanController({
+    tracer: input.tracer,
+    spanName: input.spanName,
+    operationName: "chat",
+    conversationId: input.conversationId,
+    projectId: input.projectId,
+    userId: input.userId,
+    agentId: input.agentId,
+    rootRun: input.rootRunContext.durableRootRun,
+    upstreamParentConversationId: input.upstreamParentConversationId,
+    upstreamParentRunId: input.upstreamParentRunId,
+    spawnedFromToolCallId: input.spawnedFromToolCallId,
+  });
+
+  try {
+    const execution = await agentRunSpan.withContext(() =>
+      createBootstrappedHostedChatRuntime(input, agentRunSpan)
+    );
+    return { agentRunSpan, execution };
+  } catch (error) {
+    agentRunSpan.finalize({
+      status: "failed",
+      modelId: input.modelId,
+      terminalErrorCode: input.terminalErrorCode ?? "STREAM_ERROR",
+      terminalErrorMessage: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
 }
 
 export function createHostedChatStreamFinalizationHooks(input: {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1020,7 +1020,10 @@ export {
   type FinalizedMessageState,
 } from "./hosted-finalized-message.ts";
 export {
+  type BootstrappedHostedChatExecutionRuntime,
   cleanupAfterHostedChatExecutionFinalization,
+  createBootstrappedHostedChatExecutionRuntime,
+  type CreateBootstrappedHostedChatExecutionRuntimeInput,
   createHostedChatExecutionRuntime,
   createHostedChatExecutionRuntimeBootstrap,
   type CreateHostedChatExecutionRuntimeBootstrapInput,

--- a/src/chat/stream-watchdog.test.ts
+++ b/src/chat/stream-watchdog.test.ts
@@ -121,6 +121,13 @@ describe("chat/stream-watchdog", () => {
     watchdog.dispose();
   });
 
+  it("creates a default watchdog with host timer bindings", () => {
+    const watchdog = createChatStreamWatchdog();
+
+    assertEquals(watchdog.signal.aborted, false);
+    watchdog.dispose();
+  });
+
   it("aborts with AbortError and records timeout state", () => {
     using time = new FakeTime();
     const watchdog = createChatStreamWatchdog(watchdogOptions);

--- a/src/chat/stream-watchdog.ts
+++ b/src/chat/stream-watchdog.ts
@@ -202,13 +202,16 @@ export function createChatStreamWatchdog(options?: ChatStreamWatchdogOptions) {
 }
 
 function resolveChatStreamWatchdogOptions(options?: ChatStreamWatchdogOptions) {
+  const defaultSetTimeout = globalThis.setTimeout.bind(globalThis);
+  const defaultClearTimeout = globalThis.clearTimeout.bind(globalThis);
+
   return {
     idleTimeoutMs: options?.idleTimeoutMs ?? DEFAULT_CHAT_STREAM_IDLE_TIMEOUT_MS,
     toolRunningTimeoutMs: options?.toolRunningTimeoutMs ??
       DEFAULT_CHAT_STREAM_TOOL_RUNNING_TIMEOUT_MS,
     longRunningToolNames: new Set(options?.longRunningToolNames ?? ["invoke_agent"]),
-    setTimeoutFn: options?.setTimeoutFn ?? globalThis.setTimeout,
-    clearTimeoutFn: options?.clearTimeoutFn ?? globalThis.clearTimeout,
+    setTimeoutFn: options?.setTimeoutFn ?? defaultSetTimeout,
+    clearTimeoutFn: options?.clearTimeoutFn ?? defaultClearTimeout,
   };
 }
 

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.469";
+export const VERSION = "0.1.470";


### PR DESCRIPTION
## Summary
- add a reusable helper for bootstrapping hosted chat execution runtimes
- centralize agent-run span, root-run lifecycle adapter, stream bootstrap, and startup failure finalization wiring
- bind default stream watchdog timers and dispose startup-failure watchdogs
- bump package version to 0.1.470 for CI/CD publish

## Verification
- `deno test --no-check --allow-all src/chat/stream-watchdog.test.ts src/agent/hosted-chat-execution-runtime.test.ts`
- `deno check src/agent/index.ts`
- `deno task verify:quick`
- pre-push checks: format, lint, typecheck, unit tests (`1781 passed`, `0 failed`)
