### PR TITLE
Restore database extension export

### DIFF
--- a/src/extensions/database/index.ts
+++ b/src/extensions/database/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Database category barrel — DatabaseClient contract.
+ *
+ * @module extensions/database
+ */
+
+export type { DatabaseClient, QueryResult } from "./database-client.ts";


### PR DESCRIPTION
## Summary
- restore the public database extension barrel referenced by package exports
- unblock npm package build for stable releases

## Verification
- deno task build:npm
- deno task verify:quick
- pre-push checks: format, lint, typecheck, unit tests