### PR TITLE
Apply npm dependency audit overrides

### DIFF
--- a/scripts/build/npm-package-metadata.ts
+++ b/scripts/build/npm-package-metadata.ts
@@ -1,12 +1,20 @@
 type PackageJson = {
+	name?: string;
+	version?: string;
+	private?: boolean;
 	dependencies?: Record<string, string>;
 	optionalDependencies?: Record<string, string>;
 	peerDependencies?: Record<string, string>;
 	peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+	overrides?: Record<string, string>;
 };
 
 const OPTIONAL_NATIVE_PEERS = {
 	"better-sqlite3": ">=9.0.0",
+} as const;
+
+const REQUIRED_NPM_OVERRIDES = {
+	protobufjs: "8.2.0",
 } as const;
 
 export function normalizeNpmPackageMetadata(pkg: PackageJson): PackageJson {
@@ -18,6 +26,11 @@ export function normalizeNpmPackageMetadata(pkg: PackageJson): PackageJson {
 
 		pkg.peerDependenciesMeta ??= {};
 		pkg.peerDependenciesMeta[name] = { optional: true };
+	}
+
+	pkg.overrides ??= {};
+	for (const [name, version] of Object.entries(REQUIRED_NPM_OVERRIDES)) {
+		pkg.overrides[name] = version;
 	}
 
 	return pkg;

--- a/scripts/security/audit-npm.ts
+++ b/scripts/security/audit-npm.ts
@@ -7,6 +7,8 @@
  * Usage: deno run --allow-read --allow-run --allow-write scripts/security/audit-npm.ts
  */
 
+import { normalizeNpmPackageMetadata } from "../build/npm-package-metadata.ts";
+
 const denoConfig = JSON.parse(await Deno.readTextFile("deno.json"));
 const imports: Record<string, string> = denoConfig.imports ?? {};
 
@@ -27,12 +29,12 @@ if (Object.keys(npmDeps).length === 0) {
 
 // Create a temporary package.json for npm audit
 const tmpDir = await Deno.makeTempDir({ prefix: "vf-audit-" });
-const packageJson = {
+const packageJson = normalizeNpmPackageMetadata({
   name: "veryfront-audit",
   version: "0.0.0",
   private: true,
   dependencies: npmDeps,
-};
+});
 
 await Deno.writeTextFile(
   `${tmpDir}/package.json`,

--- a/tests/build/npm-package-metadata.test.ts
+++ b/tests/build/npm-package-metadata.test.ts
@@ -20,4 +20,7 @@ Deno.test("keeps native sqlite support optional for npm consumers", () => {
   assertEquals(pkg.peerDependenciesMeta, {
     "better-sqlite3": { optional: true },
   });
+  assertEquals(pkg.overrides, {
+    protobufjs: "8.2.0",
+  });
 });


### PR DESCRIPTION
## Summary
- apply the npm package metadata override for protobufjs during package generation
- make the npm audit script use the same generated package metadata normalization
- cover the override in package metadata tests

## Verification
- deno test --no-check --allow-read --allow-env tests/build/npm-package-metadata.test.ts
- deno task audit
- deno test --no-check --allow-read --allow-write --allow-env src/agent/runtime-builtin-skill-files.test.ts tests/build/npm-package-metadata.test.ts
- deno task verify:quick
- deno task build:npm
- pre-push checks: format, lint, typecheck, unit tests