### PR TITLE
Add agent service sandbox tool option

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.496",
+  "version": "0.1.497",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/agent-service-boundary-aliases.test.ts
+++ b/src/agent/agent-service-boundary-aliases.test.ts
@@ -16,6 +16,8 @@ import {
   createHostedAgentServiceRouteSet,
   createHostedAgUiValidationErrorResponse,
   createHostedServiceAuth,
+  type DefaultAgentServiceInvokeAgentContext,
+  type DefaultAgentServiceInvokeAgentToolOptions,
   deriveAgentServiceAgUiChatContext,
   type DerivedAgentServiceAgUiChatContext,
   deriveHostedAgUiChatContext,
@@ -82,6 +84,11 @@ Deno.test("agent-service boundary aliases are available as types", () => {
   const rootRunContext: Partial<AgentServiceConversationRootRunContext> = {};
   const normalizedRequest: Partial<NormalizedAgentServiceChatRequest> = {};
   const toolAssembly: Partial<AgentServiceChatRuntimeToolAssemblyResult> = {};
+  const invokeOptions: Partial<
+    DefaultAgentServiceInvokeAgentToolOptions<DefaultAgentServiceInvokeAgentContext>
+  > = {
+    createAgentServiceSandboxTools: undefined,
+  };
 
   assertEquals(routeOptions, {});
   assertEquals(parsedRequest, {});
@@ -89,4 +96,5 @@ Deno.test("agent-service boundary aliases are available as types", () => {
   assertEquals(rootRunContext, {});
   assertEquals(normalizedRequest, {});
   assertEquals(toolAssembly, {});
+  assertEquals(invokeOptions, { createAgentServiceSandboxTools: undefined });
 });

--- a/src/agent/default-hosted-invoke-agent-tool.ts
+++ b/src/agent/default-hosted-invoke-agent-tool.ts
@@ -127,6 +127,9 @@ export type DefaultHostedInvokeAgentToolOptions<TContext extends DefaultHostedIn
     createHostedSandboxTools?: (
       input: HostedSandboxToolsOptions,
     ) => Promise<HostedSandboxToolsResult>;
+    createAgentServiceSandboxTools?: (
+      input: HostedSandboxToolsOptions,
+    ) => Promise<HostedSandboxToolsResult>;
     createRemoteToolSource?: (config: RemoteMCPToolSourceConfig) => RemoteToolSource;
     createToolsFromRemoteDefinitions?: typeof createToolsFromRemoteDefinitions;
     createLiveStudioTools?: Parameters<typeof prepareDefaultHostedChildForkSandboxToolSources>[0][
@@ -213,7 +216,8 @@ async function prepareForkToolSources<TContext extends DefaultHostedInvokeAgentC
     isAbortError: isChildRunAbortError,
     logger: options.logger,
     createBashTool: options.createBashTool,
-    createHostedSandboxTools: options.createHostedSandboxTools ?? createHostedSandboxTools,
+    createAgentServiceSandboxTools: options.createAgentServiceSandboxTools ??
+      options.createHostedSandboxTools ?? createHostedSandboxTools,
     createLiveStudioTools: options.createLiveStudioTools ?? createLiveStudioMcpTools,
     createRemoteToolSource: options.createRemoteToolSource ?? createRemoteMCPToolSource,
     createToolsFromRemoteDefinitions: options.createToolsFromRemoteDefinitions ??

--- a/src/agent/hosted-child-fork-tool-sources.ts
+++ b/src/agent/hosted-child-fork-tool-sources.ts
@@ -68,6 +68,9 @@ export type PrepareDefaultHostedChildForkSandboxToolSourcesInput =
     createHostedSandboxTools?: (
       input: HostedSandboxToolsOptions,
     ) => Promise<HostedSandboxToolsResult>;
+    createAgentServiceSandboxTools?: (
+      input: HostedSandboxToolsOptions,
+    ) => Promise<HostedSandboxToolsResult>;
   };
 
 export async function prepareDefaultHostedChildForkToolSources(
@@ -148,10 +151,12 @@ export async function prepareDefaultHostedChildForkSandboxToolSources(
     apiUrl,
     createBashTool,
     createHostedSandboxTools: createHostedSandboxToolsOverride,
+    createAgentServiceSandboxTools: createAgentServiceSandboxToolsOverride,
     globalTools,
     ...toolSourceInput
   } = input;
-  const createSandboxTools = createHostedSandboxToolsOverride ?? createHostedSandboxTools;
+  const createSandboxTools = createAgentServiceSandboxToolsOverride ??
+    createHostedSandboxToolsOverride ?? createHostedSandboxTools;
   const sandboxResult = await createSandboxTools({
     authToken: input.authToken,
     apiUrl,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.496";
+export const VERSION = "0.1.497";


### PR DESCRIPTION
## Summary
- accept `createAgentServiceSandboxTools` alongside the hosted compatibility option in child fork sandbox tool assembly
- prefer the agent-service option when both are supplied
- bump package version for CI/CD publishing

## Verification
- deno test --no-check --allow-all --unstable-worker-options --unstable-net src/agent/agent-service-boundary-aliases.test.ts
- deno check src/agent/default-hosted-invoke-agent-tool.ts src/agent/hosted-child-fork-tool-sources.ts src/agent/agent-service-boundary-aliases.test.ts
- deno task verify:quick
- pre-push checks