### PR TITLE
docs(extensions): add README.md to the 8 extensions missing one

### DIFF
--- a/extensions/ext-babel/README.md
+++ b/extensions/ext-babel/README.md
@@ -1,0 +1,28 @@
+# @veryfront/ext-babel
+
+Veryfront extension that registers the `CodeParser` contract, backed by `@babel/parser`, `@babel/traverse`, `@babel/generator`, and `@babel/types`. Used by Veryfront's transform pipeline and the Studio Navigator to parse, traverse, and generate JavaScript / TypeScript AST.
+
+## Installation
+
+Add the extension to your project's `veryfront.config.ts`:
+
+```ts
+import extBabel from "@veryfront/ext-babel";
+
+export default defineConfig({
+  extensions: [extBabel()],
+});
+```
+
+## Provided contract
+
+`CodeParser` — exposes:
+
+- `parse(source, options)` / `traverse(ast, visitor)` / `generate(ast, options)` — generic AST pipeline for callers that want to build custom transforms.
+- `injectJsxNodePositions(source, options)` — the Studio Navigator helper that stamps `data-node-*` attributes onto JSX elements at compile time.
+
+Core's `src/transforms/plugins/babel-node-positions.ts` is a thin shim that resolves this contract at call time. When the extension is not installed and the shim is invoked, Veryfront throws an install-suggestion error directing the user to add `@veryfront/ext-babel`.
+
+## Configuration
+
+No factory options. The extension reads no environment variables and takes no config.

