### PR TITLE
Add Veryfront Cloud hosted preparation defaults

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.484",
+  "version": "0.1.485",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -156,9 +156,11 @@ project-scoped tool inventory from an external control plane can use
 `createDefaultHostedProjectSteeringRefresh()` from `veryfront/agent` to reuse
 the default refresh sequencing while keeping fetch and prompt-building policy
 local.
-Services that stream prepared hosted executions through Veryfront Cloud can use
+Services that prepare and stream hosted executions through Veryfront Cloud can
+use `prepareVeryfrontCloudHostedChatExecution()` and
 `createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions()` to reuse the
-default hosted model-provider and stream-watchdog wiring.
+default hosted model normalization, model-provider, durable root-run, and
+stream-watchdog wiring.
 
 ## Agent configuration
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -711,6 +711,20 @@ Veryfront Cloud. The helper wires the hosted model-provider resolver and default
 chat stream watchdog while the host supplies its API URL, tracer, logger, and
 optional trace hooks.
 
+### `prepareVeryfrontCloudHostedChatExecution(options)`
+
+Prepare hosted chat execution for services that run through Veryfront Cloud. The
+helper reuses the default hosted model normalization, hosted model thinking
+defaults, and durable root-run persistence diagnostics while the host supplies
+steering fetch/build callbacks and runtime creation policy.
+
+### `createVeryfrontCloudHostedChatExecutionRootRunOptions(options)`
+
+Create the default durable root-run preparation options used by
+`prepareVeryfrontCloudHostedChatExecution()`. Hosts may override persistence
+operation text, missing-user-message errors, instrumentation, implementation
+kind, or persistence-failure handling.
+
 ### `AgUiRuntimeRequestSchema`
 
 Validate the canonical open-source AG-UI runtime request contract for hosted
@@ -894,7 +908,9 @@ Clear all stored messages from memory.
 | `createAgUiSseErrorResponse`                                    | Create an AG-UI SSE error `Response`                                     |
 | `createAgUiResumeHandler`                                       | Create a POST handler for hosted AG-UI run resume values                 |
 | `createDefaultHostedProjectSteeringRefresh`                     | Create the default hosted project steering refresh callback              |
+| `createVeryfrontCloudHostedChatExecutionRootRunOptions`         | Create Veryfront Cloud hosted root-run preparation defaults              |
 | `createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions` | Create Veryfront Cloud prepared execution runtime defaults               |
