### PR TITLE
Surface SBOM in releases and GitHub dependency graph

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -330,6 +330,11 @@ jobs:
         with:
           path: binaries
 
+      - name: Generate SBOM
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: deno task sbom --output "dist/sbom-${VERSION}.json"
+
       - name: Create GitHub pre-release
         env:
           VERSION: ${{ steps.version.outputs.version }}
@@ -354,7 +359,8 @@ jobs:
           npx veryfront@rc
           ```' \
             $BINARIES \
-            scripts/install.sh
+            scripts/install.sh \
+            "dist/sbom-${VERSION}.json"
 
       - name: Trigger server deploy
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4.0.1
@@ -426,6 +432,11 @@ jobs:
         with:
           path: binaries
 
+      - name: Generate SBOM
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: deno task sbom --output "dist/sbom-${VERSION}.json"
+
       - name: Create git tag
         env:
           VERSION: ${{ steps.version.outputs.version }}
@@ -474,7 +485,8 @@ jobs:
           ```' \
               $BINARIES \
               scripts/install.sh \
-              scripts/install.ps1
+              scripts/install.ps1 \
+              "dist/sbom-${VERSION}.json"
           fi
 
       - name: Create source repo release

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
     paths:
       - "deno.json"
+  push:
+    branches: [main]
+    paths:
+      - "deno.lock"
+      - "deno.json"
   schedule:
     # Run weekly on Monday at 06:00 UTC
     - cron: "0 6 * * 1"
@@ -26,3 +31,19 @@ jobs:
 
       - name: Run dependency lint
         run: deno task lint:deps
+
+  submit-dependency-snapshot:
+    # Only push/schedule/manual — PRs from forks lack write access.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    name: Submit Dependency Snapshot
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: ./.github/actions/setup-deno
+
+      - name: Submit deno.lock graph to GitHub
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: deno task submit-deps

--- a/deno.json
+++ b/deno.json
@@ -372,6 +372,7 @@
     "start-split": "deno task generate && deno run --allow-all cli/main.ts serve --split",
     "start-split:binary": "deno task generate && deno run --allow-all cli/main.ts serve --split --binary",
     "sbom": "deno run --allow-read --allow-write scripts/build/generate-sbom.ts",