--- a/extensions/ext-esbuild/README.md
+++ b/extensions/ext-esbuild/README.md
@@ -21,10 +21,10 @@ export default defineConfig({
 
 ## Provided contracts
 
-| Contract     | Implementation   | Backed by         |
-| ------------ | ---------------- | ----------------- |
-| `Bundler`    | `EsbuildBundler` | `esbuild`         |
-| `ModuleLexer`| `EsModuleLexer`  | `es-module-lexer` |
+| Contract      | Implementation   | Backed by         |
+| ------------- | ---------------- | ----------------- |
+| `Bundler`     | `EsbuildBundler` | `esbuild`         |
+| `ModuleLexer` | `EsModuleLexer`  | `es-module-lexer` |
 
 Both classes are also exported by name so callers can construct an instance outside the registry:
 

--- a/extensions/ext-esbuild/README.md
+++ b/extensions/ext-esbuild/README.md
@@ -1,0 +1,41 @@
+# @veryfront/ext-esbuild
+
+Veryfront extension that registers two contracts:
+
+- **`Bundler`** — esbuild-backed module bundler (`EsbuildBundler`)
+- **`ModuleLexer`** — es-module-lexer-backed ESM scanner (`EsModuleLexer`)
+
+These are the default implementations Veryfront expects for both the runtime build pipeline and module-graph analysis. Without this extension, both surfaces throw an install-suggestion error.
+
+## Installation
+
+Add the extension to your project's `veryfront.config.ts`:
+
+```ts
+import extEsbuild from "@veryfront/ext-esbuild";
+
+export default defineConfig({
+  extensions: [extEsbuild()],
+});
+```
+
+## Provided contracts
+
+| Contract     | Implementation   | Backed by         |
+| ------------ | ---------------- | ----------------- |
+| `Bundler`    | `EsbuildBundler` | `esbuild`         |
+| `ModuleLexer`| `EsModuleLexer`  | `es-module-lexer` |
+
+Both classes are also exported by name so callers can construct an instance outside the registry:
+
+```ts
+import { EsbuildBundler, EsModuleLexer } from "@veryfront/ext-esbuild";
+```
+
+## Configuration
+
+No factory options. The extension reads no environment variables and takes no config.
+
+## Lifecycle
+
+The factory's `teardown()` calls `EsbuildBundler.stop()` to release the esbuild service on shutdown.

--- a/extensions/ext-jwt/README.md
+++ b/extensions/ext-jwt/README.md
@@ -16,8 +16,8 @@ export default defineConfig({
 
 ## Environment Variables
 
-| Variable     | Required               | Description                                                                       |
-| ------------ | ---------------------- | --------------------------------------------------------------------------------- |
+| Variable     | Required                | Description                                                                      |
+| ------------ | ----------------------- | -------------------------------------------------------------------------------- |
 | `JWT_SECRET` | Yes (for sign / verify) | HMAC secret for symmetric JWT operations. Without it, `sign` and `verify` throw. |
 
 ## Factory configuration

--- a/extensions/ext-jwt/README.md
+++ b/extensions/ext-jwt/README.md
@@ -1,0 +1,45 @@
+# @veryfront/ext-jwt
+
+Veryfront extension that registers the `AuthProvider` contract, backed by [`jose`](https://github.com/panva/jose). Provides HMAC-based JWT sign / verify (HS256 by default), remote-JWKS verification, and protected-header decoding.
+
+## Installation
+
+Add the extension to your project's `veryfront.config.ts`:
+
+```ts
+import extJwt from "@veryfront/ext-jwt";
+
+export default defineConfig({
+  extensions: [extJwt()],
+});
+```
+
+## Environment Variables
+
+| Variable     | Required               | Description                                                                       |
+| ------------ | ---------------------- | --------------------------------------------------------------------------------- |
+| `JWT_SECRET` | Yes (for sign / verify) | HMAC secret for symmetric JWT operations. Without it, `sign` and `verify` throw. |
+
+## Factory configuration
+
+```ts
+extJwt({
+  secret: "...",                  // overrides JWT_SECRET when set
+  jwksResolverFactory: (url) => /* custom JWKS resolver — test seam */,
+});
+```
+
+Both fields are optional. `jwksResolverFactory` is primarily a test seam — production callers should leave it unset so `createRemoteJWKSet` resolves the real JWKS URL.
+
+## Provided contract
+
+`AuthProvider` — supports:
+
+- `sign(payload, options)` — HS256 JWT signing using the configured / env secret.
+- `verify(token, options)` — symmetric verification using the same secret.
+- `verifyWithJwks(token, jwksUrl, options)` — remote-JWKS verification, with the JWKS document cached per URL by `createRemoteJWKSet`.
+- `decodeHeader(token)` — read `kid`, `alg`, etc. without verifying the signature.
+
+## Capabilities
+
+- **net `*`:** `createRemoteJWKSet` fetches JWKS documents from arbitrary issuers at verify time.

--- a/extensions/ext-mdx/README.md
+++ b/extensions/ext-mdx/README.md
@@ -24,9 +24,9 @@ export default defineConfig({
 
 ## Default plugin stack
 
-| Phase  | Plugins                                                                                            |
-| ------ | -------------------------------------------------------------------------------------------------- |
-| remark | `remark-gfm`, `remark-frontmatter`                                                                 |
+| Phase  | Plugins                                                                                                       |
+| ------ | ------------------------------------------------------------------------------------------------------------- |
+| remark | `remark-gfm`, `remark-frontmatter`                                                                            |
 | rehype | `rehype-slug`, `rehype-highlight`, `rehype-starry-night`, `rehype-raw`, `rehype-sanitize`, `rehype-stringify` |
 
 Pass `plugins.remark` / `plugins.rehype` in `ContentCompileOptions` to extend the stack at the call site.

--- a/extensions/ext-mdx/README.md
+++ b/extensions/ext-mdx/README.md
@@ -1,0 +1,40 @@
+# @veryfront/ext-mdx
+
+Veryfront extension that registers the `ContentTransformer` contract, backed by [`@mdx-js/mdx`](https://github.com/mdx-js/mdx) and the [`unified`](https://unifiedjs.com/) ecosystem. Compiles MDX and Markdown into runtime React bundles, with sanitized HTML output, frontmatter extraction, and heading collection.
+
+## Installation
+
+Add the extension to your project's `veryfront.config.ts`:
+
+```ts
+import extMdx from "@veryfront/ext-mdx";
+
+export default defineConfig({
+  extensions: [extMdx()],
+});
+```
+
+## Provided contract
+
+`ContentTransformer` — exposes:
+
+- `compileMdx(options)` — runs `@mdx-js/mdx` through Veryfront's bundled remark + rehype plugin stack and returns compiled ESM, extracted headings, and frontmatter.
+- `compileMarkdown(options)` — runs a unified Markdown pipeline (`remark-parse` → `remark-rehype` → `rehype-sanitize` → `rehype-stringify`) producing sanitized HTML wrapped in a React component.
+- `getRemarkPlugins()` / `getRehypePlugins()` — returns the configured plugin list so callers can build a custom pipeline.
+
+## Default plugin stack
+
+| Phase  | Plugins                                                                                            |
+| ------ | -------------------------------------------------------------------------------------------------- |
+| remark | `remark-gfm`, `remark-frontmatter`                                                                 |
+| rehype | `rehype-slug`, `rehype-highlight`, `rehype-starry-night`, `rehype-raw`, `rehype-sanitize`, `rehype-stringify` |
+
+Pass `plugins.remark` / `plugins.rehype` in `ContentCompileOptions` to extend the stack at the call site.
+
+## Configuration
+
+No factory options. The extension reads no environment variables and takes no config.
+
+## Behavior when missing
+
+If the extension is not installed and core's MDX or Markdown transformer is invoked, Veryfront throws an actionable install message pointing to `@veryfront/ext-mdx`.

--- a/extensions/ext-node-compat/README.md
+++ b/extensions/ext-node-compat/README.md
@@ -1,0 +1,36 @@
+# @veryfront/ext-node-compat
+
+Veryfront extension that registers the `NodeCompat` contract — Node-style compatibility shims for SQLite-backed persistence and document text extraction.
+
+## Installation
+
+Add the extension to your project's `veryfront.config.ts`:
+
+```ts
+import extNodeCompat from "@veryfront/ext-node-compat";
+
+export default defineConfig({
+  extensions: [extNodeCompat()],
+});
+```
+
+## Provided contract
+
+`NodeCompat` — exposes:
+
+- `openSqliteDatabase(path?)` — opens a SQLite database via `better-sqlite3`. Defaults to `:memory:`; pass a file path for persistent storage.
+- `importKreuzberg()` — loads the [Kreuzberg](https://kreuzberg.dev) document-text extractor. Uses `@kreuzberg/wasm` on Deno and `@kreuzberg/node` on Node / Bun.
+- `extractInWorker(buffer, mimeType)` — runs Kreuzberg extraction inside an isolated Deno Worker with a 30-second timeout, so a hung WASM call cannot block the server.
+
+## When you need this
+
+- The Veryfront proxy / KV layer falls back to in-memory storage without this extension. Install it for persistent local development storage or any production deployment that doesn't have an external KV backing.
+- Document upload and text-extraction features (PDF, DOCX, images, etc.) are unavailable without it.
+
+## Capabilities
+
+- **fs (read + write):** SQLite database files and Kreuzberg temporary files.
+
+## Configuration
+
+No factory options. The SQLite database path is passed per-call to `openSqliteDatabase`.

--- a/extensions/ext-opentelemetry/README.md
+++ b/extensions/ext-opentelemetry/README.md
@@ -18,12 +18,12 @@ export default defineConfig({
 
 The extension reads the standard OpenTelemetry env vars at setup time:
 
-| Variable                       | Required          | Description                                                                          |
-| ------------------------------ | ----------------- | ------------------------------------------------------------------------------------ |
-| `OTEL_EXPORTER_OTLP_ENDPOINT`  | Yes (for export)  | Collector URL — e.g. `http://localhost:4318/v1/traces`                                |
-| `OTEL_EXPORTER_OTLP_HEADERS`   | No                | Comma-separated `key=value` pairs (commonly used for auth tokens)                    |
-| `OTEL_SERVICE_NAME`            | No                | Service name attached to spans                                                       |
-| `OTEL_TRACES_ENABLED`          | No                | Set to `false` to disable tracing without removing the extension                     |
+| Variable                      | Required         | Description                                                       |
+| ----------------------------- | ---------------- | ----------------------------------------------------------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes (for export) | Collector URL — e.g. `http://localhost:4318/v1/traces`            |
+| `OTEL_EXPORTER_OTLP_HEADERS`  | No               | Comma-separated `key=value` pairs (commonly used for auth tokens) |
+| `OTEL_SERVICE_NAME`           | No               | Service name attached to spans                                    |
+| `OTEL_TRACES_ENABLED`         | No               | Set to `false` to disable tracing without removing the extension  |
 
 Explicit config under `ctx.config.otel` wins over env vars.
 

--- a/extensions/ext-opentelemetry/README.md
+++ b/extensions/ext-opentelemetry/README.md
@@ -1,0 +1,58 @@
+# @veryfront/ext-opentelemetry
+
+Veryfront extension that registers the `TracingExporter` contract, backed by the [OpenTelemetry JS SDK](https://github.com/open-telemetry/opentelemetry-js). Exports trace spans over OTLP / HTTP to any OTel-compatible collector.
+
+## Installation
+
+Add the extension to your project's `veryfront.config.ts`:
+
+```ts
+import extOpenTelemetry from "@veryfront/ext-opentelemetry";
+
+export default defineConfig({
+  extensions: [extOpenTelemetry()],
+});
+```
+
+## Environment Variables
+
+The extension reads the standard OpenTelemetry env vars at setup time:
+
+| Variable                       | Required          | Description                                                                          |
+| ------------------------------ | ----------------- | ------------------------------------------------------------------------------------ |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`  | Yes (for export)  | Collector URL — e.g. `http://localhost:4318/v1/traces`                                |
+| `OTEL_EXPORTER_OTLP_HEADERS`   | No                | Comma-separated `key=value` pairs (commonly used for auth tokens)                    |
+| `OTEL_SERVICE_NAME`            | No                | Service name attached to spans                                                       |
+| `OTEL_TRACES_ENABLED`          | No                | Set to `false` to disable tracing without removing the extension                     |
+
+Explicit config under `ctx.config.otel` wins over env vars.
+
+## Factory configuration
+
+```ts
+extOpenTelemetry();
+```
+
+Configuration is read from `ctx.config.otel`:
+
+```ts
+config = {
+  otel: {
+    serviceName: "my-app",
+    serviceVersion: "1.0.0",
+    endpoint: "http://collector:4318/v1/traces",
+    headers: { authorization: "Bearer <token>" },
+  },
+};
+```
+
+## Provided contract
+
+`TracingExporter` — Veryfront's core shim calls `getProvider()` to wire the SDK's `TracerProvider` into framework-emitted spans. Spans are batched and exported by the SDK's `BatchSpanProcessor`; `export(spans)` on the contract is intentionally a no-op (the SDK owns the export pipeline).
+
+`start(config)` constructs the provider + OTLP HTTP exporter; `shutdown()` flushes and shuts down the provider.
+
+## Capabilities
+
+- **net `*`:** OTLP exporter reaches the configured collector.
+- **env:** reads the four `OTEL_*` variables listed above.

--- a/extensions/ext-redis/README.md
+++ b/extensions/ext-redis/README.md
@@ -16,10 +16,10 @@ export default defineConfig({
 
 ## Environment Variables
 
-| Variable       | Required                       | Description                                                                |
-| -------------- | ------------------------------ | -------------------------------------------------------------------------- |
+| Variable       | Required                       | Description                                                                  |
+| -------------- | ------------------------------ | ---------------------------------------------------------------------------- |
 | `REDIS_URL`    | Yes (if explicit config unset) | Redis connection URL — e.g. `redis://localhost:6379` or `rediss://...` (TLS) |
-| `REDIS_PREFIX` | No                             | Key prefix for all stored entries (default: none)                          |
+| `REDIS_PREFIX` | No                             | Key prefix for all stored entries (default: none)                            |
 
 Explicit config under `ctx.config.proxy.cache.redis` wins over env vars.
 
@@ -33,8 +33,8 @@ config = {
     cache: {
       type: "redis",
       redis: {
-        url: "redis://...",       // or REDIS_URL
-        prefix: "vf:",            // or REDIS_PREFIX
+        url: "redis://...", // or REDIS_URL
+        prefix: "vf:", // or REDIS_PREFIX
         tls: true,
         username: "...",
         password: "...",

--- a/extensions/ext-redis/README.md
+++ b/extensions/ext-redis/README.md
@@ -1,0 +1,56 @@
+# @veryfront/ext-redis
+
+Veryfront extension that registers the `TokenCacheStore` contract, backed by Redis. Used by the Veryfront proxy to persist OAuth tokens across processes — the in-memory fallback works for a single-process dev server but loses tokens on restart and doesn't share across workers.
+
+## Installation
+
+Add the extension to your project's `veryfront.config.ts`:
+
+```ts
+import extRedis from "@veryfront/ext-redis";
+
+export default defineConfig({
+  extensions: [extRedis()],
+});
+```
+
+## Environment Variables
+
+| Variable       | Required                       | Description                                                                |
+| -------------- | ------------------------------ | -------------------------------------------------------------------------- |
+| `REDIS_URL`    | Yes (if explicit config unset) | Redis connection URL — e.g. `redis://localhost:6379` or `rediss://...` (TLS) |
+| `REDIS_PREFIX` | No                             | Key prefix for all stored entries (default: none)                          |
+
+Explicit config under `ctx.config.proxy.cache.redis` wins over env vars.
+
+## Factory configuration
+
+Configuration is read from `ctx.config.proxy.cache.redis` at setup time:
+
+```ts
+config = {
+  proxy: {
+    cache: {
+      type: "redis",
+      redis: {
+        url: "redis://...",       // or REDIS_URL
+        prefix: "vf:",            // or REDIS_PREFIX
+        tls: true,
+        username: "...",
+        password: "...",
+        connectTimeout: 5000,
+      },
+    },
+  },
+};
+```
+
+`url` is required; the rest are optional.
+
+## Provided contract
+
+`TokenCacheStore` — `get(key)`, `set(key, value, ttlMs?)`, `delete(key)`. Used by the proxy's OAuth flow to cache access and refresh tokens.
+
+## Capabilities
+
+- **net `*`:** Redis connection. Narrow to a specific host in your own deployment policy if you're not using a wildcard.

--- a/extensions/ext-tailwind/README.md
+++ b/extensions/ext-tailwind/README.md
@@ -1,0 +1,39 @@
+# @veryfront/ext-tailwind
+
+Veryfront extension that registers the `CSSProcessor` contract, backed by Tailwind CSS v4. Compiles stylesheets at render time and supports dynamic plugin loading from CDN.
+
+## Installation
+
+Add the extension to your project's `veryfront.config.ts`:
+
+```ts
+import extTailwind from "@veryfront/ext-tailwind";
+
+export default defineConfig({
+  extensions: [extTailwind()],
+});
+```
+
+## Provided contract
+
+`CSSProcessor` — exposes:
+
+- `compile(stylesheet, options)` — delegates to Tailwind's native `compile()` and returns a compiler whose `build(candidates)` emits CSS for the class-name candidates discovered at render time.
+
+## Plugin shims
+
+On setup the extension installs three `globalThis` shims so that Tailwind plugin bundles loaded at runtime from `esm.sh` bind their `tailwindcss/plugin`, `tailwindcss/defaultTheme`, and `tailwindcss/colors` imports to the same tailwindcss copy this extension ships. Core's `plugin-loader.ts` rewrites plugin bundle code to reference these shims by name; without them, dynamic plugin loading fails.
+
+The shims live at:
+
+- `globalThis.__tailwindPluginShim`
+- `globalThis.__tailwindDefaultThemeShim`
+- `globalThis.__tailwindColorsShim`
+
+## Capabilities
+
+- **net `esm.sh`:** loading user-declared Tailwind plugins from CDN at runtime.
+
+## Configuration
+
+No factory options. The extension reads no environment variables and takes no config.


### PR DESCRIPTION
## Summary

Adds `README.md` to the 8 first-party extensions that were missing one. Today the repo ships READMEs for `ext-anthropic`, `ext-google`, and `ext-openai`; the other 8 had nothing — anyone landing on the package page (jsr / npm) or browsing the repo saw no documentation.

| Extension          | Contract(s)               | Backed by                                          |
| ------------------ | ------------------------- | -------------------------------------------------- |
| `ext-babel`        | `CodeParser`              | `@babel/parser` + traverse / generate / types      |
| `ext-esbuild`      | `Bundler`, `ModuleLexer`  | `esbuild`, `es-module-lexer`                       |
| `ext-jwt`          | `AuthProvider`            | `jose`                                             |
| `ext-mdx`          | `ContentTransformer`      | `@mdx-js/mdx` + `unified` / remark / rehype stack  |
| `ext-node-compat`  | `NodeCompat`              | `better-sqlite3`, `@kreuzberg/wasm` / `@kreuzberg/node` |
| `ext-opentelemetry`| `TracingExporter`         | OpenTelemetry JS SDK (OTLP / HTTP)                 |
| `ext-redis`        | `TokenCacheStore`         | `redis`                                            |
| `ext-tailwind`     | `CSSProcessor`            | Tailwind CSS v4                                    |

## Convention

Each README follows the existing `ext-openai/README.md` structure:

- Title + one-line description
- Installation snippet for `veryfront.config.ts`
- Environment variables table (where the extension reads any)
- Factory configuration (where it takes config)
- Provided contract(s)
- Capabilities declared in `deno.json#veryfront.capabilities` (net / fs / env)

All content is factual against the current `src/index.ts` and `deno.json` of each extension — nothing is forward-looking or aspirational. If a behavior isn't already in the code, it isn't documented.

## Test plan

- [x] `deno fmt --check` — passes after running `deno fmt` on the new files.
- [x] Pre-push hook (`deno fmt --check` + `deno lint` + `deno check src/index.ts` + `deno task test:unit`) — 1795 tests pass.
- [ ] Visual review of each README in the GitHub diff.

## Out of scope

- Updating the existing three READMEs (`ext-anthropic`, `ext-google`, `ext-openai`) to match a unified template — they already exist with their own structure; if a template harmonization is wanted, separate PR.
- The Plan A reorg PRs (#1564–#1577) rename several of these extensions (`ext-jwt` → `ext-auth-jwt`, `ext-mdx` → `ext-content-mdx`, `ext-tailwind` → `ext-css-tailwind`, etc.). If a reorg PR lands before this one, the rename will need to be reflected in the corresponding README — a small followup.