+| `prepareVeryfrontCloudHostedChatExecution`                      | Prepare hosted chat execution with Veryfront Cloud defaults              |
 | `normalizeAgUiRuntimeMessages`                                  | Normalize runtime AG-UI messages into package `Message[]`                |
 | `parseAgUiRuntimeRequest`                                       | Parse and validate the canonical runtime AG-UI request body              |
 | `parseAgUiRuntimeRequestOrError`                                | Parse runtime AG-UI input or return a `400` validation `Response`        |

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1127,6 +1127,12 @@ export {
   type CreateVeryfrontCloudPreparedHostedChatExecutionRuntimeOptionsInput,
 } from "./veryfront-cloud-prepared-hosted-chat-execution-runtime.ts";
 export {
+  createVeryfrontCloudHostedChatExecutionRootRunOptions,
+  prepareVeryfrontCloudHostedChatExecution,
+  type PrepareVeryfrontCloudHostedChatExecutionInput,
+  type VeryfrontCloudHostedChatExecutionPreparationLogger,
+} from "./veryfront-cloud-hosted-chat-execution-preparation.ts";
+export {
   finalizeHostedDetached,
   type FinalizeHostedDetachedOptions,
   finalizeHostedResponse,

--- a/src/agent/veryfront-cloud-hosted-chat-execution-preparation.test.ts
+++ b/src/agent/veryfront-cloud-hosted-chat-execution-preparation.test.ts
@@ -1,0 +1,168 @@
+import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ChatSystemMessage } from "#veryfront/chat/types.ts";
+import type {
+  HostedChatRuntimeAgent,
+  HostedChatRuntimeCreationOptions,
+} from "./hosted-chat-runtime-contract.ts";
+import type { ParsedHostedChatRequest } from "./hosted-chat-request-parser.ts";
+import type { RuntimeAgentThinkingConfig } from "./runtime-agent-definition.ts";
+import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
+import {
+  createVeryfrontCloudHostedChatExecutionRootRunOptions,
+  prepareVeryfrontCloudHostedChatExecution,
+} from "./veryfront-cloud-hosted-chat-execution-preparation.ts";
+
+type TestAgentConfig = {
+  id: string;
+  model?: string;
+  maxSteps?: number;
+};
+
+type TestRuntimeResult = {
+  runtimeKind: "framework";
+  agent: HostedChatRuntimeAgent;
+  modelId: string;
+  cleanup: () => Promise<void>;
+};
+
+async function* emptyStream() {}
+
+function createRuntimeAgent(): HostedChatRuntimeAgent {
+  return {
+    stream: () =>
+      Promise.resolve({
+        steps: Promise.resolve([]),
+        toUIMessageStream: () => emptyStream(),
+      }),
+  };
+}
+
+function createRequest(): ParsedHostedChatRequest {
+  return {
+    userId: "user-1",
+    authToken: "auth-token",
+    messages: [
+      {
+        id: "message-1",
+        role: "user",
+        parts: [{ type: "text", text: "Hello" }],
+      },
+    ],
+    validatedContext: {
+      conversationId: undefined,
+      projectId: null,
+      branchId: null,
+    },
+    conversationId: undefined,
+    projectId: null,
+    parentRunId: undefined,
+    upstreamParentConversationId: undefined,
+    upstreamParentRunId: undefined,
+    spawnedFromToolCallId: undefined,
+    model: undefined,
+    allowDelegation: undefined,
+    forwardedProps: undefined,
+    runtimeOverrides: undefined,
+    durableRootRun: undefined,
+    persistLatestUserMessageBeforeDurableRun: false,
+  };
+}
+
+describe("agent/veryfront-cloud-hosted-chat-execution-preparation", () => {
+  it("prepares hosted chat execution with Veryfront Cloud model defaults", async () => {
+    let runtimeOptions:
+      | HostedChatRuntimeCreationOptions<TestAgentConfig, RuntimeAgentThinkingConfig>
+      | undefined;
+    const skills: RuntimeSkillDefinition[] = [];
+
+    const result = await prepareVeryfrontCloudHostedChatExecution({
+      request: createRequest(),
+      agentConfig: {
+        id: "agent-1",
+        model: "openai/gpt-5.2",
+        maxSteps: 12,
+      },
+      apiUrl: "https://api.example.com",
+      abortSignal: new AbortController().signal,
+      fetchSteering: () => Promise.resolve({ instructions: "Project rules", skills }),
+      buildInstructions: (input): ChatSystemMessage[] => [
+        {
+          role: "system",
+          content: `${input.agentConfig.id}: ${input.instructions}`,
+        },
+      ],
+      createRuntime: (options) => {
+        runtimeOptions = options;
+        return Promise.resolve({
+          runtimeKind: "framework",
+          agent: createRuntimeAgent(),
+          modelId: options.model ?? "default-model",
+          cleanup: () => Promise.resolve(),
+        });
+      },
+    });
+
+    assertEquals(runtimeOptions?.model, "veryfront-cloud/openai/gpt-5.2");
+    assertEquals(runtimeOptions?.maxSteps, 12);
+    assertEquals(runtimeOptions?.instructions, [
+      {
+        role: "system",
+        content: "agent-1: Project rules",
+      },
+    ]);
+    assertEquals(result.rootRunContext.durableRootRun, null);
+    assertEquals(result.runtime.modelId, "veryfront-cloud/openai/gpt-5.2");
+  });
+
+  it("builds default root-run persistence diagnostics and preserves overrides", () => {
+    const loggerCalls: unknown[] = [];
+    const instrumentation = {
+      trace: <TResult>(_operationName: string, operation: () => Promise<TResult>) => operation(),
+    };
+
+    const defaults = createVeryfrontCloudHostedChatExecutionRootRunOptions({
+      logger: {
+        error: (_message, metadata) => loggerCalls.push(metadata),
+      },
+      rootRun: {
+        implementationKind: "custom-kind",
+        instrumentation,
+      },
+    });
+
+    const failure = {
+      conversationId: "conversation-1",
+      messageId: "message-1",
+      status: 500,
+      statusText: "Internal Server Error",
+      body: "error",
+    };
+    defaults.onPersistLatestUserMessageFailure?.(failure);
+
+    assertEquals(defaults.persistLatestUserMessageOperation, "Persist durable root user message");
+    assertEquals(
+      defaults.missingUserMessageErrorMessage,
+      "DURABLE_CHAT_ROOT_REQUIRES_USER_MESSAGE",
+    );
+    assertEquals(defaults.implementationKind, "custom-kind");
+    assertStrictEquals(defaults.instrumentation, instrumentation);
+    assertEquals(loggerCalls, [failure]);
+
+    const customFailure = (customFailureInput: unknown) => loggerCalls.push(customFailureInput);
+    const overridden = createVeryfrontCloudHostedChatExecutionRootRunOptions({
+      logger: {
+        error: (_message, metadata) => loggerCalls.push(metadata),
+      },
+      rootRun: {
+        persistLatestUserMessageOperation: "Persist custom message",
+        missingUserMessageErrorMessage: "CUSTOM_MISSING_MESSAGE",
+        onPersistLatestUserMessageFailure: customFailure,
+      },
+    });
+
+    assertEquals(overridden.persistLatestUserMessageOperation, "Persist custom message");
+    assertEquals(overridden.missingUserMessageErrorMessage, "CUSTOM_MISSING_MESSAGE");
+    assertStrictEquals(overridden.onPersistLatestUserMessageFailure, customFailure);
+  });
+});

