### PR TITLE
fix(ci): exclude GitHub web-flow from CLA check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -45,7 +45,7 @@ jobs:
           missing=()
           for login in "${contributors[@]}"; do
             case "${login}" in
-              dependabot\[bot\]|github-actions\[bot\]|renovate\[bot\]|aikido-autofix\[bot\])
+              dependabot\[bot\]|github-actions\[bot\]|renovate\[bot\]|aikido-autofix\[bot\]|web-flow)
                 continue
                 ;;
             esac


### PR DESCRIPTION
## Summary
- Add `web-flow` to the bot exclusion list in the CLA workflow
- `web-flow` is GitHub's internal GPG-signing account that appears as committer on web-UI operations (merges, edits) — not a real contributor
- Prevents false CLA failures on PRs with GitHub-web-originated commits

## Test plan
- [ ] Verify CLA check passes on PRs that previously failed due to `web-flow`