### PR TITLE
Add Node hosted service infrastructure helper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.491",
+  "version": "0.1.492",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -167,8 +167,8 @@ stream-watchdog wiring. Hosted services can also use
 `parseHostedAgentServiceConfig()` to share the default env-file precedence and
 environment contract for API URL, hosted MCP URL, port, CORS origins, durable
 feature flags, and OpenTelemetry flags. Node-hosted services can pair that with
-`resolveNodeHostedAgentServiceTelemetryConfig()` and
-`initializeNodeHostedAgentServiceOpenTelemetry()` to reuse the default Node SDK
+`createNodeHostedAgentServiceRuntimeInfrastructure()` to reuse the default
+config parsing, logger, service tracer, trace-context getter, and Node SDK
 telemetry setup while keeping non-Node runtimes on the lower-level
 observability APIs.
 Use `resolveRuntimeAgentDefinitionsDir()` and

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -793,6 +793,14 @@ configuration resolved by `resolveNodeHostedAgentServiceTelemetryConfig()`. This
 helper is intentionally Node-specific; cross-runtime service shells should keep
 using the lower-level framework observability APIs.
 
+### `createNodeHostedAgentServiceRuntimeInfrastructure(options)`
+
+Create the standard Node hosted service infrastructure bundle for separately
+deployed agent services: hosted service config parsing, component logger,
+service tracer, active-span attribute setter, trace-context getter, and Node
+OpenTelemetry startup. The helper is intentionally Node-specific because it
+binds the npm OpenTelemetry API and Node SDK startup path.
+
 ### `AgUiRuntimeRequestSchema`
 
 Validate the canonical open-source AG-UI runtime request contract for hosted
@@ -982,6 +990,7 @@ Clear all stored messages from memory.
 | `createVeryfrontCloudRuntimeSystemMessages`                     | Create Veryfront Cloud runtime system messages                           |
 | `fetchDefaultHostedProjectSteering`                             | Fetch initial hosted project instructions and skills                     |
 | `filterAgentTraceAttributes`                                    | Filter unknown records to valid agent trace attributes                   |
+| `createNodeHostedAgentServiceRuntimeInfrastructure`             | Create Node hosted service config, logger, tracer, and telemetry bundle  |
 | `loadHostedAgentServiceEnvFiles`                                | Load hosted service env files while preserving host process env          |
 | `initializeNodeHostedAgentServiceOpenTelemetry`                 | Initialize Node OpenTelemetry for a hosted agent service                 |
 | `loadRuntimeAgentMarkdownDefinitionFromFile`                    | Load and parse a markdown agent definition from an agents directory      |

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -312,6 +312,11 @@ export {
   type ResolveNodeHostedAgentServiceTelemetryConfigOptions,
 } from "./node-hosted-agent-service-telemetry.ts";
 export {
+  createNodeHostedAgentServiceRuntimeInfrastructure,
+  type CreateNodeHostedAgentServiceRuntimeInfrastructureOptions,
+  type NodeHostedAgentServiceRuntimeInfrastructure,
+} from "./node-hosted-agent-service-runtime-infrastructure.ts";
+export {
   type AgentServiceBootstrapExit,
   type AgentServiceTraceContext,
   type AgentServiceTraceContextGetter,

--- a/src/agent/node-hosted-agent-service-runtime-infrastructure.test.ts
+++ b/src/agent/node-hosted-agent-service-runtime-infrastructure.test.ts
@@ -1,0 +1,36 @@
+import { assertEquals, assertObjectMatch } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createNodeHostedAgentServiceRuntimeInfrastructure } from "./node-hosted-agent-service-runtime-infrastructure.ts";
+
+describe("createNodeHostedAgentServiceRuntimeInfrastructure", () => {
+  it("binds hosted service config, logging, tracing, and disabled telemetry startup", async () => {
+    const infoMessages: string[] = [];
+    const infrastructure = createNodeHostedAgentServiceRuntimeInfrastructure({
+      serviceName: "custom-service",
+      env: {
+        VERYFRONT_API_URL: "https://api.example.com",
+        ALLOWED_ORIGINS: "https://studio.example.com",
+        OTEL_ENABLED: "false",
+      },
+      telemetryLogger: {
+        info(message) {
+          infoMessages.push(message);
+        },
+        error(message) {
+          throw new Error(message);
+        },
+      },
+    });
+
+    assertObjectMatch(infrastructure.getConfig(), {
+      VERYFRONT_API_URL: "https://api.example.com",
+      VERYFRONT_MCP_URL: "https://api.example.com/mcp",
+      ALLOWED_ORIGINS: ["https://studio.example.com"],
+    });
+    assertEquals(typeof infrastructure.logger.info, "function");
+    assertEquals(typeof infrastructure.tracer.trace, "function");
+    assertEquals(infrastructure.getTraceContext(), {});
+    assertEquals(await infrastructure.initializeOpenTelemetry(), false);
+    assertEquals(infoMessages, ["OpenTelemetry disabled"]);
+  });
+});

