### PR TITLE
Add Node hosted service telemetry helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.490",
+  "version": "0.1.491",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [
@@ -258,6 +258,12 @@
     "react-dom/client": "https://esm.sh/react-dom@19.2.4/client?external=react&target=es2022&deps=csstype@3.2.3",
     "react/jsx-runtime": "https://esm.sh/react@19.2.4/jsx-runtime?external=react&target=es2022&deps=csstype@3.2.3",
     "react/jsx-dev-runtime": "https://esm.sh/react@19.2.4/jsx-dev-runtime?external=react&target=es2022&deps=csstype@3.2.3",
+    "@opentelemetry/api": "npm:@opentelemetry/api@1.9.1",
+    "@opentelemetry/auto-instrumentations-node": "npm:@opentelemetry/auto-instrumentations-node@0.75.0",
+    "@opentelemetry/exporter-trace-otlp-http": "npm:@opentelemetry/exporter-trace-otlp-http@0.217.0",
+    "@opentelemetry/resources": "npm:@opentelemetry/resources@2.7.1",
+    "@opentelemetry/sdk-node": "npm:@opentelemetry/sdk-node@0.217.0",
+    "@opentelemetry/sdk-trace-base": "npm:@opentelemetry/sdk-trace-base@2.7.1",
     "@mdx-js/mdx": "npm:@mdx-js/mdx@3.1.1",
     "@babel/parser": "npm:@babel/parser@7.29.2",
     "gray-matter": "npm:gray-matter@4.0.3",

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -166,7 +166,11 @@ stream-watchdog wiring. Hosted services can also use
 `loadHostedAgentServiceEnvFiles()` before
 `parseHostedAgentServiceConfig()` to share the default env-file precedence and
 environment contract for API URL, hosted MCP URL, port, CORS origins, durable
-feature flags, and OpenTelemetry flags.
+feature flags, and OpenTelemetry flags. Node-hosted services can pair that with
+`resolveNodeHostedAgentServiceTelemetryConfig()` and
+`initializeNodeHostedAgentServiceOpenTelemetry()` to reuse the default Node SDK
+telemetry setup while keeping non-Node runtimes on the lower-level
+observability APIs.
 Use `resolveRuntimeAgentDefinitionsDir()` and
 `loadRuntimeAgentMarkdownDefinitionFromFile()` when a separately deployed
 hosted agent stores persona/configuration in `agents/*.md` files.

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -779,6 +779,20 @@ preserves variables that were already present in the host process environment,
 and lets later env files override earlier env-file values. This matches the
 recommended service bootstrap shape for separately deployed hosted agents.
 
+### `resolveNodeHostedAgentServiceTelemetryConfig(options)`
+
+Resolve the default Node hosted-agent OpenTelemetry configuration from a service
+environment. The helper centralizes `OTEL_ENABLED`, service name/version,
+sampling, exporter headers, and Node auto-instrumentation flags for separately
+deployed Node agent services.
+
+### `initializeNodeHostedAgentServiceOpenTelemetry(options)`
+
+Initialize the Node OpenTelemetry SDK for a hosted agent service using the
+configuration resolved by `resolveNodeHostedAgentServiceTelemetryConfig()`. This
+helper is intentionally Node-specific; cross-runtime service shells should keep
+using the lower-level framework observability APIs.
+
 ### `AgUiRuntimeRequestSchema`
 
 Validate the canonical open-source AG-UI runtime request contract for hosted
@@ -969,8 +983,10 @@ Clear all stored messages from memory.
 | `fetchDefaultHostedProjectSteering`                             | Fetch initial hosted project instructions and skills                     |
 | `filterAgentTraceAttributes`                                    | Filter unknown records to valid agent trace attributes                   |
 | `loadHostedAgentServiceEnvFiles`                                | Load hosted service env files while preserving host process env          |
+| `initializeNodeHostedAgentServiceOpenTelemetry`                 | Initialize Node OpenTelemetry for a hosted agent service                 |
 | `loadRuntimeAgentMarkdownDefinitionFromFile`                    | Load and parse a markdown agent definition from an agents directory      |
 | `parseHostedAgentServiceConfig`                                 | Parse default hosted agent service environment config                    |
+| `resolveNodeHostedAgentServiceTelemetryConfig`                  | Resolve Node hosted service OpenTelemetry config from environment        |
 | `prepareVeryfrontCloudHostedChatExecution`                      | Prepare hosted chat execution with Veryfront Cloud defaults              |
 | `normalizeAgUiRuntimeMessages`                                  | Normalize runtime AG-UI messages into package `Message[]`                |
 | `parseAgUiRuntimeRequest`                                       | Parse and validate the canonical runtime AG-UI request body              |

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -301,6 +301,17 @@ export {
   loadHostedAgentServiceEnvFiles,
 } from "./hosted-agent-service-env-files.ts";
 export {
+  initializeNodeHostedAgentServiceOpenTelemetry,
+  type InitializeNodeHostedAgentServiceTelemetryOptions,
+  type NodeHostedAgentServiceInstrumentationConfig,
+  type NodeHostedAgentServiceTelemetryConfig,
+  type NodeHostedAgentServiceTelemetryEnv,
+  type NodeHostedAgentServiceTelemetryLogger,
+  type NodeHostedAgentServiceTelemetryProcessTarget,
+  resolveNodeHostedAgentServiceTelemetryConfig,
+  type ResolveNodeHostedAgentServiceTelemetryConfigOptions,
+} from "./node-hosted-agent-service-telemetry.ts";
+export {
   type AgentServiceBootstrapExit,
   type AgentServiceTraceContext,
   type AgentServiceTraceContextGetter,

--- a/src/agent/node-hosted-agent-service-telemetry.test.ts
+++ b/src/agent/node-hosted-agent-service-telemetry.test.ts
@@ -1,0 +1,72 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { resolveNodeHostedAgentServiceTelemetryConfig } from "./node-hosted-agent-service-telemetry.ts";
+
+describe("agent/node-hosted-agent-service-telemetry", () => {
+  it("defaults to production-enabled hosted service telemetry", () => {
+    const config = resolveNodeHostedAgentServiceTelemetryConfig({
+      env: { NODE_ENV: "production" },
+      defaultServiceName: "agent-service",
+    });
+
+    assertEquals(config, {
+      enabled: true,
+      serviceName: "agent-service",
+      serviceVersion: "0.1.0",
+      deploymentEnvironment: "production",
+      samplingRatio: 1,
+      exporterHeaders: undefined,
+      instrumentation: {
+        http: true,
+        express: true,
+        fs: false,
+      },
+    });
+  });
+
+  it("honors explicit enable flags, headers, sampling, and instrumentation overrides", () => {
+    const config = resolveNodeHostedAgentServiceTelemetryConfig({
+      env: {
+        NODE_ENV: "test",
+        npm_package_version: "1.2.3",
+        OTEL_ENABLED: "true",
+        OTEL_SERVICE_NAME: "custom-agent",
+        OTEL_SAMPLING_RATIO: "0.5",
+        OTEL_EXPORTER_OTLP_HEADERS: "x-api-key=secret,x-tenant=myorg",
+        OTEL_INSTRUMENTATION_HTTP: "false",
+        OTEL_INSTRUMENTATION_EXPRESS: "false",
+        OTEL_INSTRUMENTATION_FS: "true",
+      },
+      defaultServiceName: "agent-service",
+    });
+
+    assertEquals(config, {
+      enabled: true,
+      serviceName: "custom-agent",
+      serviceVersion: "1.2.3",
+      deploymentEnvironment: "test",
+      samplingRatio: 0.5,
+      exporterHeaders: { "x-api-key": "secret", "x-tenant": "myorg" },
+      instrumentation: {
+        http: false,
+        express: false,
+        fs: true,
+      },
+    });
+  });
+
+  it("supports Basic authorization headers and clamps sampling ratio", () => {
+    const config = resolveNodeHostedAgentServiceTelemetryConfig({
+      env: {
+        OTEL_ENABLED: "false",
+        OTEL_SAMPLING_RATIO: "2",
+        OTEL_EXPORTER_OTLP_HEADERS: "Basic dXNlcjpwYXNz",
+      },
+      defaultServiceName: "agent-service",
+    });
+
+    assertEquals(config.enabled, false);
+    assertEquals(config.samplingRatio, 1);
+    assertEquals(config.exporterHeaders, { Authorization: "Basic dXNlcjpwYXNz" });
+  });
+});

--- a/src/agent/node-hosted-agent-service-telemetry.ts
+++ b/src/agent/node-hosted-agent-service-telemetry.ts
@@ -1,0 +1,192 @@
+export type NodeHostedAgentServiceTelemetryEnv = Record<string, string | undefined>;
+
+export type NodeHostedAgentServiceInstrumentationConfig = {
+  http: boolean;
+  express: boolean;
+  fs: boolean;
+};
+
+export type NodeHostedAgentServiceTelemetryConfig = {
+  enabled: boolean;
+  serviceName: string;
+  serviceVersion: string;
+  deploymentEnvironment: string;
+  samplingRatio: number;
+  exporterHeaders?: Record<string, string>;
+  instrumentation: NodeHostedAgentServiceInstrumentationConfig;
+};
+
+export type ResolveNodeHostedAgentServiceTelemetryConfigOptions = {
+  env: NodeHostedAgentServiceTelemetryEnv;
+  defaultServiceName: string;
+  defaultServiceVersion?: string;
+  defaultEnabled?: boolean;
+};
+
+export type NodeHostedAgentServiceTelemetryLogger = {
+  info(message: string, metadata?: Record<string, unknown>): void;
+  error(message: string, metadata?: Record<string, unknown>): void;
+};
+
+export type NodeHostedAgentServiceTelemetryProcessTarget = {
+  on(event: "SIGTERM", listener: () => void | Promise<void>): unknown;
+};
+
+export type InitializeNodeHostedAgentServiceTelemetryOptions =
+  & NodeHostedAgentServiceTelemetryConfig
+  & {
+    logger?: NodeHostedAgentServiceTelemetryLogger;
+    processTarget?: NodeHostedAgentServiceTelemetryProcessTarget;
+  };
+
+function resolveEnabled(env: NodeHostedAgentServiceTelemetryEnv, defaultEnabled: boolean): boolean {
+  const envValue = env.OTEL_ENABLED;
+  if (envValue !== undefined) {
+    return envValue !== "false" && envValue !== "0";
+  }
+  return defaultEnabled;
+}
+
+function resolveSamplingRatio(env: NodeHostedAgentServiceTelemetryEnv): number {
+  const ratio = Number.parseFloat(env.OTEL_SAMPLING_RATIO ?? "");
+  if (Number.isNaN(ratio)) return 1.0;
+  return Math.min(Math.max(ratio, 0), 1);
+}
+
+function parseExporterHeaders(headersEnv: string | undefined): Record<string, string> | undefined {
+  if (!headersEnv) return undefined;
+
+  const headers: Record<string, string> = {};
+
+  if (headersEnv.startsWith("Basic ")) {
+    headers.Authorization = headersEnv;
+  } else {
+    for (const part of headersEnv.split(",")) {
+      const [key, ...valueParts] = part.split("=");
+      if (key && valueParts.length > 0) {
+        headers[key.trim()] = valueParts.join("=").trim();
+      }
+    }
+  }
+
+  return Object.keys(headers).length > 0 ? headers : undefined;
+}
+
+function resolveInstrumentationConfig(
+  env: NodeHostedAgentServiceTelemetryEnv,
+): NodeHostedAgentServiceInstrumentationConfig {
+  return {
+    http: env.OTEL_INSTRUMENTATION_HTTP !== "false",
+    express: env.OTEL_INSTRUMENTATION_EXPRESS !== "false",
+    fs: env.OTEL_INSTRUMENTATION_FS === "true",
+  };
+}
+
+export function resolveNodeHostedAgentServiceTelemetryConfig(
+  options: ResolveNodeHostedAgentServiceTelemetryConfigOptions,
+): NodeHostedAgentServiceTelemetryConfig {
+  const defaultEnabled = options.defaultEnabled ?? options.env.NODE_ENV === "production";
+
+  return {
+    enabled: resolveEnabled(options.env, defaultEnabled),
+    serviceName: options.env.OTEL_SERVICE_NAME ?? options.defaultServiceName,
+    serviceVersion: options.env.npm_package_version ?? options.defaultServiceVersion ?? "0.1.0",
+    deploymentEnvironment: options.env.NODE_ENV ?? "development",
+    samplingRatio: resolveSamplingRatio(options.env),
+    exporterHeaders: parseExporterHeaders(options.env.OTEL_EXPORTER_OTLP_HEADERS),
+    instrumentation: resolveInstrumentationConfig(options.env),
+  };
+}
+
+function logInfo(
+  logger: NodeHostedAgentServiceTelemetryLogger | undefined,
+  message: string,
+  metadata?: Record<string, unknown>,
+): void {
+  if (logger) {
+    logger.info(message, metadata);
+    return;
+  }
+  console.log(JSON.stringify({ level: "info", msg: message, ...metadata }));
+}
+
+function logError(
+  logger: NodeHostedAgentServiceTelemetryLogger | undefined,
+  message: string,
+  error: unknown,
+): void {
+  if (logger) {
+    logger.error(message, { error: error instanceof Error ? error.message : String(error) });
+    return;
+  }
+  console.error(
+    JSON.stringify({
+      level: "error",
+      msg: message,
+      error: error instanceof Error ? error.message : String(error),
+    }),
+  );
+}
+
+export async function initializeNodeHostedAgentServiceOpenTelemetry(
+  options: InitializeNodeHostedAgentServiceTelemetryOptions,
+): Promise<boolean> {
+  if (!options.enabled) {
+    logInfo(options.logger, "OpenTelemetry disabled");
+    return false;
+  }
+
+  try {
+    const { NodeSDK } = await import("@opentelemetry/sdk-node");
+    const { resourceFromAttributes } = await import("@opentelemetry/resources");
+    const { BatchSpanProcessor, ParentBasedSampler, TraceIdRatioBasedSampler } = await import(
+      "@opentelemetry/sdk-trace-base"
+    );
+    const { OTLPTraceExporter } = await import("@opentelemetry/exporter-trace-otlp-http");
+    const { getNodeAutoInstrumentations } = await import(
+      "@opentelemetry/auto-instrumentations-node"
+    );
+
+    const resource = resourceFromAttributes({
+      "service.name": options.serviceName,
+      "service.version": options.serviceVersion,
+      "deployment.environment": options.deploymentEnvironment,
+    });
+    const traceExporter = new OTLPTraceExporter({ headers: options.exporterHeaders });
+
+    const sdk = new NodeSDK({
+      resource,
+      sampler: new ParentBasedSampler({
+        root: new TraceIdRatioBasedSampler(options.samplingRatio),
+      }),
+      spanProcessor: new BatchSpanProcessor(traceExporter, {
+        maxExportBatchSize: 100,
+        scheduledDelayMillis: 500,
+      }),
+      instrumentations: [
+        getNodeAutoInstrumentations({
+          "@opentelemetry/instrumentation-fs": { enabled: options.instrumentation.fs },
+          "@opentelemetry/instrumentation-http": { enabled: options.instrumentation.http },
+          "@opentelemetry/instrumentation-express": { enabled: options.instrumentation.express },
+        }),
+      ],
+    });
+
+    sdk.start();
+
+    logInfo(options.logger, "OpenTelemetry initialized", {
+      serviceName: options.serviceName,
+      samplingRatio: options.samplingRatio,
+    });
+
+    options.processTarget?.on("SIGTERM", async () => {
+      await sdk.shutdown();
+      logInfo(options.logger, "OpenTelemetry shutdown complete");
+    });
+
+    return true;
+  } catch (error) {
+    logError(options.logger, "Failed to initialize OpenTelemetry", error);
+    return false;
+  }
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.490";
+export const VERSION = "0.1.491";


### PR DESCRIPTION
## Summary\n- add a reusable Node hosted-service OpenTelemetry config resolver and initializer\n- export the helper from the agent framework surface\n- document the Node-specific telemetry seam for separately deployed hosted services\n- bump package version to 0.1.491\n- use current OpenTelemetry package versions so npm audit remains green\n\n## Verification\n- deno task audit\n- deno check src/agent/index.ts\n- deno test --no-check -A src/agent/node-hosted-agent-service-telemetry.test.ts\n- deno task verify:quick\n- pre-push checks: fmt, lint, typecheck, unit tests (1810 passed)