### PR TITLE
Add agent service bootstrap helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.476",
+  "version": "0.1.477",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/agent-service-bootstrap.test.ts
+++ b/src/agent/agent-service-bootstrap.test.ts
@@ -1,0 +1,101 @@
+import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { bootstrapAgentService, runAgentServiceMain } from "./agent-service-bootstrap.ts";
+import type { AbortRejectionProcessTarget } from "./abort-rejection-guard.ts";
+
+function createProcessTarget(): {
+  target: AbortRejectionProcessTarget;
+  listenerCount(): number;
+} {
+  const listeners: Array<(reason: unknown) => void> = [];
+  return {
+    target: {
+      on(_event, listener) {
+        listeners.push(listener);
+      },
+      off(_event, listener) {
+        const index = listeners.indexOf(listener);
+        if (index >= 0) listeners.splice(index, 1);
+      },
+    },
+    listenerCount() {
+      return listeners.length;
+    },
+  };
+}
+
+describe("agent/agent-service-bootstrap", () => {
+  it("runs generic service startup steps in order", async () => {
+    const events: string[] = [];
+    const traceContext = { traceId: "trace-1", spanId: "span-1" };
+    let registeredTraceContext: (() => typeof traceContext) | undefined;
+
+    await bootstrapAgentService({
+      initializeTelemetry: () => {
+        events.push("initialize-telemetry");
+        return true;
+      },
+      onTelemetryInitialized: () => {
+        events.push("telemetry-initialized");
+      },
+      getTraceContext: () => traceContext,
+      registerTraceContextGetter: (getter) => {
+        events.push("register-trace-context");
+        registeredTraceContext = getter;
+      },
+      start: () => {
+        events.push("start");
+      },
+    });
+
+    assertEquals(events, [
+      "initialize-telemetry",
+      "telemetry-initialized",
+      "register-trace-context",
+      "start",
+    ]);
+    assertEquals(registeredTraceContext?.(), traceContext);
+  });
+
+  it("skips telemetry initialized callback when telemetry setup is disabled", async () => {
+    const events: string[] = [];
+
+    await bootstrapAgentService({
+      initializeTelemetry: () => {
+        events.push("initialize-telemetry");
+        return false;
+      },
+      onTelemetryInitialized: () => {
+        events.push("telemetry-initialized");
+      },
+      start: () => {
+        events.push("start");
+      },
+    });
+
+    assertEquals(events, ["initialize-telemetry", "start"]);
+  });
+
+  it("handles fatal startup errors through the host callback and exit hook", async () => {
+    const events: string[] = [];
+    let exitCode: number | undefined;
+    const processTarget = createProcessTarget();
+
+    await runAgentServiceMain({
+      processTarget: processTarget.target,
+      start: () => {
+        throw new Error("startup failed");
+      },
+      onStartupError: (error) => {
+        events.push(error instanceof Error ? error.message : String(error));
+      },
+      exit: (code) => {
+        exitCode = code;
+      },
+    });
+
+    assertEquals(events, ["startup failed"]);
+    assertStrictEquals(exitCode, 1);
+    assertStrictEquals(processTarget.listenerCount(), 1);
+  });
+});

--- a/src/agent/agent-service-bootstrap.ts
+++ b/src/agent/agent-service-bootstrap.ts
@@ -1,0 +1,79 @@
+import {
+  type AbortRejectionGuardLogger,
+  type AbortRejectionProcessTarget,
+  installAbortRejectionGuard,
+} from "./abort-rejection-guard.ts";
+
+export type AgentServiceTraceContext = {
+  traceId?: string;
+  spanId?: string;
+};
+
+export type AgentServiceTraceContextGetter = () => AgentServiceTraceContext;
+
+export type AgentServiceBootstrapExit = (code: number) => never | void;
+
+export type BootstrapAgentServiceOptions = {
+  loadLogger?: () => AbortRejectionGuardLogger | Promise<AbortRejectionGuardLogger>;
+  initializeTelemetry?: () => boolean | Promise<boolean>;
+  onTelemetryInitialized?: () => void | Promise<void>;
+  getTraceContext?: AgentServiceTraceContextGetter;
+  registerTraceContextGetter?: (getter: AgentServiceTraceContextGetter) => void | Promise<void>;
+  start: () => void | Promise<void>;
+};
+
+export type RunAgentServiceMainOptions = BootstrapAgentServiceOptions & {
+  onStartupError?: (error: unknown) => void | Promise<void>;
+  exit?: AgentServiceBootstrapExit;
+  processTarget?: AbortRejectionProcessTarget | null;
+};
+
+async function initializeTelemetry(
+  options: Pick<BootstrapAgentServiceOptions, "initializeTelemetry" | "onTelemetryInitialized">,
+): Promise<void> {
+  const enabled = await options.initializeTelemetry?.();
+  if (enabled) {
+    await options.onTelemetryInitialized?.();
+  }
+}
+
+async function registerTraceContext(
+  options: Pick<BootstrapAgentServiceOptions, "getTraceContext" | "registerTraceContextGetter">,
+): Promise<void> {
+  if (!options.getTraceContext || !options.registerTraceContextGetter) {
+    return;
+  }
+
+  await options.registerTraceContextGetter(options.getTraceContext);
+}
+
+export async function bootstrapAgentService(
+  options: BootstrapAgentServiceOptions,
+): Promise<void> {
+  installAbortRejectionGuard({
+    loadLogger: options.loadLogger,
+  });
+
+  await initializeTelemetry(options);
+  await registerTraceContext(options);
+  await options.start();
+}
+
+export function runAgentServiceMain(options: RunAgentServiceMainOptions): Promise<void> {
+  installAbortRejectionGuard({
+    loadLogger: options.loadLogger,
+    processTarget: options.processTarget,
+  });
+
+  return initializeTelemetry(options)
+    .then(() => registerTraceContext(options))
+    .then(() => options.start())
+    .catch(async (error: unknown) => {
+      await options.onStartupError?.(error);
+      if (options.exit) {
+        options.exit(1);
+        return;
+      }
+      throw error;
+    });
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -242,6 +242,15 @@ export {
   type StartNodeAgentServiceServerOptions,
 } from "./agent-service-server.ts";
 export {
+  type AgentServiceBootstrapExit,
+  type AgentServiceTraceContext,
+  type AgentServiceTraceContextGetter,
+  bootstrapAgentService,
+  type BootstrapAgentServiceOptions,
+  runAgentServiceMain,
+  type RunAgentServiceMainOptions,
+} from "./agent-service-bootstrap.ts";
+export {
   type AbortRejectionEvent,
   type AbortRejectionEventTarget,
   type AbortRejectionGuardLogger,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.476";
+export const VERSION = "0.1.477";


### PR DESCRIPTION
## Summary\n- add a reusable agent service bootstrap helper for process entrypoints\n- centralize generic startup sequencing: abort-rejection guard, telemetry initialization, trace-context registration, service start, and fatal startup handling\n- bump framework package version to 0.1.477\n\n## Verification\n- deno test --no-check --allow-all src/agent/agent-service-bootstrap.test.ts src/agent/abort-rejection-guard.test.ts\n- deno check src/agent/index.ts\n- deno task verify:quick\n- deno task build:npm\n- pre-push checks