### PR TITLE
Clarify agent service startup options

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.500",
+  "version": "0.1.501",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -268,7 +268,7 @@ host-supplied routes. For Node deployments, `startNodeAgentService()` wraps that
 runtime in the shared Veryfront service server with graceful shutdown.
 
 For a Veryfront Cloud-backed service that should use the default
-configuration, telemetry, model routing, sandbox, Studio MCP, project steering,
+configuration, telemetry, model routing, sandbox, project steering,
 durable-run, and prepared-execution wiring, use
 `startAgentService()` from a process entrypoint and keep the
 agent behavior in `agents/<agent-id>.md` or `agents/<agent-id>.ts`:
@@ -279,7 +279,23 @@ import { startAgentService } from "veryfront/agent";
 await startAgentService({
   serviceName: "support-agent",
   agentId: "support",
-  entryUrl: import.meta.url,
+});
+```
+
+By default, discovery is rooted at the process cwd. Pass `baseDir` only when the
+service may start from another working directory. `entrypointUrl` is a
+convenience fallback for deriving `baseDir` from an entry module URL; `entryUrl`
+remains supported as a compatibility alias.
+
+Studio MCP tools are opt-in because they are Studio/control-plane specific:
+
+```ts
+await startAgentService({
+  serviceName: "support-agent",
+  agentId: "support",
+  mcp: {
+    studio: true,
+  },
 });
 ```
 
@@ -830,13 +846,15 @@ conventions and `veryfront.config.ts` discovery settings as a Veryfront project.
 It can use a code agent from `agents/*.ts` or fall back to a markdown-backed
 `agents/*.md` definition, uses the default service config and project-steering
 adapter, wires local tools (`form_input`, `load_skill`, `sleep`, discovered
-project tools, and `invoke_agent`), sandbox tools, Studio MCP tools, remote MCP
-definitions, prepared chat execution, AG-UI streaming, and detached durable-run
-execution.
+project tools, and `invoke_agent`), sandbox tools, Veryfront API MCP tools,
+opt-in Studio MCP tools, prepared chat execution, AG-UI streaming, and detached
+durable-run execution.
 
-Hosts provide the service name, agent id, entry URL or base directory, and
-optionally a custom bash-tool factory. Use this helper when tests or custom
-hosts need the runtime bundle without starting the service server.
+Hosts provide the service name and agent id. Discovery defaults to cwd; hosts
+can pass `baseDir` when cwd is not the project root, or `entrypointUrl` when it
+is more convenient to derive the base directory from a module URL. Use this
+helper when tests or custom hosts need the runtime bundle without starting the
+service server.
 
 ### `startNodeVeryfrontCloudAgentService(options)`
 

--- a/src/agent/default-hosted-chat-runtime.ts
+++ b/src/agent/default-hosted-chat-runtime.ts
@@ -44,6 +44,7 @@ export type DefaultHostedChatRuntimeConfig = {
   apiUrl: string;
   apiMcpUrl: string;
   studioMcpUrl?: string | null;
+  studioMcpEnabled?: boolean;
 };
 
 export type DefaultHostedChatRuntimeLogger = {
@@ -153,6 +154,7 @@ async function buildToolAssembly(
     apiUrl: input.config.apiUrl,
     apiMcpUrl: input.config.apiMcpUrl,
     studioMcpUrl: input.config.studioMcpUrl,
+    studioMcpEnabled: input.config.studioMcpEnabled,
     conversationId: input.options.conversationId,
     allowedToolNames: input.options.allowedTools ?? null,
     projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions,

--- a/src/agent/hosted-chat-runtime-tool-assembly.test.ts
+++ b/src/agent/hosted-chat-runtime-tool-assembly.test.ts
@@ -80,6 +80,7 @@ Deno.test("prepareHostedChatRuntimeToolAssembly builds provider-compatible runti
     apiUrl: "https://api.example.com",
     apiMcpUrl: "https://api.example.com/mcp",
     studioMcpUrl: "https://studio.example.com/mcp",
+    studioMcpEnabled: true,
     conversationId: "conversation-1",
     allowedToolNames: ["sleep", "create_file", "studio_open_project"],
     projectScopedRemoteToolOptions: {

--- a/src/agent/hosted-chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted-chat-runtime-tool-assembly.ts
@@ -58,6 +58,7 @@ export type PrepareHostedChatRuntimeToolAssemblyInput<
   apiUrl: string;
   apiMcpUrl: string;
   studioMcpUrl?: string | null;
+  studioMcpEnabled?: boolean;
   conversationId?: string;
   allowedToolNames?: HostedChatRuntimeAllowedToolNames;
   projectScopedRemoteToolOptions?: ProjectScopedRemoteToolOptions;
@@ -120,6 +121,7 @@ export async function prepareHostedChatRuntimeToolAssembly<
     authToken: input.taskContext.authToken,
     apiMcpUrl: input.apiMcpUrl,
     studioMcpUrl: input.studioMcpUrl,
+    studioMcpEnabled: input.studioMcpEnabled,
     clientProfile: input.taskContext.clientProfile,
     createRemoteToolSource: input.createRemoteToolSource ?? createRemoteMCPToolSource,
     defaultProjectId: () => activeProjectId(input.taskContext),

--- a/src/agent/hosted-project-remote-tool-source.test.ts
+++ b/src/agent/hosted-project-remote-tool-source.test.ts
@@ -51,7 +51,7 @@ function createRemoteSource(input: {
   return {
     id: input.id ?? "source-1",
     listTools: () => Promise.resolve(input.tools),
-    executeTool: (toolName, args, context) =>
+    executeTool: async (toolName, args, context) =>
       input.execute?.(toolName, args, context) ?? { ok: true },
   };
 }
@@ -237,13 +237,38 @@ Deno.test("createHostedProjectRemoteToolSource skips mutation callbacks for fail
   assertEquals(mutationCount, 0);
 });
 
-Deno.test("createHostedProjectRemoteToolSources builds API and gated Studio MCP sources", async () => {
+Deno.test("createHostedProjectRemoteToolSources keeps Studio MCP opt-in", async () => {
+  const configs: RemoteMCPToolSourceConfig[] = [];
+  const sources = createHostedProjectRemoteToolSources({
+    authToken: "token-1",
+    apiMcpUrl: "https://api.example/mcp",
+    studioMcpUrl: "https://studio.example/mcp",
+    studioMcpEnabled: false,
+    clientProfile: {
+      id: "veryfront-studio",
+      type: "web",
+      trusted: true,
+      capabilities: ["ui_panels"],
+    },
+    getProjectId: () => "project-1",
+    createRemoteToolSource: (config) => {
+      configs.push(config);
+      return createRemoteSource({ id: config.id, tools: [projectFileTool("update_file")] });
+    },
+  });
+
+  assertEquals(sources.map((source) => source.id), ["veryfront-mcp"]);
+  assertEquals(configs.map((config) => config.endpoint), ["https://api.example/mcp"]);
+});
+
+Deno.test("createHostedProjectRemoteToolSources builds API and explicit gated Studio MCP sources", async () => {
   const configs: RemoteMCPToolSourceConfig[] = [];
   let activeProjectId = "project-1";
   const sources = createHostedProjectRemoteToolSources({
     authToken: "token-1",
     apiMcpUrl: "https://api.example/mcp",
     studioMcpUrl: "https://studio.example/mcp",
+    studioMcpEnabled: true,
     clientProfile: {
       id: "veryfront-studio",
       type: "web",
@@ -276,6 +301,7 @@ Deno.test("createHostedProjectRemoteToolSources builds API and gated Studio MCP 
     authToken: "token-1",
     apiMcpUrl: "https://api.example/mcp",
     studioMcpUrl: "https://studio.example/mcp",
+    studioMcpEnabled: true,
     clientProfile: {
       id: "veryfront-cli",
       type: "cli",
@@ -298,6 +324,7 @@ Deno.test("createHostedProjectRemoteToolSources applies project wrapper policy t
     authToken: "token-1",
     apiMcpUrl: "https://api.example/mcp",
     studioMcpUrl: "https://studio.example/mcp",
+    studioMcpEnabled: true,
     clientProfile: {
       id: "veryfront-studio",
       type: "web",

--- a/src/agent/hosted-project-remote-tool-source.ts
+++ b/src/agent/hosted-project-remote-tool-source.ts
@@ -188,6 +188,7 @@ export type CreateHostedProjectRemoteToolSourcesInput =
     authToken: string;
     apiMcpUrl: string;
     studioMcpUrl?: string | null;
+    studioMcpEnabled?: boolean;
     clientProfile?: RuntimeClientProfile | null;
     getProjectId: () => string | null | undefined;
     conversationId?: string;
@@ -242,7 +243,9 @@ export function createHostedProjectRemoteToolSources(
     ),
   ];
 
-  if (!input.studioMcpUrl || !clientAllowsStudioMcp(input.clientProfile)) {
+  if (
+    !input.studioMcpEnabled || !input.studioMcpUrl || !clientAllowsStudioMcp(input.clientProfile)
+  ) {
     return sources;
   }
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -329,6 +329,7 @@ export {
 } from "./hosted-agent-service-runtime.ts";
 export {
   createNodeVeryfrontCloudAgentServiceRuntime,
+  type NodeVeryfrontCloudAgentServiceMcpOptions,
   type NodeVeryfrontCloudAgentServiceOptions,
   type NodeVeryfrontCloudAgentServicePreparedExecution,
   type NodeVeryfrontCloudAgentServiceProcessTarget,

--- a/src/agent/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/veryfront-cloud-agent-service.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { CreateSandboxBashTool } from "#veryfront/sandbox";
@@ -76,6 +76,15 @@ function writeCodeAgentDefinition(
 
 const createBashTool: CreateSandboxBashTool = () => Promise.resolve({ tools: {} });
 
+function getRuntimeAgent(
+  bundle: Awaited<ReturnType<typeof createNodeVeryfrontCloudAgentServiceRuntime>>,
+  agentId: string,
+) {
+  const runtimeAgent = bundle.runtime.contract.agents[agentId];
+  assert(runtimeAgent);
+  return runtimeAgent;
+}
+
 Deno.test("createNodeVeryfrontCloudAgentServiceRuntime loads the markdown agent and binds service routes", async () => {
   await withTempDir(async (rootDir) => {
     writeMarkdownAgentDefinition(rootDir);
@@ -96,12 +105,59 @@ Deno.test("createNodeVeryfrontCloudAgentServiceRuntime loads the markdown agent 
     assertEquals(bundle.config.VERYFRONT_API_URL, "https://api.example.com");
     assertEquals(bundle.runtime.contract.serviceName, "veryfront-agent-test");
     assertEquals(bundle.runtime.contract.defaultAgentId, "veryfront");
-    assertEquals(bundle.runtime.contract.agents.veryfront.id, "veryfront");
-    assertEquals(bundle.runtime.contract.agents.veryfront.config.model, "openai/gpt-5.4");
+    const runtimeAgent = getRuntimeAgent(bundle, "veryfront");
+    assertEquals(runtimeAgent.id, "veryfront");
+    assertEquals(runtimeAgent.config.model, "openai/gpt-5.4");
 
     const liveness = await bundle.runtime.request("http://localhost/liveness");
     assertEquals(liveness.status, 200);
     assertEquals(await liveness.text(), "OK");
+  });
+});
+
+Deno.test("createNodeVeryfrontCloudAgentServiceRuntime defaults discovery to cwd", async () => {
+  await withTempDir(async (rootDir) => {
+    writeMarkdownAgentDefinition(rootDir);
+    const previousCwd = Deno.cwd();
+    Deno.chdir(rootDir);
+    try {
+      const bundle = await createNodeVeryfrontCloudAgentServiceRuntime({
+        serviceName: "cwd-agent-test",
+        agentId: "veryfront",
+        env: {
+          NODE_ENV: "test",
+          VERYFRONT_API_URL: "https://api.example.com",
+          PORT: "3144",
+          ALLOWED_ORIGINS: "https://studio.example.com",
+        },
+      });
+
+      assertEquals(bundle.runtime.contract.defaultAgentId, "veryfront");
+      assertEquals(getRuntimeAgent(bundle, "veryfront").config.model, "openai/gpt-5.4");
+    } finally {
+      Deno.chdir(previousCwd);
+    }
+  });
+});
+
+Deno.test("createNodeVeryfrontCloudAgentServiceRuntime accepts entrypointUrl alias", async () => {
+  await withTempDir(async (rootDir) => {
+    writeMarkdownAgentDefinition(rootDir);
+
+    const bundle = await createNodeVeryfrontCloudAgentServiceRuntime({
+      serviceName: "entrypoint-url-agent-test",
+      agentId: "veryfront",
+      entrypointUrl: pathToFileURL(resolve(rootDir, "main.ts")),
+      env: {
+        NODE_ENV: "test",
+        VERYFRONT_API_URL: "https://api.example.com",
+        PORT: "3145",
+        ALLOWED_ORIGINS: "https://studio.example.com",
+      },
+    });
+
+    assertEquals(bundle.runtime.contract.defaultAgentId, "veryfront");
+    assertEquals(getRuntimeAgent(bundle, "veryfront").config.model, "openai/gpt-5.4");
   });
 });
 
@@ -143,7 +199,7 @@ Deno.test({
       });
 
       assertEquals(bundle.runtime.contract.defaultAgentId, "support");
-      assertEquals(bundle.runtime.contract.agents.support.config.system, "Help users from code.");
+      assertEquals(getRuntimeAgent(bundle, "support").config.system, "Help users from code.");
       assertEquals(toolRegistry.has("echo"), true);
     });
   },
@@ -175,9 +231,10 @@ Deno.test({
       });
 
       assertEquals(bundle.runtime.contract.defaultAgentId, "support");
-      assertEquals(bundle.runtime.contract.agents.support.config.system, "Help users from code.");
-      assertEquals(bundle.runtime.contract.agents.support.config.model, "openai/gpt-5.4");
-      assertEquals(bundle.runtime.contract.agents.support.config.maxSteps, 8);
+      const runtimeAgent = getRuntimeAgent(bundle, "support");
+      assertEquals(runtimeAgent.config.system, "Help users from code.");
+      assertEquals(runtimeAgent.config.model, "openai/gpt-5.4");
+      assertEquals(runtimeAgent.config.maxSteps, 8);
       assertEquals(toolRegistry.has("echo"), true);
     });
   },

--- a/src/agent/veryfront-cloud-agent-service.ts
+++ b/src/agent/veryfront-cloud-agent-service.ts
@@ -108,13 +108,35 @@ export type NodeVeryfrontCloudAgentServiceProcessTarget =
 
 export type NodeVeryfrontCloudAgentServiceAgentSource = "auto" | "code" | "markdown";
 
+export type NodeVeryfrontCloudAgentServiceMcpOptions = {
+  /**
+   * Opt in to Studio UI/control-plane MCP tools for trusted Studio-capable clients.
+   * API MCP tools remain part of the Veryfront Cloud service preset.
+   */
+  studio?: boolean;
+};
+
+type AgentServicePathOption = string | URL;
+
 export type NodeVeryfrontCloudAgentServiceOptions = {
   serviceName: string;
   agentId: string;
-  baseDir?: string;
+  /**
+   * Project/discovery root. Defaults to the process cwd when neither baseDir
+   * nor an entrypoint URL is provided.
+   */
+  baseDir?: AgentServicePathOption;
   projectDir?: string;
-  entryUrl?: string | URL;
+  /**
+   * Convenience URL for deriving baseDir from the entry module location.
+   */
+  entrypointUrl?: AgentServicePathOption;
+  /**
+   * Compatibility alias for entrypointUrl.
+   */
+  entryUrl?: AgentServicePathOption;
   agentSource?: NodeVeryfrontCloudAgentServiceAgentSource;
+  mcp?: NodeVeryfrontCloudAgentServiceMcpOptions;
   forwardedConfigNamespace?: string;
   createBashTool?: HostedSandboxToolsOptions["createBashTool"];
   env?: CreateNodeAgentServiceRuntimeInfrastructureOptions["env"];
@@ -157,14 +179,21 @@ const PROJECT_CONFIG_FILES = [
   "veryfront.config.mjs",
 ];
 
+function pathOptionToPath(pathOption: AgentServicePathOption): string {
+  return pathOption instanceof URL ? fileURLToPath(pathOption) : pathOption;
+}
+
 function resolveBaseDir(
-  options: Pick<NodeVeryfrontCloudAgentServiceOptions, "baseDir" | "entryUrl">,
+  options: Pick<NodeVeryfrontCloudAgentServiceOptions, "baseDir" | "entrypointUrl" | "entryUrl">,
 ): string {
-  if (options.baseDir) {
-    return options.baseDir;
+  if (options.baseDir !== undefined) {
+    return pathOptionToPath(options.baseDir);
   }
-  if (options.entryUrl) {
-    return dirname(fileURLToPath(options.entryUrl));
+  if (options.entrypointUrl !== undefined) {
+    return dirname(pathOptionToPath(options.entrypointUrl));
+  }
+  if (options.entryUrl !== undefined) {
+    return dirname(pathOptionToPath(options.entryUrl));
   }
   if (typeof process !== "undefined") {
     return process.cwd();
@@ -191,7 +220,10 @@ function uniquePaths(paths: string[]): string[] {
 }
 
 function resolveProjectDir(
-  options: Pick<NodeVeryfrontCloudAgentServiceOptions, "baseDir" | "entryUrl" | "projectDir">,
+  options: Pick<
+    NodeVeryfrontCloudAgentServiceOptions,
+    "baseDir" | "entrypointUrl" | "entryUrl" | "projectDir"
+  >,
 ): string {
   if (options.projectDir) {
     return options.projectDir;
@@ -406,11 +438,12 @@ function getInvokeAgentConfig(
   context: NodeVeryfrontCloudAgentServiceContext,
 ): DefaultHostedInvokeAgentConfig {
   const config = context.infrastructure.getConfig();
+  const studioMcpUrl = context.options.mcp?.studio ? config.VERYFRONT_STUDIO_MCP_URL : "";
 
   return {
     apiUrl: config.VERYFRONT_API_URL,
     apiMcpUrl: config.VERYFRONT_MCP_URL,
-    studioMcpUrl: config.VERYFRONT_STUDIO_MCP_URL,
+    studioMcpUrl,
     enableDurableInvokeAgent: config.VERYFRONT_ENABLE_DURABLE_INVOKE_AGENT,
   };
 }
@@ -490,7 +523,8 @@ function createAgentRuntime(
     config: {
       apiUrl: config.VERYFRONT_API_URL,
       apiMcpUrl: config.VERYFRONT_MCP_URL,
-      studioMcpUrl: config.VERYFRONT_STUDIO_MCP_URL,
+      studioMcpUrl: context.options.mcp?.studio ? config.VERYFRONT_STUDIO_MCP_URL : "",
+      studioMcpEnabled: context.options.mcp?.studio ?? false,
     },
     buildLocalTools: (taskContext) => buildLocalTools(context, options, taskContext),
     refreshSystem,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.500";
+export const VERSION = "0.1.501";


### PR DESCRIPTION
## Summary
- default agent-service discovery to cwd while retaining baseDir and entrypointUrl overrides
- keep entryUrl as a compatibility alias
- make Studio MCP an explicit opt-in for agent-service runtimes
- bump package version to 0.1.501

## Verification
- deno test -A --no-lock src/agent/hosted-chat-runtime-tool-assembly.test.ts src/agent/hosted-project-remote-tool-source.test.ts src/agent/veryfront-cloud-agent-service.test.ts
- deno task verify:quick
- deno task build:npm
- pre-push full unit test suite