--- a/src/agent/node-hosted-agent-service-runtime-infrastructure.ts
+++ b/src/agent/node-hosted-agent-service-runtime-infrastructure.ts
@@ -1,0 +1,63 @@
+import * as api from "@opentelemetry/api";
+import {
+  createOpenTelemetryServiceTracer,
+  type ServiceTracerAttributes,
+} from "../observability/tracing/service-tracer.ts";
+import { agentLogger, type Logger } from "../utils/logger/index.ts";
+import {
+  type HostedAgentServiceConfig,
+  type HostedAgentServiceConfigInput,
+  parseHostedAgentServiceConfig,
+} from "./hosted-agent-service-config.ts";
+import {
+  initializeNodeHostedAgentServiceOpenTelemetry,
+  type NodeHostedAgentServiceTelemetryEnv,
+  type NodeHostedAgentServiceTelemetryLogger,
+  type NodeHostedAgentServiceTelemetryProcessTarget,
+  resolveNodeHostedAgentServiceTelemetryConfig,
+} from "./node-hosted-agent-service-telemetry.ts";
+
+export type CreateNodeHostedAgentServiceRuntimeInfrastructureOptions = {
+  serviceName: string;
+  env: HostedAgentServiceConfigInput & NodeHostedAgentServiceTelemetryEnv;
+  telemetryLogger?: NodeHostedAgentServiceTelemetryLogger;
+  processTarget?: NodeHostedAgentServiceTelemetryProcessTarget;
+};
+
+export type NodeHostedAgentServiceRuntimeInfrastructure = {
+  getConfig(): HostedAgentServiceConfig;
+  logger: Logger;
+  tracer: ReturnType<typeof createOpenTelemetryServiceTracer>["tracer"];
+  setActiveSpanAttributes(attributes: ServiceTracerAttributes): void;
+  getTraceContext(): { traceId?: string; spanId?: string };
+  initializeOpenTelemetry(): Promise<boolean>;
+};
+
+export function createNodeHostedAgentServiceRuntimeInfrastructure(
+  options: CreateNodeHostedAgentServiceRuntimeInfrastructureOptions,
+): NodeHostedAgentServiceRuntimeInfrastructure {
+  const telemetryConfig = resolveNodeHostedAgentServiceTelemetryConfig({
+    env: options.env,
+    defaultServiceName: options.serviceName,
+  });
+  const serviceTracer = createOpenTelemetryServiceTracer({
+    serviceName: telemetryConfig.serviceName,
+    context: api.context,
+    trace: api.trace,
+    errorStatusCode: api.SpanStatusCode.ERROR,
+  });
+
+  return {
+    getConfig: () => parseHostedAgentServiceConfig(options.env),
+    logger: agentLogger.component(options.serviceName),
+    tracer: serviceTracer.tracer,
+    setActiveSpanAttributes: serviceTracer.setActiveSpanAttributes,
+    getTraceContext: serviceTracer.getTraceContext,
+    initializeOpenTelemetry: () =>
+      initializeNodeHostedAgentServiceOpenTelemetry({
+        ...telemetryConfig,
+        logger: options.telemetryLogger,
+        processTarget: options.processTarget,
+      }),
+  };
+}

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.491";
+export const VERSION = "0.1.492";


### PR DESCRIPTION
## Summary\n- add a Node hosted service infrastructure helper for config parsing, component logging, service tracing, trace context, and telemetry startup\n- export the helper from the agent runtime surface\n- document the Node-specific service infrastructure bundle for separately deployed hosted services\n\n## Verification\n- deno check src/agent/index.ts\n- deno test --no-check -A src/agent/node-hosted-agent-service-runtime-infrastructure.test.ts\n- deno task verify:quick\n- pre-push checks\n