### PR TITLE
Add default hosted steering preparation helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.489",
+  "version": "0.1.490",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -155,13 +155,15 @@ Hosted service runtimes that fetch project instructions, skills, and
 project-scoped tool inventory from an external control plane can use
 `createDefaultHostedProjectSteeringRefresh()` from `veryfront/agent` to reuse
 the default refresh sequencing while keeping fetch and prompt-building policy
-local.
+local. Use `fetchDefaultHostedProjectSteering()` for the matching initial
+execution-preparation fetch.
 Services that prepare and stream hosted executions through Veryfront Cloud can
 use `prepareVeryfrontCloudHostedChatExecution()`,
 `createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions()`, and
-`createVeryfrontCloudRuntimeSystemMessages()` to reuse the default hosted model
+`buildVeryfrontCloudRuntimeInstructions()` to reuse the default hosted model
 normalization, model-provider, runtime system-message, durable root-run, and
-stream-watchdog wiring. Hosted services can also use `loadHostedAgentServiceEnvFiles()` before
+stream-watchdog wiring. Hosted services can also use
+`loadHostedAgentServiceEnvFiles()` before
 `parseHostedAgentServiceConfig()` to share the default env-file precedence and
 environment contract for API URL, hosted MCP URL, port, CORS origins, durable
 feature flags, and OpenTelemetry flags.

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -704,6 +704,12 @@ Hosts provide the control-plane fetchers and prompt builder, keeping product
 policy outside the framework while reusing the generic hosted refresh
 sequencing.
 
+### `fetchDefaultHostedProjectSteering(options)`
+
+Fetch initial hosted project steering for execution preparation. The helper
+returns empty steering when no project is active, otherwise fetches project
+instructions and skills in parallel with an optional host trace wrapper.
+
 ### `createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions(options)`
 
 Create the default runtime options used by prepared hosted chat execution on
@@ -717,6 +723,13 @@ Create the default runtime system messages for Veryfront Cloud hosted services.
 The helper inserts project instructions and project context blocks at the
 runtime-context marker, includes available skills, and appends environment
 context using the same prompt-block conventions as the core runtime.
+
+### `buildVeryfrontCloudRuntimeInstructions(input)`
+
+Adapt hosted chat runtime preparation input into Veryfront Cloud runtime system
+messages. This is the callback-shaped companion to
+`createVeryfrontCloudRuntimeSystemMessages()` for
+`prepareVeryfrontCloudHostedChatExecution()`.
 
 ### `resolveRuntimeAgentDefinitionsDir(options)`
 
@@ -949,9 +962,11 @@ Clear all stored messages from memory.
 | `createAgUiSseErrorResponse`                                    | Create an AG-UI SSE error `Response`                                     |
 | `createAgUiResumeHandler`                                       | Create a POST handler for hosted AG-UI run resume values                 |
 | `createDefaultHostedProjectSteeringRefresh`                     | Create the default hosted project steering refresh callback              |
+| `buildVeryfrontCloudRuntimeInstructions`                        | Adapt hosted preparation input to Veryfront Cloud system messages        |
 | `createVeryfrontCloudHostedChatExecutionRootRunOptions`         | Create Veryfront Cloud hosted root-run preparation defaults              |
 | `createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions` | Create Veryfront Cloud prepared execution runtime defaults               |
 | `createVeryfrontCloudRuntimeSystemMessages`                     | Create Veryfront Cloud runtime system messages                           |
+| `fetchDefaultHostedProjectSteering`                             | Fetch initial hosted project instructions and skills                     |
 | `filterAgentTraceAttributes`                                    | Filter unknown records to valid agent trace attributes                   |
 | `loadHostedAgentServiceEnvFiles`                                | Load hosted service env files while preserving host process env          |
 | `loadRuntimeAgentMarkdownDefinitionFromFile`                    | Load and parse a markdown agent definition from an agents directory      |

