### PR TITLE
Resolve bare-name dep edges and broaden snapshot trigger

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -6,10 +6,10 @@ on:
     paths:
       - "deno.json"
   push:
+    # No path filter: deno.lock is gitignored, and `npm:` specifiers live both
+    # in deno.json and inline in source files. A broad trigger keeps the
+    # dependency graph in sync with whatever lands on main.
     branches: [main]
-    paths:
-      - "deno.lock"
-      - "deno.json"
   schedule:
     # Run weekly on Monday at 06:00 UTC
     - cron: "0 6 * * 1"

--- a/scripts/security/submit-dependency-snapshot.ts
+++ b/scripts/security/submit-dependency-snapshot.ts
@@ -103,6 +103,30 @@ export function snapshotFromLock(
     directKeys.add(`${name}@${resolvedVersion}`);
   }
 
+  // Deno v5 lockfiles use bare child names ("zod") instead of "zod@x.y.z" for
+  // most transitive edges. Build a name → versions index so we can resolve
+  // them. When a name has multiple resolved versions we emit edges to all of
+  // them — over-approximating preserves reachability for vuln correlation.
+  const versionsByName = new Map<string, Set<string>>();
+  for (const key of Object.keys(npm)) {
+    const nv = parseNameVersion(key);
+    if (!nv) continue;
+    let versions = versionsByName.get(nv.name);
+    if (!versions) {
+      versions = new Set();
+      versionsByName.set(nv.name, versions);
+    }
+    versions.add(nv.version);
+  }
+
+  function resolveDepEdge(depKey: string): string[] {
+    const qualified = parseNameVersion(depKey);
+    if (qualified) return [purl(qualified.name, qualified.version)];
+    const versions = versionsByName.get(depKey);
+    if (!versions) return [];
+    return [...versions].map((v) => purl(depKey, v));
+  }
+
   const resolved: Record<string, ResolvedDependency> = {};
   for (const [key, info] of Object.entries(npm)) {
     const nv = parseNameVersion(key);
@@ -110,8 +134,7 @@ export function snapshotFromLock(
 
     const deps: string[] = [];
     for (const depKey of info.dependencies ?? []) {
-      const depNv = parseNameVersion(depKey);
-      if (depNv) deps.push(purl(depNv.name, depNv.version));
+      for (const purlStr of resolveDepEdge(depKey)) deps.push(purlStr);
     }
 
     resolved[`${nv.name}@${nv.version}`] = {


### PR DESCRIPTION
Follow-up to #1597. Addresses the two Codex review comments that landed after #1597 was merged.

## Summary
- **P1** — Deno v5 lockfiles use bare package names (`"zod"`) for ~78% of transitive edges, not `"zod@x.y.z"` keys. The previous parser dropped all of them. Built a `name → Set<version>` index from `lock.npm` keys; bare deps now resolve to all known versions for that name. **Edges emitted: 263 → 1,198.** Multi-version cases (18 of 507 packages, mostly opentelemetry) over-approximate rather than drop — preserves vuln reachability.
- **P2** — `deno.lock` is gitignored and inline `npm:` imports exist in `src/` (e.g. `src/transforms/esm/specifier-resolver.test.ts`), so the previous `paths: [deno.lock, deno.json]` filter on the push trigger missed real dependency changes. Dropped the filter so every push to main runs.

## Test plan
- [x] Snapshot generator emits 1,198 edges (vs 263 before) against current `deno.lock`
- [x] Verified one previously-broken case (`@asamuzakjp/css-color@4.1.2`) now emits its 5 transitive edges
- [x] Direct/indirect classification preserved (56 direct from 59 npm specifiers)
- [x] `security-audit.yml` parses cleanly
- [ ] After merge: confirm first push to main lands a fresh snapshot under **Insights → Dependency graph**