### PR TITLE
Add default hosted chat runtime helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.480",
+  "version": "0.1.481",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/default-hosted-chat-runtime.test.ts
+++ b/src/agent/default-hosted-chat-runtime.test.ts
@@ -1,0 +1,67 @@
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import type {
+  RemoteMCPToolSourceConfig,
+  RemoteToolSource,
+  ToolExecutionContext,
+} from "#veryfront/tool";
+import { z } from "zod";
+import {
+  createDefaultHostedChatRuntime,
+  type DefaultHostedChatRuntimeTaskContext,
+} from "./default-hosted-chat-runtime.ts";
+
+function localTool(description: string) {
+  return {
+    description,
+    inputSchema: z.object({}),
+    execute: () => ({ ok: true }),
+  };
+}
+
+function emptyRemoteSource(config: RemoteMCPToolSourceConfig): RemoteToolSource {
+  return {
+    id: config.id ?? "source",
+    listTools: () => Promise.resolve([]),
+    executeTool: (_toolName: string, _args: unknown, _context?: ToolExecutionContext) =>
+      Promise.resolve({ ok: true }),
+  };
+}
+
+Deno.test("createDefaultHostedChatRuntime builds a cloud-backed hosted runtime", async () => {
+  let capturedContext: DefaultHostedChatRuntimeTaskContext | undefined;
+
+  const runtime = await createDefaultHostedChatRuntime({
+    options: {
+      projectId: "project-1",
+      branchId: "branch-1",
+      authToken: "token-1",
+      instructions: "Base instructions",
+      model: "sonnet",
+      allowedTools: ["sleep"],
+      conversationId: "conversation-1",
+      userId: "user-1",
+      parentRunId: "run-1",
+      parentMessageId: "message-1",
+    },
+    config: {
+      apiUrl: "https://api.example.com",
+      apiMcpUrl: "https://api.example.com/mcp",
+      studioMcpUrl: "https://studio.example.com/mcp",
+    },
+    buildLocalTools: (taskContext) => {
+      capturedContext = taskContext;
+      return { sleep: localTool("Sleep") };
+    },
+    createRemoteToolSource: emptyRemoteSource,
+    preloadLatestConversationUserText: false,
+  });
+
+  assertEquals(runtime.runtimeKind, "framework");
+  assertEquals(runtime.modelId, "anthropic/claude-sonnet-4-6");
+  assertExists(capturedContext);
+  assertEquals(capturedContext.projectId, "project-1");
+  assertEquals(capturedContext.branchId, "branch-1");
+  assertEquals(capturedContext.model, "anthropic/claude-sonnet-4-6");
+  assertEquals(capturedContext.userId, "user-1");
+  assertEquals(capturedContext.availableToolNames, ["sleep"]);
+});

