### PR TITLE
Add explicit agent service MCP server config

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.509",
+  "version": "0.1.510",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "workspace": [

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -273,11 +273,12 @@ durable-run, and prepared-execution wiring, use
 agent behavior in `agents/<agent-id>.md` or `agents/<agent-id>.ts`:
 
 ```ts
-import { startAgentService } from "veryfront/agent";
+import { startAgentService, veryfrontMcpServer } from "veryfront/agent";
 
 await startAgentService({
   serviceName: "support-agent",
   agentId: "support",
+  mcpServers: [veryfrontMcpServer()],
 });
 ```
 
@@ -285,17 +286,32 @@ By default, discovery is rooted at the process cwd. Pass `baseDir` only when the
 service may start from another working directory. `entrypointUrl` is a
 convenience fallback for deriving `baseDir` from an entry module URL.
 
-Studio MCP tools are opt-in because they are Studio/control-plane specific:
+Remote MCP servers are configured as an explicit list. Use normal MCP server
+configs for third-party servers, and use `veryfrontMcpServer()` helpers for
+Veryfront-owned control-plane servers. Studio MCP tools are still gated to
+trusted Studio-capable clients:
 
 ```ts
 await startAgentService({
   serviceName: "support-agent",
   agentId: "support",
-  mcp: {
-    studio: true,
-  },
+  mcpServers: [
+    veryfrontMcpServer(),
+    veryfrontMcpServer("studio"),
+    {
+      id: "linear",
+      endpoint: process.env.LINEAR_MCP_URL,
+      headers: {
+        Authorization: `Bearer ${process.env.LINEAR_API_KEY}`,
+      },
+    },
+  ],
 });
 ```
+
+If `mcpServers` is omitted, the Veryfront Cloud preset includes
+`veryfrontMcpServer()` by default. Pass `mcpServers: []` to run without remote
+MCP tools.
 
 `createNodeVeryfrontCloudAgentServiceRuntime()` returns the same runtime bundle
 without starting a server, which is useful for tests and custom host shells.
@@ -850,8 +866,8 @@ conventions and `veryfront.config.ts` discovery settings as a Veryfront project.
 It can use a code agent from `agents/*.ts` or fall back to a markdown-backed
 `agents/*.md` definition, uses the default service config and project-steering
 adapter, wires local tools (`form_input`, `load_skill`, `sleep`, discovered
-project tools, and `invoke_agent`), sandbox tools, Veryfront API MCP tools,
-opt-in Studio MCP tools, prepared chat execution, AG-UI streaming, and detached
+project tools, and `invoke_agent`), sandbox tools, explicit remote MCP servers,
+prepared chat execution, AG-UI streaming, and detached
 durable-run execution.
 
 Hosts provide the service name and agent id. Discovery defaults to cwd; hosts
@@ -879,7 +895,7 @@ through the provided process target.
 Parse the default agent service environment contract. The helper
 validates API URL, node environment, port, durable feature flags, OAuth public
 key, Studio MCP URL, allowed origins, and OpenTelemetry endpoint flags, and it
-derives the hosted MCP URL from `VERYFRONT_API_URL`.
+derives the Veryfront API MCP URL from `VERYFRONT_API_URL`.
 
 `parseHostedAgentServiceConfig()` remains available as a compatibility alias.
 

--- a/src/agent/default-hosted-chat-runtime.ts
+++ b/src/agent/default-hosted-chat-runtime.ts
@@ -29,6 +29,7 @@ import {
   prepareHostedChatRuntimeToolAssembly,
   type PrepareHostedChatRuntimeToolAssemblyInput,
 } from "./hosted-chat-runtime-tool-assembly.ts";
