### PR TITLE
ci(security): SHA-pin actions and add least-priv permissions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -22,7 +25,7 @@ jobs:
       matrix:
         check: [format, lint, typecheck]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - uses: ./.github/actions/setup-deno
       - name: Run ${{ matrix.check }}
         run: |
@@ -44,12 +47,12 @@ jobs:
       matrix:
         suite: [unit, integration]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - uses: ./.github/actions/setup-deno
         with:
           warm-cache: "true"
           warm-redis-cache: "true"
-      - uses: nick-fields/retry@v4.0.0
+      - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
           timeout_minutes: ${{ matrix.suite == 'integration' && 10 || 5 }}
           max_attempts: 3
@@ -66,7 +69,7 @@ jobs:
     timeout-minutes: 25
     name: tests (rsc browser e2e)
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - uses: ./.github/actions/setup-deno
         with:
           warm-cache: "true"
@@ -96,7 +99,7 @@ jobs:
             sudo rm -rf /var/lib/apt/lists/*
             sleep $((attempt * 20))
           done
-      - uses: nick-fields/retry@v4.0.0
+      - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 2
@@ -112,7 +115,7 @@ jobs:
     timeout-minutes: 35
     name: tests (binary e2e)
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - uses: ./.github/actions/setup-deno
         with:
           warm-cache: "true"
@@ -142,7 +145,7 @@ jobs:
             sudo rm -rf /var/lib/apt/lists/*
             sleep $((attempt * 20))
           done
-      - uses: nick-fields/retry@v4.0.0
+      - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
           timeout_minutes: 15
           max_attempts: 2
@@ -161,7 +164,7 @@ jobs:
     name: tests (split mode)
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - uses: ./.github/actions/setup-deno
 
       - name: Compile binary
@@ -218,7 +221,7 @@ jobs:
       version: ${{ steps.check.outputs.version }}
       is_stable: ${{ steps.check.outputs.is_stable }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Detect release type
         id: check
         run: |
@@ -260,7 +263,7 @@ jobs:
             target: x86_64-pc-windows-msvc
             name: veryfront-windows-x64.exe
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - uses: ./.github/actions/setup-deno
 
       - run: deno task build:prepare
@@ -272,7 +275,7 @@ jobs:
             --target ${{ matrix.target }} \
             --output ${{ matrix.name }}
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.name }}
@@ -292,11 +295,11 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - uses: ./.github/actions/setup-deno
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
@@ -323,7 +326,7 @@ jobs:
             npm publish --access public --tag rc
           fi
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           path: binaries
 
@@ -354,7 +357,7 @@ jobs:
             scripts/install.sh
 
       - name: Trigger server deploy
-        uses: peter-evans/repository-dispatch@v4.0.1
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
         with:
           token: ${{ secrets.GH_PAT_VERYFRONT }}
           repository: veryfront/veryfront-server
@@ -362,7 +365,7 @@ jobs:
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
 
       - name: Trigger job-runner deploy
-        uses: peter-evans/repository-dispatch@v4.0.1
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
         with:
           token: ${{ secrets.GH_PAT_VERYFRONT }}
           repository: veryfront/veryfront-job-runner
@@ -370,7 +373,7 @@ jobs:
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
 
       - name: Trigger sandbox deploy
-        uses: peter-evans/repository-dispatch@v4.0.1
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
         with:
           token: ${{ secrets.GH_PAT_VERYFRONT }}
           repository: veryfront/veryfront-sandbox
@@ -392,7 +395,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Read version
         id: version
@@ -402,7 +405,7 @@ jobs:
 
       - uses: ./.github/actions/setup-deno
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
@@ -419,7 +422,7 @@ jobs:
             cd npm && npm publish --access public
           fi
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           path: binaries
 
@@ -489,7 +492,7 @@ jobs:
           fi
 
       - name: Trigger server deploy
-        uses: peter-evans/repository-dispatch@v4.0.1
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
         with:
           token: ${{ secrets.GH_PAT_VERYFRONT }}
           repository: veryfront/veryfront-server
@@ -497,7 +500,7 @@ jobs:
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
 
       - name: Trigger job-runner deploy
-        uses: peter-evans/repository-dispatch@v4.0.1
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
         with:
           token: ${{ secrets.GH_PAT_VERYFRONT }}
           repository: veryfront/veryfront-job-runner
@@ -505,7 +508,7 @@ jobs:
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
 
       - name: Trigger sandbox deploy
-        uses: peter-evans/repository-dispatch@v4.0.1
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
         with:
           token: ${{ secrets.GH_PAT_VERYFRONT }}
           repository: veryfront/veryfront-sandbox
@@ -520,10 +523,10 @@ jobs:
     needs: [release, version-check]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Update Homebrew tap
-        uses: nick-fields/retry@v4.0.0
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         env:
           HOMEBREW_TAP_PAT: ${{ secrets.GH_PAT_HOMEBREW_TAP || secrets.GH_PAT_VERYFRONT }}
         with:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
       github.event.pull_request.user.login != 'aikido-autofix[bot]'
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           ref: ${{ github.event.pull_request.base.ref }}
 
@@ -73,7 +73,7 @@ jobs:
 
       - name: Post CLA reminder
         if: steps.check.outputs.signed == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         env:
           MISSING_LOGINS: ${{ steps.check.outputs.missing_logins }}
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,13 +18,13 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@7fd177fa680c9881b53cdab4d346d32574c9f7f4  # v3
         with:
           languages: javascript-typescript
           queries: security-and-quality
 
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@7fd177fa680c9881b53cdab4d346d32574c9f7f4  # v3
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -10,12 +10,15 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   npm-audit:
     runs-on: ubuntu-latest
     name: NPM Dependency Audit
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - uses: ./.github/actions/setup-deno
 
       - name: Run npm dependency audit

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -10,11 +10,14 @@ on:
       - "deno.json"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
-      - uses: peter-evans/repository-dispatch@v4.0.1
+      - uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
         with:
           token: ${{ secrets.GH_PAT_VERYFRONT }}
           repository: veryfront/veryfront-docs


### PR DESCRIPTION
## Summary
- All third-party `uses:` in workflows + composite actions now pinned to 40-char commit SHAs with the original tag preserved in a trailing comment.
- Every workflow declares a top-level `permissions: contents: read`. Per-job widening only where required (release jobs already declared `contents: write` + `id-token: write`).

## Why
A tag in `uses:` is mutable — `actions/checkout@v5` resolves to whatever the v5 tag points to today. If a third-party action is compromised and the tag is force-moved, every downstream workflow runs the new code at next CI invocation. SHA pinning makes that impossible without a code review.

Least-privilege `permissions:` blocks limit what a compromised step can do with `GITHUB_TOKEN`.

## Pinned actions
- `actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd` (v5)
- `actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` (v8)
- `actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b` (v7)
- `actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (v6)
- `actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f` (v6)
- `github/codeql-action/{init,analyze}@7fd177fa680c9881b53cdab4d346d32574c9f7f4` (v3)
- `nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60` (v4.0.0)
- `peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697` (v4.0.1)

## Notes
- **Frozen-lockfile guard not added.** `deno.lock` is gitignored in this repo (`.gitignore:45`), so `git diff --exit-code deno.lock` would always pass trivially. Apply the guard once the lockfile is tracked (separate decision).
- `actionlint` not run locally (binary not installed in this environment); YAML parse-validated for every modified file.

## Verification
- [x] No `uses: <repo>@v<digit>` reference remains in any workflow
- [x] Every workflow has a top-level `permissions:` block
- [x] Every job-level `permissions:` block lists scopes explicitly (no `write-all`)
- [x] CI green on this branch

## Future work
- Pin Docker actions by digest, not tag
- Add OpenSSF Scorecard workflow
- Track `deno.lock` then add the frozen-lockfile guard