--- a/src/agent/default-hosted-chat-runtime.ts
+++ b/src/agent/default-hosted-chat-runtime.ts
@@ -1,0 +1,325 @@
+import {
+  type HostToolSet,
+  type RemoteMCPToolSourceConfig,
+  type RemoteToolSource,
+} from "#veryfront/tool";
+import { runWithRequestContextAsync, serverLogger } from "#veryfront/utils";
+import {
+  resolveVeryfrontCloudModelId,
+  resolveVeryfrontCloudThinkingProviderOptions,
+} from "#veryfront/provider/veryfront-cloud/model-catalog.ts";
+import {
+  runWithVeryfrontCloudContext,
+  runWithVeryfrontCloudContextAsync,
+  type VeryfrontCloudContext,
+} from "#veryfront/provider/veryfront-cloud/context.ts";
+import { agent } from "./factory.ts";
+import {
+  applyDefaultResearchArtifactPath,
+  createDefaultResearchRunArtifactMirrorHandler,
+  shouldRetryCreateResearchArtifactAsUpdate,
+} from "./default-research-artifact-support.ts";
+import { createHostedChatRuntimeAgentAdapter } from "./hosted-chat-runtime-agent-adapter.ts";
+import type {
+  HostedChatRuntimeCreationOptions,
+  HostedChatRuntimeCreationResult,
+} from "./hosted-chat-runtime-contract.ts";
+import {
+  type HostedChatRuntimeToolAssemblyResult,
+  prepareHostedChatRuntimeToolAssembly,
+  type PrepareHostedChatRuntimeToolAssemblyInput,
+} from "./hosted-chat-runtime-tool-assembly.ts";
+import {
+  createHostedRuntimeStateResolver,
+  type HostedRuntimeStateResolverContext,
+} from "./hosted-runtime-state-resolver.ts";
+import type { ProjectSteeringMutationResult } from "./project-steering-mutation.ts";
+import type {
+  RuntimeAgentMarkdownDefinition,
+  RuntimeAgentThinkingConfig,
+} from "./runtime-agent-definition.ts";
+import type { AgentConfig } from "./types.ts";
+
+export type DefaultHostedChatRuntimeConfig = {
+  apiUrl: string;
+  apiMcpUrl: string;
+  studioMcpUrl?: string | null;
+};
+
+export type DefaultHostedChatRuntimeLogger = {
+  warn(message: string, metadata?: Record<string, unknown>): void;
+};
+
+export type DefaultHostedChatRuntimeCreationOptions =
+  & HostedChatRuntimeCreationOptions<
+    RuntimeAgentMarkdownDefinition,
+    RuntimeAgentThinkingConfig
+  >
+  & {
+    userId?: string;
+  };
+
+export type DefaultHostedChatRuntimeTaskContext = HostedRuntimeStateResolverContext & {
+  authToken: string;
+  projectId: string;
+  branchId: string | null;
+  model: string | undefined;
+  clientProfile?: DefaultHostedChatRuntimeCreationOptions["clientProfile"];
+  conversationId?: string;
+  userId?: string;
+  parentRunId?: string;
+  parentMessageId?: string;
+  availableSkillIds?: string[];
+  publishParentRunEvents?: DefaultHostedChatRuntimeCreationOptions["publishParentRunEvents"];
+  availableToolNames?: string[];
+};
+
+export type CreateDefaultHostedChatRuntimeContextInput = {
+  options: DefaultHostedChatRuntimeCreationOptions;
+  modelId: string;
+};
+
+export type DefaultHostedChatRuntimeSystemRefreshInput = {
+  taskContext: DefaultHostedChatRuntimeTaskContext;
+  liveProjectSteering: NonNullable<DefaultHostedChatRuntimeCreationOptions["liveProjectSteering"]>;
+  toolAssembly: HostedChatRuntimeToolAssemblyResult;
+};
+
+export type DefaultHostedChatRuntimeSteeringMutationInput = {
+  mutation: ProjectSteeringMutationResult;
+  taskContext: DefaultHostedChatRuntimeTaskContext;
+};
+
+export type DefaultHostedChatRuntimeProjectSwitchInput = {
+  projectId: string;
+  taskContext: DefaultHostedChatRuntimeTaskContext;
+};
+
+export type CreateDefaultHostedChatRuntimeOptions = {
+  options: DefaultHostedChatRuntimeCreationOptions;
+  config: DefaultHostedChatRuntimeConfig;
+  buildLocalTools: (taskContext: DefaultHostedChatRuntimeTaskContext) => HostToolSet;
+  createTaskContext?: (
+    input: CreateDefaultHostedChatRuntimeContextInput,
+  ) => DefaultHostedChatRuntimeTaskContext;
+  refreshSystem?: (
+    input: DefaultHostedChatRuntimeSystemRefreshInput,
+  ) => Promise<string> | string;
+  onSteeringMutation?: (
+    input: DefaultHostedChatRuntimeSteeringMutationInput,
+  ) => Promise<void> | void;
+  onStudioProjectSwitch?: (
+    input: DefaultHostedChatRuntimeProjectSwitchInput,
+  ) => Promise<boolean> | boolean;
+  projectScopedRemoteToolOptions?:
+    PrepareHostedChatRuntimeToolAssemblyInput["projectScopedRemoteToolOptions"];
+  createRemoteToolSource?: (config: RemoteMCPToolSourceConfig) => RemoteToolSource;
+  traceLocalTools?: PrepareHostedChatRuntimeToolAssemblyInput["traceLocalTools"];
+  preloadLatestConversationUserText?: boolean;
+  logger?: DefaultHostedChatRuntimeLogger;
+};
+
+function createDefaultTaskContext(
+  input: CreateDefaultHostedChatRuntimeContextInput,
+): DefaultHostedChatRuntimeTaskContext {
+  return {
+    authToken: input.options.authToken,
+    projectId: input.options.projectId ?? "",
+    branchId: input.options.branchId ?? null,
+    model: input.modelId,
+    clientProfile: input.options.clientProfile,
+    conversationId: input.options.conversationId,
+    userId: input.options.userId,
+    parentRunId: input.options.parentRunId,
+    parentMessageId: input.options.parentMessageId,
+    availableSkillIds: input.options.availableSkillIds,
+    publishParentRunEvents: input.options.publishParentRunEvents,
+  };
+}
+
+function incrementSteeringRevision(context: DefaultHostedChatRuntimeTaskContext): void {
+  context.steeringRevision = (context.steeringRevision ?? 0) + 1;
+}
+
+async function buildToolAssembly(
+  input: CreateDefaultHostedChatRuntimeOptions & {
+    taskContext: DefaultHostedChatRuntimeTaskContext;
+  },
+): Promise<HostedChatRuntimeToolAssemblyResult> {
+  return prepareHostedChatRuntimeToolAssembly({
+    taskContext: input.taskContext,
+    instructions: input.options.instructions,
+    localTools: input.buildLocalTools(input.taskContext),
+    apiUrl: input.config.apiUrl,
+    apiMcpUrl: input.config.apiMcpUrl,
+    studioMcpUrl: input.config.studioMcpUrl,
+    conversationId: input.options.conversationId,
+    allowedToolNames: input.options.allowedTools ?? null,
+    projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions,
+    createRemoteToolSource: input.createRemoteToolSource,
+    traceLocalTools: input.traceLocalTools,
+    preloadLatestConversationUserText: input.preloadLatestConversationUserText,
+    prepareRemoteToolInput: ({ toolName, toolInput }) =>
+      applyDefaultResearchArtifactPath(toolName, toolInput, input.taskContext),
+    shouldRetryWithRemoteTool: ({ toolName, toolInput, error }) =>
+      shouldRetryCreateResearchArtifactAsUpdate({
+        toolName,
+        toolInput,
+        taskContext: input.taskContext,
+        error,
+      }),
+    onSteeringMutation: async (mutation) => {
+      await input.onSteeringMutation?.({ mutation, taskContext: input.taskContext });
+      if (mutation.instructionsChanged || mutation.skillsChanged) {
+        incrementSteeringRevision(input.taskContext);
+      }
+    },
+    onStudioProjectSwitch: async (projectId) => {
+      const changed = await input.onStudioProjectSwitch?.({
+        projectId,
+        taskContext: input.taskContext,
+      });
+      if (changed) {
+        incrementSteeringRevision(input.taskContext);
+      }
+    },
+  });
+}
+
+function createRuntimeAgentConfig(input: {
+  options: DefaultHostedChatRuntimeCreationOptions;
+  taskContext: DefaultHostedChatRuntimeTaskContext;
+  toolAssembly: HostedChatRuntimeToolAssemblyResult;
+  modelId: string;
+  refreshSystem?: CreateDefaultHostedChatRuntimeOptions["refreshSystem"];
+}): AgentConfig {
+  const liveProjectSteering = input.options.liveProjectSteering;
+  const systemRefresh = input.refreshSystem;
+  const refreshSystem = systemRefresh && liveProjectSteering
+    ? () =>
+      systemRefresh({
+        taskContext: input.taskContext,
+        liveProjectSteering,
+        toolAssembly: input.toolAssembly,
+      })
+    : undefined;
+
+  return {
+    id: "veryfront-hosted-runtime",
+    model: input.modelId,
+    system: input.toolAssembly.systemInstructions,
+    tools: input.toolAssembly.runtimeTools,
+    remoteTools: input.toolAssembly.remoteToolSources,
+    allowedRemoteTools: input.toolAssembly.compatibleRemoteToolNames,
+    maxSteps: input.options.maxSteps ?? 50,
+    resolveModelTransport: ({ resolvedModel }) => {
+      const providerOptions = resolveVeryfrontCloudThinkingProviderOptions(
+        resolvedModel,
+        input.options.thinking,
+      );
+      return providerOptions ? { providerOptions } : {};
+    },
+    resolveRuntimeState: createHostedRuntimeStateResolver({
+      taskContext: input.taskContext,
+      refreshSystem,
+    }),
+    onToolResult: createDefaultResearchRunArtifactMirrorHandler({
+      taskContext: input.taskContext,
+      remoteToolSource: input.toolAssembly.remoteToolSources[0],
+    }),
+  };
+}
+
+function createCloudContext(input: {
+  config: DefaultHostedChatRuntimeConfig;
+  options: DefaultHostedChatRuntimeCreationOptions;
+}): VeryfrontCloudContext {
+  return {
+    apiBaseUrl: input.config.apiUrl,
+    apiToken: input.options.authToken,
+    serviceLayer: "cloud",
+  };
+}
+
+function runWithDefaultHostedRequestContext<TResult>(
+  input: {
+    taskContext: DefaultHostedChatRuntimeTaskContext;
+    cloudContext: VeryfrontCloudContext;
+    operation: () => Promise<TResult>;
+  },
+): Promise<TResult> {
+  const requestContext = {
+    logger: serverLogger.child({
+      project_id: input.taskContext.projectId || undefined,
+      user_id: input.taskContext.userId,
+      conversation_id: input.taskContext.conversationId,
+    }),
+    requestId: crypto.randomUUID(),
+    projectId: input.taskContext.projectId || undefined,
+    userId: input.taskContext.userId,
+    conversationId: input.taskContext.conversationId,
+  };
+
+  return runWithRequestContextAsync(
+    requestContext,
+    () => runWithVeryfrontCloudContextAsync(input.cloudContext, input.operation),
+  );
+}
+
+export async function createDefaultHostedChatRuntime(
+  input: CreateDefaultHostedChatRuntimeOptions,
+): Promise<HostedChatRuntimeCreationResult> {
+  const modelId = resolveVeryfrontCloudModelId(input.options.model);
+  const cloudContext = createCloudContext({
+    config: input.config,
+    options: input.options,
+  });
+  const taskContext = input.createTaskContext
+    ? input.createTaskContext({ options: input.options, modelId })
+    : createDefaultTaskContext({ options: input.options, modelId });
+  const cleanup = () => Promise.resolve();
+
+  try {
+    const toolAssembly = await buildToolAssembly({
+      ...input,
+      taskContext,
+    });
+    const runtimeAgentConfig = createRuntimeAgentConfig({
+      options: input.options,
+      taskContext,
+      toolAssembly,
+      modelId,
+      refreshSystem: input.refreshSystem,
+    });
+    const runtimeAgent = runWithVeryfrontCloudContext(
+      cloudContext,
+      () => agent(runtimeAgentConfig),
+    );
+
+    return {
+      runtimeKind: "framework",
+      modelId,
+      cleanup,
+      agent: createHostedChatRuntimeAgentAdapter({
+        runtimeAgent,
+        runStream: (operation) =>
+          runWithDefaultHostedRequestContext({
+            taskContext,
+            cloudContext,
+            operation,
+          }),
+        warnOrphanedToolInput: (message, metadata) => {
+          input.logger?.warn(message, {
+            ...metadata,
+            ...(taskContext.projectId ? { project_id: taskContext.projectId } : {}),
+            ...(taskContext.userId ? { user_id: taskContext.userId } : {}),
+            ...(taskContext.conversationId ? { conversation_id: taskContext.conversationId } : {}),
+          });
+        },
+      }),
+    };
+  } catch (error) {
+    await cleanup();
+    throw error;
+  }
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -242,6 +242,19 @@ export {
   type StartNodeAgentServiceServerOptions,
 } from "./agent-service-server.ts";
 export {
+  createDefaultHostedChatRuntime,
+  type CreateDefaultHostedChatRuntimeContextInput,
+  type CreateDefaultHostedChatRuntimeOptions,
+  type DefaultHostedChatRuntimeConfig,
+  type DefaultHostedChatRuntimeCreationOptions,
+  type DefaultHostedChatRuntimeLogger,
+  type DefaultHostedChatRuntimeProjectSwitchInput,
+  type DefaultHostedChatRuntimeSteeringMutationInput,
+  type DefaultHostedChatRuntimeSystemRefreshInput,
+  type DefaultHostedChatRuntimeTaskContext,
+} from "./default-hosted-chat-runtime.ts";
+
+export {
   createHostedAgentServiceRuntime,
   type CreateHostedAgentServiceRuntimeOptions,
   type HostedAgentServiceRuntimeBundle,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.480";
+export const VERSION = "0.1.481";


### PR DESCRIPTION
## Summary
- add a reusable default hosted chat runtime helper for cloud-backed agent services
- centralize hosted runtime assembly, remote tool defaults, request context, and artifact mirroring
- bump package version to 0.1.481 for CI release

## Test Plan
- [x] deno check src/agent/index.ts
- [x] deno test --no-check --allow-all src/agent/default-hosted-chat-runtime.test.ts src/agent/hosted-chat-runtime-tool-assembly.test.ts src/agent/hosted-chat-runtime-agent-adapter.test.ts
- [x] deno lint src/agent/default-hosted-chat-runtime.ts src/agent/default-hosted-chat-runtime.test.ts src/agent/index.ts