### PR TITLE
Export observability APIs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.472",
+  "version": "0.1.473",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [
@@ -57,6 +57,8 @@
     "./jobs": "./src/jobs/index.ts",
     "./mcp": "./src/mcp/index.ts",
     "./middleware": "./src/middleware/index.ts",
+    "./observability": "./src/observability/index.ts",
+    "./observability/otlp-setup": "./src/observability/tracing/otlp-setup.ts",
     "./utils": "./src/utils/index.ts",
     "./oauth": "./src/oauth/index.ts",
     "./provider": "./src/provider/index.ts",

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -3,6 +3,15 @@
  * fetch/HTTP/React, OTLP export, and structured error and log buffering.
  *
  * @module observability
+ *
+ * @example
+ * ```ts
+ * import { withSpan } from "veryfront/observability";
+ *
+ * const result = await withSpan("load-data", async () => {
+ *   return await fetch("https://example.com/data");
+ * });
+ * ```
  */
 
 export {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.472";
+export const VERSION = "0.1.473";


### PR DESCRIPTION
## Summary\n- Add public package exports for the observability barrel and OTLP setup module.\n- Bump the framework package patch version to 0.1.473.\n- Add the required public API example to the observability barrel docs.\n\n## Verification\n- deno task verify:quick\n- deno test --no-check --allow-all src/observability/tracing/otlp-setup.test.ts src/observability/tracing/config.test.ts\n- deno task build:npm\n- Local npm build export check for ./observability and ./observability/otlp-setup