### PR TITLE
ci(supply-chain): SBOM lock-walk + stricter esm.sh audit

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -349,6 +349,7 @@
     "lint:wildcard-exports": "deno run --allow-read scripts/lint/ban-wildcard-exports.ts",
     "lint:deps": "deno run --allow-read scripts/lint/audit-deps.ts",
     "lint:barrel-jsdoc": "deno run --allow-read scripts/lint/check-barrel-jsdoc.ts",
+    "test:scripts": "deno test --config=scripts/test.deno.json --no-check --allow-read scripts/build/generate-sbom.test.ts scripts/lint/audit-deps.test.ts",
     "test:cross-runtime": "deno run --allow-all src/platform/compat/cross-runtime.test.ts",
     "test:node": "node ./tests/node/run-tests.mjs 'src/**/*.test.ts'",
     "test:bun": "node ./tests/bun/run-tests.mjs src/",

--- a/scripts/build/generate-sbom.test.ts
+++ b/scripts/build/generate-sbom.test.ts
@@ -1,0 +1,78 @@
+import { assertEquals, assertThrows } from "#std/assert";
+import { describe, it } from "jsr:@std/testing/bdd";
+import { componentsFromLock, SUPPORTED_LOCK_VERSIONS } from "./generate-sbom.ts";
+
+describe("componentsFromLock", () => {
+  it("emits a CycloneDX library component per npm package, deduplicated", () => {
+    const lock = JSON.stringify({
+      version: "5",
+      specifiers: { "npm:zod@4.3.6": "4.3.6" },
+      npm: {
+        "zod@4.3.6": { integrity: "sha512-aaa", dependencies: [] },
+        "fast-deep-equal@3.1.3": { integrity: "sha512-bbb" },
+      },
+    });
+
+    const components = componentsFromLock(lock);
+
+    assertEquals(components.length, 2);
+    const zod = components.find((c) => c.name === "zod")!;
+    assertEquals(zod.version, "4.3.6");
+    assertEquals(zod.purl, "pkg:npm/zod@4.3.6");
+    assertEquals(zod.hashes?.[0], { alg: "SHA-512", content: "aaa" });
+  });
+
+  it("strips peer-disambiguator suffix from canonical name@version", () => {
+    const lock = JSON.stringify({
+      version: "5",
+      specifiers: {},
+      npm: {
+        "@mdx-js/mdx@3.1.1_acorn@8.16.0": { integrity: "sha512-x" },
+      },
+    });
+    const c = componentsFromLock(lock)[0];
+    assertEquals(c.name, "@mdx-js/mdx");
+    assertEquals(c.version, "3.1.1");
+    assertEquals(c.purl, "pkg:npm/%40mdx-js/mdx@3.1.1");
+  });
+
+  it("deduplicates entries that resolve to the same canonical name@version", () => {
+    const lock = JSON.stringify({
+      version: "5",
+      specifiers: {},
+      npm: {
+        "@opentelemetry/core@2.6.0": { integrity: "sha512-a" },
+        "@opentelemetry/core@2.6.0_@opentelemetry+api@1.9.0": { integrity: "sha512-a" },
+      },
+    });
+    assertEquals(componentsFromLock(lock).length, 1);
+  });
+
+  it("includes scoped npm packages with encoded purl", () => {
+    const lock = JSON.stringify({
+      version: "5",
+      specifiers: {},
+      npm: { "@opentelemetry/api@1.9.0": { integrity: "sha512-x" } },
+    });
+    const components = componentsFromLock(lock);
+    assertEquals(components[0].purl, "pkg:npm/%40opentelemetry/api@1.9.0");
+  });
+
+  it("ignores jsr — not in scope for npm SBOM", () => {
+    const lock = JSON.stringify({
+      version: "5",
+      specifiers: { "jsr:@std/path@1": "1.0.0" },
+      jsr: { "@std/path@1.0.0": {} },
+    });
+    assertEquals(componentsFromLock(lock).length, 0);
+  });
+
+  it("throws on unsupported lock format", () => {
+    const lock = JSON.stringify({ version: "999", npm: {} });
+    assertThrows(() => componentsFromLock(lock), Error, "Unsupported deno.lock version");
+  });
+
+  it("SUPPORTED_LOCK_VERSIONS lists at least the current format", () => {
+    assertEquals(SUPPORTED_LOCK_VERSIONS.includes("5"), true);
+  });
+});