+    "submit-deps": "deno run --allow-read --allow-env --allow-net=api.github.com scripts/security/submit-dependency-snapshot.ts",
     "audit": "deno run --allow-read --allow-run --allow-write scripts/security/audit-npm.ts"
   },
   "lint": {

--- a/scripts/security/submit-dependency-snapshot.ts
+++ b/scripts/security/submit-dependency-snapshot.ts
@@ -1,0 +1,189 @@
+/**
+ * Submit deno.lock npm graph to GitHub's Dependency Submission API.
+ *
+ * Reads deno.lock, builds a snapshot in GitHub's format, and POSTs to
+ * /repos/{owner}/{repo}/dependency-graph/snapshots. The result is visible
+ * under Insights → Dependency graph and feeds Dependabot alerts.
+ *
+ * Usage:
+ *   deno run --allow-read --allow-env --allow-net=api.github.com \
+ *     scripts/security/submit-dependency-snapshot.ts
+ *
+ * Required env (GitHub Actions provides all of these):
+ *   GITHUB_TOKEN, GITHUB_REPOSITORY, GITHUB_SHA, GITHUB_REF,
+ *   GITHUB_RUN_ID, GITHUB_JOB, GITHUB_WORKFLOW
+ *
+ * Token needs `contents: write` permission.
+ */
+
+interface DenoLockV5 {
+  version: string;
+  specifiers?: Record<string, string>;
+  npm?: Record<string, { integrity?: string; dependencies?: string[] }>;
+}
+
+interface ResolvedDependency {
+  package_url: string;
+  relationship: "direct" | "indirect";
+  scope: "runtime" | "development";
+  dependencies?: string[];
+}
+
+interface Manifest {
+  name: string;
+  file: { source_location: string };
+  resolved: Record<string, ResolvedDependency>;
+}
+
+interface Snapshot {
+  version: 0;
+  sha: string;
+  ref: string;
+  job: { correlator: string; id: string };
+  detector: { name: string; version: string; url: string };
+  scanned: string;
+  manifests: Record<string, Manifest>;
+}
+
+const DETECTOR = {
+  name: "veryfront-deno-lock",
+  version: "1.0.0",
+  url: "https://github.com/veryfront/veryfront-code",
+} as const;
+
+function parseNameVersion(
+  key: string,
+): { name: string; version: string } | null {
+  let scope = "";
+  let rest = key;
+  if (key.startsWith("@")) {
+    const slash = key.indexOf("/");
+    if (slash < 0) return null;
+    scope = key.slice(0, slash + 1);
+    rest = key.slice(slash + 1);
+  }
+  const at = rest.indexOf("@");
+  if (at <= 0) return null;
+  const name = scope + rest.slice(0, at);
+  let version = rest.slice(at + 1);
+  const underscore = version.indexOf("_");
+  if (underscore >= 0) version = version.slice(0, underscore);
+  return { name, version };
+}
+
+function purl(name: string, version: string): string {
+  const encoded = name.split("/").map(encodeURIComponent).join("/");
+  return `pkg:npm/${encoded}@${version}`;
+}
+
+export function snapshotFromLock(
+  lockText: string,
+  ctx: {
+    sha: string;
+    ref: string;
+    correlator: string;
+    runId: string;
+  },
+): Snapshot {
+  const lock = JSON.parse(lockText) as DenoLockV5;
+  if (lock.version !== "5") {
+    throw new Error(
+      `Unsupported deno.lock version: "${lock.version}" (expected "5")`,
+    );
+  }
+
+  const npm = lock.npm ?? {};
+  const directKeys = new Set<string>();
+  for (const [spec, resolvedVersion] of Object.entries(lock.specifiers ?? {})) {
+    if (!spec.startsWith("npm:")) continue;
+    const bare = spec.slice("npm:".length);
+    const lastAt = bare.lastIndexOf("@");
+    if (lastAt <= 0) continue;
+    const name = bare.slice(0, lastAt);
+    directKeys.add(`${name}@${resolvedVersion}`);
+  }
+
+  const resolved: Record<string, ResolvedDependency> = {};
+  for (const [key, info] of Object.entries(npm)) {
+    const nv = parseNameVersion(key);
+    if (!nv) continue;
+
+    const deps: string[] = [];
+    for (const depKey of info.dependencies ?? []) {
+      const depNv = parseNameVersion(depKey);
+      if (depNv) deps.push(purl(depNv.name, depNv.version));
+    }
+
+    resolved[`${nv.name}@${nv.version}`] = {
+      package_url: purl(nv.name, nv.version),
+      relationship: directKeys.has(key) ? "direct" : "indirect",
+      scope: "runtime",
+      ...(deps.length ? { dependencies: deps } : {}),
+    };
+  }
+
+  return {
+    version: 0,
+    sha: ctx.sha,
+    ref: ctx.ref,
+    job: { correlator: ctx.correlator, id: ctx.runId },
+    detector: DETECTOR,
+    scanned: new Date().toISOString(),
+    manifests: {
+      "deno.lock": {
+        name: "deno.lock",
+        file: { source_location: "deno.lock" },
+        resolved,
+      },
+    },
+  };
+}
+
+function requireEnv(name: string): string {
+  const v = Deno.env.get(name);
+  if (!v) throw new Error(`Missing required env var: ${name}`);
+  return v;
+}
+
+if (import.meta.main) {
+  const token = requireEnv("GITHUB_TOKEN");
+  const repo = requireEnv("GITHUB_REPOSITORY");
+  const sha = requireEnv("GITHUB_SHA");
+  const ref = requireEnv("GITHUB_REF");
+  const runId = requireEnv("GITHUB_RUN_ID");
+  const correlator = `${Deno.env.get("GITHUB_WORKFLOW") ?? "ci"}/${
+    Deno.env.get("GITHUB_JOB") ?? "submit-dependency-snapshot"
+  }`;
+
+  const lockText = await Deno.readTextFile("deno.lock");
+  const snapshot = snapshotFromLock(lockText, { sha, ref, correlator, runId });
+
+  const componentCount = Object.keys(snapshot.manifests["deno.lock"].resolved)
+    .length;
+
+  const res = await fetch(
+    `https://api.github.com/repos/${repo}/dependency-graph/snapshots`,
+    {
+      method: "POST",
+      headers: {
+        "Accept": "application/vnd.github+json",
+        "Authorization": `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: JSON.stringify(snapshot),
+    },
+  );
+
+  const body = await res.text();
+  if (!res.ok) {
+    console.error(`❌ Submission failed: ${res.status} ${res.statusText}`);
+    console.error(body);
+    Deno.exit(1);
+  }
+
+  console.log(
+    `✅ Submitted dependency snapshot: ${componentCount} packages, ref=${ref}`,
+  );
+  console.log(`   Response: ${body}`);
+}


### PR DESCRIPTION
## Summary
- Attach `dist/sbom-<version>.json` (CycloneDX 1.5) to every prerelease and stable release on GitHub Releases.
- Submit the npm graph from `deno.lock` to GitHub's Dependency Submission API on push to `main` (when `deno.lock` / `deno.json` change), weekly, and on manual dispatch — populates **Insights → Dependency graph** and feeds **Dependabot alerts**.
- Direct vs indirect classification comes from `lock.specifiers`; transitive edges come from each npm entry's `dependencies` list.

## Why
Releases consumers and auditors can now grab a CycloneDX SBOM directly from the release page. The dependency-graph submission gives us native GitHub UI for the npm subgraph and free CVE correlation via Dependabot — Deno isn't a first-class ecosystem in the graph otherwise.

## What changed
| File | Change |
|---|---|
| `scripts/security/submit-dependency-snapshot.ts` | New — parses `deno.lock`, builds GitHub snapshot, POSTs to `/repos/{owner}/{repo}/dependency-graph/snapshots`. |
| `deno.json` | Added `deno task submit-deps`. |
| `.github/workflows/security-audit.yml` | New `submit-dependency-snapshot` job (push to main, weekly, manual). PRs skipped (forks lack write access). |
| `.github/workflows/cicd.yml` | Added `Generate SBOM` step + SBOM asset upload in both `prerelease` and `release` jobs. |

## Test plan
- [x] `deno task sbom --output /tmp/sbom-test.json` → 526 components, CycloneDX 1.5
- [x] `deno task submit-deps` (locally) → fails as expected with "Missing required env var: GITHUB_TOKEN" — confirms entry point + arg wiring
- [x] Smoke-tested `snapshotFromLock` against current `deno.lock` → 525 packages, 56 direct, 469 indirect
- [x] Both YAML files parse cleanly
- [ ] After merge: confirm first push to main lands a snapshot under **Insights → Dependency graph**
- [ ] After next release: verify `sbom-<version>.json` appears as an asset on the `veryfront/veryfront` release page