### PR TITLE
Add prepared hosted chat execution helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It gives you agents, tools, workflows, and a complete React rendering stack in a
 
 Purpose-built for TypeScript and React, Veryfront gives you everything you need to build agentic full-stack applications out-of-the-box.
 
-- [**Agents**](https://veryfront.com/docs/code/guides/agents) — Build autonomous agents with model routing, system prompts, and tool calling. Agents reason about goals and iterate until they reach a final answer.
+- [**Agents**](https://veryfront.com/docs/code/guides/agents) — Build autonomous agents with model routing, system prompts, hosted execution helpers, and tool calling. Agents reason about goals and iterate until they reach a final answer.
 
 - [**Tools**](https://veryfront.com/docs/code/guides/tools) — Define Zod-validated functions that agents can call. Tools are auto-discovered from the file system with no registration needed.
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.481",
+  "version": "0.1.482",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/architecture/04-mcp-servers.md
+++ b/docs/architecture/04-mcp-servers.md
@@ -80,6 +80,7 @@ The App MCP server implements the MCP protocol (versions 2025-11-25 and 2024-11-
 4. **Async Tasks:** For long-running tools, the caller opts into task mode by including a `task` object. The server creates a task and returns a task ID. The client polls `tasks/get` for status and `tasks/result` for output until the task reaches a terminal state (`completed`, `failed`, `cancelled`). Tasks have a max capacity of 1000, with TTL-based cleanup of terminal tasks.
 
 Key features:
+
 - **Auth:** Bearer token validation on every request
 - **CORS:** Origin allowlisting with configurable headers
 - **Session Management:** UUID-based sessions with capability tracking
@@ -214,7 +215,7 @@ The internal AG-UI transport bridges AI agents with the Studio UI:
 2. **Injected Tool Pattern:** The Studio passes tool definitions (name, schema) that the agent can call. The system creates wrapper tools that, when called by the agent, block execution and wait for the Studio to submit tool results. This enables human-in-the-loop tool execution where the UI handles the actual tool interaction.
 3. **Tool Result Submission:** When the agent calls an injected tool, the run pauses (up to 5 minutes). The Studio submits the tool result via `/internal/agents/runs/:runId/resume`. The wrapper tool unblocks and returns the result to the agent.
 4. **AG-UI Streaming:** All events are streamed as SSE in the AG-UI wire format (`RunStarted`, `TextMessageContent`, `ToolCallStart`, `ToolCallArgs`, `ToolCallEnd`, `ToolCallResult`, `RunFinished`).
-5. **Contract Boundary:** The internal `/internal/agents/*` routes are compatibility/control-plane wrappers. The canonical package-level AG-UI handlers live under `veryfront/agent` and are designed around host-configurable endpoints such as `/api/ag-ui`.
+5. **Contract Boundary:** The internal `/internal/agents/*` routes are compatibility/control-plane wrappers. The canonical package-level AG-UI handlers live under `veryfront/agent` and are designed around host-configurable endpoints such as `/api/ag-ui`. Hosted services should use the framework prepared-execution helpers to stream prepared chat runs to AG-UI responses or finish detached durable runs instead of reimplementing that lifecycle locally.
 
 Session states: `active` → `waiting` (for tool result) → `completed` / `failed` / `cancelled`. Default session TTL is 15 minutes.
 

--- a/src/README.md
+++ b/src/README.md
@@ -473,6 +473,7 @@ See [`transforms/import-rewriter/README.md`](./transforms/import-rewriter/README
 **Exports**: `veryfront/agent`
 
 - Agent factory and runtime execution
+- Hosted chat preparation, prepared execution streaming, and detached run finalization
 - Memory management (conversation, buffer, summary)
 - Agent composition (`agentAsTool`)
 - React hooks (`useChat`, `useAgent`)

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1109,6 +1109,14 @@ export {
   toHostedChatExecutionFinalState,
 } from "./hosted-chat-execution-runtime.ts";
 export {
+  type PreparedHostedChatExecution,
+  type PreparedHostedChatExecutionDetachedInput,
+  type PreparedHostedChatExecutionRuntimeOptions,
+  type PreparedHostedChatExecutionStreamInput,
+  runPreparedHostedChatExecutionDetached,
+  streamPreparedHostedChatExecutionToAgUiResponse,
+} from "./prepared-hosted-chat-execution.ts";
+export {
   finalizeHostedDetached,
   type FinalizeHostedDetachedOptions,
   finalizeHostedResponse,

--- a/src/agent/prepared-hosted-chat-execution.test.ts
+++ b/src/agent/prepared-hosted-chat-execution.test.ts
@@ -1,0 +1,181 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ChatUiMessageChunk, MessageMetadata } from "../chat/types.ts";
+import type { HostedAgentRunSpan, HostedAgentRunTracer } from "./hosted-agent-run-lifecycle.ts";
+import type { HostedChatRuntimeToUiMessageStreamOptions } from "./hosted-chat-runtime-contract.ts";
+import type { HostedConversationRootRunContext } from "./conversation-root-run-lifecycle.ts";
+import type { AgUiRuntimeRequest } from "./runtime-ag-ui-contract.ts";
+import {
+  type PreparedHostedChatExecution,
+  type PreparedHostedChatExecutionRuntimeOptions,
+  runPreparedHostedChatExecutionDetached,
+  streamPreparedHostedChatExecutionToAgUiResponse,
+} from "./prepared-hosted-chat-execution.ts";
+
+async function* emptyStream(): AsyncIterable<ChatUiMessageChunk<MessageMetadata>> {}
+
+function createRootRunContext(): HostedConversationRootRunContext {
+  return {
+    durableRootRun: null,
+    durableRunMirror: null,
+  };
+}
+
+function createAgUiInput(): AgUiRuntimeRequest {
+  return {
+    runId: "ag-ui-run-1",
+    threadId: "thread-1",
+    messages: [],
+    tools: [],
+    context: [],
+  };
+}
+
+function createTracer() {
+  const attributes: Array<Parameters<HostedAgentRunSpan["setAttributes"]>[0]> = [];
+  const spanNames: string[] = [];
+  let contextCount = 0;
+  let finishCount = 0;
+  const tracer: HostedAgentRunTracer = {
+    startSpan: (name) => {
+      spanNames.push(name);
+      return {
+        setAttributes: (nextAttributes) => {
+          attributes.push(nextAttributes);
+        },
+        finish: () => {
+          finishCount += 1;
+        },
+        withContext: (fn) => {
+          contextCount += 1;
+          return fn();
+        },
+      };
+    },
+  };
+
+  return {
+    tracer,
+    attributes,
+    spanNames,
+    get contextCount() {
+      return contextCount;
+    },
+    get finishCount() {
+      return finishCount;
+    },
+  };
+}
+
+function createRuntimeOptions(input?: {
+  traces?: string[];
+  activeAttributes?: Record<string, unknown>[];
+}): PreparedHostedChatExecutionRuntimeOptions {
+  const tracer = createTracer();
+  return {
+    apiUrl: "https://api.example.test",
+    tracer: tracer.tracer,
+    resolveProvider: (modelId) => modelId.split("/")[0] ?? "unknown",
+    createRootStreamWatchdog: () => ({
+      signal: new AbortController().signal,
+      get lastTimeoutState() {
+        return null;
+      },
+      observe: () => {},
+      dispose: () => {},
+    }),
+    trace: async (operationName, operation) => {
+      input?.traces?.push(operationName);
+      return await operation();
+    },
+    setActiveSpanAttributes: (attributes) => {
+      input?.activeAttributes?.push(attributes);
+    },
+    logger: {
+      error: () => {},
+      warn: () => {},
+    },
+  };
+}
+
+function createPreparedExecution(input?: {
+  captureStreamOptions?: (options?: HostedChatRuntimeToUiMessageStreamOptions) => void;
+  waitForSteps?: Promise<readonly unknown[]>;
+  cleanup?: () => Promise<void>;
+}): PreparedHostedChatExecution {
+  return {
+    authToken: "auth-token",
+    agent: {
+      stream: async () => ({
+        steps: input?.waitForSteps ?? Promise.resolve([{}]),
+        toUIMessageStream: (options) => {
+          input?.captureStreamOptions?.(options);
+          return emptyStream();
+        },
+      }),
+    },
+    agentId: "agent-1",
+    modelId: "openai/gpt-test",
+    cleanup: input?.cleanup ?? (async () => {}),
+    messages: [],
+    finalMessages: [],
+    projectId: "project-1",
+    userId: "user-1",
+    rootRunContext: createRootRunContext(),
+    runtimeKind: "framework",
+  };
+}
+
+describe("agent/prepared-hosted-chat-execution", () => {
+  it("streams a prepared execution to an AG-UI response with stable defaults", async () => {
+    const traces: string[] = [];
+    const activeAttributes: Record<string, unknown>[] = [];
+    let capturedOptions: HostedChatRuntimeToUiMessageStreamOptions | undefined;
+
+    const response = await streamPreparedHostedChatExecutionToAgUiResponse({
+      execution: {
+        ...createPreparedExecution({
+          captureStreamOptions: (options) => {
+            capturedOptions = options;
+          },
+        }),
+        requestAbortSignal: new AbortController().signal,
+        agUiInput: createAgUiInput(),
+      },
+      runtime: createRuntimeOptions({ traces, activeAttributes }),
+    });
+
+    if (!capturedOptions) {
+      throw new Error("Expected stream options to be captured");
+    }
+
+    assertEquals(response instanceof Response, true);
+    assertEquals(traces, ["chat.streamToAgUiResponse"]);
+    assertEquals(activeAttributes, [{
+      "conversation.id": undefined,
+      "project.id": "project-1",
+      "agent.runtime.kind": "framework",
+    }]);
+    assertEquals(capturedOptions.generateMessageId?.(), "ag-ui-run-1:assistant");
+  });
+
+  it("runs a prepared execution detached and waits for finalization", async () => {
+    const traces: string[] = [];
+    let cleanupCount = 0;
+
+    await runPreparedHostedChatExecutionDetached({
+      execution: {
+        ...createPreparedExecution({
+          cleanup: async () => {
+            cleanupCount += 1;
+          },
+        }),
+        abortSignal: new AbortController().signal,
+      },
+      runtime: createRuntimeOptions({ traces }),
+    });
+
+    assertEquals(traces, ["chat.runDetached"]);
+    assertEquals(cleanupCount, 1);
+  });
+});

--- a/src/agent/prepared-hosted-chat-execution.ts
+++ b/src/agent/prepared-hosted-chat-execution.ts
@@ -1,0 +1,188 @@
+import type { AgentTraceAttributes } from "./agent-trace-attributes.ts";
+import { createAgUiChatUiTrackedBrowserResponse } from "./ag-ui-chat-ui-chunk-browser-encoder.ts";
+import {
+  type BootstrappedHostedChatExecutionRuntime,
+  createBootstrappedHostedChatExecutionRuntime,
+  type CreateBootstrappedHostedChatExecutionRuntimeInput,
+} from "./hosted-chat-execution-runtime.ts";
+import { runHostedLifecycle } from "./hosted-lifecycle.ts";
+import type { AgUiRuntimeRequest } from "./runtime-ag-ui-contract.ts";
+
+export type PreparedHostedChatExecution =
+  & Omit<
+    CreateBootstrappedHostedChatExecutionRuntimeInput,
+    | "apiUrl"
+    | "abortSignal"
+    | "responseMessageId"
+    | "tracer"
+    | "resolveProvider"
+    | "traceStream"
+    | "logger"
+    | "spanName"
+    | "terminalErrorCode"
+    | "incompleteToolCallsPartErrorText"
+    | "createRootStreamWatchdog"
+    | "createTerminalAdapter"
+  >
+  & {
+    runtimeKind?: string;
+  };
+
+export type PreparedHostedChatExecutionRuntimeOptions =
+  & Pick<
+    CreateBootstrappedHostedChatExecutionRuntimeInput,
+    | "tracer"
+    | "resolveProvider"
+    | "traceStream"
+    | "logger"
+    | "spanName"
+    | "terminalErrorCode"
+    | "incompleteToolCallsPartErrorText"
+    | "createRootStreamWatchdog"
+    | "createTerminalAdapter"
+  >
+  & {
+    apiUrl: string | URL;
+    trace?: <TResult>(operationName: string, operation: () => Promise<TResult>) => Promise<TResult>;
+    setActiveSpanAttributes?: (attributes: AgentTraceAttributes) => void;
+  };
+
+export type PreparedHostedChatExecutionStreamInput<
+  TExecution extends PreparedHostedChatExecution = PreparedHostedChatExecution,
+> = TExecution & {
+  requestAbortSignal: AbortSignal;
+  agUiInput: AgUiRuntimeRequest;
+};
+
+export type PreparedHostedChatExecutionDetachedInput<
+  TExecution extends PreparedHostedChatExecution = PreparedHostedChatExecution,
+> = TExecution & {
+  abortSignal: AbortSignal;
+};
+
+function tracePreparedHostedChatExecution<TResult>(input: {
+  spanName: string;
+  execution: PreparedHostedChatExecution;
+  runtime: PreparedHostedChatExecutionRuntimeOptions;
+  run: () => Promise<TResult>;
+}): Promise<TResult> {
+  const run = async () => {
+    input.runtime.setActiveSpanAttributes?.({
+      "conversation.id": input.execution.conversationId,
+      "project.id": input.execution.projectId ?? "none",
+      "agent.runtime.kind": input.execution.runtimeKind,
+    });
+    return await input.run();
+  };
+
+  if (!input.runtime.trace) {
+    return run();
+  }
+
+  return input.runtime.trace(input.spanName, run);
+}
+
+function createBootstrappedPreparedHostedChatExecutionRuntime(input: {
+  execution: PreparedHostedChatExecution;
+  abortSignal: AbortSignal;
+  runtime: PreparedHostedChatExecutionRuntimeOptions;
+  responseMessageId?: string;
+}): Promise<BootstrappedHostedChatExecutionRuntime> {
+  return createBootstrappedHostedChatExecutionRuntime({
+    ...input.execution,
+    apiUrl: input.runtime.apiUrl.toString(),
+    abortSignal: input.abortSignal,
+    tracer: input.runtime.tracer,
+    resolveProvider: input.runtime.resolveProvider,
+    traceStream: input.runtime.traceStream,
+    logger: input.runtime.logger,
+    spanName: input.runtime.spanName,
+    terminalErrorCode: input.runtime.terminalErrorCode,
+    incompleteToolCallsPartErrorText: input.runtime.incompleteToolCallsPartErrorText,
+    createRootStreamWatchdog: input.runtime.createRootStreamWatchdog,
+    createTerminalAdapter: input.runtime.createTerminalAdapter,
+    ...(input.responseMessageId ? { responseMessageId: input.responseMessageId } : {}),
+  });
+}
+
+export async function streamPreparedHostedChatExecutionToAgUiResponse<
+  TExecution extends PreparedHostedChatExecution,
+>(input: {
+  execution: PreparedHostedChatExecutionStreamInput<TExecution>;
+  runtime: PreparedHostedChatExecutionRuntimeOptions;
+}): Promise<Response> {
+  return await tracePreparedHostedChatExecution({
+    spanName: "chat.streamToAgUiResponse",
+    execution: input.execution,
+    runtime: input.runtime,
+    run: async () => {
+      const agUiRunId = input.execution.agUiInput.runId ??
+        input.execution.rootRunContext.durableRootRun?.runId;
+      const { execution } = await createBootstrappedPreparedHostedChatExecutionRuntime({
+        execution: input.execution,
+        abortSignal: input.execution.requestAbortSignal,
+        runtime: input.runtime,
+        ...(agUiRunId ? { responseMessageId: `${agUiRunId}:assistant` } : {}),
+      });
+
+      return createAgUiChatUiTrackedBrowserResponse({
+        agUiInput: input.execution.agUiInput,
+        defaults: {
+          ...(input.execution.conversationId ? { threadId: input.execution.conversationId } : {}),
+          ...(agUiRunId ? { runId: agUiRunId } : {}),
+        },
+        agentId: input.execution.agentId,
+        modelId: input.execution.modelId,
+        execution,
+      });
+    },
+  });
+}
+
+export async function runPreparedHostedChatExecutionDetached<
+  TExecution extends PreparedHostedChatExecution,
+>(input: {
+  execution: PreparedHostedChatExecutionDetachedInput<TExecution>;
+  runtime: PreparedHostedChatExecutionRuntimeOptions;
+}): Promise<void> {
+  await tracePreparedHostedChatExecution({
+    spanName: "chat.runDetached",
+    execution: input.execution,
+    runtime: input.runtime,
+    run: async () => {
+      const { agentRunSpan, execution } =
+        await createBootstrappedPreparedHostedChatExecutionRuntime({
+          execution: input.execution,
+          abortSignal: input.execution.abortSignal,
+          runtime: input.runtime,
+        });
+
+      try {
+        await agentRunSpan.withContext(async () => {
+          await runHostedLifecycle({
+            abortSignal: input.execution.abortSignal,
+            execution: {
+              stream: execution.agentUIStream,
+              waitForFinish: execution.waitForFinish,
+            },
+            adapter: {
+              startRun: () => ({
+                runId: input.execution.rootRunContext.durableRootRun?.runId ?? "detached-run",
+              }),
+            },
+            resolveTerminalState: () => ({
+              status: input.execution.abortSignal.aborted ? "cancelled" : "completed",
+            }),
+          });
+        });
+      } catch (error) {
+        input.runtime.logger?.error("Detached durable chat execution failed", {
+          conversationId: input.execution.conversationId,
+          runId: input.execution.rootRunContext.durableRootRun?.runId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        await execution.fail(error);
+      }
+    },
+  });
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.481";
+export const VERSION = "0.1.482";


### PR DESCRIPTION
## Summary\n- add framework helpers for streaming prepared hosted chat executions to AG-UI responses\n- add detached prepared execution finalization helper\n- export the helpers and document the hosted execution seam\n- bump package version to 0.1.482 for CI release\n\n## Verification\n- deno task verify:quick\n- deno test --no-check --allow-all src/agent/prepared-hosted-chat-execution.test.ts