### PR TITLE
Add composable service server runtime

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.470",
+  "version": "0.1.471",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -172,6 +172,9 @@ export {
 } from "./hosted-child-fork-tool-sources.ts";
 
 export {
+  createRuntimeAgentSystemMessages,
+  type CreateRuntimeAgentSystemMessagesInput,
+  DEFAULT_RUNTIME_AGENT_CONTEXT_MARKER,
   parseRuntimeAgentMarkdownDefinition,
   type ParseRuntimeAgentMarkdownDefinitionInput,
   parseRuntimeAgentMarkdownDefinitionInputSchema,

--- a/src/agent/runtime-agent-definition.test.ts
+++ b/src/agent/runtime-agent-definition.test.ts
@@ -1,5 +1,8 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { parseRuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
+import {
+  createRuntimeAgentSystemMessages,
+  parseRuntimeAgentMarkdownDefinition,
+} from "./runtime-agent-definition.ts";
 
 Deno.test("parseRuntimeAgentMarkdownDefinition normalizes frontmatter and instructions", () => {
   const result = parseRuntimeAgentMarkdownDefinition({
@@ -57,4 +60,42 @@ Create a plan.
     }).thinking,
     { enabled: true },
   );
+});
+
+Deno.test("createRuntimeAgentSystemMessages inserts runtime blocks at marker", () => {
+  const result = createRuntimeAgentSystemMessages({
+    agent: {
+      id: "support",
+      name: "Support",
+      description: "Helps users",
+      instructions: "Base instructions\n\n<!-- veryfront-runtime-context -->\n\nStatic policy",
+    },
+    runtimeBlocks: ['<project_context>\nproject_reference: "project-123"\n</project_context>'],
+  });
+
+  assertEquals(result.length, 1);
+  assertEquals(
+    result[0]?.content,
+    'Base instructions\n\n<project_context>\nproject_reference: "project-123"\n</project_context>\n\nStatic policy',
+  );
+});
+
+Deno.test("createRuntimeAgentSystemMessages appends runtime blocks when marker is absent", () => {
+  const result = createRuntimeAgentSystemMessages({
+    agent: {
+      id: "support",
+      name: "Support",
+      description: "Helps users",
+      instructions: "Base instructions",
+    },
+    runtimeBlocks: ["Dynamic context"],
+    environmentContext: "Browser timezone: UTC",
+  });
+
+  assertEquals(result.length, 2);
+  assertEquals(result[0]?.content, "Base instructions\n\nDynamic context");
+  assertEquals(result[1], {
+    role: "system",
+    content: "<environment_context>\nBrowser timezone: UTC\n</environment_context>",
+  });
 });

--- a/src/agent/runtime-agent-definition.ts
+++ b/src/agent/runtime-agent-definition.ts
@@ -1,5 +1,9 @@
 import { extract } from "#std/front-matter/yaml.ts";
 import { z } from "zod";
+import type { ChatSystemMessage } from "#veryfront/chat/types.ts";
+import { createRuntimePromptBlock } from "./runtime-prompt-block.ts";
+import { buildRuntimeAvailableSkillsPromptBlock } from "./runtime-skill-prompt.ts";
+import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
 
 export const runtimeAgentThinkingConfigSchema = z.object({
   enabled: z.boolean(),
@@ -20,6 +24,8 @@ export const runtimeAgentMarkdownDefinitionSchema = z.object({
 
 export type RuntimeAgentMarkdownDefinition = z.infer<typeof runtimeAgentMarkdownDefinitionSchema>;
 
+export const DEFAULT_RUNTIME_AGENT_CONTEXT_MARKER = "<!-- veryfront-runtime-context -->";
+
 export const parseRuntimeAgentMarkdownDefinitionInputSchema = z.object({
   id: z.string().min(1),
   content: z.string(),
@@ -28,6 +34,14 @@ export const parseRuntimeAgentMarkdownDefinitionInputSchema = z.object({
 export type ParseRuntimeAgentMarkdownDefinitionInput = z.infer<
   typeof parseRuntimeAgentMarkdownDefinitionInputSchema
 >;
+
+export type CreateRuntimeAgentSystemMessagesInput = {
+  agent: RuntimeAgentMarkdownDefinition;
+  runtimeBlocks?: readonly string[];
+  skills?: readonly RuntimeSkillDefinition[];
+  environmentContext?: string;
+  runtimeContextMarker?: string;
+};
 
 function parseThinking(value: unknown): RuntimeAgentThinkingConfig | undefined {
   if (typeof value === "number" && value > 0) {
@@ -62,4 +76,67 @@ export function parseRuntimeAgentMarkdownDefinition(
     ...(thinking ? { thinking } : {}),
     ...(maxSteps === undefined ? {} : { maxSteps }),
   });
+}
+
+function splitRuntimeAgentInstructions(input: {
+  instructions: string;
+  runtimeContextMarker: string;
+}): { before: string; after: string | null } {
+  const markerIndex = input.instructions.indexOf(input.runtimeContextMarker);
+
+  if (markerIndex < 0) {
+    return { before: input.instructions, after: null };
+  }
+
+  return {
+    before: input.instructions.slice(0, markerIndex).trim(),
+    after: input.instructions.slice(markerIndex + input.runtimeContextMarker.length).trim() || null,
+  };
+}
+
+export function createRuntimeAgentSystemMessages(
+  input: CreateRuntimeAgentSystemMessagesInput,
+): ChatSystemMessage[] {
+  const runtimeContextMarker = input.runtimeContextMarker ?? DEFAULT_RUNTIME_AGENT_CONTEXT_MARKER;
+  const splitInstructions = splitRuntimeAgentInstructions({
+    instructions: input.agent.instructions,
+    runtimeContextMarker,
+  });
+  const staticParts: string[] = [];
+
+  if (splitInstructions.before) {
+    staticParts.push(splitInstructions.before);
+  }
+
+  staticParts.push(...(input.runtimeBlocks ?? []).filter((block) => block.length > 0));
+
+  if (splitInstructions.after) {
+    staticParts.push(splitInstructions.after);
+  }
+
+  if (input.skills?.length) {
+    staticParts.push(buildRuntimeAvailableSkillsPromptBlock(input.skills));
+  }
+
+  const result: ChatSystemMessage[] = [
+    {
+      role: "system",
+      content: staticParts.join("\n\n"),
+      providerOptions: {
+        anthropic: { cacheControl: { type: "ephemeral" } },
+      },
+    },
+  ];
+
+  if (input.environmentContext) {
+    result.push({
+      role: "system",
+      content: createRuntimePromptBlock({
+        name: "environment_context",
+        content: input.environmentContext,
+      }),
+    });
+  }
+
+  return result;
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -34,13 +34,24 @@ import {
   HMR_CLOSE_RATE_LIMIT,
   HMR_MAX_MESSAGE_SIZE_BYTES,
   HMR_MAX_MESSAGES_PER_MINUTE,
-  serverLogger,
 } from "#veryfront/utils";
 
 /** Default server port when no port is specified */
 const DEFAULT_SERVER_PORT = 3_000;
 
 export { DevServer, startDevServer, startProductionServer };
+export {
+  createVeryfrontServer,
+  type CreateVeryfrontServerOptions,
+  type NodeVeryfrontServiceServer,
+  startNodeVeryfrontServer,
+  type StartNodeVeryfrontServerOptions,
+  type VeryfrontServiceServerFetch,
+  type VeryfrontServiceServerLogger,
+  type VeryfrontServiceServerModule,
+  type VeryfrontServiceServerModuleResponse,
+  type VeryfrontServiceServerRuntime,
+} from "./service-server.ts";
 export type {
   DevServerOptions,
   DiscoveryOptions,
@@ -320,46 +331,7 @@ export async function createHandler(
  * const server = createServer(toNodeHandler(handler))
  * ```
  */
-export function toNodeHandler(
-  handler: (req: Request) => Promise<Response> | Response,
-): (req: import("node:http").IncomingMessage, res: import("node:http").ServerResponse) => void {
-  return async (req, res) => {
-    try {
-      const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
-      const headers: Record<string, string> = {};
-      for (const [key, value] of Object.entries(req.headers)) {
-        if (typeof value === "string") headers[key] = value;
-        else if (Array.isArray(value)) headers[key] = value[0] ?? "";
-      }
-      const method = req.method ?? "GET";
-      const body = method === "GET" || method === "HEAD" ? null : req;
-      const init: RequestInit & { duplex?: string } = {
-        method,
-        headers,
-        body: body as BodyInit | null,
-      };
-      if (body) init.duplex = "half";
-
-      const response = await handler(new Request(url.toString(), init));
-
-      if (response.status === 101) return;
-      res.writeHead(response.status, Object.fromEntries(response.headers));
-      if (response.body) {
-        const reader = response.body.getReader();
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          res.write(value);
-        }
-      }
-      res.end();
-    } catch (error) {
-      serverLogger.debug("toNodeHandler request failed", { error });
-      res.writeHead(500);
-      res.end("Internal Server Error");
-    }
-  };
-}
+export { toNodeHandler } from "./node-handler.ts";
 
 /**
  * Start a Veryfront server in development or production mode.

--- a/src/server/node-handler.ts
+++ b/src/server/node-handler.ts
@@ -1,0 +1,42 @@
+import { serverLogger } from "#veryfront/utils";
+
+export function toNodeHandler(
+  handler: (req: Request) => Promise<Response> | Response,
+): (req: import("node:http").IncomingMessage, res: import("node:http").ServerResponse) => void {
+  return async (req, res) => {
+    try {
+      const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+      const headers: Record<string, string> = {};
+      for (const [key, value] of Object.entries(req.headers)) {
+        if (typeof value === "string") headers[key] = value;
+        else if (Array.isArray(value)) headers[key] = value[0] ?? "";
+      }
+      const method = req.method ?? "GET";
+      const body = method === "GET" || method === "HEAD" ? null : req;
+      const init: RequestInit & { duplex?: string } = {
+        method,
+        headers,
+        body: body as BodyInit | null,
+      };
+      if (body) init.duplex = "half";
+
+      const response = await handler(new Request(url.toString(), init));
+
+      if (response.status === 101) return;
+      res.writeHead(response.status, Object.fromEntries(response.headers));
+      if (response.body) {
+        const reader = response.body.getReader();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          res.write(value);
+        }
+      }
+      res.end();
+    } catch (error) {
+      serverLogger.debug("toNodeHandler request failed", { error });
+      res.writeHead(500);
+      res.end("Internal Server Error");
+    }
+  };
+}

--- a/src/server/service-server.test.ts
+++ b/src/server/service-server.test.ts
@@ -1,0 +1,58 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { createVeryfrontServer } from "./service-server.ts";
+
+Deno.test("createVeryfrontServer dispatches to the first module response", async () => {
+  const runtime = createVeryfrontServer({
+    modules: [
+      {
+        name: "miss",
+        handle: () => null,
+      },
+      {
+        name: "hit",
+        handle: () => new Response("ok", { status: 201 }),
+      },
+    ],
+  });
+
+  const response = await runtime.fetch(new Request("http://localhost/test"));
+
+  assertEquals(response.status, 201);
+  assertEquals(await response.text(), "ok");
+});
+
+Deno.test("createVeryfrontServer returns a default 404 when no module handles the request", async () => {
+  const runtime = createVeryfrontServer({
+    modules: [{ name: "empty", handle: () => null }],
+  });
+
+  const response = await runtime.fetch(new Request("http://localhost/missing"));
+
+  assertEquals(response.status, 404);
+  assertEquals(await response.text(), "Not Found");
+});
+
+Deno.test("createVeryfrontServer fans out shutdown state and stop hooks", async () => {
+  const events: string[] = [];
+  const runtime = createVeryfrontServer({
+    modules: [
+      {
+        name: "first",
+        handle: () => null,
+        setShuttingDown: () => events.push("first:shutdown"),
+        stop: () => events.push("first:stop"),
+      },
+      {
+        name: "second",
+        handle: () => null,
+        setShuttingDown: () => events.push("second:shutdown"),
+        stop: async () => events.push("second:stop"),
+      },
+    ],
+  });
+
+  runtime.setShuttingDown();
+  await runtime.stop();
+
+  assertEquals(events, ["first:shutdown", "second:shutdown", "first:stop", "second:stop"]);
+});

--- a/src/server/service-server.ts
+++ b/src/server/service-server.ts
@@ -1,0 +1,186 @@
+import { serverLogger } from "#veryfront/utils";
+import { toNodeHandler } from "./node-handler.ts";
+
+export type VeryfrontServiceServerFetch = (request: Request) => Response | Promise<Response>;
+export type VeryfrontServiceServerModuleResponse = Response | null | undefined;
+
+export type VeryfrontServiceServerModule = {
+  name: string;
+  handle: (
+    request: Request,
+  ) => VeryfrontServiceServerModuleResponse | Promise<VeryfrontServiceServerModuleResponse>;
+  setShuttingDown?: () => void;
+  stop?: () => void | Promise<void>;
+};
+
+export type VeryfrontServiceServerLogger = {
+  debug?: (message: string, metadata?: Record<string, unknown>) => void;
+  info?: (message: string, metadata?: Record<string, unknown>) => void;
+  warn?: (message: string, metadata?: Record<string, unknown>) => void;
+  error?: (message: string, metadata?: Record<string, unknown>) => void;
+};
+
+export type CreateVeryfrontServerOptions = {
+  modules: readonly VeryfrontServiceServerModule[];
+  notFound?: (request: Request) => Response | Promise<Response>;
+  onError?: (error: unknown, request: Request) => Response | Promise<Response>;
+  logger?: VeryfrontServiceServerLogger;
+};
+
+export type VeryfrontServiceServerRuntime = {
+  fetch: VeryfrontServiceServerFetch;
+  setShuttingDown: () => void;
+  stop: () => Promise<void>;
+};
+
+export type StartNodeVeryfrontServerOptions = {
+  runtime: VeryfrontServiceServerRuntime;
+  port: number;
+  bindAddress?: string;
+  logger?: VeryfrontServiceServerLogger;
+  signals?: readonly NodeJS.Signals[];
+  hardShutdownTimeoutMs?: number;
+};
+
+export type NodeVeryfrontServiceServer = {
+  server: import("node:http").Server;
+  ready: Promise<void>;
+  stop: () => Promise<void>;
+  port: number;
+  url: string;
+};
+
+function defaultNotFound(): Response {
+  return new Response("Not Found", { status: 404 });
+}
+
+function defaultErrorResponse(
+  error: unknown,
+  request: Request,
+  logger: VeryfrontServiceServerLogger,
+): Response {
+  logger.error?.("Veryfront service request failed", {
+    url: request.url,
+    error: error instanceof Error ? error.message : String(error),
+  });
+  return new Response("Internal Server Error", { status: 500 });
+}
+
+export function createVeryfrontServer(
+  options: CreateVeryfrontServerOptions,
+): VeryfrontServiceServerRuntime {
+  const logger = options.logger ?? serverLogger.component("service-server");
+  const notFound = options.notFound ?? defaultNotFound;
+  const onError = options.onError ??
+    ((error, request) => defaultErrorResponse(error, request, logger));
+
+  return {
+    fetch: async (request) => {
+      try {
+        for (const module of options.modules) {
+          const response = await module.handle(request);
+          if (response) {
+            return response;
+          }
+        }
+
+        return await notFound(request);
+      } catch (error) {
+        return await onError(error, request);
+      }
+    },
+    setShuttingDown: () => {
+      for (const module of options.modules) {
+        module.setShuttingDown?.();
+      }
+    },
+    stop: async () => {
+      for (const module of options.modules) {
+        await module.stop?.();
+      }
+    },
+  };
+}
+
+function closeNodeServer(server: import("node:http").Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+export async function startNodeVeryfrontServer(
+  options: StartNodeVeryfrontServerOptions,
+): Promise<NodeVeryfrontServiceServer> {
+  const { createServer } = await import("node:http");
+  const logger = options.logger ?? serverLogger.component("service-server");
+  const bindAddress = options.bindAddress ?? "0.0.0.0";
+  const hardShutdownTimeoutMs = options.hardShutdownTimeoutMs ?? 20_000;
+  const server = createServer(toNodeHandler(options.runtime.fetch));
+  let shutdownStarted = false;
+
+  const stop = async () => {
+    if (shutdownStarted) {
+      return;
+    }
+
+    shutdownStarted = true;
+    options.runtime.setShuttingDown();
+    await closeNodeServer(server);
+    await options.runtime.stop();
+  };
+
+  const ready = new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options.port, bindAddress, () => {
+      server.off("error", reject);
+      logger.info?.("Veryfront service server listening", {
+        port: options.port,
+        bindAddress,
+      });
+      resolve();
+    });
+  });
+
+  for (const signal of options.signals ?? ["SIGTERM"]) {
+    process.on(signal, () => {
+      if (shutdownStarted) {
+        return;
+      }
+
+      logger.info?.("Veryfront service server received shutdown signal", { signal });
+      const hardTimeout = setTimeout(() => {
+        logger.error?.("Veryfront service server graceful shutdown timed out", { signal });
+        process.exit(1);
+      }, hardShutdownTimeoutMs);
+
+      void stop()
+        .then(() => {
+          clearTimeout(hardTimeout);
+          process.exit(0);
+        })
+        .catch((error: unknown) => {
+          clearTimeout(hardTimeout);
+          logger.error?.("Veryfront service server shutdown failed", {
+            signal,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          process.exit(1);
+        });
+    });
+  }
+
+  return {
+    server,
+    ready,
+    stop,
+    port: options.port,
+    url: `http://${bindAddress}:${options.port}`,
+  };
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.470";
+export const VERSION = "0.1.471";


### PR DESCRIPTION
## Summary\n- add portable service-server module composition for fetch-based runtimes\n- add a Node service server adapter with graceful shutdown hooks\n- move the existing Node handler helper into a reusable module\n- add runtime agent system-message assembly around a markdown insertion marker\n- bump package version to 0.1.471\n\n## Verification\n- deno task verify:quick\n- pre-push checks: formatting, lint, typecheck, unit tests\n