### PR TITLE
Add hosted agent service runtime helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.478",
+  "version": "0.1.479",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/hosted-agent-service-runtime.test.ts
+++ b/src/agent/hosted-agent-service-runtime.test.ts
@@ -1,0 +1,86 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  createHostedAgentServiceRuntime,
+  startNodeHostedAgentService,
+} from "./hosted-agent-service-runtime.ts";
+
+function createLogger() {
+  return {
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+  };
+}
+
+describe("agent/hosted-agent-service-runtime", () => {
+  it("assembles hosted service auth, routes, lifecycle, and runtime shell", async () => {
+    const bundle = createHostedAgentServiceRuntime({
+      serviceName: "test-agent-service",
+      getConfig: () => ({
+        VERYFRONT_API_URL: "https://api.example.test",
+        NODE_ENV: "test",
+        PORT: 3180,
+        ALLOWED_ORIGINS: ["https://studio.example.test"],
+      }),
+      getAgentConfig: () => ({
+        id: "assistant",
+        name: "Assistant",
+        description: "",
+        instructions: "You are a test assistant.",
+        model: "test/model",
+        maxSteps: 4,
+      }),
+      logger: createLogger(),
+      prepareExecution: async () => ({ ok: true }),
+      streamExecutionToAgUiResponse: () => new Response("streamed"),
+      startDetachedExecution: async () => {},
+    });
+
+    assertEquals(bundle.config.PORT, 3180);
+    assertEquals(bundle.runtime.contract.serviceName, "test-agent-service");
+    assertEquals(bundle.runtime.contract.defaultAgentId, "assistant");
+    assertEquals(bundle.routes.map((route) => route.path), [
+      "/api/ag-ui/messages/stream",
+      "/api/ag-ui",
+      "/api/ag-ui/runs/:runId",
+      "/api/ag-ui/runs",
+      "/internal/agents/stream",
+    ]);
+
+    const ready = await bundle.runtime.request("/readiness");
+    assertEquals(ready.status, 200);
+  });
+
+  it("starts the node agent service server from the assembled runtime", async () => {
+    const service = await startNodeHostedAgentService({
+      serviceName: "node-test-agent-service",
+      getConfig: () => ({
+        VERYFRONT_API_URL: "https://api.example.test",
+        NODE_ENV: "test",
+        PORT: 0,
+        ALLOWED_ORIGINS: ["*"],
+      }),
+      getAgentConfig: () => ({
+        id: "assistant",
+        name: "Assistant",
+        description: "",
+        instructions: "You are a test assistant.",
+      }),
+      logger: createLogger(),
+      prepareExecution: async () => ({ ok: true }),
+      streamExecutionToAgUiResponse: () => new Response("streamed"),
+      startDetachedExecution: async () => {},
+      signals: [],
+      hardShutdownTimeoutMs: 50,
+    });
+
+    try {
+      assertEquals(service.runtime.contract.serviceName, "node-test-agent-service");
+      assertEquals(typeof service.nodeServer.port, "number");
+    } finally {
+      await service.nodeServer.stop();
+    }
+  });
+});

