### PR TITLE
Add Veryfront Cloud runtime system message builder

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.487",
+  "version": "0.1.488",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -157,9 +157,10 @@ project-scoped tool inventory from an external control plane can use
 the default refresh sequencing while keeping fetch and prompt-building policy
 local.
 Services that prepare and stream hosted executions through Veryfront Cloud can
-use `prepareVeryfrontCloudHostedChatExecution()` and
-`createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions()` to reuse the
-default hosted model normalization, model-provider, durable root-run, and
+use `prepareVeryfrontCloudHostedChatExecution()`,
+`createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions()`, and
+`createVeryfrontCloudRuntimeSystemMessages()` to reuse the default hosted model
+normalization, model-provider, runtime system-message, durable root-run, and
 stream-watchdog wiring. Hosted services can also use `loadHostedAgentServiceEnvFiles()` before
 `parseHostedAgentServiceConfig()` to share the default env-file precedence and
 environment contract for API URL, hosted MCP URL, port, CORS origins, durable

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -711,6 +711,13 @@ Veryfront Cloud. The helper wires the hosted model-provider resolver and default
 chat stream watchdog while the host supplies its API URL, tracer, logger, and
 optional trace hooks.
 
+### `createVeryfrontCloudRuntimeSystemMessages(options)`
+
+Create the default runtime system messages for Veryfront Cloud hosted services.
+The helper inserts project instructions and project context blocks at the
+runtime-context marker, includes available skills, and appends environment
+context using the same prompt-block conventions as the core runtime.
+
 ### `prepareVeryfrontCloudHostedChatExecution(options)`
 
 Prepare hosted chat execution for services that run through Veryfront Cloud. The
@@ -925,6 +932,7 @@ Clear all stored messages from memory.
 | `createDefaultHostedProjectSteeringRefresh`                     | Create the default hosted project steering refresh callback              |
 | `createVeryfrontCloudHostedChatExecutionRootRunOptions`         | Create Veryfront Cloud hosted root-run preparation defaults              |
 | `createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions` | Create Veryfront Cloud prepared execution runtime defaults               |
