### PR TITLE
Add hosted service env file loader

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.486",
+  "version": "0.1.487",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -160,10 +160,10 @@ Services that prepare and stream hosted executions through Veryfront Cloud can
 use `prepareVeryfrontCloudHostedChatExecution()` and
 `createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions()` to reuse the
 default hosted model normalization, model-provider, durable root-run, and
-stream-watchdog wiring. Hosted services can also use
-`parseHostedAgentServiceConfig()` to share the default environment contract for
-API URL, hosted MCP URL, port, CORS origins, durable feature flags, and
-OpenTelemetry flags.
+stream-watchdog wiring. Hosted services can also use `loadHostedAgentServiceEnvFiles()` before
+`parseHostedAgentServiceConfig()` to share the default env-file precedence and
+environment contract for API URL, hosted MCP URL, port, CORS origins, durable
+feature flags, and OpenTelemetry flags.
 
 ## Agent configuration
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -732,6 +732,14 @@ validates API URL, node environment, port, durable feature flags, OAuth public
 key, Studio MCP URL, allowed origins, and OpenTelemetry endpoint flags, and it
 derives the hosted MCP URL from `VERYFRONT_API_URL`.
 
+### `loadHostedAgentServiceEnvFiles(options)`
+
+Load hosted agent service env files before parsing config. By default the
+helper reads `.env` and then `.env.local` from the current working directory,
+preserves variables that were already present in the host process environment,
+and lets later env files override earlier env-file values. This matches the
+recommended service bootstrap shape for separately deployed hosted agents.
+
 ### `AgUiRuntimeRequestSchema`
 
 Validate the canonical open-source AG-UI runtime request contract for hosted
@@ -917,6 +925,7 @@ Clear all stored messages from memory.
 | `createDefaultHostedProjectSteeringRefresh`                     | Create the default hosted project steering refresh callback              |
 | `createVeryfrontCloudHostedChatExecutionRootRunOptions`         | Create Veryfront Cloud hosted root-run preparation defaults              |
 | `createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions` | Create Veryfront Cloud prepared execution runtime defaults               |
+| `loadHostedAgentServiceEnvFiles`                                | Load hosted service env files while preserving host process env          |
 | `parseHostedAgentServiceConfig`                                 | Parse default hosted agent service environment config                    |
 | `prepareVeryfrontCloudHostedChatExecution`                      | Prepare hosted chat execution with Veryfront Cloud defaults              |
 | `normalizeAgUiRuntimeMessages`                                  | Normalize runtime AG-UI messages into package `Message[]`                |

