### PR TITLE
Expose agent service chat API aliases

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.494",
+  "version": "0.1.495",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -149,23 +149,23 @@ export default agent({
 });
 ```
 
-For step-boundary refresh during a long-lived hosted run, use
+For step-boundary refresh during a long-lived agent-service run, use
 `resolveRuntimeState` instead of relying on `system()` to re-run mid-turn.
-Hosted service runtimes that fetch project instructions, skills, and
+Agent service runtimes that fetch project instructions, skills, and
 project-scoped tool inventory from an external control plane can use
-`createDefaultHostedProjectSteeringRefresh()` from `veryfront/agent` to reuse
-the default refresh sequencing while keeping fetch and prompt-building policy
-local. Use `fetchDefaultHostedProjectSteering()` for the matching initial
+`createDefaultAgentServiceProjectSteeringRefresh()` from
+`veryfront/agent` to reuse the default refresh sequencing while keeping fetch and prompt-building policy
+local. Use `fetchDefaultAgentServiceProjectSteering()` for the matching initial
 execution-preparation fetch.
-Services that prepare and stream hosted executions through Veryfront Cloud can
-use `prepareVeryfrontCloudHostedChatExecution()`,
-`createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions()`, and
-`buildVeryfrontCloudRuntimeInstructions()` to reuse the default hosted model
-normalization, model-provider, runtime system-message, durable root-run, and
+Services that prepare and stream agent-service executions through Veryfront Cloud can
+use `prepareVeryfrontCloudAgentServiceChatExecution()`,
+`createVeryfrontCloudPreparedAgentServiceChatExecutionRuntimeOptions()`, and
+`buildVeryfrontCloudRuntimeInstructions()` to reuse the default Veryfront Cloud
+model normalization, model-provider, runtime system-message, durable root-run, and
 stream-watchdog wiring. Agent services can also use
 `loadAgentServiceEnvFiles()` before
 `parseAgentServiceConfig()` to share the default env-file precedence and
-environment contract for API URL, hosted MCP URL, port, CORS origins, durable
+environment contract for API URL, service MCP URL, port, CORS origins, durable
 feature flags, and OpenTelemetry flags. Node services can pair that with
 `createNodeAgentServiceRuntimeInfrastructure()` to reuse the default
 config parsing, logger, service tracer, trace-context getter, and Node SDK
@@ -173,10 +173,10 @@ telemetry setup while keeping non-Node runtimes on the lower-level
 observability APIs.
 Use `resolveRuntimeAgentDefinitionsDir()` and
 `loadRuntimeAgentMarkdownDefinitionFromFile()` when a separately deployed
-hosted agent stores persona/configuration in `agents/*.md` files.
-If the service also uses the hosted project-files API for instructions, skills,
-and `load_skill`, use `createHostedAgentProjectSteering()` to bind the markdown
-agent definition and hosted steering adapter as one reusable service primitive.
+agent stores persona/configuration in `agents/*.md` files.
+If the service also uses the project-files API for instructions, skills,
+and `load_skill`, use `createAgentServiceProjectSteering()` to bind the markdown
+agent definition and project-steering adapter as one reusable service primitive.
 
 ## Agent configuration
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -702,9 +702,9 @@ Create a `RunError` AG-UI SSE event payload.
 Create an AG-UI SSE `Response` from a prepared AG-UI event, preserving the
 existing `RunError` wire shape used by hosted routes.
 
-### `createDefaultHostedProjectSteeringRefresh(options)`
+### `createDefaultAgentServiceProjectSteeringRefresh(options)`
 
-Create the default hosted step-boundary project steering refresh callback. The
+Create the default agent-service step-boundary project steering refresh callback. The
 helper refreshes project instructions, skills, and project-scoped remote tool
 names, filters skills by the runtime task context, records compatible available
 tool names, and appends the runtime tool inventory to the system instructions.
@@ -713,44 +713,44 @@ Hosts provide the control-plane fetchers and prompt builder, keeping product
 policy outside the framework while reusing the generic hosted refresh
 sequencing.
 
-### `fetchDefaultHostedProjectSteering(options)`
+### `fetchDefaultAgentServiceProjectSteering(options)`
 
-Fetch initial hosted project steering for execution preparation. The helper
+Fetch initial agent-service project steering for execution preparation. The helper
 returns empty steering when no project is active, otherwise fetches project
 instructions and skills in parallel with an optional host trace wrapper.
 
-### `createHostedAgentProjectSteering(options)`
+### `createAgentServiceProjectSteering(options)`
 
-Create a reusable hosted project-steering binding for separately deployed agent
-services. The helper loads and caches a markdown-backed `agents/*.md` definition
-and wires the hosted project-steering adapter for project instructions, project
+Create a reusable agent-service project-steering binding for separately
+deployed agent services. The helper loads and caches a markdown-backed `agents/*.md` definition
+and wires the project-steering adapter for project instructions, project
 skills, builtin skills, `load_skill`, and skill-id refresh. Hosts provide the
 service API URL plus optional logger, trace, and fetch hooks.
 
-### `createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions(options)`
+### `createVeryfrontCloudPreparedAgentServiceChatExecutionRuntimeOptions(options)`
 
-Create the default runtime options used by prepared hosted chat execution on
-Veryfront Cloud. The helper wires the hosted model-provider resolver and default
-chat stream watchdog while the host supplies its API URL, tracer, logger, and
+Create the default runtime options used by prepared agent-service chat execution
+on Veryfront Cloud. The helper wires the Veryfront Cloud model-provider resolver
+and default chat stream watchdog while the host supplies its API URL, tracer, logger, and
 optional trace hooks.
 
 ### `createVeryfrontCloudRuntimeSystemMessages(options)`
 
-Create the default runtime system messages for Veryfront Cloud hosted services.
+Create the default runtime system messages for Veryfront Cloud agent services.
 The helper inserts project instructions and project context blocks at the
 runtime-context marker, includes available skills, and appends environment
 context using the same prompt-block conventions as the core runtime.
 
 ### `buildVeryfrontCloudRuntimeInstructions(input)`
 
-Adapt hosted chat runtime preparation input into Veryfront Cloud runtime system
-messages. This is the callback-shaped companion to
+Adapt agent-service chat runtime preparation input into Veryfront Cloud runtime
+system messages. This is the callback-shaped companion to
 `createVeryfrontCloudRuntimeSystemMessages()` for
-`prepareVeryfrontCloudHostedChatExecution()`.
+`prepareVeryfrontCloudAgentServiceChatExecution()`.
 
 ### `resolveRuntimeAgentDefinitionsDir(options)`
 
-Resolve the `agents/` directory for a hosted service from a source or bundled
+Resolve the `agents/` directory for an agent service from a source or bundled
 module directory. The helper checks source-layout, bundled `dist/src`, and
 deeper bundled server paths for a markdown definition such as `assistant.md`.
 
@@ -759,7 +759,7 @@ deeper bundled server paths for a markdown definition such as `assistant.md`.
 Read a markdown agent definition from an `agents/` directory and parse its
 frontmatter plus body with `parseRuntimeAgentMarkdownDefinition()`. This keeps
 file loading, traversal-prone file-name validation, and markdown parsing
-consistent across separately deployed hosted agents.
+consistent across separately deployed agents.
 
 ### `filterAgentTraceAttributes(attributes)`
 
@@ -767,19 +767,22 @@ Filter an unknown attribute record down to OpenTelemetry-safe agent trace
 attribute values: strings, numbers, booleans, arrays of those primitives,
 `null`, or `undefined`.
 
-### `prepareVeryfrontCloudHostedChatExecution(options)`
+### `prepareVeryfrontCloudAgentServiceChatExecution(options)`
 
-Prepare hosted chat execution for services that run through Veryfront Cloud. The
-helper reuses the default hosted model normalization, hosted model thinking
+Prepare agent-service chat execution for services that run through Veryfront
+Cloud. The helper reuses the default Veryfront Cloud model normalization, model thinking
 defaults, and durable root-run persistence diagnostics while the host supplies
 steering fetch/build callbacks and runtime creation policy.
 
-### `createVeryfrontCloudHostedChatExecutionRootRunOptions(options)`
+### `createVeryfrontCloudAgentServiceChatExecutionRootRunOptions(options)`
 
 Create the default durable root-run preparation options used by
-`prepareVeryfrontCloudHostedChatExecution()`. Hosts may override persistence
-operation text, missing-user-message errors, instrumentation, implementation
+`prepareVeryfrontCloudAgentServiceChatExecution()`. Hosts may override
+persistence operation text, missing-user-message errors, instrumentation, implementation
 kind, or persistence-failure handling.
+
+The hosted-prefixed API names for these helpers remain available as compatibility
+aliases for existing services.
 
 ### `parseAgentServiceConfig(env)`
 
@@ -1001,54 +1004,54 @@ Clear all stored messages from memory.
 
 ### Functions
 
-| Name                                                            | Description                                                              |
-| --------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `agent`                                                         | Create an agent                                                          |
-| `agentAsTool`                                                   | Wrap agent as callable tool                                              |
-| `createAgUiCancelHandler`                                       | Create a DELETE handler for hosted AG-UI run cancellation                |
-| `createAgUiDetachedStartHandler`                                | Create a POST handler for detached hosted AG-UI run kickoff              |
-| `executeAgUiDetachedStart`                                      | Run detached hosted-start lifecycle from a validated request object      |
-| `createAgUiHandler`                                             | Create a POST handler for an AG-UI route                                 |
-| `createAgUiRuntimeHandler`                                      | Create a POST handler for the canonical runtime AG-UI request contract   |
-| `createAgUiRunErrorEvent`                                       | Create a `RunError` AG-UI SSE event                                      |
-| `createAgUiSseErrorResponse`                                    | Create an AG-UI SSE error `Response`                                     |
-| `createAgUiResumeHandler`                                       | Create a POST handler for hosted AG-UI run resume values                 |
-| `createAgentServiceRuntime`                                     | Create an agent service runtime with default service routes              |
-| `createDefaultHostedProjectSteeringRefresh`                     | Create the default hosted project steering refresh callback              |
-| `createHostedAgentProjectSteering`                              | Create hosted agent-definition and project-steering bindings             |
-| `buildVeryfrontCloudRuntimeInstructions`                        | Adapt hosted preparation input to Veryfront Cloud system messages        |
-| `createVeryfrontCloudHostedChatExecutionRootRunOptions`         | Create Veryfront Cloud hosted root-run preparation defaults              |
-| `createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions` | Create Veryfront Cloud prepared execution runtime defaults               |
-| `createVeryfrontCloudRuntimeSystemMessages`                     | Create Veryfront Cloud runtime system messages                           |
-| `fetchDefaultHostedProjectSteering`                             | Fetch initial hosted project instructions and skills                     |
-| `filterAgentTraceAttributes`                                    | Filter unknown records to valid agent trace attributes                   |
-| `createNodeAgentServiceRuntimeInfrastructure`                   | Create Node service config, logger, tracer, and telemetry bundle         |
-| `loadAgentServiceEnvFiles`                                      | Load service env files while preserving host process env                 |
-| `initializeNodeAgentServiceOpenTelemetry`                       | Initialize Node OpenTelemetry for an agent service                       |
-| `loadRuntimeAgentMarkdownDefinitionFromFile`                    | Load and parse a markdown agent definition from an agents directory      |
-| `parseAgentServiceConfig`                                       | Parse default agent service environment config                           |
-| `resolveNodeAgentServiceTelemetryConfig`                        | Resolve Node service OpenTelemetry config from environment               |
-| `prepareVeryfrontCloudHostedChatExecution`                      | Prepare hosted chat execution with Veryfront Cloud defaults              |
-| `normalizeAgUiRuntimeMessages`                                  | Normalize runtime AG-UI messages into package `Message[]`                |
-| `parseAgUiRuntimeRequest`                                       | Parse and validate the canonical runtime AG-UI request body              |
-| `parseAgUiRuntimeRequestOrError`                                | Parse runtime AG-UI input or return a `400` validation `Response`        |
-| `parseRuntimeAgentRunInvocation`                                | Parse and validate a control-plane runtime agent invocation body         |
-| `startNodeAgentService`                                         | Start an agent service with the Node service server adapter              |
-| `parseRuntimeAgentRunInvocationOrError`                         | Parse a runtime agent invocation or return a `400` validation `Response` |
-| `resolveRuntimeAgentDefinitionsDir`                             | Resolve a hosted service `agents/` directory from source/bundled paths   |
-| `createChatHandler`                                             | Create a POST handler for a chat API route.                              |
-| `createMemory`                                                  | Create memory (buffer, conversation, summary)                            |
-| `createRedisMemory`                                             | Create Redis-backed memory                                               |
-| `createWorkflow`                                                | Create sequential agent workflow                                         |
-| `getAgent`                                                      | Get agent by ID                                                          |
-| `getAgentsAsTools`                                              | Get agents as tools (multi-agent)                                        |
-| `getAllAgentIds`                                                | List registered agent IDs                                                |
-| `getTextFromParts`                                              | Extract text from multi-part message                                     |
-| `getToolArguments`                                              | Extract parsed tool call args                                            |
-| `hasArgs`                                                       | Check for parsed args on tool call                                       |
-| `hasInput`                                                      | Check for raw input on tool call                                         |
-| `registerAgent`                                                 | Register agent for discovery                                             |
-| `waitForHumanInput`                                             | Wait for a canonical human-input response over hosted AG-UI run control  |
+| Name                                                                  | Description                                                              |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `agent`                                                               | Create an agent                                                          |
+| `agentAsTool`                                                         | Wrap agent as callable tool                                              |
+| `createAgUiCancelHandler`                                             | Create a DELETE handler for hosted AG-UI run cancellation                |
+| `createAgUiDetachedStartHandler`                                      | Create a POST handler for detached hosted AG-UI run kickoff              |
+| `executeAgUiDetachedStart`                                            | Run detached hosted-start lifecycle from a validated request object      |
+| `createAgUiHandler`                                                   | Create a POST handler for an AG-UI route                                 |
+| `createAgUiRuntimeHandler`                                            | Create a POST handler for the canonical runtime AG-UI request contract   |
+| `createAgUiRunErrorEvent`                                             | Create a `RunError` AG-UI SSE event                                      |
+| `createAgUiSseErrorResponse`                                          | Create an AG-UI SSE error `Response`                                     |
+| `createAgUiResumeHandler`                                             | Create a POST handler for hosted AG-UI run resume values                 |
+| `createAgentServiceRuntime`                                           | Create an agent service runtime with default service routes              |
+| `createDefaultAgentServiceProjectSteeringRefresh`                     | Create the default agent-service project steering refresh callback       |
+| `createAgentServiceProjectSteering`                                   | Create agent-service agent-definition and project-steering bindings      |
+| `buildVeryfrontCloudRuntimeInstructions`                              | Adapt agent-service preparation input to Veryfront Cloud system messages |
+| `createVeryfrontCloudAgentServiceChatExecutionRootRunOptions`         | Create Veryfront Cloud agent-service root-run preparation defaults       |
+| `createVeryfrontCloudPreparedAgentServiceChatExecutionRuntimeOptions` | Create Veryfront Cloud prepared execution runtime defaults               |
+| `createVeryfrontCloudRuntimeSystemMessages`                           | Create Veryfront Cloud runtime system messages                           |
+| `fetchDefaultAgentServiceProjectSteering`                             | Fetch initial agent-service project instructions and skills              |
+| `filterAgentTraceAttributes`                                          | Filter unknown records to valid agent trace attributes                   |
+| `createNodeAgentServiceRuntimeInfrastructure`                         | Create Node service config, logger, tracer, and telemetry bundle         |
+| `loadAgentServiceEnvFiles`                                            | Load service env files while preserving host process env                 |
+| `initializeNodeAgentServiceOpenTelemetry`                             | Initialize Node OpenTelemetry for an agent service                       |
+| `loadRuntimeAgentMarkdownDefinitionFromFile`                          | Load and parse a markdown agent definition from an agents directory      |
+| `parseAgentServiceConfig`                                             | Parse default agent service environment config                           |
+| `resolveNodeAgentServiceTelemetryConfig`                              | Resolve Node service OpenTelemetry config from environment               |
+| `prepareVeryfrontCloudAgentServiceChatExecution`                      | Prepare agent-service chat execution with Veryfront Cloud defaults       |
+| `normalizeAgUiRuntimeMessages`                                        | Normalize runtime AG-UI messages into package `Message[]`                |
+| `parseAgUiRuntimeRequest`                                             | Parse and validate the canonical runtime AG-UI request body              |
+| `parseAgUiRuntimeRequestOrError`                                      | Parse runtime AG-UI input or return a `400` validation `Response`        |
+| `parseRuntimeAgentRunInvocation`                                      | Parse and validate a control-plane runtime agent invocation body         |
+| `startNodeAgentService`                                               | Start an agent service with the Node service server adapter              |
+| `parseRuntimeAgentRunInvocationOrError`                               | Parse a runtime agent invocation or return a `400` validation `Response` |
+| `resolveRuntimeAgentDefinitionsDir`                                   | Resolve a hosted service `agents/` directory from source/bundled paths   |
+| `createChatHandler`                                                   | Create a POST handler for a chat API route.                              |
+| `createMemory`                                                        | Create memory (buffer, conversation, summary)                            |
+| `createRedisMemory`                                                   | Create Redis-backed memory                                               |
+| `createWorkflow`                                                      | Create sequential agent workflow                                         |
+| `getAgent`                                                            | Get agent by ID                                                          |
+| `getAgentsAsTools`                                                    | Get agents as tools (multi-agent)                                        |
+| `getAllAgentIds`                                                      | List registered agent IDs                                                |
+| `getTextFromParts`                                                    | Extract text from multi-part message                                     |
+| `getToolArguments`                                                    | Extract parsed tool call args                                            |
+| `hasArgs`                                                             | Check for parsed args on tool call                                       |
+| `hasInput`                                                            | Check for raw input on tool call                                         |
+| `registerAgent`                                                       | Register agent for discovery                                             |
+| `waitForHumanInput`                                                   | Wait for a canonical human-input response over hosted AG-UI run control  |
 
 ### Classes
 

--- a/src/agent/agent-service-api-aliases.test.ts
+++ b/src/agent/agent-service-api-aliases.test.ts
@@ -1,0 +1,67 @@
+import {
+  createAgentServiceFormInputTool,
+  createAgentServiceProjectSteering,
+  createDefaultAgentServiceChatRuntime,
+  createDefaultAgentServiceInvokeAgentTool,
+  createDefaultAgentServiceProjectSteeringRefresh,
+  createDefaultHostedChatRuntime,
+  createDefaultHostedInvokeAgentTool,
+  createDefaultHostedProjectSteeringRefresh,
+  createHostedAgentProjectSteering,
+  createHostedFormInputTool,
+  createVeryfrontCloudPreparedAgentServiceChatExecutionRuntimeOptions,
+  createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions,
+  fetchDefaultAgentServiceProjectSteering,
+  fetchDefaultHostedProjectSteering,
+  prepareVeryfrontCloudAgentServiceChatExecution,
+  prepareVeryfrontCloudHostedChatExecution,
+  runPreparedAgentServiceChatExecutionDetached,
+  runPreparedHostedChatExecutionDetached,
+  streamPreparedAgentServiceChatExecutionToAgUiResponse,
+  streamPreparedHostedChatExecutionToAgUiResponse,
+} from "./index.ts";
+
+Deno.test("agent-service API names alias existing hosted runtime primitives", () => {
+  if (createDefaultAgentServiceChatRuntime !== createDefaultHostedChatRuntime) {
+    throw new Error("Expected chat runtime alias to reference the hosted implementation");
+  }
+  if (createDefaultAgentServiceInvokeAgentTool !== createDefaultHostedInvokeAgentTool) {
+    throw new Error("Expected invoke_agent alias to reference the hosted implementation");
+  }
+  if (
+    createDefaultAgentServiceProjectSteeringRefresh !== createDefaultHostedProjectSteeringRefresh
+  ) {
+    throw new Error(
+      "Expected project steering refresh alias to reference the hosted implementation",
+    );
+  }
+  if (fetchDefaultAgentServiceProjectSteering !== fetchDefaultHostedProjectSteering) {
+    throw new Error("Expected project steering fetch alias to reference the hosted implementation");
+  }
+  if (createAgentServiceProjectSteering !== createHostedAgentProjectSteering) {
+    throw new Error("Expected project steering alias to reference the hosted implementation");
+  }
+  if (createAgentServiceFormInputTool !== createHostedFormInputTool) {
+    throw new Error("Expected form input alias to reference the hosted implementation");
+  }
+  if (
+    createVeryfrontCloudPreparedAgentServiceChatExecutionRuntimeOptions !==
+      createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions
+  ) {
+    throw new Error(
+      "Expected prepared runtime options alias to reference the hosted implementation",
+    );
+  }
+  if (prepareVeryfrontCloudAgentServiceChatExecution !== prepareVeryfrontCloudHostedChatExecution) {
+    throw new Error("Expected chat preparation alias to reference the hosted implementation");
+  }
+  if (runPreparedAgentServiceChatExecutionDetached !== runPreparedHostedChatExecutionDetached) {
+    throw new Error("Expected detached execution alias to reference the hosted implementation");
+  }
+  if (
+    streamPreparedAgentServiceChatExecutionToAgUiResponse !==
+      streamPreparedHostedChatExecutionToAgUiResponse
+  ) {
+    throw new Error("Expected AG-UI stream alias to reference the hosted implementation");
+  }
+});

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -258,24 +258,46 @@ export {
 } from "./agent-service-server.ts";
 export {
   createDefaultHostedChatRuntime,
+  createDefaultHostedChatRuntime as createDefaultAgentServiceChatRuntime,
   type CreateDefaultHostedChatRuntimeContextInput,
+  type CreateDefaultHostedChatRuntimeContextInput
+    as CreateDefaultAgentServiceChatRuntimeContextInput,
   type CreateDefaultHostedChatRuntimeOptions,
+  type CreateDefaultHostedChatRuntimeOptions as CreateDefaultAgentServiceChatRuntimeOptions,
   type DefaultHostedChatRuntimeConfig,
+  type DefaultHostedChatRuntimeConfig as DefaultAgentServiceChatRuntimeConfig,
   type DefaultHostedChatRuntimeCreationOptions,
+  type DefaultHostedChatRuntimeCreationOptions as DefaultAgentServiceChatRuntimeCreationOptions,
   type DefaultHostedChatRuntimeLogger,
+  type DefaultHostedChatRuntimeLogger as DefaultAgentServiceChatRuntimeLogger,
   type DefaultHostedChatRuntimeProjectSwitchInput,
+  type DefaultHostedChatRuntimeProjectSwitchInput
+    as DefaultAgentServiceChatRuntimeProjectSwitchInput,
   type DefaultHostedChatRuntimeSteeringMutationInput,
+  type DefaultHostedChatRuntimeSteeringMutationInput
+    as DefaultAgentServiceChatRuntimeSteeringMutationInput,
   type DefaultHostedChatRuntimeSystemRefreshInput,
+  type DefaultHostedChatRuntimeSystemRefreshInput
+    as DefaultAgentServiceChatRuntimeSystemRefreshInput,
   type DefaultHostedChatRuntimeTaskContext,
+  type DefaultHostedChatRuntimeTaskContext as DefaultAgentServiceChatRuntimeTaskContext,
 } from "./default-hosted-chat-runtime.ts";
 export {
   createDefaultHostedProjectSteeringRefresh,
+  createDefaultHostedProjectSteeringRefresh as createDefaultAgentServiceProjectSteeringRefresh,
   type CreateDefaultHostedProjectSteeringRefreshOptions,
+  type CreateDefaultHostedProjectSteeringRefreshOptions
+    as CreateDefaultAgentServiceProjectSteeringRefreshOptions,
   type DefaultHostedProjectSteeringFetchers,
+  type DefaultHostedProjectSteeringFetchers as DefaultAgentServiceProjectSteeringFetchers,
   type DefaultHostedProjectSteeringRefreshLogger,
+  type DefaultHostedProjectSteeringRefreshLogger as DefaultAgentServiceProjectSteeringRefreshLogger,
   type DefaultHostedProjectSteeringRefreshLookup,
+  type DefaultHostedProjectSteeringRefreshLookup as DefaultAgentServiceProjectSteeringRefreshLookup,
   fetchDefaultHostedProjectSteering,
+  fetchDefaultHostedProjectSteering as fetchDefaultAgentServiceProjectSteering,
   type FetchDefaultHostedProjectSteeringInput,
+  type FetchDefaultHostedProjectSteeringInput as FetchDefaultAgentServiceProjectSteeringInput,
 } from "./default-hosted-project-steering-refresh.ts";
 
 export {
@@ -433,14 +455,23 @@ export {
 
 export type {
   HostedChatRuntimeAgent,
+  HostedChatRuntimeAgent as AgentServiceChatRuntimeAgent,
   HostedChatRuntimeCreationOptions,
+  HostedChatRuntimeCreationOptions as AgentServiceChatRuntimeCreationOptions,
   HostedChatRuntimeCreationResult,
+  HostedChatRuntimeCreationResult as AgentServiceChatRuntimeCreationResult,
   HostedChatRuntimeFinishPart,
+  HostedChatRuntimeFinishPart as AgentServiceChatRuntimeFinishPart,
   HostedChatRuntimeOnFinishEvent,
+  HostedChatRuntimeOnFinishEvent as AgentServiceChatRuntimeOnFinishEvent,
   HostedChatRuntimeProjectSteering,
+  HostedChatRuntimeProjectSteering as AgentServiceChatRuntimeProjectSteering,
   HostedChatRuntimeStreamInput,
+  HostedChatRuntimeStreamInput as AgentServiceChatRuntimeStreamInput,
   HostedChatRuntimeStreamResult,
+  HostedChatRuntimeStreamResult as AgentServiceChatRuntimeStreamResult,
   HostedChatRuntimeToUiMessageStreamOptions,
+  HostedChatRuntimeToUiMessageStreamOptions as AgentServiceChatRuntimeToUiMessageStreamOptions,
 } from "./hosted-chat-runtime-contract.ts";
 
 export {
@@ -916,18 +947,29 @@ export {
 } from "./hosted-child-invoke-tool.ts";
 export {
   createDefaultHostedInvokeAgentTool,
+  createDefaultHostedInvokeAgentTool as createDefaultAgentServiceInvokeAgentTool,
   type DefaultHostedInvokeAgentConfig,
+  type DefaultHostedInvokeAgentConfig as DefaultAgentServiceInvokeAgentConfig,
   type DefaultHostedInvokeAgentContext,
+  type DefaultHostedInvokeAgentContext as DefaultAgentServiceInvokeAgentContext,
   type DefaultHostedInvokeAgentInput,
+  type DefaultHostedInvokeAgentInput as DefaultAgentServiceInvokeAgentInput,
   defaultHostedInvokeAgentInputSchema,
   type DefaultHostedInvokeAgentLogger,
+  type DefaultHostedInvokeAgentLogger as DefaultAgentServiceInvokeAgentLogger,
   type DefaultHostedInvokeAgentProjectRefresh,
+  type DefaultHostedInvokeAgentProjectRefresh as DefaultAgentServiceInvokeAgentProjectRefresh,
   defaultHostedInvokeAgentSelectionSchema,
   type DefaultHostedInvokeAgentToolOptions,
+  type DefaultHostedInvokeAgentToolOptions as DefaultAgentServiceInvokeAgentToolOptions,
   type DefaultHostedInvokeAgentToolResult,
+  type DefaultHostedInvokeAgentToolResult as DefaultAgentServiceInvokeAgentToolResult,
   type DefaultHostedInvokeAgentTrace,
+  type DefaultHostedInvokeAgentTrace as DefaultAgentServiceInvokeAgentTrace,
   type DefaultHostedInvokeAgentTraceAttributes,
+  type DefaultHostedInvokeAgentTraceAttributes as DefaultAgentServiceInvokeAgentTraceAttributes,
   executeDefaultHostedInvokeAgentTool,
+  executeDefaultHostedInvokeAgentTool as executeDefaultAgentServiceInvokeAgentTool,
 } from "./default-hosted-invoke-agent-tool.ts";
 export {
   buildDefaultHostedChildForkToolSet,
@@ -1049,15 +1091,21 @@ export {
 } from "./runtime-project-files-client.ts";
 export {
   createHostedAgentProjectSteering,
+  createHostedAgentProjectSteering as createAgentServiceProjectSteering,
   type HostedAgentProjectSteering,
+  type HostedAgentProjectSteering as AgentServiceProjectSteering,
   type HostedAgentProjectSteeringLogger,
+  type HostedAgentProjectSteeringLogger as AgentServiceProjectSteeringLogger,
   type HostedAgentProjectSteeringOptions,
+  type HostedAgentProjectSteeringOptions as AgentServiceProjectSteeringOptions,
   type HostedAgentProjectSteeringOptionsData,
+  type HostedAgentProjectSteeringOptionsData as AgentServiceProjectSteeringOptionsData,
   hostedAgentProjectSteeringOptionsSchema,
 } from "./hosted-agent-project-steering.ts";
 export {
   createHostedProjectSteeringAdapter,
   type HostedProjectSkillIdsContext,
+  type HostedProjectSkillIdsContext as AgentServiceProjectSkillIdsContext,
   type HostedProjectSteeringAdapter,
   type HostedProjectSteeringAdapterOptions,
   type HostedProjectSteeringLogger,
@@ -1199,21 +1247,39 @@ export {
 } from "./hosted-chat-execution-runtime.ts";
 export {
   type PreparedHostedChatExecution,
+  type PreparedHostedChatExecution as PreparedAgentServiceChatExecution,
   type PreparedHostedChatExecutionDetachedInput,
+  type PreparedHostedChatExecutionDetachedInput as PreparedAgentServiceChatExecutionDetachedInput,
   type PreparedHostedChatExecutionRuntimeOptions,
+  type PreparedHostedChatExecutionRuntimeOptions as PreparedAgentServiceChatExecutionRuntimeOptions,
   type PreparedHostedChatExecutionStreamInput,
+  type PreparedHostedChatExecutionStreamInput as PreparedAgentServiceChatExecutionStreamInput,
   runPreparedHostedChatExecutionDetached,
+  runPreparedHostedChatExecutionDetached as runPreparedAgentServiceChatExecutionDetached,
   streamPreparedHostedChatExecutionToAgUiResponse,
+  streamPreparedHostedChatExecutionToAgUiResponse
+    as streamPreparedAgentServiceChatExecutionToAgUiResponse,
 } from "./prepared-hosted-chat-execution.ts";
 export {
   createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions,
+  createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions
+    as createVeryfrontCloudPreparedAgentServiceChatExecutionRuntimeOptions,
   type CreateVeryfrontCloudPreparedHostedChatExecutionRuntimeOptionsInput,
+  type CreateVeryfrontCloudPreparedHostedChatExecutionRuntimeOptionsInput
+    as CreateVeryfrontCloudPreparedAgentServiceChatExecutionRuntimeOptionsInput,
 } from "./veryfront-cloud-prepared-hosted-chat-execution-runtime.ts";
 export {
   createVeryfrontCloudHostedChatExecutionRootRunOptions,
+  createVeryfrontCloudHostedChatExecutionRootRunOptions
+    as createVeryfrontCloudAgentServiceChatExecutionRootRunOptions,
   prepareVeryfrontCloudHostedChatExecution,
+  prepareVeryfrontCloudHostedChatExecution as prepareVeryfrontCloudAgentServiceChatExecution,
   type PrepareVeryfrontCloudHostedChatExecutionInput,
+  type PrepareVeryfrontCloudHostedChatExecutionInput
+    as PrepareVeryfrontCloudAgentServiceChatExecutionInput,
   type VeryfrontCloudHostedChatExecutionPreparationLogger,
+  type VeryfrontCloudHostedChatExecutionPreparationLogger
+    as VeryfrontCloudAgentServiceChatExecutionPreparationLogger,
 } from "./veryfront-cloud-hosted-chat-execution-preparation.ts";
 export {
   finalizeHostedDetached,
@@ -1468,7 +1534,9 @@ export {
 } from "./ag-ui-handler.ts";
 export {
   createHostedFormInputTool,
+  createHostedFormInputTool as createAgentServiceFormInputTool,
   type HostedFormInputToolContext,
+  type HostedFormInputToolContext as AgentServiceFormInputToolContext,
 } from "./hosted-form-input-tool.ts";
 export {
   buildInputRequestLifecycleDataEvent,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.494";
+export const VERSION = "0.1.495";


### PR DESCRIPTION
## Summary
- Add agent-service named aliases for reusable chat runtime, project steering, invoke_agent, form input, prepared execution, and Veryfront Cloud preparation helpers.
- Keep hosted-prefixed names as compatibility aliases for existing services.
- Update docs/reference to use the agent-service names by default.
- Bump package version to 0.1.495 for CI/CD publish.

## Verification
- `deno test --no-check --allow-all --unstable-worker-options --unstable-net src/agent/agent-service-api-aliases.test.ts src/agent/default-hosted-chat-runtime.test.ts src/agent/default-hosted-project-steering-refresh.test.ts src/agent/default-hosted-invoke-agent-tool.test.ts src/agent/hosted-agent-project-steering.test.ts src/agent/veryfront-cloud-hosted-chat-execution-preparation.test.ts src/agent/veryfront-cloud-prepared-hosted-chat-execution-runtime.test.ts src/agent/hosted-form-input-tool.test.ts`
- `deno task verify:quick`
- pre-push checks, including full unit suite
