### PR TITLE
Share runtime source context schema

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.505",
+  "version": "0.1.506",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/internal-agents/schema.test.ts
+++ b/src/internal-agents/schema.test.ts
@@ -70,6 +70,38 @@ describe("internal-agents/schema", () => {
     );
   });
 
+  it("uses the shared runtime agent source context contract", () => {
+    const parsed = getInternalAgentStreamRequestSchema().parse({
+      agentId: "agent_1",
+      threadId: "10000000-1000-4000-8000-100000000001",
+      runId: "run_1",
+      messages: [],
+      agentSource: {
+        type: "environment",
+        environmentName: "staging",
+        releaseId: "release_1",
+      },
+    });
+
+    assertEquals(parsed.agentSource, {
+      type: "environment",
+      environmentName: "staging",
+      releaseId: "release_1",
+    });
+    assertThrows(
+      () =>
+        getInternalAgentStreamRequestSchema().parse({
+          agentId: "agent_1",
+          threadId: "10000000-1000-4000-8000-100000000001",
+          runId: "run_1",
+          messages: [],
+          agentSource: { type: "branch", branch: "" },
+        }),
+      Error,
+      "Too small: expected string to have >=1 characters",
+    );
+  });
+
   it("accepts a canonical AG-UI-aligned runtime payload", () => {
     const parsed = getRuntimeRunAgentInputSchema().parse({
       threadId: crypto.randomUUID(),

--- a/src/internal-agents/schema.ts
+++ b/src/internal-agents/schema.ts
@@ -13,6 +13,10 @@ import {
   getAgUiRuntimeToolCallSchema,
 } from "#veryfront/agent/runtime-ag-ui-contract.ts";
 import { stripLeadingEmptyObjectPlaceholder } from "#veryfront/agent/data-stream.ts";
+import {
+  getRuntimeAgentSourceContextSchema,
+  type RuntimeAgentSourceContext,
+} from "#veryfront/agent/runtime-agent-invocation-contract.ts";
 
 const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const MAX_FORWARDED_PROPS_BYTES = 65_536;
@@ -33,24 +37,6 @@ export const getRunIdSchema = getAgUiRuntimeRunIdSchema;
 
 export const getAgentIdSchema = defineSchema((v) =>
   v.string().min(1).max(128).regex(AGENT_ID_PATTERN)
-);
-
-export const getRuntimeAgentSourceContextSchema = defineSchema((v) =>
-  v.discriminatedUnion("type", [
-    v.object({
-      type: v.literal("branch"),
-      branch: v.string().min(1).max(255),
-    }),
-    v.object({
-      type: v.literal("environment"),
-      environmentName: v.string().min(1).max(255),
-      releaseId: v.string().min(1).max(255).optional(),
-    }),
-    v.object({
-      type: v.literal("release"),
-      releaseId: v.string().min(1).max(255),
-    }),
-  ])
 );
 
 export const getRuntimeInjectedToolSchema = getAgUiRuntimeInjectedToolSchema;
@@ -326,11 +312,10 @@ export const getResumeSignalSchema = defineSchema((v) =>
   ])
 );
 
+export { getRuntimeAgentSourceContextSchema };
+export type { RuntimeAgentSourceContext };
 export type RuntimeInjectedTool = InferSchema<ReturnType<typeof getRuntimeInjectedToolSchema>>;
 export type RuntimeContextItem = AgUiRuntimeContextItem;
-export type RuntimeAgentSourceContext = InferSchema<
-  ReturnType<typeof getRuntimeAgentSourceContextSchema>
->;
 export type RuntimeRunAgentInput = AgUiRuntimeRequest;
 export type InternalAgentStreamRequest = InferSchema<
   ReturnType<typeof getInternalAgentStreamRequestSchema>

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.505";
+export const VERSION = "0.1.506";


### PR DESCRIPTION
## Summary\n- reuse the runtime invocation source-context schema for internal project-agent stream requests\n- keep the internal schema export stable while removing the duplicate source-context definition\n- bump package version to 0.1.506 for release\n\n## Verification\n- deno test --no-check --allow-all src/internal-agents/schema.test.ts src/server/handlers/request/agent-stream.handler.test.ts src/agent/runtime-agent-invocation-contract.test.ts\n- deno task typecheck\n- deno task verify:quick\n- deno task build:npm