+| `createVeryfrontCloudRuntimeSystemMessages`                     | Create Veryfront Cloud runtime system messages                           |
 | `loadHostedAgentServiceEnvFiles`                                | Load hosted service env files while preserving host process env          |
 | `parseHostedAgentServiceConfig`                                 | Parse default hosted agent service environment config                    |
 | `prepareVeryfrontCloudHostedChatExecution`                      | Prepare hosted chat execution with Veryfront Cloud defaults              |

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -185,6 +185,11 @@ export {
 } from "./runtime-agent-definition.ts";
 
 export {
+  createVeryfrontCloudRuntimeSystemMessages,
+  type CreateVeryfrontCloudRuntimeSystemMessagesInput,
+} from "./veryfront-cloud-runtime-system-messages.ts";
+
+export {
   applyAgentProjectContextChange,
   getConfirmedProjectContextSwitchId,
   type MutableAgentProjectContext,

--- a/src/agent/veryfront-cloud-runtime-system-messages.test.ts
+++ b/src/agent/veryfront-cloud-runtime-system-messages.test.ts
@@ -1,0 +1,72 @@
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  createVeryfrontCloudRuntimeSystemMessages,
+} from "./veryfront-cloud-runtime-system-messages.ts";
+import type { RuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
+import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
+
+function createAgent(
+  overrides: Partial<RuntimeAgentMarkdownDefinition> = {},
+): RuntimeAgentMarkdownDefinition {
+  return {
+    id: "assistant",
+    name: "Assistant",
+    description: "A test assistant",
+    instructions: "Base instructions\n\n<!-- veryfront-runtime-context -->\n\nStatic tail",
+    ...overrides,
+  };
+}
+
+Deno.test("createVeryfrontCloudRuntimeSystemMessages inserts project instructions and context at runtime marker", () => {
+  const [message] = createVeryfrontCloudRuntimeSystemMessages({
+    agent: createAgent(),
+    instructions: "Use the project policy.",
+    projectId: "project-123",
+    branchId: "branch-456",
+  });
+
+  assertEquals(message?.role, "system");
+  assertStringIncludes(message?.content ?? "", "Base instructions");
+  assertStringIncludes(message?.content ?? "", "<project_instructions>");
+  assertStringIncludes(message?.content ?? "", "Use the project policy.");
+  assertStringIncludes(message?.content ?? "", "<project_context>");
+  assertStringIncludes(message?.content ?? "", 'project_reference: "project-123"');
+  assertStringIncludes(message?.content ?? "", 'branch_id: "branch-456"');
+  assertStringIncludes(message?.content ?? "", "Static tail");
+});
+
+Deno.test("createVeryfrontCloudRuntimeSystemMessages uses main branch guidance when branch id is absent", () => {
+  const [message] = createVeryfrontCloudRuntimeSystemMessages({
+    agent: createAgent(),
+    projectId: "project-123",
+  });
+
+  assertStringIncludes(
+    message?.content ?? "",
+    "branch_id: main (no branch_id needed for file operations)",
+  );
+});
+
+Deno.test("createVeryfrontCloudRuntimeSystemMessages includes skills and environment context", () => {
+  const skills: RuntimeSkillDefinition[] = [
+    {
+      id: "deploy",
+      name: "Deploy",
+      description: "Deployment guidance",
+      references: [],
+    },
+  ];
+
+  const messages = createVeryfrontCloudRuntimeSystemMessages({
+    agent: createAgent({ instructions: "Base instructions" }),
+    skills,
+    environmentContext: "Runtime facts",
+  });
+
+  assertEquals(messages.length, 2);
+  assertStringIncludes(messages[0]?.content ?? "", "<available_skills>");
+  assertStringIncludes(messages[0]?.content ?? "", "Deployment guidance");
+  assertEquals(messages[1]?.role, "system");
+  assertStringIncludes(messages[1]?.content ?? "", "<environment_context>");
+  assertStringIncludes(messages[1]?.content ?? "", "Runtime facts");
+});

--- a/src/agent/veryfront-cloud-runtime-system-messages.ts
+++ b/src/agent/veryfront-cloud-runtime-system-messages.ts
@@ -1,0 +1,65 @@
+import type { ChatSystemMessage } from "#veryfront/chat/types.ts";
+import {
+  createRuntimeAgentSystemMessages,
+  type RuntimeAgentMarkdownDefinition,
+} from "./runtime-agent-definition.ts";
+import { createRuntimePromptBlock } from "./runtime-prompt-block.ts";
+import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
+
+export type CreateVeryfrontCloudRuntimeSystemMessagesInput = {
+  agent: RuntimeAgentMarkdownDefinition;
+  instructions?: string;
+  skills?: readonly RuntimeSkillDefinition[];
+  projectId?: string | null;
+  branchId?: string | null;
+  environmentContext?: string;
+};
+
+function createProjectInstructionsBlock(instructions: string): string {
+  return createRuntimePromptBlock({
+    name: "project_instructions",
+    content: `CRITICAL: You MUST follow these project-specific guidelines:\n\n${instructions}`,
+  });
+}
+
+function createProjectContextBlock(input: { projectId: string; branchId?: string | null }): string {
+  const branchLine = input.branchId
+    ? `branch_id: "${input.branchId}"`
+    : "branch_id: main (no branch_id needed for file operations)";
+
+  return createRuntimePromptBlock({
+    name: "project_context",
+    content: `project_reference: "${input.projectId}"
+${branchLine}
+
+Use the exact project_reference above for project/platform tools unless a tool result explicitly confirms a different active project.
+
+CRITICAL: Do NOT guess or invent project references. If a tool requires project_reference, use the value above.`,
+  });
+}
+
+export function createVeryfrontCloudRuntimeSystemMessages(
+  input: CreateVeryfrontCloudRuntimeSystemMessagesInput,
+): ChatSystemMessage[] {
+  const runtimeBlocks: string[] = [];
+
+  if (input.instructions) {
+    runtimeBlocks.push(createProjectInstructionsBlock(input.instructions));
+  }
+
+  if (input.projectId) {
+    runtimeBlocks.push(
+      createProjectContextBlock({
+        projectId: input.projectId,
+        branchId: input.branchId,
+      }),
+    );
+  }
+
+  return createRuntimeAgentSystemMessages({
+    agent: input.agent,
+    runtimeBlocks,
+    skills: input.skills,
+    environmentContext: input.environmentContext,
+  });
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.487";
+export const VERSION = "0.1.488";


### PR DESCRIPTION
## Summary
- add a reusable Veryfront Cloud runtime system-message builder
- cover project instructions, project context, skills, and environment context
- document the new public helper and bump the package version to 0.1.488

## Verification
- deno test --no-check -A src/agent/veryfront-cloud-runtime-system-messages.test.ts
- deno check src/agent/index.ts
- deno task verify:quick
- pre-push checks