### PR TITLE
docs(security): rewrite SECURITY.md as actual policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,25 +1,71 @@
 # Security Policy
 
-## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
-| < 0.1.0 | :x:                |
+Veryfront takes the security of our framework, core, and published extensions seriously. This document explains how to report a vulnerability, what we cover, and how we respond.
 
 ## Reporting a Vulnerability
 
-We take the security of Veryfront seriously. If you have found a security vulnerability, please do not report it in the public issue tracker.
+**Email:** `security@veryfront.com`
 
-Instead, please email **security@veryfront.com** with details. We will review the issue and respond within 48 hours.
+Please **do not** open a public issue for security concerns. Email the details directly. We aim to acknowledge within **48 hours** and provide an initial assessment within **5 business days**.
 
-### What to include:
+If you require encrypted communication, request our PGP key at the same address. We will respond with a current key fingerprint over a separate channel.
 
-*   A description of the vulnerability.
-*   Steps to reproduce the issue.
-*   Potential impact.
+### What to include
+- A description of the vulnerability and its impact
+- Steps to reproduce (a minimal repro is ideal — code, manifest, command-line)
+- Affected version(s) — `deno.json` version field or commit SHA
+- Whether you have already disclosed elsewhere (CVE, advisory, vendor)
 
-We appreciate your efforts to responsibly disclose your findings.
+### Embargo and disclosure
+- We treat reports as embargoed until either a fix ships or 90 days pass, whichever is sooner.
+- We will keep you informed of remediation progress and credit you in the advisory unless you prefer otherwise.
+
+## Supported Versions
+
+| Version | Status |
+|---|---|
+| `0.1.x` (latest minor) | Active — receives security patches |
+| `< 0.1.<latest>` | End of life — please upgrade |
+
+Pin a recent `0.1.x` release. Versions older than the current minor receive **no** patches.
+
+## Scope
+
+In scope for this policy:
+- The `veryfront` core (this repository: `src/`, `cli/`).
+- First-party extensions published from this monorepo (`extensions/ext-*`).
+- Build, release, and CI scripts (`scripts/`, `.github/workflows/`).
+- The compiled binary distributed via official channels.
+
+Out of scope (report through the usual project channels, not security@):
+- Demo applications and example sites.
+- Third-party plugins not in `extensions/`.
+- Vulnerabilities in dependencies that are already CVE-tracked upstream — we monitor those automatically (see Supply Chain).
+
+## Supply Chain Posture
+
+We are working to make the framework's supply chain auditable and tamper-evident. The following describes today's reality; rolling improvements are tracked in the issue tracker.
+
+- **SBOM:** `deno task sbom` generates a CycloneDX 1.5 SBOM (`dist/sbom.json`) from the npm and `esm.sh` imports declared in `deno.json`. Coverage of transitive dependencies is in progress.
+- **Continuous scanning:** CodeQL (`security-and-quality` queries) and an `npm audit` job run weekly and on every pull request that touches `deno.json` (see `.github/workflows/codeql.yml`, `.github/workflows/security-audit.yml`). Socket.dev is configured via `socket.yml` and reviews pull requests as a GitHub App.
+- **Pinned dependencies:** all `npm:` and `esm.sh` imports are required to declare exact `x.y.z` versions, enforced by `scripts/lint/audit-deps.ts` (`deno task lint:deps`). Git URL and tarball imports are rejected outright.
+- **Capability descriptors:** each first-party extension declares the capabilities it requires (e.g. `net`, `fs`, `env`) in its `deno.json`. These are descriptive today; runtime enforcement is on the roadmap.
+- **Install-script allow-list:** native postinstall scripts are explicitly allow- or deny-listed in `deno.json`'s `allowScripts` field. Unlisted packages cannot run install hooks.
+- **Reproducible builds, lockfile enforcement, SHA-pinned GitHub Actions, automated dependency PRs, and release-artifact signing/provenance are in progress.** We will update this section as each lands; until then, do not assume any of those controls are active.
+
+## Security Hardening Recommendations for Operators
+
+When deploying veryfront to production:
+
+- Verify the binary's checksum against the published `sha256` on each release page.
+- Pin the binary version explicitly. Avoid `latest`.
+- Limit Deno permissions to the minimum your application needs (`--allow-net=<host>` not `--allow-net`, etc.).
+- Subscribe to GitHub Security Advisories on this repository for notifications.
+
+## Changelog
+
+Security advisories are published as GitHub Security Advisories on this repository. Each advisory includes:
+- Affected versions
+- CVSS v3.1 score
+- A patched version reference
+- Reporter credit (if requested)


### PR DESCRIPTION
## Summary
- Full rewrite of `SECURITY.md`.
- Documents disclosure email, embargo, scope, supply-chain controls, and operator hardening guidance.
- Replaces GitHub default-template language.

## Why
The previous file was the GitHub Markdown default and made unverified claims (`0.1.x: supported`, no SLA, no scope). With the supply-chain work in PRs 1–6 we have concrete commitments worth publishing — and downstream consumers / auditors increasingly require a real SECURITY.md.

## Reality-checked posture
Each "Supply Chain Posture" bullet was verified against the current state of the repo on `main`. Items that depend on PRs 4–6 landing are grouped under an "in progress" footer, not stated as present-tense capabilities. Specifically:
- **Kept** (verified live): exact `x.y.z` pins (`audit-deps.ts`), `allowScripts` allow/deny lists, capability descriptors per extension, npm audit / CodeQL / Socket.dev workflows.
- **Softened or moved to "in progress"**: SBOM lock-walk (PR 5), reproducible builds + frozen lockfile (PR 6), OSV-Scanner (PR 4), SHA-pinned actions (PR 6), Dependabot (PR 4), npm provenance / Sigstore (not yet decided).

## TODOs before merging
1. **Verify `security@veryfront.com` routes to a monitored inbox.** The 48h-ACK SLA depends on this.
2. **Decide GPG posture.** The doc says "request our PGP key" — change to "We do not currently publish a PGP key" if you don't maintain one.
3. **Decide release-signing posture.** All `--provenance` / Sigstore claims were omitted; add them back if you ship release signing.
4. **Confirm supported-versions table.** Current draft is "latest minor only" (`deno.json` is `0.1.459`).
5. **Once PRs 4–6 land**, promote the "in progress" bullets to active-tense.