### PR TITLE
chore(deps): bump @types/react to 19.x to match runtime

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -259,8 +259,8 @@
     "@std/fs": "jsr:@std/fs",
     "@std/async": "jsr:@std/async",
     "@std/front-matter/yaml": "./src/platform/compat/std/front-matter-yaml.ts",
-    "@types/react": "https://esm.sh/@types/react@18.3.27?deps=csstype@3.2.3",
-    "@types/react-dom": "https://esm.sh/@types/react-dom@18.3.7?deps=csstype@3.2.3",
+    "@types/react": "https://esm.sh/@types/react@19.2.14?deps=csstype@3.2.3",
+    "@types/react-dom": "https://esm.sh/@types/react-dom@19.2.3?deps=csstype@3.2.3",
     "react": "https://esm.sh/react@19.2.4?target=es2022&deps=csstype@3.2.3",
     "react-dom": "https://esm.sh/react-dom@19.2.4?external=react&target=es2022&deps=csstype@3.2.3",
     "react-dom/server": "https://esm.sh/react-dom@19.2.4/server?external=react&target=es2022&deps=csstype@3.2.3",
@@ -291,7 +291,7 @@
     "noImplicitAny": true,
     "noUncheckedIndexedAccess": true,
     "types": [
-      "npm:@types/react@18.3.27"
+      "npm:@types/react@19.2.14"
     ],
     "lib": [
       "deno.window",


### PR DESCRIPTION
## Summary
- Bumps `@types/react` 18.3.27 → 19.2.14 and `@types/react-dom` 18.3.7 → 19.2.3 in `deno.json` to match the `react@19.2.4` runtime.
- Updates `compilerOptions.types` to `npm:@types/react@19.2.14`.

## Why
Type-package version drift is a supply-chain hygiene issue: audits report 18.x type CVEs against a runtime no longer using them, and 19-only APIs pass through type-checking as `any`. This is also a correctness fix.

## Verification
- `deno task typecheck` PASS — full project entry-point check, no `.tsx` source changes required (React 19 type tightenings did not bite any current call site).
- `deno test src/react src/agent/react src/workflow/react` — 16 files, 218 steps, all PASS.
- Pre-push hook (full `deno task test:unit`): 1758 passed, 0 failed.
- Dev-server smoke test skipped (interactive task; not suitable for non-interactive verification).