--- a/src/agent/hosted-agent-service-runtime.ts
+++ b/src/agent/hosted-agent-service-runtime.ts
@@ -1,0 +1,194 @@
+import { agent } from "./factory.ts";
+import {
+  type AgentServiceRoute,
+  type AgentServiceRuntime,
+  defineAgentService,
+} from "./agent-service.ts";
+import {
+  createDetachedRunShutdownLifecycle,
+  createDetachedRunTracker,
+  type DetachedRunShutdownLifecycle,
+  type DetachedRunTracker,
+} from "./detached-run-tracker.ts";
+import {
+  createHostedAgentServiceRouteSet,
+  type HostedAgentServiceActiveSpanAttributes,
+  type HostedAgentServiceDetachedCleanupInput,
+  type HostedAgentServiceDetachedExecutionInput,
+  type HostedAgentServiceRouteSet,
+  type HostedAgentServiceStreamExecutionInput,
+} from "./hosted-agent-service-routes.ts";
+import {
+  createHostedServiceAuth,
+  type HostedServiceAuth,
+  type HostedServiceAuthConfig,
+} from "./hosted-service-auth.ts";
+import type { ParsedHostedChatRequest } from "./hosted-chat-request-parser.ts";
+import type { AgUiResumeValue } from "./ag-ui-tool-shared.ts";
+import type { RuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
+import {
+  type NodeAgentServiceServer,
+  startNodeAgentServiceServer,
+} from "./agent-service-server.ts";
+import type { VeryfrontServiceServerLogger } from "../server/service-server.ts";
+
+export type HostedAgentServiceRuntimeConfig = HostedServiceAuthConfig & {
+  PORT: number;
+  ALLOWED_ORIGINS: string[];
+};
+
+export type HostedAgentServiceRuntimeLogger = VeryfrontServiceServerLogger & {
+  info(message: string, metadata?: Record<string, unknown>): void;
+  error(message: string, metadata?: Record<string, unknown>): void;
+};
+
+export type HostedAgentServiceRuntimeTrace = <TResult>(
+  operationName: string,
+  operation: () => Promise<TResult>,
+) => Promise<TResult>;
+
+export type CreateHostedAgentServiceRuntimeOptions<
+  TExecution extends object,
+  TConfig extends HostedAgentServiceRuntimeConfig = HostedAgentServiceRuntimeConfig,
+> = {
+  serviceName: string;
+  getConfig: () => TConfig;
+  getAgentConfig: () => RuntimeAgentMarkdownDefinition;
+  forwardedConfigNamespace?: string;
+  logger: HostedAgentServiceRuntimeLogger;
+  trace?: HostedAgentServiceRuntimeTrace;
+  setActiveSpanAttributes?: (attributes: HostedAgentServiceActiveSpanAttributes) => void;
+  prepareExecution: (req: ParsedHostedChatRequest) => Promise<TExecution>;
+  streamExecutionToAgUiResponse: (
+    input: HostedAgentServiceStreamExecutionInput<TExecution>,
+  ) => Promise<Response> | Response;
+  startDetachedExecution: (
+    input: HostedAgentServiceDetachedExecutionInput<TExecution>,
+  ) => Promise<void>;
+  cleanupExecution?: (
+    input: HostedAgentServiceDetachedCleanupInput<TExecution>,
+  ) => Promise<void>;
+  tracker?: DetachedRunTracker<AgUiResumeValue>;
+  drainTimeoutMs?: number;
+};
+
+export type HostedAgentServiceRuntimeBundle<
+  TExecution extends object,
+  TConfig extends HostedAgentServiceRuntimeConfig = HostedAgentServiceRuntimeConfig,
+> = {
+  config: TConfig;
+  tracker: DetachedRunTracker<AgUiResumeValue>;
+  auth: HostedServiceAuth;
+  routeSet: HostedAgentServiceRouteSet<TExecution>;
+  routes: AgentServiceRoute[];
+  lifecycle: DetachedRunShutdownLifecycle;
+  runtime: AgentServiceRuntime;
+};
+
+export type StartNodeHostedAgentServiceOptions<
+  TExecution extends object,
+  TConfig extends HostedAgentServiceRuntimeConfig = HostedAgentServiceRuntimeConfig,
+> = CreateHostedAgentServiceRuntimeOptions<TExecution, TConfig> & {
+  bindAddress?: string;
+  hardShutdownTimeoutMs?: number;
+  signals?: readonly NodeJS.Signals[];
+};
+
+export type StartNodeHostedAgentServiceResult<
+  TExecution extends object,
+  TConfig extends HostedAgentServiceRuntimeConfig = HostedAgentServiceRuntimeConfig,
+> = HostedAgentServiceRuntimeBundle<TExecution, TConfig> & {
+  nodeServer: NodeAgentServiceServer;
+};
+
+function defaultTrace<TResult>(
+  _operationName: string,
+  operation: () => Promise<TResult>,
+): Promise<TResult> {
+  return operation();
+}
+
+export function createHostedAgentServiceRuntime<
+  TExecution extends object,
+  TConfig extends HostedAgentServiceRuntimeConfig = HostedAgentServiceRuntimeConfig,
+>(
+  options: CreateHostedAgentServiceRuntimeOptions<TExecution, TConfig>,
+): HostedAgentServiceRuntimeBundle<TExecution, TConfig> {
+  const config = options.getConfig();
+  const tracker = options.tracker ?? createDetachedRunTracker<AgUiResumeValue>();
+  const trace = options.trace ?? defaultTrace;
+  const auth = createHostedServiceAuth({
+    getConfig: options.getConfig,
+    logger: options.logger,
+    trace,
+  });
+  const routeSet = createHostedAgentServiceRouteSet({
+    forwardedConfigNamespace: options.forwardedConfigNamespace,
+    authenticateRequest: auth.authenticateRequest,
+    verifyProjectAccess: (projectId, authToken) => auth.verifyProjectAccess(projectId, authToken),
+    tracker,
+    prepareExecution: options.prepareExecution,
+    streamExecutionToAgUiResponse: options.streamExecutionToAgUiResponse,
+    startDetachedExecution: options.startDetachedExecution,
+    cleanupExecution: options.cleanupExecution,
+    setActiveSpanAttributes: options.setActiveSpanAttributes,
+    trace,
+    logger: options.logger,
+  });
+  const agentConfig = options.getAgentConfig();
+  const service = defineAgentService({
+    serviceName: options.serviceName,
+    agent: agent({
+      id: agentConfig.id,
+      system: agentConfig.instructions,
+      model: agentConfig.model,
+      maxSteps: agentConfig.maxSteps,
+    }),
+    server: {
+      port: config.PORT,
+      cors: {
+        origins: config.ALLOWED_ORIGINS,
+        credentials: true,
+      },
+    },
+  });
+  const routes = routeSet.routes;
+
+  return {
+    config,
+    tracker,
+    auth,
+    routeSet,
+    routes,
+    lifecycle: createDetachedRunShutdownLifecycle({
+      tracker,
+      logger: options.logger,
+      drainTimeoutMs: options.drainTimeoutMs,
+    }),
+    runtime: service.createRuntime({ routes }),
+  };
+}
+
+export async function startNodeHostedAgentService<
+  TExecution extends object,
+  TConfig extends HostedAgentServiceRuntimeConfig = HostedAgentServiceRuntimeConfig,
+>(
+  options: StartNodeHostedAgentServiceOptions<TExecution, TConfig>,
+): Promise<StartNodeHostedAgentServiceResult<TExecution, TConfig>> {
+  const bundle = createHostedAgentServiceRuntime(options);
+  const nodeServer = await startNodeAgentServiceServer({
+    runtime: bundle.runtime,
+    serviceName: options.serviceName,
+    lifecycle: bundle.lifecycle,
+    port: bundle.config.PORT,
+    bindAddress: options.bindAddress,
+    signals: options.signals,
+    logger: options.logger,
+    hardShutdownTimeoutMs: options.hardShutdownTimeoutMs,
+  });
+
+  return {
+    ...bundle,
+    nodeServer,
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -242,6 +242,17 @@ export {
   type StartNodeAgentServiceServerOptions,
 } from "./agent-service-server.ts";
 export {
+  createHostedAgentServiceRuntime,
+  type CreateHostedAgentServiceRuntimeOptions,
+  type HostedAgentServiceRuntimeBundle,
+  type HostedAgentServiceRuntimeConfig,
+  type HostedAgentServiceRuntimeLogger,
+  type HostedAgentServiceRuntimeTrace,
+  startNodeHostedAgentService,
+  type StartNodeHostedAgentServiceOptions,
+  type StartNodeHostedAgentServiceResult,
+} from "./hosted-agent-service-runtime.ts";
+export {
   type AgentServiceBootstrapExit,
   type AgentServiceTraceContext,
   type AgentServiceTraceContextGetter,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.478";
+export const VERSION = "0.1.479";


### PR DESCRIPTION
## Summary
- add a reusable hosted agent service runtime assembly helper
- add a node startup helper that wires service runtime, routes, auth, tracker, and shutdown lifecycle
- bump framework version to 0.1.479

## Verification
- deno test --no-check --allow-all src/agent/hosted-agent-service-runtime.test.ts
- deno check src/agent/index.ts src/agent/hosted-agent-service-runtime.ts
- deno task verify:quick
- deno test --no-check --allow-all src/agent/hosted-agent-service-runtime.test.ts src/agent/hosted-agent-service-routes.test.ts src/agent/agent-service-server.test.ts
- deno task build:npm
- pre-push checks