### PR TITLE
Expose agent service runtime naming

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.493",
+  "version": "0.1.494",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -162,12 +162,12 @@ use `prepareVeryfrontCloudHostedChatExecution()`,
 `createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions()`, and
 `buildVeryfrontCloudRuntimeInstructions()` to reuse the default hosted model
 normalization, model-provider, runtime system-message, durable root-run, and
-stream-watchdog wiring. Hosted services can also use
-`loadHostedAgentServiceEnvFiles()` before
-`parseHostedAgentServiceConfig()` to share the default env-file precedence and
+stream-watchdog wiring. Agent services can also use
+`loadAgentServiceEnvFiles()` before
+`parseAgentServiceConfig()` to share the default env-file precedence and
 environment contract for API URL, hosted MCP URL, port, CORS origins, durable
-feature flags, and OpenTelemetry flags. Node-hosted services can pair that with
-`createNodeHostedAgentServiceRuntimeInfrastructure()` to reuse the default
+feature flags, and OpenTelemetry flags. Node services can pair that with
+`createNodeAgentServiceRuntimeInfrastructure()` to reuse the default
 config parsing, logger, service tracer, trace-context getter, and Node SDK
 telemetry setup while keeping non-Node runtimes on the lower-level
 observability APIs.

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -23,6 +23,7 @@ import {
   AgUiResumeSignalSchema,
   AgUiRuntimeRequestSchema,
   buildAgUiBrowserFinalizeResponse,
+  createAgentServiceRuntime,
   createAgUiBrowserEncoderState,
   createAgUiCancelHandler,
   createAgUiDetachedStartHandler,
@@ -32,6 +33,7 @@ import {
   createAgUiRuntimeHandler,
   createAgUiSseErrorResponse,
   createMemory,
+  createNodeAgentServiceRuntimeInfrastructure,
   defineAgentService,
   DurableRunSink,
   executeAgUiDetachedStart,
@@ -42,8 +44,10 @@ import {
   HostedLifecycleTerminalState,
   HumanInputRequestSchema,
   isHostedChildTerminalErrorCode,
+  loadAgentServiceEnvFiles,
   normalizeAgUiMessages,
   normalizeAgUiRuntimeMessages,
+  parseAgentServiceConfig,
   parseAgUiRequest,
   parseAgUiRequestOrError,
   parseAgUiRuntimeRequest,
@@ -56,6 +60,7 @@ import {
   RunResumeSessionManager,
   RuntimeAgentRunInvocationSchema,
   shouldSkipHostedChildTerminalPersistence,
+  startNodeAgentService,
   waitForHumanInput,
 } from "veryfront/agent";
 ```
@@ -229,7 +234,7 @@ await runHostedLifecycle({
 });
 ```
 
-### Phase-0 hosted service contract stub
+### Agent service runtime shell
 
 ```ts
 import { agent, defineAgentService, type DurableRunSink } from "veryfront/agent";
@@ -245,14 +250,18 @@ const durableRunSink: DurableRunSink = {
   cancelRun: async () => {},
 };
 
-// Phase 0 reserves the public signature only. This currently throws until the
-// hosted runtime implementation lands in a later migration phase.
-defineAgentService({
+const service = defineAgentService({
   serviceName: "veryfront-agent",
   agent: assistant,
   durableRunSink,
 });
 ```
+
+`defineAgentService()` normalizes single-agent and multi-agent services into
+one registry contract. `service.createRuntime({ routes })` creates a
+request-native runtime with readiness, liveness, CORS, shutdown state, and
+host-supplied routes. For Node deployments, `startNodeAgentService()` wraps that
+runtime in the shared Veryfront service server with graceful shutdown.
 
 For a conversations/control-plane host composition that combines
 `runHostedLifecycle()` with the public durable-run helpers, see
@@ -772,42 +781,55 @@ Create the default durable root-run preparation options used by
 operation text, missing-user-message errors, instrumentation, implementation
 kind, or persistence-failure handling.
 
-### `parseHostedAgentServiceConfig(env)`
+### `parseAgentServiceConfig(env)`
 
-Parse the default hosted agent service environment contract. The helper
+Parse the default agent service environment contract. The helper
 validates API URL, node environment, port, durable feature flags, OAuth public
 key, Studio MCP URL, allowed origins, and OpenTelemetry endpoint flags, and it
 derives the hosted MCP URL from `VERYFRONT_API_URL`.
 
-### `loadHostedAgentServiceEnvFiles(options)`
+`parseHostedAgentServiceConfig()` remains available as a compatibility alias.
 
-Load hosted agent service env files before parsing config. By default the
+### `loadAgentServiceEnvFiles(options)`
+
+Load agent service env files before parsing config. By default the
 helper reads `.env` and then `.env.local` from the current working directory,
 preserves variables that were already present in the host process environment,
 and lets later env files override earlier env-file values. This matches the
-recommended service bootstrap shape for separately deployed hosted agents.
+recommended service bootstrap shape for separately deployed agents.
 
-### `resolveNodeHostedAgentServiceTelemetryConfig(options)`
+`loadHostedAgentServiceEnvFiles()` remains available as a compatibility alias.
+
+### `resolveNodeAgentServiceTelemetryConfig(options)`
 
 Resolve the default Node hosted-agent OpenTelemetry configuration from a service
 environment. The helper centralizes `OTEL_ENABLED`, service name/version,
 sampling, exporter headers, and Node auto-instrumentation flags for separately
 deployed Node agent services.
 
-### `initializeNodeHostedAgentServiceOpenTelemetry(options)`
+`resolveNodeHostedAgentServiceTelemetryConfig()` remains available as a
+compatibility alias.
+
+### `initializeNodeAgentServiceOpenTelemetry(options)`
 
 Initialize the Node OpenTelemetry SDK for a hosted agent service using the
-configuration resolved by `resolveNodeHostedAgentServiceTelemetryConfig()`. This
+configuration resolved by `resolveNodeAgentServiceTelemetryConfig()`. This
 helper is intentionally Node-specific; cross-runtime service shells should keep
 using the lower-level framework observability APIs.
 
-### `createNodeHostedAgentServiceRuntimeInfrastructure(options)`
+`initializeNodeHostedAgentServiceOpenTelemetry()` remains available as a
+compatibility alias.
+
+### `createNodeAgentServiceRuntimeInfrastructure(options)`
 
 Create the standard Node hosted service infrastructure bundle for separately
 deployed agent services: hosted service config parsing, component logger,
 service tracer, active-span attribute setter, trace-context getter, and Node
 OpenTelemetry startup. The helper is intentionally Node-specific because it
 binds the npm OpenTelemetry API and Node SDK startup path.
+
+`createNodeHostedAgentServiceRuntimeInfrastructure()` remains available as a
+compatibility alias.
 
 ### `AgUiRuntimeRequestSchema`
 
@@ -991,6 +1013,7 @@ Clear all stored messages from memory.
 | `createAgUiRunErrorEvent`                                       | Create a `RunError` AG-UI SSE event                                      |
 | `createAgUiSseErrorResponse`                                    | Create an AG-UI SSE error `Response`                                     |
 | `createAgUiResumeHandler`                                       | Create a POST handler for hosted AG-UI run resume values                 |
+| `createAgentServiceRuntime`                                     | Create an agent service runtime with default service routes              |
 | `createDefaultHostedProjectSteeringRefresh`                     | Create the default hosted project steering refresh callback              |
 | `createHostedAgentProjectSteering`                              | Create hosted agent-definition and project-steering bindings             |
 | `buildVeryfrontCloudRuntimeInstructions`                        | Adapt hosted preparation input to Veryfront Cloud system messages        |
@@ -999,17 +1022,18 @@ Clear all stored messages from memory.
 | `createVeryfrontCloudRuntimeSystemMessages`                     | Create Veryfront Cloud runtime system messages                           |
 | `fetchDefaultHostedProjectSteering`                             | Fetch initial hosted project instructions and skills                     |
 | `filterAgentTraceAttributes`                                    | Filter unknown records to valid agent trace attributes                   |
-| `createNodeHostedAgentServiceRuntimeInfrastructure`             | Create Node hosted service config, logger, tracer, and telemetry bundle  |
-| `loadHostedAgentServiceEnvFiles`                                | Load hosted service env files while preserving host process env          |
-| `initializeNodeHostedAgentServiceOpenTelemetry`                 | Initialize Node OpenTelemetry for a hosted agent service                 |
+| `createNodeAgentServiceRuntimeInfrastructure`                   | Create Node service config, logger, tracer, and telemetry bundle         |
+| `loadAgentServiceEnvFiles`                                      | Load service env files while preserving host process env                 |
+| `initializeNodeAgentServiceOpenTelemetry`                       | Initialize Node OpenTelemetry for an agent service                       |
 | `loadRuntimeAgentMarkdownDefinitionFromFile`                    | Load and parse a markdown agent definition from an agents directory      |
-| `parseHostedAgentServiceConfig`                                 | Parse default hosted agent service environment config                    |
-| `resolveNodeHostedAgentServiceTelemetryConfig`                  | Resolve Node hosted service OpenTelemetry config from environment        |
+| `parseAgentServiceConfig`                                       | Parse default agent service environment config                           |
+| `resolveNodeAgentServiceTelemetryConfig`                        | Resolve Node service OpenTelemetry config from environment               |
 | `prepareVeryfrontCloudHostedChatExecution`                      | Prepare hosted chat execution with Veryfront Cloud defaults              |
 | `normalizeAgUiRuntimeMessages`                                  | Normalize runtime AG-UI messages into package `Message[]`                |
 | `parseAgUiRuntimeRequest`                                       | Parse and validate the canonical runtime AG-UI request body              |
 | `parseAgUiRuntimeRequestOrError`                                | Parse runtime AG-UI input or return a `400` validation `Response`        |
 | `parseRuntimeAgentRunInvocation`                                | Parse and validate a control-plane runtime agent invocation body         |
+| `startNodeAgentService`                                         | Start an agent service with the Node service server adapter              |
 | `parseRuntimeAgentRunInvocationOrError`                         | Parse a runtime agent invocation or return a `400` validation `Response` |
 | `resolveRuntimeAgentDefinitionsDir`                             | Resolve a hosted service `agents/` directory from source/bundled paths   |
 | `createChatHandler`                                             | Create a POST handler for a chat API route.                              |

--- a/src/agent/agent-service.ts
+++ b/src/agent/agent-service.ts
@@ -1,8 +1,7 @@
 import type { Agent } from "./types.ts";
 
 /**
- * Transport-neutral durable run lifecycle sink reserved for hosted agent-service
- * adoption work.
+ * Transport-neutral durable run lifecycle sink for agent-service adoption work.
  */
 export interface DurableRunSink<
   TStartInput = void,
@@ -17,8 +16,7 @@ export interface DurableRunSink<
 }
 
 /**
- * Placeholder host-facing server config reserved for the future hosted service
- * implementation.
+ * Host-facing server config for the agent service runtime shell.
  */
 export type AgentServiceRouteMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS";
 
@@ -68,7 +66,7 @@ export interface AgentServiceContractBase<
 }
 
 /**
- * Multi-agent hosted-service contract. Framework services route to
+ * Multi-agent service contract. Framework services route to
  * `defaultAgentId` unless the host chooses another registered agent.
  */
 export interface AgentServiceRegistryContract<
@@ -97,7 +95,7 @@ export interface AgentServiceSingleAgentContract<
 }
 
 /**
- * Phase-0 contract draft for the future framework-owned hosted agent service.
+ * Framework-owned agent service contract.
  */
 export type AgentContract<
   TStartInput = void,