--- a/src/agent/veryfront-cloud-hosted-chat-execution-preparation.ts
+++ b/src/agent/veryfront-cloud-hosted-chat-execution-preparation.ts
@@ -1,0 +1,98 @@
+import {
+  resolveHostedVeryfrontCloudModelId,
+  resolveVeryfrontCloudModelThinking,
+} from "#veryfront/provider";
+import type { HostedChatRuntimeCreationResult } from "./hosted-chat-runtime-contract.ts";
+import {
+  type HostedChatExecutionPreparationInput,
+  type HostedChatExecutionPreparationResult,
+  type HostedChatExecutionPreparationRootRunOptions,
+  prepareHostedChatExecution,
+} from "./hosted-chat-preparation.ts";
+import type { RuntimeAgentThinkingConfig } from "./runtime-agent-definition.ts";
+
+const DEFAULT_PERSIST_LATEST_USER_MESSAGE_OPERATION = "Persist durable root user message";
+const DEFAULT_MISSING_USER_MESSAGE_ERROR_MESSAGE = "DURABLE_CHAT_ROOT_REQUIRES_USER_MESSAGE";
+const DEFAULT_PERSIST_LATEST_USER_MESSAGE_FAILURE_MESSAGE =
+  "Failed to persist user message before durable run setup";
+
+export type VeryfrontCloudHostedChatExecutionPreparationLogger = {
+  error: (message: string, metadata?: unknown) => void;
+};
+
+export type PrepareVeryfrontCloudHostedChatExecutionInput<
+  TRuntimeAgentDefinition extends {
+    id: string;
+    model?: string;
+    thinking?: RuntimeAgentThinkingConfig;
+    maxSteps?: number;
+  },
+  TRuntimeResult extends HostedChatRuntimeCreationResult,
+> =
+  & Omit<
+    HostedChatExecutionPreparationInput<TRuntimeAgentDefinition, TRuntimeResult>,
+    "resolveModelId" | "resolveModelThinking" | "rootRun"
+  >
+  & {
+    rootRun?: Partial<HostedChatExecutionPreparationRootRunOptions>;
+    logger?: VeryfrontCloudHostedChatExecutionPreparationLogger;
+  };
+
+export function createVeryfrontCloudHostedChatExecutionRootRunOptions(input: {
+  rootRun?: Partial<HostedChatExecutionPreparationRootRunOptions>;
+  logger?: VeryfrontCloudHostedChatExecutionPreparationLogger;
+}): HostedChatExecutionPreparationRootRunOptions {
+  const rootRun: HostedChatExecutionPreparationRootRunOptions = {
+    persistLatestUserMessageOperation: input.rootRun?.persistLatestUserMessageOperation ??
+      DEFAULT_PERSIST_LATEST_USER_MESSAGE_OPERATION,
+    missingUserMessageErrorMessage: input.rootRun?.missingUserMessageErrorMessage ??
+      DEFAULT_MISSING_USER_MESSAGE_ERROR_MESSAGE,
+  };
+
+  if (input.rootRun?.implementationKind !== undefined) {
+    rootRun.implementationKind = input.rootRun.implementationKind;
+  }
+
+  if (input.rootRun?.instrumentation) {
+    rootRun.instrumentation = input.rootRun.instrumentation;
+  }
+
+  if (input.rootRun?.onPersistLatestUserMessageFailure) {
+    rootRun.onPersistLatestUserMessageFailure = input.rootRun.onPersistLatestUserMessageFailure;
+  } else if (input.logger) {
+    rootRun.onPersistLatestUserMessageFailure = (failure) => {
+      input.logger?.error(DEFAULT_PERSIST_LATEST_USER_MESSAGE_FAILURE_MESSAGE, failure);
+    };
+  }
+
+  return rootRun;
+}
+
+export async function prepareVeryfrontCloudHostedChatExecution<
+  TRuntimeAgentDefinition extends {
+    id: string;
+    model?: string;
+    thinking?: RuntimeAgentThinkingConfig;
+    maxSteps?: number;
+  },
+  TRuntimeResult extends HostedChatRuntimeCreationResult,
+>(
+  input: PrepareVeryfrontCloudHostedChatExecutionInput<
+    TRuntimeAgentDefinition,
+    TRuntimeResult
+  >,
+): Promise<
+  HostedChatExecutionPreparationResult<TRuntimeAgentDefinition, TRuntimeResult>
+> {
+  const { logger, rootRun, ...preparationInput } = input;
+
+  return await prepareHostedChatExecution({
+    ...preparationInput,
+    rootRun: createVeryfrontCloudHostedChatExecutionRootRunOptions({
+      rootRun,
+      logger,
+    }),
+    resolveModelId: resolveHostedVeryfrontCloudModelId,
+    resolveModelThinking: resolveVeryfrontCloudModelThinking,
+  });
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.484";
+export const VERSION = "0.1.485";


### PR DESCRIPTION
## Summary
- add reusable Veryfront Cloud hosted chat preparation defaults
- wire hosted model normalization, model thinking defaults, and durable root-run diagnostics
- document the helper and bump the package patch version

## Verification
- deno task verify:quick
- pre-push checks: format, lint, typecheck, unit tests