### PR TITLE
Add agent abort rejection guard

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.475",
+  "version": "0.1.476",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/abort-rejection-guard.test.ts
+++ b/src/agent/abort-rejection-guard.test.ts
@@ -1,0 +1,143 @@
+import { assertEquals, assertStrictEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  type AbortRejectionEvent,
+  type AbortRejectionEventTarget,
+  type AbortRejectionProcessTarget,
+  installAbortRejectionGuard,
+  isAbortRejectionReason,
+} from "./abort-rejection-guard.ts";
+
+function createProcessTarget(): {
+  target: AbortRejectionProcessTarget;
+  emit(reason: unknown): void;
+  listenerCount(): number;
+} {
+  const listeners: Array<(reason: unknown) => void> = [];
+  return {
+    target: {
+      on(_event, listener) {
+        listeners.push(listener);
+      },
+      off(_event, listener) {
+        const index = listeners.indexOf(listener);
+        if (index >= 0) listeners.splice(index, 1);
+      },
+    },
+    emit(reason) {
+      for (const listener of [...listeners]) listener(reason);
+    },
+    listenerCount() {
+      return listeners.length;
+    },
+  };
+}
+
+function createEventTarget(): {
+  target: AbortRejectionEventTarget;
+  emit(reason: unknown): boolean;
+  listenerCount(): number;
+} {
+  const listeners: Array<(event: AbortRejectionEvent) => void> = [];
+  return {
+    target: {
+      addEventListener(_event, listener) {
+        listeners.push(listener);
+      },
+      removeEventListener(_event, listener) {
+        const index = listeners.indexOf(listener);
+        if (index >= 0) listeners.splice(index, 1);
+      },
+    },
+    emit(reason) {
+      let prevented = false;
+      for (const listener of [...listeners]) {
+        listener({
+          reason,
+          preventDefault() {
+            prevented = true;
+          },
+        });
+      }
+      return prevented;
+    },
+    listenerCount() {
+      return listeners.length;
+    },
+  };
+}
+
+describe("agent/abort-rejection-guard", () => {
+  it("identifies AbortError-shaped rejection reasons", () => {
+    assertEquals(isAbortRejectionReason(new DOMException("cancelled", "AbortError")), true);
+    assertEquals(isAbortRejectionReason(new Error("not an abort")), false);
+    assertEquals(isAbortRejectionReason({ name: "AbortError" }), true);
+  });
+
+  it("logs AbortError unhandled rejections and preserves fatal behavior for other errors", async () => {
+    const processTarget = createProcessTarget();
+    const warnings: Array<{ message: string; metadata?: Record<string, unknown> }> = [];
+
+    const guard = installAbortRejectionGuard({
+      processTarget: processTarget.target,
+      eventTarget: null,
+      loadLogger: () => ({
+        warn: (message, metadata) => warnings.push({ message, metadata }),
+      }),
+      fallbackWarn: (message, metadata) => warnings.push({ message, metadata }),
+    });
+
+    const abortError = new DOMException("stream cancelled", "AbortError");
+    processTarget.emit(abortError);
+    await Promise.resolve();
+
+    assertEquals(warnings.length, 1);
+    assertEquals(warnings[0]?.message, "Agent abort rejection swallowed");
+    assertEquals(warnings[0]?.metadata?.message, "stream cancelled");
+
+    const failure = new Error("boom");
+    assertThrows(() => processTarget.emit(failure), Error, "boom");
+
+    guard.dispose();
+    assertEquals(processTarget.listenerCount(), 0);
+  });
+
+  it("prevents default browser-style AbortError rejection handling", async () => {
+    const eventTarget = createEventTarget();
+    const warnings: string[] = [];
+    const guard = installAbortRejectionGuard({
+      processTarget: null,
+      eventTarget: eventTarget.target,
+      loadLogger: () => ({
+        warn: (message) => warnings.push(message),
+      }),
+    });
+
+    assertEquals(eventTarget.emit(new Error("boom")), false);
+    assertEquals(eventTarget.emit(new DOMException("cancelled", "AbortError")), true);
+    await Promise.resolve();
+
+    assertEquals(warnings, ["Agent abort rejection swallowed"]);
+    guard.dispose();
+    assertEquals(eventTarget.listenerCount(), 0);
+  });
+
+  it("falls back when logger loading fails", async () => {
+    const processTarget = createProcessTarget();
+    const fallbackWarnings: Array<Record<string, unknown> | undefined> = [];
+    installAbortRejectionGuard({
+      processTarget: processTarget.target,
+      eventTarget: null,
+      loadLogger: () => {
+        throw new Error("logger import failed");
+      },
+      fallbackWarn: (_message, metadata) => fallbackWarnings.push(metadata),
+    });
+
+    processTarget.emit(new DOMException("cancelled", "AbortError"));
+    await Promise.resolve();
+
+    assertStrictEquals(fallbackWarnings.length, 1);
+    assertEquals(fallbackWarnings[0]?.loggerImportError, "logger import failed");
+  });
+});

