### PR TITLE
Add Veryfront Cloud prepared execution runtime defaults

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.483",
+  "version": "0.1.484",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -156,6 +156,9 @@ project-scoped tool inventory from an external control plane can use
 `createDefaultHostedProjectSteeringRefresh()` from `veryfront/agent` to reuse
 the default refresh sequencing while keeping fetch and prompt-building policy
 local.
+Services that stream prepared hosted executions through Veryfront Cloud can use
+`createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions()` to reuse the
+default hosted model-provider and stream-watchdog wiring.
 
 ## Agent configuration
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -704,6 +704,13 @@ Hosts provide the control-plane fetchers and prompt builder, keeping product
 policy outside the framework while reusing the generic hosted refresh
 sequencing.
 
+### `createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions(options)`
+
+Create the default runtime options used by prepared hosted chat execution on
+Veryfront Cloud. The helper wires the hosted model-provider resolver and default
+chat stream watchdog while the host supplies its API URL, tracer, logger, and
+optional trace hooks.
+
 ### `AgUiRuntimeRequestSchema`
 
 Validate the canonical open-source AG-UI runtime request contract for hosted
@@ -874,37 +881,38 @@ Clear all stored messages from memory.
 
 ### Functions
 
-| Name                                        | Description                                                              |
-| ------------------------------------------- | ------------------------------------------------------------------------ |
-| `agent`                                     | Create an agent                                                          |
-| `agentAsTool`                               | Wrap agent as callable tool                                              |
-| `createAgUiCancelHandler`                   | Create a DELETE handler for hosted AG-UI run cancellation                |
-| `createAgUiDetachedStartHandler`            | Create a POST handler for detached hosted AG-UI run kickoff              |
-| `executeAgUiDetachedStart`                  | Run detached hosted-start lifecycle from a validated request object      |
-| `createAgUiHandler`                         | Create a POST handler for an AG-UI route                                 |
-| `createAgUiRuntimeHandler`                  | Create a POST handler for the canonical runtime AG-UI request contract   |
-| `createAgUiRunErrorEvent`                   | Create a `RunError` AG-UI SSE event                                      |
-| `createAgUiSseErrorResponse`                | Create an AG-UI SSE error `Response`                                     |
-| `createAgUiResumeHandler`                   | Create a POST handler for hosted AG-UI run resume values                 |
-| `createDefaultHostedProjectSteeringRefresh` | Create the default hosted project steering refresh callback              |
-| `normalizeAgUiRuntimeMessages`              | Normalize runtime AG-UI messages into package `Message[]`                |
-| `parseAgUiRuntimeRequest`                   | Parse and validate the canonical runtime AG-UI request body              |
-| `parseAgUiRuntimeRequestOrError`            | Parse runtime AG-UI input or return a `400` validation `Response`        |
-| `parseRuntimeAgentRunInvocation`            | Parse and validate a control-plane runtime agent invocation body         |
-| `parseRuntimeAgentRunInvocationOrError`     | Parse a runtime agent invocation or return a `400` validation `Response` |
-| `createChatHandler`                         | Create a POST handler for a chat API route.                              |
-| `createMemory`                              | Create memory (buffer, conversation, summary)                            |
-| `createRedisMemory`                         | Create Redis-backed memory                                               |
-| `createWorkflow`                            | Create sequential agent workflow                                         |
-| `getAgent`                                  | Get agent by ID                                                          |
-| `getAgentsAsTools`                          | Get agents as tools (multi-agent)                                        |
-| `getAllAgentIds`                            | List registered agent IDs                                                |
-| `getTextFromParts`                          | Extract text from multi-part message                                     |
-| `getToolArguments`                          | Extract parsed tool call args                                            |
-| `hasArgs`                                   | Check for parsed args on tool call                                       |
-| `hasInput`                                  | Check for raw input on tool call                                         |
-| `registerAgent`                             | Register agent for discovery                                             |
-| `waitForHumanInput`                         | Wait for a canonical human-input response over hosted AG-UI run control  |
+| Name                                                            | Description                                                              |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `agent`                                                         | Create an agent                                                          |
+| `agentAsTool`                                                   | Wrap agent as callable tool                                              |
+| `createAgUiCancelHandler`                                       | Create a DELETE handler for hosted AG-UI run cancellation                |
+| `createAgUiDetachedStartHandler`                                | Create a POST handler for detached hosted AG-UI run kickoff              |
+| `executeAgUiDetachedStart`                                      | Run detached hosted-start lifecycle from a validated request object      |
+| `createAgUiHandler`                                             | Create a POST handler for an AG-UI route                                 |
+| `createAgUiRuntimeHandler`                                      | Create a POST handler for the canonical runtime AG-UI request contract   |
+| `createAgUiRunErrorEvent`                                       | Create a `RunError` AG-UI SSE event                                      |
+| `createAgUiSseErrorResponse`                                    | Create an AG-UI SSE error `Response`                                     |
+| `createAgUiResumeHandler`                                       | Create a POST handler for hosted AG-UI run resume values                 |
+| `createDefaultHostedProjectSteeringRefresh`                     | Create the default hosted project steering refresh callback              |
+| `createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions` | Create Veryfront Cloud prepared execution runtime defaults               |
+| `normalizeAgUiRuntimeMessages`                                  | Normalize runtime AG-UI messages into package `Message[]`                |
+| `parseAgUiRuntimeRequest`                                       | Parse and validate the canonical runtime AG-UI request body              |
+| `parseAgUiRuntimeRequestOrError`                                | Parse runtime AG-UI input or return a `400` validation `Response`        |
+| `parseRuntimeAgentRunInvocation`                                | Parse and validate a control-plane runtime agent invocation body         |
+| `parseRuntimeAgentRunInvocationOrError`                         | Parse a runtime agent invocation or return a `400` validation `Response` |
+| `createChatHandler`                                             | Create a POST handler for a chat API route.                              |
+| `createMemory`                                                  | Create memory (buffer, conversation, summary)                            |
+| `createRedisMemory`                                             | Create Redis-backed memory                                               |
+| `createWorkflow`                                                | Create sequential agent workflow                                         |
+| `getAgent`                                                      | Get agent by ID                                                          |
+| `getAgentsAsTools`                                              | Get agents as tools (multi-agent)                                        |
+| `getAllAgentIds`                                                | List registered agent IDs                                                |
+| `getTextFromParts`                                              | Extract text from multi-part message                                     |
+| `getToolArguments`                                              | Extract parsed tool call args                                            |
+| `hasArgs`                                                       | Check for parsed args on tool call                                       |
+| `hasInput`                                                      | Check for raw input on tool call                                         |
+| `registerAgent`                                                 | Register agent for discovery                                             |
+| `waitForHumanInput`                                             | Wait for a canonical human-input response over hosted AG-UI run control  |
 
 ### Classes
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1123,6 +1123,10 @@ export {
   streamPreparedHostedChatExecutionToAgUiResponse,
 } from "./prepared-hosted-chat-execution.ts";
 export {
+  createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions,
+  type CreateVeryfrontCloudPreparedHostedChatExecutionRuntimeOptionsInput,
+} from "./veryfront-cloud-prepared-hosted-chat-execution-runtime.ts";
+export {
   finalizeHostedDetached,
   type FinalizeHostedDetachedOptions,
   finalizeHostedResponse,

--- a/src/agent/veryfront-cloud-prepared-hosted-chat-execution-runtime.test.ts
+++ b/src/agent/veryfront-cloud-prepared-hosted-chat-execution-runtime.test.ts
@@ -1,0 +1,63 @@
+import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createChatStreamWatchdog } from "#veryfront/chat/stream-watchdog.ts";
+import type { AgentTraceAttributes } from "./agent-trace-attributes.ts";
+import type { HostedAgentRunTracer } from "./hosted-agent-run-lifecycle.ts";
+import { createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions } from "./veryfront-cloud-prepared-hosted-chat-execution-runtime.ts";
+
+function createTracer(): HostedAgentRunTracer {
+  return {
+    startSpan: () => ({
+      setAttributes: () => {},
+      finish: () => {},
+      withContext: (fn) => fn(),
+    }),
+  };
+}
+
+describe("agent/veryfront-cloud-prepared-hosted-chat-execution-runtime", () => {
+  it("builds prepared execution runtime options with Veryfront Cloud provider defaults", () => {
+    const tracer = createTracer();
+    const logger = {
+      error: () => {},
+      warn: () => {},
+    };
+    const trace = async <TResult>(
+      _operationName: string,
+      operation: () => Promise<TResult>,
+    ): Promise<TResult> => await operation();
+    const traceStream = async <TResult>(operation: () => Promise<TResult>): Promise<TResult> =>
+      await operation();
+    const setActiveSpanAttributes = (_attributes: AgentTraceAttributes) => {};
+
+    const options = createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions({
+      apiUrl: "https://api.example.com",
+      tracer,
+      logger,
+      trace,
+      traceStream,
+      setActiveSpanAttributes,
+    });
+
+    assertEquals(options.apiUrl, "https://api.example.com");
+    assertStrictEquals(options.tracer, tracer);
+    assertStrictEquals(options.logger, logger);
+    assertStrictEquals(options.trace, trace);
+    assertStrictEquals(options.traceStream, traceStream);
+    assertStrictEquals(options.setActiveSpanAttributes, setActiveSpanAttributes);
+    assertEquals(options.resolveProvider("veryfront-cloud/openai/gpt-5.2"), "openai");
+    assertEquals(typeof options.createRootStreamWatchdog, "function");
+  });
+
+  it("preserves host-provided watchdog factories", () => {
+    const createRootStreamWatchdog = () => createChatStreamWatchdog();
+
+    const options = createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions({
+      apiUrl: new URL("https://api.example.com"),
+      tracer: createTracer(),
+      createRootStreamWatchdog,
+    });
+
+    assertStrictEquals(options.createRootStreamWatchdog, createRootStreamWatchdog);
+  });
+});