--- a/scripts/build/generate-sbom.ts
+++ b/scripts/build/generate-sbom.ts
@@ -1,96 +1,145 @@
 /**
- * Generate a CycloneDX 1.5 SBOM from deno.json imports.
+ * Generate a CycloneDX 1.5 SBOM from deno.lock.
  *
  * Usage: deno run --allow-read --allow-write scripts/build/generate-sbom.ts [--output path]
  *
- * Outputs CycloneDX 1.5 JSON to dist/sbom.json (or specified path).
+ * Walks deno.lock so the SBOM lists the transitive npm graph that ships in
+ * the binary, not just the top-level import map.
  */
 
 import { parseArgs } from "#std/flags";
 
-const args = parseArgs(Deno.args, { string: ["output"], default: { output: "dist/sbom.json" } });
-
-const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
-const imports: Record<string, string> = denoConfig.imports ?? {};
-
-interface CycloneDXComponent {
-  type: string;
+export interface CycloneDXComponent {
+  type: "library";
   name: string;
   version: string;
-  purl?: string;
-  scope?: string;
-  properties?: Array<{ name: string; value: string }>;
+  purl: string;
+  hashes?: Array<{ alg: string; content: string }>;
 }
 
-function parseNpmSpecifier(target: string): { name: string; version: string } | null {
-  const match = target.match(/^npm:(.+)@(\d[^/]*)/);
-  if (!match) return null;
-  return { name: match[1], version: match[2] };
+/**
+ * Lockfile versions whose schema this parser has been validated against.
+ * Bump (and re-test) when Deno introduces a new lock format.
+ */
+export const SUPPORTED_LOCK_VERSIONS = ["5"] as const;
+
+interface DenoLockV5 {
+  version: string;
+  specifiers?: Record<string, string>;
+  npm?: Record<string, { integrity?: string; dependencies?: string[] }>;
+  jsr?: Record<string, unknown>;
 }
 
-function parseEsmShSpecifier(target: string): { name: string; version: string } | null {
-  const match = target.match(/esm\.sh\/(.+?)@(\d[^/?]*)/);
-  if (!match) return null;
-  return { name: match[1], version: match[2] };
-}
-
-const seen = new Set<string>();
-const components: CycloneDXComponent[] = [];
-
-for (const [_specifier, target] of Object.entries(imports)) {
-  // Skip local paths and jsr imports
-  if (target.startsWith("./") || target.startsWith("../") || target.startsWith("jsr:")) continue;
-
-  let parsed: { name: string; version: string } | null = null;
-
-  if (target.startsWith("npm:")) {
-    parsed = parseNpmSpecifier(target);
-  } else if (target.startsWith("https://esm.sh/")) {
-    parsed = parseEsmShSpecifier(target);
+function parseNameVersion(key: string): { name: string; version: string } | null {
+  let scope = "";
+  let rest = key;
+  if (key.startsWith("@")) {
+    const slash = key.indexOf("/");
+    if (slash < 0) return null;
+    scope = key.slice(0, slash + 1);
+    rest = key.slice(slash + 1);
   }
+  const at = rest.indexOf("@");
+  if (at <= 0) return null;
+  const name = scope + rest.slice(0, at);
+  let version = rest.slice(at + 1);
+  const underscore = version.indexOf("_");
+  if (underscore >= 0) version = version.slice(0, underscore);
+  return { name, version };
+}
 
-  if (!parsed) continue;
+function purlFor(name: string, version: string): string {
+  const encoded = name.split("/").map(encodeURIComponent).join("/");
+  return `pkg:npm/${encoded}@${version}`;
+}
 
-  const key = `${parsed.name}@${parsed.version}`;
-  if (seen.has(key)) continue;
-  seen.add(key);
+function hashFromIntegrity(
+  integrity: string | undefined,
+): { alg: string; content: string } | undefined {
+  if (!integrity) return undefined;
+  const m = integrity.match(/^sha(256|384|512)-(.+)$/);
+  if (!m) return undefined;
+  return { alg: `SHA-${m[1]}`, content: m[2] };
+}
 
-  const component: CycloneDXComponent = {
-    type: "library",
-    name: parsed.name,
-    version: parsed.version,
-    purl: `pkg:npm/${parsed.name.split("/").map(encodeURIComponent).join("/")}@${parsed.version}`,
+export function componentsFromLock(lockText: string): CycloneDXComponent[] {
+  const lock = JSON.parse(lockText) as DenoLockV5;
+  if (
+    !SUPPORTED_LOCK_VERSIONS.includes(
+      lock.version as typeof SUPPORTED_LOCK_VERSIONS[number],
+    )
+  ) {
+    throw new Error(
+      `Unsupported deno.lock version: "${lock.version}" (supported: ${
+        SUPPORTED_LOCK_VERSIONS.join(", ")
+      })`,
+    );
+  }
+  const npm = lock.npm ?? {};
+  const seen = new Set<string>();
+  const components: CycloneDXComponent[] = [];
+  for (const [key, info] of Object.entries(npm)) {
+    const nv = parseNameVersion(key);
+    if (!nv) continue;
+    const canonical = `${nv.name}@${nv.version}`;
+    if (seen.has(canonical)) continue;
+    seen.add(canonical);
+    const hash = hashFromIntegrity(info.integrity);
+    components.push({
+      type: "library",
+      name: nv.name,
+      version: nv.version,
+      purl: purlFor(nv.name, nv.version),
+      ...(hash ? { hashes: [hash] } : {}),
+    });
+  }
+  return components;
+}
+
+if (import.meta.main) {
+  const args = parseArgs(Deno.args, {
+    string: ["output"],
+    default: { output: "dist/sbom.json" },
+  });
+
+  const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
+  const lockText = await Deno.readTextFile("deno.lock");
+  const components = componentsFromLock(lockText);
+
+  const sbom = {
+    bomFormat: "CycloneDX",
+    specVersion: "1.5",
+    version: 1,
+    serialNumber: `urn:uuid:${crypto.randomUUID()}`,
+    metadata: {
+      timestamp: new Date().toISOString(),
+      component: {
+        "bom-ref": "veryfront",
+        type: "application",
+        name: denoConfig.name ?? "veryfront",
+        version: denoConfig.version ?? "0.0.0",
+      },
+      tools: [{ name: "generate-sbom", version: "1.1.0" }],
+    },
+    components: components.map((c) => ({
+      "bom-ref": `${c.name}@${c.version}`,
+      ...c,
+    })),
+    dependencies: [
+      {
+        ref: "veryfront",
+        dependsOn: components.map((c) => `${c.name}@${c.version}`),
+      },
+    ],
   };
 
-  if (target.startsWith("https://esm.sh/")) {
-    component.properties = [{ name: "cdnSource", value: "esm.sh" }];
+  const outputPath = args.output;
+  const outputDir = outputPath.substring(0, outputPath.lastIndexOf("/"));
+  if (outputDir) {
+    await Deno.mkdir(outputDir, { recursive: true });
   }
+  await Deno.writeTextFile(outputPath, JSON.stringify(sbom, null, 2) + "\n");
 
-  components.push(component);
+  console.log(`✅ Generated SBOM: ${outputPath}`);
+  console.log(`   ${components.length} components, CycloneDX 1.5 format`);
 }
-
-const sbom = {
-  bomFormat: "CycloneDX",
-  specVersion: "1.5",
-  version: 1,
-  metadata: {
-    timestamp: new Date().toISOString(),
-    component: {
-      type: "application",
-      name: denoConfig.name ?? "veryfront",
-      version: denoConfig.version ?? "0.0.0",
-    },
-    tools: [{ name: "generate-sbom", version: "1.0.0" }],
-  },
-  components,
-};
-
-const outputPath = args.output;
-const outputDir = outputPath.substring(0, outputPath.lastIndexOf("/"));
-if (outputDir) {
-  await Deno.mkdir(outputDir, { recursive: true });
-}
-await Deno.writeTextFile(outputPath, JSON.stringify(sbom, null, 2) + "\n");
-
-console.log(`✅ Generated SBOM: ${outputPath}`);
-console.log(`   ${components.length} components, CycloneDX 1.5 format`);

--- a/scripts/lint/audit-deps.test.ts
+++ b/scripts/lint/audit-deps.test.ts
@@ -1,0 +1,52 @@
+import { assertEquals } from "#std/assert";
+import { describe, it } from "jsr:@std/testing/bdd";
+import { auditEsmShPin } from "./audit-deps.ts";
+
+describe("auditEsmShPin", () => {
+  it("accepts exact x.y.z pins", () => {
+    assertEquals(auditEsmShPin("https://esm.sh/react@19.2.4?target=es2022"), null);
+  });
+
+  it("rejects major-only pins", () => {
+    const issue = auditEsmShPin("https://esm.sh/react@19");
+    assertEquals(issue?.severity, "error");
+  });
+
+  it("rejects unpinned (no version)", () => {
+    const issue = auditEsmShPin("https://esm.sh/react?target=es2022");
+    assertEquals(issue?.severity, "error");
+  });
+
+  it("rejects caret/tilde ranges", () => {
+    const issue = auditEsmShPin("https://esm.sh/react@^19.2.4");
+    assertEquals(issue?.severity, "error");
+  });
+
+  it("requires HTTPS host to be esm.sh", () => {
+    const issue = auditEsmShPin("https://cdn.skypack.dev/react@19.2.4");
+    assertEquals(issue?.severity, "warning");
+  });
+
+  it("returns null for non-https targets", () => {
+    assertEquals(auditEsmShPin("npm:react@19.2.4"), null);
+  });
+
+  it("accepts pre-release suffixes on x.y.z pins", () => {
+    assertEquals(
+      auditEsmShPin("https://esm.sh/react@19.2.4-rc.1"),
+      null,
+    );
+  });
+
+  it("accepts scoped packages with exact pins", () => {
+    assertEquals(
+      auditEsmShPin("https://esm.sh/@types/react@19.2.14?deps=csstype@3.2.3"),
+      null,
+    );
+  });
+
+  it("rejects scoped packages with major-only pins", () => {
+    const issue = auditEsmShPin("https://esm.sh/@types/react@19?deps=csstype@3.2.3");
+    assertEquals(issue?.severity, "error");
+  });
+});

--- a/scripts/lint/audit-deps.ts
+++ b/scripts/lint/audit-deps.ts
@@ -2,131 +2,155 @@
  * Dependency audit script — flags supply chain risks in deno.json imports.
  *
  * Checks for:
- * - Unpinned npm versions (e.g., "npm:foo" without @version)
+ * - Unpinned npm versions (e.g., "npm:foo" without @x.y.z)
  * - git:// or tarball URLs
  * - Non-https URLs (except local paths)
- * - esm.sh URLs without pinned versions
+ * - esm.sh URLs without exact x.y.z version pins
+ * - Non-esm.sh https CDNs (warning)
  *
  * Usage: deno run --allow-read scripts/lint/audit-deps.ts
  */
 
-const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
-const imports: Record<string, string> = denoConfig.imports ?? {};
+export type Severity = "error" | "warning";
 
-interface Issue {
+export interface AuditIssue {
   specifier: string;
   target: string;
-  severity: "error" | "warning";
+  severity: Severity;
   message: string;
 }
 
-const issues: Issue[] = [];
-
-for (const [specifier, target] of Object.entries(imports)) {
-  // Skip local path imports
-  if (target.startsWith("./") || target.startsWith("../")) continue;
-  // Skip jsr: imports (managed by Deno)
-  if (target.startsWith("jsr:")) continue;
-
-  // Check for git:// or tarball URLs
-  if (target.startsWith("git://") || target.startsWith("git+")) {
-    issues.push({
-      specifier,
-      target,
-      severity: "error",
-      message: "Git URL import — vulnerable to repo compromise",
-    });
-    continue;
-  }
-
-  if (target.match(/\.(tar\.gz|tgz|tar)([?#]|$)/)) {
-    issues.push({
-      specifier,
-      target,
-      severity: "error",
-      message: "Tarball import — cannot verify integrity",
-    });
-    continue;
-  }
-
-  // Check npm: imports for version pinning
-  if (target.startsWith("npm:")) {
-    // Require exact semver (x.y.z), not just major-only like @1
-    const hasExactVersion = target.match(/npm:.+@\d+\.\d+\.\d/);
-    if (!hasExactVersion) {
-      issues.push({
+/**
+ * Inspect an https:// import target. Returns null when the target is fine
+ * (or non-https, which is handled elsewhere). Reports:
+ * - non-esm.sh CDN → warning (must be reviewed for trust)
+ * - esm.sh URL missing version → error
+ * - esm.sh URL not pinned to exact x.y.z (no caret, tilde, major-only) → error
+ */
+export function auditEsmShPin(target: string, specifier = ""): AuditIssue | null {
+  if (!target.startsWith("https://esm.sh/")) {
+    if (target.startsWith("https://")) {
+      // jsr.io is managed by Deno (handled by the jsr: branch in main loop);
+      // anything else is an unknown CDN.
+      if (target.startsWith("https://jsr.io/")) return null;
+      return {
         specifier,
         target,
         severity: "warning",
-        message: "Unpinned npm version — specify exact version (x.y.z) for reproducibility",
-      });
+        message: "Non-esm.sh CDN — ensure source is trusted",
+      };
     }
-    continue;
+    return null;
   }
 
-  // Check https:// URLs (esm.sh etc.)
-  if (target.startsWith("https://")) {
-    if (!target.startsWith("https://esm.sh/") && !target.startsWith("https://jsr.io/")) {
+  const path = target.split("?")[0];
+  // Match either scoped (@scope/name) or unscoped (name) before @version
+  const versionMatch = path.match(/esm\.sh\/(?:@[^/@]+\/[^@/]+|[^@/]+)@([^/]+)/);
+  if (!versionMatch) {
+    return {
+      specifier,
+      target,
+      severity: "error",
+      message: "esm.sh URL missing version pin",
+    };
+  }
+  const ver = versionMatch[1];
+
+  if (!/^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$/.test(ver)) {
+    return {
+      specifier,
+      target,
+      severity: "error",
+      message: `esm.sh URL not pinned to exact x.y.z (got "${ver}")`,
+    };
+  }
+  return null;
+}
+
+if (import.meta.main) {
+  const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
+  const imports: Record<string, string> = denoConfig.imports ?? {};
+
+  const issues: AuditIssue[] = [];
+
+  for (const [specifier, target] of Object.entries(imports)) {
+    if (target.startsWith("./") || target.startsWith("../")) continue;
+    if (target.startsWith("jsr:")) continue;
+
+    if (target.startsWith("git://") || target.startsWith("git+")) {
       issues.push({
         specifier,
         target,
-        severity: "warning",
-        message: "Non-standard CDN URL — ensure this source is trusted",
+        severity: "error",
+        message: "Git URL import — vulnerable to repo compromise",
       });
+      continue;
     }
 
-    // Check esm.sh for version pinning
-    if (target.startsWith("https://esm.sh/")) {
-      // Check package path (before ?) for version, not query string params
-      const urlPath = target.split("?")[0];
-      const hasVersion = urlPath.match(/esm\.sh\/.+@\d/);
-      if (!hasVersion) {
+    if (target.match(/\.(tar\.gz|tgz|tar)([?#]|$)/)) {
+      issues.push({
+        specifier,
+        target,
+        severity: "error",
+        message: "Tarball import — cannot verify integrity",
+      });
+      continue;
+    }
+
+    if (target.startsWith("npm:")) {
+      const hasExactVersion = target.match(/npm:.+@\d+\.\d+\.\d/);
+      if (!hasExactVersion) {
         issues.push({
           specifier,
           target,
           severity: "warning",
-          message: "Unpinned esm.sh version — specify exact version",
+          message:
+            "Unpinned npm version — specify exact version (x.y.z) for reproducibility",
         });
       }
+      continue;
     }
-    continue;
+
+    if (target.startsWith("https://")) {
+      const issue = auditEsmShPin(target, specifier);
+      if (issue) issues.push(issue);
+      continue;
+    }
+
+    if (target.startsWith("http://")) {
+      issues.push({
+        specifier,
+        target,
+        severity: "error",
+        message: "Non-HTTPS import — vulnerable to MITM attacks",
+      });
+    }
   }
 
-  // Check for http:// (non-TLS)
-  if (target.startsWith("http://")) {
-    issues.push({
-      specifier,
-      target,
-      severity: "error",
-      message: "Non-HTTPS import — vulnerable to MITM attacks",
-    });
+  if (issues.length === 0) {
+    console.log("✅ No supply chain issues found in dependency imports.");
+    Deno.exit(0);
   }
-}
 
-// Report results
-if (issues.length === 0) {
-  console.log("✅ No supply chain issues found in dependency imports.");
-  Deno.exit(0);
-}
+  const errors = issues.filter((i) => i.severity === "error");
+  const warnings = issues.filter((i) => i.severity === "warning");
 
-const errors = issues.filter((i) => i.severity === "error");
-const warnings = issues.filter((i) => i.severity === "warning");
-
-if (warnings.length > 0) {
-  console.log(`\n⚠️  ${warnings.length} warning(s):`);
-  for (const w of warnings) {
-    console.log(`  ${w.specifier}: ${w.message}`);
-    console.log(`    → ${w.target}`);
+  if (warnings.length > 0) {
+    console.log(`\n⚠️  ${warnings.length} warning(s):`);
+    for (const w of warnings) {
+      console.log(`  ${w.specifier}: ${w.message}`);
+      console.log(`    → ${w.target}`);
+    }
   }
-}
 
-if (errors.length > 0) {
-  console.log(`\n❌ ${errors.length} error(s):`);
-  for (const e of errors) {
-    console.log(`  ${e.specifier}: ${e.message}`);
-    console.log(`    → ${e.target}`);
+  if (errors.length > 0) {
+    console.log(`\n❌ ${errors.length} error(s):`);
+    for (const e of errors) {
+      console.log(`  ${e.specifier}: ${e.message}`);
+      console.log(`    → ${e.target}`);
+    }
+    Deno.exit(1);
   }
-  Deno.exit(1);
-}
 
-console.log("\n✅ No blocking issues (warnings only).");
+  console.log("\n✅ No blocking issues (warnings only).");
+}

--- a/scripts/test.deno.json
+++ b/scripts/test.deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "#std/assert": "jsr:@std/assert",
+    "#std/flags": "jsr:@std/cli/parse-args"
+  }
+}


### PR DESCRIPTION
## Summary
- `scripts/build/generate-sbom.ts` now walks `deno.lock` (transitive npm graph) and emits CycloneDX 1.5 with hashes + a `dependencies` block.
- `scripts/lint/audit-deps.ts` now requires exact `x.y.z` version pins for `esm.sh` URLs and treats non-esm.sh CDNs as warnings.
- Both refactored to export pure functions (`componentsFromLock`, `auditEsmShPin`); script bodies gated by `import.meta.main`.
- New `deno task test:scripts` runs the unit tests via a scoped `scripts/test.deno.json` (root `deno.json` excludes `scripts/` from default test discovery).

## Why
The previous SBOM was misleading — consumers thought it documented "what veryfront depends on" but it only listed top-level import-map keys. CVE-correlation tools that ingest CycloneDX missed the actual ship payload. Walking the lock makes the SBOM reflect reality (12 → **304 components** locally).

`audit-deps`'s old esm.sh check accepted `react@1` style major-only pins; that's not reproducible. Tighten to `x.y.z` to match the npm-side check. Regex now handles both scoped (`@scope/name`) and unscoped esm.sh packages.

## Verification
- [x] `deno task test:scripts` — 16/16 pass (componentsFromLock + auditEsmShPin)
- [x] `deno task sbom` regenerates `dist/sbom.json` with 304 components
- [x] `deno task lint:deps` passes
- No callers of removed `parseNpmSpecifier` / `parseEsmShSpecifier` (verified via `git grep`)