### PR TITLE
Extract shared deno.lock parser into scripts/lib

### DIFF
--- a/scripts/build/generate-sbom.ts
+++ b/scripts/build/generate-sbom.ts
@@ -8,6 +8,14 @@
  */
 
 import { parseArgs } from "#std/flags";
+import {
+  parseLock,
+  parseNameVersion,
+  purl,
+  SUPPORTED_LOCK_VERSIONS,
+} from "../lib/deno-lock.ts";
+
+export { SUPPORTED_LOCK_VERSIONS };
 
 export interface CycloneDXComponent {
   type: "library";
@@ -15,42 +23,6 @@ export interface CycloneDXComponent {
   version: string;
   purl: string;
   hashes?: Array<{ alg: string; content: string }>;
-}
-
-/**
- * Lockfile versions whose schema this parser has been validated against.
- * Bump (and re-test) when Deno introduces a new lock format.
- */
-export const SUPPORTED_LOCK_VERSIONS = ["5"] as const;
-
-interface DenoLockV5 {
-  version: string;
-  specifiers?: Record<string, string>;
-  npm?: Record<string, { integrity?: string; dependencies?: string[] }>;
-  jsr?: Record<string, unknown>;
-}
-
-function parseNameVersion(key: string): { name: string; version: string } | null {
-  let scope = "";
-  let rest = key;
-  if (key.startsWith("@")) {
-    const slash = key.indexOf("/");
-    if (slash < 0) return null;
-    scope = key.slice(0, slash + 1);
-    rest = key.slice(slash + 1);
-  }
-  const at = rest.indexOf("@");
-  if (at <= 0) return null;
-  const name = scope + rest.slice(0, at);
-  let version = rest.slice(at + 1);
-  const underscore = version.indexOf("_");
-  if (underscore >= 0) version = version.slice(0, underscore);
-  return { name, version };
-}
-
-function purlFor(name: string, version: string): string {
-  const encoded = name.split("/").map(encodeURIComponent).join("/");
-  return `pkg:npm/${encoded}@${version}`;
 }
 
 function hashFromIntegrity(
@@ -63,18 +35,7 @@ function hashFromIntegrity(
 }
 
 export function componentsFromLock(lockText: string): CycloneDXComponent[] {
-  const lock = JSON.parse(lockText) as DenoLockV5;
-  if (
-    !SUPPORTED_LOCK_VERSIONS.includes(
-      lock.version as typeof SUPPORTED_LOCK_VERSIONS[number],
-    )
-  ) {
-    throw new Error(
-      `Unsupported deno.lock version: "${lock.version}" (supported: ${
-        SUPPORTED_LOCK_VERSIONS.join(", ")
-      })`,
-    );
-  }
+  const lock = parseLock(lockText);
   const npm = lock.npm ?? {};
   const seen = new Set<string>();
   const components: CycloneDXComponent[] = [];
@@ -89,7 +50,7 @@ export function componentsFromLock(lockText: string): CycloneDXComponent[] {
       type: "library",
       name: nv.name,
       version: nv.version,
-      purl: purlFor(nv.name, nv.version),
+      purl: purl(nv.name, nv.version),
       ...(hash ? { hashes: [hash] } : {}),
     });
   }

--- a/scripts/lib/deno-lock.ts
+++ b/scripts/lib/deno-lock.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared helpers for parsing deno.lock v5 npm entries.
+ *
+ * Used by `scripts/build/generate-sbom.ts` (CycloneDX export) and
+ * `scripts/security/submit-dependency-snapshot.ts` (GitHub Dependency
+ * Submission). Keep this module dependency-free so it can be imported by
+ * any script without pulling in network or fs permissions.
+ */
+
+/**
+ * Lockfile versions whose schema these helpers have been validated against.
+ * Bump (and re-test) when Deno introduces a new lock format.
+ */
+export const SUPPORTED_LOCK_VERSIONS = ["5"] as const;
+
+export interface DenoLockV5 {
+  version: string;
+  specifiers?: Record<string, string>;
+  npm?: Record<string, { integrity?: string; dependencies?: string[] }>;
+  jsr?: Record<string, unknown>;
+}
+
+/**
+ * Split a deno.lock npm key (`name@version` or `name@version_peer@x`) into
+ * its name and base version, discarding any peer-dep suffix. Returns null
+ * for keys that can't be parsed (e.g. bare names with no `@`).
+ */
+export function parseNameVersion(
+  key: string,
+): { name: string; version: string } | null {
+  let scope = "";
+  let rest = key;
+  if (key.startsWith("@")) {
+    const slash = key.indexOf("/");
+    if (slash < 0) return null;
+    scope = key.slice(0, slash + 1);
+    rest = key.slice(slash + 1);
+  }
+  const at = rest.indexOf("@");
+  if (at <= 0) return null;
+  const name = scope + rest.slice(0, at);
+  let version = rest.slice(at + 1);
+  const underscore = version.indexOf("_");
+  if (underscore >= 0) version = version.slice(0, underscore);
+  return { name, version };
+}
+
+/** Build a `pkg:npm/...` Package URL for a name+version pair. */
+export function purl(name: string, version: string): string {
+  const encoded = name.split("/").map(encodeURIComponent).join("/");
+  return `pkg:npm/${encoded}@${version}`;
+}
+
+/**
+ * Parse and validate a deno.lock JSON blob. Throws if the lock version is
+ * not in {@link SUPPORTED_LOCK_VERSIONS}.
+ */
+export function parseLock(lockText: string): DenoLockV5 {
+  const lock = JSON.parse(lockText) as DenoLockV5;
+  if (
+    !SUPPORTED_LOCK_VERSIONS.includes(
+      lock.version as typeof SUPPORTED_LOCK_VERSIONS[number],
+    )
+  ) {
+    throw new Error(
+      `Unsupported deno.lock version: "${lock.version}" (supported: ${
+        SUPPORTED_LOCK_VERSIONS.join(", ")
+      })`,
+    );
+  }
+  return lock;
+}

--- a/scripts/security/submit-dependency-snapshot.ts
+++ b/scripts/security/submit-dependency-snapshot.ts
@@ -16,11 +16,7 @@
  * Token needs `contents: write` permission.
  */
 
-interface DenoLockV5 {
-  version: string;
-  specifiers?: Record<string, string>;
-  npm?: Record<string, { integrity?: string; dependencies?: string[] }>;
-}
+import { parseLock, parseNameVersion, purl } from "../lib/deno-lock.ts";
 
 interface ResolvedDependency {
   package_url: string;
@@ -51,31 +47,6 @@ const DETECTOR = {
   url: "https://github.com/veryfront/veryfront-code",
 } as const;
 
-function parseNameVersion(
-  key: string,
-): { name: string; version: string } | null {
-  let scope = "";
-  let rest = key;
-  if (key.startsWith("@")) {
-    const slash = key.indexOf("/");
-    if (slash < 0) return null;
-    scope = key.slice(0, slash + 1);
-    rest = key.slice(slash + 1);
-  }
-  const at = rest.indexOf("@");
-  if (at <= 0) return null;
-  const name = scope + rest.slice(0, at);
-  let version = rest.slice(at + 1);
-  const underscore = version.indexOf("_");
-  if (underscore >= 0) version = version.slice(0, underscore);
-  return { name, version };
-}
-
-function purl(name: string, version: string): string {
-  const encoded = name.split("/").map(encodeURIComponent).join("/");
-  return `pkg:npm/${encoded}@${version}`;
-}
-
 export function snapshotFromLock(
   lockText: string,
   ctx: {
@@ -85,13 +56,7 @@ export function snapshotFromLock(
     runId: string;
   },
 ): Snapshot {
-  const lock = JSON.parse(lockText) as DenoLockV5;
-  if (lock.version !== "5") {
-    throw new Error(
-      `Unsupported deno.lock version: "${lock.version}" (expected "5")`,
-    );
-  }
-
+  const lock = parseLock(lockText);
   const npm = lock.npm ?? {};
   const directKeys = new Set<string>();
   for (const [spec, resolvedVersion] of Object.entries(lock.specifiers ?? {})) {


### PR DESCRIPTION
Stacked on #1598. Targets \`fix-sbom-bare-deps\` so it auto-retargets to main when that merges.

## Summary
Pure refactor — extracts byte-identical helpers (`parseNameVersion`, `purl`, lock-version validation) from `generate-sbom.ts` and `submit-dependency-snapshot.ts` into a new `scripts/lib/deno-lock.ts`. Both scripts now import from it.

## Why
- Two consumers, identical helpers → one source of truth.
- Lets future scripts (e.g. another lock-based audit) reuse the same parser without copy-paste drift.
- Doubles as a real change to verify the dependency-graph submission workflow added in #1597 / #1598 picks up new pushes to main.

## What changed
| File | Change |
|---|---|
| `scripts/lib/deno-lock.ts` | New — `parseLock`, `parseNameVersion`, `purl`, `SUPPORTED_LOCK_VERSIONS`. |
| `scripts/build/generate-sbom.ts` | Imports from shared lib; re-exports `SUPPORTED_LOCK_VERSIONS` for test back-compat. |
| `scripts/security/submit-dependency-snapshot.ts` | Imports from shared lib. |

Net -7 lines.

## Test plan
- [x] `deno task test:scripts` passes (existing `generate-sbom.test.ts` + `audit-deps.test.ts`)
- [x] `deno task sbom` emits 525 components (unchanged)
- [x] `snapshotFromLock` emits 1,198 edges (unchanged)
- [ ] After merge to main: verify push triggers the new `submit-dependency-snapshot` job and populates Insights → Dependency graph