### PR TITLE
refactor(extensions): move TracingExporter → src/extensions/tracing/, rename ext-opentelemetry → ext-tracing-opentelemetry

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -13,8 +13,8 @@
     "./extensions/ext-content-mdx",
     "./extensions/ext-css-tailwind",
     "./extensions/ext-node-compatibility",
-    "./extensions/ext-opentelemetry",
-    "./extensions/ext-parser-babel"
+    "./extensions/ext-parser-babel",
+    "./extensions/ext-tracing-opentelemetry"
   ],
   "exclude": [
     "npm/",
@@ -77,6 +77,7 @@
     "./extensions/content": "./src/extensions/content/index.ts",
     "./extensions/css": "./src/extensions/css/index.ts",
     "./extensions/parser": "./src/extensions/parser/index.ts",
+    "./extensions/tracing": "./src/extensions/tracing/index.ts",
     "./testing": "./src/testing/index.ts",
     "./testing/assert": "./src/testing/assert.ts",
     "./testing/bdd": "./src/testing/bdd.ts",
@@ -166,6 +167,7 @@
     "veryfront/extensions/css": "./src/extensions/css/index.ts",
     "veryfront/extensions/interfaces": "./src/extensions/interfaces/index.ts",
     "veryfront/extensions/parser": "./src/extensions/parser/index.ts",
+    "veryfront/extensions/tracing": "./src/extensions/tracing/index.ts",
     "jose": "npm:jose@5.9.6",
     "#veryfront": "./src/index.ts",
     "#veryfront/agent": "./src/agent/index.ts",

--- a/extensions/ext-tracing-opentelemetry/deno.json
+++ b/extensions/ext-tracing-opentelemetry/deno.json
@@ -1,5 +1,5 @@
 {
-  "name": "@veryfront/ext-opentelemetry",
+  "name": "@veryfront/ext-tracing-opentelemetry",
   "version": "0.1.0",
   "exports": "./src/index.ts",
   "veryfront": {
@@ -28,8 +28,8 @@
     "@opentelemetry/semantic-conventions": "npm:@opentelemetry/semantic-conventions@1.40.0",
     "@std/assert": "jsr:@std/assert@1",
     "@std/testing/bdd": "jsr:@std/testing@1/bdd",
-    "veryfront/extensions": "../../../src/extensions/index.ts",
-    "veryfront/extensions/interfaces": "../../../src/extensions/interfaces/index.ts"
+    "veryfront/extensions": "../../src/extensions/index.ts",
+    "veryfront/extensions/tracing": "../../src/extensions/tracing/index.ts"
   },
   "tasks": {
     "test": "deno test --no-check --allow-all src/"

--- a/extensions/ext-tracing-opentelemetry/src/index.test.ts
+++ b/extensions/ext-tracing-opentelemetry/src/index.test.ts
@@ -1,7 +1,7 @@
 /**
- * ext-opentelemetry extension tests.
+ * ext-tracing-opentelemetry extension tests.
  *
- * @module extensions/ext-opentelemetry/test
+ * @module extensions/ext-tracing-opentelemetry/test
  */
 
 import { assertEquals, assertExists } from "@std/assert";
@@ -16,10 +16,10 @@ const noopLogger = {
   error: () => {},
 };
 
-describe("ext-opentelemetry factory", () => {
-  it("produces an Extension with name ext-opentelemetry", () => {
+describe("ext-tracing-opentelemetry factory", () => {
+  it("produces an Extension with name ext-tracing-opentelemetry", () => {
     const ext = factory();
-    assertEquals(ext.name, "ext-opentelemetry");
+    assertEquals(ext.name, "ext-tracing-opentelemetry");
     assertEquals(ext.version, "0.1.0");
     assertEquals(Array.isArray(ext.capabilities), true);
     assertEquals(
@@ -29,7 +29,7 @@ describe("ext-opentelemetry factory", () => {
   });
 });
 
-describe("ext-opentelemetry TracingExporter", () => {
+describe("ext-tracing-opentelemetry TracingExporter", () => {
   it("registers TracingExporter on setup", async () => {
     const provided = new Map<string, unknown>();
 

--- a/extensions/ext-tracing-opentelemetry/src/index.ts
+++ b/extensions/ext-tracing-opentelemetry/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * ext-opentelemetry — TracingExporter implementation backed by the
+ * ext-tracing-opentelemetry — TracingExporter implementation backed by the
  * official OpenTelemetry JS SDK.
  *
  * Provides the `TracingExporter` contract:
@@ -11,11 +11,11 @@
  * Configuration is read from `ctx.config` (see `OtlpExtConfig`) and falls
  * back to standard OTEL environment variables.
  *
- * @module extensions/ext-opentelemetry
+ * @module extensions/ext-tracing-opentelemetry
  */
 
 import type { ExtensionFactory } from "veryfront/extensions";
-import type { SpanData, TracingExporter } from "veryfront/extensions/interfaces";
+import type { SpanData, TracingExporter } from "veryfront/extensions/tracing";
 
 import { metrics, trace } from "@opentelemetry/api";
 import { W3CTraceContextPropagator } from "@opentelemetry/core";
@@ -177,7 +177,7 @@ class OtlpTracingExporter implements TracingExporter {
 }
 
 /**
- * Default export — the ext-opentelemetry extension factory.
+ * Default export — the ext-tracing-opentelemetry extension factory.
  *
  * Produces an extension that registers a `TracingExporter` contract
  * implementation backed by the OpenTelemetry JS SDK.
@@ -186,7 +186,7 @@ const extOpenTelemetry: ExtensionFactory = () => {
   const exporterImpl = new OtlpTracingExporter();
 
   return {
-    name: "ext-opentelemetry",
+    name: "ext-tracing-opentelemetry",
     version: "0.1.0",
     capabilities: [
       { type: "contract", name: "TracingExporter" },
@@ -195,7 +195,7 @@ const extOpenTelemetry: ExtensionFactory = () => {
     async setup(ctx) {
       await exporterImpl.start(ctx.config);
       ctx.provide("TracingExporter", exporterImpl);
-      ctx.logger.info("[ext-opentelemetry] TracingExporter registered");
+      ctx.logger.info("[ext-tracing-opentelemetry] TracingExporter registered");
     },
     async teardown() {
       await exporterImpl.shutdown();

--- a/src/extensions/integration.test.ts
+++ b/src/extensions/integration.test.ts
@@ -22,7 +22,7 @@ import {
   getTracer,
   setGlobalTracerProvider,
 } from "#veryfront/observability/tracing/api-shim.ts";
-import type { TracingExporter } from "./interfaces/tracing-exporter.ts";
+import type { TracingExporter } from "./tracing/tracing-exporter.ts";
 
 const noopLogger = {
   debug: () => {},
@@ -191,7 +191,7 @@ describe("extensions/integration", () => {
     await loader.teardownAll();
   });
 
-  it("ext-opentelemetry: TracingExporter registers and returns a real tracer", async () => {
+  it("ext-tracing-opentelemetry: TracingExporter registers and returns a real tracer", async () => {
     _resetShimForTests();
 
     let shimProvider: { getTracer(name: string): unknown } | null = null;
@@ -232,7 +232,7 @@ describe("extensions/integration", () => {
       },
     };
 
-    const otelExt = makeExt("ext-opentelemetry", {
+    const otelExt = makeExt("ext-tracing-opentelemetry", {
       provides: { TracingExporter: exporterStub },
       async setup(ctx) {
         await exporterStub.start(ctx.config);

--- a/src/extensions/interfaces/index.ts
+++ b/src/extensions/interfaces/index.ts
@@ -63,8 +63,8 @@ export type {
   VerifyOptions,
 } from "../auth/index.ts";
 
-// Tracing exporter
-export type { SpanData, TracerProvider, TracingExporter } from "./tracing-exporter.ts";
+// Tracing exporter — moved to ../tracing/
+export type { SpanData, TracerProvider, TracingExporter } from "../tracing/index.ts";
 
 // AI provider (registry + per-provider contract) — moved to ../ai/
 export type { AIProvider, AIProviderConfig, AIProviderRegistry } from "../ai/index.ts";

--- a/src/extensions/recommendations.ts
+++ b/src/extensions/recommendations.ts
@@ -15,7 +15,7 @@ const recommendations = new Map<string, string>([
   ["ContentTransformer", "@veryfront/ext-content-mdx"],
   ["DatabaseClient", "@veryfront/ext-postgres"],
   ["AuthProvider", "@veryfront/ext-auth-jwt"],
-  ["TracingExporter", "@veryfront/ext-opentelemetry"],
+  ["TracingExporter", "@veryfront/ext-tracing-opentelemetry"],
   ["AIProviderRegistry", "@veryfront/ext-ai-openai"],
   ["AIProvider:openai", "@veryfront/ext-ai-openai"],
   ["AIProvider:anthropic", "@veryfront/ext-ai-anthropic"],

--- a/src/extensions/tracing/index.ts
+++ b/src/extensions/tracing/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Tracing category barrel — TracingExporter contract.
+ *
+ * @module extensions/tracing
+ */
+
+export type {
+  SpanData,
+  TracerProvider,
+  TracingExporter,
+} from "./tracing-exporter.ts";

--- a/src/extensions/tracing/tracing-exporter.ts
+++ b/src/extensions/tracing/tracing-exporter.ts
@@ -1,9 +1,9 @@
 /**
  * Contract interface for tracing/telemetry exporters.
  *
- * Default implementation: `@veryfront/ext-opentelemetry`
+ * Default implementation: `@veryfront/ext-tracing-opentelemetry`
  *
- * @module extensions/interfaces/tracing-exporter
+ * @module extensions/tracing/tracing-exporter
  */
 
 /**

--- a/src/observability/metrics/manager.ts
+++ b/src/observability/metrics/manager.ts
@@ -80,7 +80,7 @@ export class MetricsManager {
     }
 
     try {
-      // The metrics API is injected by ext-opentelemetry via setGlobalMetricsAPI().
+      // The metrics API is injected by ext-tracing-opentelemetry via setGlobalMetricsAPI().
       // When the extension is not active, metrics collection is disabled.
       const metricsApi = getGlobalMetricsAPI();
       if (!metricsApi) {

--- a/src/observability/simple-metrics/otel-instruments.ts
+++ b/src/observability/simple-metrics/otel-instruments.ts
@@ -27,7 +27,7 @@ export async function ensureOtelInstruments(): Promise<void> {
   if (!isDeno) return;
 
   try {
-    // The metrics API is injected by ext-opentelemetry via setGlobalMetricsAPI().
+    // The metrics API is injected by ext-tracing-opentelemetry via setGlobalMetricsAPI().
     // When the extension is not active, the meter is unavailable and we return.
     const metricsApi = getGlobalMetricsAPI();
     if (!metricsApi) return;

--- a/src/observability/tracing/api-shim.ts
+++ b/src/observability/tracing/api-shim.ts
@@ -2,7 +2,7 @@
  * Thin in-process shim for `@opentelemetry/api`.
  *
  * Core files that previously imported directly from `@opentelemetry/api` now
- * import from this module.  When the `ext-opentelemetry` extension is present
+ * import from this module.  When the `ext-tracing-opentelemetry` extension is present
  * the real SDK provider is wired in via `setGlobalTracerProvider`; otherwise
  * every call falls back to a no-op implementation so the core boots without the
  * extension installed.
@@ -172,7 +172,7 @@ export interface MetricsAPI {
 }
 
 // ---------------------------------------------------------------------------
-// No-op provider (default when ext-opentelemetry is not installed)
+// No-op provider (default when ext-tracing-opentelemetry is not installed)
 // ---------------------------------------------------------------------------
 
 function createNoopContext(): Context {
@@ -254,7 +254,7 @@ let _propagator: TextMapPropagator | null = null;
 
 /**
  * Optional accessor for the currently active span. Wired by
- * ext-opentelemetry (via `setGlobalActiveSpanAccessor`) so `trace.getActiveSpan()`
+ * ext-tracing-opentelemetry (via `setGlobalActiveSpanAccessor`) so `trace.getActiveSpan()`
  * and `trace.getSpan()` return the real SDK span once the extension is active.
  */
 let _activeSpanAccessor: {
@@ -264,7 +264,7 @@ let _activeSpanAccessor: {
 
 /**
  * Register the real OTel trace API's span accessors. Called by the
- * ext-opentelemetry extension after it wires the SDK so that the shim's
+ * ext-tracing-opentelemetry extension after it wires the SDK so that the shim's
  * `trace.getActiveSpan()` / `trace.getSpan()` can return real spans.
  */
 export function setGlobalActiveSpanAccessor(
@@ -287,7 +287,7 @@ export function getGlobalTracerProvider(): TracerProvider {
 
 /**
  * Get a tracer from the active provider.
- * Returns the no-op tracer when ext-opentelemetry is not installed.
+ * Returns the no-op tracer when ext-tracing-opentelemetry is not installed.
  */
 export function getTracer(name: string, version?: string): Tracer {
   return _provider.getTracer(name, version);
@@ -378,14 +378,14 @@ export const defaultTextMapSetter: TextMapSetter<Record<string, string>> = {
 };
 
 // ---------------------------------------------------------------------------
-// Metrics API registry (injected by ext-opentelemetry when active)
+// Metrics API registry (injected by ext-tracing-opentelemetry when active)
 // ---------------------------------------------------------------------------
 
 let _metricsApi: MetricsAPI | null = null;
 
 /**
  * Register the OTel Metrics API (from the SDK).
- * Called by ext-opentelemetry in its setup hook so the metrics subsystem
+ * Called by ext-tracing-opentelemetry in its setup hook so the metrics subsystem
  * can use `getMeter()` when available.
  */
 export function setGlobalMetricsAPI(api: MetricsAPI): void {

--- a/src/observability/tracing/manager.ts
+++ b/src/observability/tracing/manager.ts
@@ -56,7 +56,7 @@ export class TracingManager {
   }
 
   private async initializeTracer(config: TracingConfig): Promise<void> {
-    // Use the shim API — delegates to the real SDK when ext-opentelemetry is wired.
+    // Use the shim API — delegates to the real SDK when ext-tracing-opentelemetry is wired.
     const shimApi = await import("./api-shim.ts");
     const api: OpenTelemetryAPI = {
       trace: {
@@ -79,7 +79,7 @@ export class TracingManager {
 
     this.state.tracer = api.trace.getTracer(config.serviceName ?? "veryfront", VERSION);
 
-    // No-op propagator used only when ext-opentelemetry is NOT installed.
+    // No-op propagator used only when ext-tracing-opentelemetry is NOT installed.
     // When the extension is active, it registers W3CTraceContextPropagator
     // on the shim directly; we intentionally do NOT wrap shimApi.propagation
     // here (doing so would cause infinite recursion when the global

--- a/src/observability/tracing/otlp-setup.ts
+++ b/src/observability/tracing/otlp-setup.ts
@@ -1,7 +1,7 @@
 /**************************
  * OpenTelemetry OTLP Setup
  *
- * Thin wrapper that delegates to the `ext-opentelemetry` extension via the
+ * Thin wrapper that delegates to the `ext-tracing-opentelemetry` extension via the
  * `TracingExporter` contract.  When the extension is not installed, all span
  * operations silently no-op.
  *
@@ -79,15 +79,15 @@ export async function initializeOTLP(): Promise<void> {
     logger.debug("Already initialized");
     return;
   }
-  // Actual provider setup is handled by ext-opentelemetry via bootstrap.
+  // Actual provider setup is handled by ext-tracing-opentelemetry via bootstrap.
   // This is kept for backward compatibility.
   initialized = true;
-  logger.debug("OTLP setup delegated to ext-opentelemetry extension");
+  logger.debug("OTLP setup delegated to ext-tracing-opentelemetry extension");
 }
 
 export async function shutdownOTLP(): Promise<void> {
   // Actual shutdown is handled by the extension loader teardown.
-  logger.debug("OTLP shutdown delegated to ext-opentelemetry extension");
+  logger.debug("OTLP shutdown delegated to ext-tracing-opentelemetry extension");
 }
 
 export function isOTLPEnabled(): boolean {

--- a/src/proxy/tracing.ts
+++ b/src/proxy/tracing.ts
@@ -1,7 +1,7 @@
 /****
  * OpenTelemetry OTLP tracing for proxy.
  *
- * Uses the core api-shim for in-process tracing; when ext-opentelemetry
+ * Uses the core api-shim for in-process tracing; when ext-tracing-opentelemetry
  * is loaded, the shim delegates to the real SDK provider.
  *
  * Env: OTEL_TRACES_ENABLED, OTEL_SERVICE_NAME, OTEL_EXPORTER_OTLP_ENDPOINT,
@@ -71,7 +71,7 @@ export async function initializeOTLPWithApis(): Promise<void> {
   }
 
   try {
-    // The shim's provider is wired by ext-opentelemetry via bootstrap.ts.
+    // The shim's provider is wired by ext-tracing-opentelemetry via bootstrap.ts.
     // We simply get a tracer from the shim — it delegates to the real SDK
     // when the extension is active, otherwise returns the no-op tracer.
     tracer = shimTrace.getTracer(config.serviceName);

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -7,7 +7,7 @@ import { AIProviderRegistryName, createAIProviderRegistry } from "#veryfront/ext
 import { createBuiltinExtensions } from "#veryfront/extensions/builtin-extensions.ts";
 import { MISSING_EXTENSION_ERROR } from "#veryfront/extensions/errors.ts";
 import { getRecommendation } from "#veryfront/extensions/recommendations.ts";
-import type { TracingExporter } from "#veryfront/extensions/interfaces/tracing-exporter.ts";
+import type { TracingExporter } from "#veryfront/extensions/tracing/tracing-exporter.ts";
 import {
   setGlobalActiveSpanAccessor,
   setGlobalMetricsAPI,


### PR DESCRIPTION
## Summary

Moves the TracingExporter contract and renames the OpenTelemetry extension.

- src/extensions/interfaces/tracing-exporter.ts → src/extensions/tracing/tracing-exporter.ts
- New src/extensions/tracing/index.ts barrel (3 interfaces)
- extensions/ext-opentelemetry → extensions/ext-tracing-opentelemetry (@veryfront/ext-tracing-opentelemetry)
- Consumer updates: src/server/bootstrap.ts (TracingExporter type-only import), integration.test virtual:// origins, observability/* comments, runtime name