### PR TITLE
ci(audit-deps): promote unpinned npm imports from warning to error

### DIFF
--- a/scripts/lint/audit-deps.test.ts
+++ b/scripts/lint/audit-deps.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "#std/assert";
 import { describe, it } from "jsr:@std/testing/bdd";
-import { auditEsmShPin } from "./audit-deps.ts";
+import { auditEsmShPin, auditNpmPin } from "./audit-deps.ts";
 
 describe("auditEsmShPin", () => {
   it("accepts exact x.y.z pins", () => {
@@ -48,5 +48,53 @@ describe("auditEsmShPin", () => {
   it("rejects scoped packages with major-only pins", () => {
     const issue = auditEsmShPin("https://esm.sh/@types/react@19?deps=csstype@3.2.3");
     assertEquals(issue?.severity, "error");
+  });
+});
+
+describe("auditNpmPin", () => {
+  it("accepts exact x.y.z pins", () => {
+    assertEquals(auditNpmPin("npm:react@19.2.4"), null);
+  });
+
+  it("accepts scoped packages with exact pins", () => {
+    assertEquals(auditNpmPin("npm:@types/react@19.2.14"), null);
+  });
+
+  it("accepts pre-release suffixes on x.y.z pins", () => {
+    assertEquals(auditNpmPin("npm:react@19.2.4-rc.1"), null);
+  });
+
+  it("accepts subpath imports after an exact pin", () => {
+    assertEquals(auditNpmPin("npm:react-dom@19.2.4/server"), null);
+  });
+
+  it("rejects bare names (no version)", () => {
+    const issue = auditNpmPin("npm:react");
+    assertEquals(issue?.severity, "error");
+  });
+
+  it("rejects major-only pins", () => {
+    const issue = auditNpmPin("npm:react@19");
+    assertEquals(issue?.severity, "error");
+  });
+
+  it("rejects caret/tilde ranges", () => {
+    const issue = auditNpmPin("npm:react@^19.2.4");
+    assertEquals(issue?.severity, "error");
+  });
+
+  it("rejects wildcard (npm:foo@*)", () => {
+    const issue = auditNpmPin("npm:react@*");
+    assertEquals(issue?.severity, "error");
+  });
+
+  it("rejects scoped packages with major-only pins", () => {
+    const issue = auditNpmPin("npm:@types/react@19");
+    assertEquals(issue?.severity, "error");
+  });
+
+  it("returns null for non-npm targets", () => {
+    assertEquals(auditNpmPin("https://esm.sh/react@19.2.4"), null);
+    assertEquals(auditNpmPin("jsr:@std/assert@1.0.0"), null);
   });
 });

--- a/scripts/lint/audit-deps.ts
+++ b/scripts/lint/audit-deps.ts
@@ -2,11 +2,11 @@
  * Dependency audit script — flags supply chain risks in deno.json imports.
  *
  * Checks for:
- * - Unpinned npm versions (e.g., "npm:foo" without @x.y.z)
- * - git:// or tarball URLs
- * - Non-https URLs (except local paths)
- * - esm.sh URLs without exact x.y.z version pins
- * - Non-esm.sh https CDNs (warning)
+ * - Unpinned npm versions (e.g., "npm:foo" without @x.y.z) → error
+ * - git:// or tarball URLs → error
+ * - Non-https URLs (except local paths) → error
+ * - esm.sh URLs without exact x.y.z version pins → error
+ * - Non-esm.sh https CDNs → warning
  *
  * Usage: deno run --allow-read scripts/lint/audit-deps.ts
  */
@@ -19,6 +19,10 @@ export interface AuditIssue {
   severity: Severity;
   message: string;
 }
+
+// Shared by auditEsmShPin and auditNpmPin so both CDN paths apply the same
+// definition of "pinned". Allows pre-release suffixes (e.g., 1.2.3-rc.1).
+const EXACT_SEMVER_RE = /^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$/;
 
 /**
  * Inspect an https:// import target. Returns null when the target is fine
@@ -56,12 +60,37 @@ export function auditEsmShPin(target: string, specifier = ""): AuditIssue | null
   }
   const ver = versionMatch[1];
 
-  if (!/^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$/.test(ver)) {
+  if (!EXACT_SEMVER_RE.test(ver)) {
     return {
       specifier,
       target,
       severity: "error",
       message: `esm.sh URL not pinned to exact x.y.z (got "${ver}")`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Inspect an npm: import target. Returns null when the target is pinned to
+ * exact x.y.z (optionally with a pre-release suffix). Otherwise reports an
+ * error. Mirrors `auditEsmShPin` so the two CDN paths can't silently diverge
+ * on what counts as "pinned" — the SECURITY.md policy promises the same
+ * guarantee for both.
+ */
+export function auditNpmPin(target: string, specifier = ""): AuditIssue | null {
+  if (!target.startsWith("npm:")) return null;
+  // npm:[@scope/]name@version[/subpath]
+  const match = target.match(/^npm:(?:@[^/@]+\/[^@/]+|[^@/]+)@([^/]+)/);
+  const ver = match?.[1];
+  if (!ver || !EXACT_SEMVER_RE.test(ver)) {
+    return {
+      specifier,
+      target,
+      severity: "error",
+      message: ver
+        ? `Unpinned npm version — specify exact x.y.z (got "${ver}")`
+        : "Unpinned npm version — specify exact version (x.y.z) for reproducibility",
     };
   }
   return null;
@@ -98,16 +127,8 @@ if (import.meta.main) {
     }
 
     if (target.startsWith("npm:")) {
-      const hasExactVersion = target.match(/npm:.+@\d+\.\d+\.\d/);
-      if (!hasExactVersion) {
-        issues.push({
-          specifier,
-          target,
-          severity: "warning",
-          message:
-            "Unpinned npm version — specify exact version (x.y.z) for reproducibility",
-        });
-      }
+      const issue = auditNpmPin(target, specifier);
+      if (issue) issues.push(issue);
       continue;
     }
 


### PR DESCRIPTION
## Summary

Promotes unpinned `npm:` imports from `warning` to `error` in `scripts/lint/audit-deps.ts`, so `deno task lint:deps` exits non-zero when a PR adds an unpinned npm specifier — matching the existing behavior for `esm.sh`.

PR #1549 already made `esm.sh` strict. The `npm:` side stayed as a warning, which meant a PR could add `npm:foo@^1` or `npm:foo@*` and the lint would still pass. SECURITY.md (PR #1550) and the supply-chain plan both claim symmetric enforcement for the two CDNs; this change makes the code match the claim.

## Changes

- Extract `auditNpmPin()` exported function mirroring `auditEsmShPin()` shape — both now share a single `EXACT_SEMVER_RE` constant so the two CDN paths can't silently diverge on what counts as "pinned".
- Promote unpinned-npm severity from `"warning"` to `"error"`.
- Inline the call from the main loop instead of duplicating the regex.
- Update header doc comment so the per-bucket severity is explicit.
- Add 10 test cases for `auditNpmPin` mirroring esm.sh coverage: exact pins, scoped pins, pre-release, subpath, bare name, major-only, caret/tilde, wildcard, scoped major-only, non-npm targets.

## Why now

PR #1550 (SECURITY.md rewrite) makes the policy claim "all `npm:` and `esm.sh` imports are required to declare exact `x.y.z` versions, enforced by `scripts/lint/audit-deps.ts`." That claim is overstated for `npm:` today. Two paths to alignment:

- **Tighten the script (this PR).** Then #1550's text is accurate as-written.
- Soften #1550's text to document the gap.

This PR is the first option because the gap is small (3 lines flipped + symmetry refactor + tests) and the policy already implies the intent.

## Backwards-compat impact

Audited at the time of writing:
- Root `deno.json` `imports`: 0 unpinned `npm:` entries.
- All `extensions/ext-*/deno.json` `imports`: 0 unpinned `npm:` entries.
- `deno task lint:deps` on this branch's `main` baseline: `✅ No supply chain issues found in dependency imports.`

So no existing PRs need to fix unpinned specifiers. Future PRs that add `npm:foo@^1`, `npm:foo@*`, or `npm:foo` (bare) will fail the lint and need to specify `x.y.z`.

## Test plan

- [x] `deno task test:scripts` — 26 passed, 0 failed (10 new auditNpmPin tests).
- [x] `deno task lint:deps` on the branch — exits 0 (no unpinned npm in tree).
- [x] `deno check scripts/lint/audit-deps.ts scripts/lint/audit-deps.test.ts` — clean.
- [x] Pre-push hook (deno fmt --check, deno lint, deno check src/index.ts, deno task test:unit) — 1795 tests pass.
- [ ] CI green on this branch.

## Followup

After this lands, PR #1550's SECURITY.md text needs no further edits — the "enforced by audit-deps.ts" claim becomes accurate for both CDN paths.
