### PR TITLE
Add OpenTelemetry service tracer facade

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.474",
+  "version": "0.1.475",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -81,6 +81,24 @@ export {
 } from "./tracing/otlp-setup.ts";
 
 export {
+  createOpenTelemetryServiceTracer,
+  type CreateOpenTelemetryServiceTracerOptions,
+  type OpenTelemetryContextApi,
+  type OpenTelemetryServiceTracer,
+  type OpenTelemetrySpan,
+  type OpenTelemetrySpanContext,
+  type OpenTelemetryTraceApi,
+  type OpenTelemetryTracer,
+  type ServiceTracer,
+  type ServiceTracerAttributeInput,
+  type ServiceTracerAttributes,
+  type ServiceTracerAttributeValue,
+  type ServiceTracerSpan,
+  type ServiceTracerSpanContext,
+  type ServiceTracerStartSpanOptions,
+} from "./tracing/service-tracer.ts";
+
+export {
   type DevError,
   ErrorCollector,
   type ErrorFilter,

--- a/src/observability/tracing/service-tracer.test.ts
+++ b/src/observability/tracing/service-tracer.test.ts
@@ -1,0 +1,198 @@
+import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createOpenTelemetryServiceTracer } from "./service-tracer.ts";
+
+type FakeContext = {
+  readonly span?: FakeSpan;
+};
+
+type FakeSpanOptions = {
+  childOf?: unknown;
+  attributes?: Record<string, string | number | boolean>;
+};
+
+class FakeSpan {
+  readonly context: { traceId: string; spanId: string };
+  readonly attributes: Record<string, unknown> = {};
+  status: { code: number } | null = null;
+  exceptions: unknown[] = [];
+  ended = false;
+
+  constructor(readonly name: string) {
+    this.context = {
+      traceId: `${name}-trace`,
+      spanId: `${name}-span`,
+    };
+  }
+
+  setAttribute(key: string, value: unknown): FakeSpan {
+    this.attributes[key] = value;
+    return this;
+  }
+
+  setAttributes(attributes: Record<string, unknown>): FakeSpan {
+    for (const [key, value] of Object.entries(attributes)) {
+      this.attributes[key] = value;
+    }
+    return this;
+  }
+
+  setStatus(status: { code: number }): FakeSpan {
+    this.status = status;
+    return this;
+  }
+
+  recordException(error: unknown): void {
+    this.exceptions.push(error);
+  }
+
+  end(): void {
+    this.ended = true;
+  }
+
+  spanContext(): { traceId: string; spanId: string } {
+    return this.context;
+  }
+}
+
+function createHarness() {
+  let activeContext: FakeContext = {};
+  const startedSpans: FakeSpan[] = [];
+  const contextApi = {
+    active: () => activeContext,
+    with: <T>(context: FakeContext, fn: () => T): T => {
+      const previous = activeContext;
+      activeContext = context;
+      try {
+        return fn();
+      } finally {
+        activeContext = previous;
+      }
+    },
+  };
+  const traceApi = {
+    getTracer: (_serviceName: string) => ({
+      startSpan: (
+        name: string,
+        _options: FakeSpanOptions | undefined,
+        _context: FakeContext,
+      ): FakeSpan => {
+        const span = new FakeSpan(name);
+        startedSpans.push(span);
+        return span;
+      },
+      startActiveSpan: <T>(name: string, fn: (span: FakeSpan) => T): T => {
+        const span = new FakeSpan(name);
+        startedSpans.push(span);
+        return contextApi.with({ span }, () => fn(span));
+      },
+    }),
+    setSpan: (_context: FakeContext, span: FakeSpan): FakeContext => ({ span }),
+    getSpan: (context: FakeContext): FakeSpan | undefined => context.span,
+  };
+
+  return {
+    contextApi,
+    traceApi,
+    startedSpans,
+  };
+}
+
+describe("observability/tracing/service-tracer", () => {
+  it("creates active spans and exposes trace context", () => {
+    const harness = createHarness();
+    const serviceTracer = createOpenTelemetryServiceTracer({
+      serviceName: "test-service",
+      context: harness.contextApi,
+      trace: harness.traceApi,
+      errorStatusCode: 2,
+    });
+
+    const result = serviceTracer.tracer.trace("operation", () => {
+      serviceTracer.setActiveSpanAttributes({
+        "service.value": "ok",
+      });
+      return serviceTracer.getTraceContext();
+    });
+
+    assertEquals(result, {
+      traceId: "operation-trace",
+      spanId: "operation-span",
+    });
+    assertEquals(harness.startedSpans[0]?.attributes, {
+      "service.value": "ok",
+    });
+    assertEquals(harness.startedSpans[0]?.ended, true);
+  });
+
+  it("records sync and async trace failures before rethrowing", async () => {
+    const syncHarness = createHarness();
+    const syncTracer = createOpenTelemetryServiceTracer({
+      serviceName: "test-service",
+      context: syncHarness.contextApi,
+      trace: syncHarness.traceApi,
+      errorStatusCode: 2,
+    });
+    const syncError = new Error("sync failed");
+
+    assertThrows(
+      () =>
+        syncTracer.tracer.trace("sync-operation", () => {
+          throw syncError;
+        }),
+      Error,
+      "sync failed",
+    );
+    assertEquals(syncHarness.startedSpans[0]?.status, { code: 2 });
+    assertEquals(syncHarness.startedSpans[0]?.exceptions, [syncError]);
+    assertEquals(syncHarness.startedSpans[0]?.ended, true);
+
+    const asyncHarness = createHarness();
+    const asyncTracer = createOpenTelemetryServiceTracer({
+      serviceName: "test-service",
+      context: asyncHarness.contextApi,
+      trace: asyncHarness.traceApi,
+      errorStatusCode: 2,
+    });
+    const asyncError = new Error("async failed");
+
+    await assertRejects(
+      () =>
+        asyncTracer.tracer.trace("async-operation", async () => {
+          throw asyncError;
+        }),
+      Error,
+      "async failed",
+    );
+    assertEquals(asyncHarness.startedSpans[0]?.status, { code: 2 });
+    assertEquals(asyncHarness.startedSpans[0]?.exceptions, [asyncError]);
+    assertEquals(asyncHarness.startedSpans[0]?.ended, true);
+  });
+
+  it("provides a datadog-style startSpan wrapper with attribute coercion", () => {
+    const harness = createHarness();
+    const serviceTracer = createOpenTelemetryServiceTracer({
+      serviceName: "test-service",
+      context: harness.contextApi,
+      trace: harness.traceApi,
+      errorStatusCode: 2,
+    });
+
+    const span = serviceTracer.tracer.startSpan("manual-operation");
+    span.setTag("nullable", null);
+    span.setTag("object", { ok: true });
+    span.setAttributes({
+      number: 1,
+      undefinedValue: undefined,
+    });
+
+    assertEquals(span.context()?.toTraceId(), "manual-operation-trace");
+    assertEquals(span.context()?.toSpanId(), "manual-operation-span");
+    assertEquals(harness.startedSpans[0]?.attributes, {
+      nullable: "",
+      object: '{"ok":true}',
+      number: 1,
+      undefinedValue: "",
+    });
+  });
+});

