### PR TITLE
Add hosted agent service config defaults

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.485",
+  "version": "0.1.486",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -160,7 +160,10 @@ Services that prepare and stream hosted executions through Veryfront Cloud can
 use `prepareVeryfrontCloudHostedChatExecution()` and
 `createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions()` to reuse the
 default hosted model normalization, model-provider, durable root-run, and
-stream-watchdog wiring.
+stream-watchdog wiring. Hosted services can also use
+`parseHostedAgentServiceConfig()` to share the default environment contract for
+API URL, hosted MCP URL, port, CORS origins, durable feature flags, and
+OpenTelemetry flags.
 
 ## Agent configuration
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -725,6 +725,13 @@ Create the default durable root-run preparation options used by
 operation text, missing-user-message errors, instrumentation, implementation
 kind, or persistence-failure handling.
 
+### `parseHostedAgentServiceConfig(env)`
+
+Parse the default hosted agent service environment contract. The helper
+validates API URL, node environment, port, durable feature flags, OAuth public
+key, Studio MCP URL, allowed origins, and OpenTelemetry endpoint flags, and it
+derives the hosted MCP URL from `VERYFRONT_API_URL`.
+
 ### `AgUiRuntimeRequestSchema`
 
 Validate the canonical open-source AG-UI runtime request contract for hosted
@@ -910,6 +917,7 @@ Clear all stored messages from memory.
 | `createDefaultHostedProjectSteeringRefresh`                     | Create the default hosted project steering refresh callback              |
 | `createVeryfrontCloudHostedChatExecutionRootRunOptions`         | Create Veryfront Cloud hosted root-run preparation defaults              |
 | `createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions` | Create Veryfront Cloud prepared execution runtime defaults               |
+| `parseHostedAgentServiceConfig`                                 | Parse default hosted agent service environment config                    |
 | `prepareVeryfrontCloudHostedChatExecution`                      | Prepare hosted chat execution with Veryfront Cloud defaults              |
 | `normalizeAgUiRuntimeMessages`                                  | Normalize runtime AG-UI messages into package `Message[]`                |
 | `parseAgUiRuntimeRequest`                                       | Parse and validate the canonical runtime AG-UI request body              |

--- a/src/agent/hosted-agent-service-config.test.ts
+++ b/src/agent/hosted-agent-service-config.test.ts
@@ -1,0 +1,50 @@
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { parseHostedAgentServiceConfig } from "./hosted-agent-service-config.ts";
+
+describe("agent/hosted-agent-service-config", () => {
+  it("builds hosted agent service config defaults", () => {
+    const config = parseHostedAgentServiceConfig({});
+
+    assertEquals(config.VERYFRONT_API_URL, "https://api.veryfront.com");
+    assertEquals(config.VERYFRONT_MCP_URL, "https://api.veryfront.com/mcp");
+    assertEquals(config.VERYFRONT_STUDIO_MCP_URL, "");
+    assertEquals(config.NODE_ENV, "development");
+    assertEquals(config.PORT, 3001);
+    assertEquals(config.ALLOWED_ORIGINS, ["http://localhost:3000", "http://veryfront.me:3000"]);
+    assertEquals(config.OTEL_ENABLED, false);
+    assertEquals(config.VERYFRONT_ENABLE_DURABLE_INVOKE_AGENT, false);
+    assertEquals(config.VERYFRONT_ENABLE_DURABLE_TASK, false);
+  });
+
+  it("normalizes derived URLs, booleans, port, and origins", () => {
+    const config = parseHostedAgentServiceConfig({
+      VERYFRONT_API_URL: "https://api.example.com",
+      NODE_ENV: "production",
+      PORT: "4200",
+      OAUTH_PUBLIC_KEY: "public-key",
+      VERYFRONT_STUDIO_MCP_URL: "https://studio.example.com/mcp",
+      VERYFRONT_ENABLE_DURABLE_INVOKE_AGENT: "true",
+      VERYFRONT_ENABLE_DURABLE_TASK: "true",
+      ALLOWED_ORIGINS: "https://a.example.com, https://b.example.com",
+      OTEL_ENABLED: "true",
+      OTEL_EXPORTER_OTLP_ENDPOINT: "https://otel.example.com",
+    });
+
+    assertEquals(config.VERYFRONT_API_URL, "https://api.example.com");
+    assertEquals(config.VERYFRONT_MCP_URL, "https://api.example.com/mcp");
+    assertEquals(config.NODE_ENV, "production");
+    assertEquals(config.PORT, 4200);
+    assertEquals(config.OAUTH_PUBLIC_KEY, "public-key");
+    assertEquals(config.VERYFRONT_STUDIO_MCP_URL, "https://studio.example.com/mcp");
+    assertEquals(config.VERYFRONT_ENABLE_DURABLE_INVOKE_AGENT, true);
+    assertEquals(config.VERYFRONT_ENABLE_DURABLE_TASK, true);
+    assertEquals(config.ALLOWED_ORIGINS, ["https://a.example.com", "https://b.example.com"]);
+    assertEquals(config.OTEL_ENABLED, true);
+    assertEquals(config.OTEL_EXPORTER_OTLP_ENDPOINT, "https://otel.example.com");
+  });
+
+  it("rejects invalid API URLs", () => {
+    assertThrows(() => parseHostedAgentServiceConfig({ VERYFRONT_API_URL: "not-a-url" }));
+  });
+});