--- a/src/agent/default-hosted-project-steering-refresh.test.ts
+++ b/src/agent/default-hosted-project-steering-refresh.test.ts
@@ -1,7 +1,10 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { DefaultHostedChatRuntimeSystemRefreshInput } from "./default-hosted-chat-runtime.ts";
-import { createDefaultHostedProjectSteeringRefresh } from "./default-hosted-project-steering-refresh.ts";
+import {
+  createDefaultHostedProjectSteeringRefresh,
+  fetchDefaultHostedProjectSteering,
+} from "./default-hosted-project-steering-refresh.ts";
 import type { RuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
 import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
 
@@ -52,6 +55,60 @@ function createRefreshInput(
 }
 
 describe("agent/default-hosted-project-steering-refresh", () => {
+  it("fetches project steering in parallel for an active project", async () => {
+    const lookups: Array<{ projectId: string; authToken: string; branchId?: string | null }> = [];
+    const traceOperations: string[] = [];
+
+    const steering = await fetchDefaultHostedProjectSteering({
+      projectId: "project-1",
+      authToken: "auth-token",
+      branchId: "branch-1",
+      fetchProjectInstructions: (lookup) => {
+        lookups.push(lookup);
+        return Promise.resolve("Fresh instructions");
+      },
+      fetchSkills: (lookup) => {
+        lookups.push(lookup);
+        return Promise.resolve([createSkill("build")]);
+      },
+      trace: async (operationName, operation) => {
+        traceOperations.push(operationName);
+        return await operation();
+      },
+      traceOperationName: "test.fetchProjectSteering",
+    });
+
+    assertEquals(traceOperations, ["test.fetchProjectSteering"]);
+    assertEquals(lookups, [
+      { projectId: "project-1", authToken: "auth-token", branchId: "branch-1" },
+      { projectId: "project-1", authToken: "auth-token", branchId: "branch-1" },
+    ]);
+    assertEquals(steering, {
+      instructions: "Fresh instructions",
+      skills: [createSkill("build")],
+    });
+  });
+
+  it("returns empty steering without fetching when no project is active", async () => {
+    let fetchCount = 0;
+
+    const steering = await fetchDefaultHostedProjectSteering({
+      projectId: null,
+      authToken: "auth-token",
+      fetchProjectInstructions: () => {
+        fetchCount++;
+        return Promise.resolve("Fresh instructions");
+      },
+      fetchSkills: () => {
+        fetchCount++;
+        return Promise.resolve([createSkill("build")]);
+      },
+    });
+
+    assertEquals(fetchCount, 0);
+    assertEquals(steering, { instructions: "", skills: [] });
+  });
+
   it("refreshes instructions, filters visible skills, and records available tools", async () => {
     const lookups: Array<{ projectId: string; authToken: string; branchId?: string | null }> = [];
     const refresh = createDefaultHostedProjectSteeringRefresh({

--- a/src/agent/default-hosted-project-steering-refresh.ts
+++ b/src/agent/default-hosted-project-steering-refresh.ts
@@ -7,6 +7,7 @@ import type {
   DefaultHostedChatRuntimeSystemRefreshInput,
   DefaultHostedChatRuntimeTaskContext,
 } from "./default-hosted-chat-runtime.ts";
+import type { HostedChatRuntimePreparationSteering } from "./hosted-chat-preparation.ts";
 import type { RuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
 import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
 import { selectProviderCompatibleToolNames } from "./runtime/provider-tool-compat.ts";
@@ -23,19 +24,76 @@ export type DefaultHostedProjectSteeringRefreshLookup = {
   branchId?: string | null;
 };
 
-export type CreateDefaultHostedProjectSteeringRefreshOptions = {
+export type DefaultHostedProjectSteeringFetchers = {
   fetchProjectInstructions: (
     lookup: DefaultHostedProjectSteeringRefreshLookup,
   ) => Promise<string>;
   fetchSkills: (
     lookup: DefaultHostedProjectSteeringRefreshLookup,
   ) => Promise<RuntimeSkillDefinition[]>;
-  buildInstructions: (
-    input: HostedChatRuntimeInstructionsInput<RuntimeAgentMarkdownDefinition>,
-  ) => string | ChatSystemMessage[];
-  projectScopedRemoteToolOptions?: ProjectScopedRemoteToolOptions;
-  logger?: DefaultHostedProjectSteeringRefreshLogger;
 };
+
+export type CreateDefaultHostedProjectSteeringRefreshOptions =
+  & DefaultHostedProjectSteeringFetchers
+  & {
+    buildInstructions: (
+      input: HostedChatRuntimeInstructionsInput<RuntimeAgentMarkdownDefinition>,
+    ) => string | ChatSystemMessage[];
+    projectScopedRemoteToolOptions?: ProjectScopedRemoteToolOptions;
+    logger?: DefaultHostedProjectSteeringRefreshLogger;
+  };
+
+export type FetchDefaultHostedProjectSteeringInput =
+  & DefaultHostedProjectSteeringFetchers
+  & {
+    projectId: string | null;
+    authToken: string;
+    branchId?: string | null;
+    trace?: <TResult>(
+      operationName: string,
+      operation: () => Promise<TResult>,
+    ) => Promise<TResult>;
+    traceOperationName?: string;
+  };
+
+export async function fetchDefaultHostedProjectSteering(
+  input: FetchDefaultHostedProjectSteeringInput,
+): Promise<HostedChatRuntimePreparationSteering> {
+  const projectId = input.projectId;
+
+  if (!projectId) {
+    return { instructions: "", skills: [] };
+  }
+
+  const fetchSteering = async () => {
+    const [instructions, skills] = await Promise.all([
+      input.fetchProjectInstructions({
+        projectId,
+        authToken: input.authToken,
+        branchId: input.branchId,
+      }),
+      input.fetchSkills({
+        projectId,
+        authToken: input.authToken,
+        branchId: input.branchId,
+      }),
+    ]);
+
+    return {
+      instructions,
+      skills,
+    };
+  };
+
+  if (!input.trace) {
+    return await fetchSteering();
+  }
+
+  return await input.trace(
+    input.traceOperationName ?? "agent.fetchProjectSteering",
+    fetchSteering,
+  );
+}
 
 function getActiveProjectId(taskContext: DefaultHostedChatRuntimeTaskContext): string | null {
   return taskContext.projectId || null;

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -194,6 +194,7 @@ export {
 } from "./runtime-agent-definition.ts";
 
 export {
+  buildVeryfrontCloudRuntimeInstructions,
   createVeryfrontCloudRuntimeSystemMessages,
   type CreateVeryfrontCloudRuntimeSystemMessagesInput,
 } from "./veryfront-cloud-runtime-system-messages.ts";
@@ -270,8 +271,11 @@ export {
 export {
   createDefaultHostedProjectSteeringRefresh,
   type CreateDefaultHostedProjectSteeringRefreshOptions,
+  type DefaultHostedProjectSteeringFetchers,
   type DefaultHostedProjectSteeringRefreshLogger,
   type DefaultHostedProjectSteeringRefreshLookup,
+  fetchDefaultHostedProjectSteering,
+  type FetchDefaultHostedProjectSteeringInput,
 } from "./default-hosted-project-steering-refresh.ts";
 
 export {

--- a/src/agent/veryfront-cloud-runtime-system-messages.test.ts
+++ b/src/agent/veryfront-cloud-runtime-system-messages.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import {
+  buildVeryfrontCloudRuntimeInstructions,
   createVeryfrontCloudRuntimeSystemMessages,
 } from "./veryfront-cloud-runtime-system-messages.ts";
 import type { RuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
@@ -69,4 +70,24 @@ Deno.test("createVeryfrontCloudRuntimeSystemMessages includes skills and environ
   assertEquals(messages[1]?.role, "system");
   assertStringIncludes(messages[1]?.content ?? "", "<environment_context>");
   assertStringIncludes(messages[1]?.content ?? "", "Runtime facts");
+});
+
+Deno.test("buildVeryfrontCloudRuntimeInstructions adapts hosted preparation input", () => {
+  const messages = buildVeryfrontCloudRuntimeInstructions({
+    agentConfig: createAgent(),
+    projectId: "project-123",
+    branchId: null,
+    environmentContext: "Runtime facts",
+    instructions: "Use the project policy.",
+    skills: [],
+  });
+
+  const message = messages[0];
+  const environmentMessage = messages[1];
+
+  assertEquals(message?.role, "system");
+  assertStringIncludes(message?.content ?? "", "Use the project policy.");
+  assertStringIncludes(message?.content ?? "", 'project_reference: "project-123"');
+  assertEquals(environmentMessage?.role, "system");
+  assertStringIncludes(environmentMessage?.content ?? "", "Runtime facts");
 });

--- a/src/agent/veryfront-cloud-runtime-system-messages.ts
+++ b/src/agent/veryfront-cloud-runtime-system-messages.ts
@@ -3,6 +3,7 @@ import {
   createRuntimeAgentSystemMessages,
   type RuntimeAgentMarkdownDefinition,
 } from "./runtime-agent-definition.ts";
+import type { HostedChatRuntimeInstructionsInput } from "./hosted-chat-preparation.ts";
 import { createRuntimePromptBlock } from "./runtime-prompt-block.ts";
 import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
 
@@ -60,6 +61,19 @@ export function createVeryfrontCloudRuntimeSystemMessages(
     agent: input.agent,
     runtimeBlocks,
     skills: input.skills,
+    environmentContext: input.environmentContext,
+  });
+}
+
+export function buildVeryfrontCloudRuntimeInstructions(
+  input: HostedChatRuntimeInstructionsInput<RuntimeAgentMarkdownDefinition>,
+): ChatSystemMessage[] {
+  return createVeryfrontCloudRuntimeSystemMessages({
+    agent: input.agentConfig,
+    instructions: input.instructions || undefined,
+    skills: input.skills.length > 0 ? input.skills : undefined,
+    projectId: input.projectId,
+    branchId: input.branchId,
     environmentContext: input.environmentContext,
   });
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.489";
+export const VERSION = "0.1.490";


### PR DESCRIPTION
## Summary\n- add a reusable hosted project steering fetch helper for initial execution preparation\n- add a callback-shaped Veryfront Cloud runtime instruction builder\n- document the new hosted service helpers\n- bump package version to 0.1.490 for CI/CD publishing\n\n## Verification\n- deno check src/agent/index.ts\n- deno test --no-check -A src/agent/default-hosted-project-steering-refresh.test.ts src/agent/veryfront-cloud-runtime-system-messages.test.ts\n- deno task verify:quick\n- pre-push checks