--- a/src/agent/abort-rejection-guard.ts
+++ b/src/agent/abort-rejection-guard.ts
@@ -1,0 +1,162 @@
+export type AbortRejectionGuardLogger = {
+  warn?: (message: string, metadata?: Record<string, unknown>) => void;
+};
+
+export type AbortRejectionProcessTarget = {
+  on(event: "unhandledRejection", listener: (reason: unknown) => void): void;
+  off?(event: "unhandledRejection", listener: (reason: unknown) => void): void;
+};
+
+export type AbortRejectionEvent = {
+  reason: unknown;
+  preventDefault(): void;
+};
+
+export type AbortRejectionEventTarget = {
+  addEventListener(
+    event: "unhandledrejection",
+    listener: (event: AbortRejectionEvent) => void,
+  ): void;
+  removeEventListener?(
+    event: "unhandledrejection",
+    listener: (event: AbortRejectionEvent) => void,
+  ): void;
+};
+
+export type InstallAbortRejectionGuardOptions = {
+  loadLogger?: () => AbortRejectionGuardLogger | Promise<AbortRejectionGuardLogger>;
+  fallbackWarn?: (message: string, metadata?: Record<string, unknown>) => void;
+  processTarget?: AbortRejectionProcessTarget | null;
+  eventTarget?: AbortRejectionEventTarget | null;
+  cause?: string;
+};
+
+export type InstalledAbortRejectionGuard = {
+  dispose(): void;
+};
+
+function hasAbortErrorName(reason: unknown): boolean {
+  return typeof reason === "object" && reason !== null && "name" in reason &&
+    reason.name === "AbortError";
+}
+
+export function isAbortRejectionReason(reason: unknown): boolean {
+  return hasAbortErrorName(reason);
+}
+
+function getReasonName(reason: unknown): string | null {
+  if (typeof reason !== "object" || reason === null || !("name" in reason)) {
+    return null;
+  }
+  return typeof reason.name === "string" ? reason.name : null;
+}
+
+function getReasonMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason);
+}
+
+function getReasonStack(reason: unknown): string | null {
+  return reason instanceof Error ? reason.stack ?? null : null;
+}
+
+function createAbortRejectionMetadata(
+  reason: unknown,
+  cause: string,
+): Record<string, unknown> {
+  return {
+    cause,
+    name: getReasonName(reason),
+    message: getReasonMessage(reason),
+    stack: getReasonStack(reason),
+  };
+}
+
+function resolveDefaultProcessTarget(): AbortRejectionProcessTarget | null {
+  if (typeof process === "undefined") {
+    return null;
+  }
+
+  return process;
+}
+
+async function logAbortRejection(
+  reason: unknown,
+  options:
+    & Required<Pick<InstallAbortRejectionGuardOptions, "cause" | "fallbackWarn">>
+    & Pick<InstallAbortRejectionGuardOptions, "loadLogger">,
+): Promise<void> {
+  const metadata = createAbortRejectionMetadata(reason, options.cause);
+  try {
+    const logger = await options.loadLogger?.();
+    if (logger?.warn) {
+      logger.warn("Agent abort rejection swallowed", metadata);
+      return;
+    }
+  } catch (importError) {
+    options.fallbackWarn("Agent abort rejection swallowed before logger was available", {
+      reason: getReasonMessage(reason),
+      loggerImportError: getReasonMessage(importError),
+    });
+    return;
+  }
+
+  options.fallbackWarn("Agent abort rejection swallowed", metadata);
+}
+
+export function installAbortRejectionGuard(
+  options: InstallAbortRejectionGuardOptions = {},
+): InstalledAbortRejectionGuard {
+  const processTarget = options.processTarget === undefined
+    ? resolveDefaultProcessTarget()
+    : options.processTarget;
+  const fallbackWarn = options.fallbackWarn ?? console.warn;
+  const cause = options.cause ?? "process_unhandled_rejection_abort";
+  const logOptions = {
+    cause,
+    fallbackWarn,
+    loadLogger: options.loadLogger,
+  };
+
+  const nodeHandler = (reason: unknown): void => {
+    if (!isAbortRejectionReason(reason)) {
+      throw reason;
+    }
+    void logAbortRejection(reason, logOptions);
+  };
+
+  processTarget?.on("unhandledRejection", nodeHandler);
+
+  let customEventTargetHandler: ((event: AbortRejectionEvent) => void) | undefined;
+  let browserHandler: ((event: PromiseRejectionEvent) => void) | undefined;
+  if (options.eventTarget) {
+    customEventTargetHandler = (event) => {
+      if (!isAbortRejectionReason(event.reason)) {
+        return;
+      }
+      event.preventDefault();
+      void logAbortRejection(event.reason, logOptions);
+    };
+    options.eventTarget.addEventListener("unhandledrejection", customEventTargetHandler);
+  } else if (typeof globalThis.addEventListener === "function") {
+    browserHandler = (event) => {
+      if (!isAbortRejectionReason(event.reason)) {
+        return;
+      }
+      event.preventDefault();
+      void logAbortRejection(event.reason, logOptions);
+    };
+    globalThis.addEventListener("unhandledrejection", browserHandler);
+  }
+
+  return {
+    dispose() {
+      processTarget?.off?.("unhandledRejection", nodeHandler);
+      if (customEventTargetHandler) {
+        options.eventTarget?.removeEventListener?.("unhandledrejection", customEventTargetHandler);
+      }
+      if (browserHandler && typeof globalThis.removeEventListener === "function") {
+        globalThis.removeEventListener("unhandledrejection", browserHandler);
+      }
+    },
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -242,6 +242,16 @@ export {
   type StartNodeAgentServiceServerOptions,
 } from "./agent-service-server.ts";
 export {
+  type AbortRejectionEvent,
+  type AbortRejectionEventTarget,
+  type AbortRejectionGuardLogger,
+  type AbortRejectionProcessTarget,
+  installAbortRejectionGuard,
+  type InstallAbortRejectionGuardOptions,
+  type InstalledAbortRejectionGuard,
+  isAbortRejectionReason,
+} from "./abort-rejection-guard.ts";
+export {
   type CachedRequestAuthResult,
   createRequestAuthCache,
   type CreateRequestAuthCacheOptions,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.475";
+export const VERSION = "0.1.476";


### PR DESCRIPTION
## Summary\n- add a reusable agent abort-rejection guard for Node and browser-style runtimes\n- export the guard from the agent package surface\n- bump framework package version to 0.1.476\n\n## Verification\n- deno test --no-check --allow-all src/agent/abort-rejection-guard.test.ts\n- deno check src/agent/index.ts\n- deno task verify:quick\n- deno task build:npm\n- pre-push checks