### PR TITLE
Route runtime invocations to requested agents

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.503",
+  "version": "0.1.504",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -189,7 +189,7 @@ import { startAgentService } from "veryfront/agent";
 await startAgentService({
   serviceName: "support-agent",
   agentId: "support",
-  entryUrl: import.meta.url,
+  entrypointUrl: import.meta.url,
 });
 ```
 
@@ -201,6 +201,12 @@ Veryfront projects: `agents/`, `tools/`, `skills/`, `resources/`, `prompts/`,
 `workflows/`, and `tasks/`. When a project needs non-standard paths, configure
 them in `veryfront.config.ts` under `ai.<primitive>.discovery.paths` instead of
 adding service-specific discovery configuration.
+
+The `agentId` option selects the default agent for direct `/api/runs` requests.
+Control-plane runtime invocations can target any discovered code or markdown
+agent by setting `run.agentId` in the `/api/control-plane/agents/stream`
+payload. This lets one deployed service expose multiple project agents while
+keeping direct chat integrations on a predictable default.
 
 ## Agent configuration
 

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -311,6 +311,12 @@ available from discovery; set `agentSource: "markdown"` to force markdown
 definitions. Use `veryfront.config.ts` `ai.<primitive>.discovery.paths` for
 non-standard project paths.
 
+The `agentId` option selects the default agent for direct `/api/runs` requests.
+Control-plane runtime invocations can target any discovered code or markdown
+agent by setting `run.agentId` in the `/api/control-plane/agents/stream`
+payload. This lets one deployed service expose multiple project agents while
+keeping direct chat integrations on a predictable default.
+
 For a conversations/control-plane host composition that combines
 `runHostedLifecycle()` with the public durable-run helpers, see
 [`Conversation-backed agent hosts`](./agent-conversation-control-plane.md).

--- a/src/agent/hosted-ag-ui-chat-request.ts
+++ b/src/agent/hosted-ag-ui-chat-request.ts
@@ -175,6 +175,7 @@ export async function buildParsedHostedAgUiRequest(
   }
 
   return {
+    agentId: undefined,
     agUiInput: input.agUiInput,
     userId: input.userId,
     authToken: input.authToken,

--- a/src/agent/hosted-agent-service-routes.test.ts
+++ b/src/agent/hosted-agent-service-routes.test.ts
@@ -32,6 +32,27 @@ function createAgUiBody(): Record<string, unknown> {
   };
 }
 
+function createRuntimeAgentInvocationBody(): Record<string, unknown> {
+  return {
+    run: {
+      agentServiceId: "test-agent-service",
+      agentId: "builder",
+      conversationId: "00000000-0000-4000-8000-000000000001",
+      runId: "run-1",
+      messageId: "00000000-0000-4000-8000-000000000002",
+      inputAnchorMessageId: "00000000-0000-4000-8000-000000000003",
+      requestedByUserId: "00000000-0000-4000-8000-000000000004",
+      project: {
+        projectId: "00000000-0000-4000-8000-000000000005",
+        projectSlug: "demo",
+      },
+    },
+    messages: [],
+    tools: [],
+    context: [],
+  };
+}
+
 function createRouteSet(input: {
   prepareExecution?: (req: ParsedHostedChatRequest) => Promise<{ executionId: string }>;
   streamResponse?: Response;
@@ -103,6 +124,20 @@ Deno.test("hosted agent service routes stream prepared AG-UI execution", async (
   assertEquals(response, streamResponse);
   assertEquals(preparedRequests.length, 1);
   assertEquals(streamInputs, [{ executionId: "exec-1", agUiRunId: "run-1" }]);
+});
+
+Deno.test("hosted agent service routes preserve control-plane target agent ids", async () => {
+  const { routeSet, preparedRequests } = createRouteSet();
+  const response = await routeSet.handleRuntimeAgentRunInvocationExecuteRequest({
+    request: createAuthenticatedRequest(
+      "/api/control-plane/agents/stream",
+      createRuntimeAgentInvocationBody(),
+    ),
+  });
+
+  assertEquals(response.status, 202);
+  assertEquals(preparedRequests.length, 1);
+  assertEquals(preparedRequests[0]?.agentId, "builder");
 });
 
 Deno.test("hosted agent service routes enforce durable root lineage", async () => {

--- a/src/agent/hosted-chat-request-parser.ts
+++ b/src/agent/hosted-chat-request-parser.ts
@@ -27,6 +27,7 @@ export type HostedChatProjectAccessResult =
   | { success: false; error: HostedChatProjectAccessError };
 
 export type ParsedHostedChatRequest = {
+  agentId: string | undefined;
   userId: string;
   authToken: string;
   messages: ChatUiMessage[];
@@ -99,6 +100,7 @@ async function verifyHostedChatProjectAccess(input: {
 
 export async function buildParsedHostedChatRequest(input: {
   chatRequest: HostedChatRequest;
+  agentId?: string;
   authToken: string;
   userId: string;
   verifyProjectAccess?: ParseHostedChatRequestOptions["verifyProjectAccess"];
@@ -125,6 +127,7 @@ export async function buildParsedHostedChatRequest(input: {
   }
 
   return {
+    agentId: input.agentId,
     userId: input.userId,
     authToken: input.authToken,
     messages: messages as ChatUiMessage[],
@@ -200,6 +203,7 @@ export async function parseRuntimeAgentRunInvocationHostedChatRequestFromRequest
     authToken: authenticatedRequest.authToken,
     userId: authenticatedRequest.userId,
     chatRequest: chatRequest.data,
+    agentId: invocation.data.run.agentId,
     verifyProjectAccess: options.verifyProjectAccess,
   });
 }

--- a/src/agent/veryfront-cloud-agent-service.ts
+++ b/src/agent/veryfront-cloud-agent-service.ts
@@ -63,6 +63,10 @@ import { type HostedProjectSkillIdsContext } from "./hosted-project-steering-ada
 import type { RuntimeLoadSkillToolContext } from "./runtime-load-skill-tool.ts";
 import type { RuntimeProjectSteeringLookup } from "./runtime-project-skill-catalog.ts";
 import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
+import {
+  loadRuntimeAgentMarkdownDefinitionFromFile,
+  resolveRuntimeAgentDefinitionsDir,
+} from "./runtime-agent-definition-files.ts";
 import type { RuntimeAgentMarkdownDefinition } from "./runtime-agent-definition.ts";
 import {
   buildVeryfrontCloudRuntimeInstructions,
@@ -313,6 +317,7 @@ function createNodeVeryfrontCloudAgentServiceContext(
     tracker: createDetachedRunTracker<AgUiResumeValue>(),
     discoveryResult: null as DiscoveryResult | null,
     agentConfig: null as RuntimeAgentMarkdownDefinition | null,
+    agentConfigs: new Map<string, RuntimeAgentMarkdownDefinition>(),
   };
 }
 
@@ -339,21 +344,50 @@ function getMarkdownAgentConfig(
   return context.projectSteering.getAgentConfig();
 }
 
+function loadMarkdownAgentConfig(
+  context: NodeVeryfrontCloudAgentServiceContext,
+  agentId: string,
+): RuntimeAgentMarkdownDefinition {
+  if (agentId === context.options.agentId) {
+    return getMarkdownAgentConfig(context);
+  }
+
+  const agentsDir = resolveRuntimeAgentDefinitionsDir({
+    baseDir: resolveBaseDir(context.options),
+    id: agentId,
+  });
+
+  return loadRuntimeAgentMarkdownDefinitionFromFile({
+    agentsDir,
+    id: agentId,
+  });
+}
+
 async function resolveAgentConfig(
   context: NodeVeryfrontCloudAgentServiceContext,
+  agentId: string,
 ): Promise<RuntimeAgentMarkdownDefinition> {
+  const cachedAgentConfig = context.agentConfigs.get(agentId);
+  if (cachedAgentConfig) {
+    return cachedAgentConfig;
+  }
+
   const source = context.options.agentSource ?? "auto";
-  const codeAgent = getAgent(context.options.agentId);
+  const codeAgent = getAgent(agentId);
 
   if (source !== "markdown" && codeAgent) {
-    return await createRuntimeAgentDefinitionFromCodeAgent(codeAgent);
+    const agentConfig = await createRuntimeAgentDefinitionFromCodeAgent(codeAgent);
+    context.agentConfigs.set(agentConfig.id, agentConfig);
+    return agentConfig;
   }
 
   if (source === "code") {
-    throw new Error(`Code agent "${context.options.agentId}" was not discovered.`);
+    throw new Error(`Code agent "${agentId}" was not discovered.`);
   }
 
-  return getMarkdownAgentConfig(context);
+  const agentConfig = loadMarkdownAgentConfig(context, agentId);
+  context.agentConfigs.set(agentConfig.id, agentConfig);
+  return agentConfig;
 }
 
 function getResolvedAgentConfig(
@@ -386,7 +420,7 @@ async function initializeNodeVeryfrontCloudAgentServiceContext(
   context: NodeVeryfrontCloudAgentServiceContext,
 ): Promise<void> {
   await discoverProjectPrimitives(context);
-  context.agentConfig = await resolveAgentConfig(context);
+  context.agentConfig = await resolveAgentConfig(context, context.options.agentId);
 }
 
 function getDiscoveredHostTools(): HostToolSet {
@@ -638,7 +672,7 @@ async function prepareChatExecution(
 
   setPrepareChatExecutionStartAttributes(context, { projectId, userId });
 
-  const agentConfig = getResolvedAgentConfig(context);
+  const agentConfig = await resolveAgentConfig(context, req.agentId ?? context.options.agentId);
   const {
     effectiveMessages,
     rootRunContext,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.503";
+export const VERSION = "0.1.504";


### PR DESCRIPTION
## Summary
- preserve `run.agentId` when normalizing control-plane runtime invocations
- resolve the requested discovered code or markdown agent during service execution
- document multi-agent service targeting and bump package version to `0.1.504`

## Verification
- `deno test --no-check --allow-all src/agent/hosted-agent-service-routes.test.ts src/agent/veryfront-cloud-agent-service.test.ts`
- `deno task verify:quick`
- `deno task build:npm`
- pre-push checks: format, lint, typecheck, unit tests `1832 passed (17412 steps), 0 failed`