### PR TITLE
Add hosted project steering refresh helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.482",
+  "version": "0.1.483",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -151,6 +151,11 @@ export default agent({
 
 For step-boundary refresh during a long-lived hosted run, use
 `resolveRuntimeState` instead of relying on `system()` to re-run mid-turn.
+Hosted service runtimes that fetch project instructions, skills, and
+project-scoped tool inventory from an external control plane can use
+`createDefaultHostedProjectSteeringRefresh()` from `veryfront/agent` to reuse
+the default refresh sequencing while keeping fetch and prompt-building policy
+local.
 
 ## Agent configuration
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -693,6 +693,17 @@ Create a `RunError` AG-UI SSE event payload.
 Create an AG-UI SSE `Response` from a prepared AG-UI event, preserving the
 existing `RunError` wire shape used by hosted routes.
 
+### `createDefaultHostedProjectSteeringRefresh(options)`
+
+Create the default hosted step-boundary project steering refresh callback. The
+helper refreshes project instructions, skills, and project-scoped remote tool
+names, filters skills by the runtime task context, records compatible available
+tool names, and appends the runtime tool inventory to the system instructions.
+
+Hosts provide the control-plane fetchers and prompt builder, keeping product
+policy outside the framework while reusing the generic hosted refresh
+sequencing.
+
 ### `AgUiRuntimeRequestSchema`
 
 Validate the canonical open-source AG-UI runtime request contract for hosted
@@ -863,36 +874,37 @@ Clear all stored messages from memory.
 
 ### Functions
 
-| Name                                    | Description                                                              |
-| --------------------------------------- | ------------------------------------------------------------------------ |
-| `agent`                                 | Create an agent                                                          |
-| `agentAsTool`                           | Wrap agent as callable tool                                              |
-| `createAgUiCancelHandler`               | Create a DELETE handler for hosted AG-UI run cancellation                |
-| `createAgUiDetachedStartHandler`        | Create a POST handler for detached hosted AG-UI run kickoff              |
-| `executeAgUiDetachedStart`              | Run detached hosted-start lifecycle from a validated request object      |
-| `createAgUiHandler`                     | Create a POST handler for an AG-UI route                                 |
-| `createAgUiRuntimeHandler`              | Create a POST handler for the canonical runtime AG-UI request contract   |
-| `createAgUiRunErrorEvent`               | Create a `RunError` AG-UI SSE event                                      |
-| `createAgUiSseErrorResponse`            | Create an AG-UI SSE error `Response`                                     |
-| `createAgUiResumeHandler`               | Create a POST handler for hosted AG-UI run resume values                 |
-| `normalizeAgUiRuntimeMessages`          | Normalize runtime AG-UI messages into package `Message[]`                |
-| `parseAgUiRuntimeRequest`               | Parse and validate the canonical runtime AG-UI request body              |
-| `parseAgUiRuntimeRequestOrError`        | Parse runtime AG-UI input or return a `400` validation `Response`        |
-| `parseRuntimeAgentRunInvocation`        | Parse and validate a control-plane runtime agent invocation body         |
-| `parseRuntimeAgentRunInvocationOrError` | Parse a runtime agent invocation or return a `400` validation `Response` |
-| `createChatHandler`                     | Create a POST handler for a chat API route.                              |
-| `createMemory`                          | Create memory (buffer, conversation, summary)                            |
-| `createRedisMemory`                     | Create Redis-backed memory                                               |
-| `createWorkflow`                        | Create sequential agent workflow                                         |
-| `getAgent`                              | Get agent by ID                                                          |
-| `getAgentsAsTools`                      | Get agents as tools (multi-agent)                                        |
-| `getAllAgentIds`                        | List registered agent IDs                                                |
-| `getTextFromParts`                      | Extract text from multi-part message                                     |
-| `getToolArguments`                      | Extract parsed tool call args                                            |
-| `hasArgs`                               | Check for parsed args on tool call                                       |
-| `hasInput`                              | Check for raw input on tool call                                         |
-| `registerAgent`                         | Register agent for discovery                                             |
-| `waitForHumanInput`                     | Wait for a canonical human-input response over hosted AG-UI run control  |
+| Name                                        | Description                                                              |
+| ------------------------------------------- | ------------------------------------------------------------------------ |
+| `agent`                                     | Create an agent                                                          |
+| `agentAsTool`                               | Wrap agent as callable tool                                              |
+| `createAgUiCancelHandler`                   | Create a DELETE handler for hosted AG-UI run cancellation                |
+| `createAgUiDetachedStartHandler`            | Create a POST handler for detached hosted AG-UI run kickoff              |
+| `executeAgUiDetachedStart`                  | Run detached hosted-start lifecycle from a validated request object      |
+| `createAgUiHandler`                         | Create a POST handler for an AG-UI route                                 |
+| `createAgUiRuntimeHandler`                  | Create a POST handler for the canonical runtime AG-UI request contract   |
+| `createAgUiRunErrorEvent`                   | Create a `RunError` AG-UI SSE event                                      |
+| `createAgUiSseErrorResponse`                | Create an AG-UI SSE error `Response`                                     |
+| `createAgUiResumeHandler`                   | Create a POST handler for hosted AG-UI run resume values                 |
+| `createDefaultHostedProjectSteeringRefresh` | Create the default hosted project steering refresh callback              |
+| `normalizeAgUiRuntimeMessages`              | Normalize runtime AG-UI messages into package `Message[]`                |
+| `parseAgUiRuntimeRequest`                   | Parse and validate the canonical runtime AG-UI request body              |
+| `parseAgUiRuntimeRequestOrError`            | Parse runtime AG-UI input or return a `400` validation `Response`        |
+| `parseRuntimeAgentRunInvocation`            | Parse and validate a control-plane runtime agent invocation body         |
+| `parseRuntimeAgentRunInvocationOrError`     | Parse a runtime agent invocation or return a `400` validation `Response` |
+| `createChatHandler`                         | Create a POST handler for a chat API route.                              |
+| `createMemory`                              | Create memory (buffer, conversation, summary)                            |
+| `createRedisMemory`                         | Create Redis-backed memory                                               |
+| `createWorkflow`                            | Create sequential agent workflow                                         |
+| `getAgent`                                  | Get agent by ID                                                          |
+| `getAgentsAsTools`                          | Get agents as tools (multi-agent)                                        |
+| `getAllAgentIds`                            | List registered agent IDs                                                |
+| `getTextFromParts`                          | Extract text from multi-part message                                     |
+| `getToolArguments`                          | Extract parsed tool call args                                            |
+| `hasArgs`                                   | Check for parsed args on tool call                                       |
+| `hasInput`                                  | Check for raw input on tool call                                         |
+| `registerAgent`                             | Register agent for discovery                                             |
+| `waitForHumanInput`                         | Wait for a canonical human-input response over hosted AG-UI run control  |
 
 ### Classes
 

--- a/src/README.md
+++ b/src/README.md
@@ -473,7 +473,7 @@ See [`transforms/import-rewriter/README.md`](./transforms/import-rewriter/README
 **Exports**: `veryfront/agent`
 
 - Agent factory and runtime execution
-- Hosted chat preparation, prepared execution streaming, and detached run finalization
+- Hosted chat preparation, live steering refresh, prepared execution streaming, and detached run finalization
 - Memory management (conversation, buffer, summary)
 - Agent composition (`agentAsTool`)
 - React hooks (`useChat`, `useAgent`)

--- a/src/agent/default-hosted-project-steering-refresh.test.ts
+++ b/src/agent/default-hosted-project-steering-refresh.test.ts
@@ -1,0 +1,123 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { DefaultHostedChatRuntimeSystemRefreshInput } from "./default-hosted-chat-runtime.ts";
+import { createDefaultHostedProjectSteeringRefresh } from "./default-hosted-project-steering-refresh.ts";
+import type { RuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
+import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
+
+function createAgent(): RuntimeAgentMarkdownDefinition {
+  return {
+    id: "agent-1",
+    name: "Agent",
+    instructions: "Base instructions",
+  };
+}
+
+function createSkill(id: string): RuntimeSkillDefinition {
+  return {
+    id,
+    title: id,
+    description: `${id} skill`,
+  };
+}
+
+function createRefreshInput(
+  overrides: Partial<DefaultHostedChatRuntimeSystemRefreshInput> = {},
+): DefaultHostedChatRuntimeSystemRefreshInput {
+  return {
+    taskContext: {
+      authToken: "auth-token",
+      projectId: "project-1",
+      branchId: "branch-1",
+      model: "openai/gpt-test",
+      availableSkillIds: ["build"],
+    },
+    liveProjectSteering: {
+      agent: createAgent(),
+      environmentContext: "Editor context",
+      initialProjectInstructions: "Initial instructions",
+      initialSkills: [createSkill("initial")],
+    },
+    toolAssembly: {
+      runtimeTools: {},
+      remoteToolSources: [],
+      localToolNames: ["load_skill", "sleep"],
+      remoteToolNames: [],
+      availableToolNames: [],
+      compatibleRemoteToolNames: [],
+      systemInstructions: "",
+    },
+    ...overrides,
+  };
+}
+
+describe("agent/default-hosted-project-steering-refresh", () => {
+  it("refreshes instructions, filters visible skills, and records available tools", async () => {
+    const lookups: Array<{ projectId: string; authToken: string; branchId?: string | null }> = [];
+    const refresh = createDefaultHostedProjectSteeringRefresh({
+      fetchProjectInstructions: (lookup) => {
+        lookups.push(lookup);
+        return Promise.resolve("Fresh instructions");
+      },
+      fetchSkills: (lookup) => {
+        lookups.push(lookup);
+        return Promise.resolve([createSkill("build"), createSkill("hidden")]);
+      },
+      buildInstructions: (input) => [
+        {
+          role: "system",
+          content: `${input.instructions}:${
+            input.skills.map((skill) => skill.id).join(",")
+          }:${input.environmentContext}`,
+        },
+      ],
+    });
+    const input = createRefreshInput();
+
+    const system = await refresh(input);
+
+    assertEquals(lookups, [
+      { projectId: "project-1", authToken: "auth-token", branchId: "branch-1" },
+      { projectId: "project-1", authToken: "auth-token", branchId: "branch-1" },
+    ]);
+    assertEquals(input.taskContext.availableToolNames, ["load_skill", "sleep"]);
+    assertEquals(
+      system.includes("Fresh instructions:build:Editor context"),
+      true,
+    );
+    assertEquals(system.includes("Current run tool inventory:"), true);
+  });
+
+  it("falls back to initial steering when refresh lookups fail", async () => {
+    const errors: Array<{ message: string; metadata?: Record<string, unknown> }> = [];
+    const refresh = createDefaultHostedProjectSteeringRefresh({
+      fetchProjectInstructions: () => Promise.reject(new Error("instructions down")),
+      fetchSkills: () => Promise.reject(new Error("skills down")),
+      buildInstructions: (input) =>
+        `${input.instructions}:${input.skills.map((skill) => skill.id).join(",")}`,
+      logger: {
+        error: (message, metadata) => {
+          errors.push({ message, metadata });
+        },
+      },
+    });
+
+    const system = await refresh(
+      createRefreshInput({
+        taskContext: {
+          authToken: "auth-token",
+          projectId: "project-1",
+          branchId: "branch-1",
+          model: "openai/gpt-test",
+          availableSkillIds: ["initial"],
+        },
+      }),
+    );
+
+    assertEquals(system.includes("Initial instructions:initial"), true);
+    assertEquals(errors.map((error) => error.message), [
+      "Refreshing project instructions failed during hosted runtime steering update",
+      "Refreshing skills failed during hosted runtime steering update",
+    ]);
+  });
+});

--- a/src/agent/default-hosted-project-steering-refresh.ts
+++ b/src/agent/default-hosted-project-steering-refresh.ts
@@ -1,0 +1,169 @@
+import type { ChatSystemMessage } from "#veryfront/chat/types.ts";
+import {
+  listProjectScopedRemoteToolNames,
+  type ProjectScopedRemoteToolOptions,
+} from "#veryfront/tool";
+import type {
+  DefaultHostedChatRuntimeSystemRefreshInput,
+  DefaultHostedChatRuntimeTaskContext,
+} from "./default-hosted-chat-runtime.ts";
+import type { RuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
+import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
+import { selectProviderCompatibleToolNames } from "./runtime/provider-tool-compat.ts";
+import { flattenSystemInstructions, withRuntimeToolInventory } from "./runtime-tool-inventory.ts";
+import type { HostedChatRuntimeInstructionsInput } from "./hosted-chat-preparation.ts";
+
+export type DefaultHostedProjectSteeringRefreshLogger = {
+  error(message: string, metadata?: Record<string, unknown>): void;
+};
+
+export type DefaultHostedProjectSteeringRefreshLookup = {
+  projectId: string;
+  authToken: string;
+  branchId?: string | null;
+};
+
+export type CreateDefaultHostedProjectSteeringRefreshOptions = {
+  fetchProjectInstructions: (
+    lookup: DefaultHostedProjectSteeringRefreshLookup,
+  ) => Promise<string>;
+  fetchSkills: (
+    lookup: DefaultHostedProjectSteeringRefreshLookup,
+  ) => Promise<RuntimeSkillDefinition[]>;
+  buildInstructions: (
+    input: HostedChatRuntimeInstructionsInput<RuntimeAgentMarkdownDefinition>,
+  ) => string | ChatSystemMessage[];
+  projectScopedRemoteToolOptions?: ProjectScopedRemoteToolOptions;
+  logger?: DefaultHostedProjectSteeringRefreshLogger;
+};
+
+function getActiveProjectId(taskContext: DefaultHostedChatRuntimeTaskContext): string | null {
+  return taskContext.projectId || null;
+}
+
+function getActiveBranchId(taskContext: DefaultHostedChatRuntimeTaskContext): string | null {
+  return taskContext.branchId ?? null;
+}
+
+async function fetchProjectInstructionsWithFallback(input: {
+  options: CreateDefaultHostedProjectSteeringRefreshOptions;
+  taskContext: DefaultHostedChatRuntimeTaskContext;
+  projectId: string;
+  branchId: string | null;
+  initialProjectInstructions: string;
+}): Promise<string> {
+  try {
+    return await input.options.fetchProjectInstructions({
+      projectId: input.projectId,
+      authToken: input.taskContext.authToken,
+      branchId: input.branchId,
+    });
+  } catch (error) {
+    input.options.logger?.error(
+      "Refreshing project instructions failed during hosted runtime steering update",
+      {
+        projectId: input.projectId,
+        branchId: input.branchId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return input.initialProjectInstructions;
+  }
+}
+
+async function fetchSkillsWithFallback(input: {
+  options: CreateDefaultHostedProjectSteeringRefreshOptions;
+  taskContext: DefaultHostedChatRuntimeTaskContext;
+  projectId: string;
+  branchId: string | null;
+  initialSkills: RuntimeSkillDefinition[];
+}): Promise<RuntimeSkillDefinition[]> {
+  try {
+    return await input.options.fetchSkills({
+      projectId: input.projectId,
+      authToken: input.taskContext.authToken,
+      branchId: input.branchId,
+    });
+  } catch (error) {
+    input.options.logger?.error(
+      "Refreshing skills failed during hosted runtime steering update",
+      {
+        projectId: input.projectId,
+        branchId: input.branchId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return input.initialSkills;
+  }
+}
+
+function filterVisibleSkills(input: {
+  skills: RuntimeSkillDefinition[];
+  allowedSkillIds?: string[];
+}): RuntimeSkillDefinition[] {
+  if (!input.allowedSkillIds || input.allowedSkillIds.length === 0) {
+    return input.skills;
+  }
+
+  return input.skills.filter((skill) => input.allowedSkillIds?.includes(skill.id));
+}
+
+export function createDefaultHostedProjectSteeringRefresh(
+  options: CreateDefaultHostedProjectSteeringRefreshOptions,
+): (input: DefaultHostedChatRuntimeSystemRefreshInput) => Promise<string> {
+  return async (input) => {
+    const projectId = getActiveProjectId(input.taskContext);
+    const branchId = getActiveBranchId(input.taskContext);
+    const initialProjectInstructions = input.liveProjectSteering.initialProjectInstructions ?? "";
+    const initialSkills = input.liveProjectSteering.initialSkills ?? [];
+
+    const [projectInstructions, skills, remoteToolNames] = await Promise.all([
+      projectId
+        ? fetchProjectInstructionsWithFallback({
+          options,
+          taskContext: input.taskContext,
+          projectId,
+          branchId,
+          initialProjectInstructions,
+        })
+        : Promise.resolve(""),
+      projectId
+        ? fetchSkillsWithFallback({
+          options,
+          taskContext: input.taskContext,
+          projectId,
+          branchId,
+          initialSkills,
+        })
+        : Promise.resolve([]),
+      listProjectScopedRemoteToolNames(input.toolAssembly.remoteToolSources, {
+        projectId,
+        projectScopedRemoteToolOptions: options.projectScopedRemoteToolOptions,
+      }),
+    ]);
+
+    const visibleSkills = filterVisibleSkills({
+      skills,
+      allowedSkillIds: input.taskContext.availableSkillIds,
+    });
+    const allToolNames = [
+      ...new Set([...input.toolAssembly.localToolNames, ...remoteToolNames]),
+    ].sort();
+    const toolNames = selectProviderCompatibleToolNames(allToolNames, {
+      model: input.taskContext.model,
+      requiredToolNames: input.toolAssembly.localToolNames,
+    });
+    input.taskContext.availableToolNames = toolNames;
+
+    const refreshedInstructions = options.buildInstructions({
+      agentConfig: input.liveProjectSteering.agent,
+      projectId,
+      branchId,
+      environmentContext: input.liveProjectSteering.environmentContext,
+      instructions: projectInstructions,
+      skills: visibleSkills,
+    });
+
+    return flattenSystemInstructions(withRuntimeToolInventory(refreshedInstructions, toolNames));
+  };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -253,6 +253,12 @@ export {
   type DefaultHostedChatRuntimeSystemRefreshInput,
   type DefaultHostedChatRuntimeTaskContext,
 } from "./default-hosted-chat-runtime.ts";
+export {
+  createDefaultHostedProjectSteeringRefresh,
+  type CreateDefaultHostedProjectSteeringRefreshOptions,
+  type DefaultHostedProjectSteeringRefreshLogger,
+  type DefaultHostedProjectSteeringRefreshLookup,
+} from "./default-hosted-project-steering-refresh.ts";
 
 export {
   createHostedAgentServiceRuntime,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.482";
+export const VERSION = "0.1.483";


### PR DESCRIPTION
## Summary
- add a reusable hosted project steering refresh helper
- refresh project instructions, skills, and project-scoped tool inventory with host-provided fetch and prompt-building policy
- document the public helper and bump the package patch version

## Verification
- deno task verify:quick
- pre-push checks: fmt, lint, typecheck, unit tests