### PR TITLE
Add hosted runtime definition and trace helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.488",
+  "version": "0.1.489",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -165,6 +165,9 @@ stream-watchdog wiring. Hosted services can also use `loadHostedAgentServiceEnvF
 `parseHostedAgentServiceConfig()` to share the default env-file precedence and
 environment contract for API URL, hosted MCP URL, port, CORS origins, durable
 feature flags, and OpenTelemetry flags.
+Use `resolveRuntimeAgentDefinitionsDir()` and
+`loadRuntimeAgentMarkdownDefinitionFromFile()` when a separately deployed
+hosted agent stores persona/configuration in `agents/*.md` files.
 
 ## Agent configuration
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -718,6 +718,25 @@ The helper inserts project instructions and project context blocks at the
 runtime-context marker, includes available skills, and appends environment
 context using the same prompt-block conventions as the core runtime.
 
+### `resolveRuntimeAgentDefinitionsDir(options)`
+
+Resolve the `agents/` directory for a hosted service from a source or bundled
+module directory. The helper checks source-layout, bundled `dist/src`, and
+deeper bundled server paths for a markdown definition such as `assistant.md`.
+
+### `loadRuntimeAgentMarkdownDefinitionFromFile(options)`
+
+Read a markdown agent definition from an `agents/` directory and parse its
+frontmatter plus body with `parseRuntimeAgentMarkdownDefinition()`. This keeps
+file loading, traversal-prone file-name validation, and markdown parsing
+consistent across separately deployed hosted agents.
+
+### `filterAgentTraceAttributes(attributes)`
+
+Filter an unknown attribute record down to OpenTelemetry-safe agent trace
+attribute values: strings, numbers, booleans, arrays of those primitives,
+`null`, or `undefined`.
+
 ### `prepareVeryfrontCloudHostedChatExecution(options)`
 
 Prepare hosted chat execution for services that run through Veryfront Cloud. The
@@ -933,7 +952,9 @@ Clear all stored messages from memory.
 | `createVeryfrontCloudHostedChatExecutionRootRunOptions`         | Create Veryfront Cloud hosted root-run preparation defaults              |
 | `createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions` | Create Veryfront Cloud prepared execution runtime defaults               |
 | `createVeryfrontCloudRuntimeSystemMessages`                     | Create Veryfront Cloud runtime system messages                           |
+| `filterAgentTraceAttributes`                                    | Filter unknown records to valid agent trace attributes                   |
 | `loadHostedAgentServiceEnvFiles`                                | Load hosted service env files while preserving host process env          |
+| `loadRuntimeAgentMarkdownDefinitionFromFile`                    | Load and parse a markdown agent definition from an agents directory      |
 | `parseHostedAgentServiceConfig`                                 | Parse default hosted agent service environment config                    |
 | `prepareVeryfrontCloudHostedChatExecution`                      | Prepare hosted chat execution with Veryfront Cloud defaults              |
 | `normalizeAgUiRuntimeMessages`                                  | Normalize runtime AG-UI messages into package `Message[]`                |
@@ -941,6 +962,7 @@ Clear all stored messages from memory.
 | `parseAgUiRuntimeRequestOrError`                                | Parse runtime AG-UI input or return a `400` validation `Response`        |
 | `parseRuntimeAgentRunInvocation`                                | Parse and validate a control-plane runtime agent invocation body         |
 | `parseRuntimeAgentRunInvocationOrError`                         | Parse a runtime agent invocation or return a `400` validation `Response` |
+| `resolveRuntimeAgentDefinitionsDir`                             | Resolve a hosted service `agents/` directory from source/bundled paths   |
 | `createChatHandler`                                             | Create a POST handler for a chat API route.                              |
 | `createMemory`                                                  | Create memory (buffer, conversation, summary)                            |
 | `createRedisMemory`                                             | Create Redis-backed memory                                               |

--- a/src/agent/agent-trace-attributes.test.ts
+++ b/src/agent/agent-trace-attributes.test.ts
@@ -5,9 +5,35 @@ import {
   buildExecuteToolTraceAttributes,
   buildFinalizedAgentRunTraceAttributes,
   buildInvokeAgentTraceAttributes,
+  filterAgentTraceAttributes,
+  isAgentTraceAttributeValue,
 } from "./index.ts";
 
 describe("agent/agent-trace-attributes", () => {
+  it("filters unknown values to valid trace attributes", () => {
+    assertEquals(isAgentTraceAttributeValue(["a", 1, true]), true);
+    assertEquals(isAgentTraceAttributeValue(["a", { invalid: true }]), false);
+    assertEquals(
+      filterAgentTraceAttributes({
+        string: "value",
+        number: 1,
+        boolean: true,
+        array: ["a", 2, false],
+        nullValue: null,
+        undefinedValue: undefined,
+        object: { nested: true },
+      }),
+      {
+        string: "value",
+        number: 1,
+        boolean: true,
+        array: ["a", 2, false],
+        nullValue: null,
+        undefinedValue: undefined,
+      },
+    );
+  });
+
   it("builds core agent run lineage attributes", () => {
     assertEquals(
       buildAgentRunTraceAttributes({

--- a/src/agent/agent-trace-attributes.ts
+++ b/src/agent/agent-trace-attributes.ts
@@ -18,6 +18,32 @@ function compactTraceAttributes(attributes: AgentTraceAttributes): AgentTraceAtt
   );
 }
 
+function isAgentTraceAttributePrimitive(value: unknown): value is TracePrimitive {
+  return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+}
+
+export function isAgentTraceAttributeValue(value: unknown): value is AgentTraceAttributeValue {
+  if (value === null || value === undefined || isAgentTraceAttributePrimitive(value)) {
+    return true;
+  }
+
+  return Array.isArray(value) && value.every(isAgentTraceAttributePrimitive);
+}
+
+export function filterAgentTraceAttributes(
+  attributes: Record<string, unknown>,
+): AgentTraceAttributes {
+  const traceAttributes: AgentTraceAttributes = {};
+
+  for (const [key, value] of Object.entries(attributes)) {
+    if (isAgentTraceAttributeValue(value)) {
+      traceAttributes[key] = value;
+    }
+  }
+
+  return traceAttributes;
+}
+
 function resolveGenAiProviderName(modelId: string | null | undefined): string | null {
   const normalizedModelId = modelId?.startsWith("veryfront-cloud/")
     ? modelId.slice("veryfront-cloud/".length)

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -172,6 +172,15 @@ export {
 } from "./hosted-child-fork-tool-sources.ts";
 
 export {
+  loadRuntimeAgentMarkdownDefinitionFromFile,
+  type LoadRuntimeAgentMarkdownDefinitionFromFileInput,
+  loadRuntimeAgentMarkdownDefinitionFromFileInputSchema,
+  resolveRuntimeAgentDefinitionsDir,
+  type ResolveRuntimeAgentDefinitionsDirInput,
+  resolveRuntimeAgentDefinitionsDirInputSchema,
+  resolveRuntimeAgentMarkdownDefinitionFilePath,
+} from "./runtime-agent-definition-files.ts";
+export {
   createRuntimeAgentSystemMessages,
   type CreateRuntimeAgentSystemMessagesInput,
   DEFAULT_RUNTIME_AGENT_CONTEXT_MARKER,
@@ -352,6 +361,8 @@ export {
   buildExecuteToolTraceAttributes,
   buildFinalizedAgentRunTraceAttributes,
   buildInvokeAgentTraceAttributes,
+  filterAgentTraceAttributes,
+  isAgentTraceAttributeValue,
 } from "./agent-trace-attributes.ts";
 export {
   createHostedChatRuntimeAgentAdapter,

--- a/src/agent/runtime-agent-definition-files.test.ts
+++ b/src/agent/runtime-agent-definition-files.test.ts
@@ -1,0 +1,112 @@
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { resolve } from "node:path";
+import {
+  loadRuntimeAgentMarkdownDefinitionFromFile,
+  resolveRuntimeAgentDefinitionsDir,
+  resolveRuntimeAgentMarkdownDefinitionFilePath,
+} from "./runtime-agent-definition-files.ts";
+
+function withTempDir(fn: (dir: string) => void): void {
+  const dir = Deno.makeTempDirSync();
+  try {
+    fn(dir);
+  } finally {
+    Deno.removeSync(dir, { recursive: true });
+  }
+}
+
+Deno.test("resolveRuntimeAgentDefinitionsDir resolves source and bundled agent directories", () => {
+  withTempDir((rootDir) => {
+    const agentsDir = resolve(rootDir, "agents");
+    Deno.mkdirSync(agentsDir, { recursive: true });
+    Deno.writeTextFileSync(
+      resolve(agentsDir, "support.md"),
+      "---\nname: Support\n---\nHelp users.",
+    );
+
+    assertEquals(
+      resolveRuntimeAgentDefinitionsDir({
+        baseDir: resolve(rootDir, "src"),
+        id: "support",
+      }),
+      agentsDir,
+    );
+    assertEquals(
+      resolveRuntimeAgentDefinitionsDir({
+        baseDir: resolve(rootDir, "dist", "src"),
+        id: "support",
+      }),
+      agentsDir,
+    );
+    assertEquals(
+      resolveRuntimeAgentDefinitionsDir({
+        baseDir: resolve(rootDir, "dist", "server", "src"),
+        id: "support",
+      }),
+      agentsDir,
+    );
+  });
+});
+
+Deno.test("resolveRuntimeAgentDefinitionsDir falls back to the nearest source-layout candidate", () => {
+  withTempDir((rootDir) => {
+    assertEquals(
+      resolveRuntimeAgentDefinitionsDir({
+        baseDir: resolve(rootDir, "src"),
+        id: "support",
+      }),
+      resolve(rootDir, "agents"),
+    );
+  });
+});
+
+Deno.test("loadRuntimeAgentMarkdownDefinitionFromFile reads and parses markdown definitions", () => {
+  withTempDir((rootDir) => {
+    const agentsDir = resolve(rootDir, "agents");
+    Deno.mkdirSync(agentsDir, { recursive: true });
+    Deno.writeTextFileSync(
+      resolve(agentsDir, "writer.md"),
+      `---
+name: Writer
+description: Writes copy
+model: gpt-5.4
+---
+
+Draft concise copy.
+`,
+    );
+
+    assertEquals(
+      resolveRuntimeAgentMarkdownDefinitionFilePath({ agentsDir, id: "writer" }),
+      resolve(agentsDir, "writer.md"),
+    );
+    assertEquals(
+      loadRuntimeAgentMarkdownDefinitionFromFile({ agentsDir, id: "writer" }),
+      {
+        id: "writer",
+        name: "Writer",
+        description: "Writes copy",
+        model: "gpt-5.4",
+        instructions: "Draft concise copy.",
+      },
+    );
+  });
+});
+
+Deno.test("runtime agent definition file helpers reject traversal-prone names", () => {
+  withTempDir((rootDir) => {
+    assertThrows(() =>
+      resolveRuntimeAgentDefinitionsDir({
+        baseDir: rootDir,
+        id: "../escape",
+      })
+    );
+    assertThrows(() =>
+      loadRuntimeAgentMarkdownDefinitionFromFile({
+        agentsDir: rootDir,
+        id: "support",
+        fileName: "../support.md",
+      })
+    );
+  });
+});

--- a/src/agent/runtime-agent-definition-files.ts
+++ b/src/agent/runtime-agent-definition-files.ts
@@ -1,0 +1,80 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { z } from "zod";
+import {
+  parseRuntimeAgentMarkdownDefinition,
+  type RuntimeAgentMarkdownDefinition,
+} from "./runtime-agent-definition.ts";
+
+const runtimeAgentDefinitionFileNameSchema = z.string().min(1).regex(/^[A-Za-z0-9._-]+\.md$/);
+const runtimeAgentDefinitionFileIdSchema = z.string().min(1).regex(/^[A-Za-z0-9._-]+$/);
+
+export const resolveRuntimeAgentDefinitionsDirInputSchema = z.object({
+  baseDir: z.string().min(1),
+  id: runtimeAgentDefinitionFileIdSchema,
+  fileName: runtimeAgentDefinitionFileNameSchema.optional(),
+});
+
+export type ResolveRuntimeAgentDefinitionsDirInput = z.infer<
+  typeof resolveRuntimeAgentDefinitionsDirInputSchema
+>;
+
+export const loadRuntimeAgentMarkdownDefinitionFromFileInputSchema = z.object({
+  agentsDir: z.string().min(1),
+  id: runtimeAgentDefinitionFileIdSchema,
+  fileName: runtimeAgentDefinitionFileNameSchema.optional(),
+});
+
+export type LoadRuntimeAgentMarkdownDefinitionFromFileInput = z.infer<
+  typeof loadRuntimeAgentMarkdownDefinitionFromFileInputSchema
+>;
+
+function getRuntimeAgentDefinitionFileName(input: {
+  id: string;
+  fileName?: string;
+}): string {
+  return input.fileName ?? `${input.id}.md`;
+}
+
+function hasRuntimeAgentDefinitionFile(path: string, fileName: string): boolean {
+  return existsSync(resolve(path, fileName));
+}
+
+export function resolveRuntimeAgentDefinitionsDir(
+  input: ResolveRuntimeAgentDefinitionsDirInput,
+): string {
+  const parsedInput = resolveRuntimeAgentDefinitionsDirInputSchema.parse(input);
+  const fileName = getRuntimeAgentDefinitionFileName(parsedInput);
+  const firstCandidate = resolve(parsedInput.baseDir, "../agents");
+  const candidates = [
+    firstCandidate,
+    resolve(parsedInput.baseDir, "../../agents"),
+    resolve(parsedInput.baseDir, "../../../agents"),
+  ];
+
+  return candidates.find((candidate) => hasRuntimeAgentDefinitionFile(candidate, fileName)) ??
+    firstCandidate;
+}
+
+export function resolveRuntimeAgentMarkdownDefinitionFilePath(
+  input: LoadRuntimeAgentMarkdownDefinitionFromFileInput,
+): string {
+  const parsedInput = loadRuntimeAgentMarkdownDefinitionFromFileInputSchema.parse(input);
+
+  return resolve(
+    parsedInput.agentsDir,
+    getRuntimeAgentDefinitionFileName(parsedInput),
+  );
+}
+
+export function loadRuntimeAgentMarkdownDefinitionFromFile(
+  input: LoadRuntimeAgentMarkdownDefinitionFromFileInput,
+): RuntimeAgentMarkdownDefinition {
+  const parsedInput = loadRuntimeAgentMarkdownDefinitionFromFileInputSchema.parse(input);
+  const filePath = resolveRuntimeAgentMarkdownDefinitionFilePath(parsedInput);
+
+  return parseRuntimeAgentMarkdownDefinition({
+    id: parsedInput.id,
+    content: readFileSync(filePath, "utf-8"),
+  });
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.488";
+export const VERSION = "0.1.489";


### PR DESCRIPTION
## Summary
- add reusable hosted runtime agent definition file loading helpers
- add agent trace attribute filtering for host instrumentation adapters
- bump package version to 0.1.489 for release

## Verification
- deno test --no-check -A src/agent/runtime-agent-definition-files.test.ts src/agent/agent-trace-attributes.test.ts
- deno check src/agent/index.ts
- deno task verify:quick
- pre-push checks: format, lint, typecheck, unit tests