+import type { HostedProjectMcpServerConfig } from "./hosted-project-remote-tool-source.ts";
 import {
   createHostedRuntimeStateResolver,
   type HostedRuntimeStateResolverContext,
@@ -44,7 +45,7 @@ export type DefaultHostedChatRuntimeConfig = {
   apiUrl: string;
   apiMcpUrl: string;
   studioMcpUrl?: string | null;
-  studioMcpEnabled?: boolean;
+  mcpServers?: readonly HostedProjectMcpServerConfig[];
 };
 
 export type DefaultHostedChatRuntimeLogger = {
@@ -154,7 +155,7 @@ async function buildToolAssembly(
     apiUrl: input.config.apiUrl,
     apiMcpUrl: input.config.apiMcpUrl,
     studioMcpUrl: input.config.studioMcpUrl,
-    studioMcpEnabled: input.config.studioMcpEnabled,
+    mcpServers: input.config.mcpServers,
     conversationId: input.options.conversationId,
     allowedToolNames: input.options.allowedTools ?? null,
     projectScopedRemoteToolOptions: input.projectScopedRemoteToolOptions,

--- a/src/agent/default-hosted-invoke-agent-tool.ts
+++ b/src/agent/default-hosted-invoke-agent-tool.ts
@@ -28,6 +28,7 @@ import { startHostedChildForkRuntimeWithHostTools } from "./hosted-child-fork-ru
 import {
   prepareDefaultHostedChildForkSandboxToolSources,
 } from "./hosted-child-fork-tool-sources.ts";
+import type { HostedProjectMcpServerConfig } from "./hosted-project-remote-tool-source.ts";
 import { executeHostedChildForkToolInput } from "./hosted-child-fork-execution-runner.ts";
 import { createHostedChildInvokeTool } from "./hosted-child-invoke-tool.ts";
 import {
@@ -78,6 +79,7 @@ export type DefaultHostedInvokeAgentConfig = {
   apiUrl: string;
   apiMcpUrl: string;
   studioMcpUrl?: string | null;
+  mcpServers?: readonly HostedProjectMcpServerConfig[];
   enableDurableInvokeAgent?: boolean;
 };
 
@@ -219,6 +221,7 @@ async function prepareForkToolSources<TContext extends DefaultHostedInvokeAgentC
     apiUrl: config.apiUrl,
     apiMcpUrl: config.apiMcpUrl,
     studioMcpUrl: config.studioMcpUrl,
+    mcpServers: config.mcpServers,
     clientProfile: options.context.clientProfile,
     getProjectId: () => options.context.projectId || null,
     conversationId: options.context.conversationId,

--- a/src/agent/hosted-chat-runtime-tool-assembly.test.ts
+++ b/src/agent/hosted-chat-runtime-tool-assembly.test.ts
@@ -80,7 +80,7 @@ Deno.test("prepareHostedChatRuntimeToolAssembly builds provider-compatible runti
     apiUrl: "https://api.example.com",
     apiMcpUrl: "https://api.example.com/mcp",
     studioMcpUrl: "https://studio.example.com/mcp",
-    studioMcpEnabled: true,
+    mcpServers: [{ kind: "veryfront-api" }, { kind: "veryfront-studio" }],
     conversationId: "conversation-1",
     allowedToolNames: ["sleep", "create_file", "studio_open_project"],
     projectScopedRemoteToolOptions: {

--- a/src/agent/hosted-chat-runtime-tool-assembly.ts
+++ b/src/agent/hosted-chat-runtime-tool-assembly.ts
@@ -19,6 +19,7 @@ import {
 } from "./default-research-artifact-support.ts";
 import {
   createHostedProjectRemoteToolSources,
+  type HostedProjectMcpServerConfig,
   type HostedProjectRemoteToolSourceMutationHandler,
   type HostedProjectRemoteToolSourcePrepareToolInput,
   type HostedProjectRemoteToolSourceProjectSwitchHandler,
@@ -58,7 +59,7 @@ export type PrepareHostedChatRuntimeToolAssemblyInput<
   apiUrl: string;
   apiMcpUrl: string;
   studioMcpUrl?: string | null;
-  studioMcpEnabled?: boolean;
+  mcpServers?: readonly HostedProjectMcpServerConfig[];
   conversationId?: string;
   allowedToolNames?: HostedChatRuntimeAllowedToolNames;
   projectScopedRemoteToolOptions?: ProjectScopedRemoteToolOptions;
@@ -121,7 +122,7 @@ export async function prepareHostedChatRuntimeToolAssembly<
     authToken: input.taskContext.authToken,
     apiMcpUrl: input.apiMcpUrl,
     studioMcpUrl: input.studioMcpUrl,
-    studioMcpEnabled: input.studioMcpEnabled,
+    mcpServers: input.mcpServers,
     clientProfile: input.taskContext.clientProfile,
     createRemoteToolSource: input.createRemoteToolSource ?? createRemoteMCPToolSource,
     defaultProjectId: () => activeProjectId(input.taskContext),

--- a/src/agent/hosted-child-fork-tool-sources.test.ts
+++ b/src/agent/hosted-child-fork-tool-sources.test.ts
@@ -120,6 +120,7 @@ Deno.test("prepareDefaultHostedChildForkToolSources loads API, live Studio, and 
   const result = await prepareDefaultHostedChildForkToolSources({
     authToken: "token-1",
     apiMcpUrl: "https://api.example/mcp",
+    mcpServers: [{ kind: "veryfront-api" }, { kind: "veryfront-studio" }],
     studioMcpUrl: "https://studio.example/mcp",
     clientProfile: trustedStudioProfile,
     getProjectId: () => "project-1",
@@ -145,8 +146,8 @@ Deno.test("prepareDefaultHostedChildForkToolSources loads API, live Studio, and 
   assertEquals(
     fixtures.createdConfigs.map((config) => [config.id, config.endpoint]),
     [
-      ["studio-mcp-live-tools", "https://studio.example/mcp"],
       ["veryfront-mcp-fork", "https://api.example/mcp"],
+      ["studio-mcp-live-tools", "https://studio.example/mcp"],
     ],
   );
 
@@ -171,6 +172,7 @@ Deno.test("prepareDefaultHostedChildForkToolSources reports Studio setup failure
   const result = await prepareDefaultHostedChildForkToolSources({
     authToken: "token-1",
     apiMcpUrl: "https://api.example/mcp",
+    mcpServers: [{ kind: "veryfront-studio" }],
     getProjectId: () => "project-1",
     createLiveStudioTools: () => {
       throw new Error("studio unavailable");
@@ -221,6 +223,7 @@ Deno.test("prepareDefaultHostedChildForkSandboxToolSources merges sandbox tools 
     authToken: "token-1",
     apiUrl: "https://api.example",
     apiMcpUrl: "https://api.example/mcp",
+    mcpServers: [{ kind: "veryfront-api" }, { kind: "veryfront-studio" }],
     studioMcpUrl: "https://studio.example/mcp",
     clientProfile: trustedStudioProfile,
     getProjectId: () => "project-1",
@@ -280,6 +283,7 @@ Deno.test("prepareDefaultHostedChildForkSandboxToolSources closes sandbox when s
     authToken: "token-1",
     apiUrl: "https://api.example",
     apiMcpUrl: "https://api.example/mcp",
+    mcpServers: [{ kind: "veryfront-studio" }],
     getProjectId: () => "project-1",
     createBashTool,
     createLiveStudioTools: () => {

--- a/src/agent/hosted-child-fork-tool-sources.ts
+++ b/src/agent/hosted-child-fork-tool-sources.ts
@@ -14,6 +14,11 @@ import {
   createLiveStudioMcpTools,
   type LiveStudioMcpToolsOptions,
 } from "./live-studio-mcp-tools.ts";
+import type { HostedProjectMcpServerConfig } from "./hosted-project-remote-tool-source.ts";
+import {
+  createHostedProjectGenericRemoteMcpConfig,
+  createHostedProjectVeryfrontApiRemoteMcpConfig,
+} from "./hosted-project-remote-tool-source.ts";
 import type { RuntimeClientProfile } from "./runtime-client-profile.ts";
 import {
   type HostedChildProjectSwitchHandler,
@@ -31,13 +36,13 @@ export type HostedChildForkToolSourcesLogger = {
 export type PrepareDefaultHostedChildForkToolSourcesInput = {
   authToken: string;
   apiMcpUrl: string;
+  mcpServers?: readonly HostedProjectMcpServerConfig[];
   getProjectId: () => string | null | undefined;
   studioMcpUrl?: string | null;
   clientProfile?: RuntimeClientProfile | null;
   conversationId?: string;
   globalTools?: HostToolSet;
   abortSignal?: AbortSignal;
-  apiSourceId?: string;
   onConfirmedStudioProjectSwitch?: HostedChildProjectSwitchHandler;
   createRemoteToolSource?: (config: RemoteMCPToolSourceConfig) => RemoteToolSource;
   createToolsFromRemoteDefinitions?: typeof createToolsFromRemoteDefinitions;
@@ -70,26 +75,59 @@ export type PrepareDefaultHostedChildForkSandboxToolSourcesInput =
     ) => Promise<AgentServiceSandboxToolsResult>;
   };
 
+function defaultChildForkMcpServers(): HostedProjectMcpServerConfig[] {
+  return [{ kind: "veryfront-api" }];
+}
+
 export async function prepareDefaultHostedChildForkToolSources(
   input: PrepareDefaultHostedChildForkToolSourcesInput,
 ): Promise<DefaultHostedChildForkToolSourcesResult> {
+  throwIfAborted(input.abortSignal);
+
   let closeStudioMcpTools: (() => Promise<void>) | undefined;
   let studioMcpTools: HostToolSet = {};
+  let remoteMcpTools: HostToolSet = {};
   const createLiveStudioTools = input.createLiveStudioTools ?? createLiveStudioMcpTools;
+  const createRemoteToolSource = input.createRemoteToolSource ?? createRemoteMCPToolSource;
+  const materializeRemoteTools = input.createToolsFromRemoteDefinitions ??
+    createToolsFromRemoteDefinitions;
 
   try {
-    const studioTools = await createLiveStudioTools({
-      authToken: input.authToken,
-      clientProfile: input.clientProfile,
-      getProjectId: input.getProjectId,
-      studioMcpUrl: input.studioMcpUrl,
-      ...(input.conversationId ? { conversationId: input.conversationId } : {}),
-      ...(input.createRemoteToolSource
-        ? { createRemoteToolSource: input.createRemoteToolSource }
-        : {}),
-    });
-    studioMcpTools = studioTools.tools;
-    closeStudioMcpTools = studioTools.close;
+    const mcpServers = input.mcpServers ?? defaultChildForkMcpServers();
+    for (const server of mcpServers) {
+      if (server.kind === "veryfront-studio") {
+        const studioTools = await createLiveStudioTools({
+          authToken: input.authToken,
+          clientProfile: input.clientProfile,
+          getProjectId: input.getProjectId,
+          studioMcpUrl: input.studioMcpUrl,
+          ...(input.conversationId ? { conversationId: input.conversationId } : {}),
+          ...(input.createRemoteToolSource
+            ? { createRemoteToolSource: input.createRemoteToolSource }
+            : {}),
+        });
+        studioMcpTools = {
+          ...studioMcpTools,
+          ...studioTools.tools,
+        };
+        closeStudioMcpTools = studioTools.close;
+        continue;
+      }
+
+      const remoteConfig = server.kind === "veryfront-api"
+        ? createHostedProjectVeryfrontApiRemoteMcpConfig({
+          authToken: input.authToken,
+          apiMcpUrl: input.apiMcpUrl,
+          defaultSourceId: "veryfront-mcp-fork",
+        }, server)
+        : createHostedProjectGenericRemoteMcpConfig(server);
+      const remoteSource = createRemoteToolSource(remoteConfig);
+      const definitions = await remoteSource.listTools();
+      remoteMcpTools = {
+        ...remoteMcpTools,
+        ...materializeRemoteTools(remoteSource, definitions),
+      };
+    }
   } catch (error) {
     if (input.abortSignal?.aborted || input.isAbortError?.(error)) {
       throw error;
@@ -108,19 +146,6 @@ export async function prepareDefaultHostedChildForkToolSources(
 
   throwIfAborted(input.abortSignal);
 
-  const createRemoteToolSource = input.createRemoteToolSource ?? createRemoteMCPToolSource;
-  const materializeRemoteTools = input.createToolsFromRemoteDefinitions ??
-    createToolsFromRemoteDefinitions;
-  const apiMcpSource = createRemoteToolSource({
-    id: input.apiSourceId ?? "veryfront-mcp-fork",
-    endpoint: input.apiMcpUrl,
-    headers: {
-      Authorization: `Bearer ${input.authToken}`,
-    },
-  });
-  const apiMcpDefinitions = await apiMcpSource.listTools();
-  const apiMcpTools = materializeRemoteTools(apiMcpSource, apiMcpDefinitions);
-
   if (input.onConfirmedStudioProjectSwitch) {
     wrapHostedChildProjectSwitchTool({
       tools: studioMcpTools,
@@ -133,7 +158,7 @@ export async function prepareDefaultHostedChildForkToolSources(
   return {
     ok: true,
     forkTools: buildDefaultHostedChildForkToolSet(
-      apiMcpTools,
+      remoteMcpTools,
       studioMcpTools,
       input.globalTools ?? {},
     ),

--- a/src/agent/hosted-project-remote-tool-source.test.ts
+++ b/src/agent/hosted-project-remote-tool-source.test.ts
@@ -237,13 +237,12 @@ Deno.test("createHostedProjectRemoteToolSource skips mutation callbacks for fail
   assertEquals(mutationCount, 0);
 });
 
-Deno.test("createHostedProjectRemoteToolSources keeps Studio MCP opt-in", async () => {
+Deno.test("createHostedProjectRemoteToolSources defaults to the Veryfront API MCP server", async () => {
   const configs: RemoteMCPToolSourceConfig[] = [];
   const sources = createHostedProjectRemoteToolSources({
     authToken: "token-1",
     apiMcpUrl: "https://api.example/mcp",
     studioMcpUrl: "https://studio.example/mcp",
-    studioMcpEnabled: false,
     clientProfile: {
       id: "veryfront-studio",
       type: "web",
@@ -268,7 +267,7 @@ Deno.test("createHostedProjectRemoteToolSources builds API and explicit gated St
     authToken: "token-1",
     apiMcpUrl: "https://api.example/mcp",
     studioMcpUrl: "https://studio.example/mcp",
-    studioMcpEnabled: true,
+    mcpServers: [{ kind: "veryfront-api" }, { kind: "veryfront-studio" }],
     clientProfile: {
       id: "veryfront-studio",
       type: "web",
@@ -301,7 +300,7 @@ Deno.test("createHostedProjectRemoteToolSources builds API and explicit gated St
     authToken: "token-1",
     apiMcpUrl: "https://api.example/mcp",
     studioMcpUrl: "https://studio.example/mcp",
-    studioMcpEnabled: true,
+    mcpServers: [{ kind: "veryfront-api" }, { kind: "veryfront-studio" }],
     clientProfile: {
       id: "veryfront-cli",
       type: "cli",
@@ -316,6 +315,53 @@ Deno.test("createHostedProjectRemoteToolSources builds API and explicit gated St
   assertEquals(blockedSources.map((source) => source.id), ["veryfront-mcp"]);
 });
 
+Deno.test("createHostedProjectRemoteToolSources builds explicit MCP server lists", async () => {
+  const configs: RemoteMCPToolSourceConfig[] = [];
+  let activeProjectId = "project-1";
+  const sources = createHostedProjectRemoteToolSources({
+    authToken: "token-1",
+    apiMcpUrl: "https://api.example/mcp",
+    mcpServers: [
+      { kind: "veryfront-api" },
+      { kind: "veryfront-studio" },
+      {
+        id: "linear",
+        endpoint: "https://linear.example/mcp",
+        headers: { Authorization: "Bearer linear-token" },
+      },
+    ],
+    studioMcpUrl: "https://studio.example/mcp",
+    clientProfile: {
+      id: "veryfront-studio",
+      type: "web",
+      trusted: true,
+      capabilities: ["ui_panels"],
+    },
+    getProjectId: () => activeProjectId,
+    conversationId: "conversation-1",
+    createRemoteToolSource: (config) => {
+      configs.push(config);
+      return createRemoteSource({ id: config.id, tools: [projectFileTool("update_file")] });
+    },
+  });
+
+  assertEquals(sources.map((source) => source.id), ["veryfront-mcp", "studio-mcp", "linear"]);
+  assertEquals(configs.map((config) => config.endpoint), [
+    "https://api.example/mcp",
+    "https://studio.example/mcp",
+    "https://linear.example/mcp",
+  ]);
+  assertEquals(configs[0]?.headers, { Authorization: "Bearer token-1" });
+  assertEquals(configs[2]?.headers, { Authorization: "Bearer linear-token" });
+
+  activeProjectId = "project-2";
+  assertEquals(await resolveTestHeaders(configs[1]?.headers), {
+    Authorization: "Bearer token-1",
+    "x-conversation-id": "conversation-1",
+    "x-project-id": "project-2",
+  });
+});
+
 Deno.test("createHostedProjectRemoteToolSources applies project wrapper policy to created sources", async () => {
   const executed: Array<{ toolName: string; args: unknown; context?: ToolExecutionContext }> = [];
   const switchedProjects: string[] = [];
@@ -324,7 +370,7 @@ Deno.test("createHostedProjectRemoteToolSources applies project wrapper policy t
     authToken: "token-1",
     apiMcpUrl: "https://api.example/mcp",
     studioMcpUrl: "https://studio.example/mcp",
-    studioMcpEnabled: true,
+    mcpServers: [{ kind: "veryfront-api" }, { kind: "veryfront-studio" }],
     clientProfile: {
       id: "veryfront-studio",
       type: "web",

--- a/src/agent/hosted-project-remote-tool-source.ts
+++ b/src/agent/hosted-project-remote-tool-source.ts
@@ -27,6 +27,31 @@ export type HostedProjectRemoteToolSourceProjectSwitchHandler = (
   projectId: string,
 ) => Promise<void> | void;
 
+export type HostedProjectVeryfrontApiMcpServerConfig = {
+  kind: "veryfront-api";
+  id?: string;
+};
+
+export type HostedProjectVeryfrontStudioMcpServerConfig = {
+  kind: "veryfront-studio";
+  id?: string;
+};
+
+export type HostedProjectGenericMcpServerConfig = {
+  kind?: "generic";
+  id?: string;
+  endpoint: RemoteMCPToolSourceConfig["endpoint"];
+  headers?: RemoteMCPToolSourceConfig["headers"];
+  fetch?: RemoteMCPToolSourceConfig["fetch"];
+  listMethod?: RemoteMCPToolSourceConfig["listMethod"];
+  callMethod?: RemoteMCPToolSourceConfig["callMethod"];
+};
+
+export type HostedProjectMcpServerConfig =
+  | HostedProjectVeryfrontApiMcpServerConfig
+  | HostedProjectVeryfrontStudioMcpServerConfig
+  | HostedProjectGenericMcpServerConfig;
+
 export type HostedProjectRemoteToolSourcePrepareToolInput = (input: {
   toolName: string;
   toolInput: Record<string, unknown>;
@@ -188,15 +213,86 @@ export type CreateHostedProjectRemoteToolSourcesInput =
     authToken: string;
     apiMcpUrl: string;
     studioMcpUrl?: string | null;
-    studioMcpEnabled?: boolean;
+    mcpServers?: readonly HostedProjectMcpServerConfig[];
     clientProfile?: RuntimeClientProfile | null;
     getProjectId: () => string | null | undefined;
     conversationId?: string;
-    apiSourceId?: string;
-    studioSourceId?: string;
     createRemoteToolSource?: (config: RemoteMCPToolSourceConfig) => RemoteToolSource;
     onStudioProjectSwitch?: HostedProjectRemoteToolSourceProjectSwitchHandler;
   };
+
+function defaultHostedProjectMcpServers(): HostedProjectMcpServerConfig[] {
+  return [{ kind: "veryfront-api" }];
+}
+
+export function createHostedProjectGenericRemoteMcpConfig(
+  server: HostedProjectGenericMcpServerConfig,
+): RemoteMCPToolSourceConfig {
+  const config: RemoteMCPToolSourceConfig = {
+    endpoint: server.endpoint,
+  };
+
+  if (server.id !== undefined) config.id = server.id;
+  if (server.headers !== undefined) config.headers = server.headers;
+  if (server.fetch !== undefined) config.fetch = server.fetch;
+  if (server.listMethod !== undefined) config.listMethod = server.listMethod;
+  if (server.callMethod !== undefined) config.callMethod = server.callMethod;
+
+  return config;
+}
+
+export function createHostedProjectVeryfrontApiRemoteMcpConfig(
+  input: Pick<CreateHostedProjectRemoteToolSourcesInput, "apiMcpUrl" | "authToken"> & {
+    defaultSourceId?: string;
+  },
+  server: HostedProjectVeryfrontApiMcpServerConfig,
+): RemoteMCPToolSourceConfig {
+  return {
+    id: server.id ?? input.defaultSourceId ?? "veryfront-mcp",
+    endpoint: input.apiMcpUrl,
+    headers: {
+      Authorization: `Bearer ${input.authToken}`,
+    },
+  };
+}
+
+function createVeryfrontStudioRemoteMcpConfig(
+  input: Pick<
+    CreateHostedProjectRemoteToolSourcesInput,
+    "authToken" | "clientProfile" | "conversationId" | "getProjectId" | "studioMcpUrl"
+  >,
+  server: HostedProjectVeryfrontStudioMcpServerConfig,
+): RemoteMCPToolSourceConfig | null {
+  if (!input.studioMcpUrl || !clientAllowsStudioMcp(input.clientProfile)) {
+    return null;
+  }
+
+  return {
+    id: server.id ?? "studio-mcp",
+    endpoint: input.studioMcpUrl,
+    headers: () =>
+      buildStudioMcpHeaders(
+        input.authToken,
+        input.getProjectId() ?? null,
+        input.conversationId,
+      ),
+  };
+}
+
+function createRemoteMcpConfig(
+  input: CreateHostedProjectRemoteToolSourcesInput,
+  server: HostedProjectMcpServerConfig,
+): RemoteMCPToolSourceConfig | null {
+  if (server.kind === "veryfront-api") {
+    return createHostedProjectVeryfrontApiRemoteMcpConfig(input, server);
+  }
+
+  if (server.kind === "veryfront-studio") {
+    return createVeryfrontStudioRemoteMcpConfig(input, server);
+  }
+
+  return createHostedProjectGenericRemoteMcpConfig(server);
+}
 
 function createHostedProjectRemoteToolSourceFromConfig(
   input: CreateHostedProjectRemoteToolSourcesInput,
@@ -230,41 +326,23 @@ export function createHostedProjectRemoteToolSources(
   input: CreateHostedProjectRemoteToolSourcesInput,
 ): RemoteToolSource[] {
   const createRemoteToolSource = input.createRemoteToolSource ?? createRemoteMCPToolSource;
-  const sources = [
-    createHostedProjectRemoteToolSourceFromConfig(
-      input,
-      createRemoteToolSource({
-        id: input.apiSourceId ?? "veryfront-mcp",
-        endpoint: input.apiMcpUrl,
-        headers: {
-          Authorization: `Bearer ${input.authToken}`,
-        },
-      }),
-    ),
-  ];
+  const sources: RemoteToolSource[] = [];
+  const mcpServers = input.mcpServers ?? defaultHostedProjectMcpServers();
 
-  if (
-    !input.studioMcpEnabled || !input.studioMcpUrl || !clientAllowsStudioMcp(input.clientProfile)
-  ) {
-    return sources;
+  for (const server of mcpServers) {
+    const remoteConfig = createRemoteMcpConfig(input, server);
+    if (!remoteConfig) {
+      continue;
+    }
+
+    sources.push(
+      createHostedProjectRemoteToolSourceFromConfig(
+        input,
+        createRemoteToolSource(remoteConfig),
+        server.kind === "veryfront-studio" ? input.onStudioProjectSwitch : undefined,
+      ),
+    );
   }
-
-  sources.push(
-    createHostedProjectRemoteToolSourceFromConfig(
-      input,
-      createRemoteToolSource({
-        id: input.studioSourceId ?? "studio-mcp",
-        endpoint: input.studioMcpUrl,
-        headers: () =>
-          buildStudioMcpHeaders(
-            input.authToken,
-            input.getProjectId() ?? null,
-            input.conversationId,
-          ),
-      }),
-      input.onStudioProjectSwitch,
-    ),
-  );
 
   return sources;
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -335,13 +335,15 @@ export {
 } from "./agent-service-runtime.ts";
 export {
   createNodeVeryfrontCloudAgentServiceRuntime,
-  type NodeVeryfrontCloudAgentServiceMcpOptions,
+  type NodeVeryfrontCloudAgentServiceMcpServer,
   type NodeVeryfrontCloudAgentServiceOptions,
   type NodeVeryfrontCloudAgentServicePreparedExecution,
   type NodeVeryfrontCloudAgentServiceProcessTarget,
   startAgentService,
   startNodeVeryfrontCloudAgentService,
   type VeryfrontCloudAgentServiceOptions,
+  veryfrontMcpServer,
+  type VeryfrontMcpServerKind,
 } from "./veryfront-cloud-agent-service.ts";
 export {
   type AgentServiceConfig,

--- a/src/agent/veryfront-cloud-agent-service.test.ts
+++ b/src/agent/veryfront-cloud-agent-service.test.ts
@@ -4,7 +4,10 @@ import { pathToFileURL } from "node:url";
 import type { CreateSandboxBashTool } from "#veryfront/sandbox";
 import { toolRegistry } from "#veryfront/tool";
 import { agentRegistry } from "./composition/index.ts";
-import { createNodeVeryfrontCloudAgentServiceRuntime } from "./veryfront-cloud-agent-service.ts";
+import {
+  createNodeVeryfrontCloudAgentServiceRuntime,
+  veryfrontMcpServer,
+} from "./veryfront-cloud-agent-service.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 
 async function withTempDir(fn: (dir: string) => Promise<void> | void): Promise<void> {
@@ -159,6 +162,11 @@ Deno.test("createNodeVeryfrontCloudAgentServiceRuntime accepts entrypointUrl for
     assertEquals(bundle.runtime.contract.defaultAgentId, "veryfront");
     assertEquals(getRuntimeAgent(bundle, "veryfront").config.model, "openai/gpt-5.4");
   });
+});
+
+Deno.test("veryfrontMcpServer creates explicit Veryfront MCP server configs", () => {
+  assertEquals(veryfrontMcpServer(), { kind: "veryfront-api" });
+  assertEquals(veryfrontMcpServer("studio"), { kind: "veryfront-studio" });
 });
 
 Deno.test({

--- a/src/agent/veryfront-cloud-agent-service.ts
+++ b/src/agent/veryfront-cloud-agent-service.ts
@@ -60,6 +60,7 @@ import {
   fetchDefaultHostedProjectSteering,
 } from "./default-hosted-project-steering-refresh.ts";
 import { type HostedProjectSkillIdsContext } from "./hosted-project-steering-adapter.ts";
+import type { HostedProjectMcpServerConfig } from "./hosted-project-remote-tool-source.ts";
 import type { RuntimeLoadSkillToolContext } from "./runtime-load-skill-tool.ts";
 import type { RuntimeProjectSteeringLookup } from "./runtime-project-skill-catalog.ts";
 import type { RuntimeSkillDefinition } from "./runtime-skill-metadata.ts";
@@ -112,13 +113,19 @@ export type NodeVeryfrontCloudAgentServiceProcessTarget =
 
 export type NodeVeryfrontCloudAgentServiceAgentSource = "auto" | "code" | "markdown";
 
-export type NodeVeryfrontCloudAgentServiceMcpOptions = {
-  /**
-   * Opt in to Studio UI/control-plane MCP tools for trusted Studio-capable clients.
-   * API MCP tools remain part of the Veryfront Cloud service preset.
-   */
-  studio?: boolean;
-};
+export type VeryfrontMcpServerKind = "api" | "studio";
+
+export type NodeVeryfrontCloudAgentServiceMcpServer = HostedProjectMcpServerConfig;
+
+export function veryfrontMcpServer(
+  kind: VeryfrontMcpServerKind = "api",
+): HostedProjectMcpServerConfig {
+  if (kind === "studio") {
+    return { kind: "veryfront-studio" };
+  }
+
+  return { kind: "veryfront-api" };
+}
 
 type AgentServicePathOption = string | URL;
 
@@ -136,7 +143,11 @@ export type NodeVeryfrontCloudAgentServiceOptions = {
    */
   entrypointUrl?: AgentServicePathOption;
   agentSource?: NodeVeryfrontCloudAgentServiceAgentSource;
-  mcp?: NodeVeryfrontCloudAgentServiceMcpOptions;
+  /**
+   * Remote MCP servers available to the runtime. Defaults to the Veryfront API
+   * MCP server. Pass [] to run without remote MCP tools.
+   */
+  mcpServers?: readonly NodeVeryfrontCloudAgentServiceMcpServer[];
   forwardedConfigNamespace?: string;
   createBashTool?: AgentServiceSandboxToolsOptions["createBashTool"];
   env?: CreateNodeAgentServiceRuntimeInfrastructureOptions["env"];
@@ -236,6 +247,12 @@ function resolveDefaultProcessTarget(): NodeVeryfrontCloudAgentServiceProcessTar
     return undefined;
   }
   return process;
+}
+
+function resolveMcpServers(
+  options: Pick<NodeVeryfrontCloudAgentServiceOptions, "mcpServers">,
+): readonly NodeVeryfrontCloudAgentServiceMcpServer[] {
+  return options.mcpServers ?? [veryfrontMcpServer()];
 }
 
 async function loadDefaultCreateBashTool(): Promise<
@@ -465,12 +482,12 @@ function getInvokeAgentConfig(
   context: NodeVeryfrontCloudAgentServiceContext,
 ): DefaultHostedInvokeAgentConfig {
   const config = context.infrastructure.getConfig();
-  const studioMcpUrl = context.options.mcp?.studio ? config.VERYFRONT_STUDIO_MCP_URL : "";
 
   return {
     apiUrl: config.VERYFRONT_API_URL,
     apiMcpUrl: config.VERYFRONT_MCP_URL,
-    studioMcpUrl,
+    studioMcpUrl: config.VERYFRONT_STUDIO_MCP_URL,
+    mcpServers: resolveMcpServers(context.options),
     enableDurableInvokeAgent: config.VERYFRONT_ENABLE_DURABLE_INVOKE_AGENT,
   };
 }
@@ -550,8 +567,8 @@ function createAgentRuntime(
     config: {
       apiUrl: config.VERYFRONT_API_URL,
       apiMcpUrl: config.VERYFRONT_MCP_URL,
-      studioMcpUrl: context.options.mcp?.studio ? config.VERYFRONT_STUDIO_MCP_URL : "",
-      studioMcpEnabled: context.options.mcp?.studio ?? false,
+      studioMcpUrl: config.VERYFRONT_STUDIO_MCP_URL,
+      mcpServers: resolveMcpServers(context.options),
     },
     buildLocalTools: (taskContext) => buildLocalTools(context, options, taskContext),
     refreshSystem,

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,3 +1,3 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
-export const VERSION = "0.1.509";
+export const VERSION = "0.1.510";


### PR DESCRIPTION
## Summary
- add explicit agent-service MCP server list configuration and Veryfront MCP helper
- remove the Studio boolean service option in favor of normal MCP server config
- propagate explicit MCP server lists through root and child run tool assembly
- bump framework version to 0.1.510

## Verification
- deno test --no-check --allow-all src/agent/veryfront-cloud-agent-service.test.ts --filter 'veryfrontMcpServer'
- deno test --no-check --allow-all src/agent/hosted-chat-runtime-tool-assembly.test.ts src/agent/default-hosted-chat-runtime.test.ts src/agent/hosted-project-remote-tool-source.test.ts
- deno test --no-check --allow-all src/agent/hosted-child-fork-tool-sources.test.ts src/agent/default-hosted-invoke-agent-tool.test.ts
- deno task typecheck
- deno task verify:quick
- deno task build:npm
- pre-push checks