### PR TITLE
Add Veryfront Cloud agent service preset

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.498",
+  "version": "0.1.499",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -180,7 +180,8 @@ agent definition and project-steering adapter as one reusable service primitive.
 For the standard Veryfront Cloud service shape, use
 `runNodeVeryfrontCloudAgentServiceMain()` to bind those pieces in one Node
 process entrypoint. The service entrypoint can stay small while agent behavior
-lives in `agents/<agent-id>.md`:
+lives in `agents/<agent-id>.md` or a discovered code agent such as
+`agents/<agent-id>.ts`:
 
 ```ts
 import { createBashTool } from "bash-tool";
@@ -196,6 +197,12 @@ await runNodeVeryfrontCloudAgentServiceMain({
 
 Use the lower-level helpers when a service needs custom tools, non-Node
 startup, or a different control-plane integration.
+
+The cloud service helper uses the same project discovery conventions as normal
+Veryfront projects: `agents/`, `tools/`, `skills/`, `resources/`, `prompts/`,
+`workflows/`, and `tasks/`. When a project needs non-standard paths, configure
+them in `veryfront.config.ts` under `ai.<primitive>.discovery.paths` instead of
+adding service-specific discovery configuration.
 
 ## Agent configuration
 

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -177,6 +177,25 @@ agent stores persona/configuration in `agents/*.md` files.
 If the service also uses the project-files API for instructions, skills,
 and `load_skill`, use `createAgentServiceProjectSteering()` to bind the markdown
 agent definition and project-steering adapter as one reusable service primitive.
+For the standard Veryfront Cloud service shape, use
+`runNodeVeryfrontCloudAgentServiceMain()` to bind those pieces in one Node
+process entrypoint. The service entrypoint can stay small while agent behavior
+lives in `agents/<agent-id>.md`:
+
+```ts
+import { createBashTool } from "bash-tool";
+import { runNodeVeryfrontCloudAgentServiceMain } from "veryfront/agent";
+
+await runNodeVeryfrontCloudAgentServiceMain({
+  serviceName: "support-agent",
+  agentId: "support",
+  entryUrl: import.meta.url,
+  createBashTool,
+});
+```
+
+Use the lower-level helpers when a service needs custom tools, non-Node
+startup, or a different control-plane integration.
 
 ## Agent configuration
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -107,7 +107,7 @@ defineConfig({
 });
 ```
 
-### AI discovery (tools, agents, skills)
+### AI discovery
 
 Control which directories are scanned for AI primitives:
 
@@ -132,13 +132,33 @@ defineConfig({
         paths: ["skills", "internal/skills"],
       },
     },
+    prompts: {
+      discovery: {
+        paths: ["prompts"],
+      },
+    },
+    resources: {
+      discovery: {
+        paths: ["resources"],
+      },
+    },
+    workflows: {
+      discovery: {
+        paths: ["workflows"],
+      },
+    },
+    tasks: {
+      discovery: {
+        paths: ["tasks"],
+      },
+    },
   },
 });
 ```
 
 Notes:
 - `paths` are relative to your project root.
-- Defaults are `tools`, `agents`, and `skills`.
+- Defaults are `tools`, `agents`, `skills`, `prompts`, `resources`, `workflows`, and `tasks`.
 - Set `enabled: false` to disable discovery for that primitive.
 
 ### AI providers and MCP

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -34,6 +34,7 @@ import {
   createAgUiSseErrorResponse,
   createMemory,
   createNodeAgentServiceRuntimeInfrastructure,
+  createVeryfrontCloudAgentServiceRuntime,
   defineAgentService,
   DurableRunSink,
   executeAgUiDetachedStart,
@@ -57,10 +58,12 @@ import {
   registerAgent,
   runHostedChildLifecycle,
   runHostedLifecycle,
+  runNodeVeryfrontCloudAgentServiceMain,
   RunResumeSessionManager,
   RuntimeAgentRunInvocationSchema,
   shouldSkipHostedChildTerminalPersistence,
   startNodeAgentService,
+  startNodeVeryfrontCloudAgentService,
   waitForHumanInput,
 } from "veryfront/agent";
 ```
@@ -262,6 +265,29 @@ one registry contract. `service.createRuntime({ routes })` creates a
 request-native runtime with readiness, liveness, CORS, shutdown state, and
 host-supplied routes. For Node deployments, `startNodeAgentService()` wraps that
 runtime in the shared Veryfront service server with graceful shutdown.
+
+For a Veryfront Cloud-backed Node service that should use the default
+configuration, telemetry, model routing, sandbox, Studio MCP, project steering,
+durable-run, and prepared-execution wiring, use
+`runNodeVeryfrontCloudAgentServiceMain()` from a process entrypoint and keep the
+agent behavior in `agents/<agent-id>.md`:
+
+```ts
+import { createBashTool } from "bash-tool";
+import { runNodeVeryfrontCloudAgentServiceMain } from "veryfront/agent";
+
+await runNodeVeryfrontCloudAgentServiceMain({
+  serviceName: "support-agent",
+  agentId: "support",
+  entryUrl: import.meta.url,
+  createBashTool,
+});
+```
+
+`createVeryfrontCloudAgentServiceRuntime()` returns the same runtime bundle
+without starting a server, which is useful for tests and custom host shells.
+`startNodeVeryfrontCloudAgentService()` starts the Node server directly without
+the process bootstrap wrapper.
 
 For a conversations/control-plane host composition that combines
 `runHostedLifecycle()` with the public durable-run helpers, see
@@ -790,6 +816,32 @@ helpers; for example `createAgentServiceRouteSet()`,
 `prepareAgentServiceConversationRootRunContext()`,
 `toMirroredAgentServiceStreamPart()`, and `createAgentServiceAuth()`.
 
+### `createVeryfrontCloudAgentServiceRuntime(options)`
+
+Create a full Veryfront Cloud agent-service runtime bundle for separately
+deployed agents. The helper loads a markdown-backed `agents/*.md` definition,
+uses the default service config and project-steering adapter, wires local tools
+(`form_input`, `load_skill`, `sleep`, and `invoke_agent`), sandbox tools, Studio
+MCP tools, remote MCP definitions, prepared chat execution, AG-UI streaming, and
+detached durable-run execution.
+
+Hosts provide the service name, agent id, Node entry URL or base directory, and
+a bash-tool factory. Use this helper when tests or custom hosts need the runtime
+bundle without starting the Node server.
+
+### `startNodeVeryfrontCloudAgentService(options)`
+
+Start a Veryfront Cloud agent-service runtime with the shared Node service
+server and graceful shutdown handling. This helper is Node-specific. Use the
+lower-level agent-service runtime APIs for non-Node hosts.
+
+### `runNodeVeryfrontCloudAgentServiceMain(options)`
+
+Run the default Node process bootstrap for a Veryfront Cloud agent service. The
+helper loads `.env` files, initializes OpenTelemetry, registers trace-context
+logging, starts the Node service server, and handles startup failures through
+the provided process target.
+
 ### `parseAgentServiceConfig(env)`
 
 Parse the default agent service environment contract. The helper
@@ -1035,6 +1087,7 @@ Clear all stored messages from memory.
 | `deriveAgentServiceAgUiChatContext`                                   | Derive chat context from canonical AG-UI runtime input                   |
 | `filterAgentTraceAttributes`                                          | Filter unknown records to valid agent trace attributes                   |
 | `createNodeAgentServiceRuntimeInfrastructure`                         | Create Node service config, logger, tracer, and telemetry bundle         |
+| `createVeryfrontCloudAgentServiceRuntime`                             | Create a full Veryfront Cloud agent-service runtime bundle               |
 | `loadAgentServiceEnvFiles`                                            | Load service env files while preserving host process env                 |
 | `initializeNodeAgentServiceOpenTelemetry`                             | Initialize Node OpenTelemetry for an agent service                       |
 | `parseAgentServiceChatRequestFromRequest`                             | Parse the agent-service chat request body and auth context               |
@@ -1046,7 +1099,9 @@ Clear all stored messages from memory.
 | `parseAgUiRuntimeRequest`                                             | Parse and validate the canonical runtime AG-UI request body              |
 | `parseAgUiRuntimeRequestOrError`                                      | Parse runtime AG-UI input or return a `400` validation `Response`        |
 | `parseRuntimeAgentRunInvocation`                                      | Parse and validate a control-plane runtime agent invocation body         |
+| `runNodeVeryfrontCloudAgentServiceMain`                               | Run the default Node process bootstrap for a Veryfront Cloud service     |
 | `startNodeAgentService`                                               | Start an agent service with the Node service server adapter              |
+| `startNodeVeryfrontCloudAgentService`                                 | Start a Veryfront Cloud agent service with the Node server adapter       |
 | `parseRuntimeAgentRunInvocationOrError`                               | Parse a runtime agent invocation or return a `400` validation `Response` |
 | `resolveRuntimeAgentDefinitionsDir`                                   | Resolve a hosted service `agents/` directory from source/bundled paths   |
 | `createChatHandler`                                                   | Create a POST handler for a chat API route.                              |

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -270,7 +270,7 @@ For a Veryfront Cloud-backed Node service that should use the default
 configuration, telemetry, model routing, sandbox, Studio MCP, project steering,
 durable-run, and prepared-execution wiring, use
 `runNodeVeryfrontCloudAgentServiceMain()` from a process entrypoint and keep the
-agent behavior in `agents/<agent-id>.md`:
+agent behavior in `agents/<agent-id>.md` or `agents/<agent-id>.ts`:
 
 ```ts
 import { createBashTool } from "bash-tool";
@@ -288,6 +288,13 @@ await runNodeVeryfrontCloudAgentServiceMain({
 without starting a server, which is useful for tests and custom host shells.
 `startNodeVeryfrontCloudAgentService()` starts the Node server directly without
 the process bootstrap wrapper.
+
+The Veryfront Cloud service preset discovers the same project primitives as the
+project runtime: `agents/`, `tools/`, `skills/`, `resources/`, `prompts/`,
+`workflows/`, and `tasks/`. Code agents are preferred when the same `agentId` is
+available from discovery; set `agentSource: "markdown"` to force markdown
+definitions. Use `veryfront.config.ts` `ai.<primitive>.discovery.paths` for
+non-standard project paths.
 
 For a conversations/control-plane host composition that combines
 `runHostedLifecycle()` with the public durable-run helpers, see
@@ -819,11 +826,14 @@ helpers; for example `createAgentServiceRouteSet()`,
 ### `createNodeVeryfrontCloudAgentServiceRuntime(options)`
 
 Create a full Veryfront Cloud agent-service runtime bundle for separately
-deployed agents. The helper loads a markdown-backed `agents/*.md` definition,
-uses the default service config and project-steering adapter, wires local tools
-(`form_input`, `load_skill`, `sleep`, and `invoke_agent`), sandbox tools, Studio
-MCP tools, remote MCP definitions, prepared chat execution, AG-UI streaming, and
-detached durable-run execution.
+deployed agents. The helper discovers project primitives using the same
+conventions and `veryfront.config.ts` discovery settings as a Veryfront project.
+It can use a code agent from `agents/*.ts` or fall back to a markdown-backed
+`agents/*.md` definition, uses the default service config and project-steering
+adapter, wires local tools (`form_input`, `load_skill`, `sleep`, discovered
+project tools, and `invoke_agent`), sandbox tools, Studio MCP tools, remote MCP
+definitions, prepared chat execution, AG-UI streaming, and detached durable-run
+execution.
 
 Hosts provide the service name, agent id, Node entry URL or base directory, and
 a bash-tool factory. Use this helper when tests or custom hosts need the runtime

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -34,7 +34,7 @@ import {
   createAgUiSseErrorResponse,
   createMemory,
   createNodeAgentServiceRuntimeInfrastructure,
-  createVeryfrontCloudAgentServiceRuntime,
+  createNodeVeryfrontCloudAgentServiceRuntime,
   defineAgentService,
   DurableRunSink,
   executeAgUiDetachedStart,
@@ -284,7 +284,7 @@ await runNodeVeryfrontCloudAgentServiceMain({
 });
 ```
 
-`createVeryfrontCloudAgentServiceRuntime()` returns the same runtime bundle
+`createNodeVeryfrontCloudAgentServiceRuntime()` returns the same runtime bundle
 without starting a server, which is useful for tests and custom host shells.
 `startNodeVeryfrontCloudAgentService()` starts the Node server directly without
 the process bootstrap wrapper.
@@ -816,7 +816,7 @@ helpers; for example `createAgentServiceRouteSet()`,
 `prepareAgentServiceConversationRootRunContext()`,
 `toMirroredAgentServiceStreamPart()`, and `createAgentServiceAuth()`.
 
-### `createVeryfrontCloudAgentServiceRuntime(options)`
+### `createNodeVeryfrontCloudAgentServiceRuntime(options)`
 
 Create a full Veryfront Cloud agent-service runtime bundle for separately
 deployed agents. The helper loads a markdown-backed `agents/*.md` definition,
@@ -1087,7 +1087,7 @@ Clear all stored messages from memory.
 | `deriveAgentServiceAgUiChatContext`                                   | Derive chat context from canonical AG-UI runtime input                   |
 | `filterAgentTraceAttributes`                                          | Filter unknown records to valid agent trace attributes                   |
 | `createNodeAgentServiceRuntimeInfrastructure`                         | Create Node service config, logger, tracer, and telemetry bundle         |
-| `createVeryfrontCloudAgentServiceRuntime`                             | Create a full Veryfront Cloud agent-service runtime bundle               |
+| `createNodeVeryfrontCloudAgentServiceRuntime`                         | Create a full Veryfront Cloud agent-service runtime bundle               |
 | `loadAgentServiceEnvFiles`                                            | Load service env files while preserving host process env                 |
 | `initializeNodeAgentServiceOpenTelemetry`                             | Initialize Node OpenTelemetry for an agent service                       |
 | `parseAgentServiceChatRequestFromRequest`                             | Parse the agent-service chat request body and auth context               |

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -322,6 +322,14 @@ export {
   type StartNodeHostedAgentServiceResult,
 } from "./hosted-agent-service-runtime.ts";
 export {
+  createVeryfrontCloudAgentServiceRuntime,
+  runNodeVeryfrontCloudAgentServiceMain,
+  startNodeVeryfrontCloudAgentService,
+  type VeryfrontCloudAgentServiceOptions,
+  type VeryfrontCloudAgentServicePreparedExecution,
+  type VeryfrontCloudAgentServiceProcessTarget,
+} from "./veryfront-cloud-agent-service.ts";
+export {
   type AgentServiceConfig,
   type AgentServiceConfigInput,
   agentServiceConfigSchema,

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -322,12 +322,12 @@ export {
   type StartNodeHostedAgentServiceResult,
 } from "./hosted-agent-service-runtime.ts";
 export {
-  createVeryfrontCloudAgentServiceRuntime,
+  createNodeVeryfrontCloudAgentServiceRuntime,
+  type NodeVeryfrontCloudAgentServiceOptions,
+  type NodeVeryfrontCloudAgentServicePreparedExecution,
+  type NodeVeryfrontCloudAgentServiceProcessTarget,
   runNodeVeryfrontCloudAgentServiceMain,
   startNodeVeryfrontCloudAgentService,
-  type VeryfrontCloudAgentServiceOptions,
-  type VeryfrontCloudAgentServicePreparedExecution,
-  type VeryfrontCloudAgentServiceProcessTarget,
 } from "./veryfront-cloud-agent-service.ts";
 export {
   type AgentServiceConfig,

--- a/src/agent/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/veryfront-cloud-agent-service.test.ts
@@ -1,0 +1,62 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { CreateSandboxBashTool } from "#veryfront/sandbox";
+import { createVeryfrontCloudAgentServiceRuntime } from "./veryfront-cloud-agent-service.ts";
+
+function withTempDir(fn: (dir: string) => Promise<void> | void): Promise<void> | void {
+  const dir = Deno.makeTempDirSync();
+  try {
+    return fn(dir);
+  } finally {
+    Deno.removeSync(dir, { recursive: true });
+  }
+}
+
+function writeAgentDefinition(rootDir: string): void {
+  const agentsDir = resolve(rootDir, "agents");
+  Deno.mkdirSync(agentsDir, { recursive: true });
+  Deno.writeTextFileSync(
+    resolve(agentsDir, "veryfront.md"),
+    `---
+name: Veryfront
+model: openai/gpt-5.4
+max-steps: 12
+---
+
+Help users build with Veryfront.
+`,
+  );
+}
+
+const createBashTool: CreateSandboxBashTool = () => Promise.resolve({ tools: {} });
+
+Deno.test("createVeryfrontCloudAgentServiceRuntime loads the markdown agent and binds service routes", async () => {
+  await withTempDir(async (rootDir) => {
+    writeAgentDefinition(rootDir);
+
+    const bundle = createVeryfrontCloudAgentServiceRuntime({
+      serviceName: "veryfront-agent-test",
+      agentId: "veryfront",
+      entryUrl: pathToFileURL(resolve(rootDir, "src", "main.ts")),
+      createBashTool,
+      env: {
+        NODE_ENV: "test",
+        VERYFRONT_API_URL: "https://api.example.com",
+        PORT: "3141",
+        ALLOWED_ORIGINS: "https://studio.example.com",
+      },
+    });
+
+    assertEquals(bundle.config.PORT, 3141);
+    assertEquals(bundle.config.VERYFRONT_API_URL, "https://api.example.com");
+    assertEquals(bundle.runtime.contract.serviceName, "veryfront-agent-test");
+    assertEquals(bundle.runtime.contract.defaultAgentId, "veryfront");
+    assertEquals(bundle.runtime.contract.agents.veryfront.id, "veryfront");
+    assertEquals(bundle.runtime.contract.agents.veryfront.config.model, "openai/gpt-5.4");
+
+    const liveness = await bundle.runtime.request("http://localhost/liveness");
+    assertEquals(liveness.status, 200);
+    assertEquals(await liveness.text(), "OK");
+  });
+});

--- a/src/agent/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/veryfront-cloud-agent-service.test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { CreateSandboxBashTool } from "#veryfront/sandbox";
-import { createVeryfrontCloudAgentServiceRuntime } from "./veryfront-cloud-agent-service.ts";
+import { createNodeVeryfrontCloudAgentServiceRuntime } from "./veryfront-cloud-agent-service.ts";
 
 function withTempDir(fn: (dir: string) => Promise<void> | void): Promise<void> | void {
   const dir = Deno.makeTempDirSync();
@@ -31,11 +31,11 @@ Help users build with Veryfront.
 
 const createBashTool: CreateSandboxBashTool = () => Promise.resolve({ tools: {} });
 
-Deno.test("createVeryfrontCloudAgentServiceRuntime loads the markdown agent and binds service routes", async () => {
+Deno.test("createNodeVeryfrontCloudAgentServiceRuntime loads the markdown agent and binds service routes", async () => {
   await withTempDir(async (rootDir) => {
     writeAgentDefinition(rootDir);
 
-    const bundle = createVeryfrontCloudAgentServiceRuntime({
+    const bundle = createNodeVeryfrontCloudAgentServiceRuntime({
       serviceName: "veryfront-agent-test",
       agentId: "veryfront",
       entryUrl: pathToFileURL(resolve(rootDir, "src", "main.ts")),

--- a/src/agent/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/veryfront-cloud-agent-service.test.ts
@@ -2,18 +2,24 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { CreateSandboxBashTool } from "#veryfront/sandbox";
+import { toolRegistry } from "#veryfront/tool";
+import { agentRegistry } from "./composition/index.ts";
 import { createNodeVeryfrontCloudAgentServiceRuntime } from "./veryfront-cloud-agent-service.ts";
+import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 
-function withTempDir(fn: (dir: string) => Promise<void> | void): Promise<void> | void {
+async function withTempDir(fn: (dir: string) => Promise<void> | void): Promise<void> {
   const dir = Deno.makeTempDirSync();
   try {
-    return fn(dir);
+    await fn(dir);
   } finally {
+    await stopEsbuild();
     Deno.removeSync(dir, { recursive: true });
+    agentRegistry.clearAll();
+    toolRegistry.clearAll();
   }
 }
 
-function writeAgentDefinition(rootDir: string): void {
+function writeMarkdownAgentDefinition(rootDir: string): void {
   const agentsDir = resolve(rootDir, "agents");
   Deno.mkdirSync(agentsDir, { recursive: true });
   Deno.writeTextFileSync(
@@ -29,13 +35,52 @@ Help users build with Veryfront.
   );
 }
 
+function writeCodeAgentDefinition(
+  rootDir: string,
+  options: { agentsDir?: string; toolsDir?: string } = {},
+): void {
+  const agentsDir = resolve(rootDir, options.agentsDir ?? "agents");
+  const toolsDir = resolve(rootDir, options.toolsDir ?? "tools");
+  Deno.mkdirSync(agentsDir, { recursive: true });
+  Deno.mkdirSync(toolsDir, { recursive: true });
+  Deno.writeTextFileSync(
+    resolve(agentsDir, "support.ts"),
+    [
+      'import { agent } from "veryfront/agent";',
+      "",
+      "export default agent({",
+      '  id: "support",',
+      '  model: "openai/gpt-5.4",',
+      "  maxSteps: 8,",
+      '  system: "Help users from code.",',
+      "});",
+      "",
+    ].join("\n"),
+  );
+  Deno.writeTextFileSync(
+    resolve(toolsDir, "echo.ts"),
+    [
+      'import { tool } from "veryfront/tool";',
+      'import { z } from "zod";',
+      "",
+      "export default tool({",
+      '  id: "echo",',
+      '  description: "Echo input",',
+      "  inputSchema: z.object({ text: z.string() }),",
+      "  execute: ({ text }) => ({ text }),",
+      "});",
+      "",
+    ].join("\n"),
+  );
+}
+
 const createBashTool: CreateSandboxBashTool = () => Promise.resolve({ tools: {} });
 
 Deno.test("createNodeVeryfrontCloudAgentServiceRuntime loads the markdown agent and binds service routes", async () => {
   await withTempDir(async (rootDir) => {
-    writeAgentDefinition(rootDir);
+    writeMarkdownAgentDefinition(rootDir);
 
-    const bundle = createNodeVeryfrontCloudAgentServiceRuntime({
+    const bundle = await createNodeVeryfrontCloudAgentServiceRuntime({
       serviceName: "veryfront-agent-test",
       agentId: "veryfront",
       entryUrl: pathToFileURL(resolve(rootDir, "src", "main.ts")),
@@ -59,4 +104,82 @@ Deno.test("createNodeVeryfrontCloudAgentServiceRuntime loads the markdown agent 
     assertEquals(liveness.status, 200);
     assertEquals(await liveness.text(), "OK");
   });
+});
+
+Deno.test({
+  name: "createNodeVeryfrontCloudAgentServiceRuntime uses veryfront.config.ts discovery paths",
+  // Code primitive discovery invokes the esbuild-backed transpiler, which starts
+  // an esbuild child process. This matches the sanitizer policy in
+  // src/discovery/transpiler.test.ts.
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withTempDir(async (rootDir) => {
+      writeCodeAgentDefinition(rootDir, { agentsDir: "crew", toolsDir: "tooling" });
+      Deno.writeTextFileSync(
+        resolve(rootDir, "veryfront.config.ts"),
+        [
+          "export default {",
+          "  ai: {",
+          '    agents: { discovery: { paths: ["crew"] } },',
+          '    tools: { discovery: { paths: ["tooling"] } },',
+          "  },",
+          "};",
+          "",
+        ].join("\n"),
+      );
+
+      const bundle = await createNodeVeryfrontCloudAgentServiceRuntime({
+        serviceName: "configured-agent-test",
+        agentId: "support",
+        agentSource: "code",
+        entryUrl: pathToFileURL(resolve(rootDir, "src", "main.ts")),
+        createBashTool,
+        env: {
+          NODE_ENV: "test",
+          VERYFRONT_API_URL: "https://api.example.com",
+          PORT: "3143",
+          ALLOWED_ORIGINS: "https://studio.example.com",
+        },
+      });
+
+      assertEquals(bundle.runtime.contract.defaultAgentId, "support");
+      assertEquals(bundle.runtime.contract.agents.support.config.system, "Help users from code.");
+      assertEquals(toolRegistry.has("echo"), true);
+    });
+  },
+});
+
+Deno.test({
+  name: "createNodeVeryfrontCloudAgentServiceRuntime discovers code agents and project primitives",
+  // Code primitive discovery invokes the esbuild-backed transpiler, which starts
+  // an esbuild child process. This matches the sanitizer policy in
+  // src/discovery/transpiler.test.ts.
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    await withTempDir(async (rootDir) => {
+      writeCodeAgentDefinition(rootDir);
+
+      const bundle = await createNodeVeryfrontCloudAgentServiceRuntime({
+        serviceName: "support-agent-test",
+        agentId: "support",
+        agentSource: "code",
+        entryUrl: pathToFileURL(resolve(rootDir, "src", "main.ts")),
+        createBashTool,
+        env: {
+          NODE_ENV: "test",
+          VERYFRONT_API_URL: "https://api.example.com",
+          PORT: "3142",
+          ALLOWED_ORIGINS: "https://studio.example.com",
+        },
+      });
+
+      assertEquals(bundle.runtime.contract.defaultAgentId, "support");
+      assertEquals(bundle.runtime.contract.agents.support.config.system, "Help users from code.");
+      assertEquals(bundle.runtime.contract.agents.support.config.model, "openai/gpt-5.4");
+      assertEquals(bundle.runtime.contract.agents.support.config.maxSteps, 8);
+      assertEquals(toolRegistry.has("echo"), true);
+    });
+  },
 });

--- a/src/agent/veryfront-cloud-agent-service.ts
+++ b/src/agent/veryfront-cloud-agent-service.ts
@@ -82,7 +82,7 @@ import {
 } from "./veryfront-cloud-hosted-chat-execution-preparation.ts";
 import { applyAgentProjectContextChange } from "./project-context.ts";
 
-export type VeryfrontCloudAgentServiceProcessTarget =
+export type NodeVeryfrontCloudAgentServiceProcessTarget =
   & NonNullable<RunAgentServiceMainOptions["processTarget"]>
   & NonNullable<CreateNodeAgentServiceRuntimeInfrastructureOptions["processTarget"]>
   & {
@@ -90,7 +90,7 @@ export type VeryfrontCloudAgentServiceProcessTarget =
     exit?: (code: number) => never | void;
   };
 
-export type VeryfrontCloudAgentServiceOptions = {
+export type NodeVeryfrontCloudAgentServiceOptions = {
   serviceName: string;
   agentId: string;
   baseDir?: string;
@@ -98,12 +98,12 @@ export type VeryfrontCloudAgentServiceOptions = {
   forwardedConfigNamespace?: string;
   createBashTool: HostedSandboxToolsOptions["createBashTool"];
   env?: CreateNodeAgentServiceRuntimeInfrastructureOptions["env"];
-  processTarget?: VeryfrontCloudAgentServiceProcessTarget;
+  processTarget?: NodeVeryfrontCloudAgentServiceProcessTarget;
   drainTimeoutMs?: number;
   hardShutdownTimeoutMs?: number;
 };
 
-export type VeryfrontCloudAgentServicePreparedExecution = PreparedHostedChatExecution & {
+export type NodeVeryfrontCloudAgentServicePreparedExecution = PreparedHostedChatExecution & {
   config: AgentServiceRuntimeConfig;
   agent: HostedChatRuntimeCreationResult["agent"];
   runtimeKind: "framework";
@@ -112,7 +112,9 @@ export type VeryfrontCloudAgentServicePreparedExecution = PreparedHostedChatExec
   rootRunContext: HostedConversationRootRunContext;
 };
 
-type VeryfrontCloudAgentServiceContext = ReturnType<typeof createVeryfrontCloudAgentServiceContext>;
+type NodeVeryfrontCloudAgentServiceContext = ReturnType<
+  typeof createNodeVeryfrontCloudAgentServiceContext
+>;
 type ChildRunContext = DefaultHostedInvokeAgentContext & {
   clientProfile?: RuntimeClientProfile | null;
 };
@@ -123,7 +125,7 @@ const DEFAULT_HARD_SHUTDOWN_TIMEOUT_MS = 20_000;
 const DEFAULT_PROJECT_NAVIGATION_TOOL_NAMES = ["studio_open_project"];
 
 function resolveBaseDir(
-  options: Pick<VeryfrontCloudAgentServiceOptions, "baseDir" | "entryUrl">,
+  options: Pick<NodeVeryfrontCloudAgentServiceOptions, "baseDir" | "entryUrl">,
 ): string {
   if (options.baseDir) {
     return options.baseDir;
@@ -137,7 +139,7 @@ function resolveBaseDir(
   return Deno.cwd();
 }
 
-function resolveDefaultProcessTarget(): VeryfrontCloudAgentServiceProcessTarget | undefined {
+function resolveDefaultProcessTarget(): NodeVeryfrontCloudAgentServiceProcessTarget | undefined {
   if (typeof process === "undefined") {
     return undefined;
   }
@@ -145,7 +147,7 @@ function resolveDefaultProcessTarget(): VeryfrontCloudAgentServiceProcessTarget 
 }
 
 function resolveEnvironment(
-  options: Pick<VeryfrontCloudAgentServiceOptions, "env" | "processTarget">,
+  options: Pick<NodeVeryfrontCloudAgentServiceOptions, "env" | "processTarget">,
 ): CreateNodeAgentServiceRuntimeInfrastructureOptions["env"] {
   if (options.env) {
     return options.env;
@@ -159,7 +161,9 @@ function resolveEnvironment(
   return {};
 }
 
-function createVeryfrontCloudAgentServiceContext(options: VeryfrontCloudAgentServiceOptions) {
+function createNodeVeryfrontCloudAgentServiceContext(
+  options: NodeVeryfrontCloudAgentServiceOptions,
+) {
   const processTarget = options.processTarget ?? resolveDefaultProcessTarget();
   const infrastructure = createNodeAgentServiceRuntimeInfrastructure({
     serviceName: options.serviceName,
@@ -196,7 +200,7 @@ function createVeryfrontCloudAgentServiceContext(options: VeryfrontCloudAgentSer
 }
 
 function getProjectInstructions(
-  context: VeryfrontCloudAgentServiceContext,
+  context: NodeVeryfrontCloudAgentServiceContext,
   lookup: RuntimeProjectSteeringLookup,
 ): Promise<string> {
   return context.trace("chat.getProjectInstructions", async () => {
@@ -205,7 +209,7 @@ function getProjectInstructions(
 }
 
 function getSkillsConfig(
-  context: VeryfrontCloudAgentServiceContext,
+  context: NodeVeryfrontCloudAgentServiceContext,
   lookup: RuntimeProjectSteeringLookup,
 ): Promise<RuntimeSkillDefinition[]> {
   return context.trace("chat.getSkillsConfig", async () => {
@@ -214,28 +218,28 @@ function getSkillsConfig(
 }
 
 function createLoadSkillTool(
-  context: VeryfrontCloudAgentServiceContext,
+  context: NodeVeryfrontCloudAgentServiceContext,
   toolContext: RuntimeLoadSkillToolContext,
 ) {
   return context.projectSteering.createLoadSkillTool(toolContext);
 }
 
 async function refreshProjectSkillIds(
-  context: VeryfrontCloudAgentServiceContext,
+  context: NodeVeryfrontCloudAgentServiceContext,
   skillContext: HostedProjectSkillIdsContext,
 ): Promise<void> {
   await context.projectSteering.refreshProjectSkillIds(skillContext);
 }
 
 function setFilteredTraceAttributes(
-  context: VeryfrontCloudAgentServiceContext,
+  context: NodeVeryfrontCloudAgentServiceContext,
   attributes: Record<string, unknown>,
 ): void {
   context.infrastructure.setActiveSpanAttributes(filterAgentTraceAttributes(attributes));
 }
 
 function getInvokeAgentConfig(
-  context: VeryfrontCloudAgentServiceContext,
+  context: NodeVeryfrontCloudAgentServiceContext,
 ): DefaultHostedInvokeAgentConfig {
   const config = context.infrastructure.getConfig();
 
@@ -252,7 +256,7 @@ function shouldRethrowInvokeAgentError(error: unknown): boolean {
 }
 
 function createInvokeAgentTool(
-  context: VeryfrontCloudAgentServiceContext,
+  context: NodeVeryfrontCloudAgentServiceContext,
   childContext: ChildRunContext,
 ) {
   return createDefaultHostedInvokeAgentTool({
@@ -279,7 +283,7 @@ function createInvokeAgentTool(
 }
 
 function buildLocalTools(
-  context: VeryfrontCloudAgentServiceContext,
+  context: NodeVeryfrontCloudAgentServiceContext,
   options: DefaultHostedChatRuntimeCreationOptions,
   taskContext: DefaultHostedChatRuntimeTaskContext,
 ): HostToolSet {
@@ -297,7 +301,7 @@ function buildLocalTools(
   return tools;
 }
 
-function createProjectSteeringRefresh(context: VeryfrontCloudAgentServiceContext) {
+function createProjectSteeringRefresh(context: NodeVeryfrontCloudAgentServiceContext) {
   return createDefaultHostedProjectSteeringRefresh({
     fetchProjectInstructions: (lookup) => getProjectInstructions(context, lookup),
     fetchSkills: (lookup) => getSkillsConfig(context, lookup),
@@ -310,7 +314,7 @@ function createProjectSteeringRefresh(context: VeryfrontCloudAgentServiceContext
 }
 
 function createAgentRuntime(
-  context: VeryfrontCloudAgentServiceContext,
+  context: NodeVeryfrontCloudAgentServiceContext,
   options: DefaultHostedChatRuntimeCreationOptions,
 ): Promise<HostedChatRuntimeCreationResult> {
   const config = context.infrastructure.getConfig();
@@ -362,7 +366,7 @@ function createAgentRuntime(
 }
 
 function setPrepareChatExecutionStartAttributes(
-  context: VeryfrontCloudAgentServiceContext,
+  context: NodeVeryfrontCloudAgentServiceContext,
   input: { projectId: string | null; userId: string },
 ): void {
   const span = context.infrastructure.tracer.scope().active();
@@ -373,7 +377,7 @@ function setPrepareChatExecutionStartAttributes(
 }
 
 function setPrepareChatExecutionResultAttributes(
-  context: VeryfrontCloudAgentServiceContext,
+  context: NodeVeryfrontCloudAgentServiceContext,
   input: {
     conversationId?: string;
     projectId: string | null;
@@ -406,7 +410,7 @@ function setPrepareChatExecutionResultAttributes(
 }
 
 function fetchProjectSteering(
-  context: VeryfrontCloudAgentServiceContext,
+  context: NodeVeryfrontCloudAgentServiceContext,
   input: { projectId: string | null; authToken: string; branchId?: string | null },
 ) {
   return fetchDefaultHostedProjectSteering({
@@ -419,9 +423,9 @@ function fetchProjectSteering(
 }
 
 async function prepareChatExecution(
-  context: VeryfrontCloudAgentServiceContext,
+  context: NodeVeryfrontCloudAgentServiceContext,
   req: ParsedHostedChatRequest,
-): Promise<VeryfrontCloudAgentServicePreparedExecution> {
+): Promise<NodeVeryfrontCloudAgentServicePreparedExecution> {
   const {
     userId,
     authToken,
@@ -499,7 +503,7 @@ async function prepareChatExecution(
 }
 
 function createPreparedExecutionRuntimeOptions(
-  context: VeryfrontCloudAgentServiceContext,
+  context: NodeVeryfrontCloudAgentServiceContext,
   config: AgentServiceRuntimeConfig,
 ) {
   return createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions({
@@ -512,9 +516,9 @@ function createPreparedExecutionRuntimeOptions(
   });
 }
 
-function createVeryfrontCloudAgentServiceRuntimeOptions(
-  context: VeryfrontCloudAgentServiceContext,
-): CreateAgentServiceRuntimeOptions<VeryfrontCloudAgentServicePreparedExecution> {
+function createNodeVeryfrontCloudAgentServiceRuntimeOptions(
+  context: NodeVeryfrontCloudAgentServiceContext,
+): CreateAgentServiceRuntimeOptions<NodeVeryfrontCloudAgentServicePreparedExecution> {
   return {
     serviceName: context.options.serviceName,
     forwardedConfigNamespace: context.options.forwardedConfigNamespace ??
@@ -555,32 +559,32 @@ function createVeryfrontCloudAgentServiceRuntimeOptions(
   };
 }
 
-export function createVeryfrontCloudAgentServiceRuntime(
-  options: VeryfrontCloudAgentServiceOptions,
-): AgentServiceRuntimeBundle<VeryfrontCloudAgentServicePreparedExecution> {
-  const context = createVeryfrontCloudAgentServiceContext(options);
-  return createAgentServiceRuntime(createVeryfrontCloudAgentServiceRuntimeOptions(context));
+export function createNodeVeryfrontCloudAgentServiceRuntime(
+  options: NodeVeryfrontCloudAgentServiceOptions,
+): AgentServiceRuntimeBundle<NodeVeryfrontCloudAgentServicePreparedExecution> {
+  const context = createNodeVeryfrontCloudAgentServiceContext(options);
+  return createAgentServiceRuntime(createNodeVeryfrontCloudAgentServiceRuntimeOptions(context));
 }
 
 export async function startNodeVeryfrontCloudAgentService(
-  options: VeryfrontCloudAgentServiceOptions,
-): Promise<StartNodeAgentServiceResult<VeryfrontCloudAgentServicePreparedExecution>> {
-  const context = createVeryfrontCloudAgentServiceContext(options);
+  options: NodeVeryfrontCloudAgentServiceOptions,
+): Promise<StartNodeAgentServiceResult<NodeVeryfrontCloudAgentServicePreparedExecution>> {
+  const context = createNodeVeryfrontCloudAgentServiceContext(options);
   return await startNodeAgentService({
-    ...createVeryfrontCloudAgentServiceRuntimeOptions(context),
+    ...createNodeVeryfrontCloudAgentServiceRuntimeOptions(context),
     hardShutdownTimeoutMs: options.hardShutdownTimeoutMs ?? DEFAULT_HARD_SHUTDOWN_TIMEOUT_MS,
   });
 }
 
 export async function runNodeVeryfrontCloudAgentServiceMain(
-  options: VeryfrontCloudAgentServiceOptions,
+  options: NodeVeryfrontCloudAgentServiceOptions,
 ): Promise<void> {
   const processTarget = options.processTarget ?? resolveDefaultProcessTarget();
   let getRuntimeTraceContext: NonNullable<BootstrapAgentServiceOptions["getTraceContext"]> =
     () => ({});
 
   await loadAgentServiceEnvFiles();
-  const context = createVeryfrontCloudAgentServiceContext({
+  const context = createNodeVeryfrontCloudAgentServiceContext({
     ...options,
     processTarget,
   });
@@ -603,7 +607,7 @@ export async function runNodeVeryfrontCloudAgentServiceMain(
     },
     start: async () => {
       await startNodeAgentService({
-        ...createVeryfrontCloudAgentServiceRuntimeOptions(context),
+        ...createNodeVeryfrontCloudAgentServiceRuntimeOptions(context),
         hardShutdownTimeoutMs: options.hardShutdownTimeoutMs ?? DEFAULT_HARD_SHUTDOWN_TIMEOUT_MS,
       });
     },

--- a/src/agent/veryfront-cloud-agent-service.ts
+++ b/src/agent/veryfront-cloud-agent-service.ts
@@ -1,0 +1,616 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { HostedSandboxToolsOptions } from "#veryfront/sandbox";
+import { createHostedSandboxTools } from "#veryfront/sandbox";
+import {
+  createRemoteMCPToolSource,
+  createToolsFromRemoteDefinitions,
+  type HostToolSet,
+  sleepTool,
+} from "#veryfront/tool";
+import { parseProviderError } from "../chat/provider-errors.ts";
+import {
+  getVeryfrontCloudProviderFromModelId,
+  resolveVeryfrontCloudModelId,
+  resolveVeryfrontCloudThinkingProviderOptions,
+} from "../provider/index.ts";
+import { __registerTraceContextGetter } from "../utils/logger/logger.ts";
+import {
+  buildAgentRunTraceAttributes,
+  buildExecuteToolTraceAttributes,
+  filterAgentTraceAttributes,
+} from "./agent-trace-attributes.ts";
+import {
+  type BootstrapAgentServiceOptions,
+  runAgentServiceMain,
+  type RunAgentServiceMainOptions,
+} from "./agent-service-bootstrap.ts";
+import { loadAgentServiceEnvFiles } from "./hosted-agent-service-env-files.ts";
+import { createHostedFormInputTool } from "./hosted-form-input-tool.ts";
+import { createHostedAgentProjectSteering } from "./hosted-agent-project-steering.ts";
+import { type HostedChatRuntimeCreationResult } from "./hosted-chat-runtime-contract.ts";
+import type { HostedConversationRootRunContext } from "./conversation-root-run-lifecycle.ts";
+import { type AgentRuntimeMessage } from "./agent-runtime-message-adapter.ts";
+import { createLiveStudioMcpTools } from "./live-studio-mcp-tools.ts";
+import {
+  createDefaultHostedChatRuntime,
+  type DefaultHostedChatRuntimeCreationOptions,
+  type DefaultHostedChatRuntimeTaskContext,
+} from "./default-hosted-chat-runtime.ts";
+import { createDefaultHostedInvokeAgentTool } from "./default-hosted-invoke-agent-tool.ts";
+import type { RuntimeClientProfile } from "./runtime-client-profile.ts";
+import type {
+  DefaultHostedInvokeAgentConfig,
+  DefaultHostedInvokeAgentContext,
+} from "./default-hosted-invoke-agent-tool.ts";
+import {
+  createDefaultHostedProjectSteeringRefresh,
+  fetchDefaultHostedProjectSteering,
+} from "./default-hosted-project-steering-refresh.ts";
+import { type HostedProjectSkillIdsContext } from "./hosted-project-steering-adapter.ts";
+import type { RuntimeLoadSkillToolContext } from "./runtime-load-skill-tool.ts";
+import type { RuntimeProjectSteeringLookup } from "./runtime-project-skill-catalog.ts";
+import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
+import {
+  buildVeryfrontCloudRuntimeInstructions,
+} from "./veryfront-cloud-runtime-system-messages.ts";
+import {
+  createNodeAgentServiceRuntimeInfrastructure,
+  type CreateNodeAgentServiceRuntimeInfrastructureOptions,
+} from "./node-hosted-agent-service-runtime-infrastructure.ts";
+import {
+  type AgentServiceRuntimeBundle,
+  type AgentServiceRuntimeConfig,
+  createAgentServiceRuntime,
+  type CreateAgentServiceRuntimeOptions,
+  startNodeAgentService,
+  type StartNodeAgentServiceResult,
+} from "./hosted-agent-service-runtime.ts";
+import { createDetachedRunTracker } from "./detached-run-tracker.ts";
+import type { AgUiResumeValue } from "./ag-ui-tool-shared.ts";
+import type { ParsedHostedChatRequest } from "./hosted-chat-request-parser.ts";
+import type { PreparedHostedChatExecution } from "./prepared-hosted-chat-execution.ts";
+import {
+  runPreparedHostedChatExecutionDetached,
+  streamPreparedHostedChatExecutionToAgUiResponse,
+} from "./prepared-hosted-chat-execution.ts";
+import {
+  createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions,
+} from "./veryfront-cloud-prepared-hosted-chat-execution-runtime.ts";
+import {
+  prepareVeryfrontCloudHostedChatExecution,
+} from "./veryfront-cloud-hosted-chat-execution-preparation.ts";
+import { applyAgentProjectContextChange } from "./project-context.ts";
+
+export type VeryfrontCloudAgentServiceProcessTarget =
+  & NonNullable<RunAgentServiceMainOptions["processTarget"]>
+  & NonNullable<CreateNodeAgentServiceRuntimeInfrastructureOptions["processTarget"]>
+  & {
+    env?: Record<string, string | undefined>;
+    exit?: (code: number) => never | void;
+  };
+
+export type VeryfrontCloudAgentServiceOptions = {
+  serviceName: string;
+  agentId: string;
+  baseDir?: string;
+  entryUrl?: string | URL;
+  forwardedConfigNamespace?: string;
+  createBashTool: HostedSandboxToolsOptions["createBashTool"];
+  env?: CreateNodeAgentServiceRuntimeInfrastructureOptions["env"];
+  processTarget?: VeryfrontCloudAgentServiceProcessTarget;
+  drainTimeoutMs?: number;
+  hardShutdownTimeoutMs?: number;
+};
+
+export type VeryfrontCloudAgentServicePreparedExecution = PreparedHostedChatExecution & {
+  config: AgentServiceRuntimeConfig;
+  agent: HostedChatRuntimeCreationResult["agent"];
+  runtimeKind: "framework";
+  finalMessages: AgentRuntimeMessage[];
+  messages: PreparedHostedChatExecution["messages"];
+  rootRunContext: HostedConversationRootRunContext;
+};
+
+type VeryfrontCloudAgentServiceContext = ReturnType<typeof createVeryfrontCloudAgentServiceContext>;
+type ChildRunContext = DefaultHostedInvokeAgentContext & {
+  clientProfile?: RuntimeClientProfile | null;
+};
+
+const DEFAULT_FORWARDED_CONFIG_NAMESPACE = "veryfront";
+const DEFAULT_DRAIN_TIMEOUT_MS = 15_000;
+const DEFAULT_HARD_SHUTDOWN_TIMEOUT_MS = 20_000;
+const DEFAULT_PROJECT_NAVIGATION_TOOL_NAMES = ["studio_open_project"];
+
+function resolveBaseDir(
+  options: Pick<VeryfrontCloudAgentServiceOptions, "baseDir" | "entryUrl">,
+): string {
+  if (options.baseDir) {
+    return options.baseDir;
+  }
+  if (options.entryUrl) {
+    return dirname(fileURLToPath(options.entryUrl));
+  }
+  if (typeof process !== "undefined") {
+    return process.cwd();
+  }
+  return Deno.cwd();
+}
+
+function resolveDefaultProcessTarget(): VeryfrontCloudAgentServiceProcessTarget | undefined {
+  if (typeof process === "undefined") {
+    return undefined;
+  }
+  return process;
+}
+
+function resolveEnvironment(
+  options: Pick<VeryfrontCloudAgentServiceOptions, "env" | "processTarget">,
+): CreateNodeAgentServiceRuntimeInfrastructureOptions["env"] {
+  if (options.env) {
+    return options.env;
+  }
+  if (options.processTarget?.env) {
+    return options.processTarget.env;
+  }
+  if (typeof process !== "undefined") {
+    return process.env;
+  }
+  return {};
+}
+
+function createVeryfrontCloudAgentServiceContext(options: VeryfrontCloudAgentServiceOptions) {
+  const processTarget = options.processTarget ?? resolveDefaultProcessTarget();
+  const infrastructure = createNodeAgentServiceRuntimeInfrastructure({
+    serviceName: options.serviceName,
+    env: resolveEnvironment({ env: options.env, processTarget }),
+    processTarget,
+  });
+  function trace<TResult>(
+    operationName: string,
+    operation: () => Promise<TResult>,
+  ): Promise<TResult>;
+  function trace<TResult>(operationName: string, operation: () => TResult): TResult;
+  function trace<TResult>(
+    operationName: string,
+    operation: () => TResult | Promise<TResult>,
+  ): TResult | Promise<TResult> {
+    return infrastructure.tracer.trace(operationName, operation);
+  }
+  const projectSteering = createHostedAgentProjectSteering({
+    baseDir: resolveBaseDir(options),
+    agentId: options.agentId,
+    getApiUrl: () => infrastructure.getConfig().VERYFRONT_API_URL,
+    logger: infrastructure.logger,
+    trace,
+  });
+
+  return {
+    options,
+    processTarget,
+    infrastructure,
+    trace,
+    projectSteering,
+    tracker: createDetachedRunTracker<AgUiResumeValue>(),
+  };
+}
+
+function getProjectInstructions(
+  context: VeryfrontCloudAgentServiceContext,
+  lookup: RuntimeProjectSteeringLookup,
+): Promise<string> {
+  return context.trace("chat.getProjectInstructions", async () => {
+    return await context.projectSteering.getProjectInstructions(lookup);
+  });
+}
+
+function getSkillsConfig(
+  context: VeryfrontCloudAgentServiceContext,
+  lookup: RuntimeProjectSteeringLookup,
+): Promise<RuntimeSkillDefinition[]> {
+  return context.trace("chat.getSkillsConfig", async () => {
+    return await context.projectSteering.getSkillsConfig(lookup);
+  });
+}
+
+function createLoadSkillTool(
+  context: VeryfrontCloudAgentServiceContext,
+  toolContext: RuntimeLoadSkillToolContext,
+) {
+  return context.projectSteering.createLoadSkillTool(toolContext);
+}
+
+async function refreshProjectSkillIds(
+  context: VeryfrontCloudAgentServiceContext,
+  skillContext: HostedProjectSkillIdsContext,
+): Promise<void> {
+  await context.projectSteering.refreshProjectSkillIds(skillContext);
+}
+
+function setFilteredTraceAttributes(
+  context: VeryfrontCloudAgentServiceContext,
+  attributes: Record<string, unknown>,
+): void {
+  context.infrastructure.setActiveSpanAttributes(filterAgentTraceAttributes(attributes));
+}
+
+function getInvokeAgentConfig(
+  context: VeryfrontCloudAgentServiceContext,
+): DefaultHostedInvokeAgentConfig {
+  const config = context.infrastructure.getConfig();
+
+  return {
+    apiUrl: config.VERYFRONT_API_URL,
+    apiMcpUrl: config.VERYFRONT_MCP_URL,
+    studioMcpUrl: config.VERYFRONT_STUDIO_MCP_URL,
+    enableDurableInvokeAgent: config.VERYFRONT_ENABLE_DURABLE_INVOKE_AGENT,
+  };
+}
+
+function shouldRethrowInvokeAgentError(error: unknown): boolean {
+  return parseProviderError(error).code === "INSUFFICIENT_CREDITS";
+}
+
+function createInvokeAgentTool(
+  context: VeryfrontCloudAgentServiceContext,
+  childContext: ChildRunContext,
+) {
+  return createDefaultHostedInvokeAgentTool({
+    context: childContext,
+    getConfig: () => getInvokeAgentConfig(context),
+    logger: context.infrastructure.logger,
+    trace: context.trace,
+    setTraceAttributes: context.infrastructure.setActiveSpanAttributes,
+    createBashTool: context.options.createBashTool,
+    resolveModelId: resolveVeryfrontCloudModelId,
+    resolveProvider: getVeryfrontCloudProviderFromModelId,
+    resolveProviderOptions: resolveVeryfrontCloudThinkingProviderOptions,
+    shouldRethrowError: shouldRethrowInvokeAgentError,
+    buildGlobalTools: (globalToolContext) => ({
+      load_skill: createLoadSkillTool(context, globalToolContext),
+    }),
+    refreshProjectSkillIds: (projectSkillContext) =>
+      refreshProjectSkillIds(context, projectSkillContext),
+    createHostedSandboxTools,
+    createLiveStudioTools: createLiveStudioMcpTools,
+    createRemoteToolSource: createRemoteMCPToolSource,
+    createToolsFromRemoteDefinitions,
+  });
+}
+
+function buildLocalTools(
+  context: VeryfrontCloudAgentServiceContext,
+  options: DefaultHostedChatRuntimeCreationOptions,
+  taskContext: DefaultHostedChatRuntimeTaskContext,
+): HostToolSet {
+  const config = context.infrastructure.getConfig();
+  const tools: HostToolSet = {
+    form_input: createHostedFormInputTool(taskContext, config.VERYFRONT_API_URL),
+    load_skill: createLoadSkillTool(context, taskContext),
+    sleep: sleepTool,
+  };
+
+  if (options.allowDelegation !== false) {
+    tools.invoke_agent = createInvokeAgentTool(context, taskContext);
+  }
+
+  return tools;
+}
+
+function createProjectSteeringRefresh(context: VeryfrontCloudAgentServiceContext) {
+  return createDefaultHostedProjectSteeringRefresh({
+    fetchProjectInstructions: (lookup) => getProjectInstructions(context, lookup),
+    fetchSkills: (lookup) => getSkillsConfig(context, lookup),
+    buildInstructions: buildVeryfrontCloudRuntimeInstructions,
+    projectScopedRemoteToolOptions: {
+      projectNavigationToolNames: DEFAULT_PROJECT_NAVIGATION_TOOL_NAMES,
+    },
+    logger: context.infrastructure.logger,
+  });
+}
+
+function createAgentRuntime(
+  context: VeryfrontCloudAgentServiceContext,
+  options: DefaultHostedChatRuntimeCreationOptions,
+): Promise<HostedChatRuntimeCreationResult> {
+  const config = context.infrastructure.getConfig();
+  const refreshSystem = createProjectSteeringRefresh(context);
+
+  return createDefaultHostedChatRuntime({
+    options,
+    config: {
+      apiUrl: config.VERYFRONT_API_URL,
+      apiMcpUrl: config.VERYFRONT_MCP_URL,
+      studioMcpUrl: config.VERYFRONT_STUDIO_MCP_URL,
+    },
+    buildLocalTools: (taskContext) => buildLocalTools(context, options, taskContext),
+    refreshSystem,
+    onSteeringMutation: async ({ mutation, taskContext }) => {
+      if (mutation.skillsChanged) {
+        await refreshProjectSkillIds(context, {
+          ...taskContext,
+          authToken: taskContext.authToken,
+        });
+      }
+    },
+    onStudioProjectSwitch: async ({ projectId, taskContext }) => {
+      if (!applyAgentProjectContextChange(taskContext, projectId)) {
+        return false;
+      }
+
+      await refreshProjectSkillIds(context, {
+        ...taskContext,
+        authToken: taskContext.authToken,
+      });
+      return true;
+    },
+    projectScopedRemoteToolOptions: {
+      projectNavigationToolNames: DEFAULT_PROJECT_NAVIGATION_TOOL_NAMES,
+    },
+    createRemoteToolSource: createRemoteMCPToolSource,
+    traceLocalTools: {
+      trace: (spanName, operation) => context.infrastructure.tracer.trace(spanName, operation),
+      buildAttributes: ({ toolName, toolCallId }) =>
+        buildExecuteToolTraceAttributes({
+          toolName,
+          toolCallId,
+        }),
+      setAttributes: (attributes) => setFilteredTraceAttributes(context, attributes),
+    },
+    logger: context.infrastructure.logger,
+  });
+}
+
+function setPrepareChatExecutionStartAttributes(
+  context: VeryfrontCloudAgentServiceContext,
+  input: { projectId: string | null; userId: string },
+): void {
+  const span = context.infrastructure.tracer.scope().active();
+  span?.setAttributes({
+    "chat.projectId": input.projectId ?? "none",
+    "chat.userId": input.userId,
+  });
+}
+
+function setPrepareChatExecutionResultAttributes(
+  context: VeryfrontCloudAgentServiceContext,
+  input: {
+    conversationId?: string;
+    projectId: string | null;
+    userId: string;
+    agentId: string;
+    runId?: string;
+    upstreamParentConversationId?: string;
+    upstreamParentRunId?: string;
+    spawnedFromToolCallId?: string;
+    runtimeKind: "framework";
+  },
+): void {
+  const span = context.infrastructure.tracer.scope().active();
+  span?.setAttributes(
+    buildAgentRunTraceAttributes({
+      operationName: "chat",
+      conversationId: input.conversationId,
+      projectId: input.projectId,
+      userId: input.userId,
+      agentId: input.agentId,
+      runId: input.runId,
+      parentConversationId: input.upstreamParentConversationId,
+      parentRunId: input.upstreamParentRunId,
+      toolCallId: input.spawnedFromToolCallId,
+    }),
+  );
+  span?.setAttributes({
+    "agent.runtime.kind": input.runtimeKind,
+  });
+}
+
+function fetchProjectSteering(
+  context: VeryfrontCloudAgentServiceContext,
+  input: { projectId: string | null; authToken: string; branchId?: string | null },
+) {
+  return fetchDefaultHostedProjectSteering({
+    ...input,
+    fetchProjectInstructions: (lookup) => getProjectInstructions(context, lookup),
+    fetchSkills: (lookup) => getSkillsConfig(context, lookup),
+    trace: context.trace,
+    traceOperationName: "chat.fetchSteering",
+  });
+}
+
+async function prepareChatExecution(
+  context: VeryfrontCloudAgentServiceContext,
+  req: ParsedHostedChatRequest,
+): Promise<VeryfrontCloudAgentServicePreparedExecution> {
+  const {
+    userId,
+    authToken,
+    projectId,
+    conversationId,
+    upstreamParentConversationId,
+    upstreamParentRunId,
+    spawnedFromToolCallId,
+  } = req;
+  const config = context.infrastructure.getConfig();
+
+  setPrepareChatExecutionStartAttributes(context, { projectId, userId });
+
+  const agentConfig = context.projectSteering.getAgentConfig();
+  const {
+    effectiveMessages,
+    rootRunContext,
+    runtime: { agent, runtimeKind, modelId, cleanup },
+    finalMessages,
+  } = await prepareVeryfrontCloudHostedChatExecution({
+    request: req,
+    agentConfig,
+    apiUrl: config.VERYFRONT_API_URL,
+    abortSignal: new AbortController().signal,
+    logger: context.infrastructure.logger,
+    rootRun: {
+      instrumentation: {
+        trace: context.trace,
+        setTraceAttributes: context.infrastructure.setActiveSpanAttributes,
+        debug: (message, metadata) => context.infrastructure.logger.debug(message, metadata),
+        warn: (message, metadata) => context.infrastructure.logger.warn(message, metadata),
+        error: (message, metadata) => context.infrastructure.logger.error(message, metadata),
+      },
+    },
+    fetchSteering: (steeringInput) => fetchProjectSteering(context, steeringInput),
+    buildInstructions: buildVeryfrontCloudRuntimeInstructions,
+    createRuntime: (creationOptions) =>
+      context.trace("chat.createRuntime", () =>
+        createAgentRuntime(context, {
+          ...creationOptions,
+          userId: req.userId,
+        })),
+  });
+
+  setPrepareChatExecutionResultAttributes(context, {
+    conversationId,
+    projectId,
+    userId,
+    agentId: agentConfig.id,
+    runId: rootRunContext.durableRootRun?.runId,
+    upstreamParentConversationId,
+    upstreamParentRunId,
+    spawnedFromToolCallId,
+    runtimeKind,
+  });
+
+  return {
+    config,
+    agent,
+    agentId: agentConfig.id,
+    runtimeKind,
+    modelId,
+    cleanup,
+    messages: effectiveMessages,
+    finalMessages,
+    conversationId,
+    authToken,
+    projectId,
+    userId,
+    rootRunContext,
+    upstreamParentConversationId,
+    upstreamParentRunId,
+    spawnedFromToolCallId,
+  };
+}
+
+function createPreparedExecutionRuntimeOptions(
+  context: VeryfrontCloudAgentServiceContext,
+  config: AgentServiceRuntimeConfig,
+) {
+  return createVeryfrontCloudPreparedHostedChatExecutionRuntimeOptions({
+    apiUrl: config.VERYFRONT_API_URL,
+    tracer: context.infrastructure.tracer,
+    trace: context.trace,
+    traceStream: (operation) => context.infrastructure.tracer.trace("chat.stream", operation),
+    logger: context.infrastructure.logger,
+    setActiveSpanAttributes: context.infrastructure.setActiveSpanAttributes,
+  });
+}
+
+function createVeryfrontCloudAgentServiceRuntimeOptions(
+  context: VeryfrontCloudAgentServiceContext,
+): CreateAgentServiceRuntimeOptions<VeryfrontCloudAgentServicePreparedExecution> {
+  return {
+    serviceName: context.options.serviceName,
+    forwardedConfigNamespace: context.options.forwardedConfigNamespace ??
+      DEFAULT_FORWARDED_CONFIG_NAMESPACE,
+    getConfig: context.infrastructure.getConfig,
+    getAgentConfig: () => context.projectSteering.getAgentConfig(),
+    tracker: context.tracker,
+    prepareExecution: (request) => prepareChatExecution(context, request),
+    streamExecutionToAgUiResponse: (execution) =>
+      streamPreparedHostedChatExecutionToAgUiResponse({
+        execution,
+        runtime: createPreparedExecutionRuntimeOptions(context, execution.config),
+      }),
+    startDetachedExecution: ({ execution, abortSignal }) =>
+      runPreparedHostedChatExecutionDetached({
+        execution: {
+          ...execution,
+          abortSignal,
+        },
+        runtime: createPreparedExecutionRuntimeOptions(context, execution.config),
+      }),
+    cleanupExecution: async ({ execution, runId, conversationId }) => {
+      await execution.cleanup().catch((error) => {
+        context.infrastructure.logger.error(
+          "Detached durable run cleanup failed after duplicate start",
+          {
+            runId,
+            conversationId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      });
+    },
+    setActiveSpanAttributes: context.infrastructure.setActiveSpanAttributes,
+    trace: context.trace,
+    logger: context.infrastructure.logger,
+    drainTimeoutMs: context.options.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS,
+  };
+}
+
+export function createVeryfrontCloudAgentServiceRuntime(
+  options: VeryfrontCloudAgentServiceOptions,
+): AgentServiceRuntimeBundle<VeryfrontCloudAgentServicePreparedExecution> {
+  const context = createVeryfrontCloudAgentServiceContext(options);
+  return createAgentServiceRuntime(createVeryfrontCloudAgentServiceRuntimeOptions(context));
+}
+
+export async function startNodeVeryfrontCloudAgentService(
+  options: VeryfrontCloudAgentServiceOptions,
+): Promise<StartNodeAgentServiceResult<VeryfrontCloudAgentServicePreparedExecution>> {
+  const context = createVeryfrontCloudAgentServiceContext(options);
+  return await startNodeAgentService({
+    ...createVeryfrontCloudAgentServiceRuntimeOptions(context),
+    hardShutdownTimeoutMs: options.hardShutdownTimeoutMs ?? DEFAULT_HARD_SHUTDOWN_TIMEOUT_MS,
+  });
+}
+
+export async function runNodeVeryfrontCloudAgentServiceMain(
+  options: VeryfrontCloudAgentServiceOptions,
+): Promise<void> {
+  const processTarget = options.processTarget ?? resolveDefaultProcessTarget();
+  let getRuntimeTraceContext: NonNullable<BootstrapAgentServiceOptions["getTraceContext"]> =
+    () => ({});
+
+  await loadAgentServiceEnvFiles();
+  const context = createVeryfrontCloudAgentServiceContext({
+    ...options,
+    processTarget,
+  });
+  getRuntimeTraceContext = context.infrastructure.getTraceContext;
+
+  await runAgentServiceMain({
+    loadLogger: () => context.infrastructure.logger,
+    initializeTelemetry: async () => {
+      return await context.infrastructure.initializeOpenTelemetry().catch((error) => {
+        console.error("Failed to initialize OpenTelemetry:", error);
+        return false;
+      });
+    },
+    onTelemetryInitialized: () => {
+      console.log("OpenTelemetry initialized successfully");
+    },
+    getTraceContext: () => getRuntimeTraceContext(),
+    registerTraceContextGetter: (getter) => {
+      __registerTraceContextGetter(getter);
+    },
+    start: async () => {
+      await startNodeAgentService({
+        ...createVeryfrontCloudAgentServiceRuntimeOptions(context),
+        hardShutdownTimeoutMs: options.hardShutdownTimeoutMs ?? DEFAULT_HARD_SHUTDOWN_TIMEOUT_MS,
+      });
+    },
+    onStartupError: (error) => {
+      console.error("Error in server startup:", error);
+    },
+    exit: processTarget?.exit,
+    processTarget,
+  });
+}

--- a/src/agent/veryfront-cloud-agent-service.ts
+++ b/src/agent/veryfront-cloud-agent-service.ts
@@ -1,4 +1,5 @@
-import { dirname } from "node:path";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { HostedSandboxToolsOptions } from "#veryfront/sandbox";
 import { createHostedSandboxTools } from "#veryfront/sandbox";
@@ -7,8 +8,19 @@ import {
   createToolsFromRemoteDefinitions,
   type HostToolSet,
   sleepTool,
+  toolRegistry,
 } from "#veryfront/tool";
 import { parseProviderError } from "../chat/provider-errors.ts";
+import { getConfig } from "../config/index.ts";
+import {
+  clearTrackedAgents,
+  clearTranspileCache,
+  createProjectDiscoveryConfig,
+  DEFAULT_PROJECT_DISCOVERY_DIRS,
+  discoverAll,
+} from "../discovery/index.ts";
+import type { DiscoveryResult } from "../discovery/types.ts";
+import { nodeAdapter } from "../platform/adapters/node.ts";
 import {
   getVeryfrontCloudProviderFromModelId,
   resolveVeryfrontCloudModelId,
@@ -51,6 +63,7 @@ import { type HostedProjectSkillIdsContext } from "./hosted-project-steering-ada
 import type { RuntimeLoadSkillToolContext } from "./runtime-load-skill-tool.ts";
 import type { RuntimeProjectSteeringLookup } from "./runtime-project-skill-catalog.ts";
 import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
+import type { RuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
 import {
   buildVeryfrontCloudRuntimeInstructions,
 } from "./veryfront-cloud-runtime-system-messages.ts";
@@ -81,6 +94,8 @@ import {
   prepareVeryfrontCloudHostedChatExecution,
 } from "./veryfront-cloud-hosted-chat-execution-preparation.ts";
 import { applyAgentProjectContextChange } from "./project-context.ts";
+import type { Agent, AgentConfig } from "./types.ts";
+import { agentRegistry, getAgent } from "./composition/index.ts";
 
 export type NodeVeryfrontCloudAgentServiceProcessTarget =
   & NonNullable<RunAgentServiceMainOptions["processTarget"]>
@@ -90,11 +105,15 @@ export type NodeVeryfrontCloudAgentServiceProcessTarget =
     exit?: (code: number) => never | void;
   };
 
+export type NodeVeryfrontCloudAgentServiceAgentSource = "auto" | "code" | "markdown";
+
 export type NodeVeryfrontCloudAgentServiceOptions = {
   serviceName: string;
   agentId: string;
   baseDir?: string;
+  projectDir?: string;
   entryUrl?: string | URL;
+  agentSource?: NodeVeryfrontCloudAgentServiceAgentSource;
   forwardedConfigNamespace?: string;
   createBashTool: HostedSandboxToolsOptions["createBashTool"];
   env?: CreateNodeAgentServiceRuntimeInfrastructureOptions["env"];
@@ -123,6 +142,11 @@ const DEFAULT_FORWARDED_CONFIG_NAMESPACE = "veryfront";
 const DEFAULT_DRAIN_TIMEOUT_MS = 15_000;
 const DEFAULT_HARD_SHUTDOWN_TIMEOUT_MS = 20_000;
 const DEFAULT_PROJECT_NAVIGATION_TOOL_NAMES = ["studio_open_project"];
+const PROJECT_CONFIG_FILES = [
+  "veryfront.config.js",
+  "veryfront.config.ts",
+  "veryfront.config.mjs",
+];
 
 function resolveBaseDir(
   options: Pick<NodeVeryfrontCloudAgentServiceOptions, "baseDir" | "entryUrl">,
@@ -137,6 +161,36 @@ function resolveBaseDir(
     return process.cwd();
   }
   return Deno.cwd();
+}
+function hasDiscoveryRoot(baseDir: string): boolean {
+  const discoveryDirs = [
+    ...DEFAULT_PROJECT_DISCOVERY_DIRS.agentDirs,
+    ...DEFAULT_PROJECT_DISCOVERY_DIRS.toolDirs,
+    ...DEFAULT_PROJECT_DISCOVERY_DIRS.skillDirs,
+    ...DEFAULT_PROJECT_DISCOVERY_DIRS.resourceDirs,
+    ...DEFAULT_PROJECT_DISCOVERY_DIRS.promptDirs,
+    ...DEFAULT_PROJECT_DISCOVERY_DIRS.workflowDirs,
+    ...DEFAULT_PROJECT_DISCOVERY_DIRS.taskDirs,
+  ];
+
+  return discoveryDirs.some((dir) => existsSync(resolve(baseDir, dir))) ||
+    PROJECT_CONFIG_FILES.some((file) => existsSync(resolve(baseDir, file)));
+}
+
+function uniquePaths(paths: string[]): string[] {
+  return [...new Set(paths.map((path) => resolve(path)))];
+}
+
+function resolveProjectDir(
+  options: Pick<NodeVeryfrontCloudAgentServiceOptions, "baseDir" | "entryUrl" | "projectDir">,
+): string {
+  if (options.projectDir) {
+    return options.projectDir;
+  }
+
+  const baseDir = resolveBaseDir(options);
+  const candidates = uniquePaths([baseDir, dirname(baseDir), dirname(dirname(baseDir))]);
+  return candidates.find(hasDiscoveryRoot) ?? baseDir;
 }
 
 function resolveDefaultProcessTarget(): NodeVeryfrontCloudAgentServiceProcessTarget | undefined {
@@ -192,11 +246,93 @@ function createNodeVeryfrontCloudAgentServiceContext(
   return {
     options,
     processTarget,
+    projectDir: resolveProjectDir(options),
     infrastructure,
     trace,
     projectSteering,
     tracker: createDetachedRunTracker<AgUiResumeValue>(),
+    discoveryResult: null as DiscoveryResult | null,
+    agentConfig: null as RuntimeAgentMarkdownDefinition | null,
   };
+}
+
+function resolveAgentSystem(system: AgentConfig["system"]): Promise<string> | string {
+  return typeof system === "function" ? system() : system;
+}
+
+async function createRuntimeAgentDefinitionFromCodeAgent(
+  codeAgent: Agent,
+): Promise<RuntimeAgentMarkdownDefinition> {
+  return {
+    id: codeAgent.id,
+    name: codeAgent.id,
+    description: "",
+    instructions: await resolveAgentSystem(codeAgent.config.system),
+    model: codeAgent.config.model,
+    maxSteps: codeAgent.config.maxSteps,
+  };
+}
+
+function getMarkdownAgentConfig(
+  context: NodeVeryfrontCloudAgentServiceContext,
+): RuntimeAgentMarkdownDefinition {
+  return context.projectSteering.getAgentConfig();
+}
+
+async function resolveAgentConfig(
+  context: NodeVeryfrontCloudAgentServiceContext,
+): Promise<RuntimeAgentMarkdownDefinition> {
+  const source = context.options.agentSource ?? "auto";
+  const codeAgent = getAgent(context.options.agentId);
+
+  if (source !== "markdown" && codeAgent) {
+    return await createRuntimeAgentDefinitionFromCodeAgent(codeAgent);
+  }
+
+  if (source === "code") {
+    throw new Error(`Code agent "${context.options.agentId}" was not discovered.`);
+  }
+
+  return getMarkdownAgentConfig(context);
+}
+
+function getResolvedAgentConfig(
+  context: NodeVeryfrontCloudAgentServiceContext,
+): RuntimeAgentMarkdownDefinition {
+  if (!context.agentConfig) {
+    throw new Error("Agent service context has not been initialized.");
+  }
+  return context.agentConfig;
+}
+
+async function discoverProjectPrimitives(
+  context: NodeVeryfrontCloudAgentServiceContext,
+): Promise<void> {
+  clearTrackedAgents();
+  clearTranspileCache();
+  agentRegistry.clear();
+  toolRegistry.clear();
+
+  const config = await getConfig(context.projectDir, nodeAdapter);
+  const discoveryOptions = createProjectDiscoveryConfig({
+    projectDir: context.projectDir,
+    config,
+  });
+
+  context.discoveryResult = await discoverAll(discoveryOptions);
+}
+
+async function initializeNodeVeryfrontCloudAgentServiceContext(
+  context: NodeVeryfrontCloudAgentServiceContext,
+): Promise<void> {
+  await discoverProjectPrimitives(context);
+  context.agentConfig = await resolveAgentConfig(context);
+}
+
+function getDiscoveredHostTools(): HostToolSet {
+  return Object.fromEntries(
+    [...toolRegistry.getAll()].sort(([left], [right]) => left.localeCompare(right)),
+  );
 }
 
 function getProjectInstructions(
@@ -289,6 +425,7 @@ function buildLocalTools(
 ): HostToolSet {
   const config = context.infrastructure.getConfig();
   const tools: HostToolSet = {
+    ...getDiscoveredHostTools(),
     form_input: createHostedFormInputTool(taskContext, config.VERYFRONT_API_URL),
     load_skill: createLoadSkillTool(context, taskContext),
     sleep: sleepTool,
@@ -439,7 +576,7 @@ async function prepareChatExecution(
 
   setPrepareChatExecutionStartAttributes(context, { projectId, userId });
 
-  const agentConfig = context.projectSteering.getAgentConfig();
+  const agentConfig = getResolvedAgentConfig(context);
   const {
     effectiveMessages,
     rootRunContext,
@@ -524,7 +661,7 @@ function createNodeVeryfrontCloudAgentServiceRuntimeOptions(
     forwardedConfigNamespace: context.options.forwardedConfigNamespace ??
       DEFAULT_FORWARDED_CONFIG_NAMESPACE,
     getConfig: context.infrastructure.getConfig,
-    getAgentConfig: () => context.projectSteering.getAgentConfig(),
+    getAgentConfig: () => getResolvedAgentConfig(context),
     tracker: context.tracker,
     prepareExecution: (request) => prepareChatExecution(context, request),
     streamExecutionToAgUiResponse: (execution) =>
@@ -559,10 +696,11 @@ function createNodeVeryfrontCloudAgentServiceRuntimeOptions(
   };
 }
 
-export function createNodeVeryfrontCloudAgentServiceRuntime(
+export async function createNodeVeryfrontCloudAgentServiceRuntime(
   options: NodeVeryfrontCloudAgentServiceOptions,
-): AgentServiceRuntimeBundle<NodeVeryfrontCloudAgentServicePreparedExecution> {
+): Promise<AgentServiceRuntimeBundle<NodeVeryfrontCloudAgentServicePreparedExecution>> {
   const context = createNodeVeryfrontCloudAgentServiceContext(options);
+  await initializeNodeVeryfrontCloudAgentServiceContext(context);
   return createAgentServiceRuntime(createNodeVeryfrontCloudAgentServiceRuntimeOptions(context));
 }
 
@@ -570,6 +708,7 @@ export async function startNodeVeryfrontCloudAgentService(
   options: NodeVeryfrontCloudAgentServiceOptions,
 ): Promise<StartNodeAgentServiceResult<NodeVeryfrontCloudAgentServicePreparedExecution>> {
   const context = createNodeVeryfrontCloudAgentServiceContext(options);
+  await initializeNodeVeryfrontCloudAgentServiceContext(context);
   return await startNodeAgentService({
     ...createNodeVeryfrontCloudAgentServiceRuntimeOptions(context),
     hardShutdownTimeoutMs: options.hardShutdownTimeoutMs ?? DEFAULT_HARD_SHUTDOWN_TIMEOUT_MS,
@@ -589,6 +728,7 @@ export async function runNodeVeryfrontCloudAgentServiceMain(
     processTarget,
   });
   getRuntimeTraceContext = context.infrastructure.getTraceContext;
+  await initializeNodeVeryfrontCloudAgentServiceContext(context);
 
   await runAgentServiceMain({
     loadLogger: () => context.infrastructure.logger,

--- a/src/config/schemas/config.schema.ts
+++ b/src/config/schemas/config.schema.ts
@@ -426,6 +426,54 @@ export const veryfrontConfigSchema = z
           })
           .partial()
           .optional(),
+        resources: z
+          .object({
+            discovery: z
+              .object({
+                enabled: z.boolean().optional(),
+                paths: z.array(z.string()).optional(),
+              })
+              .partial()
+              .optional(),
+          })
+          .partial()
+          .optional(),
+        prompts: z
+          .object({
+            discovery: z
+              .object({
+                enabled: z.boolean().optional(),
+                paths: z.array(z.string()).optional(),
+              })
+              .partial()
+              .optional(),
+          })
+          .partial()
+          .optional(),
+        workflows: z
+          .object({
+            discovery: z
+              .object({
+                enabled: z.boolean().optional(),
+                paths: z.array(z.string()).optional(),
+              })
+              .partial()
+              .optional(),
+          })
+          .partial()
+          .optional(),
+        tasks: z
+          .object({
+            discovery: z
+              .object({
+                enabled: z.boolean().optional(),
+                paths: z.array(z.string()).optional(),
+              })
+              .partial()
+              .optional(),
+          })
+          .partial()
+          .optional(),
         mcp: z
           .object({
             enabled: z.boolean().optional(),

--- a/src/discovery/index.ts
+++ b/src/discovery/index.ts
@@ -19,6 +19,10 @@ export type {
 
 // Re-export main discovery function
 export { discoverAll } from "./discovery-engine.ts";
+export {
+  createProjectDiscoveryConfig,
+  DEFAULT_PROJECT_DISCOVERY_DIRS,
+} from "./project-discovery-config.ts";
 
 // Re-export utilities
 export { clearTrackedAgents, filenameToId, filePathToPattern } from "./discovery-utils.ts";

--- a/src/discovery/project-discovery-config.ts
+++ b/src/discovery/project-discovery-config.ts
@@ -1,0 +1,89 @@
+import type { VeryfrontConfig } from "../config/index.ts";
+import type { FileSystemAdapter } from "../platform/adapters/base.ts";
+import type { DiscoveryConfig } from "./types.ts";
+
+export const DEFAULT_PROJECT_DISCOVERY_DIRS = {
+  toolDirs: ["tools"],
+  agentDirs: ["agents"],
+  skillDirs: ["skills"],
+  resourceDirs: ["resources"],
+  promptDirs: ["prompts"],
+  workflowDirs: ["workflows"],
+  taskDirs: ["tasks"],
+};
+
+type DiscoverySettings = {
+  enabled?: boolean;
+  paths?: string[];
+};
+
+type ProjectDiscoveryConfigInput = {
+  projectDir: string;
+  config?: VeryfrontConfig | null;
+  fsAdapter?: FileSystemAdapter;
+  verbose?: boolean;
+};
+
+export type ProjectDiscoveryConfig = DiscoveryConfig & {
+  toolDirs: string[];
+  agentDirs: string[];
+  skillDirs: string[];
+  resourceDirs: string[];
+  promptDirs: string[];
+  workflowDirs: string[];
+  taskDirs: string[];
+};
+
+function isDiscoveryEnabled(discovery: DiscoverySettings | undefined): boolean {
+  return discovery?.enabled ?? true;
+}
+
+function resolveDiscoveryPaths(
+  discovery: DiscoverySettings | undefined,
+  defaultPaths: string[],
+): string[] {
+  if (!isDiscoveryEnabled(discovery)) {
+    return [];
+  }
+  return discovery?.paths ?? defaultPaths;
+}
+
+export function createProjectDiscoveryConfig(
+  input: ProjectDiscoveryConfigInput,
+): ProjectDiscoveryConfig {
+  const aiConfig = input.config?.ai;
+
+  return {
+    baseDir: input.projectDir,
+    toolDirs: resolveDiscoveryPaths(
+      aiConfig?.tools?.discovery,
+      DEFAULT_PROJECT_DISCOVERY_DIRS.toolDirs,
+    ),
+    agentDirs: resolveDiscoveryPaths(
+      aiConfig?.agents?.discovery,
+      DEFAULT_PROJECT_DISCOVERY_DIRS.agentDirs,
+    ),
+    skillDirs: resolveDiscoveryPaths(
+      aiConfig?.skills?.discovery,
+      DEFAULT_PROJECT_DISCOVERY_DIRS.skillDirs,
+    ),
+    resourceDirs: resolveDiscoveryPaths(
+      aiConfig?.resources?.discovery,
+      DEFAULT_PROJECT_DISCOVERY_DIRS.resourceDirs,
+    ),
+    promptDirs: resolveDiscoveryPaths(
+      aiConfig?.prompts?.discovery,
+      DEFAULT_PROJECT_DISCOVERY_DIRS.promptDirs,
+    ),
+    workflowDirs: resolveDiscoveryPaths(
+      aiConfig?.workflows?.discovery,
+      DEFAULT_PROJECT_DISCOVERY_DIRS.workflowDirs,
+    ),
+    taskDirs: resolveDiscoveryPaths(
+      aiConfig?.tasks?.discovery,
+      DEFAULT_PROJECT_DISCOVERY_DIRS.taskDirs,
+    ),
+    fsAdapter: input.fsAdapter,
+    verbose: input.verbose ?? false,
+  };
+}

--- a/src/server/handlers/request/api/project-discovery.ts
+++ b/src/server/handlers/request/api/project-discovery.ts
@@ -1,5 +1,5 @@
 import { serverLogger } from "#veryfront/utils";
-import { clearTrackedAgents } from "#veryfront/discovery";
+import { clearTrackedAgents, createProjectDiscoveryConfig } from "#veryfront/discovery";
 import { tryGetCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
 import type { HandlerContext } from "../../types.ts";
 
@@ -15,31 +15,6 @@ const logger = serverLogger.component("api-wrapper");
  * allows retry on failure (the key is deleted if discovery rejects).
  */
 const discoveredProjects = new Map<string, Promise<void>>();
