### PR TITLE
Add detached run shutdown lifecycle

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.477",
+  "version": "0.1.478",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/detached-run-tracker.test.ts
+++ b/src/agent/detached-run-tracker.test.ts
@@ -1,6 +1,9 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { createDetachedRunTracker } from "./detached-run-tracker.ts";
+import {
+  createDetachedRunShutdownLifecycle,
+  createDetachedRunTracker,
+} from "./detached-run-tracker.ts";
 
 function deferred(): { promise: Promise<void>; resolve: () => Promise<void> } {
   let resolvePromise: () => void = () => undefined;
@@ -69,5 +72,71 @@ describe("agent/detached-run-tracker", () => {
       drained: true,
       pendingRunIds: [],
     });
+  });
+
+  it("creates a shutdown lifecycle that cancels and drains detached runs", async () => {
+    const tracker = createDetachedRunTracker({ pollIntervalMs: 1 });
+    const execution = deferred();
+    const infoEntries: Array<{ message: string; metadata?: unknown }> = [];
+    const errorEntries: Array<{ message: string; metadata?: unknown }> = [];
+    const lifecycle = createDetachedRunShutdownLifecycle({
+      tracker,
+      drainTimeoutMs: 50,
+      pollIntervalMs: 1,
+      logger: {
+        info: (message, metadata) => infoEntries.push({ message, metadata }),
+        error: (message, metadata) => errorEntries.push({ message, metadata }),
+      },
+    });
+
+    tracker.registerExecution("run_1", execution.promise);
+
+    lifecycle.setShuttingDown();
+    await execution.resolve();
+    await lifecycle.stop();
+
+    assertEquals(infoEntries, [
+      {
+        message: "Cancelled active detached durable runs during shutdown",
+        metadata: { runIds: ["run_1"], count: 1 },
+      },
+      {
+        message: "All connections and detached durable runs drained, exiting",
+        metadata: undefined,
+      },
+    ]);
+    assertEquals(errorEntries, []);
+  });
+
+  it("throws and logs pending detached runs when shutdown drain times out", async () => {
+    const tracker = createDetachedRunTracker({ pollIntervalMs: 1 });
+    const execution = deferred();
+    const errorEntries: Array<{ message: string; metadata?: unknown }> = [];
+    const lifecycle = createDetachedRunShutdownLifecycle({
+      tracker,
+      drainTimeoutMs: 1,
+      pollIntervalMs: 1,
+      logger: {
+        info: () => undefined,
+        error: (message, metadata) => errorEntries.push({ message, metadata }),
+      },
+    });
+
+    tracker.registerExecution("run_1", execution.promise);
+
+    await assertRejects(
+      () => lifecycle.stop(),
+      Error,
+      "Detached durable runs did not drain before shutdown timeout",
+    );
+
+    assertEquals(errorEntries, [
+      {
+        message: "Detached durable runs did not drain before shutdown timeout",
+        metadata: { pendingRunIds: ["run_1"], count: 1 },
+      },
+    ]);
+
+    await execution.resolve();
   });
 });

--- a/src/agent/detached-run-tracker.ts
+++ b/src/agent/detached-run-tracker.ts
@@ -23,6 +23,27 @@ export interface DetachedRunTracker<TResumeValue> {
   reset(): void;
 }
 
+export interface DetachedRunShutdownLogger {
+  info(message: string, metadata?: Record<string, unknown>): void;
+  error(message: string, metadata?: Record<string, unknown>): void;
+}
+
+export interface DetachedRunShutdownLifecycle {
+  setShuttingDown(): void;
+  stop(): Promise<void>;
+}
+
+export interface DetachedRunShutdownLifecycleOptions<TResumeValue> {
+  tracker: DetachedRunTracker<TResumeValue>;
+  logger: DetachedRunShutdownLogger;
+  drainTimeoutMs?: number;
+  pollIntervalMs?: number;
+}
+
+const DEFAULT_DETACHED_RUN_DRAIN_TIMEOUT_MS = 15_000;
+const DETACHED_RUN_DRAIN_TIMEOUT_MESSAGE =
+  "Detached durable runs did not drain before shutdown timeout";
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -107,6 +128,41 @@ export function createDetachedRunTracker<TResumeValue = unknown>(
       sessionManager.reset();
       activeRunIds.clear();
       activeExecutions.clear();
+    },
+  };
+}
+
+export function createDetachedRunShutdownLifecycle<TResumeValue = unknown>(
+  options: DetachedRunShutdownLifecycleOptions<TResumeValue>,
+): DetachedRunShutdownLifecycle {
+  const drainTimeoutMs = options.drainTimeoutMs ?? DEFAULT_DETACHED_RUN_DRAIN_TIMEOUT_MS;
+
+  return {
+    setShuttingDown() {
+      const cancelledRunIds = options.tracker.cancelAllRuns();
+      if (cancelledRunIds.length === 0) {
+        return;
+      }
+
+      options.logger.info("Cancelled active detached durable runs during shutdown", {
+        runIds: cancelledRunIds,
+        count: cancelledRunIds.length,
+      });
+    },
+    async stop() {
+      const drainResult = await options.tracker.waitForDrain({
+        timeoutMs: drainTimeoutMs,
+        pollIntervalMs: options.pollIntervalMs,
+      });
+      if (!drainResult.drained) {
+        options.logger.error(DETACHED_RUN_DRAIN_TIMEOUT_MESSAGE, {
+          pendingRunIds: drainResult.pendingRunIds,
+          count: drainResult.pendingRunIds.length,
+        });
+        throw new Error(DETACHED_RUN_DRAIN_TIMEOUT_MESSAGE);
+      }
+
+      options.logger.info("All connections and detached durable runs drained, exiting");
     },
   };
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1285,8 +1285,12 @@ export {
 } from "./ag-ui-detached-start.ts";
 export type { AgUiResumeValue } from "./ag-ui-tool-shared.ts";
 export {
+  createDetachedRunShutdownLifecycle,
   createDetachedRunTracker,
   type DetachedRunDrainResult,
+  type DetachedRunShutdownLifecycle,
+  type DetachedRunShutdownLifecycleOptions,
+  type DetachedRunShutdownLogger,
   type DetachedRunTracker,
   type DetachedRunTrackerOptions,
 } from "./detached-run-tracker.ts";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.477";
+export const VERSION = "0.1.478";


### PR DESCRIPTION
## Summary
- add a reusable detached run shutdown lifecycle helper
- centralize cancellation, drain logging, and timeout failure behavior for service runtimes
- bump framework version to 0.1.478

## Verification
- deno test --no-check --allow-all src/agent/detached-run-tracker.test.ts
- deno check src/agent/index.ts
- deno test --no-check --allow-all src/agent/detached-run-tracker.test.ts src/agent/agent-service-server.test.ts
- deno task verify:quick
- deno task build:npm
- pre-push checks