### PR TITLE
Share runtime invocation stream mapper

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.506",
+  "version": "0.1.507",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -607,10 +607,12 @@ export {
   resolveHostedRuntimeThinkingOverride,
 } from "./hosted-runtime-request-config.ts";
 export {
+  buildRuntimeAgentControlPlaneStreamRequestFromInvocation,
   parseRuntimeAgentRunInvocation,
   parseRuntimeAgentRunInvocationOrError,
   type RuntimeAgentContextItem,
   RuntimeAgentContextItemSchema,
+  type RuntimeAgentControlPlaneStreamRequest,
   RuntimeAgentIdSchema,
   type RuntimeAgentProjectContext,
   RuntimeAgentProjectContextSchema,

--- a/src/agent/runtime-agent-invocation-contract.test.ts
+++ b/src/agent/runtime-agent-invocation-contract.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertInstanceOf, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  buildRuntimeAgentControlPlaneStreamRequestFromInvocation,
   parseRuntimeAgentRunInvocation,
   parseRuntimeAgentRunInvocationOrError,
   RuntimeAgentRunInvocationSchema,
@@ -155,6 +156,39 @@ describe("agent/runtime-agent-invocation-contract", () => {
         },
       }))
     );
+  });
+
+  it("builds the control-plane stream request from a runtime invocation", () => {
+    const parsed = RuntimeAgentRunInvocationSchema.parse(createInvocation({
+      run: {
+        agentServiceId: "veryfront-platform-agent",
+        agentId: "builder",
+        conversationId,
+        runId: "run_child_1",
+        messageId,
+        inputAnchorMessageId,
+        requestedByUserId: userId,
+        project: {
+          projectId,
+          projectSlug: "demo-project",
+        },
+        parentRunId: "run_root_1",
+      },
+    }));
+
+    const request = buildRuntimeAgentControlPlaneStreamRequestFromInvocation(parsed);
+
+    assertEquals(request, {
+      agentId: "builder",
+      threadId: conversationId,
+      runId: "run_child_1",
+      parentRunId: "run_root_1",
+      messages: parsed.messages,
+      tools: parsed.tools,
+      context: parsed.context,
+      agentSource: parsed.agentSource,
+      forwardedProps: parsed.forwardedProps,
+    });
   });
 
   it("parses runtime agent invocation request bodies through the public helper", async () => {

--- a/src/agent/runtime-agent-invocation-contract.ts
+++ b/src/agent/runtime-agent-invocation-contract.ts
@@ -311,6 +311,34 @@ export type RuntimeAgentRunInvocation = InferSchema<
   ReturnType<typeof getRuntimeAgentRunInvocationSchema>
 >;
 
+export type RuntimeAgentControlPlaneStreamRequest = {
+  agentId: RuntimeAgentRunContext["agentId"];
+  threadId: RuntimeAgentRunContext["conversationId"];
+  runId: RuntimeAgentRunContext["runId"];
+  parentRunId?: Exclude<RuntimeAgentRunContext["parentRunId"], null | undefined>;
+  messages: RuntimeAgentRunInvocation["messages"];
+  tools: RuntimeAgentRunInvocation["tools"];
+  context: RuntimeAgentRunInvocation["context"];
+  agentSource?: RuntimeAgentRunInvocation["agentSource"];
+  forwardedProps?: RuntimeAgentRunInvocation["forwardedProps"];
+};
+
+export function buildRuntimeAgentControlPlaneStreamRequestFromInvocation(
+  input: RuntimeAgentRunInvocation,
+): RuntimeAgentControlPlaneStreamRequest {
+  return {
+    agentId: input.run.agentId,
+    threadId: input.run.conversationId,
+    runId: input.run.runId,
+    ...(input.run.parentRunId ? { parentRunId: input.run.parentRunId } : {}),
+    messages: input.messages,
+    tools: input.tools,
+    context: input.context,
+    ...(input.agentSource ? { agentSource: input.agentSource } : {}),
+    ...(input.forwardedProps ? { forwardedProps: input.forwardedProps } : {}),
+  };
+}
+
 export async function parseRuntimeAgentRunInvocation(
   request: Request,
 ): Promise<RuntimeAgentRunInvocation> {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.506";
+export const VERSION = "0.1.507";


### PR DESCRIPTION
## Summary\n- add a shared helper for converting runtime agent invocations into control-plane stream requests\n- export the helper from veryfront/agent\n- bump package version to 0.1.507\n\n## Verification\n- deno test --no-check --allow-all src/agent/runtime-agent-invocation-contract.test.ts\n- deno task typecheck\n- deno task verify:quick\n- deno task build:npm