-
-function isDiscoveryEnabled(
-  discovery: { enabled?: boolean } | undefined,
-): boolean {
-  return discovery?.enabled ?? true;
-}
-
-function buildDiscoveryConfig(ctx: HandlerContext) {
-  const discoveryConfig = ctx.config?.ai;
-  const toolDiscovery = discoveryConfig?.tools?.discovery;
-  const agentDiscovery = discoveryConfig?.agents?.discovery;
-  const skillDiscovery = discoveryConfig?.skills?.discovery;
-
-  return {
-    baseDir: ctx.projectDir,
-    toolDirs: isDiscoveryEnabled(toolDiscovery) ? (toolDiscovery?.paths ?? ["tools"]) : [],
-    agentDirs: isDiscoveryEnabled(agentDiscovery) ? (agentDiscovery?.paths ?? ["agents"]) : [],
-    skillDirs: isDiscoveryEnabled(skillDiscovery) ? (skillDiscovery?.paths ?? ["skills"]) : [],
-    resourceDirs: ["resources"],
-    promptDirs: ["prompts"],
-    workflowDirs: ["workflows"],
-    fsAdapter: ctx.adapter.fs,
-    verbose: false,
-  };
-}
 
 /** Build a discovery cache key that incorporates the release/version. */
 function discoveryKey(ctx: HandlerContext): string {
@@ -99,7 +74,11 @@ export async function ensureProjectDiscovery(ctx: HandlerContext): Promise<void>
     agentRegistry.clear();
     toolRegistry.clear();
 
-    const discoveryOptions = buildDiscoveryConfig(ctx);
+    const discoveryOptions = createProjectDiscoveryConfig({
+      projectDir: ctx.projectDir,
+      config: ctx.config,
+      fsAdapter: ctx.adapter.fs,
+    });
     const result = await discoverAll(discoveryOptions);
     const shouldWarnOnEmptyAiDiscovery = discoveryOptions.toolDirs.length > 0 ||
       discoveryOptions.agentDirs.length > 0;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.498";
+export const VERSION = "0.1.499";


### PR DESCRIPTION
## Summary
- add a public Veryfront Cloud agent-service preset for separately deployed Node services
- wire markdown agent definitions, default runtime infrastructure, project steering, local tools, sandbox, Studio MCP, prepared execution, and detached durable execution
- document the preset and bump the package patch version for CI/CD publish

## Verification
- deno fmt src/agent/veryfront-cloud-agent-service.ts src/agent/veryfront-cloud-agent-service.test.ts src/agent/index.ts deno.json src/utils/version-constant.ts docs/reference/agent.md docs/guides/agents.md
- deno check --allow-import src/agent/index.ts
- deno test --no-check --allow-all src/agent/veryfront-cloud-agent-service.test.ts src/agent/agent-service-api-aliases.test.ts src/agent/hosted-agent-service-runtime.test.ts
- deno test --no-check --allow-all --parallel --unstable-worker-options '--ignore=tests,src/workflow/__tests__,cli/commands/*.integration.test.ts'
- pre-push checks: fmt, lint, type check, unit tests