### PR TITLE
Add agent service server runtime

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.473",
+  "version": "0.1.474",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/agent-service-route-export.check.ts
+++ b/src/agent/agent-service-route-export.check.ts
@@ -1,4 +1,9 @@
-import { agent, type AgentServiceRoute, defineAgentService } from "./index.ts";
+import {
+  agent,
+  type AgentServiceRoute,
+  createAgentServiceServerRuntime,
+  defineAgentService,
+} from "./index.ts";
 
 const routes: AgentServiceRoute[] = [
   {
@@ -17,3 +22,4 @@ const service = defineAgentService({
 });
 
 service.createRuntime({ routes });
+createAgentServiceServerRuntime({ runtime: service.createRuntime({ routes }) });

--- a/src/agent/agent-service-server.test.ts
+++ b/src/agent/agent-service-server.test.ts
@@ -1,0 +1,63 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { agent } from "./factory.ts";
+import { defineAgentService } from "./agent-service.ts";
+import { createAgentServiceServerRuntime } from "./agent-service-server.ts";
+
+const assistant = agent({
+  id: "server-runtime-test-agent",
+  system: "You verify agent service server runtime behavior.",
+});
+
+describe("agent/agent-service-server", () => {
+  it("wraps an agent service runtime in a Veryfront service server runtime", async () => {
+    const serviceRuntime = defineAgentService({
+      serviceName: "agent-service-server-test",
+      agent: assistant,
+    }).createRuntime({
+      routes: [
+        {
+          method: "GET",
+          path: "/custom",
+          handler: () => new Response("custom response"),
+        },
+      ],
+    });
+
+    const serverRuntime = createAgentServiceServerRuntime({
+      runtime: serviceRuntime,
+    });
+
+    const response = await serverRuntime.fetch(new Request("https://agent.test/custom"));
+
+    assertEquals(response.status, 200);
+    assertEquals(await response.text(), "custom response");
+  });
+
+  it("runs host lifecycle hooks during graceful shutdown", async () => {
+    const serviceRuntime = defineAgentService({
+      serviceName: "agent-service-shutdown-test",
+      agent: assistant,
+    }).createRuntime();
+    const lifecycleEvents: string[] = [];
+
+    const serverRuntime = createAgentServiceServerRuntime({
+      runtime: serviceRuntime,
+      lifecycle: {
+        setShuttingDown: () => {
+          lifecycleEvents.push("host-set-shutting-down");
+        },
+        stop: () => {
+          lifecycleEvents.push("host-stop");
+        },
+      },
+    });
+
+    serverRuntime.setShuttingDown();
+    const readiness = await serviceRuntime.fetch(new Request("https://agent.test/readiness"));
+    await serverRuntime.stop();
+
+    assertEquals(readiness.status, 503);
+    assertEquals(lifecycleEvents, ["host-set-shutting-down", "host-stop"]);
+  });
+});

--- a/src/agent/agent-service-server.ts
+++ b/src/agent/agent-service-server.ts
@@ -1,0 +1,72 @@
+import {
+  createVeryfrontServer,
+  type NodeVeryfrontServiceServer,
+  startNodeVeryfrontServer,
+  type VeryfrontServiceServerLogger,
+  type VeryfrontServiceServerRuntime,
+} from "../server/service-server.ts";
+import type { AgentServiceRuntime } from "./agent-service.ts";
+
+export type AgentServiceServerLifecycle = {
+  setShuttingDown?: () => void;
+  stop?: () => void | Promise<void>;
+};
+
+export type CreateAgentServiceServerRuntimeOptions = {
+  runtime: AgentServiceRuntime;
+  serviceName?: string;
+  lifecycle?: AgentServiceServerLifecycle;
+  logger?: VeryfrontServiceServerLogger;
+};
+
+export type StartNodeAgentServiceServerOptions = CreateAgentServiceServerRuntimeOptions & {
+  port: number;
+  bindAddress?: string;
+  signals?: readonly NodeJS.Signals[];
+  hardShutdownTimeoutMs?: number;
+};
+
+export type NodeAgentServiceServer = NodeVeryfrontServiceServer;
+
+function getAgentServiceServerName(
+  options: CreateAgentServiceServerRuntimeOptions,
+): string {
+  return options.serviceName ?? options.runtime.contract.serviceName;
+}
+
+export function createAgentServiceServerRuntime(
+  options: CreateAgentServiceServerRuntimeOptions,
+): VeryfrontServiceServerRuntime {
+  const serviceName = getAgentServiceServerName(options);
+
+  return createVeryfrontServer({
+    modules: [
+      {
+        name: serviceName,
+        handle: (request) => options.runtime.fetch(request),
+        setShuttingDown: () => {
+          options.runtime.setShuttingDown();
+          options.lifecycle?.setShuttingDown?.();
+        },
+        stop: () => options.lifecycle?.stop?.(),
+      },
+    ],
+    logger: options.logger,
+  });
+}
+
+export async function startNodeAgentServiceServer(
+  options: StartNodeAgentServiceServerOptions,
+): Promise<NodeAgentServiceServer> {
+  const runtime = createAgentServiceServerRuntime(options);
+  const server = await startNodeVeryfrontServer({
+    runtime,
+    port: options.port,
+    bindAddress: options.bindAddress,
+    logger: options.logger,
+    signals: options.signals,
+    hardShutdownTimeoutMs: options.hardShutdownTimeoutMs,
+  });
+  await server.ready;
+  return server;
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -234,6 +234,14 @@ export {
   type NormalizedAgentServiceContract,
 } from "./agent-service.ts";
 export {
+  type AgentServiceServerLifecycle,
+  createAgentServiceServerRuntime,
+  type CreateAgentServiceServerRuntimeOptions,
+  type NodeAgentServiceServer,
+  startNodeAgentServiceServer,
+  type StartNodeAgentServiceServerOptions,
+} from "./agent-service-server.ts";
+export {
   type CachedRequestAuthResult,
   createRequestAuthCache,
   type CreateRequestAuthCacheOptions,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.473";
+export const VERSION = "0.1.474";


### PR DESCRIPTION
## Summary\n- add a reusable agent service server runtime helper that composes an agent service runtime with the existing Veryfront service server\n- add a Node-specific starter while keeping the runtime helper Fetch-based and platform-neutral\n- export the helper from the agent module and bump the package patch version to 0.1.474\n\n## Verification\n- deno test --no-check --allow-all src/agent/agent-service-server.test.ts src/agent/agent-service.test.ts\n- deno task verify:quick\n- deno task build:npm\n- pre-push checks: fmt, lint, typecheck, test:unit\n