@@ -119,8 +117,7 @@ export interface NormalizedAgentServiceContract<
 }
 
 /**
- * Type-preserving service definition reserved ahead of the runtime
- * implementation landing in a later migration phase.
+ * Type-preserving service definition for request-native agent service runtimes.
  */
 export interface AgentServiceDefinition<
   TStartInput = void,
@@ -364,7 +361,7 @@ function createAgentServiceRuntime<
 }
 
 /**
- * Define a hosted agent service and expose a policy-neutral runtime shell.
+ * Define an agent service and expose a policy-neutral runtime shell.
  *
  * The first implementation slice owns contract normalization plus standard
  * health/readiness behavior. Hosts pass product-specific routes explicitly so

--- a/src/agent/hosted-agent-service-config.test.ts
+++ b/src/agent/hosted-agent-service-config.test.ts
@@ -1,8 +1,21 @@
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { parseHostedAgentServiceConfig } from "./hosted-agent-service-config.ts";
+import {
+  agentServiceConfigSchema,
+  parseAgentServiceConfig,
+  parseHostedAgentServiceConfig,
+} from "./hosted-agent-service-config.ts";
 
 describe("agent/hosted-agent-service-config", () => {
+  it("exposes agent service aliases without the hosted prefix", () => {
+    const config = parseAgentServiceConfig({
+      VERYFRONT_API_URL: "https://api.example.com",
+    });
+
+    assertEquals(config.VERYFRONT_MCP_URL, "https://api.example.com/mcp");
+    assertEquals(agentServiceConfigSchema.parse({}).PORT, 3001);
+  });
+
   it("builds hosted agent service config defaults", () => {
     const config = parseHostedAgentServiceConfig({});
 

--- a/src/agent/hosted-agent-service-config.ts
+++ b/src/agent/hosted-agent-service-config.ts
@@ -38,8 +38,19 @@ export const hostedAgentServiceConfigSchema = z.object({
 export type HostedAgentServiceConfig = z.infer<typeof hostedAgentServiceConfigSchema>;
 export type HostedAgentServiceConfigInput = z.input<typeof hostedAgentServiceConfigSchema>;
 
+export const agentServiceConfigSchema = hostedAgentServiceConfigSchema;
+
+export type AgentServiceConfig = HostedAgentServiceConfig;
+export type AgentServiceConfigInput = HostedAgentServiceConfigInput;
+
 export function parseHostedAgentServiceConfig(
   input: HostedAgentServiceConfigInput,
 ): HostedAgentServiceConfig {
   return hostedAgentServiceConfigSchema.parse(input);
+}
+
+export function parseAgentServiceConfig(
+  input: AgentServiceConfigInput,
+): AgentServiceConfig {
+  return parseHostedAgentServiceConfig(input);
 }

--- a/src/agent/hosted-agent-service-env-files.test.ts
+++ b/src/agent/hosted-agent-service-env-files.test.ts
@@ -1,7 +1,10 @@
 import { assertEquals } from "@std/assert";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { deleteEnv, getEnv, setEnv } from "#veryfront/platform/compat/process.ts";
-import { loadHostedAgentServiceEnvFiles } from "./hosted-agent-service-env-files.ts";
+import {
+  loadAgentServiceEnvFiles,
+  loadHostedAgentServiceEnvFiles,
+} from "./hosted-agent-service-env-files.ts";
 
 const TEST_KEYS = [
   "VF_AGENT_ENV_FILE_TEST_SHARED",
@@ -75,5 +78,17 @@ describe("loadHostedAgentServiceEnvFiles", () => {
 
     assertEquals(result.loadedFiles, [`${tempDir}/custom.env`]);
     assertEquals(getEnv("VF_AGENT_ENV_FILE_TEST_SHARED"), "custom");
+  });
+
+  it("exposes an agent service env loader alias without the hosted prefix", async () => {
+    await Deno.writeTextFile(`${tempDir}/custom.env`, "VF_AGENT_ENV_FILE_TEST_LOCAL_ONLY=alias");
+
+    const result = await loadAgentServiceEnvFiles({
+      cwd: tempDir,
+      files: ["custom.env"],
+    });
+
+    assertEquals(result.loadedVariables, 1);
+    assertEquals(getEnv("VF_AGENT_ENV_FILE_TEST_LOCAL_ONLY"), "alias");
   });
 });

--- a/src/agent/hosted-agent-service-env-files.ts
+++ b/src/agent/hosted-agent-service-env-files.ts
@@ -13,6 +13,9 @@ export type HostedAgentServiceEnvFileLoadOptions = {
   files?: readonly string[];
 };
 
+export type AgentServiceEnvFileLoadResult = HostedAgentServiceEnvFileLoadResult;
+export type AgentServiceEnvFileLoadOptions = HostedAgentServiceEnvFileLoadOptions;
+
 function joinEnvPath(cwd: string, file: string): string {
   if (file.startsWith("/") || file.startsWith("./") || file.startsWith("../")) {
     return file;
@@ -52,4 +55,10 @@ export async function loadHostedAgentServiceEnvFiles(
   }
 
   return { loadedFiles, loadedVariables };
+}
+
+export async function loadAgentServiceEnvFiles(
+  options: AgentServiceEnvFileLoadOptions = {},
+): Promise<AgentServiceEnvFileLoadResult> {
+  return loadHostedAgentServiceEnvFiles(options);
 }

--- a/src/agent/hosted-agent-service-runtime.test.ts
+++ b/src/agent/hosted-agent-service-runtime.test.ts
@@ -1,7 +1,9 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  createAgentServiceRuntime,
   createHostedAgentServiceRuntime,
+  startNodeAgentService,
   startNodeHostedAgentService,
 } from "./hosted-agent-service-runtime.ts";
 
@@ -15,6 +17,33 @@ function createLogger() {
 }
 
 describe("agent/hosted-agent-service-runtime", () => {
+  it("exposes agent service aliases without the hosted prefix for developer-facing APIs", async () => {
+    const bundle = createAgentServiceRuntime({
+      serviceName: "test-agent-service",
+      getConfig: () => ({
+        VERYFRONT_API_URL: "https://api.example.test",
+        NODE_ENV: "test",
+        PORT: 3180,
+        ALLOWED_ORIGINS: ["https://studio.example.test"],
+      }),
+      getAgentConfig: () => ({
+        id: "assistant",
+        name: "Assistant",
+        description: "",
+        instructions: "You are a test assistant.",
+      }),
+      logger: createLogger(),
+      prepareExecution: async () => ({ ok: true }),
+      streamExecutionToAgUiResponse: () => new Response("streamed"),
+      startDetachedExecution: async () => {},
+    });
+
+    const ready = await bundle.runtime.request("/readiness");
+
+    assertEquals(bundle.runtime.contract.serviceName, "test-agent-service");
+    assertEquals(ready.status, 200);
+  });
+
   it("assembles hosted service auth, routes, lifecycle, and runtime shell", async () => {
     const bundle = createHostedAgentServiceRuntime({
       serviceName: "test-agent-service",
@@ -54,7 +83,7 @@ describe("agent/hosted-agent-service-runtime", () => {
   });
 
   it("starts the node agent service server from the assembled runtime", async () => {
-    const service = await startNodeHostedAgentService({
+    const service = await startNodeAgentService({
       serviceName: "node-test-agent-service",
       getConfig: () => ({
         VERYFRONT_API_URL: "https://api.example.test",
@@ -78,6 +107,37 @@ describe("agent/hosted-agent-service-runtime", () => {
 
     try {
       assertEquals(service.runtime.contract.serviceName, "node-test-agent-service");
+      assertEquals(typeof service.nodeServer.port, "number");
+    } finally {
+      await service.nodeServer.stop();
+    }
+  });
+
+  it("keeps the hosted-prefixed start function as a compatibility alias", async () => {
+    const service = await startNodeHostedAgentService({
+      serviceName: "node-hosted-test-agent-service",
+      getConfig: () => ({
+        VERYFRONT_API_URL: "https://api.example.test",
+        NODE_ENV: "test",
+        PORT: 0,
+        ALLOWED_ORIGINS: ["*"],
+      }),
+      getAgentConfig: () => ({
+        id: "assistant",
+        name: "Assistant",
+        description: "",
+        instructions: "You are a test assistant.",
+      }),
+      logger: createLogger(),
+      prepareExecution: async () => ({ ok: true }),
+      streamExecutionToAgUiResponse: () => new Response("streamed"),
+      startDetachedExecution: async () => {},
+      signals: [],
+      hardShutdownTimeoutMs: 50,
+    });
+
+    try {
+      assertEquals(service.runtime.contract.serviceName, "node-hosted-test-agent-service");
       assertEquals(typeof service.nodeServer.port, "number");
     } finally {
       await service.nodeServer.stop();

--- a/src/agent/hosted-agent-service-runtime.ts
+++ b/src/agent/hosted-agent-service-runtime.ts
@@ -37,15 +37,21 @@ export type HostedAgentServiceRuntimeConfig = HostedServiceAuthConfig & {
   ALLOWED_ORIGINS: string[];
 };
 
+export type AgentServiceRuntimeConfig = HostedAgentServiceRuntimeConfig;
+
 export type HostedAgentServiceRuntimeLogger = VeryfrontServiceServerLogger & {
   info(message: string, metadata?: Record<string, unknown>): void;
   error(message: string, metadata?: Record<string, unknown>): void;
 };
 
+export type AgentServiceRuntimeLogger = HostedAgentServiceRuntimeLogger;
+
 export type HostedAgentServiceRuntimeTrace = <TResult>(
   operationName: string,
   operation: () => Promise<TResult>,
 ) => Promise<TResult>;
+
+export type AgentServiceRuntimeTrace = HostedAgentServiceRuntimeTrace;
 
 export type CreateHostedAgentServiceRuntimeOptions<
   TExecution extends object,
@@ -72,6 +78,11 @@ export type CreateHostedAgentServiceRuntimeOptions<
   drainTimeoutMs?: number;
 };
 
+export type CreateAgentServiceRuntimeOptions<
+  TExecution extends object,
+  TConfig extends AgentServiceRuntimeConfig = AgentServiceRuntimeConfig,
+> = CreateHostedAgentServiceRuntimeOptions<TExecution, TConfig>;
+
 export type HostedAgentServiceRuntimeBundle<
   TExecution extends object,
   TConfig extends HostedAgentServiceRuntimeConfig = HostedAgentServiceRuntimeConfig,
@@ -85,6 +96,11 @@ export type HostedAgentServiceRuntimeBundle<
   runtime: AgentServiceRuntime;
 };
 
+export type AgentServiceRuntimeBundle<
+  TExecution extends object,
+  TConfig extends AgentServiceRuntimeConfig = AgentServiceRuntimeConfig,
+> = HostedAgentServiceRuntimeBundle<TExecution, TConfig>;
+
 export type StartNodeHostedAgentServiceOptions<
   TExecution extends object,
   TConfig extends HostedAgentServiceRuntimeConfig = HostedAgentServiceRuntimeConfig,
@@ -94,12 +110,22 @@ export type StartNodeHostedAgentServiceOptions<
   signals?: readonly NodeJS.Signals[];
 };
 
+export type StartNodeAgentServiceOptions<
+  TExecution extends object,
+  TConfig extends AgentServiceRuntimeConfig = AgentServiceRuntimeConfig,
+> = StartNodeHostedAgentServiceOptions<TExecution, TConfig>;
+
 export type StartNodeHostedAgentServiceResult<
   TExecution extends object,
   TConfig extends HostedAgentServiceRuntimeConfig = HostedAgentServiceRuntimeConfig,
 > = HostedAgentServiceRuntimeBundle<TExecution, TConfig> & {
   nodeServer: NodeAgentServiceServer;
 };
+
+export type StartNodeAgentServiceResult<
+  TExecution extends object,
+  TConfig extends AgentServiceRuntimeConfig = AgentServiceRuntimeConfig,
+> = StartNodeHostedAgentServiceResult<TExecution, TConfig>;
 
 function defaultTrace<TResult>(
   _operationName: string,
@@ -169,6 +195,15 @@ export function createHostedAgentServiceRuntime<
   };
 }
 
+export function createAgentServiceRuntime<
+  TExecution extends object,
+  TConfig extends AgentServiceRuntimeConfig = AgentServiceRuntimeConfig,
+>(
+  options: CreateAgentServiceRuntimeOptions<TExecution, TConfig>,
+): AgentServiceRuntimeBundle<TExecution, TConfig> {
+  return createHostedAgentServiceRuntime(options);
+}
+
 export async function startNodeHostedAgentService<
   TExecution extends object,
   TConfig extends HostedAgentServiceRuntimeConfig = HostedAgentServiceRuntimeConfig,
@@ -191,4 +226,13 @@ export async function startNodeHostedAgentService<
     ...bundle,
     nodeServer,
   };
+}
+
+export async function startNodeAgentService<
+  TExecution extends object,
+  TConfig extends AgentServiceRuntimeConfig = AgentServiceRuntimeConfig,
+>(
+  options: StartNodeAgentServiceOptions<TExecution, TConfig>,
+): Promise<StartNodeAgentServiceResult<TExecution, TConfig>> {
+  return startNodeHostedAgentService(options);
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -279,41 +279,69 @@ export {
 } from "./default-hosted-project-steering-refresh.ts";
 
 export {
+  type AgentServiceRuntimeBundle,
+  type AgentServiceRuntimeConfig,
+  type AgentServiceRuntimeLogger,
+  type AgentServiceRuntimeTrace,
+  createAgentServiceRuntime,
+  type CreateAgentServiceRuntimeOptions,
   createHostedAgentServiceRuntime,
   type CreateHostedAgentServiceRuntimeOptions,
   type HostedAgentServiceRuntimeBundle,
   type HostedAgentServiceRuntimeConfig,
   type HostedAgentServiceRuntimeLogger,
   type HostedAgentServiceRuntimeTrace,
+  startNodeAgentService,
+  type StartNodeAgentServiceOptions,
+  type StartNodeAgentServiceResult,
   startNodeHostedAgentService,
   type StartNodeHostedAgentServiceOptions,
   type StartNodeHostedAgentServiceResult,
 } from "./hosted-agent-service-runtime.ts";
 export {
+  type AgentServiceConfig,
+  type AgentServiceConfigInput,
+  agentServiceConfigSchema,
   type HostedAgentServiceConfig,
   type HostedAgentServiceConfigInput,
   hostedAgentServiceConfigSchema,
+  parseAgentServiceConfig,
   parseHostedAgentServiceConfig,
 } from "./hosted-agent-service-config.ts";
 export {
+  type AgentServiceEnvFileLoadOptions,
+  type AgentServiceEnvFileLoadResult,
   type HostedAgentServiceEnvFileLoadOptions,
   type HostedAgentServiceEnvFileLoadResult,
+  loadAgentServiceEnvFiles,
   loadHostedAgentServiceEnvFiles,
 } from "./hosted-agent-service-env-files.ts";
 export {
+  initializeNodeAgentServiceOpenTelemetry,
+  type InitializeNodeAgentServiceTelemetryOptions,
   initializeNodeHostedAgentServiceOpenTelemetry,
   type InitializeNodeHostedAgentServiceTelemetryOptions,
+  type NodeAgentServiceInstrumentationConfig,
+  type NodeAgentServiceTelemetryConfig,
+  type NodeAgentServiceTelemetryEnv,
+  type NodeAgentServiceTelemetryLogger,
+  type NodeAgentServiceTelemetryProcessTarget,
   type NodeHostedAgentServiceInstrumentationConfig,
   type NodeHostedAgentServiceTelemetryConfig,
   type NodeHostedAgentServiceTelemetryEnv,
   type NodeHostedAgentServiceTelemetryLogger,
   type NodeHostedAgentServiceTelemetryProcessTarget,
+  resolveNodeAgentServiceTelemetryConfig,
+  type ResolveNodeAgentServiceTelemetryConfigOptions,
   resolveNodeHostedAgentServiceTelemetryConfig,
   type ResolveNodeHostedAgentServiceTelemetryConfigOptions,
 } from "./node-hosted-agent-service-telemetry.ts";
 export {
+  createNodeAgentServiceRuntimeInfrastructure,
+  type CreateNodeAgentServiceRuntimeInfrastructureOptions,
   createNodeHostedAgentServiceRuntimeInfrastructure,
   type CreateNodeHostedAgentServiceRuntimeInfrastructureOptions,
+  type NodeAgentServiceRuntimeInfrastructure,
   type NodeHostedAgentServiceRuntimeInfrastructure,
 } from "./node-hosted-agent-service-runtime-infrastructure.ts";
 export {

--- a/src/agent/node-hosted-agent-service-runtime-infrastructure.test.ts
+++ b/src/agent/node-hosted-agent-service-runtime-infrastructure.test.ts
@@ -1,8 +1,24 @@
 import { assertEquals, assertObjectMatch } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { createNodeHostedAgentServiceRuntimeInfrastructure } from "./node-hosted-agent-service-runtime-infrastructure.ts";
+import {
+  createNodeAgentServiceRuntimeInfrastructure,
+  createNodeHostedAgentServiceRuntimeInfrastructure,
+} from "./node-hosted-agent-service-runtime-infrastructure.ts";
 
 describe("createNodeHostedAgentServiceRuntimeInfrastructure", () => {
+  it("exposes a node agent service infrastructure alias without the hosted prefix", async () => {
+    const infrastructure = createNodeAgentServiceRuntimeInfrastructure({
+      serviceName: "custom-service",
+      env: {
+        VERYFRONT_API_URL: "https://api.example.com",
+        OTEL_ENABLED: "false",
+      },
+    });
+
+    assertEquals(infrastructure.getConfig().VERYFRONT_API_URL, "https://api.example.com");
+    assertEquals(await infrastructure.initializeOpenTelemetry(), false);
+  });
+
   it("binds hosted service config, logging, tracing, and disabled telemetry startup", async () => {
     const infoMessages: string[] = [];
     const infrastructure = createNodeHostedAgentServiceRuntimeInfrastructure({

--- a/src/agent/node-hosted-agent-service-runtime-infrastructure.ts
+++ b/src/agent/node-hosted-agent-service-runtime-infrastructure.ts
@@ -24,6 +24,9 @@ export type CreateNodeHostedAgentServiceRuntimeInfrastructureOptions = {
   processTarget?: NodeHostedAgentServiceTelemetryProcessTarget;
 };
 
+export type CreateNodeAgentServiceRuntimeInfrastructureOptions =
+  CreateNodeHostedAgentServiceRuntimeInfrastructureOptions;
+
 export type NodeHostedAgentServiceRuntimeInfrastructure = {
   getConfig(): HostedAgentServiceConfig;
   logger: Logger;
@@ -32,6 +35,8 @@ export type NodeHostedAgentServiceRuntimeInfrastructure = {
   getTraceContext(): { traceId?: string; spanId?: string };
   initializeOpenTelemetry(): Promise<boolean>;
 };
+
+export type NodeAgentServiceRuntimeInfrastructure = NodeHostedAgentServiceRuntimeInfrastructure;
 
 export function createNodeHostedAgentServiceRuntimeInfrastructure(
   options: CreateNodeHostedAgentServiceRuntimeInfrastructureOptions,
@@ -60,4 +65,10 @@ export function createNodeHostedAgentServiceRuntimeInfrastructure(
         processTarget: options.processTarget,
       }),
   };
+}
+
+export function createNodeAgentServiceRuntimeInfrastructure(
+  options: CreateNodeAgentServiceRuntimeInfrastructureOptions,
+): NodeAgentServiceRuntimeInfrastructure {
+  return createNodeHostedAgentServiceRuntimeInfrastructure(options);
 }

--- a/src/agent/node-hosted-agent-service-telemetry.test.ts
+++ b/src/agent/node-hosted-agent-service-telemetry.test.ts
@@ -1,8 +1,22 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { resolveNodeHostedAgentServiceTelemetryConfig } from "./node-hosted-agent-service-telemetry.ts";
+import {
+  resolveNodeAgentServiceTelemetryConfig,
+  resolveNodeHostedAgentServiceTelemetryConfig,
+} from "./node-hosted-agent-service-telemetry.ts";
 
 describe("agent/node-hosted-agent-service-telemetry", () => {
+  it("exposes a node agent service telemetry resolver alias without the hosted prefix", () => {
+    const config = resolveNodeAgentServiceTelemetryConfig({
+      env: { NODE_ENV: "production" },
+      defaultServiceName: "agent-service",
+      defaultEnabled: false,
+    });
+
+    assertEquals(config.enabled, false);
+    assertEquals(config.serviceName, "agent-service");
+  });
+
   it("defaults to production-enabled hosted service telemetry", () => {
     const config = resolveNodeHostedAgentServiceTelemetryConfig({
       env: { NODE_ENV: "production" },

--- a/src/agent/node-hosted-agent-service-telemetry.ts
+++ b/src/agent/node-hosted-agent-service-telemetry.ts
@@ -1,10 +1,14 @@
 export type NodeHostedAgentServiceTelemetryEnv = Record<string, string | undefined>;
 
+export type NodeAgentServiceTelemetryEnv = NodeHostedAgentServiceTelemetryEnv;
+
 export type NodeHostedAgentServiceInstrumentationConfig = {
   http: boolean;
   express: boolean;
   fs: boolean;
 };
+
+export type NodeAgentServiceInstrumentationConfig = NodeHostedAgentServiceInstrumentationConfig;
 
 export type NodeHostedAgentServiceTelemetryConfig = {
   enabled: boolean;
@@ -16,6 +20,8 @@ export type NodeHostedAgentServiceTelemetryConfig = {
   instrumentation: NodeHostedAgentServiceInstrumentationConfig;
 };
 
+export type NodeAgentServiceTelemetryConfig = NodeHostedAgentServiceTelemetryConfig;
+
 export type ResolveNodeHostedAgentServiceTelemetryConfigOptions = {
   env: NodeHostedAgentServiceTelemetryEnv;
   defaultServiceName: string;
@@ -23,14 +29,21 @@ export type ResolveNodeHostedAgentServiceTelemetryConfigOptions = {
   defaultEnabled?: boolean;
 };
 
+export type ResolveNodeAgentServiceTelemetryConfigOptions =
+  ResolveNodeHostedAgentServiceTelemetryConfigOptions;
+
 export type NodeHostedAgentServiceTelemetryLogger = {
   info(message: string, metadata?: Record<string, unknown>): void;
   error(message: string, metadata?: Record<string, unknown>): void;
 };
 
+export type NodeAgentServiceTelemetryLogger = NodeHostedAgentServiceTelemetryLogger;
+
 export type NodeHostedAgentServiceTelemetryProcessTarget = {
   on(event: "SIGTERM", listener: () => void | Promise<void>): unknown;
 };
+
+export type NodeAgentServiceTelemetryProcessTarget = NodeHostedAgentServiceTelemetryProcessTarget;
 
 export type InitializeNodeHostedAgentServiceTelemetryOptions =
   & NodeHostedAgentServiceTelemetryConfig
@@ -38,6 +51,9 @@ export type InitializeNodeHostedAgentServiceTelemetryOptions =
     logger?: NodeHostedAgentServiceTelemetryLogger;
     processTarget?: NodeHostedAgentServiceTelemetryProcessTarget;
   };
+
+export type InitializeNodeAgentServiceTelemetryOptions =
+  InitializeNodeHostedAgentServiceTelemetryOptions;
 
 function resolveEnabled(env: NodeHostedAgentServiceTelemetryEnv, defaultEnabled: boolean): boolean {
   const envValue = env.OTEL_ENABLED;
@@ -96,6 +112,12 @@ export function resolveNodeHostedAgentServiceTelemetryConfig(
     exporterHeaders: parseExporterHeaders(options.env.OTEL_EXPORTER_OTLP_HEADERS),
     instrumentation: resolveInstrumentationConfig(options.env),
   };
+}
+
+export function resolveNodeAgentServiceTelemetryConfig(
+  options: ResolveNodeAgentServiceTelemetryConfigOptions,
+): NodeAgentServiceTelemetryConfig {
+  return resolveNodeHostedAgentServiceTelemetryConfig(options);
 }
 
 function logInfo(
@@ -189,4 +211,10 @@ export async function initializeNodeHostedAgentServiceOpenTelemetry(
     logError(options.logger, "Failed to initialize OpenTelemetry", error);
     return false;
   }
+}
+
+export async function initializeNodeAgentServiceOpenTelemetry(
+  options: InitializeNodeAgentServiceTelemetryOptions,
+): Promise<boolean> {
+  return initializeNodeHostedAgentServiceOpenTelemetry(options);
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.493";
+export const VERSION = "0.1.494";


### PR DESCRIPTION
## Summary
- Add non-hosted developer-facing aliases for agent service config, env loading, telemetry, runtime infrastructure, and Node service startup.
- Keep hosted-prefixed names as compatibility aliases.
- Update agent service docs/reference to use the generic service naming.
- Bump package version to 0.1.494 for CI/CD publish.

## Verification
- `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/agent/hosted-agent-service-runtime.test.ts src/agent/hosted-agent-service-config.test.ts src/agent/hosted-agent-service-env-files.test.ts src/agent/node-hosted-agent-service-telemetry.test.ts src/agent/node-hosted-agent-service-runtime-infrastructure.test.ts src/agent/agent-service.test.ts src/agent/agent-service-server.test.ts`
- `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/utils/version.test.ts src/utils/logger/logger.test.ts src/agent/hosted-agent-service-runtime.test.ts`
- `deno task verify:quick`
