### PR TITLE
Remove legacy agent service entry aliases

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.504",
+  "version": "0.1.505",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -58,7 +58,6 @@ import {
   registerAgent,
   runHostedChildLifecycle,
   runHostedLifecycle,
-  runNodeVeryfrontCloudAgentServiceMain,
   RunResumeSessionManager,
   RuntimeAgentRunInvocationSchema,
   shouldSkipHostedChildTerminalPersistence,
@@ -284,8 +283,7 @@ await startAgentService({
 
 By default, discovery is rooted at the process cwd. Pass `baseDir` only when the
 service may start from another working directory. `entrypointUrl` is a
-convenience fallback for deriving `baseDir` from an entry module URL; `entryUrl`
-remains supported as a compatibility alias.
+convenience fallback for deriving `baseDir` from an entry module URL.
 
 Studio MCP tools are opt-in because they are Studio/control-plane specific:
 
@@ -876,10 +874,6 @@ helper loads `.env` files, initializes OpenTelemetry where supported, registers
 trace-context logging, starts the service server, and handles startup failures
 through the provided process target.
 
-### `runNodeVeryfrontCloudAgentServiceMain(options)`
-
-Compatibility alias for `startAgentService()`.
-
 ### `parseAgentServiceConfig(env)`
 
 Parse the default agent service environment contract. The helper
@@ -1138,7 +1132,6 @@ Clear all stored messages from memory.
 | `parseAgUiRuntimeRequestOrError`                                      | Parse runtime AG-UI input or return a `400` validation `Response`        |
 | `parseRuntimeAgentRunInvocation`                                      | Parse and validate a control-plane runtime agent invocation body         |
 | `startAgentService`                                                   | Run the default cross-runtime bootstrap for a Veryfront Cloud service    |
-| `runNodeVeryfrontCloudAgentServiceMain`                               | Compatibility alias for `startAgentService`                              |
 | `startNodeAgentService`                                               | Start an agent service with the Node service server adapter              |
 | `startNodeVeryfrontCloudAgentService`                                 | Start a Veryfront Cloud agent service with the Node server adapter       |
 | `parseRuntimeAgentRunInvocationOrError`                               | Parse a runtime agent invocation or return a `400` validation `Response` |

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -339,7 +339,6 @@ export {
   type NodeVeryfrontCloudAgentServiceOptions,
   type NodeVeryfrontCloudAgentServicePreparedExecution,
   type NodeVeryfrontCloudAgentServiceProcessTarget,
-  runNodeVeryfrontCloudAgentServiceMain,
   startAgentService,
   startNodeVeryfrontCloudAgentService,
   type VeryfrontCloudAgentServiceOptions,

--- a/src/agent/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/veryfront-cloud-agent-service.test.ts
@@ -92,7 +92,7 @@ Deno.test("createNodeVeryfrontCloudAgentServiceRuntime loads the markdown agent 
     const bundle = await createNodeVeryfrontCloudAgentServiceRuntime({
       serviceName: "veryfront-agent-test",
       agentId: "veryfront",
-      entryUrl: pathToFileURL(resolve(rootDir, "main.ts")),
+      entrypointUrl: pathToFileURL(resolve(rootDir, "main.ts")),
       env: {
         NODE_ENV: "test",
         VERYFRONT_API_URL: "https://api.example.com",
@@ -140,7 +140,7 @@ Deno.test("createNodeVeryfrontCloudAgentServiceRuntime defaults discovery to cwd
   });
 });
 
-Deno.test("createNodeVeryfrontCloudAgentServiceRuntime accepts entrypointUrl alias", async () => {
+Deno.test("createNodeVeryfrontCloudAgentServiceRuntime accepts entrypointUrl for discovery", async () => {
   await withTempDir(async (rootDir) => {
     writeMarkdownAgentDefinition(rootDir);
 
@@ -188,7 +188,7 @@ Deno.test({
         serviceName: "configured-agent-test",
         agentId: "support",
         agentSource: "code",
-        entryUrl: pathToFileURL(resolve(rootDir, "src", "main.ts")),
+        entrypointUrl: pathToFileURL(resolve(rootDir, "src", "main.ts")),
         createBashTool,
         env: {
           NODE_ENV: "test",
@@ -220,7 +220,7 @@ Deno.test({
         serviceName: "support-agent-test",
         agentId: "support",
         agentSource: "code",
-        entryUrl: pathToFileURL(resolve(rootDir, "src", "main.ts")),
+        entrypointUrl: pathToFileURL(resolve(rootDir, "src", "main.ts")),
         createBashTool,
         env: {
           NODE_ENV: "test",

--- a/src/agent/veryfront-cloud-agent-service.ts
+++ b/src/agent/veryfront-cloud-agent-service.ts
@@ -135,10 +135,6 @@ export type NodeVeryfrontCloudAgentServiceOptions = {
    * Convenience URL for deriving baseDir from the entry module location.
    */
   entrypointUrl?: AgentServicePathOption;
-  /**
-   * Compatibility alias for entrypointUrl.
-   */
-  entryUrl?: AgentServicePathOption;
   agentSource?: NodeVeryfrontCloudAgentServiceAgentSource;
   mcp?: NodeVeryfrontCloudAgentServiceMcpOptions;
   forwardedConfigNamespace?: string;
@@ -188,16 +184,13 @@ function pathOptionToPath(pathOption: AgentServicePathOption): string {
 }
 
 function resolveBaseDir(
-  options: Pick<NodeVeryfrontCloudAgentServiceOptions, "baseDir" | "entrypointUrl" | "entryUrl">,
+  options: Pick<NodeVeryfrontCloudAgentServiceOptions, "baseDir" | "entrypointUrl">,
 ): string {
   if (options.baseDir !== undefined) {
     return pathOptionToPath(options.baseDir);
   }
   if (options.entrypointUrl !== undefined) {
     return dirname(pathOptionToPath(options.entrypointUrl));
-  }
-  if (options.entryUrl !== undefined) {
-    return dirname(pathOptionToPath(options.entryUrl));
   }
   if (typeof process !== "undefined") {
     return process.cwd();
@@ -226,7 +219,7 @@ function uniquePaths(paths: string[]): string[] {
 function resolveProjectDir(
   options: Pick<
     NodeVeryfrontCloudAgentServiceOptions,
-    "baseDir" | "entrypointUrl" | "entryUrl" | "projectDir"
+    "baseDir" | "entrypointUrl" | "projectDir"
   >,
 ): string {
   if (options.projectDir) {
@@ -856,10 +849,4 @@ export async function startAgentService(
     exit: processTarget?.exit,
     processTarget,
   });
-}
-
-export async function runNodeVeryfrontCloudAgentServiceMain(
-  options: NodeVeryfrontCloudAgentServiceOptions,
-): Promise<void> {
-  await startAgentService(options);
 }

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.504";
+export const VERSION = "0.1.505";


### PR DESCRIPTION
## Summary
- remove the legacy entry URL option from the agent-service preset
- remove the legacy main-runner alias in favor of the canonical startAgentService entrypoint
- update agent-service docs and tests to use entrypointUrl when an explicit module URL is needed

## Verification
- deno test --no-check --allow-all src/agent/veryfront-cloud-agent-service.test.ts src/agent/agent-service-route-export.check.ts
- deno task typecheck
- deno task verify:quick
- deno task build:npm
- pre-push checks