### PR TITLE
Fix cwd skill discovery

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.501",
+  "version": "0.1.502",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/runtime-builtin-skill-files.test.ts
+++ b/src/agent/runtime-builtin-skill-files.test.ts
@@ -31,11 +31,21 @@ Deno.test("resolveRuntimeBuiltinSkillsDir resolves repo-root skills from dist-li
   });
 });
 
+Deno.test("resolveRuntimeBuiltinSkillsDir resolves root-level skills from cwd base dir", () => {
+  withTempDir((rootDir) => {
+    const skillsDir = resolve(rootDir, "skills");
+    Deno.mkdirSync(resolve(skillsDir, "veryfront"), { recursive: true });
+    Deno.writeTextFileSync(resolve(skillsDir, "veryfront", "SKILL.md"), "body");
+
+    assertEquals(resolveRuntimeBuiltinSkillsDir(rootDir), skillsDir);
+  });
+});
+
 Deno.test("resolveRuntimeBuiltinSkillsDir falls back to the first candidate", () => {
   withTempDir((rootDir) => {
     const baseDir = resolve(rootDir, "app", "src", "skills");
 
-    assertEquals(resolveRuntimeBuiltinSkillsDir(baseDir), resolve(baseDir, "../../../skills"));
+    assertEquals(resolveRuntimeBuiltinSkillsDir(baseDir), resolve(baseDir, "skills"));
   });
 });
 

--- a/src/agent/runtime-builtin-skill-files.ts
+++ b/src/agent/runtime-builtin-skill-files.ts
@@ -13,11 +13,12 @@ function hasRuntimeBuiltinSkillFiles(path: string): boolean {
 }
 
 export function resolveRuntimeBuiltinSkillsDir(baseDir: string): string {
-  const firstCandidate = resolve(baseDir, "../../../skills");
+  const firstCandidate = resolve(baseDir, "skills");
   const candidates = [
     firstCandidate,
-    resolve(baseDir, "../../skills"),
     resolve(baseDir, "../skills"),
+    resolve(baseDir, "../../skills"),
+    resolve(baseDir, "../../../skills"),
   ];
 
   return candidates.find((candidate) => hasRuntimeBuiltinSkillFiles(candidate)) ?? firstCandidate;

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.501";
+export const VERSION = "0.1.502";


### PR DESCRIPTION
## Summary
- resolve root-level skills when an agent service uses the project cwd as its base directory
- keep legacy parent-directory skill discovery candidates for source and build layouts
- bump package version to 0.1.502

## Verification
- deno test --no-check --allow-read --allow-write --allow-env src/agent/runtime-builtin-skill-files.test.ts
- deno test --no-check --allow-all src/agent/hosted-agent-project-steering.test.ts src/agent/veryfront-cloud-agent-service.test.ts
- deno task verify:quick
- deno task build:npm
- pre-push checks: format, lint, typecheck, unit tests