### PR TITLE
Promote agent-service sandbox naming

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.507",
+  "version": "0.1.508",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/sandbox.md
+++ b/docs/reference/sandbox.md
@@ -184,9 +184,9 @@ Options for a lazily-provisioned sandbox session.
 | `heartbeatIntervalMs?` | `number`                            | Background heartbeat interval for active sessions. Defaults to 30000.                                                                                                                |
 | `heartbeatGraceMs?`    | `number`                            | Minimum gap between non-forced heartbeats. Defaults to 5000.                                                                                                                         |
 
-### `HostedSandboxToolsOptions`
+### `AgentServiceSandboxToolsOptions`
 
-Options for creating hosted sandbox tools.
+Options for creating agent-service sandbox tools.
 
 | Property         | Type                                | Description                                                               |
 | ---------------- | ----------------------------------- | ------------------------------------------------------------------------- |

--- a/src/agent/default-hosted-invoke-agent-tool.ts
+++ b/src/agent/default-hosted-invoke-agent-tool.ts
@@ -1,5 +1,8 @@
-import type { HostedSandboxToolsOptions, HostedSandboxToolsResult } from "#veryfront/sandbox";
-import { createHostedSandboxTools } from "#veryfront/sandbox";
+import type {
+  AgentServiceSandboxToolsOptions,
+  AgentServiceSandboxToolsResult,
+} from "#veryfront/sandbox";
+import { createAgentServiceSandboxTools } from "#veryfront/sandbox";
 import {
   createRemoteMCPToolSource,
   createToolsFromRemoteDefinitions,
@@ -112,7 +115,7 @@ export type DefaultHostedInvokeAgentToolOptions<TContext extends DefaultHostedIn
     logger: DefaultHostedInvokeAgentLogger;
     trace: DefaultHostedInvokeAgentTrace;
     setTraceAttributes: (attributes: DefaultHostedInvokeAgentTraceAttributes) => void;
-    createBashTool: HostedSandboxToolsOptions["createBashTool"];
+    createBashTool: AgentServiceSandboxToolsOptions["createBashTool"];
     resolveModelId: (model: string) => string;
     resolveProvider: (modelId: string) => string;
     resolveProviderOptions?: (
@@ -125,12 +128,9 @@ export type DefaultHostedInvokeAgentToolOptions<TContext extends DefaultHostedIn
     defaultModel?: string;
     defaultMaxSteps?: number;
     resolveChildAgentId?: (input: DefaultHostedInvokeAgentInput) => string;
-    createHostedSandboxTools?: (
-      input: HostedSandboxToolsOptions,
-    ) => Promise<HostedSandboxToolsResult>;
     createAgentServiceSandboxTools?: (
-      input: HostedSandboxToolsOptions,
-    ) => Promise<HostedSandboxToolsResult>;
+      input: AgentServiceSandboxToolsOptions,
+    ) => Promise<AgentServiceSandboxToolsResult>;
     createRemoteToolSource?: (config: RemoteMCPToolSourceConfig) => RemoteToolSource;
     createToolsFromRemoteDefinitions?: typeof createToolsFromRemoteDefinitions;
     createLiveStudioTools?: Parameters<typeof prepareDefaultHostedChildForkSandboxToolSources>[0][
@@ -228,7 +228,7 @@ async function prepareForkToolSources<TContext extends DefaultHostedInvokeAgentC
     logger: options.logger,
     createBashTool: options.createBashTool,
     createAgentServiceSandboxTools: options.createAgentServiceSandboxTools ??
-      options.createHostedSandboxTools ?? createHostedSandboxTools,
+      createAgentServiceSandboxTools,
     createLiveStudioTools: options.createLiveStudioTools ?? createLiveStudioMcpTools,
     createRemoteToolSource: options.createRemoteToolSource ?? createRemoteMCPToolSource,
     createToolsFromRemoteDefinitions: options.createToolsFromRemoteDefinitions ??

--- a/src/agent/hosted-child-fork-tool-sources.test.ts
+++ b/src/agent/hosted-child-fork-tool-sources.test.ts
@@ -1,10 +1,10 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import type {
+  AgentServiceSandboxToolsOptions,
+  AgentServiceSandboxToolsResult,
   CommandJob,
   CommandJobOutput,
   CreateSandboxBashTool,
-  HostedSandboxToolsOptions,
-  HostedSandboxToolsResult,
 } from "#veryfront/sandbox";
 import type {
   RemoteMCPToolSourceConfig,
@@ -92,9 +92,9 @@ function commandJobOutput(): CommandJobOutput {
 }
 
 function createSandboxToolsResult(input: {
-  tools?: HostedSandboxToolsResult["tools"];
+  tools?: AgentServiceSandboxToolsResult["tools"];
   closeSandbox: () => Promise<void>;
-}): HostedSandboxToolsResult {
+}): AgentServiceSandboxToolsResult {
   return {
     tools: input.tools ?? {},
     sandbox: {
@@ -213,7 +213,7 @@ Deno.test("prepareDefaultHostedChildForkToolSources rethrows abort errors", asyn
 
 Deno.test("prepareDefaultHostedChildForkSandboxToolSources merges sandbox tools and returns runtime cleanup", async () => {
   const fixtures = createRemoteSourceFixtures();
-  const sandboxToolInputs: HostedSandboxToolsOptions[] = [];
+  const sandboxToolInputs: AgentServiceSandboxToolsOptions[] = [];
   let sandboxClosed = false;
   const createBashTool: CreateSandboxBashTool = () => Promise.resolve({ tools: {} });
 
@@ -233,7 +233,7 @@ Deno.test("prepareDefaultHostedChildForkSandboxToolSources merges sandbox tools 
     },
     createBashTool,
     createRemoteToolSource: fixtures.createRemoteToolSource,
-    createHostedSandboxTools: (sandboxInput) => {
+    createAgentServiceSandboxTools: (sandboxInput) => {
       sandboxToolInputs.push(sandboxInput);
       return Promise.resolve(
         createSandboxToolsResult({
@@ -285,7 +285,7 @@ Deno.test("prepareDefaultHostedChildForkSandboxToolSources closes sandbox when s
     createLiveStudioTools: () => {
       throw new Error("studio unavailable");
     },
-    createHostedSandboxTools: () =>
+    createAgentServiceSandboxTools: () =>
       Promise.resolve(
         createSandboxToolsResult({
           closeSandbox: () => {

--- a/src/agent/hosted-child-fork-tool-sources.ts
+++ b/src/agent/hosted-child-fork-tool-sources.ts
@@ -6,9 +6,9 @@ import {
   type RemoteToolSource,
 } from "#veryfront/tool";
 import {
-  createHostedSandboxTools,
-  type HostedSandboxToolsOptions,
-  type HostedSandboxToolsResult,
+  type AgentServiceSandboxToolsOptions,
+  type AgentServiceSandboxToolsResult,
+  createAgentServiceSandboxTools,
 } from "#veryfront/sandbox";
 import {
   createLiveStudioMcpTools,
@@ -64,13 +64,10 @@ export type PrepareDefaultHostedChildForkSandboxToolSourcesInput =
   & PrepareDefaultHostedChildForkToolSourcesInput
   & {
     apiUrl: string;
-    createBashTool: HostedSandboxToolsOptions["createBashTool"];
-    createHostedSandboxTools?: (
-      input: HostedSandboxToolsOptions,
-    ) => Promise<HostedSandboxToolsResult>;
+    createBashTool: AgentServiceSandboxToolsOptions["createBashTool"];
     createAgentServiceSandboxTools?: (
-      input: HostedSandboxToolsOptions,
-    ) => Promise<HostedSandboxToolsResult>;
+      input: AgentServiceSandboxToolsOptions,
+    ) => Promise<AgentServiceSandboxToolsResult>;
   };
 
 export async function prepareDefaultHostedChildForkToolSources(
@@ -150,13 +147,12 @@ export async function prepareDefaultHostedChildForkSandboxToolSources(
   const {
     apiUrl,
     createBashTool,
-    createHostedSandboxTools: createHostedSandboxToolsOverride,
     createAgentServiceSandboxTools: createAgentServiceSandboxToolsOverride,
     globalTools,
     ...toolSourceInput
   } = input;
   const createSandboxTools = createAgentServiceSandboxToolsOverride ??
-    createHostedSandboxToolsOverride ?? createHostedSandboxTools;
+    createAgentServiceSandboxTools;
   const sandboxResult = await createSandboxTools({
     authToken: input.authToken,
     apiUrl,

--- a/src/agent/veryfront-cloud-agent-service.ts
+++ b/src/agent/veryfront-cloud-agent-service.ts
@@ -1,8 +1,8 @@
 import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { HostedSandboxToolsOptions } from "#veryfront/sandbox";
-import { createHostedSandboxTools } from "#veryfront/sandbox";
+import type { AgentServiceSandboxToolsOptions } from "#veryfront/sandbox";
+import { createAgentServiceSandboxTools } from "#veryfront/sandbox";
 import {
   createRemoteMCPToolSource,
   createToolsFromRemoteDefinitions,
@@ -138,7 +138,7 @@ export type NodeVeryfrontCloudAgentServiceOptions = {
   agentSource?: NodeVeryfrontCloudAgentServiceAgentSource;
   mcp?: NodeVeryfrontCloudAgentServiceMcpOptions;
   forwardedConfigNamespace?: string;
-  createBashTool?: HostedSandboxToolsOptions["createBashTool"];
+  createBashTool?: AgentServiceSandboxToolsOptions["createBashTool"];
   env?: CreateNodeAgentServiceRuntimeInfrastructureOptions["env"];
   processTarget?: NodeVeryfrontCloudAgentServiceProcessTarget;
   drainTimeoutMs?: number;
@@ -150,7 +150,7 @@ export type VeryfrontCloudAgentServiceOptions = NodeVeryfrontCloudAgentServiceOp
 type ResolvedNodeVeryfrontCloudAgentServiceOptions =
   & NodeVeryfrontCloudAgentServiceOptions
   & {
-    createBashTool: HostedSandboxToolsOptions["createBashTool"];
+    createBashTool: AgentServiceSandboxToolsOptions["createBashTool"];
   };
 
 export type NodeVeryfrontCloudAgentServicePreparedExecution = PreparedHostedChatExecution & {
@@ -239,7 +239,7 @@ function resolveDefaultProcessTarget(): NodeVeryfrontCloudAgentServiceProcessTar
 }
 
 async function loadDefaultCreateBashTool(): Promise<
-  HostedSandboxToolsOptions["createBashTool"]
+  AgentServiceSandboxToolsOptions["createBashTool"]
 > {
   const { createBashTool } = await import("bash-tool");
   return createBashTool;
@@ -499,7 +499,7 @@ function createInvokeAgentTool(
     }),
     refreshProjectSkillIds: (projectSkillContext) =>
       refreshProjectSkillIds(context, projectSkillContext),
-    createHostedSandboxTools,
+    createAgentServiceSandboxTools,
     createLiveStudioTools: createLiveStudioMcpTools,
     createRemoteToolSource: createRemoteMCPToolSource,
     createToolsFromRemoteDefinitions,

--- a/src/sandbox/agent-service-sandbox-aliases.test.ts
+++ b/src/sandbox/agent-service-sandbox-aliases.test.ts
@@ -9,7 +9,7 @@ import {
   createHostedSandboxTools,
 } from "./index.ts";
 
-Deno.test("agent-service sandbox aliases point at hosted compatibility exports", () => {
+Deno.test("hosted sandbox compatibility exports point at agent-service factories", () => {
   assertEquals(createAgentServiceSandboxClient, createHostedSandboxClient);
   assertEquals(createAgentServiceSandboxTools, createHostedSandboxTools);
 });

--- a/src/sandbox/agent-service-tools.test.ts
+++ b/src/sandbox/agent-service-tools.test.ts
@@ -3,11 +3,11 @@ import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd";
 import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert";
 import type { CreateSandboxBashTool, SandboxShellToolSet } from "./shell-tools.ts";
 import {
-  createHostedSandboxClient,
-  createHostedSandboxTools,
+  createAgentServiceSandboxClient,
+  createAgentServiceSandboxTools,
   createProjectScopedExecOptions,
   unwrapSandboxWorkingDirectoryCommand,
-} from "./hosted-tools.ts";
+} from "./agent-service-tools.ts";
 import {
   clearSandboxEnv,
   type FetchCall,
@@ -83,7 +83,7 @@ async function executeStartCommandJob(
   return await execute({ command });
 }
 
-describe("sandbox/hosted-tools", () => {
+describe("sandbox/agent-service-tools", () => {
   beforeEach(() => {
     fetchCalls = [];
     fetchResponses = [];
@@ -97,7 +97,7 @@ describe("sandbox/hosted-tools", () => {
   it("creates shell tools and async command job tools", async () => {
     mockFetch([]);
 
-    const { tools } = await createHostedSandboxTools({
+    const { tools } = await createAgentServiceSandboxTools({
       authToken: "test-token",
       apiUrl: "https://api.example.com",
       projectId: "project-123",
@@ -124,7 +124,7 @@ describe("sandbox/hosted-tools", () => {
     ]);
 
     let projectId = "project-1";
-    const sandbox = createHostedSandboxClient({
+    const sandbox = createAgentServiceSandboxClient({
       authToken: "test-token",
       apiUrl: "https://api.example.com",
       getProjectId: () => projectId,
@@ -169,7 +169,7 @@ describe("sandbox/hosted-tools", () => {
       jsonResponse(createJobPayload()),
     ]);
 
-    const { tools } = await createHostedSandboxTools({
+    const { tools } = await createAgentServiceSandboxTools({
       authToken: "test-token",
       apiUrl: "https://api.example.com",
       projectId: "project-123",

--- a/src/sandbox/agent-service-tools.ts
+++ b/src/sandbox/agent-service-tools.ts
@@ -13,14 +13,15 @@ const SANDBOX_WORKING_DIRECTORY = "/workspace";
 const SANDBOX_WORKING_DIRECTORY_PREFIX_PATTERN =
   /^\s*(?:mkdir -p \/tmp\/bash-tool\s*&&\s*)?cd\s+"\/workspace"\s*&&\s*/i;
 
-export interface HostedSandboxJobClient {
+export interface AgentServiceSandboxJobClient {
   startCommandJob(command: string): Promise<CommandJob>;
   getCommandJob(jobId: string): Promise<CommandJob>;
   getCommandJobOutput(jobId: string): Promise<CommandJobOutput>;
   cancelCommandJob(jobId: string): Promise<CommandJob>;
 }
 
-export interface HostedSandboxClient extends BashToolSandboxLike, HostedSandboxJobClient {
+export interface AgentServiceSandboxClient
+  extends BashToolSandboxLike, AgentServiceSandboxJobClient {
   ensure(): Promise<void>;
   close(): Promise<void>;
   readonly isActive: boolean;
@@ -28,15 +29,15 @@ export interface HostedSandboxClient extends BashToolSandboxLike, HostedSandboxJ
   readonly url: string | null;
 }
 
-export interface HostedSandboxClientOptions extends LazySandboxOptions {}
+export interface AgentServiceSandboxClientOptions extends LazySandboxOptions {}
 
-export interface HostedSandboxToolsOptions extends HostedSandboxClientOptions {
+export interface AgentServiceSandboxToolsOptions extends AgentServiceSandboxClientOptions {
   createBashTool: CreateSandboxBashTool;
 }
 
-export interface HostedSandboxToolsResult {
+export interface AgentServiceSandboxToolsResult {
   tools: SandboxShellToolSet;
-  sandbox: HostedSandboxClient;
+  sandbox: AgentServiceSandboxClient;
   closeSandbox: () => Promise<void>;
 }
 
@@ -80,9 +81,9 @@ function normalizeSandboxWriteFile(file: unknown): { path: string; content: stri
   };
 }
 
-export function createHostedSandboxClient(
-  input: HostedSandboxClientOptions = {},
-): HostedSandboxClient {
+export function createAgentServiceSandboxClient(
+  input: AgentServiceSandboxClientOptions = {},
+): AgentServiceSandboxClient {
   const getProjectId = input.getProjectId ?? (() => input.projectId);
   const sandbox = new LazySandbox({ ...input, getProjectId });
 
@@ -132,10 +133,10 @@ const getCommandJobIdInputSchema = defineSchema((v) =>
   })
 );
 
-export async function createHostedSandboxTools(
-  input: HostedSandboxToolsOptions,
-): Promise<HostedSandboxToolsResult> {
-  const sandbox = createHostedSandboxClient(input);
+export async function createAgentServiceSandboxTools(
+  input: AgentServiceSandboxToolsOptions,
+): Promise<AgentServiceSandboxToolsResult> {
+  const sandbox = createAgentServiceSandboxClient(input);
   const shellTools = await createSandboxShellTools(sandbox, input.createBashTool);
 
   const tools: SandboxShellToolSet = {
@@ -171,3 +172,12 @@ export async function createHostedSandboxTools(
     closeSandbox: () => sandbox.close(),
   };
 }
+
+export type HostedSandboxJobClient = AgentServiceSandboxJobClient;
+export type HostedSandboxClient = AgentServiceSandboxClient;
+export type HostedSandboxClientOptions = AgentServiceSandboxClientOptions;
+export type HostedSandboxToolsOptions = AgentServiceSandboxToolsOptions;
+export type HostedSandboxToolsResult = AgentServiceSandboxToolsResult;
+
+export const createHostedSandboxClient = createAgentServiceSandboxClient;
+export const createHostedSandboxTools = createAgentServiceSandboxTools;

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -47,20 +47,20 @@ export {
   type SandboxShellToolSet,
 } from "./shell-tools.ts";
 export {
+  type AgentServiceSandboxClient,
+  type AgentServiceSandboxClientOptions,
+  type AgentServiceSandboxJobClient,
+  type AgentServiceSandboxToolsOptions,
+  type AgentServiceSandboxToolsResult,
+  createAgentServiceSandboxClient,
+  createAgentServiceSandboxTools,
   createHostedSandboxClient,
-  createHostedSandboxClient as createAgentServiceSandboxClient,
   createHostedSandboxTools,
-  createHostedSandboxTools as createAgentServiceSandboxTools,
   createProjectScopedExecOptions,
   type HostedSandboxClient,
-  type HostedSandboxClient as AgentServiceSandboxClient,
   type HostedSandboxClientOptions,
-  type HostedSandboxClientOptions as AgentServiceSandboxClientOptions,
   type HostedSandboxJobClient,
-  type HostedSandboxJobClient as AgentServiceSandboxJobClient,
   type HostedSandboxToolsOptions,
-  type HostedSandboxToolsOptions as AgentServiceSandboxToolsOptions,
   type HostedSandboxToolsResult,
-  type HostedSandboxToolsResult as AgentServiceSandboxToolsResult,
   unwrapSandboxWorkingDirectoryCommand,
-} from "./hosted-tools.ts";
+} from "./agent-service-tools.ts";

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.507";
+export const VERSION = "0.1.508";


### PR DESCRIPTION
## Summary
- make agent-service sandbox factories and types the primary implementation names
- keep hosted sandbox exports as compatibility aliases from the sandbox boundary
- update agent-service internals and sandbox docs to use the primary names
- bump framework package version to 0.1.508

## Verification
- deno test --no-check --allow-all src/sandbox/agent-service-tools.test.ts src/sandbox/agent-service-sandbox-aliases.test.ts src/agent/hosted-child-fork-tool-sources.test.ts src/agent/default-hosted-invoke-agent-tool.test.ts src/agent/veryfront-cloud-agent-service.test.ts
- deno task typecheck
- deno task verify:quick
- deno task build:npm