--- a/src/agent/veryfront-cloud-prepared-hosted-chat-execution-runtime.ts
+++ b/src/agent/veryfront-cloud-prepared-hosted-chat-execution-runtime.ts
@@ -1,0 +1,35 @@
+import { createChatStreamWatchdog } from "#veryfront/chat/stream-watchdog.ts";
+import { getVeryfrontCloudProviderFromModelId } from "#veryfront/provider";
+import type { AgentTraceAttributes } from "./agent-trace-attributes.ts";
+import type { HostedChatExecutionRuntimeLogger } from "./hosted-chat-execution-runtime.ts";
+import type { PreparedHostedChatExecutionRuntimeOptions } from "./prepared-hosted-chat-execution.ts";
+
+export type CreateVeryfrontCloudPreparedHostedChatExecutionRuntimeOptionsInput = {
+  apiUrl: string | URL;
+  tracer: PreparedHostedChatExecutionRuntimeOptions["tracer"];
+  logger?: HostedChatExecutionRuntimeLogger;
+  trace?: <TResult>(operationName: string, operation: () => Promise<TResult>) => Promise<TResult>;
+  traceStream?: <TResult>(operation: () => Promise<TResult>) => Promise<TResult>;
+  setActiveSpanAttributes?: (attributes: AgentTraceAttributes) => void;
+  createRootStreamWatchdog?: PreparedHostedChatExecutionRuntimeOptions["createRootStreamWatchdog"];
+};
+
+export function createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions(
+  input: CreateVeryfrontCloudPreparedHostedChatExecutionRuntimeOptionsInput,
+): PreparedHostedChatExecutionRuntimeOptions {
+  return {
+    apiUrl: input.apiUrl,
+    tracer: input.tracer,
+    resolveProvider: getVeryfrontCloudProviderFromModelId,
+    trace: input.trace,
+    traceStream: input.traceStream,
+    createRootStreamWatchdog: input.createRootStreamWatchdog ??
+      (() =>
+        createChatStreamWatchdog({
+          setTimeoutFn: globalThis.setTimeout,
+          clearTimeoutFn: globalThis.clearTimeout,
+        })),
+    logger: input.logger,
+    setActiveSpanAttributes: input.setActiveSpanAttributes,
+  };
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.483";
+export const VERSION = "0.1.484";


### PR DESCRIPTION
## Summary
- add a reusable Veryfront Cloud prepared hosted execution runtime-options helper
- wire default hosted provider resolution and chat stream watchdog creation
- document the helper and bump the package patch version

## Verification
- deno task verify:quick