--- a/src/agent/hosted-agent-service-config.ts
+++ b/src/agent/hosted-agent-service-config.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+function parseBooleanFlag(value: string): boolean {
+  return value === "true";
+}
+
+function splitAllowedOrigins(value: string): string[] {
+  return value.split(",").map((origin) => origin.trim());
+}
+
+const booleanFlagSchema = z.string().default("false").transform(parseBooleanFlag);
+
+export const hostedAgentServiceConfigSchema = z.object({
+  VERYFRONT_API_URL: z.string().url().default("https://api.veryfront.com"),
+  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+  PORT: z.coerce.number().default(3001),
+  OAUTH_PUBLIC_KEY: z.string().optional(),
+  VERYFRONT_STUDIO_MCP_URL: z.string().default(""),
+  VERYFRONT_ENABLE_DURABLE_INVOKE_AGENT: booleanFlagSchema,
+  VERYFRONT_ENABLE_DURABLE_TASK: booleanFlagSchema,
+  ALLOWED_ORIGINS: z.string().default("http://localhost:3000,http://veryfront.me:3000"),
+  OTEL_ENABLED: booleanFlagSchema,
+  OTEL_EXPORTER_OTLP_ENDPOINT: z.string().optional(),
+}).transform((env) => ({
+  VERYFRONT_API_URL: env.VERYFRONT_API_URL,
+  VERYFRONT_MCP_URL: `${env.VERYFRONT_API_URL}/mcp`,
+  VERYFRONT_STUDIO_MCP_URL: env.VERYFRONT_STUDIO_MCP_URL,
+  VERYFRONT_ENABLE_DURABLE_INVOKE_AGENT: env.VERYFRONT_ENABLE_DURABLE_INVOKE_AGENT,
+  VERYFRONT_ENABLE_DURABLE_TASK: env.VERYFRONT_ENABLE_DURABLE_TASK,
+  NODE_ENV: env.NODE_ENV,
+  PORT: env.PORT,
+  OAUTH_PUBLIC_KEY: env.OAUTH_PUBLIC_KEY,
+  ALLOWED_ORIGINS: splitAllowedOrigins(env.ALLOWED_ORIGINS),
+  OTEL_ENABLED: env.OTEL_ENABLED,
+  OTEL_EXPORTER_OTLP_ENDPOINT: env.OTEL_EXPORTER_OTLP_ENDPOINT,
+}));
+
+export type HostedAgentServiceConfig = z.infer<typeof hostedAgentServiceConfigSchema>;
+export type HostedAgentServiceConfigInput = z.input<typeof hostedAgentServiceConfigSchema>;
+
+export function parseHostedAgentServiceConfig(
+  input: HostedAgentServiceConfigInput,
+): HostedAgentServiceConfig {
+  return hostedAgentServiceConfigSchema.parse(input);
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -272,6 +272,12 @@ export {
   type StartNodeHostedAgentServiceResult,
 } from "./hosted-agent-service-runtime.ts";
 export {
+  type HostedAgentServiceConfig,
+  type HostedAgentServiceConfigInput,
+  hostedAgentServiceConfigSchema,
+  parseHostedAgentServiceConfig,
+} from "./hosted-agent-service-config.ts";
+export {
   type AgentServiceBootstrapExit,
   type AgentServiceTraceContext,
   type AgentServiceTraceContextGetter,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.485";
+export const VERSION = "0.1.486";


### PR DESCRIPTION
## Summary
- add reusable hosted agent service environment config defaults
- derive hosted MCP URL and normalize durable, CORS, port, and OpenTelemetry flags
- document the helper and bump the package patch version

## Verification
- deno task verify:quick
- pre-push checks: format, lint, typecheck, unit tests