### PR TITLE
Add cross-runtime agent service start

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -275,8 +275,8 @@
     "veryfront/chat/message-prep": "./src/chat/message-prep.ts",
     "veryfront/chat/final-step-fallback": "./src/chat/final-step-fallback.ts",
     "veryfront/chat/provider-errors": "./src/chat/provider-errors.ts",
-    "bash-tool": "npm:bash-tool@^1.3.16",
-    "just-bash": "npm:just-bash@^2.14.0"
+    "bash-tool": "npm:bash-tool@1.3.16",
+    "just-bash": "npm:just-bash@2.14.3"
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.499",
+  "version": "0.1.500",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [
@@ -274,7 +274,9 @@
     "veryfront/chat/conversation": "./src/chat/conversation.ts",
     "veryfront/chat/message-prep": "./src/chat/message-prep.ts",
     "veryfront/chat/final-step-fallback": "./src/chat/final-step-fallback.ts",
-    "veryfront/chat/provider-errors": "./src/chat/provider-errors.ts"
+    "veryfront/chat/provider-errors": "./src/chat/provider-errors.ts",
+    "bash-tool": "npm:bash-tool@^1.3.16",
+    "just-bash": "npm:just-bash@^2.14.0"
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/deno.json
+++ b/deno.json
@@ -276,7 +276,7 @@
     "veryfront/chat/final-step-fallback": "./src/chat/final-step-fallback.ts",
     "veryfront/chat/provider-errors": "./src/chat/provider-errors.ts",
     "bash-tool": "npm:bash-tool@1.3.16",
-    "just-bash": "npm:just-bash@2.14.3"
+    "just-bash": "npm:just-bash@2.14.5"
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -178,25 +178,23 @@ If the service also uses the project-files API for instructions, skills,
 and `load_skill`, use `createAgentServiceProjectSteering()` to bind the markdown
 agent definition and project-steering adapter as one reusable service primitive.
 For the standard Veryfront Cloud service shape, use
-`runNodeVeryfrontCloudAgentServiceMain()` to bind those pieces in one Node
+`startAgentService()` to bind those pieces in one cross-runtime
 process entrypoint. The service entrypoint can stay small while agent behavior
 lives in `agents/<agent-id>.md` or a discovered code agent such as
 `agents/<agent-id>.ts`:
 
 ```ts
-import { createBashTool } from "bash-tool";
-import { runNodeVeryfrontCloudAgentServiceMain } from "veryfront/agent";
+import { startAgentService } from "veryfront/agent";
 
-await runNodeVeryfrontCloudAgentServiceMain({
+await startAgentService({
   serviceName: "support-agent",
   agentId: "support",
   entryUrl: import.meta.url,
-  createBashTool,
 });
 ```
 
-Use the lower-level helpers when a service needs custom tools, non-Node
-startup, or a different control-plane integration.
+Use the lower-level helpers when a service needs custom tools, a custom
+server adapter, or a different control-plane integration.
 
 The cloud service helper uses the same project discovery conventions as normal
 Veryfront projects: `agents/`, `tools/`, `skills/`, `resources/`, `prompts/`,

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -62,6 +62,7 @@ import {
   RunResumeSessionManager,
   RuntimeAgentRunInvocationSchema,
   shouldSkipHostedChildTerminalPersistence,
+  startAgentService,
   startNodeAgentService,
   startNodeVeryfrontCloudAgentService,
   waitForHumanInput,
@@ -266,21 +267,19 @@ request-native runtime with readiness, liveness, CORS, shutdown state, and
 host-supplied routes. For Node deployments, `startNodeAgentService()` wraps that
 runtime in the shared Veryfront service server with graceful shutdown.
 
-For a Veryfront Cloud-backed Node service that should use the default
+For a Veryfront Cloud-backed service that should use the default
 configuration, telemetry, model routing, sandbox, Studio MCP, project steering,
 durable-run, and prepared-execution wiring, use
-`runNodeVeryfrontCloudAgentServiceMain()` from a process entrypoint and keep the
+`startAgentService()` from a process entrypoint and keep the
 agent behavior in `agents/<agent-id>.md` or `agents/<agent-id>.ts`:
 
 ```ts
-import { createBashTool } from "bash-tool";
-import { runNodeVeryfrontCloudAgentServiceMain } from "veryfront/agent";
+import { startAgentService } from "veryfront/agent";
 
-await runNodeVeryfrontCloudAgentServiceMain({
+await startAgentService({
   serviceName: "support-agent",
   agentId: "support",
   entryUrl: import.meta.url,
-  createBashTool,
 });
 ```
 
@@ -835,22 +834,27 @@ project tools, and `invoke_agent`), sandbox tools, Studio MCP tools, remote MCP
 definitions, prepared chat execution, AG-UI streaming, and detached durable-run
 execution.
 
-Hosts provide the service name, agent id, Node entry URL or base directory, and
-a bash-tool factory. Use this helper when tests or custom hosts need the runtime
-bundle without starting the Node server.
+Hosts provide the service name, agent id, entry URL or base directory, and
+optionally a custom bash-tool factory. Use this helper when tests or custom
+hosts need the runtime bundle without starting the service server.
 
 ### `startNodeVeryfrontCloudAgentService(options)`
 
 Start a Veryfront Cloud agent-service runtime with the shared Node service
-server and graceful shutdown handling. This helper is Node-specific. Use the
-lower-level agent-service runtime APIs for non-Node hosts.
+server and graceful shutdown handling. This helper remains available for
+Node-specific hosts; use `startAgentService()` for the default cross-runtime
+process entrypoint.
+
+### `startAgentService(options)`
+
+Run the default cross-runtime bootstrap for a Veryfront Cloud agent service. The
+helper loads `.env` files, initializes OpenTelemetry where supported, registers
+trace-context logging, starts the service server, and handles startup failures
+through the provided process target.
 
 ### `runNodeVeryfrontCloudAgentServiceMain(options)`
 
-Run the default Node process bootstrap for a Veryfront Cloud agent service. The
-helper loads `.env` files, initializes OpenTelemetry, registers trace-context
-logging, starts the Node service server, and handles startup failures through
-the provided process target.
+Compatibility alias for `startAgentService()`.
 
 ### `parseAgentServiceConfig(env)`
 
@@ -1109,7 +1113,8 @@ Clear all stored messages from memory.
 | `parseAgUiRuntimeRequest`                                             | Parse and validate the canonical runtime AG-UI request body              |
 | `parseAgUiRuntimeRequestOrError`                                      | Parse runtime AG-UI input or return a `400` validation `Response`        |
 | `parseRuntimeAgentRunInvocation`                                      | Parse and validate a control-plane runtime agent invocation body         |
-| `runNodeVeryfrontCloudAgentServiceMain`                               | Run the default Node process bootstrap for a Veryfront Cloud service     |
+| `startAgentService`                                                   | Run the default cross-runtime bootstrap for a Veryfront Cloud service    |
+| `runNodeVeryfrontCloudAgentServiceMain`                               | Compatibility alias for `startAgentService`                              |
 | `startNodeAgentService`                                               | Start an agent service with the Node service server adapter              |
 | `startNodeVeryfrontCloudAgentService`                                 | Start a Veryfront Cloud agent service with the Node server adapter       |
 | `parseRuntimeAgentRunInvocationOrError`                               | Parse a runtime agent invocation or return a `400` validation `Response` |

--- a/docs/reference/sandbox.md
+++ b/docs/reference/sandbox.md
@@ -61,7 +61,7 @@ Create a lazily-provisioned sandbox client for agent-service runtimes. The clien
 
 ### `createAgentServiceSandboxTools(options)`
 
-Create sandbox shell tools plus async command job tools for agent-service runtimes. Pass an injected `createBashTool` factory to keep the framework independent of a concrete bash-tool package.
+Create sandbox shell tools plus async command job tools for agent-service runtimes. The higher-level agent-service preset provides the bash-tool factory by default; pass `createBashTool` here when composing sandbox tools directly.
 
 `createHostedSandboxTools()` remains available as a compatibility alias.
 

--- a/scripts/build/build-npm-dnt.ts
+++ b/scripts/build/build-npm-dnt.ts
@@ -134,6 +134,7 @@ await build({
 		dependencies: {
 			"@types/react": "^19.0.0",
 			"@types/react-dom": "^19.0.0",
+			"bash-tool": "^1.3.16",
 			"ws": "^8.18.0",
 			"@kreuzberg/node": "^4.4.2",
 		},

--- a/src/agent/agent-service-server.ts
+++ b/src/agent/agent-service-server.ts
@@ -2,6 +2,8 @@ import {
   createVeryfrontServer,
   type NodeVeryfrontServiceServer,
   startNodeVeryfrontServer,
+  startVeryfrontServer,
+  type VeryfrontServiceServer,
   type VeryfrontServiceServerLogger,
   type VeryfrontServiceServerRuntime,
 } from "../server/service-server.ts";
@@ -26,7 +28,15 @@ export type StartNodeAgentServiceServerOptions = CreateAgentServiceServerRuntime
   hardShutdownTimeoutMs?: number;
 };
 
+export type StartAgentServiceServerOptions = CreateAgentServiceServerRuntimeOptions & {
+  port: number;
+  bindAddress?: string;
+  signals?: readonly NodeJS.Signals[];
+  hardShutdownTimeoutMs?: number;
+};
+
 export type NodeAgentServiceServer = NodeVeryfrontServiceServer;
+export type AgentServiceServer = VeryfrontServiceServer | NodeVeryfrontServiceServer;
 
 function getAgentServiceServerName(
   options: CreateAgentServiceServerRuntimeOptions,
@@ -60,6 +70,22 @@ export async function startNodeAgentServiceServer(
 ): Promise<NodeAgentServiceServer> {
   const runtime = createAgentServiceServerRuntime(options);
   const server = await startNodeVeryfrontServer({
+    runtime,
+    port: options.port,
+    bindAddress: options.bindAddress,
+    logger: options.logger,
+    signals: options.signals,
+    hardShutdownTimeoutMs: options.hardShutdownTimeoutMs,
+  });
+  await server.ready;
+  return server;
+}
+
+export async function startAgentServiceServer(
+  options: StartAgentServiceServerOptions,
+): Promise<AgentServiceServer> {
+  const runtime = createAgentServiceServerRuntime(options);
+  const server = await startVeryfrontServer({
     runtime,
     port: options.port,
     bindAddress: options.bindAddress,

--- a/src/agent/hosted-agent-service-runtime.ts
+++ b/src/agent/hosted-agent-service-runtime.ts
@@ -27,7 +27,9 @@ import type { ParsedHostedChatRequest } from "./hosted-chat-request-parser.ts";
 import type { AgUiResumeValue } from "./ag-ui-tool-shared.ts";
 import type { RuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
 import {
+  type AgentServiceServer,
   type NodeAgentServiceServer,
+  startAgentServiceServer,
   startNodeAgentServiceServer,
 } from "./agent-service-server.ts";
 import type { VeryfrontServiceServerLogger } from "../server/service-server.ts";
@@ -115,6 +117,15 @@ export type StartNodeAgentServiceOptions<
   TConfig extends AgentServiceRuntimeConfig = AgentServiceRuntimeConfig,
 > = StartNodeHostedAgentServiceOptions<TExecution, TConfig>;
 
+export type StartAgentServiceRuntimeOptions<
+  TExecution extends object,
+  TConfig extends AgentServiceRuntimeConfig = AgentServiceRuntimeConfig,
+> = CreateAgentServiceRuntimeOptions<TExecution, TConfig> & {
+  bindAddress?: string;
+  hardShutdownTimeoutMs?: number;
+  signals?: readonly NodeJS.Signals[];
+};
+
 export type StartNodeHostedAgentServiceResult<
   TExecution extends object,
   TConfig extends HostedAgentServiceRuntimeConfig = HostedAgentServiceRuntimeConfig,
@@ -126,6 +137,13 @@ export type StartNodeAgentServiceResult<
   TExecution extends object,
   TConfig extends AgentServiceRuntimeConfig = AgentServiceRuntimeConfig,
 > = StartNodeHostedAgentServiceResult<TExecution, TConfig>;
+
+export type StartAgentServiceRuntimeResult<
+  TExecution extends object,
+  TConfig extends AgentServiceRuntimeConfig = AgentServiceRuntimeConfig,
+> = AgentServiceRuntimeBundle<TExecution, TConfig> & {
+  server: AgentServiceServer;
+};
 
 function defaultTrace<TResult>(
   _operationName: string,
@@ -235,4 +253,28 @@ export async function startNodeAgentService<
   options: StartNodeAgentServiceOptions<TExecution, TConfig>,
 ): Promise<StartNodeAgentServiceResult<TExecution, TConfig>> {
   return startNodeHostedAgentService(options);
+}
+
+export async function startAgentServiceRuntime<
+  TExecution extends object,
+  TConfig extends AgentServiceRuntimeConfig = AgentServiceRuntimeConfig,
+>(
+  options: StartAgentServiceRuntimeOptions<TExecution, TConfig>,
+): Promise<StartAgentServiceRuntimeResult<TExecution, TConfig>> {
+  const bundle = createAgentServiceRuntime(options);
+  const server = await startAgentServiceServer({
+    runtime: bundle.runtime,
+    serviceName: options.serviceName,
+    lifecycle: bundle.lifecycle,
+    port: bundle.config.PORT,
+    bindAddress: options.bindAddress,
+    signals: options.signals,
+    logger: options.logger,
+    hardShutdownTimeoutMs: options.hardShutdownTimeoutMs,
+  });
+
+  return {
+    ...bundle,
+    server,
+  };
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -250,10 +250,13 @@ export {
   type NormalizedAgentServiceContract,
 } from "./agent-service.ts";
 export {
+  type AgentServiceServer,
   type AgentServiceServerLifecycle,
   createAgentServiceServerRuntime,
   type CreateAgentServiceServerRuntimeOptions,
   type NodeAgentServiceServer,
+  startAgentServiceServer,
+  type StartAgentServiceServerOptions,
   startNodeAgentServiceServer,
   type StartNodeAgentServiceServerOptions,
 } from "./agent-service-server.ts";
@@ -314,6 +317,9 @@ export {
   type HostedAgentServiceRuntimeConfig,
   type HostedAgentServiceRuntimeLogger,
   type HostedAgentServiceRuntimeTrace,
+  startAgentServiceRuntime,
+  type StartAgentServiceRuntimeOptions,
+  type StartAgentServiceRuntimeResult,
   startNodeAgentService,
   type StartNodeAgentServiceOptions,
   type StartNodeAgentServiceResult,
@@ -327,7 +333,9 @@ export {
   type NodeVeryfrontCloudAgentServicePreparedExecution,
   type NodeVeryfrontCloudAgentServiceProcessTarget,
   runNodeVeryfrontCloudAgentServiceMain,
+  startAgentService,
   startNodeVeryfrontCloudAgentService,
+  type VeryfrontCloudAgentServiceOptions,
 } from "./veryfront-cloud-agent-service.ts";
 export {
   type AgentServiceConfig,

--- a/src/agent/runtime-agent-definition-files.test.ts
+++ b/src/agent/runtime-agent-definition-files.test.ts
@@ -26,6 +26,13 @@ Deno.test("resolveRuntimeAgentDefinitionsDir resolves source and bundled agent d
 
     assertEquals(
       resolveRuntimeAgentDefinitionsDir({
+        baseDir: rootDir,
+        id: "support",
+      }),
+      agentsDir,
+    );
+    assertEquals(
+      resolveRuntimeAgentDefinitionsDir({
         baseDir: resolve(rootDir, "src"),
         id: "support",
       }),
@@ -50,6 +57,13 @@ Deno.test("resolveRuntimeAgentDefinitionsDir resolves source and bundled agent d
 
 Deno.test("resolveRuntimeAgentDefinitionsDir falls back to the nearest source-layout candidate", () => {
   withTempDir((rootDir) => {
+    assertEquals(
+      resolveRuntimeAgentDefinitionsDir({
+        baseDir: rootDir,
+        id: "support",
+      }),
+      resolve(rootDir, "agents"),
+    );
     assertEquals(
       resolveRuntimeAgentDefinitionsDir({
         baseDir: resolve(rootDir, "src"),

--- a/src/agent/runtime-agent-definition-files.ts
+++ b/src/agent/runtime-agent-definition-files.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import { z } from "zod";
 import {
   parseRuntimeAgentMarkdownDefinition,
@@ -45,15 +45,20 @@ export function resolveRuntimeAgentDefinitionsDir(
 ): string {
   const parsedInput = resolveRuntimeAgentDefinitionsDirInputSchema.parse(input);
   const fileName = getRuntimeAgentDefinitionFileName(parsedInput);
-  const firstCandidate = resolve(parsedInput.baseDir, "../agents");
+  const firstCandidate = resolve(parsedInput.baseDir, "agents");
+  const sourceLayoutCandidate = resolve(parsedInput.baseDir, "../agents");
   const candidates = [
     firstCandidate,
+    sourceLayoutCandidate,
     resolve(parsedInput.baseDir, "../../agents"),
     resolve(parsedInput.baseDir, "../../../agents"),
   ];
+  const fallbackCandidate = basename(parsedInput.baseDir) === "src"
+    ? sourceLayoutCandidate
+    : firstCandidate;
 
   return candidates.find((candidate) => hasRuntimeAgentDefinitionFile(candidate, fileName)) ??
-    firstCandidate;
+    fallbackCandidate;
 }
 
 export function resolveRuntimeAgentMarkdownDefinitionFilePath(

--- a/src/agent/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/veryfront-cloud-agent-service.test.ts
@@ -83,8 +83,7 @@ Deno.test("createNodeVeryfrontCloudAgentServiceRuntime loads the markdown agent 
     const bundle = await createNodeVeryfrontCloudAgentServiceRuntime({
       serviceName: "veryfront-agent-test",
       agentId: "veryfront",
-      entryUrl: pathToFileURL(resolve(rootDir, "src", "main.ts")),
-      createBashTool,
+      entryUrl: pathToFileURL(resolve(rootDir, "main.ts")),
       env: {
         NODE_ENV: "test",
         VERYFRONT_API_URL: "https://api.example.com",

--- a/src/agent/veryfront-cloud-agent-service.ts
+++ b/src/agent/veryfront-cloud-agent-service.ts
@@ -76,6 +76,7 @@ import {
   type AgentServiceRuntimeConfig,
   createAgentServiceRuntime,
   type CreateAgentServiceRuntimeOptions,
+  startAgentServiceRuntime,
   startNodeAgentService,
   type StartNodeAgentServiceResult,
 } from "./hosted-agent-service-runtime.ts";
@@ -115,12 +116,20 @@ export type NodeVeryfrontCloudAgentServiceOptions = {
   entryUrl?: string | URL;
   agentSource?: NodeVeryfrontCloudAgentServiceAgentSource;
   forwardedConfigNamespace?: string;
-  createBashTool: HostedSandboxToolsOptions["createBashTool"];
+  createBashTool?: HostedSandboxToolsOptions["createBashTool"];
   env?: CreateNodeAgentServiceRuntimeInfrastructureOptions["env"];
   processTarget?: NodeVeryfrontCloudAgentServiceProcessTarget;
   drainTimeoutMs?: number;
   hardShutdownTimeoutMs?: number;
 };
+
+export type VeryfrontCloudAgentServiceOptions = NodeVeryfrontCloudAgentServiceOptions;
+
+type ResolvedNodeVeryfrontCloudAgentServiceOptions =
+  & NodeVeryfrontCloudAgentServiceOptions
+  & {
+    createBashTool: HostedSandboxToolsOptions["createBashTool"];
+  };
 
 export type NodeVeryfrontCloudAgentServicePreparedExecution = PreparedHostedChatExecution & {
   config: AgentServiceRuntimeConfig;
@@ -200,6 +209,22 @@ function resolveDefaultProcessTarget(): NodeVeryfrontCloudAgentServiceProcessTar
   return process;
 }
 
+async function loadDefaultCreateBashTool(): Promise<
+  HostedSandboxToolsOptions["createBashTool"]
+> {
+  const { createBashTool } = await import("bash-tool");
+  return createBashTool;
+}
+
+async function resolveNodeVeryfrontCloudAgentServiceOptions(
+  options: NodeVeryfrontCloudAgentServiceOptions,
+): Promise<ResolvedNodeVeryfrontCloudAgentServiceOptions> {
+  return {
+    ...options,
+    createBashTool: options.createBashTool ?? await loadDefaultCreateBashTool(),
+  };
+}
+
 function resolveEnvironment(
   options: Pick<NodeVeryfrontCloudAgentServiceOptions, "env" | "processTarget">,
 ): CreateNodeAgentServiceRuntimeInfrastructureOptions["env"] {
@@ -212,11 +237,14 @@ function resolveEnvironment(
   if (typeof process !== "undefined") {
     return process.env;
   }
+  if (typeof Deno !== "undefined") {
+    return Deno.env.toObject();
+  }
   return {};
 }
 
 function createNodeVeryfrontCloudAgentServiceContext(
-  options: NodeVeryfrontCloudAgentServiceOptions,
+  options: ResolvedNodeVeryfrontCloudAgentServiceOptions,
 ) {
   const processTarget = options.processTarget ?? resolveDefaultProcessTarget();
   const infrastructure = createNodeAgentServiceRuntimeInfrastructure({
@@ -699,7 +727,8 @@ function createNodeVeryfrontCloudAgentServiceRuntimeOptions(
 export async function createNodeVeryfrontCloudAgentServiceRuntime(
   options: NodeVeryfrontCloudAgentServiceOptions,
 ): Promise<AgentServiceRuntimeBundle<NodeVeryfrontCloudAgentServicePreparedExecution>> {
-  const context = createNodeVeryfrontCloudAgentServiceContext(options);
+  const resolvedOptions = await resolveNodeVeryfrontCloudAgentServiceOptions(options);
+  const context = createNodeVeryfrontCloudAgentServiceContext(resolvedOptions);
   await initializeNodeVeryfrontCloudAgentServiceContext(context);
   return createAgentServiceRuntime(createNodeVeryfrontCloudAgentServiceRuntimeOptions(context));
 }
@@ -707,7 +736,8 @@ export async function createNodeVeryfrontCloudAgentServiceRuntime(
 export async function startNodeVeryfrontCloudAgentService(
   options: NodeVeryfrontCloudAgentServiceOptions,
 ): Promise<StartNodeAgentServiceResult<NodeVeryfrontCloudAgentServicePreparedExecution>> {
-  const context = createNodeVeryfrontCloudAgentServiceContext(options);
+  const resolvedOptions = await resolveNodeVeryfrontCloudAgentServiceOptions(options);
+  const context = createNodeVeryfrontCloudAgentServiceContext(resolvedOptions);
   await initializeNodeVeryfrontCloudAgentServiceContext(context);
   return await startNodeAgentService({
     ...createNodeVeryfrontCloudAgentServiceRuntimeOptions(context),
@@ -715,7 +745,7 @@ export async function startNodeVeryfrontCloudAgentService(
   });
 }
 
-export async function runNodeVeryfrontCloudAgentServiceMain(
+export async function startAgentService(
   options: NodeVeryfrontCloudAgentServiceOptions,
 ): Promise<void> {
   const processTarget = options.processTarget ?? resolveDefaultProcessTarget();
@@ -723,8 +753,9 @@ export async function runNodeVeryfrontCloudAgentServiceMain(
     () => ({});
 
   await loadAgentServiceEnvFiles();
+  const resolvedOptions = await resolveNodeVeryfrontCloudAgentServiceOptions(options);
   const context = createNodeVeryfrontCloudAgentServiceContext({
-    ...options,
+    ...resolvedOptions,
     processTarget,
   });
   getRuntimeTraceContext = context.infrastructure.getTraceContext;
@@ -746,7 +777,7 @@ export async function runNodeVeryfrontCloudAgentServiceMain(
       __registerTraceContextGetter(getter);
     },
     start: async () => {
-      await startNodeAgentService({
+      await startAgentServiceRuntime({
         ...createNodeVeryfrontCloudAgentServiceRuntimeOptions(context),
         hardShutdownTimeoutMs: options.hardShutdownTimeoutMs ?? DEFAULT_HARD_SHUTDOWN_TIMEOUT_MS,
       });
@@ -757,4 +788,10 @@ export async function runNodeVeryfrontCloudAgentServiceMain(
     exit: processTarget?.exit,
     processTarget,
   });
+}
+
+export async function runNodeVeryfrontCloudAgentServiceMain(
+  options: NodeVeryfrontCloudAgentServiceOptions,
+): Promise<void> {
+  await startAgentService(options);
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -61,11 +61,15 @@ export {
   type NodeVeryfrontServiceServer,
   startNodeVeryfrontServer,
   type StartNodeVeryfrontServerOptions,
+  startVeryfrontServer,
+  type StartVeryfrontServerOptions,
+  type VeryfrontServiceServer,
   type VeryfrontServiceServerFetch,
   type VeryfrontServiceServerLogger,
   type VeryfrontServiceServerModule,
   type VeryfrontServiceServerModuleResponse,
   type VeryfrontServiceServerRuntime,
+  type VeryfrontServiceServerRuntimeKind,
 } from "./service-server.ts";
 export type {
   DevServerOptions,

--- a/src/server/service-server.test.ts
+++ b/src/server/service-server.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { createVeryfrontServer } from "./service-server.ts";
+import { createVeryfrontServer, startVeryfrontServer } from "./service-server.ts";
 
 Deno.test("createVeryfrontServer dispatches to the first module response", async () => {
   const runtime = createVeryfrontServer({
@@ -55,4 +55,33 @@ Deno.test("createVeryfrontServer fans out shutdown state and stop hooks", async 
   await runtime.stop();
 
   assertEquals(events, ["first:shutdown", "second:shutdown", "first:stop", "second:stop"]);
+});
+
+Deno.test("startVeryfrontServer starts the current runtime fetch server", async () => {
+  const events: string[] = [];
+  const runtime = createVeryfrontServer({
+    modules: [{
+      name: "test",
+      handle: () => new Response("served"),
+      setShuttingDown: () => events.push("shutdown"),
+      stop: () => events.push("stop"),
+    }],
+  });
+  const server = await startVeryfrontServer({
+    runtime,
+    port: 0,
+    bindAddress: "127.0.0.1",
+  });
+
+  try {
+    const response = await fetch(server.url);
+
+    assertEquals(response.status, 200);
+    assertEquals(await response.text(), "served");
+    assertEquals(server.runtime, "deno");
+  } finally {
+    await server.stop();
+  }
+
+  assertEquals(events, ["shutdown", "stop"]);
 });

--- a/src/server/service-server.ts
+++ b/src/server/service-server.ts
@@ -89,6 +89,9 @@ type DenoHttpServer = {
 
 type DenoServeRuntime = {
   serve: (options: DenoServeOptions, handler: DenoServeHandler) => DenoHttpServer;
+  addSignalListener?: (signal: NodeJS.Signals, handler: SignalHandler) => void;
+  removeSignalListener?: (signal: NodeJS.Signals, handler: SignalHandler) => void;
+  exit?: (code: number) => never | void;
 };
 
 type BunServeOptions = {
@@ -105,6 +108,14 @@ type BunHttpServer = {
 
 type BunServeRuntime = {
   serve: (options: BunServeOptions) => BunHttpServer;
+};
+
+type SignalHandler = () => void;
+
+type SignalRuntime = {
+  add: (signal: NodeJS.Signals, handler: SignalHandler) => void;
+  remove?: (signal: NodeJS.Signals, handler: SignalHandler) => void;
+  exit?: (code: number) => never | void;
 };
 
 function defaultNotFound(): Response {
@@ -208,10 +219,13 @@ function getDenoServeRuntime(): DenoServeRuntime | null {
     return null;
   }
   const serve = denoGlobal.serve;
+  const addSignalListener = denoGlobal.addSignalListener;
+  const removeSignalListener = denoGlobal.removeSignalListener;
+  const exit = denoGlobal.exit;
   if (typeof serve !== "function") {
     return null;
   }
-  return {
+  const runtime: DenoServeRuntime = {
     serve: (options, handler) => {
       const server: unknown = Reflect.apply(serve, denoGlobal, [options, handler]);
       if (!isDenoHttpServer(server)) {
@@ -220,6 +234,20 @@ function getDenoServeRuntime(): DenoServeRuntime | null {
       return server;
     },
   };
+  if (typeof addSignalListener === "function") {
+    runtime.addSignalListener = (signal, handler) => {
+      Reflect.apply(addSignalListener, denoGlobal, [signal, handler]);
+    };
+  }
+  if (typeof removeSignalListener === "function") {
+    runtime.removeSignalListener = (signal, handler) => {
+      Reflect.apply(removeSignalListener, denoGlobal, [signal, handler]);
+    };
+  }
+  if (typeof exit === "function") {
+    runtime.exit = (code) => Reflect.apply(exit, denoGlobal, [code]);
+  }
+  return runtime;
 }
 
 function getBunServeRuntime(): BunServeRuntime | null {
@@ -242,6 +270,49 @@ function getBunServeRuntime(): BunServeRuntime | null {
   };
 }
 
+function getProcessSignalRuntime(): SignalRuntime | null {
+  const processGlobal: unknown = Reflect.get(globalThis, "process");
+  if (!isObject(processGlobal)) {
+    return null;
+  }
+  const on = processGlobal.on;
+  const off = processGlobal.off;
+  const removeListener = processGlobal.removeListener;
+  const exit = processGlobal.exit;
+  if (typeof on !== "function") {
+    return null;
+  }
+  const runtime: SignalRuntime = {
+    add: (signal, handler) => {
+      Reflect.apply(on, processGlobal, [signal, handler]);
+    },
+  };
+  if (typeof off === "function") {
+    runtime.remove = (signal, handler) => {
+      Reflect.apply(off, processGlobal, [signal, handler]);
+    };
+  } else if (typeof removeListener === "function") {
+    runtime.remove = (signal, handler) => {
+      Reflect.apply(removeListener, processGlobal, [signal, handler]);
+    };
+  }
+  if (typeof exit === "function") {
+    runtime.exit = (code) => Reflect.apply(exit, processGlobal, [code]);
+  }
+  return runtime;
+}
+
+function createDenoSignalRuntime(deno: DenoServeRuntime): SignalRuntime | null {
+  if (!deno.addSignalListener) {
+    return null;
+  }
+  return {
+    add: deno.addSignalListener,
+    remove: deno.removeSignalListener,
+    exit: deno.exit,
+  };
+}
+
 function resolveRuntimeKind(): VeryfrontServiceServerRuntimeKind {
   if (getBunServeRuntime()) {
     return "bun";
@@ -261,6 +332,84 @@ async function stopRuntime(
   await runtime.stop();
 }
 
+function installSignalHandlers(options: {
+  signalRuntime: SignalRuntime | null;
+  signals?: readonly NodeJS.Signals[];
+  logger: VeryfrontServiceServerLogger;
+  stop: () => Promise<void>;
+  hardShutdownTimeoutMs?: number;
+  runtime: VeryfrontServiceServerRuntimeKind;
+}): () => void {
+  if (!options.signalRuntime) {
+    return () => undefined;
+  }
+
+  const hardShutdownTimeoutMs = options.hardShutdownTimeoutMs ?? 20_000;
+  const installedHandlers: Array<{ signal: NodeJS.Signals; handler: SignalHandler }> = [];
+  let signalShutdownStarted = false;
+
+  for (const signal of options.signals ?? ["SIGTERM"]) {
+    const handler = () => {
+      if (signalShutdownStarted) {
+        return;
+      }
+
+      signalShutdownStarted = true;
+      options.logger.info?.("Veryfront service server received shutdown signal", {
+        signal,
+        runtime: options.runtime,
+      });
+      const hardTimeout = setTimeout(() => {
+        options.logger.error?.("Veryfront service server graceful shutdown timed out", {
+          signal,
+          runtime: options.runtime,
+        });
+        options.signalRuntime?.exit?.(1);
+      }, hardShutdownTimeoutMs);
+
+      void options.stop()
+        .then(() => {
+          clearTimeout(hardTimeout);
+          options.signalRuntime?.exit?.(0);
+        })
+        .catch((error: unknown) => {
+          clearTimeout(hardTimeout);
+          options.logger.error?.("Veryfront service server shutdown failed", {
+            signal,
+            runtime: options.runtime,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          options.signalRuntime?.exit?.(1);
+        });
+    };
+
+    try {
+      options.signalRuntime.add(signal, handler);
+      installedHandlers.push({ signal, handler });
+    } catch (error) {
+      options.logger.warn?.("Veryfront service server could not install shutdown signal handler", {
+        signal,
+        runtime: options.runtime,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return () => {
+    for (const { signal, handler } of installedHandlers) {
+      try {
+        options.signalRuntime?.remove?.(signal, handler);
+      } catch (error) {
+        options.logger.warn?.("Veryfront service server could not remove shutdown signal handler", {
+          signal,
+          runtime: options.runtime,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  };
+}
+
 async function startDenoVeryfrontServer(
   options: StartVeryfrontServerOptions,
   deno: DenoServeRuntime,
@@ -275,6 +424,7 @@ async function startDenoVeryfrontServer(
     onListen: () => undefined,
   }, options.runtime.fetch);
   let shutdownStarted = false;
+  let removeSignalHandlers: () => void = () => undefined;
 
   const stop = async () => {
     if (shutdownStarted) {
@@ -282,15 +432,28 @@ async function startDenoVeryfrontServer(
     }
 
     shutdownStarted = true;
-    await stopRuntime(options.runtime, async () => {
-      if (server.shutdown) {
-        await server.shutdown();
-        return;
-      }
-      abortController.abort();
-      await server.finished?.catch(() => undefined);
-    });
+    try {
+      await stopRuntime(options.runtime, async () => {
+        if (server.shutdown) {
+          await server.shutdown();
+          return;
+        }
+        abortController.abort();
+        await server.finished?.catch(() => undefined);
+      });
+    } finally {
+      removeSignalHandlers();
+    }
   };
+
+  removeSignalHandlers = installSignalHandlers({
+    signalRuntime: createDenoSignalRuntime(deno),
+    signals: options.signals,
+    logger,
+    stop,
+    hardShutdownTimeoutMs: options.hardShutdownTimeoutMs,
+    runtime: "deno",
+  });
 
   logger.info?.("Veryfront service server listening", {
     port: server.addr?.port ?? options.port,
@@ -319,6 +482,7 @@ async function startBunVeryfrontServer(
     fetch: options.runtime.fetch,
   });
   let shutdownStarted = false;
+  let removeSignalHandlers: () => void = () => undefined;
 
   const stop = async () => {
     if (shutdownStarted) {
@@ -326,10 +490,23 @@ async function startBunVeryfrontServer(
     }
 
     shutdownStarted = true;
-    await stopRuntime(options.runtime, async () => {
-      await server.stop?.();
-    });
+    try {
+      await stopRuntime(options.runtime, async () => {
+        await server.stop?.();
+      });
+    } finally {
+      removeSignalHandlers();
+    }
   };
+
+  removeSignalHandlers = installSignalHandlers({
+    signalRuntime: getProcessSignalRuntime(),
+    signals: options.signals,
+    logger,
+    stop,
+    hardShutdownTimeoutMs: options.hardShutdownTimeoutMs,
+    runtime: "bun",
+  });
 
   logger.info?.("Veryfront service server listening", {
     port: server.port ?? options.port,

--- a/src/server/service-server.ts
+++ b/src/server/service-server.ts
@@ -42,12 +42,69 @@ export type StartNodeVeryfrontServerOptions = {
   hardShutdownTimeoutMs?: number;
 };
 
+export type StartVeryfrontServerOptions = {
+  runtime: VeryfrontServiceServerRuntime;
+  port: number;
+  bindAddress?: string;
+  logger?: VeryfrontServiceServerLogger;
+  signals?: readonly NodeJS.Signals[];
+  hardShutdownTimeoutMs?: number;
+};
+
+export type VeryfrontServiceServerRuntimeKind = "node" | "deno" | "bun";
+
+export type VeryfrontServiceServer = {
+  ready: Promise<void>;
+  stop: () => Promise<void>;
+  port: number;
+  url: string;
+  runtime: VeryfrontServiceServerRuntimeKind;
+};
+
 export type NodeVeryfrontServiceServer = {
   server: import("node:http").Server;
   ready: Promise<void>;
   stop: () => Promise<void>;
   port: number;
   url: string;
+  runtime: "node";
+};
+
+type DenoServeOptions = {
+  port: number;
+  hostname?: string;
+  signal?: AbortSignal;
+  onListen?: (address: { port: number; hostname: string }) => void;
+};
+
+type DenoServeHandler = (request: Request) => Response | Promise<Response>;
+
+type DenoHttpServer = {
+  addr?: {
+    port?: number;
+  };
+  finished?: Promise<void>;
+  shutdown?: () => void | Promise<void>;
+};
+
+type DenoServeRuntime = {
+  serve: (options: DenoServeOptions, handler: DenoServeHandler) => DenoHttpServer;
+};
+
+type BunServeOptions = {
+  port: number;
+  hostname?: string;
+  fetch: VeryfrontServiceServerFetch;
+};
+
+type BunHttpServer = {
+  port?: number;
+  url?: URL;
+  stop?: () => void | Promise<void>;
+};
+
+type BunServeRuntime = {
+  serve: (options: BunServeOptions) => BunHttpServer;
 };
 
 function defaultNotFound(): Response {
@@ -113,6 +170,199 @@ function closeNodeServer(server: import("node:http").Server): Promise<void> {
       resolve();
     });
   });
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isDenoHttpServer(value: unknown): value is DenoHttpServer {
+  if (!isObject(value)) {
+    return false;
+  }
+  const finished = value.finished;
+  const shutdown = value.shutdown;
+  const addr = value.addr;
+  const port = isObject(addr) ? addr.port : undefined;
+  return (addr === undefined || isObject(addr)) &&
+    (port === undefined || typeof port === "number") &&
+    (finished === undefined || finished instanceof Promise) &&
+    (shutdown === undefined || typeof shutdown === "function");
+}
+
+function isBunHttpServer(value: unknown): value is BunHttpServer {
+  if (!isObject(value)) {
+    return false;
+  }
+  const port = value.port;
+  const url = value.url;
+  const stop = value.stop;
+  return (port === undefined || typeof port === "number") &&
+    (url === undefined || url instanceof URL) &&
+    (stop === undefined || typeof stop === "function");
+}
+
+function getDenoServeRuntime(): DenoServeRuntime | null {
+  const denoGlobal: unknown = Reflect.get(globalThis, "Deno");
+  if (!isObject(denoGlobal)) {
+    return null;
+  }
+  const serve = denoGlobal.serve;
+  if (typeof serve !== "function") {
+    return null;
+  }
+  return {
+    serve: (options, handler) => {
+      const server: unknown = Reflect.apply(serve, denoGlobal, [options, handler]);
+      if (!isDenoHttpServer(server)) {
+        return {};
+      }
+      return server;
+    },
+  };
+}
+
+function getBunServeRuntime(): BunServeRuntime | null {
+  const bunGlobal: unknown = Reflect.get(globalThis, "Bun");
+  if (!isObject(bunGlobal)) {
+    return null;
+  }
+  const serve = bunGlobal.serve;
+  if (typeof serve !== "function") {
+    return null;
+  }
+  return {
+    serve: (options) => {
+      const server: unknown = Reflect.apply(serve, bunGlobal, [options]);
+      if (!isBunHttpServer(server)) {
+        return {};
+      }
+      return server;
+    },
+  };
+}
+
+function resolveRuntimeKind(): VeryfrontServiceServerRuntimeKind {
+  if (getBunServeRuntime()) {
+    return "bun";
+  }
+  if (getDenoServeRuntime()) {
+    return "deno";
+  }
+  return "node";
+}
+
+async function stopRuntime(
+  runtime: VeryfrontServiceServerRuntime,
+  stopServer: () => void | Promise<void>,
+): Promise<void> {
+  runtime.setShuttingDown();
+  await stopServer();
+  await runtime.stop();
+}
+
+async function startDenoVeryfrontServer(
+  options: StartVeryfrontServerOptions,
+  deno: DenoServeRuntime,
+): Promise<VeryfrontServiceServer> {
+  const logger = options.logger ?? serverLogger.component("service-server");
+  const bindAddress = options.bindAddress ?? "0.0.0.0";
+  const abortController = new AbortController();
+  const server = deno.serve({
+    port: options.port,
+    hostname: bindAddress,
+    signal: abortController.signal,
+    onListen: () => undefined,
+  }, options.runtime.fetch);
+  let shutdownStarted = false;
+
+  const stop = async () => {
+    if (shutdownStarted) {
+      return;
+    }
+
+    shutdownStarted = true;
+    await stopRuntime(options.runtime, async () => {
+      if (server.shutdown) {
+        await server.shutdown();
+        return;
+      }
+      abortController.abort();
+      await server.finished?.catch(() => undefined);
+    });
+  };
+
+  logger.info?.("Veryfront service server listening", {
+    port: server.addr?.port ?? options.port,
+    bindAddress,
+    runtime: "deno",
+  });
+
+  return {
+    ready: Promise.resolve(),
+    stop,
+    port: server.addr?.port ?? options.port,
+    url: `http://${bindAddress}:${server.addr?.port ?? options.port}`,
+    runtime: "deno",
+  };
+}
+
+async function startBunVeryfrontServer(
+  options: StartVeryfrontServerOptions,
+  bun: BunServeRuntime,
+): Promise<VeryfrontServiceServer> {
+  const logger = options.logger ?? serverLogger.component("service-server");
+  const bindAddress = options.bindAddress ?? "0.0.0.0";
+  const server = bun.serve({
+    port: options.port,
+    hostname: bindAddress,
+    fetch: options.runtime.fetch,
+  });
+  let shutdownStarted = false;
+
+  const stop = async () => {
+    if (shutdownStarted) {
+      return;
+    }
+
+    shutdownStarted = true;
+    await stopRuntime(options.runtime, async () => {
+      await server.stop?.();
+    });
+  };
+
+  logger.info?.("Veryfront service server listening", {
+    port: server.port ?? options.port,
+    bindAddress,
+    runtime: "bun",
+  });
+
+  return {
+    ready: Promise.resolve(),
+    stop,
+    port: server.port ?? options.port,
+    url: server.url?.toString() ?? `http://${bindAddress}:${options.port}`,
+    runtime: "bun",
+  };
+}
+
+export async function startVeryfrontServer(
+  options: StartVeryfrontServerOptions,
+): Promise<VeryfrontServiceServer | NodeVeryfrontServiceServer> {
+  const runtimeKind = resolveRuntimeKind();
+  if (runtimeKind === "bun") {
+    const bun = getBunServeRuntime();
+    if (bun) {
+      return await startBunVeryfrontServer(options, bun);
+    }
+  }
+  if (runtimeKind === "deno") {
+    const deno = getDenoServeRuntime();
+    if (deno) {
+      return await startDenoVeryfrontServer(options, deno);
+    }
+  }
+  return await startNodeVeryfrontServer(options);
 }
 
 export async function startNodeVeryfrontServer(
@@ -182,5 +432,6 @@ export async function startNodeVeryfrontServer(
     stop,
     port: options.port,
     url: `http://${bindAddress}:${options.port}`,
+    runtime: "node",
   };
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.499";
+export const VERSION = "0.1.500";


### PR DESCRIPTION
## Summary
- Add a runtime-neutral `startAgentService()` preset for cloud agent services while keeping Node-specific compatibility aliases
- Let the preset provide the default bash-tool factory so service entrypoints do not need direct bash-tool wiring
- Support root-level service entrypoints by resolving project-local `agents/` directories
- Add a cross-runtime Veryfront service server start path with Deno/Bun adapters and Node fallback

## Verification
- `deno test --no-check --allow-all src/server/service-server.test.ts src/agent/runtime-agent-definition-files.test.ts src/agent/veryfront-cloud-agent-service.test.ts`
- `deno task verify:quick`
- `deno task build:npm`
- `git push` pre-push checks: format, lint, typecheck, test:unit