--- a/src/agent/hosted-agent-service-env-files.test.ts
+++ b/src/agent/hosted-agent-service-env-files.test.ts
@@ -1,0 +1,79 @@
+import { assertEquals } from "@std/assert";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { deleteEnv, getEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import { loadHostedAgentServiceEnvFiles } from "./hosted-agent-service-env-files.ts";
+
+const TEST_KEYS = [
+  "VF_AGENT_ENV_FILE_TEST_SHARED",
+  "VF_AGENT_ENV_FILE_TEST_LOCAL_ONLY",
+  "VF_AGENT_ENV_FILE_TEST_PROTECTED",
+  "VF_AGENT_ENV_FILE_TEST_EMPTY",
+];
+
+describe("loadHostedAgentServiceEnvFiles", () => {
+  let tempDir = "";
+
+  beforeEach(async () => {
+    tempDir = await Deno.makeTempDir({ prefix: "hosted-agent-env-files-" });
+    for (const key of TEST_KEYS) {
+      deleteEnv(key);
+    }
+  });
+
+  afterEach(async () => {
+    for (const key of TEST_KEYS) {
+      deleteEnv(key);
+    }
+
+    if (tempDir) {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("loads .env then .env.local while preserving existing process env", async () => {
+    setEnv("VF_AGENT_ENV_FILE_TEST_PROTECTED", "from-process");
+    await Deno.writeTextFile(
+      `${tempDir}/.env`,
+      [
+        "VF_AGENT_ENV_FILE_TEST_SHARED=from-env",
+        "VF_AGENT_ENV_FILE_TEST_PROTECTED=from-env",
+      ].join("\n"),
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/.env.local`,
+      [
+        "VF_AGENT_ENV_FILE_TEST_SHARED=from-local",
+        "VF_AGENT_ENV_FILE_TEST_LOCAL_ONLY=local",
+      ].join("\n"),
+    );
+
+    const result = await loadHostedAgentServiceEnvFiles({ cwd: tempDir });
+
+    assertEquals(result.loadedFiles, [`${tempDir}/.env`, `${tempDir}/.env.local`]);
+    assertEquals(result.loadedVariables, 3);
+    assertEquals(getEnv("VF_AGENT_ENV_FILE_TEST_SHARED"), "from-local");
+    assertEquals(getEnv("VF_AGENT_ENV_FILE_TEST_LOCAL_ONLY"), "local");
+    assertEquals(getEnv("VF_AGENT_ENV_FILE_TEST_PROTECTED"), "from-process");
+  });
+
+  it("supports empty values from env files", async () => {
+    await Deno.writeTextFile(`${tempDir}/.env`, "VF_AGENT_ENV_FILE_TEST_EMPTY=");
+
+    const result = await loadHostedAgentServiceEnvFiles({ cwd: tempDir });
+
+    assertEquals(result.loadedVariables, 1);
+    assertEquals(getEnv("VF_AGENT_ENV_FILE_TEST_EMPTY"), "");
+  });
+
+  it("supports explicit env file lists", async () => {
+    await Deno.writeTextFile(`${tempDir}/custom.env`, "VF_AGENT_ENV_FILE_TEST_SHARED=custom");
+
+    const result = await loadHostedAgentServiceEnvFiles({
+      cwd: tempDir,
+      files: ["custom.env"],
+    });
+
+    assertEquals(result.loadedFiles, [`${tempDir}/custom.env`]);
+    assertEquals(getEnv("VF_AGENT_ENV_FILE_TEST_SHARED"), "custom");
+  });
+});

--- a/src/agent/hosted-agent-service-env-files.ts
+++ b/src/agent/hosted-agent-service-env-files.ts
@@ -1,0 +1,55 @@
+import { cwd as getCwd, env as getProcessEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import { load as loadDotenv } from "#veryfront/platform/compat/std/dotenv.ts";
+
+const DEFAULT_HOSTED_AGENT_SERVICE_ENV_FILES = [".env", ".env.local"] as const;
+
+export type HostedAgentServiceEnvFileLoadResult = {
+  loadedFiles: string[];
+  loadedVariables: number;
+};
+
+export type HostedAgentServiceEnvFileLoadOptions = {
+  cwd?: string;
+  files?: readonly string[];
+};
+
+function joinEnvPath(cwd: string, file: string): string {
+  if (file.startsWith("/") || file.startsWith("./") || file.startsWith("../")) {
+    return file;
+  }
+
+  return `${cwd.replace(/\/$/, "")}/${file}`;
+}
+
+export async function loadHostedAgentServiceEnvFiles(
+  options: HostedAgentServiceEnvFileLoadOptions = {},
+): Promise<HostedAgentServiceEnvFileLoadResult> {
+  const cwd = options.cwd ?? getCwd();
+  const files = options.files ?? DEFAULT_HOSTED_AGENT_SERVICE_ENV_FILES;
+  const protectedKeys = new Set(Object.keys(getProcessEnv()));
+  const loadedFiles: string[] = [];
+  let loadedVariables = 0;
+
+  for (const file of files) {
+    const envPath = joinEnvPath(cwd, file);
+    const parsed = await loadDotenv({ envPath, allowEmptyValues: true });
+    const entries = Object.entries(parsed);
+
+    if (entries.length === 0) {
+      continue;
+    }
+
+    loadedFiles.push(envPath);
+
+    for (const [key, value] of entries) {
+      if (protectedKeys.has(key)) {
+        continue;
+      }
+
+      setEnv(key, value);
+      loadedVariables++;
+    }
+  }
+
+  return { loadedFiles, loadedVariables };
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -278,6 +278,11 @@ export {
   parseHostedAgentServiceConfig,
 } from "./hosted-agent-service-config.ts";
 export {
+  type HostedAgentServiceEnvFileLoadOptions,
+  type HostedAgentServiceEnvFileLoadResult,
+  loadHostedAgentServiceEnvFiles,
+} from "./hosted-agent-service-env-files.ts";
+export {
   type AgentServiceBootstrapExit,
   type AgentServiceTraceContext,
   type AgentServiceTraceContextGetter,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.486";
+export const VERSION = "0.1.487";


### PR DESCRIPTION
## Summary
- add a reusable hosted service env-file loader for .env and .env.local precedence
- preserve host process environment values while allowing later env files to override earlier env-file values
- document the helper and bump the package patch version

## Verification
- deno task verify:quick
- deno test --no-check -A src/agent/hosted-agent-service-env-files.test.ts
- pre-push checks: format, lint, typecheck, unit tests