--- a/src/observability/tracing/service-tracer.ts
+++ b/src/observability/tracing/service-tracer.ts
@@ -1,0 +1,267 @@
+export type OpenTelemetrySpanContext = {
+  traceId: string;
+  spanId: string;
+};
+
+export type OpenTelemetrySpan = {
+  setAttribute(key: string, value: string | number | boolean): unknown;
+  setAttributes(attributes: Record<string, string | number | boolean>): unknown;
+  setStatus(status: { code: number }): unknown;
+  recordException(error: unknown): unknown;
+  end(): unknown;
+  spanContext(): OpenTelemetrySpanContext;
+};
+
+export type OpenTelemetryTracer<TContext, TSpan extends OpenTelemetrySpan, TSpanOptions> = {
+  startSpan(name: string, options: TSpanOptions | undefined, context: TContext): TSpan;
+  startActiveSpan<T>(name: string, fn: (span: TSpan) => T): T;
+};
+
+export type OpenTelemetryTraceApi<TContext, TSpan extends OpenTelemetrySpan, TSpanOptions> = {
+  getTracer(serviceName: string): OpenTelemetryTracer<TContext, TSpan, TSpanOptions>;
+  getSpan(context: TContext): TSpan | undefined;
+  setSpan(context: TContext, span: TSpan): TContext;
+};
+
+export type OpenTelemetryContextApi<TContext> = {
+  active(): TContext;
+  with<T>(context: TContext, fn: () => T): T;
+};
+
+export type ServiceTracerAttributeInput = string | number | boolean | null | undefined | object;
+export type ServiceTracerAttributePrimitive = string | number | boolean;
+export type ServiceTracerAttributeValue =
+  | ServiceTracerAttributePrimitive
+  | readonly ServiceTracerAttributePrimitive[]
+  | null
+  | undefined;
+export type ServiceTracerAttributes = Record<string, ServiceTracerAttributeValue>;
+
+export type ServiceTracerSpanContext = {
+  toTraceId(): string;
+  toSpanId(): string;
+};
+
+export type ServiceTracerSpan<
+  TContext,
+  TSpan extends OpenTelemetrySpan,
+> = {
+  setTag(key: string, value: ServiceTracerAttributeInput): TSpan;
+  setAttributes(attributes: Record<string, ServiceTracerAttributeInput>): TSpan;
+  finish(): void;
+  withContext<T>(fn: () => T): T;
+  context(): ServiceTracerSpanContext | undefined;
+  readonly otelSpan: TSpan;
+  readonly otelContext: TContext;
+};
+
+export type ServiceTracerStartSpanOptions<
+  TContext,
+  TSpan extends OpenTelemetrySpan,
+  TSpanOptions,
+> = TSpanOptions & {
+  childOf?: ServiceTracerSpan<TContext, TSpan>;
+};
+
+export type ServiceTracer<TContext, TSpan extends OpenTelemetrySpan, TSpanOptions> = {
+  init(): void;
+  startSpan(
+    name: string,
+    options?: ServiceTracerStartSpanOptions<TContext, TSpan, TSpanOptions>,
+  ): ServiceTracerSpan<TContext, TSpan>;
+  scope(): {
+    active(): ServiceTracerSpan<TContext, TSpan> | null;
+  };
+  wrap<TArgs extends unknown[], TResult>(
+    name: string,
+    fn: (...args: TArgs) => TResult,
+  ): (...args: TArgs) => TResult;
+  trace<T>(name: string, fn: () => Promise<T>): Promise<T>;
+  trace<T>(name: string, fn: () => T): T;
+};
+
+export type CreateOpenTelemetryServiceTracerOptions<
+  TContext,
+  TSpan extends OpenTelemetrySpan,
+  TSpanOptions,
+> = {
+  serviceName: string;
+  context: OpenTelemetryContextApi<TContext>;
+  trace: OpenTelemetryTraceApi<TContext, TSpan, TSpanOptions>;
+  errorStatusCode: number;
+};
+
+export type OpenTelemetryServiceTracer<
+  TContext,
+  TSpan extends OpenTelemetrySpan,
+  TSpanOptions,
+> = {
+  tracer: ServiceTracer<TContext, TSpan, TSpanOptions>;
+  setActiveSpanAttributes(attributes: ServiceTracerAttributes): void;
+  getTraceContext(): { traceId?: string; spanId?: string };
+};
+
+function toAttributeValue(value: ServiceTracerAttributeInput): string | number | boolean {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+
+  return value;
+}
+
+function createTracerSpan<TContext, TSpan extends OpenTelemetrySpan>(
+  contextApi: OpenTelemetryContextApi<TContext>,
+  span: TSpan,
+  context: TContext,
+): ServiceTracerSpan<TContext, TSpan> {
+  const spanContext = span.spanContext();
+
+  return {
+    setTag: (key, value) => {
+      span.setAttribute(key, toAttributeValue(value));
+      return span;
+    },
+    setAttributes: (attributes) => {
+      for (const [key, value] of Object.entries(attributes)) {
+        span.setAttribute(key, toAttributeValue(value));
+      }
+      return span;
+    },
+    finish: () => {
+      span.end();
+    },
+    withContext: <T>(fn: () => T): T => contextApi.with(context, fn),
+    context: () => ({
+      toTraceId: () => spanContext.traceId,
+      toSpanId: () => spanContext.spanId,
+    }),
+    otelSpan: span,
+    otelContext: context,
+  };
+}
+
+function setSpanErrorStatus<TSpan extends OpenTelemetrySpan>(
+  span: TSpan,
+  errorStatusCode: number,
+  error: unknown,
+): void {
+  span.setStatus({ code: errorStatusCode });
+  if (error instanceof Error) {
+    span.recordException(error);
+  }
+}
+
+function isPromise<T>(value: T | Promise<T>): value is Promise<T> {
+  return value instanceof Promise;
+}
+
+export function createOpenTelemetryServiceTracer<
+  TContext,
+  TSpan extends OpenTelemetrySpan,
+  TSpanOptions,
+>(
+  options: CreateOpenTelemetryServiceTracerOptions<TContext, TSpan, TSpanOptions>,
+): OpenTelemetryServiceTracer<TContext, TSpan, TSpanOptions> {
+  const otelTracer = options.trace.getTracer(options.serviceName);
+
+  function wrap<TArgs extends unknown[], TResult>(
+    name: string,
+    fn: (...args: TArgs) => TResult,
+  ): (...args: TArgs) => TResult {
+    return (...args: TArgs): TResult => {
+      const span = otelTracer.startSpan(name, undefined, options.context.active());
+      const contextWithSpan = options.trace.setSpan(options.context.active(), span);
+      try {
+        return options.context.with(contextWithSpan, () => fn(...args));
+      } catch (error) {
+        setSpanErrorStatus(span, options.errorStatusCode, error);
+        throw error;
+      } finally {
+        span.end();
+      }
+    };
+  }
+
+  function trace<T>(name: string, fn: () => Promise<T>): Promise<T>;
+  function trace<T>(name: string, fn: () => T): T;
+  function trace<T>(name: string, fn: () => T | Promise<T>): T | Promise<T> {
+    return otelTracer.startActiveSpan(name, (span) => {
+      try {
+        const result = fn();
+        if (isPromise(result)) {
+          return result
+            .then((value) => {
+              span.end();
+              return value;
+            })
+            .catch((error) => {
+              setSpanErrorStatus(span, options.errorStatusCode, error);
+              span.end();
+              throw error;
+            });
+        }
+        span.end();
+        return result;
+      } catch (error) {
+        setSpanErrorStatus(span, options.errorStatusCode, error);
+        span.end();
+        throw error;
+      }
+    });
+  }
+
+  const tracer: ServiceTracer<TContext, TSpan, TSpanOptions> = {
+    init: () => {},
+    startSpan: (name, startOptions) => {
+      let parentContext = options.context.active();
+
+      if (startOptions?.childOf?.otelSpan) {
+        parentContext = options.trace.setSpan(
+          options.context.active(),
+          startOptions.childOf.otelSpan,
+        );
+      }
+
+      const span = otelTracer.startSpan(name, startOptions, parentContext);
+      const spanContext = options.trace.setSpan(parentContext, span);
+      return createTracerSpan(options.context, span, spanContext);
+    },
+    scope: () => ({
+      active: () => {
+        const activeContext = options.context.active();
+        const activeSpan = options.trace.getSpan(activeContext);
+        if (!activeSpan) return null;
+
+        return createTracerSpan(options.context, activeSpan, activeContext);
+      },
+    }),
+    wrap,
+    trace,
+  };
+
+  return {
+    tracer,
+    setActiveSpanAttributes(attributes) {
+      const activeSpan = tracer.scope().active();
+      if (!activeSpan) return;
+
+      activeSpan.setAttributes(attributes);
+    },
+    getTraceContext() {
+      const activeSpan = tracer.scope().active();
+      if (!activeSpan) {
+        return {};
+      }
+
+      const spanContext = activeSpan.otelSpan.spanContext();
+      return {
+        traceId: spanContext.traceId,
+        spanId: spanContext.spanId,
+      };
+    },
+  };
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.474";
+export const VERSION = "0.1.475";


### PR DESCRIPTION
## Summary\n- add a reusable OpenTelemetry-backed service tracer facade for hosted services\n- export the facade from the observability module\n- bump package patch version to 0.1.475\n\n## Verification\n- deno test --no-check --allow-all src/observability/tracing/service-tracer.test.ts\n- deno check src/observability/index.ts\n- deno task verify:quick\n- deno task build:npm\n- pre-push checks: fmt, lint, typecheck, test:unit\n